### PR TITLE
Cherry pick: Auto mTLS for namespace/mesh beta peer authn policies

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1726,3 +1726,33 @@ func (ps *PushContext) NetworkGatewaysByNetwork(network string) []*Gateway {
 
 	return nil
 }
+
+// BestEffortInferServiceMTLSMode infers the mTLS mode for the service + port from all authentication
+// policies (both alpha and beta) in the system. The function always returns MTLSUnknown for external service.
+// The resulst is a best effort. It is because the PeerAuthentication is workload-based, this function is unable
+// to compute the correct service mTLS mode without knowing service to workload binding. For now, this
+// function uses only mesh and namespace level PeerAuthentication and ignore workload & port level policies.
+// This function is used to give a hint for auto-mTLS configuration on client side.
+func (ps *PushContext) BestEffortInferServiceMTLSMode(service *Service, port *Port) MutualTLSMode {
+	if service.MeshExternal {
+		// Only need the authentication MTLS mode when service is not external.
+		return MTLSUnknown
+	}
+
+	// First , check mTLS settings from beta policy (i.e PeerAuthentication) at namespace / mesh level.
+	// If the mode is not unknown, use it.
+	if serviceMTLSMode := ps.AuthnBetaPolicies.GetNamespaceMutualTLSMode(service.Attributes.Namespace); serviceMTLSMode != MTLSUnknown {
+		return serviceMTLSMode
+	}
+
+	// Namespace/Mesh PeerAuthentication does not exist, check alpha authN policy.
+	policy, _ := ps.AuthenticationPolicyForWorkload(service, port)
+	if policy != nil {
+		log.Infof("Found policy for %v, %v,  %#v", service, port, policy)
+		// If alpha authN policy exist, used the mode defined by the policy.
+		return v1alpha1PolicyToMutualTLSMode(policy)
+	}
+
+	// When all are failed, default to permissive.
+	return MTLSPermissive
+}

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -24,6 +24,8 @@ import (
 	authn "istio.io/api/authentication/v1alpha1"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
+	securityBeta "istio.io/api/security/v1beta1"
+	selectorpb "istio.io/api/type/v1beta1"
 
 	"istio.io/istio/pilot/pkg/model/test"
 	"istio.io/istio/pkg/config/constants"
@@ -651,6 +653,181 @@ func TestSidecarScope(t *testing.T) {
 		if c.sidecar != scopeToSidecar(scope) {
 			t.Errorf("case with %s should get sidecar %s but got %s", c.describe, c.sidecar, scopeToSidecar(scope))
 		}
+	}
+}
+
+func TestBestEffortInferServiceMTLSMode(t *testing.T) {
+	const alphaNamespace string = "alpha-namespace"
+	const betaNamespace string = "beta-namespace"
+	const otherNamespace string = "other-namespace"
+	ps := NewPushContext()
+	env := &Environment{Watcher: mesh.NewFixedWatcher(&meshconfig.MeshConfig{RootNamespace: "istio-system"})}
+	ps.Mesh = env.Mesh()
+	ps.ServiceDiscovery = env
+	authNPolicies := map[string]*authn.Policy{
+		constants.DefaultAuthenticationPolicyName: {},
+		"mtls-strict-svc": {
+			Targets: []*authn.TargetSelector{{
+				Name: "mtls-strict-svc",
+			}},
+			Peers: []*authn.PeerAuthenticationMethod{{
+				Params: &authn.PeerAuthenticationMethod_Mtls{},
+			},
+			}},
+		"mtls-strict-svc-port": {
+			Targets: []*authn.TargetSelector{{
+				Name: "mtls-strict-svc-port",
+				Ports: []*authn.PortSelector{
+					{
+						Port: &authn.PortSelector_Number{
+							Number: 80,
+						},
+					},
+				},
+			}},
+			Peers: []*authn.PeerAuthenticationMethod{{
+				Params: &authn.PeerAuthenticationMethod_Mtls{},
+			},
+			}},
+		"mtls-disable-svc": {
+			Targets: []*authn.TargetSelector{{
+				Name: "mtls-disable-svc",
+			}},
+		},
+	}
+	configStore := newFakeStore()
+	for key, value := range authNPolicies {
+		cfg := Config{
+			ConfigMeta: ConfigMeta{
+				Type:      collections.IstioAuthenticationV1Alpha1Policies.Resource().Kind(),
+				Group:     collections.IstioAuthenticationV1Alpha1Policies.Resource().Group(),
+				Version:   collections.IstioAuthenticationV1Alpha1Policies.Resource().Version(),
+				Name:      key,
+				Domain:    "cluster.local",
+				Namespace: alphaNamespace,
+			},
+			Spec: value,
+		}
+		if _, err := configStore.Create(cfg); err != nil {
+			t.Error(err)
+		}
+	}
+
+	// Add cluster-scoped policy
+	globalPolicy := &authn.Policy{
+		Peers: []*authn.PeerAuthenticationMethod{{
+			Params: &authn.PeerAuthenticationMethod_Mtls{
+				Mtls: &authn.MutualTls{
+					Mode: authn.MutualTls_PERMISSIVE,
+				},
+			},
+		}},
+	}
+	globalCfg := Config{
+		ConfigMeta: ConfigMeta{
+			Type:    collections.IstioAuthenticationV1Alpha1Meshpolicies.Resource().Kind(),
+			Group:   collections.IstioAuthenticationV1Alpha1Meshpolicies.Resource().Group(),
+			Version: collections.IstioAuthenticationV1Alpha1Meshpolicies.Resource().Version(),
+			Name:    constants.DefaultAuthenticationPolicyName,
+			Domain:  "cluster.local",
+		},
+		Spec: globalPolicy,
+	}
+
+	// Add beta policies
+	configStore.Create(*createTestPeerAuthenticationResource("default", betaNamespace, nil, securityBeta.PeerAuthentication_MutualTLS_STRICT))
+	// workload level beta policy.
+	configStore.Create(*createTestPeerAuthenticationResource("workload-beta-policy", alphaNamespace, &selectorpb.WorkloadSelector{
+		MatchLabels: map[string]string{
+			"app":     "httpbin",
+			"version": "v1",
+		},
+	}, securityBeta.PeerAuthentication_MutualTLS_STRICT))
+
+	if _, err := configStore.Create(globalCfg); err != nil {
+		t.Error(err)
+	}
+
+	store := istioConfigStore{ConfigStore: configStore}
+	env.IstioConfigStore = &store
+	if err := ps.initAuthnPolicies(env); err != nil {
+		t.Fatalf("init authn policies failed: %v", err)
+	}
+
+	cases := []struct {
+		name             string
+		serviceName      host.Name
+		serviceNamespace string
+		servicePort      int
+		wanted           MutualTLSMode
+	}{
+		{
+			name:             "from beta policy",
+			serviceName:      "some-service",
+			serviceNamespace: betaNamespace,
+			servicePort:      80,
+			wanted:           MTLSStrict,
+		},
+		{
+			name:             "from alpha global policy",
+			serviceName:      "some-service",
+			serviceNamespace: otherNamespace,
+			servicePort:      80,
+			wanted:           MTLSPermissive,
+		},
+		{
+			name:             "from alpha namespace policy",
+			serviceName:      "some-service",
+			serviceNamespace: alphaNamespace,
+			servicePort:      80,
+			wanted:           MTLSDisable,
+		},
+		{
+			name:             "from service specific alpha policy",
+			serviceName:      "mtls-strict-svc",
+			serviceNamespace: alphaNamespace,
+			servicePort:      80,
+			wanted:           MTLSStrict,
+		},
+		{
+			name:             "from service-port specific alpha policy",
+			serviceName:      "mtls-strict-svc-port",
+			serviceNamespace: alphaNamespace,
+			servicePort:      80,
+			wanted:           MTLSStrict,
+		},
+		{
+			name:             "from namespace alpha policy - miss port",
+			serviceName:      "mtls-strict-svc-port",
+			serviceNamespace: alphaNamespace,
+			servicePort:      90,
+			wanted:           MTLSDisable,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			service := &Service{
+				Hostname:   host.Name(fmt.Sprintf("%s.%s.svc.cluster.local", tc.serviceName, tc.serviceNamespace)),
+				Attributes: ServiceAttributes{Namespace: tc.serviceNamespace},
+			}
+			// Intentionally use the externalService with the same name and namespace for test, though
+			// these attributes don't matter.
+			externalService := &Service{
+				Hostname:     host.Name(fmt.Sprintf("%s.%s.svc.cluster.local", tc.serviceName, tc.serviceNamespace)),
+				Attributes:   ServiceAttributes{Namespace: tc.serviceNamespace},
+				MeshExternal: true,
+			}
+
+			port := &Port{
+				Port: tc.servicePort,
+			}
+			if got := ps.BestEffortInferServiceMTLSMode(service, port); got != tc.wanted {
+				t.Fatalf("want %s, but got %s", tc.wanted, got)
+			}
+			if got := ps.BestEffortInferServiceMTLSMode(externalService, port); got != MTLSUnknown {
+				t.Fatalf("MTLS mode for external service should always be %s, but got %s", MTLSUnknown, got)
+			}
+		})
 	}
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -40,7 +40,6 @@ import (
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/loadbalancer"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
-	authn_v1alpha1_applier "istio.io/istio/pilot/pkg/security/authn/v1alpha1"
 	authn_model "istio.io/istio/pilot/pkg/security/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pkg/config/constants"
@@ -207,12 +206,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(proxy *model.Proxy, 
 			}
 
 			setUpstreamProtocol(proxy, defaultCluster, port, model.TrafficDirectionOutbound)
-			serviceMTLSMode := model.MTLSUnknown
-			if !service.MeshExternal {
-				// Only need the authentication MTLS mode when service is not external.
-				policy, _ := push.AuthenticationPolicyForWorkload(service, port)
-				serviceMTLSMode = authn_v1alpha1_applier.GetMutualTLSMode(policy)
-			}
+			serviceMTLSMode := push.BestEffortInferServiceMTLSMode(service, port)
 			clusters = append(clusters, defaultCluster)
 			destinationRule := castDestinationRuleOrDefault(destRule)
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -38,6 +38,8 @@ import (
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/api/networking/v1alpha3"
 	networking "istio.io/api/networking/v1alpha3"
+	authn_beta "istio.io/api/security/v1beta1"
+	selectorpb "istio.io/api/type/v1beta1"
 
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
@@ -227,12 +229,13 @@ func buildTestClusters(serviceHostname string, serviceResolution model.Resolutio
 		mesh,
 		destRule,
 		nil, // authnPolicy
+		nil, // peerAuthn
 	)
 }
 
 func buildTestClustersWithAuthnPolicy(serviceHostname string, serviceResolution model.Resolution, externalService bool,
 	nodeType model.NodeType, locality *core.Locality, mesh meshconfig.MeshConfig,
-	destRule proto.Message, authnPolicy *authn.Policy) ([]*apiv2.Cluster, error) {
+	destRule proto.Message, authnPolicy *authn.Policy, peerAuthn *authn_beta.PeerAuthentication) ([]*apiv2.Cluster, error) {
 	return buildTestClustersWithProxyMetadata(
 		serviceHostname,
 		serviceResolution,
@@ -242,30 +245,34 @@ func buildTestClustersWithAuthnPolicy(serviceHostname string, serviceResolution 
 		mesh,
 		destRule,
 		authnPolicy,
+		peerAuthn,
 		&model.NodeMetadata{},
 		model.MaxIstioVersion)
 }
 
 func buildTestClustersWithIstioVersion(serviceHostname string, serviceResolution model.Resolution,
 	nodeType model.NodeType, locality *core.Locality, mesh meshconfig.MeshConfig,
-	destRule proto.Message, authnPolicy *authn.Policy, istioVersion *model.IstioVersion) ([]*apiv2.Cluster, error) {
+	destRule proto.Message, authnPolicy *authn.Policy, peerAuthn *authn_beta.PeerAuthentication,
+	istioVersion *model.IstioVersion) ([]*apiv2.Cluster, error) {
 	return buildTestClustersWithProxyMetadata(serviceHostname, serviceResolution, false /* externalService */, nodeType, locality, mesh, destRule,
-		authnPolicy, &model.NodeMetadata{}, istioVersion)
+		authnPolicy, peerAuthn, &model.NodeMetadata{}, istioVersion)
 }
 
 func buildTestClustersWithProxyMetadata(serviceHostname string, serviceResolution model.Resolution, externalService bool,
 	nodeType model.NodeType, locality *core.Locality, mesh meshconfig.MeshConfig,
-	destRule proto.Message, authnPolicy *authn.Policy, meta *model.NodeMetadata, istioVersion *model.IstioVersion) ([]*apiv2.Cluster, error) {
+	destRule proto.Message, authnPolicy *authn.Policy, peerAuthn *authn_beta.PeerAuthentication,
+	meta *model.NodeMetadata, istioVersion *model.IstioVersion) ([]*apiv2.Cluster, error) {
 	return buildTestClustersWithProxyMetadataWithIps(serviceHostname, serviceResolution, externalService,
 		nodeType, locality, mesh,
-		destRule, authnPolicy, meta, istioVersion,
+		destRule, authnPolicy, peerAuthn, meta, istioVersion,
 		// Add default sidecar proxy meta
 		[]string{"6.6.6.6", "::1"})
 }
 
 func buildTestClustersWithProxyMetadataWithIps(serviceHostname string, serviceResolution model.Resolution, externalService bool,
 	nodeType model.NodeType, locality *core.Locality, mesh meshconfig.MeshConfig,
-	destRule proto.Message, authnPolicy *authn.Policy, meta *model.NodeMetadata, istioVersion *model.IstioVersion, proxyIps []string) ([]*apiv2.Cluster, error) {
+	destRule proto.Message, authnPolicy *authn.Policy, peerAuthn *authn_beta.PeerAuthentication,
+	meta *model.NodeMetadata, istioVersion *model.IstioVersion, proxyIps []string) ([]*apiv2.Cluster, error) {
 	configgen := NewConfigGenerator([]plugin.Plugin{})
 
 	serviceDiscovery := &fakes.ServiceDiscovery{}
@@ -376,6 +383,22 @@ func buildTestClustersWithProxyMetadataWithIps(serviceHostname string, serviceRe
 					},
 						Spec: authnPolicy,
 					}}, nil
+			}
+			if typ == collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind() && peerAuthn != nil {
+				policyName := "default"
+				if peerAuthn.Selector != nil {
+					policyName = "acme"
+				}
+				return []model.Config{
+					{ConfigMeta: model.ConfigMeta{
+						Type:      collections.IstioSecurityV1Beta1Peerauthentications.Resource().Kind(),
+						Version:   collections.IstioSecurityV1Beta1Peerauthentications.Resource().Version(),
+						Name:      policyName,
+						Namespace: TestServiceNamespace,
+					},
+						Spec: peerAuthn,
+					}}, nil
+
 			}
 			return nil, nil
 		},
@@ -562,7 +585,7 @@ func TestBuildClustersWithMutualTlsAndNodeMetadataCertfileOverrides(t *testing.T
 	}
 
 	clusters, err := buildTestClustersWithProxyMetadata("foo.example.org", model.ClientSideLB, false, model.SidecarProxy,
-		nil, testMesh, destRule, nil, envoyMetadata, model.MaxIstioVersion)
+		nil, testMesh, destRule, nil, nil, envoyMetadata, model.MaxIstioVersion)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	g.Expect(clusters).To(HaveLen(10))
@@ -620,6 +643,7 @@ func buildSniTestClustersWithMetadata(sniValue string, typ model.NodeType, meta 
 			},
 		},
 		nil, // authnPolicy
+		nil, // peerAuthn
 		meta,
 		model.MaxIstioVersion,
 	)
@@ -1295,6 +1319,7 @@ func TestGatewayLocalityLB(t *testing.T) {
 			},
 		},
 		nil, // authnPolicy
+		nil, // peerAuthn,
 		&model.NodeMetadata{RouterMode: string(model.SniDnatRouter)},
 		model.MaxIstioVersion)
 
@@ -1345,6 +1370,7 @@ func TestGatewayLocalityLB(t *testing.T) {
 			},
 		},
 		nil, // authnPolicy
+		nil, // peerAuthn
 		&model.NodeMetadata{RouterMode: string(model.SniDnatRouter)},
 		model.MaxIstioVersion)
 
@@ -1553,6 +1579,7 @@ func TestClusterDiscoveryTypeAndLbPolicyPassthroughIstioVersion12(t *testing.T) 
 			},
 		},
 		nil, // authnPolicy
+		nil, // peerAuthn
 		&model.IstioVersion{Major: 1, Minor: 2})
 
 	g.Expect(err).NotTo(HaveOccurred())
@@ -1943,6 +1970,7 @@ func TestPassthroughClustersBuildUponProxyIpVersions(t *testing.T) {
 				},
 			},
 			nil, // authnPolicy
+			nil, // peerAuthn
 			&model.NodeMetadata{},
 			model.MaxIstioVersion,
 			inAndOut.ips,
@@ -1981,7 +2009,7 @@ func TestAutoMTLSClusterPlaintextMode(t *testing.T) {
 		Peers: []*authn.PeerAuthenticationMethod{},
 	}
 
-	clusters, err := buildTestClustersWithAuthnPolicy(TestServiceNHostname, 0, false, model.SidecarProxy, nil, testMesh, destRule, authnPolicy)
+	clusters, err := buildTestClustersWithAuthnPolicy(TestServiceNHostname, 0, false, model.SidecarProxy, nil, testMesh, destRule, authnPolicy, nil)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	// mTLS is disabled by authN policy so autoMTLS does not kick in. No cluster should have TLS context.
@@ -2028,7 +2056,7 @@ func TestAutoMTLSClusterStrictMode(t *testing.T) {
 
 	testMesh.EnableAutoMtls.Value = true
 
-	clusters, err := buildTestClustersWithAuthnPolicy(TestServiceNHostname, 0, false, model.SidecarProxy, nil, testMesh, destRule, authnPolicy)
+	clusters, err := buildTestClustersWithAuthnPolicy(TestServiceNHostname, 0, false, model.SidecarProxy, nil, testMesh, destRule, authnPolicy, nil)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	// For port 8080, (m)TLS settings is automatically added, thus its cluster should have TLS context.
@@ -2082,7 +2110,17 @@ func TestAutoMTLSClusterStrictMode_SkipForExternal(t *testing.T) {
 		},
 	}
 
-	clusters, err := buildTestClustersWithAuthnPolicy(TestServiceNHostname, 0, true, model.SidecarProxy, nil, testMesh, destRule, authnPolicy)
+	clusters, err := buildTestClustersWithAuthnPolicy(
+		TestServiceNHostname,
+		0,
+		true,
+		model.SidecarProxy,
+		nil,
+		testMesh,
+		destRule,
+		authnPolicy,
+		nil, // peerAuthn
+	)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	// Service is external, use the TLS settings specified in DR.
@@ -2131,7 +2169,11 @@ func TestAutoMTLSClusterPerPortStrictMode(t *testing.T) {
 
 	testMesh.EnableAutoMtls.Value = true
 
-	clusters, err := buildTestClustersWithAuthnPolicy(TestServiceNHostname, 0, false, model.SidecarProxy, nil, testMesh, destRule, authnPolicy)
+	clusters, err := buildTestClustersWithAuthnPolicy(
+		TestServiceNHostname,
+		0, false, model.SidecarProxy, nil, testMesh, destRule, authnPolicy,
+		nil, // peerAuthn
+	)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	// For port 8080, (m)TLS settings is automatically added, thus its cluster should have TLS context.
@@ -2140,6 +2182,126 @@ func TestAutoMTLSClusterPerPortStrictMode(t *testing.T) {
 	g.Expect(clusters[0].TransportSocketMatches).To(HaveLen(2))
 
 	// For 9090, authn policy disable mTLS, so it should not have TLS context.
+	g.Expect(getTLSContext(t, clusters[1])).To(BeNil())
+
+	// Sanity check: make sure TLS is not accidentally added to other clusters.
+	for i := 2; i < len(clusters); i++ {
+		cluster := clusters[i]
+		g.Expect(getTLSContext(t, cluster)).To(BeNil())
+	}
+}
+
+func TestAutoMTLSClusterWithPeerAuthnStrictMode(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	destRule := &networking.DestinationRule{
+		Host: TestServiceNHostname,
+		TrafficPolicy: &networking.TrafficPolicy{
+			ConnectionPool: &networking.ConnectionPoolSettings{
+				Http: &networking.ConnectionPoolSettings_HTTPSettings{
+					MaxRequestsPerConnection: 1,
+				},
+			},
+			PortLevelSettings: []*networking.TrafficPolicy_PortTrafficPolicy{
+				{
+					Port: &networking.PortSelector{
+						Number: 9090,
+					},
+					Tls: &networking.TLSSettings{
+						Mode: networking.TLSSettings_DISABLE,
+					},
+				},
+			},
+		},
+	}
+
+	// This alpha policy will be ignored.
+	authnPolicy := &authn.Policy{
+		Peers: []*authn.PeerAuthenticationMethod{
+			{
+				Params: &authn.PeerAuthenticationMethod_Mtls{
+					Mtls: &authn.MutualTls{
+						Mode: authn.MutualTls_PERMISSIVE,
+					},
+				},
+			},
+		},
+	}
+
+	peerAuthn := &authn_beta.PeerAuthentication{
+		Mtls: &authn_beta.PeerAuthentication_MutualTLS{
+			Mode: authn_beta.PeerAuthentication_MutualTLS_STRICT,
+		},
+	}
+
+	testMesh.EnableAutoMtls.Value = true
+
+	clusters, err := buildTestClustersWithAuthnPolicy(TestServiceNHostname, 0, false, model.SidecarProxy, nil, testMesh, destRule, authnPolicy, peerAuthn)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// For port 8080, (m)TLS settings is automatically added, thus its cluster should have TLS context.
+	// TlsContext is nil because we use socket match instead
+	g.Expect(getTLSContext(t, clusters[0])).To(BeNil())
+	g.Expect(clusters[0].TransportSocketMatches).To(HaveLen(2))
+
+	// For 9090, use the TLS settings are explicitly specified in DR (which disable TLS)
+	g.Expect(getTLSContext(t, clusters[1])).To(BeNil())
+
+	// Sanity check: make sure TLS is not accidentally added to other clusters.
+	for i := 2; i < len(clusters); i++ {
+		cluster := clusters[i]
+		g.Expect(getTLSContext(t, cluster)).To(BeNil())
+	}
+}
+
+func TestAutoMTLSClusterIgnoreWorkloadLevelPeerAuthn(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	destRule := &networking.DestinationRule{
+		Host: TestServiceNHostname,
+		TrafficPolicy: &networking.TrafficPolicy{
+			ConnectionPool: &networking.ConnectionPoolSettings{
+				Http: &networking.ConnectionPoolSettings_HTTPSettings{
+					MaxRequestsPerConnection: 1,
+				},
+			},
+			PortLevelSettings: []*networking.TrafficPolicy_PortTrafficPolicy{
+				{
+					Port: &networking.PortSelector{
+						Number: 9090,
+					},
+					Tls: &networking.TLSSettings{
+						Mode: networking.TLSSettings_DISABLE,
+					},
+				},
+			},
+		},
+	}
+
+	// This workload-level beta policy doesn't affect CDS (yet).
+	peerAuthn := &authn_beta.PeerAuthentication{
+		Selector: &selectorpb.WorkloadSelector{
+			MatchLabels: map[string]string{
+				"version": "v1",
+			},
+		},
+		Mtls: &authn_beta.PeerAuthentication_MutualTLS{
+			Mode: authn_beta.PeerAuthentication_MutualTLS_STRICT,
+		},
+	}
+
+	testMesh.EnableAutoMtls.Value = true
+
+	clusters, err := buildTestClustersWithAuthnPolicy(TestServiceNHostname, 0, false, model.SidecarProxy, nil, testMesh, destRule, nil, peerAuthn)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// No policy visible, auto-mTLS should set to PERMISSIVE.
+	// For port 8080, (m)TLS settings is automatically added, thus its cluster should have TLS context.
+	// TlsContext is nil because we use socket match instead
+	g.Expect(getTLSContext(t, clusters[0])).To(BeNil())
+	g.Expect(clusters[0].TransportSocketMatches).To(HaveLen(2))
+
+	// For 9090, use the TLS settings are explicitly specified in DR (which disable TLS)
 	g.Expect(getTLSContext(t, clusters[1])).To(BeNil())
 
 	// Sanity check: make sure TLS is not accidentally added to other clusters.

--- a/pilot/pkg/security/authn/v1beta1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier.go
@@ -146,7 +146,7 @@ func (a *v1beta1PolicyApplier) AuthNFilter(proxyType model.NodeType, isXDSMarsha
 func (a *v1beta1PolicyApplier) InboundFilterChain(endpointPort uint32, sdsUdsPath string, node *model.Proxy) []plugin.FilterChain {
 	// If beta mTLS policy (PeerAuthentication) is not used for this workload, fallback to alpha policy.
 	if a.consolidatedPeerPolicy == nil && a.hasAlphaMTLSPolicy {
-		authnLog.Debug("InboundFilterChain: fallback to alpha policy applier")
+		authnLog.Debugf("InboundFilterChain [%v:%d]: fallback to alpha policy applier", node.ID, endpointPort)
 		return a.alphaApplier.InboundFilterChain(endpointPort, sdsUdsPath, node)
 	}
 	effectiveMTLSMode := model.MTLSPermissive
@@ -184,7 +184,7 @@ func NewPolicyApplier(rootNamespace string,
 		processedJwtRules:      processedJwtRules,
 		consolidatedPeerPolicy: composePeerAuthentication(rootNamespace, peerPolicies),
 		alphaApplier:           alpha_applier.NewPolicyApplier(policy),
-		hasAlphaMTLSPolicy:     alpha_applier.GetMutualTLS(policy) != nil,
+		hasAlphaMTLSPolicy:     policy != nil,
 	}
 }
 

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -154,6 +154,57 @@ func TestReachability(t *testing.T) {
 						return true
 					},
 				},
+				{
+					ConfigFile:          "beta-mtls-automtls.yaml",
+					Namespace:           rctx.Namespace,
+					RequiredEnvironment: environment.Kube,
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						return true
+					},
+					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+						// autoMtls doesn't work for client that doesn't have proxy, unless target doesn't
+						// have proxy neither.
+						if src == rctx.Naked {
+							return opts.Target == rctx.Naked
+						}
+						return true
+					},
+				},
+				{
+					ConfigFile:          "beta-mtls-partial-automtls.yaml",
+					Namespace:           rctx.Namespace,
+					RequiredEnvironment: environment.Kube,
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						return true
+					},
+					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+						// autoMtls doesn't work for client that doesn't have proxy, unless target doesn't
+						// have proxy or have mTLS disabled
+						if src == rctx.Naked {
+							return opts.Target == rctx.Naked || (opts.Target == rctx.B && opts.PortName != "http")
+
+						}
+						// PeerAuthentication disable mTLS for workload app:b, except http port. Thus, autoMTLS
+						// will fail on all ports on b, except http port.
+						return opts.Target != rctx.B || opts.PortName == "http"
+					},
+				},
+				{
+					ConfigFile:          "alpha-mtls-automtls.yaml",
+					Namespace:           rctx.Namespace,
+					RequiredEnvironment: environment.Kube,
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						return true
+					},
+					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+						// autoMtls doesn't work for client that doesn't have proxy, unless target doesn't
+						// have proxy or have mTLS disabled.
+						if src == rctx.Naked {
+							return opts.Target == rctx.Naked || (opts.Target == rctx.B && opts.PortName != "http")
+						}
+						return true
+					},
+				},
 			}
 			rctx.Run(testCases)
 		})

--- a/tests/integration/security/testdata/alpha-mtls-automtls.yaml
+++ b/tests/integration/security/testdata/alpha-mtls-automtls.yaml
@@ -1,0 +1,34 @@
+# Verify auto mTLS (still) works with alpha policy.
+apiVersion: authentication.istio.io/v1alpha1
+kind: MeshPolicy
+metadata:
+  name: "default"
+  annotations:
+    test-suite: "alpha-mtls-automtls"
+spec:
+  peers:
+  - mtls: {}
+---
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: "b-mtls-off"
+  annotations:
+    test-suite: "alpha-mtls-automtls"
+spec:
+  targets:
+  - name: "b"
+---
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: "b-80-mtls-on"
+  annotations:
+    test-suite: "alpha-mtls-automtls"
+spec:
+  targets:
+  - name: "b"
+    ports:
+    - name: http
+  peers:
+  - mtls: {}

--- a/tests/integration/security/testdata/beta-mtls-automtls.yaml
+++ b/tests/integration/security/testdata/beta-mtls-automtls.yaml
@@ -1,0 +1,19 @@
+# Alpha API disable, making test more hermetic.
+# No DR is added for this test. enableAutoMtls is expected on by default.
+apiVersion: authentication.istio.io/v1alpha1
+kind: MeshPolicy
+metadata:
+  name: "default"
+  annotations:
+    test-suite: "beta-mtls-automtls"
+spec: {}
+---
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "default"
+  annotations:
+    test-suite: "beta-mtls-automtls"
+spec:
+  mtls:
+    mode: STRICT

--- a/tests/integration/security/testdata/beta-mtls-partial-automtls.yaml
+++ b/tests/integration/security/testdata/beta-mtls-partial-automtls.yaml
@@ -1,0 +1,37 @@
+# Alpha API disable, making test more hermetic.
+# No DR is added for this test. enableAutoMtls is expected on by default.
+# Workload-level PeerAuthentication will expectedly cause trouble to connect to the corresponding service
+apiVersion: authentication.istio.io/v1alpha1
+kind: MeshPolicy
+metadata:
+  name: "default"
+  annotations:
+    test-suite: "beta-mtls-partial-automtls"
+spec: {}
+---
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "default"
+  annotations:
+    test-suite: "beta-mtls-partial-automtls"
+spec:
+  mtls:
+    mode: STRICT
+---
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "per-port"
+  annotations:
+    test-suite: "beta-mtls-partial-automtls"
+spec:
+  selector:
+    matchLabels:
+      app: b
+  mtls:
+    mode: DISABLE
+  portLevelMtls:
+    # 8090 is the targetPort for service http(80)
+    8090:
+      mode: STRICT


### PR DESCRIPTION
git cherry-pick 96f6f1842e82d8bb674f252af923b48187b0933c

Auto mTLS for namespace/mesh beta peer authn policies (#21124)

* Include PeerAuthentication policies to set the serviceMtlsMode for auto-mtls

* Add e2e test for auto-mTLS with clean beta-only policy

* Lint

* Add missing test file

* Correct cut-and-paste typo: all traffic should success if auto-mTLS is triggerred correctly

* Add const for namespace string

* Add test for autoMTLS when there are workload-level peer authn

* Add automtls e2e test for alpha policies

* Check selector empty to identify namespace & mesh policy instead of using name

* Fix e2e tests

* Fix e2e test for real

* Fix e2e tests, one more try.

* Fix e2e for alpha automtls

* Address comment

* Address comments

* Recommit local changes

* Fix fallback to alpha policy that disable mtls