### PR TITLE
Use respect_dns_ttl in bootstrap

### DIFF
--- a/manifests/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/istio-control/istio-discovery/files/injection-template.yaml
@@ -134,8 +134,6 @@ template: |
     - "{{ annotation .ObjectMeta `sidecar.istio.io/discoveryAddress` .ProxyConfig.DiscoveryAddress }}"
     - --proxyLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel}}
     - --proxyComponentLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel}}
-    - --dnsRefreshRate
-    - {{ valueOrDefault .Values.global.proxy.dnsRefreshRate "300s" }}
   {{- if (ne (annotation .ObjectMeta "status.sidecar.istio.io/port" .Values.global.proxy.statusPort) "0") }}
     - --statusPort
     - "{{ annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort }}"

--- a/manifests/istio-telemetry/prometheus/templates/deployment.yaml
+++ b/manifests/istio-telemetry/prometheus/templates/deployment.yaml
@@ -123,8 +123,6 @@ spec:
             - --controlPlaneAuthPolicy
             - NONE
               {{- end }}
-            - --dnsRefreshRate
-            - "300s"
             - --statusPort
             - "15020"
               {{- if .Values.global.trustDomain }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -625,8 +625,6 @@ spec:
             - "15000"
             - --controlPlaneAuthPolicy
             - NONE
-            - --dnsRefreshRate
-            - "300s"
             - --statusPort
             - "15020"
             - --trust-domain=cluster.local
@@ -9107,8 +9105,6 @@ data:
         - "{{ annotation .ObjectMeta `sidecar.istio.io/discoveryAddress` .ProxyConfig.DiscoveryAddress }}"
         - --proxyLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel}}
         - --proxyComponentLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel}}
-        - --dnsRefreshRate
-        - {{ valueOrDefault .Values.global.proxy.dnsRefreshRate "300s" }}
       {{- if (ne (annotation .ObjectMeta "status.sidecar.istio.io/port" .Values.global.proxy.statusPort) "0") }}
         - --statusPort
         - "{{ annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort }}"

--- a/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.golden.yaml
@@ -381,8 +381,6 @@ spec:
             - "15000"
             - --controlPlaneAuthPolicy
             - NONE
-            - --dnsRefreshRate
-            - "300s"
             - --statusPort
             - "15020"
             - --trust-domain=cluster.local
@@ -8093,8 +8091,6 @@ data:
         - "{{ annotation .ObjectMeta `sidecar.istio.io/discoveryAddress` .ProxyConfig.DiscoveryAddress }}"
         - --proxyLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel}}
         - --proxyComponentLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel}}
-        - --dnsRefreshRate
-        - {{ valueOrDefault .Values.global.proxy.dnsRefreshRate "300s" }}
       {{- if (ne (annotation .ObjectMeta "status.sidecar.istio.io/port" .Values.global.proxy.statusPort) "0") }}
         - --statusPort
         - "{{ annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort }}"

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_force.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_force.golden.yaml
@@ -896,8 +896,6 @@ data:
         - "{{ annotation .ObjectMeta `sidecar.istio.io/discoveryAddress` .ProxyConfig.DiscoveryAddress }}"
         - --proxyLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel}}
         - --proxyComponentLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel}}
-        - --dnsRefreshRate
-        - {{ valueOrDefault .Values.global.proxy.dnsRefreshRate "300s" }}
       {{- if (ne (annotation .ObjectMeta "status.sidecar.istio.io/port" .Values.global.proxy.statusPort) "0") }}
         - --statusPort
         - "{{ annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort }}"

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output.golden.yaml
@@ -895,8 +895,6 @@ data:
         - "{{ annotation .ObjectMeta `sidecar.istio.io/discoveryAddress` .ProxyConfig.DiscoveryAddress }}"
         - --proxyLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel}}
         - --proxyComponentLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel}}
-        - --dnsRefreshRate
-        - {{ valueOrDefault .Values.global.proxy.dnsRefreshRate "300s" }}
       {{- if (ne (annotation .ObjectMeta "status.sidecar.istio.io/port" .Values.global.proxy.statusPort) "0") }}
         - --statusPort
         - "{{ annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort }}"

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
@@ -6943,8 +6943,6 @@ data:
         - "{{ annotation .ObjectMeta `sidecar.istio.io/discoveryAddress` .ProxyConfig.DiscoveryAddress }}"
         - --proxyLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel}}
         - --proxyComponentLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel}}
-        - --dnsRefreshRate
-        - {{ valueOrDefault .Values.global.proxy.dnsRefreshRate "300s" }}
       {{- if (ne (annotation .ObjectMeta "status.sidecar.istio.io/port" .Values.global.proxy.statusPort) "0") }}
         - --statusPort
         - "{{ annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort }}"

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.golden.yaml
@@ -6356,8 +6356,6 @@ spec:
             - "15000"
             - --controlPlaneAuthPolicy
             - NONE
-            - --dnsRefreshRate
-            - "300s"
             - --statusPort
             - "15020"
             - --trust-domain=cluster.local
@@ -7883,8 +7881,6 @@ data:
         - "{{ annotation .ObjectMeta `sidecar.istio.io/discoveryAddress` .ProxyConfig.DiscoveryAddress }}"
         - --proxyLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel}}
         - --proxyComponentLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel}}
-        - --dnsRefreshRate
-        - {{ valueOrDefault .Values.global.proxy.dnsRefreshRate "300s" }}
       {{- if (ne (annotation .ObjectMeta "status.sidecar.istio.io/port" .Values.global.proxy.statusPort) "0") }}
         - --statusPort
         - "{{ annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort }}"

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_override_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_override_values.golden.yaml
@@ -893,8 +893,6 @@ data:
         - "{{ annotation .ObjectMeta `sidecar.istio.io/discoveryAddress` .ProxyConfig.DiscoveryAddress }}"
         - --proxyLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel}}
         - --proxyComponentLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel}}
-        - --dnsRefreshRate
-        - {{ valueOrDefault .Values.global.proxy.dnsRefreshRate "300s" }}
       {{- if (ne (annotation .ObjectMeta "status.sidecar.istio.io/port" .Values.global.proxy.statusPort) "0") }}
         - --statusPort
         - "{{ annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort }}"

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.golden.yaml
@@ -381,8 +381,6 @@ spec:
             - "15000"
             - --controlPlaneAuthPolicy
             - NONE
-            - --dnsRefreshRate
-            - "300s"
             - --statusPort
             - "15020"
             - --trust-domain=cluster.local
@@ -7883,8 +7881,6 @@ data:
         - "{{ annotation .ObjectMeta `sidecar.istio.io/discoveryAddress` .ProxyConfig.DiscoveryAddress }}"
         - --proxyLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel}}
         - --proxyComponentLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel}}
-        - --dnsRefreshRate
-        - {{ valueOrDefault .Values.global.proxy.dnsRefreshRate "300s" }}
       {{- if (ne (annotation .ObjectMeta "status.sidecar.istio.io/port" .Values.global.proxy.statusPort) "0") }}
         - --statusPort
         - "{{ annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort }}"

--- a/operator/cmd/mesh/testdata/manifest-generate/output/gateways_override_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/gateways_override_default.golden.yaml
@@ -381,8 +381,6 @@ spec:
             - "15000"
             - --controlPlaneAuthPolicy
             - NONE
-            - --dnsRefreshRate
-            - "300s"
             - --statusPort
             - "15020"
             - --trust-domain=cluster.local

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -893,8 +893,6 @@ data:
         - "{{ annotation .ObjectMeta `sidecar.istio.io/discoveryAddress` .ProxyConfig.DiscoveryAddress }}"
         - --proxyLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel}}
         - --proxyComponentLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel}}
-        - --dnsRefreshRate
-        - {{ valueOrDefault .Values.global.proxy.dnsRefreshRate "300s" }}
       {{- if (ne (annotation .ObjectMeta "status.sidecar.istio.io/port" .Values.global.proxy.statusPort) "0") }}
         - --statusPort
         - "{{ annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort }}"

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.golden.yaml
@@ -893,8 +893,6 @@ data:
         - "{{ annotation .ObjectMeta `sidecar.istio.io/discoveryAddress` .ProxyConfig.DiscoveryAddress }}"
         - --proxyLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel}}
         - --proxyComponentLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel}}
-        - --dnsRefreshRate
-        - {{ valueOrDefault .Values.global.proxy.dnsRefreshRate "300s" }}
       {{- if (ne (annotation .ObjectMeta "status.sidecar.istio.io/port" .Values.global.proxy.statusPort) "0") }}
         - --statusPort
         - "{{ annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort }}"

--- a/operator/cmd/mesh/testdata/manifest-generate/output/prometheus.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/prometheus.golden.yaml
@@ -381,8 +381,6 @@ spec:
             - "15000"
             - --controlPlaneAuthPolicy
             - NONE
-            - --dnsRefreshRate
-            - "300s"
             - --statusPort
             - "15020"
             - --trust-domain=cluster.local

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -10627,8 +10627,6 @@ template: |
     - "{{ annotation .ObjectMeta `+"`"+`sidecar.istio.io/discoveryAddress`+"`"+` .ProxyConfig.DiscoveryAddress }}"
     - --proxyLogLevel={{ annotation .ObjectMeta `+"`"+`sidecar.istio.io/logLevel`+"`"+` .Values.global.proxy.logLevel}}
     - --proxyComponentLogLevel={{ annotation .ObjectMeta `+"`"+`sidecar.istio.io/componentLogLevel`+"`"+` .Values.global.proxy.componentLogLevel}}
-    - --dnsRefreshRate
-    - {{ valueOrDefault .Values.global.proxy.dnsRefreshRate "300s" }}
   {{- if (ne (annotation .ObjectMeta "status.sidecar.istio.io/port" .Values.global.proxy.statusPort) "0") }}
     - --statusPort
     - "{{ annotation .ObjectMeta `+"`"+`status.sidecar.istio.io/port`+"`"+` .Values.global.proxy.statusPort }}"
@@ -34180,8 +34178,6 @@ spec:
             - --controlPlaneAuthPolicy
             - NONE
               {{- end }}
-            - --dnsRefreshRate
-            - "300s"
             - --statusPort
             - "15020"
               {{- if .Values.global.trustDomain }}

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -102,7 +102,6 @@ var (
 	customConfigFile         string
 	proxyLogLevel            string
 	proxyComponentLogLevel   string
-	dnsRefreshRate           string
 	concurrency              int
 	templateFile             string
 	disableInternalTelemetry bool
@@ -546,7 +545,6 @@ var (
 				PilotSubjectAltName: pilotSAN,
 				MixerSubjectAltName: mixerSAN,
 				NodeIPs:             role.IPAddresses,
-				DNSRefreshRate:      dnsRefreshRate,
 				PodName:             podName,
 				PodNamespace:        podNamespace,
 				PodIP:               podIP,
@@ -808,8 +806,6 @@ func init() {
 	// See https://www.envoyproxy.io/docs/envoy/latest/operations/cli#cmdoption-component-log-level
 	proxyCmd.PersistentFlags().StringVar(&proxyComponentLogLevel, "proxyComponentLogLevel", "misc:error",
 		"The component log level used to start the Envoy proxy")
-	proxyCmd.PersistentFlags().StringVar(&dnsRefreshRate, "dnsRefreshRate", "300s",
-		"The dns_refresh_rate for bootstrap STRICT_DNS clusters")
 	proxyCmd.PersistentFlags().IntVar(&concurrency, "concurrency", int(values.Concurrency),
 		"number of worker threads to run")
 	proxyCmd.PersistentFlags().StringVar(&templateFile, "templateFile", "",

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -79,7 +79,6 @@ var (
 // Config for creating a bootstrap file.
 type Config struct {
 	Node                string
-	DNSRefreshRate      string
 	Proxy               *meshAPI.ProxyConfig
 	PlatEnv             platform.Environment
 	PilotSubjectAltName []string
@@ -120,7 +119,6 @@ func (cfg Config) toTemplateParams() (map[string]interface{}, error) {
 		option.PodIP(cfg.PodIP),
 		option.PilotSubjectAltName(cfg.PilotSubjectAltName),
 		option.MixerSubjectAltName(cfg.MixerSubjectAltName),
-		option.DNSRefreshRate(cfg.DNSRefreshRate),
 		option.SDSTokenPath(cfg.SDSTokenPath),
 		option.SDSUDSPath(cfg.SDSUDSPath),
 		option.ControlPlaneAuth(cfg.ControlPlaneAuth),

--- a/pkg/bootstrap/instance_test.go
+++ b/pkg/bootstrap/instance_test.go
@@ -34,6 +34,8 @@ import (
 	"github.com/golang/protobuf/jsonpb"
 	diff "gopkg.in/d4l3k/messagediff.v1"
 
+	"istio.io/istio/pilot/test/util"
+
 	"istio.io/api/annotation"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 
@@ -263,10 +265,9 @@ func TestGolden(t *testing.T) {
 			}
 
 			fn, err := New(Config{
-				Node:           "sidecar~1.2.3.4~foo~bar",
-				DNSRefreshRate: "60s",
-				Proxy:          proxyConfig,
-				PlatEnv:        &fakePlatform{},
+				Node:    "sidecar~1.2.3.4~foo~bar",
+				Proxy:   proxyConfig,
+				PlatEnv: &fakePlatform{},
 				PilotSubjectAltName: []string{
 					"spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"},
 				LocalEnv:       localEnv,
@@ -300,7 +301,10 @@ func TestGolden(t *testing.T) {
 				return
 			}
 
-			golden, err := ioutil.ReadFile("testdata/" + c.base + "_golden.json")
+			goldenFile := "testdata/" + c.base + "_golden.json"
+			util.RefreshGoldenFile(read, goldenFile, t)
+
+			golden, err := ioutil.ReadFile(goldenFile)
 			if err != nil {
 				golden = []byte{}
 			}

--- a/pkg/bootstrap/option/instances.go
+++ b/pkg/bootstrap/option/instances.go
@@ -86,10 +86,6 @@ func DiscoveryAddress(value string) Instance {
 	return newOption("discovery_address", value)
 }
 
-func DNSRefreshRate(value string) Instance {
-	return newOption("dns_refresh_rate", value)
-}
-
 func Localhost(value LocalhostValue) Instance {
 	return newOption("localhost", value)
 }

--- a/pkg/bootstrap/option/instances_test.go
+++ b/pkg/bootstrap/option/instances_test.go
@@ -127,12 +127,6 @@ func TestOptions(t *testing.T) {
 			expected: "fake",
 		},
 		{
-			testName: "dns refresh rate",
-			key:      "dns_refresh_rate",
-			option:   option.DNSRefreshRate("1s"),
-			expected: "1s",
-		},
-		{
 			testName: "localhost v4",
 			key:      "localhost",
 			option:   option.Localhost(option.LocalhostIPv4),

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -2,8 +2,12 @@
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
-    "locality": {},
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT"}
+    "locality": {
+      
+      
+      
+    },
+    "metadata": {"EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT","INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6"}
   },
   "stats_config": {
     "use_all_default_tags": false,
@@ -17,8 +21,8 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "tag_name": "response_code",
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+          "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+          "tag_name": "response_code"
       },
       {
         "tag_name": "response_code_class",
@@ -41,108 +45,108 @@
         "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
       },
       {
-        "regex": "(reporter=\\.=(.+?);\\.;)",
-        "tag_name": "reporter"
+          "regex": "(reporter=\\.=(.+?);\\.;)",
+          "tag_name": "reporter"
       },
       {
-        "regex": "(source_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "source_namespace"
+          "regex": "(source_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "source_namespace"
       },
       {
-        "regex": "(source_workload=\\.=(.+?);\\.;)",
-        "tag_name": "source_workload"
+          "regex": "(source_workload=\\.=(.+?);\\.;)",
+          "tag_name": "source_workload"
       },
       {
-        "regex": "(source_workload_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "source_workload_namespace"
+          "regex": "(source_workload_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "source_workload_namespace"
       },
       {
-        "regex": "(source_principal=\\.=(.+?);\\.;)",
-        "tag_name": "source_principal"
+          "regex": "(source_principal=\\.=(.+?);\\.;)",
+          "tag_name": "source_principal"
       },
       {
-        "regex": "(source_app=\\.=(.+?);\\.;)",
-        "tag_name": "source_app"
+          "regex": "(source_app=\\.=(.+?);\\.;)",
+          "tag_name": "source_app"
       },
       {
-        "regex": "(source_version=\\.=(.+?);\\.;)",
-        "tag_name": "source_version"
+          "regex": "(source_version=\\.=(.+?);\\.;)",
+          "tag_name": "source_version"
       },
       {
-        "regex": "(destination_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_namespace"
+          "regex": "(destination_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_namespace"
       },
       {
-        "regex": "(destination_workload=\\.=(.+?);\\.;)",
-        "tag_name": "destination_workload"
+          "regex": "(destination_workload=\\.=(.+?);\\.;)",
+          "tag_name": "destination_workload"
       },
       {
-        "regex": "(destination_workload_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_workload_namespace"
+          "regex": "(destination_workload_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_workload_namespace"
       },
       {
-        "regex": "(destination_principal=\\.=(.+?);\\.;)",
-        "tag_name": "destination_principal"
+          "regex": "(destination_principal=\\.=(.+?);\\.;)",
+          "tag_name": "destination_principal"
       },
       {
-        "regex": "(destination_app=\\.=(.+?);\\.;)",
-        "tag_name": "destination_app"
+          "regex": "(destination_app=\\.=(.+?);\\.;)",
+          "tag_name": "destination_app"
       },
       {
-        "regex": "(destination_version=\\.=(.+?);\\.;)",
-        "tag_name": "destination_version"
+          "regex": "(destination_version=\\.=(.+?);\\.;)",
+          "tag_name": "destination_version"
       },
       {
-        "regex": "(destination_service=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service"
+          "regex": "(destination_service=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service"
       },
       {
-        "regex": "(destination_service_name=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service_name"
+          "regex": "(destination_service_name=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service_name"
       },
       {
-        "regex": "(destination_service_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service_namespace"
+          "regex": "(destination_service_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service_namespace"
       },
       {
         "regex": "(destination_port=\\.=(.+?);\\.;)",
         "tag_name": "destination_port"
       },
       {
-        "regex": "(request_protocol=\\.=(.+?);\\.;)",
-        "tag_name": "request_protocol"
+          "regex": "(request_protocol=\\.=(.+?);\\.;)",
+          "tag_name": "request_protocol"
       },
       {
-        "regex": "(response_flags=\\.=(.+?);\\.;)",
-        "tag_name": "response_flags"
+          "regex": "(response_flags=\\.=(.+?);\\.;)",
+          "tag_name": "response_flags"
       },
       {
-        "regex": "(grpc_response_status=\\.=(.*?);\\.;)",
-        "tag_name": "grpc_response_status"
+          "regex": "(grpc_response_status=\\.=(.*?);\\.;)",
+          "tag_name": "grpc_response_status"
       },
       {
-        "regex": "(connection_security_policy=\\.=(.+?);\\.;)",
-        "tag_name": "connection_security_policy"
+          "regex": "(connection_security_policy=\\.=(.+?);\\.;)",
+          "tag_name": "connection_security_policy"
       },
       {
-        "regex": "(permissive_response_code=\\.=(.+?);\\.;)",
-        "tag_name": "permissive_response_code"
+          "regex": "(permissive_response_code=\\.=(.+?);\\.;)",
+          "tag_name": "permissive_response_code"
       },
       {
-        "regex": "(permissive_response_policyid=\\.=(.+?);\\.;)",
-        "tag_name": "permissive_response_policyid"
+          "regex": "(permissive_response_policyid=\\.=(.+?);\\.;)",
+          "tag_name": "permissive_response_policyid"
       },
       {
-        "regex": "(cache\\.(.+?)\\.)",
-        "tag_name": "cache"
+          "regex": "(cache\\.(.+?)\\.)",
+          "tag_name": "cache"
       },
       {
-        "regex": "(component\\.(.+?)\\.)",
-        "tag_name": "component"
+          "regex": "(component\\.(.+?)\\.)",
+          "tag_name": "component"
       },
       {
-        "regex": "(tag\\.(.+?)\\.)",
-        "tag_name": "tag"
+          "regex": "(tag\\.(.+?)\\.)",
+          "tag_name": "tag"
       },
       {
           "regex": "(source_canonical_service=\\.=(.+?);\\.;)",
@@ -163,28 +167,34 @@
     ],
     "stats_matcher": {
       "inclusion_list": {
-        "patterns": [{"prefix": "reporter="},
+        "patterns": [
           {
-            "prefix": "cluster_manager"
+          "prefix": "reporter="
           },
           {
-            "prefix": "listener_manager"
+          "prefix": "component"
           },
           {
-            "prefix": "http_mixer_filter"
+          "prefix": "cluster_manager"
           },
           {
-            "prefix": "tcp_mixer_filter"
+          "prefix": "listener_manager"
           },
           {
-            "prefix": "server"
+          "prefix": "http_mixer_filter"
           },
           {
-            "prefix": "cluster.xds-grpc"
+          "prefix": "tcp_mixer_filter"
           },
           {
-            "suffix": "ssl_context_update_by_sds"
-          }
+          "prefix": "server"
+          },
+          {
+          "prefix": "cluster.xds-grpc"
+          },
+          {
+          "suffix": "ssl_context_update_by_sds"
+          },
         ]
       }
     }
@@ -236,10 +246,11 @@
       {
         "name": "xds-grpc",
         "type": "STRICT_DNS",
-        "dns_refresh_rate": "60s",
+        "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "7s",
         "lb_policy": "ROUND_ROBIN",
+        
         
         "tls_context": {
           "common_tls_context": {
@@ -260,12 +271,11 @@
               "trusted_ca": {
                 "filename": "/etc/certs/root-cert.pem"
               },
-              "verify_subject_alt_name": [
-                "spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"
-              ]
+              "verify_subject_alt_name": ["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"]
             }
           }
         },
+        
         
         "hosts": [
           {
@@ -301,7 +311,7 @@
       {
         "name": "zipkin",
         "type": "STRICT_DNS",
-        "dns_refresh_rate": "60s",
+        "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -311,12 +321,17 @@
           }
         ]
       }
-
+      
+      
       ,
       {
         "name": "envoy_metrics_service",
         "type": "STRICT_DNS",
-        "dns_refresh_rate": "60s",
+      
+        "tls_context": {"common_tls_context":{"tls_certificates":[{"certificate_chain":{"filename":"/etc/istio/ms/client.pem"},"private_key":{"filename":"/etc/istio/ms/key.pem"}}],"validation_context":{"trusted_ca":{"filename":"/etc/istio/ms/ca.pem"}},"alpn_protocols":["h2"]}},
+      
+      
+        "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -325,44 +340,25 @@
           {
             "socket_address": {"address": "metrics-service", "port_value": 15000}
           }
-        ],
-        "tls_context":{ 
-          "common_tls_context":{ 
-             "alpn_protocols":[ 
-                "h2"
-             ],
-             "tls_certificates":[ 
-                { 
-                   "certificate_chain":{ 
-                      "filename":"/etc/istio/ms/client.pem"
-                   },
-                   "private_key":{ 
-                      "filename":"/etc/istio/ms/key.pem"
-                   }
-                }
-             ],
-             "validation_context":{ 
-                "trusted_ca":{ 
-                   "filename":"/etc/istio/ms/ca.pem"
-                }
-             }
-          }
-       }
+        ]
       }
-
+      
+      
       ,
       {
         "name": "envoy_accesslog_service",
         "type": "STRICT_DNS",
-        "dns_refresh_rate": "60s",
+      
+      
+        "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
         "http2_protocol_options": {},
         "hosts": [
-           {
-             "socket_address": {"address": "accesslog-service", "port_value": 15000}
-           }
+          {
+            "socket_address": {"address": "accesslog-service", "port_value": 15000}
+          }
         ]
       }
       
@@ -424,7 +420,7 @@
         "collector_cluster": "zipkin",
         "collector_endpoint": "/api/v2/spans",
         "collector_endpoint_version": "HTTP_JSON",
-        "trace_id_128bit":"true",
+        "trace_id_128bit": "true",
         "shared_span_context": "false"
       }
     }
@@ -433,7 +429,7 @@
   
   ,
   "stats_sinks": [
-
+    
     {
       "name": "envoy.metrics_service",
       "config": {
@@ -444,7 +440,8 @@
         }
       }
     },
-
+    
+    
     {
       "name": "envoy.statsd",
       "config": {
@@ -452,14 +449,16 @@
           "socket_address": {"address": "10.1.1.1", "port_value": 9125}
         }
       }
-    }
-
+    },
+    
   ]
+  
   
   ,
   "cluster_manager": {
     "outlier_detection": {
-      "event_log_path": "/dev/stdout"
+      "event_log_path": /dev/stdout
     }
   }
+  
 }

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -2,9 +2,12 @@
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
-    "locality": {},
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6",
-      "EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT"}
+    "locality": {
+      
+      
+      
+    },
+    "metadata": {"EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT","INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6"}
   },
   "stats_config": {
     "use_all_default_tags": false,
@@ -18,8 +21,8 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "tag_name": "response_code",
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+          "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+          "tag_name": "response_code"
       },
       {
         "tag_name": "response_code_class",
@@ -42,108 +45,108 @@
         "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
       },
       {
-        "regex": "(reporter=\\.=(.+?);\\.;)",
-        "tag_name": "reporter"
+          "regex": "(reporter=\\.=(.+?);\\.;)",
+          "tag_name": "reporter"
       },
       {
-        "regex": "(source_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "source_namespace"
+          "regex": "(source_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "source_namespace"
       },
       {
-        "regex": "(source_workload=\\.=(.+?);\\.;)",
-        "tag_name": "source_workload"
+          "regex": "(source_workload=\\.=(.+?);\\.;)",
+          "tag_name": "source_workload"
       },
       {
-        "regex": "(source_workload_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "source_workload_namespace"
+          "regex": "(source_workload_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "source_workload_namespace"
       },
       {
-        "regex": "(source_principal=\\.=(.+?);\\.;)",
-        "tag_name": "source_principal"
+          "regex": "(source_principal=\\.=(.+?);\\.;)",
+          "tag_name": "source_principal"
       },
       {
-        "regex": "(source_app=\\.=(.+?);\\.;)",
-        "tag_name": "source_app"
+          "regex": "(source_app=\\.=(.+?);\\.;)",
+          "tag_name": "source_app"
       },
       {
-        "regex": "(source_version=\\.=(.+?);\\.;)",
-        "tag_name": "source_version"
+          "regex": "(source_version=\\.=(.+?);\\.;)",
+          "tag_name": "source_version"
       },
       {
-        "regex": "(destination_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_namespace"
+          "regex": "(destination_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_namespace"
       },
       {
-        "regex": "(destination_workload=\\.=(.+?);\\.;)",
-        "tag_name": "destination_workload"
+          "regex": "(destination_workload=\\.=(.+?);\\.;)",
+          "tag_name": "destination_workload"
       },
       {
-        "regex": "(destination_workload_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_workload_namespace"
+          "regex": "(destination_workload_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_workload_namespace"
       },
       {
-        "regex": "(destination_principal=\\.=(.+?);\\.;)",
-        "tag_name": "destination_principal"
+          "regex": "(destination_principal=\\.=(.+?);\\.;)",
+          "tag_name": "destination_principal"
       },
       {
-        "regex": "(destination_app=\\.=(.+?);\\.;)",
-        "tag_name": "destination_app"
+          "regex": "(destination_app=\\.=(.+?);\\.;)",
+          "tag_name": "destination_app"
       },
       {
-        "regex": "(destination_version=\\.=(.+?);\\.;)",
-        "tag_name": "destination_version"
+          "regex": "(destination_version=\\.=(.+?);\\.;)",
+          "tag_name": "destination_version"
       },
       {
-        "regex": "(destination_service=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service"
+          "regex": "(destination_service=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service"
       },
       {
-        "regex": "(destination_service_name=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service_name"
+          "regex": "(destination_service_name=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service_name"
       },
       {
-        "regex": "(destination_service_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service_namespace"
+          "regex": "(destination_service_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service_namespace"
       },
       {
         "regex": "(destination_port=\\.=(.+?);\\.;)",
         "tag_name": "destination_port"
       },
       {
-        "regex": "(request_protocol=\\.=(.+?);\\.;)",
-        "tag_name": "request_protocol"
+          "regex": "(request_protocol=\\.=(.+?);\\.;)",
+          "tag_name": "request_protocol"
       },
       {
-        "regex": "(response_flags=\\.=(.+?);\\.;)",
-        "tag_name": "response_flags"
+          "regex": "(response_flags=\\.=(.+?);\\.;)",
+          "tag_name": "response_flags"
       },
       {
-        "regex": "(grpc_response_status=\\.=(.*?);\\.;)",
-        "tag_name": "grpc_response_status"
+          "regex": "(grpc_response_status=\\.=(.*?);\\.;)",
+          "tag_name": "grpc_response_status"
       },
       {
-        "regex": "(connection_security_policy=\\.=(.+?);\\.;)",
-        "tag_name": "connection_security_policy"
+          "regex": "(connection_security_policy=\\.=(.+?);\\.;)",
+          "tag_name": "connection_security_policy"
       },
       {
-        "regex": "(permissive_response_code=\\.=(.+?);\\.;)",
-        "tag_name": "permissive_response_code"
+          "regex": "(permissive_response_code=\\.=(.+?);\\.;)",
+          "tag_name": "permissive_response_code"
       },
       {
-        "regex": "(permissive_response_policyid=\\.=(.+?);\\.;)",
-        "tag_name": "permissive_response_policyid"
+          "regex": "(permissive_response_policyid=\\.=(.+?);\\.;)",
+          "tag_name": "permissive_response_policyid"
       },
       {
-        "regex": "(cache\\.(.+?)\\.)",
-        "tag_name": "cache"
+          "regex": "(cache\\.(.+?)\\.)",
+          "tag_name": "cache"
       },
       {
-        "regex": "(component\\.(.+?)\\.)",
-        "tag_name": "component"
+          "regex": "(component\\.(.+?)\\.)",
+          "tag_name": "component"
       },
       {
-        "regex": "(tag\\.(.+?)\\.)",
-        "tag_name": "tag"
+          "regex": "(tag\\.(.+?)\\.)",
+          "tag_name": "tag"
       },
       {
           "regex": "(source_canonical_service=\\.=(.+?);\\.;)",
@@ -164,27 +167,34 @@
     ],
     "stats_matcher": {
       "inclusion_list": {
-        "patterns": [{"prefix": "reporter="},{
-            "prefix": "cluster_manager"
+        "patterns": [
+          {
+          "prefix": "reporter="
           },
           {
-            "prefix": "listener_manager"
+          "prefix": "component"
           },
           {
-            "prefix": "http_mixer_filter"
+          "prefix": "cluster_manager"
           },
           {
-            "prefix": "tcp_mixer_filter"
+          "prefix": "listener_manager"
           },
           {
-            "prefix": "server"
+          "prefix": "http_mixer_filter"
           },
           {
-            "prefix": "cluster.xds-grpc"
+          "prefix": "tcp_mixer_filter"
           },
           {
-            "suffix": "ssl_context_update_by_sds"
-          }
+          "prefix": "server"
+          },
+          {
+          "prefix": "cluster.xds-grpc"
+          },
+          {
+          "suffix": "ssl_context_update_by_sds"
+          },
         ]
       }
     }
@@ -236,10 +246,11 @@
       {
         "name": "xds-grpc",
         "type": "STRICT_DNS",
-        "dns_refresh_rate": "60s",
+        "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
+        
         
         "tls_context": {
           "common_tls_context": {
@@ -260,12 +271,11 @@
               "trusted_ca": {
                 "filename": "/etc/certs/root-cert.pem"
               },
-              "verify_subject_alt_name": [
-                "spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"
-              ]
+              "verify_subject_alt_name": ["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"]
             }
           }
         },
+        
         
         "hosts": [
           {
@@ -296,6 +306,8 @@
         "max_requests_per_connection": 1,
         "http2_protocol_options": { }
       }
+      
+      
       
     ],
     "listeners":[
@@ -347,10 +359,13 @@
     ]
   }
   
+  
+  
   ,
   "cluster_manager": {
     "outlier_detection": {
-      "event_log_path": "/dev/stdout"
+      "event_log_path": /dev/stdout
     }
   }
+  
 }

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -2,11 +2,12 @@
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
-    "locality": {},
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6",
-      "SDS": "true",
-      "TRUSTJWT": "true",
-      "EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT"}
+    "locality": {
+      
+      
+      
+    },
+    "metadata": {"EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT","INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","SDS":"true","TRUSTJWT":"true"}
   },
   "stats_config": {
     "use_all_default_tags": false,
@@ -20,8 +21,8 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "tag_name": "response_code",
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$"
+          "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+          "tag_name": "response_code"
       },
       {
         "tag_name": "response_code_class",
@@ -44,108 +45,108 @@
         "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
       },
       {
-        "regex": "(reporter=\\.=(.+?);\\.;)",
-        "tag_name": "reporter"
+          "regex": "(reporter=\\.=(.+?);\\.;)",
+          "tag_name": "reporter"
       },
       {
-        "regex": "(source_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "source_namespace"
+          "regex": "(source_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "source_namespace"
       },
       {
-        "regex": "(source_workload=\\.=(.+?);\\.;)",
-        "tag_name": "source_workload"
+          "regex": "(source_workload=\\.=(.+?);\\.;)",
+          "tag_name": "source_workload"
       },
       {
-        "regex": "(source_workload_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "source_workload_namespace"
+          "regex": "(source_workload_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "source_workload_namespace"
       },
       {
-        "regex": "(source_principal=\\.=(.+?);\\.;)",
-        "tag_name": "source_principal"
+          "regex": "(source_principal=\\.=(.+?);\\.;)",
+          "tag_name": "source_principal"
       },
       {
-        "regex": "(source_app=\\.=(.+?);\\.;)",
-        "tag_name": "source_app"
+          "regex": "(source_app=\\.=(.+?);\\.;)",
+          "tag_name": "source_app"
       },
       {
-        "regex": "(source_version=\\.=(.+?);\\.;)",
-        "tag_name": "source_version"
+          "regex": "(source_version=\\.=(.+?);\\.;)",
+          "tag_name": "source_version"
       },
       {
-        "regex": "(destination_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_namespace"
+          "regex": "(destination_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_namespace"
       },
       {
-        "regex": "(destination_workload=\\.=(.+?);\\.;)",
-        "tag_name": "destination_workload"
+          "regex": "(destination_workload=\\.=(.+?);\\.;)",
+          "tag_name": "destination_workload"
       },
       {
-        "regex": "(destination_workload_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_workload_namespace"
+          "regex": "(destination_workload_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_workload_namespace"
       },
       {
-        "regex": "(destination_principal=\\.=(.+?);\\.;)",
-        "tag_name": "destination_principal"
+          "regex": "(destination_principal=\\.=(.+?);\\.;)",
+          "tag_name": "destination_principal"
       },
       {
-        "regex": "(destination_app=\\.=(.+?);\\.;)",
-        "tag_name": "destination_app"
+          "regex": "(destination_app=\\.=(.+?);\\.;)",
+          "tag_name": "destination_app"
       },
       {
-        "regex": "(destination_version=\\.=(.+?);\\.;)",
-        "tag_name": "destination_version"
+          "regex": "(destination_version=\\.=(.+?);\\.;)",
+          "tag_name": "destination_version"
       },
       {
-        "regex": "(destination_service=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service"
+          "regex": "(destination_service=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service"
       },
       {
-        "regex": "(destination_service_name=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service_name"
+          "regex": "(destination_service_name=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service_name"
       },
       {
-        "regex": "(destination_service_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service_namespace"
+          "regex": "(destination_service_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service_namespace"
       },
       {
         "regex": "(destination_port=\\.=(.+?);\\.;)",
         "tag_name": "destination_port"
       },
       {
-        "regex": "(request_protocol=\\.=(.+?);\\.;)",
-        "tag_name": "request_protocol"
+          "regex": "(request_protocol=\\.=(.+?);\\.;)",
+          "tag_name": "request_protocol"
       },
       {
-        "regex": "(response_flags=\\.=(.+?);\\.;)",
-        "tag_name": "response_flags"
+          "regex": "(response_flags=\\.=(.+?);\\.;)",
+          "tag_name": "response_flags"
       },
       {
-        "regex": "(grpc_response_status=\\.=(.*?);\\.;)",
-        "tag_name": "grpc_response_status"
+          "regex": "(grpc_response_status=\\.=(.*?);\\.;)",
+          "tag_name": "grpc_response_status"
       },
       {
-        "regex": "(connection_security_policy=\\.=(.+?);\\.;)",
-        "tag_name": "connection_security_policy"
+          "regex": "(connection_security_policy=\\.=(.+?);\\.;)",
+          "tag_name": "connection_security_policy"
       },
       {
-        "regex": "(permissive_response_code=\\.=(.+?);\\.;)",
-        "tag_name": "permissive_response_code"
+          "regex": "(permissive_response_code=\\.=(.+?);\\.;)",
+          "tag_name": "permissive_response_code"
       },
       {
-        "regex": "(permissive_response_policyid=\\.=(.+?);\\.;)",
-        "tag_name": "permissive_response_policyid"
+          "regex": "(permissive_response_policyid=\\.=(.+?);\\.;)",
+          "tag_name": "permissive_response_policyid"
       },
       {
-        "regex": "(cache\\.(.+?)\\.)",
-        "tag_name": "cache"
+          "regex": "(cache\\.(.+?)\\.)",
+          "tag_name": "cache"
       },
       {
-        "regex": "(component\\.(.+?)\\.)",
-        "tag_name": "component"
+          "regex": "(component\\.(.+?)\\.)",
+          "tag_name": "component"
       },
       {
-        "regex": "(tag\\.(.+?)\\.)",
-        "tag_name": "tag"
+          "regex": "(tag\\.(.+?)\\.)",
+          "tag_name": "tag"
       },
       {
           "regex": "(source_canonical_service=\\.=(.+?);\\.;)",
@@ -166,27 +167,34 @@
     ],
     "stats_matcher": {
       "inclusion_list": {
-        "patterns": [{"prefix": "reporter="},{
-            "prefix": "cluster_manager"
+        "patterns": [
+          {
+          "prefix": "reporter="
           },
           {
-            "prefix": "listener_manager"
+          "prefix": "component"
           },
           {
-            "prefix": "http_mixer_filter"
+          "prefix": "cluster_manager"
           },
           {
-            "prefix": "tcp_mixer_filter"
+          "prefix": "listener_manager"
           },
           {
-            "prefix": "server"
+          "prefix": "http_mixer_filter"
           },
           {
-            "prefix": "cluster.xds-grpc"
+          "prefix": "tcp_mixer_filter"
           },
           {
-            "suffix": "ssl_context_update_by_sds"
-          }
+          "prefix": "server"
+          },
+          {
+          "prefix": "cluster.xds-grpc"
+          },
+          {
+          "suffix": "ssl_context_update_by_sds"
+          },
         ]
       }
     }
@@ -238,16 +246,18 @@
       {
         "name": "xds-grpc",
         "type": "STRICT_DNS",
-        "dns_refresh_rate": "60s",
+        "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
+        
         
         "tls_context": {
           "common_tls_context": {
             "alpn_protocols": [
               "h2"
             ],
+            
             "tls_certificate_sds_secret_configs":[
               {
                 "name":"default",
@@ -286,9 +296,7 @@
             ],
             "combined_validation_context":{
               "default_validation_context":{
-                "verify_subject_alt_name":[
-                  "spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"
-                ]
+                "verify_subject_alt_name": ["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"]
               },
               "validation_context_sds_secret_config":{
                 "name":"ROOTCA",
@@ -325,8 +333,10 @@
                 }
               }
             }
-          }
+            
+          },
         },
+        
         
         "hosts": [
           {
@@ -357,6 +367,8 @@
         "max_requests_per_connection": 1,
         "http2_protocol_options": { }
       }
+      
+      
       
     ],
     "listeners":[
@@ -408,10 +420,13 @@
     ]
   }
   
+  
+  
   ,
   "cluster_manager": {
     "outlier_detection": {
-      "event_log_path": "/dev/stdout"
+      "event_log_path": /dev/stdout
     }
   }
+  
 }

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -2,8 +2,12 @@
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
-    "locality": {},
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT"}
+    "locality": {
+      
+      
+      
+    },
+    "metadata": {"EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT","INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6"}
   },
   "stats_config": {
     "use_all_default_tags": false,
@@ -17,8 +21,8 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "tag_name": "response_code",
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+          "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+          "tag_name": "response_code"
       },
       {
         "tag_name": "response_code_class",
@@ -41,108 +45,108 @@
         "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
       },
       {
-        "regex": "(reporter=\\.=(.+?);\\.;)",
-        "tag_name": "reporter"
+          "regex": "(reporter=\\.=(.+?);\\.;)",
+          "tag_name": "reporter"
       },
       {
-        "regex": "(source_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "source_namespace"
+          "regex": "(source_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "source_namespace"
       },
       {
-        "regex": "(source_workload=\\.=(.+?);\\.;)",
-        "tag_name": "source_workload"
+          "regex": "(source_workload=\\.=(.+?);\\.;)",
+          "tag_name": "source_workload"
       },
       {
-        "regex": "(source_workload_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "source_workload_namespace"
+          "regex": "(source_workload_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "source_workload_namespace"
       },
       {
-        "regex": "(source_principal=\\.=(.+?);\\.;)",
-        "tag_name": "source_principal"
+          "regex": "(source_principal=\\.=(.+?);\\.;)",
+          "tag_name": "source_principal"
       },
       {
-        "regex": "(source_app=\\.=(.+?);\\.;)",
-        "tag_name": "source_app"
+          "regex": "(source_app=\\.=(.+?);\\.;)",
+          "tag_name": "source_app"
       },
       {
-        "regex": "(source_version=\\.=(.+?);\\.;)",
-        "tag_name": "source_version"
+          "regex": "(source_version=\\.=(.+?);\\.;)",
+          "tag_name": "source_version"
       },
       {
-        "regex": "(destination_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_namespace"
+          "regex": "(destination_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_namespace"
       },
       {
-        "regex": "(destination_workload=\\.=(.+?);\\.;)",
-        "tag_name": "destination_workload"
+          "regex": "(destination_workload=\\.=(.+?);\\.;)",
+          "tag_name": "destination_workload"
       },
       {
-        "regex": "(destination_workload_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_workload_namespace"
+          "regex": "(destination_workload_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_workload_namespace"
       },
       {
-        "regex": "(destination_principal=\\.=(.+?);\\.;)",
-        "tag_name": "destination_principal"
+          "regex": "(destination_principal=\\.=(.+?);\\.;)",
+          "tag_name": "destination_principal"
       },
       {
-        "regex": "(destination_app=\\.=(.+?);\\.;)",
-        "tag_name": "destination_app"
+          "regex": "(destination_app=\\.=(.+?);\\.;)",
+          "tag_name": "destination_app"
       },
       {
-        "regex": "(destination_version=\\.=(.+?);\\.;)",
-        "tag_name": "destination_version"
+          "regex": "(destination_version=\\.=(.+?);\\.;)",
+          "tag_name": "destination_version"
       },
       {
-        "regex": "(destination_service=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service"
+          "regex": "(destination_service=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service"
       },
       {
-        "regex": "(destination_service_name=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service_name"
+          "regex": "(destination_service_name=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service_name"
       },
       {
-        "regex": "(destination_service_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service_namespace"
+          "regex": "(destination_service_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service_namespace"
       },
       {
         "regex": "(destination_port=\\.=(.+?);\\.;)",
         "tag_name": "destination_port"
       },
       {
-        "regex": "(request_protocol=\\.=(.+?);\\.;)",
-        "tag_name": "request_protocol"
+          "regex": "(request_protocol=\\.=(.+?);\\.;)",
+          "tag_name": "request_protocol"
       },
       {
-        "regex": "(response_flags=\\.=(.+?);\\.;)",
-        "tag_name": "response_flags"
+          "regex": "(response_flags=\\.=(.+?);\\.;)",
+          "tag_name": "response_flags"
       },
       {
-        "regex": "(grpc_response_status=\\.=(.*?);\\.;)",
-        "tag_name": "grpc_response_status"
+          "regex": "(grpc_response_status=\\.=(.*?);\\.;)",
+          "tag_name": "grpc_response_status"
       },
       {
-        "regex": "(connection_security_policy=\\.=(.+?);\\.;)",
-        "tag_name": "connection_security_policy"
+          "regex": "(connection_security_policy=\\.=(.+?);\\.;)",
+          "tag_name": "connection_security_policy"
       },
       {
-        "regex": "(permissive_response_code=\\.=(.+?);\\.;)",
-        "tag_name": "permissive_response_code"
+          "regex": "(permissive_response_code=\\.=(.+?);\\.;)",
+          "tag_name": "permissive_response_code"
       },
       {
-        "regex": "(permissive_response_policyid=\\.=(.+?);\\.;)",
-        "tag_name": "permissive_response_policyid"
+          "regex": "(permissive_response_policyid=\\.=(.+?);\\.;)",
+          "tag_name": "permissive_response_policyid"
       },
       {
-        "regex": "(cache\\.(.+?)\\.)",
-        "tag_name": "cache"
+          "regex": "(cache\\.(.+?)\\.)",
+          "tag_name": "cache"
       },
       {
-        "regex": "(component\\.(.+?)\\.)",
-        "tag_name": "component"
+          "regex": "(component\\.(.+?)\\.)",
+          "tag_name": "component"
       },
       {
-        "regex": "(tag\\.(.+?)\\.)",
-        "tag_name": "tag"
+          "regex": "(tag\\.(.+?)\\.)",
+          "tag_name": "tag"
       },
       {
           "regex": "(source_canonical_service=\\.=(.+?);\\.;)",
@@ -163,27 +167,34 @@
     ],
     "stats_matcher": {
       "inclusion_list": {
-        "patterns": [{"prefix": "reporter="},{
-            "prefix": "cluster_manager"
+        "patterns": [
+          {
+          "prefix": "reporter="
           },
           {
-            "prefix": "listener_manager"
+          "prefix": "component"
           },
           {
-            "prefix": "http_mixer_filter"
+          "prefix": "cluster_manager"
           },
           {
-            "prefix": "tcp_mixer_filter"
+          "prefix": "listener_manager"
           },
           {
-            "prefix": "server"
+          "prefix": "http_mixer_filter"
           },
           {
-            "prefix": "cluster.xds-grpc"
+          "prefix": "tcp_mixer_filter"
           },
           {
-            "suffix": "ssl_context_update_by_sds"
-          }
+          "prefix": "server"
+          },
+          {
+          "prefix": "cluster.xds-grpc"
+          },
+          {
+          "suffix": "ssl_context_update_by_sds"
+          },
         ]
       }
     }
@@ -235,7 +246,7 @@
       {
         "name": "xds-grpc",
         "type": "STRICT_DNS",
-        "dns_refresh_rate": "60s",
+        "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -269,6 +280,8 @@
         "max_requests_per_connection": 1,
         "http2_protocol_options": { }
       }
+      
+      
       
     ],
     "listeners":[
@@ -320,10 +333,13 @@
     ]
   }
   
+  
+  
   ,
   "cluster_manager": {
     "outlier_detection": {
-      "event_log_path": "/dev/stdout"
+      "event_log_path": /dev/stdout
     }
   }
+  
 }

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -3,29 +3,17 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {
+      
       "region": "regionA",
+      
+      
       "zone": "zoneB",
-      "sub_zone": "sub_zoneC"
+      
+      
+      "sub_zone": "sub_zoneC",
+      
     },
-    "metadata": {
-      "INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6",
-      "INTERCEPTION_MODE":"REDIRECT",
-      "ISTIO_VERSION":"release-3.1",
-      "istio.io/insecurepath":"{\"paths\":[\"/metrics\",\"/live\"]}",
-      "istio-locality": "regionA.zoneB.sub_zoneC",
-      "EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT",
-      "NAME": "svc-0-0-0-6944fb884d-4pgx8",
-      "NAMESPACE": "test",
-      "POD_NAME": "svc-0-0-0-6944fb884d-4pgx8",
-      "app": "test",
-      "ISTIO_PROXY_SHA": "istio-proxy:sha",
-      "version": "v1alpha1",
-      "LABELS": {
-          "version": "v1alpha1",
-          "app": "test",
-          "istio-locality": "regionA.zoneB.sub_zoneC"
-      }
-    }
+    "metadata": {"EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT","INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","INTERCEPTION_MODE":"REDIRECT","ISTIO_PROXY_SHA":"istio-proxy:sha","ISTIO_VERSION":"release-3.1","LABELS":{"app":"test","istio-locality":"regionA.zoneB.sub_zoneC","version":"v1alpha1"},"NAME":"svc-0-0-0-6944fb884d-4pgx8","NAMESPACE":"test","POD_NAME":"svc-0-0-0-6944fb884d-4pgx8","app":"test","istio-locality":"regionA.zoneB.sub_zoneC","istio.io/insecurepath":"{\"paths\":[\"/metrics\",\"/live\"]}","version":"v1alpha1"}
   },
   "stats_config": {
     "use_all_default_tags": false,
@@ -39,8 +27,8 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "tag_name": "response_code",
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+          "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+          "tag_name": "response_code"
       },
       {
         "tag_name": "response_code_class",
@@ -63,108 +51,108 @@
         "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
       },
       {
-        "regex": "(reporter=\\.=(.+?);\\.;)",
-        "tag_name": "reporter"
+          "regex": "(reporter=\\.=(.+?);\\.;)",
+          "tag_name": "reporter"
       },
       {
-        "regex": "(source_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "source_namespace"
+          "regex": "(source_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "source_namespace"
       },
       {
-        "regex": "(source_workload=\\.=(.+?);\\.;)",
-        "tag_name": "source_workload"
+          "regex": "(source_workload=\\.=(.+?);\\.;)",
+          "tag_name": "source_workload"
       },
       {
-        "regex": "(source_workload_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "source_workload_namespace"
+          "regex": "(source_workload_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "source_workload_namespace"
       },
       {
-        "regex": "(source_principal=\\.=(.+?);\\.;)",
-        "tag_name": "source_principal"
+          "regex": "(source_principal=\\.=(.+?);\\.;)",
+          "tag_name": "source_principal"
       },
       {
-        "regex": "(source_app=\\.=(.+?);\\.;)",
-        "tag_name": "source_app"
+          "regex": "(source_app=\\.=(.+?);\\.;)",
+          "tag_name": "source_app"
       },
       {
-        "regex": "(source_version=\\.=(.+?);\\.;)",
-        "tag_name": "source_version"
+          "regex": "(source_version=\\.=(.+?);\\.;)",
+          "tag_name": "source_version"
       },
       {
-        "regex": "(destination_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_namespace"
+          "regex": "(destination_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_namespace"
       },
       {
-        "regex": "(destination_workload=\\.=(.+?);\\.;)",
-        "tag_name": "destination_workload"
+          "regex": "(destination_workload=\\.=(.+?);\\.;)",
+          "tag_name": "destination_workload"
       },
       {
-        "regex": "(destination_workload_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_workload_namespace"
+          "regex": "(destination_workload_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_workload_namespace"
       },
       {
-        "regex": "(destination_principal=\\.=(.+?);\\.;)",
-        "tag_name": "destination_principal"
+          "regex": "(destination_principal=\\.=(.+?);\\.;)",
+          "tag_name": "destination_principal"
       },
       {
-        "regex": "(destination_app=\\.=(.+?);\\.;)",
-        "tag_name": "destination_app"
+          "regex": "(destination_app=\\.=(.+?);\\.;)",
+          "tag_name": "destination_app"
       },
       {
-        "regex": "(destination_version=\\.=(.+?);\\.;)",
-        "tag_name": "destination_version"
+          "regex": "(destination_version=\\.=(.+?);\\.;)",
+          "tag_name": "destination_version"
       },
       {
-        "regex": "(destination_service=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service"
+          "regex": "(destination_service=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service"
       },
       {
-        "regex": "(destination_service_name=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service_name"
+          "regex": "(destination_service_name=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service_name"
       },
       {
-        "regex": "(destination_service_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service_namespace"
+          "regex": "(destination_service_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service_namespace"
       },
       {
         "regex": "(destination_port=\\.=(.+?);\\.;)",
         "tag_name": "destination_port"
       },
       {
-        "regex": "(request_protocol=\\.=(.+?);\\.;)",
-        "tag_name": "request_protocol"
+          "regex": "(request_protocol=\\.=(.+?);\\.;)",
+          "tag_name": "request_protocol"
       },
       {
-        "regex": "(response_flags=\\.=(.+?);\\.;)",
-        "tag_name": "response_flags"
+          "regex": "(response_flags=\\.=(.+?);\\.;)",
+          "tag_name": "response_flags"
       },
       {
-        "regex": "(grpc_response_status=\\.=(.*?);\\.;)",
-        "tag_name": "grpc_response_status"
+          "regex": "(grpc_response_status=\\.=(.*?);\\.;)",
+          "tag_name": "grpc_response_status"
       },
       {
-        "regex": "(connection_security_policy=\\.=(.+?);\\.;)",
-        "tag_name": "connection_security_policy"
+          "regex": "(connection_security_policy=\\.=(.+?);\\.;)",
+          "tag_name": "connection_security_policy"
       },
       {
-        "regex": "(permissive_response_code=\\.=(.+?);\\.;)",
-        "tag_name": "permissive_response_code"
+          "regex": "(permissive_response_code=\\.=(.+?);\\.;)",
+          "tag_name": "permissive_response_code"
       },
       {
-        "regex": "(permissive_response_policyid=\\.=(.+?);\\.;)",
-        "tag_name": "permissive_response_policyid"
+          "regex": "(permissive_response_policyid=\\.=(.+?);\\.;)",
+          "tag_name": "permissive_response_policyid"
       },
       {
-        "regex": "(cache\\.(.+?)\\.)",
-        "tag_name": "cache"
+          "regex": "(cache\\.(.+?)\\.)",
+          "tag_name": "cache"
       },
       {
-        "regex": "(component\\.(.+?)\\.)",
-        "tag_name": "component"
+          "regex": "(component\\.(.+?)\\.)",
+          "tag_name": "component"
       },
       {
-        "regex": "(tag\\.(.+?)\\.)",
-        "tag_name": "tag"
+          "regex": "(tag\\.(.+?)\\.)",
+          "tag_name": "tag"
       },
       {
           "regex": "(source_canonical_service=\\.=(.+?);\\.;)",
@@ -185,27 +173,34 @@
     ],
     "stats_matcher": {
       "inclusion_list": {
-        "patterns": [{"prefix": "reporter="},{
-            "prefix": "cluster_manager"
+        "patterns": [
+          {
+          "prefix": "reporter="
           },
           {
-            "prefix": "listener_manager"
+          "prefix": "component"
           },
           {
-            "prefix": "http_mixer_filter"
+          "prefix": "cluster_manager"
           },
           {
-            "prefix": "tcp_mixer_filter"
+          "prefix": "listener_manager"
           },
           {
-            "prefix": "server"
+          "prefix": "http_mixer_filter"
           },
           {
-            "prefix": "cluster.xds-grpc"
+          "prefix": "tcp_mixer_filter"
           },
           {
-            "suffix": "ssl_context_update_by_sds"
-          }
+          "prefix": "server"
+          },
+          {
+          "prefix": "cluster.xds-grpc"
+          },
+          {
+          "suffix": "ssl_context_update_by_sds"
+          },
         ]
       }
     }
@@ -257,10 +252,11 @@
       {
         "name": "xds-grpc",
         "type": "STRICT_DNS",
-        "dns_refresh_rate": "60s",
+        "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "7s",
         "lb_policy": "ROUND_ROBIN",
+        
         
         "tls_context": {
           "common_tls_context": {
@@ -281,12 +277,11 @@
               "trusted_ca": {
                 "filename": "/etc/certs/root-cert.pem"
               },
-              "verify_subject_alt_name": [
-                "spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"
-              ]
+              "verify_subject_alt_name": ["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"]
             }
           }
         },
+        
         
         "hosts": [
           {
@@ -322,7 +317,7 @@
       {
         "name": "zipkin",
         "type": "STRICT_DNS",
-        "dns_refresh_rate": "60s",
+        "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -332,6 +327,8 @@
           }
         ]
       }
+      
+      
       
     ],
     "listeners":[
@@ -391,8 +388,8 @@
         "collector_cluster": "zipkin",
         "collector_endpoint": "/api/v2/spans",
         "collector_endpoint_version": "HTTP_JSON",
-        "trace_id_128bit":"true",
-        "shared_span_context":"false"
+        "trace_id_128bit": "true",
+        "shared_span_context": "false"
       }
     }
   }
@@ -400,6 +397,8 @@
   
   ,
   "stats_sinks": [
+    
+    
     {
       "name": "envoy.statsd",
       "config": {
@@ -407,13 +406,16 @@
           "socket_address": {"address": "10.1.1.1", "port_value": 9125}
         }
       }
-    }
+    },
+    
   ]
+  
   
   ,
   "cluster_manager": {
     "outlier_detection": {
-      "event_log_path": "/dev/stdout"
+      "event_log_path": /dev/stdout
     }
   }
+  
 }

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -3,31 +3,17 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {
+      
       "region": "regionA",
+      
+      
       "zone": "zoneB",
-      "sub_zone": "sub_zoneC"
+      
+      
+      "sub_zone": "sub_zoneC",
+      
     },
-    "metadata": {
-      "INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6",
-      "INTERCEPTION_MODE":"REDIRECT",
-      "ISTIO_VERSION":"release-3.1",
-      "SDS": "true",
-      "TRUSTJWT": "true",
-      "istio.io/insecurepath":"{\"paths\":[\"/metrics\",\"/live\"]}",
-      "istio-locality": "regionA.zoneB.sub_zoneC",
-      "EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT",
-      "NAME": "svc-0-0-0-6944fb884d-4pgx8",
-      "NAMESPACE": "test",
-      "POD_NAME": "svc-0-0-0-6944fb884d-4pgx8",
-      "app": "test",
-      "ISTIO_PROXY_SHA": "istio-proxy:sha",
-      "version": "v1alpha1",
-      "LABELS": {
-          "version": "v1alpha1",
-          "app": "test",
-          "istio-locality": "regionA.zoneB.sub_zoneC"
-      }
-    }
+    "metadata": {"EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT","INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","INTERCEPTION_MODE":"REDIRECT","ISTIO_PROXY_SHA":"istio-proxy:sha","ISTIO_VERSION":"release-3.1","LABELS":{"app":"test","istio-locality":"regionA.zoneB.sub_zoneC","version":"v1alpha1"},"NAME":"svc-0-0-0-6944fb884d-4pgx8","NAMESPACE":"test","POD_NAME":"svc-0-0-0-6944fb884d-4pgx8","SDS":"true","TRUSTJWT":"true","app":"test","istio-locality":"regionA.zoneB.sub_zoneC","istio.io/insecurepath":"{\"paths\":[\"/metrics\",\"/live\"]}","version":"v1alpha1"}
   },
   "stats_config": {
     "use_all_default_tags": false,
@@ -41,8 +27,8 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "tag_name": "response_code",
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$"
+          "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+          "tag_name": "response_code"
       },
       {
         "tag_name": "response_code_class",
@@ -65,108 +51,108 @@
         "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
       },
       {
-        "regex": "(reporter=\\.=(.+?);\\.;)",
-        "tag_name": "reporter"
+          "regex": "(reporter=\\.=(.+?);\\.;)",
+          "tag_name": "reporter"
       },
       {
-        "regex": "(source_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "source_namespace"
+          "regex": "(source_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "source_namespace"
       },
       {
-        "regex": "(source_workload=\\.=(.+?);\\.;)",
-        "tag_name": "source_workload"
+          "regex": "(source_workload=\\.=(.+?);\\.;)",
+          "tag_name": "source_workload"
       },
       {
-        "regex": "(source_workload_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "source_workload_namespace"
+          "regex": "(source_workload_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "source_workload_namespace"
       },
       {
-        "regex": "(source_principal=\\.=(.+?);\\.;)",
-        "tag_name": "source_principal"
+          "regex": "(source_principal=\\.=(.+?);\\.;)",
+          "tag_name": "source_principal"
       },
       {
-        "regex": "(source_app=\\.=(.+?);\\.;)",
-        "tag_name": "source_app"
+          "regex": "(source_app=\\.=(.+?);\\.;)",
+          "tag_name": "source_app"
       },
       {
-        "regex": "(source_version=\\.=(.+?);\\.;)",
-        "tag_name": "source_version"
+          "regex": "(source_version=\\.=(.+?);\\.;)",
+          "tag_name": "source_version"
       },
       {
-        "regex": "(destination_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_namespace"
+          "regex": "(destination_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_namespace"
       },
       {
-        "regex": "(destination_workload=\\.=(.+?);\\.;)",
-        "tag_name": "destination_workload"
+          "regex": "(destination_workload=\\.=(.+?);\\.;)",
+          "tag_name": "destination_workload"
       },
       {
-        "regex": "(destination_workload_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_workload_namespace"
+          "regex": "(destination_workload_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_workload_namespace"
       },
       {
-        "regex": "(destination_principal=\\.=(.+?);\\.;)",
-        "tag_name": "destination_principal"
+          "regex": "(destination_principal=\\.=(.+?);\\.;)",
+          "tag_name": "destination_principal"
       },
       {
-        "regex": "(destination_app=\\.=(.+?);\\.;)",
-        "tag_name": "destination_app"
+          "regex": "(destination_app=\\.=(.+?);\\.;)",
+          "tag_name": "destination_app"
       },
       {
-        "regex": "(destination_version=\\.=(.+?);\\.;)",
-        "tag_name": "destination_version"
+          "regex": "(destination_version=\\.=(.+?);\\.;)",
+          "tag_name": "destination_version"
       },
       {
-        "regex": "(destination_service=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service"
+          "regex": "(destination_service=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service"
       },
       {
-        "regex": "(destination_service_name=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service_name"
+          "regex": "(destination_service_name=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service_name"
       },
       {
-        "regex": "(destination_service_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service_namespace"
+          "regex": "(destination_service_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service_namespace"
       },
       {
         "regex": "(destination_port=\\.=(.+?);\\.;)",
         "tag_name": "destination_port"
       },
       {
-        "regex": "(request_protocol=\\.=(.+?);\\.;)",
-        "tag_name": "request_protocol"
+          "regex": "(request_protocol=\\.=(.+?);\\.;)",
+          "tag_name": "request_protocol"
       },
       {
-        "regex": "(response_flags=\\.=(.+?);\\.;)",
-        "tag_name": "response_flags"
+          "regex": "(response_flags=\\.=(.+?);\\.;)",
+          "tag_name": "response_flags"
       },
       {
-        "regex": "(grpc_response_status=\\.=(.*?);\\.;)",
-        "tag_name": "grpc_response_status"
+          "regex": "(grpc_response_status=\\.=(.*?);\\.;)",
+          "tag_name": "grpc_response_status"
       },
       {
-        "regex": "(connection_security_policy=\\.=(.+?);\\.;)",
-        "tag_name": "connection_security_policy"
+          "regex": "(connection_security_policy=\\.=(.+?);\\.;)",
+          "tag_name": "connection_security_policy"
       },
       {
-        "regex": "(permissive_response_code=\\.=(.+?);\\.;)",
-        "tag_name": "permissive_response_code"
+          "regex": "(permissive_response_code=\\.=(.+?);\\.;)",
+          "tag_name": "permissive_response_code"
       },
       {
-        "regex": "(permissive_response_policyid=\\.=(.+?);\\.;)",
-        "tag_name": "permissive_response_policyid"
+          "regex": "(permissive_response_policyid=\\.=(.+?);\\.;)",
+          "tag_name": "permissive_response_policyid"
       },
       {
-        "regex": "(cache\\.(.+?)\\.)",
-        "tag_name": "cache"
+          "regex": "(cache\\.(.+?)\\.)",
+          "tag_name": "cache"
       },
       {
-        "regex": "(component\\.(.+?)\\.)",
-        "tag_name": "component"
+          "regex": "(component\\.(.+?)\\.)",
+          "tag_name": "component"
       },
       {
-        "regex": "(tag\\.(.+?)\\.)",
-        "tag_name": "tag"
+          "regex": "(tag\\.(.+?)\\.)",
+          "tag_name": "tag"
       },
       {
           "regex": "(source_canonical_service=\\.=(.+?);\\.;)",
@@ -187,27 +173,34 @@
     ],
     "stats_matcher": {
       "inclusion_list": {
-        "patterns": [{"prefix": "reporter="},{
-            "prefix": "cluster_manager"
+        "patterns": [
+          {
+          "prefix": "reporter="
           },
           {
-            "prefix": "listener_manager"
+          "prefix": "component"
           },
           {
-            "prefix": "http_mixer_filter"
+          "prefix": "cluster_manager"
           },
           {
-            "prefix": "tcp_mixer_filter"
+          "prefix": "listener_manager"
           },
           {
-            "prefix": "server"
+          "prefix": "http_mixer_filter"
           },
           {
-            "prefix": "cluster.xds-grpc"
+          "prefix": "tcp_mixer_filter"
           },
           {
-            "suffix": "ssl_context_update_by_sds"
-          }
+          "prefix": "server"
+          },
+          {
+          "prefix": "cluster.xds-grpc"
+          },
+          {
+          "suffix": "ssl_context_update_by_sds"
+          },
         ]
       }
     }
@@ -259,16 +252,18 @@
       {
         "name": "xds-grpc",
         "type": "STRICT_DNS",
-        "dns_refresh_rate": "60s",
+        "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "7s",
         "lb_policy": "ROUND_ROBIN",
+        
         
         "tls_context": {
           "common_tls_context": {
             "alpn_protocols": [
               "h2"
             ],
+            
             "tls_certificate_sds_secret_configs":[
               {
                 "name":"default",
@@ -307,9 +302,7 @@
             ],
             "combined_validation_context":{
               "default_validation_context":{
-                "verify_subject_alt_name":[
-                  "spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"
-                ]
+                "verify_subject_alt_name": ["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"]
               },
               "validation_context_sds_secret_config":{
                 "name":"ROOTCA",
@@ -346,8 +339,10 @@
                 }
               }
             }
-          }
+            
+          },
         },
+        
         
         "hosts": [
           {
@@ -383,7 +378,7 @@
       {
         "name": "zipkin",
         "type": "STRICT_DNS",
-        "dns_refresh_rate": "60s",
+        "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -393,6 +388,8 @@
           }
         ]
       }
+      
+      
       
     ],
     "listeners":[
@@ -452,8 +449,8 @@
         "collector_cluster": "zipkin",
         "collector_endpoint": "/api/v2/spans",
         "collector_endpoint_version": "HTTP_JSON",
-        "trace_id_128bit":"true",
-        "shared_span_context":"false"
+        "trace_id_128bit": "true",
+        "shared_span_context": "false"
       }
     }
   }
@@ -461,6 +458,8 @@
   
   ,
   "stats_sinks": [
+    
+    
     {
       "name": "envoy.statsd",
       "config": {
@@ -468,13 +467,16 @@
           "socket_address": {"address": "10.1.1.1", "port_value": 9125}
         }
       }
-    }
+    },
+    
   ]
+  
   
   ,
   "cluster_manager": {
     "outlier_detection": {
-      "event_log_path": "/dev/stdout"
+      "event_log_path": /dev/stdout
     }
   }
+  
 }

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -2,8 +2,12 @@
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
-    "locality": {},
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","sidecar.istio.io/statsInclusionPrefixes":"cluster_manager,cluster.xds-grpc,listener.","EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT","sidecar.istio.io/extraStatTags":"dlp_status,dlp_error"}
+    "locality": {
+      
+      
+      
+    },
+    "metadata": {"EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT","INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","sidecar.istio.io/extraStatTags":"dlp_status,dlp_error","sidecar.istio.io/statsInclusionRegexps":"http.[0-9]*\\.[0-9]*\\.[0-9]*\\.[0-9]*_8080.downstream_rq_time"}
   },
   "stats_config": {
     "use_all_default_tags": false,
@@ -17,8 +21,8 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "tag_name": "response_code",
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+          "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+          "tag_name": "response_code"
       },
       {
         "tag_name": "response_code_class",
@@ -41,116 +45,116 @@
         "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
       },
       {
-        "regex": "(reporter=\\.=(.+?);\\.;)",
-        "tag_name": "reporter"
+          "regex": "(reporter=\\.=(.+?);\\.;)",
+          "tag_name": "reporter"
       },
       {
-        "regex": "(source_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "source_namespace"
+          "regex": "(source_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "source_namespace"
       },
       {
-        "regex": "(source_workload=\\.=(.+?);\\.;)",
-        "tag_name": "source_workload"
+          "regex": "(source_workload=\\.=(.+?);\\.;)",
+          "tag_name": "source_workload"
       },
       {
-        "regex": "(source_workload_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "source_workload_namespace"
+          "regex": "(source_workload_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "source_workload_namespace"
       },
       {
-        "regex": "(source_principal=\\.=(.+?);\\.;)",
-        "tag_name": "source_principal"
+          "regex": "(source_principal=\\.=(.+?);\\.;)",
+          "tag_name": "source_principal"
       },
       {
-        "regex": "(source_app=\\.=(.+?);\\.;)",
-        "tag_name": "source_app"
+          "regex": "(source_app=\\.=(.+?);\\.;)",
+          "tag_name": "source_app"
       },
       {
-        "regex": "(source_version=\\.=(.+?);\\.;)",
-        "tag_name": "source_version"
+          "regex": "(source_version=\\.=(.+?);\\.;)",
+          "tag_name": "source_version"
       },
       {
-        "regex": "(destination_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_namespace"
+          "regex": "(destination_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_namespace"
       },
       {
-        "regex": "(destination_workload=\\.=(.+?);\\.;)",
-        "tag_name": "destination_workload"
+          "regex": "(destination_workload=\\.=(.+?);\\.;)",
+          "tag_name": "destination_workload"
       },
       {
-        "regex": "(destination_workload_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_workload_namespace"
+          "regex": "(destination_workload_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_workload_namespace"
       },
       {
-        "regex": "(destination_principal=\\.=(.+?);\\.;)",
-        "tag_name": "destination_principal"
+          "regex": "(destination_principal=\\.=(.+?);\\.;)",
+          "tag_name": "destination_principal"
       },
       {
-        "regex": "(destination_app=\\.=(.+?);\\.;)",
-        "tag_name": "destination_app"
+          "regex": "(destination_app=\\.=(.+?);\\.;)",
+          "tag_name": "destination_app"
       },
       {
-        "regex": "(destination_version=\\.=(.+?);\\.;)",
-        "tag_name": "destination_version"
+          "regex": "(destination_version=\\.=(.+?);\\.;)",
+          "tag_name": "destination_version"
       },
       {
-        "regex": "(destination_service=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service"
+          "regex": "(destination_service=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service"
       },
       {
-        "regex": "(destination_service_name=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service_name"
+          "regex": "(destination_service_name=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service_name"
       },
       {
-        "regex": "(destination_service_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service_namespace"
+          "regex": "(destination_service_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service_namespace"
       },
       {
         "regex": "(destination_port=\\.=(.+?);\\.;)",
         "tag_name": "destination_port"
       },
       {
-        "regex": "(request_protocol=\\.=(.+?);\\.;)",
-        "tag_name": "request_protocol"
+          "regex": "(request_protocol=\\.=(.+?);\\.;)",
+          "tag_name": "request_protocol"
       },
       {
-        "regex": "(response_flags=\\.=(.+?);\\.;)",
-        "tag_name": "response_flags"
+          "regex": "(response_flags=\\.=(.+?);\\.;)",
+          "tag_name": "response_flags"
       },
       {
-        "regex": "(grpc_response_status=\\.=(.*?);\\.;)",
-        "tag_name": "grpc_response_status"
+          "regex": "(grpc_response_status=\\.=(.*?);\\.;)",
+          "tag_name": "grpc_response_status"
       },
       {
-        "regex": "(connection_security_policy=\\.=(.+?);\\.;)",
-        "tag_name": "connection_security_policy"
+          "regex": "(connection_security_policy=\\.=(.+?);\\.;)",
+          "tag_name": "connection_security_policy"
       },
       {
-        "regex": "(permissive_response_code=\\.=(.+?);\\.;)",
-        "tag_name": "permissive_response_code"
+          "regex": "(permissive_response_code=\\.=(.+?);\\.;)",
+          "tag_name": "permissive_response_code"
       },
       {
-        "regex": "(permissive_response_policyid=\\.=(.+?);\\.;)",
-        "tag_name": "permissive_response_policyid"
+          "regex": "(permissive_response_policyid=\\.=(.+?);\\.;)",
+          "tag_name": "permissive_response_policyid"
       },
       {
-        "regex": "(cache\\.(.+?)\\.)",
-        "tag_name": "cache"
+          "regex": "(cache\\.(.+?)\\.)",
+          "tag_name": "cache"
       },
       {
-        "regex": "(component\\.(.+?)\\.)",
-        "tag_name": "component"
+          "regex": "(component\\.(.+?)\\.)",
+          "tag_name": "component"
       },
       {
-        "regex": "(tag\\.(.+?)\\.)",
-        "tag_name": "tag"
+          "regex": "(tag\\.(.+?)\\.)",
+          "tag_name": "tag"
       },
       {
-        "regex": "(dlp_status=\\.=(.*?);\\.;)",
-        "tag_name": "dlp_status"
+          "regex": "(dlp_status=\\.=(.*?);\\.;)",
+          "tag_name": "dlp_status"
       },
       {
-        "regex": "(dlp_error=\\.=(.*?);\\.;)",
-        "tag_name": "dlp_error"
+          "regex": "(dlp_error=\\.=(.*?);\\.;)",
+          "tag_name": "dlp_error"
       },
       {
           "regex": "(source_canonical_service=\\.=(.+?);\\.;)",
@@ -171,15 +175,37 @@
     ],
     "stats_matcher": {
       "inclusion_list": {
-        "patterns": [{"prefix": "reporter="},{
-            "prefix": "cluster_manager"
+        "patterns": [
+          {
+          "prefix": "reporter="
           },
           {
-            "prefix": "cluster.xds-grpc"
+          "prefix": "component"
           },
           {
-            "prefix": "listener."
-          }
+          "prefix": "cluster_manager"
+          },
+          {
+          "prefix": "listener_manager"
+          },
+          {
+          "prefix": "http_mixer_filter"
+          },
+          {
+          "prefix": "tcp_mixer_filter"
+          },
+          {
+          "prefix": "server"
+          },
+          {
+          "prefix": "cluster.xds-grpc"
+          },
+          {
+          "suffix": "ssl_context_update_by_sds"
+          },
+          {
+          "regex": "http.[0-9]*\\.[0-9]*\\.[0-9]*\\.[0-9]*_8080.downstream_rq_time"
+          },
         ]
       }
     }
@@ -231,7 +257,7 @@
       {
         "name": "xds-grpc",
         "type": "STRICT_DNS",
-        "dns_refresh_rate": "60s",
+        "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -265,6 +291,8 @@
         "max_requests_per_connection": 1,
         "http2_protocol_options": { }
       }
+      
+      
       
     ],
     "listeners":[
@@ -316,10 +344,13 @@
     ]
   }
   
+  
+  
   ,
   "cluster_manager": {
     "outlier_detection": {
-      "event_log_path": "/dev/stdout"
+      "event_log_path": /dev/stdout
     }
   }
+  
 }

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -2,8 +2,12 @@
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
-    "locality": {},
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT"}
+    "locality": {
+      
+      
+      
+    },
+    "metadata": {"EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT","INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6"}
   },
   "stats_config": {
     "use_all_default_tags": false,
@@ -17,8 +21,8 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "tag_name": "response_code",
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+          "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+          "tag_name": "response_code"
       },
       {
         "tag_name": "response_code_class",
@@ -41,108 +45,108 @@
         "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
       },
       {
-        "regex": "(reporter=\\.=(.+?);\\.;)",
-        "tag_name": "reporter"
+          "regex": "(reporter=\\.=(.+?);\\.;)",
+          "tag_name": "reporter"
       },
       {
-        "regex": "(source_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "source_namespace"
+          "regex": "(source_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "source_namespace"
       },
       {
-        "regex": "(source_workload=\\.=(.+?);\\.;)",
-        "tag_name": "source_workload"
+          "regex": "(source_workload=\\.=(.+?);\\.;)",
+          "tag_name": "source_workload"
       },
       {
-        "regex": "(source_workload_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "source_workload_namespace"
+          "regex": "(source_workload_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "source_workload_namespace"
       },
       {
-        "regex": "(source_principal=\\.=(.+?);\\.;)",
-        "tag_name": "source_principal"
+          "regex": "(source_principal=\\.=(.+?);\\.;)",
+          "tag_name": "source_principal"
       },
       {
-        "regex": "(source_app=\\.=(.+?);\\.;)",
-        "tag_name": "source_app"
+          "regex": "(source_app=\\.=(.+?);\\.;)",
+          "tag_name": "source_app"
       },
       {
-        "regex": "(source_version=\\.=(.+?);\\.;)",
-        "tag_name": "source_version"
+          "regex": "(source_version=\\.=(.+?);\\.;)",
+          "tag_name": "source_version"
       },
       {
-        "regex": "(destination_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_namespace"
+          "regex": "(destination_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_namespace"
       },
       {
-        "regex": "(destination_workload=\\.=(.+?);\\.;)",
-        "tag_name": "destination_workload"
+          "regex": "(destination_workload=\\.=(.+?);\\.;)",
+          "tag_name": "destination_workload"
       },
       {
-        "regex": "(destination_workload_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_workload_namespace"
+          "regex": "(destination_workload_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_workload_namespace"
       },
       {
-        "regex": "(destination_principal=\\.=(.+?);\\.;)",
-        "tag_name": "destination_principal"
+          "regex": "(destination_principal=\\.=(.+?);\\.;)",
+          "tag_name": "destination_principal"
       },
       {
-        "regex": "(destination_app=\\.=(.+?);\\.;)",
-        "tag_name": "destination_app"
+          "regex": "(destination_app=\\.=(.+?);\\.;)",
+          "tag_name": "destination_app"
       },
       {
-        "regex": "(destination_version=\\.=(.+?);\\.;)",
-        "tag_name": "destination_version"
+          "regex": "(destination_version=\\.=(.+?);\\.;)",
+          "tag_name": "destination_version"
       },
       {
-        "regex": "(destination_service=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service"
+          "regex": "(destination_service=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service"
       },
       {
-        "regex": "(destination_service_name=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service_name"
+          "regex": "(destination_service_name=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service_name"
       },
       {
-        "regex": "(destination_service_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service_namespace"
+          "regex": "(destination_service_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service_namespace"
       },
       {
         "regex": "(destination_port=\\.=(.+?);\\.;)",
         "tag_name": "destination_port"
       },
       {
-        "regex": "(request_protocol=\\.=(.+?);\\.;)",
-        "tag_name": "request_protocol"
+          "regex": "(request_protocol=\\.=(.+?);\\.;)",
+          "tag_name": "request_protocol"
       },
       {
-        "regex": "(response_flags=\\.=(.+?);\\.;)",
-        "tag_name": "response_flags"
+          "regex": "(response_flags=\\.=(.+?);\\.;)",
+          "tag_name": "response_flags"
       },
       {
-        "regex": "(grpc_response_status=\\.=(.*?);\\.;)",
-        "tag_name": "grpc_response_status"
+          "regex": "(grpc_response_status=\\.=(.*?);\\.;)",
+          "tag_name": "grpc_response_status"
       },
       {
-        "regex": "(connection_security_policy=\\.=(.+?);\\.;)",
-        "tag_name": "connection_security_policy"
+          "regex": "(connection_security_policy=\\.=(.+?);\\.;)",
+          "tag_name": "connection_security_policy"
       },
       {
-        "regex": "(permissive_response_code=\\.=(.+?);\\.;)",
-        "tag_name": "permissive_response_code"
+          "regex": "(permissive_response_code=\\.=(.+?);\\.;)",
+          "tag_name": "permissive_response_code"
       },
       {
-        "regex": "(permissive_response_policyid=\\.=(.+?);\\.;)",
-        "tag_name": "permissive_response_policyid"
+          "regex": "(permissive_response_policyid=\\.=(.+?);\\.;)",
+          "tag_name": "permissive_response_policyid"
       },
       {
-        "regex": "(cache\\.(.+?)\\.)",
-        "tag_name": "cache"
+          "regex": "(cache\\.(.+?)\\.)",
+          "tag_name": "cache"
       },
       {
-        "regex": "(component\\.(.+?)\\.)",
-        "tag_name": "component"
+          "regex": "(component\\.(.+?)\\.)",
+          "tag_name": "component"
       },
       {
-        "regex": "(tag\\.(.+?)\\.)",
-        "tag_name": "tag"
+          "regex": "(tag\\.(.+?)\\.)",
+          "tag_name": "tag"
       },
       {
           "regex": "(source_canonical_service=\\.=(.+?);\\.;)",
@@ -164,27 +168,33 @@
     "stats_matcher": {
       "inclusion_list": {
         "patterns": [
-            {
-              "prefix": "cluster_manager"
-            },
-            {
-              "prefix": "listener_manager"
-            },
-            {
-              "prefix": "http_mixer_filter"
-            },
-            {
-              "prefix": "tcp_mixer_filter"
-            },
-            {
-              "prefix": "server"
-            },
-            {
-              "prefix": "cluster.xds-grpc"
-            },
-            {
-              "suffix": "ssl_context_update_by_sds"
-            }
+          {
+          "prefix": "reporter="
+          },
+          {
+          "prefix": "component"
+          },
+          {
+          "prefix": "cluster_manager"
+          },
+          {
+          "prefix": "listener_manager"
+          },
+          {
+          "prefix": "http_mixer_filter"
+          },
+          {
+          "prefix": "tcp_mixer_filter"
+          },
+          {
+          "prefix": "server"
+          },
+          {
+          "prefix": "cluster.xds-grpc"
+          },
+          {
+          "suffix": "ssl_context_update_by_sds"
+          },
         ]
       }
     }
@@ -236,7 +246,7 @@
       {
         "name": "xds-grpc",
         "type": "STRICT_DNS",
-        "dns_refresh_rate": "60s",
+        "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -276,7 +286,7 @@
         "name": "datadog_agent",
         "connect_timeout": "1s",
         "type": "STRICT_DNS",
-        "dns_refresh_rate": "60s",
+        "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",
         "lb_policy": "ROUND_ROBIN",
         "hosts": [
@@ -285,6 +295,7 @@
           }
         ]
       }
+      
       
       
     ],
@@ -348,10 +359,13 @@
     }
   }
   
+  
+  
   ,
   "cluster_manager": {
     "outlier_detection": {
-      "event_log_path": "/dev/stdout"
+      "event_log_path": /dev/stdout
     }
   }
+  
 }

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -2,8 +2,12 @@
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
-    "locality": {},
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT"}
+    "locality": {
+      
+      
+      
+    },
+    "metadata": {"EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT","INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6"}
   },
   "stats_config": {
     "use_all_default_tags": false,
@@ -17,8 +21,8 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "tag_name": "response_code",
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+          "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+          "tag_name": "response_code"
       },
       {
         "tag_name": "response_code_class",
@@ -41,108 +45,108 @@
         "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
       },
       {
-        "regex": "(reporter=\\.=(.+?);\\.;)",
-        "tag_name": "reporter"
+          "regex": "(reporter=\\.=(.+?);\\.;)",
+          "tag_name": "reporter"
       },
       {
-        "regex": "(source_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "source_namespace"
+          "regex": "(source_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "source_namespace"
       },
       {
-        "regex": "(source_workload=\\.=(.+?);\\.;)",
-        "tag_name": "source_workload"
+          "regex": "(source_workload=\\.=(.+?);\\.;)",
+          "tag_name": "source_workload"
       },
       {
-        "regex": "(source_workload_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "source_workload_namespace"
+          "regex": "(source_workload_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "source_workload_namespace"
       },
       {
-        "regex": "(source_principal=\\.=(.+?);\\.;)",
-        "tag_name": "source_principal"
+          "regex": "(source_principal=\\.=(.+?);\\.;)",
+          "tag_name": "source_principal"
       },
       {
-        "regex": "(source_app=\\.=(.+?);\\.;)",
-        "tag_name": "source_app"
+          "regex": "(source_app=\\.=(.+?);\\.;)",
+          "tag_name": "source_app"
       },
       {
-        "regex": "(source_version=\\.=(.+?);\\.;)",
-        "tag_name": "source_version"
+          "regex": "(source_version=\\.=(.+?);\\.;)",
+          "tag_name": "source_version"
       },
       {
-        "regex": "(destination_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_namespace"
+          "regex": "(destination_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_namespace"
       },
       {
-        "regex": "(destination_workload=\\.=(.+?);\\.;)",
-        "tag_name": "destination_workload"
+          "regex": "(destination_workload=\\.=(.+?);\\.;)",
+          "tag_name": "destination_workload"
       },
       {
-        "regex": "(destination_workload_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_workload_namespace"
+          "regex": "(destination_workload_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_workload_namespace"
       },
       {
-        "regex": "(destination_principal=\\.=(.+?);\\.;)",
-        "tag_name": "destination_principal"
+          "regex": "(destination_principal=\\.=(.+?);\\.;)",
+          "tag_name": "destination_principal"
       },
       {
-        "regex": "(destination_app=\\.=(.+?);\\.;)",
-        "tag_name": "destination_app"
+          "regex": "(destination_app=\\.=(.+?);\\.;)",
+          "tag_name": "destination_app"
       },
       {
-        "regex": "(destination_version=\\.=(.+?);\\.;)",
-        "tag_name": "destination_version"
+          "regex": "(destination_version=\\.=(.+?);\\.;)",
+          "tag_name": "destination_version"
       },
       {
-        "regex": "(destination_service=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service"
+          "regex": "(destination_service=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service"
       },
       {
-        "regex": "(destination_service_name=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service_name"
+          "regex": "(destination_service_name=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service_name"
       },
       {
-        "regex": "(destination_service_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service_namespace"
+          "regex": "(destination_service_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service_namespace"
       },
       {
         "regex": "(destination_port=\\.=(.+?);\\.;)",
         "tag_name": "destination_port"
       },
       {
-        "regex": "(request_protocol=\\.=(.+?);\\.;)",
-        "tag_name": "request_protocol"
+          "regex": "(request_protocol=\\.=(.+?);\\.;)",
+          "tag_name": "request_protocol"
       },
       {
-        "regex": "(response_flags=\\.=(.+?);\\.;)",
-        "tag_name": "response_flags"
+          "regex": "(response_flags=\\.=(.+?);\\.;)",
+          "tag_name": "response_flags"
       },
       {
-        "regex": "(grpc_response_status=\\.=(.*?);\\.;)",
-        "tag_name": "grpc_response_status"
+          "regex": "(grpc_response_status=\\.=(.*?);\\.;)",
+          "tag_name": "grpc_response_status"
       },
       {
-        "regex": "(connection_security_policy=\\.=(.+?);\\.;)",
-        "tag_name": "connection_security_policy"
+          "regex": "(connection_security_policy=\\.=(.+?);\\.;)",
+          "tag_name": "connection_security_policy"
       },
       {
-        "regex": "(permissive_response_code=\\.=(.+?);\\.;)",
-        "tag_name": "permissive_response_code"
+          "regex": "(permissive_response_code=\\.=(.+?);\\.;)",
+          "tag_name": "permissive_response_code"
       },
       {
-        "regex": "(permissive_response_policyid=\\.=(.+?);\\.;)",
-        "tag_name": "permissive_response_policyid"
+          "regex": "(permissive_response_policyid=\\.=(.+?);\\.;)",
+          "tag_name": "permissive_response_policyid"
       },
       {
-        "regex": "(cache\\.(.+?)\\.)",
-        "tag_name": "cache"
+          "regex": "(cache\\.(.+?)\\.)",
+          "tag_name": "cache"
       },
       {
-        "regex": "(component\\.(.+?)\\.)",
-        "tag_name": "component"
+          "regex": "(component\\.(.+?)\\.)",
+          "tag_name": "component"
       },
       {
-        "regex": "(tag\\.(.+?)\\.)",
-        "tag_name": "tag"
+          "regex": "(tag\\.(.+?)\\.)",
+          "tag_name": "tag"
       },
       {
           "regex": "(source_canonical_service=\\.=(.+?);\\.;)",
@@ -163,27 +167,34 @@
     ],
     "stats_matcher": {
       "inclusion_list": {
-        "patterns": [{"prefix": "reporter="},{
-            "prefix": "cluster_manager"
+        "patterns": [
+          {
+          "prefix": "reporter="
           },
           {
-            "prefix": "listener_manager"
+          "prefix": "component"
           },
           {
-            "prefix": "http_mixer_filter"
+          "prefix": "cluster_manager"
           },
           {
-            "prefix": "tcp_mixer_filter"
+          "prefix": "listener_manager"
           },
           {
-            "prefix": "server"
+          "prefix": "http_mixer_filter"
           },
           {
-            "prefix": "cluster.xds-grpc"
+          "prefix": "tcp_mixer_filter"
           },
           {
-            "suffix": "ssl_context_update_by_sds"
-          }
+          "prefix": "server"
+          },
+          {
+          "prefix": "cluster.xds-grpc"
+          },
+          {
+          "suffix": "ssl_context_update_by_sds"
+          },
         ]
       }
     }
@@ -235,7 +246,7 @@
       {
         "name": "xds-grpc",
         "type": "STRICT_DNS",
-        "dns_refresh_rate": "60s",
+        "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -289,7 +300,7 @@
         },
         
         "type": "STRICT_DNS",
-        "dns_refresh_rate": "60s",
+        "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -299,6 +310,8 @@
           }
         ]
       }
+      
+      
       
     ],
     "listeners":[
@@ -361,10 +374,13 @@
     }
   }
   
+  
+  
   ,
   "cluster_manager": {
     "outlier_detection": {
-      "event_log_path": "/dev/stdout"
+      "event_log_path": /dev/stdout
     }
   }
+  
 }

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -2,8 +2,12 @@
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
-    "locality": {},
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT"}
+    "locality": {
+      
+      
+      
+    },
+    "metadata": {"EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT","INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6"}
   },
   "stats_config": {
     "use_all_default_tags": false,
@@ -17,8 +21,8 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "tag_name": "response_code",
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+          "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+          "tag_name": "response_code"
       },
       {
         "tag_name": "response_code_class",
@@ -41,108 +45,108 @@
         "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
       },
       {
-        "regex": "(reporter=\\.=(.+?);\\.;)",
-        "tag_name": "reporter"
+          "regex": "(reporter=\\.=(.+?);\\.;)",
+          "tag_name": "reporter"
       },
       {
-        "regex": "(source_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "source_namespace"
+          "regex": "(source_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "source_namespace"
       },
       {
-        "regex": "(source_workload=\\.=(.+?);\\.;)",
-        "tag_name": "source_workload"
+          "regex": "(source_workload=\\.=(.+?);\\.;)",
+          "tag_name": "source_workload"
       },
       {
-        "regex": "(source_workload_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "source_workload_namespace"
+          "regex": "(source_workload_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "source_workload_namespace"
       },
       {
-        "regex": "(source_principal=\\.=(.+?);\\.;)",
-        "tag_name": "source_principal"
+          "regex": "(source_principal=\\.=(.+?);\\.;)",
+          "tag_name": "source_principal"
       },
       {
-        "regex": "(source_app=\\.=(.+?);\\.;)",
-        "tag_name": "source_app"
+          "regex": "(source_app=\\.=(.+?);\\.;)",
+          "tag_name": "source_app"
       },
       {
-        "regex": "(source_version=\\.=(.+?);\\.;)",
-        "tag_name": "source_version"
+          "regex": "(source_version=\\.=(.+?);\\.;)",
+          "tag_name": "source_version"
       },
       {
-        "regex": "(destination_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_namespace"
+          "regex": "(destination_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_namespace"
       },
       {
-        "regex": "(destination_workload=\\.=(.+?);\\.;)",
-        "tag_name": "destination_workload"
+          "regex": "(destination_workload=\\.=(.+?);\\.;)",
+          "tag_name": "destination_workload"
       },
       {
-        "regex": "(destination_workload_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_workload_namespace"
+          "regex": "(destination_workload_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_workload_namespace"
       },
       {
-        "regex": "(destination_principal=\\.=(.+?);\\.;)",
-        "tag_name": "destination_principal"
+          "regex": "(destination_principal=\\.=(.+?);\\.;)",
+          "tag_name": "destination_principal"
       },
       {
-        "regex": "(destination_app=\\.=(.+?);\\.;)",
-        "tag_name": "destination_app"
+          "regex": "(destination_app=\\.=(.+?);\\.;)",
+          "tag_name": "destination_app"
       },
       {
-        "regex": "(destination_version=\\.=(.+?);\\.;)",
-        "tag_name": "destination_version"
+          "regex": "(destination_version=\\.=(.+?);\\.;)",
+          "tag_name": "destination_version"
       },
       {
-        "regex": "(destination_service=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service"
+          "regex": "(destination_service=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service"
       },
       {
-        "regex": "(destination_service_name=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service_name"
+          "regex": "(destination_service_name=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service_name"
       },
       {
-        "regex": "(destination_service_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service_namespace"
+          "regex": "(destination_service_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service_namespace"
       },
       {
         "regex": "(destination_port=\\.=(.+?);\\.;)",
         "tag_name": "destination_port"
       },
       {
-        "regex": "(request_protocol=\\.=(.+?);\\.;)",
-        "tag_name": "request_protocol"
+          "regex": "(request_protocol=\\.=(.+?);\\.;)",
+          "tag_name": "request_protocol"
       },
       {
-        "regex": "(response_flags=\\.=(.+?);\\.;)",
-        "tag_name": "response_flags"
+          "regex": "(response_flags=\\.=(.+?);\\.;)",
+          "tag_name": "response_flags"
       },
       {
-        "regex": "(grpc_response_status=\\.=(.*?);\\.;)",
-        "tag_name": "grpc_response_status"
+          "regex": "(grpc_response_status=\\.=(.*?);\\.;)",
+          "tag_name": "grpc_response_status"
       },
       {
-        "regex": "(connection_security_policy=\\.=(.+?);\\.;)",
-        "tag_name": "connection_security_policy"
+          "regex": "(connection_security_policy=\\.=(.+?);\\.;)",
+          "tag_name": "connection_security_policy"
       },
       {
-        "regex": "(permissive_response_code=\\.=(.+?);\\.;)",
-        "tag_name": "permissive_response_code"
+          "regex": "(permissive_response_code=\\.=(.+?);\\.;)",
+          "tag_name": "permissive_response_code"
       },
       {
-        "regex": "(permissive_response_policyid=\\.=(.+?);\\.;)",
-        "tag_name": "permissive_response_policyid"
+          "regex": "(permissive_response_policyid=\\.=(.+?);\\.;)",
+          "tag_name": "permissive_response_policyid"
       },
       {
-        "regex": "(cache\\.(.+?)\\.)",
-        "tag_name": "cache"
+          "regex": "(cache\\.(.+?)\\.)",
+          "tag_name": "cache"
       },
       {
-        "regex": "(component\\.(.+?)\\.)",
-        "tag_name": "component"
+          "regex": "(component\\.(.+?)\\.)",
+          "tag_name": "component"
       },
       {
-        "regex": "(tag\\.(.+?)\\.)",
-        "tag_name": "tag"
+          "regex": "(tag\\.(.+?)\\.)",
+          "tag_name": "tag"
       },
       {
           "regex": "(source_canonical_service=\\.=(.+?);\\.;)",
@@ -163,24 +167,34 @@
     ],
     "stats_matcher": {
       "inclusion_list": {
-        "patterns": [{"prefix": "reporter="},{
-            "prefix": "cluster_manager"
+        "patterns": [
+          {
+          "prefix": "reporter="
           },
           {
-            "prefix": "listener_manager"
+          "prefix": "component"
           },
           {
-            "prefix": "http_mixer_filter"
+          "prefix": "cluster_manager"
           },
           {
-            "prefix": "tcp_mixer_filter"
+          "prefix": "listener_manager"
           },
           {
-            "prefix": "server"
+          "prefix": "http_mixer_filter"
           },
           {
-            "prefix": "cluster.xds-grpc"
-          }
+          "prefix": "tcp_mixer_filter"
+          },
+          {
+          "prefix": "server"
+          },
+          {
+          "prefix": "cluster.xds-grpc"
+          },
+          {
+          "suffix": "ssl_context_update_by_sds"
+          },
         ]
       }
     }
@@ -232,7 +246,7 @@
       {
         "name": "xds-grpc",
         "type": "STRICT_DNS",
-        "dns_refresh_rate": "60s",
+        "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -266,6 +280,9 @@
         "max_requests_per_connection": 1,
         "http2_protocol_options": { }
       }
+      
+      
+      
     ],
     "listeners":[
       {
@@ -315,33 +332,36 @@
       }
     ]
   }
+  
   ,
   "tracing": {
     "http": {
       "name": "envoy.tracers.opencensus",
       "config": {
-        "stackdriver_exporter_enabled": true,
-        "stackdriver_project_id": "my-sd-project",
-        "stdout_exporter_enabled": true,
-        "incoming_trace_context": ["CLOUD_TRACE_CONTEXT", "TRACE_CONTEXT", "GRPC_TRACE_BIN", "B3"],
-        "outgoing_trace_context": ["CLOUD_TRACE_CONTEXT", "TRACE_CONTEXT", "GRPC_TRACE_BIN", "B3"],
-        "trace_config":{
-          "constant_sampler":{
-            "decision": "ALWAYS_PARENT"
-          },
-          "max_number_of_annotations": 201,
-          "max_number_of_attributes": 200,
-          "max_number_of_message_events": 201,
-          "max_number_of_links": 200,
-        }
-      }
-    }
-  }
-
+      "stackdriver_exporter_enabled": true,
+      "stackdriver_project_id": "my-sd-project",
+      "stdout_exporter_enabled": true,
+      "incoming_trace_context": ["CLOUD_TRACE_CONTEXT", "TRACE_CONTEXT", "GRPC_TRACE_BIN", "B3"],
+      "outgoing_trace_context": ["CLOUD_TRACE_CONTEXT", "TRACE_CONTEXT", "GRPC_TRACE_BIN", "B3"],
+      "trace_config":{
+        "constant_sampler":{
+          "decision": "ALWAYS_PARENT"
+        },
+        "max_number_of_annotations": 201,
+        "max_number_of_attributes": 200,
+        "max_number_of_message_events": 201,
+        "max_number_of_links": 200,
+       }
+     }
+  }}
+  
+  
+  
   ,
   "cluster_manager": {
     "outlier_detection": {
-      "event_log_path": "/dev/stdout"
+      "event_log_path": /dev/stdout
     }
   }
+  
 }

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -2,8 +2,12 @@
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
-    "locality": {},
-    "metadata": {"INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT"}
+    "locality": {
+      
+      
+      
+    },
+    "metadata": {"EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT","INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6"}
   },
   "stats_config": {
     "use_all_default_tags": false,
@@ -17,8 +21,8 @@
         "regex": "^tcp\\.((.*?)\\.)\\w+?$"
       },
       {
-        "tag_name": "response_code",
-        "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+          "regex": "(response_code=\\.=(.+?);\\.;)|_rq(_(\\.d{3}))$",
+          "tag_name": "response_code"
       },
       {
         "tag_name": "response_code_class",
@@ -41,108 +45,108 @@
         "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
       },
       {
-        "regex": "(reporter=\\.=(.+?);\\.;)",
-        "tag_name": "reporter"
+          "regex": "(reporter=\\.=(.+?);\\.;)",
+          "tag_name": "reporter"
       },
       {
-        "regex": "(source_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "source_namespace"
+          "regex": "(source_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "source_namespace"
       },
       {
-        "regex": "(source_workload=\\.=(.+?);\\.;)",
-        "tag_name": "source_workload"
+          "regex": "(source_workload=\\.=(.+?);\\.;)",
+          "tag_name": "source_workload"
       },
       {
-        "regex": "(source_workload_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "source_workload_namespace"
+          "regex": "(source_workload_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "source_workload_namespace"
       },
       {
-        "regex": "(source_principal=\\.=(.+?);\\.;)",
-        "tag_name": "source_principal"
+          "regex": "(source_principal=\\.=(.+?);\\.;)",
+          "tag_name": "source_principal"
       },
       {
-        "regex": "(source_app=\\.=(.+?);\\.;)",
-        "tag_name": "source_app"
+          "regex": "(source_app=\\.=(.+?);\\.;)",
+          "tag_name": "source_app"
       },
       {
-        "regex": "(source_version=\\.=(.+?);\\.;)",
-        "tag_name": "source_version"
+          "regex": "(source_version=\\.=(.+?);\\.;)",
+          "tag_name": "source_version"
       },
       {
-        "regex": "(destination_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_namespace"
+          "regex": "(destination_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_namespace"
       },
       {
-        "regex": "(destination_workload=\\.=(.+?);\\.;)",
-        "tag_name": "destination_workload"
+          "regex": "(destination_workload=\\.=(.+?);\\.;)",
+          "tag_name": "destination_workload"
       },
       {
-        "regex": "(destination_workload_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_workload_namespace"
+          "regex": "(destination_workload_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_workload_namespace"
       },
       {
-        "regex": "(destination_principal=\\.=(.+?);\\.;)",
-        "tag_name": "destination_principal"
+          "regex": "(destination_principal=\\.=(.+?);\\.;)",
+          "tag_name": "destination_principal"
       },
       {
-        "regex": "(destination_app=\\.=(.+?);\\.;)",
-        "tag_name": "destination_app"
+          "regex": "(destination_app=\\.=(.+?);\\.;)",
+          "tag_name": "destination_app"
       },
       {
-        "regex": "(destination_version=\\.=(.+?);\\.;)",
-        "tag_name": "destination_version"
+          "regex": "(destination_version=\\.=(.+?);\\.;)",
+          "tag_name": "destination_version"
       },
       {
-        "regex": "(destination_service=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service"
+          "regex": "(destination_service=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service"
       },
       {
-        "regex": "(destination_service_name=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service_name"
+          "regex": "(destination_service_name=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service_name"
       },
       {
-        "regex": "(destination_service_namespace=\\.=(.+?);\\.;)",
-        "tag_name": "destination_service_namespace"
+          "regex": "(destination_service_namespace=\\.=(.+?);\\.;)",
+          "tag_name": "destination_service_namespace"
       },
       {
         "regex": "(destination_port=\\.=(.+?);\\.;)",
         "tag_name": "destination_port"
       },
       {
-        "regex": "(request_protocol=\\.=(.+?);\\.;)",
-        "tag_name": "request_protocol"
+          "regex": "(request_protocol=\\.=(.+?);\\.;)",
+          "tag_name": "request_protocol"
       },
       {
-        "regex": "(response_flags=\\.=(.+?);\\.;)",
-        "tag_name": "response_flags"
+          "regex": "(response_flags=\\.=(.+?);\\.;)",
+          "tag_name": "response_flags"
       },
       {
-        "regex": "(grpc_response_status=\\.=(.*?);\\.;)",
-        "tag_name": "grpc_response_status"
+          "regex": "(grpc_response_status=\\.=(.*?);\\.;)",
+          "tag_name": "grpc_response_status"
       },
       {
-        "regex": "(connection_security_policy=\\.=(.+?);\\.;)",
-        "tag_name": "connection_security_policy"
+          "regex": "(connection_security_policy=\\.=(.+?);\\.;)",
+          "tag_name": "connection_security_policy"
       },
       {
-        "regex": "(permissive_response_code=\\.=(.+?);\\.;)",
-        "tag_name": "permissive_response_code"
+          "regex": "(permissive_response_code=\\.=(.+?);\\.;)",
+          "tag_name": "permissive_response_code"
       },
       {
-        "regex": "(permissive_response_policyid=\\.=(.+?);\\.;)",
-        "tag_name": "permissive_response_policyid"
+          "regex": "(permissive_response_policyid=\\.=(.+?);\\.;)",
+          "tag_name": "permissive_response_policyid"
       },
       {
-        "regex": "(cache\\.(.+?)\\.)",
-        "tag_name": "cache"
+          "regex": "(cache\\.(.+?)\\.)",
+          "tag_name": "cache"
       },
       {
-        "regex": "(component\\.(.+?)\\.)",
-        "tag_name": "component"
+          "regex": "(component\\.(.+?)\\.)",
+          "tag_name": "component"
       },
       {
-        "regex": "(tag\\.(.+?)\\.)",
-        "tag_name": "tag"
+          "regex": "(tag\\.(.+?)\\.)",
+          "tag_name": "tag"
       },
       {
           "regex": "(source_canonical_service=\\.=(.+?);\\.;)",
@@ -163,27 +167,34 @@
     ],
     "stats_matcher": {
       "inclusion_list": {
-        "patterns": [{"prefix": "reporter="},{
-            "prefix": "cluster_manager"
+        "patterns": [
+          {
+          "prefix": "reporter="
           },
           {
-            "prefix": "listener_manager"
+          "prefix": "component"
           },
           {
-            "prefix": "http_mixer_filter"
+          "prefix": "cluster_manager"
           },
           {
-            "prefix": "tcp_mixer_filter"
+          "prefix": "listener_manager"
           },
           {
-            "prefix": "server"
+          "prefix": "http_mixer_filter"
           },
           {
-            "prefix": "cluster.xds-grpc"
+          "prefix": "tcp_mixer_filter"
           },
           {
-            "suffix": "ssl_context_update_by_sds"
-          }
+          "prefix": "server"
+          },
+          {
+          "prefix": "cluster.xds-grpc"
+          },
+          {
+          "suffix": "ssl_context_update_by_sds"
+          },
         ]
       }
     }
@@ -235,7 +246,7 @@
       {
         "name": "xds-grpc",
         "type": "STRICT_DNS",
-        "dns_refresh_rate": "60s",
+        "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -274,7 +285,7 @@
       {
         "name": "zipkin",
         "type": "STRICT_DNS",
-        "dns_refresh_rate": "60s",
+        "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -284,6 +295,8 @@
           }
         ]
       }
+      
+      
       
     ],
     "listeners":[
@@ -343,16 +356,19 @@
         "collector_cluster": "zipkin",
         "collector_endpoint": "/api/v2/spans",
         "collector_endpoint_version": "HTTP_JSON",
-        "trace_id_128bit":"true",
+        "trace_id_128bit": "true",
         "shared_span_context": "false"
       }
     }
   }
   
+  
+  
   ,
   "cluster_manager": {
     "outlier_detection": {
-      "event_log_path": "/dev/stdout"
+      "event_log_path": /dev/stdout
     }
   }
+  
 }

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -51,7 +51,6 @@ type ProxyConfig struct {
 	PilotSubjectAltName []string
 	MixerSubjectAltName []string
 	NodeIPs             []string
-	DNSRefreshRate      string
 	PodName             string
 	PodNamespace        string
 	PodIP               net.IP
@@ -154,7 +153,6 @@ func (e *envoy) Run(config interface{}, epoch int, abort <-chan error) error {
 	} else {
 		out, err := bootstrap.New(bootstrap.Config{
 			Node:                e.Node,
-			DNSRefreshRate:      e.DNSRefreshRate,
 			Proxy:               &e.Config,
 			PilotSubjectAltName: e.PilotSubjectAltName,
 			MixerSubjectAltName: e.MixerSubjectAltName,

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -33,7 +33,6 @@ func TestEnvoyArgs(t *testing.T) {
 		LogLevel:          "trace",
 		ComponentLogLevel: "misc:error",
 		NodeIPs:           []string{"10.75.2.9", "192.168.11.18"},
-		DNSRefreshRate:    "60s",
 		PodName:           "",
 		PodNamespace:      "",
 		PodIP:             nil,

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -72,8 +72,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -69,8 +69,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
@@ -68,8 +68,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
@@ -52,8 +52,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
@@ -69,8 +69,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
@@ -51,8 +51,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
@@ -54,8 +54,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
@@ -68,8 +68,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
@@ -51,8 +51,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
@@ -62,8 +62,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
@@ -48,8 +48,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -48,8 +48,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -48,8 +48,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -42,8 +42,6 @@ spec:
             - istio-pilot:15010
             - --proxyLogLevel=warning
             - --proxyComponentLogLevel=misc:error
-            - --dnsRefreshRate
-            - 300s
             - --statusPort
             - "15020"
             - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -46,8 +46,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -61,8 +61,6 @@ items:
           - istio-pilot:15010
           - --proxyLogLevel=warning
           - --proxyComponentLogLevel=misc:error
-          - --dnsRefreshRate
-          - 300s
           - --statusPort
           - "15020"
           - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -46,8 +46,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
@@ -49,8 +49,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -48,8 +48,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -48,8 +48,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -65,8 +65,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -48,8 +48,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
@@ -48,8 +48,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
@@ -49,8 +49,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
@@ -48,8 +48,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
@@ -48,8 +48,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -50,8 +50,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local
@@ -270,8 +268,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -49,8 +49,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -48,8 +48,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -49,8 +49,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
@@ -48,8 +48,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -48,8 +48,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
@@ -48,8 +48,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -48,8 +48,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -40,8 +40,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -49,8 +49,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "123"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -49,8 +49,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -66,8 +66,6 @@ items:
           - istio-pilot:15010
           - --proxyLogLevel=warning
           - --proxyComponentLogLevel=misc:error
-          - --dnsRefreshRate
-          - 300s
           - --statusPort
           - "15020"
           - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -52,8 +52,6 @@ items:
           - istio-pilot:15010
           - --proxyLogLevel=warning
           - --proxyComponentLogLevel=misc:error
-          - --dnsRefreshRate
-          - 300s
           - --statusPort
           - "15020"
           - --trust-domain=cluster.local
@@ -271,8 +269,6 @@ items:
           - istio-pilot:15010
           - --proxyLogLevel=warning
           - --proxyComponentLogLevel=misc:error
-          - --dnsRefreshRate
-          - 300s
           - --statusPort
           - "15020"
           - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
@@ -50,8 +50,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -48,8 +48,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -34,8 +34,6 @@ spec:
     - istio-pilot:15010
     - --proxyLogLevel=warning
     - --proxyComponentLogLevel=misc:error
-    - --dnsRefreshRate
-    - 300s
     - --statusPort
     - "15020"
     - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -43,8 +43,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -42,8 +42,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -51,8 +51,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -49,8 +49,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "123"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -44,8 +44,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "123"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -45,8 +45,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -45,8 +45,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -46,8 +46,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -44,8 +44,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -45,8 +45,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --trust-domain=cluster.local
         - --controlPlaneBootstrap=false
         - --concurrency

--- a/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
@@ -45,8 +45,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
@@ -44,8 +44,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig-with-canonical-service-label.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig-with-canonical-service-label.yaml.injected
@@ -44,8 +44,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
@@ -44,8 +44,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
@@ -50,8 +50,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
@@ -46,8 +46,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/webhook/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-mtls-not-ready.yaml.injected
@@ -46,8 +46,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
@@ -48,8 +48,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local
@@ -263,8 +261,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
@@ -66,8 +66,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/webhook/job.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/job.yaml.injected
@@ -41,8 +41,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
@@ -50,8 +50,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/webhook/list.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/list.yaml.injected
@@ -48,8 +48,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local
@@ -263,8 +261,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
@@ -42,8 +42,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
@@ -40,8 +40,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
@@ -44,8 +44,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
@@ -49,8 +49,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
@@ -47,8 +47,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "123"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
@@ -46,8 +46,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
@@ -46,8 +46,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
@@ -47,8 +47,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
@@ -48,8 +48,6 @@ spec:
         - istio-pilot:15010
         - --proxyLogLevel=warning
         - --proxyComponentLogLevel=misc:error
-        - --dnsRefreshRate
-        - 300s
         - --statusPort
         - "15020"
         - --trust-domain=cluster.local

--- a/tools/packaging/common/envoy_bootstrap_v2.json
+++ b/tools/packaging/common/envoy_bootstrap_v2.json
@@ -266,7 +266,7 @@
       {
         "name": "xds-grpc",
         "type": "STRICT_DNS",
-        "dns_refresh_rate": "{{ .dns_refresh_rate }}",
+        "respect_dns_ttl": true,
         "dns_lookup_family": "{{ .dns_lookup_family }}",
         "connect_timeout": "{{ .connect_timeout }}",
         "lb_policy": "ROUND_ROBIN",
@@ -444,7 +444,7 @@
       {
         "name": "zipkin",
         "type": "STRICT_DNS",
-        "dns_refresh_rate": "{{ .dns_refresh_rate }}",
+        "respect_dns_ttl": true,
         "dns_lookup_family": "{{ .dns_lookup_family }}",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -474,7 +474,7 @@
         },
         {{ end }}
         "type": "STRICT_DNS",
-        "dns_refresh_rate": "{{ .dns_refresh_rate }}",
+        "respect_dns_ttl": true,
         "dns_lookup_family": "{{ .dns_lookup_family }}",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -490,7 +490,7 @@
         "name": "datadog_agent",
         "connect_timeout": "1s",
         "type": "STRICT_DNS",
-        "dns_refresh_rate": "{{ .dns_refresh_rate }}",
+        "respect_dns_ttl": true,
         "dns_lookup_family": "{{ .dns_lookup_family }}",
         "lb_policy": "ROUND_ROBIN",
         "hosts": [
@@ -511,7 +511,7 @@
       {{ if .envoy_metrics_service_tcp_keepalive }}
         "upstream_connection_options": {{ .envoy_metrics_service_tcp_keepalive }},
       {{ end }}
-        "dns_refresh_rate": "{{ .dns_refresh_rate }}",
+        "respect_dns_ttl": true,
         "dns_lookup_family": "{{ .dns_lookup_family }}",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -534,7 +534,7 @@
       {{ if .envoy_accesslog_service_tcp_keepalive }}
         "upstream_connection_options": {{ .envoy_accesslog_service_tcp_keepalive }},
       {{ end }}
-        "dns_refresh_rate": "{{ .dns_refresh_rate }}",
+        "respect_dns_ttl": true,
         "dns_lookup_family": "{{ .dns_lookup_family }}",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",


### PR DESCRIPTION
For https://github.com/istio/istio/issues/21222

This cleans up our config a bit. Rather than resolving DNS every 5 min for pilot, just use the TTL return in the dns response. This is what we are doing for ServiceEntries already, so its proven to work fine.

There is 1000s of lines of autogenerated garbage, see the first commit for easier review, the second one just adds the gen