### PR TITLE
[release-1.4] authz: fix the validation for request.headers

### DIFF
--- a/pilot/pkg/security/authz/model/principal.go
+++ b/pilot/pkg/security/authz/model/principal.go
@@ -66,7 +66,7 @@ func (principal *Principal) ValidateForTCP(forTCP bool) error {
 
 	for _, p := range principal.Properties {
 		for key := range p {
-			if strings.HasPrefix(key, "request.auth.") || key == attrSrcUser {
+			if strings.HasPrefix(key, "request.") || key == attrSrcUser {
 				return fmt.Errorf("property(%v)", p)
 			}
 		}

--- a/pilot/pkg/security/authz/model/principal_test.go
+++ b/pilot/pkg/security/authz/model/principal_test.go
@@ -52,6 +52,16 @@ func TestPrincipal_ValidateForTCP(t *testing.T) {
 			},
 		},
 		{
+			name: "principal with request.headers",
+			principal: &Principal{
+				Properties: []KeyValues{
+					{
+						"request.headers[x-foo]": []string{"bar"},
+					},
+				},
+			},
+		},
+		{
 			name: "good principal",
 			principal: &Principal{
 				Users: []string{"user"},

--- a/tests/integration/security/testdata/rbac/v1beta1-request-headers.yaml.tmpl
+++ b/tests/integration/security/testdata/rbac/v1beta1-request-headers.yaml.tmpl
@@ -1,0 +1,16 @@
+# The following policy allows request to path "/allow" to workload b.
+
+apiVersion: "security.istio.io/v1beta1"
+kind: AuthorizationPolicy
+metadata:
+  name: policy-b
+  namespace: "{{ .Namespace }}"
+spec:
+  selector:
+    matchLabels:
+      "app": "b"
+  rules:
+  - when:
+    - key: request.headers[:path]
+      values: ["/allow"]
+---


### PR DESCRIPTION
This fixes the validation for the "request.headers" to correctly generate the filter config. Note the bug has already been fixed in master and release-1.5 in a separate PR before.