### PR TITLE
Fix port allocation conflicts in tests and naming style issues

### DIFF
--- a/mixer/test/client/env/ports.go
+++ b/mixer/test/client/env/ports.go
@@ -68,6 +68,8 @@ const (
 	STSRenewTest
 	STSFailureTest
 	STSTimeoutTest
+	STSServerCacheTest
+	STSShortLivedCacheTest
 
 	// The number of total tests. has to be the last one.
 	maxTestNum
@@ -76,7 +78,7 @@ const (
 const (
 	portBase uint16 = 20000
 	// Maximum number of ports used in each test.
-	portNum uint16 = 7
+	portNum uint16 = 8
 	// Number of ports used by Envoy in each test.
 	envoyPortNum uint16 = 4
 )

--- a/mixer/test/client/env/ports.go
+++ b/mixer/test/client/env/ports.go
@@ -90,6 +90,7 @@ type Ports struct {
 	MixerPort       uint16
 	BackendPort     uint16
 	DiscoveryPort   uint16
+	STSPort         uint16
 
 	// Pilot ports, used when testing mixer-pilot integration.
 	PilotGrpcPort uint16
@@ -141,6 +142,7 @@ func NewPorts(name uint16) *Ports {
 		MixerPort:       base + 4,
 		BackendPort:     base + 5,
 		DiscoveryPort:   base + 6,
+		STSPort:         base + 7,
 	}
 }
 
@@ -155,5 +157,6 @@ func NewEnvoyPorts(ports *Ports, name uint16) *Ports {
 		MixerPort:       ports.MixerPort,
 		BackendPort:     ports.BackendPort,
 		DiscoveryPort:   ports.DiscoveryPort,
+		STSPort:         ports.STSPort,
 	}
 }

--- a/mixer/test/client/tracing_header/tracing_header_test.go
+++ b/mixer/test/client/tracing_header/tracing_header_test.go
@@ -121,7 +121,7 @@ const reportAttributesOkGet = `
   "context.reporter.uid": "",
   "destination.ip": "[127 0 0 1]",
   "destination.namespace": "",
-  "destination.port": "20271",
+  "destination.port": "20309",
   "destination.uid": "",
   "mesh1.ip": "[1 1 1 1]",
   "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",

--- a/security/pkg/stsservice/test/failure_sts_token_fetch/token_failure_test.go
+++ b/security/pkg/stsservice/test/failure_sts_token_fetch/token_failure_test.go
@@ -33,7 +33,7 @@ func TestTokenFetchFailureOne(t *testing.T) {
 	t.Skip("https://github.com/istio/istio/issues/20133")
 	cb := xdsService.CreateXdsCallback(t)
 	// Start all test servers
-	setup := stsTest.SetUpTest(t, cb, testID.STSFailureTest, false)
+	setup := stsTest.SetupTest(t, cb, testID.STSFailureTest, false)
 
 	// Get initial number of calls to auth server. They are not zero due to STS flow test
 	// in the test setup, to make sure the servers are up and ready to serve.
@@ -45,7 +45,7 @@ func TestTokenFetchFailureOne(t *testing.T) {
 
 	// Verify that auth backend gets token exchange calls, and envoy fails to start.
 	g := gomega.NewWithT(t)
-	g.Expect(setup.ProxySetUp.SetUp()).To(gomega.HaveOccurred())
+	g.Expect(setup.ProxySetup.SetUp()).To(gomega.HaveOccurred())
 	numFederatedTokenCall := setup.AuthServer.NumGetFederatedTokenCalls()
 	numAccessTokenCall := setup.AuthServer.NumGetAccessTokenCalls()
 	g.Expect(numFederatedTokenCall).Should(gomega.BeNumerically(">", initialNumFederatedTokenCall))
@@ -64,7 +64,7 @@ func TestTokenFetchFailureTwo(t *testing.T) {
 	t.Skip("https://github.com/istio/istio/issues/20133")
 	cb := xdsService.CreateXdsCallback(t)
 	// Start all test servers
-	setup := stsTest.SetUpTest(t, cb, testID.STSFailureTest, false)
+	setup := stsTest.SetupTest(t, cb, testID.STSFailureTest, false)
 
 	// Get initial number of calls to auth server. They are not zero due to STS flow test
 	// in the test setup, to make sure the servers are up and ready to serve.
@@ -76,7 +76,7 @@ func TestTokenFetchFailureTwo(t *testing.T) {
 
 	// Verify that auth backend gets token exchange calls, and envoy fails to start.
 	g := gomega.NewWithT(t)
-	g.Expect(setup.ProxySetUp.SetUp()).To(gomega.HaveOccurred())
+	g.Expect(setup.ProxySetup.SetUp()).To(gomega.HaveOccurred())
 	numFederatedTokenCall := setup.AuthServer.NumGetFederatedTokenCalls()
 	numAccessTokenCall := setup.AuthServer.NumGetAccessTokenCalls()
 	g.Expect(numFederatedTokenCall).Should(gomega.BeNumerically(">", initialNumFederatedTokenCall))

--- a/security/pkg/stsservice/test/proxy_cached_sts_token/proxy_cached_token_test.go
+++ b/security/pkg/stsservice/test/proxy_cached_sts_token/proxy_cached_token_test.go
@@ -37,7 +37,7 @@ func TestProxyCachedToken(t *testing.T) {
 	// Force XDS server to close streams 3 times and keep the 4th stream open.
 	cb.SetNumberOfStreamClose(numCloseStream, 0)
 	// Start all test servers and proxy
-	setup := stsTest.SetUpTest(t, cb, testID.STSCacheTest, false)
+	setup := stsTest.SetupTest(t, cb, testID.STSCacheTest, false)
 	// Explicitly set token life time to a long duration.
 	setup.AuthServer.SetTokenLifeTime(3600)
 	// Explicitly set auth server to return different access token to each call.
@@ -51,7 +51,7 @@ func TestProxyCachedToken(t *testing.T) {
 	initialNumFederatedTokenCall := setup.AuthServer.NumGetFederatedTokenCalls()
 	initialNumAccessTokenCall := setup.AuthServer.NumGetAccessTokenCalls()
 	setup.StartProxy(t)
-	setup.ProxySetUp.WaitEnvoyReady()
+	setup.ProxySetup.WaitEnvoyReady()
 	// Verify that proxy re-connects XDS server after each stream close, and the
 	// same token is received.
 	g.Expect(cb.NumStream()).To(gomega.Equal(numCloseStream + 1))

--- a/security/pkg/stsservice/test/renew_sts_token/renew_token_test.go
+++ b/security/pkg/stsservice/test/renew_sts_token/renew_token_test.go
@@ -39,7 +39,7 @@ func TestRenewToken(t *testing.T) {
 	// stream should present a new token.
 	cb.SetNumberOfStreamClose(numCloseStream, tokenLifeTimeInSec+1)
 	// Start all test servers and proxy
-	setup := stsTest.SetUpTest(t, cb, testID.STSRenewTest, false)
+	setup := stsTest.SetupTest(t, cb, testID.STSRenewTest, false)
 	// Explicitly set token life time to a short duration.
 	setup.AuthServer.SetTokenLifeTime(tokenLifeTimeInSec)
 	// Explicitly set auth server to return different access token to each call.
@@ -53,7 +53,7 @@ func TestRenewToken(t *testing.T) {
 	initialNumFederatedTokenCall := setup.AuthServer.NumGetFederatedTokenCalls()
 	initialNumAccessTokenCall := setup.AuthServer.NumGetAccessTokenCalls()
 	setup.StartProxy(t)
-	setup.ProxySetUp.WaitEnvoyReady()
+	setup.ProxySetup.WaitEnvoyReady()
 	// Verify that proxy re-connects XDS server after each stream close, and a
 	// different token is received.
 	g.Expect(cb.NumStream()).To(gomega.Equal(numCloseStream + 1))

--- a/security/pkg/stsservice/test/server_cached_short_lived_sts_token/short_lived_cached_token_test.go
+++ b/security/pkg/stsservice/test/server_cached_short_lived_sts_token/short_lived_cached_token_test.go
@@ -34,7 +34,7 @@ func TestServerShortLivedCachedToken(t *testing.T) {
 	// Sets up callback that verifies token on new XDS stream.
 	cb := xdsService.CreateXdsCallback(t)
 	// Start all test servers and proxy
-	setup := stsTest.SetUpTest(t, cb, testID.STSCacheTest, true)
+	setup := stsTest.SetupTest(t, cb, testID.STSCacheTest, true)
 	// Explicitly set token life time to a short duration, which is below the grace
 	// period (5 minutes) of using cached token. Cached token is not in use.
 	setup.ClearTokenCache()
@@ -53,8 +53,8 @@ func TestServerShortLivedCachedToken(t *testing.T) {
 	// Starting proxy will send a STS request to the STS server. Because cached
 	// token is deleted, the STS server fetches a new token.
 	setup.StartProxy(t)
-	setup.ProxySetUp.WaitEnvoyReady()
-	setup.ProxySetUp.ReStartEnvoy()
+	setup.ProxySetup.WaitEnvoyReady()
+	setup.ProxySetup.ReStartEnvoy()
 	// Restarting proxy will send another STS request to the STS server. Because
 	// cached token is within grace period, the STS server fetches a new token.
 	g.Expect(cb.NumStream()).To(gomega.Equal(2))

--- a/security/pkg/stsservice/test/server_cached_short_lived_sts_token/short_lived_cached_token_test.go
+++ b/security/pkg/stsservice/test/server_cached_short_lived_sts_token/short_lived_cached_token_test.go
@@ -34,7 +34,7 @@ func TestServerShortLivedCachedToken(t *testing.T) {
 	// Sets up callback that verifies token on new XDS stream.
 	cb := xdsService.CreateXdsCallback(t)
 	// Start all test servers and proxy
-	setup := stsTest.SetupTest(t, cb, testID.STSCacheTest, true)
+	setup := stsTest.SetupTest(t, cb, testID.STSShortLivedCacheTest, true)
 	// Explicitly set token life time to a short duration, which is below the grace
 	// period (5 minutes) of using cached token. Cached token is not in use.
 	setup.ClearTokenCache()

--- a/security/pkg/stsservice/test/server_cached_sts_token/server_cached_token_test.go
+++ b/security/pkg/stsservice/test/server_cached_sts_token/server_cached_token_test.go
@@ -34,7 +34,7 @@ func TestServerCachedToken(t *testing.T) {
 	// Sets up callback that verifies token on new XDS stream.
 	cb := xdsService.CreateXdsCallback(t)
 	// Start all test servers and proxy
-	setup := stsTest.SetUpTest(t, cb, testID.STSCacheTest, true)
+	setup := stsTest.SetupTest(t, cb, testID.STSCacheTest, true)
 	// Explicitly set token life time to a long duration.
 	setup.AuthServer.SetTokenLifeTime(3600)
 	// Explicitly set auth server to return different access token to each call.
@@ -51,8 +51,8 @@ func TestServerCachedToken(t *testing.T) {
 	// Starting proxy will send a STS request to the STS server, and gets a cached
 	// token. This token is used to set up gRPC stream with XDS server.
 	setup.StartProxy(t)
-	setup.ProxySetUp.WaitEnvoyReady()
-	setup.ProxySetUp.ReStartEnvoy()
+	setup.ProxySetup.WaitEnvoyReady()
+	setup.ProxySetup.ReStartEnvoy()
 	// Restarting proxy will send another STS request to the STS server, and gets
 	// a cached token. This token is used to set up a new gRPC stream with the XDS
 	// server.

--- a/security/pkg/stsservice/test/server_cached_sts_token/server_cached_token_test.go
+++ b/security/pkg/stsservice/test/server_cached_sts_token/server_cached_token_test.go
@@ -34,7 +34,7 @@ func TestServerCachedToken(t *testing.T) {
 	// Sets up callback that verifies token on new XDS stream.
 	cb := xdsService.CreateXdsCallback(t)
 	// Start all test servers and proxy
-	setup := stsTest.SetupTest(t, cb, testID.STSCacheTest, true)
+	setup := stsTest.SetupTest(t, cb, testID.STSServerCacheTest, true)
 	// Explicitly set token life time to a long duration.
 	setup.AuthServer.SetTokenLifeTime(3600)
 	// Explicitly set auth server to return different access token to each call.

--- a/security/pkg/stsservice/test/setup.go
+++ b/security/pkg/stsservice/test/setup.go
@@ -45,16 +45,14 @@ const (
 	// match bootstrap config in testdata/bootstrap.yaml
 	certPath       = "/tmp/sts-ca-certificates.crt"
 	proxyTokenPath = "/tmp/sts-envoy-token.jwt"
-	// STS server port
-	stsPort = 15463
 )
 
 type Env struct {
-	ProxySetUp *proxyEnv.TestSetup
+	ProxySetup *proxyEnv.TestSetup
 	AuthServer *tokenBackend.AuthorizationServer
 
 	stsServer           *stsServer.Server
-	xDSServer           *grpc.Server
+	xdsServer           *grpc.Server
 	ProxyListenerPort   int
 	initialToken        string // initial token is sent to STS server for token exchange
 	tokenExchangePlugin *google.Plugin
@@ -63,9 +61,9 @@ type Env struct {
 func (e *Env) TearDown() {
 	// Stop proxy first, otherwise XDS stream is still alive and server's graceful
 	// stop will be blocked.
-	e.ProxySetUp.TearDown()
+	e.ProxySetup.TearDown()
 	_ = e.AuthServer.Stop()
-	e.xDSServer.GracefulStop()
+	e.xdsServer.GracefulStop()
 	e.stsServer.Stop()
 }
 
@@ -94,7 +92,7 @@ func WriteDataToFile(path string, content string) error {
 	return nil
 }
 
-// SetUpTest starts Envoy, XDS server, STS server, token manager, and a token service backend.
+// SetupTest starts Envoy, XDS server, STS server, token manager, and a token service backend.
 // Envoy loads a test config that requires token credential to access XDS server.
 // That token credential is provisioned by STS server.
 // enableCache indicates whether to enable token cache at STS server side.
@@ -106,7 +104,7 @@ func WriteDataToFile(path string, content string) error {
 // XDS server             : DiscoveryPort
 // test backend           : BackendPort
 // proxy admin            : AdminPort
-func SetUpTest(t *testing.T, cb *xdsService.XDSCallbacks, testID uint16, enableCache bool) *Env {
+func SetupTest(t *testing.T, cb *xdsService.XDSCallbacks, testID uint16, enableCache bool) *Env {
 	// Set up credential files for bootstrap config
 	jwtToken := getDataFromFile(istioEnv.IstioSrc+"/security/pkg/stsservice/test/testdata/trustworthy-jwt.jwt", t)
 	if err := WriteDataToFile(proxyTokenPath, jwtToken); err != nil {
@@ -121,15 +119,15 @@ func SetUpTest(t *testing.T, cb *xdsService.XDSCallbacks, testID uint16, enableC
 		initialToken: jwtToken,
 	}
 	// Set up test environment for Proxy
-	proxySetUp := proxyEnv.NewTestSetup(testID, t)
-	proxySetUp.SetNoMixer(true)
-	proxySetUp.EnvoyTemplate = getDataFromFile(istioEnv.IstioSrc+"/security/pkg/stsservice/test/testdata/bootstrap.yaml", t)
-	env.ProxySetUp = proxySetUp
+	proxySetup := proxyEnv.NewTestSetup(testID, t)
+	proxySetup.SetNoMixer(true)
+	proxySetup.EnvoyTemplate = getDataFromFile(istioEnv.IstioSrc+"/security/pkg/stsservice/test/testdata/bootstrap.yaml", t)
+	env.ProxySetup = proxySetup
 	env.DumpPortMap(t)
 	// Set up auth server that provides token service
 	backend, err := tokenBackend.StartNewServer(t, tokenBackend.Config{
 		SubjectToken: jwtToken,
-		Port:         int(proxySetUp.Ports().MixerPort),
+		Port:         int(proxySetup.Ports().MixerPort),
 		AccessToken:  cb.ExpectedToken(),
 	})
 	if err != nil {
@@ -138,7 +136,7 @@ func SetUpTest(t *testing.T, cb *xdsService.XDSCallbacks, testID uint16, enableC
 	env.AuthServer = backend
 
 	// Set up STS server
-	stsServer, plugin, err := setUpSTS(stsPort, backend.URL, enableCache)
+	stsServer, plugin, err := setupSTS(int(proxySetup.Ports().STSPort), backend.URL, enableCache)
 	if err != nil {
 		t.Fatalf("failed to start a STS server: %v", err)
 	}
@@ -149,16 +147,16 @@ func SetUpTest(t *testing.T, cb *xdsService.XDSCallbacks, testID uint16, enableC
 	env.WaitForStsFlowReady(t)
 
 	// Set up XDS server
-	env.ProxyListenerPort = int(proxySetUp.Ports().ClientProxyPort)
+	env.ProxyListenerPort = int(proxySetup.Ports().ClientProxyPort)
 	ls := &xdsService.DynamicListener{Port: env.ProxyListenerPort}
 	xds, err := xdsService.StartXDSServer(
-		xdsService.XDSConf{Port: int(proxySetUp.Ports().DiscoveryPort),
+		xdsService.XDSConf{Port: int(proxySetup.Ports().DiscoveryPort),
 			CertFile: istioEnv.IstioSrc + "/security/pkg/stsservice/test/testdata/server-certificate.crt",
 			KeyFile:  istioEnv.IstioSrc + "/security/pkg/stsservice/test/testdata/server-key.key"}, cb, ls, true)
 	if err != nil {
 		t.Fatalf("failed to start XDS server: %v", err)
 	}
-	env.xDSServer = xds
+	env.xdsServer = xds
 
 	return env
 }
@@ -179,10 +177,10 @@ func (e *Env) DumpPortMap(t *testing.T) {
 		"static listener port\t:\t%d\n"+
 		"XDS server\t\t:\t%d\n"+
 		"test backend\t\t:\t%d\n"+
-		"proxy admin\t\t:\t%d", e.ProxySetUp.Ports().MixerPort,
-		stsPort, e.ProxySetUp.Ports().ClientProxyPort,
-		e.ProxySetUp.Ports().TCPProxyPort, e.ProxySetUp.Ports().DiscoveryPort,
-		e.ProxySetUp.Ports().BackendPort, e.ProxySetUp.Ports().AdminPort)
+		"proxy admin\t\t:\t%d", e.ProxySetup.Ports().MixerPort,
+		e.ProxySetup.Ports().STSPort, e.ProxySetup.Ports().ClientProxyPort,
+		e.ProxySetup.Ports().TCPProxyPort, e.ProxySetup.Ports().DiscoveryPort,
+		e.ProxySetup.Ports().BackendPort, e.ProxySetup.Ports().AdminPort)
 }
 
 func (e *Env) ClearTokenCache() {
@@ -190,7 +188,7 @@ func (e *Env) ClearTokenCache() {
 }
 
 func (e *Env) StartProxy(t *testing.T) {
-	if err := e.ProxySetUp.SetUp(); err != nil {
+	if err := e.ProxySetup.SetUp(); err != nil {
 		t.Fatalf("failed to start proxy: %v", err)
 	}
 	log.Println("proxy is running...")
@@ -200,7 +198,7 @@ func (e *Env) StartProxy(t *testing.T) {
 // verifies that the STS flow is ready.
 func (e *Env) WaitForStsFlowReady(t *testing.T) {
 	t.Logf("%s check if all servers in the STS flow are up and ready", time.Now().String())
-	addr, _ := net.ResolveTCPAddr("tcp", fmt.Sprintf("127.0.0.1:%d", stsPort))
+	addr, _ := net.ResolveTCPAddr("tcp", fmt.Sprintf("127.0.0.1:%d", e.ProxySetup.Ports().STSPort))
 	stsServerAddress := addr.String()
 	hTTPClient := &http.Client{
 		Transport: &http.Transport{
@@ -243,7 +241,7 @@ func (e *Env) genStsReq(stsAddr string) (req *http.Request) {
 	return req
 }
 
-func setUpSTS(stsPort int, backendURL string, enableCache bool) (*stsServer.Server, *google.Plugin, error) {
+func setupSTS(stsPort int, backendURL string, enableCache bool) (*stsServer.Server, *google.Plugin, error) {
 	// Create token exchange Google plugin
 	tokenExchangePlugin, _ := google.CreateTokenManagerPlugin(tokenBackend.FakeTrustDomain,
 		tokenBackend.FakeProjectNum, tokenBackend.FakeGKEClusterURL, enableCache)

--- a/security/pkg/stsservice/test/setup.go
+++ b/security/pkg/stsservice/test/setup.go
@@ -98,7 +98,7 @@ func WriteDataToFile(path string, content string) error {
 // enableCache indicates whether to enable token cache at STS server side.
 // Here is a map between ports and servers
 // auth server            : MixerPort
-// STS server             : stsPort
+// STS server             : STSPort
 // Dynamic proxy listener : ClientProxyPort
 // Static proxy listener  : TCPProxyPort
 // XDS server             : DiscoveryPort
@@ -163,7 +163,7 @@ func SetupTest(t *testing.T, cb *xdsService.XDSCallbacks, testID uint16, enableC
 
 // DumpPortMap dumps port allocation status
 // auth server            : MixerPort
-// STS server             : stsPort
+// STS server             : STSPort
 // Dynamic proxy listener : ClientProxyPort
 // Static proxy listener  : TCPProxyPort
 // XDS server             : DiscoveryPort

--- a/security/pkg/stsservice/test/sts_fetch_timeout/sts_timeout_test.go
+++ b/security/pkg/stsservice/test/sts_fetch_timeout/sts_timeout_test.go
@@ -32,7 +32,7 @@ func TestTokenFetchTimeoutOne(t *testing.T) {
 	t.Skip("https://github.com/istio/istio/issues/20133")
 	cb := xdsService.CreateXdsCallback(t)
 	// Start all test servers
-	setup := stsTest.SetUpTest(t, cb, testID.STSTimeoutTest, false)
+	setup := stsTest.SetupTest(t, cb, testID.STSTimeoutTest, false)
 
 	// Get initial number of calls to auth server. They are not zero due to STS flow test
 	// in the test setup, to make sure the servers are up and ready to serve.
@@ -43,7 +43,7 @@ func TestTokenFetchTimeoutOne(t *testing.T) {
 	setup.AuthServer.BlockFederatedTokenRequest(true)
 
 	g := gomega.NewWithT(t)
-	g.Expect(setup.ProxySetUp.SetUp()).To(gomega.HaveOccurred())
+	g.Expect(setup.ProxySetup.SetUp()).To(gomega.HaveOccurred())
 
 	numFederatedTokenCall := setup.AuthServer.NumGetFederatedTokenCalls()
 	numAccessTokenCall := setup.AuthServer.NumGetAccessTokenCalls()
@@ -53,7 +53,7 @@ func TestTokenFetchTimeoutOne(t *testing.T) {
 	g.Expect(numAccessTokenCall).To(gomega.Equal(initialNumAccessTokenCall))
 	g.Expect(cb.NumStream()).To(gomega.Equal(0))
 	g.Expect(cb.NumTokenReceived()).To(gomega.Equal(0))
-	setup.ProxySetUp.SilentlyStopProxy(true)
+	setup.ProxySetup.SilentlyStopProxy(true)
 	setup.TearDown()
 }
 
@@ -65,7 +65,7 @@ func TestTokenFetchTimeoutTwo(t *testing.T) {
 	t.Skip("https://github.com/istio/istio/issues/20133")
 	cb := xdsService.CreateXdsCallback(t)
 	// Start all test servers
-	setup := stsTest.SetUpTest(t, cb, testID.STSTimeoutTest, false)
+	setup := stsTest.SetupTest(t, cb, testID.STSTimeoutTest, false)
 
 	// Get initial number of calls to auth server. They are not zero due to STS flow test
 	// in the test setup, to make sure the servers are up and ready to serve.
@@ -76,7 +76,7 @@ func TestTokenFetchTimeoutTwo(t *testing.T) {
 	setup.AuthServer.BlockAccessTokenRequest(true)
 
 	g := gomega.NewWithT(t)
-	g.Expect(setup.ProxySetUp.SetUp()).To(gomega.HaveOccurred())
+	g.Expect(setup.ProxySetup.SetUp()).To(gomega.HaveOccurred())
 
 	numFederatedTokenCall := setup.AuthServer.NumGetFederatedTokenCalls()
 	numAccessTokenCall := setup.AuthServer.NumGetAccessTokenCalls()
@@ -86,6 +86,6 @@ func TestTokenFetchTimeoutTwo(t *testing.T) {
 	g.Expect(numAccessTokenCall).To(gomega.BeNumerically(">", initialNumAccessTokenCall+1))
 	g.Expect(cb.NumStream()).To(gomega.Equal(0))
 	g.Expect(cb.NumTokenReceived()).To(gomega.Equal(0))
-	setup.ProxySetUp.SilentlyStopProxy(true)
+	setup.ProxySetup.SilentlyStopProxy(true)
 	setup.TearDown()
 }

--- a/security/pkg/stsservice/test/success_sts/proxy_sts_test.go
+++ b/security/pkg/stsservice/test/success_sts/proxy_sts_test.go
@@ -45,7 +45,7 @@ func TestProxySTS(t *testing.T) {
 	cb := xdsService.CreateXdsCallback(t)
 	cb.SetExpectedToken(expectedToken)
 	// Start all test servers and proxy
-	setup := stsTest.SetUpTest(t, cb, testID.STSTest, false)
+	setup := stsTest.SetupTest(t, cb, testID.STSTest, false)
 	// Verify that initially XDS stream is not set up, stats do not update initial stats
 	g := gomega.NewWithT(t)
 	g.Expect(cb.NumStream()).To(gomega.Equal(0))
@@ -56,7 +56,7 @@ func TestProxySTS(t *testing.T) {
 	g.Expect(cb.NumTokenReceived()).To(gomega.Equal(1))
 	// Verify that LDS push is done and dynamic listener works properly, this is
 	// to make sure XDS stream is working properly
-	setup.ProxySetUp.WaitEnvoyReady()
+	setup.ProxySetup.WaitEnvoyReady()
 	// Issues a GET echo request with 0 size body to the dynamic listener
 	if _, _, err := env.HTTPGet(fmt.Sprintf("http://localhost:%d/echo", setup.ProxyListenerPort)); err != nil {
 		t.Errorf("Failed in request: %v", err)

--- a/security/pkg/stsservice/test/testdata/bootstrap.yaml
+++ b/security/pkg/stsservice/test/testdata/bootstrap.yaml
@@ -21,7 +21,7 @@ dynamic_resources:
               filename: /tmp/sts-ca-certificates.crt
         call_credentials:
           sts_service:
-            token_exchange_service_uri: http://127.0.0.1:{{.Ports.ServerProxyPort}}/token
+            token_exchange_service_uri: http://127.0.0.1:{{.Ports.STSPort}}/token
             subject_token_path: /tmp/sts-envoy-token.jwt
             subject_token_type: urn:ietf:params:oauth:token-type:jwt
             scope: https://www.googleapis.com/auth/cloud-platform

--- a/security/pkg/stsservice/test/testdata/bootstrap.yaml
+++ b/security/pkg/stsservice/test/testdata/bootstrap.yaml
@@ -21,7 +21,7 @@ dynamic_resources:
               filename: /tmp/sts-ca-certificates.crt
         call_credentials:
           sts_service:
-            token_exchange_service_uri: http://127.0.0.1:15463/token
+            token_exchange_service_uri: http://127.0.0.1:{{.Ports.ServerProxyPort}}/token
             subject_token_path: /tmp/sts-envoy-token.jwt
             subject_token_type: urn:ietf:params:oauth:token-type:jwt
             scope: https://www.googleapis.com/auth/cloud-platform


### PR DESCRIPTION
The STS integration tests are running in parallel. In each test the STS server listens on a unique port and is configured to behave differently. https://github.com/istio/istio/pull/21238 uses a universal port for STS server, which causes problems when tests are running in parallel. 
This PR allocates different port for each test, and fixes some naming issues (https://github.com/istio/istio/pull/21244).



#20133