### PR TITLE
Clean up pilot bootstrap args

### DIFF
--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -127,11 +127,11 @@ func init() {
 		"comma separated list of networking plugins to enable")
 
 	// MCP client flags
-	discoveryCmd.PersistentFlags().IntVar(&serverArgs.MCPMaxMessageSize, "mcpMaxMsgSize", defaultMCPMaxMessageSize,
+	discoveryCmd.PersistentFlags().IntVar(&serverArgs.MCPOptions.MaxMessageSize, "mcpMaxMsgSize", defaultMCPMaxMessageSize,
 		"Max message size received by MCP's grpc client")
-	discoveryCmd.PersistentFlags().IntVar(&serverArgs.MCPInitialWindowSize, "mcpInitialWindowSize", defaultMCPInitialWindowSize,
+	discoveryCmd.PersistentFlags().IntVar(&serverArgs.MCPOptions.InitialWindowSize, "mcpInitialWindowSize", defaultMCPInitialWindowSize,
 		"Initial window size for MCP's gRPC connection")
-	discoveryCmd.PersistentFlags().IntVar(&serverArgs.MCPInitialConnWindowSize, "mcpInitialConnWindowSize", defaultMCPInitialConnWindowSize,
+	discoveryCmd.PersistentFlags().IntVar(&serverArgs.MCPOptions.InitialConnWindowSize, "mcpInitialConnWindowSize", defaultMCPInitialConnWindowSize,
 		"Initial connection window size for MCP's gRPC connection")
 
 	// Config Controller options

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -324,9 +324,9 @@ func grpcDial(ctx context.Context,
 		Timeout: args.KeepaliveOptions.Timeout,
 	})
 
-	initialWindowSizeOption := grpc.WithInitialWindowSize(int32(args.MCPInitialWindowSize))
-	initialConnWindowSizeOption := grpc.WithInitialConnWindowSize(int32(args.MCPInitialConnWindowSize))
-	msgSizeOption := grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(args.MCPMaxMessageSize))
+	initialWindowSizeOption := grpc.WithInitialWindowSize(int32(args.MCPOptions.InitialWindowSize))
+	initialConnWindowSizeOption := grpc.WithInitialConnWindowSize(int32(args.MCPOptions.InitialConnWindowSize))
+	msgSizeOption := grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(args.MCPOptions.MaxMessageSize))
 
 	return grpc.DialContext(
 		ctx,

--- a/pilot/pkg/bootstrap/options.go
+++ b/pilot/pkg/bootstrap/options.go
@@ -107,10 +107,6 @@ type DiscoveryServiceOptions struct {
 	// "" means disabling secure GRPC, used in test.
 	SecureGrpcAddr string
 
-	// The listening address for secure GRPC with DNS-based certificates. Default is :15012, if certificates are available.
-	// Will not start otherwise.
-	SecureGrpcDNSAddr string
-
 	// The listening address for the monitoring port. If the port in the address is empty or "0" (as in "127.0.0.1:" or "[::1]:0")
 	// a port number is automatically chosen.
 	MonitoringAddr string

--- a/pilot/pkg/bootstrap/options.go
+++ b/pilot/pkg/bootstrap/options.go
@@ -66,23 +66,21 @@ type ServiceArgs struct {
 
 // PilotArgs provides all of the configuration parameters for the Pilot discovery service.
 type PilotArgs struct {
-	DiscoveryOptions         DiscoveryServiceOptions
-	InjectionOptions         InjectionOptions
-	PodName                  string
-	Namespace                string
-	Revision                 string
-	ServiceAccountName       string
-	Mesh                     MeshArgs
-	Config                   ConfigArgs
-	Service                  ServiceArgs
-	MeshConfig               *meshconfig.MeshConfig
-	NetworksConfigFile       string
-	CtrlZOptions             *ctrlz.Options
-	Plugins                  []string
-	MCPMaxMessageSize        int
-	MCPInitialWindowSize     int
-	MCPInitialConnWindowSize int
-	KeepaliveOptions         *istiokeepalive.Options
+	DiscoveryOptions   DiscoveryServiceOptions
+	InjectionOptions   InjectionOptions
+	PodName            string
+	Namespace          string
+	Revision           string
+	ServiceAccountName string
+	Mesh               MeshArgs
+	Config             ConfigArgs
+	Service            ServiceArgs
+	MeshConfig         *meshconfig.MeshConfig
+	NetworksConfigFile string
+	CtrlZOptions       *ctrlz.Options
+	Plugins            []string
+	MCPOptions         MCPOptions
+	KeepaliveOptions   *istiokeepalive.Options
 	// ForceStop is set as true when used for testing to make the server stop quickly
 	ForceStop bool
 }
@@ -117,6 +115,12 @@ type DiscoveryServiceOptions struct {
 type InjectionOptions struct {
 	// Directory of injection related config files.
 	InjectionDirectory string
+}
+
+type MCPOptions struct {
+	MaxMessageSize        int
+	InitialWindowSize     int
+	InitialConnWindowSize int
 }
 
 var PodNamespaceVar = env.RegisterStringVar("POD_NAMESPACE", "", "")

--- a/pilot/pkg/bootstrap/options.go
+++ b/pilot/pkg/bootstrap/options.go
@@ -85,7 +85,6 @@ type PilotArgs struct {
 	KeepaliveOptions         *istiokeepalive.Options
 	// ForceStop is set as true when used for testing to make the server stop quickly
 	ForceStop bool
-	BasePort  int
 }
 
 // DiscoveryServiceOptions contains options for create a new discovery
@@ -159,7 +158,6 @@ func (p *PilotArgs) applyDefaults() {
 	p.ServiceAccountName = serviceAccountVar.Get()
 	p.Revision = revisionVar.Get()
 	p.KeepaliveOptions = istiokeepalive.DefaultOption()
-	p.BasePort = 15000
 	p.Config.DistributionTrackingEnabled = features.EnableDistributionTracking
 	p.Config.DistributionCacheRetention = features.DistributionHistoryRetention
 }

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -142,8 +142,6 @@ type Server struct {
 	HTTPListener net.Listener
 	GRPCListener net.Listener
 
-	basePort int
-
 	// for test
 	forceStop bool
 
@@ -170,7 +168,6 @@ func NewServer(args *PilotArgs) (*Server, error) {
 	}
 
 	s := &Server{
-		basePort:       args.BasePort,
 		clusterID:      getClusterID(args),
 		environment:    e,
 		EnvoyXdsServer: envoyv2.NewDiscoveryServer(e, args.Plugins),

--- a/pkg/test/framework/components/pilot/native.go
+++ b/pkg/test/framework/components/pilot/native.go
@@ -126,7 +126,7 @@ func newNative(ctx resource.Context, cfg Config) (Instance, error) {
 		Address: galleyHostPort,
 	})
 
-	bootstrapArgs.MCPMaxMessageSize = 1024 * 1024 * 4
+	bootstrapArgs.MCPOptions.MaxMessageSize = 1024 * 1024 * 4
 
 	var err error
 	// Create the server for the discovery service.

--- a/tests/util/pilot_server.go
+++ b/tests/util/pilot_server.go
@@ -97,7 +97,7 @@ func setup(additionalArgs ...func(*bootstrap.PilotArgs)) (*bootstrap.Server, Tea
 			FileDir: env.IstioSrc + "/tests/testdata/config",
 		}
 		p.MeshConfig = &meshConfig
-		p.MCPMaxMessageSize = 1024 * 1024 * 4
+		p.MCPOptions.MaxMessageSize = 1024 * 1024 * 4
 		p.KeepaliveOptions = keepalive.DefaultOption()
 		p.ForceStop = true
 


### PR DESCRIPTION
1. remove `basePort`

2. remove `SecureGrpcDNSAddr`

3. abstract MCPOptions