### PR TITLE
Fix alpha policy port matching selection

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1477,7 +1477,7 @@ func authenticationPolicyForWorkload(policiesByPort []*authnPolicyByPort, port *
 			matchedMeta = policiesByPort[i].configMeta
 		}
 
-		if port != nil && policyByPort.portSelector != nil &&  port.Match(policyByPort.portSelector) {
+		if port != nil && policyByPort.portSelector != nil && port.Match(policyByPort.portSelector) {
 			matchedPolicy = policiesByPort[i].policy
 			matchedMeta = policiesByPort[i].configMeta
 			break

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1477,7 +1477,7 @@ func authenticationPolicyForWorkload(policiesByPort []*authnPolicyByPort, port *
 			matchedMeta = policiesByPort[i].configMeta
 		}
 
-		if port != nil && port.Match(policyByPort.portSelector) {
+		if port != nil && policyByPort.portSelector != nil &&  port.Match(policyByPort.portSelector) {
 			matchedPolicy = policiesByPort[i].policy
 			matchedMeta = policiesByPort[i].configMeta
 			break

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -147,9 +147,25 @@ func TestAuthNPolicies(t *testing.T) {
 	authNPolicies := map[string]*authn.Policy{
 		constants.DefaultAuthenticationPolicyName: {},
 
+		"mtls-strict-svc": {
+			Targets: []*authn.TargetSelector{{
+				Name: "mtls-strict-svc-port",
+			}},
+			Peers: []*authn.PeerAuthenticationMethod{{
+				Params: &authn.PeerAuthenticationMethod_Mtls{},
+			},
+			}},
+
 		"mtls-strict-svc-port": {
 			Targets: []*authn.TargetSelector{{
 				Name: "mtls-strict-svc-port",
+				Ports: []*authn.PortSelector{
+					{
+						Port: &authn.PortSelector_Number{
+							Number: 80,
+						},
+					},
+				},
 			}},
 			Peers: []*authn.PeerAuthenticationMethod{{
 				Params: &authn.PeerAuthenticationMethod_Mtls{},
@@ -260,6 +276,14 @@ func TestAuthNPolicies(t *testing.T) {
 			port:                    Port{Port: 80},
 			expectedPolicy:          authNPolicies["mtls-strict-svc-port"],
 			expectedPolicyName:      "mtls-strict-svc-port",
+			expectedPolicyNamespace: testNamespace,
+		},
+		{
+			hostname:                "mtls-strict-svc-port.test-namespace.svc.cluster.local",
+			namespace:               testNamespace,
+			port:                    Port{Port: 90},
+			expectedPolicy:          authNPolicies["mtls-strict-svc"],
+			expectedPolicyName:      "mtls-strict-svc",
 			expectedPolicyNamespace: testNamespace,
 		},
 		{


### PR DESCRIPTION
When doing port matching for (alpha) authN policy selection, we didn't check if the policy have port selector or not. As a result, if there are 2 policies on the same service, one with port-selector, and one without, the policy that is picked could be arbitrary based on which one is examined first.

This bug was caught while debugging the flaky integration test  `TestReachability/alpha-mtls-automtls`. This new test is added in the recently (https://github.com/istio/istio/pull/21124), and is the only test that set up 2 alpha policies on the same service. Due to that bug, the policy for b:80 could be fluctuated between `disable` (if "b-mtls-off" is selected), and `strict` if the other is selected.

```
apiVersion: authentication.istio.io/v1alpha1
kind: Policy
metadata:
  name: "b-mtls-off"
  annotations:
    test-suite: "alpha-mtls-automtls"
spec:
  targets:
  - name: "b"
---
apiVersion: authentication.istio.io/v1alpha1
kind: Policy
metadata:
  name: "b-80-mtls-on"
  annotations:
    test-suite: "alpha-mtls-automtls"
spec:
  targets:
  - name: "b"
    ports:
    - name: http
  peers:
  - mtls: {}
```

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
