### PR TITLE
Fix peer authentiation selection bug due to drop in singleton restriction

### DIFF
--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -133,9 +133,6 @@ func (policy *AuthenticationPolicies) addPeerAuthentication(configs []Config) {
 	seenNamespaceOrMeshConfig := make(map[string]time.Time)
 
 	for _, config := range configs {
-		policy.peerAuthentications[config.Namespace] =
-			append(policy.peerAuthentications[config.Namespace], config)
-
 		// Mesh & namespace level policy are those that have empty selector.
 		spec := config.Spec.(*v1beta1.PeerAuthentication)
 		if spec.Selector == nil || len(spec.Selector.MatchLabels) == 0 {
@@ -163,6 +160,11 @@ func (policy *AuthenticationPolicies) addPeerAuthentication(configs []Config) {
 				foundNamespaceMTLS[config.Namespace] = mode
 			}
 		}
+
+		// Add the config to the map by namespace for future look up. This is done after namespace/mesh
+		// singleton check so there should be at most one namespace/mesh config is added to the map.
+		policy.peerAuthentications[config.Namespace] =
+			append(policy.peerAuthentications[config.Namespace], config)
 	}
 
 	// Process found namespace-level policy.

--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	securityBeta "istio.io/api/security/v1beta1"
@@ -35,6 +36,7 @@ const (
 var (
 	peerAuthenticationGvk    = collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind()
 	requestAuthenticationGvk = collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind()
+	baseTimestamp            = time.Date(2020, 2, 2, 2, 2, 2, 0, time.UTC)
 )
 
 func TestGetPoliciesForWorkload(t *testing.T) {
@@ -77,11 +79,12 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			wantPeerAuthn: []*Config{
 				{
 					ConfigMeta: ConfigMeta{
-						Type:      peerAuthenticationGvk.Kind,
-						Version:   peerAuthenticationGvk.Version,
-						Group:     peerAuthenticationGvk.Group,
-						Name:      "default",
-						Namespace: "foo",
+						Type:              peerAuthenticationGvk.Kind,
+						Version:           peerAuthenticationGvk.Version,
+						Group:             peerAuthenticationGvk.Group,
+						CreationTimestamp: baseTimestamp,
+						Name:              "default",
+						Namespace:         "foo",
 					},
 					Spec: &securityBeta.PeerAuthentication{
 						Mtls: &securityBeta.PeerAuthentication_MutualTLS{
@@ -91,11 +94,12 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 				},
 				{
 					ConfigMeta: ConfigMeta{
-						Type:      peerAuthenticationGvk.Kind,
-						Version:   peerAuthenticationGvk.Version,
-						Group:     peerAuthenticationGvk.Group,
-						Name:      "default",
-						Namespace: "istio-config",
+						Type:              peerAuthenticationGvk.Kind,
+						Version:           peerAuthenticationGvk.Version,
+						Group:             peerAuthenticationGvk.Group,
+						CreationTimestamp: baseTimestamp,
+						Name:              "default",
+						Namespace:         "istio-config",
 					},
 					Spec: &securityBeta.PeerAuthentication{
 						Mtls: &securityBeta.PeerAuthentication_MutualTLS{
@@ -135,11 +139,12 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			wantPeerAuthn: []*Config{
 				{
 					ConfigMeta: ConfigMeta{
-						Type:      peerAuthenticationGvk.Kind,
-						Version:   peerAuthenticationGvk.Version,
-						Group:     peerAuthenticationGvk.Group,
-						Name:      "default",
-						Namespace: "istio-config",
+						Type:              peerAuthenticationGvk.Kind,
+						Version:           peerAuthenticationGvk.Version,
+						Group:             peerAuthenticationGvk.Group,
+						CreationTimestamp: baseTimestamp,
+						Name:              "default",
+						Namespace:         "istio-config",
 					},
 					Spec: &securityBeta.PeerAuthentication{
 						Mtls: &securityBeta.PeerAuthentication_MutualTLS{
@@ -169,11 +174,12 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			wantPeerAuthn: []*Config{
 				{
 					ConfigMeta: ConfigMeta{
-						Type:      peerAuthenticationGvk.Kind,
-						Version:   peerAuthenticationGvk.Version,
-						Group:     peerAuthenticationGvk.Group,
-						Name:      "default",
-						Namespace: "istio-config",
+						Type:              peerAuthenticationGvk.Kind,
+						Version:           peerAuthenticationGvk.Version,
+						Group:             peerAuthenticationGvk.Group,
+						CreationTimestamp: baseTimestamp,
+						Name:              "default",
+						Namespace:         "istio-config",
 					},
 					Spec: &securityBeta.PeerAuthentication{
 						Mtls: &securityBeta.PeerAuthentication_MutualTLS{
@@ -246,11 +252,12 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			wantPeerAuthn: []*Config{
 				{
 					ConfigMeta: ConfigMeta{
-						Type:      peerAuthenticationGvk.Kind,
-						Version:   peerAuthenticationGvk.Version,
-						Group:     peerAuthenticationGvk.Group,
-						Name:      "default",
-						Namespace: "foo",
+						Type:              peerAuthenticationGvk.Kind,
+						Version:           peerAuthenticationGvk.Version,
+						Group:             peerAuthenticationGvk.Group,
+						CreationTimestamp: baseTimestamp,
+						Name:              "default",
+						Namespace:         "foo",
 					},
 					Spec: &securityBeta.PeerAuthentication{
 						Mtls: &securityBeta.PeerAuthentication_MutualTLS{
@@ -260,11 +267,12 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 				},
 				{
 					ConfigMeta: ConfigMeta{
-						Type:      peerAuthenticationGvk.Kind,
-						Version:   peerAuthenticationGvk.Version,
-						Group:     peerAuthenticationGvk.Group,
-						Name:      "peer-with-selector",
-						Namespace: "foo",
+						Type:              peerAuthenticationGvk.Kind,
+						Version:           peerAuthenticationGvk.Version,
+						Group:             peerAuthenticationGvk.Group,
+						CreationTimestamp: baseTimestamp,
+						Name:              "peer-with-selector",
+						Namespace:         "foo",
 					},
 					Spec: &securityBeta.PeerAuthentication{
 						Selector: &selectorpb.WorkloadSelector{
@@ -279,11 +287,12 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 				},
 				{
 					ConfigMeta: ConfigMeta{
-						Type:      peerAuthenticationGvk.Kind,
-						Version:   peerAuthenticationGvk.Version,
-						Group:     peerAuthenticationGvk.Group,
-						Name:      "default",
-						Namespace: "istio-config",
+						Type:              peerAuthenticationGvk.Kind,
+						Version:           peerAuthenticationGvk.Version,
+						Group:             peerAuthenticationGvk.Group,
+						CreationTimestamp: baseTimestamp,
+						Name:              "default",
+						Namespace:         "istio-config",
 					},
 					Spec: &securityBeta.PeerAuthentication{
 						Mtls: &securityBeta.PeerAuthentication_MutualTLS{
@@ -339,11 +348,12 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			wantPeerAuthn: []*Config{
 				{
 					ConfigMeta: ConfigMeta{
-						Type:      peerAuthenticationGvk.Kind,
-						Version:   peerAuthenticationGvk.Version,
-						Group:     peerAuthenticationGvk.Group,
-						Name:      "default",
-						Namespace: "istio-config",
+						Type:              peerAuthenticationGvk.Kind,
+						Version:           peerAuthenticationGvk.Version,
+						Group:             peerAuthenticationGvk.Group,
+						CreationTimestamp: baseTimestamp,
+						Name:              "default",
+						Namespace:         "istio-config",
 					},
 					Spec: &securityBeta.PeerAuthentication{
 						Mtls: &securityBeta.PeerAuthentication_MutualTLS{
@@ -399,11 +409,12 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			wantPeerAuthn: []*Config{
 				{
 					ConfigMeta: ConfigMeta{
-						Type:      peerAuthenticationGvk.Kind,
-						Version:   peerAuthenticationGvk.Version,
-						Group:     peerAuthenticationGvk.Group,
-						Name:      "default",
-						Namespace: "foo",
+						Type:              peerAuthenticationGvk.Kind,
+						Version:           peerAuthenticationGvk.Version,
+						Group:             peerAuthenticationGvk.Group,
+						CreationTimestamp: baseTimestamp,
+						Name:              "default",
+						Namespace:         "foo",
 					},
 					Spec: &securityBeta.PeerAuthentication{
 						Mtls: &securityBeta.PeerAuthentication_MutualTLS{
@@ -413,11 +424,12 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 				},
 				{
 					ConfigMeta: ConfigMeta{
-						Type:      peerAuthenticationGvk.Kind,
-						Version:   peerAuthenticationGvk.Version,
-						Group:     peerAuthenticationGvk.Group,
-						Name:      "default",
-						Namespace: "istio-config",
+						Type:              peerAuthenticationGvk.Kind,
+						Version:           peerAuthenticationGvk.Version,
+						Group:             peerAuthenticationGvk.Group,
+						CreationTimestamp: baseTimestamp,
+						Name:              "default",
+						Namespace:         "istio-config",
 					},
 					Spec: &securityBeta.PeerAuthentication{
 						Mtls: &securityBeta.PeerAuthentication_MutualTLS{
@@ -462,11 +474,12 @@ func TestGetPoliciesForWorkloadWithoutMeshPeerAuthn(t *testing.T) {
 			wantPeerAuthn: []*Config{
 				{
 					ConfigMeta: ConfigMeta{
-						Type:      peerAuthenticationGvk.Kind,
-						Version:   peerAuthenticationGvk.Version,
-						Group:     peerAuthenticationGvk.Group,
-						Name:      "default",
-						Namespace: "foo",
+						Type:              peerAuthenticationGvk.Kind,
+						Version:           peerAuthenticationGvk.Version,
+						Group:             peerAuthenticationGvk.Group,
+						CreationTimestamp: baseTimestamp,
+						Name:              "default",
+						Namespace:         "foo",
 					},
 					Spec: &securityBeta.PeerAuthentication{
 						Mtls: &securityBeta.PeerAuthentication_MutualTLS{
@@ -498,11 +511,12 @@ func TestGetPoliciesForWorkloadWithoutMeshPeerAuthn(t *testing.T) {
 			wantPeerAuthn: []*Config{
 				{
 					ConfigMeta: ConfigMeta{
-						Type:      peerAuthenticationGvk.Kind,
-						Version:   peerAuthenticationGvk.Version,
-						Group:     peerAuthenticationGvk.Group,
-						Name:      "default",
-						Namespace: "foo",
+						Type:              peerAuthenticationGvk.Kind,
+						Version:           peerAuthenticationGvk.Version,
+						Group:             peerAuthenticationGvk.Group,
+						CreationTimestamp: baseTimestamp,
+						Name:              "default",
+						Namespace:         "foo",
 					},
 					Spec: &securityBeta.PeerAuthentication{
 						Mtls: &securityBeta.PeerAuthentication_MutualTLS{
@@ -512,11 +526,12 @@ func TestGetPoliciesForWorkloadWithoutMeshPeerAuthn(t *testing.T) {
 				},
 				{
 					ConfigMeta: ConfigMeta{
-						Type:      peerAuthenticationGvk.Kind,
-						Version:   peerAuthenticationGvk.Version,
-						Group:     peerAuthenticationGvk.Group,
-						Name:      "peer-with-selector",
-						Namespace: "foo",
+						Type:              peerAuthenticationGvk.Kind,
+						Version:           peerAuthenticationGvk.Version,
+						Group:             peerAuthenticationGvk.Group,
+						CreationTimestamp: baseTimestamp,
+						Name:              "peer-with-selector",
+						Namespace:         "foo",
 					},
 					Spec: &securityBeta.PeerAuthentication{
 						Selector: &selectorpb.WorkloadSelector{
@@ -546,11 +561,12 @@ func TestGetPoliciesForWorkloadWithoutMeshPeerAuthn(t *testing.T) {
 			wantPeerAuthn: []*Config{
 				{
 					ConfigMeta: ConfigMeta{
-						Type:      peerAuthenticationGvk.Kind,
-						Version:   peerAuthenticationGvk.Version,
-						Group:     peerAuthenticationGvk.Group,
-						Name:      "default",
-						Namespace: "foo",
+						Type:              peerAuthenticationGvk.Kind,
+						Version:           peerAuthenticationGvk.Version,
+						Group:             peerAuthenticationGvk.Group,
+						CreationTimestamp: baseTimestamp,
+						Name:              "default",
+						Namespace:         "foo",
 					},
 					Spec: &securityBeta.PeerAuthentication{
 						Mtls: &securityBeta.PeerAuthentication_MutualTLS{
@@ -610,15 +626,16 @@ func createTestRequestAuthenticationResource(name string, namespace string, sele
 	}
 }
 
-func createTestPeerAuthenticationResource(name string, namespace string,
+func createTestPeerAuthenticationResource(name string, namespace string, timestamp time.Time,
 	selector *selectorpb.WorkloadSelector, mode securityBeta.PeerAuthentication_MutualTLS_Mode) *Config {
 	return &Config{
 		ConfigMeta: ConfigMeta{
-			Type:      collections.IstioSecurityV1Beta1Peerauthentications.Resource().Kind(),
-			Version:   collections.IstioSecurityV1Beta1Peerauthentications.Resource().Version(),
-			Group:     collections.IstioSecurityV1Beta1Peerauthentications.Resource().Group(),
-			Name:      name,
-			Namespace: namespace,
+			Type:              collections.IstioSecurityV1Beta1Peerauthentications.Resource().Kind(),
+			Version:           collections.IstioSecurityV1Beta1Peerauthentications.Resource().Version(),
+			Group:             collections.IstioSecurityV1Beta1Peerauthentications.Resource().Group(),
+			Name:              name,
+			Namespace:         namespace,
+			CreationTimestamp: timestamp,
 		},
 		Spec: &securityBeta.PeerAuthentication{
 			Selector: selector,
@@ -647,21 +664,24 @@ func createTestConfigs(withMeshPeerAuthn bool) []*Config {
 		createTestRequestAuthenticationResource("default", "foo", nil),
 		createTestRequestAuthenticationResource("default", "bar", nil),
 		createTestRequestAuthenticationResource("with-selector", "foo", selector),
-		createTestPeerAuthenticationResource("global-peer-with-selector", rootNamespace, &selectorpb.WorkloadSelector{
+		createTestPeerAuthenticationResource("global-peer-with-selector", rootNamespace, baseTimestamp, &selectorpb.WorkloadSelector{
 			MatchLabels: map[string]string{
 				"app":     "httpbin",
 				"version": "v2",
 			},
 		}, securityBeta.PeerAuthentication_MutualTLS_UNSET),
-		createTestPeerAuthenticationResource("default", "foo", nil, securityBeta.PeerAuthentication_MutualTLS_STRICT),
-		createTestPeerAuthenticationResource("peer-with-selector", "foo", &selectorpb.WorkloadSelector{
+		createTestPeerAuthenticationResource("default", "foo", baseTimestamp, nil, securityBeta.PeerAuthentication_MutualTLS_STRICT),
+		createTestPeerAuthenticationResource("ignored-newer-default", "foo", baseTimestamp.Add(time.Second), nil, securityBeta.PeerAuthentication_MutualTLS_STRICT),
+		createTestPeerAuthenticationResource("peer-with-selector", "foo", baseTimestamp, &selectorpb.WorkloadSelector{
 			MatchLabels: map[string]string{
 				"version": "v1",
 			},
 		}, securityBeta.PeerAuthentication_MutualTLS_DISABLE))
 
 	if withMeshPeerAuthn {
-		configs = append(configs, createTestPeerAuthenticationResource("default", rootNamespace, nil, securityBeta.PeerAuthentication_MutualTLS_UNSET))
+		configs = append(configs, createTestPeerAuthenticationResource("ignored-newer", rootNamespace, baseTimestamp.Add(time.Second*2), nil, securityBeta.PeerAuthentication_MutualTLS_UNSET))
+		configs = append(configs, createTestPeerAuthenticationResource("default", rootNamespace, baseTimestamp, nil, securityBeta.PeerAuthentication_MutualTLS_UNSET))
+		configs = append(configs, createTestPeerAuthenticationResource("ignored-another-newer", rootNamespace, baseTimestamp.Add(time.Second), nil, securityBeta.PeerAuthentication_MutualTLS_UNSET))
 	}
 
 	return configs

--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -679,9 +679,13 @@ func createTestConfigs(withMeshPeerAuthn bool) []*Config {
 		}, securityBeta.PeerAuthentication_MutualTLS_DISABLE))
 
 	if withMeshPeerAuthn {
-		configs = append(configs, createTestPeerAuthenticationResource("ignored-newer", rootNamespace, baseTimestamp.Add(time.Second*2), nil, securityBeta.PeerAuthentication_MutualTLS_UNSET))
-		configs = append(configs, createTestPeerAuthenticationResource("default", rootNamespace, baseTimestamp, nil, securityBeta.PeerAuthentication_MutualTLS_UNSET))
-		configs = append(configs, createTestPeerAuthenticationResource("ignored-another-newer", rootNamespace, baseTimestamp.Add(time.Second), nil, securityBeta.PeerAuthentication_MutualTLS_UNSET))
+		configs = append(configs,
+			createTestPeerAuthenticationResource("ignored-newer", rootNamespace, baseTimestamp.Add(time.Second*2),
+				nil, securityBeta.PeerAuthentication_MutualTLS_UNSET),
+			createTestPeerAuthenticationResource("default", rootNamespace, baseTimestamp,
+				nil, securityBeta.PeerAuthentication_MutualTLS_UNSET),
+			createTestPeerAuthenticationResource("ignored-another-newer", rootNamespace, baseTimestamp.Add(time.Second),
+				nil, securityBeta.PeerAuthentication_MutualTLS_UNSET))
 	}
 
 	return configs

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -754,9 +754,9 @@ func TestBestEffortInferServiceMTLSMode(t *testing.T) {
 	}
 
 	// Add beta policies
-	configStore.Create(*createTestPeerAuthenticationResource("default", betaNamespace, nil, securityBeta.PeerAuthentication_MutualTLS_STRICT))
+	configStore.Create(*createTestPeerAuthenticationResource("default", betaNamespace, time.Now(), nil, securityBeta.PeerAuthentication_MutualTLS_STRICT))
 	// workload level beta policy.
-	configStore.Create(*createTestPeerAuthenticationResource("workload-beta-policy", alphaNamespace, &selectorpb.WorkloadSelector{
+	configStore.Create(*createTestPeerAuthenticationResource("workload-beta-policy", alphaNamespace, time.Now(), &selectorpb.WorkloadSelector{
 		MatchLabels: map[string]string{
 			"app":     "httpbin",
 			"version": "v1",

--- a/pilot/pkg/security/authn/v1beta1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
@@ -144,7 +143,7 @@ func (a *v1beta1PolicyApplier) InboundFilterChain(endpointPort uint32, sdsUdsPat
 	if a.consolidatedPeerPolicy != nil {
 		effectiveMTLSMode = a.getMutualTLSModeForPort(endpointPort)
 	}
-	authnLog.Debugf("InboundFilterChain: build inbound filter change for %v : %d in %s mode", node.ID, endpointPort, effectiveMTLSMode)
+	authnLog.Debugf("InboundFilterChain: build inbound filter change for %v:%d in %s mode", node.ID, endpointPort, effectiveMTLSMode)
 	return authn_utils.BuildInboundFilterChain(effectiveMTLSMode, sdsUdsPath, node)
 }
 
@@ -353,26 +352,33 @@ func getMutualTLSMode(mtls *v1beta1.PeerAuthentication_MutualTLS) model.MutualTL
 // replaced with config from workload-level, UNSET in workload-level config will be replaced with
 // one in namespace-level and so on.
 func composePeerAuthentication(rootNamespace string, configs []*model.Config) *v1beta1.PeerAuthentication {
-	var meshPolicy, namespacePolicy, workloadPolicy *v1beta1.PeerAuthentication
-	// Creation time associate with the selected workloadPolicy above. Initially set to max time.
-	workloadPolicyCreationTime := time.Unix(1<<63-1, 0)
+	var meshCfg, namespaceCfg, workloadCfg *model.Config
 
 	for _, cfg := range configs {
 		spec := cfg.Spec.(*v1beta1.PeerAuthentication)
-		if cfg.Namespace == rootNamespace && spec.Selector == nil {
-			meshPolicy = spec
-		} else if spec.Selector == nil {
-			namespacePolicy = spec
+		if spec.Selector == nil || len(spec.Selector.MatchLabels) == 0 {
+			// Namespace-level or mesh-level policy
+			if cfg.Namespace == rootNamespace {
+				if meshCfg == nil || cfg.CreationTimestamp.Before(meshCfg.CreationTimestamp) {
+					authnLog.Debugf("Switch selected mesh policy to %s.%s (%v)", cfg.Name, cfg.Namespace, cfg.CreationTimestamp)
+					meshCfg = cfg
+				}
+			} else {
+				if namespaceCfg == nil || cfg.CreationTimestamp.Before(namespaceCfg.CreationTimestamp) {
+					authnLog.Debugf("Switch selected namespace policy to %s.%s (%v)", cfg.Name, cfg.Namespace, cfg.CreationTimestamp)
+					namespaceCfg = cfg
+				}
+			}
 		} else if cfg.Namespace != rootNamespace {
-			// Assign to the (selected) workloadPolicy, if it is not set or have a newer timestamp.
-			if workloadPolicy == nil || cfg.CreationTimestamp.Before(workloadPolicyCreationTime) {
-				workloadPolicy = spec
-				workloadPolicyCreationTime = cfg.CreationTimestamp
+			// Workload level policy, aka the one with selector and not in root namespace.
+			if workloadCfg == nil || cfg.CreationTimestamp.Before(workloadCfg.CreationTimestamp) {
+				authnLog.Debugf("Switch selected workload policy to %s.%s (%v)", cfg.Name, cfg.Namespace, cfg.CreationTimestamp)
+				workloadCfg = cfg
 			}
 		}
 	}
 
-	if meshPolicy == nil && namespacePolicy == nil && workloadPolicy == nil {
+	if meshCfg == nil && namespaceCfg == nil && workloadCfg == nil {
 		// Return nil so that caller can fallback to apply alpha policy. Once we deprecate alpha API,
 		// this special case can be removed.
 		return nil
@@ -387,15 +393,20 @@ func composePeerAuthentication(rootNamespace string, configs []*model.Config) *v
 
 	// Process in mesh, namespace, workload order to resolve inheritance (UNSET)
 
-	if meshPolicy != nil && !isMtlsModeUnset(meshPolicy.Mtls) {
+	if meshCfg != nil && !isMtlsModeUnset(meshCfg.Spec.(*v1beta1.PeerAuthentication).Mtls) {
 		// If mesh policy is defined, update parentPolicy to mesh policy.
-		outputPolicy.Mtls = meshPolicy.Mtls
+		outputPolicy.Mtls = meshCfg.Spec.(*v1beta1.PeerAuthentication).Mtls
 	}
 
-	if namespacePolicy != nil && !isMtlsModeUnset(namespacePolicy.Mtls) {
+	if namespaceCfg != nil && !isMtlsModeUnset(namespaceCfg.Spec.(*v1beta1.PeerAuthentication).Mtls) {
 		// If namespace policy is defined, update output policy to namespace policy. This means namespace
 		// policy overwrite mesh policy.
-		outputPolicy.Mtls = namespacePolicy.Mtls
+		outputPolicy.Mtls = namespaceCfg.Spec.(*v1beta1.PeerAuthentication).Mtls
+	}
+
+	var workloadPolicy *v1beta1.PeerAuthentication
+	if workloadCfg != nil {
+		workloadPolicy = workloadCfg.Spec.(*v1beta1.PeerAuthentication)
 	}
 
 	if workloadPolicy != nil && !isMtlsModeUnset(workloadPolicy.Mtls) {

--- a/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
@@ -1606,6 +1606,98 @@ func TestComposePeerAuthentication(t *testing.T) {
 			},
 		},
 		{
+			name: "multiple mesh policy",
+			configs: []*model.Config{
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:              "now",
+						Namespace:         "root-namespace",
+						CreationTimestamp: now,
+					},
+					Spec: &v1beta1.PeerAuthentication{
+						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+							Mode: v1beta1.PeerAuthentication_MutualTLS_DISABLE,
+						},
+					},
+				},
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:              "second ago",
+						Namespace:         "root-namespace",
+						CreationTimestamp: now.Add(time.Second * -1),
+					},
+					Spec: &v1beta1.PeerAuthentication{
+						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+							Mode: v1beta1.PeerAuthentication_MutualTLS_PERMISSIVE,
+						},
+					},
+				},
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:              "second later",
+						Namespace:         "root-namespace",
+						CreationTimestamp: now.Add(time.Second * -1),
+					},
+					Spec: &v1beta1.PeerAuthentication{
+						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+							Mode: v1beta1.PeerAuthentication_MutualTLS_STRICT,
+						},
+					},
+				},
+			},
+			want: &v1beta1.PeerAuthentication{
+				Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+					Mode: v1beta1.PeerAuthentication_MutualTLS_PERMISSIVE,
+				},
+			},
+		},
+		{
+			name: "multiple namespace policy",
+			configs: []*model.Config{
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:              "now",
+						Namespace:         "my-ns",
+						CreationTimestamp: now,
+					},
+					Spec: &v1beta1.PeerAuthentication{
+						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+							Mode: v1beta1.PeerAuthentication_MutualTLS_DISABLE,
+						},
+					},
+				},
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:              "second ago",
+						Namespace:         "my-ns",
+						CreationTimestamp: now.Add(time.Second * -1),
+					},
+					Spec: &v1beta1.PeerAuthentication{
+						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+							Mode: v1beta1.PeerAuthentication_MutualTLS_PERMISSIVE,
+						},
+					},
+				},
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:              "second later",
+						Namespace:         "my-ns",
+						CreationTimestamp: now.Add(time.Second * -1),
+					},
+					Spec: &v1beta1.PeerAuthentication{
+						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+							Mode: v1beta1.PeerAuthentication_MutualTLS_STRICT,
+						},
+					},
+				},
+			},
+			want: &v1beta1.PeerAuthentication{
+				Mtls: &v1beta1.PeerAuthentication_MutualTLS{
+					Mode: v1beta1.PeerAuthentication_MutualTLS_PERMISSIVE,
+				},
+			},
+		},
+		{
 			name: "multiple workload policy",
 			configs: []*model.Config{
 				{


### PR DESCRIPTION
As we drop the restriction for the namespace/mesh policy name in https://github.com/istio/istio/pull/21136, the guarantee that there is at most CR that have no selector per namespace is no longer hold. As a result, we need to check all policy and keep the oldest to be consistent.