### PR TITLE
Allow ledgers to be used in complex aggregate config stores

### DIFF
--- a/istioctl/cmd/istioctl_test.go
+++ b/istioctl/cmd/istioctl_test.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"testing"
 
+	"istio.io/pkg/ledger"
+
 	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/test/util"
@@ -32,6 +34,14 @@ import (
 // a stable List() which helps with testing `istioctl get` output.
 type sortedConfigStore struct {
 	store model.ConfigStore
+}
+
+func (cs sortedConfigStore) GetLedger() ledger.Ledger {
+	return cs.store.GetLedger()
+}
+
+func (cs sortedConfigStore) SetLedger(l ledger.Ledger) error {
+	return cs.store.SetLedger(l)
 }
 
 type testCase struct {

--- a/pilot/pkg/config/aggregate/config.go
+++ b/pilot/pkg/config/aggregate/config.go
@@ -19,11 +19,14 @@ import (
 	"errors"
 	"fmt"
 
+	"istio.io/pkg/ledger"
+
 	"github.com/hashicorp/go-multierror"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/resource"
+	"istio.io/pkg/log"
 )
 
 var errorUnsupported = errors.New("unsupported operation: the config aggregator is read-only")
@@ -53,21 +56,20 @@ func Make(stores []model.ConfigStore) (model.ConfigStore, error) {
 		stores:  storeTypes,
 	}
 
-	// in most cases (all cases supported by helm), pilot has only one configStore, but it is always wrapped in this
-	// aggregate.  This allows us to pass through data from a single config ledger, while gracefully failing in the
-	// unlikely scenario that multiple configSources are supplied.
-	// in the case of multiple configSources, we could simply require that all sources share a single ledger,
-	// but the ledger has to be provided at construction time since it is an implementation detail.  Perhaps we should
-	// consider allowing the ledger to be set on the fly to accommodate this scenario?
-	if len(stores) == 1 {
-		result.getVersion = stores[0].Version
-		result.getResourceAtVersion = stores[0].GetResourceAtVersion
-	} else {
-		result.getVersion = func() string { return "" }
-		result.getResourceAtVersion = func(one, two string) (string, error) {
-			return "", errors.New("config distribution status not supported on multiple configSources")
+	var l ledger.Ledger
+	for _, store := range stores {
+		if l == nil {
+			l = store.GetLedger()
+			result.getVersion = store.Version
+			result.getResourceAtVersion = store.GetResourceAtVersion
+		} else {
+			err := store.SetLedger(l)
+			if err != nil {
+				log.Warnf("Config Store %v cannot track distribution in aggregate", store)
+			}
 		}
 	}
+
 	return result, nil
 }
 
@@ -98,6 +100,17 @@ type store struct {
 	getVersion func() string
 
 	getResourceAtVersion func(version, key string) (resourceVersion string, err error)
+
+	ledger ledger.Ledger
+}
+
+func (cr *store) GetLedger() ledger.Ledger {
+	return cr.ledger
+}
+
+func (cr *store) SetLedger(l ledger.Ledger) error {
+	cr.ledger = l
+	return nil
 }
 
 func (cr *store) GetResourceAtVersion(version string, key string) (resourceVersion string, err error) {

--- a/pilot/pkg/config/aggregate/fakes/config_store_cache.gen.go
+++ b/pilot/pkg/config/aggregate/fakes/config_store_cache.gen.go
@@ -7,6 +7,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/resource"
+	"istio.io/pkg/ledger"
 )
 
 type ConfigStoreCache struct {
@@ -48,6 +49,16 @@ type ConfigStoreCache struct {
 	}
 	getReturnsOnCall map[int]struct {
 		result1 *model.Config
+	}
+	GetLedgerStub        func() ledger.Ledger
+	getLedgerMutex       sync.RWMutex
+	getLedgerArgsForCall []struct {
+	}
+	getLedgerReturns struct {
+		result1 ledger.Ledger
+	}
+	getLedgerReturnsOnCall map[int]struct {
+		result1 ledger.Ledger
 	}
 	GetResourceAtVersionStub        func(string, string) (string, error)
 	getResourceAtVersionMutex       sync.RWMutex
@@ -107,6 +118,17 @@ type ConfigStoreCache struct {
 	}
 	schemasReturnsOnCall map[int]struct {
 		result1 collection.Schemas
+	}
+	SetLedgerStub        func(ledger.Ledger) error
+	setLedgerMutex       sync.RWMutex
+	setLedgerArgsForCall []struct {
+		arg1 ledger.Ledger
+	}
+	setLedgerReturns struct {
+		result1 error
+	}
+	setLedgerReturnsOnCall map[int]struct {
+		result1 error
 	}
 	UpdateStub        func(model.Config) (string, error)
 	updateMutex       sync.RWMutex
@@ -319,6 +341,58 @@ func (fake *ConfigStoreCache) GetReturnsOnCall(i int, result1 *model.Config) {
 	}
 	fake.getReturnsOnCall[i] = struct {
 		result1 *model.Config
+	}{result1}
+}
+
+func (fake *ConfigStoreCache) GetLedger() ledger.Ledger {
+	fake.getLedgerMutex.Lock()
+	ret, specificReturn := fake.getLedgerReturnsOnCall[len(fake.getLedgerArgsForCall)]
+	fake.getLedgerArgsForCall = append(fake.getLedgerArgsForCall, struct {
+	}{})
+	fake.recordInvocation("GetLedger", []interface{}{})
+	fake.getLedgerMutex.Unlock()
+	if fake.GetLedgerStub != nil {
+		return fake.GetLedgerStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.getLedgerReturns
+	return fakeReturns.result1
+}
+
+func (fake *ConfigStoreCache) GetLedgerCallCount() int {
+	fake.getLedgerMutex.RLock()
+	defer fake.getLedgerMutex.RUnlock()
+	return len(fake.getLedgerArgsForCall)
+}
+
+func (fake *ConfigStoreCache) GetLedgerCalls(stub func() ledger.Ledger) {
+	fake.getLedgerMutex.Lock()
+	defer fake.getLedgerMutex.Unlock()
+	fake.GetLedgerStub = stub
+}
+
+func (fake *ConfigStoreCache) GetLedgerReturns(result1 ledger.Ledger) {
+	fake.getLedgerMutex.Lock()
+	defer fake.getLedgerMutex.Unlock()
+	fake.GetLedgerStub = nil
+	fake.getLedgerReturns = struct {
+		result1 ledger.Ledger
+	}{result1}
+}
+
+func (fake *ConfigStoreCache) GetLedgerReturnsOnCall(i int, result1 ledger.Ledger) {
+	fake.getLedgerMutex.Lock()
+	defer fake.getLedgerMutex.Unlock()
+	fake.GetLedgerStub = nil
+	if fake.getLedgerReturnsOnCall == nil {
+		fake.getLedgerReturnsOnCall = make(map[int]struct {
+			result1 ledger.Ledger
+		})
+	}
+	fake.getLedgerReturnsOnCall[i] = struct {
+		result1 ledger.Ledger
 	}{result1}
 }
 
@@ -617,6 +691,66 @@ func (fake *ConfigStoreCache) SchemasReturnsOnCall(i int, result1 collection.Sch
 	}{result1}
 }
 
+func (fake *ConfigStoreCache) SetLedger(arg1 ledger.Ledger) error {
+	fake.setLedgerMutex.Lock()
+	ret, specificReturn := fake.setLedgerReturnsOnCall[len(fake.setLedgerArgsForCall)]
+	fake.setLedgerArgsForCall = append(fake.setLedgerArgsForCall, struct {
+		arg1 ledger.Ledger
+	}{arg1})
+	fake.recordInvocation("SetLedger", []interface{}{arg1})
+	fake.setLedgerMutex.Unlock()
+	if fake.SetLedgerStub != nil {
+		return fake.SetLedgerStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.setLedgerReturns
+	return fakeReturns.result1
+}
+
+func (fake *ConfigStoreCache) SetLedgerCallCount() int {
+	fake.setLedgerMutex.RLock()
+	defer fake.setLedgerMutex.RUnlock()
+	return len(fake.setLedgerArgsForCall)
+}
+
+func (fake *ConfigStoreCache) SetLedgerCalls(stub func(ledger.Ledger) error) {
+	fake.setLedgerMutex.Lock()
+	defer fake.setLedgerMutex.Unlock()
+	fake.SetLedgerStub = stub
+}
+
+func (fake *ConfigStoreCache) SetLedgerArgsForCall(i int) ledger.Ledger {
+	fake.setLedgerMutex.RLock()
+	defer fake.setLedgerMutex.RUnlock()
+	argsForCall := fake.setLedgerArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *ConfigStoreCache) SetLedgerReturns(result1 error) {
+	fake.setLedgerMutex.Lock()
+	defer fake.setLedgerMutex.Unlock()
+	fake.SetLedgerStub = nil
+	fake.setLedgerReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *ConfigStoreCache) SetLedgerReturnsOnCall(i int, result1 error) {
+	fake.setLedgerMutex.Lock()
+	defer fake.setLedgerMutex.Unlock()
+	fake.SetLedgerStub = nil
+	if fake.setLedgerReturnsOnCall == nil {
+		fake.setLedgerReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.setLedgerReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *ConfigStoreCache) Update(arg1 model.Config) (string, error) {
 	fake.updateMutex.Lock()
 	ret, specificReturn := fake.updateReturnsOnCall[len(fake.updateArgsForCall)]
@@ -741,6 +875,8 @@ func (fake *ConfigStoreCache) Invocations() map[string][][]interface{} {
 	defer fake.deleteMutex.RUnlock()
 	fake.getMutex.RLock()
 	defer fake.getMutex.RUnlock()
+	fake.getLedgerMutex.RLock()
+	defer fake.getLedgerMutex.RUnlock()
 	fake.getResourceAtVersionMutex.RLock()
 	defer fake.getResourceAtVersionMutex.RUnlock()
 	fake.hasSyncedMutex.RLock()
@@ -753,6 +889,8 @@ func (fake *ConfigStoreCache) Invocations() map[string][][]interface{} {
 	defer fake.runMutex.RUnlock()
 	fake.schemasMutex.RLock()
 	defer fake.schemasMutex.RUnlock()
+	fake.setLedgerMutex.RLock()
+	defer fake.setLedgerMutex.RUnlock()
 	fake.updateMutex.RLock()
 	defer fake.updateMutex.RUnlock()
 	fake.versionMutex.RLock()

--- a/pilot/pkg/config/kube/crd/controller/client.go
+++ b/pilot/pkg/config/kube/crd/controller/client.go
@@ -351,6 +351,15 @@ func (cl *Client) GetResourceAtVersion(version string, key string) (resourceVers
 	return cl.configLedger.GetPreviousValue(version, key)
 }
 
+func (cl *Client) GetLedger() ledger.Ledger {
+	return cl.configLedger
+}
+
+func (cl *Client) SetLedger(l ledger.Ledger) error {
+	cl.configLedger = l
+	return nil
+}
+
 // List implements store interface
 func (cl *Client) List(kind resource.GroupVersionKind, namespace string) ([]model.Config, error) {
 	t, ok := crd.SupportedTypes[kind]

--- a/pilot/pkg/config/kube/crd/controller/controller.go
+++ b/pilot/pkg/config/kube/crd/controller/controller.go
@@ -20,6 +20,8 @@ import (
 	"reflect"
 	"time"
 
+	"istio.io/pkg/ledger"
+
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -263,6 +265,14 @@ func (c *controller) Version() string {
 
 func (c *controller) GetResourceAtVersion(version string, key string) (resourceVersion string, err error) {
 	return c.client.GetResourceAtVersion(version, key)
+}
+
+func (c *controller) GetLedger() ledger.Ledger {
+	return c.client.GetLedger()
+}
+
+func (c *controller) SetLedger(l ledger.Ledger) error {
+	return c.client.SetLedger(l)
 }
 
 func (c *controller) HasSynced() bool {

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -21,6 +21,8 @@ import (
 	"reflect"
 	"time"
 
+	"istio.io/pkg/ledger"
+
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/client-go/informers/extensions/v1beta1"
 	"k8s.io/client-go/kubernetes"
@@ -185,6 +187,15 @@ func (c *controller) Version() string {
 
 func (c *controller) GetResourceAtVersion(string, string) (resourceVersion string, err error) {
 	panic("implement me")
+}
+
+func (c *controller) GetLedger() ledger.Ledger {
+	log.Warnf("GetLedger: %s", errors.New("this operation is not supported by kube ingress controller"))
+	return nil
+}
+
+func (c *controller) SetLedger(ledger.Ledger) error {
+	return errors.New("this SetLedger operation is not supported by kube ingress controller")
 }
 
 func (c *controller) HasSynced() bool {

--- a/pilot/pkg/config/memory/config.go
+++ b/pilot/pkg/config/memory/config.go
@@ -62,6 +62,15 @@ func (cr *store) GetResourceAtVersion(version string, key string) (resourceVersi
 	return cr.ledger.GetPreviousValue(version, key)
 }
 
+func (cr *store) GetLedger() ledger.Ledger {
+	return cr.ledger
+}
+
+func (cr *store) SetLedger(l ledger.Ledger) error {
+	cr.ledger = l
+	return nil
+}
+
 func (cr *store) Schemas() collection.Schemas {
 	return cr.schemas
 }

--- a/pilot/pkg/config/memory/controller.go
+++ b/pilot/pkg/config/memory/controller.go
@@ -17,6 +17,8 @@ package memory
 import (
 	"errors"
 
+	"istio.io/pkg/ledger"
+
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/resource"
@@ -53,6 +55,14 @@ func (c *controller) Version() string {
 
 func (c *controller) GetResourceAtVersion(version string, key string) (resourceVersion string, err error) {
 	return c.configStore.GetResourceAtVersion(version, key)
+}
+
+func (c *controller) GetLedger() ledger.Ledger {
+	return c.configStore.GetLedger()
+}
+
+func (c *controller) SetLedger(l ledger.Ledger) error {
+	return c.configStore.SetLedger(l)
 }
 
 func (c *controller) Run(stop <-chan struct{}) {

--- a/pilot/pkg/model/authorization_test.go
+++ b/pilot/pkg/model/authorization_test.go
@@ -19,6 +19,8 @@ import (
 	"reflect"
 	"testing"
 
+	"istio.io/pkg/ledger"
+
 	"github.com/gogo/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -867,6 +869,14 @@ type authzFakeStore struct {
 		ns  string
 		cfg Config
 	}
+}
+
+func (fs *authzFakeStore) GetLedger() ledger.Ledger {
+	panic("implement me")
+}
+
+func (fs *authzFakeStore) SetLedger(ledger.Ledger) error {
+	panic("implement me")
 }
 
 func (fs *authzFakeStore) add(config Config) {

--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"time"
 
+	"istio.io/pkg/ledger"
+
 	udpa "github.com/cncf/udpa/go/udpa/type/v1"
 	"github.com/mitchellh/copystructure"
 
@@ -172,6 +174,10 @@ type ConfigStore interface {
 	Version() string
 
 	GetResourceAtVersion(version string, key string) (resourceVersion string, err error)
+
+	GetLedger() ledger.Ledger
+
+	SetLedger(ledger.Ledger) error
 }
 
 // Key function for the configuration objects

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"istio.io/pkg/ledger"
+
 	authn "istio.io/api/authentication/v1alpha1"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
@@ -910,4 +912,12 @@ func (*fakeStore) Version() string {
 }
 func (*fakeStore) GetResourceAtVersion(version string, key string) (resourceVersion string, err error) {
 	return "not implemented", nil
+}
+
+func (s *fakeStore) GetLedger() ledger.Ledger {
+	panic("implement me")
+}
+
+func (s *fakeStore) SetLedger(ledger.Ledger) error {
+	panic("implement me")
 }

--- a/pilot/pkg/networking/core/v1alpha3/fakes/fake_istio_config_store.gen.go
+++ b/pilot/pkg/networking/core/v1alpha3/fakes/fake_istio_config_store.gen.go
@@ -8,6 +8,7 @@ import (
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/resource"
+	"istio.io/pkg/ledger"
 )
 
 type IstioConfigStore struct {
@@ -92,6 +93,16 @@ type IstioConfigStore struct {
 	}
 	getReturnsOnCall map[int]struct {
 		result1 *model.Config
+	}
+	GetLedgerStub        func() ledger.Ledger
+	getLedgerMutex       sync.RWMutex
+	getLedgerArgsForCall []struct {
+	}
+	getLedgerReturns struct {
+		result1 ledger.Ledger
+	}
+	getLedgerReturnsOnCall map[int]struct {
+		result1 ledger.Ledger
 	}
 	GetResourceAtVersionStub        func(string, string) (string, error)
 	getResourceAtVersionMutex       sync.RWMutex
@@ -183,6 +194,17 @@ type IstioConfigStore struct {
 	}
 	serviceRolesReturnsOnCall map[int]struct {
 		result1 []model.Config
+	}
+	SetLedgerStub        func(ledger.Ledger) error
+	setLedgerMutex       sync.RWMutex
+	setLedgerArgsForCall []struct {
+		arg1 ledger.Ledger
+	}
+	setLedgerReturns struct {
+		result1 error
+	}
+	setLedgerReturnsOnCall map[int]struct {
+		result1 error
 	}
 	UpdateStub        func(model.Config) (string, error)
 	updateMutex       sync.RWMutex
@@ -627,6 +649,58 @@ func (fake *IstioConfigStore) GetReturnsOnCall(i int, result1 *model.Config) {
 	}
 	fake.getReturnsOnCall[i] = struct {
 		result1 *model.Config
+	}{result1}
+}
+
+func (fake *IstioConfigStore) GetLedger() ledger.Ledger {
+	fake.getLedgerMutex.Lock()
+	ret, specificReturn := fake.getLedgerReturnsOnCall[len(fake.getLedgerArgsForCall)]
+	fake.getLedgerArgsForCall = append(fake.getLedgerArgsForCall, struct {
+	}{})
+	fake.recordInvocation("GetLedger", []interface{}{})
+	fake.getLedgerMutex.Unlock()
+	if fake.GetLedgerStub != nil {
+		return fake.GetLedgerStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.getLedgerReturns
+	return fakeReturns.result1
+}
+
+func (fake *IstioConfigStore) GetLedgerCallCount() int {
+	fake.getLedgerMutex.RLock()
+	defer fake.getLedgerMutex.RUnlock()
+	return len(fake.getLedgerArgsForCall)
+}
+
+func (fake *IstioConfigStore) GetLedgerCalls(stub func() ledger.Ledger) {
+	fake.getLedgerMutex.Lock()
+	defer fake.getLedgerMutex.Unlock()
+	fake.GetLedgerStub = stub
+}
+
+func (fake *IstioConfigStore) GetLedgerReturns(result1 ledger.Ledger) {
+	fake.getLedgerMutex.Lock()
+	defer fake.getLedgerMutex.Unlock()
+	fake.GetLedgerStub = nil
+	fake.getLedgerReturns = struct {
+		result1 ledger.Ledger
+	}{result1}
+}
+
+func (fake *IstioConfigStore) GetLedgerReturnsOnCall(i int, result1 ledger.Ledger) {
+	fake.getLedgerMutex.Lock()
+	defer fake.getLedgerMutex.Unlock()
+	fake.GetLedgerStub = nil
+	if fake.getLedgerReturnsOnCall == nil {
+		fake.getLedgerReturnsOnCall = make(map[int]struct {
+			result1 ledger.Ledger
+		})
+	}
+	fake.getLedgerReturnsOnCall[i] = struct {
+		result1 ledger.Ledger
 	}{result1}
 }
 
@@ -1094,6 +1168,66 @@ func (fake *IstioConfigStore) ServiceRolesReturnsOnCall(i int, result1 []model.C
 	}{result1}
 }
 
+func (fake *IstioConfigStore) SetLedger(arg1 ledger.Ledger) error {
+	fake.setLedgerMutex.Lock()
+	ret, specificReturn := fake.setLedgerReturnsOnCall[len(fake.setLedgerArgsForCall)]
+	fake.setLedgerArgsForCall = append(fake.setLedgerArgsForCall, struct {
+		arg1 ledger.Ledger
+	}{arg1})
+	fake.recordInvocation("SetLedger", []interface{}{arg1})
+	fake.setLedgerMutex.Unlock()
+	if fake.SetLedgerStub != nil {
+		return fake.SetLedgerStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.setLedgerReturns
+	return fakeReturns.result1
+}
+
+func (fake *IstioConfigStore) SetLedgerCallCount() int {
+	fake.setLedgerMutex.RLock()
+	defer fake.setLedgerMutex.RUnlock()
+	return len(fake.setLedgerArgsForCall)
+}
+
+func (fake *IstioConfigStore) SetLedgerCalls(stub func(ledger.Ledger) error) {
+	fake.setLedgerMutex.Lock()
+	defer fake.setLedgerMutex.Unlock()
+	fake.SetLedgerStub = stub
+}
+
+func (fake *IstioConfigStore) SetLedgerArgsForCall(i int) ledger.Ledger {
+	fake.setLedgerMutex.RLock()
+	defer fake.setLedgerMutex.RUnlock()
+	argsForCall := fake.setLedgerArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *IstioConfigStore) SetLedgerReturns(result1 error) {
+	fake.setLedgerMutex.Lock()
+	defer fake.setLedgerMutex.Unlock()
+	fake.SetLedgerStub = nil
+	fake.setLedgerReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *IstioConfigStore) SetLedgerReturnsOnCall(i int, result1 error) {
+	fake.setLedgerMutex.Lock()
+	defer fake.setLedgerMutex.Unlock()
+	fake.SetLedgerStub = nil
+	if fake.setLedgerReturnsOnCall == nil {
+		fake.setLedgerReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.setLedgerReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *IstioConfigStore) Update(arg1 model.Config) (string, error) {
 	fake.updateMutex.Lock()
 	ret, specificReturn := fake.updateReturnsOnCall[len(fake.updateArgsForCall)]
@@ -1226,6 +1360,8 @@ func (fake *IstioConfigStore) Invocations() map[string][][]interface{} {
 	defer fake.gatewaysMutex.RUnlock()
 	fake.getMutex.RLock()
 	defer fake.getMutex.RUnlock()
+	fake.getLedgerMutex.RLock()
+	defer fake.getLedgerMutex.RUnlock()
 	fake.getResourceAtVersionMutex.RLock()
 	defer fake.getResourceAtVersionMutex.RUnlock()
 	fake.listMutex.RLock()
@@ -1242,6 +1378,8 @@ func (fake *IstioConfigStore) Invocations() map[string][][]interface{} {
 	defer fake.serviceRoleBindingsMutex.RUnlock()
 	fake.serviceRolesMutex.RLock()
 	defer fake.serviceRolesMutex.RUnlock()
+	fake.setLedgerMutex.RLock()
+	defer fake.setLedgerMutex.RUnlock()
 	fake.updateMutex.RLock()
 	defer fake.updateMutex.RUnlock()
 	fake.versionMutex.RLock()

--- a/pilot/pkg/serviceregistry/mcp/controller.go
+++ b/pilot/pkg/serviceregistry/mcp/controller.go
@@ -241,6 +241,15 @@ func (c *controller) GetResourceAtVersion(version string, key string) (resourceV
 	return c.ledger.GetPreviousValue(version, key)
 }
 
+func (c *controller) GetLedger() ledger.Ledger {
+	return c.ledger
+}
+
+func (c *controller) SetLedger(l ledger.Ledger) error {
+	c.ledger = l
+	return nil
+}
+
 // Run is not implemented
 func (c *controller) Run(<-chan struct{}) {
 	log.Warnf("Run: %s", errUnsupported)


### PR DESCRIPTION
fixes #21277

In Istio 1.4.x, Pilot uses only one Config Store at a time, based on the helm variables supplied by users. In Istio 1.5.x, Istiod will use multiple Config Stores, presenting the necessity of merging ledgers across Config Store instances. This PR allows that merge, with the assumption that any data existing in the ledger before the merge may be safely discarded.

master fork of #21296
