### PR TITLE
Fix non-istiod mode on 1.5

### DIFF
--- a/manifests/istio-control/istio-autoinject/files/injection-template.yaml
+++ b/manifests/istio-control/istio-autoinject/files/injection-template.yaml
@@ -367,7 +367,7 @@ template: |
     - mountPath: /var/run/sds
       name: sds-uds-path
       readOnly: true
-    {{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
+    {{- if and (eq .Values.global.jwtPolicy "third-party-jwt") .Values.global.istiod.enabled }}
     - mountPath: /var/run/secrets/tokens
       name: istio-token
     {{- end }}
@@ -405,7 +405,7 @@ template: |
   - name: sds-uds-path
     hostPath:
       path: /var/run/sds
-  {{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
+  {{- if and (eq .Values.global.jwtPolicy "third-party-jwt") .Values.global.istiod.enabled }}
   - name: istio-token
     projected:
       sources:

--- a/manifests/istio-control/istio-discovery/templates/configmap.yaml
+++ b/manifests/istio-control/istio-discovery/templates/configmap.yaml
@@ -282,19 +282,17 @@ data:
         {{- end }}
       {{- end }}
 
-    {{- if .Values.global.istiod.enabled }}
-    {{- if not (eq .Values.revision "") }}
-    {{- $defPilotHostname := printf "istiod-%s.%s" .Values.revision .Release.Namespace }}
-    {{- else }}
-    {{- $defPilotHostname := printf "istiod.%s"  .Release.Namespace }}
-    {{- end }}
-    {{- $defPilotHostname := printf "istiod%s.%s" .Values.revision .Release.Namespace }}
+    {{- $defPilotHostname := printf "istio-pilot.%s" .Release.Namespace }}
     {{- $pilotAddress := .Values.global.remotePilotAddress | default $defPilotHostname }}
-
+    {{- if .Values.global.istiod.enabled }}
       # If port is 15012, will use SDS.
       # controlPlaneAuthPolicy is for mounted secrets, will wait for the files.
       controlPlaneAuthPolicy: NONE
-      discoveryAddress: {{ $defPilotHostname }}.svc:15012
+      {{- if .Values.global.remotePilotAddress }}
+      discoveryAddress: {{ .Values.global.remotePilotAddress }}
+      {{- else }}
+      discoveryAddress: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{.Release.Namespace}}.svc:15012
+      {{- end }}
 
     {{- else if .Values.global.controlPlaneSecurityEnabled }}
       #

--- a/manifests/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
+++ b/manifests/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
@@ -1,5 +1,5 @@
 {{ if or (eq .Values.revision "") (not .Values.clusterResources) }}
-{{- if not .Values.global.omitSidecarInjectorConfigMap }}
+{{- if and (not .Values.global.omitSidecarInjectorConfigMap) .Values.global.istiod.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/manifests/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/manifests/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -1,5 +1,5 @@
 # Installed for each revision - not installed for cluster resources ( cluster roles, bindings, crds)
-{{- if not .Values.global.operatorManageWebhooks }}
+{{- if and (not .Values.global.operatorManageWebhooks) .Values.global.istiod.enabled }}
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:

--- a/manifests/istio-telemetry/prometheus/templates/deployment.yaml
+++ b/manifests/istio-telemetry/prometheus/templates/deployment.yaml
@@ -56,8 +56,7 @@ spec:
             mountPath: /etc/prometheus
           - mountPath: /etc/istio-certs
             name: istio-certs
-
-{{- if .Values.prometheus.provisionPrometheusCert }}
+{{- if and .Values.prometheus.provisionPrometheusCert .Values.global.istiod.enabled }}
         - name: istio-proxy
           image: "{{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}"
           ports:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.yaml
@@ -8570,7 +8570,6 @@ data:
         zipkin:
           # Address of the Zipkin collector
           address: zipkin.istio-system:9411
-
       # If port is 15012, will use SDS.
       # controlPlaneAuthPolicy is for mounted secrets, will wait for the files.
       controlPlaneAuthPolicy: NONE
@@ -11073,7 +11072,7 @@ data:
         - mountPath: /var/run/sds
           name: sds-uds-path
           readOnly: true
-        {{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
+        {{- if and (eq .Values.global.jwtPolicy "third-party-jwt") .Values.global.istiod.enabled }}
         - mountPath: /var/run/secrets/tokens
           name: istio-token
         {{- end }}
@@ -11111,7 +11110,7 @@ data:
       - name: sds-uds-path
         hostPath:
           path: /var/run/sds
-      {{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
+      {{- if and (eq .Values.global.jwtPolicy "third-party-jwt") .Values.global.istiod.enabled }}
       - name: istio-token
         projected:
           sources:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.yaml
@@ -7541,7 +7541,6 @@ data:
         zipkin:
           # Address of the Zipkin collector
           address: zipkin.istio-system:9411
-
       # If port is 15012, will use SDS.
       # controlPlaneAuthPolicy is for mounted secrets, will wait for the files.
       controlPlaneAuthPolicy: NONE

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.yaml
@@ -6396,7 +6396,6 @@ data:
         zipkin:
           # Address of the Zipkin collector
           address: zipkin.istio-system:9411
-
       # If port is 15012, will use SDS.
       # controlPlaneAuthPolicy is for mounted secrets, will wait for the files.
       controlPlaneAuthPolicy: NONE

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.yaml
@@ -7329,7 +7329,6 @@ data:
         zipkin:
           # Address of the Zipkin collector
           address: zipkin.istio-system:9411
-
       # If port is 15012, will use SDS.
       # controlPlaneAuthPolicy is for mounted secrets, will wait for the files.
       controlPlaneAuthPolicy: NONE

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.yaml
@@ -7331,7 +7331,6 @@ data:
         zipkin:
           # Address of the Zipkin collector
           address: zipkin.istio-system:9411
-
       # If port is 15012, will use SDS.
       # controlPlaneAuthPolicy is for mounted secrets, will wait for the files.
       controlPlaneAuthPolicy: NONE

--- a/operator/data/profiles/separate.yaml
+++ b/operator/data/profiles/separate.yaml
@@ -1,0 +1,25 @@
+# The separate profile will disable istiod and bring back the old microservices model
+# This will be removed in future (1.6) releases
+apiVersion: operator.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  components:
+    sidecarInjector:
+      enabled: true
+    citadel:
+      enabled: true
+    galley:
+      enabled: true
+    telemetry:
+      enabled: true
+  values:
+    telemetry:
+      v1:
+        enabled: true
+      v2:
+        enabled: false
+    global:
+      pilotCertProvider: kubernetes
+      mountMtlsCerts: true
+      istiod:
+        enabled: false


### PR DESCRIPTION
*This does not apply to master, which only supports istiod now.*

This fixes a number of bugs:
* Pilot address is broken, helm chart won't even render
* Backport the profile to enable this from master
* Fix prometheus sidecar
* Fix injector referencing the wrong service
* Fix agent to not attempt to run SDS