### PR TITLE
Add managed labels to manifest generate output

### DIFF
--- a/operator/cmd/mesh/manifest-generate.go
+++ b/operator/cmd/mesh/manifest-generate.go
@@ -20,19 +20,16 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/spf13/cobra"
 	"k8s.io/client-go/rest"
 
 	"istio.io/api/operator/v1alpha1"
 	"istio.io/istio/operator/pkg/controlplane"
-	"istio.io/istio/operator/pkg/translate"
-	"istio.io/istio/operator/version"
-
 	"istio.io/istio/operator/pkg/helm"
-
-	"github.com/spf13/cobra"
-
 	"istio.io/istio/operator/pkg/manifest"
 	"istio.io/istio/operator/pkg/name"
+	"istio.io/istio/operator/pkg/translate"
+	"istio.io/istio/operator/version"
 )
 
 type manifestGenerateArgs struct {
@@ -146,8 +143,13 @@ func GenManifests(inFilename []string, setOverlayYAML string, force bool,
 
 	manifests, errs := cp.RenderManifest()
 	if errs != nil {
-		return manifests, mergedIOPS, errs.ToError()
+		return nil, nil, errs.ToError()
 	}
+
+	if manifests, err = manifest.AddManagedLabelsNoReorder(manifests); err != nil {
+		return nil, nil, err
+	}
+
 	return manifests, mergedIOPS, nil
 }
 

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -5,6 +5,7 @@ kind: ClusterRole
 metadata:
   name: istiocoredns
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiocoredns
     release: istio
 rules:
@@ -19,6 +20,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istio-istiocoredns-role-binding-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiocoredns
     release: istio
 roleRef:
@@ -38,6 +40,7 @@ metadata:
   name: coredns
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiocoredns
     release: istio
 data:
@@ -65,6 +68,7 @@ metadata:
   name: istiocoredns
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiocoredns
     release: istio
 spec:
@@ -178,6 +182,7 @@ metadata:
   name: istiocoredns
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiocoredns
     release: istio
 spec:
@@ -199,6 +204,7 @@ metadata:
   name: istiocoredns-service-account
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiocoredns
     release: istio
 ---
@@ -217,6 +223,7 @@ kind: ClusterRole
 metadata:
   name: prometheus-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 rules:
@@ -242,6 +249,7 @@ kind: ClusterRoleBinding
 metadata:
   name: prometheus-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 roleRef:
@@ -261,6 +269,7 @@ metadata:
   name: prometheus
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 data:
@@ -552,6 +561,7 @@ metadata:
   name: prometheus
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 spec:
@@ -757,6 +767,7 @@ metadata:
   annotations:
     prometheus.io/scrape: 'true'
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 spec:
@@ -775,6 +786,7 @@ metadata:
   name: prometheus
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 ---
@@ -789,6 +801,7 @@ kind: ClusterRole
 metadata:
   name: istio-reader-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-reader
     release: istio
 rules:
@@ -814,6 +827,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istio-reader-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-reader
     release: istio
 roleRef:
@@ -833,6 +847,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-citadel
     chart: istio
     heritage: Tiller
@@ -1559,6 +1574,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-citadel
     chart: istio
     heritage: Tiller
@@ -2285,6 +2301,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-mixer
     chart: istio
     heritage: Tiller
@@ -2497,6 +2514,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-mixer
     chart: istio
     heritage: Tiller
@@ -2591,6 +2609,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-mixer
     chart: istio
     heritage: Tiller
@@ -2676,6 +2695,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-mixer
     chart: istio
     heritage: Tiller
@@ -2757,6 +2777,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -3746,6 +3767,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -4043,6 +4065,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -4195,6 +4218,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -4344,6 +4368,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -4625,6 +4650,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -5343,6 +5369,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -5420,6 +5447,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -5585,6 +5613,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -5648,6 +5677,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -5804,6 +5834,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -5892,6 +5923,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -5981,6 +6013,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -6093,6 +6126,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -6296,6 +6330,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -6496,6 +6531,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -6573,6 +6609,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -6678,6 +6715,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
   name: adapters.config.istio.io
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     package: adapter
     istio: mixer-adapter
@@ -6710,6 +6748,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
   name: templates.config.istio.io
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     package: template
     istio: mixer-template
@@ -6742,6 +6781,7 @@ kind: Namespace
 metadata:
   name: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     istio-operator-managed: Reconcile
     istio-injection: disabled
 ---
@@ -6753,6 +6793,7 @@ metadata:
   name: istio-reader-service-account
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-reader
     release: istio
 ---
@@ -6764,6 +6805,7 @@ kind: ClusterRole
 metadata:
   name: istio-citadel-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: citadel
     release: istio
 rules:
@@ -6787,6 +6829,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istio-citadel-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -6803,6 +6846,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    operator.istio.io/managed: Reconcile
     app: security
     istio: citadel
     release: istio
@@ -6899,6 +6943,7 @@ metadata:
   name: istio-citadel
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: security
     istio: citadel
     release: istio
@@ -6918,6 +6963,7 @@ metadata:
   name: istio-citadel
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: security
     istio: citadel
     release: istio
@@ -6941,6 +6987,7 @@ metadata:
   name: istio-citadel-service-account
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: security
     release: istio
 ---
@@ -6955,6 +7002,7 @@ metadata:
   name: istio-egressgateway
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-egressgateway
     istio: egressgateway
     
@@ -6980,6 +7028,7 @@ metadata:
   name: istio-egressgateway
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-egressgateway
     istio: egressgateway
     
@@ -7208,6 +7257,7 @@ metadata:
   name: istio-egressgateway
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-egressgateway
     istio: egressgateway
     
@@ -7229,6 +7279,7 @@ metadata:
   name: istio-multicluster-egressgateway
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-egressgateway
     istio: egressgateway
     
@@ -7253,6 +7304,7 @@ metadata:
   name: istio-multicluster-egressgateway
   namespace: istio-system 
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-egressgateway
     istio: egressgateway
     
@@ -7282,6 +7334,7 @@ metadata:
   name: istio-multicluster-egressgateway
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-egressgateway
     istio: egressgateway
     
@@ -7305,6 +7358,7 @@ metadata:
   name: istio-multicluster-egressgateway
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-egressgateway
     istio: egressgateway
     
@@ -7324,6 +7378,7 @@ metadata:
   namespace: istio-system
   annotations:
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-egressgateway
     istio: egressgateway
     
@@ -7354,6 +7409,7 @@ metadata:
   name: istio-egressgateway-service-account
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-egressgateway
     istio: egressgateway
     
@@ -7367,6 +7423,7 @@ kind: ClusterRole
 metadata:
   name: istio-galley-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 rules:
   # For reading Istio resources
@@ -7415,6 +7472,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istio-galley-admin-role-binding-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -7433,6 +7491,7 @@ metadata:
   namespace: istio-system
   name: galley-envoy-config
   labels:
+    operator.istio.io/managed: Reconcile
     app: galley
     istio: galley
     release: istio
@@ -7525,6 +7584,7 @@ metadata:
   name: istio-mesh-galley
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 data:
   mesh: |-
@@ -7538,6 +7598,7 @@ metadata:
   name: istio-galley-configuration
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 data:
   validatingwebhookconfiguration.yaml: |-    
@@ -7558,6 +7619,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    operator.istio.io/managed: Reconcile
     app: galley
     istio: galley
     release: istio
@@ -7734,6 +7796,7 @@ metadata:
   name: istio-galley
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: galley
     release: istio
     istio: galley
@@ -7753,6 +7816,7 @@ metadata:
   name: istio-galley
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: galley
     istio: galley
     release: istio
@@ -7778,6 +7842,7 @@ metadata:
   name: istio-galley-service-account
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: galley
     release: istio
 ---
@@ -7789,6 +7854,7 @@ metadata:
   name: istio-galley
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: galley
     release: istio
     istio: galley
@@ -7803,6 +7869,7 @@ metadata:
   name: istio-ingressgateway
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     
@@ -7828,6 +7895,7 @@ metadata:
   name: istio-ingressgateway
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     
@@ -8072,6 +8140,7 @@ metadata:
   name: ingressgateway
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 spec:
   selector:
@@ -8093,6 +8162,7 @@ metadata:
   name: ingressgateway
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     
@@ -8114,6 +8184,7 @@ metadata:
   name: istio-ingressgateway-sds
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 rules:
 - apiGroups: [""]
@@ -8128,6 +8199,7 @@ metadata:
   name: istio-ingressgateway-sds
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8146,6 +8218,7 @@ metadata:
   namespace: istio-system
   annotations:
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     
@@ -8198,6 +8271,7 @@ metadata:
   name: istio-ingressgateway-service-account
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     
@@ -8211,6 +8285,7 @@ metadata:
   name: default
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 spec:
   egress:
@@ -8226,6 +8301,7 @@ metadata:
   name: istiod
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 spec:
@@ -8248,6 +8324,7 @@ kind: ClusterRole
 metadata:
   name: istio-pilot-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     release: istio
 rules:
@@ -8291,6 +8368,7 @@ kind: ClusterRole
 metadata:
   name: istiod-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 rules:
@@ -8365,6 +8443,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istio-pilot-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     release: istio
 roleRef:
@@ -8383,6 +8462,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istiod-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 roleRef:
@@ -8402,6 +8482,7 @@ metadata:
   name: istio
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 data:
 
@@ -8571,6 +8652,7 @@ metadata:
   name: istiod
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     istio: pilot
     release: istio
@@ -8759,6 +8841,7 @@ kind: "MeshPolicy"
 metadata:
   name: "default"
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 spec:
   peers:
@@ -8773,6 +8856,7 @@ metadata:
   name: istio-sidecar-injector
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 data:
 
@@ -9393,6 +9477,7 @@ metadata:
   name: istio-sidecar-injector
 
   labels:
+    operator.istio.io/managed: Reconcile
     app: sidecar-injector
     release: istio
 webhooks:
@@ -9421,6 +9506,7 @@ metadata:
   name: istiod-
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
     istio: pilot
@@ -9440,6 +9526,7 @@ metadata:
   name: istio-pilot
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     release: istio
     istio: pilot
@@ -9469,6 +9556,7 @@ metadata:
   name: istiod
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 spec:
@@ -9492,6 +9580,7 @@ metadata:
   name: istiod-service-account
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 ---
@@ -9500,6 +9589,8 @@ metadata:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: metadata-exchange-1.4
   namespace: istio-system
 spec:
@@ -9530,6 +9621,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: stats-filter-1.4
   namespace: istio-system
 spec:
@@ -9624,6 +9717,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: metadata-exchange-1.5
   namespace: istio-system
 spec:
@@ -9658,6 +9753,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-metadata-exchange-1.5
   namespace: istio-system
 spec:
@@ -9712,6 +9809,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: stats-filter-1.5
   namespace: istio-system
 spec:
@@ -9818,6 +9917,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-stats-filter-1.5
   namespace: istio-system
 spec:
@@ -9918,6 +10019,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: metadata-exchange-1.6
   namespace: istio-system
 spec:
@@ -9952,6 +10055,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-metadata-exchange-1.6
   namespace: istio-system
 spec:
@@ -10006,6 +10111,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: stats-filter-1.6
   namespace: istio-system
 spec:
@@ -10112,6 +10219,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-stats-filter-1.6
   namespace: istio-system
 spec:
@@ -10215,6 +10324,7 @@ metadata:
   name: istiod-istio-system
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
     istio: istiod
@@ -10254,6 +10364,7 @@ metadata:
   name: istio-galley
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: galley
     release: istio
     istio: galley
@@ -10266,6 +10377,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     release: istio
   name: istio-policy
@@ -10291,6 +10403,7 @@ kind: ClusterRole
 metadata:
   name: istio-policy
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
     app: istio-policy
 rules:
@@ -10314,6 +10427,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istio-policy-admin-role-binding-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-policy
     release: istio
 roleRef:
@@ -10333,6 +10447,7 @@ metadata:
   name: istio-policy
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-policy
     release: istio
 spec:
@@ -10358,6 +10473,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-policy
     istio: mixer
     release: istio
@@ -10530,6 +10646,7 @@ metadata:
   name: istio-policy
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: policy
     release: istio
     istio: mixer
@@ -10550,6 +10667,7 @@ metadata:
   name: istio-policy
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     istio: mixer
     release: istio
@@ -10573,6 +10691,7 @@ metadata:
   name: istio-policy-service-account
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-policy
     release: istio
 ---
@@ -10583,6 +10702,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     release: istio
   name: istio-telemetry
@@ -10608,6 +10728,7 @@ kind: ClusterRole
 metadata:
   name: istio-mixer-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 rules:
@@ -10631,6 +10752,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istio-mixer-admin-role-binding-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 roleRef:
@@ -10650,6 +10772,7 @@ metadata:
   name: istioproxy
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -10792,6 +10915,7 @@ metadata:
   name: kubernetes
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -10857,6 +10981,7 @@ metadata:
   name: requestcount
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -10893,6 +11018,7 @@ metadata:
   name: requestduration
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -10929,6 +11055,7 @@ metadata:
   name: requestsize
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -10965,6 +11092,7 @@ metadata:
   name: responsesize
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -11001,6 +11129,7 @@ metadata:
   name: tcpbytesent
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -11034,6 +11163,7 @@ metadata:
   name: tcpbytereceived
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -11067,6 +11197,7 @@ metadata:
   name: tcpconnectionsopened
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -11100,6 +11231,7 @@ metadata:
   name: tcpconnectionsclosed
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -11133,6 +11265,7 @@ metadata:
   name: prometheus
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -11335,6 +11468,7 @@ metadata:
   name: promhttp
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -11355,6 +11489,7 @@ metadata:
   name: promtcp
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -11373,6 +11508,7 @@ metadata:
   name: promtcpconnectionopen
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -11390,6 +11526,7 @@ metadata:
   name: promtcpconnectionclosed
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -11407,6 +11544,7 @@ metadata:
   name: kubernetesenv
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -11427,6 +11565,7 @@ metadata:
   name: kubeattrgenrulerule
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -11443,6 +11582,7 @@ metadata:
   name: tcpkubeattrgenrulerule
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -11460,6 +11600,7 @@ metadata:
   name: attributes
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -11503,6 +11644,7 @@ metadata:
   name: istio-telemetry
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -11530,6 +11672,7 @@ metadata:
   namespace: istio-system
   name: telemetry-envoy-config
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 data:
   # Explicitly defined - moved from istio/istio/pilot/docker.
@@ -11828,6 +11971,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-mixer
     istio: mixer
     release: istio
@@ -12012,6 +12156,7 @@ metadata:
   name: istio-telemetry
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: telemetry
     release: istio
     istio: mixer
@@ -12032,6 +12177,7 @@ metadata:
   name: istio-telemetry
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     istio: mixer
     release: istio
@@ -12057,6 +12203,7 @@ metadata:
   name: istio-mixer-service-account
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 ---

--- a/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.golden.yaml
@@ -11,6 +11,7 @@ kind: ClusterRole
 metadata:
   name: prometheus-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 rules:
@@ -36,6 +37,7 @@ kind: ClusterRoleBinding
 metadata:
   name: prometheus-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 roleRef:
@@ -55,6 +57,7 @@ metadata:
   name: prometheus
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 data:
@@ -308,6 +311,7 @@ metadata:
   name: prometheus
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 spec:
@@ -513,6 +517,7 @@ metadata:
   annotations:
     prometheus.io/scrape: 'true'
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 spec:
@@ -531,6 +536,7 @@ metadata:
   name: prometheus
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 ---
@@ -545,6 +551,7 @@ kind: ClusterRole
 metadata:
   name: istio-reader-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-reader
     release: istio
 rules:
@@ -570,6 +577,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istio-reader-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-reader
     release: istio
 roleRef:
@@ -589,6 +597,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-citadel
     chart: istio
     heritage: Tiller
@@ -1315,6 +1324,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-citadel
     chart: istio
     heritage: Tiller
@@ -2041,6 +2051,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-mixer
     chart: istio
     heritage: Tiller
@@ -2253,6 +2264,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-mixer
     chart: istio
     heritage: Tiller
@@ -2347,6 +2359,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-mixer
     chart: istio
     heritage: Tiller
@@ -2432,6 +2445,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-mixer
     chart: istio
     heritage: Tiller
@@ -2513,6 +2527,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -3502,6 +3517,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -3799,6 +3815,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -3951,6 +3968,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -4100,6 +4118,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -4381,6 +4400,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -5099,6 +5119,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -5176,6 +5197,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -5341,6 +5363,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -5404,6 +5427,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -5560,6 +5584,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -5648,6 +5673,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -5737,6 +5763,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -5849,6 +5876,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -6052,6 +6080,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -6252,6 +6281,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -6329,6 +6359,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -6434,6 +6465,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
   name: adapters.config.istio.io
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     package: adapter
     istio: mixer-adapter
@@ -6466,6 +6498,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
   name: templates.config.istio.io
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     package: template
     istio: mixer-template
@@ -6498,6 +6531,7 @@ kind: Namespace
 metadata:
   name: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     istio-operator-managed: Reconcile
     istio-injection: disabled
 ---
@@ -6509,6 +6543,7 @@ metadata:
   name: istio-reader-service-account
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-reader
     release: istio
 ---
@@ -6522,6 +6557,7 @@ kind: ClusterRole
 metadata:
   name: istio-cni
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-cni
     release: istio
 rules:
@@ -6539,6 +6575,7 @@ kind: ClusterRole
 metadata:
   name: istio-cni-repair-role
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-cni
     release: istio
 rules:
@@ -6556,6 +6593,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istio-cni
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-cni
     release: istio
 roleRef:
@@ -6575,6 +6613,7 @@ metadata:
   name: istio-cni-repair-rolebinding
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     k8s-app: istio-cni-repair
 subjects:
 - kind: ServiceAccount
@@ -6593,6 +6632,7 @@ metadata:
   name: istio-cni-config
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-cni
     release: istio
 data:
@@ -6617,6 +6657,7 @@ metadata:
   name: istio-cni-node
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     k8s-app: istio-cni-node
     release: istio
 spec:
@@ -6721,6 +6762,7 @@ metadata:
   name: istio-cni
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-cni
     release: istio
 ---
@@ -6735,6 +6777,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     release: istio
@@ -6760,6 +6803,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     release: istio
@@ -7002,6 +7046,7 @@ metadata:
   name: ingressgateway
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 spec:
   selector:
@@ -7023,6 +7068,7 @@ metadata:
   name: ingressgateway
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     
@@ -7044,6 +7090,7 @@ metadata:
   name: istio-ingressgateway-sds
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 rules:
 - apiGroups: [""]
@@ -7058,6 +7105,7 @@ metadata:
   name: istio-ingressgateway-sds
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -7076,6 +7124,7 @@ metadata:
   namespace: istio-system
   annotations:
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     
@@ -7128,6 +7177,7 @@ metadata:
   name: istio-ingressgateway-service-account
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     
@@ -7141,6 +7191,7 @@ metadata:
   name: default
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 spec:
   egress:
@@ -7156,6 +7207,7 @@ metadata:
   name: istiod
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 spec:
@@ -7178,6 +7230,7 @@ kind: ClusterRole
 metadata:
   name: istio-galley-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 rules:
   # For reading Istio resources
@@ -7230,6 +7283,7 @@ kind: ClusterRole
 metadata:
   name: istio-pilot-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     release: istio
 rules:
@@ -7273,6 +7327,7 @@ kind: ClusterRole
 metadata:
   name: istiod-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 rules:
@@ -7347,6 +7402,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istio-pilot-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     release: istio
 roleRef:
@@ -7365,6 +7421,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istiod-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 roleRef:
@@ -7384,6 +7441,7 @@ metadata:
   name: istio
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 data:
 
@@ -7549,6 +7607,7 @@ metadata:
   name: istiod
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     istio: pilot
     release: istio
@@ -7737,6 +7796,7 @@ kind: "MeshPolicy"
 metadata:
   name: "default"
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 spec:
   peers:
@@ -7751,6 +7811,7 @@ metadata:
   name: istio-sidecar-injector
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 data:
 
@@ -8371,6 +8432,7 @@ metadata:
   name: istio-sidecar-injector
 
   labels:
+    operator.istio.io/managed: Reconcile
     app: sidecar-injector
     release: istio
 webhooks:
@@ -8399,6 +8461,7 @@ metadata:
   name: istiod-
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
     istio: pilot
@@ -8418,6 +8481,7 @@ metadata:
   name: istio-pilot
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     release: istio
     istio: pilot
@@ -8447,6 +8511,7 @@ metadata:
   name: istiod
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 spec:
@@ -8470,6 +8535,7 @@ metadata:
   name: istiod-service-account
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 ---
@@ -8478,6 +8544,8 @@ metadata:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: metadata-exchange-1.4
   namespace: istio-system
 spec:
@@ -8508,6 +8576,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: stats-filter-1.4
   namespace: istio-system
 spec:
@@ -8602,6 +8672,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: metadata-exchange-1.5
   namespace: istio-system
 spec:
@@ -8636,6 +8708,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-metadata-exchange-1.5
   namespace: istio-system
 spec:
@@ -8690,6 +8764,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: stats-filter-1.5
   namespace: istio-system
 spec:
@@ -8796,6 +8872,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-stats-filter-1.5
   namespace: istio-system
 spec:
@@ -8896,6 +8974,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: metadata-exchange-1.6
   namespace: istio-system
 spec:
@@ -8930,6 +9010,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-metadata-exchange-1.6
   namespace: istio-system
 spec:
@@ -8984,6 +9066,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: stats-filter-1.6
   namespace: istio-system
 spec:
@@ -9090,6 +9174,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-stats-filter-1.6
   namespace: istio-system
 spec:
@@ -9193,6 +9279,7 @@ metadata:
   name: istiod-istio-system
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
     istio: istiod
@@ -9232,6 +9319,7 @@ metadata:
   name: istio-galley
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: galley
     release: istio
     istio: galley

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_force.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_force.golden.yaml
@@ -25,6 +25,7 @@ metadata:
   name: istiod
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 spec:
@@ -47,6 +48,7 @@ kind: ClusterRole
 metadata:
   name: istio-galley-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 rules:
   # For reading Istio resources
@@ -99,6 +101,7 @@ kind: ClusterRole
 metadata:
   name: istio-pilot-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     release: istio
 rules:
@@ -142,6 +145,7 @@ kind: ClusterRole
 metadata:
   name: istiod-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 rules:
@@ -216,6 +220,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istio-pilot-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     release: istio
 roleRef:
@@ -234,6 +239,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istiod-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 roleRef:
@@ -336,6 +342,7 @@ data:
 kind: ConfigMap
 metadata:
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
   name: istio
   namespace: istio-system
@@ -349,6 +356,7 @@ metadata:
   name: istiod
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     istio: pilot
     release: istio
@@ -537,6 +545,7 @@ kind: "MeshPolicy"
 metadata:
   name: "default"
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 spec:
   peers:
@@ -551,6 +560,7 @@ metadata:
   name: istio-sidecar-injector
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 data:
 
@@ -1172,6 +1182,7 @@ metadata:
   name: istio-sidecar-injector
 
   labels:
+    operator.istio.io/managed: Reconcile
     app: sidecar-injector
     release: istio
 webhooks:
@@ -1200,6 +1211,7 @@ metadata:
   name: istiod-
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
     istio: pilot
@@ -1219,6 +1231,7 @@ metadata:
   name: istio-pilot
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     release: istio
     istio: pilot
@@ -1248,6 +1261,7 @@ metadata:
   name: istiod
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 spec:
@@ -1271,6 +1285,7 @@ metadata:
   name: istiod-service-account
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 ---
@@ -1279,6 +1294,8 @@ metadata:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: metadata-exchange-1.4
   namespace: istio-system
 spec:
@@ -1309,6 +1326,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: stats-filter-1.4
   namespace: istio-system
 spec:
@@ -1403,6 +1422,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: metadata-exchange-1.5
   namespace: istio-system
 spec:
@@ -1437,6 +1458,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-metadata-exchange-1.5
   namespace: istio-system
 spec:
@@ -1491,6 +1514,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: stats-filter-1.5
   namespace: istio-system
 spec:
@@ -1597,6 +1622,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-stats-filter-1.5
   namespace: istio-system
 spec:
@@ -1697,6 +1724,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: metadata-exchange-1.6
   namespace: istio-system
 spec:
@@ -1731,6 +1760,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-metadata-exchange-1.6
   namespace: istio-system
 spec:
@@ -1785,6 +1816,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: stats-filter-1.6
   namespace: istio-system
 spec:
@@ -1891,6 +1924,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-stats-filter-1.6
   namespace: istio-system
 spec:
@@ -1994,6 +2029,7 @@ metadata:
   name: istiod-istio-system
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
     istio: istiod
@@ -2033,6 +2069,7 @@ metadata:
   name: istio-galley
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: galley
     release: istio
     istio: galley

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output.golden.yaml
@@ -25,6 +25,7 @@ metadata:
   name: istiod
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 spec:
@@ -47,6 +48,7 @@ kind: ClusterRole
 metadata:
   name: istio-galley-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 rules:
   # For reading Istio resources
@@ -99,6 +101,7 @@ kind: ClusterRole
 metadata:
   name: istio-pilot-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     release: istio
 rules:
@@ -142,6 +145,7 @@ kind: ClusterRole
 metadata:
   name: istiod-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 rules:
@@ -216,6 +220,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istio-pilot-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     release: istio
 roleRef:
@@ -234,6 +239,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istiod-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 roleRef:
@@ -336,6 +342,7 @@ data:
 kind: ConfigMap
 metadata:
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
   name: istio
   namespace: istio-system
@@ -349,6 +356,7 @@ metadata:
   name: istiod
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     istio: pilot
     release: istio
@@ -537,6 +545,7 @@ kind: "MeshPolicy"
 metadata:
   name: "default"
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 spec:
   peers:
@@ -551,6 +560,7 @@ metadata:
   name: istio-sidecar-injector
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 data:
 
@@ -1171,6 +1181,7 @@ metadata:
   name: istio-sidecar-injector
 
   labels:
+    operator.istio.io/managed: Reconcile
     app: sidecar-injector
     release: istio
 webhooks:
@@ -1199,6 +1210,7 @@ metadata:
   name: istiod-
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
     istio: pilot
@@ -1218,6 +1230,7 @@ metadata:
   name: istio-pilot
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     release: istio
     istio: pilot
@@ -1247,6 +1260,7 @@ metadata:
   name: istiod
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 spec:
@@ -1270,6 +1284,7 @@ metadata:
   name: istiod-service-account
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 ---
@@ -1278,6 +1293,8 @@ metadata:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: metadata-exchange-1.4
   namespace: istio-system
 spec:
@@ -1308,6 +1325,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: stats-filter-1.4
   namespace: istio-system
 spec:
@@ -1402,6 +1421,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: metadata-exchange-1.5
   namespace: istio-system
 spec:
@@ -1436,6 +1457,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-metadata-exchange-1.5
   namespace: istio-system
 spec:
@@ -1490,6 +1513,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: stats-filter-1.5
   namespace: istio-system
 spec:
@@ -1596,6 +1621,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-stats-filter-1.5
   namespace: istio-system
 spec:
@@ -1696,6 +1723,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: metadata-exchange-1.6
   namespace: istio-system
 spec:
@@ -1730,6 +1759,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-metadata-exchange-1.6
   namespace: istio-system
 spec:
@@ -1784,6 +1815,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: stats-filter-1.6
   namespace: istio-system
 spec:
@@ -1890,6 +1923,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-stats-filter-1.6
   namespace: istio-system
 spec:
@@ -1993,6 +2028,7 @@ metadata:
   name: istiod-istio-system
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
     istio: istiod
@@ -2032,6 +2068,7 @@ metadata:
   name: istio-galley
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: galley
     release: istio
     istio: galley

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
@@ -16,6 +16,7 @@ kind: ClusterRole
 metadata:
   name: istio-reader-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-reader
     release: istio
 rules:
@@ -41,6 +42,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istio-reader-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-reader
     release: istio
 roleRef:
@@ -60,6 +62,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-citadel
     chart: istio
     heritage: Tiller
@@ -786,6 +789,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-citadel
     chart: istio
     heritage: Tiller
@@ -1512,6 +1516,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-mixer
     chart: istio
     heritage: Tiller
@@ -1724,6 +1729,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-mixer
     chart: istio
     heritage: Tiller
@@ -1818,6 +1824,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-mixer
     chart: istio
     heritage: Tiller
@@ -1903,6 +1910,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-mixer
     chart: istio
     heritage: Tiller
@@ -1984,6 +1992,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -2973,6 +2982,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -3270,6 +3280,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -3422,6 +3433,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -3571,6 +3583,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -3852,6 +3865,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -4570,6 +4584,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -4647,6 +4662,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -4812,6 +4828,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -4875,6 +4892,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -5031,6 +5049,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -5119,6 +5138,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -5208,6 +5228,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -5320,6 +5341,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -5523,6 +5545,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -5723,6 +5746,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -5800,6 +5824,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -5905,6 +5930,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
   name: adapters.config.istio.io
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     package: adapter
     istio: mixer-adapter
@@ -5937,6 +5963,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
   name: templates.config.istio.io
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     package: template
     istio: mixer-template
@@ -5969,6 +5996,7 @@ kind: Namespace
 metadata:
   name: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     istio-operator-managed: Reconcile
     istio-injection: disabled
 ---
@@ -5980,6 +6008,7 @@ metadata:
   name: istio-reader-service-account
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-reader
     release: istio
 ---
@@ -6002,6 +6031,7 @@ metadata:
   name: istiod
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 spec:
@@ -6024,6 +6054,7 @@ kind: ClusterRole
 metadata:
   name: istio-galley-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 rules:
   # For reading Istio resources
@@ -6076,6 +6107,7 @@ kind: ClusterRole
 metadata:
   name: istio-pilot-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     release: istio
 rules:
@@ -6119,6 +6151,7 @@ kind: ClusterRole
 metadata:
   name: istiod-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 rules:
@@ -6193,6 +6226,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istio-pilot-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     release: istio
 roleRef:
@@ -6211,6 +6245,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istiod-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 roleRef:
@@ -6230,6 +6265,7 @@ metadata:
   name: istio
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 data:
 
@@ -6397,6 +6433,7 @@ metadata:
   name: istiod
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     istio: pilot
     release: istio
@@ -6585,6 +6622,7 @@ kind: "MeshPolicy"
 metadata:
   name: "default"
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 spec:
   peers:
@@ -6599,6 +6637,7 @@ metadata:
   name: istio-sidecar-injector
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 data:
 
@@ -7219,6 +7258,7 @@ metadata:
   name: istio-sidecar-injector
 
   labels:
+    operator.istio.io/managed: Reconcile
     app: sidecar-injector
     release: istio
 webhooks:
@@ -7247,6 +7287,7 @@ metadata:
   name: istiod-
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
     istio: pilot
@@ -7266,6 +7307,7 @@ metadata:
   name: istio-pilot
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     release: istio
     istio: pilot
@@ -7295,6 +7337,7 @@ metadata:
   name: istiod
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 spec:
@@ -7318,6 +7361,7 @@ metadata:
   name: istiod-service-account
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 ---
@@ -7326,6 +7370,8 @@ metadata:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: metadata-exchange-1.4
   namespace: istio-system
 spec:
@@ -7356,6 +7402,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: stats-filter-1.4
   namespace: istio-system
 spec:
@@ -7450,6 +7498,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: metadata-exchange-1.5
   namespace: istio-system
 spec:
@@ -7484,6 +7534,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-metadata-exchange-1.5
   namespace: istio-system
 spec:
@@ -7538,6 +7590,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: stats-filter-1.5
   namespace: istio-system
 spec:
@@ -7644,6 +7698,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-stats-filter-1.5
   namespace: istio-system
 spec:
@@ -7744,6 +7800,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: metadata-exchange-1.6
   namespace: istio-system
 spec:
@@ -7778,6 +7836,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-metadata-exchange-1.6
   namespace: istio-system
 spec:
@@ -7832,6 +7892,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: stats-filter-1.6
   namespace: istio-system
 spec:
@@ -7938,6 +8000,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-stats-filter-1.6
   namespace: istio-system
 spec:
@@ -8041,6 +8105,7 @@ metadata:
   name: istiod-istio-system
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
     istio: istiod
@@ -8080,6 +8145,7 @@ metadata:
   name: istio-galley
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: galley
     release: istio
     istio: galley

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.golden.yaml
@@ -5,6 +5,7 @@ kind: ClusterRole
 metadata:
   name: istio-reader-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-reader
     release: istio
 rules:
@@ -30,6 +31,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istio-reader-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-reader
     release: istio
 roleRef:
@@ -49,6 +51,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-citadel
     chart: istio
     heritage: Tiller
@@ -775,6 +778,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-citadel
     chart: istio
     heritage: Tiller
@@ -1501,6 +1505,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-mixer
     chart: istio
     heritage: Tiller
@@ -1713,6 +1718,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-mixer
     chart: istio
     heritage: Tiller
@@ -1807,6 +1813,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-mixer
     chart: istio
     heritage: Tiller
@@ -1892,6 +1899,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-mixer
     chart: istio
     heritage: Tiller
@@ -1973,6 +1981,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -2962,6 +2971,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -3259,6 +3269,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -3411,6 +3422,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -3560,6 +3572,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -3841,6 +3854,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -4559,6 +4573,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -4636,6 +4651,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -4801,6 +4817,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -4864,6 +4881,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -5020,6 +5038,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -5108,6 +5127,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -5197,6 +5217,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -5309,6 +5330,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -5512,6 +5534,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -5712,6 +5735,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -5789,6 +5813,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -5894,6 +5919,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
   name: adapters.config.istio.io
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     package: adapter
     istio: mixer-adapter
@@ -5926,6 +5952,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
   name: templates.config.istio.io
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     package: template
     istio: mixer-template
@@ -5958,6 +5985,7 @@ kind: Namespace
 metadata:
   name: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     istio-operator-managed: Reconcile
     istio-injection: disabled
 ---
@@ -5969,6 +5997,7 @@ metadata:
   name: istio-reader-service-account
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-reader
     release: istio
 ---
@@ -5986,6 +6015,7 @@ kind: ClusterRole
 metadata:
   name: prometheus-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 rules:
@@ -6011,6 +6041,7 @@ kind: ClusterRoleBinding
 metadata:
   name: prometheus-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 roleRef:
@@ -6030,6 +6061,7 @@ metadata:
   name: prometheus
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 data:
@@ -6283,6 +6315,7 @@ metadata:
   name: prometheus
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 spec:
@@ -6488,6 +6521,7 @@ metadata:
   annotations:
     prometheus.io/scrape: 'true'
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 spec:
@@ -6506,6 +6540,7 @@ metadata:
   name: prometheus
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 ---
@@ -6527,6 +6562,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     release: istio
@@ -6552,6 +6588,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     release: istio
@@ -6794,6 +6831,7 @@ metadata:
   name: ingressgateway
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 spec:
   selector:
@@ -6815,6 +6853,7 @@ metadata:
   name: ingressgateway
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     
@@ -6836,6 +6875,7 @@ metadata:
   name: istio-ingressgateway-sds
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 rules:
 - apiGroups: [""]
@@ -6850,6 +6890,7 @@ metadata:
   name: istio-ingressgateway-sds
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -6868,6 +6909,7 @@ metadata:
   namespace: istio-system
   annotations:
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     
@@ -6920,6 +6962,7 @@ metadata:
   name: istio-ingressgateway-service-account
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     
@@ -6933,6 +6976,7 @@ metadata:
   name: default
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 spec:
   egress:
@@ -6948,6 +6992,7 @@ metadata:
   name: istiod
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 spec:
@@ -6970,6 +7015,7 @@ kind: ClusterRole
 metadata:
   name: istio-galley-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 rules:
   # For reading Istio resources
@@ -7022,6 +7068,7 @@ kind: ClusterRole
 metadata:
   name: istio-pilot-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     release: istio
 rules:
@@ -7065,6 +7112,7 @@ kind: ClusterRole
 metadata:
   name: istiod-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 rules:
@@ -7139,6 +7187,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istio-pilot-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     release: istio
 roleRef:
@@ -7157,6 +7206,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istiod-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 roleRef:
@@ -7176,6 +7226,7 @@ metadata:
   name: istio
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 data:
 
@@ -7341,6 +7392,7 @@ metadata:
   name: istiod
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     istio: pilot
     release: istio
@@ -7529,6 +7581,7 @@ kind: "MeshPolicy"
 metadata:
   name: "default"
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 spec:
   peers:
@@ -7543,6 +7596,7 @@ metadata:
   name: istio-sidecar-injector
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 data:
 
@@ -8163,6 +8217,7 @@ metadata:
   name: istio-sidecar-injector
 
   labels:
+    operator.istio.io/managed: Reconcile
     app: sidecar-injector
     release: istio
 webhooks:
@@ -8191,6 +8246,7 @@ metadata:
   name: istiod-
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
     istio: pilot
@@ -8210,6 +8266,7 @@ metadata:
   name: istio-pilot
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     release: istio
     istio: pilot
@@ -8239,6 +8296,7 @@ metadata:
   name: istiod
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 spec:
@@ -8262,6 +8320,7 @@ metadata:
   name: istiod-service-account
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 ---
@@ -8270,6 +8329,8 @@ metadata:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: metadata-exchange-1.4
   namespace: istio-system
 spec:
@@ -8300,6 +8361,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: stats-filter-1.4
   namespace: istio-system
 spec:
@@ -8394,6 +8457,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: metadata-exchange-1.5
   namespace: istio-system
 spec:
@@ -8428,6 +8493,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-metadata-exchange-1.5
   namespace: istio-system
 spec:
@@ -8482,6 +8549,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: stats-filter-1.5
   namespace: istio-system
 spec:
@@ -8588,6 +8657,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-stats-filter-1.5
   namespace: istio-system
 spec:
@@ -8688,6 +8759,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: metadata-exchange-1.6
   namespace: istio-system
 spec:
@@ -8722,6 +8795,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-metadata-exchange-1.6
   namespace: istio-system
 spec:
@@ -8776,6 +8851,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: stats-filter-1.6
   namespace: istio-system
 spec:
@@ -8882,6 +8959,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-stats-filter-1.6
   namespace: istio-system
 spec:
@@ -8985,6 +9064,7 @@ metadata:
   name: istiod-istio-system
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
     istio: istiod
@@ -9024,6 +9104,7 @@ metadata:
   name: istio-galley
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: galley
     release: istio
     istio: galley

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_override_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_override_values.golden.yaml
@@ -23,6 +23,7 @@ metadata:
   name: istiod
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 spec:
@@ -45,6 +46,7 @@ kind: ClusterRole
 metadata:
   name: istio-galley-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 rules:
   # For reading Istio resources
@@ -97,6 +99,7 @@ kind: ClusterRole
 metadata:
   name: istio-pilot-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     release: istio
 rules:
@@ -140,6 +143,7 @@ kind: ClusterRole
 metadata:
   name: istiod-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 rules:
@@ -214,6 +218,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istio-pilot-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     release: istio
 roleRef:
@@ -232,6 +237,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istiod-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 roleRef:
@@ -334,6 +340,7 @@ data:
 kind: ConfigMap
 metadata:
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
   name: istio
   namespace: istio-system
@@ -347,6 +354,7 @@ metadata:
   name: istiod
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     istio: pilot
     release: istio
@@ -535,6 +543,7 @@ kind: "MeshPolicy"
 metadata:
   name: "default"
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 spec:
   peers:
@@ -549,6 +558,7 @@ metadata:
   name: istio-sidecar-injector
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 data:
 
@@ -1169,6 +1179,7 @@ metadata:
   name: istio-sidecar-injector
 
   labels:
+    operator.istio.io/managed: Reconcile
     app: sidecar-injector
     release: istio
 webhooks:
@@ -1197,6 +1208,7 @@ metadata:
   name: istiod-
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
     istio: pilot
@@ -1216,6 +1228,7 @@ metadata:
   name: istio-pilot
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     release: istio
     istio: pilot
@@ -1245,6 +1258,7 @@ metadata:
   name: istiod
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 spec:
@@ -1268,6 +1282,7 @@ metadata:
   name: istiod-service-account
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 ---
@@ -1276,6 +1291,8 @@ metadata:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: metadata-exchange-1.4
   namespace: istio-system
 spec:
@@ -1306,6 +1323,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: stats-filter-1.4
   namespace: istio-system
 spec:
@@ -1400,6 +1419,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: metadata-exchange-1.5
   namespace: istio-system
 spec:
@@ -1434,6 +1455,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-metadata-exchange-1.5
   namespace: istio-system
 spec:
@@ -1488,6 +1511,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: stats-filter-1.5
   namespace: istio-system
 spec:
@@ -1594,6 +1619,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-stats-filter-1.5
   namespace: istio-system
 spec:
@@ -1694,6 +1721,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: metadata-exchange-1.6
   namespace: istio-system
 spec:
@@ -1728,6 +1757,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-metadata-exchange-1.6
   namespace: istio-system
 spec:
@@ -1782,6 +1813,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: stats-filter-1.6
   namespace: istio-system
 spec:
@@ -1888,6 +1921,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-stats-filter-1.6
   namespace: istio-system
 spec:
@@ -1991,6 +2026,7 @@ metadata:
   name: istiod-istio-system
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
     istio: istiod
@@ -2030,6 +2066,7 @@ metadata:
   name: istio-galley
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: galley
     release: istio
     istio: galley

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.golden.yaml
@@ -11,6 +11,7 @@ kind: ClusterRole
 metadata:
   name: prometheus-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 rules:
@@ -36,6 +37,7 @@ kind: ClusterRoleBinding
 metadata:
   name: prometheus-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 roleRef:
@@ -55,6 +57,7 @@ metadata:
   name: prometheus
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 data:
@@ -308,6 +311,7 @@ metadata:
   name: prometheus
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 spec:
@@ -513,6 +517,7 @@ metadata:
   annotations:
     prometheus.io/scrape: 'true'
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 spec:
@@ -531,6 +536,7 @@ metadata:
   name: prometheus
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 ---
@@ -545,6 +551,7 @@ kind: ClusterRole
 metadata:
   name: istio-reader-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-reader
     release: istio
 rules:
@@ -570,6 +577,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istio-reader-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-reader
     release: istio
 roleRef:
@@ -589,6 +597,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-citadel
     chart: istio
     heritage: Tiller
@@ -1315,6 +1324,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-citadel
     chart: istio
     heritage: Tiller
@@ -2041,6 +2051,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-mixer
     chart: istio
     heritage: Tiller
@@ -2253,6 +2264,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-mixer
     chart: istio
     heritage: Tiller
@@ -2347,6 +2359,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-mixer
     chart: istio
     heritage: Tiller
@@ -2432,6 +2445,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-mixer
     chart: istio
     heritage: Tiller
@@ -2513,6 +2527,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -3502,6 +3517,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -3799,6 +3815,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -3951,6 +3968,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -4100,6 +4118,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -4381,6 +4400,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -5099,6 +5119,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -5176,6 +5197,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -5341,6 +5363,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -5404,6 +5427,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -5560,6 +5584,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -5648,6 +5673,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -5737,6 +5763,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -5849,6 +5876,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     chart: istio
     heritage: Tiller
@@ -6052,6 +6080,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -6252,6 +6281,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -6329,6 +6359,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-pilot
     chart: istio
     heritage: Tiller
@@ -6434,6 +6465,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
   name: adapters.config.istio.io
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     package: adapter
     istio: mixer-adapter
@@ -6466,6 +6498,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
   name: templates.config.istio.io
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     package: template
     istio: mixer-template
@@ -6498,6 +6531,7 @@ kind: Namespace
 metadata:
   name: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     istio-operator-managed: Reconcile
     istio-injection: disabled
 ---
@@ -6509,6 +6543,7 @@ metadata:
   name: istio-reader-service-account
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-reader
     release: istio
 ---
@@ -6527,6 +6562,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     release: istio
@@ -6552,6 +6588,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     release: istio
@@ -6794,6 +6831,7 @@ metadata:
   name: ingressgateway
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 spec:
   selector:
@@ -6815,6 +6853,7 @@ metadata:
   name: ingressgateway
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     
@@ -6836,6 +6875,7 @@ metadata:
   name: istio-ingressgateway-sds
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 rules:
 - apiGroups: [""]
@@ -6850,6 +6890,7 @@ metadata:
   name: istio-ingressgateway-sds
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -6868,6 +6909,7 @@ metadata:
   namespace: istio-system
   annotations:
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     
@@ -6920,6 +6962,7 @@ metadata:
   name: istio-ingressgateway-service-account
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     
@@ -6933,6 +6976,7 @@ metadata:
   name: default
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 spec:
   egress:
@@ -6948,6 +6992,7 @@ metadata:
   name: istiod
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 spec:
@@ -6970,6 +7015,7 @@ kind: ClusterRole
 metadata:
   name: istio-galley-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 rules:
   # For reading Istio resources
@@ -7022,6 +7068,7 @@ kind: ClusterRole
 metadata:
   name: istio-pilot-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     release: istio
 rules:
@@ -7065,6 +7112,7 @@ kind: ClusterRole
 metadata:
   name: istiod-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 rules:
@@ -7139,6 +7187,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istio-pilot-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     release: istio
 roleRef:
@@ -7157,6 +7206,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istiod-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 roleRef:
@@ -7176,6 +7226,7 @@ metadata:
   name: istio
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 data:
 
@@ -7341,6 +7392,7 @@ metadata:
   name: istiod
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     istio: pilot
     release: istio
@@ -7529,6 +7581,7 @@ kind: "MeshPolicy"
 metadata:
   name: "default"
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 spec:
   peers:
@@ -7543,6 +7596,7 @@ metadata:
   name: istio-sidecar-injector
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 data:
 
@@ -8163,6 +8217,7 @@ metadata:
   name: istio-sidecar-injector
 
   labels:
+    operator.istio.io/managed: Reconcile
     app: sidecar-injector
     release: istio
 webhooks:
@@ -8191,6 +8246,7 @@ metadata:
   name: istiod-
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
     istio: pilot
@@ -8210,6 +8266,7 @@ metadata:
   name: istio-pilot
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     release: istio
     istio: pilot
@@ -8239,6 +8296,7 @@ metadata:
   name: istiod
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 spec:
@@ -8262,6 +8320,7 @@ metadata:
   name: istiod-service-account
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 ---
@@ -8270,6 +8329,8 @@ metadata:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: metadata-exchange-1.4
   namespace: istio-system
 spec:
@@ -8300,6 +8361,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: stats-filter-1.4
   namespace: istio-system
 spec:
@@ -8394,6 +8457,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: metadata-exchange-1.5
   namespace: istio-system
 spec:
@@ -8428,6 +8493,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-metadata-exchange-1.5
   namespace: istio-system
 spec:
@@ -8482,6 +8549,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: stats-filter-1.5
   namespace: istio-system
 spec:
@@ -8588,6 +8657,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-stats-filter-1.5
   namespace: istio-system
 spec:
@@ -8688,6 +8759,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: metadata-exchange-1.6
   namespace: istio-system
 spec:
@@ -8722,6 +8795,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-metadata-exchange-1.6
   namespace: istio-system
 spec:
@@ -8776,6 +8851,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: stats-filter-1.6
   namespace: istio-system
 spec:
@@ -8882,6 +8959,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-stats-filter-1.6
   namespace: istio-system
 spec:
@@ -8985,6 +9064,7 @@ metadata:
   name: istiod-istio-system
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
     istio: istiod
@@ -9024,6 +9104,7 @@ metadata:
   name: istio-galley
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: galley
     release: istio
     istio: galley

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_values_enable_egressgateway.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_values_enable_egressgateway.golden.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: istio-system
   annotations:
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-egressgateway
     istio: egressgateway
     

--- a/operator/cmd/mesh/testdata/manifest-generate/output/gateways.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/gateways.golden.yaml
@@ -25,6 +25,7 @@ metadata:
   name: istio-ingressgateway
   namespace: istio-ingress-1-ns
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     
@@ -48,6 +49,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     release: istio
@@ -285,6 +287,7 @@ metadata:
   name: ingressgateway
   namespace: istio-ingress-1-ns
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 spec:
   selector:
@@ -306,6 +309,7 @@ metadata:
   name: ingressgateway
   namespace: istio-ingress-1-ns
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     
@@ -327,6 +331,7 @@ metadata:
   name: istio-ingressgateway-sds
   namespace: istio-ingress-1-ns
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 rules:
 - apiGroups: [""]
@@ -341,6 +346,7 @@ metadata:
   name: istio-ingressgateway-sds
   namespace: istio-ingress-1-ns
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -359,6 +365,7 @@ metadata:
   namespace: istio-ingress-1-ns
   annotations:
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     
@@ -411,6 +418,7 @@ metadata:
   name: istio-ingressgateway-service-account
   namespace: istio-ingress-1-ns
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     
@@ -424,6 +432,7 @@ metadata:
   name: default
   namespace: istio-ingress-1-ns
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 spec:
   egress:
@@ -440,6 +449,7 @@ metadata:
   name: istio-ingressgateway
   namespace: istio-ingress-2-ns
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     
@@ -465,6 +475,7 @@ metadata:
   name: istio-ingressgateway
   namespace: istio-ingress-2-ns
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     
@@ -704,6 +715,7 @@ metadata:
   name: ingressgateway
   namespace: istio-ingress-2-ns
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 spec:
   selector:
@@ -725,6 +737,7 @@ metadata:
   name: ingressgateway
   namespace: istio-ingress-2-ns
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     
@@ -746,6 +759,7 @@ metadata:
   name: istio-ingressgateway-sds
   namespace: istio-ingress-2-ns
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 rules:
 - apiGroups: [""]
@@ -760,6 +774,7 @@ metadata:
   name: istio-ingressgateway-sds
   namespace: istio-ingress-2-ns
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -778,6 +793,7 @@ metadata:
   namespace: istio-ingress-2-ns
   annotations:
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     
@@ -830,6 +846,7 @@ metadata:
   name: istio-ingressgateway-service-account
   namespace: istio-ingress-2-ns
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     
@@ -843,6 +860,7 @@ metadata:
   name: default
   namespace: istio-ingress-2-ns
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 spec:
   egress:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/gateways_override_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/gateways_override_default.golden.yaml
@@ -11,6 +11,7 @@ kind: ClusterRole
 metadata:
   name: prometheus-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 rules:
@@ -36,6 +37,7 @@ kind: ClusterRoleBinding
 metadata:
   name: prometheus-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 roleRef:
@@ -55,6 +57,7 @@ metadata:
   name: prometheus
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 data:
@@ -308,6 +311,7 @@ metadata:
   name: prometheus
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 spec:
@@ -513,6 +517,7 @@ metadata:
   annotations:
     prometheus.io/scrape: 'true'
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 spec:
@@ -531,6 +536,7 @@ metadata:
   name: prometheus
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 ---
@@ -559,6 +565,7 @@ metadata:
   name: istio-ingressgateway
   namespace: istio-ingress-ns
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     
@@ -582,6 +589,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     release: istio
@@ -821,6 +829,7 @@ metadata:
   name: ingressgateway
   namespace: istio-ingress-ns
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 spec:
   selector:
@@ -842,6 +851,7 @@ metadata:
   name: ingressgateway
   namespace: istio-ingress-ns
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     
@@ -863,6 +873,7 @@ metadata:
   name: istio-ingressgateway-sds
   namespace: istio-ingress-ns
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 rules:
 - apiGroups: [""]
@@ -877,6 +888,7 @@ metadata:
   name: istio-ingressgateway-sds
   namespace: istio-ingress-ns
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -895,6 +907,7 @@ metadata:
   namespace: istio-ingress-ns
   annotations:
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     
@@ -947,6 +960,7 @@ metadata:
   name: istio-ingressgateway-service-account
   namespace: istio-ingress-ns
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     
@@ -960,6 +974,7 @@ metadata:
   name: default
   namespace: istio-ingress-ns
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 spec:
   egress:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/helm_values_enablement.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/helm_values_enablement.golden.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-egressgateway
     istio: egressgateway
     release: istio
@@ -227,6 +228,7 @@ metadata:
   name: kiali
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: kiali
     release: istio
 spec:
@@ -342,6 +344,7 @@ metadata:
   namespace: istio-system
   annotations:
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-egressgateway
     istio: egressgateway
     
@@ -372,6 +375,7 @@ metadata:
   name: kiali
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: kiali
     release: istio
 spec:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/ingressgateway_k8s_settings.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/ingressgateway_k8s_settings.golden.yaml
@@ -4,6 +4,7 @@ metadata:
   name: istio-ingressgateway
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     
@@ -247,6 +248,7 @@ kind: Service
 metadata:
   annotations: null
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-ingressgateway
     istio: ingressgateway
     release: istio

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -23,6 +23,7 @@ metadata:
   name: istiod
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 spec:
@@ -45,6 +46,7 @@ kind: ClusterRole
 metadata:
   name: istio-galley-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 rules:
   # For reading Istio resources
@@ -97,6 +99,7 @@ kind: ClusterRole
 metadata:
   name: istio-pilot-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     release: istio
 rules:
@@ -140,6 +143,7 @@ kind: ClusterRole
 metadata:
   name: istiod-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 rules:
@@ -214,6 +218,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istio-pilot-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     release: istio
 roleRef:
@@ -232,6 +237,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istiod-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 roleRef:
@@ -334,6 +340,7 @@ data:
 kind: ConfigMap
 metadata:
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
   name: istio
   namespace: istio-system
@@ -347,6 +354,7 @@ metadata:
   name: istiod
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     istio: pilot
     release: istio
@@ -535,6 +543,7 @@ kind: "MeshPolicy"
 metadata:
   name: "default"
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 spec:
   peers:
@@ -549,6 +558,7 @@ metadata:
   name: istio-sidecar-injector
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 data:
 
@@ -1169,6 +1179,7 @@ metadata:
   name: istio-sidecar-injector
 
   labels:
+    operator.istio.io/managed: Reconcile
     app: sidecar-injector
     release: istio
 webhooks:
@@ -1197,6 +1208,7 @@ metadata:
   name: istiod-
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
     istio: pilot
@@ -1216,6 +1228,7 @@ metadata:
   name: istio-pilot
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     release: istio
     istio: pilot
@@ -1245,6 +1258,7 @@ metadata:
   name: istiod
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 spec:
@@ -1268,6 +1282,7 @@ metadata:
   name: istiod-service-account
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 ---
@@ -1276,6 +1291,8 @@ metadata:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: metadata-exchange-1.4
   namespace: istio-system
 spec:
@@ -1306,6 +1323,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: stats-filter-1.4
   namespace: istio-system
 spec:
@@ -1400,6 +1419,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: metadata-exchange-1.5
   namespace: istio-system
 spec:
@@ -1434,6 +1455,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-metadata-exchange-1.5
   namespace: istio-system
 spec:
@@ -1488,6 +1511,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: stats-filter-1.5
   namespace: istio-system
 spec:
@@ -1594,6 +1619,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-stats-filter-1.5
   namespace: istio-system
 spec:
@@ -1694,6 +1721,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: metadata-exchange-1.6
   namespace: istio-system
 spec:
@@ -1728,6 +1757,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-metadata-exchange-1.6
   namespace: istio-system
 spec:
@@ -1782,6 +1813,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: stats-filter-1.6
   namespace: istio-system
 spec:
@@ -1888,6 +1921,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-stats-filter-1.6
   namespace: istio-system
 spec:
@@ -1991,6 +2026,7 @@ metadata:
   name: istiod-istio-system
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
     istio: istiod
@@ -2030,6 +2066,7 @@ metadata:
   name: istio-galley
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: galley
     release: istio
     istio: galley

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.golden.yaml
@@ -23,6 +23,7 @@ metadata:
   name: istiod
   namespace: istio-control
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 spec:
@@ -45,6 +46,7 @@ kind: ClusterRole
 metadata:
   name: istio-galley-istio-control
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 rules:
   # For reading Istio resources
@@ -97,6 +99,7 @@ kind: ClusterRole
 metadata:
   name: istio-pilot-istio-control
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     release: istio
 rules:
@@ -140,6 +143,7 @@ kind: ClusterRole
 metadata:
   name: istiod-istio-control
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 rules:
@@ -214,6 +218,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istio-pilot-istio-control
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     release: istio
 roleRef:
@@ -232,6 +237,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istiod-istio-control
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 roleRef:
@@ -334,6 +340,7 @@ data:
 kind: ConfigMap
 metadata:
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
   name: istio
   namespace: istio-control
@@ -347,6 +354,7 @@ metadata:
   name: istiod
   namespace: istio-control
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     istio: pilot
     release: istio
@@ -535,6 +543,7 @@ kind: "MeshPolicy"
 metadata:
   name: "default"
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 spec:
   peers:
@@ -549,6 +558,7 @@ metadata:
   name: istio-sidecar-injector
   namespace: istio-control
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 data:
 
@@ -1168,6 +1178,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: istio-sidecar-injector-istio-control
   labels:
+    operator.istio.io/managed: Reconcile
     app: sidecar-injector
     release: istio
 webhooks:
@@ -1196,6 +1207,7 @@ metadata:
   name: istiod-
   namespace: istio-control
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
     istio: pilot
@@ -1215,6 +1227,7 @@ metadata:
   name: istio-pilot
   namespace: istio-control
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     release: istio
     istio: pilot
@@ -1244,6 +1257,7 @@ metadata:
   name: istiod
   namespace: istio-control
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 spec:
@@ -1267,6 +1281,7 @@ metadata:
   name: istiod-service-account
   namespace: istio-control
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
 ---
@@ -1275,6 +1290,8 @@ metadata:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: metadata-exchange-1.4
   namespace: istio-control
 spec:
@@ -1305,6 +1322,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: stats-filter-1.4
   namespace: istio-control
 spec:
@@ -1399,6 +1418,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: metadata-exchange-1.5
   namespace: istio-control
 spec:
@@ -1433,6 +1454,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-metadata-exchange-1.5
   namespace: istio-control
 spec:
@@ -1487,6 +1510,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: stats-filter-1.5
   namespace: istio-control
 spec:
@@ -1593,6 +1618,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-stats-filter-1.5
   namespace: istio-control
 spec:
@@ -1693,6 +1720,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: metadata-exchange-1.6
   namespace: istio-control
 spec:
@@ -1727,6 +1756,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-metadata-exchange-1.6
   namespace: istio-control
 spec:
@@ -1781,6 +1812,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: stats-filter-1.6
   namespace: istio-control
 spec:
@@ -1887,6 +1920,8 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  labels:
+    operator.istio.io/managed: Reconcile
   name: tcp-stats-filter-1.6
   namespace: istio-control
 spec:
@@ -1990,6 +2025,7 @@ metadata:
   name: istiod-istio-control
   namespace: istio-control
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     release: istio
     istio: istiod
@@ -2029,6 +2065,7 @@ metadata:
   name: istio-galley
   namespace: istio-control
   labels:
+    operator.istio.io/managed: Reconcile
     app: galley
     release: istio
     istio: galley

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_merge_meshconfig.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_merge_meshconfig.golden.yaml
@@ -90,6 +90,7 @@ data:
 kind: ConfigMap
 metadata:
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
   name: istio
   namespace: istio-system

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_kubernetes.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_kubernetes.golden.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     istio: pilot
     release: istio
@@ -183,6 +184,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    operator.istio.io/managed: Reconcile
     app: pilot
     istio: pilot
     release: istio

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_values.golden.yaml
@@ -4,6 +4,7 @@ metadata:
   name: istiod
   namespace: istio-control
   labels:
+    operator.istio.io/managed: Reconcile
     app: istiod
     istio: pilot
     release: istio

--- a/operator/cmd/mesh/testdata/manifest-generate/output/prometheus.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/prometheus.golden.yaml
@@ -11,6 +11,7 @@ kind: ClusterRole
 metadata:
   name: prometheus-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 rules:
@@ -36,6 +37,7 @@ kind: ClusterRoleBinding
 metadata:
   name: prometheus-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 roleRef:
@@ -55,6 +57,7 @@ metadata:
   name: prometheus
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 data:
@@ -308,6 +311,7 @@ metadata:
   name: prometheus
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 spec:
@@ -513,6 +517,7 @@ metadata:
   annotations:
     prometheus.io/scrape: 'true'
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 spec:
@@ -531,6 +536,7 @@ metadata:
   name: prometheus
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: prometheus
     release: istio
 ---

--- a/operator/cmd/mesh/testdata/manifest-generate/output/telemetry_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/telemetry_default.golden.yaml
@@ -27,6 +27,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     release: istio
   name: istio-telemetry
@@ -52,6 +53,7 @@ kind: ClusterRole
 metadata:
   name: istio-mixer-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 rules:
@@ -75,6 +77,7 @@ kind: ClusterRoleBinding
 metadata:
   name: istio-mixer-admin-role-binding-istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 roleRef:
@@ -94,6 +97,7 @@ metadata:
   name: istioproxy
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -236,6 +240,7 @@ metadata:
   name: kubernetes
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -301,6 +306,7 @@ metadata:
   name: requestcount
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -337,6 +343,7 @@ metadata:
   name: requestduration
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -373,6 +380,7 @@ metadata:
   name: requestsize
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -409,6 +417,7 @@ metadata:
   name: responsesize
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -445,6 +454,7 @@ metadata:
   name: tcpbytesent
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -478,6 +488,7 @@ metadata:
   name: tcpbytereceived
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -511,6 +522,7 @@ metadata:
   name: tcpconnectionsopened
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -544,6 +556,7 @@ metadata:
   name: tcpconnectionsclosed
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -577,6 +590,7 @@ metadata:
   name: prometheus
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -779,6 +793,7 @@ metadata:
   name: promhttp
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -799,6 +814,7 @@ metadata:
   name: promtcp
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -817,6 +833,7 @@ metadata:
   name: promtcpconnectionopen
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -834,6 +851,7 @@ metadata:
   name: promtcpconnectionclosed
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -851,6 +869,7 @@ metadata:
   name: kubernetesenv
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -871,6 +890,7 @@ metadata:
   name: kubeattrgenrulerule
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -887,6 +907,7 @@ metadata:
   name: tcpkubeattrgenrulerule
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -904,6 +925,7 @@ metadata:
   name: attributes
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -947,6 +969,7 @@ metadata:
   name: istio-telemetry
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:
@@ -974,6 +997,7 @@ metadata:
   namespace: istio-system
   name: telemetry-envoy-config
   labels:
+    operator.istio.io/managed: Reconcile
     release: istio
 data:
   # Explicitly defined - moved from istio/istio/pilot/docker.
@@ -1259,6 +1283,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-mixer
     istio: mixer
     release: istio
@@ -1394,6 +1419,7 @@ metadata:
   name: istio-telemetry
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: telemetry
     release: istio
     istio: mixer
@@ -1414,6 +1440,7 @@ metadata:
   name: istio-telemetry
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     istio: mixer
     release: istio
@@ -1439,6 +1466,7 @@ metadata:
   name: istio-mixer-service-account
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 ---

--- a/operator/cmd/mesh/testdata/manifest-generate/output/telemetry_k8s_settings.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/telemetry_k8s_settings.golden.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-mixer
     istio: mixer
     release: istio
@@ -145,6 +146,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   labels:
+    operator.istio.io/managed: Reconcile
     app: mixer
     release: istio
   name: istio-telemetry

--- a/operator/cmd/mesh/testdata/manifest-generate/output/telemetry_override_kubernetes.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/telemetry_override_kubernetes.golden.yaml
@@ -2,6 +2,7 @@ apiVersion: config.istio.io/v1alpha2
 kind: handler
 metadata:
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
   name: prometheus
@@ -215,6 +216,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-mixer
     istio: mixer
     release: istio

--- a/operator/cmd/mesh/testdata/manifest-generate/output/telemetry_override_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/telemetry_override_values.golden.yaml
@@ -4,6 +4,7 @@ metadata:
   name: prometheus
   namespace: istio-system
   labels:
+    operator.istio.io/managed: Reconcile
     app: istio-telemetry
     release: istio
 spec:

--- a/operator/pkg/util/path.go
+++ b/operator/pkg/util/path.go
@@ -76,6 +76,63 @@ func (p Path) String() string {
 	return strings.Join(p, PathSeparator)
 }
 
+// Push adds elem to the end of p.
+func (p *Path) Push(elem string) {
+	*p = append(*p, elem)
+}
+
+// Pop removes the last element from p, or does nothing if p is empty.
+func (p *Path) Pop() {
+	if len(*p) == 0 {
+		return
+	}
+	*p = (*p)[:len(*p)-1]
+}
+
+// UpdateLastElem updates the last element of path
+func (p *Path) UpdateLastElem(newElem string) {
+	if len(*p) == 0 {
+		*p = append(*p, newElem)
+		return
+	}
+	(*p)[len(*p)-1] = newElem
+}
+
+// Last returns the last element of p or empty string is path is empty.
+func (p *Path) Last() string {
+	if len(*p) == 0 {
+		return ""
+	}
+	return (*p)[len(*p)-1]
+}
+
+// Copy copies the path in from into p.
+func (p *Path) Copy(from Path) {
+	*p = make(Path, len(from))
+	copy(*p, from)
+}
+
+// Equals reports whether p is equal to other.
+func (p *Path) Equals(other Path) bool {
+	if len(*p) != len(other) {
+		return false
+	}
+	for i, v := range *p {
+		if v != other[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// AppendPath appends newElem to p and returns the new Path. If newElem is empty, it returns p.
+func AppendPath(p Path, newElem string) Path {
+	if newElem == "" {
+		return p
+	}
+	return append(p, newElem)
+}
+
 // ToYAMLPath converts a path string to path such that the first letter of each path element is lower case.
 func ToYAMLPath(path string) Path {
 	p := PathFromString(path)
@@ -87,7 +144,8 @@ func ToYAMLPath(path string) Path {
 
 // ToYAMLPathString converts a path string such that the first letter of each path element is lower case.
 func ToYAMLPathString(path string) string {
-	return ToYAMLPath(path).String()
+	p := ToYAMLPath(path)
+	return p.String()
 }
 
 // IsValidPathElement reports whether pe is a valid path element.

--- a/operator/pkg/util/yaml_text.go
+++ b/operator/pkg/util/yaml_text.go
@@ -1,0 +1,369 @@
+/*
+yaml_text.go provides tools for adding/replacing YAML paths which preserves key ordering and all file decorations
+like comments and whitespace.
+*/
+
+package util
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/ghodss/yaml"
+
+	"istio.io/pkg/log"
+)
+
+const (
+	yamlSeparator = "---"
+)
+
+var (
+	// tabSize is the global tab size for the YAML text being processed.
+	tabSize      = 0
+	commentRegex = regexp.MustCompile("#")
+)
+
+// Rule is a YAML text processing rule. Rule lists are applied sequentially, first to last.
+// The default rule action is to add after the matching path.
+type Rule struct {
+	// Path is the path that the rule applies to.
+	Path Path
+	// Op is the operation to perform on the matching path.
+	Op Op
+	// Position is the position to apply the operation, relative to the matching line.
+	Position Position
+	// Key is the key to add, for add operations.
+	Key string
+	// Val is the value to add, for add operations.
+	Val string
+}
+
+// Position indicates a relative position for text insertion.
+type Position int
+
+const (
+	AFTER Position = iota
+	AT
+	BEFORE
+)
+
+// Op is an add/replace/delete operation type.
+type Op int
+
+const (
+	ADD Op = iota
+	REPLACE
+	// TODO: implement DELETE
+)
+
+// pathChange tracks whether a path has become shorted, longer or is unchanged.
+type pathChange int
+
+const (
+	NONE pathChange = iota
+	PUSH
+	POP
+)
+
+// state tracks internal text processing state.
+type state struct {
+	path, prevPath Path
+	pathChange     pathChange
+	indent         int
+}
+
+func newState() *state {
+	return &state{
+		// -ve indent means we haven't hit the object root yet.
+		indent: -1 * tabSize,
+	}
+}
+
+// ProcessYAMLText applies the given rules in the given order to the given manifest string and returns the resulting
+// manifest.
+func ProcessYAMLText(manifest string, rules []*Rule) (string, error) {
+	if isEmptyManifest(manifest) {
+		return manifest, nil
+	}
+	var err error
+	tabSize, err = detectTabSize(manifest)
+	if err != nil {
+		return "", err
+	}
+	ymls, err := splitManifest(manifest)
+	if err != nil {
+		return "", err
+	}
+
+	var newYamls []string
+	for _, yml := range ymls {
+		var newYaml []string
+		// Tree is required to know whether a path already exists somewhere in the resource.
+		tree := make(map[string]interface{})
+		if err := yaml.Unmarshal([]byte(yml), &tree); err != nil {
+			return "", err
+		}
+		for _, r := range rules {
+			newYaml = []string{}
+			s := newState()
+			lprev := ""
+			for _, l := range strings.Split(yml, "\n") {
+				// Preprocess the line to handle comments and whitespace.
+				lc := removeComments(l)
+				if spaceOnly(lc) {
+					newYaml = append(newYaml, l)
+					continue
+				}
+
+				// Update indent state.
+				s.indent = numLeadingSpaces(lc)
+				indentJump, err := getIndentJump(lprev, lc)
+				if err != nil {
+					return "", fmt.Errorf("indentation problem: %s\n%s\n%s", err, lprev, l)
+				}
+
+				// ProcessYAMLText key-value.
+				k, _ := getKV(l)
+
+				// Update the path.
+				s.pathChange, err = updatePath(s, indentJump, k)
+				if err != nil {
+					return "", err
+				}
+
+				// Apply the rule if it matches.
+				newLines, op, position := applyRule(tree, r, s, l)
+
+				var writeLines []string
+				switch op {
+				case ADD:
+					switch position {
+					case BEFORE:
+						writeLines = append(newLines, l)
+					case AFTER:
+						writeLines = append([]string{l}, newLines...)
+					default:
+						return "", fmt.Errorf("unsupported position %v for operation %v", position, op)
+					}
+				case REPLACE:
+					switch position {
+					case AT:
+						writeLines = newLines
+					default:
+						return "", fmt.Errorf("unsupported position %v for operation %v", position, op)
+					}
+
+				default:
+					return "", fmt.Errorf("illegal operation %v", op)
+				}
+				newYaml = append(newYaml, writeLines...)
+				lprev = l
+			}
+			yml = strings.Join(newYaml, "\n")
+		}
+		newYamls = append(newYamls, strings.Join(newYaml, "\n"))
+	}
+
+	return strings.Join(newYamls, yamlSeparator+"\n"), nil
+}
+
+// isEmptyManifest reports whether the given manifest contains any YAML data. Comments and whitespace are excluded
+// before the check.
+func isEmptyManifest(manifest string) bool {
+	for _, l := range strings.Split(manifest, "\n") {
+		// Preprocess the line to handle comments and whitespace.
+		if strings.TrimSpace(removeComments(l)) != "" {
+			return false
+		}
+	}
+	return true
+}
+
+// detectTabSize attempts to detect the tab size (number of spaces per indent block) in the given YAML manifest.
+// No checking for spacing errors or consistency is performed; it is assumed that the given manifest has correct,
+// consistent spacing.
+func detectTabSize(manifest string) (int, error) {
+	yamls, err := splitManifest(manifest)
+	if err != nil {
+		return 0, err
+	}
+	for _, yaml := range yamls {
+		indent := 0
+		for _, l := range strings.Split(yaml, "\n") {
+			lc := removeComments(l)
+			if spaceOnly(lc) {
+				continue
+			}
+			newIndent := numLeadingSpaces(lc)
+			if newIndent > indent {
+				return newIndent, nil
+			}
+		}
+	}
+	return 0, fmt.Errorf("could not detect tab size in manifest")
+}
+
+// splitManifest splits the given manifest into a slice of individual YAML blocks.
+func splitManifest(manifest string) ([]string, error) {
+	var b bytes.Buffer
+
+	var yamls []string
+	scanner := bufio.NewScanner(strings.NewReader(manifest))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.TrimSpace(line) == yamlSeparator {
+			// yaml separator
+			yamls = append(yamls, b.String())
+			b.Reset()
+		} else {
+			if _, err := b.WriteString(line); err != nil {
+				return nil, err
+			}
+			if _, err := b.WriteString("\n"); err != nil {
+				return nil, err
+			}
+		}
+	}
+	yamls = append(yamls, b.String())
+	return yamls, nil
+}
+
+// applyRule applies the given rule to the given line and returns a slice of strings that should be written at the
+// given position in the manifest with the given operation.
+func applyRule(tree map[string]interface{}, r *Rule, s *state, line string) ([]string, Op, Position) {
+	if !s.path.Equals(r.Path) {
+		// If rule doesn't match, replace the current line with itself.
+		return []string{line}, REPLACE, AT
+	}
+	if r.Op == ADD && hasPath(tree, AppendPath(r.Path, r.Key)) {
+		// If path is already in the tree, replace the current line with itself.
+		return []string{line}, REPLACE, AT
+	}
+	vv := strings.Split(r.Val, "\n")
+	var ns []string
+	pad := padStr(s.indent, 1)
+	padNext := padStr(s.indent, 2)
+	key := r.Key
+	if r.Op == REPLACE {
+		key = s.path.Last()
+		pad = padStr(s.indent, 0)
+	}
+	switch {
+	case r.Val == "":
+		ns = []string{fmt.Sprintf("%s%s:", pad, key)}
+	case len(vv) == 1:
+		ns = []string{fmt.Sprintf("%s%s: %s", pad, key, r.Val)}
+	case len(vv) > 1:
+		ns = []string{fmt.Sprintf("%s%s:", pad, s.path.Last())}
+		for _, v := range vv {
+			ns = append(ns, fmt.Sprintf("%s%s", padNext, v))
+		}
+	}
+	return ns, r.Op, r.Position
+}
+
+// updatePath updates the state path with the given key and indentation jump.
+func updatePath(s *state, indentJump int, key string) (pathChange, error) {
+	ret := NONE
+	s.prevPath.Copy(s.path)
+	switch {
+	case indentJump == 0:
+		s.path.UpdateLastElem(key)
+		ret = NONE
+	case indentJump >= 1:
+		s.path.Push(key)
+		ret = PUSH
+	default:
+		for i := 0; i < -1*indentJump; i++ {
+			s.path.Pop()
+		}
+		s.path.UpdateLastElem(key)
+		ret = POP
+	}
+
+	return ret, nil
+}
+
+// hasPath reports whether the given tree has the given path.
+func hasPath(tree map[string]interface{}, path Path) bool {
+	if len(path) == 0 {
+		return true
+	}
+	if IsValueNil(tree) {
+		return false
+	}
+	ni, ok := tree[path[0]]
+	if !ok {
+		return false
+	}
+	if len(path) == 1 {
+		return true
+	}
+
+	n, ok := ni.(map[string]interface{})
+	if !ok {
+		return false
+	}
+
+	return hasPath(n, path[1:])
+}
+
+// spaceOnly reports whether s contains only whitespace.
+func spaceOnly(s string) bool {
+	return len(strings.TrimSpace(s)) == 0
+}
+
+// removeComments returns s with anything after and including the first # character removed.
+func removeComments(s string) string {
+	iv := commentRegex.FindIndex([]byte(s))
+	if iv == nil {
+		return s
+	}
+	return s[:iv[0]]
+}
+
+// getIndentJump returns the number of indentation jumps between old and new indents. It returns an error if the
+// positive indentation change is not one tab size.
+func getIndentJump(oldLine, newLine string) (int, error) {
+	oldIndent := numLeadingSpaces(oldLine)
+	newIndent := numLeadingSpaces(newLine)
+	if (newIndent-oldIndent)%tabSize != 0 {
+		log.Warnf("bad indent change of %d:\n%s\n%s", newIndent-oldIndent, oldLine, newLine)
+	}
+	indentJump := (newIndent - oldIndent) / tabSize
+	return indentJump, nil
+}
+
+// getKV returns the key / value pair in s if it contains one. If the line is
+// a list element, it returns null strings for both key and value.
+func getKV(inStr string) (string, string) {
+	s := strings.TrimSpace(inStr)
+	kv := strings.Split(s, ":")
+	if len(kv) == 1 {
+		return "", s
+	}
+	// If line contains more than one ':", assume it's an escaped value, not invalid YAML.
+	return strings.TrimSpace(kv[0]), strings.TrimSpace(strings.Join(kv[1:], ":"))
+}
+
+// numLeadingSpaces returns the number of leading spaces in the line of text s.
+func numLeadingSpaces(s string) int {
+	ret := 0
+	for _, c := range s {
+		if c == ' ' {
+			ret++
+		} else {
+			break
+		}
+	}
+	return ret
+}
+
+// padStr returns a string with the given indentation, plus the given number of tabs (using global tabSize).
+func padStr(indent, numTabs int) string {
+	return strings.Repeat(" ", indent+numTabs*tabSize)
+}

--- a/operator/pkg/util/yaml_text_test.go
+++ b/operator/pkg/util/yaml_text_test.go
@@ -1,0 +1,181 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/kylelemons/godebug/diff"
+)
+
+func TestProcessYAMLText(t *testing.T) {
+	testRules := []*Rule{
+		{
+			// Add "labels" key under "metadata" if it doesn't exist.
+			Path: PathFromString("metadata"),
+			Key:  "labels",
+		},
+		{
+			// Add "add-key: add-value" under "metadata.labels" if it doesn't exist.
+			Path: PathFromString("metadata.labels"),
+			Key:  "add-key",
+			Val:  "add-value",
+		},
+		{
+			// Replace value at "metadata.labels.replace" with "new-value".
+			Path:     PathFromString("metadata.labels.replace"),
+			Val:      "new-value",
+			Op:       REPLACE,
+			Position: AT,
+		},
+	}
+	tests := []struct {
+		desc  string
+		in    string
+		rules []*Rule
+		want  string
+	}{
+		{
+			desc:  "empty",
+			in:    "",
+			rules: testRules,
+			want:  "",
+		},
+		{
+			desc: "no labels",
+			in: `
+kind: ClusterRole
+metadata:
+  name: cr1
+rules: # comment
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - '*'
+`,
+			rules: testRules,
+			want: `
+kind: ClusterRole
+metadata:
+  labels:
+    add-key: add-value
+  name: cr1
+rules: # comment
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - '*'
+`,
+		},
+		{
+			desc: "has labels",
+			in: `
+kind: ClusterRole
+metadata:
+  labels:
+    aaa: bbb
+  name: cr1
+rules: # comment
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - '*'
+`,
+			rules: testRules,
+			want: `
+kind: ClusterRole
+metadata:
+  labels:
+    add-key: add-value
+    aaa: bbb
+  name: cr1
+rules: # comment
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - '*'
+`,
+		},
+		{
+			desc: "replace",
+			in: `
+kind: ClusterRole
+metadata:
+  labels:
+    replace: old-value
+  name: cr1
+`,
+			rules: testRules,
+			want: `
+kind: ClusterRole
+metadata:
+  labels:
+    add-key: add-value
+    replace: new-value
+  name: cr1
+`,
+		},
+		{
+			desc: "mixed manifest",
+			in: `
+kind: ClusterRole
+metadata:
+  name: cr1
+  labels:
+    abc: xyz
+rules: # comment
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - '*'
+---
+# comment
+---
+kind: ClusterRole
+metadata:
+  name: cr2
+rules:
+- apiGroups:  # comment
+  - networking.istio.io
+  resources:
+  - '*'
+`,
+			rules: testRules,
+			want: `
+kind: ClusterRole
+metadata:
+  name: cr1
+  labels:
+    add-key: add-value
+    abc: xyz
+rules: # comment
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - '*'
+---
+# comment
+---
+kind: ClusterRole
+metadata:
+  labels:
+    add-key: add-value
+  name: cr2
+rules:
+- apiGroups:  # comment
+  - networking.istio.io
+  resources:
+  - '*'
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got, err := ProcessYAMLText(tt.in, tt.rules)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Errorf("%s: got: \n%s\n\ndiff (-got, +want):\n%s", tt.desc, got, diff.Diff(got, tt.want))
+			}
+		})
+	}
+}

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -229,6 +229,7 @@ import (
 	"strings"
 	"time"
 )
+
 type asset struct {
 	bytes []byte
 	info  os.FileInfo
@@ -2683,7 +2684,7 @@ spec:
                                   format: string
                                   type: string
                                 clientCertificate:
-                                  description: REQUIRED if mode is `+"`"+`MUTUAL`+"`"+`.
+                                  description: REQUIRED if mode is ` + "`" + `MUTUAL` + "`" + `.
                                   format: string
                                   type: string
                                 mode:
@@ -2694,7 +2695,7 @@ spec:
                                   - ISTIO_MUTUAL
                                   type: string
                                 privateKey:
-                                  description: REQUIRED if mode is `+"`"+`MUTUAL`+"`"+`.
+                                  description: REQUIRED if mode is ` + "`" + `MUTUAL` + "`" + `.
                                   format: string
                                   type: string
                                 sni:
@@ -2718,7 +2719,7 @@ spec:
                             format: string
                             type: string
                           clientCertificate:
-                            description: REQUIRED if mode is `+"`"+`MUTUAL`+"`"+`.
+                            description: REQUIRED if mode is ` + "`" + `MUTUAL` + "`" + `.
                             format: string
                             type: string
                           mode:
@@ -2729,7 +2730,7 @@ spec:
                             - ISTIO_MUTUAL
                             type: string
                           privateKey:
-                            description: REQUIRED if mode is `+"`"+`MUTUAL`+"`"+`.
+                            description: REQUIRED if mode is ` + "`" + `MUTUAL` + "`" + `.
                             format: string
                             type: string
                           sni:
@@ -3134,7 +3135,7 @@ spec:
                             format: string
                             type: string
                           clientCertificate:
-                            description: REQUIRED if mode is `+"`"+`MUTUAL`+"`"+`.
+                            description: REQUIRED if mode is ` + "`" + `MUTUAL` + "`" + `.
                             format: string
                             type: string
                           mode:
@@ -3145,7 +3146,7 @@ spec:
                             - ISTIO_MUTUAL
                             type: string
                           privateKey:
-                            description: REQUIRED if mode is `+"`"+`MUTUAL`+"`"+`.
+                            description: REQUIRED if mode is ` + "`" + `MUTUAL` + "`" + `.
                             format: string
                             type: string
                           sni:
@@ -3169,7 +3170,7 @@ spec:
                       format: string
                       type: string
                     clientCertificate:
-                      description: REQUIRED if mode is `+"`"+`MUTUAL`+"`"+`.
+                      description: REQUIRED if mode is ` + "`" + `MUTUAL` + "`" + `.
                       format: string
                       type: string
                     mode:
@@ -3180,7 +3181,7 @@ spec:
                       - ISTIO_MUTUAL
                       type: string
                     privateKey:
-                      description: REQUIRED if mode is `+"`"+`MUTUAL`+"`"+`.
+                      description: REQUIRED if mode is ` + "`" + `MUTUAL` + "`" + `.
                       format: string
                       type: string
                     sni:
@@ -3575,7 +3576,7 @@ spec:
                       behavior.
                     properties:
                       caCertificates:
-                        description: REQUIRED if mode is `+"`"+`MUTUAL`+"`"+`.
+                        description: REQUIRED if mode is ` + "`" + `MUTUAL` + "`" + `.
                         format: string
                         type: string
                       cipherSuites:
@@ -3617,11 +3618,11 @@ spec:
                         - ISTIO_MUTUAL
                         type: string
                       privateKey:
-                        description: REQUIRED if mode is `+"`"+`SIMPLE`+"`"+` or `+"`"+`MUTUAL`+"`"+`.
+                        description: REQUIRED if mode is ` + "`" + `SIMPLE` + "`" + ` or ` + "`" + `MUTUAL` + "`" + `.
                         format: string
                         type: string
                       serverCertificate:
-                        description: REQUIRED if mode is `+"`"+`SIMPLE`+"`"+` or `+"`"+`MUTUAL`+"`"+`.
+                        description: REQUIRED if mode is ` + "`" + `SIMPLE` + "`" + ` or ` + "`" + `MUTUAL` + "`" + `.
                         format: string
                         type: string
                       subjectAltNames:
@@ -3869,7 +3870,7 @@ spec:
             inboundTls:
               properties:
                 caCertificates:
-                  description: REQUIRED if mode is `+"`"+`MUTUAL`+"`"+`.
+                  description: REQUIRED if mode is ` + "`" + `MUTUAL` + "`" + `.
                   format: string
                   type: string
                 cipherSuites:
@@ -3911,11 +3912,11 @@ spec:
                   - ISTIO_MUTUAL
                   type: string
                 privateKey:
-                  description: REQUIRED if mode is `+"`"+`SIMPLE`+"`"+` or `+"`"+`MUTUAL`+"`"+`.
+                  description: REQUIRED if mode is ` + "`" + `SIMPLE` + "`" + ` or ` + "`" + `MUTUAL` + "`" + `.
                   format: string
                   type: string
                 serverCertificate:
-                  description: REQUIRED if mode is `+"`"+`SIMPLE`+"`"+` or `+"`"+`MUTUAL`+"`"+`.
+                  description: REQUIRED if mode is ` + "`" + `SIMPLE` + "`" + ` or ` + "`" + `MUTUAL` + "`" + `.
                   format: string
                   type: string
                 subjectAltNames:
@@ -3951,10 +3952,10 @@ spec:
                     format: string
                     type: string
                   inboundTls:
-                    description: Overrides Sidecar level `+"`"+`inboundTls`+"`"+` settings.
+                    description: Overrides Sidecar level ` + "`" + `inboundTls` + "`" + ` settings.
                     properties:
                       caCertificates:
-                        description: REQUIRED if mode is `+"`"+`MUTUAL`+"`"+`.
+                        description: REQUIRED if mode is ` + "`" + `MUTUAL` + "`" + `.
                         format: string
                         type: string
                       cipherSuites:
@@ -3996,11 +3997,11 @@ spec:
                         - ISTIO_MUTUAL
                         type: string
                       privateKey:
-                        description: REQUIRED if mode is `+"`"+`SIMPLE`+"`"+` or `+"`"+`MUTUAL`+"`"+`.
+                        description: REQUIRED if mode is ` + "`" + `SIMPLE` + "`" + ` or ` + "`" + `MUTUAL` + "`" + `.
                         format: string
                         type: string
                       serverCertificate:
-                        description: REQUIRED if mode is `+"`"+`SIMPLE`+"`"+` or `+"`"+`MUTUAL`+"`"+`.
+                        description: REQUIRED if mode is ` + "`" + `SIMPLE` + "`" + ` or ` + "`" + `MUTUAL` + "`" + `.
                         format: string
                         type: string
                       subjectAltNames:
@@ -4505,15 +4506,15 @@ spec:
                         type: string
                     type: object
                   mirror_percent:
-                    description: Percentage of the traffic to be mirrored by the `+"`"+`mirror`+"`"+`
+                    description: Percentage of the traffic to be mirrored by the ` + "`" + `mirror` + "`" + `
                       field.
                     type: integer
                   mirrorPercent:
-                    description: Percentage of the traffic to be mirrored by the `+"`"+`mirror`+"`"+`
+                    description: Percentage of the traffic to be mirrored by the ` + "`" + `mirror` + "`" + `
                       field.
                     type: integer
                   mirrorPercentage:
-                    description: Percentage of the traffic to be mirrored by the `+"`"+`mirror`+"`"+`
+                    description: Percentage of the traffic to be mirrored by the ` + "`" + `mirror` + "`" + `
                       field.
                     properties:
                       value:
@@ -5135,7 +5136,7 @@ spec:
           properties:
             actions:
               description: The actions that will be executed when match evaluates
-                to `+"`"+`true`+"`"+`.
+                to ` + "`" + `true` + "`" + `.
               items:
                 properties:
                   handler:
@@ -5209,7 +5210,7 @@ spec:
                   properties:
                     attributeExpression:
                       description: Specifies an attribute expression to use to override
-                        the numerator in the `+"`"+`percent_sampled`+"`"+` field.
+                        the numerator in the ` + "`" + `percent_sampled` + "`" + ` field.
                       format: string
                       type: string
                     percentSampled:
@@ -5227,13 +5228,13 @@ spec:
                       type: object
                     useIndependentRandomness:
                       description: By default sampling will be based on the value
-                        of the request header `+"`"+`x-request-id`+"`"+`.
+                        of the request header ` + "`" + `x-request-id` + "`" + `.
                       type: boolean
                   type: object
                 rateLimit:
                   properties:
                     maxUnsampledEntries:
-                      description: Number of entries to allow during the `+"`"+`sampling_duration`+"`"+`
+                      description: Number of entries to allow during the ` + "`" + `sampling_duration` + "`" + `
                         before sampling is enforced.
                       format: int64
                       type: integer
@@ -6345,30 +6346,21 @@ subsets:
 - addresses:
   - ip: {{ .Values.global.remotePilotAddress }}
   ports:
+  - port: 15003
+    name: http-old-discovery # mTLS or non-mTLS depending on auth setting
+  - port: 15005
+    name: https-discovery # always mTLS
+  - port: 15007
+    name: http-discovery # always plain-text
   - port: 15010
     name: grpc-xds # direct
   - port: 15011
     name: https-xds # mTLS or non-mTLS depending on auth setting
   - port: 8080
     name: http-legacy-discovery # direct
-  - port: 15012
-    name: http-istiod
   - port: 15014
     name: http-monitoring
----
-apiVersion: v1
-kind: Endpoints
-metadata:
-  name: istiod
-  namespace: {{ .Release.Namespace }}
-subsets:
-- addresses:
-  - ip: {{ .Values.global.remotePilotAddress }}
-  ports:
-  - port: 15012
-    name: http-istiod
 {{- end }}
-
 {{- if and .Values.global.remotePolicyAddress .Values.global.createRemoteSvcEndpoints }}
 ---
 apiVersion: v1
@@ -6547,27 +6539,21 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
+  - port: 15003
+    name: http-old-discovery # mTLS or non-mTLS depending on auth setting
+  - port: 15005
+    name: https-discovery # always mTLS
+  - port: 15007
+    name: http-discovery # always plain-text
   - port: 15010
     name: grpc-xds # direct
   - port: 15011
     name: https-xds # mTLS or non-mTLS depending on auth setting
   - port: 8080
     name: http-legacy-discovery # direct
-  - port: 15012
-    name: http-istiod    
   - port: 15014
     name: http-monitoring
   clusterIP: None
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: istiod
-  namespace: {{ .Release.Namespace }}
-spec:
-  ports:
-  - port: 15012
-    name: http-istiod
 ---
 {{- end }}
 {{- if and .Values.global.remotePolicyAddress .Values.global.createRemoteSvcEndpoints }}
@@ -7147,11 +7133,12 @@ spec:
             value: |
 {{ toJson $gateway.podAnnotations | indent 16}}
 {{ end }}
+          - name: ISTIO_METAJSON_LABELS
+            value: |
+              {{ $gateway.labels | toJson }}
           - name: ISTIO_META_CLUSTER_ID
-            value: "{{ $.Values.global.multiCluster.clusterName | default `+"`"+`Kubernetes`+"`"+` }}"
+            value: "{{ $.Values.global.multiCluster.clusterName | default ` + "`" + `Kubernetes` + "`" + ` }}"
           volumeMounts:
-          - name: config-volume
-            mountPath: /etc/istio/config
           {{- if eq .Values.global.pilotCertProvider "citadel" }}
           - mountPath: /etc/istio/citadel-ca-cert
             name: citadel-ca-cert
@@ -7167,8 +7154,6 @@ spec:
             mountPath: /etc/certs
             readOnly: true
           {{- end }}
-          - name: podinfo
-            mountPath: /etc/istio/pod
           {{- range $gateway.secretVolumes }}
           - name: {{ .name }}
             mountPath: {{ .mountPath | quote }}
@@ -7183,15 +7168,6 @@ spec:
         configMap:
           name: istio-ca-root-cert
       {{- end }}
-      - name: podinfo
-        downwardAPI:
-          items:
-            - path: "labels"
-              fieldRef:
-                fieldPath: metadata.labels
-            - path: "annotations"
-              fieldRef:
-                fieldPath: metadata.annotations
 {{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
       - name: istio-token
         projected:
@@ -7208,10 +7184,6 @@ spec:
           secretName: istio.default
           optional: true
       {{- end }}
-      - name: config-volume
-        configMap:
-          name: istio{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-          optional: true
       {{- range $gateway.secretVolumes }}
       - name: {{ .name }}
         secret:
@@ -7561,9 +7533,6 @@ gateways:
     # "security" and value "S1".
     podAntiAffinityLabelSelector: []
     podAntiAffinityTermLabelSelector: []
-
-# Revision is set as 'version' label and part of the resource names when installing multiple control planes.
-revision: ""
 `)
 
 func chartsGatewaysIstioEgressValuesYamlBytes() ([]byte, error) {
@@ -8201,11 +8170,12 @@ spec:
             value: |
 {{ toJson $gateway.podAnnotations | indent 16}}
 {{ end }}
+          - name: ISTIO_METAJSON_LABELS
+            value: |
+              {{ $gateway.labels | toJson }}
           - name: ISTIO_META_CLUSTER_ID
-            value: "{{ $.Values.global.multiCluster.clusterName | default `+"`"+`Kubernetes`+"`"+` }}"
+            value: "{{ $.Values.global.multiCluster.clusterName | default ` + "`" + `Kubernetes` + "`" + ` }}"
           volumeMounts:
-          - name: config-volume
-            mountPath: /etc/istio/config
 {{- if eq .Values.global.pilotCertProvider "citadel" }}
           - mountPath: /etc/istio/citadel-ca-cert
             name: citadel-ca-cert
@@ -8223,8 +8193,6 @@ spec:
             mountPath: /etc/certs
             readOnly: true
           {{- end }}
-          - name: podinfo
-            mountPath: /etc/istio/pod
           {{- range $gateway.secretVolumes }}
           - name: {{ .name }}
             mountPath: {{ .mountPath | quote }}
@@ -8239,15 +8207,6 @@ spec:
         configMap:
           name: istio-ca-root-cert
 {{- end }}
-      - name: podinfo
-        downwardAPI:
-          items:
-            - path: "labels"
-              fieldRef:
-                fieldPath: metadata.labels
-            - path: "annotations"
-              fieldRef:
-                fieldPath: metadata.annotations
       - name: ingressgatewaysdsudspath
         emptyDir: {}
 {{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
@@ -8266,10 +8225,6 @@ spec:
           secretName: istio.istio-ingressgateway-service-account
           optional: true
       {{- end }}
-      - name: config-volume
-        configMap:
-          name: istio{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-          optional: true
       {{- range $gateway.secretVolumes }}
       - name: {{ .name }}
         secret:
@@ -9071,9 +9026,6 @@ gateways:
     # "security" and value "S1".
     podAntiAffinityLabelSelector: []
     podAntiAffinityTermLabelSelector: []
-
-# Revision is set as 'version' label and part of the resource names when installing multiple control planes.
-revision: ""
 `)
 
 func chartsGatewaysIstioIngressValuesYamlBytes() ([]byte, error) {
@@ -9374,6 +9326,8 @@ spec:
                 fieldPath: spec.nodeName
           - name: "REPAIR_LABEL-PODS"
             value: "{{.Values.cni.repair.labelPods}}"
+          - name: "REPAIR_CREATE-EVENTS"
+            value: "{{.Values.cni.repair.createEvents}}"
           # Set to true to enable pod deletion
           - name: "REPAIR_DELETE-PODS"
             value: "{{.Values.cni.repair.deletePods}}"
@@ -9481,10 +9435,11 @@ var _chartsIstioCniValuesYaml = []byte(`cni:
 
   repair:
     enabled: true
-    hub: ""
-    tag: ""
+    hub: gcr.io/istio-testing
+    tag: latest
 
     labelPods: "true"
+    createEvents: "true"
     deletePods: "true"
 
     initContainerName: "istio-validation"
@@ -9580,13 +9535,13 @@ A cluster should have a single galley with validation enabled - usually the prod
 It is possible to enable validation on other environments as well - but each Galley will do its own
 validation, and a staging version may impact production validation.
 
-`+"`"+``+"`"+``+"`"+`yamml
+` + "`" + `` + "`" + `` + "`" + `yamml
 security:
     ...
     dnsCerts:
         ...
         istio-galley-service-account.MY_NAMESPACE: istio-galley.MY_NAMESPACE.svc
-`+"`"+``+"`"+``+"`"+`
+` + "`" + `` + "`" + `` + "`" + `
 `)
 
 func chartsIstioControlIstioConfigReadmeMdBytes() ([]byte, error) {
@@ -10529,7 +10484,7 @@ var _chartsIstioControlIstioDiscoveryFilesInjectionTemplateYaml = []byte(`# Conf
 template: |
   rewriteAppHTTPProbe: {{ valueOrDefault .Values.sidecarInjectorWebhook.rewriteAppHTTPProbe false }}
   initContainers:
-  {{ if ne (annotation .ObjectMeta `+"`"+`sidecar.istio.io/interceptionMode`+"`"+` .ProxyConfig.InterceptionMode) `+"`"+`NONE`+"`"+` }}
+  {{ if ne (annotation .ObjectMeta ` + "`" + `sidecar.istio.io/interceptionMode` + "`" + ` .ProxyConfig.InterceptionMode) ` + "`" + `NONE` + "`" + ` }}
   {{ if .Values.istio_cni.enabled -}}
   - name: istio-validation
   {{ else -}}
@@ -10549,28 +10504,28 @@ template: |
     - "-u"
     - 1337
     - "-m"
-    - "{{ annotation .ObjectMeta `+"`"+`sidecar.istio.io/interceptionMode`+"`"+` .ProxyConfig.InterceptionMode }}"
+    - "{{ annotation .ObjectMeta ` + "`" + `sidecar.istio.io/interceptionMode` + "`" + ` .ProxyConfig.InterceptionMode }}"
     - "-i"
-    - "{{ annotation .ObjectMeta `+"`"+`traffic.sidecar.istio.io/includeOutboundIPRanges`+"`"+` .Values.global.proxy.includeIPRanges }}"
+    - "{{ annotation .ObjectMeta ` + "`" + `traffic.sidecar.istio.io/includeOutboundIPRanges` + "`" + ` .Values.global.proxy.includeIPRanges }}"
     - "-x"
-    - "{{ annotation .ObjectMeta `+"`"+`traffic.sidecar.istio.io/excludeOutboundIPRanges`+"`"+` .Values.global.proxy.excludeIPRanges }}"
+    - "{{ annotation .ObjectMeta ` + "`" + `traffic.sidecar.istio.io/excludeOutboundIPRanges` + "`" + ` .Values.global.proxy.excludeIPRanges }}"
     - "-b"
-    - "{{ annotation .ObjectMeta `+"`"+`traffic.sidecar.istio.io/includeInboundPorts`+"`"+` `+"`"+`*`+"`"+` }}"
+    - "{{ annotation .ObjectMeta ` + "`" + `traffic.sidecar.istio.io/includeInboundPorts` + "`" + ` ` + "`" + `*` + "`" + ` }}"
     - "-d"
-    - "{{ excludeInboundPort (annotation .ObjectMeta `+"`"+`status.sidecar.istio.io/port`+"`"+` .Values.global.proxy.statusPort) (annotation .ObjectMeta `+"`"+`traffic.sidecar.istio.io/excludeInboundPorts`+"`"+` .Values.global.proxy.excludeInboundPorts) }}"
-    {{ if or (isset .ObjectMeta.Annotations `+"`"+`traffic.sidecar.istio.io/excludeOutboundPorts`+"`"+`) (ne (valueOrDefault .Values.global.proxy.excludeOutboundPorts "") "") -}}
+    - "{{ excludeInboundPort (annotation .ObjectMeta ` + "`" + `status.sidecar.istio.io/port` + "`" + ` .Values.global.proxy.statusPort) (annotation .ObjectMeta ` + "`" + `traffic.sidecar.istio.io/excludeInboundPorts` + "`" + ` .Values.global.proxy.excludeInboundPorts) }}"
+    {{ if or (isset .ObjectMeta.Annotations ` + "`" + `traffic.sidecar.istio.io/excludeOutboundPorts` + "`" + `) (ne (valueOrDefault .Values.global.proxy.excludeOutboundPorts "") "") -}}
     - "-o"
-    - "{{ annotation .ObjectMeta `+"`"+`traffic.sidecar.istio.io/excludeOutboundPorts`+"`"+` .Values.global.proxy.excludeOutboundPorts }}"
+    - "{{ annotation .ObjectMeta ` + "`" + `traffic.sidecar.istio.io/excludeOutboundPorts` + "`" + ` .Values.global.proxy.excludeOutboundPorts }}"
     {{ end -}}
-    {{ if (isset .ObjectMeta.Annotations `+"`"+`traffic.sidecar.istio.io/kubevirtInterfaces`+"`"+`) -}}
+    {{ if (isset .ObjectMeta.Annotations ` + "`" + `traffic.sidecar.istio.io/kubevirtInterfaces` + "`" + `) -}}
     - "-k"
-    - "{{ index .ObjectMeta.Annotations `+"`"+`traffic.sidecar.istio.io/kubevirtInterfaces`+"`"+` }}"
+    - "{{ index .ObjectMeta.Annotations ` + "`" + `traffic.sidecar.istio.io/kubevirtInterfaces` + "`" + ` }}"
     {{ end -}}
     {{ if .Values.istio_cni.enabled -}}
     - "--run-validation"
     - "--skip-rule-apply"
     {{ end -}}
-    imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `+"`"+`Always`+"`"+` }}"
+    imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy ` + "`" + `Always` + "`" + ` }}"
   {{- if .Values.global.proxy_init.resources }}
     resources:
       {{ toYaml .Values.global.proxy_init.resources | indent 4 }}
@@ -10612,7 +10567,7 @@ template: |
   {{- else }}
     image: "{{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}"
   {{- end }}
-    imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `+"`"+`Always`+"`"+` }}"
+    imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy ` + "`" + `Always` + "`" + ` }}"
     resources: {}
     securityContext:
       allowPrivilegeEscalation: true
@@ -10629,8 +10584,8 @@ template: |
   {{ end }}
   containers:
   - name: istio-proxy
-  {{- if contains "/" (annotation .ObjectMeta `+"`"+`sidecar.istio.io/proxyImage`+"`"+` .Values.global.proxy.image) }}
-    image: "{{ annotation .ObjectMeta `+"`"+`sidecar.istio.io/proxyImage`+"`"+` .Values.global.proxy.image }}"
+  {{- if contains "/" (annotation .ObjectMeta ` + "`" + `sidecar.istio.io/proxyImage` + "`" + ` .Values.global.proxy.image) }}
+    image: "{{ annotation .ObjectMeta ` + "`" + `sidecar.istio.io/proxyImage` + "`" + ` .Values.global.proxy.image }}"
   {{- else }}
     image: "{{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}"
   {{- end }}
@@ -10643,17 +10598,25 @@ template: |
     - sidecar
     - --domain
     - $(POD_NAMESPACE).svc.{{ .Values.global.proxy.clusterDomain }}
+    - --configPath
+    - "/etc/istio/proxy"
+    - --binaryPath
+    - "/usr/local/bin/envoy"
     - --serviceCluster
     {{ if ne "" (index .ObjectMeta.Labels "app") -}}
-    - "{{ index .ObjectMeta.Labels `+"`"+`app`+"`"+` }}.$(POD_NAMESPACE)"
+    - "{{ index .ObjectMeta.Labels ` + "`" + `app` + "`" + ` }}.$(POD_NAMESPACE)"
     {{ else -}}
-    - "{{ valueOrDefault .DeploymentMeta.Name `+"`"+`istio-proxy`+"`"+` }}.{{ valueOrDefault .DeploymentMeta.Namespace `+"`"+`default`+"`"+` }}"
+    - "{{ valueOrDefault .DeploymentMeta.Name ` + "`" + `istio-proxy` + "`" + ` }}.{{ valueOrDefault .DeploymentMeta.Namespace ` + "`" + `default` + "`" + ` }}"
     {{ end -}}
+    - --discoveryAddress
+    - "{{ annotation .ObjectMeta `+"`"+`sidecar.istio.io/discoveryAddress`+"`"+` .ProxyConfig.DiscoveryAddress }}"
     - --proxyLogLevel={{ annotation .ObjectMeta `+"`"+`sidecar.istio.io/logLevel`+"`"+` .Values.global.proxy.logLevel}}
     - --proxyComponentLogLevel={{ annotation .ObjectMeta `+"`"+`sidecar.istio.io/componentLogLevel`+"`"+` .Values.global.proxy.componentLogLevel}}
+    - --dnsRefreshRate
+    - {{ valueOrDefault .Values.global.proxy.dnsRefreshRate "300s" }}
   {{- if (ne (annotation .ObjectMeta "status.sidecar.istio.io/port" .Values.global.proxy.statusPort) "0") }}
     - --statusPort
-    - "{{ annotation .ObjectMeta `+"`"+`status.sidecar.istio.io/port`+"`"+` .Values.global.proxy.statusPort }}"
+    - "{{ annotation .ObjectMeta ` + "`" + `status.sidecar.istio.io/port` + "`" + ` .Values.global.proxy.statusPort }}"
   {{- end }}
   {{- if .Values.global.sts.servicePort }}
     - --stsPort={{ .Values.global.sts.servicePort }}
@@ -10718,7 +10681,7 @@ template: |
         {{- end}}
         ]
     - name: ISTIO_META_CLUSTER_ID
-      value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `+"`"+`Kubernetes`+"`"+` }}"
+      value: "{{ valueOrDefault .Values.global.multiCluster.clusterName ` + "`" + `Kubernetes` + "`" + ` }}"
     - name: ISTIO_META_POD_NAME
       valueFrom:
         fieldRef:
@@ -10728,7 +10691,7 @@ template: |
         fieldRef:
           fieldPath: metadata.namespace
     - name: ISTIO_META_INTERCEPTION_MODE
-      value: "{{ or (index .ObjectMeta.Annotations `+"`"+`sidecar.istio.io/interceptionMode`+"`"+`) .ProxyConfig.InterceptionMode.String }}"
+      value: "{{ or (index .ObjectMeta.Annotations ` + "`" + `sidecar.istio.io/interceptionMode` + "`" + `) .ProxyConfig.InterceptionMode.String }}"
     {{- if .Values.global.network }}
     - name: ISTIO_META_NETWORK
       value: "{{ .Values.global.network }}"
@@ -10738,15 +10701,20 @@ template: |
       value: |
              {{ toJSON .ObjectMeta.Annotations }}
     {{ end }}
+    {{ if .ObjectMeta.Labels }}
+    - name: ISTIO_METAJSON_LABELS
+      value: |
+             {{ toJSON .ObjectMeta.Labels }}
+    {{ end }}
     {{- if .DeploymentMeta.Name }}
     - name: ISTIO_META_WORKLOAD_NAME
       value: {{ .DeploymentMeta.Name }}
     {{ end }}
     {{- if and .TypeMeta.APIVersion .DeploymentMeta.Name }}
     - name: ISTIO_META_OWNER
-      value: kubernetes://apis/{{ .TypeMeta.APIVersion }}/namespaces/{{ valueOrDefault .DeploymentMeta.Namespace `+"`"+`default`+"`"+` }}/{{ toLower .TypeMeta.Kind}}s/{{ .DeploymentMeta.Name }}
+      value: kubernetes://apis/{{ .TypeMeta.APIVersion }}/namespaces/{{ valueOrDefault .DeploymentMeta.Namespace ` + "`" + `default` + "`" + ` }}/{{ toLower .TypeMeta.Kind}}s/{{ .DeploymentMeta.Name }}
     {{- end}}
-    {{- if (isset .ObjectMeta.Annotations `+"`"+`sidecar.istio.io/bootstrapOverride`+"`"+`) }}
+    {{- if (isset .ObjectMeta.Annotations ` + "`" + `sidecar.istio.io/bootstrapOverride` + "`" + `) }}
     - name: ISTIO_BOOTSTRAP_OVERRIDE
       value: "/etc/istio/custom-bootstrap/custom_bootstrap.json"
     {{- end }}
@@ -10757,8 +10725,8 @@ template: |
     - name: ISTIO_META_MESH_ID
       value: "{{ .Values.global.trustDomain }}"
     {{- end }}
-    {{- if and (eq .Values.global.proxy.tracer "datadog") (isset .ObjectMeta.Annotations `+"`"+`apm.datadoghq.com/env`+"`"+`) }}
-    {{- range $key, $value := fromJSON (index .ObjectMeta.Annotations `+"`"+`apm.datadoghq.com/env`+"`"+`) }}
+    {{- if and (eq .Values.global.proxy.tracer "datadog") (isset .ObjectMeta.Annotations ` + "`" + `apm.datadoghq.com/env` + "`" + `) }}
+    {{- range $key, $value := fromJSON (index .ObjectMeta.Annotations ` + "`" + `apm.datadoghq.com/env` + "`" + `) }}
       - name: {{ $key }}
         value: "{{ $value }}"
     {{- end }}
@@ -10767,25 +10735,25 @@ template: |
     - name: {{ $key }}
       value: "{{ $value }}"
     {{- end }}
-    imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `+"`"+`Always`+"`"+` }}"
-    {{ if ne (annotation .ObjectMeta `+"`"+`status.sidecar.istio.io/port`+"`"+` .Values.global.proxy.statusPort) `+"`"+`0`+"`"+` }}
+    imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy ` + "`" + `Always` + "`" + ` }}"
+    {{ if ne (annotation .ObjectMeta ` + "`" + `status.sidecar.istio.io/port` + "`" + ` .Values.global.proxy.statusPort) ` + "`" + `0` + "`" + ` }}
     readinessProbe:
       httpGet:
         path: /healthz/ready
-        port: {{ annotation .ObjectMeta `+"`"+`status.sidecar.istio.io/port`+"`"+` .Values.global.proxy.statusPort }}
-      initialDelaySeconds: {{ annotation .ObjectMeta `+"`"+`readiness.status.sidecar.istio.io/initialDelaySeconds`+"`"+` .Values.global.proxy.readinessInitialDelaySeconds }}
-      periodSeconds: {{ annotation .ObjectMeta `+"`"+`readiness.status.sidecar.istio.io/periodSeconds`+"`"+` .Values.global.proxy.readinessPeriodSeconds }}
-      failureThreshold: {{ annotation .ObjectMeta `+"`"+`readiness.status.sidecar.istio.io/failureThreshold`+"`"+` .Values.global.proxy.readinessFailureThreshold }}
+        port: {{ annotation .ObjectMeta ` + "`" + `status.sidecar.istio.io/port` + "`" + ` .Values.global.proxy.statusPort }}
+      initialDelaySeconds: {{ annotation .ObjectMeta ` + "`" + `readiness.status.sidecar.istio.io/initialDelaySeconds` + "`" + ` .Values.global.proxy.readinessInitialDelaySeconds }}
+      periodSeconds: {{ annotation .ObjectMeta ` + "`" + `readiness.status.sidecar.istio.io/periodSeconds` + "`" + ` .Values.global.proxy.readinessPeriodSeconds }}
+      failureThreshold: {{ annotation .ObjectMeta ` + "`" + `readiness.status.sidecar.istio.io/failureThreshold` + "`" + ` .Values.global.proxy.readinessFailureThreshold }}
     {{ end -}}
     securityContext:
       allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
       capabilities:
-        {{ if or (eq (annotation .ObjectMeta `+"`"+`sidecar.istio.io/interceptionMode`+"`"+` .ProxyConfig.InterceptionMode) `+"`"+`TPROXY`+"`"+`) (eq (annotation .ObjectMeta `+"`"+`sidecar.istio.io/capNetBindService`+"`"+` .Values.global.proxy.capNetBindService) `+"`"+`true`+"`"+`) -}}
+        {{ if or (eq (annotation .ObjectMeta ` + "`" + `sidecar.istio.io/interceptionMode` + "`" + ` .ProxyConfig.InterceptionMode) ` + "`" + `TPROXY` + "`" + `) (eq (annotation .ObjectMeta ` + "`" + `sidecar.istio.io/capNetBindService` + "`" + ` .Values.global.proxy.capNetBindService) ` + "`" + `true` + "`" + `) -}}
         add:
-        {{ if eq (annotation .ObjectMeta `+"`"+`sidecar.istio.io/interceptionMode`+"`"+` .ProxyConfig.InterceptionMode) `+"`"+`TPROXY`+"`"+` -}}
+        {{ if eq (annotation .ObjectMeta ` + "`" + `sidecar.istio.io/interceptionMode` + "`" + ` .ProxyConfig.InterceptionMode) ` + "`" + `TPROXY` + "`" + ` -}}
         - NET_ADMIN
         {{- end }}
-        {{ if eq (annotation .ObjectMeta `+"`"+`sidecar.istio.io/capNetBindService`+"`"+` .Values.global.proxy.capNetBindService) `+"`"+`true`+"`"+` -}}
+        {{ if eq (annotation .ObjectMeta ` + "`" + `sidecar.istio.io/capNetBindService` + "`" + ` .Values.global.proxy.capNetBindService) ` + "`" + `true` + "`" + ` -}}
         - NET_BIND_SERVICE
         {{- end }}
         {{- end }}
@@ -10795,7 +10763,7 @@ template: |
       readOnlyRootFilesystem: {{ not .Values.global.proxy.enableCoreDump }}
       runAsGroup: 1337
       fsGroup: 1337
-      {{ if or (eq (annotation .ObjectMeta `+"`"+`sidecar.istio.io/interceptionMode`+"`"+` .ProxyConfig.InterceptionMode) `+"`"+`TPROXY`+"`"+`) (eq (annotation .ObjectMeta `+"`"+`sidecar.istio.io/capNetBindService`+"`"+` .Values.global.proxy.capNetBindService) `+"`"+`true`+"`"+`) -}}
+      {{ if or (eq (annotation .ObjectMeta ` + "`" + `sidecar.istio.io/interceptionMode` + "`" + ` .ProxyConfig.InterceptionMode) ` + "`" + `TPROXY` + "`" + `) (eq (annotation .ObjectMeta ` + "`" + `sidecar.istio.io/capNetBindService` + "`" + ` .Values.global.proxy.capNetBindService) ` + "`" + `true` + "`" + `) -}}
       runAsNonRoot: false
       runAsUser: 0
       {{- else -}}
@@ -10803,13 +10771,13 @@ template: |
       runAsUser: 1337
       {{- end }}
     resources:
-      {{ if or (isset .ObjectMeta.Annotations `+"`"+`sidecar.istio.io/proxyCPU`+"`"+`) (isset .ObjectMeta.Annotations `+"`"+`sidecar.istio.io/proxyMemory`+"`"+`) -}}
+      {{ if or (isset .ObjectMeta.Annotations ` + "`" + `sidecar.istio.io/proxyCPU` + "`" + `) (isset .ObjectMeta.Annotations ` + "`" + `sidecar.istio.io/proxyMemory` + "`" + `) -}}
       requests:
-        {{ if (isset .ObjectMeta.Annotations `+"`"+`sidecar.istio.io/proxyCPU`+"`"+`) -}}
-        cpu: "{{ index .ObjectMeta.Annotations `+"`"+`sidecar.istio.io/proxyCPU`+"`"+` }}"
+        {{ if (isset .ObjectMeta.Annotations ` + "`" + `sidecar.istio.io/proxyCPU` + "`" + `) -}}
+        cpu: "{{ index .ObjectMeta.Annotations ` + "`" + `sidecar.istio.io/proxyCPU` + "`" + ` }}"
         {{ end}}
-        {{ if (isset .ObjectMeta.Annotations `+"`"+`sidecar.istio.io/proxyMemory`+"`"+`) -}}
-        memory: "{{ index .ObjectMeta.Annotations `+"`"+`sidecar.istio.io/proxyMemory`+"`"+` }}"
+        {{ if (isset .ObjectMeta.Annotations ` + "`" + `sidecar.istio.io/proxyMemory` + "`" + `) -}}
+        memory: "{{ index .ObjectMeta.Annotations ` + "`" + `sidecar.istio.io/proxyMemory` + "`" + ` }}"
         {{ end }}
     {{ else -}}
   {{- if .Values.global.proxy.resources }}
@@ -10821,7 +10789,7 @@ template: |
     - mountPath: /etc/istio/citadel-ca-cert
       name: citadel-ca-cert
     {{- end }}
-    {{ if (isset .ObjectMeta.Annotations `+"`"+`sidecar.istio.io/bootstrapOverride`+"`"+`) }}
+    {{ if (isset .ObjectMeta.Annotations ` + "`" + `sidecar.istio.io/bootstrapOverride` + "`" + `) }}
     - mountPath: /etc/istio/custom-bootstrap
       name: custom-bootstrap-volume
     {{- end }}
@@ -10838,38 +10806,27 @@ template: |
       name: istio-certs
       readOnly: true
     {{- end }}
-    - name: podinfo
-      mountPath: /etc/istio/pod
     {{- if and (eq .Values.global.proxy.tracer "lightstep") .Values.global.tracer.lightstep.cacertPath }}
     - mountPath: {{ directory .ProxyConfig.GetTracing.GetLightstep.GetCacertPath }}
       name: lightstep-certs
       readOnly: true
     {{- end }}
-      {{- if isset .ObjectMeta.Annotations `+"`"+`sidecar.istio.io/userVolumeMount`+"`"+` }}
-      {{ range $index, $value := fromJSON (index .ObjectMeta.Annotations `+"`"+`sidecar.istio.io/userVolumeMount`+"`"+`) }}
+      {{- if isset .ObjectMeta.Annotations ` + "`" + `sidecar.istio.io/userVolumeMount` + "`" + ` }}
+      {{ range $index, $value := fromJSON (index .ObjectMeta.Annotations ` + "`" + `sidecar.istio.io/userVolumeMount` + "`" + `) }}
     - name: "{{  $index }}"
       {{ toYaml $value | indent 4 }}
       {{ end }}
       {{- end }}
   volumes:
-  {{- if (isset .ObjectMeta.Annotations `+"`"+`sidecar.istio.io/bootstrapOverride`+"`"+`) }}
+  {{- if (isset .ObjectMeta.Annotations ` + "`" + `sidecar.istio.io/bootstrapOverride` + "`" + `) }}
   - name: custom-bootstrap-volume
     configMap:
-      name: {{ annotation .ObjectMeta `+"`"+`sidecar.istio.io/bootstrapOverride`+"`"+` "" }}
+      name: {{ annotation .ObjectMeta ` + "`" + `sidecar.istio.io/bootstrapOverride` + "`" + ` "" }}
   {{- end }}
   # SDS channel between istioagent and Envoy
   - emptyDir:
       medium: Memory
     name: istio-envoy
-  - name: podinfo
-    downwardAPI:
-      items:
-        - path: "labels"
-          fieldRef:
-            fieldPath: metadata.labels
-        - path: "annotations"
-          fieldRef:
-            fieldPath: metadata.annotations
   {{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
   - name: istio-token
     projected:
@@ -10895,8 +10852,8 @@ template: |
       secretName: {{  printf "istio.%s" .Spec.ServiceAccountName }}
       {{  end -}}
   {{- end }}
-    {{- if isset .ObjectMeta.Annotations `+"`"+`sidecar.istio.io/userVolume`+"`"+` }}
-    {{range $index, $value := fromJSON (index .ObjectMeta.Annotations `+"`"+`sidecar.istio.io/userVolume`+"`"+`) }}
+    {{- if isset .ObjectMeta.Annotations ` + "`" + `sidecar.istio.io/userVolume` + "`" + ` }}
+    {{range $index, $value := fromJSON (index .ObjectMeta.Annotations ` + "`" + `sidecar.istio.io/userVolume` + "`" + `) }}
   - name: "{{ $index }}"
     {{ toYaml $value | indent 2 }}
     {{ end }}
@@ -10915,15 +10872,15 @@ template: |
       {{- end }}
   {{- end }}
   podRedirectAnnot:
-    sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `+"`"+`sidecar.istio.io/interceptionMode`+"`"+` .ProxyConfig.InterceptionMode }}"
-    traffic.sidecar.istio.io/includeOutboundIPRanges: "{{ annotation .ObjectMeta `+"`"+`traffic.sidecar.istio.io/includeOutboundIPRanges`+"`"+` .Values.global.proxy.includeIPRanges }}"
-    traffic.sidecar.istio.io/excludeOutboundIPRanges: "{{ annotation .ObjectMeta `+"`"+`traffic.sidecar.istio.io/excludeOutboundIPRanges`+"`"+` .Values.global.proxy.excludeIPRanges }}"
-    traffic.sidecar.istio.io/includeInboundPorts: "{{ annotation .ObjectMeta `+"`"+`traffic.sidecar.istio.io/includeInboundPorts`+"`"+` (includeInboundPorts .Spec.Containers) }}"
-    traffic.sidecar.istio.io/excludeInboundPorts: "{{ excludeInboundPort (annotation .ObjectMeta `+"`"+`status.sidecar.istio.io/port`+"`"+` .Values.global.proxy.statusPort) (annotation .ObjectMeta `+"`"+`traffic.sidecar.istio.io/excludeInboundPorts`+"`"+` .Values.global.proxy.excludeInboundPorts) }}"
-  {{ if or (isset .ObjectMeta.Annotations `+"`"+`traffic.sidecar.istio.io/excludeOutboundPorts`+"`"+`) (ne .Values.global.proxy.excludeOutboundPorts "") }}
-    traffic.sidecar.istio.io/excludeOutboundPorts: "{{ annotation .ObjectMeta `+"`"+`traffic.sidecar.istio.io/excludeOutboundPorts`+"`"+` .Values.global.proxy.excludeOutboundPorts }}"
+    sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta ` + "`" + `sidecar.istio.io/interceptionMode` + "`" + ` .ProxyConfig.InterceptionMode }}"
+    traffic.sidecar.istio.io/includeOutboundIPRanges: "{{ annotation .ObjectMeta ` + "`" + `traffic.sidecar.istio.io/includeOutboundIPRanges` + "`" + ` .Values.global.proxy.includeIPRanges }}"
+    traffic.sidecar.istio.io/excludeOutboundIPRanges: "{{ annotation .ObjectMeta ` + "`" + `traffic.sidecar.istio.io/excludeOutboundIPRanges` + "`" + ` .Values.global.proxy.excludeIPRanges }}"
+    traffic.sidecar.istio.io/includeInboundPorts: "{{ annotation .ObjectMeta ` + "`" + `traffic.sidecar.istio.io/includeInboundPorts` + "`" + ` (includeInboundPorts .Spec.Containers) }}"
+    traffic.sidecar.istio.io/excludeInboundPorts: "{{ excludeInboundPort (annotation .ObjectMeta ` + "`" + `status.sidecar.istio.io/port` + "`" + ` .Values.global.proxy.statusPort) (annotation .ObjectMeta ` + "`" + `traffic.sidecar.istio.io/excludeInboundPorts` + "`" + ` .Values.global.proxy.excludeInboundPorts) }}"
+  {{ if or (isset .ObjectMeta.Annotations ` + "`" + `traffic.sidecar.istio.io/excludeOutboundPorts` + "`" + `) (ne .Values.global.proxy.excludeOutboundPorts "") }}
+    traffic.sidecar.istio.io/excludeOutboundPorts: "{{ annotation .ObjectMeta ` + "`" + `traffic.sidecar.istio.io/excludeOutboundPorts` + "`" + ` .Values.global.proxy.excludeOutboundPorts }}"
   {{- end }}
-    traffic.sidecar.istio.io/kubevirtInterfaces: "{{ index .ObjectMeta.Annotations `+"`"+`traffic.sidecar.istio.io/kubevirtInterfaces`+"`"+` }}"
+    traffic.sidecar.istio.io/kubevirtInterfaces: "{{ index .ObjectMeta.Annotations ` + "`" + `traffic.sidecar.istio.io/kubevirtInterfaces` + "`" + ` }}"
 `)
 
 func chartsIstioControlIstioDiscoveryFilesInjectionTemplateYamlBytes() ([]byte, error) {
@@ -13506,7 +13463,7 @@ webhooks:
         resources:
         - "*"
     # Fail open until the validation webhook is ready. The webhook controller
-    # will update this to `+"`"+`Fail`+"`"+` and patch in the `+"`"+`caBundle`+"`"+` when the webhook
+    # will update this to ` + "`" + `Fail` + "`" + ` and patch in the ` + "`" + `caBundle` + "`" + ` when the webhook
     # endpoint is ready.
     failurePolicy: Ignore
     sideEffects: None
@@ -28111,7 +28068,7 @@ var _chartsIstioTelemetryGrafanaDashboardsPilotDashboardJson = []byte(`{
       },
       "id": 58,
       "panels": [],
-      "title": "Pilot Push Information",
+      "title": "Pilot push Information",
       "type": "row"
     },
     {
@@ -28322,14 +28279,14 @@ var _chartsIstioTelemetryGrafanaDashboardsPilotDashboardJson = []byte(`{
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
-          "legendFormat": "Push Context Errors",
+          "legendFormat": "push Context Errors",
           "refId": "K"
         },
         {
           "expr": "sum(rate(pilot_xds_pushes{type!~\"lds|cds|rds|eds\"}[1m])) by (type)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Push Errors ({{ type }})",
+          "legendFormat": "push Errors ({{ type }})",
           "refId": "L"
         },
         {
@@ -28337,21 +28294,21 @@ var _chartsIstioTelemetryGrafanaDashboardsPilotDashboardJson = []byte(`{
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
-          "legendFormat": "Push Errors ({{ type }})",
+          "legendFormat": "push Errors ({{ type }})",
           "refId": "I"
         },
         {
           "expr": "sum(rate(pilot_xds_push_timeout{job=\"pilot\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Push Timeouts",
+          "legendFormat": "push Timeouts",
           "refId": "G"
         },
         {
           "expr": "sum(rate(pilot_xds_push_timeout_failures{job=\"pilot\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Push Timeouts Failures",
+          "legendFormat": "push Timeouts Failures",
           "refId": "J"
         }
       ],
@@ -28465,7 +28422,7 @@ var _chartsIstioTelemetryGrafanaDashboardsPilotDashboardJson = []byte(`{
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Proxy Push Time",
+      "title": "Proxy push Time",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -30439,7 +30396,7 @@ var _chartsIstioTelemetryKialiValuesYaml = []byte(`#
 # addon kiali
 #
 kiali:
-  enabled: false # Note that if using the demo or demo-auth yaml when installing via Helm, this default will be `+"`"+`true`+"`"+`.
+  enabled: false # Note that if using the demo or demo-auth yaml when installing via Helm, this default will be ` + "`" + `true` + "`" + `.
   replicaCount: 1
   hub: quay.io/kiali
   tag: v1.13
@@ -34202,6 +34159,8 @@ spec:
             - --controlPlaneAuthPolicy
             - NONE
               {{- end }}
+            - --dnsRefreshRate
+            - "300s"
             - --statusPort
             - "15020"
               {{- if .Values.global.trustDomain }}
@@ -40343,32 +40302,32 @@ var _bindata = map[string]func() (*asset, error){
 	"examples/user-gateway/ingress-gateway-only.yaml":                                        examplesUserGatewayIngressGatewayOnlyYaml,
 	"examples/vm/values-istio-meshexpansion-gateways.yaml":                                   examplesVmValuesIstioMeshexpansionGatewaysYaml,
 	"examples/vm/values-istio-meshexpansion.yaml":                                            examplesVmValuesIstioMeshexpansionYaml,
-	"operator/Chart.yaml":                                                                    operatorChartYaml,
-	"operator/templates/clusterrole.yaml":                                                    operatorTemplatesClusterroleYaml,
-	"operator/templates/clusterrole_binding.yaml":                                            operatorTemplatesClusterrole_bindingYaml,
-	"operator/templates/crd.yaml":                                                            operatorTemplatesCrdYaml,
-	"operator/templates/deployment.yaml":                                                     operatorTemplatesDeploymentYaml,
-	"operator/templates/namespace.yaml":                                                      operatorTemplatesNamespaceYaml,
-	"operator/templates/service.yaml":                                                        operatorTemplatesServiceYaml,
-	"operator/templates/service_account.yaml":                                                operatorTemplatesService_accountYaml,
-	"profiles/default.yaml":                                                                  profilesDefaultYaml,
-	"profiles/demo.yaml":                                                                     profilesDemoYaml,
-	"profiles/empty.yaml":                                                                    profilesEmptyYaml,
-	"profiles/minimal.yaml":                                                                  profilesMinimalYaml,
-	"profiles/remote.yaml":                                                                   profilesRemoteYaml,
-	"profiles/separate.yaml":                                                                 profilesSeparateYaml,
-	"translateConfig/names-1.5.yaml":                                                         translateconfigNames15Yaml,
-	"translateConfig/names-1.6.yaml":                                                         translateconfigNames16Yaml,
-	"translateConfig/reverseTranslateConfig-1.4.yaml":                                        translateconfigReversetranslateconfig14Yaml,
-	"translateConfig/reverseTranslateConfig-1.5.yaml":                                        translateconfigReversetranslateconfig15Yaml,
-	"translateConfig/reverseTranslateConfig-1.6.yaml":                                        translateconfigReversetranslateconfig16Yaml,
-	"translateConfig/translate-ICP-IOP-1.5.yaml":                                             translateconfigTranslateIcpIop15Yaml,
-	"translateConfig/translate-ICP-IOP-1.6.yaml":                                             translateconfigTranslateIcpIop16Yaml,
-	"translateConfig/translateConfig-1.3.yaml":                                               translateconfigTranslateconfig13Yaml,
-	"translateConfig/translateConfig-1.4.yaml":                                               translateconfigTranslateconfig14Yaml,
-	"translateConfig/translateConfig-1.5.yaml":                                               translateconfigTranslateconfig15Yaml,
-	"translateConfig/translateConfig-1.6.yaml":                                               translateconfigTranslateconfig16Yaml,
-	"versions.yaml":                                                                          versionsYaml,
+	"operator/Chart.yaml":                             operatorChartYaml,
+	"operator/templates/clusterrole.yaml":             operatorTemplatesClusterroleYaml,
+	"operator/templates/clusterrole_binding.yaml":     operatorTemplatesClusterrole_bindingYaml,
+	"operator/templates/crd.yaml":                     operatorTemplatesCrdYaml,
+	"operator/templates/deployment.yaml":              operatorTemplatesDeploymentYaml,
+	"operator/templates/namespace.yaml":               operatorTemplatesNamespaceYaml,
+	"operator/templates/service.yaml":                 operatorTemplatesServiceYaml,
+	"operator/templates/service_account.yaml":         operatorTemplatesService_accountYaml,
+	"profiles/default.yaml":                           profilesDefaultYaml,
+	"profiles/demo.yaml":                              profilesDemoYaml,
+	"profiles/empty.yaml":                             profilesEmptyYaml,
+	"profiles/minimal.yaml":                           profilesMinimalYaml,
+	"profiles/remote.yaml":                            profilesRemoteYaml,
+	"profiles/separate.yaml":                          profilesSeparateYaml,
+	"translateConfig/names-1.5.yaml":                  translateconfigNames15Yaml,
+	"translateConfig/names-1.6.yaml":                  translateconfigNames16Yaml,
+	"translateConfig/reverseTranslateConfig-1.4.yaml": translateconfigReversetranslateconfig14Yaml,
+	"translateConfig/reverseTranslateConfig-1.5.yaml": translateconfigReversetranslateconfig15Yaml,
+	"translateConfig/reverseTranslateConfig-1.6.yaml": translateconfigReversetranslateconfig16Yaml,
+	"translateConfig/translate-ICP-IOP-1.5.yaml":      translateconfigTranslateIcpIop15Yaml,
+	"translateConfig/translate-ICP-IOP-1.6.yaml":      translateconfigTranslateIcpIop16Yaml,
+	"translateConfig/translateConfig-1.3.yaml":        translateconfigTranslateconfig13Yaml,
+	"translateConfig/translateConfig-1.4.yaml":        translateconfigTranslateconfig14Yaml,
+	"translateConfig/translateConfig-1.5.yaml":        translateconfigTranslateconfig15Yaml,
+	"translateConfig/translateConfig-1.6.yaml":        translateconfigTranslateconfig16Yaml,
+	"versions.yaml":                                   versionsYaml,
 }
 
 // AssetDir returns the file names below a certain
@@ -40510,9 +40469,9 @@ var _bintree = &bintree{nil, map[string]*bintree{
 					"injection-template.yaml": &bintree{chartsIstioControlIstioDiscoveryFilesInjectionTemplateYaml, map[string]*bintree{}},
 				}},
 				"templates": &bintree{nil, map[string]*bintree{
-					"_affinity.tpl":                           &bintree{chartsIstioControlIstioDiscoveryTemplates_affinityTpl, map[string]*bintree{}},
-					"_helpers.tpl":                            &bintree{chartsIstioControlIstioDiscoveryTemplates_helpersTpl, map[string]*bintree{}},
-					"autoscale.yaml":                          &bintree{chartsIstioControlIstioDiscoveryTemplatesAutoscaleYaml, map[string]*bintree{}},
+					"_affinity.tpl":  &bintree{chartsIstioControlIstioDiscoveryTemplates_affinityTpl, map[string]*bintree{}},
+					"_helpers.tpl":   &bintree{chartsIstioControlIstioDiscoveryTemplates_helpersTpl, map[string]*bintree{}},
+					"autoscale.yaml": &bintree{chartsIstioControlIstioDiscoveryTemplatesAutoscaleYaml, map[string]*bintree{}},
 					"clusterrole-galley-disable-webhook.yaml": &bintree{chartsIstioControlIstioDiscoveryTemplatesClusterroleGalleyDisableWebhookYaml, map[string]*bintree{}},
 					"clusterrole.yaml":                        &bintree{chartsIstioControlIstioDiscoveryTemplatesClusterroleYaml, map[string]*bintree{}},
 					"clusterrolebinding.yaml":                 &bintree{chartsIstioControlIstioDiscoveryTemplatesClusterrolebindingYaml, map[string]*bintree{}},


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/21225.
This turned out to be much more work than would appear at first glance since all YAML processors I could find reorder keys and/or otherwise reformat the manifest. 
To preserve the output of generate so that it resembles the source Helm templates, we must resort to a combination of text and YAML processing to avoid reordering/reformatting the original manifest.