### PR TITLE
authz: add e2e tests for conditions

### DIFF
--- a/tests/integration/security/rbac_v1beta1_test.go
+++ b/tests/integration/security/rbac_v1beta1_test.go
@@ -15,6 +15,7 @@
 package security
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -667,6 +668,118 @@ func TestV1beta1_TCP(t *testing.T) {
 				newTestCase(c, d, "tcp", true),
 				newTestCase(x, a, "tcp", true),
 				newTestCase(x, d, "tcp", false),
+			}
+
+			rbacUtil.RunRBACTest(t, cases)
+		})
+}
+
+// TestV1beta1_Conditions tests v1beta1 authorization with conditions.
+func TestV1beta1_Conditions(t *testing.T) {
+	framework.NewTest(t).
+		RequiresEnvironment(environment.Kube).
+		Run(func(ctx framework.TestContext) {
+			nsA := namespace.NewOrFail(t, ctx, namespace.Config{
+				Prefix: "v1beta1-conditions-a",
+				Inject: true,
+			})
+			nsB := namespace.NewOrFail(t, ctx, namespace.Config{
+				Prefix: "v1beta1-conditions-b",
+				Inject: true,
+			})
+			nsC := namespace.NewOrFail(t, ctx, namespace.Config{
+				Prefix: "v1beta1-conditions-c",
+				Inject: true,
+			})
+
+			portC := 8090
+			var a, b, c echo.Instance
+			echoboot.NewBuilderOrFail(t, ctx).
+				With(&a, util.EchoConfig("a", nsA, false, nil, g, p)).
+				With(&b, util.EchoConfig("b", nsB, false, nil, g, p)).
+				With(&c, echo.Config{
+					Service:   "c",
+					Namespace: nsC,
+					Ports: []echo.Port{
+						{
+							Name:         "http",
+							Protocol:     protocol.HTTP,
+							InstancePort: portC,
+						},
+					},
+					Galley: g,
+					Pilot:  p,
+				}).
+				BuildOrFail(t)
+
+			args := map[string]string{
+				"NamespaceA": nsA.Name(),
+				"NamespaceB": nsB.Name(),
+				"NamespaceC": nsC.Name(),
+				"IpA":        getWorkload(a, t).Address(),
+				"IpB":        getWorkload(b, t).Address(),
+				"IpC":        getWorkload(c, t).Address(),
+				"PortC":      fmt.Sprintf("%d", portC),
+			}
+			policies := tmpl.EvaluateAllOrFail(t, args, file.AsStringOrFail(t, "testdata/rbac/v1beta1-conditions.yaml.tmpl"))
+			g.ApplyConfigOrFail(t, nil, policies...)
+			defer g.DeleteConfigOrFail(t, nil, policies...)
+
+			newTestCase := func(from echo.Instance, path string, headers map[string]string, expectAllowed bool) rbacUtil.TestCase {
+				return rbacUtil.TestCase{
+					Request: connection.Checker{
+						From: from,
+						Options: echo.CallOptions{
+							Target:   c,
+							PortName: "http",
+							Scheme:   scheme.HTTP,
+							Path:     path,
+						},
+					},
+					Headers:       headers,
+					ExpectAllowed: expectAllowed,
+				}
+			}
+			cases := []rbacUtil.TestCase{
+				newTestCase(a, "/request-headers", map[string]string{"x-foo": "foo"}, true),
+				newTestCase(b, "/request-headers", map[string]string{"x-foo": "foo"}, true),
+				newTestCase(a, "/request-headers", map[string]string{"x-foo": "bar"}, false),
+				newTestCase(b, "/request-headers", map[string]string{"x-foo": "bar"}, false),
+				newTestCase(a, "/request-headers", nil, false),
+				newTestCase(b, "/request-headers", nil, false),
+
+				newTestCase(a, "/source-ip-a", nil, true),
+				newTestCase(b, "/source-ip-a", nil, false),
+				newTestCase(a, "/source-ip-b", nil, false),
+				newTestCase(b, "/source-ip-b", nil, true),
+
+				newTestCase(a, "/source-namespace-a", nil, true),
+				newTestCase(b, "/source-namespace-a", nil, false),
+				newTestCase(a, "/source-namespace-b", nil, false),
+				newTestCase(b, "/source-namespace-b", nil, true),
+
+				newTestCase(a, "/source-principal-a", nil, true),
+				newTestCase(b, "/source-principal-a", nil, false),
+				newTestCase(a, "/source-principal-b", nil, false),
+				newTestCase(b, "/source-principal-b", nil, true),
+
+				newTestCase(a, "/destination-ip-good", nil, true),
+				newTestCase(b, "/destination-ip-good", nil, true),
+				newTestCase(a, "/destination-ip-bad", nil, false),
+				newTestCase(b, "/destination-ip-bad", nil, false),
+
+				newTestCase(a, "/destination-port-good", nil, true),
+				newTestCase(b, "/destination-port-good", nil, true),
+				newTestCase(a, "/destination-port-bad", nil, false),
+				newTestCase(b, "/destination-port-bad", nil, false),
+
+				newTestCase(a, "/connection-sni-good", nil, true),
+				newTestCase(b, "/connection-sni-good", nil, true),
+				newTestCase(a, "/connection-sni-bad", nil, false),
+				newTestCase(b, "/connection-sni-bad", nil, false),
+
+				newTestCase(a, "/other", nil, false),
+				newTestCase(b, "/other", nil, false),
 			}
 
 			rbacUtil.RunRBACTest(t, cases)

--- a/tests/integration/security/testdata/rbac/v1beta1-conditions.yaml.tmpl
+++ b/tests/integration/security/testdata/rbac/v1beta1-conditions.yaml.tmpl
@@ -1,0 +1,189 @@
+# The following policy enables mTLS for workload c.
+
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: mtls
+  namespace: "{{ .NamespaceC }}"
+spec:
+  selector:
+    matchLabels:
+      app: c
+  mtls:
+    mode: STRICT
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: mtls
+  namespace: "{{ .NamespaceC }}"
+spec:
+  host: "c.{{ .NamespaceC }}.svc.cluster.local"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+---
+
+# Each of the following authorization policy uses a different condition on the given path.
+
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: condition-request-headers
+  namespace: "{{ .NamespaceC }}"
+spec:
+  selector:
+    matchLabels:
+      app: c
+  rules:
+  - to:
+    - operation:
+        paths: ["/request-headers"]
+    when:
+    - key: request.headers[x-foo]
+      values: ["foo"]
+---
+
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: condition-source-ip
+  namespace: "{{ .NamespaceC }}"
+spec:
+  selector:
+    matchLabels:
+      app: c
+  rules:
+  - to:
+    - operation:
+        paths: ["/source-ip-a"]
+    when:
+    - key: source.ip
+      values: ["{{ .IpA }}"]
+  - to:
+    - operation:
+        paths: ["/source-ip-b"]
+    when:
+    - key: source.ip
+      values: ["{{ .IpB }}"]
+---
+
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: condition-source-namespace
+  namespace: "{{ .NamespaceC }}"
+spec:
+  selector:
+    matchLabels:
+      app: c
+  rules:
+  - to:
+    - operation:
+        paths: ["/source-namespace-a"]
+    when:
+    - key: source.namespace
+      values: ["{{ .NamespaceA }}"]
+  - to:
+    - operation:
+        paths: ["/source-namespace-b"]
+    when:
+    - key: source.namespace
+      values: ["{{ .NamespaceB }}"]
+---
+
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: condition-source-principal
+  namespace: "{{ .NamespaceC }}"
+spec:
+  selector:
+    matchLabels:
+      app: c
+  rules:
+  - to:
+    - operation:
+        paths: ["/source-principal-a"]
+    when:
+    - key: source.principal
+      values: ["cluster.local/ns/{{ .NamespaceA }}/sa/a"]
+  - to:
+    - operation:
+        paths: ["/source-principal-b"]
+    when:
+    - key: source.principal
+      values: ["cluster.local/ns/{{ .NamespaceB }}/sa/b"]
+---
+
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: condition-destination-ip
+  namespace: "{{ .NamespaceC }}"
+spec:
+  selector:
+    matchLabels:
+      app: c
+  rules:
+  - to:
+    - operation:
+        paths: ["/destination-ip-good"]
+    when:
+    - key: destination.ip
+      values: ["{{ .IpC }}"]
+  - to:
+    - operation:
+        paths: ["/destination-ip-bad"]
+    when:
+    - key: destination.ip
+      values: ["1.2.3.4"]
+---
+
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: condition-destination-port
+  namespace: "{{ .NamespaceC }}"
+spec:
+  selector:
+    matchLabels:
+      app: c
+  rules:
+  - to:
+    - operation:
+        paths: ["/destination-port-good"]
+    when:
+    - key: destination.port
+      values: ["{{ .PortC }}"]
+  - to:
+    - operation:
+        paths: ["/destination-port-bad"]
+    when:
+    - key: destination.port
+      values: ["1"]
+---
+
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: condition-connection-sni
+  namespace: "{{ .NamespaceC }}"
+spec:
+  selector:
+    matchLabels:
+      app: c
+  rules:
+  - to:
+    - operation:
+        paths: ["/connection-sni-good"]
+    when:
+    - key: connection.sni
+      values: ["*.c.{{ .NamespaceC }}.svc.cluster.local"]
+  - to:
+    - operation:
+        paths: ["/connection-sni-bad"]
+    when:
+    - key: connection.sni
+      values: ["never-matched"]
+---

--- a/tests/integration/security/util/rbac_util/util.go
+++ b/tests/integration/security/util/rbac_util/util.go
@@ -31,6 +31,7 @@ type TestCase struct {
 	Request       connection.Checker
 	ExpectAllowed bool
 	Jwt           string
+	Headers       map[string]string
 }
 
 func getError(req connection.Checker, expect, actual string) error {
@@ -56,6 +57,9 @@ func (tc TestCase) CheckRBACRequest() error {
 	headers := make(http.Header)
 	if len(tc.Jwt) > 0 {
 		headers.Add("Authorization", "Bearer "+tc.Jwt)
+	}
+	for k, v := range tc.Headers {
+		headers.Add(k, v)
 	}
 	tc.Request.Options.Headers = headers
 


### PR DESCRIPTION
This PR adds e2e tests for all the conditions (e.g. `source.ip`, `destination.port`, `connection.sni`, etc.) in the authorization policy.