### PR TITLE
Cherry pick: Change to installer/helm to use peer authentication for global mTLS enable (#21017)

### DIFF
--- a/manifests/istio-control/istio-discovery/templates/enable-mesh-mtls.yaml
+++ b/manifests/istio-control/istio-discovery/templates/enable-mesh-mtls.yaml
@@ -47,18 +47,5 @@ spec:
     tls:
       mode: DISABLE
 ---
-{{- else }}
-# Authentication policy to enable permissive mode for all services (that have sidecar) in the mesh.
-apiVersion: "authentication.istio.io/v1alpha1"
-kind: "MeshPolicy"
-metadata:
-  name: "default"
-  labels:
-    release: {{ .Release.Name }}
-spec:
-  peers:
-  - mtls:
-      mode: PERMISSIVE
----
 {{ end }}
 {{ end }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.yaml
@@ -8779,19 +8779,6 @@ spec:
 ---
 
 
-apiVersion: "authentication.istio.io/v1alpha1"
-kind: "MeshPolicy"
-metadata:
-  name: "default"
-  labels:
-    release: istio
-spec:
-  peers:
-  - mtls:
-      mode: PERMISSIVE
----
-
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.yaml
@@ -7740,19 +7740,6 @@ spec:
 ---
 
 
-apiVersion: "authentication.istio.io/v1alpha1"
-kind: "MeshPolicy"
-metadata:
-  name: "default"
-  labels:
-    release: istio
-spec:
-  peers:
-  - mtls:
-      mode: PERMISSIVE
----
-
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_force.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_force.yaml
@@ -697,19 +697,6 @@ spec:
 ---
 
 
-apiVersion: "authentication.istio.io/v1alpha1"
-kind: "MeshPolicy"
-metadata:
-  name: "default"
-  labels:
-    release: istio
-spec:
-  peers:
-  - mtls:
-      mode: PERMISSIVE
----
-
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output.yaml
@@ -695,19 +695,6 @@ spec:
 ---
 
 
-apiVersion: "authentication.istio.io/v1alpha1"
-kind: "MeshPolicy"
-metadata:
-  name: "default"
-  labels:
-    release: istio
-spec:
-  peers:
-  - mtls:
-      mode: PERMISSIVE
----
-
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.yaml
@@ -6589,19 +6589,6 @@ spec:
 ---
 
 
-apiVersion: "authentication.istio.io/v1alpha1"
-kind: "MeshPolicy"
-metadata:
-  name: "default"
-  labels:
-    release: istio
-spec:
-  peers:
-  - mtls:
-      mode: PERMISSIVE
----
-
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.yaml
@@ -7530,19 +7530,6 @@ spec:
 ---
 
 
-apiVersion: "authentication.istio.io/v1alpha1"
-kind: "MeshPolicy"
-metadata:
-  name: "default"
-  labels:
-    release: istio
-spec:
-  peers:
-  - mtls:
-      mode: PERMISSIVE
----
-
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_override_values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_override_values.yaml
@@ -695,19 +695,6 @@ spec:
 ---
 
 
-apiVersion: "authentication.istio.io/v1alpha1"
-kind: "MeshPolicy"
-metadata:
-  name: "default"
-  labels:
-    release: istio
-spec:
-  peers:
-  - mtls:
-      mode: PERMISSIVE
----
-
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.yaml
@@ -7532,19 +7532,6 @@ spec:
 ---
 
 
-apiVersion: "authentication.istio.io/v1alpha1"
-kind: "MeshPolicy"
-metadata:
-  name: "default"
-  labels:
-    release: istio
-spec:
-  peers:
-  - mtls:
-      mode: PERMISSIVE
----
-
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.yaml
@@ -695,19 +695,6 @@ spec:
 ---
 
 
-apiVersion: "authentication.istio.io/v1alpha1"
-kind: "MeshPolicy"
-metadata:
-  name: "default"
-  labels:
-    release: istio
-spec:
-  peers:
-  - mtls:
-      mode: PERMISSIVE
----
-
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.yaml
@@ -701,19 +701,6 @@ spec:
 ---
 
 
-apiVersion: "authentication.istio.io/v1alpha1"
-kind: "MeshPolicy"
-metadata:
-  name: "default"
-  labels:
-    release: istio
-spec:
-  peers:
-  - mtls:
-      mode: PERMISSIVE
----
-
-
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -14062,19 +14062,6 @@ spec:
     tls:
       mode: DISABLE
 ---
-{{- else }}
-# Authentication policy to enable permissive mode for all services (that have sidecar) in the mesh.
-apiVersion: "authentication.istio.io/v1alpha1"
-kind: "MeshPolicy"
-metadata:
-  name: "default"
-  labels:
-    release: {{ .Release.Name }}
-spec:
-  peers:
-  - mtls:
-      mode: PERMISSIVE
----
 {{ end }}
 {{ end }}
 `)


### PR DESCRIPTION
git cherry-pick 9fa013cda7007db174d401b6fb93812562e72587

* Change to installer/helm to use peer authentication for global mTLS enable

* Rerun gen-charts

* Update operator unit tests

* Revert changes under install/kubernetes folder

* Fix the old e2e test for authn-policy.

* Disable dashboard test for galley_istio_authentication_meshpolicies query

* Fix typo

* Revert commit 58984591a (Fix the old e2e test for authn-policy)

* Revert dashboard test

* Revert enable-mesh-mtls manifest for mtls enabled

* Regen assets

* Revert install/kuberenetes/ template