### PR TITLE
add contextPath to grafana and prometheus deployment to support ingress sub path rule

### DIFF
--- a/install/kubernetes/helm/istio/charts/grafana/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/deployment.yaml
@@ -74,6 +74,12 @@ spec:
           - name: GF_AUTH_ANONYMOUS_ORG_ROLE
             value: Admin
 {{- end }}
+{{- if $.Values.contextPath }}
+          - name: GF_SERVER_ROOT_URL
+            value: "%(protocol)s://%(domain)s:%(http_port)s{{- $.Values.contextPath -}}"
+          - name: GF_SERVER_SERVE_FROM_SUB_PATH
+            value: "true"
+{{- end }}
           - name: GF_PATHS_DATA
             value: /data/grafana
           {{- range $key, $value := $.Values.env }}

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
@@ -35,16 +35,17 @@ spec:
           args:
             - '--storage.tsdb.retention={{ .Values.retention }}'
             - '--config.file=/etc/prometheus/prometheus.yml'
+            - '--web.external-url={{ if $.Values.contextPath }} {{- $.Values.contextPath -}} {{ else }}/{{ end }}'
           ports:
             - containerPort: 9090
               name: http
           livenessProbe:
             httpGet:
-              path: /-/healthy
+              path: {{ $.Values.contextPath }}/-/healthy
               port: 9090
           readinessProbe:
             httpGet:
-              path: /-/ready
+              path: {{ $.Values.contextPath }}/-/ready
               port: 9090
           resources:
 {{- if .Values.resources }}


### PR DESCRIPTION
Now if I set `ingress.enabled=true`, deployment template not support `contextPath`, must set `contextPath=/`.