### PR TITLE
istioctl manifest and profile enhancements (#20912)

### DIFF
--- a/istioctl/cmd/version.go
+++ b/istioctl/cmd/version.go
@@ -38,6 +38,7 @@ func newVersionCommand() *cobra.Command {
 		GetRemoteVersion: getRemoteInfo,
 		GetProxyVersions: getProxyInfo,
 	})
+
 	versionCmd.Flags().VisitAll(func(flag *pflag.Flag) {
 		if flag.Name == "short" {
 			err := flag.Value.Set("true")

--- a/operator/cmd/mesh/manifest-common.go
+++ b/operator/cmd/mesh/manifest-common.go
@@ -22,12 +22,10 @@ import (
 
 	"github.com/ghodss/yaml"
 
-	"istio.io/istio/operator/pkg/tpath"
-
-	"istio.io/istio/operator/pkg/validate"
-
 	"istio.io/api/operator/v1alpha1"
+	"istio.io/istio/operator/pkg/tpath"
 	"istio.io/istio/operator/pkg/util"
+	"istio.io/istio/operator/pkg/validate"
 )
 
 var (

--- a/operator/cmd/mesh/testdata/profile-dump/output/all_off.yaml
+++ b/operator/cmd/mesh/testdata/profile-dump/output/all_off.yaml
@@ -1,260 +1,36 @@
-addonComponents:
-  prometheus:
-    enabled: true
-components:
-  base:
-    enabled: true
-  citadel:
-    enabled: false
-    k8s:
-      strategy:
-        rollingUpdate:
-          maxSurge: 100%
-          maxUnavailable: 25%
-  cni:
-    enabled: false
-  egressGateways:
-  - enabled: false
-    k8s:
-      hpaSpec:
-        maxReplicas: 5
-        metrics:
-        - resource:
-            name: cpu
-            targetAverageUtilization: 80
-          type: Resource
-        minReplicas: 1
-        scaleTargetRef:
-          apiVersion: apps/v1
-          kind: Deployment
-          name: istio-ingressgateway
-      resources:
-        limits:
-          cpu: 2000m
-          memory: 1024Mi
-        requests:
-          cpu: 100m
-          memory: 128Mi
-      strategy:
-        rollingUpdate:
-          maxSurge: 100%
-          maxUnavailable: 25%
-    name: istio-egressgateway
-  galley:
-    enabled: false
-    k8s:
-      replicaCount: 1
-      resources:
-        requests:
-          cpu: 100m
-      strategy:
-        rollingUpdate:
-          maxSurge: 100%
-          maxUnavailable: 25%
-  ingressGateways:
-  - enabled: true
-    k8s:
-      hpaSpec:
-        maxReplicas: 5
-        metrics:
-        - resource:
-            name: cpu
-            targetAverageUtilization: 80
-          type: Resource
-        minReplicas: 1
-        scaleTargetRef:
-          apiVersion: apps/v1
-          kind: Deployment
-          name: istio-ingressgateway
-      resources:
-        limits:
-          cpu: 2000m
-          memory: 1024Mi
-        requests:
-          cpu: 100m
-          memory: 128Mi
-      strategy:
-        rollingUpdate:
-          maxSurge: 100%
-          maxUnavailable: 25%
-    name: istio-ingressgateway
-  nodeAgent:
-    enabled: false
-  pilot:
-    enabled: false
-    k8s:
-      env:
-      - name: POD_NAME
-        valueFrom:
-          fieldRef:
-            apiVersion: v1
-            fieldPath: metadata.name
-      - name: POD_NAMESPACE
-        valueFrom:
-          fieldRef:
-            apiVersion: v1
-            fieldPath: metadata.namespace
-      readinessProbe:
-        httpGet:
-          path: /ready
-          port: 8080
-        initialDelaySeconds: 5
-        periodSeconds: 5
-        timeoutSeconds: 5
-      resources:
-        requests:
-          cpu: 500m
-          memory: 2048Mi
-      strategy:
-        rollingUpdate:
-          maxSurge: 100%
-          maxUnavailable: 25%
-  policy:
-    enabled: false
-    k8s:
-      env:
-      - name: POD_NAMESPACE
-        valueFrom:
-          fieldRef:
-            apiVersion: v1
-            fieldPath: metadata.namespace
-      hpaSpec:
-        maxReplicas: 5
-        metrics:
-        - resource:
-            name: cpu
-            targetAverageUtilization: 80
-          type: Resource
-        minReplicas: 1
-        scaleTargetRef:
-          apiVersion: apps/v1
-          kind: Deployment
-          name: istio-policy
-      strategy:
-        rollingUpdate:
-          maxSurge: 100%
-          maxUnavailable: 25%
-  proxy:
-    enabled: false
-  sidecarInjector:
-    enabled: false
-    k8s:
-      replicaCount: 1
-      strategy:
-        rollingUpdate:
-          maxSurge: 100%
-          maxUnavailable: 25%
-  telemetry:
-    enabled: false
-    k8s:
-      env:
-      - name: POD_NAMESPACE
-        valueFrom:
-          fieldRef:
-            apiVersion: v1
-            fieldPath: metadata.namespace
-      - name: GOMAXPROCS
-        value: "6"
-      hpaSpec:
-        maxReplicas: 5
-        metrics:
-        - resource:
-            name: cpu
-            targetAverageUtilization: 80
-          type: Resource
-        minReplicas: 1
-        scaleTargetRef:
-          apiVersion: apps/v1
-          kind: Deployment
-          name: istio-telemetry
-      replicaCount: 1
-      resources:
-        limits:
-          cpu: 4800m
-          memory: 4G
-        requests:
-          cpu: 1000m
-          memory: 1G
-      strategy:
-        rollingUpdate:
-          maxSurge: 100%
-          maxUnavailable: 25%
-hub: gcr.io/istio-testing
-profile: default
-tag: latest
-values:
-  clusterResources: true
-  galley:
-    enableAnalysis: false
-    image: galley
-  gateways:
-    istio-egressgateway:
-      autoscaleEnabled: true
-      env:
-        ISTIO_META_ROUTER_MODE: sni-dnat
-      ports:
-      - name: http2
-        port: 80
-      - name: https
-        port: 443
-      - name: tls
-        port: 15443
-        targetPort: 15443
-      secretVolumes:
-      - mountPath: /etc/istio/egressgateway-certs
-        name: egressgateway-certs
-        secretName: istio-egressgateway-certs
-      - mountPath: /etc/istio/egressgateway-ca-certs
-        name: egressgateway-ca-certs
-        secretName: istio-egressgateway-ca-certs
-      type: ClusterIP
-      zvpn:
-        enabled: true
-        suffix: global
-    istio-ingressgateway:
-      applicationPorts: ""
-      autoscaleEnabled: true
-      debug: info
-      domain: ""
-      env:
-        ISTIO_META_ROUTER_MODE: sni-dnat
-      meshExpansionPorts:
-      - name: tcp-pilot-grpc-tls
-        port: 15011
-        targetPort: 15011
-      - name: tcp-citadel-grpc-tls
-        port: 8060
-        targetPort: 8060
-      - name: tcp-dns-tls
-        port: 853
-        targetPort: 853
-      ports:
-      - name: status-port
-        port: 15020
-        targetPort: 15020
-      - name: http2
-        port: 80
-        targetPort: 80
-      - name: https
-        port: 443
-      - name: kiali
-        port: 15029
-        targetPort: 15029
-      - name: prometheus
-        port: 15030
-        targetPort: 15030
-      - name: grafana
-        port: 15031
-        targetPort: 15031
-      - name: tracing
-        port: 15032
-        targetPort: 15032
-      - name: tls
-        port: 15443
-        targetPort: 15443
-      sds:
-        enabled: false
-        image: node-agent-k8s
+apiVersion: operator.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  addonComponents:
+    prometheus:
+      enabled: true
+  components:
+    base:
+      enabled: true
+    citadel:
+      enabled: false
+      k8s:
+        strategy:
+          rollingUpdate:
+            maxSurge: 100%
+            maxUnavailable: 25%
+    cni:
+      enabled: false
+    egressGateways:
+    - enabled: false
+      k8s:
+        hpaSpec:
+          maxReplicas: 5
+          metrics:
+          - resource:
+              name: cpu
+              targetAverageUtilization: 80
+            type: Resource
+          minReplicas: 1
+          scaleTargetRef:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: istio-ingressgateway
         resources:
           limits:
             cpu: 2000m
@@ -262,417 +38,618 @@ values:
           requests:
             cpu: 100m
             memory: 128Mi
-      secretVolumes:
-      - mountPath: /etc/istio/ingressgateway-certs
-        name: ingressgateway-certs
-        secretName: istio-ingressgateway-certs
-      - mountPath: /etc/istio/ingressgateway-ca-certs
-        name: ingressgateway-ca-certs
-        secretName: istio-ingressgateway-ca-certs
-      type: LoadBalancer
-      zvpn:
-        enabled: true
-        suffix: global
-  global:
-    arch:
-      amd64: 2
-      ppc64le: 2
-      s390x: 2
-    certificates: []
-    configValidation: true
-    controlPlaneSecurityEnabled: true
-    defaultNodeSelector: {}
-    defaultPodDisruptionBudget:
-      enabled: true
-    defaultResources:
-      requests:
-        cpu: 10m
-    disablePolicyChecks: true
-    enableHelmTest: false
-    enableTracing: true
-    imagePullPolicy: IfNotPresent
-    imagePullSecrets: []
-    istioNamespace: istio-system
-    istiod:
-      enabled: true
-    jwtPolicy: third-party-jwt
-    k8sIngress:
-      enableHttps: false
+        strategy:
+          rollingUpdate:
+            maxSurge: 100%
+            maxUnavailable: 25%
+      name: istio-egressgateway
+    galley:
       enabled: false
-      gatewayName: ingressgateway
-    localityLbSetting:
-      enabled: true
-    logAsJson: false
-    logging:
-      level: default:info
-    meshExpansion:
+      k8s:
+        replicaCount: 1
+        resources:
+          requests:
+            cpu: 100m
+        strategy:
+          rollingUpdate:
+            maxSurge: 100%
+            maxUnavailable: 25%
+    ingressGateways:
+    - enabled: true
+      k8s:
+        hpaSpec:
+          maxReplicas: 5
+          metrics:
+          - resource:
+              name: cpu
+              targetAverageUtilization: 80
+            type: Resource
+          minReplicas: 1
+          scaleTargetRef:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: istio-ingressgateway
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 1024Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        strategy:
+          rollingUpdate:
+            maxSurge: 100%
+            maxUnavailable: 25%
+      name: istio-ingressgateway
+    nodeAgent:
       enabled: false
-      useILB: false
-    meshNetworks: {}
-    mountMtlsCerts: false
-    mtls:
-      auto: true
+    pilot:
       enabled: false
-    multiCluster:
-      clusterName: ""
+      k8s:
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 500m
+            memory: 2048Mi
+        strategy:
+          rollingUpdate:
+            maxSurge: 100%
+            maxUnavailable: 25%
+    policy:
       enabled: false
-    network: ""
-    omitSidecarInjectorConfigMap: false
-    oneNamespace: false
-    operatorManageWebhooks: false
-    outboundTrafficPolicy:
-      mode: ALLOW_ANY
-    pilotCertProvider: citadel
-    policyCheckFailOpen: false
-    priorityClassName: ""
+      k8s:
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        hpaSpec:
+          maxReplicas: 5
+          metrics:
+          - resource:
+              name: cpu
+              targetAverageUtilization: 80
+            type: Resource
+          minReplicas: 1
+          scaleTargetRef:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: istio-policy
+        strategy:
+          rollingUpdate:
+            maxSurge: 100%
+            maxUnavailable: 25%
     proxy:
-      accessLogEncoding: TEXT
-      accessLogFile: ""
-      accessLogFormat: ""
-      autoInject: enabled
-      clusterDomain: cluster.local
-      componentLogLevel: misc:error
-      concurrency: 2
-      dnsRefreshRate: 300s
-      enableCoreDump: false
-      envoyAccessLogService:
-        enabled: false
-        host: null
-        port: null
-      envoyMetricsService:
-        enabled: false
-        host: null
-        port: null
-        tcpKeepalive:
-          interval: 10s
-          probes: 3
-          time: 10s
-        tlsSettings:
-          caCertificates: null
-          clientCertificate: null
-          mode: DISABLE
-          privateKey: null
-          sni: null
-          subjectAltNames: []
-      envoyStatsd:
-        enabled: false
-        host: null
-        port: null
-      excludeIPRanges: ""
-      excludeInboundPorts: ""
-      excludeOutboundPorts: ""
-      image: proxyv2
-      includeIPRanges: '*'
-      includeInboundPorts: '*'
-      kubevirtInterfaces: ""
-      logLevel: warning
-      privileged: false
-      protocolDetectionTimeout: 100ms
-      readinessFailureThreshold: 30
-      readinessInitialDelaySeconds: 1
-      readinessPeriodSeconds: 2
-      resources:
-        limits:
-          cpu: 2000m
-          memory: 1024Mi
-        requests:
-          cpu: 100m
-          memory: 128Mi
-      statusPort: 15020
-      tracer: zipkin
-    proxy_init:
-      image: proxyv2
-      resources:
-        limits:
-          cpu: 100m
-          memory: 50Mi
+      enabled: false
+    sidecarInjector:
+      enabled: false
+      k8s:
+        replicaCount: 1
+        strategy:
+          rollingUpdate:
+            maxSurge: 100%
+            maxUnavailable: 25%
+    telemetry:
+      enabled: false
+      k8s:
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: GOMAXPROCS
+          value: "6"
+        hpaSpec:
+          maxReplicas: 5
+          metrics:
+          - resource:
+              name: cpu
+              targetAverageUtilization: 80
+            type: Resource
+          minReplicas: 1
+          scaleTargetRef:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: istio-telemetry
+        replicaCount: 1
+        resources:
+          limits:
+            cpu: 4800m
+            memory: 4G
+          requests:
+            cpu: 1000m
+            memory: 1G
+        strategy:
+          rollingUpdate:
+            maxSurge: 100%
+            maxUnavailable: 25%
+  hub: gcr.io/istio-testing
+  profile: default
+  tag: latest
+  values:
+    clusterResources: true
+    galley:
+      enableAnalysis: false
+      image: galley
+    gateways:
+      istio-egressgateway:
+        autoscaleEnabled: true
+        env:
+          ISTIO_META_ROUTER_MODE: sni-dnat
+        ports:
+        - name: http2
+          port: 80
+        - name: https
+          port: 443
+        - name: tls
+          port: 15443
+          targetPort: 15443
+        secretVolumes:
+        - mountPath: /etc/istio/egressgateway-certs
+          name: egressgateway-certs
+          secretName: istio-egressgateway-certs
+        - mountPath: /etc/istio/egressgateway-ca-certs
+          name: egressgateway-ca-certs
+          secretName: istio-egressgateway-ca-certs
+        type: ClusterIP
+        zvpn:
+          enabled: true
+          suffix: global
+      istio-ingressgateway:
+        applicationPorts: ""
+        autoscaleEnabled: true
+        debug: info
+        domain: ""
+        env:
+          ISTIO_META_ROUTER_MODE: sni-dnat
+        meshExpansionPorts:
+        - name: tcp-pilot-grpc-tls
+          port: 15011
+          targetPort: 15011
+        - name: tcp-citadel-grpc-tls
+          port: 8060
+          targetPort: 8060
+        - name: tcp-dns-tls
+          port: 853
+          targetPort: 853
+        ports:
+        - name: status-port
+          port: 15020
+          targetPort: 15020
+        - name: http2
+          port: 80
+          targetPort: 80
+        - name: https
+          port: 443
+        - name: kiali
+          port: 15029
+          targetPort: 15029
+        - name: prometheus
+          port: 15030
+          targetPort: 15030
+        - name: grafana
+          port: 15031
+          targetPort: 15031
+        - name: tracing
+          port: 15032
+          targetPort: 15032
+        - name: tls
+          port: 15443
+          targetPort: 15443
+        sds:
+          enabled: false
+          image: node-agent-k8s
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 1024Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+        secretVolumes:
+        - mountPath: /etc/istio/ingressgateway-certs
+          name: ingressgateway-certs
+          secretName: istio-ingressgateway-certs
+        - mountPath: /etc/istio/ingressgateway-ca-certs
+          name: ingressgateway-ca-certs
+          secretName: istio-ingressgateway-ca-certs
+        type: LoadBalancer
+        zvpn:
+          enabled: true
+          suffix: global
+    global:
+      arch:
+        amd64: 2
+        ppc64le: 2
+        s390x: 2
+      certificates: []
+      configValidation: true
+      controlPlaneSecurityEnabled: true
+      defaultNodeSelector: {}
+      defaultPodDisruptionBudget:
+        enabled: true
+      defaultResources:
         requests:
           cpu: 10m
-          memory: 10Mi
-    sds:
-      enabled: false
-      token:
-        aud: istio-ca
-      udsPath: ""
-    sts:
-      servicePort: 0
-    tracer:
-      datadog:
-        address: $(HOST_IP):8126
-      lightstep:
-        accessToken: ""
-        address: ""
-        cacertPath: ""
-        secure: true
-      stackdriver:
-        debug: false
-        maxNumberOfAnnotations: 200
-        maxNumberOfAttributes: 200
-        maxNumberOfMessageEvents: 200
-      zipkin:
-        address: ""
-    trustDomain: cluster.local
-    useMCP: false
-  grafana:
-    accessMode: ReadWriteMany
-    contextPath: /grafana
-    dashboardProviders:
-      dashboardproviders.yaml:
-        apiVersion: 1
-        providers:
-        - disableDeletion: false
-          folder: istio
-          name: istio
-          options:
-            path: /var/lib/grafana/dashboards/istio
-          orgId: 1
-          type: file
-    datasources:
-      datasources.yaml:
-        apiVersion: 1
-        datasources: null
-    enabled: false
-    env: {}
-    envSecrets: {}
-    image:
-      repository: grafana/grafana
-      tag: 6.5.2
-    ingress:
-      annotations: null
-      enabled: false
-      hosts:
-      - grafana.local
-      tls: null
-    nodeSelector: {}
-    persist: false
-    podAntiAffinityLabelSelector: []
-    podAntiAffinityTermLabelSelector: []
-    replicaCount: 1
-    security:
-      enabled: false
-      passphraseKey: passphrase
-      secretName: grafana
-      usernameKey: username
-    service:
-      annotations: {}
-      externalPort: 3000
-      loadBalancerIP: null
-      loadBalancerSourceRanges: null
-      name: http
-      type: ClusterIP
-    storageClassName: ""
-    tolerations: []
-  istiocoredns:
-    coreDNSImage: coredns/coredns
-    coreDNSPluginImage: istio/coredns-plugin:0.2-istio-1.1
-    coreDNSTag: 1.6.2
-    enabled: false
-  kiali:
-    contextPath: /kiali
-    createDemoSecret: false
-    dashboard:
-      grafanaURL: null
-      jaegerURL: null
-      passphraseKey: passphrase
-      secretName: kiali
-      usernameKey: username
-      viewOnlyMode: false
-    enabled: false
-    hub: quay.io/kiali
-    ingress:
-      annotations: null
-      enabled: false
-      hosts:
-      - kiali.local
-      tls: null
-    nodeSelector: {}
-    podAntiAffinityLabelSelector: []
-    podAntiAffinityTermLabelSelector: []
-    prometheusNamespace: null
-    replicaCount: 1
-    security:
-      cert_file: /kiali-cert/cert-chain.pem
-      enabled: false
-      private_key_file: /kiali-cert/key.pem
-    tag: v1.9
-  mixer:
-    adapters:
-      kubernetesenv:
+      disablePolicyChecks: true
+      enableHelmTest: false
+      enableTracing: true
+      imagePullPolicy: IfNotPresent
+      imagePullSecrets: []
+      istioNamespace: istio-system
+      istiod:
         enabled: true
-      prometheus:
-        enabled: true
-        metricsExpiryDuration: 10m
-      stackdriver:
-        auth:
-          apiKey: ""
-          appCredentials: false
-          serviceAccountPath: ""
+      jwtPolicy: third-party-jwt
+      k8sIngress:
+        enableHttps: false
         enabled: false
-        tracer:
+        gatewayName: ingressgateway
+      localityLbSetting:
+        enabled: true
+      logAsJson: false
+      logging:
+        level: default:info
+      meshExpansion:
+        enabled: false
+        useILB: false
+      meshNetworks: {}
+      mountMtlsCerts: false
+      mtls:
+        auto: true
+        enabled: false
+      multiCluster:
+        clusterName: ""
+        enabled: false
+      network: ""
+      omitSidecarInjectorConfigMap: false
+      oneNamespace: false
+      operatorManageWebhooks: false
+      outboundTrafficPolicy:
+        mode: ALLOW_ANY
+      pilotCertProvider: citadel
+      policyCheckFailOpen: false
+      priorityClassName: ""
+      proxy:
+        accessLogEncoding: TEXT
+        accessLogFile: ""
+        accessLogFormat: ""
+        autoInject: enabled
+        clusterDomain: cluster.local
+        componentLogLevel: misc:error
+        concurrency: 2
+        dnsRefreshRate: 300s
+        enableCoreDump: false
+        envoyAccessLogService:
           enabled: false
-          sampleProbability: 1
-      stdio:
+        envoyMetricsService:
+          enabled: false
+          tcpKeepalive:
+            interval: 10s
+            probes: 3
+            time: 10s
+          tlsSettings:
+            mode: DISABLE
+            subjectAltNames: []
+        envoyStatsd:
+          enabled: false
+        excludeIPRanges: ""
+        excludeInboundPorts: ""
+        excludeOutboundPorts: ""
+        image: proxyv2
+        includeIPRanges: '*'
+        includeInboundPorts: '*'
+        kubevirtInterfaces: ""
+        logLevel: warning
+        privileged: false
+        protocolDetectionTimeout: 100ms
+        readinessFailureThreshold: 30
+        readinessInitialDelaySeconds: 1
+        readinessPeriodSeconds: 2
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 1024Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        statusPort: 15020
+        tracer: zipkin
+      proxy_init:
+        image: proxyv2
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 10m
+            memory: 10Mi
+      sds:
         enabled: false
-        outputAsJson: false
-      useAdapterCRDs: false
-    policy:
-      adapters:
-        kubernetesenv:
-          enabled: true
-        useAdapterCRDs: false
-      autoscaleEnabled: true
-      image: mixer
-      sessionAffinityEnabled: false
-    telemetry:
-      autoscaleEnabled: true
-      env:
-        GOMAXPROCS: "6"
-      image: mixer
-      loadshedding:
-        latencyThreshold: 100ms
-        mode: enforce
+        token:
+          aud: istio-ca
+        udsPath: ""
+      sts:
+        servicePort: 0
+      tracer:
+        datadog:
+          address: $(HOST_IP):8126
+        lightstep:
+          accessToken: ""
+          address: ""
+          cacertPath: ""
+          secure: true
+        stackdriver:
+          debug: false
+          maxNumberOfAnnotations: 200
+          maxNumberOfAttributes: 200
+          maxNumberOfMessageEvents: 200
+        zipkin:
+          address: ""
+      trustDomain: cluster.local
+      useMCP: false
+    grafana:
+      accessMode: ReadWriteMany
+      contextPath: /grafana
+      dashboardProviders:
+        dashboardproviders.yaml:
+          apiVersion: 1
+          providers:
+          - disableDeletion: false
+            folder: istio
+            name: istio
+            options:
+              path: /var/lib/grafana/dashboards/istio
+            orgId: 1
+            type: file
+      datasources:
+        datasources.yaml:
+          apiVersion: 1
+      enabled: false
+      env: {}
+      envSecrets: {}
+      image:
+        repository: grafana/grafana
+        tag: 6.5.2
+      ingress:
+        enabled: false
+        hosts:
+        - grafana.local
+      nodeSelector: {}
+      persist: false
+      podAntiAffinityLabelSelector: []
+      podAntiAffinityTermLabelSelector: []
+      replicaCount: 1
+      security:
+        enabled: false
+        passphraseKey: passphrase
+        secretName: grafana
+        usernameKey: username
+      service:
+        annotations: {}
+        externalPort: 3000
+        name: http
+        type: ClusterIP
+      storageClassName: ""
+      tolerations: []
+    istiocoredns:
+      coreDNSImage: coredns/coredns
+      coreDNSPluginImage: istio/coredns-plugin:0.2-istio-1.1
+      coreDNSTag: 1.6.2
+      enabled: false
+    kiali:
+      contextPath: /kiali
+      createDemoSecret: false
+      dashboard:
+        passphraseKey: passphrase
+        secretName: kiali
+        usernameKey: username
+        viewOnlyMode: false
+      enabled: false
+      hub: quay.io/kiali
+      ingress:
+        enabled: false
+        hosts:
+        - kiali.local
       nodeSelector: {}
       podAntiAffinityLabelSelector: []
       podAntiAffinityTermLabelSelector: []
       replicaCount: 1
-      reportBatchMaxEntries: 100
-      reportBatchMaxTime: 1s
-      sessionAffinityEnabled: false
-      tolerations: []
-  nodeagent:
-    image: node-agent-k8s
-  pilot:
-    appNamespaces: []
-    autoscaleEnabled: true
-    autoscaleMax: 5
-    autoscaleMin: 1
-    configMap: true
-    configNamespace: istio-config
-    cpu:
-      targetAverageUtilization: 80
-    deploymentLabels: null
-    enableProtocolSniffingForInbound: false
-    enableProtocolSniffingForOutbound: true
-    env: {}
-    image: pilot
-    ingress:
-      ingressClass: istio
-      ingressControllerMode: STRICT
-      ingressService: istio-ingressgateway
-    keepaliveMaxServerConnectionAge: 30m
-    meshNetworks:
-      networks: {}
-    nodeSelector: {}
-    podAntiAffinityLabelSelector: []
-    podAntiAffinityTermLabelSelector: []
-    policy:
-      enabled: false
-    replicaCount: 1
-    tolerations: []
-    traceSampling: 1
-  prometheus:
-    contextPath: /prometheus
-    enabled: true
-    hub: docker.io/prom
-    ingress:
-      annotations: null
-      enabled: false
-      hosts:
-      - prometheus.local
-      tls: null
-    nodeSelector: {}
-    podAntiAffinityLabelSelector: []
-    podAntiAffinityTermLabelSelector: []
-    provisionPrometheusCert: true
-    replicaCount: 1
-    retention: 6h
-    scrapeInterval: 15s
-    security:
-      enabled: true
-    tag: v2.15.1
-    tolerations: []
-  security:
-    dnsCerts:
-      istio-pilot-service-account.istio-control: istio-pilot.istio-control
-    enableNamespacesByDefault: true
-    image: citadel
-    selfSigned: true
-  sidecarInjectorWebhook:
-    enableNamespacesByDefault: false
-    image: sidecar_injector
-    injectLabel: istio-injection
-    objectSelector:
-      autoInject: true
-      enabled: false
-    rewriteAppHTTPProbe: false
-    selfSigned: false
-  telemetry:
-    enabled: true
-    v1:
-      enabled: false
-    v2:
-      enabled: true
-      prometheus:
-        enabled: true
-      stackdriver:
-        configOverride: {}
+      security:
+        cert_file: /kiali-cert/cert-chain.pem
         enabled: false
-        logging: false
-        monitoring: false
-        topology: false
-  tracing:
-    enabled: false
-    ingress:
-      annotations: null
-      enabled: false
-      hosts: null
-      tls: null
-    jaeger:
-      accessMode: ReadWriteMany
-      hub: docker.io/jaegertracing
-      memory:
-        max_traces: 50000
-      persist: false
-      spanStorageType: badger
-      storageClassName: ""
-      tag: "1.16"
-    nodeSelector: {}
-    opencensus:
-      exporters:
+        private_key_file: /kiali-cert/key.pem
+      tag: v1.9
+    mixer:
+      adapters:
+        kubernetesenv:
+          enabled: true
+        prometheus:
+          enabled: true
+          metricsExpiryDuration: 10m
         stackdriver:
-          enable_tracing: true
-      hub: docker.io/omnition
-      resources:
-        limits:
-          cpu: "1"
-          memory: 2Gi
-        requests:
-          cpu: 200m
-          memory: 400Mi
-      tag: 0.1.9
-    podAntiAffinityLabelSelector: []
-    podAntiAffinityTermLabelSelector: []
-    provider: jaeger
-    service:
-      annotations: {}
-      externalPort: 9411
-      name: http-query
-      type: ClusterIP
-    zipkin:
-      hub: docker.io/openzipkin
-      javaOptsHeap: 700
-      maxSpans: 500000
-      node:
-        cpus: 2
-      probeStartupDelay: 200
-      queryPort: 9411
-      resources:
-        limits:
-          cpu: 300m
-          memory: 900Mi
-        requests:
-          cpu: 150m
-          memory: 900Mi
-      tag: 2.14.2
-  version: ""
+          auth:
+            apiKey: ""
+            appCredentials: false
+            serviceAccountPath: ""
+          enabled: false
+          tracer:
+            enabled: false
+            sampleProbability: 1
+        stdio:
+          enabled: false
+          outputAsJson: false
+        useAdapterCRDs: false
+      policy:
+        adapters:
+          kubernetesenv:
+            enabled: true
+          useAdapterCRDs: false
+        autoscaleEnabled: true
+        image: mixer
+        sessionAffinityEnabled: false
+      telemetry:
+        autoscaleEnabled: true
+        env:
+          GOMAXPROCS: "6"
+        image: mixer
+        loadshedding:
+          latencyThreshold: 100ms
+          mode: enforce
+        nodeSelector: {}
+        podAntiAffinityLabelSelector: []
+        podAntiAffinityTermLabelSelector: []
+        replicaCount: 1
+        reportBatchMaxEntries: 100
+        reportBatchMaxTime: 1s
+        sessionAffinityEnabled: false
+        tolerations: []
+    nodeagent:
+      image: node-agent-k8s
+    pilot:
+      appNamespaces: []
+      autoscaleEnabled: true
+      autoscaleMax: 5
+      autoscaleMin: 1
+      configMap: true
+      configNamespace: istio-config
+      cpu:
+        targetAverageUtilization: 80
+      enableProtocolSniffingForInbound: false
+      enableProtocolSniffingForOutbound: true
+      env: {}
+      image: pilot
+      ingress:
+        ingressClass: istio
+        ingressControllerMode: STRICT
+        ingressService: istio-ingressgateway
+      keepaliveMaxServerConnectionAge: 30m
+      meshNetworks:
+        networks: {}
+      nodeSelector: {}
+      podAntiAffinityLabelSelector: []
+      podAntiAffinityTermLabelSelector: []
+      policy:
+        enabled: false
+      replicaCount: 1
+      tolerations: []
+      traceSampling: 1
+    prometheus:
+      contextPath: /prometheus
+      enabled: true
+      hub: docker.io/prom
+      ingress:
+        enabled: false
+        hosts:
+        - prometheus.local
+      nodeSelector: {}
+      podAntiAffinityLabelSelector: []
+      podAntiAffinityTermLabelSelector: []
+      provisionPrometheusCert: true
+      replicaCount: 1
+      retention: 6h
+      scrapeInterval: 15s
+      security:
+        enabled: true
+      tag: v2.15.1
+      tolerations: []
+    security:
+      dnsCerts:
+        istio-pilot-service-account.istio-control: istio-pilot.istio-control
+      enableNamespacesByDefault: true
+      image: citadel
+      selfSigned: true
+    sidecarInjectorWebhook:
+      enableNamespacesByDefault: false
+      image: sidecar_injector
+      injectLabel: istio-injection
+      objectSelector:
+        autoInject: true
+        enabled: false
+      rewriteAppHTTPProbe: false
+      selfSigned: false
+    telemetry:
+      enabled: true
+      v1:
+        enabled: false
+      v2:
+        enabled: true
+        prometheus:
+          enabled: true
+        stackdriver:
+          configOverride: {}
+          enabled: false
+          logging: false
+          monitoring: false
+          topology: false
+    tracing:
+      enabled: false
+      ingress:
+        enabled: false
+      jaeger:
+        accessMode: ReadWriteMany
+        hub: docker.io/jaegertracing
+        memory:
+          max_traces: 50000
+        persist: false
+        spanStorageType: badger
+        storageClassName: ""
+        tag: "1.16"
+      nodeSelector: {}
+      opencensus:
+        exporters:
+          stackdriver:
+            enable_tracing: true
+        hub: docker.io/omnition
+        resources:
+          limits:
+            cpu: "1"
+            memory: 2Gi
+          requests:
+            cpu: 200m
+            memory: 400Mi
+        tag: 0.1.9
+      podAntiAffinityLabelSelector: []
+      podAntiAffinityTermLabelSelector: []
+      provider: jaeger
+      service:
+        annotations: {}
+        externalPort: 9411
+        name: http-query
+        type: ClusterIP
+      zipkin:
+        hub: docker.io/openzipkin
+        javaOptsHeap: 700
+        maxSpans: 500000
+        node:
+          cpus: 2
+        probeStartupDelay: 200
+        queryPort: 9411
+        resources:
+          limits:
+            cpu: 300m
+            memory: 900Mi
+          requests:
+            cpu: 150m
+            memory: 900Mi
+        tag: 2.14.2
+    version: ""
 

--- a/operator/pkg/translate/icp_iop.go
+++ b/operator/pkg/translate/icp_iop.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	istioOperatorTreeString = `
+	IstioOperatorTreeString = `
 apiVersion: operator.istio.io/v1alpha1
 kind: IstioOperator
 `
@@ -123,7 +123,7 @@ func ICPToIOP(icp string, translations map[string]string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return util.OverlayYAML(istioOperatorTreeString, out)
+	return util.OverlayYAML(IstioOperatorTreeString, out)
 }
 
 // getSpecSubtree takes a YAML tree with the root node spec and returns the subtree under this root node.


### PR DESCRIPTION
This PR includes several UX enhancements for the istioctl manifest and profile subcommands:

* `istioctl manifest` and `istioctl profile` recognizes the special
  `-` character for reading from STDIN. This can be useful for demos
  and docs where profiles are shown and applied inline.

* `istioctl profile dump` prints a valid IstioOperator CR by default
  when the `--config-path` option is not used. The output can now be
  directly applied by istioctl.

* `istioctl profile dump` now accepts an optional `-o|--output`
  argument. This can be combined with `jq` as an alternative to
  `--config-path`, e.g. `istioctl profile dump default -s -o json | jq
  .spec.component.pilot`

(cherry picked from commit 6a3396aba4792c7dae3f3af200ef713d3d00acc0)