### PR TITLE
add contextPath to prometheus and grafana deployment to support ingress sub path rule

### DIFF
--- a/manifests/istio-telemetry/grafana/templates/deployment.yaml
+++ b/manifests/istio-telemetry/grafana/templates/deployment.yaml
@@ -76,6 +76,12 @@ spec:
           - name: GF_AUTH_ANONYMOUS_ORG_ROLE
             value: Admin
 {{- end }}
+{{- if $.Values.grafana.contextPath }}
+          - name: GF_SERVER_ROOT_URL
+            value: "%(protocol)s://%(domain)s:%(http_port)s{{- $.Values.grafana.contextPath -}}"
+          - name: GF_SERVER_SERVE_FROM_SUB_PATH
+            value: "true"
+{{- end }}
           - name: GF_PATHS_DATA
             value: /data/grafana
           {{- range $key, $value := $.Values.grafana.env }}

--- a/manifests/istio-telemetry/prometheus/templates/deployment.yaml
+++ b/manifests/istio-telemetry/prometheus/templates/deployment.yaml
@@ -36,16 +36,19 @@ spec:
           args:
             - '--storage.tsdb.retention={{ .Values.prometheus.retention }}'
             - '--config.file=/etc/prometheus/prometheus.yml'
+{{- if $.Values.prometheus.contextPath }}
+            - '--web.external-url={{- $.Values.prometheus.contextPath -}}'
+{{- end }}
           ports:
             - containerPort: 9090
               name: http
           livenessProbe:
             httpGet:
-              path: /-/healthy
+              path: {{ $.Values.prometheus.contextPath }}/-/healthy
               port: 9090
           readinessProbe:
             httpGet:
-              path: /-/ready
+              path: {{ $.Values.prometheus.contextPath }}/-/ready
               port: 9090
           resources:
 {{- if .Values.prometheus.resources }}


### PR DESCRIPTION
Now if I set `values.prometheus.ingress.enabled=true`, ingress rule `path:  /prometheus`. 
But deployment not support sub path. 
Request `http://prometheus.local/prometheus` will get 404, must set `contextPath=/`.

```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: prometheus
  namespace: istio-system
  labels:
    app: prometheus
    release: istio
  annotations:
spec:
  rules:
    - host: prometheus.local
      http:
        paths:
          - path:  /prometheus 
            backend:
              serviceName: prometheus
              servicePort: 9090
```