### PR TITLE
bootstrap: remove deprecated fields

### DIFF
--- a/pkg/bootstrap/instance_test.go
+++ b/pkg/bootstrap/instance_test.go
@@ -279,11 +279,12 @@ func TestGolden(t *testing.T) {
 				PlatEnv: &fakePlatform{},
 				PilotSubjectAltName: []string{
 					"spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"},
-				LocalEnv:       localEnv,
-				NodeIPs:        []string{"10.3.3.3", "10.4.4.4", "10.5.5.5", "10.6.6.6", "10.4.4.4"},
-				SDSUDSPath:     c.sdsUDSPath,
-				SDSTokenPath:   c.sdsTokenPath,
-				OutlierLogPath: "/dev/stdout",
+				LocalEnv:          localEnv,
+				NodeIPs:           []string{"10.3.3.3", "10.4.4.4", "10.5.5.5", "10.6.6.6", "10.4.4.4"},
+				SDSUDSPath:        c.sdsUDSPath,
+				SDSTokenPath:      c.sdsTokenPath,
+				OutlierLogPath:    "/dev/stdout",
+				PilotCertProvider: "citadel",
 			}).CreateFileForEpoch(0)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/bootstrap/instance_test.go
+++ b/pkg/bootstrap/instance_test.go
@@ -27,12 +27,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/golang/protobuf/ptypes"
+
 	v1 "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	v2 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v2"
 	tracev2 "github.com/envoyproxy/go-control-plane/envoy/config/trace/v2"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
-	"github.com/envoyproxy/go-control-plane/pkg/conversion"
 	"github.com/ghodss/yaml"
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/protobuf/jsonpb"
@@ -172,9 +173,9 @@ func TestGolden(t *testing.T) {
 			},
 			check: func(got *v2.Bootstrap, t *testing.T) {
 				// nolint: staticcheck
-				cfg := got.Tracing.Http.GetConfig()
+				cfg := got.Tracing.Http.GetTypedConfig()
 				sdMsg := tracev2.OpenCensusConfig{}
-				if err := conversion.StructToMessage(cfg, &sdMsg); err != nil {
+				if err := ptypes.UnmarshalAny(cfg, &sdMsg); err != nil {
 					t.Fatalf("unable to parse: %v %v", cfg, err)
 				}
 

--- a/pkg/bootstrap/instance_test.go
+++ b/pkg/bootstrap/instance_test.go
@@ -284,7 +284,7 @@ func TestGolden(t *testing.T) {
 				SDSUDSPath:        c.sdsUDSPath,
 				SDSTokenPath:      c.sdsTokenPath,
 				OutlierLogPath:    "/dev/stdout",
-				PilotCertProvider: "citadel",
+				PilotCertProvider: "istiod",
 			}).CreateFileForEpoch(0)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -3,9 +3,6 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {
-      
-      
-      
     },
     "metadata": {"EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT","INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6"}
   },
@@ -233,15 +230,43 @@
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
-        "hosts": [
-          {
-            "socket_address": {
-              "protocol": "TCP",
-              "address": "127.0.0.1",
-              "port_value": 15005
-            }
-          }
-        ]
+        "load_assignment": {
+          "cluster_name": "prometheus_stats",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {
+                    "protocol": "TCP",
+                    "address": "127.0.0.1",
+                    "port_value": 15005
+                  }
+                }
+              }
+            }]
+          }]
+        }
+      },
+      {
+        "name": "sds-grpc",
+        "type": "STATIC",
+        "http2_protocol_options": {},
+        "connect_timeout": "7s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "sds-grpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "pipe": {
+                    "path": "/etc/istio/proxy/SDS"
+                  }
+                }
+              }
+            }]
+          }]
+        }
       },
       {
         "name": "xds-grpc",
@@ -250,38 +275,49 @@
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "7s",
         "lb_policy": "ROUND_ROBIN",
-        
-        
-        "tls_context": {
-          "common_tls_context": {
-            "alpn_protocols": [
-              "h2"
-            ],
-            "tls_certificates": [
-              {
-                "certificate_chain": {
-                  "filename": "/etc/certs/cert-chain.pem"
-                },
-                "private_key": {
-                  "filename": "/etc/certs/key.pem"
+        "transport_socket": {
+          "name": "envoy.transport_sockets.tls",
+          "typed_config": {
+            "@type": "type.googleapis.com/envoy.api.v2.auth.UpstreamTlsContext",
+            "common_tls_context": {
+              "alpn_protocols": [
+                "h2"
+              ],
+              "tls_certificate_sds_secret_configs": [
+                {
+                  "name": "default",
+                  "sds_config": {
+                    "api_config_source": {
+                      "api_type": "GRPC",
+                      "grpc_services": [
+                        {
+                          "envoy_grpc": { "cluster_name": "sds-grpc" }
+                        }
+                      ]
+                    }
+                  }
                 }
+              ],
+              "validation_context": {
+                "trusted_ca": {
+                },
+                "verify_subject_alt_name": ["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"]
               }
-            ],
-            "validation_context": {
-              "trusted_ca": {
-                "filename": "/etc/certs/root-cert.pem"
-              },
-              "verify_subject_alt_name": ["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"]
             }
           }
         },
-        
-        
-        "hosts": [
-          {
-            "socket_address": {"address": "mypilot", "port_value": 15011}
-          }
-        ],
+        "load_assignment": {
+          "cluster_name": "xds-rgpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {"address": "mypilot", "port_value": 15011}
+                }
+              }
+            }]
+          }]
+        },
         "circuit_breakers": {
           "thresholds": [
             {
@@ -315,11 +351,18 @@
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
-        "hosts": [
-          {
-            "socket_address": {"address": "localhost", "port_value": 6000}
-          }
-        ]
+        "load_assignment": {
+          "cluster_name": "zipkin",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {"address": "localhost", "port_value": 6000}
+                }
+              }
+            }]
+          }]
+        }
       }
       
       
@@ -336,11 +379,18 @@
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
         "http2_protocol_options": {},
-        "hosts": [
-          {
-            "socket_address": {"address": "metrics-service", "port_value": 15000}
-          }
-        ]
+        "load_assignment": {
+          "cluster_name": "envoy_metrics_service",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {"address": "metrics-service", "port_value": 15000}
+                }
+              }
+            }]
+          }]
+        }
       }
       
       
@@ -355,11 +405,18 @@
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
         "http2_protocol_options": {},
-        "hosts": [
-          {
-            "socket_address": {"address": "accesslog-service", "port_value": 15000}
-          }
-        ]
+        "load_assignment": {
+          "cluster_name": "envoy_accesslog_service",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {"address": "accesslog-service", "port_value": 15000}
+                }
+              }
+            }]
+          }]
+        }
       }
       
     ],
@@ -377,7 +434,8 @@
             "filters": [
               {
                 "name": "envoy.http_connection_manager",
-                "config": {
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
                   "codec_type": "AUTO",
                   "stat_prefix": "stats",
                   "route_config": {
@@ -400,9 +458,9 @@
                       }
                     ]
                   },
-                  "http_filters": {
+                  "http_filters": [{
                     "name": "envoy.router"
-                  }
+                  }]
                 }
               }
             ]
@@ -416,12 +474,13 @@
   "tracing": {
     "http": {
       "name": "envoy.zipkin",
-      "config": {
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.config.trace.v2.ZipkinConfig",
         "collector_cluster": "zipkin",
         "collector_endpoint": "/api/v2/spans",
         "collector_endpoint_version": "HTTP_JSON",
-        "trace_id_128bit": "true",
-        "shared_span_context": "false"
+        "trace_id_128bit": true,
+        "shared_span_context": false
       }
     }
   }

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -300,6 +300,7 @@
               ],
               "validation_context": {
                 "trusted_ca": {
+                  "filename": "./etc/istio/citadel-ca-cert/ca-cert-ns.pem"
                 },
                 "verify_subject_alt_name": ["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"]
               }

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -283,32 +283,21 @@
               "alpn_protocols": [
                 "h2"
               ],
-              "tls_certificate_sds_secret_configs": [
+              "tls_certificates": [
                 {
-                  "name": "default",
-                  "sds_config": {
-                    "api_config_source": {
-                      "api_type": "GRPC",
-                      "grpc_services": [
-                        {
-                          "envoy_grpc": { "cluster_name": "sds-grpc" }
-                        }
-                      ]
-                    }
-                  }
+                  "certificate_chain": { "filename": "/etc/certs/cert-chain.pem" },
+                  "private_key": { "filename": "/etc/certs/key.pem" }
                 }
               ],
               "validation_context": {
-                "trusted_ca": {
-                  "filename": "./etc/istio/citadel-ca-cert/ca-cert-ns.pem"
-                },
+                "trusted_ca": { "filename": "/etc/certs/root-cert.pem" },
                 "verify_subject_alt_name": ["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"]
-              }
+              },
             }
           }
         },
         "load_assignment": {
-          "cluster_name": "xds-rgpc",
+          "cluster_name": "xds-grpc",
           "endpoints": [{
             "lb_endpoints": [{
               "endpoint": {

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -3,9 +3,6 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {
-      
-      
-      
     },
     "metadata": {"EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT","INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6"}
   },
@@ -233,15 +230,43 @@
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
-        "hosts": [
-          {
-            "socket_address": {
-              "protocol": "TCP",
-              "address": "127.0.0.1",
-              "port_value": 15000
-            }
-          }
-        ]
+        "load_assignment": {
+          "cluster_name": "prometheus_stats",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {
+                    "protocol": "TCP",
+                    "address": "127.0.0.1",
+                    "port_value": 15000
+                  }
+                }
+              }
+            }]
+          }]
+        }
+      },
+      {
+        "name": "sds-grpc",
+        "type": "STATIC",
+        "http2_protocol_options": {},
+        "connect_timeout": "1s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "sds-grpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "pipe": {
+                    "path": "/etc/istio/proxy/SDS"
+                  }
+                }
+              }
+            }]
+          }]
+        }
       },
       {
         "name": "xds-grpc",
@@ -250,38 +275,49 @@
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
-        
-        
-        "tls_context": {
-          "common_tls_context": {
-            "alpn_protocols": [
-              "h2"
-            ],
-            "tls_certificates": [
-              {
-                "certificate_chain": {
-                  "filename": "/etc/certs/cert-chain.pem"
-                },
-                "private_key": {
-                  "filename": "/etc/certs/key.pem"
+        "transport_socket": {
+          "name": "envoy.transport_sockets.tls",
+          "typed_config": {
+            "@type": "type.googleapis.com/envoy.api.v2.auth.UpstreamTlsContext",
+            "common_tls_context": {
+              "alpn_protocols": [
+                "h2"
+              ],
+              "tls_certificate_sds_secret_configs": [
+                {
+                  "name": "default",
+                  "sds_config": {
+                    "api_config_source": {
+                      "api_type": "GRPC",
+                      "grpc_services": [
+                        {
+                          "envoy_grpc": { "cluster_name": "sds-grpc" }
+                        }
+                      ]
+                    }
+                  }
                 }
+              ],
+              "validation_context": {
+                "trusted_ca": {
+                },
+                "verify_subject_alt_name": ["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"]
               }
-            ],
-            "validation_context": {
-              "trusted_ca": {
-                "filename": "/etc/certs/root-cert.pem"
-              },
-              "verify_subject_alt_name": ["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"]
             }
           }
         },
-        
-        
-        "hosts": [
-          {
-            "socket_address": {"address": "istio-pilot", "port_value": 15011}
-          }
-        ],
+        "load_assignment": {
+          "cluster_name": "xds-rgpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {"address": "istio-pilot", "port_value": 15011}
+                }
+              }
+            }]
+          }]
+        },
         "circuit_breakers": {
           "thresholds": [
             {
@@ -324,7 +360,8 @@
             "filters": [
               {
                 "name": "envoy.http_connection_manager",
-                "config": {
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
                   "codec_type": "AUTO",
                   "stat_prefix": "stats",
                   "route_config": {
@@ -347,9 +384,9 @@
                       }
                     ]
                   },
-                  "http_filters": {
+                  "http_filters": [{
                     "name": "envoy.router"
-                  }
+                  }]
                 }
               }
             ]

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -300,6 +300,7 @@
               ],
               "validation_context": {
                 "trusted_ca": {
+                  "filename": "./etc/istio/citadel-ca-cert/ca-cert-ns.pem"
                 },
                 "verify_subject_alt_name": ["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"]
               }

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -283,32 +283,21 @@
               "alpn_protocols": [
                 "h2"
               ],
-              "tls_certificate_sds_secret_configs": [
+              "tls_certificates": [
                 {
-                  "name": "default",
-                  "sds_config": {
-                    "api_config_source": {
-                      "api_type": "GRPC",
-                      "grpc_services": [
-                        {
-                          "envoy_grpc": { "cluster_name": "sds-grpc" }
-                        }
-                      ]
-                    }
-                  }
+                  "certificate_chain": { "filename": "/etc/certs/cert-chain.pem" },
+                  "private_key": { "filename": "/etc/certs/key.pem" }
                 }
               ],
               "validation_context": {
-                "trusted_ca": {
-                  "filename": "./etc/istio/citadel-ca-cert/ca-cert-ns.pem"
-                },
+                "trusted_ca": { "filename": "/etc/certs/root-cert.pem" },
                 "verify_subject_alt_name": ["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"]
-              }
+              },
             }
           }
         },
         "load_assignment": {
-          "cluster_name": "xds-rgpc",
+          "cluster_name": "xds-grpc",
           "endpoints": [{
             "lb_endpoints": [{
               "endpoint": {

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -3,9 +3,6 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {
-      
-      
-      
     },
     "metadata": {"EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT","INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","SDS":"true","TRUSTJWT":"true"}
   },
@@ -233,15 +230,43 @@
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
-        "hosts": [
-          {
-            "socket_address": {
-              "protocol": "TCP",
-              "address": "127.0.0.1",
-              "port_value": 15000
-            }
-          }
-        ]
+        "load_assignment": {
+          "cluster_name": "prometheus_stats",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {
+                    "protocol": "TCP",
+                    "address": "127.0.0.1",
+                    "port_value": 15000
+                  }
+                }
+              }
+            }]
+          }]
+        }
+      },
+      {
+        "name": "sds-grpc",
+        "type": "STATIC",
+        "http2_protocol_options": {},
+        "connect_timeout": "1s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "sds-grpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "pipe": {
+                    "path": "/etc/istio/proxy/SDS"
+                  }
+                }
+              }
+            }]
+          }]
+        }
       },
       {
         "name": "xds-grpc",
@@ -250,99 +275,49 @@
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
-        
-        
-        "tls_context": {
-          "common_tls_context": {
-            "alpn_protocols": [
-              "h2"
-            ],
-            
-            "tls_certificate_sds_secret_configs":[
-              {
-                "name":"default",
-                "sds_config":{
-                  "api_config_source":{
-                    "api_type":"GRPC",
-                    "grpc_services":[
-                      {
-                        "google_grpc":{
-                          "target_uri": "udspath",
-                          "channel_credentials":{
-                            "local_credentials":{
-                            }
-                          },
-                          "call_credentials":[
-                            {
-                              "from_plugin":{
-                                "name":"envoy.grpc_credentials.file_based_metadata",
-                                "config":{
-                                  "secret_data":{
-                                    "filename": "/var/run/secrets/tokens/istio-token"
-                                  },
-                                  "header_key":"istio_sds_credentials_header-bin"
-                                }
-                              }
-                            }
-                          ],
-                          "credentials_factory_name":"envoy.grpc_credentials.file_based_metadata",
-                          "stat_prefix":"sdsstat"
+        "transport_socket": {
+          "name": "envoy.transport_sockets.tls",
+          "typed_config": {
+            "@type": "type.googleapis.com/envoy.api.v2.auth.UpstreamTlsContext",
+            "common_tls_context": {
+              "alpn_protocols": [
+                "h2"
+              ],
+              "tls_certificate_sds_secret_configs": [
+                {
+                  "name": "default",
+                  "sds_config": {
+                    "api_config_source": {
+                      "api_type": "GRPC",
+                      "grpc_services": [
+                        {
+                          "envoy_grpc": { "cluster_name": "sds-grpc" }
                         }
-                      }
-                    ]
+                      ]
+                    }
                   }
                 }
-              }
-            ],
-            "combined_validation_context":{
-              "default_validation_context":{
+              ],
+              "validation_context": {
+                "trusted_ca": {
+                },
                 "verify_subject_alt_name": ["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"]
-              },
-              "validation_context_sds_secret_config":{
-                "name":"ROOTCA",
-                "sds_config":{
-                  "api_config_source":{
-                    "api_type":"GRPC",
-                    "grpc_services":[
-                      {
-                        "google_grpc":{
-                          "target_uri": "udspath",
-                          "channel_credentials":{
-                            "local_credentials":{
-                            }
-                          },
-                          "call_credentials":[
-                            {
-                              "from_plugin":{
-                                "name":"envoy.grpc_credentials.file_based_metadata",
-                                "config":{
-                                  "secret_data":{
-                                    "filename": "/var/run/secrets/tokens/istio-token"
-                                  },
-                                  "header_key":"istio_sds_credentials_header-bin"
-                                }
-                              }
-                            }
-                          ],
-                          "credentials_factory_name":"envoy.grpc_credentials.file_based_metadata",
-                          "stat_prefix":"sdsstat"
-                        }
-                      }
-                    ]
-                  }
-                }
               }
             }
-            
-          },
-        },
-        
-        
-        "hosts": [
-          {
-            "socket_address": {"address": "istio-pilot", "port_value": 15011}
           }
-        ],
+        },
+        "load_assignment": {
+          "cluster_name": "xds-rgpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {"address": "istio-pilot", "port_value": 15011}
+                }
+              }
+            }]
+          }]
+        },
         "circuit_breakers": {
           "thresholds": [
             {
@@ -385,7 +360,8 @@
             "filters": [
               {
                 "name": "envoy.http_connection_manager",
-                "config": {
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
                   "codec_type": "AUTO",
                   "stat_prefix": "stats",
                   "route_config": {
@@ -408,9 +384,9 @@
                       }
                     ]
                   },
-                  "http_filters": {
+                  "http_filters": [{
                     "name": "envoy.router"
-                  }
+                  }]
                 }
               }
             ]

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -300,6 +300,7 @@
               ],
               "validation_context": {
                 "trusted_ca": {
+                  "filename": "./etc/istio/citadel-ca-cert/ca-cert-ns.pem"
                 },
                 "verify_subject_alt_name": ["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"]
               }

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -308,7 +308,7 @@
           }
         },
         "load_assignment": {
-          "cluster_name": "xds-rgpc",
+          "cluster_name": "xds-grpc",
           "endpoints": [{
             "lb_endpoints": [{
               "endpoint": {

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -300,7 +300,7 @@
               ],
               "validation_context": {
                 "trusted_ca": {
-                  "filename": "./etc/istio/citadel-ca-cert/ca-cert-ns.pem"
+                  "filename": "./var/run/secrets/istio/root-cert.pem"
                 },
                 "verify_subject_alt_name": ["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"]
               }

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -276,7 +276,7 @@
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
         "load_assignment": {
-          "cluster_name": "xds-rgpc",
+          "cluster_name": "xds-grpc",
           "endpoints": [{
             "lb_endpoints": [{
               "endpoint": {

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -3,9 +3,6 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {
-      
-      
-      
     },
     "metadata": {"EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT","INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6"}
   },
@@ -233,15 +230,43 @@
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
-        "hosts": [
-          {
-            "socket_address": {
-              "protocol": "TCP",
-              "address": "127.0.0.1",
-              "port_value": 15000
-            }
-          }
-        ]
+        "load_assignment": {
+          "cluster_name": "prometheus_stats",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {
+                    "protocol": "TCP",
+                    "address": "127.0.0.1",
+                    "port_value": 15000
+                  }
+                }
+              }
+            }]
+          }]
+        }
+      },
+      {
+        "name": "sds-grpc",
+        "type": "STATIC",
+        "http2_protocol_options": {},
+        "connect_timeout": "1s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "sds-grpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "pipe": {
+                    "path": "/etc/istio/proxy/SDS"
+                  }
+                }
+              }
+            }]
+          }]
+        }
       },
       {
         "name": "xds-grpc",
@@ -250,12 +275,18 @@
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
-        
-        "hosts": [
-          {
-            "socket_address": {"address": "istio-pilot", "port_value": 15010}
-          }
-        ],
+        "load_assignment": {
+          "cluster_name": "xds-rgpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {"address": "istio-pilot", "port_value": 15010}
+                }
+              }
+            }]
+          }]
+        },
         "circuit_breakers": {
           "thresholds": [
             {
@@ -298,7 +329,8 @@
             "filters": [
               {
                 "name": "envoy.http_connection_manager",
-                "config": {
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
                   "codec_type": "AUTO",
                   "stat_prefix": "stats",
                   "route_config": {
@@ -321,9 +353,9 @@
                       }
                     ]
                   },
-                  "http_filters": {
+                  "http_filters": [{
                     "name": "envoy.router"
-                  }
+                  }]
                 }
               }
             ]

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -303,6 +303,7 @@
               ],
               "validation_context": {
                 "trusted_ca": {
+                  "filename": "./etc/istio/citadel-ca-cert/ca-cert-ns.pem"
                 },
                 "verify_subject_alt_name": ["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"]
               }

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -3,15 +3,9 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {
-      
       "region": "regionA",
-      
-      
       "zone": "zoneB",
-      
-      
       "sub_zone": "sub_zoneC",
-      
     },
     "metadata": {"EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT","INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","INTERCEPTION_MODE":"REDIRECT","ISTIO_PROXY_SHA":"istio-proxy:sha","ISTIO_VERSION":"release-3.1","LABELS":{"app":"test","istio-locality":"regionA.zoneB.sub_zoneC","version":"v1alpha1"},"NAME":"svc-0-0-0-6944fb884d-4pgx8","NAMESPACE":"test","POD_NAME":"svc-0-0-0-6944fb884d-4pgx8","app":"test","istio-locality":"regionA.zoneB.sub_zoneC","istio.io/insecurepath":"{\"paths\":[\"/metrics\",\"/live\"]}","version":"v1alpha1"}
   },
@@ -239,15 +233,43 @@
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
-        "hosts": [
-          {
-            "socket_address": {
-              "protocol": "TCP",
-              "address": "127.0.0.1",
-              "port_value": 15005
-            }
-          }
-        ]
+        "load_assignment": {
+          "cluster_name": "prometheus_stats",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {
+                    "protocol": "TCP",
+                    "address": "127.0.0.1",
+                    "port_value": 15005
+                  }
+                }
+              }
+            }]
+          }]
+        }
+      },
+      {
+        "name": "sds-grpc",
+        "type": "STATIC",
+        "http2_protocol_options": {},
+        "connect_timeout": "7s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "sds-grpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "pipe": {
+                    "path": "/etc/istio/proxy/SDS"
+                  }
+                }
+              }
+            }]
+          }]
+        }
       },
       {
         "name": "xds-grpc",
@@ -256,38 +278,49 @@
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "7s",
         "lb_policy": "ROUND_ROBIN",
-        
-        
-        "tls_context": {
-          "common_tls_context": {
-            "alpn_protocols": [
-              "h2"
-            ],
-            "tls_certificates": [
-              {
-                "certificate_chain": {
-                  "filename": "/etc/certs/cert-chain.pem"
-                },
-                "private_key": {
-                  "filename": "/etc/certs/key.pem"
+        "transport_socket": {
+          "name": "envoy.transport_sockets.tls",
+          "typed_config": {
+            "@type": "type.googleapis.com/envoy.api.v2.auth.UpstreamTlsContext",
+            "common_tls_context": {
+              "alpn_protocols": [
+                "h2"
+              ],
+              "tls_certificate_sds_secret_configs": [
+                {
+                  "name": "default",
+                  "sds_config": {
+                    "api_config_source": {
+                      "api_type": "GRPC",
+                      "grpc_services": [
+                        {
+                          "envoy_grpc": { "cluster_name": "sds-grpc" }
+                        }
+                      ]
+                    }
+                  }
                 }
+              ],
+              "validation_context": {
+                "trusted_ca": {
+                },
+                "verify_subject_alt_name": ["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"]
               }
-            ],
-            "validation_context": {
-              "trusted_ca": {
-                "filename": "/etc/certs/root-cert.pem"
-              },
-              "verify_subject_alt_name": ["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"]
             }
           }
         },
-        
-        
-        "hosts": [
-          {
-            "socket_address": {"address": "mypilot", "port_value": 1001}
-          }
-        ],
+        "load_assignment": {
+          "cluster_name": "xds-rgpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {"address": "mypilot", "port_value": 1001}
+                }
+              }
+            }]
+          }]
+        },
         "circuit_breakers": {
           "thresholds": [
             {
@@ -321,11 +354,18 @@
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
-        "hosts": [
-          {
-            "socket_address": {"address": "localhost", "port_value": 6000}
-          }
-        ]
+        "load_assignment": {
+          "cluster_name": "zipkin",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {"address": "localhost", "port_value": 6000}
+                }
+              }
+            }]
+          }]
+        }
       }
       
       
@@ -345,7 +385,8 @@
             "filters": [
               {
                 "name": "envoy.http_connection_manager",
-                "config": {
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
                   "codec_type": "AUTO",
                   "stat_prefix": "stats",
                   "route_config": {
@@ -368,9 +409,9 @@
                       }
                     ]
                   },
-                  "http_filters": {
+                  "http_filters": [{
                     "name": "envoy.router"
-                  }
+                  }]
                 }
               }
             ]
@@ -384,12 +425,13 @@
   "tracing": {
     "http": {
       "name": "envoy.zipkin",
-      "config": {
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.config.trace.v2.ZipkinConfig",
         "collector_cluster": "zipkin",
         "collector_endpoint": "/api/v2/spans",
         "collector_endpoint_version": "HTTP_JSON",
-        "trace_id_128bit": "true",
-        "shared_span_context": "false"
+        "trace_id_128bit": true,
+        "shared_span_context": false
       }
     }
   }

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -286,32 +286,21 @@
               "alpn_protocols": [
                 "h2"
               ],
-              "tls_certificate_sds_secret_configs": [
+              "tls_certificates": [
                 {
-                  "name": "default",
-                  "sds_config": {
-                    "api_config_source": {
-                      "api_type": "GRPC",
-                      "grpc_services": [
-                        {
-                          "envoy_grpc": { "cluster_name": "sds-grpc" }
-                        }
-                      ]
-                    }
-                  }
+                  "certificate_chain": { "filename": "/etc/certs/cert-chain.pem" },
+                  "private_key": { "filename": "/etc/certs/key.pem" }
                 }
               ],
               "validation_context": {
-                "trusted_ca": {
-                  "filename": "./etc/istio/citadel-ca-cert/ca-cert-ns.pem"
-                },
+                "trusted_ca": { "filename": "/etc/certs/root-cert.pem" },
                 "verify_subject_alt_name": ["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"]
-              }
+              },
             }
           }
         },
         "load_assignment": {
-          "cluster_name": "xds-rgpc",
+          "cluster_name": "xds-grpc",
           "endpoints": [{
             "lb_endpoints": [{
               "endpoint": {

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -3,15 +3,9 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {
-      
       "region": "regionA",
-      
-      
       "zone": "zoneB",
-      
-      
       "sub_zone": "sub_zoneC",
-      
     },
     "metadata": {"EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT","INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","INTERCEPTION_MODE":"REDIRECT","ISTIO_PROXY_SHA":"istio-proxy:sha","ISTIO_VERSION":"release-3.1","LABELS":{"app":"test","istio-locality":"regionA.zoneB.sub_zoneC","version":"v1alpha1"},"NAME":"svc-0-0-0-6944fb884d-4pgx8","NAMESPACE":"test","POD_NAME":"svc-0-0-0-6944fb884d-4pgx8","SDS":"true","TRUSTJWT":"true","app":"test","istio-locality":"regionA.zoneB.sub_zoneC","istio.io/insecurepath":"{\"paths\":[\"/metrics\",\"/live\"]}","version":"v1alpha1"}
   },
@@ -239,15 +233,43 @@
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
-        "hosts": [
-          {
-            "socket_address": {
-              "protocol": "TCP",
-              "address": "127.0.0.1",
-              "port_value": 15005
-            }
-          }
-        ]
+        "load_assignment": {
+          "cluster_name": "prometheus_stats",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {
+                    "protocol": "TCP",
+                    "address": "127.0.0.1",
+                    "port_value": 15005
+                  }
+                }
+              }
+            }]
+          }]
+        }
+      },
+      {
+        "name": "sds-grpc",
+        "type": "STATIC",
+        "http2_protocol_options": {},
+        "connect_timeout": "7s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "sds-grpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "pipe": {
+                    "path": "/etc/istio/proxy/SDS"
+                  }
+                }
+              }
+            }]
+          }]
+        }
       },
       {
         "name": "xds-grpc",
@@ -256,99 +278,49 @@
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "7s",
         "lb_policy": "ROUND_ROBIN",
-        
-        
-        "tls_context": {
-          "common_tls_context": {
-            "alpn_protocols": [
-              "h2"
-            ],
-            
-            "tls_certificate_sds_secret_configs":[
-              {
-                "name":"default",
-                "sds_config":{
-                  "api_config_source":{
-                    "api_type":"GRPC",
-                    "grpc_services":[
-                      {
-                        "google_grpc":{
-                          "target_uri": "udspath",
-                          "channel_credentials":{
-                            "local_credentials":{
-                            }
-                          },
-                          "call_credentials":[
-                            {
-                              "from_plugin":{
-                                "name":"envoy.grpc_credentials.file_based_metadata",
-                                "config":{
-                                  "secret_data":{
-                                    "filename": "/var/run/secrets/tokens/istio-token"
-                                  },
-                                  "header_key":"istio_sds_credentials_header-bin"
-                                }
-                              }
-                            }
-                          ],
-                          "credentials_factory_name":"envoy.grpc_credentials.file_based_metadata",
-                          "stat_prefix":"sdsstat"
+        "transport_socket": {
+          "name": "envoy.transport_sockets.tls",
+          "typed_config": {
+            "@type": "type.googleapis.com/envoy.api.v2.auth.UpstreamTlsContext",
+            "common_tls_context": {
+              "alpn_protocols": [
+                "h2"
+              ],
+              "tls_certificate_sds_secret_configs": [
+                {
+                  "name": "default",
+                  "sds_config": {
+                    "api_config_source": {
+                      "api_type": "GRPC",
+                      "grpc_services": [
+                        {
+                          "envoy_grpc": { "cluster_name": "sds-grpc" }
                         }
-                      }
-                    ]
+                      ]
+                    }
                   }
                 }
-              }
-            ],
-            "combined_validation_context":{
-              "default_validation_context":{
+              ],
+              "validation_context": {
+                "trusted_ca": {
+                },
                 "verify_subject_alt_name": ["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"]
-              },
-              "validation_context_sds_secret_config":{
-                "name":"ROOTCA",
-                "sds_config":{
-                  "api_config_source":{
-                    "api_type":"GRPC",
-                    "grpc_services":[
-                      {
-                        "google_grpc":{
-                          "target_uri": "udspath",
-                          "channel_credentials":{
-                            "local_credentials":{
-                            }
-                          },
-                          "call_credentials":[
-                            {
-                              "from_plugin":{
-                                "name":"envoy.grpc_credentials.file_based_metadata",
-                                "config":{
-                                  "secret_data":{
-                                    "filename": "/var/run/secrets/tokens/istio-token"
-                                  },
-                                  "header_key":"istio_sds_credentials_header-bin"
-                                }
-                              }
-                            }
-                          ],
-                          "credentials_factory_name":"envoy.grpc_credentials.file_based_metadata",
-                          "stat_prefix":"sdsstat"
-                        }
-                      }
-                    ]
-                  }
-                }
               }
             }
-            
-          },
-        },
-        
-        
-        "hosts": [
-          {
-            "socket_address": {"address": "mypilot", "port_value": 1001}
           }
-        ],
+        },
+        "load_assignment": {
+          "cluster_name": "xds-rgpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {"address": "mypilot", "port_value": 1001}
+                }
+              }
+            }]
+          }]
+        },
         "circuit_breakers": {
           "thresholds": [
             {
@@ -382,11 +354,18 @@
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
-        "hosts": [
-          {
-            "socket_address": {"address": "localhost", "port_value": 6000}
-          }
-        ]
+        "load_assignment": {
+          "cluster_name": "zipkin",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {"address": "localhost", "port_value": 6000}
+                }
+              }
+            }]
+          }]
+        }
       }
       
       
@@ -406,7 +385,8 @@
             "filters": [
               {
                 "name": "envoy.http_connection_manager",
-                "config": {
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
                   "codec_type": "AUTO",
                   "stat_prefix": "stats",
                   "route_config": {
@@ -429,9 +409,9 @@
                       }
                     ]
                   },
-                  "http_filters": {
+                  "http_filters": [{
                     "name": "envoy.router"
-                  }
+                  }]
                 }
               }
             ]
@@ -445,12 +425,13 @@
   "tracing": {
     "http": {
       "name": "envoy.zipkin",
-      "config": {
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.config.trace.v2.ZipkinConfig",
         "collector_cluster": "zipkin",
         "collector_endpoint": "/api/v2/spans",
         "collector_endpoint_version": "HTTP_JSON",
-        "trace_id_128bit": "true",
-        "shared_span_context": "false"
+        "trace_id_128bit": true,
+        "shared_span_context": false
       }
     }
   }

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -303,6 +303,7 @@
               ],
               "validation_context": {
                 "trusted_ca": {
+                  "filename": "./etc/istio/citadel-ca-cert/ca-cert-ns.pem"
                 },
                 "verify_subject_alt_name": ["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"]
               }

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -311,7 +311,7 @@
           }
         },
         "load_assignment": {
-          "cluster_name": "xds-rgpc",
+          "cluster_name": "xds-grpc",
           "endpoints": [{
             "lb_endpoints": [{
               "endpoint": {

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -303,7 +303,7 @@
               ],
               "validation_context": {
                 "trusted_ca": {
-                  "filename": "./etc/istio/citadel-ca-cert/ca-cert-ns.pem"
+                  "filename": "./var/run/secrets/istio/root-cert.pem"
                 },
                 "verify_subject_alt_name": ["spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"]
               }

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -3,9 +3,6 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {
-      
-      
-      
     },
     "metadata": {"EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT","INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","sidecar.istio.io/extraStatTags":"dlp_status,dlp_error","sidecar.istio.io/statsInclusionRegexps":"http.[0-9]*\\.[0-9]*\\.[0-9]*\\.[0-9]*_8080.downstream_rq_time"}
   },
@@ -244,15 +241,43 @@
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
-        "hosts": [
-          {
-            "socket_address": {
-              "protocol": "TCP",
-              "address": "127.0.0.1",
-              "port_value": 15000
-            }
-          }
-        ]
+        "load_assignment": {
+          "cluster_name": "prometheus_stats",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {
+                    "protocol": "TCP",
+                    "address": "127.0.0.1",
+                    "port_value": 15000
+                  }
+                }
+              }
+            }]
+          }]
+        }
+      },
+      {
+        "name": "sds-grpc",
+        "type": "STATIC",
+        "http2_protocol_options": {},
+        "connect_timeout": "1s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "sds-grpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "pipe": {
+                    "path": "/etc/istio/proxy/SDS"
+                  }
+                }
+              }
+            }]
+          }]
+        }
       },
       {
         "name": "xds-grpc",
@@ -261,12 +286,18 @@
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
-        
-        "hosts": [
-          {
-            "socket_address": {"address": "istio-pilot", "port_value": 15010}
-          }
-        ],
+        "load_assignment": {
+          "cluster_name": "xds-rgpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {"address": "istio-pilot", "port_value": 15010}
+                }
+              }
+            }]
+          }]
+        },
         "circuit_breakers": {
           "thresholds": [
             {
@@ -309,7 +340,8 @@
             "filters": [
               {
                 "name": "envoy.http_connection_manager",
-                "config": {
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
                   "codec_type": "AUTO",
                   "stat_prefix": "stats",
                   "route_config": {
@@ -332,9 +364,9 @@
                       }
                     ]
                   },
-                  "http_filters": {
+                  "http_filters": [{
                     "name": "envoy.router"
-                  }
+                  }]
                 }
               }
             ]

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -287,7 +287,7 @@
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
         "load_assignment": {
-          "cluster_name": "xds-rgpc",
+          "cluster_name": "xds-grpc",
           "endpoints": [{
             "lb_endpoints": [{
               "endpoint": {

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -276,7 +276,7 @@
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
         "load_assignment": {
-          "cluster_name": "xds-rgpc",
+          "cluster_name": "xds-grpc",
           "endpoints": [{
             "lb_endpoints": [{
               "endpoint": {

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -3,9 +3,6 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {
-      
-      
-      
     },
     "metadata": {"EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT","INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6"}
   },
@@ -233,15 +230,43 @@
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
-        "hosts": [
-          {
-            "socket_address": {
-              "protocol": "TCP",
-              "address": "127.0.0.1",
-              "port_value": 15000
-            }
-          }
-        ]
+        "load_assignment": {
+          "cluster_name": "prometheus_stats",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {
+                    "protocol": "TCP",
+                    "address": "127.0.0.1",
+                    "port_value": 15000
+                  }
+                }
+              }
+            }]
+          }]
+        }
+      },
+      {
+        "name": "sds-grpc",
+        "type": "STATIC",
+        "http2_protocol_options": {},
+        "connect_timeout": "1s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "sds-grpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "pipe": {
+                    "path": "/etc/istio/proxy/SDS"
+                  }
+                }
+              }
+            }]
+          }]
+        }
       },
       {
         "name": "xds-grpc",
@@ -250,12 +275,18 @@
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
-        
-        "hosts": [
-          {
-            "socket_address": {"address": "istio-pilot", "port_value": 15010}
-          }
-        ],
+        "load_assignment": {
+          "cluster_name": "xds-rgpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {"address": "istio-pilot", "port_value": 15010}
+                }
+              }
+            }]
+          }]
+        },
         "circuit_breakers": {
           "thresholds": [
             {
@@ -289,11 +320,18 @@
         "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",
         "lb_policy": "ROUND_ROBIN",
-        "hosts": [
-          {
-            "socket_address": {"address": "localhost", "port_value": 8126}
-          }
-        ]
+        "load_assignment": {
+          "cluster_name": "datadog_agent",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {"address": "localhost", "port_value": 8126}
+                }
+              }
+            }]
+          }]
+        }
       }
       
       
@@ -313,7 +351,8 @@
             "filters": [
               {
                 "name": "envoy.http_connection_manager",
-                "config": {
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
                   "codec_type": "AUTO",
                   "stat_prefix": "stats",
                   "route_config": {
@@ -336,9 +375,9 @@
                       }
                     ]
                   },
-                  "http_filters": {
+                  "http_filters": [{
                     "name": "envoy.router"
-                  }
+                  }]
                 }
               }
             ]
@@ -352,7 +391,8 @@
   "tracing": {
     "http": {
       "name": "envoy.tracers.datadog",
-      "config": {
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.config.trace.v2.DatadogConfig",
         "collector_cluster": "datadog_agent",
         "service_name": "istio-proxy"
       }

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -276,7 +276,7 @@
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
         "load_assignment": {
-          "cluster_name": "xds-rgpc",
+          "cluster_name": "xds-grpc",
           "endpoints": [{
             "lb_endpoints": [{
               "endpoint": {

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -3,9 +3,6 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {
-      
-      
-      
     },
     "metadata": {"EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT","INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6"}
   },
@@ -233,15 +230,43 @@
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
-        "hosts": [
-          {
-            "socket_address": {
-              "protocol": "TCP",
-              "address": "127.0.0.1",
-              "port_value": 15000
-            }
-          }
-        ]
+        "load_assignment": {
+          "cluster_name": "prometheus_stats",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {
+                    "protocol": "TCP",
+                    "address": "127.0.0.1",
+                    "port_value": 15000
+                  }
+                }
+              }
+            }]
+          }]
+        }
+      },
+      {
+        "name": "sds-grpc",
+        "type": "STATIC",
+        "http2_protocol_options": {},
+        "connect_timeout": "1s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "sds-grpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "pipe": {
+                    "path": "/etc/istio/proxy/SDS"
+                  }
+                }
+              }
+            }]
+          }]
+        }
       },
       {
         "name": "xds-grpc",
@@ -250,12 +275,18 @@
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
-        
-        "hosts": [
-          {
-            "socket_address": {"address": "istio-pilot", "port_value": 15010}
-          }
-        ],
+        "load_assignment": {
+          "cluster_name": "xds-rgpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {"address": "istio-pilot", "port_value": 15010}
+                }
+              }
+            }]
+          }]
+        },
         "circuit_breakers": {
           "thresholds": [
             {
@@ -304,11 +335,18 @@
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
-        "hosts": [
-          {
-            "socket_address": {"address": "lightstep-satellite", "port_value": 8080}
-          }
-        ]
+        "load_assignment": {
+          "cluster_name": "lightstep",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {"address": "lightstep-satellite", "port_value": 8080}
+                }
+              }
+            }]
+          }]
+        }
       }
       
       
@@ -328,7 +366,8 @@
             "filters": [
               {
                 "name": "envoy.http_connection_manager",
-                "config": {
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
                   "codec_type": "AUTO",
                   "stat_prefix": "stats",
                   "route_config": {
@@ -351,9 +390,9 @@
                       }
                     ]
                   },
-                  "http_filters": {
+                  "http_filters": [{
                     "name": "envoy.router"
-                  }
+                  }]
                 }
               }
             ]
@@ -367,7 +406,8 @@
   "tracing": {
     "http": {
       "name": "envoy.lightstep",
-      "config": {
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.config.trace.v2.LightstepConfig",
         "collector_cluster": "lightstep",
         "access_token_file": "/test-path/lightstep_access_token.txt"
       }

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -276,7 +276,7 @@
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
         "load_assignment": {
-          "cluster_name": "xds-rgpc",
+          "cluster_name": "xds-grpc",
           "endpoints": [{
             "lb_endpoints": [{
               "endpoint": {

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -3,9 +3,6 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {
-      
-      
-      
     },
     "metadata": {"EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT","INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6"}
   },
@@ -233,15 +230,43 @@
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
-        "hosts": [
-          {
-            "socket_address": {
-              "protocol": "TCP",
-              "address": "127.0.0.1",
-              "port_value": 15000
-            }
-          }
-        ]
+        "load_assignment": {
+          "cluster_name": "prometheus_stats",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {
+                    "protocol": "TCP",
+                    "address": "127.0.0.1",
+                    "port_value": 15000
+                  }
+                }
+              }
+            }]
+          }]
+        }
+      },
+      {
+        "name": "sds-grpc",
+        "type": "STATIC",
+        "http2_protocol_options": {},
+        "connect_timeout": "1s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "sds-grpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "pipe": {
+                    "path": "/etc/istio/proxy/SDS"
+                  }
+                }
+              }
+            }]
+          }]
+        }
       },
       {
         "name": "xds-grpc",
@@ -250,12 +275,18 @@
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
-        
-        "hosts": [
-          {
-            "socket_address": {"address": "istio-pilot", "port_value": 15010}
-          }
-        ],
+        "load_assignment": {
+          "cluster_name": "xds-rgpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {"address": "istio-pilot", "port_value": 15010}
+                }
+              }
+            }]
+          }]
+        },
         "circuit_breakers": {
           "thresholds": [
             {
@@ -298,7 +329,8 @@
             "filters": [
               {
                 "name": "envoy.http_connection_manager",
-                "config": {
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
                   "codec_type": "AUTO",
                   "stat_prefix": "stats",
                   "route_config": {
@@ -321,9 +353,9 @@
                       }
                     ]
                   },
-                  "http_filters": {
+                  "http_filters": [{
                     "name": "envoy.router"
-                  }
+                  }]
                 }
               }
             ]
@@ -337,7 +369,8 @@
   "tracing": {
     "http": {
       "name": "envoy.tracers.opencensus",
-      "config": {
+      "typed_config": {
+      "@type": "type.googleapis.com/envoy.config.trace.v2.OpenCensusConfig",
       "stackdriver_exporter_enabled": true,
       "stackdriver_project_id": "my-sd-project",
       "stdout_exporter_enabled": true,

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -373,6 +373,7 @@
       "@type": "type.googleapis.com/envoy.config.trace.v2.OpenCensusConfig",
       "stackdriver_exporter_enabled": true,
       "stackdriver_project_id": "my-sd-project",
+      
       "stdout_exporter_enabled": true,
       "incoming_trace_context": ["CLOUD_TRACE_CONTEXT", "TRACE_CONTEXT", "GRPC_TRACE_BIN", "B3"],
       "outgoing_trace_context": ["CLOUD_TRACE_CONTEXT", "TRACE_CONTEXT", "GRPC_TRACE_BIN", "B3"],

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -276,7 +276,7 @@
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
         "load_assignment": {
-          "cluster_name": "xds-rgpc",
+          "cluster_name": "xds-grpc",
           "endpoints": [{
             "lb_endpoints": [{
               "endpoint": {

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -3,9 +3,6 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {
-      
-      
-      
     },
     "metadata": {"EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT","INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6"}
   },
@@ -233,15 +230,43 @@
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
-        "hosts": [
-          {
-            "socket_address": {
-              "protocol": "TCP",
-              "address": "127.0.0.1",
-              "port_value": 15000
-            }
-          }
-        ]
+        "load_assignment": {
+          "cluster_name": "prometheus_stats",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {
+                    "protocol": "TCP",
+                    "address": "127.0.0.1",
+                    "port_value": 15000
+                  }
+                }
+              }
+            }]
+          }]
+        }
+      },
+      {
+        "name": "sds-grpc",
+        "type": "STATIC",
+        "http2_protocol_options": {},
+        "connect_timeout": "1s",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "sds-grpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "pipe": {
+                    "path": "/etc/istio/proxy/SDS"
+                  }
+                }
+              }
+            }]
+          }]
+        }
       },
       {
         "name": "xds-grpc",
@@ -250,12 +275,18 @@
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
-        
-        "hosts": [
-          {
-            "socket_address": {"address": "istio-pilot", "port_value": 15010}
-          }
-        ],
+        "load_assignment": {
+          "cluster_name": "xds-rgpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {"address": "istio-pilot", "port_value": 15010}
+                }
+              }
+            }]
+          }]
+        },
         "circuit_breakers": {
           "thresholds": [
             {
@@ -289,11 +320,18 @@
         "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
-        "hosts": [
-          {
-            "socket_address": {"address": "localhost", "port_value": 6000}
-          }
-        ]
+        "load_assignment": {
+          "cluster_name": "zipkin",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {"address": "localhost", "port_value": 6000}
+                }
+              }
+            }]
+          }]
+        }
       }
       
       
@@ -313,7 +351,8 @@
             "filters": [
               {
                 "name": "envoy.http_connection_manager",
-                "config": {
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
                   "codec_type": "AUTO",
                   "stat_prefix": "stats",
                   "route_config": {
@@ -336,9 +375,9 @@
                       }
                     ]
                   },
-                  "http_filters": {
+                  "http_filters": [{
                     "name": "envoy.router"
-                  }
+                  }]
                 }
               }
             ]
@@ -352,12 +391,13 @@
   "tracing": {
     "http": {
       "name": "envoy.zipkin",
-      "config": {
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.config.trace.v2.ZipkinConfig",
         "collector_cluster": "zipkin",
         "collector_endpoint": "/api/v2/spans",
         "collector_endpoint_version": "HTTP_JSON",
-        "trace_id_128bit": "true",
-        "shared_span_context": "false"
+        "trace_id_128bit": true,
+        "shared_span_context": false
       }
     }
   }

--- a/pkg/config/xds/filter_types.go
+++ b/pkg/config/xds/filter_types.go
@@ -69,4 +69,5 @@ import (
 	_ "github.com/envoyproxy/go-control-plane/envoy/config/filter/thrift/rate_limit/v2alpha1"
 	_ "github.com/envoyproxy/go-control-plane/envoy/config/filter/thrift/router/v2alpha1"
 	_ "github.com/envoyproxy/go-control-plane/envoy/config/filter/udp/udp_proxy/v2alpha"
+	_ "github.com/envoyproxy/go-control-plane/envoy/config/trace/v2"
 )

--- a/tools/packaging/common/envoy_bootstrap_v2.json
+++ b/tools/packaging/common/envoy_bootstrap_v2.json
@@ -3,15 +3,15 @@
     "id": "{{ .nodeID }}",
     "cluster": "{{ .cluster }}",
     "locality": {
-      {{ if .region }}
+      {{- if .region }}
       "region": "{{ .region }}",
-      {{ end }}
-      {{ if .zone }}
+      {{- end }}
+      {{- if .zone }}
       "zone": "{{ .zone }}",
-      {{ end }}
-      {{ if .sub_zone }}
+      {{- end }}
+      {{- if .sub_zone }}
       "sub_zone": "{{ .sub_zone }}",
-      {{ end }}
+      {{- end }}
     },
     "metadata": {{ .meta_json_str }}
   },
@@ -239,30 +239,44 @@
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
-        "hosts": [
-          {
-            "socket_address": {
-              "protocol": "TCP",
-              "address": "{{ .localhost }}",
-              "port_value": {{ .config.ProxyAdminPort }}
-            }
-          }
-        ]
+        "load_assignment": {
+          "cluster_name": "prometheus_stats",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {
+                    "protocol": "TCP",
+                    "address": "{{ .localhost }}",
+                    "port_value": {{ .config.ProxyAdminPort }}
+                  }
+                }
+              }
+            }]
+          }]
+        }
       },
-      {{- if eq .sds_uds_path "unix:/etc/istio/proxy/SDS" }}
       {
         "name": "sds-grpc",
         "type": "STATIC",
         "http2_protocol_options": {},
         "connect_timeout": "{{ .connect_timeout }}",
         "lb_policy": "ROUND_ROBIN",
-        "hosts": [{
-          "pipe": {
-            "path": "/etc/istio/proxy/SDS"
-           }
-        }]
+        "load_assignment": {
+          "cluster_name": "sds-grpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "pipe": {
+                    "path": "/etc/istio/proxy/SDS"
+                  }
+                }
+              }
+            }]
+          }]
+        }
       },
-      {{- end }}
       {
         "name": "xds-grpc",
         "type": "STRICT_DNS",
@@ -270,151 +284,54 @@
         "dns_lookup_family": "{{ .dns_lookup_family }}",
         "connect_timeout": "{{ .connect_timeout }}",
         "lb_policy": "ROUND_ROBIN",
-        {{ if eq .config.ControlPlaneAuthPolicy 1 }}
-        {{ if .sds_uds_path }}
-        "tls_context": {
-          "common_tls_context": {
-            "alpn_protocols": [
-              "h2"
-            ],
-            {{ if eq .sds_uds_path "unix:/etc/istio/proxy/SDS" }}
-             "tls_certificate_sds_secret_configs":[
-              {
-                "name":"default",
-                "sds_config":{
-                  "api_config_source":{
-                    "api_type":"GRPC",
-                    "grpc_services":[
-                      {
-                        "envoy_grpc":{
-                          "cluster_name": "sds-grpc"
+        "transport_socket": {
+          "name": "envoy.transport_sockets.tls",
+          "typed_config": {
+            "@type": "type.googleapis.com/envoy.api.v2.auth.UpstreamTlsContext",
+            "common_tls_context": {
+              "alpn_protocols": [
+                "h2"
+              ],
+              "tls_certificate_sds_secret_configs": [
+                {
+                  "name": "default",
+                  "sds_config": {
+                    "api_config_source": {
+                      "api_type": "GRPC",
+                      "grpc_services": [
+                        {
+                          "envoy_grpc": { "cluster_name": "sds-grpc" }
                         }
-                      }
-                    ]
+                      ]
+                    }
                   }
                 }
-              }
-            ],
-            "validation_context": {
-              "trusted_ca": {
-                {{ if eq .pilot_cert_provider "kubernetes" }}
-                "filename": "./var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-                {{ else if eq .pilot_cert_provider "istiod" }}
-                "filename": "./var/run/secrets/istio/root-cert.pem"
-                {{ end }}
-              },
-              "verify_subject_alt_name": {{ toJSON .pilot_SAN }}
-            }
-            {{ else }}
-            "tls_certificate_sds_secret_configs":[
-              {
-                "name":"default",
-                "sds_config":{
-                  "api_config_source":{
-                    "api_type":"GRPC",
-                    "grpc_services":[
-                      {
-                        "google_grpc":{
-                          "target_uri": "{{ .sds_uds_path }}",
-                          "channel_credentials":{
-                            "local_credentials":{
-                            }
-                          },
-                          "call_credentials":[
-                            {
-                              "from_plugin":{
-                                "name":"envoy.grpc_credentials.file_based_metadata",
-                                "config":{
-                                  "secret_data":{
-                                    "filename": "{{ .sds_token_path }}"
-                                  },
-                                  "header_key":"istio_sds_credentials_header-bin"
-                                }
-                              }
-                            }
-                          ],
-                          "credentials_factory_name":"envoy.grpc_credentials.file_based_metadata",
-                          "stat_prefix":"sdsstat"
-                        }
-                      }
-                    ]
-                  }
-                }
-              }
-            ],
-            "combined_validation_context":{
-              "default_validation_context":{
-                "verify_subject_alt_name": {{ toJSON .pilot_SAN }}
-              },
-              "validation_context_sds_secret_config":{
-                "name":"ROOTCA",
-                "sds_config":{
-                  "api_config_source":{
-                    "api_type":"GRPC",
-                    "grpc_services":[
-                      {
-                        "google_grpc":{
-                          "target_uri": "{{ .sds_uds_path }}",
-                          "channel_credentials":{
-                            "local_credentials":{
-                            }
-                          },
-                          "call_credentials":[
-                            {
-                              "from_plugin":{
-                                "name":"envoy.grpc_credentials.file_based_metadata",
-                                "config":{
-                                  "secret_data":{
-                                    "filename": "{{ .sds_token_path }}"
-                                  },
-                                  "header_key":"istio_sds_credentials_header-bin"
-                                }
-                              }
-                            }
-                          ],
-                          "credentials_factory_name":"envoy.grpc_credentials.file_based_metadata",
-                          "stat_prefix":"sdsstat"
-                        }
-                      }
-                    ]
-                  }
-                }
-              }
-            }
-            {{ end }}
-          },
-        },
-        {{ else }}
-        "tls_context": {
-          "common_tls_context": {
-            "alpn_protocols": [
-              "h2"
-            ],
-            "tls_certificates": [
-              {
-                "certificate_chain": {
-                  "filename": "/etc/certs/cert-chain.pem"
+              ],
+              "validation_context": {
+                "trusted_ca": {
+                    {{- if eq .pilot_cert_provider "kubernetes" }}
+                  "filename": "./var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+                      {{- else if eq .pilot_cert_provider "istiod" }}
+                    "filename": "./var/run/secrets/istio/root-cert.pem"
+                      {{- end }}
                 },
-                "private_key": {
-                  "filename": "/etc/certs/key.pem"
-                }
+                "verify_subject_alt_name": {{ toJSON .pilot_SAN }}
               }
-            ],
-            "validation_context": {
-              "trusted_ca": {
-                "filename": "/etc/certs/root-cert.pem"
-              },
-              "verify_subject_alt_name": {{ toJSON .pilot_SAN }}
             }
           }
         },
-        {{ end }}
-        {{ end }}
-        "hosts": [
-          {
-            "socket_address": {{ .pilot_grpc_address }}
-          }
-        ],
+        "load_assignment": {
+          "cluster_name": "xds-rgpc",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {{ .pilot_grpc_address }}
+                }
+              }
+            }]
+          }]
+        },
         "circuit_breakers": {
           "thresholds": [
             {
@@ -448,11 +365,18 @@
         "dns_lookup_family": "{{ .dns_lookup_family }}",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
-        "hosts": [
-          {
-            "socket_address": {{ .zipkin }}
-          }
-        ]
+        "load_assignment": {
+          "cluster_name": "zipkin",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {{ .zipkin }}
+                }
+              }
+            }]
+          }]
+        }
       }
       {{ else if .lightstep }}
       ,
@@ -478,11 +402,18 @@
         "dns_lookup_family": "{{ .dns_lookup_family }}",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
-        "hosts": [
-          {
-            "socket_address": {{ .lightstep }}
-          }
-        ]
+        "load_assignment": {
+          "cluster_name": "lightstep",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {{ .lightstep }}
+                }
+              }
+            }]
+          }]
+        }
       }
       {{ else if .datadog }}
       ,
@@ -493,11 +424,18 @@
         "respect_dns_ttl": true,
         "dns_lookup_family": "{{ .dns_lookup_family }}",
         "lb_policy": "ROUND_ROBIN",
-        "hosts": [
-          {
-            "socket_address": {{ .datadog }}
-          }
-        ]
+        "load_assignment": {
+          "cluster_name": "datadog_agent",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {{ .datadog }}
+                }
+              }
+            }]
+          }]
+        }
       }
       {{ end }}
       {{ if .envoy_metrics_service_address }}
@@ -516,11 +454,18 @@
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
         "http2_protocol_options": {},
-        "hosts": [
-          {
-            "socket_address": {{ .envoy_metrics_service_address }}
-          }
-        ]
+        "load_assignment": {
+          "cluster_name": "envoy_metrics_service",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {{ .envoy_metrics_service_address }}
+                }
+              }
+            }]
+          }]
+        }
       }
       {{ end }}
       {{ if .envoy_accesslog_service_address }}
@@ -539,11 +484,18 @@
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
         "http2_protocol_options": {},
-        "hosts": [
-          {
-            "socket_address": {{ .envoy_accesslog_service_address }}
-          }
-        ]
+        "load_assignment": {
+          "cluster_name": "envoy_accesslog_service",
+          "endpoints": [{
+            "lb_endpoints": [{
+              "endpoint": {
+                "address":{
+                  "socket_address": {{ .envoy_accesslog_service_address }}
+                }
+              }
+            }]
+          }]
+        }
       }
       {{ end }}
     ],
@@ -561,7 +513,8 @@
             "filters": [
               {
                 "name": "envoy.http_connection_manager",
-                "config": {
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
                   "codec_type": "AUTO",
                   "stat_prefix": "stats",
                   "route_config": {
@@ -600,7 +553,8 @@
   "tracing": {
     "http": {
       "name": "envoy.zipkin",
-      "config": {
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.config.trace.v2.ZipkinConfig",
         "collector_cluster": "zipkin",
         "collector_endpoint": "/api/v2/spans",
         "collector_endpoint_version": "HTTP_JSON",
@@ -614,7 +568,8 @@
   "tracing": {
     "http": {
       "name": "envoy.lightstep",
-      "config": {
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.config.trace.v2.LightstepConfig",
         "collector_cluster": "lightstep",
         "access_token_file": "{{ .lightstepToken}}"
       }
@@ -625,7 +580,8 @@
   "tracing": {
     "http": {
       "name": "envoy.tracers.datadog",
-      "config": {
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.config.trace.v2.DatadogConfig",
         "collector_cluster": "datadog_agent",
         "service_name": "{{ .cluster }}"
       }
@@ -636,7 +592,8 @@
   "tracing": {
     "http": {
       "name": "envoy.tracers.opencensus",
-      "config": {
+      "typed_config": {
+      "@type": "type.googleapis.com/envoy.config.trace.v2.OpenCensusConfig",
       "stackdriver_exporter_enabled": true,
       "stackdriver_project_id": "{{ .stackdriverProjectID }}",
       {{ if .sts_port }}

--- a/tools/packaging/common/envoy_bootstrap_v2.json
+++ b/tools/packaging/common/envoy_bootstrap_v2.json
@@ -310,11 +310,11 @@
               ],
               "validation_context": {
                 "trusted_ca": {
-                    {{- if eq .pilot_cert_provider "kubernetes" }}
+                  {{- if eq .pilot_cert_provider "kubernetes" }}
                   "filename": "./var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-                      {{- else if eq .pilot_cert_provider "istiod" }}
-                    "filename": "./var/run/secrets/istio/root-cert.pem"
-                      {{- end }}
+                  {{- else if eq .pilot_cert_provider "istiod" }}
+                  "filename": "./var/run/secrets/istio/root-cert.pem"
+                  {{- end }}
                 },
                 "verify_subject_alt_name": {{ toJSON .pilot_SAN }}
               }

--- a/tools/packaging/common/envoy_bootstrap_v2.json
+++ b/tools/packaging/common/envoy_bootstrap_v2.json
@@ -293,6 +293,7 @@
               "alpn_protocols": [
                 "h2"
               ],
+              {{- if .sds_uds_path }}
               "tls_certificate_sds_secret_configs": [
                 {
                   "name": "default",
@@ -318,12 +319,24 @@
                 },
                 "verify_subject_alt_name": {{ toJSON .pilot_SAN }}
               }
+              {{- else }}
+              "tls_certificates": [
+                {
+                  "certificate_chain": { "filename": "/etc/certs/cert-chain.pem" },
+                  "private_key": { "filename": "/etc/certs/key.pem" }
+                }
+              ],
+              "validation_context": {
+                "trusted_ca": { "filename": "/etc/certs/root-cert.pem" },
+                "verify_subject_alt_name": {{ toJSON .pilot_SAN }}
+              },
+              {{- end }}
             }
           }
         },
         {{- end }}
         "load_assignment": {
-          "cluster_name": "xds-rgpc",
+          "cluster_name": "xds-grpc",
           "endpoints": [{
             "lb_endpoints": [{
               "endpoint": {

--- a/tools/packaging/common/envoy_bootstrap_v2.json
+++ b/tools/packaging/common/envoy_bootstrap_v2.json
@@ -284,6 +284,7 @@
         "dns_lookup_family": "{{ .dns_lookup_family }}",
         "connect_timeout": "{{ .connect_timeout }}",
         "lb_policy": "ROUND_ROBIN",
+        {{- if eq .config.ControlPlaneAuthPolicy 1 }}
         "transport_socket": {
           "name": "envoy.transport_sockets.tls",
           "typed_config": {
@@ -320,6 +321,7 @@
             }
           }
         },
+        {{- end }}
         "load_assignment": {
           "cluster_name": "xds-rgpc",
           "endpoints": [{
@@ -537,9 +539,9 @@
                       }
                     ]
                   },
-                  "http_filters": {
+                  "http_filters": [{
                     "name": "envoy.router"
-                  }
+                  }]
                 }
               }
             ]
@@ -558,8 +560,8 @@
         "collector_cluster": "zipkin",
         "collector_endpoint": "/api/v2/spans",
         "collector_endpoint_version": "HTTP_JSON",
-        "trace_id_128bit": "true",
-        "shared_span_context": "false"
+        "trace_id_128bit": true,
+        "shared_span_context": false
       }
     }
   }


### PR DESCRIPTION
Right now we are using quite a few deprecated fields in the bootstrap. This PR attempts to replace these with the modern equivalents. In theory, there should be no behavioral change here, but I would strongly encourage reviewers to closely review the golden files, as this is a fairly error prone PR. Existing tests give pretty good coverage of this, but the customer tracers in particular may warrant a second look.