### PR TITLE
set grpc timeout for egress route

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -204,7 +204,9 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(node *
 							Route: &route.RouteAction{
 								ClusterSpecifier: &route.RouteAction_Cluster{Cluster: egressCluster},
 								// Disable timeout instead of assuming some defaults.
-								Timeout:        notimeout,
+								Timeout: notimeout,
+								// If not configured at all, the grpc-timeout header is not used and
+								// gRPC requests time out like any other requests using timeout or its default.
 								MaxGrpcTimeout: notimeout,
 							},
 						},

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
@@ -192,6 +191,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(node *
 					nil, // service is being passe as nil to take care of the case when service becomes available at some later point in time
 					0)
 			}
+			notimeout := ptypes.DurationProto(0)
 			virtualHosts = append(virtualHosts, &route.VirtualHost{
 				Name:    util.PassthroughRouteName,
 				Domains: []string{"*"},
@@ -204,7 +204,8 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(node *
 							Route: &route.RouteAction{
 								ClusterSpecifier: &route.RouteAction_Cluster{Cluster: egressCluster},
 								// Disable timeout instead of assuming some defaults.
-								Timeout: ptypes.DurationProto(0 * time.Millisecond),
+								Timeout:        notimeout,
+								MaxGrpcTimeout: notimeout,
 							},
 						},
 					},

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -826,7 +826,7 @@ func getRouteOperation(in *route.Route, vsName string, port int) string {
 
 // BuildDefaultHTTPInboundRoute builds a default inbound route.
 func BuildDefaultHTTPInboundRoute(node *model.Proxy, clusterName string, operation string) *route.Route {
-	notimeout := ptypes.DurationProto(0 * time.Second)
+	notimeout := ptypes.DurationProto(0)
 
 	val := &route.Route{
 		Match: translateRouteMatch(nil, node),


### PR DESCRIPTION

set `MaxGrpcTimeout` for egress route as default inbound/outbound route