### PR TITLE
Simplify mesh config unmarshalling

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -465,7 +465,7 @@ var (
 func getMeshConfig() (meshconfig.MeshConfig, error) {
 	defaultConfig := mesh.DefaultMeshConfig()
 	if meshConfig != "" {
-		mc, err := mesh.ApplyMeshConfigJSON(meshConfig, defaultConfig)
+		mc, err := mesh.ApplyMeshConfig(meshConfig, defaultConfig)
 		if err != nil || mc == nil {
 			return meshconfig.MeshConfig{}, fmt.Errorf("failed to unmarshal mesh config config [%v]: %v", meshConfig, err)
 		}

--- a/pkg/kube/inject/inject_test.go
+++ b/pkg/kube/inject/inject_test.go
@@ -608,7 +608,7 @@ func TestCleanMeshConfig(t *testing.T) {
 			if got != tt.expect {
 				t.Fatalf("incorrect output: got %v, expected %v", got, tt.expect)
 			}
-			roundTrip, err := mesh.ApplyMeshConfigJSON(got, mesh.DefaultMeshConfig())
+			roundTrip, err := mesh.ApplyMeshConfig(got, mesh.DefaultMeshConfig())
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
In a previous PR, I added a new json unmarshal function. This isn't
really needed, because yaml is a superset of json. Reverting this allows
users passing mesh config as yaml (useful when not auto-generated) and
simplifies the code. The only downside is a tiny perf impact, but mesh
config is read one time so this doesn't matter.