### PR TITLE
confirm validation webhook is callable before updating it to fail-closed (#21354)

### DIFF
--- a/galley/pkg/server/components/validation.go
+++ b/galley/pkg/server/components/validation.go
@@ -168,7 +168,11 @@ func NewValidationController(options controller.Options, kubeconfig string) proc
 			if err != nil {
 				return err
 			}
-			c, err := controller.New(options, client)
+			dynamicInterface, err := restConfig.DynamicInterface()
+			if err != nil {
+				return err
+			}
+			c, err := controller.New(options, client, dynamicInterface)
 			if err != nil {
 				return err
 			}

--- a/manifests/istio-control/istio-discovery/templates/clusterrole.yaml
+++ b/manifests/istio-control/istio-discovery/templates/clusterrole.yaml
@@ -65,6 +65,12 @@ rules:
     verbs: ["get", "list", "watch", "update"]
 {{ end }}
 
+  # permissions to verify the webhook is ready and rejecting
+  # invalid config. We use --server-dry-run so no config is persisted.
+  - apiGroups: ["networking.istio.io"]
+    verbs: ["create"]
+    resources: ["gateways"]
+
   # istio configuration
   - apiGroups: ["config.istio.io", "rbac.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io"]
     verbs: ["get", "watch", "list"]

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.yaml
@@ -8160,6 +8160,12 @@ rules:
     verbs: ["get", "list", "watch", "update"]
 
 
+  # permissions to verify the webhook is ready and rejecting
+  # invalid config. We use --server-dry-run so no config is persisted.
+  - apiGroups: ["networking.istio.io"]
+    verbs: ["create"]
+    resources: ["gateways"]
+
   # istio configuration
   - apiGroups: ["config.istio.io", "rbac.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io"]
     verbs: ["get", "watch", "list"]

--- a/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.yaml
@@ -7125,6 +7125,12 @@ rules:
     verbs: ["get", "list", "watch", "update"]
 
 
+  # permissions to verify the webhook is ready and rejecting
+  # invalid config. We use --server-dry-run so no config is persisted.
+  - apiGroups: ["networking.istio.io"]
+    verbs: ["create"]
+    resources: ["gateways"]
+
   # istio configuration
   - apiGroups: ["config.istio.io", "rbac.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io"]
     verbs: ["get", "watch", "list"]

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_force.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_force.yaml
@@ -152,6 +152,12 @@ rules:
     verbs: ["get", "list", "watch", "update"]
 
 
+  # permissions to verify the webhook is ready and rejecting
+  # invalid config. We use --server-dry-run so no config is persisted.
+  - apiGroups: ["networking.istio.io"]
+    verbs: ["create"]
+    resources: ["gateways"]
+
   # istio configuration
   - apiGroups: ["config.istio.io", "rbac.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io"]
     verbs: ["get", "watch", "list"]

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output.yaml
@@ -150,6 +150,12 @@ rules:
     verbs: ["get", "list", "watch", "update"]
 
 
+  # permissions to verify the webhook is ready and rejecting
+  # invalid config. We use --server-dry-run so no config is persisted.
+  - apiGroups: ["networking.istio.io"]
+    verbs: ["create"]
+    resources: ["gateways"]
+
   # istio configuration
   - apiGroups: ["config.istio.io", "rbac.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io"]
     verbs: ["get", "watch", "list"]

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.yaml
@@ -5972,6 +5972,12 @@ rules:
     verbs: ["get", "list", "watch", "update"]
 
 
+  # permissions to verify the webhook is ready and rejecting
+  # invalid config. We use --server-dry-run so no config is persisted.
+  - apiGroups: ["networking.istio.io"]
+    verbs: ["create"]
+    resources: ["gateways"]
+
   # istio configuration
   - apiGroups: ["config.istio.io", "rbac.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io"]
     verbs: ["get", "watch", "list"]

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.yaml
@@ -6915,6 +6915,12 @@ rules:
     verbs: ["get", "list", "watch", "update"]
 
 
+  # permissions to verify the webhook is ready and rejecting
+  # invalid config. We use --server-dry-run so no config is persisted.
+  - apiGroups: ["networking.istio.io"]
+    verbs: ["create"]
+    resources: ["gateways"]
+
   # istio configuration
   - apiGroups: ["config.istio.io", "rbac.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io"]
     verbs: ["get", "watch", "list"]

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_override_values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_override_values.yaml
@@ -150,6 +150,12 @@ rules:
     verbs: ["get", "list", "watch", "update"]
 
 
+  # permissions to verify the webhook is ready and rejecting
+  # invalid config. We use --server-dry-run so no config is persisted.
+  - apiGroups: ["networking.istio.io"]
+    verbs: ["create"]
+    resources: ["gateways"]
+
   # istio configuration
   - apiGroups: ["config.istio.io", "rbac.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io"]
     verbs: ["get", "watch", "list"]

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.yaml
@@ -6917,6 +6917,12 @@ rules:
     verbs: ["get", "list", "watch", "update"]
 
 
+  # permissions to verify the webhook is ready and rejecting
+  # invalid config. We use --server-dry-run so no config is persisted.
+  - apiGroups: ["networking.istio.io"]
+    verbs: ["create"]
+    resources: ["gateways"]
+
   # istio configuration
   - apiGroups: ["config.istio.io", "rbac.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io"]
     verbs: ["get", "watch", "list"]

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.yaml
@@ -150,6 +150,12 @@ rules:
     verbs: ["get", "list", "watch", "update"]
 
 
+  # permissions to verify the webhook is ready and rejecting
+  # invalid config. We use --server-dry-run so no config is persisted.
+  - apiGroups: ["networking.istio.io"]
+    verbs: ["create"]
+    resources: ["gateways"]
+
   # istio configuration
   - apiGroups: ["config.istio.io", "rbac.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io"]
     verbs: ["get", "watch", "list"]

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.yaml
@@ -150,6 +150,12 @@ rules:
     verbs: ["get", "list", "watch", "update"]
 
 
+  # permissions to verify the webhook is ready and rejecting
+  # invalid config. We use --server-dry-run so no config is persisted.
+  - apiGroups: ["networking.istio.io"]
+    verbs: ["create"]
+    resources: ["gateways"]
+
   # istio configuration
   - apiGroups: ["config.istio.io", "rbac.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io"]
     verbs: ["get", "watch", "list"]

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -12946,6 +12946,12 @@ rules:
     verbs: ["get", "list", "watch", "update"]
 {{ end }}
 
+  # permissions to verify the webhook is ready and rejecting
+  # invalid config. We use --server-dry-run so no config is persisted.
+  - apiGroups: ["networking.istio.io"]
+    verbs: ["create"]
+    resources: ["gateways"]
+
   # istio configuration
   - apiGroups: ["config.istio.io", "rbac.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io"]
     verbs: ["get", "watch", "list"]

--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -31,11 +32,14 @@ import (
 	kubeErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	kubeApiMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	kubeSchema "k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/runtime/serializer/versioning"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -46,6 +50,7 @@ import (
 
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/labels"
+	"istio.io/istio/pkg/config/schema/collections"
 )
 
 var scope = log.RegisterScope("validationController", "validation webhook controller", 0)
@@ -119,12 +124,14 @@ func (o Options) String() string {
 type readFileFunc func(filename string) ([]byte, error)
 
 type Controller struct {
-	o                 Options
-	client            kubernetes.Interface
-	queue             workqueue.RateLimitingInterface
-	sharedInformers   informers.SharedInformerFactory
-	endpointReadyOnce bool
-	fw                filewatcher.FileWatcher
+	o                             Options
+	client                        kubernetes.Interface
+	dynamicResourceInterface      dynamic.ResourceInterface
+	queue                         workqueue.RateLimitingInterface
+	sharedInformers               informers.SharedInformerFactory
+	endpointReadyOnce             bool
+	dryRunOfInvalidConfigRejected bool
+	fw                            filewatcher.FileWatcher
 
 	// unittest hooks
 	readFile      readFileFunc
@@ -214,15 +221,22 @@ func makeHandler(queue workqueue.Interface, gvk schema.GroupVersionKind, name st
 var (
 	configGVK   = kubeApiAdmission.SchemeGroupVersion.WithKind(reflect.TypeOf(kubeApiAdmission.ValidatingWebhookConfiguration{}).Name())
 	endpointGVK = kubeApiCore.SchemeGroupVersion.WithKind(reflect.TypeOf(kubeApiCore.Endpoints{}).Name())
+
+	istioGatewayGVK = kubeSchema.GroupVersionResource{
+		Group:    collections.IstioNetworkingV1Alpha3Gateways.Resource().Group(),
+		Version:  collections.IstioNetworkingV1Alpha3Gateways.Resource().Version(),
+		Resource: collections.IstioNetworkingV1Alpha3Gateways.Resource().Plural(),
+	}
 )
 
-func New(o Options, client kubernetes.Interface) (*Controller, error) {
-	return newController(o, client, filewatcher.NewWatcher, ioutil.ReadFile, nil)
+func New(o Options, client kubernetes.Interface, dface dynamic.Interface) (*Controller, error) {
+	return newController(o, client, dface, filewatcher.NewWatcher, ioutil.ReadFile, nil)
 }
 
 func newController(
 	o Options,
 	client kubernetes.Interface,
+	dface dynamic.Interface,
 	newFileWatcher filewatcher.NewFileWatcherFunc,
 	readFile readFileFunc,
 	reconcileDone func(),
@@ -232,13 +246,16 @@ func newController(
 		return nil, err
 	}
 
+	dynamicResourceInterface := dface.Resource(istioGatewayGVK).Namespace(o.WatchedNamespace)
+
 	c := &Controller{
-		o:             o,
-		client:        client,
-		queue:         workqueue.NewRateLimitingQueue(workqueue.DefaultItemBasedRateLimiter()),
-		fw:            caFileWatcher,
-		readFile:      readFile,
-		reconcileDone: reconcileDone,
+		o:                        o,
+		client:                   client,
+		dynamicResourceInterface: dynamicResourceInterface,
+		queue:                    workqueue.NewRateLimitingQueue(workqueue.DefaultItemBasedRateLimiter()),
+		fw:                       caFileWatcher,
+		readFile:                 readFile,
+		reconcileDone:            reconcileDone,
 	}
 
 	c.sharedInformers = informers.NewSharedInformerFactoryWithOptions(client, o.ResyncPeriod,
@@ -322,23 +339,18 @@ func (c *Controller) reconcileRequest(req *reconcileRequest) error {
 	scope.Infof("Reconcile(enter): %v", req)
 	defer func() { scope.Debugf("Reconcile(exit)") }()
 
-	// don't create the webhook config before the endpoint is ready
-	if !c.endpointReadyOnce {
-		ready, reason, err := c.isEndpointReady()
-		if err != nil {
-			scope.Errorf("Error checking endpoint readiness: %v", err)
-			return err
-		}
-		if !ready {
-			scope.Infof("Endpoint %v is not ready: %v", c.o.ServiceName, reason)
-			return nil
-		}
-		c.endpointReadyOnce = true
-	}
-
-	// actively remove the webhook configuration if the controller is running but the webhook
 	if c.o.UnregisterValidationWebhook {
 		return c.deleteValidatingWebhookConfiguration()
+	}
+
+	ready, err := c.readyForFailClose()
+	if err != nil {
+		return err
+	}
+
+	failurePolicy := kubeApiAdmission.Ignore
+	if ready {
+		failurePolicy = kubeApiAdmission.Fail
 	}
 
 	caBundle, err := c.loadCABundle()
@@ -348,8 +360,36 @@ func (c *Controller) reconcileRequest(req *reconcileRequest) error {
 		// no point in retrying unless cert file changes.
 		return nil
 	}
+	return c.updateValidatingWebhookConfiguration(caBundle, failurePolicy)
+}
 
-	return c.updateValidatingWebhookConfiguration(caBundle)
+func (c *Controller) readyForFailClose() (bool, error) {
+	// don't create the webhook config before the endpoint is ready
+	if !c.endpointReadyOnce {
+		ready, reason, err := c.isEndpointReady()
+		if err != nil {
+			scope.Errorf("Error checking endpoint readiness: %v", err)
+			return false, err
+		}
+		if !ready {
+			scope.Infof("Endpoint %v is not ready: %v", c.o.ServiceName, reason)
+			return false, nil
+		}
+		scope.Infof("Endpoint %v is not ready", c.o.ServiceName)
+		c.endpointReadyOnce = true
+	}
+
+	if !c.dryRunOfInvalidConfigRejected {
+		if rejected, reason := c.isDryRunOfInvalidConfigRejected(); !rejected {
+			scope.Infof("Not ready to switch validation to fail-closed: %v", reason)
+			req := &reconcileRequest{"retry dry-run creation of invalid config"}
+			c.queue.AddAfter(req, time.Second)
+			return false, nil
+		}
+		scope.Info("Endpoint successfully rejected invalid config. Switching to fail-close.")
+		c.dryRunOfInvalidConfigRejected = true
+	}
+	return true, nil
 }
 
 func (c *Controller) isEndpointReady() (ready bool, reason string, err error) {
@@ -363,6 +403,31 @@ func (c *Controller) isEndpointReady() (ready bool, reason string, err error) {
 	}
 	ready, reason = isEndpointReady(endpoint)
 	return ready, reason, nil
+}
+
+const deniedRequestMessageFragment = `admission webhook "validation.istio.io" denied the request`
+
+// Confirm invalid configuration is successfully rejected before switching to FAIL-CLOSE.
+func (c *Controller) isDryRunOfInvalidConfigRejected() (rejected bool, reason string) {
+	invalid := &unstructured.Unstructured{}
+	invalid.SetGroupVersionKind(istioGatewayGVK.GroupVersion().WithKind("Gateway"))
+	invalid.SetName("invalid-gateway")
+	invalid.SetNamespace(c.o.WatchedNamespace)
+	invalid.Object["spec"] = map[string]interface{}{} // gateway must have at least one server
+
+	createOptions := kubeApiMeta.CreateOptions{DryRun: []string{kubeApiMeta.DryRunAll}}
+	_, err := c.dynamicResourceInterface.Create(invalid, createOptions)
+	if kubeErrors.IsAlreadyExists(err) {
+		updateOptions := kubeApiMeta.UpdateOptions{DryRun: []string{kubeApiMeta.DryRunAll}}
+		_, err = c.dynamicResourceInterface.Update(invalid, updateOptions)
+	}
+	if err == nil {
+		return false, fmt.Sprintf("dummy invalid config not rejected")
+	}
+	if !strings.Contains(err.Error(), deniedRequestMessageFragment) {
+		return false, fmt.Sprintf("dummy invalid rejected for the wrong reason: %v", err)
+	}
+	return true, ""
 }
 
 func isEndpointReady(endpoint *kubeApiCore.Endpoints) (ready bool, reason string) {
@@ -389,14 +454,13 @@ func (c *Controller) deleteValidatingWebhookConfiguration() error {
 	return nil
 }
 
-func (c *Controller) updateValidatingWebhookConfiguration(caBundle []byte) error {
+func (c *Controller) updateValidatingWebhookConfiguration(caBundle []byte, failurePolicy kubeApiAdmission.FailurePolicyType) error {
 	current, err := c.sharedInformers.Admissionregistration().V1beta1().
 		ValidatingWebhookConfigurations().Lister().Get(c.o.WebhookConfigName)
 
 	if err != nil {
 		if kubeErrors.IsNotFound(err) {
-			scope.Warnf("validatingwebhookconfiguration %v not found: %v",
-				c.o.WebhookConfigName, err)
+			scope.Warn(err.Error())
 			reportValidationConfigUpdateError(kubeErrors.ReasonForError(err))
 			return nil
 		}
@@ -410,27 +474,27 @@ func (c *Controller) updateValidatingWebhookConfiguration(caBundle []byte) error
 
 	for i := range updated.Webhooks {
 		updated.Webhooks[i].ClientConfig.CABundle = caBundle
-		updated.Webhooks[i].FailurePolicy = &defaultFailurePolicy
+		updated.Webhooks[i].FailurePolicy = &failurePolicy
 	}
 
 	if !reflect.DeepEqual(updated, current) {
 		latest, err := c.client.AdmissionregistrationV1beta1().
 			ValidatingWebhookConfigurations().Update(updated)
 		if err != nil {
-			scope.Errorf("Failed to update validatingwebhookconfiguration %v (resourceVersion=%v): %v",
-				c.o.WebhookConfigName, updated.ResourceVersion, err)
+			scope.Errorf("Failed to update validatingwebhookconfiguration %v (failurePolicy=%v, resourceVersion=%v): %v",
+				c.o.WebhookConfigName, failurePolicy, updated.ResourceVersion, err)
 			reportValidationConfigUpdateError(kubeErrors.ReasonForError(err))
 			return err
 		}
 
-		scope.Infof("Successfully updated validatingwebhookconfiguration %v (resourceVersion=%v)",
-			c.o.WebhookConfigName, latest.ResourceVersion)
+		scope.Infof("Successfully updated validatingwebhookconfiguration %v (failurePolicy=%v,resourceVersion=%v)",
+			c.o.WebhookConfigName, failurePolicy, latest.ResourceVersion)
 		reportValidationConfigUpdate()
 		return nil
 	}
 
-	scope.Infof("validatingwebhookconfiguration %v (resourceVersion=%v) is up-to-date. No change required.",
-		c.o.WebhookConfigName, current.ResourceVersion)
+	scope.Infof("validatingwebhookconfiguration %v (failurePolicy=%v, resourceVersion=%v) is up-to-date. No change required.",
+		c.o.WebhookConfigName, failurePolicy, current.ResourceVersion)
 
 	return nil
 }
@@ -451,10 +515,6 @@ func (e configError) Reason() string {
 var (
 	codec  runtime.Codec
 	scheme *runtime.Scheme
-
-	// defaults per k8s spec
-	defaultFailurePolicy = kubeApiAdmission.Fail
-	FailurePolicyIgnore  = kubeApiAdmission.Ignore
 )
 
 func init() {


### PR DESCRIPTION


The validation webhook controller's endpoint readiness check isn't
sufficient in some environments. This results in "connection refused"
errors seconds after kube-apiserver advertises the endpoint is
ready. This PR adds an additional check to verify the kube-apiserver
can successful invoke the webhook. The webhook is ready to serve if
invalid configuration is rejected. If the configuration is accepted
the webhook is still configured for fail-open and the kube-apiserver
wasn't able to reach the webhook.

Manual cherry-pick of https://github.com/istio/istio/pull/21354.

(cherry picked from commit 7665555747d19cf7d24d2d011817d29aa2dd6cb9)

