### PR TITLE
Implement source namespace matching

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -678,6 +678,7 @@ func convertTLSMatchToL4Match(tlsMatch *networking.TLSMatchAttributes) *networki
 		Port:               tlsMatch.Port,
 		SourceLabels:       tlsMatch.SourceLabels,
 		Gateways:           tlsMatch.Gateways,
+		SourceNamespace:    tlsMatch.SourceNamespace,
 	}
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -305,7 +305,7 @@ func BuildHTTPRoutesForVirtualService(
 
 // sourceMatchHttp checks if the sourceLabels or the gateways in a match condition match with the
 // labels for the proxy or the gateway name for which we are generating a route
-func sourceMatchHTTP(match *networking.HTTPMatchRequest, proxyLabels labels.Collection, gatewayNames map[string]bool) bool {
+func sourceMatchHTTP(match *networking.HTTPMatchRequest, proxyLabels labels.Collection, gatewayNames map[string]bool, proxyNamespace string) bool {
 	if match == nil {
 		return true
 	}
@@ -318,7 +318,7 @@ func sourceMatchHTTP(match *networking.HTTPMatchRequest, proxyLabels labels.Coll
 			}
 		}
 	} else if proxyLabels.IsSupersetOf(match.GetSourceLabels()) {
-		return true
+		return match.SourceNamespace == "" || match.SourceNamespace == proxyNamespace
 	}
 
 	return false
@@ -335,7 +335,7 @@ func translateRoute(push *model.PushContext, node *model.Proxy, in *networking.H
 	// resolved Traffic to such clusters will blackhole.
 
 	// Match by source labels/gateway names inside the match condition
-	if !sourceMatchHTTP(match, labels.Collection{node.Metadata.Labels}, gatewayNames) {
+	if !sourceMatchHTTP(match, labels.Collection{node.Metadata.Labels}, gatewayNames, node.Metadata.Namespace) {
 		return nil
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/tls_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/tls_test.go
@@ -1,0 +1,144 @@
+// Copyright 2020 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha3
+
+import (
+	"testing"
+
+	"istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pkg/config/labels"
+)
+
+func TestMatchTLS(t *testing.T) {
+	type args struct {
+		match       *v1alpha3.TLSMatchAttributes
+		proxyLabels labels.Collection
+		gateways    map[string]bool
+		port        int
+		namespace   string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			"source namespace match",
+			args{
+				match: &v1alpha3.TLSMatchAttributes{
+					SourceNamespace: "foo",
+				},
+				namespace: "foo",
+			},
+			true,
+		},
+		{
+			"source namespace not match",
+			args{
+				match: &v1alpha3.TLSMatchAttributes{
+					SourceNamespace: "foo",
+				},
+				namespace: "bar",
+			},
+			false,
+		},
+		{
+			"source namespace not match when empty",
+			args{
+				match: &v1alpha3.TLSMatchAttributes{
+					SourceNamespace: "foo",
+				},
+				namespace: "",
+			},
+			false,
+		},
+		{
+			"source namespace any",
+			args{
+				match:     &v1alpha3.TLSMatchAttributes{},
+				namespace: "bar",
+			},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchTLS(tt.args.match, tt.args.proxyLabels, tt.args.gateways, tt.args.port, tt.args.namespace); got != tt.want {
+				t.Errorf("matchTLS() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchTCP(t *testing.T) {
+	type args struct {
+		match       *v1alpha3.L4MatchAttributes
+		proxyLabels labels.Collection
+		gateways    map[string]bool
+		port        int
+		namespace   string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			"source namespace match",
+			args{
+				match: &v1alpha3.L4MatchAttributes{
+					SourceNamespace: "foo",
+				},
+				namespace: "foo",
+			},
+			true,
+		},
+		{
+			"source namespace not match",
+			args{
+				match: &v1alpha3.L4MatchAttributes{
+					SourceNamespace: "foo",
+				},
+				namespace: "bar",
+			},
+			false,
+		},
+		{
+			"source namespace not match when empty",
+			args{
+				match: &v1alpha3.L4MatchAttributes{
+					SourceNamespace: "foo",
+				},
+				namespace: "",
+			},
+			false,
+		},
+		{
+			"source namespace any",
+			args{
+				match:     &v1alpha3.L4MatchAttributes{},
+				namespace: "bar",
+			},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchTCP(tt.args.match, tt.args.proxyLabels, tt.args.gateways, tt.args.port, tt.args.namespace); got != tt.want {
+				t.Errorf("matchTLS() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
It would be useful to be able to route on source namespace additional to source labels. The implementation is essentially identical to for source labels.