### PR TITLE
Exclude capture inbound on prometheus port 15090

### DIFF
--- a/istioctl/cmd/testdata/uninject/cronjob.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/cronjob.yaml.injected
@@ -132,7 +132,7 @@ spec:
             - -b
             - ""
             - -d
-            - "15020"
+            - "15090, 15020"
             image: docker.io/istio/proxy_init:unittest
             imagePullPolicy: IfNotPresent
             name: istio-init

--- a/istioctl/cmd/testdata/uninject/cronjob.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/cronjob.yaml.injected
@@ -132,7 +132,7 @@ spec:
             - -b
             - ""
             - -d
-            - "15090, 15020"
+            - "15090,15020"
             image: docker.io/istio/proxy_init:unittest
             imagePullPolicy: IfNotPresent
             name: istio-init

--- a/istioctl/cmd/testdata/uninject/daemonset.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/daemonset.yaml.injected
@@ -137,7 +137,7 @@ spec:
         - -b
         - "80"
         - -d
-        - "15020"
+        - "15090, 15020"
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/istioctl/cmd/testdata/uninject/daemonset.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/daemonset.yaml.injected
@@ -137,7 +137,7 @@ spec:
         - -b
         - "80"
         - -d
-        - "15090, 15020"
+        - "15090,15020"
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/istioctl/cmd/testdata/uninject/deploymentconfig-multi.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/deploymentconfig-multi.yaml.injected
@@ -156,7 +156,7 @@ items:
           - -b
           - "80"
           - -d
-          - "15020"
+          - "15090, 15020"
           image: docker.io/istio/proxy_init:unittest
           imagePullPolicy: IfNotPresent
           name: istio-init

--- a/istioctl/cmd/testdata/uninject/deploymentconfig-multi.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/deploymentconfig-multi.yaml.injected
@@ -156,7 +156,7 @@ items:
           - -b
           - "80"
           - -d
-          - "15090, 15020"
+          - "15090,15020"
           image: docker.io/istio/proxy_init:unittest
           imagePullPolicy: IfNotPresent
           name: istio-init

--- a/istioctl/cmd/testdata/uninject/deploymentconfig.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/deploymentconfig.yaml.injected
@@ -141,7 +141,7 @@ spec:
         - -b
         - "80"
         - -d
-        - "15020"
+        - "15090, 15020"
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/istioctl/cmd/testdata/uninject/deploymentconfig.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/deploymentconfig.yaml.injected
@@ -141,7 +141,7 @@ spec:
         - -b
         - "80"
         - -d
-        - "15090, 15020"
+        - "15090,15020"
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/istioctl/cmd/testdata/uninject/enable-core-dump.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/enable-core-dump.yaml.injected
@@ -142,7 +142,7 @@ spec:
         - -b
         - "80"
         - -d
-        - "15090, 15020"
+        - "15090,15020"
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/istioctl/cmd/testdata/uninject/enable-core-dump.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/enable-core-dump.yaml.injected
@@ -142,7 +142,7 @@ spec:
         - -b
         - "80"
         - -d
-        - "15020"
+        - "15090, 15020"
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/istioctl/cmd/testdata/uninject/job.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/job.yaml.injected
@@ -130,7 +130,7 @@ spec:
         - -b
         - ""
         - -d
-        - "15020"
+        - "15090, 15020"
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/istioctl/cmd/testdata/uninject/job.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/job.yaml.injected
@@ -130,7 +130,7 @@ spec:
         - -b
         - ""
         - -d
-        - "15090, 15020"
+        - "15090,15020"
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/istioctl/cmd/testdata/uninject/list.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/list.yaml.injected
@@ -151,7 +151,7 @@ items:
           - -b
           - "80"
           - -d
-          - "15020"
+          - "15090, 15020"
           image: docker.io/istio/proxy_init:unittest
           imagePullPolicy: IfNotPresent
           name: istio-init
@@ -335,7 +335,7 @@ items:
           - -b
           - "81"
           - -d
-          - "15020"
+          - "15090, 15020"
           image: docker.io/istio/proxy_init:unittest
           imagePullPolicy: IfNotPresent
           name: istio-init

--- a/istioctl/cmd/testdata/uninject/list.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/list.yaml.injected
@@ -151,7 +151,7 @@ items:
           - -b
           - "80"
           - -d
-          - "15090, 15020"
+          - "15090,15020"
           image: docker.io/istio/proxy_init:unittest
           imagePullPolicy: IfNotPresent
           name: istio-init
@@ -335,7 +335,7 @@ items:
           - -b
           - "81"
           - -d
-          - "15090, 15020"
+          - "15090,15020"
           image: docker.io/istio/proxy_init:unittest
           imagePullPolicy: IfNotPresent
           name: istio-init

--- a/istioctl/cmd/testdata/uninject/pod.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/pod.yaml.injected
@@ -130,7 +130,7 @@ spec:
     - -b
     - "80"
     - -d
-    - "15090, 15020"
+    - "15090,15020"
     image: docker.io/istio/proxy_init:unittest
     imagePullPolicy: IfNotPresent
     name: istio-init

--- a/istioctl/cmd/testdata/uninject/pod.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/pod.yaml.injected
@@ -130,7 +130,7 @@ spec:
     - -b
     - "80"
     - -d
-    - "15020"
+    - "15090, 15020"
     image: docker.io/istio/proxy_init:unittest
     imagePullPolicy: IfNotPresent
     name: istio-init

--- a/istioctl/cmd/testdata/uninject/replicaset.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/replicaset.yaml.injected
@@ -138,7 +138,7 @@ spec:
         - -b
         - "80"
         - -d
-        - "15090, 15020"
+        - "15090,15020"
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/istioctl/cmd/testdata/uninject/replicaset.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/replicaset.yaml.injected
@@ -138,7 +138,7 @@ spec:
         - -b
         - "80"
         - -d
-        - "15020"
+        - "15090, 15020"
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/istioctl/cmd/testdata/uninject/replicationcontroller.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/replicationcontroller.yaml.injected
@@ -137,7 +137,7 @@ spec:
         - -b
         - "80"
         - -d
-        - "15020"
+        - "15090, 15020"
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/istioctl/cmd/testdata/uninject/replicationcontroller.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/replicationcontroller.yaml.injected
@@ -137,7 +137,7 @@ spec:
         - -b
         - "80"
         - -d
-        - "15090, 15020"
+        - "15090,15020"
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/istioctl/cmd/testdata/uninject/statefulset.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/statefulset.yaml.injected
@@ -146,7 +146,7 @@ spec:
         - -b
         - "80"
         - -d
-        - "15090, 15020"
+        - "15090,15020"
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/istioctl/cmd/testdata/uninject/statefulset.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/statefulset.yaml.injected
@@ -146,7 +146,7 @@ spec:
         - -b
         - "80"
         - -d
-        - "15020"
+        - "15090, 15020"
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/manifests/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/istio-control/istio-discovery/files/injection-template.yaml
@@ -34,7 +34,7 @@ template: |
     - "-b"
     - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
     - "-d"
-    - "{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
+    - "15090, {{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
     {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.excludeOutboundPorts "") "") -}}
     - "-o"
     - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}"

--- a/manifests/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/istio-control/istio-discovery/files/injection-template.yaml
@@ -34,7 +34,7 @@ template: |
     - "-b"
     - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
     - "-d"
-    - "15090, {{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
+    - "15090,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
     {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.excludeOutboundPorts "") "") -}}
     - "-o"
     - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}"

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -9004,7 +9004,7 @@ data:
         - "-b"
         - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
         - "-d"
-        - "{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
+        - "15090,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
         {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.excludeOutboundPorts "") "") -}}
         - "-o"
         - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}"

--- a/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.golden.yaml
@@ -7982,7 +7982,7 @@ data:
         - "-b"
         - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
         - "-d"
-        - "{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
+        - "15090,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
         {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.excludeOutboundPorts "") "") -}}
         - "-o"
         - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}"

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_force.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_force.golden.yaml
@@ -783,7 +783,7 @@ data:
         - "-b"
         - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
         - "-d"
-        - "{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
+        - "15090,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
         {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.excludeOutboundPorts "") "") -}}
         - "-o"
         - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}"

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output.golden.yaml
@@ -782,7 +782,7 @@ data:
         - "-b"
         - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
         - "-d"
-        - "{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
+        - "15090,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
         {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.excludeOutboundPorts "") "") -}}
         - "-o"
         - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}"

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
@@ -6830,7 +6830,7 @@ data:
         - "-b"
         - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
         - "-d"
-        - "{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
+        - "15090,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
         {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.excludeOutboundPorts "") "") -}}
         - "-o"
         - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}"

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.golden.yaml
@@ -7774,7 +7774,7 @@ data:
         - "-b"
         - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
         - "-d"
-        - "{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
+        - "15090,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
         {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.excludeOutboundPorts "") "") -}}
         - "-o"
         - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}"

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_override_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_override_values.golden.yaml
@@ -780,7 +780,7 @@ data:
         - "-b"
         - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
         - "-d"
-        - "{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
+        - "15090,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
         {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.excludeOutboundPorts "") "") -}}
         - "-o"
         - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}"

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.golden.yaml
@@ -7774,7 +7774,7 @@ data:
         - "-b"
         - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
         - "-d"
-        - "{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
+        - "15090,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
         {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.excludeOutboundPorts "") "") -}}
         - "-o"
         - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}"

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -780,7 +780,7 @@ data:
         - "-b"
         - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
         - "-d"
-        - "{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
+        - "15090,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
         {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.excludeOutboundPorts "") "") -}}
         - "-o"
         - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}"

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.golden.yaml
@@ -780,7 +780,7 @@ data:
         - "-b"
         - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
         - "-d"
-        - "{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
+        - "15090,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
         {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.excludeOutboundPorts "") "") -}}
         - "-o"
         - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}"

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -10557,7 +10557,7 @@ template: |
     - "-b"
     - "{{ annotation .ObjectMeta `+"`"+`traffic.sidecar.istio.io/includeInboundPorts`+"`"+` `+"`"+`*`+"`"+` }}"
     - "-d"
-    - "{{ excludeInboundPort (annotation .ObjectMeta `+"`"+`status.sidecar.istio.io/port`+"`"+` .Values.global.proxy.statusPort) (annotation .ObjectMeta `+"`"+`traffic.sidecar.istio.io/excludeInboundPorts`+"`"+` .Values.global.proxy.excludeInboundPorts) }}"
+    - "15090, {{ excludeInboundPort (annotation .ObjectMeta `+"`"+`status.sidecar.istio.io/port`+"`"+` .Values.global.proxy.statusPort) (annotation .ObjectMeta `+"`"+`traffic.sidecar.istio.io/excludeInboundPorts`+"`"+` .Values.global.proxy.excludeInboundPorts) }}"
     {{ if or (isset .ObjectMeta.Annotations `+"`"+`traffic.sidecar.istio.io/excludeOutboundPorts`+"`"+`) (ne (valueOrDefault .Values.global.proxy.excludeOutboundPorts "") "") -}}
     - "-o"
     - "{{ annotation .ObjectMeta `+"`"+`traffic.sidecar.istio.io/excludeOutboundPorts`+"`"+` .Values.global.proxy.excludeOutboundPorts }}"

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -10557,7 +10557,7 @@ template: |
     - "-b"
     - "{{ annotation .ObjectMeta `+"`"+`traffic.sidecar.istio.io/includeInboundPorts`+"`"+` `+"`"+`*`+"`"+` }}"
     - "-d"
-    - "15090, {{ excludeInboundPort (annotation .ObjectMeta `+"`"+`status.sidecar.istio.io/port`+"`"+` .Values.global.proxy.statusPort) (annotation .ObjectMeta `+"`"+`traffic.sidecar.istio.io/excludeInboundPorts`+"`"+` .Values.global.proxy.excludeInboundPorts) }}"
+    - "15090,{{ excludeInboundPort (annotation .ObjectMeta `+"`"+`status.sidecar.istio.io/port`+"`"+` .Values.global.proxy.statusPort) (annotation .ObjectMeta `+"`"+`traffic.sidecar.istio.io/excludeInboundPorts`+"`"+` .Values.global.proxy.excludeInboundPorts) }}"
     {{ if or (isset .ObjectMeta.Annotations `+"`"+`traffic.sidecar.istio.io/excludeOutboundPorts`+"`"+`) (ne (valueOrDefault .Values.global.proxy.excludeOutboundPorts "") "") -}}
     - "-o"
     - "{{ annotation .ObjectMeta `+"`"+`traffic.sidecar.istio.io/excludeOutboundPorts`+"`"+` .Values.global.proxy.excludeOutboundPorts }}"

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -189,7 +189,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -189,7 +189,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -184,7 +184,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
@@ -180,7 +180,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
@@ -180,7 +180,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
@@ -163,7 +163,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
@@ -181,7 +181,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
@@ -162,7 +162,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
@@ -162,7 +162,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
@@ -165,7 +165,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
@@ -165,7 +165,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
@@ -180,7 +180,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
@@ -162,7 +162,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
@@ -162,7 +162,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
@@ -174,7 +174,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
@@ -159,7 +159,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
@@ -159,7 +159,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -159,7 +159,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -159,7 +159,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -159,7 +159,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -159,7 +159,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -152,7 +152,7 @@ spec:
             - -b
             - '*'
             - -d
-            - "15090, 15020"
+            - 15090,15020
             image: gcr.io/istio-testing/proxyv2:latest
             imagePullPolicy: Always
             name: istio-init

--- a/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -152,7 +152,7 @@ spec:
             - -b
             - '*'
             - -d
-            - "15020"
+            - "15090, 15020"
             image: gcr.io/istio-testing/proxyv2:latest
             imagePullPolicy: Always
             name: istio-init

--- a/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -157,7 +157,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -157,7 +157,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -172,7 +172,7 @@ items:
           - -b
           - '*'
           - -d
-          - "15020"
+          - "15090, 15020"
           image: gcr.io/istio-testing/proxyv2:latest
           imagePullPolicy: Always
           name: istio-init

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -172,7 +172,7 @@ items:
           - -b
           - '*'
           - -d
-          - "15090, 15020"
+          - 15090,15020
           image: gcr.io/istio-testing/proxyv2:latest
           imagePullPolicy: Always
           name: istio-init

--- a/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -157,7 +157,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -157,7 +157,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
@@ -163,7 +163,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
@@ -163,7 +163,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -159,7 +159,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -159,7 +159,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -159,7 +159,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -175,7 +175,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -175,7 +175,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -159,7 +159,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -159,7 +159,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
@@ -159,7 +159,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
@@ -159,7 +159,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
@@ -163,7 +163,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
@@ -163,7 +163,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
@@ -162,7 +162,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
@@ -159,7 +159,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
@@ -159,7 +159,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -161,7 +161,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init
@@ -373,7 +373,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -161,7 +161,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init
@@ -373,7 +373,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -160,7 +160,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -159,7 +159,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Never
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -159,7 +159,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Never
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -163,7 +163,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
@@ -163,7 +163,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
@@ -163,7 +163,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -161,7 +161,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -161,7 +161,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
@@ -159,7 +159,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - 15090,15020
         - --run-validation
         - --skip-rule-apply
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -159,7 +159,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -159,7 +159,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -150,7 +150,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -150,7 +150,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -163,7 +163,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "123"
+        - 15090,123
         - -k
         - net1
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -163,7 +163,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         - -k
         - net1,net2
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -163,7 +163,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - 15090,15020
         - -k
         - net1,net2
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -176,7 +176,7 @@ items:
           - -b
           - '*'
           - -d
-          - "15090, 15020"
+          - 15090,15020
           image: gcr.io/istio-testing/proxyv2:latest
           imagePullPolicy: Always
           name: istio-init

--- a/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -176,7 +176,7 @@ items:
           - -b
           - '*'
           - -d
-          - "15020"
+          - "15090, 15020"
           image: gcr.io/istio-testing/proxyv2:latest
           imagePullPolicy: Always
           name: istio-init

--- a/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -163,7 +163,7 @@ items:
           - -b
           - '*'
           - -d
-          - "15020"
+          - 15090,15020
           image: gcr.io/istio-testing/proxyv2:latest
           imagePullPolicy: Always
           name: istio-init
@@ -374,7 +374,7 @@ items:
           - -b
           - '*'
           - -d
-          - "15090, 15020"
+          - 15090,15020
           image: gcr.io/istio-testing/proxyv2:latest
           imagePullPolicy: Always
           name: istio-init

--- a/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -374,7 +374,7 @@ items:
           - -b
           - '*'
           - -d
-          - "15020"
+          - "15090, 15020"
           image: gcr.io/istio-testing/proxyv2:latest
           imagePullPolicy: Always
           name: istio-init

--- a/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
@@ -161,7 +161,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -173,7 +173,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -173,7 +173,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -145,7 +145,7 @@ spec:
     - -b
     - '*'
     - -d
-    - "15020"
+    - 15090,15020
     image: gcr.io/istio-testing/proxyv2:latest
     imagePullPolicy: Always
     name: istio-init

--- a/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -154,7 +154,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -154,7 +154,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -153,7 +153,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -162,7 +162,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -162,7 +162,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -163,7 +163,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 123"
+        - 15090,123
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -163,7 +163,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "123"
+        - "15090, 123"
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -155,7 +155,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "123"
+        - 15090,123
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -159,7 +159,7 @@ spec:
         - -b
         - ""
         - -d
-        - 4,5,6,15020
+        - 15090, 4,5,6,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -159,7 +159,7 @@ spec:
         - -b
         - ""
         - -d
-        - 15090, 4,5,6,15020
+        - 15090,4,5,6,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -159,7 +159,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 4,5,6,15020
+        - 15090,4,5,6,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -160,7 +160,7 @@ spec:
         - -b
         - 1,2,3
         - -d
-        - 4,5,6,15020
+        - 15090,4,5,6,15020
         - -o
         - 7,8,9
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -155,7 +155,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - 15090,15020
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -155,7 +155,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -147,7 +147,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 4,5,6
+        - 15090,4,5,6
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
@@ -152,7 +152,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - "15090,15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
@@ -152,7 +152,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
@@ -151,7 +151,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
@@ -151,7 +151,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - "15090,15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig-with-canonical-service-label.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig-with-canonical-service-label.yaml.injected
@@ -151,7 +151,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig-with-canonical-service-label.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig-with-canonical-service-label.yaml.injected
@@ -151,7 +151,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - "15090,15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
@@ -151,7 +151,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
@@ -151,7 +151,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - "15090,15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
@@ -156,7 +156,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - "15090,15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
@@ -156,7 +156,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
@@ -153,7 +153,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
@@ -153,7 +153,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - "15090,15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-mtls-not-ready.yaml.injected
@@ -153,7 +153,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-mtls-not-ready.yaml.injected
@@ -153,7 +153,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - "15090,15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
@@ -155,7 +155,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - "15090,15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init
@@ -362,7 +362,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - "15090,15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
@@ -155,7 +155,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init
@@ -362,7 +362,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
@@ -174,7 +174,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
@@ -174,7 +174,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - "15090,15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/job.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/job.yaml.injected
@@ -151,7 +151,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/job.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/job.yaml.injected
@@ -151,7 +151,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - "15090,15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
@@ -156,7 +156,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - "15090,15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
@@ -156,7 +156,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/list.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/list.yaml.injected
@@ -155,7 +155,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - "15090,15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init
@@ -362,7 +362,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - "15090,15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/list.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/list.yaml.injected
@@ -155,7 +155,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init
@@ -362,7 +362,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/multi-init.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/multi-init.yaml.injected
@@ -143,7 +143,7 @@ spec:
         - -b
         - "80"
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/multi-init.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/multi-init.yaml.injected
@@ -143,7 +143,7 @@ spec:
         - -b
         - "80"
         - -d
-        - "15090, 15020"
+        - "15090,15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
@@ -149,7 +149,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - "15090,15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
@@ -149,7 +149,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
@@ -151,7 +151,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
@@ -151,7 +151,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - "15090,15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
@@ -148,7 +148,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - "15090,15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
@@ -148,7 +148,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
@@ -156,7 +156,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - "15090,15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
@@ -156,7 +156,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
@@ -154,7 +154,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "123"
+        - "15090, 123"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
@@ -154,7 +154,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 123"
+        - "15090,123"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
@@ -153,7 +153,7 @@ spec:
         - -b
         - ""
         - -d
-        - 15090, 4,5,6,15020
+        - 15090,4,5,6,15020
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
@@ -153,7 +153,7 @@ spec:
         - -b
         - ""
         - -d
-        - 4,5,6,15020
+        - 15090, 4,5,6,15020
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
@@ -153,7 +153,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 15090, 4,5,6,15020
+        - 15090,4,5,6,15020
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
@@ -153,7 +153,7 @@ spec:
         - -b
         - '*'
         - -d
-        - 4,5,6,15020
+        - 15090, 4,5,6,15020
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
@@ -154,7 +154,7 @@ spec:
         - -b
         - 1,2,3
         - -d
-        - 15090, 4,5,6,15020
+        - 15090,4,5,6,15020
         - -o
         - 7,8,9
         image: gcr.io/istio-release/proxy_init:master-latest-daily

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
@@ -154,7 +154,7 @@ spec:
         - -b
         - 1,2,3
         - -d
-        - 4,5,6,15020
+        - 15090, 4,5,6,15020
         - -o
         - 7,8,9
         image: gcr.io/istio-release/proxy_init:master-latest-daily

--- a/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
@@ -160,7 +160,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15090, 15020"
+        - "15090,15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
@@ -160,7 +160,7 @@ spec:
         - -b
         - '*'
         - -d
-        - "15020"
+        - "15090, 15020"
         image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: Always
         name: istio-init


### PR DESCRIPTION
Port 15090 is used by prometheus with static config, and shouldn't be captured. If so, traffic will go through virtualInbound / passthrough listener, which will have mTLS enforced with the new mTLS API.