### PR TITLE
add a tcp port to the demo profile

### DIFF
--- a/manifests/gateways/istio-ingress/values.yaml
+++ b/manifests/gateways/istio-ingress/values.yaml
@@ -33,8 +33,8 @@ gateways:
       targetPort: 15032
       name: tracing
     - port: 31400
+      targetPort: 31400
       name: tcp
-      nodePort: 31400
       # This is the port where sni routing happens
     - port: 15443
       targetPort: 15443

--- a/manifests/gateways/istio-ingress/values.yaml
+++ b/manifests/gateways/istio-ingress/values.yaml
@@ -32,6 +32,9 @@ gateways:
     - port: 15032
       targetPort: 15032
       name: tracing
+    - port: 31400
+      name: tcp
+      nodePort: 31400
       # This is the port where sni routing happens
     - port: 15443
       targetPort: 15443

--- a/operator/data/profiles/demo.yaml
+++ b/operator/data/profiles/demo.yaml
@@ -103,6 +103,38 @@ spec:
         autoscaleEnabled: false
       istio-ingressgateway:
         autoscaleEnabled: false
-
+        ports:
+        ## You can add custom gateway ports in user values overrides, but it must include those ports since helm replaces.
+        # Note that AWS ELB will by default perform health checks on the first port
+        # on this list. Setting this to the health check port will ensure that health
+        # checks always work. https://github.com/istio/istio/issues/12503
+        - port: 15020
+          targetPort: 15020
+          name: status-port
+        - port: 80
+          targetPort: 8080
+          name: http2
+        - port: 443
+          targetPort: 8443
+          name: https
+        - port: 15029
+          targetPort: 15029
+          name: kiali
+        - port: 15030
+          targetPort: 15030
+          name: prometheus
+        - port: 15031
+          targetPort: 15031
+          name: grafana
+        - port: 15032
+          targetPort: 15032
+          name: tracing
+        - port: 31400
+          name: tcp
+          nodePort: 31400
+          # This is the port where sni routing happens
+        - port: 15443
+          targetPort: 15443
+          name: tls
     kiali:
       createDemoSecret: true

--- a/operator/data/profiles/demo.yaml
+++ b/operator/data/profiles/demo.yaml
@@ -130,8 +130,8 @@ spec:
           targetPort: 15032
           name: tracing
         - port: 31400
+          targetPort: 31400
           name: tcp
-          nodePort: 31400
           # This is the port where sni routing happens
         - port: 15443
           targetPort: 15443

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -8935,6 +8935,9 @@ gateways:
     - port: 15032
       targetPort: 15032
       name: tracing
+    - port: 31400
+      name: tcp
+      nodePort: 31400
       # This is the port where sni routing happens
     - port: 15443
       targetPort: 15443
@@ -38740,7 +38743,39 @@ spec:
         autoscaleEnabled: false
       istio-ingressgateway:
         autoscaleEnabled: false
-
+        ports:
+        ## You can add custom gateway ports in user values overrides, but it must include those ports since helm replaces.
+        # Note that AWS ELB will by default perform health checks on the first port
+        # on this list. Setting this to the health check port will ensure that health
+        # checks always work. https://github.com/istio/istio/issues/12503
+        - port: 15020
+          targetPort: 15020
+          name: status-port
+        - port: 80
+          targetPort: 8080
+          name: http2
+        - port: 443
+          targetPort: 8443
+          name: https
+        - port: 15029
+          targetPort: 15029
+          name: kiali
+        - port: 15030
+          targetPort: 15030
+          name: prometheus
+        - port: 15031
+          targetPort: 15031
+          name: grafana
+        - port: 15032
+          targetPort: 15032
+          name: tracing
+        - port: 31400
+          name: tcp
+          nodePort: 31400
+          # This is the port where sni routing happens
+        - port: 15443
+          targetPort: 15443
+          name: tls
     kiali:
       createDemoSecret: true
 `)

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -8936,8 +8936,8 @@ gateways:
       targetPort: 15032
       name: tracing
     - port: 31400
+      targetPort: 31400
       name: tcp
-      nodePort: 31400
       # This is the port where sni routing happens
     - port: 15443
       targetPort: 15443
@@ -38770,8 +38770,8 @@ spec:
           targetPort: 15032
           name: tracing
         - port: 31400
+          targetPort: 31400
           name: tcp
-          nodePort: 31400
           # This is the port where sni routing happens
         - port: 15443
           targetPort: 15443


### PR DESCRIPTION
 Please provide a description for what this PR is for.
add a tcp port to the demo profile for tcp traffic shift tasks on isio.io

https://preliminary.istio.io/docs/tasks/traffic-management/tcp-traffic-shifting/#apply-weight-based-tcp-routing
The following command currently fails and none of the other exposed ports work in the task
```
kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="tcp")].port}'
```
And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ X ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
