### PR TITLE
[release-1.5] ValidatingWebhookConfig is a cluster resource

### DIFF
--- a/manifests/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
+++ b/manifests/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.clusterResources }}
 {{- if .Values.global.istiod.enabled }}
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
@@ -58,4 +59,5 @@ metadata:
     release: {{ .Release.Name }}
     istio: istiod
 webhooks:
+{{- end }}
 {{- end }}

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -15092,7 +15092,8 @@ func chartsIstioControlIstioDiscoveryTemplatesTelemetryv2_15Yaml() (*asset, erro
 	return a, nil
 }
 
-var _chartsIstioControlIstioDiscoveryTemplatesValidatingwebhookconfigurationYaml = []byte(`{{- if .Values.global.istiod.enabled }}
+var _chartsIstioControlIstioDiscoveryTemplatesValidatingwebhookconfigurationYaml = []byte(`{{- if .Values.clusterResources }}
+{{- if .Values.global.istiod.enabled }}
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -15152,7 +15153,9 @@ metadata:
     release: {{ .Release.Name }}
     istio: istiod
 webhooks:
-{{- end }}`)
+{{- end }}
+{{- end }}
+`)
 
 func chartsIstioControlIstioDiscoveryTemplatesValidatingwebhookconfigurationYamlBytes() ([]byte, error) {
 	return _chartsIstioControlIstioDiscoveryTemplatesValidatingwebhookconfigurationYaml, nil


### PR DESCRIPTION
I think the webhook configuration should be set as a clusterwide resource. 

If we want it to be a non-clusterwide resource that works too, but it should only generate in one of the two values for `.Values.clusterResources`, not both.