### PR TITLE
[release-1.5] authn: fix to add the authn filter when PeerAuthentication is used

### DIFF
--- a/pilot/pkg/security/authn/v1beta1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier.go
@@ -62,7 +62,7 @@ type v1beta1PolicyApplier struct {
 
 func (a *v1beta1PolicyApplier) JwtFilter(isXDSMarshalingToAnyEnabled bool) *http_conn.HttpFilter {
 	if len(a.processedJwtRules) == 0 {
-		log.Debugf("JwtFilter: RequestAuthentication (beta policy) not found, fallback to alpha if available")
+		authnLog.Debug("JwtFilter: RequestAuthentication (beta policy) not found, fallback to alpha if available")
 		return a.alphaApplier.JwtFilter(isXDSMarshalingToAnyEnabled)
 	}
 
@@ -123,8 +123,8 @@ func convertToIstioAuthnFilterConfig(jwtRules []*v1beta1.JWTRule) *authn_filter.
 // ensure Authn Filter won't reject the request, but still transform the attributes, e.g. request.auth.principal.
 // proxyType does not matter here, exists only for legacy reason.
 func (a *v1beta1PolicyApplier) AuthNFilter(proxyType model.NodeType, isXDSMarshalingToAnyEnabled bool) *http_conn.HttpFilter {
-	if len(a.processedJwtRules) == 0 {
-		log.Debugf("AuthnFilter: RequestAuthentication (beta policy) not found, fallback to alpha if available")
+	if len(a.processedJwtRules) == 0 && a.consolidatedPeerPolicy == nil {
+		authnLog.Debug("AuthnFilter: RequestAuthentication nor PeerAuthentication (beta policy) not found, fallback to alpha if available")
 		return a.alphaApplier.AuthNFilter(proxyType, isXDSMarshalingToAnyEnabled)
 	}
 	out := &http_conn.HttpFilter{


### PR DESCRIPTION
Fix the missed change in the cherry-pick (https://github.com/istio/istio/pull/20955),

This is caught by a new e2e test that pass on master but fail in release-1.5:  https://github.com/istio/istio/pull/21444.


The root cause seems due to an incomplete cherry-pick to release-1.5 (https://github.com/istio/istio/pull/20955) that missed some changes from the original PR to master.

Compare the release-1.5 
https://github.com/istio/istio/blob/6ee7fb07cdc776605c916a4fa1f7e938a57a4db9/pilot/pkg/security/authn/v1beta1/policy_applier.go#L125-L129, to the master https://github.com/istio/istio/blob/8194854eae8894ee9bbbaf6f2c977d739c404fa4/pilot/pkg/security/authn/v1beta1/policy_applier.go#L120-L124, it missed the `&& a.consolidatedPeerPolicy == nil`

