### PR TITLE
[Release-1.5] [Helm Install] Fix extra .Value in deployment file for stackdriver tracing vars

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -276,15 +276,15 @@ spec:
             value: "{{ $.Values.global.tracer.stackdriver.debug }}"
           {{- if $.Values.global.tracer.stackdriver.maxNumberOfAnnotations }}
           - name: STACKDRIVER_TRACING_MAX_NUMBER_OF_ANNOTATIONS
-            value: "{{ $.Values.global.tracer.stackdriver.maxNumberOfAnnotations.Value }}"
+            value: "{{ $.Values.global.tracer.stackdriver.maxNumberOfAnnotations }}"
           {{- end }}
           {{- if $.Values.global.tracer.stackdriver.maxNumberOfAttributes }}
           - name: STACKDRIVER_TRACING_MAX_NUMBER_OF_ATTRIBUTES
-            value: "{{ $.Values.global.tracer.stackdriver.maxNumberOfAttributes.Value }}"
+            value: "{{ $.Values.global.tracer.stackdriver.maxNumberOfAttributes }}"
           {{- end }}
           {{- if $.Values.global.tracer.stackdriver.maxNumberOfMessageEvents }}
           - name: STACKDRIVER_TRACING_MAX_NUMBER_OF_MESSAGE_EVENTS
-            value: "{{ $.Values.global.tracer.stackdriver.maxNumberOfMessageEvents.Value }}"
+            value: "{{ $.Values.global.tracer.stackdriver.maxNumberOfMessageEvents }}"
           {{- end }}
           {{- end }}
           {{- if $spec.sds }}


### PR DESCRIPTION
Fix extra .Value in deployment file for stackdriver tracing vars
Ref: https://github.com/istio/istio/pull/21218


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure