### PR TITLE
enable istiod for remote component

### DIFF
--- a/operator/data/profiles/remote.yaml
+++ b/operator/data/profiles/remote.yaml
@@ -3,7 +3,7 @@ kind: IstioOperator
 spec:
   components:
     pilot:
-      enabled: false
+      enabled: true
     policy:
       enabled: false
     telemetry:

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -38901,7 +38901,7 @@ kind: IstioOperator
 spec:
   components:
     pilot:
-      enabled: false
+      enabled: true
     policy:
       enabled: false
     telemetry:


### PR DESCRIPTION
Based on discussion in env WG, we need to enable istiod/pilot for remote profile for 1.5, to serve as its injection and citadel functionality.

Note: istiod is already enabled as part of default profile.