### PR TITLE
Remove endpoints from prune kinds list

### DIFF
--- a/operator/pkg/controller/istiocontrolplane/pruningdetails.go
+++ b/operator/pkg/controller/istiocontrolplane/pruningdetails.go
@@ -71,7 +71,8 @@ var (
 		{Group: "apps", Version: "v1", Kind: "DaemonSet"},
 		{Group: "extensions", Version: "v1beta1", Kind: "Ingress"},
 		{Group: "", Version: "v1", Kind: "Service"},
-		{Group: "", Version: "v1", Kind: "Endpoints"},
+		// Endpoints are dynamically created, never from charts.
+		// {Group: "", Version: "v1", Kind: "Endpoints"},
 		{Group: "", Version: "v1", Kind: "ConfigMap"},
 		{Group: "", Version: "v1", Kind: "PersistentVolumeClaim"},
 		{Group: "", Version: "v1", Kind: "Pod"},


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/21495.
Endpoints should not be pruned since they are created and removed dynamically from services and pods. 
