### PR TITLE
fix watch ns in deploy

### DIFF
--- a/operator/deploy/operator.yaml
+++ b/operator/deploy/operator.yaml
@@ -31,7 +31,7 @@ spec:
               memory: 128Mi
           env:
             - name: WATCH_NAMESPACE
-              value: "istio-operator"
+              value: "istio-system"
             - name: LEADER_ELECTION_NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Since the example iop cr is deployed in istio-system, now if install the operator using `kubectl apply -k deploy/` it does not watch the correct ns.

Open question: should we move the controller to istio-system or keep it in istio-operator?