### PR TITLE
Perfomance: remove Discovery.adsSidecarIDConnectionsMap

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -685,15 +685,6 @@ func (s *DiscoveryServer) addCon(conID string, con *XdsConnection) {
 	defer s.adsClientsMutex.Unlock()
 	s.adsClients[conID] = con
 	xdsClients.Record(float64(len(s.adsClients)))
-	if con.node != nil {
-		node := con.node
-
-		if _, ok := s.adsSidecarIDConnectionsMap[node.ID]; !ok {
-			s.adsSidecarIDConnectionsMap[node.ID] = map[string]*XdsConnection{conID: con}
-		} else {
-			s.adsSidecarIDConnectionsMap[node.ID][conID] = con
-		}
-	}
 }
 
 func (s *DiscoveryServer) removeCon(conID string, con *XdsConnection) {
@@ -712,13 +703,6 @@ func (s *DiscoveryServer) removeCon(conID string, con *XdsConnection) {
 	}
 
 	xdsClients.Record(float64(len(s.adsClients)))
-	if con.node != nil {
-		node := con.node
-		delete(s.adsSidecarIDConnectionsMap[node.ID], conID)
-		if len(s.adsSidecarIDConnectionsMap[node.ID]) == 0 {
-			delete(s.adsSidecarIDConnectionsMap, node.ID)
-		}
-	}
 }
 
 // Send with timeout

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"sort"
+	"strings"
 
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/kube/inject"
@@ -434,38 +435,27 @@ func configName(config *model.ConfigMeta) string {
 func (s *DiscoveryServer) Authenticationz(w http.ResponseWriter, req *http.Request) {
 	w.Header().Add("Content-Type", "application/json")
 	if proxyID := req.URL.Query().Get("proxyID"); proxyID != "" {
-		s.adsClientsMutex.RLock()
-		defer s.adsClientsMutex.RUnlock()
-
-		connections, ok := s.adsSidecarIDConnectionsMap[proxyID]
-		if !ok {
+		con := s.getProxyConnection(proxyID)
+		if con == nil {
 			w.WriteHeader(http.StatusNotFound)
 			// Need to dump an empty JSON array so istioctl can peacefully ignore.
 			_, _ = fmt.Fprintf(w, "\n[\n]")
 			return
 		}
-
-		var mostRecentProxy *model.Proxy
-		mostRecent := ""
-		for key := range connections {
-			if mostRecent == "" || key > mostRecent {
-				mostRecent = key
-			}
-		}
-		mostRecentProxy = connections[mostRecent].node
-		svc, _ := s.Env.ServiceDiscovery.Services()
+		pushContext := s.globalPushContext()
+		svcs := pushContext.Services(con.node)
 		meshConfig := s.Env.Mesh()
 		autoMTLSEnabled := meshConfig.GetEnableAutoMtls() != nil && meshConfig.GetEnableAutoMtls().Value
 		info := make([]*AuthenticationDebug, 0)
-		for _, ss := range svc {
-			if ss.MeshExternal {
+		for _, svc := range svcs {
+			if svc.MeshExternal {
 				// Skip external services
 				continue
 			}
-			for _, p := range ss.Ports {
-				authnPolicy, authnMeta := s.globalPushContext().AuthenticationPolicyForWorkload(ss, p)
-				destConfig := s.globalPushContext().DestinationRule(mostRecentProxy, ss)
-				info = append(info, AnalyzeMTLSSettings(autoMTLSEnabled, ss.Hostname, p, authnPolicy, authnMeta, destConfig)...)
+			for _, p := range svc.Ports {
+				authnPolicy, authnMeta := pushContext.AuthenticationPolicyForWorkload(svc, p)
+				destConfig := pushContext.DestinationRule(con.node, svc)
+				info = append(info, AnalyzeMTLSSettings(autoMTLSEnabled, svc.Hostname, p, authnPolicy, authnMeta, destConfig)...)
 			}
 		}
 		if b, err := json.MarshalIndent(info, "  ", "  "); err == nil {
@@ -618,23 +608,15 @@ func (s *DiscoveryServer) adsz(w http.ResponseWriter, req *http.Request) {
 // should look like according to Pilot vs what it currently does look like.
 func (s *DiscoveryServer) ConfigDump(w http.ResponseWriter, req *http.Request) {
 	if proxyID := req.URL.Query().Get("proxyID"); proxyID != "" {
-		s.adsClientsMutex.RLock()
-		defer s.adsClientsMutex.RUnlock()
-		connections, ok := s.adsSidecarIDConnectionsMap[proxyID]
-		if !ok || len(connections) == 0 {
+		con := s.getProxyConnection(proxyID)
+		if con == nil {
 			w.WriteHeader(http.StatusNotFound)
 			_, _ = w.Write([]byte("Proxy not connected to this Pilot instance"))
 			return
 		}
 
 		jsonm := &jsonpb.Marshaler{Indent: "    "}
-		mostRecent := ""
-		for key := range connections {
-			if mostRecent == "" || key > mostRecent {
-				mostRecent = key
-			}
-		}
-		dump, err := s.configDump(connections[mostRecent])
+		dump, err := s.configDump(con)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			_, _ = w.Write([]byte(err.Error()))
@@ -785,24 +767,14 @@ func (s *DiscoveryServer) edsz(w http.ResponseWriter, req *http.Request) {
 	}
 	var con *XdsConnection
 	if proxyID := req.URL.Query().Get("proxyID"); proxyID != "" {
-		s.adsClientsMutex.RLock()
-		defer s.adsClientsMutex.RUnlock()
-		connections, ok := s.adsSidecarIDConnectionsMap[proxyID]
+		con = s.getProxyConnection(proxyID)
 		// We can't guarantee the Pilot we are connected to has a connection to the proxy we requested
 		// There isn't a great way around this, but for debugging purposes its suitable to have the caller retry.
-		if !ok || len(connections) == 0 {
+		if con == nil {
 			w.WriteHeader(http.StatusNotFound)
 			_, _ = w.Write([]byte("Proxy not connected to this Pilot instance. It may be connected to another instance."))
 			return
 		}
-
-		mostRecent := ""
-		for key := range connections {
-			if mostRecent == "" || key > mostRecent {
-				mostRecent = key
-			}
-		}
-		con = connections[mostRecent]
 	}
 
 	edsClusterMutex.RLock()
@@ -928,4 +900,17 @@ func printRoutes(w io.Writer, c *XdsConnection) {
 			return
 		}
 	}
+}
+
+func (s *DiscoveryServer) getProxyConnection(proxyID string) *XdsConnection {
+	s.adsClientsMutex.RLock()
+	defer s.adsClientsMutex.RUnlock()
+
+	for conID := range s.adsClients {
+		if strings.Contains(conID, proxyID) {
+			return s.adsClients[conID]
+		}
+	}
+
+	return nil
 }

--- a/pilot/pkg/proxy/envoy/v2/debug_test.go
+++ b/pilot/pkg/proxy/envoy/v2/debug_test.go
@@ -224,35 +224,26 @@ func TestConfigDump(t *testing.T) {
 			s, tearDown := initLocalPilotTestEnv(t)
 			defer tearDown()
 
-			for i := 0; i < 2; i++ {
-				envoy, cancel, err := connectADS(util.MockPilotGrpcAddr)
-				if err != nil {
-					t.Fatal(err)
-				}
-				defer cancel()
-				if err := sendCDSReq(sidecarID(app3Ip, "dumpApp"), envoy); err != nil {
-					t.Fatal(err)
-				}
-				if err := sendLDSReq(sidecarID(app3Ip, "dumpApp"), envoy); err != nil {
-					t.Fatal(err)
-				}
-				// Only most recent proxy will have routes
-				if i == 1 {
-					if err := sendRDSReq(sidecarID(app3Ip, "dumpApp"), []string{"80", "8080"}, "", envoy); err != nil {
-						t.Fatal(err)
-					}
-					_, err := adsReceive(envoy, 5*time.Second)
-					if err != nil {
-						t.Fatal("Recv failed", err)
-					}
-				}
-				for j := 0; j < 2; j++ {
-					_, err := adsReceive(envoy, 5*time.Second)
-					if err != nil {
-						t.Fatal("Recv failed", err)
-					}
-				}
+			envoy, cancel, err := connectADS(util.MockPilotGrpcAddr)
+			if err != nil {
+				t.Fatal(err)
 			}
+			defer cancel()
+			if err := sendCDSReq(sidecarID(app3Ip, "dumpApp"), envoy); err != nil {
+				t.Fatal(err)
+			}
+			if err := sendLDSReq(sidecarID(app3Ip, "dumpApp"), envoy); err != nil {
+				t.Fatal(err)
+			}
+			// Only most recent proxy will have routes
+			if err := sendRDSReq(sidecarID(app3Ip, "dumpApp"), []string{"80", "8080"}, "", envoy); err != nil {
+				t.Fatal(err)
+			}
+			_, err = adsReceive(envoy, 5*time.Second)
+			if err != nil {
+				t.Fatal("Recv failed", err)
+			}
+
 			wrapper := getConfigDump(t, s.EnvoyXdsServer, tt.proxyID, tt.wantCode)
 			if wrapper != nil {
 				if rs, err := wrapper.GetDynamicRouteDump(false); err != nil || len(rs.DynamicRouteConfigs) == 0 {

--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -116,11 +116,6 @@ type DiscoveryServer struct {
 	// adsClients reflect active gRPC channels, for both ADS and EDS.
 	adsClients      map[string]*XdsConnection
 	adsClientsMutex sync.RWMutex
-
-	// Map of sidecar IDs to XdsConnections, first key is sidecarID, second key is connID
-	// This is a map due to an edge case during envoy restart whereby the 'old' envoy
-	// reconnects after the 'new/restarted' envoy
-	adsSidecarIDConnectionsMap map[string]map[string]*XdsConnection
 }
 
 // EndpointShards holds the set of endpoint shards of a service. Registries update
@@ -146,16 +141,15 @@ type EndpointShards struct {
 // NewDiscoveryServer creates DiscoveryServer that sources data from Pilot's internal mesh data structures
 func NewDiscoveryServer(env *model.Environment, plugins []string) *DiscoveryServer {
 	out := &DiscoveryServer{
-		Env:                        env,
-		ConfigGenerator:            core.NewConfigGenerator(plugins),
-		EndpointShardsByService:    map[string]map[string]*EndpointShards{},
-		concurrentPushLimit:        make(chan struct{}, features.PushThrottle),
-		pushChannel:                make(chan *model.PushRequest, 10),
-		pushQueue:                  NewPushQueue(),
-		DebugConfigs:               features.DebugConfigs,
-		debugHandlers:              map[string]string{},
-		adsClients:                 map[string]*XdsConnection{},
-		adsSidecarIDConnectionsMap: map[string]map[string]*XdsConnection{},
+		Env:                     env,
+		ConfigGenerator:         core.NewConfigGenerator(plugins),
+		EndpointShardsByService: map[string]map[string]*EndpointShards{},
+		concurrentPushLimit:     make(chan struct{}, features.PushThrottle),
+		pushChannel:             make(chan *model.PushRequest, 10),
+		pushQueue:               NewPushQueue(),
+		DebugConfigs:            features.DebugConfigs,
+		debugHandlers:           map[string]string{},
+		adsClients:              map[string]*XdsConnection{},
 	}
 
 	// Flush cached discovery responses when detecting jwt public key change.


### PR DESCRIPTION

adsSidecarIDConnectionsMap is only used by debug api, and it can be replace by adsClients