### PR TITLE
operator: remove code duplication by unifying unmarshalling

### DIFF
--- a/operator/cmd/mesh/profile-common.go
+++ b/operator/cmd/mesh/profile-common.go
@@ -29,6 +29,7 @@ import (
 	"istio.io/istio/operator/pkg/name"
 
 	"istio.io/api/operator/v1alpha1"
+	"istio.io/istio/operator/pkg/apis/istio"
 	iopv1alpha1 "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/helm"
 	"istio.io/istio/operator/pkg/tpath"
@@ -321,15 +322,10 @@ func overlayValuesEnablement(baseYAML, fileOverlayYAML, setOverlayYAML string) (
 // representation if successful. If force is set, validation errors are written to logger rather than causing an
 // error.
 func unmarshalAndValidateIOPS(iopsYAML string, force bool, l *Logger) (*v1alpha1.IstioOperatorSpec, error) {
-	iops := &v1alpha1.IstioOperatorSpec{}
-	if err := util.UnmarshalWithJSONPB(iopsYAML, iops, false); err != nil {
-		return nil, fmt.Errorf("could not unmarshal the merged YAML: %s\n\nYAML:\n%s", err, iopsYAML)
-	}
-	if errs := validate.CheckIstioOperatorSpec(iops, true); len(errs) != 0 {
-		if !force {
-			l.logAndError("Run the command with the --force flag if you want to ignore the validation error and proceed.")
-			return nil, fmt.Errorf(errs.Error())
-		}
+	iops, err := istio.UnmarshalAndValidateIOPS(iopsYAML)
+	if err != nil && !force {
+		l.logAndError("Run the command with the --force flag if you want to ignore the validation error and proceed.")
+		return nil, err
 	}
 	return iops, nil
 }

--- a/operator/pkg/apis/istio/common.go
+++ b/operator/pkg/apis/istio/common.go
@@ -1,0 +1,37 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package istio
+
+import (
+	"fmt"
+
+	"istio.io/api/operator/v1alpha1"
+	"istio.io/istio/operator/pkg/util"
+	"istio.io/istio/operator/pkg/validate"
+)
+
+// UnmarshalAndValidateIOPS unmarshals a string containing IstioOperator YAML, validates it, and returns a struct
+// representation if successful. In case of validation errors, it returns both the IstioOperatorSpec struct and
+// an error, so the caller can decide how to handle it.
+func UnmarshalAndValidateIOPS(iopsYAML string) (*v1alpha1.IstioOperatorSpec, error) {
+	iops := &v1alpha1.IstioOperatorSpec{}
+	if err := util.UnmarshalWithJSONPB(iopsYAML, iops, false); err != nil {
+		return nil, fmt.Errorf("could not unmarshal the merged YAML: %s\n\nYAML:\n%s", err, iopsYAML)
+	}
+	if errs := validate.CheckIstioOperatorSpec(iops, true); len(errs) != 0 {
+		return iops, fmt.Errorf(errs.Error())
+	}
+	return iops, nil
+}

--- a/operator/pkg/helmreconciler/rendering.go
+++ b/operator/pkg/helmreconciler/rendering.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"istio.io/api/operator/v1alpha1"
+	"istio.io/istio/operator/pkg/apis/istio"
 	valuesv1alpha1 "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/controlplane"
 	"istio.io/istio/operator/pkg/helm"
@@ -160,20 +161,7 @@ func MergeIOPSWithProfile(iop *v1alpha1.IstioOperatorSpec) (*v1alpha1.IstioOpera
 	if err != nil {
 		return nil, fmt.Errorf("could not overlay user config over base: %s", err)
 	}
-	return unmarshalAndValidateIOPSpec(mergedYAML)
-}
-
-// unmarshalAndValidateIOPSpec unmarshals the IstioOperatorSpec in the iopsYAML string and validates it.
-// If successful, it returns a struct representation of iopsYAML.
-func unmarshalAndValidateIOPSpec(iopsYAML string) (*v1alpha1.IstioOperatorSpec, error) {
-	iops := &v1alpha1.IstioOperatorSpec{}
-	if err := util.UnmarshalWithJSONPB(iopsYAML, iops, false); err != nil {
-		return nil, fmt.Errorf("could not unmarshal the merged YAML: %s\n\nYAML:\n%s", err, iopsYAML)
-	}
-	if errs := validate.CheckIstioOperatorSpec(iops, true); len(errs) != 0 {
-		return nil, fmt.Errorf(errs.Error())
-	}
-	return iops, nil
+	return istio.UnmarshalAndValidateIOPS(mergedYAML)
 }
 
 // ProcessManifest apply the manifest to create or update resources, returns the number of objects processed


### PR DESCRIPTION
A small step towards a cleaner operator codebase.

I'm happy to hear suggestions as to where this func should live! Not sure if `pkg/apis/istio` is the right place.

[x] Installation
