### PR TITLE
[Release-1.4] Fix PSP sample file to allow NET_RAW.

### DIFF
--- a/samples/security/psp/all-pods-psp.yaml
+++ b/samples/security/psp/all-pods-psp.yaml
@@ -12,6 +12,7 @@ spec:
   # Allow the istio sidecar injector to work
   allowedCapabilities:
     - NET_ADMIN
+    - NET_RAW
   seLinux:
     rule: RunAsAny
   supplementalGroups:


### PR DESCRIPTION
Make corresponding PSP config change for the init container SecurityContext change: https://github.com/istio/istio/pull/19832

On master and 1.5 branch, these PSP sample files will be removed since Istio Agent is used.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ X ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure