### PR TITLE
fix(stats): stop adding pod labels to istio metrics

### DIFF
--- a/manifests/istio-telemetry/prometheus-operator/templates/servicemonitors.yaml
+++ b/manifests/istio-telemetry/prometheus-operator/templates/servicemonitors.yaml
@@ -61,7 +61,7 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_container_port_name]
       action: keep
       regex: '.*-envoy-prom'
-    - action: labelmap
+    - action: labeldrop
       regex: "__meta_kubernetes_pod_label_(.+)"
     - sourceLabels: [__meta_kubernetes_namespace]
       action: replace

--- a/manifests/istio-telemetry/prometheus/templates/configmap.yaml
+++ b/manifests/istio-telemetry/prometheus/templates/configmap.yaml
@@ -40,7 +40,7 @@ data:
         regex: ([^:]+)(?::\d+)?;(\d+)
         replacement: $1:15090
         target_label: __address__
-      - action: labelmap
+      - action: labeldrop
         regex: __meta_kubernetes_pod_label_(.+)
       - source_labels: [__meta_kubernetes_namespace]
         action: replace

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -297,7 +297,7 @@ data:
         regex: ([^:]+)(?::\d+)?;(\d+)
         replacement: $1:15090
         target_label: __address__
-      - action: labelmap
+      - action: labeldrop
         regex: __meta_kubernetes_pod_label_(.+)
       - source_labels: [__meta_kubernetes_namespace]
         action: replace

--- a/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.golden.yaml
@@ -94,7 +94,7 @@ data:
         regex: ([^:]+)(?::\d+)?;(\d+)
         replacement: $1:15090
         target_label: __address__
-      - action: labelmap
+      - action: labeldrop
         regex: __meta_kubernetes_pod_label_(.+)
       - source_labels: [__meta_kubernetes_namespace]
         action: replace

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.golden.yaml
@@ -6065,7 +6065,7 @@ data:
         regex: ([^:]+)(?::\d+)?;(\d+)
         replacement: $1:15090
         target_label: __address__
-      - action: labelmap
+      - action: labeldrop
         regex: __meta_kubernetes_pod_label_(.+)
       - source_labels: [__meta_kubernetes_namespace]
         action: replace

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.golden.yaml
@@ -94,7 +94,7 @@ data:
         regex: ([^:]+)(?::\d+)?;(\d+)
         replacement: $1:15090
         target_label: __address__
-      - action: labelmap
+      - action: labeldrop
         regex: __meta_kubernetes_pod_label_(.+)
       - source_labels: [__meta_kubernetes_namespace]
         action: replace

--- a/operator/cmd/mesh/testdata/manifest-generate/output/gateways_override_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/gateways_override_default.golden.yaml
@@ -94,7 +94,7 @@ data:
         regex: ([^:]+)(?::\d+)?;(\d+)
         replacement: $1:15090
         target_label: __address__
-      - action: labelmap
+      - action: labeldrop
         regex: __meta_kubernetes_pod_label_(.+)
       - source_labels: [__meta_kubernetes_namespace]
         action: replace

--- a/operator/cmd/mesh/testdata/manifest-generate/output/prometheus.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/prometheus.golden.yaml
@@ -94,7 +94,7 @@ data:
         regex: ([^:]+)(?::\d+)?;(\d+)
         replacement: $1:15090
         target_label: __address__
-      - action: labelmap
+      - action: labeldrop
         regex: __meta_kubernetes_pod_label_(.+)
       - source_labels: [__meta_kubernetes_namespace]
         action: replace

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -33867,7 +33867,7 @@ data:
         regex: ([^:]+)(?::\d+)?;(\d+)
         replacement: $1:15090
         target_label: __address__
-      - action: labelmap
+      - action: labeldrop
         regex: __meta_kubernetes_pod_label_(.+)
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
@@ -35048,7 +35048,7 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_container_port_name]
       action: keep
       regex: '.*-envoy-prom'
-    - action: labelmap
+    - action: labeldrop
       regex: "__meta_kubernetes_pod_label_(.+)"
     - sourceLabels: [__meta_kubernetes_namespace]
       action: replace


### PR DESCRIPTION
This PR prevents prometheus from adding kubernetes pod labels to the collected metrics from envoy endpoints. This is an attempt to reduce overall metric cardinality at point of collection and reduce some of the noise and additional labeling that is showing up in `istio_` metrics with v2 telemetry.

Related discussion: https://github.com/istio/istio/issues/19090

Note: `pod_name` and `namespace` are left intact for now, to ensure unique timeseries across workload instances. Recording rules + federation approach is probably the right way to address that sort of aggregation.

/cc: @Stono 

Signed-off-by: Douglas Reid <douglas-reid@users.noreply.github.com>

[ X ] Policies and Telemetry
