### PR TITLE
correct the apiVersion for IOP

### DIFF
--- a/operator/README.md
+++ b/operator/README.md
@@ -40,7 +40,7 @@ an Istio install and can be customized by creating customization overlay files o
 ```yaml
 # sds.yaml
 
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   profile: sds
@@ -234,7 +234,7 @@ The simplest customization is to select a profile different to `default` e.g. `s
 
 ```yaml
 # sds-install.yaml
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   profile: sds
@@ -275,7 +275,7 @@ istioctl manifest generate --set values.gateways.istio-ingressgateway.enabled=fa
 The compiled in charts and profiles are used by default, but you can specify a file path, for example:
 
 ```yaml
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   profile: /usr/home/bob/go/src/github.com/ostromart/istio-installer/data/profiles/default.yaml
@@ -320,7 +320,7 @@ defines install time parameters like feature and component enablement and namesp
 The simplest customization is to turn features and components on and off. For example, to turn off all policy ([samples/sds-policy-off.yaml](samples/sds-policy-off.yaml)):
 
 ```yaml
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   profile: sds
@@ -336,7 +336,7 @@ Each Istio component has K8s settings, and these can be overridden from the defa
 Istio defined schemas ([samples/pilot-k8s.yaml](samples/pilot-k8s.yaml)):
 
 ```yaml
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   components:
@@ -391,7 +391,7 @@ are overridden the same way as the new API, though a customized CR overlaid over
 profile. Here's an example of overriding some global level default values ([samples/values-global.yaml](samples/values-global.yaml)):
 
 ```yaml
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   profile: sds
@@ -405,7 +405,7 @@ Values overrides can also be specified for a particular component
  ([samples/values-pilot.yaml](samples/values-pilot.yaml)):
 
 ```yaml
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   values:
@@ -423,7 +423,7 @@ possible to overlay the generated K8s resources before they are applied with use
 override some container level values in the Pilot container  ([samples/pilot-advanced-override.yaml](samples/pilot-advanced-override.yaml)):
 
 ```yaml
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   components:

--- a/operator/cmd/mesh/testdata/manifest-migrate/output/default_icp_iop.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-migrate/output/default_icp_iop.golden.yaml
@@ -1,4 +1,4 @@
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   addonComponents:

--- a/operator/cmd/mesh/testdata/manifest-migrate/output/default_icp_iop.yaml
+++ b/operator/cmd/mesh/testdata/manifest-migrate/output/default_icp_iop.yaml
@@ -1,4 +1,4 @@
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   addonComponents:

--- a/operator/cmd/mesh/testdata/profile-dump/output/all_off.yaml
+++ b/operator/cmd/mesh/testdata/profile-dump/output/all_off.yaml
@@ -1,4 +1,4 @@
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   addonComponents:

--- a/operator/data/profiles/default.yaml
+++ b/operator/data/profiles/default.yaml
@@ -1,4 +1,4 @@
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 metadata:
   namespace: istio-system

--- a/operator/data/profiles/demo.yaml
+++ b/operator/data/profiles/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   components:

--- a/operator/data/profiles/empty.yaml
+++ b/operator/data/profiles/empty.yaml
@@ -1,6 +1,6 @@
 # The empty profile has everything disabled
 # This is useful as a base for custom user configuration
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   components:

--- a/operator/data/profiles/minimal.yaml
+++ b/operator/data/profiles/minimal.yaml
@@ -1,5 +1,5 @@
 # The minimal profile will install just the core control plane
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   components:

--- a/operator/data/profiles/preview.yaml
+++ b/operator/data/profiles/preview.yaml
@@ -1,6 +1,6 @@
 # The preview profile contains features that are experimental.
 # This is intended to explore new features coming to Istio.
 # Stability, security, and performance are not guaranteed - use at your own risk.
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec: {}

--- a/operator/data/profiles/remote.yaml
+++ b/operator/data/profiles/remote.yaml
@@ -1,4 +1,4 @@
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   components:

--- a/operator/data/profiles/separate.yaml
+++ b/operator/data/profiles/separate.yaml
@@ -1,6 +1,6 @@
 # The separate profile will disable istiod and bring back the old microservices model
 # This will be removed in future (1.6) releases
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   components:

--- a/operator/pkg/translate/icp_iop.go
+++ b/operator/pkg/translate/icp_iop.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	IstioOperatorTreeString = `
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 `
 	iCPIOPTranslationsFilename = "translate-ICP-IOP-"

--- a/operator/pkg/translate/testdata/icp-iop/output/addons.yaml
+++ b/operator/pkg/translate/testdata/icp-iop/output/addons.yaml
@@ -1,4 +1,4 @@
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   addonComponents:

--- a/operator/pkg/translate/testdata/icp-iop/output/default.yaml
+++ b/operator/pkg/translate/testdata/icp-iop/output/default.yaml
@@ -1,4 +1,4 @@
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   addonComponents:

--- a/operator/pkg/translate/testdata/icp-iop/output/gateways.yaml
+++ b/operator/pkg/translate/testdata/icp-iop/output/gateways.yaml
@@ -1,4 +1,4 @@
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   components:

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -37946,7 +37946,7 @@ func operatorTemplatesService_accountYaml() (*asset, error) {
 	return a, nil
 }
 
-var _profilesDefaultYaml = []byte(`apiVersion: operator.istio.io/v1alpha1
+var _profilesDefaultYaml = []byte(`apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 metadata:
   namespace: istio-system
@@ -38647,7 +38647,7 @@ func profilesDefaultYaml() (*asset, error) {
 	return a, nil
 }
 
-var _profilesDemoYaml = []byte(`apiVersion: operator.istio.io/v1alpha1
+var _profilesDemoYaml = []byte(`apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   components:
@@ -38806,7 +38806,7 @@ func profilesDemoYaml() (*asset, error) {
 
 var _profilesEmptyYaml = []byte(`# The empty profile has everything disabled
 # This is useful as a base for custom user configuration
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   components:
@@ -38837,7 +38837,7 @@ func profilesEmptyYaml() (*asset, error) {
 }
 
 var _profilesMinimalYaml = []byte(`# The minimal profile will install just the core control plane
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   components:
@@ -38871,7 +38871,7 @@ func profilesMinimalYaml() (*asset, error) {
 var _profilesPreviewYaml = []byte(`# The preview profile contains features that are experimental.
 # This is intended to explore new features coming to Istio.
 # Stability, security, and performance are not guaranteed - use at your own risk.
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec: {}`)
 
@@ -38890,7 +38890,7 @@ func profilesPreviewYaml() (*asset, error) {
 	return a, nil
 }
 
-var _profilesRemoteYaml = []byte(`apiVersion: operator.istio.io/v1alpha1
+var _profilesRemoteYaml = []byte(`apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   components:
@@ -38942,7 +38942,7 @@ func profilesRemoteYaml() (*asset, error) {
 
 var _profilesSeparateYaml = []byte(`# The separate profile will disable istiod and bring back the old microservices model
 # This will be removed in future (1.6) releases
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   components:


### PR DESCRIPTION
We have inconsistent version for IOP, update the "operator.istio.io/v1alpha1" to "install.istio.io/v1alpha1" to align with the CRD.

It should not impact the istioctl installation but it affects controller case, related issue: https://github.com/istio/istio/issues/21540
