### PR TITLE
rework configgen.OnVirtualListener logic

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1801,8 +1801,8 @@ func (configgen *ConfigGeneratorImpl) onVirtualOutboundListener(
 	}
 
 	// Set the protocol for each filter chain
-	for _, fc := range mutable.FilterChains {
-		fc.ListenerProtocol = plugin.ListenerProtocolTCP
+	for index := range mutable.FilterChains {
+		mutable.FilterChains[index].ListenerProtocol = plugin.ListenerProtocolTCP
 	}
 	for _, p := range configgen.Plugins {
 		if err := p.OnVirtualListener(pluginParams, mutable); err != nil {

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -258,17 +258,7 @@ func (mixerplugin) OnInboundListener(in *plugin.InputParams, mutable *plugin.Mut
 
 // OnVirtualListener implements the Plugin interface method.
 func (mixerplugin) OnVirtualListener(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
-	if in.Push.Mesh.MixerCheckServer == "" && in.Push.Mesh.MixerReportServer == "" {
-		return nil
-	}
-	if in.ListenerProtocol == plugin.ListenerProtocolTCP {
-		attrs := createOutboundListenerAttributes(in)
-		tcpFilter := buildOutboundTCPFilter(in.Push.Mesh, attrs, in.Node, in.Service)
-		for cnum := range mutable.FilterChains {
-			mutable.FilterChains[cnum].TCP = append(mutable.FilterChains[cnum].TCP, tcpFilter)
-		}
-	}
-	return nil
+	return mixerplugin{}.OnOutboundListener(in, mutable)
 }
 
 // OnOutboundCluster implements the Plugin interface method.


### PR DESCRIPTION
The existing logic for OnVirtualListener is clunky. It breaks when we add
more filter chains to the virtual outbound as it is hardcoded to expect
exactly one filter chain with exactly one filter! This PR reworks the
logic to be more generic.

Broken out from https://github.com/istio/istio/pull/21548 

Signed-off-by: Shriram Rajagopalan <rshriram@tetrate.io>