### PR TITLE
Fix CEL test with golang 1.14

### DIFF
--- a/mixer/pkg/il/testing/tests.go
+++ b/mixer/pkg/il/testing/tests.go
@@ -1628,7 +1628,7 @@ end
 		I: map[string]interface{}{
 			"as": ":/",
 		},
-		Err: `error converting string to uri ':/': 'parse :/: missing protocol scheme'`,
+		Err: `error converting string to uri`,
 	},
 
 	{


### PR DESCRIPTION
For https://github.com/istio/istio/issues/21567

The test does a prefix match on the error, golang changed internal error message so we make the test a bit more lenient (as we do every new golang version :slightly_smiling_face: )