### PR TITLE
add logging when fail to generate IOP during reconcile

### DIFF
--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
@@ -198,6 +198,7 @@ func (r *ReconcileIstioOperator) Reconcile(request reconcile.Request) (reconcile
 	iopMerged := *iop
 	iopMerged.Spec, err = helmreconciler.MergeIOPSWithProfile(iop.Spec)
 	if err != nil {
+		log.Errorf("failed to generate IstioOperator spec, %v", err)
 		return reconcile.Result{}, err
 	}
 	reconciler, err := r.getOrCreateReconciler(&iopMerged)


### PR DESCRIPTION
solve the missing logging part: https://github.com/istio/istio/issues/21521, otherwise the logs seems normal but actually reconcile fails. The status update issue would be addressed separately
