### PR TITLE
update operator cr default ns to istio-operator.

### DIFF
--- a/operator/cmd/mesh/testdata/operator/output/operator-init.yaml
+++ b/operator/cmd/mesh/testdata/operator/output/operator-init.yaml
@@ -201,7 +201,7 @@ spec:
               memory: 128Mi
           env:
             - name: WATCH_NAMESPACE
-              value: istio-test-namespace
+              value: operator-test-namespace
             - name: LEADER_ELECTION_NAMESPACE
               value: operator-test-namespace
             - name: POD_NAME

--- a/operator/cmd/mesh/testdata/operator/output/operator-remove.yaml
+++ b/operator/cmd/mesh/testdata/operator/output/operator-remove.yaml
@@ -201,7 +201,7 @@ spec:
               memory: 128Mi
           env:
             - name: WATCH_NAMESPACE
-              value: istio-test-namespace
+              value: operator-test-namespace
             - name: LEADER_ELECTION_NAMESPACE
               value: operator-test-namespace
             - name: POD_NAME

--- a/operator/data/operator/templates/deployment.yaml
+++ b/operator/data/operator/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
               memory: 128Mi
           env:
             - name: WATCH_NAMESPACE
-              value: {{.Values.istioNamespace}}
+              value: {{.Values.operatorNamespace}}
             - name: LEADER_ELECTION_NAMESPACE
               value: {{.Values.operatorNamespace}}
             - name: POD_NAME

--- a/operator/deploy/crds/istio_v1alpha1_istiooperator_cr.yaml
+++ b/operator/deploy/crds/istio_v1alpha1_istiooperator_cr.yaml
@@ -2,7 +2,7 @@
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 metadata:
-  namespace: istio-system
+  namespace: istio-operator
   name: example-istiocontrolplane
 spec:
   profile: demo

--- a/operator/deploy/operator.yaml
+++ b/operator/deploy/operator.yaml
@@ -31,7 +31,7 @@ spec:
               memory: 128Mi
           env:
             - name: WATCH_NAMESPACE
-              value: "istio-system"
+              value: "istio-operator"
             - name: LEADER_ELECTION_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -37883,7 +37883,7 @@ spec:
               memory: 128Mi
           env:
             - name: WATCH_NAMESPACE
-              value: {{.Values.istioNamespace}}
+              value: {{.Values.operatorNamespace}}
             - name: LEADER_ELECTION_NAMESPACE
               value: {{.Values.operatorNamespace}}
             - name: POD_NAME


### PR DESCRIPTION
Update default IOP instance namespace from `istio-system` to `istio-operator` for the following two reasons:

1. To align with statement at: https://github.com/istio/istio/tree/master/operator#controller-running-locally

> Set env $WATCH_NAMESPACE and $LEADER_ELECTION_NAMESPACE (default value is "istio-operator")

2. To avoid error `namespaces "istio-system" not found`
```
# kubectl apply -f operator/deploy/crds/istio_v1alpha1_istiooperator_cr.yaml
Error from server (NotFound): error when creating "operator/deploy/crds/istio_v1alpha1_istiooperator_cr.yaml": namespaces "istio-system" not found
```


[ ] Configuration Infrastructure
[ ] Docs
[ X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure