### PR TITLE
fix(bootstrap): fix regex for tag tag in stats

### DIFF
--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -145,7 +145,7 @@
           "tag_name": "component"
       },
       {
-          "regex": "(tag\\.(.+?)\\.)",
+          "regex": "(tag\\.(.+?);\\.)",
           "tag_name": "tag"
       },
       {

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -145,7 +145,7 @@
           "tag_name": "component"
       },
       {
-          "regex": "(tag\\.(.+?)\\.)",
+          "regex": "(tag\\.(.+?);\\.)",
           "tag_name": "tag"
       },
       {

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -145,7 +145,7 @@
           "tag_name": "component"
       },
       {
-          "regex": "(tag\\.(.+?)\\.)",
+          "regex": "(tag\\.(.+?);\\.)",
           "tag_name": "tag"
       },
       {

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -145,7 +145,7 @@
           "tag_name": "component"
       },
       {
-          "regex": "(tag\\.(.+?)\\.)",
+          "regex": "(tag\\.(.+?);\\.)",
           "tag_name": "tag"
       },
       {

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -151,7 +151,7 @@
           "tag_name": "component"
       },
       {
-          "regex": "(tag\\.(.+?)\\.)",
+          "regex": "(tag\\.(.+?);\\.)",
           "tag_name": "tag"
       },
       {

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -151,7 +151,7 @@
           "tag_name": "component"
       },
       {
-          "regex": "(tag\\.(.+?)\\.)",
+          "regex": "(tag\\.(.+?);\\.)",
           "tag_name": "tag"
       },
       {

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -145,7 +145,7 @@
           "tag_name": "component"
       },
       {
-          "regex": "(tag\\.(.+?)\\.)",
+          "regex": "(tag\\.(.+?);\\.)",
           "tag_name": "tag"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -145,7 +145,7 @@
           "tag_name": "component"
       },
       {
-          "regex": "(tag\\.(.+?)\\.)",
+          "regex": "(tag\\.(.+?);\\.)",
           "tag_name": "tag"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -145,7 +145,7 @@
           "tag_name": "component"
       },
       {
-          "regex": "(tag\\.(.+?)\\.)",
+          "regex": "(tag\\.(.+?);\\.)",
           "tag_name": "tag"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -145,7 +145,7 @@
           "tag_name": "component"
       },
       {
-          "regex": "(tag\\.(.+?)\\.)",
+          "regex": "(tag\\.(.+?);\\.)",
           "tag_name": "tag"
       },
       {

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -145,7 +145,7 @@
           "tag_name": "component"
       },
       {
-          "regex": "(tag\\.(.+?)\\.)",
+          "regex": "(tag\\.(.+?);\\.)",
           "tag_name": "tag"
       },
       {

--- a/tools/packaging/common/envoy_bootstrap_v2.json
+++ b/tools/packaging/common/envoy_bootstrap_v2.json
@@ -151,7 +151,7 @@
           "tag_name": "component"
       },
       {
-          "regex": "(tag\\.(.+?)\\.)",
+          "regex": "(tag\\.(.+?);\\.)",
           "tag_name": "tag"
       },
       {{- range $a, $tag := .extraStatTags }}


### PR DESCRIPTION
This PR updates the regular expression used to extract the "tag" for the `istio_build` metric to appropriately handle tags. This updates to match the regex used in the tests in istio/proxy.

Signed-off-by: Douglas Reid <douglas-reid@users.noreply.github.com>

[X] Policies and Telemetry

Fixes: #21589 