### PR TITLE
Deflake tests TestTokenFetchFailure

### DIFF
--- a/security/pkg/stsservice/test/failure_sts_token_fetch/token_failure_test.go
+++ b/security/pkg/stsservice/test/failure_sts_token_fetch/token_failure_test.go
@@ -49,7 +49,7 @@ func TestTokenFetchFailureOne(t *testing.T) {
 	g.Expect(numAccessTokenCall).To(gomega.Equal(initialNumAccessTokenCall))
 	g.Expect(cb.NumStream()).To(gomega.Equal(0))
 	g.Expect(cb.NumTokenReceived()).To(gomega.Equal(0))
-
+	setup.ProxySetup.SilentlyStopProxy(true)
 	setup.TearDown()
 }
 
@@ -77,6 +77,6 @@ func TestTokenFetchFailureTwo(t *testing.T) {
 	g.Expect(numAccessTokenCall).Should(gomega.BeNumerically(">", initialNumAccessTokenCall))
 	g.Expect(cb.NumStream()).To(gomega.Equal(0))
 	g.Expect(cb.NumTokenReceived()).To(gomega.Equal(0))
-
+	setup.ProxySetup.SilentlyStopProxy(true)
 	setup.TearDown()
 }


### PR DESCRIPTION
Suppress an error log when the test forces Envoy to fail on start. 

https://github.com/istio/istio/issues/21497