### PR TITLE
[release-1.5] authz: fix authz egress test on postsubmit

### DIFF
--- a/tests/integration/security/main_test.go
+++ b/tests/integration/security/main_test.go
@@ -56,6 +56,7 @@ func setupConfig(cfg *istio.Config) {
 	}
 	rootNamespace = cfg.SystemNamespace
 
+	cfg.Values["gateways.istio-egressgateway.enabled"] = "true"
 	cfg.ControlPlaneValues = `
 components:
   citadel:


### PR DESCRIPTION
Fixes #21576 

Sending the PR directly to release-1.5 branch since the master branch has changed to only use operator in the tests.