### PR TITLE
update proxy sha to 5789f68

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,7 +4,7 @@
     "name": "PROXY_REPO_SHA",
     "repoName": "proxy",
     "file": "",
-    "lastStableSHA": "3a04f855cd176213f316b5f12d67c2a79e2ffdb9"
+    "lastStableSHA": "5789f684ac335043e42b4a0242b42d4f48c3a0cd"
   },
   {
     "_comment": "",


### PR DESCRIPTION
The following changes are included for the new proxy:

```
5789f68 (HEAD -> master, upstream/master) Update Envoy SHA (Feb 26) (#2727)
b6b1a8b Remove wasm binary file (#2726)
e586f25 Use envoy_cc_library in sd extension (#2722)
c2c64d4 revert of https://github.com/istio/proxy/pull/2591 (#2714)
e75aa44 Cherry-pick JWT CVE fix into 1.4 (#12) (#2716)
d9a18f9 Lazy set BAZEL_OUTPUT_PATH so that bazel is not required (#2682)
9faeb5f feat(edges): support configurable batch size (#2707)
06edc92 feat(stats): add canonical rev labels (#2711)
c32cb79 Test Client metrics too (#2691)
49a3874 Re-enable RBE (cache only). (#2708)
c38b04c Fix duration unit conversion (#2701)
f3dc116 Make connection security policy string lowercase for prometheus (#2699)
```