### PR TITLE
[release-1.5] Fix analyzer postsubmit tests

### DIFF
--- a/tests/integration/galley/main_test.go
+++ b/tests/integration/galley/main_test.go
@@ -32,6 +32,11 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite("galley_test", m).
 		SetupOnEnv(environment.Kube, istio.Setup(nil, func(cfg *istio.Config) {
+			// the helm charts still deploy deprecated MeshPolicy resources, so we suppress the warnings
+			if !cfg.Operator {
+				suppressor = []string{"-S", suppressDefaultMeshConfigDeprecated}
+			}
+
 			cfg.ControlPlaneValues = `
 components:
   galley:


### PR DESCRIPTION
Fixes #21633 by suppressing MeshPolicy deprecation warning when deploying using helm charts