### PR TITLE
Change example command to use non-deprecated flags

### DIFF
--- a/operator/cmd/mesh/manifest-apply.go
+++ b/operator/cmd/mesh/manifest-apply.go
@@ -70,8 +70,8 @@ func manifestApplyCmd(rootArgs *rootArgs, maArgs *manifestApplyArgs) *cobra.Comm
 		Example: `  # Apply a default Istio installation
   istioctl manifest apply
 
-  # Enable security
-  istioctl manifest apply --set values.global.mtls.enabled=true --set values.global.controlPlaneSecurityEnabled=true
+  # Enable grafana dashboard
+  istioctl manifest apply --set values.grafana.enabled=true
 
   # Generate the demo profile and don't wait for confirmation
   istioctl manifest apply --set profile=demo --skip-confirmation

--- a/operator/cmd/mesh/manifest-generate.go
+++ b/operator/cmd/mesh/manifest-generate.go
@@ -63,8 +63,8 @@ func manifestGenerateCmd(rootArgs *rootArgs, mgArgs *manifestGenerateArgs) *cobr
 		Example: `  # Generate a default Istio installation
   istioctl manifest generate
 
-  # Enable security
-  istioctl manifest generate --set values.global.mtls.enabled=true --set values.global.controlPlaneSecurityEnabled=true
+  # Enable grafana dashboard
+  istioctl manifest generate --set values.grafana.enabled=true
 
   # Generate the demo profile
   istioctl manifest generate --set profile=demo

--- a/operator/cmd/mesh/root.go
+++ b/operator/cmd/mesh/root.go
@@ -25,10 +25,10 @@ import (
 
 const (
 	SetFlagHelpStr = `Override an IstioOperator value, e.g. to choose a profile
-(--set profile=demo), enable or disable components (--set components.policy.enabled=true), or override Istio 
-settings (--set values.global.mtls.enabled=true). See documentation for more info: 
+(--set profile=demo), enable or disable components (--set components.policy.enabled=true), or override Istio
+settings (--set values.grafana.enabled=true). See documentation for more info:
 https://istio.io/docs/reference/config/istio.operator.v1alpha12.pb/#IstioControlPlaneSpec`
-	skipConfirmationFlagHelpStr = `skipConfirmation determines whether the user is prompted for confirmation. 
+	skipConfirmationFlagHelpStr = `skipConfirmation determines whether the user is prompted for confirmation.
 If set to true, the user is not prompted and a Yes response is assumed in all cases.`
 	filenameFlagHelpStr = `Path to file containing IstioOperator custom resource
 This flag can be specified multiple times to overlay multiple files. Multiple files are overlaid in left to right order.`


### PR DESCRIPTION
This change is simply remove the command examples that using that flag. It has no effect on the functionality of the flag.

The reason is we want to remove this flag in the future release. Instead, users should submit authN policy themselves. 