### PR TITLE
[release-1.5] remove namespace for validatingwebhookconfiguration. (#21390)

### DIFF
--- a/manifests/istio-control/istio-config/templates/validatingwebhookconfiguration.yaml
+++ b/manifests/istio-control/istio-config/templates/validatingwebhookconfiguration.yaml
@@ -7,7 +7,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istio-galley
-  namespace: {{ .Release.Namespace }}
   labels:
     app: galley
     release: {{ .Release.Name }}
@@ -18,7 +17,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istio-galley
-  namespace: {{ .Release.Namespace }}
   labels:
     app: galley
     release: {{ .Release.Name }}

--- a/manifests/istio-control/istio-config/templates/validatingwebhookconfiguration.yaml.tpl
+++ b/manifests/istio-control/istio-config/templates/validatingwebhookconfiguration.yaml.tpl
@@ -19,7 +19,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istio-galley
-  namespace: {{ .Release.Namespace }}
   labels:
     app: galley
     release: {{ .Release.Name }}

--- a/manifests/istio-control/istio-config/templates/validatingwebhookconfiguration.yaml.tpl
+++ b/manifests/istio-control/istio-config/templates/validatingwebhookconfiguration.yaml.tpl
@@ -9,7 +9,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istio-galley
-  namespace: {{ .Release.Namespace }}
   labels:
     app: galley
     release: {{ .Release.Name }}

--- a/manifests/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
+++ b/manifests/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
@@ -4,7 +4,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istiod-{{ .Release.Namespace }}
-  namespace: {{ .Release.Namespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}

--- a/manifests/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
+++ b/manifests/istio-control/istio-discovery/templates/validatingwebhookconfiguration.yaml
@@ -40,7 +40,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istio-galley
-  namespace: {{ .Release.Namespace }}
   labels:
     app: galley
     release: {{ .Release.Name }}
@@ -52,7 +51,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istiod-{{ .Release.Namespace }}
-  namespace: {{ .Release.Namespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.yaml
@@ -9927,7 +9927,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istiod-istio-system
-  namespace: istio-system
   labels:
     app: istiod
     release: istio

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.yaml
@@ -7298,7 +7298,6 @@ data:
     kind: ValidatingWebhookConfiguration
     metadata:
       name: istio-galley
-      namespace: istio-system
       labels:
         app: galley
         release: istio
@@ -7551,7 +7550,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istio-galley
-  namespace: istio-system
   labels:
     app: galley
     release: istio
@@ -9965,7 +9963,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istio-galley
-  namespace: istio-system
   labels:
     app: galley
     release: istio

--- a/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.yaml
@@ -8991,7 +8991,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istiod-istio-system
-  namespace: istio-system
   labels:
     app: istiod
     release: istio

--- a/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.yaml
@@ -9029,7 +9029,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istio-galley
-  namespace: istio-system
   labels:
     app: galley
     release: istio

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_force.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_force.yaml
@@ -1985,7 +1985,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istio-galley
-  namespace: istio-system
   labels:
     app: galley
     release: istio

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_force.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_force.yaml
@@ -1947,7 +1947,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istiod-istio-system
-  namespace: istio-system
   labels:
     app: istiod
     release: istio

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output.yaml
@@ -1944,7 +1944,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istiod-istio-system
-  namespace: istio-system
   labels:
     app: istiod
     release: istio

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output.yaml
@@ -1982,7 +1982,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istio-galley
-  namespace: istio-system
   labels:
     app: galley
     release: istio

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.yaml
@@ -7876,7 +7876,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istio-galley
-  namespace: istio-system
   labels:
     app: galley
     release: istio

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.yaml
@@ -7838,7 +7838,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istiod-istio-system
-  namespace: istio-system
   labels:
     app: istiod
     release: istio

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.yaml
@@ -8817,7 +8817,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istio-galley
-  namespace: istio-system
   labels:
     app: galley
     release: istio

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.yaml
@@ -8779,7 +8779,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istiod-istio-system
-  namespace: istio-system
   labels:
     app: istiod
     release: istio

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_override_values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_override_values.yaml
@@ -1944,7 +1944,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istiod-istio-system
-  namespace: istio-system
   labels:
     app: istiod
     release: istio

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_override_values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_override_values.yaml
@@ -1982,7 +1982,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istio-galley
-  namespace: istio-system
   labels:
     app: galley
     release: istio

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.yaml
@@ -8819,7 +8819,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istio-galley
-  namespace: istio-system
   labels:
     app: galley
     release: istio

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.yaml
@@ -8781,7 +8781,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istiod-istio-system
-  namespace: istio-system
   labels:
     app: istiod
     release: istio

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.yaml
@@ -1944,7 +1944,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istiod-istio-system
-  namespace: istio-system
   labels:
     app: istiod
     release: istio

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.yaml
@@ -1982,7 +1982,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istio-galley
-  namespace: istio-system
   labels:
     app: galley
     release: istio

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.yaml
@@ -1987,7 +1987,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istio-galley
-  namespace: istio-control
   labels:
     app: galley
     release: istio

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.yaml
@@ -1949,7 +1949,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istiod-istio-control
-  namespace: istio-control
   labels:
     app: istiod
     release: istio

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -11785,7 +11785,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istio-galley
-  namespace: {{ .Release.Namespace }}
   labels:
     app: galley
     release: {{ .Release.Name }}
@@ -11896,7 +11895,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istio-galley
-  namespace: {{ .Release.Namespace }}
   labels:
     app: galley
     release: {{ .Release.Name }}
@@ -15022,7 +15020,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istiod-{{ .Release.Namespace }}
-  namespace: {{ .Release.Namespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -11774,7 +11774,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istio-galley
-  namespace: {{ .Release.Namespace }}
   labels:
     app: galley
     release: {{ .Release.Name }}
@@ -11884,7 +11883,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istio-galley
-  namespace: {{ .Release.Namespace }}
   labels:
     app: galley
     release: {{ .Release.Name }}
@@ -15056,7 +15054,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istio-galley
-  namespace: {{ .Release.Namespace }}
   labels:
     app: galley
     release: {{ .Release.Name }}
@@ -15068,7 +15065,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istiod-{{ .Release.Namespace }}
-  namespace: {{ .Release.Namespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}


### PR DESCRIPTION
manual cherry-pick to resolve: https://github.com/istio/istio/issues/21647
