### PR TITLE
Clean up debug output and add FQ object names

### DIFF
--- a/operator/pkg/helmreconciler/listeners.go
+++ b/operator/pkg/helmreconciler/listeners.go
@@ -252,25 +252,21 @@ func (l *LoggingRenderingListener) BeginResource(_ string, obj runtime.Object) (
 
 // ResourceCreated logs the event
 func (l *LoggingRenderingListener) ResourceCreated(created runtime.Object) error {
-	log.Infof("resource created: %s", created.GetObjectKind().GroupVersionKind())
 	return nil
 }
 
 // ResourceUpdated logs the event
 func (l *LoggingRenderingListener) ResourceUpdated(updated runtime.Object, old runtime.Object) error {
-	log.Infof("resource updated: %s", updated.GetObjectKind().GroupVersionKind())
 	return nil
 }
 
 // ResourceDeleted logs the event
 func (l *LoggingRenderingListener) ResourceDeleted(deleted runtime.Object) error {
-	log.Infof("resource deleted: %s", deleted.GetObjectKind().GroupVersionKind())
 	return nil
 }
 
 // ResourceError logs the event and the error
 func (l *LoggingRenderingListener) ResourceError(obj runtime.Object, err error) error {
-	log.Errorf("error processing resource: %s", obj.GetObjectKind().GroupVersionKind())
 	return nil
 }
 

--- a/operator/pkg/helmreconciler/rendering.go
+++ b/operator/pkg/helmreconciler/rendering.go
@@ -281,10 +281,10 @@ func (h *HelmReconciler) ProcessObject(chartName string, obj *unstructured.Unstr
 	objectKey, _ := client.ObjectKeyFromObject(mutatedObj)
 
 	if err = h.client.Get(context.TODO(), objectKey, receiver); apierrors.IsNotFound(err) {
-		log.Infof("creating resource: %s", objectKey)
+		log.Infof("creating resource: %s/%s/%s", obj.GetKind(), obj.GetNamespace(), obj.GetName())
 		return h.client.Create(context.TODO(), mutatedObj)
 	} else if err == nil {
-		log.Infof("updating resource: %s", objectKey)
+		log.Infof("updating resource: %s/%s/%s", obj.GetKind(), obj.GetNamespace(), obj.GetName())
 		if err := applyOverlay(receiver, mutatedObj); err != nil {
 			return err
 		}


### PR DESCRIPTION
This removes log noise and outputs full object names.