### PR TITLE
update tcp-echo to support multiple ports

### DIFF
--- a/samples/tcp-echo/src/Dockerfile
+++ b/samples/tcp-echo/src/Dockerfile
@@ -12,15 +12,14 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+# BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
+ARG BASE_DISTRIBUTION=default
+
 # build a tcp-echo binary using the golang container
 FROM golang:1.12 as builder
 WORKDIR /go/src/istio.io/tcp-echo-server/
 COPY main.go .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o tcp-echo main.go
-
-
-# BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
-ARG BASE_DISTRIBUTION=default
 
 # The following section is used as base image if BASE_DISTRIBUTION=default
 # No tag available https://hub.docker.com/_/scratch?tab=description

--- a/samples/tcp-echo/src/main.go
+++ b/samples/tcp-echo/src/main.go
@@ -20,16 +20,26 @@ import (
 	"io"
 	"net"
 	"os"
+	"strings"
 )
 
 // main serves as the program entry point
 func main() {
 	// obtain the port and prefix via program arguments
-	port := fmt.Sprintf(":%s", os.Args[1])
+	ports := strings.Split(os.Args[1], ",")
 	prefix := os.Args[2]
+	for _, port := range ports {
+		addr := fmt.Sprintf(":%s", port)
+		go serve(addr, prefix)
+	}
+	ch := make(chan struct{})
+	<-ch
+}
 
+// serve starts serving on a given address
+func serve(addr, prefix string) {
 	// create a tcp listener on the given port
-	listener, err := net.Listen("tcp", port)
+	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		fmt.Println("failed to create listener, err:", err)
 		os.Exit(1)

--- a/samples/tcp-echo/src/main_test.go
+++ b/samples/tcp-echo/src/main_test.go
@@ -31,28 +31,30 @@ func TestTcpEchoServer(t *testing.T) {
 	want := prefix + " " + request
 
 	// start the TCP Echo Server
-	os.Args = []string{"main", "9000", prefix}
+	os.Args = []string{"main", "9000,9001", prefix}
 	go main()
 
 	// wait for the TCP Echo Server to start
 	time.Sleep(2 * time.Second)
 
-	// connect to the TCP Echo Server
-	conn, err := net.Dial("tcp", ":9000")
-	if err != nil {
-		t.Fatalf("couldn't connect to the server: %v", err)
-	}
-	defer conn.Close()
+	for _, addr := range []string{":9000", ":9001"} {
+		// connect to the TCP Echo Server
+		conn, err := net.Dial("tcp", addr)
+		if err != nil {
+			t.Fatalf("couldn't connect to the server: %v", err)
+		}
+		defer conn.Close()
 
-	// test the TCP Echo Server output
-	if _, err := conn.Write([]byte(request + "\n")); err != nil {
-		t.Fatalf("couldn't send request: %v", err)
-	} else {
-		reader := bufio.NewReader(conn)
-		if response, err := reader.ReadBytes(byte('\n')); err != nil {
-			t.Fatalf("couldn't read server response: %v", err)
-		} else if !strings.HasPrefix(string(response), want) {
-			t.Errorf("output doesn't match, wanted: %s, got: %s", want, response)
+		// test the TCP Echo Server output
+		if _, err := conn.Write([]byte(request + "\n")); err != nil {
+			t.Fatalf("couldn't send request: %v", err)
+		} else {
+			reader := bufio.NewReader(conn)
+			if response, err := reader.ReadBytes(byte('\n')); err != nil {
+				t.Fatalf("couldn't read server response: %v", err)
+			} else if !strings.HasPrefix(string(response), want) {
+				t.Errorf("output doesn't match, wanted: %s, got: %s", want, response)
+			}
 		}
 	}
 }

--- a/samples/tcp-echo/tcp-echo-services.yaml
+++ b/samples/tcp-echo/tcp-echo-services.yaml
@@ -22,6 +22,9 @@ spec:
   ports:
   - name: tcp
     port: 9000
+  - name: tcp-other
+    port: 9001
+  # Port 9002 is omitted intentionally for testing the pass through filter chain.
   selector:
     app: tcp-echo
 ---
@@ -43,11 +46,12 @@ spec:
     spec:
       containers:
       - name: tcp-echo
-        image: docker.io/istio/tcp-echo-server:1.1
+        image: docker.io/istio/tcp-echo-server:1.2
         imagePullPolicy: IfNotPresent
-        args: [ "9000", "one" ]
+        args: [ "9000,9001,9002", "one" ]
         ports:
         - containerPort: 9000
+        - containerPort: 9001
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -67,8 +71,9 @@ spec:
     spec:
       containers:
       - name: tcp-echo
-        image: docker.io/istio/tcp-echo-server:1.1
+        image: docker.io/istio/tcp-echo-server:1.2
         imagePullPolicy: IfNotPresent
-        args: [ "9000", "two" ]
+        args: [ "9000,9001,9002", "two" ]
         ports:
         - containerPort: 9000
+        - containerPort: 9001

--- a/samples/tcp-echo/tcp-echo.yaml
+++ b/samples/tcp-echo/tcp-echo.yaml
@@ -25,6 +25,9 @@ spec:
   ports:
   - name: tcp
     port: 9000
+  - name: tcp-other
+    port: 9001
+  # Port 9002 is omitted intentionally for testing the pass through filter chain.
   selector:
     app: tcp-echo
 ---
@@ -46,8 +49,9 @@ spec:
     spec:
       containers:
       - name: tcp-echo
-        image: docker.io/istio/tcp-echo-server:1.1
+        image: docker.io/istio/tcp-echo-server:1.2
         imagePullPolicy: IfNotPresent
-        args: [ "9000", "hello" ]
+        args: [ "9000,9001,9002", "hello" ]
         ports:
         - containerPort: 9000
+        - containerPort: 9001


### PR DESCRIPTION
Need multiple ports on tcp-echo for a new authorization task in 1.5.