### PR TITLE
revert default operator ns and corrrect readme.

### DIFF
--- a/operator/README.md
+++ b/operator/README.md
@@ -118,7 +118,7 @@ the Istio control plane into the istio-system namespace by default.
 
 #### Controller (running locally)
 
-1. Set env $WATCH_NAMESPACE and $LEADER_ELECTION_NAMESPACE (default value is "istio-operator")
+1. Set env $WATCH_NAMESPACE (default value is "istio-system") and $LEADER_ELECTION_NAMESPACE (default value is "istio-operator")
 
 1. From the operator repo root directory, run `go run ./cmd/manager/*.go server`
 

--- a/operator/cmd/mesh/testdata/operator/output/operator-init.yaml
+++ b/operator/cmd/mesh/testdata/operator/output/operator-init.yaml
@@ -201,7 +201,7 @@ spec:
               memory: 128Mi
           env:
             - name: WATCH_NAMESPACE
-              value: operator-test-namespace
+              value: istio-test-namespace
             - name: LEADER_ELECTION_NAMESPACE
               value: operator-test-namespace
             - name: POD_NAME

--- a/operator/cmd/mesh/testdata/operator/output/operator-remove.yaml
+++ b/operator/cmd/mesh/testdata/operator/output/operator-remove.yaml
@@ -201,7 +201,7 @@ spec:
               memory: 128Mi
           env:
             - name: WATCH_NAMESPACE
-              value: operator-test-namespace
+              value: istio-test-namespace
             - name: LEADER_ELECTION_NAMESPACE
               value: operator-test-namespace
             - name: POD_NAME

--- a/operator/data/operator/templates/deployment.yaml
+++ b/operator/data/operator/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
               memory: 128Mi
           env:
             - name: WATCH_NAMESPACE
-              value: {{.Values.operatorNamespace}}
+              value: {{.Values.istioNamespace}}
             - name: LEADER_ELECTION_NAMESPACE
               value: {{.Values.operatorNamespace}}
             - name: POD_NAME

--- a/operator/deploy/crds/istio_v1alpha1_istiooperator_cr.yaml
+++ b/operator/deploy/crds/istio_v1alpha1_istiooperator_cr.yaml
@@ -2,7 +2,7 @@
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 metadata:
-  namespace: istio-operator
+  namespace: istio-system
   name: example-istiocontrolplane
 spec:
   profile: demo

--- a/operator/deploy/namespace.yaml
+++ b/operator/deploy/namespace.yaml
@@ -3,4 +3,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: istio-operator
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-system
+  labels:
+    istio-injection: disabled
 ...

--- a/operator/deploy/operator.yaml
+++ b/operator/deploy/operator.yaml
@@ -31,7 +31,7 @@ spec:
               memory: 128Mi
           env:
             - name: WATCH_NAMESPACE
-              value: "istio-operator"
+              value: "istio-system"
             - name: LEADER_ELECTION_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -45920,7 +45920,7 @@ spec:
               memory: 128Mi
           env:
             - name: WATCH_NAMESPACE
-              value: {{.Values.operatorNamespace}}
+              value: {{.Values.istioNamespace}}
             - name: LEADER_ELECTION_NAMESPACE
               value: {{.Values.operatorNamespace}}
             - name: POD_NAME


### PR DESCRIPTION
Please provide a description for what this PR is for.

revert https://github.com/istio/istio/pull/21573
and:
- add `istio-system` namespace in deploy manifests
- correct namespace error in readme file

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
