### PR TITLE
Fix the healthcheck probe in Istio to handle user specified timeout

### DIFF
--- a/pilot/cmd/pilot-agent/status/server_test.go
+++ b/pilot/cmd/pilot-agent/status/server_test.go
@@ -54,27 +54,31 @@ func TestNewServer(t *testing.T) {
 		},
 		// map key is not well formed.
 		{
-			httpProbe: `{"abc": {"path": "/app-foo/health"}}`,
+			httpProbe: `{"abc": {"HTTPGetAction": {"path": "/app-foo/health"}}}`,
 			err:       "invalid key",
 		},
 		// Port is not Int typed.
 		{
-			httpProbe: `{"/app-health/hello-world/readyz": {"path": "/hello/sunnyvale", "port": "container-port-dontknow"}}`,
+			httpProbe: `{"/app-health/hello-world/readyz": {"HTTPGetAction": {"path": "/hello/sunnyvale", "port": "container-port-dontknow"}}}`,
 			err:       "must be int type",
 		},
 		// A valid input.
 		{
-			httpProbe: `{"/app-health/hello-world/readyz": {"path": "/hello/sunnyvale", "port": 8080},` +
-				`"/app-health/business/livez": {"path": "/buisiness/live", "port": 9090}}`,
+			httpProbe: `{"/app-health/hello-world/readyz": {"HTTPGetAction":{"path": "/hello/sunnyvale", "port": 8080}},` +
+				`"/app-health/business/livez": {"HTTPGetAction":{"path": "/buisiness/live", "port": 9090}}}`,
 		},
 		// A valid input with empty probing path, which happens when HTTPGetAction.Path is not specified.
 		{
-			httpProbe: `{"/app-health/hello-world/readyz": {"path": "/hello/sunnyvale", "port": 8080},
-"/app-health/business/livez": {"port": 9090}}`,
+			httpProbe: `{"/app-health/hello-world/readyz": {"HTTPGetAction":{"path": "/hello/sunnyvale", "port": 8080}},
+"/app-health/business/livez": {"HTTPGetAction":{"port": 9090}}}`,
 		},
 		// A valid input without any prober info.
 		{
 			httpProbe: `{}`,
+		},
+		// A valid input with Timeout info,
+		{
+			httpProbe: `{"/app-health/hello-world/readyz": {"HTTPGetAction": {"path": "/hello/sunnyvale", "port": 8080}, "TimeoutSeconds": 7}}`,
 		},
 	}
 	for _, tc := range testCases {
@@ -110,8 +114,8 @@ func TestAppProbe(t *testing.T) {
 	// Starts the pilot agent status server.
 	server, err := NewServer(Config{
 		StatusPort: 0,
-		KubeAppHTTPProbers: fmt.Sprintf(`{"/app-health/hello-world/readyz": {"path": "/hello/sunnyvale", "port": %v},
-"/app-health/hello-world/livez": {"port": %v}}`, appPort, appPort),
+		KubeAppHTTPProbers: fmt.Sprintf(`{"/app-health/hello-world/readyz": {"HTTPGetAction":{"path": "/hello/sunnyvale", "port": %v}},
+"/app-health/hello-world/livez": {"HTTPGetAction":{"port": %v}}}`, appPort, appPort),
 	})
 	if err != nil {
 		t.Errorf("failed to create status server %v", err)
@@ -175,8 +179,8 @@ func TestHttpsAppProbe(t *testing.T) {
 	// Starts the pilot agent status server.
 	server, err := NewServer(Config{
 		StatusPort: 0,
-		KubeAppHTTPProbers: fmt.Sprintf(`{"/app-health/hello-world/readyz": {"path": "/hello/sunnyvale", "port": %v, "scheme": "HTTPS"},
-"/app-health/hello-world/livez": {"port": %v, "scheme": "HTTPS"}}`, appPort, appPort),
+		KubeAppHTTPProbers: fmt.Sprintf(`{"/app-health/hello-world/readyz": {"HTTPGetAction":{"path": "/hello/sunnyvale", "port": %v, "scheme": "HTTPS"},
+"TimeoutSeconds": 20}, "/app-health/hello-world/livez": {"HTTPGetAction":{"port": %v, "scheme": "HTTPS"}, "TimeoutSeconds": 13}}`, appPort, appPort),
 	})
 	if err != nil {
 		t.Errorf("failed to create status server %v", err)

--- a/pkg/kube/inject/app_probe.go
+++ b/pkg/kube/inject/app_probe.go
@@ -152,10 +152,16 @@ func DumpAppProbers(podspec *corev1.PodSpec) string {
 			}
 		}
 		if h := updateNamedPort(c.ReadinessProbe, portMap); h != nil {
-			out[readyz] = h
+			prober := status.Prober{}
+			prober.HTTPGetAction = h
+			prober.TimeoutSeconds = c.ReadinessProbe.TimeoutSeconds
+			out[readyz] = prober
 		}
 		if h := updateNamedPort(c.LivenessProbe, portMap); h != nil {
-			out[livez] = h
+			prober := status.Prober{}
+			prober.HTTPGetAction = h
+			prober.TimeoutSeconds = c.LivenessProbe.TimeoutSeconds
+			out[livez] = prober
 		}
 	}
 	b, err := json.Marshal(out)
@@ -191,6 +197,7 @@ func rewriteAppHTTPProbe(annotations map[string]string, podSpec *corev1.PodSpec,
 		if c.Name == ProxyContainerName {
 			continue
 		}
+
 		readyz, livez := status.FormatProberURL(c.Name)
 		if hg := convertAppProber(c.ReadinessProbe, readyz, statusPort); hg != nil {
 			*c.ReadinessProbe.HTTPGet = *hg

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -130,7 +130,7 @@ spec:
         - name: ISTIO_META_MESH_ID
           value: cluster.local
         - name: ISTIO_KUBE_APP_PROBERS
-          value: '{"/app-health/hello/livez":{"port":80},"/app-health/hello/readyz":{"port":3333},"/app-health/world/livez":{"port":90}}'
+          value: '{"/app-health/hello/livez":{"HTTPGetAction":{"port":80},"TimeoutSeconds":0},"/app-health/hello/readyz":{"HTTPGetAction":{"port":3333},"TimeoutSeconds":0},"/app-health/world/livez":{"HTTPGetAction":{"port":90},"TimeoutSeconds":0}}'
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-proxy

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_nosidecar_rewrite.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_nosidecar_rewrite.patch
@@ -25,7 +25,7 @@
       "env": [
         {
           "name": "ISTIO_KUBE_APP_PROBERS",
-          "value": "{\"/app-health/hello/livez\":{\"path\":\"/live\",\"port\":80},\"/app-health/hello/readyz\":{\"path\":\"/ready\",\"port\":3333},\"/app-health/second/livez\":{\"port\":9000}}"
+          "value": "{\"/app-health/hello/livez\":{\"HTTPGetAction\":{\"path\":\"/live\",\"port\":80},\"TimeoutSeconds\":0},\"/app-health/hello/readyz\":{\"HTTPGetAction\":{\"path\":\"/ready\",\"port\":3333},\"TimeoutSeconds\":0},\"/app-health/second/livez\":{\"HTTPGetAction\":{\"port\":9000},\"TimeoutSeconds\":0}}"
         }
       ],
       "resources": {}

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite.patch
@@ -29,7 +29,7 @@
       "env": [
         {
           "name": "ISTIO_KUBE_APP_PROBERS",
-          "value": "{\"/app-health/hello/livez\":{\"path\":\"/live\",\"port\":80},\"/app-health/hello/readyz\":{\"path\":\"/ready\",\"port\":3333},\"/app-health/second/livez\":{\"port\":9000}}"
+          "value": "{\"/app-health/hello/livez\":{\"HTTPGetAction\":{\"path\":\"/live\",\"port\":80},\"TimeoutSeconds\":0},\"/app-health/hello/readyz\":{\"HTTPGetAction\":{\"path\":\"/ready\",\"port\":3333},\"TimeoutSeconds\":0},\"/app-health/second/livez\":{\"HTTPGetAction\":{\"port\":9000},\"TimeoutSeconds\":0}}"
         }
       ],
       "resources": {}

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_enabled_via_annotation.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_enabled_via_annotation.patch
@@ -29,7 +29,7 @@
       "env": [
         {
           "name": "ISTIO_KUBE_APP_PROBERS",
-          "value": "{\"/app-health/hello/livez\":{\"path\":\"/live\",\"port\":80},\"/app-health/hello/readyz\":{\"path\":\"/ready\",\"port\":3333},\"/app-health/second/livez\":{\"port\":9000}}"
+          "value": "{\"/app-health/hello/livez\":{\"HTTPGetAction\":{\"path\":\"/live\",\"port\":80},\"TimeoutSeconds\":0},\"/app-health/hello/readyz\":{\"HTTPGetAction\":{\"path\":\"/ready\",\"port\":3333},\"TimeoutSeconds\":0},\"/app-health/second/livez\":{\"HTTPGetAction\":{\"port\":9000},\"TimeoutSeconds\":0}}"
         }
       ],
       "resources": {}

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_https_probe_rewrite.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_https_probe_rewrite.patch
@@ -29,7 +29,7 @@
       "env": [
         {
           "name": "ISTIO_KUBE_APP_PROBERS",
-          "value": "{\"/app-health/hello/livez\":{\"path\":\"/live\",\"port\":80},\"/app-health/hello/readyz\":{\"path\":\"/ready\",\"port\":3333,\"scheme\":\"HTTPS\"},\"/app-health/second/livez\":{\"port\":9000}}"
+          "value": "{\"/app-health/hello/livez\":{\"HTTPGetAction\":{\"path\":\"/live\",\"port\":80},\"TimeoutSeconds\":0},\"/app-health/hello/readyz\":{\"HTTPGetAction\":{\"path\":\"/ready\",\"port\":3333,\"scheme\":\"HTTPS\"},\"TimeoutSeconds\":0},\"/app-health/second/livez\":{\"HTTPGetAction\":{\"port\":9000},\"TimeoutSeconds\":0}}"
         }
       ],
       "resources": {}


### PR DESCRIPTION
The httpClient created in the pilot agent code currently uses the default timeout of 10s.
Updated the code to use the timeout specified by the user instead.

Fixes: #18242



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure