### PR TITLE
convert deprecated EnvoyFilter to new syntax

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/preconfigured.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/preconfigured.yaml
@@ -194,28 +194,33 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
-  workloadLabels:
-  {{- range $key, $spec := .Values }}
-  {{- if eq $key "istio-ingressgateway" }}
-  {{- if $spec.enabled }}
-    {{- range $key, $val := $spec.labels }}
-    {{ $key }}: {{ $val }}
+  workloadSelector:
+    labels:
+    {{- range $key, $spec := .Values }}
+    {{- if eq $key "istio-ingressgateway" }}
+    {{- if $spec.enabled }}
+      {{- range $key, $val := $spec.labels }}
+      {{ $key }}: {{ $val }}
+      {{- end }}
     {{- end }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
-  filters:
-  - listenerMatch:
-      portNumber: 15443
-      listenerType: GATEWAY
-    insertPosition:
-      index: AFTER
-      relativeTo: envoy.filters.network.sni_cluster
-    filterName: envoy.filters.network.tcp_cluster_rewrite
-    filterType: NETWORK
-    filterConfig:
-      cluster_pattern: "\\.global$"
-      cluster_replacement: ".svc.{{ .Values.global.proxy.clusterDomain }}"
+    {{- end }}
+    {{- end }}
+  configPatches:
+  - applyTo: NETWORK_FILTER
+    match:
+      context: GATEWAY
+      listener:
+        portNumber: 15443
+        filterChain:
+          filter:
+            name: "envoy.filters.network.sni_cluster"
+    patch:
+      operation: INSERT_AFTER
+      value:
+        name: "envoy.filters.network.tcp_cluster_rewrite"
+        config:
+          cluster_pattern: "\\.global$"
+          cluster_replacement: ".svc.{{ .Values.global.proxy.clusterDomain }}"
 ---
 ## To ensure all traffic to *.global is using mTLS
 apiVersion: networking.istio.io/v1alpha3

--- a/manifests/gateways/istio-ingress/templates/preconfigured.yaml
+++ b/manifests/gateways/istio-ingress/templates/preconfigured.yaml
@@ -65,20 +65,25 @@ metadata:
 {{ $gateway.labels | toYaml | indent 4 }}
     release: {{ .Release.Name }}
 spec:
-   workloadLabels:
-     istio: ingressgateway
-   filters:
-   - listenerMatch:
-       portNumber: 15443
-       listenerType: GATEWAY
-     insertPosition:
-       index: AFTER
-       relativeTo: envoy.filters.network.sni_cluster
-     filterName: envoy.filters.network.tcp_cluster_rewrite
-     filterType: NETWORK
-     filterConfig:
-       cluster_pattern: "\\.global$"
-       cluster_replacement: ".svc.{{ .Values.global.proxy.clusterDomain }}"       
+  workloadSelector:
+    labels:
+      istio: ingressgateway
+  configPatches:
+  - applyTo: NETWORK_FILTER
+    match:
+      context: GATEWAY
+      listener:
+        portNumber: 15443
+        filterChain:
+          filter:
+            name: "envoy.filters.network.sni_cluster"
+    patch:
+      operation: INSERT_AFTER
+      value:
+        name: "envoy.filters.network.tcp_cluster_rewrite"
+        config:
+          cluster_pattern: "\\.global$"
+          cluster_replacement: ".svc.{{ .Values.global.proxy.clusterDomain }}"
 ---
 ## To ensure all traffic to *.global is using mTLS
 apiVersion: networking.istio.io/v1alpha3

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -8538,20 +8538,25 @@ metadata:
 {{ $gateway.labels | toYaml | indent 4 }}
     release: {{ .Release.Name }}
 spec:
-   workloadLabels:
-     istio: ingressgateway
-   filters:
-   - listenerMatch:
-       portNumber: 15443
-       listenerType: GATEWAY
-     insertPosition:
-       index: AFTER
-       relativeTo: envoy.filters.network.sni_cluster
-     filterName: envoy.filters.network.tcp_cluster_rewrite
-     filterType: NETWORK
-     filterConfig:
-       cluster_pattern: "\\.global$"
-       cluster_replacement: ".svc.{{ .Values.global.proxy.clusterDomain }}"       
+  workloadSelector:
+    labels:
+      istio: ingressgateway
+  configPatches:
+  - applyTo: NETWORK_FILTER
+    match:
+      context: GATEWAY
+      listener:
+        portNumber: 15443
+        filterChain:
+          filter:
+            name: "envoy.filters.network.sni_cluster"
+    patch:
+      operation: INSERT_AFTER
+      value:
+        name: "envoy.filters.network.tcp_cluster_rewrite"
+        config:
+          cluster_pattern: "\\.global$"
+          cluster_replacement: ".svc.{{ .Values.global.proxy.clusterDomain }}"
 ---
 ## To ensure all traffic to *.global is using mTLS
 apiVersion: networking.istio.io/v1alpha3


### PR DESCRIPTION
Manual cherry-pick of https://github.com/istio/istio/pull/20702. It looks like this should have been included in 1.5 but was skipped over. I came across this will looking into https://github.com/istio/istio/issues/21676. I don't know if the two are related or not.
