### PR TITLE
should prioritize exact matches in MostSpecificHostMatch (fixes #19459)

### DIFF
--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -352,10 +352,19 @@ func resolveGatewayName(gwname string, meta ConfigMeta) string {
 // MostSpecificHostMatch compares the elements of the stack to the needle, and returns the longest stack element
 // matching the needle, or false if no element in the stack matches the needle.
 func MostSpecificHostMatch(needle host.Name, stack []host.Name) (host.Name, bool) {
+	matches := []host.Name{}
 	for _, h := range stack {
-		if needle.Matches(h) {
-			return h, true
+		if needle == h {
+			// exact match, return immediately
+			return needle, true
 		}
+		if needle.Matches(h) {
+			matches = append(matches, h)
+		}
+	}
+	if len(matches) > 0 {
+		// TODO: return closest match out of all non-exact matching hosts
+		return matches[0], true
 	}
 	return "", false
 }

--- a/pilot/pkg/model/config_test.go
+++ b/pilot/pkg/model/config_test.go
@@ -391,6 +391,10 @@ func TestMostSpecificHostMatch(t *testing.T) {
 
 		{[]host.Name{"bar.com", "*.foo.com"}, "*foo.com", "*.foo.com"},
 		{[]host.Name{"foo.com", "*.foo.com"}, "*foo.com", "foo.com"},
+
+		// should prioritize closest match
+		{[]host.Name{"*.bar.com", "foo.bar.com"}, "foo.bar.com", "foo.bar.com"},
+		{[]host.Name{"*.foo.bar.com", "bar.foo.bar.com"}, "bar.foo.bar.com", "bar.foo.bar.com"},
 	}
 
 	for idx, tt := range tests {


### PR DESCRIPTION
This fixes the hostname matching for DestinationRule, and now prioritizes exact matches (fixes #19459).