### PR TITLE
Remove goimports from go-gen

### DIFF
--- a/galley/pkg/config/analysis/msg/messages.go
+++ b/galley/pkg/config/analysis/msg/messages.go
@@ -16,5 +16,3 @@ package msg
 
 // Create static initializers file
 //go:generate go run "$REPO_ROOT/galley/pkg/config/analysis/msg/generate.main.go" messages.yaml messages.gen.go
-
-//go:generate goimports -w -local istio.io "$REPO_ROOT/galley/pkg/config/analysis/msg/messages.gen.go"

--- a/galley/pkg/config/testing/basicmeta/generate.go
+++ b/galley/pkg/config/testing/basicmeta/generate.go
@@ -22,6 +22,3 @@ package basicmeta
 
 // Create collection constants
 //go:generate go run $REPO_ROOT/pkg/config/schema/codegen/tools/collections.main.go basicmeta basicmeta.yaml collections.gen.go
-
-//go:generate goimports -w -local istio.io "$REPO_ROOT/galley/pkg/config/testing/basicmeta/collections.gen.go"
-//go:generate goimports -w -local istio.io "$REPO_ROOT/galley/pkg/config/testing/basicmeta/staticinit.gen.go"

--- a/galley/pkg/config/testing/k8smeta/generate.go
+++ b/galley/pkg/config/testing/k8smeta/generate.go
@@ -22,6 +22,3 @@ package k8smeta
 
 // Create collection constants
 //go:generate go run $REPO_ROOT/pkg/config/schema/codegen/tools/collections.main.go k8smeta k8smeta.yaml collections.gen.go
-
-//go:generate goimports -w -local istio.io "$REPO_ROOT/galley/pkg/config/testing/k8smeta/collections.gen.go"
-//go:generate goimports -w -local istio.io "$REPO_ROOT/galley/pkg/config/testing/k8smeta/staticinit.gen.go"

--- a/galley/testdatasets/validation/dataset.go
+++ b/galley/testdatasets/validation/dataset.go
@@ -15,4 +15,3 @@
 package validation
 
 //go:generate go-bindata --nocompress --nometadata --pkg validation -o dataset.gen.go dataset/...
-//go:generate goimports -w dataset.gen.go

--- a/pkg/config/schema/generate.go
+++ b/pkg/config/schema/generate.go
@@ -31,4 +31,3 @@ package schema
 // Create snapshot constants
 // nolint: lll
 //go:generate go run $REPO_ROOT/pkg/config/schema/codegen/tools/snapshots.main.go snapshots metadata.yaml "$REPO_ROOT/pkg/config/schema/snapshots/snapshots.gen.go"
-

--- a/pkg/config/schema/generate.go
+++ b/pkg/config/schema/generate.go
@@ -32,8 +32,3 @@ package schema
 // nolint: lll
 //go:generate go run $REPO_ROOT/pkg/config/schema/codegen/tools/snapshots.main.go snapshots metadata.yaml "$REPO_ROOT/pkg/config/schema/snapshots/snapshots.gen.go"
 
-//go:generate goimports -w -local istio.io "$REPO_ROOT/pkg/config/schema/collections/collections.gen.go"
-//go:generate goimports -w -local istio.io "$REPO_ROOT/pkg/config/schema/snapshots/snapshots.gen.go"
-//go:generate goimports -w -local istio.io "$REPO_ROOT/pkg/config/schema/staticinit.gen.go"
-//go:generate goimports -w -local istio.io "$REPO_ROOT/pkg/config/schema/collections/staticinit.gen.go"
-//go:generate goimports -w -local istio.io "$REPO_ROOT/pkg/config/schema/snapshots/staticinit.gen.go"


### PR DESCRIPTION
This is already run after by `gen`. The motivation for this is that
somehow this command sometimes fail.