### PR TITLE
remove self signed config for multicluster sample

### DIFF
--- a/operator/data/examples/multicluster/values-istio-multicluster-primary.yaml
+++ b/operator/data/examples/multicluster/values-istio-multicluster-primary.yaml
@@ -2,8 +2,6 @@ apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   values:
-    security:
-      selfSigned: false
     gateways:
       istio-ingressgateway:
         env:

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -45494,8 +45494,6 @@ var _examplesMulticlusterValuesIstioMulticlusterPrimaryYaml = []byte(`apiVersion
 kind: IstioOperator
 spec:
   values:
-    security:
-      selfSigned: false
     gateways:
       istio-ingressgateway:
         env:


### PR DESCRIPTION
as this config doesn't work for istiod and it is confusing.  The istiod code checks the signing key file existence rather than relying on a static config.


[ ] Configuration Infrastructure
[ ] Docs
[ x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure