### PR TITLE
authz: fix deny policy to generate TCP-only config instead deny all config when HTTP fields are used on TCP filter

### DIFF
--- a/pilot/pkg/security/authz/builder/testdata/v1beta1/action-deny-HTTP-for-TCP-filter-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1/action-deny-HTTP-for-TCP-filter-in.yaml
@@ -6,24 +6,51 @@ metadata:
 spec:
   action: DENY
   rules:
+  # rule[0] `from`: HTTP field, `to`: HTTP field.
   - from:
     - source:
         requestPrincipals: ["id-1"]
     to:
     - operation:
         methods: ["GET"]
+  # rule[1] `from`: nil, `to`: HTTP field.
   - to:
     - operation:
         methods: ["GET"]
+  # rule[2] `from`: HTTP field, `to`: nil.
   - from:
     - source:
           requestPrincipals: ["id-1"]
+  # rule[3] `from`: TCP field, `to`: HTTP field.
+  - from:
+    - source:
+        namespaces: ["ns-1"]
+    to:
+    - operation:
+          methods: ["GET"]
+  # rule[4] `from`: HTTP field, `to`: TCP field.
+  - from:
+    - source:
+          requestPrincipals: ["id-1"]
+    to:
+    - operation:
+          ports: ["80"]
+  # rule[5] `from`: TCP field, `to`: TCP field.
   - from:
     - source:
         namespaces: ["ns-1"]
     to:
     - operation:
         ports: ["80"]
+  # rule[6] `from`: nil, `to`: nil, `when`: HTTP field.
+  - when:
+    - key: "request.headers[:method]"
+      values: ["GET"]
+  # rule[7] `from`: nil, `to`: nil, `when`: TCP field.
+  - when:
+    - key: "destination.port"
+      values: ["80"]
+  # rule[8] `from`: all fields, `to`: all fields, `when`: all fields.
   - from:
     - source:
         principals: ["principal"]

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1/action-deny-HTTP-for-TCP-filter-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1/action-deny-HTTP-for-TCP-filter-in.yaml
@@ -12,9 +12,72 @@ spec:
     to:
     - operation:
         methods: ["GET"]
+  - to:
+    - operation:
+        methods: ["GET"]
+  - from:
+    - source:
+          requestPrincipals: ["id-1"]
   - from:
     - source:
         namespaces: ["ns-1"]
     to:
     - operation:
         ports: ["80"]
+  - from:
+    - source:
+        principals: ["principal"]
+        requestPrincipals: ["requestPrincipals"]
+        namespaces: ["ns"]
+        ipBlocks: ["1.2.3.4"]
+        notPrincipals: ["not-principal"]
+        notRequestPrincipals: ["not-requestPrincipals"]
+        notNamespaces: ["not-ns"]
+        notIpBlocks: ["9.0.0.1"]
+    to:
+    - operation:
+        methods: ["method"]
+        hosts: ["exact.com"]
+        ports: ["80"]
+        paths: ["/exact"]
+        notMethods: ["not-method"]
+        notHosts: ["not-exact.com"]
+        notPorts: ["8000"]
+        notPaths: ["/not-exact"]
+    when:
+      - key: "request.headers[X-header]"
+        values: ["header"]
+        notValues: ["not-header"]
+      - key: "source.ip"
+        values: ["10.10.10.10"]
+        notValues: ["90.10.10.10"]
+      - key: "source.namespace"
+        values: ["ns"]
+        notValues: ["not-ns"]
+      - key: "source.principal"
+        values: ["principal"]
+        notValues: ["not-principal"]
+      - key: "request.auth.principal"
+        values: ["requestPrincipals"]
+        notValues: ["not-requestPrincipals"]
+      - key: "request.auth.audiences"
+        values: ["audiences"]
+        notValues: ["not-audiences"]
+      - key: "request.auth.presenter"
+        values: ["presenter"]
+        notValues: ["not-presenter"]
+      - key: "request.auth.claims[iss]"
+        values: ["iss"]
+        notValues: ["not-iss"]
+      - key: "destination.ip"
+        values: ["10.10.10.10"]
+        notValues: ["90.10.10.10"]
+      - key: "destination.port"
+        values: ["91"]
+        notValues: ["9001"]
+      - key: "connection.sni"
+        values: ["exact.com"]
+        notValues: ["not-exact.com"]
+      - key: "experimental.envoy.filters.a.b[c]"
+        values: ["exact"]
+        notValues: ["not-exact"]

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1/action-deny-HTTP-for-TCP-filter-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1/action-deny-HTTP-for-TCP-filter-out.yaml
@@ -1,8 +1,181 @@
 rules:
   action: DENY
   policies:
-    '[default-deny-all]-ns[foo]-policy[httpbin-deny]-rule[0]':
+    ns[foo]-policy[httpbin-deny]-rule[0]:
       permissions:
-      - any: true
+      - andRules:
+          rules:
+          - any: true
       principals:
-      - any: true
+      - andIds:
+          ids:
+          - any: true
+    ns[foo]-policy[httpbin-deny]-rule[1]:
+      permissions:
+      - andRules:
+          rules:
+          - any: true
+      principals:
+      - andIds:
+          ids:
+          - any: true
+    ns[foo]-policy[httpbin-deny]-rule[2]:
+      permissions:
+      - andRules:
+          rules:
+          - any: true
+      principals:
+      - andIds:
+          ids:
+          - any: true
+    ns[foo]-policy[httpbin-deny]-rule[3]:
+      permissions:
+      - andRules:
+          rules:
+          - orRules:
+              rules:
+              - destinationPort: 80
+      principals:
+      - andIds:
+          ids:
+          - orIds:
+              ids:
+              - authenticated:
+                  principalName:
+                    safeRegex:
+                      googleRe2: {}
+                      regex: .*/ns/ns-1/.*
+    ns[foo]-policy[httpbin-deny]-rule[4]:
+      permissions:
+      - andRules:
+          rules:
+          - orRules:
+              rules:
+              - destinationPort: 80
+          - notRule:
+              orRules:
+                rules:
+                - destinationPort: 8000
+          - orRules:
+              rules:
+              - destinationIp:
+                  addressPrefix: 10.10.10.10
+                  prefixLen: 32
+          - notRule:
+              orRules:
+                rules:
+                - destinationIp:
+                    addressPrefix: 90.10.10.10
+                    prefixLen: 32
+          - orRules:
+              rules:
+              - destinationPort: 91
+          - notRule:
+              orRules:
+                rules:
+                - destinationPort: 9001
+          - orRules:
+              rules:
+              - requestedServerName:
+                  exact: exact.com
+          - notRule:
+              orRules:
+                rules:
+                - requestedServerName:
+                    exact: not-exact.com
+          - orRules:
+              rules:
+              - metadata:
+                  filter: envoy.filters.a.b
+                  path:
+                  - key: c
+                  value:
+                    stringMatch:
+                      exact: exact
+          - notRule:
+              orRules:
+                rules:
+                - metadata:
+                    filter: envoy.filters.a.b
+                    path:
+                    - key: c
+                    value:
+                      stringMatch:
+                        exact: not-exact
+      principals:
+      - andIds:
+          ids:
+          - orIds:
+              ids:
+              - authenticated:
+                  principalName:
+                    exact: spiffe://principal
+          - notId:
+              orIds:
+                ids:
+                - authenticated:
+                    principalName:
+                      exact: spiffe://not-principal
+          - orIds:
+              ids:
+              - authenticated:
+                  principalName:
+                    safeRegex:
+                      googleRe2: {}
+                      regex: .*/ns/ns/.*
+          - notId:
+              orIds:
+                ids:
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .*/ns/not-ns/.*
+          - orIds:
+              ids:
+              - sourceIp:
+                  addressPrefix: 1.2.3.4
+                  prefixLen: 32
+          - notId:
+              orIds:
+                ids:
+                - sourceIp:
+                    addressPrefix: 9.0.0.1
+                    prefixLen: 32
+          - orIds:
+              ids:
+              - sourceIp:
+                  addressPrefix: 10.10.10.10
+                  prefixLen: 32
+          - notId:
+              orIds:
+                ids:
+                - sourceIp:
+                    addressPrefix: 90.10.10.10
+                    prefixLen: 32
+          - orIds:
+              ids:
+              - authenticated:
+                  principalName:
+                    safeRegex:
+                      googleRe2: {}
+                      regex: .*/ns/ns/.*
+          - notId:
+              orIds:
+                ids:
+                - authenticated:
+                    principalName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .*/ns/not-ns/.*
+          - orIds:
+              ids:
+              - authenticated:
+                  principalName:
+                    exact: spiffe://principal
+          - notId:
+              orIds:
+                ids:
+                - authenticated:
+                    principalName:
+                      exact: spiffe://not-principal

--- a/pilot/pkg/security/authz/builder/testdata/v1beta1/action-deny-HTTP-for-TCP-filter-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/v1beta1/action-deny-HTTP-for-TCP-filter-out.yaml
@@ -32,6 +32,32 @@ rules:
       permissions:
       - andRules:
           rules:
+          - any: true
+      principals:
+      - andIds:
+          ids:
+          - orIds:
+              ids:
+              - authenticated:
+                  principalName:
+                    safeRegex:
+                      googleRe2: {}
+                      regex: .*/ns/ns-1/.*
+    ns[foo]-policy[httpbin-deny]-rule[4]:
+      permissions:
+      - andRules:
+          rules:
+          - orRules:
+              rules:
+              - destinationPort: 80
+      principals:
+      - andIds:
+          ids:
+          - any: true
+    ns[foo]-policy[httpbin-deny]-rule[5]:
+      permissions:
+      - andRules:
+          rules:
           - orRules:
               rules:
               - destinationPort: 80
@@ -45,7 +71,27 @@ rules:
                     safeRegex:
                       googleRe2: {}
                       regex: .*/ns/ns-1/.*
-    ns[foo]-policy[httpbin-deny]-rule[4]:
+    ns[foo]-policy[httpbin-deny]-rule[6]:
+      permissions:
+      - andRules:
+          rules:
+          - any: true
+      principals:
+      - andIds:
+          ids:
+          - any: true
+    ns[foo]-policy[httpbin-deny]-rule[7]:
+      permissions:
+      - andRules:
+          rules:
+          - orRules:
+              rules:
+              - destinationPort: 80
+      principals:
+      - andIds:
+          ids:
+          - any: true
+    ns[foo]-policy[httpbin-deny]-rule[8]:
       permissions:
       - andRules:
           rules:

--- a/pilot/pkg/security/authz/model/model.go
+++ b/pilot/pkg/security/authz/model/model.go
@@ -22,10 +22,9 @@ import (
 
 	istio_rbac "istio.io/api/rbac/v1alpha1"
 	security "istio.io/api/security/v1beta1"
-	istiolog "istio.io/pkg/log"
-
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/security/trustdomain"
+	istiolog "istio.io/pkg/log"
 )
 
 const (
@@ -293,11 +292,15 @@ func NewModelV1beta1(trustDomainBundle trustdomain.Bundle, rule *security.Rule) 
 // in the model for the given service. This function only generates the policy if the constraints
 // and properties specified in the model is matched with the given service. It also validates if the
 // model is valid for TCP filter.
-func (m *Model) Generate(service *ServiceMetadata, forTCPFilter bool) *envoy_rbac.Policy {
+// When the policy uses HTTP fields for TCP filter (forTCPFilter is true):
+// - If it's allow policy (forDenyPolicy is false), returns nil so that the allow policy is ignored to avoid granting more permissions in this case.
+// - If it's deny policy (forDenyPolicy is true), returns a config that only includes the TCP fields (e.g. port) from the policy. This makes sure
+//   the generated deny policy is more restrictive so that it never grants extra permission in this case.
+func (m *Model) Generate(service *ServiceMetadata, forTCPFilter, forDenyPolicy bool) *envoy_rbac.Policy {
 	policy := &envoy_rbac.Policy{}
 	for _, permission := range m.Permissions {
 		if service == nil || permission.Match(service) {
-			p, err := permission.Generate(forTCPFilter)
+			p, err := permission.Generate(forTCPFilter, forDenyPolicy)
 			if err != nil {
 				rbacLog.Debugf("ignored HTTP permission for TCP service: %v", err)
 				continue
@@ -312,7 +315,7 @@ func (m *Model) Generate(service *ServiceMetadata, forTCPFilter bool) *envoy_rba
 	}
 
 	for _, principal := range m.Principals {
-		p, err := principal.Generate(forTCPFilter)
+		p, err := principal.Generate(forTCPFilter, forDenyPolicy)
 		if err != nil {
 			rbacLog.Debugf("ignored HTTP principal for TCP service: %v", err)
 			continue

--- a/pilot/pkg/security/authz/model/model_test.go
+++ b/pilot/pkg/security/authz/model/model_test.go
@@ -537,6 +537,7 @@ func TestModel_Generate(t *testing.T) {
 		permissions    []Permission
 		principals     []Principal
 		forTCPFilter   bool
+		forDeny        bool
 		wantPermission []string
 		wantPrincipal  []string
 	}{
@@ -598,6 +599,23 @@ func TestModel_Generate(t *testing.T) {
 			},
 			forTCPFilter: true,
 		},
+		{
+			name: "forTCPFilter and forDeny: permission and principal",
+			permissions: []Permission{
+				simplePermission(serviceFoo, "perm-1"),
+			},
+			principals: []Principal{
+				simplePrincipal("id-1"),
+			},
+			wantPermission: []string{
+				"any",
+			},
+			wantPrincipal: []string{
+				principalTag("id-1"),
+			},
+			forTCPFilter: true,
+			forDeny:      true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -605,7 +623,7 @@ func TestModel_Generate(t *testing.T) {
 			Permissions: tc.permissions,
 			Principals:  tc.principals,
 		}
-		got := m.Generate(serviceMetadata, tc.forTCPFilter)
+		got := m.Generate(serviceMetadata, tc.forTCPFilter, tc.forDeny)
 		if len(tc.wantPermission) == 0 || len(tc.wantPrincipal) == 0 {
 			if got != nil {
 				t.Errorf("%s: got %v but want nil", tc.name, *got)

--- a/pilot/pkg/security/authz/model/permission.go
+++ b/pilot/pkg/security/authz/model/permission.go
@@ -112,7 +112,7 @@ func (permission *Permission) ValidateForTCP(forTCP bool) error {
 	}
 	for _, constraint := range permission.Constraints {
 		for k := range constraint {
-			if strings.HasPrefix(k, attrRequestHeader) {
+			if !validConditionForTCP(k) {
 				return fmt.Errorf("constraint(%v)", constraint)
 			}
 		}
@@ -120,49 +120,64 @@ func (permission *Permission) ValidateForTCP(forTCP bool) error {
 	return nil
 }
 
-func (permission *Permission) Generate(forTCPFilter bool) (*envoy_rbac.Permission, error) {
+func validConditionForTCP(k string) bool {
+	return !strings.HasPrefix(k, attrRequestHeader)
+}
+
+// Generate generates the RBAC filter config for the given permission.
+// When the policy uses HTTP fields for TCP filter (forTCPFilter is true):
+// - If it's allow policy (forDenyPolicy is false), returns nil so that the allow policy is ignored to avoid granting more permissions in this case.
+// - If it's deny policy (forDenyPolicy is true), returns a config that only includes the TCP fields (e.g. port) from the policy. This makes sure
+//   the generated deny policy is more restrictive so that it never grants extra permission in this case.
+func (permission *Permission) Generate(forTCPFilter, forDenyPolicy bool) (*envoy_rbac.Permission, error) {
 	if permission == nil {
 		return nil, nil
 	}
 
+	onlyTCPFields := false
 	if err := permission.ValidateForTCP(forTCPFilter); err != nil {
-		return nil, err
+		if !forDenyPolicy {
+			return nil, err
+		}
+		onlyTCPFields = true
 	}
 	pg := permissionGenerator{}
 
 	if permission.AllowAll {
-		pg.append(permissionAny(true))
+		pg.append(permissionAny())
 		return pg.andPermissions(), nil
 	}
 
-	if len(permission.Hosts) > 0 {
-		permission := permission.forKeyValues(hostHeader, permission.Hosts)
-		pg.append(permission)
-	}
+	if !onlyTCPFields {
+		if len(permission.Hosts) > 0 {
+			permission := permission.forKeyValues(hostHeader, permission.Hosts)
+			pg.append(permission)
+		}
 
-	if len(permission.NotHosts) > 0 {
-		permission := permission.forKeyValues(hostHeader, permission.NotHosts)
-		pg.append(permissionNot(permission))
-	}
+		if len(permission.NotHosts) > 0 {
+			permission := permission.forKeyValues(hostHeader, permission.NotHosts)
+			pg.append(permissionNot(permission))
+		}
 
-	if len(permission.Methods) > 0 {
-		permission := permission.forKeyValues(methodHeader, permission.Methods)
-		pg.append(permission)
-	}
+		if len(permission.Methods) > 0 {
+			permission := permission.forKeyValues(methodHeader, permission.Methods)
+			pg.append(permission)
+		}
 
-	if len(permission.NotMethods) > 0 {
-		permission := permission.forKeyValues(methodHeader, permission.NotMethods)
-		pg.append(permissionNot(permission))
-	}
+		if len(permission.NotMethods) > 0 {
+			permission := permission.forKeyValues(methodHeader, permission.NotMethods)
+			pg.append(permissionNot(permission))
+		}
 
-	if len(permission.Paths) > 0 {
-		permission := permission.forKeyValues(pathMatcher, permission.Paths)
-		pg.append(permission)
-	}
+		if len(permission.Paths) > 0 {
+			permission := permission.forKeyValues(pathMatcher, permission.Paths)
+			pg.append(permission)
+		}
 
-	if len(permission.NotPaths) > 0 {
-		permission := permission.forKeyValues(pathMatcher, permission.NotPaths)
-		pg.append(permissionNot(permission))
+		if len(permission.NotPaths) > 0 {
+			permission := permission.forKeyValues(pathMatcher, permission.NotPaths)
+			pg.append(permissionNot(permission))
+		}
 	}
 
 	if len(permission.Ports) > 0 {
@@ -181,7 +196,9 @@ func (permission *Permission) Generate(forTCPFilter bool) (*envoy_rbac.Permissio
 		for _, constraint := range permission.Constraints {
 			var keys []string
 			for key := range constraint {
-				keys = append(keys, key)
+				if !onlyTCPFields || validConditionForTCP(key) {
+					keys = append(keys, key)
+				}
 			}
 			sort.Strings(keys)
 
@@ -200,7 +217,7 @@ func (permission *Permission) Generate(forTCPFilter bool) (*envoy_rbac.Permissio
 
 	if pg.isEmpty() {
 		// None of above permission satisfied means the permission applies to all paths/methods/constraints.
-		pg.append(permissionAny(true))
+		pg.append(permissionAny())
 	}
 
 	return pg.andPermissions(), nil
@@ -344,10 +361,10 @@ func (pg *permissionGenerator) orPermissions() *envoy_rbac.Permission {
 	}
 }
 
-func permissionAny(any bool) *envoy_rbac.Permission {
+func permissionAny() *envoy_rbac.Permission {
 	return &envoy_rbac.Permission{
 		Rule: &envoy_rbac.Permission_Any{
-			Any: any,
+			Any: true,
 		},
 	}
 }

--- a/pilot/pkg/security/authz/model/permission.go
+++ b/pilot/pkg/security/authz/model/permission.go
@@ -134,11 +134,14 @@ func (permission *Permission) Generate(forTCPFilter, forDenyPolicy bool) (*envoy
 		return nil, nil
 	}
 
+	// When true, the function will only handle the TCP fields in the permission.
 	onlyTCPFields := false
 	if err := permission.ValidateForTCP(forTCPFilter); err != nil {
 		if !forDenyPolicy {
 			return nil, err
 		}
+		// Set onlyTCPFields to true if the deny policy is using HTTP fields so that
+		// we generate a deny policy with only TCP fields.
 		onlyTCPFields = true
 	}
 	pg := permissionGenerator{}

--- a/pilot/pkg/security/authz/model/permission_test.go
+++ b/pilot/pkg/security/authz/model/permission_test.go
@@ -767,8 +767,8 @@ func TestPermission_Generate(t *testing.T) {
 				Methods: []string{"GET"},
 				Constraints: []KeyValues{
 					{
-						attrDestIP: Values{
-							Values: []string{"1.2.3.4", "5.6.7.8"},
+						"request.headers[:foo]": Values{
+							Values: []string{"bar"},
 						},
 					},
 				},
@@ -784,12 +784,24 @@ func TestPermission_Generate(t *testing.T) {
                   name: :method
           - orRules:
               rules:
-              - destinationIp:
-                  addressPrefix: 1.2.3.4
-                  prefixLen: 32
-              - destinationIp:
-                  addressPrefix: 5.6.7.8
-                  prefixLen: 32`,
+              - header:
+                  exactMatch: bar
+                  name: :foo`,
+		},
+		{
+			name: "permission with forTCP",
+			permission: &Permission{
+				Methods: []string{"GET"},
+				Constraints: []KeyValues{
+					{
+						"request.headers[:foo]": Values{
+							Values: []string{"bar"},
+						},
+					},
+				},
+			},
+			forTCPFilter: true,
+			wantError:    "methods([GET])",
 		},
 		{
 			name: "permission with forTCP and forDeny",

--- a/pilot/pkg/security/authz/model/permission_test.go
+++ b/pilot/pkg/security/authz/model/permission_test.go
@@ -249,6 +249,7 @@ func TestPermission_Generate(t *testing.T) {
 		name         string
 		permission   *Permission
 		forTCPFilter bool
+		forDeny      bool
 		wantYAML     string
 		wantError    string
 	}{
@@ -761,6 +762,84 @@ func TestPermission_Generate(t *testing.T) {
                   name: :path`,
 		},
 		{
+			name: "permission with forDeny",
+			permission: &Permission{
+				Methods: []string{"GET"},
+				Constraints: []KeyValues{
+					{
+						attrDestIP: Values{
+							Values: []string{"1.2.3.4", "5.6.7.8"},
+						},
+					},
+				},
+			},
+			forDeny: true,
+			wantYAML: `
+        andRules:
+          rules:
+          - orRules:
+              rules:
+              - header:
+                  exactMatch: GET
+                  name: :method
+          - orRules:
+              rules:
+              - destinationIp:
+                  addressPrefix: 1.2.3.4
+                  prefixLen: 32
+              - destinationIp:
+                  addressPrefix: 5.6.7.8
+                  prefixLen: 32`,
+		},
+		{
+			name: "permission with forTCP and forDeny",
+			permission: &Permission{
+				Methods:    []string{"GET"},
+				NotMethods: []string{"POST"},
+				Paths:      []string{"/abc"},
+				NotPaths:   []string{"/xyz"},
+				Ports:      []string{"80"},
+				NotPorts:   []string{"81"},
+				Hosts:      []string{"host.com"},
+				NotHosts:   []string{"other.com"},
+				Constraints: []KeyValues{
+					{
+						attrDestIP: Values{
+							Values: []string{"1.2.3.4"},
+						},
+						attrDestPort: Values{
+							Values:    []string{"90"},
+							NotValues: []string{"91"},
+						},
+					},
+				},
+			},
+			forTCPFilter: true,
+			forDeny:      true,
+			wantYAML: `
+        andRules:
+          rules:
+          - orRules:
+              rules:
+              - destinationPort: 80
+          - notRule:
+              orRules:
+                rules:
+                - destinationPort: 81
+          - orRules:
+              rules:
+              - destinationIp:
+                  addressPrefix: 1.2.3.4
+                  prefixLen: 32
+          - orRules:
+              rules:
+              - destinationPort: 90
+          - notRule:
+              orRules:
+                rules:
+                - destinationPort: 91`,
+		},
+		{
 			name: "permission invalid for TCP",
 			permission: &Permission{
 				Hosts: []string{"host-1"},
@@ -771,7 +850,7 @@ func TestPermission_Generate(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		got, err := tc.permission.Generate(tc.forTCPFilter)
+		got, err := tc.permission.Generate(tc.forTCPFilter, tc.forDeny)
 		if tc.wantError != "" {
 			if err == nil || !strings.Contains(err.Error(), tc.wantError) {
 				t.Errorf("%s: got error %q but want error %q", tc.name, err, tc.wantError)

--- a/pilot/pkg/security/authz/model/principal.go
+++ b/pilot/pkg/security/authz/model/principal.go
@@ -96,11 +96,14 @@ func (principal *Principal) Generate(forTCPFilter, forDenyPolicy bool) (*envoy_r
 		return nil, nil
 	}
 
+	// When true, the function will only handle the TCP fields in the principal.
 	onlyTCPFields := false
 	if err := principal.ValidateForTCP(forTCPFilter); err != nil {
 		if !forDenyPolicy {
 			return nil, err
 		}
+		// Set onlyTCPFields to true if the deny policy is using HTTP fields so that
+		// we generate a deny policy with only TCP fields.
 		onlyTCPFields = true
 	}
 

--- a/pilot/pkg/security/authz/model/principal.go
+++ b/pilot/pkg/security/authz/model/principal.go
@@ -72,9 +72,7 @@ func (principal *Principal) ValidateForTCP(forTCP bool) error {
 
 	for _, p := range principal.Properties {
 		for key := range p {
-			// The "request.auth.*" and "request.headers" attributes are only available for HTTP.
-			// See https://istio.io/docs/reference/config/security/conditions/.
-			if strings.HasPrefix(key, "request.") || key == attrSrcUser {
+			if !validPropertyForTCP(key) {
 				return fmt.Errorf("property(%v)", p)
 			}
 		}
@@ -82,23 +80,38 @@ func (principal *Principal) ValidateForTCP(forTCP bool) error {
 	return nil
 }
 
-func (principal *Principal) Generate(forTCPFilter bool) (*envoy_rbac.Principal, error) {
+func validPropertyForTCP(p string) bool {
+	// The "request.auth.*" and "request.headers" attributes are only available for HTTP.
+	// See https://istio.io/docs/reference/config/security/conditions/.
+	return !strings.HasPrefix(p, "request.") && p != attrSrcUser
+}
+
+// Generate generates the RBAC filter config for the given principal.
+// When the policy uses HTTP fields for TCP filter (forTCPFilter is true):
+// - If it's allow policy (forDenyPolicy is false), returns nil so that the allow policy is ignored to avoid granting more permissions in this case.
+// - If it's deny policy (forDenyPolicy is true), returns a config that only includes the TCP fields (e.g. source.principal). This makes sure
+//   the generated deny policy is more restrictive so that it never grants any extra permission in this case.
+func (principal *Principal) Generate(forTCPFilter, forDenyPolicy bool) (*envoy_rbac.Principal, error) {
 	if principal == nil {
 		return nil, nil
 	}
 
+	onlyTCPFields := false
 	if err := principal.ValidateForTCP(forTCPFilter); err != nil {
-		return nil, err
+		if !forDenyPolicy {
+			return nil, err
+		}
+		onlyTCPFields = true
 	}
 
 	pg := principalGenerator{}
 
 	if principal.AllowAll {
-		pg.append(principalAny(true))
+		pg.append(principalAny())
 		return pg.andPrincipals(), nil
 	}
 
-	if len(principal.Users) != 0 {
+	if !onlyTCPFields && len(principal.Users) != 0 {
 		principal := principal.forKeyValues(attrSrcPrincipal, principal.Users, forTCPFilter)
 		pg.append(principal)
 	}
@@ -113,30 +126,32 @@ func (principal *Principal) Generate(forTCPFilter bool) (*envoy_rbac.Principal, 
 		pg.append(principalNot(principal))
 	}
 
-	if len(principal.RequestPrincipals) > 0 {
-		principal := principal.forKeyValues(attrRequestPrincipal, principal.RequestPrincipals, forTCPFilter)
-		pg.append(principal)
-	}
+	if !onlyTCPFields {
+		if len(principal.RequestPrincipals) > 0 {
+			principal := principal.forKeyValues(attrRequestPrincipal, principal.RequestPrincipals, forTCPFilter)
+			pg.append(principal)
+		}
 
-	if len(principal.NotRequestPrincipals) > 0 {
-		principal := principal.forKeyValues(attrRequestPrincipal, principal.NotRequestPrincipals, forTCPFilter)
-		pg.append(principalNot(principal))
-	}
+		if len(principal.NotRequestPrincipals) > 0 {
+			principal := principal.forKeyValues(attrRequestPrincipal, principal.NotRequestPrincipals, forTCPFilter)
+			pg.append(principalNot(principal))
+		}
 
-	if principal.Group != "" {
-		principal := principal.forKeyValue(attrRequestClaimGroups, principal.Group, forTCPFilter)
-		pg.append(principal)
-	}
+		if principal.Group != "" {
+			principal := principal.forKeyValue(attrRequestClaimGroups, principal.Group, forTCPFilter)
+			pg.append(principal)
+		}
 
-	if len(principal.Groups) > 0 {
-		// TODO: Validate attrRequestClaimGroups and principal.Groups are not used at the same time.
-		principal := principal.forKeyValues(attrRequestClaimGroups, principal.Groups, forTCPFilter)
-		pg.append(principal)
-	}
+		if len(principal.Groups) > 0 {
+			// TODO: Validate attrRequestClaimGroups and principal.Groups are not used at the same time.
+			principal := principal.forKeyValues(attrRequestClaimGroups, principal.Groups, forTCPFilter)
+			pg.append(principal)
+		}
 
-	if len(principal.NotGroups) > 0 {
-		principal := principal.forKeyValues(attrRequestClaimGroups, principal.NotGroups, forTCPFilter)
-		pg.append(principalNot(principal))
+		if len(principal.NotGroups) > 0 {
+			principal := principal.forKeyValues(attrRequestClaimGroups, principal.NotGroups, forTCPFilter)
+			pg.append(principalNot(principal))
+		}
 	}
 
 	if len(principal.Namespaces) > 0 {
@@ -164,7 +179,9 @@ func (principal *Principal) Generate(forTCPFilter bool) (*envoy_rbac.Principal, 
 		// config is stable.
 		var keys []string
 		for key := range p {
-			keys = append(keys, key)
+			if !onlyTCPFields || validPropertyForTCP(key) {
+				keys = append(keys, key)
+			}
 		}
 		sort.Strings(keys)
 
@@ -182,8 +199,14 @@ func (principal *Principal) Generate(forTCPFilter bool) (*envoy_rbac.Principal, 
 	}
 
 	if pg.isEmpty() {
-		// None of above principal satisfied means nobody has the permission.
-		principal := principalNot(principalAny(true))
+		var principal *envoy_rbac.Principal
+		if forDenyPolicy {
+			// Deny everything
+			principal = principalAny()
+		} else {
+			// None of above principal satisfied means nobody has the permission.
+			principal = principalNot(principalAny())
+		}
 		pg.append(principal)
 	}
 
@@ -242,7 +265,7 @@ func (principal *Principal) forKeyValue(key, value string, forTCPFilter bool) *e
 		if !principal.v1beta1 {
 			// Legacy support for the v1alpha1 policy. The v1beta1 doesn't support these.
 			if value == allUsers || value == "*" {
-				return principalAny(true)
+				return principalAny()
 			}
 			// We don't allow users to use "*" in names or not_names. However, we will use "*" internally to
 			// refer to authenticated users, since existing code using regex to map "*" to all authenticated
@@ -332,10 +355,10 @@ func (pg *principalGenerator) orPrincipals() *envoy_rbac.Principal {
 	}
 }
 
-func principalAny(any bool) *envoy_rbac.Principal {
+func principalAny() *envoy_rbac.Principal {
 	return &envoy_rbac.Principal{
 		Identifier: &envoy_rbac.Principal_Any{
-			Any: any,
+			Any: true,
 		},
 	}
 }

--- a/pilot/pkg/security/authz/policy/policy.go
+++ b/pilot/pkg/security/authz/policy/policy.go
@@ -16,32 +16,8 @@ package policy
 
 import (
 	envoyRbacHttpPb "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/rbac/v2"
-	envoyRbacPb "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v2"
 )
 
 type Generator interface {
 	Generate(forTCPFilter bool) (denyConfig *envoyRbacHttpPb.RBAC, allowConfig *envoyRbacHttpPb.RBAC)
-}
-
-// DefaultDenyAllConfig returns a default RBAC filter config that denies all requests.
-func DefaultDenyAllConfig(name string) *envoyRbacHttpPb.RBAC {
-	return &envoyRbacHttpPb.RBAC{
-		Rules: &envoyRbacPb.RBAC{
-			Action: envoyRbacPb.RBAC_DENY,
-			Policies: map[string]*envoyRbacPb.Policy{
-				name: {
-					Permissions: []*envoyRbacPb.Permission{
-						{
-							Rule: &envoyRbacPb.Permission_Any{Any: true},
-						},
-					},
-					Principals: []*envoyRbacPb.Principal{
-						{
-							Identifier: &envoyRbacPb.Principal_Any{Any: true},
-						},
-					},
-				},
-			},
-		},
-	}
 }

--- a/pilot/pkg/security/authz/policy/v1alpha1/v1alpha1.go
+++ b/pilot/pkg/security/authz/policy/v1alpha1/v1alpha1.go
@@ -115,5 +115,5 @@ func (g *v1alpha1Generator) generatePolicy(trustDomainBundle trustdomain.Bundle,
 	}
 
 	m := authz_model.NewModelV1alpha1(trustDomainBundle, role, bindings)
-	return m.Generate(g.serviceMetadata, forTCPFilter)
+	return m.Generate(g.serviceMetadata, forTCPFilter, false)
 }

--- a/pilot/pkg/security/authz/policy/v1alpha1/v1alpha1.go
+++ b/pilot/pkg/security/authz/policy/v1alpha1/v1alpha1.go
@@ -115,5 +115,5 @@ func (g *v1alpha1Generator) generatePolicy(trustDomainBundle trustdomain.Bundle,
 	}
 
 	m := authz_model.NewModelV1alpha1(trustDomainBundle, role, bindings)
-	return m.Generate(g.serviceMetadata, forTCPFilter, false)
+	return m.Generate(g.serviceMetadata, forTCPFilter, false /* forDenyPolicy */)
 }

--- a/tests/integration/security/rbac_v1beta1_test.go
+++ b/tests/integration/security/rbac_v1beta1_test.go
@@ -752,7 +752,7 @@ func TestV1beta1_TCP(t *testing.T) {
 				// The policy on workload b denies request with path "/data" to port 8090:
 				// - request to port http-8090 should be denied because both path and port are matched.
 				// - request to port http-8091 should be allowed because the port is not matched.
-				// - request to port tcp should be denied because the port is not matched.
+				// - request to port tcp should be allowed because the port is not matched.
 				newTestCase(a, b, "http-8090", false),
 				newTestCase(a, b, "http-8091", true),
 				newTestCase(a, b, "tcp", true),

--- a/tests/integration/security/rbac_v1beta1_test.go
+++ b/tests/integration/security/rbac_v1beta1_test.go
@@ -671,7 +671,7 @@ func TestV1beta1_TCP(t *testing.T) {
 			g.ApplyConfigOrFail(t, nil, policy...)
 			defer g.DeleteConfigOrFail(t, nil, policy...)
 
-			var a, b, c, d, x echo.Instance
+			var a, b, c, d, e, x echo.Instance
 			ports := []echo.Port{
 				{
 					Name:         "http-8090",
@@ -723,6 +723,14 @@ func TestV1beta1_TCP(t *testing.T) {
 					Ports:          ports,
 					ServiceAccount: true,
 				}).
+				With(&e, echo.Config{
+					Namespace:      ns,
+					Galley:         g,
+					Pilot:          p,
+					Service:        "e",
+					Ports:          ports,
+					ServiceAccount: true,
+				}).
 				BuildOrFail(t)
 
 			newTestCase := func(from, target echo.Instance, port string, expectAllowed bool) rbacUtil.TestCase {
@@ -744,11 +752,10 @@ func TestV1beta1_TCP(t *testing.T) {
 				// The policy on workload b denies request with path "/data" to port 8090:
 				// - request to port http-8090 should be denied because both path and port are matched.
 				// - request to port http-8091 should be allowed because the port is not matched.
-				// - request to port tcp should be denied because a default deny-all policy should
-				//   be generated when HTTP field (i.e. path) is used on TCP port.
+				// - request to port tcp should be denied because the port is not matched.
 				newTestCase(a, b, "http-8090", false),
 				newTestCase(a, b, "http-8091", true),
-				newTestCase(a, b, "tcp", false),
+				newTestCase(a, b, "tcp", true),
 
 				// The policy on workload c denies request to port 8090:
 				// - request to port http-8090 should be denied because the port is matched.
@@ -769,6 +776,14 @@ func TestV1beta1_TCP(t *testing.T) {
 				newTestCase(c, d, "tcp", true),
 				newTestCase(x, a, "tcp", true),
 				newTestCase(x, d, "tcp", false),
+
+				// The policy on workload e denies request with path "/other":
+				// - request to port http-8090 should be allowed because the path is not matched.
+				// - request to port http-8091 should be allowed because the path is not matched.
+				// - request to port tcp should be denied because policy uses HTTP fields.
+				newTestCase(a, e, "http-8090", true),
+				newTestCase(a, e, "http-8091", true),
+				newTestCase(a, e, "tcp", false),
 			}
 
 			rbacUtil.RunRBACTest(t, cases)

--- a/tests/integration/security/testdata/rbac/v1beta1-tcp.yaml.tmpl
+++ b/tests/integration/security/testdata/rbac/v1beta1-tcp.yaml.tmpl
@@ -54,3 +54,21 @@ spec:
     - source:
         namespaces: ["{{ .Namespace2 }}"]
 ---
+
+# The following policy denies request with path "/other" for workload e
+
+apiVersion: "security.istio.io/v1beta1"
+kind: AuthorizationPolicy
+metadata:
+  name: policy-e-deny
+  namespace: "{{ .Namespace }}"
+spec:
+  selector:
+    matchLabels:
+      "app": "e"
+  action: DENY
+  rules:
+  - to:
+    - operation:
+        paths: ["/other"]
+---


### PR DESCRIPTION
Previously in https://github.com/istio/istio/pull/20442 we changed to generate a deny-all policy whenever HTTP fields are used for TCP filter in a deny policy for security consideration.

This is the most secure way but it may break some use cases when both HTTP and TCP filters are used in the same time. In this case, the user may want to have a deny policy only for the HTTP filter, however, we will still generate a deny-all config for the TCP filter as long as it uses any HTTP fields.

The better way is to generate a "downgraded" config that only uses the TCP fields from the deny policy for the TCP filter. This is okay for deny policy because it means the deny policy is denying more requests in this case. (For allow policy, the behavior is not changed in this case, it still rejects all requests)

For #19894