### PR TITLE
fix: namespace isolation for ClusterRole and ClusterRoleBinding of kiali

### DIFF
--- a/manifests/istio-telemetry/kiali/templates/clusterrole.yaml
+++ b/manifests/istio-telemetry/kiali/templates/clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kiali
+  name: kiali-{{ .Release.Namespace }}
   labels:
     app: kiali
     release: {{ .Release.Name }}
@@ -44,7 +44,7 @@ rules:
       - get
       - list
       - watch
-  - apiGroups: 
+  - apiGroups:
     - config.istio.io
     - networking.istio.io
     - authentication.istio.io
@@ -68,7 +68,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kiali-viewer
+  name: kiali-viewer-{{ .Release.Namespace }}
   labels:
     app: kiali
     release: {{ .Release.Name }}
@@ -111,7 +111,7 @@ rules:
       - get
       - list
       - watch
-  - apiGroups: 
+  - apiGroups:
     - config.istio.io
     - networking.istio.io
     - authentication.istio.io

--- a/manifests/istio-telemetry/kiali/templates/clusterrolebinding.yaml
+++ b/manifests/istio-telemetry/kiali/templates/clusterrolebinding.yaml
@@ -2,14 +2,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kiali
+  name: kiali-{{ .Release.Namespace }}
   labels:
     app: kiali
     release: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kiali
+  name: kiali-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: kiali-service-account
@@ -25,7 +25,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kiali-viewer
+  name: kiali-viewer-{{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
   name: kiali-service-account

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -38056,7 +38056,7 @@ func chartsIstioTelemetryKialiTemplates_affinityTpl() (*asset, error) {
 var _chartsIstioTelemetryKialiTemplatesClusterroleYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kiali
+  name: kiali-{{ .Release.Namespace }}
   labels:
     app: kiali
     release: {{ .Release.Name }}
@@ -38099,7 +38099,7 @@ rules:
       - get
       - list
       - watch
-  - apiGroups: 
+  - apiGroups:
     - config.istio.io
     - networking.istio.io
     - authentication.istio.io
@@ -38123,7 +38123,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kiali-viewer
+  name: kiali-viewer-{{ .Release.Namespace }}
   labels:
     app: kiali
     release: {{ .Release.Name }}
@@ -38166,7 +38166,7 @@ rules:
       - get
       - list
       - watch
-  - apiGroups: 
+  - apiGroups:
     - config.istio.io
     - networking.istio.io
     - authentication.istio.io
@@ -38204,14 +38204,14 @@ var _chartsIstioTelemetryKialiTemplatesClusterrolebindingYaml = []byte(`{{- if n
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kiali
+  name: kiali-{{ .Release.Namespace }}
   labels:
     app: kiali
     release: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kiali
+  name: kiali-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: kiali-service-account
@@ -38227,7 +38227,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kiali-viewer
+  name: kiali-viewer-{{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
   name: kiali-service-account


### PR DESCRIPTION
add namespace isolation for ClusterRole and ClusterRoleBinding of kiali so that multiple kiali can be installed.

This PR fixes #21751 