### PR TITLE
read root cert from PROV_CERT to support VM

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -561,6 +561,7 @@ var (
 				DisableReportCalls:  disableInternalTelemetry,
 				OutlierLogPath:      outlierLogPath,
 				PilotCertProvider:   pilotCertProvider,
+				OutputKeyCertToDir:  outputKeyCertToDir,
 			})
 
 			agent := envoy.NewAgent(envoyProxy, features.TerminationDrainDuration())

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -96,6 +96,7 @@ type Config struct {
 	DisableReportCalls  bool
 	OutlierLogPath      string
 	PilotCertProvider   string
+	OutputKeyCertToDir  string
 }
 
 // newTemplateParams creates a new template configuration for the given configuration.
@@ -126,6 +127,7 @@ func (cfg Config) toTemplateParams() (map[string]interface{}, error) {
 		option.ControlPlaneAuth(cfg.ControlPlaneAuth),
 		option.DisableReportCalls(cfg.DisableReportCalls),
 		option.PilotCertProvider(cfg.PilotCertProvider),
+		option.OutputKeyCertToDir(cfg.OutputKeyCertToDir),
 		option.OutlierLogPath(cfg.OutlierLogPath))
 
 	if cfg.STSPort > 0 {

--- a/pkg/bootstrap/option/instances.go
+++ b/pkg/bootstrap/option/instances.go
@@ -244,6 +244,10 @@ func PilotCertProvider(value string) Instance {
 	return newOption("pilot_cert_provider", value)
 }
 
+func OutputKeyCertToDir(value string) Instance {
+	return newOption("output_key_cert_to_dir", value)
+}
+
 func STSPort(value int) Instance {
 	return newOption("sts_port", value)
 }

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -62,6 +62,7 @@ type ProxyConfig struct {
 	DisableReportCalls  bool
 	OutlierLogPath      string
 	PilotCertProvider   string
+	OutputKeyCertToDir  string
 }
 
 // NewProxy creates an instance of the proxy control commands
@@ -170,6 +171,7 @@ func (e *envoy) Run(config interface{}, epoch int, abort <-chan error) error {
 			DisableReportCalls:  e.DisableReportCalls,
 			OutlierLogPath:      e.OutlierLogPath,
 			PilotCertProvider:   e.PilotCertProvider,
+			OutputKeyCertToDir:  e.OutputKeyCertToDir,
 		}).CreateFileForEpoch(epoch)
 		if err != nil {
 			log.Errora("Failed to generate bootstrap config: ", err)

--- a/tools/packaging/common/envoy_bootstrap_v2.json
+++ b/tools/packaging/common/envoy_bootstrap_v2.json
@@ -293,7 +293,10 @@
             ],
             "validation_context": {
               "trusted_ca": {
-                {{ if eq .pilot_cert_provider "kubernetes" }}
+                {{ if .output_key_cert_to_dir }}
+                {{ $combine := (printf "%s%s" .output_key_cert_to_dir "/root-cert.pem")}}
+                "filename": "{{ $combine }}"
+                {{ else if eq .pilot_cert_provider "kubernetes" }}
                 "filename": "./var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
                 {{ else if eq .pilot_cert_provider "istiod" }}
                 "filename": "./var/run/secrets/istio/root-cert.pem"


### PR DESCRIPTION
if we have `/etc/certs/root-cert.pem` on VM , we should use it directly instead of asking user to create folder like: `/var/run/secrets/istio/`.

This is to fix this.