### PR TITLE
Update the gen_istio_image_list script to reflect updates

### DIFF
--- a/tools/gen_istio_image_list.sh
+++ b/tools/gen_istio_image_list.sh
@@ -30,24 +30,31 @@ function get_istio_images() {
 
     while IFS= read -r line 
     do 
-       if [[ $line == DOCKER_TARGETS:=*\\ ]]
+       if [[ $line == DOCKER_TARGETS* ]]
        then
-           buff+=${line#DOCKER_TARGETS:=}
+           buff+=${line#DOCKER_TARGETS}
            continue_processing=1
        else
            if [ $continue_processing -eq 1 ]
            then
-              buff=${buff%\\}$line
-              break
+              if [[ $line == *\\ ]]
+              then
+                buff=${buff%\\}$line
+              else
+                buff=${buff%\\}$line
+                break
+              fi
            fi
        fi
     done < temp.file
 
     for repo in $buff; do
-       istio_component=${repo##docker.};
-       istio_repo=istio/$istio_component;
-       #istio_tag=$(get_latest_tag "$istio_repo")
-       echo docker.io/"$istio_repo":"${1}"
+       if [[ $repo == *docker.* ]]
+       then
+           istio_component=${repo##*docker.};
+           istio_repo=istio/$istio_component;
+           echo docker.io/"$istio_repo":"${1}"
+       fi
     done
 
     if [ -f temp.file ];


### PR DESCRIPTION
Made changes to the script file so that it reflects the changes to the DOCKER_TARGETS
target from `DOCKER_TARGETS:=` to `DOCKER_TARGETS ?= ` in 1.5.

Fixes: #21356