### PR TITLE
read root cert from PROV_CERT to support VM

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -47,6 +47,7 @@ import (
 	"istio.io/istio/pkg/jwt"
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/util/gogoprotomarshal"
+	citadel "istio.io/istio/security/pkg/nodeagent/caclient/providers/citadel"
 	stsserver "istio.io/istio/security/pkg/stsservice/server"
 	"istio.io/istio/security/pkg/stsservice/tokenmanager"
 	cleaniptables "istio.io/istio/tools/istio-clean-iptables/pkg/cmd"
@@ -296,6 +297,7 @@ var (
 				DisableReportCalls:  disableInternalTelemetry,
 				OutlierLogPath:      outlierLogPath,
 				PilotCertProvider:   pilotCertProvider,
+				ProvCert:            citadel.ProvCert,
 			})
 
 			agent := envoy.NewAgent(envoyProxy, features.TerminationDrainDuration())

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -94,6 +94,7 @@ type Config struct {
 	DisableReportCalls  bool
 	OutlierLogPath      string
 	PilotCertProvider   string
+	ProvCert            string
 }
 
 // newTemplateParams creates a new template configuration for the given configuration.
@@ -122,7 +123,8 @@ func (cfg Config) toTemplateParams() (map[string]interface{}, error) {
 		option.ControlPlaneAuth(cfg.ControlPlaneAuth),
 		option.DisableReportCalls(cfg.DisableReportCalls),
 		option.PilotCertProvider(cfg.PilotCertProvider),
-		option.OutlierLogPath(cfg.OutlierLogPath))
+		option.OutlierLogPath(cfg.OutlierLogPath),
+		option.ProvCert(cfg.ProvCert))
 
 	if cfg.STSPort > 0 {
 		opts = append(opts, option.STSEnabled(true),

--- a/pkg/bootstrap/option/instances.go
+++ b/pkg/bootstrap/option/instances.go
@@ -243,3 +243,7 @@ func STSPort(value int) Instance {
 func STSEnabled(value bool) Instance {
 	return newOption("sts", value)
 }
+
+func ProvCert(value string) Instance {
+	return newOption("provisioned_cert", value)
+}

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -60,6 +60,7 @@ type ProxyConfig struct {
 	DisableReportCalls  bool
 	OutlierLogPath      string
 	PilotCertProvider   string
+	ProvCert            string
 }
 
 // NewProxy creates an instance of the proxy control commands
@@ -166,6 +167,7 @@ func (e *envoy) Run(config interface{}, epoch int, abort <-chan error) error {
 			DisableReportCalls:  e.DisableReportCalls,
 			OutlierLogPath:      e.OutlierLogPath,
 			PilotCertProvider:   e.PilotCertProvider,
+			ProvCert:            e.ProvCert,
 		}).CreateFileForEpoch(epoch)
 		if err != nil {
 			log.Errora("Failed to generate bootstrap config: ", err)

--- a/pkg/test/framework/components/echo/docker/workload.go
+++ b/pkg/test/framework/components/echo/docker/workload.go
@@ -23,8 +23,6 @@ import (
 	"strings"
 	"time"
 
-	istio_agent "istio.io/istio/pkg/istio-agent"
-
 	envoyAdmin "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/google/uuid"
@@ -141,6 +139,7 @@ func newWorkload(e *native.Environment, cfg echo.Config, dumpDir string) (out *w
 
 		metaJSONLabels := fmt.Sprintf("{\"app\":\"%s\"}", cfg.Service)
 		interceptionMode := "REDIRECT"
+		prop_cert := "./etc/certs"
 
 		env = append(env,
 			"ECHO_ARGS="+strings.Join(echoArgs, " "),
@@ -151,7 +150,7 @@ func newWorkload(e *native.Environment, cfg echo.Config, dumpDir string) (out *w
 			"POD_NAMESPACE="+cfg.Namespace.Name(),
 			"PILOT_ADDRESS="+pilotAddress,
 			"CA_ADDR="+pilotAddress,
-			"PROV_CERT=./etc/certs",
+			"PROV_CERT="+prop_cert,
 			"ENVOY_PORT=15001",
 			"ENVOY_USER=istio-proxy",
 			"ISTIO_AGENT_FLAGS="+agentArgs,

--- a/pkg/test/framework/components/echo/docker/workload.go
+++ b/pkg/test/framework/components/echo/docker/workload.go
@@ -151,7 +151,7 @@ func newWorkload(e *native.Environment, cfg echo.Config, dumpDir string) (out *w
 			"POD_NAMESPACE="+cfg.Namespace.Name(),
 			"PILOT_ADDRESS="+pilotAddress,
 			"CA_ADDR="+pilotAddress,
-			"PROV_CERT="+"./etc/certs",
+			"PROV_CERT=./etc/certs",
 			"ENVOY_PORT=15001",
 			"ENVOY_USER=istio-proxy",
 			"ISTIO_AGENT_FLAGS="+agentArgs,

--- a/pkg/test/framework/components/echo/docker/workload.go
+++ b/pkg/test/framework/components/echo/docker/workload.go
@@ -151,7 +151,7 @@ func newWorkload(e *native.Environment, cfg echo.Config, dumpDir string) (out *w
 			"POD_NAMESPACE="+cfg.Namespace.Name(),
 			"PILOT_ADDRESS="+pilotAddress,
 			"CA_ADDR="+pilotAddress,
-			"PROV_CERT="+istio_agent.CitadelCACertPath,
+			"PROV_CERT="+"./etc/certs",
 			"ENVOY_PORT=15001",
 			"ENVOY_USER=istio-proxy",
 			"ISTIO_AGENT_FLAGS="+agentArgs,

--- a/pkg/test/framework/components/echo/docker/workload.go
+++ b/pkg/test/framework/components/echo/docker/workload.go
@@ -139,7 +139,7 @@ func newWorkload(e *native.Environment, cfg echo.Config, dumpDir string) (out *w
 
 		metaJSONLabels := fmt.Sprintf("{\"app\":\"%s\"}", cfg.Service)
 		interceptionMode := "REDIRECT"
-		propCert := "./etc/certs"
+		propCert := "./var/lib/istio/default"
 
 		env = append(env,
 			"ECHO_ARGS="+strings.Join(echoArgs, " "),

--- a/pkg/test/framework/components/echo/docker/workload.go
+++ b/pkg/test/framework/components/echo/docker/workload.go
@@ -139,7 +139,7 @@ func newWorkload(e *native.Environment, cfg echo.Config, dumpDir string) (out *w
 
 		metaJSONLabels := fmt.Sprintf("{\"app\":\"%s\"}", cfg.Service)
 		interceptionMode := "REDIRECT"
-		prop_cert := "./etc/certs"
+		propCert := "./etc/certs"
 
 		env = append(env,
 			"ECHO_ARGS="+strings.Join(echoArgs, " "),
@@ -150,7 +150,7 @@ func newWorkload(e *native.Environment, cfg echo.Config, dumpDir string) (out *w
 			"POD_NAMESPACE="+cfg.Namespace.Name(),
 			"PILOT_ADDRESS="+pilotAddress,
 			"CA_ADDR="+pilotAddress,
-			"PROV_CERT="+prop_cert,
+			"PROV_CERT="+propCert,
 			"ENVOY_PORT=15001",
 			"ENVOY_USER=istio-proxy",
 			"ISTIO_AGENT_FLAGS="+agentArgs,

--- a/tools/packaging/common/envoy_bootstrap_v2.json
+++ b/tools/packaging/common/envoy_bootstrap_v2.json
@@ -334,7 +334,7 @@
               "validation_context": {
                 "trusted_ca": {
                   {{- if .provisioned_cert }}
-                  "filename": {{(printf "%s%s" .provisioned_cert "/root-cert.pem") }}
+                  "filename": "{{(printf "%s%s" .provisioned_cert "/root-cert.pem") }}"
                   {{- else if eq .pilot_cert_provider "kubernetes" }}
                   "filename": "./var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
                   {{- else if eq .pilot_cert_provider "istiod" }}

--- a/tools/packaging/common/envoy_bootstrap_v2.json
+++ b/tools/packaging/common/envoy_bootstrap_v2.json
@@ -333,7 +333,9 @@
               ],
               "validation_context": {
                 "trusted_ca": {
-                  {{- if eq .pilot_cert_provider "kubernetes" }}
+                  {{- if .provisioned_cert }}
+                  "filename": {{(printf "%s%s" .provisioned_cert "/root-cert.pem") }}
+                  {{- else if eq .pilot_cert_provider "kubernetes" }}
                   "filename": "./var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
                   {{- else if eq .pilot_cert_provider "istiod" }}
                   "filename": "./var/run/secrets/istio/root-cert.pem"


### PR DESCRIPTION
This flag is currently used only for VMs.  You can define the provided-cert via `PROV_CERT=/etc/certs` in sidecar.env to plugin the root cert , cert chain and private key for VM. 
Otherwise you must have root cert specified in `/var/run/secrets/istio/root-cert.pem`