### PR TITLE
[r1.5] revert #21618: remove beginreconcile listener for statusupdater

### DIFF
--- a/operator/pkg/controller/istiocontrolplane/listeners.go
+++ b/operator/pkg/controller/istiocontrolplane/listeners.go
@@ -79,30 +79,6 @@ func NewIstioStatusUpdater(instance *iop.IstioOperator) helmreconciler.Rendering
 	}
 }
 
-// BeginReconcile updates the status field on the IstioOperator instance before reconciling.
-func (u *IstioStatusUpdater) BeginReconcile(_ runtime.Object) error {
-	isop := &iop.IstioOperator{}
-	namespacedName := types.NamespacedName{
-		Name:      u.instance.Name,
-		Namespace: u.instance.Namespace,
-	}
-	if err := u.reconciler.GetClient().Get(context.TODO(), namespacedName, isop); err != nil {
-		return fmt.Errorf("failed to get IstioOperator before updating status due to %v", err)
-	}
-	if isop.Status == nil {
-		isop.Status = &v1alpha1.InstallStatus{Status: v1alpha1.InstallStatus_RECONCILING}
-	} else {
-		cs := isop.Status.ComponentStatus
-		for cn := range cs {
-			cs[cn] = &v1alpha1.InstallStatus_VersionStatus{
-				Status: v1alpha1.InstallStatus_RECONCILING,
-			}
-		}
-		isop.Status.Status = v1alpha1.InstallStatus_RECONCILING
-	}
-	return u.reconciler.GetClient().Status().Update(context.TODO(), isop)
-}
-
 // EndReconcile updates the status field on the IstioOperator instance based on the resulting err parameter.
 func (u *IstioStatusUpdater) EndReconcile(_ runtime.Object, status *v1alpha1.InstallStatus) error {
 	iop := &iop.IstioOperator{}


### PR DESCRIPTION
revert https://github.com/istio/istio/pull/21618 for release 1.5, since we need to add predicate as well for it to work: https://github.com/istio/istio/pull/21745, which considered to be risky at this stage. 
