### PR TITLE
Drop down negative test timeout for mtls healthcheck

### DIFF
--- a/tests/integration/security/mtls_healthcheck_test.go
+++ b/tests/integration/security/mtls_healthcheck_test.go
@@ -89,7 +89,7 @@ spec:
 	}
 	// Negative test, we expect the health check fails, so set a timeout duration.
 	if !rewrite {
-		cfg.ReadinessTimeout = time.Second * 40
+		cfg.ReadinessTimeout = time.Second * 15
 	}
 	err := echoboot.NewBuilderOrFail(t, ctx).
 		With(&healthcheck, cfg).


### PR DESCRIPTION
Pods typically get ready within ~5s. I think we still get 99% of the
coverage and can save some time by dropping this down a bit. This will
help bring the overal test time down.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
