### PR TITLE
Add support for GatewayClass

### DIFF
--- a/pilot/pkg/config/kube/gateway/conversion_test.go
+++ b/pilot/pkg/config/kube/gateway/conversion_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestConvertResources(t *testing.T) {
-	cases := []string{"simple"}
+	cases := []string{"simple", "mismatch"}
 	for _, tt := range cases {
 		t.Run(tt, func(t *testing.T) {
 			input := readConfig(t, fmt.Sprintf("testdata/%s.yaml", tt))
@@ -53,7 +53,10 @@ func TestConvertResources(t *testing.T) {
 }
 
 func splitOutput(configs []model.Config) IstioResources {
-	out := IstioResources{}
+	out := IstioResources{
+		Gateway:        []model.Config{},
+		VirtualService: []model.Config{},
+	}
 	for _, c := range configs {
 		switch c.GroupVersionKind() {
 		case gatewayType.GroupVersionKind():

--- a/pilot/pkg/config/kube/gateway/testdata/mismatch.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/mismatch.yaml
@@ -1,0 +1,17 @@
+# Mismatch shows that we don't generate config for Gateways that do not match the GatewayClass
+apiVersion: networking.x.k8s.io/v1alpha1
+kind: GatewayClass
+metadata:
+  name: istio
+spec:
+  controller: istio.io/gateway-controller
+---
+apiVersion: networking.x.k8s.io/v1alpha1
+kind: Gateway
+metadata:
+  name: gateway
+  namespace: istio-system
+spec:
+  class: something-else
+  listeners: []
+  routes: []

--- a/pilot/pkg/config/kube/gateway/testdata/simple.yaml
+++ b/pilot/pkg/config/kube/gateway/testdata/simple.yaml
@@ -11,7 +11,7 @@ metadata:
   name: gateway
   namespace: istio-system
 spec:
-  class: gatewayclass
+  class: istio
   listeners:
   - name: primary
     address:


### PR DESCRIPTION
Previously we just ignored this CRD. This adds support for properly
selecting only applicable gateways.