### PR TITLE
update operator init to use dev image.

### DIFF
--- a/operator/README.md
+++ b/operator/README.md
@@ -102,7 +102,8 @@ the file deploy/operator.yaml to point to your docker hub:
 Install the controller manifest and example IstioOperator CR:
 
 ```bash
-istioctl operator init
+istioctl operator init --hub docker.io/<your-account> --tag latest
+kubectl create ns istio-system
 kubectl apply -f operator/deploy/crds/istio_v1alpha1_istiooperator_cr.yaml
 ```
 


### PR DESCRIPTION
- fix `istio operator init` doc to use customized image build in last step
- create `istio-system` namespace before applying the operator CR


[ ] Configuration Infrastructure
[ X ] Docs
[ X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure