### PR TITLE
virtualhost: remove wrong comment

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -477,7 +477,6 @@ func getUniqueAndSharedDNSDomain(fqdnHostname, proxyDomain string) (string, stri
 }
 
 func buildCatchAllVirtualHost(node *model.Proxy) *route.VirtualHost {
-	// This needs to be the last virtual host, as routes are evaluated in order.
 	if util.IsAllowAnyOutbound(node) {
 		egressCluster := util.PassthroughCluster
 		notimeout := ptypes.DurationProto(0)

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -669,6 +669,7 @@ func (s *DiscoveryServer) configDump(conn *XdsConnection) (*adminapi.ConfigDump,
 			return nil, err
 		}
 		dynamicActiveListeners = append(dynamicActiveListeners, &adminapi.ListenersConfigDump_DynamicListener{
+			Name:        cs.Name,
 			ActiveState: &adminapi.ListenersConfigDump_DynamicListenerState{Listener: listener}})
 	}
 	listenersAny, err := util.MessageToAnyWithError(&adminapi.ListenersConfigDump{


### PR DESCRIPTION

The vhosts orders does not matter, https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route_components.proto.html?highlight=virtualhosts#
```
Domain search order:
Exact domain names: www.foo.com.

Suffix domain wildcards: *.foo.com or *-bar.foo.com.

Prefix domain wildcards: foo.* or foo-*.

Special wildcard * matching any domain.
```