### PR TITLE
Properly return errors in updateContext

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -887,7 +887,7 @@ func (ps *PushContext) InitContext(env *Environment, oldPushContext *PushContext
 		}
 	} else {
 		if err := ps.updateContext(env, oldPushContext, pushReq); err != nil {
-			return nil
+			return err
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/21816

root cause: if any of the `initXYZ` functions fail, we continue, which leads to a partial initialized push context