### PR TITLE
Read gcp info from env var GCP_METADATA

### DIFF
--- a/pkg/bootstrap/platform/gcp.go
+++ b/pkg/bootstrap/platform/gcp.go
@@ -17,9 +17,12 @@ package platform
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"cloud.google.com/go/compute/metadata"
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+
+	"istio.io/pkg/env"
 
 	"istio.io/pkg/log"
 )
@@ -30,6 +33,10 @@ const (
 	GCPCluster       = "gcp_gke_cluster_name"
 	GCPLocation      = "gcp_location"
 	GCEInstanceID    = "gcp_gce_instance_id"
+)
+
+var (
+	gcpMetadataVar = env.RegisterStringVar("GCP_METADATA", "", "Pipe separted GCP metadata, schemed as PROJECT_ID|PROJECT_NUMBER|CLUSTER_NAME|CLUSTER_ZONE")
 )
 
 var (
@@ -63,6 +70,10 @@ type gcpEnv struct {
 
 // IsGCP returns whether or not the platform for bootstrapping is Google Cloud Platform.
 func IsGCP() bool {
+	if gcpMetadataVar.Get() != "" {
+		// Assume this is running on GCP if GCP project env variable is set.
+		return true
+	}
 	return metadata.OnGCE()
 }
 
@@ -87,25 +98,44 @@ func (e *gcpEnv) Metadata() map[string]string {
 	if e == nil {
 		return md
 	}
-	if !e.shouldFillMetadata() {
+	if gcpMetadataVar.Get() == "" && !e.shouldFillMetadata() {
 		return md
 	}
-	if pid, err := e.projectIDFn(); err == nil {
+	envPid, envNPid, envCN, envLoc := parseGCPMetadata()
+	if envPid != "" {
+		md[GCPProject] = envPid
+	} else if pid, err := e.projectIDFn(); err == nil {
 		md[GCPProject] = pid
 	}
-	if npid, err := e.numericProjectIDFn(); err == nil {
+	if envNPid != "" {
+		md[GCPProjectNumber] = envNPid
+	} else if npid, err := e.numericProjectIDFn(); err == nil {
 		md[GCPProjectNumber] = npid
 	}
-	if l, err := e.locationFn(); err == nil {
+	if envLoc != "" {
+		md[GCPLocation] = envLoc
+	} else if l, err := e.locationFn(); err == nil {
 		md[GCPLocation] = l
 	}
-	if cn, err := e.clusterNameFn(); err == nil {
+	if envCN != "" {
+		md[GCPCluster] = envCN
+	} else if cn, err := e.clusterNameFn(); err == nil {
 		md[GCPCluster] = cn
 	}
 	if id, err := e.instanceIDFn(); err == nil {
 		md[GCEInstanceID] = id
 	}
 	return md
+}
+
+func parseGCPMetadata() (pid, npid, cluster, location string) {
+	gcpmd := gcpMetadataVar.Get()
+	log.Infof("Extract GCP metadata from env variable GCP_METADATA: %v", gcpmd)
+	parts := strings.Split(gcpmd, "|")
+	if len(parts) != 4 {
+		return
+	}
+	return parts[0], parts[1], parts[2], parts[3]
 }
 
 // Converts a GCP zone into a region.


### PR DESCRIPTION
STS server and proxy filter needs GCP metadata during bootstrap. Add a flag that supports passing GCP metadata by customer.

https://github.com/istio/istio/issues/20133
https://github.com/istio/istio/issues/21904