### PR TITLE
"istioctl x describe" output grammar fix

### DIFF
--- a/istioctl/cmd/describe_test.go
+++ b/istioctl/cmd/describe_test.go
@@ -668,7 +668,7 @@ func TestDescribeAutoMTLS(t *testing.T) {
 --------------------
 Service: productpage
    Port:  9080/auto-detect targets pod port 9080
-Pod is STRICT, clients configured automatically
+Pod is Strict mTLS, clients configured automatically
 
 
 Exposed on Ingress Gateway http://10.1.2.3:0
@@ -685,7 +685,7 @@ VirtualService: bookinfo
 			args:             strings.Split("x describe svc productpage", " "),
 			expectedOutput: `Service: productpage
    Port:  9080/auto-detect targets pod port 9080
-Pod is STRICT, clients configured automatically
+Pod is Strict mTLS, clients configured automatically
 
 
 Exposed on Ingress Gateway http://10.1.2.3:0


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/21711

Does not address https://github.com/istio/istio/issues/21821 .  This PR is just about the messages output when displaying client vs server TLS settings based on response from 1.5.0 Istiod /debug/authenticationz