### PR TITLE
Fix flaky tests

### DIFF
--- a/security/pkg/stsservice/test/proxy_cached_sts_token/proxy_cached_token_test.go
+++ b/security/pkg/stsservice/test/proxy_cached_sts_token/proxy_cached_token_test.go
@@ -16,6 +16,7 @@ package proxycachedststoken
 
 import (
 	"testing"
+	"time"
 
 	"github.com/onsi/gomega"
 
@@ -48,10 +49,10 @@ func TestProxyCachedToken(t *testing.T) {
 	initialNumFederatedTokenCall := setup.AuthServer.NumGetFederatedTokenCalls()
 	initialNumAccessTokenCall := setup.AuthServer.NumGetAccessTokenCalls()
 	setup.StartProxy(t)
-	setup.ProxySetup.WaitEnvoyReady()
 	// Verify that proxy re-connects XDS server after each stream close, and the
 	// same token is received.
-	g.Expect(cb.NumStream()).To(gomega.Equal(numCloseStream + 1))
+	gomega.SetDefaultEventuallyTimeout(10 * time.Second)
+	g.Eventually(func() int { return cb.NumStream() }).Should(gomega.Equal(numCloseStream + 1))
 	g.Expect(cb.NumTokenReceived()).To(gomega.Equal(1))
 	// Verify there is only one extra call for each token.
 	g.Expect(setup.AuthServer.NumGetFederatedTokenCalls()).To(gomega.Equal(initialNumFederatedTokenCall + 1))

--- a/security/pkg/stsservice/test/proxy_cached_sts_token/proxy_cached_token_test.go
+++ b/security/pkg/stsservice/test/proxy_cached_sts_token/proxy_cached_token_test.go
@@ -52,7 +52,7 @@ func TestProxyCachedToken(t *testing.T) {
 	// Verify that proxy re-connects XDS server after each stream close, and the
 	// same token is received.
 	gomega.SetDefaultEventuallyTimeout(10 * time.Second)
-	g.Eventually(func() int { return cb.NumStream() }).Should(gomega.Equal(numCloseStream + 1))
+	g.Eventually(func() int { return cb.NumStream() }).Should(gomega.Equal(numCloseStream + 1)) // nolint:gocritic
 	g.Expect(cb.NumTokenReceived()).To(gomega.Equal(1))
 	// Verify there is only one extra call for each token.
 	g.Expect(setup.AuthServer.NumGetFederatedTokenCalls()).To(gomega.Equal(initialNumFederatedTokenCall + 1))

--- a/security/pkg/stsservice/test/renew_sts_token/renew_token_test.go
+++ b/security/pkg/stsservice/test/renew_sts_token/renew_token_test.go
@@ -16,6 +16,7 @@ package renewststoken
 
 import (
 	"testing"
+	"time"
 
 	"github.com/onsi/gomega"
 
@@ -53,7 +54,8 @@ func TestRenewToken(t *testing.T) {
 	setup.ProxySetup.WaitEnvoyReady()
 	// Verify that proxy re-connects XDS server after each stream close, and a
 	// different token is received.
-	g.Expect(cb.NumStream()).To(gomega.Equal(numCloseStream + 1))
+	gomega.SetDefaultEventuallyTimeout(10 * time.Second)
+	g.Eventually(func() int { return cb.NumStream() }).Should(gomega.Equal(numCloseStream + 1))
 	g.Expect(cb.NumTokenReceived()).To(gomega.Equal(numCloseStream + 1))
 	// Verify every time proxy reconnects to XDS server, gRPC STS fetches a new token.
 	g.Expect(setup.AuthServer.NumGetFederatedTokenCalls()).To(gomega.Equal(initialNumFederatedTokenCall + numCloseStream + 1))

--- a/security/pkg/stsservice/test/renew_sts_token/renew_token_test.go
+++ b/security/pkg/stsservice/test/renew_sts_token/renew_token_test.go
@@ -55,7 +55,7 @@ func TestRenewToken(t *testing.T) {
 	// Verify that proxy re-connects XDS server after each stream close, and a
 	// different token is received.
 	gomega.SetDefaultEventuallyTimeout(10 * time.Second)
-	g.Eventually(func() int { return cb.NumStream() }).Should(gomega.Equal(numCloseStream + 1))
+	g.Eventually(func() int { return cb.NumStream() }).Should(gomega.Equal(numCloseStream + 1)) // nolint:gocritic
 	g.Expect(cb.NumTokenReceived()).To(gomega.Equal(numCloseStream + 1))
 	// Verify every time proxy reconnects to XDS server, gRPC STS fetches a new token.
 	g.Expect(setup.AuthServer.NumGetFederatedTokenCalls()).To(gomega.Equal(initialNumFederatedTokenCall + numCloseStream + 1))


### PR DESCRIPTION
The test force the XDS streams to close, which could delay Envoy bootstrap. Moving this logic out of initial stream to let Envoy finish initialization. 


https://github.com/istio/istio/issues/21684
https://github.com/istio/istio/issues/21626