### PR TITLE
make multicluster secret controller handle updates

### DIFF
--- a/mixer/adapter/kubernetesenv/kubernetesenv.go
+++ b/mixer/adapter/kubernetesenv/kubernetesenv.go
@@ -388,6 +388,13 @@ func (b *builder) createCacheController(k8sInterface k8s.Interface, clusterID st
 	return b.kubeHandler.env.Logger().Errorf("error on creating remote controller %s err = %v", clusterID, err)
 }
 
+func (b *builder) updateCacheController(k8sInterface k8s.Interface, clusterID string) error {
+	if err := b.deleteCacheController(clusterID); err != nil {
+		return err
+	}
+	return b.createCacheController(k8sInterface, clusterID)
+}
+
 func (b *builder) deleteCacheController(clusterID string) error {
 	b.Lock()
 	delete(b.controllers, clusterID)
@@ -418,7 +425,8 @@ func initMultiClusterSecretController(b *builder, kubeconfig string, env adapter
 		return fmt.Errorf("could not create K8s client: %v", err)
 	}
 
-	err = secretcontroller.StartSecretController(kubeClient, b.createCacheController, b.deleteCacheController, clusterNs)
+	err = secretcontroller.StartSecretController(kubeClient, b.createCacheController,
+		b.updateCacheController, b.deleteCacheController, clusterNs)
 	if err != nil {
 		return fmt.Errorf("could not start secret controller: %v", err)
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -72,6 +72,7 @@ func NewMulticluster(kc kubernetes.Interface, secretNamespace string,
 
 	err := secretcontroller.StartSecretController(kc,
 		mc.AddMemberCluster,
+		mc.UpdateMemberCluster,
 		mc.DeleteMemberCluster,
 		secretNamespace)
 	return mc, err
@@ -105,6 +106,13 @@ func (m *Multicluster) AddMemberCluster(clientset kubernetes.Interface, clusterI
 	_ = kubectl.AppendInstanceHandler(func(*model.ServiceInstance, model.Event) { m.updateHandler() })
 	go kubectl.Run(stopCh)
 	return nil
+}
+
+func (m *Multicluster) UpdateMemberCluster(clientset kubernetes.Interface, clusterID string) error {
+	if err := m.DeleteMemberCluster(clusterID); err != nil {
+		return err
+	}
+	return m.AddMemberCluster(clientset, clusterID)
 }
 
 // DeleteMemberCluster is passed to the secret controller as a callback to be called

--- a/pkg/kube/secretcontroller/secretcontroller.go
+++ b/pkg/kube/secretcontroller/secretcontroller.go
@@ -15,7 +15,11 @@
 package secretcontroller
 
 import (
+	"bytes"
+	"crypto/sha256"
+	"errors"
 	"fmt"
+	"reflect"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -52,6 +56,9 @@ var CreateInterfaceFromClusterConfig = kube.CreateInterfaceFromClusterConfig
 // addSecretCallback prototype for the add secret callback function.
 type addSecretCallback func(clientset kubernetes.Interface, dataKey string) error
 
+// updateSecretCallback prototype for the update secret callback function.
+type updateSecretCallback func(clientset kubernetes.Interface, dataKey string) error
+
 // removeSecretCallback prototype for the remove secret callback function.
 type removeSecretCallback func(dataKey string) error
 
@@ -63,12 +70,15 @@ type Controller struct {
 	queue          workqueue.RateLimitingInterface
 	informer       cache.SharedIndexInformer
 	addCallback    addSecretCallback
+	updateCallback updateSecretCallback
 	removeCallback removeSecretCallback
 }
 
 // RemoteCluster defines cluster structZZ
 type RemoteCluster struct {
-	secretName string
+	secretName    string
+	client        kubernetes.Interface
+	kubeConfigSha [sha256.Size]byte
 }
 
 // ClusterStore is a collection of clusters
@@ -90,6 +100,7 @@ func NewController(
 	namespace string,
 	cs *ClusterStore,
 	addCallback addSecretCallback,
+	updateCallback updateSecretCallback,
 	removeCallback removeSecretCallback) *Controller {
 
 	secretsInformer := cache.NewSharedIndexInformer(
@@ -115,6 +126,7 @@ func NewController(
 		informer:       secretsInformer,
 		queue:          queue,
 		addCallback:    addCallback,
+		updateCallback: updateCallback,
 		removeCallback: removeCallback,
 	}
 
@@ -123,6 +135,17 @@ func NewController(
 		AddFunc: func(obj interface{}) {
 			key, err := cache.MetaNamespaceKeyFunc(obj)
 			log.Infof("Processing add: %s", key)
+			if err == nil {
+				queue.Add(key)
+			}
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			if oldObj == newObj || reflect.DeepEqual(oldObj, newObj) {
+				return
+			}
+
+			key, err := cache.MetaNamespaceKeyFunc(newObj)
+			log.Infof("Processing update: %s", key)
 			if err == nil {
 				queue.Add(key)
 			}
@@ -160,11 +183,12 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 // StartSecretController creates the secret controller.
 func StartSecretController(k8s kubernetes.Interface,
 	addCallback addSecretCallback,
+	updateCallback updateSecretCallback,
 	removeCallback removeSecretCallback,
 	namespace string) error {
 	stopCh := make(chan struct{})
 	clusterStore := newClustersStore()
-	controller := NewController(k8s, namespace, clusterStore, addCallback, removeCallback)
+	controller := NewController(k8s, namespace, clusterStore, addCallback, updateCallback, removeCallback)
 
 	go controller.Run(stopCh)
 
@@ -215,56 +239,89 @@ func (c *Controller) processItem(secretName string) error {
 	return nil
 }
 
+func createRemoteCluster(kubeConfig []byte, secretName string) (*RemoteCluster, error) {
+	if len(kubeConfig) == 0 {
+		return nil, errors.New("kubeconfig is empty")
+	}
+
+	clientConfig, err := LoadKubeConfig(kubeConfig)
+	if err != nil {
+		return nil, fmt.Errorf("kubeconfig cannot be loaded: %v", err)
+	}
+
+	if err := ValidateClientConfig(*clientConfig); err != nil {
+		return nil, fmt.Errorf("kubeconfig is not valid: %v", err)
+	}
+
+	client, err := CreateInterfaceFromClusterConfig(clientConfig)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create client interface: %v", err)
+	}
+
+	return &RemoteCluster{
+		secretName:    secretName,
+		client:        client,
+		kubeConfigSha: sha256.Sum256(kubeConfig),
+	}, nil
+}
+
 func (c *Controller) addMemberCluster(secretName string, s *corev1.Secret) {
 	for clusterID, kubeConfig := range s.Data {
 		// clusterID must be unique even across multiple secrets
-		if _, ok := c.cs.remoteClusters[clusterID]; !ok {
-			if len(kubeConfig) == 0 {
-				log.Infof("Data '%s' in the secret %s in namespace %s is empty, and disregarded ",
-					clusterID, secretName, s.Namespace)
+		if prev, ok := c.cs.remoteClusters[clusterID]; !ok {
+			log.Infof("Adding cluster_id=%v from secret=%v", clusterID, secretName)
+
+			remoteCluster, err := createRemoteCluster(kubeConfig, secretName)
+			if err != nil {
+				log.Errorf("Failed to add remote cluster from secret=%v for cluster_id=%v: %v",
+					secretName, clusterID, err)
 				continue
 			}
 
-			clientConfig, err := LoadKubeConfig(kubeConfig)
-			if err != nil {
-				log.Infof("Data '%s' in the secret %s in namespace %s is not a kubeconfig: %v",
-					clusterID, secretName, s.Namespace, err)
-				continue
-			}
-
-			if err := ValidateClientConfig(*clientConfig); err != nil {
-				log.Errorf("Data '%s' in the secret %s in namespace %s is not a valid kubeconfig: %v",
-					clusterID, secretName, s.Namespace, err)
-				continue
-			}
-
-			log.Infof("Adding new cluster member: %s", clusterID)
-			c.cs.remoteClusters[clusterID] = &RemoteCluster{}
-			c.cs.remoteClusters[clusterID].secretName = secretName
-			client, err := CreateInterfaceFromClusterConfig(clientConfig)
-			if err != nil {
-				log.Errorf("error during create of kubernetes client interface for cluster: %s %v", clusterID, err)
-				continue
-			}
-			err = c.addCallback(client, clusterID)
-			if err != nil {
-				log.Errorf("error during create of clusterID: %s %v", clusterID, err)
+			c.cs.remoteClusters[clusterID] = remoteCluster
+			if err := c.addCallback(remoteCluster.client, clusterID); err != nil {
+				log.Errorf("Error creating cluster_id=%s from secret %v: %v",
+					clusterID, secretName, err)
 			}
 		} else {
-			log.Infof("Cluster %s in the secret %s in namespace %s already exists",
-				clusterID, c.cs.remoteClusters[clusterID].secretName, s.Namespace)
+			if prev.secretName != secretName {
+				log.Errorf("ClusterID reused in two different secrets: %v and %v. ClusterID "+
+					"must be unique across all secrets", prev.secretName, secretName)
+				continue
+			}
+
+			kubeConfigSha := sha256.Sum256(kubeConfig)
+			if bytes.Equal(kubeConfigSha[:], prev.kubeConfigSha[:]) {
+				log.Infof("Updating cluster_id=%v from secret=%v: (kubeconfig are identical)", clusterID, secretName)
+			} else {
+				log.Infof("Updating cluster %v from secret %v", clusterID, secretName)
+
+				remoteCluster, err := createRemoteCluster(kubeConfig, secretName)
+				if err != nil {
+					log.Errorf("Error updating cluster_id=%v from secret=%v: %v",
+						clusterID, secretName, err)
+					continue
+				}
+				c.cs.remoteClusters[clusterID] = remoteCluster
+				if err := c.updateCallback(remoteCluster.client, clusterID); err != nil {
+					log.Errorf("Error updating cluster_id from secret=%v: %s %v",
+						clusterID, secretName, err)
+				}
+			}
 		}
 	}
+
 	log.Infof("Number of remote clusters: %d", len(c.cs.remoteClusters))
 }
 
 func (c *Controller) deleteMemberCluster(secretName string) {
 	for clusterID, cluster := range c.cs.remoteClusters {
 		if cluster.secretName == secretName {
-			log.Infof("Deleting cluster member: %s", clusterID)
+			log.Infof("Deleting cluster_id=%v configured by secret=%v", clusterID, secretName)
 			err := c.removeCallback(clusterID)
 			if err != nil {
-				log.Errorf("error during cluster delete: %s %v", clusterID, err)
+				log.Errorf("Error removing cluster_id=%v configured by secret=%v: %v",
+					clusterID, secretName, err)
 			}
 			delete(c.cs.remoteClusters, clusterID)
 		}

--- a/pkg/kube/secretcontroller/secretcontroller_test.go
+++ b/pkg/kube/secretcontroller/secretcontroller_test.go
@@ -15,60 +15,20 @@
 package secretcontroller
 
 import (
-	"sync/atomic"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
+	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-
-	pkgtest "istio.io/istio/pkg/test"
 )
 
-const secretName string = "testSecretName"
 const secretNamespace string = "istio-system"
-
-var testCreateControllerCalled int32
-var testDeleteControllerCalled int32
-
-func testCreateController(_ kubernetes.Interface, _ string) error {
-	atomic.StoreInt32(&testCreateControllerCalled, 1)
-	return nil
-}
-
-func testDeleteController(_ string) error {
-	atomic.StoreInt32(&testDeleteControllerCalled, 1)
-	return nil
-}
-
-func createMultiClusterSecret(k8s *fake.Clientset) error {
-	data := map[string][]byte{}
-	secret := v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      secretName,
-			Namespace: secretNamespace,
-			Labels: map[string]string{
-				MultiClusterSecretLabel: "true",
-			},
-		},
-		Data: map[string][]byte{},
-	}
-
-	data["testRemoteCluster"] = []byte("Test")
-	secret.Data = data
-	_, err := k8s.CoreV1().Secrets(secretNamespace).Create(&secret)
-	return err
-}
-
-func deleteMultiClusterSecret(k8s *fake.Clientset) error {
-	var immediate int64
-
-	return k8s.CoreV1().Secrets(secretNamespace).Delete(
-		secretName, &metav1.DeleteOptions{GracePeriodSeconds: &immediate})
-}
 
 func mockLoadKubeConfig(_ []byte) (*clientcmdapi.Config, error) {
 	return &clientcmdapi.Config{}, nil
@@ -82,59 +42,141 @@ func mockCreateInterfaceFromClusterConfig(_ *clientcmdapi.Config) (kubernetes.In
 	return fake.NewSimpleClientset(), nil
 }
 
-func verifyControllerDeleted(t *testing.T, timeoutName string) {
-	pkgtest.NewEventualOpts(10*time.Millisecond, 5*time.Second).Eventually(t, timeoutName, func() bool {
-		return atomic.LoadInt32(&testDeleteControllerCalled) == 1
-	})
+func makeSecret(secret, clusterID string, kubeconfig []byte) *v1.Secret {
+	return &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secret,
+			Namespace: secretNamespace,
+			Labels: map[string]string{
+				MultiClusterSecretLabel: "true",
+			},
+		},
+		Data: map[string][]byte{
+			clusterID: kubeconfig,
+		},
+	}
 }
 
-func verifyControllerCreated(t *testing.T, timeoutName string) {
-	pkgtest.NewEventualOpts(10*time.Millisecond, 5*time.Second).Eventually(t, timeoutName, func() bool {
-		return atomic.LoadInt32(&testCreateControllerCalled) == 1
-	})
+var (
+	mu      sync.Mutex
+	added   string
+	updated string
+	deleted string
+)
+
+func addCallback(_ kubernetes.Interface, id string) error {
+	mu.Lock()
+	defer mu.Unlock()
+	added = id
+	return nil
+}
+
+func updateCallback(_ kubernetes.Interface, id string) error {
+	mu.Lock()
+	defer mu.Unlock()
+	updated = id
+	return nil
+}
+func deleteCallback(id string) error {
+	mu.Lock()
+	defer mu.Unlock()
+	deleted = id
+	return nil
+}
+
+func resetCallbackData() {
+	added = ""
+	updated = ""
+	deleted = ""
 }
 
 func Test_SecretController(t *testing.T) {
+	g := NewWithT(t)
+
 	LoadKubeConfig = mockLoadKubeConfig
 	ValidateClientConfig = mockValidateClientConfig
 	CreateInterfaceFromClusterConfig = mockCreateInterfaceFromClusterConfig
 
 	clientset := fake.NewSimpleClientset()
 
-	// Start the secret controller and sleep to allow secret process to start.
-	err := StartSecretController(
-		clientset, testCreateController, testDeleteController, secretNamespace)
-	if err != nil {
-		t.Fatalf("Could not start secret controller: %v", err)
+	var (
+		secret0                        = makeSecret("s0", "c0", []byte("kubeconfig0-0"))
+		secret0UpdateKubeconfigChanged = makeSecret("s0", "c0", []byte("kubeconfig0-1"))
+		secret0UpdateKubeconfigSame    = makeSecret("s0", "c0", []byte("kubeconfig0-1"))
+		secret1                        = makeSecret("s1", "c1", []byte("kubeconfig1-0"))
+	)
+	secret0UpdateKubeconfigSame.Annotations = map[string]string{"foo": "bar"}
+
+	steps := []struct {
+		// only set one of these per step. The others should be nil.
+		add    *v1.Secret
+		update *v1.Secret
+		delete *v1.Secret
+
+		// only set one of these per step. The others should be empty.
+		wantAdded   string
+		wantUpdated string
+		wantDeleted string
+	}{
+		{add: secret0, wantAdded: "c0"},
+		{update: secret0UpdateKubeconfigChanged, wantUpdated: "c0"},
+		{update: secret0UpdateKubeconfigSame},
+		{add: secret1, wantAdded: "c1"},
+		{delete: secret0, wantDeleted: "c0"},
+		{delete: secret1, wantDeleted: "c1"},
 	}
+
+	// Start the secret controller and sleep to allow secret process to start.
+	g.Expect(
+		StartSecretController(clientset, addCallback, updateCallback, deleteCallback, secretNamespace)).
+		Should(Succeed())
+
 	time.Sleep(100 * time.Millisecond)
 
-	// Create the multicluster secret.
-	err = createMultiClusterSecret(clientset)
-	if err != nil {
-		t.Fatalf("Unexpected error on secret create: %v", err)
-	}
+	for i, step := range steps {
+		resetCallbackData()
 
-	verifyControllerCreated(t, "Create remote secret controller")
+		t.Run(fmt.Sprintf("[%v]", i), func(t *testing.T) {
+			g := NewWithT(t)
 
-	if atomic.LoadInt32(&testDeleteControllerCalled) == 1 {
-		t.Fatalf("Test failed on create secret, delete callback function called")
-	}
+			switch {
+			case step.add != nil:
+				_, err := clientset.CoreV1().Secrets(secretNamespace).Create(step.add)
+				g.Expect(err).Should(BeNil())
+			case step.update != nil:
+				_, err := clientset.CoreV1().Secrets(secretNamespace).Update(step.update)
+				g.Expect(err).Should(BeNil())
+			case step.delete != nil:
+				g.Expect(clientset.CoreV1().Secrets(secretNamespace).Delete(step.delete.Name, &metav1.DeleteOptions{})).
+					Should(Succeed())
+			}
 
-	// Reset test variables and delete the multicluster secret.
-	atomic.StoreInt32(&testCreateControllerCalled, 0)
-	atomic.StoreInt32(&testDeleteControllerCalled, 0)
-
-	err = deleteMultiClusterSecret(clientset)
-	if err != nil {
-		t.Fatalf("Unexpected error on secret delete: %v", err)
-	}
-
-	// Test - Verify that the remote controller has been removed.
-	verifyControllerDeleted(t, "delete remote secret controller")
-
-	// Test
-	if atomic.LoadInt32(&testCreateControllerCalled) == 1 {
-		t.Fatalf("Test failed on delete secret, create callback function called")
+			switch {
+			case step.wantAdded != "":
+				g.Eventually(func() string {
+					mu.Lock()
+					defer mu.Unlock()
+					return added
+				}).Should(Equal(step.wantAdded))
+			case step.wantUpdated != "":
+				g.Eventually(func() string {
+					mu.Lock()
+					defer mu.Unlock()
+					return updated
+				}).Should(Equal(step.wantUpdated))
+			case step.wantDeleted != "":
+				g.Eventually(func() string {
+					mu.Lock()
+					defer mu.Unlock()
+					return deleted
+				}).Should(Equal(step.wantDeleted))
+			default:
+				g.Consistently(func() bool {
+					mu.Lock()
+					defer mu.Unlock()
+					return added == "" && updated == "" && deleted == ""
+				}).Should(Equal(true))
+			}
+		})
 	}
 }

--- a/pkg/kube/secretcontroller/secretcontroller_test.go
+++ b/pkg/kube/secretcontroller/secretcontroller_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"sync"
 	"testing"
-	"time"
 
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -130,8 +129,6 @@ func Test_SecretController(t *testing.T) {
 	g.Expect(
 		StartSecretController(clientset, addCallback, updateCallback, deleteCallback, secretNamespace)).
 		Should(Succeed())
-
-	time.Sleep(100 * time.Millisecond)
 
 	for i, step := range steps {
 		resetCallbackData()


### PR DESCRIPTION
The multicluster secret controller was silently ignoring updates to
secrets. Users had to delete and re-add secrets if they wanted to
change the credentials for remote clusters. This PR adds update
support and also improves the unit tests.

fixes https://github.com/istio/istio/issues/18708
