### PR TITLE
Fix broken Prometheus cert provisioning on istio-1.5.0-beta.5

### DIFF
--- a/manifests/istio-telemetry/prometheus/templates/deployment.yaml
+++ b/manifests/istio-telemetry/prometheus/templates/deployment.yaml
@@ -132,7 +132,7 @@ spec:
               {{- end }}
             - --controlPlaneBootstrap=false
           env:
-            - name: OUTPUT_KEY_CERT_TO_DIRECTORY
+            - name: OUTPUT_CERTS
               value: "/etc/istio-certs"
             - name: JWT_POLICY
               value: {{ .Values.global.jwtPolicy }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.yaml
@@ -635,7 +635,7 @@ spec:
             - --trust-domain=cluster.local
             - --controlPlaneBootstrap=false
           env:
-            - name: OUTPUT_KEY_CERT_TO_DIRECTORY
+            - name: OUTPUT_CERTS
               value: "/etc/istio-certs"
             - name: JWT_POLICY
               value: third-party-jwt

--- a/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.yaml
@@ -392,7 +392,7 @@ spec:
             - --trust-domain=cluster.local
             - --controlPlaneBootstrap=false
           env:
-            - name: OUTPUT_KEY_CERT_TO_DIRECTORY
+            - name: OUTPUT_CERTS
               value: "/etc/istio-certs"
             - name: JWT_POLICY
               value: third-party-jwt

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.yaml
@@ -6146,7 +6146,7 @@ spec:
             - --trust-domain=cluster.local
             - --controlPlaneBootstrap=false
           env:
-            - name: OUTPUT_KEY_CERT_TO_DIRECTORY
+            - name: OUTPUT_CERTS
               value: "/etc/istio-certs"
             - name: JWT_POLICY
               value: third-party-jwt

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.yaml
@@ -392,7 +392,7 @@ spec:
             - --trust-domain=cluster.local
             - --controlPlaneBootstrap=false
           env:
-            - name: OUTPUT_KEY_CERT_TO_DIRECTORY
+            - name: OUTPUT_CERTS
               value: "/etc/istio-certs"
             - name: JWT_POLICY
               value: third-party-jwt

--- a/operator/cmd/mesh/testdata/manifest-generate/output/gateways_override_default.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/gateways_override_default.yaml
@@ -392,7 +392,7 @@ spec:
             - --trust-domain=cluster.local
             - --controlPlaneBootstrap=false
           env:
-            - name: OUTPUT_KEY_CERT_TO_DIRECTORY
+            - name: OUTPUT_CERTS
               value: "/etc/istio-certs"
             - name: JWT_POLICY
               value: third-party-jwt

--- a/operator/cmd/mesh/testdata/manifest-generate/output/prometheus.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/prometheus.yaml
@@ -392,7 +392,7 @@ spec:
             - --trust-domain=cluster.local
             - --controlPlaneBootstrap=false
           env:
-            - name: OUTPUT_KEY_CERT_TO_DIRECTORY
+            - name: OUTPUT_CERTS
               value: "/etc/istio-certs"
             - name: JWT_POLICY
               value: third-party-jwt

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -35624,7 +35624,7 @@ spec:
               {{- end }}
             - --controlPlaneBootstrap=false
           env:
-            - name: OUTPUT_KEY_CERT_TO_DIRECTORY
+            - name: OUTPUT_CERTS
               value: "/etc/istio-certs"
             - name: JWT_POLICY
               value: {{ .Values.global.jwtPolicy }}


### PR DESCRIPTION
Please provide a description for what this PR is for: https://github.com/istio/istio/issues/21843.

Cause for https://github.com/istio/istio/issues/21843: outputKeyCertToDir used by Prometheus cert provisioning reads its value from the environmental variable OUTPUT_KEY_CERT_TO_DIRECTORY. On release-1.5 branch, a [commit](https://github.com/istio/istio/pull/21445) in istio-1.5.0-beta.5 changes outputKeyCertToDir to read its value from the environmental variable OUTPUT_CERTS, which was not set in the Prometheus deployment.

The master branch does not have the problem in #21843 because the [commit](https://github.com/istio/istio/pull/21445) in istio-1.5.0-beta.5 that changes outputKeyCertToDir to read its value from the environmental variable OUTPUT_CERTS is only merged in the release-1.5 branch but not in the master branch.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[X ] Policies and Telemetry
[X ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure