### PR TITLE
DestinationRule for specific host matches wildcards (fixes #19459)

### DIFF
--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -358,7 +358,7 @@ func MostSpecificHostMatch(needle host.Name, stack []host.Name) (host.Name, bool
 			// exact match, return immediately
 			return needle, true
 		}
-		if needle.Matches(h) {
+		if needle.SubsetOf(h) {
 			matches = append(matches, h)
 		}
 	}

--- a/pilot/pkg/model/config_test.go
+++ b/pilot/pkg/model/config_test.go
@@ -397,8 +397,8 @@ func TestMostSpecificHostMatch(t *testing.T) {
 		{[]host.Name{"*.foo.bar.com", "bar.foo.bar.com"}, "bar.foo.bar.com", "bar.foo.bar.com"},
 
 		// should not match non-wildcards for wildcard needle
-		{[]host.Name{"bar.foo.com","foo.bar.com"}, "*.foo.com", ""},
-		{[]host.Name{"foo.bar.foo.com","bar.foo.bar.com"}, "*.bar.foo.com", ""},
+		{[]host.Name{"bar.foo.com", "foo.bar.com"}, "*.foo.com", ""},
+		{[]host.Name{"foo.bar.foo.com", "bar.foo.bar.com"}, "*.bar.foo.com", ""},
 	}
 
 	for idx, tt := range tests {

--- a/pilot/pkg/model/config_test.go
+++ b/pilot/pkg/model/config_test.go
@@ -387,14 +387,18 @@ func TestMostSpecificHostMatch(t *testing.T) {
 		{[]host.Name{"*.foo.com", "foo.com"}, "*.foo.com", "*.foo.com"},
 
 		// this passes because we sort alphabetically
-		{[]host.Name{"bar.com", "foo.com"}, "*.com", "bar.com"},
+		{[]host.Name{"bar.com", "foo.com"}, "*.com", ""},
 
-		{[]host.Name{"bar.com", "*.foo.com"}, "*foo.com", "*.foo.com"},
-		{[]host.Name{"foo.com", "*.foo.com"}, "*foo.com", "foo.com"},
+		{[]host.Name{"bar.com", "*.foo.com"}, "*foo.com", ""},
+		{[]host.Name{"foo.com", "*.foo.com"}, "*foo.com", ""},
 
 		// should prioritize closest match
 		{[]host.Name{"*.bar.com", "foo.bar.com"}, "foo.bar.com", "foo.bar.com"},
 		{[]host.Name{"*.foo.bar.com", "bar.foo.bar.com"}, "bar.foo.bar.com", "bar.foo.bar.com"},
+
+		// should not match non-wildcards for wildcard needle
+		{[]host.Name{"bar.foo.com","foo.bar.com"}, "*.foo.com", ""},
+		{[]host.Name{"foo.bar.foo.com","bar.foo.bar.com"}, "*.bar.foo.com", ""},
 	}
 
 	for idx, tt := range tests {


### PR DESCRIPTION
Given there is a ServiceEntry for `*.bar.com`, a `DestinationRule`
for `foo.bar.com` applies to `SerivceEntry/*.bar.com` while it shouldn't.
This PR fixes this issue by changing the way of matching
DestinationRules from overlaps to subsets of a ServiceEntry hostname.

Fixes additional issues in #19459 