### PR TITLE
Fix default out directory

### DIFF
--- a/pkg/test/env/istio.go
+++ b/pkg/test/env/istio.go
@@ -129,7 +129,7 @@ func getDefaultIstioBin() string {
 }
 
 func getDefaultIstioOut() string {
-	return fmt.Sprintf("%s/out/%s_%s", build.Default.GOPATH, runtime.GOOS, runtime.GOARCH)
+	return fmt.Sprintf("%s/out/%s_%s", IstioSrc, runtime.GOOS, runtime.GOARCH)
 }
 
 func verifyFile(v Variable, f string) string {


### PR DESCRIPTION
This causes Envoy to be searched under GOPATH/out, when we should be
looking at istio.io/istio/out/...