### PR TITLE
[release-1.5] Only use autoscaling when .Values.mixer.telemetry is true

### DIFF
--- a/manifests/istio-telemetry/mixer-telemetry/templates/autoscale.yaml
+++ b/manifests/istio-telemetry/mixer-telemetry/templates/autoscale.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.mixer.telemetry.autoscaleMin }}
+{{ $telemetry := index .Values "mixer" "telemetry" }}
+{{- if and $telemetry.autoscaleEnabled $telemetry.autoscaleMin $telemetry.autoscaleMax }}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -8,8 +9,8 @@ metadata:
     app: mixer
     release: {{ .Release.Name }}
 spec:
-    maxReplicas: {{ .Values.mixer.telemetry.autoscaleMax }}
-    minReplicas: {{ .Values.mixer.telemetry.autoscaleMin }}
+    maxReplicas: {{ $telemetry.autoscaleMax }}
+    minReplicas: {{ $telemetry.autoscaleMin }}
     scaleTargetRef:
       apiVersion: apps/v1
       kind: Deployment
@@ -18,6 +19,6 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.mixer.telemetry.cpu.targetAverageUtilization }}
+        targetAverageUtilization: {{ $telemetry.cpu.targetAverageUtilization }}
 ---
 {{- end }}

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -32093,7 +32093,8 @@ func chartsIstioTelemetryMixerTelemetryTemplates_affinityTpl() (*asset, error) {
 	return a, nil
 }
 
-var _chartsIstioTelemetryMixerTelemetryTemplatesAutoscaleYaml = []byte(`{{- if .Values.mixer.telemetry.autoscaleMin }}
+var _chartsIstioTelemetryMixerTelemetryTemplatesAutoscaleYaml = []byte(`{{ $telemetry := index .Values "mixer" "telemetry" }}
+{{- if and $telemetry.autoscaleEnabled $telemetry.autoscaleMin $telemetry.autoscaleMax }}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -32103,8 +32104,8 @@ metadata:
     app: mixer
     release: {{ .Release.Name }}
 spec:
-    maxReplicas: {{ .Values.mixer.telemetry.autoscaleMax }}
-    minReplicas: {{ .Values.mixer.telemetry.autoscaleMin }}
+    maxReplicas: {{ $telemetry.autoscaleMax }}
+    minReplicas: {{ $telemetry.autoscaleMin }}
     scaleTargetRef:
       apiVersion: apps/v1
       kind: Deployment
@@ -32113,7 +32114,7 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.mixer.telemetry.cpu.targetAverageUtilization }}
+        targetAverageUtilization: {{ $telemetry.cpu.targetAverageUtilization }}
 ---
 {{- end }}
 `)


### PR DESCRIPTION
Manual backport of https://github.com/istio/istio/pull/20985

Co-authored-by: Julian Stiller <julian.stiller@pdfforge.org>