### PR TITLE
Analyzer for the regexps in Virtual Service

### DIFF
--- a/galley/pkg/config/analysis/analyzers/all.go
+++ b/galley/pkg/config/analysis/analyzers/all.go
@@ -52,6 +52,7 @@ func All() []analysis.Analyzer {
 		&virtualservice.DestinationHostAnalyzer{},
 		&virtualservice.DestinationRuleAnalyzer{},
 		&virtualservice.GatewayAnalyzer{},
+		&virtualservice.RegexAnalyzer{},
 	}
 
 	analyzers = append(analyzers, schema.AllValidationAnalyzers()...)

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -427,6 +427,23 @@ var testGrid = []testCase{
 			// no messages, this test case verifies no false positives
 		},
 	},
+	{
+		name: "regexes",
+		inputFiles: []string{
+			"testdata/virtualservice_regexes.yaml",
+		},
+		analyzer: &virtualservice.RegexAnalyzer{},
+		expected: []message{
+			{msg.InvalidRegexp, "VirtualService bad-match"},
+			{msg.InvalidRegexp, "VirtualService ecma-not-v2"},
+			{msg.InvalidRegexp, "VirtualService lots-of-regexes"},
+			{msg.InvalidRegexp, "VirtualService lots-of-regexes"},
+			{msg.InvalidRegexp, "VirtualService lots-of-regexes"},
+			{msg.InvalidRegexp, "VirtualService lots-of-regexes"},
+			{msg.InvalidRegexp, "VirtualService lots-of-regexes"},
+			{msg.InvalidRegexp, "VirtualService lots-of-regexes"},
+		},
+	},
 }
 
 // regex patterns for analyzer names that should be explicitly ignored for testing

--- a/galley/pkg/config/analysis/analyzers/testdata/virtualservice_regexes.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/virtualservice_regexes.yaml
@@ -1,0 +1,79 @@
+# Broken config in a yaml config file
+#
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: bad-match
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - bookinfo-gateway
+  http:
+  - match:
+    - uri:
+        regex: "[A-Z"
+    route:
+    - destination:
+        host: productpage
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: ecma-not-v2
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - bookinfo-gateway
+  http:
+  - match:
+    - uri:
+        regex: "^(?!.<path to match here>.).*"
+    route:
+    - destination:
+        host: productpage
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: no-regexes
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - bookinfo-gateway
+  http:
+  - route:
+    - destination:
+        host: productpage
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: lots-of-regexes
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - bookinfo-gateway
+  http:
+  - match:
+    - uri:
+        regex: "[A-Z"
+    - scheme:
+        regex: "[A-"
+    - authority:
+        regex: "[A-B"
+    - headers:
+        end-user:
+          regex: "[jason-"
+    - queryParams:
+        zipcode:
+          regex: "[1-"
+    corsPolicy:
+      allowOrigins:
+      - regex: "[O-R"
+    route:
+    - destination:
+        host: productpage

--- a/galley/pkg/config/analysis/analyzers/testdata/virtualservice_regexes.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/virtualservice_regexes.yaml
@@ -20,6 +20,23 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
+  name: valid-regexp
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - bookinfo-gateway
+  http:
+  - match:
+    - uri:
+        regex: "[A-Z]"
+    route:
+    - destination:
+        host: productpage
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
   name: ecma-not-v2
 spec:
   hosts:

--- a/galley/pkg/config/analysis/analyzers/virtualservice/regexes.go
+++ b/galley/pkg/config/analysis/analyzers/virtualservice/regexes.go
@@ -61,17 +61,15 @@ func (a *RegexAnalyzer) analyzeVirtualService(r *resource.Instance, ctx analysis
 			analyzeStringMatch(r, m.GetMethod(), ctx, "method")
 			analyzeStringMatch(r, m.GetAuthority(), ctx, "authority")
 			for _, h := range m.GetHeaders() {
-				analyzeStringMatch(r, h, ctx, "header")
+				analyzeStringMatch(r, h, ctx, "headers")
 			}
 			for _, qp := range m.GetQueryParams() {
-				analyzeStringMatch(r, qp, ctx, "query param")
+				analyzeStringMatch(r, qp, ctx, "queryParams")
 			}
-			for _, wh := range m.GetWithoutHeaders() {
-				analyzeStringMatch(r, wh, ctx, "without header")
-			}
+			// We don't validate withoutHeaders, because they are undocumented
 		}
 		for _, origin := range route.GetCorsPolicy().GetAllowOrigins() {
-			analyzeStringMatch(r, origin, ctx, "CORS policy allow origins")
+			analyzeStringMatch(r, origin, ctx, "corsPolicy.allowOrigins")
 		}
 	}
 }
@@ -88,5 +86,5 @@ func analyzeStringMatch(r *resource.Instance, sm *v1alpha3.StringMatch, ctx anal
 	}
 
 	ctx.Report(collections.IstioNetworkingV1Alpha3Virtualservices.Name(),
-		msg.NewInvalidRegexp(r, where, re))
+		msg.NewInvalidRegexp(r, where, re, err.Error()))
 }

--- a/galley/pkg/config/analysis/analyzers/virtualservice/regexes.go
+++ b/galley/pkg/config/analysis/analyzers/virtualservice/regexes.go
@@ -1,0 +1,92 @@
+// Copyright 2020 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package virtualservice
+
+import (
+	"regexp"
+
+	"istio.io/api/networking/v1alpha3"
+
+	"istio.io/istio/galley/pkg/config/analysis"
+	"istio.io/istio/galley/pkg/config/analysis/msg"
+	"istio.io/istio/pkg/config/resource"
+	"istio.io/istio/pkg/config/schema/collection"
+	"istio.io/istio/pkg/config/schema/collections"
+)
+
+// RegexAnalyzer checks all regexes in a virtual service
+type RegexAnalyzer struct{}
+
+var _ analysis.Analyzer = &RegexAnalyzer{}
+
+// Metadata implements Analyzer
+func (a *RegexAnalyzer) Metadata() analysis.Metadata {
+	return analysis.Metadata{
+		Name:        "virtualservice.RegexAnalyzer",
+		Description: "Checks regex syntax",
+		Inputs: collection.Names{
+			collections.IstioNetworkingV1Alpha3Virtualservices.Name(),
+		},
+	}
+}
+
+// Analyze implements Analyzer
+func (a *RegexAnalyzer) Analyze(ctx analysis.Context) {
+	ctx.ForEach(collections.IstioNetworkingV1Alpha3Virtualservices.Name(), func(r *resource.Instance) bool {
+		a.analyzeVirtualService(r, ctx)
+		return true
+	})
+}
+
+func (a *RegexAnalyzer) analyzeVirtualService(r *resource.Instance, ctx analysis.Context) {
+
+	vs := r.Message.(*v1alpha3.VirtualService)
+
+	for _, route := range vs.GetHttp() {
+		for _, m := range route.GetMatch() {
+			analyzeStringMatch(r, m.GetUri(), ctx, "uri")
+			analyzeStringMatch(r, m.GetScheme(), ctx, "scheme")
+			analyzeStringMatch(r, m.GetMethod(), ctx, "method")
+			analyzeStringMatch(r, m.GetAuthority(), ctx, "authority")
+			for _, h := range m.GetHeaders() {
+				analyzeStringMatch(r, h, ctx, "header")
+			}
+			for _, qp := range m.GetQueryParams() {
+				analyzeStringMatch(r, qp, ctx, "query param")
+			}
+			for _, wh := range m.GetWithoutHeaders() {
+				analyzeStringMatch(r, wh, ctx, "without header")
+			}
+		}
+		for _, origin := range route.GetCorsPolicy().GetAllowOrigins() {
+			analyzeStringMatch(r, origin, ctx, "CORS policy allow origins")
+		}
+	}
+}
+
+func analyzeStringMatch(r *resource.Instance, sm *v1alpha3.StringMatch, ctx analysis.Context, where string) {
+	re := sm.GetRegex()
+	if re == "" {
+		return
+	}
+
+	_, err := regexp.Compile(re)
+	if err == nil {
+		return
+	}
+
+	ctx.Report(collections.IstioNetworkingV1Alpha3Virtualservices.Name(),
+		msg.NewInvalidRegexp(r, where, re))
+}

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -100,6 +100,10 @@ var (
 	// MeshPolicyResourceIsDeprecated defines a diag.MessageType for message "MeshPolicyResourceIsDeprecated".
 	// Description: The MeshPolicy resource is deprecated and will be removed in a future Istio release. Migrate to the PeerAuthentication resource.
 	MeshPolicyResourceIsDeprecated = diag.NewMessageType(diag.Info, "IST0121", "The MeshPolicy resource is deprecated and will be removed in a future Istio release. Migrate to the PeerAuthentication resource.")
+
+	// InvalidRegexp defines a diag.MessageType for message "InvalidRegexp".
+	// Description: Invalid Regex
+	InvalidRegexp = diag.NewMessageType(diag.Warning, "IST0122", "Invalid or unsupported %s regexp %q.")
 )
 
 // All returns a list of all known message types.
@@ -128,6 +132,7 @@ func All() []*diag.MessageType {
 		JwtFailureDueToInvalidServicePortPrefix,
 		PolicyResourceIsDeprecated,
 		MeshPolicyResourceIsDeprecated,
+		InvalidRegexp,
 	}
 }
 
@@ -354,5 +359,15 @@ func NewMeshPolicyResourceIsDeprecated(r *resource.Instance) diag.Message {
 	return diag.NewMessage(
 		MeshPolicyResourceIsDeprecated,
 		r,
+	)
+}
+
+// NewInvalidRegexp returns a new diag.Message based on InvalidRegexp.
+func NewInvalidRegexp(r *resource.Instance, where string, re string) diag.Message {
+	return diag.NewMessage(
+		InvalidRegexp,
+		r,
+		where,
+		re,
 	)
 }

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -103,7 +103,7 @@ var (
 
 	// InvalidRegexp defines a diag.MessageType for message "InvalidRegexp".
 	// Description: Invalid Regex
-	InvalidRegexp = diag.NewMessageType(diag.Warning, "IST0122", "Invalid or unsupported %s regexp %q.")
+	InvalidRegexp = diag.NewMessageType(diag.Warning, "IST0122", "Field %q regular expression invalid: %q (%s)")
 )
 
 // All returns a list of all known message types.
@@ -363,11 +363,12 @@ func NewMeshPolicyResourceIsDeprecated(r *resource.Instance) diag.Message {
 }
 
 // NewInvalidRegexp returns a new diag.Message based on InvalidRegexp.
-func NewInvalidRegexp(r *resource.Instance, where string, re string) diag.Message {
+func NewInvalidRegexp(r *resource.Instance, where string, re string, problem string) diag.Message {
 	return diag.NewMessage(
 		InvalidRegexp,
 		r,
 		where,
 		re,
+		problem,
 	)
 }

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -243,3 +243,13 @@ messages:
     description: "The MeshPolicy resource is deprecated and will be removed in a future Istio release. Migrate to the PeerAuthentication resource."
     template: "The MeshPolicy resource is deprecated and will be removed in a future Istio release. Migrate to the PeerAuthentication resource."
 
+  - name: "InvalidRegexp"
+    code: IST0122
+    level: Warning
+    description: "Invalid Regex"
+    template: "Invalid or unsupported %s regexp %q."
+    args:
+      - name: where
+        type: string
+      - name: re
+        type: string

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -247,9 +247,11 @@ messages:
     code: IST0122
     level: Warning
     description: "Invalid Regex"
-    template: "Invalid or unsupported %s regexp %q."
+    template: "Field %q regular expression invalid: %q (%s)"
     args:
       - name: where
         type: string
       - name: re
+        type: string
+      - name: problem
         type: string


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/21717 by adding analysis for the regexps in virtual service.

After we get some experience with this, we can consider adding this logic to the webhook.

(edit - formerly I claimed this "mitigates" 21717, because it only adds the analyzer, not the webhook/validator.  For 1.6 we will do the analyzer.  If we need this function in the webhook we'll need to track that separately).