### PR TITLE
Performance: remove legacy global edsClusters

### DIFF
--- a/istioctl/pkg/writer/pilot/status_test.go
+++ b/istioctl/pkg/writer/pilot/status_test.go
@@ -166,15 +166,14 @@ func TestStatusWriter_PrintSingle(t *testing.T) {
 func statusInput1() []v2.SyncStatus {
 	return []v2.SyncStatus{
 		{
-			ProxyID:         "proxy1",
-			IstioVersion:    "1.1",
-			ClusterSent:     preDefinedNonce,
-			ClusterAcked:    newNonce(),
-			ListenerSent:    preDefinedNonce,
-			ListenerAcked:   preDefinedNonce,
-			EndpointSent:    preDefinedNonce,
-			EndpointAcked:   preDefinedNonce,
-			EndpointPercent: 100,
+			ProxyID:       "proxy1",
+			IstioVersion:  "1.1",
+			ClusterSent:   preDefinedNonce,
+			ClusterAcked:  newNonce(),
+			ListenerSent:  preDefinedNonce,
+			ListenerAcked: preDefinedNonce,
+			EndpointSent:  preDefinedNonce,
+			EndpointAcked: preDefinedNonce,
 		},
 	}
 }

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -83,7 +83,6 @@ type XdsConnection struct {
 	RouteNonceSent, RouteNonceAcked       string
 	RouteVersionInfoSent                  string
 	EndpointNonceSent, EndpointNonceAcked string
-	EndpointPercent                       int
 
 	// current list of clusters monitored by the client
 	Clusters []string
@@ -341,12 +340,7 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 					adsLog.Debugf("ADS:EDS: ACK %s %s %s %s", peerAddr, con.ConID, discReq.VersionInfo, discReq.ResponseNonce)
 					if discReq.ResponseNonce != "" {
 						con.mu.Lock()
-						edsClusterMutex.RLock()
 						con.EndpointNonceAcked = discReq.ResponseNonce
-						if len(edsClusters) != 0 {
-							con.EndpointPercent = int((float64(len(clusters)) / float64(len(edsClusters))) * float64(100))
-						}
-						edsClusterMutex.RUnlock()
 						con.mu.Unlock()
 					}
 					continue

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -417,7 +417,7 @@ func (s *DiscoveryServer) initConnection(node *core.Node, con *XdsConnection) (f
 	s.addCon(con.ConID, con)
 	con.mu.Unlock()
 
-	return func() { s.removeCon(con.ConID, con) }, nil
+	return func() { s.removeCon(con.ConID) }, nil
 }
 
 // initProxy initializes the Proxy from node.
@@ -609,7 +609,7 @@ func AdsPushAll(s *DiscoveryServer) {
 // to the model ConfigStorageCache and Controller.
 func (s *DiscoveryServer) AdsPushAll(version string, req *model.PushRequest) {
 	if !req.Full {
-		s.edsIncremental(version, req.Push, req)
+		s.edsIncremental(version, req)
 		return
 	}
 
@@ -654,7 +654,7 @@ func (s *DiscoveryServer) addCon(conID string, con *XdsConnection) {
 	xdsClients.Record(float64(len(s.adsClients)))
 }
 
-func (s *DiscoveryServer) removeCon(conID string, con *XdsConnection) {
+func (s *DiscoveryServer) removeCon(conID string) {
 	s.adsClientsMutex.Lock()
 	defer s.adsClientsMutex.Unlock()
 

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -895,6 +895,7 @@ func (s *DiscoveryServer) getProxyConnection(proxyID string) *XdsConnection {
 	defer s.adsClientsMutex.RUnlock()
 
 	for conID := range s.adsClients {
+
 		if strings.Contains(conID, proxyID) {
 			return s.adsClients[conID]
 		}

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -153,18 +153,17 @@ func (s *DiscoveryServer) addDebugHandler(mux *http.ServeMux, path string, help 
 
 // SyncStatus is the synchronization status between Pilot and a given Envoy
 type SyncStatus struct {
-	ProxyID         string `json:"proxy,omitempty"`
-	ProxyVersion    string `json:"proxy_version,omitempty"`
-	IstioVersion    string `json:"istio_version,omitempty"`
-	ClusterSent     string `json:"cluster_sent,omitempty"`
-	ClusterAcked    string `json:"cluster_acked,omitempty"`
-	ListenerSent    string `json:"listener_sent,omitempty"`
-	ListenerAcked   string `json:"listener_acked,omitempty"`
-	RouteSent       string `json:"route_sent,omitempty"`
-	RouteAcked      string `json:"route_acked,omitempty"`
-	EndpointSent    string `json:"endpoint_sent,omitempty"`
-	EndpointAcked   string `json:"endpoint_acked,omitempty"`
-	EndpointPercent int    `json:"endpoint_percent,omitempty"`
+	ProxyID       string `json:"proxy,omitempty"`
+	ProxyVersion  string `json:"proxy_version,omitempty"`
+	IstioVersion  string `json:"istio_version,omitempty"`
+	ClusterSent   string `json:"cluster_sent,omitempty"`
+	ClusterAcked  string `json:"cluster_acked,omitempty"`
+	ListenerSent  string `json:"listener_sent,omitempty"`
+	ListenerAcked string `json:"listener_acked,omitempty"`
+	RouteSent     string `json:"route_sent,omitempty"`
+	RouteAcked    string `json:"route_acked,omitempty"`
+	EndpointSent  string `json:"endpoint_sent,omitempty"`
+	EndpointAcked string `json:"endpoint_acked,omitempty"`
 }
 
 // Syncz dumps the synchronization status of all Envoys connected to this Pilot instance
@@ -175,17 +174,16 @@ func (s *DiscoveryServer) Syncz(w http.ResponseWriter, _ *http.Request) {
 		con.mu.RLock()
 		if con.node != nil {
 			syncz = append(syncz, SyncStatus{
-				ProxyID:         con.node.ID,
-				IstioVersion:    con.node.Metadata.IstioVersion,
-				ClusterSent:     con.ClusterNonceSent,
-				ClusterAcked:    con.ClusterNonceAcked,
-				ListenerSent:    con.ListenerNonceSent,
-				ListenerAcked:   con.ListenerNonceAcked,
-				RouteSent:       con.RouteNonceSent,
-				RouteAcked:      con.RouteNonceAcked,
-				EndpointSent:    con.EndpointNonceSent,
-				EndpointAcked:   con.EndpointNonceAcked,
-				EndpointPercent: con.EndpointPercent,
+				ProxyID:       con.node.ID,
+				IstioVersion:  con.node.Metadata.IstioVersion,
+				ClusterSent:   con.ClusterNonceSent,
+				ClusterAcked:  con.ClusterNonceAcked,
+				ListenerSent:  con.ListenerNonceSent,
+				ListenerAcked: con.ListenerNonceAcked,
+				RouteSent:     con.RouteNonceSent,
+				RouteAcked:    con.RouteNonceAcked,
+				EndpointSent:  con.EndpointNonceSent,
+				EndpointAcked: con.EndpointNonceAcked,
 			})
 		}
 		con.mu.RUnlock()

--- a/pilot/pkg/proxy/envoy/v2/debug_test.go
+++ b/pilot/pkg/proxy/envoy/v2/debug_test.go
@@ -187,9 +187,6 @@ func verifySyncStatus(t *testing.T, s *v2.DiscoveryServer, nodeID string, wantSe
 				if (ss.EndpointAcked != "") != wantAcked {
 					errorHandler("wanted EndpointAcked set %v got %v for %v", wantAcked, ss.EndpointAcked, nodeID)
 				}
-				if (ss.EndpointPercent != 0) != wantAcked {
-					errorHandler("wanted EndpointPercent set %v got %v for %v", wantAcked, ss.EndpointPercent, nodeID)
-				}
 				return
 			}
 		}

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -33,7 +33,6 @@ import (
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
-	"istio.io/istio/pilot/pkg/util/sets"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/protocol"
@@ -60,17 +59,11 @@ import (
 //
 // TODO: for selector-less services (mesh expansion), skip pod processing
 // TODO: optimize the code path for ExternalEndpoint, no additional processing needed
-// TODO: if a service doesn't have split traffic - we can also skip pod and lable processing
+// TODO: if a service doesn't have split traffic - we can also skip pod and label processing
 // TODO: efficient label processing. In alpha3, the destination policies are set per service, so
 // we may only need to search in a small list.
 
 var (
-	edsClusterMutex sync.RWMutex
-
-	// edsClusters keep tracks of all watched clusters in 1.0 (not isolated) mode
-	// TODO: if global isolation is enabled, don't update or use this.
-	edsClusters = map[string]*EdsCluster{}
-
 	// Tracks connections, increment on each new connection.
 	connectionNumber = int64(0)
 )
@@ -89,13 +82,6 @@ type EdsCluster struct {
 }
 
 // TODO: add prom metrics !
-
-// Return the load assignment with mutex. The field can be updated by another routine.
-func loadAssignment(c *EdsCluster) *xdsapi.ClusterLoadAssignment {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-	return c.LoadAssignment
-}
 
 // buildEnvoyLbEndpoint packs the endpoint based on istio info.
 func buildEnvoyLbEndpoint(e *model.IstioEndpoint, push *model.PushContext) *endpoint.LbEndpoint {
@@ -133,74 +119,12 @@ func legacyServiceForHostname(hostname host.Name, serviceByHostname map[host.Nam
 	return nil
 }
 
-// updateClusterInc computes an envoy cluster assignment from the service shards.
-// This happens when endpoints are updated.
-// TODO: this code is specific for 1.0 / pre-isolation. With config scoping, two sidecars can get
-// a cluster of same name but with different set of endpoints. See the
-// explanation below for more details
-func (s *DiscoveryServer) updateClusterInc(push *model.PushContext, clusterName string,
-	edsCluster *EdsCluster) error {
-
-	var hostname host.Name
-	var clusterPort int
-	var subsetName string
-	_, subsetName, hostname, clusterPort = model.ParseSubsetKey(clusterName)
-
-	// TODO: BUG. this code is incorrect if 1.1 isolation is used. With destination rule scoping
-	// (public/private) as well as sidecar scopes allowing import of
-	// specific destination rules, the destination rule for a given
-	// namespace should be determined based on the sidecar scope or the
-	// proxy's config namespace. As such, this code searches through all
-	// destination rules, public and private and returns a completely
-	// arbitrary destination rule's subset labels!
-	subsetLabels := push.SubsetToLabels(nil, subsetName, hostname)
-
-	push.Mutex.Lock()
-	svc := legacyServiceForHostname(hostname, push.ServiceByHostnameAndNamespace)
-	push.Mutex.Unlock()
-	if svc == nil {
-		return s.updateCluster(push, clusterName, edsCluster)
-	}
-
-	// Check that there is a matching port
-	// We don't use the port though, as there could be multiple matches
-	svcPort, found := svc.Ports.GetByPort(clusterPort)
-	if !found {
-		return s.updateCluster(push, clusterName, edsCluster)
-	}
-
-	s.mutex.RLock()
-	// The service was never updated - do the full update
-	se, f := s.EndpointShardsByService[string(hostname)][svc.Attributes.Namespace]
-	s.mutex.RUnlock()
-	if !f {
-		return s.updateCluster(push, clusterName, edsCluster)
-	}
-
-	locEps := buildLocalityLbEndpointsFromShards(se, svcPort, subsetLabels, clusterName, push)
-	// There is a chance multiple goroutines will update the cluster at the same time.
-	// This could be prevented by a lock - but because the update may be slow, it may be
-	// better to accept the extra computations.
-	// We still lock the access to the LoadAssignments.
-	edsCluster.mutex.Lock()
-	defer edsCluster.mutex.Unlock()
-
-	edsCluster.LoadAssignment = &xdsapi.ClusterLoadAssignment{
-		ClusterName: clusterName,
-		Endpoints:   locEps,
-	}
-	return nil
-}
-
 // updateServiceShards will list the endpoints and create the shards.
 // This is used to reconcile and to support non-k8s registries (until they migrate).
 // Note that aggregated list is expensive (for large numbers) - we want to replace
 // it with a model where DiscoveryServer keeps track of all endpoint registries
 // directly, and calls them one by one.
 func (s *DiscoveryServer) updateServiceShards(push *model.PushContext) error {
-
-	// TODO: if ServiceDiscovery is aggregate, and all members support direct, use
-	// the direct interface.
 	var registries []serviceregistry.Instance
 	var nonK8sRegistries []serviceregistry.Instance
 	if agg, ok := s.Env.ServiceDiscovery.(*aggregate.Controller); ok {
@@ -252,61 +176,6 @@ func (s *DiscoveryServer) updateServiceShards(push *model.PushContext) error {
 	return nil
 }
 
-// updateCluster is called from the event (or global cache invalidation) to update
-// the endpoints for the cluster.
-func (s *DiscoveryServer) updateCluster(push *model.PushContext, clusterName string, edsCluster *EdsCluster) error {
-	// TODO: should we lock this as well ? Once we move to event-based it may not matter.
-	var locEps []*endpoint.LocalityLbEndpoints
-	direction, subsetName, hostname, port := model.ParseSubsetKey(clusterName)
-
-	if direction == model.TrafficDirectionInbound ||
-		direction == model.TrafficDirectionOutbound {
-		subsetLabels := push.SubsetToLabels(nil, subsetName, hostname)
-		svc := legacyServiceForHostname(hostname, push.ServiceByHostnameAndNamespace)
-		var instances []*model.ServiceInstance
-		if svc == nil {
-			adsLog.Warnf("service lookup for hostname %v failed", hostname)
-		} else {
-			var err error
-			instances, err = s.Env.ServiceDiscovery.InstancesByPort(svc, port, subsetLabels)
-			if err != nil {
-				adsLog.Errorf("endpoints for service cluster %q returned error %v", clusterName, err)
-				totalXDSInternalErrors.Increment()
-				return err
-			}
-		}
-
-		if len(instances) == 0 {
-			push.AddMetric(model.ProxyStatusClusterNoInstances, clusterName, nil, "")
-			adsLog.Debugf("EDS: Cluster %q (host:%s ports:%v labels:%v) has no instances", clusterName, hostname, port, subsetLabels)
-		}
-		locEps = localityLbEndpointsFromInstances(instances, push)
-		updateEdsStats(locEps, clusterName)
-	}
-
-	for i := 0; i < len(locEps); i++ {
-		var weight uint32
-		for _, ep := range locEps[i].LbEndpoints {
-			weight += ep.LoadBalancingWeight.GetValue()
-		}
-		locEps[i].LoadBalancingWeight = &wrappers.UInt32Value{
-			Value: weight,
-		}
-	}
-	// There is a chance multiple goroutines will update the cluster at the same time.
-	// This could be prevented by a lock - but because the update may be slow, it may be
-	// better to accept the extra computations.
-	// We still lock the access to the LoadAssignments.
-	edsCluster.mutex.Lock()
-	defer edsCluster.mutex.Unlock()
-
-	edsCluster.LoadAssignment = &xdsapi.ClusterLoadAssignment{
-		ClusterName: clusterName,
-		Endpoints:   locEps,
-	}
-	return nil
-}
-
 // SvcUpdate is a callback from service discovery when service info changes.
 func (s *DiscoveryServer) SvcUpdate(cluster, hostname string, namespace string, event model.Event) {
 	// When a service deleted, we should cleanup the endpoint shards and also remove keys from EndpointShardsByService to
@@ -326,33 +195,6 @@ func (s *DiscoveryServer) SvcUpdate(cluster, hostname string, namespace string, 
 func (s *DiscoveryServer) edsIncremental(version string, push *model.PushContext, req *model.PushRequest) {
 	adsLog.Infof("XDS:EDSInc Pushing:%s Services:%v ConnectedEndpoints:%d",
 		version, req.EdsUpdates, s.adsClientCount())
-	t0 := time.Now()
-
-	// First update all cluster load assignments. This is computed for each cluster once per config change
-	// instead of once per endpoint.
-	edsClusterMutex.Lock()
-	// Create a temp map to avoid locking the add/remove
-	cMap := make(map[string]*EdsCluster, len(edsClusters))
-	for k, v := range edsClusters {
-		_, _, hostname, _ := model.ParseSubsetKey(k)
-		if _, ok := req.EdsUpdates[string(hostname)]; !ok {
-			// Cluster was not updated, skip recomputing.
-			continue
-		}
-		cMap[k] = v
-	}
-	edsClusterMutex.Unlock()
-
-	// UpdateCluster updates the cluster with a mutex, this code is safe ( but computing
-	// the update may be duplicated if multiple goroutines compute at the same time).
-	// In general this code is called from the 'event' callback that is throttled.
-	for clusterName, edsCluster := range cMap {
-		if err := s.updateClusterInc(push, clusterName, edsCluster); err != nil {
-			adsLog.Errorf("updateCluster failed with clusterName:%s", clusterName)
-		}
-	}
-	adsLog.Infof("Cluster init time %v %s", time.Since(t0), version)
-
 	s.startPush(req)
 }
 
@@ -487,57 +329,9 @@ func (s *DiscoveryServer) deleteService(cluster, serviceName, namespace string) 
 	}
 }
 
-// LocalityLbEndpointsFromInstances returns a list of Envoy v2 LocalityLbEndpoints.
-// Envoy v2 Endpoints are constructed from Pilot's older data structure involving
-// model.ServiceInstance objects. Envoy expects the endpoints grouped by zone, so
-// a map is created - in new data structures this should be part of the model.
-func localityLbEndpointsFromInstances(instances []*model.ServiceInstance, push *model.PushContext) []*endpoint.LocalityLbEndpoints {
-	localityEpMap := make(map[string]*endpoint.LocalityLbEndpoints)
-	for _, instance := range instances {
-		lbEp := buildEnvoyLbEndpoint(instance.Endpoint, push)
-		locality := instance.Endpoint.Locality.Label
-		locLbEps, found := localityEpMap[locality]
-		if !found {
-			locLbEps = &endpoint.LocalityLbEndpoints{
-				Locality: util.ConvertLocality(locality),
-			}
-			localityEpMap[locality] = locLbEps
-		}
-		locLbEps.LbEndpoints = append(locLbEps.LbEndpoints, lbEp)
-	}
-	out := make([]*endpoint.LocalityLbEndpoints, 0, len(localityEpMap))
-	for _, locLbEps := range localityEpMap {
-		out = append(out, locLbEps)
-	}
-	return out
-}
-
 func connectionID(node string) string {
 	id := atomic.AddInt64(&connectionNumber, 1)
 	return node + "-" + strconv.FormatInt(id, 10)
-}
-
-// loadAssignmentsForClusterLegacy return the pre-computed, 1.0-style endpoints for a cluster
-func (s *DiscoveryServer) loadAssignmentsForClusterLegacy(push *model.PushContext,
-	clusterName string) *xdsapi.ClusterLoadAssignment {
-	c := s.getEdsCluster(clusterName)
-	if c == nil {
-		totalXDSInternalErrors.Increment()
-		adsLog.Errorf("cluster %s was nil skipping it.", clusterName)
-		return nil
-	}
-
-	l := loadAssignment(c)
-	if l == nil { // fresh cluster
-		if err := s.updateCluster(push, clusterName, c); err != nil {
-			adsLog.Errorf("error returned from updateCluster for cluster name %s, skipping it.", clusterName)
-			totalXDSInternalErrors.Increment()
-			return nil
-		}
-		l = loadAssignment(c)
-	}
-
-	return l
 }
 
 // loadAssignmentsForClusterIsolated return the endpoints for a proxy in an isolated namespace
@@ -545,11 +339,6 @@ func (s *DiscoveryServer) loadAssignmentsForClusterLegacy(push *model.PushContex
 // perf tests. The logic to compute is based on the current UpdateClusterInc
 func (s *DiscoveryServer) loadAssignmentsForClusterIsolated(proxy *model.Proxy, push *model.PushContext,
 	clusterName string) *xdsapi.ClusterLoadAssignment {
-	// TODO: fail-safe, use the old implementation based on some flag.
-	// Users who make sure all DestinationRules are in the right namespace and don't have override may turn it on
-	// (some very-large scale customers are in this category)
-
-	// This code is similar with the update code.
 	_, subsetName, hostname, port := model.ParseSubsetKey(clusterName)
 
 	// TODO: BUG. this code is incorrect if 1.1 isolation is used. With destination rule scoping
@@ -565,8 +354,9 @@ func (s *DiscoveryServer) loadAssignmentsForClusterIsolated(proxy *model.Proxy, 
 	svc := proxy.SidecarScope.ServiceForHostname(hostname, push.ServiceByHostnameAndNamespace)
 	push.Mutex.Unlock()
 	if svc == nil {
-		// Shouldn't happen here - but just in case fallback
-		return s.loadAssignmentsForClusterLegacy(push, clusterName)
+		// Shouldn't happen here
+		adsLog.Warnf("can not find the service for cluster %s", clusterName)
+		return nil
 	}
 
 	// Service resolution type might have changed and Cluster may be still in the EDS cluster list of "XdsConnection.Clusters".
@@ -583,8 +373,9 @@ func (s *DiscoveryServer) loadAssignmentsForClusterIsolated(proxy *model.Proxy, 
 
 	svcPort, f := svc.Ports.GetByPort(port)
 	if !f {
-		// Shouldn't happen here - but just in case fallback
-		return s.loadAssignmentsForClusterLegacy(push, clusterName)
+		// Shouldn't happen here
+		adsLog.Warnf("can not find the service port %d for cluster %s", port, clusterName)
+		return nil
 	}
 
 	// The service was never updated - do the full update
@@ -592,8 +383,9 @@ func (s *DiscoveryServer) loadAssignmentsForClusterIsolated(proxy *model.Proxy, 
 	se, f := s.EndpointShardsByService[string(hostname)][svc.Attributes.Namespace]
 	s.mutex.RUnlock()
 	if !f {
-		// Shouldn't happen here - but just in case fallback
-		return s.loadAssignmentsForClusterLegacy(push, clusterName)
+		// Shouldn't happen here
+		adsLog.Warnf("can not find the endpointShards for cluster %s", clusterName)
+		return nil
 	}
 
 	locEps := buildLocalityLbEndpointsFromShards(se, svcPort, subsetLabels, clusterName, push)
@@ -617,7 +409,6 @@ func (s *DiscoveryServer) generateEndpoints(
 	}
 
 	l := s.loadAssignmentsForClusterIsolated(proxy, push, clusterName)
-
 	if l == nil {
 		return nil
 	}
@@ -739,77 +530,6 @@ func getOutlierDetectionAndLoadBalancerSettings(push *model.PushContext, proxy *
 		}
 	}
 	return outlierDetectionEnabled, lbSettings
-}
-
-// getEdsCluster returns a cluster.
-func (s *DiscoveryServer) getEdsCluster(clusterName string) *EdsCluster {
-	// separate method only to have proper lock.
-	edsClusterMutex.RLock()
-	defer edsClusterMutex.RUnlock()
-	return edsClusters[clusterName]
-}
-
-// removeEdsCon is called when a gRPC stream is closed, for each cluster that was watched by the
-// stream. As of 0.7 envoy watches a single cluster per gprc stream.
-func (s *DiscoveryServer) removeEdsCon(clusterName string, conID string) {
-	c := s.getEdsCluster(clusterName)
-	if c == nil {
-		adsLog.Warnf("EDS: Missing cluster: %s", clusterName)
-		return
-	}
-
-	edsClusterMutex.Lock()
-	defer edsClusterMutex.Unlock()
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-	delete(c.EdsClients, conID)
-	if len(c.EdsClients) == 0 {
-		// This happens when a previously used cluster is no longer watched by any
-		// sidecar. It should not happen very often - normally all clusters are sent
-		// in CDS requests to all sidecars. It may happen if all connections are closed.
-		adsLog.Debugf("EDS: Remove unwatched cluster node:%s cluster:%s", conID, clusterName)
-		delete(edsClusters, clusterName)
-	}
-}
-
-func (s *DiscoveryServer) updateEdsClients(added sets.Set, removed sets.Set, connection *XdsConnection) {
-	edsClusterMutex.Lock()
-	defer edsClusterMutex.Unlock()
-
-	for rc := range removed {
-		c := edsClusters[rc]
-		if c == nil {
-			adsLog.Warnf("EDS: Missing cluster: %s", rc)
-			continue
-		}
-		c.mutex.Lock()
-		delete(c.EdsClients, connection.ConID)
-		clients := len(c.EdsClients)
-		c.mutex.Unlock()
-		if clients == 0 {
-			// This happens when a previously used cluster is no longer watched by any
-			// sidecar. It should not happen very often - normally all clusters are sent
-			// in CDS requests to all sidecars. It may happen if all connections are closed.
-			adsLog.Debugf("EDS: Remove unwatched cluster node:%s cluster:%s", connection.ConID, rc)
-			delete(edsClusters, rc)
-		}
-	}
-
-	for ac := range added {
-		c := edsClusters[ac]
-		if c == nil {
-			c = &EdsCluster{
-				EdsClients: map[string]struct{}{},
-			}
-			edsClusters[ac] = c
-		}
-
-		// TODO: find a more efficient way to make edsClusters and EdsClients init atomic
-		// Currently use edsClusterMutex lock
-		c.mutex.Lock()
-		c.EdsClients[connection.ConID] = struct{}{}
-		c.mutex.Unlock()
-	}
 }
 
 func endpointDiscoveryResponse(loadAssignments []*xdsapi.ClusterLoadAssignment, version string, noncePrefix string) *xdsapi.DiscoveryResponse {

--- a/pilot/pkg/proxy/envoy/v2/eds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_test.go
@@ -82,7 +82,7 @@ func TestEds(t *testing.T) {
 
 	t.Run("TCPEndpoints", func(t *testing.T) {
 		testTCPEndpoints("127.0.0.1", adscConn, t)
-		testEdsz(t)
+		testEdsz(t, "test-1.default")
 	})
 	t.Run("LocalityPrioritizedEndpoints", func(t *testing.T) {
 		testLocalityPrioritizedEndpoints(adscConn, adscConn2, t)
@@ -845,8 +845,8 @@ func addOverlappingEndpoints(server *bootstrap.Server) {
 // TODO: use this in integration tests.
 // TODO: refine the output
 // TODO: dump the ServiceInstances as well
-func testEdsz(t *testing.T) {
-	edszURL := fmt.Sprintf("http://localhost:%d/debug/edsz", testEnv.Ports().PilotHTTPPort)
+func testEdsz(t *testing.T, proxyID string) {
+	edszURL := fmt.Sprintf("http://localhost:%d/debug/edsz?proxyID=%s", testEnv.Ports().PilotHTTPPort, proxyID)
 	res, err := http.Get(edszURL)
 	if err != nil {
 		t.Fatalf("Failed to fetch %s", edszURL)

--- a/pilot/pkg/proxy/envoy/v2/mem.go
+++ b/pilot/pkg/proxy/envoy/v2/mem.go
@@ -212,7 +212,7 @@ func (sd *MemServiceDiscovery) SetEndpoints(service string, namespace string, en
 	}
 
 	for _, e := range endpoints {
-		//servicePortName string, servicePort int, address string, port int
+		// servicePortName string, servicePort int, address string, port int
 		p, _ := svc.Ports.Get(e.ServicePortName)
 
 		instance := &model.ServiceInstance{

--- a/pilot/pkg/proxy/envoy/v2/xds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/xds_test.go
@@ -171,28 +171,25 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 			Address:  "10.10.0.3",
 			Ports:    testPorts(0),
 			Attributes: model.ServiceAttributes{
-				Name:      "service3",
+				Name:      "local",
 				Namespace: "default",
 			},
 		})
-		server.EnvoyXdsServer.MemRegistry.AddInstance(hostname, &model.ServiceInstance{
-			Endpoint: &model.IstioEndpoint{
+
+		server.EnvoyXdsServer.MemRegistry.SetEndpoints(string(hostname), "default", []*model.IstioEndpoint{
+			{
 				Address:         "127.0.0.1",
 				EndpointPort:    uint32(testEnv.Ports().BackendPort),
 				ServicePortName: "http",
 				Locality:        model.Locality{Label: "az"},
 				ServiceAccount:  "hello-sa",
 			},
-			ServicePort: &model.Port{
-				Name:     "http",
-				Port:     80,
-				Protocol: protocol.HTTP,
-			},
 		})
 
 		// "local" service points to the current host and the in-process mixer http test endpoint
-		server.EnvoyXdsServer.MemRegistry.AddService("local.default.svc.cluster.local", &model.Service{
-			Hostname: "local.default.svc.cluster.local",
+		hostname = "local.default.svc.cluster.local"
+		server.EnvoyXdsServer.MemRegistry.AddService(hostname, &model.Service{
+			Hostname: hostname,
 			Address:  "10.10.0.4",
 			Ports: []*model.Port{
 				{
@@ -205,17 +202,13 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 				Namespace: "default",
 			},
 		})
-		server.EnvoyXdsServer.MemRegistry.AddInstance("local.default.svc.cluster.local", &model.ServiceInstance{
-			Endpoint: &model.IstioEndpoint{
+
+		server.EnvoyXdsServer.MemRegistry.SetEndpoints(string(hostname), "default", []*model.IstioEndpoint{
+			{
 				Address:         localIP,
 				EndpointPort:    uint32(testEnv.Ports().BackendPort),
 				ServicePortName: "http",
 				Locality:        model.Locality{Label: "az"},
-			},
-			ServicePort: &model.Port{
-				Name:     "http",
-				Port:     80,
-				Protocol: protocol.HTTP,
 			},
 		})
 

--- a/pilot/pkg/proxy/envoy/v2/xds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/xds_test.go
@@ -214,8 +214,9 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 
 		// Explicit test service, in the v2 memory registry. Similar with mock.MakeService,
 		// but easier to read.
-		server.EnvoyXdsServer.MemRegistry.AddService("service3.default.svc.cluster.local", &model.Service{
-			Hostname: "service3.default.svc.cluster.local",
+		hostname = "service3.default.svc.cluster.local"
+		server.EnvoyXdsServer.MemRegistry.AddService(hostname, &model.Service{
+			Hostname: hostname,
 			Address:  "10.10.0.1",
 			Ports:    testPorts(0),
 			Attributes: model.ServiceAttributes{
@@ -224,34 +225,17 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 			},
 		})
 
-		server.EnvoyXdsServer.MemRegistry.AddInstance("service3.default.svc.cluster.local", &model.ServiceInstance{
-			Endpoint: &model.IstioEndpoint{
+		svc3Endpoints := make([]*model.IstioEndpoint, len(testPorts(0)))
+		for i, p := range testPorts(0) {
+			svc3Endpoints[i] = &model.IstioEndpoint{
 				Address:         app3Ip,
-				EndpointPort:    2080,
-				ServicePortName: "http-main",
+				EndpointPort:    uint32(p.Port),
+				ServicePortName: p.Name,
 				Locality:        model.Locality{Label: "az"},
-				Labels:          map[string]string{"version": "v1"},
-			},
-			ServicePort: &model.Port{
-				Name:     "http-main",
-				Port:     1080,
-				Protocol: protocol.HTTP,
-			},
-		})
-		server.EnvoyXdsServer.MemRegistry.AddInstance("service3.default.svc.cluster.local", &model.ServiceInstance{
-			Endpoint: &model.IstioEndpoint{
-				Address:         gatewayIP,
-				EndpointPort:    2080,
-				ServicePortName: "http-main",
-				Locality:        model.Locality{Label: "az"},
-				Labels:          map[string]string{"version": "v2", "app": "my-gateway-controller"},
-			},
-			ServicePort: &model.Port{
-				Name:     "http-main",
-				Port:     1080,
-				Protocol: protocol.HTTP,
-			},
-		})
+			}
+		}
+
+		server.EnvoyXdsServer.MemRegistry.SetEndpoints(string(hostname), "default", svc3Endpoints)
 
 		// Mock ingress service
 		server.EnvoyXdsServer.MemRegistry.AddService("istio-ingress.istio-system.svc.cluster.local", &model.Service{


### PR DESCRIPTION
Please provide a description for what this PR is for.

remove legacy `edsClusters` to save cpu and memory.


fix: #21913

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[x] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
