### PR TITLE
Bind local tests to localhost

### DIFF
--- a/pkg/test/docker/container.go
+++ b/pkg/test/docker/container.go
@@ -39,7 +39,7 @@ type PortMap map[ContainerPort]HostPort
 func (m PortMap) toNatPortMap() nat.PortMap {
 	out := make(nat.PortMap)
 	for k, v := range m {
-		out[toNatPort(k)] = []nat.PortBinding{{HostPort: strconv.Itoa(int(v))}}
+		out[toNatPort(k)] = []nat.PortBinding{{HostIP: "127.0.0.1", HostPort: strconv.Itoa(int(v))}}
 	}
 	return out
 }


### PR DESCRIPTION
Internal security team got mad at me for exposing insecure endpoints.
Seems like this is an easy fix with no impact on the tests.