### PR TITLE
Fix imagePullSecrets configuration in Citadel service account

### DIFF
--- a/manifests/security/citadel/templates/serviceaccount.yaml
+++ b/manifests/security/citadel/templates/serviceaccount.yaml
@@ -6,10 +6,9 @@ metadata:
   labels:
     app: security
     release: {{ .Release.Name }}
-  {{- if .Values.global.imagePullSecrets }}
-spec:
-  imagePullSecrets:
-  {{- range .Values.global.imagePullSecrets }}
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
   - name: {{ . }}
-  {{- end }}
-  {{- end }}
+{{- end }}
+{{- end }}

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -45284,13 +45284,12 @@ metadata:
   labels:
     app: security
     release: {{ .Release.Name }}
-  {{- if .Values.global.imagePullSecrets }}
-spec:
-  imagePullSecrets:
-  {{- range .Values.global.imagePullSecrets }}
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
   - name: {{ . }}
-  {{- end }}
-  {{- end }}
+{{- end }}
+{{- end }}
 `)
 
 func chartsSecurityCitadelTemplatesServiceaccountYamlBytes() ([]byte, error) {


### PR DESCRIPTION

The Citadel serviceaccount incorrectly sets the `imagePullSecrets` on `spec`. The `imagePullSecrets` is a top level field (e.g like the istio-ingress [serviceaccount.yaml](https://github.com/istio/istio/blob/master/manifests/gateways/istio-ingress/templates/serviceaccount.yaml#L4-L9)).

When running `istioctl manifest apply` with the following configuration:
```
apiVersion: install.istio.io/v1alpha2
kind: IstioControlPlane
spec:
  unvalidatedValues:
    global:
      imagePullSecrets:
      - some-image-secret
```
results in:
```
- Applying manifest for component Base...
✔ Finished applying manifest for component Base.
- Applying manifest for component Citadel...
- Applying manifest for component Pilot...
- Applying manifest for component Prometheus...
- Applying manifest for component IngressGateway...
✘ Finished applying manifest for component Citadel.
✔ Finished applying manifest for component IngressGateway.
✔ Finished applying manifest for component Prometheus.
✔ Finished applying manifest for component Pilot.

Component Citadel - manifest apply returned the following errors:
Error: error running kubectl: exit status 1

Error detail:

error: error validating "STDIN": error validating data: ValidationError(ServiceAccount): unknown field "spec" in io.k8s.api.core.v1.ServiceAccount; if you choose to ignore these errors, turn validation off with --validate=false (repeated 1 times)






✘ Errors were logged during apply operation. Please check component installation logs above.

Failed to generate and apply manifests, error: errors were logged during apply operation
```