### PR TITLE
auto mtls partial sidecar injected test case.

### DIFF
--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -40,207 +40,219 @@ func TestReachability(t *testing.T) {
 			systemNM := namespace.ClaimSystemNamespaceOrFail(ctx, ctx)
 
 			testCases := []reachability.TestCase{
-				{
-					ConfigFile:          "global-mtls-on.yaml",
-					Namespace:           systemNM,
-					RequiredEnvironment: environment.Kube,
-					Include: func(src echo.Instance, opts echo.CallOptions) bool {
-						return true
-					},
-					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-						if src == rctx.Naked && opts.Target == rctx.Naked {
-							// naked->naked should always succeed.
-							return true
-						}
+				// {
+				// 	ConfigFile:          "global-mtls-on.yaml",
+				// 	Namespace:           systemNM,
+				// 	RequiredEnvironment: environment.Kube,
+				// 	Include: func(src echo.Instance, opts echo.CallOptions) bool {
+				// 		return true
+				// 	},
+				// 	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+				// 		if src == rctx.Naked && opts.Target == rctx.Naked {
+				// 			// naked->naked should always succeed.
+				// 			return true
+				// 		}
 
-						// If one of the two endpoints is naked, expect failure.
-						return src != rctx.Naked && opts.Target != rctx.Naked
-					},
-				},
-				{
-					ConfigFile:          "global-mtls-permissive.yaml",
-					Namespace:           systemNM,
-					RequiredEnvironment: environment.Kube,
-					Include: func(src echo.Instance, opts echo.CallOptions) bool {
-						// Exclude calls to the naked app.
-						return opts.Target != rctx.Naked
-					},
-					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-						return true
-					},
-				},
-				{
-					ConfigFile: "global-mtls-off.yaml",
-					Namespace:  systemNM,
-					Include: func(src echo.Instance, opts echo.CallOptions) bool {
-						return true
-					},
-					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-						return true
-					},
-				},
-				{
-					ConfigFile:          "single-port-mtls-on.yaml",
-					Namespace:           rctx.Namespace,
-					RequiredEnvironment: environment.Kube,
-					Include: func(src echo.Instance, opts echo.CallOptions) bool {
-						// Include all tests that target app B, which has the single-port config.
-						return opts.Target == rctx.B
-					},
-					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-						return opts.PortName != "http"
-					},
-				},
-				{
-					ConfigFile:          "beta-mtls-on.yaml",
-					Namespace:           systemNM,
-					RequiredEnvironment: environment.Kube,
-					Include: func(src echo.Instance, opts echo.CallOptions) bool {
-						return true
-					},
-					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-						if src == rctx.Naked && opts.Target == rctx.Naked {
-							// naked->naked should always succeed.
-							return true
-						}
+				// 		// If one of the two endpoints is naked, expect failure.
+				// 		return src != rctx.Naked && opts.Target != rctx.Naked
+				// 	},
+				// },
+				// {
+				// 	ConfigFile:          "global-mtls-permissive.yaml",
+				// 	Namespace:           systemNM,
+				// 	RequiredEnvironment: environment.Kube,
+				// 	Include: func(src echo.Instance, opts echo.CallOptions) bool {
+				// 		// Exclude calls to the naked app.
+				// 		return opts.Target != rctx.Naked
+				// 	},
+				// 	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+				// 		return true
+				// 	},
+				// },
+				// {
+				// 	ConfigFile: "global-mtls-off.yaml",
+				// 	Namespace:  systemNM,
+				// 	Include: func(src echo.Instance, opts echo.CallOptions) bool {
+				// 		return true
+				// 	},
+				// 	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+				// 		return true
+				// 	},
+				// },
+				// {
+				// 	ConfigFile:          "single-port-mtls-on.yaml",
+				// 	Namespace:           rctx.Namespace,
+				// 	RequiredEnvironment: environment.Kube,
+				// 	Include: func(src echo.Instance, opts echo.CallOptions) bool {
+				// 		// Include all tests that target app B, which has the single-port config.
+				// 		return opts.Target == rctx.B
+				// 	},
+				// 	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+				// 		return opts.PortName != "http"
+				// 	},
+				// },
+				// {
+				// 	ConfigFile:          "beta-mtls-on.yaml",
+				// 	Namespace:           systemNM,
+				// 	RequiredEnvironment: environment.Kube,
+				// 	Include: func(src echo.Instance, opts echo.CallOptions) bool {
+				// 		return true
+				// 	},
+				// 	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+				// 		if src == rctx.Naked && opts.Target == rctx.Naked {
+				// 			// naked->naked should always succeed.
+				// 			return true
+				// 		}
 
-						// If one of the two endpoints is naked, expect failure.
-						return src != rctx.Naked && opts.Target != rctx.Naked
-					},
-				},
-				{
-					ConfigFile:          "beta-mtls-permissive.yaml",
-					Namespace:           systemNM,
-					RequiredEnvironment: environment.Kube,
-					Include: func(src echo.Instance, opts echo.CallOptions) bool {
-						// Exclude calls to the naked app.
-						return opts.Target != rctx.Naked
-					},
-					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-						return true
-					},
-				},
-				{
-					ConfigFile:          "beta-mtls-off.yaml",
-					Namespace:           systemNM,
-					RequiredEnvironment: environment.Kube,
-					Include: func(src echo.Instance, opts echo.CallOptions) bool {
-						return true
-					},
-					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-						return true
-					},
-				},
-				{
-					ConfigFile:          "beta-per-port-mtls.yaml",
-					Namespace:           rctx.Namespace,
-					RequiredEnvironment: environment.Kube,
-					Include: func(src echo.Instance, opts echo.CallOptions) bool {
-						// Include all tests that target app B, which has the single-port config.
-						return opts.Target == rctx.B
-					},
-					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-						return opts.PortName != "http"
-					},
-				},
-				{
-					ConfigFile:          "mix-mtls-api.yaml",
-					Namespace:           systemNM,
-					RequiredEnvironment: environment.Kube,
-					Include: func(src echo.Instance, opts echo.CallOptions) bool {
-						return true
-					},
-					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-						return true
-					},
-				},
-				{
-					ConfigFile:          "beta-mtls-automtls.yaml",
-					Namespace:           rctx.Namespace,
-					RequiredEnvironment: environment.Kube,
-					Include: func(src echo.Instance, opts echo.CallOptions) bool {
-						return true
-					},
-					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-						// autoMtls doesn't work for client that doesn't have proxy, unless target doesn't
-						// have proxy neither.
-						if src == rctx.Naked {
-							return opts.Target == rctx.Naked
-						}
-						return true
-					},
-				},
-				{
-					ConfigFile:          "beta-mtls-partial-automtls.yaml",
-					Namespace:           rctx.Namespace,
-					RequiredEnvironment: environment.Kube,
-					Include: func(src echo.Instance, opts echo.CallOptions) bool {
-						return true
-					},
-					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-						// autoMtls doesn't work for client that doesn't have proxy, unless target doesn't
-						// have proxy or have mTLS disabled
-						if src == rctx.Naked {
-							return opts.Target == rctx.Naked || (opts.Target == rctx.B && opts.PortName != "http")
+				// 		// If one of the two endpoints is naked, expect failure.
+				// 		return src != rctx.Naked && opts.Target != rctx.Naked
+				// 	},
+				// },
+				// {
+				// 	ConfigFile:          "beta-mtls-permissive.yaml",
+				// 	Namespace:           systemNM,
+				// 	RequiredEnvironment: environment.Kube,
+				// 	Include: func(src echo.Instance, opts echo.CallOptions) bool {
+				// 		// Exclude calls to the naked app.
+				// 		return opts.Target != rctx.Naked
+				// 	},
+				// 	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+				// 		return true
+				// 	},
+				// },
+				// {
+				// 	ConfigFile:          "beta-mtls-off.yaml",
+				// 	Namespace:           systemNM,
+				// 	RequiredEnvironment: environment.Kube,
+				// 	Include: func(src echo.Instance, opts echo.CallOptions) bool {
+				// 		return true
+				// 	},
+				// 	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+				// 		return true
+				// 	},
+				// },
+				// {
+				// 	ConfigFile:          "beta-per-port-mtls.yaml",
+				// 	Namespace:           rctx.Namespace,
+				// 	RequiredEnvironment: environment.Kube,
+				// 	Include: func(src echo.Instance, opts echo.CallOptions) bool {
+				// 		// Include all tests that target app B, which has the single-port config.
+				// 		return opts.Target == rctx.B
+				// 	},
+				// 	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+				// 		return opts.PortName != "http"
+				// 	},
+				// },
+				// {
+				// 	ConfigFile:          "mix-mtls-api.yaml",
+				// 	Namespace:           systemNM,
+				// 	RequiredEnvironment: environment.Kube,
+				// 	Include: func(src echo.Instance, opts echo.CallOptions) bool {
+				// 		return true
+				// 	},
+				// 	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+				// 		return true
+				// 	},
+				// },
+				// {
+				// 	ConfigFile:          "beta-mtls-automtls.yaml",
+				// 	Namespace:           rctx.Namespace,
+				// 	RequiredEnvironment: environment.Kube,
+				// 	Include: func(src echo.Instance, opts echo.CallOptions) bool {
+				// 		return true
+				// 	},
+				// 	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+				// 		// autoMtls doesn't work for client that doesn't have proxy, unless target doesn't
+				// 		// have proxy neither.
+				// 		if src == rctx.Naked {
+				// 			return opts.Target == rctx.Naked
+				// 		}
+				// 		return true
+				// 	},
+				// },
+				// {
+				// 	ConfigFile:          "beta-mtls-partial-automtls.yaml",
+				// 	Namespace:           rctx.Namespace,
+				// 	RequiredEnvironment: environment.Kube,
+				// 	Include: func(src echo.Instance, opts echo.CallOptions) bool {
+				// 		return true
+				// 	},
+				// 	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+				// 		// autoMtls doesn't work for client that doesn't have proxy, unless target doesn't
+				// 		// have proxy or have mTLS disabled
+				// 		if src == rctx.Naked {
+				// 			return opts.Target == rctx.Naked || (opts.Target == rctx.B && opts.PortName != "http")
 
-						}
-						// PeerAuthentication disable mTLS for workload app:b, except http port. Thus, autoMTLS
-						// will fail on all ports on b, except http port.
-						return opts.Target != rctx.B || opts.PortName == "http"
-					},
-				},
-				{
-					ConfigFile:          "alpha-mtls-automtls.yaml",
-					Namespace:           rctx.Namespace,
-					RequiredEnvironment: environment.Kube,
-					Include: func(src echo.Instance, opts echo.CallOptions) bool {
-						return true
-					},
-					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-						// autoMtls doesn't work for client that doesn't have proxy, unless target doesn't
-						// have proxy or have mTLS disabled.
-						if src == rctx.Naked {
-							return opts.Target == rctx.Naked || (opts.Target == rctx.B && opts.PortName != "http")
-						}
-						return true
-					},
-				},
-				{
-					ConfigFile:          "global-mtls-on-no-dr.yaml",
-					Namespace:           systemNM,
-					RequiredEnvironment: environment.Kube,
-					Include: func(src echo.Instance, opts echo.CallOptions) bool {
-						// Exclude calls to the headless service.
-						// Auto mtls does not apply to headless service, because for headless service
-						// the cluster discovery type is ORIGINAL_DST, and it will not apply upstream tls setting
-						return opts.Target != rctx.Headless
-					},
-					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-						// When mTLS is in STRICT mode, DR's TLS settings are default to mTLS so the result would
-						// be the same as having global DR rule.
-						if opts.Target == rctx.Naked {
-							// calls to naked should always succeed.
-							return true
-						}
+				// 		}
+				// 		// PeerAuthentication disable mTLS for workload app:b, except http port. Thus, autoMTLS
+				// 		// will fail on all ports on b, except http port.
+				// 		return opts.Target != rctx.B || opts.PortName == "http"
+				// 	},
+				// },
+				// {
+				// 	ConfigFile:          "alpha-mtls-automtls.yaml",
+				// 	Namespace:           rctx.Namespace,
+				// 	RequiredEnvironment: environment.Kube,
+				// 	Include: func(src echo.Instance, opts echo.CallOptions) bool {
+				// 		return true
+				// 	},
+				// 	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+				// 		// autoMtls doesn't work for client that doesn't have proxy, unless target doesn't
+				// 		// have proxy or have mTLS disabled.
+				// 		if src == rctx.Naked {
+				// 			return opts.Target == rctx.Naked || (opts.Target == rctx.B && opts.PortName != "http")
+				// 		}
+				// 		return true
+				// 	},
+				// },
+				// {
+				// 	ConfigFile:          "global-mtls-on-no-dr.yaml",
+				// 	Namespace:           systemNM,
+				// 	RequiredEnvironment: environment.Kube,
+				// 	Include: func(src echo.Instance, opts echo.CallOptions) bool {
+				// 		// Exclude calls to the headless service.
+				// 		// Auto mtls does not apply to headless service, because for headless service
+				// 		// the cluster discovery type is ORIGINAL_DST, and it will not apply upstream tls setting
+				// 		return opts.Target != rctx.Headless
+				// 	},
+				// 	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+				// 		// When mTLS is in STRICT mode, DR's TLS settings are default to mTLS so the result would
+				// 		// be the same as having global DR rule.
+				// 		if opts.Target == rctx.Naked {
+				// 			// calls to naked should always succeed.
+				// 			return true
+				// 		}
 
-						// If source is naked, and destination is not, expect failure.
-						return !(src == rctx.Naked && opts.Target != rctx.Naked)
-					},
-				},
-				{
-					ConfigFile:          "global-plaintext.yaml",
-					Namespace:           systemNM,
-					RequiredEnvironment: environment.Kube,
-					Include: func(src echo.Instance, opts echo.CallOptions) bool {
-						// Exclude calls to the headless TCP port.
-						if opts.Target == rctx.Headless && opts.PortName == "tcp" {
-							return false
-						}
+				// 		// If source is naked, and destination is not, expect failure.
+				// 		return !(src == rctx.Naked && opts.Target != rctx.Naked)
+				// 	},
+				// },
+				// {
+				// 	ConfigFile:          "global-plaintext.yaml",
+				// 	Namespace:           systemNM,
+				// 	RequiredEnvironment: environment.Kube,
+				// 	Include: func(src echo.Instance, opts echo.CallOptions) bool {
+				// 		// Exclude calls to the headless TCP port.
+				// 		if opts.Target == rctx.Headless && opts.PortName == "tcp" {
+				// 			return false
+				// 		}
 
-						return true
+				// 		return true
+				// 	},
+				// 	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+				// 		// When mTLS is disabled, all traffic should work.
+				// 		return true
+				// 	},
+				// },
+				{
+					ConfigFile:          "automtls-partial-sidecar-dr-no-tls.yaml",
+					RequiredEnvironment: environment.Kube,
+					Namespace:           systemNM,
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						// We only need one pair.
+						return src == rctx.A && opts.Target == rctx.Multiversion
 					},
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-						// When mTLS is disabled, all traffic should work.
 						return true
 					},
 				},

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -245,33 +245,33 @@ func TestReachability(t *testing.T) {
 				// 		return true
 				// 	},
 				// },
-				// ------------------------------
+				// --------start of auto mtls partial test cases ---------------
 				// The follow three consecutive test together ensures the auto mtls works as intended
 				// for sidecar migration scenario.
-				// {
-				// 	ConfigFile:          "automtls-partial-sidecar-dr-no-tls.yaml",
-				// 	RequiredEnvironment: environment.Kube,
-				// 	Namespace:           systemNM,
-				// 	CallOpts: []echo.CallOptions{
-				// 		{
-				// 			PortName: "http",
-				// 			Scheme:   scheme.HTTP,
-				// 			Path:     "/vistio",
-				// 		},
-				// 		{
-				// 			PortName: "http",
-				// 			Scheme:   scheme.HTTP,
-				// 			Path:     "/vlegacy",
-				// 		},
-				// 	},
-				// 	Include: func(src echo.Instance, opts echo.CallOptions) bool {
-				// 		// We only need one pair.
-				// 		return src == rctx.A && opts.Target == rctx.Multiversion
-				// 	},
-				// 	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-				// 		return true
-				// 	},
-				// },
+				{
+					ConfigFile:          "automtls-partial-sidecar-dr-no-tls.yaml",
+					RequiredEnvironment: environment.Kube,
+					Namespace:           systemNM,
+					CallOpts: []echo.CallOptions{
+						{
+							PortName: "http",
+							Scheme:   scheme.HTTP,
+							Path:     "/vistio",
+						},
+						{
+							PortName: "http",
+							Scheme:   scheme.HTTP,
+							Path:     "/vlegacy",
+						},
+					},
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						// We only need one pair.
+						return src == rctx.A && opts.Target == rctx.Multiversion
+					},
+					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+						return true
+					},
+				},
 				{
 					ConfigFile:          "automtls-partial-sidecar-dr-disable.yaml",
 					RequiredEnvironment: environment.Kube,

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -41,210 +41,210 @@ func TestReachability(t *testing.T) {
 			systemNM := namespace.ClaimSystemNamespaceOrFail(ctx, ctx)
 
 			testCases := []reachability.TestCase{
-				// {
-				// 	ConfigFile:          "global-mtls-on.yaml",
-				// 	Namespace:           systemNM,
-				// 	RequiredEnvironment: environment.Kube,
-				// 	Include: func(src echo.Instance, opts echo.CallOptions) bool {
-				// 		return true
-				// 	},
-				// 	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-				// 		if src == rctx.Naked && opts.Target == rctx.Naked {
-				// 			// naked->naked should always succeed.
-				// 			return true
-				// 		}
+				{
+					ConfigFile:          "global-mtls-on.yaml",
+					Namespace:           systemNM,
+					RequiredEnvironment: environment.Kube,
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						return true
+					},
+					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+						if src == rctx.Naked && opts.Target == rctx.Naked {
+							// naked->naked should always succeed.
+							return true
+						}
 
-				// 		// If one of the two endpoints is naked, expect failure.
-				// 		return src != rctx.Naked && opts.Target != rctx.Naked
-				// 	},
-				// },
-				// {
-				// 	ConfigFile:          "global-mtls-permissive.yaml",
-				// 	Namespace:           systemNM,
-				// 	RequiredEnvironment: environment.Kube,
-				// 	Include: func(src echo.Instance, opts echo.CallOptions) bool {
-				// 		// Exclude calls to the naked app.
-				// 		return opts.Target != rctx.Naked
-				// 	},
-				// 	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-				// 		return true
-				// 	},
-				// },
-				// {
-				// 	ConfigFile: "global-mtls-off.yaml",
-				// 	Namespace:  systemNM,
-				// 	Include: func(src echo.Instance, opts echo.CallOptions) bool {
-				// 		return true
-				// 	},
-				// 	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-				// 		return true
-				// 	},
-				// },
-				// {
-				// 	ConfigFile:          "single-port-mtls-on.yaml",
-				// 	Namespace:           rctx.Namespace,
-				// 	RequiredEnvironment: environment.Kube,
-				// 	Include: func(src echo.Instance, opts echo.CallOptions) bool {
-				// 		// Include all tests that target app B, which has the single-port config.
-				// 		return opts.Target == rctx.B
-				// 	},
-				// 	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-				// 		return opts.PortName != "http"
-				// 	},
-				// },
-				// {
-				// 	ConfigFile:          "beta-mtls-on.yaml",
-				// 	Namespace:           systemNM,
-				// 	RequiredEnvironment: environment.Kube,
-				// 	Include: func(src echo.Instance, opts echo.CallOptions) bool {
-				// 		return true
-				// 	},
-				// 	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-				// 		if src == rctx.Naked && opts.Target == rctx.Naked {
-				// 			// naked->naked should always succeed.
-				// 			return true
-				// 		}
+						// If one of the two endpoints is naked, expect failure.
+						return src != rctx.Naked && opts.Target != rctx.Naked
+					},
+				},
+				{
+					ConfigFile:          "global-mtls-permissive.yaml",
+					Namespace:           systemNM,
+					RequiredEnvironment: environment.Kube,
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						// Exclude calls to the naked app.
+						return opts.Target != rctx.Naked
+					},
+					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+						return true
+					},
+				},
+				{
+					ConfigFile: "global-mtls-off.yaml",
+					Namespace:  systemNM,
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						return true
+					},
+					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+						return true
+					},
+				},
+				{
+					ConfigFile:          "single-port-mtls-on.yaml",
+					Namespace:           rctx.Namespace,
+					RequiredEnvironment: environment.Kube,
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						// Include all tests that target app B, which has the single-port config.
+						return opts.Target == rctx.B
+					},
+					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+						return opts.PortName != "http"
+					},
+				},
+				{
+					ConfigFile:          "beta-mtls-on.yaml",
+					Namespace:           systemNM,
+					RequiredEnvironment: environment.Kube,
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						return true
+					},
+					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+						if src == rctx.Naked && opts.Target == rctx.Naked {
+							// naked->naked should always succeed.
+							return true
+						}
 
-				// 		// If one of the two endpoints is naked, expect failure.
-				// 		return src != rctx.Naked && opts.Target != rctx.Naked
-				// 	},
-				// },
-				// {
-				// 	ConfigFile:          "beta-mtls-permissive.yaml",
-				// 	Namespace:           systemNM,
-				// 	RequiredEnvironment: environment.Kube,
-				// 	Include: func(src echo.Instance, opts echo.CallOptions) bool {
-				// 		// Exclude calls to the naked app.
-				// 		return opts.Target != rctx.Naked
-				// 	},
-				// 	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-				// 		return true
-				// 	},
-				// },
-				// {
-				// 	ConfigFile:          "beta-mtls-off.yaml",
-				// 	Namespace:           systemNM,
-				// 	RequiredEnvironment: environment.Kube,
-				// 	Include: func(src echo.Instance, opts echo.CallOptions) bool {
-				// 		return true
-				// 	},
-				// 	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-				// 		return true
-				// 	},
-				// },
-				// {
-				// 	ConfigFile:          "beta-per-port-mtls.yaml",
-				// 	Namespace:           rctx.Namespace,
-				// 	RequiredEnvironment: environment.Kube,
-				// 	Include: func(src echo.Instance, opts echo.CallOptions) bool {
-				// 		// Include all tests that target app B, which has the single-port config.
-				// 		return opts.Target == rctx.B
-				// 	},
-				// 	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-				// 		return opts.PortName != "http"
-				// 	},
-				// },
-				// {
-				// 	ConfigFile:          "mix-mtls-api.yaml",
-				// 	Namespace:           systemNM,
-				// 	RequiredEnvironment: environment.Kube,
-				// 	Include: func(src echo.Instance, opts echo.CallOptions) bool {
-				// 		return true
-				// 	},
-				// 	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-				// 		return true
-				// 	},
-				// },
-				// {
-				// 	ConfigFile:          "beta-mtls-automtls.yaml",
-				// 	Namespace:           rctx.Namespace,
-				// 	RequiredEnvironment: environment.Kube,
-				// 	Include: func(src echo.Instance, opts echo.CallOptions) bool {
-				// 		return true
-				// 	},
-				// 	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-				// 		// autoMtls doesn't work for client that doesn't have proxy, unless target doesn't
-				// 		// have proxy neither.
-				// 		if src == rctx.Naked {
-				// 			return opts.Target == rctx.Naked
-				// 		}
-				// 		return true
-				// 	},
-				// },
-				// {
-				// 	ConfigFile:          "beta-mtls-partial-automtls.yaml",
-				// 	Namespace:           rctx.Namespace,
-				// 	RequiredEnvironment: environment.Kube,
-				// 	Include: func(src echo.Instance, opts echo.CallOptions) bool {
-				// 		return true
-				// 	},
-				// 	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-				// 		// autoMtls doesn't work for client that doesn't have proxy, unless target doesn't
-				// 		// have proxy or have mTLS disabled
-				// 		if src == rctx.Naked {
-				// 			return opts.Target == rctx.Naked || (opts.Target == rctx.B && opts.PortName != "http")
+						// If one of the two endpoints is naked, expect failure.
+						return src != rctx.Naked && opts.Target != rctx.Naked
+					},
+				},
+				{
+					ConfigFile:          "beta-mtls-permissive.yaml",
+					Namespace:           systemNM,
+					RequiredEnvironment: environment.Kube,
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						// Exclude calls to the naked app.
+						return opts.Target != rctx.Naked
+					},
+					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+						return true
+					},
+				},
+				{
+					ConfigFile:          "beta-mtls-off.yaml",
+					Namespace:           systemNM,
+					RequiredEnvironment: environment.Kube,
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						return true
+					},
+					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+						return true
+					},
+				},
+				{
+					ConfigFile:          "beta-per-port-mtls.yaml",
+					Namespace:           rctx.Namespace,
+					RequiredEnvironment: environment.Kube,
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						// Include all tests that target app B, which has the single-port config.
+						return opts.Target == rctx.B
+					},
+					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+						return opts.PortName != "http"
+					},
+				},
+				{
+					ConfigFile:          "mix-mtls-api.yaml",
+					Namespace:           systemNM,
+					RequiredEnvironment: environment.Kube,
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						return true
+					},
+					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+						return true
+					},
+				},
+				{
+					ConfigFile:          "beta-mtls-automtls.yaml",
+					Namespace:           rctx.Namespace,
+					RequiredEnvironment: environment.Kube,
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						return true
+					},
+					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+						// autoMtls doesn't work for client that doesn't have proxy, unless target doesn't
+						// have proxy neither.
+						if src == rctx.Naked {
+							return opts.Target == rctx.Naked
+						}
+						return true
+					},
+				},
+				{
+					ConfigFile:          "beta-mtls-partial-automtls.yaml",
+					Namespace:           rctx.Namespace,
+					RequiredEnvironment: environment.Kube,
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						return true
+					},
+					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+						// autoMtls doesn't work for client that doesn't have proxy, unless target doesn't
+						// have proxy or have mTLS disabled
+						if src == rctx.Naked {
+							return opts.Target == rctx.Naked || (opts.Target == rctx.B && opts.PortName != "http")
 
-				// 		}
-				// 		// PeerAuthentication disable mTLS for workload app:b, except http port. Thus, autoMTLS
-				// 		// will fail on all ports on b, except http port.
-				// 		return opts.Target != rctx.B || opts.PortName == "http"
-				// 	},
-				// },
-				// {
-				// 	ConfigFile:          "alpha-mtls-automtls.yaml",
-				// 	Namespace:           rctx.Namespace,
-				// 	RequiredEnvironment: environment.Kube,
-				// 	Include: func(src echo.Instance, opts echo.CallOptions) bool {
-				// 		return true
-				// 	},
-				// 	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-				// 		// autoMtls doesn't work for client that doesn't have proxy, unless target doesn't
-				// 		// have proxy or have mTLS disabled.
-				// 		if src == rctx.Naked {
-				// 			return opts.Target == rctx.Naked || (opts.Target == rctx.B && opts.PortName != "http")
-				// 		}
-				// 		return true
-				// 	},
-				// },
-				// {
-				// 	ConfigFile:          "global-mtls-on-no-dr.yaml",
-				// 	Namespace:           systemNM,
-				// 	RequiredEnvironment: environment.Kube,
-				// 	Include: func(src echo.Instance, opts echo.CallOptions) bool {
-				// 		// Exclude calls to the headless service.
-				// 		// Auto mtls does not apply to headless service, because for headless service
-				// 		// the cluster discovery type is ORIGINAL_DST, and it will not apply upstream tls setting
-				// 		return opts.Target != rctx.Headless
-				// 	},
-				// 	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-				// 		// When mTLS is in STRICT mode, DR's TLS settings are default to mTLS so the result would
-				// 		// be the same as having global DR rule.
-				// 		if opts.Target == rctx.Naked {
-				// 			// calls to naked should always succeed.
-				// 			return true
-				// 		}
+						}
+						// PeerAuthentication disable mTLS for workload app:b, except http port. Thus, autoMTLS
+						// will fail on all ports on b, except http port.
+						return opts.Target != rctx.B || opts.PortName == "http"
+					},
+				},
+				{
+					ConfigFile:          "alpha-mtls-automtls.yaml",
+					Namespace:           rctx.Namespace,
+					RequiredEnvironment: environment.Kube,
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						return true
+					},
+					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+						// autoMtls doesn't work for client that doesn't have proxy, unless target doesn't
+						// have proxy or have mTLS disabled.
+						if src == rctx.Naked {
+							return opts.Target == rctx.Naked || (opts.Target == rctx.B && opts.PortName != "http")
+						}
+						return true
+					},
+				},
+				{
+					ConfigFile:          "global-mtls-on-no-dr.yaml",
+					Namespace:           systemNM,
+					RequiredEnvironment: environment.Kube,
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						// Exclude calls to the headless service.
+						// Auto mtls does not apply to headless service, because for headless service
+						// the cluster discovery type is ORIGINAL_DST, and it will not apply upstream tls setting
+						return opts.Target != rctx.Headless
+					},
+					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+						// When mTLS is in STRICT mode, DR's TLS settings are default to mTLS so the result would
+						// be the same as having global DR rule.
+						if opts.Target == rctx.Naked {
+							// calls to naked should always succeed.
+							return true
+						}
 
-				// 		// If source is naked, and destination is not, expect failure.
-				// 		return !(src == rctx.Naked && opts.Target != rctx.Naked)
-				// 	},
-				// },
-				// {
-				// 	ConfigFile:          "global-plaintext.yaml",
-				// 	Namespace:           systemNM,
-				// 	RequiredEnvironment: environment.Kube,
-				// 	Include: func(src echo.Instance, opts echo.CallOptions) bool {
-				// 		// Exclude calls to the headless TCP port.
-				// 		if opts.Target == rctx.Headless && opts.PortName == "tcp" {
-				// 			return false
-				// 		}
+						// If source is naked, and destination is not, expect failure.
+						return !(src == rctx.Naked && opts.Target != rctx.Naked)
+					},
+				},
+				{
+					ConfigFile:          "global-plaintext.yaml",
+					Namespace:           systemNM,
+					RequiredEnvironment: environment.Kube,
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						// Exclude calls to the headless TCP port.
+						if opts.Target == rctx.Headless && opts.PortName == "tcp" {
+							return false
+						}
 
-				// 		return true
-				// 	},
-				// 	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-				// 		// When mTLS is disabled, all traffic should work.
-				// 		return true
-				// 	},
-				// },
+						return true
+					},
+					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+						// When mTLS is disabled, all traffic should work.
+						return true
+					},
+				},
 				// --------start of auto mtls partial test cases ---------------
 				// The follow three consecutive test together ensures the auto mtls works as intended
 				// for sidecar migration scenario.

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -251,7 +251,7 @@ func TestReachability(t *testing.T) {
 				{
 					ConfigFile:          "automtls-partial-sidecar-dr-no-tls.yaml",
 					RequiredEnvironment: environment.Kube,
-					Namespace:           systemNM,
+					Namespace:           rctx.Namespace,
 					CallOpts: []echo.CallOptions{
 						{
 							PortName: "http",
@@ -275,7 +275,7 @@ func TestReachability(t *testing.T) {
 				{
 					ConfigFile:          "automtls-partial-sidecar-dr-disable.yaml",
 					RequiredEnvironment: environment.Kube,
-					Namespace:           systemNM,
+					Namespace:           rctx.Namespace,
 					CallOpts: []echo.CallOptions{
 						{
 							PortName: "http",
@@ -300,7 +300,7 @@ func TestReachability(t *testing.T) {
 				{
 					ConfigFile:          "automtls-partial-sidecar-dr-mutual.yaml",
 					RequiredEnvironment: environment.Kube,
-					Namespace:           systemNM,
+					Namespace:           rctx.Namespace,
 					CallOpts: []echo.CallOptions{
 						{
 							PortName: "http",

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -245,20 +245,47 @@ func TestReachability(t *testing.T) {
 				// 		return true
 				// 	},
 				// },
+				// ------------------------------
+				// The follow three consecutive test together ensures the auto mtls works as intended
+				// for sidecar migration scenario.
+				// {
+				// 	ConfigFile:          "automtls-partial-sidecar-dr-no-tls.yaml",
+				// 	RequiredEnvironment: environment.Kube,
+				// 	Namespace:           systemNM,
+				// 	CallOpts: []echo.CallOptions{
+				// 		{
+				// 			PortName: "http",
+				// 			Scheme:   scheme.HTTP,
+				// 			Path:     "/vistio",
+				// 		},
+				// 		{
+				// 			PortName: "http",
+				// 			Scheme:   scheme.HTTP,
+				// 			Path:     "/vlegacy",
+				// 		},
+				// 	},
+				// 	Include: func(src echo.Instance, opts echo.CallOptions) bool {
+				// 		// We only need one pair.
+				// 		return src == rctx.A && opts.Target == rctx.Multiversion
+				// 	},
+				// 	ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+				// 		return true
+				// 	},
+				// },
 				{
-					ConfigFile:          "automtls-partial-sidecar-dr-no-tls.yaml",
+					ConfigFile:          "automtls-partial-sidecar-dr-disable.yaml",
 					RequiredEnvironment: environment.Kube,
 					Namespace:           systemNM,
 					CallOpts: []echo.CallOptions{
 						{
 							PortName: "http",
 							Scheme:   scheme.HTTP,
-							Path:     "/v1",
+							Path:     "/vistio",
 						},
 						{
 							PortName: "http",
 							Scheme:   scheme.HTTP,
-							Path:     "/v2-default",
+							Path:     "/vlegacy",
 						},
 					},
 					Include: func(src echo.Instance, opts echo.CallOptions) bool {
@@ -266,9 +293,36 @@ func TestReachability(t *testing.T) {
 						return src == rctx.A && opts.Target == rctx.Multiversion
 					},
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-						return true
+						// Only the request to legacy one succeeds as we disable mtls explicitly.
+						return opts.Path == "/vlegacy"
 					},
 				},
+				{
+					ConfigFile:          "automtls-partial-sidecar-dr-mutual.yaml",
+					RequiredEnvironment: environment.Kube,
+					Namespace:           systemNM,
+					CallOpts: []echo.CallOptions{
+						{
+							PortName: "http",
+							Scheme:   scheme.HTTP,
+							Path:     "/vistio",
+						},
+						{
+							PortName: "http",
+							Scheme:   scheme.HTTP,
+							Path:     "/vlegacy",
+						},
+					},
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						// We only need one pair.
+						return src == rctx.A && opts.Target == rctx.Multiversion
+					},
+					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+						// Only the request to vistio one succeeds as we enable mtls explicitly.
+						return opts.Path == "/vistio"
+					},
+				},
+				// ----- end of automtls partial test suites -----
 			}
 			rctx.Run(testCases)
 		})

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -17,6 +17,7 @@ package security
 import (
 	"testing"
 
+	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/environment"
@@ -248,6 +249,18 @@ func TestReachability(t *testing.T) {
 					ConfigFile:          "automtls-partial-sidecar-dr-no-tls.yaml",
 					RequiredEnvironment: environment.Kube,
 					Namespace:           systemNM,
+					CallOpts: []echo.CallOptions{
+						{
+							PortName: "http",
+							Scheme:   scheme.HTTP,
+							Path:     "/v1",
+						},
+						{
+							PortName: "http",
+							Scheme:   scheme.HTTP,
+							Path:     "/v2-default",
+						},
+					},
 					Include: func(src echo.Instance, opts echo.CallOptions) bool {
 						// We only need one pair.
 						return src == rctx.A && opts.Target == rctx.Multiversion

--- a/tests/integration/security/testdata/automtls-partial-sidecar-dr-disable.yaml
+++ b/tests/integration/security/testdata/automtls-partial-sidecar-dr-disable.yaml
@@ -3,7 +3,7 @@ kind: "PeerAuthentication"
 metadata:
   name: "default"
   annotations:
-    test-suite: "automtls-partial-sidecar-dr-no-tls"
+    test-suite: "automtls-partial-dr-disable"
 spec:
   mtls:
     mode: STRICT
@@ -13,7 +13,7 @@ kind: VirtualService
 metadata:
   name: "multiversion-route"
   annotations:
-    test-suite: "automtls-partial-sidecar-dr-no-tls"
+    test-suite: "automtls-partial-dr-disable"
 spec:
   hosts:
   - "multiversion"
@@ -37,7 +37,7 @@ kind: DestinationRule
 metadata:
   name: "multiversion"
   annotations:
-    test-suite: "automtls-partial-sidecar-dr-no-tls"
+    test-suite: "automtls-partial-dr-disable"
 spec:
   host: "multiversion"
   subsets:
@@ -47,3 +47,6 @@ spec:
   - name: "vlegacy"
     labels:
       version: "vlegacy"
+  trafficPolicy:
+    tls:
+      mode: DISABLE

--- a/tests/integration/security/testdata/automtls-partial-sidecar-dr-disable.yaml
+++ b/tests/integration/security/testdata/automtls-partial-sidecar-dr-disable.yaml
@@ -44,9 +44,15 @@ spec:
   - name: "vistio"
     labels:
       version: "vistio"
+    trafficPolicy:
+      tls:
+        mode: DISABLE
   - name: "vlegacy"
     labels:
       version: "vlegacy"
+    trafficPolicy:
+      tls:
+        mode: DISABLE
   trafficPolicy:
     tls:
       mode: DISABLE

--- a/tests/integration/security/testdata/automtls-partial-sidecar-dr-mutual.yaml
+++ b/tests/integration/security/testdata/automtls-partial-sidecar-dr-mutual.yaml
@@ -44,9 +44,15 @@ spec:
   - name: "vistio"
     labels:
       version: "vistio"
+    trafficPolicy:
+      tls:
+        mode: ISTIO_MUTUAL
   - name: "vlegacy"
     labels:
       version: "vlegacy"
+    trafficPolicy:
+      tls:
+        mode: ISTIO_MUTUAL
   trafficPolicy:
     tls:
-      mode: DISABLE
+      mode: ISTIO_MUTUAL

--- a/tests/integration/security/testdata/automtls-partial-sidecar-dr-mutual.yaml
+++ b/tests/integration/security/testdata/automtls-partial-sidecar-dr-mutual.yaml
@@ -3,7 +3,7 @@ kind: "PeerAuthentication"
 metadata:
   name: "default"
   annotations:
-    test-suite: "automtls-partial-sidecar-dr-no-tls"
+    test-suite: "automtls-partial-dr-mutual"
 spec:
   mtls:
     mode: STRICT
@@ -13,7 +13,7 @@ kind: VirtualService
 metadata:
   name: "multiversion-route"
   annotations:
-    test-suite: "automtls-partial-sidecar-dr-no-tls"
+    test-suite: "automtls-partial-dr-mutual"
 spec:
   hosts:
   - "multiversion"
@@ -37,7 +37,7 @@ kind: DestinationRule
 metadata:
   name: "multiversion"
   annotations:
-    test-suite: "automtls-partial-sidecar-dr-no-tls"
+    test-suite: "automtls-partial-dr-mutual"
 spec:
   host: "multiversion"
   subsets:
@@ -47,3 +47,6 @@ spec:
   - name: "vlegacy"
     labels:
       version: "vlegacy"
+  trafficPolicy:
+    tls:
+      mode: DISABLE

--- a/tests/integration/security/testdata/automtls-partial-sidecar-dr-no-tls.yaml
+++ b/tests/integration/security/testdata/automtls-partial-sidecar-dr-no-tls.yaml
@@ -1,0 +1,50 @@
+# Alpha API disable, making test more hermetic.
+apiVersion: authentication.istio.io/v1alpha1
+kind: MeshPolicy
+metadata:
+  name: "default"
+  annotations:
+    test-suite: "beta-mtls-workload-automtls"
+spec: {}
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: "multiversion-route"
+  annotations:
+    test-suite: "beta-mtls-workload-automtls"
+spec:
+  hosts:
+  - "multiversion"
+  http:
+  - name: "v1-route"
+    match:
+    - uri:
+        prefix: "/v1"
+    rewrite:
+      uri: "/v1"
+    route:
+    - destination:
+        host: "multiversion"
+        subset: "v1"
+  - name: "v2-route-by-default"
+    route:
+    - destination:
+        host: "multiversion"
+        subset: "v2"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: "multiversion-subset"
+  annotations:
+    test-suite: "beta-mtls-workload-automtls"
+spec:
+  host: "multiversion"
+  subsets:
+  - name: "v1"
+    labels:
+      version: "v1"
+  - name: "v2"
+    labels:
+      version: "v2"

--- a/tests/integration/security/util/reachability/context.go
+++ b/tests/integration/security/util/reachability/context.go
@@ -81,11 +81,13 @@ func CreateContext(ctx framework.TestContext, g galley.Instance, p pilot.Instanc
 	var a, b, multiVersion, headless, naked echo.Instance
 	cfg := util.EchoConfig("multiversion", ns, false, nil, g, p)
 	cfg.Subsets = []echo.SubsetConfig{
+		// Istio deployment, with sidecar.
 		{
-			Version: "v1",
+			Version: "vistio",
 		},
+		// Legacy deployment subset, does not have sidecar injected.
 		{
-			Version:     "v-legacy",
+			Version:     "vlegacy",
 			Annotations: echo.NewAnnotations().SetBool(echo.SidecarInject, false),
 		},
 	}


### PR DESCRIPTION
This utilize the recent added feature of testing framework, to support multiple subsets in a single echo instance. This allows us to annotate sidecar inject true/false within a single service.

We have three test cases. All of them are having multiversion app, deployed as vistio(sidecar injected) and vlegacy(no sidecar). We define DestintaionRule subsets and virtual service routing to ensure request are routed correctly to the right workloads, making test deterministcally.

3 test cases together shows either ISTIO_MUTUAL or DISABLE can't work, auto mtls works for both of them.

we cant use nake app since no determinstic routing can be used there.