### PR TITLE
Make sidecar selection not require a service in ns

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -96,7 +96,8 @@ type PushContext struct {
 	allExportedDestRules       *processedDestRules
 
 	// sidecars for each namespace
-	sidecarsByNamespace map[string][]*SidecarScope
+	sidecarsByNamespace  map[string][]*SidecarScope
+	defaultSidecarConfig *Config
 	// envoy filters for each namespace including global config namespace
 	envoyFiltersByNamespace map[string][]*EnvoyFilterWrapper
 	// gateways for each namespace
@@ -753,7 +754,7 @@ func (ps *PushContext) getSidecarScope(proxy *Proxy, workloadLabels labels.Colle
 		}
 	}
 
-	return DefaultSidecarScopeForNamespace(ps, proxy.ConfigNamespace)
+	return ConvertToSidecarScope(ps, ps.defaultSidecarConfig, proxy.ConfigNamespace)
 }
 
 // GetAllSidecarScopes returns a map of namespace and the set of SidecarScope
@@ -1422,6 +1423,8 @@ func (ps *PushContext) initSidecarScopes(env *Environment) error {
 			}
 		}
 	}
+
+	ps.defaultSidecarConfig = rootNSConfig
 
 	return nil
 }


### PR DESCRIPTION
Currently, if you have a namespace with no Services, Sidecar selection
fails. This is because we precompute the sidecar scope for "all"
namespaces, but we get namespaces from the list of Services in
the cluster. As a result, if there is no service, we don't compute
anything for that namespace.

Technically, we require a Service:
https://istio.io/docs/ops/deployment/requirements/, but its pretty poor
behavior. On the other hand, this is inefficient and adds complexity for
a weird edge case.

@hzxuzhonghu @rshriram @ramaraochavali I am not convinced this is a good idea, so I figured I would send this out an get opinions