### PR TITLE
Fix a typo in egressGateways.k8s.hpaSpec.scaleTargetRef.name

### DIFF
--- a/operator/cmd/mesh/testdata/profile-dump/output/all_off.yaml
+++ b/operator/cmd/mesh/testdata/profile-dump/output/all_off.yaml
@@ -44,7 +44,7 @@ spec:
           scaleTargetRef:
             apiVersion: apps/v1
             kind: Deployment
-            name: istio-ingressgateway
+            name: istio-egressgateway
         resources:
           limits:
             cpu: 2000m

--- a/operator/cmd/mesh/testdata/profile-dump/output/config_path.yaml
+++ b/operator/cmd/mesh/testdata/profile-dump/output/config_path.yaml
@@ -23,7 +23,7 @@ egressGateways:
       scaleTargetRef:
         apiVersion: apps/v1
         kind: Deployment
-        name: istio-ingressgateway
+        name: istio-egressgateway
     resources:
       limits:
         cpu: 2000m

--- a/operator/data/profiles/default.yaml
+++ b/operator/data/profiles/default.yaml
@@ -161,7 +161,7 @@ spec:
           scaleTargetRef:
             apiVersion: apps/v1
             kind: Deployment
-            name: istio-ingressgateway
+            name: istio-egressgateway
           metrics:
             - type: Resource
               resource:

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -46175,7 +46175,7 @@ spec:
           scaleTargetRef:
             apiVersion: apps/v1
             kind: Deployment
-            name: istio-ingressgateway
+            name: istio-egressgateway
           metrics:
             - type: Resource
               resource:


### PR DESCRIPTION
Issue found here: https://github.com/istio/istio/pull/21942