### PR TITLE
feat: adds istioctl operator 'dump' sub command

### DIFF
--- a/operator/cmd/mesh/operator-common.go
+++ b/operator/cmd/mesh/operator-common.go
@@ -14,7 +14,22 @@
 
 package mesh
 
-import "istio.io/istio/operator/pkg/manifest"
+import (
+	"istio.io/istio/operator/pkg/helm"
+	"istio.io/istio/operator/pkg/manifest"
+	"istio.io/istio/operator/pkg/util"
+)
+
+type operatorCommonArgs struct {
+	// hub is the hub for the operator image.
+	hub string
+	// tag is the tag for the operator image.
+	tag string
+	// operatorNamespace is the namespace the operator controller is installed into.
+	operatorNamespace string
+	// istioNamespace is the namespace Istio is installed into.
+	istioNamespace string
+}
 
 const (
 	operatorResourceName = "istio-operator"
@@ -22,4 +37,41 @@ const (
 
 func isControllerInstalled(kubeconfig, context, operatorNamespace string) (bool, error) {
 	return manifest.DeploymentExists(kubeconfig, context, operatorNamespace, operatorResourceName)
+}
+
+// chartsRootDir, helmBaseDir, componentName, namespace string) (Template, TemplateRenderer, error) {
+func renderOperatorManifest(_ *rootArgs, ocArgs *operatorCommonArgs, _ *Logger) (string, string, error) {
+	r, err := helm.NewHelmRenderer("", "../operator-chart", istioControllerComponentName, ocArgs.operatorNamespace)
+	if err != nil {
+		return "", "", err
+	}
+
+	if err := r.Run(); err != nil {
+		return "", "", err
+	}
+
+	tmpl := `
+operatorNamespace: {{.OperatorNamespace}}
+istioNamespace: {{.IstioNamespace}}
+hub: {{.Hub}}
+tag: {{.Tag}}
+`
+
+	tv := struct {
+		OperatorNamespace string
+		IstioNamespace    string
+		Hub               string
+		Tag               string
+	}{
+		OperatorNamespace: ocArgs.operatorNamespace,
+		IstioNamespace:    ocArgs.istioNamespace,
+		Hub:               ocArgs.hub,
+		Tag:               ocArgs.tag,
+	}
+	vals, err := util.RenderTemplate(tmpl, tv)
+	if err != nil {
+		return "", "", err
+	}
+	manifest, err := r.RenderManifest(vals)
+	return vals, manifest, err
 }

--- a/operator/cmd/mesh/operator-dump.go
+++ b/operator/cmd/mesh/operator-dump.go
@@ -16,6 +16,7 @@ package mesh
 
 import (
 	"github.com/spf13/cobra"
+
 	buildversion "istio.io/pkg/version"
 )
 

--- a/operator/cmd/mesh/operator-dump.go
+++ b/operator/cmd/mesh/operator-dump.go
@@ -1,0 +1,62 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mesh
+
+import (
+	"github.com/spf13/cobra"
+	buildversion "istio.io/pkg/version"
+)
+
+type operatorDumpArgs struct {
+	// common is shared operator args
+	common operatorCommonArgs
+}
+
+func addOperatorDumpFlags(cmd *cobra.Command, args *operatorDumpArgs) {
+	hub, tag := buildversion.DockerInfo.Hub, buildversion.DockerInfo.Tag
+	if hub == "" {
+		hub = "gcr.io/istio-testing"
+	}
+	if tag == "" {
+		tag = "latest"
+	}
+	cmd.PersistentFlags().StringVar(&args.common.hub, "hub", hub, "The hub for the operator controller image")
+	cmd.PersistentFlags().StringVar(&args.common.tag, "tag", tag, "The tag for the operator controller image")
+	cmd.PersistentFlags().StringVar(&args.common.operatorNamespace, "operatorNamespace", "istio-operator",
+		"The namespace the operator controller is installed into")
+	cmd.PersistentFlags().StringVar(&args.common.istioNamespace, "istioNamespace", "istio-system",
+		"The namespace Istio is installed into")
+}
+
+func operatorDumpCmd(rootArgs *rootArgs, odArgs *operatorDumpArgs) *cobra.Command {
+	return &cobra.Command{
+		Use:   "dump",
+		Short: "Dumps the Istio operator controller manifest.",
+		Long:  "The dump subcommand dumps the Istio operator controller manifest.",
+		Args:  cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			l := NewLogger(rootArgs.logToStdErr, cmd.OutOrStdout(), cmd.ErrOrStderr())
+			operatorDump(rootArgs, odArgs, l)
+		}}
+}
+
+func operatorDump(args *rootArgs, odArgs *operatorDumpArgs, l *Logger) {
+	_, mstr, err := renderOperatorManifest(args, &odArgs.common, l)
+	if err != nil {
+		l.logAndFatal(err)
+	}
+
+	l.print(mstr)
+}

--- a/operator/cmd/mesh/operator-init.go
+++ b/operator/cmd/mesh/operator-init.go
@@ -26,7 +26,6 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/utils/pointer"
 
-	"istio.io/istio/operator/pkg/helm"
 	"istio.io/istio/operator/pkg/kubectlcmd"
 	"istio.io/istio/operator/pkg/manifest"
 	"istio.io/istio/operator/pkg/name"
@@ -37,14 +36,9 @@ import (
 )
 
 type operatorInitArgs struct {
-	// hub is the hub for the operator image.
-	hub string
-	// tag is the tag for the operator image.
-	tag string
-	// operatorNamespace is the namespace the operator controller is installed into.
-	operatorNamespace string
-	// istioNamespace is the namespace Istio is installed into.
-	istioNamespace string
+	// common is shared operator args
+	common operatorCommonArgs
+
 	// inFilenames is the path to the input IstioOperator CR.
 	inFilename string
 
@@ -87,11 +81,11 @@ func addOperatorInitFlags(cmd *cobra.Command, args *operatorInitArgs) {
 	cmd.PersistentFlags().BoolVarP(&args.wait, "wait", "w", false, "Wait, if set will wait until all Pods, Services, and minimum number of Pods "+
 		"of a Deployment are in a ready state before the command exits. It will wait for a maximum duration of --readiness-timeout seconds")
 
-	cmd.PersistentFlags().StringVar(&args.hub, "hub", hub, "The hub for the operator controller image")
-	cmd.PersistentFlags().StringVar(&args.tag, "tag", tag, "The tag for the operator controller image")
-	cmd.PersistentFlags().StringVar(&args.operatorNamespace, "operatorNamespace", "istio-operator",
+	cmd.PersistentFlags().StringVar(&args.common.hub, "hub", hub, "The hub for the operator controller image")
+	cmd.PersistentFlags().StringVar(&args.common.tag, "tag", tag, "The tag for the operator controller image")
+	cmd.PersistentFlags().StringVar(&args.common.operatorNamespace, "operatorNamespace", "istio-operator",
 		"The namespace the operator controller is installed into")
-	cmd.PersistentFlags().StringVar(&args.istioNamespace, "istioNamespace", "istio-system",
+	cmd.PersistentFlags().StringVar(&args.common.istioNamespace, "istioNamespace", "istio-system",
 		"The namespace Istio is installed into")
 }
 
@@ -112,18 +106,19 @@ func operatorInit(args *rootArgs, oiArgs *operatorInitArgs, l *Logger, apply man
 	initLogsOrExit(args)
 
 	// Error here likely indicates Deployment is missing. If some other K8s error, we will hit it again later.
-	already, _ := isControllerInstalled(oiArgs.kubeConfigPath, oiArgs.context, oiArgs.operatorNamespace)
+	already, _ := isControllerInstalled(oiArgs.kubeConfigPath, oiArgs.context, oiArgs.common.operatorNamespace)
 	if already {
-		l.logAndPrintf("Operator controller is already installed in %s namespace, updating.", oiArgs.operatorNamespace)
+		l.logAndPrintf("Operator controller is already installed in %s namespace, updating.", oiArgs.common.operatorNamespace)
 	}
 
-	l.logAndPrintf("Using operator Deployment image: %s/operator:%s", oiArgs.hub, oiArgs.tag)
+	l.logAndPrintf("Using operator Deployment image: %s/operator:%s", oiArgs.common.hub, oiArgs.common.tag)
 
-	mstr, err := renderOperatorManifest(args, oiArgs, l)
+	vals, mstr, err := renderOperatorManifest(args, &oiArgs.common, l)
 	if err != nil {
 		l.logAndFatal(err)
 	}
 
+	scope.Infof("Installing operator charts with the following values:\n%s", vals)
 	scope.Infof("Using the following manifest to install operator:\n%s\n", mstr)
 
 	opts := &kubectlcmd.Options{
@@ -209,43 +204,6 @@ func getCRAndNamespaceFromFile(filePath string, l *Logger) (customResource strin
 	customResource = string(b)
 	istioNamespace = v1alpha1.Namespace(mergedIOPS)
 	return
-}
-
-// chartsRootDir, helmBaseDir, componentName, namespace string) (TemplateRenderer, error) {
-func renderOperatorManifest(_ *rootArgs, oiArgs *operatorInitArgs, _ *Logger) (string, error) {
-	r, err := helm.NewHelmRenderer("", "../operator-chart", istioControllerComponentName, oiArgs.operatorNamespace)
-	if err != nil {
-		return "", err
-	}
-
-	if err := r.Run(); err != nil {
-		return "", err
-	}
-
-	tmpl := `
-operatorNamespace: {{.OperatorNamespace}}
-istioNamespace: {{.IstioNamespace}}
-hub: {{.Hub}}
-tag: {{.Tag}}
-`
-
-	tv := struct {
-		OperatorNamespace string
-		IstioNamespace    string
-		Hub               string
-		Tag               string
-	}{
-		OperatorNamespace: oiArgs.operatorNamespace,
-		IstioNamespace:    oiArgs.istioNamespace,
-		Hub:               oiArgs.hub,
-		Tag:               oiArgs.tag,
-	}
-	vals, err := util.RenderTemplate(tmpl, tv)
-	if err != nil {
-		return "", err
-	}
-	scope.Infof("Installing operator charts with the following values:\n%s", vals)
-	return r.RenderManifest(vals)
 }
 
 func genNamespaceResource(namespace string) string {

--- a/operator/cmd/mesh/operator-remove.go
+++ b/operator/cmd/mesh/operator-remove.go
@@ -59,20 +59,20 @@ func operatorRemoveCmd(rootArgs *rootArgs, orArgs *operatorRemoveArgs) *cobra.Co
 func operatorRemove(args *rootArgs, orArgs *operatorRemoveArgs, l *Logger, deleteManifestFunc manifestDeleter) {
 	initLogsOrExit(args)
 
-	installed, err := isControllerInstalled(orArgs.kubeConfigPath, orArgs.context, orArgs.operatorNamespace)
+	installed, err := isControllerInstalled(orArgs.kubeConfigPath, orArgs.context, orArgs.common.operatorNamespace)
 	if installed && err != nil {
 		l.logAndFatal(err)
 	}
 	if !installed {
-		l.logAndPrintf("Operator controller is not installed in %s namespace (no Deployment detected).", orArgs.operatorNamespace)
+		l.logAndPrintf("Operator controller is not installed in %s namespace (no Deployment detected).", orArgs.common.operatorNamespace)
 		if !orArgs.force {
 			l.logAndFatal("Aborting, use --force to override.")
 		}
 	}
 
-	l.logAndPrintf("Using operator Deployment image: %s/operator:%s", orArgs.hub, orArgs.tag)
+	l.logAndPrintf("Using operator Deployment image: %s/operator:%s", orArgs.common.hub, orArgs.common.tag)
 
-	mstr, err := renderOperatorManifest(args, &orArgs.operatorInitArgs, l)
+	_, mstr, err := renderOperatorManifest(args, &orArgs.common, l)
 	if err != nil {
 		l.logAndFatal(err)
 	}

--- a/operator/cmd/mesh/operator.go
+++ b/operator/cmd/mesh/operator.go
@@ -26,19 +26,24 @@ func OperatorCmd() *cobra.Command {
 		Long:  "The operator subcommand installs, removes and shows the status of the operator controller.",
 	}
 
+	odArgs := &operatorDumpArgs{}
 	oiArgs := &operatorInitArgs{}
 	orArgs := &operatorRemoveArgs{}
 	args := &rootArgs{}
 
+	odc := operatorDumpCmd(args, odArgs)
 	oic := operatorInitCmd(args, oiArgs)
 	orc := operatorRemoveCmd(args, orArgs)
 
+	addFlags(odc, args)
 	addFlags(oic, args)
 	addFlags(orc, args)
 
+	addOperatorDumpFlags(odc, odArgs)
 	addOperatorInitFlags(oic, oiArgs)
 	addOperatorRemoveFlags(orc, orArgs)
 
+	oc.AddCommand(odc)
 	oc.AddCommand(oic)
 	oc.AddCommand(orc)
 


### PR DESCRIPTION
Signed-off-by: Marshall Ford <inbox@marshallford.me>

As the title suggests, this PR adds a `dump` option to the `istioctl operator` command. Fixes #21243.

Couple of notes:

1. Please let me know if the `common` args struct goes against Go or Istio conventions. I can take another stab at it if need be.

2. I would expect some documentation needs to be updated, I'll poke around the repo and see what I can find besides `istio/operator/README.md` .

3. ~~I'm working on understanding how to test this, more to come.~~