### PR TITLE
[release-1.5] Fix a typo in egressGateways.k8s.hpaSpec.scaleTargetRef.name

### DIFF
--- a/mixer/adapter/stackdriver/internal/cloud.google.com/go/contextgraph/apiv1alpha1/mock_test.go
+++ b/mixer/adapter/stackdriver/internal/cloud.google.com/go/contextgraph/apiv1alpha1/mock_test.go
@@ -17,10 +17,6 @@
 package contextgraph
 
 import (
-	contextgraphpb "istio.io/istio/mixer/adapter/stackdriver/internal/google.golang.org/genproto/googleapis/cloud/contextgraph/v1alpha1"
-)
-
-import (
 	"flag"
 	"fmt"
 	"io"
@@ -34,10 +30,14 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"golang.org/x/net/context"
 	"google.golang.org/api/option"
+
+	contextgraphpb "istio.io/istio/mixer/adapter/stackdriver/internal/google.golang.org/genproto/googleapis/cloud/contextgraph/v1alpha1"
+
 	status "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+
 	gstatus "google.golang.org/grpc/status"
 )
 

--- a/operator/cmd/mesh/testdata/profile-dump/output/all_off.yaml
+++ b/operator/cmd/mesh/testdata/profile-dump/output/all_off.yaml
@@ -44,7 +44,7 @@ spec:
           scaleTargetRef:
             apiVersion: apps/v1
             kind: Deployment
-            name: istio-ingressgateway
+            name: istio-egressgateway
         resources:
           limits:
             cpu: 2000m

--- a/operator/cmd/mesh/testdata/profile-dump/output/config_path.yaml
+++ b/operator/cmd/mesh/testdata/profile-dump/output/config_path.yaml
@@ -23,7 +23,7 @@ egressGateways:
       scaleTargetRef:
         apiVersion: apps/v1
         kind: Deployment
-        name: istio-ingressgateway
+        name: istio-egressgateway
     resources:
       limits:
         cpu: 2000m

--- a/operator/data/profiles/default.yaml
+++ b/operator/data/profiles/default.yaml
@@ -178,7 +178,7 @@ spec:
           scaleTargetRef:
             apiVersion: apps/v1
             kind: Deployment
-            name: istio-ingressgateway
+            name: istio-egressgateway
           metrics:
             - type: Resource
               resource:

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -39931,7 +39931,7 @@ spec:
           scaleTargetRef:
             apiVersion: apps/v1
             kind: Deployment
-            name: istio-ingressgateway
+            name: istio-egressgateway
           metrics:
             - type: Resource
               resource:


### PR DESCRIPTION
This is a cherry-pick of #21947

