### PR TITLE
Add basic benchmark for pilot config gen

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/cds.go
+++ b/pilot/pkg/proxy/envoy/v2/cds.go
@@ -24,7 +24,7 @@ import (
 )
 
 // clusters aggregate a DiscoveryResponse for pushing.
-func (conn *XdsConnection) clusters(response []*xdsapi.Cluster, noncePrefix string) *xdsapi.DiscoveryResponse {
+func cdsDiscoveryResponse(response []*xdsapi.Cluster, noncePrefix string) *xdsapi.DiscoveryResponse {
 	out := &xdsapi.DiscoveryResponse{
 		// All resources for CDS ought to be of the type ClusterLoadAssignment
 		TypeUrl: ClusterType,
@@ -53,7 +53,7 @@ func (s *DiscoveryServer) pushCds(con *XdsConnection, push *model.PushContext, v
 	if s.DebugConfigs {
 		con.CDSClusters = rawClusters
 	}
-	response := con.clusters(rawClusters, push.Version)
+	response := cdsDiscoveryResponse(rawClusters, push.Version)
 	err := con.send(response)
 	cdsPushTime.Record(time.Since(pushStart).Seconds())
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/16940

This adds some basic benchmarking for all XDS generation. Right now we
don't have any variance in terms of the inputs, but that can easily be
extended later. The short term goal here is a low effort way to see the
impacts of changes to this code paths. We don't run this in CI yet
(tracking in https://github.com/istio/istio/issues/18135) but hopefully
we will soon so we can also detect any regressions.