### PR TITLE
fix wait logic when waiting for the root cert

### DIFF
--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -281,7 +281,7 @@ func (sc *SecretCache) GenerateSecret(ctx context.Context, connectionID, resourc
 		wait := retryWaitDuration
 		retryNum := 0
 		for ; retryNum < maxRetryNum; retryNum++ {
-			time.Sleep(retryWaitDuration)
+			time.Sleep(wait)
 			if sc.rootCert != nil {
 				break
 			}


### PR DESCRIPTION
This PR is for the wait logic when generate secret in SDS service, there is a wait time which should be double during retry, but seems in the origin logic the wait parameter is not used and it always waiting with the initial duration.