### PR TITLE
cluster: refactor destination rule logic

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -192,8 +192,6 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(proxy *model.Proxy, 
 
 			subsetClusters := applyDestinationRule(defaultCluster, DefaultClusterMode, service, port, proxy, networkView, push)
 
-			maybeApplyEdsConfig(defaultCluster)
-
 			// call plugins for subset clusters.
 			for _, subsetCluster := range subsetClusters {
 				for _, p := range configgen.Plugins {
@@ -239,7 +237,6 @@ func (configgen *ConfigGeneratorImpl) buildOutboundSniDnatClusters(proxy *model.
 			}
 			clusters = append(clusters, defaultCluster)
 			clusters = append(clusters, applyDestinationRule(defaultCluster, SniDnatClusterMode, service, port, proxy, networkView, push)...)
-			maybeApplyEdsConfig(defaultCluster)
 		}
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -189,9 +189,10 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(proxy *model.Proxy, 
 
 			setUpstreamProtocol(proxy, defaultCluster, port, model.TrafficDirectionOutbound)
 			clusters = append(clusters, defaultCluster)
-			maybeApplyEdsConfig(defaultCluster)
 
 			subsetClusters := applyDestinationRule(defaultCluster, DefaultClusterMode, service, port, proxy, networkView, push)
+
+			maybeApplyEdsConfig(defaultCluster)
 
 			// call plugins for subset clusters.
 			for _, subsetCluster := range subsetClusters {
@@ -237,8 +238,8 @@ func (configgen *ConfigGeneratorImpl) buildOutboundSniDnatClusters(proxy *model.
 				continue
 			}
 			clusters = append(clusters, defaultCluster)
-			maybeApplyEdsConfig(defaultCluster)
 			clusters = append(clusters, applyDestinationRule(defaultCluster, SniDnatClusterMode, service, port, proxy, networkView, push)...)
+			maybeApplyEdsConfig(defaultCluster)
 		}
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -152,7 +152,7 @@ func normalizeClusters(metrics model.Metrics, proxy *model.Proxy, clusters []*ap
 
 func (configgen *ConfigGeneratorImpl) buildOutboundClusters(proxy *model.Proxy, push *model.PushContext) []*apiv2.Cluster {
 	clusters := make([]*apiv2.Cluster, 0)
-
+	cb := NewClusterBuilder(proxy, push)
 	inputParams := &plugin.InputParams{
 		Push: push,
 		Node: proxy,
@@ -189,8 +189,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(proxy *model.Proxy, 
 
 			setUpstreamProtocol(proxy, defaultCluster, port, model.TrafficDirectionOutbound)
 			clusters = append(clusters, defaultCluster)
-
-			subsetClusters := applyDestinationRule(defaultCluster, DefaultClusterMode, service, port, proxy, networkView, push)
+			subsetClusters := cb.applyDestinationRule(defaultCluster, DefaultClusterMode, service, port, networkView)
 
 			// call plugins for subset clusters.
 			for _, subsetCluster := range subsetClusters {
@@ -214,6 +213,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(proxy *model.Proxy, 
 // All SniDnat clusters are internal services in the mesh.
 func (configgen *ConfigGeneratorImpl) buildOutboundSniDnatClusters(proxy *model.Proxy, push *model.PushContext) []*apiv2.Cluster {
 	clusters := make([]*apiv2.Cluster, 0)
+	cb := NewClusterBuilder(proxy, push)
 
 	networkView := model.GetNetworkView(proxy)
 
@@ -236,7 +236,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundSniDnatClusters(proxy *model.
 				continue
 			}
 			clusters = append(clusters, defaultCluster)
-			clusters = append(clusters, applyDestinationRule(defaultCluster, SniDnatClusterMode, service, port, proxy, networkView, push)...)
+			clusters = append(clusters, cb.applyDestinationRule(defaultCluster, SniDnatClusterMode, service, port, networkView)...)
 		}
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -18,6 +18,7 @@ import (
 	apiv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
+
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
@@ -79,7 +80,8 @@ func applyDestinationRule(cluster *apiv2.Cluster, clusterMode ClusterMode, servi
 			lbEndpoints = buildLocalityLbEndpoints(push, proxyNetworkView, service, port.Port, []labels.Instance{subset.Labels})
 		}
 
-		subsetCluster := buildDefaultCluster(push, subsetClusterName, cluster.GetType(), lbEndpoints, model.TrafficDirectionOutbound, proxy, nil, service.MeshExternal)
+		subsetCluster := buildDefaultCluster(push, subsetClusterName, cluster.GetType(), lbEndpoints,
+			model.TrafficDirectionOutbound, proxy, nil, service.MeshExternal)
 
 		if subsetCluster == nil {
 			continue

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -1,0 +1,139 @@
+// Copyright 2020 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha3
+
+import (
+	apiv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
+	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/istio/pkg/config/labels"
+)
+
+var (
+	defaultDestinationRule = networking.DestinationRule{}
+)
+
+// applyDestinationRule applies the destination rule if it exists for the Service. It returns the subset clusters if any created as it
+// applies the destination rule.
+func applyDestinationRule(cluster *apiv2.Cluster, clusterMode ClusterMode, service *model.Service, port *model.Port, proxy *model.Proxy,
+	proxyNetworkView map[string]bool, push *model.PushContext) []*apiv2.Cluster {
+	destRule := push.DestinationRule(proxy, service)
+	destinationRule := castDestinationRuleOrDefault(destRule)
+
+	opts := buildClusterOpts{
+		push:        push,
+		cluster:     cluster,
+		policy:      destinationRule.TrafficPolicy,
+		port:        port,
+		clusterMode: clusterMode,
+		direction:   model.TrafficDirectionOutbound,
+		proxy:       proxy,
+	}
+
+	if clusterMode == DefaultClusterMode {
+		opts.serviceAccounts = push.ServiceAccounts[service.Hostname][port.Port]
+		opts.istioMtlsSni = model.BuildDNSSrvSubsetKey(model.TrafficDirectionOutbound, "", service.Hostname, port.Port)
+		opts.simpleTLSSni = string(service.Hostname)
+		opts.meshExternal = service.MeshExternal
+		opts.serviceMTLSMode = push.BestEffortInferServiceMTLSMode(service, port)
+	}
+
+	// Apply traffic policy for the main default cluster.
+	applyTrafficPolicy(opts, proxy)
+	var clusterMetadata *core.Metadata
+	if destRule != nil {
+		clusterMetadata = util.BuildConfigInfoMetadata(destRule.ConfigMeta)
+		cluster.Metadata = clusterMetadata
+	}
+	subsetClusters := make([]*apiv2.Cluster, 0)
+	for _, subset := range destinationRule.Subsets {
+		var subsetClusterName string
+		var defaultSni string
+		if clusterMode == DefaultClusterMode {
+			subsetClusterName = model.BuildSubsetKey(model.TrafficDirectionOutbound, subset.Name, service.Hostname, port.Port)
+			defaultSni = model.BuildDNSSrvSubsetKey(model.TrafficDirectionOutbound, subset.Name, service.Hostname, port.Port)
+
+		} else {
+			subsetClusterName = model.BuildDNSSrvSubsetKey(model.TrafficDirectionOutbound, subset.Name, service.Hostname, port.Port)
+		}
+		// clusters with discovery type STATIC, STRICT_DNS rely on cluster.hosts field
+		// ServiceEntry's need to filter hosts based on subset.labels in order to perform weighted routing
+		var lbEndpoints []*endpoint.LocalityLbEndpoints
+		if cluster.GetType() != apiv2.Cluster_EDS && len(subset.Labels) != 0 {
+			lbEndpoints = buildLocalityLbEndpoints(push, proxyNetworkView, service, port.Port, []labels.Instance{subset.Labels})
+		}
+
+		subsetCluster := buildDefaultCluster(push, subsetClusterName, cluster.GetType(), lbEndpoints, model.TrafficDirectionOutbound, proxy, nil, service.MeshExternal)
+
+		if subsetCluster == nil {
+			continue
+		}
+		if len(push.Mesh.OutboundClusterStatName) != 0 {
+			subsetCluster.AltStatName = util.BuildStatPrefix(push.Mesh.OutboundClusterStatName, string(service.Hostname), subset.Name, port, service.Attributes)
+		}
+		setUpstreamProtocol(proxy, subsetCluster, port, model.TrafficDirectionOutbound)
+
+		// Apply traffic policy for subset cluster with the destination rule traffice policy.
+		opts.cluster = subsetCluster
+		opts.policy = destinationRule.TrafficPolicy
+		opts.istioMtlsSni = defaultSni
+		applyTrafficPolicy(opts, proxy)
+
+		// If subset has a traffic policy, apply it so that it overrides the destination rule traffic policy.
+		if subset.TrafficPolicy != nil {
+			opts.policy = subset.TrafficPolicy
+			applyTrafficPolicy(opts, proxy)
+		}
+
+		maybeApplyEdsConfig(subsetCluster)
+
+		subsetCluster.Metadata = util.AddSubsetToMetadata(clusterMetadata, subset.Name)
+		subsetClusters = append(subsetClusters, subsetCluster)
+	}
+	return subsetClusters
+}
+
+// castDestinationRuleOrDefault returns the destination rule enclosed by the config, if not null.
+// Otherwise, return default (empty) DR.
+func castDestinationRuleOrDefault(config *model.Config) *networking.DestinationRule {
+	if config != nil {
+		return config.Spec.(*networking.DestinationRule)
+	}
+
+	return &defaultDestinationRule
+}
+
+// maybeApplyEdsConfig applies EdsClusterConfig on the passed in cluster if it is an EDS type of cluster.
+func maybeApplyEdsConfig(cluster *apiv2.Cluster) {
+	switch v := cluster.ClusterDiscoveryType.(type) {
+	case *apiv2.Cluster_Type:
+		if v.Type != apiv2.Cluster_EDS {
+			return
+		}
+	}
+	cluster.EdsClusterConfig = &apiv2.Cluster_EdsClusterConfig{
+		ServiceName: cluster.Name,
+		EdsConfig: &core.ConfigSource{
+			ConfigSourceSpecifier: &core.ConfigSource_Ads{
+				Ads: &core.AggregatedConfigSource{},
+			},
+			InitialFetchTimeout: features.InitialFetchTimeout,
+		},
+	}
+}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -57,6 +57,11 @@ func applyDestinationRule(cluster *apiv2.Cluster, clusterMode ClusterMode, servi
 
 	// Apply traffic policy for the main default cluster.
 	applyTrafficPolicy(opts, proxy)
+
+	// Apply EdsConfig if needed. This should be called after traffic policy is applied because, traffic policy might change
+	// discovery type.
+	maybeApplyEdsConfig(cluster)
+
 	var clusterMetadata *core.Metadata
 	if destRule != nil {
 		clusterMetadata = util.BuildConfigInfoMetadata(destRule.ConfigMeta)

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -1,0 +1,293 @@
+// Copyright 2020 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha3
+
+import (
+	"reflect"
+	"testing"
+
+	apiv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_api_v2_cluster "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	"github.com/golang/protobuf/ptypes/wrappers"
+	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/fakes"
+	"istio.io/istio/pkg/config/host"
+	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/resource"
+)
+
+func TestApplyDestinationRule(t *testing.T) {
+	servicePort := model.PortList{
+		&model.Port{
+			Name:     "default",
+			Port:     8080,
+			Protocol: protocol.HTTP,
+		},
+		&model.Port{
+			Name:     "auto",
+			Port:     9090,
+			Protocol: protocol.Unsupported,
+		},
+	}
+	serviceAttribute := model.ServiceAttributes{
+		Namespace: TestServiceNamespace,
+	}
+	service := &model.Service{
+		Hostname:    host.Name("foo"),
+		Address:     "1.1.1.1",
+		ClusterVIPs: make(map[string]string),
+		Ports:       servicePort,
+		Resolution:  model.ClientSideLB,
+		Attributes:  serviceAttribute,
+	}
+
+	cases := []struct {
+		name                   string
+		cluster                *apiv2.Cluster
+		clusterMode            ClusterMode
+		service                *model.Service
+		port                   *model.Port
+		proxy                  *model.Proxy
+		networkView            map[string]bool
+		destRule               *networking.DestinationRule
+		expectedSubsetClusters []*apiv2.Cluster
+	}{
+		// TODO(ramaraochavali): Add more tests to cover additional conditions.
+		{
+			name:                   "nil destination rule",
+			cluster:                &apiv2.Cluster{},
+			clusterMode:            DefaultClusterMode,
+			service:                &model.Service{},
+			port:                   &model.Port{},
+			proxy:                  &model.Proxy{},
+			networkView:            map[string]bool{},
+			destRule:               nil,
+			expectedSubsetClusters: []*apiv2.Cluster{},
+		},
+		{
+			name:        "destination rule with subsets",
+			cluster:     &apiv2.Cluster{Name: "foo", ClusterDiscoveryType: &apiv2.Cluster_Type{Type: apiv2.Cluster_EDS}},
+			clusterMode: DefaultClusterMode,
+			service:     service,
+			port:        servicePort[0],
+			proxy:       &model.Proxy{},
+			networkView: map[string]bool{},
+			destRule: &networking.DestinationRule{
+				Host: "foo",
+				Subsets: []*networking.Subset{
+					{
+						Name:   "foobar",
+						Labels: map[string]string{"foo": "bar"},
+					},
+				},
+			},
+			expectedSubsetClusters: []*apiv2.Cluster{
+				&apiv2.Cluster{
+					Name:                 "outbound|8080|foobar|foo",
+					ClusterDiscoveryType: &apiv2.Cluster_Type{Type: apiv2.Cluster_EDS},
+					EdsClusterConfig: &apiv2.Cluster_EdsClusterConfig{
+						ServiceName: "outbound|8080|foobar|foo",
+					},
+				},
+			},
+		},
+		{
+			name:        "destination rule with subsets for SniDnat cluster",
+			cluster:     &apiv2.Cluster{Name: "foo", ClusterDiscoveryType: &apiv2.Cluster_Type{Type: apiv2.Cluster_EDS}},
+			clusterMode: SniDnatClusterMode,
+			service:     service,
+			port:        servicePort[0],
+			proxy:       &model.Proxy{},
+			networkView: map[string]bool{},
+			destRule: &networking.DestinationRule{
+				Host: "foo",
+				Subsets: []*networking.Subset{
+					{
+						Name:   "foobar",
+						Labels: map[string]string{"foo": "bar"},
+					},
+				},
+			},
+			expectedSubsetClusters: []*apiv2.Cluster{
+				&apiv2.Cluster{
+					Name:                 "outbound_.8080_.foobar_.foo",
+					ClusterDiscoveryType: &apiv2.Cluster_Type{Type: apiv2.Cluster_EDS},
+					EdsClusterConfig: &apiv2.Cluster_EdsClusterConfig{
+						ServiceName: "outbound_.8080_.foobar_.foo",
+					},
+				},
+			},
+		},
+		{
+			name:        "destination rule with subset traffic policy",
+			cluster:     &apiv2.Cluster{Name: "foo", ClusterDiscoveryType: &apiv2.Cluster_Type{Type: apiv2.Cluster_EDS}},
+			clusterMode: DefaultClusterMode,
+			service:     service,
+			port:        servicePort[0],
+			proxy:       &model.Proxy{},
+			networkView: map[string]bool{},
+			destRule: &networking.DestinationRule{
+				Host: "foo",
+				Subsets: []*networking.Subset{
+					{
+						Name:   "foobar",
+						Labels: map[string]string{"foo": "bar"},
+						TrafficPolicy: &networking.TrafficPolicy{
+							ConnectionPool: &networking.ConnectionPoolSettings{
+								Http: &networking.ConnectionPoolSettings_HTTPSettings{
+									MaxRetries: 10,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedSubsetClusters: []*apiv2.Cluster{
+				&apiv2.Cluster{
+					Name:                 "outbound|8080|foobar|foo",
+					ClusterDiscoveryType: &apiv2.Cluster_Type{Type: apiv2.Cluster_EDS},
+					EdsClusterConfig: &apiv2.Cluster_EdsClusterConfig{
+						ServiceName: "outbound|8080|foobar|foo",
+					},
+					CircuitBreakers: &envoy_api_v2_cluster.CircuitBreakers{
+						Thresholds: []*envoy_api_v2_cluster.CircuitBreakers_Thresholds{
+							{
+								MaxRetries: &wrappers.UInt32Value{
+									Value: 10,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+
+			serviceDiscovery := &fakes.ServiceDiscovery{}
+
+			instances := []*model.ServiceInstance{
+				{
+					Service:     tt.service,
+					ServicePort: tt.port,
+					Endpoint: &model.IstioEndpoint{
+						Address:      "192.168.1.1",
+						EndpointPort: 10001,
+						Locality: model.Locality{
+							ClusterID: "",
+							Label:     "region1/zone1/subzone1",
+						},
+						TLSMode: model.IstioMutualTLSModeLabel,
+					},
+				},
+			}
+
+			serviceDiscovery.ServicesReturns([]*model.Service{tt.service}, nil)
+			serviceDiscovery.GetProxyServiceInstancesReturns(instances, nil)
+			serviceDiscovery.InstancesByPortReturns(instances, nil)
+
+			configStore := &fakes.IstioConfigStore{
+				ListStub: func(typ resource.GroupVersionKind, namespace string) (configs []model.Config, e error) {
+					if typ == collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind() {
+						if tt.destRule != nil {
+							return []model.Config{
+								{ConfigMeta: model.ConfigMeta{
+									Type:    collections.IstioNetworkingV1Alpha3Destinationrules.Resource().Kind(),
+									Version: collections.IstioNetworkingV1Alpha3Destinationrules.Resource().Version(),
+									Name:    "acme",
+								},
+									Spec: tt.destRule,
+								}}, nil
+						}
+					}
+					return nil, nil
+				},
+			}
+			env := newTestEnvironment(serviceDiscovery, testMesh, configStore)
+
+			proxy.SetSidecarScope(env.PushContext)
+
+			subsetClusters := applyDestinationRule(tt.cluster, tt.clusterMode, tt.service, tt.port, tt.proxy, tt.networkView, env.PushContext)
+			if len(subsetClusters) != len(tt.expectedSubsetClusters) {
+				t.Errorf("Unexpected subset clusters want %v, got %v", len(tt.expectedSubsetClusters), len(subsetClusters))
+			}
+			if len(tt.expectedSubsetClusters) > 0 {
+				compareClusters(t, tt.expectedSubsetClusters[0], subsetClusters[0])
+			}
+		})
+	}
+}
+
+func compareClusters(t *testing.T, ec *apiv2.Cluster, gc *apiv2.Cluster) {
+	// TODO(ramaraochavali): Expand the comparision to more fields.
+	t.Helper()
+	if ec.Name != gc.Name {
+		t.Errorf("Unexpected cluster name want %s, got %s", ec.Name, gc.Name)
+	}
+	if ec.GetType() != gc.GetType() {
+		t.Errorf("Unexpected cluster discovery type want %v, got %v", ec.GetType(), gc.GetType())
+	}
+	if ec.GetType() == apiv2.Cluster_EDS && ec.EdsClusterConfig.ServiceName != gc.EdsClusterConfig.ServiceName {
+		t.Errorf("Unexpected service name in EDS config want %v, got %v", ec.EdsClusterConfig.ServiceName, gc.EdsClusterConfig.ServiceName)
+	}
+	if ec.CircuitBreakers != nil {
+		if ec.CircuitBreakers.Thresholds[0].MaxRetries.Value != gc.CircuitBreakers.Thresholds[0].MaxRetries.Value {
+			t.Errorf("Unexpected circuit breaker thresholds want %v, got %v", ec.CircuitBreakers.Thresholds[0].MaxRetries, gc.CircuitBreakers.Thresholds[0].MaxRetries)
+		}
+	}
+}
+
+func TestApplyEdsConfig(t *testing.T) {
+
+	cases := []struct {
+		name      string
+		cluster   *apiv2.Cluster
+		edsConfig *apiv2.Cluster_EdsClusterConfig
+	}{
+		{
+			name:      "non eds type of cluster",
+			cluster:   &apiv2.Cluster{Name: "foo", ClusterDiscoveryType: &apiv2.Cluster_Type{Type: apiv2.Cluster_STRICT_DNS}},
+			edsConfig: nil,
+		},
+		{
+			name:    "eds type of cluster",
+			cluster: &apiv2.Cluster{Name: "foo", ClusterDiscoveryType: &apiv2.Cluster_Type{Type: apiv2.Cluster_EDS}},
+			edsConfig: &apiv2.Cluster_EdsClusterConfig{
+				ServiceName: "foo",
+				EdsConfig: &core.ConfigSource{
+					ConfigSourceSpecifier: &core.ConfigSource_Ads{
+						Ads: &core.AggregatedConfigSource{},
+					},
+					InitialFetchTimeout: features.InitialFetchTimeout,
+				},
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			maybeApplyEdsConfig(tt.cluster)
+			if !reflect.DeepEqual(tt.cluster.EdsClusterConfig, tt.edsConfig) {
+				t.Errorf("Unexpected Eds config in cluster. want %v, got %v", tt.edsConfig, tt.cluster.EdsClusterConfig)
+			}
+		})
+	}
+}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -21,7 +21,9 @@ import (
 	apiv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_cluster "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+
 	"github.com/golang/protobuf/ptypes/wrappers"
+
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
@@ -98,7 +100,7 @@ func TestApplyDestinationRule(t *testing.T) {
 				},
 			},
 			expectedSubsetClusters: []*apiv2.Cluster{
-				&apiv2.Cluster{
+				{
 					Name:                 "outbound|8080|foobar|foo",
 					ClusterDiscoveryType: &apiv2.Cluster_Type{Type: apiv2.Cluster_EDS},
 					EdsClusterConfig: &apiv2.Cluster_EdsClusterConfig{
@@ -125,7 +127,7 @@ func TestApplyDestinationRule(t *testing.T) {
 				},
 			},
 			expectedSubsetClusters: []*apiv2.Cluster{
-				&apiv2.Cluster{
+				{
 					Name:                 "outbound_.8080_.foobar_.foo",
 					ClusterDiscoveryType: &apiv2.Cluster_Type{Type: apiv2.Cluster_EDS},
 					EdsClusterConfig: &apiv2.Cluster_EdsClusterConfig{
@@ -237,7 +239,7 @@ func TestApplyDestinationRule(t *testing.T) {
 }
 
 func compareClusters(t *testing.T, ec *apiv2.Cluster, gc *apiv2.Cluster) {
-	// TODO(ramaraochavali): Expand the comparision to more fields.
+	// TODO(ramaraochavali): Expand the comparison to more fields.
 	t.Helper()
 	if ec.Name != gc.Name {
 		t.Errorf("Unexpected cluster name want %s, got %s", ec.Name, gc.Name)

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -161,7 +161,7 @@ func TestApplyDestinationRule(t *testing.T) {
 				},
 			},
 			expectedSubsetClusters: []*apiv2.Cluster{
-				&apiv2.Cluster{
+				{
 					Name:                 "outbound|8080|foobar|foo",
 					ClusterDiscoveryType: &apiv2.Cluster_Type{Type: apiv2.Cluster_EDS},
 					EdsClusterConfig: &apiv2.Cluster_EdsClusterConfig{

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -227,7 +227,9 @@ func TestApplyDestinationRule(t *testing.T) {
 
 			proxy.SetSidecarScope(env.PushContext)
 
-			subsetClusters := applyDestinationRule(tt.cluster, tt.clusterMode, tt.service, tt.port, tt.proxy, tt.networkView, env.PushContext)
+			cb := NewClusterBuilder(tt.proxy, env.PushContext)
+
+			subsetClusters := cb.applyDestinationRule(tt.cluster, tt.clusterMode, tt.service, tt.port, tt.networkView)
 			if len(subsetClusters) != len(tt.expectedSubsetClusters) {
 				t.Errorf("Unexpected subset clusters want %v, got %v", len(tt.expectedSubsetClusters), len(subsetClusters))
 			}


### PR DESCRIPTION
The logic to apply destination rule has mostly duplicated across normal outbound cluster and snidnat cluster with minor differences. This PR refactors that logic in to a separate function so that it can be easily unit tested. I have added few tests to start with. Will add few more in follow-up PRs.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
