### PR TITLE
Allow Envoy profiling without injection template mods

### DIFF
--- a/pkg/bootstrap/instance_test.go
+++ b/pkg/bootstrap/instance_test.go
@@ -43,7 +43,6 @@ import (
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/test/util"
 	"istio.io/istio/pkg/bootstrap/platform"
-	"istio.io/istio/pkg/test/env"
 )
 
 type stats struct {
@@ -76,10 +75,7 @@ var (
 // cp $TOP/out/linux_amd64/release/bootstrap/tracing_lightstep/envoy-rev0.json pkg/bootstrap/testdata/tracing_lightstep_golden.json
 // cp $TOP/out/linux_amd64/release/bootstrap/tracing_zipkin/envoy-rev0.json pkg/bootstrap/testdata/tracing_zipkin_golden.json
 func TestGolden(t *testing.T) {
-	out := env.ISTIO_OUT.Value() // defined in the makefile
-	if out == "" {
-		out = "/tmp"
-	}
+	out := "/tmp"
 	var ts *httptest.Server
 
 	cases := []struct {

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -198,6 +198,7 @@
   },
   "admin": {
     "access_log_path": "/dev/null",
+    "profile_path": "/tmp/bootstrap/all/envoy.prof",
     "address": {
       "socket_address": {
         "address": "127.0.0.1",

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -198,6 +198,7 @@
   },
   "admin": {
     "access_log_path": "/dev/null",
+    "profile_path": "/tmp/bootstrap/auth/envoy.prof",
     "address": {
       "socket_address": {
         "address": "127.0.0.1",

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -198,6 +198,7 @@
   },
   "admin": {
     "access_log_path": "/dev/null",
+    "profile_path": "/tmp/bootstrap/authsds/envoy.prof",
     "address": {
       "socket_address": {
         "address": "127.0.0.1",

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -198,6 +198,7 @@
   },
   "admin": {
     "access_log_path": "/dev/null",
+    "profile_path": "/tmp/bootstrap/default/envoy.prof",
     "address": {
       "socket_address": {
         "address": "127.0.0.1",

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -201,6 +201,7 @@
   },
   "admin": {
     "access_log_path": "/dev/null",
+    "profile_path": "/tmp/bootstrap/running/envoy.prof",
     "address": {
       "socket_address": {
         "address": "127.0.0.1",

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -201,6 +201,7 @@
   },
   "admin": {
     "access_log_path": "/dev/null",
+    "profile_path": "/tmp/bootstrap/runningsds/envoy.prof",
     "address": {
       "socket_address": {
         "address": "127.0.0.1",

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -209,6 +209,7 @@
   },
   "admin": {
     "access_log_path": "/dev/null",
+    "profile_path": "/tmp/bootstrap/stats_inclusion/envoy.prof",
     "address": {
       "socket_address": {
         "address": "127.0.0.1",

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -198,6 +198,7 @@
   },
   "admin": {
     "access_log_path": "/dev/null",
+    "profile_path": "/tmp/bootstrap/tracing_datadog/envoy.prof",
     "address": {
       "socket_address": {
         "address": "127.0.0.1",

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -198,6 +198,7 @@
   },
   "admin": {
     "access_log_path": "/dev/null",
+    "profile_path": "/tmp/bootstrap/tracing_lightstep/envoy.prof",
     "address": {
       "socket_address": {
         "address": "127.0.0.1",

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -198,6 +198,7 @@
   },
   "admin": {
     "access_log_path": "/dev/null",
+    "profile_path": "/tmp/bootstrap/tracing_stackdriver/envoy.prof",
     "address": {
       "socket_address": {
         "address": "127.0.0.1",

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -198,6 +198,7 @@
   },
   "admin": {
     "access_log_path": "/dev/null",
+    "profile_path": "/tmp/bootstrap/tracing_zipkin/envoy.prof",
     "address": {
       "socket_address": {
         "address": "127.0.0.1",

--- a/tools/packaging/common/envoy_bootstrap_v2.json
+++ b/tools/packaging/common/envoy_bootstrap_v2.json
@@ -207,6 +207,7 @@
   },
   "admin": {
     "access_log_path": "/dev/null",
+    "profile_path": "{{ .config.ConfigPath }}/envoy.prof",
     "address": {
       "socket_address": {
         "address": "{{ .localhost }}",


### PR DESCRIPTION
Currently in the default install profiling is broken, because it tries
to write to a read only FS. This changes that to default to a writeable
directory, so users don't need hacks to get things writeable. This is
especially important since those hacks require a restart of the pod
which will lose important state.