### PR TITLE
Remove legacy infinite loop blocker

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -176,14 +176,6 @@ var (
 		false,
 		"Skip validating the peer is from the same trust domain when mTLS is enabled in authentication policy")
 
-	RestrictPodIPTrafficLoops = env.RegisterBoolVar(
-		"PILOT_RESTRICT_POD_UP_TRAFFIC_LOOP",
-		true,
-		"If enabled, this will block inbound traffic from matching outbound listeners, which "+
-			"could result in an infinite loop of traffic. This option is only provided for backward compatibility purposes "+
-			"and will be removed in the near future.",
-	)
-
 	EnableProtocolSniffingForOutbound = env.RegisterBoolVar(
 		"PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_OUTBOUND",
 		true,

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -443,10 +443,6 @@ func TestOutboundListenerTCPWithVS(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if features.RestrictPodIPTrafficLoops.Get() {
-				// Expect a filter chain on the node IP
-				tt.expectedChains = append([]string{"1.1.1.1"}, tt.expectedChains...)
-			}
 			services := []*model.Service{
 				buildService("test.com", tt.CIDR, protocol.TCP, tnow),
 			}
@@ -798,19 +794,19 @@ func testOutboundListenerConflictV14(t *testing.T, services ...*model.Service) {
 	oldestProtocol := oldestService.Ports[0].Protocol
 	if oldestProtocol == protocol.MySQL {
 		if len(listeners[0].FilterChains) != 2 {
-			t.Fatalf("expectd %d filter chains, found %d", 2, len(listeners[0].FilterChains))
+			t.Fatalf("expected %d filter chains, found %d", 2, len(listeners[0].FilterChains))
 		} else if !isTCPFilterChain(listeners[0].FilterChains[1]) {
 			t.Fatalf("expected tcp filter chain, found %s", listeners[0].FilterChains[1].Filters[0].Name)
 		}
 	} else if oldestProtocol != protocol.HTTP && oldestProtocol != protocol.TCP {
-		if len(listeners[0].FilterChains) != 3 {
-			t.Fatalf("expectd %d filter chains, found %d", 3, len(listeners[0].FilterChains))
+		if len(listeners[0].FilterChains) != 2 {
+			t.Fatalf("expectd %d filter chains, found %d", 2, len(listeners[0].FilterChains))
 		} else {
-			if !isHTTPFilterChain(listeners[0].FilterChains[2]) {
+			if !isHTTPFilterChain(listeners[0].FilterChains[1]) {
 				t.Fatalf("expected http filter chain, found %s", listeners[0].FilterChains[1].Filters[0].Name)
 			}
 
-			if !isTCPFilterChain(listeners[0].FilterChains[1]) {
+			if !isTCPFilterChain(listeners[0].FilterChains[0]) {
 				t.Fatalf("expected tcp filter chain, found %s", listeners[0].FilterChains[2].Filters[0].Name)
 			}
 		}

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -733,7 +733,7 @@ func testOutboundListenerRouteV14(t *testing.T, services ...*model.Service) {
 		t.Fatalf("expect listener %s", "0.0.0.0_8080")
 	}
 
-	f := l.FilterChains[1].Filters[0]
+	f := l.FilterChains[0].Filters[0]
 	cfg, _ := conversion.MessageToStruct(f.GetTypedConfig())
 	rds := cfg.Fields["rds"].GetStructValue().Fields["route_config_name"].GetStringValue()
 	if rds != "8080" {
@@ -793,9 +793,9 @@ func testOutboundListenerConflictV14(t *testing.T, services ...*model.Service) {
 
 	oldestProtocol := oldestService.Ports[0].Protocol
 	if oldestProtocol == protocol.MySQL {
-		if len(listeners[0].FilterChains) != 2 {
-			t.Fatalf("expected %d filter chains, found %d", 2, len(listeners[0].FilterChains))
-		} else if !isTCPFilterChain(listeners[0].FilterChains[1]) {
+		if len(listeners[0].FilterChains) != 1 {
+			t.Fatalf("expected %d filter chains, found %d", 1, len(listeners[0].FilterChains))
+		} else if !isTCPFilterChain(listeners[0].FilterChains[0]) {
 			t.Fatalf("expected tcp filter chain, found %s", listeners[0].FilterChains[1].Filters[0].Name)
 		}
 	} else if oldestProtocol != protocol.HTTP && oldestProtocol != protocol.TCP {
@@ -811,7 +811,7 @@ func testOutboundListenerConflictV14(t *testing.T, services ...*model.Service) {
 			}
 		}
 
-		verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[2], model.TrafficDirectionOutbound, false)
+		verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[1], model.TrafficDirectionOutbound, false)
 		if len(listeners[0].ListenerFilters) != 2 ||
 			listeners[0].ListenerFilters[0].Name != "envoy.listener.tls_inspector" ||
 			listeners[0].ListenerFilters[1].Name != "envoy.listener.http_inspector" {
@@ -824,7 +824,7 @@ func testOutboundListenerConflictV14(t *testing.T, services ...*model.Service) {
 				listeners[0].ListenerFiltersTimeout)
 		}
 
-		f := listeners[0].FilterChains[2].Filters[0]
+		f := listeners[0].FilterChains[1].Filters[0]
 		cfg, _ := conversion.MessageToStruct(f.GetTypedConfig())
 		rds := cfg.Fields["rds"].GetStructValue().Fields["route_config_name"].GetStringValue()
 		expect := fmt.Sprintf("%d", oldestService.Ports[0].Port)
@@ -832,19 +832,19 @@ func testOutboundListenerConflictV14(t *testing.T, services ...*model.Service) {
 			t.Fatalf("expect routes %s, found %s", expect, rds)
 		}
 	} else {
-		if len(listeners[0].FilterChains) != 3 {
-			t.Fatalf("expectd %d filter chains, found %d", 3, len(listeners[0].FilterChains))
+		if len(listeners[0].FilterChains) != 2 {
+			t.Fatalf("expectd %d filter chains, found %d", 2, len(listeners[0].FilterChains))
 		}
 
-		if !isTCPFilterChain(listeners[0].FilterChains[1]) {
-			t.Fatalf("expected tcp filter chain, found %s", listeners[0].FilterChains[2].Filters[0].Name)
+		if !isTCPFilterChain(listeners[0].FilterChains[0]) {
+			t.Fatalf("expected tcp filter chain, found %s", listeners[0].FilterChains[0].Filters[0].Name)
 		}
 
-		if !isHTTPFilterChain(listeners[0].FilterChains[2]) {
+		if !isHTTPFilterChain(listeners[0].FilterChains[1]) {
 			t.Fatalf("expected http filter chain, found %s", listeners[0].FilterChains[1].Filters[0].Name)
 		}
 
-		verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[2], model.TrafficDirectionOutbound, false)
+		verifyHTTPFilterChainMatch(t, listeners[0].FilterChains[1], model.TrafficDirectionOutbound, false)
 		if len(listeners[0].ListenerFilters) != 2 ||
 			listeners[0].ListenerFilters[0].Name != "envoy.listener.tls_inspector" ||
 			listeners[0].ListenerFilters[1].Name != "envoy.listener.http_inspector" {
@@ -1050,18 +1050,18 @@ func testOutboundListenerConfigWithSidecarV14(t *testing.T, services ...*model.S
 	}
 
 	l := findListenerByPort(listeners, 8080)
-	if len(l.FilterChains) != 4 {
-		t.Fatalf("expectd %d filter chains, found %d", 4, len(l.FilterChains))
+	if len(l.FilterChains) != 2 {
+		t.Fatalf("expectd %d filter chains, found %d", 2, len(l.FilterChains))
 	} else {
-		if !isHTTPFilterChain(l.FilterChains[3]) {
-			t.Fatalf("expected http filter chain, found %s", l.FilterChains[3].Filters[0].Name)
+		if !isHTTPFilterChain(l.FilterChains[1]) {
+			t.Fatalf("expected http filter chain, found %s", l.FilterChains[1].Filters[0].Name)
 		}
 
-		if !isTCPFilterChain(l.FilterChains[1]) {
-			t.Fatalf("expected tcp filter chain, found %s", l.FilterChains[1].Filters[0].Name)
+		if !isTCPFilterChain(l.FilterChains[0]) {
+			t.Fatalf("expected tcp filter chain, found %s", l.FilterChains[0].Filters[0].Name)
 		}
 
-		verifyHTTPFilterChainMatch(t, l.FilterChains[3], model.TrafficDirectionOutbound, false)
+		verifyHTTPFilterChainMatch(t, l.FilterChains[1], model.TrafficDirectionOutbound, false)
 
 		if len(l.ListenerFilters) != 2 ||
 			l.ListenerFilters[0].Name != "envoy.listener.tls_inspector" ||

--- a/pilot/pkg/proxy/envoy/v2/lds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/lds_test.go
@@ -429,9 +429,6 @@ func TestLDSWithSidecarForWorkloadWithoutService(t *testing.T) {
 	// instead of looking at it as a listener with multiple filter chains
 	if l := adsResponse.GetHTTPListeners()["0.0.0.0_8081"]; l != nil {
 		expected := 1
-		if features.RestrictPodIPTrafficLoops.Get() {
-			expected = 2
-		}
 		if len(l.FilterChains) != expected {
 			t.Fatalf("Expected %d filter chains, got %d", expected, len(l.FilterChains))
 		}

--- a/tests/integration/pilot/sidecar_api_test.go
+++ b/tests/integration/pilot/sidecar_api_test.go
@@ -87,27 +87,14 @@ func TestSidecarListeners(t *testing.T) {
 }
 
 func validateListenersNoConfig(t *testing.T, response *structpath.Instance) {
-	t.Run("iptables-listener-block-loops", func(t *testing.T) {
-		response.
-			Select("{.resources[?(@.address.socketAddress.portValue==15001)]}").
-			Equals("virtualOutbound", "{.name}").
-			Equals("0.0.0.0", "{.address.socketAddress.address}").
-			Equals("envoy.tcp_proxy", "{.filterChains[0].filters[0].name}").
-			Equals("BlackHoleCluster", "{.filterChains[0].filters[0].typedConfig.cluster}").
-			Equals("10.2.0.1", "{.filterChains[0].filterChainMatch.prefixRanges[0].addressPrefix}").
-			Equals("32", "{.filterChains[0].filterChainMatch.prefixRanges[0].prefixLen}").
-			Equals(true, "{.useOriginalDst}").
-			CheckOrFail(t)
-	})
-
 	t.Run("iptables-forwarding-listener", func(t *testing.T) {
 		response.
 			Select("{.resources[?(@.address.socketAddress.portValue==15001)]}").
 			Equals("virtualOutbound", "{.name}").
 			Equals("0.0.0.0", "{.address.socketAddress.address}").
-			Equals("envoy.tcp_proxy", "{.filterChains[1].filters[0].name}").
-			Equals("PassthroughCluster", "{.filterChains[1].filters[0].typedConfig.cluster}").
-			Equals("PassthroughCluster", "{.filterChains[1].filters[0].typedConfig.statPrefix}").
+			Equals("envoy.tcp_proxy", "{.filterChains[0].filters[0].name}").
+			Equals("PassthroughCluster", "{.filterChains[0].filters[0].typedConfig.cluster}").
+			Equals("PassthroughCluster", "{.filterChains[0].filters[0].typedConfig.statPrefix}").
 			Equals(true, "{.useOriginalDst}").
 			CheckOrFail(t)
 	})


### PR DESCRIPTION
Context: https://github.com/istio/istio/issues/14242
Original PR: https://github.com/istio/istio/pull/15833/files

Back then, we had an issue where the traffic for inbound could match the
outbound listener, which would lead to it being redirected through
passthrough cluster back to itself, indefinitely. This was in the 1.1.x
times. Now, we have a split listener, so this issue should never occur,
as we have another fix for this case
(https://github.com/istio/istio/pull/15906).

This PR cleans up the code/config so we are no longer sending an
additional filter chain on every listener.

I have tested this using the original regression test
(https://github.com/istio/tools/tree/master/perf/stability/looper) as
well as deploying this in the same config that I spotted the original
issue in, and have detected no issues with this disabled. However, I am
not 100% sure, so I will place a hold on this until I get multiple
approvals, since this is a pretty high impact change if I am wrong and
this is not safe to remove.