### PR TITLE
ALPN cleanup

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -1126,7 +1126,7 @@ func applyUpstreamTLSSettings(opts *buildClusterOpts, tls *networking.TLSSetting
 		}
 		if cluster.Http2ProtocolOptions != nil {
 			// This is HTTP/2 cluster, advertise it with ALPN.
-			tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNH2Only
+			tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNPlaintextH2Only
 		}
 	case networking.TLSSettings_MUTUAL, networking.TLSSettings_ISTIO_MUTUAL:
 		if tls.ClientCertificate == "" || tls.PrivateKey == "" {
@@ -1178,17 +1178,13 @@ func applyUpstreamTLSSettings(opts *buildClusterOpts, tls *networking.TLSSetting
 		if cluster.Http2ProtocolOptions != nil {
 			// This is HTTP/2 in-mesh cluster, advertise it with ALPN.
 			if tls.Mode == networking.TLSSettings_ISTIO_MUTUAL {
-				tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNInMeshH2
+				tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNMtlsH2
 			} else {
-				tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNH2Only
+				tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNPlaintextH2Only
 			}
 		} else if tls.Mode == networking.TLSSettings_ISTIO_MUTUAL {
 			// This is in-mesh cluster, advertise it with ALPN.
-			if util.IsTCPMetadataExchangeEnabled(node) {
-				tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNInMeshWithMxc
-			} else {
-				tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNInMesh
-			}
+			tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNMtlsTcpWithMxc
 		}
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -1126,7 +1126,7 @@ func applyUpstreamTLSSettings(opts *buildClusterOpts, tls *networking.TLSSetting
 		}
 		if cluster.Http2ProtocolOptions != nil {
 			// This is HTTP/2 cluster, advertise it with ALPN.
-			tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNPlaintextH2Only
+			tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNPlaintextH2
 		}
 	case networking.TLSSettings_MUTUAL, networking.TLSSettings_ISTIO_MUTUAL:
 		if tls.ClientCertificate == "" || tls.PrivateKey == "" {
@@ -1180,11 +1180,11 @@ func applyUpstreamTLSSettings(opts *buildClusterOpts, tls *networking.TLSSetting
 			if tls.Mode == networking.TLSSettings_ISTIO_MUTUAL {
 				tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNMtlsH2
 			} else {
-				tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNPlaintextH2Only
+				tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNPlaintextH2
 			}
 		} else if tls.Mode == networking.TLSSettings_ISTIO_MUTUAL {
 			// This is in-mesh cluster, advertise it with ALPN.
-			tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNMtlsTcpWithMxc
+			tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNMtlsTCPWithMxc
 		}
 	}
 
@@ -1199,7 +1199,7 @@ func applyUpstreamTLSSettings(opts *buildClusterOpts, tls *networking.TLSSetting
 	// Apply auto mtls to clusters excluding these kind of headless service
 	if cluster.LbPolicy != apiv2.Cluster_CLUSTER_PROVIDED {
 		// convert to transport socket matcher if the mode was auto detected
-		if tls.Mode == networking.TLSSettings_ISTIO_MUTUAL && mtlsCtxType == autoDetected && util.IsIstioVersionGE14(proxy) {
+		if tls.Mode == networking.TLSSettings_ISTIO_MUTUAL && mtlsCtxType == autoDetected {
 			transportSocket := cluster.TransportSocket
 			cluster.TransportSocket = nil
 			cluster.TransportSocketMatches = []*apiv2.Cluster_TransportSocketMatch{
@@ -1287,9 +1287,7 @@ func buildDefaultCluster(push *model.PushContext, name string, discoveryType api
 		cluster.DnsLookupFamily = apiv2.Cluster_V4_ONLY
 		dnsRate := gogo.DurationToProtoDuration(push.Mesh.DnsRefreshRate)
 		cluster.DnsRefreshRate = dnsRate
-		if util.IsIstioVersionGE13(proxy) {
-			cluster.RespectDnsTtl = true
-		}
+		cluster.RespectDnsTtl = true
 	}
 
 	if discoveryType == apiv2.Cluster_STATIC || discoveryType == apiv2.Cluster_STRICT_DNS {

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -415,7 +415,7 @@ func buildGatewayListenerTLSContext(
 
 	tls := &auth.DownstreamTlsContext{
 		CommonTlsContext: &auth.CommonTlsContext{
-			AlpnProtocols: util.ALPNHttp,
+			AlpnProtocols: util.ALPNPlaintextHttp,
 		},
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -284,10 +284,8 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 				},
 			},
 		}}
-		if util.IsIstioVersionGE13(node) {
-			// add a name to the route
-			virtualHosts[0].Routes[0].Name = istio_route.DefaultRouteName
-		}
+		// add a name to the route
+		virtualHosts[0].Routes[0].Name = istio_route.DefaultRouteName
 	} else {
 		virtualHosts = make([]*route.VirtualHost, 0, len(vHostDedupMap))
 		for _, v := range vHostDedupMap {
@@ -415,7 +413,7 @@ func buildGatewayListenerTLSContext(
 
 	tls := &auth.DownstreamTlsContext{
 		CommonTlsContext: &auth.CommonTlsContext{
-			AlpnProtocols: util.ALPNPlaintextHttp,
+			AlpnProtocols: util.ALPNPlaintextHTTP,
 		},
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -57,7 +57,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 			enableIngressSdsAgent: false,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
-					AlpnProtocols: util.ALPNHttp,
+					AlpnProtocols: util.ALPNPlaintextHttp,
 					TlsCertificates: []*auth.TlsCertificate{
 						{
 							CertificateChain: &core.DataSource{
@@ -97,7 +97,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 			sdsPath:               "unix:/var/run/sds/uds_path",
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
-					AlpnProtocols: util.ALPNHttp,
+					AlpnProtocols: util.ALPNPlaintextHttp,
 					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 						{
 							Name: "default",
@@ -156,7 +156,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 			enableIngressSdsAgent: true,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
-					AlpnProtocols: util.ALPNHttp,
+					AlpnProtocols: util.ALPNPlaintextHttp,
 					TlsCertificates: []*auth.TlsCertificate{
 						{
 							CertificateChain: &core.DataSource{
@@ -187,7 +187,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 			enableIngressSdsAgent: true,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
-					AlpnProtocols: util.ALPNHttp,
+					AlpnProtocols: util.ALPNPlaintextHttp,
 					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 						{
 							Name: "ingress-sds-resource-name",
@@ -229,7 +229,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 			enableIngressSdsAgent: true,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
-					AlpnProtocols: util.ALPNHttp,
+					AlpnProtocols: util.ALPNPlaintextHttp,
 					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 						{
 							Name: "ingress-sds-resource-name",
@@ -275,7 +275,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 			enableIngressSdsAgent: false,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
-					AlpnProtocols: util.ALPNHttp,
+					AlpnProtocols: util.ALPNPlaintextHttp,
 					TlsCertificates: []*auth.TlsCertificate{
 						{
 							CertificateChain: &core.DataSource{
@@ -307,7 +307,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 			enableIngressSdsAgent: true,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
-					AlpnProtocols: util.ALPNHttp,
+					AlpnProtocols: util.ALPNPlaintextHttp,
 					TlsCertificates: []*auth.TlsCertificate{
 						{
 							CertificateChain: &core.DataSource{
@@ -342,7 +342,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 			enableIngressSdsAgent: true,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
-					AlpnProtocols: util.ALPNHttp,
+					AlpnProtocols: util.ALPNPlaintextHttp,
 					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 						{
 							Name: "ingress-sds-resource-name",
@@ -412,7 +412,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 			enableIngressSdsAgent: true,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
-					AlpnProtocols: util.ALPNHttp,
+					AlpnProtocols: util.ALPNPlaintextHttp,
 					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 						{
 							Name: "ingress-sds-resource-name",
@@ -482,7 +482,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 			enableIngressSdsAgent: true,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
-					AlpnProtocols: util.ALPNHttp,
+					AlpnProtocols: util.ALPNPlaintextHttp,
 					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 						{
 							Name: "ingress-sds-resource-name",

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -57,7 +57,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 			enableIngressSdsAgent: false,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
-					AlpnProtocols: util.ALPNPlaintextHttp,
+					AlpnProtocols: util.ALPNPlaintextHTTP,
 					TlsCertificates: []*auth.TlsCertificate{
 						{
 							CertificateChain: &core.DataSource{
@@ -97,7 +97,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 			sdsPath:               "unix:/var/run/sds/uds_path",
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
-					AlpnProtocols: util.ALPNPlaintextHttp,
+					AlpnProtocols: util.ALPNPlaintextHTTP,
 					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 						{
 							Name: "default",
@@ -156,7 +156,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 			enableIngressSdsAgent: true,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
-					AlpnProtocols: util.ALPNPlaintextHttp,
+					AlpnProtocols: util.ALPNPlaintextHTTP,
 					TlsCertificates: []*auth.TlsCertificate{
 						{
 							CertificateChain: &core.DataSource{
@@ -187,7 +187,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 			enableIngressSdsAgent: true,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
-					AlpnProtocols: util.ALPNPlaintextHttp,
+					AlpnProtocols: util.ALPNPlaintextHTTP,
 					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 						{
 							Name: "ingress-sds-resource-name",
@@ -229,7 +229,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 			enableIngressSdsAgent: true,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
-					AlpnProtocols: util.ALPNPlaintextHttp,
+					AlpnProtocols: util.ALPNPlaintextHTTP,
 					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 						{
 							Name: "ingress-sds-resource-name",
@@ -275,7 +275,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 			enableIngressSdsAgent: false,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
-					AlpnProtocols: util.ALPNPlaintextHttp,
+					AlpnProtocols: util.ALPNPlaintextHTTP,
 					TlsCertificates: []*auth.TlsCertificate{
 						{
 							CertificateChain: &core.DataSource{
@@ -307,7 +307,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 			enableIngressSdsAgent: true,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
-					AlpnProtocols: util.ALPNPlaintextHttp,
+					AlpnProtocols: util.ALPNPlaintextHTTP,
 					TlsCertificates: []*auth.TlsCertificate{
 						{
 							CertificateChain: &core.DataSource{
@@ -342,7 +342,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 			enableIngressSdsAgent: true,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
-					AlpnProtocols: util.ALPNPlaintextHttp,
+					AlpnProtocols: util.ALPNPlaintextHTTP,
 					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 						{
 							Name: "ingress-sds-resource-name",
@@ -412,7 +412,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 			enableIngressSdsAgent: true,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
-					AlpnProtocols: util.ALPNPlaintextHttp,
+					AlpnProtocols: util.ALPNPlaintextHTTP,
 					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 						{
 							Name: "ingress-sds-resource-name",
@@ -482,7 +482,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 			enableIngressSdsAgent: true,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
-					AlpnProtocols: util.ALPNPlaintextHttp,
+					AlpnProtocols: util.ALPNPlaintextHTTP,
 					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 						{
 							Name: "ingress-sds-resource-name",

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -178,69 +178,25 @@ var (
 	plaintextHTTPALPNs = []string{"http/1.0", "http/1.1", "h2c"}
 	mtlsHTTPALPNs      = []string{"istio-http/1.0", "istio-http/1.1", "istio-h2"}
 
-	mtlsTCPALPNs        = []string{"istio"}
 	mtlsTCPWithMxcALPNs = []string{"istio-peer-exchange", "istio"}
 
 	// These ALPNs are injected in the client side by the ALPN filter.
-	// "istio" is added for each upstream protocol in order to make it
-	// backward compatible. e.g., 1.4 proxy -> 1.3 proxy.
-	mtlsHTTP10ALPN = []string{"istio-http/1.0", "istio"}
-	mtlsHTTP11ALPN = []string{"istio-http/1.1", "istio"}
-	mtlsHTTP2ALPN  = []string{"istio-h2", "istio"}
+	mtlsHTTP10ALPN = []string{"istio-http/1.0"}
+	mtlsHTTP11ALPN = []string{"istio-http/1.1"}
+	mtlsHTTP2ALPN  = []string{"istio-h2"}
 
 	// Double the number of filter chains. Half of filter chains are used as http filter chain and half of them are used as tcp proxy
 	// id in [0, len(allChains)/2) are configured as http filter chain, [(len(allChains)/2, len(allChains)) are configured as tcp proxy
 	// If mTLS permissive is enabled, there are five filter chains. The filter chain match should be
 	//  FCM 1: ALPN [istio-http/1.0, istio-http/1.1, istio-h2] Transport protocol: tls      --> HTTP traffic from sidecar over TLS
 	//  FCM 2: ALPN [http/1.0, http/1.1, h2c] Transport protocol: N/A                       --> HTTP traffic over plain text
-	//  FCM 3: ALPN [istio] Transport protocol: tls                                         --> TCP traffic from sidecar over TLS
+	//  FCM 3: ALPN [istio, istio-peer-exchange] Transport protocol: tls                    --> TCP traffic from sidecar over TLS
 	//  FCM 4: ALPN [] Transport protocol: N/A                                              --> TCP traffic over plain text
 	//  FCM 5: ALPN [] Transport protocol: tls                                              --> TCP traffic over TLS
 	// If traffic is over plain text or mTLS is strict mode, there are two filter chains. The filter chain match should be
 	//  FCM 1: ALPN [http/1.0, http/1.1, h2c, istio-http/1.0, istio-http/1.1, istio-h2]     --> HTTP traffic over plain text or TLS
 	//  FCM 2: ALPN []                                                                      --> TCP traffic over plain text or TLS
 	inboundPermissiveFilterChainMatchOptions = []FilterChainMatchOptions{
-		{
-			// client side traffic was detected as HTTP by the outbound listener, sent over mTLS
-			ApplicationProtocols: mtlsHTTPALPNs,
-			// If client sends mTLS traffic, transport protocol will be set by the TLS inspector
-			TransportProtocol: "tls",
-			Protocol:          istionetworking.ListenerProtocolHTTP,
-		},
-		{
-			// client side traffic was detected as HTTP by the outbound listener, sent out as plain text
-			ApplicationProtocols: plaintextHTTPALPNs,
-			// No transport protocol match as this filter chain (+match) will be used for plain text connections
-			Protocol: istionetworking.ListenerProtocolHTTP,
-		},
-		{
-			// client side traffic could not be identified by the outbound listener, but sent over mTLS
-			ApplicationProtocols: mtlsTCPALPNs,
-			// If client sends mTLS traffic, transport protocol will be set by the TLS inspector
-			TransportProtocol: "tls",
-			Protocol:          istionetworking.ListenerProtocolTCP,
-		},
-		{
-			// client side traffic could not be identified by the outbound listener, sent over plaintext
-			// or it could be that the client has no sidecar. In this case, this filter chain is simply
-			// receiving plaintext TCP traffic.
-			Protocol: istionetworking.ListenerProtocolTCP,
-		},
-		{
-			// client side traffic could not be identified by the outbound listener, sent over one-way
-			// TLS (HTTPS for example) by the downstream application.
-			// or it could be that the client has no sidecar, and it is directly making a HTTPS connection to
-			// this sidecar. In this case, this filter chain is receiving plaintext one-way TLS traffic. The TLS
-			// inspector would detect this as TLS traffic [not necessarily mTLS]. But since there is no ALPN to match,
-			// this filter chain match will treat the traffic as just another TCP proxy.
-			TransportProtocol: "tls",
-			Protocol:          istionetworking.ListenerProtocolTCP,
-		},
-	}
-
-	// Same as inboundPermissiveFilterChainMatchOptions except for following case:
-	// FCM 3: ALPN [istio-peer-exchange, istio] Transport protocol: tls            --> TCP traffic from sidecar over TLS
-	inboundPermissiveFilterChainMatchWithMxcOptions = []FilterChainMatchOptions{
 		{
 			// client side traffic was detected as HTTP by the outbound listener, sent over mTLS
 			ApplicationProtocols: mtlsHTTPALPNs,
@@ -737,12 +693,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListenerForPortOrUDS(no
 		allChains = append(allChains, allChains...)
 		if tlsInspectorEnabled {
 			allChains = append(allChains, istionetworking.FilterChain{})
-			if util.IsTCPMetadataExchangeEnabled(node) {
-				filterChainMatchOption = inboundPermissiveFilterChainMatchWithMxcOptions
-			} else {
-				filterChainMatchOption = inboundPermissiveFilterChainMatchOptions
-			}
-
+			filterChainMatchOption = inboundPermissiveFilterChainMatchOptions
 		} else {
 			if hasTLSContext {
 				filterChainMatchOption = inboundStrictFilterChainMatchOptions
@@ -851,7 +802,7 @@ func buildSidecarListenerTLSContext(userTLSOpts *networking.Server_TLSOptions, m
 
 	tls := &auth.DownstreamTlsContext{
 		CommonTlsContext: &auth.CommonTlsContext{
-			AlpnProtocols: util.ALPNHttp,
+			AlpnProtocols: util.ALPNPlaintextHttp,
 		},
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -1178,7 +1178,7 @@ func testInboundListenerConfigWithSidecar(t *testing.T, proxy *model.Proxy, serv
 	}
 	expectedTLSContext := &auth.DownstreamTlsContext{
 		CommonTlsContext: &auth.CommonTlsContext{
-			AlpnProtocols: util.ALPNHttp,
+			AlpnProtocols: util.ALPNPlaintextHttp,
 			TlsCertificates: []*auth.TlsCertificate{
 				{
 					CertificateChain: &core.DataSource{
@@ -2330,7 +2330,7 @@ func TestBuildSidecarListenerTlsContext(t *testing.T) {
 			},
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
-					AlpnProtocols: util.ALPNHttp,
+					AlpnProtocols: util.ALPNPlaintextHttp,
 					TlsCertificates: []*auth.TlsCertificate{
 						{
 							CertificateChain: &core.DataSource{
@@ -2362,7 +2362,7 @@ func TestBuildSidecarListenerTlsContext(t *testing.T) {
 			},
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
-					AlpnProtocols: util.ALPNHttp,
+					AlpnProtocols: util.ALPNPlaintextHttp,
 					TlsCertificates: []*auth.TlsCertificate{
 						{
 							CertificateChain: &core.DataSource{
@@ -2404,7 +2404,7 @@ func TestBuildSidecarListenerTlsContext(t *testing.T) {
 			},
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
-					AlpnProtocols: util.ALPNHttp,
+					AlpnProtocols: util.ALPNPlaintextHttp,
 					TlsCertificates: []*auth.TlsCertificate{
 						{
 							CertificateChain: &core.DataSource{
@@ -2446,7 +2446,7 @@ func TestBuildSidecarListenerTlsContext(t *testing.T) {
 			sdsUdsPath: "unix:/var/run/sidecar/sds",
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
-					AlpnProtocols: util.ALPNHttp,
+					AlpnProtocols: util.ALPNPlaintextHttp,
 					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 						{
 							Name: "test",

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -1178,7 +1178,7 @@ func testInboundListenerConfigWithSidecar(t *testing.T, proxy *model.Proxy, serv
 	}
 	expectedTLSContext := &auth.DownstreamTlsContext{
 		CommonTlsContext: &auth.CommonTlsContext{
-			AlpnProtocols: util.ALPNPlaintextHttp,
+			AlpnProtocols: util.ALPNPlaintextHTTP,
 			TlsCertificates: []*auth.TlsCertificate{
 				{
 					CertificateChain: &core.DataSource{
@@ -2330,7 +2330,7 @@ func TestBuildSidecarListenerTlsContext(t *testing.T) {
 			},
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
-					AlpnProtocols: util.ALPNPlaintextHttp,
+					AlpnProtocols: util.ALPNPlaintextHTTP,
 					TlsCertificates: []*auth.TlsCertificate{
 						{
 							CertificateChain: &core.DataSource{
@@ -2362,7 +2362,7 @@ func TestBuildSidecarListenerTlsContext(t *testing.T) {
 			},
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
-					AlpnProtocols: util.ALPNPlaintextHttp,
+					AlpnProtocols: util.ALPNPlaintextHTTP,
 					TlsCertificates: []*auth.TlsCertificate{
 						{
 							CertificateChain: &core.DataSource{
@@ -2404,7 +2404,7 @@ func TestBuildSidecarListenerTlsContext(t *testing.T) {
 			},
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
-					AlpnProtocols: util.ALPNPlaintextHttp,
+					AlpnProtocols: util.ALPNPlaintextHTTP,
 					TlsCertificates: []*auth.TlsCertificate{
 						{
 							CertificateChain: &core.DataSource{
@@ -2446,7 +2446,7 @@ func TestBuildSidecarListenerTlsContext(t *testing.T) {
 			sdsUdsPath: "unix:/var/run/sidecar/sds",
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
-					AlpnProtocols: util.ALPNPlaintextHttp,
+					AlpnProtocols: util.ALPNPlaintextHTTP,
 					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 						{
 							Name: "test",

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -77,7 +77,7 @@ func setAccessLog(push *model.PushContext, node *model.Proxy, config *tcp_proxy.
 		config.AccessLog = append(config.AccessLog, acc)
 	}
 
-	if push.Mesh.EnableEnvoyAccessLogService && util.IsIstioVersionGE14(node) {
+	if push.Mesh.EnableEnvoyAccessLogService {
 		fl := &accesslogconfig.TcpGrpcAccessLogConfig{
 			CommonConfig: &accesslogconfig.CommonGrpcAccessLogConfig{
 				LogName: tcpEnvoyAccessLogFriendlyName,
@@ -91,9 +91,7 @@ func setAccessLog(push *model.PushContext, node *model.Proxy, config *tcp_proxy.
 			},
 		}
 
-		if util.IsIstioVersionGE14(node) {
-			fl.CommonConfig.FilterStateObjectsToLog = envoyWasmStateToLog
-		}
+		fl.CommonConfig.FilterStateObjectsToLog = envoyWasmStateToLog
 
 		acc := &accesslog.AccessLog{
 			Name:       tcpEnvoyALSName,

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -349,14 +349,13 @@ func translateRoute(push *model.PushContext, node *model.Proxy, in *networking.H
 		Metadata: util.BuildConfigInfoMetadata(virtualService.ConfigMeta),
 	}
 
-	if util.IsIstioVersionGE13(node) {
-		routeName := in.Name
-		if match != nil && match.Name != "" {
-			routeName = routeName + "." + match.Name
-		}
-		out.Name = routeName
-		// add a name to the route
+	// add a name to the route
+	routeName := in.Name
+	if match != nil && match.Name != "" {
+		routeName = routeName + "." + match.Name
 	}
+	out.Name = routeName
+
 	out.TypedPerFilterConfig = make(map[string]*any.Any)
 	if redirect := in.Redirect; redirect != nil {
 		action := &route.Route_Redirect{
@@ -583,12 +582,10 @@ func translateRouteMatch(in *networking.HTTPMatchRequest, node *model.Proxy) *ro
 		out.Headers = append(out.Headers, &matcher)
 	}
 
-	if util.IsIstioVersionGE14(node) {
-		for name, stringMatch := range in.WithoutHeaders {
-			matcher := translateHeaderMatch(name, stringMatch, node)
-			matcher.InvertMatch = true
-			out.Headers = append(out.Headers, &matcher)
-		}
+	for name, stringMatch := range in.WithoutHeaders {
+		matcher := translateHeaderMatch(name, stringMatch, node)
+		matcher.InvertMatch = true
+		out.Headers = append(out.Headers, &matcher)
 	}
 
 	// guarantee ordering of headers
@@ -603,19 +600,15 @@ func translateRouteMatch(in *networking.HTTPMatchRequest, node *model.Proxy) *ro
 		case *networking.StringMatch_Prefix:
 			out.PathSpecifier = &route.RouteMatch_Prefix{Prefix: m.Prefix}
 		case *networking.StringMatch_Regex:
-			if !util.IsIstioVersionGE14(node) {
-				out.PathSpecifier = &route.RouteMatch_Regex{Regex: m.Regex}
-			} else {
-				out.PathSpecifier = &route.RouteMatch_SafeRegex{
-					SafeRegex: &matcher.RegexMatcher{
-						EngineType: &matcher.RegexMatcher_GoogleRe2{GoogleRe2: &matcher.RegexMatcher_GoogleRE2{
-							MaxProgramSize: &wrappers.UInt32Value{
-								Value: uint32(maxRegExProgramSize),
-							},
-						}},
-						Regex: m.Regex,
-					},
-				}
+			out.PathSpecifier = &route.RouteMatch_SafeRegex{
+				SafeRegex: &matcher.RegexMatcher{
+					EngineType: &matcher.RegexMatcher_GoogleRe2{GoogleRe2: &matcher.RegexMatcher_GoogleRE2{
+						MaxProgramSize: &wrappers.UInt32Value{
+							Value: uint32(maxRegExProgramSize),
+						},
+					}},
+					Regex: m.Regex,
+				},
 			}
 		}
 	}
@@ -710,15 +703,11 @@ func translateHeaderMatch(name string, in *networking.StringMatch, node *model.P
 		// Golang has a slightly different regex grammar
 		out.HeaderMatchSpecifier = &route.HeaderMatcher_PrefixMatch{PrefixMatch: m.Prefix}
 	case *networking.StringMatch_Regex:
-		if !util.IsIstioVersionGE14(node) {
-			out.HeaderMatchSpecifier = &route.HeaderMatcher_RegexMatch{RegexMatch: m.Regex}
-		} else {
-			out.HeaderMatchSpecifier = &route.HeaderMatcher_SafeRegexMatch{
-				SafeRegexMatch: &matcher.RegexMatcher{
-					EngineType: regexEngine,
-					Regex:      m.Regex,
-				},
-			}
+		out.HeaderMatchSpecifier = &route.HeaderMatcher_SafeRegexMatch{
+			SafeRegexMatch: &matcher.RegexMatcher{
+				EngineType: regexEngine,
+				Regex:      m.Regex,
+			},
 		}
 	}
 
@@ -840,9 +829,7 @@ func BuildDefaultHTTPInboundRoute(node *model.Proxy, clusterName string, operati
 		},
 	}
 
-	if util.IsIstioVersionGE13(node) {
-		val.Name = DefaultRouteName
-	}
+	val.Name = DefaultRouteName
 	return val
 }
 

--- a/pilot/pkg/networking/plugin/authn/authentication.go
+++ b/pilot/pkg/networking/plugin/authn/authentication.go
@@ -38,7 +38,7 @@ func NewPlugin() plugin.Plugin {
 func (Plugin) OnInboundFilterChains(in *plugin.InputParams) []networking.FilterChain {
 	return factory.NewPolicyApplier(in.Push,
 		in.ServiceInstance, in.Node.Metadata.Namespace, labels.Collection{in.Node.Metadata.Labels}).InboundFilterChain(
-		in.ServiceInstance.Endpoint.EndpointPort, in.Push.Mesh.SdsUdsPath, in.Node)
+		in.ServiceInstance.Endpoint.EndpointPort, in.Push.Mesh.SdsUdsPath, in.Node, in.ListenerProtocol)
 }
 
 // OnOutboundListener is called whenever a new outbound listener is added to the LDS output for a given service

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -94,24 +94,28 @@ const (
 	subsetNameStatPattern      = "%SUBSET_NAME%"
 )
 
-// ALPNPlaintextH2Only advertises that Proxy is going to use HTTP/2 when talking to the cluster.
-var ALPNPlaintextH2Only = []string{"h2"}
+var (
+	// ALPNMtlsTCPWithMxc advertises that Proxy is going to talk to the in-mesh cluster and has metadata exchange enabled for
+	// TCP. The custom "istio-peer-exchange" value indicates, metadata exchange is enabled for TCP. The custom "istio" value
+	// indicates in-mesh traffic and it's going to be used for routing decisions.
+	// TODO: remove istio alpn in 1.7
+	ALPNMtlsTCPWithMxc = []string{"istio-peer-exchange", "istio"}
 
-// ALPNMtlsH2 advertises that Proxy is going to use HTTP/2 when talking to the in-mesh cluster.
-// The custom "istio" value indicates in-mesh traffic and it's going to be used for routing decisions.
-// Once Envoy supports client-side ALPN negotiation, this should be {"istio", "h2", "http/1.1"}.
-var ALPNMtlsH2 = []string{"istio-h2"}
+	// ALPNPlaintextHTTP advertises that Proxy is going to talking either http2 or http 1.1 or http/1.0
+	ALPNPlaintextHTTP = []string{"http/1.0", "h2", "http/1.1"}
+	// ALPNMtlsHTTP advertises that the proxy is going to be talking either http2 or http 1.1 or http/1.0 over mTLS
+	ALPNMtlsHTTP = []string{"istio-http/1.0", "istio-http/1.1", "istio-h2"}
 
-// ALPNMtlsTcpWithMxc advertises that Proxy is going to talk to the in-mesh cluster and has metadata exchange enabled for
-// TCP. The custom "istio-peer-exchange" value indicates, metadata exchange is enabled for TCP. The custom "istio" value
-// indicates in-mesh traffic and it's going to be used for routing decisions.
-var ALPNMtlsTcpWithMxc = []string{"istio-peer-exchange", "istio"}
+	// ALPNPlaintextH2 advertises that Proxy is going to use HTTP/2 when talking to the cluster.
+	ALPNPlaintextH2 = []string{"h2"}
+	// ALPNMtlsH2 advertises that Proxy is going to use HTTP/2 when talking to the in-mesh endpoint over mTLS.
+	ALPNMtlsH2 = []string{"istio-h2"}
 
-// ALPNPlaintextHttp advertises that Proxy is going to talking either http2 or http 1.1.
-var ALPNPlaintextHttp = []string{"h2", "http/1.1"}
-
-// ALPNDownstream advertises that Proxy is going to talking either tcp(for metadata exchange), http2 or http 1.1.
-var ALPNDownstream = []string{"istio-peer-exchange", "h2", "http/1.1"}
+	// ALPNMtlsHTTP10 indicates the proxy is speaking over mTLS with http/1.0 protocol
+	ALPNMtlsHTTP10 = []string{"istio-http/1.0"}
+	// ALPNMtlsHTTP11 indicates the proxy is speaking over mTLS with http/1.1 protocol
+	ALPNMtlsHTTP11 = []string{"istio-http/1.1"}
+)
 
 // FallThroughFilterChainBlackHoleService is the blackhole service used for fall though
 // filter chain
@@ -263,12 +267,12 @@ func IsIstioVersionGE15(node *model.Proxy) bool {
 }
 
 // IsProtocolSniffingEnabled checks whether protocol sniffing is enabled.
-func IsProtocolSniffingEnabledForOutbound(node *model.Proxy) bool {
-	return features.EnableProtocolSniffingForOutbound.Get() && IsIstioVersionGE13(node)
+func IsProtocolSniffingEnabledForOutbound(_ *model.Proxy) bool {
+	return features.EnableProtocolSniffingForOutbound.Get()
 }
 
-func IsProtocolSniffingEnabledForInbound(node *model.Proxy) bool {
-	return features.EnableProtocolSniffingForInbound.Get() && IsIstioVersionGE14(node)
+func IsProtocolSniffingEnabledForInbound(_ *model.Proxy) bool {
+	return features.EnableProtocolSniffingForInbound.Get()
 }
 
 func IsProtocolSniffingEnabledForPort(node *model.Proxy, port *model.Port) bool {

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -70,9 +70,6 @@ const (
 
 	// SniClusterFilter is the name of the sni_cluster envoy filter
 	SniClusterFilter = "envoy.filters.network.sni_cluster"
-	// ForwardDownstreamSniFilter forwards the sni from downstream connections to upstream
-	// Used only in the fallthrough filter stack for TLS connections
-	ForwardDownstreamSniFilter = "forward_downstream_sni"
 	// IstioMetadataKey is the key under which metadata is added to a route or cluster
 	// regarding the virtual service or destination rule used for each
 	IstioMetadataKey = "istio"
@@ -97,25 +94,21 @@ const (
 	subsetNameStatPattern      = "%SUBSET_NAME%"
 )
 
-// ALPNH2Only advertises that Proxy is going to use HTTP/2 when talking to the cluster.
-var ALPNH2Only = []string{"h2"}
+// ALPNPlaintextH2Only advertises that Proxy is going to use HTTP/2 when talking to the cluster.
+var ALPNPlaintextH2Only = []string{"h2"}
 
-// ALPNInMeshH2 advertises that Proxy is going to use HTTP/2 when talking to the in-mesh cluster.
+// ALPNMtlsH2 advertises that Proxy is going to use HTTP/2 when talking to the in-mesh cluster.
 // The custom "istio" value indicates in-mesh traffic and it's going to be used for routing decisions.
 // Once Envoy supports client-side ALPN negotiation, this should be {"istio", "h2", "http/1.1"}.
-var ALPNInMeshH2 = []string{"istio", "h2"}
+var ALPNMtlsH2 = []string{"istio-h2"}
 
-// ALPNInMesh advertises that Proxy is going to talk to the in-mesh cluster.
-// The custom "istio" value indicates in-mesh traffic and it's going to be used for routing decisions.
-var ALPNInMesh = []string{"istio"}
-
-// ALPNInMeshWithMxc advertises that Proxy is going to talk to the in-mesh cluster and has metadata exchange enabled for
+// ALPNMtlsTcpWithMxc advertises that Proxy is going to talk to the in-mesh cluster and has metadata exchange enabled for
 // TCP. The custom "istio-peer-exchange" value indicates, metadata exchange is enabled for TCP. The custom "istio" value
 // indicates in-mesh traffic and it's going to be used for routing decisions.
-var ALPNInMeshWithMxc = []string{"istio-peer-exchange", "istio"}
+var ALPNMtlsTcpWithMxc = []string{"istio-peer-exchange", "istio"}
 
-// ALPNHttp advertises that Proxy is going to talking either http2 or http 1.1.
-var ALPNHttp = []string{"h2", "http/1.1"}
+// ALPNPlaintextHttp advertises that Proxy is going to talking either http2 or http 1.1.
+var ALPNPlaintextHttp = []string{"h2", "http/1.1"}
 
 // ALPNDownstream advertises that Proxy is going to talking either tcp(for metadata exchange), http2 or http 1.1.
 var ALPNDownstream = []string{"istio-peer-exchange", "h2", "http/1.1"}
@@ -288,11 +281,6 @@ func IsProtocolSniffingEnabledForInboundPort(node *model.Proxy, port *model.Port
 
 func IsProtocolSniffingEnabledForOutboundPort(node *model.Proxy, port *model.Port) bool {
 	return IsProtocolSniffingEnabledForOutbound(node) && port.Protocol.IsUnsupported()
-}
-
-// IsTCPMetadataExchangeEnabled checks whether Metadata Exchanged enabled for TCP using ALPN.
-func IsTCPMetadataExchangeEnabled(node *model.Proxy) bool {
-	return features.EnableTCPMetadataExchange.Get() && IsIstioVersionGE15(node)
 }
 
 // ConvertLocality converts '/' separated locality string to Locality struct.

--- a/pilot/pkg/security/authn/policy_applier.go
+++ b/pilot/pkg/security/authn/policy_applier.go
@@ -26,7 +26,8 @@ import (
 type PolicyApplier interface {
 	// InboundFilterChain returns inbound filter chain(s) for the given endpoint (aka workload) port to
 	// enforce the underlying authentication policy.
-	InboundFilterChain(endpointPort uint32, sdsUdsPath string, node *model.Proxy) []networking.FilterChain
+	InboundFilterChain(endpointPort uint32, sdsUdsPath string,
+		node *model.Proxy, protocol networking.ListenerProtocol) []networking.FilterChain
 
 	// AuthNFilter returns the JWT HTTP filter to enforce the underlying authentication policy.
 	// It may return nil, if no JWT validation is needed.

--- a/pilot/pkg/security/authn/v1alpha1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1alpha1/policy_applier.go
@@ -326,11 +326,12 @@ func AuthNFilterConfigForBackwarding(alphaApplier authn.PolicyApplier, proxyType
 }
 
 // v1alpha1 applier is already per port, so the endpointPort param is not needed.
-func (a v1alpha1PolicyApplier) InboundFilterChain(_ uint32, sdsUdsPath string, node *model.Proxy) []networking.FilterChain {
+func (a v1alpha1PolicyApplier) InboundFilterChain(_ uint32, sdsUdsPath string,
+	node *model.Proxy, protocol networking.ListenerProtocol) []networking.FilterChain {
 	if a.policy == nil || len(a.policy.Peers) == 0 {
 		return nil
 	}
-	return authn_utils.BuildInboundFilterChain(GetMutualTLSMode(a.policy), sdsUdsPath, node)
+	return authn_utils.BuildInboundFilterChain(GetMutualTLSMode(a.policy), sdsUdsPath, node, protocol)
 }
 
 // NewPolicyApplier returns new applier for v1alpha1 authentication policy.

--- a/pilot/pkg/security/authn/v1beta1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier.go
@@ -187,15 +187,16 @@ func (a *v1beta1PolicyApplier) AuthNFilter(proxyType model.NodeType, port uint32
 	}
 }
 
-func (a *v1beta1PolicyApplier) InboundFilterChain(endpointPort uint32, sdsUdsPath string, node *model.Proxy) []networking.FilterChain {
+func (a *v1beta1PolicyApplier) InboundFilterChain(endpointPort uint32, sdsUdsPath string,
+	node *model.Proxy, protocol networking.ListenerProtocol) []networking.FilterChain {
 	// If beta mTLS policy (PeerAuthentication) is not used for this workload, fallback to alpha policy.
 	if a.shouldUseAlphaMtlsPolicy() {
 		authnLog.Debugf("InboundFilterChain [%v:%d]: fallback to alpha policy applier", node.ID, endpointPort)
-		return a.alphaApplier.InboundFilterChain(endpointPort, sdsUdsPath, node)
+		return a.alphaApplier.InboundFilterChain(endpointPort, sdsUdsPath, node, protocol)
 	}
 	effectiveMTLSMode := a.getMutualTLSModeForPort(endpointPort)
 	authnLog.Debugf("InboundFilterChain: build inbound filter change for %v:%d in %s mode", node.ID, endpointPort, effectiveMTLSMode)
-	return authn_utils.BuildInboundFilterChain(effectiveMTLSMode, sdsUdsPath, node)
+	return authn_utils.BuildInboundFilterChain(effectiveMTLSMode, sdsUdsPath, node, protocol)
 }
 
 // NewPolicyApplier returns new applier for v1beta1 authentication policies.

--- a/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
@@ -2050,6 +2050,7 @@ func TestOnInboundFilterChain(t *testing.T) {
 				8080,
 				tc.sdsUdsPath,
 				testNode,
+				networking.ListenerProtocolTCP,
 			)
 			if !reflect.DeepEqual(got, tc.expected) {
 				t.Errorf("[%v] unexpected filter chains, got %v, want %v", tc.name, got, tc.expected)

--- a/pkg/bootstrap/option/convert.go
+++ b/pkg/bootstrap/option/convert.go
@@ -84,7 +84,7 @@ func tlsConverter(tls *networkingAPI.TLSSettings, sniName string, metadata *mode
 				},
 				Sni: tls.Sni,
 			}
-			tlsContext.CommonTLSContext.AlpnProtocols = util.ALPNH2Only
+			tlsContext.CommonTLSContext.AlpnProtocols = util.ALPNPlaintextH2Only
 		case networkingAPI.TLSSettings_MUTUAL, networkingAPI.TLSSettings_ISTIO_MUTUAL:
 			clientCertificate := tls.ClientCertificate
 			if tls.ClientCertificate == "" && tls.Mode == networkingAPI.TLSSettings_ISTIO_MUTUAL {
@@ -120,9 +120,9 @@ func tlsConverter(tls *networkingAPI.TLSSettings, sniName string, metadata *mode
 				tlsContext.Sni = sniName
 			}
 			if tls.Mode == networkingAPI.TLSSettings_ISTIO_MUTUAL {
-				tlsContext.CommonTLSContext.AlpnProtocols = util.ALPNInMeshH2
+				tlsContext.CommonTLSContext.AlpnProtocols = util.ALPNMtlsH2
 			} else {
-				tlsContext.CommonTLSContext.AlpnProtocols = util.ALPNH2Only
+				tlsContext.CommonTLSContext.AlpnProtocols = util.ALPNPlaintextH2Only
 			}
 		default:
 			// No TLS.

--- a/pkg/bootstrap/option/convert.go
+++ b/pkg/bootstrap/option/convert.go
@@ -84,7 +84,7 @@ func tlsConverter(tls *networkingAPI.TLSSettings, sniName string, metadata *mode
 				},
 				Sni: tls.Sni,
 			}
-			tlsContext.CommonTLSContext.AlpnProtocols = util.ALPNPlaintextH2Only
+			tlsContext.CommonTLSContext.AlpnProtocols = util.ALPNPlaintextH2
 		case networkingAPI.TLSSettings_MUTUAL, networkingAPI.TLSSettings_ISTIO_MUTUAL:
 			clientCertificate := tls.ClientCertificate
 			if tls.ClientCertificate == "" && tls.Mode == networkingAPI.TLSSettings_ISTIO_MUTUAL {
@@ -122,7 +122,7 @@ func tlsConverter(tls *networkingAPI.TLSSettings, sniName string, metadata *mode
 			if tls.Mode == networkingAPI.TLSSettings_ISTIO_MUTUAL {
 				tlsContext.CommonTLSContext.AlpnProtocols = util.ALPNMtlsH2
 			} else {
-				tlsContext.CommonTLSContext.AlpnProtocols = util.ALPNPlaintextH2Only
+				tlsContext.CommonTLSContext.AlpnProtocols = util.ALPNPlaintextH2
 			}
 		default:
 			// No TLS.

--- a/tests/integration/pilot/sidecartls/main_test.go
+++ b/tests/integration/pilot/sidecartls/main_test.go
@@ -291,7 +291,7 @@ func checkCustomInboundFilterChainTLS(resp *xdsapi.DiscoveryResponse) (success b
 					},
 				},
 			},
-			AlpnProtocols: util.ALPNHttp,
+			AlpnProtocols: util.ALPNPlaintextHttp,
 		},
 		RequireClientCertificate: &wrappers.BoolValue{
 			Value: false,

--- a/tests/integration/pilot/sidecartls/main_test.go
+++ b/tests/integration/pilot/sidecartls/main_test.go
@@ -243,7 +243,7 @@ func checkInboundFilterChainMTLS(resp *xdsapi.DiscoveryResponse) (success bool, 
 					},
 				},
 			},
-			AlpnProtocols: util.ALPNDownstream,
+			AlpnProtocols: util.ALPNMtlsHTTP,
 		},
 		RequireClientCertificate: &wrappers.BoolValue{
 			Value: true,
@@ -291,7 +291,7 @@ func checkCustomInboundFilterChainTLS(resp *xdsapi.DiscoveryResponse) (success b
 					},
 				},
 			},
-			AlpnProtocols: util.ALPNPlaintextHttp,
+			AlpnProtocols: util.ALPNPlaintextHTTP,
 		},
 		RequireClientCertificate: &wrappers.BoolValue{
 			Value: false,


### PR DESCRIPTION
We had quite a bit of cruft in the ALPN logic spread over authn and the listener code. Some ALPNs constructed by authn for strict/permissive non sniffing mode was being overwritten by the listener code. And in some cases, we were constructing ALPN and matches that was plain wrong and not even reachable. This PR take a major pass at cleaning up all the ALPN references throughout the networking code. 

Notable changes are as follows:
1. TCP Metadata exchange is now always enabled. This cuts down the number of filter chains and the explosion by a large amount.
2. All outbound traffic from a proxy is always using istio custom ALPNs (istio-http1.1, etc.) since Istio 1.4. So, some cleanups in the filter chain matches reflect this property.