### PR TITLE
Make pilot-agent items owned by networking

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -22,7 +22,7 @@ Makefile*                                                        @istio/wg-test-
 /pilot/pkg/networking/core                                       @istio/wg-networking-maintainers-pilot
 /pilot/pkg/proxy                                                 @istio/wg-networking-maintainers-pilot
 /pkg/adsc/                                                       @istio/wg-networking-maintainers
-/pkg/bootstrap/                                                  @istio/wg-environments-maintainers
+/pkg/bootstrap/                                                  @istio/wg-networking-maintainers
 /pkg/config/                                                     @istio/wg-networking-maintainers
 /pkg/envoy/                                                      @istio/wg-networking-maintainers
 /pkg/istio-agent/                                                @istio/wg-networking-maintainers
@@ -52,5 +52,6 @@ Makefile*                                                        @istio/wg-test-
 /tests/integration/security/                                     @istio/wg-security-maintainers
 /tests/integration/istioctl/                                     @istio/wg-user-experience-maintainers
 /tools/                                                          @istio/wg-test-and-release-maintainers
+/tools/packaging/common/envoy_bootstrap_v2.json                  @istio/wg-networking-maintainers
 /tools/istio-iptables/                                           @istio/wg-networking-maintainers
 /tools/istio-clean-iptables/                                     @istio/wg-networking-maintainers


### PR DESCRIPTION
Everytime you make a change to the agent right now it asks for owners
for t&r, environments, and networking. This is owned by networking, so
it should only require that approval