### PR TITLE
Add blackhole and passthrough cluster test for mixer

### DIFF
--- a/pkg/test/env/istio.go
+++ b/pkg/test/env/istio.go
@@ -98,11 +98,17 @@ var (
 	// IstioChartDir is the Kubernetes Helm chart directory in the repository
 	IstioChartDir = path.Join(ChartsDir, "istio")
 
+	// SamplesRoot is the root folder for the samples directory
+	SamplesRoot = path.Join(IstioSrc, "samples")
+
 	// BookInfoRoot is the root folder for the bookinfo samples
-	BookInfoRoot = path.Join(IstioSrc, "samples/bookinfo")
+	BookInfoRoot = path.Join(SamplesRoot, "bookinfo")
 
 	// BookInfoKube is the book info folder that contains Yaml deployment files.
 	BookInfoKube = path.Join(BookInfoRoot, "platform/kube")
+
+	// SleepRoot is the root folder for the sleep samples directory
+	SleepRoot = path.Join(SamplesRoot, "sleep")
 
 	// ServiceAccountFilePath is the helm service account file.
 	ServiceAccountFilePath = path.Join(ChartsDir, "helm-service-account.yaml")

--- a/pkg/test/framework/components/deployment/deployment.go
+++ b/pkg/test/framework/components/deployment/deployment.go
@@ -16,6 +16,7 @@ package deployment
 
 import (
 	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/resource"
 )
@@ -29,6 +30,9 @@ type Instance interface {
 
 	// Namespace of the deployment, if any.
 	Namespace() namespace.Instance
+
+	// Environment of the deployment
+	Env() *kube.Environment
 }
 
 type Config struct {

--- a/pkg/test/framework/components/deployment/kube.go
+++ b/pkg/test/framework/components/deployment/kube.go
@@ -79,6 +79,10 @@ func (c *kubeComponent) Name() string {
 	return c.cfg.Name
 }
 
+func (c *kubeComponent) Env() *kube.Environment {
+	return c.env
+}
+
 func (c *kubeComponent) Namespace() namespace.Instance {
 	return c.cfg.Namespace
 }

--- a/pkg/test/framework/components/sleep/kube.go
+++ b/pkg/test/framework/components/sleep/kube.go
@@ -1,0 +1,71 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sleep
+
+import (
+	"io/ioutil"
+	"path"
+
+	"istio.io/istio/pkg/test/env"
+	"istio.io/istio/pkg/test/framework/components/deployment"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+type sleepConfig string
+
+type sleepComponent struct {
+	deployment.Instance
+}
+
+const (
+	// Sleep uses "sleep.yaml"
+	Sleep          sleepConfig = "sleep.yaml"
+)
+
+func deploy(ctx resource.Context, cfg Config) (i SleepInstance, err error) {
+	ns := cfg.Namespace
+	if ns == nil {
+		ns, err = namespace.Claim(ctx, "default")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	yamlFile := path.Join(env.SleepRoot, string(cfg.Cfg))
+	by, err := ioutil.ReadFile(yamlFile)
+	if err != nil {
+		return nil, err
+	}
+
+	depcfg := deployment.Config{
+		Name:      string(cfg.Cfg),
+		Namespace: ns,
+		Yaml:      string(by),
+	}
+
+	return newSleepInstance(ctx, depcfg)
+}
+
+func newSleepInstance(ctx resource.Context, cfg deployment.Config) (SleepInstance, error) {
+	deploymentInst, err := deployment.New(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &sleepComponent{
+		Instance: deploymentInst,
+	}, nil
+}

--- a/pkg/test/framework/components/sleep/sleep.go
+++ b/pkg/test/framework/components/sleep/sleep.go
@@ -1,0 +1,76 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sleep
+
+import (
+	"fmt"
+
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/framework/components/deployment"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+type SleepInstance interface {
+	deployment.Instance
+	Curl(uri string) (string, error)
+}
+
+type Config struct {
+	Namespace namespace.Instance
+	Cfg       sleepConfig
+}
+
+const (
+	sleepContainerName = "sleep"
+)
+
+// Deploy returns a new instance of deployed Sleep
+func Deploy(ctx resource.Context, cfg Config) (i SleepInstance, err error) {
+	err = resource.UnsupportedEnvironment(ctx.Environment())
+
+	ctx.Environment().Case(environment.Kube, func() {
+		i, err = deploy(ctx, cfg)
+	})
+
+	return
+}
+
+// DeployOrFail returns a new instance of deployed Sleep or fails test
+func DeployOrFail(t test.Failer, ctx resource.Context, cfg Config) SleepInstance {
+	t.Helper()
+
+	i, err := Deploy(ctx, cfg)
+	if err != nil {
+		t.Fatalf("sleep.DeployOrFail: %v", err)
+	}
+
+	return i
+}
+
+// Curl makes a GET request to the given url for the sleep deployment and returns
+// the HTTP response code
+func (s *sleepComponent) Curl(url string) (string, error) {
+	pods, err := s.Env().GetPods(s.Namespace().Name(), "app=sleep")
+	if err != nil {
+		return "", fmt.Errorf("unable to find sleep pod: %v", err)
+	}
+	podNs, podName := pods[0].Namespace, pods[0].Name
+
+	// Exec onto the pod and make a curl request for the given curl
+	command := fmt.Sprintf("curl -w %%{http_code} %s", url)
+	return s.Env().Accessor.Exec(podNs, podName, sleepContainerName, command)
+}

--- a/pkg/test/framework/components/sleep/sleep.go
+++ b/pkg/test/framework/components/sleep/sleep.go
@@ -71,6 +71,6 @@ func (s *sleepComponent) Curl(url string) (string, error) {
 	podNs, podName := pods[0].Namespace, pods[0].Name
 
 	// Exec onto the pod and make a curl request for the given curl
-	command := fmt.Sprintf("curl -w %%{http_code} %s", url)
+	command := fmt.Sprintf("curl -o /dev/null -w %%{http_code} %s", url)
 	return s.Env().Accessor.Exec(podNs, podName, sleepContainerName, command)
 }

--- a/tests/integration/mixer/telemetry/metrics/blackhole/blackhole_test.go
+++ b/tests/integration/mixer/telemetry/metrics/blackhole/blackhole_test.go
@@ -1,0 +1,103 @@
+package blackhole
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/environment"
+	"istio.io/istio/pkg/test/framework/components/galley"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/mixer"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/components/prometheus"
+	"istio.io/istio/pkg/test/framework/components/sleep"
+	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
+	util "istio.io/istio/tests/integration/mixer"
+)
+
+var (
+	sleepNs    namespace.Instance
+	ist        istio.Instance
+	prom       prometheus.Instance
+)
+
+func TestBlackHoleClustersMetric(t *testing.T) {
+	framework.
+		NewTest(t).
+		RequiresEnvironment(environment.Kube).
+		Run(func(ctx framework.TestContext) {
+			sleepInst := sleep.DeployOrFail(t, ctx, sleep.Config{Namespace: sleepNs, Cfg: sleep.Sleep})
+			respCode, err := sleepInst.Curl("http://istio.io")
+			if err != nil {
+				t.Fatalf("Unable to exec curl http://istio.io from sleep pod: %v", err)
+			}
+			if respCode != "502" {
+				t.Fatalf("502 not returned from sleep pod; received http response code: %s", respCode)
+			}
+			query := `sum(istio_requests_total{destination_service_name="BlackHoleCluster"})`
+			util.ValidateMetric(t, prom, query, "istio_requests_total", 1)
+
+			respCode, err = sleepInst.Curl("https://istio.io")
+			if err == nil {
+				t.Fatal("expected exec curl https://istio.io from sleep pod to error out")
+			}
+			if respCode != "000" {
+				t.Fatalf("000 not returned from sleep pod; received http response code: %s", respCode)
+			}
+			query = `sum(istio_tcp_connections_closed_total{destination_service="BlackHoleCluster",destination_service_name="BlackHoleCluster"})`
+			util.ValidateMetric(t, prom, query, "istio_tcp_connections_closed_total", 1)
+		})
+}
+
+func TestMain(m *testing.M) {
+	framework.
+		NewSuite("mixer_telemetry_metrics", m).
+		RequireEnvironment(environment.Kube).
+		Label(label.CustomSetup).
+		SetupOnEnv(environment.Kube, istio.Setup(&ist, func(cfg *istio.Config) {
+			cfg.ControlPlaneValues = `
+values:
+  prometheus:
+    enabled: true
+  global:
+    disablePolicyChecks: false
+    outboundTrafficPolicy:
+      mode: REGISTRY_ONLY
+  telemetry:
+    v1:
+      enabled: true
+    v2:
+      enabled: false
+components:
+  policy:
+    enabled: true
+  telemetry:
+    enabled: true`
+		})).
+		Setup(testsetup).
+		Run()
+}
+
+func testsetup(ctx resource.Context) (err error) {
+	sleepNs, err = namespace.New(ctx, namespace.Config{
+		Prefix: "istio-sleep",
+		Inject: true,
+	})
+	if err != nil {
+		return
+	}
+	g, err := galley.New(ctx, galley.Config{})
+	if err != nil {
+		return err
+	}
+	if _, err = mixer.New(ctx, mixer.Config{Galley: g}); err != nil {
+		return err
+	}
+	prom, err = prometheus.New(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/tests/integration/mixer/telemetry/metrics/passthrough/passthrough_test.go
+++ b/tests/integration/mixer/telemetry/metrics/passthrough/passthrough_test.go
@@ -22,7 +22,7 @@ var (
 	prom       prometheus.Instance
 )
 
-func TestBlackHoleClusterMetric(t *testing.T) {
+func TestPassthroughClusterMetric(t *testing.T) {
 	framework.
 		NewTest(t).
 		RequiresEnvironment(environment.Kube).
@@ -32,20 +32,20 @@ func TestBlackHoleClusterMetric(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Unable to exec curl http://istio.io from sleep pod: %v", err)
 			}
-			if respCode != "502" {
-				t.Fatalf("502 not returned from sleep pod; received http response code: %s", respCode)
+			if respCode != "301" {
+				t.Fatalf("301 not returned from sleep pod; received http response code: %s", respCode)
 			}
-			query := `sum(istio_requests_total{destination_service_name="BlackHoleCluster"})`
+			query := `sum(istio_requests_total{destination_service_name="PassthroughCluster"})`
 			util.ValidateMetric(t, prom, query, "istio_requests_total", 1)
 
 			respCode, err = sleepInst.Curl("https://istio.io")
-			if err == nil {
-				t.Fatal("expected exec curl https://istio.io from sleep pod to error out")
+			if err != nil {
+				t.Fatalf("Unable to exec curl https://istio.io from sleep pod: %v", err)
 			}
-			if respCode != "000" {
-				t.Fatalf("000 not returned from sleep pod; received http response code: %s", respCode)
+			if respCode != "200" {
+				t.Fatalf("200 not returned from sleep pod; received http response code: %s", respCode)
 			}
-			query = `sum(istio_tcp_connections_closed_total{destination_service="BlackHoleCluster",destination_service_name="BlackHoleCluster"})`
+			query = `sum(istio_tcp_connections_closed_total{destination_service="PassthroughCluster",destination_service_name="PassthroughCluster"})`
 			util.ValidateMetric(t, prom, query, "istio_tcp_connections_closed_total", 1)
 		})
 }
@@ -63,7 +63,7 @@ values:
   global:
     disablePolicyChecks: false
     outboundTrafficPolicy:
-      mode: REGISTRY_ONLY
+      mode: ALLOW_ANY
   telemetry:
     v1:
       enabled: true

--- a/tests/integration/mixer/telemetry/metrics/scenarios_test.go
+++ b/tests/integration/mixer/telemetry/metrics/scenarios_test.go
@@ -27,6 +27,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/mixer"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/components/prometheus"
+	"istio.io/istio/pkg/test/framework/components/sleep"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/util/tmpl"
@@ -36,6 +37,7 @@ import (
 var (
 	ist        istio.Instance
 	bookinfoNs namespace.Instance
+	sleepNs    namespace.Instance
 	g          galley.Instance
 	ing        ingress.Instance
 	prom       prometheus.Instance
@@ -188,6 +190,34 @@ func TestTcpMetric(t *testing.T) {
 		})
 }
 
+func TestBlackHoleClustersMetric(t *testing.T) {
+	framework.
+		NewTest(t).
+		RequiresEnvironment(environment.Kube).
+		Run(func(ctx framework.TestContext) {
+			sleepInst := sleep.DeployOrFail(t, ctx, sleep.Config{Namespace: sleepNs, Cfg: sleep.Sleep})
+			respCode, err := sleepInst.Curl("http://istio.io")
+			if err != nil {
+				t.Fatalf("Unable to exec curl http://istio.io from sleep pod: %v", err)
+			}
+			if respCode != "502" {
+				t.Fatalf("502 not returned from sleep pod; received http response code: %s", respCode)
+			}
+			query := `sum(istio_requests_total{destination_service_name="BlackHoleCluster"})`
+			util.ValidateMetric(t, prom, query, "istio_requests_total", 1)
+
+			respCode, err = sleepInst.Curl("https://istio.io")
+			if err == nil {
+				t.Fatal("expected exec curl https://istio.io from sleep pod to error out")
+			}
+			if respCode != "000" {
+				t.Fatalf("000 not returned from sleep pod; received http response code: %s", respCode)
+			}
+			query = `sum(istio_tcp_connections_closed_total{destination_service="BlackHoleCluster",destination_service_name="BlackHoleCluster"})`
+			util.ValidateMetric(t, prom, query, "istio_tcp_connections_closed_total", 1)
+		})
+}
+
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite("mixer_telemetry_metrics", m).
@@ -200,6 +230,8 @@ values:
     enabled: true
   global:
     disablePolicyChecks: false
+    outboundTrafficPolicy:
+      mode: REGISTRY_ONLY
   telemetry:
     v1:
       enabled: true
@@ -218,6 +250,13 @@ components:
 func testsetup(ctx resource.Context) (err error) {
 	bookinfoNs, err = namespace.New(ctx, namespace.Config{
 		Prefix: "istio-bookinfo",
+		Inject: true,
+	})
+	if err != nil {
+		return
+	}
+	sleepNs, err = namespace.New(ctx, namespace.Config{
+		Prefix: "istio-sleep",
 		Inject: true,
 	})
 	if err != nil {

--- a/tests/integration/mixer/telemetry/metrics/scenarios_test.go
+++ b/tests/integration/mixer/telemetry/metrics/scenarios_test.go
@@ -27,7 +27,6 @@ import (
 	"istio.io/istio/pkg/test/framework/components/mixer"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/components/prometheus"
-	"istio.io/istio/pkg/test/framework/components/sleep"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/util/tmpl"
@@ -37,7 +36,6 @@ import (
 var (
 	ist        istio.Instance
 	bookinfoNs namespace.Instance
-	sleepNs    namespace.Instance
 	g          galley.Instance
 	ing        ingress.Instance
 	prom       prometheus.Instance
@@ -190,34 +188,6 @@ func TestTcpMetric(t *testing.T) {
 		})
 }
 
-func TestBlackHoleClustersMetric(t *testing.T) {
-	framework.
-		NewTest(t).
-		RequiresEnvironment(environment.Kube).
-		Run(func(ctx framework.TestContext) {
-			sleepInst := sleep.DeployOrFail(t, ctx, sleep.Config{Namespace: sleepNs, Cfg: sleep.Sleep})
-			respCode, err := sleepInst.Curl("http://istio.io")
-			if err != nil {
-				t.Fatalf("Unable to exec curl http://istio.io from sleep pod: %v", err)
-			}
-			if respCode != "502" {
-				t.Fatalf("502 not returned from sleep pod; received http response code: %s", respCode)
-			}
-			query := `sum(istio_requests_total{destination_service_name="BlackHoleCluster"})`
-			util.ValidateMetric(t, prom, query, "istio_requests_total", 1)
-
-			respCode, err = sleepInst.Curl("https://istio.io")
-			if err == nil {
-				t.Fatal("expected exec curl https://istio.io from sleep pod to error out")
-			}
-			if respCode != "000" {
-				t.Fatalf("000 not returned from sleep pod; received http response code: %s", respCode)
-			}
-			query = `sum(istio_tcp_connections_closed_total{destination_service="BlackHoleCluster",destination_service_name="BlackHoleCluster"})`
-			util.ValidateMetric(t, prom, query, "istio_tcp_connections_closed_total", 1)
-		})
-}
-
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite("mixer_telemetry_metrics", m).
@@ -250,13 +220,6 @@ components:
 func testsetup(ctx resource.Context) (err error) {
 	bookinfoNs, err = namespace.New(ctx, namespace.Config{
 		Prefix: "istio-bookinfo",
-		Inject: true,
-	})
-	if err != nil {
-		return
-	}
-	sleepNs, err = namespace.New(ctx, namespace.Config{
-		Prefix: "istio-sleep",
 		Inject: true,
 	})
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/22001

Add an integration test for mixer v1 for blackhole and passthrough clusters.

The intent is to use this as a baseline for telemetry v2 parity testing due to https://github.com/istio/istio/issues/21566

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[X] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
