### PR TITLE
clone LbEndpoint to prevent data race

### DIFF
--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -413,6 +413,21 @@ func cloneLocalityLbEndpoints(endpoints []*endpoint.LocalityLbEndpoints) []*endp
 	return out
 }
 
+// return a shallow copy LbEndpoint
+func CloneLbEndpoint(endpoint *endpoint.LbEndpoint) *endpoint.LbEndpoint {
+	if endpoint == nil {
+		return nil
+	}
+
+	clone := *endpoint
+	if endpoint.LoadBalancingWeight != nil {
+		clone.LoadBalancingWeight = &wrappers.UInt32Value{
+			Value: endpoint.GetLoadBalancingWeight().GetValue(),
+		}
+	}
+	return &clone
+}
+
 // BuildConfigInfoMetadata builds core.Metadata struct containing the
 // name.namespace of the config, the type, etc. Used by Mixer client
 // to generate attributes for policy and telemetry.

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -44,6 +44,17 @@ import (
 	proto2 "istio.io/istio/pkg/proto"
 )
 
+func TestCloneLbEndpoint(t *testing.T) {
+	ep := &endpoint.LbEndpoint{
+		LoadBalancingWeight: &wrappers.UInt32Value{Value: 100},
+	}
+	cloned := CloneLbEndpoint(ep)
+	cloned.LoadBalancingWeight.Value = 200
+	if ep.LoadBalancingWeight.GetValue() != 100 {
+		t.Errorf("original LbEndpoint is mutated")
+	}
+}
+
 func TestConvertAddressToCidr(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pilot/pkg/proxy/envoy/v2/ep_filters.go
+++ b/pilot/pkg/proxy/envoy/v2/ep_filters.go
@@ -55,10 +55,12 @@ func EndpointsByNetworkFilter(push *model.PushContext, proxyNetwork string, endp
 			// but can be accessed directly from local network.
 			if epNetwork == proxyNetwork ||
 				len(push.NetworkGatewaysByNetwork(epNetwork)) == 0 {
-				lbEp.LoadBalancingWeight = &wrappers.UInt32Value{
+				// shallow lbEndpoint to prevent data race
+				clonedLbEp := util.CloneLbEndpoint(lbEp)
+				clonedLbEp.LoadBalancingWeight = &wrappers.UInt32Value{
 					Value: uint32(multiples),
 				}
-				lbEndpoints = append(lbEndpoints, lbEp)
+				lbEndpoints = append(lbEndpoints, clonedLbEp)
 			} else {
 				// Remote network endpoint which can not be accessed directly from local network.
 				// Increase the weight counter


### PR DESCRIPTION
Hope to fix: https://github.com/istio/istio/pull/21912#issuecomment-596133369

#20087 can be caused by updateCluster and with #21917, it can be fixed as well.