### PR TITLE
Implementation of incremental MCP

### DIFF
--- a/galley/pkg/envvar/envvars.go
+++ b/galley/pkg/envvar/envvars.go
@@ -43,6 +43,9 @@ var (
 
 	// MCPSourceReqFreq is the frequency that is used by the rate limiter in MCP Sources
 	MCPSourceReqFreq = env.RegisterDurationVar("MCP_SOURCE_REQ_FREQ", time.Second, "")
+
+	// EnableIncrementalMCP is an option to enable incremental mcp
+	EnableIncrementalMCP = env.RegisterBoolVar("ENABLE_INCREMENTAL_MCP", false, "")
 )
 
 // RegisteredEnvVarNames returns the names of registered environment variables.

--- a/galley/pkg/server/components/processing.go
+++ b/galley/pkg/server/components/processing.go
@@ -176,6 +176,13 @@ func (p *Processing) Start() (err error) {
 		ConnRateLimiter:    mcpSourceRateLimiter,
 	}
 
+	// set incremental flag of all collections to true when incremental mcp enabled
+	if envvar.EnableIncrementalMCP.Get() {
+		for i := range options.CollectionsOptions {
+			options.CollectionsOptions[i].Incremental = true
+		}
+	}
+
 	md := grpcMetadata.MD{
 		versionMetadataKey: []string{version.Info.Version},
 	}

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -278,7 +278,7 @@ func (s *Server) mcpController(
 	all := collections.Pilot.All()
 	cols := make([]sink.CollectionOptions, 0, len(all))
 	for _, c := range all {
-		cols = append(cols, sink.CollectionOptions{Name: c.Name().String(), Incremental: false})
+		cols = append(cols, sink.CollectionOptions{Name: c.Name().String(), Incremental: features.EnableIncrementalMCP})
 	}
 
 	mcpController := mcp.NewController(opts)

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -296,4 +296,11 @@ var (
 	EnableServiceApis = env.RegisterBoolVar("PILOT_ENABLED_SERVICE_APIS", false,
 		"If this is set to true, support for Kubernetes service-apis (github.com/kubernetes-sigs/service-apis) will "+
 			" be enabled. This feature is currently experimental, and is off by default.").Get()
+
+	EnableIncrementalMCP = env.RegisterBoolVar(
+		"PILOT_ENABLE_INCREMENTAL_MCP",
+		false,
+		"If enabled, pilot will set the incremental flag of the options in the mcp controller "+
+			"to true, and then galley may push data incrementally, it depends on whether the "+
+			"resource supports incremental. By default, this is false.").Get()
 )

--- a/pilot/pkg/serviceregistry/mcp/controller_test.go
+++ b/pilot/pkg/serviceregistry/mcp/controller_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 	. "github.com/onsi/gomega"
-
 	"istio.io/istio/pkg/config/schema/resource"
 
 	authn "istio.io/api/authentication/v1alpha1"
@@ -850,4 +849,143 @@ func (f *FakeXdsUpdater) SvcUpdate(_, _, _ string, _ model.Event) {
 }
 
 func (f *FakeXdsUpdater) ProxyUpdate(_, _ string) {
+}
+
+func TestApplyIncrementalChangeRemove(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	fx := NewFakeXDS()
+	testControllerOptions.XDSUpdater = fx
+	controller := mcp.NewController(testControllerOptions)
+
+	message := convertToResource(g, collections.IstioNetworkingV1Alpha3Gateways.Resource().Proto(), gateway)
+
+	change := convertToChange([]proto.Message{message},
+		[]string{"random-namespace/test-gateway"},
+		setIncremental(),
+		setCollection(collections.IstioNetworkingV1Alpha3Gateways.Name().String()),
+		setTypeURL(collections.IstioNetworkingV1Alpha3Gateways.Resource().Proto()))
+
+	err := controller.Apply(change)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	entries, err := controller.List(gatewayGvk, "")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(entries).To(HaveLen(1))
+	g.Expect(entries[0].Name).To(Equal("test-gateway"))
+
+	update := <-fx.Events
+	g.Expect(update).To(Equal("ConfigUpdate"))
+
+	message2 := convertToResource(g, collections.IstioNetworkingV1Alpha3Gateways.Resource().Proto(), gateway2)
+	change = convertToChange([]proto.Message{message2},
+		[]string{"random-namespace/test-gateway2"},
+		setIncremental(),
+		setCollection(collections.IstioNetworkingV1Alpha3Gateways.Name().String()),
+		setTypeURL(collections.IstioNetworkingV1Alpha3Gateways.Resource().Proto()))
+
+	err = controller.Apply(change)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	entries, err = controller.List(gatewayGvk, "")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(entries).To(HaveLen(2))
+
+	update = <-fx.Events
+	g.Expect(update).To(Equal("ConfigUpdate"))
+
+	for _, gw := range entries {
+		g.Expect(gw.Type).To(Equal(gatewayGvk))
+		switch gw.Name {
+		case "test-gateway":
+			g.Expect(gw.Spec).To(Equal(message))
+		case "test-gateway2":
+			g.Expect(gw.Spec).To(Equal(message2))
+		}
+	}
+
+	change = convertToChange([]proto.Message{message2},
+		[]string{"random-namespace/test-gateway2"},
+		setIncremental(),
+		setRemoved([]string{"random-namespace/test-gateway"}),
+		setCollection(collections.IstioNetworkingV1Alpha3Gateways.Name().String()),
+		setTypeURL(collections.IstioNetworkingV1Alpha3Gateways.Resource().Proto()))
+
+	err = controller.Apply(change)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	entries, err = controller.List(gatewayGvk, "")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(entries).To(HaveLen(1))
+	g.Expect(entries[0].Name).To(Equal("test-gateway2"))
+	g.Expect(entries[0].Spec).To(Equal(message2))
+
+	update = <-fx.Events
+	g.Expect(update).To(Equal("ConfigUpdate"))
+}
+
+func TestApplyIncrementalChange(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	fx := NewFakeXDS()
+	testControllerOptions.XDSUpdater = fx
+	controller := mcp.NewController(testControllerOptions)
+
+	message := convertToResource(g, collections.IstioNetworkingV1Alpha3Gateways.Resource().Proto(), gateway)
+
+	change := convertToChange([]proto.Message{message},
+		[]string{"random-namespace/test-gateway"},
+		setIncremental(),
+		setCollection(collections.IstioNetworkingV1Alpha3Gateways.Name().String()),
+		setTypeURL(collections.IstioNetworkingV1Alpha3Gateways.Resource().Proto()))
+
+	err := controller.Apply(change)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	entries, err := controller.List(gatewayGvk, "")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(entries).To(HaveLen(1))
+	g.Expect(entries[0].Name).To(Equal("test-gateway"))
+
+	update := <-fx.Events
+	g.Expect(update).To(Equal("ConfigUpdate"))
+
+	message2 := convertToResource(g, collections.IstioNetworkingV1Alpha3Gateways.Resource().Proto(), gateway2)
+	change = convertToChange([]proto.Message{message2},
+		[]string{"random-namespace/test-gateway2"},
+		setIncremental(),
+		setCollection(collections.IstioNetworkingV1Alpha3Gateways.Name().String()),
+		setTypeURL(collections.IstioNetworkingV1Alpha3Gateways.Resource().Proto()))
+
+	err = controller.Apply(change)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	entries, err = controller.List(gatewayGvk, "")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(entries).To(HaveLen(2))
+
+	for _, gw := range entries {
+		g.Expect(gw.Type).To(Equal(gatewayGvk))
+		switch gw.Name {
+		case "test-gateway":
+			g.Expect(gw.Spec).To(Equal(message))
+		case "test-gateway2":
+			g.Expect(gw.Spec).To(Equal(message2))
+		}
+	}
+
+	update = <-fx.Events
+	g.Expect(update).To(Equal("ConfigUpdate"))
+}
+
+func setIncremental() func(*sink.Change) {
+	return func(c *sink.Change) {
+		c.Incremental = true
+	}
+}
+
+func setRemoved(removed []string) func(*sink.Change) {
+	return func(c *sink.Change) {
+		c.Removed = removed
+	}
 }

--- a/pkg/mcp/source/source.go
+++ b/pkg/mcp/source/source.go
@@ -342,7 +342,7 @@ func (con *connection) pushServerResponse(w *watch, resp *WatchResponse) error {
 		Collection:        resp.Collection,
 		Resources:         added,
 		RemovedResources:  removed,
-		Incremental:       incremental,
+		Incremental:       con.streamNonce > 0 && incremental, // the first response was not consider as incremental
 	}
 
 	// increment nonce


### PR DESCRIPTION

In the latest code (1.5.0), incremental updates have not yet been implemented in mcpController, and the incremental flag is hard-coded to false. In large clusters, the number of CRs, such as VirtualService, is in tens of thousands. When frequent changes occur, the CPU usage of pilot will exceed 60%, and using incremental updates, the CPU usage will not exceed 10%.

I did the following to make incremental updates work：
1. Add option EnableIncrementalMCP to galley;
2. Add option EnableIncrementalMCP to pilot;
3. Implement incremental update in mcpController;

Close #19622