### PR TITLE
Fixes #22034. Apply default Sidecar to consumer only proxies

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -65,6 +65,10 @@ type PushContext struct {
 	defaultVirtualServiceExportTo  map[visibility.Instance]bool
 	defaultDestinationRuleExportTo map[visibility.Instance]bool
 
+	// The default Sidecar configuration from the config root namespace.
+	// This is used when a proxy not belonging to a services connects to Pilot.
+	defaultSidecarConfig *Config
+
 	// Service related
 	// TODO: move to a sub struct
 
@@ -753,7 +757,7 @@ func (ps *PushContext) getSidecarScope(proxy *Proxy, workloadLabels labels.Colle
 		}
 	}
 
-	return DefaultSidecarScopeForNamespace(ps, proxy.ConfigNamespace)
+	return ConvertToSidecarScope(ps, ps.defaultSidecarConfig, proxy.ConfigNamespace)
 }
 
 // GetAllSidecarScopes returns a map of namespace and the set of SidecarScope
@@ -1407,6 +1411,7 @@ func (ps *PushContext) initSidecarScopes(env *Environment) error {
 			if sidecarConfig.Namespace == ps.Mesh.RootNamespace &&
 				sidecarConfig.Spec.(*networking.Sidecar).WorkloadSelector == nil {
 				rootNSConfig = &sidecarConfig
+				ps.defaultSidecarConfig = rootNSConfig
 				break
 			}
 		}

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1079,6 +1079,7 @@ func (ps *PushContext) updateContext(
 		}
 	} else {
 		ps.sidecarsByNamespace = oldPushContext.sidecarsByNamespace
+		ps.defaultSidecarConfig = oldPushContext.defaultSidecarConfig
 	}
 
 	return nil

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -665,6 +665,12 @@ func TestSidecarScope(t *testing.T) {
 			sidecar:    "istio-system/global",
 			describe:   "no sidecar",
 		},
+		{
+			proxy:      &Proxy{ConfigNamespace: "noservice"},
+			collection: labels.Collection{map[string]string{"app": "bar"}},
+			sidecar:    "istio-system/global",
+			describe:   "no service",
+		},
 	}
 	for _, c := range cases {
 		scope := ps.getSidecarScope(c.proxy, c.collection)


### PR DESCRIPTION



This PR fixes #20202 
It makes sure that the default Sidecar in the config root namespace also applies to proxies that have no associated Service.

This is done by storing the default sidecar resource as a dedicated property in the PushContext.
When no Sidecar context can be found in `PushContext.getSidecarScope()` this is considered for creating the sidecar scope.