### PR TITLE
Avoid deleting files in error when use the parameter "--templateFile".

### DIFF
--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -205,13 +205,11 @@ func (e *envoy) Run(config interface{}, epoch int, abort <-chan error) error {
 }
 
 func (e *envoy) Cleanup(epoch int) {
-	var filePath string
-	// when use the parameter "--templateFile=/path/xxx.tmpl"
+	// should return when use the parameter "--templateFile=/path/xxx.tmpl".
 	if e.Config.CustomConfigFile != "" {
-		filePath = e.Config.CustomConfigFile
-	} else {
-		filePath = configFile(e.Config.ConfigPath, epoch)
+		return
 	}
+	filePath := configFile(e.Config.ConfigPath, epoch)
 	if err := os.Remove(filePath); err != nil {
 		log.Warnf("Failed to delete config file %s for %d, %v", filePath, epoch, err)
 	}

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -205,7 +205,13 @@ func (e *envoy) Run(config interface{}, epoch int, abort <-chan error) error {
 }
 
 func (e *envoy) Cleanup(epoch int) {
-	filePath := configFile(e.Config.ConfigPath, epoch)
+	var filePath string
+	// when use the parameter "--templateFile=/path/xxx.tmpl"
+	if e.Config.CustomConfigFile != "" {
+		filePath = e.Config.CustomConfigFile
+	} else {
+		filePath = configFile(e.Config.ConfigPath, epoch)
+	}
 	if err := os.Remove(filePath); err != nil {
 		log.Warnf("Failed to delete config file %s for %d, %v", filePath, epoch, err)
 	}


### PR DESCRIPTION
When the `--templateFile` parameter is used in the pilot-agent, the file will be cleanup in error. Then the error log is as follows:

```
2020-03-10T03:04:02.209696Z	warn	Failed to delete config file /etc/istio/proxy/envoy-rev0.json for 0, remove /etc/istio/proxy/envoy-rev0.json: no such file or directory
 
```

fixed as follows

```
diff --git a/pkg/envoy/proxy.go b/pkg/envoy/proxy.go
--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -205,6 +205,10 @@ func (e *envoy) Run(config interface{}, epoch int, abort <-chan error) error {
 }

 func (e *envoy) Cleanup(epoch int) {
+       // should return when use the parameter "--templateFile=/path/xxx.tmpl".
+       if e.Config.CustomConfigFile != "" {
+               return
+       }
        filePath := configFile(e.Config.ConfigPath, epoch)
        if err := os.Remove(filePath); err != nil {
                log.Warnf("Failed to delete config file %s for %d, %v", filePath, epoch, err)
        }
```
