### PR TITLE
Allow analysis message to display file as a source of an error

### DIFF
--- a/galley/pkg/config/analysis/analyzers/analyzers_bench_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_bench_test.go
@@ -74,8 +74,11 @@ type origin struct {
 	friendlyName string
 }
 
+var _ resource.Origin = &origin{}
+
 func (o origin) Namespace() resource.Namespace { return "" }
 func (o origin) FriendlyName() string          { return o.friendlyName }
+func (o origin) Reference() string             { return "" }
 
 // This is a very basic benchmark on unit test data, so it doesn't tell us anything about how an analyzer performs at scale
 func BenchmarkAnalyzers(b *testing.B) {

--- a/galley/pkg/config/analysis/analyzers/schema/validation_test.go
+++ b/galley/pkg/config/analysis/analyzers/schema/validation_test.go
@@ -152,3 +152,4 @@ type fakeOrigin struct{}
 
 func (fakeOrigin) FriendlyName() string          { return "myFriendlyName" }
 func (fakeOrigin) Namespace() resource.Namespace { return "myNamespace" }
+func (fakeOrigin) Reference() string             { return "" }

--- a/galley/pkg/config/analysis/diag/helper_test.go
+++ b/galley/pkg/config/analysis/diag/helper_test.go
@@ -18,14 +18,21 @@ import (
 	"istio.io/istio/pkg/config/resource"
 )
 
-var _ resource.Origin = testOrigin("")
+var _ resource.Origin = &testOrigin{}
 
-type testOrigin string
+type testOrigin struct {
+	name string
+	ref  string
+}
 
 func (o testOrigin) FriendlyName() string {
-	return string(o)
+	return o.name
 }
 
 func (o testOrigin) Namespace() resource.Namespace {
 	return ""
+}
+
+func (o testOrigin) Reference() string {
+	return o.ref
 }

--- a/galley/pkg/config/analysis/diag/message.go
+++ b/galley/pkg/config/analysis/diag/message.go
@@ -68,6 +68,9 @@ func (m *Message) Unstructured(includeOrigin bool) map[string]interface{} {
 	result["level"] = m.Type.Level().String()
 	if includeOrigin && m.Resource != nil {
 		result["origin"] = m.Resource.Origin.FriendlyName()
+		if m.Resource.Origin.Reference() != "" {
+			result["reference"] = m.Resource.Origin.Reference()
+		}
 	}
 	result["message"] = fmt.Sprintf(m.Type.Template(), m.Parameters...)
 
@@ -84,7 +87,11 @@ func (m *Message) Unstructured(includeOrigin bool) map[string]interface{} {
 func (m *Message) String() string {
 	origin := ""
 	if m.Resource != nil {
-		origin = "(" + m.Resource.Origin.FriendlyName() + ")"
+		loc := ""
+		if m.Resource.Origin.Reference() != "" {
+			loc = " " + m.Resource.Origin.Reference()
+		}
+		origin = " (" + m.Resource.Origin.FriendlyName() + loc + ")"
 	}
 	return fmt.Sprintf(
 		"%v [%v]%s %s", m.Type.Level(), m.Type.Code(), origin, fmt.Sprintf(m.Type.Template(), m.Parameters...))

--- a/galley/pkg/config/analysis/diag/message_test.go
+++ b/galley/pkg/config/analysis/diag/message_test.go
@@ -34,9 +34,9 @@ func TestMessage_String(t *testing.T) {
 func TestMessageWithResource_String(t *testing.T) {
 	g := NewGomegaWithT(t)
 	mt := NewMessageType(Error, "IST-0042", "Cheese type not found: %q")
-	m := NewMessage(mt, &resource.Instance{Origin: testOrigin("toppings/cheese")}, "Feta")
+	m := NewMessage(mt, &resource.Instance{Origin: testOrigin{name: "toppings/cheese", ref: "path/to/file"}}, "Feta")
 
-	g.Expect(m.String()).To(Equal(`Error [IST-0042](toppings/cheese) Cheese type not found: "Feta"`))
+	g.Expect(m.String()).To(Equal(`Error [IST-0042] (toppings/cheese path/to/file) Cheese type not found: "Feta"`))
 }
 
 func TestMessage_Unstructured(t *testing.T) {
@@ -47,7 +47,7 @@ func TestMessage_Unstructured(t *testing.T) {
 	g.Expect(m.Unstructured(true)).To(Not(HaveKey("origin")))
 	g.Expect(m.Unstructured(false)).To(Not(HaveKey("origin")))
 
-	m = NewMessage(mt, &resource.Instance{Origin: testOrigin("toppings/cheese")}, "Feta")
+	m = NewMessage(mt, &resource.Instance{Origin: testOrigin{name: "toppings/cheese"}}, "Feta")
 
 	g.Expect(m.Unstructured(true)).To((HaveKey("origin")))
 	g.Expect(m.Unstructured(false)).To(Not(HaveKey("origin")))
@@ -64,9 +64,9 @@ func TestMessageWithDocRef(t *testing.T) {
 func TestMessage_JSON(t *testing.T) {
 	g := NewGomegaWithT(t)
 	mt := NewMessageType(Error, "IST-0042", "Cheese type not found: %q")
-	m := NewMessage(mt, &resource.Instance{Origin: testOrigin("toppings/cheese")}, "Feta")
+	m := NewMessage(mt, &resource.Instance{Origin: testOrigin{name: "toppings/cheese", ref: "path/to/file"}}, "Feta")
 
 	j, _ := json.Marshal(&m)
 	g.Expect(string(j)).To(Equal(`{"code":"IST-0042","documentation_url":"https://istio.io/docs/reference/config/analysis/IST-0042"` +
-		`,"level":"Error","message":"Cheese type not found: \"Feta\"","origin":"toppings/cheese"}`))
+		`,"level":"Error","message":"Cheese type not found: \"Feta\"","origin":"toppings/cheese","reference":"path/to/file"}`))
 }

--- a/galley/pkg/config/analysis/diag/messages_test.go
+++ b/galley/pkg/config/analysis/diag/messages_test.go
@@ -119,6 +119,6 @@ func testResource(name string) *resource.Instance {
 		Metadata: resource.Metadata{
 			FullName: resource.NewShortOrFullName("default", name),
 		},
-		Origin: testOrigin(name),
+		Origin: testOrigin{name: name},
 	}
 }

--- a/galley/pkg/config/processing/snapshotter/analyzingdistributor_test.go
+++ b/galley/pkg/config/processing/snapshotter/analyzingdistributor_test.go
@@ -506,3 +506,4 @@ type fakeOrigin struct {
 
 func (f fakeOrigin) Namespace() resource.Namespace { return f.namespace }
 func (f fakeOrigin) FriendlyName() string          { return f.friendlyName }
+func (f fakeOrigin) Reference() string             { return "" }

--- a/galley/pkg/config/source/kube/apiserver/watcher.go
+++ b/galley/pkg/config/source/kube/apiserver/watcher.go
@@ -124,7 +124,7 @@ func (w *watcher) handleEvent(c event.Kind, obj interface{}) {
 		return
 	}
 
-	r := rt.ToResource(object, w.schema, res)
+	r := rt.ToResource(object, w.schema, res, "")
 
 	if w.statusCtl != nil && !w.adapter.IsBuiltIn() {
 		w.statusCtl.UpdateResourceStatus(

--- a/galley/pkg/config/source/kube/inmemory/kubesource.go
+++ b/galley/pkg/config/source/kube/inmemory/kubesource.go
@@ -220,7 +220,7 @@ func (s *KubeSource) parseContent(r *collection.Schemas, name, yamlText string) 
 		}
 
 		chunk := bytes.TrimSpace(doc)
-		r, err := s.parseChunk(r, chunk)
+		r, err := s.parseChunk(r, name, chunk)
 		if err != nil {
 			var uerr *unknownSchemaError
 			if errors.As(err, &uerr) {
@@ -251,7 +251,7 @@ func (e unknownSchemaError) Error() string {
 	return fmt.Sprintf("failed finding schema for group/version/kind: %s/%s/%s", e.group, e.version, e.kind)
 }
 
-func (s *KubeSource) parseChunk(r *collection.Schemas, yamlChunk []byte) (kubeResource, error) {
+func (s *KubeSource) parseChunk(r *collection.Schemas, name string, yamlChunk []byte) (kubeResource, error) {
 	// Convert to JSON
 	jsonChunk, err := yaml.ToJSON(yamlChunk)
 	if err != nil {
@@ -305,6 +305,6 @@ func (s *KubeSource) parseChunk(r *collection.Schemas, yamlChunk []byte) (kubeRe
 	return kubeResource{
 		schema:   schema,
 		sha:      sha1.Sum(yamlChunk),
-		resource: rt.ToResource(objMeta, schema, item),
+		resource: rt.ToResource(objMeta, schema, item, name),
 	}, nil
 }

--- a/galley/pkg/config/source/kube/rt/adapter.go
+++ b/galley/pkg/config/source/kube/rt/adapter.go
@@ -98,7 +98,7 @@ func (p *Adapter) JSONToEntry(s string) (*resource.Instance, error) {
 		return nil, err
 	}
 
-	return ToResource(obj, nil, item), nil
+	return ToResource(obj, nil, item, ""), nil
 
 }
 

--- a/galley/pkg/config/source/kube/rt/extract.go
+++ b/galley/pkg/config/source/kube/rt/extract.go
@@ -25,7 +25,7 @@ import (
 )
 
 // ToResource converts the given object and proto to a resource.Instance
-func ToResource(object metav1.Object, schema collection.Schema, item proto.Message) *resource.Instance {
+func ToResource(object metav1.Object, schema collection.Schema, item proto.Message, source string) *resource.Instance {
 	var o *Origin
 
 	name := resource.NewFullName(resource.Namespace(object.GetNamespace()), resource.LocalName(object.GetName()))
@@ -39,6 +39,7 @@ func ToResource(object metav1.Object, schema collection.Schema, item proto.Messa
 			Collection: schema.Name(),
 			Kind:       schema.Resource().Kind(),
 			Version:    version,
+			Ref:        source,
 		}
 	}
 

--- a/galley/pkg/config/source/kube/rt/origin.go
+++ b/galley/pkg/config/source/kube/rt/origin.go
@@ -29,6 +29,7 @@ type Origin struct {
 	Kind       string
 	FullName   resource.FullName
 	Version    resource.Version
+	Ref        string
 }
 
 var _ resource.Origin = &Origin{}
@@ -52,4 +53,9 @@ func (o *Origin) Namespace() resource.Namespace {
 	}
 
 	return o.FullName.Namespace
+}
+
+// Reference implements resource.Origin
+func (o *Origin) Reference() string {
+	return o.Ref
 }

--- a/galley/pkg/config/source/mcp/origin.go
+++ b/galley/pkg/config/source/mcp/origin.go
@@ -33,3 +33,7 @@ func (o origin) FriendlyName() string {
 func (o origin) Namespace() resource.Namespace {
 	return ""
 }
+
+func (o origin) Reference() string {
+	return ""
+}

--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -431,7 +431,11 @@ func colorSuffix() string {
 func renderMessage(m diag.Message) string {
 	origin := ""
 	if m.Resource != nil {
-		origin = " (" + m.Resource.Origin.FriendlyName() + ")"
+		loc := ""
+		if m.Resource.Origin.Reference() != "" {
+			loc = " " + m.Resource.Origin.Reference()
+		}
+		origin = " (" + m.Resource.Origin.FriendlyName() + loc + ")"
 	}
 	return fmt.Sprintf(
 		"%s%v%s [%v]%s %s", colorPrefix(m), m.Type.Level(), colorSuffix(), m.Type.Code(), origin, fmt.Sprintf(m.Type.Template(), m.Parameters...))

--- a/pkg/config/resource/origin.go
+++ b/pkg/config/resource/origin.go
@@ -19,4 +19,6 @@ type Origin interface {
 	FriendlyName() string
 
 	Namespace() Namespace
+
+	Reference() string
 }


### PR DESCRIPTION
fix https://github.com/istio/istio/issues/20887

Example output:
`Error [IST0101] (VirtualService frontend.default /Users/jasonwzm/Downloads/istio/example-vs.yaml) Referenced gateway not found: "httpbin-gateway-bogus"`
in structured output:
```
{
	"code": "IST0101",
	"documentation_url": "https://istio.io/docs/reference/config/analysis/IST0101?ref=istioctl-analyze",
	"level": "Error",
	"message": "Referenced gateway not found: \"httpbin-gateway-bogus\"",
	"origin": "VirtualService frontend.default",
	"reference": "/Users/jasonwzm/Downloads/istio/example-vs.yaml"
}
```

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure
