### PR TITLE
Add support for RetryRemoteLocalities

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/route/retry/retry.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/retry/retry.go
@@ -22,8 +22,14 @@ import (
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/golang/protobuf/ptypes/wrappers"
 
+	previouspriorities "github.com/envoyproxy/go-control-plane/envoy/config/retry/previous_priorities"
+
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/networking/util"
+)
+
+var (
+	defaultRetryPriorityTypedConfig = util.MessageToAny(buildPreviousPrioritiesConfig())
 )
 
 // DefaultPolicy gets a copy of the default retry policy.
@@ -83,6 +89,16 @@ func ConvertPolicy(in *networking.HTTPRetry) *route.RetryPolicy {
 	if in.PerTryTimeout != nil {
 		out.PerTryTimeout = util.GogoDurationToDuration(in.PerTryTimeout)
 	}
+
+	if in.RetryRemoteLocalities != nil && in.RetryRemoteLocalities.GetValue() {
+		out.RetryPriority = &route.RetryPolicy_RetryPriority{
+			Name: "envoy.retry_priorities.previous_priorities",
+			ConfigType: &route.RetryPolicy_RetryPriority_TypedConfig{
+				TypedConfig: defaultRetryPriorityTypedConfig,
+			},
+		}
+	}
+
 	return out
 }
 
@@ -108,4 +124,12 @@ func parseRetryOn(retryOn string) (string, []uint32) {
 	}
 
 	return strings.Join(tojoin, ","), codes
+}
+
+// buildPreviousPrioritiesConfig builds a PreviousPrioritiesConfig with a default
+// value for UpdateFrequency which indicated how often to update the priority.
+func buildPreviousPrioritiesConfig() *previouspriorities.PreviousPrioritiesConfig {
+	return &previouspriorities.PreviousPrioritiesConfig{
+		UpdateFrequency: int32(2),
+	}
 }

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -2546,7 +2546,7 @@ func validateHTTPRetry(retries *networking.HTTPRetry) (errs error) {
 		errs = multierror.Append(errs, errors.New("attempts cannot be negative"))
 	}
 
-	if retries.Attempts == 0 && (retries.PerTryTimeout != nil || retries.RetryOn != "") {
+	if retries.Attempts == 0 && (retries.PerTryTimeout != nil || retries.RetryOn != "" || retries.RetryRemoteLocalities != nil) {
 		errs = appendErrors(errs, errors.New("http retry policy configured when attempts are set to 0 (disabled)"))
 	}
 

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -1852,6 +1852,10 @@ func TestValidateHTTPRetry(t *testing.T) {
 			PerTryTimeout: &types.Duration{Seconds: 2},
 			RetryOn:       "600,connect-failure",
 		}, valid: false},
+		{name: "invalid, retryRemoteLocalities configured but attempts set to zero", in: &networking.HTTPRetry{
+			Attempts:              0,
+			RetryRemoteLocalities: &types.BoolValue{Value: false},
+		}, valid: false},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
https://github.com/istio/istio/issues/18418
https://github.com/istio/api/pull/1156

this will let envoy retry to other priorities as shown in: 
https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/http/http_connection_management#arch-overview-http-retry-plugins

and we set a default value for `update_frequency` which indicated how often to update the priority as we talk in https://github.com/istio/api/pull/1156#discussion_r350513192