### PR TITLE
Update sample psp to reflect sidecar capability changes in 1.4

### DIFF
--- a/samples/security/psp/all-pods-psp.yaml
+++ b/samples/security/psp/all-pods-psp.yaml
@@ -12,6 +12,7 @@ spec:
   # Allow the istio sidecar injector to work
   allowedCapabilities:
     - NET_ADMIN
+    - NET_RAW
   seLinux:
     rule: RunAsAny
   supplementalGroups:


### PR DESCRIPTION
Since istio 1.4 the sidecar requires the NET_RAW capability to work.
This should be reflected in the sample psp.