### PR TITLE
Setup second revision only in revision test

### DIFF
--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -38,22 +38,6 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite("pilot_test", m).
 		SetupOnEnv(environment.Kube, istio.Setup(&i, nil)).
-		SetupOnEnv(environment.Kube, istio.Setup(&i, func(cfg *istio.Config) {
-			cfg.ControlPlaneValues = `
-components:
-  base:
-    enabled: false
-  pilot:
-    enabled: true
-  ingressGateways:
-addonComponents:
-  prometheus:
-    enabled: false
-revision: canary
-values:
-  clusterResources: false
-`
-		})).
 		Setup(func(ctx resource.Context) (err error) {
 			if g, err = galley.New(ctx, galley.Config{}); err != nil {
 				return err

--- a/tests/integration/pilot/revisions_test.go
+++ b/tests/integration/pilot/revisions_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 	"time"
 
+	"istio.io/istio/pkg/test/framework/components/istio"
+
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
@@ -30,6 +32,24 @@ import (
 func TestMultiRevision(t *testing.T) {
 	framework.NewTest(t).
 		Run(func(ctx framework.TestContext) {
+			if err := istio.Setup(&i, func(cfg *istio.Config) {
+				cfg.ControlPlaneValues = `
+components:
+  base:
+    enabled: false
+  pilot:
+    enabled: true
+  ingressGateways:
+addonComponents:
+  prometheus:
+    enabled: false
+revision: canary
+values:
+  clusterResources: false
+`
+			})(ctx); err != nil {
+				t.Fatalf("failed to set up additional revision: %v", err)
+			}
 			stable := namespace.NewOrFail(t, ctx, namespace.Config{
 				Prefix: "stable",
 				Inject: true,


### PR DESCRIPTION
Right now we spin up the 2nd revision for the whole test suite even if
its not used. We should instead just spin it up for the one test that
uses it. As we test more advanced features, this will be useful as well.