### PR TITLE
Add retry.Converge option to UntilSuccess

### DIFF
--- a/pkg/test/util/retry/retry.go
+++ b/pkg/test/util/retry/retry.go
@@ -105,7 +105,7 @@ func Do(fn RetriableFunc, options ...Option) (interface{}, error) {
 		option(&cfg)
 	}
 
-	sucesses := 0
+	successes := 0
 	var lasterr error
 	to := time.After(cfg.timeout)
 	for {
@@ -118,15 +118,15 @@ func Do(fn RetriableFunc, options ...Option) (interface{}, error) {
 		result, completed, err := fn()
 		if completed {
 			if err == nil {
-				sucesses++
+				successes++
 			} else {
-				sucesses = 0
+				successes = 0
 			}
-			if sucesses >= cfg.converge {
+			if successes >= cfg.converge {
 				return result, err
 			}
 		} else {
-			sucesses = 0
+			successes = 0
 		}
 		if err != nil {
 			lasterr = err

--- a/pkg/test/util/retry/retry.go
+++ b/pkg/test/util/retry/retry.go
@@ -27,18 +27,23 @@ const (
 
 	// DefaultDelay the default delay between successive retry attempts
 	DefaultDelay = time.Millisecond * 10
+
+	// DefaultConverge the default converge, requiring something to succeed one time
+	DefaultConverge = 1
 )
 
 var (
 	defaultConfig = config{
-		timeout: DefaultTimeout,
-		delay:   DefaultDelay,
+		timeout:  DefaultTimeout,
+		delay:    DefaultDelay,
+		converge: DefaultConverge,
 	}
 )
 
 type config struct {
-	timeout time.Duration
-	delay   time.Duration
+	timeout  time.Duration
+	delay    time.Duration
+	converge int
 }
 
 // Option for a retry opteration.
@@ -55,6 +60,15 @@ func Timeout(timeout time.Duration) Option {
 func Delay(delay time.Duration) Option {
 	return func(cfg *config) {
 		cfg.delay = delay
+	}
+}
+
+// Converge sets the number of successes in a row needed to count a success.
+// This is useful to avoid the case where tests like `coin.Flip() == HEADS` will always
+// return success due to random variance.
+func Converge(successes int) Option {
+	return func(cfg *config) {
+		cfg.converge = successes
 	}
 }
 
@@ -91,6 +105,7 @@ func Do(fn RetriableFunc, options ...Option) (interface{}, error) {
 		option(&cfg)
 	}
 
+	sucesses := 0
 	var lasterr error
 	to := time.After(cfg.timeout)
 	for {
@@ -102,7 +117,16 @@ func Do(fn RetriableFunc, options ...Option) (interface{}, error) {
 
 		result, completed, err := fn()
 		if completed {
-			return result, err
+			if err == nil {
+				sucesses++
+			} else {
+				sucesses = 0
+			}
+			if sucesses >= cfg.converge {
+				return result, err
+			}
+		} else {
+			sucesses = 0
 		}
 		if err != nil {
 			lasterr = err

--- a/pkg/test/util/retry/retry_test.go
+++ b/pkg/test/util/retry/retry_test.go
@@ -1,0 +1,51 @@
+//  Copyright 2020 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package retry
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestConverge(t *testing.T) {
+	t.Run("no converge", func(t *testing.T) {
+		flipFlop := true
+		err := UntilSuccess(func() error {
+			flipFlop = !flipFlop
+			if flipFlop {
+				return fmt.Errorf("flipFlop was true")
+			}
+			return nil
+		}, Converge(2), Timeout(time.Millisecond*10), Delay(time.Millisecond))
+		if err == nil {
+			t.Fatal("expected no convergence, but test passed")
+		}
+	})
+
+	t.Run("converge", func(t *testing.T) {
+		n := 0
+		err := UntilSuccess(func() error {
+			n++
+			if n < 10 {
+				return fmt.Errorf("%v is too low, try again", n)
+			}
+			return nil
+		}, Converge(2), Timeout(time.Second*10000), Delay(time.Millisecond))
+		if err != nil {
+			t.Fatalf("expected convergance, but test failed: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
This will allow us to avoid false positives where a test randomly
succeeds and we mark it as passing.