### PR TITLE
Support replicated control plane in test framework

### DIFF
--- a/pkg/test/framework/components/echo/common/envoy.go
+++ b/pkg/test/framework/components/echo/common/envoy.go
@@ -86,14 +86,14 @@ func WaitForConfig(fetch ConfigFetchFunc, accept ConfigAcceptFunc, options ...re
 
 // OutboundConfigAcceptFunc returns a function that accepts Envoy configuration if it contains
 // outbound configuration for all of the given instances.
-func OutboundConfigAcceptFunc(outboundInstances ...echo.Instance) ConfigAcceptFunc {
+func OutboundConfigAcceptFunc(source echo.Instance, targets ...echo.Instance) ConfigAcceptFunc {
 	return func(cfg *envoyAdmin.ConfigDump) (bool, error) {
 		validator := structpath.ForProto(cfg)
 
-		for _, target := range outboundInstances {
+		for _, target := range targets {
 			for _, port := range target.Config().Ports {
 				// Ensure that we have an outbound configuration for the target port.
-				if err := CheckOutboundConfig(target, port, validator); err != nil {
+				if err := CheckOutboundConfig(source, target, port, validator); err != nil {
 					return false, err
 				}
 			}
@@ -104,7 +104,7 @@ func OutboundConfigAcceptFunc(outboundInstances ...echo.Instance) ConfigAcceptFu
 }
 
 // CheckOutboundConfig checks the Envoy config dump for outbound configuration to the given target.
-func CheckOutboundConfig(target echo.Instance, port echo.Port, validator *structpath.Instance) error {
+func CheckOutboundConfig(source echo.Instance, target echo.Instance, port echo.Port, validator *structpath.Instance) error {
 	// Verify that we have an outbound cluster for the target.
 	clusterName := clusterName(target, port)
 	if err := validator.
@@ -126,7 +126,7 @@ func CheckOutboundConfig(target echo.Instance, port echo.Port, validator *struct
 			Check()
 	}
 
-	if !target.Config().Headless {
+	if !target.Config().Headless && source.Config().ClusterIndex() == target.Config().ClusterIndex() {
 		// TCP case: Make sure we have an outbound listener configured.
 		listenerName := listenerName(target.Address(), port)
 		return validator.

--- a/pkg/test/framework/components/echo/common/envoy_test.go
+++ b/pkg/test/framework/components/echo/common/envoy_test.go
@@ -45,6 +45,8 @@ func TestCheckOutboundConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	src := testConfig{}
+
 	cfgs := []testConfig{
 		{
 			protocol:    protocol.HTTP,
@@ -100,7 +102,7 @@ func TestCheckOutboundConfig(t *testing.T) {
 
 	for _, cfg := range cfgs {
 		t.Run(fmt.Sprintf("%s_%d[%s]", cfg.service, cfg.servicePort, cfg.protocol), func(t *testing.T) {
-			if err := common.CheckOutboundConfig(&cfg, cfg.Config().Ports[0], validator); err != nil {
+			if err := common.CheckOutboundConfig(&src, &cfg, cfg.Config().Ports[0], validator); err != nil {
 				t.Fatal(err)
 			}
 		})

--- a/pkg/test/framework/components/echo/config.go
+++ b/pkg/test/framework/components/echo/config.go
@@ -111,3 +111,11 @@ func (c Config) FQDN() string {
 	}
 	return out
 }
+
+// ClusterIndex returns the index of the cluster or 0 (the default) if none specified.
+func (c Config) ClusterIndex() resource.ClusterIndex {
+	if c.Cluster != nil {
+		return c.Cluster.Index()
+	}
+	return 0
+}

--- a/pkg/test/framework/components/echo/docker/instance.go
+++ b/pkg/test/framework/components/echo/docker/instance.go
@@ -156,7 +156,7 @@ func (i *instance) WaitUntilCallable(instances ...echo.Instance) error {
 	// Wait for the outbound config to be received by each workload from Pilot.
 	for _, w := range i.workloads {
 		if w.sidecar != nil {
-			if err := w.sidecar.WaitForConfig(common.OutboundConfigAcceptFunc(instances...)); err != nil {
+			if err := w.sidecar.WaitForConfig(common.OutboundConfigAcceptFunc(i, instances...)); err != nil {
 				return err
 			}
 		}

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	deploymentYAML = `
+	serviceYAML = `
 {{- if .ServiceAccount }}
 apiVersion: v1
 kind: ServiceAccount
@@ -58,7 +58,9 @@ spec:
 {{- end }}
   selector:
     app: {{ .Service }}
----
+`
+
+	deploymentYAML = `
 {{$subsets := .Subsets }}
 {{- range $i, $subset := $subsets }}
 apiVersion: apps/v1
@@ -170,26 +172,32 @@ data:
 )
 
 var (
+	serviceTemplate    *template.Template
 	deploymentTemplate *template.Template
 )
 
 func init() {
+	serviceTemplate = template.New("echo_service")
+	if _, err := serviceTemplate.Funcs(sprig.TxtFuncMap()).Parse(serviceYAML); err != nil {
+		panic(fmt.Sprintf("unable to parse echo service template: %v", err))
+	}
+
 	deploymentTemplate = template.New("echo_deployment")
 	if _, err := deploymentTemplate.Funcs(sprig.TxtFuncMap()).Parse(deploymentYAML); err != nil {
 		panic(fmt.Sprintf("unable to parse echo deployment template: %v", err))
 	}
 }
 
-func generateYAML(cfg echo.Config) (string, error) {
+func generateYAML(cfg echo.Config) (serviceYAML string, deploymentYAML string, err error) {
 	// Create the parameters for the YAML template.
 	settings, err := image.SettingsFromCommandLine()
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	return generateYAMLWithSettings(cfg, settings)
 }
 
-func generateYAMLWithSettings(cfg echo.Config, settings *image.Settings) (string, error) {
+func generateYAMLWithSettings(cfg echo.Config, settings *image.Settings) (serviceYAML string, deploymentYAML string, err error) {
 	// Convert legacy config to workload oritended.
 	if cfg.Subsets == nil {
 		cfg.Subsets = []echo.SubsetConfig{
@@ -223,6 +231,12 @@ func generateYAMLWithSettings(cfg echo.Config, settings *image.Settings) (string
 		"TLSSettings":         cfg.TLSSettings,
 	}
 
+	serviceYAML, err = tmpl.Execute(serviceTemplate, params)
+	if err != nil {
+		return
+	}
+
 	// Generate the YAML content.
-	return tmpl.Execute(deploymentTemplate, params)
+	deploymentYAML, err = tmpl.Execute(deploymentTemplate, params)
+	return
 }

--- a/pkg/test/framework/components/echo/kube/deployment_test.go
+++ b/pkg/test/framework/components/echo/kube/deployment_test.go
@@ -133,11 +133,11 @@ func TestDeploymentYAML(t *testing.T) {
 		},
 	}
 	for _, tc := range testCase {
-		yaml, err := generateYAMLWithSettings(tc.config, settings)
+		serviceYAML, deploymentYAML, err := generateYAMLWithSettings(tc.config, settings)
 		if err != nil {
 			t.Errorf("failed to generate yaml %v", err)
 		}
-		gotBytes := []byte(yaml)
+		gotBytes := []byte(serviceYAML + "---" + deploymentYAML)
 		wantedBytes := testutil.ReadGoldenFile(gotBytes, tc.wantFilePath, t)
 
 		wantBytes := testutil.StripVersion(wantedBytes)

--- a/pkg/test/framework/components/environment/kube/cluster.go
+++ b/pkg/test/framework/components/environment/kube/cluster.go
@@ -27,8 +27,9 @@ var _ resource.Cluster = Cluster{}
 // Cluster for a Kubernetes cluster. Provides access via a kube.Accessor.
 type Cluster struct {
 	*kube.Accessor
-	filename string
-	index    resource.ClusterIndex
+	filename            string
+	index               resource.ClusterIndex
+	controlPlaneCluster bool
 }
 
 func (c Cluster) String() string {
@@ -36,6 +37,7 @@ func (c Cluster) String() string {
 
 	_, _ = fmt.Fprintf(buf, "Index:               %d\n", c.index)
 	_, _ = fmt.Fprintf(buf, "Filename:            %s\n", c.filename)
+	_, _ = fmt.Fprintf(buf, "ControlPlaneCluster: %t\n", c.controlPlaneCluster)
 
 	return buf.String()
 }
@@ -53,6 +55,11 @@ func (c Cluster) Name() string {
 // Index of this cluster within the Environment.
 func (c Cluster) Index() resource.ClusterIndex {
 	return c.index
+}
+
+// IsControlPlaneCluster indicates whether this cluster contains an instance of the Istio control plane.
+func (c Cluster) IsControlPlaneCluster() bool {
+	return c.controlPlaneCluster
 }
 
 // ClusterOrDefault gets the given cluster as a kube Cluster if available. Otherwise

--- a/pkg/test/framework/components/environment/kube/kube.go
+++ b/pkg/test/framework/components/environment/kube/kube.go
@@ -53,6 +53,8 @@ func New(ctx resource.Context) (resource.Environment, error) {
 	}
 	e.id = ctx.TrackResource(e)
 
+	controlPlaneClusters := s.GetControlPlaneClusters()
+
 	e.KubeClusters = make([]Cluster, 0, len(s.KubeConfig))
 	for i := range s.KubeConfig {
 		a, err := kube.NewAccessor(s.KubeConfig[i], workDir)
@@ -61,9 +63,10 @@ func New(ctx resource.Context) (resource.Environment, error) {
 		}
 		clusterIndex := resource.ClusterIndex(i)
 		e.KubeClusters = append(e.KubeClusters, Cluster{
-			filename: s.KubeConfig[i],
-			index:    clusterIndex,
-			Accessor: a,
+			filename:            s.KubeConfig[i],
+			index:               clusterIndex,
+			controlPlaneCluster: controlPlaneClusters[clusterIndex],
+			Accessor:            a,
 		})
 	}
 
@@ -82,6 +85,16 @@ func (e *Environment) Clusters() []resource.Cluster {
 	out := make([]resource.Cluster, 0, len(e.KubeClusters))
 	for _, c := range e.KubeClusters {
 		out = append(out, c)
+	}
+	return out
+}
+
+func (e *Environment) ControlPlaneClusters() []Cluster {
+	out := make([]Cluster, 0, len(e.KubeClusters))
+	for _, c := range e.KubeClusters {
+		if c.IsControlPlaneCluster() {
+			out = append(out, c)
+		}
 	}
 	return out
 }

--- a/pkg/test/framework/components/environment/kube/settings.go
+++ b/pkg/test/framework/components/environment/kube/settings.go
@@ -16,6 +16,8 @@ package kube
 
 import (
 	"fmt"
+
+	"istio.io/istio/pkg/test/framework/resource"
 )
 
 // Settings provide kube-specific Settings from flags.
@@ -26,6 +28,10 @@ type Settings struct {
 	// Indicates that the Ingress Gateway is not available. This typically happens in Minikube. The Ingress
 	// component will fall back to node-port in this case.
 	Minikube bool
+
+	// ControlPlaneTopology maps each cluster to the cluster that runs its control plane. For replicated control
+	// plane cases (where each cluster has its own control plane), the cluster will map to itself (e.g. 0->0).
+	ControlPlaneTopology map[resource.ClusterIndex]resource.ClusterIndex
 }
 
 func (s *Settings) clone() *Settings {
@@ -33,12 +39,22 @@ func (s *Settings) clone() *Settings {
 	return &c
 }
 
+// GetControlPlaneClusters returns a set containing just the cluster indexes that contain control planes.
+func (s *Settings) GetControlPlaneClusters() map[resource.ClusterIndex]bool {
+	out := make(map[resource.ClusterIndex]bool)
+	for _, controlPlaneClusterIndex := range s.ControlPlaneTopology {
+		out[controlPlaneClusterIndex] = true
+	}
+	return out
+}
+
 // String implements fmt.Stringer
 func (s *Settings) String() string {
 	result := ""
 
-	result += fmt.Sprintf("KubeConfig:      %s\n", s.KubeConfig)
-	result += fmt.Sprintf("MiniKubeIngress: %v\n", s.Minikube)
+	result += fmt.Sprintf("KubeConfig:           %s\n", s.KubeConfig)
+	result += fmt.Sprintf("MiniKubeIngress:      %v\n", s.Minikube)
+	result += fmt.Sprintf("ControlPlaneTopology: %v\n", s.ControlPlaneTopology)
 
 	return result
 }

--- a/pkg/test/framework/components/environment/native/cluster.go
+++ b/pkg/test/framework/components/environment/native/cluster.go
@@ -35,3 +35,7 @@ func (c cluster) Index() resource.ClusterIndex {
 	// Multicluster not supported natively.
 	return 0
 }
+
+func (c cluster) IsControlPlaneCluster() bool {
+	return true
+}

--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -73,6 +73,7 @@ var (
 		ChartDir:                       env.IstioChartDir,
 		ValuesFile:                     E2EValuesFile,
 		CustomSidecarInjectorNamespace: "",
+		ControlPlaneTopology:           make(map[resource.ClusterIndex]resource.ClusterIndex),
 	}
 )
 
@@ -122,6 +123,10 @@ type Config struct {
 	// Indicates that the test should deploy Istio into the target Kubernetes cluster before running tests.
 	DeployIstio bool
 
+	// ControlPlaneTopology maps each cluster to the cluster that runs its control plane. For replicated control
+	// plane cases (where each cluster has its own control plane), the cluster will map to itself (e.g. 0->0).
+	ControlPlaneTopology map[resource.ClusterIndex]resource.ClusterIndex
+
 	// Do not wait for the validation webhook before completing the deployment. This is useful for
 	// doing deployments without Galley.
 	SkipWaitForValidationWebhook bool
@@ -162,7 +167,7 @@ func (c *Config) IsMtlsEnabled() bool {
 	return true
 }
 
-func (c *Config) IstioOperator() string {
+func (c *Config) IstioOperatorConfigYAML() string {
 	data := ""
 	if c.ControlPlaneValues != "" {
 		data = Indent(c.ControlPlaneValues, "  ")
@@ -336,6 +341,7 @@ func (c *Config) String() string {
 	result += fmt.Sprintf("ValuesFile:                     %s\n", c.ValuesFile)
 	result += fmt.Sprintf("SkipWaitForValidationWebhook:   %v\n", c.SkipWaitForValidationWebhook)
 	result += fmt.Sprintf("CustomSidecarInjectorNamespace: %s\n", c.CustomSidecarInjectorNamespace)
+	result += fmt.Sprintf("ControlPlaneTopology:           %v\n", c.ControlPlaneTopology)
 
 	return result
 }

--- a/pkg/test/framework/components/istio/flags.go
+++ b/pkg/test/framework/components/istio/flags.go
@@ -48,5 +48,4 @@ func init() {
 		"Manual overrides for Helm values file. Only valid when deploying Istio.")
 	flag.StringVar(&settingsFromCommandline.CustomSidecarInjectorNamespace, "istio.test.kube.customSidecarInjectorNamespace",
 		settingsFromCommandline.CustomSidecarInjectorNamespace, "Inject the sidecar from the specified namespace")
-
 }

--- a/pkg/test/framework/resource/cluster.go
+++ b/pkg/test/framework/resource/cluster.go
@@ -27,4 +27,7 @@ type Cluster interface {
 
 	// Index of this Cluster within the Environment
 	Index() ClusterIndex
+
+	// IsControlPlaneCluster indicates whether or not a control plane has/should have a control plane deployed.
+	IsControlPlaneCluster() bool
 }

--- a/pkg/test/framework/suite_test.go
+++ b/pkg/test/framework/suite_test.go
@@ -503,6 +503,10 @@ func (f fakeCluster) Index() resource.ClusterIndex {
 	return resource.ClusterIndex(f.index)
 }
 
+func (f fakeCluster) IsControlPlaneCluster() bool {
+	panic("not implemented")
+}
+
 func (f fakeCluster) String() string {
 	return fmt.Sprintf("fake_cluster_%d", f.index)
 }

--- a/pkg/test/util/file/file.go
+++ b/pkg/test/util/file/file.go
@@ -53,6 +53,15 @@ func AsBytesOrFail(t test.Failer, filename string) []byte {
 	return content
 }
 
+// AsBytesOrPanic calls AsBytes and panics if any errors occurred.
+func AsBytesOrPanic(filename string) []byte {
+	content, err := AsBytes(filename)
+	if err != nil {
+		panic(err)
+	}
+	return content
+}
+
 // AsString is a convenience wrapper around ioutil.ReadFile that converts the content to a string.
 func AsString(filename string) (string, error) {
 	bytes, err := AsBytes(filename)

--- a/tests/integration/multicluster/main_test.go
+++ b/tests/integration/multicluster/main_test.go
@@ -1,0 +1,54 @@
+//  Copyright Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package multicluster
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/galley"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/pilot"
+	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/framework/resource/environment"
+)
+
+var (
+	ist istio.Instance
+	g   galley.Instance
+	p   pilot.Instance
+)
+
+func TestMain(m *testing.M) {
+	framework.
+		NewSuite("multicluster", m).
+		Label(label.Multicluster).
+		RequireEnvironment(environment.Kube).
+		RequireMinClusters(2).
+		SetupOnEnv(environment.Kube, istio.Setup(&ist, nil)).
+		Setup(func(ctx resource.Context) (err error) {
+			if g, err = galley.New(ctx, galley.Config{}); err != nil {
+				return err
+			}
+			if p, err = pilot.New(ctx, pilot.Config{
+				Galley: g,
+			}); err != nil {
+				return err
+			}
+			return nil
+		}).
+		Run()
+}

--- a/tests/integration/multicluster/reachability_test.go
+++ b/tests/integration/multicluster/reachability_test.go
@@ -1,0 +1,120 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicluster
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/test/echo/common/scheme"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/util/retry"
+)
+
+var (
+	retryTimeout = time.Second * 30
+	retryDelay   = time.Millisecond * 100
+)
+
+// TestMulticlusterReachability tests that services in 2 different clusters can talk to each other.
+func TestMulticlusterReachability(t *testing.T) {
+	framework.NewTest(t).
+		Label(label.Multicluster).
+		Run(func(ctx framework.TestContext) {
+			ns := namespace.NewOrFail(ctx, ctx, namespace.Config{
+				Prefix: "mc-reachability",
+				Inject: true,
+			})
+
+			// Deploy a and b in different clusters.
+			var a, b echo.Instance
+			echoboot.NewBuilderOrFail(ctx, ctx).
+				With(&a, newEchoConfig("a", ns, ctx.Environment().Clusters()[0])).
+				With(&b, newEchoConfig("b", ns, ctx.Environment().Clusters()[1])).
+				BuildOrFail(ctx)
+
+			// Now verify that they can talk to each other.
+			for _, src := range []echo.Instance{a, b} {
+				for _, dest := range []echo.Instance{a, b} {
+					subTestName := fmt.Sprintf("%s->%s://%s:%s%s",
+						src.Config().Service,
+						"http",
+						dest.Config().Service,
+						"http",
+						"/")
+
+					ctx.NewSubTest(subTestName).
+						RunParallel(func(ctx framework.TestContext) {
+							if err := retry.UntilSuccess(func() error {
+								results, err := src.Call(echo.CallOptions{
+									Target:   dest,
+									PortName: "http",
+									Scheme:   scheme.HTTP,
+								})
+								if err == nil {
+									err = results.CheckOK()
+								}
+								if err != nil {
+									return fmt.Errorf("%s to %s:%s using %s: expected success but failed: %v",
+										src, dest, "http", scheme.HTTP, err)
+								}
+								return nil
+							}, retry.Timeout(retryTimeout), retry.Delay(retryDelay)); err != nil {
+								t.Fatal(err)
+							}
+						})
+				}
+			}
+		})
+}
+
+func newEchoConfig(service string, ns namespace.Instance, cluster resource.Cluster) echo.Config {
+	return echo.Config{
+		Galley:         g,
+		Pilot:          p,
+		Service:        service,
+		Namespace:      ns,
+		Cluster:        cluster,
+		ServiceAccount: true,
+		Subsets: []echo.SubsetConfig{
+			{
+				Version: "v1",
+			},
+		},
+		Ports: []echo.Port{
+			{
+				Name:     "http",
+				Protocol: protocol.HTTP,
+				// We use a port > 1024 to not require root
+				InstancePort: 8090,
+			},
+			{
+				Name:     "tcp",
+				Protocol: protocol.TCP,
+			},
+			{
+				Name:     "grpc",
+				Protocol: protocol.GRPC,
+			},
+		},
+	}
+}


### PR DESCRIPTION
This refactors some of the test framework to support deploying Istio with a shared control plane configuration.

Follow-on work will add support for shared control plane and multi-network configurations.