### PR TITLE
Fix migrate cmd execute error

### DIFF
--- a/operator/cmd/mesh/manifest-migrate.go
+++ b/operator/cmd/mesh/manifest-migrate.go
@@ -151,7 +151,7 @@ func migrateFromClusterConfig(rootArgs *rootArgs, mmArgs *manifestMigrateArgs, l
 	c := kubectlcmd.New()
 	opts := &kubectlcmd.Options{
 		Namespace: mmArgs.namespace,
-		ExtraArgs: []string{"jsonpath='{.data.values}'"},
+		Output:    "jsonpath='{.data.values}'",
 	}
 	output, stderr, err := c.GetConfigMap("istio-sidecar-injector", opts)
 	if err != nil {


### PR DESCRIPTION
The migrate cmd call kubectl with `get cm istio-sidecar-injector -n istio-system jsonpath='{.data.values}'`, the `-o` flag missed for output format.