### PR TITLE
Stop linting links of 1.4 branch

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -373,7 +373,7 @@ $(foreach bin,$(BINARIES),$(shell basename $(bin))): build
 
 MARKDOWN_LINT_WHITELIST=localhost:8080,storage.googleapis.com/istio-artifacts/pilot/,http://ratings.default.svc.cluster.local:9080/ratings
 
-lint: lint-python lint-copyright-banner lint-scripts lint-dockerfiles lint-markdown lint-yaml lint-licenses
+lint: lint-python lint-copyright-banner lint-scripts lint-dockerfiles lint-yaml lint-licenses
 	@bin/check_helm.sh
 	@bin/check_samples.sh
 	@bin/check_dashboards.sh


### PR DESCRIPTION
This is going to continue to break as istio.io changes. We already
disabled this on 1.5/master.
This is co-dependant on https://github.com/istio/istio/pull/22131 so we will need to force merge