### PR TITLE
[WIP] Pilot agent for GCP on-premise

### DIFF
--- a/install/gcp/bootstrap/gcp_envoy_bootstrap.json
+++ b/install/gcp/bootstrap/gcp_envoy_bootstrap.json
@@ -37,7 +37,14 @@
               }
             },
             "call_credentials": {
+            {{ if .gcp_service_account_key }}
+              "service_account_jwt_access": {
+                "json_key": '{{ .gcp_service_account_key }}',
+                "token_lifetime_seconds": 3600
+              }
+            {{ else }}
               "google_compute_engine": {}
+            {{ end }}
             }
           }
         }
@@ -67,6 +74,11 @@
               "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
               "scope": "https://www.googleapis.com/auth/cloud-platform",
             }
+            {{ else if .gcp_service_account_key }}
+              "service_account_jwt_access": {
+                "json_key": '{{ .gcp_service_account_key }}',
+                "token_lifetime_seconds": 3600
+              }
             {{ else }}
               "google_compute_engine": {}
             {{ end }}

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -108,6 +108,7 @@ var (
 	tlsCertsToWatch          []string
 	loggingOptions           = log.DefaultOptions()
 	outlierLogPath           string
+	gcpConfigPath            string
 
 	wg sync.WaitGroup
 
@@ -438,6 +439,7 @@ var (
 				DisableReportCalls:  disableInternalTelemetry,
 				OutlierLogPath:      outlierLogPath,
 				PilotCertProvider:   pilotCertProvider,
+				GCPConfigPath:       gcpConfigPath,
 			})
 
 			agent := envoy.NewAgent(envoyProxy, features.TerminationDrainDuration())
@@ -715,6 +717,8 @@ func init() {
 		"Process bootstrap provided via templateFile to be used by control plane components.")
 	proxyCmd.PersistentFlags().StringVar(&outlierLogPath, "outlierLogPath", "",
 		"The log path for outlier detection")
+	proxyCmd.PersistentFlags().StringVar(&gcpConfigPath, "gcpConfigPath", "",
+		"The path to a GCP config file, Used by on-premise Envoy managed by Traffic Director.")
 
 	// Attach the Istio logging options to the command.
 	loggingOptions.AttachCobraFlags(rootCmd)

--- a/pkg/bootstrap/option/instances.go
+++ b/pkg/bootstrap/option/instances.go
@@ -247,3 +247,7 @@ func STSPort(value int) Instance {
 func STSEnabled(value bool) Instance {
 	return newOption("sts", value)
 }
+
+func GCPServiceAccountKey(value string) Instance {
+	return newOption("gcp_service_account_key", value)
+}

--- a/pkg/bootstrap/platform/aws.go
+++ b/pkg/bootstrap/platform/aws.go
@@ -88,6 +88,10 @@ func (a *awsEnv) Locality() *core.Locality {
 	}
 }
 
+func (a *awsEnv) Credentials() string {
+	return ""
+}
+
 func getEC2MetadataClient() *ec2metadata.EC2Metadata {
 	sess, err := session.NewSession(&aws.Config{
 		// eliminate retries to prevent 20s wait for Available() on non-aws platforms.

--- a/pkg/bootstrap/platform/gcp.go
+++ b/pkg/bootstrap/platform/gcp.go
@@ -139,3 +139,7 @@ func (e *gcpEnv) Locality() *core.Locality {
 
 	return &l
 }
+
+func (e *gcpEnv) Credentials() string {
+	return ""
+}

--- a/pkg/bootstrap/platform/gcp_onprem.go
+++ b/pkg/bootstrap/platform/gcp_onprem.go
@@ -1,0 +1,38 @@
+package platform
+
+import (
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+
+	"istio.io/pkg/log"
+)
+
+type gcpOnPremEnv struct {
+	zone string
+	jsonKey string
+}
+
+func NewGCPOnPremEnv(zone string, jsonKey string) Environment {
+	return &gcpOnPremEnv{
+		zone: zone,
+		jsonKey: jsonKey,
+	}
+}
+
+func (*gcpOnPremEnv) Metadata() map[string]string {
+	return map[string]string{}
+}
+
+func (e *gcpOnPremEnv) Locality() *core.Locality {
+	region, err := zoneToRegion(e.zone)
+	if err != nil {
+		log.Warnf("%v", err)
+	}
+	return &core.Locality{
+		Region: region,
+		Zone: e.zone,
+	}
+}
+
+func (e *gcpOnPremEnv) Credentials() string {
+	return e.jsonKey
+}

--- a/pkg/bootstrap/platform/platform.go
+++ b/pkg/bootstrap/platform/platform.go
@@ -30,6 +30,8 @@ type Environment interface {
 	// Locality returns the run location for the bootstrap transformed from the
 	// platform-specific representation into the Envoy Locality schema.
 	Locality() *core.Locality
+
+	Credentials() string
 }
 
 // Unknown provides a default platform environment for cases in which the platform
@@ -44,4 +46,8 @@ func (*Unknown) Metadata() map[string]string {
 // Locality returns an empty core.Locality struct.
 func (*Unknown) Locality() *core.Locality {
 	return &core.Locality{}
+}
+
+func (*Unknown) Credentials() string {
+	return ""
 }

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -61,6 +61,7 @@ type ProxyConfig struct {
 	DisableReportCalls  bool
 	OutlierLogPath      string
 	PilotCertProvider   string
+	GCPConfigPath       string
 }
 
 // NewProxy creates an instance of the proxy control commands
@@ -168,6 +169,7 @@ func (e *envoy) Run(config interface{}, epoch int, abort <-chan error) error {
 			DisableReportCalls:  e.DisableReportCalls,
 			OutlierLogPath:      e.OutlierLogPath,
 			PilotCertProvider:   e.PilotCertProvider,
+			GCPConfigPath:       e.GCPConfigPath,
 		}).CreateFileForEpoch(epoch)
 		if err != nil {
 			log.Errora("Failed to generate bootstrap config: ", err)


### PR DESCRIPTION
NOT READY FOR REVIEW!

Add an option to pilot agent "gcpConfigPath". It points to a JSON config file containing configuration for on-premise Envoy to be managed by GCP Traffic Director. The config file has the following fields:
* zone: the closest GCP zone to the on-premise Envoy
* key_path: the path to a GCP service account key file, which will be used by Envoy when connecting to Traffic Director.