### PR TITLE
add annotations for setting cpu/memory limits on sidecar

### DIFF
--- a/manifests/istio-control/istio-autoinject/files/injection-template.yaml
+++ b/manifests/istio-control/istio-autoinject/files/injection-template.yaml
@@ -340,6 +340,17 @@ template: |
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
         memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
         {{ end }}
+      limits:
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
+        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+        {{ else}}
+        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+        {{ end}}
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
+        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+        {{ else}}
+        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+        {{ end }}
     {{ else -}}
   {{- if .Values.global.proxy.resources }}
       {{ toYaml .Values.global.proxy.resources | indent 4 }}

--- a/manifests/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/istio-control/istio-discovery/files/injection-template.yaml
@@ -357,6 +357,17 @@ template: |
         {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
         memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
         {{ end }}
+      limits:
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
+        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+        {{ else}}
+        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+        {{ end}}
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
+        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+        {{ else}}
+        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+        {{ end }}
     {{ else -}}
   {{- if .Values.global.proxy.resources }}
       {{ toYaml .Values.global.proxy.resources | indent 4 }}


### PR DESCRIPTION
When a limitrange is active, not setting the limits will result
in an error. This patch will allow setting limits for the sidecar
and when not set, use the requests value.