### PR TITLE
Fix GOBUILDFLAGS usage in codecov scripts

### DIFF
--- a/bin/codecov.sh
+++ b/bin/codecov.sh
@@ -27,6 +27,7 @@ DIR="./..."
 CODECOV_SKIP=${CODECOV_SKIP:-"${ROOTDIR}/codecov.skip"}
 SKIPPED_TESTS_GREP_ARGS=
 TEST_RETRY_COUNT=3
+GOBUILDFLAGS=${GOBUILDFLAGS:-""}
 
 # Set GOPATH to match the expected layout
 GO_TOP=$(cd "$(dirname "$0")"/../../../..; pwd)
@@ -57,7 +58,9 @@ function code_coverage() {
   local filename
   local count=${2:-0}
   filename="$(echo "${1}" | tr '/' '-')"
-  go test "${GOBUILDFLAGS}" \
+
+  # shellcheck disable=SC2086
+  go test ${GOBUILDFLAGS} \
     -coverpkg=istio.io/istio/... \
     -coverprofile="${COVERAGEDIR}/${filename}.cov" \
     -covermode=atomic "${1}" \

--- a/bin/codecov_diff.sh
+++ b/bin/codecov_diff.sh
@@ -20,6 +20,7 @@ set -o pipefail
 
 SCRIPTPATH="$(cd "$(dirname "$0")" ; pwd -P)"
 ROOTDIR="$(dirname "${SCRIPTPATH}")"
+GOBUILDFLAGS=${GOBUILDFLAGS:-""}
 
 REPORT_PATH=${GOPATH}/out/codecov/pr
 BASELINE_PATH=${GOPATH}/out/codecov/baseline
@@ -62,7 +63,8 @@ if [[ -n "${CIRCLE_PR_NUMBER:-}" ]]; then
   git checkout "${CIRCLE_SHA1}"
 
   # Test that coverage is not dropped
-  go test "${GOBUILDFLAGS}" -v istio.io/istio/tests/codecov/... \
+  # shellcheck disable=SC2086
+  go test ${GOBUILDFLAGS} -v istio.io/istio/tests/codecov/... \
     --report_file="${REPORT_PATH}/coverage.html" \
     --baseline_file="${BASELINE_PATH}/coverage.html" \
     --threshold_files="${THRESHOLD_FILE},${CODECOV_SKIP}" \


### PR DESCRIPTION
This variable needs to be set before used (set -u) and must not be
quoted, otherwise it will become an empty arg for go test if it's empty.