### PR TITLE
add routename for prometheus_stats's static route_config in envoy_bootstrap_tmpl.json

### DIFF
--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -484,6 +484,7 @@
                   "codec_type": "AUTO",
                   "stat_prefix": "stats",
                   "route_config": {
+                    "name": "static-prometheus:15090",
                     "virtual_hosts": [
                       {
                         "name": "backend",

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -409,6 +409,7 @@
                   "codec_type": "AUTO",
                   "stat_prefix": "stats",
                   "route_config": {
+                    "name": "static-prometheus:15090",
                     "virtual_hosts": [
                       {
                         "name": "backend",

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -409,6 +409,7 @@
                   "codec_type": "AUTO",
                   "stat_prefix": "stats",
                   "route_config": {
+                    "name": "static-prometheus:15090",
                     "virtual_hosts": [
                       {
                         "name": "backend",

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -377,6 +377,7 @@
                   "codec_type": "AUTO",
                   "stat_prefix": "stats",
                   "route_config": {
+                    "name": "static-prometheus:15090",
                     "virtual_hosts": [
                       {
                         "name": "backend",

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -437,6 +437,7 @@
                   "codec_type": "AUTO",
                   "stat_prefix": "stats",
                   "route_config": {
+                    "name": "static-prometheus:15090",
                     "virtual_hosts": [
                       {
                         "name": "backend",

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -437,6 +437,7 @@
                   "codec_type": "AUTO",
                   "stat_prefix": "stats",
                   "route_config": {
+                    "name": "static-prometheus:15090",
                     "virtual_hosts": [
                       {
                         "name": "backend",

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -392,6 +392,7 @@
                   "codec_type": "AUTO",
                   "stat_prefix": "stats",
                   "route_config": {
+                    "name": "static-prometheus:15090",
                     "virtual_hosts": [
                       {
                         "name": "backend",

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -400,6 +400,7 @@
                   "codec_type": "AUTO",
                   "stat_prefix": "stats",
                   "route_config": {
+                    "name": "static-prometheus:15090",
                     "virtual_hosts": [
                       {
                         "name": "backend",

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -401,6 +401,7 @@
                   "codec_type": "AUTO",
                   "stat_prefix": "stats",
                   "route_config": {
+                    "name": "static-prometheus:15090",
                     "virtual_hosts": [
                       {
                         "name": "backend",

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -377,6 +377,7 @@
                   "codec_type": "AUTO",
                   "stat_prefix": "stats",
                   "route_config": {
+                    "name": "static-prometheus:15090",
                     "virtual_hosts": [
                       {
                         "name": "backend",

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -400,6 +400,7 @@
                   "codec_type": "AUTO",
                   "stat_prefix": "stats",
                   "route_config": {
+                    "name": "static-prometheus:15090",
                     "virtual_hosts": [
                       {
                         "name": "backend",

--- a/pkg/envoy/testdata/envoy_bootstrap_v2.tmpl.json
+++ b/pkg/envoy/testdata/envoy_bootstrap_v2.tmpl.json
@@ -48,6 +48,7 @@
                   "codec_type": "AUTO",
                   "stat_prefix": "stats",
                   "route_config": {
+                    "name": "static-prometheus:{{ .listenerPort }}",
                     "virtual_hosts": [
                       {
                         "name": "backend",

--- a/pkg/test/framework/components/echo/common/testdata/config_dump.json
+++ b/pkg/test/framework/components/echo/common/testdata/config_dump.json
@@ -40,6 +40,7 @@
                       "name": "envoy.http_connection_manager",
                       "hidden_envoy_deprecated_config": {
                         "route_config": {
+                          "name": "static-prometheus:15090",
                           "virtual_hosts": [
                             {
                               "routes": [
@@ -2458,6 +2459,7 @@
                       },
                       "stat_prefix": "stats",
                       "route_config": {
+                        "name": "static-prometheus:15090",
                         "virtual_hosts": [
                           {
                             "domains": [

--- a/tools/packaging/common/envoy_bootstrap_v2.json
+++ b/tools/packaging/common/envoy_bootstrap_v2.json
@@ -442,6 +442,7 @@
                   "codec_type": "AUTO",
                   "stat_prefix": "stats",
                   "route_config": {
+                    "name": "static-prometheus:15090",
                     "virtual_hosts": [
                       {
                         "name": "backend",


### PR DESCRIPTION
without route name, istioctl proxy-config route will show an empty route name, this will make user confused.