### PR TITLE
remove extraneous user_sds feature flag

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -345,11 +345,10 @@ type NodeMetadata struct {
 	// SdsTokenPath specifies the path of the SDS token used by the Envoy proxy.
 	// If not set, Pilot uses the default SDS token path.
 	SdsTokenPath string     `json:"SDS_TOKEN_PATH,omitempty"`
-	UserSds      StringBool `json:"USER_SDS,omitempty"`
 	SdsBase      string     `json:"BASE,omitempty"`
-	// SdsEnabled indicates if SDS is enabled or not. This is are set to "1" if true
+	// SdsEnabled indicates if SDS is enabled or not. This is set to "1" if true
 	SdsEnabled StringBool `json:"SDS,omitempty"`
-	// SdsTrustJwt indicates if SDS trust jwt is enabled or not. This is are set to "1" if true
+	// SdsTrustJwt indicates if SDS trust jwt is enabled or not. This is set to "1" if true
 	SdsTrustJwt StringBool `json:"TRUSTJWT,omitempty"`
 
 	// StsPort specifies the port of security token exchange server (STS).

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -370,7 +370,7 @@ func (configgen *ConfigGeneratorImpl) createGatewayHTTPFilterChainOpts(
 		// and that no two non-HTTPS servers can be on same port or share port names.
 		// Validation is done per gateway and also during merging
 		sniHosts:   getSNIHostsForServer(server),
-		tlsContext: buildGatewayListenerTLSContext(server, bool(node.Metadata.UserSds), sdsPath, node.Metadata),
+		tlsContext: buildGatewayListenerTLSContext(server, sdsPath, node.Metadata),
 		httpOpts: &httpListenerOpts{
 			rds:              routeName,
 			useRemoteAddress: true,
@@ -407,7 +407,7 @@ func (configgen *ConfigGeneratorImpl) createGatewayHTTPFilterChainOpts(
 //
 // Note that ISTIO_MUTUAL TLS mode and ingressSds should not be used simultaneously on the same ingress gateway.
 func buildGatewayListenerTLSContext(
-	server *networking.Server, enableIngressSds bool, sdsPath string, metadata *model.NodeMetadata) *auth.DownstreamTlsContext {
+	server *networking.Server, sdsPath string, metadata *model.NodeMetadata) *auth.DownstreamTlsContext {
 	// Server.TLS cannot be nil or passthrough. But as a safety guard, return nil
 	if server.Tls == nil || gateway.IsPassThroughServer(server) {
 		return nil // We don't need to setup TLS context for passthrough mode
@@ -419,7 +419,7 @@ func buildGatewayListenerTLSContext(
 		},
 	}
 
-	if enableIngressSds && server.Tls.CredentialName != "" {
+	if server.Tls.CredentialName != "" {
 		// If SDS is enabled at gateway, and credential name is specified at gateway config, create
 		// SDS config for gateway to fetch key/cert at gateway agent.
 		util.ApplyCustomSDSToCommonTLSContext(tls.CommonTlsContext, server.Tls, authn_model.IngressGatewaySdsUdsPath)
@@ -519,7 +519,7 @@ func (configgen *ConfigGeneratorImpl) createGatewayTCPFilterChainOpts(
 			return []*filterChainOpts{
 				{
 					sniHosts:       getSNIHostsForServer(server),
-					tlsContext:     buildGatewayListenerTLSContext(server, bool(node.Metadata.UserSds), push.Mesh.SdsUdsPath, node.Metadata),
+					tlsContext:     buildGatewayListenerTLSContext(server, push.Mesh.SdsUdsPath, node.Metadata),
 					networkFilters: filters,
 				},
 			}

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -42,19 +42,17 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 	testCases := []struct {
 		name                  string
 		server                *networking.Server
-		enableIngressSdsAgent bool
 		sdsPath               string
 		result                *auth.DownstreamTlsContext
 	}{
 		{
-			name: "ingress sdsagent disabled, mesh SDS disabled, tls mode ISTIO_MUTUAL",
+			name: "mesh SDS disabled, tls mode ISTIO_MUTUAL",
 			server: &networking.Server{
 				Hosts: []string{"httpbin.example.com"},
 				Tls: &networking.Server_TLSOptions{
 					Mode: networking.Server_TLSOptions_ISTIO_MUTUAL,
 				},
 			},
-			enableIngressSdsAgent: false,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					AlpnProtocols: util.ALPNHttp,
@@ -86,14 +84,13 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 			},
 		},
 		{
-			name: "ingress sdsagent disabled, mesh SDS enabled, tls mode ISTIO_MUTUAL",
+			name: "mesh SDS enabled, tls mode ISTIO_MUTUAL",
 			server: &networking.Server{
 				Hosts: []string{"httpbin.example.com"},
 				Tls: &networking.Server_TLSOptions{
 					Mode: networking.Server_TLSOptions_ISTIO_MUTUAL,
 				},
 			},
-			enableIngressSdsAgent: false,
 			sdsPath:               "unix:/var/run/sds/uds_path",
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
@@ -153,7 +150,6 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 					Mode: networking.Server_TLSOptions_SIMPLE,
 				},
 			},
-			enableIngressSdsAgent: true,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					AlpnProtocols: util.ALPNHttp,
@@ -184,7 +180,6 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 					CredentialName: "ingress-sds-resource-name",
 				},
 			},
-			enableIngressSdsAgent: true,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					AlpnProtocols: util.ALPNHttp,
@@ -226,7 +221,6 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 					SubjectAltNames: []string{"subject.name.a.com", "subject.name.b.com"},
 				},
 			},
-			enableIngressSdsAgent: true,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					AlpnProtocols: util.ALPNHttp,
@@ -272,7 +266,6 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 					PrivateKey:        "private-key.key",
 				},
 			},
-			enableIngressSdsAgent: false,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					AlpnProtocols: util.ALPNHttp,
@@ -304,7 +297,6 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 					PrivateKey:        "private-key.key",
 				},
 			},
-			enableIngressSdsAgent: true,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					AlpnProtocols: util.ALPNHttp,
@@ -339,7 +331,6 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 					SubjectAltNames:   []string{"subject.name.a.com", "subject.name.b.com"},
 				},
 			},
-			enableIngressSdsAgent: true,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					AlpnProtocols: util.ALPNHttp,
@@ -409,7 +400,6 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 					VerifyCertificateSpki: []string{"abcdef"},
 				},
 			},
-			enableIngressSdsAgent: true,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					AlpnProtocols: util.ALPNHttp,
@@ -479,7 +469,6 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 					VerifyCertificateHash: []string{"fedcba"},
 				},
 			},
-			enableIngressSdsAgent: true,
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					AlpnProtocols: util.ALPNHttp,
@@ -548,13 +537,12 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 					PrivateKey:        "private-key.key",
 				},
 			},
-			enableIngressSdsAgent: true,
 			result:                nil,
 		},
 	}
 
 	for _, tc := range testCases {
-		ret := buildGatewayListenerTLSContext(tc.server, tc.enableIngressSdsAgent, tc.sdsPath, &pilot_model.NodeMetadata{SdsEnabled: true})
+		ret := buildGatewayListenerTLSContext(tc.server, tc.sdsPath, &pilot_model.NodeMetadata{})
 		if !reflect.DeepEqual(tc.result, ret) {
 			t.Errorf("test case %s: expecting:\n %v but got:\n %v", tc.name, tc.result, ret)
 		}

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -861,7 +861,7 @@ func buildSidecarListenerTLSContext(userTLSOpts *networking.Server_TLSOptions, m
 	}
 
 	// user sds enabled
-	if metadata.UserSds && userTLSOpts.CredentialName != "" {
+	if userTLSOpts.CredentialName != "" {
 		util.ApplyCustomSDSToCommonTLSContext(tls.CommonTlsContext, userTLSOpts, sdsUdsPath)
 	} else {
 		// Fall back to the read-from-file approach when SDS is not enabled or Tls.CredentialName is not specified.

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -2321,7 +2321,6 @@ func TestBuildSidecarListenerTlsContext(t *testing.T) {
 				PrivateKey:        "private-key",
 			},
 			nodeMeta: &model.NodeMetadata{
-				UserSds: false,
 			},
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
@@ -2353,7 +2352,6 @@ func TestBuildSidecarListenerTlsContext(t *testing.T) {
 				CaCertificates:    "ca",
 			},
 			nodeMeta: &model.NodeMetadata{
-				UserSds: false,
 			},
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
@@ -2395,7 +2393,6 @@ func TestBuildSidecarListenerTlsContext(t *testing.T) {
 				SubjectAltNames:   []string{"subject.name.a.com", "subject.name.b.com"},
 			},
 			nodeMeta: &model.NodeMetadata{
-				UserSds: false,
 			},
 			result: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
@@ -2436,7 +2433,6 @@ func TestBuildSidecarListenerTlsContext(t *testing.T) {
 				SubjectAltNames: []string{"subject.name.a.com", "subject.name.b.com"},
 			},
 			nodeMeta: &model.NodeMetadata{
-				UserSds: true,
 			},
 			sdsUdsPath: "unix:/var/run/sidecar/sds",
 			result: &auth.DownstreamTlsContext{


### PR DESCRIPTION
We created the ISTIO_META_USER_SDS boolean as a way of feature testing
the SDS feature a year ago. Gateway's SDS has stabilized. We no longer
need this feature flag. This has remained always enabled for over a year :). 
Users can choose to use the `credentialName` field in the Gateway API to specify the secret.