### PR TITLE
Fix flaky SDS tests.

### DIFF
--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -167,12 +167,15 @@ func testHelper(t *testing.T, arg Options, cb secretCallback, testInvalidResourc
 
 	if arg.EnableWorkloadSDS {
 		sendRequestAndVerifyResponse(t, cb, arg.WorkloadUDSPath, proxyID, testInvalidResourceNames)
-
 		// Request for root certificate.
 		sendRequestForRootCertAndVerifyResponse(t, cb, arg.WorkloadUDSPath, proxyID)
+
+		recycleConnection(getClientConID(proxyID), testResourceName)
+		recycleConnection(getClientConID(proxyID), "ROOTCA")
 	}
 	if arg.EnableIngressGatewaySDS {
 		sendRequestAndVerifyResponse(t, cb, arg.IngressGatewayUDSPath, proxyID, testInvalidResourceNames)
+		recycleConnection(getClientConID(proxyID), testResourceName)
 	}
 	// Check to make sure number of staled connections is 0.
 	checkStaledConnCount(t)
@@ -241,7 +244,7 @@ func createSDSServer(t *testing.T, socket string) (*Server, *mockSecretStore) {
 	arg := Options{
 		EnableIngressGatewaySDS: false,
 		EnableWorkloadSDS:       true,
-		RecycleInterval:         100 * time.Millisecond,
+		RecycleInterval:         100 * time.Second,
 		WorkloadUDSPath:         socket,
 	}
 	st := &mockSecretStore{
@@ -440,54 +443,38 @@ func getClientConID(proxyID string) string {
 }
 
 func TestStreamSecretsPush(t *testing.T) {
-	// reset connectionNumber since since its value is kept in memory for all unit test cases
-	// lifetime, reset since it may be updated in other test case.
-	atomic.StoreInt64(&connectionNumber, 0)
+	setup := StartTest(t)
+	defer setup.server.Stop()
 
-	initialTotalPush, err := util.GetMetricsCounterValue("total_pushes")
-	if err != nil {
-		t.Errorf("Fail to get initial value from metric totalPush: %v", err)
-	}
-	expectedTotalPush := 0
+	var expectedTotalPush int64
 
-	socket := fmt.Sprintf("/tmp/gotest%s.sock", string(uuid.NewUUID()))
-	server, st := createSDSServer(t, socket)
-	defer server.Stop()
-
-	connOne, streamOne := createSDSStream(t, socket, fakeToken1)
+	connOne, streamOne := createSDSStream(t, setup.socket, fakeToken1)
+	defer connOne.Close()
 	proxyID := "sidecar~127.0.0.1~SecretsPushStreamOne~local"
 	notifyChanOne := make(chan notifyMsg)
 	go testSDSStreamOne(streamOne, proxyID, notifyChanOne)
 	expectedTotalPush += 2
 
-	connTwo, streamTwo := createSDSStream(t, socket, fakeToken2)
+	connTwo, streamTwo := createSDSStream(t, setup.socket, fakeToken2)
+	defer connTwo.Close()
 	proxyIDTwo := "sidecar~127.0.0.1~SecretsPushStreamTwo~local"
 	notifyChanTwo := make(chan notifyMsg)
 	go testSDSStreamTwo(streamTwo, proxyIDTwo, notifyChanTwo)
 	expectedTotalPush++
 
 	// verify that the first SDS request sent by two streams do not hit cache.
-	waitForSecretCacheCheck(t, st, false, 2)
+	waitForSecretCacheCheck(t, setup.secretStore, false, 2)
 	waitForNotificationToProceed(t, notifyChanOne, "notify push secret 1")
 	// verify that the second SDS request hits cache.
-	waitForSecretCacheCheck(t, st, true, 1)
+	waitForSecretCacheCheck(t, setup.secretStore, true, 1)
 
 	// simulate logic in constructConnectionID() function.
 	conID := getClientConID(proxyID)
 	// Test push new secret to proxy. This SecretItem is for StreamOne.
-	pushSecret := &model.SecretItem{
-		CertificateChain: fakePushCertificateChain,
-		PrivateKey:       fakePushPrivateKey,
-		ResourceName:     testResourceName,
-		Version:          time.Now().Format("01-02 15:04:05.000"),
-		Token:            fakeToken1,
-	}
 	if err := NotifyProxy(cache.ConnKey{ConnectionID: conID, ResourceName: testResourceName},
-		pushSecret); err != nil {
+		setup.generatePushSecret(conID, fakeToken1)); err != nil {
 		t.Fatalf("failed to send push notification to proxy %q: %v", conID, err)
 	}
-	// load pushed secret into cache, this is needed to detect an ACK request.
-	st.secrets.Store(cache.ConnKey{ConnectionID: conID, ResourceName: testResourceName}, pushSecret)
 	notifyChanOne <- notifyMsg{Err: nil, Message: "receive secret"}
 
 	// Verify that pushed secret is stored in cache.
@@ -495,13 +482,13 @@ func TestStreamSecretsPush(t *testing.T) {
 		ConnectionID: conID,
 		ResourceName: testResourceName,
 	}
-	if _, found := st.secrets.Load(key); !found {
+	if _, found := setup.secretStore.secrets.Load(key); !found {
 		t.Fatalf("Failed to find cached secret")
 	}
 
 	waitForNotificationToProceed(t, notifyChanOne, "notify push secret 2")
 	// verify that the third SDS request hits cache.
-	waitForSecretCacheCheck(t, st, true, 2)
+	waitForSecretCacheCheck(t, setup.secretStore, true, 2)
 
 	// Test push nil secret(indicates close the streaming connection) to proxy.
 	if err := NotifyProxy(cache.ConnKey{ConnectionID: conID, ResourceName: testResourceName}, nil); err != nil {
@@ -510,17 +497,15 @@ func TestStreamSecretsPush(t *testing.T) {
 	notifyChanOne <- notifyMsg{Err: nil, Message: "receive nil secret"}
 
 	waitForNotificationToProceed(t, notifyChanOne, "close stream")
-	connOne.Close()
 	waitForNotificationToProceed(t, notifyChanTwo, "close stream")
-	connTwo.Close()
 
-	if _, found := st.secrets.Load(key); found {
+	if _, found := setup.secretStore.secrets.Load(key); found {
 		t.Fatalf("Found cached secret after stream close, expected the secret to not exist")
 	}
-	// Wait the recycle job run to clear all staled client connections.
-	// TODO(JimmyCYJ): replace this sleep with measuring metrics totalStaleConnCounts.
-	time.Sleep(1 * time.Second)
 
+	recycleConnection(getClientConID(proxyID), testResourceName)
+	recycleConnection(getClientConID(proxyIDTwo), testResourceName)
+	clearStaledClients()
 	// Add RLock to avoid racetest fail.
 	sdsClientsMutex.RLock()
 	if len(sdsClients) != 0 {
@@ -528,15 +513,7 @@ func TestStreamSecretsPush(t *testing.T) {
 	}
 	sdsClientsMutex.RUnlock()
 
-	totalPushVal, err := util.GetMetricsCounterValue("total_pushes")
-	if err != nil {
-		t.Errorf("Fail to get value from metric totalPush: %v", err)
-	}
-	totalPushVal -= initialTotalPush
-	if totalPushVal != float64(expectedTotalPush) {
-		t.Errorf("unexpected metric totalPush: expected %v but got %v", expectedTotalPush,
-			totalPushVal)
-	}
+	setup.verifyTotalPushes(expectedTotalPush)
 }
 
 func testSDSStreamMultiplePush(stream sds.SecretDiscoveryService_StreamSecretsClient, proxyID string,
@@ -565,16 +542,9 @@ func testSDSStreamMultiplePush(stream sds.SecretDiscoveryService_StreamSecretsCl
 
 	// Don't send a request and force SDS server to push secret, as a duplicate push.
 	notifyChan <- notifyMsg{Err: nil, Message: "notify push secret"}
-	if notify := <-notifyChan; notify.Message == "receive secret" {
-		// Verify that Recv() does not receive secret push and returns when stream is closed.
-		_, err = stream.Recv()
-		if err == nil {
-			notifyChan <- notifyMsg{Err: err, Message: fmt.Sprintf("stream.Send failed: %v", err)}
-		}
-		if !strings.Contains(err.Error(), "closing") {
-			errMisMatch := fmt.Errorf("received error does not match, got %v", err)
-			notifyChan <- notifyMsg{Err: errMisMatch, Message: errMisMatch.Error()}
-		}
+	if notify := <-notifyChan; notify.Message != "receive secret" {
+		errMisMatch := fmt.Errorf("received error does not match, got %v", err)
+		notifyChan <- notifyMsg{Err: errMisMatch, Message: errMisMatch.Error()}
 	}
 
 	notifyChan <- notifyMsg{Err: nil, Message: "close stream"}
@@ -583,52 +553,30 @@ func testSDSStreamMultiplePush(stream sds.SecretDiscoveryService_StreamSecretsCl
 // TestStreamSecretsMultiplePush verifies that only one response is pushed per request, and that multiple
 // pushes are detected and skipped.
 func TestStreamSecretsMultiplePush(t *testing.T) {
-	// reset connectionNumber since since its value is kept in memory for all unit test cases lifetime, reset since it may be updated in other test case.
-	atomic.StoreInt64(&connectionNumber, 0)
+	setup := StartTest(t)
+	defer setup.server.Stop()
 
-	initialTotalPush, err := util.GetMetricsCounterValue("total_pushes")
-	if err != nil {
-		t.Errorf("Fail to get initial value from metric totalPush: %v", err)
-	}
-	socket := fmt.Sprintf("/tmp/gotest%s.sock", string(uuid.NewUUID()))
-	server, st := createSDSServer(t, socket)
-	defer server.Stop()
-
-	conn, stream := createSDSStream(t, socket, fakeToken1)
+	conn, stream := createSDSStream(t, setup.socket, fakeToken1)
+	defer conn.Close()
 	proxyID := "sidecar~127.0.0.1~StreamMultiplePush~local"
 	notifyChan := make(chan notifyMsg)
 	go testSDSStreamMultiplePush(stream, proxyID, notifyChan)
 
 	waitForNotificationToProceed(t, notifyChan, "notify push secret")
 	// verify that the first SDS request does not hit cache.
-	waitForSecretCacheCheck(t, st, false, 1)
-
+	waitForSecretCacheCheck(t, setup.secretStore, false, 1)
+	setup.verifyTotalPushes(1)
 	// simulate logic in constructConnectionID() function.
-	conID := proxyID + "-1"
-	pushSecret := &model.SecretItem{
-		CertificateChain: fakePushCertificateChain,
-		PrivateKey:       fakePushPrivateKey,
-		ResourceName:     testResourceName,
-		Version:          time.Now().Format("01-02 15:04:05.000"),
-	}
+	conID := getClientConID(proxyID)
 	// Test push new secret to proxy.
 	if err := NotifyProxy(cache.ConnKey{ConnectionID: conID, ResourceName: testResourceName},
-		pushSecret); err != nil {
+		setup.generatePushSecret(conID, fakeToken1)); err != nil {
 		t.Fatalf("failed to send push notification to proxy %q", conID)
 	}
-
 	notifyChan <- notifyMsg{Err: nil, Message: "receive secret"}
-	conn.Close()
 	waitForNotificationToProceed(t, notifyChan, "close stream")
-
-	totalPushVal, err := util.GetMetricsCounterValue("total_pushes")
-	if err != nil {
-		t.Errorf("Fail to get value from metric totalPush: %v", err)
-	}
-	totalPushVal -= initialTotalPush
-	if totalPushVal != float64(1) {
-		t.Errorf("unexpected metric totalPush: expected 1 but got %v", totalPushVal)
-	}
+	// Verify that there is no push this time, total number of pushes is not changed.
+	setup.verifyTotalPushes(1)
 }
 
 func testSDSStreamUpdateFailures(stream sds.SecretDiscoveryService_StreamSecretsClient, proxyID string,
@@ -697,70 +645,122 @@ func testSDSStreamUpdateFailures(stream sds.SecretDiscoveryService_StreamSecrets
 // (verify) <--    RESP
 // "close stream" -----------> (close stream)
 func TestStreamSecretsUpdateFailures(t *testing.T) {
-	// reset connectionNumber since since its value is kept in memory for all unit test cases lifetime,
-	// reset since it may be updated in other test case.
-	atomic.StoreInt64(&connectionNumber, 0)
+	setup := StartTest(t)
+	defer setup.server.Stop()
 
-	socket := fmt.Sprintf("/tmp/gotest%s.sock", string(uuid.NewUUID()))
-	server, st := createSDSServer(t, socket)
-	defer server.Stop()
-
-	initialTotalPush, err := util.GetMetricsCounterValue("total_pushes")
-	if err != nil {
-		t.Errorf("Fail to get initial value from metric totalPush: %v", err)
-	}
-	initialTotalUpdateFailures, err := util.GetMetricsCounterValue("total_secret_update_failures")
-	if err != nil {
-		t.Errorf("Fail to get initial value from metric totalSecretUpdateFailureCounts: %v", err)
-	}
-
-	conn, stream := createSDSStream(t, socket, fakeToken1)
+	conn, stream := createSDSStream(t, setup.socket, fakeToken1)
+	defer conn.Close()
 	proxyID := "sidecar~127.0.0.1~SecretsUpdateFailure~local"
 	notifyChan := make(chan notifyMsg)
 	go testSDSStreamUpdateFailures(stream, proxyID, notifyChan)
 
 	waitForNotificationToProceed(t, notifyChan, "notify push secret")
 	// verify that the first SDS request does not hit cache, and that the second SDS request hits cache.
-	waitForSecretCacheCheck(t, st, false, 1)
-	waitForSecretCacheCheck(t, st, true, 0)
+	waitForSecretCacheCheck(t, setup.secretStore, false, 1)
+	waitForSecretCacheCheck(t, setup.secretStore, true, 0)
 
 	// simulate logic in constructConnectionID() function.
-	conID := proxyID + "-1"
+	conID := getClientConID(proxyID)
+	// Test push new secret to proxy.
+	if err := NotifyProxy(cache.ConnKey{ConnectionID: conID, ResourceName: testResourceName},
+		setup.generatePushSecret(conID, fakeToken1)); err != nil {
+		t.Fatalf("failed to send push notification to proxy %q: %v", conID, err)
+	}
+	notifyChan <- notifyMsg{Err: nil, Message: "receive secret"}
+	waitForNotificationToProceed(t, notifyChan, "close stream")
+
+	setup.verifyUpdateFailureCount(1)
+	setup.verifyTotalPushes(2)
+}
+
+type Setup struct {
+	t                          *testing.T
+	socket                     string
+	server                     *Server
+	secretStore                *mockSecretStore
+	initialTotalPush           float64
+	initialTotalUpdateFailures float64
+}
+
+// StartTest starts SDS server and checks SDS connectivity.
+func StartTest(t *testing.T) *Setup {
+	s := &Setup{t: t}
+	// reset connectionNumber since since its value is kept in memory for all unit test cases lifetime,
+	// reset since it may be updated in other test case.
+	atomic.StoreInt64(&connectionNumber, 0)
+
+	s.socket = fmt.Sprintf("/tmp/gotest%s.sock", string(uuid.NewUUID()))
+	s.server, s.secretStore = createSDSServer(t, s.socket)
+
+	if err := s.waitForSDSReady(); err != nil {
+		t.Fatalf("fail to start SDS server: %v", err)
+	}
+
+	// Get initial SDS push stats.
+	initialTotalPush, err := util.GetMetricsCounterValue("total_pushes")
+	if err != nil {
+		t.Fatalf("fail to get initial value from metric totalPush: %v", err)
+	}
+	initialTotalUpdateFailures, err := util.GetMetricsCounterValue("total_secret_update_failures")
+	if err != nil {
+		t.Fatalf("fail to get initial value from metric totalSecretUpdateFailureCounts: %v", err)
+	}
+	s.initialTotalPush = initialTotalPush
+	s.initialTotalUpdateFailures = initialTotalUpdateFailures
+
+	return s
+}
+
+func (s *Setup) waitForSDSReady() error {
+	var conErr, streamErr error
+	var conn *grpc.ClientConn
+	for i := 0; i < 20; i++ {
+		if conn, conErr = setupConnection(s.socket); conErr == nil {
+			sdsClient := sds.NewSecretDiscoveryServiceClient(conn)
+			header := metadata.Pairs(credentialTokenHeaderKey, fakeToken1)
+			ctx := metadata.NewOutgoingContext(context.Background(), header)
+			if _, streamErr = sdsClient.StreamSecrets(ctx); streamErr == nil {
+				return nil
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return fmt.Errorf("cannot connect SDS server, connErr: %v, streamErr: %v", conErr, streamErr)
+}
+
+func (s *Setup) verifyUpdateFailureCount(expected int64) {
+	totalSecretUpdateFailureVal, err := util.GetMetricsCounterValue("total_secret_update_failures")
+	if err != nil {
+		s.t.Errorf("Fail to get value from metric totalSecretUpdateFailureCounts: %v", err)
+	}
+	totalSecretUpdateFailureVal -= s.initialTotalUpdateFailures
+	if totalSecretUpdateFailureVal != float64(expected) {
+		s.t.Errorf("unexpected metric totalSecretUpdateFailureCounts: expected %d but got %v",
+			expected, totalSecretUpdateFailureVal)
+	}
+}
+
+func (s *Setup) verifyTotalPushes(expected int64) {
+	totalPushVal, err := util.GetMetricsCounterValue("total_pushes")
+	if err != nil {
+		s.t.Errorf("Fail to get value from metric totalPush: %v", err)
+	}
+	totalPushVal -= s.initialTotalPush
+	if totalPushVal != float64(expected) {
+		s.t.Errorf("unexpected metric totalPush: expected %d but got %v", expected, totalPushVal)
+	}
+}
+
+func (s *Setup) generatePushSecret(conID, token string) *model.SecretItem {
 	pushSecret := &model.SecretItem{
 		CertificateChain: fakePushCertificateChain,
 		PrivateKey:       fakePushPrivateKey,
 		ResourceName:     testResourceName,
 		Version:          time.Now().Format("01-02 15:04:05.000"),
+		Token:            token,
 	}
-	// Test push new secret to proxy.
-	if err := NotifyProxy(cache.ConnKey{ConnectionID: conID, ResourceName: testResourceName},
-		pushSecret); err != nil {
-		t.Fatalf("failed to send push notification to proxy %q: %v", conID, err)
-	}
-	// load pushed secret into cache, this is needed to detect an ACK request.
-	st.secrets.Store(cache.ConnKey{ConnectionID: conID, ResourceName: testResourceName}, pushSecret)
-	notifyChan <- notifyMsg{Err: nil, Message: "receive secret"}
-
-	waitForNotificationToProceed(t, notifyChan, "close stream")
-	conn.Close()
-
-	totalSecretUpdateFailureVal, err := util.GetMetricsCounterValue("total_secret_update_failures")
-	if err != nil {
-		t.Errorf("Fail to get value from metric totalSecretUpdateFailureCounts: %v", err)
-	}
-	totalSecretUpdateFailureVal -= initialTotalUpdateFailures
-	if totalSecretUpdateFailureVal != float64(1) {
-		t.Errorf("unexpected metric totalSecretUpdateFailureCounts: expected 1 but got %v",
-			totalSecretUpdateFailureVal)
-	}
-	totalPushVal, err := util.GetMetricsCounterValue("total_pushes")
-	if err != nil {
-		t.Errorf("Fail to get value from metric totalPush: %v", err)
-	}
-	totalPushVal -= initialTotalPush
-	if totalPushVal != float64(2) {
-		t.Errorf("unexpected metric totalPush: expected 3 but got %v", totalPushVal)
-	}
+	s.secretStore.secrets.Store(cache.ConnKey{ConnectionID: conID, ResourceName: testResourceName}, pushSecret)
+	return pushSecret
 }
 
 func verifySDSSResponse(resp *api.DiscoveryResponse, expectedPrivateKey []byte, expectedCertChain []byte) error {


### PR DESCRIPTION
Explicitly recycle stale connections at the end of the test, instead of relying on periodic recycling. To make sure the stale connection counter is 0. This is to deflake the verification of stale connection counter.
https://github.com/istio/istio/issues/18256
https://github.com/istio/istio/issues/17175

Add waitForSDSReady() to make sure SDS server is up and running at the beginning of tests. Refactoring TestStreamSecretsUpdateFailures, TestStreamSecretsMultiplePush and TestStreamSecretsPush by moving common steps into Setup util methods. This is to avoid secret push failures due to disconnect.
https://github.com/istio/istio/issues/22024