### PR TITLE
fix duplicate ips

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -155,6 +155,8 @@ var (
 				log.Infof("Obtained private IP %v", ipAddrs)
 				if len(role.IPAddresses) == 1 {
 					for _, ip := range ipAddrs {
+						// prevent duplicate ips, the first one must be the pod ip
+						// as we pick the first ip as pod ip in istiod
 						if role.IPAddresses[0] != ip {
 							role.IPAddresses = append(role.IPAddresses, ip)
 						}

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -144,7 +144,6 @@ var (
 				}
 			}
 
-			//Do we need to get IP from the command line or environment?
 			if len(proxyIP) != 0 {
 				role.IPAddresses = append(role.IPAddresses, proxyIP)
 			} else if podIP != nil {
@@ -162,6 +161,8 @@ var (
 				role.IPAddresses = append(role.IPAddresses, "127.0.0.1")
 				role.IPAddresses = append(role.IPAddresses, "::1")
 			}
+
+			role.IPAddresses = dedupeStrings(role.IPAddresses)
 
 			// Check if proxy runs in ipv4 or ipv6 environment to set Envoy's
 			// operational parameters correctly.


### PR DESCRIPTION

Without this, i have seen `2020-03-16T02:48:08.352325Z	info	Proxy role: &model.Proxy{ClusterID:"", Type:"sidecar", IPAddresses:[]string{"10.244.0.53", "10.244.0.53", "fe80::78c4:bff:fe2b:8378"}, ID:"productpage-v1-85b9bf9cd7-trfvx.istio-bookinfo-1-40038", Locality:(*envoy_api_v2_core.Locality)(nil), DNSDomain:"istio-bookinfo-1-40038.svc.cluster.local", ConfigNamespace:"", Metadata:(*model.NodeMetadata)(nil), SidecarScope:(*model.SidecarScope)(nil), MergedGateway:(*model.MergedGateway)(nil), ServiceInstances:[]*model.ServiceInstance(nil), IstioVersion:(*model.IstioVersion)(nil), ipv6Support:false, ipv4Support:false}
2020-03-16T02:48:08.352332Z	info	JWT policy is third-party-jwt`