### PR TITLE
Remove legacy 15011 listener for Pilot

### DIFF
--- a/manifests/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/istio-control/istio-discovery/files/gen-istio.yaml
@@ -981,7 +981,6 @@ spec:
           - --log_output_level=default:info
           - --domain
           - cluster.local
-          - --secureGrpcAddr=:15011
           - --trust-domain=cluster.local
           - --keepaliveMaxServerConnectionAge
           - "30m"

--- a/manifests/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/istio-control/istio-discovery/templates/deployment.yaml
@@ -80,12 +80,6 @@ spec:
           - "-a"
           - {{ .Release.Namespace }}
 {{- end }}
-
-{{- if and .Values.global.controlPlaneSecurityEnabled }}
-          - --secureGrpcAddr=:15011
-{{- else }}
-          - --secureGrpcAddr=
-{{- end }}
 {{- if .Values.global.trustDomain }}
           - --trust-domain={{ .Values.global.trustDomain }}
 {{- end }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -8409,7 +8409,6 @@ spec:
         - --log_output_level=default:info
         - --domain
         - cluster.local
-        - --secureGrpcAddr=:15011
         - --trust-domain=cluster.local
         - --keepaliveMaxServerConnectionAge
         - 30m

--- a/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/component_hub_tag.golden.yaml
@@ -452,7 +452,6 @@ spec:
         - --log_output_level=default:info
         - --domain
         - cluster.local
-        - --secureGrpcAddr=:15011
         - --trust-domain=cluster.local
         - --keepaliveMaxServerConnectionAge
         - 30m

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output.golden.yaml
@@ -63,7 +63,6 @@ spec:
         - --log_output_level=default:info
         - --domain
         - cluster.local
-        - --secureGrpcAddr=:15011
         - --trust-domain=cluster.local
         - --keepaliveMaxServerConnectionAge
         - 30m

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
@@ -6535,7 +6535,6 @@ spec:
         - --log_output_level=default:info
         - --domain
         - cluster.local
-        - --secureGrpcAddr=:15011
         - --trust-domain=cluster.local
         - --keepaliveMaxServerConnectionAge
         - 30m

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_override_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_override_values.golden.yaml
@@ -63,7 +63,6 @@ spec:
         - --log_output_level=default:info
         - --domain
         - cluster.local
-        - --secureGrpcAddr=:15011
         - --trust-domain=cluster.local
         - --keepaliveMaxServerConnectionAge
         - 30m

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -254,7 +254,6 @@ spec:
         - --log_output_level=default:info
         - --domain
         - cluster.local
-        - --secureGrpcAddr=:15011
         - --trust-domain=cluster.local
         - --keepaliveMaxServerConnectionAge
         - 30m

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.golden.yaml
@@ -63,7 +63,6 @@ spec:
         - --log_output_level=default:info
         - --domain
         - cluster.local
-        - --secureGrpcAddr=:15011
         - --trust-domain=cluster.local
         - --keepaliveMaxServerConnectionAge
         - 30m

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_kubernetes.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_kubernetes.golden.yaml
@@ -63,7 +63,6 @@ spec:
         - --log_output_level=default:info
         - --domain
         - cluster.local
-        - --secureGrpcAddr=:15011
         - --trust-domain=cluster.local
         - --keepaliveMaxServerConnectionAge
         - 60m

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_values.golden.yaml
@@ -63,7 +63,6 @@ spec:
         - --log_output_level=default:info
         - --domain
         - cluster.local
-        - --secureGrpcAddr=:15011
         - --trust-domain=cluster.local
         - --keepaliveMaxServerConnectionAge
         - 30m

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -17912,7 +17912,6 @@ spec:
           - --log_output_level=default:info
           - --domain
           - cluster.local
-          - --secureGrpcAddr=:15011
           - --trust-domain=cluster.local
           - --keepaliveMaxServerConnectionAge
           - "30m"
@@ -19949,12 +19948,6 @@ spec:
 {{- if .Values.global.oneNamespace }}
           - "-a"
           - {{ .Release.Namespace }}
-{{- end }}
-
-{{- if and .Values.global.controlPlaneSecurityEnabled }}
-          - --secureGrpcAddr=:15011
-{{- else }}
-          - --secureGrpcAddr=
 {{- end }}
 {{- if .Values.global.trustDomain }}
           - --trust-domain={{ .Values.global.trustDomain }}

--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -161,8 +161,6 @@ func init() {
 		"Injection and validation service HTTPS address")
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.DiscoveryOptions.GrpcAddr, "grpcAddr", ":15010",
 		"Discovery service grpc address")
-	discoveryCmd.PersistentFlags().StringVar(&serverArgs.DiscoveryOptions.SecureGrpcAddr, "secureGrpcAddr", "",
-		"Discovery service grpc address, with https")
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.DiscoveryOptions.MonitoringAddr, "monitoringAddr", ":15014",
 		"HTTP address to use for pilot's self-monitoring information")
 	discoveryCmd.PersistentFlags().BoolVar(&serverArgs.DiscoveryOptions.EnableProfiling, "profile", true,

--- a/pilot/pkg/bootstrap/options.go
+++ b/pilot/pkg/bootstrap/options.go
@@ -100,11 +100,6 @@ type DiscoveryServiceOptions struct {
 	// a port number is automatically chosen.
 	GrpcAddr string
 
-	// The listening address for secure GRPC. If the port in the address is empty or "0" (as in "127.0.0.1:" or "[::1]:0")
-	// a port number is automatically chosen.
-	// "" means disabling secure GRPC, used in test.
-	SecureGrpcAddr string
-
 	// The listening address for the monitoring port. If the port in the address is empty or "0" (as in "127.0.0.1:" or "[::1]:0")
 	// a port number is automatically chosen.
 	MonitoringAddr string

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -19,13 +19,10 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
-	"os"
 	"path"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -37,16 +34,13 @@ import (
 
 	"istio.io/istio/pilot/pkg/leaderelection"
 
-	"istio.io/istio/pkg/jwt"
-	"istio.io/istio/pkg/spiffe"
-	"istio.io/istio/security/pkg/pki/util"
-
 	middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	prom "github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
+	"istio.io/istio/pkg/jwt"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -116,7 +110,6 @@ type startFunc func(stop <-chan struct{}) error
 
 // Server contains the runtime configuration for the Pilot discovery service.
 type Server struct {
-	SecureGRPCListeningAddr net.Addr
 	MonitorListeningAddr    net.Addr
 
 	// TODO(nmittler): Consider alternatives to exposing these directly
@@ -478,56 +471,6 @@ func (s *Server) initDiscoveryService(args *PilotArgs) error {
 	}
 	s.GRPCListener = grpcListener
 
-	// run grpc server using the Citadel secrets. New installer uses a sidecar for this.
-	// Will be deprecated once Istiod mode is stable.
-	if args.DiscoveryOptions.SecureGrpcAddr != "" {
-		// create secure grpc server
-		if err := s.initSecureGrpcServer(args.KeepaliveOptions, args.Namespace, args.ServiceAccountName); err != nil {
-			return fmt.Errorf("secure grpc server: %s", err)
-		}
-		// create secure grpc listener
-		secureGrpcListener, err := net.Listen("tcp", args.DiscoveryOptions.SecureGrpcAddr)
-		if err != nil {
-			return err
-		}
-		s.SecureGRPCListeningAddr = secureGrpcListener.Addr()
-
-		s.addStartFunc(func(stop <-chan struct{}) error {
-			go func() {
-				if !s.waitForCacheSync(stop) {
-					return
-				}
-
-				log.Infof("starting discovery service at secure grpc=%s", secureGrpcListener.Addr())
-				go func() {
-					// This seems the only way to call setupHTTP2 - it may also be possible to set NextProto
-					// on a listener
-					err := s.secureHTTPServer.ServeTLS(secureGrpcListener, "", "")
-					msg := fmt.Sprintf("Stopped listening on %s", secureGrpcListener.Addr().String())
-					select {
-					case <-stop:
-						log.Info(msg)
-					default:
-						panic(fmt.Sprintf("%s due to error: %v", msg, err))
-					}
-				}()
-				go func() {
-					<-stop
-					if args.ForceStop {
-						s.grpcServer.Stop()
-					} else {
-						s.grpcServer.GracefulStop()
-					}
-					ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-					defer cancel()
-					_ = s.secureHTTPServer.Shutdown(ctx)
-					s.secureGRPCServer.Stop()
-				}()
-			}()
-			return nil
-		})
-	}
-
 	return nil
 }
 
@@ -563,110 +506,6 @@ func (s *Server) initGrpcServer(options *istiokeepalive.Options) {
 	grpcOptions := s.grpcServerOptions(options)
 	s.grpcServer = grpc.NewServer(grpcOptions...)
 	s.EnvoyXdsServer.Register(s.grpcServer)
-}
-
-func (s *Server) generateKeyAndCert(saName string, saNamespace string) ([]byte, []byte, error) {
-	id := spiffe.MustGenSpiffeURI(saNamespace, saName)
-
-	options := util.CertOptions{
-		Host:       id,
-		RSAKeySize: 2048,
-	}
-
-	csrPEM, keyPEM, err := util.GenCSR(options)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	certChainPEM := s.ca.GetCAKeyCertBundle().GetCertChainPem()
-	certPEM, signErr := s.ca.Sign(csrPEM, strings.Split(id, ","), time.Hour, false)
-	if signErr != nil {
-		return nil, nil, fmt.Errorf("CSR signing error (%v)", signErr)
-	}
-	certPEM = append(certPEM, certChainPEM...)
-
-	return certPEM, keyPEM, nil
-}
-
-func (s *Server) getSpiffeeCert(namespace, san string) (*tls.Certificate, *credentials.TransportCredentials, string, error) {
-	certDir := features.CertDir
-	if certDir == "" {
-		certDir = PilotCertDir
-	}
-	ca := path.Join(certDir, constants.RootCertFilename)
-	key := path.Join(certDir, constants.KeyFilename)
-	cert := path.Join(certDir, constants.CertChainFilename)
-
-	// Use existing file mounted certificates
-	if fileExists(ca) && fileExists(key) && fileExists(cert) {
-		log.Infof("Using file mounted certificates")
-		tlsCreds, err := credentials.NewServerTLSFromFile(cert, key)
-		if err != nil {
-			return nil, nil, "", fmt.Errorf("failed to load %s and %s: %v", cert, key, err)
-		}
-
-		// TODO: parse the file to determine expiration date. Restart listener before expiration
-		certificate, err := tls.LoadX509KeyPair(cert, key)
-		if err != nil {
-			return nil, nil, "", fmt.Errorf("failed to load certificate: %v", err)
-		}
-		return &certificate, &tlsCreds, ca, nil
-	}
-	log.Infof("Generating a certificate for secure gRPC (%s/%s)", san, namespace)
-
-	genCert, genKey, err := s.generateKeyAndCert(san, namespace)
-	if err != nil {
-		return nil, nil, "", fmt.Errorf("failed to generate certificate: %v", err)
-	}
-
-	certificate, err := tls.X509KeyPair(genCert, genKey)
-	if err != nil {
-		return nil, nil, "", fmt.Errorf("failed to load certificate: %v", err)
-	}
-	tlsCreds := credentials.NewServerTLSFromCert(&certificate)
-	return &certificate, &tlsCreds, s.caBundlePath, nil
-}
-
-// initialize secureGRPCServer
-func (s *Server) initSecureGrpcServer(options *istiokeepalive.Options, namespace string, san string) error {
-	certificate, tlsCreds, ca, err := s.getSpiffeeCert(namespace, san)
-	if err != nil {
-		return fmt.Errorf("failed to get certs for secure listener: %v", err)
-	}
-	caCert, err := ioutil.ReadFile(ca)
-	if err != nil {
-		caCert = s.ca.GetCAKeyCertBundle().GetRootCertPem()
-	}
-	caCertPool := x509.NewCertPool()
-	caCertPool.AppendCertsFromPEM(caCert)
-
-	opts := s.grpcServerOptions(options)
-	opts = append(opts, grpc.Creds(*tlsCreds))
-	s.secureGRPCServer = grpc.NewServer(opts...)
-	s.EnvoyXdsServer.Register(s.secureGRPCServer)
-	s.secureHTTPServer = &http.Server{
-		TLSConfig: &tls.Config{
-			Certificates: []tls.Certificate{*certificate},
-			VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
-				// For now accept any certs - pilot is not authenticating the caller, TLS used for
-				// privacy
-				return nil
-			},
-			NextProtos: []string{"h2", "http/1.1"},
-			ClientAuth: tls.RequireAndVerifyClientCert,
-			ClientCAs:  caCertPool,
-		},
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.ProtoMajor == 2 && strings.HasPrefix(
-				r.Header.Get("Content-Type"), "application/grpc") {
-				s.secureGRPCServer.ServeHTTP(w, r)
-			} else {
-				s.mux.ServeHTTP(w, r)
-			}
-		}),
-	}
-
-	return nil
 }
 
 // initialize secureGRPCServer - using DNS certs
@@ -880,12 +719,3 @@ func (s *Server) initLeaderElection(args *PilotArgs) {
 	}
 }
 
-func fileExists(path string) bool {
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return false
-	} else if err != nil {
-		log.Errorf("error checking file path %v", path)
-		return false
-	}
-	return true
-}

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -40,6 +40,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
+
 	"istio.io/istio/pkg/jwt"
 
 	"k8s.io/client-go/kubernetes"
@@ -110,7 +111,7 @@ type startFunc func(stop <-chan struct{}) error
 
 // Server contains the runtime configuration for the Pilot discovery service.
 type Server struct {
-	MonitorListeningAddr    net.Addr
+	MonitorListeningAddr net.Addr
 
 	// TODO(nmittler): Consider alternatives to exposing these directly
 	EnvoyXdsServer *envoyv2.DiscoveryServer
@@ -125,8 +126,6 @@ type Server struct {
 	httpsServer         *http.Server // webhooks
 	httpsReadyClient    *http.Client
 	grpcServer          *grpc.Server
-	secureHTTPServer    *http.Server
-	secureGRPCServer    *grpc.Server
 	secureGRPCServerDNS *grpc.Server
 	mux                 *http.ServeMux // debug
 	httpsMux            *http.ServeMux // webhooks
@@ -718,4 +717,3 @@ func (s *Server) initLeaderElection(args *PilotArgs) {
 		s.leaderElection = leaderelection.NewLeaderElection(args.Namespace, args.PodName, s.kubeClient)
 	}
 }
-

--- a/pilot/pkg/proxy/envoy/v2/ads_test.go
+++ b/pilot/pkg/proxy/envoy/v2/ads_test.go
@@ -119,25 +119,6 @@ func TestAdsReconnect(t *testing.T) {
 	t.Log("Received ", m)
 }
 
-func TestTLS(t *testing.T) {
-	_, tearDown := initLocalPilotTestEnv(t)
-	defer tearDown()
-
-	edsstr, cancel, err := connectADSS(util.MockPilotSecureAddr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cancel()
-	err = sendCDSReq(sidecarID(app3Ip, "app3"), edsstr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = adsReceive(edsstr, 3*time.Second)
-	if err != nil {
-		t.Error("Failed to receive with TLS connection ", err)
-	}
-}
-
 func TestAdsClusterUpdate(t *testing.T) {
 	_, tearDown := initLocalPilotTestEnv(t)
 	defer tearDown()

--- a/pilot/pkg/proxy/envoy/v2/init_test.go
+++ b/pilot/pkg/proxy/envoy/v2/init_test.go
@@ -33,6 +33,7 @@ import (
 	ads "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
+
 	"istio.io/istio/tests/util"
 )
 

--- a/pilot/pkg/proxy/envoy/v2/init_test.go
+++ b/pilot/pkg/proxy/envoy/v2/init_test.go
@@ -15,12 +15,9 @@ package v2_test
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"time"
 
@@ -36,10 +33,6 @@ import (
 	ads "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-
-	"istio.io/istio/pkg/config/constants"
-	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/tests/util"
 )
 
@@ -80,52 +73,6 @@ func connectADS(url string) (ads.AggregatedDiscoveryService_StreamAggregatedReso
 		return nil, nil, fmt.Errorf("stream resources failed: %s", err)
 	}
 
-	return edsstr, func() {
-		_ = edsstr.CloseSend()
-		_ = conn.Close()
-	}, nil
-}
-
-func connectADSS(url string) (ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient, util.TearDownFunc, error) {
-	certDir := env.IstioSrc + "/tests/testdata/certs/default/"
-
-	clientCert, err := tls.LoadX509KeyPair(certDir+constants.CertChainFilename, certDir+constants.KeyFilename)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed loading clients certs: %s", err)
-	}
-
-	serverCABytes, err := ioutil.ReadFile(certDir + constants.RootCertFilename)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed loading CA certs: %s", err)
-	}
-	serverCAs := x509.NewCertPool()
-	if ok := serverCAs.AppendCertsFromPEM(serverCABytes); !ok {
-		return nil, nil, fmt.Errorf("failed adding CA certs to pool: %s", err)
-	}
-
-	tlsCfg := &tls.Config{
-		Certificates: []tls.Certificate{clientCert},
-		RootCAs:      serverCAs,
-		ServerName:   "istio-pilot.istio-system.svc",
-	}
-
-	creds := credentials.NewTLS(tlsCfg)
-
-	opts := []grpc.DialOption{
-		// Verify Pilot cert and service account
-		grpc.WithTransportCredentials(creds),
-		grpc.WithBlock(),
-	}
-	conn, err := grpc.Dial(url, opts...)
-	if err != nil {
-		return nil, nil, fmt.Errorf("GRPC dial failed: %s", err)
-	}
-
-	xds := ads.NewAggregatedDiscoveryServiceClient(conn)
-	edsstr, err := xds.StreamAggregatedResources(context.Background())
-	if err != nil {
-		return nil, nil, fmt.Errorf("stream resources failed: %s", err)
-	}
 	return edsstr, func() {
 		_ = edsstr.CloseSend()
 		_ = conn.Close()

--- a/pkg/test/framework/components/pilot/native.go
+++ b/pkg/test/framework/components/pilot/native.go
@@ -85,7 +85,6 @@ func newNative(ctx resource.Context, cfg Config) (Instance, error) {
 		HTTPAddr:       ":0",
 		MonitoringAddr: ":0",
 		GrpcAddr:       ":0",
-		SecureGrpcAddr: ":0",
 	}
 
 	tmpMesh := mesh.DefaultMeshConfig()

--- a/tests/util/pilot_server.go
+++ b/tests/util/pilot_server.go
@@ -36,9 +36,6 @@ var (
 	// MockPilotGrpcAddr is the address to be used for grpc connections.
 	MockPilotGrpcAddr string
 
-	// MockPilotSecureAddr is the address to be used for secure grpc connections.
-	MockPilotSecureAddr string
-
 	// MockPilotHTTPPort is the dynamic port for pilot http
 	MockPilotHTTPPort int
 
@@ -84,7 +81,6 @@ func setup(additionalArgs ...func(*bootstrap.PilotArgs)) (*bootstrap.Server, Tea
 		p.DiscoveryOptions = bootstrap.DiscoveryServiceOptions{
 			HTTPAddr:        httpAddr,
 			GrpcAddr:        ":0",
-			SecureGrpcAddr:  ":0",
 			EnableProfiling: true,
 		}
 		//TODO: start mixer first, get its address
@@ -133,12 +129,6 @@ func setup(additionalArgs ...func(*bootstrap.PilotArgs)) (*bootstrap.Server, Tea
 	}
 	MockPilotGrpcAddr = "localhost:" + port
 	MockPilotGrpcPort, _ = strconv.Atoi(port)
-
-	_, port, err = net.SplitHostPort(s.SecureGRPCListeningAddr.String())
-	if err != nil {
-		return nil, nil, err
-	}
-	MockPilotSecureAddr = "localhost:" + port
 
 	// Wait a bit for the server to come up.
 	err = wait.Poll(500*time.Millisecond, 5*time.Second, func() (bool, error) {


### PR DESCRIPTION
This was around for legacy purposes only to support 1.4 -> 1.5 upgrade and is no longer needed