### PR TITLE
Deflake analyzing distributor tests

### DIFF
--- a/galley/pkg/config/processing/snapshotter/analyzingdistributor_test.go
+++ b/galley/pkg/config/processing/snapshotter/analyzingdistributor_test.go
@@ -37,6 +37,9 @@ import (
 type updaterMock struct {
 	m        sync.RWMutex
 	messages diag.Messages
+
+	waitCh      chan struct{}
+	waitTimeout time.Duration
 }
 
 // Update implements StatusUpdater
@@ -44,13 +47,36 @@ func (u *updaterMock) Update(messages diag.Messages) {
 	u.m.Lock()
 	defer u.m.Unlock()
 	u.messages = messages
+
+	if u.waitCh != nil {
+		close(u.waitCh)
+		u.waitCh = nil
+	}
 }
 
 func (u *updaterMock) getMessages() diag.Messages {
-	u.m.RLock()
-	messages := u.messages
-	u.m.RUnlock()
-	return messages
+	u.m.Lock()
+	ms := u.messages
+	if ms != nil {
+		u.m.Unlock()
+		return ms
+	}
+
+	if u.waitCh == nil {
+		u.waitCh = make(chan struct{})
+	}
+	ch := u.waitCh
+	u.m.Unlock()
+
+	select {
+	case <-time.After(u.waitTimeout):
+		return nil
+	case <-ch:
+		u.m.RLock()
+		m := u.messages
+		u.m.RUnlock()
+		return m
+	}
 }
 
 type analyzerMock struct {
@@ -161,10 +187,9 @@ func TestAnalyzeAndDistributeSnapshots(t *testing.T) {
 }
 
 func TestAnalyzeNamespaceMessageHasNoResource(t *testing.T) {
-	t.Skip("https://github.com/istio/istio/issues/20936")
 	g := NewGomegaWithT(t)
 
-	u := &updaterMock{}
+	u := &updaterMock{waitTimeout: 1 * time.Second}
 	a := &analyzerMock{
 		collectionToAccess: basicmeta.K8SCollection1.Name(),
 		resourcesToReport: []*resource.Instance{
@@ -192,10 +217,9 @@ func TestAnalyzeNamespaceMessageHasNoResource(t *testing.T) {
 }
 
 func TestAnalyzeNamespaceMessageHasOriginWithNoNamespace(t *testing.T) {
-	t.Skip("https://github.com/istio/istio/issues/20936")
 	g := NewGomegaWithT(t)
 
-	u := &updaterMock{}
+	u := &updaterMock{waitTimeout: 1 * time.Second}
 	a := &analyzerMock{
 		collectionToAccess: basicmeta.K8SCollection1.Name(),
 		resourcesToReport: []*resource.Instance{
@@ -231,7 +255,7 @@ func TestAnalyzeNamespaceMessageHasOriginWithNoNamespace(t *testing.T) {
 func TestAnalyzeSortsMessages(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	u := &updaterMock{}
+	u := &updaterMock{waitTimeout: 1 * time.Second}
 	r1 := &resource.Instance{
 		Origin: &rt.Origin{
 			Collection: basicmeta.K8SCollection1.Name(),
@@ -265,7 +289,6 @@ func TestAnalyzeSortsMessages(t *testing.T) {
 	sDefault := getTestSnapshot()
 
 	ad.Distribute(snapshots.Default, sDefault)
-	time.Sleep(1 * time.Second)
 
 	g.Eventually(a.getAnalyzeCalls).Should(ConsistOf(sDefault))
 
@@ -277,7 +300,7 @@ func TestAnalyzeSortsMessages(t *testing.T) {
 func TestAnalyzeSuppressesMessages(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	u := &updaterMock{}
+	u := &updaterMock{waitTimeout: 1 * time.Second}
 	r1 := &resource.Instance{
 		Origin: &rt.Origin{
 			Collection: basicmeta.K8SCollection1.Name(),
@@ -318,7 +341,6 @@ func TestAnalyzeSuppressesMessages(t *testing.T) {
 	sDefault := getTestSnapshot()
 
 	ad.Distribute(snapshots.Default, sDefault)
-	time.Sleep(1 * time.Second)
 
 	g.Eventually(a.getAnalyzeCalls).Should(ConsistOf(sDefault))
 
@@ -329,7 +351,7 @@ func TestAnalyzeSuppressesMessages(t *testing.T) {
 func TestAnalyzeSuppressesMessagesWithWildcards(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	u := &updaterMock{}
+	u := &updaterMock{waitTimeout: 1 * time.Second}
 	// r1 and r2 have the same prefix, but r3 does not
 	r1 := &resource.Instance{
 		Origin: &rt.Origin{
@@ -377,7 +399,6 @@ func TestAnalyzeSuppressesMessagesWithWildcards(t *testing.T) {
 	sDefault := getTestSnapshot()
 
 	ad.Distribute(snapshots.Default, sDefault)
-	time.Sleep(1 * time.Second)
 
 	g.Eventually(a.getAnalyzeCalls).Should(ConsistOf(sDefault))
 
@@ -386,7 +407,6 @@ func TestAnalyzeSuppressesMessagesWithWildcards(t *testing.T) {
 }
 
 func TestAnalyzeSuppressesMessagesWhenResourceIsAnnotated(t *testing.T) {
-	t.Skip("https://github.com/istio/istio/issues/20936")
 	// AnalyzerMock always throws IST0001.
 	tests := map[string]struct {
 		annotations  map[string]string
@@ -433,7 +453,7 @@ func TestAnalyzeSuppressesMessagesWhenResourceIsAnnotated(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
-			u := &updaterMock{}
+			u := &updaterMock{waitTimeout: 1 * time.Second}
 			r := &resource.Instance{
 				Metadata: resource.Metadata{
 					Annotations: tc.annotations,


### PR DESCRIPTION
Please provide a description for what this PR is for.

fix https://github.com/istio/istio/issues/20936
Making `getMessages()` be blocking with a wait timeout so that assertion can get the messages even if it is called before `Update()` is called.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure
