### PR TITLE
Update proxy to pickup fixes for ISTIO-SECURITY-2020-003.

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,7 +4,7 @@
     "name": "PROXY_REPO_SHA",
     "repoName": "proxy",
     "file": "",
-    "lastStableSHA": "5e9c866f7e7198d5119347b3d06dceb6e29f4715"
+    "lastStableSHA": "aa9f6a9eadad401d8630be220af2ee8a033a2fdb"
   },
   {
     "_comment": "",


### PR DESCRIPTION
Once this merges all the fixes for ISTIO-SECURITY-2020-003 will be in and we can ship a 1.4.7 if we need to.