### PR TITLE
Support OpenID discovery for RequestAuthentication (#22049)

### DIFF
--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -105,6 +105,9 @@ func initAuthenticationPolicies(env *Environment) (*AuthenticationPolicies, erro
 
 func (policy *AuthenticationPolicies) addRequestAuthentication(configs []Config) {
 	for _, config := range configs {
+		reqPolicy := config.Spec.(*v1beta1.RequestAuthentication)
+		// Follow OIDC discovery to resolve JwksURI if need to.
+		JwtKeyResolver.ResolveJwksURI(reqPolicy)
 		policy.requestAuthentications[config.Namespace] =
 			append(policy.requestAuthentications[config.Namespace], config)
 	}

--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -24,6 +24,7 @@ import (
 	securityBeta "istio.io/api/security/v1beta1"
 	selectorpb "istio.io/api/type/v1beta1"
 
+	"istio.io/istio/pilot/pkg/model/test"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/collections"
@@ -591,6 +592,183 @@ func TestGetPoliciesForWorkloadWithoutMeshPeerAuthn(t *testing.T) {
 	}
 }
 
+func TestGetPoliciesForWorkloadWithJwksResolver(t *testing.T) {
+	ms, err := test.StartNewServer()
+	defer ms.Stop()
+	if err != nil {
+		t.Fatal("failed to start a mock server")
+	}
+
+	mockCertURL := ms.URL + "/oauth2/v3/certs"
+
+	policies := getTestAuthenticationPolicies(createNonTrivialRequestAuthnTestConfigs(ms.URL), t)
+
+	cases := []struct {
+		name              string
+		workloadNamespace string
+		workloadLabels    labels.Collection
+		wantRequestAuthn  []*Config
+	}{
+		{
+			name:              "single hit",
+			workloadNamespace: "foo",
+			workloadLabels:    labels.Collection{},
+			wantRequestAuthn: []*Config{
+				{
+					ConfigMeta: ConfigMeta{
+						Type:      requestAuthenticationGvk.Kind,
+						Version:   requestAuthenticationGvk.Version,
+						Group:     requestAuthenticationGvk.Group,
+						Name:      "default",
+						Namespace: rootNamespace,
+					},
+					Spec: &securityBeta.RequestAuthentication{
+						JwtRules: []*securityBeta.JWTRule{
+							{
+								Issuer:  ms.URL,
+								JwksUri: mockCertURL,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:              "double hit",
+			workloadNamespace: "foo",
+			workloadLabels:    labels.Collection{{"app": "httpbin"}},
+			wantRequestAuthn: []*Config{
+				{
+					ConfigMeta: ConfigMeta{
+						Type:      requestAuthenticationGvk.Kind,
+						Version:   requestAuthenticationGvk.Version,
+						Group:     requestAuthenticationGvk.Group,
+						Name:      "default",
+						Namespace: rootNamespace,
+					},
+					Spec: &securityBeta.RequestAuthentication{
+						JwtRules: []*securityBeta.JWTRule{
+							{
+								Issuer:  ms.URL,
+								JwksUri: mockCertURL,
+							},
+						},
+					},
+				},
+				{
+					ConfigMeta: ConfigMeta{
+						Type:      requestAuthenticationGvk.Kind,
+						Version:   requestAuthenticationGvk.Version,
+						Group:     requestAuthenticationGvk.Group,
+						Name:      "global-with-selector",
+						Namespace: rootNamespace,
+					},
+					Spec: &securityBeta.RequestAuthentication{
+						Selector: &selectorpb.WorkloadSelector{
+							MatchLabels: map[string]string{
+								"app": "httpbin",
+							},
+						},
+						JwtRules: []*securityBeta.JWTRule{
+							{
+								Issuer:  ms.URL,
+								JwksUri: mockCertURL,
+							},
+							{
+								Issuer: "bad-issuer",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:              "tripple hit",
+			workloadNamespace: "foo",
+			workloadLabels:    labels.Collection{{"app": "httpbin", "version": "v1"}},
+			wantRequestAuthn: []*Config{
+				{
+					ConfigMeta: ConfigMeta{
+						Type:      requestAuthenticationGvk.Kind,
+						Version:   requestAuthenticationGvk.Version,
+						Group:     requestAuthenticationGvk.Group,
+						Name:      "with-selector",
+						Namespace: "foo",
+					},
+					Spec: &securityBeta.RequestAuthentication{
+						Selector: &selectorpb.WorkloadSelector{
+							MatchLabels: map[string]string{
+								"app":     "httpbin",
+								"version": "v1",
+							},
+						},
+						JwtRules: []*securityBeta.JWTRule{
+							{
+								Issuer:  "issuer-with-jwks-uri",
+								JwksUri: "example.com",
+							},
+							{
+								Issuer: "issuer-with-jwks",
+								Jwks:   "deadbeef",
+							},
+						},
+					},
+				},
+				{
+					ConfigMeta: ConfigMeta{
+						Type:      requestAuthenticationGvk.Kind,
+						Version:   requestAuthenticationGvk.Version,
+						Group:     requestAuthenticationGvk.Group,
+						Name:      "default",
+						Namespace: rootNamespace,
+					},
+					Spec: &securityBeta.RequestAuthentication{
+						JwtRules: []*securityBeta.JWTRule{
+							{
+								Issuer:  ms.URL,
+								JwksUri: mockCertURL,
+							},
+						},
+					},
+				},
+				{
+					ConfigMeta: ConfigMeta{
+						Type:      requestAuthenticationGvk.Kind,
+						Version:   requestAuthenticationGvk.Version,
+						Group:     requestAuthenticationGvk.Group,
+						Name:      "global-with-selector",
+						Namespace: rootNamespace,
+					},
+					Spec: &securityBeta.RequestAuthentication{
+						Selector: &selectorpb.WorkloadSelector{
+							MatchLabels: map[string]string{
+								"app": "httpbin",
+							},
+						},
+						JwtRules: []*securityBeta.JWTRule{
+							{
+								Issuer:  ms.URL,
+								JwksUri: mockCertURL,
+							},
+							{
+								Issuer: "bad-issuer",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := policies.GetJwtPoliciesForWorkload(tc.workloadNamespace, tc.workloadLabels); !reflect.DeepEqual(tc.wantRequestAuthn, got) {
+				t.Fatalf("want %+v\n, but got %+v\n", printConfigs(tc.wantRequestAuthn), printConfigs(got))
+			}
+		})
+	}
+}
+
 func getTestAuthenticationPolicies(configs []*Config, t *testing.T) *AuthenticationPolicies {
 	configStore := newFakeStore()
 	for _, cfg := range configs {
@@ -687,6 +865,49 @@ func createTestConfigs(withMeshPeerAuthn bool) []*Config {
 			createTestPeerAuthenticationResource("ignored-another-newer", rootNamespace, baseTimestamp.Add(time.Second),
 				nil, securityBeta.PeerAuthentication_MutualTLS_UNSET))
 	}
+
+	return configs
+}
+
+func addJwtRule(issuer, jwksURI, jwks string, config *Config) {
+	spec := config.Spec.(*securityBeta.RequestAuthentication)
+	if spec.JwtRules == nil {
+		spec.JwtRules = make([]*securityBeta.JWTRule, 0)
+	}
+	spec.JwtRules = append(spec.JwtRules, &securityBeta.JWTRule{
+		Issuer:  issuer,
+		JwksUri: jwksURI,
+		Jwks:    jwks,
+	})
+}
+
+func createNonTrivialRequestAuthnTestConfigs(issuer string) []*Config {
+	configs := make([]*Config, 0)
+
+	globalCfg := createTestRequestAuthenticationResource("default", rootNamespace, nil)
+	addJwtRule(issuer, "", "", globalCfg)
+	configs = append(configs, globalCfg)
+
+	httpbinCfg :=
+		createTestRequestAuthenticationResource("global-with-selector", rootNamespace, &selectorpb.WorkloadSelector{
+			MatchLabels: map[string]string{
+				"app": "httpbin",
+			},
+		})
+
+	addJwtRule(issuer, "", "", httpbinCfg)
+	addJwtRule("bad-issuer", "", "", httpbinCfg)
+	configs = append(configs, httpbinCfg)
+
+	httpbinCfgV1 := createTestRequestAuthenticationResource("with-selector", "foo", &selectorpb.WorkloadSelector{
+		MatchLabels: map[string]string{
+			"app":     "httpbin",
+			"version": "v1",
+		},
+	})
+	addJwtRule("issuer-with-jwks-uri", "example.com", "", httpbinCfgV1)
+	addJwtRule("issuer-with-jwks", "", "deadbeef", httpbinCfgV1)
+	configs = append(configs, httpbinCfgV1)
 
 	return configs
 }

--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	authn "istio.io/api/authentication/v1alpha1"
+	"istio.io/api/security/v1beta1"
 	"istio.io/pkg/cache"
 	"istio.io/pkg/monitoring"
 )
@@ -223,6 +224,19 @@ func (r *JwksResolver) SetAuthenticationPolicyJwksURIs(policy *authn.Policy) err
 	}
 
 	return nil
+}
+
+// ResolveJwksURI sets jwks_uri through openID discovery if it's not set in request authentication policy.
+func (r *JwksResolver) ResolveJwksURI(policy *v1beta1.RequestAuthentication) {
+	for _, rule := range policy.JwtRules {
+		if rule.JwksUri == "" && rule.Jwks == "" {
+			if uri, err := r.resolveJwksURIUsingOpenID(rule.Issuer); err == nil {
+				rule.JwksUri = uri
+			} else {
+				log.Warnf("Failed to get jwks_uri for issuer %q: %v", rule.Issuer, err)
+			}
+		}
+	}
 }
 
 // GetPublicKey gets JWT public key and cache the key for future use.

--- a/pilot/pkg/model/jwks_resolver_test.go
+++ b/pilot/pkg/model/jwks_resolver_test.go
@@ -15,6 +15,7 @@
 package model
 
 import (
+	"reflect"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -22,6 +23,7 @@ import (
 	"go.opencensus.io/stats/view"
 
 	authn "istio.io/api/authentication/v1alpha1"
+	"istio.io/api/security/v1beta1"
 	"istio.io/istio/pilot/pkg/model/test"
 )
 
@@ -171,6 +173,106 @@ func TestSetAuthenticationPolicyJwksURIs(t *testing.T) {
 		if want := c.expected; got != want {
 			t.Errorf("setAuthenticationPolicyJwksURIs(%+v): expected (%s), got (%s)", c.in, c.expected, c.in)
 		}
+	}
+}
+
+func TestResolveJwksURI(t *testing.T) {
+	r := NewJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval)
+
+	ms, err := test.StartNewServer()
+	defer ms.Stop()
+	if err != nil {
+		t.Fatal("failed to start a mock server")
+	}
+
+	mockCertURL := ms.URL + "/oauth2/v3/certs"
+
+	cases := []struct {
+		name     string
+		in       *v1beta1.RequestAuthentication
+		expected []string
+	}{
+		{
+			name: "single jwt",
+			in: &v1beta1.RequestAuthentication{
+				JwtRules: []*v1beta1.JWTRule{
+					{
+						Issuer: ms.URL,
+					},
+				},
+			},
+			expected: []string{mockCertURL},
+		},
+		{
+			name: "duplicate single jwt",
+			in: &v1beta1.RequestAuthentication{
+				JwtRules: []*v1beta1.JWTRule{
+					{
+						Issuer: ms.URL,
+					},
+					{
+						Issuer: ms.URL,
+					},
+				},
+			},
+			expected: []string{mockCertURL, mockCertURL},
+		},
+		{
+			name: "bad one",
+			in: &v1beta1.RequestAuthentication{
+				JwtRules: []*v1beta1.JWTRule{
+					{
+						Issuer: "bad-one",
+					},
+					{
+						Issuer: ms.URL,
+					},
+				},
+			},
+			expected: []string{"", mockCertURL},
+		},
+		{
+			name: "JwksURI provided",
+			in: &v1beta1.RequestAuthentication{
+				JwtRules: []*v1beta1.JWTRule{
+					{
+						Issuer:  "jwks URI provided",
+						JwksUri: "example.com",
+					},
+					{
+						Issuer: ms.URL,
+					},
+				},
+			},
+			expected: []string{"example.com", mockCertURL},
+		},
+		{
+			name: "Jwks provided",
+			in: &v1beta1.RequestAuthentication{
+				JwtRules: []*v1beta1.JWTRule{
+					{
+						Issuer: "jwks provided",
+						Jwks:   "deadbeef",
+					},
+					{
+						Issuer: ms.URL,
+					},
+				},
+			},
+			expected: []string{"", mockCertURL},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r.ResolveJwksURI(c.in)
+			got := make([]string, 0, len(c.in.JwtRules))
+			for _, rule := range c.in.JwtRules {
+				got = append(got, rule.JwksUri)
+			}
+			if !reflect.DeepEqual(c.expected, got) {
+				t.Errorf("want %v, got %v", c.expected, c.in)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
git cherry-pick 8f7dd02c146fa6e8969296a498ef5991691b6669

* Resolve jwks URI for request authentication API

* Lint

* Lint