### PR TITLE
Support metrics in echo server

### DIFF
--- a/pkg/test/echo/cmd/server/main.go
+++ b/pkg/test/echo/cmd/server/main.go
@@ -30,13 +30,14 @@ import (
 )
 
 var (
-	httpPorts []int
-	grpcPorts []int
-	tcpPorts  []int
-	uds       string
-	version   string
-	crt       string
-	key       string
+	httpPorts   []int
+	grpcPorts   []int
+	tcpPorts    []int
+	metricsPort int
+	uds         string
+	version     string
+	crt         string
+	key         string
 
 	loggingOptions = log.DefaultOptions()
 
@@ -76,6 +77,7 @@ var (
 
 			s := server.New(server.Config{
 				Ports:     ports,
+				Metrics:   metricsPort,
 				TLSCert:   crt,
 				TLSKey:    key,
 				Version:   version,
@@ -109,6 +111,7 @@ func init() {
 	rootCmd.PersistentFlags().IntSliceVar(&httpPorts, "port", []int{8080}, "HTTP/1.1 ports")
 	rootCmd.PersistentFlags().IntSliceVar(&grpcPorts, "grpc", []int{7070}, "GRPC ports")
 	rootCmd.PersistentFlags().IntSliceVar(&tcpPorts, "tcp", []int{9090}, "TCP ports")
+	rootCmd.PersistentFlags().IntVar(&metricsPort, "metrics", 0, "Metrics port")
 	rootCmd.PersistentFlags().StringVar(&uds, "uds", "", "HTTP server on unix domain socket")
 	rootCmd.PersistentFlags().StringVar(&version, "version", "", "Version string")
 	rootCmd.PersistentFlags().StringVar(&crt, "crt", "", "gRPC TLS server-side certificate")

--- a/pkg/test/echo/common/metrics.go
+++ b/pkg/test/echo/common/metrics.go
@@ -1,0 +1,43 @@
+// Copyright 2020 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type EchoMetrics struct {
+	HttpRequests *prometheus.CounterVec
+	GrpcRequests *prometheus.CounterVec
+	TcpRequests  *prometheus.CounterVec
+}
+
+var (
+	Metrics = &EchoMetrics{
+		HttpRequests: promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "istio_echo_http_requests_total",
+			Help: "The number of http requests total",
+		}, []string{"port"}),
+		GrpcRequests: promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "istio_echo_grpc_requests_total",
+			Help: "The number of http requests total",
+		}, []string{"port"}),
+		TcpRequests: promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "istio_echo_tcp_requests_total",
+			Help: "The number of http requests total",
+		}, []string{"port"}),
+	}
+)

--- a/pkg/test/echo/common/metrics.go
+++ b/pkg/test/echo/common/metrics.go
@@ -15,29 +15,33 @@
 package common
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
+	"istio.io/pkg/monitoring"
 )
 
 type EchoMetrics struct {
-	HTTPRequests *prometheus.CounterVec
-	GrpcRequests *prometheus.CounterVec
-	TCPRequests  *prometheus.CounterVec
+	HTTPRequests monitoring.Metric
+	GrpcRequests monitoring.Metric
+	TCPRequests  monitoring.Metric
 }
 
 var (
+	Port    = monitoring.MustCreateLabel("port")
 	Metrics = &EchoMetrics{
-		HTTPRequests: promauto.NewCounterVec(prometheus.CounterOpts{
-			Name: "istio_echo_http_requests_total",
-			Help: "The number of http requests total",
-		}, []string{"port"}),
-		GrpcRequests: promauto.NewCounterVec(prometheus.CounterOpts{
-			Name: "istio_echo_grpc_requests_total",
-			Help: "The number of http requests total",
-		}, []string{"port"}),
-		TCPRequests: promauto.NewCounterVec(prometheus.CounterOpts{
-			Name: "istio_echo_tcp_requests_total",
-			Help: "The number of http requests total",
-		}, []string{"port"}),
+		HTTPRequests: monitoring.NewSum(
+			"istio_echo_http_requests_total",
+			"The number of http requests total",
+		),
+		GrpcRequests: monitoring.NewSum(
+			"istio_echo_grpc_requests_total",
+			"The number of grpc requests total",
+		),
+		TCPRequests: monitoring.NewSum(
+			"istio_echo_tcp_requests_total",
+			"The number of tcp requests total",
+		),
 	}
 )
+
+func init() {
+	monitoring.MustRegister(Metrics.HTTPRequests, Metrics.GrpcRequests, Metrics.TCPRequests)
+}

--- a/pkg/test/echo/common/metrics.go
+++ b/pkg/test/echo/common/metrics.go
@@ -20,14 +20,14 @@ import (
 )
 
 type EchoMetrics struct {
-	HttpRequests *prometheus.CounterVec
+	HTTPRequests *prometheus.CounterVec
 	GrpcRequests *prometheus.CounterVec
-	TcpRequests  *prometheus.CounterVec
+	TCPRequests  *prometheus.CounterVec
 }
 
 var (
 	Metrics = &EchoMetrics{
-		HttpRequests: promauto.NewCounterVec(prometheus.CounterOpts{
+		HTTPRequests: promauto.NewCounterVec(prometheus.CounterOpts{
 			Name: "istio_echo_http_requests_total",
 			Help: "The number of http requests total",
 		}, []string{"port"}),
@@ -35,7 +35,7 @@ var (
 			Name: "istio_echo_grpc_requests_total",
 			Help: "The number of http requests total",
 		}, []string{"port"}),
-		TcpRequests: promauto.NewCounterVec(prometheus.CounterOpts{
+		TCPRequests: promauto.NewCounterVec(prometheus.CounterOpts{
 			Name: "istio_echo_tcp_requests_total",
 			Help: "The number of http requests total",
 		}, []string{"port"}),

--- a/pkg/test/echo/server/endpoint/grpc.go
+++ b/pkg/test/echo/server/endpoint/grpc.go
@@ -122,7 +122,7 @@ type grpcHandler struct {
 }
 
 func (h *grpcHandler) Echo(ctx context.Context, req *proto.EchoRequest) (*proto.EchoResponse, error) {
-	defer common.Metrics.GrpcRequests.WithLabelValues(strconv.Itoa(h.Port.Port)).Inc()
+	defer common.Metrics.GrpcRequests.With(common.Port.Value(strconv.Itoa(h.Port.Port))).Increment()
 	host := "-"
 	body := bytes.Buffer{}
 	md, ok := metadata.FromIncomingContext(ctx)

--- a/pkg/test/echo/server/endpoint/grpc.go
+++ b/pkg/test/echo/server/endpoint/grpc.go
@@ -122,6 +122,7 @@ type grpcHandler struct {
 }
 
 func (h *grpcHandler) Echo(ctx context.Context, req *proto.EchoRequest) (*proto.EchoResponse, error) {
+	defer common.Metrics.GrpcRequests.WithLabelValues(strconv.Itoa(h.Port.Port)).Inc()
 	host := "-"
 	body := bytes.Buffer{}
 	md, ok := metadata.FromIncomingContext(ctx)

--- a/pkg/test/echo/server/endpoint/http.go
+++ b/pkg/test/echo/server/endpoint/http.go
@@ -169,7 +169,7 @@ type codeAndSlices struct {
 func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	log.Infof("HTTP Request:\n  Method: %s\n  URL: %v,\n  Host: %s\n  Headers: %v",
 		r.Method, r.URL, r.Host, r.Header)
-	defer common.Metrics.HTTPRequests.WithLabelValues(strconv.Itoa(h.Port.Port)).Inc()
+	defer common.Metrics.HTTPRequests.With(common.Port.Value(strconv.Itoa(h.Port.Port))).Increment()
 	if !h.IsServerReady() {
 		// Handle readiness probe failure.
 		log.Infof("HTTP service not ready, returning 503")

--- a/pkg/test/echo/server/endpoint/http.go
+++ b/pkg/test/echo/server/endpoint/http.go
@@ -169,7 +169,7 @@ type codeAndSlices struct {
 func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	log.Infof("HTTP Request:\n  Method: %s\n  URL: %v,\n  Host: %s\n  Headers: %v",
 		r.Method, r.URL, r.Host, r.Header)
-	defer common.Metrics.HttpRequests.WithLabelValues(strconv.Itoa(h.Port.Port)).Inc()
+	defer common.Metrics.HTTPRequests.WithLabelValues(strconv.Itoa(h.Port.Port)).Inc()
 	if !h.IsServerReady() {
 		// Handle readiness probe failure.
 		log.Infof("HTTP service not ready, returning 503")

--- a/pkg/test/echo/server/endpoint/http.go
+++ b/pkg/test/echo/server/endpoint/http.go
@@ -169,7 +169,7 @@ type codeAndSlices struct {
 func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	log.Infof("HTTP Request:\n  Method: %s\n  URL: %v,\n  Host: %s\n  Headers: %v",
 		r.Method, r.URL, r.Host, r.Header)
-
+	defer common.Metrics.HttpRequests.WithLabelValues(strconv.Itoa(h.Port.Port)).Inc()
 	if !h.IsServerReady() {
 		// Handle readiness probe failure.
 		log.Infof("HTTP service not ready, returning 503")

--- a/pkg/test/echo/server/endpoint/tcp.go
+++ b/pkg/test/echo/server/endpoint/tcp.go
@@ -76,7 +76,7 @@ func (s *tcpInstance) Start(onReady OnReadyFunc) error {
 
 // Handles incoming connection.
 func (s *tcpInstance) echo(conn io.ReadWriteCloser) {
-	defer common.Metrics.TCPRequests.WithLabelValues(strconv.Itoa(s.Port.Port)).Inc()
+	defer common.Metrics.TCPRequests.With(common.Port.Value(strconv.Itoa(s.Port.Port))).Increment()
 	defer func() {
 		_ = conn.Close()
 	}()

--- a/pkg/test/echo/server/endpoint/tcp.go
+++ b/pkg/test/echo/server/endpoint/tcp.go
@@ -19,6 +19,9 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strconv"
+
+	"istio.io/istio/pkg/test/echo/common"
 
 	"istio.io/istio/pkg/test/echo/common/response"
 
@@ -73,6 +76,7 @@ func (s *tcpInstance) Start(onReady OnReadyFunc) error {
 
 // Handles incoming connection.
 func (s *tcpInstance) echo(conn io.ReadWriteCloser) {
+	defer common.Metrics.TcpRequests.WithLabelValues(strconv.Itoa(s.Port.Port)).Inc()
 	defer func() {
 		_ = conn.Close()
 	}()

--- a/pkg/test/echo/server/endpoint/tcp.go
+++ b/pkg/test/echo/server/endpoint/tcp.go
@@ -76,7 +76,7 @@ func (s *tcpInstance) Start(onReady OnReadyFunc) error {
 
 // Handles incoming connection.
 func (s *tcpInstance) echo(conn io.ReadWriteCloser) {
-	defer common.Metrics.TcpRequests.WithLabelValues(strconv.Itoa(s.Port.Port)).Inc()
+	defer common.Metrics.TCPRequests.WithLabelValues(strconv.Itoa(s.Port.Port)).Inc()
 	defer func() {
 		_ = conn.Close()
 	}()


### PR DESCRIPTION
This will be used in the future to test prometheus application metric
scraping. This is useful for testing things like
https://github.com/istio/istio/issues/21366,
https://github.com/istio/istio/issues/21457,
https://github.com/istio/istio/issues/20011, etc.