### PR TITLE
Fix Gateway helm chart for helm 3

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/role.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/role.yaml
@@ -1,7 +1,8 @@
 {{- range $key, $spec := .Values }}
 {{- if ne $key "enabled" }}
 {{- if $spec.enabled }}
-{{- if ($spec.sds) and (eq $spec.sds.enabled true) }}
+{{- if $spec.sds }}
+{{- if eq $spec.sds.enabled true }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -12,6 +13,7 @@ rules:
   resources: ["secrets"]
   verbs: ["get", "watch", "list"]
 ---
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/install/kubernetes/helm/istio/charts/gateways/templates/rolebindings.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/rolebindings.yaml
@@ -1,7 +1,8 @@
 {{- range $key, $spec := .Values }}
 {{- if ne $key "enabled" }}
 {{- if $spec.enabled }}
-{{- if ($spec.sds) and (eq $spec.sds.enabled true) }}
+{{- if $spec.sds }}
+{{- if eq $spec.sds.enabled true }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -15,6 +16,7 @@ subjects:
 - kind: ServiceAccount
   name: {{ $key }}-service-account
 ---
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Helm 3 threw an error that `$spec.sds` is not a function. Removing the parentheses led to the next problem: the `and` evaluates all expressions so `spec.sds.enabled` resulted in a `nil` exception. 

By nesting the if, the problem is resolved

Tested with helm v3.1.2. Encountered the problem while [trying to install Istio for Knative](https://knative.dev/development/install/installing-istio/#installing-istio-with-sds-to-secure-the-ingress-gateway), which wants you to run this command:

```
# Add the extra gateway.
helm template --namespace=istio-system \
  --set gateways.custom-gateway.autoscaleMin=1 \
  --set gateways.custom-gateway.autoscaleMax=2 \
  --set gateways.custom-gateway.cpu.targetAverageUtilization=60 \
  --set gateways.custom-gateway.labels.app='cluster-local-gateway' \
  --set gateways.custom-gateway.labels.istio='cluster-local-gateway' \
  --set gateways.custom-gateway.type='ClusterIP' \
  --set gateways.istio-ingressgateway.enabled=false \
  --set gateways.istio-egressgateway.enabled=false \
  --set gateways.istio-ilbgateway.enabled=false \
  --set global.mtls.auto=false \
  install/kubernetes/helm/istio \
  -f install/kubernetes/helm/istio/example-values/values-istio-gateways.yaml \
  | sed -e "s/custom-gateway/cluster-local-gateway/g" -e "s/customgateway/clusterlocalgateway/g" \
  > ./istio-local-gateway.yaml

kubectl apply -f istio-local-gateway.yaml
```


[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure