### PR TITLE
Fully update Ingress and make it strict by default

### DIFF
--- a/pkg/config/mesh/mesh.go
+++ b/pkg/config/mesh/mesh.go
@@ -62,6 +62,7 @@ func DefaultMeshConfig() meshconfig.MeshConfig {
 	proxyConfig := DefaultProxyConfig()
 	return meshconfig.MeshConfig{
 		IngressClass:                      "istio",
+		IngressControllerMode:             meshconfig.MeshConfig_STRICT,
 		ReportBatchMaxTime:                types.DurationProto(1 * time.Second),
 		ReportBatchMaxEntries:             100,
 		MixerCheckServer:                  "",

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -971,6 +971,9 @@ func cleanMeshConfig(v proto.Message) proto.Message {
 	if cpy.SdsUdsPath == defaults.SdsUdsPath {
 		cpy.SdsUdsPath = ""
 	}
+	if cpy.IngressControllerMode == defaults.IngressControllerMode {
+		cpy.IngressControllerMode = meshconfig.MeshConfig_UNSPECIFIED
+	}
 	return &cpy
 }
 

--- a/pkg/kube/inject/inject_test.go
+++ b/pkg/kube/inject/inject_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"istio.io/api/mesh/v1alpha1"
+
 	"github.com/gogo/protobuf/types"
 	"github.com/google/go-cmp/cmp"
 
@@ -563,6 +565,7 @@ func TestCleanMeshConfig(t *testing.T) {
 	explicit.DefaultConfig.DrainDuration = types.DurationProto(45 * time.Second)
 	overrides := mesh.DefaultMeshConfig()
 	overrides.TrustDomain = "foo.bar"
+	overrides.IngressControllerMode = v1alpha1.MeshConfig_OFF
 	cases := []struct {
 		name   string
 		mesh   meshapi.MeshConfig
@@ -581,7 +584,7 @@ func TestCleanMeshConfig(t *testing.T) {
 		{
 			"overrides",
 			overrides,
-			`{"trustDomain":"foo.bar"}`,
+			`{"ingressControllerMode":"OFF","trustDomain":"foo.bar"}`,
 		},
 	}
 	for _, tt := range cases {

--- a/tests/integration/pilot/ingress/ingress_test.go
+++ b/tests/integration/pilot/ingress/ingress_test.go
@@ -62,7 +62,6 @@ func TestMain(m *testing.M) {
 			return nil
 		}).
 		SetupOnEnv(environment.Kube, istio.Setup(&i, func(cfg *istio.Config) {
-			cfg.Values["global.k8sIngress.enabled"] = "true"
 			cfg.Values["pilot.env.PILOT_ENABLED_SERVICE_APIS"] = "true"
 		})).
 		Setup(func(ctx resource.Context) (err error) {


### PR DESCRIPTION
The status controller was still reading "extensions" API group