### PR TITLE
Move extra istio revision out of main test

### DIFF
--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -127,10 +127,6 @@ type Config struct {
 	// CustomSidecarInjectorNamespace allows injecting the sidecar from the specified namespace.
 	// if the value is "", use the default sidecar injection instead.
 	CustomSidecarInjectorNamespace string
-
-	// PartialCleanup will only clean up the configurations generate by istioctl. This avoids removing
-	// extra things like the namespace, webhooks, etc. This is useful for multiple control plane
-	PartialCleanup bool
 }
 
 // IsMtlsEnabled checks in Values flag and Values file.

--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -127,6 +127,10 @@ type Config struct {
 	// CustomSidecarInjectorNamespace allows injecting the sidecar from the specified namespace.
 	// if the value is "", use the default sidecar injection instead.
 	CustomSidecarInjectorNamespace string
+
+	// PartialCleanup will only clean up the configurations generate by istioctl. This avoids removing
+	// extra things like the namespace, webhooks, etc. This is useful for multiple control plane
+	PartialCleanup bool
 }
 
 // IsMtlsEnabled checks in Values flag and Values file.

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -114,9 +114,10 @@ func deploy(ctx resource.Context, env *kube.Environment, cfg Config) (Instance, 
 	scopes.CI.Infof("================================")
 
 	i := &operatorComponent{
-		environment: env,
-		settings:    cfg,
-		ctx:         ctx,
+		environment:     env,
+		settings:        cfg,
+		ctx:             ctx,
+		installManifest: map[string]string{},
 	}
 	i.id = ctx.TrackResource(i)
 

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -210,7 +210,7 @@ func deployControlPlane(c *operatorComponent, cfg Config, cluster kube.Cluster, 
 		defaultsIOPFile = filepath.Join(env.IstioSrc, defaultsIOPFile)
 	}
 
-	i.installSettings = []string{
+	c.installSettings = []string{
 		"-f", iopFile,
 		"--set", "values.global.imagePullPolicy=" + s.PullPolicy,
 	}
@@ -218,13 +218,13 @@ func deployControlPlane(c *operatorComponent, cfg Config, cluster kube.Cluster, 
 	// just for helm use case. Otherwise, include all values.
 	if cfg.ControlPlaneValues == "" {
 		for k, v := range cfg.Values {
-			i.installSettings = append(i.installSettings, "--set", fmt.Sprintf("values.%s=%s", k, v))
+			c.installSettings = append(c.installSettings, "--set", fmt.Sprintf("values.%s=%s", k, v))
 		}
 	}
 	if c.environment.IsMulticluster() {
 		// Set the clusterName for the local cluster.
 		// This MUST match the clusterName in the remote secret for this cluster.
-		i.installSettings = append(i.installSettings, "--set", "values.global.multiCluster.clusterName="+cluster.Name())
+		c.installSettings = append(c.installSettings, "--set", "values.global.multiCluster.clusterName="+cluster.Name())
 	}
 
 	cmd := []string{
@@ -233,7 +233,7 @@ func deployControlPlane(c *operatorComponent, cfg Config, cluster kube.Cluster, 
 		"--logtostderr",
 		"--wait",
 	}
-	cmd = append(cmd, i.installSettings...)
+	cmd = append(cmd, c.installSettings...)
 
 	scopes.CI.Infof("Running istio control plane on cluster %s %v", cluster.Name(), cmd)
 	if _, err := istioCtl.Invoke(cmd); err != nil {

--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -39,20 +39,6 @@ func TestMain(m *testing.M) {
 		NewSuite("pilot_test", m).
 		RequireSingleCluster().
 		SetupOnEnv(environment.Kube, istio.Setup(&i, nil)).
-		SetupOnEnv(environment.Kube, istio.Setup(&i, func(cfg *istio.Config) {
-			cfg.ControlPlaneValues = `
-components:
-  base:
-    enabled: false
-  pilot:
-    enabled: true
-  ingressGateways:
-addonComponents:
-  prometheus:
-    enabled: false
-revision: canary
-`
-		})).
 		Setup(func(ctx resource.Context) (err error) {
 			if g, err = galley.New(ctx, galley.Config{}); err != nil {
 				return err

--- a/tests/integration/pilot/revisions_test.go
+++ b/tests/integration/pilot/revisions_test.go
@@ -18,6 +18,9 @@ import (
 	"testing"
 	"time"
 
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/resource/environment"
+
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
@@ -29,7 +32,21 @@ import (
 // belong to different control planes.
 func TestMultiRevision(t *testing.T) {
 	framework.NewTest(t).
+		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
+
+			if err := istio.Setup(&i, func(cfg *istio.Config) {
+				cfg.ControlPlaneValues = `
+profile: empty
+revision: canary
+components:
+  pilot:
+    enabled: true
+`
+				cfg.PartialCleanup = true
+			})(ctx); err != nil {
+				t.Fatal(err)
+			}
 			stable := namespace.NewOrFail(t, ctx, namespace.Config{
 				Prefix: "stable",
 				Inject: true,

--- a/tests/integration/pilot/revisions_test.go
+++ b/tests/integration/pilot/revisions_test.go
@@ -43,7 +43,6 @@ components:
   pilot:
     enabled: true
 `
-				cfg.PartialCleanup = true
 			})(ctx); err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
This applies istio inside of the revision test, instead of for every
pilot test. This gives us more flexibility. The reason this wasn't done
before is the cleanup was broken