### PR TITLE
authz: fix TCP test failure

### DIFF
--- a/pkg/test/echo/server/endpoint/tcp.go
+++ b/pkg/test/echo/server/endpoint/tcp.go
@@ -81,7 +81,8 @@ func (s *tcpInstance) echo(conn net.Conn) {
 		_ = conn.Close()
 	}()
 
-	for initialReply := true; ; {
+	initialReply := true
+	for {
 		buf, err := bufio.NewReader(conn).ReadBytes(byte('\n'))
 		if err != nil {
 			if err != io.EOF {

--- a/pkg/test/echo/server/endpoint/tcp.go
+++ b/pkg/test/echo/server/endpoint/tcp.go
@@ -60,7 +60,7 @@ func (s *tcpInstance) Start(onReady OnReadyFunc) error {
 		for {
 			conn, err := listener.Accept()
 			if err != nil {
-				log.Warn("tcp accept failed: " + err.Error())
+				log.Warn("TCP accept failed: " + err.Error())
 				return
 			}
 
@@ -75,22 +75,25 @@ func (s *tcpInstance) Start(onReady OnReadyFunc) error {
 }
 
 // Handles incoming connection.
-func (s *tcpInstance) echo(conn io.ReadWriteCloser) {
+func (s *tcpInstance) echo(conn net.Conn) {
 	defer common.Metrics.TCPRequests.With(common.Port.Value(strconv.Itoa(s.Port.Port))).Increment()
 	defer func() {
 		_ = conn.Close()
 	}()
 
-	// Fill the field in the response
-	_, _ = conn.Write([]byte(fmt.Sprintf("%s=%s\n", string(response.StatusCodeField), response.StatusCodeOK)))
-
-	for {
+	for initialReply := true; ; {
 		buf, err := bufio.NewReader(conn).ReadBytes(byte('\n'))
 		if err != nil {
 			if err != io.EOF {
-				log.Warn("tcp read failed: " + err.Error())
+				log.Warn("TCP read failed: " + err.Error())
 			}
 			return
+		}
+		log.Infof("TCP Request:\n  Source IP:%s\n  Destination Port:%d", conn.RemoteAddr(), s.Port.Port)
+		if initialReply {
+			// Fill the field in the response
+			_, _ = conn.Write([]byte(fmt.Sprintf("%s=%s\n", string(response.StatusCodeField), response.StatusCodeOK)))
+			initialReply = false
 		}
 
 		// echo the message in the buffer

--- a/tests/integration/security/rbac_v1beta1_test.go
+++ b/tests/integration/security/rbac_v1beta1_test.go
@@ -753,7 +753,6 @@ func TestV1beta1_TCP(t *testing.T) {
 				}
 			}
 
-			// TODO(https://github.com/istio/istio/issues/22189) some TCP tests are skipped
 			cases := []rbacUtil.TestCase{
 				// The policy on workload b denies request with path "/data" to port 8090:
 				// - request to port http-8090 should be denied because both path and port are matched.
@@ -761,7 +760,7 @@ func TestV1beta1_TCP(t *testing.T) {
 				// - request to port tcp should be allowed because the port is not matched.
 				newTestCase(a, b, "http-8090", false, scheme.HTTP),
 				newTestCase(a, b, "http-8091", true, scheme.HTTP),
-				//newTestCase(a, b, "tcp", true, scheme.TCP),
+				newTestCase(a, b, "tcp", true, scheme.TCP),
 
 				// The policy on workload c denies request to port 8090:
 				// - request to port http-8090 should be denied because the port is matched.
@@ -769,7 +768,7 @@ func TestV1beta1_TCP(t *testing.T) {
 				// - request to tcp port 8092 should be allowed because the port is not matched.
 				newTestCase(a, c, "http-8090", false, scheme.HTTP),
 				newTestCase(a, c, "http-8091", true, scheme.HTTP),
-				//newTestCase(a, c, "tcp", true, scheme.TCP),
+				newTestCase(a, c, "tcp", true, scheme.TCP),
 
 				// The policy on workload d denies request from service account a and workloads in namespace 2:
 				// - request from a to d should be denied because it has service account a.
@@ -777,11 +776,11 @@ func TestV1beta1_TCP(t *testing.T) {
 				// - request from c to d should be allowed.
 				// - request from x to a should be allowed because there is no policy on a.
 				// - request from x to d should be denied because it's in namespace 2.
-				//newTestCase(a, d, "tcp", false, scheme.TCP),
-				//newTestCase(b, d, "tcp", true, scheme.TCP),
-				//newTestCase(c, d, "tcp", true, scheme.TCP),
-				//newTestCase(x, a, "tcp", true, scheme.TCP),
-				//newTestCase(x, d, "tcp", false, scheme.TCP),
+				newTestCase(a, d, "tcp", false, scheme.TCP),
+				newTestCase(b, d, "tcp", true, scheme.TCP),
+				newTestCase(c, d, "tcp", true, scheme.TCP),
+				newTestCase(x, a, "tcp", true, scheme.TCP),
+				newTestCase(x, d, "tcp", false, scheme.TCP),
 
 				// The policy on workload e denies request with path "/other":
 				// - request to port http-8090 should be allowed because the path is not matched.
@@ -789,7 +788,7 @@ func TestV1beta1_TCP(t *testing.T) {
 				// - request to port tcp should be denied because policy uses HTTP fields.
 				newTestCase(a, e, "http-8090", true, scheme.HTTP),
 				newTestCase(a, e, "http-8091", true, scheme.HTTP),
-				//newTestCase(a, e, "tcp", false, scheme.TCP),
+				newTestCase(a, e, "tcp", false, scheme.TCP),
 			}
 
 			rbacUtil.RunRBACTest(t, cases)


### PR DESCRIPTION
This PR changes the test app to not to write the data to the connection right after it is established. The RBAC filter cannot enforce access control on the initial connection and the response will pass through. This is due to a long standing issue in Envoy (https://github.com/envoyproxy/envoy/issues/9023) in its onConnection() design.

Fixes https://github.com/istio/istio/issues/22189.