### PR TITLE
Use 'k8s.gcr.io' instead of 'gcr.io/google-containers'

### DIFF
--- a/galley/pkg/config/testing/data/builtin.gen.go
+++ b/galley/pkg/config/testing/data/builtin.gen.go
@@ -609,7 +609,7 @@ spec:
         fieldRef:
           apiVersion: v1
           fieldPath: metadata.namespace
-    image: gcr.io/google-containers/prometheus-to-sd:v0.2.3
+    image: k8s.gcr.io/prometheus-to-sd:v0.2.3
     imagePullPolicy: IfNotPresent
     name: prometheus-to-sd
     resources: {}
@@ -690,8 +690,8 @@ status:
       running:
         startedAt: 2018-12-03T17:00:10Z
   - containerID: docker://e823b79a0a48af75f2eebb1c89ba4c31e8c1ee67ee0d917ac7b4891b67d2cd0f
-    image: gcr.io/google-containers/prometheus-to-sd:v0.2.3
-    imageID: docker-pullable://gcr.io/google-containers/prometheus-to-sd@sha256:be220ec4a66275442f11d420033c106bb3502a3217a99c806eef3cf9858788a2
+    image: k8s.gcr.io/prometheus-to-sd:v0.2.3
+    imageID: docker-pullable://k8s.gcr.io/prometheus-to-sd@sha256:be220ec4a66275442f11d420033c106bb3502a3217a99c806eef3cf9858788a2
     lastState: {}
     name: prometheus-to-sd
     ready: true

--- a/galley/pkg/config/testing/data/builtin/pod.yaml
+++ b/galley/pkg/config/testing/data/builtin/pod.yaml
@@ -176,7 +176,7 @@ spec:
         fieldRef:
           apiVersion: v1
           fieldPath: metadata.namespace
-    image: gcr.io/google-containers/prometheus-to-sd:v0.2.3
+    image: k8s.gcr.io/prometheus-to-sd:v0.2.3
     imagePullPolicy: IfNotPresent
     name: prometheus-to-sd
     resources: {}
@@ -257,8 +257,8 @@ status:
       running:
         startedAt: 2018-12-03T17:00:10Z
   - containerID: docker://e823b79a0a48af75f2eebb1c89ba4c31e8c1ee67ee0d917ac7b4891b67d2cd0f
-    image: gcr.io/google-containers/prometheus-to-sd:v0.2.3
-    imageID: docker-pullable://gcr.io/google-containers/prometheus-to-sd@sha256:be220ec4a66275442f11d420033c106bb3502a3217a99c806eef3cf9858788a2
+    image: k8s.gcr.io/prometheus-to-sd:v0.2.3
+    imageID: docker-pullable://k8s.gcr.io/prometheus-to-sd@sha256:be220ec4a66275442f11d420033c106bb3502a3217a99c806eef3cf9858788a2
     lastState: {}
     name: prometheus-to-sd
     ready: true


### PR DESCRIPTION
Related issue: kubernetes/release#270

Use "k8s.gcr.io" for container images rather than "gcr.io/google_containers".  This is just a redirect, for now, so should not impact anyone materially.  

Documentation and tools should all convert to the new name. Users should take note of this in case they see this new name in the system.

Signed-off-by: Nguyen Hai Truong <truongnh@vn.fujitsu.com>
