### PR TITLE
Add ISTIOD_SERVICE as a pilot arg

### DIFF
--- a/pilot/pkg/bootstrap/options.go
+++ b/pilot/pkg/bootstrap/options.go
@@ -72,6 +72,7 @@ type PilotArgs struct {
 	Namespace          string
 	Revision           string
 	ServiceAccountName string
+	ServiceAddress     string
 	Mesh               MeshArgs
 	Config             ConfigArgs
 	Service            ServiceArgs
@@ -155,4 +156,5 @@ func (p *PilotArgs) applyDefaults() {
 	p.KeepaliveOptions = istiokeepalive.DefaultOption()
 	p.Config.DistributionTrackingEnabled = features.EnableDistributionTracking
 	p.Config.DistributionCacheRetention = features.DistributionHistoryRetention
+	p.ServiceAddress = features.IstiodService.Get()
 }

--- a/pilot/pkg/bootstrap/sidecarinjector.go
+++ b/pilot/pkg/bootstrap/sidecarinjector.go
@@ -47,6 +47,10 @@ const (
 // Was not used in Pilot for 1.3/1.4 (injector was standalone).
 // In 1.5 - used as part of istiod, if the inject template exists.
 func (s *Server) initSidecarInjector(args *PilotArgs) error {
+	if args.ServiceAddress == "" {
+		log.Infof("Skipping sidecar injector, service address not set")
+		return nil
+	}
 	// Injector should run along, even if not used - but only if the injection template is mounted.
 	// ./var/lib/istio/inject - enabled by mounting a template in the config.
 	injectPath := args.InjectionOptions.InjectionDirectory

--- a/pilot/pkg/bootstrap/validation.go
+++ b/pilot/pkg/bootstrap/validation.go
@@ -23,7 +23,6 @@ import (
 
 	"istio.io/istio/galley/pkg/config/source/kube"
 	"istio.io/istio/mixer/pkg/validate"
-	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/webhooks/validation/controller"
 	"istio.io/istio/pkg/webhooks/validation/server"
@@ -43,7 +42,7 @@ func (s *Server) initConfigValidation(args *PilotArgs) error {
 	if s.kubeClient == nil {
 		return nil
 	}
-	if features.IstiodService.Get() == "" {
+	if args.ServiceAddress == "" {
 		return nil
 	}
 

--- a/pilot/pkg/bootstrap/webhook.go
+++ b/pilot/pkg/bootstrap/webhook.go
@@ -24,7 +24,6 @@ import (
 	"istio.io/pkg/filewatcher"
 	"istio.io/pkg/log"
 
-	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/webhooks/validation/server"
 )
 
@@ -40,7 +39,7 @@ func (s *Server) getWebhookCertificate(info *tls.ClientHelloInfo) (*tls.Certific
 }
 
 func (s *Server) initHTTPSWebhookServer(args *PilotArgs) error {
-	if features.IstiodService.Get() == "" {
+	if args.ServiceAddress == "" {
 		log.Info("Not starting HTTPS webhook server: istiod address not set")
 		return nil
 	}

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -263,7 +263,7 @@ var (
 	// imposed by K8S - that's how the names for webhooks are defined, based on webhook service (which will be
 	// istio-pilot or istiod) plus namespace and .svc.
 	// The 15010 port is used with plain text, 15011 with Spiffee certs - we need a different port for DNS cert.
-	IstiodService = env.RegisterStringVar("ISTIOD_ADDR", "istiod.istio-system.svc:15012",
+	IstiodService = env.RegisterStringVar("ISTIOD_ADDR", "",
 		"Service name of istiod. If empty the istiod listener, certs will be disabled.")
 
 	PilotCertProvider = env.RegisterStringVar("PILOT_CERT_PROVIDER", "istiod",

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -263,7 +263,7 @@ var (
 	// imposed by K8S - that's how the names for webhooks are defined, based on webhook service (which will be
 	// istio-pilot or istiod) plus namespace and .svc.
 	// The 15010 port is used with plain text, 15011 with Spiffee certs - we need a different port for DNS cert.
-	IstiodService = env.RegisterStringVar("ISTIOD_ADDR", "",
+	IstiodService = env.RegisterStringVar("ISTIOD_ADDR", "istiod.istio-system.svc:15012",
 		"Service name of istiod. If empty the istiod listener, certs will be disabled.")
 
 	PilotCertProvider = env.RegisterStringVar("PILOT_CERT_PROVIDER", "istiod",

--- a/pkg/test/framework/components/pilot/native.go
+++ b/pkg/test/framework/components/pilot/native.go
@@ -22,8 +22,6 @@ import (
 	"path"
 	"time"
 
-	"istio.io/istio/pilot/pkg/features"
-
 	"github.com/hashicorp/go-multierror"
 
 	meshapi "istio.io/api/mesh/v1alpha1"
@@ -105,6 +103,7 @@ func newNative(ctx resource.Context, cfg Config) (Instance, error) {
 
 	bootstrapArgs := bootstrap.NewPilotArgs(func(p *bootstrap.PilotArgs) {
 		p.Namespace = e.SystemNamespace
+		p.ServiceAddress = "istiod.istio-system.svc:0"
 		p.DiscoveryOptions = options
 		p.Config = bootstrap.ConfigArgs{
 			ControllerOptions: controller.Options{
@@ -136,10 +135,6 @@ func newNative(ctx resource.Context, cfg Config) (Instance, error) {
 
 	// Use testing certs
 	if err := os.Setenv(bootstrap.LocalCertDir.Name, path.Join(env.IstioSrc, "tests/testdata/certs/pilot")); err != nil {
-		return nil, err
-	}
-	// TODO make this the default instead of feature flag, replace with standard configuration for address/port
-	if err := os.Setenv(features.IstiodService.Name, "istiod.istio-system.svc:0"); err != nil {
 		return nil, err
 	}
 	var err error


### PR DESCRIPTION
So we don't need hacks to set the env when running local tests