### PR TITLE
Remove deprecated use_original_dst for the recommended listener filter

### DIFF
--- a/istioctl/cmd/testdata/authz/productpage_config_dump.json
+++ b/istioctl/cmd/testdata/authz/productpage_config_dump.json
@@ -7080,7 +7080,11 @@
                 ]
               }
             ],
-            "use_original_dst": true
+            "listener_filters": [
+             {
+              "name": "envoy.listener.original_dst"
+             }
+            ]
           },
           "last_updated": "2019-04-02T19:54:31.890Z"
         }}

--- a/istioctl/cmd/testdata/describe/productpage-v1-7bbd79f8fd-k6j79.json
+++ b/istioctl/cmd/testdata/describe/productpage-v1-7bbd79f8fd-k6j79.json
@@ -9569,7 +9569,11 @@
         ]
        }
       ],
-      "use_original_dst": true
+      "listener_filters": [
+       {
+        "name": "envoy.listener.original_dst"
+       }
+      ]
      },
      "last_updated": "2019-09-10T20:23:51.671Z"
     }},

--- a/istioctl/cmd/testdata/describe/productpage-v1-c7765c886-v99jb.json
+++ b/istioctl/cmd/testdata/describe/productpage-v1-c7765c886-v99jb.json
@@ -2021,7 +2021,11 @@
         ]
        }
       ],
-      "use_original_dst": true
+      "listener_filters": [
+       {
+        "name": "envoy.listener.original_dst"
+       }
+      ]
      },
      "last_updated": "2019-10-21T14:42:45.474Z"
     }},

--- a/istioctl/cmd/testdata/describe/ratings-v1-f745cf57b-vfwcv.json
+++ b/istioctl/cmd/testdata/describe/ratings-v1-f745cf57b-vfwcv.json
@@ -3837,7 +3837,11 @@
         ]
        }
       ],
-      "use_original_dst": true
+      "listener_filters": [
+       {
+        "name": "envoy.listener.original_dst"
+       }
+      ]
      },
      "last_updated": "2019-08-22T18:08:55.229Z"
     }}

--- a/pilot/pkg/proxy/envoy/v2/testdata/none_lds_tcp.json
+++ b/pilot/pkg/proxy/envoy/v2/testdata/none_lds_tcp.json
@@ -2042,9 +2042,10 @@
           ]
         }
       ],
-      "use_original_dst": {
-        "value": true
-      },
-      "listener_filters": null
+      "listener_filters": [
+       {
+        "name": "envoy.listener.original_dst"
+       }
+      ]
     }
   }

--- a/pkg/test/framework/components/echo/common/testdata/config_dump.json
+++ b/pkg/test/framework/components/echo/common/testdata/config_dump.json
@@ -8511,7 +8511,11 @@
                 ]
               }
             ],
-            "use_original_dst": true
+            "listener_filters": [
+             {
+              "name": "envoy.listener.original_dst"
+             }
+            ]
           },
           "last_updated": "2019-04-14T15:36:46.426Z"
         }}

--- a/tests/testdata/envoy_local.json
+++ b/tests/testdata/envoy_local.json
@@ -98,9 +98,6 @@
             "port_value": 17001
           }
         },
-        "use_original_dst": {
-            "value": true
-        },
         "filter_chains": [
           {
             "filters": [


### PR DESCRIPTION
This is part of a bigger task to remove all the deprecated envoy fields prior to 1.6.