### PR TITLE
Add TCP to outbound traffic test

### DIFF
--- a/pkg/test/framework/components/echo/docker/workload.go
+++ b/pkg/test/framework/components/echo/docker/workload.go
@@ -260,6 +260,7 @@ func (w *workload) Dump() {
 		srcFiles := []string{
 			"/var/log/istio/istio.log",
 			"/var/log/istio/istio.err.log",
+			"/var/log/istio/access.log",
 		}
 
 		for _, srcFile := range srcFiles {

--- a/pkg/test/framework/components/pilot/native.go
+++ b/pkg/test/framework/components/pilot/native.go
@@ -92,6 +92,7 @@ func newNative(ctx resource.Context, cfg Config) (Instance, error) {
 	if cfg.MeshConfig != nil {
 		m = cfg.MeshConfig
 	}
+	m.AccessLogFile = "/var/log/istio/access.log"
 	// The local tests will use SDS, so we need to override the mesh to specify the UDS path
 	// TODO(howardjohn) should we make this mesh wide default?
 	m.SdsUdsPath = "unix:/etc/istio/proxy/SDS"

--- a/prow/integ-suite-local.sh
+++ b/prow/integ-suite-local.sh
@@ -37,4 +37,5 @@ export TAG="${TAG:-"istio-testing"}"
 make docker.app_sidecar docker.app
 
 export T="-v"
+export CI="true"
 make "$@"

--- a/tests/integration/pilot/outboundtrafficpolicy/allowany/traffic_allow_any_test.go
+++ b/tests/integration/pilot/outboundtrafficpolicy/allowany/traffic_allow_any_test.go
@@ -29,6 +29,8 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite("outbound_traffic_policy_allow_any", m).
 		RequireSingleCluster().
+		// Broken on native by https://github.com/istio/istio/issues/22402
+		RequireEnvironment(environment.Kube).
 		Label(label.CustomSetup).
 		SetupOnEnv(environment.Kube, istio.Setup(&ist, setupConfig)).
 		Run()

--- a/tests/integration/pilot/outboundtrafficpolicy/allowany/traffic_allow_any_test.go
+++ b/tests/integration/pilot/outboundtrafficpolicy/allowany/traffic_allow_any_test.go
@@ -56,6 +56,8 @@ func TestOutboundTrafficPolicyAllowAny(t *testing.T) {
 		"http":        {"200"},
 		"http_egress": {"200"},
 		"https":       {"200"},
+		// BUG: https://github.com/istio/istio/issues/16458 this should be 200
+		"tcp":       {""},
 	}
 	outboundtrafficpolicy.RunExternalRequestTest(expected, t)
 }

--- a/tests/integration/pilot/outboundtrafficpolicy/allowany/traffic_allow_any_test.go
+++ b/tests/integration/pilot/outboundtrafficpolicy/allowany/traffic_allow_any_test.go
@@ -57,7 +57,7 @@ func TestOutboundTrafficPolicyAllowAny(t *testing.T) {
 		"http_egress": {"200"},
 		"https":       {"200"},
 		// BUG: https://github.com/istio/istio/issues/16458 this should be 200
-		"tcp":       {""},
+		"tcp": {""},
 	}
 	outboundtrafficpolicy.RunExternalRequestTest(expected, t)
 }

--- a/tests/integration/pilot/outboundtrafficpolicy/helper.go
+++ b/tests/integration/pilot/outboundtrafficpolicy/helper.go
@@ -229,10 +229,10 @@ func RunExternalRequestTest(expected map[string][]string, t *testing.T) {
 					Galley:    g,
 					Ports: []echo.Port{
 						{
-							Name:     "http",
-							Protocol: protocol.HTTP,
+							Name:         "http",
+							Protocol:     protocol.HTTP,
 							InstancePort: 8090,
-							ServicePort: 80,
+							ServicePort:  80,
 						},
 						{
 							Name:         "https",
@@ -241,10 +241,10 @@ func RunExternalRequestTest(expected map[string][]string, t *testing.T) {
 							ServicePort:  443,
 						},
 						{
-							Name:     "tcp",
-							Protocol: protocol.TCP,
+							Name:         "tcp",
+							Protocol:     protocol.TCP,
 							InstancePort: 8092,
-							ServicePort: 9090,
+							ServicePort:  9090,
 						},
 					},
 				}).BuildOrFail(t)
@@ -278,7 +278,7 @@ func RunExternalRequestTest(expected map[string][]string, t *testing.T) {
 					name:     "HTTPS Traffic",
 					portName: "https",
 					// TODO: set up TLS here instead of just sending HTTP. We get a false positive here
-					scheme:   scheme.HTTP,
+					scheme: scheme.HTTP,
 				},
 				{
 					name:     "HTTP Traffic Egress",

--- a/tests/integration/pilot/outboundtrafficpolicy/registryonly/traffic_registry_only_test.go
+++ b/tests/integration/pilot/outboundtrafficpolicy/registryonly/traffic_registry_only_test.go
@@ -56,6 +56,7 @@ func TestOutboundTrafficPolicyRegistryOnly(t *testing.T) {
 		"http":        {"502"}, // HTTP will return an error code
 		"http_egress": {"200"}, // We define the virtual service in the namespace, so we should be able to reach it
 		"https":       {},      // HTTPS will direct to blackhole cluster, giving no response
+		"tcp":         {""},    // HTTPS will direct to blackhole cluster, giving no response
 	}
 	outboundtrafficpolicy.RunExternalRequestTest(expected, t)
 }

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -66,6 +66,7 @@ TEST_PACKAGES = $(shell go list ./tests/integration/... | grep -v /qualification
 test.integration.%.local: | $(JUNIT_REPORT)
 	$(GO) test -p 1 ${T} -race ./tests/integration/$(subst .,/,$*)/... \
 	--istio.test.env native \
+	${_INTEGRATION_TEST_FLAGS} ${_INTEGRATION_TEST_SELECT_FLAGS} \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
 
 # Generate presubmit integration test targets for each component in kubernetes environment
@@ -73,12 +74,6 @@ test.integration.%.kube.presubmit: istioctl | $(JUNIT_REPORT)
 	PATH=${PATH}:${ISTIO_OUT} $(GO) test -p 1 ${T} ./tests/integration/$(subst .,/,$*)/... -timeout 30m \
 	--istio.test.env kube \
 	${_INTEGRATION_TEST_FLAGS} ${_INTEGRATION_TEST_SELECT_FLAGS} \
-	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
-
-# Generate presubmit integration test targets for each component in local environment.
-test.integration.%.local.presubmit: | $(JUNIT_REPORT)
-	$(GO) test -p 1 ${T} -race ./tests/integration/$(subst .,/,$*)/... \
-	--istio.test.env native \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
 
 # Presubmit integration tests targeting Kubernetes environment.


### PR DESCRIPTION
This is currently broken, adding this as a test so that when we fix it
we can switch this to expecting 200 and verify we really fixed this

cc @jacob-delgado I can rebase this onto your change if we merge yours in first, just trying to add some more coverage here