### PR TITLE
Fix for issue #20090 that causes JWT authentication filter changes to be pushed to envoy sidecar more frequently than necessary

### DIFF
--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -474,9 +474,8 @@ func compareJWKSResponse(oldKeyString string, newKeyString string) (bool, error)
 			key2Id, kid2Exists := key2["kid"]
 			if kid1Exists && kid2Exists {
 				return key1Id.(string) < key2Id.(string)
-			} else {
-				return fmt.Sprintf("%v", key1) < fmt.Sprintf("%v", key2)
 			}
+			return len(key1) < len(key2)
 		})
 		sort.Slice(newKeys, func(i, j int) bool {
 			key1 := newKeys[i].(map[string]interface{})
@@ -485,16 +484,15 @@ func compareJWKSResponse(oldKeyString string, newKeyString string) (bool, error)
 			key2Id, kid2Exists := key2["kid"]
 			if kid1Exists && kid2Exists {
 				return key1Id.(string) < key2Id.(string)
-			} else {
-				return len(key1) < len(key2)
 			}
+			return len(key1) < len(key2)
 		})
 
 		// Once sorted, return the result of deep comparison of the arrays of keys
 		return !reflect.DeepEqual(oldKeys, newKeys), nil
-	} else {
-		// If we aren't able to compare using keys, we should return true
-		// since we already checked exact equality of the responses
-		return true, nil
 	}
+
+	// If we aren't able to compare using keys, we should return true
+	// since we already checked exact equality of the responses
+	return true, nil
 }

--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -410,8 +410,8 @@ func (r *JwksResolver) refresh() {
 				lastRefreshedTime: now,            // update the lastRefreshedTime if we get a success response from the network.
 				lastUsedTime:      e.lastUsedTime, // keep original lastUsedTime.
 			})
-			isNewKey, error := compareJWKSResponse(oldPubKey, newPubKey)
-			if error != nil {
+			isNewKey, err := compareJWKSResponse(oldPubKey, newPubKey)
+			if err != nil {
 				log.Errorf("Failed to refresh JWT public key from %q: %v", jwksURI, err)
 				return
 			}

--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -451,14 +451,12 @@ func compareJWKSResponse(oldKeyString string, newKeyString string) (bool, error)
 
 	var oldJWKs map[string]interface{}
 	var newJWKs map[string]interface{}
-	e := json.Unmarshal([]byte(newKeyString), &newJWKs)
-	if e != nil {
+	if err := json.Unmarshal([]byte(newKeyString), &newJWKs); err != nil {
 		// If the new key is not parseable as JSON return an error since we will not want to use this key
 		log.Warnf("New JWKs public key JSON is not parseable: %s", newKeyString)
-		return false, e
+		return false, err
 	}
-	e = json.Unmarshal([]byte(oldKeyString), &oldJWKs)
-	if e != nil {
+	if err := json.Unmarshal([]byte(oldKeyString), &oldJWKs); err != nil {
 		log.Warnf("Previous JWKs public key JSON is not parseable: %s", oldKeyString)
 		return true, nil
 	}
@@ -468,22 +466,34 @@ func compareJWKSResponse(oldKeyString string, newKeyString string) (bool, error)
 	newKeys, newKeysExists := newJWKs["keys"].([]interface{})
 	if oldKeysExists && newKeysExists {
 		sort.Slice(oldKeys, func(i, j int) bool {
-			key1 := oldKeys[i].(map[string]interface{})
-			key2 := oldKeys[j].(map[string]interface{})
-			key1Id, kid1Exists := key1["kid"]
-			key2Id, kid2Exists := key2["kid"]
-			if kid1Exists && kid2Exists {
-				return key1Id.(string) < key2Id.(string)
+			key1, ok1 := oldKeys[i].(map[string]interface{})
+			key2, ok2 := oldKeys[j].(map[string]interface{})
+			if ok1 && ok2 {
+				key1Id, kid1Exists := key1["kid"]
+				key2Id, kid2Exists := key2["kid"]
+				if kid1Exists && kid2Exists {
+					key1IdStr, ok1 := key1Id.(string)
+					key2IdStr, ok2 := key2Id.(string)
+					if ok1 && ok2 {
+						return key1IdStr < key2IdStr
+					}
+				}
 			}
 			return len(key1) < len(key2)
 		})
 		sort.Slice(newKeys, func(i, j int) bool {
-			key1 := newKeys[i].(map[string]interface{})
-			key2 := newKeys[j].(map[string]interface{})
-			key1Id, kid1Exists := key1["kid"]
-			key2Id, kid2Exists := key2["kid"]
-			if kid1Exists && kid2Exists {
-				return key1Id.(string) < key2Id.(string)
+			key1, ok1 := newKeys[i].(map[string]interface{})
+			key2, ok2 := newKeys[j].(map[string]interface{})
+			if ok1 && ok2 {
+				key1Id, kid1Exists := key1["kid"]
+				key2Id, kid2Exists := key2["kid"]
+				if kid1Exists && kid2Exists {
+					key1IdStr, ok1 := key1Id.(string)
+					key2IdStr, ok2 := key2Id.(string)
+					if ok1 && ok2 {
+						return key1IdStr < key2IdStr
+					}
+				}
 			}
 			return len(key1) < len(key2)
 		})

--- a/pilot/pkg/model/jwks_resolver_test.go
+++ b/pilot/pkg/model/jwks_resolver_test.go
@@ -656,12 +656,22 @@ func TestCompareJWKSResponse(t *testing.T) {
 		want    bool
 		wantErr bool
 	}{
-		// TODO: Add test cases.
 		{"testEquivalentStrings", args{test.JwtPubKey1, test.JwtPubKey1}, false, false},
 		{"testReorderedKeys", args{test.JwtPubKey1, test.JwtPubKey1Reordered}, false, false},
 		{"testDifferentKeys", args{test.JwtPubKey1, test.JwtPubKey2}, true, false},
 		{"testOldJsonParseFailure", args{"This is not JSON", test.JwtPubKey1}, true, false},
 		{"testNewJsonParseFailure", args{test.JwtPubKey1, "This is not JSON"}, false, true},
+		{"testNewNoKid", args{test.JwtPubKey1, test.JwtPubKeyNoKid}, true, false},
+		{"testOldNoKid", args{test.JwtPubKeyNoKid, test.JwtPubKey1}, true, false},
+		{"testBothNoKidSame", args{test.JwtPubKeyNoKid, test.JwtPubKeyNoKid}, false, false},
+		{"testBothNoKidDifferent", args{test.JwtPubKeyNoKid, test.JwtPubKeyNoKid2}, true, false},
+		{"testNewNoKeys", args{test.JwtPubKey1, test.JwtPubKeyNoKeys}, true, false},
+		{"testOldNoKeys", args{test.JwtPubKeyNoKeys, test.JwtPubKey1}, true, false},
+		{"testBothNoKeysSame", args{test.JwtPubKeyNoKeys, test.JwtPubKeyNoKeys}, false, false},
+		{"testBothNoKeysDifferent", args{test.JwtPubKeyNoKeys, test.JwtPubKeyNoKeys2}, true, false},
+		{"testNewExtraElements", args{test.JwtPubKey1, test.JwtPubKeyExtraElements}, true, false},
+		{"testOldExtraElements", args{test.JwtPubKeyExtraElements, test.JwtPubKey1}, true, false},
+		{"testBothExtraElements", args{test.JwtPubKeyExtraElements, test.JwtPubKeyExtraElements}, false, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pilot/pkg/model/jwks_resolver_test.go
+++ b/pilot/pkg/model/jwks_resolver_test.go
@@ -644,3 +644,35 @@ func verifyKeyLastRefreshedTime(t *testing.T, r *JwksResolver, ms *test.MockOpen
 		t.Errorf("Want changed: %t but got %t", wantChanged, actualChanged)
 	}
 }
+
+func TestCompareJWKSResponse(t *testing.T) {
+	type args struct {
+		oldKeyString string
+		newKeyString string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+		{"testEquivalentStrings", args{test.JwtPubKey1, test.JwtPubKey1}, false, false},
+		{"testReorderedKeys", args{test.JwtPubKey1, test.JwtPubKey1Reordered}, false, false},
+		{"testDifferentKeys", args{test.JwtPubKey1, test.JwtPubKey2}, true, false},
+		{"testOldJsonParseFailure", args{"This is not JSON", test.JwtPubKey1}, true, false},
+		{"testNewJsonParseFailure", args{test.JwtPubKey1, "This is not JSON"}, false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := compareJWKSResponse(tt.args.oldKeyString, tt.args.newKeyString)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("compareJWKSResponse() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("compareJWKSResponse() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pilot/pkg/model/jwks_resolver_test.go
+++ b/pilot/pkg/model/jwks_resolver_test.go
@@ -351,7 +351,7 @@ func TestGetPublicKeyReorderedKey(t *testing.T) {
 		if c.expectedJwtPubkey != pk {
 			t.Errorf("GetPublicKey(%+v): expected (%s), got (%s)", c.in, c.expectedJwtPubkey, pk)
 		}
-		time.Sleep(30 * time.Millisecond)
+		r.refresh()
 	}
 
 	// Verify mock server http://localhost:9999/oauth2/v3/certs was only called once because of the cache.

--- a/pilot/pkg/model/test/mockopenidserver.go
+++ b/pilot/pkg/model/test/mockopenidserver.go
@@ -47,6 +47,21 @@ const (
 	// JwtPubKey2 is the response to later calls for JWT public key returned by mock server.
 	JwtPubKey2 = `{ "keys": [ { "kid": "fakeKey2_1", "alg": "RS256", "kty": "RSA", "n": "ghi", "e": "lmn" },
 			{ "kid": "fakeKey2_2", "alg": "RS256", "kty": "RSA", "n": "789", "e": "1234" } ] }`
+
+	JwtPubKeyNoKid = `{ "keys": [ { "alg": "RS256", "kty": "RSA", "n": "abc", "e": "def" },
+			{ "alg": "RS256", "kty": "RSA", "n": "123", "e": "456" } ] }`
+
+	JwtPubKeyNoKid2 = `{ "keys": [ { "alg": "RS256", "kty": "RSA", "n": "ghi", "e": "lmn" },
+			{ "alg": "RS256", "kty": "RSA", "n": "789", "e": "123" } ] }`
+
+	JwtPubKeyNoKeys = `{ "pub": [ { "kid": "fakeKey1_1", "alg": "RS256", "kty": "RSA", "n": "abc", "e": "def" },
+			{ "kid": "fakeKey1_2", "alg": "RS256", "kty": "RSA", "n": "123", "e": "456" } ] }`
+
+	JwtPubKeyNoKeys2 = `{ "pub": [ { "kid": "fakeKey1_3", "alg": "RS256", "kty": "RSA", "n": "abc", "e": "def" },
+			{ "kid": "fakeKey1_4", "alg": "RS256", "kty": "RSA", "n": "123", "e": "456" } ] }`
+
+	JwtPubKeyExtraElements = `{ "keys": [ { "kid": "fakeKey1_1", "alg": "RS256", "kty": "RSA", "n": "abc", "e": "def", "bla": "blah" },
+			{ "kid": "fakeKey1_2", "alg": "RS256", "kty": "RSA", "n": "123", "e": "456", "bla": "blah" } ] }`
 )
 
 // MockOpenIDDiscoveryServer is the in-memory openID discovery server.

--- a/pilot/pkg/model/test/mockopenidserver.go
+++ b/pilot/pkg/model/test/mockopenidserver.go
@@ -37,16 +37,16 @@ var (
 
 const (
 	// JwtPubKey1 is the response to 1st call for JWT public key returned by mock server.
-	JwtPubKey1 = "{ \"keys\": [ { \"kid\": \"fakeKey1_1\", \"alg\": \"RS256\", \"kty\": \"RSA\", \"n\": \"abc\", \"e\": \"def\" }," +
-		" { \"kid\": \"fakeKey1_2\", \"alg\": \"RS256\", \"kty\": \"RSA\", \"n\": \"123\", \"e\": \"456\" } ] }"
+	JwtPubKey1 = `{ "keys": [ { "kid": "fakeKey1_1", "alg": "RS256", "kty": "RSA", "n": "abc", "e": "def" },
+			{ "kid": "fakeKey1_2", "alg": "RS256", "kty": "RSA", "n": "123", "e": "456" } ] }`
 
 	// JwtPubKey1Reordered is the response to 1st call for JWT public key returned by mock server, but in a modified order of json elements.
-	JwtPubKey1Reordered = "{ \"keys\": [ { \"alg\": \"RS256\", \"kid\": \"fakeKey1_2\", \"n\": \"123\", \"kty\": \"RSA\", \"e\": \"456\" }," +
-		" { \"n\": \"abc\", \"alg\": \"RS256\", \"kty\": \"RSA\", \"kid\": \"fakeKey1_1\", \"e\": \"def\" } ] }"
+	JwtPubKey1Reordered = `{ "keys": [ { "alg": "RS256", "kid": "fakeKey1_2", "n": "123", "kty": "RSA", "e": "456" },
+			{ "n": "abc", "alg": "RS256", "kty": "RSA", "kid": "fakeKey1_1", "e": "def" } ] }`
 
 	// JwtPubKey2 is the response to later calls for JWT public key returned by mock server.
-	JwtPubKey2 = "{ \"keys\": [ { \"kid\": \"fakeKey2_1\", \"alg\": \"RS256\", \"kty\": \"RSA\", \"n\": \"ghi\", \"e\": \"lmn\" }," +
-		" { \"kid\": \"fakeKey2_2\", \"alg\": \"RS256\", \"kty\": \"RSA\", \"n\": \"789\", \"e\": \"1234\" } ] }"
+	JwtPubKey2 = `{ "keys": [ { "kid": "fakeKey2_1", "alg": "RS256", "kty": "RSA", "n": "ghi", "e": "lmn" },
+			{ "kid": "fakeKey2_2", "alg": "RS256", "kty": "RSA", "n": "789", "e": "1234" } ] }`
 )
 
 // MockOpenIDDiscoveryServer is the in-memory openID discovery server.

--- a/pilot/pkg/model/test/mockopenidserver.go
+++ b/pilot/pkg/model/test/mockopenidserver.go
@@ -37,10 +37,16 @@ var (
 
 const (
 	// JwtPubKey1 is the response to 1st call for JWT public key returned by mock server.
-	JwtPubKey1 = "fakeKey1"
+	JwtPubKey1 = "{ \"keys\": [ { \"kid\": \"fakeKey1_1\", \"alg\": \"RS256\", \"kty\": \"RSA\", \"n\": \"abc\", \"e\": \"def\" }," +
+		" { \"kid\": \"fakeKey1_2\", \"alg\": \"RS256\", \"kty\": \"RSA\", \"n\": \"123\", \"e\": \"456\" } ] }"
+
+	// JwtPubKey1Reordered is the response to 1st call for JWT public key returned by mock server, but in a modified order of json elements.
+	JwtPubKey1Reordered = "{ \"keys\": [ { \"alg\": \"RS256\", \"kid\": \"fakeKey1_2\", \"n\": \"123\", \"kty\": \"RSA\", \"e\": \"456\" }," +
+		" { \"n\": \"abc\", \"alg\": \"RS256\", \"kty\": \"RSA\", \"kid\": \"fakeKey1_1\", \"e\": \"def\" } ] }"
 
 	// JwtPubKey2 is the response to later calls for JWT public key returned by mock server.
-	JwtPubKey2 = "fakeKey2"
+	JwtPubKey2 = "{ \"keys\": [ { \"kid\": \"fakeKey2_1\", \"alg\": \"RS256\", \"kty\": \"RSA\", \"n\": \"ghi\", \"e\": \"lmn\" }," +
+		" { \"kid\": \"fakeKey2_2\", \"alg\": \"RS256\", \"kty\": \"RSA\", \"n\": \"789\", \"e\": \"1234\" } ] }"
 )
 
 // MockOpenIDDiscoveryServer is the in-memory openID discovery server.
@@ -62,6 +68,10 @@ type MockOpenIDDiscoveryServer struct {
 	// The mock server will start to return an error after the first number of hits for public key,
 	// this is used to simulate network errors and test the refresh logic in jwks resolver.
 	ReturnErrorAfterFirstNumHits uint64
+
+	// The mock server will start to return an error after the first number of hits for public key,
+	// this is used to simulate network errors and test the refresh logic in jwks resolver.
+	ReturnReorderedKeyAfterFirstNumHits uint64
 
 	// If both TLSKeyFile and TLSCertFile are set, Start() will attempt to start a HTTPS server.
 	TLSKeyFile  string
@@ -197,6 +207,11 @@ func (ms *MockOpenIDDiscoveryServer) jwtPubKey(w http.ResponseWriter, req *http.
 
 	if atomic.LoadUint64(&ms.PubKeyHitNum) == ms.ReturnErrorForFirstNumHits+1 {
 		fmt.Fprintf(w, "%v", JwtPubKey1)
+		return
+	}
+
+	if ms.ReturnReorderedKeyAfterFirstNumHits != 0 && atomic.LoadUint64(&ms.PubKeyHitNum) >= ms.ReturnReorderedKeyAfterFirstNumHits+1 {
+		fmt.Fprintf(w, "%v", JwtPubKey1Reordered)
 		return
 	}
 


### PR DESCRIPTION
Updated the jwks_resolver to handle ordering changes in the response for the public key from the JWKs URI. This includes updates to the applicable tests. Now if the only change in the response is ordering differences, then the jwks_resolver does not consider it a change and would not trigger updates.