### PR TITLE
Make use of generated deepcopy instead of copystructure

### DIFF
--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -23,8 +23,6 @@ import (
 	"istio.io/pkg/ledger"
 
 	udpa "github.com/cncf/udpa/go/udpa/type/v1"
-	"github.com/mitchellh/copystructure"
-
 	"github.com/gogo/protobuf/proto"
 
 	mccpb "istio.io/api/mixer/v1/config/client"
@@ -653,13 +651,8 @@ func SortQuotaSpec(specs []Config) {
 }
 
 func (c Config) DeepCopy() Config {
-	copied, err := copystructure.Copy(c)
-	if err != nil {
-		// There are 2 locations where errors are generated in copystructure.Copy:
-		//  * The reflection walk over the structure fails, which should never happen
-		//  * A configurable copy function returns an error. This is only used for copying times, which never returns an error.
-		// Therefore, this should never happen
-		panic(err)
-	}
-	return copied.(Config)
+	var clone Config
+	clone.ConfigMeta = c.ConfigMeta
+	clone.Spec = proto.Clone(c.Spec)
+	return clone
 }

--- a/pilot/pkg/model/config_test.go
+++ b/pilot/pkg/model/config_test.go
@@ -853,4 +853,12 @@ func TestDeepCopy(t *testing.T) {
 		t.Fatalf("cloned config is not identical")
 	}
 
+	// change the copied gateway to see if the original config is not effected
+	copiedGateway := copied.Spec.(*networking.Gateway)
+	copiedGateway.Selector = map[string]string{"app": "test"}
+
+	gateway := cfg.Spec.(*networking.Gateway)
+	if gateway.Selector != nil {
+		t.Errorf("Original gateway is mutated")
+	}
 }

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1203,11 +1203,7 @@ func (ps *PushContext) initVirtualServices(env *Environment) error {
 	vservices := make([]Config, len(virtualServices))
 
 	for i := range vservices {
-		var tmpCopy networking.VirtualService
-		vs := virtualServices[i].Spec.(*networking.VirtualService)
-		vs.DeepCopyInto(&tmpCopy)
-		vservices[i].ConfigMeta = virtualServices[i].ConfigMeta
-		vservices[i].Spec = &tmpCopy
+		vservices[i] = virtualServices[i].DeepCopy()
 	}
 
 	totalVirtualServices.Record(float64(len(virtualServices)))
@@ -1423,13 +1419,8 @@ func (ps *PushContext) initDestinationRules(env *Environment) error {
 	// values returned from ConfigStore.List are immutable.
 	// Therefore, we make a copy
 	destRules := make([]Config, len(configs))
-
 	for i := range destRules {
-		var tmpCopy networking.DestinationRule
-		dr := configs[i].Spec.(*networking.DestinationRule)
-		dr.DeepCopyInto(&tmpCopy)
-		destRules[i].ConfigMeta = configs[i].ConfigMeta
-		destRules[i].Spec = &tmpCopy
+		destRules[i] = configs[i].DeepCopy()
 	}
 
 	ps.SetDestinationRules(destRules)

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1203,7 +1203,11 @@ func (ps *PushContext) initVirtualServices(env *Environment) error {
 	vservices := make([]Config, len(virtualServices))
 
 	for i := range vservices {
-		vservices[i] = virtualServices[i].DeepCopy()
+		var tmpCopy networking.VirtualService
+		vs := virtualServices[i].Spec.(*networking.VirtualService)
+		vs.DeepCopyInto(&tmpCopy)
+		vservices[i].ConfigMeta = virtualServices[i].ConfigMeta
+		vservices[i].Spec = &tmpCopy
 	}
 
 	totalVirtualServices.Record(float64(len(virtualServices)))
@@ -1421,7 +1425,11 @@ func (ps *PushContext) initDestinationRules(env *Environment) error {
 	destRules := make([]Config, len(configs))
 
 	for i := range destRules {
-		destRules[i] = configs[i].DeepCopy()
+		var tmpCopy networking.DestinationRule
+		dr := configs[i].Spec.(*networking.DestinationRule)
+		dr.DeepCopyInto(&tmpCopy)
+		destRules[i].ConfigMeta = configs[i].ConfigMeta
+		destRules[i].Spec = &tmpCopy
 	}
 
 	ps.SetDestinationRules(destRules)


### PR DESCRIPTION

```
BenchmarkCopyStruct-4       	    5301	    228819 ns/op
BenchmarkDeepCopy-4         	  113806	     11320 ns/op
```
The result shows that the deepcopy generated is 20x faster than copystructure