### PR TITLE
listener: move grpc status filter to well known names

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1869,11 +1869,12 @@ func buildHTTPConnectionManager(pluginParams *plugin.InputParams, httpOpts *http
 	}
 
 	if util.IsIstioVersionGE14(pluginParams.Node) &&
+		pluginParams.Node.Type == model.SidecarProxy &&
 		pluginParams.ServiceInstance != nil &&
 		pluginParams.ServiceInstance.ServicePort != nil &&
 		pluginParams.ServiceInstance.ServicePort.Protocol == protocol.GRPC {
 		filters = append(filters, &http_conn.HttpFilter{
-			Name: "envoy.filters.http.grpc_stats",
+			Name: wellknown.HTTPGRPCStats,
 			ConfigType: &http_conn.HttpFilter_TypedConfig{
 				TypedConfig: util.MessageToAny(&grpc_stats.FilterConfig{
 					EmitFilterState: true,

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1869,7 +1869,6 @@ func buildHTTPConnectionManager(pluginParams *plugin.InputParams, httpOpts *http
 	}
 
 	if util.IsIstioVersionGE14(pluginParams.Node) &&
-		pluginParams.Node.Type == model.SidecarProxy &&
 		pluginParams.ServiceInstance != nil &&
 		pluginParams.ServiceInstance.ServicePort != nil &&
 		pluginParams.ServiceInstance.ServicePort.Protocol == protocol.GRPC {


### PR DESCRIPTION
Given this issue https://github.com/envoyproxy/envoy/issues/10445, we should enable gRPC stats filter only for sidecars or control it via a feature flag.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
