### PR TITLE
Increase test coverage in operator/pkg/version

### DIFF
--- a/operator/pkg/version/version_test.go
+++ b/operator/pkg/version/version_test.go
@@ -560,9 +560,9 @@ func TestGetVersionCompatibleMap(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			uri := ""
 			if tt.filecontent != "" {
-				filePath, close := tempFile(t, tt.filecontent)
+				filePath, clean := tempFile(t, tt.filecontent)
 				uri = filePath
-				defer close()
+				defer clean()
 			}
 			if tt.httpuri != "" {
 				uri = tt.httpuri
@@ -616,7 +616,6 @@ func tempFile(t *testing.T, content string) (string, func()) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// return tmpfile
 
 	clean := func() {
 		_ = tmpfile.Close()

--- a/operator/pkg/version/version_test.go
+++ b/operator/pkg/version/version_test.go
@@ -131,6 +131,17 @@ supportedIstioVersions: "> 1.1, < 1.4.0"
 `,
 		},
 		{
+			desc: "k8s client and server version provided",
+			yamlStr: `
+operatorVersion: 1.3.0
+operatorVersionRange: 1.3.0
+recommendedIstioVersions: 1.3.0
+supportedIstioVersions: 1.3.0
+k8sClientVersionRange: 1.15.0
+k8sServerVersionRange: 1.15.0
+`,
+		},
+		{
 			desc: "missing operatorVersion",
 			yamlStr: `
 supportedIstioVersions: 1.3.0
@@ -145,6 +156,70 @@ operatorVersion: 1.3.0
 recommendedIstioVersions: 1.3.0
 `,
 			wantErr: `supportedIstioVersions must be set`,
+		},
+		{
+			desc: "incorrect operatorVersion provided",
+			yamlStr: `
+operatorVersion: .X.3.0
+operatorVersionRange: 1.3.0
+recommendedIstioVersions: 1.3.0
+supportedIstioVersions: 1.3.0
+`,
+			wantErr: `Malformed version: .X.3.0`,
+		},
+		{
+			desc: "incorrect operatorVersionRange provided",
+			yamlStr: `
+operatorVersion: 1.3.0
+operatorVersionRange: .Y.3.0
+recommendedIstioVersions: 1.3.0
+supportedIstioVersions: 1.3.0
+`,
+			wantErr: `Malformed constraint: .Y.3.0`,
+		},
+		{
+			desc: "incorrect recommendedIstioVersions provided",
+			yamlStr: `
+operatorVersion: 1.3.0
+operatorVersionRange: 1.3.0
+recommendedIstioVersions: .Z.3.0
+supportedIstioVersions: 1.3.0
+`,
+			wantErr: `Malformed constraint: .Z.3.0`,
+		},
+		{
+			desc: "incorrect supportedIstioVersions provided",
+			yamlStr: `
+operatorVersion: 1.3.0
+operatorVersionRange: 1.3.0
+recommendedIstioVersions: 1.3.0
+supportedIstioVersions: .A.3.0
+`,
+			wantErr: `Malformed constraint: .A.3.0`,
+		},
+		{
+			desc: "incorrect k8sClientVersionRange provided",
+			yamlStr: `
+operatorVersion: 1.3.0
+operatorVersionRange: 1.3.0
+recommendedIstioVersions: 1.3.0
+supportedIstioVersions: 1.3.0
+k8sClientVersionRange: .8.15.0
+k8sServerVersionRange: 1.15.0
+`,
+			wantErr: `Malformed constraint: .8.15.0`,
+		},
+		{
+			desc: "incorrect k8sServerVersionRange provided",
+			yamlStr: `
+operatorVersion: 1.3.0
+operatorVersionRange: 1.3.0
+recommendedIstioVersions: 1.3.0
+supportedIstioVersions: 1.3.0
+k8sClientVersionRange: 1.15.0
+k8sServerVersionRange: .9.15.0
+`,
+			wantErr: `Malformed constraint: .9.15.0`,
 		},
 		{
 			desc: "unknown field",

--- a/operator/pkg/version/version_test.go
+++ b/operator/pkg/version/version_test.go
@@ -438,6 +438,19 @@ func TestTagToVersionString(t *testing.T) {
 	}
 }
 
+func TestUnmarshalYAML(t *testing.T) {
+	v := &Version{}
+	expectedErr := fmt.Errorf("test error")
+	errReturn := func(interface{}) error { return expectedErr }
+	gotErr := v.UnmarshalYAML(errReturn)
+	if gotErr == nil {
+		t.Errorf("expected error but got nil")
+	}
+	if gotErr != expectedErr {
+		t.Errorf("error mismatch")
+	}
+}
+
 func TestGetVersionCompatibleMap(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/operator/pkg/version/version_test.go
+++ b/operator/pkg/version/version_test.go
@@ -438,6 +438,30 @@ func TestTagToVersionString(t *testing.T) {
 	}
 }
 
+func TestVersionString(t *testing.T) {
+	tests := map[string]struct {
+		version Version
+		want    string
+	}{
+		"with suffix": {
+			version: NewVersion(1, 2, 3, "xyz"),
+			want:    "1.2.3-xyz",
+		},
+		"without suffix": {
+			version: NewVersion(1, 5, 0, ""),
+			want:    "1.5.0",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := tt.version.String()
+			if got != tt.want {
+				t.Errorf("Version.String(): got: %s, want: %s", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestUnmarshalYAML(t *testing.T) {
 	v := &Version{}
 	expectedErr := fmt.Errorf("test error")


### PR DESCRIPTION



--

I wanted to contribute back to Istio for the first time, and picked up relatively easy looking issue. I increased the test coverage from 59.8% to 96.7% on operator/pkg/version without touching the main source file at all.

I could not achieve 100% coverage, with the following lines missing coverage:

- line#134 seems to be duplicate error check from line#125
- line#284 - couldn't figure how to get error from `vfs.ReadFile`
- line#289 - couldn't figure how to test against unmarshal error
- line#323 - could be done by providing a real uri, but that probably won't work on CI env

Apologies how it's all over the place, and I'm sure there are some incorrect approaches to other tests as well. Some feedback will be really appreciated!

--

Updates #21886 