### PR TITLE
do not apply default failover when locality lb is disabled

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer.go
+++ b/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer.go
@@ -69,8 +69,9 @@ func ApplyLocalityLBSetting(
 	// one of Distribute or Failover settings can be applied.
 	if localityLB.GetDistribute() != nil {
 		applyLocalityWeight(locality, loadAssignment, localityLB.GetDistribute())
-	} else if enableFailover {
 		// Failover needs outlier detection, otherwise Envoy will never drop down to a lower priority.
+		// Do not apply default failover when locality LB is disabled.
+	} else if enableFailover && (localityLB.Enabled == nil || localityLB.Enabled.Value) {
 		applyLocalityFailover(locality, loadAssignment, localityLB.GetFailover())
 	}
 }

--- a/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer_test.go
@@ -156,6 +156,18 @@ func TestApplyLocalitySetting(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("Failover: with locality lb disabled", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		cluster := buildSmallClusterWithNilLocalities()
+		lbsetting := &networking.LocalityLoadBalancerSetting{
+			Enabled: &types.BoolValue{Value: false},
+		}
+		ApplyLocalityLBSetting(locality, cluster.LoadAssignment, lbsetting, true)
+		for _, localityEndpoint := range cluster.LoadAssignment.Endpoints {
+			g.Expect(localityEndpoint.Priority).To(Equal(uint32(0)))
+		}
+	})
 }
 
 func TestGetLocalityLbSetting(t *testing.T) {


### PR DESCRIPTION
Currently we apply default region failover logic when outlier detection is enabled. But for some protocols like Redis, we do not want this automatic failover logic (because we have to shard across all instances) and also need outlier detection. So this PR enhances this behaviour by not applying the automatic failover when LocalityLB is disabled. So services can set this to false and also set outlier detection to get both.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
