### PR TITLE
Cleanup integration test defaults

### DIFF
--- a/tests/integration/iop-integration-test-defaults.yaml
+++ b/tests/integration/iop-integration-test-defaults.yaml
@@ -33,36 +33,6 @@ spec:
           limits:
             cpu: 100m
             memory: 128Mi
-        # Disable the specific nodePort mappings for testing
-        # These occasionally cause port conflict flakes (#14190)
-        # Lacking a good way to override just part of a list, this is copied from
-        # the prod values.yaml with nodePort omitted
-        ports:
-        - port: 15020
-          targetPort: 15020
-          name: status-port
-        - port: 80
-          targetPort: 80
-          name: http2
-        - port: 443
-          name: https
-        - port: 31400
-          name: tcp
-        - port: 15029
-          targetPort: 15029
-          name: https-kiali
-        - port: 15030
-          targetPort: 15030
-          name: https-prometheus
-        - port: 15031
-          targetPort: 15031
-          name: https-grafana
-        - port: 15032
-          targetPort: 15032
-          name: https-tracing
-        - port: 15443
-          targetPort: 15443
-          name: tls
 
       istio-egressgateway:
         autoscaleMax: 1
@@ -98,6 +68,3 @@ spec:
       adapters:
         stdio:
           enabled: true
-
-    sidecarInjectorWebhook:
-      rewriteAppHTTPProbe: true


### PR DESCRIPTION
- We don't define `nodePorts` anymore anyway, so not necessary
- rewriteAppHTTPProbe is true by default now

This now only sets some defaults regarding resource limits and output, which are useful for CI