### PR TITLE
Add csr count and success count back into serverca

### DIFF
--- a/security/pkg/server/ca/server.go
+++ b/security/pkg/server/ca/server.go
@@ -85,6 +85,7 @@ type Server struct {
 // it is signed by the CA signing key.
 func (s *Server) CreateCertificate(ctx context.Context, request *pb.IstioCertificateRequest) (
 	*pb.IstioCertificateResponse, error) {
+	s.monitoring.CSR.Increment()
 	caller := s.authenticate(ctx)
 	if caller == nil {
 		serverCaLog.Warn("request authentication failure")
@@ -110,6 +111,7 @@ func (s *Server) CreateCertificate(ctx context.Context, request *pb.IstioCertifi
 	response := &pb.IstioCertificateResponse{
 		CertChain: respCertChain,
 	}
+	s.monitoring.Success.Increment()
 	serverCaLog.Debug("CSR successfully signed.")
 
 	return response, nil


### PR DESCRIPTION
There are a few other metrics that are missing that I'm not sure are still relevant:

- `citadel_server_csr_parsing_err_count`
- `citadel_server_id_extraction_err_count`

Please let me know if and where these should be added.

Signed-off-by: Liam White <liam@tetrate.io>