### PR TITLE
Add namespace to Grafana PVC

### DIFF
--- a/manifests/istio-telemetry/grafana/templates/pvc.yaml
+++ b/manifests/istio-telemetry/grafana/templates/pvc.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: istio-grafana-pvc
+  namespace: {{ .Release.Namespace }}
   labels:
     app: grafana
     release: {{ .Release.Name }}

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -38589,6 +38589,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: istio-grafana-pvc
+  namespace: {{ .Release.Namespace }}
   labels:
     app: grafana
     release: {{ .Release.Name }}


### PR DESCRIPTION
This fixes an issue when enabling persistence for Grafana. The PVC is created in the default namespace and the Grafana pod is unable to be scheduled. By adding the namespace, the Grafana PVC is created in the correct namespace