### PR TITLE
Label pods with the revision of the control plane that injected them

### DIFF
--- a/istioctl/cmd/kubeinject.go
+++ b/istioctl/cmd/kubeinject.go
@@ -164,6 +164,8 @@ const (
 )
 
 func injectCommand() *cobra.Command {
+	var revision string
+
 	injectCmd := &cobra.Command{
 		Use:   "kube-inject",
 		Short: "Inject Envoy sidecar into Kubernetes pod resources",
@@ -304,7 +306,7 @@ istioctl kube-inject -f samples/bookinfo/platform/kube/bookinfo.yaml \
 				return nil
 			}
 
-			return inject.IntoResourceFile(sidecarTemplate, valuesConfig, meshConfig, reader, writer)
+			return inject.IntoResourceFile(sidecarTemplate, valuesConfig, revision, meshConfig, reader, writer)
 		},
 		PersistentPreRunE: func(c *cobra.Command, args []string) error {
 			// istioctl kube-inject is typically redirected to a .yaml file;
@@ -335,6 +337,9 @@ istioctl kube-inject -f samples/bookinfo/platform/kube/bookinfo.yaml \
 		fmt.Sprintf("ConfigMap name for Istio mesh configuration, key should be %q", configMapKey))
 	injectCmd.PersistentFlags().StringVar(&injectConfigMapName, "injectConfigMapName", defaultInjectConfigMapName,
 		fmt.Sprintf("ConfigMap name for Istio sidecar injection, key should be %q.", injectConfigMapKey))
+
+	injectCmd.PersistentFlags().StringVar(&revision, "revision", "",
+		"control plane revision")
 
 	return injectCmd
 }

--- a/istioctl/cmd/testdata/deployment/hello.yaml.injected
+++ b/istioctl/cmd/testdata/deployment/hello.yaml.injected
@@ -18,6 +18,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pilot/pkg/bootstrap/options.go
+++ b/pilot/pkg/bootstrap/options.go
@@ -122,7 +122,9 @@ var PodNamespaceVar = env.RegisterStringVar("POD_NAMESPACE", "istio-system", "")
 var podNameVar = env.RegisterStringVar("POD_NAME", "", "")
 var serviceAccountVar = env.RegisterStringVar("SERVICE_ACCOUNT", "", "")
 
-var revisionVar = env.RegisterStringVar("REVISION", "", "")
+// RevisionVar is the value of the Istio control plane revision, e.g. "canary",
+// and is the value used by the "istio.io/rev" label.
+var RevisionVar = env.RegisterStringVar("REVISION", "", "")
 
 // NewPilotArgs constructs pilotArgs with default values.
 func NewPilotArgs(initFuncs ...func(*PilotArgs)) *PilotArgs {
@@ -151,7 +153,7 @@ func (p *PilotArgs) applyDefaults() {
 	p.Namespace = PodNamespaceVar.Get()
 	p.PodName = podNameVar.Get()
 	p.ServiceAccountName = serviceAccountVar.Get()
-	p.Revision = revisionVar.Get()
+	p.Revision = RevisionVar.Get()
 	p.KeepaliveOptions = istiokeepalive.DefaultOption()
 	p.Config.DistributionTrackingEnabled = features.EnableDistributionTracking
 	p.Config.DistributionCacheRetention = features.DistributionHistoryRetention

--- a/pilot/pkg/bootstrap/sidecarinjector.go
+++ b/pilot/pkg/bootstrap/sidecarinjector.go
@@ -71,6 +71,7 @@ func (s *Server) initSidecarInjector(args *PilotArgs) error {
 		// Disable monitoring. The injection metrics will be picked up by Pilots metrics exporter already
 		MonitoringPort: -1,
 		Mux:            s.httpsMux,
+		Revision:       args.Revision,
 	}
 
 	wh, err := inject.NewWebhook(parameters)

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -554,7 +554,7 @@ func parseTemplate(tmplStr string, funcMap map[string]interface{}, data SidecarT
 
 // IntoResourceFile injects the istio proxy into the specified
 // kubernetes YAML file.
-func IntoResourceFile(sidecarTemplate string, valuesConfig string, meshconfig *meshconfig.MeshConfig, in io.Reader, out io.Writer) error {
+func IntoResourceFile(sidecarTemplate string, valuesConfig string, revision string, meshconfig *meshconfig.MeshConfig, in io.Reader, out io.Writer) error {
 	reader := yamlDecoder.NewYAMLReader(bufio.NewReaderSize(in, 4096))
 	for {
 		raw, err := reader.Read()
@@ -572,7 +572,7 @@ func IntoResourceFile(sidecarTemplate string, valuesConfig string, meshconfig *m
 
 		var updated []byte
 		if err == nil {
-			outObject, err := IntoObject(sidecarTemplate, valuesConfig, meshconfig, obj) // nolint: vetshadow
+			outObject, err := IntoObject(sidecarTemplate, valuesConfig, revision, meshconfig, obj) // nolint: vetshadow
 			if err != nil {
 				return err
 			}
@@ -613,7 +613,7 @@ func FromRawToObject(raw []byte) (runtime.Object, error) {
 }
 
 // IntoObject convert the incoming resources into Injected resources
-func IntoObject(sidecarTemplate string, valuesConfig string, meshconfig *meshconfig.MeshConfig, in runtime.Object) (interface{}, error) {
+func IntoObject(sidecarTemplate string, valuesConfig string, revision string, meshconfig *meshconfig.MeshConfig, in runtime.Object) (interface{}, error) {
 	out := in.DeepCopyObject()
 
 	var deploymentMetadata *metav1.ObjectMeta
@@ -634,7 +634,7 @@ func IntoObject(sidecarTemplate string, valuesConfig string, meshconfig *meshcon
 				return nil, err
 			}
 
-			r, err := IntoObject(sidecarTemplate, valuesConfig, meshconfig, obj) // nolint: vetshadow
+			r, err := IntoObject(sidecarTemplate, valuesConfig, revision, meshconfig, obj) // nolint: vetshadow
 			if err != nil {
 				return nil, err
 			}
@@ -763,10 +763,13 @@ func IntoObject(sidecarTemplate string, valuesConfig string, meshconfig *meshcon
 	}
 
 	metadata.Annotations[annotation.SidecarStatus.Name] = status
+	if metadata.Labels == nil {
+		metadata.Labels = make(map[string]string)
+	}
+	// This function, IntoObject(), is only used on the 'istioctl kube-kubeinject' path, which
+	// doesn't use Pilot bootstrap variables.
+	metadata.Labels[model.RevisionLabel] = revision
 	if status != "" && metadata.Labels[model.TLSModeLabelName] == "" {
-		if metadata.Labels == nil {
-			metadata.Labels = make(map[string]string)
-		}
 		metadata.Labels[model.TLSModeLabelName] = model.IstioMutualTLSModeLabel
 	}
 

--- a/pkg/kube/inject/inject_test.go
+++ b/pkg/kube/inject/inject_test.go
@@ -320,7 +320,7 @@ values:
 			}
 			defer func() { _ = in.Close() }()
 			var got bytes.Buffer
-			if err = IntoResourceFile(sidecarTemplate.Template, valuesConfig, &m, in, &got); err != nil {
+			if err = IntoResourceFile(sidecarTemplate.Template, valuesConfig, "", &m, in, &got); err != nil {
 				t.Fatalf("IntoResourceFile(%v) returned an error: %v", inputFilePath, err)
 			}
 
@@ -414,7 +414,7 @@ func TestRewriteAppProbe(t *testing.T) {
 			}
 			defer func() { _ = in.Close() }()
 			var got bytes.Buffer
-			if err = IntoResourceFile(sidecarTemplate.Template, valuesConfig, &m, in, &got); err != nil {
+			if err = IntoResourceFile(sidecarTemplate.Template, valuesConfig, "", &m, in, &got); err != nil {
 				t.Fatalf("IntoResourceFile(%v) returned an error: %v", inputFilePath, err)
 			}
 
@@ -467,7 +467,7 @@ func TestInvalidAnnotations(t *testing.T) {
 			}
 			defer func() { _ = in.Close() }()
 			var got bytes.Buffer
-			if err = IntoResourceFile(sidecarTemplate.Template, valuesConfig, &m, in, &got); err == nil {
+			if err = IntoResourceFile(sidecarTemplate.Template, valuesConfig, "", &m, in, &got); err == nil {
 				t.Fatalf("expected error")
 			} else if !strings.Contains(strings.ToLower(err.Error()), c.annotation) {
 				t.Fatalf("unexpected error: %v", err)

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -13,6 +13,7 @@ spec:
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
       creationTimestamp: null
       labels:
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
     spec:
       template:

--- a/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -35,6 +35,7 @@ items:
         creationTimestamp: null
         labels:
           app: hello
+          istio.io/rev: ""
           security.istio.io/tlsMode: istio
           tier: backend
           track: stable

--- a/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -35,6 +35,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: frontend
         track: stable

--- a/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: disabled
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable
@@ -226,6 +227,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -13,6 +13,7 @@ spec:
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
       creationTimestamp: null
       labels:
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
       name: pi
     spec:

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -23,6 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -36,6 +36,7 @@ items:
         creationTimestamp: null
         labels:
           app: hello
+          istio.io/rev: ""
           security.istio.io/tlsMode: istio
           tier: frontend
           track: stable

--- a/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -25,6 +25,7 @@ items:
         creationTimestamp: null
         labels:
           app: hello
+          istio.io/rev: ""
           security.istio.io/tlsMode: istio
           tier: backend
           track: stable
@@ -227,6 +228,7 @@ items:
         creationTimestamp: null
         labels:
           app: hello
+          istio.io/rev: ""
           security.istio.io/tlsMode: istio
           tier: backend
           track: stable

--- a/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: app
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
     spec:
       containers:

--- a/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -9,6 +9,7 @@ metadata:
     traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
   creationTimestamp: null
   labels:
+    istio.io/rev: ""
     security.istio.io/tlsMode: istio
   name: hellopod
 spec:

--- a/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -19,6 +19,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
     spec:
       containers:

--- a/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -18,6 +18,7 @@ spec:
       creationTimestamp: null
       labels:
         app: nginx
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
       name: nginx
     spec:

--- a/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         tier: backend
         track: stable

--- a/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -25,6 +25,7 @@ spec:
       creationTimestamp: null
       labels:
         app: status
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
     spec:
       containers:

--- a/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: status
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
     spec:
       containers:

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -21,6 +21,7 @@ spec:
       creationTimestamp: null
       labels:
         app: traffic
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
     spec:
       containers:

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -21,6 +21,7 @@ spec:
       creationTimestamp: null
       labels:
         app: traffic
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
     spec:
       containers:

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -22,6 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: traffic
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
     spec:
       containers:

--- a/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: traffic
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
     spec:
       containers:

--- a/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -21,6 +21,7 @@ spec:
       creationTimestamp: null
       labels:
         app: traffic
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
     spec:
       containers:

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject.patch
@@ -57,8 +57,13 @@
     "op": "add",
     "path": "/metadata/labels",
     "value": {
-      "security.istio.io/tlsMode": "istio"
+      "istio.io/rev": ""
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/security.istio.io~1tlsMode",
+    "value": "istio"
   },
   {
     "op": "add",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_nosidecar_rewrite.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_nosidecar_rewrite.patch
@@ -71,8 +71,13 @@
     "op": "add",
     "path": "/metadata/labels",
     "value": {
-      "security.istio.io/tlsMode": "istio"
+      "istio.io/rev": ""
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/security.istio.io~1tlsMode",
+    "value": "istio"
   },
   {
     "op": "add",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite.patch
@@ -75,8 +75,13 @@
     "op": "add",
     "path": "/metadata/labels",
     "value": {
-      "security.istio.io/tlsMode": "istio"
+      "istio.io/rev": ""
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/security.istio.io~1tlsMode",
+    "value": "istio"
   },
   {
     "op": "add",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_disabled_via_annotation.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_disabled_via_annotation.patch
@@ -55,8 +55,13 @@
     "op": "add",
     "path": "/metadata/labels",
     "value": {
-      "security.istio.io/tlsMode": "istio"
+      "istio.io/rev": ""
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/security.istio.io~1tlsMode",
+    "value": "istio"
   },
   {
     "op": "add",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_enabled_via_annotation.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_enabled_via_annotation.patch
@@ -73,8 +73,13 @@
     "op": "add",
     "path": "/metadata/labels",
     "value": {
-      "security.istio.io/tlsMode": "istio"
+      "istio.io/rev": ""
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/security.istio.io~1tlsMode",
+    "value": "istio"
   },
   {
     "op": "add",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_https_probe_rewrite.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_https_probe_rewrite.patch
@@ -75,8 +75,13 @@
     "op": "add",
     "path": "/metadata/labels",
     "value": {
-      "security.istio.io/tlsMode": "istio"
+      "istio.io/rev": ""
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/security.istio.io~1tlsMode",
+    "value": "istio"
   },
   {
     "op": "add",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_injectorAnnotations.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_injectorAnnotations.patch
@@ -67,8 +67,13 @@
     "op": "add",
     "path": "/metadata/labels",
     "value": {
-      "security.istio.io/tlsMode": "istio"
+      "istio.io/rev": ""
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/security.istio.io~1tlsMode",
+    "value": "istio"
   },
   {
     "op": "add",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_mtls_not_ready.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_mtls_not_ready.patch
@@ -55,6 +55,11 @@
   },
   {
     "op": "add",
+    "path": "/metadata/labels/istio.io~1rev",
+    "value": ""
+  },
+  {
+    "op": "add",
     "path": "/metadata/labels/service.istio.io~1canonical-name",
     "value": ""
   },

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers.patch
@@ -57,8 +57,13 @@
     "op": "add",
     "path": "/metadata/labels",
     "value": {
-      "security.istio.io/tlsMode": "istio"
+      "istio.io/rev": ""
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/security.istio.io~1tlsMode",
+    "value": "istio"
   },
   {
     "op": "add",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_imagePullSecrets.patch
@@ -59,8 +59,13 @@
     "op": "add",
     "path": "/metadata/labels",
     "value": {
-      "security.istio.io/tlsMode": "istio"
+      "istio.io/rev": ""
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/security.istio.io~1tlsMode",
+    "value": "istio"
   },
   {
     "op": "add",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes.patch
@@ -59,8 +59,13 @@
     "op": "add",
     "path": "/metadata/labels",
     "value": {
-      "security.istio.io/tlsMode": "istio"
+      "istio.io/rev": ""
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/security.istio.io~1tlsMode",
+    "value": "istio"
   },
   {
     "op": "add",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes_imagePullSecrets.patch
@@ -61,8 +61,13 @@
     "op": "add",
     "path": "/metadata/labels",
     "value": {
-      "security.istio.io/tlsMode": "istio"
+      "istio.io/rev": ""
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/security.istio.io~1tlsMode",
+    "value": "istio"
   },
   {
     "op": "add",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_imagePullSecrets.patch
@@ -57,8 +57,13 @@
     "op": "add",
     "path": "/metadata/labels",
     "value": {
-      "security.istio.io/tlsMode": "istio"
+      "istio.io/rev": ""
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/security.istio.io~1tlsMode",
+    "value": "istio"
   },
   {
     "op": "add",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers.patch
@@ -57,8 +57,13 @@
     "op": "add",
     "path": "/metadata/labels",
     "value": {
-      "security.istio.io/tlsMode": "istio"
+      "istio.io/rev": ""
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/security.istio.io~1tlsMode",
+    "value": "istio"
   },
   {
     "op": "add",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers.patch
@@ -59,8 +59,13 @@
     "op": "add",
     "path": "/metadata/labels",
     "value": {
-      "security.istio.io/tlsMode": "istio"
+      "istio.io/rev": ""
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/security.istio.io~1tlsMode",
+    "value": "istio"
   },
   {
     "op": "add",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_imagePullSecrets.patch
@@ -61,8 +61,13 @@
     "op": "add",
     "path": "/metadata/labels",
     "value": {
-      "security.istio.io/tlsMode": "istio"
+      "istio.io/rev": ""
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/security.istio.io~1tlsMode",
+    "value": "istio"
   },
   {
     "op": "add",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_volumes.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_volumes.patch
@@ -61,8 +61,13 @@
     "op": "add",
     "path": "/metadata/labels",
     "value": {
-      "security.istio.io/tlsMode": "istio"
+      "istio.io/rev": ""
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/security.istio.io~1tlsMode",
+    "value": "istio"
   },
   {
     "op": "add",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_imagePullSecrets.patch
@@ -59,8 +59,13 @@
     "op": "add",
     "path": "/metadata/labels",
     "value": {
-      "security.istio.io/tlsMode": "istio"
+      "istio.io/rev": ""
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/security.istio.io~1tlsMode",
+    "value": "istio"
   },
   {
     "op": "add",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes.patch
@@ -59,8 +59,13 @@
     "op": "add",
     "path": "/metadata/labels",
     "value": {
-      "security.istio.io/tlsMode": "istio"
+      "istio.io/rev": ""
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/security.istio.io~1tlsMode",
+    "value": "istio"
   },
   {
     "op": "add",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes_imagePullSecrets.patch
@@ -61,8 +61,13 @@
     "op": "add",
     "path": "/metadata/labels",
     "value": {
-      "security.istio.io/tlsMode": "istio"
+      "istio.io/rev": ""
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/security.istio.io~1tlsMode",
+    "value": "istio"
   },
   {
     "op": "add",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initcontainers_containers_volumes_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initcontainers_containers_volumes_imagePullSecrets.patch
@@ -63,8 +63,13 @@
     "op": "add",
     "path": "/metadata/labels",
     "value": {
-      "security.istio.io/tlsMode": "istio"
+      "istio.io/rev": ""
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/security.istio.io~1tlsMode",
+    "value": "istio"
   },
   {
     "op": "add",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes.patch
@@ -57,8 +57,13 @@
     "op": "add",
     "path": "/metadata/labels",
     "value": {
-      "security.istio.io/tlsMode": "istio"
+      "istio.io/rev": ""
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/security.istio.io~1tlsMode",
+    "value": "istio"
   },
   {
     "op": "add",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes_imagePullSecrets.patch
@@ -59,8 +59,13 @@
     "op": "add",
     "path": "/metadata/labels",
     "value": {
-      "security.istio.io/tlsMode": "istio"
+      "istio.io/rev": ""
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/security.istio.io~1tlsMode",
+    "value": "istio"
   },
   {
     "op": "add",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_probe_rewrite_timeout_retention.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_probe_rewrite_timeout_retention.patch
@@ -75,8 +75,13 @@
     "op": "add",
     "path": "/metadata/labels",
     "value": {
-      "security.istio.io/tlsMode": "istio"
+      "istio.io/rev": ""
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/security.istio.io~1tlsMode",
+    "value": "istio"
   },
   {
     "op": "add",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace.patch
@@ -67,8 +67,13 @@
     "op": "add",
     "path": "/metadata/labels",
     "value": {
-      "security.istio.io/tlsMode": "istio"
+      "istio.io/rev": ""
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/security.istio.io~1tlsMode",
+    "value": "istio"
   },
   {
     "op": "add",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace_backwards_compat.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace_backwards_compat.patch
@@ -71,8 +71,13 @@
     "op": "add",
     "path": "/metadata/labels",
     "value": {
-      "security.istio.io/tlsMode": "istio"
+      "istio.io/rev": ""
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/security.istio.io~1tlsMode",
+    "value": "istio"
   },
   {
     "op": "add",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_validationOrder.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_validationOrder.patch
@@ -66,8 +66,13 @@
     "op": "add",
     "path": "/metadata/labels",
     "value": {
-      "security.istio.io/tlsMode": "istio"
+      "istio.io/rev": ""
     }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/security.istio.io~1tlsMode",
+    "value": "istio"
   },
   {
     "op": "add",

--- a/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
@@ -17,6 +17,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
@@ -16,6 +16,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig-with-canonical-service-label.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig-with-canonical-service-label.yaml.injected
@@ -16,6 +16,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: test-service-name
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
@@ -16,6 +16,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
@@ -18,6 +18,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
@@ -18,6 +18,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/webhook/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-mtls-not-ready.yaml.injected
@@ -18,6 +18,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: disabled
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
@@ -19,6 +19,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: v1
@@ -217,6 +218,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: v2

--- a/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
@@ -18,6 +18,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/webhook/job.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/job.yaml.injected
@@ -12,6 +12,7 @@ spec:
         sidecar.istio.io/status: '{"version":"unit-test-fake-version","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: pi
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
@@ -18,6 +18,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/webhook/list.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/list.yaml.injected
@@ -19,6 +19,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: v1
@@ -217,6 +218,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: v2

--- a/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
@@ -16,6 +16,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
@@ -14,6 +14,7 @@ spec:
       creationTimestamp: null
       labels:
         app: nginx
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: nginx
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: resource
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: resource
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
@@ -18,6 +18,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
@@ -21,6 +21,7 @@ spec:
       creationTimestamp: null
       labels:
         app: status
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: status
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: traffic
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: traffic
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: traffic
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: traffic
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
@@ -21,6 +21,7 @@ spec:
       creationTimestamp: null
       labels:
         app: traffic
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: traffic
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
@@ -20,6 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: user-volume
+        istio.io/rev: ""
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: user-volume
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -81,6 +81,7 @@ type Webhook struct {
 	cert       *tls.Certificate
 	mon        *monitor
 	env        *model.Environment
+	revision   string
 }
 
 // env will be used for other things besides meshConfig - when webhook is running in Istiod it can take advantage
@@ -158,6 +159,9 @@ type WebhookParameters struct {
 
 	// Use an existing mux instead of creating our own.
 	Mux *http.ServeMux
+
+	// The istio.io/rev this injector is responsible for
+	Revision string
 }
 
 // NewWebhook creates a new instance of a mutating webhook for automatic sidecar injection.
@@ -547,7 +551,7 @@ func updateAnnotation(target map[string]string, added map[string]string) (patch 
 	return patch
 }
 
-func createPatch(pod *corev1.Pod, prevStatus *SidecarInjectionStatus, annotations map[string]string, sic *SidecarInjectionSpec,
+func createPatch(pod *corev1.Pod, prevStatus *SidecarInjectionStatus, revision string, annotations map[string]string, sic *SidecarInjectionSpec,
 	workloadName string, statusPort int32) ([]byte, error) {
 
 	var patch []rfc6902PatchOperation
@@ -595,6 +599,7 @@ func createPatch(pod *corev1.Pod, prevStatus *SidecarInjectionStatus, annotation
 	patch = append(patch, addLabels(pod.Labels, map[string]string{
 		model.TLSModeLabelName:                       model.IstioMutualTLSModeLabel,
 		model.IstioCanonicalServiceLabelName:         canonicalSvc,
+		"istio.io/rev":                               revision,
 		model.IstioCanonicalServiceRevisionLabelName: canonicalRev})...)
 
 	if rewrite {
@@ -779,7 +784,7 @@ func (wh *Webhook) inject(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionRespons
 		annotations[k] = v
 	}
 
-	patchBytes, err := createPatch(&pod, injectionStatus(&pod), annotations, spec, deployMeta.Name, wh.meshConfig.GetDefaultConfig().GetStatusPort())
+	patchBytes, err := createPatch(&pod, injectionStatus(&pod), wh.revision, annotations, spec, deployMeta.Name, wh.meshConfig.GetDefaultConfig().GetStatusPort())
 	if err != nil {
 		handleError(fmt.Sprintf("AdmissionResponse: err=%v spec=%v\n", err, spec))
 		return toAdmissionResponse(err)

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -1315,12 +1315,17 @@ func TestRunAndServe(t *testing.T) {
          "sidecar.istio.io/status":"{\"version\":\"461c380844de8df1d1e2a80a09b6d7b58b8313c4a7d6796530eb124740a1440f\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
       }
    },
-   {
-      "op": "add",
-      "path": "/metadata/labels",
-      "value": {
-         "security.istio.io/tlsMode": "istio"
+    {
+      "op":"add",
+      "path":"/metadata/labels",
+      "value":{
+         "istio.io/rev":""
       }
+    },
+    {
+      "op":"add",
+      "path":"/metadata/labels/security.istio.io~1tlsMode",
+      "value":"istio"
     },
     {
       "op": "add",


### PR DESCRIPTION
As part of the work on https://github.com/istio/istio/issues/22274 we label injected pods with the control plane revision that injected them.

In the future the `istioctl` troubleshooting commands will use this to determine which revision of the control plane is associated with a pod.