### PR TITLE
Fix indentation in Kiali deployment template

### DIFF
--- a/manifests/istio-telemetry/kiali/templates/deployment.yaml
+++ b/manifests/istio-telemetry/kiali/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
       containers:
       - image: "{{ .Values.kiali.hub }}/{{ .Values.kiali.image }}:{{ .Values.kiali.tag }}"
 {{- if .Values.global.imagePullPolicy }}
-      imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
 {{- end }}
         name: kiali
         command:

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -37765,7 +37765,7 @@ spec:
       containers:
       - image: "{{ .Values.kiali.hub }}/{{ .Values.kiali.image }}:{{ .Values.kiali.tag }}"
 {{- if .Values.global.imagePullPolicy }}
-      imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
 {{- end }}
         name: kiali
         command:


### PR DESCRIPTION
This fixes the indentation level for the imagePullPolicy in the Kiali
deployment template.  It was changed in: #20707