### PR TITLE
Fix error handling in test framework deployment

### DIFF
--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -212,8 +212,8 @@ func deployControlPlane(c *operatorComponent, cfg Config, cluster kube.Cluster, 
 	// Save the manifest generate output so we can later cleanup
 	genCmd := []string{"manifest", "generate"}
 	genCmd = append(genCmd, installSettings...)
-	out, e := istioCtl.Invoke(genCmd)
-	if e != nil {
+	out, err := istioCtl.Invoke(genCmd)
+	if err != nil {
 		return err
 	}
 	c.installManifest[cluster.Name()] = out


### PR DESCRIPTION
This fixes handling of errors returned when generating the manifests
during a control-plane deployment in the test framework.  Previously
deployControlPlane would return early in case of an error generating
the manifests, but failed to actually return the error value.