### PR TITLE
Warn on missing IstioOperator file in DefaultConfig

### DIFF
--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -28,6 +28,7 @@ import (
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework/image"
 	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/scopes"
 
 	kubeCore "k8s.io/api/core/v1"
 )
@@ -209,7 +210,7 @@ func DefaultConfig(ctx resource.Context) (Config, error) {
 	}
 
 	if err := checkFileExists(iopFile); err != nil {
-		return Config{}, err
+		scopes.Framework.Warnf("Default IOPFile missing: %v", err)
 	}
 
 	deps, err := image.SettingsFromCommandLine()


### PR DESCRIPTION
This changes `DefaultConfig` in the test framework to only print a
warning when the default `IstioOperator` file can't be found rather
than return an error.  Otherwise, it may be impossible to override the
path in a user supplied setup function because `DefaultConfig` is
called before the setup function, and if it errors, setup is aborted
early.

I don't know if this is actually the right thing to do, but I found
myself in a situation where the `iop-integration-test-defaults.yaml`
file wasn't found, but I couldn't pass my own by setting `cfg.IOPFile`
because `DefaultConfig` would throw an error.  If the default path is
missing, and you haven't overridden it, then things should fail early
anyway while generating the manifests after #22517 lands.