### PR TITLE
[1.4] clone LbEndpoint to prevent data race (#22023)

### DIFF
--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -439,6 +439,21 @@ func cloneLocalityLbEndpoints(endpoints []*endpoint.LocalityLbEndpoints) []*endp
 	return out
 }
 
+// return a shallow copy LbEndpoint
+func CloneLbEndpoint(endpoint *endpoint.LbEndpoint) *endpoint.LbEndpoint {
+	if endpoint == nil {
+		return nil
+	}
+
+	clone := *endpoint
+	if endpoint.LoadBalancingWeight != nil {
+		clone.LoadBalancingWeight = &wrappers.UInt32Value{
+			Value: endpoint.GetLoadBalancingWeight().GetValue(),
+		}
+	}
+	return &clone
+}
+
 // BuildConfigInfoMetadata builds core.Metadata struct containing the
 // name.namespace of the config, the type, etc. Used by Mixer client
 // to generate attributes for policy and telemetry.

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -40,6 +40,17 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 )
 
+func TestCloneLbEndpoint(t *testing.T) {
+	ep := &endpoint.LbEndpoint{
+		LoadBalancingWeight: &wrappers.UInt32Value{Value: 100},
+	}
+	cloned := CloneLbEndpoint(ep)
+	cloned.LoadBalancingWeight.Value = 200
+	if ep.LoadBalancingWeight.GetValue() != 100 {
+		t.Errorf("original LbEndpoint is mutated")
+	}
+}
+
 func TestConvertAddressToCidr(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pilot/pkg/proxy/envoy/v2/ep_filters.go
+++ b/pilot/pkg/proxy/envoy/v2/ep_filters.go
@@ -69,10 +69,12 @@ func EndpointsByNetworkFilter(endpoints []*endpoint.LocalityLbEndpoints, conn *X
 			epNetwork := istioMetadata(lbEp, "network")
 			if epNetwork == network {
 				// This is a local endpoint
-				lbEp.LoadBalancingWeight = &wrappers.UInt32Value{
+				// shallow lbEndpoint to prevent data race
+				clonedLbEp := util.CloneLbEndpoint(lbEp)
+				clonedLbEp.LoadBalancingWeight = &wrappers.UInt32Value{
 					Value: uint32(multiples),
 				}
-				lbEndpoints = append(lbEndpoints, lbEp)
+				lbEndpoints = append(lbEndpoints, clonedLbEp)
 			} else {
 				// Remote endpoint. Increase the weight counter
 				remoteEps[epNetwork]++


### PR DESCRIPTION
(cherry picked from commit fdc6dd4143680af197dbab8f5f5afdf8fb6c1c06)

https://github.com/istio/istio/pull/22023