### PR TITLE
Fix prometheus operator for istiod

### DIFF
--- a/manifests/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/istio-control/istio-discovery/files/gen-istio.yaml
@@ -826,6 +826,7 @@ metadata:
   labels:
     istio.io/rev: default
     app: istiod
+    istio: pilot
     release: istio-base
 spec:
   ports:

--- a/manifests/istio-control/istio-discovery/templates/service.yaml
+++ b/manifests/istio-control/istio-discovery/templates/service.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
     app: istiod
+    istio: pilot
     release: {{ .Release.Name }}
 spec:
   ports:

--- a/manifests/istio-telemetry/prometheusOperator/templates/servicemonitors.yaml
+++ b/manifests/istio-telemetry/prometheusOperator/templates/servicemonitors.yaml
@@ -27,6 +27,7 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   jobLabel: istio
+  targetLabels: [app]
   selector:
     matchExpressions:
       - {key: istio, operator: In, values: [mixer,pilot,galley,citadel,sidecar-injector]}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -9813,6 +9813,7 @@ metadata:
   labels:
     istio.io/rev: default
     app: istiod
+    istio: pilot
     release: istio
 spec:
   ports:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
@@ -7939,6 +7939,7 @@ metadata:
   labels:
     istio.io/rev: default
     app: istiod
+    istio: pilot
     release: istio
 spec:
   ports:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/icp_input.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/icp_input.golden.yaml
@@ -142,6 +142,7 @@ kind: Service
 metadata:
   labels:
     app: istiod
+    istio: pilot
     istio.io/rev: default
     release: istio
   name: istiod

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -947,6 +947,7 @@ metadata:
   labels:
     istio.io/rev: default
     app: istiod
+    istio: pilot
     release: istio
 spec:
   ports:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_kubernetes.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_kubernetes.golden.yaml
@@ -142,6 +142,7 @@ kind: Service
 metadata:
   labels:
     app: istiod
+    istio: pilot
     istio.io/rev: default
     release: istio
   name: istiod

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -18824,6 +18824,7 @@ metadata:
   labels:
     istio.io/rev: default
     app: istiod
+    istio: pilot
     release: istio-base
 spec:
   ports:
@@ -21003,6 +21004,7 @@ metadata:
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
     app: istiod
+    istio: pilot
     release: {{ .Release.Name }}
 spec:
   ports:
@@ -41515,6 +41517,7 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   jobLabel: istio
+  targetLabels: [app]
   selector:
     matchExpressions:
       - {key: istio, operator: In, values: [mixer,pilot,galley,citadel,sidecar-injector]}


### PR DESCRIPTION
A recent change made our grafana dashboards query based on the app label
instead of the job label. The operator configs do not have the app
label. This change adds the app label, and additionally adds istio=pilot
label to the Service for consistency (otherwise we will need another
ServiceMonitor)