### PR TITLE
Make use of metadata informer

### DIFF
--- a/mixer/adapter/kubernetesenv/kubernetesenv.go
+++ b/mixer/adapter/kubernetesenv/kubernetesenv.go
@@ -34,6 +34,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	k8s "k8s.io/client-go/kubernetes"
+	kubemeta "k8s.io/client-go/metadata"
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // needed for auth
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
@@ -370,7 +371,7 @@ func newKubernetesClient(kubeconfigPath string, env adapter.Env) (k8s.Interface,
 	return k8s.NewForConfig(config)
 }
 
-func (b *builder) createCacheController(k8sInterface k8s.Interface, clusterID string) error {
+func (b *builder) createCacheController(k8sInterface k8s.Interface, _ kubemeta.Interface, clusterID string) error {
 	controller, err := runNewController(b, k8sInterface, b.kubeHandler.env)
 	if err == nil {
 		b.Lock()
@@ -388,11 +389,11 @@ func (b *builder) createCacheController(k8sInterface k8s.Interface, clusterID st
 	return b.kubeHandler.env.Logger().Errorf("error on creating remote controller %s err = %v", clusterID, err)
 }
 
-func (b *builder) updateCacheController(k8sInterface k8s.Interface, clusterID string) error {
+func (b *builder) updateCacheController(k8sInterface k8s.Interface, _ kubemeta.Interface, clusterID string) error {
 	if err := b.deleteCacheController(clusterID); err != nil {
 		return err
 	}
-	return b.createCacheController(k8sInterface, clusterID)
+	return b.createCacheController(k8sInterface, nil, clusterID)
 }
 
 func (b *builder) deleteCacheController(clusterID string) error {

--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -85,7 +85,7 @@ func (s *Server) initKubeRegistry(serviceControllers *aggregate.Controller, args
 	} else {
 		args.Config.ControllerOptions.EndpointMode = kubecontroller.EndpointsOnly
 	}
-	kubeRegistry := kubecontroller.NewController(s.kubeClient, args.Config.ControllerOptions)
+	kubeRegistry := kubecontroller.NewController(s.kubeClient, s.metadataClient, args.Config.ControllerOptions)
 	s.kubeRegistry = kubeRegistry
 	serviceControllers.AddRegistry(kubeRegistry)
 	return

--- a/pilot/pkg/serviceregistry/kube/controller/util.go
+++ b/pilot/pkg/serviceregistry/kube/controller/util.go
@@ -16,6 +16,7 @@ package controller
 
 import (
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func hasProxyIP(addresses []v1.EndpointAddress, proxyIP string) bool {
@@ -27,11 +28,12 @@ func hasProxyIP(addresses []v1.EndpointAddress, proxyIP string) bool {
 	return false
 }
 
-func getLabelValue(node *v1.Node, label string, fallBackLabel string) string {
-	val := node.Labels[label]
+func getLabelValue(metadata metav1.Object, label string, fallBackLabel string) string {
+	labels := metadata.GetLabels()
+	val := labels[label]
 	if val != "" {
 		return val
 	}
 
-	return node.Labels[fallBackLabel]
+	return labels[fallBackLabel]
 }


### PR DESCRIPTION
Please provide a description for what this PR is for.

Currently istio watches k8s node with the shared informer, and caches all the node object. But actually we only need the node labels.  K8s provides a metadata infomer, with which we can only get/cache the metadata.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[X] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
