### PR TITLE
Make analyzer skip files with non yaml or json extension

### DIFF
--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -89,6 +89,8 @@ var (
 		diag.Warning: "\033[33m",   // yellow
 		diag.Error:   "\033[1;31m", // bold red
 	}
+
+	fileExtensions = []string{".json", ".yaml", ".yml"}
 )
 
 // Analyze command
@@ -141,7 +143,7 @@ istioctl analyze -L
 				return nil
 			}
 
-			readers, err := gatherFiles(args)
+			readers, err := gatherFiles(cmd, args)
 			if err != nil {
 				return err
 			}
@@ -334,7 +336,7 @@ istioctl analyze -L
 	return analysisCmd
 }
 
-func gatherFiles(args []string) ([]local.ReaderSource, error) {
+func gatherFiles(cmd *cobra.Command, args []string) ([]local.ReaderSource, error) {
 	var readers []local.ReaderSource
 	for _, f := range args {
 		var r *os.File
@@ -342,7 +344,7 @@ func gatherFiles(args []string) ([]local.ReaderSource, error) {
 		// Handle "-" as stdin as a special case.
 		if f == "-" {
 			if isatty.IsTerminal(os.Stdin.Fd()) {
-				fmt.Fprint(os.Stderr, "Reading from stdin:\n")
+				fmt.Fprint(cmd.OutOrStdout(), "Reading from stdin:\n")
 			}
 			r = os.Stdin
 			readers = append(readers, local.ReaderSource{Name: f, Reader: r})
@@ -355,12 +357,16 @@ func gatherFiles(args []string) ([]local.ReaderSource, error) {
 		}
 
 		if fi.IsDir() {
-			dirReaders, err := gatherFilesInDirectory(f)
+			dirReaders, err := gatherFilesInDirectory(cmd, f)
 			if err != nil {
 				return nil, err
 			}
 			readers = append(readers, dirReaders...)
 		} else {
+			if !isValidFile(f) {
+				fmt.Fprintf(cmd.OutOrStderr(), "Skipping file %v, recognized file extensions are: %v\n", f, fileExtensions)
+				continue
+			}
 			rs, err := gatherFile(f)
 			if err != nil {
 				return nil, err
@@ -380,7 +386,7 @@ func gatherFile(f string) (local.ReaderSource, error) {
 	return local.ReaderSource{Name: f, Reader: r}, nil
 }
 
-func gatherFilesInDirectory(dir string) ([]local.ReaderSource, error) {
+func gatherFilesInDirectory(cmd *cobra.Command, dir string) ([]local.ReaderSource, error) {
 	var readers []local.ReaderSource
 
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
@@ -393,6 +399,11 @@ func gatherFilesInDirectory(dir string) ([]local.ReaderSource, error) {
 			if !recursive && dir != path {
 				return filepath.SkipDir
 			}
+			return nil
+		}
+
+		if !isValidFile(path) {
+			fmt.Fprintf(cmd.OutOrStdout(), "Skipping file %v, recognized file extensions are: %v\n", path, fileExtensions)
 			return nil
 		}
 
@@ -469,6 +480,16 @@ func errorIfMessagesExceedThreshold(messages []diag.Message) error {
 	}
 
 	return nil
+}
+
+func isValidFile(f string) bool {
+	ext := filepath.Ext(f)
+	for _, e := range fileExtensions {
+		if e == ext {
+			return true
+		}
+	}
+	return false
 }
 
 type messageThreshold struct {

--- a/tests/integration/galley/analyze_test.go
+++ b/tests/integration/galley/analyze_test.go
@@ -34,6 +34,7 @@ const (
 	serviceRoleBindingFile = "testdata/servicerolebinding.yaml"
 	serviceRoleFile        = "testdata/servicerole.yaml"
 	invalidFile            = "testdata/invalid.yaml"
+	invalidExtensionFile   = "testdata/invalid.md"
 	dirWithConfig          = "testdata/some-dir/"
 )
 
@@ -129,7 +130,7 @@ func TestDirectoryWithRecursion(t *testing.T) {
 		})
 }
 
-func TestFileParseError(t *testing.T) {
+func TestInvalidFileError(t *testing.T) {
 	framework.
 		NewTest(t).
 		Run(func(ctx framework.TestContext) {
@@ -142,8 +143,13 @@ func TestFileParseError(t *testing.T) {
 
 			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
 
+			// Skip the file with invalid extension and produce no errors.
+			output, err := istioctlSafe(t, istioCtl, ns.Name(), false, invalidExtensionFile)
+			g.Expect(output[0]).To(ContainSubstring(fmt.Sprintf("Skipping file %v, recognized file extensions are: [.json .yaml .yml]", invalidExtensionFile)))
+			g.Expect(err).To(BeNil())
+
 			// Parse error as the yaml file itself is not valid yaml.
-			output, err := istioctlSafe(t, istioCtl, ns.Name(), false, invalidFile)
+			output, err = istioctlSafe(t, istioCtl, ns.Name(), false, invalidFile)
 			g.Expect(output[0]).To(ContainSubstring("Error(s) adding files"))
 			g.Expect(output[1]).To(ContainSubstring(fmt.Sprintf("errors parsing content \"%s\"", invalidFile)))
 

--- a/tests/integration/galley/testdata/invalid.md
+++ b/tests/integration/galley/testdata/invalid.md
@@ -1,0 +1,1 @@
+This is a markdown not yaml.

--- a/tests/integration/galley/testdata/servicerolebinding.json
+++ b/tests/integration/galley/testdata/servicerolebinding.json
@@ -1,0 +1,19 @@
+{
+  "apiVersion": "rbac.istio.io/v1alpha1",
+  "kind": "ServiceRoleBinding",
+  "metadata": {
+    "name": "service-role-binding"
+  },
+  "spec": {
+    "mode": "PERMISSIVE",
+    "roleRef": {
+      "kind": "ServiceRole",
+      "name": "service-role"
+    },
+    "subjects": [
+      {
+        "user": "*"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Please provide a description for what this PR is for.
fix https://github.com/istio/istio/issues/21712
We are already handling parsing error. This fix just skips the files with non yaml or json extension and prints out a message.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure
