### PR TITLE
Do not have Namespace in manifests

### DIFF
--- a/manifests/base/files/gen-istio-cluster.yaml
+++ b/manifests/base/files/gen-istio-cluster.yaml
@@ -1,14 +1,4 @@
 ---
-# Source: base/templates/namespaces.yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: istio-system
-  labels:
-    istio-operator-managed: Reconcile
-    istio-injection: disabled
-
----
 # Source: base/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount

--- a/manifests/base/templates/namespaces.yaml
+++ b/manifests/base/templates/namespaces.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.global.istioNamespace }}
-  labels:
-    istio-operator-managed: Reconcile
-    istio-injection: disabled

--- a/manifests/base/values.yaml
+++ b/manifests/base/values.yaml
@@ -2,12 +2,8 @@ global:
 
   # ImagePullSecrets for control plane ServiceAccount, list of secrets in the same namespace
   # to use for pulling any images in pods that reference this ServiceAccount.
-  # Must be set for any clustser configured with private docker registry.
+  # Must be set for any cluster configured with private docker registry.
   imagePullSecrets: []
 
-  # Used to locate istio-pilot.
-  # Default is to install pilot in a dedicated namespace, istio-pilot11. You can use multiple namespaces, but
-  # for each 'profile' you need to match the control plane namespace and the value of istioNamespace
-  # It is assumed that istio-system is running either 1.0 or an upgraded version of 1.1, but only security components are
-  # used (citadel generating the secrets).
+  # Used to locate istiod.
   istioNamespace: istio-system

--- a/operator/cmd/mesh/manifest-apply.go
+++ b/operator/cmd/mesh/manifest-apply.go
@@ -145,7 +145,7 @@ func ApplyManifests(setOverlay []string, inFilenames []string, force bool, dryRu
 		manifests[cn] = append(manifests[cn], fmt.Sprintf("# %s component has been deprecated.\n", cn))
 	}
 
-	out, err := manifest.ApplyAll(manifests, version.OperatorBinaryVersion, iop, opts)
+	out, err := manifest.ApplyAll(manifests, version.OperatorBinaryVersion, iops, opts)
 	if err != nil {
 		return fmt.Errorf("failed to apply manifest with kubectl client: %v", err)
 	}

--- a/operator/cmd/mesh/manifest-apply.go
+++ b/operator/cmd/mesh/manifest-apply.go
@@ -145,7 +145,7 @@ func ApplyManifests(setOverlay []string, inFilenames []string, force bool, dryRu
 		manifests[cn] = append(manifests[cn], fmt.Sprintf("# %s component has been deprecated.\n", cn))
 	}
 
-	out, err := manifest.ApplyAll(manifests, version.OperatorBinaryVersion, iops.Revision, opts)
+	out, err := manifest.ApplyAll(manifests, version.OperatorBinaryVersion, iop, opts)
 	if err != nil {
 		return fmt.Errorf("failed to apply manifest with kubectl client: %v", err)
 	}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -7478,16 +7478,6 @@ spec:
 
 
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: istio-system
-  labels:
-    istio-operator-managed: Reconcile
-    istio-injection: disabled
----
-
-
-apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: istio-reader-service-account

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
@@ -6728,16 +6728,6 @@ spec:
 
 
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: istio-system
-  labels:
-    istio-operator-managed: Reconcile
-    istio-injection: disabled
----
-
-
-apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: istio-reader-service-account

--- a/operator/pkg/manifest/installer.go
+++ b/operator/pkg/manifest/installer.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"istio.io/api/operator/v1alpha1"
 	"os"
 	"path/filepath"
 	"sort"
@@ -26,7 +25,8 @@ import (
 	"sync"
 	"time"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"istio.io/api/operator/v1alpha1"
+
 	"github.com/ghodss/yaml"
 	"github.com/hashicorp/go-multierror"
 	goversion "github.com/hashicorp/go-version"
@@ -35,6 +35,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"

--- a/operator/pkg/manifest/installer.go
+++ b/operator/pkg/manifest/installer.go
@@ -293,8 +293,14 @@ func createNamespace(namespace string) error {
 	if e != nil {
 		return fmt.Errorf("k8s client error: %s", e)
 	}
-	_, err := cs.CoreV1().Namespaces().Create(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
-	if err != nil && !kerrors.IsNotFound(err) {
+	ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: namespace,
+		Labels: map[string]string{
+			"istio-injection": "disabled",
+		},
+	}}
+	_, err := cs.CoreV1().Namespaces().Create(ns)
+	if err != nil && !kerrors.IsAlreadyExists(err) {
 		return fmt.Errorf("failed to create namespace %v: %v", namespace, err)
 	}
 	return nil

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -11,7 +11,6 @@
 // charts/base/templates/clusterrolebinding.yaml
 // charts/base/templates/crds.yaml
 // charts/base/templates/endpoints.yaml
-// charts/base/templates/namespaces.yaml
 // charts/base/templates/serviceaccount.yaml
 // charts/base/templates/services.yaml
 // charts/base/templates/validatingwebhookconfiguration.yaml
@@ -6829,16 +6828,6 @@ func chartsBaseFilesCrdOperatorYaml() (*asset, error) {
 }
 
 var _chartsBaseFilesGenIstioClusterYaml = []byte(`---
-# Source: base/templates/namespaces.yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: istio-system
-  labels:
-    istio-operator-managed: Reconcile
-    istio-injection: disabled
-
----
 # Source: base/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -13981,30 +13970,6 @@ func chartsBaseTemplatesEndpointsYaml() (*asset, error) {
 	return a, nil
 }
 
-var _chartsBaseTemplatesNamespacesYaml = []byte(`apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.global.istioNamespace }}
-  labels:
-    istio-operator-managed: Reconcile
-    istio-injection: disabled
-`)
-
-func chartsBaseTemplatesNamespacesYamlBytes() ([]byte, error) {
-	return _chartsBaseTemplatesNamespacesYaml, nil
-}
-
-func chartsBaseTemplatesNamespacesYaml() (*asset, error) {
-	bytes, err := chartsBaseTemplatesNamespacesYamlBytes()
-	if err != nil {
-		return nil, err
-	}
-
-	info := bindataFileInfo{name: "charts/base/templates/namespaces.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
-	a := &asset{bytes: bytes, info: info}
-	return a, nil
-}
-
 var _chartsBaseTemplatesServiceaccountYaml = []byte(`apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.global.imagePullSecrets }}
@@ -14201,14 +14166,10 @@ var _chartsBaseValuesYaml = []byte(`global:
 
   # ImagePullSecrets for control plane ServiceAccount, list of secrets in the same namespace
   # to use for pulling any images in pods that reference this ServiceAccount.
-  # Must be set for any clustser configured with private docker registry.
+  # Must be set for any cluster configured with private docker registry.
   imagePullSecrets: []
 
-  # Used to locate istio-pilot.
-  # Default is to install pilot in a dedicated namespace, istio-pilot11. You can use multiple namespaces, but
-  # for each 'profile' you need to match the control plane namespace and the value of istioNamespace
-  # It is assumed that istio-system is running either 1.0 or an upgraded version of 1.1, but only security components are
-  # used (citadel generating the secrets).
+  # Used to locate istiod.
   istioNamespace: istio-system
 `)
 
@@ -45540,7 +45501,6 @@ var _bindata = map[string]func() (*asset, error){
 	"charts/base/templates/clusterrolebinding.yaml":                                        chartsBaseTemplatesClusterrolebindingYaml,
 	"charts/base/templates/crds.yaml":                                                      chartsBaseTemplatesCrdsYaml,
 	"charts/base/templates/endpoints.yaml":                                                 chartsBaseTemplatesEndpointsYaml,
-	"charts/base/templates/namespaces.yaml":                                                chartsBaseTemplatesNamespacesYaml,
 	"charts/base/templates/serviceaccount.yaml":                                            chartsBaseTemplatesServiceaccountYaml,
 	"charts/base/templates/services.yaml":                                                  chartsBaseTemplatesServicesYaml,
 	"charts/base/templates/validatingwebhookconfiguration.yaml":                            chartsBaseTemplatesValidatingwebhookconfigurationYaml,
@@ -45790,7 +45750,6 @@ var _bintree = &bintree{nil, map[string]*bintree{
 				"clusterrolebinding.yaml":             &bintree{chartsBaseTemplatesClusterrolebindingYaml, map[string]*bintree{}},
 				"crds.yaml":                           &bintree{chartsBaseTemplatesCrdsYaml, map[string]*bintree{}},
 				"endpoints.yaml":                      &bintree{chartsBaseTemplatesEndpointsYaml, map[string]*bintree{}},
-				"namespaces.yaml":                     &bintree{chartsBaseTemplatesNamespacesYaml, map[string]*bintree{}},
 				"serviceaccount.yaml":                 &bintree{chartsBaseTemplatesServiceaccountYaml, map[string]*bintree{}},
 				"services.yaml":                       &bintree{chartsBaseTemplatesServicesYaml, map[string]*bintree{}},
 				"validatingwebhookconfiguration.yaml": &bintree{chartsBaseTemplatesValidatingwebhookconfigurationYaml, map[string]*bintree{}},


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/22313
Fixes https://github.com/istio/istio/issues/22492

Managing a namespace is outside of the scope of an Istio installation.
The user experience here is not impacted, as we will create the
namespace if it doesn't exist. Controller is not impacted, as the
namespace must exist in order for the IOP to exist. Helm is not impacted
here because creating the namespace as part of the templates is
considered a "bad practice" in helm3 (source: https://github.com/helm/helm/issues/5753#issuecomment-502163585)