### PR TITLE
Allow missing CRDs in Pilot

### DIFF
--- a/pilot/pkg/config/kube/crd/controller/client.go
+++ b/pilot/pkg/config/kube/crd/controller/client.go
@@ -422,7 +422,7 @@ func (cl *Client) objectInEnvironment(o *model.Config) bool {
 func (cl *Client) CRDExists(schema collection.Schema) (bool, error) {
 	// From the spec: "Its name MUST be in the format <.spec.name>.<.spec.group>."
 	name := fmt.Sprintf("%s.%s", schema.Resource().Plural(), schema.Resource().Group())
-	_, err := cl.crdClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(name, meta_v1.GetOptions{})
+	_, err := cl.crdClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context2.TODO(), name, meta_v1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		// Not found, return false
 		return false, nil

--- a/pilot/pkg/config/kube/crd/controller/controller.go
+++ b/pilot/pkg/config/kube/crd/controller/controller.go
@@ -121,6 +121,8 @@ func NewController(client *Client, options controller2.Options) model.ConfigStor
 	for _, s := range client.Schemas().All() {
 		if crdExistsWithRetry(client, s) {
 			out.addInformer(s, options.WatchedNamespace, options.ResyncPeriod)
+		} else {
+			log.Warnf("Skipping CRD %v as it is not present", s.String())
 		}
 	}
 

--- a/pilot/pkg/config/kube/crd/controller/controller.go
+++ b/pilot/pkg/config/kube/crd/controller/controller.go
@@ -331,7 +331,14 @@ func (c *controller) Run(stop <-chan struct{}) {
 }
 
 func (c *controller) Schemas() collection.Schemas {
-	return c.client.Schemas()
+	sb := collection.NewSchemasBuilder()
+	for _, schema := range c.client.Schemas().All() {
+		gvk := schema.Resource().GroupVersionKind()
+		if _, f := c.kinds[gvk]; f {
+			sb.MustAdd(schema)
+		}
+	}
+	return sb.Build()
 }
 
 func (c *controller) Get(typ resource.GroupVersionKind, name, namespace string) *model.Config {

--- a/pkg/config/schema/resource/schema.go
+++ b/pkg/config/schema/resource/schema.go
@@ -76,9 +76,9 @@ type Schema interface {
 }
 
 type GroupVersionKind struct {
-	Group   string
-	Version string
-	Kind    string
+	Group   string `json:"group"`
+	Version string `json:"version"`
+	Kind    string `json:"kind"`
 }
 
 var _ fmt.Stringer = GroupVersionKind{}

--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -407,7 +407,10 @@ func (c *Controller) isEndpointReady() (ready bool, reason string, err error) {
 	return ready, reason, nil
 }
 
-const deniedRequestMessageFragment = `admission webhook "validation.istio.io" denied the request`
+const (
+	deniedRequestMessageFragment   = `admission webhook "validation.istio.io" denied the request`
+	missingResourceMessageFragment = `the server could not find the requested resource`
+)
 
 // Confirm invalid configuration is successfully rejected before switching to FAIL-CLOSE.
 func (c *Controller) isDryRunOfInvalidConfigRejected() (rejected bool, reason string) {
@@ -426,7 +429,7 @@ func (c *Controller) isDryRunOfInvalidConfigRejected() (rejected bool, reason st
 	if err == nil {
 		return false, fmt.Sprintf("dummy invalid config not rejected")
 	}
-	if !strings.Contains(err.Error(), deniedRequestMessageFragment) {
+	if !(strings.Contains(err.Error(), deniedRequestMessageFragment) || strings.Contains(err.Error(), missingResourceMessageFragment)) {
 		return false, fmt.Sprintf("dummy invalid rejected for the wrong reason: %v", err)
 	}
 	return true, ""


### PR DESCRIPTION
Currently we will block startup if we do not have CRDs. In reality, we
don't need to do this - its perfectly reasonable to not have the CRDs if
you are not planning to use them.

This changes the startup scheme to block startup until all CRDs that
exist are sycned - other CRDs, we will continue to poll in the
background to ensure if they are later added we can start recieving
configs.