### PR TITLE
Support cluster-local services

### DIFF
--- a/pilot/pkg/bootstrap/mesh.go
+++ b/pilot/pkg/bootstrap/mesh.go
@@ -125,7 +125,7 @@ func getMeshConfig(kube kubernetes.Interface, namespace, name string) (*meshconf
 
 	meshConfig, err := mesh.ApplyMeshConfigDefaults(cfgYaml)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed reading mesh config: %v. YAML:\n%s", err, cfgYaml)
 	}
 
 	log.Warn("Loading default mesh config from K8S, no reload support.")

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -50,7 +50,7 @@ func NewClusterBuilder(proxy *model.Proxy, push *model.PushContext) *ClusterBuil
 
 // applyDestinationRule applies the destination rule if it exists for the Service. It returns the subset clusters if any created as it
 // applies the destination rule.
-func (cb *ClusterBuilder) applyDestinationRule(cluster *apiv2.Cluster, clusterMode ClusterMode, service *model.Service, port *model.Port,
+func (cb *ClusterBuilder) applyDestinationRule(proxy *model.Proxy, cluster *apiv2.Cluster, clusterMode ClusterMode, service *model.Service, port *model.Port,
 	proxyNetworkView map[string]bool) []*apiv2.Cluster {
 	destRule := cb.push.DestinationRule(cb.proxy, service)
 	destinationRule := castDestinationRuleOrDefault(destRule)
@@ -100,7 +100,7 @@ func (cb *ClusterBuilder) applyDestinationRule(cluster *apiv2.Cluster, clusterMo
 		// ServiceEntry's need to filter hosts based on subset.labels in order to perform weighted routing
 		var lbEndpoints []*endpoint.LocalityLbEndpoints
 		if cluster.GetType() != apiv2.Cluster_EDS && len(subset.Labels) != 0 {
-			lbEndpoints = buildLocalityLbEndpoints(cb.push, proxyNetworkView, service, port.Port, []labels.Instance{subset.Labels})
+			lbEndpoints = buildLocalityLbEndpoints(proxy, cb.push, proxyNetworkView, service, port.Port, []labels.Instance{subset.Labels})
 		}
 
 		subsetCluster := cb.buildDefaultCluster(subsetClusterName, cluster.GetType(), lbEndpoints,

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -233,7 +233,7 @@ func TestApplyDestinationRule(t *testing.T) {
 
 			cb := NewClusterBuilder(tt.proxy, env.PushContext)
 
-			subsetClusters := cb.applyDestinationRule(tt.cluster, tt.clusterMode, tt.service, tt.port, tt.networkView)
+			subsetClusters := cb.applyDestinationRule(tt.proxy, tt.cluster, tt.clusterMode, tt.service, tt.port, tt.networkView)
 			if len(subsetClusters) != len(tt.expectedSubsetClusters) {
 				t.Errorf("Unexpected subset clusters want %v, got %v", len(tt.expectedSubsetClusters), len(subsetClusters))
 			}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -17,20 +17,22 @@ package v1alpha3
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 	"time"
 
-	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
-
-	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/wrappers"
-
 	apiv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	apiv2_cluster "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	envoyEndpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/ptypes"
+	structpb "github.com/golang/protobuf/ptypes/struct"
+	"github.com/golang/protobuf/ptypes/wrappers"
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 
 	authn "istio.io/api/authentication/v1alpha1"
@@ -539,6 +541,11 @@ func newTestEnvironment(serviceDiscovery model.ServiceDiscovery, meshConfig mesh
 	env.PushContext = model.NewPushContext()
 	_ = env.PushContext.InitContext(env, nil, nil)
 
+	return env
+}
+
+func withClusterLocalNamespaces(env *model.Environment, ns ...string) *model.Environment { // nolint:interfacer
+	env.Mesh().ClusterLocalNamespaces = ns
 	return env
 }
 
@@ -1442,9 +1449,9 @@ func TestGatewayLocalityLB(t *testing.T) {
 }
 
 func TestBuildLocalityLbEndpoints(t *testing.T) {
-	g := NewGomegaWithT(t)
-	serviceDiscovery := &fakes.ServiceDiscovery{}
-
+	proxy := &model.Proxy{
+		ClusterID: "cluster-1",
+	}
 	servicePort := &model.Port{
 		Name:     "default",
 		Port:     8080,
@@ -1456,63 +1463,251 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 		ClusterVIPs: make(map[string]string),
 		Ports:       model.PortList{servicePort},
 		Resolution:  model.DNSLB,
-	}
-	instances := []*model.ServiceInstance{
-		{
-			Service:     service,
-			ServicePort: servicePort,
-			Endpoint: &model.IstioEndpoint{
-				Address:      "192.168.1.1",
-				EndpointPort: 10001,
-				Locality: model.Locality{
-					ClusterID: "",
-					Label:     "region1/zone1/subzone1",
-				},
-				LbWeight: 30,
-			},
-		},
-		{
-			Service:     service,
-			ServicePort: servicePort,
-			Endpoint: &model.IstioEndpoint{
-				Address:      "192.168.1.2",
-				EndpointPort: 10001,
-				Locality: model.Locality{
-					ClusterID: "",
-					Label:     "region1/zone1/subzone1",
-				},
-				LbWeight: 30,
-			},
-		},
-		{
-			Service:     service,
-			ServicePort: servicePort,
-			Endpoint: &model.IstioEndpoint{
-				Address:      "192.168.1.3",
-				EndpointPort: 10001,
-				Locality: model.Locality{
-					ClusterID: "",
-					Label:     "region2/zone1/subzone1",
-				},
-				LbWeight: 40,
-			},
+		Attributes: model.ServiceAttributes{
+			Name:      "TestService",
+			Namespace: "test-ns",
 		},
 	}
 
-	serviceDiscovery.ServicesReturns([]*model.Service{service}, nil)
-	serviceDiscovery.InstancesByPortReturns(instances, nil)
+	emptyMetadata := &core.Metadata{
+		FilterMetadata: make(map[string]*structpb.Struct),
+	}
 
-	configStore := &fakes.IstioConfigStore{}
-	env := newTestEnvironment(serviceDiscovery, testMesh, configStore)
+	cases := []struct {
+		name      string
+		newEnv    func(model.ServiceDiscovery, model.IstioConfigStore) *model.Environment
+		instances []*model.ServiceInstance
+		expected  []*envoyEndpoint.LocalityLbEndpoints
+	}{
+		{
+			name: "basics",
+			newEnv: func(sd model.ServiceDiscovery, cs model.IstioConfigStore) *model.Environment {
+				return newTestEnvironment(sd, testMesh, cs)
+			},
+			instances: []*model.ServiceInstance{
+				{
+					Service:     service,
+					ServicePort: servicePort,
+					Endpoint: &model.IstioEndpoint{
+						Address:      "192.168.1.1",
+						EndpointPort: 10001,
+						Locality: model.Locality{
+							ClusterID: "cluster-1",
+							Label:     "region1/zone1/subzone1",
+						},
+						LbWeight: 30,
+					},
+				},
+				{
+					Service:     service,
+					ServicePort: servicePort,
+					Endpoint: &model.IstioEndpoint{
+						Address:      "192.168.1.2",
+						EndpointPort: 10001,
+						Locality: model.Locality{
+							ClusterID: "cluster-2",
+							Label:     "region1/zone1/subzone1",
+						},
+						LbWeight: 30,
+					},
+				},
+				{
+					Service:     service,
+					ServicePort: servicePort,
+					Endpoint: &model.IstioEndpoint{
+						Address:      "192.168.1.3",
+						EndpointPort: 10001,
+						Locality: model.Locality{
+							ClusterID: "cluster-3",
+							Label:     "region2/zone1/subzone1",
+						},
+						LbWeight: 40,
+					},
+				},
+			},
+			expected: []*envoyEndpoint.LocalityLbEndpoints{
+				{
+					Locality: &core.Locality{
+						Region:  "region1",
+						Zone:    "zone1",
+						SubZone: "subzone1",
+					},
+					LoadBalancingWeight: &wrappers.UInt32Value{
+						Value: 60,
+					},
+					LbEndpoints: []*envoyEndpoint.LbEndpoint{
+						{
+							HostIdentifier: &envoyEndpoint.LbEndpoint_Endpoint{
+								Endpoint: &envoyEndpoint.Endpoint{
+									Address: &core.Address{
+										Address: &core.Address_SocketAddress{
+											SocketAddress: &core.SocketAddress{
+												Address: "192.168.1.1",
+												PortSpecifier: &core.SocketAddress_PortValue{
+													PortValue: 10001,
+												},
+											},
+										},
+									},
+								},
+							},
+							Metadata: emptyMetadata,
+							LoadBalancingWeight: &wrappers.UInt32Value{
+								Value: 30,
+							},
+						},
+						{
+							HostIdentifier: &envoyEndpoint.LbEndpoint_Endpoint{
+								Endpoint: &envoyEndpoint.Endpoint{
+									Address: &core.Address{
+										Address: &core.Address_SocketAddress{
+											SocketAddress: &core.SocketAddress{
+												Address: "192.168.1.2",
+												PortSpecifier: &core.SocketAddress_PortValue{
+													PortValue: 10001,
+												},
+											},
+										},
+									},
+								},
+							},
+							Metadata: emptyMetadata,
+							LoadBalancingWeight: &wrappers.UInt32Value{
+								Value: 30,
+							},
+						},
+					},
+				},
+				{
+					Locality: &core.Locality{
+						Region:  "region2",
+						Zone:    "zone1",
+						SubZone: "subzone1",
+					},
+					LoadBalancingWeight: &wrappers.UInt32Value{
+						Value: 40,
+					},
+					LbEndpoints: []*envoyEndpoint.LbEndpoint{
+						{
+							HostIdentifier: &envoyEndpoint.LbEndpoint_Endpoint{
+								Endpoint: &envoyEndpoint.Endpoint{
+									Address: &core.Address{
+										Address: &core.Address_SocketAddress{
+											SocketAddress: &core.SocketAddress{
+												Address: "192.168.1.3",
+												PortSpecifier: &core.SocketAddress_PortValue{
+													PortValue: 10001,
+												},
+											},
+										},
+									},
+								},
+							},
+							Metadata: emptyMetadata,
+							LoadBalancingWeight: &wrappers.UInt32Value{
+								Value: 40,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "cluster local",
+			newEnv: func(sd model.ServiceDiscovery, cs model.IstioConfigStore) *model.Environment {
+				return withClusterLocalNamespaces(newTestEnvironment(sd, testMesh, cs), "test-ns")
+			},
+			instances: []*model.ServiceInstance{
+				{
+					Service:     service,
+					ServicePort: servicePort,
+					Endpoint: &model.IstioEndpoint{
+						Address:      "192.168.1.1",
+						EndpointPort: 10001,
+						Locality: model.Locality{
+							ClusterID: "cluster-1",
+							Label:     "region1/zone1/subzone1",
+						},
+						LbWeight: 30,
+					},
+				},
+				{
+					Service:     service,
+					ServicePort: servicePort,
+					Endpoint: &model.IstioEndpoint{
+						Address:      "192.168.1.2",
+						EndpointPort: 10001,
+						Locality: model.Locality{
+							ClusterID: "cluster-2",
+							Label:     "region1/zone1/subzone1",
+						},
+						LbWeight: 30,
+					},
+				},
+			},
+			expected: []*envoyEndpoint.LocalityLbEndpoints{
+				{
+					Locality: &core.Locality{
+						Region:  "region1",
+						Zone:    "zone1",
+						SubZone: "subzone1",
+					},
+					LoadBalancingWeight: &wrappers.UInt32Value{
+						Value: 30,
+					},
+					LbEndpoints: []*envoyEndpoint.LbEndpoint{
+						{
+							HostIdentifier: &envoyEndpoint.LbEndpoint_Endpoint{
+								Endpoint: &envoyEndpoint.Endpoint{
+									Address: &core.Address{
+										Address: &core.Address_SocketAddress{
+											SocketAddress: &core.SocketAddress{
+												Address: "192.168.1.1",
+												PortSpecifier: &core.SocketAddress_PortValue{
+													PortValue: 10001,
+												},
+											},
+										},
+									},
+								},
+							},
+							Metadata: emptyMetadata,
+							LoadBalancingWeight: &wrappers.UInt32Value{
+								Value: 30,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 
-	localityLbEndpoints := buildLocalityLbEndpoints(env.PushContext, model.GetNetworkView(nil), service, 8080, nil)
-	g.Expect(len(localityLbEndpoints)).To(Equal(2))
-	for _, ep := range localityLbEndpoints {
-		if ep.Locality.Region == "region1" {
-			g.Expect(ep.LoadBalancingWeight.GetValue()).To(Equal(uint32(60)))
-		} else if ep.Locality.Region == "region2" {
-			g.Expect(ep.LoadBalancingWeight.GetValue()).To(Equal(uint32(40)))
-		}
+	sortEndpoints := func(endpoints []*envoyEndpoint.LocalityLbEndpoints) {
+		sort.SliceStable(endpoints, func(i, j int) bool {
+			if strings.Compare(endpoints[i].Locality.Region, endpoints[j].Locality.Region) < 0 {
+				return true
+			}
+			if strings.Compare(endpoints[i].Locality.Zone, endpoints[j].Locality.Zone) < 0 {
+				return true
+			}
+			return strings.Compare(endpoints[i].Locality.SubZone, endpoints[j].Locality.SubZone) < 0
+		})
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			configStore := &fakes.IstioConfigStore{}
+			serviceDiscovery := &fakes.ServiceDiscovery{}
+			serviceDiscovery.ServicesReturns([]*model.Service{service}, nil)
+			serviceDiscovery.InstancesByPortReturns(c.instances, nil)
+
+			env := c.newEnv(serviceDiscovery, configStore)
+			actual := buildLocalityLbEndpoints(proxy, env.PushContext, model.GetNetworkView(nil), service, 8080, nil)
+			sortEndpoints(actual)
+			if v := cmp.Diff(c.expected, actual); v != "" {
+				t.Fatalf("Expected (-) != actual (+):\n%s", v)
+			}
+		})
 	}
 }
 

--- a/pkg/test/framework/components/galley/snapshot.go
+++ b/pkg/test/framework/components/galley/snapshot.go
@@ -72,7 +72,7 @@ func getForNamespace(ns string, actuals []*SnapshotObject) (result []*SnapshotOb
 
 // NewGoldenSnapshotValidator creates a SnapshotValidatorFunc that tests for equivalence against
 // a set of golden object.
-func NewGoldenSnapshotValidator(ns string, goldens []map[string]interface{}) SnapshotValidatorFunc {
+func NewGoldenSnapshotValidator(goldens []map[string]interface{}) SnapshotValidatorFunc {
 	return func(actuals []*SnapshotObject) error {
 		// Convert goldens to a map of JSON objects indexed by name.
 		goldenMap := make(map[string]interface{})

--- a/tests/integration/galley/conversion_test.go
+++ b/tests/integration/galley/conversion_test.go
@@ -110,7 +110,7 @@ func runTest(t *testing.T, ctx resource.Context, fset *conversion.FileSet, gal g
 	}
 
 	for collection, e := range expected {
-		validator := galley.NewGoldenSnapshotValidator(ns.Name(), e)
+		validator := galley.NewGoldenSnapshotValidator(e)
 		if err = gal.WaitForSnapshot(collection, validator); err != nil {
 			t.Fatalf("failed waiting for %s:\n%v\n", collection, err)
 		}

--- a/tests/integration/multicluster/cluster_local_test.go
+++ b/tests/integration/multicluster/cluster_local_test.go
@@ -1,0 +1,47 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicluster
+
+import (
+	"fmt"
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/framework/label"
+)
+
+func TestClusterLocalService(t *testing.T) {
+	framework.NewTest(t).
+		Label(label.Multicluster).
+		Run(func(ctx framework.TestContext) {
+			cluster1 := ctx.Environment().Clusters()[0]
+			cluster2 := ctx.Environment().Clusters()[1]
+
+			// Deploy a only in cluster1, but b in both clusters.
+			var a1, b1, b2 echo.Instance
+			echoboot.NewBuilderOrFail(ctx, ctx).
+				With(&a1, newEchoConfig("a", clusterLocalNS, cluster1)).
+				With(&b1, newEchoConfig("b", clusterLocalNS, cluster1)).
+				With(&b2, newEchoConfig("b", clusterLocalNS, cluster2)).
+				BuildOrFail(ctx)
+
+			results := callOrFail(ctx, a1, b1)
+
+			// Ensure that all requests went to cluster 1.
+			results.CheckClusterOrFail(ctx, fmt.Sprintf("%d", cluster1.Index()))
+		})
+}

--- a/tests/integration/multicluster/reachability_test.go
+++ b/tests/integration/multicluster/reachability_test.go
@@ -20,6 +20,8 @@ import (
 	"time"
 
 	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/echo/client"
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
@@ -66,23 +68,7 @@ func TestMulticlusterReachability(t *testing.T) {
 
 					ctx.NewSubTest(subTestName).
 						RunParallel(func(ctx framework.TestContext) {
-							if err := retry.UntilSuccess(func() error {
-								results, err := src.Call(echo.CallOptions{
-									Target:   dest,
-									PortName: "http",
-									Scheme:   scheme.HTTP,
-								})
-								if err == nil {
-									err = results.CheckOK()
-								}
-								if err != nil {
-									return fmt.Errorf("%s to %s:%s using %s: expected success but failed: %v",
-										src, dest, "http", scheme.HTTP, err)
-								}
-								return nil
-							}, retry.Timeout(retryTimeout), retry.Delay(retryDelay)); err != nil {
-								t.Fatal(err)
-							}
+							_ = callOrFail(ctx, src, dest)
 						})
 				}
 			}
@@ -91,8 +77,7 @@ func TestMulticlusterReachability(t *testing.T) {
 
 func newEchoConfig(service string, ns namespace.Instance, cluster resource.Cluster) echo.Config {
 	return echo.Config{
-		Galley:         g,
-		Pilot:          p,
+		Pilot:          pilots[cluster.Index()],
 		Service:        service,
 		Namespace:      ns,
 		Cluster:        cluster,
@@ -119,4 +104,26 @@ func newEchoConfig(service string, ns namespace.Instance, cluster resource.Clust
 			},
 		},
 	}
+}
+
+func callOrFail(ctx test.Failer, src, dest echo.Instance) client.ParsedResponses {
+	ctx.Helper()
+	var results client.ParsedResponses
+	retry.UntilSuccessOrFail(ctx, func() (err error) {
+		results, err = src.Call(echo.CallOptions{
+			Target:   dest,
+			PortName: "http",
+			Scheme:   scheme.HTTP,
+			Count:    5,
+		})
+		if err == nil {
+			err = results.CheckOK()
+		}
+		if err != nil {
+			return fmt.Errorf("%s to %s:%s using %s: expected success but failed: %v",
+				src.Config().Service, dest.Config().Service, "http", scheme.HTTP, err)
+		}
+		return nil
+	}, retry.Timeout(retryTimeout), retry.Delay(retryDelay))
+	return results
 }


### PR DESCRIPTION
Adds a configuration option to exclude namespaces from being used mesh-wide. If a service is cluster-local, workloads will only use endpoints that reside in the same cluster.go

By default, all services in the `kube-system` and `default` namespaces will be considered cluster local.

Fixes: https://github.com/istio/istio/issues/14692