### PR TITLE
features: evaluate flags at initialization

### DIFF
--- a/pilot/pkg/config/kube/crd/controller/controller.go
+++ b/pilot/pkg/config/kube/crd/controller/controller.go
@@ -332,7 +332,7 @@ func (c *controller) Get(typ resource.GroupVersionKind, name, namespace string) 
 	}
 
 	config, err := crd.ConvertObject(s, obj, c.client.domainSuffix)
-	if err == nil && features.EnableCRDValidation.Get() {
+	if err == nil && features.EnableCRDValidation {
 		if err = s.Resource().ValidateProto(config.Name, config.Namespace, config.Spec); err != nil {
 			handleValidationFailure(obj, err)
 			return nil
@@ -373,7 +373,7 @@ func (c *controller) List(typ resource.GroupVersionKind, namespace string) ([]mo
 
 		config, err := crd.ConvertObject(s, item, c.client.domainSuffix)
 
-		if err == nil && features.EnableCRDValidation.Get() {
+		if err == nil && features.EnableCRDValidation {
 			err = s.Resource().ValidateProto(config.Name, config.Namespace, config.Spec)
 		}
 

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -135,7 +135,7 @@ var (
 		"PILOT_ENABLE_MYSQL_FILTER",
 		false,
 		"EnableMysqlFilter enables injection of `envoy.filters.network.mysql_proxy` in the filter chain.",
-	)
+	).Get()
 
 	// EnableRedisFilter enables injection of `envoy.filters.network.redis_proxy` in the filter chain.
 	// Pilot injects this outbound filter if the service port name is `redis`.
@@ -143,7 +143,7 @@ var (
 		"PILOT_ENABLE_REDIS_FILTER",
 		false,
 		"EnableRedisFilter enables injection of `envoy.filters.network.redis_proxy` in the filter chain.",
-	)
+	).Get()
 
 	// UseRemoteAddress sets useRemoteAddress to true for side car outbound listeners so that it picks up the localhost
 	// address of the sender, which is an internal address, so that trusted headers are not sanitized.
@@ -151,7 +151,7 @@ var (
 		"PILOT_SIDECAR_USE_REMOTE_ADDRESS",
 		false,
 		"UseRemoteAddress sets useRemoteAddress to true for side car outbound listeners.",
-	)
+	).Get()
 
 	// EnableThriftFilter enables injection of `envoy.filters.network.thrift_proxy` in the filter chain.
 	// Pilot injects this outbound filter if the service port name is `thrift`.
@@ -159,7 +159,7 @@ var (
 		"PILOT_ENABLE_THRIFT_FILTER",
 		false,
 		"EnableThriftFilter enables injection of `envoy.filters.network.thrift_proxy` in the filter chain.",
-	)
+	).Get()
 
 	// SkipValidateTrustDomain tells the server proxy to not to check the peer's trust domain when
 	// mTLS is enabled in authentication policy.
@@ -184,14 +184,14 @@ var (
 		"PILOT_ENABLE_TCP_METADATA_EXCHANGE",
 		true,
 		"If enabled, metadata exchange will be enabled for TCP using ALPN and Network Metadata Exchange filters in Envoy",
-	)
+	).Get()
 
 	ScopeGatewayToNamespace = env.RegisterBoolVar(
 		"PILOT_SCOPE_GATEWAY_TO_NAMESPACE",
 		false,
 		"If enabled, a gateway workload can only select gateway resources in the same namespace. "+
 			"Gateways with same selectors in different namespaces will not be applicable.",
-	)
+	).Get()
 
 	InboundProtocolDetectionTimeout = env.RegisterDurationVar(
 		"PILOT_INBOUND_PROTOCOL_DETECTION_TIMEOUT",
@@ -205,7 +205,7 @@ var (
 		"If enabled, for a headless service/stateful set in Kubernetes, pilot will generate an "+
 			"outbound listener for each pod in a headless service. This feature should be disabled "+
 			"if headless services have a large number of pods.",
-	)
+	).Get()
 
 	EnableEDSForHeadless = env.RegisterBoolVar(
 		"PILOT_ENABLE_EDS_FOR_HEADLESS_SERVICES",
@@ -213,7 +213,7 @@ var (
 		"If enabled, for headless service in Kubernetes, pilot will send endpoints over EDS, "+
 			"allowing the sidecar to load balance among pods in the headless service. This feature "+
 			"should be enabled if applications access all services explicitly via a HTTP proxy port in the sidecar.",
-	)
+	).Get()
 
 	BlockHTTPonHTTPSPort = env.RegisterBoolVar(
 		"PILOT_BLOCK_HTTP_ON_443",
@@ -249,7 +249,7 @@ var (
 		"If enabled, pilot will validate CRDs while retrieving CRDs from kubernetes cache."+
 			"Use this flag to enable validation of CRDs in Pilot, especially in deployments "+
 			"that do not have galley installed.",
-	)
+	).Get()
 
 	EnableAnalysis = env.RegisterBoolVar(
 		"PILOT_ENABLE_ANALYSIS",

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -172,13 +172,13 @@ var (
 		"PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_OUTBOUND",
 		true,
 		"If enabled, protocol sniffing will be used for outbound listeners whose port protocol is not specified or unsupported",
-	)
+	).Get()
 
 	EnableProtocolSniffingForInbound = env.RegisterBoolVar(
 		"PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND",
 		true,
 		"If enabled, protocol sniffing will be used for inbound listeners whose port protocol is not specified or unsupported",
-	)
+	).Get()
 
 	EnableTCPMetadataExchange = env.RegisterBoolVar(
 		"PILOT_ENABLE_TCP_METADATA_EXCHANGE",

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -282,7 +282,7 @@ var (
 
 	DefaultRequestTimeout = func() *duration.Duration {
 		return ptypes.DurationProto(defaultRequestTimeoutVar.Get())
-	}
+	}()
 
 	EnableServiceApis = env.RegisterBoolVar("PILOT_ENABLED_SERVICE_APIS", false,
 		"If this is set to true, support for Kubernetes service-apis (github.com/kubernetes-sigs/service-apis) will "+

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1536,7 +1536,7 @@ func (ps *PushContext) mergeGateways(proxy *Proxy) *MergedGateway {
 	out := make([]Config, 0)
 
 	var configs []Config
-	if features.ScopeGatewayToNamespace.Get() {
+	if features.ScopeGatewayToNamespace {
 		configs = ps.gatewaysByNamespace[proxy.ConfigNamespace]
 	} else {
 		configs = ps.allGateways

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -500,7 +500,7 @@ func convertResolution(proxy *model.Proxy, service *model.Service) apiv2.Cluster
 	case model.Passthrough:
 		// Gateways cannot use passthrough clusters. So fallback to EDS
 		if proxy.Type == model.SidecarProxy {
-			if service.Attributes.ServiceRegistry == string(serviceregistry.Kubernetes) && features.EnableEDSForHeadless.Get() {
+			if service.Attributes.ServiceRegistry == string(serviceregistry.Kubernetes) && features.EnableEDSForHeadless {
 				return apiv2.Cluster_EDS
 			}
 
@@ -891,7 +891,7 @@ func applyLoadBalancer(cluster *apiv2.Cluster, lb *networking.LoadBalancerSettin
 	}
 
 	// Redis protocol must be defaulted with MAGLEV to benefit from client side sharding.
-	if features.EnableRedisFilter.Get() && port != nil && port.Protocol == protocol.Redis {
+	if features.EnableRedisFilter && port != nil && port.Protocol == protocol.Redis {
 		cluster.LbPolicy = apiv2.Cluster_MAGLEV
 		return
 	}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -16,7 +16,6 @@ package v1alpha3
 
 import (
 	"fmt"
-	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -1745,9 +1744,9 @@ func TestRedisProtocolClusterAtGateway(t *testing.T) {
 	}
 
 	// enable redis filter to true
-	_ = os.Setenv(features.EnableRedisFilter.Name, "true")
-
-	defer func() { _ = os.Unsetenv(features.EnableRedisFilter.Name) }()
+	defaultValue := features.EnableRedisFilter
+	features.EnableRedisFilter = true
+	defer func() { features.EnableRedisFilter = defaultValue }()
 
 	serviceDiscovery.ServicesReturns([]*model.Service{service}, nil)
 
@@ -2127,8 +2126,9 @@ func TestApplyLoadBalancer(t *testing.T) {
 			}
 
 			if test.port != nil && test.port.Protocol == protocol.Redis {
-				os.Setenv("PILOT_ENABLE_REDIS_FILTER", "true")
-				defer os.Unsetenv("PILOT_ENABLE_REDIS_FILTER")
+				defaultValue := features.EnableRedisFilter
+				features.EnableRedisFilter = true
+				defer func() { features.EnableRedisFilter = defaultValue }()
 			}
 
 			applyLoadBalancer(cluster, test.lbSettings, test.port, &proxy, &meshconfig.MeshConfig{})

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -197,11 +197,9 @@ func TestCommonHttpProtocolOptions(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		if tc.sniffingEnabledForInbound {
-			_ = os.Setenv(features.EnableProtocolSniffingForInbound.Name, "true")
-		} else {
-			_ = os.Setenv(features.EnableProtocolSniffingForInbound.Name, "false")
-		}
+		defaultValue := features.EnableProtocolSniffingForInbound
+		features.EnableProtocolSniffingForInbound = tc.sniffingEnabledForInbound
+		defer func() { features.EnableProtocolSniffingForInbound = defaultValue }()
 
 		settingsName := "default"
 		if settings != nil {

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -130,7 +130,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(node *
 	listenerPort := 0
 	useSniffing := false
 	var err error
-	if features.EnableProtocolSniffingForOutbound.Get() &&
+	if features.EnableProtocolSniffingForOutbound &&
 		!strings.HasPrefix(routeName, model.UnixAddressPrefix) {
 		index := strings.IndexRune(routeName, ':')
 		if index != -1 {

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1060,7 +1060,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(node *model.
 					// Instead of generating a single 0.0.0.0:Port listener, generate a listener
 					// for each instance. HTTP services can happily reside on 0.0.0.0:PORT and use the
 					// wildcard route match to get to the appropriate pod through original dst clusters.
-					if features.EnableHeadlessService.Get() && bind == "" && service.Resolution == model.Passthrough &&
+					if features.EnableHeadlessService && bind == "" && service.Resolution == model.Passthrough &&
 						service.Attributes.ServiceRegistry == string(serviceregistry.Kubernetes) && servicePort.Protocol.IsTCP() {
 						if instances, err := push.InstancesByPort(service, servicePort.Port, nil); err == nil {
 							for _, instance := range instances {
@@ -1082,7 +1082,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(node *model.
 						}
 					} else {
 						// Standard logic for headless and non headless services
-						if features.EnableThriftFilter.Get() &&
+						if features.EnableThriftFilter &&
 							servicePort.Protocol.IsThrift() {
 							listenerOpts.bind = service.Address
 						}
@@ -1255,7 +1255,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPListenerOptsForPor
 		// Set useRemoteAddress to true for side car outbound listeners so that it picks up the localhost address of the sender,
 		// which is an internal address, so that trusted headers are not sanitized. This helps to retain the timeout headers
 		// such as "x-envoy-upstream-rq-timeout-ms" set by the calling application.
-		useRemoteAddress: features.UseRemoteAddress.Get(),
+		useRemoteAddress: features.UseRemoteAddress,
 		rds:              rdsName,
 	}
 
@@ -2217,7 +2217,7 @@ func buildCompleteFilterChain(pluginParams *plugin.InputParams, mutable *istione
 		mutable.Listener.FilterChains[i].Metadata = opt.metadata
 		mutable.Listener.FilterChains[i].Name = opt.filterChainName
 
-		if opt.thriftOpts != nil && features.EnableThriftFilter.Get() {
+		if opt.thriftOpts != nil && features.EnableThriftFilter {
 			var quotas []model.Config
 			// Add the TCP filters first.. and then the Thrift filter
 			mutable.Listener.FilterChains[i].Filters = append(mutable.Listener.FilterChains[i].Filters, chain.TCP...)

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1189,7 +1189,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPListenerOptsForPor
 	*listenerMapKey = listenerOpts.bind + ":" + strconv.Itoa(pluginParams.Port.Port)
 
 	var exists bool
-	sniffingEnabled := features.EnableProtocolSniffingForOutbound.Get()
+	sniffingEnabled := features.EnableProtocolSniffingForOutbound
 
 	// Have we already generated a listener for this Port based on user
 	// specified listener ports? if so, we should not add any more HTTP
@@ -1380,7 +1380,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundTCPListenerOptsForPort
 			return false, nil
 		}
 
-		if !features.EnableProtocolSniffingForOutbound.Get() {
+		if !features.EnableProtocolSniffingForOutbound {
 			// Check for port collisions between TCP/TLS and HTTP (or unknown). If
 			// configured correctly, TCP/TLS ports may not collide. We'll
 			// need to do additional work to find out if there is a
@@ -1453,7 +1453,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListenerForPortOrUDS(n
 
 	conflictType := NoConflict
 
-	outboundSniffingEnabled := features.EnableProtocolSniffingForOutbound.Get()
+	outboundSniffingEnabled := features.EnableProtocolSniffingForOutbound
 
 	// For HTTP_PROXY protocol defined by sidecars, just create the HTTP listener right away.
 	if pluginParams.Port.Protocol == protocol.HTTP_PROXY {

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -141,7 +141,7 @@ func (lb *ListenerBuilder) aggregateVirtualInboundListener(needTLSForPassThrough
 	// Note: the HTTP inspector should be after TLS inspector.
 	// If TLS inspector sets transport protocol to tls, the http inspector
 	// won't inspect the packet.
-	if features.EnableProtocolSniffingForInbound.Get() {
+	if features.EnableProtocolSniffingForInbound {
 		lb.virtualInboundListener.ListenerFilters =
 			append(lb.virtualInboundListener.ListenerFilters, &listener.ListenerFilter{
 				Name: xdsutil.HttpInspector,
@@ -257,7 +257,7 @@ func (lb *ListenerBuilder) buildVirtualInboundListener(configgen *ConfigGenerato
 	actualWildcard, _ := getActualWildcardAndLocalHost(lb.node)
 	// add an extra listener that binds to the port that is the recipient of the iptables redirect
 	filterChains, needTLSForPassThroughFilterChain := buildInboundCatchAllNetworkFilterChains(configgen, lb.node, lb.push)
-	if features.EnableProtocolSniffingForInbound.Get() {
+	if features.EnableProtocolSniffingForInbound {
 		filterChains = append(filterChains, buildInboundCatchAllHTTPFilterChains(configgen, lb.node, lb.push)...)
 	}
 	lb.virtualInboundListener = &xdsapi.Listener{

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
@@ -15,7 +15,6 @@
 package v1alpha3
 
 import (
-	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -196,8 +195,9 @@ func prepareListeners(t *testing.T) []*v2.Listener {
 }
 
 func TestVirtualInboundListenerBuilder(t *testing.T) {
-	_ = os.Setenv(features.EnableProtocolSniffingForInbound.Name, "true")
-	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffingForInbound.Name) }()
+	defaultValue := features.EnableProtocolSniffingForInbound
+	features.EnableProtocolSniffingForInbound = true
+	defer func() { features.EnableProtocolSniffingForInbound = defaultValue }()
 
 	// prepare
 	t.Helper()
@@ -244,8 +244,9 @@ func TestVirtualInboundListenerBuilder(t *testing.T) {
 }
 
 func TestVirtualInboundHasPassthroughClusters(t *testing.T) {
-	_ = os.Setenv(features.EnableProtocolSniffingForInbound.Name, "true")
-	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffingForInbound.Name) }()
+	defaultValue := features.EnableProtocolSniffingForInbound
+	features.EnableProtocolSniffingForInbound = true
+	defer func() { features.EnableProtocolSniffingForInbound = defaultValue }()
 	// prepare
 	t.Helper()
 	listeners := prepareListeners(t)

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -16,7 +16,6 @@ package v1alpha3
 
 import (
 	"fmt"
-	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -546,7 +545,7 @@ func TestInboundListenerConfig_HTTP(t *testing.T) {
 
 func TestOutboundListenerConfig_WithDisabledSniffing_WithSidecar(t *testing.T) {
 	defaultValue := features.EnableProtocolSniffingForOutbound
-	features.EnableProtocolSniffingForOutbound = true
+	features.EnableProtocolSniffingForOutbound = false
 	defer func() { features.EnableProtocolSniffingForOutbound = defaultValue }()
 
 	// Add a service and verify it's config
@@ -702,7 +701,7 @@ func testOutboundListenerConflict(t *testing.T, services ...*model.Service) {
 	t.Helper()
 
 	defaultValue := features.EnableProtocolSniffingForOutbound
-	features.EnableProtocolSniffingForOutbound = true
+	features.EnableProtocolSniffingForOutbound = false
 	defer func() { features.EnableProtocolSniffingForOutbound = defaultValue }()
 
 	oldestService := getOldestService(services...)
@@ -1049,9 +1048,9 @@ func testOutboundListenerConfigWithSidecarV14(t *testing.T, services ...*model.S
 	}
 
 	// enable mysql filter that is used here
-	_ = os.Setenv(features.EnableMysqlFilter.Name, "true")
-
-	defer func() { _ = os.Unsetenv(features.EnableMysqlFilter.Name) }()
+	defaultValue := features.EnableMysqlFilter
+	features.EnableMysqlFilter = true
+	defer func() { features.EnableMysqlFilter = defaultValue }()
 
 	listeners := buildOutboundListeners(p, &proxy14, sidecarConfig, nil, services...)
 	if len(listeners) != 4 {
@@ -1249,9 +1248,9 @@ func testOutboundListenerConfigWithSidecar(t *testing.T, services ...*model.Serv
 	}
 
 	// enable mysql filter that is used here
-	_ = os.Setenv(features.EnableMysqlFilter.Name, "true")
-
-	defer func() { _ = os.Unsetenv(features.EnableMysqlFilter.Name) }()
+	defaultValue := features.EnableMysqlFilter
+	features.EnableMysqlFilter = true
+	defer func() { features.EnableMysqlFilter = defaultValue }()
 
 	listeners := buildOutboundListeners(p, &proxy, sidecarConfig, nil, services...)
 	if len(listeners) != 1 {
@@ -1287,9 +1286,9 @@ func testOutboundListenerConfigWithSidecarWithUseRemoteAddress(t *testing.T, ser
 	}
 
 	// enable use remote address to true
-	_ = os.Setenv(features.UseRemoteAddress.Name, "true")
-
-	defer func() { _ = os.Unsetenv(features.UseRemoteAddress.Name) }()
+	defaultValue := features.UseRemoteAddress
+	features.UseRemoteAddress = true
+	defer func() { features.UseRemoteAddress = defaultValue }()
 
 	listeners := buildOutboundListeners(p, &proxy, sidecarConfig, nil, services...)
 
@@ -2192,12 +2191,11 @@ func TestOutboundRateLimitedThriftListenerConfig(t *testing.T) {
 	svcIP := "127.0.22.2"
 	limitedSvcName := "thrift-service"
 	limitedSvcIP := "127.0.22.3"
-	if err := os.Setenv("PILOT_ENABLE_THRIFT_FILTER", "true"); err != nil {
-		t.Error(err.Error())
-	}
-	defer func() {
-		_ = os.Unsetenv(features.EnableThriftFilter.Name)
-	}()
+
+	defaultValue := features.EnableThriftFilter
+	features.EnableThriftFilter = true
+	defer func() { features.EnableThriftFilter = defaultValue }()
+
 	services := []*model.Service{
 		buildService(svcName+".default.svc.cluster.local", svcIP, protocol.Thrift, tnow),
 		buildService(limitedSvcName+".default.svc.cluster.local", limitedSvcIP, protocol.Thrift, tnow)}

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -169,8 +169,9 @@ var (
 )
 
 func TestInboundListenerConfigProxyV14(t *testing.T) {
-	_ = os.Setenv(features.EnableProtocolSniffingForInbound.Name, "true")
-	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffingForInbound.Name) }()
+	defaultValue := features.EnableProtocolSniffingForInbound
+	features.EnableProtocolSniffingForInbound = true
+	defer func() { features.EnableProtocolSniffingForInbound = defaultValue }()
 
 	for _, p := range []*model.Proxy{&proxy14, &proxy14HTTP10} {
 		testInboundListenerConfigV14(t, p,
@@ -185,8 +186,9 @@ func TestInboundListenerConfigProxyV14(t *testing.T) {
 }
 
 func TestOutboundListenerConflict_HTTPWithCurrentUnknownV14(t *testing.T) {
-	_ = os.Setenv(features.EnableProtocolSniffingForOutbound.Name, "true")
-	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffingForOutbound.Name) }()
+	defaultValue := features.EnableProtocolSniffingForOutbound
+	features.EnableProtocolSniffingForOutbound = true
+	defer func() { features.EnableProtocolSniffingForOutbound = defaultValue }()
 
 	// The oldest service port is unknown.  We should encounter conflicts when attempting to add the HTTP ports. Purposely
 	// storing the services out of time order to test that it's being sorted properly.
@@ -197,8 +199,9 @@ func TestOutboundListenerConflict_HTTPWithCurrentUnknownV14(t *testing.T) {
 }
 
 func TestOutboundListenerConflict_WellKnowPortsV14(t *testing.T) {
-	_ = os.Setenv(features.EnableProtocolSniffingForOutbound.Name, "true")
-	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffingForOutbound.Name) }()
+	defaultValue := features.EnableProtocolSniffingForOutbound
+	features.EnableProtocolSniffingForOutbound = true
+	defer func() { features.EnableProtocolSniffingForOutbound = defaultValue }()
 
 	// The oldest service port is unknown.  We should encounter conflicts when attempting to add the HTTP ports. Purposely
 	// storing the services out of time order to test that it's being sorted properly.
@@ -211,8 +214,9 @@ func TestOutboundListenerConflict_WellKnowPortsV14(t *testing.T) {
 }
 
 func TestOutboundListenerConflict_TCPWithCurrentUnknownV14(t *testing.T) {
-	_ = os.Setenv(features.EnableProtocolSniffingForOutbound.Name, "true")
-	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffingForOutbound.Name) }()
+	defaultValue := features.EnableProtocolSniffingForOutbound
+	features.EnableProtocolSniffingForOutbound = true
+	defer func() { features.EnableProtocolSniffingForOutbound = defaultValue }()
 
 	// The oldest service port is unknown.  We should encounter conflicts when attempting to add the HTTP ports. Purposely
 	// storing the services out of time order to test that it's being sorted properly.
@@ -223,8 +227,9 @@ func TestOutboundListenerConflict_TCPWithCurrentUnknownV14(t *testing.T) {
 }
 
 func TestOutboundListenerConflict_UnknownWithCurrentTCPV14(t *testing.T) {
-	_ = os.Setenv(features.EnableProtocolSniffingForOutbound.Name, "true")
-	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffingForOutbound.Name) }()
+	defaultValue := features.EnableProtocolSniffingForOutbound
+	features.EnableProtocolSniffingForOutbound = true
+	defer func() { features.EnableProtocolSniffingForOutbound = defaultValue }()
 
 	// The oldest service port is TCP.  We should encounter conflicts when attempting to add the HTTP ports. Purposely
 	// storing the services out of time order to test that it's being sorted properly.
@@ -235,8 +240,9 @@ func TestOutboundListenerConflict_UnknownWithCurrentTCPV14(t *testing.T) {
 }
 
 func TestOutboundListenerConflict_UnknownWithCurrentHTTPV14(t *testing.T) {
-	_ = os.Setenv(features.EnableProtocolSniffingForOutbound.Name, "true")
-	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffingForOutbound.Name) }()
+	defaultValue := features.EnableProtocolSniffingForOutbound
+	features.EnableProtocolSniffingForOutbound = true
+	defer func() { features.EnableProtocolSniffingForOutbound = defaultValue }()
 
 	// The oldest service port is TCP.  We should encounter conflicts when attempting to add the HTTP ports. Purposely
 	// storing the services out of time order to test that it's being sorted properly.
@@ -247,8 +253,9 @@ func TestOutboundListenerConflict_UnknownWithCurrentHTTPV14(t *testing.T) {
 }
 
 func TestOutboundListenerRouteV14(t *testing.T) {
-	_ = os.Setenv(features.EnableProtocolSniffingForOutbound.Name, "true")
-	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffingForOutbound.Name) }()
+	defaultValue := features.EnableProtocolSniffingForOutbound
+	features.EnableProtocolSniffingForOutbound = true
+	defer func() { features.EnableProtocolSniffingForOutbound = defaultValue }()
 
 	testOutboundListenerRouteV14(t,
 		buildService("test1.com", "1.2.3.4", "unknown", tnow.Add(1*time.Second)),
@@ -538,8 +545,9 @@ func TestInboundListenerConfig_HTTP(t *testing.T) {
 }
 
 func TestOutboundListenerConfig_WithDisabledSniffing_WithSidecar(t *testing.T) {
-	_ = os.Setenv(features.EnableProtocolSniffingForOutbound.Name, "false")
-	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffingForOutbound.Name) }()
+	defaultValue := features.EnableProtocolSniffingForOutbound
+	features.EnableProtocolSniffingForOutbound = true
+	defer func() { features.EnableProtocolSniffingForOutbound = defaultValue }()
 
 	// Add a service and verify it's config
 	services := []*model.Service{
@@ -693,8 +701,9 @@ func TestGetActualWildcardAndLocalHost(t *testing.T) {
 func testOutboundListenerConflict(t *testing.T, services ...*model.Service) {
 	t.Helper()
 
-	_ = os.Setenv(features.EnableProtocolSniffingForOutbound.Name, "false")
-	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffingForOutbound.Name) }()
+	defaultValue := features.EnableProtocolSniffingForOutbound
+	features.EnableProtocolSniffingForOutbound = true
+	defer func() { features.EnableProtocolSniffingForOutbound = defaultValue }()
 
 	oldestService := getOldestService(services...)
 

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -154,19 +154,19 @@ func buildNetworkFiltersStack(_ *model.Proxy, port *model.Port, tcpFilter *liste
 	case protocol.Mongo:
 		filterstack = append(filterstack, buildMongoFilter(statPrefix), tcpFilter)
 	case protocol.Redis:
-		if features.EnableRedisFilter.Get() {
+		if features.EnableRedisFilter {
 			// redis filter has route config, it is a terminating filter, no need append tcp filter.
 			filterstack = append(filterstack, buildRedisFilter(statPrefix, clusterName))
 		} else {
 			filterstack = append(filterstack, tcpFilter)
 		}
 	case protocol.MySQL:
-		if features.EnableMysqlFilter.Get() {
+		if features.EnableMysqlFilter {
 			filterstack = append(filterstack, buildMySQLFilter(statPrefix))
 		}
 		filterstack = append(filterstack, tcpFilter)
 	case protocol.Thrift:
-		if features.EnableThriftFilter.Get() {
+		if features.EnableThriftFilter {
 			// Thrift filter has route config, it is a terminating filter, no need append tcp filter.
 			filterstack = append(filterstack, buildThriftFilter(statPrefix))
 		} else {

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -394,7 +394,7 @@ func translateRoute(push *model.PushContext, node *model.Proxy, in *networking.H
 		if in.Timeout != nil {
 			d = gogo.DurationToProtoDuration(in.Timeout)
 		} else {
-			d = features.DefaultRequestTimeout()
+			d = features.DefaultRequestTimeout
 		}
 
 		action.Timeout = d

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -18,15 +18,18 @@ import (
 	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	envoyroute "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/ptypes"
 	"github.com/onsi/gomega"
 
 	"istio.io/istio/pkg/util/gogo"
 
 	networking "istio.io/api/networking/v1alpha3"
 
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/route"
 	"istio.io/istio/pkg/config/host"
@@ -78,8 +81,9 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	t.Run("for virtual service with changed default timeout", func(t *testing.T) {
 		g := gomega.NewGomegaWithT(t)
 
-		os.Setenv("ISTIO_DEFAULT_REQUEST_TIMEOUT", "1s")
-		defer os.Unsetenv("ISTIO_DEFAULT_REQUEST_TIMEOUT")
+		dt := features.DefaultRequestTimeout
+		features.DefaultRequestTimeout = ptypes.DurationProto(1 * time.Second)
+		defer func() { features.DefaultRequestTimeout = dt }()
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node, nil, virtualServicePlain, serviceRegistry, 8080, gatewayNames)
 		g.Expect(err).NotTo(gomega.HaveOccurred())

--- a/pilot/pkg/networking/networking.go
+++ b/pilot/pkg/networking/networking.go
@@ -69,7 +69,7 @@ func ModelProtocolToListenerProtocol(node *model.Proxy, p protocol.Instance,
 		protocol.Mongo, protocol.Redis, protocol.MySQL:
 		return ListenerProtocolTCP
 	case protocol.Thrift:
-		if features.EnableThriftFilter.Get() {
+		if features.EnableThriftFilter {
 			return ListenerProtocolThrift
 		}
 		return ListenerProtocolTCP

--- a/pilot/pkg/networking/networking.go
+++ b/pilot/pkg/networking/networking.go
@@ -50,11 +50,11 @@ func ModelProtocolToListenerProtocol(node *model.Proxy, p protocol.Instance,
 	if p == protocol.Unsupported {
 		switch trafficDirection {
 		case core.TrafficDirection_INBOUND:
-			if !features.EnableProtocolSniffingForInbound.Get() {
+			if !features.EnableProtocolSniffingForInbound {
 				p = protocol.TCP
 			}
 		case core.TrafficDirection_OUTBOUND:
-			if !features.EnableProtocolSniffingForOutbound.Get() {
+			if !features.EnableProtocolSniffingForOutbound {
 				p = protocol.TCP
 			}
 		default:

--- a/pilot/pkg/networking/networking_test.go
+++ b/pilot/pkg/networking/networking_test.go
@@ -15,7 +15,6 @@
 package networking
 
 import (
-	"os"
 	"testing"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
@@ -125,23 +124,17 @@ func TestModelProtocolToListenerProtocol(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.sniffingEnabledForInbound {
-				_ = os.Setenv(features.EnableProtocolSniffingForInbound.Name, "true")
-			} else {
-				_ = os.Setenv(features.EnableProtocolSniffingForInbound.Name, "false")
-			}
-			if tt.sniffingEnabledForOutbound {
-				_ = os.Setenv(features.EnableProtocolSniffingForOutbound.Name, "true")
-			} else {
-				_ = os.Setenv(features.EnableProtocolSniffingForOutbound.Name, "false")
-			}
+			defaultValue := features.EnableProtocolSniffingForOutbound
+			features.EnableProtocolSniffingForOutbound = tt.sniffingEnabledForOutbound
+			defer func() { features.EnableProtocolSniffingForOutbound = defaultValue }()
+
+			defaultInboundValue := features.EnableProtocolSniffingForInbound
+			features.EnableProtocolSniffingForInbound = tt.sniffingEnabledForInbound
+			defer func() { features.EnableProtocolSniffingForInbound = defaultInboundValue }()
 
 			if got := ModelProtocolToListenerProtocol(tt.node, tt.protocol, tt.direction); got != tt.want {
 				t.Errorf("ModelProtocolToListenerProtocol() = %v, want %v", got, tt.want)
 			}
-
-			_ = os.Unsetenv(features.EnableProtocolSniffingForInbound.Name)
-			_ = os.Unsetenv(features.EnableProtocolSniffingForOutbound.Name)
 		})
 	}
 }

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -273,7 +273,7 @@ func IsProtocolSniffingEnabledForOutboundPort(port *model.Port) bool {
 
 // IsTCPMetadataExchangeEnabled checks whether Metadata Exchanged enabled for TCP using ALPN.
 func IsTCPMetadataExchangeEnabled(node *model.Proxy) bool {
-	return features.EnableTCPMetadataExchange.Get() && IsIstioVersionGE15(node)
+	return features.EnableTCPMetadataExchange && IsIstioVersionGE15(node)
 }
 
 // ConvertLocality converts '/' separated locality string to Locality struct.

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -260,15 +260,15 @@ func IsIstioVersionGE15(node *model.Proxy) bool {
 }
 
 func IsProtocolSniffingEnabledForPort(port *model.Port) bool {
-	return features.EnableProtocolSniffingForOutbound.Get() && port.Protocol.IsUnsupported()
+	return features.EnableProtocolSniffingForOutbound && port.Protocol.IsUnsupported()
 }
 
 func IsProtocolSniffingEnabledForInboundPort(port *model.Port) bool {
-	return features.EnableProtocolSniffingForInbound.Get() && port.Protocol.IsUnsupported()
+	return features.EnableProtocolSniffingForInbound && port.Protocol.IsUnsupported()
 }
 
 func IsProtocolSniffingEnabledForOutboundPort(port *model.Port) bool {
-	return features.EnableProtocolSniffingForOutbound.Get() && port.Protocol.IsUnsupported()
+	return features.EnableProtocolSniffingForOutbound && port.Protocol.IsUnsupported()
 }
 
 // IsTCPMetadataExchangeEnabled checks whether Metadata Exchanged enabled for TCP using ALPN.

--- a/pilot/pkg/proxy/envoy/v2/lds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/lds_test.go
@@ -42,8 +42,9 @@ import (
 
 // TestLDS using isolated namespaces
 func TestLDSIsolated(t *testing.T) {
-	_ = os.Setenv(features.EnableProtocolSniffingForInbound.Name, "true")
-	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffingForInbound.Name) }()
+	defaultInboundValue := features.EnableProtocolSniffingForInbound
+	features.EnableProtocolSniffingForInbound = true
+	defer func() { features.EnableProtocolSniffingForInbound = defaultInboundValue }()
 	_, tearDown := initLocalPilotTestEnv(t)
 	defer tearDown()
 
@@ -456,8 +457,9 @@ func TestLDSWithSidecarForWorkloadWithoutService(t *testing.T) {
 
 // TestLDS using default sidecar in root namespace
 func TestLDSEnvoyFilterWithWorkloadSelector(t *testing.T) {
-	_ = os.Setenv(features.EnableProtocolSniffingForInbound.Name, "true")
-	defer func() { _ = os.Unsetenv(features.EnableProtocolSniffingForInbound.Name) }()
+	defaultInboundValue := features.EnableProtocolSniffingForInbound
+	features.EnableProtocolSniffingForInbound = true
+	defer func() { features.EnableProtocolSniffingForInbound = defaultInboundValue }()
 	server, tearDown := util.EnsureTestServer(func(args *bootstrap.PilotArgs) {
 		args.Plugins = bootstrap.DefaultPlugins
 		args.Config.FileDir = env.IstioSrc + "/tests/testdata/networking/envoyfilter-without-service"

--- a/pilot/pkg/serviceregistry/kube/controller/endpointsdiscovery.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointsdiscovery.go
@@ -61,7 +61,7 @@ func (e *kubeEndpoints) handleEvent(name string, namespace string, event model.E
 	log.Debugf("Handle event %s for endpoint %s in namespace %s", event, name, namespace)
 
 	// headless service cluster discovery type is ORIGINAL_DST, we do not need update EDS.
-	if features.EnableHeadlessService.Get() {
+	if features.EnableHeadlessService {
 		if obj, _, _ := e.c.services.GetIndexer().GetByKey(kube.KeyFunc(name, namespace)); obj != nil {
 			svc := obj.(*v1.Service)
 			// if the service is headless service, trigger a full push.


### PR DESCRIPTION
Evaluate features flags at initialization rather than during usage. This is bring in consistency on how they are evaluated (changed all of the flags used in configgen paths). It might improve performance a bit (but not tested - how much it is)