### PR TITLE
Fix dashboard injection query

### DIFF
--- a/manifests/istio-telemetry/grafana/dashboards/pilot-dashboard.json
+++ b/manifests/istio-telemetry/grafana/dashboards/pilot-dashboard.json
@@ -1707,7 +1707,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(rate(sidecar_injection_success_total[1m]))",
+          "expr": "sum(rate(sidecar_injection_failure_total[1m]))",
           "interval": "",
           "legendFormat": "Injections (Failure)",
           "refId": "B"

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -35515,7 +35515,7 @@ var _chartsIstioTelemetryGrafanaDashboardsPilotDashboardJson = []byte(`{
           "refId": "A"
         },
         {
-          "expr": "sum(rate(sidecar_injection_success_total[1m]))",
+          "expr": "sum(rate(sidecar_injection_failure_total[1m]))",
           "interval": "",
           "legendFormat": "Injections (Failure)",
           "refId": "B"

--- a/tests/integration/telemetry/dashboard_test.go
+++ b/tests/integration/telemetry/dashboard_test.go
@@ -59,6 +59,8 @@ var (
 				"pilot_xds_eds_instances",
 				"_timeout",
 				"_rejects",
+				// We do not simulate injection errors
+				"sidecar_injection_failure_total",
 				// In default install, we have no proxy
 				"istio-proxy",
 				// cAdvisor does not expose this metrics, and we don't have kubelet in kind


### PR DESCRIPTION
Right now its mistakenly grabbing the success query for failure.