### PR TITLE
make key cert rotation job works for VM

### DIFF
--- a/pkg/istio-agent/sds-agent.go
+++ b/pkg/istio-agent/sds-agent.go
@@ -61,9 +61,6 @@ var (
 	// TODO: default to same as discovery address
 	caEndpointEnv = env.RegisterStringVar(caEndpoint, "", "").Get()
 
-	alwaysValidTokenFlag = env.RegisterBoolVar("AlwaysValidTokenFlag", false, "token "+
-		"used is always valid or not, set this to true on VM since no token on VM").Get()
-
 	pluginNamesEnv             = env.RegisterStringVar(pluginNames, "", "").Get()
 	enableIngressGatewaySDSEnv = env.RegisterBoolVar(enableIngressGatewaySDS, false, "").Get()
 
@@ -458,6 +455,8 @@ func applyEnvVars() {
 	workloadSdsCacheOptions.InitialBackoffInMilliSec = int64(initialBackoffInMilliSecEnv)
 	// Disable the secret eviction for istio agent.
 	workloadSdsCacheOptions.EvictionDuration = 0
-	workloadSdsCacheOptions.AlwaysValidTokenFlag = alwaysValidTokenFlag
+	if citadel.ProvCert != "" {
+		workloadSdsCacheOptions.AlwaysValidTokenFlag = true
+	}
 	workloadSdsCacheOptions.OutputKeyCertToDir = serverOptions.OutputKeyCertToDir
 }

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -31,9 +31,10 @@ import (
 	"istio.io/istio/security/pkg/nodeagent/model"
 	"istio.io/istio/security/pkg/nodeagent/plugin"
 	"istio.io/istio/security/pkg/nodeagent/secretfetcher"
-	nodeagentutil "istio.io/istio/security/pkg/nodeagent/util"
 	"istio.io/istio/security/pkg/pki/util"
 	"istio.io/pkg/log"
+
+	nodeagentutil "istio.io/istio/security/pkg/nodeagent/util"
 
 	"github.com/google/uuid"
 )
@@ -129,6 +130,9 @@ type Options struct {
 
 	// Whether to generate PKCS#8 private keys.
 	Pkcs8Keys bool
+
+	// OutputKeyCertToDir is the directory for output the key and certificate
+	OutputKeyCertToDir string
 }
 
 // SecretManager defines secrets management interface which is used by SDS.
@@ -549,7 +553,6 @@ func (sc *SecretCache) rotate(updateRootFlag bool) {
 		// Re-generate secret if it's expired.
 		if sc.shouldRotate(&secret) {
 			atomic.AddUint64(&sc.secretChangedCount, 1)
-
 			// Send the notification to close the stream if token is expired, so that client could re-connect with a new token.
 			if sc.isTokenExpired() {
 				cacheLog.Debugf("%s token expired", logPrefix)
@@ -569,6 +572,13 @@ func (sc *SecretCache) rotate(updateRootFlag bool) {
 				ns, err := sc.generateSecret(context.Background(), secret.Token, connKey, now)
 				if err != nil {
 					cacheLog.Errorf("%s failed to rotate secret: %v", logPrefix, err)
+					return
+				}
+				// Output the key and cert to dir to make sure key and cert are rotated.
+				if err = nodeagentutil.OutputKeyCertToDir(sc.configOptions.OutputKeyCertToDir, ns.PrivateKey,
+					ns.CertificateChain, ns.RootCert); err != nil {
+					cacheLog.Errorf("(%v) error when output the key and cert: %v",
+						connKey, err)
 					return
 				}
 

--- a/security/pkg/nodeagent/caclient/providers/citadel/client.go
+++ b/security/pkg/nodeagent/caclient/providers/citadel/client.go
@@ -133,7 +133,6 @@ func (c *citadelClient) getTLSDialOption() (grpc.DialOption, error) {
 	config := tls.Config{
 		Certificates: []tls.Certificate{certificate},
 		GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
-			log.Infof("call getclientCertificate")
 			if ProvCert != "" {
 				// Load the certificate from disk
 				certificate, err = tls.LoadX509KeyPair(ProvCert+"/cert-chain.pem", ProvCert+"/key.pem")

--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -117,6 +117,9 @@ type Options struct {
 
 	// Existing certs, for VM or existing certificates
 	CertsDir string
+
+	// whether  ControlPlaneAuthPolicy is MUTUAL_TLS
+	TLSEnabled bool
 }
 
 // Server is the gPRC server that exposes SDS through UDS.

--- a/tools/packaging/common/istio-start.sh
+++ b/tools/packaging/common/istio-start.sh
@@ -100,6 +100,8 @@ ISTIO_CA=${ISTIO_CA:-${PILOT_ADDRESS}}
 export ISTIO_CA
 export PROV_CERT
 export OUTPUT_CERTS
+export CA_ADDR
+export AlwaysValidTokenFlag
 
 # If predefined ISTIO_AGENT_FLAGS is null, make it an empty string.
 ISTIO_AGENT_FLAGS=${ISTIO_AGENT_FLAGS:-}

--- a/tools/packaging/common/istio-start.sh
+++ b/tools/packaging/common/istio-start.sh
@@ -101,7 +101,6 @@ export ISTIO_CA
 export PROV_CERT
 export OUTPUT_CERTS
 export CA_ADDR
-export AlwaysValidTokenFlag
 
 # If predefined ISTIO_AGENT_FLAGS is null, make it an empty string.
 ISTIO_AGENT_FLAGS=${ISTIO_AGENT_FLAGS:-}

--- a/tools/packaging/common/sidecar.env
+++ b/tools/packaging/common/sidecar.env
@@ -85,7 +85,7 @@
 
 # Location of provisioning certificates. VM provisioning tools must generate a certificate with
 # the expected SAN. Istio-agent will use it to connect to istiod and get fresh certificates.
-#PROV_CERT=/var/run/secrets/istio
+PROV_CERT=/etc/certs
 
 
 # Location to save the certificates from the CA. Setting this to the same location with PROV_CERT
@@ -102,8 +102,4 @@ OUTPUT_CERTS=/etc/certs
 # and returning workload certificates. Istiod is implementing the protocol, and is the default value
 # if ISTIO_CA is not set.
 #ISTIO_CA
-
-#set CA_ADDR if your istiod is running on port other than 15012
-#CA_ADDR=istiod.istio-system.svc:32108
-# set this as true on VM since no token on VM, this will make the key/cert rotation job works
-AlwaysValidTokenFlag=true
+CA_ADDR=istiod.istio-system.svc:32018

--- a/tools/packaging/common/sidecar.env
+++ b/tools/packaging/common/sidecar.env
@@ -101,5 +101,5 @@ OUTPUT_CERTS=/etc/certs
 # and returning workload certificates. Istiod is implementing the protocol, and is the default value
 # if ISTIO_CA is not set.
 #ISTIO_CA
-# set CA_ADDR if your istiod.istio-system.svc is on port other than 15102
+# set CA_ADDR if your istiod.istio-system.svc is on port other than 15012
 #CA_ADDR=istiod.istio-system.svc:32018

--- a/tools/packaging/common/sidecar.env
+++ b/tools/packaging/common/sidecar.env
@@ -85,8 +85,7 @@
 
 # Location of provisioning certificates. VM provisioning tools must generate a certificate with
 # the expected SAN. Istio-agent will use it to connect to istiod and get fresh certificates.
-PROV_CERT=/etc/certs
-
+#PROV_CERT=/var/run/secrets/istio
 
 # Location to save the certificates from the CA. Setting this to the same location with PROV_CERT
 # allows rotation of the secrets. Users may also use longer-lived PROV_CERT, rotated under the control
@@ -102,4 +101,5 @@ OUTPUT_CERTS=/etc/certs
 # and returning workload certificates. Istiod is implementing the protocol, and is the default value
 # if ISTIO_CA is not set.
 #ISTIO_CA
-CA_ADDR=istiod.istio-system.svc:32018
+# set CA_ADDR if your istiod.istio-system.svc is on port other than 15102
+#CA_ADDR=istiod.istio-system.svc:32018

--- a/tools/packaging/common/sidecar.env
+++ b/tools/packaging/common/sidecar.env
@@ -102,3 +102,8 @@ OUTPUT_CERTS=/etc/certs
 # and returning workload certificates. Istiod is implementing the protocol, and is the default value
 # if ISTIO_CA is not set.
 #ISTIO_CA
+
+#set CA_ADDR if your istiod is running on port other than 15012
+#CA_ADDR=istiod.istio-system.svc:32108
+# set this as true on VM since no token on VM, this will make the key/cert rotation job works
+AlwaysValidTokenFlag=true


### PR DESCRIPTION
#22176
- set and export ·alwaysValidTokenFlag=true` on VM to make the rotation job work
- outputCertToDir in rotation job as well to make sure key/cert on dir has been updated
- Define `getClientCert` for `getTLSDialOption`
- do not rely on port `15102` to see whether mtls enabled