### PR TITLE
Properly stop/start namespace controller for leader election

### DIFF
--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -228,13 +228,13 @@ func (s *Server) RunCA(grpc *grpc.Server, ca caserver.CertificateAuthority, opts
 	log.Info("Istiod CA has started")
 
 	if s.kubeClient != nil {
-		nc := NewNamespaceController(func() map[string]string {
-			return map[string]string{
-				constants.CACertNamespaceConfigMapDataName: string(ca.GetCAKeyCertBundle().GetRootCertPem()),
-			}
-		}, s.kubeClient)
-		s.leaderElection.AddRunFunction(func(_ <-chan struct{}) {
-			nc.Run(stopCh)
+		s.leaderElection.AddRunFunction(func(stop <-chan struct{}) {
+			nc := NewNamespaceController(func() map[string]string {
+				return map[string]string{
+					constants.CACertNamespaceConfigMapDataName: string(ca.GetCAKeyCertBundle().GetRootCertPem()),
+				}
+			}, s.kubeClient)
+			nc.Run(stop)
 		})
 	}
 


### PR DESCRIPTION
Might fix https://github.com/istio/istio/issues/22463, was found during
debugging this.

https://github.com/istio/istio/pull/21669 made a change that set the
stop channel to the global stop channel instead of leader election stop
channel, so it doesn't stop when leader is lost. Once that is fixed we
need to create new informers, or client-go will crash due to closing the
same informer twice