### PR TITLE
Deepequal instead of pointer ==

### DIFF
--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
@@ -310,7 +310,7 @@ func (r *ReconcileIstioOperator) getOrCreateReconciler(iop *iopv1alpha1.IstioOpe
 		reconciler.SetNeedUpdateAndPrune(false)
 		oldInstance := reconciler.GetInstance()
 		reconciler.SetInstance(iop)
-		if reconciler.GetInstance() != oldInstance {
+		if !reflect.DeepEqual(reconciler.GetInstance(), oldInstance) {
 			//regenerate the reconciler
 			if reconciler, err = r.factory.New(iop, r.client); err == nil {
 				reconcilers[key] = reconciler


### PR DESCRIPTION
Istio operator pointer address is compared instead of the value itself. Every call to getOrCreateReconciler would have a different iop address and the would always result in equality failing when this is compared with reconciler.GetInstance