### PR TITLE
Simplify namespace controller

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
@@ -16,21 +16,20 @@ package controller
 
 import (
 	"context"
-	"fmt"
 	"time"
+
+	"istio.io/istio/security/pkg/listwatch"
+	certutil "istio.io/istio/security/pkg/util"
+	"istio.io/pkg/log"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
-	informer "k8s.io/client-go/informers/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
 
-	"istio.io/pkg/log"
-
-	"istio.io/istio/pkg/queue"
-	certutil "istio.io/istio/security/pkg/util"
 )
 
 const (
@@ -52,12 +51,9 @@ type NamespaceController struct {
 	getData func() map[string]string
 	client  corev1.CoreV1Interface
 
-	queue queue.Instance
-
 	// Controller and store for namespace objects
 	namespaceController cache.Controller
-	// Controller and store for ConfigMap objects
-	configMapController cache.Controller
+	namespaceStore      cache.Store
 }
 
 // NewNamespaceController returns a pointer to a newly constructed NamespaceController instance.
@@ -65,75 +61,67 @@ func NewNamespaceController(data func() map[string]string, options Options, kube
 	c := &NamespaceController{
 		getData: data,
 		client:  kubeClient.CoreV1(),
-		queue:   queue.NewQueue(time.Second),
 	}
 
-	configmapInformer := informer.NewFilteredConfigMapInformer(kubeClient, metav1.NamespaceAll, options.ResyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
-		func(options *metav1.ListOptions) {
-			options.LabelSelector = fields.SelectorFromSet(configMapLabel).String()
-		})
-	configmapInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		UpdateFunc: func(oldObj, newObj interface{}) {
-			c.queue.Push(func() error {
-				return c.configMapChange(newObj)
-			})
-		},
-		DeleteFunc: func(obj interface{}) {
-			cm, ok := obj.(*v1.ConfigMap)
-			if !ok {
-				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-				if !ok {
-					log.Errorf("error decoding object, invalid type")
-					return
-				}
-				cm, ok = tombstone.Obj.(*v1.ConfigMap)
-				if !ok {
-					log.Errorf("error decoding object tombstone, invalid type")
-					return
-				}
-			}
-			c.queue.Push(func() error {
-				ns, err := kubeClient.CoreV1().Namespaces().Get(context.TODO(), cm.Namespace, metav1.GetOptions{})
-				if err != nil {
-					return err
-				}
-				// If the namespace is terminating, we may get into a loop of trying to re-add the configmap back
-				// We should make sure the namespace still exists
-				if ns.Status.Phase != v1.NamespaceTerminating {
-					return c.insertDataForNamespace(cm.Namespace)
-				}
-				return nil
-			})
-		},
+	namespaceLW := listwatch.MultiNamespaceListerWatcher([]string{metav1.NamespaceAll}, func(namespace string) cache.ListerWatcher {
+		return &cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				return c.client.Namespaces().List(context.TODO(), options)
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				return c.client.Namespaces().Watch(context.TODO(), options)
+			}}
 	})
-	c.configMapController = configmapInformer
 
-	namespaceInformer := informer.NewNamespaceInformer(kubeClient, options.ResyncPeriod, cache.Indexers{})
-	namespaceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			c.queue.Push(func() error {
-				return c.namespaceChange(obj)
-			})
-		},
-		UpdateFunc: func(_, obj interface{}) {
-			c.queue.Push(func() error {
-				return c.namespaceChange(obj)
-			})
-		},
-	})
-	c.namespaceController = namespaceInformer
+	c.namespaceStore, c.namespaceController =
+		cache.NewInformer(namespaceLW, &v1.Namespace{}, namespaceResyncPeriod, cache.ResourceEventHandlerFuncs{
+			UpdateFunc: c.namespaceUpdated,
+			AddFunc:    c.namespaceAdded,
+		})
 
 	return c
+}
+
+// When a namespace is created, Citadel adds its public CA certificate
+// to a well known configmap in the namespace.
+func (nc *NamespaceController) namespaceAdded(obj interface{}) {
+	ns, ok := obj.(*v1.Namespace)
+
+	if ok {
+		err := nc.insertDataForNamespace(ns.Name)
+		if err != nil {
+			log.Errorf("error when inserting CA cert to configmap: %v", err)
+		} else {
+			log.Debugf("inserted CA cert to configmap %v in ns %v",
+				CACertNamespaceConfigMap, ns.GetName())
+		}
+	}
+}
+
+func (nc *NamespaceController) namespaceUpdated(oldObj, newObj interface{}) {
+	ns, ok := newObj.(*v1.Namespace)
+
+	if ok {
+		// Every namespaceResyncPeriod, namespaceUpdated() will be invoked
+		// for every namespace. If a namespace does not have the Citadel CA
+		// certificate or the certificate in a ConfigMap of the namespace is not
+		// up to date, Citadel updates the certificate in the namespace.
+		// For simplifying the implementation and no overhead for reading the certificate from the ConfigMap,
+		// simply updates the ConfigMap to the current Citadel CA certificate.
+		err := nc.insertDataForNamespace(ns.Name)
+		if err != nil {
+			log.Errorf("error when updating CA cert in configmap: %v", err)
+		} else {
+			log.Debugf("updated CA cert in configmap %v in ns %v",
+				CACertNamespaceConfigMap, ns.GetName())
+		}
+	}
 }
 
 // Run starts the NamespaceController until a value is sent to stopCh.
 func (nc *NamespaceController) Run(stopCh <-chan struct{}) {
 	go nc.namespaceController.Run(stopCh)
-	go nc.configMapController.Run(stopCh)
-	cache.WaitForCacheSync(stopCh, nc.namespaceController.HasSynced, nc.configMapController.HasSynced)
 	log.Infof("Namespace controller started")
-	go nc.queue.Run(stopCh)
 }
 
 // insertDataForNamespace will add data into the configmap for the specified namespace
@@ -146,27 +134,4 @@ func (nc *NamespaceController) insertDataForNamespace(ns string) error {
 		Labels:    configMapLabel,
 	}
 	return certutil.InsertDataToConfigMap(nc.client, meta, nc.getData())
-}
-
-// On namespace change, update the config map.
-// If terminating, this will be skipped
-func (nc *NamespaceController) namespaceChange(obj interface{}) error {
-	ns, ok := obj.(*v1.Namespace)
-
-	if ok && ns.Status.Phase != v1.NamespaceTerminating {
-		return nc.insertDataForNamespace(ns.Name)
-	}
-	return nil
-}
-
-// When a config map is changed, merge the data into the configmap
-func (nc *NamespaceController) configMapChange(obj interface{}) error {
-	cm, ok := obj.(*v1.ConfigMap)
-
-	if ok {
-		if err := certutil.UpdateDataInConfigMap(nc.client, cm.DeepCopy(), nc.getData()); err != nil {
-			return fmt.Errorf("error when inserting CA cert to configmap %v: %v", cm.Name, err)
-		}
-	}
-	return nil
 }

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
-
 )
 
 const (
@@ -74,7 +73,7 @@ func NewNamespaceController(data func() map[string]string, options Options, kube
 	})
 
 	c.namespaceStore, c.namespaceController =
-		cache.NewInformer(namespaceLW, &v1.Namespace{}, namespaceResyncPeriod, cache.ResourceEventHandlerFuncs{
+		cache.NewInformer(namespaceLW, &v1.Namespace{}, NamespaceResyncPeriod, cache.ResourceEventHandlerFuncs{
 			UpdateFunc: c.namespaceUpdated,
 			AddFunc:    c.namespaceAdded,
 		})
@@ -101,7 +100,7 @@ func (nc *NamespaceController) namespaceAdded(obj interface{}) {
 func (nc *NamespaceController) namespaceUpdated(oldObj, newObj interface{}) {
 	ns, ok := newObj.(*v1.Namespace)
 
-	if ok {
+	if ok && ns.Status.Phase != v1.NamespaceTerminating {
 		// Every namespaceResyncPeriod, namespaceUpdated() will be invoked
 		// for every namespace. If a namespace does not have the Citadel CA
 		// certificate or the certificate in a ConfigMap of the namespace is not

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
@@ -49,13 +49,6 @@ func TestNamespaceController(t *testing.T) {
 	expectConfigMap(t, client, "foo", newData)
 }
 
-func deleteConfigMap(t *testing.T, client *fake.Clientset, ns string) {
-	t.Helper()
-	if err := client.CoreV1().ConfigMaps(ns).Delete(context.TODO(), CACertNamespaceConfigMap, metav1.DeleteOptions{}); err != nil {
-		t.Fatal(err)
-	}
-}
-
 func createNamespace(t *testing.T, client *fake.Clientset, ns string) {
 	t.Helper()
 	if _, err := client.CoreV1().Namespaces().Create(context.TODO(), &v1.Namespace{

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
@@ -47,9 +47,6 @@ func TestNamespaceController(t *testing.T) {
 		t.Fatal(err)
 	}
 	expectConfigMap(t, client, "foo", newData)
-
-	deleteConfigMap(t, client, "foo")
-	expectConfigMap(t, client, "foo", testdata)
 }
 
 func deleteConfigMap(t *testing.T, client *fake.Clientset, ns string) {


### PR DESCRIPTION
Please provide a description for what this PR is for: https://github.com/istio/istio/issues/22463

The current implementation of the namespace controller is complicated and difficult to reason its correctness. Simplifying the implementation makes code easier to reason its correctness and may solve the bugs in https://github.com/istio/istio/issues/22463. This PR makes the implementation very simple:
- The namespace controller only handles the events of adding a namespace and updating a namespace. The event handler simply writes the configmap to a namespace. The delete events are not handled because when the namespace is deleted, the configmap in the namespace is deleted too and there is no extra actions needed. The controller for configmap is removed to simplify the implementation. 
- The update handler of the namespace controller periodically writes the configmap to a namespace, which is useful when the namespace controller needs to sync the configmaps in namespaces. If only the adding events are handled, the namespace controller may miss the adding events and cause the configmap to be out-of-sync.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
