### PR TITLE
Add local SDS integration tests

### DIFF
--- a/mixer/test/client/env/ports.go
+++ b/mixer/test/client/env/ports.go
@@ -70,6 +70,7 @@ const (
 	STSTimeoutTest
 	STSServerCacheTest
 	STSShortLivedCacheTest
+	SDSTest
 
 	// The number of total tests. has to be the last one.
 	maxTestNum

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -185,6 +185,7 @@ type SecretCache struct {
 	// close channel.
 	closing chan bool
 
+	// Read/Write to rootCert and rootCertExpireTime should use getRootCert() and setRootCert().
 	rootCertMutex      *sync.RWMutex
 	rootCert           []byte
 	rootCertExpireTime time.Time

--- a/security/pkg/nodeagent/test/README.md
+++ b/security/pkg/nodeagent/test/README.md
@@ -1,0 +1,28 @@
+# SDS Local Integration Test
+
+## Test Setup
+
+This test starts an Envoy proxy, a SDS server, a test backend and a dummy CA server. All of 
+these components are running in individual processes.
+
+The Envoy has two sets of listener and cluster configurations, which mimics two sidecars. An HTTP client sends a request and should expect response sent from the test backend.
+
+```bash
+                                  +---------+
+                                  |   CA    |
+                                  |  server |
+                                  +----+----+
+                                       |
+                                  +----+----+
+                                  |   SDS   |
+                             +----+  server +----+
+                             |    |         |    |
+                             |    +---------+    |
++--------+    +------------------------------------------------+    +---------+    
+| HTTP   |--->| outbound-->outbound<--mTLS-->inbound-->inbound |--->| test    |
+| client |    | listener   cluster           listener  cluster |    | backend | 
++--------+    +------------------------------------------------+    +---------+
+
+```
+
+Outbound cluster and inbound listener contain SDS configuration, with separate resource name. SDS server generates CSR requests for each of them and sends CSR to CA for cert signing.

--- a/security/pkg/nodeagent/test/README.md
+++ b/security/pkg/nodeagent/test/README.md
@@ -2,8 +2,7 @@
 
 ## Test Setup
 
-This test starts an Envoy proxy, a SDS server, a test backend and a dummy CA server. All of 
-these components are running in individual processes.
+This test starts an Envoy proxy, a SDS server, a test backend and a dummy CA server. All of these components are running in individual processes.
 
 The Envoy has two sets of listener and cluster configurations, which mimics two sidecars. An HTTP client sends a request and should expect response sent from the test backend.
 
@@ -18,9 +17,9 @@ The Envoy has two sets of listener and cluster configurations, which mimics two 
                              +----+  server +----+
                              |    |         |    |
                              |    +---------+    |
-+--------+    +------------------------------------------------+    +---------+    
++--------+    +--------------+-------------------+-------------+    +---------+
 | HTTP   |--->| outbound-->outbound<--mTLS-->inbound-->inbound |--->| test    |
-| client |    | listener   cluster           listener  cluster |    | backend | 
+| client |    | listener   cluster           listener  cluster |    | backend |
 +--------+    +------------------------------------------------+    +---------+
 
 ```

--- a/security/pkg/nodeagent/test/mock/caserver.go
+++ b/security/pkg/nodeagent/test/mock/caserver.go
@@ -116,7 +116,7 @@ func (s *CAServer) CreateCertificate(ctx context.Context, request *pb.IstioCerti
 	return response, nil
 }
 
-func (s *CAServer) sign(csrPEM []byte, subjectIDs []string, _, forCA bool) ([]byte, error) {
+func (s *CAServer) sign(csrPEM []byte, subjectIDs []string, _ time.Duration, forCA bool) ([]byte, error) {
 	csr, err := util.ParsePemEncodedCSR(csrPEM)
 	if err != nil {
 		caServerLog.Errorf("failed to parse CSR: %+v", err)

--- a/security/pkg/nodeagent/test/mock/caserver.go
+++ b/security/pkg/nodeagent/test/mock/caserver.go
@@ -21,8 +21,8 @@ import (
 	"net"
 	"time"
 
-	ghc "github.com/go-training/grpc-health-check/proto"
 	"google.golang.org/grpc"
+	ghc "google.golang.org/grpc/health/grpc_health_v1"
 
 	"istio.io/istio/pkg/mcp/status"
 	"istio.io/istio/pkg/spiffe"
@@ -137,9 +137,14 @@ func (s *CAServer) sign(csrPEM []byte, subjectIDs []string, _ time.Duration, for
 	return cert, nil
 }
 
-// Check implements `service Health`.
+// Check handles health check requests.
 func (s *CAServer) Check(ctx context.Context, in *ghc.HealthCheckRequest) (*ghc.HealthCheckResponse, error) {
 	return &ghc.HealthCheckResponse{
 		Status: ghc.HealthCheckResponse_SERVING,
 	}, nil
+}
+
+// Watch handles health check streams.
+func (s *CAServer) Watch(_ *ghc.HealthCheckRequest, _ ghc.Health_WatchServer) error {
+	return nil
 }

--- a/security/pkg/nodeagent/test/mock/caserver.go
+++ b/security/pkg/nodeagent/test/mock/caserver.go
@@ -1,0 +1,139 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mock
+
+import (
+	"context"
+	"encoding/pem"
+	"fmt"
+	"net"
+	"time"
+
+	"google.golang.org/grpc"
+
+	"istio.io/istio/pkg/mcp/status"
+	"istio.io/istio/pkg/spiffe"
+	caerror "istio.io/istio/security/pkg/pki/error"
+	"istio.io/istio/security/pkg/pki/util"
+	pb "istio.io/istio/security/proto"
+	"istio.io/pkg/log"
+)
+
+var caServerLog = log.RegisterScope("ca", "CA service debugging", 0)
+
+// CAServer is a mock CA server.
+type CAServer struct {
+	URL        string
+	GRPCServer *grpc.Server
+
+	certPem       []byte
+	keyPem        []byte
+	keyCertBundle util.KeyCertBundle
+}
+
+// NewCAServer creates a new CA server that listens on port.
+func NewCAServer(port int) (*CAServer, error) {
+	// Create root cert and private key.
+	options := util.CertOptions{
+		TTL:          3650 * 24 * time.Hour,
+		Org:          spiffe.GetTrustDomain(),
+		IsCA:         true,
+		IsSelfSigned: true,
+		RSAKeySize:   2048,
+		IsDualUse:    true,
+	}
+	cert, key, err := util.GenCertKeyFromOptions(options)
+	if err != nil {
+		caServerLog.Errorf("cannot create CA cert and private key: %+v", err)
+		return nil, err
+	}
+	keyCertBundle, err := util.NewVerifiedKeyCertBundleFromPem(cert, key, nil, cert)
+	if err != nil {
+		caServerLog.Errorf("failed to create CA KeyCertBundle: %+v", err)
+		return nil, err
+	}
+
+	server := &CAServer{
+		certPem:       cert,
+		keyPem:        key,
+		keyCertBundle: keyCertBundle,
+		GRPCServer:    grpc.NewServer(),
+	}
+	// Register CA service at gRPC server.
+	pb.RegisterIstioCertificateServiceServer(server.GRPCServer, server)
+
+	return server, server.start(port)
+}
+
+func (s *CAServer) start(port int) error {
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		caServerLog.Errorf("cannot listen on port %d (error: %v)", port, err)
+		return err
+	}
+
+	// If passed in port is 0, get the actual chosen port.
+	port = listener.Addr().(*net.TCPAddr).Port
+	s.URL = fmt.Sprintf("http://localhost:%d", port)
+	go func() {
+		log.Infof("start CA server on %s", s.URL)
+		if err := s.GRPCServer.Serve(listener); err != nil {
+			log.Errorf("CA Server failed to serve in %q: %v", s.URL, err)
+		}
+	}()
+	// sleep a while for mock server to start.
+	time.Sleep(time.Second)
+	return nil
+}
+
+// CreateCertificate handles CSR.
+func (s *CAServer) CreateCertificate(ctx context.Context, request *pb.IstioCertificateRequest) (
+	*pb.IstioCertificateResponse, error) {
+	cert, err := s.sign([]byte(request.Csr), []string{"client-identity"}, time.Duration(request.ValidityDuration)*time.Second, false)
+	if err != nil {
+		caServerLog.Errorf("failed to sign CSR: %+v", err)
+		return nil, status.Errorf(err.(*caerror.Error).HTTPErrorCode(), "CSR signing error: %+v", err.(*caerror.Error))
+	}
+	respCertChain := []string{string(cert)}
+	respCertChain = append(respCertChain, string(s.certPem))
+	response := &pb.IstioCertificateResponse{
+		CertChain: respCertChain,
+	}
+	caServerLog.Info("send back CSR success response")
+	return response, nil
+}
+
+func (s *CAServer) sign(csrPEM []byte, subjectIDs []string, requestedLifetime time.Duration, forCA bool) ([]byte, error) {
+	log.Infof("lifetime: %s", requestedLifetime.String())
+	csr, err := util.ParsePemEncodedCSR(csrPEM)
+	if err != nil {
+		caServerLog.Errorf("failed to parse CSR: %+v", err)
+		return nil, caerror.NewError(caerror.CSRError, err)
+	}
+	lifetime := 24 * time.Hour
+	signingCert, signingKey, _, _ := s.keyCertBundle.GetAll()
+	certBytes, err := util.GenCertFromCSR(csr, signingCert, csr.PublicKey, *signingKey, subjectIDs, lifetime, forCA)
+	if err != nil {
+		caServerLog.Errorf("failed to generate cert from CSR: %+v", err)
+		return nil, caerror.NewError(caerror.CertGenError, err)
+	}
+	block := &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	}
+	cert := pem.EncodeToMemory(block)
+
+	return cert, nil
+}

--- a/security/pkg/nodeagent/test/setup.go
+++ b/security/pkg/nodeagent/test/setup.go
@@ -23,8 +23,8 @@ import (
 	"testing"
 	"time"
 
-	ghc "github.com/go-training/grpc-health-check/proto"
 	"google.golang.org/grpc"
+	ghc "google.golang.org/grpc/health/grpc_health_v1"
 
 	proxyEnv "istio.io/istio/mixer/test/client/env"
 	"istio.io/istio/pkg/spiffe"

--- a/security/pkg/nodeagent/test/setup.go
+++ b/security/pkg/nodeagent/test/setup.go
@@ -16,30 +16,45 @@ package test
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"testing"
+	"time"
 
 	proxyEnv "istio.io/istio/mixer/test/client/env"
+	"istio.io/istio/pkg/spiffe"
 	istioEnv "istio.io/istio/pkg/test/env"
+	"istio.io/istio/security/pkg/nodeagent/cache"
+	citadel "istio.io/istio/security/pkg/nodeagent/caclient/providers/citadel"
+	"istio.io/istio/security/pkg/nodeagent/sds"
+	"istio.io/istio/security/pkg/nodeagent/secretfetcher"
+	caserver "istio.io/istio/security/pkg/nodeagent/test/mock"
 )
 
 const (
 	proxyTokenPath = "/tmp/sts-envoy-token.jwt"
+	sdsPath        = "/tmp/sdstestudspath"
 )
 
+// Env manages test setup and teardown.
 type Env struct {
-	ProxySetup *proxyEnv.TestSetup
-
+	ProxySetup           *proxyEnv.TestSetup
+	OutboundListenerPort int
 	// SDS server
-
-	// CSR server
+	SDSServer *sds.Server
+	// CA server
+	CAServer *caserver.CAServer
 }
 
+// TearDown tears down all components.
 func (e *Env) TearDown() {
 	// Stop proxy first, otherwise XDS stream is still alive and server's graceful
 	// stop will be blocked.
 	e.ProxySetup.TearDown()
+	e.SDSServer.Stop()
+	e.CAServer.GRPCServer.GracefulStop()
 }
 
 func getDataFromFile(filePath string, t *testing.T) string {
@@ -67,10 +82,16 @@ func WriteDataToFile(path string, content string) error {
 	return nil
 }
 
-// SetupTest starts Envoy, a dummy backend
+// SetupTest starts Envoy, SDS server, CA server and a dummy backend.
+// The test allow HTTP request flow.
+//                                                     CA server
+//                                                         |
+//                                           +---------SDS server-------+
+//                                           |                          |
+// HTTP request->outbound listener->outbound TLS cluster<-mTLS->inbound TLS listener->inbound cluster->backend
 func SetupTest(t *testing.T, testID uint16) *Env {
 	// Set up credential files for bootstrap config
-	jwtToken := getDataFromFile(istioEnv.IstioSrc+"/security/pkg/stsservice/test/testdata/trustworthy-jwt.jwt", t)
+	jwtToken := getDataFromFile(istioEnv.IstioSrc+"/security/pkg/nodeagent/test/testdata/jwt-token.jwt", t)
 	if err := WriteDataToFile(proxyTokenPath, jwtToken); err != nil {
 		t.Fatalf("failed to set up token file %s: %v", proxyTokenPath, err)
 	}
@@ -79,10 +100,72 @@ func SetupTest(t *testing.T, testID uint16) *Env {
 	// Set up test environment for Proxy
 	proxySetup := proxyEnv.NewTestSetup(testID, t)
 	proxySetup.SetNoMixer(true)
-	proxySetup.EnvoyTemplate = getDataFromFile(istioEnv.IstioSrc+"/security/pkg/stsservice/test/testdata/bootstrap.yaml", t)
+	proxySetup.EnvoyTemplate = getDataFromFile(istioEnv.IstioSrc+"/security/pkg/nodeagent/test/testdata/bootstrap.yaml", t)
 	env.ProxySetup = proxySetup
+	env.OutboundListenerPort = int(proxySetup.Ports().ClientProxyPort)
 
+	env.DumpPortMap(t)
+	ca, err := caserver.NewCAServer(int(proxySetup.Ports().MixerPort))
+	if err != nil {
+		t.Fatalf("failed to start CA server: %+v", err)
+	}
+	env.CAServer = ca
+	env.StartSDSServer(t)
 	return env
 }
 
+// DumpPortMap dumps port allocation status
+// outbound listener      : ClientProxyPort
+// inbound listener       : ServerProxyPort
+// test backend           : BackendPort
+// proxy admin            : AdminPort
+// CSR server             : MixerPort
+func (e *Env) DumpPortMap(t *testing.T) {
+	log.Printf("\n\tport allocation status\t\t\t\n"+
+		"outbound listener\t\t:\t%d\n"+
+		"inbound listener\t\t:\t%d\n"+
+		"test backend\t\t\t:\t%d\n"+
+		"proxy admin\t\t\t:\t%d\n"+
+		"CSR server\t\t\t:\t%d\n", e.ProxySetup.Ports().ClientProxyPort,
+		e.ProxySetup.Ports().ServerProxyPort, e.ProxySetup.Ports().BackendPort,
+		e.ProxySetup.Ports().AdminPort, e.ProxySetup.Ports().MixerPort)
+}
 
+// StartProxy starts proxy.
+func (e *Env) StartProxy(t *testing.T) {
+	if err := e.ProxySetup.SetUp(); err != nil {
+		t.Fatalf("failed to start proxy: %v", err)
+	}
+	log.Println("proxy is running...")
+}
+
+// StartSDSServer starts SDS server
+func (e *Env) StartSDSServer(t *testing.T) {
+	serverOptions := sds.Options{
+		WorkloadUDSPath:   sdsPath,
+		UseLocalJWT:       true,
+		JWTPath:           proxyTokenPath,
+		CAEndpoint:        fmt.Sprintf("127.0.0.1:%d", e.ProxySetup.Ports().MixerPort),
+		EnableWorkloadSDS: true,
+		RecycleInterval:   5 * time.Minute,
+	}
+
+	caClient, err := citadel.NewCitadelClient(serverOptions.CAEndpoint, false, nil)
+	if err != nil {
+		log.Fatalf("failed to create CA client: %+v", err)
+	}
+	secretFetcher := &secretfetcher.SecretFetcher{
+		UseCaClient: true,
+		CaClient:    caClient,
+	}
+	opt := cache.Options{
+		TrustDomain:      spiffe.GetTrustDomain(),
+		RotationInterval: 5 * time.Minute,
+	}
+	workloadSecretCache := cache.NewSecretCache(secretFetcher, sds.NotifyProxy, opt)
+	sdsServer, err := sds.NewServer(serverOptions, workloadSecretCache, nil)
+	if err != nil {
+		t.Fatalf("failed to start SDS server: %+v", err)
+	}
+	e.SDSServer = sdsServer
+}

--- a/security/pkg/nodeagent/test/setup.go
+++ b/security/pkg/nodeagent/test/setup.go
@@ -39,6 +39,7 @@ import (
 const (
 	proxyTokenPath = "/tmp/sds-envoy-token.jwt"
 	sdsPath        = "/tmp/sdstestudspath"
+	jwtToken       = "thisisafakejwt"
 )
 
 // Env manages test setup and teardown.
@@ -95,8 +96,7 @@ func WriteDataToFile(path string, content []byte) error {
 // request   listener   cluster                listener      cluster
 func SetupTest(t *testing.T, testID uint16) *Env {
 	// Set up credential files for bootstrap config
-	jwtToken := getDataFromFile(istioEnv.IstioSrc+"/security/pkg/nodeagent/test/testdata/jwt-token.jwt", t)
-	if err := WriteDataToFile(proxyTokenPath, jwtToken); err != nil {
+	if err := WriteDataToFile(proxyTokenPath, []byte(jwtToken)); err != nil {
 		t.Fatalf("failed to set up token file %s: %v", proxyTokenPath, err)
 	}
 

--- a/security/pkg/nodeagent/test/setup.go
+++ b/security/pkg/nodeagent/test/setup.go
@@ -1,0 +1,88 @@
+// Copyright 2020 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	proxyEnv "istio.io/istio/mixer/test/client/env"
+	istioEnv "istio.io/istio/pkg/test/env"
+)
+
+const (
+	proxyTokenPath = "/tmp/sts-envoy-token.jwt"
+)
+
+type Env struct {
+	ProxySetup *proxyEnv.TestSetup
+
+	// SDS server
+
+	// CSR server
+}
+
+func (e *Env) TearDown() {
+	// Stop proxy first, otherwise XDS stream is still alive and server's graceful
+	// stop will be blocked.
+	e.ProxySetup.TearDown()
+}
+
+func getDataFromFile(filePath string, t *testing.T) string {
+	data, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("failed to read %q", filePath)
+	}
+	return string(data)
+}
+
+// WriteDataToFile writes data into file
+func WriteDataToFile(path string, content string) error {
+	if path == "" {
+		return errors.New("empty file path")
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if _, err = f.WriteString(content); err != nil {
+		return err
+	}
+	_ = f.Sync()
+	return nil
+}
+
+// SetupTest starts Envoy, a dummy backend
+func SetupTest(t *testing.T, testID uint16) *Env {
+	// Set up credential files for bootstrap config
+	jwtToken := getDataFromFile(istioEnv.IstioSrc+"/security/pkg/stsservice/test/testdata/trustworthy-jwt.jwt", t)
+	if err := WriteDataToFile(proxyTokenPath, jwtToken); err != nil {
+		t.Fatalf("failed to set up token file %s: %v", proxyTokenPath, err)
+	}
+
+	env := &Env{}
+	// Set up test environment for Proxy
+	proxySetup := proxyEnv.NewTestSetup(testID, t)
+	proxySetup.SetNoMixer(true)
+	proxySetup.EnvoyTemplate = getDataFromFile(istioEnv.IstioSrc+"/security/pkg/stsservice/test/testdata/bootstrap.yaml", t)
+	env.ProxySetup = proxySetup
+
+	return env
+}
+
+

--- a/security/pkg/nodeagent/test/setup.go
+++ b/security/pkg/nodeagent/test/setup.go
@@ -25,6 +25,7 @@ import (
 
 	ghc "github.com/go-training/grpc-health-check/proto"
 	"google.golang.org/grpc"
+
 	proxyEnv "istio.io/istio/mixer/test/client/env"
 	"istio.io/istio/pkg/spiffe"
 	istioEnv "istio.io/istio/pkg/test/env"

--- a/security/pkg/nodeagent/test/setup.go
+++ b/security/pkg/nodeagent/test/setup.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"testing"
 	"time"
@@ -84,11 +83,12 @@ func WriteDataToFile(path string, content string) error {
 
 // SetupTest starts Envoy, SDS server, CA server and a dummy backend.
 // The test allow HTTP request flow.
-//                                                     CA server
-//                                                         |
-//                                           +---------SDS server-------+
-//                                           |                          |
-// HTTP request->outbound listener->outbound TLS cluster<-mTLS->inbound TLS listener->inbound cluster->backend
+//                                 CA server
+//                                     |
+//                        +--------SDS server--------+
+//                        |                          |
+// HTTP    ->outbound ->outbound TLS <--mTLS-->inbound TLS ->inbound ->backend
+// request   listener   cluster                listener      cluster
 func SetupTest(t *testing.T, testID uint16) *Env {
 	// Set up credential files for bootstrap config
 	jwtToken := getDataFromFile(istioEnv.IstioSrc+"/security/pkg/nodeagent/test/testdata/jwt-token.jwt", t)
@@ -121,7 +121,7 @@ func SetupTest(t *testing.T, testID uint16) *Env {
 // proxy admin            : AdminPort
 // CSR server             : MixerPort
 func (e *Env) DumpPortMap(t *testing.T) {
-	log.Printf("\n\tport allocation status\t\t\t\n"+
+	t.Logf("\n\tport allocation status\t\t\t\n"+
 		"outbound listener\t\t:\t%d\n"+
 		"inbound listener\t\t:\t%d\n"+
 		"test backend\t\t\t:\t%d\n"+
@@ -136,7 +136,7 @@ func (e *Env) StartProxy(t *testing.T) {
 	if err := e.ProxySetup.SetUp(); err != nil {
 		t.Fatalf("failed to start proxy: %v", err)
 	}
-	log.Println("proxy is running...")
+	t.Log("proxy is running...")
 }
 
 // StartSDSServer starts SDS server
@@ -152,7 +152,7 @@ func (e *Env) StartSDSServer(t *testing.T) {
 
 	caClient, err := citadel.NewCitadelClient(serverOptions.CAEndpoint, false, nil)
 	if err != nil {
-		log.Fatalf("failed to create CA client: %+v", err)
+		t.Fatalf("failed to create CA client: %+v", err)
 	}
 	secretFetcher := &secretfetcher.SecretFetcher{
 		UseCaClient: true,

--- a/security/pkg/nodeagent/test/setup.go
+++ b/security/pkg/nodeagent/test/setup.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	proxyTokenPath = "/tmp/sts-envoy-token.jwt"
+	proxyTokenPath = "/tmp/sds-envoy-token.jwt"
 	sdsPath        = "/tmp/sdstestudspath"
 )
 

--- a/security/pkg/nodeagent/test/success_sds/doc.go
+++ b/security/pkg/nodeagent/test/success_sds/doc.go
@@ -1,0 +1,15 @@
+// Copyright 2020 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package successsds

--- a/security/pkg/nodeagent/test/success_sds/sds_test.go
+++ b/security/pkg/nodeagent/test/success_sds/sds_test.go
@@ -13,3 +13,28 @@
 // limitations under the License.
 
 package successsds
+
+import (
+	"fmt"
+	"testing"
+
+	"istio.io/istio/mixer/test/client/env"
+	testID "istio.io/istio/mixer/test/client/env"
+	sdsTest "istio.io/istio/security/pkg/nodeagent/test"
+)
+
+func TestProxySDS(t *testing.T) {
+	setup := sdsTest.SetupTest(t, testID.SDSTest)
+	defer setup.TearDown()
+
+	setup.StartProxy(t)
+	for i := 0; i < 10; i++ {
+		code, _, err := env.HTTPGet(fmt.Sprintf("http://localhost:%d/echo", setup.OutboundListenerPort))
+		if err != nil {
+			t.Errorf("Failed in request: %v", err)
+		}
+		if code != 200 {
+			t.Errorf("Unexpected status code: %d", code)
+		}
+	}
+}

--- a/security/pkg/nodeagent/test/success_sds/sds_test.go
+++ b/security/pkg/nodeagent/test/success_sds/sds_test.go
@@ -1,0 +1,15 @@
+// Copyright 2020 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package successsds

--- a/security/pkg/nodeagent/test/testdata/bootstrap.yaml
+++ b/security/pkg/nodeagent/test/testdata/bootstrap.yaml
@@ -1,0 +1,98 @@
+admin:
+  access_log_path: {{.AccessLogPath}}
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: {{.Ports.AdminPort}}
+node:
+  id: id
+  cluster: sds-test
+static_resources:
+  clusters:
+    - name: backend
+      connect_timeout: 5s
+      hosts:
+        - socket_address:
+            address: 127.0.0.1
+            port_value: {{.Ports.BackendPort}}
+      type: STATIC
+    - name: outbound_cluster_tls
+      connect_timeout: 5s
+      hosts:
+        - socket_address:
+            address: 127.0.0.1
+            port_value: {{.Ports.ServerProxyPort}}
+      type: STATIC
+      tls_context:
+        common_tls_context:
+          tls_certificate_sds_secret_configs:
+            - name: "SPKI"
+              sds_config:
+                api_config_source:
+                  api_type: GRPC
+                  grpc_services:
+                    - envoy_grpc:
+                        cluster_name: "sds-grpc"
+                  refresh_delay: 60s
+  listeners:
+    - name: outbound_listener
+      address:
+        socket_address:
+          address: 127.0.0.1
+          port_value: {{.Ports.ClientProxyPort}}
+      filter_chains:
+        filters:
+          - name: envoy.http_connection_manager
+          - config:
+              codec_type: auto
+              stat_prefix: outbound
+              http_filters:
+                - config: {}
+                  name: envoy.router
+              route_config:
+                name: outbound_cluster_tls
+                virtual_hosts:
+                  - domains:
+                      - "*"
+                    name: service
+                    routes:
+                      - match:
+                          prefix: "/"
+                        route:
+                          cluster: outbound_cluster_tls
+    - name: inbound_listener_tls
+      address:
+        socket_address:
+          address: 127.0.0.1
+          port_value: {{.Ports.ServerProxyPort}}
+      filter_chains:
+        tls_context:
+          common_tls_context:
+            tls_certificate_sds_secret_configs:
+              - name: "SPKI"
+                sds_config:
+                  api_config_source:
+                    api_type: GRPC
+                    grpc_services:
+                      - envoy_grpc:
+                          cluster_name: "sds-grpc"
+                    refresh_delay: 60s
+        filters:
+          - config:
+              codec_type: auto
+              stat_prefix: inbound
+              http_filters:
+                - config: {}
+                  name: envoy.router
+              route_config:
+                name: backend
+                virtual_hosts:
+                  - domains:
+                      - "*"
+                    name: service
+                    routes:
+                      - match:
+                          prefix: "/"
+                        route:
+                          cluster: backend
+            name: envoy.http_connection_manager

--- a/security/pkg/nodeagent/test/testdata/bootstrap.yaml
+++ b/security/pkg/nodeagent/test/testdata/bootstrap.yaml
@@ -6,93 +6,108 @@ admin:
       port_value: {{.Ports.AdminPort}}
 node:
   id: id
-  cluster: sds-test
+  cluster: sdstest
 static_resources:
   clusters:
-    - name: backend
-      connect_timeout: 5s
-      hosts:
-        - socket_address:
-            address: 127.0.0.1
-            port_value: {{.Ports.BackendPort}}
-      type: STATIC
-    - name: outbound_cluster_tls
-      connect_timeout: 5s
-      hosts:
-        - socket_address:
-            address: 127.0.0.1
-            port_value: {{.Ports.ServerProxyPort}}
-      type: STATIC
+  - name: backend
+    connect_timeout: 5s
+    hosts:
+    - socket_address:
+        address: 127.0.0.1
+        port_value: {{.Ports.BackendPort}}
+    type: STATIC
+  - name: outbound_cluster_tls
+    connect_timeout: 5s
+    hosts:
+    - socket_address:
+        address: 127.0.0.1
+        port_value: {{.Ports.ServerProxyPort}}
+    type: STATIC
+    tls_context:
+      common_tls_context:
+        tls_certificate_sds_secret_configs:
+          - name: "outbound-sds"
+            sds_config:
+              api_config_source:
+                api_type: GRPC
+                grpc_services:
+                  - envoy_grpc:
+                      cluster_name: "sds-grpc"
+                refresh_delay: 60s
+        combined_validation_context:
+          default_validation_context: {}
+          validation_context_sds_secret_config:
+            name: ROOTCA
+            sds_config:
+              api_config_source:
+                api_type: GRPC
+                grpc_services:
+                - envoy_grpc:
+                    cluster_name: sds-grpc        
+  - name: sds-grpc
+    type: STATIC
+    http2_protocol_options: {}
+    connect_timeout: 5s
+    lb_policy: ROUND_ROBIN
+    hosts:
+    - pipe:
+        path: "/tmp/sdstestudspath"
+  listeners:
+  - name: outbound_listener
+    address:
+      socket_address:
+        address: 127.0.0.1
+        port_value: {{.Ports.ClientProxyPort}}
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        config:
+          codec_type: auto
+          stat_prefix: outbound
+          http_filters:
+          - name: envoy.router
+          route_config:
+            name: outbound_cluster_tls
+            virtual_hosts:
+            - name: outbound_cluster_tls
+              domains: ["*"]
+              routes:
+              - match:
+                  prefix: /
+                route:
+                  cluster: outbound_cluster_tls
+  - name: inbound_listener_tls
+    address:
+      socket_address:
+        address: 127.0.0.1
+        port_value: {{.Ports.ServerProxyPort}}
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager 
+        config:
+          codec_type: auto
+          stat_prefix: inbound
+          http_filters:
+          - name: envoy.router
+          route_config:
+            name: backend
+            virtual_hosts:
+            - name: backend  
+              domains: ["*"]
+              routes:
+              - match:
+                  prefix: /
+                route:
+                  cluster: backend
       tls_context:
         common_tls_context:
           tls_certificate_sds_secret_configs:
-            - name: "SPKI"
+            - name: "inbound-sds"
               sds_config:
                 api_config_source:
                   api_type: GRPC
                   grpc_services:
                     - envoy_grpc:
                         cluster_name: "sds-grpc"
-                  refresh_delay: 60s
-  listeners:
-    - name: outbound_listener
-      address:
-        socket_address:
-          address: 127.0.0.1
-          port_value: {{.Ports.ClientProxyPort}}
-      filter_chains:
-        filters:
-          - name: envoy.http_connection_manager
-          - config:
-              codec_type: auto
-              stat_prefix: outbound
-              http_filters:
-                - config: {}
-                  name: envoy.router
-              route_config:
-                name: outbound_cluster_tls
-                virtual_hosts:
-                  - domains:
-                      - "*"
-                    name: service
-                    routes:
-                      - match:
-                          prefix: "/"
-                        route:
-                          cluster: outbound_cluster_tls
-    - name: inbound_listener_tls
-      address:
-        socket_address:
-          address: 127.0.0.1
-          port_value: {{.Ports.ServerProxyPort}}
-      filter_chains:
-        tls_context:
-          common_tls_context:
-            tls_certificate_sds_secret_configs:
-              - name: "SPKI"
-                sds_config:
-                  api_config_source:
-                    api_type: GRPC
-                    grpc_services:
-                      - envoy_grpc:
-                          cluster_name: "sds-grpc"
-                    refresh_delay: 60s
-        filters:
-          - config:
-              codec_type: auto
-              stat_prefix: inbound
-              http_filters:
-                - config: {}
-                  name: envoy.router
-              route_config:
-                name: backend
-                virtual_hosts:
-                  - domains:
-                      - "*"
-                    name: service
-                    routes:
-                      - match:
-                          prefix: "/"
-                        route:
-                          cluster: backend
-            name: envoy.http_connection_manager
+                  refresh_delay: 60s            
+          

--- a/security/pkg/nodeagent/test/testdata/jwt-token.jwt
+++ b/security/pkg/nodeagent/test/testdata/jwt-token.jwt
@@ -1,0 +1,1 @@
+thisisafakejwt

--- a/security/pkg/nodeagent/test/testdata/jwt-token.jwt
+++ b/security/pkg/nodeagent/test/testdata/jwt-token.jwt
@@ -1,1 +1,0 @@
-thisisafakejwt


### PR DESCRIPTION
Please provide a description for what this PR is for.
This test setup starts Envoy, SDS server, and mock CA server as individual processes that run locally. This helps to add negative tests for SDS flow and to reproduce SDS issues without building images and deploying Istio.

The test catches a race condition https://github.com/istio/istio/issues/22627 and that is fixed in this PR.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

https://github.com/istio/istio/issues/22438
https://github.com/istio/istio/issues/22627