### PR TITLE
Support ca.crt secret key item

### DIFF
--- a/security/pkg/nodeagent/secretfetcher/secretfetcher.go
+++ b/security/pkg/nodeagent/secretfetcher/secretfetcher.go
@@ -52,6 +52,8 @@ const (
 	tlsScrtCert = "tls.crt"
 	// The ID/name for the k8sKey in kubernetes tls secret.
 	tlsScrtKey = "tls.key"
+	// The ID/name for the CA certificate in kubernetes tls secret
+	tlsScrtCaCert = "ca.crt"
 
 	// IngressSecretNamespace the namespace of kubernetes secrets to watch.
 	ingressSecretNamespace = "INGRESS_GATEWAY_NAMESPACE"
@@ -229,6 +231,8 @@ func extractCertAndKey(scrt *v1.Secret) (cert, key []byte, exist bool) {
 func extractCACert(scrt *v1.Secret, fromCompoundSecret bool) (caCert []byte, exist bool) {
 	if len(scrt.Data[genericScrtCaCert]) > 0 {
 		caCert = scrt.Data[genericScrtCaCert]
+	} else if len(scrt.Data[tlsScrtCaCert]) > 0 {
+		caCert = scrt.Data[tlsScrtCaCert]
 	} else if !fromCompoundSecret {
 		caCert = scrt.Data[tlsScrtCert]
 	}

--- a/security/pkg/nodeagent/secretfetcher/secretfetcher_test.go
+++ b/security/pkg/nodeagent/secretfetcher/secretfetcher_test.go
@@ -268,6 +268,20 @@ oCvHkuhGyVKRT4Ddff4gfbvMPlls
 		},
 		Type: "test-tls-ca-secret",
 	}
+
+	k8sSecretNameG           = "test-scrtG"
+	k8sTestKubernetesSecretG = &v1.Secret{
+		Data: map[string][]byte{
+			tlsScrtCert:   k8sCertChainB,
+			tlsScrtKey:    k8sKeyB,
+			tlsScrtCaCert: k8sCaCertB,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      k8sSecretNameG,
+			Namespace: "test-namespace",
+		},
+		Type: "test-secret",
+	}
 )
 
 type expectedSecret struct {
@@ -405,6 +419,42 @@ func TestSecretFetcher(t *testing.T) {
 		},
 	}
 	testDeleteSecret(t, gSecretFetcher, k8sTestGenericCASecretE, expectedDeletedCASecrets)
+
+	// Add test secret and verify that key/cert pair is stored.
+	expectedAddedSecrets = []expectedSecret{
+		{
+			exist: true,
+			secret: &model.SecretItem{
+				ResourceName:     k8sSecretNameG,
+				CertificateChain: k8sCertChainB,
+				ExpireTime:       k8sTestCertChainExpireTimeA,
+				PrivateKey:       k8sKeyB,
+			},
+		},
+		{
+			exist: true,
+			secret: &model.SecretItem{
+				ResourceName: k8sSecretNameG + IngressGatewaySdsCaSuffix,
+				RootCert:     k8sCaCertB,
+				ExpireTime:   k8sTestCaCertExpireTimeA,
+			},
+		},
+	}
+	testAddSecret(t, gSecretFetcher, k8sTestKubernetesSecretG, expectedAddedSecrets, &secretVersionOne)
+
+	// Delete test secret and verify that key/cert pair in secret is removed from local store.
+	expectedDeletedSecrets = []expectedSecret{
+		{
+			exist:  false,
+			secret: &model.SecretItem{ResourceName: k8sSecretNameG},
+		},
+		{
+			exist:  false,
+			secret: &model.SecretItem{ResourceName: k8sSecretNameG + IngressGatewaySdsCaSuffix},
+		},
+	}
+	testDeleteSecret(t, gSecretFetcher, k8sTestKubernetesSecretG, expectedDeletedSecrets)
+
 }
 
 // TestSecretFetcherInvalidSecret verifies that if a secret does not have key or cert, secret fetcher
@@ -772,6 +822,7 @@ func TestSecretFetcherUsingFallbackIngressSecret(t *testing.T) {
 }
 
 func compareSecret(t *testing.T, secret, expectedSecret *model.SecretItem) {
+	t.Helper()
 	if expectedSecret.ResourceName != secret.ResourceName {
 		t.Errorf("resource name verification error: expected %s but got %s", expectedSecret.ResourceName, secret.ResourceName)
 	}
@@ -787,6 +838,7 @@ func compareSecret(t *testing.T, secret, expectedSecret *model.SecretItem) {
 }
 
 func testAddSecret(t *testing.T, sf *SecretFetcher, k8ssecret *v1.Secret, expectedSecrets []expectedSecret, version *string) {
+	t.Helper()
 	// Add a test secret and find the secret.
 	sf.scrtAdded(k8ssecret)
 	for _, es := range expectedSecrets {


### PR DESCRIPTION
Currently we require users to use a generic secret, or to have two
secrets, "X" with the key and cert, and "X-cacert" with the cacert.

This PR extends this to allow kubernetes.io/tls secrets to also read the
ca.crt field instead of requiring a separate Secret. This allows
integration with tools like cert-manager.

Fixes https://github.com/istio/istio/issues/21076
