### PR TITLE
Unskip leader election test

### DIFF
--- a/pilot/pkg/leaderelection/leaderelection_test.go
+++ b/pilot/pkg/leaderelection/leaderelection_test.go
@@ -93,7 +93,6 @@ func TestLeaderElectionConfigMapRemoved(t *testing.T) {
 }
 
 func TestLeaderElectionNoPermission(t *testing.T) {
-	t.Skip("https://github.com/istio/istio/issues/22038")
 	client := fake.NewSimpleClientset()
 	allowRbac := atomic.NewBool(true)
 	client.Fake.PrependReactor("update", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {


### PR DESCRIPTION
This is fixed in k8s 1.18, which we have updated to

Fixes https://github.com/istio/istio/issues/22038

I ran this test 10,000 times locally with no failure