### PR TITLE
Applying cel upgrade to release 1.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 // indirect
 	github.com/golang/protobuf v1.3.2
 	github.com/golang/sync v0.0.0-20180314180146-1d60e4601c6f
-	github.com/google/cel-go v0.2.0
+	github.com/google/cel-go v0.4.1
 	github.com/google/go-cmp v0.3.1
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6/go.mod h1:SGn
 github.com/alicebob/miniredis v0.0.0-20180201100744-9d52b1fc8da9 h1:wqvIPbcOreD8CAde3cnOydGj2rjUN/awKZcfyccW9hA=
 github.com/alicebob/miniredis v0.0.0-20180201100744-9d52b1fc8da9/go.mod h1:8HZjEj4yU0dwhYHky+DxYx+6BMjkBbe5ONFIF1MXffk=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
-github.com/antlr/antlr4 v0.0.0-20190223165740-dade65a895c2 h1:Q1TGw0wvj6lqZQ4/CMfZykGQDnkslNcvuDID+AfNiQE=
-github.com/antlr/antlr4 v0.0.0-20190223165740-dade65a895c2/go.mod h1:T7PbCXFs94rrTttyxjbyT5+/1V8T2TYDejxUfHJjw1Y=
+github.com/antlr/antlr4 v0.0.0-20190819145818-b43a4c3a8015 h1:StuiJFxQUsxSCzcby6NFZRdEhPkXD5vxN7TZ4MD6T84=
+github.com/antlr/antlr4 v0.0.0-20190819145818-b43a4c3a8015/go.mod h1:T7PbCXFs94rrTttyxjbyT5+/1V8T2TYDejxUfHJjw1Y=
 github.com/aokoli/goutils v1.0.1 h1:7fpzNGoJ3VA8qcrm++XEE1QUe0mIwNeLa02Nwq7RDkg=
 github.com/aokoli/goutils v1.0.1/go.mod h1:SijmP0QR8LtwsmDs8Yii5Z/S4trXFGFC2oO5g9DP+DQ=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
@@ -283,7 +283,6 @@ github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFU
 github.com/golang/protobuf v0.0.0-20161109072736-4bd1920723d7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.0.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/golang/protobuf v1.3.0/go.mod h1:Qd/q+1AKNOZr9uGQzbzCmRO6sUih6GTPZv6a1/R87v0=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -298,9 +297,9 @@ github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e/go.mod h1:0AA//
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
-github.com/google/cel-go v0.2.0 h1:1xQjGc4NQ0Kk0308Om1gfSt7Tkk4hwgVMGEpEEYwf9g=
-github.com/google/cel-go v0.2.0/go.mod h1:fTCVOuSN/Vn6d49zvRpr3fDAKFyfpLViE0gU+9Vtm7g=
-github.com/google/cel-spec v0.2.0/go.mod h1:MjQm800JAGhOZXI7vatnVpmIaFTR6L8FHcKk+piiKpI=
+github.com/google/cel-go v0.4.1 h1:2kqc5arTucvtLJzXVUbmiUh7n2xjizwZijPrpEsagAE=
+github.com/google/cel-go v0.4.1/go.mod h1:F0UncVAXNlNjl/4C8hqGdoV6APmuFpetoMJSLIQLBPU=
+github.com/google/cel-spec v0.3.0/go.mod h1:MjQm800JAGhOZXI7vatnVpmIaFTR6L8FHcKk+piiKpI=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
@@ -864,8 +863,6 @@ google.golang.org/appengine v1.6.2/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww
 google.golang.org/appengine v1.6.5 h1:tycE03LOZYQNhDpS27tcQdAzLCVMaj7QT2SXxebnpCM=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
-google.golang.org/genproto v0.0.0-20180831171423-11092d34479b/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
-google.golang.org/genproto v0.0.0-20190227213309-4f5b463f9597/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190404172233-64821d5d2107/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/mixer/pkg/il/testing/tests.go
+++ b/mixer/pkg/il/testing/tests.go
@@ -1127,30 +1127,30 @@ end
 	},
 
 	{
-		E:    `dnsName(as)`,
+		E:    `dnsName(abc)`,
 		Type: descriptor.DNS_NAME,
-		Err:  "lookup failed: 'as'",
+		Err:  "lookup failed: 'abc'",
 	},
 
 	{
-		E:    `dnsName(as)`,
+		E:    `dnsName(abc)`,
 		Type: descriptor.DNS_NAME,
 		I: map[string]interface{}{
-			"as": "-foo.-bar",
+			"abc": "-foo.-bar",
 		},
 		Err: `error converting '-foo.-bar' to dns name: 'idna: invalid label "-foo"'`,
 	},
 
 	{
-		E:    `dnsName(as)`,
+		E:    `dnsName(abc)`,
 		Type: descriptor.DNS_NAME,
 		I: map[string]interface{}{
-			"as": "foo.bar",
+			"abc": "foo.bar",
 		},
 		R: "foo.bar",
 		IL: `
 fn eval() string
-  resolve_s "as"
+  resolve_s "abc"
   call dnsName
   ret
 end
@@ -1244,14 +1244,14 @@ end`,
 	},
 
 	{
-		E:    `dnsName(as | bs | "foo")`,
+		E:    `dnsName(abc | bs | "foo")`,
 		Type: descriptor.DNS_NAME,
 		R:    "foo",
 		// CEL does not support top-level ident presence
 		CEL: errors.New("error converting"),
 		IL: `
  fn eval() string
-  tresolve_s "as"
+  tresolve_s "abc"
   jnz L0
   tresolve_s "bs"
   jnz L0
@@ -1263,10 +1263,10 @@ end`,
 	},
 
 	{
-		E:    `dnsName(as | bs | "foo")`,
+		E:    `dnsName(abc | bs | "foo")`,
 		Type: descriptor.DNS_NAME,
 		I: map[string]interface{}{
-			"as": "foo.bar.com",
+			"abc": "foo.bar.com",
 		},
 		R: "foo.bar.com",
 	},
@@ -1310,13 +1310,13 @@ end`,
 	},
 
 	{
-		E:          `adns == as`,
-		CompileErr: "EQ($adns, $as) arg 2 ($as) typeError got STRING, expected DNS_NAME",
+		E:          `adns == abc`,
+		CompileErr: "EQ($adns, $abc) arg 2 ($abc) typeError got STRING, expected DNS_NAME",
 	},
 
 	{
-		E:          `adns != as`,
-		CompileErr: "NEQ($adns, $as) arg 2 ($as) typeError got STRING, expected DNS_NAME",
+		E:          `adns != abc`,
+		CompileErr: "NEQ($adns, $abc) arg 2 ($abc) typeError got STRING, expected DNS_NAME",
 	},
 
 	{
@@ -1376,30 +1376,30 @@ end
 	},
 
 	{
-		E:    `email(as)`,
+		E:    `email(abc)`,
 		Type: descriptor.EMAIL_ADDRESS,
-		Err:  "lookup failed: 'as'",
+		Err:  "lookup failed: 'abc'",
 	},
 
 	{
-		E:    `email(as)`,
+		E:    `email(abc)`,
 		Type: descriptor.EMAIL_ADDRESS,
 		I: map[string]interface{}{
-			"as": "barfoo",
+			"abc": "barfoo",
 		},
 		Err: `error converting 'barfoo' to e-mail:`,
 	},
 
 	{
-		E:    `email(as)`,
+		E:    `email(abc)`,
 		Type: descriptor.EMAIL_ADDRESS,
 		I: map[string]interface{}{
-			"as": "istio@istio.io",
+			"abc": "istio@istio.io",
 		},
 		R: "istio@istio.io",
 		IL: `
 fn eval() string
-  resolve_s "as"
+  resolve_s "abc"
   call email
   ret
 end
@@ -1407,10 +1407,10 @@ end
 	},
 
 	{
-		E:    `email(as)`,
+		E:    `email(abc)`,
 		Type: descriptor.EMAIL_ADDRESS,
 		I: map[string]interface{}{
-			"as": `"istio"@istio.io`, // The e-mail should not get normalized.
+			"abc": `"istio"@istio.io`, // The e-mail should not get normalized.
 		},
 		R: `"istio"@istio.io`,
 	},
@@ -1502,14 +1502,14 @@ end`,
 	},
 
 	{
-		E:    `email(as | bs | "istio@istio.io")`,
+		E:    `email(abc | bs | "istio@istio.io")`,
 		Type: descriptor.EMAIL_ADDRESS,
 		R:    "istio@istio.io",
 		// CEL does not support top-level ident presence
 		CEL: errors.New("error converting"),
 		IL: `
  fn eval() string
-  tresolve_s "as"
+  tresolve_s "abc"
   jnz L0
   tresolve_s "bs"
   jnz L0
@@ -1521,10 +1521,10 @@ end`,
 	},
 
 	{
-		E:    `email(as | bs | "pilot@istio.io")`,
+		E:    `email(abc | bs | "pilot@istio.io")`,
 		Type: descriptor.EMAIL_ADDRESS,
 		I: map[string]interface{}{
-			"as": "istio@istio.io",
+			"abc": "istio@istio.io",
 		},
 		R: "istio@istio.io",
 	},
@@ -1568,13 +1568,13 @@ end`,
 	},
 
 	{
-		E:          `amail == as`,
-		CompileErr: "EQ($amail, $as) arg 2 ($as) typeError got STRING, expected EMAIL_ADDRESS",
+		E:          `amail == abc`,
+		CompileErr: "EQ($amail, $abc) arg 2 ($abc) typeError got STRING, expected EMAIL_ADDRESS",
 	},
 
 	{
-		E:          `amail != as`,
-		CompileErr: "NEQ($amail, $as) arg 2 ($as) typeError got STRING, expected EMAIL_ADDRESS",
+		E:          `amail != abc`,
+		CompileErr: "NEQ($amail, $abc) arg 2 ($abc) typeError got STRING, expected EMAIL_ADDRESS",
 	},
 
 	{
@@ -1617,30 +1617,30 @@ end
 	},
 
 	{
-		E:    `uri(as)`,
+		E:    `uri(abc)`,
 		Type: descriptor.URI,
-		Err:  "lookup failed: 'as'",
+		Err:  "lookup failed: 'abc'",
 	},
 
 	{
-		E:    `uri(as)`,
+		E:    `uri(abc)`,
 		Type: descriptor.URI,
 		I: map[string]interface{}{
-			"as": ":/",
+			"abc": ":/",
 		},
 		Err: `error converting string to uri ':/': 'parse :/: missing protocol scheme'`,
 	},
 
 	{
-		E:    `uri(as)`,
+		E:    `uri(abc)`,
 		Type: descriptor.URI,
 		I: map[string]interface{}{
-			"as": "urn:foo",
+			"abc": "urn:foo",
 		},
 		R: "urn:foo",
 		IL: `
 fn eval() string
-  resolve_s "as"
+  resolve_s "abc"
   call uri
   ret
 end
@@ -1734,14 +1734,14 @@ end`,
 	},
 
 	{
-		E:    `uri(as | bs | "ftp://ftp.istio.io/releases")`,
+		E:    `uri(abc | bs | "ftp://ftp.istio.io/releases")`,
 		Type: descriptor.URI,
 		R:    "ftp://ftp.istio.io/releases",
 		// CEL does not support top-level ident presence
 		CEL: errors.New("error converting"),
 		IL: `
  fn eval() string
-  tresolve_s "as"
+  tresolve_s "abc"
   jnz L0
   tresolve_s "bs"
   jnz L0
@@ -1753,10 +1753,10 @@ end`,
 	},
 
 	{
-		E:    `uri(as | bs | "ftp://ftp.istio.io/releases")`,
+		E:    `uri(abc | bs | "ftp://ftp.istio.io/releases")`,
 		Type: descriptor.URI,
 		I: map[string]interface{}{
-			"as": "http://istio.io",
+			"abc": "http://istio.io",
 		},
 		R: "http://istio.io",
 	},
@@ -1800,13 +1800,13 @@ end`,
 	},
 
 	{
-		E:          `auri == as`,
-		CompileErr: "EQ($auri, $as) arg 2 ($as) typeError got STRING, expected URI",
+		E:          `auri == abc`,
+		CompileErr: "EQ($auri, $abc) arg 2 ($abc) typeError got STRING, expected URI",
 	},
 
 	{
-		E:          `auri != as`,
-		CompileErr: "NEQ($auri, $as) arg 2 ($as) typeError got STRING, expected URI",
+		E:          `auri != abc`,
+		CompileErr: "NEQ($auri, $abc) arg 2 ($abc) typeError got STRING, expected URI",
 	},
 
 	{
@@ -1905,15 +1905,15 @@ end`,
 		CEL: false,
 	},
 	{
-		E:    `as`,
+		E:    `abc`,
 		Type: descriptor.STRING,
 		I: map[string]interface{}{
-			"as": "AAA",
+			"abc": "AAA",
 		},
 		R: "AAA",
 		IL: `
 fn eval() string
-  resolve_s "as"
+  resolve_s "abc"
   ret
 end`,
 	},
@@ -1986,28 +1986,28 @@ L0:
 end`,
 	},
 	{
-		E:       `as | ""`,
+		E:       `abc | ""`,
 		Type:    descriptor.STRING,
 		R:       "",
-		SkipAst: true, // AST returns nil for this case.
+		Skipast: true, // ast returns nil for this cabce.
 	},
 	{
-		E:    `as | ""`,
+		E:    `abc | ""`,
 		Type: descriptor.STRING,
 		I: map[string]interface{}{
-			"as": "foo",
+			"abc": "foo",
 		},
 		R: "foo",
 	},
 	{
-		E:    `as | "user1"`,
+		E:    `abc | "user1"`,
 		Type: descriptor.STRING,
 		R:    "user1",
 		// top-level idents do not support presence
 		CEL: "",
 		IL: `
 fn eval() string
-  tresolve_s "as"
+  tresolve_s "abc"
   jnz L0
   apush_s "user1"
 L0:
@@ -2015,22 +2015,22 @@ L0:
 end`,
 	},
 	{
-		E:    `as | "user1"`,
+		E:    `abc | "user1"`,
 		Type: descriptor.STRING,
 		R:    "a2",
 		I: map[string]interface{}{
-			"as": "a2",
+			"abc": "a2",
 		},
 	},
 	{
-		E:    `as | bs | "user1"`,
+		E:    `abc | bs | "user1"`,
 		Type: descriptor.STRING,
 		R:    "user1",
 		// top-level idents do not support presence
 		CEL: "",
 		IL: `
 fn eval() string
-  tresolve_s "as"
+  tresolve_s "abc"
   jnz L0
   tresolve_s "bs"
   jnz L0
@@ -2040,16 +2040,16 @@ L0:
 end`,
 	},
 	{
-		E:    `as | bs | "user1"`,
+		E:    `abc | bs | "user1"`,
 		Type: descriptor.STRING,
 		I: map[string]interface{}{
-			"as": "a2",
+			"abc": "a2",
 		},
 		R:          "a2",
-		Referenced: []string{"as"},
+		Referenced: []string{"abc"},
 	},
 	{
-		E:    `as | bs | "user1"`,
+		E:    `abc | bs | "user1"`,
 		Type: descriptor.STRING,
 		I: map[string]interface{}{
 			"bs": "b2",
@@ -2057,18 +2057,18 @@ end`,
 		R: "b2",
 		// top-level idents do not support presence
 		CEL:           "",
-		Referenced:    []string{"-as", "bs"},
-		ReferencedCEL: []string{"-as"},
+		Referenced:    []string{"-abc", "bs"},
+		ReferencedCEL: []string{"-abc"},
 	},
 	{
-		E:    `as | bs | "user1"`,
+		E:    `abc | bs | "user1"`,
 		Type: descriptor.STRING,
 		I: map[string]interface{}{
-			"as": "a2",
-			"bs": "b2",
+			"abc": "a2",
+			"bs":  "b2",
 		},
 		R:          "a2",
-		Referenced: []string{"as"},
+		Referenced: []string{"abc"},
 	},
 
 	{
@@ -2269,7 +2269,7 @@ end`,
 	{
 		E:       `(ar | br)["foo"]`,
 		Type:    descriptor.STRING,
-		SkipAst: true, // AST evaluator panics for this case.
+		Skipast: true, // ast evaluator panics for this cabce.
 		I: map[string]interface{}{
 			"ar": map[string]string{
 				"foo": "bar",
@@ -2293,7 +2293,7 @@ end`,
 	{
 		E:       `(ar | br)["foo"]`,
 		Type:    descriptor.STRING,
-		SkipAst: true, // AST evaluator panics for this case.
+		Skipast: true, // ast evaluator panics for this cabce.
 		I: map[string]interface{}{
 			"br": map[string]string{
 				"foo": "far",
@@ -2328,16 +2328,16 @@ end`,
 		R: false,
 	},
 	{
-		E:    "as == bs",
+		E:    "abc == bs",
 		Type: descriptor.BOOL,
 		I: map[string]interface{}{
-			"as": "ABC",
-			"bs": "ABC",
+			"abc": "ABC",
+			"bs":  "ABC",
 		},
 		R: true,
 		IL: `
 fn eval() bool
-  resolve_s "as"
+  resolve_s "abc"
   resolve_s "bs"
   eq_s
   ret
@@ -2423,18 +2423,18 @@ fn eval() string
 end`,
 	},
 	{
-		E:    `sm[as]`,
+		E:    `sm[abc]`,
 		Type: descriptor.STRING,
 		I: map[string]interface{}{
-			"as": "foo",
-			"sm": map[string]string{"foo": "bar"},
+			"abc": "foo",
+			"sm":  map[string]string{"foo": "bar"},
 		},
 		R:          "bar",
-		Referenced: []string{"as", "sm", "sm[foo]"},
+		Referenced: []string{"abc", "sm", "sm[foo]"},
 		IL: `
 fn eval() string
   resolve_f "sm"
-  resolve_s "as"
+  resolve_s "abc"
   nlookup
   ret
 end`,
@@ -2469,20 +2469,20 @@ end`,
 		R: "b",
 	},
 	{
-		E:          `ar[as] | "foo"`,
+		E:          `ar[abc] | "foo"`,
 		Type:       descriptor.STRING,
 		I:          map[string]interface{}{},
 		R:          "foo",
 		Referenced: []string{"-ar"},
 		// CEL index operator is a function that always resolves the index
-		ReferencedCEL: []string{"-ar", "-as"},
+		ReferencedCEL: []string{"-abc", "-ar"},
 		IL: `
 fn eval() string
   tresolve_f "ar"
   jnz L0
   jmp L1
 L0:
-  tresolve_s "as"
+  tresolve_s "abc"
   jnz L2
   jmp L1
 L2:
@@ -2495,46 +2495,46 @@ L3:
 end`,
 	},
 	{
-		E:    `ar[as] | "foo"`,
+		E:    `ar[abc] | "foo"`,
 		Type: descriptor.STRING,
 		I: map[string]interface{}{
-			"ar": map[string]string{"as": "bar"},
+			"ar": map[string]string{"abc": "bar"},
 		},
 		R:          "foo",
-		Referenced: []string{"-as", "ar"},
+		Referenced: []string{"-abc", "ar"},
 		// CEL resolved missing stringmap attributes to an empty map
-		ReferencedCEL: []string{"-ar[]", "-as", "ar"},
+		ReferencedCEL: []string{"-abc", "-ar[]", "ar"},
 	},
 	{
-		E:    `ar[as] | "foo"`,
+		E:    `ar[abc] | "foo"`,
 		Type: descriptor.STRING,
 		I: map[string]interface{}{
-			"as": "bar",
+			"abc": "bar",
 		},
 		R:          "foo",
 		Referenced: []string{"-ar"},
 		// CEL index operator is a function that always resolves the index
-		ReferencedCEL: []string{"-ar", "as"},
+		ReferencedCEL: []string{"-ar", "abc"},
 	},
 	{
-		E:    `ar[as] | "foo"`,
+		E:    `ar[abc] | "foo"`,
 		Type: descriptor.STRING,
 		I: map[string]interface{}{
-			"ar": map[string]string{"as": "bar"},
-			"as": "!!!!",
+			"ar":  map[string]string{"abc": "bar"},
+			"abc": "!!!!",
 		},
 		R:          "foo",
-		Referenced: []string{"-ar[!!!!]", "ar", "as"},
+		Referenced: []string{"-ar[!!!!]", "abc", "ar"},
 	},
 	{
-		E:    `ar[as] | "foo"`,
+		E:    `ar[abc] | "foo"`,
 		Type: descriptor.STRING,
 		I: map[string]interface{}{
-			"ar": map[string]string{"asval": "bar"},
-			"as": "asval",
+			"ar":  map[string]string{"abcval": "bar"},
+			"abc": "abcval",
 		},
 		R:          "bar",
-		Referenced: []string{"ar", "ar[asval]", "as"},
+		Referenced: []string{"abc", "ar", "ar[abcval]"},
 	},
 	{
 		E:    `ar["b"] | ar["c"] | "null"`,
@@ -2978,14 +2978,14 @@ end
 	},
 
 	{
-		E:    `ip(as)`,
+		E:    `ip(abc)`,
 		Type: descriptor.IP_ADDRESS,
 		I: map[string]interface{}{
-			"as": "1.2.3.4",
+			"abc": "1.2.3.4",
 		},
 		IL: `
 fn eval() interface
-  resolve_s "as"
+  resolve_s "abc"
   call ip
   ret
 end
@@ -3010,11 +3010,11 @@ end
 	},
 
 	{
-		E:    `ip(as | "5.6.7.8")`,
+		E:    `ip(abc | "5.6.7.8")`,
 		Type: descriptor.IP_ADDRESS,
 		IL: `
 fn eval() interface
-  tresolve_s "as"
+  tresolve_s "abc"
   jnz L0
   apush_s "5.6.7.8"
 L0:
@@ -3028,7 +3028,7 @@ end
 	},
 
 	{
-		E:    `ip(as | bs)`,
+		E:    `ip(abc | bs)`,
 		Type: descriptor.IP_ADDRESS,
 		I: map[string]interface{}{
 			"bs": "1.2.3.4",
@@ -3039,7 +3039,7 @@ end
 	},
 
 	{
-		E:    `ip(as | bs)`,
+		E:    `ip(abc | bs)`,
 		Type: descriptor.IP_ADDRESS,
 		Err:  "lookup failed: 'bs'",
 		// CEL does not support top-level ident presence
@@ -3064,15 +3064,15 @@ end
 	},
 
 	{
-		E:    `ip(as) | ip(bs)`,
+		E:    `ip(abc) | ip(bs)`,
 		Type: descriptor.IP_ADDRESS,
 		I: map[string]interface{}{
-			"as": "1.2.3.4",
-			"bs": "5.6.7.8",
+			"abc": "1.2.3.4",
+			"bs":  "5.6.7.8",
 		},
 		IL: `
 fn eval() interface
-  resolve_s "as"
+  resolve_s "abc"
   call ip
   jmp L0
   resolve_s "bs"
@@ -3085,12 +3085,12 @@ end
 	},
 
 	{
-		E:    `ip(as) | ip(bs)`,
+		E:    `ip(abc) | ip(bs)`,
 		Type: descriptor.IP_ADDRESS,
 		I: map[string]interface{}{
 			"bs": "1.2.3.4",
 		},
-		Err: `lookup failed: 'as'`,
+		Err: `lookup failed: 'abc'`,
 	},
 
 	{
@@ -3332,17 +3332,17 @@ end
 	},
 
 	{
-		E:    `reverse(as)`,
+		E:    `reverse(abc)`,
 		Type: descriptor.STRING,
 		IL: `
 fn eval() string
-  resolve_s "as"
+  resolve_s "abc"
   call reverse
   ret
 end
 `,
 		I: map[string]interface{}{
-			"as": "str1",
+			"abc": "str1",
 		},
 		R: "1rts",
 		Fns: []ast.FunctionMetadata{
@@ -4104,204 +4104,204 @@ end`,
 	},
 
 	{
-		E:    `as < "b"`,
+		E:    `abc < "b"`,
 		Type: descriptor.BOOL,
 		I: map[string]interface{}{
-			"as": "a",
+			"abc": "a",
 		},
 		R: true,
 		IL: `fn eval() bool
-  resolve_s "as"
+  resolve_s "abc"
   alt_s "b"
   ret
 end`,
 	},
 	{
-		E:    `"b" < as`,
+		E:    `"b" < abc`,
 		Type: descriptor.BOOL,
 		I: map[string]interface{}{
-			"as": "a",
+			"abc": "a",
 		},
 		R: false,
 		IL: `fn eval() bool
   apush_s "b"
-  resolve_s "as"
+  resolve_s "abc"
   lt_s
   ret
 end`,
 	},
 	{
-		E:    `as < bs`,
+		E:    `abc < bs`,
 		Type: descriptor.BOOL,
 		I: map[string]interface{}{
-			"as": "a",
-			"bs": "b",
+			"abc": "a",
+			"bs":  "b",
 		},
 		R: true,
 		IL: `fn eval() bool
-  resolve_s "as"
+  resolve_s "abc"
   resolve_s "bs"
   lt_s
   ret
 end`,
 	},
 	{
-		E:    `bs < as`,
+		E:    `bs < abc`,
 		Type: descriptor.BOOL,
 		I: map[string]interface{}{
-			"as": "a",
-			"bs": "b",
+			"abc": "a",
+			"bs":  "b",
 		},
 		R: false,
 		IL: `fn eval() bool
   resolve_s "bs"
-  resolve_s "as"
+  resolve_s "abc"
   lt_s
   ret
 end`,
 	},
 	{
-		E:    `as < as`,
+		E:    `abc < abc`,
 		Type: descriptor.BOOL,
 		I: map[string]interface{}{
-			"as": "a",
+			"abc": "a",
 		},
 		R: false,
 		IL: `fn eval() bool
-  resolve_s "as"
-  resolve_s "as"
+  resolve_s "abc"
+  resolve_s "abc"
   lt_s
   ret
 end`,
 	},
 	{
-		E:    `as <= bs`,
+		E:    `abc <= bs`,
 		Type: descriptor.BOOL,
 		I: map[string]interface{}{
-			"as": "a",
-			"bs": "b",
+			"abc": "a",
+			"bs":  "b",
 		},
 		R: true,
 		IL: `fn eval() bool
-  resolve_s "as"
+  resolve_s "abc"
   resolve_s "bs"
   le_s
   ret
 end`,
 	},
 	{
-		E:    `bs <= as`,
+		E:    `bs <= abc`,
 		Type: descriptor.BOOL,
 		I: map[string]interface{}{
-			"as": "a",
-			"bs": "b",
+			"abc": "a",
+			"bs":  "b",
 		},
 		R: false,
 		IL: `fn eval() bool
   resolve_s "bs"
-  resolve_s "as"
+  resolve_s "abc"
   le_s
   ret
 end`,
 	},
 	{
-		E:    `as <= as`,
+		E:    `abc <= abc`,
 		Type: descriptor.BOOL,
 		I: map[string]interface{}{
-			"as": "a",
+			"abc": "a",
 		},
 		R: true,
 		IL: `fn eval() bool
-  resolve_s "as"
-  resolve_s "as"
+  resolve_s "abc"
+  resolve_s "abc"
   le_s
   ret
 end`,
 	},
 	{
-		E:    `as > bs`,
+		E:    `abc > bs`,
 		Type: descriptor.BOOL,
 		I: map[string]interface{}{
-			"as": "a",
-			"bs": "b",
+			"abc": "a",
+			"bs":  "b",
 		},
 		R: false,
 		IL: `fn eval() bool
-  resolve_s "as"
+  resolve_s "abc"
   resolve_s "bs"
   gt_s
   ret
 end`,
 	},
 	{
-		E:    `bs > as`,
+		E:    `bs > abc`,
 		Type: descriptor.BOOL,
 		I: map[string]interface{}{
-			"as": "a",
-			"bs": "b",
+			"abc": "a",
+			"bs":  "b",
 		},
 		R: true,
 		IL: `fn eval() bool
   resolve_s "bs"
-  resolve_s "as"
+  resolve_s "abc"
   gt_s
   ret
 end`,
 	},
 	{
-		E:    `as > as`,
+		E:    `abc > abc`,
 		Type: descriptor.BOOL,
 		I: map[string]interface{}{
-			"as": "a",
+			"abc": "a",
 		},
 		R: false,
 		IL: `fn eval() bool
-  resolve_s "as"
-  resolve_s "as"
+  resolve_s "abc"
+  resolve_s "abc"
   gt_s
   ret
 end`,
 	},
 	{
-		E:    `as >= bs`,
+		E:    `abc >= bs`,
 		Type: descriptor.BOOL,
 		I: map[string]interface{}{
-			"as": "a",
-			"bs": "b",
+			"abc": "a",
+			"bs":  "b",
 		},
 		R: false,
 		IL: `fn eval() bool
-  resolve_s "as"
+  resolve_s "abc"
   resolve_s "bs"
   ge_s
   ret
 end`,
 	},
 	{
-		E:    `bs >= as`,
+		E:    `bs >= abc`,
 		Type: descriptor.BOOL,
 		I: map[string]interface{}{
-			"as": "a",
-			"bs": "b",
+			"abc": "a",
+			"bs":  "b",
 		},
 		R: true,
 		IL: `fn eval() bool
   resolve_s "bs"
-  resolve_s "as"
+  resolve_s "abc"
   ge_s
   ret
 end`,
 	},
 	{
-		E:    `as >= as`,
+		E:    `abc >= abc`,
 		Type: descriptor.BOOL,
 		I: map[string]interface{}{
-			"as": "a",
+			"abc": "a",
 		},
 		R: true,
 		IL: `fn eval() bool
-  resolve_s "as"
-  resolve_s "as"
+  resolve_s "abc"
+  resolve_s "abc"
   ge_s
   ret
 end`,
@@ -4337,62 +4337,62 @@ end`,
 end`,
 	},
 	{
-		E:    `as <= as`,
+		E:    `abc <= abc`,
 		Type: descriptor.BOOL,
 		I: map[string]interface{}{
-			"as": "a",
+			"abc": "a",
 		},
 		R: true,
 		IL: `fn eval() bool
-  resolve_s "as"
-  resolve_s "as"
+  resolve_s "abc"
+  resolve_s "abc"
   le_s
   ret
 end`,
 	},
 	{
-		E:    `as <= bs`,
+		E:    `abc <= bs`,
 		Type: descriptor.BOOL,
 		I: map[string]interface{}{
-			"as": "a",
-			"bs": "b",
+			"abc": "a",
+			"bs":  "b",
 		},
 		R: true,
 		IL: `fn eval() bool
-  resolve_s "as"
+  resolve_s "abc"
   resolve_s "bs"
   le_s
   ret
 end`,
 	},
 	{
-		E:    `bs <= as`,
+		E:    `bs <= abc`,
 		Type: descriptor.BOOL,
 		I: map[string]interface{}{
-			"as": "a",
-			"bs": "b",
+			"abc": "a",
+			"bs":  "b",
 		},
 		R: false,
 		IL: `fn eval() bool
   resolve_s "bs"
-  resolve_s "as"
+  resolve_s "abc"
   le_s
   ret
 end`,
 	},
 
 	{
-		E:    `as.reverse()`,
+		E:    `abc.reverse()`,
 		Type: descriptor.STRING,
 		IL: `
 fn eval() string
-  resolve_s "as"
+  resolve_s "abc"
   call reverse
   ret
 end
 `,
 		I: map[string]interface{}{
-			"as": "str1",
+			"abc": "str1",
 		},
 		R: "1rts",
 		Fns: []ast.FunctionMetadata{
@@ -4457,29 +4457,29 @@ end
 		CEL: false,
 	},
 	{
-		E:    `as.matches(bs)`,
+		E:    `abc.matches(bs)`,
 		Type: descriptor.BOOL,
 		IL: `
 fn eval() bool
-  resolve_s "as"
+  resolve_s "abc"
   resolve_s "bs"
   call matches
   ret
 end`,
 		I: map[string]interface{}{
-			"as": "st.*",
-			"bs": "str1",
+			"abc": "st.*",
+			"bs":  "str1",
 		},
 		R: true,
 		// CEL reverse the arguments of matches overload
 		CEL: false,
 	},
 	{
-		E:    `as.matches(bs)`,
+		E:    `abc.matches(bs)`,
 		Type: descriptor.BOOL,
 		I: map[string]interface{}{
-			"as": "st.*",
-			"bs": "sqr1",
+			"abc": "st.*",
+			"bs":  "sqr1",
 		},
 		R: false,
 		// CEL reverse the arguments of matches overload
@@ -4530,27 +4530,27 @@ end
 		R:    false,
 	},
 	{
-		E:    `as.startsWith(bs)`,
+		E:    `abc.startsWith(bs)`,
 		Type: descriptor.BOOL,
 		IL: `
 fn eval() bool
-  resolve_s "as"
+  resolve_s "abc"
   resolve_s "bs"
   call startsWith
   ret
 end`,
 		I: map[string]interface{}{
-			"as": "abcd",
-			"bs": "ab",
+			"abc": "abcd",
+			"bs":  "ab",
 		},
 		R: true,
 	},
 	{
-		E:    `as.startsWith(bs)`,
+		E:    `abc.startsWith(bs)`,
 		Type: descriptor.BOOL,
 		I: map[string]interface{}{
-			"as": "bcda",
-			"bs": "abc",
+			"abc": "bcda",
+			"bs":  "abc",
 		},
 		R: false,
 	},
@@ -4599,27 +4599,27 @@ end
 		R:    false,
 	},
 	{
-		E:    `as.endsWith(bs)`,
+		E:    `abc.endsWith(bs)`,
 		Type: descriptor.BOOL,
 		IL: `
 fn eval() bool
-  resolve_s "as"
+  resolve_s "abc"
   resolve_s "bs"
   call endsWith
   ret
 end`,
 		I: map[string]interface{}{
-			"as": "abcd",
-			"bs": "cd",
+			"abc": "abcd",
+			"bs":  "cd",
 		},
 		R: true,
 	},
 	{
-		E:    `as.endsWith(bs)`,
+		E:    `abc.endsWith(bs)`,
 		Type: descriptor.BOOL,
 		I: map[string]interface{}{
-			"as": "bcda",
-			"bs": "abc",
+			"abc": "bcda",
+			"bs":  "abc",
 		},
 		R: false,
 	},
@@ -4759,7 +4759,7 @@ end
 `,
 	},
 	{
-		E:    `as | conditional(ab, "foo", "bar") | bs`,
+		E:    `abc | conditional(ab, "foo", "bar") | bs`,
 		Type: descriptor.STRING,
 		R:    "bar",
 		// top-level idents do not support presence
@@ -4769,7 +4769,7 @@ end
 		},
 		IL: `
 fn eval() string
-  tresolve_s "as"
+  tresolve_s "abc"
   jnz L0
   resolve_b "ab"
   jz L1
@@ -4786,7 +4786,7 @@ end
 `,
 	},
 	{
-		E:    `as | conditional(ab, "foo", "bar") | bs`,
+		E:    `abc | conditional(ab, "foo", "bar") | bs`,
 		Type: descriptor.STRING,
 		R:    "foo",
 		// top-level idents do not support presence
@@ -4796,7 +4796,7 @@ end
 		},
 	},
 	{
-		E:    `as | bs | conditional(ab, "foo", "bar")`,
+		E:    `abc | bs | conditional(ab, "foo", "bar")`,
 		Type: descriptor.STRING,
 		R:    "bar",
 		// top-level idents do not support presence
@@ -4806,7 +4806,7 @@ end
 		},
 		IL: `
 fn eval() string
-  tresolve_s "as"
+  tresolve_s "abc"
   jnz L0
   tresolve_s "bs"
   jnz L0
@@ -4822,7 +4822,7 @@ end
 `,
 	},
 	{
-		E:    `as | bs | conditional(ab, "foo", "bar")`,
+		E:    `abc | bs | conditional(ab, "foo", "bar")`,
 		Type: descriptor.STRING,
 		R:    "foo",
 		// top-level idents do not support presence
@@ -4832,15 +4832,15 @@ end
 		},
 	},
 	{
-		E:    `as | bs | conditional(ab, "foo", "bar")`,
+		E:    `abc | bs | conditional(ab, "foo", "bar")`,
 		Type: descriptor.STRING,
 		R:    "boo",
 		I: map[string]interface{}{
-			"as": "boo",
+			"abc": "boo",
 		},
 	},
 	{
-		E:    `as | bs | conditional(ab, "foo", "bar")`,
+		E:    `abc | bs | conditional(ab, "foo", "bar")`,
 		Type: descriptor.STRING,
 		R:    "zoo",
 		// top-level idents do not support presence
@@ -4850,7 +4850,7 @@ end
 		},
 	},
 	{
-		E:    `conditional(ab, "foo", "bar") | as | bs`,
+		E:    `conditional(ab, "foo", "bar") | abc | bs`,
 		Type: descriptor.STRING,
 		R:    "bar",
 		I: map[string]interface{}{
@@ -4866,7 +4866,7 @@ L0:
   apush_s "bar"
 L1:
   jmp L2
-  tresolve_s "as"
+  tresolve_s "abc"
   jnz L2
   resolve_s "bs"
 L2:
@@ -4875,7 +4875,7 @@ end
 `,
 	},
 	{
-		E:    `conditional(ab, "foo", "bar") | as | bs`,
+		E:    `conditional(ab, "foo", "bar") | abc | bs`,
 		Type: descriptor.STRING,
 		R:    "foo",
 		I: map[string]interface{}{
@@ -4883,16 +4883,16 @@ end
 		},
 	},
 	{
-		E:    `conditional(ab, "foo", "bar") | as | bs`,
+		E:    `conditional(ab, "foo", "bar") | abc | bs`,
 		Type: descriptor.STRING,
 		R:    "foo",
 		I: map[string]interface{}{
-			"as": "boo",
-			"ab": true,
+			"abc": "boo",
+			"ab":  true,
 		},
 	},
 	{
-		E:    `conditional(ab, "foo", "bar") | as | bs`,
+		E:    `conditional(ab, "foo", "bar") | abc | bs`,
 		Type: descriptor.STRING,
 		R:    "foo",
 		I: map[string]interface{}{
@@ -4901,17 +4901,17 @@ end
 		},
 	},
 	{
-		E:    `conditional(ab, "foo", "bar") | as | bs`,
+		E:    `conditional(ab, "foo", "bar") | abc | bs`,
 		Type: descriptor.STRING,
 		R:    "foo",
 		I: map[string]interface{}{
-			"as": "boo",
-			"bs": "zoo",
-			"ab": true,
+			"abc": "boo",
+			"bs":  "zoo",
+			"ab":  true,
 		},
 	},
 	{
-		E:    `conditional(ab, "foo", "bar") | as | bs`,
+		E:    `conditional(ab, "foo", "bar") | abc | bs`,
 		Type: descriptor.STRING,
 		R:    "bar",
 		I: map[string]interface{}{
@@ -4919,16 +4919,16 @@ end
 		},
 	},
 	{
-		E:    `conditional(ab, "foo", "bar") | as | bs`,
+		E:    `conditional(ab, "foo", "bar") | abc | bs`,
 		Type: descriptor.STRING,
 		R:    "bar",
 		I: map[string]interface{}{
-			"as": "boo",
-			"ab": false,
+			"abc": "boo",
+			"ab":  false,
 		},
 	},
 	{
-		E:    `conditional(ab, "foo", "bar") | as | bs`,
+		E:    `conditional(ab, "foo", "bar") | abc | bs`,
 		Type: descriptor.STRING,
 		R:    "bar",
 		I: map[string]interface{}{
@@ -4937,26 +4937,26 @@ end
 		},
 	},
 	{
-		E:    `conditional(ab, "foo", "bar") | as | bs`,
+		E:    `conditional(ab, "foo", "bar") | abc | bs`,
 		Type: descriptor.STRING,
 		R:    "bar",
 		I: map[string]interface{}{
-			"as": "boo",
-			"bs": "zoo",
-			"ab": false,
+			"abc": "boo",
+			"bs":  "zoo",
+			"ab":  false,
 		},
 	},
 	{
-		E:    `as + bs`,
+		E:    `abc + bs`,
 		Type: descriptor.STRING,
 		R:    "ab",
 		I: map[string]interface{}{
-			"as": "a",
-			"bs": "b",
+			"abc": "a",
+			"bs":  "b",
 		},
 		IL: `
 fn eval() string
-  resolve_s "as"
+  resolve_s "abc"
   resolve_s "bs"
   add_s
   ret
@@ -4964,15 +4964,15 @@ end
 `,
 	},
 	{
-		E:    `as + "b"`,
+		E:    `abc + "b"`,
 		Type: descriptor.STRING,
 		R:    "ab",
 		I: map[string]interface{}{
-			"as": "a",
+			"abc": "a",
 		},
 		IL: `
 fn eval() string
-  resolve_s "as"
+  resolve_s "abc"
   apush_s "b"
   add_s
   ret
@@ -4980,16 +4980,16 @@ end
 `,
 	},
 	{
-		E:    `"b" + as`,
+		E:    `"b" + abc`,
 		Type: descriptor.STRING,
 		R:    "ba",
 		I: map[string]interface{}{
-			"as": "a",
+			"abc": "a",
 		},
 		IL: `
 fn eval() string
   apush_s "b"
-  resolve_s "as"
+  resolve_s "abc"
   add_s
   ret
 end
@@ -5009,15 +5009,15 @@ end
 `,
 	},
 	{
-		E:    `as | "unknown" + "b"`,
+		E:    `abc | "unknown" + "b"`,
 		Type: descriptor.STRING,
 		R:    "ab",
 		I: map[string]interface{}{
-			"as": "a",
+			"abc": "a",
 		},
 		IL: `
 fn eval() string
-  tresolve_s "as"
+  tresolve_s "abc"
   jnz L0
   apush_s "unknown"
 L0:
@@ -5028,14 +5028,14 @@ end
 `,
 	},
 	{
-		E:    `as | "a" + "b"`,
+		E:    `abc | "a" + "b"`,
 		Type: descriptor.STRING,
 		R:    "ab",
 		// top-level idents do not support presence
 		CEL: "b",
 	},
 	{
-		E:    `as | "a" + bs + "c"`,
+		E:    `abc | "a" + bs + "c"`,
 		Type: descriptor.STRING,
 		R:    "abc",
 		// top-level idents do not support presence
@@ -5045,7 +5045,7 @@ end
 		},
 		IL: `
 fn eval() string
-  tresolve_s "as"
+  tresolve_s "abc"
   jnz L0
   apush_s "a"
 L0:
@@ -5058,17 +5058,17 @@ end
 `,
 	},
 	{
-		E:    `as + (bs | "b") + "c"`,
+		E:    `abc + (bs | "b") + "c"`,
 		Type: descriptor.STRING,
 		R:    "abc",
 		// top-level idents do not support presence
 		CEL: "ac",
 		I: map[string]interface{}{
-			"as": "a",
+			"abc": "a",
 		},
 		IL: `
 fn eval() string
-  resolve_s "as"
+  resolve_s "abc"
   tresolve_s "bs"
   jnz L0
   apush_s "b"
@@ -5151,25 +5151,25 @@ end
 		CompileErr: `ADD(1, "b") arg 2 ("b") typeError got STRING, expected INT64`,
 	},
 	{
-		E: `1 + as`,
+		E: `1 + abc`,
 		I: map[string]interface{}{
-			"as": "a",
+			"abc": "a",
 		},
-		CompileErr: `ADD(1, $as) arg 2 ($as) typeError got STRING, expected INT64`,
+		CompileErr: `ADD(1, $abc) arg 2 ($abc) typeError got STRING, expected INT64`,
 	},
 	{
-		E: `as + 1.0`,
+		E: `abc + 1.0`,
 		I: map[string]interface{}{
-			"as": "a",
+			"abc": "a",
 		},
-		CompileErr: `ADD($as, 1.0) arg 2 (1.0) typeError got DOUBLE, expected STRING`,
+		CompileErr: `ADD($abc, 1.0) arg 2 (1.0) typeError got DOUBLE, expected STRING`,
 	},
 	{
-		E: `as + 1.0`,
+		E: `abc + 1.0`,
 		I: map[string]interface{}{
-			"as": "a",
+			"abc": "a",
 		},
-		CompileErr: `ADD($as, 1.0) arg 2 (1.0) typeError got DOUBLE, expected STRING`,
+		CompileErr: `ADD($abc, 1.0) arg 2 (1.0) typeError got DOUBLE, expected STRING`,
 	},
 	{
 		E: `ab + bb`,
@@ -5180,11 +5180,11 @@ end
 		CompileErr: `internal compiler error -- Add for type not yet implemented: bool`,
 	},
 	{
-		E: `+as`,
+		E: `+abc`,
 		I: map[string]interface{}{
-			"as": "a",
+			"abc": "a",
 		},
-		CompileErr: `ADD($as) arity mismatch. Got 1 arg(s), expected 2 arg(s)`,
+		CompileErr: `ADD($abc) arity mismatch. Got 1 arg(s), expected 2 arg(s)`,
 	},
 	{
 		E:    `size("x")`,
@@ -5198,15 +5198,15 @@ end
 `,
 	},
 	{
-		E:    `size(as)`,
+		E:    `size(abc)`,
 		Type: descriptor.INT64,
 		I: map[string]interface{}{
-			"as": "two",
+			"abc": "two",
 		},
 		R: int64(3),
 		IL: `
 fn eval() integer
-  resolve_s "as"
+  resolve_s "abc"
   size_s
   ret
 end
@@ -5276,7 +5276,7 @@ type TestInfo struct {
 	Type descriptor.ValueType
 
 	// SkipAst indicates that AST based evaluator should not be used for this test.
-	SkipAst bool
+	Skipast bool
 
 	// Use this test as a benchmark as well.
 	Bench bool
@@ -5405,7 +5405,7 @@ var defaultAttrs = map[string]*pb.AttributeManifest_AttributeInfo{
 	"ab": {
 		ValueType: descriptor.BOOL,
 	},
-	"as": {
+	"abc": {
 		ValueType: descriptor.STRING,
 	},
 	"ad": {

--- a/mixer/pkg/lang/cel/builder.go
+++ b/mixer/pkg/lang/cel/builder.go
@@ -40,7 +40,7 @@ const (
 type ExpressionBuilder struct {
 	mode     LanguageMode
 	provider *attributeProvider
-	env      celgo.Env
+	env      *celgo.Env
 }
 
 type expression struct {
@@ -104,7 +104,7 @@ func NewBuilder(finder attribute.AttributeDescriptorFinder, mode LanguageMode) *
 }
 
 // Compile the given text and return a pre-compiled expression object.
-func (exb *ExpressionBuilder) check(text string) (checked celgo.Ast, typ descriptor.ValueType, err error) {
+func (exb *ExpressionBuilder) check(text string) (checked *celgo.Ast, typ descriptor.ValueType, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("panic during CEL parsing of expression %q", text)

--- a/mixer/pkg/lang/cel/builder_test.go
+++ b/mixer/pkg/lang/cel/builder_test.go
@@ -267,15 +267,15 @@ var (
 			referenced: []string{"context.reporter.kind"},
 		},
 		{
-			text:       `as`,
+			text:       `abc`,
 			result:     "",
-			referenced: []string{"-as"},
+			referenced: []string{"-abc"},
 		},
 		{
-			text:       `as`,
-			bag:        map[string]interface{}{"as": "test"},
+			text:       `abc`,
+			bag:        map[string]interface{}{"abc": "test"},
 			result:     "test",
-			referenced: []string{"as"},
+			referenced: []string{"abc"},
 		},
 		{
 			text:       `context.reporter.kind`,
@@ -474,7 +474,7 @@ var (
 			result: "ab",
 		},
 		{
-			text:       `conditional(context.reporter.kind == "client", pick(as, "test"), "inbound")`,
+			text:       `conditional(context.reporter.kind == "client", pick(abc, "test"), "inbound")`,
 			result:     "inbound",
 			referenced: []string{"-context.reporter.kind"},
 		},
@@ -596,7 +596,7 @@ var (
 		},
 		{
 			text:   `{}.a`,
-			result: errors.New("no such key: 'a'"),
+			result: errors.New("no such key: a"),
 		},
 		{
 			text:   `{'a':'b'}["a"]`,
@@ -615,7 +615,7 @@ var (
 			result: int64(1),
 		},
 		{
-			text:       `request.size + google.protobuf.Int64Value{value: 1}.value`,
+			text:       `request.size + google.protobuf.Int64Value{value: 1}`,
 			bag:        map[string]interface{}{"request.size": int64(123)},
 			result:     int64(124),
 			referenced: []string{"request.size"},
@@ -626,9 +626,197 @@ var (
 			// note that type lookup is a runtime operation, so the attribute lookup is necessary
 			referenced: []string{"-context.reporter.kind"},
 		},
+		//Taken from cel-go strings readme: https://github.com/google/cel-go/tree/master/ext
+		//Replace
+		{
+			text:       `source.name.replace('he', 'we')`,
+			bag:        map[string]interface{}{"source.name": "hello hello"},
+			result:     "wello wello",
+			referenced: []string{"source.name"},
+		},
+		{
+			text:       `source.name.replace('he', 'we', -1)`,
+			bag:        map[string]interface{}{"source.name": "hello hello"},
+			result:     "wello wello",
+			referenced: []string{"source.name"},
+		},
+		{
+			text:       `source.name.replace('he', 'we', 1)`,
+			bag:        map[string]interface{}{"source.name": "hello hello"},
+			result:     "wello hello",
+			referenced: []string{"source.name"},
+		},
+		{
+			text:       `source.name.replace('he', 'we', 0)`,
+			bag:        map[string]interface{}{"source.name": "hello hello"},
+			result:     "hello hello",
+			referenced: []string{"source.name"},
+		},
+		//CharAt
+		{
+			text:       `source.name.charAt(4)`,
+			bag:        map[string]interface{}{"source.name": "hello"},
+			result:     "o",
+			referenced: []string{"source.name"},
+		},
+		{
+			text:       `source.name.charAt(5)`,
+			bag:        map[string]interface{}{"source.name": "hello"},
+			result:     "",
+			referenced: []string{"source.name"},
+		},
+		{
+			text:       `source.name.charAt(-1)`,
+			bag:        map[string]interface{}{"source.name": "hello"},
+			result:     errors.New("index out of range: -1"),
+			referenced: []string{"source.name"},
+		},
+		//index of
+		{
+			text:       `source.name.indexOf('')`,
+			bag:        map[string]interface{}{"source.name": "hello mellow"},
+			result:     int64(0),
+			referenced: []string{"source.name"},
+		},
+		{
+			text:       `source.name.indexOf('ello')`,
+			bag:        map[string]interface{}{"source.name": "hello mellow"},
+			result:     int64(1),
+			referenced: []string{"source.name"},
+		},
+		{
+			text:       `source.name.indexOf('jello')`,
+			bag:        map[string]interface{}{"source.name": "hello mellow"},
+			result:     int64(-1),
+			referenced: []string{"source.name"},
+		},
+		{
+			text:       `source.name.indexOf('', 2)`,
+			bag:        map[string]interface{}{"source.name": "hello mellow"},
+			result:     int64(2),
+			referenced: []string{"source.name"},
+		},
+		{
+			text:       `source.name.indexOf('ello', 2)`,
+			bag:        map[string]interface{}{"source.name": "hello mellow"},
+			result:     int64(7),
+			referenced: []string{"source.name"},
+		},
+		{
+			text:       `source.name.indexOf('ello', 20)`,
+			bag:        map[string]interface{}{"source.name": "hello mellow"},
+			result:     errors.New("index out of range: 20"),
+			referenced: []string{"source.name"},
+		},
+		//LastIndexOf
+		{
+			text:       `source.name.lastIndexOf('')`,
+			bag:        map[string]interface{}{"source.name": "hello mellow"},
+			result:     int64(12),
+			referenced: []string{"source.name"},
+		},
+		{
+			text:       `source.name.lastIndexOf('ello')`,
+			bag:        map[string]interface{}{"source.name": "hello mellow"},
+			result:     int64(7),
+			referenced: []string{"source.name"},
+		},
+		{
+			text:       `source.name.lastIndexOf('jello')`,
+			bag:        map[string]interface{}{"source.name": "hello mellow"},
+			result:     int64(-1),
+			referenced: []string{"source.name"},
+		},
+		{
+			text:       `source.name.lastIndexOf('ello', 6)`,
+			bag:        map[string]interface{}{"source.name": "hello mellow"},
+			result:     int64(1),
+			referenced: []string{"source.name"},
+		},
+		{
+			text:       `source.name.lastIndexOf('ello', -1)`,
+			bag:        map[string]interface{}{"source.name": "hello mellow"},
+			result:     errors.New("index out of range: -1"),
+			referenced: []string{"source.name"},
+		},
+		//Split
+		{
+			text:       `source.name.split(' ')`,
+			bag:        map[string]interface{}{"source.name": "hello hello hello"},
+			result:     []string{"hello", "hello", "hello"},
+			referenced: []string{"source.name"},
+		},
+		{
+			text:       `source.name.split(' ', 0)`,
+			bag:        map[string]interface{}{"source.name": "hello hello hello"},
+			result:     []string{},
+			referenced: []string{"source.name"},
+		},
+		{
+			text:       `source.name.split(' ', 1)`,
+			bag:        map[string]interface{}{"source.name": "hello hello hello"},
+			result:     []string{"hello hello hello"},
+			referenced: []string{"source.name"},
+		},
+		{
+			text:       `source.name.split(' ', 2)`,
+			bag:        map[string]interface{}{"source.name": "hello hello hello"},
+			result:     []string{"hello", "hello hello"},
+			referenced: []string{"source.name"},
+		},
+		{
+			text:       `source.name.split(' ', -1)`,
+			bag:        map[string]interface{}{"source.name": "hello hello hello"},
+			result:     []string{"hello", "hello", "hello"},
+			referenced: []string{"source.name"},
+		},
+		//substring
+		{
+			text:       `source.name.substring(4)`,
+			bag:        map[string]interface{}{"source.name": "tacocat"},
+			result:     "cat",
+			referenced: []string{"source.name"},
+		},
+		{
+			text:       `source.name.substring(0, 4)`,
+			bag:        map[string]interface{}{"source.name": "tacocat"},
+			result:     "taco",
+			referenced: []string{"source.name"},
+		},
+		{
+			text:       `source.name.substring(-1)`,
+			bag:        map[string]interface{}{"source.name": "tacocat"},
+			result:     errors.New("index out of range: -1"),
+			referenced: []string{"source.name"},
+		},
+		{
+			text:       `source.name.substring(2, 1)`,
+			bag:        map[string]interface{}{"source.name": "tacocat"},
+			result:     errors.New("invalid substring range. start: 2, end: 1"),
+			referenced: []string{"source.name"},
+		},
+		//trim
+		{
+			text:       `source.name.trim()`,
+			bag:        map[string]interface{}{"source.name": "  foo  "},
+			result:     "foo",
+			referenced: []string{"source.name"},
+		},
+		{
+			text:       `source.name.trim()`,
+			bag:        map[string]interface{}{"source.name": "foo \n"},
+			result:     "foo",
+			referenced: []string{"source.name"},
+		},
+		{
+			text:       `source.name.trim()`,
+			bag:        map[string]interface{}{"source.name": "foo"},
+			result:     "foo",
+			referenced: []string{"source.name"},
+		},
 	}
 	attrs = map[string]*v1beta1.AttributeManifest_AttributeInfo{
-		"as":                        {ValueType: v1beta1.STRING},
+		"abc":                       {ValueType: v1beta1.STRING},
 		"connection.duration":       {ValueType: v1beta1.DURATION},
 		"connection.id":             {ValueType: v1beta1.STRING},
 		"connection.received.bytes": {ValueType: v1beta1.INT64},
@@ -662,7 +850,7 @@ var (
 	}
 )
 
-func testExpression(env celgo.Env, provider *attributeProvider, test testCase, mutex sync.Locker) func(t *testing.T) {
+func testExpression(env *celgo.Env, provider *attributeProvider, test testCase, mutex sync.Locker) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
 

--- a/mixer/pkg/lang/cel/provider.go
+++ b/mixer/pkg/lang/cel/provider.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/common/types/traits"
+	"github.com/google/cel-go/ext"
 	"github.com/google/cel-go/interpreter"
 	"github.com/google/cel-go/parser"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
@@ -115,7 +116,7 @@ func newAttributeProvider(attributes map[string]*v1beta1.AttributeManifest_Attri
 	return out
 }
 
-func (ap *attributeProvider) newEnvironment() celgo.Env {
+func (ap *attributeProvider) newEnvironment() *celgo.Env {
 	var declarations []*exprpb.Decl
 
 	// populate with root-level identifiers
@@ -133,6 +134,7 @@ func (ap *attributeProvider) newEnvironment() celgo.Env {
 		celgo.CustomTypeProvider(ap),
 		celgo.Declarations(declarations...),
 		celgo.Declarations(standardFunctions...),
+		ext.Strings(),
 		macros)
 
 	return env
@@ -249,7 +251,7 @@ func (v value) IsSet(index ref.Val) ref.Val {
 	return types.True
 }
 
-func (a attributeActivation) ResolveName(name string) (ref.Val, bool) {
+func (a attributeActivation) ResolveName(name string) (interface{}, bool) {
 	if node, ok := a.provider.root.children[name]; ok {
 		return resolve(node, a.bag), true
 	}

--- a/mixer/pkg/lang/cel/types.go
+++ b/mixer/pkg/lang/cel/types.go
@@ -158,6 +158,12 @@ func recoverValue(value ref.Val) (interface{}, error) {
 		return value.Value(), nil
 	case wrapperType:
 		return value.Value(), nil
+	case types.ListType:
+		size := value.(traits.Sizer).Size()
+		if size.Type() == types.IntType && size.Value().(int64) == 0 {
+			return []string{}, nil
+		}
+		return value.Value(), nil
 	}
 	return nil, fmt.Errorf("failed to recover of type %s", value.Type())
 }


### PR DESCRIPTION

We (Intuit) would like to use these string functions for our logging via Mixer (until we move away from mixer-telemetry), and would like to be able to leverage them in 1.5. (Ref: https://istio.slack.com/archives/C382V8Q92/p1585682045040300)