### PR TITLE
[Test Framework] Allow both ControlPlaneValues and Values

### DIFF
--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -108,7 +108,6 @@ type Config struct {
 
 	// Override values specifically for the ICP crd
 	// This is mostly required for cases where --set cannot be used
-	// If specified, Values will be ignored
 	ControlPlaneValues string
 
 	// Overrides for the Helm values file.

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -217,12 +217,9 @@ func deployControlPlane(c *operatorComponent, cfg Config, cluster kube.Cluster, 
 		"-f", iopFile,
 		"--set", "values.global.imagePullPolicy=" + s.PullPolicy,
 	}
-	// If control plane values set, assume this includes the full set of values, and .Values is
-	// just for helm use case. Otherwise, include all values.
-	if cfg.ControlPlaneValues == "" {
-		for k, v := range cfg.Values {
-			installSettings = append(installSettings, "--set", fmt.Sprintf("values.%s=%s", k, v))
-		}
+	// Include all user-specified values.
+	for k, v := range cfg.Values {
+		installSettings = append(installSettings, "--set", fmt.Sprintf("values.%s=%s", k, v))
 	}
 	if c.environment.IsMulticluster() {
 		// Set the clusterName for the local cluster.


### PR DESCRIPTION
Currently, Values are ignored if ControlPlaneValues are specified. This is not a restriction of istioctl, itself, but of the Istio test component.

Eventually, we should remove Values and only use ControlPlaneValues, but we can address that in a future PR.