### PR TITLE
Support TLS on all protocols in echo

### DIFF
--- a/pkg/test/echo/cmd/server/main.go
+++ b/pkg/test/echo/cmd/server/main.go
@@ -22,9 +22,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/cmd"
 	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/test/echo/common"
 	"istio.io/istio/pkg/test/echo/server"
 	"istio.io/pkg/log"
 )
@@ -33,6 +33,7 @@ var (
 	httpPorts   []int
 	grpcPorts   []int
 	tcpPorts    []int
+	tlsPorts    []int
 	metricsPort int
 	uds         string
 	version     string
@@ -48,29 +49,36 @@ var (
 		Long:              `Echo application for testing Istio E2E`,
 		PersistentPreRunE: configureLogging,
 		Run: func(cmd *cobra.Command, args []string) {
-			ports := make(model.PortList, len(httpPorts)+len(grpcPorts)+len(tcpPorts))
+			ports := make(common.PortList, len(httpPorts)+len(grpcPorts)+len(tcpPorts))
+			tlsByPort := map[int]bool{}
+			for _, p := range tlsPorts {
+				tlsByPort[p] = true
+			}
 			portIndex := 0
 			for i, p := range httpPorts {
-				ports[portIndex] = &model.Port{
+				ports[portIndex] = &common.Port{
 					Name:     "http-" + strconv.Itoa(i),
 					Protocol: protocol.HTTP,
 					Port:     p,
+					TLS:      tlsByPort[p],
 				}
 				portIndex++
 			}
 			for i, p := range grpcPorts {
-				ports[portIndex] = &model.Port{
+				ports[portIndex] = &common.Port{
 					Name:     "grpc-" + strconv.Itoa(i),
 					Protocol: protocol.GRPC,
 					Port:     p,
+					TLS:      tlsByPort[p],
 				}
 				portIndex++
 			}
 			for i, p := range tcpPorts {
-				ports[portIndex] = &model.Port{
+				ports[portIndex] = &common.Port{
 					Name:     "tcp-" + strconv.Itoa(i),
 					Protocol: protocol.TCP,
 					Port:     p,
+					TLS:      tlsByPort[p],
 				}
 				portIndex++
 			}
@@ -111,6 +119,7 @@ func init() {
 	rootCmd.PersistentFlags().IntSliceVar(&httpPorts, "port", []int{8080}, "HTTP/1.1 ports")
 	rootCmd.PersistentFlags().IntSliceVar(&grpcPorts, "grpc", []int{7070}, "GRPC ports")
 	rootCmd.PersistentFlags().IntSliceVar(&tcpPorts, "tcp", []int{9090}, "TCP ports")
+	rootCmd.PersistentFlags().IntSliceVar(&tlsPorts, "tls", []int{}, "Ports that are using TLS. These must be defined as http/grpc/tcp.")
 	rootCmd.PersistentFlags().IntVar(&metricsPort, "metrics", 0, "Metrics port")
 	rootCmd.PersistentFlags().StringVar(&uds, "uds", "", "HTTP server on unix domain socket")
 	rootCmd.PersistentFlags().StringVar(&version, "version", "", "Version string")

--- a/pkg/test/echo/common/metrics.go
+++ b/pkg/test/echo/common/metrics.go
@@ -25,8 +25,8 @@ type EchoMetrics struct {
 }
 
 var (
-	Port    = monitoring.MustCreateLabel("port")
-	Metrics = &EchoMetrics{
+	PortLabel = monitoring.MustCreateLabel("port")
+	Metrics   = &EchoMetrics{
 		HTTPRequests: monitoring.NewSum(
 			"istio_echo_http_requests_total",
 			"The number of http requests total",

--- a/pkg/test/echo/common/model.go
+++ b/pkg/test/echo/common/model.go
@@ -14,6 +14,8 @@
 
 package common
 
+import "istio.io/istio/pkg/config/protocol"
+
 // TLSSettings defines TLS configuration for Echo server
 type TLSSettings struct {
 	RootCert   string
@@ -24,3 +26,26 @@ type TLSSettings struct {
 	// any DNS certs will not validate.
 	Hostname string
 }
+
+// Port represents a network port where a service is listening for
+// connections. The port should be annotated with the type of protocol
+// used by the port.
+type Port struct {
+	// Name ascribes a human readable name for the port object. When a
+	// service has multiple ports, the name field is mandatory
+	Name string
+
+	// Port number where the service can be reached. Does not necessarily
+	// map to the corresponding port numbers for the instances behind the
+	// service.
+	Port int
+
+	// Protocol to be used for the port.
+	Protocol protocol.Instance
+
+	// TLS determines if the port will use TLS.
+	TLS bool
+}
+
+// PortList is a set of ports
+type PortList []*Port

--- a/pkg/test/echo/server/endpoint/http.go
+++ b/pkg/test/echo/server/endpoint/http.go
@@ -76,11 +76,11 @@ func (s *httpInstance) Start(onReady OnReadyFunc) error {
 		port = 0
 		listener, err = listenOnUDS(s.UDSServer)
 	} else if s.Port.TLS {
-		cer, err := tls.LoadX509KeyPair(s.TLSCert, s.TLSKey)
-		if err != nil {
+		cert, cerr := tls.LoadX509KeyPair(s.TLSCert, s.TLSKey)
+		if cerr != nil {
 			return fmt.Errorf("could not load TLS keys: %v", err)
 		}
-		config := &tls.Config{Certificates: []tls.Certificate{cer}}
+		config := &tls.Config{Certificates: []tls.Certificate{cert}}
 		// Listen on the given port and update the port if it changed from what was passed in.
 		listener, port, err = listenOnPortTLS(s.Port.Port, config)
 		// Store the actual listening port back to the argument.

--- a/pkg/test/echo/server/endpoint/http.go
+++ b/pkg/test/echo/server/endpoint/http.go
@@ -17,6 +17,7 @@ package endpoint
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"fmt"
 	"math/rand"
 	"net"
@@ -74,6 +75,16 @@ func (s *httpInstance) Start(onReady OnReadyFunc) error {
 	if s.isUDS() {
 		port = 0
 		listener, err = listenOnUDS(s.UDSServer)
+	} else if s.Port.TLS {
+		cer, err := tls.LoadX509KeyPair(s.TLSCert, s.TLSKey)
+		if err != nil {
+			return fmt.Errorf("could not load TLS keys: %v", err)
+		}
+		config := &tls.Config{Certificates: []tls.Certificate{cer}}
+		// Listen on the given port and update the port if it changed from what was passed in.
+		listener, port, err = listenOnPortTLS(s.Port.Port, config)
+		// Store the actual listening port back to the argument.
+		s.Port.Port = port
 	} else {
 		// Listen on the given port and update the port if it changed from what was passed in.
 		listener, port, err = listenOnPort(s.Port.Port)
@@ -87,6 +98,9 @@ func (s *httpInstance) Start(onReady OnReadyFunc) error {
 
 	if s.isUDS() {
 		fmt.Printf("Listening HTTP/1.1 on %v\n", s.UDSServer)
+	} else if s.Port.TLS {
+		s.server.Addr = fmt.Sprintf(":%d", port)
+		fmt.Printf("Listening HTTPS/1.1 on %v\n", port)
 	} else {
 		s.server.Addr = fmt.Sprintf(":%d", port)
 		fmt.Printf("Listening HTTP/1.1 on %v\n", port)
@@ -119,12 +133,15 @@ func (s *httpInstance) awaitReady(onReady OnReadyFunc, port int) {
 				return net.Dial("unix", s.UDSServer)
 			},
 		}
+	} else if s.Port.TLS {
+		url = fmt.Sprintf("https://127.0.0.1:%d", port)
+		client.Transport = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
 	} else {
 		url = fmt.Sprintf("http://127.0.0.1:%d", port)
 	}
 
 	err := retry.UntilSuccess(func() error {
-		resp, err := http.Get(url)
+		resp, err := client.Get(url)
 		if err != nil {
 			return err
 		}
@@ -169,7 +186,7 @@ type codeAndSlices struct {
 func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	log.Infof("HTTP Request:\n  Method: %s\n  URL: %v,\n  Host: %s\n  Headers: %v",
 		r.Method, r.URL, r.Host, r.Header)
-	defer common.Metrics.HTTPRequests.With(common.Port.Value(strconv.Itoa(h.Port.Port))).Increment()
+	defer common.Metrics.HTTPRequests.With(common.PortLabel.Value(strconv.Itoa(h.Port.Port))).Increment()
 	if !h.IsServerReady() {
 		// Handle readiness probe failure.
 		log.Infof("HTTP service not ready, returning 503")

--- a/pkg/test/echo/server/endpoint/instance.go
+++ b/pkg/test/echo/server/endpoint/instance.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"io"
 
-	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/echo/common"
 )
@@ -37,7 +36,7 @@ type Config struct {
 	TLSKey        string
 	UDSServer     string
 	Dialer        common.Dialer
-	Port          *model.Port
+	Port          *common.Port
 }
 
 // Instance of an endpoint that serves the Echo application on a single port/protocol.

--- a/pkg/test/echo/server/endpoint/tcp.go
+++ b/pkg/test/echo/server/endpoint/tcp.go
@@ -16,6 +16,7 @@ package endpoint
 
 import (
 	"bufio"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net"
@@ -43,17 +44,36 @@ func newTCP(config Config) Instance {
 }
 
 func (s *tcpInstance) Start(onReady OnReadyFunc) error {
-	// Listen on the given port and update the port if it changed from what was passed in.
-	listener, p, err := listenOnPort(s.Port.Port)
+
+	var listener net.Listener
+	var port int
+	var err error
+	if s.Port.TLS {
+		cer, err := tls.LoadX509KeyPair(s.TLSCert, s.TLSKey)
+		if err != nil {
+			return fmt.Errorf("could not load TLS keys: %v", err)
+		}
+		config := &tls.Config{Certificates: []tls.Certificate{cer}}
+		// Listen on the given port and update the port if it changed from what was passed in.
+		listener, port, err = listenOnPortTLS(s.Port.Port, config)
+		// Store the actual listening port back to the argument.
+		s.Port.Port = port
+	} else {
+		// Listen on the given port and update the port if it changed from what was passed in.
+		listener, port, err = listenOnPort(s.Port.Port)
+		// Store the actual listening port back to the argument.
+		s.Port.Port = port
+	}
 	if err != nil {
 		return err
 	}
 
-	// Store the actual listening port back to the argument.
-	s.Port.Port = p
 	s.l = listener
-
-	fmt.Printf("Listening TCP on %v\n", p)
+	if s.Port.TLS {
+		fmt.Printf("Listening TCP (over TLS) on %v\n", port)
+	} else {
+		fmt.Printf("Listening TCP on %v\n", port)
+	}
 
 	// Start serving TCP traffic.
 	go func() {
@@ -69,14 +89,14 @@ func (s *tcpInstance) Start(onReady OnReadyFunc) error {
 	}()
 
 	// Notify the WaitGroup once the port has transitioned to ready.
-	go s.awaitReady(onReady, p)
+	go s.awaitReady(onReady, port)
 
 	return nil
 }
 
 // Handles incoming connection.
 func (s *tcpInstance) echo(conn net.Conn) {
-	defer common.Metrics.TCPRequests.With(common.Port.Value(strconv.Itoa(s.Port.Port))).Increment()
+	defer common.Metrics.TCPRequests.With(common.PortLabel.Value(strconv.Itoa(s.Port.Port))).Increment()
 	defer func() {
 		_ = conn.Close()
 	}()

--- a/pkg/test/echo/server/endpoint/tcp.go
+++ b/pkg/test/echo/server/endpoint/tcp.go
@@ -49,11 +49,11 @@ func (s *tcpInstance) Start(onReady OnReadyFunc) error {
 	var port int
 	var err error
 	if s.Port.TLS {
-		cer, err := tls.LoadX509KeyPair(s.TLSCert, s.TLSKey)
-		if err != nil {
+		cert, cerr := tls.LoadX509KeyPair(s.TLSCert, s.TLSKey)
+		if cerr != nil {
 			return fmt.Errorf("could not load TLS keys: %v", err)
 		}
-		config := &tls.Config{Certificates: []tls.Certificate{cer}}
+		config := &tls.Config{Certificates: []tls.Certificate{cert}}
 		// Listen on the given port and update the port if it changed from what was passed in.
 		listener, port, err = listenOnPortTLS(s.Port.Port, config)
 		// Store the actual listening port back to the argument.

--- a/pkg/test/echo/server/endpoint/util.go
+++ b/pkg/test/echo/server/endpoint/util.go
@@ -16,6 +16,7 @@ package endpoint
 
 import (
 	"bytes"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"os"
@@ -25,6 +26,16 @@ import (
 
 func listenOnPort(port int) (net.Listener, int, error) {
 	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		return nil, 0, err
+	}
+
+	port = ln.Addr().(*net.TCPAddr).Port
+	return ln, port, nil
+}
+
+func listenOnPortTLS(port int, cfg *tls.Config) (net.Listener, int, error) {
+	ln, err := tls.Listen("tcp", fmt.Sprintf(":%d", port), cfg)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/pkg/test/echo/server/instance.go
+++ b/pkg/test/echo/server/instance.go
@@ -27,7 +27,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/echo/common"
 	"istio.io/istio/pkg/test/echo/server/endpoint"
@@ -36,7 +35,7 @@ import (
 
 // Config for an echo server Instance.
 type Config struct {
-	Ports     model.PortList
+	Ports     common.PortList
 	Metrics   int
 	TLSCert   string
 	TLSKey    string
@@ -110,7 +109,7 @@ func (s *Instance) Close() (err error) {
 	return
 }
 
-func (s *Instance) newEndpoint(port *model.Port, udsServer string) (endpoint.Instance, error) {
+func (s *Instance) newEndpoint(port *common.Port, udsServer string) (endpoint.Instance, error) {
 	return endpoint.New(endpoint.Config{
 		Port:          port,
 		UDSServer:     udsServer,

--- a/pkg/test/framework/components/echo/echo.go
+++ b/pkg/test/framework/components/echo/echo.go
@@ -86,6 +86,9 @@ type WorkloadPort struct {
 
 	// Protocol to be used for this port.
 	Protocol protocol.Instance
+
+	// TLS determines whether the connection will be plain text or TLS. By default this is false (plain text).
+	TLS bool
 }
 
 // Port exposed by an Echo Instance
@@ -104,6 +107,9 @@ type Port struct {
 	// InstancePort number where this instance is listening for connections.
 	// This need not be the same as the ServicePort where the service is accessed.
 	InstancePort int
+
+	// TLS determines whether the connection will be plain text or TLS. By default this is false (plain text).
+	TLS bool
 }
 
 // Workload provides an interface for a single deployed echo server.

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -114,6 +114,9 @@ spec:
           - --port
 {{- end }}
           - "{{ $p.Port }}"
+{{- if $p.TLS }}
+          - --tls={{ $p.Port }}
+{{- end }}
 {{- end }}
 {{- range $i, $p := $.WorkloadOnlyPorts }}
 {{- if eq .Protocol "TCP" }}
@@ -122,6 +125,9 @@ spec:
           - --port
 {{- end }}
           - "{{ $p.Port }}"
+{{- if $p.TLS }}
+          - --tls={{ $p.Port }}
+{{- end }}
 {{- end }}
           - --version
           - "{{ $subset.Version }}"


### PR DESCRIPTION
Currently only gRPC respects the TLS settings, meaning we cannot test
HTTP, or TCP over TLS. This extends echo to take support these
protocols. Additionally, I extended one of the tests that uses this to
test TCP and HTTP, which validates this works correctly.

I think it makes sense for a single echo to be able to serve TLS and non
TLS traffic as well, so I moved the TLS configuration to the port level.
TLS ports are specified with --tls, and in the echo config `TLS: true`.

There are some other tests that can be extended to include these
changes, but for now I will keep this PR smaller.