### PR TITLE
support for setting k8s overlay from values

### DIFF
--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -181,7 +181,7 @@ func TestManifestGeneratePilot(t *testing.T) {
 		},
 		{
 			desc:       "pilot_override_values",
-			diffSelect: "Deployment:*:istiod",
+			diffSelect: "Deployment:*:istiod,HorizontalPodAutoscaler:*:istiod",
 		},
 		{
 			desc:       "pilot_override_kubernetes",

--- a/operator/cmd/mesh/profile-common.go
+++ b/operator/cmd/mesh/profile-common.go
@@ -16,9 +16,10 @@ package mesh
 
 import (
 	"fmt"
-	"github.com/ghodss/yaml"
 	"path/filepath"
 	"strings"
+
+	"github.com/ghodss/yaml"
 
 	"k8s.io/client-go/rest"
 
@@ -221,12 +222,13 @@ func translateK8SfromValueToIOP(userOverlayYaml string, l *Logger) (string, erro
 	}
 	valuesOverlay, err := tpath.GetConfigSubtree(userOverlayYaml, "spec.values")
 	if err != nil {
-		return "", fmt.Errorf("error getting values overlay yaml from userOverlayYaml %v", err)
+		scope.Debugf("no spec.values section from userOverlayYaml %v", err)
+		return "", nil
 	}
 	var valuesOverlayTree = make(map[string]interface{})
 	err = yaml.Unmarshal([]byte(valuesOverlay), &valuesOverlayTree)
 	if err != nil {
-		return "", fmt.Errorf("error when unmarshalling values overlay yaml into untype tree %v", err)
+		return "", fmt.Errorf("error unmarshalling values overlay yaml into untype tree %v", err)
 	}
 	iopSpecTree := make(map[string]interface{})
 	if err = t.TranslateK8S(valuesOverlayTree, iopSpecTree); err != nil {
@@ -241,16 +243,16 @@ func translateK8SfromValueToIOP(userOverlayYaml string, l *Logger) (string, erro
 	}
 	iopSpecTreeYAML, err := yaml.Marshal(iopSpecTree)
 	if err != nil {
-		return "", fmt.Errorf("error when marshalling reverse translated tree %v", err)
+		return "", fmt.Errorf("error marshaling reverse translated tree %v", err)
 	}
 	iopTreeYAML, err := tpath.AddSpecRoot(string(iopSpecTreeYAML))
 	if err != nil {
-		return "", fmt.Errorf("error when adding spec root: %v", err)
+		return "", fmt.Errorf("error adding spec root: %v", err)
 	}
 	// overlay the reverse translated iopTreeYAML back to userOverlayYaml
 	finalYAML, err := util.OverlayYAML(userOverlayYaml, iopTreeYAML)
 	if err != nil {
-		return "", fmt.Errorf("error overlay the reverse translated iopTreeYAML: %v", err)
+		return "", fmt.Errorf("failed to overlay the reverse translated iopTreeYAML: %v", err)
 	}
 	return finalYAML, err
 }

--- a/operator/cmd/mesh/testdata/manifest-generate/input/pilot_override_values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/input/pilot_override_values.yaml
@@ -16,5 +16,8 @@ spec:
         requests:
           cpu: 222m
           memory: 333Mi
+      autoscaleMax: 8
+      autoscaleMin: 2
+      rollingMaxUnavailable: 30%
   unvalidatedValues:
       myCustomKey: someValue

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_values.golden.yaml
@@ -145,6 +145,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   labels:
     app: istiod
+    istio.io/rev: default
     release: istio
   name: istiod
   namespace: istio-control

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_values.golden.yaml
@@ -15,7 +15,7 @@ spec:
   strategy:
     rollingUpdate:
       maxSurge: 100%
-      maxUnavailable: 25%
+      maxUnavailable: 30%
   template:
     metadata:
       annotations:
@@ -137,4 +137,27 @@ spec:
       - configMap:
           name: istio
         name: config-volume
+---
+
+
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    app: istiod
+    release: istio
+  name: istiod
+  namespace: istio-control
+spec:
+  maxReplicas: 8
+  metrics:
+  - resource:
+      name: cpu
+      targetAverageUtilization: 80
+    type: Resource
+  minReplicas: 2
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: istiod
 ---

--- a/operator/cmd/mesh/testdata/manifest-migrate/output/default_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-migrate/output/default_values.golden.yaml
@@ -6,10 +6,23 @@ spec:
   addonComponents:
     grafana:
       enabled: false
+      k8s:
+        env: []
+        nodeSelector: {}
+        replicaCount: 1
+        tolerations: []
     istiocoredns:
       enabled: false
+      k8s:
+        nodeSelector: {}
+        replicaCount: 1
+        tolerations: []
     kiali:
       enabled: false
+      k8s:
+        nodeSelector: {}
+        replicaCount: 1
+        tolerations: []
     prometheus:
       enabled: true
       k8s:
@@ -184,6 +197,7 @@ spec:
       tag: master-latest-daily
     gateways:
       istio-egressgateway:
+        autoscaleEnabled: true
         connectTimeout: 10s
         drainDuration: 45s
         podAntiAffinityLabelSelector: []
@@ -209,6 +223,7 @@ spec:
           suffix: global
       istio-ingressgateway:
         applicationPorts: ""
+        autoscaleEnabled: true
         debug: info
         domain: ""
         externalIPs: []
@@ -422,7 +437,6 @@ spec:
       persist: false
       podAntiAffinityLabelSelector: []
       podAntiAffinityTermLabelSelector: []
-      replicaCount: 1
       security:
         enabled: false
         passphraseKey: passphrase
@@ -433,14 +447,11 @@ spec:
         name: http
         type: ClusterIP
       storageClassName: ""
-      tolerations: []
     istiocoredns:
       coreDNSImage: coredns/coredns:1.1.2
       coreDNSPluginImage: istio/coredns-plugin:0.2-istio-1.1
       podAntiAffinityLabelSelector: []
       podAntiAffinityTermLabelSelector: []
-      replicaCount: 1
-      tolerations: []
     kiali:
       contextPath: /kiali
       createDemoSecret: false
@@ -455,22 +466,22 @@ spec:
       image: kiali
       podAntiAffinityLabelSelector: []
       podAntiAffinityTermLabelSelector: []
-      replicaCount: 1
       security:
         cert_file: /kiali-cert/cert-chain.pem
         enabled: true
         private_key_file: /kiali-cert/key.pem
       tag: v1.1.0
-      tolerations: []
     mixer:
       policy:
         adapters:
           kubernetesenv:
             enabled: true
+        autoscaleEnabled: true
         image: mixer
         podAntiAffinityLabelSelector: []
         podAntiAffinityTermLabelSelector: []
       telemetry:
+        autoscaleEnabled: true
         image: mixer
         loadshedding:
           latencyThreshold: 100ms
@@ -483,6 +494,7 @@ spec:
         useMCP: true
     pilot:
       appNamespaces: []
+      autoscaleEnabled: true
       configMap: true
       configNamespace: istio-config
       image: pilot

--- a/operator/cmd/mesh/testdata/manifest-migrate/output/overlay_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-migrate/output/overlay_values.golden.yaml
@@ -7,6 +7,9 @@ spec:
     ingressGateways:
     - enabled: true
       k8s:
+        hpaSpec:
+          maxReplicas: 20
+          minReplicas: 20
         nodeSelector:
           scalers.istio: dedicated
         tolerations:
@@ -17,6 +20,9 @@ spec:
       name: istio-ingressgateway
     pilot:
       k8s:
+        hpaSpec:
+          maxReplicas: 20
+          minReplicas: 20
         nodeSelector:
           scalers.istio: dedicated
         tolerations:
@@ -31,16 +37,12 @@ spec:
   values:
     gateways:
       istio-ingressgateway:
-        autoscaleMax: 20
-        autoscaleMin: 20
         podAntiAffinityTermLabelSelector:
         - key: istio
           operator: In
           topologyKey: kubernetes.io/hostname
           values: ingressgateway
     pilot:
-      autoscaleMax: 20
-      autoscaleMin: 20
       podAntiAffinityTermLabelSelector:
       - key: istio
         operator: In

--- a/operator/pkg/helmreconciler/rendering.go
+++ b/operator/pkg/helmreconciler/rendering.go
@@ -130,6 +130,15 @@ func MergeIOPSWithProfile(iop *valuesv1alpha1.IstioOperator) (*v1alpha1.IstioOpe
 	if err != nil {
 		return nil, err
 	}
+	mvs := binversion.OperatorBinaryVersion.MinorVersion
+	t, err := translate.NewReverseTranslator(mvs)
+	if err != nil {
+		return nil, fmt.Errorf("error creating values.yaml translator: %s", err)
+	}
+	overlayYAML, err = t.TranslateK8SfromValueToIOP(overlayYAML)
+	if err != nil {
+		return nil, fmt.Errorf("could not overlay k8s settings from values to IOP: %s", err)
+	}
 
 	mergedYAML, err := util.OverlayYAML(profileYAML, overlayYAML)
 	if err != nil {

--- a/operator/pkg/translate/translate_value.go
+++ b/operator/pkg/translate/translate_value.go
@@ -474,7 +474,7 @@ func (t *ReverseTranslator) translateK8sTree(valueTree map[string]interface{},
 		if len(path) != 0 {
 			k8sSettingName = path[len(path)-1]
 		}
-	    if k8sSettingName == "autoscaleEnabled" {
+		if k8sSettingName == "autoscaleEnabled" {
 			if err := translateHPASpec(inPath, v.OutPath, valueTree, cpSpecTree); err != nil {
 				return fmt.Errorf("error in translating K8s HPA spec: %s", err)
 			}

--- a/operator/pkg/translate/translate_value_test.go
+++ b/operator/pkg/translate/translate_value_test.go
@@ -271,7 +271,7 @@ values:
 				ms := jsonpb.Marshaler{}
 				gotString, err := ms.MarshalToString(gotSpec)
 				if err != nil {
-					t.Errorf("error when marshal translated IstioOperatorSpec: %s", err)
+					t.Errorf("failed to marshal translated IstioOperatorSpec: %s", err)
 				}
 				cpYaml, _ := yaml.JSONToYAML([]byte(gotString))
 				if want := tt.want; !util.IsYAMLEqual(gotString, want) {

--- a/operator/pkg/translate/translate_value_test.go
+++ b/operator/pkg/translate/translate_value_test.go
@@ -140,6 +140,7 @@ values:
     telemetryNamespace: istio-telemetry
   pilot:
     image: pilot
+    autoscaleEnabled: true
     traceSampling: 1
     podAntiAffinityLabelSelector:
     - key: istio


### PR DESCRIPTION
Currently some k8s related settings from values does not take effect, because it would be overridden by the k8s part of IOP at the last step as overlay. What this PR does is to use reverse translator to generate an IOP overlay file from user's values overlay at the beginning and then merge with the original IOP.

One pending issue is about how to handle the gateways settings, because the reverse translated IOP will override the gateway node if using json merge instead of merging since the reverse translated gateway node is specific item in the slice.

Discussed with @ostromart offline, considering that values part supports only two provided gateways while the IOP api supports a list of gateways,  it is hard to define the behavior, for example: values.gateways.istio-ingressgateway.foo=bar, whether it should be applied to all gateways or only the provided gateway, but then what if user modify the provided gateway, it seems to make more sense to issue an warning instead to suggest using IOP api part then.
