### PR TITLE
Full push scoping

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -97,6 +97,12 @@ func (s *Server) initConfigController(args *PilotArgs) error {
 		}
 	}
 
+	// Used for tests.
+	memStore := memory.Make(collections.Pilot)
+	memConfigController := memory.NewController(memStore)
+	s.ConfigStores = append(s.ConfigStores, memConfigController)
+	s.EnvoyXdsServer.MemConfigController = memConfigController
+
 	// If running in ingress mode (requires k8s), wrap the config controller.
 	if hasKubeRegistry(args.Service.Registries) && meshConfig.IngressControllerMode != meshconfig.MeshConfig_OFF {
 		// Wrap the config controller with a cache.

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -688,8 +688,10 @@ func (s *Server) initEventHandlers() error {
 		pushReq := &model.PushRequest{
 			Full:              true,
 			NamespacesUpdated: map[string]struct{}{svc.Attributes.Namespace: {}},
-			ConfigsUpdated:    map[resource.GroupVersionKind]map[string]struct{}{model.ServiceEntryKind: {}},
-			Reason:            []model.TriggerReason{model.ServiceUpdate},
+			ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{model.ServiceEntryKind: {
+				string(svc.Hostname): struct{}{},
+			}},
+			Reason: []model.TriggerReason{model.ServiceUpdate},
 		}
 		s.EnvoyXdsServer.ConfigUpdate(pushReq)
 	}
@@ -704,8 +706,10 @@ func (s *Server) initEventHandlers() error {
 		s.EnvoyXdsServer.ConfigUpdate(&model.PushRequest{
 			Full:              true,
 			NamespacesUpdated: map[string]struct{}{si.Service.Attributes.Namespace: {}},
-			ConfigsUpdated:    map[resource.GroupVersionKind]map[string]struct{}{model.ServiceEntryKind: {}},
-			Reason:            []model.TriggerReason{model.ServiceUpdate},
+			ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{model.ServiceEntryKind: {
+				string(si.Service.Hostname): struct{}{},
+			}},
+			Reason: []model.TriggerReason{model.ServiceUpdate},
 		})
 	}
 	if err := s.ServiceController().AppendInstanceHandler(instanceHandler); err != nil {
@@ -716,7 +720,7 @@ func (s *Server) initEventHandlers() error {
 		configHandler := func(_, curr model.Config, _ model.Event) {
 			pushReq := &model.PushRequest{
 				Full:           true,
-				ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{curr.GroupVersionKind(): {}},
+				ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{curr.GroupVersionKind(): {curr.Name: {}}},
 				Reason:         []model.TriggerReason{model.ConfigUpdate},
 			}
 			s.EnvoyXdsServer.ConfigUpdate(pushReq)

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -719,10 +719,9 @@ func (s *Server) initEventHandlers() error {
 	if s.configController != nil {
 		configHandler := func(_, curr model.Config, _ model.Event) {
 			pushReq := &model.PushRequest{
-				Full:              true,
-				NamespacesUpdated: map[string]struct{}{curr.Namespace: {}},
-				ConfigsUpdated:    map[resource.GroupVersionKind]map[string]struct{}{curr.GroupVersionKind(): {curr.Name: {}}},
-				Reason:            []model.TriggerReason{model.ConfigUpdate},
+				Full:           true,
+				ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{curr.GroupVersionKind(): {curr.Name: {}}},
+				Reason:         []model.TriggerReason{model.ConfigUpdate},
 			}
 			s.EnvoyXdsServer.ConfigUpdate(pushReq)
 		}

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -719,9 +719,10 @@ func (s *Server) initEventHandlers() error {
 	if s.configController != nil {
 		configHandler := func(_, curr model.Config, _ model.Event) {
 			pushReq := &model.PushRequest{
-				Full:           true,
-				ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{curr.GroupVersionKind(): {curr.Name: {}}},
-				Reason:         []model.TriggerReason{model.ConfigUpdate},
+				Full:              true,
+				NamespacesUpdated: map[string]struct{}{curr.Namespace: {}},
+				ConfigsUpdated:    map[resource.GroupVersionKind]map[string]struct{}{curr.GroupVersionKind(): {curr.Name: {}}},
+				Reason:            []model.TriggerReason{model.ConfigUpdate},
 			}
 			s.EnvoyXdsServer.ConfigUpdate(pushReq)
 		}

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -685,9 +685,8 @@ func (s *Server) initEventHandlers() error {
 	// Flush cached discovery responses whenever services configuration change.
 	serviceHandler := func(svc *model.Service, _ model.Event) {
 		pushReq := &model.PushRequest{
-			Full:              true,
-			NamespacesUpdated: map[string]struct{}{svc.Attributes.Namespace: {}},
-			ConfigsUpdated: map[model.ConfigKey]struct{}{model.ConfigKey{
+			Full: true,
+			ConfigsUpdated: map[model.ConfigKey]struct{}{{
 				Kind:      model.ServiceEntryKind,
 				Name:      string(svc.Hostname),
 				Namespace: svc.Attributes.Namespace,
@@ -705,9 +704,8 @@ func (s *Server) initEventHandlers() error {
 		// In all cases, this is simply an instance update and not a config update. So, we need to update
 		// EDS in all proxies, and do a full config push for the instance that just changed (add/update only).
 		s.EnvoyXdsServer.ConfigUpdate(&model.PushRequest{
-			Full:              true,
-			NamespacesUpdated: map[string]struct{}{si.Service.Attributes.Namespace: {}},
-			ConfigsUpdated: map[model.ConfigKey]struct{}{model.ConfigKey{
+			Full: true,
+			ConfigsUpdated: map[model.ConfigKey]struct{}{{
 				Kind:      model.ServiceEntryKind,
 				Name:      string(si.Service.Hostname),
 				Namespace: si.Service.Attributes.Namespace,
@@ -723,7 +721,7 @@ func (s *Server) initEventHandlers() error {
 		configHandler := func(_, curr model.Config, _ model.Event) {
 			pushReq := &model.PushRequest{
 				Full: true,
-				ConfigsUpdated: map[model.ConfigKey]struct{}{model.ConfigKey{
+				ConfigsUpdated: map[model.ConfigKey]struct{}{{
 					Kind:      curr.GroupVersionKind(),
 					Name:      curr.Name,
 					Namespace: curr.Namespace,

--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -45,8 +45,8 @@ const (
 	RevisionLabel = "istio.io/rev"
 )
 
-// ConfigKey describe a specific config item depends on or get changed.
-// In most cases name is config name except that for ServiceEntry it's Service.Hostname.
+// ConfigKey describe a specific config item.
+// In most cases, the name is the config's name. However, for ServiceEntry it is service's FQDN.
 type ConfigKey struct {
 	Kind      resource.GroupVersionKind
 	Name      string

--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -45,6 +45,40 @@ const (
 	RevisionLabel = "istio.io/rev"
 )
 
+// ConfigKey describe a specific config item depends on or get changed.
+// In most cases name is config name except that for ServiceEntry it's Service.Hostname.
+type ConfigKey struct {
+	Kind      resource.GroupVersionKind
+	Name      string
+	Namespace string
+}
+
+// ConfigsOfKind extracts configs of the specified kind.
+func ConfigsOfKind(configs map[ConfigKey]struct{}, kind resource.GroupVersionKind) map[ConfigKey]struct{} {
+	ret := make(map[ConfigKey]struct{})
+
+	for conf := range configs {
+		if conf.Kind == kind {
+			ret[conf] = struct{}{}
+		}
+	}
+
+	return ret
+}
+
+// ConfigNamesOfKind extracts config names of the specified kind.
+func ConfigNamesOfKind(configs map[ConfigKey]struct{}, kind resource.GroupVersionKind) map[string]struct{} {
+	ret := make(map[string]struct{})
+
+	for conf := range configs {
+		if conf.Kind == kind {
+			ret[conf.Name] = struct{}{}
+		}
+	}
+
+	return ret
+}
+
 // ConfigMeta is metadata attached to each configuration unit.
 // The revision is optional, and if provided, identifies the
 // last update operation on the object.

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -271,11 +271,11 @@ func (first *PushRequest) Merge(other *PushRequest) *PushRequest {
 			}
 		}
 
-		if !merged.Full {
-			for kind := range merged.ConfigsUpdated {
-				d1 := first.ConfigsUpdated[kind]
-				d2 := other.ConfigsUpdated[kind]
+		for kind := range merged.ConfigsUpdated {
+			d1 := first.ConfigsUpdated[kind]
+			d2 := other.ConfigsUpdated[kind]
 
+			if len(d1) > 0 && len(d2) > 0 {
 				for update := range d1 {
 					merged.ConfigsUpdated[kind][update] = struct{}{}
 				}
@@ -908,7 +908,7 @@ func (ps *PushContext) updateContext(
 	pushReq *PushRequest) error {
 
 	var servicesChanged, virtualServicesChanged, destinationRulesChanged, gatewayChanged,
-		authnChanged, authzChanged, envoyFiltersChanged, sidecarsChanged, quotasChanged bool
+	authnChanged, authzChanged, envoyFiltersChanged, sidecarsChanged, quotasChanged bool
 
 	for k := range pushReq.ConfigsUpdated {
 		switch k {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -233,7 +233,9 @@ const (
 )
 
 var (
-	ServiceEntryKind = collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind()
+	ServiceEntryKind    = collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind()
+	VirtualServiceKind  = collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind()
+	DestinationRuleKind = collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind()
 )
 
 // Merge two update requests together

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -910,7 +910,7 @@ func (ps *PushContext) updateContext(
 	pushReq *PushRequest) error {
 
 	var servicesChanged, virtualServicesChanged, destinationRulesChanged, gatewayChanged,
-	authnChanged, authzChanged, envoyFiltersChanged, sidecarsChanged, quotasChanged bool
+		authnChanged, authzChanged, envoyFiltersChanged, sidecarsChanged, quotasChanged bool
 
 	for k := range pushReq.ConfigsUpdated {
 		switch k {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -185,6 +185,9 @@ type PushRequest struct {
 	Full bool
 
 	// ConfigsUpdated keeps track of configs that have changed.
+	// This is used as an optimization to avoid unnecessary pushes to proxies that are scoped with a Sidecar.
+	// If this is empty, then all proxies will get an update.
+	// Otherwise only proxies depend on these configs will get an update.
 	// The kind of resources are defined in pkg/config/schemas.
 	ConfigsUpdated map[ConfigKey]struct{}
 
@@ -872,11 +875,11 @@ func (ps *PushContext) updateContext(
 
 	for conf := range pushReq.ConfigsUpdated {
 		switch conf.Kind {
-		case collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind():
+		case ServiceEntryKind:
 			servicesChanged = true
-		case collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind():
+		case DestinationRuleKind:
 			destinationRulesChanged = true
-		case collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind():
+		case VirtualServiceKind:
 			virtualServicesChanged = true
 		case collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind():
 			gatewayChanged = true

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -63,25 +63,25 @@ func TestMergeUpdateRequest(t *testing.T) {
 		{
 			"simple merge",
 			&PushRequest{
-				Full:              true,
-				Push:              push0,
-				Start:             t0,
+				Full:  true,
+				Push:  push0,
+				Start: t0,
 				ConfigsUpdated: map[ConfigKey]struct{}{
 					{Kind: resource.GroupVersionKind{Kind: "cfg1"}, Namespace: "ns1"}: {}},
 				Reason: []TriggerReason{ServiceUpdate, ServiceUpdate},
 			},
 			&PushRequest{
-				Full:              false,
-				Push:              push1,
-				Start:             t1,
+				Full:  false,
+				Push:  push1,
+				Start: t1,
 				ConfigsUpdated: map[ConfigKey]struct{}{
 					{Kind: resource.GroupVersionKind{Kind: "cfg2"}, Namespace: "ns2"}: {}},
 				Reason: []TriggerReason{EndpointUpdate},
 			},
 			PushRequest{
-				Full:              true,
-				Push:              push1,
-				Start:             t0,
+				Full:  true,
+				Push:  push1,
+				Start: t0,
 				ConfigsUpdated: map[ConfigKey]struct{}{
 					{Kind: resource.GroupVersionKind{Kind: "cfg1"}, Namespace: "ns1"}: {},
 					{Kind: resource.GroupVersionKind{Kind: "cfg2"}, Namespace: "ns2"}: {}},

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -66,7 +66,6 @@ func TestMergeUpdateRequest(t *testing.T) {
 				Full:              true,
 				Push:              push0,
 				Start:             t0,
-				NamespacesUpdated: map[string]struct{}{"ns1": {}},
 				ConfigsUpdated: map[ConfigKey]struct{}{
 					{Kind: resource.GroupVersionKind{Kind: "cfg1"}, Namespace: "ns1"}: {}},
 				Reason: []TriggerReason{ServiceUpdate, ServiceUpdate},
@@ -75,7 +74,6 @@ func TestMergeUpdateRequest(t *testing.T) {
 				Full:              false,
 				Push:              push1,
 				Start:             t1,
-				NamespacesUpdated: map[string]struct{}{"ns2": {}},
 				ConfigsUpdated: map[ConfigKey]struct{}{
 					{Kind: resource.GroupVersionKind{Kind: "cfg2"}, Namespace: "ns2"}: {}},
 				Reason: []TriggerReason{EndpointUpdate},
@@ -84,18 +82,11 @@ func TestMergeUpdateRequest(t *testing.T) {
 				Full:              true,
 				Push:              push1,
 				Start:             t0,
-				NamespacesUpdated: map[string]struct{}{"ns1": {}, "ns2": {}},
 				ConfigsUpdated: map[ConfigKey]struct{}{
 					{Kind: resource.GroupVersionKind{Kind: "cfg1"}, Namespace: "ns1"}: {},
 					{Kind: resource.GroupVersionKind{Kind: "cfg2"}, Namespace: "ns2"}: {}},
 				Reason: []TriggerReason{ServiceUpdate, ServiceUpdate, EndpointUpdate},
 			},
-		},
-		{
-			"skip namespace merge: one empty",
-			&PushRequest{Full: true, NamespacesUpdated: nil},
-			&PushRequest{Full: true, NamespacesUpdated: map[string]struct{}{"ns2": {}}},
-			PushRequest{Full: true, NamespacesUpdated: nil},
 		},
 		{
 			"skip config type merge: one empty",

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -67,79 +67,29 @@ func TestMergeUpdateRequest(t *testing.T) {
 				Push:              push0,
 				Start:             t0,
 				NamespacesUpdated: map[string]struct{}{"ns1": {}},
-				ConfigsUpdated:    map[resource.GroupVersionKind]map[string]struct{}{{Kind: "cfg1"}: {}},
-				Reason:            []TriggerReason{ServiceUpdate, ServiceUpdate},
+				ConfigsUpdated: map[ConfigKey]struct{}{
+					{Kind: resource.GroupVersionKind{Kind: "cfg1"}, Namespace: "ns1"}: {}},
+				Reason: []TriggerReason{ServiceUpdate, ServiceUpdate},
 			},
 			&PushRequest{
 				Full:              false,
 				Push:              push1,
 				Start:             t1,
 				NamespacesUpdated: map[string]struct{}{"ns2": {}},
-				ConfigsUpdated:    map[resource.GroupVersionKind]map[string]struct{}{{Kind: "cfg2"}: {}},
-				Reason:            []TriggerReason{EndpointUpdate},
+				ConfigsUpdated: map[ConfigKey]struct{}{
+					{Kind: resource.GroupVersionKind{Kind: "cfg2"}, Namespace: "ns2"}: {}},
+				Reason: []TriggerReason{EndpointUpdate},
 			},
 			PushRequest{
 				Full:              true,
 				Push:              push1,
 				Start:             t0,
 				NamespacesUpdated: map[string]struct{}{"ns1": {}, "ns2": {}},
-				ConfigsUpdated:    map[resource.GroupVersionKind]map[string]struct{}{{Kind: "cfg1"}: {}, {Kind: "cfg2"}: {}},
-				Reason:            []TriggerReason{ServiceUpdate, ServiceUpdate, EndpointUpdate},
+				ConfigsUpdated: map[ConfigKey]struct{}{
+					{Kind: resource.GroupVersionKind{Kind: "cfg1"}, Namespace: "ns1"}: {},
+					{Kind: resource.GroupVersionKind{Kind: "cfg2"}, Namespace: "ns2"}: {}},
+				Reason: []TriggerReason{ServiceUpdate, ServiceUpdate, EndpointUpdate},
 			},
-		},
-		{
-			"incremental eds merge",
-			&PushRequest{Full: false,
-				ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{
-					ServiceEntryKind: {"svc-1": {}}}},
-			&PushRequest{Full: false,
-				ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{
-					ServiceEntryKind: {"svc-2": {}}}},
-			PushRequest{Full: false,
-				ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{
-					ServiceEntryKind: {"svc-1": {}, "svc-2": {}}}},
-		},
-		{
-			"skip eds merge: left full",
-			&PushRequest{Full: true},
-			&PushRequest{Full: false,
-				ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{
-					ServiceEntryKind: {"svc-2": {}}}},
-			PushRequest{Full: true},
-		},
-		{
-			"two kinds of resources: left full",
-			&PushRequest{Full: true,
-				ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{
-					{Kind: "cfg1"}: {}}},
-			&PushRequest{Full: false,
-				ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{
-					ServiceEntryKind: {"svc-2": {}}}},
-			PushRequest{Full: true,
-				ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{
-					ServiceEntryKind: {},
-					{Kind: "cfg1"}:   {},
-				}},
-		},
-		{
-			"skip eds merge: right full",
-			&PushRequest{Full: false,
-				ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{
-					ServiceEntryKind: {"svc-1": {}}}},
-			&PushRequest{Full: true},
-			PushRequest{Full: true},
-		},
-		{
-			"incremental merge",
-			&PushRequest{Full: false, NamespacesUpdated: map[string]struct{}{"ns1": {}},
-				ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{
-					ServiceEntryKind: {"svc-1": {}}}},
-			&PushRequest{Full: false, NamespacesUpdated: map[string]struct{}{"ns2": {}},
-				ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{
-					ServiceEntryKind: {"svc-2": {}}}},
-			PushRequest{Full: false, NamespacesUpdated: map[string]struct{}{"ns1": {}, "ns2": {}},
-				ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{
-					ServiceEntryKind: {"svc-1": {}, "svc-2": {}}}},
 		},
 		{
 			"skip namespace merge: one empty",
@@ -150,7 +100,8 @@ func TestMergeUpdateRequest(t *testing.T) {
 		{
 			"skip config type merge: one empty",
 			&PushRequest{Full: true, ConfigsUpdated: nil},
-			&PushRequest{Full: true, ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{{Kind: "cfg2"}: {}}},
+			&PushRequest{Full: true, ConfigsUpdated: map[ConfigKey]struct{}{{
+				Kind: resource.GroupVersionKind{Kind: "cfg2"}}: {}}},
 			PushRequest{Full: true, ConfigsUpdated: nil},
 		},
 	}

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -156,11 +156,10 @@ func DefaultSidecarScopeForNamespace(ps *PushContext, configNamespace string) *S
 	defaultEgressListener.virtualServices = ps.VirtualServices(&dummyNode, meshGateway)
 
 	out := &SidecarScope{
-		EgressListeners:       []*IstioEgressListenerWrapper{defaultEgressListener},
-		services:              defaultEgressListener.services,
-		destinationRules:      make(map[host.Name]*Config),
-		configDependencies:    make(map[ConfigKey]struct{}),
-		namespaceDependencies: make(map[string]struct{}),
+		EgressListeners:    []*IstioEgressListenerWrapper{defaultEgressListener},
+		services:           defaultEgressListener.services,
+		destinationRules:   make(map[host.Name]*Config),
+		configDependencies: make(map[ConfigKey]struct{}),
 	}
 
 	// Now that we have all the services that sidecars using this scope (in
@@ -170,7 +169,6 @@ func DefaultSidecarScopeForNamespace(ps *PushContext, configNamespace string) *S
 		if dr := ps.DestinationRule(&dummyNode, s); dr != nil {
 			out.destinationRules[s.Hostname] = dr
 		}
-		out.namespaceDependencies[s.Attributes.Namespace] = struct{}{}
 		out.AddConfigDependencies(ConfigKey{
 			Kind:      ServiceEntryKind,
 			Name:      string(s.Hostname),
@@ -213,8 +211,7 @@ func ConvertToSidecarScope(ps *PushContext, sidecarConfig *Config, configNamespa
 
 	r := sidecarConfig.Spec.(*networking.Sidecar)
 	out := &SidecarScope{
-		configDependencies:    make(map[ConfigKey]struct{}),
-		namespaceDependencies: make(map[string]struct{}),
+		configDependencies: make(map[ConfigKey]struct{}),
 	}
 
 	out.EgressListeners = make([]*IstioEgressListenerWrapper, 0)
@@ -243,7 +240,6 @@ func ConvertToSidecarScope(ps *PushContext, sidecarConfig *Config, configNamespa
 				Namespace: s.Attributes.Namespace,
 			})
 			out.services = append(out.services, s)
-			out.namespaceDependencies[s.Attributes.Namespace] = struct{}{}
 		} else if foundSvc.Attributes.Namespace == s.Attributes.Namespace && s.Ports != nil && len(s.Ports) > 0 {
 			// merge the ports to service when each listener generates partial service
 			// we only merge if the found service is in the same namespace as the one we're trying to add

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -169,15 +169,15 @@ func DefaultSidecarScopeForNamespace(ps *PushContext, configNamespace string) *S
 	// this config namespace) will see, identify all the destinationRules
 	// that these services need
 	for _, s := range out.services {
-		out.destinationRules[s.Hostname] = ps.DestinationRule(&dummyNode, s)
+		if dr := ps.DestinationRule(&dummyNode, s); dr != nil {
+			out.destinationRules[s.Hostname] = dr
+		}
 		out.namespaceDependencies[s.Attributes.Namespace] = struct{}{}
 		serviceDependencies[string(s.Hostname)] = struct{}{}
 	}
 
 	for _, dr := range out.destinationRules {
-		if dr != nil {
-			destinationRuleDependencies[dr.Name] = struct{}{}
-		}
+		destinationRuleDependencies[dr.Name] = struct{}{}
 	}
 
 	for _, el := range out.EgressListeners {
@@ -307,8 +307,8 @@ func ConvertToSidecarScope(ps *PushContext, sidecarConfig *Config, configNamespa
 	out.destinationRules = make(map[host.Name]*Config)
 	for _, s := range out.services {
 		dr := ps.DestinationRule(&dummyNode, s)
-		out.destinationRules[s.Hostname] = dr
 		if dr != nil {
+			out.destinationRules[s.Hostname] = dr
 			destinationRuleDependencies[dr.Name] = struct{}{}
 		}
 	}

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -451,7 +451,7 @@ func (sc *SidecarScope) DependsOnNamespace(namespace string) bool {
 	return exists
 }
 
-// DependsOnConfig determines if the Sidecar depends on the given config.
+// DependsOnConfig determines if the proxy depends on the given config.
 // Returns whether depends on this config and whether this kind of config is scoped here.
 func (sc *SidecarScope) DependsOnConfig(kind resource.GroupVersionKind, name string) (bool, bool) {
 	if sc == nil {
@@ -468,7 +468,7 @@ func (sc *SidecarScope) DependsOnConfig(kind resource.GroupVersionKind, name str
 
 // AddConfigDependencies add extra config dependencies to this scope. This action should be done before the
 // SidecarScope being used to avoid concurrent read/write.
-func (sc *SidecarScope) AddConfigDependencies(kind resource.GroupVersionKind, names ...string) {
+func (sc *SidecarScope) AddConfigDependencies(kind resource.GroupVersionKind, dependencies ...string) {
 	if sc == nil {
 		return
 	}
@@ -477,18 +477,14 @@ func (sc *SidecarScope) AddConfigDependencies(kind resource.GroupVersionKind, na
 		sc.configDependencies = make(map[resource.GroupVersionKind]map[string]struct{})
 	}
 
-	var (
-		dependencies map[string]struct{}
-		f            bool
-	)
-
-	if dependencies, f = sc.configDependencies[kind]; !f {
-		dependencies = make(map[string]struct{})
-		sc.configDependencies[kind] = dependencies
+	kindDeps, f := sc.configDependencies[kind]
+	if !f {
+		kindDeps = make(map[string]struct{})
+		sc.configDependencies[kind] = kindDeps
 	}
 
-	for _, name := range names {
-		dependencies[name] = struct{}{}
+	for _, name := range dependencies {
+		kindDeps[name] = struct{}{}
 	}
 }
 

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -133,7 +133,7 @@ type IstioEgressListenerWrapper struct {
 	virtualServices []Config
 }
 
-// DefaultSidecarScope is a sidecar scope object with a default catch all egress listener
+// DefaultSidecarScopeForNamespace is a sidecar scope object with a default catch all egress listener
 // that matches the default Istio behavior: a sidecar has listeners for all services in the mesh
 // We use this scope when the user has not set any sidecar Config for a given config namespace.
 func DefaultSidecarScopeForNamespace(ps *PushContext, configNamespace string) *SidecarScope {
@@ -474,12 +474,12 @@ func (sc *SidecarScope) DependsOnConfig(kind resource.GroupVersionKind, name str
 		return false, false
 	}
 
-	if d, exists := sc.configDependencies[kind]; !exists {
+	d, exists := sc.configDependencies[kind]
+	if !exists {
 		return false, false
-	} else {
-		_, exists = d[name]
-		return exists, true
 	}
+	_, exists = d[name]
+	return exists, true
 }
 
 // AddConfigDependencies add extra config dependencies to this scope. This action should be done before the

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -93,9 +93,6 @@ type SidecarScope struct {
 	// This field will be used to determine the config/resource scope
 	// which means which config changes will affect the proxies within this scope.
 	configDependencies map[ConfigKey]struct{}
-
-	// Backup of previous configDependencies. Used to check for dependencies of deleted configs.
-	prevConfigDependencies map[ConfigKey]struct{}
 }
 
 // IstioEgressListenerWrapper is a wrapper for
@@ -479,20 +476,10 @@ func (sc *SidecarScope) DependsOnConfig(config ConfigKey) bool {
 	}
 
 	_, exists := sc.configDependencies[config]
-	if !exists && sc.prevConfigDependencies != nil {
-		_, exists = sc.prevConfigDependencies[config]
-	}
 	return exists
 }
 
-// ApplyPrevious will obtain some data from previous sidecarScope.
-func (sc *SidecarScope) ApplyPrevious(prev *SidecarScope) {
-	if prev != nil {
-		sc.prevConfigDependencies = prev.configDependencies
-	}
-}
-
-// AddConfigDependencies adds extra config dependencies to this scope. This action should be done before the
+// AddConfigDependencies add extra config dependencies to this scope. This action should be done before the
 // SidecarScope being used to avoid concurrent read/write.
 func (sc *SidecarScope) AddConfigDependencies(dependencies ...ConfigKey) {
 	if sc == nil {

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -89,12 +89,9 @@ type SidecarScope struct {
 	// be forwarded.
 	OutboundTrafficPolicy *networking.OutboundTrafficPolicy
 
-	// Set of all namespaces this sidecar depends on. This is determined from the egress config
-	namespaceDependencies map[string]struct{}
-
 	// Set of known configs this sidecar depends on.
 	// This field will be used to determine the config/resource scope
-	// which means which config changes will affect the proxies with this scope.
+	// which means which config changes will affect the proxies within this scope.
 	configDependencies map[ConfigKey]struct{}
 }
 
@@ -465,16 +462,6 @@ func (ilw *IstioEgressListenerWrapper) VirtualServices() []Config {
 	}
 
 	return ilw.virtualServices
-}
-
-// DependsOnNamespace determines if the Sidecar includes the given namespace.
-func (sc *SidecarScope) DependsOnNamespace(namespace string) bool {
-	if sc == nil {
-		return true
-	}
-
-	_, exists := sc.namespaceDependencies[namespace]
-	return exists
 }
 
 // DependsOnConfig determines if the proxy depends on the given config.

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -67,9 +67,13 @@ type SidecarScope struct {
 
 	// Union of services imported across all egress listeners for use by CDS code.
 	services []*Service
+
 	// Set of all services this sidecar depends on.
+	// This field and similar fields below will be used to determine the config/resource scope
+	// which means which config changes will affect the proxies with this scope.
 	serviceDependencies map[host.Name]struct{}
 
+	// Set of all virtualServices this sidecar depends on.
 	virtualServiceDependencies map[string]struct{}
 
 	// Destination rules imported across all egress listeners. This
@@ -452,47 +456,38 @@ func (sc *SidecarScope) DependsOnNamespace(namespace string) bool {
 		return true
 	}
 
-	if _, f := sc.namespaceDependencies[namespace]; f {
-		return true
-	}
-
-	return false
+	_, exists := sc.namespaceDependencies[namespace]
+	return exists
 }
 
+// DependsOnService determines if the Sidecar includes the given service.
 func (sc *SidecarScope) DependsOnService(service host.Name) bool {
 	if sc == nil {
 		return true
 	}
 
-	if _, f := sc.serviceDependencies[service]; f {
-		return true
-	}
-
-	return false
+	_, exists := sc.serviceDependencies[service]
+	return exists
 }
 
+// DependsOnVirtualService determines if the Sidecar includes the given virtualService.
 func (sc *SidecarScope) DependsOnVirtualService(name string) bool {
 	if sc == nil {
 		return true
 	}
 
-	if _, f := sc.virtualServiceDependencies[name]; f {
-		return true
-	}
-
-	return false
+	_, exists := sc.virtualServiceDependencies[name]
+	return exists
 }
 
+// DependsOnDestinationRule determines if the Sidecar includes the given destinationRule.
 func (sc *SidecarScope) DependsOnDestinationRule(name string) bool {
 	if sc == nil {
 		return true
 	}
 
-	if _, f := sc.destinationRuleDependencies[name]; f {
-		return true
-	}
-
-	return false
+	_, exists := sc.destinationRuleDependencies[name]
+	return exists
 }
 
 // Given a list of virtual services visible to this namespace,

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pkg/config/schema/resource"
 
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
@@ -488,6 +489,35 @@ func (sc *SidecarScope) DependsOnDestinationRule(name string) bool {
 
 	_, exists := sc.destinationRuleDependencies[name]
 	return exists
+}
+
+// AddConfigDependencies add extra config dependencies to this scope. This action should be done before the
+// SidecarScope being used to avoid concurrent read/write.
+// Currently this method is used to prepare test data only.
+func (sc *SidecarScope) AddConfigDependencies(kind resource.GroupVersionKind, names ...string) {
+	switch kind {
+	case ServiceEntryKind:
+		if sc.serviceDependencies == nil {
+			sc.serviceDependencies = make(map[host.Name]struct{})
+		}
+		for _, name := range names {
+			sc.serviceDependencies[host.Name(name)] = struct{}{}
+		}
+	case VirtualServiceKind:
+		if sc.virtualServiceDependencies == nil {
+			sc.virtualServiceDependencies = make(map[string]struct{})
+		}
+		for _, name := range names {
+			sc.virtualServiceDependencies[name] = struct{}{}
+		}
+	case DestinationRuleKind:
+		if sc.destinationRuleDependencies == nil {
+			sc.destinationRuleDependencies = make(map[string]struct{})
+		}
+		for _, name := range names {
+			sc.destinationRuleDependencies[name] = struct{}{}
+		}
+	}
 }
 
 // Given a list of virtual services visible to this namespace,

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -465,18 +465,18 @@ func (ilw *IstioEgressListenerWrapper) VirtualServices() []Config {
 }
 
 // DependsOnConfig determines if the proxy depends on the given config.
-// Returns whether depends on this config and whether this kind of config is scoped(or known to be depended or not) here.
-func (sc *SidecarScope) DependsOnConfig(config ConfigKey) (bool, bool) {
+// Returns whether depends on this config or this kind of config is not scoped(unknown to be depended) here.
+func (sc *SidecarScope) DependsOnConfig(config ConfigKey) bool {
 	if sc == nil {
-		return false, false
+		return true
 	}
 	// This kind of config is unknown to sidecarScope.
 	if _, f := sidecarScopeKnownConfigTypes[config.Kind]; !f {
-		return false, false
+		return true
 	}
 
 	_, exists := sc.configDependencies[config]
-	return exists, true
+	return exists
 }
 
 // AddConfigDependencies add extra config dependencies to this scope. This action should be done before the

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -452,7 +452,7 @@ func (sc *SidecarScope) DependsOnNamespace(namespace string) bool {
 }
 
 // DependsOnConfig determines if the proxy depends on the given config.
-// Returns whether depends on this config and whether this kind of config is scoped here.
+// Returns whether depends on this config and whether this kind of config is scoped(or known to be depended or not) here.
 func (sc *SidecarScope) DependsOnConfig(kind resource.GroupVersionKind, name string) (bool, bool) {
 	if sc == nil {
 		return false, false

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -93,6 +93,9 @@ type SidecarScope struct {
 	// This field will be used to determine the config/resource scope
 	// which means which config changes will affect the proxies within this scope.
 	configDependencies map[ConfigKey]struct{}
+
+	// Backup of previous configDependencies. Used to check for dependencies of deleted configs.
+	prevConfigDependencies map[ConfigKey]struct{}
 }
 
 // IstioEgressListenerWrapper is a wrapper for
@@ -476,10 +479,20 @@ func (sc *SidecarScope) DependsOnConfig(config ConfigKey) bool {
 	}
 
 	_, exists := sc.configDependencies[config]
+	if !exists && sc.prevConfigDependencies != nil {
+		_, exists = sc.prevConfigDependencies[config]
+	}
 	return exists
 }
 
-// AddConfigDependencies add extra config dependencies to this scope. This action should be done before the
+// ApplyPrevious will obtain some data from previous sidecarScope.
+func (sc *SidecarScope) ApplyPrevious(prev *SidecarScope) {
+	if prev != nil {
+		sc.prevConfigDependencies = prev.configDependencies
+	}
+}
+
+// AddConfigDependencies adds extra config dependencies to this scope. This action should be done before the
 // SidecarScope being used to avoid concurrent read/write.
 func (sc *SidecarScope) AddConfigDependencies(dependencies ...ConfigKey) {
 	if sc == nil {

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -1158,19 +1158,24 @@ func TestIstioEgressListenerWrapper(t *testing.T) {
 	}
 }
 
-func TestContainsEgressNamespace(t *testing.T) {
+func TestContainsEgressDependencies(t *testing.T) {
+	const svcName = "svc1.com"
 	cases := []struct {
 		name      string
 		egress    []string
 		namespace string
 		contains  bool
+
+		services        []host.Name
+		virtualServices []string
+		destinationRule []string
 	}{
-		{"Just wildcard", []string{"*/*"}, "ns", true},
-		{"Namespace and wildcard", []string{"ns/*", "*/*"}, "ns", true},
-		{"Just Namespace", []string{"ns/*"}, "ns", true},
-		{"Wrong Namespace", []string{"ns/*"}, "other-ns", false},
-		{"No Sidecar", nil, "ns", true},
-		{"No Sidecar Other Namespace", nil, "other-ns", false},
+		{"Just wildcard", []string{"*/*"}, "ns", true, []host.Name{svcName}, []string{"vs1"}, []string{"dr1"}},
+		{"Namespace and wildcard", []string{"ns/*", "*/*"}, "ns", true, []host.Name{svcName}, []string{"vs1"}, []string{"dr1"}},
+		{"Just Namespace", []string{"ns/*"}, "ns", true, []host.Name{svcName}, []string{"vs1"}, []string{"dr1"}},
+		{"Wrong Namespace", []string{"ns/*"}, "other-ns", false, nil, nil, nil},
+		{"No Sidecar", nil, "ns", true, []host.Name{svcName}, []string{"vs1"}, []string{"dr1"}},
+		{"No Sidecar Other Namespace", nil, "other-ns", false, nil, nil, nil},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1193,9 +1198,34 @@ func TestContainsEgressNamespace(t *testing.T) {
 
 			services := []*Service{
 				{Hostname: "nomatch", Attributes: ServiceAttributes{Namespace: "nomatch"}},
-				{Hostname: "ns", Attributes: ServiceAttributes{Namespace: "ns"}},
+				{Hostname: svcName, Attributes: ServiceAttributes{Namespace: "ns"}},
+			}
+			virtualServices := []Config{
+				{
+					ConfigMeta: ConfigMeta{
+						Name:      "vs1",
+						Namespace: "ns",
+					},
+					Spec: &networking.VirtualService{
+						Hosts: []string{svcName},
+					},
+				},
+			}
+			destinationRules := []Config{
+				{
+					ConfigMeta: ConfigMeta{
+						Name:      "dr1",
+						Namespace: "ns",
+					},
+					Spec: &networking.DestinationRule{
+						Host:     svcName,
+						ExportTo: []string{"*"},
+					},
+				},
 			}
 			ps.publicServices = append(ps.publicServices, services...)
+			ps.publicVirtualServices = append(ps.publicVirtualServices, virtualServices...)
+			ps.SetDestinationRules(destinationRules)
 			sidecarScope := ConvertToSidecarScope(ps, cfg, "default")
 			if len(tt.egress) == 0 {
 				sidecarScope = DefaultSidecarScopeForNamespace(ps, "default")
@@ -1204,6 +1234,22 @@ func TestContainsEgressNamespace(t *testing.T) {
 			got := sidecarScope.DependsOnNamespace(tt.namespace)
 			if got != tt.contains {
 				t.Fatalf("Expected contains %v, got %v", tt.contains, got)
+			}
+
+			for _, name := range tt.services {
+				if !sidecarScope.DependsOnService(name) {
+					t.Fatalf("Expected contains %v, but no %s", tt.services, name)
+				}
+			}
+			for _, name := range tt.virtualServices {
+				if !sidecarScope.DependsOnVirtualService(name) {
+					t.Fatalf("Expected contains %v, but no %s", tt.virtualServices, name)
+				}
+			}
+			for _, svc := range tt.destinationRule {
+				if !sidecarScope.DependsOnDestinationRule(svc) {
+					t.Fatalf("Expected contains %v, but no %s", tt.destinationRule, svc)
+				}
 			}
 		})
 	}

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -1242,7 +1242,7 @@ func TestContainsEgressDependencies(t *testing.T) {
 			}
 
 			for k, v := range tt.contains {
-				if ok, _ := sidecarScope.DependsOnConfig(k); ok != v {
+				if ok := sidecarScope.DependsOnConfig(k); ok != v {
 					t.Fatalf("Expected contains %v-%v, but no match", k, v)
 				}
 			}

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -1237,18 +1237,18 @@ func TestContainsEgressDependencies(t *testing.T) {
 			}
 
 			for _, name := range tt.services {
-				if ok, _ := sidecarScope.DependsOnConfig(ServiceEntryKind, string(name)); !ok {
+				if ok, _ := sidecarScope.DependsOnConfig(ConfigKey{ServiceEntryKind, string(name), "ns"}); !ok {
 					t.Fatalf("Expected contains %v, but no %s", tt.services, name)
 				}
 			}
 			for _, name := range tt.virtualServices {
-				if ok, _ := sidecarScope.DependsOnConfig(VirtualServiceKind, name); !ok {
+				if ok, _ := sidecarScope.DependsOnConfig(ConfigKey{VirtualServiceKind, name, "ns"}); !ok {
 					t.Fatalf("Expected contains %v, but no %s", tt.virtualServices, name)
 				}
 			}
-			for _, svc := range tt.destinationRule {
-				if ok, _ := sidecarScope.DependsOnConfig(DestinationRuleKind, svc); !ok {
-					t.Fatalf("Expected contains %v, but no %s", tt.destinationRule, svc)
+			for _, name := range tt.destinationRule {
+				if ok, _ := sidecarScope.DependsOnConfig(ConfigKey{DestinationRuleKind, name, "ns"}); !ok {
+					t.Fatalf("Expected contains %v, but no %s", tt.destinationRule, name)
 				}
 			}
 		})

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -1231,11 +1231,7 @@ func TestContainsEgressDependencies(t *testing.T) {
 				sidecarScope = DefaultSidecarScopeForNamespace(ps, "default")
 			}
 
-			got := sidecarScope.DependsOnNamespace(tt.namespace)
-			if got != tt.contains {
-				t.Fatalf("Expected contains %v, got %v", tt.contains, got)
-			}
-
+			// TODO yonka: Improve this test case.
 			for _, name := range tt.services {
 				if ok, _ := sidecarScope.DependsOnConfig(ConfigKey{ServiceEntryKind, string(name), "ns"}); !ok {
 					t.Fatalf("Expected contains %v, but no %s", tt.services, name)

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -1237,17 +1237,17 @@ func TestContainsEgressDependencies(t *testing.T) {
 			}
 
 			for _, name := range tt.services {
-				if !sidecarScope.DependsOnService(name) {
+				if ok, _ := sidecarScope.DependsOnConfig(ServiceEntryKind, string(name)); !ok {
 					t.Fatalf("Expected contains %v, but no %s", tt.services, name)
 				}
 			}
 			for _, name := range tt.virtualServices {
-				if !sidecarScope.DependsOnVirtualService(name) {
+				if ok, _ := sidecarScope.DependsOnConfig(VirtualServiceKind, name); !ok {
 					t.Fatalf("Expected contains %v, but no %s", tt.virtualServices, name)
 				}
 			}
 			for _, svc := range tt.destinationRule {
-				if !sidecarScope.DependsOnDestinationRule(svc) {
+				if ok, _ := sidecarScope.DependsOnConfig(DestinationRuleKind, svc); !ok {
 					t.Fatalf("Expected contains %v, but no %s", tt.destinationRule, svc)
 				}
 			}

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -508,7 +508,7 @@ func (s *DiscoveryServer) pushConnection(con *XdsConnection, pushEv *XdsEvent) e
 		}
 		// Push only EDS. This is indexed already - push immediately
 		// (may need a throttle)
-		if len(con.Clusters) > 0  {
+		if len(con.Clusters) > 0 {
 			if len(edsUpdatedServices) == 0 {
 				edsUpdatedServices = nil
 			}

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -102,8 +102,6 @@ type XdsEvent struct {
 	// Indicate whether the push is Full Push
 	full bool
 
-	namespacesUpdated map[string]struct{}
-
 	configsUpdated map[model.ConfigKey]struct{}
 
 	// Push context to use for the push.

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -503,7 +503,7 @@ func (s *DiscoveryServer) pushConnection(con *XdsConnection, pushEv *XdsEvent) e
 		}
 		// Push only EDS. This is indexed already - push immediately
 		// (may need a throttle)
-		if len(con.Clusters) > 0 {
+		if len(con.Clusters) > 0 && len(edsUpdatedServices) > 0 {
 			if err := s.pushEds(pushEv.push, con, versionInfo(), edsUpdatedServices); err != nil {
 				return err
 			}

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -508,7 +508,10 @@ func (s *DiscoveryServer) pushConnection(con *XdsConnection, pushEv *XdsEvent) e
 		}
 		// Push only EDS. This is indexed already - push immediately
 		// (may need a throttle)
-		if len(con.Clusters) > 0 && len(edsUpdatedServices) > 0 {
+		if len(con.Clusters) > 0  {
+			if len(edsUpdatedServices) == 0 {
+				edsUpdatedServices = nil
+			}
 			if err := s.pushEds(pushEv.push, con, versionInfo(), edsUpdatedServices); err != nil {
 				return err
 			}

--- a/pilot/pkg/proxy/envoy/v2/ads_common.go
+++ b/pilot/pkg/proxy/envoy/v2/ads_common.go
@@ -49,9 +49,8 @@ func ConfigAffectsProxy(pushEv *XdsEvent, proxy *model.Proxy) bool {
 		// Detailed config dependencies check.
 		switch proxy.Type {
 		case model.SidecarProxy:
-			// Not scoping of all config types are known to SidecarScope. We consider the unknown cases as "affected".
-			ok, scoped := proxy.SidecarScope.DependsOnConfig(config)
-			if !scoped || ok {
+			depended := proxy.SidecarScope.DependsOnConfig(config)
+			if depended {
 				return true
 			}
 		// TODO We'll add the check for other proxy types later.

--- a/pilot/pkg/proxy/envoy/v2/ads_common.go
+++ b/pilot/pkg/proxy/envoy/v2/ads_common.go
@@ -30,6 +30,10 @@ var (
 )
 
 func serviceEntryAffectProxy(proxy *model.Proxy, pushEv *XdsEvent, resources map[string]struct{}) bool {
+	if len(resources) == 0 {
+		return true
+	}
+
 	for name := range resources {
 		if proxy.SidecarScope.DependsOnService(host.Name(name)) {
 			return true
@@ -39,6 +43,10 @@ func serviceEntryAffectProxy(proxy *model.Proxy, pushEv *XdsEvent, resources map
 }
 
 func virtualServiceAffectProxy(proxy *model.Proxy, pushEv *XdsEvent, resources map[string]struct{}) bool {
+	if len(resources) == 0 {
+		return true
+	}
+
 	for name := range resources {
 		if proxy.SidecarScope.DependsOnVirtualService(name) {
 			return true
@@ -48,6 +56,10 @@ func virtualServiceAffectProxy(proxy *model.Proxy, pushEv *XdsEvent, resources m
 }
 
 func destinationRuleAffectProxy(proxy *model.Proxy, pushEv *XdsEvent, resources map[string]struct{}) bool {
+	if len(resources) == 0 {
+		return true
+	}
+
 	for name := range resources {
 		if proxy.SidecarScope.DependsOnDestinationRule(name) {
 			return true

--- a/pilot/pkg/proxy/envoy/v2/ads_common.go
+++ b/pilot/pkg/proxy/envoy/v2/ads_common.go
@@ -20,6 +20,7 @@ import (
 	"istio.io/istio/pkg/config/schema/resource"
 )
 
+// configKindAffectedProxyTypes contains known config types which will affect certain node types.
 var configKindAffectedProxyTypes = map[resource.GroupVersionKind][]model.NodeType{
 	collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind():           {model.Router},
 	collections.IstioMixerV1ConfigClientQuotaspecs.Resource().GroupVersionKind():        {model.SidecarProxy},

--- a/pilot/pkg/proxy/envoy/v2/ads_common.go
+++ b/pilot/pkg/proxy/envoy/v2/ads_common.go
@@ -74,6 +74,9 @@ func destinationRuleAffectsProxy(proxy *model.Proxy, pushEv *XdsEvent, resources
 // PushAffectsProxy checks if a pushEv will affect a specified proxy. That means whether the push will be performed
 // towards the proxy.
 func PushAffectsProxy(pushEv *XdsEvent, proxy *model.Proxy) bool {
+	if proxy.Type != model.SidecarProxy {
+		return true
+	}
 	if len(pushEv.configsUpdated) == 0 {
 		return true
 	}

--- a/pilot/pkg/proxy/envoy/v2/ads_common.go
+++ b/pilot/pkg/proxy/envoy/v2/ads_common.go
@@ -23,13 +23,13 @@ import (
 
 var (
 	pushResourceScope = map[resource.GroupVersionKind]func(proxy *model.Proxy, pushEv *XdsEvent, resources map[string]struct{}) bool{
-		model.ServiceEntryKind:    serviceEntryAffectProxy,
-		model.VirtualServiceKind:  virtualServiceAffectProxy,
-		model.DestinationRuleKind: destinationRuleAffectProxy,
+		model.ServiceEntryKind:    serviceEntryAffectsProxy,
+		model.VirtualServiceKind:  virtualServiceAffectsProxy,
+		model.DestinationRuleKind: destinationRuleAffectsProxy,
 	}
 )
 
-func serviceEntryAffectProxy(proxy *model.Proxy, pushEv *XdsEvent, resources map[string]struct{}) bool {
+func serviceEntryAffectsProxy(proxy *model.Proxy, pushEv *XdsEvent, resources map[string]struct{}) bool {
 	_ = pushEv
 	if len(resources) == 0 {
 		return true
@@ -43,7 +43,7 @@ func serviceEntryAffectProxy(proxy *model.Proxy, pushEv *XdsEvent, resources map
 	return false
 }
 
-func virtualServiceAffectProxy(proxy *model.Proxy, pushEv *XdsEvent, resources map[string]struct{}) bool {
+func virtualServiceAffectsProxy(proxy *model.Proxy, pushEv *XdsEvent, resources map[string]struct{}) bool {
 	_ = pushEv
 	if len(resources) == 0 {
 		return true
@@ -57,7 +57,7 @@ func virtualServiceAffectProxy(proxy *model.Proxy, pushEv *XdsEvent, resources m
 	return false
 }
 
-func destinationRuleAffectProxy(proxy *model.Proxy, pushEv *XdsEvent, resources map[string]struct{}) bool {
+func destinationRuleAffectsProxy(proxy *model.Proxy, pushEv *XdsEvent, resources map[string]struct{}) bool {
 	_ = pushEv
 	if len(resources) == 0 {
 		return true
@@ -71,7 +71,9 @@ func destinationRuleAffectProxy(proxy *model.Proxy, pushEv *XdsEvent, resources 
 	return false
 }
 
-func PushAffectProxy(pushEv *XdsEvent, proxy *model.Proxy) bool {
+// PushAffectsProxy checks if a pushEv will affect a specified proxy. That means whether the push will be performed
+// towards the proxy.
+func PushAffectsProxy(pushEv *XdsEvent, proxy *model.Proxy) bool {
 	if len(pushEv.configsUpdated) == 0 {
 		return true
 	}
@@ -116,7 +118,7 @@ Loop:
 	}
 
 	if appliesToProxy {
-		appliesToProxy = PushAffectProxy(pushEv, proxy)
+		appliesToProxy = PushAffectsProxy(pushEv, proxy)
 	}
 
 	if !appliesToProxy {

--- a/pilot/pkg/proxy/envoy/v2/ads_common.go
+++ b/pilot/pkg/proxy/envoy/v2/ads_common.go
@@ -30,6 +30,7 @@ var (
 )
 
 func serviceEntryAffectProxy(proxy *model.Proxy, pushEv *XdsEvent, resources map[string]struct{}) bool {
+	_ = pushEv
 	if len(resources) == 0 {
 		return true
 	}
@@ -43,6 +44,7 @@ func serviceEntryAffectProxy(proxy *model.Proxy, pushEv *XdsEvent, resources map
 }
 
 func virtualServiceAffectProxy(proxy *model.Proxy, pushEv *XdsEvent, resources map[string]struct{}) bool {
+	_ = pushEv
 	if len(resources) == 0 {
 		return true
 	}
@@ -56,6 +58,7 @@ func virtualServiceAffectProxy(proxy *model.Proxy, pushEv *XdsEvent, resources m
 }
 
 func destinationRuleAffectProxy(proxy *model.Proxy, pushEv *XdsEvent, resources map[string]struct{}) bool {
+	_ = pushEv
 	if len(resources) == 0 {
 		return true
 	}

--- a/pilot/pkg/proxy/envoy/v2/ads_common.go
+++ b/pilot/pkg/proxy/envoy/v2/ads_common.go
@@ -34,8 +34,8 @@ func PushAffectsProxy(pushEv *XdsEvent, proxy *model.Proxy) bool {
 			return true
 		}
 
-		for name := range resources {
-			ok, scoped := proxy.SidecarScope.DependsOnConfig(kind, name)
+		for res := range resources {
+			ok, scoped := proxy.SidecarScope.DependsOnConfig(kind, res)
 			if !scoped || ok {
 				return true
 			}

--- a/pilot/pkg/proxy/envoy/v2/ads_common.go
+++ b/pilot/pkg/proxy/envoy/v2/ads_common.go
@@ -16,6 +16,7 @@ package v2
 
 import (
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/resource"
 )
@@ -34,7 +35,7 @@ var (
 
 func serviceEntryAffectProxy(proxy *model.Proxy, pushEv *XdsEvent, resources map[string]struct{}) bool {
 	for resource := range resources {
-		if proxy.SidecarScope.DependsOnService(resource) {
+		if proxy.SidecarScope.DependsOnService(host.Name(resource)) {
 			return true
 		}
 	}

--- a/pilot/pkg/proxy/envoy/v2/ads_common.go
+++ b/pilot/pkg/proxy/envoy/v2/ads_common.go
@@ -49,8 +49,9 @@ func ConfigAffectsProxy(pushEv *XdsEvent, proxy *model.Proxy) bool {
 		// Detailed config dependencies check.
 		switch proxy.Type {
 		case model.SidecarProxy:
-			depended := proxy.SidecarScope.DependsOnConfig(config)
-			if depended {
+			if proxy.SidecarScope.DependsOnConfig(config) {
+				return true
+			} else if proxy.PrevSidecarScope != nil && proxy.PrevSidecarScope.DependsOnConfig(config) {
 				return true
 			}
 		// TODO We'll add the check for other proxy types later.

--- a/pilot/pkg/proxy/envoy/v2/ads_common_test.go
+++ b/pilot/pkg/proxy/envoy/v2/ads_common_test.go
@@ -32,6 +32,7 @@ func TestProxyNeedsPush(t *testing.T) {
 		vsName      = "vs1"
 	)
 
+	pushResourceScopeBak := pushResourceScope
 	pushResourceScope = map[resource.GroupVersionKind]func(proxy *model.Proxy, pushEv *XdsEvent, resources map[string]struct{}) bool{
 		model.ServiceEntryKind: func(proxy *model.Proxy, pushEv *XdsEvent, resources map[string]struct{}) bool {
 			if len(resources) == 0 {
@@ -55,6 +56,9 @@ func TestProxyNeedsPush(t *testing.T) {
 			return f
 		},
 	}
+	defer func() {
+		pushResourceScope = pushResourceScopeBak
+	}()
 
 	sidecar := &model.Proxy{Type: model.SidecarProxy, IPAddresses: []string{"127.0.0.1"}}
 	gateway := &model.Proxy{Type: model.Router}

--- a/pilot/pkg/proxy/envoy/v2/ads_common_test.go
+++ b/pilot/pkg/proxy/envoy/v2/ads_common_test.go
@@ -30,6 +30,7 @@ func TestProxyNeedsPush(t *testing.T) {
 		svcName     = "svc1.com"
 		drName      = "dr1"
 		vsName      = "vs1"
+		generalName = "name1"
 	)
 
 	sidecar := &model.Proxy{Type: model.SidecarProxy, IPAddresses: []string{"127.0.0.1"}, Metadata: &model.NodeMetadata{}, SidecarScope: &model.SidecarScope{}}
@@ -48,13 +49,13 @@ func TestProxyNeedsPush(t *testing.T) {
 	}{
 		{"no namespace or configs", sidecar, nil, nil, true},
 		{"gateway config for sidecar", sidecar, nil, map[resource.GroupVersionKind]map[string]struct{}{
-			collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind(): {}}, false},
+			collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind(): {generalName: {}}}, false},
 		{"gateway config for gateway", gateway, nil, map[resource.GroupVersionKind]map[string]struct{}{
-			collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind(): {}}, true},
+			collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind(): {generalName: {}}}, true},
 		{"quotaspec config for sidecar", sidecar, nil, map[resource.GroupVersionKind]map[string]struct{}{
-			collections.IstioMixerV1ConfigClientQuotaspecs.Resource().GroupVersionKind(): {}}, true},
+			collections.IstioMixerV1ConfigClientQuotaspecs.Resource().GroupVersionKind(): {generalName: {}}}, true},
 		{"quotaspec config for gateway", gateway, nil, map[resource.GroupVersionKind]map[string]struct{}{
-			collections.IstioMixerV1ConfigClientQuotaspecs.Resource().GroupVersionKind(): {}}, false},
+			collections.IstioMixerV1ConfigClientQuotaspecs.Resource().GroupVersionKind(): {generalName: {}}}, false},
 		{"invalid config for sidecar", sidecar, nil, map[resource.GroupVersionKind]map[string]struct{}{
 			{Kind: invalidKind}: {}}, true},
 		{"serviceentry empty config for sidecar", sidecar, nil, map[resource.GroupVersionKind]map[string]struct{}{

--- a/pilot/pkg/proxy/envoy/v2/ads_common_test.go
+++ b/pilot/pkg/proxy/envoy/v2/ads_common_test.go
@@ -45,10 +45,13 @@ func TestProxyNeedsPush(t *testing.T) {
 		want       bool
 	}
 
-	sidecar := &model.Proxy{Type: model.SidecarProxy, IPAddresses: []string{"127.0.0.1"}, Metadata: &model.NodeMetadata{}, SidecarScope: &model.SidecarScope{}}
+	sidecar := &model.Proxy{
+		Type: model.SidecarProxy, IPAddresses: []string{"127.0.0.1"}, Metadata: &model.NodeMetadata{},
+		SidecarScope: &model.SidecarScope{}}
 	gateway := &model.Proxy{Type: model.Router}
 
-	sidecarScopeKindNames := map[resource.GroupVersionKind]string{model.ServiceEntryKind: svcName, model.VirtualServiceKind: vsName, model.DestinationRuleKind: drName}
+	sidecarScopeKindNames := map[resource.GroupVersionKind]string{
+		model.ServiceEntryKind: svcName, model.VirtualServiceKind: vsName, model.DestinationRuleKind: drName}
 	for kind, name := range sidecarScopeKindNames {
 		sidecar.SidecarScope.AddConfigDependencies(kind, name)
 	}
@@ -80,29 +83,24 @@ func TestProxyNeedsPush(t *testing.T) {
 			namespace []string
 			want      bool
 		}{
-			{nil, true},  // empty namespace -> all
-			{[]string{nsName + invalidNameSuffix}, false},  // invalid namespace
+			{nil, true}, // empty namespace -> all
+			{[]string{nsName + invalidNameSuffix}, false}, // invalid namespace
 		}
 
 		for _, nsCase := range nsCases {
-			// empty
-			cases = append(cases, Case{
+			cases = append(cases, Case{ // empty
 				name:       fmt.Sprintf("%s empty config and namespace %v for sidecar", kind.Kind, nsCase.namespace),
 				proxy:      sidecar,
 				namespaces: nsCase.namespace,
 				configs:    map[resource.GroupVersionKind]map[string]struct{}{kind: {name: struct{}{}}},
 				want:       nsCase.want, // true && nsCase.want
-			})
-			// valid name
-			cases = append(cases, Case{
+			}, Case{ // valid name
 				name:       fmt.Sprintf("%s config and namespace %v for sidecar", kind.Kind, nsCase.namespace),
 				proxy:      sidecar,
 				namespaces: nsCase.namespace,
 				configs:    map[resource.GroupVersionKind]map[string]struct{}{kind: {name: struct{}{}}},
 				want:       nsCase.want,
-			})
-			// invalid name
-			cases = append(cases, Case{
+			}, Case{ // invalid name
 				name:       fmt.Sprintf("%s unmatched config and namespace %v for sidecar", kind.Kind, nsCase.namespace),
 				proxy:      sidecar,
 				namespaces: nsCase.namespace,

--- a/pilot/pkg/proxy/envoy/v2/ads_common_test.go
+++ b/pilot/pkg/proxy/envoy/v2/ads_common_test.go
@@ -19,7 +19,7 @@ import (
 	"strconv"
 	"testing"
 
-	"istio.io/istio/pilot/pkg/model"
+	model "istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/resource"
 )
@@ -33,8 +33,10 @@ func TestProxyNeedsPush(t *testing.T) {
 	)
 
 	pushResourceScopeBak := pushResourceScope
-	pushResourceScope = map[resource.GroupVersionKind]func(proxy *model.Proxy, pushEv *XdsEvent, resources map[string]struct{}) bool{
+	pushResourceScope = map[resource.GroupVersionKind]func(*model.Proxy, *XdsEvent, map[string]struct{}) bool{
 		model.ServiceEntryKind: func(proxy *model.Proxy, pushEv *XdsEvent, resources map[string]struct{}) bool {
+			_ = proxy
+			_ = pushEv
 			if len(resources) == 0 {
 				return true
 			}
@@ -42,6 +44,8 @@ func TestProxyNeedsPush(t *testing.T) {
 			return f
 		},
 		model.VirtualServiceKind: func(proxy *model.Proxy, pushEv *XdsEvent, resources map[string]struct{}) bool {
+			_ = proxy
+			_ = pushEv
 			if len(resources) == 0 {
 				return true
 			}
@@ -49,6 +53,8 @@ func TestProxyNeedsPush(t *testing.T) {
 			return f
 		},
 		model.DestinationRuleKind: func(proxy *model.Proxy, pushEv *XdsEvent, resources map[string]struct{}) bool {
+			_ = proxy
+			_ = pushEv
 			if len(resources) == 0 {
 				return true
 			}
@@ -79,7 +85,7 @@ func TestProxyNeedsPush(t *testing.T) {
 		{"quotaspec config for gateway", gateway, nil, map[resource.GroupVersionKind]map[string]struct{}{
 			collections.IstioMixerV1ConfigClientQuotaspecs.Resource().GroupVersionKind(): {}}, false},
 		{"invalid config for sidecar", sidecar, nil, map[resource.GroupVersionKind]map[string]struct{}{
-			resource.GroupVersionKind{Kind: invalidKind}: {}}, true},
+			{Kind: invalidKind}: {}}, true},
 		{"serviceentry empty config for sidecar", sidecar, nil, map[resource.GroupVersionKind]map[string]struct{}{
 			model.ServiceEntryKind: {}}, true},
 		{"serviceentry unmatched config for sidecar", sidecar, nil, map[resource.GroupVersionKind]map[string]struct{}{

--- a/pilot/pkg/proxy/envoy/v2/ads_common_test.go
+++ b/pilot/pkg/proxy/envoy/v2/ads_common_test.go
@@ -32,42 +32,13 @@ func TestProxyNeedsPush(t *testing.T) {
 		vsName      = "vs1"
 	)
 
-	pushResourceScopeBak := pushResourceScope
-	pushResourceScope = map[resource.GroupVersionKind]func(*model.Proxy, *XdsEvent, map[string]struct{}) bool{
-		model.ServiceEntryKind: func(proxy *model.Proxy, pushEv *XdsEvent, resources map[string]struct{}) bool {
-			_ = proxy
-			_ = pushEv
-			if len(resources) == 0 {
-				return true
-			}
-			_, f := resources[svcName]
-			return f
-		},
-		model.VirtualServiceKind: func(proxy *model.Proxy, pushEv *XdsEvent, resources map[string]struct{}) bool {
-			_ = proxy
-			_ = pushEv
-			if len(resources) == 0 {
-				return true
-			}
-			_, f := resources[vsName]
-			return f
-		},
-		model.DestinationRuleKind: func(proxy *model.Proxy, pushEv *XdsEvent, resources map[string]struct{}) bool {
-			_ = proxy
-			_ = pushEv
-			if len(resources) == 0 {
-				return true
-			}
-			_, f := resources[drName]
-			return f
-		},
-	}
-	defer func() {
-		pushResourceScope = pushResourceScopeBak
-	}()
-
-	sidecar := &model.Proxy{Type: model.SidecarProxy, IPAddresses: []string{"127.0.0.1"}}
+	sidecar := &model.Proxy{Type: model.SidecarProxy, IPAddresses: []string{"127.0.0.1"}, Metadata: &model.NodeMetadata{}, SidecarScope: &model.SidecarScope{}}
 	gateway := &model.Proxy{Type: model.Router}
+
+	sidecar.SidecarScope.AddConfigDependencies(model.ServiceEntryKind, svcName)
+	sidecar.SidecarScope.AddConfigDependencies(model.VirtualServiceKind, vsName)
+	sidecar.SidecarScope.AddConfigDependencies(model.DestinationRuleKind, drName)
+
 	cases := []struct {
 		name       string
 		proxy      *model.Proxy

--- a/pilot/pkg/proxy/envoy/v2/ads_test.go
+++ b/pilot/pkg/proxy/envoy/v2/ads_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
+
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	v2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
@@ -164,6 +165,7 @@ func TestAdsClusterUpdate(t *testing.T) {
 	sendEDSReqAndVerify(cluster2)
 }
 
+// nolint: lll
 func TestAdsPushScoping(t *testing.T) {
 	server, tearDown := initLocalPilotTestEnv(t)
 	defer tearDown()
@@ -245,6 +247,48 @@ func TestAdsPushScoping(t *testing.T) {
 		}})
 	}
 
+	addVirtualService := func(i int, hosts ...string) {
+		if _, err := server.EnvoyXdsServer.MemConfigController.Create(model.Config{
+			ConfigMeta: model.ConfigMeta{
+				Type:    model.VirtualServiceKind.Kind,
+				Version: model.VirtualServiceKind.Version,
+				Group:   model.VirtualServiceKind.Group,
+				Name:    fmt.Sprintf("vs%d", i), Namespace: model.IstioDefaultConfigNamespace},
+			Spec: &networking.VirtualService{
+				Hosts: hosts,
+				Http: []*networking.HTTPRoute{{Redirect: &networking.HTTPRedirect{
+					Uri:          "example.org",
+					Authority:    "some-authority.default.svc.cluster.local",
+					RedirectCode: 308,
+				}}},
+				ExportTo: nil,
+			},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	removeVirtualService := func(i int) {
+		server.EnvoyXdsServer.MemConfigController.Delete(model.VirtualServiceKind, fmt.Sprintf("vs%d", i), model.IstioDefaultConfigNamespace)
+	}
+	addDestinationRule := func(i int, host string) {
+		if _, err := server.EnvoyXdsServer.MemConfigController.Create(model.Config{
+			ConfigMeta: model.ConfigMeta{
+				Type:    model.DestinationRuleKind.Kind,
+				Version: model.DestinationRuleKind.Version,
+				Group:   model.DestinationRuleKind.Group,
+				Name:    fmt.Sprintf("dr%d", i), Namespace: model.IstioDefaultConfigNamespace},
+			Spec: &networking.DestinationRule{
+				Host:     host,
+				ExportTo: nil,
+			},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	removeDestinationRule := func(i int) {
+		server.EnvoyXdsServer.MemConfigController.Delete(model.DestinationRuleKind, fmt.Sprintf("dr%d", i), model.IstioDefaultConfigNamespace)
+	}
+
 	sc := &networking.Sidecar{
 		Egress: []*networking.IstioEgressListener{
 			{
@@ -267,31 +311,42 @@ func TestAdsPushScoping(t *testing.T) {
 
 	adscConn := adsConnectAndWait(t, 0x0a0a0a0a)
 	defer adscConn.Close()
-
 	type svcCase struct {
+		desc string
+
 		ev          model.Event
-		indexes     []int
-		names       []string
+		svcIndexes  []int
+		svcNames    []string
+		ns          string
 		instIndexes []struct {
 			name    string
 			indexes []int
 		}
-		ns string
+		vsIndexes []struct {
+			index int
+			hosts []string
+		}
+		drIndexes []struct {
+			index int
+			host  string
+		}
+
+		timeout time.Duration
 
 		expectUpdates   []string
 		unexpectUpdates []string
 	}
 	svcCases := []svcCase{
-		// Add a scoped service.
 		{
+			desc:          "Add a scoped service",
 			ev:            model.EventAdd,
-			indexes:       []int{4},
+			svcIndexes:    []int{4},
 			ns:            model.IstioDefaultConfigNamespace,
 			expectUpdates: []string{"lds"},
 		}, // then: default 1,2,3,4
-		// Add instances to a scoped service.
 		{
-			ev: model.EventAdd,
+			desc: "Add instances to a scoped service",
+			ev:   model.EventAdd,
 			instIndexes: []struct {
 				name    string
 				indexes []int
@@ -299,55 +354,136 @@ func TestAdsPushScoping(t *testing.T) {
 			ns:            model.IstioDefaultConfigNamespace,
 			expectUpdates: []string{"eds"},
 		}, // then: default 1,2,3,4
-		// Add a unscoped(name not match) service.
 		{
+			desc: "Add virtual service to a scoped service",
+			ev:   model.EventAdd,
+			vsIndexes: []struct {
+				index int
+				hosts []string
+			}{{4, []string{fmt.Sprintf("svc%d%s", 4, svcSuffix)}}},
+			expectUpdates: []string{"lds"},
+		},
+		{
+			desc: "Delete virtual service of a scoped service",
+			ev:   model.EventDelete,
+			vsIndexes: []struct {
+				index int
+				hosts []string
+			}{{index: 4}},
+			expectUpdates: []string{"lds"},
+		},
+		{
+			desc: "Add destination rule to a scoped service",
+			ev:   model.EventAdd,
+			drIndexes: []struct {
+				index int
+				host  string
+			}{{4, fmt.Sprintf("svc%d%s", 4, svcSuffix)}},
+			expectUpdates: []string{"cds"},
+		},
+		{
+			desc: "Delete destination rule of a scoped service",
+			ev:   model.EventDelete,
+			drIndexes: []struct {
+				index int
+				host  string
+			}{{index: 4}},
+			expectUpdates: []string{"cds"},
+		},
+		{
+			desc:            "Add a unscoped(name not match) service",
 			ev:              model.EventAdd,
-			names:           []string{"foo.com"},
+			svcNames:        []string{"foo.com"},
 			ns:              model.IstioDefaultConfigNamespace,
-			unexpectUpdates: []string{"lds"},
+			unexpectUpdates: []string{"cds"},
+			timeout:         time.Second,
 		}, // then: default 1,2,3,4, foo.com; ns1: 11
-		// Add instances to an unscoped service.
 		{
-			ev: model.EventAdd,
+			desc: "Add instances to an unscoped service",
+			ev:   model.EventAdd,
 			instIndexes: []struct {
 				name    string
 				indexes []int
 			}{{"foo.com", []int{1, 2}}},
 			ns:              model.IstioDefaultConfigNamespace,
 			unexpectUpdates: []string{"eds"},
+			timeout:         time.Second,
 		}, // then: default 1,2,3,4
-		// Add a unscoped(ns not match) service.
 		{
+			desc:            "Add a unscoped(ns not match) service",
 			ev:              model.EventAdd,
-			indexes:         []int{11},
+			svcIndexes:      []int{11},
 			ns:              ns1,
-			unexpectUpdates: []string{"lds"},
+			unexpectUpdates: []string{"cds"},
+			timeout:         time.Second,
 		}, // then: default 1,2,3,4, foo.com; ns1: 11
-		// Remove a scoped service.
 		{
+			desc: "Add virtual service to an unscoped service",
+			ev:   model.EventAdd,
+			vsIndexes: []struct {
+				index int
+				hosts []string
+			}{{0, []string{"foo.com"}}},
+			unexpectUpdates: []string{"cds"},
+			timeout:         time.Second,
+		},
+		{
+			desc: "Delete virtual service of a unscoped service",
+			ev:   model.EventDelete,
+			vsIndexes: []struct {
+				index int
+				hosts []string
+			}{{index: 0}},
+			unexpectUpdates: []string{"cds"},
+			timeout:         time.Second,
+		},
+		{
+			desc: "Add destination rule to an unscoped service",
+			ev:   model.EventAdd,
+			drIndexes: []struct {
+				index int
+				host  string
+			}{{0, "foo.com"}},
+			unexpectUpdates: []string{"cds"},
+			timeout:         time.Second,
+		},
+		{
+			desc: "Delete destination rule of a unscoped service",
+			ev:   model.EventDelete,
+			drIndexes: []struct {
+				index int
+				host  string
+			}{{index: 0}},
+			unexpectUpdates: []string{"cds"},
+			timeout:         time.Second,
+		},
+		{
+			desc:          "Remove a scoped service",
 			ev:            model.EventDelete,
-			indexes:       []int{4},
+			svcIndexes:    []int{4},
 			ns:            model.IstioDefaultConfigNamespace,
 			expectUpdates: []string{"lds"},
 		}, // then: default 1,2,3, foo.com; ns: 11
-		// Remove a unscoped(name not match) service.
 		{
+			desc:            "Remove a unscoped(name not match) service",
 			ev:              model.EventDelete,
-			names:           []string{"foo.com"},
+			svcNames:        []string{"foo.com"},
 			ns:              model.IstioDefaultConfigNamespace,
-			unexpectUpdates: []string{"lds"},
+			unexpectUpdates: []string{"cds"},
+			timeout:         time.Second,
 		}, // then: default 1,2,3; ns1: 11
-		// Remove a unscoped(ns not match) service.
 		{
+			desc:            "Remove a unscoped(ns not match) service",
 			ev:              model.EventDelete,
-			indexes:         []int{11},
+			svcIndexes:      []int{11},
 			ns:              ns1,
-			unexpectUpdates: []string{"lds"},
+			unexpectUpdates: []string{"cds"},
+			timeout:         time.Second,
 		}, // then: default 1,2,3
 	}
 
 	for i, c := range svcCases {
-		fmt.Printf("begin %d case %v\n", i, c)
+		fmt.Printf("begin %d case(%s) %v\n", i, c.desc, c)
 
 		var wantUpdates []string
 		wantUpdates = append(wantUpdates, c.expectUpdates...)
@@ -355,30 +491,54 @@ func TestAdsPushScoping(t *testing.T) {
 
 		switch c.ev {
 		case model.EventAdd:
-			if len(c.indexes) > 0 {
-				addService(c.ns, c.indexes...)
+			if len(c.svcIndexes) > 0 {
+				addService(c.ns, c.svcIndexes...)
 			}
-			if len(c.names) > 0 {
-				addServiceByNames(c.ns, c.names...)
+			if len(c.svcNames) > 0 {
+				addServiceByNames(c.ns, c.svcNames...)
 			}
 			if len(c.instIndexes) > 0 {
 				for _, instIndex := range c.instIndexes {
 					addServiceInstance(host.Name(instIndex.name), instIndex.indexes...)
 				}
 			}
-		case model.EventDelete:
-			if len(c.indexes) > 0 {
-				removeService(c.ns, c.indexes...)
+			if len(c.vsIndexes) > 0 {
+				for _, vsIndex := range c.vsIndexes {
+					addVirtualService(vsIndex.index, vsIndex.hosts...)
+				}
 			}
-			if len(c.names) > 0 {
-				removeServiceByNames(c.ns, c.names...)
+			if len(c.drIndexes) > 0 {
+				for _, drIndex := range c.drIndexes {
+					addDestinationRule(drIndex.index, drIndex.host)
+				}
+			}
+		case model.EventDelete:
+			if len(c.svcIndexes) > 0 {
+				removeService(c.ns, c.svcIndexes...)
+			}
+			if len(c.svcNames) > 0 {
+				removeServiceByNames(c.ns, c.svcNames...)
+			}
+			if len(c.vsIndexes) > 0 {
+				for _, vsIndex := range c.vsIndexes {
+					removeVirtualService(vsIndex.index)
+				}
+			}
+			if len(c.drIndexes) > 0 {
+				for _, drIndex := range c.drIndexes {
+					removeDestinationRule(drIndex.index)
+				}
 			}
 		default:
 			t.Fatalf("wrong event for case %v", c)
 		}
 
 		time.Sleep(200 * time.Millisecond)
-		upd, _ := adscConn.Wait(5*time.Second, wantUpdates...) // XXX slow for unexpect ...
+		timeout := 5 * time.Second
+		if c.timeout > 0 {
+			timeout = c.timeout
+		}
+		upd, _ := adscConn.Wait(timeout, wantUpdates...) // XXX slow for unexpect ...
 		for _, expect := range c.expectUpdates {
 			if !contains(upd, expect) {
 				t.Fatalf("expect %s but not contains (%v) for case %v", expect, upd, c)

--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -84,6 +84,9 @@ type DiscoveryServer struct {
 	// MemRegistry is used for debug and load testing, allow adding services. Visible for testing.
 	MemRegistry *MemServiceDiscovery
 
+	// MemRegistry is used for debug and load testing, allow adding services. Visible for testing.
+	MemConfigController model.ConfigStoreCache
+
 	// ConfigGenerator is responsible for generating data plane configuration using Istio networking
 	// APIs and service registry info
 	ConfigGenerator core.ConfigGenerator

--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -374,12 +374,12 @@ func doSendPushes(stopCh <-chan struct{}, semaphore chan struct{}, queue *PushQu
 
 			go func() {
 				pushEv := &XdsEvent{
-					full:              info.Full,
-					push:              info.Push,
-					done:              doneFunc,
-					start:             info.Start,
-					configsUpdated:    info.ConfigsUpdated,
-					noncePrefix:       info.Push.Version,
+					full:           info.Full,
+					push:           info.Push,
+					done:           doneFunc,
+					start:          info.Start,
+					configsUpdated: info.ConfigsUpdated,
+					noncePrefix:    info.Push.Version,
 				}
 
 				select {

--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -378,7 +378,6 @@ func doSendPushes(stopCh <-chan struct{}, semaphore chan struct{}, queue *PushQu
 					push:              info.Push,
 					done:              doneFunc,
 					start:             info.Start,
-					namespacesUpdated: info.NamespacesUpdated,
 					configsUpdated:    info.ConfigsUpdated,
 					noncePrefix:       info.Push.Version,
 				}

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -268,9 +268,7 @@ func (s *DiscoveryServer) edsUpdate(clusterID, serviceName string, namespace str
 	// It is done in DiscoveryServer.Push --> AdsPushAll
 	if !internal {
 		var edsUpdates map[string]struct{}
-		if !requireFull {
-			edsUpdates = map[string]struct{}{serviceName: {}}
-		}
+		edsUpdates = map[string]struct{}{serviceName: {}}
 
 		s.ConfigUpdate(&model.PushRequest{
 			Full:              requireFull,

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -207,9 +207,8 @@ func (s *DiscoveryServer) edsUpdate(clusterID, serviceName string, namespace str
 			s.deleteEndpointShards(clusterID, serviceName, namespace)
 			adsLog.Infof("Incremental push, service %s has no endpoints", serviceName)
 			s.ConfigUpdate(&model.PushRequest{
-				Full:              false,
-				NamespacesUpdated: map[string]struct{}{namespace: {}},
-				ConfigsUpdated: map[model.ConfigKey]struct{}{model.ConfigKey{
+				Full: false,
+				ConfigsUpdated: map[model.ConfigKey]struct{}{{
 					Kind:      model.ServiceEntryKind,
 					Name:      serviceName,
 					Namespace: namespace,
@@ -269,9 +268,8 @@ func (s *DiscoveryServer) edsUpdate(clusterID, serviceName string, namespace str
 	// It is done in DiscoveryServer.Push --> AdsPushAll
 	if !internal {
 		s.ConfigUpdate(&model.PushRequest{
-			Full:              requireFull,
-			NamespacesUpdated: map[string]struct{}{namespace: {}},
-			ConfigsUpdated: map[model.ConfigKey]struct{}{model.ConfigKey{
+			Full: requireFull,
+			ConfigsUpdated: map[model.ConfigKey]struct{}{{
 				Kind:      model.ServiceEntryKind,
 				Name:      serviceName,
 				Namespace: namespace,

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -267,8 +267,7 @@ func (s *DiscoveryServer) edsUpdate(clusterID, serviceName string, namespace str
 	// no need to trigger push here.
 	// It is done in DiscoveryServer.Push --> AdsPushAll
 	if !internal {
-		var edsUpdates map[string]struct{}
-		edsUpdates = map[string]struct{}{serviceName: {}}
+		edsUpdates := map[string]struct{}{serviceName: {}}
 
 		s.ConfigUpdate(&model.PushRequest{
 			Full:              requireFull,

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -36,7 +36,6 @@ import (
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/protocol"
-	"istio.io/istio/pkg/config/schema/resource"
 )
 
 // EDS returns the list of endpoints (IP:port and in future labels) associated with a real
@@ -171,7 +170,7 @@ func (s *DiscoveryServer) SvcUpdate(cluster, hostname string, namespace string, 
 // Only clusters that changed are updated/pushed.
 func (s *DiscoveryServer) edsIncremental(version string, req *model.PushRequest) {
 	adsLog.Infof("XDS:EDSInc Pushing:%s Services:%v ConnectedEndpoints:%d",
-		version, req.ConfigsUpdated[model.ServiceEntryKind], s.adsClientCount())
+		version, model.ConfigNamesOfKind(req.ConfigsUpdated, model.ServiceEntryKind), s.adsClientCount())
 	s.startPush(req)
 }
 
@@ -210,9 +209,11 @@ func (s *DiscoveryServer) edsUpdate(clusterID, serviceName string, namespace str
 			s.ConfigUpdate(&model.PushRequest{
 				Full:              false,
 				NamespacesUpdated: map[string]struct{}{namespace: {}},
-				ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{
-					model.ServiceEntryKind: {serviceName: {}},
-				},
+				ConfigsUpdated: map[model.ConfigKey]struct{}{model.ConfigKey{
+					Kind:      model.ServiceEntryKind,
+					Name:      serviceName,
+					Namespace: namespace,
+				}: {}},
 				Reason: []model.TriggerReason{model.EndpointUpdate},
 			})
 		}
@@ -267,14 +268,14 @@ func (s *DiscoveryServer) edsUpdate(clusterID, serviceName string, namespace str
 	// no need to trigger push here.
 	// It is done in DiscoveryServer.Push --> AdsPushAll
 	if !internal {
-		edsUpdates := map[string]struct{}{serviceName: {}}
-
 		s.ConfigUpdate(&model.PushRequest{
 			Full:              requireFull,
 			NamespacesUpdated: map[string]struct{}{namespace: {}},
-			ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{
-				model.ServiceEntryKind: edsUpdates,
-			},
+			ConfigsUpdated: map[model.ConfigKey]struct{}{model.ConfigKey{
+				Kind:      model.ServiceEntryKind,
+				Name:      serviceName,
+				Namespace: namespace,
+			}: {}},
 			Reason: []model.TriggerReason{model.EndpointUpdate},
 		})
 	}

--- a/pilot/pkg/proxy/envoy/v2/eds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_test.go
@@ -39,7 +39,6 @@ import (
 	"istio.io/istio/pkg/adsc"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
-	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/tests/util"
 )
@@ -388,10 +387,11 @@ func testOverlappingPorts(server *bootstrap.Server, adsc *adsc.ADSC, t *testing.
 
 	server.EnvoyXdsServer.Push(&model.PushRequest{
 		Full: true,
-		ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{
-			model.ServiceEntryKind: {
-				"overlapping.cluster.local": {},
-			}}})
+		ConfigsUpdated: map[model.ConfigKey]struct{}{model.ConfigKey{
+			Kind:      model.ServiceEntryKind,
+			Name:      "overlapping.cluster.local",
+			Namespace: "",
+		}: {}}})
 	_, _ = adsc.Wait(5 * time.Second)
 
 	// After the incremental push, we should still see the endpoint
@@ -657,14 +657,12 @@ func multipleRequest(server *bootstrap.Server, inc bool, nclients,
 	for j := 0; j < nPushes; j++ {
 		if inc {
 			// This will be throttled - we want to trigger a single push
-			updates := map[string]struct{}{
-				edsIncSvc: {},
-			}
 			server.EnvoyXdsServer.AdsPushAll(strconv.Itoa(j), &model.PushRequest{
 				Full: false,
-				ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{
-					model.ServiceEntryKind: updates,
-				},
+				ConfigsUpdated: map[model.ConfigKey]struct{}{model.ConfigKey{
+					Kind: model.ServiceEntryKind,
+					Name: edsIncSvc,
+				}: {}},
 				Push: server.EnvoyXdsServer.Env.PushContext,
 			})
 		} else {

--- a/pilot/pkg/proxy/envoy/v2/eds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_test.go
@@ -387,7 +387,7 @@ func testOverlappingPorts(server *bootstrap.Server, adsc *adsc.ADSC, t *testing.
 
 	server.EnvoyXdsServer.Push(&model.PushRequest{
 		Full: true,
-		ConfigsUpdated: map[model.ConfigKey]struct{}{model.ConfigKey{
+		ConfigsUpdated: map[model.ConfigKey]struct{}{{
 			Kind:      model.ServiceEntryKind,
 			Name:      "overlapping.cluster.local",
 			Namespace: "",
@@ -659,7 +659,7 @@ func multipleRequest(server *bootstrap.Server, inc bool, nclients,
 			// This will be throttled - we want to trigger a single push
 			server.EnvoyXdsServer.AdsPushAll(strconv.Itoa(j), &model.PushRequest{
 				Full: false,
-				ConfigsUpdated: map[model.ConfigKey]struct{}{model.ConfigKey{
+				ConfigsUpdated: map[model.ConfigKey]struct{}{{
 					Kind: model.ServiceEntryKind,
 					Name: edsIncSvc,
 				}: {}},

--- a/pilot/pkg/proxy/envoy/v2/eds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_test.go
@@ -388,9 +388,8 @@ func testOverlappingPorts(server *bootstrap.Server, adsc *adsc.ADSC, t *testing.
 	server.EnvoyXdsServer.Push(&model.PushRequest{
 		Full: true,
 		ConfigsUpdated: map[model.ConfigKey]struct{}{{
-			Kind:      model.ServiceEntryKind,
-			Name:      "overlapping.cluster.local",
-			Namespace: "",
+			Kind: model.ServiceEntryKind,
+			Name: "overlapping.cluster.local",
 		}: {}}})
 	_, _ = adsc.Wait(5 * time.Second)
 

--- a/pilot/pkg/proxy/envoy/v2/pushqueue_test.go
+++ b/pilot/pkg/proxy/envoy/v2/pushqueue_test.go
@@ -143,7 +143,7 @@ func TestProxyQueue(t *testing.T) {
 		firstTime := time.Now()
 		p.Enqueue(proxies[0], &model.PushRequest{
 			Full: false,
-			ConfigsUpdated: map[model.ConfigKey]struct{}{model.ConfigKey{
+			ConfigsUpdated: map[model.ConfigKey]struct{}{{
 				Kind:      model.ServiceEntryKind,
 				Name:      "foo",
 				Namespace: "",
@@ -153,7 +153,7 @@ func TestProxyQueue(t *testing.T) {
 
 		p.Enqueue(proxies[0], &model.PushRequest{
 			Full: false,
-			ConfigsUpdated: map[model.ConfigKey]struct{}{model.ConfigKey{
+			ConfigsUpdated: map[model.ConfigKey]struct{}{{
 				Kind:      model.ServiceEntryKind,
 				Name:      "bar",
 				Namespace: "ns1",
@@ -227,7 +227,7 @@ func TestProxyQueue(t *testing.T) {
 			for eds := 0; eds < 100; eds++ {
 				for _, pr := range proxies {
 					p.Enqueue(pr, &model.PushRequest{
-						ConfigsUpdated: map[model.ConfigKey]struct{}{model.ConfigKey{
+						ConfigsUpdated: map[model.ConfigKey]struct{}{{
 							Kind: model.ServiceEntryKind,
 							Name: fmt.Sprintf("%d", eds),
 						}: {}}})

--- a/pilot/pkg/proxy/envoy/v2/pushqueue_test.go
+++ b/pilot/pkg/proxy/envoy/v2/pushqueue_test.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pkg/config/schema/resource"
 )
 
 // Helper function to remove an item or timeout and return nil if there are no pending pushes
@@ -144,17 +143,21 @@ func TestProxyQueue(t *testing.T) {
 		firstTime := time.Now()
 		p.Enqueue(proxies[0], &model.PushRequest{
 			Full: false,
-			ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{
-				model.ServiceEntryKind: {"foo": {}},
-			},
+			ConfigsUpdated: map[model.ConfigKey]struct{}{model.ConfigKey{
+				Kind:      model.ServiceEntryKind,
+				Name:      "foo",
+				Namespace: "",
+			}: {}},
 			Start: firstTime,
 		})
 
 		p.Enqueue(proxies[0], &model.PushRequest{
 			Full: false,
-			ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{
-				model.ServiceEntryKind: {"bar": {}},
-			},
+			ConfigsUpdated: map[model.ConfigKey]struct{}{model.ConfigKey{
+				Kind:      model.ServiceEntryKind,
+				Name:      "bar",
+				Namespace: "ns1",
+			}: {}},
 			Start: firstTime.Add(time.Second),
 		})
 		_, info := p.Dequeue()
@@ -162,9 +165,17 @@ func TestProxyQueue(t *testing.T) {
 		if info.Start != firstTime {
 			t.Errorf("Expected start time to be %v, got %v", firstTime, info.Start)
 		}
-		expectedEds := map[string]struct{}{"foo": {}, "bar": {}}
-		if !reflect.DeepEqual(info.ConfigsUpdated[model.ServiceEntryKind], expectedEds) {
-			t.Errorf("Expected EdsUpdates to be %v, got %v", expectedEds, info.ConfigsUpdated[model.ServiceEntryKind])
+		expectedEds := map[model.ConfigKey]struct{}{{
+			Kind:      model.ServiceEntryKind,
+			Name:      "foo",
+			Namespace: "",
+		}: {}, {
+			Kind:      model.ServiceEntryKind,
+			Name:      "bar",
+			Namespace: "ns1",
+		}: {}}
+		if !reflect.DeepEqual(model.ConfigsOfKind(info.ConfigsUpdated, model.ServiceEntryKind), expectedEds) {
+			t.Errorf("Expected EdsUpdates to be %v, got %v", expectedEds, model.ConfigsOfKind(info.ConfigsUpdated, model.ServiceEntryKind))
 		}
 		if info.Full != false {
 			t.Errorf("Expected full to be false, got true")
@@ -216,9 +227,10 @@ func TestProxyQueue(t *testing.T) {
 			for eds := 0; eds < 100; eds++ {
 				for _, pr := range proxies {
 					p.Enqueue(pr, &model.PushRequest{
-						ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{
-							model.ServiceEntryKind: {fmt.Sprintf("%d", eds): {}},
-						}})
+						ConfigsUpdated: map[model.ConfigKey]struct{}{model.ConfigKey{
+							Kind: model.ServiceEntryKind,
+							Name: fmt.Sprintf("%d", eds),
+						}: {}}})
 				}
 			}
 		}()
@@ -228,7 +240,7 @@ func TestProxyQueue(t *testing.T) {
 		go func() {
 			for {
 				con, info := p.Dequeue()
-				for eds := range info.ConfigsUpdated[model.ServiceEntryKind] {
+				for eds := range model.ConfigNamesOfKind(info.ConfigsUpdated, model.ServiceEntryKind) {
 					mu.Lock()
 					delete(expected, key(con, eds))
 					mu.Unlock()

--- a/pilot/pkg/proxy/envoy/v2/pushqueue_test.go
+++ b/pilot/pkg/proxy/envoy/v2/pushqueue_test.go
@@ -144,9 +144,8 @@ func TestProxyQueue(t *testing.T) {
 		p.Enqueue(proxies[0], &model.PushRequest{
 			Full: false,
 			ConfigsUpdated: map[model.ConfigKey]struct{}{{
-				Kind:      model.ServiceEntryKind,
-				Name:      "foo",
-				Namespace: "",
+				Kind: model.ServiceEntryKind,
+				Name: "foo",
 			}: {}},
 			Start: firstTime,
 		})

--- a/pilot/pkg/serviceregistry/external/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/external/servicediscovery.go
@@ -168,7 +168,6 @@ func getServiceEntryHandler(c *ServiceEntryStore) func(model.Config, model.Confi
 		if fp {
 			pushReq := &model.PushRequest{
 				Full:              true,
-				NamespacesUpdated: map[string]struct{}{curr.Namespace: {}},
 				ConfigsUpdated:    map[model.ConfigKey]struct{}{},
 				Reason:            []model.TriggerReason{model.ServiceUpdate},
 			}

--- a/pilot/pkg/serviceregistry/external/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/external/servicediscovery.go
@@ -27,7 +27,6 @@ import (
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/schema/collections"
-	"istio.io/istio/pkg/config/schema/resource"
 )
 
 // TODO: move this out of 'external' package. Either 'serviceentry' package or
@@ -170,7 +169,7 @@ func getServiceEntryHandler(c *ServiceEntryStore) func(model.Config, model.Confi
 			pushReq := &model.PushRequest{
 				Full:              true,
 				NamespacesUpdated: map[string]struct{}{curr.Namespace: {}},
-				ConfigsUpdated:    map[resource.GroupVersionKind]map[string]struct{}{serviceEntryKind: {}},
+				ConfigsUpdated:    map[model.ConfigKey]struct{}{},
 				Reason:            []model.TriggerReason{model.ServiceUpdate},
 			}
 			c.XdsUpdater.ConfigUpdate(pushReq)

--- a/pilot/pkg/serviceregistry/external/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/external/servicediscovery.go
@@ -138,6 +138,8 @@ func getWorkloadEntryHandler(c *ServiceEntryStore) func(model.Config, model.Conf
 // getServiceEntryHandler defines the handler for service entries
 func getServiceEntryHandler(c *ServiceEntryStore) func(model.Config, model.Config, model.Event) {
 	return func(old, curr model.Config, event model.Event) {
+		// TODO(yonka): Apply full-push scoping to external ServiceEntryStore.
+
 		cs := convertServices(curr)
 
 		// If it is add/delete event we should always do a full push. If it is update event, we should do full push,
@@ -167,9 +169,9 @@ func getServiceEntryHandler(c *ServiceEntryStore) func(model.Config, model.Confi
 
 		if fp {
 			pushReq := &model.PushRequest{
-				Full:              true,
-				ConfigsUpdated:    map[model.ConfigKey]struct{}{},
-				Reason:            []model.TriggerReason{model.ServiceUpdate},
+				Full:           true,
+				ConfigsUpdated: map[model.ConfigKey]struct{}{},
+				Reason:         []model.TriggerReason{model.ServiceUpdate},
 			}
 			c.XdsUpdater.ConfigUpdate(pushReq)
 		} else {

--- a/pilot/pkg/serviceregistry/external/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/external/servicediscovery_test.go
@@ -16,6 +16,7 @@ package external
 
 import (
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 	"testing"
@@ -63,6 +64,7 @@ type Event struct {
 	host      string
 	namespace string
 	endpoints int
+	pushReq   *model.PushRequest
 }
 
 type FakeXdsUpdater struct {
@@ -75,8 +77,8 @@ func (fx *FakeXdsUpdater) EDSUpdate(_, hostname string, namespace string, entry 
 	return nil
 }
 
-func (fx *FakeXdsUpdater) ConfigUpdate(_ *model.PushRequest) {
-	fx.Events <- Event{kind: "xds"}
+func (fx *FakeXdsUpdater) ConfigUpdate(req *model.PushRequest) {
+	fx.Events <- Event{kind: "xds", pushReq: req}
 }
 
 func (fx *FakeXdsUpdater) ProxyUpdate(_, _ string) {
@@ -231,7 +233,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 		createConfigs([]*model.Config{httpStatic}, store, t)
 		instances := baseInstances
 		expectServiceInstances(t, sd, httpStatic, 0, instances)
-		expectEvents(t, events, Event{kind: "xds"})
+		expectEvents(t, events, Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.ConfigKey]struct{}{{Kind: serviceEntryKind, Name: httpStatic.Spec.(*networking.ServiceEntry).Hosts[0], Namespace: httpStatic.Namespace}: {}}}})
 	})
 
 	t.Run("add entry", func(t *testing.T) {
@@ -240,7 +242,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 		instances := append(baseInstances,
 			makeInstance(httpStaticOverlay, "5.5.5.5", 4567, httpStaticOverlay.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"overlay": "bar"}, PlainText))
 		expectServiceInstances(t, sd, httpStatic, 0, instances)
-		expectEvents(t, events, Event{kind: "xds"})
+		expectEvents(t, events, Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.ConfigKey]struct{}{{Kind: serviceEntryKind, Name: httpStaticOverlay.Spec.(*networking.ServiceEntry).Hosts[0], Namespace: httpStaticOverlay.Namespace}: {}}}})
 	})
 
 	t.Run("add endpoint", func(t *testing.T) {
@@ -307,7 +309,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 		// This lookup is per-namespace, so we should only see the objects in the same namespace
 		expectServiceInstances(t, sd, httpStaticOverlayUpdatedNs, 0, instances)
 		// Expect a full push, as the Service has changed
-		expectEvents(t, events, Event{kind: "xds"})
+		expectEvents(t, events, Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.ConfigKey]struct{}{{Kind: serviceEntryKind, Name: httpStaticOverlayUpdatedNs.Spec.(*networking.ServiceEntry).Hosts[0], Namespace: httpStaticOverlayUpdatedNs.Namespace}: {}}}})
 	})
 
 	t.Run("delete entry", func(t *testing.T) {
@@ -323,7 +325,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 		// svc update is only triggered on deletion. Also expect a full push as the service has changed
 		expectEvents(t, events,
 			Event{kind: "svcupdate", host: "*.google.com", namespace: httpStaticOverlay.Namespace},
-			Event{kind: "xds"})
+			Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.ConfigKey]struct{}{{Kind: serviceEntryKind, Name: "*.google.com", Namespace: httpStaticOverlayUpdated.Namespace}: {}}}})
 
 		// Add back the ServiceEntry, expect these instances to get added
 		createConfigs([]*model.Config{httpStaticOverlayUpdated}, store, t)
@@ -332,7 +334,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 			makeInstance(httpStaticOverlay, "6.6.6.6", 4567, httpStaticOverlay.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"other": "bar"}, PlainText))
 		expectServiceInstances(t, sd, httpStatic, 0, instances)
 		// Service change, so we need a full push
-		expectEvents(t, events, Event{kind: "xds"})
+		expectEvents(t, events, Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.ConfigKey]struct{}{{Kind: serviceEntryKind, Name: "*.google.com", Namespace: httpStaticOverlayUpdated.Namespace}: {}}}})
 	})
 
 	t.Run("change host", func(t *testing.T) {
@@ -360,7 +362,45 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 		}
 		expectServiceInstances(t, sd, httpStaticHost, 0, instances, instances2)
 		// Service change, so we need a full push
-		expectEvents(t, events, Event{kind: "xds"})
+		expectEvents(t, events, Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.ConfigKey]struct{}{{Kind: serviceEntryKind, Name: "other.com", Namespace: httpStaticOverlayUpdated.Namespace}: {}}}}) // service added
+
+		// restore this config and remove the added host.
+		createConfigs([]*model.Config{httpStaticOverlayUpdated}, store, t)
+		expectEvents(t, events, Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.ConfigKey]struct{}{{Kind: serviceEntryKind, Name: "other.com", Namespace: httpStaticOverlayUpdated.Namespace}: {}}}}) // service deleted
+	})
+
+	t.Run("change workload selector", func(t *testing.T) {
+		// same as selector but with an additional host
+		selector1 := func() *model.Config {
+			c := httpStaticOverlay.DeepCopy()
+			se := c.Spec.(*networking.ServiceEntry)
+			se.Hosts = append(se.Hosts, "selector1.com")
+			se.Endpoints = nil
+			se.WorkloadSelector = &networking.WorkloadSelector{
+				Labels: map[string]string{"app": "wle"},
+			}
+			return &c
+		}()
+		createConfigs([]*model.Config{selector1}, store, t)
+		// Service change, so we need a full push
+		expectEvents(t, events, Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.ConfigKey]struct{}{
+			{Kind: serviceEntryKind, Name: "*.google.com", Namespace: selector1.Namespace}:  {},
+			{Kind: serviceEntryKind, Name: "selector1.com", Namespace: selector1.Namespace}: {},
+		}}}) // service added
+
+		selector1Updated := func() *model.Config {
+			c := selector1.DeepCopy()
+			se := c.Spec.(*networking.ServiceEntry)
+			se.WorkloadSelector = &networking.WorkloadSelector{
+				Labels: map[string]string{"app": "wle1"},
+			}
+			return &c
+		}()
+		createConfigs([]*model.Config{selector1Updated}, store, t)
+		expectEvents(t, events, Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.ConfigKey]struct{}{
+			{Kind: serviceEntryKind, Name: "*.google.com", Namespace: selector1.Namespace}:  {},
+			{Kind: serviceEntryKind, Name: "selector1.com", Namespace: selector1.Namespace}: {},
+		}}}) // service updated
 	})
 }
 
@@ -465,11 +505,52 @@ func expectProxyInstances(t *testing.T, sd *ServiceEntryStore, expected []*model
 	}, retry.Converge(2), retry.Timeout(time.Second*5))
 }
 
-func expectEvents(t *testing.T, ch chan Event, events ...Event) {
+func validateEvents(t *testing.T, ch chan Event, validator func(expect Event, got Event) bool, events ...Event) {
 	t.Helper()
 	for _, event := range events {
 		got := waitForEvent(t, ch)
-		if got != event {
+		if !validator(event, got) {
+			t.Fatalf("expected event %+v, got %+v", event, got)
+		}
+	}
+	// Drain events
+	for {
+		select {
+		case e := <-ch:
+			log.Warnf("ignoring event %+v", e)
+			if len(events) == 0 {
+				t.Fatalf("got unexpected event %+v", e)
+			}
+		default:
+			return
+		}
+	}
+}
+
+func expectEvents(t *testing.T, ch chan Event, events ...Event) {
+	cmpPushRequest := func(expectReq, gotReq *model.PushRequest) bool {
+		var expectConfigs, gotConfigs map[model.ConfigKey]struct{}
+		if expectReq != nil {
+			expectConfigs = expectReq.ConfigsUpdated
+		}
+		if gotReq != nil {
+			gotConfigs = gotReq.ConfigsUpdated
+		}
+
+		return reflect.DeepEqual(expectConfigs, gotConfigs)
+	}
+
+	t.Helper()
+	for _, event := range events {
+		got := waitForEvent(t, ch)
+		if event.pushReq != nil {
+			if !cmpPushRequest(event.pushReq, got.pushReq) {
+				t.Fatalf("expected event %+v %+v, got %+v %+v", event, event.pushReq, got, got.pushReq)
+			}
+		}
+
+		event.pushReq, got.pushReq = nil, nil
+		if event != got {
 			t.Fatalf("expected event %+v, got %+v", event, got)
 		}
 	}
@@ -587,8 +668,8 @@ func TestNonServiceConfig(t *testing.T) {
 	})
 }
 
-func TestServicesChanged(t *testing.T) {
-
+// nolint: lll
+func TestServicesDiff(t *testing.T) {
 	var updatedHTTPDNS = &model.Config{
 		ConfigMeta: model.ConfigMeta{
 			Type:              collections.IstioNetworkingV1Alpha3Serviceentries.Resource().Kind(),
@@ -624,130 +705,132 @@ func TestServicesChanged(t *testing.T) {
 		},
 	}
 
-	var updatedHTTPDNSPort = &model.Config{
-		ConfigMeta: model.ConfigMeta{
-			Type:              collections.IstioNetworkingV1Alpha3Serviceentries.Resource().Kind(),
-			Name:              "httpDNS",
-			Namespace:         "httpDNS",
-			CreationTimestamp: GlobalTime,
-			Labels:            map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
-		},
-		Spec: &networking.ServiceEntry{
-			Hosts: []string{"*.google.com", "*.mail.com"},
-			Ports: []*networking.Port{
-				{Number: 80, Name: "http-port", Protocol: "http"},
-				{Number: 8080, Name: "http-alt-port", Protocol: "http"},
-				{Number: 9090, Name: "http-new-port", Protocol: "http"},
-			},
-			Endpoints: []*networking.WorkloadEntry{
-				{
-					Address: "us.google.com",
-					Ports:   map[string]uint32{"http-port": 7080, "http-alt-port": 18080},
-					Labels:  map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
-				},
-				{
-					Address: "uk.google.com",
-					Ports:   map[string]uint32{"http-port": 1080},
-					Labels:  map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
-				},
-				{
-					Address: "de.google.com",
-					Labels:  map[string]string{"foo": "bar", model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
-				},
-			},
-			Location:   networking.ServiceEntry_MESH_EXTERNAL,
-			Resolution: networking.ServiceEntry_DNS,
-		},
+	var updatedHTTPDNSPort = func() *model.Config {
+		c := updatedHTTPDNS.DeepCopy()
+		se := c.Spec.(*networking.ServiceEntry)
+		var ports []*networking.Port
+		ports = append(ports, se.Ports...)
+		ports = append(ports, &networking.Port{Number: 9090, Name: "http-new-port", Protocol: "http"})
+		se.Ports = ports
+		return &c
+	}()
+
+	var updatedEndpoint = func() *model.Config {
+		c := updatedHTTPDNS.DeepCopy()
+		se := c.Spec.(*networking.ServiceEntry)
+		var endpoints []*networking.WorkloadEntry
+		endpoints = append(endpoints, se.Endpoints...)
+		endpoints = append(endpoints, &networking.WorkloadEntry{
+			Address: "in.google.com",
+			Labels:  map[string]string{"foo": "bar", model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+		})
+		se.Endpoints = endpoints
+		return &c
+	}()
+
+	stringsToHosts := func(hosts []string) []host.Name {
+		ret := make([]host.Name, len(hosts))
+		for i, hostname := range hosts {
+			ret[i] = host.Name(hostname)
+		}
+		return ret
 	}
 
-	var updatedEndpoint = &model.Config{
-		ConfigMeta: model.ConfigMeta{
-			Type:              collections.IstioNetworkingV1Alpha3Serviceentries.Resource().Kind(),
-			Name:              "httpDNS",
-			Namespace:         "httpDNS",
-			CreationTimestamp: GlobalTime,
-			Labels:            map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
-		},
-		Spec: &networking.ServiceEntry{
-			Hosts: []string{"*.google.com", "*.mail.com"},
-			Ports: []*networking.Port{
-				{Number: 80, Name: "http-port", Protocol: "http"},
-				{Number: 8080, Name: "http-alt-port", Protocol: "http"},
-			},
-			Endpoints: []*networking.WorkloadEntry{
-				{
-					Address: "us.google.com",
-					Ports:   map[string]uint32{"http-port": 7080, "http-alt-port": 18080},
-					Labels:  map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
-				},
-				{
-					Address: "uk.google.com",
-					Ports:   map[string]uint32{"http-port": 1080},
-					Labels:  map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
-				},
-				{
-					Address: "de.google.com",
-					Labels:  map[string]string{"foo": "bar", model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
-				},
-				{
-					Address: "in.google.com",
-					Labels:  map[string]string{"foo": "bar", model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
-				},
-			},
-			Location:   networking.ServiceEntry_MESH_EXTERNAL,
-			Resolution: networking.ServiceEntry_DNS,
-		},
-	}
 	cases := []struct {
 		name string
 		a    *model.Config
 		b    *model.Config
-		want bool
+
+		added     []host.Name
+		deleted   []host.Name
+		updated   []host.Name
+		unchanged []host.Name
 	}{
 		{
-			"same config",
-			httpDNS,
-			httpDNS,
-			false,
+			name:      "same config",
+			a:         updatedHTTPDNS,
+			b:         updatedHTTPDNS,
+			unchanged: stringsToHosts(updatedHTTPDNS.Spec.(*networking.ServiceEntry).Hosts),
 		},
 		{
-			"different config",
-			httpDNS,
-			httpNoneInternal,
-			true,
+			name: "different config",
+			a:    updatedHTTPDNS,
+			b: func() *model.Config {
+				c := updatedHTTPDNS.DeepCopy()
+				c.Name = "httpDNS1"
+				return &c
+			}(),
+			unchanged: stringsToHosts(updatedHTTPDNS.Spec.(*networking.ServiceEntry).Hosts),
 		},
 		{
-			"different resolution",
-			tcpDNS,
-			tcpStatic,
-			true,
+			name: "different resolution",
+			a:    updatedHTTPDNS,
+			b: func() *model.Config {
+				c := updatedHTTPDNS.DeepCopy()
+				c.Spec.(*networking.ServiceEntry).Resolution = networking.ServiceEntry_NONE
+				return &c
+			}(),
+			updated: stringsToHosts(updatedHTTPDNS.Spec.(*networking.ServiceEntry).Hosts),
 		},
 		{
-			"config modified with additional host",
-			httpDNS,
-			updatedHTTPDNS,
-			true,
+			name: "config modified with added/deleted host",
+			a:    updatedHTTPDNS,
+			b: func() *model.Config {
+				c := updatedHTTPDNS.DeepCopy()
+				se := c.Spec.(*networking.ServiceEntry)
+				se.Hosts = []string{"*.google.com", "host.com"}
+				return &c
+			}(),
+			added:     []host.Name{"host.com"},
+			deleted:   []host.Name{"*.mail.com"},
+			unchanged: []host.Name{"*.google.com"},
 		},
 		{
-			"config modified with additional port",
-			updatedHTTPDNS,
-			updatedHTTPDNSPort,
-			true,
+			name:    "config modified with additional port",
+			a:       updatedHTTPDNS,
+			b:       updatedHTTPDNSPort,
+			updated: stringsToHosts(updatedHTTPDNS.Spec.(*networking.ServiceEntry).Hosts),
 		},
 		{
-			"same config with additional endpoint",
-			updatedHTTPDNS,
-			updatedEndpoint,
-			false,
+			name:      "same config with additional endpoint",
+			a:         updatedHTTPDNS,
+			b:         updatedEndpoint,
+			unchanged: stringsToHosts(updatedHTTPDNS.Spec.(*networking.ServiceEntry).Hosts),
 		},
 	}
+
+	servicesHostnames := func(services []*model.Service) map[host.Name]struct{} {
+		ret := make(map[host.Name]struct{})
+		for _, svc := range services {
+			ret[svc.Hostname] = struct{}{}
+		}
+		return ret
+	}
+	hostnamesToMap := func(hostnames []host.Name) map[host.Name]struct{} {
+		ret := make(map[host.Name]struct{})
+		for _, hostname := range hostnames {
+			ret[hostname] = struct{}{}
+		}
+		return ret
+	}
+
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			as := convertServices(*tt.a)
 			bs := convertServices(*tt.b)
-			got := servicesChanged(as, bs)
-			if got != tt.want {
-				t.Errorf("ServicesChanged got %v, want %v", got, tt.want)
+			added, deleted, updated, unchanged := servicesDiff(as, bs)
+			for i, item := range []struct {
+				hostnames []host.Name
+				services  []*model.Service
+			}{
+				{tt.added, added},
+				{tt.deleted, deleted},
+				{tt.updated, updated},
+				{tt.unchanged, unchanged},
+			} {
+				if !reflect.DeepEqual(servicesHostnames(item.services), hostnamesToMap(item.hostnames)) {
+					t.Errorf("ServicesChanged %d got %v, want %v", i, servicesHostnames(item.services), hostnamesToMap(item.hostnames))
+				}
 			}
 		})
 	}
@@ -803,4 +886,18 @@ func sortPorts(ports []*model.Port) {
 		}
 		return ports[i].Port < ports[j].Port
 	})
+}
+
+func configsUpdatedValidator(expect, got Event) bool {
+	expectPushReq, gotPushReq := expect.pushReq, got.pushReq
+	expect.pushReq, got.pushReq = nil, nil
+	if got != expect {
+		return false
+	}
+
+	if reflect.DeepEqual(expectPushReq.ConfigsUpdated, gotPushReq.ConfigsUpdated) {
+		return false
+	}
+
+	return true
 }

--- a/pilot/pkg/serviceregistry/kube/controller/endpointsdiscovery.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointsdiscovery.go
@@ -65,10 +65,9 @@ func (e *kubeEndpoints) handleEvent(name string, namespace string, event model.E
 			// if the service is headless service, trigger a full push.
 			if svc.Spec.ClusterIP == v1.ClusterIPNone {
 				e.c.xdsUpdater.ConfigUpdate(&model.PushRequest{
-					Full:              true,
-					NamespacesUpdated: map[string]struct{}{namespace: {}},
+					Full: true,
 					// TODO: extend and set service instance type, so no need to re-init push context
-					ConfigsUpdated: map[model.ConfigKey]struct{}{model.ConfigKey{
+					ConfigsUpdated: map[model.ConfigKey]struct{}{{
 						Kind:      model.ServiceEntryKind,
 						Name:      svc.Name,
 						Namespace: svc.Namespace,

--- a/pilot/pkg/serviceregistry/kube/controller/endpointsdiscovery.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointsdiscovery.go
@@ -69,7 +69,7 @@ func (e *kubeEndpoints) handleEvent(name string, namespace string, event model.E
 					Full:              true,
 					NamespacesUpdated: map[string]struct{}{namespace: {}},
 					// TODO: extend and set service instance type, so no need to re-init push context
-					ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{model.ServiceEntryKind: {}},
+					ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{model.ServiceEntryKind: {svc.Name: {}}},
 					Reason:         []model.TriggerReason{model.EndpointUpdate},
 				})
 				return nil

--- a/pilot/pkg/serviceregistry/kube/controller/endpointsdiscovery.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointsdiscovery.go
@@ -24,7 +24,6 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"istio.io/istio/pkg/config/labels"
-	"istio.io/istio/pkg/config/schema/resource"
 )
 
 // Pilot can get EDS information from Kubernetes from two mutually exclusive sources, Endpoints and
@@ -69,8 +68,12 @@ func (e *kubeEndpoints) handleEvent(name string, namespace string, event model.E
 					Full:              true,
 					NamespacesUpdated: map[string]struct{}{namespace: {}},
 					// TODO: extend and set service instance type, so no need to re-init push context
-					ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{model.ServiceEntryKind: {svc.Name: {}}},
-					Reason:         []model.TriggerReason{model.EndpointUpdate},
+					ConfigsUpdated: map[model.ConfigKey]struct{}{model.ConfigKey{
+						Kind:      model.ServiceEntryKind,
+						Name:      svc.Name,
+						Namespace: svc.Namespace,
+					}: {}},
+					Reason: []model.TriggerReason{model.EndpointUpdate},
 				})
 				return nil
 			}

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -26,7 +26,6 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	"istio.io/istio/pkg/config/mesh"
-	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/istio/pkg/kube/secretcontroller"
 )
 
@@ -144,9 +143,11 @@ func (m *Multicluster) updateHandler(svc *model.Service) {
 		req := &model.PushRequest{
 			Full:              true,
 			NamespacesUpdated: map[string]struct{}{svc.Attributes.Namespace: {}},
-			ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{model.ServiceEntryKind: {
-				string(svc.Hostname): {},
-			}},
+			ConfigsUpdated: map[model.ConfigKey]struct{}{model.ConfigKey{
+				Kind:      model.ServiceEntryKind,
+				Name:      string(svc.Hostname),
+				Namespace: svc.Attributes.Namespace,
+			}: {}},
 			Reason: []model.TriggerReason{model.UnknownTrigger},
 		}
 		m.XDSUpdater.ConfigUpdate(req)

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -141,9 +141,8 @@ func (m *Multicluster) DeleteMemberCluster(clusterID string) error {
 func (m *Multicluster) updateHandler(svc *model.Service) {
 	if m.XDSUpdater != nil {
 		req := &model.PushRequest{
-			Full:              true,
-			NamespacesUpdated: map[string]struct{}{svc.Attributes.Namespace: {}},
-			ConfigsUpdated: map[model.ConfigKey]struct{}{model.ConfigKey{
+			Full: true,
+			ConfigsUpdated: map[model.ConfigKey]struct{}{{
 				Kind:      model.ServiceEntryKind,
 				Name:      string(svc.Hostname),
 				Namespace: svc.Attributes.Namespace,

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -142,7 +142,8 @@ func (m *Multicluster) DeleteMemberCluster(clusterID string) error {
 func (m *Multicluster) updateHandler(svc *model.Service) {
 	if m.XDSUpdater != nil {
 		req := &model.PushRequest{
-			Full: true,
+			Full:              true,
+			NamespacesUpdated: map[string]struct{}{svc.Attributes.Namespace: {}},
 			ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{model.ServiceEntryKind: {
 				string(svc.Hostname): {},
 			}},

--- a/pilot/pkg/serviceregistry/mcp/controller.go
+++ b/pilot/pkg/serviceregistry/mcp/controller.go
@@ -130,13 +130,11 @@ func (c *controller) Apply(change *sink.Change) error {
 
 	kind := s.Resource().GroupVersionKind()
 	resourceUpdated := map[string]struct{}{} // If non-incremental, we use empty resourceUpdated to indicate all.
-	namespaceUpdated := make(map[string]struct{})
 
 	// innerStore is [namespace][name]
 	innerStore := make(map[string]map[string]*model.Config)
 	for _, obj := range change.Objects {
 		namespace, name := extractNameNamespace(obj.Metadata.Name)
-		namespaceUpdated[namespace] = struct{}{}
 
 		createTime := time.Now()
 		if obj.Metadata.CreateTime != nil {
@@ -207,10 +205,9 @@ func (c *controller) Apply(change *sink.Change) error {
 		c.serviceEntryEvents(innerStore, prevStore)
 	} else if c.options.XDSUpdater != nil {
 		c.options.XDSUpdater.ConfigUpdate(&model.PushRequest{
-			Full:              true,
-			NamespacesUpdated: namespaceUpdated,
-			ConfigsUpdated:    map[resource.GroupVersionKind]map[string]struct{}{kind: resourceUpdated},
-			Reason:            []model.TriggerReason{model.ConfigUpdate},
+			Full:           true,
+			ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{kind: resourceUpdated},
+			Reason:         []model.TriggerReason{model.ConfigUpdate},
 		})
 	}
 

--- a/pilot/pkg/serviceregistry/mcp/controller.go
+++ b/pilot/pkg/serviceregistry/mcp/controller.go
@@ -129,7 +129,7 @@ func (c *controller) Apply(change *sink.Change) error {
 	}
 
 	kind := s.Resource().GroupVersionKind()
-	names := map[string]struct{}{} // If non-incremental, we use empty names to indicate all.
+	resourceUpdated := map[string]struct{}{} // If non-incremental, we use empty resourceUpdated to indicate all.
 
 	// innerStore is [namespace][name]
 	innerStore := make(map[string]map[string]*model.Config)
@@ -147,7 +147,7 @@ func (c *controller) Apply(change *sink.Change) error {
 		}
 
 		if change.Incremental {
-			names[name] = struct{}{}
+			resourceUpdated[name] = struct{}{}
 		}
 		conf := &model.Config{
 			ConfigMeta: model.ConfigMeta{
@@ -186,7 +186,7 @@ func (c *controller) Apply(change *sink.Change) error {
 		}
 	}
 	for _, removed := range change.Removed {
-		names[removed] = struct{}{}
+		resourceUpdated[removed] = struct{}{}
 		err := c.ledger.Delete(kube.KeyFunc(change.Collection, removed))
 		if err != nil {
 			log.Warnf(ledgerLogf, err)
@@ -206,7 +206,7 @@ func (c *controller) Apply(change *sink.Change) error {
 	} else if c.options.XDSUpdater != nil {
 		c.options.XDSUpdater.ConfigUpdate(&model.PushRequest{
 			Full:           true,
-			ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{kind: names},
+			ConfigsUpdated: map[resource.GroupVersionKind]map[string]struct{}{kind: resourceUpdated},
 			Reason:         []model.TriggerReason{model.ConfigUpdate},
 		})
 	}


### PR DESCRIPTION

This PR enables full-push scoping and avoid full-push towards to unrelated proxies which do not care about the configs triggering the full-push. This will significantly reduce the proxy load on handling xDS especially in large scale service/endpoints data case.

Close #22392 