### PR TITLE
Add --revision to CLI troubleshooting commands that consult Pilot

### DIFF
--- a/istioctl/cmd/authz.go
+++ b/istioctl/cmd/authz.go
@@ -34,6 +34,7 @@ import (
 	"istio.io/pkg/log"
 
 	"istio.io/istio/istioctl/pkg/authz"
+	"istio.io/istio/istioctl/pkg/clioptions"
 	"istio.io/istio/istioctl/pkg/kubernetes"
 	"istio.io/istio/istioctl/pkg/util/configdump"
 	"istio.io/istio/istioctl/pkg/util/handlers"
@@ -106,7 +107,8 @@ THIS COMMAND IS STILL UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
 		},
 	}
 
-	convertCmd = &cobra.Command{
+	convertOpts clioptions.ControlPlaneOptions
+	convertCmd  = &cobra.Command{
 		Use:   "convert",
 		Short: "Convert v1alpha1 RBAC policy to v1beta1 authorization policy",
 		Long: `Convert Istio v1alpha1 RBAC policy to v1beta1 authorization policy. By default,
@@ -149,7 +151,7 @@ PLEASE ALWAYS REVIEW THE CONVERTED POLICIES BEFORE APPLYING.
 					return fmt.Errorf("failed to create the AuthorizationPolicies: %v", err)
 				}
 			} else {
-				authorizationPolicies, err = getAuthorizationPoliciesFromCluster()
+				authorizationPolicies, err = getAuthorizationPoliciesFromCluster(convertOpts)
 				if err != nil {
 					return fmt.Errorf("failed to get the v1alpha1 RBAC policies: %v", err)
 				}
@@ -267,9 +269,9 @@ func createAuthorizationPoliciesFromFiles(files []string, rootNamespace string) 
 	return authorizationPolicies, nil
 }
 
-func getAuthorizationPoliciesFromCluster() (*model.AuthorizationPolicies, error) {
+func getAuthorizationPoliciesFromCluster(opts clioptions.ControlPlaneOptions) (*model.AuthorizationPolicies, error) {
 	var authorizationPolicies *model.AuthorizationPolicies
-	kubeClient, err := clientExecFactory(kubeconfig, configContext)
+	kubeClient, err := clientExecFactory(kubeconfig, configContext, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -386,4 +388,5 @@ func init() {
 		"Override the root namespace used in the conversion")
 	convertCmd.PersistentFlags().BoolVarP(&allowNoClusterRbacConfig, "allowNoClusterRbacConfig", "", false,
 		"Continue the conversion even if there is no ClusterRbacConfig in the cluster")
+	convertOpts.AttachControlPlaneFlags(convertCmd)
 }

--- a/istioctl/cmd/dashboard.go
+++ b/istioctl/cmd/dashboard.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"istio.io/istio/istioctl/pkg/clioptions"
 	"istio.io/istio/istioctl/pkg/kubernetes"
 	"istio.io/istio/istioctl/pkg/util/handlers"
 
@@ -41,13 +42,14 @@ var (
 
 // port-forward to Istio System Prometheus; open browser
 func promDashCmd() *cobra.Command {
+	var opts clioptions.ControlPlaneOptions
 	cmd := &cobra.Command{
 		Use:     "prometheus",
 		Short:   "Open Prometheus web UI",
 		Long:    `Open Istio's Prometheus dashboard`,
 		Example: `istioctl dashboard prometheus`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := clientExecFactory(kubeconfig, configContext)
+			client, err := clientExecFactory(kubeconfig, configContext, opts)
 			if err != nil {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}
@@ -72,13 +74,14 @@ func promDashCmd() *cobra.Command {
 
 // port-forward to Istio System Grafana; open browser
 func grafanaDashCmd() *cobra.Command {
+	var opts clioptions.ControlPlaneOptions
 	cmd := &cobra.Command{
 		Use:     "grafana",
 		Short:   "Open Grafana web UI",
 		Long:    `Open Istio's Grafana dashboard`,
 		Example: `istioctl dashboard grafana`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := clientExecFactory(kubeconfig, configContext)
+			client, err := clientExecFactory(kubeconfig, configContext, opts)
 			if err != nil {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}
@@ -103,13 +106,14 @@ func grafanaDashCmd() *cobra.Command {
 
 // port-forward to Istio System Kiali; open browser
 func kialiDashCmd() *cobra.Command {
+	var opts clioptions.ControlPlaneOptions
 	cmd := &cobra.Command{
 		Use:     "kiali",
 		Short:   "Open Kiali web UI",
 		Long:    `Open Istio's Kiali dashboard`,
 		Example: `istioctl dashboard kiali`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := clientExecFactory(kubeconfig, configContext)
+			client, err := clientExecFactory(kubeconfig, configContext, opts)
 			if err != nil {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}
@@ -134,13 +138,14 @@ func kialiDashCmd() *cobra.Command {
 
 // port-forward to Istio System Jaeger; open browser
 func jaegerDashCmd() *cobra.Command {
+	var opts clioptions.ControlPlaneOptions
 	cmd := &cobra.Command{
 		Use:     "jaeger",
 		Short:   "Open Jaeger web UI",
 		Long:    `Open Istio's Jaeger dashboard`,
 		Example: `istioctl dashboard jaeger`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := clientExecFactory(kubeconfig, configContext)
+			client, err := clientExecFactory(kubeconfig, configContext, opts)
 			if err != nil {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}
@@ -165,13 +170,14 @@ func jaegerDashCmd() *cobra.Command {
 
 // port-forward to Istio System Zipkin; open browser
 func zipkinDashCmd() *cobra.Command {
+	var opts clioptions.ControlPlaneOptions
 	cmd := &cobra.Command{
 		Use:     "zipkin",
 		Short:   "Open Zipkin web UI",
 		Long:    `Open Istio's Zipkin dashboard`,
 		Example: `istioctl dashboard zipkin`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := clientExecFactory(kubeconfig, configContext)
+			client, err := clientExecFactory(kubeconfig, configContext, opts)
 			if err != nil {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}
@@ -212,7 +218,7 @@ func envoyDashCmd() *cobra.Command {
 				return fmt.Errorf("name cannot be provided when a selector is specified")
 			}
 
-			client, err := clientExecFactory(kubeconfig, configContext)
+			client, err := envoyClientFactory(kubeconfig, configContext)
 			if err != nil {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}
@@ -249,6 +255,7 @@ func envoyDashCmd() *cobra.Command {
 
 // port-forward to sidecar ControlZ port; open browser
 func controlZDashCmd() *cobra.Command {
+	var opts clioptions.ControlPlaneOptions
 	cmd := &cobra.Command{
 		Use:     "controlz <pod-name[.namespace]>",
 		Short:   "Open ControlZ web UI",
@@ -265,7 +272,7 @@ func controlZDashCmd() *cobra.Command {
 				return fmt.Errorf("name cannot be provided when a selector is specified")
 			}
 
-			client, err := clientExecFactory(kubeconfig, configContext)
+			client, err := clientExecFactory(kubeconfig, configContext, opts)
 			if err != nil {
 				return fmt.Errorf("failed to create k8s client: %v", err)
 			}

--- a/istioctl/cmd/dashboard_test.go
+++ b/istioctl/cmd/dashboard_test.go
@@ -20,11 +20,13 @@ import (
 	"strings"
 	"testing"
 
+	"istio.io/istio/istioctl/pkg/clioptions"
 	"istio.io/istio/istioctl/pkg/kubernetes"
 )
 
 func TestDashboard(t *testing.T) {
 	clientExecFactory = mockExecClientDashboard
+	envoyClientFactory = mockEnvoyClientDashboard
 
 	cases := []testCase{
 		{ // case 0
@@ -115,6 +117,10 @@ func TestDashboard(t *testing.T) {
 	}
 }
 
-func mockExecClientDashboard(_, _ string) (kubernetes.ExecClient, error) {
+func mockExecClientDashboard(_, _ string, _ clioptions.ControlPlaneOptions) (kubernetes.ExecClient, error) {
+	return &mockExecConfig{}, nil
+}
+
+func mockEnvoyClientDashboard(_, _ string) (kubernetes.ExecClient, error) {
 	return &mockExecConfig{}, nil
 }

--- a/istioctl/cmd/describe.go
+++ b/istioctl/cmd/describe.go
@@ -41,6 +41,7 @@ import (
 	mixerclient "istio.io/api/mixer/v1/config/client"
 	"istio.io/api/networking/v1alpha3"
 
+	"istio.io/istio/istioctl/pkg/clioptions"
 	istioctl_kubernetes "istio.io/istio/istioctl/pkg/kubernetes"
 	"istio.io/istio/istioctl/pkg/util/configdump"
 	"istio.io/istio/istioctl/pkg/util/handlers"
@@ -72,6 +73,7 @@ var (
 )
 
 func podDescribeCmd() *cobra.Command {
+	var opts clioptions.ControlPlaneOptions
 	cmd := &cobra.Command{
 		Use:   "pod <pod>",
 		Short: "Describe pods and their Istio configuration [kube-only]",
@@ -125,7 +127,7 @@ THIS COMMAND IS STILL UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
 			}
 			// TODO look for port collisions between services targeting this pod
 
-			kubeClient, err := clientExecFactory(kubeconfig, configContext)
+			kubeClient, err := clientExecFactory(kubeconfig, configContext, opts)
 			if err != nil {
 				return err
 			}
@@ -1119,6 +1121,7 @@ func getIngressIP(service v1.Service, pod v1.Pod) string {
 }
 
 func svcDescribeCmd() *cobra.Command {
+	var opts clioptions.ControlPlaneOptions
 	cmd := &cobra.Command{
 		Use:     "service <svc>",
 		Aliases: []string{"svc"},
@@ -1193,7 +1196,7 @@ THIS COMMAND IS STILL UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
 				return nil
 			}
 
-			kubeClient, err := clientExecFactory(kubeconfig, configContext)
+			kubeClient, err := clientExecFactory(kubeconfig, configContext, opts)
 			if err != nil {
 				return err
 			}

--- a/istioctl/cmd/metrics.go
+++ b/istioctl/cmd/metrics.go
@@ -29,12 +29,14 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/spf13/cobra"
 
+	"istio.io/istio/istioctl/pkg/clioptions"
 	"istio.io/istio/istioctl/pkg/kubernetes"
 	"istio.io/pkg/log"
 )
 
 var (
-	metricsCmd = &cobra.Command{
+	metricsOpts clioptions.ControlPlaneOptions
+	metricsCmd  = &cobra.Command{
 		Use:   "metrics <workload name>...",
 		Short: "Prints the metrics for the specified workload(s) when running in Kubernetes.",
 		Long: `
@@ -88,7 +90,7 @@ type workloadMetrics struct {
 func run(c *cobra.Command, args []string) error {
 	log.Debugf("metrics command invoked for workload(s): %v", args)
 
-	client, err := clientExecFactory(kubeconfig, configContext)
+	client, err := clientExecFactory(kubeconfig, configContext, metricsOpts)
 	if err != nil {
 		return fmt.Errorf("failed to create k8s client: %v", err)
 	}

--- a/istioctl/cmd/metrics_test.go
+++ b/istioctl/cmd/metrics_test.go
@@ -29,6 +29,7 @@ import (
 
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 
+	"istio.io/istio/istioctl/pkg/clioptions"
 	"istio.io/istio/istioctl/pkg/kubernetes"
 	"istio.io/pkg/version"
 
@@ -46,7 +47,7 @@ type mockPromAPI struct {
 	cannedResponse map[string]prometheus_model.Value
 }
 
-func mockExecClientAuthNoPilot(_, _ string) (kubernetes.ExecClient, error) {
+func mockExecClientAuthNoPilot(_, _ string, _ clioptions.ControlPlaneOptions) (kubernetes.ExecClient, error) {
 	return &mockExecConfig{}, nil
 }
 
@@ -91,7 +92,7 @@ func TestMetrics(t *testing.T) {
 	}
 }
 
-func mockPortForwardClientAuthPrometheus(_, _ string) (kubernetes.ExecClient, error) {
+func mockPortForwardClientAuthPrometheus(_, _ string, _ clioptions.ControlPlaneOptions) (kubernetes.ExecClient, error) {
 	return &mockPortForwardConfig{
 		discoverablePods: map[string]map[string]*v1.PodList{
 			"istio-system": {

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -146,7 +146,7 @@ var (
 )
 
 func setupPodConfigdumpWriter(podName, podNamespace string, out io.Writer) (*configdump.ConfigWriter, error) {
-	kubeClient, err := clientExecFactory(kubeconfig, configContext)
+	kubeClient, err := envoyClientFactory(kubeconfig, configContext)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create k8s client: %v", err)
 	}
@@ -185,7 +185,7 @@ func setupConfigdumpEnvoyConfigWriter(debug []byte, out io.Writer) (*configdump.
 }
 
 func setupEnvoyLogConfig(param, podName, podNamespace string) (string, error) {
-	kubeClient, err := clientExecFactory(kubeconfig, configContext)
+	kubeClient, err := envoyClientFactory(kubeconfig, configContext)
 	if err != nil {
 		return "", fmt.Errorf("failed to create Kubernetes client: %v", err)
 	}
@@ -221,7 +221,7 @@ func getLogLevelFromConfigMap() (string, error) {
 }
 
 func setupPodClustersWriter(podName, podNamespace string, out io.Writer) (*clusters.ConfigWriter, error) {
-	kubeClient, err := clientExecFactory(kubeconfig, configContext)
+	kubeClient, err := envoyClientFactory(kubeconfig, configContext)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create k8s client: %v", err)
 	}

--- a/istioctl/cmd/proxyconfig_test.go
+++ b/istioctl/cmd/proxyconfig_test.go
@@ -22,6 +22,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 
+	"istio.io/istio/istioctl/pkg/clioptions"
 	"istio.io/istio/istioctl/pkg/kubernetes"
 	"istio.io/istio/pilot/test/util"
 	"istio.io/istio/security/pkg/nodeagent/sds"
@@ -262,6 +263,7 @@ func verifyExecTestOutput(t *testing.T, c execTestCase) {
 
 	// Override the exec client factory used by proxyconfig.go and proxystatus.go
 	clientExecFactory = mockClientExecFactoryGenerator(c.execClientConfig)
+	envoyClientFactory = mockEnvoyClientFactoryGenerator(c.execClientConfig)
 
 	var out bytes.Buffer
 	rootCmd := GetRootCmd(c.args)
@@ -296,7 +298,18 @@ func verifyExecTestOutput(t *testing.T, c execTestCase) {
 
 // mockClientExecFactoryGenerator generates a function with the same signature as
 // kubernetes.NewExecClient() that returns a mock client.
-func mockClientExecFactoryGenerator(testResults map[string][]byte) func(kubeconfig, configContext string) (kubernetes.ExecClient, error) {
+// nolint: lll
+func mockClientExecFactoryGenerator(testResults map[string][]byte) func(kubeconfig, configContext string, _ clioptions.ControlPlaneOptions) (kubernetes.ExecClient, error) {
+	outFactory := func(kubeconfig, configContext string, _ clioptions.ControlPlaneOptions) (kubernetes.ExecClient, error) {
+		return mockExecConfig{
+			results: testResults,
+		}, nil
+	}
+
+	return outFactory
+}
+
+func mockEnvoyClientFactoryGenerator(testResults map[string][]byte) func(kubeconfig, configContext string) (kubernetes.ExecClient, error) {
 	outFactory := func(kubeconfig, configContext string) (kubernetes.ExecClient, error) {
 		return mockExecConfig{
 			results: testResults,

--- a/istioctl/cmd/proxystatus_test.go
+++ b/istioctl/cmd/proxystatus_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"testing"
 
+	"istio.io/istio/istioctl/pkg/clioptions"
 	"istio.io/istio/istioctl/pkg/kubernetes"
 	"istio.io/istio/pilot/test/util"
 )
@@ -65,6 +66,18 @@ default           Cert Chain     true                          WARMING     10224
 			args:          strings.Split("proxy-status random-gibberish-podname-61789237418234", " "),
 			wantException: true,
 		},
+		{ // case 6: new --revision argument
+			args:           strings.Split("proxy-status --revision canary", " "),
+			expectedString: "NAME     CDS     LDS     EDS     RDS     PILOT",
+		},
+		{ // case 7 "proxy-status podName.namespace --revision"
+			execClientConfig: cannedConfig,
+			args:             strings.Split("proxy-status details-v1-5b7f94f9bc-wp5tb.default --revision canary", " "),
+			expectedOutput: `Clusters Match
+Listeners Match
+Routes Match
+`,
+		},
 	}
 
 	for i, c := range cases {
@@ -77,8 +90,9 @@ default           Cert Chain     true                          WARMING     10224
 
 // mockClientExecFactoryGenerator generates a function with the same signature as
 // kubernetes.NewExecClient() that returns a mock client.
-func mockClientExecSDSFactoryGenerator(testResults map[string][]byte) func(kubeconfig, configContext string) (kubernetes.ExecClientSDS, error) {
-	outFactory := func(kubeconfig, configContext string) (kubernetes.ExecClientSDS, error) {
+// nolint: lll
+func mockClientExecSDSFactoryGenerator(testResults map[string][]byte) func(kubeconfig, configContext string, _ clioptions.ControlPlaneOptions) (kubernetes.ExecClientSDS, error) {
+	outFactory := func(kubeconfig, configContext string, _ clioptions.ControlPlaneOptions) (kubernetes.ExecClientSDS, error) {
 		return mockExecConfig{
 			results: testResults,
 		}, nil

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -33,6 +33,7 @@ import (
 	"istio.io/pkg/log"
 )
 
+// CommandParseError distinguishes an error parsing istioctl CLI arguments from an error processing
 type CommandParseError struct {
 	e error
 }
@@ -48,8 +49,11 @@ var (
 	istioNamespace   string
 	defaultNamespace string
 
-	// Create a kubernetes.ExecClient (or mockExecClient)
-	clientExecFactory = newExecClient
+	// Create a kubernetes.ExecClient (or mockExecClient) for talking to control plane components
+	clientExecFactory = newPilotExecClient
+
+	// Create a kubernetes.ExecClient (or mock) for talking to data plane components
+	envoyClientFactory = newEnvoyClient
 
 	// Create a kubernetes.ExecClientSDS
 	clientExecSdsFactory = newSDSExecClient

--- a/istioctl/cmd/version.go
+++ b/istioctl/cmd/version.go
@@ -87,7 +87,6 @@ func getRemoteInfoWrapper(pc **cobra.Command, opts *clioptions.ControlPlaneOptio
 
 func getProxyInfoWrapper(opts *clioptions.ControlPlaneOptions) func() (*[]istioVersion.ProxyInfo, error) {
 	return func() (*[]istioVersion.ProxyInfo, error) {
-		fmt.Printf("@@@ ecs getting proxy info, opts=%#v\n", opts)
 		return getProxyInfo(opts)
 	}
 }

--- a/istioctl/cmd/version_test.go
+++ b/istioctl/cmd/version_test.go
@@ -21,6 +21,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 
+	"istio.io/istio/istioctl/pkg/clioptions"
 	"istio.io/istio/istioctl/pkg/kubernetes"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/pkg/version"
@@ -58,6 +59,11 @@ func TestVersion(t *testing.T) {
 			expectedOutput: "Error: --output must be 'yaml' or 'json'\n",
 			wantException:  true,
 		},
+		{ // case 4 remote, --revision flag
+			configs: []model.Config{},
+			args:    strings.Split("version --remote=true --short=false --revision canary", " "),
+			// ignore the output, all output checks are now in istio/pkg
+		},
 	}
 
 	for i, c := range cases {
@@ -87,7 +93,7 @@ func (client mockExecVersionConfig) GetIstioVersions(namespace string) (*version
 	return &meshInfo, nil
 }
 
-func mockExecClientVersionTest(_, _ string) (kubernetes.ExecClient, error) {
+func mockExecClientVersionTest(_, _ string, _ clioptions.ControlPlaneOptions) (kubernetes.ExecClient, error) {
 	return &mockExecVersionConfig{}, nil
 }
 

--- a/istioctl/cmd/wait.go
+++ b/istioctl/cmd/wait.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 
+	"istio.io/istio/istioctl/pkg/clioptions"
 	"istio.io/istio/istioctl/pkg/kubernetes"
 	"istio.io/istio/istioctl/pkg/util/handlers"
 	"istio.io/istio/pilot/pkg/model"
@@ -51,6 +52,7 @@ const pollInterval = time.Second
 
 // waitCmd represents the wait command
 func waitCmd() *cobra.Command {
+	var opts clioptions.ControlPlaneOptions
 	cmd := &cobra.Command{
 		Use:   "wait [flags] <type> <name>[.<namespace>]",
 		Short: "Wait for an Istio resource",
@@ -87,14 +89,14 @@ istioctl experimental wait --for=distribution --threshold=.99 --timeout=300 virt
 			printVerbosef(cmd, "getting first version from chan")
 			firstVersion, err := w.BlockingRead()
 			if err != nil {
-				return fmt.Errorf("unable to retrieve kubernetes resource %s: %v", "", err)
+				return fmt.Errorf("unable to retrieve Kubernetes resource %s: %v", "", err)
 			}
 			resourceVersions := []string{firstVersion}
 			targetResource := model.Key(targetSchema.Resource().Kind(), nameflag, namespace)
 			for {
 				//run the check here as soon as we start
 				// because tickers won't run immediately
-				present, notpresent, err := poll(resourceVersions, targetResource)
+				present, notpresent, err := poll(resourceVersions, targetResource, opts)
 				printVerbosef(cmd, "Received poll result: %d/%d", present, present+notpresent)
 				if err != nil {
 					return err
@@ -111,7 +113,7 @@ istioctl experimental wait --for=distribution --threshold=.99 --timeout=300 virt
 					printVerbosef(cmd, "tick")
 					continue
 				case err = <-w.errorChan:
-					return fmt.Errorf("unable to retrieve kubernetes resource %s: %v", "", err)
+					return fmt.Errorf("unable to retrieve Kubernetes resource %s: %v", "", err)
 				case <-ctx.Done():
 					printVerbosef(cmd, "timeout")
 					// I think this means the timeout has happened:
@@ -140,6 +142,7 @@ istioctl experimental wait --for=distribution --threshold=.99 --timeout=300 virt
 			"kubernetes")
 	cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "enables verbose output")
 	_ = cmd.PersistentFlags().MarkHidden("verbose")
+	opts.AttachControlPlaneFlags(cmd)
 	return cmd
 }
 
@@ -172,8 +175,8 @@ func countVersions(versionCount map[string]int, configVersion string) {
 	}
 }
 
-func poll(acceptedVersions []string, targetResource string) (present, notpresent int, err error) {
-	kubeClient, err := clientExecFactory(kubeconfig, configContext)
+func poll(acceptedVersions []string, targetResource string, opts clioptions.ControlPlaneOptions) (present, notpresent int, err error) {
+	kubeClient, err := clientExecFactory(kubeconfig, configContext, opts)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/istioctl/cmd/wait_test.go
+++ b/istioctl/cmd/wait_test.go
@@ -72,6 +72,11 @@ func TestWaitCmd(t *testing.T) {
 			args:             strings.Split("x wait --timeout 2s virtualservice foo.default", " "),
 			wantException:    false,
 		},
+		{
+			execClientConfig: cannedResponseMap,
+			args:             strings.Split("x wait --revision canary virtualservice foo.default", " "),
+			wantException:    false,
+		},
 	}
 
 	_ = setupK8Sfake()

--- a/istioctl/pkg/clioptions/control_plane.go
+++ b/istioctl/pkg/clioptions/control_plane.go
@@ -1,0 +1,30 @@
+// Copyright 2020 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clioptions
+
+import "github.com/spf13/cobra"
+
+// ControlPlaneOptions defines common options used by istioctl.
+type ControlPlaneOptions struct {
+	// Revision is the istio.io/rev control plane revision
+	Revision string
+}
+
+// AttachControlPlaneFlags attaches control-plane flags to a Cobra command.
+// (Currently just --revision)
+func (o *ControlPlaneOptions) AttachControlPlaneFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringVar(&o.Revision, "revision", "",
+		"control plane revision")
+}

--- a/istioctl/pkg/clioptions/doc.go
+++ b/istioctl/pkg/clioptions/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2020 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package clioptions contains flags which can be added to istiocl commands.
+package clioptions

--- a/istioctl/pkg/kubernetes/client.go
+++ b/istioctl/pkg/kubernetes/client.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/client-go/transport/spdy"
 
 	"istio.io/istio/istioctl/pkg/clioptions"
+	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/kube"
 	"istio.io/pkg/version"
 )
@@ -213,9 +214,9 @@ func (client *Client) GetIstioPods(namespace string, params map[string]string) (
 	if client.Revision != "" {
 		labelSelector, ok := params["labelSelector"]
 		if ok {
-			params["labelSelector"] = fmt.Sprintf("%s,istio.io/rev=%s", labelSelector, client.Revision)
+			params["labelSelector"] = fmt.Sprintf("%s,%s=%s", labelSelector, model.RevisionLabel, client.Revision)
 		} else {
-			params["labelSelector"] = fmt.Sprintf("istio.io/rev=%s", client.Revision)
+			params["labelSelector"] = fmt.Sprintf("%s=%s", model.RevisionLabel, client.Revision)
 		}
 	}
 


### PR DESCRIPTION
Initial work for https://github.com/istio/istio/issues/22274

With this work, it is *possible* to consult a particular control plane revision.  For example, you can now say `istioctl proxy-status --revision canary`

With this work, if you perform `istioctl version` it will consult all Pilots; if you perform `istioctl version --revision canary` it will consult only the `canary` control plane.

A follow-on will improve the user experience for doing things like `istioctl proxy-status <pod>` allowing the user to leave off `--revision <rev>` and using the revision associated with `<pod>`.