### PR TITLE
Assorted startup chages, extracted from the DNS PR

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -190,6 +190,8 @@ var (
 				log.Infof("Effective config: %s", out)
 			}
 
+			// If not set, set a default based on platform - podNamespace.svc.cluster.local for
+			// K8S
 			role.DNSDomain = getDNSDomain(podNamespace, role.DNSDomain)
 			log.Infof("Proxy role: %#v", role)
 

--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -151,9 +151,9 @@ func (s *Server) EnableCA() bool {
 		// If TOKEN_ISSUER is set, we ignore the lack of mounted JWT token, it means user is using
 		// an external OIDC provider to validate the tokens, and istiod lack of a JWT doesn't indicate a problem.
 		if features.JwtPolicy.Get() == jwt.JWTPolicyThirdPartyJWT && trustedIssuer.Get() == "" {
-			log.Warnf("istiod running without access to K8S tokens (jwt path %v); disable the CA functionality",
+			log.Warnf("istiod running without access to K8S tokens (jwt path %v). CA will run to support VMs ",
 				s.jwtPath)
-			return false
+			return true
 		}
 	}
 	return true

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -115,6 +115,7 @@ type Server struct {
 	clusterID   string
 	environment *model.Environment
 
+	kubeConfig       *rest.Config
 	configController model.ConfigStoreCache
 	kubeClient       kubernetes.Interface
 	metadataClient   metadata.Interface
@@ -390,6 +391,11 @@ func (s *Server) WaitUntilCompletion() {
 func (s *Server) initKubeClient(args *PilotArgs) error {
 	if hasKubeRegistry(args.Service.Registries) {
 		var err error
+		// Used by validation
+		s.kubeConfig, err = kubelib.BuildClientConfig(args.Config.KubeConfig, "")
+		if err != nil {
+			return fmt.Errorf("failed creating kube config: %v", err)
+		}
 		s.kubeClient, err = kubelib.CreateClientset(args.Config.KubeConfig, "", func(config *rest.Config) {
 			config.QPS = 20
 			config.Burst = 40


### PR DESCRIPTION
Most related to things I found while testing locally in IDE:
- enable CA even if k8s certs are not present, VM and local mode should still work
- expose the sds cert objects - will be used in DNS and by other features that require agent connections.
- validation should use the same kube client as the rest ( it is shared in the rest of the code ). 