### PR TITLE
Fix blackhole and passthrough for telemetry v2

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -491,11 +491,11 @@ func buildCatchAllVirtualHost(node *model.Proxy) *route.VirtualHost {
 		}
 
 		return &route.VirtualHost{
-			Name:    util.PassthroughVirtualHost,
+			Name:    util.Passthrough,
 			Domains: []string{"*"},
 			Routes: []*route.Route{
 				{
-					Name: util.PassthroughRouteName,
+					Name: util.Passthrough,
 					Match: &route.RouteMatch{
 						PathSpecifier: &route.RouteMatch_Prefix{Prefix: "/"},
 					},
@@ -516,11 +516,11 @@ func buildCatchAllVirtualHost(node *model.Proxy) *route.VirtualHost {
 	}
 
 	return &route.VirtualHost{
-		Name:    util.BlackHoleVirtualHost,
+		Name:    util.BlackHole,
 		Domains: []string{"*"},
 		Routes: []*route.Route{
 			{
-				Name: util.BlackHoleRouteName,
+				Name: util.BlackHole,
 				Match: &route.RouteMatch{
 					PathSpecifier: &route.RouteMatch_Prefix{Prefix: "/"},
 				},

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -491,10 +491,11 @@ func buildCatchAllVirtualHost(node *model.Proxy) *route.VirtualHost {
 		}
 
 		return &route.VirtualHost{
-			Name:    util.PassthroughRouteName,
+			Name:    util.PassthroughVirtualHost,
 			Domains: []string{"*"},
 			Routes: []*route.Route{
 				{
+					Name: util.PassthroughRouteName,
 					Match: &route.RouteMatch{
 						PathSpecifier: &route.RouteMatch_Prefix{Prefix: "/"},
 					},
@@ -515,10 +516,11 @@ func buildCatchAllVirtualHost(node *model.Proxy) *route.VirtualHost {
 	}
 
 	return &route.VirtualHost{
-		Name:    util.BlackHoleRouteName,
+		Name:    util.BlackHoleVirtualHost,
 		Domains: []string{"*"},
 		Routes: []*route.Route{
 			{
+				Name: util.BlackHoleRouteName,
 				Match: &route.RouteMatch{
 					PathSpecifier: &route.RouteMatch_Prefix{Prefix: "/"},
 				},

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -524,7 +524,7 @@ func modifyOutboundRouteConfig(push *model.PushContext, in *plugin.InputParams, 
 	// route.Route_DirectResponse is used for the BlackHole cluster configuration,
 	// hence adding the attributes for the mixer filter
 	case *route.Route_DirectResponse:
-		if virtualHostname == util.BlackHoleVirtualHost {
+		if virtualHostname == util.BlackHole {
 			hostname := host.Name(util.BlackHoleCluster)
 			attrs := addVirtualDestinationServiceAttributes(make(attributes), hostname)
 			addFilterConfigToRoute(in, httpRoute, attrs)

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -524,7 +524,7 @@ func modifyOutboundRouteConfig(push *model.PushContext, in *plugin.InputParams, 
 	// route.Route_DirectResponse is used for the BlackHole cluster configuration,
 	// hence adding the attributes for the mixer filter
 	case *route.Route_DirectResponse:
-		if virtualHostname == util.BlackHoleRouteName {
+		if virtualHostname == util.BlackHoleVirtualHost {
 			hostname := host.Name(util.BlackHoleCluster)
 			attrs := addVirtualDestinationServiceAttributes(make(attributes), hostname)
 			addFilterConfigToRoute(in, httpRoute, attrs)

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -52,14 +52,19 @@ import (
 const (
 	// BlackHoleCluster to catch traffic from routes with unresolved clusters. Traffic arriving here goes nowhere.
 	BlackHoleCluster = "BlackHoleCluster"
+	// BlackHoleVirtualHost is the name of the virtual host used to block all traffic
+	BlackHoleVirtualHost = "block_all"
 	// BlackHoleRouteName is the name of the route that blocks all traffic.
-	BlackHoleRouteName = "block_all"
+	BlackHoleRouteName = "black_hole_route"
 	// PassthroughCluster to forward traffic to the original destination requested. This cluster is used when
 	// traffic does not match any listener in envoy.
 	PassthroughCluster = "PassthroughCluster"
+	// PassthroughVirtualHost is the name of the virtual host used to forward traffic to the
+	// PassthroughCluster
+	PassthroughVirtualHost = "allow_any"
 	// PassthroughRouteName is the name of the route that forwards traffic to the
 	// PassthroughCluster
-	PassthroughRouteName = "allow_any"
+	PassthroughRouteName = "pass_through_route"
 	// PassthroughFilterChain to catch traffic that doesn't match other filter chains.
 	PassthroughFilterChain = "PassthroughFilterChain"
 

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -52,19 +52,14 @@ import (
 const (
 	// BlackHoleCluster to catch traffic from routes with unresolved clusters. Traffic arriving here goes nowhere.
 	BlackHoleCluster = "BlackHoleCluster"
-	// BlackHoleVirtualHost is the name of the virtual host used to block all traffic
-	BlackHoleVirtualHost = "block_all"
-	// BlackHoleRouteName is the name of the route that blocks all traffic.
-	BlackHoleRouteName = "black_hole_route"
+	// BlackHole is the name of the virtual host and route name used to block all traffic
+	BlackHole = "block_all"
 	// PassthroughCluster to forward traffic to the original destination requested. This cluster is used when
 	// traffic does not match any listener in envoy.
 	PassthroughCluster = "PassthroughCluster"
-	// PassthroughVirtualHost is the name of the virtual host used to forward traffic to the
+	// Passthrough is the name of the virtual host used to forward traffic to the
 	// PassthroughCluster
-	PassthroughVirtualHost = "allow_any"
-	// PassthroughRouteName is the name of the route that forwards traffic to the
-	// PassthroughCluster
-	PassthroughRouteName = "pass_through_route"
+	Passthrough = "allow_any"
 	// PassthroughFilterChain to catch traffic that doesn't match other filter chains.
 	PassthroughFilterChain = "PassthroughFilterChain"
 


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/21385

VirtualHost was being set, not the name of the route. By changing the
name of the route it is possible to check in the telemetry v2 filter
the route name to see if it is sending it to Blackhole/Passthrough and
setting the destination_service_name appropriately.