### PR TITLE
Fix PHONY recursion if target matches directory name

### DIFF
--- a/Makefile.overrides.mk
+++ b/Makefile.overrides.mk
@@ -25,7 +25,7 @@ ifeq ($(BUILD_WITH_CONTAINER),1)
 PHONYS := $(shell ls | grep -v Makefile)
 .PHONY: $(PHONYS)
 $(PHONYS):
-	@$(MAKE) $@
+	@$(MAKE_DOCKER) $@
 endif
 
 # istioctl-install builds then installs istioctl into $GOPATH/BIN


### PR DESCRIPTION
Today a `make docker` or a `make istioctl` fail. The reason is we create a PHONY for all the top level directories (of which these targets are) and they simply do another `make docker` and then that does a `make docker`, etc. I believe with the change to MAKE_DOCKER in https://github.com/istio/common-files/pull/222 we also need to update the PHONY to use that as well.