### PR TITLE
Set readOnlyRootFilesystem to true for istio-init with Istio CNI is enabled

### DIFF
--- a/manifests/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/istio-control/istio-discovery/files/gen-istio.yaml
@@ -479,12 +479,13 @@ data:
         {{- end }}
             drop:
             - ALL
-          readOnlyRootFilesystem: false
         {{- if not .Values.istio_cni.enabled }}
+          readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false
           runAsUser: 0
         {{- else }}
+          readOnlyRootFilesystem: true
           runAsGroup: 1337
           runAsUser: 1337
           runAsNonRoot: true

--- a/manifests/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/istio-control/istio-discovery/files/injection-template.yaml
@@ -65,12 +65,13 @@ template: |
     {{- end }}
         drop:
         - ALL
-      readOnlyRootFilesystem: false
     {{- if not .Values.istio_cni.enabled }}
+      readOnlyRootFilesystem: false
       runAsGroup: 0
       runAsNonRoot: false
       runAsUser: 0
     {{- else }}
+      readOnlyRootFilesystem: true
       runAsGroup: 1337
       runAsUser: 1337
       runAsNonRoot: true

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -18501,12 +18501,13 @@ data:
         {{- end }}
             drop:
             - ALL
-          readOnlyRootFilesystem: false
         {{- if not .Values.istio_cni.enabled }}
+          readOnlyRootFilesystem: false
           runAsGroup: 0
           runAsNonRoot: false
           runAsUser: 0
         {{- else }}
+          readOnlyRootFilesystem: true
           runAsGroup: 1337
           runAsUser: 1337
           runAsNonRoot: true
@@ -19882,12 +19883,13 @@ template: |
     {{- end }}
         drop:
         - ALL
-      readOnlyRootFilesystem: false
     {{- if not .Values.istio_cni.enabled }}
+      readOnlyRootFilesystem: false
       runAsGroup: 0
       runAsNonRoot: false
       runAsUser: 0
     {{- else }}
+      readOnlyRootFilesystem: true
       runAsGroup: 1337
       runAsUser: 1337
       runAsNonRoot: true

--- a/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
@@ -170,7 +170,7 @@ spec:
             drop:
             - ALL
           privileged: false
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
           runAsGroup: 1337
           runAsNonRoot: true
           runAsUser: 1337


### PR DESCRIPTION
When Istio CNI is enabled, the `istio-init` container is injected. Set `readOnlyRootFilesystem: true` in this case, since the container only checks that `iptables` redirection is setup and doesn't need to write to the filesystem. This allows using PodSecurityPolicies that forbid writable filesystems.

Fixes: https://github.com/istio/istio/issues/22695