### PR TITLE
Manual cherry pick of fix blackhole and passthrough for telemetry v2 …

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -185,10 +185,11 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(node *
 		// This needs to be the last virtual host, as routes are evaluated in order.
 		if util.IsAllowAnyOutbound(node) {
 			virtualHosts = append(virtualHosts, &route.VirtualHost{
-				Name:    util.PassthroughRouteName,
+				Name:    util.Passthrough,
 				Domains: []string{"*"},
 				Routes: []*route.Route{
 					{
+						Name: util.Passthrough,
 						Match: &route.RouteMatch{
 							PathSpecifier: &route.RouteMatch_Prefix{Prefix: "/"},
 						},
@@ -204,10 +205,11 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(node *
 			})
 		} else {
 			virtualHosts = append(virtualHosts, &route.VirtualHost{
-				Name:    util.BlackHoleRouteName,
+				Name:    util.BlackHole,
 				Domains: []string{"*"},
 				Routes: []*route.Route{
 					{
+						Name: util.BlackHole,
 						Match: &route.RouteMatch{
 							PathSpecifier: &route.RouteMatch_Prefix{Prefix: "/"},
 						},

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -767,7 +767,7 @@ func TestSidecarOutboundHTTPRouteConfigWithFallthroughRouteEnabled(t *testing.T)
 		}
 		vhost := config.VirtualHosts[0]
 
-		if vhost.Name != util.PassthroughRouteName {
+		if vhost.Name != util.Passthrough {
 			t.Fatalf("vhost name is %s", vhost.Name)
 		}
 		if len(vhost.Routes) != 1 {

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -523,7 +523,7 @@ func modifyOutboundRouteConfig(push *model.PushContext, in *plugin.InputParams, 
 	// route.Route_DirectResponse is used for the BlackHole cluster configuration,
 	// hence adding the attributes for the mixer filter
 	case *route.Route_DirectResponse:
-		if virtualHostname == util.BlackHoleRouteName {
+		if virtualHostname == util.BlackHole {
 			hostname := host.Name(util.BlackHoleCluster)
 			attrs := addVirtualDestinationServiceAttributes(make(attributes), hostname)
 			addFilterConfigToRoute(in, httpRoute, attrs)

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -48,14 +48,14 @@ import (
 const (
 	// BlackHoleCluster to catch traffic from routes with unresolved clusters. Traffic arriving here goes nowhere.
 	BlackHoleCluster = "BlackHoleCluster"
-	// BlackHoleRouteName is the name of the route that blocks all traffic.
-	BlackHoleRouteName = "block_all"
+	// BlackHole is the name of the virtual host and route name used to block all traffic
+	BlackHole = "block_all"
 	// PassthroughCluster to forward traffic to the original destination requested. This cluster is used when
 	// traffic does not match any listener in envoy.
 	PassthroughCluster = "PassthroughCluster"
-	// PassthroughRouteName is the name of the route that forwards traffic to the
+	// Passthrough is the name of the virtual host used to forward traffic to the
 	// PassthroughCluster
-	PassthroughRouteName = "allow_any"
+	Passthrough = "allow_any"
 
 	// Inbound pass through cluster need to the bind the loopback ip address for the security and loop avoidance.
 	InboundPassthroughClusterIpv4 = "InboundPassthroughClusterIpv4"


### PR DESCRIPTION
…(#22693)

* Fix blackhole and passthrough for telemetry v2

VirtualHost was being set, not the name of the route. By changing the
name of the route it is possible to check in the telemetry v2 filter
the route name to see if it is sending it to Blackhole/Passthrough and
setting the destination_service_name appropriately.

* Consolidate virtualhost and route name into a single variable