### PR TITLE
add weight for bookinfo gateway route

### DIFF
--- a/samples/bookinfo/networking/bookinfo-gateway.yaml
+++ b/samples/bookinfo/networking/bookinfo-gateway.yaml
@@ -39,3 +39,4 @@ spec:
         host: productpage
         port:
           number: 9080
+      weight: 100


### PR DESCRIPTION
- [x] Configuration Infrastructure

I create Bookinfo-gateway based on [Open the application to outside traffic](https://istio.io/docs/setup/getting-started/#ip), and I received the following prompt.

```bash
[root@ks-allinone istio-1.5.1]# kubectl apply -f samples/bookinfo/networking/bookinfo-gateway.yaml
gateway.networking.istio.io/bookinfo-gateway created
The VirtualService "bookinfo" is invalid: spec.http.route.weight: Required value
```

Route `weight` seems to be required, I changed this [yaml](https://raw.githubusercontent.com/istio/istio/release-1.5/samples/bookinfo/networking/bookinfo-gateway.yaml) file, and added the weight item, then I successfully created gateway for Bookinfo.

```bash
[root@ks-allinone test]# kubectl apply -f ./bookinfo-gateway.yaml
gateway.networking.istio.io/bookinfo-gateway unchanged
virtualservice.networking.istio.io/bookinfo created
```

I noticed that both master and release-1.5 configuration files may have this problem. If possible, please add a label `cherrypick/release-1.5` to update the contents of both branches