### PR TITLE
[release-1.5] Set readOnlyRootFilesystem to true for istio-init with Istio CNI is enabled

### DIFF
--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -59,12 +59,13 @@ initContainers:
   {{- end }}
       drop:
       - ALL
-    readOnlyRootFilesystem: false
   {{- if not .Values.istio_cni.enabled }}
+    readOnlyRootFilesystem: false
     runAsGroup: 0
     runAsNonRoot: false
     runAsUser: 0
   {{- else }}
+    readOnlyRootFilesystem: true
     runAsGroup: 1337
     runAsUser: 1337
     runAsNonRoot: true

--- a/manifests/istio-control/istio-autoinject/files/injection-template.yaml
+++ b/manifests/istio-control/istio-autoinject/files/injection-template.yaml
@@ -60,12 +60,13 @@ template: |
     {{- end }}
         drop:
         - ALL
-      readOnlyRootFilesystem: false
     {{- if not .Values.istio_cni.enabled }}
+      readOnlyRootFilesystem: false
       runAsGroup: 0
       runAsNonRoot: false
       runAsUser: 0
     {{- else }}
+      readOnlyRootFilesystem: true
       runAsGroup: 1337
       runAsUser: 1337
       runAsNonRoot: true

--- a/manifests/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/istio-control/istio-discovery/files/injection-template.yaml
@@ -65,12 +65,13 @@ template: |
     {{- end }}
         drop:
         - ALL
-      readOnlyRootFilesystem: false
     {{- if not .Values.istio_cni.enabled }}
+      readOnlyRootFilesystem: false
       runAsGroup: 0
       runAsNonRoot: false
       runAsUser: 0
     {{- else }}
+      readOnlyRootFilesystem: true
       runAsGroup: 1337
       runAsUser: 1337
       runAsNonRoot: true

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -9595,12 +9595,13 @@ var _chartsIstioControlIstioAutoinjectFilesInjectionTemplateYaml = []byte(`templ
     {{- end }}
         drop:
         - ALL
-      readOnlyRootFilesystem: false
     {{- if not .Values.istio_cni.enabled }}
+      readOnlyRootFilesystem: false
       runAsGroup: 0
       runAsNonRoot: false
       runAsUser: 0
     {{- else }}
+      readOnlyRootFilesystem: true
       runAsGroup: 1337
       runAsUser: 1337
       runAsNonRoot: true
@@ -12124,12 +12125,13 @@ template: |
     {{- end }}
         drop:
         - ALL
-      readOnlyRootFilesystem: false
     {{- if not .Values.istio_cni.enabled }}
+      readOnlyRootFilesystem: false
       runAsGroup: 0
       runAsNonRoot: false
       runAsUser: 0
     {{- else }}
+      readOnlyRootFilesystem: true
       runAsGroup: 1337
       runAsUser: 1337
       runAsNonRoot: true

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -16,7 +16,7 @@ spec:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
         sidecar.istio.io/rewriteAppHTTPProbers: "true"
-        sidecar.istio.io/status: '{"version":"09a530b272ffaba013bd5b144df96b7d93dec7c9302a3123185a2c60f2fcebac","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"3fc2923ad4d167217f18ce4eaef2f85ea8168f11f825c3c972c1d3c18f746c15","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: 80,90
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -16,7 +16,7 @@ spec:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
         sidecar.istio.io/rewriteAppHTTPProbers: "false"
-        sidecar.istio.io/status: '{"version":"09a530b272ffaba013bd5b144df96b7d93dec7c9302a3123185a2c60f2fcebac","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"3fc2923ad4d167217f18ce4eaef2f85ea8168f11f825c3c972c1d3c18f746c15","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: 80,90
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"09a530b272ffaba013bd5b144df96b7d93dec7c9302a3123185a2c60f2fcebac","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"3fc2923ad4d167217f18ce4eaef2f85ea8168f11f825c3c972c1d3c18f746c15","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: 80,90
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"09a530b272ffaba013bd5b144df96b7d93dec7c9302a3123185a2c60f2fcebac","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"3fc2923ad4d167217f18ce4eaef2f85ea8168f11f825c3c972c1d3c18f746c15","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: "80"
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'

--- a/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"09a530b272ffaba013bd5b144df96b7d93dec7c9302a3123185a2c60f2fcebac","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"3fc2923ad4d167217f18ce4eaef2f85ea8168f11f825c3c972c1d3c18f746c15","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: 80,90
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'

--- a/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"09a530b272ffaba013bd5b144df96b7d93dec7c9302a3123185a2c60f2fcebac","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"3fc2923ad4d167217f18ce4eaef2f85ea8168f11f825c3c972c1d3c18f746c15","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: "80"
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'

--- a/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"09a530b272ffaba013bd5b144df96b7d93dec7c9302a3123185a2c60f2fcebac","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"3fc2923ad4d167217f18ce4eaef2f85ea8168f11f825c3c972c1d3c18f746c15","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: "80"
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'

--- a/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"09a530b272ffaba013bd5b144df96b7d93dec7c9302a3123185a2c60f2fcebac","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"3fc2923ad4d167217f18ce4eaef2f85ea8168f11f825c3c972c1d3c18f746c15","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: 80,90
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'

--- a/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"09a530b272ffaba013bd5b144df96b7d93dec7c9302a3123185a2c60f2fcebac","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"3fc2923ad4d167217f18ce4eaef2f85ea8168f11f825c3c972c1d3c18f746c15","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: "80"
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'

--- a/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/interceptionMode: REDIRECT
-        sidecar.istio.io/status: '{"version":"09a530b272ffaba013bd5b144df96b7d93dec7c9302a3123185a2c60f2fcebac","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"3fc2923ad4d167217f18ce4eaef2f85ea8168f11f825c3c972c1d3c18f746c15","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: "15020"
         traffic.sidecar.istio.io/includeInboundPorts: 80,90
         traffic.sidecar.istio.io/includeOutboundIPRanges: '*'

--- a/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
@@ -197,7 +197,7 @@ spec:
             drop:
             - ALL
           privileged: false
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
           runAsGroup: 1337
           runAsNonRoot: true
           runAsUser: 1337


### PR DESCRIPTION
This is an manual cherry-pick of https://github.com/istio/istio/pull/22701

This differs from the master PR in the manifest files modified, the files modified by `make gen`, and the Helm chart files (`release-1.5` is still shipping the Helm charts unlike `master`).

Fixes: https://github.com/istio/istio/issues/22695