### PR TITLE
Place an advisory pin on both bottom and top of K8s API

### DIFF
--- a/istioctl/pkg/install/pre-check_test.go
+++ b/istioctl/pkg/install/pre-check_test.go
@@ -43,10 +43,10 @@ var (
 		Minor:      "13",
 		GitVersion: "1.13",
 	}
-	version1_8 = &version.Info{
+	version1_12 = &version.Info{
 		Major:      "1",
-		Minor:      "8",
-		GitVersion: "1.8",
+		Minor:      "12",
+		GitVersion: "1.12",
 	}
 	version1_13GKE = &version.Info{
 		Major:      "1",
@@ -63,14 +63,27 @@ var (
 		Minor:      "8",
 		GitVersion: "v1.invalid.7",
 	}
+	version1_19 = &version.Info{
+		Major:      "1",
+		Minor:      "19",
+		GitVersion: "1.19",
+	}
 )
 
 func TestPreCheck(t *testing.T) {
 	cases := []testcase{
 		{
-			description: "Lower Kubernetes Version",
+			description: "Kubernetes version less then pin",
 			config: &mockClientExecPreCheckConfig{
-				version:   version1_8,
+				version:   version1_12,
+				namespace: "test",
+			},
+			expectedException: true,
+		},
+		{
+			description: "Kubernetes version greater then pin",
+			config: &mockClientExecPreCheckConfig{
+				version:   version1_19,
 				namespace: "test",
 			},
 			expectedException: true,


### PR DESCRIPTION
Fixes: https://github.com/istio/istio/issues/22740

The prior code only pinned the earliest API known to work with Istio.
This current code pins at the top and bottom. There are reports that
K8s 1.18 does not work with Istio 1.5, and as such we would want to
tell the operator they may run into trouble.