### PR TITLE
fix iptables null point panic

### DIFF
--- a/tools/istio-iptables/pkg/cmd/run.go
+++ b/tools/istio-iptables/pkg/cmd/run.go
@@ -462,10 +462,10 @@ func (iptConfigurator *IptablesConfigurator) executeIptablesRestoreCommand(isIpv
 		cmd = constants.IP6TABLESRESTORE
 	}
 	rulesFile, err := ioutil.TempFile("", filename)
-	defer os.Remove(rulesFile.Name())
 	if err != nil {
 		return fmt.Errorf("unable to create iptables-restore file: %v", err)
 	}
+	defer os.Remove(rulesFile.Name())
 	if err := iptConfigurator.createRulesFile(rulesFile, data); err != nil {
 		return err
 	}


### PR DESCRIPTION
[X ] Networking

We should add `os.Remove` after the check of `err` is nil or not, otherwise if `err` is not nil ,  thus `rulesFile` is nil, so when defer is called, it will cause a null point panic.