### PR TITLE
Remove reflect.DeepEqual from listener hot path

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -2582,7 +2582,6 @@ func isFilterChainMatchEmpty(fcm *listener.FilterChainMatch) bool {
 	return true
 }
 
-
 func isFallthroughFilterChain(fc *listener.FilterChain) bool {
 	if fc.Metadata != nil && fc.Metadata.FilterMetadata != nil &&
 		fc.Metadata.FilterMetadata[PilotMetaKey] != nil && fc.Metadata.FilterMetadata[PilotMetaKey].Fields["fallthrough"] != nil {

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -626,6 +626,15 @@ func TestGetActualWildcardAndLocalHost(t *testing.T) {
 	}
 }
 
+func TestIsFilterChainMatchEmpty(t *testing.T) {
+	fcm := listener.FilterChainMatch{}
+	e := reflect.ValueOf(&fcm).Elem()
+	// This isn't really testing the code, its just making sure an Envoy update won't silently break this method
+	if e.NumField() != 13 {
+		t.Fatalf("Expected 13 fields, got %v. This means we need to update isFilterChainMatchEmpty", e.NumField())
+	}
+}
+
 func testOutboundListenerConflictWithSniffingDisabled(t *testing.T, services ...*model.Service) {
 	t.Helper()
 


### PR DESCRIPTION
This is a performance optimization only
```
name                                 old time/op    new time/op    delta
ListenerGeneration/empty-6             6.98ms ± 3%    6.15ms ± 4%  -11.95%  (p=0.008 n=5+5)
ListenerGeneration/telemetry-6         7.86ms ± 4%    7.12ms ± 1%   -9.34%  (p=0.008 n=5+5)
ListenerGeneration/virtualservice-6    6.70ms ± 1%    5.95ms ± 2%  -11.14%  (p=0.008 n=5+5)

name                                 old alloc/op   new alloc/op   delta
ListenerGeneration/empty-6             2.73MB ± 0%    2.52MB ± 0%   -7.68%  (p=0.008 n=5+5)
ListenerGeneration/telemetry-6         3.13MB ± 0%    2.92MB ± 0%   -6.70%  (p=0.008 n=5+5)
ListenerGeneration/virtualservice-6    2.73MB ± 0%    2.53MB ± 0%   -7.68%  (p=0.008 n=5+5)

name                                 old allocs/op  new allocs/op  delta
ListenerGeneration/empty-6              37.4k ± 0%     34.5k ± 0%   -7.72%  (p=0.008 n=5+5)
ListenerGeneration/telemetry-6          42.4k ± 0%     39.5k ± 0%   -6.81%  (p=0.008 n=5+5)
ListenerGeneration/virtualservice-6     37.4k ± 0%     34.5k ± 0%     ~     (p=0.079 n=4+5)
```