### PR TITLE
Optimize mgmt listener build

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -818,7 +818,7 @@ func testSidecarRDSVHosts(t *testing.T, services []*model.Service,
 	p := &fakePlugin{}
 	configgen := NewConfigGenerator([]plugin.Plugin{p})
 
-	env := buildListenerEnvWithVirtualServices(services, virtualServices)
+	env := buildListenerEnvWithVirtualServices(services, virtualServices, nil)
 
 	if err := env.PushContext.InitContext(&env, nil, nil); err != nil {
 		t.Fatalf("failed to initialize push context")

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -16,6 +16,7 @@ package v1alpha3
 
 import (
 	"sort"
+	"strconv"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
@@ -173,6 +174,24 @@ func (lb *ListenerBuilder) buildSidecarOutboundListeners(configgen *ConfigGenera
 	return lb
 }
 
+// addressKey takes a *core.Address and coverts it to a unique string identifier
+func addressKey(addr *core.Address) string {
+	switch t := addr.Address.(type) {
+	case *core.Address_SocketAddress:
+		var port string
+		switch pt := t.SocketAddress.PortSpecifier.(type) {
+		case *core.SocketAddress_NamedPort:
+			port = pt.NamedPort
+		case *core.SocketAddress_PortValue:
+			port = strconv.Itoa(int(pt.PortValue))
+		}
+		return t.SocketAddress.Address + "_" + port
+	case *core.Address_Pipe:
+		return t.Pipe.Path
+	}
+	return addr.String()
+}
+
 func (lb *ListenerBuilder) buildManagementListeners(_ *ConfigGeneratorImpl) *ListenerBuilder {
 	// Do not generate any management port listeners if the user has specified a SidecarScope object
 	// with ingress listeners. Specifying the ingress listener implies that the user wants
@@ -191,12 +210,12 @@ func (lb *ListenerBuilder) buildManagementListeners(_ *ConfigGeneratorImpl) *Lis
 	addresses := make(map[string]*xdsapi.Listener)
 	for _, listener := range lb.inboundListeners {
 		if listener != nil {
-			addresses[listener.Address.String()] = listener
+			addresses[addressKey(listener.Address)] = listener
 		}
 	}
 	for _, listener := range lb.outboundListeners {
 		if listener != nil {
-			addresses[listener.Address.String()] = listener
+			addresses[addressKey(listener.Address)] = listener
 		}
 	}
 
@@ -205,7 +224,7 @@ func (lb *ListenerBuilder) buildManagementListeners(_ *ConfigGeneratorImpl) *Lis
 	// non overlapping listeners only.
 	for i := range mgmtListeners {
 		m := mgmtListeners[i]
-		addressString := m.Address.String()
+		addressString := addressKey(m.Address)
 		existingListener, ok := addresses[addressString]
 		if ok {
 			log.Debugf("Omitting listener for management address %s due to collision with service listener (%s)",

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -1881,6 +1881,7 @@ func buildListenerEnvWithVirtualServices(services []*model.Service, virtualServi
 		}
 	}
 	serviceDiscovery.GetProxyServiceInstancesReturns(instances, nil)
+	serviceDiscovery.ManagementPortsReturns([]*model.Port{{Port: 9876, Protocol: protocol.HTTP}})
 
 	envoyFilter := model.Config{
 		ConfigMeta: model.ConfigMeta{

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter_test.go
@@ -78,7 +78,7 @@ func TestInboundNetworkFilterStatPrefix(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 
-			env := buildListenerEnv(services)
+			env := buildListenerEnv(services, nil)
 			env.PushContext.InitContext(&env, nil, nil)
 			env.PushContext.Mesh.InboundClusterStatName = tt.statPattern
 
@@ -208,7 +208,7 @@ func TestOutboundNetworkFilterStatPrefix(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 
-			env := buildListenerEnv(services)
+			env := buildListenerEnv(services, nil)
 			env.PushContext.InitContext(&env, nil, nil)
 			env.PushContext.Mesh.OutboundClusterStatName = tt.statPattern
 


### PR DESCRIPTION
I also added some basic test for this, as we have none currently

```
name                                 old time/op    new time/op    delta
ListenerGeneration/empty-6             6.98ms ± 3%    5.89ms ± 2%  -15.65%  (p=0.008 n=5+5)
ListenerGeneration/telemetry-6         7.86ms ± 4%    6.71ms ± 3%  -14.58%  (p=0.008 n=5+5)
ListenerGeneration/virtualservice-6    6.70ms ± 1%    5.73ms ± 3%  -14.44%  (p=0.008 n=5+5)

name                                 old alloc/op   new alloc/op   delta
ListenerGeneration/empty-6             2.73MB ± 0%    2.57MB ± 0%   -6.12%  (p=0.008 n=5+5)
ListenerGeneration/telemetry-6         3.13MB ± 0%    2.96MB ± 0%   -5.35%  (p=0.008 n=5+5)
ListenerGeneration/virtualservice-6    2.73MB ± 0%    2.57MB ± 0%   -6.12%  (p=0.008 n=5+5)

name                                 old allocs/op  new allocs/op  delta
ListenerGeneration/empty-6              37.4k ± 0%     30.8k ± 0%  -17.55%  (p=0.000 n=5+4)
ListenerGeneration/telemetry-6          42.4k ± 0%     35.8k ± 0%  -15.49%  (p=0.008 n=5+5)
ListenerGeneration/virtualservice-6     37.4k ± 0%     30.8k ± 0%  -17.55%  (p=0.016 n=4+5)
```