### PR TITLE
Add root namespace to pilot configmap

### DIFF
--- a/manifests/istio-control/istio-discovery/templates/configmap.yaml
+++ b/manifests/istio-control/istio-discovery/templates/configmap.yaml
@@ -124,6 +124,14 @@
 {{ toYaml .Values.global.localityLbSetting | trim | indent 6 }}
     {{- end }}
 
+    # The namespace to treat as the administrative root namespace for istio
+    # configuration.
+{{- if .Values.global.configRootNamespace }}
+    rootNamespace: {{ .Values.global.configRootNamespace }}
+{{- else }}
+    rootNamespace: {{ .Release.Namespace }}
+{{- end }}
+
     # Configures DNS certificates provisioned through Chiron linked into Pilot.
     # The DNS certificate provisioning is enabled by default now so it get tested.
     # TODO (lei-tang): we'll decide whether enable it by default or not before Istio 1.4 Release.


### PR DESCRIPTION
Sets the `rootNamespace` in the Pilot configmap. Code copied directly from the legacy Helm installer https://github.com/istio/istio/blob/0f0c0a31b5a935b962db7303e006f65aa68e2dd4/install/kubernetes/helm/istio/templates/configmap.yaml#L157-L163

I haven't tested this on 1.5, but we definitely needed to do this on 1.4 (https://github.com/istio/installer/pull/592).