### PR TITLE
Select new labels in istioctl

### DIFF
--- a/istioctl/pkg/kubernetes/client.go
+++ b/istioctl/pkg/kubernetes/client.go
@@ -148,7 +148,7 @@ func (client *Client) PodExec(podName, podNamespace, container string, command [
 // AllPilotsDiscoveryDo makes an http request to each Pilot discovery instance
 func (client *Client) AllPilotsDiscoveryDo(pilotNamespace, method, path string, body []byte) (map[string][]byte, error) {
 	pilots, err := client.GetIstioPods(pilotNamespace, map[string]string{
-		"labelSelector": "istio=pilot",
+		"labelSelector": "app=istiod",
 		"fieldSelector": "status.phase=Running",
 	})
 	if err != nil {
@@ -174,7 +174,7 @@ func (client *Client) AllPilotsDiscoveryDo(pilotNamespace, method, path string, 
 // PilotDiscoveryDo makes an http request to a single Pilot discovery instance
 func (client *Client) PilotDiscoveryDo(pilotNamespace, method, path string, body []byte) ([]byte, error) {
 	pilots, err := client.GetIstioPods(pilotNamespace, map[string]string{
-		"labelSelector": "istio=pilot",
+		"labelSelector": "app=istiod",
 		"fieldSelector": "status.phase=Running",
 	})
 	if err != nil {
@@ -282,6 +282,7 @@ func (client *Client) GetIstioVersions(namespace string) (*version.MeshInfo, err
 
 	labelToPodDetail := map[string]podDetail{
 		"pilot":            {"/usr/local/bin/pilot-discovery", "discovery"},
+		"istiod":           {"/usr/local/bin/pilot-discovery", "discovery"},
 		"citadel":          {"/usr/local/bin/istio_ca", "citadel"},
 		"egressgateway":    {"/usr/local/bin/pilot-agent", "istio-proxy"},
 		"galley":           {"/usr/local/bin/galley", "galley"},

--- a/manifests/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/istio-control/istio-discovery/templates/deployment.yaml
@@ -36,6 +36,8 @@ spec:
         istio.io/rev: {{ .Values.revision | default "default" }}
         {{- if eq .Values.revision ""}}
         istio: pilot
+        {{- else }}
+        istio: istiod
         {{- end }}
       annotations:
         sidecar.istio.io/inject: "false"

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -19631,6 +19631,8 @@ spec:
         istio.io/rev: {{ .Values.revision | default "default" }}
         {{- if eq .Values.revision ""}}
         istio: pilot
+        {{- else }}
+        istio: istiod
         {{- end }}
       annotations:
         sidecar.istio.io/inject: "false"


### PR DESCRIPTION
Revisions do not have the istio=pilot label, and they cannot due legacy
purposes (the old Service must not select a revision). This changes
istioctl to look for app=istiod,which is present on 1.5+ Istiod's. This
means istioctl will no longer work with 1.4 pilot - not sure if thats
ok.

To better support `istioctl version`, I also added a istio=istiod label
to the pod