### PR TITLE
Align envoy log format with Istio

### DIFF
--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -118,7 +118,9 @@ func (e *envoy) args(fname string, epoch int, bootstrapConfig string) []string {
 		"--service-node", e.Node,
 		"--max-obj-name-len", fmt.Sprint(e.Config.StatNameLength),
 		"--local-address-ip-version", proxyLocalAddressType,
-		"--log-format", fmt.Sprintf("[Envoy (Epoch %d)] ", epoch) + "[%Y-%m-%d %T.%e][%t][%l][%n] %v",
+		// format is like `2020-04-07T16:52:30.471425Z     info    envoy config   ...message..
+		// this matches Istio log format
+		"--log-format", "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n\t%v",
 	}
 
 	startupArgs = append(startupArgs, e.extraArgs...)

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -58,7 +58,7 @@ func TestEnvoyArgs(t *testing.T) {
 		"--service-node", "my-node",
 		"--max-obj-name-len", fmt.Sprint(proxyConfig.StatNameLength),
 		"--local-address-ip-version", "v4",
-		"--log-format", "[Envoy (Epoch 5)] [%Y-%m-%d %T.%e][%t][%l][%n] %v",
+		"--log-format", "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n\t%v",
 		"-l", "trace",
 		"--component-log-level", "misc:error",
 		"--config-yaml", `{"key": "value"}`,


### PR DESCRIPTION
This makes it so we don't have two conflicting log formats going on in
the same container (istio-agent)

Example:
```
2020-04-07T23:53:03.640430Z     info    sds     resource:ROOTCA new connection
2020-04-07T23:53:03.640486Z     info    cache   Loaded root cert from certificate ROOTCA
2020-04-07T23:53:03.640629Z     info    sds     resource:ROOTCA pushed root cert to proxy
2020-04-07T16:53:03.651593Z     info    envoy upstream  [external/envoy/source/common/upstream/cluster_manager_impl.cc:171] cm init: all clusters initialized
2020-04-07T16:53:03.651615Z     info    envoy main      [external/envoy/source/server/server.cc:554] all clusters initialized. initializing init manager
2020-04-07T16:53:03.686877Z     info    envoy upstream  [external/envoy/source/server/lds_api.cc:74] lds: add/update listener '10.109.24.165_443'
2020-04-07T16:53:03.687220Z     info    envoy upstream  [external/envoy/source/server/lds_api.cc:74] lds: add/update listener '10.109.24.165_15012'
2020-04-07T16:53:03.687529Z     info    envoy upstream  [external/envoy/source/server/lds_api.cc:74] lds: add/update listener '10.111.195.20_443'
2020-04-07T16:53:03.687859Z     info    envoy upstream  [external/envoy/source/server/lds_api.cc:74] lds: add/update listener '10.111.195.20_15443'
2020-04-07T16:53:03.688170Z     info    envoy upstream  [external/envoy/source/server/lds_api.cc:74] lds: add/update listener '10.96.0.1_443'
2020-04-07T16:53:03.688481Z     info    envoy upstream  [external/envoy/source/server/lds_api.cc:74] lds: add/update listener '10.96.0.10_53'
```

