### PR TITLE
Several fixes for non-default control plane namespace

### DIFF
--- a/manifests/base/files/gen-istio-cluster.yaml
+++ b/manifests/base/files/gen-istio-cluster.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: istio-reader-service-account
-  namespace: istio-system
+  namespace: default
   labels:
     app: istio-reader
     release: istio-base
@@ -13,7 +13,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: istio-pilot-service-account
-  namespace: istio-system
+  namespace: default
   labels:
     app: pilot
     release: istio-base
@@ -6722,7 +6722,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istiod-istio-system
+  name: istiod-default
   labels:
     app: istiod
     release: istio-base
@@ -6812,7 +6812,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-reader-istio-system
+  name: istio-reader-default
   labels:
     app: istio-reader
     release: istio-base
@@ -6839,34 +6839,34 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-reader-istio-system
+  name: istio-reader-default
   labels:
     app: istio-reader
     release: istio-base
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istio-reader-istio-system
+  name: istio-reader-default
 subjects:
   - kind: ServiceAccount
     name: istio-reader-service-account
-    namespace: istio-system
+    namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istiod-pilot-istio-system
+  name: istiod-pilot-default
   labels:
     app: pilot
     release: istio-base
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istiod-istio-system
+  name: istiod-default
 subjects:
   - kind: ServiceAccount
     name: istio-pilot-service-account
-    namespace: istio-system
+    namespace: default
 ---
 
 ---
@@ -6882,7 +6882,7 @@ subjects:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: istiod-istio-system
+  name: istiod-default
   labels:
     app: istiod
     release: istio-base
@@ -6892,7 +6892,7 @@ webhooks:
     clientConfig:
       service:
         name: istiod
-        namespace: istio-system
+        namespace: default
         path: "/validate"
       caBundle: "" # patched at runtime when the webhook is ready.
     rules:
@@ -6915,3 +6915,4 @@ webhooks:
     failurePolicy: Ignore
     sideEffects: None
 ---
+

--- a/manifests/base/templates/clusterrole.yaml
+++ b/manifests/base/templates/clusterrole.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istiod-{{ .Values.global.istioNamespace }}
+  name: istiod-{{ .Release.Namespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}
@@ -105,7 +105,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-reader-{{ .Values.global.istioNamespace }}
+  name: istio-reader-{{ .Release.Namespace }}
   labels:
     app: istio-reader
     release: {{ .Release.Name }}

--- a/manifests/base/templates/clusterrolebinding.yaml
+++ b/manifests/base/templates/clusterrolebinding.yaml
@@ -1,32 +1,32 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-reader-{{ .Values.global.istioNamespace }}
+  name: istio-reader-{{ .Release.Namespace }}
   labels:
     app: istio-reader
     release: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istio-reader-{{ .Values.global.istioNamespace }}
+  name: istio-reader-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: istio-reader-service-account
-    namespace: {{ .Values.global.istioNamespace }}
+    namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istiod-pilot-{{ .Values.global.istioNamespace }}
+  name: istiod-pilot-{{ .Release.Namespace }}
   labels:
     app: pilot
     release: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istiod-{{ .Values.global.istioNamespace }}
+  name: istiod-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: istio-pilot-service-account
-    namespace: {{ .Values.global.istioNamespace }}
+    namespace: {{ .Release.Namespace }}
 ---

--- a/manifests/base/templates/endpoints.yaml
+++ b/manifests/base/templates/endpoints.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Endpoints
 metadata:
   name: istio-pilot
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Release.Namespace }}
 subsets:
 - addresses:
   - ip: {{ .Values.global.remotePilotAddress }}
@@ -33,7 +33,7 @@ apiVersion: v1
 kind: Endpoints
 metadata:
   name: istio-policy
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Release.Namespace }}
 subsets:
 - addresses:
   - ip: {{ .Values.global.remotePolicyAddress }}
@@ -51,7 +51,7 @@ apiVersion: v1
 kind: Endpoints
 metadata:
   name: istio-telemetry
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Release.Namespace }}
 subsets:
 - addresses:
   - ip: {{ .Values.global.remoteTelemetryAddress }}

--- a/manifests/base/templates/serviceaccount.yaml
+++ b/manifests/base/templates/serviceaccount.yaml
@@ -8,7 +8,7 @@ imagePullSecrets:
 {{- end }}
 metadata:
   name: istio-reader-service-account
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: istio-reader
     release: {{ .Release.Name }}
@@ -23,7 +23,7 @@ imagePullSecrets:
   {{- end }}
 metadata:
   name: istio-pilot-service-account
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: pilot
     release: {{ .Release.Name }}

--- a/manifests/base/templates/services.yaml
+++ b/manifests/base/templates/services.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: istio-pilot
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - port: 15010
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: istio-policy
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - name: grpc-mixer
@@ -48,7 +48,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: istio-telemetry
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - name: grpc-mixer

--- a/manifests/base/templates/validatingwebhookconfiguration.yaml
+++ b/manifests/base/templates/validatingwebhookconfiguration.yaml
@@ -1,7 +1,7 @@
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: istiod-{{ .Values.global.istioNamespace }}
+  name: istiod-{{ .Release.Namespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}
@@ -11,7 +11,7 @@ webhooks:
     clientConfig:
       service:
         name: istiod
-        namespace: {{ .Values.global.istioNamespace }}
+        namespace: {{ .Release.Namespace }}
         path: "/validate"
       caBundle: "" # patched at runtime when the webhook is ready.
     rules:

--- a/manifests/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/gateways/istio-ingress/templates/deployment.yaml
@@ -136,7 +136,7 @@ spec:
           {{- else if .Values.global.configNamespace }}
             value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.configNamespace }}.svc:15012
           {{- else }}
-            value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.istio-system.svc:15012
+            value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Release.Namespace }}.svc:15012
           {{- end }}
           - name: NODE_NAME
             valueFrom:

--- a/manifests/gateways/istio-ingress/templates/meshexpansion.yaml
+++ b/manifests/gateways/istio-ingress/templates/meshexpansion.yaml
@@ -26,7 +26,7 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   hosts:
-  - istiod.{{ .Values.global.istioNamespace }}.svc.{{ .Values.global.proxy.clusterDomain }}
+  - istiod.{{ .Release.Namespace }}.svc.{{ .Values.global.proxy.clusterDomain }}
   gateways:
   - meshexpansion-gateway
   tcp:
@@ -34,7 +34,7 @@ spec:
     - port: 15012
     route:
     - destination:
-        host: istiod.{{ .Values.global.istioNamespace }}.svc.{{ .Values.global.proxy.clusterDomain }}
+        host: istiod.{{ .Release.Namespace }}.svc.{{ .Values.global.proxy.clusterDomain }}
         port:
           number: 15012
 ---

--- a/manifests/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/istio-control/istio-discovery/files/gen-istio.yaml
@@ -503,7 +503,7 @@ data:
         {{- else if .Values.global.configNamespace }}
           value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.configNamespace }}.svc:15012
         {{- else }}
-          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.istio-system.svc:15012
+          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Release.Namespace }}.svc:15012
         {{- end }}
         - name: POD_NAME
           valueFrom:
@@ -1737,7 +1737,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
   name: istio-sidecar-injector
-
   labels:
     istio.io/rev: default
     app: sidecar-injector

--- a/manifests/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/istio-control/istio-discovery/files/injection-template.yaml
@@ -159,7 +159,7 @@ template: |
     {{- else if .Values.global.configNamespace }}
       value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.configNamespace }}.svc:15012
     {{- else }}
-      value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.istio-system.svc:15012
+      value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Release.Namespace }}.svc:15012
     {{- end }}
     - name: POD_NAME
       valueFrom:

--- a/manifests/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/manifests/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -3,11 +3,7 @@
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-{{- if eq .Release.Namespace "istio-system"}}
   name: istio-sidecar-injector{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-{{ else }}
-  name: istio-sidecar-injector{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}-{{ .Release.Namespace }}
-{{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
     app: sidecar-injector

--- a/manifests/istio-telemetry/kiali/templates/configmap.yaml
+++ b/manifests/istio-telemetry/kiali/templates/configmap.yaml
@@ -13,7 +13,7 @@ data:
       tracing: {{ .Values.global.telemetryNamespace }}
       pilot: {{ .Values.global.configNamespace }}
       prometheus: {{ .Values.global.prometheusNamespace }}
-    istio_namespace: {{ .Values.global.istioNamespace }}
+    istio_namespace: {{ .Release.Namespace }}
     auth:
       strategy: {{ .Values.kiali.dashboard.auth.strategy }}
 {{- if eq .Values.kiali.dashboard.auth.strategy "ldap" }}

--- a/manifests/istio-telemetry/mixer-telemetry/templates/deployment.yaml
+++ b/manifests/istio-telemetry/mixer-telemetry/templates/deployment.yaml
@@ -234,7 +234,7 @@ spec:
           {{- else if .Values.global.configNamespace }}
           value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.configNamespace }}.svc:15012
           {{- else }}
-          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.istio-system.svc:15012
+          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Release.Namespace }}.svc:15012
       {{- end }}
         resources:
 {{- if .Values.global.proxy.resources }}

--- a/manifests/istio-telemetry/prometheus/templates/configmap.yaml
+++ b/manifests/istio-telemetry/prometheus/templates/configmap.yaml
@@ -104,7 +104,7 @@ data:
       - role: endpoints
         namespaces:
           names:
-          - {{ .Values.global.istioNamespace }}
+          - {{ .Release.Namespace }}
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]

--- a/manifests/istio-telemetry/prometheus/templates/deployment.yaml
+++ b/manifests/istio-telemetry/prometheus/templates/deployment.yaml
@@ -106,7 +106,7 @@ spec:
               {{- else if .Values.global.configNamespace }}
               value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.configNamespace }}.svc:15012
               {{- else }}
-              value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.istio-system.svc:15012
+              value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Release.Namespace }}.svc:15012
               {{- end }}
             - name: POD_NAME
               valueFrom:

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -129,6 +129,9 @@ func TestManifestGenerateFlags(t *testing.T) {
 			flags:      "-s profile=minimal",
 			noInput:    true,
 		},
+		{
+			desc: "namespace_override",
+		},
 	})
 	removeDirOrFail(t, flagOutputDir)
 	removeDirOrFail(t, flagOutputValuesDir)
@@ -379,7 +382,7 @@ func TestConfigSelectors(t *testing.T) {
 		"istio": "pilot",
 	}
 	if sel := mustGetLabels(t, deployment, "spec.selector.matchLabels"); !reflect.DeepEqual(deploymentSelector15, sel) {
-		t.Fatalf("Depployment selectors are immutable, but changed since 1.5. Was %v, now is %v", deploymentSelector15, sel)
+		t.Fatalf("Deployment selectors are immutable, but changed since 1.5. Was %v, now is %v", deploymentSelector15, sel)
 	}
 }
 

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/base/templates/clusterrole.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/base/templates/clusterrole.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istiod-{{ .Values.global.istioNamespace }}
+  name: istiod-{{ .Release.Namespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}
@@ -105,7 +105,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-reader-{{ .Values.global.istioNamespace }}
+  name: istio-reader-{{ .Release.Namespace }}
   labels:
     app: istio-reader
     release: {{ .Release.Name }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/base/templates/clusterrolebinding.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/base/templates/clusterrolebinding.yaml
@@ -1,32 +1,32 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-reader-{{ .Values.global.istioNamespace }}
+  name: istio-reader-{{ .Release.Namespace }}
   labels:
     app: istio-reader
     release: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istio-reader-{{ .Values.global.istioNamespace }}
+  name: istio-reader-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: istio-reader-service-account
-    namespace: {{ .Values.global.istioNamespace }}
+    namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istiod-pilot-{{ .Values.global.istioNamespace }}
+  name: istiod-pilot-{{ .Release.Namespace }}
   labels:
     app: pilot
     release: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istiod-{{ .Values.global.istioNamespace }}
+  name: istiod-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: istio-pilot-service-account
-    namespace: {{ .Values.global.istioNamespace }}
+    namespace: {{ .Release.Namespace }}
 ---

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/base/templates/endpoints.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/base/templates/endpoints.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Endpoints
 metadata:
   name: istio-pilot
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Release.Namespace }}
 subsets:
 - addresses:
   - ip: {{ .Values.global.remotePilotAddress }}
@@ -33,7 +33,7 @@ apiVersion: v1
 kind: Endpoints
 metadata:
   name: istio-policy
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Release.Namespace }}
 subsets:
 - addresses:
   - ip: {{ .Values.global.remotePolicyAddress }}
@@ -51,7 +51,7 @@ apiVersion: v1
 kind: Endpoints
 metadata:
   name: istio-telemetry
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Release.Namespace }}
 subsets:
 - addresses:
   - ip: {{ .Values.global.remoteTelemetryAddress }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/base/templates/serviceaccount.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/base/templates/serviceaccount.yaml
@@ -8,7 +8,7 @@ imagePullSecrets:
 {{- end }}
 metadata:
   name: istio-reader-service-account
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: istio-reader
     release: {{ .Release.Name }}
@@ -23,7 +23,7 @@ imagePullSecrets:
   {{- end }}
 metadata:
   name: istio-pilot-service-account
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: pilot
     release: {{ .Release.Name }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/base/templates/services.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/base/templates/services.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: istio-pilot
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - port: 15010
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: istio-policy
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - name: grpc-mixer
@@ -48,7 +48,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: istio-telemetry
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - name: grpc-mixer

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/base/templates/validatingwebhookconfiguration.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/base/templates/validatingwebhookconfiguration.yaml
@@ -1,7 +1,7 @@
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: istiod-{{ .Values.global.istioNamespace }}
+  name: istiod-{{ .Release.Namespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}
@@ -11,7 +11,7 @@ webhooks:
     clientConfig:
       service:
         name: istiod
-        namespace: {{ .Values.global.istioNamespace }}
+        namespace: {{ .Release.Namespace }}
         path: "/validate"
       caBundle: "" # patched at runtime when the webhook is ready.
     rules:

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -136,7 +136,7 @@ spec:
           {{- else if .Values.global.configNamespace }}
             value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.configNamespace }}.svc:15012
           {{- else }}
-            value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.istio-system.svc:15012
+            value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Release.Namespace }}.svc:15012
           {{- end }}
           - name: NODE_NAME
             valueFrom:

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/gateways/istio-ingress/templates/meshexpansion.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/gateways/istio-ingress/templates/meshexpansion.yaml
@@ -26,7 +26,7 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   hosts:
-  - istiod.{{ .Values.global.istioNamespace }}.svc.{{ .Values.global.proxy.clusterDomain }}
+  - istiod.{{ .Release.Namespace }}.svc.{{ .Values.global.proxy.clusterDomain }}
   gateways:
   - meshexpansion-gateway
   tcp:
@@ -34,7 +34,7 @@ spec:
     - port: 15012
     route:
     - destination:
-        host: istiod.{{ .Values.global.istioNamespace }}.svc.{{ .Values.global.proxy.clusterDomain }}
+        host: istiod.{{ .Release.Namespace }}.svc.{{ .Values.global.proxy.clusterDomain }}
         port:
           number: 15012
 ---

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -159,7 +159,7 @@ template: |
     {{- else if .Values.global.configNamespace }}
       value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.configNamespace }}.svc:15012
     {{- else }}
-      value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.istio-system.svc:15012
+      value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Release.Namespace }}.svc:15012
     {{- end }}
     - name: POD_NAME
       valueFrom:

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -3,11 +3,7 @@
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-{{- if eq .Release.Namespace "istio-system"}}
   name: istio-sidecar-injector{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-{{ else }}
-  name: istio-sidecar-injector{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}-{{ .Release.Namespace }}
-{{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
     app: sidecar-injector

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-telemetry/kiali/templates/configmap.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-telemetry/kiali/templates/configmap.yaml
@@ -13,7 +13,7 @@ data:
       tracing: {{ .Values.global.telemetryNamespace }}
       pilot: {{ .Values.global.configNamespace }}
       prometheus: {{ .Values.global.prometheusNamespace }}
-    istio_namespace: {{ .Values.global.istioNamespace }}
+    istio_namespace: {{ .Release.Namespace }}
     auth:
       strategy: {{ .Values.kiali.dashboard.auth.strategy }}
 {{- if eq .Values.kiali.dashboard.auth.strategy "ldap" }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-telemetry/mixer-telemetry/templates/deployment.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-telemetry/mixer-telemetry/templates/deployment.yaml
@@ -234,7 +234,7 @@ spec:
           {{- else if .Values.global.configNamespace }}
           value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.configNamespace }}.svc:15012
           {{- else }}
-          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.istio-system.svc:15012
+          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Release.Namespace }}.svc:15012
       {{- end }}
         resources:
 {{- if .Values.global.proxy.resources }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-telemetry/prometheus/templates/configmap.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-telemetry/prometheus/templates/configmap.yaml
@@ -104,7 +104,7 @@ data:
       - role: endpoints
         namespaces:
           names:
-          - {{ .Values.global.istioNamespace }}
+          - {{ .Release.Namespace }}
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-telemetry/prometheus/templates/deployment.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-telemetry/prometheus/templates/deployment.yaml
@@ -106,7 +106,7 @@ spec:
               {{- else if .Values.global.configNamespace }}
               value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.configNamespace }}.svc:15012
               {{- else }}
-              value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.istio-system.svc:15012
+              value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Release.Namespace }}.svc:15012
               {{- end }}
             - name: POD_NAME
               valueFrom:

--- a/operator/cmd/mesh/testdata/manifest-generate/input/namespace_override.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/input/namespace_override.yaml
@@ -1,0 +1,4 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  namespace: istio

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
@@ -7575,7 +7575,7 @@ data:
         {{- else if .Values.global.configNamespace }}
           value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.configNamespace }}.svc:15012
         {{- else }}
-          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.istio-system.svc:15012
+          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Release.Namespace }}.svc:15012
         {{- end }}
         - name: POD_NAME
           valueFrom:
@@ -7830,7 +7830,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
   name: istio-sidecar-injector
-
   labels:
     istio.io/rev: default
     app: sidecar-injector

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.golden.yaml
@@ -346,7 +346,7 @@ data:
         {{- else if .Values.global.configNamespace }}
           value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.configNamespace }}.svc:15012
         {{- else }}
-          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.istio-system.svc:15012
+          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Release.Namespace }}.svc:15012
         {{- end }}
         - name: POD_NAME
           valueFrom:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/namespace_override.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/namespace_override.golden.yaml
@@ -1,210 +1,7 @@
 # AddonComponents grafana component is disabled.
 
 ---
-# Resources for AddonComponents istiocoredns component
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: istiocoredns
-  labels:
-    app: istiocoredns
-    release: istio
-rules:
-- apiGroups: ["networking.istio.io"]
-  resources: ["*"]
-  verbs: ["get", "watch", "list"]
----
-
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: istio-istiocoredns-role-binding-istio-system
-  labels:
-    app: istiocoredns
-    release: istio
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: istiocoredns
-subjects:
-- kind: ServiceAccount
-  name: istiocoredns-service-account
-  namespace: istio-system
----
-
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: coredns
-  namespace: istio-system
-  labels:
-    app: istiocoredns
-    release: istio
-data:
-  Corefile: |
-    .:53 {
-          errors
-          health
-          
-          # Removed support for the proxy plugin: https://coredns.io/2019/03/03/coredns-1.4.0-release/
-          grpc global 127.0.0.1:8053
-          forward . /etc/resolv.conf {
-            except global
-          }
-          
-          prometheus :9153
-          cache 30
-          reload
-        }
----
-
-
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: istiocoredns
-  namespace: istio-system
-  labels:
-    app: istiocoredns
-    release: istio
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: istiocoredns
-  strategy:
-    rollingUpdate:
-      maxSurge: 100%
-      maxUnavailable: 25%
-  template:
-    metadata:
-      name: istiocoredns
-      labels:
-        app: istiocoredns
-        release: istio
-      annotations:
-        sidecar.istio.io/inject: "false"
-    spec:
-      serviceAccountName: istiocoredns-service-account
-      containers:
-      - name: coredns
-        image: coredns/coredns:1.6.2
-        args: [ "-conf", "/etc/coredns/Corefile" ]
-        volumeMounts:
-        - name: config-volume
-          mountPath: /etc/coredns
-        ports:
-        - containerPort: 53
-          name: dns
-          protocol: UDP
-        - containerPort: 53
-          name: dns-tcp
-          protocol: TCP
-        - containerPort: 9153
-          name: metrics
-          protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 60
-          timeoutSeconds: 5
-          successThreshold: 1
-          failureThreshold: 5
-        resources:
-          requests:
-            cpu: 10m
-          
-      - name: istio-coredns-plugin
-        command:
-        - /usr/local/bin/plugin
-        image: istio/coredns-plugin:0.2-istio-1.1
-        ports:
-        - containerPort: 8053
-          name: dns-grpc
-          protocol: TCP
-        resources:
-          requests:
-            cpu: 10m
-          
-      dnsPolicy: Default
-      volumes:
-      - name: config-volume
-        configMap:
-          name: coredns
-          items:
-          - key: Corefile
-            path: Corefile
-      affinity:      
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - "amd64"
-                - "ppc64le"
-                - "s390x"
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 2
-            preference:
-              matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - "amd64"
-          - weight: 2
-            preference:
-              matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - "ppc64le"
-          - weight: 2
-            preference:
-              matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - "s390x"
----
-
-
-apiVersion: v1
-kind: Service
-metadata:
-  name: istiocoredns
-  namespace: istio-system
-  labels:
-    app: istiocoredns
-    release: istio
-spec:
-  selector:
-    app: istiocoredns
-  ports:
-  - name: dns
-    port: 53
-    protocol: UDP
-  - name: dns-tcp
-    port: 53
-    protocol: TCP
----
-
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: istiocoredns-service-account
-  namespace: istio-system
-  labels:
-    app: istiocoredns
-    release: istio
----
+# AddonComponents istiocoredns component is disabled.
 
 ---
 # AddonComponents kiali component is disabled.
@@ -215,7 +12,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: prometheus-istio-system
+  name: prometheus-istio
   labels:
     app: prometheus
     release: istio
@@ -240,18 +37,18 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: prometheus-istio-system
+  name: prometheus-istio
   labels:
     app: prometheus
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: prometheus-istio-system
+  name: prometheus-istio
 subjects:
 - kind: ServiceAccount
   name: prometheus
-  namespace: istio-system
+  namespace: istio
 ---
 
 
@@ -259,7 +56,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: prometheus
-  namespace: istio-system
+  namespace: istio
   labels:
     app: prometheus
     release: istio
@@ -276,7 +73,7 @@ data:
       - role: endpoints
         namespaces:
           names:
-          - istio-system
+          - istio
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
         action: keep
@@ -311,7 +108,7 @@ data:
       - role: endpoints
         namespaces:
           names:
-          - istio-system
+          - istio
 
 
       relabel_configs:
@@ -324,7 +121,7 @@ data:
       - role: endpoints
         namespaces:
           names:
-          - istio-system
+          - istio
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
@@ -336,7 +133,7 @@ data:
       - role: endpoints
         namespaces:
           names:
-          - istio-system
+          - istio
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
@@ -349,7 +146,7 @@ data:
       - role: endpoints
         namespaces:
           names:
-          - istio-system
+          - istio
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
@@ -361,7 +158,7 @@ data:
       - role: endpoints
         namespaces:
           names:
-          - istio-system
+          - istio
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
@@ -374,7 +171,7 @@ data:
       - role: endpoints
         namespaces:
           names:
-          - istio-system
+          - istio
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
@@ -554,7 +351,7 @@ metadata:
     app: prometheus
     release: istio
   name: prometheus
-  namespace: istio-system
+  namespace: istio
 spec:
   replicas: 1
   selector:
@@ -645,7 +442,7 @@ spec:
         - name: PILOT_CERT_PROVIDER
           value: istiod
         - name: CA_ADDR
-          value: istiod.istio-system.svc:15012
+          value: istiod.istio.svc:15012
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -733,7 +530,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: prometheus
-  namespace: istio-system
+  namespace: istio
   annotations:
     prometheus.io/scrape: 'true'
   labels:
@@ -753,7 +550,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: prometheus
-  namespace: istio-system
+  namespace: istio
   labels:
     app: prometheus
     release: istio
@@ -767,7 +564,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istiod-istio-system
+  name: istiod-istio
   labels:
     app: istiod
     release: istio
@@ -859,7 +656,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-reader-istio-system
+  name: istio-reader-istio
   labels:
     app: istio-reader
     release: istio
@@ -884,36 +681,36 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-reader-istio-system
+  name: istio-reader-istio
   labels:
     app: istio-reader
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istio-reader-istio-system
+  name: istio-reader-istio
 subjects:
   - kind: ServiceAccount
     name: istio-reader-service-account
-    namespace: istio-system
+    namespace: istio
 ---
 
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istiod-pilot-istio-system
+  name: istiod-pilot-istio
   labels:
     app: pilot
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istiod-istio-system
+  name: istiod-istio
 subjects:
   - kind: ServiceAccount
     name: istio-pilot-service-account
-    namespace: istio-system
+    namespace: istio
 ---
 
 
@@ -7639,7 +7436,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: istio-reader-service-account
-  namespace: istio-system
+  namespace: istio
   labels:
     app: istio-reader
     release: istio
@@ -7650,7 +7447,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: istio-pilot-service-account
-  namespace: istio-system
+  namespace: istio
   labels:
     app: pilot
     release: istio
@@ -7660,7 +7457,7 @@ metadata:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: istiod-istio-system
+  name: istiod-istio
   labels:
     app: istiod
     release: istio
@@ -7670,7 +7467,7 @@ webhooks:
     clientConfig:
       service:
         name: istiod
-        namespace: istio-system
+        namespace: istio
         path: "/validate"
       caBundle: "" # patched at runtime when the webhook is ready.
     rules:
@@ -7696,542 +7493,243 @@ webhooks:
 
 # Cni component is disabled.
 
-# Resources for EgressGateways component
-
-apiVersion: autoscaling/v2beta1
-kind: HorizontalPodAutoscaler
-metadata:
-  name: istio-egressgateway
-  namespace: istio-system
-  labels:
-    app: istio-egressgateway
-    istio: egressgateway
-    
-    release: istio
-spec:
-  maxReplicas: 5
-  minReplicas: 1
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: istio-egressgateway
-  metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        targetAverageUtilization: 80
----
-
-
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: istio-egressgateway
-  namespace: istio-system
-  labels:
-    app: istio-egressgateway
-    istio: egressgateway
-    
-    release: istio
-spec:
-  selector:
-    matchLabels:
-      app: istio-egressgateway
-      istio: egressgateway
-      
-  strategy:
-    rollingUpdate:
-      maxSurge: 100%
-      maxUnavailable: 25%
-  template:
-    metadata:
-      labels:
-        app: istio-egressgateway
-        istio: egressgateway
-        
-        heritage: Tiller
-        release: istio
-        chart: gateways
-        service.istio.io/canonical-name: istio-egressgateway
-        service.istio.io/canonical-revision: latest
-      annotations:
-        sidecar.istio.io/inject: "false"
-    spec:
-      serviceAccountName: istio-egressgateway-service-account
-      containers:
-        - name: istio-proxy
-          image: "gcr.io/istio-testing/proxyv2:latest"
-          ports:
-            - containerPort: 80
-            - containerPort: 443
-            - containerPort: 15443
-            - containerPort: 15090
-              protocol: TCP
-              name: http-envoy-prom
-          args:
-          - proxy
-          - router
-          - --domain
-          - $(POD_NAMESPACE).svc.cluster.local
-          - --proxyLogLevel=warning
-          - --proxyComponentLogLevel=misc:error
-          - --log_output_level=default:info
-          - --serviceCluster
-          - istio-egressgateway
-          - --trust-domain=cluster.local
-          readinessProbe:
-            failureThreshold: 30
-            httpGet:
-              path: /healthz/ready
-              port: 15020
-              scheme: HTTP
-            initialDelaySeconds: 1
-            periodSeconds: 2
-            successThreshold: 1
-            timeoutSeconds: 1
-          resources:
-            limits:
-              cpu: 2000m
-              memory: 1024Mi
-            requests:
-              cpu: 100m
-              memory: 128Mi
-            
-          env:
-          - name: JWT_POLICY
-            value: third-party-jwt
-          - name: PILOT_CERT_PROVIDER
-            value: istiod
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: spec.nodeName
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.name
-          - name: POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.namespace
-          - name: INSTANCE_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: HOST_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.hostIP
-          - name: SERVICE_ACCOUNT
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.serviceAccountName
-          - name: ISTIO_META_WORKLOAD_NAME
-            value: istio-egressgateway
-          - name: ISTIO_META_OWNER
-            value: kubernetes://apis/apps/v1/namespaces/istio-system/deployments/istio-egressgateway
-          - name: ISTIO_META_MESH_ID
-            value: "cluster.local"
-          - name: ISTIO_META_ROUTER_MODE
-            value: sni-dnat
-          
-          - name: ISTIO_META_CLUSTER_ID
-            value: "Kubernetes"
-          volumeMounts:
-          - name: config-volume
-            mountPath: /etc/istio/config
-          - mountPath: /var/run/secrets/istio
-            name: istiod-ca-cert
-          - name: istio-token
-            mountPath: /var/run/secrets/tokens
-            readOnly: true
-          - name: podinfo
-            mountPath: /etc/istio/pod
-          - name: egressgateway-certs
-            mountPath: "/etc/istio/egressgateway-certs"
-            readOnly: true
-          - name: egressgateway-ca-certs
-            mountPath: "/etc/istio/egressgateway-ca-certs"
-            readOnly: true
-      volumes:
-      - name: istiod-ca-cert
-        configMap:
-          name: istio-ca-root-cert
-      - name: podinfo
-        downwardAPI:
-          items:
-            - path: "labels"
-              fieldRef:
-                fieldPath: metadata.labels
-            - path: "annotations"
-              fieldRef:
-                fieldPath: metadata.annotations
-      - name: istio-token
-        projected:
-          sources:
-          - serviceAccountToken:
-              path: istio-token
-              expirationSeconds: 43200
-              audience: istio-ca
-      - name: config-volume
-        configMap:
-          name: istio
-          optional: true
-      - name: egressgateway-certs
-        secret:
-          secretName: "istio-egressgateway-certs"
-          optional: true
-      - name: egressgateway-ca-certs
-        secret:
-          secretName: "istio-egressgateway-ca-certs"
-          optional: true
-      affinity:      
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - "amd64"
-                - "ppc64le"
-                - "s390x"
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 2
-            preference:
-              matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - "amd64"
-          - weight: 2
-            preference:
-              matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - "ppc64le"
-          - weight: 2
-            preference:
-              matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - "s390x"
----
-
-
-apiVersion: policy/v1beta1
-kind: PodDisruptionBudget
-metadata:
-  name: istio-egressgateway
-  namespace: istio-system
-  labels:
-    app: istio-egressgateway
-    istio: egressgateway
-    
-    release: istio
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app: istio-egressgateway
-      istio: egressgateway
-      
-      release: istio
----
-
-
-apiVersion: v1
-kind: Service
-metadata:
-  name: istio-egressgateway
-  namespace: istio-system
-  annotations:
-  labels:
-    app: istio-egressgateway
-    istio: egressgateway
-    
-    release: istio
-spec:
-  type: ClusterIP
-  selector:
-    app: istio-egressgateway
-    istio: egressgateway
-    
-  ports:
-    -
-      name: http2
-      port: 80
-    -
-      name: https
-      port: 443
-    -
-      name: tls
-      port: 15443
-      targetPort: 15443
----
-
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: istio-egressgateway-service-account
-  namespace: istio-system
-  labels:
-    app: istio-egressgateway
-    istio: egressgateway
-    
-    release: istio
----
+# EgressGateways istio-egressgateway component is disabled.
 
 # Resources for IngressGateways component
 
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: istio-ingressgateway
-  namespace: istio-system
   labels:
     app: istio-ingressgateway
     istio: ingressgateway
-    
     release: istio
+  name: istio-ingressgateway
+  namespace: istio
 spec:
   maxReplicas: 5
+  metrics:
+  - resource:
+      name: cpu
+      targetAverageUtilization: 80
+    type: Resource
   minReplicas: 1
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: istio-ingressgateway
-  metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        targetAverageUtilization: 80
+
 ---
 
 
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: istio-ingressgateway
-  namespace: istio-system
   labels:
     app: istio-ingressgateway
     istio: ingressgateway
-    
     release: istio
+  name: istio-ingressgateway
+  namespace: istio
 spec:
   selector:
     matchLabels:
       app: istio-ingressgateway
       istio: ingressgateway
-      
   strategy:
     rollingUpdate:
       maxSurge: 100%
       maxUnavailable: 25%
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: istio-ingressgateway
         istio: ingressgateway
-        
-        heritage: Tiller
-        release: istio
-        chart: gateways
         service.istio.io/canonical-name: istio-ingressgateway
         service.istio.io/canonical-revision: latest
-      annotations:
-        sidecar.istio.io/inject: "false"
     spec:
-      serviceAccountName: istio-ingressgateway-service-account
-      containers:
-        - name: istio-proxy
-          image: "gcr.io/istio-testing/proxyv2:latest"
-          ports:
-            - containerPort: 15020
-            - containerPort: 8080
-            - containerPort: 8443
-            - containerPort: 15029
-            - containerPort: 15030
-            - containerPort: 15031
-            - containerPort: 15032
-            - containerPort: 15443
-            - containerPort: 15011
-            - containerPort: 15012
-            - containerPort: 8060
-            - containerPort: 853
-            - containerPort: 15090
-              protocol: TCP
-              name: http-envoy-prom
-          args:
-          - proxy
-          - router
-          - --domain
-          - $(POD_NAMESPACE).svc.cluster.local
-          - --proxyLogLevel=warning
-          - --proxyComponentLogLevel=misc:error
-          - --log_output_level=default:info
-          - --serviceCluster
-          - istio-ingressgateway
-          - --trust-domain=cluster.local
-          readinessProbe:
-            failureThreshold: 30
-            httpGet:
-              path: /healthz/ready
-              port: 15020
-              scheme: HTTP
-            initialDelaySeconds: 1
-            periodSeconds: 2
-            successThreshold: 1
-            timeoutSeconds: 1
-          resources:
-            limits:
-              cpu: 2000m
-              memory: 1024Mi
-            requests:
-              cpu: 100m
-              memory: 128Mi
-            
-          env:
-          - name: JWT_POLICY
-            value: third-party-jwt
-          - name: PILOT_CERT_PROVIDER
-            value: istiod
-          - name: CA_ADDR
-            value: istiod.istio-system.svc:15012
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: spec.nodeName
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.name
-          - name: POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.namespace
-          - name: INSTANCE_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: HOST_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.hostIP
-          - name: SERVICE_ACCOUNT
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.serviceAccountName
-          - name: ISTIO_META_WORKLOAD_NAME
-            value: istio-ingressgateway
-          - name: ISTIO_META_OWNER
-            value: kubernetes://apis/apps/v1/namespaces/istio-system/deployments/istio-ingressgateway
-          - name: ISTIO_META_MESH_ID
-            value: "cluster.local"
-          - name: ISTIO_META_ROUTER_MODE
-            value: sni-dnat
-          
-          - name: ISTIO_META_CLUSTER_ID
-            value: "Kubernetes"
-          volumeMounts:
-          - name: config-volume
-            mountPath: /etc/istio/config
-          - mountPath: /var/run/secrets/istio
-            name: istiod-ca-cert
-          - name: istio-token
-            mountPath: /var/run/secrets/tokens
-            readOnly: true
-          - name: ingressgatewaysdsudspath
-            mountPath: /var/run/ingress_gateway
-          - name: podinfo
-            mountPath: /etc/istio/pod
-          - name: ingressgateway-certs
-            mountPath: "/etc/istio/ingressgateway-certs"
-            readOnly: true
-          - name: ingressgateway-ca-certs
-            mountPath: "/etc/istio/ingressgateway-ca-certs"
-            readOnly: true
-      volumes:
-      - name: istiod-ca-cert
-        configMap:
-          name: istio-ca-root-cert
-      - name: podinfo
-        downwardAPI:
-          items:
-            - path: "labels"
-              fieldRef:
-                fieldPath: metadata.labels
-            - path: "annotations"
-              fieldRef:
-                fieldPath: metadata.annotations
-      - name: ingressgatewaysdsudspath
-        emptyDir: {}
-      - name: istio-token
-        projected:
-          sources:
-          - serviceAccountToken:
-              path: istio-token
-              expirationSeconds: 43200
-              audience: istio-ca
-      - name: config-volume
-        configMap:
-          name: istio
-          optional: true
-      - name: ingressgateway-certs
-        secret:
-          secretName: "istio-ingressgateway-certs"
-          optional: true
-      - name: ingressgateway-ca-certs
-        secret:
-          secretName: "istio-ingressgateway-ca-certs"
-          optional: true
-      affinity:      
+      affinity:
         nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+            weight: 2
+          - preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - ppc64le
+            weight: 2
+          - preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - s390x
+            weight: 2
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
               - key: beta.kubernetes.io/arch
                 operator: In
                 values:
-                - "amd64"
-                - "ppc64le"
-                - "s390x"
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 2
-            preference:
-              matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - "amd64"
-          - weight: 2
-            preference:
-              matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - "ppc64le"
-          - weight: 2
-            preference:
-              matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - "s390x"
+                - amd64
+                - ppc64le
+                - s390x
+      containers:
+      - args:
+        - proxy
+        - router
+        - --domain
+        - $(POD_NAMESPACE).svc.cluster.local
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
+        - --log_output_level=default:info
+        - --serviceCluster
+        - istio-ingressgateway
+        - --trust-domain=cluster.local
+        env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: istiod
+        - name: CA_ADDR
+          value: istiod.istio.svc:15012
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.hostIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: istio-ingressgateway
+        - name: ISTIO_META_OWNER
+          value: kubernetes://apis/apps/v1/namespaces/istio/deployments/istio-ingressgateway
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        - name: ISTIO_META_ROUTER_MODE
+          value: sni-dnat
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
+        image: gcr.io/istio-testing/proxyv2:latest
+        name: istio-proxy
+        ports:
+        - containerPort: 15020
+        - containerPort: 8080
+        - containerPort: 8443
+        - containerPort: 15029
+        - containerPort: 15030
+        - containerPort: 15031
+        - containerPort: 15032
+        - containerPort: 15443
+        - containerPort: 15011
+        - containerPort: 15012
+        - containerPort: 8060
+        - containerPort: 853
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 30
+          httpGet:
+            path: /healthz/ready
+            port: 15020
+            scheme: HTTP
+          initialDelaySeconds: 1
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 1024Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - mountPath: /etc/istio/config
+          name: config-volume
+        - mountPath: /var/run/secrets/istio
+          name: istiod-ca-cert
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
+          readOnly: true
+        - mountPath: /var/run/ingress_gateway
+          name: ingressgatewaysdsudspath
+        - mountPath: /etc/istio/pod
+          name: podinfo
+        - mountPath: /etc/istio/ingressgateway-certs
+          name: ingressgateway-certs
+          readOnly: true
+        - mountPath: /etc/istio/ingressgateway-ca-certs
+          name: ingressgateway-ca-certs
+          readOnly: true
+      serviceAccountName: istio-ingressgateway-service-account
+      volumes:
+      - configMap:
+          name: istio-ca-root-cert
+        name: istiod-ca-cert
+      - downwardAPI:
+          items:
+          - fieldRef:
+              fieldPath: metadata.labels
+            path: labels
+          - fieldRef:
+              fieldPath: metadata.annotations
+            path: annotations
+        name: podinfo
+      - emptyDir: {}
+        name: ingressgatewaysdsudspath
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio
+          optional: true
+        name: config-volume
+      - name: ingressgateway-certs
+        secret:
+          optional: true
+          secretName: istio-ingressgateway-certs
+      - name: ingressgateway-ca-certs
+        secret:
+          optional: true
+          secretName: istio-ingressgateway-ca-certs
+
 ---
 
 
@@ -8239,7 +7737,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: istio-ingressgateway
-  namespace: istio-system
+  namespace: istio
   labels:
     app: istio-ingressgateway
     istio: ingressgateway
@@ -8260,7 +7758,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: istio-ingressgateway-sds
-  namespace: istio-system
+  namespace: istio
   labels:
     release: istio
 rules:
@@ -8274,7 +7772,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: istio-ingressgateway-sds
-  namespace: istio-system
+  namespace: istio
   labels:
     release: istio
 roleRef:
@@ -8290,53 +7788,44 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
-  name: istio-ingressgateway
-  namespace: istio-system
-  annotations:
+  annotations: null
   labels:
     app: istio-ingressgateway
     istio: ingressgateway
-    
     release: istio
+  name: istio-ingressgateway
+  namespace: istio
 spec:
-  type: LoadBalancer
+  ports:
+  - name: status-port
+    port: 15020
+    targetPort: 15020
+  - name: http2
+    port: 80
+    targetPort: 8080
+  - name: https
+    port: 443
+    targetPort: 8443
+  - name: kiali
+    port: 15029
+    targetPort: 15029
+  - name: prometheus
+    port: 15030
+    targetPort: 15030
+  - name: grafana
+    port: 15031
+    targetPort: 15031
+  - name: tracing
+    port: 15032
+    targetPort: 15032
+  - name: tls
+    port: 15443
+    targetPort: 15443
   selector:
     app: istio-ingressgateway
     istio: ingressgateway
-    
-  ports:
-    -
-      name: status-port
-      port: 15020
-      targetPort: 15020
-    -
-      name: http2
-      port: 80
-      targetPort: 8080
-    -
-      name: https
-      port: 443
-      targetPort: 8443
-    -
-      name: kiali
-      port: 15029
-      targetPort: 15029
-    -
-      name: prometheus
-      port: 15030
-      targetPort: 15030
-    -
-      name: grafana
-      port: 15031
-      targetPort: 15031
-    -
-      name: tracing
-      port: 15032
-      targetPort: 15032
-    -
-      name: tls
-      port: 15443
-      targetPort: 15443
+  type: LoadBalancer
+
 ---
 
 
@@ -8344,7 +7833,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: istio-ingressgateway-service-account
-  namespace: istio-system
+  namespace: istio
   labels:
     app: istio-ingressgateway
     istio: ingressgateway
@@ -8358,7 +7847,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: istiod
-  namespace: istio-system
+  namespace: istio
   labels:
     app: istiod
     release: istio
@@ -8382,7 +7871,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: istio
-  namespace: istio-system
+  namespace: istio
   labels:
     istio.io/rev: default
     release: istio
@@ -8425,7 +7914,7 @@ data:
       configPath: /etc/istio/proxy
       connectTimeout: 10s
       controlPlaneAuthPolicy: NONE
-      discoveryAddress: istiod.istio-system.svc:15012
+      discoveryAddress: istiod.istio.svc:15012
       drainDuration: 45s
       parentShutdownDuration: 1m0s
       proxyAdminPort: 15000
@@ -8435,7 +7924,7 @@ data:
       serviceCluster: istio-proxy
       tracing:
         zipkin:
-          address: zipkin.istio-system:9411
+          address: zipkin.istio:9411
     disableMixerHttpReports: true
     disablePolicyChecks: true
     enableAutoMtls: true
@@ -8445,10 +7934,8 @@ data:
     ingressService: istio-ingressgateway
     localityLbSetting:
       enabled: true
-    mixerCheckServer: istio-policy.istio-system.svc.cluster.local:15004
     outboundTrafficPolicy:
       mode: ALLOW_ANY
-    policyCheckFailOpen: false
     protocolDetectionTimeout: 100ms
     reportBatchMaxEntries: 100
     reportBatchMaxTime: 1s
@@ -8467,7 +7954,7 @@ metadata:
     istio.io/rev: default
     release: istio
   name: istiod
-  namespace: istio-system
+  namespace: istio
 spec:
   selector:
     matchLabels:
@@ -8526,7 +8013,7 @@ spec:
         - name: INJECTION_WEBHOOK_CONFIG_NAME
           value: istio-sidecar-injector
         - name: ISTIOD_ADDR
-          value: istiod.istio-system.svc:15012
+          value: istiod.istio.svc:15012
         - name: PILOT_ENABLE_ANALYSIS
           value: "false"
         - name: CLUSTER_ID
@@ -8637,7 +8124,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: istio-sidecar-injector
-  namespace: istio-system
+  namespace: istio
   labels:
     istio.io/rev: default
     release: istio
@@ -8651,7 +8138,7 @@ data:
           "ppc64le": 2,
           "s390x": 2
         },
-        "configNamespace": "istio-system",
+        "configNamespace": "istio",
         "configValidation": true,
         "controlPlaneSecurityEnabled": true,
         "defaultNodeSelector": {},
@@ -8696,7 +8183,7 @@ data:
           "clusterName": "",
           "enabled": false
         },
-        "namespace": "istio-system",
+        "namespace": "istio",
         "network": "",
         "omitSidecarInjectorConfigMap": false,
         "oneNamespace": false,
@@ -8706,9 +8193,9 @@ data:
         },
         "pilotCertProvider": "istiod",
         "policyCheckFailOpen": false,
-        "policyNamespace": "istio-system",
+        "policyNamespace": "istio",
         "priorityClassName": "",
-        "prometheusNamespace": "istio-system",
+        "prometheusNamespace": "istio",
         "proxy": {
           "autoInject": "enabled",
           "clusterDomain": "cluster.local",
@@ -8758,12 +8245,12 @@ data:
             "aud": "istio-ca"
           }
         },
-        "securityNamespace": "istio-system",
+        "securityNamespace": "istio",
         "sts": {
           "servicePort": 0
         },
         "tag": "latest",
-        "telemetryNamespace": "istio-system",
+        "telemetryNamespace": "istio",
         "tracer": {
           "datadog": {
             "address": "$(HOST_IP):8126"
@@ -8797,7 +8284,7 @@ data:
         "enabled": false,
         "injectLabel": "istio-injection",
         "injectedAnnotations": {},
-        "namespace": "istio-system",
+        "namespace": "istio",
         "neverInjectSelector": [],
         "objectSelector": {
           "autoInject": true,
@@ -9245,7 +8732,7 @@ webhooks:
     clientConfig:
       service:
         name: istiod
-        namespace: istio-system
+        namespace: istio
         path: "/inject"
       caBundle: ""
     rules:
@@ -9264,7 +8751,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: istiod
-  namespace: istio-system
+  namespace: istio
   labels:
     app: istiod
     istio.io/rev: default
@@ -9283,7 +8770,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: istiod
-  namespace: istio-system
+  namespace: istio
   labels:
     istio.io/rev: default
     app: istiod
@@ -9320,7 +8807,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: metadata-exchange-1.4
-  namespace: istio-system
+  namespace: istio
   labels:
     istio.io/rev: default
 spec:
@@ -9352,7 +8839,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stats-filter-1.4
-  namespace: istio-system
+  namespace: istio
   labels:
     istio.io/rev: default
 spec:
@@ -9448,7 +8935,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: metadata-exchange-1.5
-  namespace: istio-system
+  namespace: istio
   labels:
     istio.io/rev: default
 spec:
@@ -9484,7 +8971,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-metadata-exchange-1.5
-  namespace: istio-system
+  namespace: istio
   labels:
     istio.io/rev: default
 spec:
@@ -9540,7 +9027,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stats-filter-1.5
-  namespace: istio-system
+  namespace: istio
   labels:
     istio.io/rev: default
 spec:
@@ -9648,7 +9135,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-stats-filter-1.5
-  namespace: istio-system
+  namespace: istio
   labels:
     istio.io/rev: default
 spec:
@@ -9750,7 +9237,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: metadata-exchange-1.6
-  namespace: istio-system
+  namespace: istio
   labels:
     istio.io/rev: default
 spec:
@@ -9786,7 +9273,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-metadata-exchange-1.6
-  namespace: istio-system
+  namespace: istio
   labels:
     istio.io/rev: default
 spec:
@@ -9845,7 +9332,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stats-filter-1.6
-  namespace: istio-system
+  namespace: istio
   labels:
     istio.io/rev: default
 spec:
@@ -9953,7 +9440,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-stats-filter-1.6
-  namespace: istio-system
+  namespace: istio
   labels:
     istio.io/rev: default
 spec:
@@ -10050,1882 +9537,7 @@ spec:
                       inline_string: "envoy.wasm.stats"
 ---
 
-# Resources for Policy component
+# Policy component is disabled.
 
-apiVersion: autoscaling/v2beta1
-kind: HorizontalPodAutoscaler
-metadata:
-  labels:
-    app: mixer
-    release: istio
-  name: istio-policy
-  namespace: istio-system
-spec:
-  maxReplicas: 5
-  metrics:
-  - resource:
-      name: cpu
-      targetAverageUtilization: 80
-    type: Resource
-  minReplicas: 1
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: istio-policy
-
----
-
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: istio-policy
-  labels:
-    release: istio
-    app: istio-policy
-rules:
-- apiGroups: ["config.istio.io"] # istio CRD watcher
-  resources: ["*"]
-  verbs: ["create", "get", "list", "watch", "patch"]
-- apiGroups: ["apiextensions.k8s.io"]
-  resources: ["customresourcedefinitions"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: [""]
-  resources: ["configmaps", "endpoints", "pods", "services", "namespaces", "secrets", "replicationcontrollers"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["extensions", "apps"]
-  resources: ["replicasets"]
-  verbs: ["get", "list", "watch"]
----
-
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: istio-policy-admin-role-binding-istio-system
-  labels:
-    app: istio-policy
-    release: istio
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: istio-policy
-subjects:
-  - kind: ServiceAccount
-    name: istio-policy-service-account
-    namespace: istio-system
----
-
-
-apiVersion: networking.istio.io/v1alpha3
-kind: DestinationRule
-metadata:
-  name: istio-policy
-  namespace: istio-system
-  labels:
-    app: istio-policy
-    release: istio
-spec:
-  host: istio-policy.istio-system.svc.cluster.local
-  trafficPolicy:
-    portLevelSettings:
-    - port:
-        number: 15004 # grpc-mixer-mtls
-      tls:
-        mode: ISTIO_MUTUAL
-    - port:
-        number: 9091 # grpc-mixer
-      tls:
-        mode: DISABLE
-    connectionPool:
-      http:
-        http2MaxRequests: 10000
-        maxRequestsPerConnection: 10000
----
-
-
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app: istio-policy
-    istio: mixer
-    release: istio
-  name: istio-policy
-  namespace: istio-system
-spec:
-  selector:
-    matchLabels:
-      istio: mixer
-      istio-mixer-type: policy
-  strategy:
-    rollingUpdate:
-      maxSurge: 100%
-      maxUnavailable: 25%
-  template:
-    metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
-      labels:
-        app: policy
-        istio: mixer
-        istio-mixer-type: policy
-    spec:
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - preference:
-              matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
-            weight: 2
-          - preference:
-              matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - ppc64le
-            weight: 2
-          - preference:
-              matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - s390x
-            weight: 2
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
-                - ppc64le
-                - s390x
-      containers:
-      - args:
-        - --monitoringPort=15014
-        - --address
-        - unix:///sock/mixer.socket
-        - --log_output_level=default:info
-        - --configStoreURL=k8s://
-        - --configDefaultNamespace=istio-system
-        - --useAdapterCRDs=false
-        - --useTemplateCRDs=false
-        - --trace_zipkin_url=http://zipkin.istio-system:9411/api/v1/spans
-        env:
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        image: gcr.io/istio-testing/mixer:latest
-        livenessProbe:
-          httpGet:
-            path: /version
-            port: 15014
-          initialDelaySeconds: 5
-          periodSeconds: 5
-        name: mixer
-        ports:
-        - containerPort: 9091
-        - containerPort: 15014
-        - containerPort: 42422
-        resources:
-          requests:
-            cpu: 10m
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-          runAsGroup: 1337
-          runAsNonRoot: true
-          runAsUser: 1337
-        volumeMounts:
-        - mountPath: /sock
-          name: uds-socket
-        - mountPath: /var/run/secrets/istio.io/policy/adapter
-          name: policy-adapter-secret
-          readOnly: true
-      - args:
-        - proxy
-        - --domain
-        - $(POD_NAMESPACE).svc.cluster.local
-        - --serviceCluster
-        - istio-policy
-        - --templateFile
-        - /etc/istio/proxy/envoy_policy.yaml.tmpl
-        - --controlPlaneAuthPolicy
-        - MUTUAL_TLS
-        - --trust-domain=cluster.local
-        env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        - name: INSTANCE_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: JWT_POLICY
-          value: third-party-jwt
-        - name: PILOT_CERT_PROVIDER
-          value: istiod
-        - name: ISTIO_META_USER_SDS
-          value: "true"
-        - name: CA_ADDR
-          value: istiod.istio-system.svc:15012
-        image: gcr.io/istio-testing/proxyv2:latest
-        name: istio-proxy
-        ports:
-        - containerPort: 15004
-        - containerPort: 15090
-          name: http-envoy-prom
-          protocol: TCP
-        resources:
-          limits:
-            cpu: 2000m
-            memory: 1024Mi
-          requests:
-            cpu: 100m
-            memory: 128Mi
-        volumeMounts:
-        - mountPath: /etc/istio/config
-          name: config-volume
-        - mountPath: /var/run/secrets/istio
-          name: istiod-ca-cert
-        - mountPath: /var/run/secrets/tokens
-          name: istio-token
-          readOnly: true
-        - mountPath: /sock
-          name: uds-socket
-      securityContext:
-        fsGroup: 1337
-      serviceAccountName: istio-policy-service-account
-      volumes:
-      - configMap:
-          name: istio
-          optional: true
-        name: config-volume
-      - configMap:
-          name: istio-ca-root-cert
-        name: istiod-ca-cert
-      - name: istio-token
-        projected:
-          sources:
-          - serviceAccountToken:
-              audience: istio-ca
-              expirationSeconds: 43200
-              path: istio-token
-      - name: istio-certs
-        secret:
-          optional: true
-          secretName: istio.istio-policy-service-account
-      - emptyDir: {}
-        name: uds-socket
-      - name: policy-adapter-secret
-        secret:
-          optional: true
-          secretName: policy-adapter-secret
-
----
-
-
-apiVersion: policy/v1beta1
-kind: PodDisruptionBudget
-metadata:
-  name: istio-policy
-  namespace: istio-system
-  labels:
-    app: policy
-    release: istio
-    istio: mixer
-    istio-mixer-type: policy
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app: policy
-      istio: mixer
-      istio-mixer-type: policy
----
-
-
-apiVersion: v1
-kind: Service
-metadata:
-  name: istio-policy
-  namespace: istio-system
-  labels:
-    app: mixer
-    istio: mixer
-    release: istio
-spec:
-  ports:
-  - name: grpc-mixer
-    port: 9091
-  - name: grpc-mixer-mtls
-    port: 15004
-  - name: http-policy-monitoring
-    port: 15014
-  selector:
-    istio: mixer
-    istio-mixer-type: policy
----
-
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: istio-policy-service-account
-  namespace: istio-system
-  labels:
-    app: istio-policy
-    release: istio
----
-
-# Resources for Telemetry component
-
-apiVersion: autoscaling/v2beta1
-kind: HorizontalPodAutoscaler
-metadata:
-  labels:
-    app: mixer
-    release: istio
-  name: istio-telemetry
-  namespace: istio-system
-spec:
-  maxReplicas: 5
-  metrics:
-  - resource:
-      name: cpu
-      targetAverageUtilization: 80
-    type: Resource
-  minReplicas: 1
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: istio-telemetry
-
----
-
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: istio-mixer-istio-system
-  labels:
-    app: istio-telemetry
-    release: istio
-rules:
-- apiGroups: ["config.istio.io"] # istio CRD watcher
-  resources: ["*"]
-  verbs: ["create", "get", "list", "watch", "patch"]
-- apiGroups: ["apiextensions.k8s.io"]
-  resources: ["customresourcedefinitions"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: [""]
-  resources: ["configmaps", "endpoints", "pods", "services", "namespaces", "secrets", "replicationcontrollers"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["extensions", "apps"]
-  resources: ["replicasets"]
-  verbs: ["get", "list", "watch"]
----
-
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: istio-mixer-admin-role-binding-istio-system
-  labels:
-    app: istio-telemetry
-    release: istio
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: istio-mixer-istio-system
-subjects:
-  - kind: ServiceAccount
-    name: istio-mixer-service-account
-    namespace: istio-system
----
-
-
-apiVersion: "config.istio.io/v1alpha2"
-kind: attributemanifest
-metadata:
-  name: istioproxy
-  namespace: istio-system
-  labels:
-    app: istio-telemetry
-    release: istio
-spec:
-  attributes:
-    origin.ip:
-      valueType: IP_ADDRESS
-    origin.uid:
-      valueType: STRING
-    origin.user:
-      valueType: STRING
-    request.headers:
-      valueType: STRING_MAP
-    request.id:
-      valueType: STRING
-    request.host:
-      valueType: STRING
-    request.method:
-      valueType: STRING
-    request.path:
-      valueType: STRING
-    request.url_path:
-      valueType: STRING
-    request.query_params:
-      valueType: STRING_MAP
-    request.reason:
-      valueType: STRING
-    request.referer:
-      valueType: STRING
-    request.scheme:
-      valueType: STRING
-    request.total_size:
-      valueType: INT64
-    request.size:
-      valueType: INT64
-    request.time:
-      valueType: TIMESTAMP
-    request.useragent:
-      valueType: STRING
-    response.code:
-      valueType: INT64
-    response.duration:
-      valueType: DURATION
-    response.headers:
-      valueType: STRING_MAP
-    response.total_size:
-      valueType: INT64
-    response.size:
-      valueType: INT64
-    response.time:
-      valueType: TIMESTAMP
-    response.grpc_status:
-      valueType: STRING
-    response.grpc_message:
-      valueType: STRING
-    source.uid:
-      valueType: STRING
-    source.user: # DEPRECATED
-      valueType: STRING
-    source.principal:
-      valueType: STRING
-    destination.uid:
-      valueType: STRING
-    destination.principal:
-      valueType: STRING
-    destination.port:
-      valueType: INT64
-    connection.event:
-      valueType: STRING
-    connection.id:
-      valueType: STRING
-    connection.received.bytes:
-      valueType: INT64
-    connection.received.bytes_total:
-      valueType: INT64
-    connection.sent.bytes:
-      valueType: INT64
-    connection.sent.bytes_total:
-      valueType: INT64
-    connection.duration:
-      valueType: DURATION
-    connection.mtls:
-      valueType: BOOL
-    connection.requested_server_name:
-      valueType: STRING
-    context.protocol:
-      valueType: STRING
-    context.proxy_error_code:
-      valueType: STRING
-    context.timestamp:
-      valueType: TIMESTAMP
-    context.time:
-      valueType: TIMESTAMP
-    # Deprecated, kept for compatibility
-    context.reporter.local:
-      valueType: BOOL
-    context.reporter.kind:
-      valueType: STRING
-    context.reporter.uid:
-      valueType: STRING
-    context.proxy_version:
-      valueType: STRING
-    api.service:
-      valueType: STRING
-    api.version:
-      valueType: STRING
-    api.operation:
-      valueType: STRING
-    api.protocol:
-      valueType: STRING
-    request.auth.principal:
-      valueType: STRING
-    request.auth.audiences:
-      valueType: STRING
-    request.auth.presenter:
-      valueType: STRING
-    request.auth.claims:
-      valueType: STRING_MAP
-    request.auth.raw_claims:
-      valueType: STRING
-    request.api_key:
-      valueType: STRING
-    rbac.permissive.response_code:
-      valueType: STRING
-    rbac.permissive.effective_policy_id:
-      valueType: STRING
-    check.error_code:
-      valueType: INT64
-    check.error_message:
-      valueType: STRING
-    check.cache_hit:
-      valueType: BOOL
-    quota.cache_hit:
-      valueType: BOOL
----
-
-
-apiVersion: "config.istio.io/v1alpha2"
-kind: attributemanifest
-metadata:
-  name: kubernetes
-  namespace: istio-system
-  labels:
-    app: istio-telemetry
-    release: istio
-spec:
-  attributes:
-    source.ip:
-      valueType: IP_ADDRESS
-    source.labels:
-      valueType: STRING_MAP
-    source.metadata:
-      valueType: STRING_MAP
-    source.name:
-      valueType: STRING
-    source.namespace:
-      valueType: STRING
-    source.owner:
-      valueType: STRING
-    source.serviceAccount:
-      valueType: STRING
-    source.services:
-      valueType: STRING
-    source.workload.uid:
-      valueType: STRING
-    source.workload.name:
-      valueType: STRING
-    source.workload.namespace:
-      valueType: STRING
-    destination.ip:
-      valueType: IP_ADDRESS
-    destination.labels:
-      valueType: STRING_MAP
-    destination.metadata:
-      valueType: STRING_MAP
-    destination.owner:
-      valueType: STRING
-    destination.name:
-      valueType: STRING
-    destination.container.name:
-      valueType: STRING
-    destination.namespace:
-      valueType: STRING
-    destination.service.uid:
-      valueType: STRING
-    destination.service.name:
-      valueType: STRING
-    destination.service.namespace:
-      valueType: STRING
-    destination.service.host:
-      valueType: STRING
-    destination.serviceAccount:
-      valueType: STRING
-    destination.workload.uid:
-      valueType: STRING
-    destination.workload.name:
-      valueType: STRING
-    destination.workload.namespace:
-      valueType: STRING
----
-
-
-apiVersion: "config.istio.io/v1alpha2"
-kind: instance
-metadata:
-  name: requestcount
-  namespace: istio-system
-  labels:
-    app: istio-telemetry
-    release: istio
-spec:
-  compiledTemplate: metric
-  params:
-    value: "1"
-    dimensions:
-      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
-      source_workload: source.workload.name | "unknown"
-      source_workload_namespace: source.workload.namespace | "unknown"
-      source_principal: source.principal | "unknown"
-      source_app: source.labels["app"] | "unknown"
-      source_version: source.labels["version"] | "unknown"
-      destination_workload: destination.workload.name | "unknown"
-      destination_workload_namespace: destination.workload.namespace | "unknown"
-      destination_principal: destination.principal | "unknown"
-      destination_app: destination.labels["app"] | "unknown"
-      destination_version: destination.labels["version"] | "unknown"
-      destination_service: destination.service.host | conditional((destination.service.name | "unknown") == "unknown", "unknown", request.host)
-      destination_service_name: destination.service.name | "unknown"
-      destination_service_namespace: destination.service.namespace | "unknown"
-      request_protocol: api.protocol | context.protocol | "unknown"
-      response_code: response.code | 200
-      grpc_response_status: response.grpc_status | ""
-      response_flags: context.proxy_error_code | "-"
-      connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
-    monitored_resource_type: '"UNSPECIFIED"'
----
-
-
-apiVersion: "config.istio.io/v1alpha2"
-kind: instance
-metadata:
-  name: requestduration
-  namespace: istio-system
-  labels:
-    app: istio-telemetry
-    release: istio
-spec:
-  compiledTemplate: metric
-  params:
-    value: response.duration | "0ms"
-    dimensions:
-      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
-      source_workload: source.workload.name | "unknown"
-      source_workload_namespace: source.workload.namespace | "unknown"
-      source_principal: source.principal | "unknown"
-      source_app: source.labels["app"] | "unknown"
-      source_version: source.labels["version"] | "unknown"
-      destination_workload: destination.workload.name | "unknown"
-      destination_workload_namespace: destination.workload.namespace | "unknown"
-      destination_principal: destination.principal | "unknown"
-      destination_app: destination.labels["app"] | "unknown"
-      destination_version: destination.labels["version"] | "unknown"
-      destination_service: destination.service.host | conditional((destination.service.name | "unknown") == "unknown", "unknown", request.host)
-      destination_service_name: destination.service.name | "unknown"
-      destination_service_namespace: destination.service.namespace | "unknown"
-      request_protocol: api.protocol | context.protocol | "unknown"
-      response_code: response.code | 200
-      grpc_response_status: response.grpc_status | ""
-      response_flags: context.proxy_error_code | "-"
-      connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
-    monitored_resource_type: '"UNSPECIFIED"'
----
-
-
-apiVersion: "config.istio.io/v1alpha2"
-kind: instance
-metadata:
-  name: requestsize
-  namespace: istio-system
-  labels:
-    app: istio-telemetry
-    release: istio
-spec:
-  compiledTemplate: metric
-  params:
-    value: request.size | 0
-    dimensions:
-      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
-      source_workload: source.workload.name | "unknown"
-      source_workload_namespace: source.workload.namespace | "unknown"
-      source_principal: source.principal | "unknown"
-      source_app: source.labels["app"] | "unknown"
-      source_version: source.labels["version"] | "unknown"
-      destination_workload: destination.workload.name | "unknown"
-      destination_workload_namespace: destination.workload.namespace | "unknown"
-      destination_principal: destination.principal | "unknown"
-      destination_app: destination.labels["app"] | "unknown"
-      destination_version: destination.labels["version"] | "unknown"
-      destination_service: destination.service.host | conditional((destination.service.name | "unknown") == "unknown", "unknown", request.host)
-      destination_service_name: destination.service.name | "unknown"
-      destination_service_namespace: destination.service.namespace | "unknown"
-      request_protocol: api.protocol | context.protocol | "unknown"
-      response_code: response.code | 200
-      grpc_response_status: response.grpc_status | ""
-      response_flags: context.proxy_error_code | "-"
-      connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
-    monitored_resource_type: '"UNSPECIFIED"'
----
-
-
-apiVersion: "config.istio.io/v1alpha2"
-kind: instance
-metadata:
-  name: responsesize
-  namespace: istio-system
-  labels:
-    app: istio-telemetry
-    release: istio
-spec:
-  compiledTemplate: metric
-  params:
-    value: response.size | 0
-    dimensions:
-      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
-      source_workload: source.workload.name | "unknown"
-      source_workload_namespace: source.workload.namespace | "unknown"
-      source_principal: source.principal | "unknown"
-      source_app: source.labels["app"] | "unknown"
-      source_version: source.labels["version"] | "unknown"
-      destination_workload: destination.workload.name | "unknown"
-      destination_workload_namespace: destination.workload.namespace | "unknown"
-      destination_principal: destination.principal | "unknown"
-      destination_app: destination.labels["app"] | "unknown"
-      destination_version: destination.labels["version"] | "unknown"
-      destination_service: destination.service.host | conditional((destination.service.name | "unknown") == "unknown", "unknown", request.host)
-      destination_service_name: destination.service.name | "unknown"
-      destination_service_namespace: destination.service.namespace | "unknown"
-      request_protocol: api.protocol | context.protocol | "unknown"
-      response_code: response.code | 200
-      grpc_response_status: response.grpc_status | ""
-      response_flags: context.proxy_error_code | "-"
-      connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
-    monitored_resource_type: '"UNSPECIFIED"'
----
-
-
-apiVersion: "config.istio.io/v1alpha2"
-kind: instance
-metadata:
-  name: tcpbytesent
-  namespace: istio-system
-  labels:
-    app: istio-telemetry
-    release: istio
-spec:
-  compiledTemplate: metric
-  params:
-    value: connection.sent.bytes | 0
-    dimensions:
-      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
-      source_workload: source.workload.name | "unknown"
-      source_workload_namespace: source.workload.namespace | "unknown"
-      source_principal: source.principal | "unknown"
-      source_app: source.labels["app"] | "unknown"
-      source_version: source.labels["version"] | "unknown"
-      destination_workload: destination.workload.name | "unknown"
-      destination_workload_namespace: destination.workload.namespace | "unknown"
-      destination_principal: destination.principal | "unknown"
-      destination_app: destination.labels["app"] | "unknown"
-      destination_version: destination.labels["version"] | "unknown"
-      destination_service: destination.service.host | "unknown"
-      destination_service_name: destination.service.name | "unknown"
-      destination_service_namespace: destination.service.namespace | "unknown"
-      connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
-      response_flags: context.proxy_error_code | "-"
-    monitored_resource_type: '"UNSPECIFIED"'
----
-
-
-apiVersion: "config.istio.io/v1alpha2"
-kind: instance
-metadata:
-  name: tcpbytereceived
-  namespace: istio-system
-  labels:
-    app: istio-telemetry
-    release: istio
-spec:
-  compiledTemplate: metric
-  params:
-    value: connection.received.bytes | 0
-    dimensions:
-      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
-      source_workload: source.workload.name | "unknown"
-      source_workload_namespace: source.workload.namespace | "unknown"
-      source_principal: source.principal | "unknown"
-      source_app: source.labels["app"] | "unknown"
-      source_version: source.labels["version"] | "unknown"
-      destination_workload: destination.workload.name | "unknown"
-      destination_workload_namespace: destination.workload.namespace | "unknown"
-      destination_principal: destination.principal | "unknown"
-      destination_app: destination.labels["app"] | "unknown"
-      destination_version: destination.labels["version"] | "unknown"
-      destination_service: destination.service.host | "unknown"
-      destination_service_name: destination.service.name | "unknown"
-      destination_service_namespace: destination.service.namespace | "unknown"
-      connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
-      response_flags: context.proxy_error_code | "-"
-    monitored_resource_type: '"UNSPECIFIED"'
----
-
-
-apiVersion: "config.istio.io/v1alpha2"
-kind: instance
-metadata:
-  name: tcpconnectionsopened
-  namespace: istio-system
-  labels:
-    app: istio-telemetry
-    release: istio
-spec:
-  compiledTemplate: metric
-  params:
-    value: "1"
-    dimensions:
-      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
-      source_workload: source.workload.name | "unknown"
-      source_workload_namespace: source.workload.namespace | "unknown"
-      source_principal: source.principal | "unknown"
-      source_app: source.labels["app"] | "unknown"
-      source_version: source.labels["version"] | "unknown"
-      destination_workload: destination.workload.name | "unknown"
-      destination_workload_namespace: destination.workload.namespace | "unknown"
-      destination_principal: destination.principal | "unknown"
-      destination_app: destination.labels["app"] | "unknown"
-      destination_version: destination.labels["version"] | "unknown"
-      destination_service: destination.service.host | "unknown"
-      destination_service_name: destination.service.name | "unknown"
-      destination_service_namespace: destination.service.namespace | "unknown"
-      connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
-      response_flags: context.proxy_error_code | "-"
-    monitored_resource_type: '"UNSPECIFIED"'
----
-
-
-apiVersion: "config.istio.io/v1alpha2"
-kind: instance
-metadata:
-  name: tcpconnectionsclosed
-  namespace: istio-system
-  labels:
-    app: istio-telemetry
-    release: istio
-spec:
-  compiledTemplate: metric
-  params:
-    value: "1"
-    dimensions:
-      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
-      source_workload: source.workload.name | "unknown"
-      source_workload_namespace: source.workload.namespace | "unknown"
-      source_principal: source.principal | "unknown"
-      source_app: source.labels["app"] | "unknown"
-      source_version: source.labels["version"] | "unknown"
-      destination_workload: destination.workload.name | "unknown"
-      destination_workload_namespace: destination.workload.namespace | "unknown"
-      destination_principal: destination.principal | "unknown"
-      destination_app: destination.labels["app"] | "unknown"
-      destination_version: destination.labels["version"] | "unknown"
-      destination_service: destination.service.host | "unknown"
-      destination_service_name: destination.service.name | "unknown"
-      destination_service_namespace: destination.service.namespace | "unknown"
-      connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
-      response_flags: context.proxy_error_code | "-"
-    monitored_resource_type: '"UNSPECIFIED"'
----
-
-
-apiVersion: "config.istio.io/v1alpha2"
-kind: handler
-metadata:
-  name: prometheus
-  namespace: istio-system
-  labels:
-    app: istio-telemetry
-    release: istio
-spec:
-  compiledAdapter: prometheus
-  params:
-    metricsExpirationPolicy:
-      metricsExpiryDuration: "10m"
-    metrics:
-    - name: requests_total
-      instance_name: requestcount.instance.istio-system
-      kind: COUNTER
-      label_names:
-      - reporter
-      - source_app
-      - source_principal
-      - source_workload
-      - source_workload_namespace
-      - source_version
-      - destination_app
-      - destination_principal
-      - destination_workload
-      - destination_workload_namespace
-      - destination_version
-      - destination_service
-      - destination_service_name
-      - destination_service_namespace
-      - request_protocol
-      - grpc_response_status
-      - response_code
-      - response_flags
-      - connection_security_policy
-    - name: request_duration_seconds
-      instance_name: requestduration.instance.istio-system
-      kind: DISTRIBUTION
-      label_names:
-      - reporter
-      - source_app
-      - source_principal
-      - source_workload
-      - source_workload_namespace
-      - source_version
-      - destination_app
-      - destination_principal
-      - destination_workload
-      - destination_workload_namespace
-      - destination_version
-      - destination_service
-      - destination_service_name
-      - destination_service_namespace
-      - request_protocol
-      - response_code
-      - grpc_response_status
-      - response_flags
-      - connection_security_policy
-      buckets:
-        explicit_buckets:
-          bounds: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
-    - name: request_bytes
-      instance_name: requestsize.instance.istio-system
-      kind: DISTRIBUTION
-      label_names:
-      - reporter
-      - source_app
-      - source_principal
-      - source_workload
-      - source_workload_namespace
-      - source_version
-      - destination_app
-      - destination_principal
-      - destination_workload
-      - destination_workload_namespace
-      - destination_version
-      - destination_service
-      - destination_service_name
-      - destination_service_namespace
-      - request_protocol
-      - response_code
-      - grpc_response_status
-      - response_flags
-      - connection_security_policy
-      buckets:
-        exponentialBuckets:
-          numFiniteBuckets: 8
-          scale: 1
-          growthFactor: 10
-    - name: response_bytes
-      instance_name: responsesize.instance.istio-system
-      kind: DISTRIBUTION
-      label_names:
-      - reporter
-      - source_app
-      - source_principal
-      - source_workload
-      - source_workload_namespace
-      - source_version
-      - destination_app
-      - destination_principal
-      - destination_workload
-      - destination_workload_namespace
-      - destination_version
-      - destination_service
-      - destination_service_name
-      - destination_service_namespace
-      - request_protocol
-      - response_code
-      - grpc_response_status
-      - response_flags
-      - connection_security_policy
-      buckets:
-        exponentialBuckets:
-          numFiniteBuckets: 8
-          scale: 1
-          growthFactor: 10
-    - name: tcp_sent_bytes_total
-      instance_name: tcpbytesent.instance.istio-system
-      kind: COUNTER
-      label_names:
-      - reporter
-      - source_app
-      - source_principal
-      - source_workload
-      - source_workload_namespace
-      - source_version
-      - destination_app
-      - destination_principal
-      - destination_workload
-      - destination_workload_namespace
-      - destination_version
-      - destination_service
-      - destination_service_name
-      - destination_service_namespace
-      - connection_security_policy
-      - response_flags
-    - name: tcp_received_bytes_total
-      instance_name: tcpbytereceived.instance.istio-system
-      kind: COUNTER
-      label_names:
-      - reporter
-      - source_app
-      - source_principal
-      - source_workload
-      - source_workload_namespace
-      - source_version
-      - destination_app
-      - destination_principal
-      - destination_workload
-      - destination_workload_namespace
-      - destination_version
-      - destination_service
-      - destination_service_name
-      - destination_service_namespace
-      - connection_security_policy
-      - response_flags
-    - name: tcp_connections_opened_total
-      instance_name: tcpconnectionsopened.instance.istio-system
-      kind: COUNTER
-      label_names:
-      - reporter
-      - source_app
-      - source_principal
-      - source_workload
-      - source_workload_namespace
-      - source_version
-      - destination_app
-      - destination_principal
-      - destination_workload
-      - destination_workload_namespace
-      - destination_version
-      - destination_service
-      - destination_service_name
-      - destination_service_namespace
-      - connection_security_policy
-      - response_flags
-    - name: tcp_connections_closed_total
-      instance_name: tcpconnectionsclosed.instance.istio-system
-      kind: COUNTER
-      label_names:
-      - reporter
-      - source_app
-      - source_principal
-      - source_workload
-      - source_workload_namespace
-      - source_version
-      - destination_app
-      - destination_principal
-      - destination_workload
-      - destination_workload_namespace
-      - destination_version
-      - destination_service
-      - destination_service_name
-      - destination_service_namespace
-      - connection_security_policy
-      - response_flags
----
-
-
-apiVersion: "config.istio.io/v1alpha2"
-kind: rule
-metadata:
-  name: promhttp
-  namespace: istio-system
-  labels:
-    app: istio-telemetry
-    release: istio
-spec:
-  match: (context.protocol == "http" || context.protocol == "grpc") && (match((request.useragent | "-"), "kube-probe*") == false) && (match((request.useragent | "-"), "Prometheus*") == false)
-  actions:
-  - handler: prometheus
-    instances:
-    - requestcount
-    - requestduration
-    - requestsize
-    - responsesize
----
-
-
-apiVersion: "config.istio.io/v1alpha2"
-kind: rule
-metadata:
-  name: promtcp
-  namespace: istio-system
-  labels:
-    app: istio-telemetry
-    release: istio
-spec:
-  match: context.protocol == "tcp"
-  actions:
-  - handler: prometheus
-    instances:
-    - tcpbytesent
-    - tcpbytereceived
----
-
-
-apiVersion: "config.istio.io/v1alpha2"
-kind: rule
-metadata:
-  name: promtcpconnectionopen
-  namespace: istio-system
-  labels:
-    app: istio-telemetry
-    release: istio
-spec:
-  match: context.protocol == "tcp" && ((connection.event | "na") == "open")
-  actions:
-  - handler: prometheus
-    instances:
-    - tcpconnectionsopened
----
-
-
-apiVersion: "config.istio.io/v1alpha2"
-kind: rule
-metadata:
-  name: promtcpconnectionclosed
-  namespace: istio-system
-  labels:
-    app: istio-telemetry
-    release: istio
-spec:
-  match: context.protocol == "tcp" && ((connection.event | "na") == "close")
-  actions:
-  - handler: prometheus
-    instances:
-    - tcpconnectionsclosed
----
-
-
-apiVersion: "config.istio.io/v1alpha2"
-kind: handler
-metadata:
-  name: kubernetesenv
-  namespace: istio-system
-  labels:
-    app: istio-telemetry
-    release: istio
-spec:
-  compiledAdapter: kubernetesenv
-  params: {}
-    # when running from mixer root, use the following config after adding a
-    # symbolic link to a kubernetes config file via:
-    #
-    # $ ln -s ~/.kube/config mixer/adapter/kubernetes/kubeconfig
-    #
-    # kubeconfig_path: "mixer/adapter/kubernetes/kubeconfig"
----
-
-
-apiVersion: "config.istio.io/v1alpha2"
-kind: rule
-metadata:
-  name: kubeattrgenrulerule
-  namespace: istio-system
-  labels:
-    app: istio-telemetry
-    release: istio
-spec:
-  actions:
-  - handler: kubernetesenv
-    instances:
-    - attributes
----
-
-
-apiVersion: "config.istio.io/v1alpha2"
-kind: rule
-metadata:
-  name: tcpkubeattrgenrulerule
-  namespace: istio-system
-  labels:
-    app: istio-telemetry
-    release: istio
-spec:
-  match: context.protocol == "tcp"
-  actions:
-  - handler: kubernetesenv
-    instances:
-    - attributes
----
-
-
-apiVersion: "config.istio.io/v1alpha2"
-kind: instance
-metadata:
-  name: attributes
-  namespace: istio-system
-  labels:
-    app: istio-telemetry
-    release: istio
-spec:
-  compiledTemplate: kubernetes
-  params:
-    # Pass the required attribute data to the adapter
-    source_uid: source.uid | ""
-    source_ip: source.ip | ip("0.0.0.0") # default to unspecified ip addr
-    destination_uid: destination.uid | ""
-    destination_port: destination.port | 0
-  attributeBindings:
-    # Fill the new attributes from the adapter produced output.
-    # $out refers to an instance of OutputTemplate message
-    source.ip: $out.source_pod_ip | ip("0.0.0.0")
-    source.uid: $out.source_pod_uid | "unknown"
-    source.labels: $out.source_labels | emptyStringMap()
-    source.name: $out.source_pod_name | "unknown"
-    source.namespace: $out.source_namespace | "default"
-    source.owner: $out.source_owner | "unknown"
-    source.serviceAccount: $out.source_service_account_name | "unknown"
-    source.workload.uid: $out.source_workload_uid | "unknown"
-    source.workload.name: $out.source_workload_name | "unknown"
-    source.workload.namespace: $out.source_workload_namespace | "unknown"
-    destination.ip: $out.destination_pod_ip | ip("0.0.0.0")
-    destination.uid: $out.destination_pod_uid | "unknown"
-    destination.labels: $out.destination_labels | emptyStringMap()
-    destination.name: $out.destination_pod_name | "unknown"
-    destination.container.name: $out.destination_container_name | "unknown"
-    destination.namespace: $out.destination_namespace | "default"
-    destination.owner: $out.destination_owner | "unknown"
-    destination.serviceAccount: $out.destination_service_account_name | "unknown"
-    destination.workload.uid: $out.destination_workload_uid | "unknown"
-    destination.workload.name: $out.destination_workload_name | "unknown"
-    destination.workload.namespace: $out.destination_workload_namespace | "unknown"
----
-
-
-apiVersion: networking.istio.io/v1alpha3
-kind: DestinationRule
-metadata:
-  name: istio-telemetry
-  namespace: istio-system
-  labels:
-    app: istio-telemetry
-    release: istio
-spec:
-  host: istio-telemetry.istio-system.svc.cluster.local
-  trafficPolicy:
-    portLevelSettings:
-    - port:
-        number: 15004 # grpc-mixer-mtls
-      tls:
-        mode: ISTIO_MUTUAL
-    - port:
-        number: 9091 # grpc-mixer
-      tls:
-        mode: DISABLE
-    connectionPool:
-      http:
-        http2MaxRequests: 10000
-        maxRequestsPerConnection: 10000
----
-
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  namespace: istio-system
-  name: telemetry-envoy-config
-  labels:
-    release: istio
-data:
-  # Explicitly defined - moved from istio/istio/pilot/docker.
-  envoy.yaml.tmpl: |-
-    admin:
-      access_log_path: /dev/null
-      address:
-        socket_address:
-          address: 127.0.0.1
-          port_value: 15000
-    stats_config:
-      use_all_default_tags: false
-      stats_tags:
-      - tag_name: cluster_name
-        regex: '^cluster\.((.+?(\..+?\.svc\.cluster\.local)?)\.)'
-      - tag_name: tcp_prefix
-        regex: '^tcp\.((.*?)\.)\w+?$'
-      - tag_name: response_code
-        regex: '_rq(_(\d{3}))$'
-      - tag_name: response_code_class
-        regex: '_rq(_(\dxx))$'
-      - tag_name: http_conn_manager_listener_prefix
-        regex: '^listener(?=\.).*?\.http\.(((?:[_.[:digit:]]*|[_\[\]aAbBcCdDeEfF[:digit:]]*))\.)'
-      - tag_name: http_conn_manager_prefix
-        regex: '^http\.(((?:[_.[:digit:]]*|[_\[\]aAbBcCdDeEfF[:digit:]]*))\.)'
-      - tag_name: listener_address
-        regex: '^listener\.(((?:[_.[:digit:]]*|[_\[\]aAbBcCdDeEfF[:digit:]]*))\.)'
-
-    static_resources:
-      clusters:
-      - name: prometheus_stats
-        type: STATIC
-        connect_timeout: 0.250s
-        lb_policy: ROUND_ROBIN
-        hosts:
-        - socket_address:
-            protocol: TCP
-            address: 127.0.0.1
-            port_value: 15000
-
-      - name: sds-grpc
-        type: STATIC
-        http2_protocol_options: {}
-        connect_timeout: 0.250s
-        lb_policy: ROUND_ROBIN
-        hosts:
-        - pipe:
-            path: "/etc/istio/proxy/SDS"
-
-      - name: inbound_9092
-        circuit_breakers:
-          thresholds:
-          - max_connections: 100000
-            max_pending_requests: 100000
-            max_requests: 100000
-            max_retries: 3
-        connect_timeout: 1.000s
-        hosts:
-        - pipe:
-            path: /sock/mixer.socket
-        http2_protocol_options: {}
-
-      - name: out.galley.15019
-        http2_protocol_options: {}
-        connect_timeout: 1.000s
-        type: STRICT_DNS
-
-        circuit_breakers:
-          thresholds:
-            - max_connections: 100000
-              max_pending_requests: 100000
-              max_requests: 100000
-              max_retries: 3
-
-        tls_context:
-          common_tls_context:
-            tls_certificate_sds_secret_configs:
-            - name: default
-              sds_config:
-                api_config_source:
-                  api_type: GRPC
-                  grpc_services:
-                  - envoy_grpc:
-                      cluster_name: sds-grpc
-            combined_validation_context:
-              default_validation_context:
-                verify_subject_alt_name:
-                - spiffe://cluster.local/ns/istio-system/sa/istio-galley-service-account
-              validation_context_sds_secret_config:
-                name: ROOTCA
-                sds_config:
-                  api_config_source:
-                    api_type: GRPC
-                    grpc_services:
-                    - envoy_grpc:
-                        cluster_name: sds-grpc
-        hosts:
-          - socket_address:
-              address: istio-galley.istio-system
-              port_value: 15019
-
-
-      listeners:
-      - name: "15090"
-        address:
-          socket_address:
-            protocol: TCP
-            address: 0.0.0.0
-            port_value: 15090
-        filter_chains:
-        - filters:
-          - name: envoy.http_connection_manager
-            config:
-              codec_type: AUTO
-              stat_prefix: stats
-              route_config:
-                virtual_hosts:
-                - name: backend
-                  domains:
-                  - '*'
-                  routes:
-                  - match:
-                      prefix: /stats/prometheus
-                    route:
-                      cluster: prometheus_stats
-              http_filters:
-              - name: envoy.router
-
-      - name: "15004"
-        address:
-          socket_address:
-            address: 0.0.0.0
-            port_value: 15004
-        filter_chains:
-        - filters:
-          - config:
-              codec_type: HTTP2
-              http2_protocol_options:
-                max_concurrent_streams: 1073741824
-              generate_request_id: true
-              http_filters:
-              - config:
-                  default_destination_service: istio-telemetry.istio-system.svc.cluster.local
-                  service_configs:
-                    istio-telemetry.istio-system.svc.cluster.local:
-                      disable_check_calls: true
-    {{- if .DisableReportCalls }}
-                      disable_report_calls: true
-    {{- end }}
-                      mixer_attributes:
-                        attributes:
-                          destination.service.host:
-                            string_value: istio-telemetry.istio-system.svc.cluster.local
-                          destination.service.uid:
-                            string_value: istio://istio-system/services/istio-telemetry
-                          destination.service.name:
-                            string_value: istio-telemetry
-                          destination.service.namespace:
-                            string_value: istio-system
-                          destination.uid:
-                            string_value: kubernetes://{{ .PodName }}.istio-system
-                          destination.namespace:
-                            string_value: istio-system
-                          destination.ip:
-                            bytes_value: {{ .PodIP }}
-                          destination.port:
-                            int64_value: 15004
-                          context.reporter.kind:
-                            string_value: inbound
-                          context.reporter.uid:
-                            string_value: kubernetes://{{ .PodName }}.istio-system
-                  transport:
-                    check_cluster: mixer_check_server
-                    report_cluster: inbound_9092
-                name: mixer
-              - name: envoy.router
-              route_config:
-                name: "15004"
-                virtual_hosts:
-                - domains:
-                  - '*'
-                  name: istio-telemetry.istio-system.svc.cluster.local
-                  routes:
-                  - decorator:
-                      operation: Report
-                    match:
-                      prefix: /
-                    route:
-                      cluster: inbound_9092
-                      timeout: 0.000s
-              stat_prefix: "15004"
-            name: envoy.http_connection_manager
-          tls_context:
-            require_client_certificate: true
-            common_tls_context:
-              alpn_protocols:
-              - h2
-              tls_certificate_sds_secret_configs:
-              - name: default
-                sds_config:
-                  api_config_source:
-                    api_type: GRPC
-                    grpc_services:
-                    - envoy_grpc:
-                        cluster_name: sds-grpc
-              validation_context_sds_secret_config:
-                name: ROOTCA
-                sds_config:
-                  api_config_source:
-                    api_type: GRPC
-                    grpc_services:
-                    - envoy_grpc:
-                        cluster_name: sds-grpc
-
-      - name: "9091"
-        address:
-          socket_address:
-            address: 0.0.0.0
-            port_value: 9091
-        filter_chains:
-        - filters:
-          - config:
-              codec_type: HTTP2
-              http2_protocol_options:
-                max_concurrent_streams: 1073741824
-              generate_request_id: true
-              http_filters:
-              - config:
-                  default_destination_service: istio-telemetry.istio-system.svc.cluster.local
-                  service_configs:
-                    istio-telemetry.istio-system.svc.cluster.local:
-                      disable_check_calls: true
-    {{- if .DisableReportCalls }}
-                      disable_report_calls: true
-    {{- end }}
-                      mixer_attributes:
-                        attributes:
-                          destination.service.host:
-                            string_value: istio-telemetry.istio-system.svc.cluster.local
-                          destination.service.uid:
-                            string_value: istio://istio-system/services/istio-telemetry
-                          destination.service.name:
-                            string_value: istio-telemetry
-                          destination.service.namespace:
-                            string_value: istio-system
-                          destination.uid:
-                            string_value: kubernetes://{{ .PodName }}.istio-system
-                          destination.namespace:
-                            string_value: istio-system
-                          destination.ip:
-                            bytes_value: {{ .PodIP }}
-                          destination.port:
-                            int64_value: 9091
-                          context.reporter.kind:
-                            string_value: inbound
-                          context.reporter.uid:
-                            string_value: kubernetes://{{ .PodName }}.istio-system
-                  transport:
-                    check_cluster: mixer_check_server
-                    report_cluster: inbound_9092
-                name: mixer
-              - name: envoy.router
-              route_config:
-                name: "9091"
-                virtual_hosts:
-                - domains:
-                  - '*'
-                  name: istio-telemetry.istio-system.svc.cluster.local
-                  routes:
-                  - decorator:
-                      operation: Report
-                    match:
-                      prefix: /
-                    route:
-                      cluster: inbound_9092
-                      timeout: 0.000s
-              stat_prefix: "9091"
-            name: envoy.http_connection_manager
-
-      - name: "local.15019"
-        address:
-          socket_address:
-            address: 127.0.0.1
-            port_value: 15019
-        filter_chains:
-          - filters:
-              - name: envoy.http_connection_manager
-                config:
-                  codec_type: HTTP2
-                  stat_prefix: "15019"
-                  stream_idle_timeout: 0s
-                  http2_protocol_options:
-                    max_concurrent_streams: 1073741824
-
-                  access_log:
-                    - name: envoy.file_access_log
-                      config:
-                        path: /dev/stdout
-
-                  http_filters:
-                    - name: envoy.router
-
-                  route_config:
-                    name: "15019"
-
-                    virtual_hosts:
-                      - name: istio-galley
-
-                        domains:
-                          - '*'
-
-                        routes:
-                          - match:
-                              prefix: /
-                            route:
-                              cluster: out.galley.15019
-                              timeout: 0.000s
----
-
-
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app: istio-mixer
-    istio: mixer
-    release: istio
-  name: istio-telemetry
-  namespace: istio-system
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      istio: mixer
-      istio-mixer-type: telemetry
-  strategy:
-    rollingUpdate:
-      maxSurge: 100%
-      maxUnavailable: 25%
-  template:
-    metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
-      labels:
-        app: telemetry
-        istio: mixer
-        istio-mixer-type: telemetry
-    spec:
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - preference:
-              matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
-            weight: 2
-          - preference:
-              matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - ppc64le
-            weight: 2
-          - preference:
-              matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - s390x
-            weight: 2
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
-                - ppc64le
-                - s390x
-      containers:
-      - args:
-        - --monitoringPort=15014
-        - --address
-        - unix:///sock/mixer.socket
-        - --log_output_level=default:info
-        - --configStoreURL=k8s://
-        - --configDefaultNamespace=istio-system
-        - --useAdapterCRDs=false
-        - --useTemplateCRDs=false
-        - --trace_zipkin_url=http://zipkin.istio-system:9411/api/v1/spans
-        env:
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        - name: GOMAXPROCS
-          value: "6"
-        image: gcr.io/istio-testing/mixer:latest
-        livenessProbe:
-          httpGet:
-            path: /version
-            port: 15014
-          initialDelaySeconds: 5
-          periodSeconds: 5
-        name: mixer
-        ports:
-        - containerPort: 9091
-        - containerPort: 15014
-        - containerPort: 42422
-        resources:
-          limits:
-            cpu: 4800m
-            memory: 4G
-          requests:
-            cpu: 1000m
-            memory: 1G
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-          runAsGroup: 1337
-          runAsNonRoot: true
-          runAsUser: 1337
-        volumeMounts:
-        - mountPath: /sock
-          name: uds-socket
-        - mountPath: /var/run/secrets/istio.io/telemetry/adapter
-          name: telemetry-adapter-secret
-          readOnly: true
-      - args:
-        - proxy
-        - --domain
-        - $(POD_NAMESPACE).svc.cluster.local
-        - --serviceCluster
-        - istio-telemetry
-        - --templateFile
-        - /var/lib/envoy/envoy.yaml.tmpl
-        - --controlPlaneAuthPolicy
-        - MUTUAL_TLS
-        - --trust-domain=cluster.local
-        env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        - name: INSTANCE_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: JWT_POLICY
-          value: third-party-jwt
-        - name: PILOT_CERT_PROVIDER
-          value: istiod
-        - name: ISTIO_META_USER_SDS
-          value: "true"
-        - name: CA_ADDR
-          value: istiod.istio-system.svc:15012
-        image: gcr.io/istio-testing/proxyv2:latest
-        name: istio-proxy
-        ports:
-        - containerPort: 15004
-        - containerPort: 15090
-          name: http-envoy-prom
-          protocol: TCP
-        resources:
-          limits:
-            cpu: 2000m
-            memory: 1024Mi
-          requests:
-            cpu: 100m
-            memory: 128Mi
-        volumeMounts:
-        - mountPath: /etc/istio/config
-          name: config-volume
-        - mountPath: /var/run/secrets/istio
-          name: istiod-ca-cert
-        - mountPath: /var/run/secrets/tokens
-          name: istio-token
-          readOnly: true
-        - mountPath: /var/lib/envoy
-          name: telemetry-envoy-config
-        - mountPath: /sock
-          name: uds-socket
-      securityContext:
-        fsGroup: 1337
-      serviceAccountName: istio-mixer-service-account
-      volumes:
-      - configMap:
-          name: istio
-          optional: true
-        name: config-volume
-      - configMap:
-          name: istio-ca-root-cert
-        name: istiod-ca-cert
-      - name: istio-token
-        projected:
-          sources:
-          - serviceAccountToken:
-              audience: istio-ca
-              expirationSeconds: 43200
-              path: istio-token
-      - name: istio-certs
-        secret:
-          optional: true
-          secretName: istio.istio-mixer-service-account
-      - emptyDir: {}
-        name: uds-socket
-      - name: telemetry-adapter-secret
-        secret:
-          optional: true
-          secretName: telemetry-adapter-secret
-      - configMap:
-          name: telemetry-envoy-config
-        name: telemetry-envoy-config
-
----
-
-
-apiVersion: policy/v1beta1
-kind: PodDisruptionBudget
-metadata:
-  name: istio-telemetry
-  namespace: istio-system
-  labels:
-    app: telemetry
-    release: istio
-    istio: mixer
-    istio-mixer-type: telemetry
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app: telemetry
-      istio: mixer
-      istio-mixer-type: telemetry
----
-
-
-apiVersion: v1
-kind: Service
-metadata:
-  name: istio-telemetry
-  namespace: istio-system
-  labels:
-    app: mixer
-    istio: mixer
-    release: istio
-spec:
-  ports:
-  - name: grpc-mixer
-    port: 9091
-  - name: grpc-mixer-mtls
-    port: 15004
-  - name: http-monitoring
-    port: 15014
-  - name: prometheus
-    port: 42422
-  selector:
-    istio: mixer
-    istio-mixer-type: telemetry
----
-
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: istio-mixer-service-account
-  namespace: istio-system
-  labels:
-    app: istio-telemetry
-    release: istio
----
+# Telemetry component is disabled.
 

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -636,7 +636,7 @@ data:
         {{- else if .Values.global.configNamespace }}
           value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.configNamespace }}.svc:15012
         {{- else }}
-          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.istio-system.svc:15012
+          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Release.Namespace }}.svc:15012
         {{- end }}
         - name: POD_NAME
           valueFrom:
@@ -891,7 +891,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
   name: istio-sidecar-injector
-
   labels:
     istio.io/rev: default
     app: sidecar-injector

--- a/operator/pkg/controller/istiocontrolplane/rendering_test.go
+++ b/operator/pkg/controller/istiocontrolplane/rendering_test.go
@@ -91,6 +91,9 @@ func TestRenderCharts(t *testing.T) {
 			desc:       "component_hub_tag",
 			diffSelect: "Deployment:*:*",
 		},
+		{
+			desc: "namespace_override",
+		},
 	})
 	removeDirOrFail(t, flagOutputDir)
 	removeDirOrFail(t, flagOutputValuesDir)

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -7024,7 +7024,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: istio-reader-service-account
-  namespace: istio-system
+  namespace: default
   labels:
     app: istio-reader
     release: istio-base
@@ -7033,7 +7033,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: istio-pilot-service-account
-  namespace: istio-system
+  namespace: default
   labels:
     app: pilot
     release: istio-base
@@ -13742,7 +13742,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istiod-istio-system
+  name: istiod-default
   labels:
     app: istiod
     release: istio-base
@@ -13832,7 +13832,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-reader-istio-system
+  name: istio-reader-default
   labels:
     app: istio-reader
     release: istio-base
@@ -13859,34 +13859,34 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-reader-istio-system
+  name: istio-reader-default
   labels:
     app: istio-reader
     release: istio-base
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istio-reader-istio-system
+  name: istio-reader-default
 subjects:
   - kind: ServiceAccount
     name: istio-reader-service-account
-    namespace: istio-system
+    namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istiod-pilot-istio-system
+  name: istiod-pilot-default
   labels:
     app: pilot
     release: istio-base
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istiod-istio-system
+  name: istiod-default
 subjects:
   - kind: ServiceAccount
     name: istio-pilot-service-account
-    namespace: istio-system
+    namespace: default
 ---
 
 ---
@@ -13902,7 +13902,7 @@ subjects:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: istiod-istio-system
+  name: istiod-default
   labels:
     app: istiod
     release: istio-base
@@ -13912,7 +13912,7 @@ webhooks:
     clientConfig:
       service:
         name: istiod
-        namespace: istio-system
+        namespace: default
         path: "/validate"
       caBundle: "" # patched at runtime when the webhook is ready.
     rules:
@@ -13935,6 +13935,7 @@ webhooks:
     failurePolicy: Ignore
     sideEffects: None
 ---
+
 `)
 
 func chartsBaseFilesGenIstioClusterYamlBytes() ([]byte, error) {
@@ -13979,7 +13980,7 @@ var _chartsBaseTemplatesClusterroleYaml = []byte(`# Dedicated cluster role - ist
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istiod-{{ .Values.global.istioNamespace }}
+  name: istiod-{{ .Release.Namespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}
@@ -14081,7 +14082,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-reader-{{ .Values.global.istioNamespace }}
+  name: istio-reader-{{ .Release.Namespace }}
   labels:
     app: istio-reader
     release: {{ .Release.Name }}
@@ -14122,34 +14123,34 @@ func chartsBaseTemplatesClusterroleYaml() (*asset, error) {
 var _chartsBaseTemplatesClusterrolebindingYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-reader-{{ .Values.global.istioNamespace }}
+  name: istio-reader-{{ .Release.Namespace }}
   labels:
     app: istio-reader
     release: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istio-reader-{{ .Values.global.istioNamespace }}
+  name: istio-reader-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: istio-reader-service-account
-    namespace: {{ .Values.global.istioNamespace }}
+    namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istiod-pilot-{{ .Values.global.istioNamespace }}
+  name: istiod-pilot-{{ .Release.Namespace }}
   labels:
     app: pilot
     release: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: istiod-{{ .Values.global.istioNamespace }}
+  name: istiod-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: istio-pilot-service-account
-    namespace: {{ .Values.global.istioNamespace }}
+    namespace: {{ .Release.Namespace }}
 ---
 `)
 
@@ -14194,7 +14195,7 @@ apiVersion: v1
 kind: Endpoints
 metadata:
   name: istio-pilot
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Release.Namespace }}
 subsets:
 - addresses:
   - ip: {{ .Values.global.remotePilotAddress }}
@@ -14223,7 +14224,7 @@ apiVersion: v1
 kind: Endpoints
 metadata:
   name: istio-policy
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Release.Namespace }}
 subsets:
 - addresses:
   - ip: {{ .Values.global.remotePolicyAddress }}
@@ -14241,7 +14242,7 @@ apiVersion: v1
 kind: Endpoints
 metadata:
   name: istio-telemetry
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Release.Namespace }}
 subsets:
 - addresses:
   - ip: {{ .Values.global.remoteTelemetryAddress }}
@@ -14282,7 +14283,7 @@ imagePullSecrets:
 {{- end }}
 metadata:
   name: istio-reader-service-account
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: istio-reader
     release: {{ .Release.Name }}
@@ -14297,7 +14298,7 @@ imagePullSecrets:
   {{- end }}
 metadata:
   name: istio-pilot-service-account
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: pilot
     release: {{ .Release.Name }}
@@ -14325,7 +14326,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: istio-pilot
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - port: 15010
@@ -14352,7 +14353,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: istio-policy
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - name: grpc-mixer
@@ -14369,7 +14370,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: istio-telemetry
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - name: grpc-mixer
@@ -14403,7 +14404,7 @@ func chartsBaseTemplatesServicesYaml() (*asset, error) {
 var _chartsBaseTemplatesValidatingwebhookconfigurationYaml = []byte(`apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: istiod-{{ .Values.global.istioNamespace }}
+  name: istiod-{{ .Release.Namespace }}
   labels:
     app: istiod
     release: {{ .Release.Name }}
@@ -14413,7 +14414,7 @@ webhooks:
     clientConfig:
       service:
         name: istiod
-        namespace: {{ .Values.global.istioNamespace }}
+        namespace: {{ .Release.Namespace }}
         path: "/validate"
       caBundle: "" # patched at runtime when the webhook is ready.
     rules:
@@ -14435,7 +14436,8 @@ webhooks:
     # endpoint is ready.
     failurePolicy: Ignore
     sideEffects: None
----`)
+---
+`)
 
 func chartsBaseTemplatesValidatingwebhookconfigurationYamlBytes() ([]byte, error) {
 	return _chartsBaseTemplatesValidatingwebhookconfigurationYaml, nil
@@ -15768,7 +15770,7 @@ spec:
           {{- else if .Values.global.configNamespace }}
             value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.configNamespace }}.svc:15012
           {{- else }}
-            value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.istio-system.svc:15012
+            value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Release.Namespace }}.svc:15012
           {{- end }}
           - name: NODE_NAME
             valueFrom:
@@ -15960,7 +15962,7 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   hosts:
-  - istiod.{{ .Values.global.istioNamespace }}.svc.{{ .Values.global.proxy.clusterDomain }}
+  - istiod.{{ .Release.Namespace }}.svc.{{ .Values.global.proxy.clusterDomain }}
   gateways:
   - meshexpansion-gateway
   tcp:
@@ -15968,7 +15970,7 @@ spec:
     - port: 15012
     route:
     - destination:
-        host: istiod.{{ .Values.global.istioNamespace }}.svc.{{ .Values.global.proxy.clusterDomain }}
+        host: istiod.{{ .Release.Namespace }}.svc.{{ .Values.global.proxy.clusterDomain }}
         port:
           number: 15012
 ---
@@ -17470,7 +17472,7 @@ data:
         {{- else if .Values.global.configNamespace }}
           value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.configNamespace }}.svc:15012
         {{- else }}
-          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.istio-system.svc:15012
+          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Release.Namespace }}.svc:15012
         {{- end }}
         - name: POD_NAME
           valueFrom:
@@ -18704,7 +18706,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
   name: istio-sidecar-injector
-
   labels:
     istio.io/rev: default
     app: sidecar-injector
@@ -18909,7 +18910,7 @@ template: |
     {{- else if .Values.global.configNamespace }}
       value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.configNamespace }}.svc:15012
     {{- else }}
-      value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.istio-system.svc:15012
+      value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Release.Namespace }}.svc:15012
     {{- end }}
     - name: POD_NAME
       valueFrom:
@@ -19916,11 +19917,7 @@ var _chartsIstioControlIstioDiscoveryTemplatesMutatingwebhookYaml = []byte(`# In
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-{{- if eq .Release.Namespace "istio-system"}}
   name: istio-sidecar-injector{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-{{ else }}
-  name: istio-sidecar-injector{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}-{{ .Release.Namespace }}
-{{- end }}
   labels:
     istio.io/rev: {{ .Values.revision | default "default" }}
     app: sidecar-injector
@@ -35831,7 +35828,7 @@ data:
       tracing: {{ .Values.global.telemetryNamespace }}
       pilot: {{ .Values.global.configNamespace }}
       prometheus: {{ .Values.global.prometheusNamespace }}
-    istio_namespace: {{ .Values.global.istioNamespace }}
+    istio_namespace: {{ .Release.Namespace }}
     auth:
       strategy: {{ .Values.kiali.dashboard.auth.strategy }}
 {{- if eq .Values.kiali.dashboard.auth.strategy "ldap" }}
@@ -38042,7 +38039,7 @@ spec:
           {{- else if .Values.global.configNamespace }}
           value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.configNamespace }}.svc:15012
           {{- else }}
-          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.istio-system.svc:15012
+          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Release.Namespace }}.svc:15012
       {{- end }}
         resources:
 {{- if .Values.global.proxy.resources }}
@@ -39611,7 +39608,7 @@ data:
       - role: endpoints
         namespaces:
           names:
-          - {{ .Values.global.istioNamespace }}
+          - {{ .Release.Namespace }}
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
@@ -39922,7 +39919,7 @@ spec:
               {{- else if .Values.global.configNamespace }}
               value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.configNamespace }}.svc:15012
               {{- else }}
-              value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.istio-system.svc:15012
+              value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Release.Namespace }}.svc:15012
               {{- end }}
             - name: POD_NAME
               valueFrom:


### PR DESCRIPTION
Resolve #22808.
The `INJECTION_WEBHOOK_CONFIG_NAME` env var to `istiod` was not being set correctly if the control plane is installed in a non-default namespace.

- Removes the namespace from the mutating webhook config so that the value is correct.
- Adds a test for setting the IstioOperator CR namespace to non-default
- Fixes several references where the incorrect namespace value was getting used to instead use `.Release.Namespace` which seems to be correctly populated from the logic here https://github.com/istio/istio/pull/22797

