### PR TITLE
feat(gcp): add additional metadata for gce managed instance groups

### DIFF
--- a/pkg/bootstrap/platform/gcp_test.go
+++ b/pkg/bootstrap/platform/gcp_test.go
@@ -25,15 +25,17 @@ import (
 
 func TestGCPMetadata(t *testing.T) {
 	tests := []struct {
-		name               string
-		shouldFill         shouldFillFn
-		projectIDFn        metadataFn
-		numericProjectIDFn metadataFn
-		locationFn         metadataFn
-		clusterNameFn      metadataFn
-		instanceIDFn       metadataFn
-		env                map[string]string
-		want               map[string]string
+		name                string
+		shouldFill          shouldFillFn
+		projectIDFn         metadataFn
+		numericProjectIDFn  metadataFn
+		locationFn          metadataFn
+		clusterNameFn       metadataFn
+		instanceIDFn        metadataFn
+		instanceTemplateFn  metadataFn
+		instanceCreatedByFn metadataFn
+		env                 map[string]string
+		want                map[string]string
 	}{
 		{
 			"should not fill",
@@ -43,6 +45,8 @@ func TestGCPMetadata(t *testing.T) {
 			func() (string, error) { return "location", nil },
 			func() (string, error) { return "cluster", nil },
 			func() (string, error) { return "instance", nil },
+			func() (string, error) { return "instanceTemplate", nil },
+			func() (string, error) { return "createdBy", nil },
 			map[string]string{},
 			map[string]string{},
 		},
@@ -54,8 +58,11 @@ func TestGCPMetadata(t *testing.T) {
 			func() (string, error) { return "location", nil },
 			func() (string, error) { return "cluster", nil },
 			func() (string, error) { return "instance", nil },
+			func() (string, error) { return "instanceTemplate", nil },
+			func() (string, error) { return "createdBy", nil },
 			map[string]string{},
-			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCPCluster: "cluster", GCEInstanceID: "instance"},
+			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCPCluster: "cluster", GCEInstanceID: "instance",
+				GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
 		},
 		{
 			"project id error",
@@ -65,8 +72,11 @@ func TestGCPMetadata(t *testing.T) {
 			func() (string, error) { return "location", nil },
 			func() (string, error) { return "cluster", nil },
 			func() (string, error) { return "instance", nil },
+			func() (string, error) { return "instanceTemplate", nil },
+			func() (string, error) { return "createdBy", nil },
 			map[string]string{},
-			map[string]string{GCPLocation: "location", GCPProjectNumber: "npid", GCPCluster: "cluster", GCEInstanceID: "instance"},
+			map[string]string{GCPLocation: "location", GCPProjectNumber: "npid", GCPCluster: "cluster", GCEInstanceID: "instance",
+				GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
 		},
 		{
 			"numeric project id error",
@@ -76,8 +86,11 @@ func TestGCPMetadata(t *testing.T) {
 			func() (string, error) { return "location", nil },
 			func() (string, error) { return "cluster", nil },
 			func() (string, error) { return "instance", nil },
+			func() (string, error) { return "instanceTemplate", nil },
+			func() (string, error) { return "createdBy", nil },
 			map[string]string{},
-			map[string]string{GCPLocation: "location", GCPProject: "pid", GCPCluster: "cluster", GCEInstanceID: "instance"},
+			map[string]string{GCPLocation: "location", GCPProject: "pid", GCPCluster: "cluster", GCEInstanceID: "instance",
+				GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
 		},
 		{
 			"location error",
@@ -87,8 +100,11 @@ func TestGCPMetadata(t *testing.T) {
 			func() (string, error) { return "location", errors.New("error") },
 			func() (string, error) { return "cluster", nil },
 			func() (string, error) { return "instance", nil },
+			func() (string, error) { return "instanceTemplate", nil },
+			func() (string, error) { return "createdBy", nil },
 			map[string]string{},
-			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPCluster: "cluster", GCEInstanceID: "instance"},
+			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPCluster: "cluster", GCEInstanceID: "instance",
+				GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
 		},
 		{
 			"cluster name error",
@@ -98,9 +114,11 @@ func TestGCPMetadata(t *testing.T) {
 			func() (string, error) { return "location", nil },
 			func() (string, error) { return "cluster", errors.New("error") },
 			func() (string, error) { return "instance", nil },
+			func() (string, error) { return "instanceTemplate", nil },
+			func() (string, error) { return "createdBy", nil },
 			map[string]string{},
-			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCEInstanceID: "instance"},
-			//map[string]string{GCPProject: "pid", GCPLocation: "location"},
+			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCEInstanceID: "instance",
+				GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
 		},
 		{
 			"instance id error",
@@ -110,8 +128,39 @@ func TestGCPMetadata(t *testing.T) {
 			func() (string, error) { return "location", nil },
 			func() (string, error) { return "cluster", nil },
 			func() (string, error) { return "", errors.New("error") },
+			func() (string, error) { return "instanceTemplate", nil },
+			func() (string, error) { return "createdBy", nil },
 			map[string]string{},
-			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCPCluster: "cluster"},
+			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCPCluster: "cluster",
+				GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
+		},
+		{
+			"instance template error",
+			func() bool { return true },
+			func() (string, error) { return "pid", nil },
+			func() (string, error) { return "npid", nil },
+			func() (string, error) { return "location", nil },
+			func() (string, error) { return "cluster", nil },
+			func() (string, error) { return "instance", nil },
+			func() (string, error) { return "", errors.New("error") },
+			func() (string, error) { return "createdBy", nil },
+			map[string]string{},
+			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCPCluster: "cluster",
+				GCEInstanceID: "instance", GCEInstanceCreatedBy: "createdBy"},
+		},
+		{
+			"instance created by error",
+			func() bool { return true },
+			func() (string, error) { return "pid", nil },
+			func() (string, error) { return "npid", nil },
+			func() (string, error) { return "location", nil },
+			func() (string, error) { return "cluster", nil },
+			func() (string, error) { return "instance", nil },
+			func() (string, error) { return "instanceTemplate", nil },
+			func() (string, error) { return "", errors.New("error") },
+			map[string]string{},
+			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCPCluster: "cluster",
+				GCEInstanceID: "instance", GCEInstanceTemplate: "instanceTemplate"},
 		},
 		{
 			"use env variable",
@@ -121,8 +170,11 @@ func TestGCPMetadata(t *testing.T) {
 			func() (string, error) { return "location", nil },
 			func() (string, error) { return "cluster", nil },
 			func() (string, error) { return "instance", nil },
+			func() (string, error) { return "instanceTemplate", nil },
+			func() (string, error) { return "createdBy", nil },
 			map[string]string{"GCP_METADATA": "env_pid|env_pn|env_cluster|env_location"},
-			map[string]string{GCPProject: "env_pid", GCPProjectNumber: "env_pn", GCPLocation: "env_location", GCPCluster: "env_cluster", GCEInstanceID: "instance"},
+			map[string]string{GCPProject: "env_pid", GCPProjectNumber: "env_pn", GCPLocation: "env_location", GCPCluster: "env_cluster", GCEInstanceID: "instance",
+				GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
 		},
 	}
 
@@ -132,7 +184,8 @@ func TestGCPMetadata(t *testing.T) {
 				os.Setenv(e, v)
 			}
 			once = sync.Once{}
-			mg := gcpEnv{tt.shouldFill, tt.projectIDFn, tt.numericProjectIDFn, tt.locationFn, tt.clusterNameFn, tt.instanceIDFn}
+			mg := gcpEnv{tt.shouldFill, tt.projectIDFn, tt.numericProjectIDFn, tt.locationFn, tt.clusterNameFn, tt.instanceIDFn,
+				tt.instanceTemplateFn, tt.instanceCreatedByFn}
 			got := mg.Metadata()
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("gcpEnv.Metadata() => '%v'; want '%v'", got, tt.want)


### PR DESCRIPTION
This PR adds additional fields to the platform-specific metadata for GCP. In particular, it adds `gcp_gce_instance_template` and `gcp_gce_instance_created_by`.

These fields can be used by Envoy extensions to determine if/when the Envoy is running on a GCE instance managed by an instance group. For instance, the Stackdriver instance can use this in reporting to `meshtelemetry.googleapis.com` and in proper population of `_owner` labels.

Manually verified on a MIG:

```
"PLATFORM_METADATA": {
       "gcp_project": "<redacted>",
       "gcp_gce_instance_id": "<redacted>",
       "gcp_gce_instance_created_by": "projects/<redacted>/zones/us-central1-a/instanceGroupManagers/mig-test-group-3",
       "gcp_project_number": "<redacted>",
       "gcp_location": "us-central1-a",
       "gcp_gce_instance_template": "projects/<redacted>/global/instanceTemplates/mig-test-template-1"
 },
```

[ X ] Policies and Telemetry
