### PR TITLE
Disable using host header in gateway stats filter

### DIFF
--- a/manifests/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1089,6 +1089,7 @@ spec:
                 {
                   "debug": "false",
                   "stat_prefix": "istio",
+                  "disable_host_header_fallback": true,
                 }
               vm_config:
                 vm_id: stats_outbound
@@ -1286,6 +1287,7 @@ spec:
                   {
                     "debug": "false",
                     "stat_prefix": "istio",
+                    "disable_host_header_fallback": true,
                   }
                 vm_config:
                   vm_id: stats_outbound
@@ -1587,6 +1589,7 @@ spec:
                   {
                     "debug": "false",
                     "stat_prefix": "istio",
+                    "disable_host_header_fallback": true,
                   }
                 vm_config:
                   vm_id: stats_outbound

--- a/manifests/istio-control/istio-discovery/templates/telemetryv2_1.4.yaml
+++ b/manifests/istio-control/istio-discovery/templates/telemetryv2_1.4.yaml
@@ -125,6 +125,7 @@ spec:
                 {
                   "debug": "false",
                   "stat_prefix": "istio",
+                  "disable_host_header_fallback": true,
                 }
               vm_config:
                 vm_id: stats_outbound

--- a/manifests/istio-control/istio-discovery/templates/telemetryv2_1.5.yaml
+++ b/manifests/istio-control/istio-discovery/templates/telemetryv2_1.5.yaml
@@ -219,6 +219,7 @@ spec:
                   {
                     "debug": "false",
                     "stat_prefix": "istio",
+                    "disable_host_header_fallback": true,
                   }
                 vm_config:
                   vm_id: stats_outbound

--- a/manifests/istio-control/istio-discovery/templates/telemetryv2_1.6.yaml
+++ b/manifests/istio-control/istio-discovery/templates/telemetryv2_1.6.yaml
@@ -222,6 +222,7 @@ spec:
                   {
                     "debug": "false",
                     "stat_prefix": "istio",
+                    "disable_host_header_fallback": true,
                   }
                 vm_config:
                   vm_id: stats_outbound

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -18082,6 +18082,7 @@ spec:
                 {
                   "debug": "false",
                   "stat_prefix": "istio",
+                  "disable_host_header_fallback": true,
                 }
               vm_config:
                 vm_id: stats_outbound
@@ -18279,6 +18280,7 @@ spec:
                   {
                     "debug": "false",
                     "stat_prefix": "istio",
+                    "disable_host_header_fallback": true,
                   }
                 vm_config:
                   vm_id: stats_outbound
@@ -18580,6 +18582,7 @@ spec:
                   {
                     "debug": "false",
                     "stat_prefix": "istio",
+                    "disable_host_header_fallback": true,
                   }
                 vm_config:
                   vm_id: stats_outbound
@@ -20210,6 +20213,7 @@ spec:
                 {
                   "debug": "false",
                   "stat_prefix": "istio",
+                  "disable_host_header_fallback": true,
                 }
               vm_config:
                 vm_id: stats_outbound
@@ -20562,6 +20566,7 @@ spec:
                   {
                     "debug": "false",
                     "stat_prefix": "istio",
+                    "disable_host_header_fallback": true,
                   }
                 vm_config:
                   vm_id: stats_outbound
@@ -21060,6 +21065,7 @@ spec:
                   {
                     "debug": "false",
                     "stat_prefix": "istio",
+                    "disable_host_header_fallback": true,
                   }
                 vm_config:
                   vm_id: stats_outbound


### PR DESCRIPTION
This is to prevent unbound cardinality caused by untrusted host header. Only cluster name will be used to get destination service information. It should be disabled when these filters were introduced.

This will change the default behavior, ingressgateway/egressgateway will not have any destination host information for NR/passthrough cases, which we will need to document clearly in release notes.