### PR TITLE
Stop using deprecated filters naming/config

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/filters.go
+++ b/pilot/pkg/networking/core/v1alpha3/filters.go
@@ -1,0 +1,78 @@
+// Copyright 2020 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha3
+
+import (
+	listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	cors "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/cors/v2"
+	fault "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/fault/v2"
+	grpcweb "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/grpc_web/v2"
+	router "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/router/v2"
+	httpinspector "github.com/envoyproxy/go-control-plane/envoy/config/filter/listener/http_inspector/v2"
+	originaldst "github.com/envoyproxy/go-control-plane/envoy/config/filter/listener/original_dst/v2"
+	tlsinspector "github.com/envoyproxy/go-control-plane/envoy/config/filter/listener/tls_inspector/v2"
+	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+
+	"istio.io/istio/pilot/pkg/networking/util"
+)
+
+// Define static filters to be reused across the codebase. This avoids duplicate marshalling/unmarshalling
+// This should not be used for filters that will be mutated
+var (
+	corsFilter = &http_conn.HttpFilter{
+		Name: wellknown.CORS,
+		ConfigType: &http_conn.HttpFilter_TypedConfig{
+			TypedConfig: util.MessageToAny(&cors.Cors{}),
+		},
+	}
+	faultFilter = &http_conn.HttpFilter{
+		Name: wellknown.Fault,
+		ConfigType: &http_conn.HttpFilter_TypedConfig{
+			TypedConfig: util.MessageToAny(&fault.HTTPFault{}),
+		},
+	}
+	routerFilter = &http_conn.HttpFilter{
+		Name: wellknown.Router,
+		ConfigType: &http_conn.HttpFilter_TypedConfig{
+			TypedConfig: util.MessageToAny(&router.Router{}),
+		},
+	}
+	grpcWebFilter = &http_conn.HttpFilter{
+		Name: wellknown.GRPCWeb,
+		ConfigType: &http_conn.HttpFilter_TypedConfig{
+			TypedConfig: util.MessageToAny(&grpcweb.GrpcWeb{}),
+		},
+	}
+
+	tlsInspectorFilter = &listener.ListenerFilter{
+		Name: wellknown.TlsInspector,
+		ConfigType: &listener.ListenerFilter_TypedConfig{
+			TypedConfig: util.MessageToAny(&tlsinspector.TlsInspector{}),
+		},
+	}
+	httpInspectorFilter = &listener.ListenerFilter{
+		Name: wellknown.HttpInspector,
+		ConfigType: &listener.ListenerFilter_TypedConfig{
+			TypedConfig: util.MessageToAny(&httpinspector.HttpInspector{}),
+		},
+	}
+	originalDestinationFilter = &listener.ListenerFilter{
+		Name: wellknown.OriginalDestination,
+		ConfigType: &listener.ListenerFilter_TypedConfig{
+			TypedConfig: util.MessageToAny(&originaldst.OriginalDst{}),
+		},
+	}
+)

--- a/pilot/pkg/networking/core/v1alpha3/filters.go
+++ b/pilot/pkg/networking/core/v1alpha3/filters.go
@@ -29,7 +29,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/util"
 )
 
-// Define static filters to be reused across the codebase. This avoids duplicate marshalling/unmarshalling
+// Define static filters to be reused across the codebase. This avoids duplicate marshaling/unmarshaling
 // This should not be used for filters that will be mutated
 var (
 	corsFilter = &http_conn.HttpFilter{

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1890,7 +1890,7 @@ func buildHTTPConnectionManager(pluginParams *plugin.InputParams, httpOpts *http
 	copy(filters, httpFilters)
 
 	if httpOpts.addGRPCWebFilter {
-		filters = append(filters, &http_conn.HttpFilter{Name: wellknown.GRPCWeb})
+		filters = append(filters, grpcWebFilter)
 	}
 
 	if pluginParams.ServiceInstance != nil &&
@@ -1931,11 +1931,7 @@ func buildHTTPConnectionManager(pluginParams *plugin.InputParams, httpOpts *http
 		})
 	}
 
-	filters = append(filters,
-		&http_conn.HttpFilter{Name: wellknown.CORS},
-		&http_conn.HttpFilter{Name: wellknown.Fault},
-		&http_conn.HttpFilter{Name: wellknown.Router},
-	)
+	filters = append(filters, corsFilter, faultFilter, routerFilter)
 
 	if httpOpts.connectionManager == nil {
 		httpOpts.connectionManager = &http_conn.HttpConnectionManager{}
@@ -2073,12 +2069,12 @@ func buildListener(opts buildListenerOpts) *xdsapi.Listener {
 	}
 	if needTLSInspector || opts.needHTTPInspector {
 		listenerFiltersMap[wellknown.TlsInspector] = true
-		listenerFilters = append(listenerFilters, &listener.ListenerFilter{Name: wellknown.TlsInspector})
+		listenerFilters = append(listenerFilters, tlsInspectorFilter)
 	}
 
 	if opts.needHTTPInspector {
 		listenerFiltersMap[wellknown.HttpInspector] = true
-		listenerFilters = append(listenerFilters, &listener.ListenerFilter{Name: wellknown.HttpInspector})
+		listenerFilters = append(listenerFilters, httpInspectorFilter)
 	}
 
 	for _, chain := range opts.filterChainOpts {
@@ -2491,12 +2487,12 @@ func appendListenerFilters(filters []*listener.ListenerFilter) []*listener.Liste
 
 	if !hasTLSInspector {
 		filters =
-			append(filters, &listener.ListenerFilter{Name: wellknown.TlsInspector})
+			append(filters, tlsInspectorFilter)
 	}
 
 	if !hasHTTPInspector {
 		filters =
-			append(filters, &listener.ListenerFilter{Name: wellknown.HttpInspector})
+			append(filters, httpInspectorFilter)
 	}
 
 	return filters

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -132,9 +132,7 @@ func (lb *ListenerBuilder) aggregateVirtualInboundListener(needTLSForPassThrough
 	// UseOriginalDst: proto.BoolTrue,
 	lb.virtualInboundListener.UseOriginalDst = nil
 	lb.virtualInboundListener.ListenerFilters = append(lb.virtualInboundListener.ListenerFilters,
-		&listener.ListenerFilter{
-			Name: xdsutil.OriginalDestination,
-		},
+		originalDestinationFilter,
 	)
 	// TODO: Trim the inboundListeners properly. Those that have been added to filter chains should
 	// be removed while those that haven't been added need to remain in the inboundListeners list.
@@ -148,9 +146,7 @@ func (lb *ListenerBuilder) aggregateVirtualInboundListener(needTLSForPassThrough
 
 	if needTLS || needTLSForPassThroughFilterChain {
 		lb.virtualInboundListener.ListenerFilters =
-			append(lb.virtualInboundListener.ListenerFilters, &listener.ListenerFilter{
-				Name: xdsutil.TlsInspector,
-			})
+			append(lb.virtualInboundListener.ListenerFilters, tlsInspectorFilter)
 	}
 
 	// Note: the HTTP inspector should be after TLS inspector.
@@ -158,9 +154,7 @@ func (lb *ListenerBuilder) aggregateVirtualInboundListener(needTLSForPassThrough
 	// won't inspect the packet.
 	if features.EnableProtocolSniffingForInbound {
 		lb.virtualInboundListener.ListenerFilters =
-			append(lb.virtualInboundListener.ListenerFilters, &listener.ListenerFilter{
-				Name: xdsutil.HttpInspector,
-			})
+			append(lb.virtualInboundListener.ListenerFilters, httpInspectorFilter)
 	}
 
 	timeout := features.InboundProtocolDetectionTimeout

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -498,7 +498,10 @@
                     ]
                   },
                   "http_filters": [{
-                    "name": "envoy.router"
+                    "name": "envoy.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                    }
                   }]
                 }
               }

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -424,7 +424,10 @@
                     ]
                   },
                   "http_filters": [{
-                    "name": "envoy.router"
+                    "name": "envoy.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                    }
                   }]
                 }
               }

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -424,7 +424,10 @@
                     ]
                   },
                   "http_filters": [{
-                    "name": "envoy.router"
+                    "name": "envoy.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                    }
                   }]
                 }
               }

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -392,7 +392,10 @@
                     ]
                   },
                   "http_filters": [{
-                    "name": "envoy.router"
+                    "name": "envoy.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                    }
                   }]
                 }
               }

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -449,7 +449,10 @@
                     ]
                   },
                   "http_filters": [{
-                    "name": "envoy.router"
+                    "name": "envoy.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                    }
                   }]
                 }
               }

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -449,7 +449,10 @@
                     ]
                   },
                   "http_filters": [{
-                    "name": "envoy.router"
+                    "name": "envoy.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                    }
                   }]
                 }
               }

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -403,7 +403,10 @@
                     ]
                   },
                   "http_filters": [{
-                    "name": "envoy.router"
+                    "name": "envoy.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                    }
                   }]
                 }
               }

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -414,7 +414,10 @@
                     ]
                   },
                   "http_filters": [{
-                    "name": "envoy.router"
+                    "name": "envoy.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                    }
                   }]
                 }
               }

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -429,7 +429,10 @@
                     ]
                   },
                   "http_filters": [{
-                    "name": "envoy.router"
+                    "name": "envoy.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                    }
                   }]
                 }
               }

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -392,7 +392,10 @@
                     ]
                   },
                   "http_filters": [{
-                    "name": "envoy.router"
+                    "name": "envoy.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                    }
                   }]
                 }
               }

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -414,7 +414,10 @@
                     ]
                   },
                   "http_filters": [{
-                    "name": "envoy.router"
+                    "name": "envoy.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                    }
                   }]
                 }
               }

--- a/tools/packaging/common/envoy_bootstrap_v2.json
+++ b/tools/packaging/common/envoy_bootstrap_v2.json
@@ -577,7 +577,10 @@
                     ]
                   },
                   "http_filters": [{
-                    "name": "envoy.router"
+                    "name": "envoy.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                    }
                   }]
                 }
               }


### PR DESCRIPTION
For https://github.com/istio/istio/issues/21183

See
https://www.envoyproxy.io/docs/envoy/latest/intro/deprecated#april-8-2020

This has an unfortunate impact on perfomance due to the extra overhead for proto marshalling, despite sharing the same filter object, since the marshalling still happens each time:
```
name                                 old time/op    new time/op    delta
ListenerGeneration/empty-6             5.02ms ± 1%    5.28ms ± 2%   +5.15%  (p=0.008 n=5+5)
ListenerGeneration/telemetry-6         5.93ms ± 2%    6.57ms ± 1%  +10.92%  (p=0.008 n=5+5)
ListenerGeneration/virtualservice-6    4.94ms ± 2%    5.24ms ± 2%   +6.05%  (p=0.008 n=5+5)

name                                 old alloc/op   new alloc/op   delta
ListenerGeneration/empty-6             2.35MB ± 0%    2.37MB ± 0%   +0.58%  (p=0.008 n=5+5)
ListenerGeneration/telemetry-6         2.75MB ± 0%    2.84MB ± 0%   +3.19%  (p=0.008 n=5+5)
ListenerGeneration/virtualservice-6    2.35MB ± 0%    2.37MB ± 0%   +0.58%  (p=0.008 n=5+5)

name                                 old allocs/op  new allocs/op  delta
ListenerGeneration/empty-6              27.8k ± 0%     27.6k ± 0%   -0.71%  (p=0.008 n=5+5)
ListenerGeneration/telemetry-6          32.8k ± 0%     33.8k ± 0%   +3.09%  (p=0.029 n=4+4)
ListenerGeneration/virtualservice-6     27.8k ± 0%     27.6k ± 0%   -0.71%  (p=0.008 n=5+5)
```
