### PR TITLE
Add source file line number to analyze messages

### DIFF
--- a/galley/pkg/config/analysis/analyzers/analyzers_bench_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_bench_test.go
@@ -75,10 +75,17 @@ type origin struct {
 }
 
 var _ resource.Origin = &origin{}
+var _ resource.Reference = &reference{}
 
 func (o origin) Namespace() resource.Namespace { return "" }
 func (o origin) FriendlyName() string          { return o.friendlyName }
-func (o origin) Reference() string             { return "" }
+func (o origin) Reference() resource.Reference { return reference{name: ""} }
+
+type reference struct {
+	name string
+}
+
+func (r reference) String() string { return r.name }
 
 // This is a very basic benchmark on unit test data, so it doesn't tell us anything about how an analyzer performs at scale
 func BenchmarkAnalyzers(b *testing.B) {

--- a/galley/pkg/config/analysis/analyzers/schema/validation_test.go
+++ b/galley/pkg/config/analysis/analyzers/schema/validation_test.go
@@ -152,4 +152,8 @@ type fakeOrigin struct{}
 
 func (fakeOrigin) FriendlyName() string          { return "myFriendlyName" }
 func (fakeOrigin) Namespace() resource.Namespace { return "myNamespace" }
-func (fakeOrigin) Reference() string             { return "" }
+func (fakeOrigin) Reference() resource.Reference { return fakeReference{} }
+
+type fakeReference struct{}
+
+func (fakeReference) String() string { return "" }

--- a/galley/pkg/config/analysis/diag/helper_test.go
+++ b/galley/pkg/config/analysis/diag/helper_test.go
@@ -19,10 +19,11 @@ import (
 )
 
 var _ resource.Origin = &testOrigin{}
+var _ resource.Reference = &testReference{}
 
 type testOrigin struct {
 	name string
-	ref  string
+	ref  resource.Reference
 }
 
 func (o testOrigin) FriendlyName() string {
@@ -33,6 +34,14 @@ func (o testOrigin) Namespace() resource.Namespace {
 	return ""
 }
 
-func (o testOrigin) Reference() string {
+func (o testOrigin) Reference() resource.Reference {
 	return o.ref
+}
+
+type testReference struct {
+	name string
+}
+
+func (r testReference) String() string {
+	return r.name
 }

--- a/galley/pkg/config/analysis/diag/message.go
+++ b/galley/pkg/config/analysis/diag/message.go
@@ -68,8 +68,8 @@ func (m *Message) Unstructured(includeOrigin bool) map[string]interface{} {
 	result["level"] = m.Type.Level().String()
 	if includeOrigin && m.Resource != nil {
 		result["origin"] = m.Resource.Origin.FriendlyName()
-		if m.Resource.Origin.Reference() != "" {
-			result["reference"] = m.Resource.Origin.Reference()
+		if m.Resource.Origin.Reference() != nil {
+			result["reference"] = m.Resource.Origin.Reference().String()
 		}
 	}
 	result["message"] = fmt.Sprintf(m.Type.Template(), m.Parameters...)
@@ -88,8 +88,8 @@ func (m *Message) String() string {
 	origin := ""
 	if m.Resource != nil {
 		loc := ""
-		if m.Resource.Origin.Reference() != "" {
-			loc = " " + m.Resource.Origin.Reference()
+		if m.Resource.Origin.Reference() != nil {
+			loc = " " + m.Resource.Origin.Reference().String()
 		}
 		origin = " (" + m.Resource.Origin.FriendlyName() + loc + ")"
 	}

--- a/galley/pkg/config/analysis/diag/message_test.go
+++ b/galley/pkg/config/analysis/diag/message_test.go
@@ -34,7 +34,7 @@ func TestMessage_String(t *testing.T) {
 func TestMessageWithResource_String(t *testing.T) {
 	g := NewGomegaWithT(t)
 	mt := NewMessageType(Error, "IST-0042", "Cheese type not found: %q")
-	m := NewMessage(mt, &resource.Instance{Origin: testOrigin{name: "toppings/cheese", ref: "path/to/file"}}, "Feta")
+	m := NewMessage(mt, &resource.Instance{Origin: testOrigin{name: "toppings/cheese", ref: testReference{"path/to/file"}}}, "Feta")
 
 	g.Expect(m.String()).To(Equal(`Error [IST-0042] (toppings/cheese path/to/file) Cheese type not found: "Feta"`))
 }
@@ -64,7 +64,7 @@ func TestMessageWithDocRef(t *testing.T) {
 func TestMessage_JSON(t *testing.T) {
 	g := NewGomegaWithT(t)
 	mt := NewMessageType(Error, "IST-0042", "Cheese type not found: %q")
-	m := NewMessage(mt, &resource.Instance{Origin: testOrigin{name: "toppings/cheese", ref: "path/to/file"}}, "Feta")
+	m := NewMessage(mt, &resource.Instance{Origin: testOrigin{name: "toppings/cheese", ref: testReference{"path/to/file"}}}, "Feta")
 
 	j, _ := json.Marshal(&m)
 	g.Expect(string(j)).To(Equal(`{"code":"IST-0042","documentation_url":"https://istio.io/docs/reference/config/analysis/IST-0042"` +

--- a/galley/pkg/config/processing/snapshotter/analyzingdistributor_test.go
+++ b/galley/pkg/config/processing/snapshotter/analyzingdistributor_test.go
@@ -518,12 +518,22 @@ func newSchema(name string) collection.Schema {
 }
 
 var _ resource.Origin = fakeOrigin{}
+var _ resource.Reference = fakeReference{}
 
 type fakeOrigin struct {
 	namespace    resource.Namespace
 	friendlyName string
+	reference    fakeReference
 }
 
 func (f fakeOrigin) Namespace() resource.Namespace { return f.namespace }
 func (f fakeOrigin) FriendlyName() string          { return f.friendlyName }
-func (f fakeOrigin) Reference() string             { return "" }
+func (f fakeOrigin) Reference() resource.Reference { return f.reference }
+
+type fakeReference struct {
+	name string
+}
+
+func (r fakeReference) String() string {
+	return r.name
+}

--- a/galley/pkg/config/source/kube/apiserver/watcher.go
+++ b/galley/pkg/config/source/kube/apiserver/watcher.go
@@ -124,7 +124,7 @@ func (w *watcher) handleEvent(c event.Kind, obj interface{}) {
 		return
 	}
 
-	r := rt.ToResource(object, w.schema, res, "")
+	r := rt.ToResource(object, w.schema, res, nil)
 
 	if w.statusCtl != nil && !w.adapter.IsBuiltIn() {
 		w.statusCtl.UpdateResourceStatus(

--- a/galley/pkg/config/source/kube/inmemory/kubesource.go
+++ b/galley/pkg/config/source/kube/inmemory/kubesource.go
@@ -32,6 +32,7 @@ import (
 	"istio.io/istio/galley/pkg/config/scope"
 	"istio.io/istio/galley/pkg/config/source/inmemory"
 	"istio.io/istio/galley/pkg/config/source/kube/rt"
+	"istio.io/istio/galley/pkg/config/util/kubeyaml"
 	"istio.io/istio/pkg/config/event"
 	"istio.io/istio/pkg/config/resource"
 	"istio.io/istio/pkg/config/schema/collection"
@@ -202,12 +203,12 @@ func (s *KubeSource) parseContent(r *collection.Schemas, name, yamlText string) 
 	var errs error
 
 	reader := bufio.NewReader(strings.NewReader(yamlText))
-	decoder := yaml.NewYAMLReader(reader)
+	decoder := kubeyaml.NewYAMLReader(reader)
 	chunkCount := -1
 
 	for {
 		chunkCount++
-		doc, err := decoder.Read()
+		doc, lineNum, err := decoder.Read()
 		if err == io.EOF {
 			break
 		}
@@ -220,7 +221,7 @@ func (s *KubeSource) parseContent(r *collection.Schemas, name, yamlText string) 
 		}
 
 		chunk := bytes.TrimSpace(doc)
-		r, err := s.parseChunk(r, name, chunk)
+		r, err := s.parseChunk(r, name, lineNum, chunk)
 		if err != nil {
 			var uerr *unknownSchemaError
 			if errors.As(err, &uerr) {
@@ -251,7 +252,7 @@ func (e unknownSchemaError) Error() string {
 	return fmt.Sprintf("failed finding schema for group/version/kind: %s/%s/%s", e.group, e.version, e.kind)
 }
 
-func (s *KubeSource) parseChunk(r *collection.Schemas, name string, yamlChunk []byte) (kubeResource, error) {
+func (s *KubeSource) parseChunk(r *collection.Schemas, name string, lineNum int, yamlChunk []byte) (kubeResource, error) {
 	// Convert to JSON
 	jsonChunk, err := yaml.ToJSON(yamlChunk)
 	if err != nil {
@@ -302,9 +303,10 @@ func (s *KubeSource) parseChunk(r *collection.Schemas, name string, yamlChunk []
 		return kubeResource{}, err
 	}
 
+	pos := rt.Position{Filename: name, Line: lineNum}
 	return kubeResource{
 		schema:   schema,
 		sha:      sha1.Sum(yamlChunk),
-		resource: rt.ToResource(objMeta, schema, item, name),
+		resource: rt.ToResource(objMeta, schema, item, &pos),
 	}, nil
 }

--- a/galley/pkg/config/source/kube/rt/adapter.go
+++ b/galley/pkg/config/source/kube/rt/adapter.go
@@ -98,7 +98,7 @@ func (p *Adapter) JSONToEntry(s string) (*resource.Instance, error) {
 		return nil, err
 	}
 
-	return ToResource(obj, nil, item, ""), nil
+	return ToResource(obj, nil, item, nil), nil
 
 }
 

--- a/galley/pkg/config/source/kube/rt/extract.go
+++ b/galley/pkg/config/source/kube/rt/extract.go
@@ -25,7 +25,7 @@ import (
 )
 
 // ToResource converts the given object and proto to a resource.Instance
-func ToResource(object metav1.Object, schema collection.Schema, item proto.Message, source string) *resource.Instance {
+func ToResource(object metav1.Object, schema collection.Schema, item proto.Message, source resource.Reference) *resource.Instance {
 	var o *Origin
 
 	name := resource.NewFullName(resource.Namespace(object.GetNamespace()), resource.LocalName(object.GetName()))

--- a/galley/pkg/config/source/kube/rt/origin.go
+++ b/galley/pkg/config/source/kube/rt/origin.go
@@ -16,6 +16,7 @@ package rt
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"istio.io/istio/pkg/config/resource"
@@ -29,10 +30,11 @@ type Origin struct {
 	Kind       string
 	FullName   resource.FullName
 	Version    resource.Version
-	Ref        string
+	Ref        resource.Reference
 }
 
 var _ resource.Origin = &Origin{}
+var _ resource.Reference = &Position{}
 
 // FriendlyName implements resource.Origin
 func (o *Origin) FriendlyName() string {
@@ -56,6 +58,29 @@ func (o *Origin) Namespace() resource.Namespace {
 }
 
 // Reference implements resource.Origin
-func (o *Origin) Reference() string {
+func (o *Origin) Reference() resource.Reference {
 	return o.Ref
+}
+
+// Position is a representation of the location of a source.
+type Position struct {
+	Filename string // filename, if any
+	Line     int    // line number, starting at 1
+}
+
+// String outputs the string representation of the position.
+func (p *Position) String() string {
+	s := p.Filename
+	// TODO: support json file position.
+	if p.isValid() && filepath.Ext(p.Filename) != ".json" {
+		if s != "" {
+			s += ":"
+		}
+		s += fmt.Sprintf("%d", p.Line)
+	}
+	return s
+}
+
+func (p *Position) isValid() bool {
+	return p.Line > 0 && p.Filename != ""
 }

--- a/galley/pkg/config/source/kube/rt/origin_test.go
+++ b/galley/pkg/config/source/kube/rt/origin_test.go
@@ -1,0 +1,50 @@
+package rt
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestPositionString(t *testing.T) {
+	testcases := []struct {
+		filename string
+		line     int
+		output   string
+	}{
+		{
+			filename: "test.yaml",
+			line:     1,
+			output:   "test.yaml:1",
+		},
+		{
+			filename: "test.yaml",
+			line:     0,
+			output:   "test.yaml",
+		},
+		{
+			filename: "test.json",
+			line:     1,
+			output:   "test.json",
+		},
+		{
+			filename: "-",
+			line:     1,
+			output:   "-:1",
+		},
+		{
+			filename: "",
+			line:     1,
+			output:   "",
+		},
+	}
+	for i, tc := range testcases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			p := Position{Filename: tc.filename, Line: tc.line}
+			g.Expect(p.String()).To(Equal(tc.output))
+		})
+	}
+}

--- a/galley/pkg/config/source/kube/rt/origin_test.go
+++ b/galley/pkg/config/source/kube/rt/origin_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package rt
 
 import (

--- a/galley/pkg/config/source/mcp/origin.go
+++ b/galley/pkg/config/source/mcp/origin.go
@@ -19,10 +19,12 @@ import (
 )
 
 const (
-	defaultOrigin = origin("mcp")
+	defaultOrigin    = origin("mcp")
+	defaultReference = reference("mcp")
 )
 
 var _ resource.Origin = defaultOrigin
+var _ resource.Reference = defaultReference
 
 type origin string
 
@@ -34,6 +36,12 @@ func (o origin) Namespace() resource.Namespace {
 	return ""
 }
 
-func (o origin) Reference() string {
-	return ""
+func (o origin) Reference() resource.Reference {
+	return defaultReference
+}
+
+type reference string
+
+func (r reference) String() string {
+	return string(r)
 }

--- a/galley/pkg/config/util/kubeyaml/kubeyaml.go
+++ b/galley/pkg/config/util/kubeyaml/kubeyaml.go
@@ -15,12 +15,16 @@
 package kubeyaml
 
 import (
+	"bufio"
 	"bytes"
+	"io"
 	"strings"
+	"unicode"
 )
 
 const (
 	yamlSeparator = "---\n"
+	separator     = "---"
 )
 
 // Join the given yaml parts into a single multipart document.
@@ -66,4 +70,87 @@ func JoinString(parts ...string) string {
 	}
 
 	return st.String()
+}
+
+type Reader interface {
+	Read() ([]byte, error)
+}
+
+// YAMLReader adapts from Kubernetes YAMLReader(apimachinery.k8s.io/pkg/util/yaml/decoder.go).
+// It records the start line number of the chunk it reads each time.
+type YAMLReader struct {
+	reader   Reader
+	currLine int
+}
+
+func NewYAMLReader(r *bufio.Reader) *YAMLReader {
+	return &YAMLReader{
+		reader:   &LineReader{reader: r},
+		currLine: 0,
+	}
+}
+
+// Read returns a full YAML document and its first line number.
+func (r *YAMLReader) Read() ([]byte, int, error) {
+	var buffer bytes.Buffer
+	startLine := r.currLine + 1
+	foundStart := false
+	for {
+		r.currLine++
+		line, err := r.reader.Read()
+		if err != nil && err != io.EOF {
+			return nil, startLine, err
+		}
+
+		// detect beginning of the chunk
+		if !bytes.Equal(line, []byte("\n")) && !bytes.Equal(line, []byte(yamlSeparator)) && !foundStart {
+			startLine = r.currLine
+			foundStart = true
+		}
+
+		sep := len([]byte(separator))
+		if i := bytes.Index(line, []byte(separator)); i == 0 {
+			// We have a potential document terminator
+			i += sep
+			after := line[i:]
+			if len(strings.TrimRightFunc(string(after), unicode.IsSpace)) == 0 {
+				if buffer.Len() != 0 {
+					return buffer.Bytes(), startLine, nil
+				}
+				if err == io.EOF {
+					return nil, startLine, err
+				}
+			}
+		}
+		if err == io.EOF {
+			if buffer.Len() != 0 {
+				// If we're at EOF, we have a final, non-terminated line. Return it.
+				return buffer.Bytes(), startLine, nil
+			}
+			return nil, startLine, err
+		}
+		buffer.Write(line)
+	}
+}
+
+type LineReader struct {
+	reader *bufio.Reader
+}
+
+// Read returns a single line (with '\n' ended) from the underlying reader.
+// An error is returned iff there is an error with the underlying reader.
+func (r *LineReader) Read() ([]byte, error) {
+	var (
+		isPrefix bool  = true
+		err      error = nil
+		line     []byte
+		buffer   bytes.Buffer
+	)
+
+	for isPrefix && err == nil {
+		line, isPrefix, err = r.reader.ReadLine()
+		buffer.Write(line)
+	}
+	buffer.WriteByte('\n')
+	return buffer.Bytes(), err
 }

--- a/galley/pkg/config/util/kubeyaml/kubeyaml_test.go
+++ b/galley/pkg/config/util/kubeyaml/kubeyaml_test.go
@@ -15,7 +15,10 @@
 package kubeyaml
 
 import (
+	"bufio"
 	"fmt"
+	"io"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -101,6 +104,43 @@ func TestJoinString(t *testing.T) {
 			actual := JoinString(c.split...)
 
 			g.Expect(actual).To(Equal(c.merged))
+		})
+	}
+}
+
+func TestLineNumber(t *testing.T) {
+	var testCases = []struct {
+		input       string
+		lineNumbers []int
+	}{
+		{
+			input:       "foo: bar\n---\nfoo: baz",
+			lineNumbers: []int{1, 3},
+		},
+		{
+			input:       "\n\nfoo: bar\n---\n\n\nfoo: baz",
+			lineNumbers: []int{3, 7},
+		},
+		{
+			input:       "---\n\nfoo: bar\n---\n\n\nfoo: baz",
+			lineNumbers: []int{3, 7},
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			reader := bufio.NewReader(strings.NewReader(tc.input))
+			decoder := NewYAMLReader(reader)
+			var expectedLineNumbers []int
+			for {
+				_, line, err := decoder.Read()
+				if err == io.EOF {
+					break
+				}
+				expectedLineNumbers = append(expectedLineNumbers, line)
+			}
+			g.Expect(expectedLineNumbers).To(Equal(tc.lineNumbers))
 		})
 	}
 }

--- a/go.sum
+++ b/go.sum
@@ -940,6 +940,7 @@ gopkg.in/yaml.v2 v2.2.7 h1:VUgggvou5XRW9mHwD/yXxIYSMtY0zoKQf/v226p2nyo=
 gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20190905181640-827449938966 h1:B0J02caTR6tpSJozBJyiAzT6CtBzjclw4pgm9gg8Ys0=
 gopkg.in/yaml.v3 v3.0.0-20190905181640-827449938966/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=

--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -443,8 +443,8 @@ func renderMessage(m diag.Message) string {
 	origin := ""
 	if m.Resource != nil {
 		loc := ""
-		if m.Resource.Origin.Reference() != "" {
-			loc = " " + m.Resource.Origin.Reference()
+		if m.Resource.Origin.Reference() != nil {
+			loc = " " + m.Resource.Origin.Reference().String()
 		}
 		origin = " (" + m.Resource.Origin.FriendlyName() + loc + ")"
 	}

--- a/pkg/config/resource/origin.go
+++ b/pkg/config/resource/origin.go
@@ -20,5 +20,10 @@ type Origin interface {
 
 	Namespace() Namespace
 
-	Reference() string
+	Reference() Reference
+}
+
+// Reference provides more information about an Origin. This is also source-implementation dependant.
+type Reference interface {
+	String() string
 }


### PR DESCRIPTION
Temporarily fix for https://github.com/istio/istio/issues/17349

This PR adds the line number of the source file to the analyzer message output, for example:
```
Error [IST0101] (VirtualService frontend.default example-vs.json:5) Referenced gateway not found: "httpbin-gateway-bogus"
```
The line number indicates the beginning of the yaml chunk for the resource in error. We currently don't have enough low-level mechanism to indicate more accurate line number. (It is possible to do it via yaml v3 parser which introduces a Node api that includes line number.) It can be done as a followup.


