### PR TITLE
enable PROV_CERT in sidecar.env by default

### DIFF
--- a/tools/packaging/common/istio-start.sh
+++ b/tools/packaging/common/istio-start.sh
@@ -96,6 +96,8 @@ if [ -z "${PILOT_ADDRESS:-}" ]; then
 fi
 
 CA_ADDR=${CA_ADDR:-${PILOT_ADDRESS}}
+PROV_CERT=${PROV_CERT:-/etc/certs}
+OUTPUT_CERTS=${OUTPUT_CERTS:-/etc/certs}
 
 export PROV_CERT
 export OUTPUT_CERTS

--- a/tools/packaging/common/sidecar.env
+++ b/tools/packaging/common/sidecar.env
@@ -95,7 +95,7 @@
 # environment variable. If the value is different from PROV_CERTS the workload certs will be saved, but
 # the provisioning cert will remain under control of the VM provisioning tools.
 #OUTPUT_CERTS=/var/run/secrets/istio
-OUTPUT_CERTS=/etc/certs
+#OUTPUT_CERTS=/etc/certs
 
 # Address of the CA. The CA must implement the Istio protocol, accepting the provisioning certificate
 # and returning workload certificates. Istiod is implementing the protocol, and is the default value


### PR DESCRIPTION
to reduce manual work for users, let's set `PROV_CERT=/etc/certs` by default to make situations like https://github.com/istio/istio/issues/22665 more smooth.