### PR TITLE
Fixes #22830. Don't mutate proxy IPAddresses while building listeners

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1979,8 +1979,11 @@ func buildListener(opts buildListenerOpts) *xdsapi.Listener {
 			}
 		}
 		if len(chain.destinationCIDRs) > 0 {
-			sort.Strings(chain.destinationCIDRs)
-			for _, d := range chain.destinationCIDRs {
+			sortedDestinationCIDRs := make([]string, 0, len(chain.destinationCIDRs))
+			sortedDestinationCIDRs = append(sortedDestinationCIDRs, chain.destinationCIDRs...)
+			sort.Strings(sortedDestinationCIDRs)
+
+			for _, d := range sortedDestinationCIDRs {
 				if len(d) == 0 {
 					continue
 				}


### PR DESCRIPTION
This PR fixes #22830.
Currently when building the listeners the IPAddresses string slice gets sorted.
This leads to unstable bind addresses when configuring an ingress listener in a sidecar resource without bind address.