### PR TITLE
22750 - JWT token refresh leads to HTTP 403: Access denied

### DIFF
--- a/security/pkg/server/ca/authenticate/authenticator.go
+++ b/security/pkg/server/ca/authenticate/authenticator.go
@@ -17,6 +17,7 @@ package authenticate
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	oidc "github.com/coreos/go-oidc"
 	"golang.org/x/net/context"
@@ -101,7 +102,7 @@ func NewIDTokenAuthenticator(aud string) (*IDTokenAuthenticator, error) {
 		return nil, err
 	}
 
-	verifier := provider.Verifier(&oidc.Config{ClientID: aud})
+	verifier := provider.Verifier(&oidc.Config{ClientID: aud, Now: func() time.Time { return time.Now().Add(-30 * time.Second) }})
 	return &IDTokenAuthenticator{verifier}, nil
 }
 


### PR DESCRIPTION
This PR adds some slack to the function that decides if a JWT token is expired. 
See https://github.com/istio/istio/issues/22750 
for details