### PR TITLE
'istioctl verify-install' consume IstioOperator

### DIFF
--- a/istioctl/pkg/install/verify.go
+++ b/istioctl/pkg/install/verify.go
@@ -16,6 +16,7 @@ package install
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -31,6 +32,11 @@ import (
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	operator_istio "istio.io/istio/operator/pkg/apis/istio"
+	"istio.io/istio/operator/pkg/apis/istio/v1alpha1"
+	"istio.io/istio/operator/pkg/controlplane"
+	"istio.io/istio/operator/pkg/translate"
+	"istio.io/istio/operator/version"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 	"istio.io/istio/pkg/config/schema"
 )
@@ -49,24 +55,47 @@ func verifyInstall(enableVerbose bool, istioNamespaceFlag string,
 		}
 		return installPreCheck(istioNamespaceFlag, restClientGetter, writer)
 	}
-	return verifyPostInstall(enableVerbose, istioNamespaceFlag, restClientGetter,
-		options, writer)
 
-}
-
-func verifyPostInstall(enableVerbose bool, istioNamespaceFlag string,
-	restClientGetter resource.RESTClientGetter, options resource.FilenameOptions, writer io.Writer) error {
-	crdCount := 0
-	istioDeploymentCount := 0
+	// This is not a pre-check.  Check that the supplied resources exist in the cluster
 	r := resource.NewBuilder(restClientGetter).
 		Unstructured().
 		FilenameParam(false, &options).
 		Flatten().
 		Do()
-	if err := r.Err(); err != nil {
+	if r.Err() != nil {
+		return r.Err()
+	}
+	visitor := genericclioptions.ResourceFinderForResult(r).Do()
+	return verifyPostInstallAndShow(enableVerbose, istioNamespaceFlag, visitor, options.Filenames[0], restClientGetter, writer)
+
+}
+
+func verifyPostInstallAndShow(enableVerbose bool, istioNamespaceFlag string,
+	visitor resource.Visitor, filename string, restClientGetter genericclioptions.RESTClientGetter, writer io.Writer) error {
+	crdCount, istioDeploymentCount, err := verifyPostInstall(enableVerbose,
+		istioNamespaceFlag,
+		visitor,
+		filename,
+		restClientGetter,
+		writer)
+	if err != nil {
 		return err
 	}
-	err := r.Visit(func(info *resource.Info, err error) error {
+	_, _ = fmt.Fprintf(writer, "Checked %v custom resource definitions\n", crdCount)
+	_, _ = fmt.Fprintf(writer, "Checked %v Istio Deployments\n", istioDeploymentCount)
+	if istioDeploymentCount == 0 {
+		_, _ = fmt.Fprintf(writer, "No Istio installation found\n")
+		return fmt.Errorf("no Istio installation found")
+	}
+	_, _ = fmt.Fprintf(writer, "Istio is installed successfully\n")
+	return nil
+}
+
+func verifyPostInstall(enableVerbose bool, istioNamespaceFlag string,
+	visitor resource.Visitor, filename string, restClientGetter genericclioptions.RESTClientGetter, writer io.Writer) (int, int, error) {
+	crdCount := 0
+	istioDeploymentCount := 0
+	err := visitor.Visit(func(info *resource.Info, err error) error {
 		if err != nil {
 			return err
 		}
@@ -99,7 +128,7 @@ func verifyPostInstall(enableVerbose bool, istioNamespaceFlag string,
 			if err != nil {
 				return err
 			}
-			err = getDeploymentStatus(deployment, name, options.Filenames[0])
+			err = getDeploymentStatus(deployment, name, filename)
 			if err != nil {
 				return err
 			}
@@ -122,10 +151,46 @@ func verifyPostInstall(enableVerbose bool, istioNamespaceFlag string,
 			for _, c := range job.Status.Conditions {
 				if c.Type == v1batch.JobFailed {
 					msg := fmt.Sprintf("Istio installation failed, incomplete or"+
-						" does not match \"%s\" - the required Job  %s failed", options.Filenames[0], name)
+						" does not match \"%s\" - the required Job %s failed", filename, name)
 					return errors.New(msg)
 				}
 			}
+		case "IstioOperator":
+			result := info.Client.
+				Get().
+				Resource(kinds).
+				Namespace(namespace).
+				Name(name).
+				Do(context.TODO())
+			if result.Error() != nil {
+				return err
+			}
+			obj, _ := result.Get()
+			un, ok := obj.(*unstructured.Unstructured)
+			if !ok {
+				return fmt.Errorf("could not read IstioOperator")
+			}
+
+			// IstioOperator isn't part of pkg/config/schema/collections,
+			// usual conversion not available.  Convert unstructured to string
+			// and ask operator code to check.
+
+			un.SetCreationTimestamp(meta_v1.Time{}) // UnmarshalIstioOperator chokes on these
+			by, err := json.Marshal(un)
+			if err != nil {
+				return err
+			}
+
+			iop, err := operator_istio.UnmarshalIstioOperator(string(by))
+			if err != nil {
+				return err
+			}
+			generatedCrds, generatedDeployments, err := verifyPostInstallIstioOperator(enableVerbose, istioNamespaceFlag, iop, filename, restClientGetter, writer)
+			if err != nil {
+				return err
+			}
+			crdCount += generatedCrds
+			istioDeploymentCount += generatedDeployments
 		default:
 			result := info.Client.
 				Get().
@@ -141,7 +206,7 @@ func verifyPostInstall(enableVerbose bool, istioNamespaceFlag string,
 					Do(context.TODO())
 				if result.Error() != nil {
 					msg := fmt.Sprintf("Istio installation failed, incomplete or"+
-						" does not match \"%s\" - the required %s:%s is not ready due to: %v", options.Filenames[0], kind, name, result.Error())
+						" does not match \"%s\" - the required %s:%s is not ready due to: %v", filename, kind, name, result.Error())
 					return errors.New(msg)
 				}
 			}
@@ -155,12 +220,9 @@ func verifyPostInstall(enableVerbose bool, istioNamespaceFlag string,
 		return nil
 	})
 	if err != nil {
-		return err
+		return crdCount, istioDeploymentCount, err
 	}
-	_, _ = fmt.Fprintf(writer, "Checked %v crds\n", crdCount)
-	_, _ = fmt.Fprintf(writer, "Checked %v Istio Deployments\n", istioDeploymentCount)
-	_, _ = fmt.Fprintf(writer, "Istio is installed successfully\n")
-	return nil
+	return crdCount, istioDeploymentCount, nil
 }
 
 // NewVerifyCommand creates a new command for verifying Istio Installation Status
@@ -269,4 +331,52 @@ func findResourceInSpec(kind string) string {
 		}
 	}
 	return ""
+}
+
+// nolint: lll
+func verifyPostInstallIstioOperator(enableVerbose bool, istioNamespaceFlag string, iop *v1alpha1.IstioOperator, filename string, restClientGetter genericclioptions.RESTClientGetter, writer io.Writer) (int, int, error) {
+	// Generate the manifest this IstioOperator will make
+	t, err := translate.NewTranslator(version.OperatorBinaryVersion.MinorVersion)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	cp, err := controlplane.NewIstioOperator(iop.Spec, t)
+	if err != nil {
+		return 0, 0, err
+	}
+	if err := cp.Run(); err != nil {
+		return 0, 0, err
+	}
+
+	manifests, errs := cp.RenderManifest()
+	if errs != nil {
+		return 0, 0, errs.ToError()
+	}
+
+	builder := resource.NewBuilder(restClientGetter).Unstructured()
+	for cat, manifest := range manifests {
+		for i, manitem := range manifest {
+			reader := strings.NewReader(manitem)
+			pseudoFilename := fmt.Sprintf("%s:%d generated from %s", cat, i, filename)
+			builder = builder.Stream(reader, pseudoFilename)
+		}
+	}
+	r := builder.Flatten().Do()
+	if r.Err() != nil {
+		return 0, 0, r.Err()
+	}
+	visitor := genericclioptions.ResourceFinderForResult(r).Do()
+	// Indirectly RECURSE back into verifyPostInstall with the manifest we just generated
+	generatedCrds, generatedDeployments, err := verifyPostInstall(enableVerbose,
+		istioNamespaceFlag,
+		visitor,
+		fmt.Sprintf("generated from %s", filename),
+		restClientGetter,
+		writer)
+	if err != nil {
+		return generatedCrds, generatedDeployments, err
+	}
+
+	return generatedCrds, generatedDeployments, nil
 }

--- a/istioctl/pkg/validate/validate.go
+++ b/istioctl/pkg/validate/validate.go
@@ -44,6 +44,7 @@ import (
 	operator_istio "istio.io/istio/operator/pkg/apis/istio"
 	operator_validate "istio.io/istio/operator/pkg/validate"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -173,6 +174,7 @@ func (v *validator) validateResource(istioNamespace string, un *unstructured.Uns
 			// usual conversion not available.  Convert unstructured to string
 			// and ask operator code to check.
 
+			un.SetCreationTimestamp(metav1.Time{}) // UnmarshalIstioOperator chokes on these
 			by, err := json.Marshal(un)
 			if err != nil {
 				return err


### PR DESCRIPTION
Part One of https://github.com/istio/istio/issues/18547

If an IstioOperator is passed to `istioctl verify install -f`, the logic here will generate a manifest from the IstioOperator and using the existing logic to verify that all of the manifest items are present in the cluster.

(This lacks tests.  The current code never had any tests.  Adding testing would be difficult -- it would mean mocking an entire Istio install via Kube API.  Thoughts?

A follow-up will allow verify-install to consume the IstioOperator preserved in the cluster, to avoid the need to specify a `-f` option.

cc @irisdingbj 