### PR TITLE
Remove AllowOrigin from route since it is deprecated in istio API

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -747,9 +747,7 @@ func translateCORSPolicy(in *networking.CorsPolicy) *route.CorsPolicy {
 
 	// CORS filter is enabled by default
 	out := route.CorsPolicy{}
-	if in.AllowOrigin != nil {
-		out.AllowOriginStringMatch = util.StringToExactMatch(in.AllowOrigin)
-	} else {
+	if in.AllowOrigins != nil {
 		out.AllowOriginStringMatch = convertToEnvoyMatch(in.AllowOrigins)
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/route/route_internal_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_internal_test.go
@@ -17,14 +17,12 @@ package route
 import (
 	"reflect"
 	"testing"
-	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	xdstype "github.com/envoyproxy/go-control-plane/envoy/type"
 	envoy_type_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
 	"github.com/gogo/protobuf/types"
-	"github.com/golang/protobuf/ptypes/wrappers"
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pkg/config/labels"
@@ -409,79 +407,37 @@ func TestCatchAllMatch(t *testing.T) {
 }
 
 func TestTranslateCORSPolicy(t *testing.T) {
-	tests := []struct {
-		name string
-		in   *networking.CorsPolicy
-		want *route.CorsPolicy
-	}{
-		{
-			name: "deprecated matcher",
-			in: &networking.CorsPolicy{
-				AllowOrigin:      []string{"foo"},
-				AllowMethods:     []string{"allow-method-1", "allow-method-2"},
-				AllowHeaders:     []string{"allow-header-1", "allow-header-2"},
-				ExposeHeaders:    []string{"expose-header-1", "expose-header-2"},
-				MaxAge:           types.DurationProto(time.Minute * 2),
-				AllowCredentials: &types.BoolValue{Value: true},
-			},
-			want: &route.CorsPolicy{
-				AllowOriginStringMatch: []*envoy_type_matcher.StringMatcher{{
-					MatchPattern: &envoy_type_matcher.StringMatcher_Exact{Exact: "foo"},
-				}},
-				AllowMethods:     "allow-method-1,allow-method-2",
-				AllowHeaders:     "allow-header-1,allow-header-2",
-				ExposeHeaders:    "expose-header-1,expose-header-2",
-				MaxAge:           "120",
-				AllowCredentials: &wrappers.BoolValue{Value: true},
-				EnabledSpecifier: &route.CorsPolicy_FilterEnabled{
-					FilterEnabled: &core.RuntimeFractionalPercent{
-						DefaultValue: &xdstype.FractionalPercent{
-							Numerator:   100,
-							Denominator: xdstype.FractionalPercent_HUNDRED,
-						},
+	corsPolicy := &networking.CorsPolicy{
+		AllowOrigins: []*networking.StringMatch{
+			{MatchType: &networking.StringMatch_Exact{Exact: "exact"}},
+			{MatchType: &networking.StringMatch_Prefix{Prefix: "prefix"}},
+			{MatchType: &networking.StringMatch_Regex{Regex: "regex"}},
+		},
+	}
+	expectedCorsPolicy := &route.CorsPolicy{
+		AllowOriginStringMatch: []*envoy_type_matcher.StringMatcher{
+			{MatchPattern: &envoy_type_matcher.StringMatcher_Exact{Exact: "exact"}},
+			{MatchPattern: &envoy_type_matcher.StringMatcher_Prefix{Prefix: "prefix"}},
+			{
+				MatchPattern: &envoy_type_matcher.StringMatcher_SafeRegex{
+					SafeRegex: &envoy_type_matcher.RegexMatcher{
+						EngineType: regexEngine,
+						Regex:      "regex",
 					},
 				},
 			},
 		},
-		{
-			name: "string matcher",
-			in: &networking.CorsPolicy{
-				AllowOrigins: []*networking.StringMatch{
-					{MatchType: &networking.StringMatch_Exact{Exact: "exact"}},
-					{MatchType: &networking.StringMatch_Prefix{Prefix: "prefix"}},
-					{MatchType: &networking.StringMatch_Regex{Regex: "regex"}},
-				},
-			},
-			want: &route.CorsPolicy{
-				AllowOriginStringMatch: []*envoy_type_matcher.StringMatcher{
-					{MatchPattern: &envoy_type_matcher.StringMatcher_Exact{Exact: "exact"}},
-					{MatchPattern: &envoy_type_matcher.StringMatcher_Prefix{Prefix: "prefix"}},
-					{
-						MatchPattern: &envoy_type_matcher.StringMatcher_SafeRegex{
-							SafeRegex: &envoy_type_matcher.RegexMatcher{
-								EngineType: regexEngine,
-								Regex:      "regex",
-							},
-						},
-					},
-				},
-				EnabledSpecifier: &route.CorsPolicy_FilterEnabled{
-					FilterEnabled: &core.RuntimeFractionalPercent{
-						DefaultValue: &xdstype.FractionalPercent{
-							Numerator:   100,
-							Denominator: xdstype.FractionalPercent_HUNDRED,
-						},
-					},
+		EnabledSpecifier: &route.CorsPolicy_FilterEnabled{
+			FilterEnabled: &core.RuntimeFractionalPercent{
+				DefaultValue: &xdstype.FractionalPercent{
+					Numerator:   100,
+					Denominator: xdstype.FractionalPercent_HUNDRED,
 				},
 			},
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := translateCORSPolicy(tt.in); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("translateCORSPolicy() = \n%v, want \n%v", got, tt.want)
-			}
-		})
+	if got := translateCORSPolicy(corsPolicy); !reflect.DeepEqual(got, expectedCorsPolicy) {
+		t.Errorf("translateCORSPolicy() = \n%v, want \n%v", got, expectedCorsPolicy)
 	}
 }
 


### PR DESCRIPTION
This PR removes the AllowOrigin and relies completely on AllowOrigins from route since it is deprecated in istio API. 