### PR TITLE
Use jsonpb for validation

### DIFF
--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -187,6 +187,8 @@ func TestManifestGeneratePilot(t *testing.T) {
 			desc:       "pilot_override_kubernetes",
 			diffSelect: "Deployment:*:istiod, Service:*:istiod",
 		},
+		// TODO https://github.com/istio/istio/issues/22347 this is broken for overriding things to default value
+		// This can be seen from REGISTRY_ONLY not applying
 		{
 			desc:       "pilot_merge_meshconfig",
 			diffSelect: "ConfigMap:*:istio$",

--- a/operator/cmd/mesh/testdata/manifest-generate/input/pilot_merge_meshconfig.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/input/pilot_merge_meshconfig.yaml
@@ -7,7 +7,10 @@ spec:
   meshConfig:
     rootNamespace: istio-control
     mixerCheckServer: foo
+    outboundTrafficPolicy:
+      mode: REGISTRY_ONLY
     defaultConfig:
+      drainDuration: 12s
       proxyMetadata:
         TERMINATION_DRAIN_DURATION_SECONDS: "120"
   components:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_merge_meshconfig.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_merge_meshconfig.golden.yaml
@@ -30,7 +30,7 @@ data:
       connectTimeout: 10s
       controlPlaneAuthPolicy: NONE
       discoveryAddress: istiod.istio-system.svc:15012
-      drainDuration: 45s
+      drainDuration: 12s
       parentShutdownDuration: 1m0s
       proxyAdminPort: 15000
       proxyMetadata:

--- a/operator/pkg/validate/common.go
+++ b/operator/pkg/validate/common.go
@@ -22,11 +22,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ghodss/yaml"
+	"istio.io/pkg/log"
 
 	"istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/util"
-	"istio.io/pkg/log"
 )
 
 var (
@@ -271,7 +270,7 @@ type ValidatorFunc func(path util.Path, i interface{}) util.Errors
 // UnmarshalIOP unmarshals a string containing IstioOperator as YAML.
 func UnmarshalIOP(iopYAML string) (*v1alpha1.IstioOperator, error) {
 	iop := &v1alpha1.IstioOperator{}
-	if err := yaml.Unmarshal([]byte(iopYAML), iop); err != nil {
+	if err := util.UnmarshalWithJSONPB(iopYAML, iop, false); err != nil {
 		return nil, fmt.Errorf("%s:\n\nYAML:\n%s", err, iopYAML)
 	}
 	return iop, nil


### PR DESCRIPTION
https://github.com/istio/istio/issues/22347

Without this change:

```
$ go run ./istioctl/cmd/istioctl manifest generate --set meshConfig.outboundTrafficPolicy.mode=REGISTRY_ONLY
Error: validation errors (use --force to override):
error unmarshaling JSON: unknown value "REGISTRY_ONLY" for enum istio.mesh.v1alpha1.MeshConfig_OutboundTrafficPolicy_Mode:

YAML:
spec:
  meshConfig:
    outboundTrafficPolicy:
      mode: REGISTRY_ONLY

exit status 1
```