### PR TITLE
Revert CoreDNS sidecar.

### DIFF
--- a/manifests/base/files/crd-operator.yaml
+++ b/manifests/base/files/crd-operator.yaml
@@ -3,6 +3,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: istiooperators.install.istio.io
+  labels:
+    release: istio
 spec:
   additionalPrinterColumns:
   - JSONPath: .spec.revision

--- a/manifests/base/files/gen-istio-cluster.yaml
+++ b/manifests/base/files/gen-istio-cluster.yaml
@@ -6672,6 +6672,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: istiooperators.install.istio.io
+  labels:
+    release: istio
 spec:
   additionalPrinterColumns:
   - JSONPath: .spec.revision

--- a/manifests/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/istio-control/istio-discovery/files/gen-istio.yaml
@@ -39,30 +39,6 @@ data:
   meshNetworks: |-
     networks: {}
 
-  # Basic config for a sidecar CoreDNS server to resolve upstream and K8S requests.
-  # Will be needed until K8S DNS server adds a secure port, to avoid clear text
-  # MITM-exposed requests between istiod and K8S core DNS server.
-  Corefile: |-
-    .:15054 {
-        errors
-        log
-        health :15056 {
-          lameduck 5s
-        }
-
-        kubernetes cluster.local in-addr.arpa ip6.arpa {
-            pods insecure
-            fallthrough in-addr.arpa ip6.arpa
-            ttl 30
-        }
-        prometheus :9153
-
-        forward . /etc/resolv.conf
-        cache 30
-        reload
-        loadbalance
-    }
-
   mesh: |-
     accessLogEncoding: TEXT
     accessLogFile: ""
@@ -889,8 +865,6 @@ spec:
             value: "false"
           - name: CLUSTER_ID
             value: "Kubernetes"
-          - name: DNS_ADDR
-            value: ""
           resources:
             requests:
               cpu: 500m

--- a/manifests/istio-control/istio-discovery/templates/configmap.yaml
+++ b/manifests/istio-control/istio-discovery/templates/configmap.yaml
@@ -269,30 +269,6 @@ data:
     networks: {}
   {{- end }}
 
-  # Basic config for a sidecar CoreDNS server to resolve upstream and K8S requests.
-  # Will be needed until K8S DNS server adds a secure port, to avoid clear text
-  # MITM-exposed requests between istiod and K8S core DNS server.
-  Corefile: |-
-    .:15054 {
-        errors
-        log
-        health :15056 {
-          lameduck 5s
-        }
-
-        kubernetes cluster.local in-addr.arpa ip6.arpa {
-            pods insecure
-            fallthrough in-addr.arpa ip6.arpa
-            ttl 30
-        }
-        prometheus :9153
-
-        forward . /etc/resolv.conf
-        cache 30
-        reload
-        loadbalance
-    }
-
   mesh: |-
 {{- if .Values.meshConfig }}
 {{ $mesh | toYaml | indent 4 }}

--- a/manifests/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/istio-control/istio-discovery/templates/deployment.yaml
@@ -144,8 +144,6 @@ spec:
             value: "{{ .Values.global.istiod.enableAnalysis }}"
           - name: CLUSTER_ID
             value: "{{ $.Values.global.multiCluster.clusterName | default `Kubernetes` }}"
-          - name: DNS_ADDR
-            value: "{{ .Values.meshConfig.defaultConfig.proxyMetadata.DNS_AGENT }}"
           resources:
 {{- if .Values.pilot.resources }}
 {{ toYaml .Values.pilot.resources | trim | indent 12 }}
@@ -179,44 +177,6 @@ spec:
           - name: extracacerts
             mountPath: /cacerts
           {{- end }}
-
-        {{- if .Values.meshConfig.defaultConfig.proxyMetadata.DNS_AGENT }}
-        # CoreDNS sidecar. Ports are used internally, to run as non-root.
-        # This is a short-term solution - the code in istiod can also be used
-        # directly. The plan is to move coreDNS on the agent.
-        - name: dns
-          image: coredns/coredns:1.1.2
-          imagePullPolicy: IfNotPresent
-          args: [ "-conf", "/var/lib/istio/coredns/Corefile" ]
-          securityContext:
-            runAsUser: 1337
-            runAsGroup: 1337
-            runAsNonRoot: true
-            capabilities:
-              drop:
-                - ALL
-          volumeMounts:
-            - name: local-certs
-              mountPath: /var/run/secrets/istio-dns
-            - name: config-volume
-              mountPath: /var/lib/istio/coredns
-          ports:
-            - containerPort: 15054
-              name: dns
-              protocol: UDP
-            - containerPort: 15055
-              name: metrics
-              protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 15056
-              scheme: HTTP
-            initialDelaySeconds: 2
-            timeoutSeconds: 5
-            successThreshold: 1
-            failureThreshold: 5
-        {{- end }}
       volumes:
       # Technically not needed on this pod - but it helps debugging/testing SDS
       # Should be removed after everything works.

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -1,5 +1,6 @@
 # tests/istio.mk defines test targets for Istio
 helm3/test/install:
+	kubectl create ns istio-system || true
 	# Base install with helm3 works only for a fresh cluster - in many cases
 	# we want to upgrade. Helm3 would complain about existing resourceshelm3 install istio-base manifests/base
 	helm3 install -n istio-system istio-16 manifests/istio-control/istio-discovery -f manifests/global.yaml
@@ -9,6 +10,7 @@ helm3/test/install:
 # Will install or upgrade a 'default' and 'canary' revisions.
 # The canary has DNS capture enabled.
 helm3/test/upgrade:
+	kubectl create ns istio-system || true
 	helm3 template istio-base manifests/base | kubectl apply -f -
 	helm3 upgrade -i -n istio-system istio-16 manifests/istio-control/istio-discovery \
 		--set global.tag=${TAG} --set global.hub=${HUB} \


### PR DESCRIPTION
Based on feedback and future plans. The reason CoreDNS was added is to allow secure istiod-dns 
communication - but it is much better to focus on deploying or using a secure DNS server for K8S.

Also fixing the helm3 test ( the namespace creation is now required due to other changes in template), and fixing the label on the new CRD - all other CRD have this label, without it it's hard to cleanup ( kubectl delete crd -l ...).  