### PR TITLE
Fix revision CR scoping

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -148,6 +148,7 @@ func (s *Server) initMCPConfigController(args *PilotArgs) (err error) {
 		DomainSuffix: args.Config.ControllerOptions.DomainSuffix,
 		ConfigLedger: buildLedger(args.Config),
 		XDSUpdater:   s.EnvoyXdsServer,
+		Revision:     args.Revision,
 	}
 	reporter := monitoring.NewStatsContext("pilot")
 

--- a/pilot/pkg/config/kube/crd/controller/client.go
+++ b/pilot/pkg/config/kube/crd/controller/client.go
@@ -254,7 +254,7 @@ func (cl *Client) Get(typ resource.GroupVersionKind, name, namespace string) *mo
 		scope.Warna(err)
 		return nil
 	}
-	if cl.objectInEnvironment(out) {
+	if cl.objectInRevision(out) {
 		return out
 	}
 	return nil
@@ -397,18 +397,14 @@ func (cl *Client) List(kind resource.GroupVersionKind, namespace string) ([]mode
 		obj, err := crd.ConvertObject(s, item, cl.domainSuffix)
 		if err != nil {
 			errs = multierror.Append(errs, err)
-		} else if cl.objectInEnvironment(obj) {
+		} else if cl.objectInRevision(obj) {
 			out = append(out, *obj)
 		}
 	}
 	return out, errs
 }
 
-func (cl *Client) objectInEnvironment(o *model.Config) bool {
-	// If revision is not configured, we will select all objects
-	if cl.revision == "" {
-		return true
-	}
+func (cl *Client) objectInRevision(o *model.Config) bool {
 	configEnv, f := o.Labels[model.RevisionLabel]
 	if !f {
 		// This is a global object, and always included

--- a/pilot/pkg/config/kube/crd/controller/controller.go
+++ b/pilot/pkg/config/kube/crd/controller/controller.go
@@ -422,7 +422,7 @@ func (c *controller) List(typ resource.GroupVersionKind, namespace string) ([]mo
 			// DO NOT RETURN ERROR: if a single object is bad, it'll be ignored (with a log message), but
 			// the rest should still be processed.
 			handleValidationFailure(item, err)
-		} else if c.client.objectInEnvironment(config) {
+		} else if c.client.objectInRevision(config) {
 			out = append(out, *config)
 		}
 	}

--- a/pilot/pkg/serviceregistry/mcp/controller.go
+++ b/pilot/pkg/serviceregistry/mcp/controller.go
@@ -121,16 +121,6 @@ func (c *controller) List(typ resource.GroupVersionKind, namespace string) (out 
 	return out, nil
 }
 
-func (c *controller) objectInRevision(o *model.Config) bool {
-	configEnv, f := o.Labels[model.RevisionLabel]
-	if !f {
-		// This is a global object, and always included
-		return true
-	}
-	// Otherwise, only return if the
-	return configEnv == c.options.Revision
-}
-
 // Apply receives changes from MCP server and creates the
 // corresponding config
 func (c *controller) Apply(change *sink.Change) error {

--- a/pilot/pkg/serviceregistry/mcp/controller.go
+++ b/pilot/pkg/serviceregistry/mcp/controller.go
@@ -52,6 +52,7 @@ type Options struct {
 	DomainSuffix string
 	XDSUpdater   model.XDSUpdater
 	ConfigLedger ledger.Ledger
+	Revision     string
 }
 
 // controller is a temporary storage for the changes received
@@ -108,16 +109,30 @@ func (c *controller) List(typ resource.GroupVersionKind, namespace string) (out 
 		// we replace the entire sub-map
 		for _, byNamespace := range byType {
 			for _, config := range byNamespace {
-				out = append(out, *config)
+				if c.objectInRevision(config) {
+					out = append(out, *config)
+				}
 			}
 		}
 		return out, nil
 	}
 
 	for _, config := range byType[namespace] {
-		out = append(out, *config)
+		if c.objectInRevision(config) {
+			out = append(out, *config)
+		}
 	}
 	return out, nil
+}
+
+func (c *controller) objectInRevision(o *model.Config) bool {
+	configEnv, f := o.Labels[model.RevisionLabel]
+	if !f {
+		// This is a global object, and always included
+		return true
+	}
+	// Otherwise, only return if the
+	return configEnv == c.options.Revision
 }
 
 // Apply receives changes from MCP server and creates the


### PR DESCRIPTION
Two issues for https://github.com/istio/istio/issues/22874:
* MCP did not implement this, breaking Galley -> Revision migration
* The logic had no revision set reads everything. Instead, it should
read only things without a istio.io/rev label. Otherwise there is no way
to apply configs that don't impact the old control plane