### PR TITLE
Do not install older telemetry v2 config when revision is set

### DIFF
--- a/manifests/istio-control/istio-discovery/templates/telemetryv2_1.4.yaml
+++ b/manifests/istio-control/istio-discovery/templates/telemetryv2_1.4.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.revision "" }}
+{{- /* Old versions not needed when revision is set, otherwise we will start applying v2 to old proxies */}}
 {{- if and .Values.telemetry.enabled .Values.telemetry.v2.enabled }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -238,5 +240,6 @@ spec:
                 code:
                   inline_string: envoy.wasm.null.stackdriver
 ---
+{{- end}}
 {{- end}}
 {{- end}}

--- a/manifests/istio-control/istio-discovery/templates/telemetryv2_1.5.yaml
+++ b/manifests/istio-control/istio-discovery/templates/telemetryv2_1.5.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.revision "" }}
+{{- /* Old versions not needed when revision is set, otherwise we will start applying v2 to old proxies */}}
 {{- if and .Values.telemetry.enabled .Values.telemetry.v2.enabled }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -475,5 +477,6 @@ spec:
                   code:
                     local: { inline_string: envoy.wasm.null.stackdriver }
 ---
+{{- end}}
 {{- end}}
 {{- end}}

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -20004,7 +20004,9 @@ func chartsIstioControlIstioDiscoveryTemplatesServiceYaml() (*asset, error) {
 	return a, nil
 }
 
-var _chartsIstioControlIstioDiscoveryTemplatesTelemetryv2_14Yaml = []byte(`{{- if and .Values.telemetry.enabled .Values.telemetry.v2.enabled }}
+var _chartsIstioControlIstioDiscoveryTemplatesTelemetryv2_14Yaml = []byte(`{{- if eq .Values.revision "" }}
+{{- /* Old versions not needed when revision is set, otherwise we will start applying v2 to old proxies */}}
+{{- if and .Values.telemetry.enabled .Values.telemetry.v2.enabled }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -20246,6 +20248,7 @@ spec:
 ---
 {{- end}}
 {{- end}}
+{{- end}}
 `)
 
 func chartsIstioControlIstioDiscoveryTemplatesTelemetryv2_14YamlBytes() ([]byte, error) {
@@ -20263,7 +20266,9 @@ func chartsIstioControlIstioDiscoveryTemplatesTelemetryv2_14Yaml() (*asset, erro
 	return a, nil
 }
 
-var _chartsIstioControlIstioDiscoveryTemplatesTelemetryv2_15Yaml = []byte(`{{- if and .Values.telemetry.enabled .Values.telemetry.v2.enabled }}
+var _chartsIstioControlIstioDiscoveryTemplatesTelemetryv2_15Yaml = []byte(`{{- if eq .Values.revision "" }}
+{{- /* Old versions not needed when revision is set, otherwise we will start applying v2 to old proxies */}}
+{{- if and .Values.telemetry.enabled .Values.telemetry.v2.enabled }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -20740,6 +20745,7 @@ spec:
                   code:
                     local: { inline_string: envoy.wasm.null.stackdriver }
 ---
+{{- end}}
 {{- end}}
 {{- end}}
 `)


### PR DESCRIPTION
Currently there are issues when applying a new 1.6 revision with an old
control plane running. For example, 1.4+mixer. When 1.6 revision is
added, we will create a bunch of EnvoyFilters. These are supposed to be
scoped to just that revision (by istio.io/rev label), but the old 1.4
control plane doesn't understand this label. This means we will get
v2+mixer and get double telemetry, and in general even if it wasn't
double telemetry we don't want our canary to impact the stable version.

There are two possible fixes for this:
1 Backport istio.io/rev support to 1.4 or even older, so they can update
to latest patch release.
2 Only install the latest EnvoyFilters when a revision is set. We will
never have a 1.5 proxy connect to a 1.6 revision, so this is never
losing config we expect. This way the EnvoyFilter will not apply to old
1.4/1.5 proxies. For 1.6 proxies in default revision this will also not
match, as the 1.6 Pilot respoects the istio.io/rev label

This PR implements the second option. We may want to also implement (1)
for other reasons, but this is useful regardless since it will work with
any release of Istio

For https://github.com/istio/istio/issues/22874