### PR TITLE
Avoid using host header in gateway for destination service

### DIFF
--- a/manifests/istio-control/istio-discovery/templates/telemetryv2_1.4.yaml
+++ b/manifests/istio-control/istio-discovery/templates/telemetryv2_1.4.yaml
@@ -122,6 +122,7 @@ spec:
                 {
                   "debug": "false",
                   "stat_prefix": "istio",
+                  "disable_host_header_fallback": true,
                 }
               vm_config:
                 vm_id: stats_outbound

--- a/manifests/istio-control/istio-discovery/templates/telemetryv2_1.5.yaml
+++ b/manifests/istio-control/istio-discovery/templates/telemetryv2_1.5.yaml
@@ -214,6 +214,7 @@ spec:
                   {
                     "debug": "false",
                     "stat_prefix": "istio",
+                    "disable_host_header_fallback": true,
                   }
                 vm_config:
                   vm_id: stats_outbound

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -15086,6 +15086,7 @@ spec:
                 {
                   "debug": "false",
                   "stat_prefix": "istio",
+                  "disable_host_header_fallback": true,
                 }
               vm_config:
                 vm_id: stats_outbound
@@ -15430,6 +15431,7 @@ spec:
                   {
                     "debug": "false",
                     "stat_prefix": "istio",
+                    "disable_host_header_fallback": true,
                   }
                 vm_config:
                   vm_id: stats_outbound


### PR DESCRIPTION
Manual cherry pick of https://github.com/istio/istio/pull/22821. This changes the default behavior of telemetry at gateway. I will update release note after this PR is in.
