### PR TITLE
Allow override proxy config from agent

### DIFF
--- a/pilot/cmd/pilot-agent/config.go
+++ b/pilot/cmd/pilot-agent/config.go
@@ -109,6 +109,9 @@ func constructProxyConfig() (meshconfig.ProxyConfig, error) {
 // 2. Then we apply any settings from file (this comes from gateway mounting configmap)
 // 3. Then we apply settings from environment variable (this comes from sidecar injection sticking meshconfig here)
 // 4. Then we apply overrides from annotation (this comes from annotation on gateway, passed through downward API)
+//
+// Merging is done by replacement. Any fields present in the overlay will replace those existing fields, while
+// untouched fields will remain untouched. This means lists will be replaced, not appended to, for example.
 func getMeshConfig(fileOverride, annotationOverride string) (meshconfig.MeshConfig, error) {
 	mc := mesh.DefaultMeshConfig()
 

--- a/pilot/cmd/pilot-agent/config.go
+++ b/pilot/cmd/pilot-agent/config.go
@@ -33,6 +33,7 @@ import (
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/validation"
+	"istio.io/istio/pkg/kube/inject"
 )
 
 // getTLSCerts returns all file based certificates from mesh config
@@ -61,9 +62,6 @@ func getTLSCerts(pc meshconfig.ProxyConfig) []string {
 	return certs
 }
 
-// TODO move this to API
-var proxyConfigAnnotation = "istio.io/meshConfig"
-
 func constructProxyConfig() (meshconfig.ProxyConfig, error) {
 	annotations, err := readPodAnnotations()
 	if err != nil {
@@ -77,7 +75,7 @@ func constructProxyConfig() (meshconfig.ProxyConfig, error) {
 		}
 		fileMeshContents = string(contents)
 	}
-	meshConfig, err := getMeshConfig(fileMeshContents, annotations[proxyConfigAnnotation])
+	meshConfig, err := getMeshConfig(fileMeshContents, annotations[inject.ProxyConfigAnnotation])
 	if err != nil {
 		return meshconfig.ProxyConfig{}, err
 	}

--- a/pilot/cmd/pilot-agent/config.go
+++ b/pilot/cmd/pilot-agent/config.go
@@ -15,7 +15,9 @@
 package main
 
 import (
+	"fmt"
 	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -23,13 +25,14 @@ import (
 
 	"istio.io/api/annotation"
 	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/pkg/log"
+
 	"istio.io/istio/pilot/pkg/proxy"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pkg/bootstrap"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/validation"
-	"istio.io/pkg/log"
 )
 
 // getTLSCerts returns all file based certificates from mesh config
@@ -58,8 +61,23 @@ func getTLSCerts(pc meshconfig.ProxyConfig) []string {
 	return certs
 }
 
+// TODO move this to API
+var proxyConfigAnnotation = "istio.io/meshConfig"
+
 func constructProxyConfig() (meshconfig.ProxyConfig, error) {
-	meshConfig, err := getMeshConfig()
+	annotations, err := readPodAnnotations()
+	if err != nil {
+		log.Warnf("failed to read pod annotations: %v", err)
+	}
+	var fileMeshContents string
+	if fileExists(meshConfigFile) {
+		contents, err := ioutil.ReadFile(meshConfigFile)
+		if err != nil {
+			return meshconfig.ProxyConfig{}, fmt.Errorf("failed to read mesh config file %v: %v", meshConfigFile, err)
+		}
+		fileMeshContents = string(contents)
+	}
+	meshConfig, err := getMeshConfig(fileMeshContents, annotations[proxyConfigAnnotation])
 	if err != nil {
 		return meshconfig.ProxyConfig{}, err
 	}
@@ -85,11 +103,54 @@ func constructProxyConfig() (meshconfig.ProxyConfig, error) {
 	if err := validation.ValidateProxyConfig(&proxyConfig); err != nil {
 		return meshconfig.ProxyConfig{}, err
 	}
-	annotations, err := readPodAnnotations()
-	if err != nil {
-		log.Warnf("failed to read pod annotations: %v", err)
-	}
 	return applyAnnotations(proxyConfig, annotations), nil
+}
+
+// getMeshConfig gets the mesh config to use for proxy configuration
+// 1. First we take the default config
+// 2. Then we apply any settings from file (this comes from gateway mounting configmap)
+// 3. Then we apply settings from environment variable (this comes from sidecar injection sticking meshconfig here)
+// 4. Then we apply overrides from annotation (this comes from annotation on gateway, passed through downward API)
+func getMeshConfig(fileOverride, annotationOverride string) (meshconfig.MeshConfig, error) {
+	mc := mesh.DefaultMeshConfig()
+
+	log.Errorf("howardjohn: get mesh config")
+	if fileOverride != "" {
+		log.Infof("Apply mesh config from file %v", fileOverride)
+		fileMesh, err := mesh.ApplyMeshConfig(fileOverride, mc)
+		if err != nil || fileMesh == nil {
+			return meshconfig.MeshConfig{}, fmt.Errorf("failed to unmarshal mesh config from file [%v]: %v", fileOverride, err)
+		}
+		mc = *fileMesh
+	}
+
+	if meshConfig != "" {
+		log.Infof("Apply mesh config from env %v", meshConfig)
+		envMesh, err := mesh.ApplyMeshConfig(meshConfig, mc)
+		if err != nil || envMesh == nil {
+			return meshconfig.MeshConfig{}, fmt.Errorf("failed to unmarshal mesh config from environment [%v]: %v", meshConfig, err)
+		}
+		mc = *envMesh
+	}
+
+	if annotationOverride != "" {
+		log.Infof("Apply mesh config from annotation %v", annotationOverride)
+		annotationMesh, err := mesh.ApplyMeshConfig(annotationOverride, mc)
+		if err != nil || annotationMesh == nil {
+			return meshconfig.MeshConfig{}, fmt.Errorf("failed to unmarshal mesh config from annotation [%v]: %v", annotationOverride, err)
+		}
+		mc = *annotationMesh
+	}
+
+	return mc, nil
+}
+
+func fileExists(path string) bool {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		log.Errorf("howardjohn: %v %v", path, err)
+		return false
+	}
+	return true
 }
 
 func readPodAnnotations() (map[string]string, error) {

--- a/pilot/cmd/pilot-agent/config.go
+++ b/pilot/cmd/pilot-agent/config.go
@@ -75,7 +75,7 @@ func constructProxyConfig() (meshconfig.ProxyConfig, error) {
 		}
 		fileMeshContents = string(contents)
 	}
-	meshConfig, err := getMeshConfig(fileMeshContents, annotations[inject.MeshConfigAnnotation])
+	meshConfig, err := getMeshConfig(fileMeshContents, annotations[inject.ProxyConfigAnnotation])
 	if err != nil {
 		return meshconfig.ProxyConfig{}, err
 	}
@@ -112,7 +112,6 @@ func constructProxyConfig() (meshconfig.ProxyConfig, error) {
 func getMeshConfig(fileOverride, annotationOverride string) (meshconfig.MeshConfig, error) {
 	mc := mesh.DefaultMeshConfig()
 
-	log.Errorf("howardjohn: get mesh config")
 	if fileOverride != "" {
 		log.Infof("Apply mesh config from file %v", fileOverride)
 		fileMesh, err := mesh.ApplyMeshConfig(fileOverride, mc)
@@ -133,7 +132,7 @@ func getMeshConfig(fileOverride, annotationOverride string) (meshconfig.MeshConf
 
 	if annotationOverride != "" {
 		log.Infof("Apply mesh config from annotation %v", annotationOverride)
-		annotationMesh, err := mesh.ApplyMeshConfig(annotationOverride, mc)
+		annotationMesh, err := mesh.ApplyProxyConfig(annotationOverride, mc)
 		if err != nil || annotationMesh == nil {
 			return meshconfig.MeshConfig{}, fmt.Errorf("failed to unmarshal mesh config from annotation [%v]: %v", annotationOverride, err)
 		}

--- a/pilot/cmd/pilot-agent/config.go
+++ b/pilot/cmd/pilot-agent/config.go
@@ -75,7 +75,7 @@ func constructProxyConfig() (meshconfig.ProxyConfig, error) {
 		}
 		fileMeshContents = string(contents)
 	}
-	meshConfig, err := getMeshConfig(fileMeshContents, annotations[inject.ProxyConfigAnnotation])
+	meshConfig, err := getMeshConfig(fileMeshContents, annotations[inject.MeshConfigAnnotation])
 	if err != nil {
 		return meshconfig.ProxyConfig{}, err
 	}

--- a/pilot/cmd/pilot-agent/config.go
+++ b/pilot/cmd/pilot-agent/config.go
@@ -144,7 +144,6 @@ func getMeshConfig(fileOverride, annotationOverride string) (meshconfig.MeshConf
 
 func fileExists(path string) bool {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		log.Errorf("howardjohn: %v %v", path, err)
 		return false
 	}
 	return true

--- a/pilot/cmd/pilot-agent/config_test.go
+++ b/pilot/cmd/pilot-agent/config_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/types"
+
 	meshconfig "istio.io/api/mesh/v1alpha1"
 
 	"istio.io/istio/pkg/config/mesh"

--- a/pilot/cmd/pilot-agent/config_test.go
+++ b/pilot/cmd/pilot-agent/config_test.go
@@ -1,0 +1,112 @@
+// Copyright 2020 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/types"
+	meshconfig "istio.io/api/mesh/v1alpha1"
+
+	"istio.io/istio/pkg/config/mesh"
+)
+
+func TestGetMeshConfig(t *testing.T) {
+	overrides := `
+defaultConfig:
+  discoveryAddress: foo:123
+  proxyMetadata:
+    SOME: setting
+  drainDuration: 1s`
+	overridesExpected := func() meshconfig.ProxyConfig {
+		m := mesh.DefaultProxyConfig()
+		m.DiscoveryAddress = "foo:123"
+		m.ProxyMetadata = map[string]string{"SOME": "setting"}
+		m.DrainDuration = types.DurationProto(time.Second)
+		return m
+	}()
+	cases := []struct {
+		name        string
+		annotation  string
+		environment string
+		file        string
+		expect      meshconfig.ProxyConfig
+	}{
+		{
+			name:   "Defaults",
+			expect: mesh.DefaultProxyConfig(),
+		},
+		{
+			name:       "Annotation Override",
+			annotation: overrides,
+			expect:     overridesExpected,
+		},
+		{
+			name:   "File Override",
+			file:   overrides,
+			expect: overridesExpected,
+		},
+		{
+			name:        "Environment Override",
+			environment: overrides,
+			expect:      overridesExpected,
+		},
+		{
+			// Hopefully no one actually has all three of these set in a real system, but we will still
+			// test them all together.
+			name: "Multiple Override",
+			// Order is file < env < annotation
+			file: `
+defaultConfig:
+  discoveryAddress: file:123
+  proxyMetadata:
+    SOME: setting
+  drainDuration: 1s`,
+			environment: `
+defaultConfig:
+  discoveryAddress: environment:123
+  proxyMetadata:
+    OTHER: option`,
+			annotation: `
+defaultConfig:
+  discoveryAddress: annotation:123
+  proxyMetadata:
+    ANNOTATION: something
+  drainDuration: 5s
+`,
+			expect: func() meshconfig.ProxyConfig {
+				m := mesh.DefaultProxyConfig()
+				m.DiscoveryAddress = "annotation:123"
+				m.ProxyMetadata = map[string]string{"ANNOTATION": "something"}
+				m.DrainDuration = types.DurationProto(5 * time.Second)
+				return m
+			}(),
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			meshConfig = tt.environment
+			got, err := getMeshConfig(tt.file, tt.annotation)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(*got.DefaultConfig, tt.expect) {
+				t.Fatalf("got \n%v expected \n%v", *got.DefaultConfig, tt.expect)
+			}
+		})
+	}
+}

--- a/pilot/cmd/pilot-agent/config_test.go
+++ b/pilot/cmd/pilot-agent/config_test.go
@@ -52,12 +52,12 @@ defaultConfig:
 			expect: mesh.DefaultProxyConfig(),
 		},
 		{
-			name:       "Annotation Override",
+			name: "Annotation Override",
 			annotation: `discoveryAddress: foo:123
 proxyMetadata:
   SOME: setting
 drainDuration: 1s`,
-			expect:     overridesExpected,
+			expect: overridesExpected,
 		},
 		{
 			name:   "File Override",

--- a/pilot/cmd/pilot-agent/config_test.go
+++ b/pilot/cmd/pilot-agent/config_test.go
@@ -53,7 +53,10 @@ defaultConfig:
 		},
 		{
 			name:       "Annotation Override",
-			annotation: overrides,
+			annotation: `discoveryAddress: foo:123
+proxyMetadata:
+  SOME: setting
+drainDuration: 1s`,
 			expect:     overridesExpected,
 		},
 		{
@@ -83,11 +86,10 @@ defaultConfig:
   proxyMetadata:
     OTHER: option`,
 			annotation: `
-defaultConfig:
-  discoveryAddress: annotation:123
-  proxyMetadata:
-    ANNOTATION: something
-  drainDuration: 5s
+discoveryAddress: annotation:123
+proxyMetadata:
+  ANNOTATION: something
+drainDuration: 5s
 `,
 			expect: func() meshconfig.ProxyConfig {
 				m := mesh.DefaultProxyConfig()

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"time"
@@ -44,7 +43,6 @@ import (
 	"istio.io/istio/pilot/pkg/util/sets"
 	"istio.io/istio/pkg/cmd"
 	"istio.io/istio/pkg/config/constants"
-	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/envoy"
 	istio_agent "istio.io/istio/pkg/istio-agent"
 	"istio.io/istio/pkg/jwt"
@@ -344,31 +342,6 @@ var (
 		},
 	}
 )
-
-// getMeshConfig gets the mesh config to use for proxy configuration
-// 1. Search for MESH_CONFIG env var. This is set in the injection template
-// 2. Attempt to read --meshConfigFile. This is used for gateways
-// 3. If neither is found, we can fallback to default settings
-func getMeshConfig() (meshconfig.MeshConfig, error) {
-	defaultConfig := mesh.DefaultMeshConfig()
-	if meshConfig != "" {
-		mc, err := mesh.ApplyMeshConfig(meshConfig, defaultConfig)
-		if err != nil || mc == nil {
-			return meshconfig.MeshConfig{}, fmt.Errorf("failed to unmarshal mesh config config [%v]: %v", meshConfig, err)
-		}
-		return *mc, nil
-	}
-	b, err := ioutil.ReadFile(meshConfigFile)
-	if err != nil {
-		log.Warnf("Failed to read mesh config file from %v or MESH_CONFIG. Falling back to defaults: %v", meshConfigFile, err)
-		return defaultConfig, nil
-	}
-	mc, err := mesh.ApplyMeshConfig(string(b), defaultConfig)
-	if err != nil || mc == nil {
-		return meshconfig.MeshConfig{}, fmt.Errorf("failed to unmarshal mesh config config [%v]: %v", string(b), err)
-	}
-	return *mc, nil
-}
 
 // dedupes the string array and also ignores the empty string.
 func dedupeStrings(in []string) []string {

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -492,7 +492,11 @@ func ParseDownwardAPI(i string) (map[string]string, error) {
 		}
 		key := sl[0]
 		// Strip the leading/trailing quotes
-		val := sl[1][1 : len(sl[1])-1]
+
+		val, err := strconv.Unquote(sl[1])
+		if err != nil {
+			return nil, fmt.Errorf("failed to unquote %v: %v", sl[1], err)
+		}
 		res[key] = val
 	}
 	return res, nil

--- a/pkg/bootstrap/config_test.go
+++ b/pkg/bootstrap/config_test.go
@@ -35,7 +35,7 @@ func TestParseDownwardApi(t *testing.T) {
 			map[string]string{"foo": "bar"},
 		},
 		{
-			"multi line",
+			"multi",
 			map[string]string{
 				"app":               "istio-ingressgateway",
 				"chart":             "gateways",
@@ -45,9 +45,18 @@ func TestParseDownwardApi(t *testing.T) {
 			},
 		},
 		{
+			"multi line",
+			map[string]string{
+				"config": `foo: bar
+other: setting`,
+				"istio": "ingressgateway",
+			},
+		},
+		{
 			"weird values",
 			map[string]string{
 				"foo": `a1_-.as1`,
+				"bar": `a=b`,
 			},
 		},
 	}

--- a/pkg/config/mesh/mesh.go
+++ b/pkg/config/mesh/mesh.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
+
 	"istio.io/api/networking/v1alpha3"
 
 	"github.com/gogo/protobuf/types"

--- a/pkg/config/mesh/mesh.go
+++ b/pkg/config/mesh/mesh.go
@@ -15,10 +15,12 @@
 package mesh
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	"istio.io/api/networking/v1alpha3"
 
 	"github.com/gogo/protobuf/types"
@@ -189,6 +191,16 @@ func IsClusterLocal(mesh *meshconfig.MeshConfig, namespace string) bool {
 		}
 	}
 	return false
+}
+
+// ApplyProxyConfig applies the give proxy config yaml to a mesh config object. The passed in mesh config
+// will not be modified.
+func ApplyProxyConfig(yaml string, meshConfig meshconfig.MeshConfig) (*meshconfig.MeshConfig, error) {
+	mc := proto.Clone(&meshConfig).(*meshconfig.MeshConfig)
+	if err := gogoprotomarshal.ApplyYAML(yaml, mc.DefaultConfig); err != nil {
+		return nil, fmt.Errorf("could not parse proxy config: %v", err)
+	}
+	return mc, nil
 }
 
 // ApplyMeshConfig returns a new MeshConfig decoded from the

--- a/pkg/config/mesh/mesh_test.go
+++ b/pkg/config/mesh/mesh_test.go
@@ -49,7 +49,7 @@ func TestApplyProxyConfig(t *testing.T) {
 			t.Fatal(err)
 		}
 		// Ensure we didn't modify the passed in mesh config
-		if mc.DefaultConfig.DiscoveryAddress != defaultDiscovery{
+		if mc.DefaultConfig.DiscoveryAddress != defaultDiscovery {
 			t.Fatalf("expected discoveryAddress: %q, got %q", defaultDiscovery, mc.DefaultConfig.DiscoveryAddress)
 		}
 		if mc.DefaultConfig.DrainDuration.Seconds != 5 {

--- a/pkg/config/mesh/mesh_test.go
+++ b/pkg/config/mesh/mesh_test.go
@@ -29,6 +29,35 @@ import (
 	"istio.io/istio/pkg/config/validation"
 )
 
+func TestApplyProxyConfig(t *testing.T) {
+	config := mesh.DefaultMeshConfig()
+	defaultDiscovery := config.DefaultConfig.DiscoveryAddress
+
+	t.Run("apply single", func(t *testing.T) {
+		mc, err := mesh.ApplyProxyConfig("discoveryAddress: foo", config)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if mc.DefaultConfig.DiscoveryAddress != "foo" {
+			t.Fatalf("expected discoveryAddress: foo, got %q", mc.DefaultConfig.DiscoveryAddress)
+		}
+	})
+
+	t.Run("apply again", func(t *testing.T) {
+		mc, err := mesh.ApplyProxyConfig("drainDuration: 5s", config)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Ensure we didn't modify the passed in mesh config
+		if mc.DefaultConfig.DiscoveryAddress != defaultDiscovery{
+			t.Fatalf("expected discoveryAddress: %q, got %q", defaultDiscovery, mc.DefaultConfig.DiscoveryAddress)
+		}
+		if mc.DefaultConfig.DrainDuration.Seconds != 5 {
+			t.Fatalf("expected drainDuration: 5s, got %q", mc.DefaultConfig.DrainDuration.Seconds)
+		}
+	})
+}
+
 func TestDefaultProxyConfig(t *testing.T) {
 	proxyConfig := mesh.DefaultProxyConfig()
 	if err := validation.ValidateProxyConfig(&proxyConfig); err != nil {

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -30,18 +30,19 @@ import (
 	"strings"
 	"text/template"
 
-	"istio.io/istio/pkg/config/mesh"
-
 	"github.com/ghodss/yaml"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 	"github.com/hashicorp/go-multierror"
 
+	"istio.io/istio/pkg/config/mesh"
+
 	"istio.io/api/annotation"
 	meshconfig "istio.io/api/mesh/v1alpha1"
-	"istio.io/istio/pilot/pkg/model"
 	"istio.io/pkg/log"
+
+	"istio.io/istio/pilot/pkg/model"
 
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/batch/v2alpha1"
@@ -89,8 +90,17 @@ var (
 		annotation.SidecarTrafficExcludeOutboundPorts.Name:        ValidateExcludeOutboundPorts,
 		annotation.SidecarTrafficKubevirtInterfaces.Name:          alwaysValidFunc,
 		annotation.PrometheusMergeMetrics.Name:                    validateBool,
+		MeshConfigAnnotation:                                      validateMeshConfig,
 	}
 )
+
+func validateMeshConfig(value string) error {
+	_, err := mesh.ApplyMeshConfigDefaults(value)
+	if err != nil {
+		return err
+	}
+	return nil
+}
 
 func validateAnnotations(annotations map[string]string) (err error) {
 	for name, value := range annotations {
@@ -426,7 +436,7 @@ func flippedContains(needle, haystack string) bool {
 	return strings.Contains(haystack, needle)
 }
 
-// TODO move this to API
+// MeshConfigAnnotation determines the mesh config overrides for a workloadTODO move this to API
 var MeshConfigAnnotation = "istio.io/meshConfig"
 
 // InjectionData renders sidecarTemplate with valuesConfig.

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml
@@ -15,6 +15,13 @@ spec:
         traffic.sidecar.istio.io/excludeOutboundPorts: "7,8,9"
         traffic.sidecar.istio.io/includeOutboundIPRanges: "127.0.0.1/24,10.96.0.1/24"
         traffic.sidecar.istio.io/excludeOutboundIPRanges: "10.96.0.2/24,10.96.0.3/24"
+        istio.io/meshConfig: |-
+          defaultConfig:
+            discoveryAddress: foo:123
+            proxyMetadata:
+              FOO: bar
+          outboundTrafficPolicy:
+            mode: REGISTRY_ONLY
       labels:
         app: traffic
     spec:

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml
@@ -15,13 +15,10 @@ spec:
         traffic.sidecar.istio.io/excludeOutboundPorts: "7,8,9"
         traffic.sidecar.istio.io/includeOutboundIPRanges: "127.0.0.1/24,10.96.0.1/24"
         traffic.sidecar.istio.io/excludeOutboundIPRanges: "10.96.0.2/24,10.96.0.3/24"
-        istio.io/meshConfig: |-
-          defaultConfig:
-            discoveryAddress: foo:123
-            proxyMetadata:
-              FOO: bar
-          outboundTrafficPolicy:
-            mode: REGISTRY_ONLY
+        istio.io/proxyConfig: |-
+          discoveryAddress: foo:123
+          proxyMetadata:
+            FOO: bar
       labels:
         app: traffic
     spec:

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -12,6 +12,13 @@ spec:
   template:
     metadata:
       annotations:
+        istio.io/meshConfig: |-
+          defaultConfig:
+            discoveryAddress: foo:123
+            proxyMetadata:
+              FOO: bar
+          outboundTrafficPolicy:
+            mode: REGISTRY_ONLY
         sidecar.istio.io/interceptionMode: REDIRECT
         sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6,15020
@@ -73,7 +80,7 @@ spec:
               fieldPath: status.hostIP
         - name: MESH_CONFIG
           value: |
-            {}
+            {"defaultConfig":{"discoveryAddress":"foo:123","proxyMetadata":{"FOO":"bar"}},"outboundTrafficPolicy":{}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -90,13 +97,15 @@ spec:
           value: REDIRECT
         - name: ISTIO_METAJSON_ANNOTATIONS
           value: |
-            {"traffic.sidecar.istio.io/excludeInboundPorts":"4,5,6","traffic.sidecar.istio.io/excludeOutboundIPRanges":"10.96.0.2/24,10.96.0.3/24","traffic.sidecar.istio.io/excludeOutboundPorts":"7,8,9","traffic.sidecar.istio.io/includeInboundPorts":"1,2,3","traffic.sidecar.istio.io/includeOutboundIPRanges":"127.0.0.1/24,10.96.0.1/24"}
+            {"istio.io/meshConfig":"defaultConfig:\n  discoveryAddress: foo:123\n  proxyMetadata:\n    FOO: bar\noutboundTrafficPolicy:\n  mode: REGISTRY_ONLY","traffic.sidecar.istio.io/excludeInboundPorts":"4,5,6","traffic.sidecar.istio.io/excludeOutboundIPRanges":"10.96.0.2/24,10.96.0.3/24","traffic.sidecar.istio.io/excludeOutboundPorts":"7,8,9","traffic.sidecar.istio.io/includeInboundPorts":"1,2,3","traffic.sidecar.istio.io/includeOutboundIPRanges":"127.0.0.1/24,10.96.0.1/24"}
         - name: ISTIO_META_WORKLOAD_NAME
           value: traffic
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/traffic
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: FOO
+          value: bar
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -160,6 +169,9 @@ spec:
         - 15090,4,5,6,15020
         - -o
         - 7,8,9
+        env:
+        - name: FOO
+          value: bar
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -12,13 +12,10 @@ spec:
   template:
     metadata:
       annotations:
-        istio.io/meshConfig: |-
-          defaultConfig:
-            discoveryAddress: foo:123
-            proxyMetadata:
-              FOO: bar
-          outboundTrafficPolicy:
-            mode: REGISTRY_ONLY
+        istio.io/proxyConfig: |-
+          discoveryAddress: foo:123
+          proxyMetadata:
+            FOO: bar
         sidecar.istio.io/interceptionMode: REDIRECT
         sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6,15020
@@ -80,7 +77,7 @@ spec:
               fieldPath: status.hostIP
         - name: MESH_CONFIG
           value: |
-            {"defaultConfig":{"discoveryAddress":"foo:123","proxyMetadata":{"FOO":"bar"}},"outboundTrafficPolicy":{}}
+            {"defaultConfig":{"discoveryAddress":"foo:123","proxyMetadata":{"FOO":"bar"}}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -97,7 +94,7 @@ spec:
           value: REDIRECT
         - name: ISTIO_METAJSON_ANNOTATIONS
           value: |
-            {"istio.io/meshConfig":"defaultConfig:\n  discoveryAddress: foo:123\n  proxyMetadata:\n    FOO: bar\noutboundTrafficPolicy:\n  mode: REGISTRY_ONLY","traffic.sidecar.istio.io/excludeInboundPorts":"4,5,6","traffic.sidecar.istio.io/excludeOutboundIPRanges":"10.96.0.2/24,10.96.0.3/24","traffic.sidecar.istio.io/excludeOutboundPorts":"7,8,9","traffic.sidecar.istio.io/includeInboundPorts":"1,2,3","traffic.sidecar.istio.io/includeOutboundIPRanges":"127.0.0.1/24,10.96.0.1/24"}
+            {"istio.io/proxyConfig":"discoveryAddress: foo:123\nproxyMetadata:\n  FOO: bar","traffic.sidecar.istio.io/excludeInboundPorts":"4,5,6","traffic.sidecar.istio.io/excludeOutboundIPRanges":"10.96.0.2/24,10.96.0.3/24","traffic.sidecar.istio.io/excludeOutboundPorts":"7,8,9","traffic.sidecar.istio.io/includeInboundPorts":"1,2,3","traffic.sidecar.istio.io/includeOutboundIPRanges":"127.0.0.1/24,10.96.0.1/24"}
         - name: ISTIO_META_WORKLOAD_NAME
           value: traffic
         - name: ISTIO_META_OWNER

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -804,7 +804,7 @@ func (wh *Webhook) inject(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionRespons
 		deployMeta.Name = pod.Name
 	}
 
-	spec, iStatus, err := InjectionData(wh.Config.Template, wh.valuesConfig, wh.sidecarTemplateVersion, typeMetadata, deployMeta, &pod.Spec, &pod.ObjectMeta, wh.meshConfig.DefaultConfig, wh.meshConfig) // nolint: lll
+	spec, iStatus, err := InjectionData(wh.Config.Template, wh.valuesConfig, wh.sidecarTemplateVersion, typeMetadata, deployMeta, &pod.Spec, &pod.ObjectMeta, wh.meshConfig) // nolint: lll
 	if err != nil {
 		handleError(fmt.Sprintf("Injection data: err=%v spec=%v\n", err, iStatus))
 		return toAdmissionResponse(err)


### PR DESCRIPTION
The goal here is to allow overrides of proxy config per workload. This is in the context of https://docs.google.com/document/d/1JJXvQSINaAww-Hl_cdfs1QnkvfaIb6omNqzg4RXcQRY and https://github.com/istio/istio/issues/22871

This adds a new hierarchy of overrides for proxyconfig. Ultimately, the user would configure these overrides through annotations on the workload (sidecar or gateway) - the rest is implementation details. For example:
```
       annotations:
          sidecar.istio.io/proxyConfig: |-
            discoveryAddress: foo:123
```

possible future changes
* (DONE - another PR) pass all proxyConfig directly back to Pilot in node metadata
