### PR TITLE
Use custom_tags in http_connection_manager filter for sidecar proxies

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -2062,7 +2062,7 @@ func buildCustomTags(customTags map[string]*meshconfig.Tracing_CustomTag) []*env
 	// looping over customTags, a map, results in the returned value
 	// being non-deterministic when multiple tags were defined; sort by the tag name
 	// to rectify this
-	sort.Slice(tags[:], func(i, j int) bool {
+	sort.Slice(tags, func(i, j int) bool {
 		return tags[i].Tag < tags[j].Tag
 	})
 

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -2012,7 +2012,7 @@ func buildTracingConfig(config *meshconfig.ProxyConfig, proxyType model.NodeType
 
 	// custom tags should only be used for sidecar proxies and should not include
 	// gateways due to client requests from outside of the mesh
-	if len(config.Tracing.CustomTags) != 0 && proxyType == model.SidecarProxy {
+	if config.Tracing != nil && len(config.Tracing.CustomTags) != 0 && proxyType == model.SidecarProxy {
 		tracingCfg.CustomTags = buildCustomTags(config.Tracing.CustomTags)
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -28,6 +28,7 @@ import (
 	http_filter "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/tcp_proxy/v2"
 	thrift_proxy "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/thrift_proxy/v2alpha1"
+	envoy_type_tracing_v2 "github.com/envoyproxy/go-control-plane/envoy/type/tracing/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/conversion"
 	xdsutil "github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/gogo/protobuf/types"
@@ -1400,6 +1401,121 @@ func TestHttpProxyListener(t *testing.T) {
 	}
 	if !strings.HasPrefix(cfg.Fields["stat_prefix"].GetStringValue(), "outbound_") {
 		t.Fatalf("expected http proxy stat prefix to have outbound, %s", cfg.Fields["stat_prefix"].GetStringValue())
+	}
+}
+
+func TestHttpProxyListener_CustomTags(t *testing.T) {
+	var customTagsTest = []struct {
+		name string
+		in  map[string]*meshconfig.Tracing_CustomTag
+		out *envoy_type_tracing_v2.CustomTag
+	}{
+		{
+			name: "request_header",
+			in: map[string]*meshconfig.Tracing_CustomTag{
+				"custom_tag_request_header": {
+					Type: &meshconfig.Tracing_CustomTag_Header{
+						Header: &meshconfig.Tracing_RequestHeader{
+							Name:         "custom_tag_request_header_name",
+							DefaultValue: "custom-defaulted-value-request-header",
+						},
+					},
+				},
+			},
+			out: &envoy_type_tracing_v2.CustomTag{
+				Tag: "custom_tag_request_header",
+				Type: &envoy_type_tracing_v2.CustomTag_RequestHeader{
+					RequestHeader: &envoy_type_tracing_v2.CustomTag_Header{
+						Name:         "custom_tag_request_header_name",
+						DefaultValue: "custom-defaulted-value-request-header",
+					},
+				},
+			},
+		},
+		{
+			name: "literals",
+			in: map[string]*meshconfig.Tracing_CustomTag{
+				"custom_tag_literal": {
+					Type: &meshconfig.Tracing_CustomTag_Literal{
+						Literal: &meshconfig.Tracing_Literal{
+							Value: "literal-value",
+						},
+					},
+				},
+			},
+			out: &envoy_type_tracing_v2.CustomTag{
+				Tag: "custom_tag_literal",
+				Type: &envoy_type_tracing_v2.CustomTag_Literal_{
+					Literal: &envoy_type_tracing_v2.CustomTag_Literal{
+						Value: "literal-value",
+					},
+				},
+			},
+		},
+		{
+			name: "envs",
+			in: map[string]*meshconfig.Tracing_CustomTag{
+				"custom_tag_env": {
+					Type: &meshconfig.Tracing_CustomTag_Environment{
+						Environment: &meshconfig.Tracing_Environment{
+							Name:         "custom_tag_env-var",
+							DefaultValue: "custom-tag-env-default",
+						},
+					},
+				},
+			},
+			out: &envoy_type_tracing_v2.CustomTag{
+				Tag: "custom_tag_env",
+				Type: &envoy_type_tracing_v2.CustomTag_Environment_{
+					Environment: &envoy_type_tracing_v2.CustomTag_Environment{
+						Name:         "custom_tag_env-var",
+						DefaultValue: "custom-tag-env-default",
+					},
+				},
+			},
+		},
+	}
+	p := &fakePlugin{}
+	configgen := NewConfigGenerator([]plugin.Plugin{p})
+
+	for _, tc := range customTagsTest {
+		env := buildListenerEnv(nil, nil)
+		if err := env.PushContext.InitContext(&env, nil, nil); err != nil {
+			t.Fatalf("error in initializing push context: %s", err)
+		}
+
+		proxy.ServiceInstances = nil
+		env.Mesh().ProxyHttpPort = 15007
+		env.Mesh().EnableTracing = true
+		env.Mesh().DefaultConfig = &meshconfig.ProxyConfig{
+			Tracing: &meshconfig.Tracing{
+				CustomTags: tc.in,
+			},
+		}
+
+		proxy.SidecarScope = model.DefaultSidecarScopeForNamespace(env.PushContext, "not-default")
+		httpProxy := configgen.buildHTTPProxy(&proxy, env.PushContext)
+
+		f := httpProxy.FilterChains[0].Filters[0]
+		verifyHttpConnectionManagerFilter(t, f, tc.out, tc.name)
+	}
+}
+
+func verifyHttpConnectionManagerFilter(t *testing.T, f *listener.Filter, expected *envoy_type_tracing_v2.CustomTag, name string) {
+	t.Helper()
+	if f.Name == "envoy.http_connection_manager" {
+		cmgr := &http_filter.HttpConnectionManager{}
+		err := getFilterConfig(f, cmgr)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		tracing := cmgr.GetTracing().GetCustomTags()[0]
+		ok := reflect.DeepEqual(tracing, expected)
+
+		if !ok {
+			t.Fatalf("Testcase failure: %s custom tags did match not expected output", name)
+		}
 	}
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -1406,13 +1406,13 @@ func TestHttpProxyListener(t *testing.T) {
 
 func TestHttpProxyListener_CustomTags(t *testing.T) {
 	var customTagsTest = []struct {
-		name string
-		in  map[string]*meshconfig.Tracing_CustomTag
-		out []*envoy_type_tracing_v2.CustomTag
+		name      string
+		in        map[string]*meshconfig.Tracing_CustomTag
+		out       []*envoy_type_tracing_v2.CustomTag
 		isGateway bool
 	}{
 		{
-			name: "custom-tags-sidecar",
+			name:      "custom-tags-sidecar",
 			isGateway: false,
 			in: map[string]*meshconfig.Tracing_CustomTag{
 				"custom_tag_env": {
@@ -1471,7 +1471,7 @@ func TestHttpProxyListener_CustomTags(t *testing.T) {
 			},
 		},
 		{
-			name: "custom-tags-gateways",
+			name:      "custom-tags-gateways",
 			isGateway: true,
 			in: map[string]*meshconfig.Tracing_CustomTag{
 				"custom_tag_request_header": {
@@ -1512,11 +1512,11 @@ func TestHttpProxyListener_CustomTags(t *testing.T) {
 		httpProxy := configgen.buildHTTPProxy(&proxy, env.PushContext)
 
 		f := httpProxy.FilterChains[0].Filters[0]
-		verifyHttpConnectionManagerFilter(t, f, tc.out, tc.name)
+		verifyHTTPConnectionManagerFilter(t, f, tc.out, tc.name)
 	}
 }
 
-func verifyHttpConnectionManagerFilter(t *testing.T, f *listener.Filter, expected []*envoy_type_tracing_v2.CustomTag, name string) {
+func verifyHTTPConnectionManagerFilter(t *testing.T, f *listener.Filter, expected []*envoy_type_tracing_v2.CustomTag, name string) {
 	t.Helper()
 	if f.Name == "envoy.http_connection_manager" {
 		cmgr := &http_filter.HttpConnectionManager{}


### PR DESCRIPTION
Partial fix for https://github.com/istio/istio/issues/13018

When the user has specified mesh wide configuration for proxies to use
custom_tags, propagate thos settings to http_connection_manager filter.

Depends on https://github.com/istio/api/pull/1369