### PR TITLE
route: optimize virtual service route generation

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -158,21 +158,38 @@ func separateVSHostsAndServices(virtualService model.Config,
 	rule := virtualService.Spec.(*networking.VirtualService)
 	hosts := make([]string, 0)
 	servicesInVirtualService := make([]*model.Service, 0)
+	wchosts := make([]host.Name, 0)
+
+	// As a performance optimization, process non wildcard hosts first, so that they can be
+	// looked up directly in the service registry map.
 	for _, hostname := range rule.Hosts {
+		vshost := host.Name(hostname)
+		if !vshost.IsWildCarded() {
+			if svc, exists := serviceRegistry[vshost]; exists {
+				servicesInVirtualService = append(servicesInVirtualService, svc)
+			} else {
+				hosts = append(hosts, hostname)
+			}
+		} else {
+			// Add it to the wildcard hosts so that they can be processed later.
+			wchosts = append(wchosts, vshost)
+		}
+	}
+
+	// Now process wild card hosts as they need to follow the slow path of looping through all services in the registry.
+	for _, hostname := range wchosts {
 		// Say host is *.global
-		vsHostname := host.Name(hostname)
 		foundSvcMatch := false
-		// TODO: Optimize me. This is O(n2) or worse. Need to prune at top level in config
 		// Say we have services *.foo.global, *.bar.global
 		for svcHost, svc := range serviceRegistry {
 			// *.foo.global matches *.global
-			if svcHost.Matches(vsHostname) {
+			if svcHost.Matches(hostname) {
 				servicesInVirtualService = append(servicesInVirtualService, svc)
 				foundSvcMatch = true
 			}
 		}
 		if !foundSvcMatch {
-			hosts = append(hosts, hostname)
+			hosts = append(hosts, string(hostname))
 		}
 	}
 	return hosts, servicesInVirtualService

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -214,11 +214,11 @@ func buildSidecarVirtualHostsForVirtualService(
 	}
 	meshGateway := map[string]bool{constants.IstioMeshGateway: true}
 	out := make([]VirtualHostWrapper, 0, len(serviceByPort))
+	routes, err := BuildHTTPRoutesForVirtualService(node, push, virtualService, serviceRegistry, listenPort, meshGateway)
+	if err != nil || len(routes) == 0 {
+		return out
+	}
 	for port, portServices := range serviceByPort {
-		routes, err := BuildHTTPRoutesForVirtualService(node, push, virtualService, serviceRegistry, listenPort, meshGateway)
-		if err != nil || len(routes) == 0 {
-			continue
-		}
 		out = append(out, VirtualHostWrapper{
 			Port:                port,
 			Services:            portServices,

--- a/pkg/config/host/name.go
+++ b/pkg/config/host/name.go
@@ -34,8 +34,8 @@ type Name string
 //  Name("*").Matches("foo.com")         = true
 //  Name("*").Matches("*.com")           = true
 func (n Name) Matches(o Name) bool {
-	hWildcard := n.isWildCarded()
-	oWildcard := o.isWildCarded()
+	hWildcard := n.IsWildCarded()
+	oWildcard := o.IsWildCarded()
 
 	if hWildcard {
 		if oWildcard {
@@ -61,8 +61,8 @@ func (n Name) Matches(o Name) bool {
 // SubsetOf returns true if this hostname is a valid subset of the other hostname. The semantics are
 // the same as "Matches", but only in one direction (i.e., h is covered by o).
 func (n Name) SubsetOf(o Name) bool {
-	hWildcard := n.isWildCarded()
-	oWildcard := o.isWildCarded()
+	hWildcard := n.IsWildCarded()
+	oWildcard := o.IsWildCarded()
 
 	if hWildcard {
 		if oWildcard {
@@ -85,6 +85,6 @@ func (n Name) SubsetOf(o Name) bool {
 	return n == o
 }
 
-func (n Name) isWildCarded() bool {
+func (n Name) IsWildCarded() bool {
 	return len(n) > 0 && n[0] == '*'
 }


### PR DESCRIPTION
This PR fixes the following
- Moves `BuildHTTPRoutesForVirtualService` outside of for loop. I could not find a reason why it has to be loop.
- Changes `separateVSHostsAndServices` method to process non wildcard hosts first so that we take advantage of `serviceRegistry` map for them