### PR TITLE
Use a distinct lock id for Istiod

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -26,6 +26,7 @@ import (
 
 	"istio.io/istio/galley/pkg/server/components"
 	"istio.io/istio/galley/pkg/server/settings"
+	"istio.io/istio/pilot/pkg/leaderelection"
 
 	"istio.io/istio/pilot/pkg/config/kube/gateway"
 	"istio.io/istio/pilot/pkg/features"
@@ -103,11 +104,18 @@ func (s *Server) initConfigController(args *PilotArgs) error {
 		s.ConfigStores = append(s.ConfigStores,
 			ingress.NewController(s.kubeClient, meshConfig, args.Config.ControllerOptions))
 
-		if ingressSyncer, errSyncer := ingress.NewStatusSyncer(meshConfig, s.kubeClient, args.Config.ControllerOptions, s.leaderElection); errSyncer != nil {
-			log.Warnf("Disabled ingress status syncer due to %v", errSyncer)
+		ingressSyncer, err := ingress.NewStatusSyncer(meshConfig, s.kubeClient, args.Config.ControllerOptions)
+		if err != nil {
+			log.Warnf("Disabled ingress status syncer due to %v", err)
 		} else {
-			s.addStartFunc(func(stop <-chan struct{}) error {
-				go ingressSyncer.Run(stop)
+			s.addTerminatingStartFunc(func(stop <-chan struct{}) error {
+				leaderelection.
+					NewLeaderElection(args.Namespace, args.PodName, leaderelection.IngressController, s.kubeClient).
+					AddRunFunction(func(stop <-chan struct{}) {
+						log.Infof("Starting ingress controller")
+						ingressSyncer.Run(stop)
+					}).
+					Run(stop)
 				return nil
 			})
 		}

--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -26,14 +26,11 @@ import (
 	"strings"
 	"time"
 
-	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
-
-	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/jwt"
 
 	"istio.io/istio/pilot/pkg/features"
 
-	oidc "github.com/coreos/go-oidc"
+	"github.com/coreos/go-oidc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -165,8 +162,7 @@ func (s *Server) EnableCA() bool {
 // Protected by installer options: the CA will be started only if the JWT token in /var/run/secrets
 // is mounted. If it is missing - for example old versions of K8S that don't support such tokens -
 // we will not start the cert-signing server, since pods will have no way to authenticate.
-func (s *Server) RunCA(grpc *grpc.Server, ca caserver.CertificateAuthority, opts *CAOptions,
-	controllerOptions controller.Options, stopCh <-chan struct{}) {
+func (s *Server) RunCA(grpc *grpc.Server, ca caserver.CertificateAuthority, opts *CAOptions) {
 	if !s.EnableCA() {
 		return
 	}
@@ -229,18 +225,6 @@ func (s *Server) RunCA(grpc *grpc.Server, ca caserver.CertificateAuthority, opts
 		log.Warnf("Failed to start GRPC server with error: %v", serverErr)
 	}
 	log.Info("Istiod CA has started")
-
-	if s.kubeClient != nil {
-		s.leaderElection.AddRunFunction(func(stop <-chan struct{}) {
-			nc := NewNamespaceController(func() map[string]string {
-				return map[string]string{
-					constants.CACertNamespaceConfigMapDataName: string(ca.GetCAKeyCertBundle().GetRootCertPem()),
-				}
-			}, controllerOptions, s.kubeClient)
-			nc.Run(stop)
-		})
-	}
-
 }
 
 type jwtAuthenticator struct {

--- a/pilot/pkg/bootstrap/validation.go
+++ b/pilot/pkg/bootstrap/validation.go
@@ -26,6 +26,7 @@ import (
 	"istio.io/istio/galley/pkg/config/source/kube"
 	"istio.io/istio/mixer/pkg/validate"
 	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pilot/pkg/leaderelection"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/webhooks/validation/controller"
 	"istio.io/istio/pkg/webhooks/validation/server"
@@ -105,10 +106,15 @@ func (s *Server) initConfigValidation(args *PilotArgs) error {
 		if err != nil {
 			return err
 		}
-
-		s.leaderElection.AddRunFunction(func(stop <-chan struct{}) {
-			log.Infof("Starting validation controller")
-			whController.Start(stop)
+		s.addTerminatingStartFunc(func(stop <-chan struct{}) error {
+			leaderelection.
+				NewLeaderElection(args.Namespace, args.PodName, leaderelection.ValidationController, s.kubeClient).
+				AddRunFunction(func(stop <-chan struct{}) {
+					log.Infof("Starting validation controller")
+					whController.Start(stop)
+				}).
+				Run(stop)
+			return nil
 		})
 	}
 	return nil

--- a/pilot/pkg/config/kube/ingress/status_test.go
+++ b/pilot/pkg/config/kube/ingress/status_test.go
@@ -131,7 +131,7 @@ func makeStatusSyncer(t *testing.T, client kubernetes.Interface) (*StatusSyncer,
 	return NewStatusSyncer(&m, client, kubecontroller.Options{
 		WatchedNamespace: testNamespace,
 		ResyncPeriod:     resync,
-	}, nil)
+	})
 }
 
 // setAndRestoreEnv set the envs with given value, and return the old setting.

--- a/pilot/pkg/leaderelection/leaderelection.go
+++ b/pilot/pkg/leaderelection/leaderelection.go
@@ -27,8 +27,13 @@ import (
 	"istio.io/pkg/log"
 )
 
+// Various locks used throughout the code
 const (
-	electionID = "istio-leader"
+	NamespaceController  = "istio-namespace-controller-election"
+	ValidationController = "istio-validation-controller-election"
+	// This holds the legacy name to not conflict with older control plane deployments which are just
+	// doing the ingress syncing.
+	IngressController = "istio-leader"
 )
 
 type LeaderElection struct {
@@ -40,7 +45,8 @@ type LeaderElection struct {
 
 	// Records which "cycle" the election is on. This is incremented each time an election is won and then lost
 	// This is mostly just for testing
-	cycle *atomic.Int32
+	cycle      *atomic.Int32
+	electionID string
 }
 
 // Run will start leader election, calling all runFns when we become the leader.
@@ -84,7 +90,7 @@ func (l *LeaderElection) create() (*leaderelection.LeaderElector, error) {
 		},
 	}
 	lock := resourcelock.ConfigMapLock{
-		ConfigMapMeta: metaV1.ObjectMeta{Namespace: l.namespace, Name: electionID},
+		ConfigMapMeta: metaV1.ObjectMeta{Namespace: l.namespace, Name: l.electionID},
 		Client:        l.client.CoreV1(),
 		LockConfig: resourcelock.ResourceLockConfig{
 			Identity: l.name,
@@ -107,15 +113,17 @@ func (l *LeaderElection) create() (*leaderelection.LeaderElector, error) {
 
 // AddRunFunction registers a function to run when we are the leader. These will be run asynchronously.
 // To avoid running when not a leader, functions should respect the stop channel.
-func (l *LeaderElection) AddRunFunction(f func(stop <-chan struct{})) {
+func (l *LeaderElection) AddRunFunction(f func(stop <-chan struct{})) *LeaderElection {
 	l.runFns = append(l.runFns, f)
+	return l
 }
 
-func NewLeaderElection(namespace, name string, client kubernetes.Interface) *LeaderElection {
+func NewLeaderElection(namespace, name, electionID string, client kubernetes.Interface) *LeaderElection {
 	return &LeaderElection{
-		namespace: namespace,
-		name:      name,
-		client:    client,
+		namespace:  namespace,
+		name:       name,
+		electionID: electionID,
+		client:     client,
 		// Default to a 30s ttl. Overridable for tests
 		ttl:   time.Second * 30,
 		cycle: atomic.NewInt32(0),

--- a/pilot/pkg/leaderelection/leaderelection_test.go
+++ b/pilot/pkg/leaderelection/leaderelection_test.go
@@ -30,10 +30,12 @@ import (
 	"istio.io/istio/pkg/test/util/retry"
 )
 
+const testLock = "test-lock"
+
 func createElection(t *testing.T, name string, expectLeader bool, client kubernetes.Interface,
 	fns ...func(stop <-chan struct{})) (*LeaderElection, chan struct{}) {
 	t.Helper()
-	l := NewLeaderElection("ns", name, client)
+	l := NewLeaderElection("ns", name, testLock, client)
 	l.ttl = time.Second
 	gotLeader := make(chan struct{})
 	l.AddRunFunction(func(stop <-chan struct{}) {
@@ -76,7 +78,7 @@ func TestLeaderElection(t *testing.T) {
 func TestLeaderElectionConfigMapRemoved(t *testing.T) {
 	client := fake.NewSimpleClientset()
 	_, stop := createElection(t, "pod1", true, client)
-	if err := client.CoreV1().ConfigMaps("ns").Delete(context.TODO(), "istio-leader", v1.DeleteOptions{}); err != nil {
+	if err := client.CoreV1().ConfigMaps("ns").Delete(context.TODO(), testLock, v1.DeleteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	retry.UntilSuccessOrFail(t, func() error {

--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -284,7 +284,7 @@ func (c *Controller) Start(stop <-chan struct{}) {
 	req := &reconcileRequest{"initial request to kickstart reconciliation"}
 	c.queue.Add(req)
 
-	go c.runWorker()
+	c.runWorker()
 }
 
 func (c *Controller) startFileWatcher(stop <-chan struct{}) {

--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -284,7 +284,7 @@ func (c *Controller) Start(stop <-chan struct{}) {
 	req := &reconcileRequest{"initial request to kickstart reconciliation"}
 	c.queue.Add(req)
 
-	c.runWorker()
+	go c.runWorker()
 }
 
 func (c *Controller) startFileWatcher(stop <-chan struct{}) {


### PR DESCRIPTION
Currently leader election is used for

* config map syncer, as an optimization
* webhook controller, as an optimization
* ingress status, not sure if this is needed for correctness or
optimization

The problem that arises is when an older istiod that only has some
subset of this functionality (for example, legacy helm install will only
have ingress syncer) holds the lock, preventing the new Istiod from
running properly (as the config map syncer does not exist). In order to
get around this, this PR proposes changing the lock name. This is a
pretty poor workaround and will break the next time we add new
functionality - I am very open to new ideas here

For https://github.com/istio/istio/issues/22874