### PR TITLE
manifests: remove .Values.global.configNamespace

### DIFF
--- a/manifests/README.md
+++ b/manifests/README.md
@@ -114,7 +114,6 @@ and it is recommended to have Pilot running in each region and in multiple avail
 ```bash
 iop istio-control istio-discovery $IBASE/istio-control/istio-discovery \
             --set global.istioNamespace=istio-system \
-            --set global.configNamespace=istio-control \
             --set global.telemetryNamespace=istio-telemetry \
             --set global.policyNamespace=istio-policy
 
@@ -122,7 +121,6 @@ iop istio-control istio-discovery $IBASE/istio-control/istio-discovery \
 TAG=latest HUB=gcr.io/istio-testing iop istio-master istio-discovery-master $IBASE/istio-control/istio-discovery \
             --set policy.enable=false \
             --set global.istioNamespace=istio-master \
-            --set global.configNamespace=istio-master \
             --set global.telemetryNamespace=istio-telemetry-master \
             --set global.policyNamespace=istio-policy-master
 ```
@@ -139,27 +137,22 @@ For large-scale gateways it is optionally possible to use a dedicated pilot in t
 ### Telemetry
 
 ```bash
-iop istio-telemetry istio-grafana $IBASE/istio-telemetry/grafana/ --set global.configNamespace=istio-control
+iop istio-telemetry istio-grafana $IBASE/istio-telemetry/grafana/
 iop istio-telemetry istio-mixer $IBASE/istio-telemetry/mixer-telemetry/ \
-        --set global.configNamespace=istio-control \
         --set global.istioNamespace=istio-system \
         --set global.telemetryNamespace=istio-telemetry \
         --set global.policyNamespace=istio-policy
 iop istio-telemetry istio-prometheus $IBASE/istio-telemetry/prometheus/ \
-        --set global.configNamespace=istio-control \
         --set global.istioNamespace=istio-system \
         --set global.telemetryNamespace=istio-telemetry \
         --set global.policyNamespace=istio-policy
 
 TAG=latest HUB=gcr.io/istio-testing iop istio-telemetry-master istio-grafana $IBASE/istio-telemetry/grafana/ \
-        --set global.configNamespace=istio-master
 TAG=latest HUB=gcr.io/istio-testing iop istio-telemetry-master istio-mixer $IBASE/istio-telemetry/mixer-telemetry/ \
-        --set global.configNamespace=istio-master \
         --set global.istioNamespace=istio-master \
         --set global.telemetryNamespace=istio-telemetry-master \
         --set global.policyNamespace=istio-policy-master
 TAG=latest HUB=gcr.io/istio-testing iop istio-telemetry-master istio-prometheus $IBASE/istio-telemetry/prometheus/ \
-        --set global.configNamespace=istio-master \
         --set global.istioNamespace=istio-master \
         --set global.telemetryNamespace=istio-telemetry-master \
         --set global.policyNamespace=istio-policy-master
@@ -169,7 +162,6 @@ TAG=latest HUB=gcr.io/istio-testing iop istio-telemetry-master istio-prometheus 
 
 ```bash
 iop istio-telemetry kiali $IBASE/istio-telemetry/kiali \
-        --set global.configNamespace=istio-control \
         --set global.istioNamespace=istio-system \
         --set global.telemetryNamespace=istio-telemetry \
         --set global.policyNamespace=istio-policy \

--- a/manifests/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/gateways/istio-ingress/templates/deployment.yaml
@@ -133,10 +133,8 @@ spec:
           - name: CA_ADDR
           {{- if .Values.global.caAddress }}
             value: {{ .Values.global.caAddress }}
-          {{- else if .Values.global.configNamespace }}
-            value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.configNamespace }}.svc:15012
           {{- else }}
-            value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.istio-system.svc:15012
+            value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
           {{- end }}
           - name: NODE_NAME
             valueFrom:

--- a/manifests/global.yaml
+++ b/manifests/global.yaml
@@ -19,7 +19,6 @@ global:
   # It is assumed that istio-system is running either 1.0 or an upgraded version of 1.1, but only security components are
   # used (citadel generating the secrets).
   istioNamespace: istio-system
-  configNamespace: istio-system
 
   # Telemetry namespace, including tracing.
   telemetryNamespace: istio-system

--- a/manifests/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/istio-control/istio-discovery/files/gen-istio.yaml
@@ -102,7 +102,6 @@ data:
         },
         "caAddress": "",
         "certificates": [],
-        "configNamespace": "istio-system",
         "configRootNamespace": "istio-system",
         "configValidation": true,
         "controlPlaneSecurityEnabled": true,
@@ -475,10 +474,8 @@ data:
         - name: CA_ADDR
         {{- if .Values.global.caAddress }}
           value: {{ .Values.global.caAddress }}
-        {{- else if .Values.global.configNamespace }}
-          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.configNamespace }}.svc:15012
         {{- else }}
-          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.istio-system.svc:15012
+          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
         {{- end }}
         - name: POD_NAME
           valueFrom:

--- a/manifests/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/istio-control/istio-discovery/files/injection-template.yaml
@@ -156,10 +156,8 @@ template: |
     - name: CA_ADDR
     {{- if .Values.global.caAddress }}
       value: {{ .Values.global.caAddress }}
-    {{- else if .Values.global.configNamespace }}
-      value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.configNamespace }}.svc:15012
     {{- else }}
-      value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.istio-system.svc:15012
+      value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
     {{- end }}
     - name: POD_NAME
       valueFrom:

--- a/manifests/istio-control/istio-discovery/values.yaml
+++ b/manifests/istio-control/istio-discovery/values.yaml
@@ -22,9 +22,6 @@ pilot:
       cpu: 500m
       memory: 2048Mi
 
-  # Namespace for Istio config
-  configNamespace: istio-config
-
   # Applications namespace list pilot manages
   appNamespaces: []
 

--- a/manifests/istio-policy/templates/deployment.yaml
+++ b/manifests/istio-policy/templates/deployment.yaml
@@ -112,12 +112,12 @@ spec:
     {{- if .Values.global.controlPlaneSecurityEnabled}}
           - --configStoreURL=mcps://istio-galley.{{ .Values.global.configNamespace }}.svc:15019
     {{- else }}
-          - --configStoreURL=mcp://istio-galley.{{ .Values.global.configNamespace }}.svc:9901
+          - --configStoreURL=mcp://istio-galley.{{ .Values.global.istioNamespace }}.svc:9901
     {{- end }}
 {{- else }}
           - --configStoreURL=k8s://
 {{- end }}
-          - --configDefaultNamespace={{ .Values.global.configNamespace }}
+          - --configDefaultNamespace={{ .Values.global.istioNamespace }}
           {{- if .Values.mixer.policy.adapters.useAdapterCRDs }}
           - --useAdapterCRDs=true
           {{- else }}
@@ -232,10 +232,8 @@ spec:
         - name: CA_ADDR
         {{- if .Values.global.caAddress }}
           value: {{ .Values.global.caAddress }}
-        {{- else if .Values.global.configNamespace }}
-          value: istiod.{{ .Values.global.configNamespace }}.svc:15012
         {{- else }}
-          value: istiod.istio-system.svc:15012
+          value: istiod.{{ .Values.global.istioNamespace }}.svc:15012
         {{- end }}
         resources:
 {{- if .Values.global.proxy.resources }}

--- a/manifests/istio-telemetry/kiali/templates/configmap.yaml
+++ b/manifests/istio-telemetry/kiali/templates/configmap.yaml
@@ -11,7 +11,7 @@ data:
     istio_component_namespaces:
       grafana: {{ .Values.global.telemetryNamespace }}
       tracing: {{ .Values.global.telemetryNamespace }}
-      pilot: {{ .Values.global.configNamespace }}
+      pilot: {{ .Values.global.istioNamespace }}
       prometheus: {{ .Values.global.prometheusNamespace }}
     istio_namespace: {{ .Values.global.istioNamespace }}
     auth:
@@ -33,7 +33,7 @@ data:
 {{- end }}
     external_services:
       istio:
-        url_service_version: http://istio-pilot.{{ .Values.global.configNamespace }}:8080/version
+        url_service_version: http://istio-pilot.{{ .Values.global.istioNamespace }}:8080/version
       tracing:
         url: {{ .Values.kiali.dashboard.jaegerURL }}
         in_cluster_url: {{ .Values.kiali.dashboard.jaegerInClusterURL }}

--- a/manifests/istio-telemetry/mixer-telemetry/templates/configmap-envoy.yaml
+++ b/manifests/istio-telemetry/mixer-telemetry/templates/configmap-envoy.yaml
@@ -91,7 +91,7 @@ data:
             combined_validation_context:
               default_validation_context:
                 verify_subject_alt_name:
-                - spiffe://{{ .Values.global.trustDomain }}/ns/{{ .Values.global.configNamespace }}/sa/istio-galley-service-account
+                - spiffe://{{ .Values.global.trustDomain }}/ns/{{ .Values.global.istioNamespace }}/sa/istio-galley-service-account
               validation_context_sds_secret_config:
                 name: ROOTCA
                 sds_config:
@@ -102,7 +102,7 @@ data:
                         cluster_name: sds-grpc
         hosts:
           - socket_address:
-              address: istio-galley.{{ .Values.global.configNamespace }}
+              address: istio-galley.{{ .Values.global.istioNamespace }}
               port_value: 15019
 
 

--- a/manifests/istio-telemetry/mixer-telemetry/templates/deployment.yaml
+++ b/manifests/istio-telemetry/mixer-telemetry/templates/deployment.yaml
@@ -111,7 +111,7 @@ spec:
     {{- if .Values.global.controlPlaneSecurityEnabled}}
           - --configStoreURL=mcp://localhost:15019
     {{- else }}
-          - --configStoreURL=mcp://istio-galley.{{ .Values.global.configNamespace }}.svc:9901
+          - --configStoreURL=mcp://istio-galley.{{ .Values.global.istioNamespace }}.svc:9901
     {{- end }}
 {{- else }}
           - --configStoreURL=k8s://
@@ -229,12 +229,10 @@ spec:
         - name: "ISTIO_META_USER_SDS"
           value: "true"
         - name: CA_ADDR
-          {{- if .Values.global.caAddress }}
+      {{- if .Values.global.caAddress }}
           value: {{ .Values.global.caAddress }}
-          {{- else if .Values.global.configNamespace }}
-          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.configNamespace }}.svc:15012
-          {{- else }}
-          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.istio-system.svc:15012
+      {{- else }}
+          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
       {{- end }}
         resources:
 {{- if .Values.global.proxy.resources }}

--- a/manifests/istio-telemetry/prometheus/templates/configmap.yaml
+++ b/manifests/istio-telemetry/prometheus/templates/configmap.yaml
@@ -79,7 +79,7 @@ data:
       - role: endpoints
         namespaces:
           names:
-          - {{ .Values.global.configNamespace }}
+          - {{ .Values.global.istioNamespace }}
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
@@ -92,7 +92,7 @@ data:
       - role: endpoints
         namespaces:
           names:
-          - {{ .Values.global.configNamespace }}
+          - {{ .Values.global.istioNamespace }}
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]

--- a/manifests/istio-telemetry/prometheus/templates/deployment.yaml
+++ b/manifests/istio-telemetry/prometheus/templates/deployment.yaml
@@ -103,10 +103,8 @@ spec:
             - name: CA_ADDR
               {{- if .Values.global.caAddress }}
               value: {{ .Values.global.caAddress }}
-              {{- else if .Values.global.configNamespace }}
-              value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.configNamespace }}.svc:15012
               {{- else }}
-              value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.istio-system.svc:15012
+              value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
               {{- end }}
             - name: POD_NAME
               valueFrom:

--- a/operator/pkg/vfs/assets.gen.go
+++ b/operator/pkg/vfs/assets.gen.go
@@ -15795,10 +15795,8 @@ spec:
           - name: CA_ADDR
           {{- if .Values.global.caAddress }}
             value: {{ .Values.global.caAddress }}
-          {{- else if .Values.global.configNamespace }}
-            value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.configNamespace }}.svc:15012
           {{- else }}
-            value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.istio-system.svc:15012
+            value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
           {{- end }}
           - name: NODE_NAME
             valueFrom:
@@ -17099,7 +17097,6 @@ data:
         },
         "caAddress": "",
         "certificates": [],
-        "configNamespace": "istio-system",
         "configRootNamespace": "istio-system",
         "configValidation": true,
         "controlPlaneSecurityEnabled": true,
@@ -17472,10 +17469,8 @@ data:
         - name: CA_ADDR
         {{- if .Values.global.caAddress }}
           value: {{ .Values.global.caAddress }}
-        {{- else if .Values.global.configNamespace }}
-          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.configNamespace }}.svc:15012
         {{- else }}
-          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.istio-system.svc:15012
+          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
         {{- end }}
         - name: POD_NAME
           valueFrom:
@@ -18879,10 +18874,8 @@ template: |
     - name: CA_ADDR
     {{- if .Values.global.caAddress }}
       value: {{ .Values.global.caAddress }}
-    {{- else if .Values.global.configNamespace }}
-      value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.configNamespace }}.svc:15012
     {{- else }}
-      value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.istio-system.svc:15012
+      value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
     {{- end }}
     - name: POD_NAME
       valueFrom:
@@ -21289,9 +21282,6 @@ pilot:
       cpu: 500m
       memory: 2048Mi
 
-  # Namespace for Istio config
-  configNamespace: istio-config
-
   # Applications namespace list pilot manages
   appNamespaces: []
 
@@ -22687,12 +22677,12 @@ spec:
     {{- if .Values.global.controlPlaneSecurityEnabled}}
           - --configStoreURL=mcps://istio-galley.{{ .Values.global.configNamespace }}.svc:15019
     {{- else }}
-          - --configStoreURL=mcp://istio-galley.{{ .Values.global.configNamespace }}.svc:9901
+          - --configStoreURL=mcp://istio-galley.{{ .Values.global.istioNamespace }}.svc:9901
     {{- end }}
 {{- else }}
           - --configStoreURL=k8s://
 {{- end }}
-          - --configDefaultNamespace={{ .Values.global.configNamespace }}
+          - --configDefaultNamespace={{ .Values.global.istioNamespace }}
           {{- if .Values.mixer.policy.adapters.useAdapterCRDs }}
           - --useAdapterCRDs=true
           {{- else }}
@@ -22807,10 +22797,8 @@ spec:
         - name: CA_ADDR
         {{- if .Values.global.caAddress }}
           value: {{ .Values.global.caAddress }}
-        {{- else if .Values.global.configNamespace }}
-          value: istiod.{{ .Values.global.configNamespace }}.svc:15012
         {{- else }}
-          value: istiod.istio-system.svc:15012
+          value: istiod.{{ .Values.global.istioNamespace }}.svc:15012
         {{- end }}
         resources:
 {{- if .Values.global.proxy.resources }}
@@ -35750,7 +35738,7 @@ data:
     istio_component_namespaces:
       grafana: {{ .Values.global.telemetryNamespace }}
       tracing: {{ .Values.global.telemetryNamespace }}
-      pilot: {{ .Values.global.configNamespace }}
+      pilot: {{ .Values.global.istioNamespace }}
       prometheus: {{ .Values.global.prometheusNamespace }}
     istio_namespace: {{ .Values.global.istioNamespace }}
     auth:
@@ -35772,7 +35760,7 @@ data:
 {{- end }}
     external_services:
       istio:
-        url_service_version: http://istio-pilot.{{ .Values.global.configNamespace }}:8080/version
+        url_service_version: http://istio-pilot.{{ .Values.global.istioNamespace }}:8080/version
       tracing:
         url: {{ .Values.kiali.dashboard.jaegerURL }}
         in_cluster_url: {{ .Values.kiali.dashboard.jaegerInClusterURL }}
@@ -37477,7 +37465,7 @@ data:
             combined_validation_context:
               default_validation_context:
                 verify_subject_alt_name:
-                - spiffe://{{ .Values.global.trustDomain }}/ns/{{ .Values.global.configNamespace }}/sa/istio-galley-service-account
+                - spiffe://{{ .Values.global.trustDomain }}/ns/{{ .Values.global.istioNamespace }}/sa/istio-galley-service-account
               validation_context_sds_secret_config:
                 name: ROOTCA
                 sds_config:
@@ -37488,7 +37476,7 @@ data:
                         cluster_name: sds-grpc
         hosts:
           - socket_address:
-              address: istio-galley.{{ .Values.global.configNamespace }}
+              address: istio-galley.{{ .Values.global.istioNamespace }}
               port_value: 15019
 
 
@@ -37840,7 +37828,7 @@ spec:
     {{- if .Values.global.controlPlaneSecurityEnabled}}
           - --configStoreURL=mcp://localhost:15019
     {{- else }}
-          - --configStoreURL=mcp://istio-galley.{{ .Values.global.configNamespace }}.svc:9901
+          - --configStoreURL=mcp://istio-galley.{{ .Values.global.istioNamespace }}.svc:9901
     {{- end }}
 {{- else }}
           - --configStoreURL=k8s://
@@ -37958,12 +37946,10 @@ spec:
         - name: "ISTIO_META_USER_SDS"
           value: "true"
         - name: CA_ADDR
-          {{- if .Values.global.caAddress }}
+      {{- if .Values.global.caAddress }}
           value: {{ .Values.global.caAddress }}
-          {{- else if .Values.global.configNamespace }}
-          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.configNamespace }}.svc:15012
-          {{- else }}
-          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.istio-system.svc:15012
+      {{- else }}
+          value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
       {{- end }}
         resources:
 {{- if .Values.global.proxy.resources }}
@@ -39507,7 +39493,7 @@ data:
       - role: endpoints
         namespaces:
           names:
-          - {{ .Values.global.configNamespace }}
+          - {{ .Values.global.istioNamespace }}
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
@@ -39520,7 +39506,7 @@ data:
       - role: endpoints
         namespaces:
           names:
-          - {{ .Values.global.configNamespace }}
+          - {{ .Values.global.istioNamespace }}
 
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
@@ -39840,10 +39826,8 @@ spec:
             - name: CA_ADDR
               {{- if .Values.global.caAddress }}
               value: {{ .Values.global.caAddress }}
-              {{- else if .Values.global.configNamespace }}
-              value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.configNamespace }}.svc:15012
               {{- else }}
-              value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.istio-system.svc:15012
+              value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
               {{- end }}
             - name: POD_NAME
               valueFrom:


### PR DESCRIPTION
We no longer have a galley component, so the `global.configNamespace` has lost its meaning. This commit removes it and replaces it with `global.istioNamespace`, with a fallback to `.Release.Namespace` if that is not set.

[x] Installation
