### PR TITLE
fix(vm metadata): automatically fill OWNER info for gce instances

### DIFF
--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -402,6 +402,15 @@ func extractAttributesMetadata(envVars []string, plat platform.Environment, meta
 	}
 	if plat != nil && len(plat.Metadata()) > 0 {
 		meta.PlatformMetadata = plat.Metadata()
+		// unlike k8s deployments where owner info is populated from the injector,
+		// vms must populate owner info from the platform metadata.
+		// TODO: with the advent of WorkloadEntry, this might need to be expanded
+		// to (a) be more general and (b) support workload name and labels extraction
+		if len(meta.Owner) == 0 {
+			// attempt to populate with GCE Owner information. If not a GCE instance,
+			// meta.Owner will remain unset.
+			meta.Owner = platform.GCEOwnerFromMetadata(plat.Metadata())
+		}
 	}
 	meta.ExchangeKeys = metadataExchangeKeys
 }

--- a/pkg/bootstrap/platform/gcp_test.go
+++ b/pkg/bootstrap/platform/gcp_test.go
@@ -193,3 +193,30 @@ func TestGCPMetadata(t *testing.T) {
 		})
 	}
 }
+
+func TestGCEOwnerFromMetadata(t *testing.T) {
+	cases := []struct {
+		name  string
+		input map[string]string
+		want  string
+	}{
+		{"empty", nil, ""},
+		{"no gce meta", map[string]string{"aws_meta": "test"}, ""},
+		{"created-by",
+			map[string]string{GCEInstanceCreatedBy: "projects/1/regions/us-central/instanceGroupManagers/4"},
+			"//compute.googleapis.com/projects/1/regions/us-central/instanceGroupManagers/4",
+		},
+		{"gce instance (not managed)",
+			map[string]string{GCEInstanceID: "14", GCPProjectNumber: "12", GCPLocation: "us-west-1c"},
+			"//compute.googleapis.com/projects/12/zones/us-west-1c/instances/14",
+		},
+	}
+
+	for _, v := range cases {
+		t.Run(v.name, func(tt *testing.T) {
+			if got := GCEOwnerFromMetadata(v.input); !reflect.DeepEqual(got, v.want) {
+				t.Errorf("GCEOwnerFromMetadata(%v) => %q, want: %q", v.input, got, v.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR sets the OWNER metadata automatically from PLATFORM_METADATA information for GCE Instances. This will allow this information to be made available for metadata exchange, as well as other extensions in the Envoy proxies.

OWNER information is automatically populated by the sidecar injector for k8s resources. However, VMs do not use the sidecar injector, and require adding ENV vars to pass in OWNER info (among other bits). This PR reduces that burden for OWNER.

It is expected that other PRs will follow to further ease VM setup, including changes that exploit the ongoing WorkloadEntry work.

[ X ] Policies and Telemetry
