### PR TITLE
Add support for istioctl logging flags to 'manifest generate' and 'apply'

### DIFF
--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -72,6 +72,7 @@ func defaultLogOptions() *log.Options {
 	o.SetOutputLevel("installer", log.WarnLevel)
 	o.SetOutputLevel("translator", log.WarnLevel)
 	o.SetOutputLevel("kube", log.ErrorLevel)
+	o.SetOutputLevel("default", log.WarnLevel)
 
 	return o
 }
@@ -153,12 +154,12 @@ debug and diagnose their Istio mesh.
 	postInstallCmd.AddCommand(Webhook())
 	experimentalCmd.AddCommand(postInstallCmd)
 
-	manifestCmd := mesh.ManifestCmd()
+	manifestCmd := mesh.ManifestCmd(loggingOptions)
 	hideInheritedFlags(manifestCmd, "namespace", "istioNamespace")
 	rootCmd.AddCommand(manifestCmd)
 	operatorCmd := mesh.OperatorCmd()
 	rootCmd.AddCommand(operatorCmd)
-	installCmd := mesh.InstallCmd()
+	installCmd := mesh.InstallCmd(loggingOptions)
 	hideInheritedFlags(installCmd, "namespace", "istioNamespace")
 	rootCmd.AddCommand(installCmd)
 

--- a/operator/cmd/mesh/manifest-apply.go
+++ b/operator/cmd/mesh/manifest-apply.go
@@ -28,6 +28,7 @@ import (
 	"istio.io/istio/operator/pkg/name"
 	"istio.io/istio/operator/pkg/translate"
 	"istio.io/istio/operator/version"
+	"istio.io/pkg/log"
 )
 
 const (
@@ -70,7 +71,7 @@ func addManifestApplyFlags(cmd *cobra.Command, args *manifestApplyArgs) {
 	cmd.PersistentFlags().StringArrayVarP(&args.set, "set", "s", nil, SetFlagHelpStr)
 }
 
-func manifestApplyCmd(rootArgs *rootArgs, maArgs *manifestApplyArgs) *cobra.Command {
+func manifestApplyCmd(rootArgs *rootArgs, maArgs *manifestApplyArgs, logOpts *log.Options) *cobra.Command {
 	return &cobra.Command{
 		Use:   "apply",
 		Short: "Applies an Istio manifest, installing or reconfiguring Istio on a cluster.",
@@ -90,12 +91,12 @@ func manifestApplyCmd(rootArgs *rootArgs, maArgs *manifestApplyArgs) *cobra.Comm
 `,
 		Args: cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runApplyCmd(cmd, rootArgs, maArgs)
+			return runApplyCmd(cmd, rootArgs, maArgs, logOpts)
 		}}
 }
 
 // InstallCmd in an alias for manifest apply.
-func InstallCmd() *cobra.Command {
+func InstallCmd(logOpts *log.Options) *cobra.Command {
 	rootArgs := &rootArgs{}
 	macArgs := &manifestApplyArgs{}
 
@@ -118,7 +119,7 @@ func InstallCmd() *cobra.Command {
 `,
 		Args: cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runApplyCmd(cmd, rootArgs, macArgs)
+			return runApplyCmd(cmd, rootArgs, macArgs, logOpts)
 		}}
 
 	addFlags(mac, rootArgs)
@@ -126,7 +127,7 @@ func InstallCmd() *cobra.Command {
 	return mac
 }
 
-func runApplyCmd(cmd *cobra.Command, rootArgs *rootArgs, maArgs *manifestApplyArgs) error {
+func runApplyCmd(cmd *cobra.Command, rootArgs *rootArgs, maArgs *manifestApplyArgs, logOpts *log.Options) error {
 	l := NewLogger(rootArgs.logToStdErr, cmd.OutOrStdout(), cmd.ErrOrStderr())
 	// Warn users if they use `manifest apply` without any config args.
 	if len(maArgs.inFilenames) == 0 && len(maArgs.set) == 0 && !rootArgs.dryRun && !maArgs.skipConfirmation {
@@ -135,7 +136,7 @@ func runApplyCmd(cmd *cobra.Command, rootArgs *rootArgs, maArgs *manifestApplyAr
 			os.Exit(1)
 		}
 	}
-	if err := configLogs(rootArgs.logToStdErr); err != nil {
+	if err := configLogs(rootArgs.logToStdErr, logOpts); err != nil {
 		return fmt.Errorf("could not configure logs: %s", err)
 	}
 	if err := ApplyManifests(maArgs.set, maArgs.inFilenames, maArgs.force, rootArgs.dryRun, rootArgs.verbose,

--- a/operator/cmd/mesh/manifest-generate.go
+++ b/operator/cmd/mesh/manifest-generate.go
@@ -26,6 +26,7 @@ import (
 	"istio.io/istio/operator/pkg/controlplane"
 	"istio.io/istio/operator/pkg/translate"
 	"istio.io/istio/operator/version"
+	"istio.io/pkg/log"
 
 	"istio.io/istio/operator/pkg/helm"
 
@@ -54,7 +55,7 @@ func addManifestGenerateFlags(cmd *cobra.Command, args *manifestGenerateArgs) {
 	cmd.PersistentFlags().BoolVar(&args.force, "force", false, "Proceed even with validation errors")
 }
 
-func manifestGenerateCmd(rootArgs *rootArgs, mgArgs *manifestGenerateArgs) *cobra.Command {
+func manifestGenerateCmd(rootArgs *rootArgs, mgArgs *manifestGenerateArgs, logOpts *log.Options) *cobra.Command {
 	return &cobra.Command{
 		Use:   "generate",
 		Short: "Generates an Istio install manifest",
@@ -80,13 +81,13 @@ func manifestGenerateCmd(rootArgs *rootArgs, mgArgs *manifestGenerateArgs) *cobr
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			l := NewLogger(rootArgs.logToStdErr, cmd.OutOrStdout(), cmd.ErrOrStderr())
-			return manifestGenerate(rootArgs, mgArgs, l)
+			return manifestGenerate(rootArgs, mgArgs, logOpts, l)
 		}}
 
 }
 
-func manifestGenerate(args *rootArgs, mgArgs *manifestGenerateArgs, l *Logger) error {
-	if err := configLogs(args.logToStdErr); err != nil {
+func manifestGenerate(args *rootArgs, mgArgs *manifestGenerateArgs, logopts *log.Options, l *Logger) error {
+	if err := configLogs(args.logToStdErr, logopts); err != nil {
 		return fmt.Errorf("could not configure logs: %s", err)
 	}
 

--- a/operator/cmd/mesh/manifest.go
+++ b/operator/cmd/mesh/manifest.go
@@ -16,6 +16,7 @@ package mesh
 
 import (
 	"github.com/spf13/cobra"
+
 	"istio.io/pkg/log"
 )
 

--- a/operator/cmd/mesh/manifest.go
+++ b/operator/cmd/mesh/manifest.go
@@ -16,10 +16,11 @@ package mesh
 
 import (
 	"github.com/spf13/cobra"
+	"istio.io/pkg/log"
 )
 
 // ManifestCmd is a group of commands related to manifest generation, installation, diffing and migration.
-func ManifestCmd() *cobra.Command {
+func ManifestCmd(logOpts *log.Options) *cobra.Command {
 	mc := &cobra.Command{
 		Use:   "manifest",
 		Short: "Commands related to Istio manifests",
@@ -34,9 +35,9 @@ func ManifestCmd() *cobra.Command {
 
 	args := &rootArgs{}
 
-	mgc := manifestGenerateCmd(args, mgcArgs)
+	mgc := manifestGenerateCmd(args, mgcArgs, logOpts)
 	mdc := manifestDiffCmd(args, mdcArgs)
-	mac := manifestApplyCmd(args, macArgs)
+	mac := manifestApplyCmd(args, macArgs, logOpts)
 	mvc := manifestVersionsCmd(args, mvArgs)
 	mmc := manifestMigrateCmd(args, mmcArgs)
 

--- a/operator/cmd/mesh/root.go
+++ b/operator/cmd/mesh/root.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 
 	binversion "istio.io/istio/operator/version"
+	"istio.io/pkg/log"
 	"istio.io/pkg/version"
 )
 
@@ -45,7 +46,7 @@ type rootArgs struct {
 
 func addFlags(cmd *cobra.Command, rootArgs *rootArgs) {
 	cmd.PersistentFlags().BoolVarP(&rootArgs.logToStdErr, "logtostderr", "",
-		false, "Send logs to stderr.")
+		true, "Send logs to stderr.")
 	cmd.PersistentFlags().BoolVarP(&rootArgs.dryRun, "dry-run", "",
 		false, "Console/log output only, make no changes.")
 	cmd.PersistentFlags().BoolVarP(&rootArgs.verbose, "verbose", "",
@@ -64,7 +65,7 @@ func GetRootCmd(args []string) *cobra.Command {
 	rootCmd.SetArgs(args)
 	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 
-	rootCmd.AddCommand(ManifestCmd())
+	rootCmd.AddCommand(ManifestCmd(log.DefaultOptions()))
 	rootCmd.AddCommand(ProfileCmd())
 	rootCmd.AddCommand(OperatorCmd())
 	rootCmd.AddCommand(version.CobraCommand())

--- a/operator/cmd/mesh/shared.go
+++ b/operator/cmd/mesh/shared.go
@@ -34,14 +34,13 @@ var (
 )
 
 func initLogsOrExit(args *rootArgs) {
-	if err := configLogs(args.logToStdErr); err != nil {
+	if err := configLogs(args.logToStdErr, log.DefaultOptions()); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Could not configure logs: %s", err)
 		os.Exit(1)
 	}
 }
 
-func configLogs(logToStdErr bool) error {
-	opt := log.DefaultOptions()
+func configLogs(logToStdErr bool, opt *log.Options) error {
 	if logToStdErr {
 		opt.OutputPaths = []string{"stderr"}
 	}


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/22956 and https://github.com/istio/istio/issues/22904

The `istioctl manifest generate` and `apply` create their own logger which did not follow the usual istioctl logging flags (see `istioctl options` for a list).

This causes those commands to use the istioctl root logging config.

Not part of this: Remove the code that recreates the logger out of the subcommands so it doesn't re-do the work the istioctl root does.  Also not part: deprecating `--logtostderr`, which is the operator version of `--log_target=stderr`.