### PR TITLE
increase secret controller test timeout

### DIFF
--- a/pkg/kube/secretcontroller/secretcontroller_test.go
+++ b/pkg/kube/secretcontroller/secretcontroller_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -165,19 +166,19 @@ func Test_SecretController(t *testing.T) {
 					mu.Lock()
 					defer mu.Unlock()
 					return added
-				}).Should(Equal(step.wantAdded))
+				}, 10*time.Second).Should(Equal(step.wantAdded))
 			case step.wantUpdated != "":
 				g.Eventually(func() string {
 					mu.Lock()
 					defer mu.Unlock()
 					return updated
-				}).Should(Equal(step.wantUpdated))
+				}, 10*time.Second).Should(Equal(step.wantUpdated))
 			case step.wantDeleted != "":
 				g.Eventually(func() string {
 					mu.Lock()
 					defer mu.Unlock()
 					return deleted
-				}).Should(Equal(step.wantDeleted))
+				}, 10*time.Second).Should(Equal(step.wantDeleted))
 			default:
 				g.Consistently(func() bool {
 					mu.Lock()


### PR DESCRIPTION
This change aims to reduce the flakiness of the secret controller test, which is currently timing out at 1 second, and accounting for 1 in 6 test flakes in the istio dashboard.

For flake examples, see https://prow.istio.io/view/gcs/istio-prow/pr-logs/pull/istio_istio/22924/unit-tests_istio/11691/ and https://prow.istio.io/view/gcs/istio-prow/pr-logs/pull/istio_istio/22924/unit-tests_istio/11691/