### PR TITLE
Move waitEnvoyReady timeout from 3 seconds to 10 to prevent flakes

### DIFF
--- a/mixer/test/client/env/setup.go
+++ b/mixer/test/client/env/setup.go
@@ -418,7 +418,7 @@ func (s *TestSetup) WaitEnvoyReady() {
 	time.Sleep(1 * time.Second)
 
 	delay := 200 * time.Millisecond
-	total := 3 * time.Second
+	total := 10 * time.Second
 	var stats map[string]uint64
 	for attempt := 0; attempt < int(total/delay); attempt++ {
 		statsURL := fmt.Sprintf("http://localhost:%d/stats?format=json&usedonly", s.Ports().AdminPort)


### PR DESCRIPTION
For examples of flakes see: 
https://prow.istio.io/view/gcs/istio-prow/pr-logs/pull/istio_istio/22719/unit-tests_istio/11322/
https://prow.istio.io/view/gcs/istio-prow/pr-logs/pull/istio_istio/22719/unit-tests_istio/11317/
https://prow.istio.io/view/gcs/istio-prow/pr-logs/pull/istio_istio/22719/unit-tests_istio/11320/
https://prow.istio.io/view/gcs/istio-prow/pr-logs/pull/istio_istio/22822/unit-tests_istio/11510/