### PR TITLE
Fix allowed file path formats for charts

### DIFF
--- a/operator/pkg/helm/helm.go
+++ b/operator/pkg/helm/helm.go
@@ -67,10 +67,8 @@ func NewHelmRenderer(operatorDataDir, helmSubdir, componentName, namespace strin
 	switch {
 	case operatorDataDir == "":
 		return NewVFSRenderer(dir, componentName, namespace), nil
-	case util.IsFilePath(operatorDataDir):
-		return NewFileTemplateRenderer(filepath.Join(operatorDataDir, dir), componentName, namespace), nil
 	default:
-		return nil, fmt.Errorf("unknown helm renderer with ChartsSubdirName=%s", operatorDataDir)
+		return NewFileTemplateRenderer(filepath.Join(operatorDataDir, dir), componentName, namespace), nil
 	}
 }
 


### PR DESCRIPTION
This allows file paths like --charts manifests.
Before, a / or . char was expected in the file path.