### PR TITLE
Allow adding additional metadata exchange keys

### DIFF
--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -376,6 +376,7 @@ func jsonStringToMap(jsonStr string) (m map[string]string) {
 }
 
 func extractAttributesMetadata(envVars []string, plat platform.Environment, meta *model.NodeMetadata) {
+	var additionalMetaExchangeKeys []string
 	for _, varStr := range envVars {
 		name, val := parseEnvVar(varStr)
 		switch name {
@@ -395,12 +396,18 @@ func extractAttributesMetadata(envVars []string, plat platform.Environment, meta
 			meta.WorkloadName = val
 		case "SERVICE_ACCOUNT":
 			meta.ServiceAccount = val
+		case "ISTIO_ADDITIONAL_METADATA_EXCHANGE_KEYS":
+			// comma separated list of keys
+			additionalMetaExchangeKeys = strings.Split(val, ",")
 		}
 	}
 	if plat != nil && len(plat.Metadata()) > 0 {
 		meta.PlatformMetadata = plat.Metadata()
 	}
-	meta.ExchangeKeys = metadataExchangeKeys
+	meta.ExchangeKeys = []string{}
+	meta.ExchangeKeys = append(meta.ExchangeKeys, metadataExchangeKeys...)
+	meta.ExchangeKeys = append(meta.ExchangeKeys, additionalMetaExchangeKeys...)
+
 }
 
 // getNodeMetaData function uses an environment variable contract


### PR DESCRIPTION
Right now, the list is pretty hard coded. We have no way to add any other
additional keys. Our access log receivers utilize this additional metadata (part of every ALS entry).