### PR TITLE
Make missing charts error message more helpful

### DIFF
--- a/operator/pkg/helm/vfs_renderer.go
+++ b/operator/pkg/helm/vfs_renderer.go
@@ -72,12 +72,9 @@ func NewVFSRenderer(helmChartDirPath, componentName, namespace string) *VFSRende
 
 // Run implements the TemplateRenderer interface.
 func (h *VFSRenderer) Run() error {
-	// This can happen if a developer creates binaries using go build instead of make and tries to use compiled in
-	// charts.
-	if _, err := vfs.Stat(ChartsSubdirName); err != nil {
-		return fmt.Errorf("compiled in charts not found in this development build, use --charts with local charts instead or run make gen")
+	if err := CheckCompiledInCharts(); err != nil {
+		return err
 	}
-
 	scope.Debugf("Run VFSRenderer with helmChart=%s, componentName=%s, namespace=%s", h.helmChartDirPath, h.componentName, h.namespace)
 	if err := h.loadChart(); err != nil {
 		return err
@@ -154,4 +151,13 @@ func stripPrefix(path, prefix string) string {
 // list all the builtin profiles.
 func ListBuiltinProfiles() []string {
 	return util.StringBoolMapToSlice(ProfileNames)
+}
+
+// CheckCompiledInCharts tests for the presence of compiled in charts. These can be missing if a developer creates
+// binaries using go build instead of make and tries to use compiled in charts.
+func CheckCompiledInCharts() error {
+	if _, err := vfs.Stat(ChartsSubdirName); err != nil {
+		return fmt.Errorf("compiled in charts not found in this development build, use --charts with local charts instead or run make gen-charts")
+	}
+	return nil
 }

--- a/operator/pkg/name/name.go
+++ b/operator/pkg/name/name.go
@@ -191,6 +191,12 @@ var onceErr error
 
 func ScanBundledAddonComponents(chartsRootDir string) error {
 	scanAddons.Do(func() {
+		if chartsRootDir == "" {
+			if onceErr = helm.CheckCompiledInCharts(); onceErr != nil {
+				return
+			}
+		}
+
 		var addonComponentNames []string
 		addonComponentNames, onceErr = helm.GetAddonNamesFromCharts(chartsRootDir, true)
 		if onceErr != nil {


### PR DESCRIPTION
This path was short-circuiting the error message for missing compiled-in charts. The message now reads as it should:

```bash
$ ic manifest generate
Error: compiled in charts not found in this development build, use --charts with local charts instead or run make gen
exit status 1

$ ic manifest generate --charts ./manifests
<correct output>
```