### PR TITLE
Ensure /opt/ibm/wlp/output/defaultServer is writable to group members

### DIFF
--- a/samples/bookinfo/src/reviews/reviews-wlpcfg/Dockerfile
+++ b/samples/bookinfo/src/reviews/reviews-wlpcfg/Dockerfile
@@ -18,7 +18,8 @@ ENV SERVERDIRNAME reviews
 
 COPY ./servers/LibertyProjectServer /opt/ibm/wlp/usr/servers/defaultServer/
 
-RUN /opt/ibm/wlp/bin/installUtility install  --acceptLicense /opt/ibm/wlp/usr/servers/defaultServer/server.xml
+RUN /opt/ibm/wlp/bin/installUtility install  --acceptLicense /opt/ibm/wlp/usr/servers/defaultServer/server.xml && \
+    chmod -R g=rwx /opt/ibm/wlp/output/defaultServer/
 
 ARG service_version
 ARG enable_ratings


### PR DESCRIPTION
When running the container with a random user id, it failed because
the process couldn't write to /opt/ibm/wlp/output/defaultServer/workarea.