### PR TITLE
Fix EnvoyFilter listener portNumber match

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
@@ -492,6 +492,8 @@ func listenerMatch(listener *xdsapi.Listener, cp *model.EnvoyFilterConfigPatchWr
 	if cMatch.PortNumber != 0 {
 		sockAddr := listener.Address.GetSocketAddress()
 		if (sockAddr == nil || sockAddr.GetPortValue() != cMatch.PortNumber) &&
+			// skip virtual inbound and outbound listener port checks
+			// to support portNumber listener filter field within those special listeners
 			listener.Name != VirtualInboundListenerName && listener.Name != VirtualOutboundListenerName {
 			return false
 		}
@@ -537,7 +539,10 @@ func filterChainMatch(fc *xdslistener.FilterChain, cp *model.EnvoyFilterConfigPa
 		}
 	}
 
-	if cMatch.PortNumber > 0 && fc.FilterChainMatch != nil && fc.FilterChainMatch.DestinationPort != nil && fc.FilterChainMatch.DestinationPort.Value != cMatch.PortNumber {
+	// check match for destination port within the FilterChainMatch
+	if cMatch.PortNumber > 0 &&
+		fc.FilterChainMatch != nil && fc.FilterChainMatch.DestinationPort != nil &&
+		fc.FilterChainMatch.DestinationPort.Value != cMatch.PortNumber {
 		return false
 	}
 


### PR DESCRIPTION
This PR is proposed solution for `portNumber` matching in EnvoyFilters for `virtualInbound` and `virtualOutbound` listeners.

We are writing several WASM filters and in our testing we've found that the `portNumber` filter specified for the listener match in the `EnvoyFilter` custom resource isn't properly handled right now, resulting in the hooks not being invoked on our filter.

The proposed fix has been applied and tested in our own Istio environment at Banzai Cloud and seem to be working fine, let me know if this is acceptable going upstream or there are proposed changes. Also I am about to make a test as well.

Fixes #19549

[x] Networking
