### PR TITLE
[release 1.4] Add annotations for setting cpu/memory limits on sidecar

### DIFF
--- a/install/kubernetes/helm/istio/files/injection-template.yaml
+++ b/install/kubernetes/helm/istio/files/injection-template.yaml
@@ -340,19 +340,30 @@ containers:
     runAsUser: 1337
     {{- end }}
   resources:
-    {{ if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
+{{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+  {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
     requests:
       {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
       cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-      {{ end}}
+      {{ end }}
       {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
       memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
       {{ end }}
-  {{ else -}}
-{{- if .Values.global.proxy.resources }}
+  {{- end }}
+  {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+    limits:
+      {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
+      cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+      {{ end }}
+      {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
+      memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+      {{ end }}
+  {{- end }}
+{{- else }}
+  {{- if .Values.global.proxy.resources }}
     {{ toYaml .Values.global.proxy.resources | indent 4 }}
+  {{- end }}
 {{- end }}
-  {{  end -}}
   volumeMounts:
   {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
   - mountPath: /etc/istio/custom-bootstrap

--- a/pkg/kube/inject/testdata/webhook/resource_annotations.yaml
+++ b/pkg/kube/inject/testdata/webhook/resource_annotations.yaml
@@ -11,7 +11,9 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/proxyCPU: "100m"
+        sidecar.istio.io/proxyCPULimit: "1000m"
         sidecar.istio.io/proxyMemory: "1Gi"
+        sidecar.istio.io/proxyMemoryLimit: "2Gi"
       labels:
         app: resource
     spec:


### PR DESCRIPTION
When a limitrange is active, not setting the limits will result
in an error. This patch will allow setting limits for the sidecar.

Fixes #16126