### PR TITLE
server: disable go grpc tracing

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -81,9 +81,8 @@ var (
 )
 
 func init() {
-	// get the grpc server wired up
-	// This should only be set before any RPCs are sent or received by this program.
-	grpc.EnableTracing = true
+	// Disable gRPC tracing. It has performance impacts (See https://github.com/grpc/grpc-go/issues/695)
+	grpc.EnableTracing = false
 
 	// Export pilot version as metric for fleet analytics.
 	pilotVersion := prom.NewGaugeVec(prom.GaugeOpts{


### PR DESCRIPTION
This PR disables go gRPC tracing. It seems to have some performance issues https://github.com/grpc/grpc-go/issues/695. Also not sure if we are using this any where. If we are using it and it is useful, I can make it configurable.