### PR TITLE
server: rename some functions and variables in server

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -112,18 +112,18 @@ type Server struct {
 	kubeClient       kubernetes.Interface
 	metadataClient   metadata.Interface
 
-	startFuncs          []startFunc
-	multicluster        *kubecontroller.Multicluster
-	httpServer          *http.Server // debug
-	httpsServer         *http.Server // webhooks
-	httpsReadyClient    *http.Client
-	grpcServer          *grpc.Server
-	secureGRPCServerDNS *grpc.Server
-	mux                 *http.ServeMux // debug
-	httpsMux            *http.ServeMux // webhooks
-	kubeRegistry        *kubecontroller.Controller
-	certController      *chiron.WebhookController
-	ca                  *ca.IstioCA
+	startFuncs       []startFunc
+	multicluster     *kubecontroller.Multicluster
+	httpServer       *http.Server // debug HTTP Server.
+	httpsServer      *http.Server // webhooks HTTPS Server.
+	httpsReadyClient *http.Client
+	grpcServer       *grpc.Server
+	secureGrpcServer *grpc.Server   //
+	mux              *http.ServeMux // debug
+	httpsMux         *http.ServeMux // webhooks
+	kubeRegistry     *kubecontroller.Controller
+	certController   *chiron.WebhookController
+	ca               *ca.IstioCA
 	// path to the caBundle that signs the DNS certs. This should be agnostic to provider.
 	caBundlePath string
 
@@ -131,10 +131,10 @@ type Server struct {
 
 	serviceEntryStore *external.ServiceEntryStore
 
-	HTTPListener    net.Listener
-	GRPCListener    net.Listener
-	GRPCDNSListener net.Listener
-	DNSListener     net.Listener
+	HTTPListener       net.Listener
+	GRPCListener       net.Listener
+	SecureGrpcListener net.Listener
+	DNSListener        net.Listener
 
 	// for test
 	forceStop bool
@@ -167,104 +167,101 @@ func NewServer(args *PilotArgs) (*Server, error) {
 		mux:            http.NewServeMux(),
 	}
 
-	log.Infof("Primary Cluster name: %s", s.clusterID)
-
 	prometheus.EnableHandlingTimeHistogram()
 
 	// Apply the arguments to the configuration.
 	if err := s.initKubeClient(args); err != nil {
-		return nil, fmt.Errorf("kube client: %v", err)
+		return nil, fmt.Errorf("error initializing kube client: %v", err)
 	}
 	fileWatcher := filewatcher.NewWatcher()
 	if err := s.initMeshConfiguration(args, fileWatcher); err != nil {
-		return nil, fmt.Errorf("mesh: %v", err)
+		return nil, fmt.Errorf("error initializing mesh config: %v", err)
 	}
 	s.initMeshNetworks(args, fileWatcher)
-	// Certificate controller is created before MCP
-	// controller in case MCP server pod waits to mount a certificate
-	// to be provisioned by the certificate controller.
+
+	// Certificate controller is created before MCP controller in case MCP server pod
+	// waits to mount a certificate to be provisioned by the certificate controller.
 	if err := s.initCertController(args); err != nil {
-		return nil, fmt.Errorf("certificate controller: %v", err)
+		return nil, fmt.Errorf("error initializing certificate controller: %v", err)
 	}
 	if err := s.initConfigController(args); err != nil {
-		return nil, fmt.Errorf("config controller: %v", err)
+		return nil, fmt.Errorf("error initializing config controller: %v", err)
 	}
 	if err := s.initServiceControllers(args); err != nil {
-		return nil, fmt.Errorf("service controllers: %v", err)
+		return nil, fmt.Errorf("error initializing service controllers: %v", err)
 	}
 
 	// Options based on the current 'defaults' in istio.
-	// If adjustments are needed - env or mesh.config ( if of general interest ).
 	caOpts := &CAOptions{
 		TrustDomain: s.environment.Mesh().TrustDomain,
 		Namespace:   args.Namespace,
 	}
 
-	// CA signing certificate must be created first.
-	if features.JwtPolicy.Get() == jwt.JWTPolicyThirdPartyJWT {
-		log.Info("JWT policy is third-party-jwt")
+	log.Infof("JWT policy is %s", features.JwtPolicy.Get())
+	switch features.JwtPolicy.Get() {
+	case jwt.JWTPolicyThirdPartyJWT:
 		s.jwtPath = ThirdPartyJWTPath
-	} else if features.JwtPolicy.Get() == jwt.JWTPolicyFirstPartyJWT {
-		log.Info("JWT policy is first-party-jwt")
+	case jwt.JWTPolicyFirstPartyJWT:
 		s.jwtPath = securityModel.K8sSAJwtFileName
-	} else {
+	default:
 		err := fmt.Errorf("invalid JWT policy %v", features.JwtPolicy.Get())
 		log.Errorf("%v", err)
 		return nil, err
 	}
+
+	// CA signing certificate must be created first.
 	if s.EnableCA() {
 		var err error
 		var corev1 v1.CoreV1Interface
 		if s.kubeClient != nil {
 			corev1 = s.kubeClient.CoreV1()
 		}
-		// May return nil, if the CA is missing required configs.
-		// This is not an error.
+		// May return nil, if the CA is missing required configs - This is not an error.
 		s.ca, err = s.createCA(corev1, caOpts)
 		if err != nil {
-			return nil, fmt.Errorf("enableCA: %v", err)
+			return nil, fmt.Errorf("failied to create CA: %v", err)
 		}
 		err = s.initPublicKey()
 		if err != nil {
-			return nil, fmt.Errorf("init public key: %v", err)
+			return nil, fmt.Errorf("error initializing public key: %v", err)
 		}
 	}
 
-	// initDNSListener() must be called after the createCA()
-	// because initDNSListener() may use a Citadel generated cert.
-	if err := s.initDNSListener(args); err != nil {
-		return nil, fmt.Errorf("grpcDNS: %v", err)
+	// Secure gRPC Server must be initialized after CA is created as may use a Citadel generated cert.
+	if err := s.initSecureGrpcListener(args); err != nil {
+		return nil, fmt.Errorf("error initializing secure gRPC Listener: %v", err)
 	}
+
 	// common https server for webhooks (e.g. injection, validation)
 	if err := s.initHTTPSWebhookServer(args); err != nil {
 		// Not crashing istiod - existing pods will keep working, new pods
 		// may fail if all webhook injectors are down.
 		// This typically happens if certs are missing.
-		log.Errorf("failed to start injectionWebhook server: %v", err)
+		log.Errorf("error initializing injection webhook server: %v", err)
 	}
 	// Will run the sidecar injector in pilot.
 	// Only operates if /var/lib/istio/inject exists
 	if err := s.initSidecarInjector(args); err != nil {
-		return nil, fmt.Errorf("sidecar injector: %v", err)
+		return nil, fmt.Errorf("error initializing sidecar injector: %v", err)
 	}
 	// Will run the config validater in pilot.
 	// Only operates if /var/lib/istio/validation exists
 	if err := s.initConfigValidation(args); err != nil {
-		return nil, fmt.Errorf("config validation: %v", err)
+		return nil, fmt.Errorf("error initializing config validator: %v", err)
 	}
 	if err := s.initDiscoveryService(args); err != nil {
-		return nil, fmt.Errorf("discovery service: %v", err)
+		return nil, fmt.Errorf("error initializing discovery service: %v", err)
 	}
 	if err := s.initMonitor(args.DiscoveryOptions.MonitoringAddr); err != nil {
-		return nil, fmt.Errorf("monitor: %v", err)
+		return nil, fmt.Errorf("error initializing monitor: %v", err)
 	}
 	if err := s.initClusterRegistries(args); err != nil {
-		return nil, fmt.Errorf("cluster registries: %v", err)
+		return nil, fmt.Errorf("error initializing cluster registries: %v", err)
 	}
 
 	if dns.DNSAddr.Get() != "" {
 		if err := s.initDNSTLSListener(dns.DNSAddr.Get()); err != nil {
-			log.Warna("Failed to start DNS-over-TLS listener ", err)
+			log.Warna("error initializing DNS-over-TLS listener ", err)
 		}
 
 		// Respond to CoreDNS gRPC queries.
@@ -281,10 +278,10 @@ func NewServer(args *PilotArgs) (*Server, error) {
 	// RunCA() must be called after createCA() and initDNSListener()
 	// because it depends on the following conditions:
 	// 1) CA certificate has been created.
-	// 2) grpc server has been generated.
+	// 2) grpc server has been started.
 	if s.ca != nil {
 		s.addStartFunc(func(stop <-chan struct{}) error {
-			s.RunCA(s.secureGRPCServerDNS, s.ca, caOpts)
+			s.RunCA(s.secureGrpcServer, s.ca, caOpts)
 			return nil
 		})
 
@@ -334,6 +331,8 @@ func getClusterID(args *PilotArgs) string {
 // If Port == 0, a port number is automatically chosen. Content serving is started by this method,
 // but is executed asynchronously. Serving can be canceled at any time by closing the provided stop channel.
 func (s *Server) Start(stop <-chan struct{}) error {
+	log.Infof("Staring Istiod Server with primary cluster %s", s.clusterID)
+
 	// Now start all of the components.
 	for _, fn := range s.startFuncs {
 		if err := fn(stop); err != nil {
@@ -342,13 +341,13 @@ func (s *Server) Start(stop <-chan struct{}) error {
 	}
 	// Race condition - if waitForCache is too fast and we run this as a startup function,
 	// the grpc server would be started before CA is registered. Listening should be last.
-	if s.GRPCDNSListener != nil {
+	if s.SecureGrpcListener != nil {
 		go func() {
 			if !s.waitForCacheSync(stop) {
 				return
 			}
-			log.Infof("starting secure (DNS) gRPC discovery service at %s", s.GRPCDNSListener.Addr())
-			if err := s.secureGRPCServerDNS.Serve(s.GRPCDNSListener); err != nil {
+			log.Infof("starting secure (DNS) gRPC discovery service at %s", s.SecureGrpcListener.Addr())
+			if err := s.secureGrpcServer.Serve(s.SecureGrpcListener); err != nil {
 				log.Errorf("error from GRPC server: %v", err)
 			}
 		}()
@@ -570,7 +569,7 @@ func (s *Server) initDNSTLSListener(dns string) error {
 }
 
 // initialize secureGRPCServer - using DNS certs
-func (s *Server) initSecureGrpcServerDNS(port string, keepalive *istiokeepalive.Options) error {
+func (s *Server) initSecureGrpcServer(port string, keepalive *istiokeepalive.Options) error {
 	certDir := dnsCertDir
 
 	key := path.Join(certDir, constants.KeyFilename)
@@ -594,25 +593,25 @@ func (s *Server) initSecureGrpcServerDNS(port string, keepalive *istiokeepalive.
 	tlsCreds := credentials.NewTLS(cfg)
 
 	// Default is 15012 - istio-agent relies on this as a default to distinguish what cert auth to expect
-	dnsGrpc := fmt.Sprintf(":%s", port)
+	secureGrpc := fmt.Sprintf(":%s", port)
 
 	// create secure grpc listener
-	l, err := net.Listen("tcp", dnsGrpc)
+	l, err := net.Listen("tcp", secureGrpc)
 	if err != nil {
 		return err
 	}
-	s.GRPCDNSListener = l
+	s.SecureGrpcListener = l
 
 	opts := s.grpcServerOptions(keepalive)
 	opts = append(opts, grpc.Creds(tlsCreds))
 
-	s.secureGRPCServerDNS = grpc.NewServer(opts...)
-	s.EnvoyXdsServer.Register(s.secureGRPCServerDNS)
+	s.secureGrpcServer = grpc.NewServer(opts...)
+	s.EnvoyXdsServer.Register(s.secureGrpcServer)
 
 	s.addStartFunc(func(stop <-chan struct{}) error {
 		go func() {
 			<-stop
-			s.secureGRPCServerDNS.Stop()
+			s.secureGrpcServer.Stop()
 		}()
 		return nil
 	})
@@ -674,7 +673,7 @@ func (s *Server) addTerminatingStartFunc(fn startFunc) {
 
 func (s *Server) waitForCacheSync(stop <-chan struct{}) bool {
 	// TODO: remove dependency on k8s lib
-	// TODO: set a limit, panic otherwise ( to not hide the error )
+	// TODO: set a limit, panic otherwise (to not hide the error)
 	if !cache.WaitForCacheSync(stop, func() bool {
 		if s.kubeRegistry != nil {
 			if !s.kubeRegistry.HasSynced() {
@@ -765,8 +764,8 @@ func (s *Server) initEventHandlers() error {
 	return nil
 }
 
-// add a GRPC listener using DNS-based certificates. Will be used for Galley, injection and CA signing.
-func (s *Server) initDNSListener(args *PilotArgs) error {
+// add a GRPC listener using DNS-based certificates
+func (s *Server) initSecureGrpcListener(args *PilotArgs) error {
 	istiodAddr := features.IstiodService.Get()
 	if istiodAddr == "" {
 		// Feature disabled
@@ -783,7 +782,7 @@ func (s *Server) initDNSListener(args *PilotArgs) error {
 		return fmt.Errorf("invalid ISTIOD_ADDR(%s): %v", istiodAddr, err)
 	}
 	if _, err := strconv.Atoi(port); err != nil {
-		return fmt.Errorf("invalid ISTIOD_ADDR(%s): %v", istiodAddr, err)
+		return fmt.Errorf("invalid port(%s) in ISTIOD_ADDR(%s): %v", port, istiodAddr, err)
 	}
 
 	// Create DNS certificates. This allows injector, validation to work without Citadel, and
@@ -794,7 +793,7 @@ func (s *Server) initDNSListener(args *PilotArgs) error {
 	}
 
 	// run secure grpc server for Istiod - using DNS-based certs from K8S
-	err = s.initSecureGrpcServerDNS(port, args.KeepaliveOptions)
+	err = s.initSecureGrpcServer(port, args.KeepaliveOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/test/framework/components/pilot/native.go
+++ b/pkg/test/framework/components/pilot/native.go
@@ -189,5 +189,5 @@ func (c *nativeComponent) GetDiscoveryAddress() *net.TCPAddr {
 
 // GetSecureDiscoveryAddress gets the discovery address for pilot.
 func (c *nativeComponent) GetSecureDiscoveryAddress() *net.TCPAddr {
-	return c.server.GRPCDNSListener.Addr().(*net.TCPAddr)
+	return c.server.SecureGrpcListener.Addr().(*net.TCPAddr)
 }


### PR DESCRIPTION
The server.go function names are confusing - With the introduction of new DNS support the earlier names used for securegRPC server with DNS certs are confusing. This PR renames them to secureGrpc*** to avoid conflicting with the DNS support.