### PR TITLE
Use proper .kube/config file

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -440,8 +440,8 @@ ifeq ($(WHAT),)
 else
        TEST_OBJ = selected-pkg-test
 endif
+
 test: | $(JUNIT_REPORT)
-	KUBECONFIG="$${KUBECONFIG:-$${REPO_ROOT}/tests/util/kubeconfig}" \
 	$(MAKE) -e -f Makefile.core.mk --keep-going $(TEST_OBJ) \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
 

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -47,7 +47,7 @@ endif
 
 # If neither $(INTEGRATION_TEST_KUBECONFIG) nor $(KUBECONFIG) specified, use default.
 ifeq ($(_INTEGRATION_TEST_KUBECONFIG),)
-    _INTEGRATION_TEST_KUBECONFIG = ~/.kube/config
+    _INTEGRATION_TEST_KUBECONFIG = /home/.kube/config
 endif
 
 _INTEGRATION_TEST_FLAGS += --istio.test.kube.config=$(_INTEGRATION_TEST_KUBECONFIG)


### PR DESCRIPTION
If using a K8s environment and KUBECONFIG is not set, use the K8s kubeconfig file in all integration testing.


Depends-On: https://github.com/istio/tools/pull/899
Depends-On: https://github.com/istio/tools/pull/900