### PR TITLE
authz: only use url_path for Envoy version >= 1.5

### DIFF
--- a/pilot/pkg/networking/plugin/authz/authorization.go
+++ b/pilot/pkg/networking/plugin/authz/authorization.go
@@ -18,6 +18,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking"
 	"istio.io/istio/pilot/pkg/networking/plugin"
+	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/security/authz/builder"
 	"istio.io/istio/pilot/pkg/security/trustdomain"
 	"istio.io/istio/pkg/config/labels"
@@ -80,7 +81,7 @@ func buildFilter(in *plugin.InputParams, mutable *networking.MutableObjects) {
 	tdBundle := trustdomain.NewBundle(spiffe.GetTrustDomain(), in.Push.Mesh.TrustDomainAliases)
 	namespace := in.Node.ConfigNamespace
 	workload := labels.Collection{in.Node.Metadata.Labels}
-	b := builder.New(tdBundle, workload, namespace, in.Push.AuthzPolicies)
+	b := builder.New(tdBundle, workload, namespace, in.Push.AuthzPolicies, util.IsIstioVersionGE15(in.Node))
 	if b == nil {
 		authzLog.Debugf("no authorization policy for workload %v in %s", workload, namespace)
 		return

--- a/pilot/pkg/security/authz/builder/builder_test.go
+++ b/pilot/pkg/security/authz/builder/builder_test.go
@@ -46,11 +46,23 @@ var (
 
 func TestGenerator_GenerateHTTP(t *testing.T) {
 	testCases := []struct {
-		name     string
-		tdBundle trustdomain.Bundle
-		input    string
-		want     []string
+		name        string
+		tdBundle    trustdomain.Bundle
+		isVersion14 bool
+		input       string
+		want        []string
 	}{
+		{
+			name:        "path14",
+			input:       "path14-in.yaml",
+			isVersion14: true,
+			want:        []string{"path14-out.yaml"},
+		},
+		{
+			name:  "path15",
+			input: "path15-in.yaml",
+			want:  []string{"path15-out.yaml"},
+		},
 		{
 			name:  "action-both",
 			input: "action-both-in.yaml",
@@ -111,7 +123,7 @@ func TestGenerator_GenerateHTTP(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			g := New(tc.tdBundle, httpbin, "foo", yamlPolicy(t, basePath+tc.input))
+			g := New(tc.tdBundle, httpbin, "foo", yamlPolicy(t, basePath+tc.input), !tc.isVersion14)
 			if g == nil {
 				t.Fatalf("failed to create generator")
 			}
@@ -142,7 +154,7 @@ func TestGenerator_GenerateTCP(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			g := New(tc.tdBundle, httpbin, "foo", yamlPolicy(t, basePath+tc.input))
+			g := New(tc.tdBundle, httpbin, "foo", yamlPolicy(t, basePath+tc.input), true)
 			if g == nil {
 				t.Fatalf("failed to create generator")
 			}

--- a/pilot/pkg/security/authz/builder/testdata/path14-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/path14-in.yaml
@@ -1,0 +1,15 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: httpbin-1
+  namespace: foo
+spec:
+  selector:
+    matchLabels:
+      app: httpbin
+      version: v1
+  rules:
+    - to:
+        - operation:
+            paths: ["/exact", "/prefix/*", "*/suffix", "*"]
+            notPaths: ["/not-exact", "/not-prefix/*", "*/not-suffix", "*"]

--- a/pilot/pkg/security/authz/builder/testdata/path14-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/path14-out.yaml
@@ -1,0 +1,42 @@
+name: envoy.filters.http.rbac
+typedConfig:
+  '@type': type.googleapis.com/envoy.config.filter.http.rbac.v2.RBAC
+  rules:
+    policies:
+      ns[foo]-policy[httpbin-1]-rule[0]:
+        permissions:
+        - andRules:
+            rules:
+            - orRules:
+                rules:
+                - header:
+                    exactMatch: /exact
+                    name: :path
+                - header:
+                    name: :path
+                    prefixMatch: /prefix/
+                - header:
+                    name: :path
+                    suffixMatch: /suffix
+                - header:
+                    name: :path
+                    presentMatch: true
+            - notRule:
+                orRules:
+                  rules:
+                  - header:
+                      exactMatch: /not-exact
+                      name: :path
+                  - header:
+                      name: :path
+                      prefixMatch: /not-prefix/
+                  - header:
+                      name: :path
+                      suffixMatch: /not-suffix
+                  - header:
+                      name: :path
+                      presentMatch: true
+        principals:
+        - andIds:
+            ids:
+            - any: true

--- a/pilot/pkg/security/authz/builder/testdata/path15-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/path15-in.yaml
@@ -1,0 +1,15 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: httpbin-1
+  namespace: foo
+spec:
+  selector:
+    matchLabels:
+      app: httpbin
+      version: v1
+  rules:
+    - to:
+        - operation:
+            paths: ["/exact", "/prefix/*", "*/suffix", "*"]
+            notPaths: ["/not-exact", "/not-prefix/*", "*/not-suffix", "*"]

--- a/pilot/pkg/security/authz/builder/testdata/path15-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/path15-out.yaml
@@ -1,0 +1,46 @@
+name: envoy.filters.http.rbac
+typedConfig:
+  '@type': type.googleapis.com/envoy.config.filter.http.rbac.v2.RBAC
+  rules:
+    policies:
+      ns[foo]-policy[httpbin-1]-rule[0]:
+        permissions:
+        - andRules:
+            rules:
+            - orRules:
+                rules:
+                - urlPath:
+                    path:
+                      exact: /exact
+                - urlPath:
+                    path:
+                      prefix: /prefix/
+                - urlPath:
+                    path:
+                      suffix: /suffix
+                - urlPath:
+                    path:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .+
+            - notRule:
+                orRules:
+                  rules:
+                  - urlPath:
+                      path:
+                        exact: /not-exact
+                  - urlPath:
+                      path:
+                        prefix: /not-prefix/
+                  - urlPath:
+                      path:
+                        suffix: /not-suffix
+                  - urlPath:
+                      path:
+                        safeRegex:
+                          googleRe2: {}
+                          regex: .+
+        principals:
+        - andIds:
+            ids:
+            - any: true

--- a/pilot/pkg/security/authz/model/generator.go
+++ b/pilot/pkg/security/authz/model/generator.go
@@ -243,11 +243,17 @@ func (hostGenerator) principal(key, value string, forTCP bool) (*rbacpb.Principa
 }
 
 type pathGenerator struct {
+	isIstioVersionGE15 bool
 }
 
-func (pathGenerator) permission(key, value string, forTCP bool) (*rbacpb.Permission, error) {
+func (g pathGenerator) permission(key, value string, forTCP bool) (*rbacpb.Permission, error) {
 	if forTCP {
 		return nil, fmt.Errorf("%s must not be used in TCP", key)
+	}
+
+	if !g.isIstioVersionGE15 {
+		m := matcher.HeaderMatcher(":path", value)
+		return permissionHeader(m), nil
 	}
 
 	m := matcher.PathMatcher(value)

--- a/pilot/pkg/security/authz/model/generator_test.go
+++ b/pilot/pkg/security/authz/model/generator_test.go
@@ -227,8 +227,17 @@ func TestGenerator(t *testing.T) {
           name: :authority`),
 		},
 		{
-			name:  "pathGenerator",
-			g:     pathGenerator{},
+			name:  "pathGenerator14",
+			g:     pathGenerator{isIstioVersionGE15: false},
+			value: "/abc",
+			want: yamlPermission(t, `
+         header:
+          exactMatch: /abc
+          name: :path`),
+		},
+		{
+			name:  "pathGenerator15",
+			g:     pathGenerator{isIstioVersionGE15: true},
 			value: "/abc",
 			want: yamlPermission(t, `
          urlPath:

--- a/pilot/pkg/security/authz/model/model.go
+++ b/pilot/pkg/security/authz/model/model.go
@@ -77,7 +77,7 @@ type Model struct {
 }
 
 // New returns a model representing a single authorization policy.
-func New(r *authzpb.Rule) (*Model, error) {
+func New(r *authzpb.Rule, isIstioVersionGE15 bool) (*Model, error) {
 	m := Model{}
 
 	basePermission := ruleList{}
@@ -134,7 +134,7 @@ func New(r *authzpb.Rule) (*Model, error) {
 		merged := basePermission
 		if o := to.Operation; o != nil {
 			merged.insertAt(first, destPortGenerator{}, attrDestPort, o.Ports, o.NotPorts)
-			merged.insertAt(first, pathGenerator{}, pathMatcher, o.Paths, o.NotPaths)
+			merged.insertAt(first, pathGenerator{isIstioVersionGE15: isIstioVersionGE15}, pathMatcher, o.Paths, o.NotPaths)
 			merged.insertAt(first, methodGenerator{}, methodHeader, o.Methods, o.NotMethods)
 			merged.insertAt(first, hostGenerator{}, hostHeader, o.Hosts, o.NotHosts)
 		}

--- a/pilot/pkg/security/authz/model/model_test.go
+++ b/pilot/pkg/security/authz/model/model_test.go
@@ -78,7 +78,7 @@ when:
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := New(tc.rule)
+			got, err := New(tc.rule, true)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -213,7 +213,7 @@ when:
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			m, err := New(tc.rule)
+			m, err := New(tc.rule, true)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
This PR fixes a bug in authz plugin that may use the `url_path` field in unsupported Envoy versions (< 1.5) which could cause problems in upgrade (See https://github.com/istio/istio/issues/23064).

After this PR, it should only use `url_path` in Envoy versions >= 1.5.