### PR TITLE
istioctl x precheck

### DIFF
--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -139,6 +139,7 @@ debug and diagnose their Istio mesh.
 	rootCmd.AddCommand(Analyze())
 
 	rootCmd.AddCommand(install.NewVerifyCommand())
+	experimentalCmd.AddCommand(install.NewPrecheckCommand())
 	experimentalCmd.AddCommand(AuthZ())
 	rootCmd.AddCommand(seeExperimentalCmd("authz"))
 	experimentalCmd.AddCommand(graduatedCmd("convert-ingress"))

--- a/istioctl/pkg/install/pre-check.go
+++ b/istioctl/pkg/install/pre-check.go
@@ -16,6 +16,7 @@ package install
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -24,12 +25,22 @@ import (
 	"strings"
 
 	multierror "github.com/hashicorp/go-multierror"
+	"github.com/spf13/cobra"
 	authorizationapi "k8s.io/api/authorization/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+
+	"istio.io/istio/istioctl/pkg/clioptions"
+	operator_istio "istio.io/istio/operator/pkg/apis/istio"
+	operator_v1alpha1 "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
+	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 )
 
 const (
@@ -37,19 +48,29 @@ const (
 )
 
 var (
-	clientExecFactory = createKubeClient
+	clientFactory = createKubeClient
 )
 
+type istioInstall struct {
+	namespace string
+	revision  string
+}
+
 type preCheckClient struct {
-	client *kubernetes.Clientset
+	client  *kubernetes.Clientset
+	dclient dynamic.Interface
 }
 type preCheckExecClient interface {
 	getNameSpace(ns string) (*v1.Namespace, error)
 	serverVersion() (*version.Info, error)
 	checkAuthorization(s *authorizationapi.SelfSubjectAccessReview) (result *authorizationapi.SelfSubjectAccessReview, err error)
 	checkMutatingWebhook() error
+	getIstioInstalls() ([]istioInstall, error)
 }
 
+// Tell the user if Istio can be installed, and if not give the reason.
+// Note: this doesn't check the IstioOperator options.  It only checks a few things every
+// Istio install needs.  It does not check the Revision.
 func installPreCheck(istioNamespaceFlag string, restClientGetter genericclioptions.RESTClientGetter, writer io.Writer) error {
 	fmt.Fprintf(writer, "\n")
 	fmt.Fprintf(writer, "Checking the cluster to make sure it is ready for Istio installation...\n")
@@ -57,7 +78,7 @@ func installPreCheck(istioNamespaceFlag string, restClientGetter genericclioptio
 	fmt.Fprintf(writer, "#1. Kubernetes-api\n")
 	fmt.Fprintf(writer, "-----------------------\n")
 	var errs error
-	c, err := clientExecFactory(restClientGetter)
+	c, err := clientFactory(restClientGetter)
 	if err != nil {
 		errs = multierror.Append(errs, fmt.Errorf("failed to initialize the Kubernetes client: %v", err))
 		fmt.Fprintf(writer, "Failed to initialize the Kubernetes client: %v.\n", err)
@@ -91,14 +112,8 @@ func installPreCheck(istioNamespaceFlag string, restClientGetter genericclioptio
 	fmt.Fprintf(writer, "\n")
 	fmt.Fprintf(writer, "#3. Istio-existence\n")
 	fmt.Fprintf(writer, "-----------------------\n")
-	_, err = c.getNameSpace(istioNamespaceFlag)
-	if err == nil {
-		msg := fmt.Sprintf("Istio cannot be installed because the Istio namespace '%v' is already in use", istioNamespaceFlag)
-		errs = multierror.Append(errs, errors.New(msg))
-		fmt.Fprintf(writer, msg+"\n")
-	} else {
-		fmt.Fprintf(writer, "Istio will be installed in the %v namespace.\n", istioNamespaceFlag)
-	}
+	_, _ = c.getNameSpace(istioNamespaceFlag)
+	fmt.Fprintf(writer, "Istio will be installed in the %v namespace.\n", istioNamespaceFlag)
 
 	fmt.Fprintf(writer, "\n")
 	fmt.Fprintf(writer, "#4. Kubernetes-setup\n")
@@ -278,7 +293,11 @@ func createKubeClient(restClientGetter genericclioptions.RESTClientGetter) (preC
 	if err != nil {
 		return nil, err
 	}
-	return &preCheckClient{client: k}, nil
+	dk, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return nil, err
+	}
+	return &preCheckClient{client: k, dclient: dk}, nil
 }
 
 func (c *preCheckClient) serverVersion() (*version.Info, error) {
@@ -299,4 +318,187 @@ func (c *preCheckClient) checkAuthorization(s *authorizationapi.SelfSubjectAcces
 func (c *preCheckClient) checkMutatingWebhook() error {
 	_, err := c.client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().List(context.TODO(), meta_v1.ListOptions{})
 	return err
+}
+
+func (c *preCheckClient) getIstioInstalls() ([]istioInstall, error) {
+	return findIstios(c.dclient)
+}
+
+// NewPrecheckCommand creates a new command for checking a Kubernetes cluster for Istio compatibility
+func NewPrecheckCommand() *cobra.Command {
+	var (
+		kubeConfigFlags = &genericclioptions.ConfigFlags{
+			Context:    strPtr(""),
+			Namespace:  strPtr(""),
+			KubeConfig: strPtr(""),
+		}
+
+		filenames     = []string{}
+		fileNameFlags = &genericclioptions.FileNameFlags{
+			Filenames: &filenames,
+			Recursive: boolPtr(false),
+			Usage:     "Istio YAML installation file.",
+		}
+		istioNamespace string
+		opts           clioptions.ControlPlaneOptions
+	)
+	precheckCmd := &cobra.Command{
+		Use:   "precheck [-f <deployment or istio operator file>]",
+		Short: "Checks Istio cluster compatibility",
+		Long: `
+		precheck inspects a Kubernetes cluster for Istio install requirements.
+`,
+		Example: `
+		# Verify that Istio can be installed
+		istioctl experimental precheck
+
+		# Verify the deployment matches a custom Istio deployment configuration
+		istioctl x precheck --set profile=demo
+
+		# Verify the deployment matches the Istio Operator deployment definition
+		istioctl x precheck -f iop.yaml
+`,
+		Args: cobra.ExactArgs(0),
+		RunE: func(c *cobra.Command, args []string) error {
+			targetNamespace := istioNamespace
+			targetRevision := opts.Revision
+			specific := c.Flags().Changed("istioNamespace") // is user asking about a specific Istio System ns or revision
+
+			// Check if we can install the IOP specified with -f
+			if len(fileNameFlags.ToOptions().Filenames) > 0 {
+				iop, err := getIOPFromFile(kubeConfigFlags, fileNameFlags.ToOptions())
+				if err != nil {
+					return err
+				}
+				// Currently we don't look at specific IOP options, just the namespace and Revision
+				targetNamespace = iop.GetNamespace()
+				targetRevision = iop.Spec.Revision
+				specific = true
+			}
+
+			cli, err := clientFactory(kubeConfigFlags)
+			if err != nil {
+				return err
+			}
+
+			installs, err := cli.getIstioInstalls()
+			if err == nil && len(installs) > 0 {
+				matched := false
+				for _, install := range installs {
+					if !specific || targetNamespace == install.namespace && targetRevision == install.revision {
+						c.Printf("Istio Revision %q already installed in namespace %q\n", install.revision, install.namespace)
+					}
+					if targetNamespace == install.namespace && targetRevision == install.revision {
+						matched = true
+					}
+				}
+				// The user has Istio, but wants to install a new revision
+				if !matched {
+					return installPreCheck(targetNamespace, kubeConfigFlags, c.OutOrStdout())
+				}
+				return nil
+			}
+
+			// No IstioOperator was found.  In 1.6.0 we fall back to checking for Istio namespace
+			nsExists, err := namespaceExists(targetNamespace, kubeConfigFlags)
+			if err != nil {
+				return err
+			}
+			if !nsExists {
+				return installPreCheck(targetNamespace, kubeConfigFlags, c.OutOrStdout())
+			}
+
+			// The Istio namespace does exist, but it wasn't installed by 1.6.0+ because no
+			// IstioOperator is there.
+			c.Printf("Istio already installed in namespace %q\n.  Skipping pre-check.", targetNamespace)
+			c.Printf("Use 'istioctl upgrade' to upgrade or 'istioctl install --set revision=<revision>' to install another control plane.")
+			return nil
+		},
+	}
+
+	flags := precheckCmd.PersistentFlags()
+	flags.StringVarP(&istioNamespace, "istioNamespace", "i", controller.IstioNamespace,
+		"Istio system namespace")
+	kubeConfigFlags.AddFlags(flags)
+	fileNameFlags.AddFlags(flags)
+	opts.AttachControlPlaneFlags(precheckCmd)
+	return precheckCmd
+}
+
+func findIstios(client dynamic.Interface) ([]istioInstall, error) {
+	retval := make([]istioInstall, 0)
+
+	// First, look for IstioOperator CRs left by 'istioctl manifest apply' or 'kubectl apply'
+	iops, err := allOperatorsInCluster(client)
+	if err != nil {
+		return retval, err
+	}
+	for _, iop := range iops {
+		retval = append(retval, istioInstall{
+			namespace: iop.Namespace,
+			revision:  iop.Spec.Revision,
+		})
+	}
+	return retval, nil
+}
+
+// nolint: lll
+func getIOPFromFile(restClientGetter resource.RESTClientGetter, options resource.FilenameOptions) (*operator_v1alpha1.IstioOperator, error) {
+	var retval *operator_v1alpha1.IstioOperator
+
+	r := resource.NewBuilder(restClientGetter).
+		Unstructured().
+		FilenameParam(false, &options).
+		Flatten().
+		Do()
+	if r.Err() != nil {
+		return nil, r.Err()
+	}
+	visitor := genericclioptions.ResourceFinderForResult(r).Do()
+	err := visitor.Visit(func(info *resource.Info, err error) error {
+		if err != nil {
+			return err
+		}
+		content, err := runtime.DefaultUnstructuredConverter.ToUnstructured(info.Object)
+		if err != nil {
+			return err
+		}
+		un := &unstructured.Unstructured{Object: content}
+		if un.GetKind() == "IstioOperator" {
+			// It is not a problem if the cluster does not include the IstioOperator
+			// we are checking.  Instead, verify the cluster has the things the
+			// IstioOperator specifies it should have.
+
+			// IstioOperator isn't part of pkg/config/schema/collections,
+			// usual conversion not available.  Convert unstructured to string
+			// and ask operator code to unmarshal.
+
+			un.SetCreationTimestamp(meta_v1.Time{}) // UnmarshalIstioOperator chokes on these
+			by, err := json.Marshal(un)
+			if err != nil {
+				return err
+			}
+
+			iop, err := operator_istio.UnmarshalIstioOperator(string(by))
+			if err != nil {
+				return err
+			}
+			retval = iop
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return retval, nil
+}
+
+func namespaceExists(ns string, restClientGetter genericclioptions.RESTClientGetter) (bool, error) {
+	c, err := clientFactory(restClientGetter)
+	if err != nil {
+		return false, err
+	}
+	_, err = c.getNameSpace(ns)
+	return err == nil, nil
 }

--- a/istioctl/pkg/install/pre-check_test.go
+++ b/istioctl/pkg/install/pre-check_test.go
@@ -104,7 +104,7 @@ func TestPreCheck(t *testing.T) {
 				version:   version1_13,
 				namespace: "istio-system",
 			},
-			expectedException: true,
+			expectedException: false, // It is fine to precheck an existing namespace; we might be installing canary control plane
 		},
 		{description: "Valid Istio System",
 			config: &mockClientExecPreCheckConfig{
@@ -149,20 +149,20 @@ func TestPreCheck(t *testing.T) {
 func verifyOutput(t *testing.T, c testcase) {
 	t.Helper()
 
-	clientExecFactory = mockPreCheckClient(c.config)
+	clientFactory = mockPreCheckClient(c.config)
 	var out bytes.Buffer
-	verifyInstallCmd := NewVerifyCommand()
-	verifyInstallCmd.SetOutput(&out)
-	fErr := verifyInstallCmd.Execute()
+	precheckCmd := NewPrecheckCommand()
+	precheckCmd.SetOutput(&out)
+	fErr := precheckCmd.Execute()
 	output := out.String()
 	if c.expectedException {
 		if fErr == nil {
-			t.Fatalf("Wanted an exception for 'istioctl verify-install',"+
+			t.Fatalf("Wanted an exception for 'istioctl x precheck',"+
 				"didn't get one, output was %q", output)
 		}
 	} else {
 		if fErr != nil {
-			t.Fatalf("Unwanted exception for 'istioctl verify-install': %v", fErr)
+			t.Fatalf("Unwanted exception for 'istioctl x precheck': %v", fErr)
 		}
 	}
 }
@@ -218,4 +218,8 @@ func (m *mockClientExecPreCheckConfig) checkAuthorization(
 
 func (m *mockClientExecPreCheckConfig) checkMutatingWebhook() error {
 	return nil
+}
+
+func (m *mockClientExecPreCheckConfig) getIstioInstalls() ([]istioInstall, error) {
+	return []istioInstall{}, nil
 }

--- a/istioctl/pkg/install/verify.go
+++ b/istioctl/pkg/install/verify.go
@@ -59,7 +59,7 @@ func verifyInstallIOPrevision(enableVerbose bool, istioNamespaceFlag string,
 
 	iop, err := operatorFromCluster(istioNamespaceFlag, opts.Revision, restClientGetter)
 	if err != nil {
-		return fmt.Errorf("could not load IstioOperator from cluster: %v", err)
+		return fmt.Errorf("could not load IstioOperator from cluster: %v.  Use --filename", err)
 	}
 	crdCount, istioDeploymentCount, err := verifyPostInstallIstioOperator(enableVerbose,
 		istioNamespaceFlag,

--- a/istioctl/pkg/install/verify.go
+++ b/istioctl/pkg/install/verify.go
@@ -46,6 +46,11 @@ import (
 
 var (
 	verifyInstallCmd *cobra.Command
+	istioOperatorGVR = apimachinery_schema.GroupVersionResource{
+		Group:    v1alpha1.SchemeGroupVersion.Group,
+		Version:  v1alpha1.SchemeGroupVersion.Version,
+		Resource: "istiooperators",
+	}
 )
 
 func verifyInstallIOPrevision(enableVerbose bool, istioNamespaceFlag string,
@@ -67,16 +72,7 @@ func verifyInstallIOPrevision(enableVerbose bool, istioNamespaceFlag string,
 
 func verifyInstall(enableVerbose bool, istioNamespaceFlag string,
 	restClientGetter genericclioptions.RESTClientGetter, options resource.FilenameOptions,
-	writer io.Writer, args []string) error {
-
-	// If no args, perform pre-check
-	if len(options.Filenames) == 0 {
-		if len(args) != 0 {
-			_, _ = fmt.Fprint(writer, verifyInstallCmd.UsageString())
-			return fmt.Errorf("verify-install takes no arguments to perform installation pre-check")
-		}
-		return installPreCheck(istioNamespaceFlag, restClientGetter, writer)
-	}
+	writer io.Writer) error {
 
 	// This is not a pre-check.  Check that the supplied resources exist in the cluster
 	r := resource.NewBuilder(restClientGetter).
@@ -283,13 +279,14 @@ func NewVerifyCommand() *cobra.Command {
 			return nil
 		},
 		RunE: func(c *cobra.Command, args []string) error {
-			// If --revision is specified, get the expected configuration from the IstioOperator
-			if c.Flags().Changed("revision") {
+			// If the user did not specify a file, compare install to in-cluster IOP
+			if len(fileNameFlags.ToOptions().Filenames) == 0 {
 				return verifyInstallIOPrevision(enableVerbose, istioNamespace, kubeConfigFlags,
 					c.OutOrStderr(), opts)
 			}
+			// When the user specifies a file, compare against it.
 			return verifyInstall(enableVerbose, istioNamespace, kubeConfigFlags,
-				fileNameFlags.ToOptions(), c.OutOrStderr(), args)
+				fileNameFlags.ToOptions(), c.OutOrStderr())
 		},
 	}
 
@@ -418,11 +415,6 @@ func operatorFromCluster(istioNamespaceFlag string, revision string, restClientG
 	if err != nil {
 		return nil, err
 	}
-	istioOperatorGVR := apimachinery_schema.GroupVersionResource{
-		Group:    v1alpha1.SchemeGroupVersion.Group,
-		Version:  v1alpha1.SchemeGroupVersion.Version,
-		Resource: "istiooperators",
-	}
 	ul, err := client.
 		Resource(istioOperatorGVR).
 		Namespace(istioNamespaceFlag).
@@ -446,4 +438,29 @@ func operatorFromCluster(istioNamespaceFlag string, revision string, restClientG
 		}
 	}
 	return nil, fmt.Errorf("control plane revision %q not found", revision)
+}
+
+// Find all IstioOperator in the cluster.
+func allOperatorsInCluster(client dynamic.Interface) ([]*v1alpha1.IstioOperator, error) {
+	ul, err := client.
+		Resource(istioOperatorGVR).
+		List(context.TODO(), meta_v1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	retval := make([]*v1alpha1.IstioOperator, 0)
+	for _, un := range ul.Items {
+		un.SetCreationTimestamp(meta_v1.Time{}) // UnmarshalIstioOperator chokes on these
+		by, err := json.Marshal(un.Object)
+		if err != nil {
+			return nil, err
+		}
+
+		iop, err := operator_istio.UnmarshalIstioOperator(string(by))
+		if err != nil {
+			return nil, err
+		}
+		retval = append(retval, iop)
+	}
+	return retval, nil
 }


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/20355

In 1.5.x and earlier, "istioctl verify-install" did two things.  If it had an argument it verified that Istio was installed, if it didn't it verified if Istio *could be installed*.

This doesn't work for multiple control planes and was confusing.

With this PR:
We now have "istioctl x precheck", which does the existing pre-Istio-install cluster compatibility check.
The existing check now supports multiple control planes -- you can ask if your cluster is compatible with an IOP, even if Istio is already installed.
The existing "istioctl verify-install" does not do pre-install check.

This is just the basic support.  We don't check compatibility with the IOP flags except for "revision" and "namespace".  We don't support `--set` to modify the IOP being checked.  If there is interest I will do those in a follow-up.

cc @irisdingbj 