### PR TITLE
Enable connection reuse for kube app probers

### DIFF
--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -395,8 +395,8 @@ func (s *Server) handleAppProbe(w http.ResponseWriter, req *http.Request) {
 	}
 	defer func() {
 		// Drain and close the body to let the Transport reuse the connection
-		io.Copy(ioutil.Discard, response.Body)
-		response.Body.Close()
+		_, _ = io.Copy(ioutil.Discard, response.Body)
+		_ = response.Body.Close()
 	}()
 
 	// We only write the status code to the response.


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/23091

Before:
```
14:45:58.252251 IP6 localhost.39460 > localhost.http-alt: Flags [S], seq 94945598, win 65476, options [mss 65476,sackOK,TS val 2531007655 ecr 0,nop,wscale 7], length 0
14:45:58.252277 IP6 localhost.http-alt > localhost.39460: Flags [S.], seq 2357198544, ack 94945599, win 65464, options [mss 65476,sackOK,TS val 2531007655 ecr 2531007655,nop,wscale 7], length 0
14:45:58.252297 IP6 localhost.39460 > localhost.http-alt: Flags [.], ack 1, win 512, options [nop,nop,TS val 2531007655 ecr 2531007655], length 0
14:45:58.252509 IP6 localhost.39460 > localhost.http-alt: Flags [P.], seq 1:113, ack 1, win 512, options [nop,nop,TS val 2531007655 ecr 2531007655], length 112: HTTP: GET /?size=10000 HTTP/1.1
14:45:58.252528 IP6 localhost.http-alt > localhost.39460: Flags [.], ack 113, win 511, options [nop,nop,TS val 2531007655 ecr 2531007655], length 0
14:45:58.252721 IP6 localhost.http-alt > localhost.39460: Flags [P.], seq 1:4097, ack 113, win 512, options [nop,nop,TS val 2531007655 ecr 2531007655], length 4096: HTTP: HTTP/1.1 200 OK
14:45:58.252746 IP6 localhost.39460 > localhost.http-alt: Flags [.], ack 4097, win 491, options [nop,nop,TS val 2531007655 ecr 2531007655], length 0
14:45:58.252791 IP6 localhost.http-alt > localhost.39460: Flags [P.], seq 4097:10120, ack 113, win 512, options [nop,nop,TS val 2531007655 ecr 2531007655], length 6023: HTTP
14:45:58.252802 IP6 localhost.39460 > localhost.http-alt: Flags [.], ack 10120, win 484, options [nop,nop,TS val 2531007655 ecr 2531007655], length 0
14:45:58.252869 IP6 localhost.39460 > localhost.http-alt: Flags [R.], seq 113, ack 10120, win 512, options [nop,nop,TS val 2531007655 ecr 2531007655], length 0
```

After:
```
14:47:47.800244 IP6 localhost.39646 > localhost.http-alt: Flags [S], seq 2927153713, win 65476, options [mss 65476,sackOK,TS val 2531117203 ecr 0,nop,wscale 7], length 0
14:47:47.800265 IP6 localhost.http-alt > localhost.39646: Flags [S.], seq 863903735, ack 2927153714, win 65464, options [mss 65476,sackOK,TS val 2531117203 ecr 2531117203,nop,wscale 7], length 0
14:47:47.800279 IP6 localhost.39646 > localhost.http-alt: Flags [.], ack 1, win 512, options [nop,nop,TS val 2531117203 ecr 2531117203], length 0
14:47:47.800502 IP6 localhost.39646 > localhost.http-alt: Flags [P.], seq 1:113, ack 1, win 512, options [nop,nop,TS val 2531117203 ecr 2531117203], length 112: HTTP: GET /?size=10000 HTTP/1.1
14:47:47.800524 IP6 localhost.http-alt > localhost.39646: Flags [.], ack 113, win 511, options [nop,nop,TS val 2531117203 ecr 2531117203], length 0
14:47:47.800921 IP6 localhost.http-alt > localhost.39646: Flags [P.], seq 1:4097, ack 113, win 512, options [nop,nop,TS val 2531117203 ecr 2531117203], length 4096: HTTP: HTTP/1.1 200 OK
14:47:47.800939 IP6 localhost.39646 > localhost.http-alt: Flags [.], ack 4097, win 491, options [nop,nop,TS val 2531117203 ecr 2531117203], length 0
14:47:47.800966 IP6 localhost.http-alt > localhost.39646: Flags [P.], seq 4097:10120, ack 113, win 512, options [nop,nop,TS val 2531117203 ecr 2531117203], length 6023: HTTP
14:47:47.800977 IP6 localhost.39646 > localhost.http-alt: Flags [.], ack 10120, win 468, options [nop,nop,TS val 2531117203 ecr 2531117203], length 0
```