### PR TITLE
feat(bootstrap): add support for metrics with cluster_id labels

### DIFF
--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -70,6 +70,10 @@
           "tag_name": "source_version"
       },
       {
+          "regex": "(source_cluster_id=\\.=(.*?);\\.;)",
+          "tag_name": "source_cluster_id"
+      },
+      {
           "regex": "(destination_namespace=\\.=(.+?);\\.;)",
           "tag_name": "destination_namespace"
       },
@@ -108,6 +112,10 @@
       {
         "regex": "(destination_port=\\.=(.+?);\\.;)",
         "tag_name": "destination_port"
+      },
+      {
+        "regex": "(destination_cluster_id=\\.=(.*?);\\.;)",
+        "tag_name": "destination_cluster_id"
       },
       {
           "regex": "(request_protocol=\\.=(.+?);\\.;)",

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -70,6 +70,10 @@
           "tag_name": "source_version"
       },
       {
+          "regex": "(source_cluster_id=\\.=(.*?);\\.;)",
+          "tag_name": "source_cluster_id"
+      },
+      {
           "regex": "(destination_namespace=\\.=(.+?);\\.;)",
           "tag_name": "destination_namespace"
       },
@@ -108,6 +112,10 @@
       {
         "regex": "(destination_port=\\.=(.+?);\\.;)",
         "tag_name": "destination_port"
+      },
+      {
+        "regex": "(destination_cluster_id=\\.=(.*?);\\.;)",
+        "tag_name": "destination_cluster_id"
       },
       {
           "regex": "(request_protocol=\\.=(.+?);\\.;)",

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -70,6 +70,10 @@
           "tag_name": "source_version"
       },
       {
+          "regex": "(source_cluster_id=\\.=(.*?);\\.;)",
+          "tag_name": "source_cluster_id"
+      },
+      {
           "regex": "(destination_namespace=\\.=(.+?);\\.;)",
           "tag_name": "destination_namespace"
       },
@@ -108,6 +112,10 @@
       {
         "regex": "(destination_port=\\.=(.+?);\\.;)",
         "tag_name": "destination_port"
+      },
+      {
+        "regex": "(destination_cluster_id=\\.=(.*?);\\.;)",
+        "tag_name": "destination_cluster_id"
       },
       {
           "regex": "(request_protocol=\\.=(.+?);\\.;)",

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -70,6 +70,10 @@
           "tag_name": "source_version"
       },
       {
+          "regex": "(source_cluster_id=\\.=(.*?);\\.;)",
+          "tag_name": "source_cluster_id"
+      },
+      {
           "regex": "(destination_namespace=\\.=(.+?);\\.;)",
           "tag_name": "destination_namespace"
       },
@@ -108,6 +112,10 @@
       {
         "regex": "(destination_port=\\.=(.+?);\\.;)",
         "tag_name": "destination_port"
+      },
+      {
+        "regex": "(destination_cluster_id=\\.=(.*?);\\.;)",
+        "tag_name": "destination_cluster_id"
       },
       {
           "regex": "(request_protocol=\\.=(.+?);\\.;)",

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -75,6 +75,10 @@
           "tag_name": "source_version"
       },
       {
+          "regex": "(source_cluster_id=\\.=(.*?);\\.;)",
+          "tag_name": "source_cluster_id"
+      },
+      {
           "regex": "(destination_namespace=\\.=(.+?);\\.;)",
           "tag_name": "destination_namespace"
       },
@@ -113,6 +117,10 @@
       {
         "regex": "(destination_port=\\.=(.+?);\\.;)",
         "tag_name": "destination_port"
+      },
+      {
+        "regex": "(destination_cluster_id=\\.=(.*?);\\.;)",
+        "tag_name": "destination_cluster_id"
       },
       {
           "regex": "(request_protocol=\\.=(.+?);\\.;)",

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -75,6 +75,10 @@
           "tag_name": "source_version"
       },
       {
+          "regex": "(source_cluster_id=\\.=(.*?);\\.;)",
+          "tag_name": "source_cluster_id"
+      },
+      {
           "regex": "(destination_namespace=\\.=(.+?);\\.;)",
           "tag_name": "destination_namespace"
       },
@@ -113,6 +117,10 @@
       {
         "regex": "(destination_port=\\.=(.+?);\\.;)",
         "tag_name": "destination_port"
+      },
+      {
+        "regex": "(destination_cluster_id=\\.=(.*?);\\.;)",
+        "tag_name": "destination_cluster_id"
       },
       {
           "regex": "(request_protocol=\\.=(.+?);\\.;)",

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -70,6 +70,10 @@
           "tag_name": "source_version"
       },
       {
+          "regex": "(source_cluster_id=\\.=(.*?);\\.;)",
+          "tag_name": "source_cluster_id"
+      },
+      {
           "regex": "(destination_namespace=\\.=(.+?);\\.;)",
           "tag_name": "destination_namespace"
       },
@@ -108,6 +112,10 @@
       {
         "regex": "(destination_port=\\.=(.+?);\\.;)",
         "tag_name": "destination_port"
+      },
+      {
+        "regex": "(destination_cluster_id=\\.=(.*?);\\.;)",
+        "tag_name": "destination_cluster_id"
       },
       {
           "regex": "(request_protocol=\\.=(.+?);\\.;)",

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -70,6 +70,10 @@
           "tag_name": "source_version"
       },
       {
+          "regex": "(source_cluster_id=\\.=(.*?);\\.;)",
+          "tag_name": "source_cluster_id"
+      },
+      {
           "regex": "(destination_namespace=\\.=(.+?);\\.;)",
           "tag_name": "destination_namespace"
       },
@@ -108,6 +112,10 @@
       {
         "regex": "(destination_port=\\.=(.+?);\\.;)",
         "tag_name": "destination_port"
+      },
+      {
+        "regex": "(destination_cluster_id=\\.=(.*?);\\.;)",
+        "tag_name": "destination_cluster_id"
       },
       {
           "regex": "(request_protocol=\\.=(.+?);\\.;)",

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -70,6 +70,10 @@
           "tag_name": "source_version"
       },
       {
+          "regex": "(source_cluster_id=\\.=(.*?);\\.;)",
+          "tag_name": "source_cluster_id"
+      },
+      {
           "regex": "(destination_namespace=\\.=(.+?);\\.;)",
           "tag_name": "destination_namespace"
       },
@@ -108,6 +112,10 @@
       {
         "regex": "(destination_port=\\.=(.+?);\\.;)",
         "tag_name": "destination_port"
+      },
+      {
+        "regex": "(destination_cluster_id=\\.=(.*?);\\.;)",
+        "tag_name": "destination_cluster_id"
       },
       {
           "regex": "(request_protocol=\\.=(.+?);\\.;)",

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -70,6 +70,10 @@
           "tag_name": "source_version"
       },
       {
+          "regex": "(source_cluster_id=\\.=(.*?);\\.;)",
+          "tag_name": "source_cluster_id"
+      },
+      {
           "regex": "(destination_namespace=\\.=(.+?);\\.;)",
           "tag_name": "destination_namespace"
       },
@@ -108,6 +112,10 @@
       {
         "regex": "(destination_port=\\.=(.+?);\\.;)",
         "tag_name": "destination_port"
+      },
+      {
+        "regex": "(destination_cluster_id=\\.=(.*?);\\.;)",
+        "tag_name": "destination_cluster_id"
       },
       {
           "regex": "(request_protocol=\\.=(.+?);\\.;)",

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -70,6 +70,10 @@
           "tag_name": "source_version"
       },
       {
+          "regex": "(source_cluster_id=\\.=(.*?);\\.;)",
+          "tag_name": "source_cluster_id"
+      },
+      {
           "regex": "(destination_namespace=\\.=(.+?);\\.;)",
           "tag_name": "destination_namespace"
       },
@@ -108,6 +112,10 @@
       {
         "regex": "(destination_port=\\.=(.+?);\\.;)",
         "tag_name": "destination_port"
+      },
+      {
+        "regex": "(destination_cluster_id=\\.=(.*?);\\.;)",
+        "tag_name": "destination_cluster_id"
       },
       {
           "regex": "(request_protocol=\\.=(.+?);\\.;)",

--- a/tools/packaging/common/envoy_bootstrap_v2.json
+++ b/tools/packaging/common/envoy_bootstrap_v2.json
@@ -85,6 +85,10 @@
           "tag_name": "source_version"
       },
       {
+          "regex": "(source_cluster_id=\\.=(.*?);\\.;)",
+          "tag_name": "source_cluster_id"
+      },
+      {
           "regex": "(destination_namespace=\\.=(.+?);\\.;)",
           "tag_name": "destination_namespace"
       },
@@ -123,6 +127,10 @@
       {
         "regex": "(destination_port=\\.=(.+?);\\.;)",
         "tag_name": "destination_port"
+      },
+      {
+        "regex": "(destination_cluster_id=\\.=(.*?);\\.;)",
+        "tag_name": "destination_cluster_id"
       },
       {
           "regex": "(request_protocol=\\.=(.+?);\\.;)",


### PR DESCRIPTION
Adds tag extraction logic for `*_cluster_id` labels to the envoy bootstrap.

This PR will enable labeling Istio metrics with source and destination clusters. This, in turn, will allow breaking down cross-cluster traffic in dashboards and alerts.

Related PR: https://github.com/istio/proxy/pull/2805

[X] Policies and Telemetry
