### PR TITLE
istioctl: check for v1alpha1 security CRDs in upgrade

### DIFF
--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -16,14 +16,18 @@ package mesh
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/docker/distribution/reference"
 	goversion "github.com/hashicorp/go-version"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
+	client_v1beta1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 
 	iop "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
@@ -167,7 +171,7 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 	}
 
 	// Check if the upgrade currentVersion -> targetVersion is supported
-	err = checkSupportedVersions(currentVersion, targetVersion, args.versionsURI)
+	err = checkSupportedVersions(kubeClient, currentVersion, targetVersion, args.versionsURI)
 	if err != nil && !args.force {
 		return fmt.Errorf("upgrade version check failed: %v -> %v. Error: %v",
 			currentVersion, targetVersion, err)
@@ -271,7 +275,7 @@ func waitForConfirmation(skipConfirmation bool, l clog.Logger) {
 }
 
 // checkSupportedVersions checks if the upgrade cur -> tar is supported by the tool
-func checkSupportedVersions(cur, tar, versionsURI string) error {
+func checkSupportedVersions(kubeClient *Client, cur, tar, versionsURI string) error {
 	tarGoVersion, err := goversion.NewVersion(tar)
 	if err != nil {
 		return fmt.Errorf("failed to parse the target version: %v", tar)
@@ -289,6 +293,14 @@ func checkSupportedVersions(cur, tar, versionsURI string) error {
 
 	if !compatibleMap.SupportedIstioVersions.Check(curGoVersion) {
 		return fmt.Errorf("upgrade is currently not supported: %v -> %v", cur, tar)
+	}
+
+	ver16, err := goversion.NewVersion("1.6")
+	if err != nil {
+		return fmt.Errorf("failed to parse version string %q: %v", "1.6", err)
+	}
+	if tarGoVersion.GreaterThanOrEqual(ver16) {
+		return kubeClient.CheckUnsupportedAlphaSecurityCRD()
 	}
 
 	return nil
@@ -521,4 +533,81 @@ func (client *Client) ConfigMapForSelector(namespace, labelSelector string) (*v1
 		return nil, fmt.Errorf("failed retrieving configmap: %v", err)
 	}
 	return obj.(*v1.ConfigMapList), nil
+}
+
+func (client *Client) CheckUnsupportedAlphaSecurityCRD() error {
+	c, err := client_v1beta1.NewForConfig(client.Config)
+	if err != nil {
+		return err
+	}
+	crds, err := c.CustomResourceDefinitions().List(context.TODO(), meta_v1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get CRDs: %v", err)
+	}
+
+	unsupportedCRD := func(name string) bool {
+		crds := []string{
+			"clusterrbacconfigs.rbac.istio.io",
+			"rbacconfigs.rbac.istio.io",
+			"servicerolebindings.rbac.istio.io",
+			"serviceroles.rbac.istio.io",
+			"policies.authentication.istio.io",
+			"meshpolicies.authentication.istio.io",
+		}
+		for _, crd := range crds {
+			if name == crd {
+				return true
+			}
+		}
+		return false
+	}
+	getResource := func(crd string) []string {
+		type ResourceItem struct {
+			Metadata meta_v1.ObjectMeta `json:"metadata,omitempty"`
+		}
+		type Resource struct {
+			Items []ResourceItem `json:"items"`
+		}
+
+		parts := strings.Split(crd, ".")
+		cmd := client.Get().AbsPath("apis", strings.Join(parts[1:], "."), "v1alpha1", parts[0])
+		obj, err := cmd.DoRaw(context.TODO())
+		if err != nil {
+			log.Errorf("failed to get resources for crd %s: %v", crd, err)
+			return nil
+		}
+		resource := &Resource{}
+		if err := json.Unmarshal(obj, resource); err != nil {
+			log.Errorf("failed decoding response for crd %s: %v", crd, err)
+			return nil
+		}
+		var foundResources []string
+		for _, res := range resource.Items {
+			n := strings.Join([]string{crd, res.Metadata.Namespace, res.Metadata.Name}, "/")
+			foundResources = append(foundResources, n)
+		}
+		return foundResources
+	}
+
+	var foundCRDs []string
+	var foundResources []string
+	for _, crd := range crds.Items {
+		if unsupportedCRD(crd.Name) {
+			foundCRDs = append(foundCRDs, crd.Name)
+			foundResources = append(foundResources, getResource(crd.Name)...)
+		}
+	}
+	if len(foundCRDs) != 0 {
+		log.Warnf("found %d CRD of unsupported v1alpha1 security policy: %v. "+
+			"The v1alpha1 security policy is no longer supported starting 1.6. It's strongly recommended to delete "+
+			"the CRD of the v1alpha1 security policy to avoid applying any of the v1alpha1 security policy in the unsupported version",
+			len(foundCRDs), foundCRDs)
+	}
+	if len(foundResources) != 0 {
+		return fmt.Errorf("found %d unsupported v1alpha1 security policy: %v. "+
+			"The v1alpha1 security policy is no longer supported starting 1.6. To continue the upgrade, "+
+			"Please migrate to the v1beta1 security policy and delete all the v1alpha1 security policy",
+			len(foundResources), foundResources)
+	}
+	return nil
 }


### PR DESCRIPTION
When upgrading to 1.6 with `istioctl upgrade`, the cluster should not include any v1alpha1 policies since it's not supported in 1.6 anymore. We will also update the release and upgrade notes to ask users to migrate to the beta policy and delete the CRDs of the v1alpha1 policies.

the `istioctl upgrade` should warn on the v1alpha1 CRDs and error on the existence of actual v1alpha1 resources when upgrading to >= 1.6, see the following for example:
```
2020-05-06T02:35:57.690629Z error found 6 CRD of unsupported v1alpha1 security policy: clusterrbacconfigs.rbac.istio.io meshpolicies.authentication.istio.io policies.authentication.istio.io rbacconfigs.rbac.istio.io servicerolebindings.rbac.istio.io serviceroles.rbac.istio.io. The v1alpha1 security policy is no longer supported starting 1.6. It's strongly recommended to delete the CRD of the v1alpha1 security policy to avoid applying any of the v1alpha1 security policy in the unsupported version

Error: found 3 unsupported v1alpha1 security policy: meshpolicies.authentication.istio.io//default policies.authentication.istio.io/default/jwt-example policies.authentication.istio.io/default/jwt-examplexx. The v1alpha1 security policy is no longer supported starting 1.6. To continue the upgrade, Please migrate to the v1beta1 security policy and delete all the v1alpha1 security policy
```