### PR TITLE
support define `IsServer`  when generating cert

### DIFF
--- a/security/tools/generate_cert/main.go
+++ b/security/tools/generate_cert/main.go
@@ -55,7 +55,8 @@ var (
 	outPriv        = flag.String("out-priv", "priv.pem", "Output private key file.")
 	keySize        = flag.Int("key-size", 2048, "Size of the generated private key")
 	mode           = flag.String("mode", selfSignedMode, "Supported mode: self-signed, signer, citadel")
-	isServer       = flag.Bool("server", false, "Whether this certificate is for a server.")
+	//enable this flag if istio mTLS is enabled and the service is running as server side
+	isServer = flag.Bool("server", false, "Whether this certificate is for a server.")
 )
 
 func checkCmdLine() {

--- a/security/tools/generate_cert/main.go
+++ b/security/tools/generate_cert/main.go
@@ -55,7 +55,7 @@ var (
 	outPriv        = flag.String("out-priv", "priv.pem", "Output private key file.")
 	keySize        = flag.Int("key-size", 2048, "Size of the generated private key")
 	mode           = flag.String("mode", selfSignedMode, "Supported mode: self-signed, signer, citadel")
-	//enable this flag if istio mTLS is enabled and the service is running as server side
+	//Enable this flag if istio mTLS is enabled and the service is running as server side
 	isServer = flag.Bool("server", false, "Whether this certificate is for a server.")
 )
 

--- a/security/tools/generate_cert/main.go
+++ b/security/tools/generate_cert/main.go
@@ -55,6 +55,7 @@ var (
 	outPriv        = flag.String("out-priv", "priv.pem", "Output private key file.")
 	keySize        = flag.Int("key-size", 2048, "Size of the generated private key")
 	mode           = flag.String("mode", selfSignedMode, "Supported mode: self-signed, signer, citadel")
+	isServer       = flag.Bool("server", false, "Whether this certificate is for a server.")
 )
 
 func checkCmdLine() {
@@ -145,6 +146,7 @@ func main() {
 		IsSelfSigned: *mode == selfSignedMode,
 		IsClient:     *isClient,
 		RSAKeySize:   *keySize,
+		IsServer:     *isServer,
 	}
 	certPem, privPem, err := util.GenCertKeyFromOptions(opts)
 


### PR DESCRIPTION
https://github.com/istio/istio/issues/23108
Now we are using this command to generate cert for VM in our docs.  We need to support generate cert which is used for both `client` and `server`. Currently it only supports `client.`
Just add an command line option to support this `IsServer`