### PR TITLE
Ensure bookinfo mysql and mongodb pods work with any user id

### DIFF
--- a/samples/bookinfo/platform/kube/bookinfo-db.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-db.yaml
@@ -50,4 +50,10 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 27017
+        volumeMounts:
+        - name: data-db
+          mountPath: /data/db
+      volumes:
+      - name: data-db
+        emptyDir:
 ---

--- a/samples/bookinfo/platform/kube/bookinfo-mysql.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-mysql.yaml
@@ -69,4 +69,10 @@ spec:
                 name: mysql-credentials
                 key: rootpasswd
         args: ["--default-authentication-plugin","mysql_native_password"]
+        volumeMounts:
+        - name: var-lib-mysql
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: var-lib-mysql
+        emptyDir:
 ---


### PR DESCRIPTION
When running either container with a random user id, it failed because
the process couldn't write to a local directory due to bad ownership /
permissions (/data/db for MongoDB and /var/lib/mysql in MySQL).

Modifying the Dockerfile to change the permissions on the directories
doesn't work because the directories are marked as Docker volumes.
The solution is to mount an emptyDir volume in these directories. By
doing this, the process can write to the directory and we ensure that
data isn't lost when the container is restarted.
