### PR TITLE
Make istioctl install much faster

### DIFF
--- a/operator/cmd/mesh/manifest-apply.go
+++ b/operator/cmd/mesh/manifest-apply.go
@@ -170,6 +170,10 @@ func ApplyManifests(setOverlay []string, inFilenames []string, force bool, dryRu
 	if err != nil {
 		return err
 	}
+	// We are running a one-off command locally, so we don't need to worry too much about rate limitting
+	// Bumping this up greatly decreases install time
+	restConfig.QPS = 50
+	restConfig.Burst = 100
 	client, err := client.New(restConfig, client.Options{Scheme: scheme.Scheme})
 	if err != nil {
 		return err


### PR DESCRIPTION
Credits to @ostromart who enabled this work

Before:
```
$ go build -o istioctl ./istioctl/cmd/istioctl && time ./istioctl/istioctl install --wait -y -d manifests
  Waiting for resources to become ready...
  Waiting for resources to become ready...
real 21.66
user 1.72
sys 0.25
```

Now:
```
$ go build -o istioctl ./istioctl/cmd/istioctl && time ./istioctl/istioctl install --wait -y -d manifests
real 1.13
user 1.17
sys 0.08