### PR TITLE
Update to new cluster-local API

### DIFF
--- a/galley/testdatasets/conversion/dataset.gen.go
+++ b/galley/testdatasets/conversion/dataset.gen.go
@@ -967,9 +967,6 @@ var _datasetMeshIstioIoV1alpha1Meshconfig_expectedJson = []byte(`{
             },
             "Body": {
                 "accessLogFile": "/dev/stdout",
-                "clusterLocalNamespaces": [
-                  "kube-system"
-                ],
                 "connectTimeout": {
                     "seconds": 10
                 },

--- a/galley/testdatasets/conversion/dataset/mesh.istio.io/v1alpha1/meshconfig_expected.json
+++ b/galley/testdatasets/conversion/dataset/mesh.istio.io/v1alpha1/meshconfig_expected.json
@@ -7,9 +7,6 @@
             },
             "Body": {
                 "accessLogFile": "/dev/stdout",
-                "clusterLocalNamespaces": [
-                  "kube-system"
-                ],
                 "connectTimeout": {
                     "seconds": 10
                 },

--- a/go.mod
+++ b/go.mod
@@ -156,7 +156,7 @@ require (
 	gopkg.in/square/go-jose.v2 v2.3.1
 	gopkg.in/yaml.v2 v2.2.8
 	helm.sh/helm/v3 v3.2.0-rc.1
-	istio.io/api v0.0.0-20200417223136-90a960729620
+	istio.io/api v0.0.0-20200422222339-c4be55f6e627
 	istio.io/gogo-genproto v0.0.0-20200326154102-997c228eecef
 	istio.io/pkg v0.0.0-20200327214633-ce134a9bd104
 	k8s.io/api v0.18.1

--- a/go.sum
+++ b/go.sum
@@ -1060,8 +1060,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3 h1:3JgtbtFHMiCmsznwGVTUWbgGov+pVqnlf1dEJTNAXeM=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 istio.io/api v0.0.0-20190515205759-982e5c3888c6/go.mod h1:hhLFQmpHia8zgaM37vb2ml9iS5NfNfqZGRt1pS9aVEo=
-istio.io/api v0.0.0-20200417223136-90a960729620 h1:16ib1e76ZepyOLV5YT5kDOtwla7KnXes/V5i5unbNr0=
-istio.io/api v0.0.0-20200417223136-90a960729620/go.mod h1:kyq3g5w42zl/AKlbzDGppYpGMQYMYMyZKeq0/eexML8=
+istio.io/api v0.0.0-20200422222339-c4be55f6e627 h1:61Fp4lbZFcSp/o4+yOn4oI8r29qh9I99xsB0n51OnrY=
+istio.io/api v0.0.0-20200422222339-c4be55f6e627/go.mod h1:kyq3g5w42zl/AKlbzDGppYpGMQYMYMyZKeq0/eexML8=
 istio.io/gogo-genproto v0.0.0-20190930162913-45029607206a/go.mod h1:OzpAts7jljZceG4Vqi5/zXy/pOg1b209T3jb7Nv5wIs=
 istio.io/gogo-genproto v0.0.0-20200326154102-997c228eecef h1:jVlVwrFW1LIm9XyPnvthNEvLjALn1zsTysGRKctl4Lc=
 istio.io/gogo-genproto v0.0.0-20200326154102-997c228eecef/go.mod h1:OzpAts7jljZceG4Vqi5/zXy/pOg1b209T3jb7Nv5wIs=

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -156,6 +156,7 @@ func NewServer(args *PilotArgs) (*Server, error) {
 	e := &model.Environment{
 		ServiceDiscovery: aggregate.NewController(),
 		PushContext:      model.NewPushContext(),
+		DomainSuffix:     args.Config.ControllerOptions.DomainSuffix,
 	}
 
 	s := &Server{

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -38,6 +38,10 @@ import (
 	"istio.io/istio/pkg/config/mesh"
 )
 
+const (
+	defaultDomainSuffix = "cluster.local"
+)
+
 var _ mesh.Holder = &Environment{}
 var _ mesh.NetworksHolder = &Environment{}
 
@@ -66,6 +70,16 @@ type Environment struct {
 	// START OF THE PUSH, THE GLOBAL ONE MAY CHANGE AND REFLECT A DIFFERENT
 	// CONFIG AND PUSH
 	PushContext *PushContext
+
+	// DomainSuffix provides a default domain for the Istio server.
+	DomainSuffix string
+}
+
+func (e *Environment) GetDomainSuffix() string {
+	if len(e.DomainSuffix) > 0 {
+		return e.DomainSuffix
+	}
+	return defaultDomainSuffix
 }
 
 func (e *Environment) Mesh() *meshconfig.MeshConfig {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"net"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -32,6 +33,10 @@ import (
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/visibility"
+)
+
+var (
+	defaultClusterLocalNamespaces = []string{"kube-system"}
 )
 
 // Metrics is an interface for capturing metrics on a per-node basis.
@@ -88,6 +93,9 @@ type PushContext struct {
 	//  namespaceExportedDestRules: all public dest rules pertaining to a service defined in a namespace
 	namespaceLocalDestRules    map[string]*processedDestRules
 	namespaceExportedDestRules map[string]*processedDestRules
+
+	// clusterLocalHosts extracted from the MeshConfig
+	clusterLocalHosts host.Names
 
 	// sidecars for each namespace
 	sidecarsByNamespace map[string][]*SidecarScope
@@ -759,6 +767,13 @@ func (ps *PushContext) DestinationRule(proxy *Proxy, service *Service) *Config {
 	return nil
 }
 
+// IsClusterLocal indicates whether the endpoints for the service should only be accessible to clients
+// within the cluster.
+func (ps *PushContext) IsClusterLocal(service *Service) bool {
+	_, ok := MostSpecificHostMatch(service.Hostname, ps.clusterLocalHosts)
+	return ok
+}
+
 // SubsetToLabels returns the labels associated with a subset of a given service.
 func (ps *PushContext) SubsetToLabels(proxy *Proxy, subsetName string, hostname host.Name) labels.Collection {
 	// empty subset
@@ -815,6 +830,8 @@ func (ps *PushContext) InitContext(env *Environment, oldPushContext *PushContext
 
 	// TODO: only do this when meshnetworks or gateway service changed
 	ps.initMeshNetworks()
+
+	ps.initClusterLocalHosts(env)
 
 	ps.initDone = true
 	return nil
@@ -1554,6 +1571,45 @@ func (ps *PushContext) initMeshNetworks() {
 
 		ps.networkGateways[network] = gateways
 	}
+}
+
+func (ps *PushContext) initClusterLocalHosts(e *Environment) {
+	// Create the default list of cluster-local hosts.
+	domainSuffix := e.GetDomainSuffix()
+	defaultClusterLocalHosts := make([]host.Name, 0, len(defaultClusterLocalNamespaces))
+	for _, n := range defaultClusterLocalNamespaces {
+		defaultClusterLocalHosts = append(defaultClusterLocalHosts, host.Name("*."+n+".svc."+domainSuffix))
+	}
+
+	// Collect the cluster-local hosts.
+	clusterLocalHosts := make([]host.Name, 0)
+	for _, serviceSettings := range ps.Mesh.ServiceSettings {
+		if serviceSettings.Settings.ClusterLocal {
+			for _, h := range serviceSettings.Hosts {
+				clusterLocalHosts = append(clusterLocalHosts, host.Name(h))
+			}
+		} else {
+			// Remove defaults if specified to be non-cluster-local.
+			for _, h := range serviceSettings.Hosts {
+				for i, defaultClusterLocalHost := range defaultClusterLocalHosts {
+					if len(defaultClusterLocalHost) > 0 && strings.HasSuffix(h, string(defaultClusterLocalHost[1:])) {
+						// This default was explicitly overridden, so remove it.
+						defaultClusterLocalHosts[i] = ""
+					}
+				}
+			}
+		}
+	}
+
+	// Add any remaining defaults to the end of the list.
+	for _, defaultClusterLocalHost := range defaultClusterLocalHosts {
+		if len(defaultClusterLocalHost) > 0 {
+			clusterLocalHosts = append(clusterLocalHosts, defaultClusterLocalHost)
+		}
+	}
+
+	sort.Sort(host.Names(clusterLocalHosts))
+	ps.clusterLocalHosts = clusterLocalHosts
 }
 
 func (ps *PushContext) initQuotaSpecs(env *Environment) error {

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -45,7 +45,6 @@ import (
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
-	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/util/gogo"
 )
@@ -259,7 +258,7 @@ func buildLocalityLbEndpoints(proxy *model.Proxy, push *model.PushContext, proxy
 
 	// Determine whether or not the target service is considered local to the cluster
 	// and should, therefore, not be accessed from outside the cluster.
-	isClusterLocal := mesh.IsClusterLocal(push.Mesh, service.Attributes.Namespace)
+	isClusterLocal := push.IsClusterLocal(service)
 
 	lbEndpoints := make(map[string][]*endpoint.LbEndpoint)
 	for _, instance := range instances {

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -34,7 +34,6 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
-	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/protocol"
 )
 
@@ -543,7 +542,7 @@ func buildLocalityLbEndpointsFromShards(
 
 	// Determine whether or not the target service is considered local to the cluster
 	// and should, therefore, not be accessed from outside the cluster.
-	isClusterLocal := mesh.IsClusterLocal(push.Mesh, svc.Attributes.Namespace)
+	isClusterLocal := push.IsClusterLocal(svc)
 
 	shards.mutex.Lock()
 	// The shards are updated independently, now need to filter and merge

--- a/pkg/config/mesh/mesh.go
+++ b/pkg/config/mesh/mesh.go
@@ -37,10 +37,6 @@ import (
 	"istio.io/istio/pkg/util/gogoprotomarshal"
 )
 
-var (
-	defaultClusterLocalNamespaces = []string{"kube-system"}
-)
-
 // DefaultProxyConfig for individual proxies
 func DefaultProxyConfig() meshconfig.ProxyConfig {
 	if TestMode {
@@ -135,7 +131,7 @@ func DefaultMeshConfig() meshconfig.MeshConfig {
 			EnableAutoMtls:                    &types.BoolValue{Value: false},
 			ThriftConfig:                      &meshconfig.MeshConfig_ThriftConfig{},
 			LocalityLbSetting:                 &v1alpha3.LocalityLoadBalancerSetting{},
-			ClusterLocalNamespaces:            append(make([]string, 0), defaultClusterLocalNamespaces...),
+			ServiceSettings:                   []*meshconfig.MeshConfig_ServiceSettings{},
 		}
 	}
 	// Defaults matching the standard install
@@ -179,19 +175,8 @@ func DefaultMeshConfig() meshconfig.MeshConfig {
 		DefaultDestinationRuleExportTo:    []string{"*"},
 		DnsRefreshRate:                    types.DurationProto(5 * time.Second), // 5 seconds is the default refresh rate used in Envoy
 		ThriftConfig:                      &meshconfig.MeshConfig_ThriftConfig{},
-		ClusterLocalNamespaces:            append(make([]string, 0), defaultClusterLocalNamespaces...),
+		ServiceSettings:                   make([]*meshconfig.MeshConfig_ServiceSettings, 0),
 	}
-
-}
-
-// IsClusterLocal indicates whether the given namespace is configured to be cluster-local.
-func IsClusterLocal(mesh *meshconfig.MeshConfig, namespace string) bool {
-	for _, clusterLocalNS := range mesh.ClusterLocalNamespaces {
-		if namespace == clusterLocalNS {
-			return true
-		}
-	}
-	return false
 }
 
 // ApplyProxyConfig applies the give proxy config yaml to a mesh config object. The passed in mesh config

--- a/pkg/config/mesh/mesh_test.go
+++ b/pkg/config/mesh/mesh_test.go
@@ -19,8 +19,6 @@ import (
 	"reflect"
 	"testing"
 
-	. "github.com/onsi/gomega"
-
 	"istio.io/istio/pkg/util/gogoprotomarshal"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -91,6 +89,11 @@ defaultConfig:
 	}
 	// Verify overrides
 	got, err = mesh.ApplyMeshConfigDefaults(`
+serviceSettings: 
+  - settings:
+      clusterLocal: true
+    host:
+      - "*.myns.svc.cluster.local"
 ingressClass: foo
 reportBatchMaxTime: 10s
 enableTracing: false
@@ -223,60 +226,6 @@ func TestResolveHostsInNetworksConfig(t *testing.T) {
 			if addrAfter != tt.address && !tt.modified {
 				t.Fatalf("Expected network address not to be modified after calling the function")
 			}
-		})
-	}
-}
-
-func TestIsClusterLocal(t *testing.T) {
-	cases := []struct {
-		name     string
-		m        meshconfig.MeshConfig
-		ns       string
-		expected bool
-	}{
-		{
-			name:     "local by default",
-			m:        mesh.DefaultMeshConfig(),
-			ns:       "kube-system",
-			expected: true,
-		},
-		{
-			name:     "not local by default",
-			m:        mesh.DefaultMeshConfig(),
-			ns:       "bob",
-			expected: false,
-		},
-		{
-			name: "local 1",
-			m: meshconfig.MeshConfig{
-				ClusterLocalNamespaces: []string{"ns1", "ns2"},
-			},
-			ns:       "ns1",
-			expected: true,
-		},
-		{
-			name: "local 2",
-			m: meshconfig.MeshConfig{
-				ClusterLocalNamespaces: []string{"ns1", "ns2"},
-			},
-			ns:       "ns2",
-			expected: true,
-		},
-		{
-			name: "not local",
-			m: meshconfig.MeshConfig{
-				ClusterLocalNamespaces: []string{"ns1", "ns2"},
-			},
-			ns:       "ns3",
-			expected: false,
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			g := NewGomegaWithT(t)
-			clusterLocal := mesh.IsClusterLocal(&c.m, c.ns)
-			g.Expect(clusterLocal).To(Equal(c.expected))
 		})
 	}
 }

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -996,8 +996,8 @@ func cleanMeshConfig(v proto.Message) proto.Message {
 	if cpy.IngressControllerMode == defaults.IngressControllerMode {
 		cpy.IngressControllerMode = meshconfig.MeshConfig_UNSPECIFIED
 	}
-	if reflect.DeepEqual(cpy.ClusterLocalNamespaces, defaults.ClusterLocalNamespaces) {
-		cpy.ClusterLocalNamespaces = nil
+	if reflect.DeepEqual(cpy.ServiceSettings, defaults.ServiceSettings) {
+		cpy.ServiceSettings = nil
 	}
 	return &cpy
 }

--- a/tests/integration/multicluster/main_test.go
+++ b/tests/integration/multicluster/main_test.go
@@ -57,7 +57,11 @@ func TestMain(m *testing.M) {
 			controlPlaneValues = fmt.Sprintf(`
 values:
   meshConfig:
-    clusterLocalNamespaces: ["kube-system", "%s"]
+    serviceSettings: 
+      - settings:
+          clusterLocal: true
+        hosts:
+          - "*.%s.svc.cluster.local"
 `,
 				ns.Name())
 			return nil


### PR DESCRIPTION
Moving the logic into PushContext so that it can leverage
existing utilities for host matching.