### PR TITLE
Modify the istioctl status bar

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/emicklei/go-restful v2.9.6+incompatible // indirect
 	github.com/envoyproxy/go-control-plane v0.9.5-0.20200326174812-e8bd2869ff56
 	github.com/evanphx/json-patch v4.5.0+incompatible
+	github.com/fatih/color v1.7.0
 	github.com/fluent/fluent-logger-golang v1.3.0
 	github.com/frankban/quicktest v1.4.1 // indirect
 	github.com/fsnotify/fsnotify v1.4.7

--- a/go.sum
+++ b/go.sum
@@ -1019,6 +1019,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/cheggaaa/pb.v1 v1.0.25 h1:Ev7yu1/f6+d+b3pi5vPdRPc6nNtP1umSfcWiEfRqv6I=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/d4l3k/messagediff.v1 v1.2.1 h1:70AthpjunwzUiarMHyED52mj9UwtAnE89l1Gmrt3EU0=
 gopkg.in/d4l3k/messagediff.v1 v1.2.1/go.mod h1:EUzikiKadqXWcD1AzJLagx0j/BeeWGtn++04Xniyg44=

--- a/operator/cmd/mesh/manifest-apply.go
+++ b/operator/cmd/mesh/manifest-apply.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,6 +30,7 @@ import (
 	"istio.io/istio/operator/pkg/manifest"
 	"istio.io/istio/operator/pkg/object"
 	"istio.io/istio/operator/pkg/translate"
+	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/operator/pkg/util/clog"
 	"istio.io/pkg/log"
 )
@@ -166,7 +168,7 @@ func ApplyManifests(setOverlay []string, inFilenames []string, force bool, dryRu
 		return err
 	}
 
-	restConfig, clientSet, err := manifest.InitK8SRestClient(kubeConfigPath, context)
+	restConfig, _, err := manifest.InitK8SRestClient(kubeConfigPath, context)
 	if err != nil {
 		return err
 	}
@@ -198,33 +200,21 @@ func ApplyManifests(setOverlay []string, inFilenames []string, force bool, dryRu
 
 	// Needed in case we are running a test through this path that doesn't start a new process.
 	helmreconciler.FlushObjectCaches()
-	reconciler, err := helmreconciler.NewHelmReconciler(client, restConfig, iop, &helmreconciler.Options{DryRun: dryRun, Log: l})
+	opts := &helmreconciler.Options{DryRun: dryRun, Log: l, Wait: wait, ProgressLog: util.NewProgressLog()}
+	reconciler, err := helmreconciler.NewHelmReconciler(client, restConfig, iop, opts)
 	if err != nil {
 		return err
 	}
 	status, err := reconciler.Reconcile()
 	if err != nil {
-		l.LogAndPrintf("\n\n✘ Errors were logged during apply operation:\n\n%s\n", err)
 		return fmt.Errorf("errors occurred during operation")
 	}
 	if status.Status != v1alpha1.InstallStatus_HEALTHY {
 		return fmt.Errorf("errors occurred during operation")
 	}
 
-	if wait {
-		l.LogAndPrint("Waiting for resources to become ready...")
-		objs, err := object.ParseK8sObjectsFromYAMLManifest(reconciler.GetManifests().String())
-		if err != nil {
-			l.LogAndPrintf("\n\n✘ Errors in manifest:\n%s\n", err)
-			return fmt.Errorf("errors during wait")
-		}
-		if err := manifest.WaitForResources(objs, clientSet, waitTimeout, dryRun, l); err != nil {
-			l.LogAndPrintf("\n\n✘ Errors during wait:\n%s\n", err)
-			return fmt.Errorf("errors during wait")
-		}
-	}
-
-	l.LogAndPrint("\n\n✔ Installation complete\n")
+	check := color.New(color.FgGreen).Sprint("✔")
+	l.LogAndPrint(check + " Installation complete")
 
 	// Save state to cluster in IstioOperator CR.
 	iopStr, err := translate.IOPStoIOPstr(iops, crName, iopv1alpha1.Namespace(iops))

--- a/operator/cmd/mesh/operator-init.go
+++ b/operator/cmd/mesh/operator-init.go
@@ -163,7 +163,7 @@ func applyManifest(manifestStr, componentName string, opts *kubectlcmd.Options, 
 		l.LogAndFatal(err.Error())
 	}
 	if opts.Wait {
-		err := manifest.WaitForResources(objs, clientSet, opts.WaitTimeout, opts.DryRun, l)
+		err := manifest.WaitForResources(objs, clientSet, opts.WaitTimeout, opts.DryRun, nil)
 		if err != nil {
 			out.Err = err
 		}

--- a/operator/cmd/mesh/operator-init.go
+++ b/operator/cmd/mesh/operator-init.go
@@ -158,17 +158,6 @@ func applyManifest(manifestStr, componentName string, opts *kubectlcmd.Options, 
 	opts.Prune = pointer.BoolPtr(false)
 	out, objs := manifest.ApplyManifest(name.ComponentName(componentName), manifestStr, version.OperatorBinaryVersion.String(), "", *opts)
 
-	_, clientSet, err := manifest.InitK8SRestClient(opts.Kubeconfig, opts.Context)
-	if err != nil {
-		l.LogAndFatal(err.Error())
-	}
-	if opts.Wait {
-		err := manifest.WaitForResources(objs, clientSet, opts.WaitTimeout, opts.DryRun, nil)
-		if err != nil {
-			out.Err = err
-		}
-	}
-
 	success := true
 	if out.Err != nil {
 		cs := fmt.Sprintf("Component %s install returned the following errors:", componentName)

--- a/operator/pkg/helmreconciler/reconcile.go
+++ b/operator/pkg/helmreconciler/reconcile.go
@@ -27,10 +27,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"istio.io/api/operator/v1alpha1"
+
 	valuesv1alpha1 "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
-	"istio.io/istio/operator/pkg/manifest"
 	"istio.io/istio/operator/pkg/name"
 	"istio.io/istio/operator/pkg/object"
+	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/operator/pkg/util/clog"
 )
 
@@ -90,6 +91,9 @@ type Options struct {
 	DryRun bool
 	// Log is a console logger for user visible CLI output.
 	Log clog.Logger
+	// Wait determines if we will wait for resources to be fully applied.
+	Wait        bool
+	ProgressLog *util.ProgressLog
 }
 
 var defaultOptions = &Options{Log: clog.NewDefaultLogger()}
@@ -167,7 +171,7 @@ func (h *HelmReconciler) processRecursive(manifests ChartManifestsMap) *v1alpha1
 			status := v1alpha1.InstallStatus_NONE
 			var err error
 			if len(m) != 0 {
-				if processedObjs, err = h.ProcessManifest(m); err != nil {
+				if processedObjs, err = h.ProcessManifest(m, len(componentDependencies[cn]) > 0); err != nil {
 					status = v1alpha1.InstallStatus_ERROR
 				} else if len(processedObjs) != 0 {
 					status = v1alpha1.InstallStatus_HEALTHY
@@ -177,14 +181,6 @@ func (h *HelmReconciler) processRecursive(manifests ChartManifestsMap) *v1alpha1
 			mu.Lock()
 			setStatus(componentStatus, c, status, err)
 			mu.Unlock()
-
-			// If we are depending on a component, we may depend on it actually running (eg Deployment is ready)
-			// For example, for the validation webhook to become ready, so we should wait for it always.
-			if err == nil && len(componentDependencies[cn]) > 0 {
-				if err := manifest.WaitForResources(processedObjs, h.clientSet, internalDepTimeout, h.opts.DryRun, h.opts.Log); err != nil {
-					scope.Errorf("Failed to wait for resource: %v", err)
-				}
-			}
 
 			// Signal all the components that depend on us.
 			for _, ch := range componentDependencies[cn] {

--- a/operator/pkg/util/progress.go
+++ b/operator/pkg/util/progress.go
@@ -1,0 +1,163 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/cheggaaa/pb/v3"
+)
+
+// ProgressLog records the progress of an installation
+type ProgressLog struct {
+	components map[string]*ManifestLog
+	bar        *pb.ProgressBar
+	mu         sync.Mutex
+}
+
+func NewProgressLog() *ProgressLog {
+	return &ProgressLog{
+		components: map[string]*ManifestLog{},
+		bar:        createBar(),
+	}
+}
+
+// createStatus will return a string to report the current status.
+// ex: - Processing resources for components. Waiting for foo, bar
+func (p *ProgressLog) createStatus(maxWidth int) string {
+	comps := []string{}
+	wait := []string{}
+	for c, l := range p.components {
+		comps = append(comps, c)
+		wait = append(wait, l.waiting...)
+	}
+	sort.Strings(comps)
+	sort.Strings(wait)
+	msg := fmt.Sprintf(`Processing resources for components %s.`, strings.Join(comps, ", "))
+	if len(wait) > 0 {
+		msg += fmt.Sprintf(` Waiting for %s`, strings.Join(wait, ", "))
+	}
+	prefix := `{{ yellow (cycle . "-" "-" "-" " ") }} `
+	// reduce by 2 to allow for the "- " that will be added below
+	maxWidth -= 2
+	if maxWidth > 0 && len(msg) > maxWidth {
+		return prefix + msg[:maxWidth-3] + "..."
+	}
+	// cycle will alternate between "-" and " ". "-" is given multiple times to avoid quick flashing back and forth
+	return prefix + msg
+}
+
+// For testing only
+var testWriter *io.Writer
+
+func createBar() *pb.ProgressBar {
+	// Don't set a total and use Static so we can explicitly control when you write. This is needed
+	// for handling the multiline issues.
+	bar := pb.New(0)
+	bar.Set(pb.Static, true)
+	if testWriter != nil {
+		bar.SetWriter(*testWriter)
+	}
+	bar.Start()
+	// if we aren't a terminal, we will return a new line for each new message
+	if !bar.GetBool(pb.Terminal) {
+		bar.Set(pb.ReturnSymbol, "\n")
+	}
+	return bar
+}
+
+// reportProgress will report an update for a given component
+// Because the bar library does not support multiple lines/bars at once, we need to aggregate current
+// progress into a single line. For example "Waiting for x, y, z". Once a component completes, we want
+// a new line created so the information is not lost. To do this, we spin up a new bar with the remaining components
+// on a new line, and create a new bay. For example, this becomes "x succeeded", "waiting for y, z".
+func (p *ProgressLog) reportProgress(component string) func() {
+	return func() {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		cmp := p.components[component]
+		// The component has completed
+		if cmp.finished || cmp.err != "" {
+			if cmp.finished {
+				p.bar.SetTemplateString(fmt.Sprintf(`{{ green "✔" }} Component %s installed`, component))
+			} else {
+				p.bar.SetTemplateString(fmt.Sprintf(`{{ red "✘" }} Component %s encountered an error: %s`, component, cmp.err))
+			}
+			// Close the bar out, outputting a new line
+			p.bar.Finish()
+			p.bar.Write()
+			delete(p.components, component)
+
+			// Now we create a new bar, which will have the remaining components
+			p.bar = createBar()
+			return
+		}
+		p.bar.SetTemplateString(p.createStatus(p.bar.Width()))
+		p.bar.Write()
+	}
+}
+
+func (p *ProgressLog) NewComponent(component string) *ManifestLog {
+	ml := &ManifestLog{
+		report: p.reportProgress(component),
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.components[component] = ml
+	return ml
+}
+
+// ManifestLog records progress for a single component
+type ManifestLog struct {
+	report   func()
+	err      string
+	finished bool
+	waiting  []string
+}
+
+func (p *ManifestLog) ReportProgress() {
+	if p == nil {
+		return
+	}
+	p.report()
+}
+
+func (p *ManifestLog) ReportError(err string) {
+	if p == nil {
+		return
+	}
+	p.err = err
+	p.report()
+}
+
+func (p *ManifestLog) ReportFinished() {
+	if p == nil {
+		return
+	}
+	p.finished = true
+	p.report()
+}
+
+func (p *ManifestLog) ReportWaiting(resources []string) {
+	if p == nil {
+		return
+	}
+	p.waiting = resources
+	p.report()
+}

--- a/operator/pkg/util/progress.go
+++ b/operator/pkg/util/progress.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Istio Authors
+// Copyright 2020 Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,6 +25,9 @@ import (
 )
 
 // ProgressLog records the progress of an installation
+// This aims to provide information about the install of multiple components in parallel, while working
+// around the limitations of the pb library, which will only support single lines. To do this, we aggregate
+// the current components into a single line, and as components complete there final state is persisted to a new line.
 type ProgressLog struct {
 	components map[string]*ManifestLog
 	bar        *pb.ProgressBar
@@ -86,7 +89,7 @@ func createBar() *pb.ProgressBar {
 // Because the bar library does not support multiple lines/bars at once, we need to aggregate current
 // progress into a single line. For example "Waiting for x, y, z". Once a component completes, we want
 // a new line created so the information is not lost. To do this, we spin up a new bar with the remaining components
-// on a new line, and create a new bay. For example, this becomes "x succeeded", "waiting for y, z".
+// on a new line, and create a new bar. For example, this becomes "x succeeded", "waiting for y, z".
 func (p *ProgressLog) reportProgress(component string) func() {
 	return func() {
 		p.mu.Lock()

--- a/operator/pkg/util/progress_test.go
+++ b/operator/pkg/util/progress_test.go
@@ -1,3 +1,17 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package util
 
 import (

--- a/operator/pkg/util/progress_test.go
+++ b/operator/pkg/util/progress_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Istio Authors
+// Copyright 2020 Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/operator/pkg/util/progress_test.go
+++ b/operator/pkg/util/progress_test.go
@@ -1,0 +1,49 @@
+package util
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+func TestProgressLog(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	testBuf := io.Writer(buf)
+	testWriter = &testBuf
+	expected := ""
+	expect := func(e string) {
+		t.Helper()
+		// In buffer mode we don't overwrite old data, so we are constantly appending to the expected
+		newExpected := expected + "\n" + e
+		if newExpected != buf.String() {
+			t.Fatalf("expected '%v', got '%v'", e, buf.String())
+		}
+		expected = newExpected
+	}
+
+	p := NewProgressLog()
+	foo := p.NewComponent("foo")
+	foo.ReportProgress()
+	expect(`- Processing resources for components foo.`)
+
+	bar := p.NewComponent("bar")
+	bar.ReportProgress()
+	// string buffer won't rewrite, so we append
+	expect(`- Processing resources for components bar, foo.`)
+	bar.ReportProgress()
+	expect(`- Processing resources for components bar, foo.`)
+	bar.ReportProgress()
+	expect(`  Processing resources for components bar, foo.`)
+
+	bar.ReportWaiting([]string{"deployment"})
+	expect(`- Processing resources for components bar, foo. Waiting for deployment`)
+
+	bar.ReportError("some error")
+	expect(`✘ Component bar encountered an error: some error`)
+
+	foo.ReportProgress()
+	expect(`- Processing resources for components foo.`)
+
+	foo.ReportFinished()
+	expect(`✔ Component foo installed`)
+}


### PR DESCRIPTION
This expands on the progress bar @ostromart originally added. End result: https://asciinema.org/a/j0aMW45OGrsf2c6qTRORhrzyL

This fixes some issues with the existing bar:
* When applying components in parallel, the bars conflict with eachother
* When not in a tty, the output is a mess. Its not perfect now, but each time the message changes it outputs a new line so its not too bad

and it also makes some stylistic changes to keep things minimal while still exposing the same information.

Additionally, the wait logic had to be slightly reworked