### PR TITLE
Change mesh config injection to proxy config

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -45,7 +45,7 @@ data:
     accessLogFormat: ""
     defaultConfig:
       concurrency: 2
-      configPath: /etc/istio/proxy
+      configPath: ./etc/istio/proxy
       connectTimeout: 10s
       controlPlaneAuthPolicy: NONE
       discoveryAddress: istiod.istio-system.svc:15012
@@ -493,9 +493,9 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
-                 {{ protoToJSON .MeshConfig }}
+                 {{ protoToJSON .ProxyConfig }}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -174,9 +174,9 @@ template: |
       valueFrom:
         fieldRef:
           fieldPath: status.hostIP
-    - name: MESH_CONFIG
+    - name: PROXY_CONFIG
       value: |
-             {{ protoToJSON .MeshConfig }}
+             {{ protoToJSON .ProxyConfig }}
     - name: ISTIO_META_POD_PORTS
       value: |-
         [

--- a/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
@@ -135,7 +135,7 @@
       #
       ### ADVANCED SETTINGS #############
       # Where should envoy's configuration be stored in the istio-proxy container
-      configPath: "/etc/istio/proxy"
+      configPath: "./etc/istio/proxy"
       # The pseudo service name used for Envoy.
       serviceCluster: istio-proxy
       # These settings that determine how long an old Envoy

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -174,9 +174,9 @@ template: |
       valueFrom:
         fieldRef:
           fieldPath: status.hostIP
-    - name: MESH_CONFIG
+    - name: PROXY_CONFIG
       value: |
-             {{ protoToJSON .MeshConfig }}
+             {{ protoToJSON .ProxyConfig }}
     - name: ISTIO_META_POD_PORTS
       value: |-
         [

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/templates/configmap.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/templates/configmap.yaml
@@ -135,7 +135,7 @@
       #
       ### ADVANCED SETTINGS #############
       # Where should envoy's configuration be stored in the istio-proxy container
-      configPath: "/etc/istio/proxy"
+      configPath: "./etc/istio/proxy"
       # The pseudo service name used for Envoy.
       serviceCluster: istio-proxy
       # These settings that determine how long an old Envoy

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -8369,7 +8369,7 @@ data:
     accessLogFormat: ""
     defaultConfig:
       concurrency: 2
-      configPath: /etc/istio/proxy
+      configPath: ./etc/istio/proxy
       connectTimeout: 10s
       controlPlaneAuthPolicy: NONE
       discoveryAddress: istiod.istio-system.svc:15012
@@ -8908,9 +8908,9 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
-                 {{ protoToJSON .MeshConfig }}
+                 {{ protoToJSON .ProxyConfig }}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
@@ -7009,7 +7009,7 @@ data:
     accessLogFormat: ""
     defaultConfig:
       concurrency: 2
-      configPath: /etc/istio/proxy
+      configPath: ./etc/istio/proxy
       connectTimeout: 10s
       controlPlaneAuthPolicy: NONE
       discoveryAddress: istiod.istio-system.svc:15012
@@ -7546,9 +7546,9 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
-                 {{ protoToJSON .MeshConfig }}
+                 {{ protoToJSON .ProxyConfig }}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.golden.yaml
@@ -360,9 +360,9 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
-                 {{ protoToJSON .MeshConfig }}
+                 {{ protoToJSON .ProxyConfig }}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -64,7 +64,7 @@ data:
     accessLogFormat: ""
     defaultConfig:
       concurrency: 2
-      configPath: /etc/istio/proxy
+      configPath: ./etc/istio/proxy
       connectTimeout: 10s
       controlPlaneAuthPolicy: NONE
       discoveryAddress: istiod.istio-system.svc:15012
@@ -602,9 +602,9 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
-                 {{ protoToJSON .MeshConfig }}
+                 {{ protoToJSON .ProxyConfig }}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_merge_meshconfig.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_merge_meshconfig.golden.yaml
@@ -18,7 +18,7 @@ data:
     accessLogFormat: ""
     defaultConfig:
       concurrency: 2
-      configPath: /etc/istio/proxy
+      configPath: ./etc/istio/proxy
       connectTimeout: 10s
       controlPlaneAuthPolicy: NONE
       discoveryAddress: my-discovery:123

--- a/pilot/cmd/pilot-agent/config.go
+++ b/pilot/cmd/pilot-agent/config.go
@@ -124,17 +124,17 @@ func getMeshConfig(fileOverride, annotationOverride string) (meshconfig.MeshConf
 		mc = *fileMesh
 	}
 
-	if meshConfig != "" {
-		log.Infof("Apply mesh config from env %v", meshConfig)
-		envMesh, err := mesh.ApplyMeshConfig(meshConfig, mc)
+	if proxyConfigEnv != "" {
+		log.Infof("Apply proxy config from env %v", proxyConfigEnv)
+		envMesh, err := mesh.ApplyProxyConfig(proxyConfigEnv, mc)
 		if err != nil || envMesh == nil {
-			return meshconfig.MeshConfig{}, fmt.Errorf("failed to unmarshal mesh config from environment [%v]: %v", meshConfig, err)
+			return meshconfig.MeshConfig{}, fmt.Errorf("failed to unmarshal mesh config from environment [%v]: %v", proxyConfigEnv, err)
 		}
 		mc = *envMesh
 	}
 
 	if annotationOverride != "" {
-		log.Infof("Apply mesh config from annotation %v", annotationOverride)
+		log.Infof("Apply proxy config from annotation %v", annotationOverride)
 		annotationMesh, err := mesh.ApplyProxyConfig(annotationOverride, mc)
 		if err != nil || annotationMesh == nil {
 			return meshconfig.MeshConfig{}, fmt.Errorf("failed to unmarshal mesh config from annotation [%v]: %v", annotationOverride, err)

--- a/pilot/cmd/pilot-agent/config_test.go
+++ b/pilot/cmd/pilot-agent/config_test.go
@@ -27,12 +27,16 @@ import (
 )
 
 func TestGetMeshConfig(t *testing.T) {
-	overrides := `
+	meshOverride := `
 defaultConfig:
   discoveryAddress: foo:123
   proxyMetadata:
     SOME: setting
   drainDuration: 1s`
+	proxyOverride := `discoveryAddress: foo:123
+proxyMetadata:
+  SOME: setting
+drainDuration: 1s`
 	overridesExpected := func() meshconfig.ProxyConfig {
 		m := mesh.DefaultProxyConfig()
 		m.DiscoveryAddress = "foo:123"
@@ -52,21 +56,18 @@ defaultConfig:
 			expect: mesh.DefaultProxyConfig(),
 		},
 		{
-			name: "Annotation Override",
-			annotation: `discoveryAddress: foo:123
-proxyMetadata:
-  SOME: setting
-drainDuration: 1s`,
-			expect: overridesExpected,
+			name:       "Annotation Override",
+			annotation: proxyOverride,
+			expect:     overridesExpected,
 		},
 		{
 			name:   "File Override",
-			file:   overrides,
+			file:   meshOverride,
 			expect: overridesExpected,
 		},
 		{
 			name:        "Environment Override",
-			environment: overrides,
+			environment: proxyOverride,
 			expect:      overridesExpected,
 		},
 		{
@@ -81,10 +82,9 @@ defaultConfig:
     SOME: setting
   drainDuration: 1s`,
 			environment: `
-defaultConfig:
-  discoveryAddress: environment:123
-  proxyMetadata:
-    OTHER: option`,
+discoveryAddress: environment:123
+proxyMetadata:
+OTHER: option`,
 			annotation: `
 discoveryAddress: annotation:123
 proxyMetadata:
@@ -102,7 +102,7 @@ drainDuration: 5s
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			meshConfig = tt.environment
+			proxyConfigEnv = tt.environment
 			got, err := getMeshConfig(tt.file, tt.annotation)
 			if err != nil {
 				t.Fatal(err)

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -425,8 +425,8 @@ func init() {
 		"The identity used as the suffix for mixer's spiffe SAN. This would only be used by pilot all other proxy would get this value from pilot")
 
 	proxyCmd.PersistentFlags().StringVar(&meshConfigFile, "meshConfig", "./etc/istio/config/mesh",
-		"File name for Istio mesh configuration. If not specified, a default mesh will be used. This may be overriden by "+
-		"PROXY_CONFIG environment variable or istio.io/proxyConfig annotation.")
+		"File name for Istio mesh configuration. If not specified, a default mesh will be used. This may be overridden by "+
+			"PROXY_CONFIG environment variable or istio.io/proxyConfig annotation.")
 	proxyCmd.PersistentFlags().IntVar(&stsPort, "stsPort", 0,
 		"HTTP Port on which to serve Security Token Service (STS). If zero, STS service will not be provided.")
 	proxyCmd.PersistentFlags().StringVar(&tokenManagerPlugin, "tokenManagerPlugin", tokenmanager.GoogleTokenExchange,

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -425,7 +425,8 @@ func init() {
 		"The identity used as the suffix for mixer's spiffe SAN. This would only be used by pilot all other proxy would get this value from pilot")
 
 	proxyCmd.PersistentFlags().StringVar(&meshConfigFile, "meshConfig", "./etc/istio/config/mesh",
-		"File name for Istio mesh configuration. If not specified, a default mesh will be used. MESH_CONFIG environment variable takes precedence.")
+		"File name for Istio mesh configuration. If not specified, a default mesh will be used. This may be overriden by "+
+		"PROXY_CONFIG environment variable or istio.io/proxyConfig annotation.")
 	proxyCmd.PersistentFlags().IntVar(&stsPort, "stsPort", 0,
 		"HTTP Port on which to serve Security Token Service (STS). If zero, STS service will not be provided.")
 	proxyCmd.PersistentFlags().StringVar(&tokenManagerPlugin, "tokenManagerPlugin", tokenmanager.GoogleTokenExchange,

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -98,7 +98,11 @@ var (
 	outputKeyCertToDir = env.RegisterStringVar("OUTPUT_CERTS", "",
 		"The output directory for the key and certificate. If empty, key and certificate will not be saved. "+
 			"Must be set for VMs using provisioning certificates.").Get()
-	meshConfig = env.RegisterStringVar("MESH_CONFIG", "", "The mesh configuration").Get()
+	proxyConfigEnv = env.RegisterStringVar(
+		"PROXY_CONFIG",
+		"",
+		"The proxy configuration. This will be set by the injection - gateways will use file mounts.",
+	).Get()
 
 	rootCmd = &cobra.Command{
 		Use:          "pilot-agent",

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -851,7 +851,7 @@ func structToJSON(v interface{}) string {
 }
 
 func protoToJSON(v proto.Message) string {
-	v = cleanMeshConfig(v)
+	v = cleanProxyConfig(v)
 	if v == nil {
 		return "{}"
 	}
@@ -866,7 +866,15 @@ func protoToJSON(v proto.Message) string {
 	return ba
 }
 
-func cleanProxyConfig(pc meshconfig.ProxyConfig) *meshconfig.ProxyConfig {
+// Rather than dump the entire proxy config, we remove fields that are default
+// This makes the pod spec much smaller
+// This is not comprehensive code, but nothing will break if this misses some fields
+func cleanProxyConfig(msg proto.Message) proto.Message {
+	originalProxyConfig, ok := msg.(*meshconfig.ProxyConfig)
+	if !ok || originalProxyConfig == nil {
+		return msg
+	}
+	pc := *originalProxyConfig
 	defaults := mesh.DefaultProxyConfig()
 	if pc.ConfigPath == defaults.ConfigPath {
 		pc.ConfigPath = ""
@@ -892,6 +900,9 @@ func cleanProxyConfig(pc meshconfig.ProxyConfig) *meshconfig.ProxyConfig {
 	if reflect.DeepEqual(pc.EnvoyAccessLogService, defaults.EnvoyAccessLogService) {
 		pc.EnvoyAccessLogService = nil
 	}
+	if reflect.DeepEqual(pc.Tracing, defaults.Tracing) {
+		pc.Tracing = nil
+	}
 	if pc.ProxyAdminPort == defaults.ProxyAdminPort {
 		pc.ProxyAdminPort = 0
 	}
@@ -901,105 +912,10 @@ func cleanProxyConfig(pc meshconfig.ProxyConfig) *meshconfig.ProxyConfig {
 	if pc.StatusPort == defaults.StatusPort {
 		pc.StatusPort = 0
 	}
-	return &pc
-}
-
-// Rather than dump the entire proxy config, we remove fields that are default
-// This makes the pod spec much smaller
-// This is not comprehensive code, but nothing will break if this misses some fields
-func cleanMeshConfig(v proto.Message) proto.Message {
-	mc, ok := v.(*meshconfig.MeshConfig)
-	if !ok || mc == nil {
-		return v
+	if pc.Concurrency == defaults.Concurrency {
+		pc.Concurrency = 0
 	}
-
-	cpy := *mc
-
-	defaults := mesh.DefaultMeshConfig()
-	if reflect.DeepEqual(cpy.DefaultConfig, defaults.DefaultConfig) {
-		cpy.DefaultConfig = nil
-	} else if cpy.DefaultConfig != nil {
-		cpy.DefaultConfig = cleanProxyConfig(*cpy.DefaultConfig)
-	}
-	if cpy.DisablePolicyChecks == defaults.DisablePolicyChecks {
-		cpy.DisablePolicyChecks = false
-	}
-	if cpy.DisableMixerHttpReports == defaults.DisableMixerHttpReports {
-		cpy.DisableMixerHttpReports = false
-	}
-	if cpy.EnableTracing == defaults.EnableTracing {
-		cpy.EnableTracing = false
-	}
-	if cpy.ProxyListenPort == defaults.ProxyListenPort {
-		cpy.ProxyListenPort = 0
-	}
-	if cpy.ReportBatchMaxEntries == defaults.ReportBatchMaxEntries {
-		cpy.ReportBatchMaxEntries = 0
-	}
-	if reflect.DeepEqual(cpy.ConnectTimeout, defaults.ConnectTimeout) {
-		cpy.ConnectTimeout = nil
-	}
-	if reflect.DeepEqual(cpy.DnsRefreshRate, defaults.DnsRefreshRate) {
-		cpy.DnsRefreshRate = nil
-	}
-	if reflect.DeepEqual(cpy.ProtocolDetectionTimeout, defaults.ProtocolDetectionTimeout) {
-		cpy.ProtocolDetectionTimeout = nil
-	}
-	if reflect.DeepEqual(cpy.DefaultServiceExportTo, defaults.DefaultServiceExportTo) {
-		cpy.DefaultServiceExportTo = nil
-	}
-	if reflect.DeepEqual(cpy.DefaultVirtualServiceExportTo, defaults.DefaultVirtualServiceExportTo) {
-		cpy.DefaultVirtualServiceExportTo = nil
-	}
-	if reflect.DeepEqual(cpy.DefaultDestinationRuleExportTo, defaults.DefaultDestinationRuleExportTo) {
-		cpy.DefaultDestinationRuleExportTo = nil
-	}
-	if reflect.DeepEqual(cpy.EnableAutoMtls, defaults.EnableAutoMtls) {
-		cpy.EnableAutoMtls = nil
-	}
-	if reflect.DeepEqual(cpy.TrustDomainAliases, defaults.TrustDomainAliases) {
-		cpy.TrustDomainAliases = nil
-	}
-	if reflect.DeepEqual(cpy.OutboundTrafficPolicy, defaults.OutboundTrafficPolicy) {
-		cpy.OutboundTrafficPolicy = nil
-	}
-	if reflect.DeepEqual(cpy.Certificates, defaults.Certificates) {
-		cpy.Certificates = nil
-	}
-	if reflect.DeepEqual(cpy.LocalityLbSetting, defaults.LocalityLbSetting) {
-		cpy.LocalityLbSetting = nil
-	}
-	if reflect.DeepEqual(cpy.ReportBatchMaxTime, defaults.ReportBatchMaxTime) {
-		cpy.ReportBatchMaxTime = nil
-	}
-	if reflect.DeepEqual(cpy.ThriftConfig, defaults.ThriftConfig) {
-		cpy.ThriftConfig = nil
-	}
-	if cpy.IngressService == defaults.IngressService {
-		cpy.IngressService = ""
-	}
-	if cpy.IngressClass == defaults.IngressClass {
-		cpy.IngressClass = ""
-	}
-	if cpy.AccessLogFile == defaults.AccessLogFile {
-		cpy.AccessLogFile = ""
-	}
-	if cpy.RootNamespace == defaults.RootNamespace {
-		cpy.RootNamespace = ""
-	}
-	if cpy.TrustDomain == defaults.TrustDomain {
-		cpy.TrustDomain = ""
-	}
-	if cpy.SdsUdsPath == defaults.SdsUdsPath {
-		cpy.SdsUdsPath = ""
-	}
-	if cpy.IngressControllerMode == defaults.IngressControllerMode {
-		cpy.IngressControllerMode = meshconfig.MeshConfig_UNSPECIFIED
-	}
-	if reflect.DeepEqual(cpy.ServiceSettings, defaults.ServiceSettings) {
-		cpy.ServiceSettings = nil
-	}
-	return &cpy
+	return proto.Message(&pc)
 }
 
 func toJSON(m map[string]string) string {

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -97,7 +97,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -94,7 +94,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
@@ -96,7 +96,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
@@ -77,7 +77,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
@@ -97,7 +97,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
@@ -77,7 +77,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
@@ -81,7 +81,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
@@ -96,7 +96,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
@@ -77,7 +77,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
@@ -87,7 +87,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -67,7 +67,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
-            - name: MESH_CONFIG
+            - name: PROXY_CONFIG
               value: |
                 {}
             - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -71,7 +71,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -86,7 +86,7 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
-          - name: MESH_CONFIG
+          - name: PROXY_CONFIG
             value: |
               {}
           - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -71,7 +71,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
@@ -74,7 +74,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -73,9 +73,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
-            {"defaultConfig":{"drainDuration":"23s","parentShutdownDuration":"42s"}}
+            {"drainDuration":"23s","parentShutdownDuration":"42s"}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -90,7 +90,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
@@ -74,7 +74,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -75,7 +75,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS
@@ -284,7 +284,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -74,7 +74,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -74,7 +74,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -73,9 +73,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
-            {"defaultConfig":{"interceptionMode":"TPROXY"}}
+            {"interceptionMode":"TPROXY"}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -65,7 +65,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -74,7 +74,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -74,7 +74,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -91,7 +91,7 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
-          - name: MESH_CONFIG
+          - name: PROXY_CONFIG
             value: |
               {}
           - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -77,7 +77,7 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
-          - name: MESH_CONFIG
+          - name: PROXY_CONFIG
             value: |
               {}
           - name: ISTIO_META_POD_PORTS
@@ -285,7 +285,7 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
-          - name: MESH_CONFIG
+          - name: PROXY_CONFIG
             value: |
               {}
           - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
@@ -75,7 +75,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -59,7 +59,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.hostIP
-    - name: MESH_CONFIG
+    - name: PROXY_CONFIG
       value: |
         {}
     - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -68,7 +68,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -67,7 +67,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -76,7 +76,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -74,7 +74,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -69,7 +69,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -70,7 +70,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -70,7 +70,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -75,9 +75,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
-            {"defaultConfig":{"discoveryAddress":"foo:123","proxyMetadata":{"FOO":"bar"}}}
+            {"discoveryAddress":"foo:123","proxyMetadata":{"FOO":"bar"}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -69,7 +69,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -70,7 +70,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: MESH_CONFIG
+        - name: PROXY_CONFIG
           value: |
             {}
         - name: ISTIO_META_POD_PORTS

--- a/tools/packaging/common/istio-start.sh
+++ b/tools/packaging/common/istio-start.sh
@@ -108,11 +108,10 @@ ISTIO_AGENT_FLAGS=${ISTIO_AGENT_FLAGS:-}
 # Split ISTIO_AGENT_FLAGS by spaces.
 IFS=' ' read -r -a ISTIO_AGENT_FLAGS_ARRAY <<< "$ISTIO_AGENT_FLAGS"
 
-export MESH_CONFIG=${MESH_CONFIG:-"
-defaultConfig:
-  serviceCluster: $SVC
-  controlPlaneAuthPolicy: ${CONTROL_PLANE_AUTH_POLICY}
-  discoveryAddress: ${PILOT_ADDRESS}
+export PROXY_CONFIG=${PROXY_CONFIG:-"
+serviceCluster: $SVC
+controlPlaneAuthPolicy: ${CONTROL_PLANE_AUTH_POLICY}
+discoveryAddress: ${PILOT_ADDRESS}
 "}
 
 if [ ${EXEC_USER} == "${USER:-}" ] ; then


### PR DESCRIPTION
We recently decided to move from injecting the mesh config to the proxy
config. This aligns with the annotation override we added. The intent
here is that all config for the proxy will be in proxy config -- if
there is ever a meshconfig field we want in the proxy we will need to
move it.