### PR TITLE
Fix download scripts

### DIFF
--- a/release/downloadIstioCandidate.sh
+++ b/release/downloadIstioCandidate.sh
@@ -43,20 +43,20 @@ if [ "x${ISTIO_VERSION}" = "x" ] ; then
 fi
 
 LOCAL_ARCH=$(uname -m)
-if [[ ${TARGET_ARCH} ]]; then
+if [ ${TARGET_ARCH} ]; then
     LOCAL_ARCH=${TARGET_ARCH}
 fi
 
-if [[ ${LOCAL_ARCH} == x86_64 ]]; then
+if [ ${LOCAL_ARCH} == x86_64 ]; then
     ISTIO_ARCH=amd64
-elif [[ ${LOCAL_ARCH} == armv8* ]]; then
+elif [ ${LOCAL_ARCH} == armv8* ]; then
     ISTIO_ARCH=arm64
-elif [[ ${LOCAL_ARCH} == aarch64* ]]; then
+elif [ ${LOCAL_ARCH} == aarch64* ]; then
     ISTIO_ARCH=arm64
-elif [[ ${LOCAL_ARCH} == armv* ]]; then
+elif [ ${LOCAL_ARCH} == armv* ]; then
     ISTIO_ARCH=armv7
 #also detect the actual arch name allowing users to enter x86_64 or amd64
-elif [[ ${LOCAL_ARCH} == amd64 || ${LOCAL_ARCH} == armv7 || ${LOCAL_ARCH} == arm64 ]]; then
+elif [ ${LOCAL_ARCH} == amd64 ] || [ ${LOCAL_ARCH} == armv7 ] || [ ${LOCAL_ARCH} == arm64 ]; then
     ISTIO_ARCH=${LOCAL_ARCH}
 else
     echo "This system's architecture, ${LOCAL_ARCH}, isn't supported"

--- a/release/downloadIstioCandidate.sh
+++ b/release/downloadIstioCandidate.sh
@@ -43,25 +43,31 @@ if [ "x${ISTIO_VERSION}" = "x" ] ; then
 fi
 
 LOCAL_ARCH=$(uname -m)
-if [ ${TARGET_ARCH} ]; then
+if [ "${TARGET_ARCH}" ]; then
     LOCAL_ARCH=${TARGET_ARCH}
 fi
 
-if [ ${LOCAL_ARCH} == x86_64 ]; then
+case "${LOCAL_ARCH}" in 
+  x86_64)
     ISTIO_ARCH=amd64
-elif [ ${LOCAL_ARCH} == armv8* ]; then
+    ;;
+  armv8*)
     ISTIO_ARCH=arm64
-elif [ ${LOCAL_ARCH} == aarch64* ]; then
+    ;;
+  aarch64*)
     ISTIO_ARCH=arm64
-elif [ ${LOCAL_ARCH} == armv* ]; then
+    ;;
+  armv*)
     ISTIO_ARCH=armv7
-#also detect the actual arch name allowing users to enter x86_64 or amd64
-elif [ ${LOCAL_ARCH} == amd64 ] || [ ${LOCAL_ARCH} == armv7 ] || [ ${LOCAL_ARCH} == arm64 ]; then
+    ;;
+  amd64|arm64)
     ISTIO_ARCH=${LOCAL_ARCH}
-else
+    ;;
+  *)
     echo "This system's architecture, ${LOCAL_ARCH}, isn't supported"
     exit 1
-fi
+    ;;
+esac
 
 if [ "x${ISTIO_VERSION}" = "x" ] ; then
   printf "Unable to get latest Istio version. Set ISTIO_VERSION env var and re-run. For example: export ISTIO_VERSION=1.0.4"

--- a/release/downloadIstioCandidate.sh
+++ b/release/downloadIstioCandidate.sh
@@ -42,6 +42,13 @@ if [ "x${ISTIO_VERSION}" = "x" ] ; then
 		  grep -v -E "(alpha|beta|rc)\.[0-9]$" | sort -t"." -k 1,1 -k 2,2 -k 3,3 -k 4,4 | tail -n 1)
 fi
 
+if [ "x${ISTIO_ARCH}" = "x" ]; then
+  ISTIO_ARCH=$(arch)
+fi
+
+#for now this supports amd64, which has arch output of x86_64. Thhe arch command will let us switch based on host
+ISTIO_ARCH="amd64"
+
 if [ "x${ISTIO_VERSION}" = "x" ] ; then
   printf "Unable to get latest Istio version. Set ISTIO_VERSION env var and re-run. For example: export ISTIO_VERSION=1.0.4"
   exit;
@@ -49,28 +56,43 @@ fi
 
 NAME="istio-$ISTIO_VERSION"
 URL="https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/istio-${ISTIO_VERSION}-${OSEXT}.tar.gz"
+ARCH_URL="https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/istio-${ISTIO_VERSION}-${OSEXT}-${ISTIO_ARCH}.tar.gz"
+
 printf "Downloading %s from %s ..." "$NAME" "$URL"
-if ! curl -L "$URL" | tar xz
+if ! curl -fsLO "$URL"
 then
-  printf "\n\n"
-  printf "Unable to download Istio %s at this moment!\n" "$ISTIO_VERSION"
-  printf "Please verify the version you are trying to download.\n\n"
+  printf "Failed.\n\n Trying with ISTIO_ARCH. Downloading %s from %s ...\n" "$NAME" "$ARCH_URL"
+  if ! curl -fsLO "$ARCH_URL"
+  then
+    printf "\n\n"
+    printf "Unable to download Istio %s at this moment!\n" "$ISTIO_VERSION"
+    printf "Please verify the version you are trying to download.\n\n"
+    exit
+  else
+    filename="istio-${ISTIO_VERSION}-${OSEXT}-${ISTIO_ARCH}.tar.gz"
+    tar -xzf "${filename}"
+    rm "${filename}"
+  fi
 else
-  printf ""
-  printf "Istio %s Download Complete!\n" "$ISTIO_VERSION"
-  printf "\n"
-  printf "Istio has been successfully downloaded into the %s folder on your system.\n" "$NAME"
-  printf "\n"
-  BINDIR="$(cd "$NAME/bin" && pwd)"
-  printf "Next Steps:\n"
-  printf "See https://istio.io/docs/setup/kubernetes/install/ to add Istio to your Kubernetes cluster.\n"
-  printf "\n"
-  printf "To configure the istioctl client tool for your workstation,\n"
-  printf "add the %s directory to your environment path variable with:\n" "$BINDIR"
-  printf "\t export PATH=\"\$PATH:%s\"\n" "$BINDIR"
-  printf "\n"
-  printf "Begin the Istio pre-installation verification check by running:\n"
-  printf "\t istioctl verify-install \n"
-  printf "\n"
-  printf "Need more information? Visit https://istio.io/docs/setup/kubernetes/install/ \n"
+  filename="istio-${ISTIO_VERSION}-${OSEXT}.tar.gz"
+  tar -xzf "${filename}"
+  rm "${filename}"
 fi
+
+printf ""
+printf "\nIstio %s Download Complete!\n" "$ISTIO_VERSION"
+printf "\n"
+printf "Istio has been successfully downloaded into the %s folder on your system.\n" "$NAME"
+printf "\n"
+BINDIR="$(cd "$NAME/bin" && pwd)"
+printf "Next Steps:\n"
+printf "See https://istio.io/docs/setup/kubernetes/install/ to add Istio to your Kubernetes cluster.\n"
+printf "\n"
+printf "To configure the istioctl client tool for your workstation,\n"
+printf "add the %s directory to your environment path variable with:\n" "$BINDIR"
+printf "\t export PATH=\"\$PATH:%s\"\n" "$BINDIR"
+printf "\n"
+printf "Begin the Istio pre-installation verification check by running:\n"
+printf "\t istioctl verify-install \n"
+printf "\n"
+printf "Need more information? Visit https://istio.io/docs/setup/kubernetes/install/ \n"

--- a/release/downloadIstioCtl.sh
+++ b/release/downloadIstioCtl.sh
@@ -45,20 +45,20 @@ if [ "x${ISTIO_VERSION}" = "x" ] ; then
 fi
 
 LOCAL_ARCH=$(uname -m)
-if [[ ${TARGET_ARCH} ]]; then
+if [ ${TARGET_ARCH} ]; then
     LOCAL_ARCH=${TARGET_ARCH}
 fi
 
-if [[ ${LOCAL_ARCH} == x86_64 ]]; then
+if [ ${LOCAL_ARCH} == x86_64 ]; then
     ISTIO_ARCH=amd64
-elif [[ ${LOCAL_ARCH} == armv8* ]]; then
+elif [ ${LOCAL_ARCH} == armv8* ]; then
     ISTIO_ARCH=arm64
-elif [[ ${LOCAL_ARCH} == aarch64* ]]; then
+elif [ ${LOCAL_ARCH} == aarch64* ]; then
     ISTIO_ARCH=arm64
-elif [[ ${LOCAL_ARCH} == armv* ]]; then
+elif [ ${LOCAL_ARCH} == armv* ]; then
     ISTIO_ARCH=armv7
 #also detect the actual arch name allowing users to enter x86_64 or amd64
-elif [[ ${LOCAL_ARCH} == amd64 || ${LOCAL_ARCH} == armv7 || ${LOCAL_ARCH} == arm64 ]]; then
+elif [ ${LOCAL_ARCH} == amd64 ] || [ ${LOCAL_ARCH} == armv7 ] || [ ${LOCAL_ARCH} == arm64 ]; then
     ISTIO_ARCH=${LOCAL_ARCH}
 else
     echo "This system's architecture, ${LOCAL_ARCH}, isn't supported"

--- a/release/downloadIstioCtl.sh
+++ b/release/downloadIstioCtl.sh
@@ -44,12 +44,26 @@ if [ "x${ISTIO_VERSION}" = "x" ] ; then
   exit;
 fi
 
-if [ "x${ISTIO_ARCH}" = "x" ]; then
-  ISTIO_ARCH=$(arch)
+LOCAL_ARCH=$(uname -m)
+if [[ ${TARGET_ARCH} ]]; then
+    LOCAL_ARCH=${TARGET_ARCH}
 fi
 
-#for now this supports amd64, which has arch output of x86_64. Thhe arch command will let us switch based on host
-ISTIO_ARCH="amd64"
+if [[ ${LOCAL_ARCH} == x86_64 ]]; then
+    ISTIO_ARCH=amd64
+elif [[ ${LOCAL_ARCH} == armv8* ]]; then
+    ISTIO_ARCH=arm64
+elif [[ ${LOCAL_ARCH} == aarch64* ]]; then
+    ISTIO_ARCH=arm64
+elif [[ ${LOCAL_ARCH} == armv* ]]; then
+    ISTIO_ARCH=armv7
+#also detect the actual arch name allowing users to enter x86_64 or amd64
+elif [[ ${LOCAL_ARCH} == amd64 || ${LOCAL_ARCH} == armv7 || ${LOCAL_ARCH} == arm64 ]]; then
+    ISTIO_ARCH=${LOCAL_ARCH}
+else
+    echo "This system's architecture, ${LOCAL_ARCH}, isn't supported"
+    exit 1
+fi
 
 download_failed () {
   printf "Download failed, please make sure your ISTIO_VERSION is correct and verify the download URL exists!"

--- a/release/downloadIstioCtl.sh
+++ b/release/downloadIstioCtl.sh
@@ -45,25 +45,31 @@ if [ "x${ISTIO_VERSION}" = "x" ] ; then
 fi
 
 LOCAL_ARCH=$(uname -m)
-if [ ${TARGET_ARCH} ]; then
+if [ "${TARGET_ARCH}" ]; then
     LOCAL_ARCH=${TARGET_ARCH}
 fi
 
-if [ ${LOCAL_ARCH} == x86_64 ]; then
+case "${LOCAL_ARCH}" in 
+  x86_64)
     ISTIO_ARCH=amd64
-elif [ ${LOCAL_ARCH} == armv8* ]; then
+    ;;
+  armv8*)
     ISTIO_ARCH=arm64
-elif [ ${LOCAL_ARCH} == aarch64* ]; then
+    ;;
+  aarch64*)
     ISTIO_ARCH=arm64
-elif [ ${LOCAL_ARCH} == armv* ]; then
+    ;;
+  armv*)
     ISTIO_ARCH=armv7
-#also detect the actual arch name allowing users to enter x86_64 or amd64
-elif [ ${LOCAL_ARCH} == amd64 ] || [ ${LOCAL_ARCH} == armv7 ] || [ ${LOCAL_ARCH} == arm64 ]; then
+    ;;
+  amd64|arm64)
     ISTIO_ARCH=${LOCAL_ARCH}
-else
+    ;;
+  *)
     echo "This system's architecture, ${LOCAL_ARCH}, isn't supported"
     exit 1
-fi
+    ;;
+esac
 
 download_failed () {
   printf "Download failed, please make sure your ISTIO_VERSION is correct and verify the download URL exists!"

--- a/release/downloadIstioCtl.sh
+++ b/release/downloadIstioCtl.sh
@@ -29,7 +29,6 @@ if [ "x${OS}" = "xDarwin" ] ; then
   OSEXT="osx"
 else
   OSEXT="linux"
-
 fi
 
 # Determines the istioctl version.
@@ -87,7 +86,7 @@ ARCH_URL="https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/isti
 printf "Downloading %s from %s ... \n" "${NAME}" "${URL}"
 if ! curl -fsLO "$URL"
 then
-  printf "Failed. \n\nTrying with ISTIO_ARCH. Downloading %s from %s ...\n" "${NAME}" "$ARCH_URL"
+  printf "Failed. \n\nTrying with TARGET_ARCH. Downloading %s from %s ...\n" "${NAME}" "$ARCH_URL"
   if ! curl -fsLO "$ARCH_URL"
   then
    download_failed


### PR DESCRIPTION
Currently, the downloadIstioCtl and downloadIstioCandidate scripts are broken on release-1.6 due to the fact that the architecture was added to the filename. This PR adds the ability to specify the architecture and download the appropriate version.