### PR TITLE
Fix errors for in-place upgrade 1.6.0 

### DIFF
--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -28,6 +28,7 @@ import (
 
 	iop "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/compare"
+	"istio.io/istio/operator/pkg/name"
 	"istio.io/istio/operator/pkg/tpath"
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/operator/pkg/util/clog"
@@ -190,13 +191,16 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 	if currentVersion != "" {
 		currentSets = append(currentSets, "installPackagePath="+installURLFromVersion(currentVersion))
 	}
-	if targetIOPS.Profile != "" {
+	profile := targetIOPS.Profile
+	if profile == "" {
+		profile = name.DefaultProfileName
+	} else {
 		currentSets = append(currentSets, "profile="+targetIOPS.Profile)
 	}
 	if ysf, err = yamlFromSetFlags(currentSets, args.force, l); err != nil {
 		return err
 	}
-	currentProfileIOPSYaml, _, err := GenerateConfig(nil, ysf, args.force, nil, l)
+	currentProfileIOPSYaml, _, err := genIOPSFromProfile(profile, "", ysf, true, nil, l)
 	if err != nil {
 		return fmt.Errorf("failed to generate Istio configs from file %s for the current version: %s, error: %v",
 			args.inFilenames, currentVersion, err)

--- a/operator/pkg/version/version.go
+++ b/operator/pkg/version/version.go
@@ -184,6 +184,16 @@ func TagToVersionString(path string) (string, error) {
 	return strings.Join(fmtParts, "."), nil
 }
 
+// TagToVersionString converts an istio container tag into a version string,
+// if any error, fallback to use the original tag.
+func TagToVersionStringGrace(path string) string {
+	v, err := TagToVersionString(path)
+	if err != nil {
+		return path
+	}
+	return v
+}
+
 // MajorVersion represents a major version.
 type MajorVersion struct {
 	Major uint32

--- a/operator/version/version.go
+++ b/operator/version/version.go
@@ -41,7 +41,7 @@ func init() {
 	// If dockerinfo has a tag (e.g., specified by LDFlags), we will use it as the version of operator
 	tag := buildversion.DockerInfo.Tag
 	if pkgversion.IsVersionString(tag) {
-		OperatorVersionString = tag
+		OperatorVersionString = pkgversion.TagToVersionStringGrace(tag)
 	}
 	OperatorBinaryGoVersion, err = goversion.NewVersion(OperatorVersionString)
 	if err != nil {


### PR DESCRIPTION
Fix https://github.com/istio/istio/issues/23205: Error for in-place upgrade 1.6.0 

1. Convert tag to the version string.
2. During upgrade, skip validation and warning for old configs