### PR TITLE
guard test output against race conditions

### DIFF
--- a/pkg/test/framework/suite.go
+++ b/pkg/test/framework/suite.go
@@ -324,12 +324,14 @@ func (s *Suite) writeOutput() {
 	artifactsPath := os.Getenv("ARTIFACTS")
 	if artifactsPath != "" {
 		ctx := rt.suiteContext()
+		ctx.outcomeMu.RLock()
 		out := SuiteOutcome{
 			Name:         ctx.Settings().TestID,
 			Environment:  ctx.Environment().EnvironmentName().String(),
 			Multicluster: ctx.Environment().IsMulticluster(),
 			TestOutcomes: ctx.testOutcomes,
 		}
+		ctx.outcomeMu.RUnlock()
 		outbytes, err := yaml.Marshal(out)
 		if err != nil {
 			log.Errorf("failed writing test suite outcome to yaml: %s", err)

--- a/pkg/test/framework/suitecontext.go
+++ b/pkg/test/framework/suitecontext.go
@@ -52,7 +52,9 @@ type suiteContext struct {
 	contextMu    sync.Mutex
 	contextNames map[string]struct{}
 
-	suiteLabels  label.Set
+	suiteLabels label.Set
+
+	outcomeMu    sync.RWMutex
 	testOutcomes []TestOutcome
 }
 
@@ -182,6 +184,8 @@ type TestOutcome struct {
 }
 
 func (s *suiteContext) registerOutcome(test *Test) {
+	s.outcomeMu.Lock()
+	defer s.outcomeMu.Unlock()
 	o := Passed
 	if test.notImplemented {
 		o = NotImplemented


### PR DESCRIPTION
This is intended as a fix for https://prow.istio.io/view/gcs/istio-prow/logs/integ-local-tests_istio_postsubmit/690

It is still unclear why there is a race condition if this function is only called after tests complete.  If by chance tests are not guaranteed to be complete before run() exits, we will be reporting incomplete outcomes.