### PR TITLE
Prevent assets.gen.go from being accidentally modified

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -359,7 +359,10 @@ update-golden: refresh-goldens
 
 gen: go-gen mirror-licenses format update-crds operator-proto gen-kustomize update-golden
 
-gen-check: gen check-clean-repo
+check-no-modify:
+	@bin/check_no_modify.sh
+
+gen-check: gen check-clean-repo check-no-modify
 
 # Generate kustomize templates.
 gen-kustomize:

--- a/bin/check_no_modify.sh
+++ b/bin/check_no_modify.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright 2020 Istio Authors
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+MD5FILE="${SCRIPT_DIR}/nomodify.md5"
+
+md5sum -c  "${MD5FILE}"|| echo "Files above should not be modified in the repo. Please remove the change from your PR or run update_no_modify.sh if you are sure."

--- a/bin/nomodify.md5
+++ b/bin/nomodify.md5
@@ -1,0 +1,1 @@
+3f58f9087d1ac501df2f6ea2cf961cd4  operator/pkg/vfs/assets.gen.go

--- a/bin/update_no_modify.sh
+++ b/bin/update_no_modify.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Copyright 2020 Istio Authors
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+MD5FILE="${SCRIPT_DIR}/nomodify.md5"
+
+# Space separated list of files that should not be modified in the repo.
+NOMODIFY_LIST="../operator/pkg/vfs/assets.gen.go"
+
+md5sum "${NOMODIFY_LIST}" > "${MD5FILE}"


### PR DESCRIPTION
Restores the check that prevents assets.gen.go from being modifed, adds a script to update it easily if needed.