### PR TITLE
test framework: split istioctl stdout and stderr

### DIFF
--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -231,7 +231,7 @@ func deployControlPlane(c *operatorComponent, cfg Config, cluster kube.Cluster, 
 	// Save the manifest generate output so we can later cleanup
 	genCmd := []string{"manifest", "generate"}
 	genCmd = append(genCmd, installSettings...)
-	out, err := istioCtl.Invoke(genCmd)
+	out, _, err := istioCtl.Invoke(genCmd)
 	if err != nil {
 		return err
 	}
@@ -246,7 +246,7 @@ func deployControlPlane(c *operatorComponent, cfg Config, cluster kube.Cluster, 
 	}
 	cmd = append(cmd, installSettings...)
 	scopes.CI.Infof("Running istio control plane on cluster %s %v", cluster.Name(), cmd)
-	if _, err := istioCtl.Invoke(cmd); err != nil {
+	if _, _, err := istioCtl.Invoke(cmd); err != nil {
 		return fmt.Errorf("manifest apply failed: %v", err)
 	}
 
@@ -299,7 +299,7 @@ func createRemoteSecret(ctx resource.Context, cluster kube.Cluster) (string, err
 	}
 
 	scopes.CI.Infof("Creating remote secret for cluster cluster %d %v", cluster.Index(), cmd)
-	out, err := istioCtl.Invoke(cmd)
+	out, _, err := istioCtl.Invoke(cmd)
 	if err != nil {
 		return "", fmt.Errorf("create remote secret failed for cluster %d: %v", cluster.Index(), err)
 	}

--- a/pkg/test/framework/components/istioctl/istioctl.go
+++ b/pkg/test/framework/components/istioctl/istioctl.go
@@ -26,12 +26,11 @@ import (
 // Instance represents "istioctl"
 type Instance interface {
 	// Invoke invokes an istioctl command and returns the output and exception.
-	// Cobra commands don't make it easy to separate stdout and stderr and the string parameter
-	// will receive both.
-	Invoke(args []string) (string, error)
+	// stdout and stderr will be returned as different strings
+	Invoke(args []string) (string, string, error)
 
 	// InvokeOrFail calls Invoke and fails tests if it returns en err
-	InvokeOrFail(t *testing.T, args []string) string
+	InvokeOrFail(t *testing.T, args []string) (string, string)
 }
 
 // Config is structured config for the istioctl component

--- a/pkg/test/framework/components/istioctl/kube.go
+++ b/pkg/test/framework/components/istioctl/kube.go
@@ -47,27 +47,29 @@ func (c *kubeComponent) ID() resource.ID {
 }
 
 // Invoke implements Instance
-func (c *kubeComponent) Invoke(args []string) (string, error) {
+func (c *kubeComponent) Invoke(args []string) (string, string, error) {
 	var cmdArgs = append([]string{
 		"--kubeconfig",
 		c.cluster.Filename(),
 	}, args...)
 
 	var out bytes.Buffer
+	var err bytes.Buffer
 	rootCmd := cmd.GetRootCmd(cmdArgs)
 	rootCmd.SetOut(&out)
-	rootCmd.SetErr(&out)
+	rootCmd.SetErr(&err)
 	fErr := rootCmd.Execute()
-	return out.String(), fErr
+	return out.String(), err.String(), fErr
 }
 
 // InvokeOrFail implements Instance
-func (c *kubeComponent) InvokeOrFail(t *testing.T, args []string) string {
-	output, err := c.Invoke(args)
+func (c *kubeComponent) InvokeOrFail(t *testing.T, args []string) (string, string) {
+	output, stderr, err := c.Invoke(args)
 	if err != nil {
 		t.Logf("Unwanted exception for 'istioctl %s': %v", strings.Join(args, " "), err)
 		t.Logf("Output:\n%v", output)
+		t.Logf("Error:\n%v", stderr)
 		t.FailNow()
 	}
-	return output
+	return output, stderr
 }

--- a/pkg/test/framework/components/istioctl/native.go
+++ b/pkg/test/framework/components/istioctl/native.go
@@ -45,22 +45,24 @@ func (c *nativeComponent) ID() resource.ID {
 }
 
 // Invoke implements Instance
-func (c *nativeComponent) Invoke(args []string) (string, error) {
+func (c *nativeComponent) Invoke(args []string) (string, string, error) {
 	var out bytes.Buffer
+	var err bytes.Buffer
 	rootCmd := cmd.GetRootCmd(args)
 	rootCmd.SetOut(&out)
-	rootCmd.SetErr(&out)
+	rootCmd.SetErr(&err)
 	fErr := rootCmd.Execute()
-	return out.String(), fErr
+	return out.String(), err.String(), fErr
 }
 
 // InvokeOrFail implements Instance
-func (c *nativeComponent) InvokeOrFail(t *testing.T, args []string) string {
-	output, err := c.Invoke(args)
+func (c *nativeComponent) InvokeOrFail(t *testing.T, args []string) (string, string) {
+	output, stderr, err := c.Invoke(args)
 	if err != nil {
 		t.Logf("Unwanted exception for 'istioctl %s': %v", strings.Join(args, " "), err)
 		t.Logf("Output:\n%v", output)
+		t.Logf("Error:\n%v", stderr)
 		t.FailNow()
 	}
-	return output
+	return output, stderr
 }

--- a/tests/integration/galley/analyze_test.go
+++ b/tests/integration/galley/analyze_test.go
@@ -151,8 +151,8 @@ func TestInvalidFileError(t *testing.T) {
 
 			// Parse error as the yaml file itself is not valid yaml.
 			output, err = istioctlSafe(t, istioCtl, ns.Name(), false, invalidFile)
-			g.Expect(output[0]).To(ContainSubstring("Error(s) adding files"))
-			g.Expect(output[1]).To(ContainSubstring(fmt.Sprintf("errors parsing content \"%s\"", invalidFile)))
+			g.Expect(strings.Join(output, "\n")).To(ContainSubstring("Error(s) adding files"))
+			g.Expect(strings.Join(output, "\n")).To(ContainSubstring(fmt.Sprintf("errors parsing content \"%s\"", invalidFile)))
 
 			g.Expect(err).To(MatchError(cmd.FileParseError{}))
 		})
@@ -319,6 +319,7 @@ func expectNoMessages(t *testing.T, g *GomegaWithT, output []string) {
 	g.Expect(output[0]).To(ContainSubstring("No validation issues found when analyzing"))
 }
 
+// istioctlSafe calls istioctl analyze with certain flags set. Stdout and Stderr are merged
 func istioctlSafe(t *testing.T, i istioctl.Instance, ns string, useKube bool, extraArgs ...string) ([]string, error) {
 	t.Helper()
 
@@ -329,11 +330,8 @@ func istioctlSafe(t *testing.T, i istioctl.Instance, ns string, useKube bool, ex
 	args = append(args, fmt.Sprintf("--use-kube=%t", useKube))
 	args = append(args, extraArgs...)
 
-	output, _, err := i.Invoke(args)
-	if output == "" {
-		return []string{}, err
-	}
-	return strings.Split(strings.TrimSpace(output), "\n"), err
+	output, stderr, err := i.Invoke(args)
+	return strings.Split(strings.TrimSpace(output+"\n"+stderr), "\n"), err
 }
 
 func applyFileOrFail(t *testing.T, ns, filename string) {

--- a/tests/integration/galley/analyze_test.go
+++ b/tests/integration/galley/analyze_test.go
@@ -329,7 +329,7 @@ func istioctlSafe(t *testing.T, i istioctl.Instance, ns string, useKube bool, ex
 	args = append(args, fmt.Sprintf("--use-kube=%t", useKube))
 	args = append(args, extraArgs...)
 
-	output, err := i.Invoke(args)
+	output, _, err := i.Invoke(args)
 	if output == "" {
 		return []string{}, err
 	}

--- a/tests/integration/mixer/telemetry/metrics/istioctl_metrics_test.go
+++ b/tests/integration/mixer/telemetry/metrics/istioctl_metrics_test.go
@@ -26,9 +26,9 @@ import (
 func testIstioctl(t *testing.T, ctx framework.TestContext, workload string) { // nolint:interfacer
 	istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
 	args := []string{"experimental", "metrics", workload}
-	output, fErr := istioCtl.Invoke(args)
+	output, stderr, fErr := istioCtl.Invoke(args)
 	if fErr != nil {
-		t.Fatalf("Unwanted exception for 'istioctl %s': %v", strings.Join(args, " "), fErr)
+		t.Fatalf("Unwanted exception for 'istioctl %s': %v. Stderr: %v", strings.Join(args, " "), fErr, stderr)
 	}
 
 	// output will be something like

--- a/tests/integration/operator/switch_cr_test.go
+++ b/tests/integration/operator/switch_cr_test.go
@@ -271,7 +271,7 @@ func compareInClusterAndGeneratedResources(t *testing.T, istioCtl istioctl.Insta
 	if originalIOPFile != "" {
 		generateCmd = append(generateCmd, "-f", originalIOPFile)
 	}
-	genManifests := istioCtl.InvokeOrFail(t, generateCmd)
+	genManifests, _ := istioCtl.InvokeOrFail(t, generateCmd)
 	genK8SObjects, err := object.ParseK8sObjectsFromYAMLManifest(genManifests)
 	if err != nil {
 		return fmt.Errorf("failed to parse generated manifest: %v", err)

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -89,7 +89,7 @@ func TestVersion(t *testing.T) {
 
 			args := []string{"version", "--remote=true", fmt.Sprintf("--istioNamespace=%s", cfg.SystemNamespace)}
 
-			output := istioCtl.InvokeOrFail(t, args)
+			output, _ := istioCtl.InvokeOrFail(t, args)
 
 			// istioctl will return a single "control plane version" if all control plane versions match
 			controlPlaneRegex := regexp.MustCompile(`control plane version: [a-z0-9\-]*`)
@@ -156,12 +156,12 @@ func TestDescribe(t *testing.T) {
 			// run in parallel.
 			args = []string{"--namespace=dummy",
 				"x", "describe", "pod", fmt.Sprintf("%s.%s", podID, ns.Name())}
-			output = istioCtl.InvokeOrFail(t, args)
+			output, _ = istioCtl.InvokeOrFail(t, args)
 			g.Expect(output).To(gomega.MatchRegexp(describePodAOutput))
 
 			args = []string{"--namespace=dummy",
 				"x", "describe", "svc", fmt.Sprintf("a.%s", ns.Name())}
-			output = istioCtl.InvokeOrFail(t, args)
+			output, _ = istioCtl.InvokeOrFail(t, args)
 			g.Expect(output).To(gomega.MatchRegexp(describeSvcAOutput))
 		})
 }
@@ -204,7 +204,7 @@ func TestAddToAndRemoveFromMesh(t *testing.T) {
 			// able to remove from mesh when the deployment is auto injected
 			args = []string{fmt.Sprintf("--namespace=%s", ns.Name()),
 				"x", "remove-from-mesh", "service", "a"}
-			output = istioCtl.InvokeOrFail(t, args)
+			output, _ = istioCtl.InvokeOrFail(t, args)
 			g.Expect(output).To(gomega.MatchRegexp(removeFromMeshPodAOutput))
 
 			// remove from mesh should be clean
@@ -215,7 +215,7 @@ func TestAddToAndRemoveFromMesh(t *testing.T) {
 
 			args = []string{fmt.Sprintf("--namespace=%s", ns.Name()),
 				"x", "add-to-mesh", "service", "a"}
-			output = istioCtl.InvokeOrFail(t, args)
+			output, _ = istioCtl.InvokeOrFail(t, args)
 			g.Expect(output).To(gomega.MatchRegexp(addToMeshPodAOutput))
 		})
 }
@@ -247,37 +247,37 @@ func TestProxyConfig(t *testing.T) {
 
 			args = []string{"--namespace=dummy",
 				"pc", "bootstrap", fmt.Sprintf("%s.%s", podID, ns.Name())}
-			output = istioCtl.InvokeOrFail(t, args)
+			output, _ = istioCtl.InvokeOrFail(t, args)
 			jsonOutput := jsonUnmarshallOrFail(t, strings.Join(args, " "), output)
 			g.Expect(jsonOutput).To(gomega.HaveKey("bootstrap"))
 
 			args = []string{"--namespace=dummy",
 				"pc", "cluster", fmt.Sprintf("%s.%s", podID, ns.Name()), "-o", "json"}
-			output = istioCtl.InvokeOrFail(t, args)
+			output, _ = istioCtl.InvokeOrFail(t, args)
 			jsonOutput = jsonUnmarshallOrFail(t, strings.Join(args, " "), output)
 			g.Expect(jsonOutput).To(gomega.Not(gomega.BeEmpty()))
 
 			args = []string{"--namespace=dummy",
 				"pc", "endpoint", fmt.Sprintf("%s.%s", podID, ns.Name()), "-o", "json"}
-			output = istioCtl.InvokeOrFail(t, args)
+			output, _ = istioCtl.InvokeOrFail(t, args)
 			jsonOutput = jsonUnmarshallOrFail(t, strings.Join(args, " "), output)
 			g.Expect(jsonOutput).To(gomega.Not(gomega.BeEmpty()))
 
 			args = []string{"--namespace=dummy",
 				"pc", "listener", fmt.Sprintf("%s.%s", podID, ns.Name()), "-o", "json"}
-			output = istioCtl.InvokeOrFail(t, args)
+			output, _ = istioCtl.InvokeOrFail(t, args)
 			jsonOutput = jsonUnmarshallOrFail(t, strings.Join(args, " "), output)
 			g.Expect(jsonOutput).To(gomega.Not(gomega.BeEmpty()))
 
 			args = []string{"--namespace=dummy",
 				"pc", "route", fmt.Sprintf("%s.%s", podID, ns.Name()), "-o", "json"}
-			output = istioCtl.InvokeOrFail(t, args)
+			output, _ = istioCtl.InvokeOrFail(t, args)
 			jsonOutput = jsonUnmarshallOrFail(t, strings.Join(args, " "), output)
 			g.Expect(jsonOutput).To(gomega.Not(gomega.BeEmpty()))
 
 			args = []string{"--namespace=dummy",
 				"pc", "secret", fmt.Sprintf("%s.%s", podID, ns.Name()), "-o", "json"}
-			output = istioCtl.InvokeOrFail(t, args)
+			output, _ = istioCtl.InvokeOrFail(t, args)
 			jsonOutput = jsonUnmarshallOrFail(t, strings.Join(args, " "), output)
 			g.Expect(jsonOutput).To(gomega.HaveKey("dynamicActiveSecrets"))
 		})

--- a/tests/integration/security/webhook/webhook_test.go
+++ b/tests/integration/security/webhook/webhook_test.go
@@ -72,7 +72,7 @@ func TestWebhookManagement(t *testing.T) {
 				"dns.istio-galley-service-account", "--namespace", "istio-system", "--validation-path", "./config/galley-webhook.yaml",
 				"--injection-path", "./config/sidecar-injector-webhook.yaml"}
 			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
-			output, fErr := istioCtl.Invoke(args)
+			output, _, fErr := istioCtl.Invoke(args)
 			if fErr != nil {
 				t.Fatalf("error returned for 'istioctl %s': %v", strings.Join(args, " "), fErr)
 			}
@@ -94,7 +94,7 @@ func TestWebhookManagement(t *testing.T) {
 			// Test that webhook statuses returned by running istioctl are as expected.
 			args = []string{"experimental", "post-install", "webhook", "status"}
 			istioCtl = istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
-			output, fErr = istioCtl.Invoke(args)
+			output, _, fErr = istioCtl.Invoke(args)
 			if fErr != nil {
 				t.Fatalf("error returned for 'istioctl %s': %v", strings.Join(args, " "), fErr)
 			}


### PR DESCRIPTION
otherwise we end up writing errors to the output, which breaks our
cleanup. This *might* fix https://github.com/istio/istio/issues/23149