### PR TITLE
removed release label from selector match label for pdb for gateways

### DIFF
--- a/manifests/charts/gateways/istio-ingress/templates/poddisruptionbudget.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/poddisruptionbudget.yaml
@@ -13,5 +13,4 @@ spec:
   selector:
     matchLabels:
 {{ $gateway.labels | toYaml | trim | indent 6 }}
-      release: {{ .Release.Name }}
 {{- end }}


### PR DESCRIPTION



gateway manifest for poddisruptionbudget has in selector matchlabels `release` key. This is not part of the gateway template if the gateway is installed in a namespace other than 'istio-system'.  This results in PDB throwing error during kubectl apply. 
Also the selector for gateway services and deployment does not include `release` key. So, its logical to remove release key from PDB as well.