### PR TITLE
Retry conflicts on reconcile

### DIFF
--- a/operator/pkg/helmreconciler/render.go
+++ b/operator/pkg/helmreconciler/render.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
 	"helm.sh/helm/v3/pkg/releaseutil"
@@ -27,6 +28,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 	util2 "k8s.io/kubectl/pkg/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -358,23 +361,30 @@ func (h *HelmReconciler) ProcessObject(chartName string, obj *unstructured.Unstr
 		return nil
 	}
 
-	err := h.client.Get(context.TODO(), objectKey, receiver)
-	switch {
-	case apierrors.IsNotFound(err):
-		scope.Infof("creating resource: %s", objectStr)
-		err = h.client.Create(context.TODO(), obj)
-		if err != nil {
-			return fmt.Errorf("failed to create %q: %w", objectStr, err)
+	backoff := wait.Backoff{Duration: time.Millisecond * 10, Factor: 2, Steps: 3}
+	return retry.RetryOnConflict(backoff, func() error {
+		err := h.client.Get(context.TODO(), objectKey, receiver)
+		switch {
+		case apierrors.IsNotFound(err):
+			scope.Infof("creating resource: %s", objectStr)
+			err = h.client.Create(context.TODO(), obj)
+			if err != nil {
+				return fmt.Errorf("failed to create %q: %w", objectStr, err)
+			}
+			return nil
+		case err == nil:
+			scope.Infof("updating resource: %s", objectStr)
+			if err := applyOverlay(receiver, obj); err != nil {
+				return err
+			}
+			updateErr := h.client.Update(context.TODO(), receiver)
+			if updateErr != nil {
+				scope.Warnf("update %v: %v", receiver.GetName(), updateErr)
+			}
+			return updateErr
 		}
 		return nil
-	case err == nil:
-		scope.Infof("updating resource: %s", objectStr)
-		if err := applyOverlay(receiver, obj); err != nil {
-			return err
-		}
-		return h.client.Update(context.TODO(), receiver)
-	}
-	return err
+	})
 }
 
 // applyOverlay applies an overlay using JSON patch strategy over the current Object in place.


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/23147

This occurs when there is a change between Get and Update. This seems to
happen occasionally on the PBD - I think because the PBD will have
status related to number of healthy/unhealthy pods, so when we change
the Deployment that number changes, and we trigger the race. Its pretty
easily reproducible if you tamper with some of the code to purposely
introduce conflicts.

The fix here is just to do what Kubernetes does internally (and provides
a help library for!) - retry.