### PR TITLE
eds: reduce locks during eds updates

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -27,6 +27,7 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core"
+	"istio.io/istio/pilot/pkg/util/sets"
 )
 
 var (
@@ -141,7 +142,7 @@ type EndpointShards struct {
 	// current list, a full push will be forced, to trigger a secure naming update.
 	// Due to the larger time, it is still possible that connection errors will occur while
 	// CDS is updated.
-	ServiceAccounts map[string]bool
+	ServiceAccounts sets.Set
 }
 
 // NewDiscoveryServer creates DiscoveryServer that sources data from Pilot's internal mesh data structures

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -539,12 +539,10 @@ func buildLocalityLbEndpointsFromShards(
 	isClusterLocal := push.IsClusterLocal(svc)
 
 	shards.mutex.Lock()
-	epShards := shards.Shards
-	shards.mutex.Unlock()
 
 	// The shards are updated independently, now need to filter and merge
 	// for this cluster
-	for clusterID, endpoints := range epShards {
+	for clusterID, endpoints := range shards.Shards {
 		// If the downstream service is configured as cluster-local, only include endpoints that
 		// reside in the same cluster.
 		if isClusterLocal && (clusterID != proxy.ClusterID) {
@@ -575,6 +573,8 @@ func buildLocalityLbEndpointsFromShards(
 
 		}
 	}
+
+	shards.mutex.Unlock()
 
 	locEps := make([]*endpoint.LocalityLbEndpoints, 0, len(localityEpMap))
 	for _, locLbEps := range localityEpMap {

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -208,7 +208,7 @@ func (s *DiscoveryServer) edsUpdate(clusterID, serviceName string, namespace str
 	fullPush := false
 
 	// Find endpoint shard for this service, if it is available - otherwise create a new one.
-	ep, created := s.findOrCreateEndpointShard(serviceName, namespace)
+	ep, created := s.getOrCreateEndpointShard(serviceName, namespace)
 
 	// If we create a new endpoint shard, that means we have not seen the service earlier. We should do a full push.
 	if created {
@@ -252,7 +252,7 @@ func (s *DiscoveryServer) handleEmptyEndpoints(clusterID, serviceName, namespace
 	}
 }
 
-func (s *DiscoveryServer) findOrCreateEndpointShard(serviceName, namespace string) (*EndpointShards, bool) {
+func (s *DiscoveryServer) getOrCreateEndpointShard(serviceName, namespace string) (*EndpointShards, bool) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -15,7 +15,6 @@
 package v2
 
 import (
-	"reflect"
 	"strconv"
 	"sync/atomic"
 	"time"
@@ -32,6 +31,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
+	"istio.io/istio/pilot/pkg/util/sets"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/protocol"
@@ -144,7 +144,7 @@ func (s *DiscoveryServer) UpdateServiceShards(push *model.PushContext) error {
 			}
 
 			// TODO(nmittler): Should we get the cluster from the endpoints instead? May require organizing endpoints by cluster first.
-			s.edsUpdate(registry.Cluster(), string(svc.Hostname), svc.Attributes.Namespace, endpoints, true)
+			s.edsUpdate(registry.Cluster(), string(svc.Hostname), svc.Attributes.Namespace, endpoints)
 		}
 	}
 
@@ -181,80 +181,54 @@ func (s *DiscoveryServer) edsIncremental(version string, req *model.PushRequest)
 func (s *DiscoveryServer) EDSUpdate(clusterID, serviceName string, namespace string,
 	istioEndpoints []*model.IstioEndpoint) error {
 	inboundEDSUpdates.Increment()
-	s.edsUpdate(clusterID, serviceName, namespace, istioEndpoints, false)
+	// Update the eds data structures and trigger a push.
+	fp := s.edsUpdate(clusterID, serviceName, namespace, istioEndpoints)
+	s.ConfigUpdate(&model.PushRequest{
+		Full: fp,
+		ConfigsUpdated: map[model.ConfigKey]struct{}{{
+			Kind:      model.ServiceEntryKind,
+			Name:      serviceName,
+			Namespace: namespace,
+		}: {}},
+		Reason: []model.TriggerReason{model.EndpointUpdate},
+	})
 	return nil
 }
 
-// edsUpdate updates EDS by clusterID, serviceName, IstioEndpoints,
-// and requests a Full/EDS push.
+// edsUpdate updates EndpointShards data by clusterID, serviceName, IstioEndpoints.
+// It also tracks the changes to ServiceAccounts. It returns whether a full push
+// is needed or incremental push is sufficient.
 func (s *DiscoveryServer) edsUpdate(clusterID, serviceName string, namespace string,
-	istioEndpoints []*model.IstioEndpoint, internal bool) {
-	// edsShardUpdate replaces a subset (shard) of endpoints, as result of an incremental
-	// update. The endpoint updates may be grouped by K8S clusters, other service registries
-	// or by deployment. Multiple updates are debounced, to avoid too frequent pushes.
-	// After debounce, the services are merged and pushed.
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-	requireFull := false
-
-	// Should delete the service EndpointShards when endpoints become zero to prevent memory leak,
-	// but we should not do not delete the keys from EndpointShardsByService map - that will trigger
-	// unnecessary full push which can become a real problem if a pod is in crashloop and thus endpoints
-	// flip flopping between 1 and 0.
+	istioEndpoints []*model.IstioEndpoint) bool {
 	if len(istioEndpoints) == 0 {
-		if s.EndpointShardsByService[serviceName][namespace] != nil {
-			s.deleteEndpointShards(clusterID, serviceName, namespace)
-			adsLog.Infof("Incremental push, service %s has no endpoints", serviceName)
-			s.ConfigUpdate(&model.PushRequest{
-				Full: false,
-				ConfigsUpdated: map[model.ConfigKey]struct{}{{
-					Kind:      model.ServiceEntryKind,
-					Name:      serviceName,
-					Namespace: namespace,
-				}: {}},
-				Reason: []model.TriggerReason{model.EndpointUpdate},
-			})
-		}
-		return
+		s.handleEmptyEndpoints(clusterID, serviceName, namespace)
+		return false
 	}
 
-	// Update the data structures for the service.
-	// 1. Find the 'per service' data
-	if _, f := s.EndpointShardsByService[serviceName]; !f {
-		s.EndpointShardsByService[serviceName] = map[string]*EndpointShards{}
-	}
-	ep, f := s.EndpointShardsByService[serviceName][namespace]
-	if !f {
-		// This endpoint is for a service that was not previously loaded.
-		// Return an error to force a full sync, which will also cause the
-		// EndpointsShardsByService to be initialized with all services.
-		ep = &EndpointShards{
-			Shards:          map[string][]*model.IstioEndpoint{},
-			ServiceAccounts: map[string]bool{},
-		}
-		s.EndpointShardsByService[serviceName][namespace] = ep
-		if !internal {
-			adsLog.Infof("Full push, new service %s", serviceName)
-			requireFull = true
-		}
+	fullPush := false
+
+	// Find endpoint shard for this service, if it is available - otherwise create a new one.
+	ep, created := s.findOrCreateEndpointShard(serviceName, namespace)
+
+	// If we create a new endpoint shard, that means we have not seen the service ealier. We should do a full push.
+	if created {
+		adsLog.Infof("Full push, new service %s", serviceName)
+		fullPush = true
 	}
 
-	// 2. Update data for the specific cluster. Each cluster gets independent
-	// updates containing the full list of endpoints for the service in that cluster.
-	serviceAccounts := map[string]bool{}
+	// Check if ServiceAccounts have changed. We should do a full push if they have changed.
+	serviceAccounts := sets.Set{}
 	for _, e := range istioEndpoints {
 		if e.ServiceAccount != "" {
-			serviceAccounts[e.ServiceAccount] = true
+			serviceAccounts.Insert(e.ServiceAccount)
 		}
 	}
 
-	if !reflect.DeepEqual(serviceAccounts, ep.ServiceAccounts) {
+	if !serviceAccounts.Equals(ep.ServiceAccounts) {
 		adsLog.Debugf("Updating service accounts now, svc %v, before service account %v, after %v",
 			serviceName, ep.ServiceAccounts, serviceAccounts)
-		if !internal {
-			requireFull = true
-			adsLog.Infof("Full push, service accounts changed, %v", serviceName)
-		}
+		adsLog.Infof("Full push, service accounts changed, %v", serviceName)
+		fullPush = true
 	}
 
 	ep.mutex.Lock()
@@ -262,20 +236,40 @@ func (s *DiscoveryServer) edsUpdate(clusterID, serviceName string, namespace str
 	ep.ServiceAccounts = serviceAccounts
 	ep.mutex.Unlock()
 
-	// for internal update: this called by DiscoveryServer.Push --> UpdateServiceShards,
-	// no need to trigger push here.
-	// It is done in DiscoveryServer.Push --> AdsPushAll
-	if !internal {
-		s.ConfigUpdate(&model.PushRequest{
-			Full: requireFull,
-			ConfigsUpdated: map[model.ConfigKey]struct{}{{
-				Kind:      model.ServiceEntryKind,
-				Name:      serviceName,
-				Namespace: namespace,
-			}: {}},
-			Reason: []model.TriggerReason{model.EndpointUpdate},
-		})
+	return fullPush
+}
+
+func (s *DiscoveryServer) handleEmptyEndpoints(clusterID, serviceName, namespace string) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	// Should delete the service EndpointShards when endpoints become zero to prevent memory leak,
+	// but we should not do not delete the keys from EndpointShardsByService map - that will trigger
+	// unnecessary full push which can become a real problem if a pod is in crashloop and thus endpoints
+	// flip flopping between 1 and 0.
+	if s.EndpointShardsByService[serviceName][namespace] != nil {
+		s.deleteEndpointShards(clusterID, serviceName, namespace)
+		adsLog.Infof("Incremental push, service %s has no endpoints", serviceName)
 	}
+}
+
+func (s *DiscoveryServer) findOrCreateEndpointShard(serviceName, namespace string) (*EndpointShards, bool) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if _, exists := s.EndpointShardsByService[serviceName]; !exists {
+		s.EndpointShardsByService[serviceName] = map[string]*EndpointShards{}
+	}
+	if ep, exists := s.EndpointShardsByService[serviceName][namespace]; exists {
+		return ep, false
+	}
+	// This endpoint is for a service that was not previously loaded.
+	ep := &EndpointShards{
+		Shards:          map[string][]*model.IstioEndpoint{},
+		ServiceAccounts: sets.Set{},
+	}
+	s.EndpointShardsByService[serviceName][namespace] = ep
+
+	return ep, true
 }
 
 // deleteEndpointShards deletes matching endpoint shards from EndpointShardsByService map. This is called when
@@ -545,9 +539,12 @@ func buildLocalityLbEndpointsFromShards(
 	isClusterLocal := push.IsClusterLocal(svc)
 
 	shards.mutex.Lock()
+	epShards := shards.Shards
+	shards.mutex.Unlock()
+
 	// The shards are updated independently, now need to filter and merge
 	// for this cluster
-	for clusterID, endpoints := range shards.Shards {
+	for clusterID, endpoints := range epShards {
 		// If the downstream service is configured as cluster-local, only include endpoints that
 		// reside in the same cluster.
 		if isClusterLocal && (clusterID != proxy.ClusterID) {
@@ -578,7 +575,6 @@ func buildLocalityLbEndpointsFromShards(
 
 		}
 	}
-	shards.mutex.Unlock()
 
 	locEps := make([]*endpoint.LocalityLbEndpoints, 0, len(localityEpMap))
 	for _, locLbEps := range localityEpMap {

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -210,7 +210,7 @@ func (s *DiscoveryServer) edsUpdate(clusterID, serviceName string, namespace str
 	// Find endpoint shard for this service, if it is available - otherwise create a new one.
 	ep, created := s.findOrCreateEndpointShard(serviceName, namespace)
 
-	// If we create a new endpoint shard, that means we have not seen the service ealier. We should do a full push.
+	// If we create a new endpoint shard, that means we have not seen the service earlier. We should do a full push.
 	if created {
 		adsLog.Infof("Full push, new service %s", serviceName)
 		fullPush = true

--- a/pilot/pkg/util/sets/string.go
+++ b/pilot/pkg/util/sets/string.go
@@ -61,3 +61,18 @@ func (s Set) Contains(item string) bool {
 	_, ok := s[item]
 	return ok
 }
+
+// Equals checks whether the given set is equal to the current set.
+func (s Set) Equals(other Set) bool {
+	if len(s) != len(other) {
+		return false
+	}
+
+	for key := range s {
+		if _, exists := other[key]; !exists {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pilot/pkg/util/sets/string_test.go
+++ b/pilot/pkg/util/sets/string_test.go
@@ -52,3 +52,44 @@ func TestDifference(t *testing.T) {
 		t.Errorf("d is not in %v", d)
 	}
 }
+
+func TestEquals(t *testing.T) {
+	tests := []struct {
+		name   string
+		first  Set
+		second Set
+		want   bool
+	}{
+		{
+			"both nil",
+			nil,
+			nil,
+			true,
+		},
+		{
+			"unequal length",
+			NewSet("test"),
+			NewSet("test", "test1"),
+			false,
+		},
+		{
+			"equal sets",
+			NewSet("test", "test1"),
+			NewSet("test", "test1"),
+			true,
+		},
+		{
+			"unequal sets",
+			NewSet("test", "test1"),
+			NewSet("test", "test2"),
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.first.Equals(tt.second); got != tt.want {
+				t.Errorf("Unexpected Equal. got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR does the following
- Reduce lock overhead on `edsUpdate` on `s.mutex` - split it in multiple functions and lock only when needed.
- Remove `reflect.DeepEquals()` call for `ServiceAccounts`
- Cleanup docs