### PR TITLE
Preserve source ip in TPROXY mode

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/filters.go
+++ b/pilot/pkg/networking/core/v1alpha3/filters.go
@@ -22,12 +22,15 @@ import (
 	router "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/router/v2"
 	httpinspector "github.com/envoyproxy/go-control-plane/envoy/config/filter/listener/http_inspector/v2"
 	originaldst "github.com/envoyproxy/go-control-plane/envoy/config/filter/listener/original_dst/v2"
+	originalsrc "github.com/envoyproxy/go-control-plane/envoy/config/filter/listener/original_src/v2alpha1"
 	tlsinspector "github.com/envoyproxy/go-control-plane/envoy/config/filter/listener/tls_inspector/v2"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 
 	"istio.io/istio/pilot/pkg/networking/util"
 )
+
+const OriginalSrc = "envoy.listener.original_src"
 
 // Define static filters to be reused across the codebase. This avoids duplicate marshaling/unmarshaling
 // This should not be used for filters that will be mutated
@@ -73,6 +76,12 @@ var (
 		Name: wellknown.OriginalDestination,
 		ConfigType: &listener.ListenerFilter_TypedConfig{
 			TypedConfig: util.MessageToAny(&originaldst.OriginalDst{}),
+		},
+	}
+	originalSrcFilter = &listener.ListenerFilter{
+		Name: OriginalSrc,
+		ConfigType: &listener.ListenerFilter_TypedConfig{
+			TypedConfig: util.MessageToAny(&originalsrc.OriginalSrc{}),
 		},
 	}
 )

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -2165,6 +2165,11 @@ func buildListener(opts buildListenerOpts) *xdsapi.Listener {
 		listenerFilters = append(listenerFilters, httpInspectorFilter)
 	}
 
+	if opts.proxy.GetInterceptionMode() == model.InterceptionTproxy {
+		listenerFiltersMap[OriginalSrc] = true
+		listenerFilters = append(listenerFilters, originalSrcFilter)
+	}
+
 	for _, chain := range opts.filterChainOpts {
 		for _, filter := range chain.listenerFilters {
 			if _, exist := listenerFiltersMap[filter.Name]; !exist {

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -151,6 +151,11 @@ func (lb *ListenerBuilder) aggregateVirtualInboundListener(needTLSForPassThrough
 			append(lb.virtualInboundListener.ListenerFilters, tlsInspectorFilter)
 	}
 
+	if lb.node.GetInterceptionMode() == model.InterceptionTproxy {
+		lb.virtualInboundListener.ListenerFilters =
+			append(lb.virtualInboundListener.ListenerFilters, originalSrcFilter)
+	}
+
 	// Note: the HTTP inspector should be after TLS inspector.
 	// If TLS inspector sets transport protocol to tls, the http inspector
 	// won't inspect the packet.

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
@@ -109,13 +109,13 @@ func TestVirtualListenerBuilder(t *testing.T) {
 
 }
 
-func setInboundCaptureAllOnThisNode(proxy *model.Proxy) {
-	proxy.Metadata.InterceptionMode = "REDIRECT"
+func setInboundCaptureAllOnThisNode(proxy *model.Proxy, mode model.TrafficInterceptionMode) {
+	proxy.Metadata.InterceptionMode = mode
 }
 
 var testServices = []*model.Service{buildService("test.com", wildcardIP, protocol.HTTP, tnow)}
 
-func prepareListeners(t *testing.T, services []*model.Service, mgmtPort []int) []*v2.Listener {
+func prepareListeners(t *testing.T, services []*model.Service, mgmtPort []int, mode model.TrafficInterceptionMode) []*v2.Listener {
 	// prepare
 	ldsEnv := getDefaultLdsEnv()
 
@@ -136,7 +136,7 @@ func prepareListeners(t *testing.T, services []*model.Service, mgmtPort []int) [
 
 	proxy := getDefaultProxy()
 	proxy.ServiceInstances = instances
-	setInboundCaptureAllOnThisNode(&proxy)
+	setInboundCaptureAllOnThisNode(&proxy, mode)
 	setNilSidecarOnProxy(&proxy, env.PushContext)
 
 	builder := NewListenerBuilder(&proxy, env.PushContext)
@@ -155,7 +155,7 @@ func TestVirtualInboundListenerBuilder(t *testing.T) {
 
 	// prepare
 	t.Helper()
-	listeners := prepareListeners(t, testServices, nil)
+	listeners := prepareListeners(t, testServices, nil, model.InterceptionRedirect)
 	// virtual inbound and outbound listener
 	if len(listeners) != 2 {
 		t.Fatalf("expected %d listeners, found %d", 2, len(listeners))
@@ -200,7 +200,7 @@ func TestVirtualInboundHasPassthroughClusters(t *testing.T) {
 	defer func() { features.EnableProtocolSniffingForInbound = defaultValue }()
 	// prepare
 	t.Helper()
-	listeners := prepareListeners(t, testServices, nil)
+	listeners := prepareListeners(t, testServices, nil, model.InterceptionRedirect)
 	// virtual inbound and outbound listener
 	if len(listeners) != 2 {
 		t.Fatalf("expect %d listeners, found %d", 2, len(listeners))
@@ -294,9 +294,30 @@ func TestVirtualInboundHasPassthroughClusters(t *testing.T) {
 }
 
 func TestManagementListenerBuilder(t *testing.T) {
-	listeners := prepareListeners(t, nil, []int{9876})
+	listeners := prepareListeners(t, nil, []int{9876}, model.InterceptionRedirect)
 	l := expectListener(t, listeners, "virtualInbound")
 	expectTCPProxy(t, l.FilterChains, "inbound|9876||mgmtCluster")
+}
+
+func TestSidecarInboundListenerWithOriginalSrc(t *testing.T) {
+	// prepare
+	t.Helper()
+	listeners := prepareListeners(t, testServices, nil, model.InterceptionTproxy)
+
+	if len(listeners) != 2 {
+		t.Fatalf("expected %d listeners, found %d", 2, len(listeners))
+	}
+	l := listeners[1]
+	originalSrcFilterFound := false
+	for _, lf := range l.ListenerFilters {
+		if lf.Name == OriginalSrc {
+			originalSrcFilterFound = true
+			break
+		}
+	}
+	if !originalSrcFilterFound {
+		t.Fatalf("listener filter %s expected", OriginalSrc)
+	}
 }
 
 func expectTCPProxy(t *testing.T, chains []*listener.FilterChain, s string) {

--- a/tools/istio-iptables/pkg/cmd/run.go
+++ b/tools/istio-iptables/pkg/cmd/run.go
@@ -427,7 +427,12 @@ func (iptConfigurator *IptablesConfigurator) run() {
 			"-p", "udp", "--dport", "53",
 			"-j", "REDIRECT", "--to-ports", "15013")
 	}
-
+	if iptConfigurator.cfg.InboundInterceptionMode == constants.TPROXY {
+		// mark outgoing packets from 127.0.0.1/32 with 1337, match it to policy routing entry setup for TPROXY mode
+		iptConfigurator.iptables.AppendRuleV4(constants.OUTPUT, constants.MANGLE,
+			"-p", constants.TCP, "-s", "127.0.0.1/32", "!", "-d", "127.0.0.1/32",
+			"-j", constants.MARK, "--set-mark", iptConfigurator.cfg.InboundTProxyMark)
+	}
 	iptConfigurator.executeCommands()
 }
 


### PR DESCRIPTION
This PR will:
1. Enable listener filter `original_src` for sidecar inbound listeners, so local process can see real client ip
2. Add iptables rule to ensure correct routing.

Related issue: https://github.com/istio/istio/issues/5679
