### PR TITLE
Use openssl ALPN option to dump certs in integ tests.

### DIFF
--- a/tests/integration/security/cert_mtls/cert_mtls_test.go
+++ b/tests/integration/security/cert_mtls/cert_mtls_test.go
@@ -74,7 +74,7 @@ func TestCertMtls(t *testing.T) {
 			out, err := cert.DumpCertFromSidecar(testNamespace, "app=a", "istio-proxy",
 				connectTarget)
 			if err != nil {
-				t.Errorf("Certificate validation failure: %v", err)
+				t.Errorf("failed to dump certificate: %v", err)
 				return
 			}
 			var certExp = regexp.MustCompile("(?sU)-----BEGIN CERTIFICATE-----(.+)-----END CERTIFICATE-----")

--- a/tests/integration/security/cert_mtls/cert_mtls_test.go
+++ b/tests/integration/security/cert_mtls/cert_mtls_test.go
@@ -63,21 +63,7 @@ func TestCertMtls(t *testing.T) {
 				return checkCACert(ctx, t, testNamespace)
 			}, retry.Delay(time.Second), retry.Timeout(10*time.Second))
 
-			// Enforce strict mTLS for app b
 			var a, b echo.Instance
-			appName := "b"
-			policyYAML := fmt.Sprintf(`apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
-metadata:
-  name: "mtls-strict-for-%v"
-spec:
-  selector:
-    matchLabels:
-      app: "%v"
-  mtls:
-    mode: STRICT
-`, appName, appName)
-			g.ApplyConfigOrFail(t, testNamespace, policyYAML)
 			echoboot.NewBuilderOrFail(ctx, ctx).
 				With(&a, util.EchoConfig("a", testNamespace, false, nil, g, p)).
 				With(&b, util.EchoConfig("b", testNamespace, false, nil, g, p)).
@@ -88,7 +74,7 @@ spec:
 			out, err := cert.DumpCertFromSidecar(testNamespace, "app=a", "istio-proxy",
 				connectTarget)
 			if err != nil {
-				t.Errorf("DumpCertFromSidecar() returns an error: %v", err)
+				t.Errorf("Certificate validation failure: %v", err)
 				return
 			}
 			var certExp = regexp.MustCompile("(?sU)-----BEGIN CERTIFICATE-----(.+)-----END CERTIFICATE-----")

--- a/tests/integration/security/util/cert/cert.go
+++ b/tests/integration/security/util/cert/cert.go
@@ -55,7 +55,7 @@ func DumpCertFromSidecar(ns namespace.Instance, fromSelector, fromContainer, con
 			fromPod, fromContainer, ns.Name(), connectTarget)
 		out, err = shell.Execute(false, execCmd)
 		if !strings.Contains(out, "-----BEGIN CERTIFICATE-----") {
-			return fmt.Errorf("the output doesn't contain certificate; the output: %v", out)
+			return fmt.Errorf("the output doesn't contain certificate: %v", out)
 		}
 		return nil
 	}

--- a/tests/integration/security/util/cert/cert.go
+++ b/tests/integration/security/util/cert/cert.go
@@ -45,16 +45,15 @@ func DumpCertFromSidecar(ns namespace.Instance, fromSelector, fromContainer, con
 
 	fromPod, err := dir.GetPodName(ns, fromSelector)
 	if err != nil {
-		return "", fmt.Errorf("err getting the from pod name: %v", err)
+		return "", fmt.Errorf("err getting the pod from pod name: %v", err)
 	}
 
 	var out string
 	retryFn := func(_ context.Context, i int) error {
 		execCmd := fmt.Sprintf(
-			"kubectl exec %s -c %s -n %s -- openssl s_client -showcerts -connect %s",
+			"kubectl exec %s -c %s -n %s -- openssl s_client -showcerts -alpn istio -connect %s",
 			fromPod, fromContainer, ns.Name(), connectTarget)
-		out, err = shell.Execute(false,
-			execCmd)
+		out, err = shell.Execute(false, execCmd)
 		if !strings.Contains(out, "-----BEGIN CERTIFICATE-----") {
 			return fmt.Errorf("the output doesn't contain certificate; the output: %v", out)
 		}


### PR DESCRIPTION

This avoids setting STRICT MTLS in the test.