### PR TITLE
    Follow K8s loading order for KUBECONFIG

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -433,8 +433,8 @@ ifeq ($(WHAT),)
 else
        TEST_OBJ = selected-pkg-test
 endif
+
 test: | $(JUNIT_REPORT)
-	KUBECONFIG="$${KUBECONFIG:-$${REPO_ROOT}/tests/util/kubeconfig}" \
 	$(MAKE) -e -f Makefile.core.mk --keep-going $(TEST_OBJ) \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
 

--- a/common/scripts/setup_env.sh
+++ b/common/scripts/setup_env.sh
@@ -92,23 +92,52 @@ done
 
 # Set conditional host mounts
 export CONDITIONAL_HOST_MOUNTS=${CONDITIONAL_HOST_MOUNTS:-}
+container_kubeconfig=''
 
 # docker conditional host mount (needed for make docker push)
 if [[ -d "${HOME}/.docker" ]]; then
   CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${HOME}/.docker,destination=/config/.docker,readonly,consistency=delegated "
 fi
 
-# gcloud conditional host mount (needed for docker push with the gcloud auth configure-docker)
-if [[ -d "${HOME}/.config/gcloud" ]]; then
-  CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${HOME}/.config/gcloud,destination=/config/.config/gcloud,readonly,consistency=delegated "
+# This function is designed for maximum compatibility with various platforms. This runs on
+# any Mac or Linux platform with bash 4.2+. Please take care not to modify this function
+# without testing properly.
+#
+# This function will properly handle any type of path including those with spaces using the
+# loading pattern specified by *kubectl config*.
+#
+# testcase: "a:b c:d"
+# testcase: "a b:c d:e f"
+# testcase: "a b:c:d e"
+parse_KUBECONFIG () {
+TMPDIR=""
+if [[ "$1" =~ ([^:]*):(.*) ]]; then
+  while true; do
+    rematch=${BASH_REMATCH[1]}
+    kubeconfig_random="$(od -vAn -N4 -tx /dev/random | tr -d '[:space:]' | cut -c1-8)"
+    container_kubeconfig+="/home/${kubeconfig_random}:"
+    CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${rematch},destination=/config/${kubeconfig_random},readonly,consistency=delegated "
+    remainder="${BASH_REMATCH[2]}"
+    if [[ ! "$remainder" =~ ([^:]*):(.*) ]]; then
+      if [[ -n "$remainder" ]]; then
+        kubeconfig_random="$(od -vAn -N4 -tx /dev/random | tr -d '[:space:]' | cut -c1-8)"
+        container_kubeconfig+="/home/${kubeconfig_random}:"
+        CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${remainder},destination=/config/${kubeconfig_random},readonly,consistency=delegated "
+        break
+      fi
+    fi
+  done
+else
+  kubeconfig_random="$(od -vAn -N4 -tx /dev/random | tr -d '[:space:]' | cut -c1-8)"
+  container_kubeconfig+="/home/${kubeconfig_random}:"
+  CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${1},destination=/config/${kubeconfig_random},readonly,consistency=delegated "
 fi
+}
 
-# Conditional host mount if KUBECONFIG is set
-if [[ -n "${KUBECONFIG}" ]]; then
-  CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=$(dirname "${KUBECONFIG}"),destination=/home/.kube,readonly,consistency=delegated "
-elif [[ -f "${HOME}/.kube/config" ]]; then
-  # otherwise execute a conditional host mount if $HOME/.kube/config is set
-  CONDITIONAL_HOST_MOUNTS+="--mount type=bind,source=${HOME}/.kube,destination=/home/.kube,readonly,consistency=delegated "
+KUBECONFIG=${KUBECONFIG:="$HOME/.kube/config"}
+parse_KUBECONFIG "${KUBECONFIG}"
+if [[ "$BUILD_WITH_CONTAINER" -eq "1" ]]; then
+  export KUBECONFIG="${container_kubeconfig%?}"
 fi
 
 # Avoid recursive calls to make from attempting to start an additional container


### PR DESCRIPTION
    from `kubectl config`:
    
     The loading order follows these rules:
    
      1.  If the --kubeconfig flag is set, then only that file is loaded. The flag may only be set once
    and no merging takes place.
      2.  If $KUBECONFIG environment variable is set, then it is used as a list of paths (normal path
    delimiting rules for your system). These paths are merged. When a value is modified, it is modified
    in the file that defines the stanza. When a value is created, it is created in the first file that
    exists. If no files in the chain exist, then it creates the last file in the list.
      3.  Otherwise, ${HOME}/.kube/config is used and no merging takes place.


Depends-On: https://github.com/istio/common-files/pull/237