### PR TITLE
remove security self signed from examples

### DIFF
--- a/operator/data/examples/multicluster/values-istio-multicluster-gateways.yaml
+++ b/operator/data/examples/multicluster/values-istio-multicluster-gateways.yaml
@@ -22,11 +22,6 @@ spec:
 
       controlPlaneSecurityEnabled: true
 
-    # Multicluster with gateways requires a root CA
-    # Cluster local CAs are bootstrapped with the root CA.
-    security:
-      selfSigned: false
-
     gateways:
       istio-egressgateway:
         env:

--- a/operator/data/examples/multicluster/values-istio-multicluster-primary.yaml
+++ b/operator/data/examples/multicluster/values-istio-multicluster-primary.yaml
@@ -3,10 +3,6 @@ kind: IstioOperator
 spec:
   # https://istio.io/docs/setup/install/multicluster/shared/#main-cluster
   values:
-    # selfSigned is required if Citadel is enabled, that is when values.global.istiod.enabled is false.
-    security:
-      selfSigned: false
-
     global:
       multiCluster:
         # unique cluster name, must be a DNS label name

--- a/operator/data/examples/multicluster/values-istio-multicluster-primary.yaml
+++ b/operator/data/examples/multicluster/values-istio-multicluster-primary.yaml
@@ -8,6 +8,7 @@ spec:
 
     global:
       multiCluster:
+        # unique cluster name, must be a DNS label name
         clusterName: main0
       network: network1
 

--- a/operator/data/examples/multicluster/values-istio-multicluster-primary.yaml
+++ b/operator/data/examples/multicluster/values-istio-multicluster-primary.yaml
@@ -1,3 +1,4 @@
+# https://istio.io/docs/setup/install/multicluster/shared/#main-cluster
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:

--- a/operator/data/examples/multicluster/values-istio-multicluster-primary.yaml
+++ b/operator/data/examples/multicluster/values-istio-multicluster-primary.yaml
@@ -1,7 +1,7 @@
-# https://istio.io/docs/setup/install/multicluster/shared/#main-cluster
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
+  # https://istio.io/docs/setup/install/multicluster/shared/#main-cluster
   values:
     # selfSigned is required if Citadel is enabled, that is when values.global.istiod.enabled is false.
     security:

--- a/operator/data/examples/multicluster/values-istio-multicluster-primary.yaml
+++ b/operator/data/examples/multicluster/values-istio-multicluster-primary.yaml
@@ -2,31 +2,33 @@ apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   values:
-    gateways:
-      istio-ingressgateway:
-        env:
-          ISTIO_META_NETWORK: "network1"
+    # selfSigned is required if Citadel is enabled, that is when values.global.istiod.enabled is false.
+    security:
+      selfSigned: false
+
     global:
-      mtls:
-        enabled: true
-      controlPlaneSecurityEnabled: true
-      proxy:
-        accessLogFile: "/dev/stdout"
+      multiCluster:
+        clusterName: main0
       network: network1
+
+      # Mesh network configuration. This is optional and may be omitted if
+      # all clusters are on the same network.
+      meshNetworks:
+        network1:
+          endpoints:
+          # Always use Kubernetes as the registry name for the main cluster in the mesh network configuration
+          - fromRegistry: Kubernetes
+          gateways:
+          - registry_service_name: istio-ingressgateway.istio-system.svc.cluster.local
+            port: 443
+
+        network2:
+          endpoints:
+          - fromRegistry: remote0
+          gateways:
+          - registry_service_name: istio-ingressgateway.istio-system.svc.cluster.local
+            port: 443
+
+      # Use the existing istio-ingressgateway.
       meshExpansion:
         enabled: true
-    pilot:
-      meshNetworks:
-        networks:
-          network1:
-            endpoints:
-            - fromRegistry: Kubernetes
-            gateways:
-            - address: 0.0.0.0
-              port: 443
-          network2:
-            endpoints:
-            - fromRegistry: n2-k8s-config
-            gateways:
-            - address: 0.0.0.0
-              port: 443

--- a/operator/data/examples/vm/values-istio-meshexpansion-gateways.yaml
+++ b/operator/data/examples/vm/values-istio-meshexpansion-gateways.yaml
@@ -11,11 +11,6 @@ spec:
 
       controlPlaneSecurityEnabled: true
 
-    # Multicluster with gateways requires a root CA
-    # Cluster local CAs are bootstrapped with the root CA.
-    security:
-      selfSigned: false
-
     # Provides dns resolution for service entries of form
     # name.namespace.global
     istiocoredns:

--- a/operator/data/examples/vm/values-istio-meshexpansion.yaml
+++ b/operator/data/examples/vm/values-istio-meshexpansion.yaml
@@ -8,7 +8,3 @@ spec:
 
       controlPlaneSecurityEnabled: true
 
-    # Multicluster with gateways requires a root CA
-    # Cluster local CAs are bootstrapped with the root CA.
-    security:
-      selfSigned: false

--- a/operator/data/examples/vm/values-istio-meshexpansion.yaml
+++ b/operator/data/examples/vm/values-istio-meshexpansion.yaml
@@ -7,4 +7,3 @@ spec:
         enabled: true
 
       controlPlaneSecurityEnabled: true
-


### PR DESCRIPTION
Else manifest generate will fail like this as this has been removed lately.

$ ./istioctl manifest generate -f ../../operator/data/examples/multicluster/values-istio-multicluster-primary.yaml --charts ~/go/src/istio.io/istio/manifests/
Error: validation errors (use --force to override): 
unknown field "security" in v1alpha1.Values