### PR TITLE
Analysis should not restrict Service visibility to its namespace

### DIFF
--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -255,6 +255,7 @@ var testGrid = []testCase{
 			{msg.ReferencedResourceNotFound, "VirtualService reviews-mirror-bogushost.default"},
 			{msg.ReferencedResourceNotFound, "VirtualService reviews-bogusport.default"},
 			{msg.VirtualServiceDestinationPortSelectorRequired, "VirtualService reviews-2port-missing.default"},
+			{msg.ReferencedResourceNotFound, "VirtualService cross-namespace-details.istio-system"},
 		},
 	},
 	{

--- a/galley/pkg/config/analysis/analyzers/testdata/virtualservice_destinationhosts.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/virtualservice_destinationhosts.yaml
@@ -213,3 +213,17 @@ spec:
         subset: v1
         port:
           number: 80 # Should not generate an error since we specify a valid port, as required in this case
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  # This VirtualService is in 'cross-namespace' and uses a FQDN destination
+  name: cross-namespace
+  namespace: istio-system
+spec:
+  hosts: [reviews]
+  http:
+    - route:
+        - destination:
+            # Should not generate error because the this host exists, just not in our namespace
+            host: reviews.default.svc.cluster.local

--- a/galley/pkg/config/analysis/analyzers/testdata/virtualservice_destinationhosts.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/virtualservice_destinationhosts.yaml
@@ -217,7 +217,7 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  # This VirtualService is in 'cross-namespace' and uses a FQDN destination
+  # This VirtualService is in 'istio-system' and uses a FQDN destination
   name: cross-namespace
   namespace: istio-system
 spec:
@@ -227,3 +227,47 @@ spec:
         - destination:
             # Should not generate error because the this host exists, just not in our namespace
             host: reviews.default.svc.cluster.local
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: details
+  namespace: default
+  annotations:
+    networking.istio.io/exportTo: banana
+  labels:
+    app: details
+    service: details
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: details
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  # This VirtualService is in 'istio-system' and uses a FQDN destination, but this ns doesn't see that Service
+  name: cross-namespace-details
+  namespace: istio-system
+spec:
+  hosts: [details]
+  http:
+    - route:
+        - destination:
+            # Should generate error, because details is only exported to "banana" ns
+            host: details.default.svc.cluster.local
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  # This is cross-namespace, but not a problem, details has explicit networking.istio.io/exportTo=banana
+  name: banana-details
+  namespace: banana
+spec:
+  hosts: [details]
+  http:
+    - route:
+        - destination:
+            host: details.default.svc.cluster.local

--- a/galley/pkg/config/analysis/analyzers/virtualservice/destinationhosts.go
+++ b/galley/pkg/config/analysis/analyzers/virtualservice/destinationhosts.go
@@ -138,12 +138,11 @@ func initServiceEntryHostMap(ctx analysis.Context) map[util.ScopedFqdn]*v1alpha3
 
 	})
 
-	// converts k8s service to servcieEntry since destinationHost
+	// converts k8s service to serviceEntry since destinationHost
 	// validation is performed against serviceEntry
 	ctx.ForEach(collections.K8SCoreV1Services.Name(), func(r *resource.Instance) bool {
 		s := r.Message.(*corev1.ServiceSpec)
 		var se *v1alpha3.ServiceEntry
-		hostsNamespaceScope := string(r.Metadata.FullName.Namespace)
 		var ports []*v1alpha3.Port
 		for _, p := range s.Ports {
 			ports = append(ports, &v1alpha3.Port{
@@ -157,7 +156,8 @@ func initServiceEntryHostMap(ctx analysis.Context) map[util.ScopedFqdn]*v1alpha3
 			Hosts: []string{host},
 			Ports: ports,
 		}
-		result[util.NewScopedFqdn(hostsNamespaceScope, r.Metadata.FullName.Namespace, r.Metadata.FullName.Name.String())] = se
+		// k8s Services export to all namespaces, they have no "exportTo" concept
+		result[util.NewScopedFqdn(util.ExportToAllNamespaces, r.Metadata.FullName.Namespace, r.Metadata.FullName.Name.String())] = se
 		return true
 
 	})


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/22698

Analysis treats Services as ServiceEntries; this change causes analysis to treat ServiceEntries as exported to `*`.