### PR TITLE
Add validation and analysis for meshnetworks

### DIFF
--- a/galley/pkg/config/analysis/analyzers/all.go
+++ b/galley/pkg/config/analysis/analyzers/all.go
@@ -22,6 +22,7 @@ import (
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/deprecation"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/gateway"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/injection"
+	"istio.io/istio/galley/pkg/config/analysis/analyzers/mesh"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/schema"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/service"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/sidecar"
@@ -41,6 +42,7 @@ func All() []analysis.Analyzer {
 		&gateway.SecretAnalyzer{},
 		&injection.Analyzer{},
 		&injection.ImageAnalyzer{},
+		&mesh.MeshNetworksAnalyzer{},
 		&service.PortNameAnalyzer{},
 		&sidecar.DefaultSelectorAnalyzer{},
 		&sidecar.SelectorAnalyzer{},

--- a/galley/pkg/config/analysis/analyzers/all.go
+++ b/galley/pkg/config/analysis/analyzers/all.go
@@ -22,7 +22,7 @@ import (
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/deprecation"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/gateway"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/injection"
-	"istio.io/istio/galley/pkg/config/analysis/analyzers/mesh"
+	"istio.io/istio/galley/pkg/config/analysis/analyzers/multicluster"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/schema"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/service"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/sidecar"
@@ -42,7 +42,7 @@ func All() []analysis.Analyzer {
 		&gateway.SecretAnalyzer{},
 		&injection.Analyzer{},
 		&injection.ImageAnalyzer{},
-		&mesh.MeshNetworksAnalyzer{},
+		&multicluster.MeshNetworksAnalyzer{},
 		&service.PortNameAnalyzer{},
 		&sidecar.DefaultSelectorAnalyzer{},
 		&sidecar.SelectorAnalyzer{},

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -33,7 +33,7 @@ import (
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/deprecation"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/gateway"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/injection"
-	"istio.io/istio/galley/pkg/config/analysis/analyzers/mesh"
+	"istio.io/istio/galley/pkg/config/analysis/analyzers/multicluster"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/service"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/sidecar"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/virtualservice"
@@ -311,7 +311,7 @@ var testGrid = []testCase{
 			"testdata/multicluster-unknown-serviceregistry.yaml",
 		},
 		meshNetworksFile: "testdata/common/meshnetworks.yaml",
-		analyzer:         &mesh.MeshNetworksAnalyzer{},
+		analyzer:         &multicluster.MeshNetworksAnalyzer{},
 		expected: []message{
 			{msg.UnknownMeshNetworksServiceRegistry, "MeshNetworks meshnetworks.istio-system"},
 			{msg.UnknownMeshNetworksServiceRegistry, "MeshNetworks meshnetworks.istio-system"},

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -33,6 +33,7 @@ import (
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/deprecation"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/gateway"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/injection"
+	"istio.io/istio/galley/pkg/config/analysis/analyzers/mesh"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/service"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/sidecar"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/virtualservice"
@@ -51,11 +52,12 @@ type message struct {
 }
 
 type testCase struct {
-	name           string
-	inputFiles     []string
-	meshConfigFile string // Optional
-	analyzer       analysis.Analyzer
-	expected       []message
+	name             string
+	inputFiles       []string
+	meshConfigFile   string // Optional
+	meshNetworksFile string // Optional
+	analyzer         analysis.Analyzer
+	expected         []message
 }
 
 // Some notes on setting up tests for Analyzers:
@@ -303,6 +305,18 @@ var testGrid = []testCase{
 			{msg.InvalidRegexp, "VirtualService lots-of-regexes"},
 		},
 	},
+	{
+		name: "unknown service registry in mesh networks",
+		inputFiles: []string{
+			"testdata/multicluster-unknown-serviceregistry.yaml",
+		},
+		meshNetworksFile: "testdata/common/meshnetworks.yaml",
+		analyzer:         &mesh.MeshNetworksAnalyzer{},
+		expected: []message{
+			{msg.UnknownMeshNetworksServiceRegistry, "MeshNetworks meshnetworks.istio-system"},
+			{msg.UnknownMeshNetworksServiceRegistry, "MeshNetworks meshnetworks.istio-system"},
+		},
+	},
 }
 
 // regex patterns for analyzer names that should be explicitly ignored for testing
@@ -427,6 +441,13 @@ func setupAnalyzerForCase(tc testCase, cr snapshotter.CollectionReporterFn) (*lo
 		err := sa.AddFileKubeMeshConfig(tc.meshConfigFile)
 		if err != nil {
 			return nil, fmt.Errorf("error applying mesh config file %s: %v", tc.meshConfigFile, err)
+		}
+	}
+
+	if tc.meshNetworksFile != "" {
+		err := sa.AddFileKubeMeshNetworks(tc.meshNetworksFile)
+		if err != nil {
+			return nil, fmt.Errorf("error apply mesh networks file %s: %v", tc.meshNetworksFile, err)
 		}
 	}
 

--- a/galley/pkg/config/analysis/analyzers/mesh/meshnetworks.go
+++ b/galley/pkg/config/analysis/analyzers/mesh/meshnetworks.go
@@ -1,0 +1,82 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mesh
+
+import (
+	v1 "k8s.io/api/core/v1"
+
+	"istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/galley/pkg/config/analysis"
+	"istio.io/istio/galley/pkg/config/analysis/analyzers/util"
+	"istio.io/istio/galley/pkg/config/analysis/msg"
+	"istio.io/istio/pkg/config/resource"
+	"istio.io/istio/pkg/config/schema/collection"
+	"istio.io/istio/pkg/config/schema/collections"
+)
+
+// MeshNetworksAnalyzer validates MeshNetworks configuration in multi-cluster.
+type MeshNetworksAnalyzer struct{}
+
+var _ analysis.Analyzer = &MeshNetworksAnalyzer{}
+
+// Metadata implements Analyzer
+func (s *MeshNetworksAnalyzer) Metadata() analysis.Metadata {
+	return analysis.Metadata{
+		Name:        "meshnetworks.MeshNetworksAnalyzer",
+		Description: "Check the validity of MeshNetworks in the cluster",
+		Inputs: collection.Names{
+			collections.IstioMeshV1Alpha1MeshNetworks.Name(),
+			collections.K8SCoreV1Secrets.Name(),
+		},
+	}
+}
+
+// Analyze implements Analyzer
+func (s *MeshNetworksAnalyzer) Analyze(c analysis.Context) {
+	// Service Registies can be Kubernetes(self), MCP and/or remote clusters.
+	serviceRegistries := []string{util.KubernetesServiceRegistry, util.MCPServiceRegistry}
+	c.ForEach(collections.K8SCoreV1Secrets.Name(), func(r *resource.Instance) bool {
+		if r.Metadata.Labels[util.MultiClusterSecretLabelKey] == "true" {
+			s := r.Message.(*v1.Secret)
+			for c := range s.Data {
+				serviceRegistries = append(serviceRegistries, c)
+			}
+		}
+		return true
+	})
+
+	// only one meshnetworks config should exist.
+	c.ForEach(collections.IstioMeshV1Alpha1MeshNetworks.Name(), func(r *resource.Instance) bool {
+		mn := r.Message.(*v1alpha1.MeshNetworks)
+		for i, n := range mn.Networks {
+			for _, e := range n.Endpoints {
+				switch re := e.Ne.(type) {
+				case *v1alpha1.Network_NetworkEndpoints_FromRegistry:
+					found := false
+					for _, s := range serviceRegistries {
+						if re.FromRegistry == s {
+							found = true
+						}
+					}
+					if !found {
+						c.Report(collections.IstioMeshV1Alpha1MeshNetworks.Name(), msg.NewUnknownMeshNetworksServiceRegistry(r, re.FromRegistry, i))
+					}
+				}
+			}
+		}
+		return true
+	})
+
+}

--- a/galley/pkg/config/analysis/analyzers/multicluster/meshnetworks.go
+++ b/galley/pkg/config/analysis/analyzers/multicluster/meshnetworks.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package mesh
+package multicluster
 
 import (
 	v1 "k8s.io/api/core/v1"

--- a/galley/pkg/config/analysis/analyzers/testdata/common/meshnetworks.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/common/meshnetworks.yaml
@@ -1,0 +1,13 @@
+networks:
+  network1:
+    endpoints:
+      - fromRegistry: kubernetes
+    gateways:
+      - port: 443
+        registry_service_name: istio-ingressgateway.istio-system.svc.cluster.local
+  network2:
+    endpoints:
+      - fromRegistry: istio-testing
+    gateways:
+      - port: 443
+        registry_service_name: istio-ingressgateway.istio-system.svc.cluster.local

--- a/galley/pkg/config/analysis/analyzers/testdata/multicluster-unknown-serviceregistry.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/multicluster-unknown-serviceregistry.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    istio/multiCluster: "true"
+  name: istio-remote-secret-istio-remote
+  namespace: istio-system
+stringData:
+  istio-remote: |
+    apiVersion: v1
+    clusters:
+    - cluster:
+        certificate-authority-data: Sis3WWhtcHNI
+        server: https://1.2.3.4
+      name: gke_istio-test_us-central1-f_istio-remote
+    contexts:
+    - context:
+        cluster: gke_istio-test_us-central1-f_istio-remote
+        user: gke_istio-test_us-central1-f_istio-remote
+      name: gke_istio-test_us-central1-f_istio-remote
+    current-context: gke_istio-test_us-central1-f_istio-remote
+    kind: Config
+    preferences: {}
+    users:
+    - name: gke_istio-test_us-central1-f_istio-remote
+      user:
+        token: zLmlvL3NlcnZ

--- a/galley/pkg/config/analysis/analyzers/util/constants.go
+++ b/galley/pkg/config/analysis/analyzers/util/constants.go
@@ -19,14 +19,11 @@ import (
 )
 
 const (
-	DefaultKubernetesDomain    = "svc.cluster.local"
-	MeshGateway                = "mesh"
-	ExportToNamespaceLocal     = "."
-	ExportToAllNamespaces      = "*"
-	Wildcard                   = "*"
-	MultiClusterSecretLabelKey = "istio/multiCluster"
-	KubernetesServiceRegistry  = "Kubernetes"
-	MCPServiceRegistry         = "MCP"
+	DefaultKubernetesDomain = "svc.cluster.local"
+	MeshGateway             = "mesh"
+	ExportToNamespaceLocal  = "."
+	ExportToAllNamespaces   = "*"
+	Wildcard                = "*"
 )
 
 var (

--- a/galley/pkg/config/analysis/analyzers/util/constants.go
+++ b/galley/pkg/config/analysis/analyzers/util/constants.go
@@ -19,11 +19,14 @@ import (
 )
 
 const (
-	DefaultKubernetesDomain = "svc.cluster.local"
-	MeshGateway             = "mesh"
-	ExportToNamespaceLocal  = "."
-	ExportToAllNamespaces   = "*"
-	Wildcard                = "*"
+	DefaultKubernetesDomain    = "svc.cluster.local"
+	MeshGateway                = "mesh"
+	ExportToNamespaceLocal     = "."
+	ExportToAllNamespaces      = "*"
+	Wildcard                   = "*"
+	MultiClusterSecretLabelKey = "istio/multiCluster"
+	KubernetesServiceRegistry  = "Kubernetes"
+	MCPServiceRegistry         = "MCP"
 )
 
 var (

--- a/galley/pkg/config/analysis/local/analyze_test.go
+++ b/galley/pkg/config/analysis/local/analyze_test.go
@@ -161,7 +161,7 @@ func TestAddRunningKubeSourceWithIstioMeshConfigMap(t *testing.T) {
 		},
 		Data: map[string]string{
 			meshConfigMapKey:   fmt.Sprintf("rootNamespace: %s", testRootNamespace),
-			meshNetworksMapKey: fmt.Sprintf(`networks: {"n1": {}, "n2": {}}`),
+			meshNetworksMapKey: `networks: {"n1": {}, "n2": {}}`,
 		},
 	}
 

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -116,6 +116,10 @@ var (
 	// InvalidAnnotation defines a diag.MessageType for message "InvalidAnnotation".
 	// Description: An Istio annotation that is not valid
 	InvalidAnnotation = diag.NewMessageType(diag.Warning, "IST0125", "Invalid annotation %s: %s")
+
+	// UnknownMeshNetworksServiceRegistry defines a diag.MessageType for message "UnknownMeshNetworksServiceRegistry".
+	// Description: A service registry in Mesh Networks is unknown
+	UnknownMeshNetworksServiceRegistry = diag.NewMessageType(diag.Error, "IST0126", "Unknown service registry %s in network %s")
 )
 
 // All returns a list of all known message types.
@@ -148,6 +152,7 @@ func All() []*diag.MessageType {
 		NamespaceMultipleInjectionLabels,
 		NamespaceInvalidInjectorRevision,
 		InvalidAnnotation,
+		UnknownMeshNetworksServiceRegistry,
 	}
 }
 
@@ -416,5 +421,15 @@ func NewInvalidAnnotation(r *resource.Instance, annotation string, problem strin
 		r,
 		annotation,
 		problem,
+	)
+}
+
+// NewUnknownMeshNetworksServiceRegistry returns a new diag.Message based on UnknownMeshNetworksServiceRegistry.
+func NewUnknownMeshNetworksServiceRegistry(r *resource.Instance, serviceregistry string, network string) diag.Message {
+	return diag.NewMessage(
+		UnknownMeshNetworksServiceRegistry,
+		r,
+		serviceregistry,
+		network,
 	)
 }

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -58,7 +58,7 @@ messages:
         type: string
       - name: port
         type: int
-  
+
   - name: "IstioProxyImageMismatch"
     code: IST0105
     level: Warning
@@ -85,10 +85,10 @@ messages:
     description: "An Istio annotation is applied to the wrong kind of resource."
     template: "Misplaced annotation: %s can only be applied to %s"
     args:
-       - name: annotation
-         type: string
-       - name: kind
-         type: string
+      - name: annotation
+        type: string
+      - name: kind
+        type: string
 
   - name: "UnknownAnnotation"
     code: IST0108
@@ -96,8 +96,8 @@ messages:
     description: "An Istio annotation is not recognized for any kind of resource"
     template: "Unknown annotation: %s"
     args:
-       - name: annotation
-         type: string
+      - name: annotation
+        type: string
 
   - name: "ConflictingMeshGatewayVirtualServiceHosts"
     code: IST0109
@@ -289,4 +289,15 @@ messages:
       - name: annotation
         type: string
       - name: problem
+        type: string
+
+  - name: "UnknownMeshNetworksServiceRegistry"
+    code: IST0126
+    level: Error
+    description: "A service registry in Mesh Networks is unknown"
+    template: "Unknown service registry %s in network %s"
+    args:
+      - name: serviceregistry
+        type: string
+      - name: network
         type: string

--- a/galley/pkg/config/mesh/const.go
+++ b/galley/pkg/config/mesh/const.go
@@ -18,8 +18,8 @@ import (
 	"istio.io/istio/pkg/config/resource"
 )
 
-// resource name for the Istio MeshConfig resource
+// MeshConfigResourceName is the resource name for the Istio MeshConfig resource.
 var MeshConfigResourceName = resource.NewFullName("istio-system", "meshconfig")
 
-/// resource name for the Istio MeshNetworks resource
+// MeshNetworksResourceName is the resource name for the Istio MeshNetworks resource.
 var MeshNetworksResourceName = resource.NewFullName("istio-system", "meshnetworks")

--- a/galley/pkg/config/mesh/const.go
+++ b/galley/pkg/config/mesh/const.go
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package meshcfg
+package mesh
 
 import (
 	"istio.io/istio/pkg/config/resource"
 )
 
-// ResourceName for the Istio Mesh Config resource
-var ResourceName = resource.NewFullName("istio-system", "meshconfig")
+// resource name for the Istio MeshConfig resource
+var MeshConfigResourceName = resource.NewFullName("istio-system", "meshconfig")
+
+/// resource name for the Istio MeshNetworks resource
+var MeshNetworksResourceName = resource.NewFullName("istio-system", "meshnetworks")

--- a/galley/pkg/config/mesh/defaults.go
+++ b/galley/pkg/config/mesh/defaults.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package meshcfg
+package mesh
 
 import (
 	"istio.io/istio/pkg/config/mesh"
@@ -20,10 +20,17 @@ import (
 	"istio.io/api/mesh/v1alpha1"
 )
 
-// Default mesh configuration
-func Default() *v1alpha1.MeshConfig {
+// DefaultMeshConfig returns a default meshconfig.
+func DefaultMeshConfig() *v1alpha1.MeshConfig {
 	meshconfig := mesh.DefaultMeshConfig()
 	meshconfig.IngressClass = "istio"
 	meshconfig.IngressControllerMode = v1alpha1.MeshConfig_STRICT
 	return &meshconfig
+}
+
+// DefaultMeshNetworks returns a default meshnetworks configuration.
+// By default, it is empty.
+func DefaultMeshNetworks() *v1alpha1.MeshNetworks {
+	mn := mesh.EmptyMeshNetworks()
+	return &mn
 }

--- a/galley/pkg/config/mesh/defaults_test.go
+++ b/galley/pkg/config/mesh/defaults_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package meshcfg
+package mesh
 
 import (
 	"testing"
@@ -27,7 +27,7 @@ import (
 func TestDefaults(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	m := Default()
+	m := DefaultMeshConfig()
 	expect := mesh.DefaultMeshConfig()
 	expect.IngressClass = "istio"
 	expect.IngressControllerMode = v1alpha1.MeshConfig_STRICT

--- a/galley/pkg/config/mesh/fs_test.go
+++ b/galley/pkg/config/mesh/fs_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package meshcfg
+package mesh
 
 import (
 	"fmt"
@@ -38,7 +38,7 @@ func TestFsSource_NoInitialFile(t *testing.T) {
 
 	file := setupDir(t, nil)
 
-	fs, err := NewFS(file)
+	fs, err := NewMeshConfigFS(file)
 	g.Expect(err).To(BeNil())
 	defer func() {
 		err = fs.Close()
@@ -58,7 +58,7 @@ func TestFsSource_NoInitialFile(t *testing.T) {
 					FullName: resource.NewFullName("istio-system", "meshconfig"),
 					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
-				Message: Default(),
+				Message: DefaultMeshConfig(),
 			},
 		},
 		{
@@ -74,7 +74,7 @@ func TestFsSource_NoInitialFile_UpdateAfterStart(t *testing.T) {
 
 	file := setupDir(t, nil)
 
-	fs, err := NewFS(file)
+	fs, err := NewMeshConfigFS(file)
 	g.Expect(err).To(BeNil())
 	defer func() {
 		err = fs.Close()
@@ -94,7 +94,7 @@ func TestFsSource_NoInitialFile_UpdateAfterStart(t *testing.T) {
 					FullName: resource.NewFullName("istio-system", "meshconfig"),
 					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
-				Message: Default(),
+				Message: DefaultMeshConfig(),
 			},
 		},
 		{
@@ -105,7 +105,7 @@ func TestFsSource_NoInitialFile_UpdateAfterStart(t *testing.T) {
 	fixtures.ExpectEventsEventually(t, acc, expected...)
 
 	acc.Clear()
-	mcfg := Default()
+	mcfg := DefaultMeshConfig()
 	mcfg.IngressClass = "foo"
 	writeMeshCfg(t, file, mcfg)
 
@@ -121,11 +121,11 @@ func TestFsSource_NoInitialFile_UpdateAfterStart(t *testing.T) {
 func TestFsSource_InitialFile_UpdateAfterStart(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	mcfg := Default()
+	mcfg := DefaultMeshConfig()
 	mcfg.IngressClass = "foo"
 	file := setupDir(t, mcfg)
 
-	fs, err := NewFS(file)
+	fs, err := NewMeshConfigFS(file)
 	g.Expect(err).To(BeNil())
 	defer func() {
 		err = fs.Close()
@@ -156,7 +156,7 @@ func TestFsSource_InitialFile_UpdateAfterStart(t *testing.T) {
 	fixtures.ExpectEventsEventually(t, acc, expected...)
 
 	acc.Clear()
-	mcfg2 := Default()
+	mcfg2 := DefaultMeshConfig()
 	mcfg2.IngressClass = "bar"
 	writeMeshCfg(t, file, mcfg2)
 
@@ -172,11 +172,11 @@ func TestFsSource_InitialFile_UpdateAfterStart(t *testing.T) {
 func TestFsSource_InitialFile(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	mcfg := Default()
+	mcfg := DefaultMeshConfig()
 	mcfg.IngressClass = "foo"
 	file := setupDir(t, mcfg)
 
-	fs, err := NewFS(file)
+	fs, err := NewMeshConfigFS(file)
 	g.Expect(err).To(BeNil())
 	defer func() {
 		err = fs.Close()
@@ -210,11 +210,11 @@ func TestFsSource_InitialFile(t *testing.T) {
 func TestFsSource_StartStopStart(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	mcfg := Default()
+	mcfg := DefaultMeshConfig()
 	mcfg.IngressClass = "foo"
 	file := setupDir(t, mcfg)
 
-	fs, err := NewFS(file)
+	fs, err := NewMeshConfigFS(file)
 	g.Expect(err).To(BeNil())
 	defer func() {
 		err = fs.Close()
@@ -254,11 +254,11 @@ func TestFsSource_StartStopStart(t *testing.T) {
 func TestFsSource_FileRemoved_NoChange(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	mcfg := Default()
+	mcfg := DefaultMeshConfig()
 	mcfg.IngressClass = "foo"
 	file := setupDir(t, mcfg)
 
-	fs, err := NewFS(file)
+	fs, err := NewMeshConfigFS(file)
 	g.Expect(err).To(BeNil())
 	defer func() {
 		err = fs.Close()
@@ -298,11 +298,11 @@ func TestFsSource_BogusFile_NoChange(t *testing.T) {
 	t.Skip("https://github.com/istio/istio/issues/15987")
 	g := NewGomegaWithT(t)
 
-	mcfg := Default()
+	mcfg := DefaultMeshConfig()
 	mcfg.IngressClass = "foo"
 	file := setupDir(t, mcfg)
 
-	fs, err := NewFS(file)
+	fs, err := NewMeshConfigFS(file)
 	g.Expect(err).To(BeNil())
 	defer func() {
 		err = fs.Close()
@@ -367,18 +367,18 @@ func TestFsSource_InvalidPath(t *testing.T) {
 	file := setupDir(t, nil)
 	file = path.Join(file, "bogus")
 
-	_, err := NewFS(file)
+	_, err := NewMeshConfigFS(file)
 	g.Expect(err).NotTo(BeNil())
 }
 
 func TestFsSource_YamlToJSONError(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	mcfg := Default()
+	mcfg := DefaultMeshConfig()
 	mcfg.IngressClass = "foo"
 	file := setupDir(t, mcfg)
 
-	fs, err := newFS(file, func([]byte) ([]byte, error) {
+	fs, err := newMeshConfigFS(file, func([]byte) ([]byte, error) {
 		return nil, fmt.Errorf("horror")
 	})
 
@@ -402,7 +402,7 @@ func TestFsSource_YamlToJSONError(t *testing.T) {
 					FullName: resource.NewFullName("istio-system", "meshconfig"),
 					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
-				Message: Default(),
+				Message: DefaultMeshConfig(),
 			},
 		},
 		{

--- a/galley/pkg/config/mesh/fs_test.go
+++ b/galley/pkg/config/mesh/fs_test.go
@@ -27,6 +27,7 @@ import (
 
 	"istio.io/api/mesh/v1alpha1"
 
+	"istio.io/istio/galley/pkg/config/source/kube/rt"
 	"istio.io/istio/galley/pkg/config/testing/fixtures"
 	"istio.io/istio/pkg/config/event"
 	"istio.io/istio/pkg/config/resource"
@@ -59,6 +60,11 @@ func TestFsSource_NoInitialFile(t *testing.T) {
 					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
 				Message: DefaultMeshConfig(),
+				Origin: &rt.Origin{
+					Collection: collections.IstioMeshV1Alpha1MeshConfig.Name(),
+					Kind:       "MeshConfig",
+					FullName:   resource.NewFullName("istio-system", "meshconfig"),
+				},
 			},
 		},
 		{
@@ -95,6 +101,11 @@ func TestFsSource_NoInitialFile_UpdateAfterStart(t *testing.T) {
 					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
 				Message: DefaultMeshConfig(),
+				Origin: &rt.Origin{
+					Collection: collections.IstioMeshV1Alpha1MeshConfig.Name(),
+					Kind:       "MeshConfig",
+					FullName:   resource.NewFullName("istio-system", "meshconfig"),
+				},
 			},
 		},
 		{
@@ -146,6 +157,11 @@ func TestFsSource_InitialFile_UpdateAfterStart(t *testing.T) {
 					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
 				Message: mcfg,
+				Origin: &rt.Origin{
+					Collection: collections.IstioMeshV1Alpha1MeshConfig.Name(),
+					Kind:       "MeshConfig",
+					FullName:   resource.NewFullName("istio-system", "meshconfig"),
+				},
 			},
 		},
 		{
@@ -197,6 +213,11 @@ func TestFsSource_InitialFile(t *testing.T) {
 					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
 				Message: mcfg,
+				Origin: &rt.Origin{
+					Collection: collections.IstioMeshV1Alpha1MeshConfig.Name(),
+					Kind:       "MeshConfig",
+					FullName:   resource.NewFullName("istio-system", "meshconfig"),
+				},
 			},
 		},
 		{
@@ -234,6 +255,11 @@ func TestFsSource_StartStopStart(t *testing.T) {
 					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
 				Message: mcfg,
+				Origin: &rt.Origin{
+					Collection: collections.IstioMeshV1Alpha1MeshConfig.Name(),
+					Kind:       "MeshConfig",
+					FullName:   resource.NewFullName("istio-system", "meshconfig"),
+				},
 			},
 		},
 		{
@@ -278,6 +304,11 @@ func TestFsSource_FileRemoved_NoChange(t *testing.T) {
 					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
 				Message: mcfg,
+				Origin: &rt.Origin{
+					Collection: collections.IstioMeshV1Alpha1MeshConfig.Name(),
+					Kind:       "MeshConfig",
+					FullName:   resource.NewFullName("istio-system", "meshconfig"),
+				},
 			},
 		},
 		{
@@ -322,6 +353,11 @@ func TestFsSource_BogusFile_NoChange(t *testing.T) {
 					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
 				Message: mcfg,
+				Origin: &rt.Origin{
+					Collection: collections.IstioMeshV1Alpha1MeshConfig.Name(),
+					Kind:       "MeshConfig",
+					FullName:   resource.NewFullName("istio-system", "meshconfig"),
+				},
 			},
 		},
 		{
@@ -403,6 +439,11 @@ func TestFsSource_YamlToJSONError(t *testing.T) {
 					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
 				Message: DefaultMeshConfig(),
+				Origin: &rt.Origin{
+					Collection: collections.IstioMeshV1Alpha1MeshConfig.Name(),
+					Kind:       "MeshConfig",
+					FullName:   resource.NewFullName("istio-system", "meshconfig"),
+				},
 			},
 		},
 		{

--- a/galley/pkg/config/mesh/inmemory_test.go
+++ b/galley/pkg/config/mesh/inmemory_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package meshcfg
+package mesh
 
 import (
 	"testing"
@@ -28,7 +28,7 @@ import (
 func TestInMemorySource_Empty(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	s := NewInmemory()
+	s := NewInmemoryMeshCfg()
 
 	acc := &fixtures.Accumulator{}
 	s.Dispatch(acc)
@@ -44,12 +44,12 @@ func TestInMemorySource_Empty(t *testing.T) {
 func TestInMemorySource_SetBeforeStart(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	s := NewInmemory()
+	s := NewInmemoryMeshCfg()
 
 	acc := &fixtures.Accumulator{}
 	s.Dispatch(acc)
 
-	s.Set(Default())
+	s.Set(DefaultMeshConfig())
 	g.Expect(s.IsSynced()).To(BeTrue())
 
 	s.Start()
@@ -59,10 +59,10 @@ func TestInMemorySource_SetBeforeStart(t *testing.T) {
 			Source: collections.IstioMeshV1Alpha1MeshConfig,
 			Resource: &resource.Instance{
 				Metadata: resource.Metadata{
-					FullName: ResourceName,
+					FullName: MeshConfigResourceName,
 					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
-				Message: Default(),
+				Message: DefaultMeshConfig(),
 			},
 		},
 		{
@@ -76,13 +76,13 @@ func TestInMemorySource_SetBeforeStart(t *testing.T) {
 func TestInMemorySource_SetAfterStart(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	s := NewInmemory()
+	s := NewInmemoryMeshCfg()
 
 	acc := &fixtures.Accumulator{}
 	s.Dispatch(acc)
 
 	s.Start()
-	s.Set(Default())
+	s.Set(DefaultMeshConfig())
 	g.Expect(s.IsSynced()).To(BeTrue())
 
 	expected := []event.Event{
@@ -91,10 +91,10 @@ func TestInMemorySource_SetAfterStart(t *testing.T) {
 			Source: collections.IstioMeshV1Alpha1MeshConfig,
 			Resource: &resource.Instance{
 				Metadata: resource.Metadata{
-					FullName: ResourceName,
+					FullName: MeshConfigResourceName,
 					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
-				Message: Default(),
+				Message: DefaultMeshConfig(),
 			},
 		},
 		{
@@ -108,12 +108,12 @@ func TestInMemorySource_SetAfterStart(t *testing.T) {
 func TestInMemorySource_DoubleStart(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	s := NewInmemory()
+	s := NewInmemoryMeshCfg()
 
 	acc := &fixtures.Accumulator{}
 	s.Dispatch(acc)
 
-	s.Set(Default())
+	s.Set(DefaultMeshConfig())
 	s.Start()
 	s.Start()
 	g.Expect(s.IsSynced()).To(BeTrue())
@@ -124,10 +124,10 @@ func TestInMemorySource_DoubleStart(t *testing.T) {
 			Source: collections.IstioMeshV1Alpha1MeshConfig,
 			Resource: &resource.Instance{
 				Metadata: resource.Metadata{
-					FullName: ResourceName,
+					FullName: MeshConfigResourceName,
 					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
-				Message: Default(),
+				Message: DefaultMeshConfig(),
 			},
 		},
 		{
@@ -141,13 +141,13 @@ func TestInMemorySource_DoubleStart(t *testing.T) {
 func TestInMemorySource_StartStop(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	s := NewInmemory()
+	s := NewInmemoryMeshCfg()
 
 	acc := &fixtures.Accumulator{}
 	s.Dispatch(acc)
 
 	s.Start()
-	s.Set(Default())
+	s.Set(DefaultMeshConfig())
 	s.Stop()
 	acc.Clear()
 
@@ -160,10 +160,10 @@ func TestInMemorySource_StartStop(t *testing.T) {
 			Source: collections.IstioMeshV1Alpha1MeshConfig,
 			Resource: &resource.Instance{
 				Metadata: resource.Metadata{
-					FullName: ResourceName,
+					FullName: MeshConfigResourceName,
 					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
-				Message: Default(),
+				Message: DefaultMeshConfig(),
 			},
 		},
 		{
@@ -175,14 +175,14 @@ func TestInMemorySource_StartStop(t *testing.T) {
 }
 
 func TestInMemorySource_ResetOnUpdate(t *testing.T) {
-	s := NewInmemory()
+	s := NewInmemoryMeshCfg()
 
 	acc := &fixtures.Accumulator{}
 	s.Dispatch(acc)
 
 	s.Start()
-	s.Set(Default())
-	m := Default()
+	s.Set(DefaultMeshConfig())
+	m := DefaultMeshConfig()
 	m.IngressClass = "foo"
 	s.Set(m)
 
@@ -192,10 +192,10 @@ func TestInMemorySource_ResetOnUpdate(t *testing.T) {
 			Source: collections.IstioMeshV1Alpha1MeshConfig,
 			Resource: &resource.Instance{
 				Metadata: resource.Metadata{
-					FullName: ResourceName,
+					FullName: MeshConfigResourceName,
 					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
-				Message: Default(),
+				Message: DefaultMeshConfig(),
 			},
 		},
 		{

--- a/galley/pkg/config/mesh/inmemory_test.go
+++ b/galley/pkg/config/mesh/inmemory_test.go
@@ -19,6 +19,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	"istio.io/istio/galley/pkg/config/source/kube/rt"
 	"istio.io/istio/galley/pkg/config/testing/fixtures"
 	"istio.io/istio/pkg/config/event"
 	"istio.io/istio/pkg/config/resource"
@@ -63,6 +64,11 @@ func TestInMemorySource_SetBeforeStart(t *testing.T) {
 					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
 				Message: DefaultMeshConfig(),
+				Origin: &rt.Origin{
+					Collection: collections.IstioMeshV1Alpha1MeshConfig.Name(),
+					Kind:       "MeshConfig",
+					FullName:   resource.NewFullName("istio-system", "meshconfig"),
+				},
 			},
 		},
 		{
@@ -95,6 +101,11 @@ func TestInMemorySource_SetAfterStart(t *testing.T) {
 					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
 				Message: DefaultMeshConfig(),
+				Origin: &rt.Origin{
+					Collection: collections.IstioMeshV1Alpha1MeshConfig.Name(),
+					Kind:       "MeshConfig",
+					FullName:   resource.NewFullName("istio-system", "meshconfig"),
+				},
 			},
 		},
 		{
@@ -128,6 +139,11 @@ func TestInMemorySource_DoubleStart(t *testing.T) {
 					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
 				Message: DefaultMeshConfig(),
+				Origin: &rt.Origin{
+					Collection: collections.IstioMeshV1Alpha1MeshConfig.Name(),
+					Kind:       "MeshConfig",
+					FullName:   resource.NewFullName("istio-system", "meshconfig"),
+				},
 			},
 		},
 		{
@@ -164,6 +180,11 @@ func TestInMemorySource_StartStop(t *testing.T) {
 					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
 				Message: DefaultMeshConfig(),
+				Origin: &rt.Origin{
+					Collection: collections.IstioMeshV1Alpha1MeshConfig.Name(),
+					Kind:       "MeshConfig",
+					FullName:   resource.NewFullName("istio-system", "meshconfig"),
+				},
 			},
 		},
 		{
@@ -196,6 +217,11 @@ func TestInMemorySource_ResetOnUpdate(t *testing.T) {
 					Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 				},
 				Message: DefaultMeshConfig(),
+				Origin: &rt.Origin{
+					Collection: collections.IstioMeshV1Alpha1MeshConfig.Name(),
+					Kind:       "MeshConfig",
+					FullName:   resource.NewFullName("istio-system", "meshconfig"),
+				},
 			},
 		},
 		{

--- a/galley/pkg/config/mesh/metadata_test.go
+++ b/galley/pkg/config/mesh/metadata_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package meshcfg
+package mesh
 
 import (
 	"testing"

--- a/galley/pkg/config/processing/runtime_test.go
+++ b/galley/pkg/config/processing/runtime_test.go
@@ -27,6 +27,7 @@ import (
 	"istio.io/istio/galley/pkg/config/mesh"
 	"istio.io/istio/galley/pkg/config/scope"
 	"istio.io/istio/galley/pkg/config/source/kube/inmemory"
+	"istio.io/istio/galley/pkg/config/source/kube/rt"
 	"istio.io/istio/galley/pkg/config/testing/basicmeta"
 	"istio.io/istio/galley/pkg/config/testing/fixtures"
 	"istio.io/istio/pkg/config/event"
@@ -185,6 +186,11 @@ func TestRuntime_MeshConfig_Causing_Restart(t *testing.T) {
 				Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 			},
 			Message: mesh.DefaultMeshConfig(),
+			Origin: &rt.Origin{
+				Collection: collections.IstioMeshV1Alpha1MeshConfig.Name(),
+				Kind:       "MeshConfig",
+				FullName:   resource.NewFullName("istio-system", "meshconfig"),
+			},
 		}),
 		event.FullSyncFor(collections.IstioMeshV1Alpha1MeshConfig),
 		event.AddFor(coll, r),
@@ -453,5 +459,10 @@ func meshConfigEntry(m *v1alpha1.MeshConfig) *resource.Instance { // nolint:inte
 			Schema:   collections.IstioMeshV1Alpha1MeshConfig.Resource(),
 		},
 		Message: m,
+		Origin: &rt.Origin{
+			Collection: collections.IstioMeshV1Alpha1MeshConfig.Name(),
+			Kind:       "MeshConfig",
+			FullName:   resource.NewFullName("istio-system", "meshconfig"),
+		},
 	}
 }

--- a/galley/pkg/config/processing/session.go
+++ b/galley/pkg/config/processing/session.go
@@ -22,7 +22,7 @@ import (
 
 	"istio.io/api/mesh/v1alpha1"
 
-	"istio.io/istio/galley/pkg/config/meshcfg"
+	"istio.io/istio/galley/pkg/config/mesh"
 	"istio.io/istio/galley/pkg/config/scope"
 	"istio.io/istio/pkg/config/event"
 	"istio.io/istio/pkg/config/schema/collections"
@@ -285,7 +285,7 @@ func (s *session) applyMeshEvent(e event.Event) {
 		s.meshCfg = proto.Clone(e.Resource.Message).(*v1alpha1.MeshConfig)
 	case event.Deleted:
 		scope.Processing.Infof("session.handleMeshEvent: received a delete mesh config event: %v", e)
-		s.meshCfg = meshcfg.Default()
+		s.meshCfg = mesh.DefaultMeshConfig()
 	case event.FullSync:
 		scope.Processing.Infof("session.applyMeshEvent meshSynced: %v => %v", s.meshSynced, true)
 		s.meshSynced = true

--- a/galley/pkg/config/processor/build_test.go
+++ b/galley/pkg/config/processor/build_test.go
@@ -20,7 +20,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	"istio.io/istio/galley/pkg/config/meshcfg"
+	"istio.io/istio/galley/pkg/config/mesh"
 	"istio.io/istio/galley/pkg/config/processing/snapshotter"
 	"istio.io/istio/galley/pkg/config/processor/transforms"
 	"istio.io/istio/galley/pkg/config/source/kube/inmemory"
@@ -50,14 +50,14 @@ spec:
 func TestProcessor(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	meshSrc := meshcfg.NewInmemory()
+	meshSrc := mesh.NewInmemoryMeshCfg()
 	src := inmemory.NewKubeSource(schema.MustGet().KubeCollections())
 	srcs := []event.Source{
 		meshSrc,
 		src,
 	}
 
-	meshSrc.Set(meshcfg.Default())
+	meshSrc.Set(mesh.DefaultMeshConfig())
 	distributor := snapshotter.NewInMemoryDistributor()
 	transformProviders := transforms.Providers(schema.MustGet())
 

--- a/galley/pkg/config/processor/transforms/ingress/dataset_test.go
+++ b/galley/pkg/config/processor/transforms/ingress/dataset_test.go
@@ -23,7 +23,7 @@ import (
 	"istio.io/api/mesh/v1alpha1"
 	"istio.io/api/networking/v1alpha3"
 
-	"istio.io/istio/galley/pkg/config/meshcfg"
+	"istio.io/istio/galley/pkg/config/mesh"
 	"istio.io/istio/galley/pkg/config/source/kube/rt"
 	"istio.io/istio/pkg/config/resource"
 )
@@ -218,7 +218,7 @@ func vs1v2() *resource.Instance {
 }
 
 func meshConfig() *v1alpha1.MeshConfig {
-	m := meshcfg.Default()
+	m := mesh.DefaultMeshConfig()
 	m.IngressClass = "cls"
 	m.IngressControllerMode = v1alpha1.MeshConfig_STRICT
 	return m

--- a/galley/pkg/config/processor/transforms/ingress/gateway_test.go
+++ b/galley/pkg/config/processor/transforms/ingress/gateway_test.go
@@ -19,7 +19,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	"istio.io/istio/galley/pkg/config/meshcfg"
+	"istio.io/istio/galley/pkg/config/mesh"
 	"istio.io/istio/galley/pkg/config/processing"
 	"istio.io/istio/galley/pkg/config/source/kube/rt"
 	"istio.io/istio/galley/pkg/config/testing/fixtures"
@@ -162,7 +162,7 @@ func TestGateway_NoListeners(t *testing.T) {
 
 	o := processing.ProcessorOptions{
 		DomainSuffix: "svc.local",
-		MeshConfig:   meshcfg.Default(),
+		MeshConfig:   mesh.DefaultMeshConfig(),
 	}
 
 	xforms := GetProviders().Create(o)

--- a/galley/pkg/config/processor/transforms/ingress/virtualService_test.go
+++ b/galley/pkg/config/processor/transforms/ingress/virtualService_test.go
@@ -19,7 +19,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	"istio.io/istio/galley/pkg/config/meshcfg"
+	"istio.io/istio/galley/pkg/config/mesh"
 	"istio.io/istio/galley/pkg/config/processing"
 	"istio.io/istio/galley/pkg/config/testing/fixtures"
 	"istio.io/istio/pkg/config/event"
@@ -153,7 +153,7 @@ func TestVirtualService_NoListeners(t *testing.T) {
 
 	o := processing.ProcessorOptions{
 		DomainSuffix: "cluster.local",
-		MeshConfig:   meshcfg.Default(),
+		MeshConfig:   mesh.DefaultMeshConfig(),
 	}
 
 	xforms := GetProviders().Create(o)

--- a/galley/pkg/server/components/patchtable.go
+++ b/galley/pkg/server/components/patchtable.go
@@ -20,7 +20,7 @@ import (
 
 	"istio.io/pkg/filewatcher"
 
-	"istio.io/istio/galley/pkg/config/meshcfg"
+	"istio.io/istio/galley/pkg/config/mesh"
 	"istio.io/istio/galley/pkg/config/processor"
 	"istio.io/istio/galley/pkg/config/source/kube"
 	"istio.io/istio/galley/pkg/config/source/kube/fs"
@@ -36,7 +36,7 @@ var (
 	newFileWatcher    = filewatcher.NewWatcher
 	readFile          = ioutil.ReadFile
 
-	meshcfgNewFS        = func(path string) (event.Source, error) { return meshcfg.NewFS(path) }
+	meshcfgNewFS        = func(path string) (event.Source, error) { return mesh.NewMeshConfigFS(path) }
 	processorInitialize = processor.Initialize
 	fsNew               = fs.New
 )
@@ -48,7 +48,7 @@ func resetPatchTable() {
 	newFileWatcher = filewatcher.NewWatcher
 	readFile = ioutil.ReadFile
 
-	meshcfgNewFS = func(path string) (event.Source, error) { return meshcfg.NewFS(path) }
+	meshcfgNewFS = func(path string) (event.Source, error) { return mesh.NewMeshConfigFS(path) }
 	processorInitialize = processor.Initialize
 	fsNew = fs.New
 }

--- a/galley/pkg/server/components/processing_test.go
+++ b/galley/pkg/server/components/processing_test.go
@@ -26,7 +26,7 @@ import (
 	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic/fake"
 
-	"istio.io/istio/galley/pkg/config/meshcfg"
+	"istio.io/istio/galley/pkg/config/mesh"
 	"istio.io/istio/galley/pkg/config/processing"
 	"istio.io/istio/galley/pkg/config/processor"
 	"istio.io/istio/galley/pkg/config/source/kube"
@@ -135,7 +135,7 @@ func TestProcessing_Basic(t *testing.T) {
 	mcpMetricReporter = func(s string) monitoring.Reporter {
 		return mcptestmon.NewInMemoryStatsContext()
 	}
-	meshcfgNewFS = func(path string) (event.Source, error) { return meshcfg.NewInmemory(), nil }
+	meshcfgNewFS = func(path string) (event.Source, error) { return mesh.NewInmemoryMeshCfg(), nil }
 
 	args := settings.DefaultArgs()
 	args.APIAddress = "tcp://0.0.0.0:0"

--- a/pkg/config/mesh/mesh.go
+++ b/pkg/config/mesh/mesh.go
@@ -242,10 +242,9 @@ func ParseMeshNetworks(yaml string) (*meshconfig.MeshNetworks, error) {
 		return nil, multierror.Prefix(err, "failed to convert to proto.")
 	}
 
-	// TODO validate the loaded MeshNetworks
-	// if err := ValidateMeshNetworks(&out); err != nil {
-	// 	return nil, err
-	// }
+	if err := validation.ValidateMeshNetworks(&out); err != nil {
+		return nil, err
+	}
 	return &out, nil
 }
 

--- a/pkg/config/schema/collections/collections.gen.go
+++ b/pkg/config/schema/collections/collections.gen.go
@@ -101,6 +101,24 @@ var (
 		}.MustBuild(),
 	}.MustBuild()
 
+	// IstioMeshV1Alpha1MeshNetworks describes the collection
+	// istio/mesh/v1alpha1/MeshNetworks
+	IstioMeshV1Alpha1MeshNetworks = collection.Builder{
+		Name:         "istio/mesh/v1alpha1/MeshNetworks",
+		VariableName: "IstioMeshV1Alpha1MeshNetworks",
+		Disabled:     false,
+		Resource: resource.Builder{
+			Group:         "",
+			Kind:          "MeshNetworks",
+			Plural:        "meshnetworks",
+			Version:       "v1alpha1",
+			Proto:         "istio.mesh.v1alpha1.MeshNetworks",
+			ProtoPackage:  "istio.io/api/mesh/v1alpha1",
+			ClusterScoped: false,
+			ValidateProto: validation.EmptyValidate,
+		}.MustBuild(),
+	}.MustBuild()
+
 	// IstioMixerV1ConfigClientQuotaspecbindings describes the collection
 	// istio/mixer/v1/config/client/quotaspecbindings
 	IstioMixerV1ConfigClientQuotaspecbindings = collection.Builder{
@@ -1162,6 +1180,7 @@ var (
 		MustAdd(IstioConfigV1Alpha2Httpapispecs).
 		MustAdd(IstioConfigV1Alpha2Templates).
 		MustAdd(IstioMeshV1Alpha1MeshConfig).
+		MustAdd(IstioMeshV1Alpha1MeshNetworks).
 		MustAdd(IstioMixerV1ConfigClientQuotaspecbindings).
 		MustAdd(IstioMixerV1ConfigClientQuotaspecs).
 		MustAdd(IstioNetworkingV1Alpha3Destinationrules).
@@ -1230,6 +1249,7 @@ var (
 		MustAdd(IstioConfigV1Alpha2Httpapispecs).
 		MustAdd(IstioConfigV1Alpha2Templates).
 		MustAdd(IstioMeshV1Alpha1MeshConfig).
+		MustAdd(IstioMeshV1Alpha1MeshNetworks).
 		MustAdd(IstioMixerV1ConfigClientQuotaspecbindings).
 		MustAdd(IstioMixerV1ConfigClientQuotaspecs).
 		MustAdd(IstioNetworkingV1Alpha3Destinationrules).

--- a/pkg/config/schema/metadata.gen.go
+++ b/pkg/config/schema/metadata.gen.go
@@ -97,6 +97,10 @@ collections:
     kind: "MeshConfig"
     group: ""
 
+  - name: "istio/mesh/v1alpha1/MeshNetworks"
+    kind: "MeshNetworks"
+    group: ""
+
   - name: "istio/mixer/v1/config/client/quotaspecs"
     kind: "QuotaSpec"
     group: "config.istio.io"
@@ -395,6 +399,7 @@ snapshots:
       - "istio/rbac/v1alpha1/servicerolebindings"
       - "istio/rbac/v1alpha1/serviceroles"
       - "istio/mesh/v1alpha1/MeshConfig"
+      - "istio/mesh/v1alpha1/MeshNetworks"
       - "istio/networking/v1alpha3/envoyfilters"
       - "istio/networking/v1alpha3/destinationrules"
       - "istio/networking/v1alpha3/gateways"
@@ -610,6 +615,14 @@ resources:
     protoPackage: "istio.io/api/mesh/v1alpha1"
     description: "describes the configuration for the Istio mesh."
 
+  - kind: "MeshNetworks"
+    plural: "meshnetworks"
+    group: ""
+    version: "v1alpha1"
+    proto: "istio.mesh.v1alpha1.MeshNetworks"
+    protoPackage: "istio.io/api/mesh/v1alpha1"
+    description: "describes the networks for the Istio mesh."
+
   - kind: "ServiceRole"
     plural: "serviceroles"
     group: "rbac.istio.io"
@@ -633,8 +646,8 @@ resources:
     proto: "istio.rbac.v1alpha1.RbacConfig"
     protoPackage: "istio.io/api/rbac/v1alpha1"
     description: "describes the mesh level RBAC config.\n
-                   Deprecated: use ClusterRbacConfig instead.\n
-                   See https://github.com/istio/istio/issues/8825 for more details."
+      Deprecated: use ClusterRbacConfig instead.\n
+      See https://github.com/istio/istio/issues/8825 for more details."
 
   - kind: "ClusterRbacConfig"
     plural: "clusterrbacconfigs"
@@ -748,6 +761,7 @@ transforms:
       "k8s/core/v1/services": "k8s/core/v1/services"
       "k8s/core/v1/configmaps": "k8s/core/v1/configmaps"
       "istio/mesh/v1alpha1/MeshConfig": "istio/mesh/v1alpha1/MeshConfig"
+      "istio/mesh/v1alpha1/MeshNetworks": "istio/mesh/v1alpha1/MeshNetworks"
 `)
 
 func metadataYamlBytes() ([]byte, error) {

--- a/pkg/config/schema/metadata.yaml
+++ b/pkg/config/schema/metadata.yaml
@@ -42,6 +42,10 @@ collections:
     kind: "MeshConfig"
     group: ""
 
+  - name: "istio/mesh/v1alpha1/MeshNetworks"
+    kind: "MeshNetworks"
+    group: ""
+
   - name: "istio/mixer/v1/config/client/quotaspecs"
     kind: "QuotaSpec"
     group: "config.istio.io"
@@ -340,6 +344,7 @@ snapshots:
       - "istio/rbac/v1alpha1/servicerolebindings"
       - "istio/rbac/v1alpha1/serviceroles"
       - "istio/mesh/v1alpha1/MeshConfig"
+      - "istio/mesh/v1alpha1/MeshNetworks"
       - "istio/networking/v1alpha3/envoyfilters"
       - "istio/networking/v1alpha3/destinationrules"
       - "istio/networking/v1alpha3/gateways"
@@ -555,6 +560,14 @@ resources:
     protoPackage: "istio.io/api/mesh/v1alpha1"
     description: "describes the configuration for the Istio mesh."
 
+  - kind: "MeshNetworks"
+    plural: "meshnetworks"
+    group: ""
+    version: "v1alpha1"
+    proto: "istio.mesh.v1alpha1.MeshNetworks"
+    protoPackage: "istio.io/api/mesh/v1alpha1"
+    description: "describes the networks for the Istio mesh."
+
   - kind: "ServiceRole"
     plural: "serviceroles"
     group: "rbac.istio.io"
@@ -578,8 +591,8 @@ resources:
     proto: "istio.rbac.v1alpha1.RbacConfig"
     protoPackage: "istio.io/api/rbac/v1alpha1"
     description: "describes the mesh level RBAC config.\n
-                   Deprecated: use ClusterRbacConfig instead.\n
-                   See https://github.com/istio/istio/issues/8825 for more details."
+      Deprecated: use ClusterRbacConfig instead.\n
+      See https://github.com/istio/istio/issues/8825 for more details."
 
   - kind: "ClusterRbacConfig"
     plural: "clusterrbacconfigs"
@@ -693,3 +706,4 @@ transforms:
       "k8s/core/v1/services": "k8s/core/v1/services"
       "k8s/core/v1/configmaps": "k8s/core/v1/configmaps"
       "istio/mesh/v1alpha1/MeshConfig": "istio/mesh/v1alpha1/MeshConfig"
+      "istio/mesh/v1alpha1/MeshNetworks": "istio/mesh/v1alpha1/MeshNetworks"

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -2899,3 +2899,46 @@ func validateLocalities(localities []string) error {
 
 	return nil
 }
+
+// ValidateMeshNetworks validates meshnetworks.
+func ValidateMeshNetworks(meshnetworks *meshconfig.MeshNetworks) (errs error) {
+	for name, network := range meshnetworks.Networks {
+		if err := validateNetwork(network); err != nil {
+			errs = multierror.Append(errs, multierror.Prefix(err, fmt.Sprintf("invalid network %v:", name)))
+		}
+	}
+	return
+}
+
+func validateNetwork(network *meshconfig.Network) (errs error) {
+	for _, n := range network.Endpoints {
+		switch e := n.Ne.(type) {
+		case *meshconfig.Network_NetworkEndpoints_FromCidr:
+			if err := ValidateIPSubnet(e.FromCidr); err != nil {
+				errs = multierror.Append(errs, err)
+			}
+		case *meshconfig.Network_NetworkEndpoints_FromRegistry:
+			r := e.FromRegistry
+			if strings.ToLower(r) == "kubernetes" && r != "Kubernetes" {
+				errs = multierror.Append(errs, fmt.Errorf("registry name should be Kubernetes instead of %v", r))
+			}
+		}
+
+	}
+	for _, n := range network.Gateways {
+		switch g := n.Gw.(type) {
+		case *meshconfig.Network_IstioNetworkGateway_RegistryServiceName:
+			if err := ValidateFQDN(g.RegistryServiceName); err != nil {
+				errs = multierror.Append(errs, err)
+			}
+		case *meshconfig.Network_IstioNetworkGateway_Address:
+			if err := ValidateIPAddress(g.Address); err != nil {
+				errs = multierror.Append(errs, err)
+			}
+		}
+		if err := ValidatePort(int(n.Port)); err != nil {
+			errs = multierror.Append(errs, err)
+		}
+	}
+	return
+}

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -2919,7 +2919,7 @@ func validateNetwork(network *meshconfig.Network) (errs error) {
 			}
 		case *meshconfig.Network_NetworkEndpoints_FromRegistry:
 			r := e.FromRegistry
-			if strings.ToLower(r) == "kubernetes" && r != "Kubernetes" {
+			if strings.EqualFold(r, "kubernetes") && r != "Kubernetes" {
 				errs = multierror.Append(errs, fmt.Errorf("registry name should be Kubernetes instead of %v", r))
 			}
 		}

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -2918,9 +2918,8 @@ func validateNetwork(network *meshconfig.Network) (errs error) {
 				errs = multierror.Append(errs, err)
 			}
 		case *meshconfig.Network_NetworkEndpoints_FromRegistry:
-			r := e.FromRegistry
-			if strings.EqualFold(r, "kubernetes") && r != "Kubernetes" {
-				errs = multierror.Append(errs, fmt.Errorf("registry name should be Kubernetes instead of %v", r))
+			if ok := labels.IsDNS1123Label(e.FromRegistry); !ok {
+				errs = multierror.Append(errs, fmt.Errorf("invalid registry name: %v", e.FromRegistry))
 			}
 		}
 

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -5909,3 +5909,96 @@ func TestServiceSettings(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateMeshNetworks(t *testing.T) {
+	testcases := []struct {
+		name  string
+		mn    *meshconfig.MeshNetworks
+		valid bool
+	}{
+		{
+			name:  "Empty MeshNetworks",
+			mn:    &meshconfig.MeshNetworks{},
+			valid: true,
+		},
+		{
+			name: "Valid MeshNetworks",
+			mn: &meshconfig.MeshNetworks{
+				Networks: map[string]*meshconfig.Network{
+					"n1": {
+						Endpoints: []*meshconfig.Network_NetworkEndpoints{
+							{
+								Ne: &meshconfig.Network_NetworkEndpoints_FromRegistry{
+									FromRegistry: "Kubernetes",
+								},
+							},
+						},
+						Gateways: []*meshconfig.Network_IstioNetworkGateway{
+							{
+								Gw: &meshconfig.Network_IstioNetworkGateway_RegistryServiceName{
+									RegistryServiceName: "istio-ingressgateway.istio-system.svc.cluster.local",
+								},
+								Port: 80,
+							},
+						},
+					},
+					"n2": {
+						Endpoints: []*meshconfig.Network_NetworkEndpoints{
+							{
+								Ne: &meshconfig.Network_NetworkEndpoints_FromRegistry{
+									FromRegistry: "cluster1",
+								},
+							},
+						},
+						Gateways: []*meshconfig.Network_IstioNetworkGateway{
+							{
+								Gw: &meshconfig.Network_IstioNetworkGateway_RegistryServiceName{
+									RegistryServiceName: "istio-ingressgateway.istio-system.svc.cluster.local",
+								},
+								Port: 443,
+							},
+						},
+					},
+				},
+			},
+			valid: true,
+		},
+		{
+			name: "Invalid registry name",
+			mn: &meshconfig.MeshNetworks{
+				Networks: map[string]*meshconfig.Network{
+					"n1": {
+						Endpoints: []*meshconfig.Network_NetworkEndpoints{
+							{
+								Ne: &meshconfig.Network_NetworkEndpoints_FromRegistry{
+									FromRegistry: "kubernetes",
+								},
+							},
+						},
+						Gateways: []*meshconfig.Network_IstioNetworkGateway{
+							{
+								Gw: &meshconfig.Network_IstioNetworkGateway_RegistryServiceName{
+									RegistryServiceName: "istio-ingressgateway.istio-system.svc.cluster.local",
+								},
+								Port: 80,
+							},
+						},
+					},
+				},
+			},
+			valid: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateMeshNetworks(tc.mn)
+			if err != nil && tc.valid {
+				t.Errorf("error not expected on valid meshnetworks: %v", *tc.mn)
+			}
+			if err == nil && !tc.valid {
+				t.Errorf("expected an error on invalid meshnetworks: %v", *tc.mn)
+			}
+		})
+	}
+}

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -5971,7 +5971,7 @@ func TestValidateMeshNetworks(t *testing.T) {
 						Endpoints: []*meshconfig.Network_NetworkEndpoints{
 							{
 								Ne: &meshconfig.Network_NetworkEndpoints_FromRegistry{
-									FromRegistry: "kubernetes",
+									FromRegistry: "cluster.local",
 								},
 							},
 						},


### PR DESCRIPTION
Validate the following cases in meshnetworks:
- validate the fromRegistry, ip addr, fqdn and port number fields

Analyze the follow case:
- analyze meshnetworks in the cluster with the added multicluster secrets in the cluster

The rest of changes are mostly adding the ability to let galley processing pipeline to retrieve meshnetworks along with meshconfig.