### PR TITLE
Make console logger compatible with scopes, cleanup

### DIFF
--- a/operator/cmd/mesh/manifest-apply.go
+++ b/operator/cmd/mesh/manifest-apply.go
@@ -132,7 +132,7 @@ func InstallCmd(logOpts *log.Options) *cobra.Command {
 }
 
 func runApplyCmd(cmd *cobra.Command, rootArgs *rootArgs, maArgs *manifestApplyArgs, logOpts *log.Options) error {
-	l := clog.NewConsoleLogger(cmd.OutOrStdout(), cmd.ErrOrStderr())
+	l := clog.NewConsoleLogger(cmd.OutOrStdout(), cmd.ErrOrStderr(), installerScope)
 	// Warn users if they use `manifest apply` without any config args.
 	if len(maArgs.inFilenames) == 0 && len(maArgs.set) == 0 && !rootArgs.dryRun && !maArgs.skipConfirmation {
 		if !confirm("This will install the default Istio profile into the cluster. Proceed? (y/N)", cmd.OutOrStdout()) {

--- a/operator/cmd/mesh/manifest-generate.go
+++ b/operator/cmd/mesh/manifest-generate.go
@@ -80,7 +80,7 @@ func manifestGenerateCmd(rootArgs *rootArgs, mgArgs *manifestGenerateArgs, logOp
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			l := clog.NewConsoleLogger(cmd.OutOrStdout(), cmd.ErrOrStderr())
+			l := clog.NewConsoleLogger(cmd.OutOrStdout(), cmd.ErrOrStderr(), installerScope)
 			return manifestGenerate(rootArgs, mgArgs, logOpts, l)
 		}}
 

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -549,7 +549,7 @@ func TestLDFlags(t *testing.T) {
 	}()
 	version.DockerInfo.Hub = "testHub"
 	version.DockerInfo.Tag = "testTag"
-	l := clog.NewConsoleLogger(os.Stdout, os.Stderr)
+	l := clog.NewConsoleLogger(os.Stdout, os.Stderr, installerScope)
 	ysf, err := yamlFromSetFlags([]string{"installPackagePath=" + liveInstallPackageDir}, false, l)
 	if err != nil {
 		t.Fatal(err)

--- a/operator/cmd/mesh/manifest-migrate.go
+++ b/operator/cmd/mesh/manifest-migrate.go
@@ -59,7 +59,7 @@ func manifestMigrateCmd(rootArgs *rootArgs, mmArgs *manifestMigrateArgs) *cobra.
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			l := clog.NewConsoleLogger(cmd.OutOrStdout(), cmd.ErrOrStderr())
+			l := clog.NewConsoleLogger(cmd.OutOrStdout(), cmd.ErrOrStderr(), installerScope)
 			return migrateFromFiles(rootArgs, mmArgs, args, l)
 		}}
 }

--- a/operator/cmd/mesh/operator-dump.go
+++ b/operator/cmd/mesh/operator-dump.go
@@ -50,7 +50,7 @@ func operatorDumpCmd(rootArgs *rootArgs, odArgs *operatorDumpArgs) *cobra.Comman
 		Long:  "The dump subcommand dumps the Istio operator controller manifest.",
 		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
-			l := clog.NewConsoleLogger(cmd.OutOrStdout(), cmd.ErrOrStderr())
+			l := clog.NewConsoleLogger(cmd.OutOrStdout(), cmd.ErrOrStderr(), installerScope)
 			operatorDump(rootArgs, odArgs, l)
 		}}
 }

--- a/operator/cmd/mesh/operator-init.go
+++ b/operator/cmd/mesh/operator-init.go
@@ -77,7 +77,7 @@ func operatorInitCmd(rootArgs *rootArgs, oiArgs *operatorInitArgs) *cobra.Comman
 		Long:  "The init subcommand installs the Istio operator controller in the cluster.",
 		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
-			l := clog.NewConsoleLogger(cmd.OutOrStdout(), cmd.ErrOrStderr())
+			l := clog.NewConsoleLogger(cmd.OutOrStdout(), cmd.ErrOrStderr(), installerScope)
 			operatorInit(rootArgs, oiArgs, l)
 		}}
 }
@@ -103,8 +103,8 @@ func operatorInit(args *rootArgs, oiArgs *operatorInitArgs, l clog.Logger) {
 		l.LogAndFatal(err)
 	}
 
-	scope.Debugf("Installing operator charts with the following values:\n%s", vals)
-	scope.Debugf("Using the following manifest to install operator:\n%s\n", mstr)
+	installerScope.Debugf("Installing operator charts with the following values:\n%s", vals)
+	installerScope.Debugf("Using the following manifest to install operator:\n%s\n", mstr)
 
 	opts := &Options{
 		DryRun:      args.dryRun,

--- a/operator/cmd/mesh/operator-remove.go
+++ b/operator/cmd/mesh/operator-remove.go
@@ -42,7 +42,7 @@ func operatorRemoveCmd(rootArgs *rootArgs, orArgs *operatorRemoveArgs) *cobra.Co
 		Long:  "The remove subcommand removes the Istio operator controller from the cluster.",
 		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
-			l := clog.NewConsoleLogger(cmd.OutOrStdout(), cmd.OutOrStderr())
+			l := clog.NewConsoleLogger(cmd.OutOrStdout(), cmd.OutOrStderr(), installerScope)
 			operatorRemove(rootArgs, orArgs, l)
 		}}
 }
@@ -74,7 +74,7 @@ func operatorRemove(args *rootArgs, orArgs *operatorRemoveArgs, l clog.Logger) {
 		l.LogAndFatal(err)
 	}
 
-	scope.Debugf("Using the following manifest to remove operator:\n%s\n", mstr)
+	installerScope.Debugf("Using the following manifest to remove operator:\n%s\n", mstr)
 
 	opts := &Options{
 		DryRun:      args.dryRun,

--- a/operator/cmd/mesh/operator_test.go
+++ b/operator/cmd/mesh/operator_test.go
@@ -77,7 +77,7 @@ func TestOperatorInit(t *testing.T) {
 		},
 	}
 
-	l := clog.NewConsoleLogger(os.Stdout, os.Stderr)
+	l := clog.NewConsoleLogger(os.Stdout, os.Stderr, installerScope)
 	_, gotYAML, err := renderOperatorManifest(rootArgs, &oiArgs.common, l)
 	if err != nil {
 		l.LogAndFatal(err)

--- a/operator/cmd/mesh/profile-common.go
+++ b/operator/cmd/mesh/profile-common.go
@@ -37,7 +37,7 @@ import (
 	pkgversion "istio.io/pkg/version"
 )
 
-var scope = log.RegisterScope("installer", "installer", 0)
+var installerScope = log.RegisterScope("installer", "installer", 0)
 
 // GenerateConfig creates an IstioOperatorSpec from the following sources, overlaid sequentially:
 // 1. Compiled in base, or optionally base from paths pointing to one or multiple ICP/IOP files at inFilenames.
@@ -172,7 +172,7 @@ func genIOPSFromProfile(profileOrPath, fileOverlayYAML, setOverlayYAML string, s
 		if err != nil {
 			return "", nil, err
 		}
-		scope.Infof("Applying Cluster specific settings: %v", kubeOverrides)
+		installerScope.Infof("Applying Cluster specific settings: %v", kubeOverrides)
 		outYAML, err = util.OverlayYAML(outYAML, kubeOverrides)
 		if err != nil {
 			return "", nil, err

--- a/operator/cmd/mesh/profile-dump.go
+++ b/operator/cmd/mesh/profile-dump.go
@@ -67,7 +67,7 @@ func profileDumpCmd(rootArgs *rootArgs, pdArgs *profileDumpArgs) *cobra.Command 
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			l := clog.NewConsoleLogger(cmd.OutOrStdout(), cmd.ErrOrStderr())
+			l := clog.NewConsoleLogger(cmd.OutOrStdout(), cmd.ErrOrStderr(), installerScope)
 			return profileDump(args, rootArgs, pdArgs, l)
 		}}
 

--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -110,7 +110,7 @@ func UpgradeCmd() *cobra.Command {
 			"traffic may be disrupted during upgrade. Please ensure PodDisruptionBudgets " +
 			"are defined to maintain service continuity.",
 		RunE: func(cmd *cobra.Command, args []string) (e error) {
-			l := clog.NewConsoleLogger(cmd.OutOrStdout(), cmd.OutOrStderr())
+			l := clog.NewConsoleLogger(cmd.OutOrStdout(), cmd.OutOrStderr(), installerScope)
 			initLogsOrExit(rootArgs)
 			err := upgrade(rootArgs, macArgs, l)
 			if err != nil {

--- a/operator/pkg/helmreconciler/reconcile.go
+++ b/operator/pkg/helmreconciler/reconcile.go
@@ -27,7 +27,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"istio.io/api/operator/v1alpha1"
-
 	valuesv1alpha1 "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/name"
 	"istio.io/istio/operator/pkg/object"

--- a/operator/pkg/util/clog/clog.go
+++ b/operator/pkg/util/clog/clog.go
@@ -34,69 +34,30 @@ type Logger interface {
 	PrintErr(s string)
 }
 
-// DefaultLogger is a passthrough to istio.io/pkg/log.
-type DefaultLogger struct{}
-
-// NewDefaultLogger creates a new logger and returns a pointer to it.
-func NewDefaultLogger() *DefaultLogger {
-	return &DefaultLogger{}
-}
-
-func (l *DefaultLogger) LogAndPrint(v ...interface{}) {
-	if len(v) == 0 {
-		return
-	}
-	s := fmt.Sprint(v...)
-	log.Infof(s)
-}
-
-func (l *DefaultLogger) LogAndError(v ...interface{}) {
-	if len(v) == 0 {
-		return
-	}
-	s := fmt.Sprint(v...)
-	log.Infof(s)
-}
-
-func (l *DefaultLogger) LogAndFatal(a ...interface{}) {
-	l.LogAndError(a...)
-	os.Exit(-1)
-}
-
-func (l *DefaultLogger) LogAndPrintf(format string, a ...interface{}) {
-	s := fmt.Sprintf(format, a...)
-	log.Infof(s)
-}
-
-func (l *DefaultLogger) LogAndErrorf(format string, a ...interface{}) {
-	s := fmt.Sprintf(format, a...)
-	log.Infof(s)
-}
-
-func (l *DefaultLogger) LogAndFatalf(format string, a ...interface{}) {
-	l.LogAndErrorf(format, a...)
-	os.Exit(-1)
-}
-
-func (l *DefaultLogger) Print(s string) {
-}
-
-func (l *DefaultLogger) PrintErr(s string) {
-}
-
 //ConsoleLogger is the struct used for mesh command
 type ConsoleLogger struct {
 	stdOut io.Writer
 	stdErr io.Writer
+	scope  *log.Scope
 }
 
 // NewConsoleLogger creates a new logger and returns a pointer to it.
-// stdOut and stdErr can be used to capture output for testing.
-func NewConsoleLogger(stdOut, stdErr io.Writer) *ConsoleLogger {
+// stdOut and stdErr can be used to capture output for testing. If scope is nil, the default scope is used.
+func NewConsoleLogger(stdOut, stdErr io.Writer, scope *log.Scope) *ConsoleLogger {
+	s := scope
+	if s == nil {
+		s = log.RegisterScope(log.DefaultScopeName, log.DefaultScopeName, 0)
+	}
 	return &ConsoleLogger{
 		stdOut: stdOut,
 		stdErr: stdErr,
+		scope:  s,
 	}
+}
+
+// NewDefaultLogger creates a new logger that outputs to stdout/stderr at default scope.
+func NewDefaultLogger() *ConsoleLogger {
+	return NewConsoleLogger(os.Stdout, os.Stderr, nil)
 }
 
 func (l *ConsoleLogger) LogAndPrint(v ...interface{}) {
@@ -105,7 +66,7 @@ func (l *ConsoleLogger) LogAndPrint(v ...interface{}) {
 	}
 	s := fmt.Sprint(v...)
 	l.Print(s + "\n")
-	log.Infof(s)
+	l.scope.Infof(s)
 }
 
 func (l *ConsoleLogger) LogAndError(v ...interface{}) {
@@ -114,7 +75,7 @@ func (l *ConsoleLogger) LogAndError(v ...interface{}) {
 	}
 	s := fmt.Sprint(v...)
 	l.PrintErr(s + "\n")
-	log.Infof(s)
+	l.scope.Infof(s)
 }
 
 func (l *ConsoleLogger) LogAndFatal(a ...interface{}) {
@@ -125,13 +86,13 @@ func (l *ConsoleLogger) LogAndFatal(a ...interface{}) {
 func (l *ConsoleLogger) LogAndPrintf(format string, a ...interface{}) {
 	s := fmt.Sprintf(format, a...)
 	l.Print(s + "\n")
-	log.Infof(s)
+	l.scope.Infof(s)
 }
 
 func (l *ConsoleLogger) LogAndErrorf(format string, a ...interface{}) {
 	s := fmt.Sprintf(format, a...)
 	l.PrintErr(s + "\n")
-	log.Infof(s)
+	l.scope.Infof(s)
 }
 
 func (l *ConsoleLogger) LogAndFatalf(format string, a ...interface{}) {

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -895,7 +895,7 @@ func loadInjectionConfigMap(t testing.TB, settings string) (template *Config, va
 	if err != nil {
 		t.Fatal(err)
 	}
-	l := clog.NewConsoleLogger(os.Stdout, os.Stderr)
+	l := clog.NewConsoleLogger(os.Stdout, os.Stderr, nil)
 	manifests, _, err := operatormesh.GenManifests(nil, oy, false, nil, l)
 	if err != nil {
 		t.Fatalf("failed to generate manifests: %v", err)


### PR DESCRIPTION
Console logger has been going to default scope rather than package scope. Also, this removes boilerplate for DefaultLogger, which can be defined as a ConsoleLogger with some defaults.