### PR TITLE
Fix operator remove

### DIFF
--- a/operator/cmd/mesh/manifest-apply.go
+++ b/operator/cmd/mesh/manifest-apply.go
@@ -202,7 +202,7 @@ func ApplyManifests(setOverlay []string, inFilenames []string, force bool, dryRu
 	}
 
 	check := color.New(color.FgGreen).Sprint("✔")
-	l.LogAndPrint(check + " Installation complete")
+	l.LogAndPrint(check + installationCompleteStr)
 
 	// Save state to cluster in IstioOperator CR.
 	iopStr, err := translate.IOPStoIOPstr(iops, crName, iopv1alpha1.Namespace(iops))

--- a/operator/cmd/mesh/operator-common.go
+++ b/operator/cmd/mesh/operator-common.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"istio.io/istio/operator/pkg/helm"
+	"istio.io/istio/operator/pkg/name"
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/operator/pkg/util/clog"
 )
@@ -48,7 +49,9 @@ type operatorCommonArgs struct {
 }
 
 const (
-	operatorResourceName = "istio-operator"
+	operatorResourceName     = "istio-operator"
+	operatorDefaultNamespace = "istio-operator"
+	istioDefaultNamespace    = "istio-system"
 )
 
 func isControllerInstalled(cs kubernetes.Interface, operatorNamespace string) (bool, error) {
@@ -61,7 +64,7 @@ func renderOperatorManifest(_ *rootArgs, ocArgs *operatorCommonArgs, _ clog.Logg
 	if ocArgs.charts != "" {
 		installPackagePath = ocArgs.charts
 	}
-	r, err := helm.NewHelmRenderer(installPackagePath, "istio-operator", istioControllerComponentName, ocArgs.operatorNamespace)
+	r, err := helm.NewHelmRenderer(installPackagePath, "istio-operator", string(name.IstioOperatorComponentName), ocArgs.operatorNamespace)
 	if err != nil {
 		return "", "", err
 	}
@@ -99,7 +102,7 @@ tag: {{.Tag}}
 func CreateNamespace(cs kubernetes.Interface, namespace string) error {
 	if namespace == "" {
 		// Setup default namespace
-		namespace = "istio-system"
+		namespace = istioDefaultNamespace
 	}
 
 	ns := &v1.Namespace{ObjectMeta: v12.ObjectMeta{
@@ -113,6 +116,10 @@ func CreateNamespace(cs kubernetes.Interface, namespace string) error {
 		return fmt.Errorf("failed to create namespace %v: %v", namespace, err)
 	}
 	return nil
+}
+
+func DeleteNamespace(cs kubernetes.Interface, namespace string) error {
+	return cs.CoreV1().Namespaces().Delete(context.TODO(), namespace, v12.DeleteOptions{})
 }
 
 func DeploymentExists(cs kubernetes.Interface, namespace, name string) (bool, error) {

--- a/operator/cmd/mesh/operator-init.go
+++ b/operator/cmd/mesh/operator-init.go
@@ -15,10 +15,10 @@
 package mesh
 
 import (
-	"time"
-
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
+	"istio.io/istio/operator/pkg/name"
 	"istio.io/istio/operator/pkg/util/clog"
 	buildversion "istio.io/pkg/version"
 )
@@ -34,16 +34,7 @@ type operatorInitArgs struct {
 	kubeConfigPath string
 	// context is the cluster context in the kube config.
 	context string
-	// readinessTimeout is maximum time to wait for all Istio resources to be ready.
-	readinessTimeout time.Duration
-	// wait is flag that indicates whether to wait resources ready before exiting.
-	wait bool
 }
-
-const (
-	istioControllerComponentName = "Operator"
-	istioOperatorCRComponentName = "OperatorCustomResource"
-)
 
 func addOperatorInitFlags(cmd *cobra.Command, args *operatorInitArgs) {
 	hub, tag := buildversion.DockerInfo.Hub, buildversion.DockerInfo.Tag
@@ -56,16 +47,11 @@ func addOperatorInitFlags(cmd *cobra.Command, args *operatorInitArgs) {
 	cmd.PersistentFlags().StringVarP(&args.inFilename, "filename", "f", "", "Path to file containing IstioOperator custom resource")
 	cmd.PersistentFlags().StringVarP(&args.kubeConfigPath, "kubeconfig", "c", "", "Path to kube config")
 	cmd.PersistentFlags().StringVar(&args.context, "context", "", "The name of the kubeconfig context to use")
-	cmd.PersistentFlags().DurationVar(&args.readinessTimeout, "readiness-timeout", 300*time.Second, "Maximum seconds to wait for the Istio operator to be ready."+
-		" The --wait flag must be set for this flag to apply")
-	cmd.PersistentFlags().BoolVarP(&args.wait, "wait", "w", false, "Wait, if set will wait until all Pods, Services, and minimum number of Pods "+
-		"of a Deployment are in a ready state before the command exits. It will wait for a maximum duration of --readiness-timeout seconds")
-
 	cmd.PersistentFlags().StringVar(&args.common.hub, "hub", hub, "The hub for the operator controller image")
 	cmd.PersistentFlags().StringVar(&args.common.tag, "tag", tag, "The tag for the operator controller image")
-	cmd.PersistentFlags().StringVar(&args.common.operatorNamespace, "operatorNamespace", "istio-operator",
+	cmd.PersistentFlags().StringVar(&args.common.operatorNamespace, "operatorNamespace", operatorDefaultNamespace,
 		"The namespace the operator controller is installed into")
-	cmd.PersistentFlags().StringVar(&args.common.istioNamespace, "istioNamespace", "istio-system",
+	cmd.PersistentFlags().StringVar(&args.common.istioNamespace, "istioNamespace", istioDefaultNamespace,
 		"The namespace Istio is installed into")
 	cmd.PersistentFlags().StringVarP(&args.common.charts, "charts", "d", "", chartsFlagHelpStr)
 }
@@ -107,11 +93,9 @@ func operatorInit(args *rootArgs, oiArgs *operatorInitArgs, l clog.Logger) {
 	installerScope.Debugf("Using the following manifest to install operator:\n%s\n", mstr)
 
 	opts := &Options{
-		DryRun:      args.dryRun,
-		Wait:        oiArgs.wait,
-		WaitTimeout: oiArgs.readinessTimeout,
-		Kubeconfig:  oiArgs.kubeConfigPath,
-		Context:     oiArgs.context,
+		DryRun:     args.dryRun,
+		Kubeconfig: oiArgs.kubeConfigPath,
+		Context:    oiArgs.context,
 	}
 
 	// If CR was passed, we must create a namespace for it and install CR into it.
@@ -120,7 +104,7 @@ func operatorInit(args *rootArgs, oiArgs *operatorInitArgs, l clog.Logger) {
 		l.LogAndFatal(err)
 	}
 
-	if err := applyManifest(restConfig, client, mstr, istioControllerComponentName, opts, l); err != nil {
+	if err := applyManifest(restConfig, client, mstr, string(name.IstioOperatorComponentName), opts, l); err != nil {
 		l.LogAndFatal(err)
 	}
 
@@ -129,10 +113,10 @@ func operatorInit(args *rootArgs, oiArgs *operatorInitArgs, l clog.Logger) {
 			l.LogAndFatal(err)
 
 		}
-		if err := applyManifest(restConfig, client, customResource, istioOperatorCRComponentName, opts, l); err != nil {
+		if err := applyManifest(restConfig, client, customResource, string(name.IstioOperatorComponentName), opts, l); err != nil {
 			l.LogAndFatal(err)
 		}
 	}
 
-	l.LogAndPrint("\n*** Success. ***\n")
+	l.LogAndPrint(color.New(color.FgGreen).Sprint("✔ ") + installationCompleteStr)
 }

--- a/operator/cmd/mesh/root.go
+++ b/operator/cmd/mesh/root.go
@@ -37,6 +37,7 @@ or release tar URL (e.g. https://github.com/istio/istio/releases/download/1.5.1/
 If set to true, the user is not prompted and a Yes response is assumed in all cases.`
 	filenameFlagHelpStr = `Path to file containing IstioOperator custom resource
 This flag can be specified multiple times to overlay multiple files. Multiple files are overlaid in left to right order.`
+	installationCompleteStr = `Installation complete`
 )
 
 type rootArgs struct {

--- a/operator/pkg/helmreconciler/prune.go
+++ b/operator/pkg/helmreconciler/prune.go
@@ -100,19 +100,6 @@ func (h *HelmReconciler) Prune(manifests ChartManifestsMap) error {
 	return errs.ToError()
 }
 
-// Delete removes all resources associated with h.
-func (h *HelmReconciler) Delete() error {
-	manifests, err := h.RenderCharts()
-	if err != nil {
-		return err
-	}
-	var errs util.Errors
-	for cname := range manifests {
-		errs = util.AppendErr(errs, h.PruneUnlistedResources(map[string]bool{}, cname))
-	}
-	return errs.ToError()
-}
-
 // Delete removes all resources associated with componentName.
 func (h *HelmReconciler) DeleteComponent(componentName string) error {
 	return h.PruneUnlistedResources(map[string]bool{}, componentName)

--- a/operator/pkg/helmreconciler/reconcile.go
+++ b/operator/pkg/helmreconciler/reconcile.go
@@ -27,7 +27,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"istio.io/api/operator/v1alpha1"
-
 	valuesv1alpha1 "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/name"
 	"istio.io/istio/operator/pkg/object"
@@ -106,6 +105,11 @@ func NewHelmReconciler(client client.Client, restConfig *rest.Config, iop *value
 	}
 	if opts.ProgressLog == nil {
 		opts.ProgressLog = util.NewProgressLog()
+	}
+	if iop == nil {
+		// allows controller code to function for cases where IOP is not provided (e.g. operator remove).
+		iop = &valuesv1alpha1.IstioOperator{}
+		iop.Spec = &v1alpha1.IstioOperatorSpec{}
 	}
 	var cs *kubernetes.Clientset
 	var err error
@@ -192,15 +196,6 @@ func (h *HelmReconciler) processRecursive(manifests ChartManifestsMap) *v1alpha1
 	}
 
 	return out
-}
-
-// Delete resources associated with the custom resource instance
-func (h *HelmReconciler) Delete() error {
-	manifestMap, err := h.RenderCharts()
-	if err != nil {
-		return err
-	}
-	return h.Prune(manifestMap)
 }
 
 // SetStatusBegin updates the status field on the IstioOperator instance before reconciling.

--- a/operator/pkg/helmreconciler/reconcile.go
+++ b/operator/pkg/helmreconciler/reconcile.go
@@ -200,6 +200,15 @@ func (h *HelmReconciler) processRecursive(manifests ChartManifestsMap) *v1alpha1
 	return out
 }
 
+// Delete resources associated with the custom resource instance
+func (h *HelmReconciler) Delete() error {
+	manifestMap, err := h.RenderCharts()
+	if err != nil {
+		return err
+	}
+	return h.Prune(manifestMap)
+}
+
 // SetStatusBegin updates the status field on the IstioOperator instance before reconciling.
 func (h *HelmReconciler) SetStatusBegin() error {
 	isop := &valuesv1alpha1.IstioOperator{}

--- a/operator/pkg/helmreconciler/render.go
+++ b/operator/pkg/helmreconciler/render.go
@@ -357,56 +357,6 @@ func (h *HelmReconciler) ProcessObject(chartName string, obj *unstructured.Unstr
 	})
 }
 
-// DeleteObject deletes obj.
-func (h *HelmReconciler) DeleteObject(chartName string, obj *unstructured.Unstructured) error {
-	if obj.GetKind() == "List" {
-		allErrors := []error{}
-		list, err := obj.ToList()
-		if err != nil {
-			scope.Errorf("error converting List object: %s", err)
-			return err
-		}
-		for _, item := range list.Items {
-			err = h.DeleteObject(chartName, &item)
-			if err != nil {
-				allErrors = append(allErrors, err)
-			}
-		}
-		return utilerrors.NewAggregate(allErrors)
-	}
-
-	receiver := &unstructured.Unstructured{}
-	receiver.SetGroupVersionKind(obj.GetObjectKind().GroupVersionKind())
-	objectKey, _ := client.ObjectKeyFromObject(obj)
-	objectStr := fmt.Sprintf("%s/%s/%s", obj.GetKind(), obj.GetNamespace(), obj.GetName())
-
-	scope.Debugf("Deleting object:\n%s\n\n", util.ToYAML(obj))
-	if h.opts.DryRun {
-		scope.Infof("Not deleting object %s because of dry run.", objectStr)
-		return nil
-	}
-
-	backoff := wait.Backoff{Duration: time.Millisecond * 10, Factor: 2, Steps: 3}
-	return retry.RetryOnConflict(backoff, func() error {
-		err := h.client.Get(context.TODO(), objectKey, receiver)
-		switch {
-		case apierrors.IsNotFound(err):
-			return nil
-		case err == nil:
-			scope.Infof("deleting resource: %s", objectStr)
-			if err := applyOverlay(receiver, obj); err != nil {
-				return err
-			}
-			updateErr := h.client.Delete(context.TODO(), receiver)
-			if updateErr != nil {
-				scope.Warnf("delete %v: %v", receiver.GetName(), updateErr)
-			}
-			return updateErr
-		}
-		return nil
-	})
-}
-
 // applyOverlay applies an overlay using JSON patch strategy over the current Object in place.
 func applyOverlay(current, overlay runtime.Object) error {
 	cj, err := runtime.Encode(unstructured.UnstructuredJSONScheme, current)

--- a/operator/pkg/helmreconciler/render.go
+++ b/operator/pkg/helmreconciler/render.go
@@ -357,6 +357,56 @@ func (h *HelmReconciler) ProcessObject(chartName string, obj *unstructured.Unstr
 	})
 }
 
+// DeleteObject deletes obj.
+func (h *HelmReconciler) DeleteObject(chartName string, obj *unstructured.Unstructured) error {
+	if obj.GetKind() == "List" {
+		allErrors := []error{}
+		list, err := obj.ToList()
+		if err != nil {
+			scope.Errorf("error converting List object: %s", err)
+			return err
+		}
+		for _, item := range list.Items {
+			err = h.DeleteObject(chartName, &item)
+			if err != nil {
+				allErrors = append(allErrors, err)
+			}
+		}
+		return utilerrors.NewAggregate(allErrors)
+	}
+
+	receiver := &unstructured.Unstructured{}
+	receiver.SetGroupVersionKind(obj.GetObjectKind().GroupVersionKind())
+	objectKey, _ := client.ObjectKeyFromObject(obj)
+	objectStr := fmt.Sprintf("%s/%s/%s", obj.GetKind(), obj.GetNamespace(), obj.GetName())
+
+	scope.Debugf("Deleting object:\n%s\n\n", util.ToYAML(obj))
+	if h.opts.DryRun {
+		scope.Infof("Not deleting object %s because of dry run.", objectStr)
+		return nil
+	}
+
+	backoff := wait.Backoff{Duration: time.Millisecond * 10, Factor: 2, Steps: 3}
+	return retry.RetryOnConflict(backoff, func() error {
+		err := h.client.Get(context.TODO(), objectKey, receiver)
+		switch {
+		case apierrors.IsNotFound(err):
+			return nil
+		case err == nil:
+			scope.Infof("deleting resource: %s", objectStr)
+			if err := applyOverlay(receiver, obj); err != nil {
+				return err
+			}
+			updateErr := h.client.Delete(context.TODO(), receiver)
+			if updateErr != nil {
+				scope.Warnf("delete %v: %v", receiver.GetName(), updateErr)
+			}
+			return updateErr
+		}
+		return nil
+	})
+}
+
 // applyOverlay applies an overlay using JSON patch strategy over the current Object in place.
 func applyOverlay(current, overlay runtime.Object) error {
 	cj, err := runtime.Encode(unstructured.UnstructuredJSONScheme, current)
@@ -479,4 +529,22 @@ func (mm ChartManifestsMap) Consolidated() map[string]string {
 		out[cname] = allM
 	}
 	return out
+}
+
+// removeFromObjectCache removes object with objHash in componentName from the object cache.
+func (h *HelmReconciler) removeFromObjectCache(componentName, objHash string) {
+	crHash, err := h.getCRHash(componentName)
+	if err != nil {
+		scope.Error(err.Error())
+	}
+	objectCachesMu.Lock()
+	objectCache := objectCaches[crHash]
+	objectCachesMu.Unlock()
+
+	if objectCache != nil {
+		objectCache.mu.Lock()
+		delete(objectCache.cache, objHash)
+		objectCache.mu.Unlock()
+		scope.Infof("Removed object %s from cache.", objHash)
+	}
 }


### PR DESCRIPTION
This command was broken after refactoring. This PR fixes it and cleans up flags that are not needed. In addition, the removal is now done through prune rather than delete so the original manifest is not required. 