### PR TITLE
Match istio.io/rev=default label for injection

### DIFF
--- a/manifests/charts/base/files/gen-istio-cluster.yaml
+++ b/manifests/charts/base/files/gen-istio-cluster.yaml
@@ -4987,7 +4987,7 @@ rules:
   # sidecar injection controller
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["mutatingwebhookconfigurations"]
-    verbs: ["get", "list", "watch", "patch"]
+    verbs: ["get", "list", "watch", "update", "patch"]
 
   # configuration validation webhook controller
   - apiGroups: ["admissionregistration.k8s.io"]

--- a/manifests/charts/base/templates/clusterrole.yaml
+++ b/manifests/charts/base/templates/clusterrole.yaml
@@ -11,7 +11,7 @@ rules:
   # sidecar injection controller
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["mutatingwebhookconfigurations"]
-    verbs: ["get", "list", "watch", "patch"]
+    verbs: ["get", "list", "watch", "update", "patch"]
 
   # configuration validation webhook controller
   - apiGroups: ["admissionregistration.k8s.io"]

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1667,6 +1667,7 @@ metadata:
     app: sidecar-injector
     release: istio
 webhooks:
+
   - name: sidecar-injector.istio.io
     clientConfig:
       service:
@@ -1681,5 +1682,33 @@ webhooks:
         resources: ["pods"]
     failurePolicy: Fail
     namespaceSelector:
-      matchLabels:
-        istio-injection: enabled
+      matchExpressions:
+      - key: istio-injection
+        operator: In
+        values:
+          - enabled
+      - key: istio.io/rev
+        operator: DoesNotExist
+
+
+  - name: sidecar-injector.istio.io
+    clientConfig:
+      service:
+        name: istiod
+        namespace: istio-system
+        path: "/inject"
+      caBundle: ""
+    rules:
+      - operations: [ "CREATE" ]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+    failurePolicy: Fail
+    namespaceSelector:
+      matchExpressions:
+        - key: istio-injection
+          operator: DoesNotExist
+        - key: istio.io/rev
+          operator: In
+          values:
+            - default

--- a/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -13,6 +13,8 @@ metadata:
     app: sidecar-injector
     release: {{ .Release.Name }}
 webhooks:
+{{- if eq .Values.revision ""}}
+{{/*  No revision set. Set up istio-injection=enabled matcher */}}
   - name: sidecar-injector.istio.io
     clientConfig:
       service:
@@ -27,7 +29,7 @@ webhooks:
         resources: ["pods"]
     failurePolicy: Fail
     namespaceSelector:
-{{- if .Values.sidecarInjectorWebhook.enableNamespacesByDefault }}
+      {{- if .Values.sidecarInjectorWebhook.enableNamespacesByDefault }}
       matchExpressions:
       - key: name
         operator: NotIn
@@ -41,29 +43,50 @@ webhooks:
         operator: DoesNotExist
       - key: istio.io/rev
         operator: DoesNotExist
-{{- else if .Values.revision }}
+      {{- else }}
       matchExpressions:
       - key: istio-injection
-        operator: DoesNotExist
-      - key: istio.io/rev
         operator: In
         values:
-        - {{ .Values.revision }}
-{{- else }}
-      matchLabels:
-        istio-injection: enabled
-{{- end }}
-{{- if .Values.sidecarInjectorWebhook.objectSelector.enabled }}
+          - enabled
+      - key: istio.io/rev
+        operator: DoesNotExist
+      {{- end }}
+    {{- if .Values.sidecarInjectorWebhook.objectSelector.enabled }}
     objectSelector:
-{{- if .Values.sidecarInjectorWebhook.objectSelector.autoInject }}
+      {{- if .Values.sidecarInjectorWebhook.objectSelector.autoInject }}
       matchExpressions:
       - key: "sidecar.istio.io/inject"
         operator: NotIn
         values:
         - "false"
-{{- else }}
+      {{- else }}
       matchLabels:
         "sidecar.istio.io/inject": "true"
+    {{- end }}
+  {{- end }}
 {{- end }}
-{{- end }}
+
+{{/*  Set up another webook that will match istio.io/rev label */}}
+  - name: sidecar-injector.istio.io
+    clientConfig:
+      service:
+        name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+        namespace: {{ .Release.Namespace }}
+        path: "/inject"
+      caBundle: ""
+    rules:
+      - operations: [ "CREATE" ]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+    failurePolicy: Fail
+    namespaceSelector:
+      matchExpressions:
+        - key: istio-injection
+          operator: DoesNotExist
+        - key: istio.io/rev
+          operator: In
+          values:
+            - {{ .Values.revision | default "default" }}
 {{- end }}

--- a/pkg/util/webhookpatch_test.go
+++ b/pkg/util/webhookpatch_test.go
@@ -16,7 +16,6 @@ package util
 
 import (
 	"bytes"
-	"encoding/json"
 	"strings"
 	"testing"
 
@@ -95,14 +94,11 @@ func TestMutatingWebhookPatch(t *testing.T) {
 					t.Fatalf("Got %q, want %q", err, tc.err)
 				}
 			} else {
-				config := admissionregistrationv1beta1.MutatingWebhookConfiguration{}
-				patch := client.Actions()[1].(k8stesting.PatchAction).GetPatch()
-				err = json.Unmarshal(patch, &config)
-				if err != nil {
-					t.Fatalf("Fail to parse the patch: %s", err.Error())
-				}
-				if !bytes.Equal(config.Webhooks[0].ClientConfig.CABundle, tc.pemData) {
-					t.Fatalf("Incorrect CA bundle: expect %s got %s", tc.pemData, config.Webhooks[0].ClientConfig.CABundle)
+				obj := client.Actions()[1].(k8stesting.UpdateAction).GetObject()
+				for _, w := range obj.(*admissionregistrationv1beta1.MutatingWebhookConfiguration).Webhooks {
+					if !bytes.Equal(w.ClientConfig.CABundle, tc.pemData) {
+						t.Fatalf("Incorrect CA bundle: expect %s got %s", tc.pemData, w.ClientConfig.CABundle)
+					}
 				}
 			}
 		})


### PR DESCRIPTION
See https://github.com/istio/istio/issues/23319

This is challenging because the k8s api does not support the label
selector `istio-injection=enabled || istio.io/rev=default`, we can only
AND them together. To get around this, we make two webhooks (in one
resource). This requires a minor patch to the patching logic