### PR TITLE
set listener's reuseport option

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -45,6 +45,10 @@ const (
 var _ mesh.Holder = &Environment{}
 var _ mesh.NetworksHolder = &Environment{}
 
+var (
+	LabelReusePort = "reuse_port"
+)
+
 // Environment provides an aggregate environmental API for Pilot
 type Environment struct {
 	// Discovery interface for listing services and instances.

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -59,6 +59,12 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(
 	actualWildcard, _ := getActualWildcardAndLocalHost(node)
 	errs := &multierror.Error{}
 	listeners := make([]*xdsapi.Listener, 0, len(mergedGateway.Servers))
+
+	reusePort := false
+	if v, found := node.Metadata.Labels[model.LabelReusePort]; found {
+		reusePort = v == "true"
+	}
+
 	for portNumber, servers := range mergedGateway.Servers {
 		var si *model.ServiceInstance
 		services := make(map[host.Name]struct{}, len(node.ServiceInstances))
@@ -86,6 +92,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(
 			bind:       actualWildcard,
 			port:       int(portNumber),
 			bindToPort: true,
+			reusePort:  reusePort,
 		}
 
 		p := protocol.Parse(servers[0].Port.Protocol)

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1882,6 +1882,7 @@ type buildListenerOpts struct {
 	bindToPort        bool
 	skipUserFilters   bool
 	needHTTPInspector bool
+	reusePort         bool
 }
 
 func buildHTTPConnectionManager(pluginParams *plugin.InputParams, httpOpts *httpListenerOpts,
@@ -2230,6 +2231,7 @@ func buildListener(opts buildListenerOpts) *xdsapi.Listener {
 		ListenerFilters: listenerFilters,
 		FilterChains:    filterChains,
 		DeprecatedV1:    deprecatedV1,
+		ReusePort:       opts.reusePort,
 	}
 
 	if opts.proxy.Type != model.Router {


### PR DESCRIPTION
Envoy's [Listener](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/listener.proto#listener) has a `reuse_port` option, this change is for enabling this option when an ingress gateway POD has  label "reuse_port: true". 