### PR TITLE
support root cert refresh and provide option to disable CA

### DIFF
--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -136,6 +136,9 @@ type CAOptions struct {
 // to have a central consistent endpoint to get whether CA functionality is
 // enabled in istiod. EnableCA() is called in multiple places.
 func (s *Server) EnableCA() bool {
+	if !features.EnableCAServer {
+		return false
+	}
 	if s.kubeClient == nil {
 		// No k8s - no self-signed certs.
 		// TODO: implement it using a local directory, for non-k8s env.

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -264,6 +264,7 @@ func NewServer(args *PilotArgs) (*Server, error) {
 	if err := s.initMonitor(args.DiscoveryOptions.MonitoringAddr); err != nil {
 		return nil, fmt.Errorf("error initializing monitor: %v", err)
 	}
+        // TODO(irisdingbj):add integration test after centralIstiod finished
 	args.Config.ControllerOptions.FetchCaRoot = nil
 	if features.CentralIstioD {
 		if s.ca != nil && s.ca.GetCAKeyCertBundle() != nil {

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -264,10 +264,16 @@ func NewServer(args *PilotArgs) (*Server, error) {
 	if err := s.initMonitor(args.DiscoveryOptions.MonitoringAddr); err != nil {
 		return nil, fmt.Errorf("error initializing monitor: %v", err)
 	}
-	args.Config.ControllerOptions.CAROOT = ""
+	args.Config.ControllerOptions.FetchcaRoot = func() map[string]string {
+		return nil
+	}
 	if features.CentralIstioD {
 		if s.ca != nil && s.ca.GetCAKeyCertBundle() != nil {
-			args.Config.ControllerOptions.CAROOT = string(s.ca.GetCAKeyCertBundle().GetRootCertPem())
+			args.Config.ControllerOptions.FetchcaRoot = func() map[string]string {
+				return map[string]string{
+					constants.CACertNamespaceConfigMapDataName: string(s.ca.GetCAKeyCertBundle().GetRootCertPem()),
+				}
+			}
 		}
 	}
 	if err := s.initClusterRegistries(args); err != nil {

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -264,12 +264,10 @@ func NewServer(args *PilotArgs) (*Server, error) {
 	if err := s.initMonitor(args.DiscoveryOptions.MonitoringAddr); err != nil {
 		return nil, fmt.Errorf("error initializing monitor: %v", err)
 	}
-	args.Config.ControllerOptions.FetchcaRoot = func() map[string]string {
-		return nil
-	}
+	args.Config.ControllerOptions.FetchCaRoot = nil
 	if features.CentralIstioD {
 		if s.ca != nil && s.ca.GetCAKeyCertBundle() != nil {
-			args.Config.ControllerOptions.FetchcaRoot = func() map[string]string {
+			args.Config.ControllerOptions.FetchCaRoot = func() map[string]string {
 				return map[string]string{
 					constants.CACertNamespaceConfigMapDataName: string(s.ca.GetCAKeyCertBundle().GetRootCertPem()),
 				}

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -264,7 +264,7 @@ func NewServer(args *PilotArgs) (*Server, error) {
 	if err := s.initMonitor(args.DiscoveryOptions.MonitoringAddr); err != nil {
 		return nil, fmt.Errorf("error initializing monitor: %v", err)
 	}
-        // TODO(irisdingbj):add integration test after centralIstiod finished
+	// TODO(irisdingbj):add integration test after centralIstiod finished
 	args.Config.ControllerOptions.FetchCaRoot = nil
 	if features.CentralIstioD {
 		if s.ca != nil && s.ca.GetCAKeyCertBundle() != nil {

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -319,6 +319,6 @@ var (
 			"resource supports incremental. By default, this is false.").Get()
 	CentralIstioD = env.RegisterBoolVar("CENTRAL_ISTIOD", false,
 		"If this is set to true, one Istiod will control remote clusters including CA.").Get()
-	EnableCAServer = env.RegisterBoolVar("EnableCAServer", true,
+	EnableCAServer = env.RegisterBoolVar("ENABLE_CA_SERVER", true,
 		"If this is set to false, will not create CA server in istiod.").Get()
 )

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -319,4 +319,6 @@ var (
 			"resource supports incremental. By default, this is false.").Get()
 	CentralIstioD = env.RegisterBoolVar("CENTRAL_ISTIOD", false,
 		"If this is set to true, one Istiod will control remote clusters including CA.").Get()
+	EnableCAServer = env.RegisterBoolVar("EnableCAServer", true,
+		"If this is set to false, will not create CA server in istiod.").Get()
 )

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -113,8 +113,8 @@ type Options struct {
 	// ClusterID identifies the remote cluster in a multicluster env.
 	ClusterID string
 
-	// FetchcaRoot defines the function to get caRoot
-	FetchcaRoot func() map[string]string
+	// FetchCaRoot defines the function to get caRoot
+	FetchCaRoot func() map[string]string
 
 	// Metrics for capturing node-based metrics.
 	Metrics model.Metrics

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -113,8 +113,8 @@ type Options struct {
 	// ClusterID identifies the remote cluster in a multicluster env.
 	ClusterID string
 
-	// CAROOT defines the CAROOT where one istiod controls remote cluster
-	CAROOT string
+	// FetchcaRoot defines the function to get caRoot
+	FetchcaRoot func() map[string]string
 
 	// Metrics for capturing node-based metrics.
 	Metrics model.Metrics

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -46,7 +46,9 @@ type Multicluster struct {
 	m                     sync.Mutex // protects remoteKubeControllers
 	remoteKubeControllers map[string]*kubeController
 	networksWatcher       mesh.NetworksWatcher
-	fetchcaRoot           func() map[string]string
+
+	// fetchCaRoot maps the certName to cert
+	fetchCaRoot func() map[string]string
 }
 
 // NewMulticluster initializes data structure to store multicluster information
@@ -69,7 +71,7 @@ func NewMulticluster(kc kubernetes.Interface, secretNamespace string, opts Optio
 		remoteKubeControllers: remoteKubeController,
 		networksWatcher:       networksWatcher,
 		metrics:               opts.Metrics,
-		fetchcaRoot:           opts.FetchcaRoot,
+		fetchCaRoot:           opts.FetchCaRoot,
 	}
 
 	err := secretcontroller.StartSecretController(
@@ -113,8 +115,8 @@ func (m *Multicluster) AddMemberCluster(clientset kubernetes.Interface, metadata
 		ResyncPeriod: m.ResyncPeriod,
 		DomainSuffix: m.DomainSuffix,
 	}
-	if m.fetchcaRoot() != nil {
-		nc := NewNamespaceController(m.fetchcaRoot, opts, clientset)
+	if m.fetchCaRoot != nil {
+		nc := NewNamespaceController(m.fetchCaRoot, opts, clientset)
 		go nc.Run(stopCh)
 	}
 	return nil

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -47,7 +47,7 @@ type Multicluster struct {
 	remoteKubeControllers map[string]*kubeController
 	networksWatcher       mesh.NetworksWatcher
 
-	// fetchCaRoot maps the certName to cert
+	// fetchCaRoot maps the certificate name to the certificate
 	fetchCaRoot func() map[string]string
 }
 


### PR DESCRIPTION
This is to support scenario described #22934 and also part of https://github.com/istio/istio/issues/23263.

remote cluster will not run CA at all, instead all workloads in remote cluster will connect back to CA on main cluster(centralIstiod enabled).

