### PR TITLE
match istio.io/rev=default label when revision is not set

### DIFF
--- a/manifests/charts/base/files/gen-istio-cluster.yaml
+++ b/manifests/charts/base/files/gen-istio-cluster.yaml
@@ -4987,7 +4987,7 @@ rules:
   # sidecar injection controller
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["mutatingwebhookconfigurations"]
-    verbs: ["get", "list", "watch", "patch"]
+    verbs: ["get", "list", "watch", "update", "patch"]
 
   # configuration validation webhook controller
   - apiGroups: ["admissionregistration.k8s.io"]

--- a/manifests/charts/base/templates/clusterrole.yaml
+++ b/manifests/charts/base/templates/clusterrole.yaml
@@ -11,7 +11,7 @@ rules:
   # sidecar injection controller
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["mutatingwebhookconfigurations"]
-    verbs: ["get", "list", "watch", "patch"]
+    verbs: ["get", "list", "watch", "update", "patch"]
 
   # configuration validation webhook controller
   - apiGroups: ["admissionregistration.k8s.io"]

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1667,6 +1667,7 @@ metadata:
     app: sidecar-injector
     release: istio
 webhooks:
+
   - name: sidecar-injector.istio.io
     clientConfig:
       service:
@@ -1681,5 +1682,33 @@ webhooks:
         resources: ["pods"]
     failurePolicy: Fail
     namespaceSelector:
-      matchLabels:
-        istio-injection: enabled
+      matchExpressions:
+      - key: istio-injection
+        operator: In
+        values:
+          - enabled
+      - key: istio.io/rev
+        operator: DoesNotExist
+
+
+  - name: sidecar-injector.istio.io
+    clientConfig:
+      service:
+        name: istiod
+        namespace: istio-system
+        path: "/inject"
+      caBundle: ""
+    rules:
+      - operations: [ "CREATE" ]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+    failurePolicy: Fail
+    namespaceSelector:
+      matchExpressions:
+        - key: istio-injection
+          operator: DoesNotExist
+        - key: istio.io/rev
+          operator: In
+          values:
+            - default

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1706,8 +1706,6 @@ webhooks:
     failurePolicy: Fail
     namespaceSelector:
       matchExpressions:
-        - key: istio-injection
-          operator: DoesNotExist
         - key: istio.io/rev
           operator: In
           values:

--- a/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -67,7 +67,12 @@ webhooks:
   {{- end }}
 {{- end }}
 
-{{/*  Set up another webook that will match istio.io/rev label */}}
+{{/*
+Set up another webook that will match istio.io/rev label. If a revision is set, then we will make sure
+that we do NOT match istio-injection=enabled. This avoids injecting other revisions. If a revision is NOT
+set, we will match istio.io/rev=default. This means we also match a namespace that is (by user error)
+labeled with both istio.io/rev=default,istio-injection=enabled.
+ */}}
   - name: sidecar-injector.istio.io
     clientConfig:
       service:
@@ -83,8 +88,10 @@ webhooks:
     failurePolicy: Fail
     namespaceSelector:
       matchExpressions:
+      {{- if ne .Values.revision ""}}
         - key: istio-injection
           operator: DoesNotExist
+      {{- end }}
         - key: istio.io/rev
           operator: In
           values:

--- a/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -13,6 +13,8 @@ metadata:
     app: sidecar-injector
     release: {{ .Release.Name }}
 webhooks:
+{{- if eq .Values.revision ""}}
+{{/*  No revision set. Set up istio-injection=enabled matcher */}}
   - name: sidecar-injector.istio.io
     clientConfig:
       service:
@@ -27,7 +29,7 @@ webhooks:
         resources: ["pods"]
     failurePolicy: Fail
     namespaceSelector:
-{{- if .Values.sidecarInjectorWebhook.enableNamespacesByDefault }}
+      {{- if .Values.sidecarInjectorWebhook.enableNamespacesByDefault }}
       matchExpressions:
       - key: name
         operator: NotIn
@@ -41,29 +43,50 @@ webhooks:
         operator: DoesNotExist
       - key: istio.io/rev
         operator: DoesNotExist
-{{- else if .Values.revision }}
+      {{- else }}
       matchExpressions:
       - key: istio-injection
-        operator: DoesNotExist
-      - key: istio.io/rev
         operator: In
         values:
-        - {{ .Values.revision }}
-{{- else }}
-      matchLabels:
-        istio-injection: enabled
-{{- end }}
-{{- if .Values.sidecarInjectorWebhook.objectSelector.enabled }}
+          - enabled
+      - key: istio.io/rev
+        operator: DoesNotExist
+      {{- end }}
+    {{- if .Values.sidecarInjectorWebhook.objectSelector.enabled }}
     objectSelector:
-{{- if .Values.sidecarInjectorWebhook.objectSelector.autoInject }}
+      {{- if .Values.sidecarInjectorWebhook.objectSelector.autoInject }}
       matchExpressions:
       - key: "sidecar.istio.io/inject"
         operator: NotIn
         values:
         - "false"
-{{- else }}
+      {{- else }}
       matchLabels:
         "sidecar.istio.io/inject": "true"
+    {{- end }}
+  {{- end }}
 {{- end }}
-{{- end }}
+
+{{/*  Set up another webook that will match istio.io/rev label */}}
+  - name: sidecar-injector.istio.io
+    clientConfig:
+      service:
+        name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+        namespace: {{ .Release.Namespace }}
+        path: "/inject"
+      caBundle: ""
+    rules:
+      - operations: [ "CREATE" ]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+    failurePolicy: Fail
+    namespaceSelector:
+      matchExpressions:
+        - key: istio-injection
+          operator: DoesNotExist
+        - key: istio.io/rev
+          operator: In
+          values:
+            - {{ .Values.revision | default "default" }}
 {{- end }}

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -509,7 +509,7 @@ func TestWebhookSelector(t *testing.T) {
 		{defaultSelector0, legacyAndCanaryLabel, false},
 
 		// Second webhook: match istio.io/rev=default. It is okay if both labels are present; only this webhook is matched
-		// Essentially the logic here is (a && !b) || b, which is equivilent to a || b, or desired end state, without
+		// Essentially the logic here is (a && !b) || b, which is equivalent to a || b, or desired end state, without
 		// triggering duplicate injection
 		{defaultSelector1, legacyLabel, false},
 		{defaultSelector1, defaultRevLabel, true},

--- a/operator/cmd/mesh/test-util.go
+++ b/operator/cmd/mesh/test-util.go
@@ -15,6 +15,7 @@
 package mesh
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -25,6 +26,7 @@ import (
 
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels2 "k8s.io/apimachinery/pkg/labels"
 
 	name2 "istio.io/istio/operator/pkg/name"
@@ -294,6 +296,24 @@ func mustGetPath(t test.Failer, obj object.K8sObject, path string) interface{} {
 		t.Fatalf("couldn't find path %v", path)
 	}
 	return got
+}
+
+func mustGetSelector(t test.Failer, obj object.K8sObject, path string) labels2.Selector {
+	t.Helper()
+	selectorS := mustGetPath(t, obj, path)
+	var ss metav1.LabelSelector
+	by, err := json.Marshal(selectorS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(by, &ss); err != nil {
+		t.Fatal(err)
+	}
+	ls, err := metav1.LabelSelectorAsSelector(&ss)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ls
 }
 
 func mustFindObject(t test.Failer, objs object.K8sObjects, name, kind string) object.K8sObject {

--- a/operator/pkg/name/name.go
+++ b/operator/pkg/name/name.go
@@ -32,20 +32,21 @@ import (
 
 // Kubernetes Kind strings.
 const (
-	CRDStr                   = "CustomResourceDefinition"
-	DaemonSetStr             = "DaemonSet"
-	DeploymentStr            = "Deployment"
-	HPAStr                   = "HorizontalPodAutoscaler"
-	NamespaceStr             = "Namespace"
-	PodStr                   = "Pod"
-	PDBStr                   = "PodDisruptionBudget"
-	ReplicationControllerStr = "ReplicationController"
-	ReplicaSetStr            = "ReplicaSet"
-	RoleStr                  = "Role"
-	RoleBindingStr           = "RoleBinding"
-	SAStr                    = "ServiceAccount"
-	ServiceStr               = "Service"
-	StatefulSetStr           = "StatefulSet"
+	CRDStr                          = "CustomResourceDefinition"
+	DaemonSetStr                    = "DaemonSet"
+	DeploymentStr                   = "Deployment"
+	HPAStr                          = "HorizontalPodAutoscaler"
+	NamespaceStr                    = "Namespace"
+	PodStr                          = "Pod"
+	PDBStr                          = "PodDisruptionBudget"
+	ReplicationControllerStr        = "ReplicationController"
+	ReplicaSetStr                   = "ReplicaSet"
+	RoleStr                         = "Role"
+	RoleBindingStr                  = "RoleBinding"
+	SAStr                           = "ServiceAccount"
+	ServiceStr                      = "Service"
+	StatefulSetStr                  = "StatefulSet"
+	MutatingWebhookConfigurationStr = "MutatingWebhookConfiguration"
 )
 
 const (

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -805,18 +805,6 @@ func (wh *Webhook) inject(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionRespons
 		deployMeta.Name = pod.Name
 	}
 
-	//skip injection for injected pods
-	if len(pod.Spec.Containers) > 1 {
-		for _, c := range pod.Spec.Containers {
-			if c.Name == ProxyContainerName {
-				log.Warnf("Skipping injection because %q has injected %q sidecar already", pod.ObjectMeta.Name, ProxyContainerName)
-				return &v1beta1.AdmissionResponse{
-					Allowed: true,
-				}
-			}
-		}
-	}
-
 	spec, iStatus, err := InjectionData(wh.Config.Template, wh.valuesConfig, wh.sidecarTemplateVersion, typeMetadata, deployMeta, &pod.Spec, &pod.ObjectMeta, wh.meshConfig) // nolint: lll
 	if err != nil {
 		handleError(fmt.Sprintf("Injection data: err=%v spec=%v\n", err, iStatus))

--- a/pkg/util/webhookpatch_test.go
+++ b/pkg/util/webhookpatch_test.go
@@ -16,7 +16,6 @@ package util
 
 import (
 	"bytes"
-	"encoding/json"
 	"strings"
 	"testing"
 
@@ -95,14 +94,11 @@ func TestMutatingWebhookPatch(t *testing.T) {
 					t.Fatalf("Got %q, want %q", err, tc.err)
 				}
 			} else {
-				config := admissionregistrationv1beta1.MutatingWebhookConfiguration{}
-				patch := client.Actions()[1].(k8stesting.PatchAction).GetPatch()
-				err = json.Unmarshal(patch, &config)
-				if err != nil {
-					t.Fatalf("Fail to parse the patch: %s", err.Error())
-				}
-				if !bytes.Equal(config.Webhooks[0].ClientConfig.CABundle, tc.pemData) {
-					t.Fatalf("Incorrect CA bundle: expect %s got %s", tc.pemData, config.Webhooks[0].ClientConfig.CABundle)
+				obj := client.Actions()[1].(k8stesting.UpdateAction).GetObject()
+				for _, w := range obj.(*admissionregistrationv1beta1.MutatingWebhookConfiguration).Webhooks {
+					if !bytes.Equal(w.ClientConfig.CABundle, tc.pemData) {
+						t.Fatalf("Incorrect CA bundle: expect %s got %s", tc.pemData, w.ClientConfig.CABundle)
+					}
 				}
 			}
 		})


### PR DESCRIPTION
See #23319

The goal here is to also support matching istio.io/rev=default when revision is not set. This has some minor improvements by having a consistent label used throughout. This makes docs/UX a bit simpler. It also means to switch from default to revision you just overwrite a label instead of `kubectl label ns istio-injection- istio.io/rev=foo`

This is challenging because the k8s api does not support the label
selector istio-injection=enabled || istio.io/rev=default, we can only
AND them together. To get around this, we make two webhooks (in one
resource). This requires a minor patch to the patching logic