### PR TITLE
test framework: enable setup for controlPlaneTopology

### DIFF
--- a/pkg/test/framework/components/environment/kube/cluster.go
+++ b/pkg/test/framework/components/environment/kube/cluster.go
@@ -27,9 +27,8 @@ var _ resource.Cluster = Cluster{}
 // Cluster for a Kubernetes cluster. Provides access via a kube.Accessor.
 type Cluster struct {
 	*kube.Accessor
-	filename            string
-	index               resource.ClusterIndex
-	controlPlaneCluster bool
+	filename string
+	index    resource.ClusterIndex
 }
 
 func (c Cluster) String() string {
@@ -37,7 +36,6 @@ func (c Cluster) String() string {
 
 	_, _ = fmt.Fprintf(buf, "Index:               %d\n", c.index)
 	_, _ = fmt.Fprintf(buf, "Filename:            %s\n", c.filename)
-	_, _ = fmt.Fprintf(buf, "ControlPlaneCluster: %t\n", c.controlPlaneCluster)
 
 	return buf.String()
 }
@@ -55,11 +53,6 @@ func (c Cluster) Name() string {
 // Index of this cluster within the Environment.
 func (c Cluster) Index() resource.ClusterIndex {
 	return c.index
-}
-
-// IsControlPlaneCluster indicates whether this cluster contains an instance of the Istio control plane.
-func (c Cluster) IsControlPlaneCluster() bool {
-	return c.controlPlaneCluster
 }
 
 // ClusterOrDefault gets the given cluster as a kube Cluster if available. Otherwise

--- a/pkg/test/framework/components/environment/kube/kube.go
+++ b/pkg/test/framework/components/environment/kube/kube.go
@@ -53,8 +53,6 @@ func New(ctx resource.Context) (resource.Environment, error) {
 	}
 	e.id = ctx.TrackResource(e)
 
-	controlPlaneClusters := s.GetControlPlaneClusters()
-
 	e.KubeClusters = make([]Cluster, 0, len(s.KubeConfig))
 	for i := range s.KubeConfig {
 		a, err := kube.NewAccessor(s.KubeConfig[i], workDir)
@@ -63,10 +61,9 @@ func New(ctx resource.Context) (resource.Environment, error) {
 		}
 		clusterIndex := resource.ClusterIndex(i)
 		e.KubeClusters = append(e.KubeClusters, Cluster{
-			filename:            s.KubeConfig[i],
-			index:               clusterIndex,
-			controlPlaneCluster: controlPlaneClusters[clusterIndex],
-			Accessor:            a,
+			filename: s.KubeConfig[i],
+			index:    clusterIndex,
+			Accessor: a,
 		})
 	}
 
@@ -92,11 +89,20 @@ func (e *Environment) Clusters() []resource.Cluster {
 func (e *Environment) ControlPlaneClusters() []Cluster {
 	out := make([]Cluster, 0, len(e.KubeClusters))
 	for _, c := range e.KubeClusters {
-		if c.IsControlPlaneCluster() {
+		if e.IsControlPlaneCluster(c) {
 			out = append(out, c)
 		}
 	}
 	return out
+}
+
+// IsControlPlaneCluster returns true if the cluster uses its own control plane in the ControlPlaneTopology.
+// We return if there is no mapping for the cluster, similar to the behavior of the istio.test.kube.controlPlaneTopology.
+func (e *Environment) IsControlPlaneCluster(cluster resource.Cluster) bool {
+	if controlPlaneIndex, ok := e.Settings().ControlPlaneTopology[cluster.Index()]; ok {
+		return controlPlaneIndex == cluster.Index()
+	}
+	return true
 }
 
 func (e *Environment) Case(name environment.Name, fn func()) {

--- a/pkg/test/framework/components/environment/kube/settings.go
+++ b/pkg/test/framework/components/environment/kube/settings.go
@@ -17,6 +17,9 @@ package kube
 import (
 	"fmt"
 
+	"istio.io/istio/pkg/test/framework/resource/environment"
+	"istio.io/istio/pkg/test/scopes"
+
 	"istio.io/istio/pkg/test/framework/resource"
 )
 
@@ -32,6 +35,21 @@ type Settings struct {
 	// ControlPlaneTopology maps each cluster to the cluster that runs its control plane. For replicated control
 	// plane cases (where each cluster has its own control plane), the cluster will map to itself (e.g. 0->0).
 	ControlPlaneTopology map[resource.ClusterIndex]resource.ClusterIndex
+}
+
+type SetupSettingsFunc func(s *Settings)
+
+// Setup is a setup function that allows overriding values in the Kube environment settings.
+func Setup(sfn SetupSettingsFunc) resource.SetupFn {
+	return func(ctx resource.Context) error {
+		switch ctx.Environment().EnvironmentName() {
+		case environment.Kube:
+			sfn(ctx.Environment().(*Environment).s)
+		default:
+			scopes.Framework.Warnf("kube.SetupSettings: Skipping on non-kube environment: %s", ctx.Environment().EnvironmentName())
+		}
+		return nil
+	}
 }
 
 func (s *Settings) clone() *Settings {

--- a/pkg/test/framework/components/environment/native/cluster.go
+++ b/pkg/test/framework/components/environment/native/cluster.go
@@ -35,7 +35,3 @@ func (c cluster) Index() resource.ClusterIndex {
 	// Multicluster not supported natively.
 	return 0
 }
-
-func (c cluster) IsControlPlaneCluster() bool {
-	return true
-}

--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -70,7 +70,6 @@ var (
 		UndeployTimeout:                0,
 		IOPFile:                        IntegrationTestDefaultsIOP,
 		CustomSidecarInjectorNamespace: "",
-		ControlPlaneTopology:           make(map[resource.ClusterIndex]resource.ClusterIndex),
 	}
 )
 
@@ -115,10 +114,6 @@ type Config struct {
 
 	// Indicates that the test should deploy Istio into the target Kubernetes cluster before running tests.
 	DeployIstio bool
-
-	// ControlPlaneTopology maps each cluster to the cluster that runs its control plane. For replicated control
-	// plane cases (where each cluster has its own control plane), the cluster will map to itself (e.g. 0->0).
-	ControlPlaneTopology map[resource.ClusterIndex]resource.ClusterIndex
 
 	// Do not wait for the validation webhook before completing the deployment. This is useful for
 	// doing deployments without Galley.
@@ -315,7 +310,6 @@ func (c *Config) String() string {
 	result += fmt.Sprintf("IOPFile:                        %s\n", c.IOPFile)
 	result += fmt.Sprintf("SkipWaitForValidationWebhook:   %v\n", c.SkipWaitForValidationWebhook)
 	result += fmt.Sprintf("CustomSidecarInjectorNamespace: %s\n", c.CustomSidecarInjectorNamespace)
-	result += fmt.Sprintf("ControlPlaneTopology:           %v\n", c.ControlPlaneTopology)
 
 	return result
 }

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -168,7 +168,7 @@ func deploy(ctx resource.Context, env *kube.Environment, cfg Config) (Instance, 
 
 	// Deploy the Istio control plane(s)
 	for _, cluster := range env.KubeClusters {
-		if cluster.IsControlPlaneCluster() {
+		if env.IsControlPlaneCluster(cluster) {
 			if err := deployControlPlane(i, cfg, cluster, iopFile); err != nil {
 				return nil, fmt.Errorf("failed deploying control plane to cluster %d: %v", cluster.Index(), err)
 			}

--- a/pkg/test/framework/resource/cluster.go
+++ b/pkg/test/framework/resource/cluster.go
@@ -27,7 +27,4 @@ type Cluster interface {
 
 	// Index of this Cluster within the Environment
 	Index() ClusterIndex
-
-	// IsControlPlaneCluster indicates whether or not a control plane has/should have a control plane deployed.
-	IsControlPlaneCluster() bool
 }

--- a/pkg/test/framework/suite_test.go
+++ b/pkg/test/framework/suite_test.go
@@ -503,10 +503,6 @@ func (f fakeCluster) Index() resource.ClusterIndex {
 	return resource.ClusterIndex(f.index)
 }
 
-func (f fakeCluster) IsControlPlaneCluster() bool {
-	panic("not implemented")
-}
-
 func (f fakeCluster) String() string {
 	return fmt.Sprintf("fake_cluster_%d", f.index)
 }


### PR DESCRIPTION
Storing controlPlane on individual kube.Clusters prevents us from being able to modify the topology in test setup  after initializing the kube.Environment.

Changes:
* Environment is responsible for `IsControlPlaneCluster` 
* Removed unused `ControlPlaneTopology` from `istio.Config`

Alternatives: 
* make `kube.Cluster` hold a reference to env settings or topology
* make `kube.Cluster::IsControlPlaneCluster` accept a topology param
* make `kube.Cluster` hold it's `controlPlaneIndex` and add `SetControlPlaneIndex`

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
