### PR TITLE
ServiceEntry - fix full push issues

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -735,8 +735,15 @@ func (s *Server) initEventHandlers() error {
 			Reason: []model.TriggerReason{model.ServiceUpdate},
 		})
 	}
-	if err := s.ServiceController().AppendInstanceHandler(instanceHandler); err != nil {
-		return fmt.Errorf("append instance handler failed: %v", err)
+	for _, registry := range s.ServiceController().GetRegistries() {
+		// Skip kubernetes and external registries as they are handled separately
+		if registry.Provider() == serviceregistry.Kubernetes ||
+			registry.Provider() == serviceregistry.External {
+			continue
+		}
+		if err := registry.AppendInstanceHandler(instanceHandler); err != nil {
+			return fmt.Errorf("append instance handler to registry %s failed: %v", registry.Provider(), err)
+		}
 	}
 
 	if s.configController != nil {


### PR DESCRIPTION
We were not doing full pushes when FQDN endpoints in a service entry changed.
We were also doing unnecessary full pushes when k8s pods changed. 

Fixed both of them.