### PR TITLE
Extend integ test readme

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -452,7 +452,8 @@ Note: this may require you to [enable forwarding from Docker containers to the o
 ```bash
 sudo sysctl net.ipv4.conf.all.forwarding=1
 sudo iptables -P FORWARD ACCEPT
-sudo iptables -A INPUT -i docker0 -j ACCEPT
+# On some machines, an additional rule may be needed to allow traffic from all `br-...` docker bridge interfaces
+sudo iptables -A INPUT -i br-+ -j ACCEPT
 ```
 
 ### Kubernetes Environment

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -447,7 +447,13 @@ also explicitly specify the native environment:
 $ go test ./... -istio.test.env native
 ```
 
-Note: this may require you to [enable forwarding from Docker containers to the outside world](https://docs.docker.com/network/bridge/#enable-forwarding-from-docker-containers-to-the-outside-world).
+Note: this may require you to [enable forwarding from Docker containers to the outside world](https://docs.docker.com/network/bridge/#enable-forwarding-from-docker-containers-to-the-outside-world):
+
+```bash
+sudo sysctl net.ipv4.conf.all.forwarding=1
+sudo iptables -P FORWARD ACCEPT
+sudo iptables -A INPUT -i docker0 -j ACCEPT
+```
 
 ### Kubernetes Environment
 


### PR DESCRIPTION
For some reason the commands on docker.com are not sufficient in some
machines