### PR TITLE
prow: run metallb on kind in multicluster topology

### DIFF
--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -295,12 +295,13 @@ data:
 }
 
 function cidr_to_ips() {
+    CIDR="$1"
     if command -v python3; then
       python3 - <<EOF
-from ipaddress import IPv4Network; [print(str(ip)) for ip in IPv4Network('$1').hosts()]
+from ipaddress import IPv4Network; [print(str(ip)) for ip in IPv4Network('$CIDR').hosts()]
 EOF
     elif command -v nmap; then
-      nmap -sL "$1" | awk '/Nmap scan report/{print $NF}'
+      nmap -sL "$CIDR" | awk '/Nmap scan report/{print $NF}'
     fi
 }
 

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -22,6 +22,10 @@ export CLUSTER3_NAME=${CLUSTER3_NAME:-"cluster3"}
 export CLUSTER_NAMES=("${CLUSTER1_NAME}" "${CLUSTER2_NAME}" "${CLUSTER3_NAME}")
 export CLUSTER_POD_SUBNETS=(10.10.0.0/16 10.20.0.0/16 10.30.0.0/16)
 
+# Take IPs from the end of the docker bridge network subnet to use for Metal LB IPs
+export DOCKER_BRIDGE_SUBNET=$(docker inspect bridge | jq .[0].IPAM.Config[0].Subnet -r)
+export METALLB_IPS=($(nmap -sL $DOCKER_BRIDGE_SUBNET | awk '/Nmap scan report/{print $NF}' | tail -n 100))
+
 function setup_gcloud_credentials() {
   if [[ $(command -v gcloud) ]]; then
     gcloud auth configure-docker -q
@@ -236,6 +240,7 @@ EOF
           connect_kind_clusters "${CLUSTERI_NAME}" "${CLUSTERI_KUBECONFIG}" "${CLUSTERJ_NAME}" "${CLUSTERJ_KUBECONFIG}"
         fi
       done
+      install_metallb $CLUSTERI_KUBECONFIG
     done
   else
     # Connect clusters 1 and 2, but leave cluster 3 on a separate network.
@@ -259,6 +264,27 @@ function connect_kind_clusters() {
   C2_POD_CIDR=$(KUBECONFIG="${C2_KUBECONFIG}" kubectl get node -ojsonpath='{.items[0].spec.podCIDR}')
   docker exec "${C1_NODE}" ip route add "${C2_POD_CIDR}" via "${C2_DOCKER_IP}"
   docker exec "${C2_NODE}" ip route add "${C1_POD_CIDR}" via "${C1_DOCKER_IP}"
+}
+
+function install_metallb() {
+  KUBECONFIG="${1}"
+  kubectl apply --kubeconfig=$KUBECONFIG -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/namespace.yaml
+  kubectl apply --kubeconfig=$KUBECONFIG -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/metallb.yaml
+  # allocate 10 IPs form METALLB_IPS array to this clusters MetalLB IP Pool
+  RANGE="${METALLB_IPS[0]}-${METALLB_IPS[9]}"
+  export METALLB_IPS=(${METALLB_IPS[@]:10})
+  echo 'apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - '$RANGE | kubectl apply --kubeconfig=$KUBECONFIG -f -
 }
 
 function cni_run_daemon_kind() {

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -296,8 +296,9 @@ data:
 
 function cidr_to_ips() {
     if command -v python3; then
-      SCRIPT="from ipaddress import IPv4Network; [print(str(ip)) for ip in IPv4Network('$1').hosts()]"
-      echo $SCRIPT | python3 -
+      python3 - <<EOF
+from ipaddress import IPv4Network; [print(str(ip)) for ip in IPv4Network('$1').hosts()]
+EOF
     elif command -v nmap; then
       nmap -sL "$1" | awk '/Nmap scan report/{print $NF}'
     fi

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -267,13 +267,13 @@ function install_metallb() {
   kubectl apply --kubeconfig="$KUBECONFIG" -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/namespace.yaml
   kubectl apply --kubeconfig="$KUBECONFIG" -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/metallb.yaml
 
- if [ -z "${METALLB_IPS[*]}" ]; then
+  if [ -z "${METALLB_IPS[*]}" ]; then
     # Take IPs from the end of the docker bridge network subnet to use for MetalLB IPs
     DOCKER_BRIDGE_SUBNET="$(docker inspect bridge | jq .[0].IPAM.Config[0].Subnet -r)"
     METALLB_IPS=()
     while read -r ip; do
       METALLB_IPS+=("$ip")
-    done < <(nmap -sL "$DOCKER_BRIDGE_SUBNET" | awk '/Nmap scan report/{print $NF}' | tail -n 100)
+    done < <(cidr_to_ips "$DOCKER_BRIDGE_SUBNET" | tail -n 100)
   fi
 
   # Give this cluster of those IPs
@@ -292,6 +292,15 @@ data:
       protocol: layer2
       addresses:
       - '"$RANGE" | kubectl apply --kubeconfig="$KUBECONFIG" -f -
+}
+
+function cidr_to_ips() {
+    if command -v python3; then
+      SCRIPT="from ipaddress import IPv4Network; [print(str(ip)) for ip in IPv4Network('$1').hosts()]"
+      echo $SCRIPT | python3 -
+    elif command -v nmap; then
+      nmap -sL "$1" | awk '/Nmap scan report/{print $NF}'
+    fi
 }
 
 function cni_run_daemon_kind() {

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -267,7 +267,7 @@ function install_metallb() {
   kubectl apply --kubeconfig="$KUBECONFIG" -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/namespace.yaml
   kubectl apply --kubeconfig="$KUBECONFIG" -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/metallb.yaml
 
- if [ -z "${METALLB_IPS[@]}" ]; then
+ if [ -z "${METALLB_IPS[*]}" ]; then
     # Take IPs from the end of the docker bridge network subnet to use for MetalLB IPs
     DOCKER_BRIDGE_SUBNET="$(docker inspect bridge | jq .[0].IPAM.Config[0].Subnet -r)"
     METALLB_IPS=()


### PR DESCRIPTION
Installing [MetalLB](https://metallb.universe.tf/) to add support for `LoadBalancer` resources in the KinD clusters we run for integration testing. This is to enable remote clusters to talk to the Istio control plane in the primary cluster for a shared control plane setup. https://github.com/istio/istio/issues/23217 