### PR TITLE
If IOP exists on cluster, use it in preference to built in profile during `upgrade`, `apply`

### DIFF
--- a/operator/cmd/mesh/manifest-apply.go
+++ b/operator/cmd/mesh/manifest-apply.go
@@ -139,7 +139,7 @@ func runApplyCmd(cmd *cobra.Command, rootArgs *rootArgs, maArgs *manifestApplyAr
 	l := clog.NewConsoleLogger(cmd.OutOrStdout(), cmd.ErrOrStderr(), installerScope)
 	// Warn users if they use `manifest apply` without any config args.
 	if len(maArgs.inFilenames) == 0 && len(maArgs.set) == 0 && !rootArgs.dryRun && !maArgs.skipConfirmation {
-		if !confirm("This will install the default Istio profile into the cluster. Proceed? (y/N)", cmd.OutOrStdout()) {
+		if !confirm("This will install or upgrade Istio upon the cluster. Proceed? (y/N)", cmd.OutOrStdout()) {
 			cmd.Print("Cancelled.\n")
 			os.Exit(1)
 		}
@@ -171,7 +171,7 @@ func ApplyManifests(setOverlay []string, inFilenames []string, force bool, dryRu
 	if err != nil {
 		return err
 	}
-	_, iops, err := GenerateConfig(inFilenames, ysf, force, restConfig, l)
+	_, iops, err := GenerateConfig(inFilenames, ysf, force, restConfig, l, true)
 	if err != nil {
 		return err
 	}

--- a/operator/cmd/mesh/manifest-apply.go
+++ b/operator/cmd/mesh/manifest-apply.go
@@ -191,14 +191,15 @@ func ApplyManifests(setOverlay []string, inFilenames []string, force bool, dryRu
 
 	// Needed in case we are running a test through this path that doesn't start a new process.
 	cache.FlushObjectCaches()
-	opts := &helmreconciler.Options{DryRun: dryRun, Log: l, Wait: wait, WaitTimeout: waitTimeout, ProgressLog: util.NewProgressLog()}
+	opts := &helmreconciler.Options{DryRun: dryRun, Log: l, Wait: wait, WaitTimeout: waitTimeout, ProgressLog: util.NewProgressLog(),
+		Force: force}
 	reconciler, err := helmreconciler.NewHelmReconciler(client, restConfig, iop, opts)
 	if err != nil {
 		return err
 	}
 	status, err := reconciler.Reconcile()
 	if err != nil {
-		return fmt.Errorf("errors occurred during operation")
+		return fmt.Errorf("errors occurred during operation: %w", err)
 	}
 	if status.Status != v1alpha1.InstallStatus_HEALTHY {
 		return fmt.Errorf("errors occurred during operation")

--- a/operator/cmd/mesh/manifest-apply.go
+++ b/operator/cmd/mesh/manifest-apply.go
@@ -135,7 +135,7 @@ func runApplyCmd(cmd *cobra.Command, rootArgs *rootArgs, maArgs *manifestApplyAr
 	l := clog.NewConsoleLogger(cmd.OutOrStdout(), cmd.ErrOrStderr(), installerScope)
 	// Warn users if they use `manifest apply` without any config args.
 	if len(maArgs.inFilenames) == 0 && len(maArgs.set) == 0 && !rootArgs.dryRun && !maArgs.skipConfirmation {
-		if !confirm("This will install the default Istio profile into the cluster. Proceed? (y/N)", cmd.OutOrStdout()) {
+		if !confirm("This will install or upgrade Istio upon the cluster. Proceed? (y/N)", cmd.OutOrStdout()) {
 			cmd.Print("Cancelled.\n")
 			os.Exit(1)
 		}
@@ -168,7 +168,7 @@ func ApplyManifests(setOverlay []string, inFilenames []string, force bool, dryRu
 	if err != nil {
 		return err
 	}
-	_, iops, err := GenerateConfig(inFilenames, ysf, force, restConfig, l)
+	_, iops, err := GenerateConfig(inFilenames, ysf, force, restConfig, l, true)
 	if err != nil {
 		return err
 	}

--- a/operator/cmd/mesh/manifest-generate.go
+++ b/operator/cmd/mesh/manifest-generate.go
@@ -126,7 +126,7 @@ func manifestGenerate(args *rootArgs, mgArgs *manifestGenerateArgs, logopts *log
 // supplied logger.
 func GenManifests(inFilename []string, setOverlayYAML string, force bool,
 	kubeConfig *rest.Config, l clog.Logger) (name.ManifestMap, *v1alpha1.IstioOperatorSpec, error) {
-	mergedYAML, _, err := GenerateConfig(inFilename, setOverlayYAML, force, kubeConfig, l)
+	mergedYAML, _, err := GenerateConfig(inFilename, setOverlayYAML, force, kubeConfig, l, false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/operator/cmd/mesh/manifest-generate.go
+++ b/operator/cmd/mesh/manifest-generate.go
@@ -123,7 +123,7 @@ func manifestGenerate(args *rootArgs, mgArgs *manifestGenerateArgs, logopts *log
 // supplied logger.
 func GenManifests(inFilename []string, setOverlayYAML string, force bool,
 	kubeConfig *rest.Config, l clog.Logger) (name.ManifestMap, *v1alpha1.IstioOperatorSpec, error) {
-	mergedYAML, _, err := GenerateConfig(inFilename, setOverlayYAML, force, kubeConfig, l)
+	mergedYAML, _, err := GenerateConfig(inFilename, setOverlayYAML, force, kubeConfig, l, false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -554,7 +554,7 @@ func TestLDFlags(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, iops, err := GenerateConfig(nil, ysf, true, nil, l)
+	_, iops, err := GenerateConfig(nil, ysf, true, nil, l, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/operator/cmd/mesh/profile-common.go
+++ b/operator/cmd/mesh/profile-common.go
@@ -69,7 +69,7 @@ func GenerateConfig(inFilenames []string, setOverlayYAML string, force bool, kub
 	var err error
 	var fy, profile string
 	if useClusterIfAvailable {
-		fy, profile, _ = overlayedOperatorFromCluster("istio-system", setOverlayYAML, force, kubeConfig, l)
+		fy, _ = overlayedOperatorFromCluster("istio-system", setOverlayYAML, kubeConfig)
 	}
 
 	if fy != "" {
@@ -349,8 +349,8 @@ func getInstallPackagePath(iopYAML string) (string, error) {
 	return iop.Spec.InstallPackagePath, nil
 }
 
-// overlayedOperatorFromCluster returns YAML of an IOP, profile name, err
-func overlayedOperatorFromCluster(istioNamespace string, setOverlayYAML string, force bool, kubeConfig *rest.Config, l clog.Logger) (string, string, error) {
+// overlayedOperatorFromCluster returns YAML of an IOP, err
+func overlayedOperatorFromCluster(istioNamespace string, setOverlayYAML string, kubeConfig *rest.Config) (string, error) {
 	// Did the user specify a particular `--set revision=`?
 	revision, err := tpath.GetConfigSubtree(setOverlayYAML, "spec.revision")
 	if err == nil {
@@ -362,10 +362,10 @@ func overlayedOperatorFromCluster(istioNamespace string, setOverlayYAML string, 
 
 	iop, err := operatorFromCluster(istioNamespace, revision, kubeConfig)
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 
-	return util.ToYAML(iop), "", nil
+	return util.ToYAML(iop), nil
 }
 
 // Find an IstioOperator matching revision in the cluster.  The IstioOperators

--- a/operator/cmd/mesh/profile-common.go
+++ b/operator/cmd/mesh/profile-common.go
@@ -67,7 +67,7 @@ func GenerateConfig(inFilenames []string, setOverlayYAML string, force bool, kub
 	var err error
 	var fy, profile string
 	if useClusterIfAvailable {
-		fy, profile, _ = overlayedOperatorFromCluster("istio-system", setOverlayYAML, force, kubeConfig, l)
+		fy, _ = overlayedOperatorFromCluster("istio-system", setOverlayYAML, kubeConfig)
 	}
 
 	if fy != "" {
@@ -347,8 +347,8 @@ func getInstallPackagePath(iopYAML string) (string, error) {
 	return iop.Spec.InstallPackagePath, nil
 }
 
-// overlayedOperatorFromCluster returns YAML of an IOP, profile name, err
-func overlayedOperatorFromCluster(istioNamespace string, setOverlayYAML string, force bool, kubeConfig *rest.Config, l clog.Logger) (string, string, error) {
+// overlayedOperatorFromCluster returns YAML of an IOP, err
+func overlayedOperatorFromCluster(istioNamespace string, setOverlayYAML string, kubeConfig *rest.Config) (string, error) {
 	// Did the user specify a particular `--set revision=`?
 	revision, err := tpath.GetConfigSubtree(setOverlayYAML, "spec.revision")
 	if err == nil {
@@ -360,10 +360,10 @@ func overlayedOperatorFromCluster(istioNamespace string, setOverlayYAML string, 
 
 	iop, err := operatorFromCluster(istioNamespace, revision, kubeConfig)
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 
-	return util.ToYAML(iop), "", nil
+	return util.ToYAML(iop), nil
 }
 
 // Find an IstioOperator matching revision in the cluster.  The IstioOperators

--- a/operator/cmd/mesh/profile-common.go
+++ b/operator/cmd/mesh/profile-common.go
@@ -15,14 +15,20 @@
 package mesh
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apimachinery_schema "k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 
 	"istio.io/api/operator/v1alpha1"
+	operator_istio "istio.io/istio/operator/pkg/apis/istio"
 	iopv1alpha1 "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/apis/istio/v1alpha1/validation"
 	"istio.io/istio/operator/pkg/helm"
@@ -37,7 +43,14 @@ import (
 	pkgversion "istio.io/pkg/version"
 )
 
-var installerScope = log.RegisterScope("installer", "installer", 0)
+var (
+	installerScope   = log.RegisterScope("installer", "installer", 0)
+	istioOperatorGVR = apimachinery_schema.GroupVersionResource{
+		Group:    iopv1alpha1.SchemeGroupVersion.Group,
+		Version:  iopv1alpha1.SchemeGroupVersion.Version,
+		Resource: "istiooperators",
+	}
+)
 
 // GenerateConfig creates an IstioOperatorSpec from the following sources, overlaid sequentially:
 // 1. Compiled in base, or optionally base from paths pointing to one or multiple ICP/IOP files at inFilenames.
@@ -51,11 +64,21 @@ var installerScope = log.RegisterScope("installer", "installer", 0)
 // In step 3, the remaining fields in the same user overlay are applied on the resulting profile base.
 // The force flag causes validation errors not to abort but only emit log/console warnings.
 func GenerateConfig(inFilenames []string, setOverlayYAML string, force bool, kubeConfig *rest.Config,
-	l clog.Logger) (string, *v1alpha1.IstioOperatorSpec, error) {
+	l clog.Logger, useClusterIfAvailable bool) (string, *v1alpha1.IstioOperatorSpec, error) {
 
-	fy, profile, err := readYamlProfle(inFilenames, setOverlayYAML, force, l)
-	if err != nil {
-		return "", nil, err
+	var err error
+	var fy, profile string
+	if useClusterIfAvailable {
+		fy, profile, _ = overlayedOperatorFromCluster("istio-system", setOverlayYAML, force, kubeConfig, l)
+	}
+
+	if fy != "" {
+		l.Print("Using Istio configuration loaded from cluster.\n")
+	} else {
+		fy, profile, err = readYamlProfile(inFilenames, setOverlayYAML, force, l)
+		if err != nil {
+			return "", nil, err
+		}
 	}
 
 	iopsString, iops, err := genIOPSFromProfile(profile, fy, setOverlayYAML, force, kubeConfig, l)
@@ -73,7 +96,7 @@ func GenerateConfig(inFilenames []string, setOverlayYAML string, force bool, kub
 	return iopsString, iops, nil
 }
 
-func readYamlProfle(inFilenames []string, setOverlayYAML string, force bool, l clog.Logger) (string, string, error) {
+func readYamlProfile(inFilenames []string, setOverlayYAML string, force bool, l clog.Logger) (string, string, error) {
 
 	profile := name.DefaultProfileName
 	// Get the overlay YAML from the list of files passed in. Also get the profile from the overlay files.
@@ -324,4 +347,55 @@ func getInstallPackagePath(iopYAML string) (string, error) {
 		return "", nil
 	}
 	return iop.Spec.InstallPackagePath, nil
+}
+
+// overlayedOperatorFromCluster returns YAML of an IOP, profile name, err
+func overlayedOperatorFromCluster(istioNamespace string, setOverlayYAML string, force bool, kubeConfig *rest.Config, l clog.Logger) (string, string, error) {
+	// Did the user specify a particular `--set revision=`?
+	revision, err := tpath.GetConfigSubtree(setOverlayYAML, "spec.revision")
+	if err == nil {
+		revision = strings.TrimSpace(revision)
+		if revision == "{}" {
+			revision = ""
+		}
+	}
+
+	iop, err := operatorFromCluster(istioNamespace, revision, kubeConfig)
+	if err != nil {
+		return "", "", err
+	}
+
+	return util.ToYAML(iop), "", nil
+}
+
+// Find an IstioOperator matching revision in the cluster.  The IstioOperators
+// don't have a label for their revision, so we parse them and check .Spec.Revision
+func operatorFromCluster(istioNamespaceFlag string, revision string, restConfig *rest.Config) (*iopv1alpha1.IstioOperator, error) {
+	client, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return nil, err
+	}
+	ul, err := client.
+		Resource(istioOperatorGVR).
+		Namespace(istioNamespaceFlag).
+		List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for _, un := range ul.Items {
+		un.SetCreationTimestamp(metav1.Time{}) // UnmarshalIstioOperator chokes on these
+		by, err := json.Marshal(un.Object)
+		if err != nil {
+			return nil, err
+		}
+
+		iop, err := operator_istio.UnmarshalIstioOperator(string(by))
+		if err != nil {
+			return nil, err
+		}
+		if revision == "" || iop.Spec.Revision == revision {
+			return iop, nil
+		}
+	}
+	return nil, fmt.Errorf("control plane revision %q not found", revision)
 }

--- a/operator/cmd/mesh/profile-dump.go
+++ b/operator/cmd/mesh/profile-dump.go
@@ -132,7 +132,7 @@ func profileDump(args []string, rootArgs *rootArgs, pdArgs *profileDumpArgs, l c
 		}
 	}
 
-	y, _, err := GenerateConfig(pdArgs.inFilenames, setFlagYAML, true, nil, l)
+	y, _, err := GenerateConfig(pdArgs.inFilenames, setFlagYAML, true, nil, l, false)
 	if err != nil {
 		return err
 	}

--- a/operator/cmd/mesh/shared.go
+++ b/operator/cmd/mesh/shared.go
@@ -229,7 +229,7 @@ func getCRAndNamespaceFromFile(filePath string, l clog.Logger) (customResource s
 		return "", "", nil
 	}
 
-	_, mergedIOPS, err := GenerateConfig([]string{filePath}, "", false, nil, l)
+	_, mergedIOPS, err := GenerateConfig([]string{filePath}, "", false, nil, l, false)
 	if err != nil {
 		return "", "", err
 	}

--- a/operator/cmd/mesh/shared.go
+++ b/operator/cmd/mesh/shared.go
@@ -161,7 +161,7 @@ func getCRAndNamespaceFromFile(filePath string, l clog.Logger) (customResource s
 		return "", "", nil
 	}
 
-	_, mergedIOPS, err := GenerateConfig([]string{filePath}, "", false, nil, l)
+	_, mergedIOPS, err := GenerateConfig([]string{filePath}, "", false, nil, l, false)
 	if err != nil {
 		return "", "", err
 	}

--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -142,7 +142,7 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 	}
 
 	// Generate IOPS parseObjectSetFromManifest
-	config, err := defaultRestConfig(args.kubeConfigPath, args.context)
+	config, _, _, err := K8sConfig(args.kubeConfigPath, args.context)
 	if err != nil {
 		return fmt.Errorf("failed to connect Kubernetes API server, error: %w", err)
 	}

--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -140,8 +140,13 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 	if err != nil {
 		return err
 	}
+
 	// Generate IOPS parseObjectSetFromManifest
-	targetIOPSYaml, targetIOPS, err := GenerateConfig(args.inFilenames, ysf, args.force, nil, l)
+	config, err := defaultRestConfig(args.kubeConfigPath, args.context)
+	if err != nil {
+		return fmt.Errorf("failed to connect Kubernetes API server, error: %w", err)
+	}
+	targetIOPSYaml, targetIOPS, err := GenerateConfig(args.inFilenames, ysf, args.force, config, l, true)
 	if err != nil {
 		return fmt.Errorf("failed to generate Istio configs from file %s, error: %s", args.inFilenames, err)
 	}
@@ -255,7 +260,7 @@ func checkUpgradeIOPS(curIOPS, tarIOPS, ignoreIOPS string, l clog.Logger) {
 	if diff == "" {
 		l.LogAndPrintf("Upgrade check: IOPS unchanged. The target IOPS are identical to the current IOPS.\n")
 	} else {
-		l.LogAndPrintf("Upgrade check: Warning!!! The following IOPS will be changed as part of upgrade. "+
+		l.LogAndPrintf("Upgrade check: Warning!!! The following Istio settings will be changed as part of upgrade. "+
 			"Please double check they are correct:\n%s", diff)
 	}
 }

--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -139,8 +139,13 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 	if err != nil {
 		return err
 	}
+
 	// Generate IOPS parseObjectSetFromManifest
-	targetIOPSYaml, targetIOPS, err := GenerateConfig(args.inFilenames, ysf, args.force, nil, l)
+	config, err := defaultRestConfig(args.kubeConfigPath, args.context)
+	if err != nil {
+		return fmt.Errorf("failed to connect Kubernetes API server, error: %w", err)
+	}
+	targetIOPSYaml, targetIOPS, err := GenerateConfig(args.inFilenames, ysf, args.force, config, l, true)
 	if err != nil {
 		return fmt.Errorf("failed to generate Istio configs from file %s, error: %s", args.inFilenames, err)
 	}
@@ -254,7 +259,7 @@ func checkUpgradeIOPS(curIOPS, tarIOPS, ignoreIOPS string, l clog.Logger) {
 	if diff == "" {
 		l.LogAndPrintf("Upgrade check: IOPS unchanged. The target IOPS are identical to the current IOPS.\n")
 	} else {
-		l.LogAndPrintf("Upgrade check: Warning!!! The following IOPS will be changed as part of upgrade. "+
+		l.LogAndPrintf("Upgrade check: Warning!!! The following Istio settings will be changed as part of upgrade. "+
 			"Please double check they are correct:\n%s", diff)
 	}
 }

--- a/operator/pkg/helmreconciler/reconciler.go
+++ b/operator/pkg/helmreconciler/reconciler.go
@@ -63,6 +63,8 @@ type Options struct {
 	WaitTimeout time.Duration
 	// ProgressLog tracks the installation progress for all components.
 	ProgressLog *util.ProgressLog
+	// Force ignores validation errors
+	Force bool
 }
 
 var defaultOptions = &Options{

--- a/operator/pkg/helmreconciler/render.go
+++ b/operator/pkg/helmreconciler/render.go
@@ -27,8 +27,10 @@ import (
 // RenderCharts renders charts for h.
 func (h *HelmReconciler) RenderCharts() (name.ManifestMap, error) {
 	iopSpec := h.iop.Spec
-	if err := validate.CheckIstioOperatorSpec(iopSpec, false); err != nil {
-		return nil, err
+	if !h.opts.Force {
+		if err := validate.CheckIstioOperatorSpec(iopSpec, false); err != nil {
+			return nil, err
+		}
 	}
 
 	t, err := translate.NewTranslator(binversion.OperatorBinaryVersion.MinorVersion)


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/23183

This PR causes `istioctl manifest apply` and `istioctl upgrade` to default to the IOP that a previous install wrote to the cluster when there is no `--filename`.

(If there is no previous install it falls back to the built-in profile.)