### PR TITLE
manifests: align securityContext of gateways and sidecars

### DIFF
--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -52,6 +52,12 @@ spec:
         runAsGroup: 1337
         runAsNonRoot: true
         fsGroup: 1337
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        privileged: false
+        readOnlyRootFilesystem: true
 {{- end }}
       serviceAccountName: istio-egressgateway-service-account
 {{- if .Values.global.priorityClassName }}

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -52,6 +52,12 @@ spec:
         runAsGroup: 1337
         runAsNonRoot: true
         fsGroup: 1337
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        privileged: false
+        readOnlyRootFilesystem: true
 {{- end }}
       serviceAccountName: istio-ingressgateway-service-account
 {{- if .Values.global.priorityClassName }}


### PR DESCRIPTION
This drops privileges even further, as per @rlenglet's [comment on my original PR](https://github.com/istio/istio/pull/23174#discussion_r414767826).