### PR TITLE
manifests: drop privileges for gateways by default

### DIFF
--- a/manifests/charts/gateways/istio-egress/values.yaml
+++ b/manifests/charts/gateways/istio-egress/values.yaml
@@ -105,7 +105,7 @@ gateways:
     podAntiAffinityTermLabelSelector: []
 
     # whether to run the gateway in a privileged container
-    runAsRoot: true
+    runAsRoot: false
 
 # Revision is set as 'version' label and part of the resource names when installing multiple control planes.
 revision: ""

--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -134,7 +134,7 @@ gateways:
     podAntiAffinityTermLabelSelector: []
 
     # whether to run the gateway in a privileged container
-    runAsRoot: true
+    runAsRoot: false
 
 # Revision is set as 'version' label and part of the resource names when installing multiple control planes.
 revision: ""


### PR DESCRIPTION
This PR enables nonroot gateways by default on master. Pushing now so we can get maximum testing exposure for 1.7.

**This should *not* be cherry-picked to 1.6!**