### PR TITLE
Use labels and annotations from istio/api repo

### DIFF
--- a/galley/pkg/config/analysis/analyzers/injection/injection.go
+++ b/galley/pkg/config/analysis/analyzers/injection/injection.go
@@ -17,6 +17,7 @@ package injection
 import (
 	"strings"
 
+	"istio.io/api/label"
 	v1 "k8s.io/api/core/v1"
 
 	"istio.io/api/annotation"
@@ -24,7 +25,6 @@ import (
 	"istio.io/istio/galley/pkg/config/analysis"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/util"
 	"istio.io/istio/galley/pkg/config/analysis/msg"
-	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/resource"
 	"istio.io/istio/pkg/config/schema/collection"
@@ -42,7 +42,7 @@ var _ analysis.Analyzer = &Analyzer{}
 const (
 	InjectionLabelName         = "istio-injection"
 	InjectionLabelEnableValue  = "enabled"
-	RevisionInjectionLabelName = model.RevisionLabel
+	RevisionInjectionLabelName = label.IstioRev
 
 	istioProxyName = "istio-proxy"
 )
@@ -68,7 +68,7 @@ func (a *Analyzer) Analyze(c analysis.Context) {
 	c.ForEach(collections.K8SCoreV1Pods.Name(), func(r *resource.Instance) bool {
 		pod := r.Message.(*v1.Pod)
 		if isControlPlane(pod) {
-			revision, ok := r.Metadata.Labels[model.RevisionLabel]
+			revision, ok := r.Metadata.Labels[label.IstioRev]
 			if ok {
 				controlPlaneRevisions[revision] = true
 			}

--- a/galley/pkg/config/analysis/analyzers/injection/injection.go
+++ b/galley/pkg/config/analysis/analyzers/injection/injection.go
@@ -17,8 +17,9 @@ package injection
 import (
 	"strings"
 
-	"istio.io/api/label"
 	v1 "k8s.io/api/core/v1"
+
+	"istio.io/api/label"
 
 	"istio.io/api/annotation"
 

--- a/istioctl/pkg/kubernetes/client.go
+++ b/istioctl/pkg/kubernetes/client.go
@@ -28,7 +28,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
-	"istio.io/api/label"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -36,6 +35,8 @@ import (
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/client-go/transport/spdy"
+
+	"istio.io/api/label"
 
 	"istio.io/pkg/version"
 

--- a/istioctl/pkg/kubernetes/client.go
+++ b/istioctl/pkg/kubernetes/client.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
+	"istio.io/api/label"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -36,10 +37,10 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/client-go/transport/spdy"
 
-	"istio.io/istio/istioctl/pkg/clioptions"
-	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pkg/kube"
 	"istio.io/pkg/version"
+
+	"istio.io/istio/istioctl/pkg/clioptions"
+	"istio.io/istio/pkg/kube"
 )
 
 var (
@@ -213,9 +214,9 @@ func (client *Client) GetIstioPods(namespace string, params map[string]string) (
 	if client.Revision != "" {
 		labelSelector, ok := params["labelSelector"]
 		if ok {
-			params["labelSelector"] = fmt.Sprintf("%s,%s=%s", labelSelector, model.RevisionLabel, client.Revision)
+			params["labelSelector"] = fmt.Sprintf("%s,%s=%s", labelSelector, label.IstioRev, client.Revision)
 		} else {
-			params["labelSelector"] = fmt.Sprintf("%s=%s", model.RevisionLabel, client.Revision)
+			params["labelSelector"] = fmt.Sprintf("%s=%s", label.IstioRev, client.Revision)
 		}
 	}
 

--- a/operator/pkg/helmreconciler/reconciler.go
+++ b/operator/pkg/helmreconciler/reconciler.go
@@ -21,14 +21,14 @@ import (
 	"sync"
 	"time"
 
-	"helm.sh/helm/v3/pkg/releaseutil"
-	"istio.io/api/label"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"istio.io/api/label"
 
 	"istio.io/api/operator/v1alpha1"
 	"istio.io/pkg/version"
@@ -39,8 +39,6 @@ import (
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/operator/pkg/util/clog"
 	"istio.io/istio/operator/pkg/util/progress"
-	"istio.io/istio/pilot/pkg/model"
-	"istio.io/pkg/version"
 )
 
 // HelmReconciler reconciles resources rendered by a set of helm charts.

--- a/operator/pkg/helmreconciler/reconciler.go
+++ b/operator/pkg/helmreconciler/reconciler.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 	"time"
 
+	"helm.sh/helm/v3/pkg/releaseutil"
+	"istio.io/api/label"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -29,6 +31,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"istio.io/api/operator/v1alpha1"
+	"istio.io/pkg/version"
+
 	valuesv1alpha1 "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/name"
 	"istio.io/istio/operator/pkg/object"
@@ -302,7 +306,7 @@ func (h *HelmReconciler) addComponentLabels(coreLabels map[string]string, compon
 		if revision == "" {
 			revision = "default"
 		}
-		labels[model.RevisionLabel] = revision
+		labels[label.IstioRev] = revision
 	}
 
 	labels[istioComponentLabelStr] = componentName

--- a/pilot/cmd/pilot-agent/config.go
+++ b/pilot/cmd/pilot-agent/config.go
@@ -33,7 +33,6 @@ import (
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/validation"
-	"istio.io/istio/pkg/kube/inject"
 )
 
 // getTLSCerts returns all file based certificates from mesh config
@@ -75,7 +74,7 @@ func constructProxyConfig() (meshconfig.ProxyConfig, error) {
 		}
 		fileMeshContents = string(contents)
 	}
-	meshConfig, err := getMeshConfig(fileMeshContents, annotations[inject.ProxyConfigAnnotation])
+	meshConfig, err := getMeshConfig(fileMeshContents, annotations[annotation.ProxyConfig.Name])
 	if err != nil {
 		return meshconfig.ProxyConfig{}, err
 	}

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -426,7 +426,7 @@ func init() {
 
 	proxyCmd.PersistentFlags().StringVar(&meshConfigFile, "meshConfig", "./etc/istio/config/mesh",
 		"File name for Istio mesh configuration. If not specified, a default mesh will be used. This may be overridden by "+
-			"PROXY_CONFIG environment variable or istio.io/proxyConfig annotation.")
+			"PROXY_CONFIG environment variable or proxy.istio.io/config annotation.")
 	proxyCmd.PersistentFlags().IntVar(&stsPort, "stsPort", 0,
 		"HTTP Port on which to serve Security Token Service (STS). If zero, STS service will not be provided.")
 	proxyCmd.PersistentFlags().StringVar(&tokenManagerPlugin, "tokenManagerPlugin", tokenmanager.GoogleTokenExchange,

--- a/pilot/pkg/config/kube/crd/controller/client.go
+++ b/pilot/pkg/config/kube/crd/controller/client.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-multierror"
+
 	"istio.io/api/label"
 
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"

--- a/pilot/pkg/config/kube/crd/controller/client.go
+++ b/pilot/pkg/config/kube/crd/controller/client.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-multierror"
+	"istio.io/api/label"
 
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -396,7 +397,7 @@ func (cl *Client) List(kind resource.GroupVersionKind, namespace string) ([]mode
 }
 
 func (cl *Client) objectInRevision(o *model.Config) bool {
-	configEnv, f := o.Labels[model.RevisionLabel]
+	configEnv, f := o.Labels[label.IstioRev]
 	if !f {
 		// This is a global object, and always included
 		return true

--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -41,10 +41,6 @@ var (
 	_ = udpa.TypedStruct{}
 )
 
-const (
-	RevisionLabel = "istio.io/rev"
-)
-
 // ConfigKey describe a specific config item.
 // In most cases, the name is the config's name. However, for ServiceEntry it is service's FQDN.
 type ConfigKey struct {

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -34,6 +34,8 @@ import (
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 	"github.com/mitchellh/copystructure"
 
+	"istio.io/api/label"
+
 	authn "istio.io/api/authentication/v1alpha1"
 
 	"istio.io/istio/pilot/pkg/util/sets"
@@ -137,10 +139,6 @@ const (
 const (
 	// TLSModeLabelShortname name used for determining endpoint level tls transport socket configuration
 	TLSModeLabelShortname = "tlsMode"
-
-	// TLSModeLabelName is the name of label given to service instances to determine whether to use mTLS or
-	// fallback to plaintext/tls
-	TLSModeLabelName = "security.istio.io/" + TLSModeLabelShortname
 
 	// DisabledTLSModeLabel implies that this endpoint should receive traffic as is (mostly plaintext)
 	DisabledTLSModeLabel = "disabled"
@@ -592,7 +590,7 @@ func (s *Service) GetServiceAddressForProxy(node *Proxy) string {
 // and apply custom transport socket matchers here.
 func GetTLSModeFromEndpointLabels(labels map[string]string) string {
 	if labels != nil {
-		if val, exists := labels[TLSModeLabelName]; exists {
+		if val, exists := labels[label.TLSMode]; exists {
 			return val
 		}
 	}

--- a/pilot/pkg/serviceregistry/external/conversion.go
+++ b/pilot/pkg/serviceregistry/external/conversion.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"strings"
 
+	"istio.io/api/label"
 	networking "istio.io/api/networking/v1alpha3"
 
 	"istio.io/istio/pilot/pkg/model"
@@ -220,7 +221,7 @@ func getTLSModeFromWorkloadEntry(wle *networking.WorkloadEntry) string {
 	// * Use security.istio.io/tlsMode if its present
 	// * If not, set TLS mode if ServiceAccount is specified
 	tlsMode := model.DisabledTLSModeLabel
-	if val, exists := wle.Labels[model.TLSModeLabelName]; exists {
+	if val, exists := wle.Labels[label.TLSMode]; exists {
 		tlsMode = val
 	} else if wle.ServiceAccount != "" {
 		tlsMode = model.IstioMutualTLSModeLabel

--- a/pilot/pkg/serviceregistry/external/conversion_test.go
+++ b/pilot/pkg/serviceregistry/external/conversion_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"istio.io/api/label"
 	networking "istio.io/api/networking/v1alpha3"
 
 	"istio.io/istio/pilot/pkg/model"
@@ -92,12 +93,12 @@ var httpStatic = &model.Config{
 			{
 				Address: "2.2.2.2",
 				Ports:   map[string]uint32{"http-port": 7080, "http-alt-port": 18080},
-				Labels:  map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+				Labels:  map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
 			},
 			{
 				Address: "3.3.3.3",
 				Ports:   map[string]uint32{"http-port": 1080},
-				Labels:  map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+				Labels:  map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
 			},
 			{
 				Address: "4.4.4.4",
@@ -144,7 +145,7 @@ var httpDNSnoEndpoints = &model.Config{
 		Name:              "httpDNSnoEndpoints",
 		Namespace:         "httpDNSnoEndpoints",
 		CreationTimestamp: GlobalTime,
-		Labels:            map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+		Labels:            map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
 	},
 	Spec: &networking.ServiceEntry{
 		Hosts: []string{"google.com", "www.wikipedia.org"},
@@ -165,7 +166,7 @@ var httpDNS = &model.Config{
 		Name:              "httpDNS",
 		Namespace:         "httpDNS",
 		CreationTimestamp: GlobalTime,
-		Labels:            map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+		Labels:            map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
 	},
 	Spec: &networking.ServiceEntry{
 		Hosts: []string{"*.google.com"},
@@ -177,16 +178,16 @@ var httpDNS = &model.Config{
 			{
 				Address: "us.google.com",
 				Ports:   map[string]uint32{"http-port": 7080, "http-alt-port": 18080},
-				Labels:  map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+				Labels:  map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
 			},
 			{
 				Address: "uk.google.com",
 				Ports:   map[string]uint32{"http-port": 1080},
-				Labels:  map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+				Labels:  map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
 			},
 			{
 				Address: "de.google.com",
-				Labels:  map[string]string{"foo": "bar", model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+				Labels:  map[string]string{"foo": "bar", label.TLSMode: model.IstioMutualTLSModeLabel},
 			},
 		},
 		Location:   networking.ServiceEntry_MESH_EXTERNAL,
@@ -202,7 +203,7 @@ var tcpDNS = &model.Config{
 		Name:              "tcpDNS",
 		Namespace:         "tcpDNS",
 		CreationTimestamp: GlobalTime,
-		Labels:            map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+		Labels:            map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
 	},
 	Spec: &networking.ServiceEntry{
 		Hosts: []string{"tcpdns.com"},
@@ -212,11 +213,11 @@ var tcpDNS = &model.Config{
 		Endpoints: []*networking.WorkloadEntry{
 			{
 				Address: "lon.google.com",
-				Labels:  map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+				Labels:  map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
 			},
 			{
 				Address: "in.google.com",
-				Labels:  map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+				Labels:  map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
 			},
 		},
 		Location:   networking.ServiceEntry_MESH_EXTERNAL,
@@ -232,7 +233,7 @@ var tcpStatic = &model.Config{
 		Name:              "tcpStatic",
 		Namespace:         "tcpStatic",
 		CreationTimestamp: GlobalTime,
-		Labels:            map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+		Labels:            map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
 	},
 	Spec: &networking.ServiceEntry{
 		Hosts:     []string{"tcpstatic.com"},
@@ -243,11 +244,11 @@ var tcpStatic = &model.Config{
 		Endpoints: []*networking.WorkloadEntry{
 			{
 				Address: "1.1.1.1",
-				Labels:  map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+				Labels:  map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
 			},
 			{
 				Address: "2.2.2.2",
-				Labels:  map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+				Labels:  map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
 			},
 		},
 		Location:   networking.ServiceEntry_MESH_EXTERNAL,
@@ -261,7 +262,7 @@ var httpNoneInternal = &model.Config{
 		Name:              "httpNoneInternal",
 		Namespace:         "httpNoneInternal",
 		CreationTimestamp: GlobalTime,
-		Labels:            map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+		Labels:            map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
 	},
 	Spec: &networking.ServiceEntry{
 		Hosts: []string{"*.google.com"},
@@ -280,7 +281,7 @@ var tcpNoneInternal = &model.Config{
 		Name:              "tcpNoneInternal",
 		Namespace:         "tcpNoneInternal",
 		CreationTimestamp: GlobalTime,
-		Labels:            map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+		Labels:            map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
 	},
 	Spec: &networking.ServiceEntry{
 		Hosts:     []string{"tcpinternal.com"},
@@ -299,7 +300,7 @@ var multiAddrInternal = &model.Config{
 		Name:              "multiAddrInternal",
 		Namespace:         "multiAddrInternal",
 		CreationTimestamp: GlobalTime,
-		Labels:            map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+		Labels:            map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
 	},
 	Spec: &networking.ServiceEntry{
 		Hosts:     []string{"tcp1.com", "tcp2.com"},
@@ -318,7 +319,7 @@ var udsLocal = &model.Config{
 		Name:              "udsLocal",
 		Namespace:         "udsLocal",
 		CreationTimestamp: GlobalTime,
-		Labels:            map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+		Labels:            map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
 	},
 	Spec: &networking.ServiceEntry{
 		Hosts: []string{"uds.cluster.local"},
@@ -326,7 +327,7 @@ var udsLocal = &model.Config{
 			{Number: 6553, Name: "grpc-1", Protocol: "grpc"},
 		},
 		Endpoints: []*networking.WorkloadEntry{
-			{Address: "unix:///test/sock", Labels: map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel}},
+			{Address: "unix:///test/sock", Labels: map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel}},
 		},
 		Resolution: networking.ServiceEntry_STATIC,
 	},
@@ -341,7 +342,7 @@ var selector = &model.Config{
 		Name:              "selector",
 		Namespace:         "selector",
 		CreationTimestamp: GlobalTime,
-		Labels:            map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+		Labels:            map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
 	},
 	Spec: &networking.ServiceEntry{
 		Hosts: []string{"selector.com"},
@@ -448,7 +449,7 @@ func makeInstance(cfg *model.Config, address string, port int,
 		if svcLabels == nil {
 			svcLabels = map[string]string{}
 		}
-		svcLabels[model.TLSModeLabelName] = model.IstioMutualTLSModeLabel
+		svcLabels[label.TLSMode] = model.IstioMutualTLSModeLabel
 	}
 	return &model.ServiceInstance{
 		Service: svc,

--- a/pilot/pkg/serviceregistry/external/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/external/servicediscovery_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"istio.io/api/label"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/pkg/log"
 
@@ -393,7 +394,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 			se.Endpoints = []*networking.WorkloadEntry{
 				{
 					Address: "lon.google.com",
-					Labels:  map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+					Labels:  map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
 				},
 			}
 			return &c
@@ -824,7 +825,7 @@ func TestServicesDiff(t *testing.T) {
 			Name:              "httpDNS",
 			Namespace:         "httpDNS",
 			CreationTimestamp: GlobalTime,
-			Labels:            map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+			Labels:            map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
 		},
 		Spec: &networking.ServiceEntry{
 			Hosts: []string{"*.google.com", "*.mail.com"},
@@ -836,16 +837,16 @@ func TestServicesDiff(t *testing.T) {
 				{
 					Address: "us.google.com",
 					Ports:   map[string]uint32{"http-port": 7080, "http-alt-port": 18080},
-					Labels:  map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+					Labels:  map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
 				},
 				{
 					Address: "uk.google.com",
 					Ports:   map[string]uint32{"http-port": 1080},
-					Labels:  map[string]string{model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+					Labels:  map[string]string{label.TLSMode: model.IstioMutualTLSModeLabel},
 				},
 				{
 					Address: "de.google.com",
-					Labels:  map[string]string{"foo": "bar", model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+					Labels:  map[string]string{"foo": "bar", label.TLSMode: model.IstioMutualTLSModeLabel},
 				},
 			},
 			Location:   networking.ServiceEntry_MESH_EXTERNAL,
@@ -870,7 +871,7 @@ func TestServicesDiff(t *testing.T) {
 		endpoints = append(endpoints, se.Endpoints...)
 		endpoints = append(endpoints, &networking.WorkloadEntry{
 			Address: "in.google.com",
-			Labels:  map[string]string{"foo": "bar", model.TLSModeLabelName: model.IstioMutualTLSModeLabel},
+			Labels:  map[string]string{"foo": "bar", label.TLSMode: model.IstioMutualTLSModeLabel},
 		})
 		se.Endpoints = endpoints
 		return &c

--- a/pilot/pkg/serviceregistry/mcp/controller.go
+++ b/pilot/pkg/serviceregistry/mcp/controller.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/types"
+	"istio.io/api/label"
 
 	"istio.io/pkg/ledger"
 	"istio.io/pkg/log"
@@ -245,7 +246,7 @@ func (c *controller) Apply(change *sink.Change) error {
 }
 
 func (c *controller) objectInRevision(o *model.Config) bool {
-	configEnv, f := o.Labels[model.RevisionLabel]
+	configEnv, f := o.Labels[label.IstioRev]
 	if !f {
 		// This is a global object, and always included
 		return true

--- a/pilot/pkg/serviceregistry/mcp/controller.go
+++ b/pilot/pkg/serviceregistry/mcp/controller.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/types"
+
 	"istio.io/api/label"
 
 	"istio.io/pkg/ledger"

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -93,7 +93,7 @@ var (
 		annotation.SidecarTrafficExcludeOutboundPorts.Name:        ValidateExcludeOutboundPorts,
 		annotation.SidecarTrafficKubevirtInterfaces.Name:          alwaysValidFunc,
 		annotation.PrometheusMergeMetrics.Name:                    validateBool,
-		ProxyConfigAnnotation:                                     validateProxyConfig,
+		annotation.ProxyConfig.Name:                               validateProxyConfig,
 	}
 )
 
@@ -439,9 +439,6 @@ func flippedContains(needle, haystack string) bool {
 	return strings.Contains(haystack, needle)
 }
 
-// ProxyConfigAnnotation determines the mesh config overrides for a workloadTODO move this to API
-var ProxyConfigAnnotation = "istio.io/proxyConfig"
-
 // InjectionData renders sidecarTemplate with valuesConfig.
 func InjectionData(sidecarTemplate, valuesConfig, version string, typeMetadata *metav1.TypeMeta, deploymentMetadata *metav1.ObjectMeta, spec *corev1.PodSpec,
 	metadata *metav1.ObjectMeta, meshConfig *meshconfig.MeshConfig) (
@@ -465,7 +462,7 @@ func InjectionData(sidecarTemplate, valuesConfig, version string, typeMetadata *
 		return nil, "", multierror.Prefix(err, "could not parse configuration values:")
 	}
 
-	if pca, f := metadata.GetAnnotations()[ProxyConfigAnnotation]; f {
+	if pca, f := metadata.GetAnnotations()[annotation.ProxyConfig.Name]; f {
 		var merr error
 		meshConfig, merr = mesh.ApplyProxyConfig(pca, *meshConfig)
 		if merr != nil {

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 	"github.com/hashicorp/go-multierror"
+	"istio.io/api/label"
 
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/validation"
@@ -790,7 +791,7 @@ func IntoObject(sidecarTemplate string, valuesConfig string, revision string, me
 	}
 	// This function, IntoObject(), is only used on the 'istioctl kube-kubeinject' path, which
 	// doesn't use Pilot bootstrap variables.
-	metadata.Labels[model.RevisionLabel] = revision
+	metadata.Labels[label.IstioRev] = revision
 	if status != "" && metadata.Labels[model.TLSModeLabelName] == "" {
 		metadata.Labels[model.TLSModeLabelName] = model.IstioMutualTLSModeLabel
 	}

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 	"github.com/hashicorp/go-multierror"
+
 	"istio.io/api/label"
 
 	"istio.io/istio/pkg/config/mesh"
@@ -789,8 +790,8 @@ func IntoObject(sidecarTemplate string, valuesConfig string, revision string, me
 	// This function, IntoObject(), is only used on the 'istioctl kube-kubeinject' path, which
 	// doesn't use Pilot bootstrap variables.
 	metadata.Labels[label.IstioRev] = revision
-	if status != "" && metadata.Labels[model.TLSModeLabelName] == "" {
-		metadata.Labels[model.TLSModeLabelName] = model.IstioMutualTLSModeLabel
+	if status != "" && metadata.Labels[label.TLSMode] == "" {
+		metadata.Labels[label.TLSMode] = model.IstioMutualTLSModeLabel
 	}
 
 	return out, nil

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml
@@ -15,7 +15,7 @@ spec:
         traffic.sidecar.istio.io/excludeOutboundPorts: "7,8,9"
         traffic.sidecar.istio.io/includeOutboundIPRanges: "127.0.0.1/24,10.96.0.1/24"
         traffic.sidecar.istio.io/excludeOutboundIPRanges: "10.96.0.2/24,10.96.0.3/24"
-        istio.io/proxyConfig: |-
+        proxy.istio.io/config: |-
           discoveryAddress: foo:123
           proxyMetadata:
             FOO: bar

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       annotations:
-        istio.io/proxyConfig: |-
+        proxy.istio.io/config: |-
           discoveryAddress: foo:123
           proxyMetadata:
             FOO: bar
@@ -94,7 +94,7 @@ spec:
           value: REDIRECT
         - name: ISTIO_METAJSON_ANNOTATIONS
           value: |
-            {"istio.io/proxyConfig":"discoveryAddress: foo:123\nproxyMetadata:\n  FOO: bar","traffic.sidecar.istio.io/excludeInboundPorts":"4,5,6","traffic.sidecar.istio.io/excludeOutboundIPRanges":"10.96.0.2/24,10.96.0.3/24","traffic.sidecar.istio.io/excludeOutboundPorts":"7,8,9","traffic.sidecar.istio.io/includeInboundPorts":"1,2,3","traffic.sidecar.istio.io/includeOutboundIPRanges":"127.0.0.1/24,10.96.0.1/24"}
+            {"proxy.istio.io/config":"discoveryAddress: foo:123\nproxyMetadata:\n  FOO: bar","traffic.sidecar.istio.io/excludeInboundPorts":"4,5,6","traffic.sidecar.istio.io/excludeOutboundIPRanges":"10.96.0.2/24,10.96.0.3/24","traffic.sidecar.istio.io/excludeOutboundPorts":"7,8,9","traffic.sidecar.istio.io/includeInboundPorts":"1,2,3","traffic.sidecar.istio.io/includeOutboundIPRanges":"127.0.0.1/24,10.96.0.1/24"}
         - name: ISTIO_META_WORKLOAD_NAME
           value: traffic
         - name: ISTIO_META_OWNER

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/howeyc/fsnotify"
+	"istio.io/api/label"
 
 	"istio.io/api/annotation"
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -613,7 +614,7 @@ func createPatch(pod *corev1.Pod, prevStatus *SidecarInjectionStatus, revision s
 	patch = append(patch, addLabels(pod.Labels, map[string]string{
 		model.TLSModeLabelName:                       model.IstioMutualTLSModeLabel,
 		model.IstioCanonicalServiceLabelName:         canonicalSvc,
-		model.RevisionLabel:                          revision,
+		label.IstioRev:                               revision,
 		model.IstioCanonicalServiceRevisionLabelName: canonicalRev})...)
 
 	if rewrite {

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/howeyc/fsnotify"
+
 	"istio.io/api/label"
 
 	"istio.io/api/annotation"
@@ -612,7 +613,7 @@ func createPatch(pod *corev1.Pod, prevStatus *SidecarInjectionStatus, revision s
 
 	canonicalSvc, canonicalRev := extractCanonicalServiceLabels(pod.Labels, workloadName)
 	patch = append(patch, addLabels(pod.Labels, map[string]string{
-		model.TLSModeLabelName:                       model.IstioMutualTLSModeLabel,
+		label.TLSMode:                                model.IstioMutualTLSModeLabel,
 		model.IstioCanonicalServiceLabelName:         canonicalSvc,
 		label.IstioRev:                               revision,
 		model.IstioCanonicalServiceRevisionLabelName: canonicalRev})...)

--- a/pkg/test/framework/components/namespace/kube.go
+++ b/pkg/test/framework/components/namespace/kube.go
@@ -25,9 +25,9 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-multierror"
+
 	"istio.io/api/label"
 
-	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/resource"

--- a/pkg/test/framework/components/namespace/kube.go
+++ b/pkg/test/framework/components/namespace/kube.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-multierror"
+	"istio.io/api/label"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
@@ -164,7 +165,7 @@ func createNamespaceLabels(cfg *Config) map[string]string {
 	l := make(map[string]string)
 	if cfg.Inject {
 		if cfg.Revision != "" {
-			l[model.RevisionLabel] = cfg.Revision
+			l[label.IstioRev] = cfg.Revision
 		} else {
 			l["istio-injection"] = "enabled"
 		}


### PR DESCRIPTION
This moves a few labels and annotations to using constants defined in API. The 3 changes are separate commits if that makes review easier. Please note the proxyConfig one is actually changing its value (not yet shipped, so not breaking), the others are just changing where its defined