### PR TITLE
Allow meshConfig.enablePrometheusMerge

### DIFF
--- a/manifests/profiles/default.yaml
+++ b/manifests/profiles/default.yaml
@@ -6,6 +6,13 @@ spec:
   hub: gcr.io/istio-testing
   tag: latest
 
+  # You may override parts of meshconfig by uncommenting the following lines.
+  meshConfig:
+    enablePrometheusMerge: false
+    # Opt-out of global http2 upgrades.
+    # Destination rule is used to opt-in.
+    # h2_upgrade_policy: DO_NOT_UPGRADE
+
   # Traffic management feature
   components:
     base:
@@ -219,12 +226,6 @@ spec:
   # Global values passed through to helm global.yaml.
   # Please keep this in sync with manifests/charts/global.yaml
   values:
-    # You may override parts of meshconfig by uncommenting the following lines.
-    meshConfig:
-      enablePrometheusMerge: false
-      # Opt-out of global http2 upgrades.
-      # Destination rule is used to opt-in.
-      # h2_upgrade_policy: DO_NOT_UPGRADE
     global:
       istioNamespace: istio-system
       istiod:

--- a/operator/cmd/mesh/manifest_shared_test.go
+++ b/operator/cmd/mesh/manifest_shared_test.go
@@ -46,7 +46,7 @@ var (
 func runCommand(command string) (string, error) {
 	var out bytes.Buffer
 	rootCmd := GetRootCmd(strings.Split(command, " "))
-	rootCmd.SetOutput(&out)
+	rootCmd.SetOut(&out)
 
 	err := rootCmd.Execute()
 	return out.String(), err

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/profiles/default.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/profiles/default.yaml
@@ -6,6 +6,13 @@ spec:
   hub: gcr.io/istio-testing
   tag: latest
 
+  # You may override parts of meshconfig by uncommenting the following lines.
+  meshConfig:
+    enablePrometheusMerge: false
+    # Opt-out of global http2 upgrades.
+    # Destination rule is used to opt-in.
+    # h2_upgrade_policy: DO_NOT_UPGRADE
+
   # Traffic management feature
   components:
     base:
@@ -36,7 +43,7 @@ spec:
             maxSurge: "100%"
             maxUnavailable: "25%"
 
-  # Policy feature
+    # Policy feature
     policy:
       enabled: false
       k8s:
@@ -63,7 +70,7 @@ spec:
             maxSurge: "100%"
             maxUnavailable: "25%"
 
-   # Telemetry feature
+    # Telemetry feature
     telemetry:
       enabled: false
       k8s:
@@ -100,7 +107,7 @@ spec:
             maxSurge: "100%"
             maxUnavailable: "25%"
 
-  # Security feature
+    # Security feature
     citadel:
       enabled: false
       k8s:
@@ -109,7 +116,7 @@ spec:
             maxSurge: "100%"
             maxUnavailable: "25%"
 
-  # Istio Gateway feature
+    # Istio Gateway feature
     ingressGateways:
     - name: istio-ingressgateway
       enabled: true
@@ -219,12 +226,6 @@ spec:
   # Global values passed through to helm global.yaml.
   # Please keep this in sync with manifests/charts/global.yaml
   values:
-    # You may override parts of meshconfig by uncommenting the following lines.
-    meshConfig:
-      enablePrometheusMerge: false
-      # Opt-out of global http2 upgrades.
-      # Destination rule is used to opt-in.
-      # h2_upgrade_policy: DO_NOT_UPGRADE
     global:
       istioNamespace: istio-system
       istiod:
@@ -594,7 +595,7 @@ spec:
         jaegerURL:
         jaegerInClusterURL: http://tracing/jaeger
         auth:
-          strategy: ""
+          strategy: login
       prometheusNamespace:
       createDemoSecret: false
       security:

--- a/operator/cmd/mesh/testdata/manifest-generate/input/pilot_merge_meshconfig.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/input/pilot_merge_meshconfig.yaml
@@ -5,6 +5,7 @@ spec:
   hub: docker.io/istio
   tag: 1.1.4
   meshConfig:
+    enablePrometheusMerge: true
     rootNamespace: istio-control
     mixerCheckServer: foo:1234
     outboundTrafficPolicy:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_merge_meshconfig.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_merge_meshconfig.golden.yaml
@@ -35,7 +35,7 @@ data:
     disableMixerHttpReports: true
     disablePolicyChecks: true
     enableAutoMtls: true
-    enablePrometheusMerge: false
+    enablePrometheusMerge: true
     enableTracing: true
     ingressClass: istio
     ingressControllerMode: STRICT


### PR DESCRIPTION
Because we define it in values.meshConfig in the profile, the user
cannot actually override this with meshConfig.enablePrometheusMerge.
This fixes this issue, and updates the test to show this. Additionally,
the test is changed to not capture stderr in the test which fixes some
errors (that happen to not break tests)