### PR TITLE
Fix integration local test races

### DIFF
--- a/pilot/pkg/config/memory/monitor.go
+++ b/pilot/pkg/config/memory/monitor.go
@@ -16,6 +16,7 @@ package memory
 
 import (
 	"go.uber.org/atomic"
+
 	"istio.io/pkg/log"
 
 	"istio.io/istio/pilot/pkg/model"

--- a/pilot/pkg/config/memory/monitor_test.go
+++ b/pilot/pkg/config/memory/monitor_test.go
@@ -24,6 +24,17 @@ import (
 	"istio.io/istio/pkg/config/schema/collections"
 )
 
+func TestMonitorLifecycle(t *testing.T) {
+	// Regression test to ensure no race conditions during monitor shutdown
+	store := memory.Make(collections.Mocks)
+	m := memory.NewMonitor(store)
+	stop := make(chan struct{})
+	go m.Run(stop)
+	m.ScheduleProcessEvent(memory.ConfigEvent{})
+	close(stop)
+	m.ScheduleProcessEvent(memory.ConfigEvent{})
+}
+
 func TestEventConsistency(t *testing.T) {
 	store := memory.Make(collections.Mocks)
 	controller := memory.NewController(store)

--- a/pilot/pkg/config/monitor/monitor.go
+++ b/pilot/pkg/config/monitor/monitor.go
@@ -37,7 +37,7 @@ type Monitor struct {
 	getSnapshotFunc func() ([]*model.Config, error)
 	// channel to trigger updates on
 	// generally set to a file watch, but used in tests as well
-	updateCh        chan struct{}
+	updateCh chan struct{}
 }
 
 // NewMonitor creates a Monitor and will delegate to a passed in controller.

--- a/pilot/pkg/config/monitor/monitor.go
+++ b/pilot/pkg/config/monitor/monitor.go
@@ -15,14 +15,12 @@
 package monitor
 
 import (
-	"os"
 	"reflect"
 	"strings"
-	"syscall"
+	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/gogo/protobuf/proto"
-
-	"istio.io/pkg/appsignals"
 
 	"istio.io/pkg/log"
 
@@ -52,29 +50,59 @@ func NewMonitor(name string, delegateStore model.ConfigStore, getSnapshotFunc fu
 	return monitor
 }
 
+const watchDebounceDelay = 50 * time.Millisecond
+
+// Trigger notifications when a file is mutated
+func fileTrigger(path string, ch chan struct{}, stop <-chan struct{}) error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	if err = watcher.Add(path); err != nil {
+		return err
+	}
+	go func() {
+		defer watcher.Close()
+		var debounceC <-chan time.Time
+		for {
+			select {
+			case <-debounceC:
+				debounceC = nil
+				ch <- struct{}{}
+			case <-watcher.Events:
+				if debounceC == nil {
+					debounceC = time.After(watchDebounceDelay)
+				}
+			case err := <-watcher.Errors:
+				log.Warnf("Error watching file trigger: %v %v", path, err)
+				return
+			case signal := <-stop:
+				log.Infof("Shutting down file watcher: %v %v", path, signal)
+				return
+			}
+		}
+	}()
+	return nil
+}
+
 // Start starts a new Monitor. Immediately checks the Monitor getSnapshotFunc
 // and updates the controller. It then kicks off an asynchronous event loop that
 // periodically polls the getSnapshotFunc for changes until a close event is sent.
 func (m *Monitor) Start(stop <-chan struct{}) {
 	m.checkAndUpdate()
 
-	c := make(chan appsignals.Signal, 1)
-	appsignals.Watch(c)
-	shut := make(chan os.Signal, 1)
-	if err := appsignals.FileTrigger(m.root, syscall.SIGUSR1, shut); err != nil {
+	c := make(chan struct{}, 1)
+	if err := fileTrigger(m.root, c, stop); err != nil {
 		log.Errorf("Unable to setup FileTrigger for %s: %v", m.root, err)
 	}
 	// Run the close loop asynchronously.
 	go func() {
 		for {
 			select {
-			case trigger := <-c:
-				if trigger.Signal == syscall.SIGUSR1 {
-					log.Infof("Triggering reload in response to: %v", trigger.Source)
-					m.checkAndUpdate()
-				}
+			case <-c:
+				log.Infof("Triggering reload of file configuration")
+				m.checkAndUpdate()
 			case <-stop:
-				shut <- syscall.SIGTERM
 				return
 			}
 		}

--- a/pilot/pkg/config/monitor/monitor_test.go
+++ b/pilot/pkg/config/monitor/monitor_test.go
@@ -12,22 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package monitor_test
+package monitor
 
 import (
 	"errors"
-	"syscall"
 	"testing"
 	"time"
-
-	"istio.io/pkg/appsignals"
 
 	"github.com/onsi/gomega"
 
 	networking "istio.io/api/networking/v1alpha3"
 
 	"istio.io/istio/pilot/pkg/config/memory"
-	"istio.io/istio/pilot/pkg/config/monitor"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
@@ -106,14 +102,14 @@ func TestMonitorForChange(t *testing.T) {
 		callCount++
 		return configs, err
 	}
-	mon := monitor.NewMonitor("", store, someConfigFunc, "")
+	mon := NewMonitor("", store, someConfigFunc, "")
 	stop := make(chan struct{})
 	defer func() { stop <- struct{}{} }() // shut it down
 	mon.Start(stop)
 
 	go func() {
 		for i := 0; i < 10; i++ {
-			appsignals.Notify("test", syscall.SIGUSR1)
+			mon.updateCh <- struct{}{}
 			time.Sleep(time.Millisecond * 100)
 		}
 	}()
@@ -180,14 +176,14 @@ func TestMonitorForError(t *testing.T) {
 		callCount++
 		return configs, err
 	}
-	mon := monitor.NewMonitor("", store, someConfigFunc, "")
+	mon := NewMonitor("", store, someConfigFunc, "")
 	stop := make(chan struct{})
 	defer func() { stop <- struct{}{} }() // shut it down
 	mon.Start(stop)
 
 	go func() {
 		for i := 0; i < 10; i++ {
-			appsignals.Notify("test", syscall.SIGUSR1)
+			mon.updateCh <- struct{}{}
 			time.Sleep(time.Millisecond * 10)
 		}
 	}()

--- a/pkg/test/docker/container.go
+++ b/pkg/test/docker/container.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"time"
 
 	"github.com/docker/docker/api/types"
 	dockerContainer "github.com/docker/docker/api/types/container"
@@ -220,7 +221,10 @@ func (c *Container) Logs() (string, error) {
 // Close stops and removes this container.
 func (c *Container) Close() error {
 	scopes.CI.Infof("Closing Docker container %s", c.id)
-	err := c.dockerClient.ContainerStop(context.Background(), c.id, nil)
+	// docker stop will send SIGTERM to the root process. In our case, this is the echo process not Istio
+	// To avoid 10s shutdown on every container, we set the time out to 0s instead.
+	instant := time.Duration(0)
+	err := c.dockerClient.ContainerStop(context.Background(), c.id, &instant)
 	return multierror.Append(err, c.dockerClient.ContainerRemove(context.Background(), c.id, types.ContainerRemoveOptions{})).ErrorOrNil()
 }
 

--- a/pkg/test/framework/components/galley/native.go
+++ b/pkg/test/framework/components/galley/native.go
@@ -20,9 +20,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"syscall"
-
-	"istio.io/pkg/appsignals"
 
 	"istio.io/istio/galley/pkg/server"
 	"istio.io/istio/pkg/test"
@@ -111,8 +108,6 @@ func (c *nativeComponent) ClearConfig() (err error) {
 
 // ApplyConfig implements Galley.ApplyConfig.
 func (c *nativeComponent) ApplyConfig(ns namespace.Instance, yamlText ...string) error {
-	defer appsignals.Notify("galley.native.ApplyConfig", syscall.SIGUSR1)
-
 	var err error
 	for _, y := range yamlText {
 		y, err = applyNamespace(ns, y)
@@ -139,8 +134,6 @@ func (c *nativeComponent) ApplyConfigOrFail(t test.Failer, ns namespace.Instance
 
 // DeleteConfig implements Galley.DeleteConfig.
 func (c *nativeComponent) DeleteConfig(ns namespace.Instance, yamlText ...string) error {
-	defer appsignals.Notify("galley.native.DeleteConfig", syscall.SIGUSR1)
-
 	var err error
 	for _, y := range yamlText {
 		y, err = applyNamespace(ns, y)
@@ -167,7 +160,6 @@ func (c *nativeComponent) DeleteConfigOrFail(t test.Failer, ns namespace.Instanc
 
 // ApplyConfigDir implements Galley.ApplyConfigDir.
 func (c *nativeComponent) ApplyConfigDir(ns namespace.Instance, sourceDir string) (err error) {
-	defer appsignals.Notify("galley.native.ApplyConfigDir", syscall.SIGUSR1)
 	return filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -200,7 +192,6 @@ func (c *nativeComponent) ApplyConfigDir(ns namespace.Instance, sourceDir string
 
 // ApplyConfigDir implements Galley.DeleteConfigDir.
 func (c *nativeComponent) DeleteConfigDir(ns namespace.Instance, sourceDir string) (err error) {
-	defer appsignals.Notify("galley.native.DeleteConfigDir", syscall.SIGUSR1)
 	return filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err

--- a/tests/integration/pilot/sidecar_api_test.go
+++ b/tests/integration/pilot/sidecar_api_test.go
@@ -122,7 +122,8 @@ func validateMongoListener(t *testing.T, response *structpath.Instance) {
 			}, "{.address.socketAddress}").
 			Select("{.filterChains[0].filters[0]}").
 			Equals("envoy.mongo_proxy", "{.name}").
-			Select("{.config}").
-			Exists("{.stat_prefix}")
+			Select("{.typedConfig}").
+			Exists("{.statPrefix}").
+			CheckOrFail(t)
 	})
 }


### PR DESCRIPTION
There have been some race conditions like https://github.com/istio/istio/issues/23404. In an attempt to fix that, which I did not fix, I found other rather conditions which are fixed here and problems.

This fixes these races, fixes an issue in the file watching logic where we miss events, fixes a test that wasn't actually verifying anything, and makes the cleanup logic much faster (previously a fixed 10s per docker image)