### PR TITLE
Send gateway readiness probe through envoy

### DIFF
--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -131,7 +131,7 @@ spec:
             failureThreshold: 30
             httpGet:
               path: /healthz/ready
-              port: 15020
+              port: 15021
               scheme: HTTP
             initialDelaySeconds: 1
             periodSeconds: 2

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -134,7 +134,7 @@ spec:
             failureThreshold: 30
             httpGet:
               path: /healthz/ready
-              port: 15020
+              port: 15021
               scheme: HTTP
             initialDelaySeconds: 1
             periodSeconds: 2

--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -12,8 +12,8 @@ gateways:
     # Note that AWS ELB will by default perform health checks on the first port
     # on this list. Setting this to the health check port will ensure that health
     # checks always work. https://github.com/istio/istio/issues/12503
-    - port: 15020
-      targetPort: 15020
+    - port: 15021
+      targetPort: 15021
       name: status-port
     - port: 80
       targetPort: 8080

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -579,7 +579,7 @@ data:
         readinessProbe:
           httpGet:
             path: /healthz/ready
-            port: 15090
+            port: 15021
           initialDelaySeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/initialDelaySeconds` .Values.global.proxy.readinessInitialDelaySeconds }}
           periodSeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/periodSeconds` .Values.global.proxy.readinessPeriodSeconds }}
           failureThreshold: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/failureThreshold` .Values.global.proxy.readinessFailureThreshold }}

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -245,7 +245,7 @@ template: |
     readinessProbe:
       httpGet:
         path: /healthz/ready
-        port: 15090
+        port: 15021
       initialDelaySeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/initialDelaySeconds` .Values.global.proxy.readinessInitialDelaySeconds }}
       periodSeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/periodSeconds` .Values.global.proxy.readinessPeriodSeconds }}
       failureThreshold: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/failureThreshold` .Values.global.proxy.readinessFailureThreshold }}

--- a/manifests/profiles/default.yaml
+++ b/manifests/profiles/default.yaml
@@ -126,8 +126,8 @@ spec:
             value: "sni-dnat"
         service:
           ports:
-            - port: 15020
-              targetPort: 15020
+            - port: 15021
+              targetPort: 15021
               name: status-port
             - port: 80
               targetPort: 8080

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -390,6 +390,7 @@
       ,
       {
         "name": "zipkin",
+        
         "type": "STRICT_DNS",
         "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",
@@ -497,7 +498,48 @@
                             "route": {
                               "cluster": "prometheus_stats"
                             }
-                          },
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": [{
+                    "name": "envoy.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                    }
+                  }]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "address": {
+          "socket_address": {
+            "protocol": "TCP",
+            "address": "0.0.0.0",
+            "port_value": 15021
+          }
+        },
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.http_connection_manager",
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
+                  "codec_type": "AUTO",
+                  "stat_prefix": "agent",
+                  "route_config": {
+                    "virtual_hosts": [
+                      {
+                        "name": "backend",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
                           {
                             "match": {
                               "prefix": "/healthz/ready"

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -423,7 +423,48 @@
                             "route": {
                               "cluster": "prometheus_stats"
                             }
-                          },
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": [{
+                    "name": "envoy.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                    }
+                  }]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "address": {
+          "socket_address": {
+            "protocol": "TCP",
+            "address": "0.0.0.0",
+            "port_value": 15021
+          }
+        },
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.http_connection_manager",
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
+                  "codec_type": "AUTO",
+                  "stat_prefix": "agent",
+                  "route_config": {
+                    "virtual_hosts": [
+                      {
+                        "name": "backend",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
                           {
                             "match": {
                               "prefix": "/healthz/ready"

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -423,7 +423,48 @@
                             "route": {
                               "cluster": "prometheus_stats"
                             }
-                          },
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": [{
+                    "name": "envoy.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                    }
+                  }]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "address": {
+          "socket_address": {
+            "protocol": "TCP",
+            "address": "0.0.0.0",
+            "port_value": 15021
+          }
+        },
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.http_connection_manager",
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
+                  "codec_type": "AUTO",
+                  "stat_prefix": "agent",
+                  "route_config": {
+                    "virtual_hosts": [
+                      {
+                        "name": "backend",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
                           {
                             "match": {
                               "prefix": "/healthz/ready"

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -391,7 +391,48 @@
                             "route": {
                               "cluster": "prometheus_stats"
                             }
-                          },
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": [{
+                    "name": "envoy.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                    }
+                  }]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "address": {
+          "socket_address": {
+            "protocol": "TCP",
+            "address": "0.0.0.0",
+            "port_value": 15021
+          }
+        },
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.http_connection_manager",
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
+                  "codec_type": "AUTO",
+                  "stat_prefix": "agent",
+                  "route_config": {
+                    "virtual_hosts": [
+                      {
+                        "name": "backend",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
                           {
                             "match": {
                               "prefix": "/healthz/ready"

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -395,6 +395,7 @@
       ,
       {
         "name": "zipkin",
+        
         "type": "STRICT_DNS",
         "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",
@@ -450,7 +451,48 @@
                             "route": {
                               "cluster": "prometheus_stats"
                             }
-                          },
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": [{
+                    "name": "envoy.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                    }
+                  }]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "address": {
+          "socket_address": {
+            "protocol": "TCP",
+            "address": "0.0.0.0",
+            "port_value": 15021
+          }
+        },
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.http_connection_manager",
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
+                  "codec_type": "AUTO",
+                  "stat_prefix": "agent",
+                  "route_config": {
+                    "virtual_hosts": [
+                      {
+                        "name": "backend",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
                           {
                             "match": {
                               "prefix": "/healthz/ready"

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -395,6 +395,7 @@
       ,
       {
         "name": "zipkin",
+        
         "type": "STRICT_DNS",
         "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",
@@ -450,7 +451,48 @@
                             "route": {
                               "cluster": "prometheus_stats"
                             }
-                          },
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": [{
+                    "name": "envoy.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                    }
+                  }]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "address": {
+          "socket_address": {
+            "protocol": "TCP",
+            "address": "0.0.0.0",
+            "port_value": 15021
+          }
+        },
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.http_connection_manager",
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
+                  "codec_type": "AUTO",
+                  "stat_prefix": "agent",
+                  "route_config": {
+                    "virtual_hosts": [
+                      {
+                        "name": "backend",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
                           {
                             "match": {
                               "prefix": "/healthz/ready"

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -406,7 +406,48 @@
                             "route": {
                               "cluster": "prometheus_stats"
                             }
-                          },
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": [{
+                    "name": "envoy.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                    }
+                  }]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "address": {
+          "socket_address": {
+            "protocol": "TCP",
+            "address": "0.0.0.0",
+            "port_value": 15021
+          }
+        },
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.http_connection_manager",
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
+                  "codec_type": "AUTO",
+                  "stat_prefix": "agent",
+                  "route_config": {
+                    "virtual_hosts": [
+                      {
+                        "name": "backend",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
                           {
                             "match": {
                               "prefix": "/healthz/ready"

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -358,6 +358,7 @@
       ,
       {
         "name": "datadog_agent",
+        
         "connect_timeout": "1s",
         "type": "STRICT_DNS",
         "respect_dns_ttl": true,
@@ -413,7 +414,48 @@
                             "route": {
                               "cluster": "prometheus_stats"
                             }
-                          },
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": [{
+                    "name": "envoy.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                    }
+                  }]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "address": {
+          "socket_address": {
+            "protocol": "TCP",
+            "address": "0.0.0.0",
+            "port_value": 15021
+          }
+        },
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.http_connection_manager",
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
+                  "codec_type": "AUTO",
+                  "stat_prefix": "agent",
+                  "route_config": {
+                    "virtual_hosts": [
+                      {
+                        "name": "backend",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
                           {
                             "match": {
                               "prefix": "/healthz/ready"

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -358,6 +358,7 @@
       ,
       {
         "name": "lightstep",
+        
         "http2_protocol_options": {},
         "type": "STRICT_DNS",
         "respect_dns_ttl": true,
@@ -414,7 +415,48 @@
                             "route": {
                               "cluster": "prometheus_stats"
                             }
-                          },
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": [{
+                    "name": "envoy.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                    }
+                  }]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "address": {
+          "socket_address": {
+            "protocol": "TCP",
+            "address": "0.0.0.0",
+            "port_value": 15021
+          }
+        },
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.http_connection_manager",
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
+                  "codec_type": "AUTO",
+                  "stat_prefix": "agent",
+                  "route_config": {
+                    "virtual_hosts": [
+                      {
+                        "name": "backend",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
                           {
                             "match": {
                               "prefix": "/healthz/ready"

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -391,7 +391,48 @@
                             "route": {
                               "cluster": "prometheus_stats"
                             }
-                          },
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": [{
+                    "name": "envoy.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                    }
+                  }]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "address": {
+          "socket_address": {
+            "protocol": "TCP",
+            "address": "0.0.0.0",
+            "port_value": 15021
+          }
+        },
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.http_connection_manager",
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
+                  "codec_type": "AUTO",
+                  "stat_prefix": "agent",
+                  "route_config": {
+                    "virtual_hosts": [
+                      {
+                        "name": "backend",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
                           {
                             "match": {
                               "prefix": "/healthz/ready"

--- a/pkg/bootstrap/testdata/tracing_tls_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_golden.json
@@ -416,7 +416,48 @@
                             "route": {
                               "cluster": "prometheus_stats"
                             }
-                          },
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": [{
+                    "name": "envoy.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                    }
+                  }]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "address": {
+          "socket_address": {
+            "protocol": "TCP",
+            "address": "0.0.0.0",
+            "port_value": 15021
+          }
+        },
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.http_connection_manager",
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
+                  "codec_type": "AUTO",
+                  "stat_prefix": "agent",
+                  "route_config": {
+                    "virtual_hosts": [
+                      {
+                        "name": "backend",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
                           {
                             "match": {
                               "prefix": "/healthz/ready"

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -358,6 +358,7 @@
       ,
       {
         "name": "zipkin",
+        
         "type": "STRICT_DNS",
         "respect_dns_ttl": true,
         "dns_lookup_family": "V4_ONLY",
@@ -413,7 +414,48 @@
                             "route": {
                               "cluster": "prometheus_stats"
                             }
-                          },
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": [{
+                    "name": "envoy.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                    }
+                  }]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "address": {
+          "socket_address": {
+            "protocol": "TCP",
+            "address": "0.0.0.0",
+            "port_value": 15021
+          }
+        },
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.http_connection_manager",
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
+                  "codec_type": "AUTO",
+                  "stat_prefix": "agent",
+                  "route_config": {
+                    "virtual_hosts": [
+                      {
+                        "name": "backend",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
                           {
                             "match": {
                               "prefix": "/healthz/ready"

--- a/tools/packaging/common/envoy_bootstrap_v2.json
+++ b/tools/packaging/common/envoy_bootstrap_v2.json
@@ -456,7 +456,48 @@
                             "route": {
                               "cluster": "prometheus_stats"
                             }
-                          },
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": [{
+                    "name": "envoy.router",
+                    "typed_config": {
+                      "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                    }
+                  }]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "address": {
+          "socket_address": {
+            "protocol": "TCP",
+            "address": "{{ .wildcard }}",
+            "port_value": 15021
+          }
+        },
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.http_connection_manager",
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
+                  "codec_type": "AUTO",
+                  "stat_prefix": "agent",
+                  "route_config": {
+                    "virtual_hosts": [
+                      {
+                        "name": "backend",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
                           {
                             "match": {
                               "prefix": "/healthz/ready"


### PR DESCRIPTION
This is already done for sidecars, but was accidentally not update for
Gateways