### PR TITLE
Let --force really work in 'manifest apply'

### DIFF
--- a/operator/cmd/mesh/manifest-apply.go
+++ b/operator/cmd/mesh/manifest-apply.go
@@ -190,7 +190,8 @@ func ApplyManifests(setOverlay []string, inFilenames []string, force bool, dryRu
 
 	// Needed in case we are running a test through this path that doesn't start a new process.
 	cache.FlushObjectCaches()
-	opts := &helmreconciler.Options{DryRun: dryRun, Log: l, Wait: wait, WaitTimeout: waitTimeout, ProgressLog: progress.NewLog()}
+	opts := &helmreconciler.Options{DryRun: dryRun, Log: l, Wait: wait, WaitTimeout: waitTimeout, ProgressLog: progress.NewLog(),
+		Force: force}
 	reconciler, err := helmreconciler.NewHelmReconciler(client, restConfig, iop, opts)
 	if err != nil {
 		return err

--- a/operator/pkg/helmreconciler/reconciler.go
+++ b/operator/pkg/helmreconciler/reconciler.go
@@ -63,6 +63,8 @@ type Options struct {
 	WaitTimeout time.Duration
 	// Log tracks the installation progress for all components.
 	ProgressLog *progress.Log
+	// Force ignores validation errors
+	Force bool
 }
 
 var defaultOptions = &Options{

--- a/operator/pkg/helmreconciler/render.go
+++ b/operator/pkg/helmreconciler/render.go
@@ -27,10 +27,11 @@ import (
 // RenderCharts renders charts for h.
 func (h *HelmReconciler) RenderCharts() (name.ManifestMap, error) {
 	iopSpec := h.iop.Spec
-	if !h.opts.Force {
-		if err := validate.CheckIstioOperatorSpec(iopSpec, false); err != nil {
+	if err := validate.CheckIstioOperatorSpec(iopSpec, false); err != nil {
+		if !h.opts.Force {
 			return nil, err
 		}
+		h.opts.Log.PrintErr(fmt.Sprintf("spec invalid; continuing because of --force: %v\n", err))
 	}
 
 	t, err := translate.NewTranslator(binversion.OperatorBinaryVersion.MinorVersion)

--- a/operator/pkg/helmreconciler/render.go
+++ b/operator/pkg/helmreconciler/render.go
@@ -27,8 +27,10 @@ import (
 // RenderCharts renders charts for h.
 func (h *HelmReconciler) RenderCharts() (name.ManifestMap, error) {
 	iopSpec := h.iop.Spec
-	if err := validate.CheckIstioOperatorSpec(iopSpec, false); err != nil {
-		return nil, err
+	if !h.opts.Force {
+		if err := validate.CheckIstioOperatorSpec(iopSpec, false); err != nil {
+			return nil, err
+		}
 	}
 
 	t, err := translate.NewTranslator(binversion.OperatorBinaryVersion.MinorVersion)

--- a/operator/pkg/util/yaml.go
+++ b/operator/pkg/util/yaml.go
@@ -16,7 +16,6 @@ package util
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -26,8 +25,6 @@ import (
 	"github.com/gogo/protobuf/proto"
 	jsonpb2 "github.com/golang/protobuf/jsonpb"
 	"github.com/kylelemons/godebug/diff"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
 )
 
@@ -71,19 +68,6 @@ func MarshalWithJSONPB(val proto.Message) (string, error) {
 // UnmarshalWithJSONPB unmarshals y into out using gogo jsonpb (required for many proto defined structs).
 func UnmarshalWithJSONPB(y string, out proto.Message, allowUnknownField bool) error {
 	jb, err := yaml.YAMLToJSON([]byte(y))
-	if err != nil {
-		return err
-	}
-
-	// Remove creationTimestamp from jb if it exists
-	content := make(map[string]interface{})
-	err = json.Unmarshal(jb, &content)
-	if err != nil {
-		return err
-	}
-	un := &unstructured.Unstructured{Object: content}
-	un.SetCreationTimestamp(meta_v1.Time{}) // UnmarshalIstioOperator chokes on these
-	jb, err = json.Marshal(un)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/23376 by letting --force really work when there are unknown fields in the IOP offered to `istioctl manifest apply`.

Also fixes the case where there is unparse-able creationTime metadata in an IOP.