### PR TITLE
test framework: dump envoy proxy configs

### DIFF
--- a/pkg/test/framework/components/namespace/kube.go
+++ b/pkg/test/framework/components/namespace/kube.go
@@ -78,7 +78,7 @@ func (n *kubeNamespace) Dump() {
 				}
 
 				if container.Name == "istio-proxy" {
-					if cfgDump, err := cluster.Exec(pod.Namespace, pod.Name, container.Name, "curl http://127.0.0.1:15000/config_dump"); err == nil {
+					if cfgDump, err := cluster.Exec(pod.Namespace, pod.Name, container.Name, "pilot-agent request GET config_dump"); err == nil {
 						fname := path.Join(d, fmt.Sprintf("%s-%s.config.json", pod.Name, container.Name))
 						if err = ioutil.WriteFile(fname, []byte(cfgDump), os.ModePerm); err != nil {
 							scopes.CI.Errorf("Unable to write logs for pod/container: %s/%s/%s", pod.Namespace, pod.Name, container.Name)

--- a/pkg/test/framework/components/namespace/kube.go
+++ b/pkg/test/framework/components/namespace/kube.go
@@ -76,6 +76,17 @@ func (n *kubeNamespace) Dump() {
 				if err = ioutil.WriteFile(fname, []byte(l), os.ModePerm); err != nil {
 					scopes.CI.Errorf("Unable to write logs for pod/container: %s/%s/%s", pod.Namespace, pod.Name, container.Name)
 				}
+
+				if container.Name == "istio-proxy" {
+					if cfgDump, err := cluster.Exec(pod.Namespace, pod.Name, container.Name, "curl http://127.0.0.1:15000/config_dump"); err == nil {
+						fname := path.Join(d, fmt.Sprintf("%s-%s.config.json", pod.Name, container.Name))
+						if err = ioutil.WriteFile(fname, []byte(cfgDump), os.ModePerm); err != nil {
+							scopes.CI.Errorf("Unable to write logs for pod/container: %s/%s/%s", pod.Namespace, pod.Name, container.Name)
+						}
+					} else {
+						scopes.CI.Errorf("Unable to get istio-proxy config dump for pod: %s/%s", pod.Namespace, pod.Name)
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
When dumping a kubeNamespace resource, check if pods have a "istio-proxy" container and if they do, dump the envoy config to help with debugging. 