### PR TITLE
Avoid accidental dynamic concurrency

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -472,6 +472,10 @@ data:
       {{- if .Values.global.logAsJson }}
         - --log_as_json
       {{- end }}
+      {{ if gt .ProxyConfig.Concurrency 0 -}}
+        - --concurrency
+        - "{{ .ProxyConfig.Concurrency }}"
+      {{ end -}}
       {{- if .Values.global.proxy.lifecycle }}
         lifecycle:
           {{ toYaml .Values.global.proxy.lifecycle | indent 4 }}

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -472,10 +472,10 @@ data:
       {{- if .Values.global.logAsJson }}
         - --log_as_json
       {{- end }}
-      {{ if gt .ProxyConfig.Concurrency 0 -}}
+      {{- if gt .ProxyConfig.Concurrency 0 }}
         - --concurrency
         - "{{ .ProxyConfig.Concurrency }}"
-      {{ end -}}
+      {{- end -}}
       {{- if .Values.global.proxy.lifecycle }}
         lifecycle:
           {{ toYaml .Values.global.proxy.lifecycle | indent 4 }}

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -138,6 +138,10 @@ template: |
   {{- if .Values.global.logAsJson }}
     - --log_as_json
   {{- end }}
+  {{ if gt .ProxyConfig.Concurrency 0 -}}
+    - --concurrency
+    - "{{ .ProxyConfig.Concurrency }}"
+  {{ end -}}
   {{- if .Values.global.proxy.lifecycle }}
     lifecycle:
       {{ toYaml .Values.global.proxy.lifecycle | indent 4 }}

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -138,10 +138,10 @@ template: |
   {{- if .Values.global.logAsJson }}
     - --log_as_json
   {{- end }}
-  {{ if gt .ProxyConfig.Concurrency 0 -}}
+  {{- if gt .ProxyConfig.Concurrency 0 }}
     - --concurrency
     - "{{ .ProxyConfig.Concurrency }}"
-  {{ end -}}
+  {{- end -}}
   {{- if .Values.global.proxy.lifecycle }}
     lifecycle:
       {{ toYaml .Values.global.proxy.lifecycle | indent 4 }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -138,6 +138,10 @@ template: |
   {{- if .Values.global.logAsJson }}
     - --log_as_json
   {{- end }}
+  {{ if gt .ProxyConfig.Concurrency 0 -}}
+    - --concurrency
+    - "{{ .ProxyConfig.Concurrency }}"
+  {{ end -}}
   {{- if .Values.global.proxy.lifecycle }}
     lifecycle:
       {{ toYaml .Values.global.proxy.lifecycle | indent 4 }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -138,10 +138,10 @@ template: |
   {{- if .Values.global.logAsJson }}
     - --log_as_json
   {{- end }}
-  {{ if gt .ProxyConfig.Concurrency 0 -}}
+  {{- if gt .ProxyConfig.Concurrency 0 }}
     - --concurrency
     - "{{ .ProxyConfig.Concurrency }}"
-  {{ end -}}
+  {{- end -}}
   {{- if .Values.global.proxy.lifecycle }}
     lifecycle:
       {{ toYaml .Values.global.proxy.lifecycle | indent 4 }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -8870,10 +8870,10 @@ data:
       {{- if .Values.global.logAsJson }}
         - --log_as_json
       {{- end }}
-      {{ if gt .ProxyConfig.Concurrency 0 -}}
+      {{- if gt .ProxyConfig.Concurrency 0 }}
         - --concurrency
         - "{{ .ProxyConfig.Concurrency }}"
-      {{ end -}}
+      {{- end -}}
       {{- if .Values.global.proxy.lifecycle }}
         lifecycle:
           {{ toYaml .Values.global.proxy.lifecycle | indent 4 }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -8870,6 +8870,10 @@ data:
       {{- if .Values.global.logAsJson }}
         - --log_as_json
       {{- end }}
+      {{ if gt .ProxyConfig.Concurrency 0 -}}
+        - --concurrency
+        - "{{ .ProxyConfig.Concurrency }}"
+      {{ end -}}
       {{- if .Values.global.proxy.lifecycle }}
         lifecycle:
           {{ toYaml .Values.global.proxy.lifecycle | indent 4 }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
@@ -7508,6 +7508,10 @@ data:
       {{- if .Values.global.logAsJson }}
         - --log_as_json
       {{- end }}
+      {{ if gt .ProxyConfig.Concurrency 0 -}}
+        - --concurrency
+        - "{{ .ProxyConfig.Concurrency }}"
+      {{ end -}}
       {{- if .Values.global.proxy.lifecycle }}
         lifecycle:
           {{ toYaml .Values.global.proxy.lifecycle | indent 4 }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
@@ -7508,10 +7508,10 @@ data:
       {{- if .Values.global.logAsJson }}
         - --log_as_json
       {{- end }}
-      {{ if gt .ProxyConfig.Concurrency 0 -}}
+      {{- if gt .ProxyConfig.Concurrency 0 }}
         - --concurrency
         - "{{ .ProxyConfig.Concurrency }}"
-      {{ end -}}
+      {{- end -}}
       {{- if .Values.global.proxy.lifecycle }}
         lifecycle:
           {{ toYaml .Values.global.proxy.lifecycle | indent 4 }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.golden.yaml
@@ -322,6 +322,10 @@ data:
       {{- if .Values.global.logAsJson }}
         - --log_as_json
       {{- end }}
+      {{ if gt .ProxyConfig.Concurrency 0 -}}
+        - --concurrency
+        - "{{ .ProxyConfig.Concurrency }}"
+      {{ end -}}
       {{- if .Values.global.proxy.lifecycle }}
         lifecycle:
           {{ toYaml .Values.global.proxy.lifecycle | indent 4 }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.golden.yaml
@@ -322,10 +322,10 @@ data:
       {{- if .Values.global.logAsJson }}
         - --log_as_json
       {{- end }}
-      {{ if gt .ProxyConfig.Concurrency 0 -}}
+      {{- if gt .ProxyConfig.Concurrency 0 }}
         - --concurrency
         - "{{ .ProxyConfig.Concurrency }}"
-      {{ end -}}
+      {{- end -}}
       {{- if .Values.global.proxy.lifecycle }}
         lifecycle:
           {{ toYaml .Values.global.proxy.lifecycle | indent 4 }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -564,6 +564,10 @@ data:
       {{- if .Values.global.logAsJson }}
         - --log_as_json
       {{- end }}
+      {{ if gt .ProxyConfig.Concurrency 0 -}}
+        - --concurrency
+        - "{{ .ProxyConfig.Concurrency }}"
+      {{ end -}}
       {{- if .Values.global.proxy.lifecycle }}
         lifecycle:
           {{ toYaml .Values.global.proxy.lifecycle | indent 4 }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -564,10 +564,10 @@ data:
       {{- if .Values.global.logAsJson }}
         - --log_as_json
       {{- end }}
-      {{ if gt .ProxyConfig.Concurrency 0 -}}
+      {{- if gt .ProxyConfig.Concurrency 0 }}
         - --concurrency
         - "{{ .ProxyConfig.Concurrency }}"
-      {{ end -}}
+      {{- end -}}
       {{- if .Values.global.proxy.lifecycle }}
         lifecycle:
           {{ toYaml .Values.global.proxy.lifecycle | indent 4 }}

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml
@@ -10,6 +10,8 @@ spec:
   template:
     metadata:
       annotations:
+        # We set 4 CPUs here and concurrency=0 below. Expect concurrency to be set to 4.
+        sidecar.istio.io/proxyCPU: 4000m
         traffic.sidecar.istio.io/includeInboundPorts: "1,2,3"
         traffic.sidecar.istio.io/excludeInboundPorts: "4,5,6"
         traffic.sidecar.istio.io/excludeOutboundPorts: "7,8,9"
@@ -17,6 +19,7 @@ spec:
         traffic.sidecar.istio.io/excludeOutboundIPRanges: "10.96.0.2/24,10.96.0.3/24"
         proxy.istio.io/config: |-
           discoveryAddress: foo:123
+          concurrency: 0
           proxyMetadata:
             FOO: bar
       labels:

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -14,9 +14,11 @@ spec:
       annotations:
         proxy.istio.io/config: |-
           discoveryAddress: foo:123
+          concurrency: 0
           proxyMetadata:
             FOO: bar
         sidecar.istio.io/interceptionMode: REDIRECT
+        sidecar.istio.io/proxyCPU: 4000m
         sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6,15020
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
@@ -47,7 +49,7 @@ spec:
         - --proxyComponentLogLevel=misc:error
         - --trust-domain=cluster.local
         - --concurrency
-        - "2"
+        - "4"
         env:
         - name: JWT_POLICY
           value: third-party-jwt
@@ -94,7 +96,7 @@ spec:
           value: REDIRECT
         - name: ISTIO_METAJSON_ANNOTATIONS
           value: |
-            {"proxy.istio.io/config":"discoveryAddress: foo:123\nproxyMetadata:\n  FOO: bar","traffic.sidecar.istio.io/excludeInboundPorts":"4,5,6","traffic.sidecar.istio.io/excludeOutboundIPRanges":"10.96.0.2/24,10.96.0.3/24","traffic.sidecar.istio.io/excludeOutboundPorts":"7,8,9","traffic.sidecar.istio.io/includeInboundPorts":"1,2,3","traffic.sidecar.istio.io/includeOutboundIPRanges":"127.0.0.1/24,10.96.0.1/24"}
+            {"proxy.istio.io/config":"discoveryAddress: foo:123\nconcurrency: 0\nproxyMetadata:\n  FOO: bar","sidecar.istio.io/proxyCPU":"4000m","traffic.sidecar.istio.io/excludeInboundPorts":"4,5,6","traffic.sidecar.istio.io/excludeOutboundIPRanges":"10.96.0.2/24,10.96.0.3/24","traffic.sidecar.istio.io/excludeOutboundPorts":"7,8,9","traffic.sidecar.istio.io/includeInboundPorts":"1,2,3","traffic.sidecar.istio.io/includeOutboundIPRanges":"127.0.0.1/24,10.96.0.1/24"}
         - name: ISTIO_META_WORKLOAD_NAME
           value: traffic
         - name: ISTIO_META_OWNER
@@ -120,12 +122,8 @@ spec:
           initialDelaySeconds: 1
           periodSeconds: 2
         resources:
-          limits:
-            cpu: "2"
-            memory: 1Gi
           requests:
-            cpu: 100m
-            memory: 128Mi
+            cpu: "4"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
Hopefully this will resolve https://github.com/istio/istio/issues/22845

Previously, we were setting concurrency from proxy config if it was set.
By default this was set to "2".
https://github.com/istio/istio/pull/21162 caused a regression switching
it to read from the CPU requests instead. This is the minimal fix to
undo that. Further improvements in master will be done, tracked in
https://github.com/istio/istio/issues/23470