### PR TITLE
Run tests through kubebuilder test env

### DIFF
--- a/operator/cmd/mesh/manifest-apply.go
+++ b/operator/cmd/mesh/manifest-apply.go
@@ -25,7 +25,6 @@ import (
 	iopv1alpha1 "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/cache"
 	"istio.io/istio/operator/pkg/helmreconciler"
-	"istio.io/istio/operator/pkg/object"
 	"istio.io/istio/operator/pkg/translate"
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/operator/pkg/util/clog"
@@ -205,18 +204,10 @@ func ApplyManifests(setOverlay []string, inFilenames []string, force bool, dryRu
 
 	opts.ProgressLog.SetState(util.StateComplete)
 
-	// Save state to cluster in IstioOperator CR.
 	iopStr, err := translate.IOPStoIOPstr(iops, crName, iopv1alpha1.Namespace(iops))
 	if err != nil {
 		return err
 	}
-	obj, err := object.ParseYAMLToK8sObject([]byte(iopStr))
-	if err != nil {
-		return err
-	}
-	if err := reconciler.ApplyObject("", obj.UnstructuredObject()); err != nil {
-		return err
-	}
 
-	return nil
+	return saveIOPToCluster(reconciler, iopStr)
 }

--- a/operator/cmd/mesh/manifest_shared_test.go
+++ b/operator/cmd/mesh/manifest_shared_test.go
@@ -16,8 +16,64 @@ package mesh
 
 import (
 	"bytes"
+	"context"
+	"flag"
+	"fmt"
 	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"istio.io/istio/operator/pkg/apis/istio/v1alpha1"
+	"istio.io/istio/operator/pkg/cache"
+	"istio.io/istio/operator/pkg/controller/istiocontrolplane"
+	"istio.io/istio/operator/pkg/helm"
+	"istio.io/istio/operator/pkg/helmreconciler"
+	"istio.io/istio/operator/pkg/object"
+	"istio.io/istio/operator/pkg/translate"
+	"istio.io/istio/operator/pkg/util"
+	"istio.io/istio/operator/pkg/util/clog"
+	"istio.io/istio/pkg/test/env"
+)
+
+// cmdType is one of the commands used to generate and optionally apply a manifest.
+type cmdType int
+
+const (
+	// istioctl manifest generate
+	cmdGenerate cmdType = iota
+	// istioctl manifest apply or istioctl install
+	cmdApply
+	// in-cluster controller
+	cmdController
+)
+
+// chartSourceType defines where charts used in the test come from.
+type chartSourceType int
+
+const (
+	// Snapshot charts are in testdata/manifest-generate/data-snapshot
+	snapshotCharts chartSourceType = iota
+	// Compiled in charts come from assets.gen.go
+	compiledInCharts
+	// Live charts come from manifests/
+	liveCharts
+)
+
+const (
+	istioTestVersion = "istio-1.5.0"
+	testTGZFilename  = istioTestVersion + "-linux.tar.gz"
+	testDataSubdir   = "cmd/mesh/testdata/manifest-generate"
 )
 
 // Golden output files add a lot of noise to pull requests. Use a unique suffix so
@@ -29,6 +85,9 @@ const (
 )
 
 var (
+	// By default, tests only run with manifest generate, since it doesn't require any external fake test environment.
+	testedManifestCmds = []cmdType{cmdGenerate}
+
 	// All below paths are dynamically derived and absolute.
 
 	// Path to the operator root dir.
@@ -41,8 +100,226 @@ var (
 	liveReleaseDir string
 	// Path to the operator install base dir in the live release.
 	liveInstallPackageDir string
+
+	// Only used if kubebuilder is installed.
+	testenv               *envtest.Environment
+	testClient            client.Client
+	testReconcileOperator *istiocontrolplane.ReconcileIstioOperator
+
+	allNamespacedGVKs = []schema.GroupVersionKind{
+		{Group: "autoscaling", Version: "v2beta1", Kind: "HorizontalPodAutoscaler"},
+		{Group: "policy", Version: "v1beta1", Kind: "PodDisruptionBudget"},
+		{Group: "apps", Version: "v1", Kind: "Deployment"},
+		{Group: "apps", Version: "v1", Kind: "DaemonSet"},
+		{Group: "", Version: "v1", Kind: "Service"},
+		{Group: "", Version: "v1", Kind: "ConfigMap"},
+		{Group: "", Version: "v1", Kind: "PersistentVolumeClaim"},
+		{Group: "", Version: "v1", Kind: "Pod"},
+		{Group: "", Version: "v1", Kind: "Secret"},
+		{Group: "", Version: "v1", Kind: "ServiceAccount"},
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "RoleBinding"},
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "Role"},
+		{Group: "networking.istio.io", Version: "v1alpha3", Kind: "DestinationRule"},
+		{Group: "networking.istio.io", Version: "v1alpha3", Kind: "EnvoyFilter"},
+		{Group: "networking.istio.io", Version: "v1alpha3", Kind: "Gateway"},
+		{Group: "networking.istio.io", Version: "v1alpha3", Kind: "VirtualService"},
+		{Group: "security.istio.io", Version: "v1beta1", Kind: "PeerAuthentication"},
+	}
+
+	// ordered by which types should be deleted, first to last
+	allClusterGVKs = []schema.GroupVersionKind{
+		{Group: "admissionregistration.k8s.io", Version: "v1beta1", Kind: "MutatingWebhookConfiguration"},
+		{Group: "admissionregistration.k8s.io", Version: "v1beta1", Kind: "ValidatingWebhookConfiguration"},
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRole"},
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "ClusterRoleBinding"},
+		{Group: "apiextensions.k8s.io", Version: "v1beta1", Kind: "CustomResourceDefinition"},
+	}
 )
 
+// TestMain is required to create a local release package in /tmp from manifests and operator/data in the format that
+// istioctl expects. It also brings up and tears down the kubebuilder test environment if it is installed.
+func TestMain(m *testing.M) {
+	var err error
+
+	// If kubebuilder is installed, use that test env for apply and controller testing.
+	if kubeBuilderInstalled() {
+		testenv = &envtest.Environment{}
+		testRestConfig, err = testenv.Start()
+		checkExit(err)
+
+		testK8Interface, err = kubernetes.NewForConfig(testRestConfig)
+		checkExit(err)
+		testClient, err = client.New(testRestConfig, client.Options{Scheme: scheme.Scheme})
+		checkExit(err)
+		// TestMode is required to not wait in the go client for resources that will never be created in the test server.
+		helmreconciler.TestMode = true
+		testReconcileOperator = istiocontrolplane.NewReconcileIstioOperator(testClient, testRestConfig, scheme.Scheme)
+
+		// Add manifest apply and controller to the list of commands to run tests against.
+		// XXX TEST
+		// testedManifestCmds = append(testedManifestCmds, cmdApply, cmdController)
+		testedManifestCmds = []cmdType{cmdController}
+	}
+	defer func() {
+		if kubeBuilderInstalled() {
+			testenv.Stop()
+		}
+	}()
+
+	operatorRootDir = filepath.Join(env.IstioSrc, "operator")
+	manifestsDir = filepath.Join(operatorRootDir, "manifests")
+	liveReleaseDir, err = createLocalReleaseCharts()
+	defer os.RemoveAll(liveReleaseDir)
+	checkExit(err)
+	liveInstallPackageDir = filepath.Join(liveReleaseDir, istioTestVersion, helm.OperatorSubdirFilePath)
+	snapshotInstallPackageDir = filepath.Join(operatorRootDir, testDataSubdir, "data-snapshot")
+
+	flag.Parse()
+	code := m.Run()
+	os.Exit(code)
+}
+
+// createLocalReleaseCharts creates local release charts using the create_release_charts.sh script and returns a path
+// to the resulting dir.
+func createLocalReleaseCharts() (string, error) {
+	releaseDir, err := ioutil.TempDir(os.TempDir(), "istio-test-release-*")
+	if err != nil {
+		return "", err
+	}
+	releaseSubDir := filepath.Join(releaseDir, istioTestVersion, helm.OperatorSubdirFilePath)
+	cmd := exec.Command("../../scripts/create_release_charts.sh", "-o", releaseSubDir)
+	if stdo, err := cmd.Output(); err != nil {
+		return "", fmt.Errorf("%s: \n%s", err, string(stdo))
+	}
+	return releaseDir, nil
+}
+
+// runManifestCommands runs all given commands with the given input IOP file, flags and chartSource. It returns
+// an objectSet for each cmd type.
+func runManifestCommands(inFile, flags string, chartSource chartSourceType) (map[cmdType]*objectSet, error) {
+	out := make(map[cmdType]*objectSet)
+	for _, cmd := range testedManifestCmds {
+		switch cmd {
+		case cmdGenerate:
+			m, _, err := generateManifest(inFile, flags, chartSource)
+			if err != nil {
+				return nil, err
+			}
+			out[cmdGenerate], err = parseObjectSetFromManifest(m)
+			if err != nil {
+				return nil, err
+			}
+
+		case cmdApply:
+			objs, err := fakeApplyManifest(inFile, flags, chartSource)
+			if err != nil {
+				return nil, err
+			}
+			out[cmdApply] = NewObjectSet(objs)
+		case cmdController:
+			objs, err := fakeControllerReconcile(inFile, chartSource)
+			if err != nil {
+				return nil, err
+			}
+			out[cmdController] = NewObjectSet(objs)
+		default:
+		}
+	}
+
+	return out, nil
+}
+
+// fakeApplyManifest runs manifest apply. It is assumed that
+func fakeApplyManifest(inFile, flags string, chartSource chartSourceType) (object.K8sObjects, error) {
+	inPath := filepath.Join(operatorRootDir, "cmd/mesh/testdata/manifest-generate/input", inFile+".yaml")
+	manifest, err := runManifestCommand("apply", []string{inPath}, flags, chartSource)
+	if err != nil {
+		return nil, fmt.Errorf("error %s: %s", err, manifest)
+	}
+	return getAllIstioObjects()
+}
+
+func fakeControllerReconcile(inFile string, chartSource chartSourceType) (object.K8sObjects, error) {
+	l := clog.NewDefaultLogger()
+	inPath := filepath.Join(operatorRootDir, "cmd/mesh/testdata/manifest-generate/input", inFile+".yaml")
+
+	ysf, err := yamlFromSetFlags([]string{"installPackagePath=" + chartSourceInstallPackagePath(chartSource)}, true, l)
+	if err != nil {
+		return nil, err
+	}
+
+	_, iops, err := GenerateConfig([]string{inPath}, ysf, false, testRestConfig, l)
+	if err != nil {
+		return nil, err
+	}
+
+	crName := installedSpecCRPrefix
+	if iops.Revision != "" {
+		crName += "-" + iops.Revision
+	}
+	iop, err := translate.IOPStoIOP(iops, crName, v1alpha1.Namespace(iops))
+	if err != nil {
+		return nil, err
+	}
+	iop.Spec.InstallPackagePath = chartSourceInstallPackagePath(chartSource)
+
+	if err := createNamespace(testK8Interface, iop.Namespace); err != nil {
+		return nil, err
+	}
+
+	reconciler, err := helmreconciler.NewHelmReconciler(testClient, testRestConfig, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := removeAllIstioResourcesFromServer(reconciler); err != nil {
+		return nil, err
+	}
+
+	iopStr, err := util.MarshalWithJSONPB(iop)
+	if err != nil {
+		return nil, err
+	}
+	if err := saveIOPToCluster(reconciler, iopStr); err != nil {
+		return nil, err
+	}
+
+	req := reconcile.Request{}
+	req.Namespace = iop.Namespace
+	if _, err = testReconcileOperator.Reconcile(req); err != nil {
+		return nil, err
+	}
+	return getAllIstioObjects()
+}
+
+// runManifestCommand runs the given manifest command. If filenames is set, passes the given filenames as -f flag,
+// flags is passed to the command verbatim. If you set both flags and path, make sure to not use -f in flags.
+func runManifestCommand(command string, filenames []string, flags string, chartSource chartSourceType) (string, error) {
+	args := "manifest " + command
+	for _, f := range filenames {
+		args += " -f " + f
+	}
+	if flags != "" {
+		args += " " + flags
+	}
+	args += " --set installPackagePath=" + chartSourceInstallPackagePath(chartSource)
+	return runCommand(args)
+}
+
+// chartSourceInstallPackagePath returns the install path for the given chart source.
+func chartSourceInstallPackagePath(chartSource chartSourceType) string {
+	out := ""
+	switch chartSource {
+	case snapshotCharts:
+		out = filepath.Join(testDataDir, "data-snapshot")
+	case liveCharts:
+		out = liveInstallPackageDir
+	case compiledInCharts:
+	default:
+	}
+	return out
+}
+
+// runCommand runs the given command string.
 func runCommand(command string) (string, error) {
 	var out bytes.Buffer
 	rootCmd := GetRootCmd(strings.Split(command, " "))
@@ -52,6 +329,30 @@ func runCommand(command string) (string, error) {
 	return out.String(), err
 }
 
+func removeAllIstioResourcesFromServer(reconciler *helmreconciler.HelmReconciler) error {
+	// Needed in case we are running a test through this path that doesn't start a new process.
+	cache.FlushObjectCaches()
+	return reconciler.DeleteAll()
+}
+
+// getAllIstioObjects lists all Istio GVK resources from the testClient.
+func getAllIstioObjects() (object.K8sObjects, error) {
+	var out object.K8sObjects
+	for _, gvk := range append(allClusterGVKs, allNamespacedGVKs...) {
+		objects := &unstructured.UnstructuredList{}
+		objects.SetGroupVersionKind(gvk)
+		if err := testClient.List(context.TODO(), objects); err != nil {
+			return nil, err
+		}
+		for _, o := range objects.Items {
+			no := o.DeepCopy()
+			out = append(out, object.NewK8sObject(no, nil, nil))
+		}
+	}
+	return out, nil
+}
+
+// readFile reads a file and returns the contents.
 func readFile(path string) (string, error) {
 	b, err := ioutil.ReadFile(path)
 	return string(b), err

--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
@@ -138,6 +138,15 @@ var (
 	}
 )
 
+// NewReconcileIstioOperator creates a new ReconcileIstioOperator and returns a ptr to it.
+func NewReconcileIstioOperator(client client.Client, config *rest.Config, scheme *runtime.Scheme) *ReconcileIstioOperator {
+	return &ReconcileIstioOperator{
+		client: client,
+		config: config,
+		scheme: scheme,
+	}
+}
+
 // ReconcileIstioOperator reconciles a IstioOperator object
 type ReconcileIstioOperator struct {
 	// This client, initialized using mgr.Client() above, is a split client

--- a/operator/pkg/helmreconciler/common.go
+++ b/operator/pkg/helmreconciler/common.go
@@ -40,6 +40,9 @@ const (
 )
 
 var (
+	// TestMode sets the controller into test mode. Used for unit tests to bypass things like waiting on resources.
+	TestMode = false
+
 	scope = log.RegisterScope("installer", "installer", 0)
 )
 

--- a/operator/pkg/helmreconciler/reconciler.go
+++ b/operator/pkg/helmreconciler/reconciler.go
@@ -187,6 +187,15 @@ func (h *HelmReconciler) Delete() error {
 	return h.Prune(manifestMap)
 }
 
+// DeleteAll deletes all Istio resources in the cluster.
+func (h *HelmReconciler) DeleteAll() error {
+	manifestMap := name.ManifestMap{}
+	for _, c := range name.AllComponentNames {
+		manifestMap[c] = nil
+	}
+	return h.Prune(manifestMap)
+}
+
 // SetStatusBegin updates the status field on the IstioOperator instance before reconciling.
 func (h *HelmReconciler) SetStatusBegin() error {
 	isop := &valuesv1alpha1.IstioOperator{}

--- a/operator/pkg/helmreconciler/wait.go
+++ b/operator/pkg/helmreconciler/wait.go
@@ -55,7 +55,7 @@ type deployment struct {
 // until all are ready or a timeout is reached
 func WaitForResources(objects object.K8sObjects, restConfig *rest.Config, cs kubernetes.Interface,
 	waitTimeout time.Duration, dryRun bool, l *util.ManifestLog) error {
-	if dryRun {
+	if dryRun || TestMode {
 		return nil
 	}
 

--- a/operator/pkg/name/name.go
+++ b/operator/pkg/name/name.go
@@ -99,6 +99,11 @@ var (
 		CNIComponentName,
 	}
 	allComponentNamesMap = make(map[ComponentName]bool)
+
+	// AllComponentNames is a list of all Istio components.
+	AllComponentNames = append(AllCoreComponentNames, IngressComponentName, EgressComponentName, AddonComponentName,
+		IstioOperatorComponentName, IstioOperatorCustomResourceName)
+
 	// DeprecatedComponentNamesMap defines the names of deprecated istio core components used in old versions,
 	// which would not appear as standalone components in current version. This is used for pruning, and alerting
 	// users to the fact that the components are deprecated.


### PR DESCRIPTION
Looking for some early high level feedback on this, not a detailed review yet. 
The idea here is to use a lightweight kubebuilder test env as a fake API server, which will let us run manifest apply and the controller reconcile loop against an input IOP and get back a set of resources from the cluster. These come back to the tests in the same format as the parsed output of manifest generate, so the same tests can be run against all three install paths. 