### PR TITLE
Integration test for ProxyStatus and Experimental AuthZ Check

### DIFF
--- a/istioctl/pkg/util/configdump/cluster.go
+++ b/istioctl/pkg/util/configdump/cluster.go
@@ -29,6 +29,10 @@ func (w *Wrapper) GetDynamicClusterDump(stripVersions bool) (*adminapi.ClustersC
 		return nil, err
 	}
 	dac := clusterDump.GetDynamicActiveClusters()
+	// Allow sorting to work even if we don't have the exact same type
+	for i := range dac {
+		dac[i].Cluster.TypeUrl = "type.googleapis.com/envoy.api.v2.Cluster"
+	}
 	sort.Slice(dac, func(i, j int) bool {
 		cluster := &xdsapi.Cluster{}
 		err = ptypes.UnmarshalAny(dac[i].Cluster, cluster)

--- a/tests/integration/istioctl/testdata/authz-a.yaml
+++ b/tests/integration/istioctl/testdata/authz-a.yaml
@@ -1,0 +1,15 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+ name: integ-test
+spec:
+ rules:
+ - from:
+   - source:
+       principals: ["cluster.local/ns/default/sa/sleep"]
+   to:
+   - operation:
+       methods: ["GET"]
+   when:
+   - key: request.headers[version]
+     values: ["v1", "v2"]

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -289,3 +289,79 @@ func jsonUnmarshallOrFail(t *testing.T, context, s string) interface{} {
 	}
 	return val
 }
+
+func TestProxyStatus(t *testing.T) {
+	framework.NewTest(t).
+		RequiresEnvironment(environment.Kube).
+		Run(func(ctx framework.TestContext) {
+			ns := namespace.NewOrFail(ctx, ctx, namespace.Config{
+				Prefix: "istioctl-ps",
+				Inject: true,
+			})
+
+			var a echo.Instance
+			echoboot.NewBuilderOrFail(ctx, ctx).
+				With(&a, echoConfig(ns, "a")).
+				BuildOrFail(ctx)
+
+			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+
+			podID, err := getPodID(a)
+			if err != nil {
+				ctx.Fatalf("Could not get Pod ID: %v", err)
+			}
+
+			var output string
+			var args []string
+			g := gomega.NewGomegaWithT(t)
+
+			// Ignore --namespace=dummy, we use fully qualified <pod>.<ns>
+			args = []string{"proxy-status"}
+			output, _ = istioCtl.InvokeOrFail(t, args)
+			// Just verify pod A is known to Pilot; implicitly this verifies that
+			// the printing code printed it.
+			g.Expect(output).To(gomega.ContainSubstring(fmt.Sprintf("%s.%s", podID, ns.Name())))
+
+			args = []string{"--namespace=dummy",
+				"proxy-status", fmt.Sprintf("%s.%s", podID, ns.Name())}
+			output, _ = istioCtl.InvokeOrFail(t, args)
+			g.Expect(output).To(gomega.ContainSubstring("Clusters Match"))
+			g.Expect(output).To(gomega.ContainSubstring("Listeners Match"))
+			g.Expect(output).To(gomega.ContainSubstring("Routes Match"))
+		})
+}
+
+func TestAuthZCheck(t *testing.T) {
+	framework.NewTest(t).
+		RequiresEnvironment(environment.Kube).
+		Run(func(ctx framework.TestContext) {
+			ns := namespace.NewOrFail(ctx, ctx, namespace.Config{
+				Prefix: "istioctl-authz",
+				Inject: true,
+			})
+
+			var a echo.Instance
+			echoboot.NewBuilderOrFail(ctx, ctx).
+				With(&a, echoConfig(ns, "a")).
+				BuildOrFail(ctx)
+
+			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+
+			podID, err := getPodID(a)
+			if err != nil {
+				ctx.Fatalf("Could not get Pod ID: %v", err)
+			}
+
+			var output string
+			var args []string
+			g := gomega.NewGomegaWithT(t)
+
+			// Ignore --namespace=dummy, we use fully qualified <pod>.<ns>
+			args = []string{"experimental", "authz", "check",
+				fmt.Sprintf("%s.%s", podID, ns.Name())}
+			output, _ = istioCtl.InvokeOrFail(t, args)
+			// Just verify pod A is known to Pilot; implicitly this verifies that
+			// the printing code printed it.
+			g.Expect(output).To(gomega.ContainSubstring("0.0.0.0_80"))
+		})
+}

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -340,7 +340,7 @@ func TestAuthZCheck(t *testing.T) {
 			})
 
 			authPol := file.AsStringOrFail(t, "../istioctl/testdata/authz-a.yaml")
-			g.ApplyConfigOrFail(t, ns, authPol)
+			ctx.ApplyConfigOrFail(t, ns.Name(), authPol)
 
 			var a echo.Instance
 			echoboot.NewBuilderOrFail(ctx, ctx).


### PR DESCRIPTION
Part one of the fix for https://github.com/istio/istio/issues/23042

Once the istioctl subcommands that query Envoy are tested during integration we will remove the static unit tests for those subcommands.

cc @howardjohn 