### PR TITLE
Add memberlist secret for metallb

### DIFF
--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -273,7 +273,7 @@ function install_metallb() {
   KUBECONFIG="${1}"
   kubectl apply --kubeconfig="$KUBECONFIG" -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/namespace.yaml
   kubectl apply --kubeconfig="$KUBECONFIG" -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/metallb.yaml
-  kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
+  kubectl create --kubeconfig="$KUBECONFIG" secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
 
   if [ -z "${METALLB_IPS[*]}" ]; then
     # Take IPs from the end of the docker bridge network subnet to use for MetalLB IPs

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -273,6 +273,7 @@ function install_metallb() {
   KUBECONFIG="${1}"
   kubectl apply --kubeconfig="$KUBECONFIG" -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/namespace.yaml
   kubectl apply --kubeconfig="$KUBECONFIG" -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/metallb.yaml
+  kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
 
   if [ -z "${METALLB_IPS[*]}" ]; then
     # Take IPs from the end of the docker bridge network subnet to use for MetalLB IPs


### PR DESCRIPTION
Without this, the pod never starts. The test seems to pass though, so
not sure what exactly this is needed for. This matches the instructions
on https://metallb.universe.tf/installation/ though. If we don't want
it, we should probably remove the deployment that is depending on this