### PR TITLE
Don't complain about both injection labels, and don't validate namesp…

### DIFF
--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -173,8 +173,6 @@ var testGrid = []testCase{
 		expected: []message{
 			{msg.NamespaceNotInjected, "Namespace bar"},
 			{msg.PodMissingProxy, "Pod noninjectedpod.default"},
-			{msg.NamespaceMultipleInjectionLabels, "Namespace busted"},
-			{msg.NamespaceInvalidInjectorRevision, "Namespace pidgeon-test"},
 		},
 	},
 	{

--- a/galley/pkg/config/analysis/analyzers/injection/injection.go
+++ b/galley/pkg/config/analysis/analyzers/injection/injection.go
@@ -26,7 +26,6 @@ import (
 	"istio.io/istio/galley/pkg/config/analysis"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/util"
 	"istio.io/istio/galley/pkg/config/analysis/msg"
-	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/resource"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
@@ -118,19 +117,4 @@ func (a *Analyzer) Analyze(c analysis.Context) {
 
 		return true
 	})
-}
-
-func isControlPlane(pod *v1.Pod) bool {
-	if pod.GetNamespace() != constants.IstioSystemNamespace {
-		return false
-	}
-
-	// Control plane typically has labels like this:
-	// app: istiod
-	// istio: pilot
-	// istio.io/rev: canary
-	// For the namespace analyzer we consider any istio-system pod with `app: istiod`
-	// as being a control plane.
-	app := pod.GetLabels()["app"]
-	return app == "istiod"
 }

--- a/galley/pkg/config/analysis/analyzers/testdata/injection.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/injection.yaml
@@ -31,23 +31,6 @@ metadata:
     istio.io/rev: canary
   name: canary-test
 ---
-# Namespace is explicitly enabled in the new style, but refers to a non-existant control plane
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    istio.io/rev: pidgeon
-  name: pidgeon-test
----
-# Namespace has both old and new labels
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: busted
-  labels:
-    istio-injection: enabled
-    istio.io/rev: canary
----
 # Pod that's injected. No warning
 apiVersion: v1
 kind: Pod

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -105,14 +105,6 @@ var (
 	// Description: Invalid Regex
 	InvalidRegexp = diag.NewMessageType(diag.Warning, "IST0122", "Field %q regular expression invalid: %q (%s)")
 
-	// NamespaceMultipleInjectionLabels defines a diag.MessageType for message "NamespaceMultipleInjectionLabels".
-	// Description: A namespace has both new and legacy injection labels
-	NamespaceMultipleInjectionLabels = diag.NewMessageType(diag.Warning, "IST0123", "The namespace has both new and legacy injection labels. Run 'kubectl label namespace %s istio.io/rev-' or 'kubectl label namespace %s istio-injection-'")
-
-	// NamespaceInvalidInjectorRevision defines a diag.MessageType for message "NamespaceInvalidInjectorRevision".
-	// Description: A namespace is labeled to inject from unknown control plane.
-	NamespaceInvalidInjectorRevision = diag.NewMessageType(diag.Warning, "IST0124", "The namespace is labeled to inject from %q but that namespace doesn't exist. Run 'kubectl label namespace %s istio.io/rev=<revision>' where <revision> is one of %s")
-
 	// InvalidAnnotation defines a diag.MessageType for message "InvalidAnnotation".
 	// Description: An Istio annotation that is not valid
 	InvalidAnnotation = diag.NewMessageType(diag.Warning, "IST0125", "Invalid annotation %s: %s")
@@ -145,8 +137,6 @@ func All() []*diag.MessageType {
 		PolicyResourceIsDeprecated,
 		MeshPolicyResourceIsDeprecated,
 		InvalidRegexp,
-		NamespaceMultipleInjectionLabels,
-		NamespaceInvalidInjectorRevision,
 		InvalidAnnotation,
 	}
 }
@@ -385,27 +375,6 @@ func NewInvalidRegexp(r *resource.Instance, where string, re string, problem str
 		where,
 		re,
 		problem,
-	)
-}
-
-// NewNamespaceMultipleInjectionLabels returns a new diag.Message based on NamespaceMultipleInjectionLabels.
-func NewNamespaceMultipleInjectionLabels(r *resource.Instance, namespace string, namespace2 string) diag.Message {
-	return diag.NewMessage(
-		NamespaceMultipleInjectionLabels,
-		r,
-		namespace,
-		namespace2,
-	)
-}
-
-// NewNamespaceInvalidInjectorRevision returns a new diag.Message based on NamespaceInvalidInjectorRevision.
-func NewNamespaceInvalidInjectorRevision(r *resource.Instance, unknownrevision string, namespace string, revisions string) diag.Message {
-	return diag.NewMessage(
-		NamespaceInvalidInjectorRevision,
-		r,
-		unknownrevision,
-		namespace,
-		revisions,
 	)
 }
 

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -256,30 +256,6 @@ messages:
       - name: problem
         type: string
 
-  - name: "NamespaceMultipleInjectionLabels"
-    code: IST0123
-    level: Warning
-    description: "A namespace has both new and legacy injection labels"
-    template: "The namespace has both new and legacy injection labels. Run 'kubectl label namespace %s istio.io/rev-' or 'kubectl label namespace %s istio-injection-'"
-    args:
-      - name: namespace
-        type: string
-      - name: namespace2
-        type: string
-
-  - name: "NamespaceInvalidInjectorRevision"
-    code: IST0124
-    level: Warning
-    description: "A namespace is labeled to inject from unknown control plane."
-    template: "The namespace is labeled to inject from %q but that namespace doesn't exist. Run 'kubectl label namespace %s istio.io/rev=<revision>' where <revision> is one of %s"
-    args:
-      - name: unknownrevision
-        type: string
-      - name: namespace
-        type: string
-      - name: revisions
-        type: string
-
   - name: "InvalidAnnotation"
     code: IST0125
     level: Warning


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/23319

This removes the two new error messages added by https://github.com/istio/istio/pull/22755

For 1.6, we will allow either the `istio-injection: enabled` OR the `istio.io/rev=default` label to signal injection so we no longer need both messages.  This behavior comes from https://github.com/istio/istio/pull/23342

For the future, in a multi-tenant situation or with multi-mesh single control plane, one K8s cluster may not have both control plane and workload.  Thus we may not know all valid values for the istio.io/rev label on a namespace.  Thus we cannot warn if the user uses that label with a value we don't recognize.  By removing this message we also make the revision labels less user-facing which should please Costin.

cc @howardjohn 