### PR TITLE
Replace kubectl exec for contacting Pilot in istioctl

### DIFF
--- a/istioctl/cmd/metrics_test.go
+++ b/istioctl/cmd/metrics_test.go
@@ -110,18 +110,13 @@ func mockPortForwardClientAuthPrometheus(_, _ string, _ clioptions.ControlPlaneO
 }
 
 // nolint: unparam
-func (client mockPortForwardConfig) AllPilotsDiscoveryDo(pilotNamespace, method, path string, body []byte) (map[string][]byte, error) {
+func (client mockPortForwardConfig) AllPilotsDiscoveryDo(pilotNamespace, path string) (map[string][]byte, error) {
 	return nil, fmt.Errorf("mockPortForwardConfig doesn't mock Pilot discovery")
 }
 
 // nolint: unparam
 func (client mockPortForwardConfig) EnvoyDo(podName, podNamespace, method, path string, body []byte) ([]byte, error) {
 	return nil, fmt.Errorf("mockPortForwardConfig doesn't mock Envoy")
-}
-
-// nolint: unparam
-func (client mockPortForwardConfig) PilotDiscoveryDo(pilotNamespace, method, path string, body []byte) ([]byte, error) {
-	return nil, fmt.Errorf("mockPortForwardConfig doesn't mock Pilot discovery")
 }
 
 func (client mockPortForwardConfig) GetIstioVersions(namespace string) (*version.MeshInfo, error) {

--- a/istioctl/cmd/proxyconfig_test.go
+++ b/istioctl/cmd/proxyconfig_test.go
@@ -320,7 +320,7 @@ func mockEnvoyClientFactoryGenerator(testResults map[string][]byte) func(kubecon
 }
 
 // nolint: unparam
-func (client mockExecConfig) AllPilotsDiscoveryDo(pilotNamespace, method, path string, body []byte) (map[string][]byte, error) {
+func (client mockExecConfig) AllPilotsDiscoveryDo(pilotNamespace, path string) (map[string][]byte, error) {
 	return client.results, nil
 }
 
@@ -331,14 +331,6 @@ func (client mockExecConfig) EnvoyDo(podName, podNamespace, method, path string,
 		return nil, fmt.Errorf("unable to retrieve Pod: pods %q not found", podName)
 	}
 	return results, nil
-}
-
-// nolint: unparam
-func (client mockExecConfig) PilotDiscoveryDo(pilotNamespace, method, path string, body []byte) ([]byte, error) {
-	for _, results := range client.results {
-		return results, nil
-	}
-	return nil, fmt.Errorf("unable to find any Pilot instances")
 }
 
 func (client mockExecConfig) GetIstioVersions(namespace string) (*version.MeshInfo, error) {

--- a/istioctl/cmd/proxystatus.go
+++ b/istioctl/cmd/proxystatus.go
@@ -75,7 +75,7 @@ Retrieves last sent and last acknowledged xDS sync from Pilot to each Envoy in t
 				}
 
 				path = fmt.Sprintf("/debug/config_dump?proxyID=%s.%s", podName, ns)
-				pilotDumps, err := kubeClient.AllPilotsDiscoveryDo(istioNamespace, "GET", path, nil)
+				pilotDumps, err := kubeClient.AllPilotsDiscoveryDo(istioNamespace, path)
 				if err != nil {
 					return err
 				}
@@ -85,7 +85,7 @@ Retrieves last sent and last acknowledged xDS sync from Pilot to each Envoy in t
 				}
 				return c.Diff()
 			}
-			statuses, err := kubeClient.AllPilotsDiscoveryDo(istioNamespace, "GET", "/debug/syncz", nil)
+			statuses, err := kubeClient.AllPilotsDiscoveryDo(istioNamespace, "/debug/syncz")
 			if err != nil {
 				return err
 			}

--- a/istioctl/cmd/version.go
+++ b/istioctl/cmd/version.go
@@ -98,7 +98,7 @@ func getProxyInfo(opts *clioptions.ControlPlaneOptions) (*[]istioVersion.ProxyIn
 	}
 
 	// Ask Pilot for the Envoy sidecar sync status, which includes the sidecar version info
-	allSyncz, err := kubeClient.AllPilotsDiscoveryDo(istioNamespace, "GET", "/debug/syncz", nil)
+	allSyncz, err := kubeClient.AllPilotsDiscoveryDo(istioNamespace, "/debug/syncz")
 	if err != nil {
 		return nil, err
 	}

--- a/istioctl/cmd/version_test.go
+++ b/istioctl/cmd/version_test.go
@@ -76,15 +76,11 @@ func TestVersion(t *testing.T) {
 type mockExecVersionConfig struct {
 }
 
-func (client mockExecVersionConfig) AllPilotsDiscoveryDo(pilotNamespace, method, path string, body []byte) (map[string][]byte, error) {
+func (client mockExecVersionConfig) AllPilotsDiscoveryDo(pilotNamespace, path string) (map[string][]byte, error) {
 	return nil, nil
 }
 
 func (client mockExecVersionConfig) EnvoyDo(podName, podNamespace, method, path string, body []byte) ([]byte, error) {
-	return nil, nil
-}
-
-func (client mockExecVersionConfig) PilotDiscoveryDo(pilotNamespace, method, path string, body []byte) ([]byte, error) {
 	return nil, nil
 }
 

--- a/istioctl/cmd/wait.go
+++ b/istioctl/cmd/wait.go
@@ -181,7 +181,7 @@ func poll(acceptedVersions []string, targetResource string, opts clioptions.Cont
 		return 0, 0, err
 	}
 	path := fmt.Sprintf("/debug/config_distribution?resource=%s", targetResource)
-	pilotResponses, err := kubeClient.AllPilotsDiscoveryDo(istioNamespace, "GET", path, nil)
+	pilotResponses, err := kubeClient.AllPilotsDiscoveryDo(istioNamespace, path)
 	if err != nil {
 		return 0, 0, fmt.Errorf("unable to query pilot for distribution "+
 			"(are you using pilot version >= 1.4 with config distribution tracking on): %s", err)

--- a/istioctl/pkg/kubernetes/client.go
+++ b/istioctl/pkg/kubernetes/client.go
@@ -148,12 +148,12 @@ func (client *Client) PodExec(podName, podNamespace, container string, command [
 
 // ProxyGet returns a response of the pod by calling it through the proxy.
 // Not a part of client-go https://github.com/kubernetes/kubernetes/issues/90768
-func (client *Client) proxyGet(name, namespace, path string) restclient.ResponseWrapper {
+func (client *Client) proxyGet(name, namespace, path string, port int) restclient.ResponseWrapper {
 	request := client.RESTClient.Get().
 		Namespace(namespace).
 		Resource("pods").
 		SubResource("proxy").
-		Name(name).
+		Name(fmt.Sprintf("%s:%d", name, port)).
 		Suffix(path)
 	return request
 }
@@ -172,7 +172,7 @@ func (client *Client) AllPilotsDiscoveryDo(pilotNamespace, path string) (map[str
 	}
 	result := map[string][]byte{}
 	for _, pilot := range pilots {
-		res, err := client.proxyGet(pilot.Name, pilot.Namespace, path).DoRaw(context.Background())
+		res, err := client.proxyGet(pilot.Name, pilot.Namespace, path, 8080).DoRaw(context.Background())
 		if err != nil {
 			return nil, err
 		}

--- a/istioctl/pkg/kubernetes/client.go
+++ b/istioctl/pkg/kubernetes/client.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/client-go/transport/spdy"
@@ -46,10 +45,8 @@ import (
 )
 
 var (
-	proxyContainer     = "istio-proxy"
-	discoveryContainer = "discovery"
-	pilotDiscoveryPath = "/usr/local/bin/pilot-discovery"
-	pilotAgentPath     = "/usr/local/bin/pilot-agent"
+	proxyContainer = "istio-proxy"
+	pilotAgentPath = "/usr/local/bin/pilot-agent"
 )
 
 // Client is a helper wrapper around the Kube RESTClient for istioctl -> Pilot/Envoy/Mesh related things
@@ -148,7 +145,7 @@ func (client *Client) PodExec(podName, podNamespace, container string, command [
 
 // ProxyGet returns a response of the pod by calling it through the proxy.
 // Not a part of client-go https://github.com/kubernetes/kubernetes/issues/90768
-func (client *Client) proxyGet(name, namespace, path string, port int) restclient.ResponseWrapper {
+func (client *Client) proxyGet(name, namespace, path string, port int) rest.ResponseWrapper {
 	request := client.RESTClient.Get().
 		Namespace(namespace).
 		Resource("pods").


### PR DESCRIPTION
This drops privledges required to run istioctl commands. Additionally,
its much faster - proxy-status with 20 Istiod instances took 2s with
this change and 13s from master.