### PR TITLE
test framework: began removal of Galley component

### DIFF
--- a/pkg/test/framework/components/echo/docker/instance.go
+++ b/pkg/test/framework/components/echo/docker/instance.go
@@ -101,9 +101,7 @@ func newInstance(ctx resource.Context, cfg echo.Config) (out *instance, err erro
 	if cfg.Pilot == nil {
 		return nil, errors.New("pilot must be provided")
 	}
-	if cfg.Cluster == nil {
-		cfg.Cluster = native.ClusterOrDefault(cfg.Cluster, ctx.Environment())
-	}
+	cfg.Cluster = native.ClusterOrDefault(cfg.Cluster, ctx.Environment())
 
 	w, err := newWorkload(e, cfg, dumpDir)
 	if err != nil {

--- a/pkg/test/framework/components/echo/docker/instance.go
+++ b/pkg/test/framework/components/echo/docker/instance.go
@@ -98,11 +98,6 @@ func newInstance(ctx resource.Context, cfg echo.Config) (out *instance, err erro
 	}()
 
 	// Validate the configuration.
-	if cfg.Galley == nil {
-		// Galley is not actually required currently, but it will be once Pilot gets
-		// all resources from Galley. Requiring now for forward-compatibility.
-		return nil, errors.New("galley must be provided")
-	}
 	if cfg.Pilot == nil {
 		return nil, errors.New("pilot must be provided")
 	}
@@ -114,7 +109,7 @@ func newInstance(ctx resource.Context, cfg echo.Config) (out *instance, err erro
 	i.workloads = append(i.workloads, w)
 
 	// Apply the configuration for the service to Galley.
-	i.se, err = newServiceEntry(cfg.Galley, w.Address(), cfg)
+	i.se, err = newServiceEntry(w.Address(), cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/test/framework/components/echo/docker/instance.go
+++ b/pkg/test/framework/components/echo/docker/instance.go
@@ -101,6 +101,9 @@ func newInstance(ctx resource.Context, cfg echo.Config) (out *instance, err erro
 	if cfg.Pilot == nil {
 		return nil, errors.New("pilot must be provided")
 	}
+	if cfg.Cluster == nil {
+		cfg.Cluster = native.ClusterOrDefault(cfg.Cluster, ctx.Environment())
+	}
 
 	w, err := newWorkload(e, cfg, dumpDir)
 	if err != nil {

--- a/pkg/test/framework/components/echo/docker/service.go
+++ b/pkg/test/framework/components/echo/docker/service.go
@@ -19,7 +19,6 @@ import (
 	"text/template"
 	"time"
 
-	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/resource"
@@ -64,8 +63,6 @@ spec:
 
 var (
 	serviceEntryTemplate *template.Template
-
-	serviceEntryCollection = collections.IstioNetworkingV1Alpha3Serviceentries.Name().String()
 )
 
 func init() {

--- a/pkg/test/framework/components/echo/docker/service.go
+++ b/pkg/test/framework/components/echo/docker/service.go
@@ -78,7 +78,7 @@ func init() {
 type serviceEntry struct {
 	yaml string
 	ns   namespace.Instance
-	cfg resource.ConfigManager
+	cfg  resource.ConfigManager
 }
 
 func newServiceEntry(address string, cfg echo.Config) (out *serviceEntry, err error) {
@@ -90,7 +90,7 @@ func newServiceEntry(address string, cfg echo.Config) (out *serviceEntry, err er
 	}()
 
 	se := &serviceEntry{
-		ns: cfg.Namespace,
+		ns:  cfg.Namespace,
 		cfg: cfg.Cluster,
 	}
 
@@ -110,7 +110,6 @@ func newServiceEntry(address string, cfg echo.Config) (out *serviceEntry, err er
 			_ = se.Close()
 		}
 	}()
-
 
 	if err != nil {
 		return nil, err

--- a/pkg/test/framework/components/environment/kube/cluster.go
+++ b/pkg/test/framework/components/environment/kube/cluster.go
@@ -17,9 +17,14 @@ package kube
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/kube"
+	"istio.io/istio/pkg/test/scopes"
 )
 
 var _ resource.Cluster = Cluster{}
@@ -29,6 +34,78 @@ type Cluster struct {
 	*kube.Accessor
 	filename string
 	index    resource.ClusterIndex
+}
+
+func (c Cluster) ApplyConfig(ns string, yamlText ...string) error {
+	for _, y := range yamlText {
+		_, err := c.ApplyContents(ns, y)
+		if err != nil {
+			return fmt.Errorf("apply: %v", err)
+		}
+		scopes.Framework.Debugf("Applied config: ns: %s\n%s\n", ns, y)
+	}
+	return nil
+}
+
+func (c Cluster) ApplyConfigOrFail(t test.Failer, ns string, yamlText ...string) {
+	t.Helper()
+	err := c.ApplyConfig(ns, yamlText...)
+	if err != nil {
+		t.Fatalf("ApplyConfigOrFail: %v", err)
+	}
+}
+
+func (c Cluster) DeleteConfig(ns string, yamlText ...string) error {
+	for _, y := range yamlText {
+		err := c.DeleteContents(ns, y)
+		if err != nil {
+			return fmt.Errorf("apply: %v", err)
+		}
+		scopes.Framework.Debugf("Deleted config: ns: %s\n%s\n", ns, y)
+	}
+	return nil
+}
+
+func (c Cluster) DeleteConfigOrFail(t test.Failer, ns string, yamlText ...string) {
+	t.Helper()
+	err := c.DeleteConfig(ns, yamlText...)
+	if err != nil {
+		t.Fatalf("DeleteConfigOrFail: %v", err)
+	}
+}
+
+func (c Cluster) ApplyConfigDir(ns string, configDir string) error {
+	return filepath.Walk(configDir, func(path string, info os.FileInfo, err error) error {
+		if info.IsDir() {
+			return nil
+		}
+
+		scopes.Framework.Debugf("Reading config file to: %v", path)
+		contents, readerr := ioutil.ReadFile(path)
+		if readerr != nil {
+			return readerr
+		}
+
+		return c.ApplyConfig(ns, string(contents))
+	})
+}
+
+func (c Cluster) DeleteConfigDir(ns string, configDir string) error {
+	return filepath.Walk(configDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+
+		contents, readerr := ioutil.ReadFile(path)
+		if readerr != nil {
+			return readerr
+		}
+
+		return c.DeleteConfig(ns, string(contents))
+	})
 }
 
 func (c Cluster) String() string {

--- a/pkg/test/framework/components/environment/native/cluster.go
+++ b/pkg/test/framework/components/environment/native/cluster.go
@@ -149,3 +149,12 @@ func (c Cluster) Index() resource.ClusterIndex {
 	// Multicluster not supported natively.
 	return 0
 }
+
+// ClusterOrDefault gets the given cluster as a kube Cluster if available. Otherwise
+// defaults to the first Cluster in the Environment.
+func ClusterOrDefault(c resource.Cluster, e resource.Environment) resource.Cluster {
+	if c == nil {
+		return e.(*Environment).Cluster
+	}
+	return c.(Cluster)
+}

--- a/pkg/test/framework/components/environment/native/cluster.go
+++ b/pkg/test/framework/components/environment/native/cluster.go
@@ -15,7 +15,14 @@
 package native
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/scopes"
+	"istio.io/istio/pkg/test/util/yml"
 )
 
 var (
@@ -23,9 +30,121 @@ var (
 	Cluster = cluster{}
 )
 
-var _ resource.Cluster = cluster{}
+var _ resource.Cluster = &cluster{}
 
-type cluster struct{}
+type cluster struct {
+	// The folder that Galley reads to local, file-based configuration from
+	configDir string
+	cache     *yml.Cache
+}
+
+func NewCluster(ctx resource.Context) (resource.Cluster, error) {
+	configDir, err := ctx.CreateTmpDirectory("config")
+	if err != nil {
+		return cluster{}, err
+	}
+	c := cluster{
+		configDir: configDir,
+		cache:     yml.NewCache(configDir),
+	}
+	return c, nil
+}
+
+func (c cluster) GetConfigDir() string {
+	return c.configDir
+}
+
+func (c cluster) ApplyConfig(ns string, yamlText ...string) error {
+	for _, y := range yamlText {
+		y, err := yml.ApplyNamespace(y, ns)
+		if err != nil {
+			return err
+		}
+
+		if _, err = c.cache.Apply(y); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c cluster) ApplyConfigOrFail(t test.Failer, ns string, yamlText ...string) {
+	t.Helper()
+	err := c.ApplyConfig(ns, yamlText...)
+	if err != nil {
+		t.Fatalf("ApplyConfigOrFail: %v", err)
+	}
+}
+
+func (c cluster) DeleteConfig(ns string, yamlText ...string) error {
+	var err error
+	for _, y := range yamlText {
+		y, err = yml.ApplyNamespace(y, ns)
+		if err != nil {
+			return err
+		}
+
+		if err = c.cache.Delete(y); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c cluster) DeleteConfigOrFail(t test.Failer, ns string, yamlText ...string) {
+	t.Helper()
+	err := c.DeleteConfig(ns, yamlText...)
+	if err != nil {
+		t.Fatalf("DeleteConfigOrFail: %v", err)
+	}
+}
+
+func (c cluster) ApplyConfigDir(ns string, configDir string) error {
+	return filepath.Walk(configDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		targetPath := c.configDir + string(os.PathSeparator) + path[len(configDir):]
+		if info.IsDir() {
+			scopes.Framework.Debugf("Making dir: %v", targetPath)
+			return os.MkdirAll(targetPath, os.ModePerm)
+		}
+		scopes.Framework.Debugf("Copying file to: %v", targetPath)
+		contents, readerr := ioutil.ReadFile(path)
+		if readerr != nil {
+			return readerr
+		}
+
+		yamlText := string(contents)
+		yamlText, err = yml.ApplyNamespace(yamlText, ns)
+		if err != nil {
+			return err
+		}
+
+		_, err = c.cache.Apply(yamlText)
+		return err
+	})
+}
+
+func (c cluster) DeleteConfigDir(ns string, configDir string) error {
+	return filepath.Walk(configDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+
+		contents, readerr := ioutil.ReadFile(path)
+		if readerr != nil {
+			return readerr
+		}
+
+		return c.DeleteConfig(ns, string(contents))
+	})
+}
 
 func (c cluster) String() string {
 	return "nativeCluster"

--- a/pkg/test/framework/components/environment/native/cluster.go
+++ b/pkg/test/framework/components/environment/native/cluster.go
@@ -27,12 +27,12 @@ import (
 
 var (
 	// Cluster used for the native environment.
-	Cluster = cluster{}
+	DefaultCluster = Cluster{}
 )
 
-var _ resource.Cluster = &cluster{}
+var _ resource.Cluster = &Cluster{}
 
-type cluster struct {
+type Cluster struct {
 	// The folder that Galley reads to local, file-based configuration from
 	configDir string
 	cache     *yml.Cache
@@ -41,20 +41,20 @@ type cluster struct {
 func NewCluster(ctx resource.Context) (resource.Cluster, error) {
 	configDir, err := ctx.CreateTmpDirectory("config")
 	if err != nil {
-		return cluster{}, err
+		return Cluster{}, err
 	}
-	c := cluster{
+	c := Cluster{
 		configDir: configDir,
 		cache:     yml.NewCache(configDir),
 	}
 	return c, nil
 }
 
-func (c cluster) GetConfigDir() string {
+func (c Cluster) GetConfigDir() string {
 	return c.configDir
 }
 
-func (c cluster) ApplyConfig(ns string, yamlText ...string) error {
+func (c Cluster) ApplyConfig(ns string, yamlText ...string) error {
 	for _, y := range yamlText {
 		y, err := yml.ApplyNamespace(y, ns)
 		if err != nil {
@@ -68,7 +68,7 @@ func (c cluster) ApplyConfig(ns string, yamlText ...string) error {
 	return nil
 }
 
-func (c cluster) ApplyConfigOrFail(t test.Failer, ns string, yamlText ...string) {
+func (c Cluster) ApplyConfigOrFail(t test.Failer, ns string, yamlText ...string) {
 	t.Helper()
 	err := c.ApplyConfig(ns, yamlText...)
 	if err != nil {
@@ -76,7 +76,7 @@ func (c cluster) ApplyConfigOrFail(t test.Failer, ns string, yamlText ...string)
 	}
 }
 
-func (c cluster) DeleteConfig(ns string, yamlText ...string) error {
+func (c Cluster) DeleteConfig(ns string, yamlText ...string) error {
 	var err error
 	for _, y := range yamlText {
 		y, err = yml.ApplyNamespace(y, ns)
@@ -92,7 +92,7 @@ func (c cluster) DeleteConfig(ns string, yamlText ...string) error {
 	return nil
 }
 
-func (c cluster) DeleteConfigOrFail(t test.Failer, ns string, yamlText ...string) {
+func (c Cluster) DeleteConfigOrFail(t test.Failer, ns string, yamlText ...string) {
 	t.Helper()
 	err := c.DeleteConfig(ns, yamlText...)
 	if err != nil {
@@ -100,7 +100,7 @@ func (c cluster) DeleteConfigOrFail(t test.Failer, ns string, yamlText ...string
 	}
 }
 
-func (c cluster) ApplyConfigDir(ns string, configDir string) error {
+func (c Cluster) ApplyConfigDir(ns string, configDir string) error {
 	return filepath.Walk(configDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -128,7 +128,7 @@ func (c cluster) ApplyConfigDir(ns string, configDir string) error {
 	})
 }
 
-func (c cluster) DeleteConfigDir(ns string, configDir string) error {
+func (c Cluster) DeleteConfigDir(ns string, configDir string) error {
 	return filepath.Walk(configDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -146,11 +146,11 @@ func (c cluster) DeleteConfigDir(ns string, configDir string) error {
 	})
 }
 
-func (c cluster) String() string {
+func (c Cluster) String() string {
 	return "nativeCluster"
 }
 
-func (c cluster) Index() resource.ClusterIndex {
+func (c Cluster) Index() resource.ClusterIndex {
 	// Multicluster not supported natively.
 	return 0
 }

--- a/pkg/test/framework/components/environment/native/cluster.go
+++ b/pkg/test/framework/components/environment/native/cluster.go
@@ -25,11 +25,6 @@ import (
 	"istio.io/istio/pkg/test/util/yml"
 )
 
-var (
-	// Cluster used for the native environment.
-	DefaultCluster = Cluster{}
-)
-
 var _ resource.Cluster = &Cluster{}
 
 type Cluster struct {

--- a/pkg/test/framework/components/environment/native/native.go
+++ b/pkg/test/framework/components/environment/native/native.go
@@ -69,7 +69,7 @@ func New(ctx resource.Context) (resource.Environment, error) {
 		ctx:             ctx,
 		SystemNamespace: systemNamespace,
 		Domain:          domain,
-		Cluster: cluster,
+		Cluster:         cluster,
 	}
 	e.id = ctx.TrackResource(e)
 

--- a/pkg/test/framework/components/environment/native/native.go
+++ b/pkg/test/framework/components/environment/native/native.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	systemNamespace = "istio-system"
-	domain          = "Cluster.local"
+	domain          = "cluster.local"
 
 	networkLabelKey   = "app"
 	networkLabelValue = "istio-test"

--- a/pkg/test/framework/components/environment/native/native.go
+++ b/pkg/test/framework/components/environment/native/native.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	systemNamespace = "istio-system"
-	domain          = "cluster.local"
+	domain          = "Cluster.local"
 
 	networkLabelKey   = "app"
 	networkLabelValue = "istio-test"
@@ -91,7 +91,7 @@ func (e *Environment) IsMulticluster() bool {
 }
 
 func (e *Environment) Clusters() []resource.Cluster {
-	return []resource.Cluster{Cluster}
+	return []resource.Cluster{DefaultCluster}
 }
 
 // ID implements resource.Instance

--- a/pkg/test/framework/components/environment/native/native.go
+++ b/pkg/test/framework/components/environment/native/native.go
@@ -54,16 +54,22 @@ type Environment struct {
 	dockerClient *client.Client
 	network      *docker.Network
 	mux          sync.Mutex
+	Cluster      resource.Cluster
 }
 
 var _ resource.Environment = &Environment{}
 
 // New returns a new native environment.
 func New(ctx resource.Context) (resource.Environment, error) {
+	cluster, err := NewCluster(ctx)
+	if err != nil {
+		return nil, err
+	}
 	e := &Environment{
 		ctx:             ctx,
 		SystemNamespace: systemNamespace,
 		Domain:          domain,
+		Cluster: cluster,
 	}
 	e.id = ctx.TrackResource(e)
 
@@ -91,7 +97,7 @@ func (e *Environment) IsMulticluster() bool {
 }
 
 func (e *Environment) Clusters() []resource.Cluster {
-	return []resource.Cluster{DefaultCluster}
+	return []resource.Cluster{e.Cluster}
 }
 
 // ID implements resource.Instance

--- a/pkg/test/framework/components/namespace/kube.go
+++ b/pkg/test/framework/components/namespace/kube.go
@@ -99,9 +99,6 @@ var _ resource.Resource = &kubeNamespace{}
 var _ resource.Dumper = &kubeNamespace{}
 
 func (n *kubeNamespace) Name() string {
-	if n == nil {
-		return ""
-	}
 	return n.name
 }
 

--- a/pkg/test/framework/components/namespace/kube.go
+++ b/pkg/test/framework/components/namespace/kube.go
@@ -99,6 +99,9 @@ var _ resource.Resource = &kubeNamespace{}
 var _ resource.Dumper = &kubeNamespace{}
 
 func (n *kubeNamespace) Name() string {
+	if n == nil {
+		return ""
+	}
 	return n.name
 }
 

--- a/pkg/test/framework/components/namespace/native.go
+++ b/pkg/test/framework/components/namespace/native.go
@@ -32,6 +32,9 @@ var _ Instance = &nativeNamespace{}
 var _ resource.Resource = &nativeNamespace{}
 
 func (n *nativeNamespace) Name() string {
+	if n == nil {
+		return ""
+	}
 	return n.name
 }
 

--- a/pkg/test/framework/components/namespace/native.go
+++ b/pkg/test/framework/components/namespace/native.go
@@ -32,9 +32,6 @@ var _ Instance = &nativeNamespace{}
 var _ resource.Resource = &nativeNamespace{}
 
 func (n *nativeNamespace) Name() string {
-	if n == nil {
-		return ""
-	}
 	return n.name
 }
 

--- a/pkg/test/framework/components/pilot/kube.go
+++ b/pkg/test/framework/components/pilot/kube.go
@@ -105,11 +105,6 @@ func (c *kubeComponent) ID() resource.ID {
 	return c.id
 }
 
-//func (c *kubeComponent) Start(ctx resource.Context) (err error) {
-//
-//
-//}
-
 // Close stops the kube pilot server.
 func (c *kubeComponent) Close() (err error) {
 	if c.client != nil {

--- a/pkg/test/framework/components/pilot/native.go
+++ b/pkg/test/framework/components/pilot/native.go
@@ -60,6 +60,9 @@ type nativeComponent struct {
 // NewNativeComponent factory function for the component
 func newNative(ctx resource.Context, cfg Config) (Instance, error) {
 	e := ctx.Environment().(*native.Environment)
+	if cfg.Cluster == nil {
+		cfg.Cluster = native.DefaultCluster
+	}
 	instance := &nativeComponent{
 		environment: ctx.Environment().(*native.Environment),
 		stopChan:    make(chan struct{}),

--- a/pkg/test/framework/components/pilot/native.go
+++ b/pkg/test/framework/components/pilot/native.go
@@ -61,7 +61,7 @@ type nativeComponent struct {
 func newNative(ctx resource.Context, cfg Config) (Instance, error) {
 	e := ctx.Environment().(*native.Environment)
 	if cfg.Cluster == nil {
-		cfg.Cluster = native.DefaultCluster
+		cfg.Cluster = e.Cluster
 	}
 	instance := &nativeComponent{
 		environment: ctx.Environment().(*native.Environment),

--- a/pkg/test/framework/components/pilot/native.go
+++ b/pkg/test/framework/components/pilot/native.go
@@ -109,8 +109,7 @@ func newNative(ctx resource.Context, cfg Config) (Instance, error) {
 	if bootstrapArgs.MeshConfig == nil {
 		bootstrapArgs.MeshConfig = &meshapi.MeshConfig{}
 	}
-	// TODO make pilot component (or something other than galley) control this
-	bootstrapArgs.Config.FileDir = cfg.Galley.GetConfigDir()
+	bootstrapArgs.Config.FileDir = cfg.Cluster.(native.Cluster).GetConfigDir()
 
 	// Use testing certs
 	if err := os.Setenv(bootstrap.LocalCertDir.Name, path.Join(env.IstioSrc, "tests/testdata/certs/pilot")); err != nil {

--- a/pkg/test/framework/components/pilot/pilot.go
+++ b/pkg/test/framework/components/pilot/pilot.go
@@ -25,7 +25,6 @@ import (
 
 	"istio.io/istio/pilot/pkg/bootstrap"
 	"istio.io/istio/pkg/test"
-	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/framework/resource/environment"
 )
@@ -57,8 +56,6 @@ type Instance interface {
 // Structured config for the Pilot component
 type Config struct {
 	fmt.Stringer
-	// If set then pilot takes a dependency on the referenced Galley instance
-	Galley galley.Instance
 
 	// The MeshConfig to be used for Pilot in native environment. In Kube environment this can be
 	// configured with Helm.

--- a/pkg/test/framework/resource/cluster.go
+++ b/pkg/test/framework/resource/cluster.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"istio.io/istio/pkg/test"
-	"istio.io/istio/pkg/test/framework/components/namespace"
 )
 
 // ClusterIndex is the index of a cluster within the Environment
@@ -26,28 +25,28 @@ type ClusterIndex int
 
 type ConfigManager interface {
 	// ApplyConfig applies the given config yaml text via Galley.
-	ApplyConfig(ns namespace.Instance, yamlText ...string) error
+	ApplyConfig(ns string, yamlText ...string) error
 
 	// ApplyConfigOrFail applies the given config yaml text via Galley.
-	ApplyConfigOrFail(t test.Failer, ns namespace.Instance, yamlText ...string)
+	ApplyConfigOrFail(t test.Failer, ns string, yamlText ...string)
 
 	// DeleteConfig deletes the given config yaml text via Galley.
-	DeleteConfig(ns namespace.Instance, yamlText ...string) error
+	DeleteConfig(ns string, yamlText ...string) error
 
 	// DeleteConfigOrFail deletes the given config yaml text via Galley.
-	DeleteConfigOrFail(t test.Failer, ns namespace.Instance, yamlText ...string)
+	DeleteConfigOrFail(t test.Failer, ns string, yamlText ...string)
 
 	// ApplyConfigDir recursively applies all the config files in the specified directory
-	ApplyConfigDir(ns namespace.Instance, configDir string) error
+	ApplyConfigDir(ns string, configDir string) error
 
 	// DeleteConfigDir recursively deletes all the config files in the specified directory
-	DeleteConfigDir(ns namespace.Instance, configDir string) error
-
+	DeleteConfigDir(ns string, configDir string) error
 }
 
 // Cluster in a multicluster environment.
 type Cluster interface {
 	fmt.Stringer
+	ConfigManager
 
 	// Index of this Cluster within the Environment
 	Index() ClusterIndex

--- a/pkg/test/framework/resource/cluster.go
+++ b/pkg/test/framework/resource/cluster.go
@@ -16,10 +16,34 @@ package resource
 
 import (
 	"fmt"
+
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/framework/components/namespace"
 )
 
 // ClusterIndex is the index of a cluster within the Environment
 type ClusterIndex int
+
+type ConfigManager interface {
+	// ApplyConfig applies the given config yaml text via Galley.
+	ApplyConfig(ns namespace.Instance, yamlText ...string) error
+
+	// ApplyConfigOrFail applies the given config yaml text via Galley.
+	ApplyConfigOrFail(t test.Failer, ns namespace.Instance, yamlText ...string)
+
+	// DeleteConfig deletes the given config yaml text via Galley.
+	DeleteConfig(ns namespace.Instance, yamlText ...string) error
+
+	// DeleteConfigOrFail deletes the given config yaml text via Galley.
+	DeleteConfigOrFail(t test.Failer, ns namespace.Instance, yamlText ...string)
+
+	// ApplyConfigDir recursively applies all the config files in the specified directory
+	ApplyConfigDir(ns namespace.Instance, configDir string) error
+
+	// DeleteConfigDir recursively deletes all the config files in the specified directory
+	DeleteConfigDir(ns namespace.Instance, configDir string) error
+
+}
 
 // Cluster in a multicluster environment.
 type Cluster interface {

--- a/pkg/test/framework/resource/context.go
+++ b/pkg/test/framework/resource/context.go
@@ -16,6 +16,8 @@ package resource
 
 // Context is the core context interface that is used by resources.
 type Context interface {
+	ConfigManager
+
 	// TrackResource tracks a resource in this context. If the context is closed, then the resource will be
 	// cleaned up.
 	TrackResource(r Resource) ID

--- a/pkg/test/framework/suite_test.go
+++ b/pkg/test/framework/suite_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/framework/resource/environment"
@@ -497,6 +498,30 @@ var _ resource.Cluster = fakeCluster{}
 
 type fakeCluster struct {
 	index int
+}
+
+func (f fakeCluster) ApplyConfig(ns string, yamlText ...string) error {
+	panic("implement me")
+}
+
+func (f fakeCluster) ApplyConfigOrFail(t test.Failer, ns string, yamlText ...string) {
+	panic("implement me")
+}
+
+func (f fakeCluster) DeleteConfig(ns string, yamlText ...string) error {
+	panic("implement me")
+}
+
+func (f fakeCluster) DeleteConfigOrFail(t test.Failer, ns string, yamlText ...string) {
+	panic("implement me")
+}
+
+func (f fakeCluster) ApplyConfigDir(ns string, configDir string) error {
+	panic("implement me")
+}
+
+func (f fakeCluster) DeleteConfigDir(ns string, configDir string) error {
+	panic("implement me")
 }
 
 func (f fakeCluster) Index() resource.ClusterIndex {

--- a/pkg/test/framework/suitecontext.go
+++ b/pkg/test/framework/suitecontext.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"sync"
 
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/features"
 
 	"istio.io/istio/pkg/test/framework/label"
@@ -165,6 +166,54 @@ func (s *suiteContext) CreateTmpDirectory(prefix string) (string, error) {
 	}
 
 	return dir, err
+}
+
+func (s *suiteContext) ApplyConfig(ns string, yamlText ...string) error {
+	for _, c := range s.Environment().Clusters() {
+		if err := c.ApplyConfig(ns, yamlText...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *suiteContext) ApplyConfigOrFail(t test.Failer, ns string, yamlText ...string) {
+	for _, c := range s.Environment().Clusters() {
+		c.ApplyConfigOrFail(t, ns, yamlText...)
+	}
+}
+
+func (s *suiteContext) DeleteConfig(ns string, yamlText ...string) error {
+	for _, c := range s.Environment().Clusters() {
+		if err := c.DeleteConfig(ns, yamlText...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *suiteContext) DeleteConfigOrFail(t test.Failer, ns string, yamlText ...string) {
+	for _, c := range s.Environment().Clusters() {
+		c.DeleteConfigOrFail(t, ns, yamlText...)
+	}
+}
+
+func (s *suiteContext) ApplyConfigDir(ns string, configDir string) error {
+	for _, c := range s.Environment().Clusters() {
+		if err := c.ApplyConfigDir(ns, configDir); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *suiteContext) DeleteConfigDir(ns string, configDir string) error {
+	for _, c := range s.Environment().Clusters() {
+		if err := c.DeleteConfigDir(ns, configDir); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 type Outcome string

--- a/pkg/test/framework/testcontext.go
+++ b/pkg/test/framework/testcontext.go
@@ -183,8 +183,8 @@ func (c *testContext) CreateTmpDirectory(prefix string) (string, error) {
 }
 
 func (c *testContext) ApplyConfig(ns string, yamlText ...string) error {
-	for _, c := range c.Environment().Clusters() {
-		if err := c.ApplyConfig(ns, yamlText...); err != nil {
+	for _, cc := range c.Environment().Clusters() {
+		if err := cc.ApplyConfig(ns, yamlText...); err != nil {
 			return err
 		}
 	}
@@ -192,14 +192,14 @@ func (c *testContext) ApplyConfig(ns string, yamlText ...string) error {
 }
 
 func (c *testContext) ApplyConfigOrFail(t test.Failer, ns string, yamlText ...string) {
-	for _, c := range c.Environment().Clusters() {
-		c.ApplyConfigOrFail(t, ns, yamlText...)
+	for _, cc := range c.Environment().Clusters() {
+		cc.ApplyConfigOrFail(t, ns, yamlText...)
 	}
 }
 
 func (c *testContext) DeleteConfig(ns string, yamlText ...string) error {
-	for _, c := range c.Environment().Clusters() {
-		if err := c.DeleteConfig(ns, yamlText...); err != nil {
+	for _, cc := range c.Environment().Clusters() {
+		if err := cc.DeleteConfig(ns, yamlText...); err != nil {
 			return err
 		}
 	}
@@ -207,14 +207,14 @@ func (c *testContext) DeleteConfig(ns string, yamlText ...string) error {
 }
 
 func (c *testContext) DeleteConfigOrFail(t test.Failer, ns string, yamlText ...string) {
-	for _, c := range c.Environment().Clusters() {
-		c.DeleteConfigOrFail(t, ns, yamlText...)
+	for _, cc := range c.Environment().Clusters() {
+		cc.DeleteConfigOrFail(t, ns, yamlText...)
 	}
 }
 
 func (c *testContext) ApplyConfigDir(ns string, configDir string) error {
-	for _, c := range c.Environment().Clusters() {
-		if err := c.ApplyConfigDir(ns, configDir); err != nil {
+	for _, cc := range c.Environment().Clusters() {
+		if err := cc.ApplyConfigDir(ns, configDir); err != nil {
 			return err
 		}
 	}
@@ -222,8 +222,8 @@ func (c *testContext) ApplyConfigDir(ns string, configDir string) error {
 }
 
 func (c *testContext) DeleteConfigDir(ns string, configDir string) error {
-	for _, c := range c.Environment().Clusters() {
-		if err := c.DeleteConfigDir(ns, configDir); err != nil {
+	for _, cc := range c.Environment().Clusters() {
+		if err := cc.DeleteConfigDir(ns, configDir); err != nil {
 			return err
 		}
 	}

--- a/pkg/test/framework/testcontext.go
+++ b/pkg/test/framework/testcontext.go
@@ -183,7 +183,7 @@ func (c *testContext) CreateTmpDirectory(prefix string) (string, error) {
 }
 
 func (c *testContext) ApplyConfig(ns string, yamlText ...string) error {
-	for _, c := range s.Environment().Clusters() {
+	for _, c := range c.Environment().Clusters() {
 		if err := c.ApplyConfig(ns, yamlText...); err != nil {
 			return err
 		}
@@ -192,13 +192,13 @@ func (c *testContext) ApplyConfig(ns string, yamlText ...string) error {
 }
 
 func (c *testContext) ApplyConfigOrFail(t test.Failer, ns string, yamlText ...string) {
-	for _, c := range s.Environment().Clusters() {
+	for _, c := range c.Environment().Clusters() {
 		c.ApplyConfigOrFail(t, ns, yamlText...)
 	}
 }
 
 func (c *testContext) DeleteConfig(ns string, yamlText ...string) error {
-	for _, c := range s.Environment().Clusters() {
+	for _, c := range c.Environment().Clusters() {
 		if err := c.DeleteConfig(ns, yamlText...); err != nil {
 			return err
 		}
@@ -207,13 +207,13 @@ func (c *testContext) DeleteConfig(ns string, yamlText ...string) error {
 }
 
 func (c *testContext) DeleteConfigOrFail(t test.Failer, ns string, yamlText ...string) {
-	for _, c := range s.Environment().Clusters() {
+	for _, c := range c.Environment().Clusters() {
 		c.DeleteConfigOrFail(t, ns, yamlText...)
 	}
 }
 
 func (c *testContext) ApplyConfigDir(ns string, configDir string) error {
-	for _, c := range s.Environment().Clusters() {
+	for _, c := range c.Environment().Clusters() {
 		if err := c.ApplyConfigDir(ns, configDir); err != nil {
 			return err
 		}
@@ -222,7 +222,7 @@ func (c *testContext) ApplyConfigDir(ns string, configDir string) error {
 }
 
 func (c *testContext) DeleteConfigDir(ns string, configDir string) error {
-	for _, c := range s.Environment().Clusters() {
+	for _, c := range c.Environment().Clusters() {
 		if err := c.DeleteConfigDir(ns, configDir); err != nil {
 			return err
 		}

--- a/pkg/test/framework/testcontext.go
+++ b/pkg/test/framework/testcontext.go
@@ -182,6 +182,54 @@ func (c *testContext) CreateTmpDirectory(prefix string) (string, error) {
 	return dir, err
 }
 
+func (s *testContext) ApplyConfig(ns string, yamlText ...string) error {
+	for _, c := range s.Environment().Clusters() {
+		if err := c.ApplyConfig(ns, yamlText...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *testContext) ApplyConfigOrFail(t test.Failer, ns string, yamlText ...string) {
+	for _, c := range s.Environment().Clusters() {
+		c.ApplyConfigOrFail(t, ns, yamlText...)
+	}
+}
+
+func (s *testContext) DeleteConfig(ns string, yamlText ...string) error {
+	for _, c := range s.Environment().Clusters() {
+		if err := c.DeleteConfig(ns, yamlText...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *testContext) DeleteConfigOrFail(t test.Failer, ns string, yamlText ...string) {
+	for _, c := range s.Environment().Clusters() {
+		c.DeleteConfigOrFail(t, ns, yamlText...)
+	}
+}
+
+func (s *testContext) ApplyConfigDir(ns string, configDir string) error {
+	for _, c := range s.Environment().Clusters() {
+		if err := c.ApplyConfigDir(ns, configDir); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *testContext) DeleteConfigDir(ns string, configDir string) error {
+	for _, c := range s.Environment().Clusters() {
+		if err := c.DeleteConfigDir(ns, configDir); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (c *testContext) CreateTmpDirectoryOrFail(prefix string) string {
 	tmp, err := c.CreateTmpDirectory(prefix)
 	if err != nil {

--- a/pkg/test/framework/testcontext.go
+++ b/pkg/test/framework/testcontext.go
@@ -182,7 +182,7 @@ func (c *testContext) CreateTmpDirectory(prefix string) (string, error) {
 	return dir, err
 }
 
-func (s *testContext) ApplyConfig(ns string, yamlText ...string) error {
+func (c *testContext) ApplyConfig(ns string, yamlText ...string) error {
 	for _, c := range s.Environment().Clusters() {
 		if err := c.ApplyConfig(ns, yamlText...); err != nil {
 			return err
@@ -191,13 +191,13 @@ func (s *testContext) ApplyConfig(ns string, yamlText ...string) error {
 	return nil
 }
 
-func (s *testContext) ApplyConfigOrFail(t test.Failer, ns string, yamlText ...string) {
+func (c *testContext) ApplyConfigOrFail(t test.Failer, ns string, yamlText ...string) {
 	for _, c := range s.Environment().Clusters() {
 		c.ApplyConfigOrFail(t, ns, yamlText...)
 	}
 }
 
-func (s *testContext) DeleteConfig(ns string, yamlText ...string) error {
+func (c *testContext) DeleteConfig(ns string, yamlText ...string) error {
 	for _, c := range s.Environment().Clusters() {
 		if err := c.DeleteConfig(ns, yamlText...); err != nil {
 			return err
@@ -206,13 +206,13 @@ func (s *testContext) DeleteConfig(ns string, yamlText ...string) error {
 	return nil
 }
 
-func (s *testContext) DeleteConfigOrFail(t test.Failer, ns string, yamlText ...string) {
+func (c *testContext) DeleteConfigOrFail(t test.Failer, ns string, yamlText ...string) {
 	for _, c := range s.Environment().Clusters() {
 		c.DeleteConfigOrFail(t, ns, yamlText...)
 	}
 }
 
-func (s *testContext) ApplyConfigDir(ns string, configDir string) error {
+func (c *testContext) ApplyConfigDir(ns string, configDir string) error {
 	for _, c := range s.Environment().Clusters() {
 		if err := c.ApplyConfigDir(ns, configDir); err != nil {
 			return err
@@ -221,7 +221,7 @@ func (s *testContext) ApplyConfigDir(ns string, configDir string) error {
 	return nil
 }
 
-func (s *testContext) DeleteConfigDir(ns string, configDir string) error {
+func (c *testContext) DeleteConfigDir(ns string, configDir string) error {
 	for _, c := range s.Environment().Clusters() {
 		if err := c.DeleteConfigDir(ns, configDir); err != nil {
 			return err

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -233,9 +233,7 @@ func TestMyLogic(t *testing.T) {
         Run(func(ctx framework.TestContext) {
             // Create the components.
             g := galley.NewOrFail(ctx, ctx, galley.Config{})
-            p := pilot.NewOrFail(ctx, ctx, pilot.Config {
-                Galley: g,
-            })
+            p := pilot.NewOrFail(ctx, ctx, pilot.Config {})
 
             // Apply configuration via Galley.
             g.ApplyConfigOrFail(ctx, nil, mycfg)

--- a/tests/integration/mixer/outboundtrafficpolicy/allowany/egressproxy/traffic_allow_any_egressproxy_test.go
+++ b/tests/integration/mixer/outboundtrafficpolicy/allowany/egressproxy/traffic_allow_any_egressproxy_test.go
@@ -81,7 +81,7 @@ func setupTest(t *testing.T, ctx resource.Context, modifyConfig func(c Config) C
 	meshConfig := mesh.DefaultMeshConfig()
 
 	g := galley.NewOrFail(t, ctx, galley.Config{MeshConfig: MeshConfig})
-	p := pilot.NewOrFail(t, ctx, pilot.Config{Galley: g, MeshConfig: &meshConfig})
+	p := pilot.NewOrFail(t, ctx, pilot.Config{MeshConfig: &meshConfig})
 
 	appNamespace := namespace.NewOrFail(t, ctx, namespace.Config{
 		Prefix: "app",

--- a/tests/integration/mixer/outboundtrafficpolicy/allowany/egressproxy/traffic_allow_any_egressproxy_test.go
+++ b/tests/integration/mixer/outboundtrafficpolicy/allowany/egressproxy/traffic_allow_any_egressproxy_test.go
@@ -90,9 +90,8 @@ func setupTest(t *testing.T, ctx resource.Context, modifyConfig func(c Config) C
 		AppNamespace: appNamespace.Name(),
 	})
 
-	cluster := ctx.Environment().Clusters()[0]
 	// Apply sidecar config
-	createConfig(t, cluster, config, Sidecar, appNamespace)
+	createConfig(t, ctx, config, Sidecar, appNamespace)
 
 	time.Sleep(time.Second * 2)
 
@@ -107,7 +106,7 @@ func setupTest(t *testing.T, ctx resource.Context, modifyConfig func(c Config) C
 	return p, nodeID
 }
 
-func createConfig(t *testing.T, cluster resource.Cluster, config Config, yaml string, namespace namespace.Instance) {
+func createConfig(t *testing.T, ctx resource.Context, config Config, yaml string, namespace namespace.Instance) {
 	tmpl, err := template.New("Config").Parse(yaml)
 	if err != nil {
 		t.Errorf("failed to create template: %v", err)
@@ -116,7 +115,7 @@ func createConfig(t *testing.T, cluster resource.Cluster, config Config, yaml st
 	if err := tmpl.Execute(&buf, config); err != nil {
 		t.Errorf("failed to create template: %v", err)
 	}
-	if err := cluster.ApplyConfig(namespace.Name(), buf.String()); err != nil {
+	if err := ctx.ApplyConfig(namespace.Name(), buf.String()); err != nil {
 		t.Fatalf("failed to apply config: %v. Config: %v", err, buf.String())
 	}
 }

--- a/tests/integration/mixer/outboundtrafficpolicy/helper.go
+++ b/tests/integration/mixer/outboundtrafficpolicy/helper.go
@@ -302,7 +302,7 @@ func RunExternalRequest(cases []*TestCase, prometheus prometheus.Instance, mode 
 
 func setupEcho(t *testing.T, ctx resource.Context, mode TrafficPolicy) (echo.Instance, echo.Instance) {
 	g := galley.NewOrFail(t, ctx, galley.Config{})
-	p := pilot.NewOrFail(t, ctx, pilot.Config{Galley: g})
+	p := pilot.NewOrFail(t, ctx, pilot.Config{})
 
 	appsNamespace := namespace.NewOrFail(t, ctx, namespace.Config{
 		Prefix: "app",

--- a/tests/integration/mixer/outboundtrafficpolicy/helper.go
+++ b/tests/integration/mixer/outboundtrafficpolicy/helper.go
@@ -35,7 +35,6 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
-	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/components/pilot"
 	"istio.io/istio/pkg/test/framework/components/prometheus"
@@ -167,7 +166,7 @@ func (t TrafficPolicy) String() string {
 
 // We want to test "external" traffic. To do this without actually hitting an external endpoint,
 // we can import only the service namespace, so the apps are not known
-func createSidecarScope(t *testing.T, tPolicy TrafficPolicy, appsNamespace namespace.Instance, serviceNamespace namespace.Instance, g galley.Instance) {
+func createSidecarScope(t *testing.T, ctx resource.Context, tPolicy TrafficPolicy, appsNamespace namespace.Instance, serviceNamespace namespace.Instance) {
 	tmpl, err := template.New("SidecarScope").Parse(SidecarScope)
 	if err != nil {
 		t.Errorf("failed to create template: %v", err)
@@ -177,7 +176,7 @@ func createSidecarScope(t *testing.T, tPolicy TrafficPolicy, appsNamespace names
 	if err := tmpl.Execute(&buf, map[string]string{"ImportNamespace": serviceNamespace.Name(), "TrafficPolicyMode": tPolicy.String()}); err != nil {
 		t.Errorf("failed to create template: %v", err)
 	}
-	if err := g.ApplyConfig(appsNamespace, buf.String()); err != nil {
+	if err := ctx.ApplyConfig(appsNamespace.Name(), buf.String()); err != nil {
 		t.Errorf("failed to apply service entries: %v", err)
 	}
 }
@@ -192,7 +191,7 @@ func mustReadCert(t *testing.T, f string) string {
 
 // We want to test "external" traffic. To do this without actually hitting an external endpoint,
 // we can import only the service namespace, so the apps are not known
-func createGateway(t *testing.T, appsNamespace namespace.Instance, serviceNamespace namespace.Instance, g galley.Instance) {
+func createGateway(t *testing.T, ctx resource.Context, appsNamespace namespace.Instance, serviceNamespace namespace.Instance) {
 	tmpl, err := template.New("Gateway").Parse(Gateway)
 	if err != nil {
 		t.Fatalf("failed to create template: %v", err)
@@ -202,7 +201,7 @@ func createGateway(t *testing.T, appsNamespace namespace.Instance, serviceNamesp
 	if err := tmpl.Execute(&buf, map[string]string{"AppNamespace": appsNamespace.Name()}); err != nil {
 		t.Fatalf("failed to create template: %v", err)
 	}
-	if err := g.ApplyConfig(serviceNamespace, buf.String()); err != nil {
+	if err := ctx.ApplyConfig(serviceNamespace.Name(), buf.String()); err != nil {
 		t.Fatalf("failed to apply gateway: %v. template: %v", err, buf.String())
 	}
 }
@@ -301,7 +300,6 @@ func RunExternalRequest(cases []*TestCase, prometheus prometheus.Instance, mode 
 }
 
 func setupEcho(t *testing.T, ctx resource.Context, mode TrafficPolicy) (echo.Instance, echo.Instance) {
-	g := galley.NewOrFail(t, ctx, galley.Config{})
 	p := pilot.NewOrFail(t, ctx, pilot.Config{})
 
 	appsNamespace := namespace.NewOrFail(t, ctx, namespace.Config{
@@ -320,14 +318,12 @@ func setupEcho(t *testing.T, ctx resource.Context, mode TrafficPolicy) (echo.Ins
 			Namespace: appsNamespace,
 			Subsets:   []echo.SubsetConfig{{}},
 			Pilot:     p,
-			Galley:    g,
 		}).
 		With(&dest, echo.Config{
 			Service:   "destination",
 			Namespace: appsNamespace,
 			Subsets:   []echo.SubsetConfig{{}},
 			Pilot:     p,
-			Galley:    g,
 			Ports: []echo.Port{
 				{
 					// Plain HTTP port, will match no listeners and fall through
@@ -373,13 +369,13 @@ func setupEcho(t *testing.T, ctx resource.Context, mode TrafficPolicy) (echo.Ins
 		}).BuildOrFail(t)
 
 	// External traffic should work even if we have service entries on the same ports
-	createSidecarScope(t, mode, appsNamespace, serviceNamespace, g)
-	if err := g.ApplyConfig(serviceNamespace, ServiceEntry); err != nil {
+	createSidecarScope(t, ctx, mode, appsNamespace, serviceNamespace)
+	if err := ctx.ApplyConfig(serviceNamespace.Name(), ServiceEntry); err != nil {
 		t.Errorf("failed to apply service entries: %v", err)
 	}
 
 	if _, kube := ctx.Environment().(*kube.Environment); kube {
-		createGateway(t, appsNamespace, serviceNamespace, g)
+		createGateway(t, ctx, appsNamespace, serviceNamespace)
 	}
 	if err := WaitUntilNotCallable(client, dest); err != nil {
 		t.Fatalf("failed to apply sidecar, %v", err)

--- a/tests/integration/mixer/policy/white_black_listing_test.go
+++ b/tests/integration/mixer/policy/white_black_listing_test.go
@@ -30,13 +30,13 @@ func TestWhiteListing(t *testing.T) {
 		// Verify you can access productpage right now.
 		util.SendTrafficAndWaitForExpectedStatus(ing, t, "Sending traffic...", "", 2, http.StatusOK)
 
-		g.ApplyConfigOrFail(
+		ctx.ApplyConfigOrFail(
 			t,
-			bookinfoNs,
+			bookinfoNs.Name(),
 			bookinfo.PolicyDenyIPRule.LoadWithNamespaceOrFail(t, bookinfoNs.Name()))
-		defer g.DeleteConfigOrFail(
+		defer ctx.DeleteConfigOrFail(
 			t,
-			bookinfoNs,
+			bookinfoNs.Name(),
 			bookinfo.PolicyDenyIPRule.LoadWithNamespaceOrFail(t, bookinfoNs.Name()))
 		util.AllowRuleSync(t)
 

--- a/tests/integration/mixer/report_test.go
+++ b/tests/integration/mixer/report_test.go
@@ -44,8 +44,8 @@ func TestMixer_Report_Direct(t *testing.T) {
 				Prefix: "mixreport",
 			})
 
-			g.ApplyConfigOrFail(t,
-				ns,
+			ctx.ApplyConfigOrFail(t,
+				ns.Name(),
 				testReportConfig,
 				be.CreateConfigSnippet("handler1", ns.Name(), policybackend.InProcess))
 

--- a/tests/integration/mixer/telemetry/logs/accesslog_test.go
+++ b/tests/integration/mixer/telemetry/logs/accesslog_test.go
@@ -35,7 +35,6 @@ import (
 var (
 	ist               istio.Instance
 	bookinfoNamespace *namespace.Instance
-	galInst           *galley.Instance
 	ingInst           *ingress.Instance
 )
 
@@ -106,11 +105,6 @@ func testsetup(ctx resource.Context) error {
 	if _, err := bookinfo.Deploy(ctx, bookinfo.Config{Namespace: bookinfoNs, Cfg: bookinfo.BookInfo}); err != nil {
 		return err
 	}
-	g, err := galley.New(ctx, galley.Config{})
-	if err != nil {
-		return err
-	}
-	galInst = &g
 	ing, err := ingress.New(ctx, ingress.Config{Istio: ist})
 	if err != nil {
 		return err
@@ -121,6 +115,7 @@ func testsetup(ctx resource.Context) error {
 	if err != nil {
 		return err
 	}
+	ctx.Environment()
 	err = g.ApplyConfig(bookinfoNs, bookinfoGateWayConfig)
 	if err != nil {
 		return err

--- a/tests/integration/mixer/telemetry/logs/accesslog_test.go
+++ b/tests/integration/mixer/telemetry/logs/accesslog_test.go
@@ -22,7 +22,6 @@ import (
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/bookinfo"
-	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/components/ingress"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/namespace"
@@ -43,16 +42,16 @@ func TestIstioAccessLog(t *testing.T) {
 		NewTest(t).
 		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
-			_, g, ing := setupComponentsOrFail(t)
+			_, ing := setupComponentsOrFail(t)
 
 			ns := namespace.ClaimOrFail(t, ctx, ist.Settings().SystemNamespace)
-			g.ApplyConfigOrFail(
+			ctx.ApplyConfigOrFail(
 				t,
-				ns,
+				ns.Name(),
 				bookinfo.TelemetryLogEntry.LoadOrFail(t))
-			defer g.DeleteConfigOrFail(
+			defer ctx.DeleteConfigOrFail(
 				t,
-				ns,
+				ns.Name(),
 				bookinfo.TelemetryLogEntry.LoadOrFail(t))
 
 			util.AllowRuleSync(t)
@@ -115,24 +114,18 @@ func testsetup(ctx resource.Context) error {
 	if err != nil {
 		return err
 	}
-	ctx.Environment()
-	err = g.ApplyConfig(bookinfoNs, bookinfoGateWayConfig)
+	err = ctx.ApplyConfig(bookinfoNs.Name(), bookinfoGateWayConfig)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func setupComponentsOrFail(t *testing.T) (bookinfoNs namespace.Instance, g galley.Instance,
-	ing ingress.Instance) {
+func setupComponentsOrFail(t *testing.T) (bookinfoNs namespace.Instance, ing ingress.Instance) {
 	if bookinfoNamespace == nil {
 		t.Fatalf("bookinfo namespace not allocated in setup")
 	}
 	bookinfoNs = *bookinfoNamespace
-	if galInst == nil {
-		t.Fatalf("galley not setup")
-	}
-	g = *galInst
 	if ingInst == nil {
 		t.Fatalf("ingress not setup")
 	}

--- a/tests/integration/mixer/telemetry/metrics/new_metric_test.go
+++ b/tests/integration/mixer/telemetry/metrics/new_metric_test.go
@@ -31,9 +31,9 @@ func TestNewMetric(t *testing.T) {
 		NewTest(t).
 		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
-			g.ApplyConfigOrFail(ctx, nil,
+			ctx.ApplyConfigOrFail(ctx, "",
 				bookinfo.DoubleMetric.LoadOrFail(ctx))
-			defer g.DeleteConfigOrFail(ctx, nil,
+			defer ctx.DeleteConfigOrFail(ctx, "",
 				bookinfo.DoubleMetric.LoadOrFail(ctx))
 
 			util.AllowRuleSync(t)

--- a/tests/integration/mixer/telemetry/metrics/scenarios_test.go
+++ b/tests/integration/mixer/telemetry/metrics/scenarios_test.go
@@ -20,10 +20,8 @@ import (
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/bookinfo"
-	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/components/ingress"
 	"istio.io/istio/pkg/test/framework/components/istio"
-	"istio.io/istio/pkg/test/framework/components/mixer"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/components/prometheus"
 	"istio.io/istio/pkg/test/framework/label"
@@ -36,7 +34,6 @@ import (
 var (
 	ist        istio.Instance
 	bookinfoNs namespace.Instance
-	g          galley.Instance
 	ing        ingress.Instance
 	prom       prometheus.Instance
 )
@@ -80,14 +77,14 @@ func TestIngessToPrometheus_IngressMetric(t *testing.T) {
 
 func testMetric(t *testing.T, ctx framework.TestContext, label string, labelValue string) { // nolint:interfacer
 	t.Helper()
-	g.ApplyConfigOrFail(
+	ctx.ApplyConfigOrFail(
 		t,
-		bookinfoNs,
+		bookinfoNs.Name(),
 		bookinfo.GetDestinationRuleConfigFileOrFail(t, ctx).LoadWithNamespaceOrFail(t, bookinfoNs.Name()),
 		bookinfo.NetworkingVirtualServiceAllV1.LoadWithNamespaceOrFail(t, bookinfoNs.Name()),
 	)
-	defer g.DeleteConfigOrFail(t,
-		bookinfoNs,
+	defer ctx.DeleteConfigOrFail(t,
+		bookinfoNs.Name(),
 		bookinfo.GetDestinationRuleConfigFileOrFail(t, ctx).LoadWithNamespaceOrFail(t, bookinfoNs.Name()),
 		bookinfo.NetworkingVirtualServiceAllV1.LoadWithNamespaceOrFail(t, bookinfoNs.Name()))
 
@@ -154,15 +151,15 @@ func TestTcpMetric(t *testing.T) {
 			defer undeploy1()
 			defer undeploy2()
 
-			g.ApplyConfigOrFail(
+			ctx.ApplyConfigOrFail(
 				t,
-				bookinfoNs,
+				bookinfoNs.Name(),
 				bookinfo.GetDestinationRuleConfigFileOrFail(t, ctx).LoadWithNamespaceOrFail(t, bookinfoNs.Name()),
 				bookinfo.NetworkingTCPDbRule.LoadWithNamespaceOrFail(t, bookinfoNs.Name()),
 			)
-			defer g.DeleteConfigOrFail(
+			defer ctx.DeleteConfigOrFail(
 				t,
-				bookinfoNs,
+				bookinfoNs.Name(),
 				bookinfo.GetDestinationRuleConfigFileOrFail(t, ctx).LoadWithNamespaceOrFail(t, bookinfoNs.Name()),
 				bookinfo.NetworkingTCPDbRule.LoadWithNamespaceOrFail(t, bookinfoNs.Name()),
 			)
@@ -229,13 +226,6 @@ func testsetup(ctx resource.Context) (err error) {
 	if _, err := bookinfo.Deploy(ctx, bookinfo.Config{Namespace: bookinfoNs, Cfg: bookinfo.BookInfo}); err != nil {
 		return err
 	}
-	g, err = galley.New(ctx, galley.Config{})
-	if err != nil {
-		return err
-	}
-	if _, err = mixer.New(ctx, mixer.Config{Galley: g}); err != nil {
-		return err
-	}
 	ing, err = ingress.New(ctx, ingress.Config{Istio: ist})
 	if err != nil {
 		return err
@@ -248,7 +238,7 @@ func testsetup(ctx resource.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	err = g.ApplyConfig(bookinfoNs, yamlText)
+	err = ctx.ApplyConfig(bookinfoNs.Name(), yamlText)
 	if err != nil {
 		return err
 	}

--- a/tests/integration/pilot/analysis/analysis_test.go
+++ b/tests/integration/pilot/analysis/analysis_test.go
@@ -50,7 +50,6 @@ func TestAnalysisWritesStatus(t *testing.T) {
 		// TODO: make feature labels heirarchical constants like:
 		// Label(features.Usability.Observability.Status).
 		Run(func(ctx framework.TestContext) {
-			cluster := ctx.Environment().Clusters()[0]
 			ns := namespace.NewOrFail(t, ctx, namespace.Config{
 				Prefix:   "default",
 				Inject:   true,
@@ -58,7 +57,7 @@ func TestAnalysisWritesStatus(t *testing.T) {
 				Labels:   nil,
 			})
 			// Apply bad config (referencing invalid host)
-		cluster.ApplyConfigOrFail(t, ns.Name(), `
+			ctx.ApplyConfigOrFail(t, ns.Name(), `
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -77,7 +76,7 @@ spec:
 				return expectStatus(t, ctx, ns, true)
 			}, retry.Timeout(time.Minute*5))
 			// Apply config to make this not invalid
-		cluster.ApplyConfigOrFail(t, ns.Name(), `
+			ctx.ApplyConfigOrFail(t, ns.Name(), `
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:

--- a/tests/integration/pilot/analysis/analysis_test.go
+++ b/tests/integration/pilot/analysis/analysis_test.go
@@ -50,6 +50,7 @@ func TestAnalysisWritesStatus(t *testing.T) {
 		// TODO: make feature labels heirarchical constants like:
 		// Label(features.Usability.Observability.Status).
 		Run(func(ctx framework.TestContext) {
+			cluster := ctx.Environment().Clusters()[0]
 			ns := namespace.NewOrFail(t, ctx, namespace.Config{
 				Prefix:   "default",
 				Inject:   true,
@@ -57,7 +58,7 @@ func TestAnalysisWritesStatus(t *testing.T) {
 				Labels:   nil,
 			})
 			// Apply bad config (referencing invalid host)
-			g.ApplyConfigOrFail(t, ns, `
+		cluster.ApplyConfigOrFail(t, ns.Name(), `
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -76,7 +77,7 @@ spec:
 				return expectStatus(t, ctx, ns, true)
 			}, retry.Timeout(time.Minute*5))
 			// Apply config to make this not invalid
-			g.ApplyConfigOrFail(t, ns, `
+		cluster.ApplyConfigOrFail(t, ns.Name(), `
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:

--- a/tests/integration/pilot/analysis/main_test.go
+++ b/tests/integration/pilot/analysis/main_test.go
@@ -18,17 +18,8 @@ import (
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
-	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/components/istio"
-	"istio.io/istio/pkg/test/framework/components/pilot"
-	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/framework/resource/environment"
-)
-
-var (
-	i istio.Instance
-	p pilot.Instance
-	g galley.Instance
 )
 
 // TestMain defines the entrypoint for pilot tests using a standard Istio installation.
@@ -39,8 +30,7 @@ func TestMain(m *testing.M) {
 		NewSuite("pilot_analysis_test", m).
 		RequireSingleCluster().
 		RequireEnvironment(environment.Kube).
-		SetupOnEnv(environment.Kube, istio.Setup(&i, func(cfg *istio.Config) {
-
+		SetupOnEnv(environment.Kube, istio.Setup(nil, func(cfg *istio.Config) {
 			cfg.ControlPlaneValues = `
 values:
   pilot:
@@ -52,14 +42,5 @@ values:
       enableAnalysis: true
 `
 		})).
-		Setup(func(ctx resource.Context) (err error) {
-			if g, err = galley.New(ctx, galley.Config{}); err != nil {
-				return err
-			}
-			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
-				return err
-			}
-			return nil
-		}).
 		Run()
 }

--- a/tests/integration/pilot/cni/cni_test.go
+++ b/tests/integration/pilot/cni/cni_test.go
@@ -59,9 +59,7 @@ func TestCNIReachability(t *testing.T) {
 			if err != nil {
 				ctx.Fatal(err)
 			}
-			p, err := pilot.New(ctx, pilot.Config{
-				Galley: g,
-			})
+			p, err := pilot.New(ctx, pilot.Config{})
 			if err != nil {
 				ctx.Fatal(err)
 			}

--- a/tests/integration/pilot/cni/cni_test.go
+++ b/tests/integration/pilot/cni/cni_test.go
@@ -20,7 +20,6 @@ import (
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
-	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/components/pilot"
@@ -55,21 +54,13 @@ components:
 func TestCNIReachability(t *testing.T) {
 	framework.NewTest(t).
 		Run(func(ctx framework.TestContext) {
-			g, err := galley.New(ctx, galley.Config{})
-			if err != nil {
-				ctx.Fatal(err)
-			}
-			p, err := pilot.New(ctx, pilot.Config{})
-			if err != nil {
-				ctx.Fatal(err)
-			}
 			kenv := ctx.Environment().(*kube.Environment)
 			cluster := kenv.KubeClusters[0]
-			_, err = cluster.WaitUntilPodsAreReady(cluster.NewSinglePodFetch("kube-system", "k8s-app=istio-cni-node"))
+			_, err := cluster.WaitUntilPodsAreReady(cluster.NewSinglePodFetch("kube-system", "k8s-app=istio-cni-node"))
 			if err != nil {
 				ctx.Fatal(err)
 			}
-			rctx := reachability.CreateContext(ctx, g, p)
+			rctx := reachability.CreateContext(ctx, pilot.NewOrFail(t, ctx, pilot.Config{}))
 			systemNM := namespace.ClaimSystemNamespaceOrFail(ctx, ctx)
 
 			testCases := []reachability.TestCase{

--- a/tests/integration/pilot/envoyfilter/main_test.go
+++ b/tests/integration/pilot/envoyfilter/main_test.go
@@ -180,7 +180,7 @@ func setupTest(t *testing.T, ctx resource.Context, modifyConfig func(c Config) C
 	meshConfig.MixerReportServer = "istio-telemetry.istio-system.svc.cluster.local:15004"
 
 	g := galley.NewOrFail(t, ctx, galley.Config{MeshConfig: MeshConfig})
-	p := pilot.NewOrFail(t, ctx, pilot.Config{Galley: g, MeshConfig: &meshConfig})
+	p := pilot.NewOrFail(t, ctx, pilot.Config{MeshConfig: &meshConfig})
 
 	appNamespace := namespace.NewOrFail(t, ctx, namespace.Config{
 		Prefix: "app",

--- a/tests/integration/pilot/envoyfilter/main_test.go
+++ b/tests/integration/pilot/envoyfilter/main_test.go
@@ -180,8 +180,6 @@ func setupTest(t *testing.T, ctx resource.Context, modifyConfig func(c Config) C
 
 	p := pilot.NewOrFail(t, ctx, pilot.Config{MeshConfig: &meshConfig})
 
-	cluster := ctx.Environment().Clusters()[0]
-
 	appNamespace := namespace.NewOrFail(t, ctx, namespace.Config{
 		Prefix: "app",
 		Inject: true,
@@ -192,10 +190,10 @@ func setupTest(t *testing.T, ctx resource.Context, modifyConfig func(c Config) C
 	})
 
 	// Apply all configs
-	createConfig(t, cluster, config, EnvoyFilterConfig, appNamespace)
-	createConfig(t, cluster, config, AppConfig, appNamespace)
-	createConfig(t, cluster, config, IncludedConfig, appNamespace)
-	createConfig(t, cluster, config, PermissiveMtls, appNamespace)
+	createConfig(t, ctx, config, EnvoyFilterConfig, appNamespace)
+	createConfig(t, ctx, config, AppConfig, appNamespace)
+	createConfig(t, ctx, config, IncludedConfig, appNamespace)
+	createConfig(t, ctx, config, PermissiveMtls, appNamespace)
 
 	time.Sleep(time.Second * 2)
 
@@ -210,7 +208,7 @@ func setupTest(t *testing.T, ctx resource.Context, modifyConfig func(c Config) C
 	return p, nodeID
 }
 
-func createConfig(t *testing.T, cluster resource.Cluster, config Config, yaml string, namespace namespace.Instance) {
+func createConfig(t *testing.T, ctx resource.Context, config Config, yaml string, namespace namespace.Instance) {
 	tmpl, err := template.New("Config").Parse(yaml)
 	if err != nil {
 		t.Errorf("failed to create template: %v", err)
@@ -219,7 +217,7 @@ func createConfig(t *testing.T, cluster resource.Cluster, config Config, yaml st
 	if err := tmpl.Execute(&buf, config); err != nil {
 		t.Errorf("failed to create template: %v", err)
 	}
-	if err := cluster.ApplyConfig(namespace.Name(), buf.String()); err != nil {
+	if err := ctx.ApplyConfig(namespace.Name(), buf.String()); err != nil {
 		t.Fatalf("failed to apply config: %v. Config: %v", err, buf.String())
 	}
 }

--- a/tests/integration/pilot/ingress/ingress_test.go
+++ b/tests/integration/pilot/ingress/ingress_test.go
@@ -67,9 +67,7 @@ func TestMain(m *testing.M) {
 			cfg.Values["pilot.env.PILOT_ENABLED_SERVICE_APIS"] = "true"
 		})).
 		Setup(func(ctx resource.Context) (err error) {
-			if p, err = pilot.New(ctx, pilot.Config{
-				Galley: g,
-			}); err != nil {
+			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
 				return err
 			}
 			if ingr, err = ingress.New(ctx, ingress.Config{

--- a/tests/integration/pilot/ingress/ingress_test.go
+++ b/tests/integration/pilot/ingress/ingress_test.go
@@ -53,7 +53,7 @@ func TestMain(m *testing.M) {
 		RequireEnvironmentVersion("1.18").
 		RequireSingleCluster().
 		Setup(func(ctx resource.Context) (err error) {
-			if err := ctx.Environment().Clusters()[0].ApplyConfigDir("", "testdata"); err != nil {
+			if err := ctx.ApplyConfigDir("", "testdata"); err != nil {
 				return err
 			}
 			return nil
@@ -102,7 +102,7 @@ func TestGateway(t *testing.T) {
 				}).
 				BuildOrFail(t)
 			instance.Address()
-			if err := ctx.Environment().Clusters()[0].ApplyConfig(ns.Name(), `
+			if err := ctx.ApplyConfig(ns.Name(), `
 apiVersion: networking.x.k8s.io/v1alpha1
 kind: GatewayClass
 metadata:
@@ -206,7 +206,7 @@ func TestIngress(t *testing.T) {
 			ingressutil.CreateIngressKubeSecret(t, ctx, []string{credName2}, ingress.TLS, ingressutil.IngressCredentialB)
 			defer ingressutil.DeleteIngressKubeSecret(t, ctx, []string{credName2})
 
-			if err := ctx.Environment().Clusters()[0].ApplyConfig(ns.Name(), `
+			if err := ctx.ApplyConfig(ns.Name(), `
 apiVersion: networking.k8s.io/v1beta1
 kind: IngressClass
 metadata:

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -26,10 +26,8 @@ import (
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
-	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/components/istioctl"
 	"istio.io/istio/pkg/test/framework/components/namespace"
-	"istio.io/istio/pkg/test/framework/components/pilot"
 	"istio.io/istio/pkg/test/framework/resource/environment"
 	"istio.io/istio/pkg/test/util/file"
 )
@@ -81,8 +79,6 @@ func TestVersion(t *testing.T) {
 		NewTest(t).
 		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
-			g := galley.NewOrFail(t, ctx, galley.Config{})
-			_ = pilot.NewOrFail(t, ctx, pilot.Config{Galley: g})
 			cfg := i.Settings()
 
 			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
@@ -130,7 +126,7 @@ func TestDescribe(t *testing.T) {
 			})
 
 			deployment := file.AsStringOrFail(t, "../istioctl/testdata/a.yaml")
-			g.ApplyConfigOrFail(t, ns, deployment)
+			c.ApplyConfigOrFail(t, ns.Name(), deployment)
 
 			var a echo.Instance
 			echoboot.NewBuilderOrFail(ctx, ctx).

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -126,7 +126,7 @@ func TestDescribe(t *testing.T) {
 			})
 
 			deployment := file.AsStringOrFail(t, "../istioctl/testdata/a.yaml")
-			cluster.ApplyConfigOrFail(t, ns.Name(), deployment)
+			ctx.ApplyConfigOrFail(t, ns.Name(), deployment)
 
 			var a echo.Instance
 			echoboot.NewBuilderOrFail(ctx, ctx).

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -126,7 +126,7 @@ func TestDescribe(t *testing.T) {
 			})
 
 			deployment := file.AsStringOrFail(t, "../istioctl/testdata/a.yaml")
-			c.ApplyConfigOrFail(t, ns.Name(), deployment)
+			cluster.ApplyConfigOrFail(t, ns.Name(), deployment)
 
 			var a echo.Instance
 			echoboot.NewBuilderOrFail(ctx, ctx).

--- a/tests/integration/pilot/locality/distribute_test.go
+++ b/tests/integration/pilot/locality/distribute_test.go
@@ -68,7 +68,7 @@ func TestDistribute(t *testing.T) {
 			fakeHostname := fmt.Sprintf("fake-eds-external-service-%v.com", r.Int())
 
 			// First, deploy across multiple zones
-			deploy(ctx, ns, serviceConfig{
+			deploy(ctx, ctx, ns, serviceConfig{
 				Name:       "distribute-eds",
 				Host:       fakeHostname,
 				Namespace:  ns.Name(),
@@ -97,7 +97,7 @@ func TestDistribute(t *testing.T) {
 
 			// Set a to no locality, b to matching locality, and c to non-matching.
 			// Expect all to get even traffic after disabling locality lb.
-			deploy(ctx, ns, serviceConfig{
+			deploy(ctx, ctx, ns, serviceConfig{
 				Name:                       "distribute-eds",
 				Host:                       fakeHostname,
 				Namespace:                  ns.Name(),

--- a/tests/integration/pilot/locality/failover_test.go
+++ b/tests/integration/pilot/locality/failover_test.go
@@ -92,7 +92,7 @@ func TestFailover(t *testing.T) {
 
 					fakeHostname := fmt.Sprintf("fake-cds-external-service-%v.com", r.Int())
 
-					deploy(ctx, ns, serviceConfig{
+					deploy(ctx, ctx, ns, serviceConfig{
 						Name:                       "failover-cds",
 						Host:                       fakeHostname,
 						Namespace:                  ns.Name(),
@@ -130,7 +130,7 @@ func TestFailover(t *testing.T) {
 						BuildOrFail(ctx)
 
 					fakeHostname := fmt.Sprintf("fake-eds-external-service-%v.com", r.Int())
-					deploy(ctx, ns, serviceConfig{
+					deploy(ctx, ctx, ns, serviceConfig{
 						Name:                       "failover-eds",
 						Host:                       fakeHostname,
 						Namespace:                  ns.Name(),

--- a/tests/integration/pilot/locality/main_test.go
+++ b/tests/integration/pilot/locality/main_test.go
@@ -197,7 +197,7 @@ func TestMain(m *testing.M) {
 			if g, err = galley.New(ctx, galley.Config{}); err != nil {
 				return err
 			}
-			if p, err = pilot.New(ctx, pilot.Config{Galley: g}); err != nil {
+			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
 				return err
 			}
 			r = rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/tests/integration/pilot/locality/prioritized_test.go
+++ b/tests/integration/pilot/locality/prioritized_test.go
@@ -83,7 +83,7 @@ func TestPrioritized(t *testing.T) {
 						BuildOrFail(ctx)
 
 					fakeHostname := fmt.Sprintf("fake-cds-external-service-%v.com", r.Int())
-					deploy(ctx, ns, serviceConfig{
+					deploy(ctx, ctx, ns, serviceConfig{
 						Name:             "prioritized-cds",
 						Host:             fakeHostname,
 						Namespace:        ns.Name(),
@@ -121,7 +121,7 @@ func TestPrioritized(t *testing.T) {
 
 					fakeHostname := fmt.Sprintf("fake-eds-external-service-%v.com", r.Int())
 
-					deploy(ctx, ns, serviceConfig{
+					deploy(ctx, ctx, ns, serviceConfig{
 						Name:             "prioritized-eds",
 						Host:             fakeHostname,
 						Namespace:        ns.Name(),

--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
-	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/pilot"
 	"istio.io/istio/pkg/test/framework/resource"
@@ -27,8 +26,8 @@ import (
 
 var (
 	i istio.Instance
-	g galley.Instance
 	p pilot.Instance
+	c resource.Cluster
 )
 
 // TestMain defines the entrypoint for pilot tests using a standard Istio installation.
@@ -40,12 +39,8 @@ func TestMain(m *testing.M) {
 		RequireSingleCluster().
 		SetupOnEnv(environment.Kube, istio.Setup(&i, nil)).
 		Setup(func(ctx resource.Context) (err error) {
-			if g, err = galley.New(ctx, galley.Config{}); err != nil {
-				return err
-			}
-			if p, err = pilot.New(ctx, pilot.Config{
-				Galley: g,
-			}); err != nil {
+			c = ctx.Environment().Clusters()[0]
+			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
 				return err
 			}
 			return nil

--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -25,9 +25,8 @@ import (
 )
 
 var (
-	i       istio.Instance
-	p       pilot.Instance
-	cluster resource.Cluster
+	i istio.Instance
+	p pilot.Instance
 )
 
 // TestMain defines the entrypoint for pilot tests using a standard Istio installation.
@@ -39,7 +38,6 @@ func TestMain(m *testing.M) {
 		RequireSingleCluster().
 		SetupOnEnv(environment.Kube, istio.Setup(&i, nil)).
 		Setup(func(ctx resource.Context) (err error) {
-			cluster = ctx.Environment().Clusters()[0]
 			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
 				return err
 			}

--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -25,9 +25,9 @@ import (
 )
 
 var (
-	i istio.Instance
-	p pilot.Instance
-	c resource.Cluster
+	i       istio.Instance
+	p       pilot.Instance
+	cluster resource.Cluster
 )
 
 // TestMain defines the entrypoint for pilot tests using a standard Istio installation.
@@ -39,7 +39,7 @@ func TestMain(m *testing.M) {
 		RequireSingleCluster().
 		SetupOnEnv(environment.Kube, istio.Setup(&i, nil)).
 		Setup(func(ctx resource.Context) (err error) {
-			c = ctx.Environment().Clusters()[0]
+			cluster = ctx.Environment().Clusters()[0]
 			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
 				return err
 			}

--- a/tests/integration/pilot/meshnetwork/main_test.go
+++ b/tests/integration/pilot/meshnetwork/main_test.go
@@ -118,7 +118,7 @@ func TestAsymmetricMeshNetworkWithGatewayIP(t *testing.T) {
 				Inject: true,
 			})
 			// First setup the VM service and its endpoints
-			if err := ctx.Environment().Clusters()[0].ApplyConfig(ns.Name(), VMService); err != nil {
+			if err := ctx.ApplyConfig(ns.Name(), VMService); err != nil {
 				t.Fatal(err)
 			}
 			// Now setup a K8S service

--- a/tests/integration/pilot/meshnetwork/main_test.go
+++ b/tests/integration/pilot/meshnetwork/main_test.go
@@ -28,7 +28,6 @@ import (
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
-	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/components/pilot"
@@ -64,7 +63,6 @@ spec:
 
 var (
 	i istio.Instance
-	g galley.Instance
 	p pilot.Instance
 )
 
@@ -75,9 +73,6 @@ func TestMain(m *testing.M) {
 		Label(label.CustomSetup).
 		SetupOnEnv(environment.Kube, istio.Setup(&i, setupConfig)).
 		Setup(func(ctx resource.Context) (err error) {
-			if g, err = galley.New(ctx, galley.Config{}); err != nil {
-				return err
-			}
 			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
 				return err
 			}
@@ -123,7 +118,7 @@ func TestAsymmetricMeshNetworkWithGatewayIP(t *testing.T) {
 				Inject: true,
 			})
 			// First setup the VM service and its endpoints
-			if err := g.ApplyConfig(ns, VMService); err != nil {
+			if err := ctx.Environment().Clusters()[0].ApplyConfig(ns.Name(), VMService); err != nil {
 				t.Fatal(err)
 			}
 			// Now setup a K8S service
@@ -133,7 +128,6 @@ func TestAsymmetricMeshNetworkWithGatewayIP(t *testing.T) {
 				Namespace: ns,
 				Subsets:   []echo.SubsetConfig{{}},
 				Pilot:     p,
-				Galley:    g,
 				Ports: []echo.Port{
 					{
 						Name:        "http",

--- a/tests/integration/pilot/meshnetwork/main_test.go
+++ b/tests/integration/pilot/meshnetwork/main_test.go
@@ -78,9 +78,7 @@ func TestMain(m *testing.M) {
 			if g, err = galley.New(ctx, galley.Config{}); err != nil {
 				return err
 			}
-			if p, err = pilot.New(ctx, pilot.Config{
-				Galley: g,
-			}); err != nil {
+			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
 				return err
 			}
 			return nil

--- a/tests/integration/pilot/mirror_test.go
+++ b/tests/integration/pilot/mirror_test.go
@@ -272,13 +272,13 @@ func verifyTrafficMirror(instances [3]echo.Instance, tc testCaseMirror, testID s
 	deltaFromExpected := math.Abs(actualPercent - tc.percentage)
 
 	if tc.threshold-deltaFromExpected < 0 {
-		err := fmt.Errorf("unexpected mirror traffic. Expected %c%%, got %.1f%% (threshold: %c%%, testID: %s)",
+		err := fmt.Errorf("unexpected mirror traffic. Expected %g%%, got %.1f%% (threshold: %g%%, testID: %s)",
 			tc.percentage, actualPercent, tc.threshold, testID)
 		log.Infof("%v", err)
 		return err
 	}
 
-	log.Infof("Got expected mirror traffic. Expected %c%%, got %.1f%% (threshold: %c%%, , testID: %s)",
+	log.Infof("Got expected mirror traffic. Expected %g%%, got %.1f%% (threshold: %g%%, , testID: %s)",
 		tc.percentage, actualPercent, tc.threshold, testID)
 	return nil
 }

--- a/tests/integration/pilot/mirror_test.go
+++ b/tests/integration/pilot/mirror_test.go
@@ -23,6 +23,7 @@ import (
 
 	"istio.io/pkg/log"
 
+	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/util/retry"
 
 	"istio.io/istio/tests/util"
@@ -64,7 +65,7 @@ type mirrorTestOptions struct {
 	t              *testing.T
 	cases          []testCaseMirror
 	mirrorHost     string
-	fnInjectConfig func(ns namespace.Instance, instances [3]echo.Instance)
+	fnInjectConfig func(ns namespace.Instance, ctx resource.Context, instances [3]echo.Instance)
 }
 
 var (
@@ -164,10 +165,10 @@ func TestMirroringExternalService(t *testing.T) {
 		t:          t,
 		cases:      cases,
 		mirrorHost: fakeExternalURL,
-		fnInjectConfig: func(ns namespace.Instance, instances [3]echo.Instance) {
-			cluster.ApplyConfigOrFail(t, ns.Name(), fmt.Sprintf(sidecar, ns.Name(),
+		fnInjectConfig: func(ns namespace.Instance, ctx resource.Context, instances [3]echo.Instance) {
+			ctx.ApplyConfigOrFail(t, ns.Name(), fmt.Sprintf(sidecar, ns.Name(),
 				instances[1].Config().Domain, fakeExternalURL))
-			cluster.ApplyConfigOrFail(t, ns.Name(), fmt.Sprintf(serviceEntry, fakeExternalURL, instances[2].Address()))
+			ctx.ApplyConfigOrFail(t, ns.Name(), fmt.Sprintf(serviceEntry, fakeExternalURL, instances[2].Address()))
 			if err := outboundtrafficpolicy.WaitUntilNotCallable(instances[0], instances[2]); err != nil {
 				t.Fatalf("failed to apply sidecar, %v", err)
 			}
@@ -192,7 +193,7 @@ func runMirrorTest(options mirrorTestOptions) {
 				BuildOrFail(options.t)
 
 			if options.fnInjectConfig != nil {
-				options.fnInjectConfig(ns, instances)
+				options.fnInjectConfig(ns, ctx, instances)
 			}
 
 			for _, c := range options.cases {
@@ -211,8 +212,8 @@ func runMirrorTest(options mirrorTestOptions) {
 
 					deployment := tmpl.EvaluateOrFail(t,
 						file.AsStringOrFail(t, "testdata/traffic-mirroring-template.yaml"), vsc)
-					cluster.ApplyConfigOrFail(t, ns.Name(), deployment)
-					defer cluster.DeleteConfigOrFail(t, ns.Name(), deployment)
+					ctx.ApplyConfigOrFail(t, ns.Name(), deployment)
+					defer ctx.DeleteConfigOrFail(t, ns.Name(), deployment)
 
 					for _, proto := range mirrorProtocols {
 						t.Run(string(proto), func(t *testing.T) {

--- a/tests/integration/pilot/mirror_test.go
+++ b/tests/integration/pilot/mirror_test.go
@@ -211,8 +211,8 @@ func runMirrorTest(options mirrorTestOptions) {
 
 					deployment := tmpl.EvaluateOrFail(t,
 						file.AsStringOrFail(t, "testdata/traffic-mirroring-template.yaml"), vsc)
-					c.ApplyConfigOrFail(t, ns.Name(), deployment)
-					defer c.DeleteConfigOrFail(t, ns.Name(), deployment)
+					cluster.ApplyConfigOrFail(t, ns.Name(), deployment)
+					defer cluster.DeleteConfigOrFail(t, ns.Name(), deployment)
 
 					for _, proto := range mirrorProtocols {
 						t.Run(string(proto), func(t *testing.T) {

--- a/tests/integration/pilot/mirror_test.go
+++ b/tests/integration/pilot/mirror_test.go
@@ -165,9 +165,9 @@ func TestMirroringExternalService(t *testing.T) {
 		cases:      cases,
 		mirrorHost: fakeExternalURL,
 		fnInjectConfig: func(ns namespace.Instance, instances [3]echo.Instance) {
-			c.ApplyConfigOrFail(t, ns.Name(), fmt.Sprintf(sidecar, ns.Name(),
+			cluster.ApplyConfigOrFail(t, ns.Name(), fmt.Sprintf(sidecar, ns.Name(),
 				instances[1].Config().Domain, fakeExternalURL))
-			c.ApplyConfigOrFail(t, ns.Name(), fmt.Sprintf(serviceEntry, fakeExternalURL, instances[2].Address()))
+			cluster.ApplyConfigOrFail(t, ns.Name(), fmt.Sprintf(serviceEntry, fakeExternalURL, instances[2].Address()))
 			if err := outboundtrafficpolicy.WaitUntilNotCallable(instances[0], instances[2]); err != nil {
 				t.Fatalf("failed to apply sidecar, %v", err)
 			}

--- a/tests/integration/pilot/mirror_test.go
+++ b/tests/integration/pilot/mirror_test.go
@@ -165,9 +165,9 @@ func TestMirroringExternalService(t *testing.T) {
 		cases:      cases,
 		mirrorHost: fakeExternalURL,
 		fnInjectConfig: func(ns namespace.Instance, instances [3]echo.Instance) {
-			g.ApplyConfigOrFail(t, ns, fmt.Sprintf(sidecar, ns.Name(),
+			c.ApplyConfigOrFail(t, ns.Name(), fmt.Sprintf(sidecar, ns.Name(),
 				instances[1].Config().Domain, fakeExternalURL))
-			g.ApplyConfigOrFail(t, ns, fmt.Sprintf(serviceEntry, fakeExternalURL, instances[2].Address()))
+			c.ApplyConfigOrFail(t, ns.Name(), fmt.Sprintf(serviceEntry, fakeExternalURL, instances[2].Address()))
 			if err := outboundtrafficpolicy.WaitUntilNotCallable(instances[0], instances[2]); err != nil {
 				t.Fatalf("failed to apply sidecar, %v", err)
 			}
@@ -211,8 +211,8 @@ func runMirrorTest(options mirrorTestOptions) {
 
 					deployment := tmpl.EvaluateOrFail(t,
 						file.AsStringOrFail(t, "testdata/traffic-mirroring-template.yaml"), vsc)
-					g.ApplyConfigOrFail(t, ns, deployment)
-					defer g.DeleteConfigOrFail(t, ns, deployment)
+					c.ApplyConfigOrFail(t, ns.Name(), deployment)
+					defer c.DeleteConfigOrFail(t, ns.Name(), deployment)
 
 					for _, proto := range mirrorProtocols {
 						t.Run(string(proto), func(t *testing.T) {
@@ -272,13 +272,13 @@ func verifyTrafficMirror(instances [3]echo.Instance, tc testCaseMirror, testID s
 	deltaFromExpected := math.Abs(actualPercent - tc.percentage)
 
 	if tc.threshold-deltaFromExpected < 0 {
-		err := fmt.Errorf("unexpected mirror traffic. Expected %g%%, got %.1f%% (threshold: %g%%, testID: %s)",
+		err := fmt.Errorf("unexpected mirror traffic. Expected %c%%, got %.1f%% (threshold: %c%%, testID: %s)",
 			tc.percentage, actualPercent, tc.threshold, testID)
 		log.Infof("%v", err)
 		return err
 	}
 
-	log.Infof("Got expected mirror traffic. Expected %g%%, got %.1f%% (threshold: %g%%, , testID: %s)",
+	log.Infof("Got expected mirror traffic. Expected %c%%, got %.1f%% (threshold: %c%%, , testID: %s)",
 		tc.percentage, actualPercent, tc.threshold, testID)
 	return nil
 }

--- a/tests/integration/pilot/ping_test.go
+++ b/tests/integration/pilot/ping_test.go
@@ -77,7 +77,6 @@ func doTest(t *testing.T, ctx framework.TestContext) {
 			Namespace:           ns,
 			Ports:               ports,
 			Subsets:             []echo.SubsetConfig{{}},
-			Galley:              g,
 			Pilot:               p,
 			IncludeInboundPorts: "*",
 		}).
@@ -86,7 +85,6 @@ func doTest(t *testing.T, ctx framework.TestContext) {
 			Namespace:           ns,
 			Subsets:             []echo.SubsetConfig{{}},
 			Ports:               ports,
-			Galley:              g,
 			Pilot:               p,
 			IncludeInboundPorts: "*",
 		}).
@@ -96,7 +94,6 @@ func doTest(t *testing.T, ctx framework.TestContext) {
 				Namespace: ns,
 				Subsets:   []echo.SubsetConfig{{}},
 				Ports:     ports,
-				Galley:    g,
 				Pilot:     p,
 			}).
 		With(&inoutUnitedApp1, echo.Config{
@@ -104,7 +101,6 @@ func doTest(t *testing.T, ctx framework.TestContext) {
 			Namespace: ns,
 			Subsets:   []echo.SubsetConfig{{}},
 			Ports:     ports,
-			Galley:    g,
 			Pilot:     p,
 		}).
 		BuildOrFail(ctx)

--- a/tests/integration/pilot/protocol_sniffing_test.go
+++ b/tests/integration/pilot/protocol_sniffing_test.go
@@ -82,14 +82,12 @@ func runTest(t *testing.T, ctx framework.TestContext) {
 			Namespace: ns,
 			Ports:     ports,
 			Subsets:   []echo.SubsetConfig{{}},
-			Galley:    g,
 			Pilot:     p,
 		}).
 		With(&fromWithoutSidecar, echo.Config{
 			Service:   "from-without-sidecar",
 			Namespace: ns,
 			Ports:     ports,
-			Galley:    g,
 			Pilot:     p,
 			Subsets: []echo.SubsetConfig{
 				{
@@ -105,7 +103,6 @@ func runTest(t *testing.T, ctx framework.TestContext) {
 			Namespace: ns,
 			Subsets:   []echo.SubsetConfig{{}},
 			Ports:     ports,
-			Galley:    g,
 			Pilot:     p,
 		}).
 		BuildOrFail(ctx)

--- a/tests/integration/pilot/routing_test.go
+++ b/tests/integration/pilot/routing_test.go
@@ -104,8 +104,8 @@ spec:
 			}
 			for _, tt := range cases {
 				ctx.NewSubTest(tt.name).Run(func(ctx framework.TestContext) {
-					g.ApplyConfigOrFail(ctx, ns, tt.vs)
-					defer g.DeleteConfigOrFail(ctx, ns, tt.vs)
+					c.ApplyConfigOrFail(ctx, ns.Name(), tt.vs)
+					defer c.DeleteConfigOrFail(ctx, ns.Name(), tt.vs)
 					retry.UntilSuccessOrFail(ctx, func() error {
 						resp, err := client.Call(echo.CallOptions{
 							Target:   server,

--- a/tests/integration/pilot/routing_test.go
+++ b/tests/integration/pilot/routing_test.go
@@ -104,8 +104,8 @@ spec:
 			}
 			for _, tt := range cases {
 				ctx.NewSubTest(tt.name).Run(func(ctx framework.TestContext) {
-					cluster.ApplyConfigOrFail(ctx, ns.Name(), tt.vs)
-					defer cluster.DeleteConfigOrFail(ctx, ns.Name(), tt.vs)
+					ctx.ApplyConfigOrFail(ctx, ns.Name(), tt.vs)
+					defer ctx.DeleteConfigOrFail(ctx, ns.Name(), tt.vs)
 					retry.UntilSuccessOrFail(ctx, func() error {
 						resp, err := client.Call(echo.CallOptions{
 							Target:   server,

--- a/tests/integration/pilot/routing_test.go
+++ b/tests/integration/pilot/routing_test.go
@@ -104,8 +104,8 @@ spec:
 			}
 			for _, tt := range cases {
 				ctx.NewSubTest(tt.name).Run(func(ctx framework.TestContext) {
-					c.ApplyConfigOrFail(ctx, ns.Name(), tt.vs)
-					defer c.DeleteConfigOrFail(ctx, ns.Name(), tt.vs)
+					cluster.ApplyConfigOrFail(ctx, ns.Name(), tt.vs)
+					defer cluster.DeleteConfigOrFail(ctx, ns.Name(), tt.vs)
 					retry.UntilSuccessOrFail(ctx, func() error {
 						resp, err := client.Call(echo.CallOptions{
 							Target:   server,

--- a/tests/integration/pilot/sidecar_api_test.go
+++ b/tests/integration/pilot/sidecar_api_test.go
@@ -66,12 +66,12 @@ func TestSidecarListeners(t *testing.T) {
 			if err != nil {
 				t.Fatalf("No such directory: %v", err)
 			}
-			err = c.ApplyConfigDir("", path)
+			err = cluster.ApplyConfigDir("", path)
 			if err != nil {
 				t.Fatalf("Error applying directory: %v", err)
 			}
 			defer func() {
-				if err := c.DeleteConfigDir("", path); err != nil {
+				if err := cluster.DeleteConfigDir("", path); err != nil {
 					scopes.CI.Errorf("failed to delete directory: %v", err)
 				}
 			}()

--- a/tests/integration/pilot/sidecar_api_test.go
+++ b/tests/integration/pilot/sidecar_api_test.go
@@ -66,12 +66,12 @@ func TestSidecarListeners(t *testing.T) {
 			if err != nil {
 				t.Fatalf("No such directory: %v", err)
 			}
-			err = cluster.ApplyConfigDir("", path)
+			err = ctx.ApplyConfigDir("", path)
 			if err != nil {
 				t.Fatalf("Error applying directory: %v", err)
 			}
 			defer func() {
-				if err := cluster.DeleteConfigDir("", path); err != nil {
+				if err := ctx.DeleteConfigDir("", path); err != nil {
 					scopes.CI.Errorf("failed to delete directory: %v", err)
 				}
 			}()

--- a/tests/integration/pilot/sidecar_api_test.go
+++ b/tests/integration/pilot/sidecar_api_test.go
@@ -66,12 +66,12 @@ func TestSidecarListeners(t *testing.T) {
 			if err != nil {
 				t.Fatalf("No such directory: %v", err)
 			}
-			err = g.ApplyConfigDir(nil, path)
+			err = c.ApplyConfigDir("", path)
 			if err != nil {
 				t.Fatalf("Error applying directory: %v", err)
 			}
 			defer func() {
-				if err := g.DeleteConfigDir(nil, path); err != nil {
+				if err := c.DeleteConfigDir("", path); err != nil {
 					scopes.CI.Errorf("failed to delete directory: %v", err)
 				}
 			}()

--- a/tests/integration/pilot/sidecarscope/main_test.go
+++ b/tests/integration/pilot/sidecarscope/main_test.go
@@ -200,7 +200,6 @@ type Config struct {
 
 func setupTest(t *testing.T, ctx resource.Context, modifyConfig func(c Config) Config) (pilot.Instance, *model.Proxy) {
 	p := pilot.NewOrFail(t, ctx, pilot.Config{})
-	cluster := ctx.Environment().Clusters()[0]
 
 	includedNamespace := namespace.NewOrFail(t, ctx, namespace.Config{
 		Prefix: "included",
@@ -223,13 +222,13 @@ func setupTest(t *testing.T, ctx resource.Context, modifyConfig func(c Config) C
 	})
 
 	// Apply all configs
-	createConfig(t, cluster, config, SidecarConfig, appNamespace)
-	createConfig(t, cluster, config, AppConfig, appNamespace)
-	createConfig(t, cluster, config, AppConfigListener, appNamespace)
-	createConfig(t, cluster, config, ExcludedConfig, excludedNamespace)
-	createConfig(t, cluster, config, IncludedConfig, includedNamespace)
-	createConfig(t, cluster, config, IncludedConfigListener, includedNamespace)
-	createConfig(t, cluster, config, ExcludedConfigListener, excludedNamespace)
+	createConfig(t, ctx, config, SidecarConfig, appNamespace)
+	createConfig(t, ctx, config, AppConfig, appNamespace)
+	createConfig(t, ctx, config, AppConfigListener, appNamespace)
+	createConfig(t, ctx, config, ExcludedConfig, excludedNamespace)
+	createConfig(t, ctx, config, IncludedConfig, includedNamespace)
+	createConfig(t, ctx, config, IncludedConfigListener, includedNamespace)
+	createConfig(t, ctx, config, ExcludedConfigListener, excludedNamespace)
 
 	time.Sleep(time.Second * 2)
 
@@ -244,7 +243,7 @@ func setupTest(t *testing.T, ctx resource.Context, modifyConfig func(c Config) C
 	return p, nodeID
 }
 
-func createConfig(t *testing.T, cluster resource.Cluster, config Config, yaml string, namespace namespace.Instance) {
+func createConfig(t *testing.T, ctx resource.Context, config Config, yaml string, namespace namespace.Instance) {
 	tmpl, err := template.New("Config").Parse(yaml)
 	if err != nil {
 		t.Errorf("failed to create template: %v", err)
@@ -253,7 +252,7 @@ func createConfig(t *testing.T, cluster resource.Cluster, config Config, yaml st
 	if err := tmpl.Execute(&buf, config); err != nil {
 		t.Errorf("failed to create template: %v", err)
 	}
-	if err := cluster.ApplyConfig(namespace.Name(), buf.String()); err != nil {
+	if err := ctx.ApplyConfig(namespace.Name(), buf.String()); err != nil {
 		t.Fatalf("failed to apply config: %v. Config: %v", err, buf.String())
 	}
 }

--- a/tests/integration/pilot/sidecarscope/main_test.go
+++ b/tests/integration/pilot/sidecarscope/main_test.go
@@ -201,7 +201,7 @@ type Config struct {
 
 func setupTest(t *testing.T, ctx resource.Context, modifyConfig func(c Config) Config) (pilot.Instance, *model.Proxy) {
 	g := galley.NewOrFail(t, ctx, galley.Config{})
-	p := pilot.NewOrFail(t, ctx, pilot.Config{Galley: g})
+	p := pilot.NewOrFail(t, ctx, pilot.Config{})
 
 	includedNamespace := namespace.NewOrFail(t, ctx, namespace.Config{
 		Prefix: "included",

--- a/tests/integration/pilot/tls_test.go
+++ b/tests/integration/pilot/tls_test.go
@@ -111,7 +111,7 @@ spec:
 							TLS:          true,
 						},
 					},
-					Pilot:  p,
+					Pilot: p,
 					// Set up TLS certs on the server. This will make the server listen with these credentials.
 					TLSSettings: &common.TLSSettings{
 						RootCert:   mustReadFile(t, "root-cert.pem"),

--- a/tests/integration/pilot/tls_test.go
+++ b/tests/integration/pilot/tls_test.go
@@ -55,7 +55,7 @@ func TestDestinationRuleTLS(t *testing.T) {
 			})
 
 			// Setup our destination rule, enforcing TLS to "server". These certs will be created/mounted below.
-			c.ApplyConfigOrFail(t, ns.Name(), `
+			cluster.ApplyConfigOrFail(t, ns.Name(), `
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:

--- a/tests/integration/pilot/tls_test.go
+++ b/tests/integration/pilot/tls_test.go
@@ -55,7 +55,7 @@ func TestDestinationRuleTLS(t *testing.T) {
 			})
 
 			// Setup our destination rule, enforcing TLS to "server". These certs will be created/mounted below.
-			g.ApplyConfigOrFail(t, ns, `
+			c.ApplyConfigOrFail(t, ns.Name(), `
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
@@ -77,7 +77,6 @@ spec:
 					Service:   "client",
 					Namespace: ns,
 					Ports:     []echo.Port{},
-					Galley:    g,
 					Pilot:     p,
 					Subsets: []echo.SubsetConfig{{
 						Version: "v1",
@@ -112,7 +111,6 @@ spec:
 							TLS:          true,
 						},
 					},
-					Galley: g,
 					Pilot:  p,
 					// Set up TLS certs on the server. This will make the server listen with these credentials.
 					TLSSettings: &common.TLSSettings{

--- a/tests/integration/pilot/tls_test.go
+++ b/tests/integration/pilot/tls_test.go
@@ -55,7 +55,7 @@ func TestDestinationRuleTLS(t *testing.T) {
 			})
 
 			// Setup our destination rule, enforcing TLS to "server". These certs will be created/mounted below.
-			cluster.ApplyConfigOrFail(t, ns.Name(), `
+			ctx.ApplyConfigOrFail(t, ns.Name(), `
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:

--- a/tests/integration/pilot/traffic_shifting_test.go
+++ b/tests/integration/pilot/traffic_shifting_test.go
@@ -161,10 +161,10 @@ func sendTraffic(t *testing.T, batchSize int, from, to echo.Instance, hosts []st
 			percentOfTrafficToHost := float64(hitCount[v]) * 100.0 / float64(totalRequests)
 			deltaFromExpected := math.Abs(float64(weight[i]) - percentOfTrafficToHost)
 			if errorThreshold-deltaFromExpected < 0 {
-				return fmt.Errorf("unexpected traffic weight for host %v. Expected %d%%, got %c%% (thresold: %c%%)",
+				return fmt.Errorf("unexpected traffic weight for host %v. Expected %d%%, got %g%% (thresold: %g%%)",
 					v, weight[i], percentOfTrafficToHost, errorThreshold)
 			}
-			t.Logf("Got expected traffic weight for host %v. Expected %d%%, got %c%% (thresold: %c%%)",
+			t.Logf("Got expected traffic weight for host %v. Expected %d%%, got %g%% (thresold: %g%%)",
 				v, weight[i], percentOfTrafficToHost, errorThreshold)
 		}
 		return nil

--- a/tests/integration/pilot/traffic_shifting_test.go
+++ b/tests/integration/pilot/traffic_shifting_test.go
@@ -108,7 +108,7 @@ func TestTrafficShifting(t *testing.T) {
 					}
 
 					deployment := tmpl.EvaluateOrFail(t, file.AsStringOrFail(t, "testdata/traffic-shifting.yaml"), vsc)
-					g.ApplyConfigOrFail(t, ns, deployment)
+					c.ApplyConfigOrFail(t, ns.Name(), deployment)
 
 					sendTraffic(t, 100, instances[0], instances[1], hosts, v, errorThreshold)
 				})
@@ -129,7 +129,6 @@ func echoConfig(ns namespace.Instance, name string) echo.Config {
 			},
 		},
 		Subsets: []echo.SubsetConfig{{}},
-		Galley:  g,
 		Pilot:   p,
 	}
 }
@@ -162,10 +161,10 @@ func sendTraffic(t *testing.T, batchSize int, from, to echo.Instance, hosts []st
 			percentOfTrafficToHost := float64(hitCount[v]) * 100.0 / float64(totalRequests)
 			deltaFromExpected := math.Abs(float64(weight[i]) - percentOfTrafficToHost)
 			if errorThreshold-deltaFromExpected < 0 {
-				return fmt.Errorf("unexpected traffic weight for host %v. Expected %d%%, got %g%% (thresold: %g%%)",
+				return fmt.Errorf("unexpected traffic weight for host %v. Expected %d%%, got %c%% (thresold: %c%%)",
 					v, weight[i], percentOfTrafficToHost, errorThreshold)
 			}
-			t.Logf("Got expected traffic weight for host %v. Expected %d%%, got %g%% (thresold: %g%%)",
+			t.Logf("Got expected traffic weight for host %v. Expected %d%%, got %c%% (thresold: %c%%)",
 				v, weight[i], percentOfTrafficToHost, errorThreshold)
 		}
 		return nil

--- a/tests/integration/pilot/traffic_shifting_test.go
+++ b/tests/integration/pilot/traffic_shifting_test.go
@@ -108,7 +108,7 @@ func TestTrafficShifting(t *testing.T) {
 					}
 
 					deployment := tmpl.EvaluateOrFail(t, file.AsStringOrFail(t, "testdata/traffic-shifting.yaml"), vsc)
-					c.ApplyConfigOrFail(t, ns.Name(), deployment)
+					cluster.ApplyConfigOrFail(t, ns.Name(), deployment)
 
 					sendTraffic(t, 100, instances[0], instances[1], hosts, v, errorThreshold)
 				})

--- a/tests/integration/pilot/traffic_shifting_test.go
+++ b/tests/integration/pilot/traffic_shifting_test.go
@@ -108,7 +108,7 @@ func TestTrafficShifting(t *testing.T) {
 					}
 
 					deployment := tmpl.EvaluateOrFail(t, file.AsStringOrFail(t, "testdata/traffic-shifting.yaml"), vsc)
-					cluster.ApplyConfigOrFail(t, ns.Name(), deployment)
+					ctx.ApplyConfigOrFail(t, ns.Name(), deployment)
 
 					sendTraffic(t, 100, instances[0], instances[1], hosts, v, errorThreshold)
 				})

--- a/tests/integration/qualification/loadbalancing_test.go
+++ b/tests/integration/qualification/loadbalancing_test.go
@@ -27,7 +27,6 @@ import (
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/bookinfo"
-	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/components/ingress"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/components/prometheus"
@@ -61,8 +60,6 @@ func TestIngressLoadBalancing(t *testing.T) {
 
 	ctx.RequireOrSkip(environment.Kube)
 
-	g := galley.NewOrFail(t, ctx, galley.Config{})
-
 	bookinfoNs, err := namespace.New(ctx, namespace.Config{
 		Prefix: "istio-bookinfo",
 		Inject: true,
@@ -73,13 +70,13 @@ func TestIngressLoadBalancing(t *testing.T) {
 	undeploy := bookinfo.DeployOrFail(t, ctx, bookinfo.Config{Namespace: bookinfoNs, Cfg: bookinfo.BookInfo})
 	defer undeploy()
 
-	g.ApplyConfigOrFail(
+	ctx.ApplyConfigOrFail(
 		t,
-		bookinfoNs,
+		bookinfoNs.Name(),
 		bookinfo.NetworkingBookinfoGateway.LoadGatewayFileWithNamespaceOrFail(t, bookinfoNs.Name()))
-	g.ApplyConfigOrFail(
+	ctx.ApplyConfigOrFail(
 		t,
-		bookinfoNs,
+		bookinfoNs.Name(),
 		bookinfo.GetDestinationRuleConfigFileOrFail(t, ctx).LoadWithNamespaceOrFail(t, bookinfoNs.Name()),
 		bookinfo.NetworkingVirtualServiceAllV1.LoadWithNamespaceOrFail(t, bookinfoNs.Name()),
 	)

--- a/tests/integration/security/authorization_test.go
+++ b/tests/integration/security/authorization_test.go
@@ -63,9 +63,9 @@ func TestAuthorization_mTLS(t *testing.T) {
 
 			var a, b, c echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&a, util.EchoConfig("a", ns, false, nil, g, p)).
-				With(&b, util.EchoConfig("b", ns, false, nil, g, p)).
-				With(&c, util.EchoConfig("c", ns2, false, nil, g, p)).
+				With(&a, util.EchoConfig("a", ns, false, nil, p)).
+				With(&b, util.EchoConfig("b", ns, false, nil, p)).
+				With(&c, util.EchoConfig("c", ns2, false, nil, p)).
 				BuildOrFail(t)
 
 			newTestCase := func(from echo.Instance, path string, expectAllowed bool) rbacUtil.TestCase {
@@ -123,10 +123,10 @@ func TestAuthorization_JWT(t *testing.T) {
 
 			var a, b, c, d echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&a, util.EchoConfig("a", ns, false, nil, g, p)).
-				With(&b, util.EchoConfig("b", ns, false, nil, g, p)).
-				With(&c, util.EchoConfig("c", ns, false, nil, g, p)).
-				With(&d, util.EchoConfig("d", ns, false, nil, g, p)).
+				With(&a, util.EchoConfig("a", ns, false, nil, p)).
+				With(&b, util.EchoConfig("b", ns, false, nil, p)).
+				With(&c, util.EchoConfig("c", ns, false, nil, p)).
+				With(&d, util.EchoConfig("d", ns, false, nil, p)).
 				BuildOrFail(t)
 
 			newTestCase := func(target echo.Instance, namePrefix string, jwt string, path string, expectAllowed bool) rbacUtil.TestCase {
@@ -199,10 +199,10 @@ func TestAuthorization_WorkloadSelector(t *testing.T) {
 
 			var a, bInNS1, cInNS1, cInNS2 echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&a, util.EchoConfig("a", ns1, false, nil, g, p)).
-				With(&bInNS1, util.EchoConfig("b", ns1, false, nil, g, p)).
-				With(&cInNS1, util.EchoConfig("c", ns1, false, nil, g, p)).
-				With(&cInNS2, util.EchoConfig("c", ns2, false, nil, g, p)).
+				With(&a, util.EchoConfig("a", ns1, false, nil, p)).
+				With(&bInNS1, util.EchoConfig("b", ns1, false, nil, p)).
+				With(&cInNS1, util.EchoConfig("c", ns1, false, nil, p)).
+				With(&cInNS2, util.EchoConfig("c", ns2, false, nil, p)).
 				BuildOrFail(t)
 
 			newTestCase := func(namePrefix string, target echo.Instance, path string, expectAllowed bool) rbacUtil.TestCase {
@@ -281,9 +281,9 @@ func TestAuthorization_Deny(t *testing.T) {
 
 			var a, b, c echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&a, util.EchoConfig("a", ns, false, nil, g, p)).
-				With(&b, util.EchoConfig("b", ns, false, nil, g, p)).
-				With(&c, util.EchoConfig("c", ns, false, nil, g, p)).
+				With(&a, util.EchoConfig("a", ns, false, nil, p)).
+				With(&b, util.EchoConfig("b", ns, false, nil, p)).
+				With(&c, util.EchoConfig("c", ns, false, nil, p)).
 				BuildOrFail(t)
 
 			newTestCase := func(target echo.Instance, path string, expectAllowed bool) rbacUtil.TestCase {
@@ -369,11 +369,11 @@ func TestAuthorization_NegativeMatch(t *testing.T) {
 
 			var a, b, c, d, x echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&a, util.EchoConfig("a", ns, false, nil, g, p)).
-				With(&b, util.EchoConfig("b", ns, false, nil, g, p)).
-				With(&c, util.EchoConfig("c", ns, false, nil, g, p)).
-				With(&d, util.EchoConfig("d", ns, false, nil, g, p)).
-				With(&x, util.EchoConfig("x", ns2, false, nil, g, p)).
+				With(&a, util.EchoConfig("a", ns, false, nil, p)).
+				With(&b, util.EchoConfig("b", ns, false, nil, p)).
+				With(&c, util.EchoConfig("c", ns, false, nil, p)).
+				With(&d, util.EchoConfig("d", ns, false, nil, p)).
+				With(&x, util.EchoConfig("x", ns2, false, nil, p)).
 				BuildOrFail(t)
 
 			newTestCase := func(from, target echo.Instance, path string, expectAllowed bool) rbacUtil.TestCase {
@@ -450,7 +450,7 @@ func TestAuthorization_IngressGateway(t *testing.T) {
 
 			var b echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&b, util.EchoConfig("b", ns, false, nil, g, p)).
+				With(&b, util.EchoConfig("b", ns, false, nil, p)).
 				BuildOrFail(t)
 
 			var ingr ingress.Instance
@@ -523,7 +523,7 @@ func TestAuthorization_EgressGateway(t *testing.T) {
 
 			var a, b echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&a, util.EchoConfig("a", ns, false, nil, g, p)).
+				With(&a, util.EchoConfig("a", ns, false, nil, p)).
 				With(&b, echo.Config{
 					Service:   "b",
 					Namespace: ns,
@@ -640,7 +640,7 @@ func TestAuthorization_TCP(t *testing.T) {
 				},
 			}
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&x, util.EchoConfig("x", ns2, false, nil, g, p)).
+				With(&x, util.EchoConfig("x", ns2, false, nil, p)).
 				With(&a, echo.Config{
 					Subsets:        []echo.SubsetConfig{{}},
 					Namespace:      ns,
@@ -765,8 +765,8 @@ func TestAuthorization_Conditions(t *testing.T) {
 			portC := 8090
 			var a, b, c echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&a, util.EchoConfig("a", nsA, false, nil, g, p)).
-				With(&b, util.EchoConfig("b", nsB, false, nil, g, p)).
+				With(&a, util.EchoConfig("a", nsA, false, nil, p)).
+				With(&b, util.EchoConfig("b", nsB, false, nil, p)).
 				With(&c, echo.Config{
 					Service:   "c",
 					Namespace: nsC,
@@ -868,10 +868,10 @@ func TestAuthorization_GRPC(t *testing.T) {
 			})
 			var a, b, c, d echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&a, util.EchoConfig("a", ns, false, nil, g, p)).
-				With(&b, util.EchoConfig("b", ns, false, nil, g, p)).
-				With(&c, util.EchoConfig("c", ns, false, nil, g, p)).
-				With(&d, util.EchoConfig("d", ns, false, nil, g, p)).
+				With(&a, util.EchoConfig("a", ns, false, nil, p)).
+				With(&b, util.EchoConfig("b", ns, false, nil, p)).
+				With(&c, util.EchoConfig("c", ns, false, nil, p)).
+				With(&d, util.EchoConfig("d", ns, false, nil, p)).
 				BuildOrFail(t)
 
 			cases := []rbacUtil.TestCase{

--- a/tests/integration/security/authorization_test.go
+++ b/tests/integration/security/authorization_test.go
@@ -360,7 +360,11 @@ func TestAuthorization_NegativeMatch(t *testing.T) {
 
 			applyPolicy := func(filename string, ns namespace.Instance) []string {
 				policy := tmpl.EvaluateAllOrFail(t, args, file.AsStringOrFail(t, filename))
-				ctx.ApplyConfigOrFail(t, ns.Name(), policy...)
+				name := ""
+				if ns != nil {
+					name = ns.Name()
+				}
+				ctx.ApplyConfigOrFail(t, name, policy...)
 				return policy
 			}
 

--- a/tests/integration/security/authorization_test.go
+++ b/tests/integration/security/authorization_test.go
@@ -96,8 +96,8 @@ func TestAuthorization_mTLS(t *testing.T) {
 			policies := tmpl.EvaluateAllOrFail(t, args,
 				file.AsStringOrFail(t, "testdata/authz/v1beta1-mtls.yaml.tmpl"))
 
-			g.ApplyConfigOrFail(t, ns, policies...)
-			defer g.DeleteConfigOrFail(t, ns, policies...)
+			ctx.ApplyConfigOrFail(t, ns.Name(), policies...)
+			defer ctx.DeleteConfigOrFail(t, ns.Name(), policies...)
 
 			rbacUtil.RunRBACTest(t, cases)
 		})
@@ -118,8 +118,8 @@ func TestAuthorization_JWT(t *testing.T) {
 			}
 			policies := tmpl.EvaluateAllOrFail(t, args,
 				file.AsStringOrFail(t, "testdata/authz/v1beta1-jwt.yaml.tmpl"))
-			g.ApplyConfigOrFail(t, ns, policies...)
-			defer g.DeleteConfigOrFail(t, ns, policies...)
+			ctx.ApplyConfigOrFail(t, ns.Name(), policies...)
+			defer ctx.DeleteConfigOrFail(t, ns.Name(), policies...)
 
 			var a, b, c, d echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
@@ -254,16 +254,16 @@ func TestAuthorization_WorkloadSelector(t *testing.T) {
 
 			applyPolicy := func(filename string, ns namespace.Instance) []string {
 				policy := tmpl.EvaluateAllOrFail(t, args, file.AsStringOrFail(t, filename))
-				g.ApplyConfigOrFail(t, ns, policy...)
+				ctx.ApplyConfigOrFail(t, ns.Name(), policy...)
 				return policy
 			}
 
 			policyNS1 := applyPolicy("testdata/authz/v1beta1-workload-ns1.yaml.tmpl", ns1)
-			defer g.DeleteConfigOrFail(t, ns1, policyNS1...)
+			defer ctx.DeleteConfigOrFail(t, ns1.Name(), policyNS1...)
 			policyNS2 := applyPolicy("testdata/authz/v1beta1-workload-ns2.yaml.tmpl", ns2)
-			defer g.DeleteConfigOrFail(t, ns2, policyNS2...)
+			defer ctx.DeleteConfigOrFail(t, ns2.Name(), policyNS2...)
 			policyNSRoot := applyPolicy("testdata/authz/v1beta1-workload-ns-root.yaml.tmpl", rootNS{})
-			defer g.DeleteConfigOrFail(t, rootNS{}, policyNSRoot...)
+			defer ctx.DeleteConfigOrFail(t, rootNS{}.Name(), policyNSRoot...)
 
 			rbacUtil.RunRBACTest(t, cases)
 		})
@@ -326,14 +326,14 @@ func TestAuthorization_Deny(t *testing.T) {
 
 			applyPolicy := func(filename string, ns namespace.Instance) []string {
 				policy := tmpl.EvaluateAllOrFail(t, args, file.AsStringOrFail(t, filename))
-				g.ApplyConfigOrFail(t, ns, policy...)
+				ctx.ApplyConfigOrFail(t, ns.Name(), policy...)
 				return policy
 			}
 
 			policy := applyPolicy("testdata/authz/v1beta1-deny.yaml.tmpl", ns)
-			defer g.DeleteConfigOrFail(t, ns, policy...)
+			defer ctx.DeleteConfigOrFail(t, ns.Name(), policy...)
 			policyNSRoot := applyPolicy("testdata/authz/v1beta1-deny-ns-root.yaml.tmpl", rootNS{})
-			defer g.DeleteConfigOrFail(t, rootNS{}, policyNSRoot...)
+			defer ctx.DeleteConfigOrFail(t, rootNS{}.Name(), policyNSRoot...)
 
 			rbacUtil.RunRBACTest(t, cases)
 		})
@@ -360,12 +360,12 @@ func TestAuthorization_NegativeMatch(t *testing.T) {
 
 			applyPolicy := func(filename string, ns namespace.Instance) []string {
 				policy := tmpl.EvaluateAllOrFail(t, args, file.AsStringOrFail(t, filename))
-				g.ApplyConfigOrFail(t, ns, policy...)
+				ctx.ApplyConfigOrFail(t, ns.Name(), policy...)
 				return policy
 			}
 
 			policies := applyPolicy("testdata/authz/v1beta1-negative-match.yaml.tmpl", nil)
-			defer g.DeleteConfigOrFail(t, nil, policies...)
+			defer ctx.DeleteConfigOrFail(t, "", policies...)
 
 			var a, b, c, d, x echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
@@ -442,11 +442,11 @@ func TestAuthorization_IngressGateway(t *testing.T) {
 
 			applyPolicy := func(filename string) []string {
 				policy := tmpl.EvaluateAllOrFail(t, args, file.AsStringOrFail(t, filename))
-				g.ApplyConfigOrFail(t, nil, policy...)
+				ctx.ApplyConfigOrFail(t, "", policy...)
 				return policy
 			}
 			policies := applyPolicy("testdata/authz/v1beta1-ingress-gateway.yaml.tmpl")
-			defer g.DeleteConfigOrFail(t, nil, policies...)
+			defer ctx.DeleteConfigOrFail(t, "", policies...)
 
 			var b echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
@@ -535,8 +535,7 @@ func TestAuthorization_EgressGateway(t *testing.T) {
 							ServicePort: 8090,
 						},
 					},
-					Galley: g,
-					Pilot:  p,
+					Pilot: p,
 				}).
 				BuildOrFail(t)
 
@@ -546,8 +545,8 @@ func TestAuthorization_EgressGateway(t *testing.T) {
 			}
 			policies := tmpl.EvaluateAllOrFail(t, args,
 				file.AsStringOrFail(t, "testdata/authz/v1beta1-egress-gateway.yaml.tmpl"))
-			g.ApplyConfigOrFail(t, nil, policies...)
-			defer g.DeleteConfigOrFail(t, nil, policies...)
+			ctx.ApplyConfigOrFail(t, "", policies...)
+			defer ctx.DeleteConfigOrFail(t, "", policies...)
 
 			cases := []struct {
 				path string
@@ -618,8 +617,8 @@ func TestAuthorization_TCP(t *testing.T) {
 				"Namespace":  ns.Name(),
 				"Namespace2": ns2.Name(),
 			}, file.AsStringOrFail(t, "testdata/authz/v1beta1-tcp.yaml.tmpl"))
-			g.ApplyConfigOrFail(t, nil, policy...)
-			defer g.DeleteConfigOrFail(t, nil, policy...)
+			ctx.ApplyConfigOrFail(t, "", policy...)
+			defer ctx.DeleteConfigOrFail(t, "", policy...)
 
 			var a, b, c, d, e, x echo.Instance
 			ports := []echo.Port{
@@ -644,7 +643,6 @@ func TestAuthorization_TCP(t *testing.T) {
 				With(&a, echo.Config{
 					Subsets:        []echo.SubsetConfig{{}},
 					Namespace:      ns,
-					Galley:         g,
 					Pilot:          p,
 					Service:        "a",
 					Ports:          ports,
@@ -653,7 +651,6 @@ func TestAuthorization_TCP(t *testing.T) {
 				With(&b, echo.Config{
 					Namespace:      ns,
 					Subsets:        []echo.SubsetConfig{{}},
-					Galley:         g,
 					Pilot:          p,
 					Service:        "b",
 					Ports:          ports,
@@ -662,7 +659,6 @@ func TestAuthorization_TCP(t *testing.T) {
 				With(&c, echo.Config{
 					Namespace:      ns,
 					Subsets:        []echo.SubsetConfig{{}},
-					Galley:         g,
 					Pilot:          p,
 					Service:        "c",
 					Ports:          ports,
@@ -671,7 +667,6 @@ func TestAuthorization_TCP(t *testing.T) {
 				With(&d, echo.Config{
 					Namespace:      ns,
 					Subsets:        []echo.SubsetConfig{{}},
-					Galley:         g,
 					Pilot:          p,
 					Service:        "d",
 					Ports:          ports,
@@ -679,7 +674,6 @@ func TestAuthorization_TCP(t *testing.T) {
 				}).
 				With(&e, echo.Config{
 					Namespace:      ns,
-					Galley:         g,
 					Pilot:          p,
 					Service:        "e",
 					Ports:          ports,
@@ -778,8 +772,7 @@ func TestAuthorization_Conditions(t *testing.T) {
 							InstancePort: portC,
 						},
 					},
-					Galley: g,
-					Pilot:  p,
+					Pilot: p,
 				}).
 				BuildOrFail(t)
 
@@ -793,8 +786,8 @@ func TestAuthorization_Conditions(t *testing.T) {
 				"PortC":      fmt.Sprintf("%d", portC),
 			}
 			policies := tmpl.EvaluateAllOrFail(t, args, file.AsStringOrFail(t, "testdata/authz/v1beta1-conditions.yaml.tmpl"))
-			g.ApplyConfigOrFail(t, nil, policies...)
-			defer g.DeleteConfigOrFail(t, nil, policies...)
+			ctx.ApplyConfigOrFail(t, "", policies...)
+			defer ctx.DeleteConfigOrFail(t, "", policies...)
 
 			newTestCase := func(from echo.Instance, path string, headers map[string]string, expectAllowed bool) rbacUtil.TestCase {
 				return rbacUtil.TestCase{
@@ -914,8 +907,8 @@ func TestAuthorization_GRPC(t *testing.T) {
 			}
 			policies := tmpl.EvaluateAllOrFail(t, namespaceTmpl,
 				file.AsStringOrFail(t, "testdata/authz/v1beta1-grpc.yaml.tmpl"))
-			g.ApplyConfigOrFail(t, ns, policies...)
-			defer g.DeleteConfigOrFail(t, ns, policies...)
+			ctx.ApplyConfigOrFail(t, ns.Name(), policies...)
+			defer ctx.DeleteConfigOrFail(t, ns.Name(), policies...)
 
 			rbacUtil.RunRBACTest(t, cases)
 		})
@@ -948,7 +941,6 @@ func TestAuthorization_Path(t *testing.T) {
 					Namespace: ns,
 					Subsets:   []echo.SubsetConfig{{}},
 					Ports:     ports,
-					Galley:    g,
 					Pilot:     p,
 				}).
 				With(&b, echo.Config{
@@ -956,7 +948,6 @@ func TestAuthorization_Path(t *testing.T) {
 					Namespace: ns,
 					Subsets:   []echo.SubsetConfig{{}},
 					Ports:     ports,
-					Galley:    g,
 					Pilot:     p,
 				}).
 				BuildOrFail(t)
@@ -994,8 +985,8 @@ func TestAuthorization_Path(t *testing.T) {
 			}
 			policies := tmpl.EvaluateAllOrFail(t, args,
 				file.AsStringOrFail(t, "testdata/authz/v1beta1-path.yaml.tmpl"))
-			g.ApplyConfigOrFail(t, ns, policies...)
-			defer g.DeleteConfigOrFail(t, ns, policies...)
+			ctx.ApplyConfigOrFail(t, ns.Name(), policies...)
+			defer ctx.DeleteConfigOrFail(t, ns.Name(), policies...)
 
 			rbacUtil.RunRBACTest(t, cases)
 		})

--- a/tests/integration/security/chiron/main_test.go
+++ b/tests/integration/security/chiron/main_test.go
@@ -18,18 +18,13 @@ import (
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
-	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/components/istio"
-	"istio.io/istio/pkg/test/framework/components/pilot"
 	"istio.io/istio/pkg/test/framework/label"
-	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/framework/resource/environment"
 )
 
 var (
 	inst istio.Instance
-	g    galley.Instance
-	p    pilot.Instance
 )
 
 func TestMain(m *testing.M) {
@@ -39,15 +34,6 @@ func TestMain(m *testing.M) {
 		RequireSingleCluster().
 		Label(label.CustomSetup).
 		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
-		Setup(func(ctx resource.Context) (err error) {
-			if g, err = galley.New(ctx, galley.Config{}); err != nil {
-				return err
-			}
-			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
-				return err
-			}
-			return nil
-		}).
 		Run()
 }
 

--- a/tests/integration/security/chiron/main_test.go
+++ b/tests/integration/security/chiron/main_test.go
@@ -43,9 +43,7 @@ func TestMain(m *testing.M) {
 			if g, err = galley.New(ctx, galley.Config{}); err != nil {
 				return err
 			}
-			if p, err = pilot.New(ctx, pilot.Config{
-				Galley: g,
-			}); err != nil {
+			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
 				return err
 			}
 			return nil

--- a/tests/integration/security/jwt_test.go
+++ b/tests/integration/security/jwt_test.go
@@ -67,11 +67,11 @@ func TestRequestAuthentication(t *testing.T) {
 
 			var a, b, c, d, e echo.Instance
 			echoboot.NewBuilderOrFail(ctx, ctx).
-				With(&a, util.EchoConfig("a", ns, false, nil, g, p)).
-				With(&b, util.EchoConfig("b", ns, false, nil, g, p)).
-				With(&c, util.EchoConfig("c", ns, false, nil, g, p)).
-				With(&d, util.EchoConfig("d", ns, false, nil, g, p)).
-				With(&e, util.EchoConfig("e", ns, false, nil, g, p)).
+				With(&a, util.EchoConfig("a", ns, false, nil, p)).
+				With(&b, util.EchoConfig("b", ns, false, nil, p)).
+				With(&c, util.EchoConfig("c", ns, false, nil, p)).
+				With(&d, util.EchoConfig("d", ns, false, nil, p)).
+				With(&e, util.EchoConfig("e", ns, false, nil, p)).
 				BuildOrFail(t)
 
 			testCases := []authn.TestCase{
@@ -311,8 +311,8 @@ func TestIngressRequestAuthentication(t *testing.T) {
 
 			var a, b echo.Instance
 			echoboot.NewBuilderOrFail(ctx, ctx).
-				With(&a, util.EchoConfig("a", ns, false, nil, g, p)).
-				With(&b, util.EchoConfig("b", ns, false, nil, g, p)).
+				With(&a, util.EchoConfig("a", ns, false, nil, p)).
+				With(&b, util.EchoConfig("b", ns, false, nil, p)).
 				BuildOrFail(t)
 
 			// These test cases verify in-mesh traffic doesn't need tokens.

--- a/tests/integration/security/jwt_test.go
+++ b/tests/integration/security/jwt_test.go
@@ -62,8 +62,8 @@ func TestRequestAuthentication(t *testing.T) {
 				file.AsStringOrFail(t, "testdata/requestauthn/c-authn.yaml.tmpl"),
 				file.AsStringOrFail(t, "testdata/requestauthn/e-authn.yaml.tmpl"),
 			)
-			g.ApplyConfigOrFail(t, ns, jwtPolicies...)
-			defer g.DeleteConfigOrFail(t, ns, jwtPolicies...)
+			ctx.ApplyConfigOrFail(t, ns.Name(), jwtPolicies...)
+			defer ctx.DeleteConfigOrFail(t, ns.Name(), jwtPolicies...)
 
 			var a, b, c, d, e echo.Instance
 			echoboot.NewBuilderOrFail(ctx, ctx).
@@ -299,15 +299,15 @@ func TestIngressRequestAuthentication(t *testing.T) {
 
 			applyPolicy := func(filename string, ns namespace.Instance) []string {
 				policy := tmpl.EvaluateAllOrFail(t, namespaceTmpl, file.AsStringOrFail(t, filename))
-				g.ApplyConfigOrFail(t, ns, policy...)
+				ctx.ApplyConfigOrFail(t, ns.Name(), policy...)
 				return policy
 			}
 
 			securityPolicies := applyPolicy("testdata/requestauthn/global-jwt.yaml.tmpl", rootNS{})
 			ingressCfgs := applyPolicy("testdata/requestauthn/ingress.yaml.tmpl", ns)
 
-			defer g.DeleteConfigOrFail(t, rootNS{}, securityPolicies...)
-			defer g.DeleteConfigOrFail(t, ns, ingressCfgs...)
+			defer ctx.DeleteConfigOrFail(t, rootNS{}.Name(), securityPolicies...)
+			defer ctx.DeleteConfigOrFail(t, ns.Name(), ingressCfgs...)
 
 			var a, b echo.Instance
 			echoboot.NewBuilderOrFail(ctx, ctx).

--- a/tests/integration/security/main_test.go
+++ b/tests/integration/security/main_test.go
@@ -41,9 +41,7 @@ func TestMain(m *testing.M) {
 			if g, err = galley.New(ctx, galley.Config{}); err != nil {
 				return err
 			}
-			if p, err = pilot.New(ctx, pilot.Config{
-				Galley: g,
-			}); err != nil {
+			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
 				return err
 			}
 			return nil

--- a/tests/integration/security/main_test.go
+++ b/tests/integration/security/main_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
-	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/pilot"
 	"istio.io/istio/pkg/test/framework/resource"
@@ -27,7 +26,6 @@ import (
 
 var (
 	ist           istio.Instance
-	g             galley.Instance
 	p             pilot.Instance
 	rootNamespace string
 )
@@ -38,9 +36,6 @@ func TestMain(m *testing.M) {
 		RequireSingleCluster().
 		SetupOnEnv(environment.Kube, istio.Setup(&ist, setupConfig)).
 		Setup(func(ctx resource.Context) (err error) {
-			if g, err = galley.New(ctx, galley.Config{}); err != nil {
-				return err
-			}
 			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
 				return err
 			}

--- a/tests/integration/security/mtls_first_party_jwt/main_test.go
+++ b/tests/integration/security/mtls_first_party_jwt/main_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
-	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/pilot"
 	"istio.io/istio/pkg/test/framework/label"
@@ -28,7 +27,6 @@ import (
 
 var (
 	inst istio.Instance
-	g    galley.Instance
 	p    pilot.Instance
 )
 
@@ -40,9 +38,6 @@ func TestMain(m *testing.M) {
 		Label(label.CustomSetup).
 		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
 		Setup(func(ctx resource.Context) (err error) {
-			if g, err = galley.New(ctx, galley.Config{}); err != nil {
-				return err
-			}
 			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
 				return err
 			}

--- a/tests/integration/security/mtls_first_party_jwt/main_test.go
+++ b/tests/integration/security/mtls_first_party_jwt/main_test.go
@@ -43,9 +43,7 @@ func TestMain(m *testing.M) {
 			if g, err = galley.New(ctx, galley.Config{}); err != nil {
 				return err
 			}
-			if p, err = pilot.New(ctx, pilot.Config{
-				Galley: g,
-			}); err != nil {
+			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
 				return err
 			}
 			return nil

--- a/tests/integration/security/mtls_first_party_jwt/strict_test.go
+++ b/tests/integration/security/mtls_first_party_jwt/strict_test.go
@@ -35,7 +35,7 @@ func TestMtlsStrictK8sCA(t *testing.T) {
 	framework.NewTest(t).
 		Run(func(ctx framework.TestContext) {
 
-			rctx := reachability.CreateContext(ctx, g, p)
+			rctx := reachability.CreateContext(ctx, p)
 			systemNM := namespace.ClaimSystemNamespaceOrFail(ctx, ctx)
 
 			testCases := []reachability.TestCase{

--- a/tests/integration/security/mtls_healthcheck_test.go
+++ b/tests/integration/security/mtls_healthcheck_test.go
@@ -66,15 +66,14 @@ spec:
   mtls:
     mode: STRICT
 `, name, name)
-	g.ApplyConfigOrFail(t, ns, policyYAML)
-	defer g.DeleteConfigOrFail(t, ns, policyYAML)
+	ctx.ApplyConfigOrFail(t, ns.Name(), policyYAML)
+	defer ctx.DeleteConfigOrFail(t, ns.Name(), policyYAML)
 
 	var healthcheck echo.Instance
 	cfg := echo.Config{
 		Namespace: ns,
 		Service:   name,
 		Pilot:     p,
-		Galley:    g,
 		Ports: []echo.Port{{
 			Name:         "http-8080",
 			Protocol:     protocol.HTTP,

--- a/tests/integration/security/mtlscert_pluginca_securenaming/main_test.go
+++ b/tests/integration/security/mtlscert_pluginca_securenaming/main_test.go
@@ -20,7 +20,6 @@ import (
 	"istio.io/istio/tests/integration/security/util/cert"
 
 	"istio.io/istio/pkg/test/framework"
-	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/pilot"
 	"istio.io/istio/pkg/test/framework/label"
@@ -30,7 +29,6 @@ import (
 
 var (
 	inst istio.Instance
-	g    galley.Instance
 	p    pilot.Instance
 )
 
@@ -49,9 +47,6 @@ func TestMain(m *testing.M) {
 		Label(label.CustomSetup).
 		SetupOnEnv(environment.Kube, istio.Setup(&inst, nil, cert.CreateCASecret)).
 		Setup(func(ctx resource.Context) (err error) {
-			if g, err = galley.New(ctx, galley.Config{}); err != nil {
-				return err
-			}
 			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
 				return err
 			}

--- a/tests/integration/security/mtlscert_pluginca_securenaming/main_test.go
+++ b/tests/integration/security/mtlscert_pluginca_securenaming/main_test.go
@@ -52,9 +52,7 @@ func TestMain(m *testing.M) {
 			if g, err = galley.New(ctx, galley.Config{}); err != nil {
 				return err
 			}
-			if p, err = pilot.New(ctx, pilot.Config{
-				Galley: g,
-			}); err != nil {
+			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
 				return err
 			}
 			return nil

--- a/tests/integration/security/mtlscert_pluginca_securenaming/mtlscert_pluginca_securenaming_test.go
+++ b/tests/integration/security/mtlscert_pluginca_securenaming/mtlscert_pluginca_securenaming_test.go
@@ -176,7 +176,7 @@ func TestMTLSCertPluginCASecureNaming(t *testing.T) {
 				ctx.NewSubTest(tc.name).
 					Run(func(ctx framework.TestContext) {
 						dr := strings.ReplaceAll(tc.destinationRule, "NS", testNamespace.Name())
-						g.ApplyConfigOrFail(t, testNamespace, dr)
+						ctx.ApplyConfigOrFail(t, testNamespace.Name(), dr)
 						// Verify mTLS works between a and b
 						callOptions := echo.CallOptions{
 							Target:   b,

--- a/tests/integration/security/mtlscert_pluginca_securenaming/mtlscert_pluginca_securenaming_test.go
+++ b/tests/integration/security/mtlscert_pluginca_securenaming/mtlscert_pluginca_securenaming_test.go
@@ -116,8 +116,8 @@ func TestMTLSCertPluginCASecureNaming(t *testing.T) {
 			}, retry.Delay(time.Second), retry.Timeout(10*time.Second))
 			var a, b echo.Instance
 			echoboot.NewBuilderOrFail(ctx, ctx).
-				With(&a, util.EchoConfig("a", testNamespace, false, nil, g, p)).
-				With(&b, util.EchoConfig("b", testNamespace, false, nil, g, p)).
+				With(&a, util.EchoConfig("a", testNamespace, false, nil, p)).
+				With(&b, util.EchoConfig("b", testNamespace, false, nil, p)).
 				BuildOrFail(t)
 
 			ctx.NewSubTest("mTLS cert validation with plugin CA").

--- a/tests/integration/security/mtlsk8sca/main_test.go
+++ b/tests/integration/security/mtlsk8sca/main_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
-	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/pilot"
 	"istio.io/istio/pkg/test/framework/label"
@@ -28,7 +27,6 @@ import (
 
 var (
 	inst istio.Instance
-	g    galley.Instance
 	p    pilot.Instance
 )
 
@@ -40,9 +38,6 @@ func TestMain(m *testing.M) {
 		Label(label.CustomSetup).
 		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
 		Setup(func(ctx resource.Context) (err error) {
-			if g, err = galley.New(ctx, galley.Config{}); err != nil {
-				return err
-			}
 			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
 				return err
 			}

--- a/tests/integration/security/mtlsk8sca/main_test.go
+++ b/tests/integration/security/mtlsk8sca/main_test.go
@@ -43,9 +43,7 @@ func TestMain(m *testing.M) {
 			if g, err = galley.New(ctx, galley.Config{}); err != nil {
 				return err
 			}
-			if p, err = pilot.New(ctx, pilot.Config{
-				Galley: g,
-			}); err != nil {
+			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
 				return err
 			}
 			return nil

--- a/tests/integration/security/mtlsk8sca/strict_test.go
+++ b/tests/integration/security/mtlsk8sca/strict_test.go
@@ -35,7 +35,7 @@ func TestMtlsStrictK8sCA(t *testing.T) {
 	framework.NewTest(t).
 		Run(func(ctx framework.TestContext) {
 
-			rctx := reachability.CreateContext(ctx, g, p)
+			rctx := reachability.CreateContext(ctx, p)
 			systemNM := namespace.ClaimSystemNamespaceOrFail(ctx, ctx)
 
 			testCases := []reachability.TestCase{

--- a/tests/integration/security/pass_through_filter_chain_test.go
+++ b/tests/integration/security/pass_through_filter_chain_test.go
@@ -49,15 +49,14 @@ func TestPassThroughFilterChain(t *testing.T) {
 			}
 			policies := tmpl.EvaluateAllOrFail(t, args,
 				file.AsStringOrFail(t, "testdata/pass-through-filter-chain.yaml.tmpl"))
-			g.ApplyConfigOrFail(t, ns, policies...)
-			defer g.DeleteConfigOrFail(t, ns, policies...)
+			ctx.ApplyConfigOrFail(t, ns.Name(), policies...)
+			defer ctx.DeleteConfigOrFail(t, ns.Name(), policies...)
 
 			newEchoConfig := func(service string) echo.Config {
 				return echo.Config{
 					Service:   service,
 					Namespace: ns,
 					Subsets:   []echo.SubsetConfig{{}},
-					Galley:    g,
 					Pilot:     p,
 					Ports: []echo.Port{
 						{

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -37,7 +37,7 @@ func TestReachability(t *testing.T) {
 	framework.NewTest(t).
 		Run(func(ctx framework.TestContext) {
 
-			rctx := reachability.CreateContext(ctx, g, p)
+			rctx := reachability.CreateContext(ctx, p)
 			systemNM := namespace.ClaimSystemNamespaceOrFail(ctx, ctx)
 
 			testCases := []reachability.TestCase{

--- a/tests/integration/security/sds_egress/main_test.go
+++ b/tests/integration/security/sds_egress/main_test.go
@@ -48,9 +48,7 @@ func TestMain(m *testing.M) {
 			if g, err = galley.New(ctx, galley.Config{}); err != nil {
 				return err
 			}
-			if p, err = pilot.New(ctx, pilot.Config{
-				Galley: g,
-			}); err != nil {
+			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
 				return err
 			}
 			if prom, err = prometheus.New(ctx, prometheus.Config{}); err != nil {

--- a/tests/integration/security/sds_egress/main_test.go
+++ b/tests/integration/security/sds_egress/main_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
-	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/pilot"
 	"istio.io/istio/pkg/test/framework/components/prometheus"
@@ -29,7 +28,6 @@ import (
 
 var (
 	inst istio.Instance
-	g    galley.Instance
 	p    pilot.Instance
 	prom prometheus.Instance
 )
@@ -45,9 +43,6 @@ func TestMain(m *testing.M) {
 		RequireSingleCluster().
 		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
 		Setup(func(ctx resource.Context) (err error) {
-			if g, err = galley.New(ctx, galley.Config{}); err != nil {
-				return err
-			}
 			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
 				return err
 			}

--- a/tests/integration/security/sds_egress/sds_istio_mutual_egress_test.go
+++ b/tests/integration/security/sds_egress/sds_istio_mutual_egress_test.go
@@ -91,7 +91,7 @@ func doIstioMutualTest(
 	ctx framework.TestContext, ns namespace.Instance, configPath, expectedResp string) {
 	var client echo.Instance
 	echoboot.NewBuilderOrFail(ctx, ctx).
-		With(&client, util.EchoConfig("client", ns, false, nil, g, p)).
+		With(&client, util.EchoConfig("client", ns, false, nil, p)).
 		BuildOrFail(ctx)
 	g.ApplyConfigOrFail(ctx, ns, file.AsStringOrFail(ctx, configPath))
 	defer g.DeleteConfigOrFail(ctx, ns, file.AsStringOrFail(ctx, configPath))

--- a/tests/integration/security/sds_egress/sds_istio_mutual_egress_test.go
+++ b/tests/integration/security/sds_egress/sds_istio_mutual_egress_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/echo/common/response"
 	epb "istio.io/istio/pkg/test/echo/proto"
 	"istio.io/istio/pkg/test/framework"
@@ -93,8 +92,8 @@ func doIstioMutualTest(
 	echoboot.NewBuilderOrFail(ctx, ctx).
 		With(&client, util.EchoConfig("client", ns, false, nil, p)).
 		BuildOrFail(ctx)
-	g.ApplyConfigOrFail(ctx, ns, file.AsStringOrFail(ctx, configPath))
-	defer g.DeleteConfigOrFail(ctx, ns, file.AsStringOrFail(ctx, configPath))
+	ctx.ApplyConfigOrFail(ctx, ns.Name(), file.AsStringOrFail(ctx, configPath))
+	defer ctx.DeleteConfigOrFail(ctx, ns.Name(), file.AsStringOrFail(ctx, configPath))
 
 	// give the configuration a moment to kick in
 	time.Sleep(time.Second * 20)
@@ -130,7 +129,7 @@ func doIstioMutualTest(
 }
 
 // sets up the destination rule to route through egress, virtual service, and service entry
-func applySetupConfig(ctx test.Failer, ns namespace.Instance) {
+func applySetupConfig(ctx framework.TestContext, ns namespace.Instance) {
 	ctx.Helper()
 
 	configFiles := []string{
@@ -140,7 +139,7 @@ func applySetupConfig(ctx test.Failer, ns namespace.Instance) {
 	}
 
 	for _, c := range configFiles {
-		if err := g.ApplyConfig(ns, file.AsStringOrFail(ctx, c)); err != nil {
+		if err := ctx.ApplyConfig(ns.Name(), file.AsStringOrFail(ctx, c)); err != nil {
 			ctx.Fatalf("failed to apply configuration file %s; err: %v", c, err)
 		}
 	}

--- a/tests/integration/security/sds_ingress/ingress_test.go
+++ b/tests/integration/security/sds_ingress/ingress_test.go
@@ -18,19 +18,14 @@ import (
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
-	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/components/ingress"
 	"istio.io/istio/pkg/test/framework/components/istio"
-	"istio.io/istio/pkg/test/framework/components/pilot"
-	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/framework/resource/environment"
 	ingressutil "istio.io/istio/tests/integration/security/sds_ingress/util"
 )
 
 var (
 	inst istio.Instance
-	g    galley.Instance
-	p    pilot.Instance
 )
 
 func TestMain(m *testing.M) {
@@ -39,15 +34,6 @@ func TestMain(m *testing.M) {
 		NewSuite("sds_ingress", m).
 		RequireSingleCluster().
 		SetupOnEnv(environment.Kube, istio.Setup(&inst, nil)).
-		Setup(func(ctx resource.Context) (err error) {
-			if g, err = galley.New(ctx, galley.Config{}); err != nil {
-				return err
-			}
-			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
-				return err
-			}
-			return nil
-		}).
 		Run()
 }
 
@@ -65,8 +51,8 @@ func TestSingleTlsGateway_SecretRotation(t *testing.T) {
 			ingressutil.CreateIngressKubeSecret(t, ctx, []string{credName}, ingress.TLS, ingressutil.IngressCredentialA)
 			defer ingressutil.DeleteIngressKubeSecret(t, ctx, []string{credName})
 
-			ns := ingressutil.SetupTest(ctx, g)
-			ingressutil.SetupConfig(t, g, ns, ingressutil.TestConfig{
+			ns := ingressutil.SetupTest(ctx)
+			ingressutil.SetupConfig(t, ctx, ns, ingressutil.TestConfig{
 				Mode:           "SIMPLE",
 				CredentialName: credName,
 				Host:           host,
@@ -121,8 +107,8 @@ func TestSingleMTLSGateway_ServerKeyCertRotation(t *testing.T) {
 				host       = "testsinglemtlsgateway-serverkeycertrotation.example.com"
 			)
 
-			ns := ingressutil.SetupTest(ctx, g)
-			ingressutil.SetupConfig(t, g, ns, ingressutil.TestConfig{
+			ns := ingressutil.SetupTest(ctx)
+			ingressutil.SetupConfig(t, ctx, ns, ingressutil.TestConfig{
 				Mode:           "MUTUAL",
 				CredentialName: credName[0],
 				Host:           host,
@@ -189,8 +175,8 @@ func TestSingleMTLSGateway_CompoundSecretRotation(t *testing.T) {
 			ingressutil.CreateIngressKubeSecret(t, ctx, credName, ingress.Mtls, ingressutil.IngressCredentialA)
 			defer ingressutil.DeleteIngressKubeSecret(t, ctx, credName)
 
-			ns := ingressutil.SetupTest(ctx, g)
-			ingressutil.SetupConfig(t, g, ns, ingressutil.TestConfig{
+			ns := ingressutil.SetupTest(ctx)
+			ingressutil.SetupConfig(t, ctx, ns, ingressutil.TestConfig{
 				Mode:           "MUTUAL",
 				CredentialName: credName[0],
 				Host:           host,
@@ -239,7 +225,7 @@ func TestTlsGateways(t *testing.T) {
 		NewTest(t).
 		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
-			ingressutil.RunTestMultiTLSGateways(ctx, inst, g)
+			ingressutil.RunTestMultiTLSGateways(ctx, inst)
 		})
 }
 
@@ -251,7 +237,7 @@ func TestMtlsGateways(t *testing.T) {
 		NewTest(t).
 		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
-			ingressutil.RunTestMultiMtlsGateways(ctx, inst, g)
+			ingressutil.RunTestMultiMtlsGateways(ctx, inst)
 		})
 }
 
@@ -263,7 +249,7 @@ func TestMultiTlsGateway_InvalidSecret(t *testing.T) {
 		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
 
-			ns := ingressutil.SetupTest(ctx, g)
+			ns := ingressutil.SetupTest(ctx)
 
 			testCase := []struct {
 				name                     string
@@ -385,7 +371,7 @@ func TestMultiTlsGateway_InvalidSecret(t *testing.T) {
 					defer ingressutil.DeleteIngressKubeSecret(ctx, ctx, []string{c.secretName})
 					ing := ingress.NewOrFail(ctx, ctx, c.ingressConfig)
 
-					ingressutil.SetupConfig(t, g, ns, ingressutil.TestConfig{
+					ingressutil.SetupConfig(t, ctx, ns, ingressutil.TestConfig{
 						Mode:           "SIMPLE",
 						CredentialName: c.secretName,
 						Host:           c.hostName,
@@ -406,7 +392,7 @@ func TestMultiMtlsGateway_InvalidSecret(t *testing.T) {
 		NewTest(t).
 		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
-			ns := ingressutil.SetupTest(ctx, g)
+			ns := ingressutil.SetupTest(ctx)
 
 			testCase := []struct {
 				name                     string
@@ -497,7 +483,7 @@ func TestMultiMtlsGateway_InvalidSecret(t *testing.T) {
 						c.ingressGatewayCredential)
 					defer ingressutil.DeleteIngressKubeSecret(t, ctx, []string{c.secretName})
 
-					ingressutil.SetupConfig(t, g, ns, ingressutil.TestConfig{
+					ingressutil.SetupConfig(t, ctx, ns, ingressutil.TestConfig{
 						Mode:           "MUTUAL",
 						CredentialName: c.secretName,
 						Host:           c.hostName,

--- a/tests/integration/security/sds_ingress/ingress_test.go
+++ b/tests/integration/security/sds_ingress/ingress_test.go
@@ -43,9 +43,7 @@ func TestMain(m *testing.M) {
 			if g, err = galley.New(ctx, galley.Config{}); err != nil {
 				return err
 			}
-			if p, err = pilot.New(ctx, pilot.Config{
-				Galley: g,
-			}); err != nil {
+			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
 				return err
 			}
 			return nil

--- a/tests/integration/security/sds_ingress_k8sca/main_test.go
+++ b/tests/integration/security/sds_ingress_k8sca/main_test.go
@@ -18,18 +18,13 @@ import (
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
-	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/components/istio"
-	"istio.io/istio/pkg/test/framework/components/pilot"
-	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/framework/resource/environment"
 	"istio.io/istio/tests/integration/security/sds_ingress/util"
 )
 
 var (
 	inst istio.Instance
-	g    galley.Instance
-	p    pilot.Instance
 )
 
 func TestMain(m *testing.M) {
@@ -39,15 +34,6 @@ func TestMain(m *testing.M) {
 		NewSuite("sds_ingress_k8sca", m).
 		RequireSingleCluster().
 		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
-		Setup(func(ctx resource.Context) (err error) {
-			if g, err = galley.New(ctx, galley.Config{}); err != nil {
-				return err
-			}
-			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
-				return err
-			}
-			return nil
-		}).
 		Run()
 
 }
@@ -69,7 +55,7 @@ func TestMtlsGatewaysK8sca(t *testing.T) {
 		NewTest(t).
 		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
-			util.RunTestMultiMtlsGateways(ctx, inst, g)
+			util.RunTestMultiMtlsGateways(ctx, inst)
 		})
 }
 
@@ -78,6 +64,6 @@ func TestTlsGatewaysK8sca(t *testing.T) {
 		NewTest(t).
 		RequiresEnvironment(environment.Kube).
 		Run(func(ctx framework.TestContext) {
-			util.RunTestMultiTLSGateways(ctx, inst, g)
+			util.RunTestMultiTLSGateways(ctx, inst)
 		})
 }

--- a/tests/integration/security/sds_ingress_k8sca/main_test.go
+++ b/tests/integration/security/sds_ingress_k8sca/main_test.go
@@ -43,9 +43,7 @@ func TestMain(m *testing.M) {
 			if g, err = galley.New(ctx, galley.Config{}); err != nil {
 				return err
 			}
-			if p, err = pilot.New(ctx, pilot.Config{
-				Galley: g,
-			}); err != nil {
+			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
 				return err
 			}
 			return nil

--- a/tests/integration/security/sds_vault_flow/main_test.go
+++ b/tests/integration/security/sds_vault_flow/main_test.go
@@ -64,9 +64,7 @@ func TestMain(m *testing.M) {
 			if g, err = galley.New(ctx, galley.Config{}); err != nil {
 				return err
 			}
-			if p, err = pilot.New(ctx, pilot.Config{
-				Galley: g,
-			}); err != nil {
+			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
 				return err
 			}
 			return nil

--- a/tests/integration/security/sds_vault_flow/main_test.go
+++ b/tests/integration/security/sds_vault_flow/main_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
-	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/pilot"
 	"istio.io/istio/pkg/test/framework/label"
@@ -46,7 +45,6 @@ const (
 
 var (
 	inst istio.Instance
-	g    galley.Instance
 	p    pilot.Instance
 )
 
@@ -61,9 +59,6 @@ func TestMain(m *testing.M) {
 		RequireSingleCluster().
 		SetupOnEnv(environment.Kube, istio.Setup(&inst, setupConfig)).
 		Setup(func(ctx resource.Context) (err error) {
-			if g, err = galley.New(ctx, galley.Config{}); err != nil {
-				return err
-			}
 			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
 				return err
 			}

--- a/tests/integration/security/sds_vault_flow/sds_vault_flow_test.go
+++ b/tests/integration/security/sds_vault_flow/sds_vault_flow_test.go
@@ -75,8 +75,8 @@ func TestSdsVaultCaFlow(t *testing.T) {
 					"Namespace": ns.Name(),
 				})
 
-			g.ApplyConfigOrFail(t, ns, deployment)
-			defer g.DeleteConfigOrFail(t, ns, deployment)
+			ctx.ApplyConfigOrFail(t, ns.Name(), deployment)
+			defer ctx.DeleteConfigOrFail(t, ns.Name(), deployment)
 
 			// Sleep 10 seconds for the policy to take effect.
 			time.Sleep(10 * time.Second)

--- a/tests/integration/security/sds_vault_flow/sds_vault_flow_test.go
+++ b/tests/integration/security/sds_vault_flow/sds_vault_flow_test.go
@@ -53,8 +53,8 @@ func TestSdsVaultCaFlow(t *testing.T) {
 
 			var a, b echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&a, util.EchoConfig("a", ns, false, nil, g, p)).
-				With(&b, util.EchoConfig("b", ns, false, nil, g, p)).
+				With(&a, util.EchoConfig("a", ns, false, nil, p)).
+				With(&b, util.EchoConfig("b", ns, false, nil, p)).
 				BuildOrFail(t)
 
 			checkers := []connection.Checker{

--- a/tests/integration/security/util/framework.go
+++ b/tests/integration/security/util/framework.go
@@ -17,12 +17,11 @@ package util
 import (
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/framework/components/echo"
-	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/components/pilot"
 )
 
-func EchoConfig(name string, ns namespace.Instance, headless bool, annos echo.Annotations, g galley.Instance, p pilot.Instance) echo.Config {
+func EchoConfig(name string, ns namespace.Instance, headless bool, annos echo.Annotations, p pilot.Instance) echo.Config {
 	out := echo.Config{
 		Service:        name,
 		Namespace:      ns,
@@ -50,7 +49,6 @@ func EchoConfig(name string, ns namespace.Instance, headless bool, annos echo.An
 				Protocol: protocol.GRPC,
 			},
 		},
-		Galley: g,
 		Pilot:  p,
 	}
 

--- a/tests/integration/security/util/framework.go
+++ b/tests/integration/security/util/framework.go
@@ -49,7 +49,7 @@ func EchoConfig(name string, ns namespace.Instance, headless bool, annos echo.An
 				Protocol: protocol.GRPC,
 			},
 		},
-		Pilot:  p,
+		Pilot: p,
 	}
 
 	// for headless service with selector, the port and target port must be equal

--- a/tests/integration/security/util/reachability/context.go
+++ b/tests/integration/security/util/reachability/context.go
@@ -147,10 +147,10 @@ func (rc *Context) Run(testCases []TestCase) {
 			retry.UntilSuccessOrFail(ctx, func() error {
 				ctx.Logf("[%s] [%v] Apply config %s", testName, time.Now(), c.ConfigFile)
 				// TODO(https://github.com/istio/istio/issues/20460) We shouldn't need a retry loop
-				return rc.ctx.Environment().Clusters()[0].ApplyConfig(c.Namespace.Name(), policyYAML)
+				return rc.ctx.ApplyConfig(c.Namespace.Name(), policyYAML)
 			})
 			ctx.WhenDone(func() error {
-				return rc.ctx.Environment().Clusters()[0].DeleteConfig(c.Namespace.Name(), policyYAML)
+				return rc.ctx.DeleteConfig(c.Namespace.Name(), policyYAML)
 			})
 
 			// Give some time for the policy propagate.

--- a/tests/integration/telemetry/dashboard_test.go
+++ b/tests/integration/telemetry/dashboard_test.go
@@ -284,7 +284,7 @@ func setupDashboardTest(t framework.TestContext) {
 		Prefix: "dashboard",
 		Inject: true,
 	})
-	g.ApplyConfigOrFail(t, ns, fmt.Sprintf(gatewayConfig, ns.Name()))
+	t.ApplyConfigOrFail(t, ns.Name(), fmt.Sprintf(gatewayConfig, ns.Name()))
 
 	var instance echo.Instance
 	echoboot.
@@ -292,7 +292,6 @@ func setupDashboardTest(t framework.TestContext) {
 		With(&instance, echo.Config{
 			Service:   "server",
 			Pilot:     p,
-			Galley:    g,
 			Namespace: ns,
 			Subsets:   []echo.SubsetConfig{{}},
 			Ports: []echo.Port{

--- a/tests/integration/telemetry/main_test.go
+++ b/tests/integration/telemetry/main_test.go
@@ -78,9 +78,7 @@ values:
 			if g, err = galley.New(ctx, galley.Config{}); err != nil {
 				return err
 			}
-			if p, err = pilot.New(ctx, pilot.Config{
-				Galley: g,
-			}); err != nil {
+			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
 				return err
 			}
 			if ingr, err = ingress.New(ctx, ingress.Config{

--- a/tests/integration/telemetry/main_test.go
+++ b/tests/integration/telemetry/main_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
-	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/components/ingress"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/pilot"
@@ -29,7 +28,6 @@ import (
 
 var (
 	i    istio.Instance
-	g    galley.Instance
 	p    pilot.Instance
 	ingr ingress.Instance
 )
@@ -75,9 +73,6 @@ values:
     enabled: true`
 		})).
 		Setup(func(ctx resource.Context) (err error) {
-			if g, err = galley.New(ctx, galley.Config{}); err != nil {
-				return err
-			}
 			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
 				return err
 			}

--- a/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
@@ -26,7 +26,6 @@ import (
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
-	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/components/stackdriver"
@@ -51,7 +50,6 @@ const (
 var (
 	ist        istio.Instance
 	echoNsInst namespace.Instance
-	galInst    galley.Instance
 	sdInst     stackdriver.Instance
 	srv        echo.Instance
 	clt        echo.Instance
@@ -63,10 +61,6 @@ func getIstioInstance() *istio.Instance {
 
 func getEchoNamespaceInstance() namespace.Instance {
 	return echoNsInst
-}
-
-func getGalInstance() galley.Instance {
-	return galInst
 }
 
 func getWantRequestCountTS() (cltRequestCount, srvRequestCount monitoring.TimeSeries, err error) {
@@ -202,10 +196,6 @@ func setupConfig(cfg *istio.Config) {
 }
 
 func testSetup(ctx resource.Context) (err error) {
-	galInst, err = galley.New(ctx, galley.Config{})
-	if err != nil {
-		return
-	}
 	echoNsInst, err = namespace.New(ctx, namespace.Config{
 		Prefix: "istio-echo",
 		Inject: true,
@@ -230,10 +220,7 @@ func testSetup(ctx resource.Context) (err error) {
 		return
 	}
 
-	err = galInst.ApplyConfig(
-		echoNsInst,
-		sdBootstrap,
-	)
+	err = ctx.ApplyConfig(echoNsInst.Name(), sdBootstrap)
 	if err != nil {
 		return
 	}
@@ -245,7 +232,6 @@ func testSetup(ctx resource.Context) (err error) {
 		With(&clt, echo.Config{
 			Service:   "clt",
 			Namespace: getEchoNamespaceInstance(),
-			Galley:    getGalInstance(),
 			Subsets: []echo.SubsetConfig{
 				{
 					Annotations: map[echo.Annotation]*echo.AnnotationValue{
@@ -258,7 +244,6 @@ func testSetup(ctx resource.Context) (err error) {
 		With(&srv, echo.Config{
 			Service:   "srv",
 			Namespace: getEchoNamespaceInstance(),
-			Galley:    getGalInstance(),
 			Subsets: []echo.SubsetConfig{
 				{
 					Annotations: map[echo.Annotation]*echo.AnnotationValue{

--- a/tests/integration/telemetry/stats/prometheus/http/stats.go
+++ b/tests/integration/telemetry/stats/prometheus/http/stats.go
@@ -106,9 +106,7 @@ func TestSetup(ctx resource.Context) (err error) {
 	if err != nil {
 		return
 	}
-	if pilotInst, err = pilot.New(ctx, pilot.Config{
-		Galley: galInst,
-	}); err != nil {
+	if pilotInst, err = pilot.New(ctx, pilot.Config{}); err != nil {
 		return err
 	}
 

--- a/tests/integration/telemetry/tracing/tracing.go
+++ b/tests/integration/telemetry/tracing/tracing.go
@@ -86,7 +86,7 @@ func TestSetup(ctx resource.Context) (err error) {
 	if err != nil {
 		return
 	}
-	err = ctx.Environment().Clusters()[0].ApplyConfig(
+	err = ctx.ApplyConfig(
 		bookinfoNsInst.Name(),
 		bookingfoGatewayFile,
 		destinationRuleFile,

--- a/tests/integration/telemetry/tracing/tracing.go
+++ b/tests/integration/telemetry/tracing/tracing.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"istio.io/istio/pkg/test/framework/components/bookinfo"
-	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/components/ingress"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/namespace"
@@ -30,14 +29,9 @@ import (
 var (
 	ist            istio.Instance
 	bookinfoNsInst namespace.Instance
-	galInst        galley.Instance
 	ingInst        ingress.Instance
 	zipkinInst     zipkin.Instance
 )
-
-func GetGalleyInstance() galley.Instance {
-	return galInst
-}
 
 func GetIstioInstance() *istio.Instance {
 	return &ist
@@ -56,10 +50,6 @@ func GetZipkinInstance() zipkin.Instance {
 }
 
 func TestSetup(ctx resource.Context) (err error) {
-	galInst, err = galley.New(ctx, galley.Config{})
-	if err != nil {
-		return
-	}
 	bookinfoNsInst, err = namespace.New(ctx, namespace.Config{
 		Prefix: "istio-bookinfo",
 		Inject: true,
@@ -96,8 +86,8 @@ func TestSetup(ctx resource.Context) (err error) {
 	if err != nil {
 		return
 	}
-	err = galInst.ApplyConfig(
-		bookinfoNsInst,
+	err = ctx.Environment().Clusters()[0].ApplyConfig(
+		bookinfoNsInst.Name(),
 		bookingfoGatewayFile,
 		destinationRuleFile,
 		virtualServiceFile,


### PR DESCRIPTION
* Make {apply,delete}Config functions a part of Cluster rather than Galley
* Wire the new Cluster resource into a few places
* Migrate a single test suite to the new model

TODO:
* Fully wire up the new cluster resource
* Remove Galley component completely
* Move all tests over to new model

Submitting this now for early feedback as the remaining steps are mechanical