### PR TITLE
[Release-1.6] Remove tcp mx alpn from http filter chains in downstreamtlscontext 

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -177,6 +177,9 @@ var (
 	mtlsHTTP11ALPN = []string{"istio-http/1.1", "istio"}
 	mtlsHTTP2ALPN  = []string{"istio-h2", "istio"}
 
+	// ALPN used for TCP Metadata Exchange.
+	tcpMxcALPN = "istio-peer-exchange"
+
 	// Double the number of filter chains. Half of filter chains are used as http filter chain and half of them are used as tcp proxy
 	// id in [0, len(allChains)/2) are configured as http filter chain, [(len(allChains)/2, len(allChains)) are configured as tcp proxy
 	// If mTLS permissive is enabled, there are five filter chains. The filter chain match should be
@@ -795,6 +798,10 @@ allChainsLabel:
 			filterChainMatch = &fcm
 			if filterChainMatchOption[id].Protocol == istionetworking.ListenerProtocolHTTP {
 				httpOpts = configgen.buildSidecarInboundHTTPListenerOptsForPortOrUDS(node, pluginParams)
+				if chain.TLSContext != nil && chain.TLSContext.CommonTlsContext != nil {
+					chain.TLSContext.CommonTlsContext.AlpnProtocols = dropAlpnFromList(
+						chain.TLSContext.CommonTlsContext.AlpnProtocols, tcpMxcALPN)
+				}
 			} else {
 				tcpNetworkFilters = buildInboundNetworkFilters(pluginParams.Push, pluginParams.Node, pluginParams.ServiceInstance)
 			}
@@ -2685,4 +2692,15 @@ func resetCachedListenerConfig(mesh *meshconfig.MeshConfig) {
 // listenerKey builds the key for a given bind and port
 func listenerKey(bind string, port int) string {
 	return bind + ":" + strconv.Itoa(port)
+}
+
+func dropAlpnFromList(alpnProtocols []string, alpnToDrop string) []string {
+	var newAlpnProtocols []string
+	for _, alpn := range alpnProtocols {
+		if alpn == alpnToDrop {
+			continue
+		}
+		newAlpnProtocols = append(newAlpnProtocols, alpn)
+	}
+	return newAlpnProtocols
 }

--- a/pilot/pkg/networking/plugin/authn/authentication.go
+++ b/pilot/pkg/networking/plugin/authn/authentication.go
@@ -38,7 +38,7 @@ func NewPlugin() plugin.Plugin {
 func (Plugin) OnInboundFilterChains(in *plugin.InputParams) []networking.FilterChain {
 	return factory.NewPolicyApplier(in.Push,
 		in.ServiceInstance, in.Node.Metadata.Namespace, labels.Collection{in.Node.Metadata.Labels}).InboundFilterChain(
-		in.ServiceInstance.Endpoint.EndpointPort, in.Push.Mesh.SdsUdsPath, in.Node)
+		in.ServiceInstance.Endpoint.EndpointPort, in.Push.Mesh.SdsUdsPath, in.Node, in.ListenerProtocol)
 }
 
 // OnOutboundListener is called whenever a new outbound listener is added to the LDS output for a given service
@@ -115,5 +115,5 @@ func (Plugin) OnInboundPassthroughFilterChains(in *plugin.InputParams) []network
 	// Pass nil for ServiceInstance so that we never consider any alpha policy for the pass through filter chain.
 	applier := factory.NewPolicyApplier(in.Push, nil /* ServiceInstance */, in.Node.Metadata.Namespace, labels.Collection{in.Node.Metadata.Labels})
 	// Pass 0 for endpointPort so that it never matches any port-level policy.
-	return applier.InboundFilterChain(0, in.Push.Mesh.SdsUdsPath, in.Node)
+	return applier.InboundFilterChain(0, in.Push.Mesh.SdsUdsPath, in.Node, in.ListenerProtocol)
 }

--- a/pilot/pkg/security/authn/policy_applier.go
+++ b/pilot/pkg/security/authn/policy_applier.go
@@ -26,7 +26,8 @@ import (
 type PolicyApplier interface {
 	// InboundFilterChain returns inbound filter chain(s) for the given endpoint (aka workload) port to
 	// enforce the underlying authentication policy.
-	InboundFilterChain(endpointPort uint32, sdsUdsPath string, node *model.Proxy) []networking.FilterChain
+	InboundFilterChain(endpointPort uint32, sdsUdsPath string, node *model.Proxy,
+		listenerProtocol networking.ListenerProtocol) []networking.FilterChain
 
 	// AuthNFilter returns the JWT HTTP filter to enforce the underlying authentication policy.
 	// It may return nil, if no JWT validation is needed.

--- a/pilot/pkg/security/authn/utils/utils.go
+++ b/pilot/pkg/security/authn/utils/utils.go
@@ -30,7 +30,8 @@ import (
 )
 
 // BuildInboundFilterChain returns the filter chain(s) corresponding to the mTLS mode.
-func BuildInboundFilterChain(mTLSMode model.MutualTLSMode, sdsUdsPath string, node *model.Proxy) []networking.FilterChain {
+func BuildInboundFilterChain(mTLSMode model.MutualTLSMode, sdsUdsPath string, node *model.Proxy,
+	listenerProtocol networking.ListenerProtocol) []networking.FilterChain {
 	if mTLSMode == model.MTLSDisable || mTLSMode == model.MTLSUnknown {
 		return nil
 	}
@@ -38,7 +39,8 @@ func BuildInboundFilterChain(mTLSMode model.MutualTLSMode, sdsUdsPath string, no
 	meta := node.Metadata
 	var alpnIstioMatch *ldsv2.FilterChainMatch
 	var tls *auth.DownstreamTlsContext
-	if util.IsTCPMetadataExchangeEnabled(node) {
+	if util.IsTCPMetadataExchangeEnabled(node) &&
+		(listenerProtocol == networking.ListenerProtocolTCP || listenerProtocol == networking.ListenerProtocolAuto) {
 		alpnIstioMatch = &ldsv2.FilterChainMatch{
 			ApplicationProtocols: util.ALPNInMeshWithMxc,
 		}

--- a/pilot/pkg/security/authn/utils/utils_test.go
+++ b/pilot/pkg/security/authn/utils/utils_test.go
@@ -33,40 +33,43 @@ import (
 )
 
 func TestBuildInboundFilterChain(t *testing.T) {
-	tlsContext := &auth.DownstreamTlsContext{
-		CommonTlsContext: &auth.CommonTlsContext{
-			TlsCertificates: []*auth.TlsCertificate{
-				{
-					CertificateChain: &core.DataSource{
-						Specifier: &core.DataSource_Filename{
-							Filename: "/etc/certs/cert-chain.pem",
+	tlsContext := func(alpnProtocols []string) *auth.DownstreamTlsContext {
+		return &auth.DownstreamTlsContext{
+			CommonTlsContext: &auth.CommonTlsContext{
+				TlsCertificates: []*auth.TlsCertificate{
+					{
+						CertificateChain: &core.DataSource{
+							Specifier: &core.DataSource_Filename{
+								Filename: "/etc/certs/cert-chain.pem",
+							},
 						},
-					},
-					PrivateKey: &core.DataSource{
-						Specifier: &core.DataSource_Filename{
-							Filename: "/etc/certs/key.pem",
-						},
-					},
-				},
-			},
-			ValidationContextType: &auth.CommonTlsContext_ValidationContext{
-				ValidationContext: &auth.CertificateValidationContext{
-					TrustedCa: &core.DataSource{
-						Specifier: &core.DataSource_Filename{
-							Filename: "/etc/certs/root-cert.pem",
+						PrivateKey: &core.DataSource{
+							Specifier: &core.DataSource_Filename{
+								Filename: "/etc/certs/key.pem",
+							},
 						},
 					},
 				},
+				ValidationContextType: &auth.CommonTlsContext_ValidationContext{
+					ValidationContext: &auth.CertificateValidationContext{
+						TrustedCa: &core.DataSource{
+							Specifier: &core.DataSource_Filename{
+								Filename: "/etc/certs/root-cert.pem",
+							},
+						},
+					},
+				},
+				AlpnProtocols: alpnProtocols,
 			},
-			AlpnProtocols: []string{"istio-peer-exchange", "h2", "http/1.1"},
-		},
-		RequireClientCertificate: protovalue.BoolTrue,
+			RequireClientCertificate: protovalue.BoolTrue,
+		}
 	}
 
 	type args struct {
-		mTLSMode   model.MutualTLSMode
-		sdsUdsPath string
-		node       *model.Proxy
+		mTLSMode         model.MutualTLSMode
+		sdsUdsPath       string
+		node             *model.Proxy
+		listenerProtocol networking.ListenerProtocol
 	}
 	tests := []struct {
 		name string
@@ -80,6 +83,7 @@ func TestBuildInboundFilterChain(t *testing.T) {
 				node: &model.Proxy{
 					Metadata: &model.NodeMetadata{},
 				},
+				listenerProtocol: networking.ListenerProtocolAuto,
 			},
 			// No need to set up filter chain, default one is okay.
 			want: nil,
@@ -91,6 +95,7 @@ func TestBuildInboundFilterChain(t *testing.T) {
 				node: &model.Proxy{
 					Metadata: &model.NodeMetadata{},
 				},
+				listenerProtocol: networking.ListenerProtocolAuto,
 			},
 			want: nil,
 		},
@@ -101,10 +106,11 @@ func TestBuildInboundFilterChain(t *testing.T) {
 				node: &model.Proxy{
 					Metadata: &model.NodeMetadata{},
 				},
+				listenerProtocol: networking.ListenerProtocolHTTP,
 			},
 			want: []networking.FilterChain{
 				{
-					TLSContext: tlsContext,
+					TLSContext: tlsContext([]string{"h2", "http/1.1"}),
 				},
 			},
 		},
@@ -115,11 +121,12 @@ func TestBuildInboundFilterChain(t *testing.T) {
 				node: &model.Proxy{
 					Metadata: &model.NodeMetadata{},
 				},
+				listenerProtocol: networking.ListenerProtocolTCP,
 			},
 			// Two filter chains, one for mtls traffic within the mesh, one for plain text traffic.
 			want: []networking.FilterChain{
 				{
-					TLSContext: tlsContext,
+					TLSContext: tlsContext([]string{"istio-peer-exchange", "h2", "http/1.1"}),
 					FilterChainMatch: &listener.FilterChainMatch{
 						ApplicationProtocols: []string{"istio-peer-exchange", "istio"},
 					},
@@ -145,6 +152,7 @@ func TestBuildInboundFilterChain(t *testing.T) {
 						SdsEnabled: true,
 					},
 				},
+				listenerProtocol: networking.ListenerProtocolHTTP,
 			},
 			want: []networking.FilterChain{
 				{
@@ -193,7 +201,7 @@ func TestBuildInboundFilterChain(t *testing.T) {
 									},
 								},
 							},
-							AlpnProtocols: []string{"istio-peer-exchange", "h2", "http/1.1"},
+							AlpnProtocols: []string{"h2", "http/1.1"},
 						},
 						RequireClientCertificate: protovalue.BoolTrue,
 					},
@@ -208,10 +216,11 @@ func TestBuildInboundFilterChain(t *testing.T) {
 				node: &model.Proxy{
 					Metadata: &model.NodeMetadata{},
 				},
+				listenerProtocol: networking.ListenerProtocolHTTP,
 			},
 			want: []networking.FilterChain{
 				{
-					TLSContext: tlsContext,
+					TLSContext: tlsContext([]string{"h2", "http/1.1"}),
 				},
 			},
 		},
@@ -226,6 +235,7 @@ func TestBuildInboundFilterChain(t *testing.T) {
 						TLSServerRootCert:  "/custom/path/to/root.pem",
 					},
 				},
+				listenerProtocol: networking.ListenerProtocolHTTP,
 			},
 			// Only one filter chain with mTLS settings should be generated.
 			want: []networking.FilterChain{
@@ -255,7 +265,7 @@ func TestBuildInboundFilterChain(t *testing.T) {
 									},
 								},
 							},
-							AlpnProtocols: []string{"istio-peer-exchange", "h2", "http/1.1"},
+							AlpnProtocols: []string{"h2", "http/1.1"},
 						},
 						RequireClientCertificate: protovalue.BoolTrue,
 					},
@@ -265,7 +275,7 @@ func TestBuildInboundFilterChain(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := BuildInboundFilterChain(tt.args.mTLSMode, tt.args.sdsUdsPath, tt.args.node); !reflect.DeepEqual(got, tt.want) {
+			if got := BuildInboundFilterChain(tt.args.mTLSMode, tt.args.sdsUdsPath, tt.args.node, tt.args.listenerProtocol); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("BuildInboundFilterChain() = %v, want %v", spew.Sdump(got), spew.Sdump(tt.want))
 				t.Logf("got:\n%v\n", got[0].TLSContext.CommonTlsContext.TlsCertificateSdsSecretConfigs[0])
 			}

--- a/pilot/pkg/security/authn/v1beta1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier.go
@@ -167,10 +167,11 @@ func (a *v1beta1PolicyApplier) AuthNFilter(proxyType model.NodeType, port uint32
 	}
 }
 
-func (a *v1beta1PolicyApplier) InboundFilterChain(endpointPort uint32, sdsUdsPath string, node *model.Proxy) []networking.FilterChain {
+func (a *v1beta1PolicyApplier) InboundFilterChain(endpointPort uint32, sdsUdsPath string, node *model.Proxy,
+	listenerProtocol networking.ListenerProtocol) []networking.FilterChain {
 	effectiveMTLSMode := a.getMutualTLSModeForPort(endpointPort)
 	authnLog.Debugf("InboundFilterChain: build inbound filter change for %v:%d in %s mode", node.ID, endpointPort, effectiveMTLSMode)
-	return authn_utils.BuildInboundFilterChain(effectiveMTLSMode, sdsUdsPath, node)
+	return authn_utils.BuildInboundFilterChain(effectiveMTLSMode, sdsUdsPath, node, listenerProtocol)
 }
 
 // NewPolicyApplier returns new applier for v1beta1 authentication policies.

--- a/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
@@ -1453,6 +1453,7 @@ func TestOnInboundFilterChain(t *testing.T) {
 				8080,
 				tc.sdsUdsPath,
 				testNode,
+				networking.ListenerProtocolAuto,
 			)
 			if !reflect.DeepEqual(got, tc.expected) {
 				t.Errorf("[%v] unexpected filter chains, got %v, want %v", tc.name, got, tc.expected)


### PR DESCRIPTION
Remove tcp mx alpn from http filter chains in downstreamtlscontext (…23465)

* fix alpn

* update alpn

* Fix utils test

* Fix lint error

Signed-off-by: gargnupur <gargnupur@google.com>

* Fix lint error

Signed-off-by: gargnupur <gargnupur@google.com>

* Fix lint error

Signed-off-by: gargnupur <gargnupur@google.com>

* Fix lint error

Signed-off-by: gargnupur <gargnupur@google.com>

* Update pilot/pkg/networking/core/v1alpha3/listener.go

Co-authored-by: Tariq Ibrahim <tariq181290@gmail.com>

* Update pilot/pkg/networking/core/v1alpha3/listener.go

Co-authored-by: Tariq Ibrahim <tariq181290@gmail.com>

* Fixed based on feedback

Signed-off-by: gargnupur <gargnupur@google.com>

Co-authored-by: Tariq Ibrahim <tariq181290@gmail.com>