### PR TITLE
Use derived ProxyConfig for tracing tls settings (#23406)

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -285,24 +285,6 @@ data:
         "trustDomainAliases": [],
         "useMCP": false
       },
-      "meshConfig": {
-        "defaultConfig": {
-          "proxyMetadata": {
-            "DNS_AGENT": ""
-          },
-          "tracing": {
-            "tlsSettings": {
-              "caCertificates": null,
-              "clientCertificate": null,
-              "mode": "DISABLE",
-              "privateKey": null,
-              "sni": null,
-              "subjectAltNames": []
-            }
-          }
-        },
-        "enablePrometheusMerge": false
-      },
       "revision": "",
       "sidecarInjectorWebhook": {
         "alwaysInjectSelector": [],
@@ -662,7 +644,7 @@ data:
         {{- end }}
         - name: istio-podinfo
           mountPath: /etc/istio/pod
-         {{- if and (eq .Values.global.proxy.tracer "lightstep") .Values.meshConfig.defaultConfig.tracing.tlsSettings }}
+         {{- if and (eq .Values.global.proxy.tracer "lightstep") .ProxyConfig.GetTracing.GetTlsSettings }}
         - mountPath: {{ directory .ProxyConfig.GetTracing.GetTlsSettings.GetCaCertificates }}
           name: lightstep-certs
           readOnly: true
@@ -725,7 +707,7 @@ data:
         {{ toYaml $value | indent 2 }}
         {{ end }}
         {{ end }}
-      {{- if and (eq .Values.global.proxy.tracer "lightstep") .Values.meshConfig.defaultConfig.tracing.tlsSettings }}
+      {{- if and (eq .Values.global.proxy.tracer "lightstep") .ProxyConfig.GetTracing.GetTlsSettings }}
       - name: lightstep-certs
         secret:
           optional: true

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -330,7 +330,7 @@ template: |
     {{- end }}
     - name: istio-podinfo
       mountPath: /etc/istio/pod
-     {{- if and (eq .Values.global.proxy.tracer "lightstep") .Values.meshConfig.defaultConfig.tracing.tlsSettings }}
+     {{- if and (eq .Values.global.proxy.tracer "lightstep") .ProxyConfig.GetTracing.GetTlsSettings }}
     - mountPath: {{ directory .ProxyConfig.GetTracing.GetTlsSettings.GetCaCertificates }}
       name: lightstep-certs
       readOnly: true
@@ -393,7 +393,7 @@ template: |
     {{ toYaml $value | indent 2 }}
     {{ end }}
     {{ end }}
-  {{- if and (eq .Values.global.proxy.tracer "lightstep") .Values.meshConfig.defaultConfig.tracing.tlsSettings }}
+  {{- if and (eq .Values.global.proxy.tracer "lightstep") .ProxyConfig.GetTracing.GetTlsSettings }}
   - name: lightstep-certs
     secret:
       optional: true

--- a/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
 data:
 {{/* Scope the values to just top level fields used in the template, to reduce the size. */}}
   values: |-
-{{ pick .Values "global" "istio_cni" "sidecarInjectorWebhook" "revision" "meshConfig" | toPrettyJson | indent 4 }}
+{{ pick .Values "global" "istio_cni" "sidecarInjectorWebhook" "revision" | toPrettyJson | indent 4 }}
 
   # To disable injection: use omitSidecarInjectorConfigMap, which disables the webhook patching
   # and istiod webhook functionality.


### PR DESCRIPTION
* Use derived ProxyConfig for tracing tls settings

Follow up to https://github.com/istio/istio/pull/23220

This should be using .ProxyConfig which is Istiod's internal
representation of the proxy config and takes annotation overrides into
account, rather than .Values which may or may not be accurate

* fix types

(cherry picked from commit 52b751dd8c9c022ae0c933cc629442d98a3fea68)