### PR TITLE
Fix portmanager race

### DIFF
--- a/pkg/test/docker/container.go
+++ b/pkg/test/docker/container.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/docker/docker/api/types"
@@ -239,12 +238,4 @@ func (c *Container) Close() error {
 
 func toNatPort(p ContainerPort) nat.Port {
 	return nat.Port(fmt.Sprintf("%d/tcp", p))
-}
-
-func fromNatPort(p string) (ContainerPort, error) {
-	cp, err := strconv.Atoi(strings.Split(p, "/")[0])
-	if err != nil {
-		return 0, err
-	}
-	return ContainerPort(cp), nil
 }

--- a/pkg/test/framework/components/echo/docker/port.go
+++ b/pkg/test/framework/components/echo/docker/port.go
@@ -21,7 +21,6 @@ import (
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/docker"
 	"istio.io/istio/pkg/test/framework/components/echo"
-	"istio.io/istio/pkg/test/util/reserveport"
 )
 
 type portMap struct {
@@ -29,27 +28,15 @@ type portMap struct {
 	hostAgentPort uint16
 }
 
-func newPortMap(portMgr reserveport.PortManager, cfg echo.Config) (*portMap, error) {
+func newPortMap(cfg echo.Config) (*portMap, error) {
 	m := &portMap{}
-
-	// Reserve a status port for the host agent.
-	var err error
-	if m.hostAgentPort, err = portMgr.ReservePortNumber(); err != nil {
-		return nil, err
-	}
 
 	hasHTTP := false
 	hasGRPC := false
 	for _, p := range cfg.Ports {
-		// Reserve a host port.
-		hostPort, err := portMgr.ReservePortNumber()
-		if err != nil {
-			return nil, err
-		}
-
 		m.ports = append(m.ports, port{
 			containerPort: p,
-			hostPort:      hostPort,
+			// hostPort will be set later by the docker library
 		})
 
 		switch p.Protocol {

--- a/pkg/test/framework/components/environment/native/native.go
+++ b/pkg/test/framework/components/environment/native/native.go
@@ -25,7 +25,6 @@ import (
 	"istio.io/istio/pkg/test/docker"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/framework/resource/environment"
-	"istio.io/istio/pkg/test/util/reserveport"
 )
 
 const (
@@ -51,9 +50,6 @@ type Environment struct {
 	// Domain used by components in the native environment.
 	Domain string
 
-	// PortManager provides free ports on-demand.
-	PortManager reserveport.PortManager
-
 	// Docker resources, Lazy-initialized.
 	dockerClient *client.Client
 	network      *docker.Network
@@ -64,16 +60,10 @@ var _ resource.Environment = &Environment{}
 
 // New returns a new native environment.
 func New(ctx resource.Context) (resource.Environment, error) {
-	portMgr, err := reserveport.NewPortManager()
-	if err != nil {
-		return nil, err
-	}
-
 	e := &Environment{
 		ctx:             ctx,
 		SystemNamespace: systemNamespace,
 		Domain:          domain,
-		PortManager:     portMgr,
 	}
 	e.id = ctx.TrackResource(e)
 

--- a/pkg/test/framework/components/environment/native/native.go
+++ b/pkg/test/framework/components/environment/native/native.go
@@ -147,11 +147,6 @@ func (e *Environment) Close() (err error) {
 	e.mux.Lock()
 	defer e.mux.Unlock()
 
-	if e.PortManager != nil {
-		err = multierror.Append(err, e.PortManager.Close()).ErrorOrNil()
-	}
-	e.PortManager = nil
-
 	if e.network != nil {
 		err = multierror.Append(err, e.network.Close()).ErrorOrNil()
 	}


### PR DESCRIPTION
    The port manager is inherintly racy: if two consumers may get the same
    port at the same time, leading to failures when they bind. This is due
    to the fact that there is (and must be) a gap in time between when the
    port is reserved and when the port is used, during which the port may be
    re-used. This has been happening frequently in CI.

    There are some possible ways to avoid this, but the easiest is just to
    have docker assign the ports itself. This avoids the race.