### PR TITLE
test framework: allow fetching resources from context

### DIFF
--- a/pkg/test/framework/resource/context.go
+++ b/pkg/test/framework/resource/context.go
@@ -22,6 +22,11 @@ type Context interface {
 	// cleaned up.
 	TrackResource(r Resource) ID
 
+	// GetResource gets a resource matching the type referenced by the passed in pointer if one exists.
+	// Only useful when only one of the given type of resource is expected in the current context.
+	// An error will be returned if ref is not a pointer, or if no matching resource is found.
+	GetResource(ref interface{}) error
+
 	// The Environment in which the tests run
 	Environment() Environment
 

--- a/pkg/test/framework/resource/context.go
+++ b/pkg/test/framework/resource/context.go
@@ -22,9 +22,10 @@ type Context interface {
 	// cleaned up.
 	TrackResource(r Resource) ID
 
-	// GetResource gets a resource matching the type referenced by the passed in pointer if one exists.
-	// Only useful when only one of the given type of resource is expected in the current context.
-	// An error will be returned if ref is not a pointer, or if no matching resource is found.
+	// GetResource finds a resource or resources of the given element type in the context.
+	// A pointer reference will be assigned to the first matching resource.
+	// All matching resources will be appended to a slice reference.
+	// An error will be returned if ref is not a pointer or a slice.
 	GetResource(ref interface{}) error
 
 	// The Environment in which the tests run

--- a/pkg/test/framework/resource/context.go
+++ b/pkg/test/framework/resource/context.go
@@ -22,9 +22,10 @@ type Context interface {
 	// cleaned up.
 	TrackResource(r Resource) ID
 
-	// GetResource find resource(s) of a given type and assigns them to the given reference.
-	// Matching resources will be appended if the passed reference points to a slice.
-	// An error will be returned if a non-pointer value is passed.
+	// GetResource accepts either a *T or *[]T where T implements Resource.
+	// For a non-slice pointer, the value will be assigned to the first matching resource.
+	// For a slice pointer, the matching resources will be appended.
+	// If ref is not a pointer, an error will be returned.
 	GetResource(ref interface{}) error
 
 	// The Environment in which the tests run

--- a/pkg/test/framework/resource/context.go
+++ b/pkg/test/framework/resource/context.go
@@ -22,10 +22,9 @@ type Context interface {
 	// cleaned up.
 	TrackResource(r Resource) ID
 
-	// GetResource finds a resource or resources of the given element type in the context.
-	// A pointer reference will be assigned to the first matching resource.
-	// All matching resources will be appended to a slice reference.
-	// An error will be returned if ref is not a pointer or a slice.
+	// GetResource find resource(s) of a given type and assigns them to the given reference.
+	// Matching resources will be appended if the passed reference points to a slice.
+	// An error will be returned if a non-pointer value is passed.
 	GetResource(ref interface{}) error
 
 	// The Environment in which the tests run

--- a/pkg/test/framework/resource/context.go
+++ b/pkg/test/framework/resource/context.go
@@ -22,7 +22,7 @@ type Context interface {
 	// cleaned up.
 	TrackResource(r Resource) ID
 
-	// GetResource accepts either a *T or *[]T where T implements Resource.
+	// GetResource accepts either a *T or *[]*T where T implements Resource.
 	// For a non-slice pointer, the value will be assigned to the first matching resource.
 	// For a slice pointer, the matching resources will be appended.
 	// If ref is not a pointer, an error will be returned.

--- a/pkg/test/framework/scope.go
+++ b/pkg/test/framework/scope.go
@@ -72,29 +72,24 @@ func (s *scope) add(r resource.Resource, id *resourceID) {
 
 func (s *scope) get(ref interface{}) error {
 	refVal := reflect.ValueOf(ref)
-	if refVal.Kind() != reflect.Ptr && refVal.Kind() != reflect.Slice {
+	if refVal.Kind() != reflect.Ptr {
 		return fmt.Errorf("ref must be a pointer or a slice, instead got: %T", ref)
 	}
 
-	var targetT reflect.Type
-	switch refVal.Kind() {
-	case reflect.Ptr:
-		targetT = refVal.Elem().Type()
-	case reflect.Slice:
-		targetT = refVal.Type().Elem()
+	if refVal.Elem().Kind() == reflect.Slice {
+		refVal = refVal.Elem()
 	}
 
+	targetT := refVal.Type().Elem()
 	for _, res := range s.resources {
 		resVal := reflect.ValueOf(res)
-		refT, resT := targetT.String(), resVal.Type().String()
-		fmt.Println(refT, resT)
 		if resVal.Type().AssignableTo(targetT) {
 			switch refVal.Kind() {
 			case reflect.Ptr:
 				refVal.Elem().Set(resVal)
 				return nil
 			case reflect.Slice:
-				reflect.Append(refVal, resVal)
+				refVal.Set(reflect.Append(refVal, resVal))
 			}
 		}
 

--- a/pkg/test/framework/scope.go
+++ b/pkg/test/framework/scope.go
@@ -91,8 +91,6 @@ func (s *scope) get(ref interface{}) error {
 	fmt.Printf("target: %s\n", target)
 	for _, res := range s.resources {
 		resVal := reflect.ValueOf(res)
-		t := fmt.Sprintf("%T", res)
-		fmt.Printf("res: %s\n", t)
 		if resVal.Type().AssignableTo(targetT) {
 			if refVal.Kind() == reflect.Slice {
 				refVal.Set(reflect.Append(refVal, resVal))

--- a/pkg/test/framework/suite_test.go
+++ b/pkg/test/framework/suite_test.go
@@ -453,7 +453,6 @@ func TestSuite_DoubleInit_Error(t *testing.T) {
 
 func TestSuite_GetResource(t *testing.T) {
 	defer cleanupRT()
-	g := NewGomegaWithT(t)
 
 	act := func(refPtr interface{}, trackedResource resource.Resource) error {
 		var err error
@@ -471,6 +470,7 @@ func TestSuite_GetResource(t *testing.T) {
 	}
 
 	t.Run("struct reference", func(t *testing.T) {
+		g := NewGomegaWithT(t)
 		var ref *fakeCluster
 		tracked := &fakeCluster{index: 1}
 		// notice that we pass **fakeCluster:
@@ -481,6 +481,7 @@ func TestSuite_GetResource(t *testing.T) {
 		g.Expect(tracked).To(Equal(ref))
 	})
 	t.Run("interface reference", func(t *testing.T) {
+		g := NewGomegaWithT(t)
 		var ref resource.Cluster
 		tracked := &fakeCluster{index: 1}
 		err := act(&ref, tracked)
@@ -488,6 +489,7 @@ func TestSuite_GetResource(t *testing.T) {
 		g.Expect(tracked).To(Equal(ref))
 	})
 	t.Run("slice reference", func(t *testing.T) {
+		g := NewGomegaWithT(t)
 		existing := &fakeCluster{index: 1}
 		tracked := &fakeCluster{index: 2}
 		ref := []resource.Cluster{existing}
@@ -498,6 +500,7 @@ func TestSuite_GetResource(t *testing.T) {
 		g.Expect(tracked).To(Equal(ref[1]))
 	})
 	t.Run("non pointer ref", func(t *testing.T) {
+		g := NewGomegaWithT(t)
 		err := act(fakeCluster{}, &fakeCluster{})
 		g.Expect(err).NotTo(BeNil())
 	})

--- a/pkg/test/framework/suite_test.go
+++ b/pkg/test/framework/suite_test.go
@@ -455,23 +455,18 @@ func TestSuite_GetResource(t *testing.T) {
 	defer cleanupRT()
 	g := NewGomegaWithT(t)
 
-	type nonResource struct{}
-
 	var (
 		structRes    fakeEnvironment
 		interfaceRes resource.Cluster
-		notFoundRes  nonResource
 
-		structErr, ifErr, sliceErr error
-		notFoundErr, nonPtrErr     error
+		structErr, ifErr, sliceErr, nonPtrErr error
 	)
 	sliceRes := []resource.Cluster{fakeCluster{index: 3}}
 
 	runFn := func(ctx *suiteContext) int {
 		structErr = ctx.GetResource(&structRes)
 		ifErr = ctx.GetResource(&interfaceRes)
-		sliceErr = ctx.GetResource(sliceRes)
-		notFoundErr = ctx.GetResource(&notFoundRes)
+		sliceErr = ctx.GetResource(&sliceRes)
 		nonPtrErr = ctx.GetResource(fakeEnvironment{})
 		return 0
 	}
@@ -496,8 +491,6 @@ func TestSuite_GetResource(t *testing.T) {
 	g.Expect(sliceRes[0].Index()).To(Equal(resource.ClusterIndex(3)))
 	g.Expect(sliceRes[1].Index()).To(Equal(resource.ClusterIndex(1)))
 
-	g.Expect(notFoundErr).To(BeNil())
-	g.Expect(notFoundRes).To(BeNil())
 	g.Expect(nonPtrErr).NotTo(BeNil())
 }
 

--- a/pkg/test/framework/suitecontext.go
+++ b/pkg/test/framework/suitecontext.go
@@ -129,6 +129,10 @@ func (s *suiteContext) TrackResource(r resource.Resource) resource.ID {
 	return rid
 }
 
+func (s *suiteContext) GetResource(ref interface{}) error {
+	return s.globalScope.get(ref)
+}
+
 // Environment implements ResourceContext
 func (s *suiteContext) Environment() resource.Environment {
 	return s.environment

--- a/pkg/test/framework/testcontext.go
+++ b/pkg/test/framework/testcontext.go
@@ -142,6 +142,13 @@ func (c *testContext) TrackResource(r resource.Resource) resource.ID {
 	return rid
 }
 
+func (c *testContext) GetResource(ref interface{}) error {
+	if err := c.scope.get(ref); err != nil {
+		return c.suite.GetResource(ref)
+	}
+	return nil
+}
+
 func (c *testContext) WorkDir() string {
 	return c.workDir
 }


### PR DESCRIPTION
In cases where another part of the testing framework or a test itself needs a reference a resource, this can be useful to avoid plumbing a reference to the resource through every constructor/function. As the PR currently sits, it's only useful when only one of the given type of resource is expected in the context. 