### PR TITLE
add labels for feature-based testing

### DIFF
--- a/pkg/test/framework/features/features.gen.go
+++ b/pkg/test/framework/features/features.gen.go
@@ -1,0 +1,34 @@
+// Copyright 2020 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+	
+//WARNING: THIS IS AN AUTO-GENERATED FILE, DO NOT EDIT.
+
+package features
+
+type Feature string
+
+const (
+	Observability	Feature = "observability"
+	Security_Certificates_Citadel	Feature = "security.certificates.citadel"
+	Security_Certificates_LetsEncrypt	Feature = "security.certificates.lets-encrypt"
+	Security_Certificates_Spire	Feature = "security.certificates.spire"
+	Security_MTLS_OnByDefault	Feature = "security.mTLS.on-by-default"
+	Traffic_CircuitBreakers_FailGracefully	Feature = "traffic.circuit-breakers.fail-gracefully"
+	Usability_Introspection_Status_Analysis_ContainsMessageWhenFalse	Feature = "usability.introspection.status.analysis.contains-message-when-false"
+	Usability_Introspection_Status_Analysis_TrueWhenWarnOnly	Feature = "usability.introspection.status.analysis.true-when-warn-only"
+	Usability_Introspection_Status_Distribution_EventuallyTrue	Feature = "usability.introspection.status.distribution.eventually-true"
+	Usability_Introspection_Status_Distribution_ImmediatelyFalse	Feature = "usability.introspection.status.distribution.immediately-false"
+	Usability_Observability_Status	Feature = "usability.observability.status"
+	Usability_Observability_Status_DefaultExists	Feature = "usability.observability.status.default-exists"
+)

--- a/pkg/test/framework/features/features.yaml
+++ b/pkg/test/framework/features/features.yaml
@@ -1,0 +1,41 @@
+# Copyright 2020 Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#Edit this file to add more feature labels for the testing dashboard
+#"values" is a keyword and must contains a list of strings. "values" is omitted when building the label name
+#   This is used when a map needs direct leaf nodes but also other maps
+features:
+  values: 
+    - observability
+  traffic:
+    circuit-breakers:
+        - fail-gracefully
+  usability:
+    observability:
+      values: status
+      status: default-exists
+    introspection:
+      status:
+        distribution:
+          - immediately-false
+          - eventually-true
+        analysis:
+          - contains-message-when-false
+          - true-when-warn-only
+  security:
+    certificates:
+      - citadel
+      - lets-encrypt
+      - spire
+    mTLS: on-by-default

--- a/pkg/test/framework/tools/featuresgen/cmd/root.go
+++ b/pkg/test/framework/tools/featuresgen/cmd/root.go
@@ -1,0 +1,217 @@
+// Copyright 2020 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	Copyright = `// Copyright 2020 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+	`
+
+	GeneratedWarning = `
+//WARNING: THIS IS AN AUTO-GENERATED FILE, DO NOT EDIT.
+`
+
+	TypeDefFeature = `
+type Feature string
+`
+
+	Package = `
+package features
+`
+
+	ConstOpen = `
+const (
+`
+
+	ConstClose = `
+)
+`
+)
+
+var (
+	input  string
+	output string
+
+	rootCmd = &cobra.Command{
+		Use:   "featuresgen [OPTIONS]",
+		Short: "FeaturesGen generates valid test labels from a yaml file",
+		Run: func(cmd *cobra.Command, args []string) {
+			createLabelsFile()
+		},
+	}
+
+	alphanumericRegex = regexp.MustCompile(`[^a-zA-Z0-9-]`)
+	dotsRegex         = regexp.MustCompile(`[\.]`)
+	replaceDashRegex  = regexp.MustCompile(`-(.)`)
+)
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println("Error running featuresgen:")
+		panic(err)
+	}
+}
+
+func init() {
+	rootCmd.Flags().StringVarP(&input, "inputFile", "i", "features.yaml", "the YAML file to use as input")
+	rootCmd.Flags().StringVarP(&output, "outputFile", "o", "features.gen.go", "output Go file with labels as string consts")
+}
+
+//Parses a map in the yaml file
+func readMap(m map[interface{}]interface{}, path []string) []string {
+	var labels []string
+	for k, v := range m {
+		//If we see "values," then the element is a root and we shouldn't put it in our label name
+		if k == "values" {
+			labels = append(labels, readVal(v, path)...)
+		} else {
+			if len(path) > 0 || k.(string) != "features" {
+				path = append(path, k.(string))
+			}
+			labels = append(labels, readVal(v, path)...)
+			if len(path) > 0 {
+				path = path[:len(path)-1]
+			}
+		}
+	}
+	return labels
+}
+
+//Parses a slice in the yaml file
+func readSlice(slc []interface{}, path []string) []string {
+	labels := make([]string, 0)
+	for _, v := range slc {
+		labels = append(labels, readVal(v, path)...)
+	}
+	return labels
+}
+
+//Determines the type of a node in the yaml file and parses it accordingly
+func readVal(v interface{}, path []string) []string {
+	typ := reflect.TypeOf(v).Kind()
+	if typ == reflect.Int || typ == reflect.String {
+		path = append(path, v.(string))
+		return []string{createConstantString(path)}
+	} else if typ == reflect.Slice {
+		return readSlice(v.([]interface{}), path)
+	} else if typ == reflect.Map {
+		return readMap(v.(map[interface{}]interface{}), path)
+	}
+	panic("Found invalid type in YAML file")
+}
+
+func removeDashAndTitle(s string) string {
+	return strings.Title(s[1:])
+}
+
+//Writes a label to the constants file
+func createConstantString(path []string) string {
+	name := ""
+	value := ""
+	for i := 0; i < len(path); i++ {
+		namePart := alphanumericRegex.ReplaceAllString(path[i], "")
+		namePart = replaceDashRegex.ReplaceAllStringFunc(namePart, removeDashAndTitle)
+		namePart = strings.Title(namePart)
+		name += namePart
+		name += "_"
+
+		value += dotsRegex.ReplaceAllString(path[i], "")
+		value += "."
+	}
+	name = strings.TrimSuffix(name, "_")
+	value = strings.TrimSuffix(value, ".")
+	return fmt.Sprintf("\t%s\tFeature = \"%s\"", name, value)
+}
+
+//Reads the yaml file and generates a string constant for each leaf node
+func createLabelsFromYaml() string {
+	data, err := ioutil.ReadFile(input)
+	if err != nil {
+		pwd, _ := os.Getwd()
+		fmt.Println("Error running featuresgen on file: ", pwd, "/", input)
+		panic(err)
+	}
+	m := make(map[interface{}]interface{})
+
+	err = yaml.Unmarshal(data, &m)
+	if err != nil {
+		pwd, _ := os.Getwd()
+		fmt.Println("Error running featuresgen on file: ", pwd, "/", input)
+		panic(err)
+	}
+
+	constants := readVal(m, make([]string, 0))
+	// The parsing of the yaml file doesn't seem to happen in a consistent order. To avoid a different file every time 'make gen' is run, we sort the list.
+	sort.Strings(constants)
+	return strings.Join(constants, "\n")
+}
+
+func check(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+//Main function that writes the new generated labels file
+func createLabelsFile() {
+	f, err := os.Create("./" + output)
+	if err != nil {
+		fmt.Println("Error running featuresgen:")
+		panic(err)
+	}
+
+	defer f.Close()
+
+	_, err = f.WriteString(Copyright)
+	check(err)
+	_, err = f.WriteString(GeneratedWarning)
+	check(err)
+	_, err = f.WriteString(Package)
+	check(err)
+	_, err = f.WriteString(TypeDefFeature)
+	check(err)
+	_, err = f.WriteString(ConstOpen)
+	check(err)
+	_, err = f.WriteString(createLabelsFromYaml())
+	check(err)
+	_, err = f.WriteString(ConstClose)
+	check(err)
+	err = f.Sync()
+	check(err)
+}

--- a/pkg/test/framework/tools/featuresgen/cmd/root_test.go
+++ b/pkg/test/framework/tools/featuresgen/cmd/root_test.go
@@ -1,0 +1,64 @@
+// Copyright 2020 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+func TestCreateConstantString(t *testing.T) {
+	s1 := createConstantString([]string{"lab-el1", "label2"})
+	if s1 != "\tLabEl1_Label2\tFeature = \"lab-el1.label2\"" {
+		t.Errorf("Expected '\tLabEl1_Label2\tFeature = \"lab-el1.label2\"' got '%s'", s1)
+	}
+
+	s2 := createConstantString([]string{"lab.*)($)#el1", "lab.el2"})
+	if s2 != "\tLabel1_Label2\tFeature = \"lab*)($)#el1.label2\"" {
+		t.Errorf("Expected '\tLabel1_Label2\tFeature = \"lab*)($)#el1.label2\"' got '%s'", s2)
+	}
+}
+
+var testYaml = `
+features:
+  values: [hello1, hello2]
+  key2:
+    values: [val1, val2]
+`
+
+const expectedResult = `	Hello1	Feature = "hello1"
+	Hello2	Feature = "hello2"
+	Key2_Val1	Feature = "key2.val1"
+	Key2_Val2	Feature = "key2.val2"`
+
+func TestReadVal(t *testing.T) {
+	m := make(map[interface{}]interface{})
+
+	err := yaml.Unmarshal([]byte(testYaml), &m)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	s1 := readVal(m, make([]string, 0))
+
+	sort.Strings(s1)
+
+	if strings.Join(s1, "\n") != expectedResult {
+		t.Errorf("Expected '%s' got '%s'", expectedResult, strings.Join(s1, "\n"))
+	}
+}

--- a/pkg/test/framework/tools/featuresgen/main.go
+++ b/pkg/test/framework/tools/featuresgen/main.go
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:generate go run ../tools/featuresgen/main.go
+package main
 
-package features
+import (
+	"istio.io/istio/pkg/test/framework/tools/featuresgen/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/tests/integration/pilot/analysis/analysis_test.go
+++ b/tests/integration/pilot/analysis/analysis_test.go
@@ -41,12 +41,12 @@ import (
 func TestStatusExistsByDefault(t *testing.T) {
 	// This test is not yet implemented
 	framework.NewTest(t).
-		NotImplementedYet(features.UsabilityObservabilityStatusDefaultExists)
+		NotImplementedYet(features.Usability_Observability_Status_DefaultExists)
 }
 
 func TestAnalysisWritesStatus(t *testing.T) {
 	framework.NewTest(t).
-		Features(features.UsabilityObservabilityStatus).
+		Features(features.Usability_Observability_Status).
 		// TODO: make feature labels heirarchical constants like:
 		// Label(features.Usability.Observability.Status).
 		Run(func(ctx framework.TestContext) {


### PR DESCRIPTION
Feature-based testing will require labels for tests. To ensure labels are consistent, spelled correctly, and are organized, a YAML file is used to generate the labels. This PR contains a generator that generates string constants from a YAML file for these labels.