### PR TITLE
Add SDS probing to istio-agent.

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -511,6 +511,7 @@ var (
 					StatusPort:     statusPort,
 					KubeAppProbers: prober,
 					NodeType:       role.Type,
+					SDSEnabled:     nodeAgentSDSEnabled,
 				})
 				if err != nil {
 					cancel()

--- a/pilot/cmd/pilot-agent/status/ready/probe.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe.go
@@ -53,7 +53,8 @@ func (p *Probe) checkConfigStatus() error {
 
 	CDSUpdated := s.CDSUpdatesSuccess > 0
 	LDSUpdated := s.LDSUpdatesSuccess > 0
-	if CDSUpdated && LDSUpdated {
+	SDSUpdated := s.SDSUpdatesSuccess > 0
+	if CDSUpdated && LDSUpdated && SDSUpdated {
 		p.receivedFirstUpdate = true
 		return nil
 	}

--- a/pilot/cmd/pilot-agent/status/ready/probe.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe.go
@@ -53,10 +53,10 @@ func (p *Probe) checkConfigStatus() error {
 	}
 
 	if s.CDSUpdatesSuccess == 0 || s.LDSUpdatesSuccess == 0 {
-		return fmt.Errorf("config not received from Pilot (is Pilot running?): %s", s.String())
+		return fmt.Errorf("config not received from XDS server (is Istiod running?): %s", s.String())
 	}
 	if p.NodeType == model.SidecarProxy && p.SDSEnabled && s.SDSUpdatesSuccess == 0 {
-		return fmt.Errorf("cert not received from istio-agent (check the istio-agent config and try to restart the pod if the error persists): %s", s.String())
+		return fmt.Errorf("secret not received from SDS server (check the istio-agent config and try to restart the pod if the error persists): %s", s.String())
 	}
 	p.receivedFirstUpdate = true
 	return nil

--- a/pilot/cmd/pilot-agent/status/ready/probe.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe.go
@@ -29,6 +29,7 @@ type Probe struct {
 	NodeType            model.NodeType
 	AdminPort           uint16
 	receivedFirstUpdate bool
+	SDSEnabled          bool
 }
 
 // Check executes the probe and returns an error if the probe fails.
@@ -54,7 +55,7 @@ func (p *Probe) checkConfigStatus() error {
 	if s.CDSUpdatesSuccess == 0 || s.LDSUpdatesSuccess == 0 {
 		return fmt.Errorf("config not received from Pilot (is Pilot running?): %s", s.String())
 	}
-	if p.NodeType == model.SidecarProxy && s.SDSUpdatesSuccess == 0 {
+	if p.NodeType == model.SidecarProxy && p.SDSEnabled && s.SDSUpdatesSuccess == 0 {
 		return fmt.Errorf("cert not received from istio-agent (check the istio-agent config and try to restart the pod if the error persists): %s", s.String())
 	}
 	p.receivedFirstUpdate = true

--- a/pilot/cmd/pilot-agent/status/ready/probe.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe.go
@@ -51,18 +51,14 @@ func (p *Probe) checkConfigStatus() error {
 		return err
 	}
 
-	CDSUpdated := s.CDSUpdatesSuccess > 0
-	LDSUpdated := s.LDSUpdatesSuccess > 0
-	SDSUpdated := s.SDSUpdatesSuccess > 0
-	if CDSUpdated && LDSUpdated && SDSUpdated {
-		p.receivedFirstUpdate = true
-		return nil
-	}
-
-	if !CDSUpdated || !LDSUpdated {
+	if s.CDSUpdatesSuccess == 0 || s.LDSUpdatesSuccess == 0 {
 		return fmt.Errorf("config not received from Pilot (is Pilot running?): %s", s.String())
 	}
-	return fmt.Errorf("cert not received from istio-agent (check the istio-agent config and try to restart the pod if the error persists): %s", s.String())
+	if p.NodeType == model.SidecarProxy && s.SDSUpdatesSuccess == 0 {
+		return fmt.Errorf("cert not received from istio-agent (check the istio-agent config and try to restart the pod if the error persists): %s", s.String())
+	}
+	p.receivedFirstUpdate = true
+	return nil
 }
 
 // checkServerState checks to ensure that Envoy is in the READY state

--- a/pilot/cmd/pilot-agent/status/ready/probe.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe.go
@@ -59,7 +59,10 @@ func (p *Probe) checkConfigStatus() error {
 		return nil
 	}
 
-	return fmt.Errorf("config not received from Pilot (is Pilot running?): %s", s.String())
+	if !CDSUpdated || !LDSUpdated {
+		return fmt.Errorf("config not received from Pilot (is Pilot running?): %s", s.String())
+	}
+	return fmt.Errorf("cert not received from istio-agent (check the istio-agent config and try to restart the pod if the error persists): %s", s.String())
 }
 
 // checkServerState checks to ensure that Envoy is in the READY state

--- a/pilot/cmd/pilot-agent/status/ready/probe_test.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+
 	"istio.io/istio/pilot/pkg/model"
 )
 

--- a/pilot/cmd/pilot-agent/status/ready/probe_test.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe_test.go
@@ -25,10 +25,12 @@ import (
 )
 
 var (
-	liveServerStats = "cluster_manager.cds.update_success: 1\nlistener_manager.lds.update_success: 1\nserver.state: 0\nlistener.0.0.0.0_15006.server_ssl_socket_factory.ssl_context_update_by_sds: 2"
+	liveServerStats = "cluster_manager.cds.update_success: 1\nlistener_manager.lds.update_success: 1\nserver.state: 0\n" +
+		"listener.0.0.0.0_15006.server_ssl_socket_factory.ssl_context_update_by_sds: 2"
 	onlyServerStats = "server.state: 0"
-	initServerStats = "cluster_manager.cds.update_success: 1\nlistener_manager.lds.update_success: 1\nserver.state: 2\nlistener.0.0.0.0_15006.server_ssl_socket_factory.ssl_context_update_by_sds: 2"
-	noServerStats   = ""
+	initServerStats = "cluster_manager.cds.update_success: 1\nlistener_manager.lds.update_success: 1\nserver.state: 2\n" +
+		"listener.0.0.0.0_15006.server_ssl_socket_factory.ssl_context_update_by_sds: 2"
+	noServerStats = ""
 )
 
 func TestEnvoyStatsCompleteAndSuccessful(t *testing.T) {

--- a/pilot/cmd/pilot-agent/status/ready/probe_test.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe_test.go
@@ -47,8 +47,9 @@ func TestEnvoyStatsCompleteAndSuccessful(t *testing.T) {
 }
 
 func TestEnvoyStats(t *testing.T) {
-	ldsCdsPrefix := "config not received from Pilot (is Pilot running?): "
-	sdsErrorPrefix := "cert not received from istio-agent (check the istio-agent config and try to restart the pod if the error persists): "
+	ldsCdsPrefix := "config not received from XDS server (is Istiod running?): "
+	sdsErrorPrefix :=
+		"secret not received from SDS server (check the istio-agent config and try to restart the pod if the error persists): "
 	cases := []struct {
 		name       string
 		stats      string
@@ -59,14 +60,16 @@ func TestEnvoyStats(t *testing.T) {
 		{
 			"only LDS",
 			"listener_manager.lds.update_success: 1",
-			ldsCdsPrefix + "cds updates: 0 successful, 0 rejected; lds updates: 1 successful, 0 rejected; sds updates: 0 successful",
+			ldsCdsPrefix +
+				"cds updates: 0 successful, 0 rejected; lds updates: 1 successful, 0 rejected; sds updates: 0 successful",
 			model.SidecarProxy,
 			true,
 		},
 		{
 			"only CDS",
 			"cluster_manager.cds.update_success: 1",
-			ldsCdsPrefix + "cds updates: 1 successful, 0 rejected; lds updates: 0 successful, 0 rejected; sds updates: 0 successful",
+			ldsCdsPrefix +
+				"cds updates: 1 successful, 0 rejected; lds updates: 0 successful, 0 rejected; sds updates: 0 successful",
 			model.SidecarProxy,
 			true,
 		},
@@ -74,17 +77,19 @@ func TestEnvoyStats(t *testing.T) {
 			"reject CDS",
 			`cluster_manager.cds.update_rejected: 1
 listener_manager.lds.update_success: 1`,
-			ldsCdsPrefix + "cds updates: 0 successful, 1 rejected; lds updates: 1 successful, 0 rejected; sds updates: 0 successful",
+			ldsCdsPrefix +
+				"cds updates: 0 successful, 1 rejected; lds updates: 1 successful, 0 rejected; sds updates: 0 successful",
 			model.SidecarProxy,
 			true,
 		},
 		{
-			"Sidecar SDS missing SDS",
+			"Sidecar SDS missing SDS update",
 			`
 cluster_manager.cds.update_success: 1
 listener_manager.lds.update_success: 1
 server.state: 0`,
-			sdsErrorPrefix + "cds updates: 1 successful, 0 rejected; lds updates: 1 successful, 0 rejected; sds updates: 0 successful",
+			sdsErrorPrefix +
+				"cds updates: 1 successful, 0 rejected; lds updates: 1 successful, 0 rejected; sds updates: 0 successful",
 			model.SidecarProxy,
 			true,
 		},
@@ -136,13 +141,13 @@ listener.0.0.0.0_15006.server_ssl_socket_factory.ssl_context_update_by_sds: 2`,
 			// Expect no error
 			if tt.result == "" {
 				if err != nil {
-					t.Fatalf("Test %s: expected no error, got: %v", tt.name, err)
+					t.Fatalf("Expected no error, got: '%v'", err)
 				}
 				return
 			}
 			// Expect error
 			if err == nil || err.Error() != tt.result {
-				t.Fatalf("Test %s: expected: \n'%v', got: \n'%v'", tt.name, tt.result, err)
+				t.Fatalf("Expected: \n'%v', got: \n'%v'", tt.result, err)
 			}
 		})
 	}

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -75,6 +75,7 @@ type Config struct {
 	NodeType       model.NodeType
 	StatusPort     uint16
 	AdminPort      uint16
+	SDSEnabled     bool
 }
 
 // Server provides an endpoint for handling status probes.
@@ -94,6 +95,7 @@ func NewServer(config Config) (*Server, error) {
 			LocalHostAddr: config.LocalHostAddr,
 			AdminPort:     config.AdminPort,
 			NodeType:      config.NodeType,
+			SDSEnabled:    config.SDSEnabled,
 		},
 	}
 	if config.KubeAppProbers == "" {

--- a/pilot/cmd/pilot-agent/status/util/stats.go
+++ b/pilot/cmd/pilot-agent/status/util/stats.go
@@ -29,7 +29,8 @@ const (
 	statLdsRejected  = "listener_manager.lds.update_rejected"
 	statsLdsSuccess  = "listener_manager.lds.update_success"
 	statServerState  = "server.state"
-	updateStatsRegex = "^(cluster_manager.cds|listener_manager.lds).(update_success|update_rejected)$"
+	statsSdsSuccess  = "listener.0.0.0.0_15006.server_ssl_socket_factory.ssl_context_update_by_sds"
+	updateStatsRegex = "^(cluster_manager.cds|listener_manager.lds).(update_success|update_rejected)$|^listener.0.0.0.0_15006.server_ssl_socket_factory.ssl_context_update_by_sds"
 )
 
 type stat struct {
@@ -45,6 +46,7 @@ type Stats struct {
 	CDSUpdatesRejection uint64
 	LDSUpdatesSuccess   uint64
 	LDSUpdatesRejection uint64
+	SDSUpdatesSuccess   uint64
 	// Server State of Envoy.
 	ServerState uint64
 }
@@ -102,6 +104,7 @@ func GetUpdateStatusStats(localHostAddr string, adminPort uint16) (*Stats, error
 		{name: statCdsRejected, value: &s.CDSUpdatesRejection},
 		{name: statsLdsSuccess, value: &s.LDSUpdatesSuccess},
 		{name: statLdsRejected, value: &s.LDSUpdatesRejection},
+		{name: statsSdsSuccess, value: &s.SDSUpdatesSuccess},
 	}
 	if err := parseStats(stats, allStats); err != nil {
 		return nil, err

--- a/pilot/cmd/pilot-agent/status/util/stats.go
+++ b/pilot/cmd/pilot-agent/status/util/stats.go
@@ -30,7 +30,8 @@ const (
 	statsLdsSuccess  = "listener_manager.lds.update_success"
 	statServerState  = "server.state"
 	statsSdsSuccess  = "listener.0.0.0.0_15006.server_ssl_socket_factory.ssl_context_update_by_sds"
-	updateStatsRegex = "^(cluster_manager.cds|listener_manager.lds).(update_success|update_rejected)$|^listener.0.0.0.0_15006.server_ssl_socket_factory.ssl_context_update_by_sds"
+	updateStatsRegex = "^(cluster_manager.cds|listener_manager.lds).(update_success|update_rejected)$|" +
+		"^listener.0.0.0.0_15006.server_ssl_socket_factory.ssl_context_update_by_sds"
 )
 
 type stat struct {

--- a/pilot/cmd/pilot-agent/status/util/stats.go
+++ b/pilot/cmd/pilot-agent/status/util/stats.go
@@ -53,11 +53,12 @@ type Stats struct {
 
 // String representation of the Stats.
 func (s *Stats) String() string {
-	return fmt.Sprintf("cds updates: %d successful, %d rejected; lds updates: %d successful, %d rejected",
+	return fmt.Sprintf("cds updates: %d successful, %d rejected; lds updates: %d successful, %d rejected; sds updates: %d successful",
 		s.CDSUpdatesSuccess,
 		s.CDSUpdatesRejection,
 		s.LDSUpdatesSuccess,
-		s.LDSUpdatesRejection)
+		s.LDSUpdatesRejection,
+		s.SDSUpdatesSuccess)
 }
 
 // GetServerState returns the current Envoy state by checking the "server.state" stat.


### PR DESCRIPTION
We want to use Istio Agent to monitor that the Envoy SDS info is successfully updated. Today it only monitors LDS and CDS.

If no SDS is received on Envoy 15006 listener port, Istio Agent will consider Envoy as not ready. I have tested that even with mTLS set to false, Envoy 15006 listener always retrieves certs from SDS. So this probing should be valid regardless of mTLS enablement.

This is a mitigation for https://github.com/istio/istio/issues/22443. In that the pods failed to obtain SDS certs will be "not ready" with "1/2" status. The users can notice this and manually restart the pods.

Will work on master if this PR makes sense.