### PR TITLE
Guard against null bool in "manifest generate"

### DIFF
--- a/operator/cmd/mesh/testdata/manifest-generate/input/bogus_cps.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/input/bogus_cps.yaml
@@ -7,4 +7,4 @@ spec:
     global:
       controlPlaneSecurityEnabled:
       mtls:
-        auto: true
+        auto:

--- a/operator/pkg/apis/istio/v1alpha1/validation/validation.go
+++ b/operator/pkg/apis/istio/v1alpha1/validation/validation.go
@@ -108,7 +108,7 @@ func validateFeatures(values *valuesv1alpha1.Values, _ *v1alpha1.IstioOperatorSp
 	if m == nil {
 		return nil
 	}
-	if m.GetAuto().Value && !g.GetControlPlaneSecurityEnabled().GetValue() {
+	if m.GetAuto().GetValue() && !g.GetControlPlaneSecurityEnabled().GetValue() {
 		return []error{fmt.Errorf("security: auto mtls is enabled, but control plane security is not enabled")}
 	}
 	return nil


### PR DESCRIPTION
After yesterday's fix https://github.com/istio/istio/pull/23587 I grepped through the code and found another example of the same flaw on the same line that I had already looked at!

This fixes the newly discovered flaw.

cc @ostromart @howardjohn I had wanted to do some kind of fuzzing of IOPs to catch more of this kind of stuff but was distracted and didn't actually create an Issue for that kind of testing.  Nor did I identify a library to do it.  We need some kind of testing because it is too easy to modify the operator to improve something but break something else.  The code coverage for the operator might be good but IOP validation and generation templates can break in surprising ways.  Should I create an issue for fuzz testing IOPs?  An agenda item for Environments WG?