### PR TITLE
use istiod flag to create istiod or Istiod-remote service

### DIFF
--- a/manifests/charts/base/templates/endpoints.yaml
+++ b/manifests/charts/base/templates/endpoints.yaml
@@ -1,23 +1,21 @@
 {{- if .Values.global.remotePilotAddress }}
-  {{- if not .Values.global.istiod.enabled }}
-apiVersion: v1
-kind: Endpoints
-metadata:
-  name: istio-pilot
-  namespace: {{ .Values.global.istioNamespace }}
-subsets:
-- addresses:
-  - ip: {{ .Values.global.remotePilotAddress }}
-  ports:
-  - port: 15010
-    name: grpc-xds # direct
-  - port: 15011
-    name: https-xds # mTLS or non-mTLS depending on auth setting
-  {{- else }}
+  {{- if .Values.global.istiod.enabled }}
 apiVersion: v1
 kind: Endpoints
 metadata:
   name: istiod-remote
+  namespace: {{ .Release.Namespace }}
+subsets:
+- addresses:
+  - ip: {{ .Values.global.remotePilotAddress }}
+  ports:
+  - port: 15012
+    name: tcp-istiod
+  {{- else }}
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: istiod
   namespace: {{ .Release.Namespace }}
 subsets:
 - addresses:

--- a/manifests/charts/base/templates/endpoints.yaml
+++ b/manifests/charts/base/templates/endpoints.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.remotePilotAddress }}
-  {{- if .Values.global.istiod.enabled }}
+  {{- if .Values.global.pilot.enabled }}
 apiVersion: v1
 kind: Endpoints
 metadata:

--- a/manifests/charts/base/templates/services.yaml
+++ b/manifests/charts/base/templates/services.yaml
@@ -1,23 +1,23 @@
 {{- if .Values.global.remotePilotAddress }}
-  {{- if not .Values.global.istiod.enabled }}
-apiVersion: v1
-kind: Service
-metadata:
-  name: istio-pilot
-  namespace: {{ .Values.global.istioNamespace }}
-spec:
-  ports:
-  - port: 15010
-    name: grpc-xds # direct
-  - port: 15011
-    name: https-xds # mTLS or non-mTLS depending on auth setting
-  clusterIP: None
-  {{- else }}
+  {{- if .Values.global.istiod.enabled }}
+# when istiod is enabled in remote cluster, we can't use istiod service name  
 apiVersion: v1
 kind: Service
 metadata:
   name: istiod-remote
   namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - port: 15012
+    name: tcp-istiod
+  clusterIP: None
+  {{- else }}
+# when istiod isn't enabled in remote cluster, we can use istiod service name
+apiVersion: v1
+kind: Service
+metadata:
+  name: istiod
+  namespace: {{ .Values.global.istioNamespace }}
 spec:
   ports:
   - port: 15012

--- a/manifests/charts/base/templates/services.yaml
+++ b/manifests/charts/base/templates/services.yaml
@@ -17,7 +17,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: istiod
-  namespace: {{ .Values.global.istioNamespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - port: 15012

--- a/manifests/charts/base/templates/services.yaml
+++ b/manifests/charts/base/templates/services.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.remotePilotAddress }}
-  {{- if .Values.global.istiod.enabled }}
+  {{- if .Values.global.pilot.enabled }}
 # when istiod is enabled in remote cluster, we can't use istiod service name  
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
use istiod flag to create istiod or Istiod-remote service on remote cluster.  Believe the Istio-pilot service is gone in 1.6 now, so we can remove it.

for central istiod, it would be simplified when the istiod service is called istiod (vs Istiod-remote) so that we don't need a different discovery address or ca address than the main istiod has.

related to #22934