### PR TITLE
set discoveryAddress to be cluster-local by default

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"time"
 
+	"istio.io/istio/pkg/config/host"
+
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	gogojsonpb "github.com/gogo/protobuf/jsonpb"
 	"github.com/golang/protobuf/jsonpb"
@@ -84,6 +86,14 @@ func (e *Environment) Mesh() *meshconfig.MeshConfig {
 		return e.Watcher.Mesh()
 	}
 	return nil
+}
+
+func (e *Environment) GetDiscoveryHost() (host.Name, error) {
+	hostname, _, err := net.SplitHostPort(e.Mesh().DefaultConfig.DiscoveryAddress)
+	if err != nil {
+		return "", err
+	}
+	return host.Name(hostname), nil
 }
 
 func (e *Environment) AddMeshHandler(h func()) {

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -25,8 +25,6 @@ import (
 	"strings"
 	"time"
 
-	"istio.io/istio/pkg/config/host"
-
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	gogojsonpb "github.com/gogo/protobuf/jsonpb"
 	"github.com/golang/protobuf/jsonpb"
@@ -37,6 +35,7 @@ import (
 	"istio.io/pkg/monitoring"
 
 	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/mesh"
 )

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -89,7 +89,11 @@ func (e *Environment) Mesh() *meshconfig.MeshConfig {
 }
 
 func (e *Environment) GetDiscoveryHost() (host.Name, error) {
-	hostname, _, err := net.SplitHostPort(e.Mesh().DefaultConfig.DiscoveryAddress)
+	proxyConfig := mesh.DefaultProxyConfig()
+	if e.Mesh().DefaultConfig != nil {
+		proxyConfig = *e.Mesh().DefaultConfig
+	}
+	hostname, _, err := net.SplitHostPort(proxyConfig.DiscoveryAddress)
 	if err != nil {
 		return "", err
 	}

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1581,6 +1581,12 @@ func (ps *PushContext) initClusterLocalHosts(e *Environment) {
 		defaultClusterLocalHosts = append(defaultClusterLocalHosts, host.Name("*."+n+".svc."+domainSuffix))
 	}
 
+	if discoveryHost, err := e.GetDiscoveryHost(); err != nil {
+		log.Errorf("failed to make discoveryAddress cluster-local: %v", err)
+	} else {
+		defaultClusterLocalHosts = append(defaultClusterLocalHosts, discoveryHost)
+	}
+
 	// Collect the cluster-local hosts.
 	clusterLocalHosts := make([]host.Name, 0)
 	for _, serviceSettings := range ps.Mesh.ServiceSettings {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1585,6 +1585,9 @@ func (ps *PushContext) initClusterLocalHosts(e *Environment) {
 		log.Errorf("failed to make discoveryAddress cluster-local: %v", err)
 	} else {
 		defaultClusterLocalHosts = append(defaultClusterLocalHosts, discoveryHost)
+		if !strings.HasSuffix(string(discoveryHost), domainSuffix) {
+			defaultClusterLocalHosts = append(defaultClusterLocalHosts, discoveryHost+host.Name("."+domainSuffix))
+		}
 	}
 
 	// Collect the cluster-local hosts.

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -888,7 +888,7 @@ func (ps *PushContext) updateContext(
 	pushReq *PushRequest) error {
 
 	var servicesChanged, virtualServicesChanged, destinationRulesChanged, gatewayChanged,
-	authnChanged, authzChanged, envoyFiltersChanged, sidecarsChanged, quotasChanged bool
+		authnChanged, authzChanged, envoyFiltersChanged, sidecarsChanged, quotasChanged bool
 
 	for conf := range pushReq.ConfigsUpdated {
 		switch conf.Kind {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -888,7 +888,7 @@ func (ps *PushContext) updateContext(
 	pushReq *PushRequest) error {
 
 	var servicesChanged, virtualServicesChanged, destinationRulesChanged, gatewayChanged,
-		authnChanged, authzChanged, envoyFiltersChanged, sidecarsChanged, quotasChanged bool
+	authnChanged, authzChanged, envoyFiltersChanged, sidecarsChanged, quotasChanged bool
 
 	for conf := range pushReq.ConfigsUpdated {
 		switch conf.Kind {
@@ -1584,10 +1584,10 @@ func (ps *PushContext) initClusterLocalHosts(e *Environment) {
 	if discoveryHost, err := e.GetDiscoveryHost(); err != nil {
 		log.Errorf("failed to make discoveryAddress cluster-local: %v", err)
 	} else {
-		defaultClusterLocalHosts = append(defaultClusterLocalHosts, discoveryHost)
 		if !strings.HasSuffix(string(discoveryHost), domainSuffix) {
-			defaultClusterLocalHosts = append(defaultClusterLocalHosts, discoveryHost+host.Name("."+domainSuffix))
+			discoveryHost += host.Name("." + domainSuffix)
 		}
+		defaultClusterLocalHosts = append(defaultClusterLocalHosts, discoveryHost)
 	}
 
 	// Collect the cluster-local hosts.

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -468,6 +468,12 @@ func TestIsClusterLocal(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "discovery server is local with domain suffix",
+			m:        mesh.DefaultMeshConfig(),
+			host:     "istiod.istio-system.svc.cluster.local",
+			expected: true,
+		},
+		{
 			name:     "not local by default",
 			m:        mesh.DefaultMeshConfig(),
 			host:     "not.cluster.local",

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -462,6 +462,12 @@ func TestIsClusterLocal(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "discovery server is local by default",
+			m:        mesh.DefaultMeshConfig(),
+			host:     "istiod.istio-system.svc",
+			expected: true,
+		},
+		{
 			name:     "not local by default",
 			m:        mesh.DefaultMeshConfig(),
 			host:     "not.cluster.local",

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -462,13 +462,7 @@ func TestIsClusterLocal(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "discovery server is local by default",
-			m:        mesh.DefaultMeshConfig(),
-			host:     "istiod.istio-system.svc",
-			expected: true,
-		},
-		{
-			name:     "discovery server is local with domain suffix",
+			name:     "discovery server is local",
 			m:        mesh.DefaultMeshConfig(),
 			host:     "istiod.istio-system.svc.cluster.local",
 			expected: true,


### PR DESCRIPTION
Any Envoy trying to connect to a discovery server will either:
- have an istiod instance in the same cluster
- have an istiod-remote service that forwards traffic to the primary cluster's ingressgateway

In either case, traffic from the proxy to the discovery server should be cluster-local. 

This fixes https://github.com/istio/istio/issues/23591