### PR TITLE
Fix broken cluster-local domain override

### DIFF
--- a/galley/pkg/config/analysis/analyzers/util/constants.go
+++ b/galley/pkg/config/analysis/analyzers/util/constants.go
@@ -16,10 +16,12 @@ package util
 
 import (
 	"regexp"
+
+	"istio.io/istio/pkg/config/constants"
 )
 
 const (
-	DefaultKubernetesDomain = "svc.cluster.local"
+	DefaultKubernetesDomain = "svc." + constants.DefaultKubernetesDomain
 	MeshGateway             = "mesh"
 	ExportToNamespaceLocal  = "."
 	ExportToAllNamespaces   = "*"

--- a/galley/pkg/config/analysis/local/analyze.go
+++ b/galley/pkg/config/analysis/local/analyze.go
@@ -42,6 +42,7 @@ import (
 	"istio.io/istio/galley/pkg/config/source/kube/apiserver"
 	"istio.io/istio/galley/pkg/config/source/kube/inmemory"
 	"istio.io/istio/galley/pkg/config/util/kuberesource"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/resource"
 	"istio.io/istio/pkg/config/schema"
@@ -51,7 +52,6 @@ import (
 )
 
 const (
-	domainSuffix       = "cluster.local"
 	meshConfigMapKey   = "mesh"
 	meshConfigMapName  = "istio"
 	meshNetworksMapKey = "meshNetworks"
@@ -209,7 +209,7 @@ func (sa *SourceAnalyzer) Analyze(cancel chan struct{}) (AnalysisResult, error) 
 
 	processorSettings := processor.Settings{
 		Metadata:           sa.m,
-		DomainSuffix:       domainSuffix,
+		DomainSuffix:       constants.DefaultKubernetesDomain,
 		Source:             newPrecedenceSource(sa.sources),
 		TransformProviders: sa.transformerProviders,
 		Distributor:        distributor,

--- a/galley/pkg/server/settings/args.go
+++ b/galley/pkg/server/settings/args.go
@@ -28,6 +28,7 @@ import (
 	"istio.io/pkg/probe"
 
 	"istio.io/istio/galley/pkg/config/util/kuberesource"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/schema/snapshots"
 	"istio.io/istio/pkg/keepalive"
 	"istio.io/istio/pkg/mcp/creds"
@@ -44,7 +45,6 @@ const (
 	defaultMeshConfigFolder = "/etc/mesh-config/"
 	defaultAccessListFile   = defaultConfigMapFolder + "accesslist.yaml"
 	defaultMeshConfigFile   = defaultMeshConfigFolder + "mesh"
-	defaultDomainSuffix     = "cluster.local"
 )
 
 // Args contains the startup arguments to instantiate Galley.
@@ -181,7 +181,7 @@ func DefaultArgs() *Args {
 		EnableServer:                    true,
 		CredentialOptions:               creds.DefaultOptions(),
 		ConfigPath:                      "",
-		DomainSuffix:                    defaultDomainSuffix,
+		DomainSuffix:                    constants.DefaultKubernetesDomain,
 		DisableResourceReadyCheck:       false,
 		ExcludedResourceKinds:           kuberesource.DefaultExcludedResourceKinds(),
 		SinkMeta:                        make([]string, 0),

--- a/galley/pkg/server/settings/args_test.go
+++ b/galley/pkg/server/settings/args_test.go
@@ -14,7 +14,11 @@
 
 package settings
 
-import "testing"
+import (
+	"testing"
+
+	"istio.io/istio/pkg/config/constants"
+)
 
 func TestDefaultArgs(t *testing.T) {
 	a := DefaultArgs()
@@ -36,7 +40,7 @@ func TestDefaultArgs(t *testing.T) {
 		t.Fatalf("unexpected MeshConfigFile: %s", a.MeshConfigFile)
 	}
 
-	if a.DomainSuffix != defaultDomainSuffix {
+	if a.DomainSuffix != constants.DefaultKubernetesDomain {
 		t.Fatalf("unexpected DomainSuffix: %s", a.DomainSuffix)
 	}
 

--- a/istioctl/cmd/add-to-mesh.go
+++ b/istioctl/cmd/add-to-mesh.go
@@ -42,6 +42,7 @@ import (
 	"istio.io/istio/istioctl/pkg/util/handlers"
 	"istio.io/istio/pilot/pkg/model"
 	kube_registry "istio.io/istio/pilot/pkg/serviceregistry/kube"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/mesh"
 	istioProtocol "istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/collections"
@@ -492,7 +493,7 @@ func generateServiceEntry(u *unstructured.Unstructured, o *vmServiceOpts) error 
 			Labels:  o.Labels,
 		})
 	}
-	host := fmt.Sprintf("%v.%v.svc.cluster.local", o.Name, o.Namespace)
+	host := fmt.Sprintf("%v.%v.svc.%s", o.Name, o.Namespace, constants.DefaultKubernetesDomain)
 	spec := &v1alpha3.ServiceEntry{
 		Hosts:      []string{host},
 		Ports:      ports,

--- a/istioctl/cmd/describe.go
+++ b/istioctl/cmd/describe.go
@@ -49,6 +49,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	authz_model "istio.io/istio/pilot/pkg/security/authz/model"
 	pilotcontroller "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/collections"
@@ -60,7 +61,7 @@ type myProtoValue struct {
 }
 
 const (
-	k8sSuffix         = ".svc.cluster.local"
+	k8sSuffix         = ".svc." + constants.DefaultKubernetesDomain
 	noVersionMetadata = "no-metadata"
 )
 

--- a/istioctl/pkg/convert/ingress.go
+++ b/istioctl/pkg/convert/ingress.go
@@ -21,6 +21,7 @@ import (
 
 	"istio.io/istio/pilot/pkg/config/kube/ingress"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config/constants"
 )
 
 // IstioIngresses converts K8s extensions/v1beta1 Ingresses with Istio rules to v1alpha3 gateway and virtual service
@@ -30,7 +31,7 @@ func IstioIngresses(ingresses []*v1beta1.Ingress, domainSuffix string) ([]model.
 		return make([]model.Config, 0), nil
 	}
 	if len(domainSuffix) == 0 {
-		domainSuffix = "cluster.local"
+		domainSuffix = constants.DefaultKubernetesDomain
 	}
 
 	ingressByHost := map[string]*model.Config{}

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -359,8 +359,8 @@ func setSpiffeTrustDomain(podNamespace string, domain string) {
 	pilotTrustDomain := trustDomain
 	if len(pilotTrustDomain) == 0 {
 		if registryID == serviceregistry.Kubernetes &&
-			(domain == podNamespace+".svc.cluster.local" || domain == "") {
-			pilotTrustDomain = "cluster.local"
+			(domain == podNamespace+".svc."+constants.DefaultKubernetesDomain || domain == "") {
+			pilotTrustDomain = constants.DefaultKubernetesDomain
 		} else if registryID == serviceregistry.Consul &&
 			(domain == "service.consul" || domain == "") {
 			pilotTrustDomain = ""
@@ -385,7 +385,7 @@ func getSAN(ns string, defaultSA string, overrideIdentity string) []string {
 func getDNSDomain(podNamespace, domain string) string {
 	if len(domain) == 0 {
 		if registryID == serviceregistry.Kubernetes {
-			domain = podNamespace + ".svc.cluster.local"
+			domain = podNamespace + ".svc." + constants.DefaultKubernetesDomain
 		} else if registryID == serviceregistry.Consul {
 			domain = "service.consul"
 		} else {

--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -32,6 +32,7 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pkg/cmd"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/spiffe"
 )
 
@@ -148,7 +149,7 @@ func init() {
 		"Restrict the applications namespace the controller manages; if not set, controller watches all namespaces")
 	discoveryCmd.PersistentFlags().DurationVar(&serverArgs.Config.ControllerOptions.ResyncPeriod, "resync", 60*time.Second,
 		"Controller resync interval")
-	discoveryCmd.PersistentFlags().StringVar(&serverArgs.Config.ControllerOptions.DomainSuffix, "domain", "cluster.local",
+	discoveryCmd.PersistentFlags().StringVar(&serverArgs.Config.ControllerOptions.DomainSuffix, "domain", constants.DefaultKubernetesDomain,
 		"DNS domain suffix")
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.Config.ControllerOptions.ClusterID, "clusterID", features.ClusterName,
 		"The ID of the cluster that this Istiod instance resides")

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -167,6 +167,7 @@ func NewServer(args *PilotArgs) (*Server, error) {
 	e := &model.Environment{
 		ServiceDiscovery: aggregate.NewController(),
 		PushContext:      model.NewPushContext(),
+		DomainSuffix:     args.Config.ControllerOptions.DomainSuffix,
 	}
 
 	s := &Server{

--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -171,7 +171,7 @@ func createRoute(action *k8s.HTTPRouteAction, ns string) []*istio.HTTPRouteDesti
 		Destination: &istio.Destination{
 			// TODO cluster.local hardcode
 			// TODO is this the right format?
-			Host: fmt.Sprintf("%s.%s.svc.cluster.local", action.ForwardTo.Name, ns),
+			Host: action.ForwardTo.Name + "." + ns + ".svc." + constants.DefaultKubernetesDomain,
 		},
 	}}
 

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -34,12 +34,9 @@ import (
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/pkg/monitoring"
 
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/mesh"
-)
-
-const (
-	defaultDomainSuffix = "cluster.local"
 )
 
 var _ mesh.Holder = &Environment{}
@@ -79,7 +76,7 @@ func (e *Environment) GetDomainSuffix() string {
 	if len(e.DomainSuffix) > 0 {
 		return e.DomainSuffix
 	}
-	return defaultDomainSuffix
+	return constants.DefaultKubernetesDomain
 }
 
 func (e *Environment) Mesh() *meshconfig.MeshConfig {

--- a/pilot/pkg/security/trustdomain/bundle.go
+++ b/pilot/pkg/security/trustdomain/bundle.go
@@ -19,6 +19,8 @@ import (
 	"strings"
 
 	istiolog "istio.io/pkg/log"
+
+	"istio.io/istio/pkg/config/constants"
 )
 
 var (
@@ -68,7 +70,7 @@ func (t Bundle) ReplaceTrustDomainAliases(principals []string) []string {
 		// Only generate configuration if the extracted trust domain from the policy is part of the trust domain list,
 		// or if the extracted/existing trust domain is "cluster.local", which is a pointer to the local trust domain
 		// and its aliases.
-		if stringMatch(trustDomainFromPrincipal, t.TrustDomains) || trustDomainFromPrincipal == "cluster.local" {
+		if stringMatch(trustDomainFromPrincipal, t.TrustDomains) || trustDomainFromPrincipal == constants.DefaultKubernetesDomain {
 			// Generate configuration for trust domain and trust domain aliases.
 			principalsIncludingAliases = append(principalsIncludingAliases, t.replaceTrustDomains(principal, trustDomainFromPrincipal)...)
 		} else {

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -59,6 +59,9 @@ const (
 	// IstioIngressNamespace is the namespace where Istio ingress controller is deployed
 	IstioIngressNamespace = "istio-system"
 
+	// DefaultKubernetesDomain the default service domain suffix for Kubernetes, if not overridden in config.
+	DefaultKubernetesDomain = "cluster.local"
+
 	// IstioLabel indicates that a workload is part of a named Istio system component.
 	IstioLabel = "istio"
 

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -28,6 +28,8 @@ import (
 
 	"istio.io/pkg/env"
 	"istio.io/pkg/log"
+
+	"istio.io/istio/pkg/config/constants"
 )
 
 // Based on istio-ecosystem/istio-coredns-plugin
@@ -167,7 +169,7 @@ func InitDNSAgent(discoveryAddress string, domain string, cert []byte, suffixes 
 	}
 
 	dnsDomainL := strings.Split(domain, ".")
-	clusterLocal := "cluster.local"
+	clusterLocal := constants.DefaultKubernetesDomain
 	if len(dnsDomainL) > 3 {
 		clusterLocal = strings.Join(dnsDomainL[2:], ".")
 	}

--- a/pkg/spiffe/spiffe.go
+++ b/pkg/spiffe/spiffe.go
@@ -20,6 +20,8 @@ import (
 	"sync"
 
 	"istio.io/pkg/log"
+
+	"istio.io/istio/pkg/config/constants"
 )
 
 const (
@@ -28,7 +30,7 @@ const (
 	URIPrefix = Scheme + "://"
 
 	// The default SPIFFE URL value for trust domain
-	defaultTrustDomain = "cluster.local"
+	defaultTrustDomain = constants.DefaultKubernetesDomain
 )
 
 var (

--- a/pkg/test/framework/components/echo/kube/instance.go
+++ b/pkg/test/framework/components/echo/kube/instance.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test"
 	appEcho "istio.io/istio/pkg/test/echo/client"
@@ -37,7 +38,7 @@ import (
 const (
 	tcpHealthPort     = 3333
 	httpReadinessPort = 8080
-	defaultDomain     = "cluster.local"
+	defaultDomain     = constants.DefaultKubernetesDomain
 )
 
 var (

--- a/pkg/test/framework/components/environment/native/native.go
+++ b/pkg/test/framework/components/environment/native/native.go
@@ -21,6 +21,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/hashicorp/go-multierror"
 
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/test/docker"
 	"istio.io/istio/pkg/test/framework/resource"
@@ -29,7 +30,7 @@ import (
 
 const (
 	systemNamespace = "istio-system"
-	domain          = "cluster.local"
+	domain          = constants.DefaultKubernetesDomain
 
 	networkLabelKey   = "app"
 	networkLabelValue = "istio-test"


### PR DESCRIPTION
This was broken by https://github.com/istio/istio/pull/23173

Restored the setting of the domain and added a test.

Also declaring a common constant for the default domain.