### PR TITLE
fix test istiod cert reload flake

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -850,30 +850,32 @@ func (s *Server) initCertificateWatches(tlsOptions TLSOptions) error {
 				case <-keyCertTimerC:
 					keyCertTimerC = nil
 					// Reload the certificates from the paths.
-					if cert, err := s.getCertKeyPair(tlsOptions); err == nil {
-						s.certMu.Lock()
-						s.istiodCert = &cert
-						s.certMu.Unlock()
-
-						var cnum int
-						log.Info("Istiod certificates are reloaded")
-						for _, c := range cert.Certificate {
-							if x509Cert, err := x509.ParseCertificates(c); err != nil {
-								log.Infof("x509 cert [%v] - ParseCertificates() error: %v\n", cnum, err)
-								cnum++
-							} else {
-								for _, c := range x509Cert {
-									log.Infof("x509 cert [%v] - Issuer: %q, Subject: %q, SN: %x, NotBefore: %q, NotAfter: %q\n",
-										cnum, c.Issuer, c.Subject, c.SerialNumber,
-										c.NotBefore.Format(time.RFC3339), c.NotAfter.Format(time.RFC3339))
-									cnum++
-								}
-							}
-						}
-					} else {
+					cert, err := s.getCertKeyPair(tlsOptions)
+					if err != nil {
 						log.Errorf("error in reloading certs, %v", err)
 						// TODO: Add metrics?
+						break
 					}
+					s.certMu.Lock()
+					s.istiodCert = &cert
+					s.certMu.Unlock()
+
+					var cnum int
+					log.Info("Istiod certificates are reloaded")
+					for _, c := range cert.Certificate {
+						if x509Cert, err := x509.ParseCertificates(c); err != nil {
+							log.Infof("x509 cert [%v] - ParseCertificates() error: %v\n", cnum, err)
+							cnum++
+						} else {
+							for _, c := range x509Cert {
+								log.Infof("x509 cert [%v] - Issuer: %q, Subject: %q, SN: %x, NotBefore: %q, NotAfter: %q\n",
+									cnum, c.Issuer, c.Subject, c.SerialNumber,
+									c.NotBefore.Format(time.RFC3339), c.NotAfter.Format(time.RFC3339))
+								cnum++
+							}
+						}
+					}
+
 				case <-s.fileWatcher.Events(certFile):
 					if keyCertTimerC == nil {
 						keyCertTimerC = time.After(watchDebounceDelay)

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -81,7 +81,7 @@ var (
 	}
 )
 
-const (
+var (
 	// debounce file watcher events to minimize noise in logs
 	watchDebounceDelay = 100 * time.Millisecond
 )

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -81,7 +81,7 @@ var (
 	}
 )
 
-var (
+const (
 	// debounce file watcher events to minimize noise in logs
 	watchDebounceDelay = 100 * time.Millisecond
 )

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"istio.io/istio/pkg/testcerts"
 	"istio.io/pkg/filewatcher"
@@ -58,6 +59,9 @@ func TestReloadIstiodCert(t *testing.T) {
 		CertFile: certFile,
 		KeyFile:  keyFile,
 	}
+
+	// Set increased value in tests to allow copy of both files to be finished.
+	watchDebounceDelay = 200 * time.Millisecond
 
 	// setup cert watches.
 	err = s.initCertificateWatches(tlsOptions)

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"istio.io/istio/pkg/testcerts"
 	"istio.io/pkg/filewatcher"
@@ -59,9 +58,6 @@ func TestReloadIstiodCert(t *testing.T) {
 		CertFile: certFile,
 		KeyFile:  keyFile,
 	}
-
-	// Set increased value in tests to allow copy of both files to be finished.
-	watchDebounceDelay = 200 * time.Millisecond
 
 	// setup cert watches.
 	err = s.initCertificateWatches(tlsOptions)


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/23638. The debounce interval in CI seems to be not sufficient - it is failing with `key cert mismatch`. Increasing it in tests for now - If the flakyness still persists , I will move FakeWatcher which needs more changes.