### PR TITLE
make istio-system cluster local

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -167,6 +167,7 @@ func NewServer(args *PilotArgs) (*Server, error) {
 	e := &model.Environment{
 		ServiceDiscovery: aggregate.NewController(),
 		PushContext:      model.NewPushContext(),
+		SystemNamespace:  args.Namespace,
 	}
 
 	s := &Server{

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -73,6 +73,9 @@ type Environment struct {
 
 	// DomainSuffix provides a default domain for the Istio server.
 	DomainSuffix string
+
+	// SystemNamespace is the namespace istiod is currently running in
+	SystemNamespace string
 }
 
 func (e *Environment) GetDomainSuffix() string {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1576,8 +1576,9 @@ func (ps *PushContext) initMeshNetworks() {
 func (ps *PushContext) initClusterLocalHosts(e *Environment) {
 	// Create the default list of cluster-local hosts.
 	domainSuffix := e.GetDomainSuffix()
-	defaultClusterLocalHosts := make([]host.Name, 0, len(defaultClusterLocalNamespaces))
-	for _, n := range defaultClusterLocalNamespaces {
+	clusterLocalNamespaces := append(defaultClusterLocalNamespaces, e.SystemNamespace)
+	defaultClusterLocalHosts := make([]host.Name, 0, len(clusterLocalNamespaces))
+	for _, n := range clusterLocalNamespaces {
 		defaultClusterLocalHosts = append(defaultClusterLocalHosts, host.Name("*."+n+".svc."+domainSuffix))
 	}
 

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -462,6 +462,12 @@ func TestIsClusterLocal(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "istiod local by default",
+			m:        mesh.DefaultMeshConfig(),
+			host:     "istiod.istio-system.svc.cluster.local",
+			expected: true,
+		},
+		{
 			name:     "not local by default",
 			m:        mesh.DefaultMeshConfig(),
 			host:     "not.cluster.local",

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -549,7 +549,7 @@ func TestIsClusterLocal(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
 
-			env := &Environment{Watcher: mesh.NewFixedWatcher(&c.m)}
+			env := &Environment{Watcher: mesh.NewFixedWatcher(&c.m), SystemNamespace: "istio-system"}
 			push := &PushContext{
 				Mesh: env.Mesh(),
 			}


### PR DESCRIPTION
As an alternative to https://github.com/istio/istio/pull/23625 for fixing https://github.com/istio/istio/issues/23591, we could make the entire system namespace cluster-local. 

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
