### PR TITLE
check for Values.global.istiod.enabled instead of pilot

### DIFF
--- a/manifests/charts/base/templates/endpoints.yaml
+++ b/manifests/charts/base/templates/endpoints.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.remotePilotAddress }}
-  {{- if .Values.global.pilot.enabled }}
+  {{- if .Values.global.istiod.enabled }}
 apiVersion: v1
 kind: Endpoints
 metadata:

--- a/manifests/charts/base/templates/services.yaml
+++ b/manifests/charts/base/templates/services.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.remotePilotAddress }}
-  {{- if .Values.global.pilot.enabled }}
+  {{- if .Values.global.istiod.enabled }}
 # when istiod is enabled in remote cluster, we can't use istiod service name  
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Changing the check for istiod.enabled to pilot.enabled breaks the GlobalConfig API.  