### PR TITLE
check for Values.pilot instead of Values.global.pilot

### DIFF
--- a/manifests/charts/base/templates/endpoints.yaml
+++ b/manifests/charts/base/templates/endpoints.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.remotePilotAddress }}
-  {{- if .Values.global.pilot.enabled }}
+  {{- if .Values.pilot.enabled }}
 apiVersion: v1
 kind: Endpoints
 metadata:

--- a/manifests/charts/base/templates/services.yaml
+++ b/manifests/charts/base/templates/services.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.remotePilotAddress }}
-  {{- if .Values.global.pilot.enabled }}
+  {{- if .Values.pilot.enabled }}
 # when istiod is enabled in remote cluster, we can't use istiod service name  
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Touchup for https://github.com/istio/istio/pull/23624, blocks multicluster testing. `pilot` lives on `Values` not `GlobalConfig`