### PR TITLE
Override rather than merge on manifest update

### DIFF
--- a/operator/cmd/mesh/manifest-apply.go
+++ b/operator/cmd/mesh/manifest-apply.go
@@ -218,7 +218,7 @@ func ApplyManifests(setOverlay []string, inFilenames []string, force bool, dryRu
 	if err != nil {
 		return err
 	}
-	if err := reconciler.ApplyObject("", obj.UnstructuredObject()); err != nil {
+	if err := reconciler.ApplyObject(obj.UnstructuredObject()); err != nil {
 		return err
 	}
 

--- a/operator/pkg/helmreconciler/apply_test.go
+++ b/operator/pkg/helmreconciler/apply_test.go
@@ -1,0 +1,91 @@
+// Copyright 2020 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helmreconciler
+
+import (
+	"context"
+	"io/ioutil"
+	"reflect"
+	"testing"
+
+	"istio.io/istio/operator/pkg/object"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestHelmReconciler_ApplyObject(t *testing.T) {
+	tests := []struct {
+		name         string
+		currentState string
+		input        string
+		want         string
+		wantErr      bool
+	}{
+		{
+			name:  "creates if not present",
+			input: "testdata/configmap.yaml",
+			want:  "testdata/configmap.yaml",
+		},
+		{
+			name:         "updates if present",
+			currentState: "testdata/configmap.yaml",
+			input:        "testdata/configmap-changed.yaml",
+			want:         "testdata/configmap-changed.yaml",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cl := fake.NewFakeClient(loadData(t, tt.input).UnstructuredObject())
+			obj := loadData(t, tt.input)
+
+			h := &HelmReconciler{client: cl, opts: &Options{}}
+			if err := h.ApplyObject(obj.UnstructuredObject()); (err != nil) != tt.wantErr {
+				t.Errorf("HelmReconciler.ApplyObject() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			manifest := loadData(t, tt.want)
+			key, _ := client.ObjectKeyFromObject(manifest.UnstructuredObject())
+			got, want := obj.UnstructuredObject(), manifest.UnstructuredObject()
+
+			if err := cl.Get(context.Background(), key, got); err != nil {
+				t.Errorf("error validating manifest %v: %v", manifest.Hash(), err)
+			}
+			// remove resource version and annotations (last applied config) when we compare as we don't care
+			unstructured.RemoveNestedField(got.Object, "metadata", "resourceVersion")
+			unstructured.RemoveNestedField(got.Object, "metadata", "annotations")
+
+			if !reflect.DeepEqual(want, got) {
+				t.Errorf("wanted:\n%v\ngot:\n%v",
+					object.NewK8sObject(want, nil, nil).YAMLDebugString(),
+					object.NewK8sObject(got, nil, nil).YAMLDebugString(),
+				)
+			}
+
+		})
+	}
+}
+
+func loadData(t *testing.T, file string) *object.K8sObject {
+	contents, err := ioutil.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	obj, err := object.ParseYAMLToK8sObject(contents)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return obj
+}

--- a/operator/pkg/helmreconciler/apply_test.go
+++ b/operator/pkg/helmreconciler/apply_test.go
@@ -20,10 +20,11 @@ import (
 	"reflect"
 	"testing"
 
-	"istio.io/istio/operator/pkg/object"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"istio.io/istio/operator/pkg/object"
 )
 
 func TestHelmReconciler_ApplyObject(t *testing.T) {

--- a/operator/pkg/helmreconciler/common.go
+++ b/operator/pkg/helmreconciler/common.go
@@ -18,10 +18,6 @@ import (
 	"io"
 	"strings"
 
-	jsonpatch "github.com/evanphx/json-patch"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	"istio.io/istio/operator/pkg/name"
 	"istio.io/pkg/log"
 )
@@ -110,21 +106,4 @@ func buildInstallTreeString(componentName name.ComponentName, prefix string, sb 
 	for k := range InstallTree[componentName].(ComponentTree) {
 		buildInstallTreeString(k, prefix+"  ", sb)
 	}
-}
-
-// applyOverlay applies an overlay using JSON patch strategy over the current Object in place.
-func applyOverlay(current, overlay runtime.Object) error {
-	cj, err := runtime.Encode(unstructured.UnstructuredJSONScheme, current)
-	if err != nil {
-		return err
-	}
-	uj, err := runtime.Encode(unstructured.UnstructuredJSONScheme, overlay)
-	if err != nil {
-		return err
-	}
-	merged, err := jsonpatch.MergePatch(cj, uj)
-	if err != nil {
-		return err
-	}
-	return runtime.DecodeInto(unstructured.UnstructuredJSONScheme, merged, current)
 }

--- a/operator/pkg/helmreconciler/testdata/configmap-changed.yaml
+++ b/operator/pkg/helmreconciler/testdata/configmap-changed.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config
+  namespace: istio-system
+data:
+  # Delete a field, update a field and create a new field
+  field: two
+  new: new

--- a/operator/pkg/helmreconciler/testdata/configmap.yaml
+++ b/operator/pkg/helmreconciler/testdata/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config
+  namespace: istio-system
+data:
+  field: one
+  delete: me


### PR DESCRIPTION
As discussed in Slack with @ostromart. The current behaviour is:

Given:
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: old
data:
  one: one
  two: two
```

I make changes that result in this config map being rendered:

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: new
data:
  one: three
```

What is actually applied:

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: whats-actually-applied
data:
  one: three
  two: two
```

The behaviour for update shouldn't be a merge. Instead, we should create exactly what we render. Merge will result in fields never being deleted.

Signed-off-by: Liam White <liam@tetrate.io>