### PR TITLE
Apply --set flags using tpath instead of building tree

### DIFF
--- a/operator/cmd/mesh/manifest-apply.go
+++ b/operator/cmd/mesh/manifest-apply.go
@@ -165,15 +165,11 @@ func runApplyCmd(cmd *cobra.Command, rootArgs *rootArgs, maArgs *manifestApplyAr
 func ApplyManifests(setOverlay []string, inFilenames []string, force bool, dryRun bool,
 	kubeConfigPath string, context string, wait bool, waitTimeout time.Duration, l clog.Logger) error {
 
-	ysf, err := yamlFromSetFlags(setOverlay, force, l)
-	if err != nil {
-		return err
-	}
 	restConfig, clientset, client, err := K8sConfig(kubeConfigPath, context)
 	if err != nil {
 		return err
 	}
-	_, iops, err := GenerateConfig(inFilenames, ysf, force, restConfig, l)
+	_, iops, err := GenerateConfig(inFilenames, setOverlay, force, restConfig, l)
 	if err != nil {
 		return err
 	}

--- a/operator/cmd/mesh/manifest-common.go
+++ b/operator/cmd/mesh/manifest-common.go
@@ -24,25 +24,7 @@ import (
 	"istio.io/istio/operator/pkg/helm"
 	"istio.io/istio/operator/pkg/tpath"
 	"istio.io/istio/operator/pkg/util"
-	"istio.io/istio/operator/pkg/util/clog"
-	"istio.io/istio/operator/pkg/validate"
 )
-
-// yamlFromSetFlags takes a slice of --set flag key-value pairs and returns a YAML tree representation.
-// If force is set, validation errors cause warning messages to be written to logger rather than causing error.
-func yamlFromSetFlags(setOverlay []string, force bool, l clog.Logger) (string, error) {
-	out, err := makeTreeFromSetList(setOverlay)
-	if err != nil {
-		return "", fmt.Errorf("failed to generate tree from the set overlay, error: %v", err)
-	}
-	if err := validate.ValidIOPYAML(out); err != nil {
-		if !force {
-			return "", fmt.Errorf("validation errors (use --force to override): \n%s", err)
-		}
-		l.LogAndErrorf("Validation errors (continuing because of --force):\n%s", err)
-	}
-	return out, nil
-}
 
 // makeTreeFromSetList creates a YAML tree from a string slice containing key-value pairs in the format key=value.
 func makeTreeFromSetList(setOverlay []string) (string, error) {

--- a/operator/cmd/mesh/manifest-generate.go
+++ b/operator/cmd/mesh/manifest-generate.go
@@ -26,14 +26,13 @@ import (
 	"k8s.io/client-go/rest"
 
 	"istio.io/api/operator/v1alpha1"
-	"istio.io/pkg/log"
-
 	"istio.io/istio/operator/pkg/controlplane"
 	"istio.io/istio/operator/pkg/helm"
 	"istio.io/istio/operator/pkg/helmreconciler"
 	"istio.io/istio/operator/pkg/name"
 	"istio.io/istio/operator/pkg/translate"
 	"istio.io/istio/operator/pkg/util/clog"
+	"istio.io/pkg/log"
 )
 
 type manifestGenerateArgs struct {
@@ -97,12 +96,7 @@ func manifestGenerate(args *rootArgs, mgArgs *manifestGenerateArgs, logopts *log
 		return fmt.Errorf("could not configure logs: %s", err)
 	}
 
-	ysf, err := yamlFromSetFlags(applyFlagAliases(mgArgs.set, mgArgs.charts, mgArgs.revision), mgArgs.force, l)
-	if err != nil {
-		return err
-	}
-
-	manifests, _, err := GenManifests(mgArgs.inFilename, ysf, mgArgs.force, nil, l)
+	manifests, _, err := GenManifests(mgArgs.inFilename, applyFlagAliases(mgArgs.set, mgArgs.charts, mgArgs.revision), mgArgs.force, nil, l)
 	if err != nil {
 		return err
 	}
@@ -127,9 +121,9 @@ func manifestGenerate(args *rootArgs, mgArgs *manifestGenerateArgs, logopts *log
 // representation of path-values passed through the --set flag.
 // If force is set, validation errors will not cause processing to abort but will result in warnings going to the
 // supplied logger.
-func GenManifests(inFilename []string, setOverlayYAML string, force bool,
+func GenManifests(inFilename []string, setFlags []string, force bool,
 	kubeConfig *rest.Config, l clog.Logger) (name.ManifestMap, *v1alpha1.IstioOperatorSpec, error) {
-	mergedYAML, _, err := GenerateConfig(inFilename, setOverlayYAML, force, kubeConfig, l)
+	mergedYAML, _, err := GenerateConfig(inFilename, setFlags, force, kubeConfig, l)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -223,7 +223,7 @@ func TestManifestGenerateFlags(t *testing.T) {
 		{
 			desc:       "gateways",
 			diffIgnore: "ConfigMap:*:istio",
-			flags:      "-s components.ingressGateways.[0].k8s.resources.requests.cpu=999m",
+			flags:      "-s components.ingressGateways.[0].k8s.resources.requests.cpu=999m -s components.ingressGateways.[name:user-ingressgateway].k8s.resources.requests.cpu=555m",
 		},
 		{
 			desc:       "gateways_override_default",

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -223,7 +223,8 @@ func TestManifestGenerateFlags(t *testing.T) {
 		{
 			desc:       "gateways",
 			diffIgnore: "ConfigMap:*:istio",
-			flags:      "-s components.ingressGateways.[0].k8s.resources.requests.cpu=999m -s components.ingressGateways.[name:user-ingressgateway].k8s.resources.requests.cpu=555m",
+			flags: "-s components.ingressGateways.[0].k8s.resources.requests.cpu=999m " +
+				"-s components.ingressGateways.[name:user-ingressgateway].k8s.resources.requests.cpu=555m",
 		},
 		{
 			desc:       "gateways_override_default",

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -223,6 +223,7 @@ func TestManifestGenerateFlags(t *testing.T) {
 		{
 			desc:       "gateways",
 			diffIgnore: "ConfigMap:*:istio",
+			flags:      "-s components.ingressGateways.[0].k8s.resources.requests.cpu=999m",
 		},
 		{
 			desc:       "gateways_override_default",
@@ -582,11 +583,7 @@ func TestLDFlags(t *testing.T) {
 	version.DockerInfo.Hub = "testHub"
 	version.DockerInfo.Tag = "testTag"
 	l := clog.NewConsoleLogger(os.Stdout, os.Stderr, installerScope)
-	ysf, err := yamlFromSetFlags([]string{"installPackagePath=" + liveInstallPackageDir}, false, l)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, iops, err := GenerateConfig(nil, ysf, true, nil, l)
+	_, iops, err := GenerateConfig(nil, []string{"installPackagePath=" + liveInstallPackageDir}, true, nil, l)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/operator/cmd/mesh/profile-common.go
+++ b/operator/cmd/mesh/profile-common.go
@@ -20,7 +20,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	yaml2 "github.com/ghodss/yaml"
+	"gopkg.in/yaml.v2"
 	"k8s.io/client-go/rest"
 
 	"istio.io/api/operator/v1alpha1"
@@ -125,7 +125,6 @@ func parseYAMLFiles(inFilenames []string, force bool, l clog.Logger) (overlayYAM
 // files and the --set flag. If successful, it returns an IstioOperatorSpec string and struct.
 func genIOPSFromProfile(profileOrPath, fileOverlayYAML string, setFlags []string, skipValidation bool,
 	kubeConfig *rest.Config, l clog.Logger) (string, *v1alpha1.IstioOperatorSpec, error) {
-	//userOverlayYAML, err := util.OverlayYAML(fileOverlayYAML, setOverlayYAML)
 
 	installPackagePath, err := getInstallPackagePath(fileOverlayYAML)
 	if err != nil {
@@ -330,7 +329,7 @@ func validateSetFlags(setFlags []string) error {
 // overlaySetFlagValues overlays each of the setFlags on top of the passed in IOP YAML string.
 func overlaySetFlagValues(iopYAML string, setFlags []string) (string, error) {
 	iop := make(map[string]interface{})
-	if err := yaml2.Unmarshal([]byte(iopYAML), &iop); err != nil {
+	if err := yaml.Unmarshal([]byte(iopYAML), &iop); err != nil {
 		return "", err
 	}
 	// Unmarshal returns nil for empty manifests but we need something to insert into.
@@ -351,7 +350,7 @@ func overlaySetFlagValues(iopYAML string, setFlags []string) (string, error) {
 		}
 	}
 
-	out, err := yaml2.Marshal(iop)
+	out, err := yaml.Marshal(iop)
 	if err != nil {
 		return "", err
 	}

--- a/operator/cmd/mesh/profile-common.go
+++ b/operator/cmd/mesh/profile-common.go
@@ -20,11 +20,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	yaml2 "github.com/ghodss/yaml"
 	"k8s.io/client-go/rest"
 
 	"istio.io/api/operator/v1alpha1"
-	pkgversion "istio.io/pkg/version"
-
 	iopv1alpha1 "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/apis/istio/v1alpha1/validation"
 	"istio.io/istio/operator/pkg/helm"
@@ -34,6 +33,7 @@ import (
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/operator/pkg/util/clog"
 	"istio.io/istio/operator/pkg/validate"
+	pkgversion "istio.io/pkg/version"
 )
 
 // GenerateConfig creates an IstioOperatorSpec from the following sources, overlaid sequentially:
@@ -47,15 +47,18 @@ import (
 // Otherwise it will be the compiled in profile YAMLs.
 // In step 3, the remaining fields in the same user overlay are applied on the resulting profile base.
 // The force flag causes validation errors not to abort but only emit log/console warnings.
-func GenerateConfig(inFilenames []string, setOverlayYAML string, force bool, kubeConfig *rest.Config,
+func GenerateConfig(inFilenames []string, setFlags []string, force bool, kubeConfig *rest.Config,
 	l clog.Logger) (string, *v1alpha1.IstioOperatorSpec, error) {
+	if err := validateSetFlags(setFlags); err != nil {
+		return "", nil, err
+	}
 
-	fy, profile, err := readYamlProfle(inFilenames, setOverlayYAML, force, l)
+	fy, profile, err := readYamlProfle(inFilenames, setFlags, force, l)
 	if err != nil {
 		return "", nil, err
 	}
 
-	iopsString, iops, err := genIOPSFromProfile(profile, fy, setOverlayYAML, force, kubeConfig, l)
+	iopsString, iops, err := genIOPSFromProfile(profile, fy, setFlags, force, kubeConfig, l)
 	if err != nil {
 		return "", nil, err
 	}
@@ -70,8 +73,7 @@ func GenerateConfig(inFilenames []string, setOverlayYAML string, force bool, kub
 	return iopsString, iops, nil
 }
 
-func readYamlProfle(inFilenames []string, setOverlayYAML string, force bool, l clog.Logger) (string, string, error) {
-
+func readYamlProfle(inFilenames []string, setFlags []string, force bool, l clog.Logger) (string, string, error) {
 	profile := name.DefaultProfileName
 	// Get the overlay YAML from the list of files passed in. Also get the profile from the overlay files.
 	fy, fp, err := parseYAMLFiles(inFilenames, force, l)
@@ -82,7 +84,7 @@ func readYamlProfle(inFilenames []string, setOverlayYAML string, force bool, l c
 		profile = fp
 	}
 	// The profile coming from --set flag has the highest precedence.
-	psf := profileFromSetOverlay(setOverlayYAML)
+	psf := getValueForSetFlag(setFlags, "profile")
 	if psf != "" {
 		profile = psf
 	}
@@ -119,31 +121,19 @@ func parseYAMLFiles(inFilenames []string, force bool, l clog.Logger) (overlayYAM
 	return y, profile, nil
 }
 
-// profileFromSetOverlay takes a YAML string and if it contains a key called "profile" in the root, it returns the key
-// value.
-func profileFromSetOverlay(yml string) string {
-	s, err := tpath.GetConfigSubtree(yml, "spec.profile")
-	if err != nil {
-		return ""
-	}
-	s = strings.TrimSpace(s)
-	if s == "{}" {
-		return ""
-	}
-	return s
-}
-
 // genIOPSFromProfile generates an IstioOperatorSpec from the given profile name or path, and overlay YAMLs from user
 // files and the --set flag. If successful, it returns an IstioOperatorSpec string and struct.
-func genIOPSFromProfile(profileOrPath, fileOverlayYAML, setOverlayYAML string, skipValidation bool,
+func genIOPSFromProfile(profileOrPath, fileOverlayYAML string, setFlags []string, skipValidation bool,
 	kubeConfig *rest.Config, l clog.Logger) (string, *v1alpha1.IstioOperatorSpec, error) {
-	userOverlayYAML, err := util.OverlayYAML(fileOverlayYAML, setOverlayYAML)
-	if err != nil {
-		return "", nil, fmt.Errorf("could not merge file and --set YAMLs: %s", err)
-	}
-	installPackagePath, err := getInstallPackagePath(userOverlayYAML)
+	//userOverlayYAML, err := util.OverlayYAML(fileOverlayYAML, setOverlayYAML)
+
+	installPackagePath, err := getInstallPackagePath(fileOverlayYAML)
 	if err != nil {
 		return "", nil, err
+	}
+	if sfp := getValueForSetFlag(setFlags, "installPackagePath"); sfp != "" {
+		// set flag installPackagePath has the highest precedence, if set.
+		installPackagePath = sfp
 	}
 
 	// If installPackagePath is a URL, fetch and extract it and continue with the local filesystem path instead.
@@ -177,14 +167,21 @@ func genIOPSFromProfile(profileOrPath, fileOverlayYAML, setOverlayYAML string, s
 			return "", nil, err
 		}
 	}
+
+	// Combine file and --set overlays and translate any K8s settings in values to IOP format. Users should not set
+	// these but we have to support this path until it's deprecated.
+	overlayYAML, err := overlaySetFlagValues(fileOverlayYAML, setFlags)
+	if err != nil {
+		return "", nil, err
+	}
 	t := translate.NewReverseTranslator()
-	userOverlayYAML, err = t.TranslateK8SfromValueToIOP(userOverlayYAML)
+	overlayYAML, err = t.TranslateK8SfromValueToIOP(overlayYAML)
 	if err != nil {
 		return "", nil, fmt.Errorf("could not overlay k8s settings from values to IOP: %s", err)
 	}
 
-	// Merge user file and --set overlays.
-	outYAML, err = util.OverlayYAML(outYAML, userOverlayYAML)
+	// Merge user file and --set flags.
+	outYAML, err = util.OverlayYAML(outYAML, overlayYAML)
 	if err != nil {
 		return "", nil, fmt.Errorf("could not overlay user config over base: %s", err)
 	}
@@ -193,7 +190,7 @@ func genIOPSFromProfile(profileOrPath, fileOverlayYAML, setOverlayYAML string, s
 		return "", nil, err
 	}
 	// If enablement came from user values overlay (file or --set), translate into addonComponents paths and overlay that.
-	outYAML, err = translate.OverlayValuesEnablement(outYAML, fileOverlayYAML, setOverlayYAML)
+	outYAML, err = translate.OverlayValuesEnablement(outYAML, overlayYAML, overlayYAML)
 	if err != nil {
 		return "", nil, err
 	}
@@ -317,4 +314,71 @@ func getInstallPackagePath(iopYAML string) (string, error) {
 		return "", nil
 	}
 	return iop.Spec.InstallPackagePath, nil
+}
+
+// validateSetFlags validates that setFlags all have path=value format.
+func validateSetFlags(setFlags []string) error {
+	for _, sf := range setFlags {
+		pv := strings.Split(sf, "=")
+		if len(pv) != 2 {
+			return fmt.Errorf("set flag %s has incorrect format, must be path=value", sf)
+		}
+	}
+	return nil
+}
+
+// overlaySetFlagValues overlays each of the setFlags on top of the passed in IOP YAML string.
+func overlaySetFlagValues(iopYAML string, setFlags []string) (string, error) {
+	iop := make(map[string]interface{})
+	if err := yaml2.Unmarshal([]byte(iopYAML), &iop); err != nil {
+		return "", err
+	}
+	// Unmarshal returns nil for empty manifests but we need something to insert into.
+	if iop == nil {
+		iop = make(map[string]interface{})
+	}
+
+	for _, sf := range setFlags {
+		p, v := getPV(sf)
+		p = strings.TrimPrefix(p, "spec.")
+		inc, _, err := tpath.GetPathContext(iop, util.PathFromString("spec."+p), true)
+		if err != nil {
+			return "", err
+		}
+		// input value type is always string, transform it to correct type before setting.
+		if err := tpath.WritePathContext(inc, util.ParseValue(v), false); err != nil {
+			return "", err
+		}
+	}
+
+	out, err := yaml2.Marshal(iop)
+	if err != nil {
+		return "", err
+	}
+
+	return string(out), nil
+}
+
+// getValueForSetFlag parses the passed set flags which have format key=value and if any set the given path,
+// returns the corresponding value, otherwise returns the empty string. setFlags must have valid format.
+func getValueForSetFlag(setFlags []string, path string) string {
+	ret := ""
+	for _, sf := range setFlags {
+		p, v := getPV(sf)
+		if p == path {
+			ret = v
+		}
+		// if set multiple times, return last set value
+	}
+	return ret
+}
+
+// getPV returns the path and value components for the given set flag string, which must be in path=value format.
+func getPV(setFlag string) (path string, value string) {
+	pv := strings.Split(setFlag, "=")
+	if len(pv) != 2 {
+		return setFlag, ""
+	}
+	path, value = strings.TrimSpace(pv[0]), strings.TrimSpace(pv[1])
+	return
 }

--- a/operator/cmd/mesh/profile-dump.go
+++ b/operator/cmd/mesh/profile-dump.go
@@ -121,18 +121,12 @@ func profileDump(args []string, rootArgs *rootArgs, pdArgs *profileDumpArgs, l c
 		return fmt.Errorf("unknown output format: %v", pdArgs.outputFormat)
 	}
 
-	setFlagYAML, err := yamlFromSetFlags(applyFlagAliases(make([]string, 0), pdArgs.charts, ""), false, l)
-	if err != nil {
-		return err
-	}
+	setFlags := applyFlagAliases(make([]string, 0), pdArgs.charts, "")
 	if len(args) == 1 {
-		var err error
-		if setFlagYAML, err = tpath.AddSpecRoot("profile: " + args[0]); err != nil {
-			return err
-		}
+		setFlags = append(setFlags, "profile="+args[0])
 	}
 
-	y, _, err := GenerateConfig(pdArgs.inFilenames, setFlagYAML, true, nil, l)
+	y, _, err := GenerateConfig(pdArgs.inFilenames, setFlags, true, nil, l)
 	if err != nil {
 		return err
 	}

--- a/operator/cmd/mesh/shared.go
+++ b/operator/cmd/mesh/shared.go
@@ -230,7 +230,7 @@ func getCRAndNamespaceFromFile(filePath string, l clog.Logger) (customResource s
 		return "", "", nil
 	}
 
-	_, mergedIOPS, err := GenerateConfig([]string{filePath}, "", false, nil, l)
+	_, mergedIOPS, err := GenerateConfig([]string{filePath}, nil, false, nil, l)
 	if err != nil {
 		return "", "", err
 	}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/gateways.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/gateways.golden.yaml
@@ -554,7 +554,7 @@ spec:
             cpu: 2000m
             memory: 1024Mi
           requests:
-            cpu: 222m
+            cpu: 555m
             memory: 128Mi
         volumeMounts:
         - mountPath: /etc/istio/config

--- a/operator/cmd/mesh/testdata/manifest-generate/output/gateways.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/gateways.golden.yaml
@@ -203,7 +203,7 @@ spec:
             cpu: 2000m
             memory: 1024Mi
           requests:
-            cpu: 111m
+            cpu: 999m
             memory: 128Mi
         volumeMounts:
         - mountPath: /etc/istio/config

--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -136,12 +136,9 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to connect Kubernetes API server, error: %v", err)
 	}
-	ysf, err := yamlFromSetFlags(applyFlagAliases(args.set, args.charts, ""), args.force, l)
-	if err != nil {
-		return err
-	}
+	setFlags := applyFlagAliases(args.set, args.charts, "")
 	// Generate IOPS parseObjectSetFromManifest
-	targetIOPSYaml, targetIOPS, err := GenerateConfig(args.inFilenames, ysf, args.force, nil, l)
+	targetIOPSYaml, targetIOPS, err := GenerateConfig(args.inFilenames, setFlags, args.force, nil, l)
 	if err != nil {
 		return fmt.Errorf("failed to generate Istio configs from file %s, error: %s", args.inFilenames, err)
 	}
@@ -201,10 +198,7 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 	} else {
 		currentSets = append(currentSets, "profile="+targetIOPS.Profile)
 	}
-	if ysf, err = yamlFromSetFlags(currentSets, args.force, l); err != nil {
-		return err
-	}
-	currentProfileIOPSYaml, _, err := genIOPSFromProfile(profile, "", ysf, true, nil, l)
+	currentProfileIOPSYaml, _, err := genIOPSFromProfile(profile, "", currentSets, true, nil, l)
 	if err != nil {
 		return fmt.Errorf("failed to generate Istio configs from file %s for the current version: %s, error: %v",
 			args.inFilenames, currentVersion, err)

--- a/operator/pkg/tpath/tree.go
+++ b/operator/pkg/tpath/tree.go
@@ -153,8 +153,14 @@ func getPathContext(nc *PathContext, fullPath, remainPath util.Path, createMissi
 	pe := remainPath[0]
 
 	if nc.Node == nil {
-		// Otherwise we panic on bad input
-		return nil, false, fmt.Errorf("node %s is zero", pe)
+		if !createMissing {
+			return nil, false, fmt.Errorf("node %s is zero", pe)
+		}
+		if util.IsNPathElement(pe) || util.IsKVPathElement(pe) {
+			nc.Node = []interface{}{}
+		} else {
+			nc.Node = make(map[string]interface{})
+		}
 	}
 
 	v := reflect.ValueOf(nc.Node)

--- a/pkg/kube/inject/inject_test.go
+++ b/pkg/kube/inject/inject_test.go
@@ -24,23 +24,22 @@ import (
 
 	"github.com/gogo/protobuf/types"
 	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
 
 	meshapi "istio.io/api/mesh/v1alpha1"
-
 	"istio.io/istio/pilot/test/util"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/mesh"
-
-	corev1 "k8s.io/api/core/v1"
 )
 
 func TestIntoResourceFile(t *testing.T) {
 	mesh.TestMode = true
 	cases := []struct {
-		in     string
-		want   string
-		values string
-		mesh   func(m *meshapi.MeshConfig)
+		in         string
+		want       string
+		setFlags   []string
+		inFilePath string
+		mesh       func(m *meshapi.MeshConfig)
 	}{
 		//"testdata/hello.yaml" is tested in http_test.go (with debug)
 		{
@@ -49,13 +48,9 @@ func TestIntoResourceFile(t *testing.T) {
 		},
 		// verify cni
 		{
-			in:   "hello.yaml",
-			want: "hello.yaml.cni.injected",
-			values: `
-components:
-  cni:
-    enabled: true
-`,
+			in:       "hello.yaml",
+			want:     "hello.yaml.cni.injected",
+			setFlags: []string{"components.cni.enabled=true"},
 		},
 		{
 			in:   "hello-mtls-not-ready.yaml",
@@ -93,22 +88,14 @@ components:
 			want: "hello-multi.yaml.injected",
 		},
 		{
-			in:   "hello.yaml",
-			want: "hello-always.yaml.injected",
-			values: `
-values:
-  global:
-    imagePullPolicy: Always
-`,
+			in:       "hello.yaml",
+			want:     "hello-always.yaml.injected",
+			setFlags: []string{"values.global.imagePullPolicy=Always"},
 		},
 		{
-			in:   "hello.yaml",
-			want: "hello-never.yaml.injected",
-			values: `
-values:
-  global:
-    imagePullPolicy: Never
-`,
+			in:       "hello.yaml",
+			want:     "hello-never.yaml.injected",
+			setFlags: []string{"values.global.imagePullPolicy=Never"},
 		},
 		{
 			in:   "hello-ignore.yaml",
@@ -123,14 +110,9 @@ values:
 			want: "statefulset.yaml.injected",
 		},
 		{
-			in:   "enable-core-dump.yaml",
-			want: "enable-core-dump.yaml.injected",
-			values: `
-values:
-  global:
-    proxy:
-      enableCoreDump: true
-`,
+			in:       "enable-core-dump.yaml",
+			want:     "enable-core-dump.yaml.injected",
+			setFlags: []string{"values.global.proxy.enableCoreDump=true"},
 		},
 		{
 			in:   "enable-core-dump-annotation.yaml",
@@ -204,15 +186,12 @@ values:
 			// Verifies that parameters are applied properly when no annotations are provided.
 			in:   "traffic-params.yaml",
 			want: "traffic-params.yaml.injected",
-			values: `
-values:
-  global:
-    proxy:
-      includeIPRanges: "127.0.0.1/24,10.96.0.1/24"
-      excludeIPRanges: "10.96.0.2/24,10.96.0.3/24"
-      excludeInboundPorts: "4,5,6"
-      statusPort: 0
-  `,
+			setFlags: []string{
+				`values.global.proxy.includeIPRanges=127.0.0.1/24,10.96.0.1/24`,
+				`values.global.proxy.excludeIPRanges=10.96.0.2/24,10.96.0.3/24`,
+				`values.global.proxy.excludeInboundPorts=4,5,6`,
+				`values.global.proxy.statusPort=0`,
+			},
 		},
 		{
 			// Verifies that empty include lists are applied properly from parameters.
@@ -244,15 +223,12 @@ values:
 			// Verifies that the status params behave properly.
 			in:   "status_params.yaml",
 			want: "status_params.yaml.injected",
-			values: `
-values:
-  global:
-    proxy:
-      statusPort: 123
-      readinessInitialDelaySeconds: 100
-      readinessPeriodSeconds: 200
-      readinessFailureThreshold: 300
-  `,
+			setFlags: []string{
+				`values.global.proxy.statusPort=123`,
+				`values.global.proxy.readinessInitialDelaySeconds=100`,
+				`values.global.proxy.readinessPeriodSeconds=200`,
+				`values.global.proxy.readinessFailureThreshold=300`,
+			},
 		},
 		{
 			// Verifies that the status annotations override the params.
@@ -263,15 +239,12 @@ values:
 			// Verifies that the kubevirtInterfaces list are applied properly from parameters..
 			in:   "kubevirtInterfaces.yaml",
 			want: "kubevirtInterfaces.yaml.injected",
-			values: `
-values:
-  global:
-    proxy:
-      statusPort: 123
-      readinessInitialDelaySeconds: 100
-      readinessPeriodSeconds: 200
-      readinessFailureThreshold: 300
-  `,
+			setFlags: []string{
+				`values.global.proxy.statusPort=123`,
+				`values.global.proxy.readinessInitialDelaySeconds=100`,
+				`values.global.proxy.readinessPeriodSeconds=200`,
+				`values.global.proxy.readinessFailureThreshold=300`,
+			},
 		},
 		{
 			// Verifies that the kubevirtInterfaces list are applied properly from parameters..
@@ -280,25 +253,15 @@ values:
 		},
 		{
 			// Verifies that global.podDNSSearchNamespaces are applied properly
-			in:   "hello.yaml",
-			want: "hello-template-in-values.yaml.injected",
-			values: `
-values:
-  global:
-    podDNSSearchNamespaces:
-    - "global"
-    - "{{ valueOrDefault .DeploymentMeta.Namespace \"default\" }}.global"
-  `,
+			in:         "hello.yaml",
+			want:       "hello-template-in-values.yaml.injected",
+			inFilePath: "hello-template-in-values-iop.yaml",
 		},
 		{
 			// Verifies that global.mountMtlsCerts is applied properly
-			in:   "hello.yaml",
-			want: "hello-mount-mtls-certs.yaml.injected",
-			values: `
-values:
-  global:
-    mountMtlsCerts: true
-  `,
+			in:       "hello.yaml",
+			want:     "hello-mount-mtls-certs.yaml.injected",
+			setFlags: []string{`values.global.mountMtlsCerts=true`},
 		},
 	}
 
@@ -311,7 +274,7 @@ values:
 			if c.mesh != nil {
 				c.mesh(&m)
 			}
-			sidecarTemplate, valuesConfig := loadInjectionConfigMap(t, c.values)
+			sidecarTemplate, valuesConfig := loadInjectionConfigMap(t, c.setFlags, c.inFilePath)
 			inputFilePath := "testdata/inject/" + c.in
 			wantFilePath := "testdata/inject/" + c.want
 			in, err := os.Open(inputFilePath)
@@ -406,7 +369,7 @@ func TestRewriteAppProbe(t *testing.T) {
 		testName := fmt.Sprintf("[%02d] %s", i, c.want)
 		t.Run(testName, func(t *testing.T) {
 			m := mesh.DefaultMeshConfig()
-			sidecarTemplate, valuesConfig := loadInjectionConfigMap(t, "")
+			sidecarTemplate, valuesConfig := loadInjectionConfigMap(t, nil, "")
 			inputFilePath := "testdata/inject/app_probe/" + c.in
 			wantFilePath := "testdata/inject/app_probe/" + c.want
 			in, err := os.Open(inputFilePath)
@@ -460,7 +423,7 @@ func TestInvalidAnnotations(t *testing.T) {
 	m := mesh.DefaultMeshConfig()
 	for _, c := range cases {
 		t.Run(c.annotation, func(t *testing.T) {
-			sidecarTemplate, valuesConfig := loadInjectionConfigMap(t, "")
+			sidecarTemplate, valuesConfig := loadInjectionConfigMap(t, nil, "")
 			inputFilePath := "testdata/inject/" + c.in
 			in, err := os.Open(inputFilePath)
 			if err != nil {

--- a/pkg/kube/inject/testdata/inject/hello-template-in-values-iop.yaml
+++ b/pkg/kube/inject/testdata/inject/hello-template-in-values-iop.yaml
@@ -1,0 +1,11 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  namespace: istio-system
+  name: example-istiocontrolplane
+spec:
+  values:
+    global:
+      podDNSSearchNamespaces:
+      - "global"
+      - "{{ valueOrDefault .DeploymentMeta.Namespace \"default\" }}.global"

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -43,8 +43,6 @@ import (
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	operatormesh "istio.io/istio/operator/cmd/mesh"
 	"istio.io/istio/operator/pkg/name"
-	"istio.io/istio/operator/pkg/tpath"
-	util2 "istio.io/istio/operator/pkg/util"
 	"istio.io/istio/operator/pkg/util/clog"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/test/util"
@@ -823,27 +821,23 @@ func createTestWebhookFromHelmConfigMap(t *testing.T) (*Webhook, func()) {
 	t.Helper()
 	// Load the config map with Helm. This simulates what will be done at runtime, by replacing function calls and
 	// variables and generating a new configmap for use by the injection logic.
-	sidecarTemplate, values := loadInjectionConfigMap(t, "")
+	sidecarTemplate, values := loadInjectionConfigMap(t, nil, "")
 	return createTestWebhook(t, sidecarTemplate, values)
 }
 
 // loadInjectionConfigMap will render the charts using the operator, with given yaml overrides.
 // This allows us to fully simulate what will actually happen at run time.
-func loadInjectionConfigMap(t testing.TB, settings string) (template *Config, values string) {
+func loadInjectionConfigMap(t testing.TB, setFlags []string, inFilePath string) (template *Config, values string) {
 	t.Helper()
 	// add --set installPackagePath=<path to charts snapshot>
-	installPackagePathYAML := "installPackagePath: " + defaultInstallPackageDir()
-	settings, err := util2.OverlayYAML(settings, installPackagePathYAML)
-	if err != nil {
-		t.Fatal(err)
+	setFlags = append(setFlags, "installPackagePath="+defaultInstallPackageDir())
+	var inFilenames []string
+	if inFilePath != "" {
+		inFilenames = []string{"testdata/inject/" + inFilePath}
 	}
 
-	oy, err := tpath.AddSpecRoot(settings)
-	if err != nil {
-		t.Fatal(err)
-	}
 	l := clog.NewConsoleLogger(os.Stdout, os.Stderr, nil)
-	manifests, _, err := operatormesh.GenManifests(nil, oy, false, nil, l)
+	manifests, _, err := operatormesh.GenManifests(inFilenames, setFlags, false, nil, l)
 	if err != nil {
 		t.Fatalf("failed to generate manifests: %v", err)
 	}
@@ -1152,7 +1146,7 @@ func createWebhook(t testing.TB, cfg *Config) (*Webhook, func()) {
 		cleanup()
 		t.Fatalf("Could not marshal test injection config: %v", err)
 	}
-	_, values := loadInjectionConfigMap(t, "")
+	_, values := loadInjectionConfigMap(t, nil, "")
 	var (
 		configFile     = filepath.Join(dir, "config-file.yaml")
 		valuesFile     = filepath.Join(dir, "values-file.yaml")
@@ -1417,7 +1411,7 @@ func testSideCarInjectorMetrics(t *testing.T, wh *Webhook) {
 }
 
 func BenchmarkInjectServe(b *testing.B) {
-	sidecarTemplate, _ := loadInjectionConfigMap(b, "")
+	sidecarTemplate, _ := loadInjectionConfigMap(b, nil, "")
 	wh, cleanup := createWebhook(b, sidecarTemplate)
 	defer cleanup()
 


### PR DESCRIPTION
This changes the approach for applying set flags from constructing a YAML tree from the flags and overlaying it to using tpath traversal instead. The advantage is that merges involving lists are done correctly which allows more robust handling of paths with list selection. 