### PR TITLE
[kiali] pilot version endpoint is gone, use the new istiod replacement

### DIFF
--- a/manifests/charts/istio-telemetry/kiali/templates/configmap.yaml
+++ b/manifests/charts/istio-telemetry/kiali/templates/configmap.yaml
@@ -11,7 +11,7 @@ data:
     istio_component_namespaces:
       grafana: {{ .Values.global.telemetryNamespace }}
       tracing: {{ .Values.global.telemetryNamespace }}
-      pilot: {{ .Values.global.istioNamespace }}
+      istiod: {{ .Values.global.istioNamespace }}
       prometheus: {{ .Values.global.prometheusNamespace }}
     istio_namespace: {{ .Values.global.istioNamespace }}
     auth:
@@ -33,7 +33,7 @@ data:
 {{- end }}
     external_services:
       istio:
-        url_service_version: http://istio-pilot.{{ .Values.global.istioNamespace }}:8080/version
+        url_service_version: http://istiod.{{ .Values.global.istioNamespace }}:15014/version
       tracing:
         url: {{ .Values.kiali.dashboard.jaegerURL }}
         in_cluster_url: {{ .Values.kiali.dashboard.jaegerInClusterURL }}


### PR DESCRIPTION
fixes: https://github.com/istio/istio/issues/23677

pilot service version endpoint is gone in 1.6 - replaced with analogous version endpoint in the istiod service. Kiali needs to switch to using the new istiod endpoint.