### PR TITLE
[kiali] move to v1.18 to address compatibility fixes for istio 1.6

### DIFF
--- a/manifests/charts/istio-telemetry/kiali/Chart.yaml
+++ b/manifests/charts/istio-telemetry/kiali/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Kiali is an open source project for service mesh observability, refer to https://www.kiali.io for details.
 name: kiali
-version: 1.15.0
-appVersion: 1.15.0
+version: 1.18.0
+appVersion: 1.18.0
 tillerVersion: ">=2.7.2"
 keywords:
   - istio-addon

--- a/manifests/charts/istio-telemetry/kiali/values.yaml
+++ b/manifests/charts/istio-telemetry/kiali/values.yaml
@@ -5,7 +5,7 @@ kiali:
   enabled: false # Note that if using the demo or demo-auth yaml when installing via Helm, this default will be `true`.
   replicaCount: 1
   hub: quay.io/kiali
-  tag: v1.15
+  tag: v1.18
   image: kiali
   contextPath: /kiali # The root context path to access the Kiali UI.
   nodeSelector: {}

--- a/manifests/profiles/default.yaml
+++ b/manifests/profiles/default.yaml
@@ -572,7 +572,7 @@ spec:
 
     kiali:
       hub: quay.io/kiali
-      tag: v1.15
+      tag: v1.18
       contextPath: /kiali
       nodeSelector: {}
       podAntiAffinityLabelSelector: []

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -146,7 +146,7 @@ func TestManifestGenerateComponentHubTag(t *testing.T) {
 		},
 		{
 			deploymentName: "kiali",
-			want:           "docker.io/testing/kiali:v1.15",
+			want:           "docker.io/testing/kiali:v1.18",
 		},
 	}
 

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-telemetry/kiali/values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-telemetry/kiali/values.yaml
@@ -5,7 +5,7 @@ kiali:
   enabled: false # Note that if using the demo or demo-auth yaml when installing via Helm, this default will be `true`.
   replicaCount: 1
   hub: quay.io/kiali
-  tag: v1.15
+  tag: v1.18
   image: kiali
   contextPath: /kiali # The root context path to access the Kiali UI.
   nodeSelector: {}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/profiles/default.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/profiles/default.yaml
@@ -580,7 +580,7 @@ spec:
 
     kiali:
       hub: quay.io/kiali
-      tag: v1.15
+      tag: v1.18
       contextPath: /kiali
       nodeSelector: {}
       podAntiAffinityLabelSelector: []

--- a/operator/cmd/mesh/testdata/manifest-generate/output/helm_values_enablement.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/helm_values_enablement.golden.yaml
@@ -267,7 +267,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/kiali/kiali:v1.15
+        image: quay.io/kiali/kiali:v1.18
         livenessProbe:
           httpGet:
             path: /kiali/healthz

--- a/operator/cmd/mesh/testdata/profile-dump/output/all_off.yaml
+++ b/operator/cmd/mesh/testdata/profile-dump/output/all_off.yaml
@@ -407,7 +407,7 @@ spec:
         private_key_file: /kiali-cert/key.pem
       service:
         annotations: {}
-      tag: v1.18
+      tag: v1.15
     mixer:
       adapters:
         kubernetesenv:

--- a/operator/cmd/mesh/testdata/profile-dump/output/all_off.yaml
+++ b/operator/cmd/mesh/testdata/profile-dump/output/all_off.yaml
@@ -407,7 +407,7 @@ spec:
         private_key_file: /kiali-cert/key.pem
       service:
         annotations: {}
-      tag: v1.15
+      tag: v1.18
     mixer:
       adapters:
         kubernetesenv:


### PR DESCRIPTION
Manual cherry-pick because this auto-cherry-pick failed: https://github.com/istio/istio/pull/23676

(cherry picked from commit ff77aa24363513406773e2cc7c7261931fad7faa)
Signed-off-by: John Mazzitelli <mazz@redhat.com>