### PR TITLE
server: move init certs out of secure gRPC listener

### DIFF
--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -409,7 +409,7 @@ func (s *Server) initPublicKey() error {
 	return nil
 }
 
-func (s *Server) createCA(client corev1.CoreV1Interface, opts *CAOptions) (*ca.IstioCA, error) {
+func (s *Server) createIstioCA(client corev1.CoreV1Interface, opts *CAOptions) (*ca.IstioCA, error) {
 	var caOpts *ca.IstioCAOptions
 	var err error
 

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -181,6 +181,12 @@ func NewServer(args *PilotArgs) (*Server, error) {
 
 	prometheus.EnableHandlingTimeHistogram()
 
+	// Parse and validate Istiod Address.
+	host, port, err := s.parseIstiodAddress()
+	if err != nil {
+		return nil, fmt.Errorf("error parsing Istiod address: %v", err)
+	}
+
 	// Apply the arguments to the configuration.
 	if err := s.initKubeClient(args); err != nil {
 		return nil, fmt.Errorf("error initializing kube client: %v", err)
@@ -190,17 +196,12 @@ func NewServer(args *PilotArgs) (*Server, error) {
 	}
 	s.initMeshNetworks(args, s.fileWatcher)
 
-	// Certificate controller is created before MCP controller in case MCP server pod
-	// waits to mount a certificate to be provisioned by the certificate controller.
-	if err := s.initCertController(args); err != nil {
-		return nil, fmt.Errorf("error initializing certificate controller: %v", err)
+	if err := s.initControllers(args); err != nil {
+		return nil, err
 	}
-	if err := s.initConfigController(args); err != nil {
-		return nil, fmt.Errorf("error initializing config controller: %v", err)
-	}
-	if err := s.initServiceControllers(args); err != nil {
-		return nil, fmt.Errorf("error initializing service controllers: %v", err)
-	}
+
+	s.initGenerators()
+	s.initJwtPolicy()
 
 	// Options based on the current 'defaults' in istio.
 	caOpts := &CAOptions{
@@ -208,50 +209,19 @@ func NewServer(args *PilotArgs) (*Server, error) {
 		Namespace:   args.Namespace,
 	}
 
-	s.EnvoyXdsServer.Generators["grpc"] = &grpcgen.GrpcConfigGenerator{}
-	epGen := &envoyv2.EdsGenerator{Server: s.EnvoyXdsServer}
-	s.EnvoyXdsServer.Generators["grpc/"+envoyv2.EndpointType] = epGen
-
-	if features.JwtPolicy.Get() != jwt.JWTPolicyThirdPartyJWT {
-		log.Infoa("JWT policy is ", features.JwtPolicy.Get())
+	// CA signing certificate must be created first if needed.
+	if err := s.maybeCreateCA(args, caOpts); err != nil {
+		return nil, err
 	}
 
-	switch features.JwtPolicy.Get() {
-	case jwt.JWTPolicyThirdPartyJWT:
-		s.jwtPath = ThirdPartyJWTPath
-	case jwt.JWTPolicyFirstPartyJWT:
-		s.jwtPath = securityModel.K8sSAJwtFileName
-	default:
-		log.Infof("unknown JWT policy %v, default to certificates ", features.JwtPolicy.Get())
-	}
-
-	// CA signing certificate must be created first only if custom TLS certs are not provided.
-	if !hasCustomTLSCerts(args.TLSOptions) && s.EnableCA() {
-		var err error
-		var corev1 v1.CoreV1Interface
-		if s.kubeClient != nil {
-			corev1 = s.kubeClient.CoreV1()
-		}
-		// May return nil, if the CA is missing required configs - This is not an error.
-		s.ca, err = s.createCA(corev1, caOpts)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create CA: %v", err)
-		}
-		err = s.initPublicKey()
-		if err != nil {
-			return nil, fmt.Errorf("error initializing public key: %v", err)
-		}
+	// Create Istiod certs and setup watches.
+	if err := s.initIstiodCerts(args, host); err != nil {
+		return nil, err
 	}
 
 	// Secure gRPC Server must be initialized after CA is created as may use a Citadel generated cert.
-	if err := s.initSecureGrpcListener(args); err != nil {
+	if err := s.initSecureGrpcListener(args, port); err != nil {
 		return nil, fmt.Errorf("error initializing secure gRPC Listener: %v", err)
-	}
-
-	// setup watches for certs - This has to be called after initSecureGrpcListener because it sets up DNS certs.
-	if err := s.initCertificateWatches(args.TLSOptions); err != nil {
-		// Not crashing istiod - This typically happens if certs are missing and in tests.
-		log.Errorf("error initializing certificate watches: %v", err)
 	}
 
 	// common https server for webhooks (e.g. injection, validation)
@@ -273,65 +243,24 @@ func NewServer(args *PilotArgs) (*Server, error) {
 	if err := s.initMonitor(args.DiscoveryOptions.MonitoringAddr); err != nil {
 		return nil, fmt.Errorf("error initializing monitor: %v", err)
 	}
+
 	// TODO(irisdingbj):add integration test after centralIstiod finished
 	args.Config.ControllerOptions.FetchCaRoot = nil
-	if features.CentralIstioD {
-		if s.ca != nil && s.ca.GetCAKeyCertBundle() != nil {
-			args.Config.ControllerOptions.FetchCaRoot = func() map[string]string {
-				return map[string]string{
-					constants.CACertNamespaceConfigMapDataName: string(s.ca.GetCAKeyCertBundle().GetRootCertPem()),
-				}
-			}
-		}
+	if features.CentralIstioD && s.ca != nil && s.ca.GetCAKeyCertBundle() != nil {
+		args.Config.ControllerOptions.FetchCaRoot = s.fetchCARoot
 	}
+
 	if err := s.initClusterRegistries(args); err != nil {
 		return nil, fmt.Errorf("error initializing cluster registries: %v", err)
 	}
-	if dns.DNSAddr.Get() != "" {
-		if err := s.initDNSTLSListener(dns.DNSAddr.Get(), args.TLSOptions); err != nil {
-			log.Warna("error initializing DNS-over-TLS listener ", err)
-		}
-
-		// Respond to CoreDNS gRPC queries.
-		s.addStartFunc(func(stop <-chan struct{}) error {
-			if s.DNSListener != nil {
-				dnsSvc := dns.InitDNS()
-				dnsSvc.StartDNS(dns.DNSAddr.Get(), s.DNSListener)
-			}
-			return nil
-		})
+	if err := s.initDNSServer(args); err != nil {
+		return nil, err
 	}
 
-	// Run the SDS signing server.
-	// RunCA() must be called after createCA() and initDNSListener()
-	// because it depends on the following conditions:
-	// 1) CA certificate has been created.
-	// 2) grpc server has been started.
-	if s.ca != nil {
-		s.addStartFunc(func(stop <-chan struct{}) error {
-			s.RunCA(s.secureGrpcServer, s.ca, caOpts)
-			return nil
-		})
+	// Start CA. This should be called after CA and Istiod certs have been created.
+	s.startCA(args, caOpts)
 
-		if s.kubeClient != nil {
-			fetchData := func() map[string]string {
-				return map[string]string{
-					constants.CACertNamespaceConfigMapDataName: string(s.ca.GetCAKeyCertBundle().GetRootCertPem()),
-				}
-			}
-			s.addTerminatingStartFunc(func(stop <-chan struct{}) error {
-				leaderelection.
-					NewLeaderElection(args.Namespace, args.PodName, leaderelection.NamespaceController, s.kubeClient).
-					AddRunFunction(func(stop <-chan struct{}) {
-						log.Infof("Starting namespace controller")
-						nc := kubecontroller.NewNamespaceController(fetchData, args.Config.ControllerOptions, s.kubeClient)
-						nc.Run(stop)
-					}).
-					Run(stop)
-				return nil
-			})
-		}
-	}
+	s.initNamespaceController(args)
 
 	// TODO: don't run this if galley is started, one ctlz is enough
 	if args.CtrlZOptions != nil {
@@ -552,6 +481,25 @@ func (s *Server) initGrpcServer(options *istiokeepalive.Options) {
 	grpcOptions := s.grpcServerOptions(options)
 	s.grpcServer = grpc.NewServer(grpcOptions...)
 	s.EnvoyXdsServer.Register(s.grpcServer)
+}
+
+// initDNSServer initializes gRPC DNS Server for DNS resolutions.
+func (s *Server) initDNSServer(args *PilotArgs) error {
+	if dns.DNSAddr.Get() != "" {
+		if err := s.initDNSTLSListener(dns.DNSAddr.Get(), args.TLSOptions); err != nil {
+			log.Warna("error initializing DNS-over-TLS listener ", err)
+		}
+
+		// Respond to CoreDNS gRPC queries.
+		s.addStartFunc(func(stop <-chan struct{}) error {
+			if s.DNSListener != nil {
+				dnsSvc := dns.InitDNS()
+				dnsSvc.StartDNS(dns.DNSAddr.Get(), s.DNSListener)
+			}
+			return nil
+		})
+	}
+	return nil
 }
 
 // initialize DNS server listener - uses the same certs as gRPC
@@ -788,43 +736,47 @@ func (s *Server) initEventHandlers() error {
 }
 
 // add a GRPC listener using DNS-based certificates
-func (s *Server) initSecureGrpcListener(args *PilotArgs) error {
-	istiodAddr := features.IstiodService.Get()
-	if istiodAddr == "" {
-		// Feature disabled
+func (s *Server) initSecureGrpcListener(args *PilotArgs, port string) error {
+	if features.IstiodService.Get() == "" {
 		return nil
 	}
+
 	if args.TLSOptions.CaCertFile == "" && s.ca == nil {
 		// Running locally without configured certs - no TLS mode
 		return nil
 	}
 
-	// validate
-	host, port, err := net.SplitHostPort(istiodAddr)
-	if err != nil {
-		return fmt.Errorf("invalid ISTIOD_ADDR(%s): %v", istiodAddr, err)
-	}
-	if _, err := strconv.Atoi(port); err != nil {
-		return fmt.Errorf("invalid port(%s) in ISTIOD_ADDR(%s): %v", port, istiodAddr, err)
+	// run secure grpc server for Istiod - using DNS-based certs from K8S
+	if err := s.initSecureGrpcServer(port, args.KeepaliveOptions, args.TLSOptions); err != nil {
+		return err
 	}
 
-	// TODO(ramaraochavali): Move the cert generation separate function and call it before we run init of any service.
+	return nil
+}
 
+// initIstiodCerts creates Istiod certificates and also sets up watches to them.
+func (s *Server) initIstiodCerts(args *PilotArgs, host string) error {
+	if err := s.maybeInitDNSCerts(args, host); err != nil {
+		return fmt.Errorf("error initializing DNS certs: %v", err)
+	}
+
+	// setup watches for certs
+	if err := s.initCertificateWatches(args.TLSOptions); err != nil {
+		// Not crashing istiod - This typically happens if certs are missing and in tests.
+		log.Errorf("error initializing certificate watches: %v", err)
+	}
+	return nil
+}
+
+func (s *Server) maybeInitDNSCerts(args *PilotArgs, host string) error {
 	// Generate DNS certificates only if custom certs are not provided via args.
 	if !hasCustomTLSCerts(args.TLSOptions) {
 		// Create DNS certificates. This allows injector, validation to work without Citadel, and
 		// allows secure SDS connections to Istiod.
-		err = s.initDNSCerts(host, features.IstiodServiceCustomHost.Get(), args.Namespace)
-		if err != nil {
+		if err := s.initDNSCerts(host, features.IstiodServiceCustomHost.Get(), args.Namespace); err != nil {
 			return err
 		}
 	}
-
-	// run secure grpc server for Istiod - using DNS-based certs from K8S
-	if err = s.initSecureGrpcServer(port, args.KeepaliveOptions, args.TLSOptions); err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -943,4 +895,135 @@ func (s *Server) getIstiodCertificate(info *tls.ClientHelloInfo) (*tls.Certifica
 	s.certMu.Lock()
 	defer s.certMu.Unlock()
 	return s.istiodCert, nil
+}
+
+// parseIstiodAddress parses the Istiod address and validates it.
+func (s *Server) parseIstiodAddress() (string, string, error) {
+	istiodAddr := features.IstiodService.Get()
+	if istiodAddr == "" {
+		// Feature disabled
+		return "", "", nil
+	}
+
+	// validate
+	host, port, err := net.SplitHostPort(istiodAddr)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid ISTIOD_ADDR(%s): %v", istiodAddr, err)
+	}
+	if _, err := strconv.Atoi(port); err != nil {
+		return "", "", fmt.Errorf("invalid port(%s) in ISTIOD_ADDR(%s): %v", port, istiodAddr, err)
+	}
+
+	return host, port, nil
+}
+
+// initControllers initializes the controllers.
+func (s *Server) initControllers(args *PilotArgs) error {
+	// Certificate controller is created before MCP controller in case MCP server pod
+	// waits to mount a certificate to be provisioned by the certificate controller.
+	if err := s.initCertController(args); err != nil {
+		return fmt.Errorf("error initializing certificate controller: %v", err)
+	}
+	if err := s.initConfigController(args); err != nil {
+		return fmt.Errorf("error initializing config controller: %v", err)
+	}
+	if err := s.initServiceControllers(args); err != nil {
+		return fmt.Errorf("error initializing service controllers: %v", err)
+	}
+	return nil
+}
+
+// initNamespaceController initializes namespace controller to sync config map.
+func (s *Server) initNamespaceController(args *PilotArgs) {
+	if s.ca != nil && s.kubeClient != nil {
+		s.addTerminatingStartFunc(func(stop <-chan struct{}) error {
+			leaderelection.
+				NewLeaderElection(args.Namespace, args.PodName, leaderelection.NamespaceController, s.kubeClient).
+				AddRunFunction(func(stop <-chan struct{}) {
+					log.Infof("Starting namespace controller")
+					nc := kubecontroller.NewNamespaceController(s.fetchCARoot, args.Config.ControllerOptions, s.kubeClient)
+					nc.Run(stop)
+				}).
+				Run(stop)
+			return nil
+		})
+	}
+}
+
+// initGenerators initializes generators to be used by XdsServer.
+func (s *Server) initGenerators() {
+	s.EnvoyXdsServer.Generators["grpc"] = &grpcgen.GrpcConfigGenerator{}
+	s.EnvoyXdsServer.Generators["grpc/"+envoyv2.EndpointType] = &envoyv2.EdsGenerator{Server: s.EnvoyXdsServer}
+}
+
+// initJwtPolicy initializes JwtPolicy.
+func (s *Server) initJwtPolicy() {
+	if features.JwtPolicy.Get() != jwt.JWTPolicyThirdPartyJWT {
+		log.Infoa("JWT policy is ", features.JwtPolicy.Get())
+	}
+
+	switch features.JwtPolicy.Get() {
+	case jwt.JWTPolicyThirdPartyJWT:
+		s.jwtPath = ThirdPartyJWTPath
+	case jwt.JWTPolicyFirstPartyJWT:
+		s.jwtPath = securityModel.K8sSAJwtFileName
+	default:
+		log.Infof("unknown JWT policy %v, default to certificates ", features.JwtPolicy.Get())
+	}
+}
+
+// maybeCreateCA creates and initializes CA Key if needed.
+func (s *Server) maybeCreateCA(args *PilotArgs, caOpts *CAOptions) error {
+	// CA signing certificate must be created only if custom TLS certs are not provided.
+	if !hasCustomTLSCerts(args.TLSOptions) && s.EnableCA() {
+		var err error
+		var corev1 v1.CoreV1Interface
+		if s.kubeClient != nil {
+			corev1 = s.kubeClient.CoreV1()
+		}
+		// May return nil, if the CA is missing required configs - This is not an error.
+		if s.ca, err = s.createIstioCA(corev1, caOpts); err != nil {
+			return fmt.Errorf("failed to create CA: %v", err)
+		}
+		if err = s.initPublicKey(); err != nil {
+			return fmt.Errorf("error initializing public key: %v", err)
+		}
+	}
+	return nil
+}
+
+// startCA starts the CA server if configured.
+func (s *Server) startCA(args *PilotArgs, caOpts *CAOptions) error {
+	if s.ca != nil {
+		s.addStartFunc(func(stop <-chan struct{}) error {
+			s.RunCA(s.secureGrpcServer, s.ca, caOpts)
+			return nil
+		})
+	}
+
+	if s.kubeClient != nil {
+		fetchData := func() map[string]string {
+			return map[string]string{
+				constants.CACertNamespaceConfigMapDataName: string(s.ca.GetCAKeyCertBundle().GetRootCertPem()),
+			}
+		}
+		s.addTerminatingStartFunc(func(stop <-chan struct{}) error {
+			leaderelection.
+				NewLeaderElection(args.Namespace, args.PodName, leaderelection.NamespaceController, s.kubeClient).
+				AddRunFunction(func(stop <-chan struct{}) {
+					log.Infof("Starting namespace controller")
+					nc := kubecontroller.NewNamespaceController(fetchData, args.Config.ControllerOptions, s.kubeClient)
+					nc.Run(stop)
+				}).
+				Run(stop)
+			return nil
+		})
+	}
+	return nil
+}
+
+func (s *Server) fetchCARoot() map[string]string {
+	return map[string]string{
+		constants.CACertNamespaceConfigMapDataName: string(s.ca.GetCAKeyCertBundle().GetRootCertPem()),
+	}
 }

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -220,7 +220,7 @@ func NewServer(args *PilotArgs) (*Server, error) {
 	}
 
 	// Secure gRPC Server must be initialized after CA is created as may use a Citadel generated cert.
-	if err := s.initSecureGrpcServer(port, args); err != nil {
+	if err := s.initSecureGrpcServer(args, port); err != nil {
 		return nil, fmt.Errorf("error initializing secure gRPC Listener: %v", err)
 	}
 
@@ -535,7 +535,7 @@ func (s *Server) initDNSTLSListener(dns string, tlsOptions TLSOptions) error {
 }
 
 // initialize secureGRPCServer.
-func (s *Server) initSecureGrpcServer(port string, args *PilotArgs) error {
+func (s *Server) initSecureGrpcServer(args *PilotArgs, port string) error {
 	if features.IstiodService.Get() == "" {
 		return nil
 	}
@@ -559,7 +559,7 @@ func (s *Server) initSecureGrpcServer(port string, args *PilotArgs) error {
 
 	tlsCreds := credentials.NewTLS(cfg)
 
-	// Default is 15012 - istio-agent relies on this as a default to distinguish what cert auth to expect
+	// Default is 15012 - istio-agent relies on this as a default to distinguish what cert auth to expect.
 	secureGrpc := fmt.Sprintf(":%s", port)
 
 	// create secure grpc listener

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -262,10 +262,9 @@ var (
 	).Get()
 
 	// IstiodService controls the istiod address - used for injection and as default value injected into pods
-	// if istiod is used. The name must be part of the DNS certificate served by pilot/istiod. The '.svc' is
-	// imposed by K8S - that's how the names for webhooks are defined, based on webhook service (which will be
-	// istio-pilot or istiod) plus namespace and .svc.
-	// The 15010 port is used with plain text, 15011 with Spiffe certs - we need a different port for DNS cert.
+	// The name must be part of the DNS certificate served by istiod. The '.svc' is imposed by K8S - that's how
+	// the names for webhooks are defined, based on webhook service (which will be stiod) plus namespace and .svc.
+	// The 15010 port is used with plain text, 15012 for secure port.
 	IstiodService = env.RegisterStringVar("ISTIOD_ADDR", "",
 		"Service name of istiod. If empty the istiod listener, certs will be disabled.")
 

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -261,10 +261,10 @@ var (
 			"See https://godoc.org/k8s.io/client-go/rest#Config Burst",
 	).Get()
 
-	// IstiodService controls the istiod address - used for injection and as default value injected into pods
+	// IstiodService controls the istiod address - used for injection and as default value injected into pods.
 	// The name must be part of the DNS certificate served by istiod. The '.svc' is imposed by K8S - that's how
-	// the names for webhooks are defined, based on webhook service (which will be stiod) plus namespace and .svc.
-	// The 15010 port is used with plain text, 15012 for secure port.
+	// the names for webhooks are defined, based on webhook service (which will be istiod) plus namespace and .svc.
+	// The 15010 port is used with plain text port 15012 is used with secure port.
 	IstiodService = env.RegisterStringVar("ISTIOD_ADDR", "",
 		"Service name of istiod. If empty the istiod listener, certs will be disabled.")
 


### PR DESCRIPTION
As noted as one of the TODOs in #23492 , this PR
- Moves `initDNSCerts` out of `initSecureGrpcListener` and creates them before we run init of any services
- Refactored parts of code in `NewServer` to separate functions so that it becomes more manageable.