### PR TITLE
rename JWT policy constants as per go conventions

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -94,7 +94,7 @@ var (
 
 	pilotCertProvider = env.RegisterStringVar("PILOT_CERT_PROVIDER", "istiod",
 		"the provider of Pilot DNS certificate.").Get()
-	jwtPolicy = env.RegisterStringVar("JWT_POLICY", jwt.JWTPolicyThirdPartyJWT,
+	jwtPolicy = env.RegisterStringVar("JWT_POLICY", jwt.PolicyThirdParty,
 		"The JWT validation policy.")
 	outputKeyCertToDir = env.RegisterStringVar("OUTPUT_CERTS", "",
 		"The output directory for the key and certificate. If empty, key and certificate will not be saved. "+
@@ -201,10 +201,10 @@ var (
 			log.Infof("Proxy role: %#v", role)
 
 			var jwtPath string
-			if jwtPolicy.Get() == jwt.JWTPolicyThirdPartyJWT {
+			if jwtPolicy.Get() == jwt.PolicyThirdParty {
 				log.Info("JWT policy is third-party-jwt")
 				jwtPath = trustworthyJWTPath
-			} else if jwtPolicy.Get() == jwt.JWTPolicyFirstPartyJWT {
+			} else if jwtPolicy.Get() == jwt.PolicyFirstParty {
 				log.Info("JWT policy is first-party-jwt")
 				jwtPath = securityModel.K8sSAJwtFileName
 			} else {

--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -154,7 +154,7 @@ func (s *Server) EnableCA() bool {
 		// for debug we may want to override this by setting trustedIssuer explicitly.
 		// If TOKEN_ISSUER is set, we ignore the lack of mounted JWT token, it means user is using
 		// an external OIDC provider to validate the tokens, and istiod lack of a JWT doesn't indicate a problem.
-		if features.JwtPolicy.Get() == jwt.JWTPolicyThirdPartyJWT && trustedIssuer.Get() == "" {
+		if features.JwtPolicy.Get() == jwt.PolicyThirdParty && trustedIssuer.Get() == "" {
 			log.Warnf("istiod running without access to K8S tokens (jwt path %v). CA will run to support VMs ",
 				s.jwtPath)
 			return true

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -916,14 +916,14 @@ func (s *Server) initGenerators() {
 
 // initJwtPolicy initializes JwtPolicy.
 func (s *Server) initJwtPolicy() {
-	if features.JwtPolicy.Get() != jwt.JWTPolicyThirdPartyJWT {
+	if features.JwtPolicy.Get() != jwt.PolicyThirdParty {
 		log.Infoa("JWT policy is ", features.JwtPolicy.Get())
 	}
 
 	switch features.JwtPolicy.Get() {
-	case jwt.JWTPolicyThirdPartyJWT:
+	case jwt.PolicyThirdParty:
 		s.jwtPath = ThirdPartyJWTPath
-	case jwt.JWTPolicyFirstPartyJWT:
+	case jwt.PolicyFirstParty:
 		s.jwtPath = securityModel.K8sSAJwtFileName
 	default:
 		log.Infof("unknown JWT policy %v, default to certificates ", features.JwtPolicy.Get())

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -269,7 +269,7 @@ var (
 	PilotCertProvider = env.RegisterStringVar("PILOT_CERT_PROVIDER", "istiod",
 		"the provider of Pilot DNS certificate.")
 
-	JwtPolicy = env.RegisterStringVar("JWT_POLICY", jwt.JWTPolicyThirdPartyJWT,
+	JwtPolicy = env.RegisterStringVar("JWT_POLICY", jwt.PolicyThirdParty,
 		"The JWT validation policy.")
 
 	// Default request timeout for virtual services if a timeout is not configured in virtual service. It defaults to zero

--- a/pkg/jwt/jwt.go
+++ b/pkg/jwt/jwt.go
@@ -15,6 +15,6 @@
 package jwt
 
 const (
-	JWTPolicyThirdPartyJWT = "third-party-jwt"
-	JWTPolicyFirstPartyJWT = "first-party-jwt"
+	PolicyThirdParty = "third-party-jwt"
+	PolicyFirstParty = "first-party-jwt"
 )

--- a/security/pkg/k8s/tokenreview/k8sauthn.go
+++ b/security/pkg/k8s/tokenreview/k8sauthn.go
@@ -44,9 +44,9 @@ func ValidateK8sJwt(kubeClient kubernetes.Interface, targetToken, jwtPolicy stri
 			Token: targetToken,
 		},
 	}
-	if jwtPolicy == jwt.JWTPolicyThirdPartyJWT {
+	if jwtPolicy == jwt.PolicyThirdParty {
 		tokenReview.Spec.Audiences = []string{DefaultAudience}
-	} else if jwtPolicy != jwt.JWTPolicyFirstPartyJWT {
+	} else if jwtPolicy != jwt.PolicyFirstParty {
 		return nil, fmt.Errorf("invalid JWT policy: %v", jwtPolicy)
 	}
 	reviewRes, err := kubeClient.AuthenticationV1().TokenReviews().Create(context.TODO(), tokenReview, metav1.CreateOptions{})

--- a/security/pkg/server/ca/authenticate/kube_jwt_test.go
+++ b/security/pkg/server/ca/authenticate/kube_jwt_test.go
@@ -34,7 +34,7 @@ import (
 
 func TestNewKubeJWTAuthenticator(t *testing.T) {
 	trustDomain := "testdomain.com"
-	jwtPolicy := jwt.JWTPolicyThirdPartyJWT
+	jwtPolicy := jwt.PolicyThirdParty
 
 	authenticator := NewKubeJWTAuthenticator(nil, "kubernetes", nil, trustDomain, jwtPolicy)
 	expectedAuthenticator := &KubeJWTAuthenticator{
@@ -98,7 +98,7 @@ func TestAuthenticate(t *testing.T) {
 					"Basic callername",
 				},
 			},
-			jwtPolicy:      jwt.JWTPolicyFirstPartyJWT,
+			jwtPolicy:      jwt.PolicyFirstParty,
 			expectedErrMsg: "failed to validate the JWT: the token is not authenticated",
 		},
 		"token authenticated": {
@@ -109,7 +109,7 @@ func TestAuthenticate(t *testing.T) {
 					"Basic callername",
 				},
 			},
-			jwtPolicy:      jwt.JWTPolicyFirstPartyJWT,
+			jwtPolicy:      jwt.PolicyFirstParty,
 			expectedID:     fmt.Sprintf(identityTemplate, "example.com", "default", "example-pod-sa"),
 			expectedErrMsg: "",
 		},
@@ -122,7 +122,7 @@ func TestAuthenticate(t *testing.T) {
 					"Basic callername",
 				},
 			},
-			jwtPolicy:      jwt.JWTPolicyFirstPartyJWT,
+			jwtPolicy:      jwt.PolicyFirstParty,
 			expectedID:     fmt.Sprintf(identityTemplate, "example.com", "default", "example-pod-sa"),
 			expectedErrMsg: "",
 		},
@@ -144,7 +144,7 @@ func TestAuthenticate(t *testing.T) {
 					Token: tc.token,
 				},
 			}
-			if tc.jwtPolicy == jwt.JWTPolicyThirdPartyJWT {
+			if tc.jwtPolicy == jwt.PolicyThirdParty {
 				tokenReview.Spec.Audiences = []string{tokenreview.DefaultAudience}
 			}
 

--- a/security/pkg/server/ca/server_test.go
+++ b/security/pkg/server/ca/server_test.go
@@ -407,7 +407,7 @@ func TestRun(t *testing.T) {
 			tc.expectedAuthenticatorsLen++
 		}
 		server, err := New(tc.ca, time.Hour, false, tc.hostname, tc.port, "testdomain.com", true,
-			jwt.JWTPolicyThirdPartyJWT, "kubernetes")
+			jwt.PolicyThirdParty, "kubernetes")
 		if err == nil {
 			err = server.Run()
 		}
@@ -495,7 +495,7 @@ func TestGetServerCertificate(t *testing.T) {
 		}
 
 		server, err := New(ca, time.Hour, false, []string{"localhost"}, 0,
-			"testdomain.com", true, jwt.JWTPolicyThirdPartyJWT, "kubernetes")
+			"testdomain.com", true, jwt.PolicyThirdParty, "kubernetes")
 		if err != nil {
 			t.Errorf("%s: Cannot crete server: %v", id, err)
 		}


### PR DESCRIPTION

Cosmetic change. As per go conventions, it is redundant to have the prefix of a constant the same as that of the package name. The context of `jwt` is already implied by referring to the `jwt` package.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure