### PR TITLE
fix(multicluster): add install time support for metrics dimensions

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.6.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.6.yaml
@@ -144,7 +144,16 @@ spec:
                 configuration: |
                   {
                     "debug": "false",
-                    "stat_prefix": "istio"
+                    "stat_prefix": "istio"{{- if .Values.global.multiCluster.clusterName }},
+                    "metrics": [
+                      {
+                        "dimensions": {
+                          "source_cluster": "node.metadata['CLUSTER_ID']",
+                          "destination_cluster": "upstream_peer.cluster_id"
+                        }
+                      }
+                    ]
+                    {{- end }}
                   }
                 vm_config:
                   vm_id: stats_outbound
@@ -183,7 +192,16 @@ spec:
                 configuration: |
                   {
                     "debug": "false",
-                    "stat_prefix": "istio"
+                    "stat_prefix": "istio"{{- if .Values.global.multiCluster.clusterName }},
+                    "metrics": [
+                      {
+                        "dimensions": {
+                          "destination_cluster": "node.metadata['CLUSTER_ID']",
+                          "source_cluster": "downstream_peer.cluster_id"
+                        }
+                      }
+                    ]
+                    {{- end }}
                   }
                 vm_config:
                   vm_id: stats_inbound
@@ -223,7 +241,16 @@ spec:
                   {
                     "debug": "false",
                     "stat_prefix": "istio",
-                    "disable_host_header_fallback": true
+                    "disable_host_header_fallback": true{{- if .Values.global.multiCluster.clusterName }},
+                    "metrics": [
+                      {
+                        "dimensions": {
+                          "source_cluster": "node.metadata['CLUSTER_ID']",
+                          "destination_cluster": "upstream_peer.cluster_id"
+                        }
+                      }
+                    ]
+                    {{- end }}
                   }
                 vm_config:
                   vm_id: stats_outbound
@@ -274,7 +301,16 @@ spec:
                 configuration: |
                   {
                     "debug": "false",
-                    "stat_prefix": "istio"
+                    "stat_prefix": "istio"{{- if .Values.global.multiCluster.clusterName }},
+                    "metrics": [
+                      {
+                        "dimensions": {
+                          "destination_cluster": "node.metadata['CLUSTER_ID']",
+                          "source_cluster": "downstream_peer.cluster_id"
+                        }
+                      }
+                    ]
+                    {{- end }}
                   }
                 vm_config:
                   vm_id: tcp_stats_inbound
@@ -311,7 +347,16 @@ spec:
                 configuration: |
                   {
                     "debug": "false",
-                    "stat_prefix": "istio"
+                    "stat_prefix": "istio"{{- if .Values.global.multiCluster.clusterName }},
+                    "metrics": [
+                      {
+                        "dimensions": {
+                          "source_cluster": "node.metadata['CLUSTER_ID']",
+                          "destination_cluster": "upstream_peer.cluster_id"
+                        }
+                      }
+                    ]
+                    {{- end }}
                   }
                 vm_config:
                   vm_id: tcp_stats_outbound
@@ -348,7 +393,16 @@ spec:
                 configuration: |
                   {
                     "debug": "false",
-                    "stat_prefix": "istio"
+                    "stat_prefix": "istio"{{- if .Values.global.multiCluster.clusterName }},
+                    "metrics": [
+                      {
+                        "dimensions": {
+                          "source_cluster": "node.metadata['CLUSTER_ID']",
+                          "destination_cluster": "upstream_peer.cluster_id"
+                        }
+                      }
+                    ]
+                    {{- end }}
                   }
                 vm_config:
                   vm_id: tcp_stats_outbound

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.7.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.7.yaml
@@ -144,7 +144,16 @@ spec:
                 configuration: |
                   {
                     "debug": "false",
-                    "stat_prefix": "istio"
+                    "stat_prefix": "istio"{{- if .Values.global.multiCluster.clusterName }},
+                    "metrics": [
+                      {
+                        "dimensions": {
+                          "source_cluster": "node.metadata['CLUSTER_ID']",
+                          "destination_cluster": "upstream_peer.cluster_id"
+                        }
+                      }
+                    ]
+                    {{- end }}
                   }
                 vm_config:
                   vm_id: stats_outbound
@@ -183,7 +192,16 @@ spec:
                 configuration: |
                   {
                     "debug": "false",
-                    "stat_prefix": "istio"
+                    "stat_prefix": "istio"{{- if .Values.global.multiCluster.clusterName }},
+                    "metrics": [
+                      {
+                        "dimensions": {
+                          "destination_cluster": "node.metadata['CLUSTER_ID']",
+                          "source_cluster": "downstream_peer.cluster_id"
+                        }
+                      }
+                    ]
+                    {{- end }}
                   }
                 vm_config:
                   vm_id: stats_inbound
@@ -223,7 +241,16 @@ spec:
                   {
                     "debug": "false",
                     "stat_prefix": "istio",
-                    "disable_host_header_fallback": true
+                    "disable_host_header_fallback": true{{- if .Values.global.multiCluster.clusterName }},
+                    "metrics": [
+                      {
+                        "dimensions": {
+                          "source_cluster": "node.metadata['CLUSTER_ID']",
+                          "destination_cluster": "upstream_peer.cluster_id"
+                        }
+                      }
+                    ]
+                    {{- end }}
                   }
                 vm_config:
                   vm_id: stats_outbound
@@ -274,7 +301,16 @@ spec:
                 configuration: |
                   {
                     "debug": "false",
-                    "stat_prefix": "istio"
+                    "stat_prefix": "istio"{{- if .Values.global.multiCluster.clusterName }},
+                    "metrics": [
+                      {
+                        "dimensions": {
+                          "destination_cluster": "node.metadata['CLUSTER_ID']",
+                          "source_cluster": "downstream_peer.cluster_id"
+                        }
+                      }
+                    ]
+                    {{- end }}
                   }
                 vm_config:
                   vm_id: tcp_stats_inbound
@@ -311,7 +347,16 @@ spec:
                 configuration: |
                   {
                     "debug": "false",
-                    "stat_prefix": "istio"
+                    "stat_prefix": "istio"{{- if .Values.global.multiCluster.clusterName }},
+                    "metrics": [
+                      {
+                        "dimensions": {
+                          "source_cluster": "node.metadata['CLUSTER_ID']",
+                          "destination_cluster": "upstream_peer.cluster_id"
+                        }
+                      }
+                    ]
+                    {{- end }}
                   }
                 vm_config:
                   vm_id: tcp_stats_outbound
@@ -348,7 +393,16 @@ spec:
                 configuration: |
                   {
                     "debug": "false",
-                    "stat_prefix": "istio"
+                    "stat_prefix": "istio"{{- if .Values.global.multiCluster.clusterName }},
+                    "metrics": [
+                      {
+                        "dimensions": {
+                          "source_cluster": "node.metadata['CLUSTER_ID']",
+                          "destination_cluster": "upstream_peer.cluster_id"
+                        }
+                      }
+                    ]
+                    {{- end }}
                   }
                 vm_config:
                   vm_id: tcp_stats_outbound


### PR DESCRIPTION
This PR updates the default set of metric dimensions for multi-cluster scenarios to add the following:
- `source_cluster`
- `destination_cluster`

This is meant to:
- simplify install operations
- provide useful dimensions for tracking cross-cluster traffic
- minimize impact on single-cluster users.

It keys off a value being set for `global.multiCluster.clusterName`.

Example metric:

```
istio_requests_total{connection_security_policy="mutual_tls",destination_app="helloworld",destination_canonical_revision="v1",destination_canonical_service="helloworld",destination_cluster="essos",destination_principal="spiffe://cluster.local/ns/sample/sa/default",destination_service="helloworld.sample:5000",destination_service_name="InboundPassthroughClusterIpv4",destination_service_namespace="sample",destination_version="v1",destination_workload="helloworld-v1",destination_workload_namespace="sample",instance="10.56.1.11:15090",job="envoy-stats",namespace="sample",pod_name="helloworld-v1-7bb88866c4-tq4kr",reporter="destination",request_protocol="http",response_code="200",response_flags="-",source_app="sleep",source_canonical_revision="latest",source_canonical_service="sleep",source_cluster="essos",source_principal="spiffe://cluster.local/ns/sample/sa/sleep",source_version="unknown",source_workload="sleep",source_workload_namespace="sample"}
```

[ X ] Installation
[ X ] Policies and Telemetry
