### PR TITLE
set discoveryAddress to be cluster-local by default (#23625)

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -34,6 +34,7 @@ import (
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/pkg/monitoring"
 
+	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/mesh"
 )
@@ -87,6 +88,18 @@ func (e *Environment) Mesh() *meshconfig.MeshConfig {
 		return e.Watcher.Mesh()
 	}
 	return nil
+}
+
+func (e *Environment) GetDiscoveryHost() (host.Name, error) {
+	proxyConfig := mesh.DefaultProxyConfig()
+	if e.Mesh().DefaultConfig != nil {
+		proxyConfig = *e.Mesh().DefaultConfig
+	}
+	hostname, _, err := net.SplitHostPort(proxyConfig.DiscoveryAddress)
+	if err != nil {
+		return "", err
+	}
+	return host.Name(hostname), nil
 }
 
 func (e *Environment) AddMeshHandler(h func()) {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1581,6 +1581,15 @@ func (ps *PushContext) initClusterLocalHosts(e *Environment) {
 		defaultClusterLocalHosts = append(defaultClusterLocalHosts, host.Name("*."+n+".svc."+domainSuffix))
 	}
 
+	if discoveryHost, err := e.GetDiscoveryHost(); err != nil {
+		log.Errorf("failed to make discoveryAddress cluster-local: %v", err)
+	} else {
+		if !strings.HasSuffix(string(discoveryHost), domainSuffix) {
+			discoveryHost += host.Name("." + domainSuffix)
+		}
+		defaultClusterLocalHosts = append(defaultClusterLocalHosts, discoveryHost)
+	}
+
 	// Collect the cluster-local hosts.
 	clusterLocalHosts := make([]host.Name, 0)
 	for _, serviceSettings := range ps.Mesh.ServiceSettings {

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -462,6 +462,12 @@ func TestIsClusterLocal(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "discovery server is local",
+			m:        mesh.DefaultMeshConfig(),
+			host:     "istiod.istio-system.svc.cluster.local",
+			expected: true,
+		},
+		{
 			name:     "not local by default",
 			m:        mesh.DefaultMeshConfig(),
 			host:     "not.cluster.local",


### PR DESCRIPTION
Cherry picking #23625 into release 1.6 to fix shared control plane multicluster