### PR TITLE
Revert #23663

### DIFF
--- a/operator/pkg/helmreconciler/apply.go
+++ b/operator/pkg/helmreconciler/apply.go
@@ -194,7 +194,7 @@ func (h *HelmReconciler) ApplyObject(obj *unstructured.Unstructured) error {
 		case err == nil:
 			scope.Infof("updating resource: %s", objectStr)
 			// The correct way to do this is with a server-side apply. However, this requires users to be running Kube 1.16.
-			// When we no longer support < 1.16 use the below code instead. Check in the linked issue for updates.
+			// When we no longer support < 1.16 use the code described in the linked issue.
 			// https://github.com/kubernetes-sigs/controller-runtime/issues/347
 			if err := applyOverlay(receiver, obj); err != nil {
 				return err

--- a/operator/pkg/helmreconciler/apply.go
+++ b/operator/pkg/helmreconciler/apply.go
@@ -199,7 +199,7 @@ func (h *HelmReconciler) ApplyObject(obj *unstructured.Unstructured) error {
 			if err := applyOverlay(receiver, obj); err != nil {
 				return err
 			}
-			return h.client.Update(context.TODO(), obj)
+			return h.client.Update(context.TODO(), receiver)
 		}
 		return nil
 	})

--- a/operator/pkg/helmreconciler/apply.go
+++ b/operator/pkg/helmreconciler/apply.go
@@ -193,10 +193,13 @@ func (h *HelmReconciler) ApplyObject(obj *unstructured.Unstructured) error {
 			return nil
 		case err == nil:
 			scope.Infof("updating resource: %s", objectStr)
-			// Kubernetes enforces read-modify-write so we need to set the resource version
-			obj.SetResourceVersion(receiver.GetResourceVersion())
-			updateErr := h.client.Update(context.TODO(), obj)
-			return updateErr
+			// The correct way to do this is with a server-side apply. However, this requires users to be running Kube 1.16.
+			// When we no longer support < 1.16 use the below code instead. Check in the linked issue for updates.
+			// https://github.com/kubernetes-sigs/controller-runtime/issues/347
+			if err := applyOverlay(receiver, obj); err != nil {
+				return err
+			}
+			return h.client.Update(context.TODO(), obj)
 		}
 		return nil
 	})

--- a/operator/pkg/helmreconciler/common.go
+++ b/operator/pkg/helmreconciler/common.go
@@ -18,6 +18,10 @@ import (
 	"io"
 	"strings"
 
+	jsonpatch "github.com/evanphx/json-patch"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"istio.io/istio/operator/pkg/name"
 	"istio.io/pkg/log"
 )
@@ -110,4 +114,21 @@ func buildInstallTreeString(componentName name.ComponentName, prefix string, sb 
 	for k := range InstallTree[componentName].(ComponentTree) {
 		buildInstallTreeString(k, prefix+"  ", sb)
 	}
+}
+
+// applyOverlay applies an overlay using JSON patch strategy over the current Object in place.
+func applyOverlay(current, overlay runtime.Object) error {
+	cj, err := runtime.Encode(unstructured.UnstructuredJSONScheme, current)
+	if err != nil {
+		return err
+	}
+	uj, err := runtime.Encode(unstructured.UnstructuredJSONScheme, overlay)
+	if err != nil {
+		return err
+	}
+	merged, err := jsonpatch.MergePatch(cj, uj)
+	if err != nil {
+		return err
+	}
+	return runtime.DecodeInto(unstructured.UnstructuredJSONScheme, merged, current)
 }

--- a/operator/pkg/helmreconciler/testdata/configmap-changed.yaml
+++ b/operator/pkg/helmreconciler/testdata/configmap-changed.yaml
@@ -4,6 +4,6 @@ metadata:
   name: config
   namespace: istio-system
 data:
-  # Delete a field, update a field and create a new field
+  # Can't delete a field until we mandate >= Kube 1.16. See ApplyObject comments.
   field: two
   new: new

--- a/operator/pkg/helmreconciler/testdata/configmap.yaml
+++ b/operator/pkg/helmreconciler/testdata/configmap.yaml
@@ -5,4 +5,3 @@ metadata:
   namespace: istio-system
 data:
   field: one
-  delete: me


### PR DESCRIPTION
#23663 doesn't correctly handle immutable fields in the Kube API such as `clusterIP` for services.

To correctly delete fields without writing code that handles every single immutable field in the Kube API requires server-side apply. This isn't supported in < Kube 1.16. 

Instead, we should leave as is until we choose to drop support for < 1.16.

Signed-off-by: Liam White <liam@tetrate.io>