### PR TITLE
Fix operator proto gen

### DIFF
--- a/operator/operator.mk
+++ b/operator/operator.mk
@@ -37,5 +37,5 @@ $(v1alpha1_pb_gos) $(v1alpha1_pb_docs): $(v1alpha1_protos)
 	@rm -fr ${TMPDIR}/pkg
 	@go run $(repo_dir)/operator/pkg/apis/istio/fixup_structs/main.go -f $(v1alpha1_path)/values_types.pb.go
 
-.PHONY: operator-proto
+.PHONY: operator-proto $(v1alpha1_pb_gos) $(v1alpha1_pb_docs)
 operator-proto: $(v1alpha1_pb_gos) $(v1alpha1_pb_docs)

--- a/operator/pkg/apis/istio/v1alpha1/v1alpha1.pb.html
+++ b/operator/pkg/apis/istio/v1alpha1/v1alpha1.pb.html
@@ -6821,7 +6821,7 @@ No
 <td><code>validationURL</code></td>
 <td><code>string</code></td>
 <td>
-<p>Configures the validation webbhook url.</p>
+<p>URL to use for validating webhook.</p>
 
 </td>
 <td>

--- a/operator/pkg/apis/istio/v1alpha1/values_types.pb.go
+++ b/operator/pkg/apis/istio/v1alpha1/values_types.pb.go
@@ -7474,7 +7474,7 @@ func (m *KialiConfig) GetService() *KialiServiceConfig {
 type BaseConfig struct {
 	// For Helm2 use, adds the CRDs to templates.
 	EnableCRDTemplates *protobuf.BoolValue `protobuf:"bytes,1,opt,name=enableCRDTemplates,proto3" json:"enableCRDTemplates,omitempty"`
-	// Configures the validation webbhook url.
+	// URL to use for validating webhook.
 	ValidationURL        string   `protobuf:"bytes,2,opt,name=validationURL,proto3" json:"validationURL,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`

--- a/operator/pkg/apis/istio/v1alpha1/values_types.proto
+++ b/operator/pkg/apis/istio/v1alpha1/values_types.proto
@@ -1905,6 +1905,9 @@ message KialiConfig {
 message BaseConfig {
   // For Helm2 use, adds the CRDs to templates.
   google.protobuf.BoolValue enableCRDTemplates = 1;
+
+  // URL to use for validating webhook.
+  string validationURL = 2;
 }
 
 message Values {


### PR DESCRIPTION
Previously this was not a PHONY target, but the logic must have been
wrong somewhere as the generation got messed up. The end result is all
PRs are broken even though locally things pass. This makes the target a
phony so it always runs properly