### PR TITLE
Neither validate nor suggest alternate revision injection labels

### DIFF
--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -176,7 +176,6 @@ var testGrid = []testCase{
 			{msg.NamespaceNotInjected, "Namespace bar"},
 			{msg.PodMissingProxy, "Pod noninjectedpod.default"},
 			{msg.NamespaceMultipleInjectionLabels, "Namespace busted"},
-			{msg.NamespaceInvalidInjectorRevision, "Namespace pidgeon-test"},
 		},
 	},
 	{

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -109,10 +109,6 @@ var (
 	// Description: A namespace has both new and legacy injection labels
 	NamespaceMultipleInjectionLabels = diag.NewMessageType(diag.Warning, "IST0123", "The namespace has both new and legacy injection labels. Run 'kubectl label namespace %s istio.io/rev-' or 'kubectl label namespace %s istio-injection-'")
 
-	// NamespaceInvalidInjectorRevision defines a diag.MessageType for message "NamespaceInvalidInjectorRevision".
-	// Description: A namespace is labeled to inject from unknown control plane.
-	NamespaceInvalidInjectorRevision = diag.NewMessageType(diag.Warning, "IST0124", "The namespace is labeled to inject from %q but that namespace doesn't exist. Run 'kubectl label namespace %s istio.io/rev=<revision>' where <revision> is one of %s")
-
 	// InvalidAnnotation defines a diag.MessageType for message "InvalidAnnotation".
 	// Description: An Istio annotation that is not valid
 	InvalidAnnotation = diag.NewMessageType(diag.Warning, "IST0125", "Invalid annotation %s: %s")
@@ -150,7 +146,6 @@ func All() []*diag.MessageType {
 		MeshPolicyResourceIsDeprecated,
 		InvalidRegexp,
 		NamespaceMultipleInjectionLabels,
-		NamespaceInvalidInjectorRevision,
 		InvalidAnnotation,
 		UnknownMeshNetworksServiceRegistry,
 	}
@@ -400,17 +395,6 @@ func NewNamespaceMultipleInjectionLabels(r *resource.Instance, namespace string,
 		r,
 		namespace,
 		namespace2,
-	)
-}
-
-// NewNamespaceInvalidInjectorRevision returns a new diag.Message based on NamespaceInvalidInjectorRevision.
-func NewNamespaceInvalidInjectorRevision(r *resource.Instance, unknownrevision string, namespace string, revisions string) diag.Message {
-	return diag.NewMessage(
-		NamespaceInvalidInjectorRevision,
-		r,
-		unknownrevision,
-		namespace,
-		revisions,
 	)
 }
 

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -267,19 +267,6 @@ messages:
       - name: namespace2
         type: string
 
-  - name: "NamespaceInvalidInjectorRevision"
-    code: IST0124
-    level: Warning
-    description: "A namespace is labeled to inject from unknown control plane."
-    template: "The namespace is labeled to inject from %q but that namespace doesn't exist. Run 'kubectl label namespace %s istio.io/rev=<revision>' where <revision> is one of %s"
-    args:
-      - name: unknownrevision
-        type: string
-      - name: namespace
-        type: string
-      - name: revisions
-        type: string
-
   - name: "InvalidAnnotation"
     code: IST0125
     level: Warning


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/23319

Supercedes https://github.com/istio/istio/pull/23528

This removes inventorying control planes, which won't work if the control plane is running on another cluster (or tenant.)

This preserves the warning about having both old and new injector labels.