### PR TITLE
fix annotation

### DIFF
--- a/pilot/pkg/security/authz/builder/builder.go
+++ b/pilot/pkg/security/authz/builder/builder.go
@@ -64,11 +64,11 @@ func (b Builder) BuildHTTP() []*httppb.HttpFilter {
 	var filters []*httppb.HttpFilter
 
 	if denyConfig := build(b.denyPolicies, b.trustDomainBundle,
-		false /* forTCP */, true /* forDeny */, b.isIstioVersionGE15); denyConfig != nil {
+		false /* forHTTP */, true /* forDeny */, b.isIstioVersionGE15); denyConfig != nil {
 		filters = append(filters, createHTTPFilter(denyConfig))
 	}
 	if allowConfig := build(b.allowPolicies, b.trustDomainBundle,
-		false /* forTCP */, false /* forDeny */, b.isIstioVersionGE15); allowConfig != nil {
+		false /* forHTTP */, false /* forAllow */, b.isIstioVersionGE15); allowConfig != nil {
 		filters = append(filters, createHTTPFilter(allowConfig))
 	}
 
@@ -84,7 +84,7 @@ func (b Builder) BuildTCP() []*tcppb.Filter {
 		filters = append(filters, createTCPFilter(denyConfig))
 	}
 	if allowConfig := build(b.allowPolicies, b.trustDomainBundle,
-		true /* forTCP */, false /* forDeny */, b.isIstioVersionGE15); allowConfig != nil {
+		true /* forTCP */, false /* forAllow */, b.isIstioVersionGE15); allowConfig != nil {
 		filters = append(filters, createTCPFilter(allowConfig))
 	}
 


### PR DESCRIPTION
- [x] Security

Just a PR for building filter-related annotations, no code changes involved.

Extra, I got a question on the order in which the authorization policy takes effect. I got this information from the [documentation](https://istio.io/docs/reference/config/security/authorization-policy/):

```text
Istio Authorization Policy enables access control on workloads in the mesh.

Authorization policy supports both allow and deny policies. When allow and deny policies are used for a workload at the same time, the deny policies are evaluated first. The evaluation is determined by the following rules:

1. If there are any DENY policies that match the request, deny the request.
2. If there are no ALLOW policies for the workload, allow the request.
3. If any of the ALLOW policies match the request, allow the request.
4. Deny the request.
```

In my opinion, the second and third rules already match all cases, and the third should take precedence over the second, and I'd like to know what cases would match to the fourth rule.

I tried to read the code to understand its process, but I failed and only found a minor flaw in the annotation and submitted this PR.

Finally, we know that the purpose of this code is to add a policy that is DENY by default, so at this point, how should I understand the order of the policy matches?

```yaml
apiVersion: security.istio.io/v1beta1 
kind: AuthorizationPolicy
metadata:
  name: deny-all
  namespace: default
spec:
  {}
```
