### PR TITLE
[1.5] Fix namespace configmap controller losing election lock

### DIFF
--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -226,18 +226,14 @@ func (s *Server) RunCA(grpc *grpc.Server, ca caserver.CertificateAuthority, opts
 	log.Info("Istiod CA has started")
 
 	if s.kubeClient != nil {
-		nc, err := NewNamespaceController(func() map[string]string {
-			return map[string]string{
-				constants.CACertNamespaceConfigMapDataName: string(ca.GetCAKeyCertBundle().GetRootCertPem()),
-			}
-		}, controllerOptions, s.kubeClient.CoreV1())
-		if err != nil {
-			log.Warnf("failed to start istiod namespace controller, error: %v", err)
-		} else {
-			s.leaderElection.AddRunFunction(func(stop <-chan struct{}) {
-				nc.Run(stop)
-			})
-		}
+		s.leaderElection.AddRunFunction(func(stop <-chan struct{}) {
+			nc := NewNamespaceController(func() map[string]string {
+				return map[string]string{
+					constants.CACertNamespaceConfigMapDataName: string(ca.GetCAKeyCertBundle().GetRootCertPem()),
+				}
+			}, controllerOptions, s.kubeClient.CoreV1())
+			nc.Run(stop)
+		})
 	}
 }
 

--- a/pilot/pkg/bootstrap/namespacecontroller.go
+++ b/pilot/pkg/bootstrap/namespacecontroller.go
@@ -64,7 +64,7 @@ type NamespaceController struct {
 }
 
 // NewNamespaceController returns a pointer to a newly constructed NamespaceController instance.
-func NewNamespaceController(data func() map[string]string, options controller.Options, core corev1.CoreV1Interface) (*NamespaceController, error) {
+func NewNamespaceController(data func() map[string]string, options controller.Options, core corev1.CoreV1Interface) *NamespaceController {
 	c := &NamespaceController{
 		getData: data,
 		core:    core,
@@ -139,7 +139,7 @@ func NewNamespaceController(data func() map[string]string, options controller.Op
 				})
 			},
 		})
-	return c, nil
+	return c
 }
 
 // Run starts the NamespaceController until a value is sent to stopCh.

--- a/pilot/pkg/bootstrap/namespacecontroller_test.go
+++ b/pilot/pkg/bootstrap/namespacecontroller_test.go
@@ -33,12 +33,10 @@ import (
 func TestNamespaceController(t *testing.T) {
 	client := fake.NewSimpleClientset()
 	testdata := map[string]string{"key": "value"}
-	nc, err := NewNamespaceController(func() map[string]string {
+	nc := NewNamespaceController(func() map[string]string {
 		return testdata
 	}, controller.Options{}, client.CoreV1())
-	if err != nil {
-		t.Fatal(err)
-	}
+
 	stop := make(chan struct{})
 	nc.Run(stop)
 


### PR DESCRIPTION
Backport of
https://github.com/istio/istio/commit/77304211dc0c75820ab9cd2f2fe03e5d5211edca.
I have confirmed this fixes https://github.com/istio/istio/issues/22463,
as I can reliably reproduce and have witness all of the logs in the
issue lose the election at some point