### PR TITLE
Overlays for cluster resources

### DIFF
--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -292,7 +292,7 @@ func TestManifestGeneratePilot(t *testing.T) {
 		},
 		{
 			desc:       "pilot_override_kubernetes",
-			diffSelect: "Deployment:*:istiod, Service:*:istiod",
+			diffSelect: "Deployment:*:istiod, Service:*:istiod,MutatingWebhookConfiguration:*:istio-sidecar-injector",
 		},
 		// TODO https://github.com/istio/istio/issues/22347 this is broken for overriding things to default value
 		// This can be seen from REGISTRY_ONLY not applying

--- a/operator/cmd/mesh/testdata/manifest-generate/input/pilot_override_kubernetes.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/input/pilot_override_kubernetes.yaml
@@ -38,3 +38,10 @@ spec:
             patches:
               - path: spec.ports.[name:https-dns].port
                 value: 11111 # OVERRIDDEN
+          # Cluster scope resource
+          - kind: MutatingWebhookConfiguration
+            name: istio-sidecar-injector
+            patches:
+              - path: webhooks.[name:sidecar-injector\.istio\.io].clientConfig.service.name
+                value: foo
+

--- a/operator/cmd/mesh/testdata/manifest-generate/input/pilot_override_kubernetes.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/input/pilot_override_kubernetes.yaml
@@ -9,6 +9,7 @@ spec:
   components:
     pilot:
       enabled: true
+      namespace: istio-control
       k8s:
         resources:
           requests:
@@ -40,7 +41,7 @@ spec:
                 value: 11111 # OVERRIDDEN
           # Cluster scope resource
           - kind: MutatingWebhookConfiguration
-            name: istio-sidecar-injector
+            name: istio-sidecar-injector-istio-control
             patches:
               - path: webhooks.[name:sidecar-injector\.istio\.io].clientConfig.service.name
                 value: foo

--- a/operator/cmd/mesh/testdata/manifest-generate/input/pilot_override_kubernetes.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/input/pilot_override_kubernetes.yaml
@@ -9,7 +9,6 @@ spec:
   components:
     pilot:
       enabled: true
-      namespace: istio-control
       k8s:
         resources:
           requests:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/gateways.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/gateways.golden.yaml
@@ -720,6 +720,28 @@ metadata:
 ---
 
 ---
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: ilb-gateway
+  namespace: user-ingressgateway-ns
+  labels:
+    app: istio-ingressgateway
+    istio: ingressgateway
+    release: istio
+spec:
+  maxReplicas: 5
+  minReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: ilb-gateway
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: 80
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -923,28 +945,6 @@ spec:
           optional: true
           secretName: istio-ingressgateway-ca-certs
 
----
-apiVersion: autoscaling/v2beta1
-kind: HorizontalPodAutoscaler
-metadata:
-  name: ilb-gateway
-  namespace: user-ingressgateway-ns
-  labels:
-    app: istio-ingressgateway
-    istio: ingressgateway
-    release: istio
-spec:
-  maxReplicas: 5
-  minReplicas: 1
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: ilb-gateway
-  metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        targetAverageUtilization: 80
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_kubernetes.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_kubernetes.golden.yaml
@@ -5,13 +5,13 @@ metadata:
     app: sidecar-injector
     istio.io/rev: default
     release: istio
-  name: istio-sidecar-injector
+  name: istio-sidecar-injector-istio-control
 webhooks:
 - clientConfig:
     caBundle: ""
     service:
       name: foo
-      namespace: istio-system
+      namespace: istio-control
       path: /inject
   failurePolicy: Fail
   name: sidecar-injector.istio.io
@@ -39,7 +39,7 @@ metadata:
     istio.io/rev: default
     release: istio
   name: istiod
-  namespace: istio-system
+  namespace: istio-control
 spec:
   selector:
     matchLabels:
@@ -94,9 +94,9 @@ spec:
         - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND
           value: "true"
         - name: INJECTION_WEBHOOK_CONFIG_NAME
-          value: istio-sidecar-injector
+          value: istio-sidecar-injector-istio-control
         - name: ISTIOD_ADDR
-          value: istiod.istio-system.svc:15012
+          value: istiod.istio-control.svc:15012
         - name: PILOT_ENABLE_ANALYSIS
           value: "false"
         - name: CLUSTER_ID
@@ -170,7 +170,7 @@ metadata:
     istio.io/rev: default
     release: istio
   name: istiod
-  namespace: istio-system
+  namespace: istio-control
 spec:
   ports:
   - name: grpc-xds

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_kubernetes.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_kubernetes.golden.yaml
@@ -1,3 +1,35 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    app: sidecar-injector
+    istio.io/rev: default
+    release: istio
+  name: istio-sidecar-injector
+webhooks:
+- clientConfig:
+    caBundle: ""
+    service:
+      name: foo
+      namespace: istio-system
+      path: /inject
+  failurePolicy: Fail
+  name: sidecar-injector.istio.io
+  namespaceSelector:
+    matchLabels:
+      istio-injection: enabled
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+---
+
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_kubernetes.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_kubernetes.golden.yaml
@@ -7,7 +7,7 @@ metadata:
     istio.io/rev: default
     release: istio
   name: istiod
-  namespace: istio-control
+  namespace: istio-system
 spec:
   selector:
     matchLabels:
@@ -62,9 +62,9 @@ spec:
         - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND
           value: "true"
         - name: INJECTION_WEBHOOK_CONFIG_NAME
-          value: istio-sidecar-injector-istio-control
+          value: istio-sidecar-injector
         - name: ISTIOD_ADDR
-          value: istiod.istio-control.svc:15012
+          value: istiod.istio-system.svc:15012
         - name: PILOT_ENABLE_ANALYSIS
           value: "false"
         - name: CLUSTER_ID
@@ -138,7 +138,7 @@ metadata:
     istio.io/rev: default
     release: istio
   name: istiod
-  namespace: istio-control
+  namespace: istio-system
 spec:
   ports:
   - name: grpc-xds

--- a/operator/pkg/object/objects.go
+++ b/operator/pkg/object/objects.go
@@ -236,6 +236,15 @@ func (os K8sObjects) String() string {
 	return strings.Join(out, helm.YAMLSeparator)
 }
 
+// Keys returns a slice with the keys of os.
+func (os K8sObjects) Keys() []string {
+	var out []string
+	for _, oo := range os {
+		out = append(out, oo.Hash())
+	}
+	return out
+}
+
 // ParseK8sObjectsFromYAMLManifest returns a K8sObjects representation of manifest.
 func ParseK8sObjectsFromYAMLManifest(manifest string) (K8sObjects, error) {
 	return ParseK8sObjectsFromYAMLManifestFailOption(manifest, true)

--- a/operator/pkg/patch/patch.go
+++ b/operator/pkg/patch/patch.go
@@ -85,13 +85,12 @@ package patch
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
-	"github.com/kr/pretty"
 	"gopkg.in/yaml.v2"
 
 	"istio.io/api/operator/v1alpha1"
+	"istio.io/istio/operator/pkg/helm"
 	"istio.io/istio/operator/pkg/object"
 	"istio.io/istio/operator/pkg/tpath"
 	"istio.io/istio/operator/pkg/util"
@@ -102,90 +101,75 @@ var (
 	scope = log.RegisterScope("patch", "patch", 0)
 )
 
+// overlayMatches reports whether obj matches the overlay for either the default namespace or no namespace (cluster scope).
+func overlayMatches(overlay *v1alpha1.K8SObjectOverlay, obj *object.K8sObject, defaultNamespace string) bool {
+	oh := obj.Hash()
+	if oh == object.Hash(overlay.Kind, defaultNamespace, overlay.Name) ||
+		oh == object.Hash(overlay.Kind, "", overlay.Name) {
+		return true
+	}
+	return false
+}
+
 // YAMLManifestPatch patches a base YAML in the given namespace with a list of overlays.
 // Each overlay has the format described in the K8SObjectOverlay definition.
 // It returns the patched manifest YAML.
-func YAMLManifestPatch(baseYAML string, namespace string, overlays []*v1alpha1.K8SObjectOverlay) (string, error) {
-	baseObjs, err := object.ParseK8sObjectsFromYAMLManifest(baseYAML)
+func YAMLManifestPatch(baseYAML string, defaultNamespace string, overlays []*v1alpha1.K8SObjectOverlay) (string, error) {
+	var ret strings.Builder
+	var errs util.Errors
+	objs, err := object.ParseK8sObjectsFromYAMLManifest(baseYAML)
 	if err != nil {
 		return "", err
 	}
 
-	bom := baseObjs.ToMap()
-	oom := objectOverrideMap(overlays, namespace)
-
-	var ret strings.Builder
-
-	var errs util.Errors
-	keys := make([]string, 0)
-	for key := range oom {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
+	matches := make(map[*v1alpha1.K8SObjectOverlay]object.K8sObjects)
 	// Try to apply the defined overlays.
-	for _, k := range keys {
-		oo := oom[k]
-		bo := bom[k]
-		if bo == nil {
-			os := ""
-			for k2 := range bom {
-				os += k2 + "\n"
+	for _, obj := range objs {
+		oy, err := obj.YAML()
+		if err != nil {
+			errs = util.AppendErr(errs, fmt.Errorf("object to YAML error (%s) for base object: \n%s", err, obj.YAMLDebugString()))
+			continue
+		}
+		oys := string(oy)
+		for _, overlay := range overlays {
+			if overlayMatches(overlay, obj, defaultNamespace) {
+				matches[overlay] = append(matches[overlay], obj)
+				var errs2 util.Errors
+				oys, errs2 = applyPatches(obj, overlay.Patches)
+				errs = util.AppendErrs(errs, errs2)
 			}
-			errs = util.AppendErr(errs, fmt.Errorf("overlay for %s does not match any object in output manifest:\n%s\n\nAvailable objects are:\n%s",
-				k, pretty.Sprint(oo), os))
-			continue
 		}
-		patched, err := applyPatches(bo, oo)
-		if err != nil {
-			errs = util.AppendErr(errs, fmt.Errorf("patch error: %s", err))
-			continue
-		}
-		if _, err := ret.Write(patched); err != nil {
-			errs = util.AppendErr(errs, fmt.Errorf("write: %s", err))
-		}
-		if _, err := ret.WriteString("\n---\n"); err != nil {
-			errs = util.AppendErr(errs, fmt.Errorf("patch WriteString error: %s", err))
-		}
-	}
-	// Render the remaining objects with no overlays.
-	// keep the original sorted order
-	keys = make([]string, 0)
-	for key := range bom {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		oo := bom[k]
-		if oom[k] != nil {
-			// Skip objects that have overlays, these were rendered above.
-			continue
-		}
-		oy, err := oo.YAML()
-		if err != nil {
-			errs = util.AppendErr(errs, fmt.Errorf("object to YAML error (%s) for base object: \n%v", err, oo))
-			continue
-		}
-		if _, err := ret.Write(oy); err != nil {
-			errs = util.AppendErr(errs, fmt.Errorf("write: %s", err))
-		}
-		if _, err := ret.WriteString("\n---\n"); err != nil {
+		if _, err := ret.WriteString(oys + helm.YAMLSeparator); err != nil {
 			errs = util.AppendErr(errs, fmt.Errorf("writeString: %s", err))
 		}
 	}
+
+	for _, overlay := range overlays {
+		// Each overlay should have exactly one match in the output manifest.
+		switch {
+		case len(matches[overlay]) == 0:
+			errs = util.AppendErr(errs, fmt.Errorf("overlay for %s:%s does not match any object in output manifest. Available objects are:\n%s",
+				overlay.Kind, overlay.Name, strings.Join(objs.Keys(), "\n")))
+		case len(matches[overlay]) > 1:
+			errs = util.AppendErr(errs, fmt.Errorf("overlay for %s:%s matches multiple objects in output manifest:\n%s\n\n",
+				overlay.Kind, overlay.Name, strings.Join(objs.Keys(), "\n")))
+		}
+	}
+
 	return ret.String(), errs.ToError()
 }
 
 // applyPatches applies the given patches against the given object. It returns the resulting patched YAML if successful,
 // or a list of errors otherwise.
-func applyPatches(base *object.K8sObject, patches []*v1alpha1.K8SObjectOverlay_PathValue) (outYAML []byte, errs util.Errors) {
+func applyPatches(base *object.K8sObject, patches []*v1alpha1.K8SObjectOverlay_PathValue) (outYAML string, errs util.Errors) {
 	bo := make(map[interface{}]interface{})
 	by, err := base.YAML()
 	if err != nil {
-		return nil, util.NewErrs(err)
+		return "", util.NewErrs(err)
 	}
 	err = yaml.Unmarshal(by, bo)
 	if err != nil {
-		return nil, util.NewErrs(err)
+		return "", util.NewErrs(err)
 	}
 	for _, p := range patches {
 		if strings.TrimSpace(p.Path) == "" {
@@ -202,17 +186,7 @@ func applyPatches(base *object.K8sObject, patches []*v1alpha1.K8SObjectOverlay_P
 	}
 	oy, err := yaml.Marshal(bo)
 	if err != nil {
-		return nil, util.AppendErr(errs, err)
+		return "", util.AppendErr(errs, err)
 	}
-	return oy, errs
-}
-
-// objectOverrideMap converts oos, a slice of object overlays, into a map of the same overlays where the key is the
-// object manifest.Hash.
-func objectOverrideMap(oos []*v1alpha1.K8SObjectOverlay, namespace string) map[string][]*v1alpha1.K8SObjectOverlay_PathValue {
-	ret := make(map[string][]*v1alpha1.K8SObjectOverlay_PathValue)
-	for _, o := range oos {
-		ret[object.Hash(o.Kind, namespace, o.Name)] = o.Patches
-	}
-	return ret
+	return string(oy), errs
 }

--- a/operator/pkg/patch/patch.go
+++ b/operator/pkg/patch/patch.go
@@ -151,7 +151,7 @@ func YAMLManifestPatch(baseYAML string, defaultNamespace string, overlays []*v1a
 			errs = util.AppendErr(errs, fmt.Errorf("overlay for %s:%s does not match any object in output manifest. Available objects are:\n%s",
 				overlay.Kind, overlay.Name, strings.Join(objs.Keys(), "\n")))
 		case len(matches[overlay]) > 1:
-			errs = util.AppendErr(errs, fmt.Errorf("overlay for %s:%s matches multiple objects in output manifest:\n%s\n\n",
+			errs = util.AppendErr(errs, fmt.Errorf("overlay for %s:%s matches multiple objects in output manifest:\n%s",
 				overlay.Kind, overlay.Name, strings.Join(objs.Keys(), "\n")))
 		}
 	}

--- a/operator/pkg/patch/patch_test.go
+++ b/operator/pkg/patch/patch_test.go
@@ -205,7 +205,6 @@ a:
 			if err != nil {
 				t.Fatalf("unmarshalWithJSONPB(%s): got error %s for string:\n%s\n", tt.desc, err, oh)
 			}
-			fmt.Printf("Good header: \n%s\n", oh)
 			got, err := YAMLManifestPatch(base, "istio-system", rc.Overlays)
 			if gotErr, wantErr := errToString(err), tt.wantErr; gotErr != wantErr {
 				t.Fatalf("YAMLManifestPatch(%s): gotErr:%s, wantErr:%s", tt.desc, gotErr, wantErr)


### PR DESCRIPTION
k8s.overlays previously always assumed default top level namespace. This doesn't work for either cluster resources or resources is non-default namespaces. The full fix requires an API change and is too involved for 1.6 but this workaround checks both the default namespace and cluster scope to match resource names so it should cover most cases. It is also compatible with the future fix where namespace will be specified through the API.