### PR TITLE
Support read from stdin for proxy config

### DIFF
--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -159,9 +159,13 @@ func setupPodConfigdumpWriter(podName, podNamespace string, out io.Writer) (*con
 }
 
 func setupFileConfigdumpWriter(filename string, out io.Writer) (*configdump.ConfigWriter, error) {
-	file, err := os.Open(filename)
-	if err != nil {
-		return nil, err
+	file := os.Stdin
+	if filename != "-" {
+		var err error
+		file, err = os.Open(filename)
+		if err != nil {
+			return nil, err
+		}
 	}
 	defer func() {
 		if err := file.Close(); err != nil {


### PR DESCRIPTION
Tested with `cat ./pkg/test/framework/components/echo/common/testdata/config_dump.json | istioctl proxy-config bootstrap --file -`