### PR TITLE
examples: update multinetwork primary iop to use correct fromRegistry

### DIFF
--- a/operator/data/examples/multicluster/values-istio-multicluster-primary.yaml
+++ b/operator/data/examples/multicluster/values-istio-multicluster-primary.yaml
@@ -14,8 +14,7 @@ spec:
       meshNetworks:
         network1:
           endpoints:
-          # Always use Kubernetes as the registry name for the main cluster in the mesh network configuration
-          - fromRegistry: Kubernetes
+          - fromRegistry: main0
           gateways:
           - registry_service_name: istio-ingressgateway.istio-system.svc.cluster.local
             port: 443


### PR DESCRIPTION
cluster-local hostnames will not be pushed to any proxies in the primary network if networks are configured and we don't set `meshNetworks.{mainNetwork}.endpoints[].fromRegistry` to the cluster name. The current examples show Kubernetes as the correct value but this fails the check in [initNetworkLookup](https://github.com/istio/istio/blob/f584ba92977e48d0d6b173c6e2d80ba511a701fe/pilot/pkg/serviceregistry/kube/controller/controller.go#L1077).

There is no way that cluster-1 will have a ranger entry or have "networkForRegistry" set if fromRegistry isn't the clusterID.

Because of this, node.ClusterID will not be set in [GetProxyServiceInstances](https://github.com/istio/istio/blob/f584ba92977e48d0d6b173c6e2d80ba511a701fe/pilot/pkg/serviceregistry/aggregate/controller.go#L293
).

This also means on the `*model.Proxy` instances used in the rest of the eds code, the clusterID will be "", making it not match in cluster-local checks.

I've backtested to 1.5 and the combination of setting up a meshNetworks configuration and setting hosts to be cluster-local prevents cluster-local endpoints from being pushed at all. 

The cause of this I believe, is that the [default](https://github.com/istio/istio/blob/f584ba92977e48d0d6b173c6e2d80ba511a701fe/pilot/pkg/features/pilot.go#L298) ClusterID of pilot gets overridden by `values.global.multiCluster.clusterName`. 

[ ] Configuration Infrastructure
[] Docs
[X] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure