### PR TITLE
use clusterID from metadata

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -150,10 +150,6 @@ type XdsResourceGenerator interface {
 // In current Istio implementation nodes use a 4-parts '~' delimited ID.
 // Type~IPAddress~ID~Domain
 type Proxy struct {
-	// ClusterID specifies the cluster where the proxy resides.
-	// TODO: clarify if this is needed in the new 'network' model, likely needs to
-	// be renamed to 'network'
-	ClusterID string
 
 	// Type specifies the node type. First part of the ID.
 	Type NodeType

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -578,8 +578,8 @@ func ParseSubsetKey(s string) (direction TrafficDirection, subsetName string, ho
 func (s *Service) GetServiceAddressForProxy(node *Proxy) string {
 	s.Mutex.RLock()
 	defer s.Mutex.RUnlock()
-	if node.ClusterID != "" && s.ClusterVIPs[node.ClusterID] != "" {
-		return s.ClusterVIPs[node.ClusterID]
+	if node.Metadata != nil && node.Metadata.ClusterID != "" && s.ClusterVIPs[node.Metadata.ClusterID] != "" {
+		return s.ClusterVIPs[node.Metadata.ClusterID]
 	}
 	return s.Address
 }

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -271,7 +271,7 @@ func buildLocalityLbEndpoints(proxy *model.Proxy, push *model.PushContext, proxy
 		}
 		// If the downstream service is configured as cluster-local, only include endpoints that
 		// reside in the same cluster.
-		if isClusterLocal && (proxy.ClusterID != instance.Endpoint.Locality.ClusterID) {
+		if isClusterLocal && (proxy.Metadata.ClusterID != instance.Endpoint.Locality.ClusterID) {
 			continue
 		}
 		addr := util.BuildAddress(instance.Endpoint.Address, instance.Endpoint.EndpointPort)

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -404,11 +404,14 @@ func buildTestClustersWithProxyMetadataWithIps(serviceHostname string, serviceRe
 	}
 	env := newTestEnvironment(serviceDiscovery, mesh, configStore)
 
+	if meta.ClusterID == "" {
+		meta.ClusterID = "some-cluster-id"
+	}
+
 	var proxy *model.Proxy
 	switch nodeType {
 	case model.SidecarProxy:
 		proxy = &model.Proxy{
-			ClusterID:    "some-cluster-id",
 			Type:         model.SidecarProxy,
 			IPAddresses:  proxyIps,
 			Locality:     locality,
@@ -418,7 +421,6 @@ func buildTestClustersWithProxyMetadataWithIps(serviceHostname string, serviceRe
 		}
 	case model.Router:
 		proxy = &model.Proxy{
-			ClusterID:    "some-cluster-id",
 			Type:         model.Router,
 			IPAddresses:  []string{"6.6.6.6"},
 			Locality:     locality,
@@ -1437,7 +1439,9 @@ func TestGatewayLocalityLB(t *testing.T) {
 
 func TestBuildLocalityLbEndpoints(t *testing.T) {
 	proxy := &model.Proxy{
-		ClusterID: "cluster-1",
+		Metadata: &model.NodeMetadata{
+			ClusterID: "cluster-1",
+		},
 	}
 	servicePort := &model.Port{
 		Name:     "default",
@@ -2368,10 +2372,11 @@ func TestBuildStaticClusterWithNoEndPoint(t *testing.T) {
 
 	configStore := &fakes.IstioConfigStore{}
 	proxy := &model.Proxy{
-		ClusterID: "some-cluster-id",
 		Type:      model.SidecarProxy,
 		DNSDomain: "com",
-		Metadata:  &model.NodeMetadata{},
+		Metadata: &model.NodeMetadata{
+			ClusterID: "some-cluster-id",
+		},
 	}
 	env := newTestEnvironment(serviceDiscovery, testMesh, configStore)
 	proxy.SetSidecarScope(env.PushContext)

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -692,7 +692,7 @@ func (s *DiscoveryServer) ProxyUpdate(clusterID, ip string) {
 
 	s.adsClientsMutex.RLock()
 	for _, v := range s.adsClients {
-		if v.node.ClusterID == clusterID && v.node.IPAddresses[0] == ip {
+		if v.node.Metadata.ClusterID == clusterID && v.node.IPAddresses[0] == ip {
 			connection = v
 			break
 		}

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -573,7 +573,7 @@ func buildLocalityLbEndpointsFromShards(
 	for clusterID, endpoints := range shards.Shards {
 		// If the downstream service is configured as cluster-local, only include endpoints that
 		// reside in the same cluster.
-		if isClusterLocal && (clusterID != proxy.ClusterID) {
+		if isClusterLocal && (clusterID != proxy.Metadata.ClusterID) {
 			continue
 		}
 

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -290,7 +290,6 @@ func (c *Controller) GetProxyServiceInstances(node *model.Proxy) ([]*model.Servi
 			errs = multierror.Append(errs, err)
 		} else if len(instances) > 0 {
 			out = append(out, instances...)
-			node.ClusterID = instances[0].Endpoint.Locality.ClusterID
 			break
 		}
 	}

--- a/tests/integration/mixer/outboundtrafficpolicy/allowany/egressproxy/traffic_allow_any_egressproxy_test.go
+++ b/tests/integration/mixer/outboundtrafficpolicy/allowany/egressproxy/traffic_allow_any_egressproxy_test.go
@@ -96,7 +96,7 @@ func setupTest(t *testing.T, ctx resource.Context, modifyConfig func(c Config) C
 	time.Sleep(time.Second * 2)
 
 	nodeID := &model.Proxy{
-		ClusterID:       "integration-test",
+		Metadata:        &model.NodeMetadata{ClusterID: "integration-test"},
 		ID:              fmt.Sprintf("httpbin.%s", appNamespace.Name()),
 		DNSDomain:       appNamespace.Name() + ".cluster.local",
 		Type:            model.SidecarProxy,

--- a/tests/integration/pilot/envoyfilter/main_test.go
+++ b/tests/integration/pilot/envoyfilter/main_test.go
@@ -199,7 +199,7 @@ func setupTest(t *testing.T, ctx resource.Context, modifyConfig func(c Config) C
 	time.Sleep(time.Second * 2)
 
 	nodeID := &model.Proxy{
-		ClusterID:       "integration-test",
+		Metadata:        &model.NodeMetadata{ClusterID: "integration-test"},
 		ID:              fmt.Sprintf("httpbin.%s", appNamespace.Name()),
 		DNSDomain:       appNamespace.Name() + ".cluster.local",
 		Type:            model.SidecarProxy,

--- a/tests/integration/pilot/sidecar_api_test.go
+++ b/tests/integration/pilot/sidecar_api_test.go
@@ -38,7 +38,7 @@ func TestSidecarListeners(t *testing.T) {
 
 			// Simulate proxy identity of a sidecar ...
 			nodeID := &model.Proxy{
-				ClusterID:    "integration-test",
+				Metadata:     &model.NodeMetadata{ClusterID: "integration-test"},
 				Type:         model.SidecarProxy,
 				IPAddresses:  []string{"10.2.0.1"},
 				ID:           "app3.testns",

--- a/tests/integration/pilot/sidecarscope/main_test.go
+++ b/tests/integration/pilot/sidecarscope/main_test.go
@@ -233,7 +233,7 @@ func setupTest(t *testing.T, ctx resource.Context, modifyConfig func(c Config) C
 	time.Sleep(time.Second * 2)
 
 	nodeID := &model.Proxy{
-		ClusterID:       "integration-test",
+		Metadata:        &model.NodeMetadata{ClusterID: "integration-test"},
 		ID:              fmt.Sprintf("app.%s", appNamespace.Name()),
 		DNSDomain:       appNamespace.Name() + ".cluster.local",
 		Type:            model.SidecarProxy,


### PR DESCRIPTION
```go
// ClusterID specifies the cluster where the proxy resides.	
// TODO: clarify if this is needed in the new 'network' model, likely needs to	
// be renamed to 'network'	
ClusterID string
```


We rely on complex logic to get the clusterID for a proxy rather than using what's provided directly be metadata. The logic depends on the registry/Controller having it's network setup properly if using meshNetwork config (see #https://github.com/istio/istio/pull/23825)

Overall this simplifies getting the cluster ID for a proxy. 