### PR TITLE
[release-1.6] Update cni/sha and other dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -158,8 +158,8 @@ require (
 	gopkg.in/yaml.v2 v2.2.8
 	helm.sh/helm/v3 v3.2.0
 	istio.io/api v0.0.0-20200512133658-88979697a95e
-	istio.io/gogo-genproto v0.0.0-20200422223746-8166b73efbae
-	istio.io/pkg v0.0.0-20200427191155-bf8aca030541
+	istio.io/gogo-genproto v0.0.0-20200511213158-02f1fd1746e5
+	istio.io/pkg v0.0.0-20200511212725-7bfbbf968c23
 	k8s.io/api v0.18.1
 	k8s.io/apiextensions-apiserver v0.18.0
 	k8s.io/apimachinery v0.18.1

--- a/go.sum
+++ b/go.sum
@@ -1064,10 +1064,10 @@ istio.io/api v0.0.0-20190515205759-982e5c3888c6/go.mod h1:hhLFQmpHia8zgaM37vb2ml
 istio.io/api v0.0.0-20200512133658-88979697a95e h1:JnVVAxwKtyL+dUMP1d6am82SYuhtF+7mY+e0+dmCSVg=
 istio.io/api v0.0.0-20200512133658-88979697a95e/go.mod h1:kyq3g5w42zl/AKlbzDGppYpGMQYMYMyZKeq0/eexML8=
 istio.io/gogo-genproto v0.0.0-20190930162913-45029607206a/go.mod h1:OzpAts7jljZceG4Vqi5/zXy/pOg1b209T3jb7Nv5wIs=
-istio.io/gogo-genproto v0.0.0-20200422223746-8166b73efbae h1:75+HSZKEDxbykK8QUoRzZzg6qESemAItGGeBkG/hrU4=
-istio.io/gogo-genproto v0.0.0-20200422223746-8166b73efbae/go.mod h1:OzpAts7jljZceG4Vqi5/zXy/pOg1b209T3jb7Nv5wIs=
-istio.io/pkg v0.0.0-20200427191155-bf8aca030541 h1:0v3n5/zaM8IUzA9AdP8rTjFxSUI5ZBirCbPBIzLriys=
-istio.io/pkg v0.0.0-20200427191155-bf8aca030541/go.mod h1:pwGaxLUDLobzL/WvWV94z72LvBbB1dr2UUUyPuasfIU=
+istio.io/gogo-genproto v0.0.0-20200511213158-02f1fd1746e5 h1:+jL9OzDdbpqHghV6i1dDy2jV+FtC7wz+CuKi2UxZoSs=
+istio.io/gogo-genproto v0.0.0-20200511213158-02f1fd1746e5/go.mod h1:OzpAts7jljZceG4Vqi5/zXy/pOg1b209T3jb7Nv5wIs=
+istio.io/pkg v0.0.0-20200511212725-7bfbbf968c23 h1:1GMOTQs9yVdNEBmVKxDlq6ios80gIAOMO1WfKYKYjZo=
+istio.io/pkg v0.0.0-20200511212725-7bfbbf968c23/go.mod h1:pwGaxLUDLobzL/WvWV94z72LvBbB1dr2UUUyPuasfIU=
 k8s.io/api v0.0.0-20190918155943-95b840bb6a1f/go.mod h1:uWuOHnjmNrtQomJrvEBg0c0HRNyQ+8KTEERVsK0PW48=
 k8s.io/api v0.17.0/go.mod h1:npsyOePkeP0CPwyGfXDHxvypiYMJxBWAMpQxCaJ4ZxI=
 k8s.io/api v0.18.0/go.mod h1:q2HRQkfDzHMBZL9l/y9rH63PkQl4vae0xRT+8prbrK8=

--- a/istio.deps
+++ b/istio.deps
@@ -11,6 +11,6 @@
     "name": "CNI_REPO_SHA",
     "repoName": "cni",
     "file": "",
-    "lastStableSHA": "6466fb920c1588cebe4eff0768b6fb7f97bd1ced"
+    "lastStableSHA": "a22a70685ae7059d044bf92c567d82552df76587"
   }
 ]

--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -32,7 +32,7 @@ DOCKER_HUB=${DOCKER_HUB:-gcr.io/istio-testing}
 GCS_BUCKET=${GCS_BUCKET:-istio-build/dev}
 
 # Use a pinned version in case breaking changes are needed
-BUILDER_SHA=da65893f8a333034dc6ff0bee835a5cc79dd58c3
+BUILDER_SHA=1d85dc7aedecf96dceaa0c6ca7a74b43767e5e47
 
 # Reference to the next minor version of Istio
 # This will create a version like 1.4-alpha.sha


### PR DESCRIPTION
The same as https://github.com/istio/istio/pull/23830, but since make gen was failing I'll over ownership. I will test this on OpenShift 4.3.5 when this gets merged.

Run `UPDATE_BRANCH=release-1.6 ./bin/update_deps.sh; make gen`