### PR TITLE
[release-1.6] Backport PR #23570 to release-1.6

### DIFF
--- a/manifests/charts/gateways/istio-egress/templates/serviceaccount.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/serviceaccount.yaml
@@ -8,7 +8,7 @@ imagePullSecrets:
 {{- end }}
 {{- end }}
 metadata:
-  name: istio-egressgateway-service-account
+  name: {{ $gateway.name | default "istio-egressgateway" }}-service-account
   namespace: {{ .Release.Namespace }}
   labels:
 {{ $gateway.labels | toYaml | indent 4 }}

--- a/manifests/charts/gateways/istio-ingress/templates/role.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: istio-ingressgateway-sds
+  name: {{ $gateway.name | default "istio-ingressgateway" }}-sds
   namespace: {{ .Release.Namespace }}
   labels:
     release: {{ .Release.Name }}

--- a/manifests/charts/gateways/istio-ingress/templates/rolebindings.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/rolebindings.yaml
@@ -2,15 +2,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: istio-ingressgateway-sds
+  name: {{ $gateway.name | default "istio-ingressgateway" }}-sds
   namespace: {{ .Release.Namespace }}
   labels:
     release: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: istio-ingressgateway-sds
+  name: {{ $gateway.name | default "istio-ingressgateway" }}-sds
 subjects:
 - kind: ServiceAccount
-  name: istio-ingressgateway-service-account
+  name: {{ $gateway.name | default "istio-ingressgateway" }}-service-account
 ---

--- a/manifests/charts/gateways/istio-ingress/templates/serviceaccount.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/serviceaccount.yaml
@@ -8,7 +8,7 @@ imagePullSecrets:
 {{- end }}
 {{- end }}
 metadata:
-  name: istio-ingressgateway-service-account
+  name: {{ $gateway.name | default "istio-ingressgateway" }}-service-account
   namespace: {{ .Release.Namespace }}
   labels:
 {{ $gateway.labels | toYaml | trim | indent 4 }}

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -171,12 +171,9 @@ func TestManifestGenerateGateways(t *testing.T) {
 	g.Expect(objs.kind(name.HPAStr).size()).Should(Equal(3))
 	g.Expect(objs.kind(name.PDBStr).size()).Should(Equal(3))
 	g.Expect(objs.kind(name.ServiceStr).size()).Should(Equal(3))
-
-	// Two namespaces so two sets of these.
-	// istio-ingressgateway and user-ingressgateway share these as they are in the same namespace (istio-system).
-	g.Expect(objs.kind(name.RoleStr).size()).Should(Equal(2))
-	g.Expect(objs.kind(name.RoleBindingStr).size()).Should(Equal(2))
-	g.Expect(objs.kind(name.SAStr).size()).Should(Equal(2))
+	g.Expect(objs.kind(name.RoleStr).size()).Should(Equal(3))
+	g.Expect(objs.kind(name.RoleBindingStr).size()).Should(Equal(3))
+	g.Expect(objs.kind(name.SAStr).size()).Should(Equal(3))
 
 	dobj := mustGetDeployment(g, objs, "istio-ingressgateway")
 	d := dobj.Unstructured()


### PR DESCRIPTION



As described in #23303, this backports #23570 the custom resource names in gateway setup