### PR TITLE
hard disable sidecar injection in istio-cni pods

### DIFF
--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -27,6 +27,7 @@ spec:
         # priority scheduling and that its resources are reserved
         # if it ever gets evicted.
         scheduler.alpha.kubernetes.io/critical-pod: ''
+        sidecar.istio.io/inject: "false"
         {{- if .Values.cni.podAnnotations }}
 {{ toYaml .Values.cni.podAnnotations | indent 8 }}
         {{- end }}


### PR DESCRIPTION

I use Istio in a namespace other than `istio-system`, it would be good to have this annotation as with the other istio-related resources