### PR TITLE
Remove vestige of a failed experiment

### DIFF
--- a/operator/data/examples/multicluster/values-istio-multicluster-gateways.yaml
+++ b/operator/data/examples/multicluster/values-istio-multicluster-gateways.yaml
@@ -15,7 +15,6 @@ spec:
       # Provides dns resolution for global services
       podDNSSearchNamespaces:
         - global
-        - "{{ valueOrDefault .DeploymentMeta.Namespace \"default\" }}.global"
 
       multiCluster:
         enabled: true


### PR DESCRIPTION
Partially-Fixes: https://github.com/istio/istio/issues/23871

This is just one approach. The other, possibly more viable approach if the release managers do not wish to create a new beta, is to document the IOP directly in the documentation. While that is not optimal, it does have some advantages.