### PR TITLE
[Test Framework] Allow customizing kube Accessor creation

### DIFF
--- a/pkg/test/framework/components/environment/kube/flags.go
+++ b/pkg/test/framework/components/environment/kube/flags.go
@@ -38,8 +38,9 @@ var (
 	controlPlaneTopology string
 )
 
-// newSettingsFromCommandline returns Settings obtained from command-line flags. flag.Parse must be called before calling this function.
-func newSettingsFromCommandline() (*Settings, error) {
+// NewSettingsFromCommandLine returns Settings obtained from command-line flags.
+// flag.Parse must be called before calling this function.
+func NewSettingsFromCommandLine() (*Settings, error) {
 	if !flag.Parsed() {
 		panic("flag.Parse must be called before this function")
 	}


### PR DESCRIPTION
This is a follow-on to the work in #23759, which does the following:

1. Allows customization of the kube client transport
2. Uses kube client for all Accessor operations (rather than kubectl)

This PR is independent, however, and can be submitted prior to #23759.