### PR TITLE
sds: skip reading jwt token for file mounted certs

### DIFF
--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -267,6 +267,7 @@ func (sc *SecretCache) GenerateSecret(ctx context.Context, connectionID, resourc
 
 	// First try to generate secret from file.
 	sdsFromFile, ns, err := sc.generateFileSecret(connKey, token)
+	fmt.Println(sdsFromFile)
 
 	if sdsFromFile {
 		if err != nil {

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -267,7 +267,6 @@ func (sc *SecretCache) GenerateSecret(ctx context.Context, connectionID, resourc
 
 	// First try to generate secret from file.
 	sdsFromFile, ns, err := sc.generateFileSecret(connKey, token)
-	fmt.Println(sdsFromFile)
 
 	if sdsFromFile {
 		if err != nil {

--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -128,6 +128,9 @@ type Options struct {
 	// The type of Elliptical Signature algorithm to use
 	// when generating private keys. Currently only ECDSA is supported.
 	ECCSigAlg string
+
+	// FileMountedCerts indicates file mounted certs.
+	FileMountedCerts bool
 }
 
 // Server is the gPRC server that exposes SDS through UDS.
@@ -146,7 +149,7 @@ type Server struct {
 // NewServer creates and starts the Grpc server for SDS.
 func NewServer(options Options, workloadSecretCache, gatewaySecretCache cache.SecretManager) (*Server, error) {
 	s := &Server{
-		workloadSds: newSDSService(workloadSecretCache, false, options.UseLocalJWT,
+		workloadSds: newSDSService(workloadSecretCache, options.FileMountedCerts, options.UseLocalJWT,
 			options.RecycleInterval, options.JWTPath, options.OutputKeyCertToDir),
 		gatewaySds: newSDSService(gatewaySecretCache, true, options.UseLocalJWT,
 			options.RecycleInterval, options.JWTPath, options.OutputKeyCertToDir),


### PR DESCRIPTION
Followup of https://github.com/istio/istio/pull/23647. For file mounted certs, SDS service needs to skip token 