### PR TITLE
pilot: cluster use select all endpoints if label is empty

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -99,8 +99,12 @@ func (cb *ClusterBuilder) applyDestinationRule(proxy *model.Proxy, cluster *apiv
 		// clusters with discovery type STATIC, STRICT_DNS rely on cluster.hosts field
 		// ServiceEntry's need to filter hosts based on subset.labels in order to perform weighted routing
 		var lbEndpoints []*endpoint.LocalityLbEndpoints
-		if cluster.GetType() != apiv2.Cluster_EDS && len(subset.Labels) != 0 {
-			lbEndpoints = buildLocalityLbEndpoints(proxy, cb.push, proxyNetworkView, service, port.Port, []labels.Instance{subset.Labels})
+		if cluster.GetType() != apiv2.Cluster_EDS {
+			if len(subset.Labels) != 0 {
+				lbEndpoints = buildLocalityLbEndpoints(proxy, cb.push, proxyNetworkView, service, port.Port, []labels.Instance{subset.Labels})
+			} else {
+				lbEndpoints = buildLocalityLbEndpoints(proxy, cb.push, proxyNetworkView, service, port.Port, nil)
+			}
 		}
 
 		subsetCluster := cb.buildDefaultCluster(subsetClusterName, cluster.GetType(), lbEndpoints,


### PR DESCRIPTION
Signed-off-by: Yuchen Dai <silentdai@gmail.com>

Thanks @howardjohn 

Fix #23821 
