### PR TITLE
Custom env addition to istio-proxy template

### DIFF
--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
         privileged: false
         readOnlyRootFilesystem: true
 {{- end }}
-      serviceAccountName: istio-egressgateway-service-account
+      serviceAccountName: {{ $gateway.name | default "istio-egressgateway" }}-service-account
 {{- if .Values.global.priorityClassName }}
       priorityClassName: "{{ .Values.global.priorityClassName }}"
 {{- end }}

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
         privileged: false
         readOnlyRootFilesystem: true
 {{- end }}
-      serviceAccountName: istio-ingressgateway-service-account
+      serviceAccountName: {{ $gateway.name | default "istio-ingressgateway" }}-service-account
 {{- if .Values.global.priorityClassName }}
       priorityClassName: "{{ .Values.global.priorityClassName }}"
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -567,6 +567,10 @@ data:
         - name: {{ $key }}
           value: "{{ $value }}"
         {{- end }}
+        {{- range $key, $val := .Values.global.proxy.env }}
+        - name: {{ $key }}
+          value: {{ $val }}
+        {{- end }}
         imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
         {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
         readinessProbe:

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -252,6 +252,10 @@ template: |
     - name: {{ $key }}
       value: "{{ $value }}"
     {{- end }}
+    {{- range $key, $val := .Values.global.proxy.env }}
+    - name: {{ $key }}
+      value: {{ $val }}
+    {{- end }}
     imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
     {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
     readinessProbe:

--- a/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -488,6 +488,10 @@ data:
         - name: {{ $key }}
           value: "{{ $value }}"
         {{- end }}
+        {{- range $key, $val := .Values.global.proxy.env }}
+        - name: {{ $key }}
+          value: {{ $val }}
+        {{- end }}
         imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
         {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
         readinessProbe:

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -252,6 +252,10 @@ template: |
     - name: {{ $key }}
       value: "{{ $value }}"
     {{- end }}
+    {{- range $key, $val := .Values.global.proxy.env }}
+    - name: {{ $key }}
+      value: {{ $val }}
+    {{- end }}
     imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
     {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
     readinessProbe:


### PR DESCRIPTION
Similar to the ingressgateway and egressgateway where a map of custom env variables can be added to the respective deployments, istio-proxy sidecar template is modified to take a map of env vars. This list would have to be copied from global.proxy.env from values file (similar to ingress and egress gateway).

This PR deals only with adding the custom env to the sidecar template. Adding this env map to global.proxy in values section needs a change to values_types.proto. I propose the latter change to be handled in a different PR. For now, one can use unvalidated section of the operator CR to pass custom environment values to the istioproxy sidecar.

ServiceAccount account name for ingress and egress gateways does not reflect the ServiceAccount of respective deployments. This shows up when users have custom gateway names instead istio-ingress-gateway or istio-egress-gateway