### PR TITLE
resolve nil pointer deference if kubectl context doesn't exist, fixes #2300

### DIFF
--- a/istioctl/pkg/install/pre-check.go
+++ b/istioctl/pkg/install/pre-check.go
@@ -83,9 +83,8 @@ func installPreCheck(istioNamespaceFlag string, restClientGetter genericclioptio
 		errs = multierror.Append(errs, fmt.Errorf("failed to initialize the Kubernetes client: %v", err))
 		fmt.Fprintf(writer, "Failed to initialize the Kubernetes client: %v.\n", err)
 		return errs
-	} else {
-		fmt.Fprintf(writer, "Can initialize the Kubernetes client.\n")
 	}
+	fmt.Fprintf(writer, "Can initialize the Kubernetes client.\n")
 	v, err := c.serverVersion()
 	if err != nil {
 		errs = multierror.Append(errs, fmt.Errorf("failed to query the Kubernetes API Server: %v", err))

--- a/istioctl/pkg/install/pre-check.go
+++ b/istioctl/pkg/install/pre-check.go
@@ -82,6 +82,7 @@ func installPreCheck(istioNamespaceFlag string, restClientGetter genericclioptio
 	if err != nil {
 		errs = multierror.Append(errs, fmt.Errorf("failed to initialize the Kubernetes client: %v", err))
 		fmt.Fprintf(writer, "Failed to initialize the Kubernetes client: %v.\n", err)
+		return errs
 	} else {
 		fmt.Fprintf(writer, "Can initialize the Kubernetes client.\n")
 	}


### PR DESCRIPTION
Fixes #23000

Signed-off-by: zillani shaik <shaikzillani@gmail.com>