### PR TITLE
enable the rotation cert test by checking the number of cert update

### DIFF
--- a/security/pkg/nodeagent/test/cert_rotation/rotation_test.go
+++ b/security/pkg/nodeagent/test/cert_rotation/rotation_test.go
@@ -25,15 +25,17 @@ import (
 )
 
 const (
-	rotateInterval = 1500 * time.Millisecond
+	rotateInterval   = 1500 * time.Millisecond
 	proxyRunningTime = 5 * rotateInterval
-	sleepTime = 100 * time.Millisecond
-	retryAttempt = 3
+	sleepTime        = 100 * time.Millisecond
+	retryAttempt     = 3
 )
+
 type void struct{}
+
 var (
 	certSet = make(map[string]void)
-	member void
+	member  void
 )
 
 func TestCertRotation(t *testing.T) {
@@ -42,7 +44,7 @@ func TestCertRotation(t *testing.T) {
 	defer setup.TearDown()
 	setup.StartProxy(t)
 	start := time.Now()
-	numReq:= 0
+	numReq := 0
 	for {
 		code, _, err := env.HTTPGet(fmt.Sprintf("http://localhost:%d/echo", setup.OutboundListenerPort))
 		if err != nil {
@@ -101,7 +103,7 @@ func TestCertRotation(t *testing.T) {
 // get Cert from the InboundListener
 func GetInboundCert(inboundListenerPort int) (string, error) {
 	return openssl("s_client", "-showcerts",
-		"-connect", fmt.Sprintf("127.0.0.1:%d",inboundListenerPort),
+		"-connect", fmt.Sprintf("127.0.0.1:%d", inboundListenerPort),
 	)
 }
 
@@ -110,7 +112,7 @@ func openssl(args ...string) (string, error) {
 	var err error
 	var out []byte
 	for attempt := 0; attempt < retryAttempt; attempt++ {
-		out, err = cmd.Output();
+		out, err = cmd.Output()
 		if err == nil {
 			return string(out), nil
 		}

--- a/security/pkg/nodeagent/test/cert_rotation/rotation_test.go
+++ b/security/pkg/nodeagent/test/cert_rotation/rotation_test.go
@@ -16,24 +16,24 @@ package rotatesds
 
 import (
 	"fmt"
+	"os/exec"
 	"testing"
 	"time"
 
 	"istio.io/istio/mixer/test/client/env"
 	sdsTest "istio.io/istio/security/pkg/nodeagent/test"
-	"os/exec"
 )
 
 const (
-	rotateInterval = 1 * time.Second
-	proxyRunningTime = 4 * rotateInterval
+	rotateInterval = 1500 * time.Millisecond
+	proxyRunningTime = 5 * rotateInterval
 	sleepTime = 100 * time.Millisecond
-	httpSuccessCode = 200
-	certShouldUpdateCount = 2
+	retryAttempt = 3
 )
-
+type void struct{}
 var (
-	certSet = make(map[string]bool)
+	certSet = make(map[string]void)
+	member void
 )
 
 func TestCertRotation(t *testing.T) {
@@ -42,65 +42,60 @@ func TestCertRotation(t *testing.T) {
 	defer setup.TearDown()
 	setup.StartProxy(t)
 	start := time.Now()
+	numReq:= 0
 	for {
 		code, _, err := env.HTTPGet(fmt.Sprintf("http://localhost:%d/echo", setup.OutboundListenerPort))
 		if err != nil {
 			t.Errorf("Failed in request: %v", err)
 		}
-		if code != httpSuccessCode {
+		if code != 200 {
 			t.Errorf("Unexpected status code: %d", code)
 		}
+		numReq++
 		if time.Since(start) > proxyRunningTime {
 			break
 		}
 		time.Sleep(sleepTime)
 		cert, err := GetInboundCert(setup.InboundListenerPort)
+
 		if err != nil {
 			continue
 		}
-		certSet[cert] = true
+		certSet[cert] = member
 	}
-	numInboundCertUpdate := len(certSet) - 1
-	if numInboundCertUpdate < certShouldUpdateCount {
-		t.Errorf("Number of inbound Cert Update should not be less than %d, get %d", certShouldUpdateCount,numInboundCertUpdate)
+
+	stats, err := setup.ProxySetup.GetStatsMap()
+	if err == nil {
+		numSSLHandshake := stats["cluster.outbound_cluster_tls.ssl.handshake"]
+		numSSLConnError := stats[fmt.Sprintf("listener.127.0.0.1_%d.ssl.connection_error", setup.InboundListenerPort)]
+		numSSLVerifyNoCert := stats[fmt.Sprintf("listener.127.0.0.1_%d.ssl.fail_verify_no_cert", setup.InboundListenerPort)]
+		numSSLVerifyCAError := stats[fmt.Sprintf("listener.127.0.0.1_%d.ssl.fail_verify_error", setup.InboundListenerPort)]
+		numOutboundSDSUpdate := stats["cluster.outbound_cluster_tls.client_ssl_socket_factory.ssl_context_update_by_sds"]
+		numInboundSDSUpdate := len(certSet) - 1
+		// Cluster config max_requests_per_connection is set to 1, the number of requests should match
+		// the number of SSL connections. This guarantees SSL connection is using the latest TLS key/cert loaded in Envoy.
+		if numSSLHandshake != uint64(numReq) {
+			t.Errorf("Number of successful SSL handshake does not match, expect %d but get %d", numReq, numSSLHandshake)
+		}
+		if numSSLConnError != 0 {
+			t.Errorf("Number of SSL connection error: %d", numSSLConnError)
+		}
+		if numSSLVerifyNoCert != 0 {
+			t.Errorf("Number of SSL handshake failures because of missing client cert: %d", numSSLVerifyNoCert)
+		}
+		if numSSLVerifyCAError != 0 {
+			t.Errorf("Number of SSL handshake failures on CA verification: %d", numSSLVerifyCAError)
+		}
+		// Verify that there are multiple SDS updates. TLS key/cert are loaded multiple times.
+		if numOutboundSDSUpdate <= 1 {
+			t.Errorf("Number of SDS updates at outbound cluster should be greater than one, get %d", numOutboundSDSUpdate)
+		}
+		if numInboundSDSUpdate <= 1 {
+			t.Errorf("Number of SDS updates at inbound listener should be greater than one, get %d", numInboundSDSUpdate)
+		}
+	} else {
+		t.Errorf("cannot get Envoy stats: %v", err)
 	}
-	/* TODO: Current the stats Map are Disabled because of performance requirement so comment out the code below
-	Detailed Info:	https://github.com/istio/istio/issues/22729
-	*/
-	//stats, err := setup.ProxySetup.GetStatsMap()
-	//if err == nil {
-	//	numSSLHandshake := stats["cluster.outbound_cluster_tls.ssl.handshake"]
-	//	numSSLConnError := stats[fmt.Sprintf("listener.127.0.0.1_%d.ssl.connection_error", setup.InboundListenerPort)]
-	//	numSSLVerifyNoCert := stats[fmt.Sprintf("listener.127.0.0.1_%d.ssl.fail_verify_no_cert", setup.InboundListenerPort)]
-	//	numSSLVerifyCAError := stats[fmt.Sprintf("listener.127.0.0.1_%d.ssl.fail_verify_error", setup.InboundListenerPort)]
-	//	fmt.Printf("============4444")
-	//	fmt.Printf(fmt.Sprintf("%d",setup.InboundListenerPort))
-	//	numOutboundSDSUpdate := stats["cluster.outbound_cluster_tls.client_ssl_socket_factory.ssl_context_update_by_sds"]
-	//	numInboundSDSUpdate := stats[fmt.Sprintf("listener.127.0.0.1_%d.server_ssl_socket_factory.ssl_context_update_by_sds", setup.InboundListenerPort)]
-	//	// Cluster config max_requests_per_connection is set to 1, the number of requests should match
-	//	// the number of SSL connections. This guarantees SSL connection is using the latest TLS key/cert loaded in Envoy.
-	//	if numSSLHandshake != uint64(numReq) {
-	//		t.Errorf("Number of successful SSL handshake does not match, expect %d but get %d", numReq, numSSLHandshake)
-	//	}
-	//	if numSSLConnError != 0 {
-	//		t.Errorf("Number of SSL connection error: %d", numSSLConnError)
-	//	}
-	//	if numSSLVerifyNoCert != 0 {
-	//		t.Errorf("Number of SSL handshake failures because of missing client cert: %d", numSSLVerifyNoCert)
-	//	}
-	//	if numSSLVerifyCAError != 0 {
-	//		t.Errorf("Number of SSL handshake failures on CA verification: %d", numSSLVerifyCAError)
-	//	}
-	//	// Verify that there are multiple SDS updates. TLS key/cert are loaded multiple times.
-	//	if numOutboundSDSUpdate <= 1 {
-	//		t.Errorf("Number of SDS updates at outbound cluster should be greater than one, get %d", numOutboundSDSUpdate)
-	//	}
-	//	if numInboundSDSUpdate <= 1 {
-	//		t.Errorf("Number of SDS updates at inbound listener should be greater than one, get %d", numInboundSDSUpdate)
-	//	}
-	//} else {
-	//	t.Errorf("cannot get Envoy stats: %v", err)
-	//}
 }
 
 // get Cert from the InboundListener
@@ -112,9 +107,14 @@ func GetInboundCert(inboundListenerPort int) (string, error) {
 
 func openssl(args ...string) (string, error) {
 	cmd := exec.Command("openssl", args...)
-	out, err := cmd.Output();
-	if err != nil {
-		return string(out), fmt.Errorf("command %s failed: %q %v", cmd.String(), string(out), err)
+	var err error
+	var out []byte
+	for attempt := 0; attempt < retryAttempt; attempt++ {
+		out, err = cmd.Output();
+		if err == nil {
+			return string(out), nil
+		}
+		time.Sleep(2 * sleepTime)
 	}
-	return string(out), nil
+	return string(out), fmt.Errorf("command %s failed: %q %v", cmd.String(), string(out), err)
 }

--- a/security/pkg/nodeagent/test/cert_rotation/rotation_test.go
+++ b/security/pkg/nodeagent/test/cert_rotation/rotation_test.go
@@ -21,63 +21,100 @@ import (
 
 	"istio.io/istio/mixer/test/client/env"
 	sdsTest "istio.io/istio/security/pkg/nodeagent/test"
+	"os/exec"
+)
+
+const (
+	rotateInterval = 1 * time.Second
+	proxyRunningTime = 4 * rotateInterval
+	sleepTime = 100 * time.Millisecond
+	httpSuccessCode = 200
+	certShouldUpdateCount = 2
+)
+
+var (
+	certSet = make(map[string]bool)
 )
 
 func TestCertRotation(t *testing.T) {
-	t.Skip("https://github.com/istio/istio/issues/22729")
-	rotateInterval := 1 * time.Second
 	sdsTest.RotateCert(rotateInterval)
 	setup := sdsTest.SetupTest(t, env.SDSCertRotation)
 	defer setup.TearDown()
-
 	setup.StartProxy(t)
 	start := time.Now()
-	numReq := 0
 	for {
 		code, _, err := env.HTTPGet(fmt.Sprintf("http://localhost:%d/echo", setup.OutboundListenerPort))
 		if err != nil {
 			t.Errorf("Failed in request: %v", err)
 		}
-		if code != 200 {
+		if code != httpSuccessCode {
 			t.Errorf("Unexpected status code: %d", code)
 		}
-		numReq++
-		if time.Since(start) > 4*rotateInterval {
+		if time.Since(start) > proxyRunningTime {
 			break
 		}
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(sleepTime)
+		cert, err := GetInboundCert(setup.InboundListenerPort)
+		if err != nil {
+			continue
+		}
+		certSet[cert] = true
 	}
+	numInboundCertUpdate := len(certSet) - 1
+	if numInboundCertUpdate < certShouldUpdateCount {
+		t.Errorf("Number of inbound Cert Update should not be less than %d, get %d", certShouldUpdateCount,numInboundCertUpdate)
+	}
+	/* TODO: Current the stats Map are Disabled because of performance requirement so comment out the code below
+	Detailed Info:	https://github.com/istio/istio/issues/22729
+	*/
+	//stats, err := setup.ProxySetup.GetStatsMap()
+	//if err == nil {
+	//	numSSLHandshake := stats["cluster.outbound_cluster_tls.ssl.handshake"]
+	//	numSSLConnError := stats[fmt.Sprintf("listener.127.0.0.1_%d.ssl.connection_error", setup.InboundListenerPort)]
+	//	numSSLVerifyNoCert := stats[fmt.Sprintf("listener.127.0.0.1_%d.ssl.fail_verify_no_cert", setup.InboundListenerPort)]
+	//	numSSLVerifyCAError := stats[fmt.Sprintf("listener.127.0.0.1_%d.ssl.fail_verify_error", setup.InboundListenerPort)]
+	//	fmt.Printf("============4444")
+	//	fmt.Printf(fmt.Sprintf("%d",setup.InboundListenerPort))
+	//	numOutboundSDSUpdate := stats["cluster.outbound_cluster_tls.client_ssl_socket_factory.ssl_context_update_by_sds"]
+	//	numInboundSDSUpdate := stats[fmt.Sprintf("listener.127.0.0.1_%d.server_ssl_socket_factory.ssl_context_update_by_sds", setup.InboundListenerPort)]
+	//	// Cluster config max_requests_per_connection is set to 1, the number of requests should match
+	//	// the number of SSL connections. This guarantees SSL connection is using the latest TLS key/cert loaded in Envoy.
+	//	if numSSLHandshake != uint64(numReq) {
+	//		t.Errorf("Number of successful SSL handshake does not match, expect %d but get %d", numReq, numSSLHandshake)
+	//	}
+	//	if numSSLConnError != 0 {
+	//		t.Errorf("Number of SSL connection error: %d", numSSLConnError)
+	//	}
+	//	if numSSLVerifyNoCert != 0 {
+	//		t.Errorf("Number of SSL handshake failures because of missing client cert: %d", numSSLVerifyNoCert)
+	//	}
+	//	if numSSLVerifyCAError != 0 {
+	//		t.Errorf("Number of SSL handshake failures on CA verification: %d", numSSLVerifyCAError)
+	//	}
+	//	// Verify that there are multiple SDS updates. TLS key/cert are loaded multiple times.
+	//	if numOutboundSDSUpdate <= 1 {
+	//		t.Errorf("Number of SDS updates at outbound cluster should be greater than one, get %d", numOutboundSDSUpdate)
+	//	}
+	//	if numInboundSDSUpdate <= 1 {
+	//		t.Errorf("Number of SDS updates at inbound listener should be greater than one, get %d", numInboundSDSUpdate)
+	//	}
+	//} else {
+	//	t.Errorf("cannot get Envoy stats: %v", err)
+	//}
+}
 
-	stats, err := setup.ProxySetup.GetStatsMap()
-	if err == nil {
-		numSSLHandshake := stats["cluster.outbound_cluster_tls.ssl.handshake"]
-		numSSLConnError := stats[fmt.Sprintf("listener.127.0.0.1_%d.ssl.connection_error", setup.InboundListenerPort)]
-		numSSLVerifyNoCert := stats[fmt.Sprintf("listener.127.0.0.1_%d.ssl.fail_verify_no_cert", setup.InboundListenerPort)]
-		numSSLVerifyCAError := stats[fmt.Sprintf("listener.127.0.0.1_%d.ssl.fail_verify_error", setup.InboundListenerPort)]
-		numOutboundSDSUpdate := stats["cluster.outbound_cluster_tls.client_ssl_socket_factory.ssl_context_update_by_sds"]
-		numInboundSDSUpdate := stats[fmt.Sprintf("listener.127.0.0.1_%d.server_ssl_socket_factory.ssl_context_update_by_sds", setup.InboundListenerPort)]
-		// Cluster config max_requests_per_connection is set to 1, the number of requests should match
-		// the number of SSL connections. This guarantees SSL connection is using the latest TLS key/cert loaded in Envoy.
-		if numSSLHandshake != uint64(numReq) {
-			t.Errorf("Number of successful SSL handshake does not match, expect %d but get %d", numReq, numSSLHandshake)
-		}
-		if numSSLConnError != 0 {
-			t.Errorf("Number of SSL connection error: %d", numSSLConnError)
-		}
-		if numSSLVerifyNoCert != 0 {
-			t.Errorf("Number of SSL handshake failures because of missing client cert: %d", numSSLVerifyNoCert)
-		}
-		if numSSLVerifyCAError != 0 {
-			t.Errorf("Number of SSL handshake failures on CA verification: %d", numSSLVerifyCAError)
-		}
-		// Verify that there are multiple SDS updates. TLS key/cert are loaded multiple times.
-		if numOutboundSDSUpdate <= 1 {
-			t.Errorf("Number of SDS updates at outbound cluster should be greater than one, get %d", numOutboundSDSUpdate)
-		}
-		if numInboundSDSUpdate <= 1 {
-			t.Errorf("Number of SDS updates at inbound listener should be greater than one, get %d", numInboundSDSUpdate)
-		}
-	} else {
-		t.Errorf("cannot get Envoy stats: %v", err)
+// get Cert from the InboundListener
+func GetInboundCert(inboundListenerPort int) (string, error) {
+	return openssl("s_client", "-showcerts",
+		"-connect", fmt.Sprintf("127.0.0.1:%d",inboundListenerPort),
+	)
+}
+
+func openssl(args ...string) (string, error) {
+	cmd := exec.Command("openssl", args...)
+	out, err := cmd.Output();
+	if err != nil {
+		return string(out), fmt.Errorf("command %s failed: %q %v", cmd.String(), string(out), err)
 	}
+	return string(out), nil
 }


### PR DESCRIPTION
Reenable the rotation cert test by checking the number of cert update during the proxy running duration

Issue Id: https://github.com/istio/istio/issues/22729