### PR TITLE
service registry: separate default ClusterID from provider IDs 

### DIFF
--- a/istioctl/pkg/multicluster/generate.go
+++ b/istioctl/pkg/multicluster/generate.go
@@ -32,7 +32,6 @@ import (
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/operator/pkg/validate"
 
-	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pkg/util/protomarshal"
 )
 
@@ -247,17 +246,10 @@ func meshNetworkForCluster(env Environment, mesh *Mesh, current *Cluster) (*v1al
 
 		}
 
-		// Use the cluster clusterName for the registry name so we have consistency across the mesh. Pilot
-		// uses a special name for the local cluster against which it is running.
-		registry := cluster.clusterName
-		if context == current.Context {
-			registry = string(serviceregistry.Kubernetes)
-		}
-
 		mn.Networks[network].Endpoints = append(mn.Networks[network].Endpoints,
 			&v1alpha1.Network_NetworkEndpoints{
 				Ne: &v1alpha1.Network_NetworkEndpoints_FromRegistry{
-					FromRegistry: registry,
+					FromRegistry: cluster.clusterName,
 				},
 			},
 		)

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -271,7 +271,7 @@ func getClusterID(args *PilotArgs) string {
 	clusterID := args.Config.ControllerOptions.ClusterID
 	if clusterID == "" {
 		if hasKubeRegistry(args.Service.Registries) {
-			clusterID = string(serviceregistry.Kubernetes)
+			clusterID = serviceregistry.DefaultLocalClusterID
 		}
 	}
 	return clusterID

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -295,8 +295,8 @@ var (
 			"By default, this is false, and virtualService with delegate will be ignored",
 	).Get()
 
-	ClusterName = env.RegisterStringVar("CLUSTER_ID", "Kubernetes",
-		"Defines the cluster and service registry that this Istiod instance is belongs to").Get()
+	ClusterName = env.RegisterStringVar("CLUSTER_ID", "default-local-istiod-cluster",
+		"Defines the cluster and service registry that this Istiod instance is belongs to if not otherwise specified").Get()
 
 	EnableIncrementalMCP = env.RegisterBoolVar(
 		"PILOT_ENABLE_INCREMENTAL_MCP",

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -17,8 +17,6 @@ package aggregate
 import (
 	"sync"
 
-	"istio.io/istio/pilot/pkg/features"
-
 	"github.com/hashicorp/go-multierror"
 
 	"istio.io/pkg/log"
@@ -254,15 +252,7 @@ func nodeClusterID(node *model.Proxy) string {
 
 // Skip the service registry when there won't be a match
 // because the proxy is in a different cluster.
-func skipSearchingRegistryForProxy(nodeClusterID, registryClusterID, selfClusterID string) bool {
-	// We can't trust the default service registry because its always
-	// named `Kubernetes`. Use the `CLUSTER_ID` envvar to find the
-	// local cluster name in these cases.
-	// TODO(https://github.com/istio/istio/issues/22093)
-	if registryClusterID == string(serviceregistry.Kubernetes) {
-		registryClusterID = selfClusterID
-	}
-
+func skipSearchingRegistryForProxy(nodeClusterID, registryClusterID string) bool {
 	// We can't be certain either way
 	if registryClusterID == "" || nodeClusterID == "" {
 		return false
@@ -279,7 +269,7 @@ func (c *Controller) GetProxyServiceInstances(node *model.Proxy) ([]*model.Servi
 	// TODO: if otherwise, warning or else what to do about it.
 	for _, r := range c.GetRegistries() {
 		nodeClusterID := nodeClusterID(node)
-		if skipSearchingRegistryForProxy(nodeClusterID, r.Cluster(), features.ClusterName) {
+		if skipSearchingRegistryForProxy(nodeClusterID, r.Cluster()) {
 			log.Debugf("GetProxyServiceInstances(): not searching registry %v: proxy %v CLUSTER_ID is %v",
 				r.Cluster(), node.ID, nodeClusterID)
 			continue

--- a/pilot/pkg/serviceregistry/aggregate/controller_test.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller_test.go
@@ -540,24 +540,21 @@ func TestSkipSearchingRegistryForProxy(t *testing.T) {
 	cases := []struct {
 		node     string
 		registry string
-		self     string
 		want     bool
 	}{
-		{"main", "remote", "main", true},
-		{"remote", "main", "main", true},
-		{"remote", "Kubernetes", "main", true},
+		{"main", "remote", true},
+		{"remote", "main", true},
 
-		{"main", "Kubernetes", "main", false},
-		{"main", "main", "main", false},
-		{"remote", "remote", "main", false},
-		{"", "main", "main", false},
-		{"main", "", "main", false},
-		{"main", "Kubernetes", "", false},
-		{"", "", "", false},
+		{"main", "main", false},
+		{"remote", "remote", false},
+		{"", "main", false},
+		{"main", "", false},
+
+		{"", "", false},
 	}
 
 	for i, c := range cases {
-		got := skipSearchingRegistryForProxy(c.node, c.registry, c.self)
+		got := skipSearchingRegistryForProxy(c.node, c.registry)
 		if got != c.want {
 			t.Errorf("%s: got %v want %v",
 				fmt.Sprintf("[%v] registry=%v node=%v", i, c.registry, c.node),

--- a/pilot/pkg/serviceregistry/instance.go
+++ b/pilot/pkg/serviceregistry/instance.go
@@ -18,6 +18,11 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 )
 
+const (
+	// DefaultLocalClusterID is the clusterID where pilot/istiod is running when not otherwise specified.
+	DefaultLocalClusterID = "default-local-istiod-cluster"
+)
+
 // Instance of a service registry. A single service registry combines the capabilities of service discovery
 // and the controller for managing asynchronous events.
 type Instance interface {


### PR DESCRIPTION
"Kubernetes" is used as the default clusterID for the cluster/serviceRegistry istiod is running in when none is specified in `values.global.multiCluster.clusterName`. This overlaps with the concept of serviceregistry.ProviderID (the type of service registry). We should use a different default value for the clusterID to make things less confusing. 

[] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
