### PR TITLE
do not check istiod ready on remote cluster's validation controller

### DIFF
--- a/pilot/pkg/bootstrap/sidecarinjector.go
+++ b/pilot/pkg/bootstrap/sidecarinjector.go
@@ -20,8 +20,7 @@ import (
 	"path/filepath"
 
 	"istio.io/istio/pilot/pkg/features"
-
-	"istio.io/istio/pkg/util"
+	"istio.io/istio/pkg/webhooks"
 
 	"istio.io/istio/pkg/kube/inject"
 	"istio.io/pkg/log"
@@ -73,7 +72,7 @@ func (s *Server) initSidecarInjector(args *PilotArgs) error {
 			if hasCustomTLSCerts(args.TLSOptions) {
 				caBundlePath = args.TLSOptions.CaCertFile
 			}
-			util.PatchCertLoop(features.InjectionWebhookConfigName.Get(), webhookName, caBundlePath, s.kubeClient, stop)
+			webhooks.PatchCertLoop(features.InjectionWebhookConfigName.Get(), webhookName, caBundlePath, s.kubeClient, stop)
 			return nil
 		})
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"istio.io/istio/pilot/pkg/features"
-	"istio.io/istio/pkg/util"
+	"istio.io/istio/pkg/webhooks"
 	"istio.io/pkg/log"
 
 	"k8s.io/client-go/dynamic"
@@ -141,9 +141,9 @@ func (m *Multicluster) AddMemberCluster(clientset kubernetes.Interface, metadata
 	if m.fetchCaRoot != nil {
 		nc := NewNamespaceController(m.fetchCaRoot, opts, clientset)
 		go nc.Run(stopCh)
-		go util.PatchCertLoop(features.InjectionWebhookConfigName.Get(), webhookName, m.caBundlePath, clientset, stopCh)
-		valicationWebhookController := util.CreateValidationWebhookController(clientset, dynamicClient, webhookConfigName,
-			m.secretNamespace, m.caBundlePath)
+		go webhooks.PatchCertLoop(features.InjectionWebhookConfigName.Get(), webhookName, m.caBundlePath, clientset, stopCh)
+		valicationWebhookController := webhooks.CreateValidationWebhookController(clientset, dynamicClient, webhookConfigName,
+			m.secretNamespace, m.caBundlePath, true)
 		if valicationWebhookController != nil {
 			go valicationWebhookController.Start(stopCh)
 		}

--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -81,14 +81,18 @@ type Options struct {
 	// without relying on the user to manually delete configs.
 	// Deprecated: istiod webhook controller shouldn't use this.
 	UnregisterValidationWebhook bool
+
+	//RemoteWebhookConfig defines whether the webhook config is comming from remote cluster
+	RemoteWebhookConfig bool
 }
 
 func DefaultArgs() Options {
 	return Options{
-		WatchedNamespace:  "istio-system",
-		CAPath:            constants.DefaultRootCert,
-		WebhookConfigName: "istio-galley",
-		ServiceName:       "istio-galley",
+		WatchedNamespace:    "istio-system",
+		CAPath:              constants.DefaultRootCert,
+		WebhookConfigName:   "istio-galley",
+		ServiceName:         "istio-galley",
+		RemoteWebhookConfig: false,
 	}
 }
 
@@ -265,8 +269,10 @@ func newController(
 	webhookInformer := c.sharedInformers.Admissionregistration().V1beta1().ValidatingWebhookConfigurations().Informer()
 	webhookInformer.AddEventHandler(makeHandler(c.queue, configGVK, o.WebhookConfigName))
 
-	endpointInformer := c.sharedInformers.Core().V1().Endpoints().Informer()
-	endpointInformer.AddEventHandler(makeHandler(c.queue, endpointGVK, o.ServiceName))
+	if !o.RemoteWebhookConfig {
+		endpointInformer := c.sharedInformers.Core().V1().Endpoints().Informer()
+		endpointInformer.AddEventHandler(makeHandler(c.queue, endpointGVK, o.ServiceName))
+	}
 
 	return c, nil
 }
@@ -343,17 +349,19 @@ func (c *Controller) reconcileRequest(req *reconcileRequest) error {
 	if c.o.UnregisterValidationWebhook {
 		return c.deleteValidatingWebhookConfiguration()
 	}
-
-	ready, err := c.readyForFailClose()
-	if err != nil {
-		return err
-	}
-
 	failurePolicy := kubeApiAdmission.Ignore
-	if ready {
+	if c.o.RemoteWebhookConfig {
 		failurePolicy = kubeApiAdmission.Fail
-	}
+	} else {
+		ready, err := c.readyForFailClose()
+		if err != nil {
+			return err
+		}
 
+		if ready {
+			failurePolicy = kubeApiAdmission.Fail
+		}
+	}
 	caBundle, err := c.loadCABundle()
 	if err != nil {
 		scope.Errorf("Failed to load CA bundle: %v", err)

--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -82,7 +82,7 @@ type Options struct {
 	// Deprecated: istiod webhook controller shouldn't use this.
 	UnregisterValidationWebhook bool
 
-	//RemoteWebhookConfig defines whether the webhook config is comming from remote cluster
+	//RemoteWebhookConfig defines whether the webhook config is coming from remote cluster
 	RemoteWebhookConfig bool
 }
 

--- a/pkg/webhooks/webhookpatch.go
+++ b/pkg/webhooks/webhookpatch.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package webhooks
 
 import (
 	"bytes"
@@ -167,12 +167,13 @@ func doPatch(cs kubernetes.Interface, webhookConfigName, webhookName string, caC
 }
 
 func CreateValidationWebhookController(client kubernetes.Interface, dynamicInterface dynamic.Interface,
-	webhookConfigName, ns, caBundlePath string) *controller.Controller {
+	webhookConfigName, ns, caBundlePath string, remote bool) *controller.Controller {
 	o := controller.Options{
-		WatchedNamespace:  ns,
-		CAPath:            caBundlePath,
-		WebhookConfigName: webhookConfigName,
-		ServiceName:       "istiod",
+		WatchedNamespace:    ns,
+		CAPath:              caBundlePath,
+		WebhookConfigName:   webhookConfigName,
+		ServiceName:         "istiod",
+		RemoteWebhookConfig: remote,
 	}
 	whController, err := controller.New(o, client, dynamicInterface)
 	if err != nil {

--- a/pkg/webhooks/webhookpatch_test.go
+++ b/pkg/webhooks/webhookpatch_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package webhooks
 
 import (
 	"bytes"


### PR DESCRIPTION
- move webhookpatch.go  under pkg/webhooks
- do not check istiod endpoint ready status for remote validation controller
- update failure policy to  as fail for remote validationwebhookconfigurations

Fix: https://github.com/istio/istio/issues/23945