### PR TITLE
sds: skip waiting for ingress gateway secret for file mounted certs

### DIFF
--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -402,10 +402,10 @@ func (sc *SecretCache) SecretExist(connectionID, resourceName, token, version st
 
 // ShouldWaitForIngressGatewaySecret returns true if node agent is working in ingress gateway agent mode
 // and needs to wait for ingress gateway secret to be ready.
-func (sc *SecretCache) ShouldWaitForIngressGatewaySecret(connectionID, resourceName, token string, fileMountedCerts bool) bool {
+func (sc *SecretCache) ShouldWaitForIngressGatewaySecret(connectionID, resourceName, token string, fileMountedCertsOnly bool) bool {
 	// If node agent works as workload agent, node agent does not expect any ingress gateway secret.
 	// If workload is using file mounted certs, we should not wait for ingress secret.
-	if sc.fetcher.UseCaClient || fileMountedCerts {
+	if sc.fetcher.UseCaClient || fileMountedCertsOnly {
 		return false
 	}
 

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -138,7 +138,7 @@ type SecretManager interface {
 	GenerateSecret(ctx context.Context, connectionID, resourceName, token string) (*model.SecretItem, error)
 
 	// ShouldWaitForIngressGatewaySecret indicates whether a valid ingress gateway secret is expected.
-	ShouldWaitForIngressGatewaySecret(connectionID, resourceName, token string) bool
+	ShouldWaitForIngressGatewaySecret(connectionID, resourceName, token string, fileMountedCerts bool) bool
 
 	// SecretExist checks if secret already existed.
 	// This API is used for sds server to check if coming request is ack request.
@@ -402,9 +402,10 @@ func (sc *SecretCache) SecretExist(connectionID, resourceName, token, version st
 
 // ShouldWaitForIngressGatewaySecret returns true if node agent is working in ingress gateway agent mode
 // and needs to wait for ingress gateway secret to be ready.
-func (sc *SecretCache) ShouldWaitForIngressGatewaySecret(connectionID, resourceName, token string) bool {
+func (sc *SecretCache) ShouldWaitForIngressGatewaySecret(connectionID, resourceName, token string, fileMountedCerts bool) bool {
 	// If node agent works as workload agent, node agent does not expect any ingress gateway secret.
-	if sc.fetcher.UseCaClient {
+	// If workload is using file mounted certs, we should not wait for ingress secret.
+	if sc.fetcher.UseCaClient || fileMountedCerts {
 		return false
 	}
 

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -138,7 +138,7 @@ type SecretManager interface {
 	GenerateSecret(ctx context.Context, connectionID, resourceName, token string) (*model.SecretItem, error)
 
 	// ShouldWaitForIngressGatewaySecret indicates whether a valid ingress gateway secret is expected.
-	ShouldWaitForIngressGatewaySecret(connectionID, resourceName, token string, fileMountedCerts bool) bool
+	ShouldWaitForIngressGatewaySecret(connectionID, resourceName, token string, fileMountedCertsOnly bool) bool
 
 	// SecretExist checks if secret already existed.
 	// This API is used for sds server to check if coming request is ack request.

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -329,7 +329,7 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 			// provisioned as kubernetes secret is not ready, wait for secret before sending SDS response.
 			// If a kubernetes secret was deleted by operator, wait for a new kubernetes secret before sending SDS response.
 			// If workload uses file mounted certs i.e. "FILE_MOUNTED_CERTS" is set to true, workdload loads certificates from
-			// mounted certificate paths andit does not depend on the presense of ingress gateway secret so
+			// mounted certificate paths and it does not depend on the presense of ingress gateway secret so
 			// we should skip waiting for it in that mode.
 			if s.st.ShouldWaitForIngressGatewaySecret(conID, resourceName, token, s.fileMountedCerts) {
 				sdsServiceLog.Warnf("%s waiting for ingress gateway secret for proxy %q\n", conIDresourceNamePrefix, discReq.Node.Id)

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -328,6 +328,8 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 			// In ingress gateway agent mode, if the first SDS request is received but kubernetes secret is not ready,
 			// wait for secret before sending SDS response. If a kubernetes secret was deleted by operator, wait
 			// for a new kubernetes secret before sending SDS response.
+			// If workload uses file mounted certs i.e. "FILE_MOUNTED" is set to true, it does not depend on ingress gateway
+			// secret setup as a kubernetes secret - we should skip waiting for it in that mode.
 			if !s.fileMountedCerts {
 				if s.st.ShouldWaitForIngressGatewaySecret(conID, resourceName, token) {
 					sdsServiceLog.Warnf("%s waiting for ingress gateway secret for proxy %q\n", conIDresourceNamePrefix, discReq.Node.Id)

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -331,7 +331,7 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 			// If workload uses file mounted certs i.e. "FILE_MOUNTED_CERTS" is set to true, workdload loads certificates from
 			// mounted certificate paths and it does not depend on the presence of ingress gateway secret so
 			// we should skip waiting for it in that mode.
-			// File Mounted certs for gateways is used in scenarios where an existing PKI infrastuctures delivers certificates
+			// File mounted certs for gateways is used in scenarios where an existing PKI infrastuctures delivers certificates
 			// to pods/VMs via files.
 			if s.st.ShouldWaitForIngressGatewaySecret(conID, resourceName, token, s.fileMountedCerts) {
 				sdsServiceLog.Warnf("%s waiting for ingress gateway secret for proxy %q\n", conIDresourceNamePrefix, discReq.Node.Id)

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -329,7 +329,7 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 			// provisioned as kubernetes secret is not ready, wait for secret before sending SDS response.
 			// If a kubernetes secret was deleted by operator, wait for a new kubernetes secret before sending SDS response.
 			// If workload uses file mounted certs i.e. "FILE_MOUNTED_CERTS" is set to true, workdload loads certificates from
-			// mounted certificate paths and it does not depend on the presense of ingress gateway secret so
+			// mounted certificate paths and it does not depend on the presence of ingress gateway secret so
 			// we should skip waiting for it in that mode.
 			if s.st.ShouldWaitForIngressGatewaySecret(conID, resourceName, token, s.fileMountedCerts) {
 				sdsServiceLog.Warnf("%s waiting for ingress gateway secret for proxy %q\n", conIDresourceNamePrefix, discReq.Node.Id)

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -326,10 +326,11 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 				discReq.ErrorDetail)
 
 			// In ingress gateway agent mode, if the first SDS request is received but Ingress gateway secret which is
-			// setup as kubernetes secret is not ready, wait for secret before sending SDS response.
+			// provisioned as kubernetes secret is not ready, wait for secret before sending SDS response.
 			// If a kubernetes secret was deleted by operator, wait for a new kubernetes secret before sending SDS response.
-			// If workload uses file mounted certs i.e. "FILE_MOUNTED" is set to true, it does not depend on ingress gateway
-			// secret setup as a kubernetes secret - we should skip waiting for it in that mode.
+			// If workload uses file mounted certs i.e. "FILE_MOUNTED_CERTS" is set to true, workdload loads certificates from
+			// mounted certificate paths andit does not depend on the presense of ingress gateway secret so
+			// we should skip waiting for it in that mode.
 			if s.st.ShouldWaitForIngressGatewaySecret(conID, resourceName, token, s.fileMountedCerts) {
 				sdsServiceLog.Warnf("%s waiting for ingress gateway secret for proxy %q\n", conIDresourceNamePrefix, discReq.Node.Id)
 				continue

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -331,6 +331,8 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 			// If workload uses file mounted certs i.e. "FILE_MOUNTED_CERTS" is set to true, workdload loads certificates from
 			// mounted certificate paths and it does not depend on the presence of ingress gateway secret so
 			// we should skip waiting for it in that mode.
+			// File Mounted certs for gateways is used in scenarios where an existing PKI infrastuctures delivers certificates
+			// to pods/VMs via files.
 			if s.st.ShouldWaitForIngressGatewaySecret(conID, resourceName, token, s.fileMountedCerts) {
 				sdsServiceLog.Warnf("%s waiting for ingress gateway secret for proxy %q\n", conIDresourceNamePrefix, discReq.Node.Id)
 				continue

--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -1022,11 +1022,8 @@ func (ms *mockSecretStore) DeleteSecret(conID, resourceName string) {
 	ms.secrets.Delete(key)
 }
 
-func (ms *mockSecretStore) ShouldWaitForIngressGatewaySecret(connectionID, resourceName, token string) bool {
-	// Return true here for file mounted cert resource name to validate that file mounted certs would
-	// not wait for ingress gateway secret. In normal cases, we should return false here in this mock to
-	// test the secret generation flow.
-	return strings.HasPrefix(resourceName, "file-root:")
+func (ms *mockSecretStore) ShouldWaitForIngressGatewaySecret(connectionID, resourceName, token string, fileMountedCerts bool) bool {
+	return false
 }
 
 func TestDebugEndpoints(t *testing.T) {

--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -1023,7 +1023,9 @@ func (ms *mockSecretStore) DeleteSecret(conID, resourceName string) {
 }
 
 func (ms *mockSecretStore) ShouldWaitForIngressGatewaySecret(connectionID, resourceName, token string) bool {
-	return false
+	// Return true here for file mounted cert resource name to validate that file mounted certs would
+	// not depend on this result and proceed with generating secret.
+	return strings.HasPrefix(resourceName, "file-root:")
 }
 
 func TestDebugEndpoints(t *testing.T) {

--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -1022,7 +1022,7 @@ func (ms *mockSecretStore) DeleteSecret(conID, resourceName string) {
 	ms.secrets.Delete(key)
 }
 
-func (ms *mockSecretStore) ShouldWaitForIngressGatewaySecret(connectionID, resourceName, token string, fileMountedCerts bool) bool {
+func (ms *mockSecretStore) ShouldWaitForIngressGatewaySecret(connectionID, resourceName, token string, fileMountedCertsOnly bool) bool {
 	return false
 }
 

--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -1024,7 +1024,8 @@ func (ms *mockSecretStore) DeleteSecret(conID, resourceName string) {
 
 func (ms *mockSecretStore) ShouldWaitForIngressGatewaySecret(connectionID, resourceName, token string) bool {
 	// Return true here for file mounted cert resource name to validate that file mounted certs would
-	// not depend on this result and proceed with generating secret.
+	// not wait for ingress gateway secret. In normal cases, we should return false here in this mock to
+	// test the secret generation flow.
 	return strings.HasPrefix(resourceName, "file-root:")
 }
 

--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -150,8 +150,9 @@ type Server struct {
 func NewServer(options Options, workloadSecretCache, gatewaySecretCache cache.SecretManager) (*Server, error) {
 	s := &Server{
 		workloadSds: newSDSService(workloadSecretCache, options.FileMountedCerts, options.UseLocalJWT,
+			options.FileMountedCerts,
 			options.RecycleInterval, options.JWTPath, options.OutputKeyCertToDir),
-		gatewaySds: newSDSService(gatewaySecretCache, true, options.UseLocalJWT,
+		gatewaySds: newSDSService(gatewaySecretCache, true, options.UseLocalJWT, options.FileMountedCerts,
 			options.RecycleInterval, options.JWTPath, options.OutputKeyCertToDir),
 	}
 	if options.EnableWorkloadSDS {


### PR DESCRIPTION
Continuing on #23647 , this PR skips waiting for ingress gateway secret for file mounted certs