### PR TITLE
Match proxyv2 limits in proxy_init

### DIFF
--- a/manifests/profiles/default.yaml
+++ b/manifests/profiles/default.yaml
@@ -263,8 +263,8 @@ spec:
         image: proxyv2
         resources:
           limits:
-            cpu: 100m
-            memory: 50Mi
+            cpu: 2000m
+            memory: 1024Mi
           requests:
             cpu: 10m
             memory: 10Mi


### PR DESCRIPTION
Having such a low limit can seriously impede the progress of the init
container due to throttling, even though it runs for only ~1s and uses
minimal resources. In some cases I have seen this take 15s+ due to the
limit.

Raising this to match the proxyv2 container. While this is overkill I
think its reasonable since if the init container is running there is a
100% chance the proxyv2 container will run moments later.