### PR TITLE
remove `-t` flag for docker build on non tty device

### DIFF
--- a/common/scripts/run.sh
+++ b/common/scripts/run.sh
@@ -37,7 +37,7 @@ export REPO_ROOT=/work
 # $CONTAINER_OPTIONS becomes an empty arg when quoted, so SC2086 is disabled for the
 # following command only
 # shellcheck disable=SC2086
-"${CONTAINER_CLI}" run -it --rm \
+"${CONTAINER_CLI}" run -i --rm \
     -u "${UID}:${DOCKER_GID}" \
     --sig-proxy=true \
     ${DOCKER_SOCKET_MOUNT:--v /var/run/docker.sock:/var/run/docker.sock} \


### PR DESCRIPTION


[ ] Configuration Infrastructure
[ ] Docs
[] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[x] Developer Infrastructure

---

relates to https://github.com/Homebrew/homebrew-core/pull/55103