### PR TITLE
WIP: Intial implementation of XDS based proxystatus

### DIFF
--- a/istioctl/cmd/proxystatus_v2.go
+++ b/istioctl/cmd/proxystatus_v2.go
@@ -1,0 +1,151 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	corev2 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/spf13/cobra"
+
+	"istio.io/istio/istioctl/pkg/clioptions"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/adsc"
+)
+
+const (
+	connectionsTypeURL = "istio.io/connections"
+)
+
+func newProxyStatusCommand() *cobra.Command {
+	var opts clioptions.CentralControlPlaneOptions
+
+	statusCmd := &cobra.Command{
+		Use:   "proxy-status [<pod-name[.namespace]>]",
+		Short: "Retrieves the synchronization status of each Envoy in the mesh",
+		Long: `
+Retrieves last sent and last acknowledged xDS sync from Pilot to each Envoy in the mesh
+
+`,
+		Example: `# Retrieve sync status for all Envoys in a mesh
+	istioctl proxy-status
+
+# Retrieve sync diff for a single Envoy and Pilot
+	istioctl proxy-status productpage-v1-679f4bcbbb-6j4j6.default
+`,
+		Aliases: []string{"ps"},
+		RunE: func(c *cobra.Command, args []string) error {
+			if opts.Xds == "" {
+				return fmt.Errorf("--endpoint default not implemented; MUST be supplied; try localhost:15012")
+			}
+			adscConn, err := adsc.Dial(opts.Xds, "", &adsc.Config{
+				IP: "1.2.3.4",
+				Meta: model.NodeMetadata{
+					Generator: "event",
+				}.ToStruct(),
+				// TODO I tried and failed to add DialOptions here and have ADSC
+				// pass them down so that I could add gRPC Interceptors for logging
+				// and debugging.
+			})
+			if err != nil {
+				return fmt.Errorf("Could not dial: %w", err)
+			}
+			if len(args) > 0 {
+				return fmt.Errorf("experimental proxy-status <pod> unimplemented")
+			}
+
+			err = adscConn.Send(&xdsapi.DiscoveryRequest{
+				Node: &corev2.Node{
+					Id: "sidecar~1.1.1.1~debug~cluster.local",
+				},
+				TypeUrl: connectionsTypeURL,
+			})
+			if err != nil {
+				return err
+			}
+
+			// TODO --timeout parameter
+			dr, err := adscConn.WaitVersion(10*time.Second, connectionsTypeURL, "")
+			if err != nil {
+				return err
+			}
+
+			nodes := make([]corev2.Node, 0)
+			for _, resource := range dr.Resources {
+				switch resource.TypeUrl {
+				case "type.googleapis.com/envoy.api.v2.core.Node":
+					node := corev2.Node{}
+					err = ptypes.UnmarshalAny(resource, &node)
+					if err != nil {
+						return fmt.Errorf("Could not unmarshal Node: %w", err)
+					}
+					nodes = append(nodes, node)
+				default:
+					fmt.Fprintf(os.Stderr, "unexpected resource type %q\n", resource.TypeUrl)
+				}
+			}
+
+			err = printNodeConnections(nodes, c.OutOrStdout())
+			return err
+		},
+	}
+
+	opts.AttachControlPlaneFlags(statusCmd)
+
+	return statusCmd
+}
+
+func printNodeConnections(nodes []corev2.Node, writer io.Writer) error {
+	w := new(tabwriter.Writer).Init(writer, 0, 8, 1, ' ', 0)
+	_, _ = fmt.Fprintln(w, "NAME\tMESH\tCDS\tLDS\tEDS\tRDS\tPILOT")
+
+	for _, node := range nodes {
+		/*
+			// This isn't working... everything ends up in meta.Raw...
+			// Is there a better way to turn a *structpb.Struct into a model.Metadata?
+			// Should I even be trying to get a model.Metadata instead of working with the Struct?
+			b, err := json.Marshal(node.GetMetadata())
+			if err != nil {
+				return err
+			}
+			meta := &model.NodeMetadata{}
+			if err := meta.UnmarshalJSON(b); err != nil {
+				return err
+			}
+			fmt.Printf("Metadata: %v#\n", meta)
+			fmt.Printf("Metadata.ProxyConfig: %v#\n", meta.ProxyConfig)
+			fmt.Printf("Metadata.Raw: %v#\n", meta.Raw)
+			fmt.Printf("%s.%s\t%s\n", meta.InstanceName, meta.Namespace, meta.MeshID)
+		*/
+		fields := node.GetMetadata().GetFields()
+		name := fields["NAME"]
+		if name.GetStringValue() == "" {
+			// Skip the unnamed node, which represents the XDS request node?!?
+			continue
+		}
+		ns := fields["NAMESPACE"]
+		meshID := fields["MESH_ID"]
+		fmt.Fprintf(w, "%s.%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			name.GetStringValue(), ns.GetStringValue(), meshID.GetStringValue(),
+			"TODO", "TODO", "TODO", "TODO", "TODO")
+	}
+	return w.Flush()
+}

--- a/istioctl/cmd/proxystatus_v2_test.go
+++ b/istioctl/cmd/proxystatus_v2_test.go
@@ -44,7 +44,7 @@ func TestProxyStatusV2(t *testing.T) {
 	// Why?
 	cases := []execTestCase{
 		{ // case 0
-			args:           strings.Split(fmt.Sprintf("experimental proxy-status --endpoint %s", pilot_util.MockPilotGrpcAddr), " "),
+			args:           strings.Split(fmt.Sprintf("experimental proxy-status --xds-address %s", pilot_util.MockPilotGrpcAddr), " "),
 			expectedString: "NAME     CDS     LDS     EDS     RDS     PILOT",
 		},
 	}

--- a/istioctl/cmd/proxystatus_v2_test.go
+++ b/istioctl/cmd/proxystatus_v2_test.go
@@ -1,0 +1,91 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"istio.io/istio/pilot/pkg/bootstrap"
+	"istio.io/istio/pilot/test/util"
+	"istio.io/istio/pkg/test/env"
+	pilot_util "istio.io/istio/tests/util"
+)
+
+func TestProxyStatusV2(t *testing.T) {
+	_, tearDown := pilot_util.EnsureTestServer(func(args *bootstrap.PilotArgs) {
+		// TODO remove any not needed or switch to something that will let istio.io/connections have data?
+		// TODO Verify this won't pull from my true cluster
+		args.Plugins = bootstrap.DefaultPlugins
+		args.Config.FileDir = env.IstioSrc + "/tests/testdata/networking/sidecar-ns-scope"
+		args.Mesh.MixerAddress = ""
+		args.MeshConfig = nil
+		args.Mesh.ConfigFile = env.IstioSrc + "/tests/testdata/networking/sidecar-ns-scope/mesh.yaml"
+		args.Service.Registries = []string{}
+	})
+	defer tearDown()
+
+	// TODO This fails with warn, ads	ADS: Unknown watched resources
+	// node:<id:"sidecar~1.2.3.4~test-1.default~default.svc.cluster.local" ...
+	// Why?
+	cases := []execTestCase{
+		{ // case 0
+			args:           strings.Split(fmt.Sprintf("experimental proxy-status --endpoint %s", pilot_util.MockPilotGrpcAddr), " "),
+			expectedString: "NAME     CDS     LDS     EDS     RDS     PILOT",
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case %d %s", i, strings.Join(c.args, " ")), func(t *testing.T) {
+			verifyGrpcTestOutput(t, c)
+		})
+	}
+}
+
+func verifyGrpcTestOutput(t *testing.T, c execTestCase) {
+	t.Helper()
+
+	var out bytes.Buffer
+	rootCmd := GetRootCmd(c.args)
+	rootCmd.SetOutput(&out)
+
+	fErr := rootCmd.Execute()
+	output := out.String()
+
+	if c.expectedOutput != "" && c.expectedOutput != output {
+		t.Fatalf("Unexpected output for 'istioctl %s'\n got: %q\nwant: %q", strings.Join(c.args, " "), output, c.expectedOutput)
+	}
+
+	if c.expectedString != "" && !strings.Contains(output, c.expectedString) {
+		t.Fatalf("Output didn't match for 'istioctl %s'\n got %v\nwant: %v", strings.Join(c.args, " "), output, c.expectedString)
+	}
+
+	if c.goldenFilename != "" {
+		util.CompareContent([]byte(output), c.goldenFilename, t)
+	}
+
+	if c.wantException {
+		if fErr == nil {
+			t.Fatalf("Wanted an exception for 'istioctl %s', didn't get one, output was %q",
+				strings.Join(c.args, " "), output)
+		}
+	} else {
+		if fErr != nil {
+			t.Fatalf("Unwanted exception for 'istioctl %s': %v", strings.Join(c.args, " "), fErr)
+		}
+	}
+}

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -174,6 +174,8 @@ debug and diagnose their Istio mesh.
 	experimentalCmd.AddCommand(multicluster.NewCreateRemoteSecretCommand())
 	experimentalCmd.AddCommand(multicluster.NewMulticlusterCommand())
 
+	experimentalCmd.AddCommand(newProxyStatusCommand())
+
 	rootCmd.AddCommand(collateral.CobraCommand(rootCmd, &doc.GenManHeader{
 		Title:   "Istio Control",
 		Section: "istioctl CLI",

--- a/istioctl/pkg/clioptions/central.go
+++ b/istioctl/pkg/clioptions/central.go
@@ -14,21 +14,49 @@
 
 package clioptions
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+)
 
 // CentralControlPlaneOptions holds options common to all subcommands
 // that invoke Istiod via xDS REST endpoint
 type CentralControlPlaneOptions struct {
-	// XDS endpoint, e.g. localhost:15010.
+	// Xds is XDS endpoint, e.g. localhost:15010.
 	Xds string
 
-	// TODO TLS options
-	// TODO timeout?
+	// XdsLabel is a Kubernetes label on the Istiod service
+	XdsLabel string
+
+	// CertDir is the local directory containing certificates
+	CertDir string
+
+	// Timeout is how long to wait before giving up on XDS
+	Timeout time.Duration
 }
 
 // AttachControlPlaneFlags attaches control-plane flags to a Cobra command.
 // (Currently just --endpoint)
 func (o *CentralControlPlaneOptions) AttachControlPlaneFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().StringVar(&o.Xds, "endpoint", "",
+	cmd.PersistentFlags().StringVar(&o.Xds, "xds-address", "",
 		"XDS Endpoint")
+	cmd.PersistentFlags().StringVar(&o.CertDir, "cert-dir", "",
+		"XDS Endpoint (UNIMPLEMENTED)")
+	cmd.PersistentFlags().StringVar(&o.XdsLabel, "xds-label", "",
+		"Istio XDS service label (UNIMPLEMENTED)")
+	cmd.PersistentFlags().DurationVar(&o.Timeout, "timeout", time.Second*30,
+		"the duration to wait before failing")
+}
+
+// ValidateControlPlaneFlags checks arguments for valid values and combinations
+func (o *CentralControlPlaneOptions) ValidateControlPlaneFlags() error {
+	if o.Xds != "" && o.XdsLabel != "" {
+		return fmt.Errorf("either --xds-address or --xds-label, not both")
+	}
+	if o.XdsLabel != "" {
+		return fmt.Errorf("--xds-label not implemented")
+	}
+	return nil
 }

--- a/istioctl/pkg/clioptions/central.go
+++ b/istioctl/pkg/clioptions/central.go
@@ -1,0 +1,34 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clioptions
+
+import "github.com/spf13/cobra"
+
+// CentralControlPlaneOptions holds options common to all subcommands
+// that invoke Istiod via xDS REST endpoint
+type CentralControlPlaneOptions struct {
+	// XDS endpoint, e.g. localhost:15010.
+	Xds string
+
+	// TODO TLS options
+	// TODO timeout?
+}
+
+// AttachControlPlaneFlags attaches control-plane flags to a Cobra command.
+// (Currently just --endpoint)
+func (o *CentralControlPlaneOptions) AttachControlPlaneFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringVar(&o.Xds, "endpoint", "",
+		"XDS Endpoint")
+}

--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -222,7 +222,11 @@ func tlsConfig(certDir string) (*tls.Config, error) {
 	return &tls.Config{
 		Certificates: []tls.Certificate{clientCert},
 		RootCAs:      serverCAs,
-		ServerName:   "istio-pilot.istio-system",
+		// If I don't do this, my connections from istioctl/port-forward fail with
+		// authentication handshake failed: x509: certificate is valid for istiod.istio-system.svc,
+		// istiod-remote.istio-system.svc, istio-pilot.istio-system.svc, not istio-pilot.istio-system
+		// TODO Why?
+		ServerName: "istio-pilot.istio-system.svc",
 		VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 			return nil
 		},


### PR DESCRIPTION
Proof of concept for https://github.com/istio/istio/issues/23538

This is a proof-of-concept of _istioctl_ talking to Pilot XDS for troubleshooting commands.

To use this, Istiod must be running a build with https://github.com/istio/istio/pull/23833 merged.

The output on my cluster of `istioctl x proxy-status --endpoint localhost:15010` is
```
NAME                                               MESH          CDS  LDS  EDS  RDS  PILOT
prometheus-857cfcb987-kt7qd.istio-system           cluster.local TODO TODO TODO TODO TODO
ratings-v1-5db7d5b85b-55wcz.default                cluster.local TODO TODO TODO TODO TODO
reviews-v3-75fd6df676-nlnxk.default                cluster.local TODO TODO TODO TODO TODO
istio-ingressgateway-665c77966f-qb67c.istio-system cluster.local TODO TODO TODO TODO TODO
details-v1-785d88564-dxsfx.default                 cluster.local TODO TODO TODO TODO TODO
productpage-v1-679f4bcbbb-6j4j6.default            cluster.local TODO TODO TODO TODO TODO
reviews-v2-84cc8985db-pcl4m.default                cluster.local TODO TODO TODO TODO TODO
reviews-v1-5cddfdfd64-g6bd9.default                cluster.local TODO TODO TODO TODO TODO
```

This is very similar to the non-experimental proxy-status.  We have added a field called MESH which comes from XDS' MeshID.  My hope is that if there are >1 cluster in a mesh that they will have unique MeshIDs.

I am hoping for a review from @costinm and @howardjohn to see if I am using the expected APIs and not abusing anything.  I am also interested in advice on how to finish the places I have TODOs.  I realize the istio.io/acks and /nacks aren't ready.  I want a review of the approach.

Feedback appreciated from @liamawhite and @therealmitchconnors.  Not for how I have factored this -- it is a ball of mud right now.  Do we think this can be made into something nice and is this the right direction to get initial central Istiod into 1.7?