### PR TITLE
Don't skip networking.istio.io/v1beta1 for "istioctl validate -f"

### DIFF
--- a/istioctl/pkg/validate/validate.go
+++ b/istioctl/pkg/validate/validate.go
@@ -97,11 +97,17 @@ func checkFields(un *unstructured.Unstructured) error {
 }
 
 func (v *validator) validateResource(istioNamespace string, un *unstructured.Unstructured) error {
-	schema, exists := collections.Pilot.FindByGroupVersionKind(resource.GroupVersionKind{
+	gvk := resource.GroupVersionKind{
 		Group:   un.GroupVersionKind().Group,
 		Version: un.GroupVersionKind().Version,
 		Kind:    un.GroupVersionKind().Kind,
-	})
+	}
+	// TODO(jasonwzm) remove this when multi-version is supported. v1beta1 shares the same
+	// schema as v1lalpha3. Fake conversion and validate against v1alpha3.
+	if gvk.Group == "networking.istio.io" && gvk.Version == "v1beta1" {
+		gvk.Version = "v1alpha3"
+	}
+	schema, exists := collections.Pilot.FindByGroupVersionKind(gvk)
 	if exists {
 		obj, err := convertObjectFromUnstructured(schema, un, "")
 		if err != nil {

--- a/istioctl/pkg/validate/validate_test.go
+++ b/istioctl/pkg/validate/validate_test.go
@@ -211,6 +211,14 @@ spec:
           host: c
           subset: v2
         weight: 25`
+	invalidVirtualServiceV1Beta1 = `
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: invalid-virtual-service
+spec:
+  http:
+`
 	validMixerRule = `
 apiVersion: "config.istio.io/v1alpha2"
 kind: rule
@@ -255,7 +263,7 @@ metadata:
 unexpected_junk:
    still_more_junk:
 spec:
-	host: productpage`
+  host: productpage`
 	versionLabelMissingDeployment = `
 apiVersion: apps/v1
 kind: Deployment
@@ -316,6 +324,11 @@ func TestValidateResource(t *testing.T) {
 		{
 			name:  "invalid pilot configuration",
 			in:    invalidVirtualService,
+			valid: false,
+		},
+		{
+			name:  "invalid pilot configuration v1beta1",
+			in:    invalidVirtualServiceV1Beta1,
 			valid: false,
 		},
 		{
@@ -549,9 +562,10 @@ $`),
 			wantError: true,
 		},
 		{
-			name:      "invalid top-level key",
-			args:      []string{"--filename", unsupportedKeyFilename},
-			wantError: true,
+			name:           "invalid top-level key",
+			args:           []string{"--filename", unsupportedKeyFilename},
+			expectedRegexp: regexp.MustCompile(`.*unknown field "unexpected_junk"`),
+			wantError:      true,
 		},
 		{
 			name:      "version label missing deployment",


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/24064 .

cc @jasonwzm the change follows your code in _pkg/webhooks/validation/server/server.go_.  When you introduce multi-version, make sure it is available to istioctl.