### PR TITLE
fix manifest rendering issue when iop is deleted.

### DIFF
--- a/operator/pkg/helmreconciler/reconciler.go
+++ b/operator/pkg/helmreconciler/reconciler.go
@@ -196,11 +196,7 @@ func (h *HelmReconciler) processRecursive(manifests name.ManifestMap) *v1alpha1.
 
 // Delete resources associated with the custom resource instance
 func (h *HelmReconciler) Delete() error {
-	manifestMap, err := h.RenderCharts()
-	if err != nil {
-		return err
-	}
-	return h.Prune(manifestMap, true)
+	return h.Prune(nil, true)
 }
 
 // SetStatusBegin updates the status field on the IstioOperator instance before reconciling.


### PR DESCRIPTION
Please provide a description for what this PR is for.

resolve: https://github.com/istio/istio/issues/24038
This simplify the prune logic for in-cluster operator:
The helm reconciler doesn't need to render manifests again, it juste need to prune all the resources matching label selectors and clean the cache if necessary.
If we really want to render manifests, we may need to merge IOP with profile and set `global` fields of `values`, that will slow the whole reconcile process.

[ X ] Installation