### PR TITLE
Fix HTTP2/HTTP conflict at Gateway

### DIFF
--- a/pilot/pkg/model/gateway.go
+++ b/pilot/pkg/model/gateway.go
@@ -117,7 +117,7 @@ func MergeGateways(gateways ...Config) *MergedGateway {
 
 				if server, exists := plaintextServers[s.Port.Number]; exists {
 					currentProto := protocol.Parse(server[0].Port.Protocol)
-					if currentProto != p || !p.IsHTTP() {
+					if !canMergeProtocols(currentProto, p) {
 						log.Debugf("skipping server on gateway %s port %s.%d.%s: conflict with existing server %s.%d.%s",
 							gatewayConfig.Name, s.Port.Name, s.Port.Number, s.Port.Protocol, server[0].Port.Name, server[0].Port.Number, server[0].Port.Protocol)
 						recordRejectedConfig(gatewayName)
@@ -200,6 +200,10 @@ func MergeGateways(gateways ...Config) *MergedGateway {
 		ServersByRouteName:   serversByRouteName,
 		RouteNamesByServer:   routeNamesByServer,
 	}
+}
+
+func canMergeProtocols(current protocol.Instance, p protocol.Instance) bool {
+	return (current.IsHTTP() || current == p) && p.IsHTTP()
 }
 
 // checkDuplicates returns all of the hosts provided that are already known

--- a/pilot/pkg/model/gateway_test.go
+++ b/pilot/pkg/model/gateway_test.go
@@ -22,12 +22,12 @@ import (
 )
 
 func TestMergeGateways(t *testing.T) {
-	gwHttpFoo := makeConfig("foo1", "not-default", "foo.bar.com", "name1", "http", 7, "ingressgateway")
-	gwHttp2Wildcard := makeConfig("foo5", "not-default", "*", "name5", "http2", 8, "ingressgateway")
-	gwHttpWildcard := makeConfig("foo3", "not-default", "*", "name3", "http", 8, "ingressgateway")
-	gwTcpWildcard := makeConfig("foo4", "not-default-2", "*", "name4", "tcp", 8, "ingressgateway")
+	gwHTTPFoo := makeConfig("foo1", "not-default", "foo.bar.com", "name1", "http", 7, "ingressgateway")
+	gwHTTP2Wildcard := makeConfig("foo5", "not-default", "*", "name5", "http2", 8, "ingressgateway")
+	gwHTTPWildcard := makeConfig("foo3", "not-default", "*", "name3", "http", 8, "ingressgateway")
+	gwTCPWildcard := makeConfig("foo4", "not-default-2", "*", "name4", "tcp", 8, "ingressgateway")
 
-	gwHttpWildcardAlternate := makeConfig("foo2", "not-default", "*", "name2", "http", 7, "ingressgateway2")
+	gwHTTPWildcardAlternate := makeConfig("foo2", "not-default", "*", "name2", "http", 7, "ingressgateway2")
 
 	tests := []struct {
 		name               string
@@ -38,49 +38,49 @@ func TestMergeGateways(t *testing.T) {
 	}{
 		{
 			"single-server-config",
-			[]Config{gwHttpFoo},
+			[]Config{gwHTTPFoo},
 			1,
 			map[string]int{"http.7": 1},
 			1,
 		},
 		{
 			"same-server-config",
-			[]Config{gwHttpFoo, gwHttpWildcardAlternate},
+			[]Config{gwHTTPFoo, gwHTTPWildcardAlternate},
 			1,
 			map[string]int{"http.7": 2},
 			2,
 		},
 		{
 			"multi-server-config",
-			[]Config{gwHttpFoo, gwHttpWildcardAlternate, gwHttpWildcard},
+			[]Config{gwHTTPFoo, gwHTTPWildcardAlternate, gwHTTPWildcard},
 			2,
 			map[string]int{"http.7": 2, "http.8": 1},
 			3,
 		},
 		{
 			"http-tcp-server-config",
-			[]Config{gwHttpFoo, gwTcpWildcard},
+			[]Config{gwHTTPFoo, gwTCPWildcard},
 			2,
 			map[string]int{"http.7": 1},
 			2,
 		},
 		{
 			"tcp-tcp-server-config",
-			[]Config{gwTcpWildcard, gwHttpWildcard},
+			[]Config{gwTCPWildcard, gwHTTPWildcard},
 			1,
 			map[string]int{},
 			2,
 		},
 		{
 			"tcp-tcp-server-config",
-			[]Config{gwHttpWildcard, gwTcpWildcard}, //order matters
+			[]Config{gwHTTPWildcard, gwTCPWildcard}, //order matters
 			1,
 			map[string]int{"http.8": 1},
 			2,
 		},
 		{
 			"http-http2-server-config",
-			[]Config{gwHttpWildcard, gwHttp2Wildcard}, //order matters
+			[]Config{gwHTTPWildcard, gwHTTP2Wildcard}, //order matters
 			1,
 			// http and http2 both present
 			map[string]int{"http.8": 2},

--- a/pilot/pkg/model/gateway_test.go
+++ b/pilot/pkg/model/gateway_test.go
@@ -22,58 +22,68 @@ import (
 )
 
 func TestMergeGateways(t *testing.T) {
-	configGw1 := makeConfig("foo1", "not-default", "foo.bar.com", "name1", "http", 7, "ingressgateway")
-	configGw2 := makeConfig("foo2", "not-default", "*", "name2", "http", 7, "ingressgateway2")
-	configGw3 := makeConfig("foo3", "not-default", "*", "name3", "http", 8, "ingressgateway")
-	configGw4 := makeConfig("foo4", "not-default-2", "*", "name4", "tcp", 8, "ingressgateway")
+	gwHttpFoo := makeConfig("foo1", "not-default", "foo.bar.com", "name1", "http", 7, "ingressgateway")
+	gwHttp2Wildcard := makeConfig("foo5", "not-default", "*", "name5", "http2", 8, "ingressgateway")
+	gwHttpWildcard := makeConfig("foo3", "not-default", "*", "name3", "http", 8, "ingressgateway")
+	gwTcpWildcard := makeConfig("foo4", "not-default-2", "*", "name4", "tcp", 8, "ingressgateway")
+
+	gwHttpWildcardAlternate := makeConfig("foo2", "not-default", "*", "name2", "http", 7, "ingressgateway2")
 
 	tests := []struct {
-		name        string
-		gwConfig    []Config
-		serversNum  int
-		routesNum   int
-		gatewaysNum int
+		name               string
+		gwConfig           []Config
+		serversNum         int
+		serversForRouteNum map[string]int
+		gatewaysNum        int
 	}{
 		{
 			"single-server-config",
-			[]Config{configGw1},
+			[]Config{gwHttpFoo},
 			1,
-			1,
+			map[string]int{"http.7": 1},
 			1,
 		},
 		{
 			"same-server-config",
-			[]Config{configGw1, configGw2},
+			[]Config{gwHttpFoo, gwHttpWildcardAlternate},
 			1,
-			1,
+			map[string]int{"http.7": 2},
 			2,
 		},
 		{
 			"multi-server-config",
-			[]Config{configGw1, configGw2, configGw3},
+			[]Config{gwHttpFoo, gwHttpWildcardAlternate, gwHttpWildcard},
 			2,
-			2,
+			map[string]int{"http.7": 2, "http.8": 1},
 			3,
 		},
 		{
 			"http-tcp-server-config",
-			[]Config{configGw1, configGw4},
+			[]Config{gwHttpFoo, gwTcpWildcard},
 			2,
-			1,
-			2,
-		},
-		{
-			"tcp-tcp-server-config",
-			[]Config{configGw4, configGw3},
-			1,
-			0,
+			map[string]int{"http.7": 1},
 			2,
 		},
 		{
 			"tcp-tcp-server-config",
-			[]Config{configGw3, configGw4}, //order matters
+			[]Config{gwTcpWildcard, gwHttpWildcard},
 			1,
+			map[string]int{},
+			2,
+		},
+		{
+			"tcp-tcp-server-config",
+			[]Config{gwHttpWildcard, gwTcpWildcard}, //order matters
 			1,
+			map[string]int{"http.8": 1},
+			2,
+		},
+		{
+			"http-http2-server-config",
+			[]Config{gwHttpWildcard, gwHttp2Wildcard}, //order matters
+			1,
+			// http and http2 both present
+			map[string]int{"http.8": 2},
 			2,
 		},
 	}
@@ -84,8 +94,13 @@ func TestMergeGateways(t *testing.T) {
 			if len(mgw.Servers) != tt.serversNum {
 				t.Errorf("Incorrect number of servers. Expected: %v Got: %d", tt.serversNum, len(mgw.Servers))
 			}
-			if len(mgw.ServersByRouteName) != tt.routesNum {
-				t.Errorf("Incorrect number of routes. Expected: %v Got: %d", tt.routesNum, len(mgw.ServersByRouteName))
+			if len(mgw.ServersByRouteName) != len(tt.serversForRouteNum) {
+				t.Errorf("Incorrect number of routes. Expected: %v Got: %d", len(tt.serversForRouteNum), len(mgw.ServersByRouteName))
+			}
+			for k, v := range mgw.ServersByRouteName {
+				if tt.serversForRouteNum[k] != len(v) {
+					t.Errorf("for route %v expected %v servers got %v", k, tt.serversForRouteNum[k], len(v))
+				}
 			}
 			if len(mgw.GatewayNameForServer) != tt.gatewaysNum {
 				t.Errorf("Incorrect number of gateways. Expected: %v Got: %d", tt.gatewaysNum, len(mgw.GatewayNameForServer))


### PR DESCRIPTION
Currently if both of these exist, only one is used. However, we generate
literally the same config for http 1 and 2 - so no reason not to merge.

Fixes https://github.com/istio/istio/issues/24061
Fixes https://github.com/istio/istio/issues/19690