### PR TITLE
Support v2 and v3 XDS transport protocols

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/adapter.go
+++ b/pilot/pkg/proxy/envoy/v2/adapter.go
@@ -29,7 +29,7 @@ import (
 // This allows v2 clients to connect, while keeping the core logic of Pilot in v3 XDS.
 // This comes with a very small performance impact, as most resources are directly copied over - most
 // importantly the actual XDS response objects are untouched.
-// Note: this is just about the transport protocol. The XDS resource versioning is independant of transport
+// Note: this is just about the transport protocol. The XDS resource versioning is independent of transport
 // protocol
 type DiscoveryStreamV2Adapter struct {
 	ads.AggregatedDiscoveryService_StreamAggregatedResourcesServer

--- a/pilot/pkg/proxy/envoy/v2/adapter.go
+++ b/pilot/pkg/proxy/envoy/v2/adapter.go
@@ -1,0 +1,113 @@
+// Copyright 2020 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import (
+	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	corev2 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	ads "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+)
+
+// DiscoveryStreamV2Adapter is a DiscoveryStream that converts v3 Discovery messages to v2 messages.
+// This allows v2 clients to connect, while keeping the core logic of Pilot in v3 XDS.
+// This comes with a very small performance impact, as most resources are directly copied over - most
+// importantly the actual XDS response objects are untouched.
+// Note: this is just about the transport protocol. The XDS resource versioning is independant of transport
+// protocol
+type DiscoveryStreamV2Adapter struct {
+	ads.AggregatedDiscoveryService_StreamAggregatedResourcesServer
+}
+
+// We implement the v3 DiscoveryStream API
+var _ DiscoveryStream = &DiscoveryStreamV2Adapter{}
+
+func (d DiscoveryStreamV2Adapter) Send(r *discovery.DiscoveryResponse) error {
+	return d.AggregatedDiscoveryService_StreamAggregatedResourcesServer.Send(&xdsapi.DiscoveryResponse{
+		VersionInfo: r.VersionInfo,
+		Resources:   r.Resources,
+		Canary:      r.Canary,
+		TypeUrl:     r.TypeUrl,
+		Nonce:       r.Nonce,
+	})
+}
+
+func (d DiscoveryStreamV2Adapter) Recv() (*discovery.DiscoveryRequest, error) {
+	v2Req, err := d.AggregatedDiscoveryService_StreamAggregatedResourcesServer.Recv()
+	if v2Req == nil {
+		return nil, err
+	}
+	return &discovery.DiscoveryRequest{
+		VersionInfo:   v2Req.VersionInfo,
+		Node:          convertToV3Node(v2Req.Node),
+		ResourceNames: v2Req.ResourceNames,
+		TypeUrl:       v2Req.TypeUrl,
+		ResponseNonce: v2Req.ResponseNonce,
+		ErrorDetail:   v2Req.ErrorDetail,
+	}, err
+}
+
+func convertToV3Node(node *corev2.Node) *corev3.Node {
+	if node == nil {
+		return nil
+	}
+	resp := &corev3.Node{
+		Id:             node.Id,
+		Cluster:        node.Cluster,
+		Metadata:       node.Metadata,
+		ClientFeatures: node.ClientFeatures,
+	}
+	if node.Locality != nil {
+		l := node.Locality
+		resp.Locality = &corev3.Locality{
+			Region:  l.Region,
+			Zone:    l.Zone,
+			SubZone: l.SubZone,
+		}
+	}
+	return resp
+}
+
+// discoveryServerV2Adapter is a DiscoveryServer that converts v3 Discovery messages to v2 messages.
+// See notes in DiscoveryStreamV2Adapter for more info.
+type discoveryServerV2Adapter struct {
+	s *DiscoveryServer
+}
+
+// We implement the v2 ADS API
+var _ ads.AggregatedDiscoveryServiceServer = &discoveryServerV2Adapter{}
+
+func (d *discoveryServerV2Adapter) StreamAggregatedResources(stream ads.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
+	v3Stream := &DiscoveryStreamV2Adapter{stream}
+	peerInfo, ok := peer.FromContext(stream.Context())
+	peerAddr := "0.0.0.0"
+	if ok {
+		peerAddr = peerInfo.Addr.String()
+	}
+	adsLog.Infof("ADS: starting legacy v2 discovery stream from %v", peerAddr)
+	return d.s.StreamAggregatedResources(v3Stream)
+}
+
+func (d discoveryServerV2Adapter) DeltaAggregatedResources(server ads.AggregatedDiscoveryService_DeltaAggregatedResourcesServer) error {
+	return status.Errorf(codes.Unimplemented, "not implemented")
+}
+
+func (s *DiscoveryServer) createV2Adapter() ads.AggregatedDiscoveryServiceServer {
+	return &discoveryServerV2Adapter{s}
+}

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -21,13 +21,11 @@ import (
 	"sync"
 	"time"
 
-	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	corev2 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
-	ads "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/peer"
@@ -51,8 +49,8 @@ var (
 // DiscoveryStream is a common interface for EDS and ADS. It also has a
 // shorter name.
 type DiscoveryStream interface {
-	Send(*xdsapi.DiscoveryResponse) error
-	Recv() (*xdsapi.DiscoveryRequest, error)
+	Send(*discovery.DiscoveryResponse) error
+	Recv() (*discovery.DiscoveryRequest, error)
 	grpc.ServerStream
 }
 
@@ -167,7 +165,7 @@ func isExpectedGRPCError(err error) bool {
 	return false
 }
 
-func receiveThread(con *XdsConnection, reqChannel chan *xdsapi.DiscoveryRequest, errP *error) {
+func receiveThread(con *XdsConnection, reqChannel chan *discovery.DiscoveryRequest, errP *error) {
 	defer close(reqChannel) // indicates close of the remote side.
 	for {
 		req, err := con.stream.Recv()
@@ -193,7 +191,7 @@ func receiveThread(con *XdsConnection, reqChannel chan *xdsapi.DiscoveryRequest,
 }
 
 // StreamAggregatedResources implements the ADS interface.
-func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
+func (s *DiscoveryServer) StreamAggregatedResources(stream discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
 	peerInfo, ok := peer.FromContext(stream.Context())
 	peerAddr := "0.0.0.0"
 	if ok {
@@ -224,7 +222,7 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 	// go routine. If go grpc adds gochannel support for streams this will not be needed.
 	// This also detects close.
 	var receiveError error
-	reqChannel := make(chan *xdsapi.DiscoveryRequest, 1)
+	reqChannel := make(chan *discovery.DiscoveryRequest, 1)
 	go receiveThread(con, reqChannel, &receiveError)
 
 	for {
@@ -331,7 +329,7 @@ func (s *DiscoveryServer) handleTypeURL(typeURL string, requestedType *string) e
 	return nil
 }
 
-func (s *DiscoveryServer) handleLds(con *XdsConnection, discReq *xdsapi.DiscoveryRequest) error {
+func (s *DiscoveryServer) handleLds(con *XdsConnection, discReq *discovery.DiscoveryRequest) error {
 	if con.LDSWatch {
 		// Already received a cluster watch request, this is an ACK
 		if discReq.ErrorDetail != nil {
@@ -356,7 +354,7 @@ func (s *DiscoveryServer) handleLds(con *XdsConnection, discReq *xdsapi.Discover
 	return nil
 }
 
-func (s *DiscoveryServer) handleCds(con *XdsConnection, discReq *xdsapi.DiscoveryRequest) error {
+func (s *DiscoveryServer) handleCds(con *XdsConnection, discReq *discovery.DiscoveryRequest) error {
 	if con.CDSWatch {
 		// Already received a cluster watch request, this is an ACK
 		if discReq.ErrorDetail != nil {
@@ -385,7 +383,7 @@ func (s *DiscoveryServer) handleCds(con *XdsConnection, discReq *xdsapi.Discover
 	return nil
 }
 
-func (s *DiscoveryServer) handleEds(con *XdsConnection, discReq *xdsapi.DiscoveryRequest) error {
+func (s *DiscoveryServer) handleEds(con *XdsConnection, discReq *discovery.DiscoveryRequest) error {
 	if discReq.ErrorDetail != nil {
 		errCode := codes.Code(discReq.ErrorDetail.Code)
 		adsLog.Warnf("ADS:EDS: ACK ERROR %s %s:%s", con.ConID, errCode.String(), discReq.ErrorDetail.GetMessage())
@@ -429,7 +427,7 @@ func (s *DiscoveryServer) handleEds(con *XdsConnection, discReq *xdsapi.Discover
 	return nil
 }
 
-func (s *DiscoveryServer) handleRds(con *XdsConnection, discReq *xdsapi.DiscoveryRequest) error {
+func (s *DiscoveryServer) handleRds(con *XdsConnection, discReq *discovery.DiscoveryRequest) error {
 	if discReq.ErrorDetail != nil {
 		errCode := codes.Code(discReq.ErrorDetail.Code)
 		adsLog.Warnf("ADS:RDS: ACK ERROR %s %s:%s", con.ConID, errCode.String(), discReq.ErrorDetail.GetMessage())
@@ -495,7 +493,7 @@ func listEqualUnordered(a []string, b []string) bool {
 
 // update the node associated with the connection, after receiving a a packet from envoy, also adds the connection
 // to the tracking map.
-func (s *DiscoveryServer) initConnection(node *corev2.Node, con *XdsConnection) error {
+func (s *DiscoveryServer) initConnection(node *corev3.Node, con *XdsConnection) error {
 	proxy, err := s.initProxy(node)
 	if err != nil {
 		return err
@@ -523,7 +521,7 @@ func (s *DiscoveryServer) initConnection(node *corev2.Node, con *XdsConnection) 
 }
 
 // initProxy initializes the Proxy from node.
-func (s *DiscoveryServer) initProxy(node *corev2.Node) (*model.Proxy, error) {
+func (s *DiscoveryServer) initProxy(node *corev3.Node) (*model.Proxy, error) {
 	meta, err := model.ParseMetadata(node.Metadata)
 	if err != nil {
 		return nil, err
@@ -603,7 +601,7 @@ func (s *DiscoveryServer) setProxyState(proxy *model.Proxy, push *model.PushCont
 // The delta protocol changes the request, adding unsubscribe/subscribe instead of sending full
 // list of resources. On the response it adds 'removed resources' and sends changes for everything.
 // TODO: we could implement this method if needed, the change is not very big.
-func (s *DiscoveryServer) DeltaAggregatedResources(stream ads.AggregatedDiscoveryService_DeltaAggregatedResourcesServer) error {
+func (s *DiscoveryServer) DeltaAggregatedResources(stream discovery.AggregatedDiscoveryService_DeltaAggregatedResourcesServer) error {
 	return status.Errorf(codes.Unimplemented, "not implemented")
 }
 
@@ -826,7 +824,7 @@ func (s *DiscoveryServer) removeCon(conID string) {
 }
 
 // Send with timeout
-func (conn *XdsConnection) send(res *xdsapi.DiscoveryResponse) error {
+func (conn *XdsConnection) send(res *discovery.DiscoveryResponse) error {
 	done := make(chan error, 1)
 	// hardcoded for now - not sure if we need a setting
 	t := time.NewTimer(SendTimeout)

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -114,7 +114,7 @@ type XdsConnection struct {
 
 	// Original node metadata, to avoid unmarshall/marshall. This is included
 	// in internal events.
-	xdsNode *corev2.Node
+	xdsNode *corev3.Node
 }
 
 // XdsEvent represents a config or registry event that results in a push.

--- a/pilot/pkg/proxy/envoy/v2/cds.go
+++ b/pilot/pkg/proxy/envoy/v2/cds.go
@@ -17,16 +17,16 @@ package v2
 import (
 	"time"
 
-	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 )
 
 // clusters aggregate a DiscoveryResponse for pushing.
-func cdsDiscoveryResponse(response []*cluster.Cluster, noncePrefix, typeURL string) *xdsapi.DiscoveryResponse {
-	out := &xdsapi.DiscoveryResponse{
+func cdsDiscoveryResponse(response []*cluster.Cluster, noncePrefix, typeURL string) *discovery.DiscoveryResponse {
+	out := &discovery.DiscoveryResponse{
 		// All resources for CDS ought to be of the type Cluster
 		TypeUrl: typeURL,
 

--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -19,7 +19,7 @@ import (
 	"sync"
 	"time"
 
-	ads "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
+	discoveryv2 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/google/uuid"
 	"go.uber.org/atomic"
@@ -165,7 +165,7 @@ func NewDiscoveryServer(env *model.Environment, plugins []string) *DiscoveryServ
 func (s *DiscoveryServer) Register(rpcs *grpc.Server) {
 	// Register v2 and v3 servers
 	discovery.RegisterAggregatedDiscoveryServiceServer(rpcs, s)
-	ads.RegisterAggregatedDiscoveryServiceServer(rpcs, s.createV2Adapter())
+	discoveryv2.RegisterAggregatedDiscoveryServiceServer(rpcs, s.createV2Adapter())
 }
 
 func (s *DiscoveryServer) Start(stopCh <-chan struct{}) {

--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	ads "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/google/uuid"
 	"go.uber.org/atomic"
 	"google.golang.org/grpc"
@@ -162,7 +163,9 @@ func NewDiscoveryServer(env *model.Environment, plugins []string) *DiscoveryServ
 
 // Register adds the ADS and EDS handles to the grpc server
 func (s *DiscoveryServer) Register(rpcs *grpc.Server) {
-	ads.RegisterAggregatedDiscoveryServiceServer(rpcs, s)
+	// Register v2 and v3 servers
+	discovery.RegisterAggregatedDiscoveryServiceServer(rpcs, s)
+	ads.RegisterAggregatedDiscoveryServiceServer(rpcs, s.createV2Adapter())
 }
 
 func (s *DiscoveryServer) Start(stopCh <-chan struct{}) {

--- a/pilot/pkg/proxy/envoy/v2/discovery_test.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"google.golang.org/grpc"
 
 	"istio.io/istio/pkg/test/util/retry"
@@ -152,11 +152,11 @@ type fakeStream struct {
 	grpc.ServerStream
 }
 
-func (h *fakeStream) Send(*xdsapi.DiscoveryResponse) error {
+func (h *fakeStream) Send(*discovery.DiscoveryResponse) error {
 	return nil
 }
 
-func (h *fakeStream) Recv() (*xdsapi.DiscoveryRequest, error) {
+func (h *fakeStream) Recv() (*discovery.DiscoveryRequest, error) {
 	return nil, nil
 }
 

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -19,8 +19,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/wrappers"
 
@@ -531,8 +531,8 @@ func getOutlierDetectionAndLoadBalancerSettings(push *model.PushContext, proxy *
 	return outlierDetectionEnabled, lbSettings
 }
 
-func endpointDiscoveryResponse(loadAssignments []*endpoint.ClusterLoadAssignment, version, noncePrefix, typeURL string) *xdsapi.DiscoveryResponse {
-	out := &xdsapi.DiscoveryResponse{
+func endpointDiscoveryResponse(loadAssignments []*endpoint.ClusterLoadAssignment, version, noncePrefix, typeURL string) *discovery.DiscoveryResponse {
+	out := &discovery.DiscoveryResponse{
 		TypeUrl: typeURL,
 		// Pilot does not really care for versioning. It always supplies what's currently
 		// available to it, irrespective of whether Envoy chooses to accept or reject EDS

--- a/pilot/pkg/proxy/envoy/v2/gen2.go
+++ b/pilot/pkg/proxy/envoy/v2/gen2.go
@@ -17,7 +17,7 @@ package v2
 import (
 	"time"
 
-	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"google.golang.org/grpc/codes"
 
 	"istio.io/istio/pilot/pkg/model"
@@ -27,7 +27,7 @@ import (
 
 // handleReqAck checks if the message is an ack/nack and handles it, returning true.
 // If false, the request should be processed by calling the generator.
-func (s *DiscoveryServer) handleReqAck(con *XdsConnection, discReq *xdsapi.DiscoveryRequest) (*model.WatchedResource, bool) {
+func (s *DiscoveryServer) handleReqAck(con *XdsConnection, discReq *discovery.DiscoveryRequest) (*model.WatchedResource, bool) {
 
 	// All NACKs should have ErrorDetail set !
 	// Relying on versionCode != sentVersionCode as nack is less reliable.
@@ -89,14 +89,14 @@ func (s *DiscoveryServer) handleReqAck(con *XdsConnection, discReq *xdsapi.Disco
 }
 
 // handleCustomGenerator uses model.Generator to generate the response.
-func (s *DiscoveryServer) handleCustomGenerator(con *XdsConnection, req *xdsapi.DiscoveryRequest) error {
+func (s *DiscoveryServer) handleCustomGenerator(con *XdsConnection, req *discovery.DiscoveryRequest) error {
 	w, isAck := s.handleReqAck(con, req)
 	if isAck {
 		return nil
 	}
 
 	push := s.globalPushContext()
-	resp := &xdsapi.DiscoveryResponse{
+	resp := &discovery.DiscoveryResponse{
 		TypeUrl:     w.TypeUrl,
 		VersionInfo: push.Version, // TODO: we can now generate per-type version !
 		Nonce:       nonce(push.Version),
@@ -153,7 +153,7 @@ func (s *DiscoveryServer) pushGeneratorV2(con *XdsConnection, push *model.PushCo
 	// become dependent of the specific resource - for example in case of API it'll be the largest
 	// version of the requested type.
 
-	resp := &xdsapi.DiscoveryResponse{
+	resp := &discovery.DiscoveryResponse{
 		TypeUrl:     w.TypeUrl,
 		VersionInfo: currentVersion,
 		Nonce:       nonce(push.Version),

--- a/pilot/pkg/proxy/envoy/v2/internalgen.go
+++ b/pilot/pkg/proxy/envoy/v2/internalgen.go
@@ -15,7 +15,7 @@
 package v2
 
 import (
-	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/golang/protobuf/ptypes/any"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 
@@ -73,7 +73,7 @@ func (sg *InternalGen) OnDisconnect(con *XdsConnection) {
 	// Note that it is quite possible for a 'connect' on a different istiod to happen before a disconnect.
 }
 
-func (sg *InternalGen) OnNack(node *model.Proxy, dr *xdsapi.DiscoveryRequest) {
+func (sg *InternalGen) OnNack(node *model.Proxy, dr *discovery.DiscoveryRequest) {
 	// Make sure we include the ID - the DR may not include metadata
 	dr.Node.Id = node.ID
 	sg.startPush(TypeURLNACK, []*any.Any{util.MessageToAny(dr)})
@@ -96,7 +96,7 @@ func (sg *InternalGen) startPush(typeURL string, data []*any.Any) {
 	}
 	sg.Server.adsClientsMutex.RUnlock()
 
-	dr := &xdsapi.DiscoveryResponse{
+	dr := &discovery.DiscoveryResponse{
 		TypeUrl:   typeURL,
 		Resources: data,
 	}

--- a/pilot/pkg/proxy/envoy/v2/lds.go
+++ b/pilot/pkg/proxy/envoy/v2/lds.go
@@ -17,8 +17,8 @@ package v2
 import (
 	"time"
 
-	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
@@ -47,8 +47,8 @@ func (s *DiscoveryServer) pushLds(con *XdsConnection, push *model.PushContext, v
 }
 
 // LdsDiscoveryResponse returns a list of listeners for the given environment and source node.
-func ldsDiscoveryResponse(ls []*listener.Listener, version, noncePrefix, typeURL string) *xdsapi.DiscoveryResponse {
-	resp := &xdsapi.DiscoveryResponse{
+func ldsDiscoveryResponse(ls []*listener.Listener, version, noncePrefix, typeURL string) *discovery.DiscoveryResponse {
+	resp := &discovery.DiscoveryResponse{
 		TypeUrl:     typeURL,
 		VersionInfo: version,
 		Nonce:       nonce(noncePrefix),

--- a/pilot/pkg/proxy/envoy/v2/rds.go
+++ b/pilot/pkg/proxy/envoy/v2/rds.go
@@ -19,9 +19,9 @@ import (
 
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 
-	"istio.io/istio/pkg/util/protomarshal"
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
-	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	"istio.io/istio/pkg/util/protomarshal"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
@@ -54,8 +54,8 @@ func (s *DiscoveryServer) pushRoute(con *XdsConnection, push *model.PushContext,
 	return nil
 }
 
-func routeDiscoveryResponse(rs []*route.RouteConfiguration, version, noncePrefix, typeURL string) *xdsapi.DiscoveryResponse {
-	resp := &xdsapi.DiscoveryResponse{
+func routeDiscoveryResponse(rs []*route.RouteConfiguration, version, noncePrefix, typeURL string) *discovery.DiscoveryResponse {
+	resp := &discovery.DiscoveryResponse{
 		TypeUrl:     typeURL,
 		VersionInfo: version,
 		Nonce:       nonce(noncePrefix),


### PR DESCRIPTION
This allows support for both versions of the transport protocols, while
keeping internal implementation limited to just v3. This involves:
* Bumping internal implemention from v2 -> v3
* Adding a new "adapter" which upconverts v2 to v3
* Add test for v3 clients

A future PR will change the defaults to actually start using V3.

For https://github.com/istio/istio/issues/19885