### PR TITLE
test(multicluster): add initial telemetry validation test

### DIFF
--- a/pkg/test/framework/components/echo/docker/sidecar.go
+++ b/pkg/test/framework/components/echo/docker/sidecar.go
@@ -24,6 +24,8 @@ import (
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
 
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/docker"
@@ -120,6 +122,19 @@ func (s *sidecar) WaitForConfigOrFail(t test.Failer, accept func(*envoyAdmin.Con
 	}
 }
 
+func (s *sidecar) Stats() (map[string]*dto.MetricFamily, error) {
+	return s.proxyStats()
+}
+
+func (s *sidecar) StatsOrFail(t test.Failer) map[string]*dto.MetricFamily {
+	t.Helper()
+	stats, err := s.Stats()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return stats
+}
+
 func (s *sidecar) Clusters() (*envoyAdmin.Clusters, error) {
 	msg := &envoyAdmin.Clusters{}
 	if err := s.adminRequest("clusters?format=json", msg); err != nil {
@@ -171,6 +186,22 @@ func (s *sidecar) adminRequest(path string, out proto.Message) error {
 			path, err, string(result.StdErr), string(result.StdOut))
 	}
 	return nil
+}
+
+func (s *sidecar) proxyStats() (map[string]*dto.MetricFamily, error) {
+	arg := fmt.Sprintf("http://%s:%d/stats/prometheus", localhost, proxyAdminPort)
+	result, err := s.container.Exec(context.Background(), "curl", arg)
+	if err != nil {
+		return nil, fmt.Errorf("failed exec on container %s: %v. Command: curl %s. Output:\n%+v",
+			s.container.Name, err, arg, result)
+	}
+
+	parser := expfmt.TextParser{}
+	mfMap, err := parser.TextToMetricFamilies(bytes.NewReader(result.StdOut))
+	if err != nil {
+		return nil, fmt.Errorf("failed parsing prometheus stats: %v", err)
+	}
+	return mfMap, nil
 }
 
 func (s *sidecar) Logs() (string, error) {

--- a/pkg/test/framework/components/echo/echo.go
+++ b/pkg/test/framework/components/echo/echo.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	envoyAdmin "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
+	dto "github.com/prometheus/client_model/go"
 
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test"
@@ -160,4 +161,7 @@ type Sidecar interface {
 	Logs() (string, error)
 	// LogsOrFail returns the logs for the sidecar container, or aborts if an error is found
 	LogsOrFail(t test.Failer) string
+
+	Stats() (map[string]*dto.MetricFamily, error)
+	StatsOrFail(t test.Failer) map[string]*dto.MetricFamily
 }

--- a/pkg/test/framework/components/echo/kube/sidecar.go
+++ b/pkg/test/framework/components/echo/kube/sidecar.go
@@ -23,6 +23,8 @@ import (
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
 
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/echo"
@@ -159,6 +161,36 @@ func (s *sidecar) ListenersOrFail(t test.Failer) *envoyAdmin.Listeners {
 		t.Fatal(err)
 	}
 	return listeners
+}
+
+func (s *sidecar) Stats() (map[string]*dto.MetricFamily, error) {
+	return s.proxyStats()
+}
+
+func (s *sidecar) StatsOrFail(t test.Failer) map[string]*dto.MetricFamily {
+	t.Helper()
+	stats, err := s.Stats()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return stats
+}
+
+func (s *sidecar) proxyStats() (map[string]*dto.MetricFamily, error) {
+	// Exec onto the pod and make a curl request to the admin port, writing
+	command := "pilot-agent request GET /stats/prometheus"
+	response, err := s.cluster.Exec(s.podNamespace, s.podName, proxyContainerName, command)
+	if err != nil {
+		return nil, fmt.Errorf("failed exec on pod %s/%s: %v. Command: %s. Output:\n%s",
+			s.podNamespace, s.podName, err, command, response)
+	}
+
+	parser := expfmt.TextParser{}
+	mfMap, err := parser.TextToMetricFamilies(strings.NewReader(response))
+	if err != nil {
+		return nil, fmt.Errorf("failed parsing prometheus stats: %v", err)
+	}
+	return mfMap, nil
 }
 
 func (s *sidecar) adminRequest(path string, out proto.Message) error {

--- a/tests/integration/multicluster/multimaster/main_test.go
+++ b/tests/integration/multicluster/multimaster/main_test.go
@@ -67,3 +67,7 @@ func TestMulticlusterReachability(t *testing.T) {
 func TestClusterLocalService(t *testing.T) {
 	multicluster.ClusterLocalTest(t, clusterLocalNS, pilots)
 }
+
+func TestTelemetry(t *testing.T) {
+	multicluster.TelemetryTest(t, mcReachabilityNS, pilots)
+}

--- a/tests/integration/multicluster/remote/main_test.go
+++ b/tests/integration/multicluster/remote/main_test.go
@@ -77,3 +77,7 @@ func TestMulticlusterReachability(t *testing.T) {
 func TestClusterLocalService(t *testing.T) {
 	multicluster.ClusterLocalTest(t, clusterLocalNS, pilots)
 }
+
+func TestTelemetry(t *testing.T) {
+	multicluster.TelemetryTest(t, mcReachabilityNS, pilots)
+}

--- a/tests/integration/multicluster/telemetry.go
+++ b/tests/integration/multicluster/telemetry.go
@@ -88,11 +88,11 @@ func validateClusterLabelsInStats(svc echo.Instance, t test.Failer) {
 			hasSourceCluster := false
 			hasDestinationCluster := false
 			for _, label := range metric.Label {
-				if *label.Name == "source_cluster" {
+				if label.GetName() == "source_cluster" {
 					hasSourceCluster = true
 					continue
 				}
-				if *label.Name == "destination_cluster" {
+				if label.GetName() == "destination_cluster" {
 					hasDestinationCluster = true
 					continue
 				}

--- a/tests/integration/multicluster/telemetry.go
+++ b/tests/integration/multicluster/telemetry.go
@@ -1,0 +1,105 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicluster
+
+import (
+	"fmt"
+	"testing"
+
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/components/pilot"
+	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+// TelemetryTest validates that source and destination labels are collected
+// for multicluster traffic.
+func TelemetryTest(t *testing.T, ns namespace.Instance, pilots []pilot.Instance) {
+	framework.NewTest(t).
+		Label(label.Multicluster).
+		Run(func(ctx framework.TestContext) {
+			ctx.NewSubTest("telemetry").
+				Run(func(ctx framework.TestContext) {
+					clusters := ctx.Environment().Clusters()
+					services := map[resource.ClusterIndex][]*echo.Instance{}
+					builder := echoboot.NewBuilderOrFail(ctx, ctx)
+					for _, cluster := range clusters {
+						var instance echo.Instance
+						ref := &instance
+						svcName := fmt.Sprintf("echo-%d", cluster.Index())
+						builder = builder.With(ref, newEchoConfig(svcName, ns, cluster, pilots))
+						services[cluster.Index()] = append(services[cluster.Index()], ref)
+					}
+					builder.BuildOrFail(ctx)
+
+					for _, srcServices := range services {
+						for _, src := range srcServices {
+							for _, dstServices := range services {
+								src := *src
+								dest := *dstServices[0]
+								subTestName := fmt.Sprintf("%s->%s://%s:%s%s",
+									src.Config().Service,
+									"http",
+									dest.Config().Service,
+									"http",
+									"/")
+
+								ctx.NewSubTest(subTestName).
+									RunParallel(func(ctx framework.TestContext) {
+										_ = callOrFail(ctx, src, dest)
+										validateClusterLabelsInStats(src, t)
+										validateClusterLabelsInStats(dest, t)
+									})
+							}
+						}
+					}
+				})
+		})
+}
+
+func validateClusterLabelsInStats(svc echo.Instance, t test.Failer) {
+	t.Helper()
+	workloads := svc.WorkloadsOrFail(t)
+	stats := workloads[0].Sidecar().StatsOrFail(t)
+
+	for _, metricName := range []string{"istio_requests_total", "istio_request_duration_milliseconds"} {
+		instances, found := stats[metricName]
+		if !found {
+			t.Fatalf("%s not found in stats: %v", metricName, stats)
+		}
+
+		for _, metric := range instances.Metric {
+			hasSourceCluster := false
+			hasDestinationCluster := false
+			for _, label := range metric.Label {
+				if *label.Name == "source_cluster" {
+					hasSourceCluster = true
+					continue
+				}
+				if *label.Name == "destination_cluster" {
+					hasDestinationCluster = true
+					continue
+				}
+			}
+			if !hasSourceCluster && !hasDestinationCluster {
+				t.Fatalf("cluster labels missing for %q. labels: %v", metricName, metric.Label)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adds initial telemetry tests to the multicluster scenarios.

This PR is the starting point for validation of multicluster telemetry. At this point in time, it simply attempts to validate that `source_cluster` and `destination_cluster` labels are available in the telemetry. It does not attempt to validate that they have any specific value or similar. These tests will hopefully be expanded upon in the 1.7 release cycle.

[ X ] Networking
[ X ] Policies and Telemetry
[ X ] Test and Release
