### PR TITLE
Optimize listener generation

### DIFF
--- a/pilot/pkg/model/fake_store.go
+++ b/pilot/pkg/model/fake_store.go
@@ -18,6 +18,9 @@ import (
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/resource"
+
+	"time"
+
 	"istio.io/pkg/ledger"
 )
 
@@ -28,7 +31,8 @@ type FakeStore struct {
 
 func NewFakeStore() *FakeStore {
 	f := FakeStore{
-		store: make(map[resource.GroupVersionKind]map[string][]Config),
+		store:  make(map[resource.GroupVersionKind]map[string][]Config),
+		ledger: ledger.Make(time.Minute),
 	}
 	return &f
 }

--- a/pilot/pkg/networking/core/v1alpha3/filters.go
+++ b/pilot/pkg/networking/core/v1alpha3/filters.go
@@ -28,6 +28,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 
 	"istio.io/istio/pilot/pkg/networking/util"
+	alpn_filter "istio.io/istio/security/proto/envoy/config/filter/http/alpn/v2alpha1"
 )
 
 const OriginalSrc = "envoy.listener.original_src"
@@ -82,6 +83,27 @@ var (
 		Name: OriginalSrc,
 		ConfigType: &listener.ListenerFilter_TypedConfig{
 			TypedConfig: util.MessageToAny(&originalsrc.OriginalSrc{}),
+		},
+	}
+	alpnFilter = &http_conn.HttpFilter{
+		Name: AlpnFilterName,
+		ConfigType: &http_conn.HttpFilter_TypedConfig{
+			TypedConfig: util.MessageToAny(&alpn_filter.FilterConfig{
+				AlpnOverride: []*alpn_filter.FilterConfig_AlpnOverride{
+					{
+						UpstreamProtocol: alpn_filter.FilterConfig_HTTP10,
+						AlpnOverride:     mtlsHTTP10ALPN,
+					},
+					{
+						UpstreamProtocol: alpn_filter.FilterConfig_HTTP11,
+						AlpnOverride:     mtlsHTTP11ALPN,
+					},
+					{
+						UpstreamProtocol: alpn_filter.FilterConfig_HTTP2,
+						AlpnOverride:     mtlsHTTP2ALPN,
+					},
+				},
+			}),
 		},
 	}
 )

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1470,13 +1470,15 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListenerForPortOrUDS(n
 				// Build HTTP listener. If current listener entry is using HTTP or protocol sniffing,
 				// append the service. Otherwise (TCP), change current listener to use protocol sniffing.
 				if currentListenerEntry.protocol.IsHTTP() {
-					conflictType = HTTPOverHTTP
+					// conflictType is HTTPOverHTTP
+					// In these cases, we just add the services and exit early rather than recreate an identical listener
 					currentListenerEntry.services = append(currentListenerEntry.services, pluginParams.Service)
 					return
 				} else if currentListenerEntry.protocol.IsTCP() {
 					conflictType = HTTPOverTCP
 				} else {
-					conflictType = HTTPOverAuto
+					// conflictType is HTTPOverAuto
+					// In these cases, we just add the services and exit early rather than recreate an identical listener
 					currentListenerEntry.services = append(currentListenerEntry.services, pluginParams.Service)
 					return
 				}
@@ -1575,7 +1577,8 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListenerForPortOrUDS(n
 				} else if currentListenerEntry.protocol.IsTCP() {
 					conflictType = AutoOverTCP
 				} else {
-					conflictType = AutoOverAuto
+					// conflictType is AutoOverAuto
+					// In these cases, we just add the services and exit early rather than recreate an identical listener
 					currentListenerEntry.services = append(currentListenerEntry.services, pluginParams.Service)
 					return
 				}


### PR DESCRIPTION
This has a couple small changes:
* Fix to the FakeStore to allow benchmark to run. We don't (yet!) run
this in CI
* Premarshall the ALPN filter to avoid creating it 100s of times
* If we have a conflict, short circuit to avoid construction a full
filter chain and throwing it away
* Stop calling listener.Validate() (see
https://github.com/istio/istio/issues/22648 for more info)

```
name                                 old time/op    new time/op    delta
ListenerGeneration/empty-6             4.09ms ± 3%    2.92ms ± 0%  -28.70%  (p=0.008 n=5+5)
ListenerGeneration/telemetry-6         5.00ms ± 4%    3.88ms ± 2%  -22.39%  (p=0.008 n=5+5)
ListenerGeneration/virtualservice-6    4.05ms ± 2%    2.92ms ± 2%  -27.88%  (p=0.008 n=5+5)

name                                 old alloc/op   new alloc/op   delta
ListenerGeneration/empty-6             1.81MB ± 0%    1.35MB ± 0%  -25.61%  (p=0.008 n=5+5)
ListenerGeneration/telemetry-6         2.12MB ± 0%    1.66MB ± 0%  -21.79%  (p=0.008 n=5+5)
ListenerGeneration/virtualservice-6    1.81MB ± 0%    1.35MB ± 0%  -25.60%  (p=0.008 n=5+5)

name                                 old allocs/op  new allocs/op  delta
ListenerGeneration/empty-6              26.9k ± 0%     19.6k ± 0%  -27.28%  (p=0.008 n=5+5)
ListenerGeneration/telemetry-6          32.3k ± 0%     25.0k ± 0%     ~     (p=0.079 n=4+5)
ListenerGeneration/virtualservice-6     26.9k ± 0%     19.6k ± 0%     ~     (p=0.079 n=4+5)
```