### PR TITLE
Update min k8 version required for Istio

### DIFF
--- a/istioctl/pkg/install/pre-check.go
+++ b/istioctl/pkg/install/pre-check.go
@@ -44,7 +44,9 @@ import (
 )
 
 const (
-	minK8SVersion = "1.13"
+	// Minimum K8 version required to run latest version of Istio
+	// https://preliminary.istio.io/docs/setup/platform-setup/
+	minK8SVersion = "1.15"
 )
 
 var (

--- a/istioctl/pkg/install/pre-check_test.go
+++ b/istioctl/pkg/install/pre-check_test.go
@@ -38,20 +38,20 @@ type testcase struct {
 }
 
 var (
-	version1_13 = &version.Info{
+	version1_15 = &version.Info{
 		Major:      "1",
-		Minor:      "13",
-		GitVersion: "1.13",
+		Minor:      "15",
+		GitVersion: "1.15",
 	}
 	version1_8 = &version.Info{
 		Major:      "1",
 		Minor:      "8",
 		GitVersion: "1.8",
 	}
-	version1_13GKE = &version.Info{
+	version1_15GKE = &version.Info{
 		Major:      "1",
-		Minor:      "13+",
-		GitVersion: "v1.13.7-gke.10",
+		Minor:      "15+",
+		GitVersion: "v1.15.7-gke.10",
 	}
 	version1_8GKE = &version.Info{
 		Major:      "1",
@@ -86,7 +86,7 @@ func TestPreCheck(t *testing.T) {
 		{
 			description: "Valid Kubernetes Version against GKE",
 			config: &mockClientExecPreCheckConfig{
-				version:   version1_13GKE,
+				version:   version1_15GKE,
 				namespace: "test",
 			},
 			expectedException: false,
@@ -101,21 +101,21 @@ func TestPreCheck(t *testing.T) {
 		},
 		{description: "Invalid Istio System",
 			config: &mockClientExecPreCheckConfig{
-				version:   version1_13,
+				version:   version1_15,
 				namespace: "istio-system",
 			},
 			expectedException: false, // It is fine to precheck an existing namespace; we might be installing canary control plane
 		},
 		{description: "Valid Istio System",
 			config: &mockClientExecPreCheckConfig{
-				version:   version1_13,
+				version:   version1_15,
 				namespace: "test",
 			},
 			expectedException: false,
 		},
 		{description: "Lacking Permission",
 			config: &mockClientExecPreCheckConfig{
-				version:   version1_13,
+				version:   version1_15,
 				namespace: "test",
 				authConfig: &authorizationapi.SelfSubjectAccessReview{
 					Spec: authorizationapi.SelfSubjectAccessReviewSpec{
@@ -133,7 +133,7 @@ func TestPreCheck(t *testing.T) {
 		},
 		{description: "Valid Case",
 			config: &mockClientExecPreCheckConfig{
-				version:   version1_13,
+				version:   version1_15,
 				namespace: "test",
 			},
 		},


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/24132

More Info: https://github.com/istio/istio/issues/23184

with **k8 1.15** or greater.
```go
$ istioctl experimental precheck

Checking the cluster to make sure it is ready for Istio installation...

#2. Kubernetes-version
-----------------------
Istio is compatible with Kubernetes: v1.15.0.

-----------------------
Install Pre-Check passed! The cluster is ready for Istio installation.

```


with **k8 1.14** throws invalid version error
```go
$ istioctl experimental precheck

Checking the cluster to make sure it is ready for Istio installation...

#2. Kubernetes-version
-----------------------
The Kubernetes API version: v1.14.0 is lower than the minimum version: 1.15

Error: 1 error occurred:
        * The Kubernetes API version: v1.14.0 is lower than the minimum version: 1.15

```
