### PR TITLE
Migrate deprecated K8s APIs in favor of newer/stable APIs

### DIFF
--- a/galley/pkg/config/processor/transforms/ingress/dataset_test.go
+++ b/galley/pkg/config/processor/transforms/ingress/dataset_test.go
@@ -30,7 +30,7 @@ import (
 
 func ingress1() *resource.Instance {
 	return toIngressResource(`
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: foo
@@ -52,7 +52,7 @@ spec:
 
 func ingress1v2() *resource.Instance {
 	return toIngressResource(`
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: foo

--- a/galley/pkg/config/processor/transforms/ingress/syntheticVirtualService.go
+++ b/galley/pkg/config/processor/transforms/ingress/syntheticVirtualService.go
@@ -18,7 +18,7 @@ import (
 	"sort"
 	"strings"
 
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking.k8s.io/v1beta1"
 
 	"istio.io/api/annotation"
 	"istio.io/api/networking/v1alpha3"

--- a/galley/pkg/config/source/kube/rt/known_test.go
+++ b/galley/pkg/config/source/kube/rt/known_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	. "github.com/onsi/gomega"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking.k8s.io/v1beta1"
 
 	"istio.io/istio/pkg/config/schema/resource"
 

--- a/galley/pkg/config/testing/data/builtin.gen.go
+++ b/galley/pkg/config/testing/data/builtin.gen.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 )
+
 type asset struct {
 	bytes []byte
 	info  os.FileInfo
@@ -154,7 +155,7 @@ func builtinEndpointsYaml() (*asset, error) {
 	return a, nil
 }
 
-var _builtinIngressYaml = []byte(`apiVersion: extensions/v1beta1
+var _builtinIngressYaml = []byte(`apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: secured-ingress

--- a/galley/pkg/config/testing/data/builtin/ingress.yaml
+++ b/galley/pkg/config/testing/data/builtin/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: secured-ingress

--- a/galley/pkg/config/testing/k8smeta/k8smeta.gen.go
+++ b/galley/pkg/config/testing/k8smeta/k8smeta.gen.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 )
+
 type asset struct {
 	bytes []byte
 	info  os.FileInfo
@@ -85,7 +86,7 @@ collections:
   - name: "k8s/core/v1/services"
     kind: "Service"
 
-  - name: "k8s/extensions/v1beta1/ingresses"
+  - name: "k8s/networking.k8s.io/v1beta1/ingresses"
     kind: "Ingress"
     group: "extensions"
 
@@ -94,13 +95,13 @@ collections:
     group: "apps"
 
 resources:
-  - collection: "k8s/extensions/v1beta1/ingresses"
+  - collection: "k8s/networking.k8s.io/v1beta1/ingresses"
     kind: "Ingress"
     plural: "ingresses"
     group: "extensions"
     version: "v1beta1"
     proto: "k8s.io.api.extensions.v1beta1.IngressSpec"
-    protoPackage: "k8s.io/api/extensions/v1beta1"
+    protoPackage: "k8s.io/api/networking.k8s.io/v1beta1"
 
   - collection: "k8s/core/v1/services"
     kind: "Service"

--- a/galley/pkg/config/testing/k8smeta/k8smeta.yaml
+++ b/galley/pkg/config/testing/k8smeta/k8smeta.yaml
@@ -30,7 +30,7 @@ collections:
   - name: "k8s/core/v1/services"
     kind: "Service"
 
-  - name: "k8s/extensions/v1beta1/ingresses"
+  - name: "k8s/networking.k8s.io/v1beta1/ingresses"
     kind: "Ingress"
     group: "extensions"
 
@@ -39,13 +39,13 @@ collections:
     group: "apps"
 
 resources:
-  - collection: "k8s/extensions/v1beta1/ingresses"
+  - collection: "k8s/networking.k8s.io/v1beta1/ingresses"
     kind: "Ingress"
     plural: "ingresses"
     group: "extensions"
     version: "v1beta1"
     proto: "k8s.io.api.extensions.v1beta1.IngressSpec"
-    protoPackage: "k8s.io/api/extensions/v1beta1"
+    protoPackage: "k8s.io/api/networking.k8s.io/v1beta1"
 
   - collection: "k8s/core/v1/services"
     kind: "Service"

--- a/galley/pkg/testing/mock/ingresses.go
+++ b/galley/pkg/testing/mock/ingresses.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"sync"
 
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking.k8s.io/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"

--- a/galley/testdatasets/conversion/dataset.gen.go
+++ b/galley/testdatasets/conversion/dataset.gen.go
@@ -37,6 +37,7 @@ import (
 	"strings"
 	"time"
 )
+
 type asset struct {
 	bytes []byte
 	info  os.FileInfo
@@ -309,7 +310,7 @@ func datasetCoreV1Service_expectedJson() (*asset, error) {
 	return a, nil
 }
 
-var _datasetExtensionsV1beta1Ingress_basicYaml = []byte(`apiVersion: extensions/v1beta1
+var _datasetExtensionsV1beta1Ingress_basicYaml = []byte(`apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: foo
@@ -332,7 +333,7 @@ func datasetExtensionsV1beta1Ingress_basicYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dataset/extensions/v1beta1/ingress_basic.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	info := bindataFileInfo{name: "dataset/networking.k8s.io/v1beta1/ingress_basic.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -379,7 +380,7 @@ func datasetExtensionsV1beta1Ingress_basic_expectedJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dataset/extensions/v1beta1/ingress_basic_expected.json", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	info := bindataFileInfo{name: "dataset/networking.k8s.io/v1beta1/ingress_basic_expected.json", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -398,12 +399,12 @@ func datasetExtensionsV1beta1Ingress_basic_meshconfigYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dataset/extensions/v1beta1/ingress_basic_meshconfig.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	info := bindataFileInfo{name: "dataset/networking.k8s.io/v1beta1/ingress_basic_meshconfig.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
-var _datasetExtensionsV1beta1Ingress_merge_0Yaml = []byte(`apiVersion: extensions/v1beta1
+var _datasetExtensionsV1beta1Ingress_merge_0Yaml = []byte(`apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: foo
@@ -420,7 +421,7 @@ spec:
           serviceName: service1
           servicePort: 4200
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: bar
@@ -449,7 +450,7 @@ func datasetExtensionsV1beta1Ingress_merge_0Yaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dataset/extensions/v1beta1/ingress_merge_0.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	info := bindataFileInfo{name: "dataset/networking.k8s.io/v1beta1/ingress_merge_0.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -575,7 +576,7 @@ func datasetExtensionsV1beta1Ingress_merge_0_expectedJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dataset/extensions/v1beta1/ingress_merge_0_expected.json", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	info := bindataFileInfo{name: "dataset/networking.k8s.io/v1beta1/ingress_merge_0_expected.json", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -594,12 +595,12 @@ func datasetExtensionsV1beta1Ingress_merge_0_meshconfigYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dataset/extensions/v1beta1/ingress_merge_0_meshconfig.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	info := bindataFileInfo{name: "dataset/networking.k8s.io/v1beta1/ingress_merge_0_meshconfig.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
-var _datasetExtensionsV1beta1Ingress_merge_1Yaml = []byte(`apiVersion: extensions/v1beta1
+var _datasetExtensionsV1beta1Ingress_merge_1Yaml = []byte(`apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: foo
@@ -616,7 +617,7 @@ spec:
           serviceName: service1
           servicePort: 4200
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: bar
@@ -646,7 +647,7 @@ func datasetExtensionsV1beta1Ingress_merge_1Yaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dataset/extensions/v1beta1/ingress_merge_1.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	info := bindataFileInfo{name: "dataset/networking.k8s.io/v1beta1/ingress_merge_1.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -772,12 +773,12 @@ func datasetExtensionsV1beta1Ingress_merge_1_expectedJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dataset/extensions/v1beta1/ingress_merge_1_expected.json", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	info := bindataFileInfo{name: "dataset/networking.k8s.io/v1beta1/ingress_merge_1_expected.json", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
-var _datasetExtensionsV1beta1Ingress_multihostYaml = []byte(`apiVersion: extensions/v1beta1
+var _datasetExtensionsV1beta1Ingress_multihostYaml = []byte(`apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: echo
@@ -808,7 +809,7 @@ func datasetExtensionsV1beta1Ingress_multihostYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dataset/extensions/v1beta1/ingress_multihost.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	info := bindataFileInfo{name: "dataset/networking.k8s.io/v1beta1/ingress_multihost.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -917,7 +918,7 @@ func datasetExtensionsV1beta1Ingress_multihost_expectedJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dataset/extensions/v1beta1/ingress_multihost_expected.json", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	info := bindataFileInfo{name: "dataset/networking.k8s.io/v1beta1/ingress_multihost_expected.json", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -936,7 +937,7 @@ func datasetExtensionsV1beta1Ingress_multihost_meshconfigYaml() (*asset, error) 
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dataset/extensions/v1beta1/ingress_multihost_meshconfig.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	info := bindataFileInfo{name: "dataset/networking.k8s.io/v1beta1/ingress_multihost_meshconfig.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1422,17 +1423,17 @@ var _bindata = map[string]func() (*asset, error){
 	"dataset/core/v1/namespace_expected.json":                                          datasetCoreV1Namespace_expectedJson,
 	"dataset/core/v1/service.yaml":                                                     datasetCoreV1ServiceYaml,
 	"dataset/core/v1/service_expected.json":                                            datasetCoreV1Service_expectedJson,
-	"dataset/extensions/v1beta1/ingress_basic.yaml":                                    datasetExtensionsV1beta1Ingress_basicYaml,
-	"dataset/extensions/v1beta1/ingress_basic_expected.json":                           datasetExtensionsV1beta1Ingress_basic_expectedJson,
-	"dataset/extensions/v1beta1/ingress_basic_meshconfig.yaml":                         datasetExtensionsV1beta1Ingress_basic_meshconfigYaml,
-	"dataset/extensions/v1beta1/ingress_merge_0.yaml":                                  datasetExtensionsV1beta1Ingress_merge_0Yaml,
-	"dataset/extensions/v1beta1/ingress_merge_0_expected.json":                         datasetExtensionsV1beta1Ingress_merge_0_expectedJson,
-	"dataset/extensions/v1beta1/ingress_merge_0_meshconfig.yaml":                       datasetExtensionsV1beta1Ingress_merge_0_meshconfigYaml,
-	"dataset/extensions/v1beta1/ingress_merge_1.yaml":                                  datasetExtensionsV1beta1Ingress_merge_1Yaml,
-	"dataset/extensions/v1beta1/ingress_merge_1_expected.json":                         datasetExtensionsV1beta1Ingress_merge_1_expectedJson,
-	"dataset/extensions/v1beta1/ingress_multihost.yaml":                                datasetExtensionsV1beta1Ingress_multihostYaml,
-	"dataset/extensions/v1beta1/ingress_multihost_expected.json":                       datasetExtensionsV1beta1Ingress_multihost_expectedJson,
-	"dataset/extensions/v1beta1/ingress_multihost_meshconfig.yaml":                     datasetExtensionsV1beta1Ingress_multihost_meshconfigYaml,
+	"dataset/networking.k8s.io/v1beta1/ingress_basic.yaml":                             datasetExtensionsV1beta1Ingress_basicYaml,
+	"dataset/networking.k8s.io/v1beta1/ingress_basic_expected.json":                    datasetExtensionsV1beta1Ingress_basic_expectedJson,
+	"dataset/networking.k8s.io/v1beta1/ingress_basic_meshconfig.yaml":                  datasetExtensionsV1beta1Ingress_basic_meshconfigYaml,
+	"dataset/networking.k8s.io/v1beta1/ingress_merge_0.yaml":                           datasetExtensionsV1beta1Ingress_merge_0Yaml,
+	"dataset/networking.k8s.io/v1beta1/ingress_merge_0_expected.json":                  datasetExtensionsV1beta1Ingress_merge_0_expectedJson,
+	"dataset/networking.k8s.io/v1beta1/ingress_merge_0_meshconfig.yaml":                datasetExtensionsV1beta1Ingress_merge_0_meshconfigYaml,
+	"dataset/networking.k8s.io/v1beta1/ingress_merge_1.yaml":                           datasetExtensionsV1beta1Ingress_merge_1Yaml,
+	"dataset/networking.k8s.io/v1beta1/ingress_merge_1_expected.json":                  datasetExtensionsV1beta1Ingress_merge_1_expectedJson,
+	"dataset/networking.k8s.io/v1beta1/ingress_multihost.yaml":                         datasetExtensionsV1beta1Ingress_multihostYaml,
+	"dataset/networking.k8s.io/v1beta1/ingress_multihost_expected.json":                datasetExtensionsV1beta1Ingress_multihost_expectedJson,
+	"dataset/networking.k8s.io/v1beta1/ingress_multihost_meshconfig.yaml":              datasetExtensionsV1beta1Ingress_multihost_meshconfigYaml,
 	"dataset/mesh.istio.io/v1alpha1/meshconfig.yaml":                                   datasetMeshIstioIoV1alpha1MeshconfigYaml,
 	"dataset/mesh.istio.io/v1alpha1/meshconfig_expected.json":                          datasetMeshIstioIoV1alpha1Meshconfig_expectedJson,
 	"dataset/networking.istio.io/v1alpha3/destinationRule.yaml":                        datasetNetworkingIstioIoV1alpha3DestinationruleYaml,

--- a/galley/testdatasets/conversion/dataset/extensions/v1beta1/ingress_basic.yaml
+++ b/galley/testdatasets/conversion/dataset/extensions/v1beta1/ingress_basic.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: foo

--- a/go.sum
+++ b/go.sum
@@ -1073,6 +1073,7 @@ k8s.io/api v0.17.0/go.mod h1:npsyOePkeP0CPwyGfXDHxvypiYMJxBWAMpQxCaJ4ZxI=
 k8s.io/api v0.18.0/go.mod h1:q2HRQkfDzHMBZL9l/y9rH63PkQl4vae0xRT+8prbrK8=
 k8s.io/api v0.18.1 h1:pnHr0LH69kvL29eHldoepUDKTuiOejNZI2A1gaxve3Q=
 k8s.io/api v0.18.1/go.mod h1:3My4jorQWzSs5a+l7Ge6JBbIxChLnY8HnuT58ZWolss=
+k8s.io/api v0.18.3 h1:2AJaUQdgUZLoDZHrun21PW2Nx9+ll6cUzvn3IKhSIn0=
 k8s.io/apiextensions-apiserver v0.0.0-20190918161926-8f644eb6e783/go.mod h1:xvae1SZB3E17UpV59AWc271W/Ph25N+bjPyR63X6tPY=
 k8s.io/apiextensions-apiserver v0.18.0 h1:HN4/P8vpGZFvB5SOMuPPH2Wt9Y/ryX+KRvIyAkchu1Q=
 k8s.io/apiextensions-apiserver v0.18.0/go.mod h1:18Cwn1Xws4xnWQNC00FLq1E350b9lUF+aOdIWDOZxgo=

--- a/istioctl/cmd/testdata/ingress/another-ingress.yaml
+++ b/istioctl/cmd/testdata/ingress/another-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:

--- a/istioctl/cmd/testdata/ingress/myservice-ingress.yaml
+++ b/istioctl/cmd/testdata/ingress/myservice-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:

--- a/pkg/config/schema/collections/collections.gen.go
+++ b/pkg/config/schema/collections/collections.gen.go
@@ -814,9 +814,9 @@ var (
 	}.MustBuild()
 
 	// K8SExtensionsV1Beta1Ingresses describes the collection
-	// k8s/extensions/v1beta1/ingresses
+	// k8s/networking.k8s.io/v1beta1/ingresses
 	K8SExtensionsV1Beta1Ingresses = collection.Builder{
-		Name:         "k8s/extensions/v1beta1/ingresses",
+		Name:         "k8s/networking.k8s.io/v1beta1/ingresses",
 		VariableName: "K8SExtensionsV1Beta1Ingresses",
 		Disabled:     false,
 		Resource: resource.Builder{
@@ -825,7 +825,7 @@ var (
 			Plural:        "ingresses",
 			Version:       "v1beta1",
 			Proto:         "k8s.io.api.extensions.v1beta1.IngressSpec",
-			ProtoPackage:  "k8s.io/api/extensions/v1beta1",
+			ProtoPackage:  "k8s.io/api/networking.k8s.io/v1beta1",
 			ClusterScoped: false,
 			ValidateProto: validation.EmptyValidate,
 		}.MustBuild(),

--- a/pkg/config/schema/metadata.gen.go
+++ b/pkg/config/schema/metadata.gen.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 )
+
 type asset struct {
 	bytes []byte
 	info  os.FileInfo
@@ -236,7 +237,7 @@ collections:
     kind: "ConfigMap"
     group: ""
 
-  - name: "k8s/extensions/v1beta1/ingresses"
+  - name: "k8s/networking.k8s.io/v1beta1/ingresses"
     kind: "Ingress"
     group: "extensions"
 
@@ -480,7 +481,7 @@ resources:
     group: "extensions"
     version: "v1beta1"
     proto: "k8s.io.api.extensions.v1beta1.IngressSpec"
-    protoPackage: "k8s.io/api/extensions/v1beta1"
+    protoPackage: "k8s.io/api/networking.k8s.io/v1beta1"
 
   - Kind: "GatewayClass"
     plural: "gatewayclasses"

--- a/pkg/config/schema/metadata.yaml
+++ b/pkg/config/schema/metadata.yaml
@@ -425,7 +425,7 @@ resources:
     group: "extensions"
     version: "v1beta1"
     proto: "k8s.io.api.extensions.v1beta1.IngressSpec"
-    protoPackage: "k8s.io/api/extensions/v1beta1"
+    protoPackage: "k8s.io/api/networking.k8s.io/v1beta1"
 
   - Kind: "GatewayClass"
     plural: "gatewayclasses"


### PR DESCRIPTION
Work in progress.

Ref: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/