### PR TITLE
Update min k8 supported version for istio 1.7

### DIFF
--- a/istioctl/pkg/install/pre-check.go
+++ b/istioctl/pkg/install/pre-check.go
@@ -45,8 +45,8 @@ import (
 
 const (
 	// Minimum K8 version required to run latest version of Istio
-	// https://preliminary.istio.io/docs/setup/platform-setup/
-	minK8SVersion = "1.15"
+	// https://istio.io/docs/setup/platform-setup/
+	minK8SVersion = "1.16"
 )
 
 var (

--- a/istioctl/pkg/install/pre-check_test.go
+++ b/istioctl/pkg/install/pre-check_test.go
@@ -38,20 +38,20 @@ type testcase struct {
 }
 
 var (
-	version1_15 = &version.Info{
+	version1_16 = &version.Info{
 		Major:      "1",
-		Minor:      "15",
-		GitVersion: "1.15",
+		Minor:      "16",
+		GitVersion: "1.16",
 	}
 	version1_8 = &version.Info{
 		Major:      "1",
 		Minor:      "8",
 		GitVersion: "1.8",
 	}
-	version1_15GKE = &version.Info{
+	version1_16GKE = &version.Info{
 		Major:      "1",
-		Minor:      "15+",
-		GitVersion: "v1.15.7-gke.10",
+		Minor:      "16+",
+		GitVersion: "v1.16.7-gke.10",
 	}
 	version1_8GKE = &version.Info{
 		Major:      "1",
@@ -86,7 +86,7 @@ func TestPreCheck(t *testing.T) {
 		{
 			description: "Valid Kubernetes Version against GKE",
 			config: &mockClientExecPreCheckConfig{
-				version:   version1_15GKE,
+				version:   version1_16GKE,
 				namespace: "test",
 			},
 			expectedException: false,
@@ -101,21 +101,21 @@ func TestPreCheck(t *testing.T) {
 		},
 		{description: "Invalid Istio System",
 			config: &mockClientExecPreCheckConfig{
-				version:   version1_15,
+				version:   version1_16,
 				namespace: "istio-system",
 			},
 			expectedException: false, // It is fine to precheck an existing namespace; we might be installing canary control plane
 		},
 		{description: "Valid Istio System",
 			config: &mockClientExecPreCheckConfig{
-				version:   version1_15,
+				version:   version1_16,
 				namespace: "test",
 			},
 			expectedException: false,
 		},
 		{description: "Lacking Permission",
 			config: &mockClientExecPreCheckConfig{
-				version:   version1_15,
+				version:   version1_16,
 				namespace: "test",
 				authConfig: &authorizationapi.SelfSubjectAccessReview{
 					Spec: authorizationapi.SelfSubjectAccessReviewSpec{
@@ -133,7 +133,7 @@ func TestPreCheck(t *testing.T) {
 		},
 		{description: "Valid Case",
 			config: &mockClientExecPreCheckConfig{
-				version:   version1_15,
+				version:   version1_16,
 				namespace: "test",
 			},
 		},


### PR DESCRIPTION
Related https://github.com/istio/istio/pull/24134

The minimum supported k8 version for Istio 1.7 is 1.16-1.18 (3 versions). Ref: https://github.com/istio/istio/pull/24134#issuecomment-634690848