### PR TITLE
[release-1.6] Disable TransportSocket for headless service when mtls is auto detected 

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -962,6 +962,15 @@ func applyUpstreamTLSSettings(opts *buildClusterOpts, tls *networking.ClientTLSS
 
 	cluster := opts.cluster
 	proxy := opts.proxy
+
+	// Disable transport socket when cluster type is `Cluster_ORIGINAL_DST` and mtls is autoDetected
+	// We don't know whether headless service instance has sidecar injected or not.
+	if c.GetType() == cluster.Cluster_ORIGINAL_DST {
+		if tls.Mode == networking.ClientTLSSettings_ISTIO_MUTUAL && mtlsCtxType == autoDetected {
+			return
+		}
+	}
+
 	certValidationContext := &auth.CertificateValidationContext{}
 	var trustedCa *core.DataSource
 	if len(tls.CaCertificates) != 0 {

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -965,7 +965,7 @@ func applyUpstreamTLSSettings(opts *buildClusterOpts, tls *networking.ClientTLSS
 
 	// Disable transport socket when cluster type is `Cluster_ORIGINAL_DST` and mtls is autoDetected
 	// We don't know whether headless service instance has sidecar injected or not.
-	if c.GetType() == cluster.Cluster_ORIGINAL_DST {
+	if cluster.GetType() == apiv2.Cluster_ORIGINAL_DST {
 		if tls.Mode == networking.ClientTLSSettings_ISTIO_MUTUAL && mtlsCtxType == autoDetected {
 			return
 		}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -2348,7 +2348,7 @@ func TestApplyUpstreamTLSSettings(t *testing.T) {
 			mtlsCtx:                    autoDetected,
 			discoveryType:              apiv2.Cluster_ORIGINAL_DST,
 			tls:                        tlsSettings,
-			expectTransportSocket:      true,
+			expectTransportSocket:      false,
 			expectTransportSocketMatch: false,
 		},
 	}

--- a/tests/integration/pilot/cni/cni_test.go
+++ b/tests/integration/pilot/cni/cni_test.go
@@ -81,13 +81,13 @@ func TestCNIReachability(t *testing.T) {
 					RequiredEnvironment: environment.Kube,
 					Include: func(src echo.Instance, opts echo.CallOptions) bool {
 						// Exclude calls to the headless TCP port.
-						if opts.Target == rctx.Headless && opts.PortName == "tcp" {
+						if rctx.IsHeadless(opts.Target) && opts.PortName == "tcp" {
 							return false
 						}
 						return true
 					},
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
-						if src == rctx.Naked && opts.Target == rctx.Naked {
+						if rctx.IsNaked(src) && rctx.IsNaked(opts.Target) {
 							// naked->naked should always succeed.
 							return true
 						}

--- a/tests/integration/security/mtls_first_party_jwt/strict_test.go
+++ b/tests/integration/security/mtls_first_party_jwt/strict_test.go
@@ -44,6 +44,10 @@ func TestMtlsStrictK8sCA(t *testing.T) {
 					Namespace:           systemNM,
 					RequiredEnvironment: environment.Kube,
 					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						// Exclude headless naked service
+						if src == rctx.HeadlessNaked || opts.Target == rctx.HeadlessNaked {
+							return false
+						}
 						// Exclude calls to the headless service.
 						// Auto mtls does not apply to headless service, because for headless service
 						// the cluster discovery type is ORIGINAL_DST, and it will not apply upstream tls setting
@@ -66,6 +70,10 @@ func TestMtlsStrictK8sCA(t *testing.T) {
 					Namespace:           systemNM,
 					RequiredEnvironment: environment.Kube,
 					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						// Exclude headless naked service
+						if src == rctx.HeadlessNaked || opts.Target == rctx.HeadlessNaked {
+							return false
+						}
 						// Exclude calls to the headless TCP port.
 						if opts.Target == rctx.Headless && opts.PortName == "tcp" {
 							return false

--- a/tests/integration/security/mtlsk8sca/strict_test.go
+++ b/tests/integration/security/mtlsk8sca/strict_test.go
@@ -44,6 +44,10 @@ func TestMtlsStrictK8sCA(t *testing.T) {
 					Namespace:           systemNM,
 					RequiredEnvironment: environment.Kube,
 					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						// Exclude headless naked service
+						if src == rctx.HeadlessNaked || opts.Target == rctx.HeadlessNaked {
+							return false
+						}
 						// Exclude calls to the headless service.
 						// Auto mtls does not apply to headless service, because for headless service
 						// the cluster discovery type is ORIGINAL_DST, and it will not apply upstream tls setting
@@ -66,6 +70,10 @@ func TestMtlsStrictK8sCA(t *testing.T) {
 					Namespace:           systemNM,
 					RequiredEnvironment: environment.Kube,
 					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						// Exclude headless naked service
+						if src == rctx.HeadlessNaked || opts.Target == rctx.HeadlessNaked {
+							return false
+						}
 						// Exclude calls to the headless TCP port.
 						if opts.Target == rctx.Headless && opts.PortName == "tcp" {
 							return false

--- a/tests/integration/security/testdata/beta-mtls-off-headless.yaml
+++ b/tests/integration/security/testdata/beta-mtls-off-headless.yaml
@@ -1,0 +1,9 @@
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "default"
+  annotations:
+    test-suite: "beta-mtls-off-headless"
+spec:
+  mtls:
+    mode: DISABLE  # This is to simulate a headless service without proxy

--- a/tests/integration/security/util/reachability/context.go
+++ b/tests/integration/security/util/reachability/context.go
@@ -61,14 +61,15 @@ type TestCase struct {
 
 // Context is a context for reachability tests.
 type Context struct {
-	ctx          framework.TestContext
-	g            galley.Instance
-	p            pilot.Instance
-	Namespace    namespace.Instance
-	A, B         echo.Instance
-	Multiversion echo.Instance
-	Headless     echo.Instance
-	Naked        echo.Instance
+	ctx           framework.TestContext
+	g             galley.Instance
+	p             pilot.Instance
+	Namespace     namespace.Instance
+	A, B          echo.Instance
+	Multiversion  echo.Instance
+	Headless      echo.Instance
+	Naked         echo.Instance
+	HeadlessNaked echo.Instance
 }
 
 // CreateContext creates and initializes reachability context.
@@ -78,7 +79,7 @@ func CreateContext(ctx framework.TestContext, g galley.Instance, p pilot.Instanc
 		Inject: true,
 	})
 
-	var a, b, multiVersion, headless, naked echo.Instance
+	var a, b, multiVersion, headless, headlessNaked, naked echo.Instance
 	cfg := util.EchoConfig("multiversion", ns, false, nil, g, p)
 	cfg.Subsets = []echo.SubsetConfig{
 		// Istio deployment, with sidecar.
@@ -101,15 +102,16 @@ func CreateContext(ctx framework.TestContext, g galley.Instance, p pilot.Instanc
 		BuildOrFail(ctx)
 
 	return Context{
-		ctx:          ctx,
-		g:            g,
-		p:            p,
-		Namespace:    ns,
-		A:            a,
-		B:            b,
-		Multiversion: multiVersion,
-		Headless:     headless,
-		Naked:        naked,
+		ctx:           ctx,
+		g:             g,
+		p:             p,
+		Namespace:     ns,
+		A:             a,
+		B:             b,
+		Multiversion:  multiVersion,
+		Headless:      headless,
+		Naked:         naked,
+		HeadlessNaked: headlessNaked,
 	}
 }
 
@@ -208,4 +210,12 @@ func (rc *Context) Run(testCases []TestCase) {
 			}
 		})
 	}
+}
+
+func (rc *Context) IsNaked(i echo.Instance) bool {
+	return i == rc.HeadlessNaked || i == rc.Naked
+}
+
+func (rc *Context) IsHeadless(i echo.Instance) bool {
+	return i == rc.HeadlessNaked || i == rc.Headless
 }


### PR DESCRIPTION
this is a manual cherry-pick from #21987

fixes: #23844