### PR TITLE
Add ISTIO_METAJSON_LABELS to the injection template

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -539,6 +539,11 @@ data:
           value: |
                  {{ toJSON .ObjectMeta.Annotations }}
         {{ end }}
+        {{ if .ObjectMeta.Labels }}
+        - name: ISTIO_METAJSON_LABELS
+          value: |
+                 {{ toJSON .ObjectMeta.Labels }}
+        {{ end }}
         {{- if .DeploymentMeta.Name }}
         - name: ISTIO_META_WORKLOAD_NAME
           value: {{ .DeploymentMeta.Name }}

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -224,6 +224,11 @@ template: |
       value: |
              {{ toJSON .ObjectMeta.Annotations }}
     {{ end }}
+    {{ if .ObjectMeta.Labels }}
+    - name: ISTIO_METAJSON_LABELS
+      value: |
+             {{ toJSON .ObjectMeta.Labels }}
+    {{ end }}
     {{- if .DeploymentMeta.Name }}
     - name: ISTIO_META_WORKLOAD_NAME
       value: {{ .DeploymentMeta.Name }}

--- a/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -460,6 +460,11 @@ data:
           value: |
                  {{ toJSON .ObjectMeta.Annotations }}
         {{ end }}
+        {{ if .ObjectMeta.Labels }}
+        - name: ISTIO_METAJSON_LABELS
+          value: |
+                 {{ toJSON .ObjectMeta.Labels }}
+        {{ end }}
         {{- if .DeploymentMeta.Name }}
         - name: ISTIO_META_WORKLOAD_NAME
           value: {{ .DeploymentMeta.Name }}

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -224,6 +224,11 @@ template: |
       value: |
              {{ toJSON .ObjectMeta.Annotations }}
     {{ end }}
+    {{ if .ObjectMeta.Labels }}
+    - name: ISTIO_METAJSON_LABELS
+      value: |
+             {{ toJSON .ObjectMeta.Labels }}
+    {{ end }}
     {{- if .DeploymentMeta.Name }}
     - name: ISTIO_META_WORKLOAD_NAME
       value: {{ .DeploymentMeta.Name }}


### PR DESCRIPTION
This change just adds the injected pod's labels via the `ISTIO_METAJSON_LABELS` env var so that they get passed along as node metadata. The specific use case we have for this is that those labels are used by our envoy metrics service implementation.

It looks like ISTIO_METAJSON_LABELS [already has some explicit support in the bootstrap rendering pipeline](https://github.com/istio/istio/blob/65edd51d4b3231a4a8286dcd69504a3656cb1b07/pkg/bootstrap/config.go#L439-L443), but it isn't currently being added to the injection template.

[x] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
