### PR TITLE
add NetworkTopology to String method

### DIFF
--- a/pkg/test/framework/components/environment/kube/settings.go
+++ b/pkg/test/framework/components/environment/kube/settings.go
@@ -95,6 +95,7 @@ func (s *Settings) String() string {
 	result += fmt.Sprintf("KubeConfig:           %s\n", s.KubeConfig)
 	result += fmt.Sprintf("MiniKubeIngress:      %v\n", s.Minikube)
 	result += fmt.Sprintf("ControlPlaneTopology: %v\n", s.ControlPlaneTopology)
+	result += fmt.Sprintf("NetworkTopology:      %v\n", s.networkTopology)
 
 	return result
 }


### PR DESCRIPTION

Follow up to https://github.com/istio/istio/pull/23732, added new flag `NetworkTopology` to String method


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure