### PR TITLE
Update path for charts and profile for 1.6

### DIFF
--- a/operator/cmd/mesh/root.go
+++ b/operator/cmd/mesh/root.go
@@ -31,7 +31,7 @@ settings (--set values.grafana.enabled=true). See documentation for more info:
 https://istio.io/docs/reference/config/istio.operator.v1alpha1/#IstioOperatorSpec`
 	// ChartsFlagHelpStr is the command line description for --charts
 	ChartsFlagHelpStr = `Specify a path to a directory of charts and profiles
-(e.g. ~/Downloads/istio-1.6.0/install/kubernetes/operator)
+(e.g. ~/Downloads/istio-1.6.0/manifests)
 or release tar URL (e.g. https://github.com/istio/istio/releases/download/1.6.0/istio-1.6.0-linux-amd64.tar.gz).
 `
 	revisionFlagHelpStr         = `Target control plane revision for the command.`


### PR DESCRIPTION

with **1.5.4** (istio-1.5.4/install/kubernetes/)
```go
$ ls istio-1.5.4/
bin  install  LICENSE  manifest.yaml  README.md  samples  tools

$ ls istio-1.5.4/install/
consul  gcp  kubernetes  README.md  tools
```
with **1.6.0** (istio-1.6.0/manifests/)
```go
$ ls istio-1.6.0/
bin  LICENSE  manifests  manifest.yaml  README.md  samples  tools

$ ls istio-1.6.0/manifests/
charts  deploy  examples  profiles  translateConfig  versions.yaml
```