### PR TITLE
Clean up Make for deprecated files to remove

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,35 +36,6 @@ bin/envvarlinter
 bin/istioctl
 # Install generated files
 install/consul/istio.yaml
-install/kubernetes/istio-demo.yaml
-install/kubernetes/istio-auth.yaml
-install/kubernetes/istio-auth-multicluster.yaml
-install/kubernetes/istio-mixer-with-health-check.yaml
-install/kubernetes/istio-mixer-validator.yaml
-install/kubernetes/istio-citadel-plugin-certs.yaml
-install/kubernetes/istio-citadel-standalone.yaml
-install/kubernetes/istio-citadel-with-health-check.yaml
-install/kubernetes/istio-multicluster-split-horizon.yaml
-install/kubernetes/istio-one-namespace-auth.yaml
-install/kubernetes/istio-one-namespace-trust-domain.yaml
-install/kubernetes/istio-one-namespace.yaml
-install/kubernetes/istio-sidecar-injector-configmap-debug.yaml
-install/kubernetes/istio-sidecar-injector-configmap-release.yaml
-install/kubernetes/istio-sidecar-injector.yaml
-install/kubernetes/istio.yaml
-install/kubernetes/istio-init.yaml
-install/kubernetes/istio-all.yaml
-install/kubernetes/istio-multicluster.yaml
-install/kubernetes/istio-multicluster-split-horizon.yaml
-install/kubernetes/istio-remote.yaml
-install/kubernetes/istio-mcp.yaml
-install/kubernetes/istio-auth-mcp.yaml
-install/kubernetes/istio-auth-non-mcp.yaml
-install/kubernetes/istio-auth-sds.yaml
-install/kubernetes/istio-init.yaml
-install/kubernetes/istio-non-mcp.yaml
-install/kubernetes/istio-minimal.yaml
-install/kubernetes/helm/istio/requirements.lock
 samples/bookinfo/platform/consul/bookinfo.sidecars.yaml
 *.orig
 # Avoid accidental istio.VERSION changes

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -562,13 +562,6 @@ include tools/istio-docker.mk
 push: docker.push
 
 FILES_TO_CLEAN+=install/consul/istio.yaml \
-                install/kubernetes/istio-auth.yaml \
-                install/kubernetes/istio-citadel-plugin-certs.yaml \
-                install/kubernetes/istio-citadel-with-health-check.yaml \
-                install/kubernetes/istio-one-namespace-auth.yaml \
-                install/kubernetes/istio-one-namespace-trust-domain.yaml \
-                install/kubernetes/istio-one-namespace.yaml \
-                install/kubernetes/istio.yaml \
                 samples/bookinfo/platform/consul/bookinfo.sidecars.yaml
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
As `install/kubernetes` is removed in 1.6, there is no need to clean and ignore it.