### PR TITLE
[release-1.6] Update base image

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -22,7 +22,7 @@ SHELL := /bin/bash -o pipefail
 VERSION ?= 1.6-dev
 
 # Base version of Istio image to use
-BASE_VERSION ?= 1.6-dev.1
+BASE_VERSION ?= 1.6-dev.2
 
 export GO111MODULE ?= on
 export GOPROXY ?= https://proxy.golang.org


### PR DESCRIPTION
Old base image was showing vulnerabilities:
```
CVE-2020-3810	apt	APT could be made to crash if it opened a specially crafted file.	Upgrade apt to >= 1.6.12ubuntu0.1	
CVE-2019-20795	iproute2	IPRoute could be made to execute arbitrary code if it received a speciallycrafted input.	Upgrade iproute2 to >= 4.15.0-2ubuntu1.1	
CVE-2019-1547	libssl1.1	Several security issues were fixed in OpenSSL.	Upgrade libssl1.1 to >= 1.1.1-1ubuntu2.1~18.04.6	
CVE-2019-1549	libssl1.1	Several security issues were fixed in OpenSSL.	Upgrade libssl1.1 to >= 1.1.1-1ubuntu2.1~18.04.6	
CVE-2019-1551	libssl1.1	Several security issues were fixed in OpenSSL.	Upgrade libssl1.1 to >= 1.1.1-1ubuntu2.1~18.04.6	
CVE-2019-1563	libssl1.1	Several security issues were fixed in OpenSSL.	Upgrade libssl1.1 to >= 1.1.1-1ubuntu2.1~18.04.6
```