### PR TITLE
Fix invalid SPIFFE cert generation

### DIFF
--- a/install/tools/certs/Makefile
+++ b/install/tools/certs/Makefile
@@ -226,8 +226,8 @@ root-key.pem:
 	@echo "extendedKeyUsage = serverAuth, clientAuth" >> $@
 	@echo "subjectAltName=@san" >> $@
 	@echo "[ san ]" >> $@
-	@echo "URI.1 = spiffe://cluster.local/ns/$(L)/sa/$(SERVICE_ACCOUNT)" >> $@
-	@echo "DNS.1 = spiffe://cluster.local/ns/$(L)/sa/$(SERVICE_ACCOUNT)" >> $@
+	@echo "URI.1 = spiffe://cluster.local/ns/$(L)sa/$(SERVICE_ACCOUNT)" >> $@
+	@echo "DNS.1 = spiffe://cluster.local/ns/$(L)sa/$(SERVICE_ACCOUNT)" >> $@
 	@echo "[ req_dn ]" >> $@
 	@echo "O = $(INTERMEDIATE_ORG)" >> $@
 	@echo "CN = $(INTERMEDIATE_CN)" >> $@


### PR DESCRIPTION
Previously this results in ns/my-namespace//sa which is not valid



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure