### PR TITLE
Fix cleanup and change readiness check for tests

### DIFF
--- a/pkg/test/framework/components/echo/kube/builder.go
+++ b/pkg/test/framework/components/echo/kube/builder.go
@@ -91,7 +91,7 @@ func (b *builder) newInstances() ([]echo.Instance, error) {
 func (b *builder) initializeInstances(instances []echo.Instance) error {
 	// Wait to receive the k8s Endpoints for each Echo Instance.
 	wg := sync.WaitGroup{}
-	instanceEndpoints := make([]*kubeCore.Endpoints, len(instances))
+	instancePods := make([][]kubeCore.Pod, len(instances))
 	aggregateErrMux := &sync.Mutex{}
 	var aggregateErr error
 	for i, inst := range instances {
@@ -106,17 +106,17 @@ func (b *builder) initializeInstances(instances []echo.Instance) error {
 		// Run the waits in parallel.
 		go func() {
 			defer wg.Done()
-
-			// Wait until all the endpoints are ready for this service
-			_, endpoints, err := cluster.WaitUntilServiceEndpointsAreReady(
-				serviceNamespace, serviceName, retry.Timeout(timeout))
+			selector := "app"
+			fetch := cluster.NewPodMustFetch(serviceNamespace, fmt.Sprintf("%s=%s", selector, serviceName))
+			// Wait until all the pods are ready for this service
+			pods, err := cluster.WaitUntilPodsAreReady(fetch, retry.Timeout(timeout))
 			if err != nil {
 				aggregateErrMux.Lock()
 				aggregateErr = multierror.Append(aggregateErr, err)
 				aggregateErrMux.Unlock()
 				return
 			}
-			instanceEndpoints[instanceIndex] = endpoints
+			instancePods[instanceIndex] = pods
 		}()
 	}
 
@@ -128,7 +128,7 @@ func (b *builder) initializeInstances(instances []echo.Instance) error {
 
 	// Initialize the workloads for each instance.
 	for i, inst := range instances {
-		if err := inst.(*instance).initialize(instanceEndpoints[i]); err != nil {
+		if err := inst.(*instance).initialize(instancePods[i]); err != nil {
 			return fmt.Errorf("initialize %v: %v", inst.ID(), err)
 		}
 	}

--- a/pkg/test/framework/components/echo/kube/instance.go
+++ b/pkg/test/framework/components/echo/kube/instance.go
@@ -216,31 +216,29 @@ func (c *instance) WaitUntilCallableOrFail(t test.Failer, instances ...echo.Inst
 }
 
 // WorkloadHasSidecar returns true if the input endpoint is deployed with sidecar injected based on the config.
-func workloadHasSidecar(cfg echo.Config, endpoint *kubeCore.ObjectReference) bool {
+func workloadHasSidecar(cfg echo.Config, podName string) bool {
 	// Match workload first.
 	for _, w := range cfg.Subsets {
-		if strings.HasPrefix(endpoint.Name, fmt.Sprintf("%v-%v", cfg.Service, w.Version)) {
+		if strings.HasPrefix(podName, fmt.Sprintf("%v-%v", cfg.Service, w.Version)) {
 			return w.Annotations.GetBool(echo.SidecarInject)
 		}
 	}
 	return true
 }
 
-func (c *instance) initialize(endpoints *kubeCore.Endpoints) error {
+func (c *instance) initialize(pods []kubeCore.Pod) error {
 	if c.workloads != nil {
 		// Already ready.
 		return nil
 	}
 
 	workloads := make([]*workload, 0)
-	for _, subset := range endpoints.Subsets {
-		for _, addr := range subset.Addresses {
-			workload, err := newWorkload(addr, workloadHasSidecar(c.cfg, addr.TargetRef), c.grpcPort, c.cluster, c.tls, c.ctx)
-			if err != nil {
-				return err
-			}
-			workloads = append(workloads, workload)
+	for _, pod := range pods {
+		workload, err := newWorkload(pod, workloadHasSidecar(c.cfg, pod.Name), c.grpcPort, c.cluster, c.tls, c.ctx)
+		if err != nil {
+			return err
 		}
+		workloads = append(workloads, workload)
 	}
 
 	if len(workloads) == 0 {

--- a/pkg/test/framework/components/echo/kube/workload.go
+++ b/pkg/test/framework/components/echo/kube/workload.go
@@ -43,7 +43,6 @@ var (
 type workload struct {
 	*client.Instance
 
-	addr      kubeCore.EndpointAddress
 	pod       kubeCore.Pod
 	forwarder kube.PortForwarder
 	sidecar   *sidecar
@@ -51,17 +50,8 @@ type workload struct {
 	ctx       resource.Context
 }
 
-func newWorkload(addr kubeCore.EndpointAddress, sidecared bool, grpcPort uint16,
+func newWorkload(pod kubeCore.Pod, sidecared bool, grpcPort uint16,
 	cluster kube2.Cluster, tls *common.TLSSettings, ctx resource.Context) (*workload, error) {
-	if addr.TargetRef == nil || addr.TargetRef.Kind != "Pod" {
-		return nil, fmt.Errorf("invalid TargetRef for endpoint %s: %v", addr.IP, addr.TargetRef)
-	}
-
-	pod, err := cluster.GetPod(addr.TargetRef.Namespace, addr.TargetRef.Name)
-	if err != nil {
-		return nil, err
-	}
-
 	// Create a forwarder to the command port of the app.
 	forwarder, err := cluster.NewPortForwarder(pod, 0, grpcPort)
 	if err != nil {
@@ -86,7 +76,6 @@ func newWorkload(addr kubeCore.EndpointAddress, sidecared bool, grpcPort uint16,
 	}
 
 	return &workload{
-		addr:      addr,
 		pod:       pod,
 		forwarder: forwarder,
 		Instance:  c,
@@ -120,7 +109,7 @@ func (w *workload) checkDeprecation() error {
 }
 
 func (w *workload) Address() string {
-	return w.addr.IP
+	return w.pod.Status.PodIP
 }
 
 func (w *workload) Sidecar() echo.Sidecar {

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -105,7 +105,7 @@ func (i *operatorComponent) Close() (err error) {
 			}
 			// Clean up dynamic leader election locks. This allows new test suites to become the leader without waiting 30s
 			for _, cm := range leaderElectionConfigMaps {
-				if e := cluster.DeleteConfigMap(i.settings.SystemNamespace, cm); e != nil {
+				if e := cluster.DeleteConfigMap(cm, i.settings.SystemNamespace); e != nil {
 					err = multierror.Append(err, e)
 				}
 			}

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"istio.io/istio/operator/pkg/util"
+	"istio.io/istio/pilot/pkg/leaderelection"
 
 	"istio.io/api/mesh/v1alpha1"
 
@@ -87,6 +88,13 @@ func removeCRDs(istioYaml string) string {
 	return yml.JoinString(nonCrds...)
 }
 
+var leaderElectionConfigMaps = []string{
+	leaderelection.IngressController,
+	leaderelection.NamespaceController,
+	leaderelection.ValidationController,
+	leaderelection.StatusController,
+}
+
 func (i *operatorComponent) Close() (err error) {
 	scopes.CI.Infof("=== BEGIN: Cleanup Istio [Suite=%s] ===", i.ctx.Settings().TestID)
 	defer scopes.CI.Infof("=== DONE: Cleanup Istio [Suite=%s] ===", i.ctx.Settings().TestID)
@@ -94,6 +102,12 @@ func (i *operatorComponent) Close() (err error) {
 		for _, cluster := range i.environment.KubeClusters {
 			if e := cluster.DeleteContents("", removeCRDs(i.installManifest[cluster.Name()])); e != nil {
 				err = multierror.Append(err, e)
+			}
+			// Clean up dynamic leader election locks. This allows new test suites to become the leader without waiting 30s
+			for _, cm := range leaderElectionConfigMaps {
+				if e := cluster.DeleteConfigDir(i.settings.SystemNamespace, cm); err != nil {
+					err = multierror.Append(err, e)
+				}
 			}
 			if i.environment.IsMulticluster() {
 				if e := cluster.DeleteNamespace(i.settings.SystemNamespace); e != nil {

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -105,7 +105,7 @@ func (i *operatorComponent) Close() (err error) {
 			}
 			// Clean up dynamic leader election locks. This allows new test suites to become the leader without waiting 30s
 			for _, cm := range leaderElectionConfigMaps {
-				if e := cluster.DeleteConfigDir(i.settings.SystemNamespace, cm); err != nil {
+				if e := cluster.DeleteConfigMap(i.settings.SystemNamespace, cm); e != nil {
 					err = multierror.Append(err, e)
 				}
 			}

--- a/pkg/test/kube/accessor.go
+++ b/pkg/test/kube/accessor.go
@@ -204,6 +204,21 @@ func (a *Accessor) NewPodFetch(namespace string, selectors ...string) PodFetchFu
 	}
 }
 
+// NewPodMustFetch creates a new PodFetchFunction that fetches all pods matching the namespace and label selectors.
+// If no pods are found, an error is returned
+func (a *Accessor) NewPodMustFetch(namespace string, selectors ...string) PodFetchFunc {
+	return func() ([]kubeApiCore.Pod, error) {
+		pods, err := a.GetPods(namespace, selectors...)
+		if err != nil {
+			return nil, err
+		}
+		if len(pods) == 0 {
+			return nil, fmt.Errorf("no pods found for %v", selectors)
+		}
+		return pods, nil
+	}
+}
+
 // NewSinglePodFetch creates a new PodFetchFunction that fetches a single pod matching the given label selectors.
 func (a *Accessor) NewSinglePodFetch(namespace string, selectors ...string) PodFetchFunc {
 	return func() ([]kubeApiCore.Pod, error) {


### PR DESCRIPTION
Broken out of https://github.com/istio/istio/pull/24166/files

Use pods for the readiness check rather than Endpoints. Its largely the
same thing if we make the assumption Kubernetes will create an endpoint
immediately or "soon enough" after marking a pod ready. This supports
pods without an associated Service.

Also cleanup leader election configmaps. This makes it so that new test
suites do not have a large delay at startup trying to become the leader
from a previous test.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure