### PR TITLE
Sort output formats - unsorted causes churn in html and istio.io PRs

### DIFF
--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -102,6 +102,7 @@ func Analyze() *cobra.Command {
 	for k := range msgOutputFormats {
 		msgOutputFormatKeys = append(msgOutputFormatKeys, k)
 	}
+	sort.Strings(msgOutputFormatKeys)
 
 	analysisCmd := &cobra.Command{
 		Use:   "analyze <file>...",


### PR DESCRIPTION

This PR should prevent the churn in the docs reference like seen here:
```
<tr>
 <td><code>--output &lt;string&gt;</code></td>
 <td><code>-o</code></td>
 - <td>Output format: one of [json yaml log]  (default `log`)</td>
 + <td>Output format: one of [log json yaml]  (default `log`)</td>
 </tr>
```


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure