### PR TITLE
CORS Policy TestData: Change to allowOrigins block

### DIFF
--- a/tests/testdata/config/rule-default-route-cors-policy.yaml
+++ b/tests/testdata/config/rule-default-route-cors-policy.yaml
@@ -29,8 +29,8 @@ spec:
       - destination:
           host: cors.test.istio.io
       corsPolicy:
-        allowOrigin:
-          - http://foo.example
+        allowOrigins:
+          - exact: http://foo.example
         allowMethods:
           - POST
           - GET


### PR DESCRIPTION
**Description**
In this PR, we change the block of CORS Policy definition on testdata files, from `allowOrigin` to `allowOrigins` so tests to run on supported resources.

Starting from Istio 1.6, the block with deprecated `allowOrigin` is not respected thus not working.

**Resolves**
- https://github.com/istio/istio/issues/24145
- https://github.com/istio/istio/issues/23757

**Related to**
- https://github.com/istio/api/pull/1453


**Checklist**
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [X] Security
- [X] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure