### PR TITLE
Fix incorrect ServiceAccount used in custom IngressGateway Deployment

### DIFF
--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
         privileged: false
         readOnlyRootFilesystem: true
 {{- end }}
-      serviceAccountName: istio-egressgateway-service-account
+      serviceAccountName: {{ $gateway.name | default "istio-egressgateway" }}-service-account
 {{- if .Values.global.priorityClassName }}
       priorityClassName: "{{ .Values.global.priorityClassName }}"
 {{- end }}

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
         privileged: false
         readOnlyRootFilesystem: true
 {{- end }}
-      serviceAccountName: istio-ingressgateway-service-account
+      serviceAccountName: {{ $gateway.name | default "istio-ingressgateway" }}-service-account
 {{- if .Values.global.priorityClassName }}
       priorityClassName: "{{ .Values.global.priorityClassName }}"
 {{- end }}


### PR DESCRIPTION


[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

Just noticed having an IngressGateway in a different namespace from `istio-system` caused the Pod creation failure due to missing ServiceAccount. The Deployment was not updated correctly when #23570 went in.

I'll be preparing a quick backport to v1.6 and v1.5 as they both have got the backport already (#23852 and #23853 respectively).

This updates #23303 