### PR TITLE
Modify CODEOWNERS with micro review optimizations

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,7 @@
 *                                                                @costinm @linsun @rshriram @howardjohn
+/.gitattributes                                                  @istio/wg-test-and-release-maintainers
+/.gitignore                                                      @istio/wg-test-and-release-maintainers
+/Makefile.core.mk                                                @istio/wg-test-and-release-maintainers
 /bin/                                                            @istio/wg-test-and-release-maintainers
 /cmd/istiod/                                                     @istio/wg-environments-maintainers
 /common/                                                         @istio/wg-test-and-release-maintainers


### PR DESCRIPTION
Add .gitignore, .gitattributes, Makefile.core.mk to the
list of files that are managed by the test and release WG.

Cheers,
-steve



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure