### PR TITLE
Display warning if the installed Istio version is different

### DIFF
--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -36,10 +36,10 @@ import (
 	"istio.io/istio/operator/pkg/util/clog"
 	"istio.io/istio/operator/pkg/util/progress"
 	pkgversion "istio.io/istio/operator/pkg/version"
+	operatorVer "istio.io/istio/operator/version"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 	"istio.io/istio/pkg/kube"
 	"istio.io/pkg/log"
-	buildversion "istio.io/pkg/version"
 )
 
 const (
@@ -132,7 +132,7 @@ func runApplyCmd(cmd *cobra.Command, rootArgs *rootArgs, iArgs *installArgs, log
 	if err != nil {
 		return err
 	}
-	tag, err := GetTagVersion(buildversion.DockerInfo.Tag)
+	tag, err := GetTagVersion(operatorVer.OperatorVersionString)
 	if err != nil {
 		return err
 	}
@@ -249,7 +249,7 @@ func DetectIstioVersionDiff(cmd *cobra.Command, tag string, kubeClient kube.Exte
 		// when the revision is not passed
 		if iArgs.revision == "" && tag != icpTag {
 			cmd.Printf("! Istio control planes installed: %s.\n"+
-				"! Use --revision=%s or --force to install Istio.\n", strings.Join(icpTags, ", "), tag)
+				"! Use --revision or --force to install Istio.\n", strings.Join(icpTags, ", "))
 		}
 		// when the revision is passed
 		if icpTag != "" && tag != icpTag && iArgs.revision != "" {

--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -238,8 +238,8 @@ func DetectIstioVersionDiff(cmd *cobra.Command, tag string, kubeClient kube.Exte
 			}
 		}
 		if icpTag != "" && tag != icpTag {
-			cmd.Printf("! istioctl version %s and the control plane version %s are different.\n"+
-				"! Proceed with caution because after installation you might experience problems.\n", tag, icpTag)
+			cmd.Printf("! Istio is being upgraded from %s -> %s.\n"+
+				"! Before upgrading, you may wish to 'istioctl analyze' to check for IST0002 deprecation warnings.\n", icpTag, tag)
 		}
 	}
 	return nil

--- a/operator/pkg/version/version_test.go
+++ b/operator/pkg/version/version_test.go
@@ -78,6 +78,11 @@ func TestVersion(t *testing.T) {
 			yamlStr: ".1.1.1-something",
 			wantErr: `Malformed version: .1.1.1-something`,
 		},
+		{
+			desc:    "Malformed version fail",
+			yamlStr: "istio-testing-distroless",
+			wantErr: `Malformed version: istio-testing-distroless`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/releasenotes/notes/18487.yaml
+++ b/releasenotes/notes/18487.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue:
+  - 18487
+
+releaseNotes:
+- |
+  **Added** `istioctl install` will detect different Istio version installed (istioctl, control plan version) and display warning.


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/18487

This PR will detect different Istio version installed (istioctl, control plan version) and display warning.

When Istio is not installed.

```
$ ./out/linux_amd64/istioctl install
This will install the Istio 1.8.0 profile into the cluster. Proceed? (y/N)
```

When a revision is not passed
```
$ ./out/linux_amd64/istioctl install --set hub=gcr.io/istio-testing -d manifests/
! Istio control planes installed: 1.6.8, 1.7.2.
! Use --revision or --force to install Istio.
This will install the Istio 1.8.0 profile into the cluster. Proceed? (y/N)
```

When a revision is passed.
```
$ ./out/linux_amd64/istioctl install --revision=1-8-0 --set hub=gcr.io/istio-testing -d manifests/
! Istio is being upgraded from 1.7.2 -> 1.8.0.
! Before upgrading, you may wish to 'istioctl analyze' to check for IST0002 deprecation warnings.
This will install the Istio 1.8.0 profile into the cluster. Proceed? (y/N)
```