### PR TITLE
[release-1.6] cherry pick use external name when remote pilot addr is hostname #24219

### DIFF
--- a/manifests/charts/base/templates/endpoints.yaml
+++ b/manifests/charts/base/templates/endpoints.yaml
@@ -11,7 +11,7 @@ subsets:
   ports:
   - port: 15012
     name: tcp-istiod
-  {{- else }}
+  {{- else if regexMatch "^([0-9]*\\.){3}[0-9]*$" .Values.global.remotePilotAddress }}
 apiVersion: v1
 kind: Endpoints
 metadata:

--- a/manifests/charts/base/templates/services.yaml
+++ b/manifests/charts/base/templates/services.yaml
@@ -22,7 +22,14 @@ spec:
   ports:
   - port: 15012
     name: tcp-istiod
+  # if the remotePilotAddress is IP addr, we use clusterIP: None.
+  # else, we use externalName
+  {{- if regexMatch "^([0-9]*\\.){3}[0-9]*$" .Values.global.remotePilotAddress }}
   clusterIP: None
+  {{- else }}
+  type: ExternalName
+  externalName: {{ .Values.global.remotePilotAddress }}
+  {{- end }}
   {{- end }}
 ---
 {{- end }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/base/templates/endpoints.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/base/templates/endpoints.yaml
@@ -9,11 +9,9 @@ subsets:
 - addresses:
   - ip: {{ .Values.global.remotePilotAddress }}
   ports:
-  - port: 15010
-    name: grpc-xds # direct
-  - port: 15011
-    name: https-xds # mTLS or non-mTLS depending on auth setting
-  {{- else }}
+  - port: 15012
+    name: tcp-istiod
+  {{- else if regexMatch "^([0-9]*\\.){3}[0-9]*$" .Values.global.remotePilotAddress }}
 apiVersion: v1
 kind: Endpoints
 metadata:

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/base/templates/services.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/base/templates/services.yaml
@@ -22,7 +22,14 @@ spec:
   ports:
   - port: 15012
     name: tcp-istiod
+  # if the remotePilotAddress is IP addr, we use clusterIP: None.
+  # else, we use externalName
+  {{- if regexMatch "^([0-9]*\\.){3}[0-9]*$" .Values.global.remotePilotAddress }}
   clusterIP: None
+  {{- else }}
+  type: ExternalName
+  externalName: {{ .Values.global.remotePilotAddress }}
+  {{- end }}
   {{- end }}
 ---
 {{- end }}


### PR DESCRIPTION
Fixes: #24269 manual cherry pick of #24219


[ ] Configuration Infrastructure
[ ] Docs
[x ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
