### PR TITLE
Fix QuotaSpec crash

### DIFF
--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -26,7 +26,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 
 	networking "istio.io/api/networking/v1alpha3"
-	mccpb "istio.io/istio/pilot/pkg/networking/plugin/mixer/client"
+	mccpb "istio.io/api/mixer/v1/config/client"
 
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/24264

I have no strong confidence this works, as we clearly have no end to end tests or this would have been caught. Apparently no one has used QuotaSpec with istiod since this should be broken since 1.5.0

Basically the issue is we are using the golang proto struct instead of gogo proto struct.