### PR TITLE
Switch to actually request/use XDS v3

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -213,6 +213,18 @@ type Proxy struct {
 	// Active contains the list of watched resources for the proxy, keyed by the DiscoveryRequest type.
 	// It is nil if the Proxy uses the default generator
 	Active map[string]*WatchedResource
+
+	// Envoy may request different versions of configuration (XDS v2 vs v3). While internally Pilot will
+	// only generate one version or the other, because the protos are wire compatible we can cast to the
+	// requested version. This struct keeps track of the types requested for each resource type.
+	// For example, if Envoy requests Clusters v3, we would track that here. Pilot would generate a v2
+	// cluster response, but change the TypeUrl in the response to be v3.
+	RequestedTypes struct {
+		CDS string
+		EDS string
+		RDS string
+		LDS string
+	}
 }
 
 // WatchedResource tracks an active DiscoveryRequest type.

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -52,6 +52,7 @@ import (
 	istionetworking "istio.io/istio/pilot/pkg/networking"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
+	v3 "istio.io/istio/pilot/pkg/proxy/envoy/v3"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
@@ -1964,6 +1965,10 @@ func buildHTTPConnectionManager(pluginParams *plugin.InputParams, httpOpts *http
 			},
 		}
 		connectionManager.RouteSpecifier = rds
+		if pluginParams.Node.RequestedTypes.LDS == v3.ListenerType {
+			// For v3 listeners, send v3 routes
+			rds.Rds.ConfigSource.ResourceApiVersion = core.ApiVersion_V3
+		}
 	} else {
 		connectionManager.RouteSpecifier = &hcm.HttpConnectionManager_RouteConfig{RouteConfig: httpOpts.routeConfig}
 	}

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -103,18 +103,6 @@ type XdsConnection struct {
 	// CDSWatch is set if the remote server is watching Clusters
 	CDSWatch bool
 
-	// Envoy may request different versions of configuration (XDS v2 vs v3). While internally Pilot will
-	// only generate one version or the other, because the protos are wire compatible we can cast to the
-	// requested version. This struct keeps track of the types requested for each resource type.
-	// For example, if Envoy requests Clusters v3, we would track that here. Pilot would generate a v2
-	// cluster response, but change the TypeUrl in the response to be v3.
-	RequestedTypes struct {
-		CDS string
-		EDS string
-		RDS string
-		LDS string
-	}
-
 	// Original node metadata, to avoid unmarshall/marshall. This is included
 	// in internal events.
 	xdsNode *corev3.Node
@@ -316,28 +304,28 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream discovery.AggregatedD
 
 			switch discReq.TypeUrl {
 			case ClusterType, v3.ClusterType:
-				if err := s.handleTypeURL(discReq.TypeUrl, &con.RequestedTypes.CDS); err != nil {
+				if err := s.handleTypeURL(discReq.TypeUrl, &con.node.RequestedTypes.CDS); err != nil {
 					return err
 				}
 				if err := s.handleCds(con, discReq); err != nil {
 					return err
 				}
 			case ListenerType, v3.ListenerType:
-				if err := s.handleTypeURL(discReq.TypeUrl, &con.RequestedTypes.LDS); err != nil {
+				if err := s.handleTypeURL(discReq.TypeUrl, &con.node.RequestedTypes.LDS); err != nil {
 					return err
 				}
 				if err := s.handleLds(con, discReq); err != nil {
 					return err
 				}
 			case RouteType, v3.RouteType:
-				if err := s.handleTypeURL(discReq.TypeUrl, &con.RequestedTypes.RDS); err != nil {
+				if err := s.handleTypeURL(discReq.TypeUrl, &con.node.RequestedTypes.RDS); err != nil {
 					return err
 				}
 				if err := s.handleRds(con, discReq); err != nil {
 					return err
 				}
 			case EndpointType, v3.EndpointType:
-				if err := s.handleTypeURL(discReq.TypeUrl, &con.RequestedTypes.EDS); err != nil {
+				if err := s.handleTypeURL(discReq.TypeUrl, &con.node.RequestedTypes.EDS); err != nil {
 					return err
 				}
 				if err := s.handleEds(con, discReq); err != nil {

--- a/pilot/pkg/proxy/envoy/v2/cds.go
+++ b/pilot/pkg/proxy/envoy/v2/cds.go
@@ -55,7 +55,7 @@ func (s *DiscoveryServer) pushCds(con *XdsConnection, push *model.PushContext, v
 	if s.DebugConfigs {
 		con.CDSClusters = rawClusters
 	}
-	response := cdsDiscoveryResponse(rawClusters, push.Version, con.RequestedTypes.CDS)
+	response := cdsDiscoveryResponse(rawClusters, push.Version, con.node.RequestedTypes.CDS)
 	err := con.send(response)
 	cdsPushTime.Record(time.Since(pushStart).Seconds())
 	if err != nil {

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -483,7 +483,7 @@ func (s *DiscoveryServer) configDump(conn *XdsConnection) (*adminapi.ConfigDump,
 		if err != nil {
 			return nil, err
 		}
-		cluster.TypeUrl = conn.RequestedTypes.CDS
+		cluster.TypeUrl = conn.node.RequestedTypes.CDS
 		dynamicActiveClusters = append(dynamicActiveClusters, &adminapi.ClustersConfigDump_DynamicCluster{Cluster: cluster})
 	}
 	clustersAny, err := util.MessageToAnyWithError(&adminapi.ClustersConfigDump{
@@ -501,7 +501,7 @@ func (s *DiscoveryServer) configDump(conn *XdsConnection) (*adminapi.ConfigDump,
 		if err != nil {
 			return nil, err
 		}
-		listener.TypeUrl = conn.RequestedTypes.LDS
+		listener.TypeUrl = conn.node.RequestedTypes.LDS
 		dynamicActiveListeners = append(dynamicActiveListeners, &adminapi.ListenersConfigDump_DynamicListener{
 			Name:        cs.Name,
 			ActiveState: &adminapi.ListenersConfigDump_DynamicListenerState{Listener: listener}})
@@ -523,7 +523,7 @@ func (s *DiscoveryServer) configDump(conn *XdsConnection) (*adminapi.ConfigDump,
 			if err != nil {
 				return nil, err
 			}
-			route.TypeUrl = conn.RequestedTypes.RDS
+			route.TypeUrl = conn.node.RequestedTypes.RDS
 			dynamicRouteConfig = append(dynamicRouteConfig, &adminapi.RoutesConfigDump_DynamicRouteConfig{RouteConfig: route})
 		}
 		routeConfigAny, err = util.MessageToAnyWithError(&adminapi.RoutesConfigDump{DynamicRouteConfigs: dynamicRouteConfig})

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -463,7 +463,7 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection, v
 		loadAssignments = append(loadAssignments, l)
 	}
 
-	response := endpointDiscoveryResponse(loadAssignments, version, push.Version, con.RequestedTypes.EDS)
+	response := endpointDiscoveryResponse(loadAssignments, version, push.Version, con.node.RequestedTypes.EDS)
 	err := con.send(response)
 	edsPushTime.Record(time.Since(pushStart).Seconds())
 	if err != nil {

--- a/pilot/pkg/proxy/envoy/v2/lds.go
+++ b/pilot/pkg/proxy/envoy/v2/lds.go
@@ -32,7 +32,7 @@ func (s *DiscoveryServer) pushLds(con *XdsConnection, push *model.PushContext, v
 	if s.DebugConfigs {
 		con.LDSListeners = rawListeners
 	}
-	response := ldsDiscoveryResponse(rawListeners, version, push.Version, con.RequestedTypes.LDS)
+	response := ldsDiscoveryResponse(rawListeners, version, push.Version, con.node.RequestedTypes.LDS)
 	err := con.send(response)
 	ldsPushTime.Record(time.Since(pushStart).Seconds())
 	if err != nil {

--- a/pilot/pkg/proxy/envoy/v2/rds.go
+++ b/pilot/pkg/proxy/envoy/v2/rds.go
@@ -40,7 +40,7 @@ func (s *DiscoveryServer) pushRoute(con *XdsConnection, push *model.PushContext,
 		}
 	}
 
-	response := routeDiscoveryResponse(rawRoutes, version, push.Version, con.RequestedTypes.RDS)
+	response := routeDiscoveryResponse(rawRoutes, version, push.Version, con.node.RequestedTypes.RDS)
 	err := con.send(response)
 	rdsPushTime.Record(time.Since(pushStart).Seconds())
 	if err != nil {

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -228,13 +228,16 @@
   },
   "dynamic_resources": {
     "lds_config": {
-      "ads": {}
+      "ads": {},
+      "resource_api_version": "V3"
     },
     "cds_config": {
-      "ads": {}
+      "ads": {},
+      "resource_api_version": "V3"
     },
     "ads_config": {
       "api_type": "GRPC",
+      "transport_api_version": "V3",
       "grpc_services": [
         {
           "envoy_grpc": {

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -228,13 +228,16 @@
   },
   "dynamic_resources": {
     "lds_config": {
-      "ads": {}
+      "ads": {},
+      "resource_api_version": "V3"
     },
     "cds_config": {
-      "ads": {}
+      "ads": {},
+      "resource_api_version": "V3"
     },
     "ads_config": {
       "api_type": "GRPC",
+      "transport_api_version": "V3",
       "grpc_services": [
         {
           "envoy_grpc": {

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -228,13 +228,16 @@
   },
   "dynamic_resources": {
     "lds_config": {
-      "ads": {}
+      "ads": {},
+      "resource_api_version": "V3"
     },
     "cds_config": {
-      "ads": {}
+      "ads": {},
+      "resource_api_version": "V3"
     },
     "ads_config": {
       "api_type": "GRPC",
+      "transport_api_version": "V3",
       "grpc_services": [
         {
           "envoy_grpc": {

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -228,13 +228,16 @@
   },
   "dynamic_resources": {
     "lds_config": {
-      "ads": {}
+      "ads": {},
+      "resource_api_version": "V3"
     },
     "cds_config": {
-      "ads": {}
+      "ads": {},
+      "resource_api_version": "V3"
     },
     "ads_config": {
       "api_type": "GRPC",
+      "transport_api_version": "V3",
       "grpc_services": [
         {
           "envoy_grpc": {

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -233,13 +233,16 @@
   },
   "dynamic_resources": {
     "lds_config": {
-      "ads": {}
+      "ads": {},
+      "resource_api_version": "V3"
     },
     "cds_config": {
-      "ads": {}
+      "ads": {},
+      "resource_api_version": "V3"
     },
     "ads_config": {
       "api_type": "GRPC",
+      "transport_api_version": "V3",
       "grpc_services": [
         {
           "envoy_grpc": {

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -233,13 +233,16 @@
   },
   "dynamic_resources": {
     "lds_config": {
-      "ads": {}
+      "ads": {},
+      "resource_api_version": "V3"
     },
     "cds_config": {
-      "ads": {}
+      "ads": {},
+      "resource_api_version": "V3"
     },
     "ads_config": {
       "api_type": "GRPC",
+      "transport_api_version": "V3",
       "grpc_services": [
         {
           "envoy_grpc": {

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -243,13 +243,16 @@
   },
   "dynamic_resources": {
     "lds_config": {
-      "ads": {}
+      "ads": {},
+      "resource_api_version": "V3"
     },
     "cds_config": {
-      "ads": {}
+      "ads": {},
+      "resource_api_version": "V3"
     },
     "ads_config": {
       "api_type": "GRPC",
+      "transport_api_version": "V3",
       "grpc_services": [
         {
           "envoy_grpc": {

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -228,13 +228,16 @@
   },
   "dynamic_resources": {
     "lds_config": {
-      "ads": {}
+      "ads": {},
+      "resource_api_version": "V3"
     },
     "cds_config": {
-      "ads": {}
+      "ads": {},
+      "resource_api_version": "V3"
     },
     "ads_config": {
       "api_type": "GRPC",
+      "transport_api_version": "V3",
       "grpc_services": [
         {
           "envoy_grpc": {

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -228,13 +228,16 @@
   },
   "dynamic_resources": {
     "lds_config": {
-      "ads": {}
+      "ads": {},
+      "resource_api_version": "V3"
     },
     "cds_config": {
-      "ads": {}
+      "ads": {},
+      "resource_api_version": "V3"
     },
     "ads_config": {
       "api_type": "GRPC",
+      "transport_api_version": "V3",
       "grpc_services": [
         {
           "envoy_grpc": {

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -228,13 +228,16 @@
   },
   "dynamic_resources": {
     "lds_config": {
-      "ads": {}
+      "ads": {},
+      "resource_api_version": "V3"
     },
     "cds_config": {
-      "ads": {}
+      "ads": {},
+      "resource_api_version": "V3"
     },
     "ads_config": {
       "api_type": "GRPC",
+      "transport_api_version": "V3",
       "grpc_services": [
         {
           "envoy_grpc": {

--- a/pkg/bootstrap/testdata/tracing_tls_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_golden.json
@@ -228,13 +228,16 @@
   },
   "dynamic_resources": {
     "lds_config": {
-      "ads": {}
+      "ads": {},
+      "resource_api_version": "V3"
     },
     "cds_config": {
-      "ads": {}
+      "ads": {},
+      "resource_api_version": "V3"
     },
     "ads_config": {
       "api_type": "GRPC",
+      "transport_api_version": "V3",
       "grpc_services": [
         {
           "envoy_grpc": {

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -228,13 +228,16 @@
   },
   "dynamic_resources": {
     "lds_config": {
-      "ads": {}
+      "ads": {},
+      "resource_api_version": "V3"
     },
     "cds_config": {
-      "ads": {}
+      "ads": {},
+      "resource_api_version": "V3"
     },
     "ads_config": {
       "api_type": "GRPC",
+      "transport_api_version": "V3",
       "grpc_services": [
         {
           "envoy_grpc": {

--- a/tools/packaging/common/envoy_bootstrap_v2.json
+++ b/tools/packaging/common/envoy_bootstrap_v2.json
@@ -119,13 +119,16 @@
   },
   "dynamic_resources": {
     "lds_config": {
-      "ads": {}
+      "ads": {},
+      "resource_api_version": "V3"
     },
     "cds_config": {
-      "ads": {}
+      "ads": {},
+      "resource_api_version": "V3"
     },
     "ads_config": {
       "api_type": "GRPC",
+      "transport_api_version": "V3",
       "grpc_services": [
         {
           "envoy_grpc": {


### PR DESCRIPTION
For https://github.com/istio/istio/issues/19885

Pilot now supports either v2 or v3 requests. This just switches the default to requesting v3. Additionally, it changes the ConfigSource types to reference the same version requested. So cds vX -> eds vX. As part of this change I had to move the requestedTypes to the node rather than the connection.