### PR TITLE
Add help message to makefile

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -260,7 +260,7 @@ ${GEN_CERT}:
 # If pre-commit script is not used, please run this manually.
 precommit: format lint
 
-format: fmt
+format: fmt ## Auto formats all code. This should be run before sending a PR.
 
 fmt: format-go format-python tidy-go
 
@@ -285,7 +285,7 @@ BINARIES:=./istioctl/cmd/istioctl \
 RELEASE_BINARIES:=pilot-discovery pilot-agent mixc mixs mixgen istioctl sdsclient
 
 .PHONY: build
-build: depend
+build: depend ## Builds all go binaries.
 	STATIC=0 GOOS=$(GOOS_LOCAL) GOARCH=$(GOARCH_LOCAL) LDFLAGS='-extldflags -static -s -w' common/scripts/gobuild.sh $(ISTIO_OUT)/ $(BINARIES)
 
 # The build-linux target is responsible for building binaries used within containers.
@@ -322,7 +322,8 @@ MARKDOWN_LINT_WHITELIST=localhost:8080,storage.googleapis.com/istio-artifacts/pi
 lint-helm-global:
 	find manifests -name 'Chart.yaml' -print0 | ${XARGS} -L 1 dirname | xargs -r helm lint --strict -f manifests/charts/global.yaml
 
-lint: lint-python lint-copyright-banner lint-scripts lint-go lint-dockerfiles lint-markdown lint-yaml lint-licenses lint-helm-global
+
+lint: lint-python lint-copyright-banner lint-scripts lint-go lint-dockerfiles lint-markdown lint-yaml lint-licenses lint-helm-global ## Runs all linters.
 	@bin/check_samples.sh
 	@go run mixer/tools/adapterlinter/main.go ./mixer/adapter/...
 	@testlinter
@@ -343,7 +344,7 @@ refresh-goldens:
 
 update-golden: refresh-goldens
 
-gen: go-gen mirror-licenses format update-crds operator-proto sync-configs-from-istiod gen-kustomize update-golden
+gen: go-gen mirror-licenses format update-crds operator-proto sync-configs-from-istiod gen-kustomize update-golden ## Update all generated code.
 
 check-no-modify:
 	@bin/check_no_modify.sh
@@ -510,7 +511,8 @@ common-coverage:
 .PHONY: racetest
 
 RACE_TESTS ?= pilot-racetest mixer-racetest security-racetest galley-test common-racetest istioctl-racetest operator-racetest
-racetest: $(JUNIT_REPORT)
+
+racetest: $(JUNIT_REPORT) ## Runs all unit tests with race detection enabled
 	$(MAKE) -e -f Makefile.core.mk --keep-going $(RACE_TESTS) \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
 
@@ -547,7 +549,7 @@ common-racetest: ${BUILD_DEPS}
 #-----------------------------------------------------------------------------
 .PHONY: clean
 
-clean:
+clean: ## Cleans all the intermediate files and folders previously generated.
 	rm -rf $(DIRS_TO_CLEAN)
 	rm -f $(FILES_TO_CLEAN)
 
@@ -559,7 +561,7 @@ clean:
 # for now docker is limited to Linux compiles - why ?
 include tools/istio-docker.mk
 
-push: docker.push
+push: docker.push ## Build and push docker images to registry defined by $HUB and $TAG
 
 FILES_TO_CLEAN+=install/consul/istio.yaml \
                 samples/bookinfo/platform/consul/bookinfo.sidecars.yaml


### PR DESCRIPTION
Example output:
```
$ make help
build                Builds all go binaries.
clean                Cleans all the intermediate files and folders previously generated.
format               Auto formats all code. This should be run before sending a PR.
gen                  Update all generated code.
help                 Show this help
lint                 Runs all linters.
push                 Build and push docker images to registry defined by $HUB and $TAG
racetest             Runs all unit tests with race detection enabled
```

This will need to go to common-files. Submitting here first to let people try it out and get initial feedback