### PR TITLE
Display deprecation msg for istioctl manifest apply

### DIFF
--- a/operator/cmd/mesh/manifest-apply.go
+++ b/operator/cmd/mesh/manifest-apply.go
@@ -95,7 +95,7 @@ func manifestApplyCmd(rootArgs *rootArgs, maArgs *manifestApplyArgs, logOpts *lo
 `,
 		Args: cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.Println("! istioctl manifest apply has graduated. Use istioctl install instead")
+			cmd.Println("! istioctl manifest apply is deprecated. Use istioctl install instead")
 			return runApplyCmd(cmd, rootArgs, maArgs, logOpts)
 		}}
 }

--- a/operator/cmd/mesh/manifest-apply.go
+++ b/operator/cmd/mesh/manifest-apply.go
@@ -95,7 +95,7 @@ func manifestApplyCmd(rootArgs *rootArgs, maArgs *manifestApplyArgs, logOpts *lo
 `,
 		Args: cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.Println("! istioctl manifest apply will be deprecated in next release; use istioctl install instead")
+			cmd.Println("! istioctl manifest apply has graduated. Use istioctl install instead")
 			return runApplyCmd(cmd, rootArgs, maArgs, logOpts)
 		}}
 }

--- a/operator/cmd/mesh/manifest-apply.go
+++ b/operator/cmd/mesh/manifest-apply.go
@@ -95,6 +95,7 @@ func manifestApplyCmd(rootArgs *rootArgs, maArgs *manifestApplyArgs, logOpts *lo
 `,
 		Args: cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.Println("! istioctl manifest apply will be deprecated in next release; use istioctl install instead")
 			return runApplyCmd(cmd, rootArgs, maArgs, logOpts)
 		}}
 }


### PR DESCRIPTION
As per the suggestion from @ostromart in https://github.com/istio/istio.io/pull/7396#pullrequestreview-421110570, Display deprecation msg for `istioctl manifest apply`.

It needs to be cherry-picked for 1.6.

Related:
https://github.com/istio/istio/pull/22563
https://github.com/istio/istio.io/pull/7336

[X] Installation
[X] User Experience