### PR TITLE
fix init container crash when iptables exist

### DIFF
--- a/tools/istio-iptables/pkg/builder/iptables_builder.go
+++ b/tools/istio-iptables/pkg/builder/iptables_builder.go
@@ -24,6 +24,14 @@ type IptablesProducer interface {
 	InsertRuleV4(chain string, table string, position int, params ...string) IptablesProducer
 	// InsertRuleV6 inserts IPv6 rule at a particular position in the chain
 	InsertRuleV6(chain string, table string, position int, params ...string) IptablesProducer
+	// EnsureV4Rule ensure IPv4 rule in given iptables chain
+	EnsureV4Rule(rule *Rule) error
+	// EnsureV6Rule ensure IPv6 rule in given iptables chain
+	EnsureV6Rule(rule *Rule) error
+	// EnsureV4Chain ensure IPv4 chain exist in given iptables
+	EnsureV4Chain(rule *Rule) error
+	// EnsureV6Chain ensure IPv4 chain exist in given iptables
+	EnsureV6Chain(rule *Rule) error
 }
 
 // IptablesConsumer is an interface for constructing iptables-rules command string or iptables-restore formatted rules
@@ -33,9 +41,9 @@ type IptablesConsumer interface {
 	// BuildV6 creates ip6tables commands
 	BuildV6() [][]string
 	// BuildV4Restore creates iptables-restore input format
-	BuildV4Restore() string
+	BuildV4Restore() ([]*Rule, []*Rule, string)
 	// BuildV6Restore creates ip6tables-restore input format
-	BuildV6Restore() string
+	BuildV6Restore() ([]*Rule, []*Rule, string)
 }
 
 // IptablesBuilder is a higher level interface based on builder pattern.

--- a/tools/istio-iptables/pkg/builder/iptables_builder_impl.go
+++ b/tools/istio-iptables/pkg/builder/iptables_builder_impl.go
@@ -19,13 +19,17 @@ import (
 	"strings"
 
 	"istio.io/istio/tools/istio-iptables/pkg/constants"
+	dep "istio.io/istio/tools/istio-iptables/pkg/dependencies"
 )
+
+const chainNotExistErr = "iptables: No chain/target/match by that name.\n"
 
 // Rule represents iptables rule - chain, table and options
 type Rule struct {
-	chain  string
-	table  string
-	params []string
+	chain     string
+	table     string
+	extraArgs []string
+	params    []string
 }
 
 // Rules represents iptables for V4 and V6
@@ -37,50 +41,56 @@ type Rules struct {
 // IptablesBuilderImpl is an implementation for IptablesBuilder interface
 type IptablesBuilderImpl struct {
 	rules Rules
+	ext   dep.Dependencies
 }
 
 // NewIptablesBuilders creates a new IptablesBuilder
-func NewIptablesBuilder() *IptablesBuilderImpl {
+func NewIptablesBuilder(ext dep.Dependencies) *IptablesBuilderImpl {
 	return &IptablesBuilderImpl{
 		rules: Rules{
 			rulesv4: []*Rule{},
 			rulesv6: []*Rule{},
 		},
+		ext: ext,
 	}
 }
 
 func (rb *IptablesBuilderImpl) InsertRuleV4(chain string, table string, position int, params ...string) IptablesProducer {
 	rb.rules.rulesv4 = append(rb.rules.rulesv4, &Rule{
-		chain:  chain,
-		table:  table,
-		params: append([]string{"-I", chain, fmt.Sprint(position)}, params...),
+		chain:     chain,
+		table:     table,
+		extraArgs: []string{"-I", chain, fmt.Sprint(position)},
+		params:    params,
 	})
 	return rb
 }
 
 func (rb *IptablesBuilderImpl) InsertRuleV6(chain string, table string, position int, params ...string) IptablesProducer {
 	rb.rules.rulesv6 = append(rb.rules.rulesv6, &Rule{
-		chain:  chain,
-		table:  table,
-		params: append([]string{"-I", chain, fmt.Sprint(position)}, params...),
+		chain:     chain,
+		table:     table,
+		extraArgs: []string{"-I", chain, fmt.Sprint(position)},
+		params:    params,
 	})
 	return rb
 }
 
 func (rb *IptablesBuilderImpl) AppendRuleV4(chain string, table string, params ...string) IptablesProducer {
 	rb.rules.rulesv4 = append(rb.rules.rulesv4, &Rule{
-		chain:  chain,
-		table:  table,
-		params: append([]string{"-A", chain}, params...),
+		chain:     chain,
+		table:     table,
+		extraArgs: []string{"-A", chain},
+		params:    params,
 	})
 	return rb
 }
 
 func (rb *IptablesBuilderImpl) AppendRuleV6(chain string, table string, params ...string) IptablesProducer {
 	rb.rules.rulesv6 = append(rb.rules.rulesv6, &Rule{
-		chain:  chain,
-		table:  table,
-		params: append([]string{"-A", chain}, params...),
+		chain:     chain,
+		table:     table,
+		extraArgs: []string{"-A", chain},
+		params:    params,
 	})
 	return rb
 }
@@ -101,7 +111,8 @@ func (rb *IptablesBuilderImpl) buildRules(command string, rules []*Rule) [][]str
 		}
 	}
 	for _, r := range rules {
-		cmd := append([]string{command, "-t", r.table}, r.params...)
+		params := append(r.extraArgs, r.params...)
+		cmd := append([]string{command, "-t", r.table}, params...)
 		output = append(output, cmd)
 	}
 	return output
@@ -129,12 +140,14 @@ func (rb *IptablesBuilderImpl) constructIptablesRestoreContents(tableRulesMap ma
 	return b.String()
 }
 
-func (rb *IptablesBuilderImpl) buildRestore(rules []*Rule) string {
+func (rb *IptablesBuilderImpl) buildRestore(rules []*Rule) ([]*Rule, []*Rule, string) {
 	tableRulesMap := map[string][]string{
 		constants.FILTER: {},
 		constants.NAT:    {},
 		constants.MANGLE: {},
 	}
+	buildInTableRules := []*Rule{}
+	definedChain := []*Rule{}
 
 	chainTableLookupMap := make(map[string]struct{})
 	for _, r := range rules {
@@ -143,22 +156,111 @@ func (rb *IptablesBuilderImpl) buildRestore(rules []*Rule) string {
 		if _, present := chainTableLookupMap[chainTable]; !present {
 			// Ignore chain creation for built-in chains for iptables
 			if _, present := constants.BuiltInChainsMap[r.chain]; !present {
-				tableRulesMap[r.table] = append(tableRulesMap[r.table], fmt.Sprintf("-N %s", r.chain))
+				tableRulesMap[r.table] = append(tableRulesMap[r.table], fmt.Sprintf(":%s - [0:0]", r.chain))
+				definedChain = append(definedChain, &Rule{
+					chain:     r.chain,
+					table:     r.table,
+					extraArgs: []string{"-N", r.chain, "-t", r.table},
+				})
 				chainTableLookupMap[chainTable] = struct{}{}
 			}
 		}
+
+		if _, buildIn := constants.BuiltInChainsMap[r.chain]; buildIn {
+			buildInTableRules = append(buildInTableRules, &Rule{
+				chain:     r.chain,
+				table:     r.table,
+				extraArgs: []string{"-A", r.chain, "-t", r.table},
+				params:    r.params,
+			})
+		} else {
+			tableRulesMap[r.table] = append(tableRulesMap[r.table], strings.Join(append(r.extraArgs, r.params...), " "))
+		}
 	}
 
-	for _, r := range rules {
-		tableRulesMap[r.table] = append(tableRulesMap[r.table], strings.Join(r.params, " "))
-	}
-	return rb.constructIptablesRestoreContents(tableRulesMap)
-
+	return buildInTableRules, definedChain, rb.constructIptablesRestoreContents(tableRulesMap)
 }
-func (rb *IptablesBuilderImpl) BuildV4Restore() string {
+
+func (rb *IptablesBuilderImpl) BuildV4Restore() ([]*Rule, []*Rule, string) {
 	return rb.buildRestore(rb.rules.rulesv4)
 }
 
-func (rb *IptablesBuilderImpl) BuildV6Restore() string {
+func (rb *IptablesBuilderImpl) BuildV6Restore() ([]*Rule, []*Rule, string) {
 	return rb.buildRestore(rb.rules.rulesv6)
+}
+
+func (rb *IptablesBuilderImpl) ruleExists(command string, rule *Rule) (bool, error) {
+	args := append([]string{"-C", rule.chain, "-t", rule.table}, rule.params...)
+
+	if stdout, err := rb.ext.Command(command, args...); err != nil {
+		if chainNotExistErr == string(stdout) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func (rb *IptablesBuilderImpl) ensureRule(command string, rule *Rule) error {
+	params := append(rule.extraArgs, rule.params...)
+	fmt.Printf("Ensure Rule: %s %s\n", command, strings.Join(params, " "))
+
+	exist, err := rb.ruleExists(command, rule)
+	if err != nil {
+		return err
+	}
+	if exist {
+		return nil
+	}
+	if err := rb.ext.Run(command, params...); err != nil {
+		return err
+	}
+	return nil
+}
+
+// EnsureV4Rule ensure rule writed in given table
+func (rb *IptablesBuilderImpl) EnsureV4Rule(rule *Rule) error {
+	return rb.ensureRule(constants.IPTABLES, rule)
+}
+
+// EnsureV6Rule ensure rule writed in given table
+func (rb *IptablesBuilderImpl) EnsureV6Rule(rule *Rule) error {
+	return rb.ensureRule(constants.IP6TABLES, rule)
+}
+
+func (rb *IptablesBuilderImpl) chainExists(command string, rule *Rule) (bool, error) {
+	if stdout, err := rb.ext.Command(command, "-L", rule.chain, "-t", rule.table); err != nil {
+		if chainNotExistErr == string(stdout) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func (rb *IptablesBuilderImpl) ensureChain(command string, rule *Rule) error {
+	params := append(rule.extraArgs, rule.params...)
+	fmt.Printf("Ensure Chain: %s %s\n", command, strings.Join(params, " "))
+
+	exist, err := rb.chainExists(command, rule)
+	if err != nil {
+		return err
+	}
+	if exist {
+		return nil
+	}
+	if err := rb.ext.Run(command, params...); err != nil {
+		return err
+	}
+	return nil
+}
+
+// EnsureV4Rule ensure chain exist in given table
+func (rb *IptablesBuilderImpl) EnsureV4Chain(rule *Rule) error {
+	return rb.ensureChain(constants.IPTABLES, rule)
+}
+
+// EnsureV6Rule ensure chain exist in given table
+func (rb *IptablesBuilderImpl) EnsureV6Chain(rule *Rule) error {
+	return rb.ensureChain(constants.IP6TABLES, rule)
 }

--- a/tools/istio-iptables/pkg/builder/iptables_builder_test.go
+++ b/tools/istio-iptables/pkg/builder/iptables_builder_test.go
@@ -19,30 +19,46 @@ import (
 	"testing"
 
 	"istio.io/istio/tools/istio-iptables/pkg/constants"
+	dep "istio.io/istio/tools/istio-iptables/pkg/dependencies"
 )
 
 // TODO(abhide): Add more testcases once BuildV6Restore() are implemented
 func TestBuildV6Restore(t *testing.T) {
-	iptables := NewIptablesBuilder()
+	ext := &dep.StdoutStubDependencies{}
+	iptables := NewIptablesBuilder(ext)
 	expected := ""
-	actual := iptables.BuildV6Restore()
-	if expected != actual {
-		t.Errorf("Output didn't match: Got: %s, Expected: %s", actual, expected)
+	buildInRules, definedChain, data := iptables.BuildV6Restore()
+	if expected != data {
+		t.Errorf("Output didn't match: Got: %s, Expected: %s", data, expected)
+	}
+	if len(buildInRules) != 0 {
+		t.Errorf("Output didn't match: Got: %d, Expected: %d", len(buildInRules), 0)
+	}
+	if len(definedChain) != 0 {
+		t.Errorf("Output didn't match: Got: %d, Expected: %d", len(definedChain), 0)
 	}
 }
 
 // TODO(abhide): Add more testcases once BuildV4Restore() are implemented
 func TestBuildV4Restore(t *testing.T) {
-	iptables := NewIptablesBuilder()
+	ext := &dep.StdoutStubDependencies{}
+	iptables := NewIptablesBuilder(ext)
 	expected := ""
-	actual := iptables.BuildV4Restore()
-	if expected != actual {
-		t.Errorf("Output didn't match: Got: %s, Expected: %s", actual, expected)
+	buildInRules, definedChain, data := iptables.BuildV4Restore()
+	if expected != data {
+		t.Errorf("Output didn't match: Got: %s, Expected: %s", data, expected)
+	}
+	if len(buildInRules) != 0 {
+		t.Errorf("Output didn't match: Got: %d, Expected: %d", len(buildInRules), 0)
+	}
+	if len(definedChain) != 0 {
+		t.Errorf("Output didn't match: Got: %d, Expected: %d", len(definedChain), 0)
 	}
 }
 
 func TestBuildV4InsertSingleRule(t *testing.T) {
-	iptables := NewIptablesBuilder()
+	ext := &dep.StdoutStubDependencies{}
+	iptables := NewIptablesBuilder(ext)
 	iptables.InsertRuleV4("chain", "table", 2, "-f", "foo", "-b", "bar")
 	if err := len(iptables.rules.rulesv6) != 0; err {
 		t.Errorf("Expected rulesV6 to be empty; but got %#v", iptables.rules.rulesv6)
@@ -63,7 +79,8 @@ func TestBuildV4InsertSingleRule(t *testing.T) {
 }
 
 func TestBuildV4AppendSingleRule(t *testing.T) {
-	iptables := NewIptablesBuilder()
+	ext := &dep.StdoutStubDependencies{}
+	iptables := NewIptablesBuilder(ext)
 	iptables.AppendRuleV4("chain", "table", "-f", "foo", "-b", "bar")
 	if err := len(iptables.rules.rulesv6) != 0; err {
 		t.Errorf("Expected rulesV6 to be empty; but got %#v", iptables.rules.rulesv6)
@@ -84,7 +101,8 @@ func TestBuildV4AppendSingleRule(t *testing.T) {
 }
 
 func TestBuildV4AppendMultipleRules(t *testing.T) {
-	iptables := NewIptablesBuilder()
+	ext := &dep.StdoutStubDependencies{}
+	iptables := NewIptablesBuilder(ext)
 	iptables.AppendRuleV4("chain", "table", "-f", "foo", "-b", "bar")
 	iptables.AppendRuleV4("chain", "table", "-f", "fu", "-b", "bar")
 	iptables.AppendRuleV4("chain", "table", "-f", "foo", "-b", "baz")
@@ -109,7 +127,8 @@ func TestBuildV4AppendMultipleRules(t *testing.T) {
 }
 
 func TestBuildV4InsertMultipleRules(t *testing.T) {
-	iptables := NewIptablesBuilder()
+	ext := &dep.StdoutStubDependencies{}
+	iptables := NewIptablesBuilder(ext)
 	iptables.InsertRuleV4("chain", "table", 1, "-f", "foo", "-b", "bar")
 	iptables.InsertRuleV4("chain", "table", 2, "-f", "foo", "-b", "baaz")
 	iptables.InsertRuleV4("chain", "table", 3, "-f", "foo", "-b", "baz")
@@ -134,7 +153,8 @@ func TestBuildV4InsertMultipleRules(t *testing.T) {
 }
 
 func TestBuildV4AppendInsertMultipleRules(t *testing.T) {
-	iptables := NewIptablesBuilder()
+	ext := &dep.StdoutStubDependencies{}
+	iptables := NewIptablesBuilder(ext)
 	iptables.AppendRuleV4("chain", "table", "-f", "foo", "-b", "bar")
 	iptables.InsertRuleV4("chain", "table", 2, "-f", "foo", "-b", "bar")
 	iptables.AppendRuleV4("chain", "table", "-f", "foo", "-b", "baz")
@@ -159,7 +179,8 @@ func TestBuildV4AppendInsertMultipleRules(t *testing.T) {
 }
 
 func TestBuildV6InsertSingleRule(t *testing.T) {
-	iptables := NewIptablesBuilder()
+	ext := &dep.StdoutStubDependencies{}
+	iptables := NewIptablesBuilder(ext)
 	iptables.InsertRuleV6("chain", "table", 2, "-f", "foo", "-b", "bar")
 	if err := len(iptables.rules.rulesv4) != 0; err {
 		t.Errorf("Expected rulesV4 to be empty; but got %#v", iptables.rules.rulesv4)
@@ -180,7 +201,8 @@ func TestBuildV6InsertSingleRule(t *testing.T) {
 }
 
 func TestBuildV6AppendSingleRule(t *testing.T) {
-	iptables := NewIptablesBuilder()
+	ext := &dep.StdoutStubDependencies{}
+	iptables := NewIptablesBuilder(ext)
 	iptables.AppendRuleV6("chain", "table", "-f", "foo", "-b", "bar")
 	if err := len(iptables.rules.rulesv4) != 0; err {
 		t.Errorf("Expected rulesV6 to be empty; but got %#v", iptables.rules.rulesv6)
@@ -201,7 +223,8 @@ func TestBuildV6AppendSingleRule(t *testing.T) {
 }
 
 func TestBuildV6AppendMultipleRules(t *testing.T) {
-	iptables := NewIptablesBuilder()
+	ext := &dep.StdoutStubDependencies{}
+	iptables := NewIptablesBuilder(ext)
 	iptables.AppendRuleV6("chain", "table", "-f", "foo", "-b", "bar")
 	iptables.AppendRuleV6("chain", "table", "-f", "fu", "-b", "bar")
 	iptables.AppendRuleV6("chain", "table", "-f", "foo", "-b", "baz")
@@ -226,7 +249,8 @@ func TestBuildV6AppendMultipleRules(t *testing.T) {
 }
 
 func TestBuildV6InsertMultipleRules(t *testing.T) {
-	iptables := NewIptablesBuilder()
+	ext := &dep.StdoutStubDependencies{}
+	iptables := NewIptablesBuilder(ext)
 	iptables.InsertRuleV6("chain", "table", 1, "-f", "foo", "-b", "bar")
 	iptables.InsertRuleV6("chain", "table", 2, "-f", "foo", "-b", "baaz")
 	iptables.InsertRuleV6("chain", "table", 3, "-f", "foo", "-b", "baz")
@@ -251,7 +275,8 @@ func TestBuildV6InsertMultipleRules(t *testing.T) {
 }
 
 func TestBuildV6InsertAppendMultipleRules(t *testing.T) {
-	iptables := NewIptablesBuilder()
+	ext := &dep.StdoutStubDependencies{}
+	iptables := NewIptablesBuilder(ext)
 	iptables.AppendRuleV6("chain", "table", "-f", "foo", "-b", "bar")
 	iptables.InsertRuleV6("chain", "table", 2, "-f", "foo", "-b", "bar")
 	iptables.InsertRuleV6("chain", "table", 1, "-f", "foo", "-b", "bar")
@@ -276,7 +301,8 @@ func TestBuildV6InsertAppendMultipleRules(t *testing.T) {
 }
 
 func TestBuildV4V6MultipleRulesWithNewChain(t *testing.T) {
-	iptables := NewIptablesBuilder()
+	ext := &dep.StdoutStubDependencies{}
+	iptables := NewIptablesBuilder(ext)
 	iptables.AppendRuleV4("chain", "table", "-f", "foo", "-b", "bar")
 	iptables.InsertRuleV4("chain", "table", 2, "-f", "foo", "-b", "bar")
 	iptables.AppendRuleV4("chain", "table", "-f", "foo", "-b", "baz")

--- a/tools/istio-iptables/pkg/dependencies/implementation.go
+++ b/tools/istio-iptables/pkg/dependencies/implementation.go
@@ -54,3 +54,8 @@ func (r *RealDependencies) Run(cmd string, args ...string) error {
 func (r *RealDependencies) RunQuietlyAndIgnore(cmd string, args ...string) {
 	_ = r.execute(cmd, true, args...)
 }
+
+// Command runs a command
+func (r *RealDependencies) Command(cmd string, args ...string) ([]byte, error) {
+	return exec.Command(cmd, args...).CombinedOutput()
+}

--- a/tools/istio-iptables/pkg/dependencies/interface.go
+++ b/tools/istio-iptables/pkg/dependencies/interface.go
@@ -22,4 +22,6 @@ type Dependencies interface {
 	Run(cmd string, args ...string) error
 	// RunQuietlyAndIgnore runs a command quietly and ignores errors
 	RunQuietlyAndIgnore(cmd string, args ...string)
+	// Command runs a command
+	Command(cmd string, args ...string) ([]byte, error)
 }

--- a/tools/istio-iptables/pkg/dependencies/stub.go
+++ b/tools/istio-iptables/pkg/dependencies/stub.go
@@ -38,3 +38,9 @@ func (s *StdoutStubDependencies) Run(cmd string, args ...string) error {
 func (s *StdoutStubDependencies) RunQuietlyAndIgnore(cmd string, args ...string) {
 	fmt.Printf("%s %s\n", cmd, strings.Join(args, " "))
 }
+
+// Command runs a command quietly and ignores errors
+func (s *StdoutStubDependencies) Command(cmd string, args ...string) ([]byte, error) {
+	fmt.Printf("%s %s\n", cmd, strings.Join(args, " "))
+	return nil, nil
+}


### PR DESCRIPTION
Prevent init container crash when iptables chain already exists.

Fixes #23288
Fixes #24148
Fixes #24101

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
