### PR TITLE
Fix race condition in adsc

### DIFF
--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -259,7 +259,6 @@ func tlsConfig(certDir string) (*tls.Config, error) {
 // Close the stream.
 func (a *ADSC) Close() {
 	a.mutex.Lock()
-	_ = a.stream.CloseSend()
 	_ = a.conn.Close()
 	a.mutex.Unlock()
 }


### PR DESCRIPTION
Regression caused by #23833

Spec: `It is also not safe to call CloseSend concurrently with SendMsg.`

Example: https://prow.istio.io/view/gcs/istio-prow/pr-logs/pull/istio_istio/24314/unit-tests_istio/14042