### PR TITLE
Allow json maps as strings in istioctl

### DIFF
--- a/operator/cmd/mesh/testdata/manifest-generate/input/pilot_merge_meshconfig.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/input/pilot_merge_meshconfig.yaml
@@ -5,6 +5,12 @@ spec:
   hub: docker.io/istio
   tag: 1.1.4
   meshConfig:
+    accessLogEncoding: JSON
+    accessLogFile: "/dev/stdout"
+    accessLogFormat: |-
+      {
+        "foo": "bar"
+      }
     enablePrometheusMerge: true
     rootNamespace: istio-control
     mixerCheckServer: foo:1234

--- a/operator/cmd/mesh/testdata/manifest-generate/input/pilot_override_kubernetes.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/input/pilot_override_kubernetes.yaml
@@ -24,9 +24,9 @@ spec:
               # Select list item by key:value
               - path: spec.template.spec.containers.[name:discovery].ports.[containerPort:8080].containerPort
                 value: 1234 # OVERRIDDEN
-              # Override with object (note | on value: first line)
+              # Override with object
               - path: spec.template.spec.containers.[name:discovery].env.[name:POD_NAMESPACE].valueFrom
-                value: |
+                value:
                   fieldRef:
                     apiVersion: v2
                     fieldPath: metadata.myPath

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_merge_meshconfig.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_merge_meshconfig.golden.yaml
@@ -13,6 +13,12 @@ data:
     networks: {}
 
   mesh: |-
+    accessLogEncoding: JSON
+    accessLogFile: /dev/stdout
+    accessLogFormat: |-
+      {
+        "foo": "bar"
+      }
     defaultConfig:
       controlPlaneAuthPolicy: NONE
       discoveryAddress: my-discovery:123

--- a/operator/pkg/tpath/tpath_test.go
+++ b/operator/pkg/tpath/tpath_test.go
@@ -567,6 +567,19 @@ components:
     - enabled: "false"
 `,
 		},
+		{
+			desc:     "nested json",
+			baseYAML:  `
+meshConfig:
+  accessLogFormat: ''
+`,
+			path:     "meshConfig.accessLogFormat",
+			value:    `{"foo": "bar"}`,
+			want: `
+meshConfig:
+  accessLogFormat: '{"foo": "bar"}'
+`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {

--- a/operator/pkg/tpath/tpath_test.go
+++ b/operator/pkg/tpath/tpath_test.go
@@ -114,10 +114,13 @@ a:
 		{
 			desc: "ModifyListEntryMapValue",
 			path: `a.b.[name:n2]`,
-			value: `name: n2
-list: 
-  - nk1: nv1
-  - nk2: nv2`,
+			value: map[string]interface{}{
+				"name": "n2",
+				"list": []map[string]interface{}{
+					{"nk1": "nv1"},
+					{"nk2": "nv2"},
+				},
+			},
 			wantFound: true,
 			want: `
 a:
@@ -349,9 +352,11 @@ a:
 		{
 			desc: "AddMapEntryMapValue",
 			path: `a.new_key`,
-			value: `new_key:
-  nk1:
-    nk2: nv2`,
+			value: map[string]interface{}{
+				"nk1": map[string]interface{}{
+					"nk2": "nv2",
+				},
+			},
 			wantFound: true,
 			want: `
 a:
@@ -371,8 +376,11 @@ a:
 		{
 			desc: "ModifyMapEntryMapValue",
 			path: `a.b`,
-			value: `nk1:
-  nk2: nv2`,
+			value: map[string]interface{}{
+				"nk1": map[string]interface{}{
+					"nk2": "nv2",
+				},
+			},
 			wantFound: true,
 			want: `
 a:
@@ -568,13 +576,13 @@ components:
 `,
 		},
 		{
-			desc:     "nested json",
-			baseYAML:  `
+			desc: "nested json",
+			baseYAML: `
 meshConfig:
   accessLogFormat: ''
 `,
-			path:     "meshConfig.accessLogFormat",
-			value:    `{"foo": "bar"}`,
+			path:  "meshConfig.accessLogFormat",
+			value: `{"foo": "bar"}`,
 			want: `
 meshConfig:
   accessLogFormat: '{"foo": "bar"}'

--- a/operator/pkg/tpath/tree.go
+++ b/operator/pkg/tpath/tree.go
@@ -523,11 +523,3 @@ func isMapOrInterface(v interface{}) bool {
 	}
 	return vv.Kind() == reflect.Map
 }
-
-// getTreeRoot returns the first key found in m. It assumes a single root tree.
-func getTreeRoot(m map[string]interface{}) string {
-	for k := range m {
-		return k
-	}
-	return ""
-}


### PR DESCRIPTION
https://github.com/istio/istio/pull/23596 added some logic to allow
strings as objects. This caused a regression in setting fields that are
expected to be maps encoded as strings.

Fixes https://github.com/istio/istio/issues/24318

This *is* a breaking change as the case seen in
pilot_override_kubernetes now changes from taking a map as input instead
of string. However, I think this is better behavior anyways.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure