### PR TITLE
Skip using gateways with hostnames in split horizon

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/ep_filters.go
+++ b/pilot/pkg/proxy/envoy/v2/ep_filters.go
@@ -15,6 +15,8 @@
 package v2
 
 import (
+	"net"
+
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	"github.com/golang/protobuf/ptypes/wrappers"
 
@@ -24,7 +26,8 @@ import (
 
 // EndpointsByNetworkFilter is a network filter function to support Split Horizon EDS - filter the endpoints based on the network
 // of the connected sidecar. The filter will filter out all endpoints which are not present within the
-// sidecar network and add a gateway endpoint to remote networks that have endpoints (if gateway exists).
+// sidecar network and add a gateway endpoint to remote networks that have endpoints
+// (if gateway exists and its IP is an IP and not a dns name).
 // Information for the mesh networks is provided as a MeshNetwork config map.
 func EndpointsByNetworkFilter(push *model.PushContext, proxyNetwork string, endpoints []*endpoint.LocalityLbEndpoints) []*endpoint.LocalityLbEndpoints {
 	// calculate the multiples of weight.
@@ -69,7 +72,8 @@ func EndpointsByNetworkFilter(push *model.PushContext, proxyNetwork string, endp
 			}
 		}
 
-		// Add remote networks' gateways to endpoints
+		// Add remote networks' gateways to endpoints if the gateway is a valid IP
+		// If its a dns name (like AWS ELB), skip adding all endpoints from this network.
 
 		// Iterate over all networks that have the cluster endpoint (weight>0) and
 		// for each one of those add a new endpoint that points to the network's
@@ -84,6 +88,10 @@ func EndpointsByNetworkFilter(push *model.PushContext, proxyNetwork string, endp
 
 			// There may be multiples gateways for one network. Add each gateway as an endpoint.
 			for _, gw := range gateways {
+				if net.ParseIP(gw.Addr) == nil {
+					// this is a gateway with hostname in it. skip this gateway as EDS can't take hostnames
+					continue
+				}
 				epAddr := util.BuildAddress(gw.Addr, gw.Port)
 				gwEp := &endpoint.LbEndpoint{
 					HostIdentifier: &endpoint.LbEndpoint_Endpoint{

--- a/pilot/pkg/proxy/envoy/v2/ep_filters_test.go
+++ b/pilot/pkg/proxy/envoy/v2/ep_filters_test.go
@@ -388,6 +388,184 @@ func TestEndpointsByNetworkFilter_RegistryServiceName(t *testing.T) {
 	}
 }
 
+func TestEndpointsByNetworkFilter_SkipLBWithHostname(t *testing.T) {
+	//  - 1 IP gateway for network1
+	//  - 1 DNS gateway for network2 where gateway obtained from registry service name
+	//  - 1 IP gateway for network3
+	//  - 0 gateways for network4
+	env := environment()
+	env.Networks().Networks["network2"] = &meshconfig.Network{
+		Endpoints: []*meshconfig.Network_NetworkEndpoints{
+			{
+				Ne: &meshconfig.Network_NetworkEndpoints_FromRegistry{
+					FromRegistry: "cluster2",
+				},
+			},
+		},
+		Gateways: []*meshconfig.Network_IstioNetworkGateway{
+			{
+				Gw: &meshconfig.Network_IstioNetworkGateway_RegistryServiceName{
+					RegistryServiceName: "istio-ingressgateway.istio-system.svc.cluster.local",
+				},
+				Port: 80,
+			},
+		},
+	}
+
+	gwSvcName := host.Name("istio-ingressgateway.istio-system.svc.cluster.local")
+	serviceDiscovery := NewMemServiceDiscovery(map[host.Name]*model.Service{
+		gwSvcName: {
+			Hostname: gwSvcName,
+			Attributes: model.ServiceAttributes{
+				ClusterExternalAddresses: map[string][]string{
+					"cluster2": {"aeiou.scooby.do"},
+				},
+			},
+		},
+	}, 0)
+
+	env.ServiceDiscovery = serviceDiscovery
+
+	// Test endpoints creates:
+	//  - 2 endpoints in network1
+	//  - 1 endpoints in network2
+	//  - 0 endpoints in network3
+	//  - 1 endpoints in network4
+	testEndpoints := testEndpoints()
+
+	// The tests below are calling the endpoints filter from each one of the
+	// networks and examines the returned filtered endpoints
+	tests := []struct {
+		name      string
+		endpoints []*endpoint.LocalityLbEndpoints
+		conn      *XdsConnection
+		env       *model.Environment
+		want      []LocLbEpInfo
+	}{
+		{
+			name:      "from_network1",
+			conn:      xdsConnection("network1"),
+			env:       env,
+			endpoints: testEndpoints,
+			want: []LocLbEpInfo{
+				{
+					lbEps: []LbEpInfo{
+						// 2 local endpoints
+						{address: "10.0.0.1", weight: 1},
+						{address: "10.0.0.2", weight: 1},
+						// 0 endpoint to gateway of network2 a its a dns name instead of IP
+						{address: "40.0.0.1", weight: 1},
+					},
+					weight: 3,
+				},
+			},
+		},
+		{
+			name:      "from_network2",
+			conn:      xdsConnection("network2"),
+			env:       env,
+			endpoints: testEndpoints,
+			want: []LocLbEpInfo{
+				{
+					lbEps: []LbEpInfo{
+						// 1 local endpoint
+						{address: "20.0.0.1", weight: 1},
+						// 1 endpoint to gateway of network1 with weight 2 because it has 2 endpoints
+						{address: "1.1.1.1", weight: 2},
+						{address: "40.0.0.1", weight: 1},
+					},
+					weight: 4,
+				},
+			},
+		},
+		{
+			name:      "from_network3",
+			conn:      xdsConnection("network3"),
+			env:       env,
+			endpoints: testEndpoints,
+			want: []LocLbEpInfo{
+				{
+					lbEps: []LbEpInfo{
+						// 1 endpoint to gateway of network1 with weight 2 because it has 2 endpoints
+						{address: "1.1.1.1", weight: 2},
+						// 0 endpoint to gateway of network2 as its a DNS gateway
+						{address: "40.0.0.1", weight: 1},
+					},
+					weight: 3,
+				},
+			},
+		},
+		{
+			name:      "from_network4",
+			conn:      xdsConnection("network4"),
+			env:       env,
+			endpoints: testEndpoints,
+			want: []LocLbEpInfo{
+				{
+					lbEps: []LbEpInfo{
+						// 1 local endpoint
+						{address: "40.0.0.1", weight: 1},
+						// 1 endpoint to gateway of network1 with weight 2 because it has 2 endpoints
+						{address: "1.1.1.1", weight: 2},
+						// 0 endpoint to gateway of network2 as its a dns gateway
+					},
+					weight: 3,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			push := model.NewPushContext()
+			_ = push.InitContext(tt.env, nil, nil)
+			filtered := EndpointsByNetworkFilter(push, tt.conn.node.Metadata.Network, tt.endpoints)
+			if len(filtered) != len(tt.want) {
+				t.Errorf("Unexpected number of filtered endpoints: got %v, want %v", len(filtered), len(tt.want))
+				return
+			}
+
+			sort.Slice(filtered, func(i, j int) bool {
+				addrI := filtered[i].LbEndpoints[0].GetEndpoint().Address.GetSocketAddress().Address
+				addrJ := filtered[j].LbEndpoints[0].GetEndpoint().Address.GetSocketAddress().Address
+				return addrI < addrJ
+			})
+
+			for i, ep := range filtered {
+				if len(ep.LbEndpoints) != len(tt.want[i].lbEps) {
+					t.Errorf("Unexpected number of LB endpoints within endpoint %d: %v, want %v", i, len(ep.LbEndpoints), len(tt.want[i].lbEps))
+				}
+
+				if ep.LoadBalancingWeight.GetValue() != tt.want[i].weight {
+					t.Errorf("Unexpected weight for endpoint %d: got %v, want %v", i, ep.LoadBalancingWeight.GetValue(), tt.want[i].weight)
+				}
+
+				for _, lbEp := range ep.LbEndpoints {
+					if lbEp.Metadata == nil {
+						t.Errorf("Expected endpoint metadata")
+					} else {
+						// ensure that all endpoints (direct ones and remote gateway endpoints have the tls mode label.
+						m := lbEp.Metadata.FilterMetadata[util.EnvoyTransportSocketMetadataKey]
+						if !reflect.DeepEqual(m, expectedMetadata) {
+							t.Errorf("Did not find the expected tlsMode metadata. got %v, want %v", m, expectedMetadata)
+						}
+					}
+					addr := lbEp.GetEndpoint().Address.GetSocketAddress().Address
+					found := false
+					for _, wantLbEp := range tt.want[i].lbEps {
+						if addr == wantLbEp.address {
+							found = true
+							break
+						}
+					}
+					if !found {
+						t.Errorf("Unexpected address for endpoint %d: %v", i, addr)
+					}
+				}
+			}
+		})
+	}
+}
+
 func xdsConnection(network string) *XdsConnection {
 	return &XdsConnection{
 		node: &model.Proxy{

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -15,9 +15,7 @@
 package kube
 
 import (
-	"context"
 	"fmt"
-	"net"
 	"sort"
 	"strconv"
 	"strings"
@@ -145,10 +143,12 @@ func ConvertService(svc coreV1.Service, domainSuffix string, clusterID string) *
 				if len(ingress.IP) > 0 {
 					lbAddrs = append(lbAddrs, ingress.IP)
 				} else if len(ingress.Hostname) > 0 {
-					addrs, err := net.DefaultResolver.LookupHost(context.TODO(), ingress.Hostname)
-					if err == nil {
-						lbAddrs = append(lbAddrs, addrs...)
-					}
+					// DO NOT resolve the DNS here. In environments like AWS, the ELB hostname
+					// does not have a repeatable DNS address and IPs resolved at an earlier point
+					// in time may not work. So, when we get just hostnames instead of IPs, we need
+					// to smartly switch from EDS to strict_dns rather than doing the naive thing of
+					// resolving the DNS name and hoping the resolution is one-time task.
+					lbAddrs = append(lbAddrs, ingress.Hostname)
 				}
 			}
 			if len(lbAddrs) > 0 {


### PR DESCRIPTION
In AWS, load balancer services get hostnames instead of IPs.
Resolving these hostnames to IPs in Pilot is incorrect as these resolutions
are transient and could lead to incorrect routing. We are better off
skipping these gateways for split horizon until we figure out a way to
ship aggregate cluster that contains the dns hostnames.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure