### PR TITLE
update object cache for watched resources.

### DIFF
--- a/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
+++ b/operator/pkg/controller/istiocontrolplane/istiocontrolplane_controller.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -106,9 +107,7 @@ var (
 			if err != nil {
 				return false
 			}
-			if obj.GetLabels()[helmreconciler.OwningResourceName] != "" &&
-				obj.GetLabels()[helmreconciler.OwningResourceNamespace] != "" &&
-				obj.GetLabels()[helmreconciler.IstioComponentLabelStr] != "" {
+			if isOperatorCreatedResource(obj) {
 				crName := obj.GetLabels()[helmreconciler.OwningResourceName]
 				crNamespace := obj.GetLabels()[helmreconciler.OwningResourceNamespace]
 				componentName := obj.GetLabels()[helmreconciler.IstioComponentLabelStr]
@@ -398,4 +397,11 @@ func watchIstioResources(c controller.Controller) error {
 		}
 	}
 	return nil
+}
+
+// Check if the specified object is created by operator
+func isOperatorCreatedResource(obj metav1.Object) bool {
+	return obj.GetLabels()[helmreconciler.OwningResourceName] != "" &&
+		obj.GetLabels()[helmreconciler.OwningResourceNamespace] != "" &&
+		obj.GetLabels()[helmreconciler.IstioComponentLabelStr] != ""
 }

--- a/operator/pkg/helmreconciler/common.go
+++ b/operator/pkg/helmreconciler/common.go
@@ -37,8 +37,8 @@ const (
 	operatorLabelStr = name.OperatorAPINamespace + "/managed"
 	// operatorReconcileStr indicates that the operator will reconcile the resource.
 	operatorReconcileStr = "Reconcile"
-	// istioComponentLabelStr indicates which Istio component a resource belongs to.
-	istioComponentLabelStr = name.OperatorAPINamespace + "/component"
+	// IstioComponentLabelStr indicates which Istio component a resource belongs to.
+	IstioComponentLabelStr = name.OperatorAPINamespace + "/component"
 	// istioVersionLabelStr indicates the Istio version of the installation.
 	istioVersionLabelStr = name.OperatorAPINamespace + "/version"
 )

--- a/operator/pkg/helmreconciler/prune.go
+++ b/operator/pkg/helmreconciler/prune.go
@@ -97,7 +97,7 @@ func (h *HelmReconciler) runForAllTypes(callback func(labels map[string]string, 
 		// First, we collect all objects for the provided GVK
 		objects := &unstructured.UnstructuredList{}
 		objects.SetGroupVersionKind(gvk)
-		componentRequirement, err := klabels.NewRequirement(istioComponentLabelStr, selection.Exists, nil)
+		componentRequirement, err := klabels.NewRequirement(IstioComponentLabelStr, selection.Exists, nil)
 		if err != nil {
 			return err
 		}

--- a/operator/pkg/helmreconciler/reconciler.go
+++ b/operator/pkg/helmreconciler/reconciler.go
@@ -321,7 +321,7 @@ func (h *HelmReconciler) addComponentLabels(coreLabels map[string]string, compon
 		labels[label.IstioRev] = revision
 	}
 
-	labels[istioComponentLabelStr] = componentName
+	labels[IstioComponentLabelStr] = componentName
 
 	return labels
 }


### PR DESCRIPTION

resolve: https://github.com/istio/istio/issues/23238
Remove object from cache when the controller gets a delete event for the corresponding object, so that it will be recreated in the next reconcile loop.


[ ] Configuration Infrastructure
[ ] Docs
[ X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure