### PR TITLE
Support appending to list via IstioOperator component patches

### DIFF
--- a/operator/pkg/patch/patch.go
+++ b/operator/pkg/patch/patch.go
@@ -177,7 +177,7 @@ func applyPatches(base *object.K8sObject, patches []*v1alpha1.K8SObjectOverlay_P
 			continue
 		}
 		scope.Debugf("applying path=%s, value=%s\n", p.Path, p.Value)
-		inc, _, err := tpath.GetPathContext(bo, util.PathFromString(p.Path), false)
+		inc, _, err := tpath.GetPathContext(bo, util.PathFromString(p.Path), true)
 		if err != nil {
 			errs = util.AppendErr(errs, err)
 			continue

--- a/operator/pkg/patch/patch_test.go
+++ b/operator/pkg/patch/patch_test.go
@@ -196,6 +196,29 @@ a:
     d: n3
 `,
 		},
+		{
+			desc:  "AppendToListEntry",
+			path:  `a.b.[name:n2].list.[3]`,
+			value: `v4`,
+			want: `
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: istio-citadel
+  namespace: istio-system
+a:
+  b:
+  - name: n1
+    value: v1
+  - list:
+    - v1
+    - v2
+    - v3_regex
+    - v4
+    name: n2
+  c:
+`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Shakti <shaktiprakash.das@salesforce.com>

Please provide a description for what this PR is for.
Fixes #24258 
Adds support for appending to a list via IstioOperator component patch. We (Salesforce) need this feature to append additional containers to Istiod Deployment. This feature will also help in adding additional command/args values to the list instead of the need to replace the entire command/args list.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[x] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
