### PR TITLE
create-remote-secret silently fails for integration tests

### DIFF
--- a/istioctl/pkg/multicluster/remote_secret.go
+++ b/istioctl/pkg/multicluster/remote_secret.go
@@ -19,7 +19,6 @@ import (
 	context2 "context"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -109,7 +108,7 @@ istioctl --Kubeconfig=c0.yaml x create-remote-secret --name c0 --auth-type=plugi
 			out, err := CreateRemoteSecret(opts, env)
 			if err != nil {
 				fmt.Fprintf(c.OutOrStderr(), "error: %v\n", err)
-				os.Exit(1)
+				return err
 			}
 			fmt.Fprint(c.OutOrStdout(), out)
 			return nil


### PR DESCRIPTION
 `create-remote-secret` command currently uses os.Exit() for one of the failure scenarios.  During integration tests, the error gets lost unless it is returned.  The integration tests will fail with no explanation if os.Exit is used



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ X ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure