### PR TITLE
Cleanup legacy USER_SDS metadata config

### DIFF
--- a/manifests/charts/istio-policy/templates/deployment.yaml
+++ b/manifests/charts/istio-policy/templates/deployment.yaml
@@ -231,8 +231,6 @@ spec:
           value: {{ .Values.global.jwtPolicy }}
         - name: PILOT_CERT_PROVIDER
           value: {{ .Values.global.pilotCertProvider }}
-        - name: "ISTIO_META_USER_SDS"
-          value: "true"
         - name: CA_ADDR
         {{- if .Values.global.caAddress }}
           value: {{ .Values.global.caAddress }}

--- a/manifests/charts/istio-telemetry/mixer-telemetry/templates/deployment.yaml
+++ b/manifests/charts/istio-telemetry/mixer-telemetry/templates/deployment.yaml
@@ -230,8 +230,6 @@ spec:
           value: {{ .Values.global.jwtPolicy }}
         - name: PILOT_CERT_PROVIDER
           value: {{ .Values.global.pilotCertProvider }}
-        - name: "ISTIO_META_USER_SDS"
-          value: "true"
         - name: CA_ADDR
       {{- if .Values.global.caAddress }}
           value: {{ .Values.global.caAddress }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-policy/templates/deployment.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-policy/templates/deployment.yaml
@@ -231,8 +231,6 @@ spec:
           value: {{ .Values.global.jwtPolicy }}
         - name: PILOT_CERT_PROVIDER
           value: {{ .Values.global.pilotCertProvider }}
-        - name: "ISTIO_META_USER_SDS"
-          value: "true"
         - name: CA_ADDR
         {{- if .Values.global.caAddress }}
           value: {{ .Values.global.caAddress }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-telemetry/mixer-telemetry/templates/deployment.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-telemetry/mixer-telemetry/templates/deployment.yaml
@@ -230,8 +230,6 @@ spec:
           value: {{ .Values.global.jwtPolicy }}
         - name: PILOT_CERT_PROVIDER
           value: {{ .Values.global.pilotCertProvider }}
-        - name: "ISTIO_META_USER_SDS"
-          value: "true"
         - name: CA_ADDR
       {{- if .Values.global.caAddress }}
           value: {{ .Values.global.caAddress }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -8872,8 +8872,6 @@ spec:
           value: third-party-jwt
         - name: PILOT_CERT_PROVIDER
           value: istiod
-        - name: ISTIO_META_USER_SDS
-          value: "true"
         - name: CA_ADDR
           value: istiod.istio-system.svc:15012
         image: gcr.io/istio-testing/proxyv2:latest
@@ -10401,8 +10399,6 @@ spec:
           value: third-party-jwt
         - name: PILOT_CERT_PROVIDER
           value: istiod
-        - name: ISTIO_META_USER_SDS
-          value: "true"
         - name: CA_ADDR
           value: istiod.istio-system.svc:15012
         image: gcr.io/istio-testing/proxyv2:latest

--- a/operator/cmd/mesh/testdata/manifest-generate/output/telemetry_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/telemetry_default.golden.yaml
@@ -1440,8 +1440,6 @@ spec:
           value: third-party-jwt
         - name: PILOT_CERT_PROVIDER
           value: istiod
-        - name: ISTIO_META_USER_SDS
-          value: "true"
         - name: CA_ADDR
           value: istiod.istio-system.svc:15012
         image: gcr.io/istio-testing/proxyv2:latest

--- a/operator/cmd/mesh/testdata/manifest-generate/output/telemetry_k8s_settings.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/telemetry_k8s_settings.golden.yaml
@@ -152,8 +152,6 @@ spec:
           value: third-party-jwt
         - name: PILOT_CERT_PROVIDER
           value: istiod
-        - name: ISTIO_META_USER_SDS
-          value: "true"
         - name: CA_ADDR
           value: istiod.istio-system.svc:15012
         image: gcr.io/istio-testing/proxyv2:latest

--- a/operator/cmd/mesh/testdata/manifest-generate/output/telemetry_override_kubernetes.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/telemetry_override_kubernetes.golden.yaml
@@ -354,8 +354,6 @@ spec:
           value: third-party-jwt
         - name: PILOT_CERT_PROVIDER
           value: istiod
-        - name: ISTIO_META_USER_SDS
-          value: "true"
         - name: CA_ADDR
           value: istiod.istio-system.svc:15012
         image: gcr.io/istio-testing/proxyv2:latest

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -374,8 +374,6 @@ func (configgen *ConfigGeneratorImpl) createGatewayHTTPFilterChainOpts(
 	// Build a filter chain for the HTTPS server
 	// We know that this is a HTTPS server because this function is called only for ports of type HTTP/HTTPS
 	// where HTTPS server's TLS mode is not passthrough and not nil
-	// If proxy sends metadata USER_SDS, then create SDS config for
-	// gateway listener.
 	return &filterChainOpts{
 		// This works because we validate that only HTTPS servers can have same port but still different port names
 		// and that no two non-HTTPS servers can be on same port or share port names.
@@ -402,12 +400,9 @@ func (configgen *ConfigGeneratorImpl) createGatewayHTTPFilterChainOpts(
 	}
 }
 
-// enableIngressSds: signifies whether this is an SDS enabled ingress controller, with an embedded node agent running
-// alongside the gateway pod (https://istio.io/docs/tasks/traffic-management/ingress/secure-ingress-sds/)
 // sdsPath: is the path to the mesh-wide workload sds uds path, and it is assumed that if this path is unset, that sds is
 // disabled mesh-wide
 // metadata: map of miscellaneous configuration values sent from the Envoy instance back to Pilot, could include the field
-// USER_SDS which signifies that the proxy is an SDS-enabled ingress gateway
 //
 // Below is a table of potential scenarios for the gateway configuration:
 //
@@ -526,8 +521,6 @@ func (configgen *ConfigGeneratorImpl) createGatewayTCPFilterChainOpts(
 		// Validation ensures that non-passthrough servers will have certs
 		if filters := buildGatewayNetworkFiltersFromTCPRoutes(node,
 			push, server, gatewaysForWorkload); len(filters) > 0 {
-			// If proxy version is over 1.1, and proxy sends metadata USER_SDS, then create SDS config for
-			// gateway listener.
 			return []*filterChainOpts{
 				{
 					sniHosts:       getSNIHostsForServer(server),


### PR DESCRIPTION
Ref: https://github.com/istio/istio/pull/22340
       https://github.com/istio/istio/pull/22200

USER_SDS metadata to enable SDS Ingress is not used anymore, documentation for a couple of functions was also old and confusing.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
