### PR TITLE
Error message update

### DIFF
--- a/operator/cmd/mesh/manifest-apply.go
+++ b/operator/cmd/mesh/manifest-apply.go
@@ -147,8 +147,8 @@ func runApplyCmd(cmd *cobra.Command, rootArgs *rootArgs, maArgs *manifestApplyAr
 	}
 	if err := ApplyManifests(applyFlagAliases(maArgs.set, maArgs.charts, maArgs.revision), maArgs.inFilenames, maArgs.force, rootArgs.dryRun,
 		maArgs.kubeConfigPath, maArgs.context, maArgs.readinessTimeout, l); err != nil {
-		if _, err := vfs.Stat(profilesRoot); err != nil {
-			return fmt.Errorf("failed to apply manifests: %v, use -d with local profiles instead", err)
+		if _, err1 := vfs.Stat(profilesRoot); err1 != nil {
+			return fmt.Errorf("failed to apply manifests: %v, use -d with local profiles instead", err1)
 		}
 		return fmt.Errorf("failed to apply manifests: %v", err)
 	}

--- a/operator/cmd/mesh/manifest-apply.go
+++ b/operator/cmd/mesh/manifest-apply.go
@@ -37,7 +37,6 @@ const (
 	// installedSpecCRPrefix is the prefix of any IstioOperator CR stored in the cluster that is a copy of the CR used
 	// in the last manifest apply operation.
 	installedSpecCRPrefix = "installed-state"
-	profilesRoot          = "profiles"
 )
 
 type manifestApplyArgs struct {
@@ -147,7 +146,6 @@ func runApplyCmd(cmd *cobra.Command, rootArgs *rootArgs, maArgs *manifestApplyAr
 	}
 	if err := ApplyManifests(applyFlagAliases(maArgs.set, maArgs.charts, maArgs.revision), maArgs.inFilenames, maArgs.force, rootArgs.dryRun,
 		maArgs.kubeConfigPath, maArgs.context, maArgs.readinessTimeout, l); err != nil {
-
 		return fmt.Errorf("failed to apply manifests: %v", err)
 	}
 

--- a/operator/cmd/mesh/manifest-apply.go
+++ b/operator/cmd/mesh/manifest-apply.go
@@ -29,6 +29,7 @@ import (
 	"istio.io/istio/operator/pkg/translate"
 	"istio.io/istio/operator/pkg/util/clog"
 	"istio.io/istio/operator/pkg/util/progress"
+	"istio.io/istio/operator/pkg/vfs"
 	"istio.io/pkg/log"
 )
 
@@ -36,6 +37,7 @@ const (
 	// installedSpecCRPrefix is the prefix of any IstioOperator CR stored in the cluster that is a copy of the CR used
 	// in the last manifest apply operation.
 	installedSpecCRPrefix = "installed-state"
+	profilesRoot          = "profiles"
 )
 
 type manifestApplyArgs struct {
@@ -145,6 +147,9 @@ func runApplyCmd(cmd *cobra.Command, rootArgs *rootArgs, maArgs *manifestApplyAr
 	}
 	if err := ApplyManifests(applyFlagAliases(maArgs.set, maArgs.charts, maArgs.revision), maArgs.inFilenames, maArgs.force, rootArgs.dryRun,
 		maArgs.kubeConfigPath, maArgs.context, maArgs.readinessTimeout, l); err != nil {
+		if _, err := vfs.Stat(profilesRoot); err != nil {
+			return fmt.Errorf("failed to apply manifests: %v, use -d with local profiles instead", err)
+		}
 		return fmt.Errorf("failed to apply manifests: %v", err)
 	}
 


### PR DESCRIPTION

When istio is built from the cloned github version, the command:
 istioctl manifest apply --set profile=demo 
returns:
Error: failed to apply manifests: Asset profiles/demo.yaml not found

This update fixes it so that the error message is instead

Error: failed to apply manifests: compiled in charts not found in this development build, use --charts with local charts instead or run make gen-charts


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure