### PR TITLE
Fix XDS client authentication

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -206,6 +206,10 @@ func (s *DiscoveryServer) authenticate(ctx context.Context) ([]string, error) {
 		if !ok {
 			return nil, errors.New("invalid context")
 		}
+		// No authentication info provided
+		if peerInfo.AuthInfo == nil {
+			return nil, nil
+		}
 		var authenticatedID *authenticate.Caller
 		for _, authn := range s.Authenticators {
 			u, err := authn.Authenticate(ctx)

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -29,6 +29,7 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 
@@ -206,8 +207,10 @@ func (s *DiscoveryServer) authenticate(ctx context.Context) ([]string, error) {
 		if !ok {
 			return nil, errors.New("invalid context")
 		}
-		// No authentication info provided
-		if peerInfo.AuthInfo == nil {
+		// Not a TLS connection, we will not authentication
+		// TODO: add a flag to prevent unauthenticated requests ( 15010 )
+		// request not over TLS ( on the insecure port
+		if _, ok := peerInfo.AuthInfo.(credentials.TLSInfo); !ok {
 			return nil, nil
 		}
 		var authenticatedID *authenticate.Caller
@@ -225,9 +228,6 @@ func (s *DiscoveryServer) authenticate(ctx context.Context) ([]string, error) {
 
 		return authenticatedID.Identities, nil
 	}
-
-	// TODO: add a flag to prevent unauthenticated requests ( 15010 )
-	// request not over TLS ( on the insecure port
 	return nil, nil
 }
 


### PR DESCRIPTION
Currently everything is declared as unauthenticate. This is because CheckSecurityLevel looks like RequestContext which isn't present. The auth info is only present in the peer info. I tried to rewrite the check security level for peer info but its not possible since its all grpc-internal. So I feel like the best option is to remove it entirely. I couldn't find any docs suggesting this was a bad idea.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure