### PR TITLE
Apply proxyMetadata to Prometheus sidecar.

### DIFF
--- a/manifests/charts/global.yaml
+++ b/manifests/charts/global.yaml
@@ -398,6 +398,7 @@ version: ""
 meshConfig:
   enablePrometheusMerge: true
   defaultConfig:
+    proxyMetadata: {}
     tracing:
       tlsSettings:
         mode: DISABLE # DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL

--- a/manifests/charts/istio-telemetry/prometheus/templates/deployment.yaml
+++ b/manifests/charts/istio-telemetry/prometheus/templates/deployment.yaml
@@ -139,6 +139,10 @@ spec:
               {{- end }}
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ .Values.global.multiCluster.clusterName | default `Kubernetes` }}"
+            {{- range $key, $value := .Values.meshConfig.defaultConfig.proxyMetadata }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+            {{- end }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy | default "Always" }}
           readinessProbe:
             failureThreshold: 30

--- a/manifests/profiles/default.yaml
+++ b/manifests/profiles/default.yaml
@@ -8,6 +8,8 @@ spec:
 
   # You may override parts of meshconfig by uncommenting the following lines.
   meshConfig:
+    defaultConfig:
+      proxyMetadata: {}
     enablePrometheusMerge: true
     # Opt-out of global http2 upgrades.
     # Destination rule is used to opt-in.


### PR DESCRIPTION
Enable applying the proxyMetadata to the Prometheus sidecar, just like workload sidecars.

Although we have the [new deployment model](https://preliminary.istio.io/docs/ops/integrations/prometheus/#option-2-metrics-merging) for Prometheus as default in 1.7, this is still needed especially for 1.6 (where the new model was in Alpha).

Will also cherry-pick to 1.6.


[ ] Configuration Infrastructure
[ ] Docs
[ X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ X ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure