### PR TITLE
Move beta.kubernetes.io/{os,arch} to kubernetes.io/{os,arch}

### DIFF
--- a/galley/pkg/config/testing/data/builtin.gen.go
+++ b/galley/pkg/config/testing/data/builtin.gen.go
@@ -232,10 +232,10 @@ metadata:
     volumes.kubernetes.io/controller-managed-attach-detach: "true"
   creationTimestamp: 2018-10-05T19:40:48Z
   labels:
-    beta.kubernetes.io/arch: amd64
+    kubernetes.io/arch: amd64
     beta.kubernetes.io/fluentd-ds-ready: "true"
     beta.kubernetes.io/instance-type: n1-standard-4
-    beta.kubernetes.io/os: linux
+    kubernetes.io/os: linux
     cloud.google.com/gke-nodepool: default-pool
     cloud.google.com/gke-os-distribution: cos
     failure-domain.beta.kubernetes.io/region: us-central1

--- a/galley/pkg/config/testing/data/builtin/node.yaml
+++ b/galley/pkg/config/testing/data/builtin/node.yaml
@@ -7,10 +7,10 @@ metadata:
     volumes.kubernetes.io/controller-managed-attach-detach: "true"
   creationTimestamp: 2018-10-05T19:40:48Z
   labels:
-    beta.kubernetes.io/arch: amd64
+    kubernetes.io/arch: amd64
     beta.kubernetes.io/fluentd-ds-ready: "true"
     beta.kubernetes.io/instance-type: n1-standard-4
-    beta.kubernetes.io/os: linux
+    kubernetes.io/os: linux
     cloud.google.com/gke-nodepool: default-pool
     cloud.google.com/gke-os-distribution: cos
     failure-domain.beta.kubernetes.io/region: us-central1

--- a/manifests/charts/gateways/istio-egress/templates/_affinity.tpl
+++ b/manifests/charts/gateways/istio-egress/templates/_affinity.tpl
@@ -11,7 +11,7 @@
 {{- define "nodeAffinityRequiredDuringScheduling" }}
       nodeSelectorTerms:
       - matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
         {{- range $key, $val := .global.arch }}
@@ -34,7 +34,7 @@
     - weight: {{ $val | int }}
       preference:
         matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
           - {{ $key | quote }}

--- a/manifests/charts/gateways/istio-ingress/templates/_affinity.tpl
+++ b/manifests/charts/gateways/istio-ingress/templates/_affinity.tpl
@@ -11,7 +11,7 @@
 {{- define "nodeAffinityRequiredDuringScheduling" }}
       nodeSelectorTerms:
       - matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
         {{- range $key, $val := .global.arch }}
@@ -34,7 +34,7 @@
     - weight: {{ $val | int }}
       preference:
         matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
           - {{ $key | quote }}

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         {{- end }}
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
         # Make sure istio-cni-node gets scheduled on all nodes.

--- a/manifests/charts/istio-policy/templates/_affinity.tpl
+++ b/manifests/charts/istio-policy/templates/_affinity.tpl
@@ -11,7 +11,7 @@
 {{- define "nodeAffinityRequiredDuringScheduling" }}
       nodeSelectorTerms:
       - matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
         {{- range $key, $val := .Values.global.arch }}
@@ -34,7 +34,7 @@
     - weight: {{ $val | int }}
       preference:
         matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
           - {{ $key | quote }}

--- a/manifests/charts/istio-telemetry/grafana/templates/_affinity.tpl
+++ b/manifests/charts/istio-telemetry/grafana/templates/_affinity.tpl
@@ -11,7 +11,7 @@
 {{- define "nodeAffinityRequiredDuringScheduling" }}
       nodeSelectorTerms:
       - matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
         {{- range $key, $val := .Values.global.arch }}
@@ -34,7 +34,7 @@
     - weight: {{ $val | int }}
       preference:
         matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
           - {{ $key | quote }}

--- a/manifests/charts/istio-telemetry/kiali/templates/_affinity.tpl
+++ b/manifests/charts/istio-telemetry/kiali/templates/_affinity.tpl
@@ -11,7 +11,7 @@
 {{- define "nodeAffinityRequiredDuringScheduling" }}
       nodeSelectorTerms:
       - matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
         {{- range $key, $val := .Values.global.arch }}
@@ -34,7 +34,7 @@
     - weight: {{ $val | int }}
       preference:
         matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
           - {{ $key | quote }}

--- a/manifests/charts/istio-telemetry/mixer-telemetry/templates/_affinity.tpl
+++ b/manifests/charts/istio-telemetry/mixer-telemetry/templates/_affinity.tpl
@@ -11,7 +11,7 @@
 {{- define "nodeAffinityRequiredDuringScheduling" }}
       nodeSelectorTerms:
       - matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
         {{- range $key, $val := .Values.global.arch }}
@@ -34,7 +34,7 @@
     - weight: {{ $val | int }}
       preference:
         matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
           - {{ $key | quote }}

--- a/manifests/charts/istio-telemetry/prometheus/templates/_affinity.tpl
+++ b/manifests/charts/istio-telemetry/prometheus/templates/_affinity.tpl
@@ -11,7 +11,7 @@
 {{- define "nodeAffinityRequiredDuringScheduling" }}
       nodeSelectorTerms:
       - matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
         {{- range $key, $val := .Values.global.arch }}
@@ -34,7 +34,7 @@
     - weight: {{ $val | int }}
       preference:
         matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
           - {{ $key | quote }}

--- a/manifests/charts/istio-telemetry/prometheusOperator/templates/_affinity.tpl
+++ b/manifests/charts/istio-telemetry/prometheusOperator/templates/_affinity.tpl
@@ -11,7 +11,7 @@
 {{- define "nodeAffinityRequiredDuringScheduling" }}
       nodeSelectorTerms:
       - matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
         {{- range $key, $val := .Values.global.arch }}
@@ -34,7 +34,7 @@
     - weight: {{ $val | int }}
       preference:
         matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
           - {{ $key | quote }}

--- a/manifests/charts/istio-telemetry/tracing/templates/_affinity.tpl
+++ b/manifests/charts/istio-telemetry/tracing/templates/_affinity.tpl
@@ -11,7 +11,7 @@
 {{- define "nodeAffinityRequiredDuringScheduling" }}
       nodeSelectorTerms:
       - matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
         {{- range $key, $val := .Values.global.arch }}
@@ -34,7 +34,7 @@
     - weight: {{ $val | int }}
       preference:
         matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
           - {{ $key | quote }}

--- a/manifests/charts/istiocoredns/templates/_affinity.tpl
+++ b/manifests/charts/istiocoredns/templates/_affinity.tpl
@@ -11,7 +11,7 @@
 {{- define "nodeAffinityRequiredDuringScheduling" }}
       nodeSelectorTerms:
       - matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
         {{- range $key, $val := .Values.global.arch }}
@@ -34,7 +34,7 @@
     - weight: {{ $val | int }}
       preference:
         matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
           - {{ $key | quote }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/gateways/istio-egress/templates/_affinity.tpl
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/gateways/istio-egress/templates/_affinity.tpl
@@ -11,7 +11,7 @@
 {{- define "nodeAffinityRequiredDuringScheduling" }}
       nodeSelectorTerms:
       - matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
         {{- range $key, $val := .global.arch }}
@@ -34,7 +34,7 @@
     - weight: {{ $val | int }}
       preference:
         matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
           - {{ $key | quote }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/gateways/istio-ingress/templates/_affinity.tpl
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/gateways/istio-ingress/templates/_affinity.tpl
@@ -11,7 +11,7 @@
 {{- define "nodeAffinityRequiredDuringScheduling" }}
       nodeSelectorTerms:
       - matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
         {{- range $key, $val := .global.arch }}
@@ -34,7 +34,7 @@
     - weight: {{ $val | int }}
       preference:
         matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
           - {{ $key | quote }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-cni/templates/daemonset.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-cni/templates/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         {{- end }}
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
         # Make sure istio-cni-node gets scheduled on all nodes.

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-policy/templates/_affinity.tpl
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-policy/templates/_affinity.tpl
@@ -11,7 +11,7 @@
 {{- define "nodeAffinityRequiredDuringScheduling" }}
       nodeSelectorTerms:
       - matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
         {{- range $key, $val := .Values.global.arch }}
@@ -34,7 +34,7 @@
     - weight: {{ $val | int }}
       preference:
         matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
           - {{ $key | quote }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-telemetry/grafana/templates/_affinity.tpl
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-telemetry/grafana/templates/_affinity.tpl
@@ -11,7 +11,7 @@
 {{- define "nodeAffinityRequiredDuringScheduling" }}
       nodeSelectorTerms:
       - matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
         {{- range $key, $val := .Values.global.arch }}
@@ -34,7 +34,7 @@
     - weight: {{ $val | int }}
       preference:
         matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
           - {{ $key | quote }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-telemetry/kiali/templates/_affinity.tpl
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-telemetry/kiali/templates/_affinity.tpl
@@ -11,7 +11,7 @@
 {{- define "nodeAffinityRequiredDuringScheduling" }}
       nodeSelectorTerms:
       - matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
         {{- range $key, $val := .Values.global.arch }}
@@ -34,7 +34,7 @@
     - weight: {{ $val | int }}
       preference:
         matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
           - {{ $key | quote }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-telemetry/mixer-telemetry/templates/_affinity.tpl
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-telemetry/mixer-telemetry/templates/_affinity.tpl
@@ -11,7 +11,7 @@
 {{- define "nodeAffinityRequiredDuringScheduling" }}
       nodeSelectorTerms:
       - matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
         {{- range $key, $val := .Values.global.arch }}
@@ -34,7 +34,7 @@
     - weight: {{ $val | int }}
       preference:
         matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
           - {{ $key | quote }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-telemetry/prometheus/templates/_affinity.tpl
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-telemetry/prometheus/templates/_affinity.tpl
@@ -11,7 +11,7 @@
 {{- define "nodeAffinityRequiredDuringScheduling" }}
       nodeSelectorTerms:
       - matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
         {{- range $key, $val := .Values.global.arch }}
@@ -34,7 +34,7 @@
     - weight: {{ $val | int }}
       preference:
         matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
           - {{ $key | quote }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-telemetry/prometheusOperator/templates/_affinity.tpl
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-telemetry/prometheusOperator/templates/_affinity.tpl
@@ -11,7 +11,7 @@
 {{- define "nodeAffinityRequiredDuringScheduling" }}
       nodeSelectorTerms:
       - matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
         {{- range $key, $val := .Values.global.arch }}
@@ -34,7 +34,7 @@
     - weight: {{ $val | int }}
       preference:
         matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
           - {{ $key | quote }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-telemetry/tracing/templates/_affinity.tpl
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-telemetry/tracing/templates/_affinity.tpl
@@ -11,7 +11,7 @@
 {{- define "nodeAffinityRequiredDuringScheduling" }}
       nodeSelectorTerms:
       - matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
         {{- range $key, $val := .Values.global.arch }}
@@ -34,7 +34,7 @@
     - weight: {{ $val | int }}
       preference:
         matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
           - {{ $key | quote }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiocoredns/templates/_affinity.tpl
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiocoredns/templates/_affinity.tpl
@@ -11,7 +11,7 @@
 {{- define "nodeAffinityRequiredDuringScheduling" }}
       nodeSelectorTerms:
       - matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
         {{- range $key, $val := .Values.global.arch }}
@@ -34,7 +34,7 @@
     - weight: {{ $val | int }}
       preference:
         matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
           - {{ $key | quote }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/addon_k8s_override.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/addon_k8s_override.golden.yaml
@@ -24,21 +24,21 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - ppc64le
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - s390x
@@ -46,7 +46,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -142,7 +142,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - "amd64"
@@ -152,21 +152,21 @@ spec:
           - weight: 2
             preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - "amd64"
           - weight: 2
             preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - "ppc64le"
           - weight: 2
             preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - "s390x"
@@ -415,21 +415,21 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - ppc64le
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - s390x
@@ -437,7 +437,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64
@@ -6002,7 +6002,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - "amd64"
@@ -6012,21 +6012,21 @@ spec:
           - weight: 2
             preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - "amd64"
           - weight: 2
             preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - "ppc64le"
           - weight: 2
             preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - "s390x"
@@ -6325,7 +6325,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - "amd64"
@@ -6335,21 +6335,21 @@ spec:
           - weight: 2
             preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - "amd64"
           - weight: 2
             preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - "ppc64le"
           - weight: 2
             preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - "s390x"
@@ -8512,21 +8512,21 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - ppc64le
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - s390x
@@ -8534,7 +8534,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64
@@ -10035,21 +10035,21 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - ppc64le
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - s390x
@@ -10057,7 +10057,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.golden.yaml
@@ -37,21 +37,21 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - ppc64le
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - s390x
@@ -59,7 +59,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_set_values.golden.yaml
@@ -637,21 +637,21 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - ppc64le
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - s390x
@@ -659,7 +659,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64

--- a/operator/cmd/mesh/testdata/manifest-generate/output/gateways.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/gateways.golden.yaml
@@ -91,21 +91,21 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - ppc64le
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - s390x
@@ -113,7 +113,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64
@@ -467,21 +467,21 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - ppc64le
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - s390x
@@ -489,7 +489,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64
@@ -828,21 +828,21 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - ppc64le
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - s390x
@@ -850,7 +850,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64

--- a/operator/cmd/mesh/testdata/manifest-generate/output/gateways_override_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/gateways_override_default.golden.yaml
@@ -214,21 +214,21 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - ppc64le
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - s390x
@@ -236,7 +236,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64
@@ -382,21 +382,21 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - ppc64le
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - s390x
@@ -404,7 +404,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64

--- a/operator/cmd/mesh/testdata/manifest-generate/output/helm_values_enablement.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/helm_values_enablement.golden.yaml
@@ -37,21 +37,21 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - ppc64le
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - s390x
@@ -59,7 +59,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64
@@ -252,21 +252,21 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - ppc64le
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - s390x
@@ -274,7 +274,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64

--- a/operator/cmd/mesh/testdata/manifest-generate/output/ingressgateway_k8s_settings.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/ingressgateway_k8s_settings.golden.yaml
@@ -200,7 +200,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - "amd64"
@@ -210,21 +210,21 @@ spec:
           - weight: 2
             preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - "amd64"
           - weight: 2
             preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - "ppc64le"
           - weight: 2
             preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - "s390x"

--- a/operator/cmd/mesh/testdata/manifest-generate/output/telemetry_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/telemetry_default.golden.yaml
@@ -1332,21 +1332,21 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - ppc64le
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - s390x
@@ -1354,7 +1354,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64

--- a/operator/cmd/mesh/testdata/manifest-generate/output/telemetry_k8s_settings.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/telemetry_k8s_settings.golden.yaml
@@ -33,21 +33,21 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - ppc64le
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - s390x
@@ -55,7 +55,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64

--- a/operator/cmd/mesh/testdata/manifest-generate/output/telemetry_override_kubernetes.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/telemetry_override_kubernetes.golden.yaml
@@ -246,21 +246,21 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - ppc64le
             weight: 2
           - preference:
               matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - s390x
@@ -268,7 +268,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64

--- a/operator/pkg/translate/translate_value_test.go
+++ b/operator/pkg/translate/translate_value_test.go
@@ -45,7 +45,7 @@ pilot:
       memory: 1G
   replicaCount: 1
   nodeSelector:
-    beta.kubernetes.io/os: linux
+    kubernetes.io/os: linux
   tolerations:
   - key: dedicated
     operator: Exists
@@ -113,7 +113,7 @@ components:
                targetAverageUtilization: 80
              type: Resource
        nodeSelector:
-          beta.kubernetes.io/os: linux
+          kubernetes.io/os: linux
        tolerations:
        - key: dedicated
          operator: Exists


### PR DESCRIPTION
According to [Istio+Kubernetes Support Matrix](https://docs.google.com/document/d/14Xfe9V0vv8d7W75c21d-cY2XyK6xvRH0_Kg8j_zfh4Y/edit#heading=h.xw1gqgyqs5b), istio 1.7 will support kubernetes 1.19? but `beta.kubernetes.io/os` and `beta.kubernetes.io/arch` will be removed in the future, Issue: https://github.com/istio/istio/issues/24375

So, I replaced all labels `beta.kubernetes.io/{os,arch}` with `kubernetes.io/{os,arch}`

Docs:
https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/
https://docs.google.com/document/d/14Xfe9V0vv8d7W75c21d-cY2XyK6xvRH0_Kg8j_zfh4Y/edit#heading=h.xw1gqgyqs5b
https://github.com/istio/istio/issues/23184
https://github.com/istio/istio/issues/24375

[X] Installation
