### PR TITLE
TLS Context Tests

### DIFF
--- a/pkg/bootstrap/option/convert_test.go
+++ b/pkg/bootstrap/option/convert_test.go
@@ -1,27 +1,42 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package option
 
 import (
+	"reflect"
+	"testing"
+
 	networkingAPI "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pkg/bootstrap/auth"
-	"reflect"
-	"testing"
 )
 
 func TestTlsContextConvert(t *testing.T) {
-	tests := []struct{
-		desc string
-		tls *networkingAPI.ClientTLSSettings
-		sni string
-		meta *model.NodeMetadata
+	tests := []struct {
+		desc         string
+		tls          *networkingAPI.ClientTLSSettings
+		sni          string
+		meta         *model.NodeMetadata
 		expectTlsCtx *auth.UpstreamTLSContext
 	}{
 		{
-			desc: "no-tls",
-			tls: &networkingAPI.ClientTLSSettings{},
-			sni: "",
-			meta: &model.NodeMetadata{},
+			desc:         "no-tls",
+			tls:          &networkingAPI.ClientTLSSettings{},
+			sni:          "",
+			meta:         &model.NodeMetadata{},
 			expectTlsCtx: nil,
 		},
 		{
@@ -29,23 +44,23 @@ func TestTlsContextConvert(t *testing.T) {
 			tls: &networkingAPI.ClientTLSSettings{
 				Mode: networkingAPI.ClientTLSSettings_SIMPLE,
 			},
-			sni: "",
+			sni:  "",
 			meta: &model.NodeMetadata{},
 			expectTlsCtx: &auth.UpstreamTLSContext{
 				CommonTLSContext: &auth.CommonTLSContext{
 					ValidationContext: nil,
-					AlpnProtocols: util.ALPNH2Only,
+					AlpnProtocols:     util.ALPNH2Only,
 				},
 			},
 		},
 		{
 			desc: "tls-simple-cert-cli",
 			tls: &networkingAPI.ClientTLSSettings{
-				Mode: networkingAPI.ClientTLSSettings_SIMPLE,
+				Mode:           networkingAPI.ClientTLSSettings_SIMPLE,
 				CaCertificates: "foo.pem",
-				Sni: "foo",
+				Sni:            "foo",
 			},
-			sni: "",
+			sni:  "",
 			meta: &model.NodeMetadata{},
 			expectTlsCtx: &auth.UpstreamTLSContext{
 				CommonTLSContext: &auth.CommonTLSContext{
@@ -62,9 +77,9 @@ func TestTlsContextConvert(t *testing.T) {
 		{
 			desc: "tls-simple-cert-cli-meta",
 			tls: &networkingAPI.ClientTLSSettings{
-				Mode: networkingAPI.ClientTLSSettings_SIMPLE,
+				Mode:           networkingAPI.ClientTLSSettings_SIMPLE,
 				CaCertificates: "foo.pem",
-				Sni: "foo",
+				Sni:            "foo",
 			},
 			sni: "",
 			meta: &model.NodeMetadata{
@@ -92,12 +107,12 @@ func TestTlsContextConvert(t *testing.T) {
 		{
 			desc: "tls-cli-mutual",
 			tls: &networkingAPI.ClientTLSSettings{
-				Mode: networkingAPI.ClientTLSSettings_MUTUAL,
+				Mode:              networkingAPI.ClientTLSSettings_MUTUAL,
 				ClientCertificate: "foo",
-				PrivateKey: "im-private-foo",
-				Sni: "bar",
+				PrivateKey:        "im-private-foo",
+				Sni:               "bar",
 			},
-			sni: "",
+			sni:  "",
 			meta: &model.NodeMetadata{},
 			expectTlsCtx: &auth.UpstreamTLSContext{
 				CommonTLSContext: &auth.CommonTLSContext{
@@ -121,7 +136,7 @@ func TestTlsContextConvert(t *testing.T) {
 			tls: &networkingAPI.ClientTLSSettings{
 				Mode: networkingAPI.ClientTLSSettings_ISTIO_MUTUAL,
 			},
-			sni: "i-should-be-sni",
+			sni:  "i-should-be-sni",
 			meta: &model.NodeMetadata{},
 			expectTlsCtx: &auth.UpstreamTLSContext{
 				CommonTLSContext: &auth.CommonTLSContext{
@@ -148,11 +163,11 @@ func TestTlsContextConvert(t *testing.T) {
 		{
 			desc: "tls-istio-mutual-provide-certs",
 			tls: &networkingAPI.ClientTLSSettings{
-				Mode: networkingAPI.ClientTLSSettings_ISTIO_MUTUAL,
+				Mode:              networkingAPI.ClientTLSSettings_ISTIO_MUTUAL,
 				ClientCertificate: "foo.pem",
-				PrivateKey: "bar.pem",
+				PrivateKey:        "bar.pem",
 			},
-			sni: "i-should-be-sni",
+			sni:  "i-should-be-sni",
 			meta: &model.NodeMetadata{},
 			expectTlsCtx: &auth.UpstreamTLSContext{
 				CommonTLSContext: &auth.CommonTLSContext{
@@ -179,14 +194,14 @@ func TestTlsContextConvert(t *testing.T) {
 		{
 			desc: "tls-istio-mutual-meta-certs",
 			tls: &networkingAPI.ClientTLSSettings{
-				Mode: networkingAPI.ClientTLSSettings_ISTIO_MUTUAL,
+				Mode:              networkingAPI.ClientTLSSettings_ISTIO_MUTUAL,
 				ClientCertificate: "foo.pem",
-				PrivateKey: "bar.pem",
+				PrivateKey:        "bar.pem",
 			},
 			sni: "i-should-be-sni",
 			meta: &model.NodeMetadata{
 				TLSClientCertChain: "better-foo.pem",
-				TLSClientKey: "better-bar.pem",
+				TLSClientKey:       "better-bar.pem",
 			},
 			expectTlsCtx: &auth.UpstreamTLSContext{
 				CommonTLSContext: &auth.CommonTLSContext{

--- a/pkg/bootstrap/option/convert_test.go
+++ b/pkg/bootstrap/option/convert_test.go
@@ -1,0 +1,94 @@
+package option
+
+import (
+	networkingAPI "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/istio/pkg/bootstrap/auth"
+	"reflect"
+	"testing"
+)
+
+func TestTlsContextConvert(t *testing.T) {
+	tests := []struct{
+		desc string
+		tls *networkingAPI.ClientTLSSettings
+		sni string
+		meta *model.NodeMetadata
+		expectTlsCtx *auth.UpstreamTLSContext
+	}{
+		{
+			desc: "no-tls",
+			tls: &networkingAPI.ClientTLSSettings{},
+			sni: "",
+			meta: &model.NodeMetadata{},
+			expectTlsCtx: nil,
+		},
+		{
+			desc: "tls-simple-no-cert",
+			tls: &networkingAPI.ClientTLSSettings{
+				Mode: networkingAPI.ClientTLSSettings_SIMPLE,
+			},
+			sni: "",
+			meta: &model.NodeMetadata{},
+			expectTlsCtx: &auth.UpstreamTLSContext{
+				CommonTLSContext: &auth.CommonTLSContext{
+					ValidationContext: nil,
+					AlpnProtocols: util.ALPNH2Only,
+				},
+			},
+		},
+		{
+			desc: "tls-simple-cert-cli-meta",
+			tls: &networkingAPI.ClientTLSSettings{
+				Mode: networkingAPI.ClientTLSSettings_SIMPLE,
+				CaCertificates: "foo.pem",
+				Sni: "foo",
+			},
+			sni: "",
+			meta: &model.NodeMetadata{
+				TLSClientRootCert: "/foo/bar/baz.pem",
+			},
+			expectTlsCtx: &auth.UpstreamTLSContext{
+				CommonTLSContext: &auth.CommonTLSContext{
+					ValidationContext: &auth.CertificateValidationContext{
+						TrustedCa: &auth.DataSource{
+							Filename: "/foo/bar/baz.pem",
+						},
+					},
+					AlpnProtocols: []string{"h2"},
+				},
+				Sni: "foo",
+			},
+		},
+		{
+			desc: "tls-simple-cert-cli",
+			tls: &networkingAPI.ClientTLSSettings{
+				Mode: networkingAPI.ClientTLSSettings_SIMPLE,
+				CaCertificates: "foo.pem",
+				Sni: "foo",
+			},
+			sni: "",
+			meta: &model.NodeMetadata{},
+			expectTlsCtx: &auth.UpstreamTLSContext{
+				CommonTLSContext: &auth.CommonTLSContext{
+					ValidationContext: &auth.CertificateValidationContext{
+						TrustedCa: &auth.DataSource{
+							Filename: "foo.pem",
+						},
+					},
+					AlpnProtocols: []string{"h2"},
+				},
+				Sni: "foo",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			if got := tlsContextConvert(tt.tls, tt.sni, tt.meta); !reflect.DeepEqual(tt.expectTlsCtx, got) {
+				t.Errorf("%s: expected TLS ctx %v got %v", tt.desc, tt.expectTlsCtx, got)
+			}
+		})
+	}
+}

--- a/pkg/bootstrap/option/convert_test.go
+++ b/pkg/bootstrap/option/convert_test.go
@@ -116,14 +116,106 @@ func TestTlsContextConvert(t *testing.T) {
 				Sni: "bar",
 			},
 		},
+		{
+			desc: "tls-istio-mutual-no-certs",
+			tls: &networkingAPI.ClientTLSSettings{
+				Mode: networkingAPI.ClientTLSSettings_ISTIO_MUTUAL,
+			},
+			sni: "i-should-be-sni",
+			meta: &model.NodeMetadata{},
+			expectTlsCtx: &auth.UpstreamTLSContext{
+				CommonTLSContext: &auth.CommonTLSContext{
+					TLSCertificates: []*auth.TLSCertificate{
+						{
+							CertificateChain: &auth.DataSource{
+								Filename: "/etc/certs/root-cert.pem",
+							},
+							PrivateKey: &auth.DataSource{
+								Filename: "/etc/certs/key.pem",
+							},
+						},
+					},
+					ValidationContext: &auth.CertificateValidationContext{
+						TrustedCa: &auth.DataSource{
+							Filename: "/etc/certs/cert-chain.pem",
+						},
+					},
+					AlpnProtocols: []string{"istio", "h2"},
+				},
+				Sni: "i-should-be-sni",
+			},
+		},
+		{
+			desc: "tls-istio-mutual-provide-certs",
+			tls: &networkingAPI.ClientTLSSettings{
+				Mode: networkingAPI.ClientTLSSettings_ISTIO_MUTUAL,
+				ClientCertificate: "foo.pem",
+				PrivateKey: "bar.pem",
+			},
+			sni: "i-should-be-sni",
+			meta: &model.NodeMetadata{},
+			expectTlsCtx: &auth.UpstreamTLSContext{
+				CommonTLSContext: &auth.CommonTLSContext{
+					TLSCertificates: []*auth.TLSCertificate{
+						{
+							CertificateChain: &auth.DataSource{
+								Filename: "foo.pem",
+							},
+							PrivateKey: &auth.DataSource{
+								Filename: "bar.pem",
+							},
+						},
+					},
+					ValidationContext: &auth.CertificateValidationContext{
+						TrustedCa: &auth.DataSource{
+							Filename: "/etc/certs/cert-chain.pem",
+						},
+					},
+					AlpnProtocols: []string{"istio", "h2"},
+				},
+				Sni: "i-should-be-sni",
+			},
+		},
+		{
+			desc: "tls-istio-mutual-meta-certs",
+			tls: &networkingAPI.ClientTLSSettings{
+				Mode: networkingAPI.ClientTLSSettings_ISTIO_MUTUAL,
+				ClientCertificate: "foo.pem",
+				PrivateKey: "bar.pem",
+			},
+			sni: "i-should-be-sni",
+			meta: &model.NodeMetadata{
+				TLSClientCertChain: "better-foo.pem",
+				TLSClientKey: "better-bar.pem",
+			},
+			expectTlsCtx: &auth.UpstreamTLSContext{
+				CommonTLSContext: &auth.CommonTLSContext{
+					TLSCertificates: []*auth.TLSCertificate{
+						{
+							CertificateChain: &auth.DataSource{
+								Filename: "better-foo.pem",
+							},
+							PrivateKey: &auth.DataSource{
+								Filename: "better-bar.pem",
+							},
+						},
+					},
+					ValidationContext: &auth.CertificateValidationContext{
+						TrustedCa: &auth.DataSource{
+							Filename: "/etc/certs/cert-chain.pem",
+						},
+					},
+					AlpnProtocols: []string{"istio", "h2"},
+				},
+				Sni: "i-should-be-sni",
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			if got := tlsContextConvert(tt.tls, tt.sni, tt.meta); !reflect.DeepEqual(tt.expectTlsCtx, got) {
 				t.Errorf("%s: expected TLS ctx %v got %v", tt.desc, tt.expectTlsCtx, got)
-				//g, _ := json.Marshal(got)
-				//log.Println(string(g))
 			}
 		})
 	}

--- a/pkg/bootstrap/option/convert_test.go
+++ b/pkg/bootstrap/option/convert_test.go
@@ -39,6 +39,27 @@ func TestTlsContextConvert(t *testing.T) {
 			},
 		},
 		{
+			desc: "tls-simple-cert-cli",
+			tls: &networkingAPI.ClientTLSSettings{
+				Mode: networkingAPI.ClientTLSSettings_SIMPLE,
+				CaCertificates: "foo.pem",
+				Sni: "foo",
+			},
+			sni: "",
+			meta: &model.NodeMetadata{},
+			expectTlsCtx: &auth.UpstreamTLSContext{
+				CommonTLSContext: &auth.CommonTLSContext{
+					ValidationContext: &auth.CertificateValidationContext{
+						TrustedCa: &auth.DataSource{
+							Filename: "foo.pem",
+						},
+					},
+					AlpnProtocols: []string{"h2"},
+				},
+				Sni: "foo",
+			},
+		},
+		{
 			desc: "tls-simple-cert-cli-meta",
 			tls: &networkingAPI.ClientTLSSettings{
 				Mode: networkingAPI.ClientTLSSettings_SIMPLE,
@@ -62,25 +83,25 @@ func TestTlsContextConvert(t *testing.T) {
 			},
 		},
 		{
-			desc: "tls-simple-cert-cli",
+			desc: "tls-cli-mutual-missing-certs",
 			tls: &networkingAPI.ClientTLSSettings{
-				Mode: networkingAPI.ClientTLSSettings_SIMPLE,
-				CaCertificates: "foo.pem",
-				Sni: "foo",
+				Mode: networkingAPI.ClientTLSSettings_MUTUAL,
+			},
+			expectTlsCtx: nil,
+		},
+		{
+			desc: "tls-cli-mutual",
+			tls: &networkingAPI.ClientTLSSettings{
+				Mode: networkingAPI.ClientTLSSettings_MUTUAL,
+				ClientCertificate: "foo",
+				PrivateKey: "im-private-foo",
+				Sni: "bar",
 			},
 			sni: "",
 			meta: &model.NodeMetadata{},
-			expectTlsCtx: &auth.UpstreamTLSContext{
-				CommonTLSContext: &auth.CommonTLSContext{
-					ValidationContext: &auth.CertificateValidationContext{
-						TrustedCa: &auth.DataSource{
-							Filename: "foo.pem",
-						},
-					},
-					AlpnProtocols: []string{"h2"},
-				},
-				Sni: "foo",
-			},
+			expectTlsCtx: &auth.CommonTLSContext{
+				// todo finish & add tests for istio mTLS
+			}
 		},
 	}
 

--- a/pkg/bootstrap/option/convert_test.go
+++ b/pkg/bootstrap/option/convert_test.go
@@ -99,9 +99,22 @@ func TestTlsContextConvert(t *testing.T) {
 			},
 			sni: "",
 			meta: &model.NodeMetadata{},
-			expectTlsCtx: &auth.CommonTLSContext{
-				// todo finish & add tests for istio mTLS
-			}
+			expectTlsCtx: &auth.UpstreamTLSContext{
+				CommonTLSContext: &auth.CommonTLSContext{
+					TLSCertificates: []*auth.TLSCertificate{
+						{
+							CertificateChain: &auth.DataSource{
+								Filename: "foo",
+							},
+							PrivateKey: &auth.DataSource{
+								Filename: "im-private-foo",
+							},
+						},
+					},
+					AlpnProtocols: []string{"h2"},
+				},
+				Sni: "bar",
+			},
 		},
 	}
 
@@ -109,6 +122,8 @@ func TestTlsContextConvert(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			if got := tlsContextConvert(tt.tls, tt.sni, tt.meta); !reflect.DeepEqual(tt.expectTlsCtx, got) {
 				t.Errorf("%s: expected TLS ctx %v got %v", tt.desc, tt.expectTlsCtx, got)
+				//g, _ := json.Marshal(got)
+				//log.Println(string(g))
 			}
 		})
 	}

--- a/pkg/bootstrap/option/convert_test.go
+++ b/pkg/bootstrap/option/convert_test.go
@@ -30,14 +30,14 @@ func TestTlsContextConvert(t *testing.T) {
 		tls          *networkingAPI.ClientTLSSettings
 		sni          string
 		meta         *model.NodeMetadata
-		expectTlsCtx *auth.UpstreamTLSContext
+		expectTLSCtx *auth.UpstreamTLSContext
 	}{
 		{
 			desc:         "no-tls",
 			tls:          &networkingAPI.ClientTLSSettings{},
 			sni:          "",
 			meta:         &model.NodeMetadata{},
-			expectTlsCtx: nil,
+			expectTLSCtx: nil,
 		},
 		{
 			desc: "tls-simple-no-cert",
@@ -46,7 +46,7 @@ func TestTlsContextConvert(t *testing.T) {
 			},
 			sni:  "",
 			meta: &model.NodeMetadata{},
-			expectTlsCtx: &auth.UpstreamTLSContext{
+			expectTLSCtx: &auth.UpstreamTLSContext{
 				CommonTLSContext: &auth.CommonTLSContext{
 					ValidationContext: nil,
 					AlpnProtocols:     util.ALPNH2Only,
@@ -62,7 +62,7 @@ func TestTlsContextConvert(t *testing.T) {
 			},
 			sni:  "",
 			meta: &model.NodeMetadata{},
-			expectTlsCtx: &auth.UpstreamTLSContext{
+			expectTLSCtx: &auth.UpstreamTLSContext{
 				CommonTLSContext: &auth.CommonTLSContext{
 					ValidationContext: &auth.CertificateValidationContext{
 						TrustedCa: &auth.DataSource{
@@ -85,7 +85,7 @@ func TestTlsContextConvert(t *testing.T) {
 			meta: &model.NodeMetadata{
 				TLSClientRootCert: "/foo/bar/baz.pem",
 			},
-			expectTlsCtx: &auth.UpstreamTLSContext{
+			expectTLSCtx: &auth.UpstreamTLSContext{
 				CommonTLSContext: &auth.CommonTLSContext{
 					ValidationContext: &auth.CertificateValidationContext{
 						TrustedCa: &auth.DataSource{
@@ -102,7 +102,7 @@ func TestTlsContextConvert(t *testing.T) {
 			tls: &networkingAPI.ClientTLSSettings{
 				Mode: networkingAPI.ClientTLSSettings_MUTUAL,
 			},
-			expectTlsCtx: nil,
+			expectTLSCtx: nil,
 		},
 		{
 			desc: "tls-cli-mutual",
@@ -114,7 +114,7 @@ func TestTlsContextConvert(t *testing.T) {
 			},
 			sni:  "",
 			meta: &model.NodeMetadata{},
-			expectTlsCtx: &auth.UpstreamTLSContext{
+			expectTLSCtx: &auth.UpstreamTLSContext{
 				CommonTLSContext: &auth.CommonTLSContext{
 					TLSCertificates: []*auth.TLSCertificate{
 						{
@@ -138,7 +138,7 @@ func TestTlsContextConvert(t *testing.T) {
 			},
 			sni:  "i-should-be-sni",
 			meta: &model.NodeMetadata{},
-			expectTlsCtx: &auth.UpstreamTLSContext{
+			expectTLSCtx: &auth.UpstreamTLSContext{
 				CommonTLSContext: &auth.CommonTLSContext{
 					TLSCertificates: []*auth.TLSCertificate{
 						{
@@ -169,7 +169,7 @@ func TestTlsContextConvert(t *testing.T) {
 			},
 			sni:  "i-should-be-sni",
 			meta: &model.NodeMetadata{},
-			expectTlsCtx: &auth.UpstreamTLSContext{
+			expectTLSCtx: &auth.UpstreamTLSContext{
 				CommonTLSContext: &auth.CommonTLSContext{
 					TLSCertificates: []*auth.TLSCertificate{
 						{
@@ -203,7 +203,7 @@ func TestTlsContextConvert(t *testing.T) {
 				TLSClientCertChain: "better-foo.pem",
 				TLSClientKey:       "better-bar.pem",
 			},
-			expectTlsCtx: &auth.UpstreamTLSContext{
+			expectTLSCtx: &auth.UpstreamTLSContext{
 				CommonTLSContext: &auth.CommonTLSContext{
 					TLSCertificates: []*auth.TLSCertificate{
 						{
@@ -229,8 +229,8 @@ func TestTlsContextConvert(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			if got := tlsContextConvert(tt.tls, tt.sni, tt.meta); !reflect.DeepEqual(tt.expectTlsCtx, got) {
-				t.Errorf("%s: expected TLS ctx %v got %v", tt.desc, tt.expectTlsCtx, got)
+			if got := tlsContextConvert(tt.tls, tt.sni, tt.meta); !reflect.DeepEqual(tt.expectTLSCtx, got) {
+				t.Errorf("%s: expected TLS ctx %v got %v", tt.desc, tt.expectTLSCtx, got)
 			}
 		})
 	}


### PR DESCRIPTION
[X ] Networking
[X ] Security

This PR adds tests to the TLS context converter. The three modes for TLS here are simple, mutual, and istio mutual, and this PR adds tests for all of them.