### PR TITLE
Fix #24291

### DIFF
--- a/operator/pkg/util/path.go
+++ b/operator/pkg/util/path.go
@@ -125,7 +125,7 @@ func IsNPathElement(pe string) bool {
 	}
 
 	n, err := strconv.Atoi(pe)
-	return err == nil && n >= InsertIndex
+	return err == nil && n > InsertIndex
 }
 
 // PathKV returns the key and value string parts of the entire key/value path element.

--- a/operator/pkg/util/path_test.go
+++ b/operator/pkg/util/path_test.go
@@ -65,9 +65,9 @@ func TestSplitEscaped(t *testing.T) {
 }
 
 func TestIsNPathElement(t *testing.T) {
-	tests := []struct{
-		desc string
-		in string
+	tests := []struct {
+		desc   string
+		in     string
 		expect bool
 	}{
 		{
@@ -76,18 +76,18 @@ func TestIsNPathElement(t *testing.T) {
 			expect: false,
 		},
 		{
-			desc: "negative",
-			in: "[-45]",
+			desc:   "negative",
+			in:     "[-45]",
 			expect: false,
 		},
 		{
-			desc: "negative-1",
-			in: "[-1]",
+			desc:   "negative-1",
+			in:     "[-1]",
 			expect: false,
 		},
 		{
-			desc: "valid",
-			in: "[0]",
+			desc:   "valid",
+			in:     "[0]",
 			expect: true,
 		},
 	}

--- a/operator/pkg/util/path_test.go
+++ b/operator/pkg/util/path_test.go
@@ -64,6 +64,43 @@ func TestSplitEscaped(t *testing.T) {
 	}
 }
 
+func TestIsNPathElement(t *testing.T) {
+	tests := []struct{
+		desc string
+		in string
+		expect bool
+	}{
+		{
+			desc:   "empty",
+			in:     "",
+			expect: false,
+		},
+		{
+			desc: "negative",
+			in: "[-45]",
+			expect: false,
+		},
+		{
+			desc: "negative-1",
+			in: "[-1]",
+			expect: false,
+		},
+		{
+			desc: "valid",
+			in: "[0]",
+			expect: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			if got := IsNPathElement(tt.in); got != tt.expect {
+				t.Errorf("%s: expect %v got %v", tt.desc, tt.expect, got)
+			}
+		})
+	}
+}
+
 func stringSlicesEqual(a, b []string) bool {
 	if len(a) != len(b) {
 		return false


### PR DESCRIPTION


[X ] Configuration Infrastructure

Fixes #24291. It turns out, -1 was being returned as a valid, index, and when there was a list access on -1, the program panicked.

This:
Fixes that bug. (simple > vs >= )
Adds unit tests for that case. More work will need to be done in this area as for unit testing, this could have easily been avoided and there is a huge gap in operator unit tests. 