### PR TITLE
eds: do not update service shards for service entries

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -193,6 +193,8 @@ func (s *DiscoveryServer) Register(rpcs *grpc.Server) {
 
 func (s *DiscoveryServer) Start(stopCh <-chan struct{}) {
 	adsLog.Infof("Starting ADS server")
+	// Initialize non-k8s registries so that they can be used
+	// for updating service shards during push.
 	s.initNonK8sRegistries()
 	go s.handleUpdates(stopCh)
 	go s.periodicRefreshMetrics(stopCh)
@@ -200,7 +202,6 @@ func (s *DiscoveryServer) Start(stopCh <-chan struct{}) {
 }
 
 func (s *DiscoveryServer) initNonK8sRegistries() {
-	// Initialize non-k8s registries so that they can be used for updating service shards during push.
 	var registries []serviceregistry.Instance
 	if agg, ok := s.Env.ServiceDiscovery.(*aggregate.Controller); ok {
 		registries = agg.GetRegistries()

--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -214,7 +214,7 @@ func (s *DiscoveryServer) initNonK8sRegistries() {
 	}
 
 	for _, registry := range registries {
-		if registry.Provider() != serviceregistry.Kubernetes {
+		if registry.Provider() != serviceregistry.Kubernetes || registry.Provider() != serviceregistry.External {
 			s.nonK8sRegistries = append(s.nonK8sRegistries, registry)
 		}
 	}

--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -125,8 +125,8 @@ type DiscoveryServer struct {
 
 	InternalGen *InternalGen
 
-	// nonK8sRegistries are registries that need endpoint reconcilation during push.
-	// Kubernetes and Service Entries does not need special reconcilation.
+	// nonK8sRegistries are registries that need endpoint update during push.
+	// Kubernetes and Service Entries does not need special treatment.
 	nonK8sRegistries []serviceregistry.Instance
 }
 

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -102,7 +102,7 @@ func (s *DiscoveryServer) UpdateServiceShards(push *model.PushContext) error {
 	// Each registry acts as a shard - we don't want to combine them because some
 	// may individually update their endpoints incrementally
 	for _, svc := range push.Services(nil) {
-		for _, registry := range s.nonK8sRegistries {
+		for _, registry := range s.getNonK8sRegistries() {
 			// skip the service in case this svc does not belong to the registry.
 			if svc.Attributes.ServiceRegistry != string(registry.Provider()) {
 				continue

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -30,8 +30,6 @@ import (
 	networking "istio.io/istio/pilot/pkg/networking/core/v1alpha3"
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/loadbalancer"
 	"istio.io/istio/pilot/pkg/networking/util"
-	"istio.io/istio/pilot/pkg/serviceregistry"
-	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	"istio.io/istio/pilot/pkg/util/sets"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
@@ -101,28 +99,10 @@ func buildEnvoyLbEndpoint(e *model.IstioEndpoint, push *model.PushContext) *endp
 // it with a model where DiscoveryServer keeps track of all endpoint registries
 // directly, and calls them one by one.
 func (s *DiscoveryServer) UpdateServiceShards(push *model.PushContext) error {
-	var registries []serviceregistry.Instance
-	var nonK8sRegistries []serviceregistry.Instance
-	if agg, ok := s.Env.ServiceDiscovery.(*aggregate.Controller); ok {
-		registries = agg.GetRegistries()
-	} else {
-		registries = []serviceregistry.Instance{
-			serviceregistry.Simple{
-				ServiceDiscovery: s.Env.ServiceDiscovery,
-			},
-		}
-	}
-
-	for _, registry := range registries {
-		if registry.Provider() != serviceregistry.Kubernetes {
-			nonK8sRegistries = append(nonK8sRegistries, registry)
-		}
-	}
-
 	// Each registry acts as a shard - we don't want to combine them because some
 	// may individually update their endpoints incrementally
 	for _, svc := range push.Services(nil) {
-		for _, registry := range nonK8sRegistries {
+		for _, registry := range s.nonK8sRegistries {
 			// skip the service in case this svc does not belong to the registry.
 			if svc.Attributes.ServiceRegistry != string(registry.Provider()) {
 				continue


### PR DESCRIPTION
Currently `UpdateServiceShards` is being executed for Service Entries also which I think is not needed unless I am missing some thing. This PR fixes it ~~and also moves the logic to identify registries to `DiscoveryServer` initialization so that it is done only once~~. Looks like some tests add registry dynamically after server is initialized.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
