### PR TITLE
eds: move split horizon test to v3

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/ads_test.go
+++ b/pilot/pkg/proxy/envoy/v2/ads_test.go
@@ -306,7 +306,7 @@ func TestAdsClusterUpdate(t *testing.T) {
 			t.Errorf("Expecting %v got %v", v3.EndpointType, res.Resources[0].TypeUrl)
 		}
 
-		cla, err := getLoadAssignment(res)
+		cla, err := getLoadAssignmentV2(res)
 		if err != nil {
 			t.Fatal("Invalid EDS response ", err)
 		}
@@ -755,7 +755,7 @@ func TestAdsUpdate(t *testing.T) {
 	if res1.Resources[0].TypeUrl != v3.EndpointType {
 		t.Errorf("Expecting %v got %v", v3.EndpointType, res1.Resources[0].TypeUrl)
 	}
-	cla, err := getLoadAssignment(res1)
+	cla, err := getLoadAssignmentV2(res1)
 	if err != nil {
 		t.Fatal("Invalid EDS response ", err)
 	}
@@ -790,7 +790,7 @@ func TestAdsUpdate(t *testing.T) {
 	if res1.Resources[0].TypeUrl != v3.EndpointType {
 		t.Errorf("Expecting %v got %v", v3.EndpointType, res1.Resources[0].TypeUrl)
 	}
-	_, err = getLoadAssignment(res1)
+	_, err = getLoadAssignmentV2(res1)
 	if err != nil {
 		t.Fatal("Invalid EDS response ", err)
 	}

--- a/pilot/pkg/proxy/envoy/v2/eds_sh_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_sh_test.go
@@ -18,10 +18,9 @@ import (
 	"testing"
 	"time"
 
-	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	corev2 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
-	ads "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -162,7 +161,7 @@ func TestSplitHorizonEds(t *testing.T) {
 // Tests whether an EDS response from the provided network matches the expected results
 func verifySplitHorizonResponse(t *testing.T, network string, sidecarID string, expected expectedResults) {
 	t.Helper()
-	edsstr, cancel, err := connectADS(util.MockPilotGrpcAddr)
+	edsstr, cancel, err := connectADSV3(util.MockPilotGrpcAddr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -177,7 +176,7 @@ func verifySplitHorizonResponse(t *testing.T, network string, sidecarID string, 
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = adsReceive(edsstr, 5*time.Second)
+	_, err = adsReceiveV3(edsstr, 5*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -186,7 +185,7 @@ func verifySplitHorizonResponse(t *testing.T, network string, sidecarID string, 
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := adsReceive(edsstr, 5*time.Second)
+	res, err := adsReceiveV3(edsstr, 5*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -310,10 +309,10 @@ func initRegistry(server *bootstrap.Server, clusterNum int, gatewaysIP []string,
 	memRegistry.SetEndpoints("service5.default.svc.cluster.local", "default", istioEndpoints)
 }
 
-func sendCDSReqWithMetadata(node string, metadata *structpb.Struct, edsstr ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient) error {
-	err := edsstr.Send(&xdsapi.DiscoveryRequest{
+func sendCDSReqWithMetadata(node string, metadata *structpb.Struct, edsstr discovery.AggregatedDiscoveryService_StreamAggregatedResourcesClient) error {
+	err := edsstr.Send(&discovery.DiscoveryRequest{
 		ResponseNonce: time.Now().String(),
-		Node: &corev2.Node{
+		Node: &core.Node{
 			Id:       node,
 			Metadata: metadata,
 		},
@@ -326,10 +325,10 @@ func sendCDSReqWithMetadata(node string, metadata *structpb.Struct, edsstr ads.A
 }
 
 func sendEDSReqWithMetadata(clusters []string, node string, metadata *structpb.Struct,
-	edsstr ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient) error {
-	err := edsstr.Send(&xdsapi.DiscoveryRequest{
+	edsstr discovery.AggregatedDiscoveryService_StreamAggregatedResourcesClient) error {
+	err := edsstr.Send(&discovery.DiscoveryRequest{
 		ResponseNonce: time.Now().String(),
-		Node: &corev2.Node{
+		Node: &core.Node{
 			Id:       node,
 			Metadata: metadata,
 		},

--- a/pilot/pkg/proxy/envoy/v2/init_test.go
+++ b/pilot/pkg/proxy/envoy/v2/init_test.go
@@ -48,7 +48,22 @@ var nodeMetadata = &structpb.Struct{Fields: map[string]*structpb.Value{
 }}
 
 // Extract cluster load assignment from a discovery response.
-func getLoadAssignment(res1 *xdsapi.DiscoveryResponse) (*endpoint.ClusterLoadAssignment, error) {
+func getLoadAssignmentV2(res1 *xdsapi.DiscoveryResponse) (*endpoint.ClusterLoadAssignment, error) {
+	if res1.TypeUrl != v3.EndpointType {
+		return nil, errors.New("Invalid typeURL" + res1.TypeUrl)
+	}
+	if res1.Resources[0].TypeUrl != v3.EndpointType {
+		return nil, errors.New("Invalid resource typeURL" + res1.Resources[0].TypeUrl)
+	}
+	cla := &endpoint.ClusterLoadAssignment{}
+	err := ptypes.UnmarshalAny(res1.Resources[0], cla)
+	if err != nil {
+		return nil, err
+	}
+	return cla, nil
+}
+
+func getLoadAssignment(res1 *discovery.DiscoveryResponse) (*endpoint.ClusterLoadAssignment, error) {
 	if res1.TypeUrl != v3.EndpointType {
 		return nil, errors.New("Invalid typeURL" + res1.TypeUrl)
 	}


### PR DESCRIPTION
Moves split horizon test to v3

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
