### PR TITLE
remove reflect deep equal in endpoint comparison

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -424,7 +424,7 @@ func (c *Controller) onNodeEvent(obj interface{}, event model.Event) error {
 		// check if the node exists as this add event could be due to controller resync
 		// if the stored object changes, then fire an update event. Otherwise, ignore this event.
 		currentNode, exists := c.nodeInfoMap[node.Name]
-		if !exists || !reflect.DeepEqual(currentNode, k8sNode) {
+		if !exists || !nodeEquals(currentNode, k8sNode) {
 			c.nodeInfoMap[node.Name] = k8sNode
 			updatedNeeded = true
 		}
@@ -438,6 +438,10 @@ func (c *Controller) onNodeEvent(obj interface{}, event model.Event) error {
 		})
 	}
 	return nil
+}
+
+func nodeEquals(a, b kubernetesNode) bool {
+	return a.address == b.address && a.labels.Equals(b.labels)
 }
 
 func isNodePortGatewayService(svc *v1.Service) bool {
@@ -483,14 +487,51 @@ func compareEndpoints(a, b *v1.Endpoints) bool {
 		return false
 	}
 	for i := range a.Subsets {
-		if !reflect.DeepEqual(a.Subsets[i].Ports, b.Subsets[i].Ports) {
+		if !portsEqual(a.Subsets[i].Ports, b.Subsets[i].Ports) {
 			return false
 		}
-		if !reflect.DeepEqual(a.Subsets[i].Addresses, b.Subsets[i].Addresses) {
+		if !addressesEqual(a.Subsets[i].Addresses, b.Subsets[i].Addresses) {
 			return false
 		}
 	}
 	return true
+}
+
+func portsEqual(a, b []v1.EndpointPort) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i].Name != b[i].Name || a[i].Port != b[i].Port || a[i].Protocol != b[i].Protocol ||
+			ptrValueOrDefault(a[i].AppProtocol, "") != ptrValueOrDefault(b[i].AppProtocol, "") {
+			return false
+		}
+	}
+
+	return true
+}
+
+func addressesEqual(a, b []v1.EndpointAddress) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i].IP != b[i].IP || a[i].Hostname != b[i].Hostname ||
+			ptrValueOrDefault(a[i].NodeName, "") != ptrValueOrDefault(b[i].NodeName, "") {
+			return false
+		}
+	}
+
+	return true
+}
+
+func ptrValueOrDefault(ptr *string, def string) string {
+	if ptr != nil {
+		return *ptr
+	}
+	return def
 }
 
 // HasSynced returns true after the initial state synchronization

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -504,7 +504,7 @@ func portsEqual(a, b []v1.EndpointPort) bool {
 
 	for i := range a {
 		if a[i].Name != b[i].Name || a[i].Port != b[i].Port || a[i].Protocol != b[i].Protocol ||
-			ptrValueOrDefault(a[i].AppProtocol, "") != ptrValueOrDefault(b[i].AppProtocol, "") {
+			ptrValueOrEmpty(a[i].AppProtocol) != ptrValueOrEmpty(b[i].AppProtocol) {
 			return false
 		}
 	}
@@ -519,7 +519,7 @@ func addressesEqual(a, b []v1.EndpointAddress) bool {
 
 	for i := range a {
 		if a[i].IP != b[i].IP || a[i].Hostname != b[i].Hostname ||
-			ptrValueOrDefault(a[i].NodeName, "") != ptrValueOrDefault(b[i].NodeName, "") {
+			ptrValueOrEmpty(a[i].NodeName) != ptrValueOrEmpty(b[i].NodeName) {
 			return false
 		}
 	}
@@ -527,11 +527,11 @@ func addressesEqual(a, b []v1.EndpointAddress) bool {
 	return true
 }
 
-func ptrValueOrDefault(ptr *string, def string) string {
+func ptrValueOrEmpty(ptr *string) string {
 	if ptr != nil {
 		return *ptr
 	}
-	return def
+	return ""
 }
 
 // HasSynced returns true after the initial state synchronization

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -1200,6 +1200,10 @@ func TestCompareEndpoints(t *testing.T) {
 	addressB := coreV1.EndpointAddress{IP: "1.2.3.4", Hostname: "b"}
 	portA := coreV1.EndpointPort{Name: "a"}
 	portB := coreV1.EndpointPort{Name: "b"}
+	appProtocolA := "http"
+	appProtocolB := "tcp"
+	appProtocolPortA := coreV1.EndpointPort{Name: "a", AppProtocol: &appProtocolA}
+	appProtocolPortB := coreV1.EndpointPort{Name: "a", AppProtocol: &appProtocolB}
 	cases := []struct {
 		name string
 		a    *coreV1.Endpoints
@@ -1255,6 +1259,26 @@ func TestCompareEndpoints(t *testing.T) {
 			}},
 			&coreV1.Endpoints{Subsets: []coreV1.EndpointSubset{
 				{Addresses: []coreV1.EndpointAddress{addressA}, Ports: []coreV1.EndpointPort{portB}},
+			}},
+			false,
+		},
+		{
+			"same app protocol",
+			&coreV1.Endpoints{Subsets: []coreV1.EndpointSubset{
+				{Addresses: []coreV1.EndpointAddress{addressA}, Ports: []coreV1.EndpointPort{appProtocolPortA}},
+			}},
+			&coreV1.Endpoints{Subsets: []coreV1.EndpointSubset{
+				{Addresses: []coreV1.EndpointAddress{addressA}, Ports: []coreV1.EndpointPort{appProtocolPortA}},
+			}},
+			true,
+		},
+		{
+			"different app protocol",
+			&coreV1.Endpoints{Subsets: []coreV1.EndpointSubset{
+				{Addresses: []coreV1.EndpointAddress{addressA}, Ports: []coreV1.EndpointPort{appProtocolPortA}},
+			}},
+			&coreV1.Endpoints{Subsets: []coreV1.EndpointSubset{
+				{Addresses: []coreV1.EndpointAddress{addressA}, Ports: []coreV1.EndpointPort{appProtocolPortB}},
 			}},
 			false,
 		},


### PR DESCRIPTION
Removes `reflect.DeepEqual` in frequently used endpoint comparison

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
