### PR TITLE
[release-1.6] Apply proxyMetadata to Prometheus sidecar

### DIFF
--- a/manifests/charts/global.yaml
+++ b/manifests/charts/global.yaml
@@ -563,6 +563,7 @@ version: ""
 meshConfig:
   enablePrometheusMerge: false
   defaultConfig:
+    proxyMetadata: {}
     tracing:
       tlsSettings:
         mode: DISABLE # DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL

--- a/manifests/charts/istio-telemetry/prometheus/templates/deployment.yaml
+++ b/manifests/charts/istio-telemetry/prometheus/templates/deployment.yaml
@@ -139,6 +139,10 @@ spec:
               {{- end }}
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ .Values.global.multiCluster.clusterName | default `Kubernetes` }}"
+            {{- range $key, $value := .Values.meshConfig.defaultConfig.proxyMetadata }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+            {{- end }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy | default "Always" }}
           readinessProbe:
             failureThreshold: 30

--- a/manifests/profiles/default.yaml
+++ b/manifests/profiles/default.yaml
@@ -8,6 +8,8 @@ spec:
 
   # You may override parts of meshconfig by uncommenting the following lines.
   meshConfig:
+    defaultConfig:
+      proxyMetadata: {}
     enablePrometheusMerge: false
     # Opt-out of global http2 upgrades.
     # Destination rule is used to opt-in.


### PR DESCRIPTION

This is a cherry-pick of https://github.com/istio/istio/pull/24415

[ ] Configuration Infrastructure
[ ] Docs
[ X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure