### PR TITLE
More detailed output and sorted output for "istioctl pc listeners"

### DIFF
--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -42,6 +42,7 @@ const (
 var (
 	fqdn, direction, subset string
 	port                    int
+	verboseListener         bool
 
 	address, listenerType string
 
@@ -382,6 +383,7 @@ func proxyConfig() *cobra.Command {
 				Address: address,
 				Port:    uint32(port),
 				Type:    listenerType,
+				Verbose: verboseListener,
 			}
 
 			switch outputFormat {
@@ -398,6 +400,7 @@ func proxyConfig() *cobra.Command {
 	listenerConfigCmd.PersistentFlags().StringVar(&address, "address", "", "Filter listeners by address field")
 	listenerConfigCmd.PersistentFlags().StringVar(&listenerType, "type", "", "Filter listeners by type field")
 	listenerConfigCmd.PersistentFlags().IntVar(&port, "port", 0, "Filter listeners by Port field")
+	listenerConfigCmd.PersistentFlags().BoolVar(&verboseListener, "verbose", false, "Output filter chain information")
 	listenerConfigCmd.PersistentFlags().StringVarP(&configDumpFile, "file", "f", "",
 		"Envoy config dump JSON file")
 

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -400,7 +400,7 @@ func proxyConfig() *cobra.Command {
 	listenerConfigCmd.PersistentFlags().StringVar(&address, "address", "", "Filter listeners by address field")
 	listenerConfigCmd.PersistentFlags().StringVar(&listenerType, "type", "", "Filter listeners by type field")
 	listenerConfigCmd.PersistentFlags().IntVar(&port, "port", 0, "Filter listeners by Port field")
-	listenerConfigCmd.PersistentFlags().BoolVar(&verboseListener, "verbose", false, "Output filter chain information")
+	listenerConfigCmd.PersistentFlags().BoolVar(&verboseListener, "verbose", true, "Output filter chain information")
 	listenerConfigCmd.PersistentFlags().StringVarP(&configDumpFile, "file", "f", "",
 		"Envoy config dump JSON file")
 

--- a/istioctl/pkg/writer/envoy/configdump/listener.go
+++ b/istioctl/pkg/writer/envoy/configdump/listener.go
@@ -304,7 +304,7 @@ func describeMatch(match *route.RouteMatch) string {
 		conds = append(conds, fmt.Sprintf("%s*", match.GetPrefix()))
 	}
 	if match.GetPath() != "" {
-		conds = append(conds, fmt.Sprintf("path %s", match.GetPath()))
+		conds = append(conds, match.GetPath())
 	}
 	if match.GetSafeRegex() != nil {
 		conds = append(conds, fmt.Sprintf("regex %s", match.GetSafeRegex().String()))


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/24353

Each line is still wider than I want.

This is based on @howardjohn 's https://github.com/howardjohn/istio/blob/istioctl/listener-filterchains/istioctl/pkg/writer/envoy/configdump/listener.go .  Minor improvements:
- works with both v2 and v3 listeners
- output sorted by port and address
- MATCH column slightly more terse
- Default is `--verbose==true`

The output, on my system, is 

```
ADDRESS        PORT  MATCH                                                           DESTINATION
172.21.0.10    53    ALL                                                             outbound|53||kube-dns.kube-system.svc.cluster.local
172.21.186.46  53    ALL                                                             outbound|53||node-local-dns.kube-system.svc.cluster.local
0.0.0.0        80    ALL                                                             PassthroughCluster
0.0.0.0        80    App: HTTP                                                       80
172.21.0.1     443   ALL                                                             outbound|443||kubernetes.default.svc.cluster.local
172.21.0.219   443   ALL                                                             outbound|443||kubernetes-dashboard.kube-system.svc.cluster.local
172.21.0.219   443   App: HTTP                                                       kubernetes-dashboard.kube-system.svc.cluster.local:443
172.21.140.44  443   ALL                                                             outbound|443||istio-ingressgateway.istio-system.svc.cluster.local
172.21.187.110 443   ALL                                                             outbound|443||istiod.istio-system.svc.cluster.local
172.21.187.210 443   ALL                                                             outbound|443||public-crbq8cb78d0ojqtbm78ucg-alb1.kube-system.svc.cluster.local
172.21.232.71  443   ALL                                                             outbound|443||metrics-server.kube-system.svc.cluster.local
172.21.232.71  443   App: HTTP                                                       metrics-server.kube-system.svc.cluster.local:443
172.21.187.110 853   ALL                                                             outbound|853||istiod.istio-system.svc.cluster.local
172.21.187.110 853   App: HTTP                                                       istiod.istio-system.svc.cluster.local:853
0.0.0.0        8000  ALL                                                             PassthroughCluster
0.0.0.0        8000  App: HTTP                                                       8000
172.21.51.85   8000  ALL                                                             outbound|8000||dashboard-metrics-scraper.kube-system.svc.cluster.local
172.21.51.85   8000  App: HTTP                                                       dashboard-metrics-scraper.kube-system.svc.cluster.local:8000
0.0.0.0        8081  ALL                                                             PassthroughCluster
0.0.0.0        8081  App: HTTP                                                       8081
172.21.97.106  8081  ALL                                                             outbound|8081||catalog-operator-metrics.ibm-system.svc.cluster.local
0.0.0.0        9080  ALL                                                             PassthroughCluster
0.0.0.0        9080  App: HTTP                                                       9080
0.0.0.0        9090  ALL                                                             PassthroughCluster
0.0.0.0        9090  App: HTTP                                                       9090
172.21.0.10    9153  ALL                                                             outbound|9153||kube-dns.kube-system.svc.cluster.local
172.21.0.10    9153  App: HTTP                                                       kube-dns.kube-system.svc.cluster.local:9153
0.0.0.0        15001 ALL                                                             PassthroughCluster
0.0.0.0        15006 Addr: 172.30.206.207/32:15021                                   inbound|15021|mgmt-15021|mgmtCluster
0.0.0.0        15006 Addr: fe80::3c85:9dff:fe24:4c3d/128:9080                        Inline Route
0.0.0.0        15006 Addr: 172.30.206.207/32:9080                                    Inline Route
0.0.0.0        15006 App: Istio HTTP Plain; Addr: 172.30.206.207/32:9080             Inline Route
0.0.0.0        15006 Trans: tls; App: HTTP TLS; Addr: 0.0.0.0/0                      Inline Route
0.0.0.0        15006 App: HTTP; Addr: 0.0.0.0/0                                      Inline Route
0.0.0.0        15006 Trans: tls; App: HTTP TLS; Addr: ::0/0                          Inline Route
0.0.0.0        15006 App: HTTP; Addr: ::0/0                                          Inline Route
0.0.0.0        15006 App: Istio HTTP Plain; Addr: fe80::3c85:9dff:fe24:4c3d/128:9080 Inline Route
0.0.0.0        15006 Addr: ::0/0                                                     InboundPassthroughClusterIpv6
0.0.0.0        15006 Trans: tls; App: TCP TLS; Addr: ::0/0                           InboundPassthroughClusterIpv6
0.0.0.0        15006 Addr: 0.0.0.0/0                                                 InboundPassthroughClusterIpv4
0.0.0.0        15006 Trans: tls; App: TCP TLS; Addr: 0.0.0.0/0                       InboundPassthroughClusterIpv4
0.0.0.0        15010 ALL                                                             PassthroughCluster
0.0.0.0        15010 App: HTTP                                                       15010
172.21.187.110 15012 ALL                                                             outbound|15012||istiod.istio-system.svc.cluster.local
0.0.0.0        15014 ALL                                                             PassthroughCluster
0.0.0.0        15014 App: HTTP                                                       15014
0.0.0.0        15021 ALL                                                             Inline Route
172.21.140.44  15021 ALL                                                             outbound|15021||istio-ingressgateway.istio-system.svc.cluster.local
172.21.140.44  15021 App: HTTP                                                       istio-ingressgateway.istio-system.svc.cluster.local:15021
0.0.0.0        15090 ALL                                                             Inline Route
172.21.140.44  15443 ALL                                                             outbound|15443||istio-ingressgateway.istio-system.svc.cluster.local
0.0.0.0        50051 ALL                                                             PassthroughCluster
0.0.0.0        50051 App: HTTP                                                       50051
```