### PR TITLE
test framework: use proto structs to manipulate iop yaml

### DIFF
--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -30,9 +30,10 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 
+	kubeApiMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	meshAPI "istio.io/api/mesh/v1alpha1"
 	pkgAPI "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
-	kubeApiMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/istio/pilot/pkg/leaderelection"
 	"istio.io/istio/pkg/test/cert/ca"

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -24,28 +24,28 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
-	"strings"
 	"time"
 
-	kubeApiMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"istio.io/istio/operator/pkg/util"
-	"istio.io/istio/pilot/pkg/leaderelection"
-	kube2 "istio.io/istio/pkg/test/kube"
-
-	"istio.io/api/mesh/v1alpha1"
+	"gopkg.in/yaml.v2"
 
 	"github.com/hashicorp/go-multierror"
 
+	meshAPI "istio.io/api/mesh/v1alpha1"
+	pkgAPI "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
+	kubeApiMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"istio.io/istio/pilot/pkg/leaderelection"
 	"istio.io/istio/pkg/test/cert/ca"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/istioctl"
 	"istio.io/istio/pkg/test/framework/image"
 	"istio.io/istio/pkg/test/framework/resource"
+	kube2 "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/test/util/yml"
+	"istio.io/istio/pkg/util/protomarshal"
 )
 
 // TODO: dynamically generate meshID to support multi-tenancy tests
@@ -237,14 +237,56 @@ func deploy(ctx resource.Context, env *kube.Environment, cfg Config) (Instance, 
 	return i, nil
 }
 
-func initIOPFile(cfg Config, env *kube.Environment, iopFile string, values string) error {
-	operatorYaml := cfg.IstioOperatorConfigYAML(values)
-	if env.IsMultinetwork() {
-		meshNetworksYaml := meshNetworkSettings(cfg, env)
-		operatorYaml += Indent("global:\n", "    ")
-		operatorYaml += Indent(meshNetworksYaml, "      ")
+func initIOPFile(cfg Config, env *kube.Environment, iopFile string, valuesYaml string) error {
+	operatorYaml := cfg.IstioOperatorConfigYAML(valuesYaml)
+
+	operatorCfg := &pkgAPI.IstioOperator{}
+	if err := protomarshal.ApplyYAML(operatorYaml, operatorCfg); err != nil {
+		return fmt.Errorf("failed to unmsarshal base iop: %v", err)
 	}
-	if err := ioutil.WriteFile(iopFile, []byte(operatorYaml), os.ModePerm); err != nil {
+	var values = &pkgAPI.Values{}
+	if operatorCfg.Spec.Values != nil {
+		valuesYml, err := yaml.Marshal(operatorCfg.Spec.Values)
+		if err != nil {
+			return fmt.Errorf("failed to marshal base values: %v", err)
+		}
+		if err := protomarshal.ApplyYAML(string(valuesYml), values); err != nil {
+			return fmt.Errorf("failed to unmsarshal base values: %v", err)
+		}
+	}
+
+	if env.IsMultinetwork() {
+		if values.Global == nil {
+			values.Global = &pkgAPI.GlobalConfig{}
+		}
+		if values.Global.MeshNetworks == nil {
+			meshNetworks, err := protomarshal.ToJSONMap(meshNetworkSettings(cfg, env))
+			if err != nil {
+				return fmt.Errorf("failed to convert meshNetworks: %v", err)
+			}
+			values.Global.MeshNetworks = meshNetworks["networks"].(map[string]interface{})
+		}
+	}
+
+	valuesMap, err := protomarshal.ToJSONMap(values)
+	if err != nil {
+		return fmt.Errorf("failed to convert values to json map: %v", err)
+	}
+	operatorCfg.Spec.Values = valuesMap
+
+	// marshaling entire operatorCfg causes panic because of *time.Time in ObjectMeta
+	out, err := protomarshal.ToYAML(operatorCfg.Spec)
+	if err != nil {
+		return fmt.Errorf("failed marshaling iop spec: %v", err)
+	}
+
+	out = fmt.Sprintf(`
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+%s`, Indent(out, "  "))
+
+	if err := ioutil.WriteFile(iopFile, []byte(out), os.ModePerm); err != nil {
 		return fmt.Errorf("failed to write iop: %v", err)
 	}
 
@@ -363,30 +405,31 @@ func deployControlPlane(c *operatorComponent, cfg Config, cluster kube.Cluster, 
 
 // meshNetworkSettings builds the values for meshNetworks with an endpoint in each network per-cluster.
 // Assumes that the registry service is always istio-ingressgateway.
-func meshNetworkSettings(cfg Config, environment *kube.Environment) string {
-	meshNetworks := v1alpha1.MeshNetworks{Networks: make(map[string]*v1alpha1.Network)}
-	defaultGateways := []*v1alpha1.Network_IstioNetworkGateway{{
-		Gw: &v1alpha1.Network_IstioNetworkGateway_RegistryServiceName{
+func meshNetworkSettings(cfg Config, environment *kube.Environment) *meshAPI.MeshNetworks {
+	meshNetworks := meshAPI.MeshNetworks{Networks: make(map[string]*meshAPI.Network)}
+	defaultGateways := []*meshAPI.Network_IstioNetworkGateway{{
+		Gw: &meshAPI.Network_IstioNetworkGateway_RegistryServiceName{
 			RegistryServiceName: "istio-ingressgateway." + cfg.IngressNamespace + ".svc.cluster.local",
 		},
 		Port: 443,
 	}}
 
 	for networkName, clusters := range environment.ClustersByNetwork() {
-		network := &v1alpha1.Network{
-			Endpoints: make([]*v1alpha1.Network_NetworkEndpoints, len(clusters)),
+		network := &meshAPI.Network{
+			Endpoints: make([]*meshAPI.Network_NetworkEndpoints, len(clusters)),
 			Gateways:  defaultGateways,
 		}
 		for i, cluster := range clusters {
-			network.Endpoints[i] = &v1alpha1.Network_NetworkEndpoints{
-				Ne: &v1alpha1.Network_NetworkEndpoints_FromRegistry{
+			network.Endpoints[i] = &meshAPI.Network_NetworkEndpoints{
+				Ne: &meshAPI.Network_NetworkEndpoints_FromRegistry{
 					FromRegistry: cluster.Name(),
 				},
 			}
 		}
 		meshNetworks.Networks[networkName] = network
 	}
-	return strings.Replace(util.ToYAMLWithJSONPB(&meshNetworks), "networks:", "meshNetworks:", 1)
+
+	return &meshNetworks
 }
 
 func waitForControlPlane(dumper resource.Dumper, cluster kube.Cluster, cfg Config) error {


### PR DESCRIPTION
Currently using string manipulation to setup meshNetworks in integration tests. This changes things to use the generated structs for all manipulation until we write the iop file. 

This fragility causes yaml like [this](https://storage.googleapis.com/istio-prow/pr-logs/pull/istio_istio/24549/integ-multicluster-k8s-tests_istio/4360/artifacts/pilot-test-583455f754f1466a9b89/_suite_context/istio-deployment-769424605/iop.yaml) to be generated. 

If we were to try to run [pilot/meshnetwork tests](https://github.com/istio/istio/blob/master/tests/integration/pilot/meshnetwork/main_test.go) they would break with conflicts in meshNetworks. 

This makes things generally less fragile and users of the framework can be more comfortable setting values via ControlPlaneValues without the test framework breaking it. 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
