### PR TITLE
Remove extraneous Send failure logs

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/cds.go
+++ b/pilot/pkg/proxy/envoy/v2/cds.go
@@ -59,8 +59,7 @@ func (s *DiscoveryServer) pushCds(con *XdsConnection, push *model.PushContext, v
 	err := con.send(response)
 	cdsPushTime.Record(time.Since(pushStart).Seconds())
 	if err != nil {
-		adsLog.Warnf("CDS: Send failure %s: %v", con.ConID, err)
-		recordSendError(cdsSendErrPushes, err)
+		recordSendError("CDS", con.ConID, cdsSendErrPushes, err)
 		return err
 	}
 	cdsPushes.Increment()

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -447,8 +447,7 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection, v
 	err := con.send(response)
 	edsPushTime.Record(time.Since(pushStart).Seconds())
 	if err != nil {
-		adsLog.Warnf("EDS: Send failure %s: %v", con.ConID, err)
-		recordSendError(edsSendErrPushes, err)
+		recordSendError("EDS", con.ConID, edsSendErrPushes, err)
 		return err
 	}
 	edsPushes.Increment()

--- a/pilot/pkg/proxy/envoy/v2/gen2.go
+++ b/pilot/pkg/proxy/envoy/v2/gen2.go
@@ -121,8 +121,7 @@ func (s *DiscoveryServer) handleCustomGenerator(con *XdsConnection, req *discove
 
 	err := con.send(resp)
 	if err != nil {
-		adsLog.Warnf("ADS: Send failure %s: %v", con.ConID, err)
-		recordSendError(apiSendErrPushes, err)
+		recordSendError("ADS", con.ConID, apiSendErrPushes, err)
 		return err
 	}
 	apiPushes.Increment()
@@ -167,8 +166,7 @@ func (s *DiscoveryServer) pushGeneratorV2(con *XdsConnection, push *model.PushCo
 
 	err := con.send(resp)
 	if err != nil {
-		adsLog.Warnf("ADS: Send failure %s %s: %v", w.TypeUrl, con.ConID, err)
-		recordSendError(apiSendErrPushes, err)
+		recordSendError("ADS", con.ConID, apiSendErrPushes, err)
 		return err
 	}
 	w.LastSent = time.Now()

--- a/pilot/pkg/proxy/envoy/v2/lds.go
+++ b/pilot/pkg/proxy/envoy/v2/lds.go
@@ -36,8 +36,7 @@ func (s *DiscoveryServer) pushLds(con *XdsConnection, push *model.PushContext, v
 	err := con.send(response)
 	ldsPushTime.Record(time.Since(pushStart).Seconds())
 	if err != nil {
-		adsLog.Warnf("LDS: Send failure %s: %v", con.ConID, err)
-		recordSendError(ldsSendErrPushes, err)
+		recordSendError("LDS", con.ConID, ldsSendErrPushes, err)
 		return err
 	}
 	ldsPushes.Increment()

--- a/pilot/pkg/proxy/envoy/v2/monitoring.go
+++ b/pilot/pkg/proxy/envoy/v2/monitoring.go
@@ -170,12 +170,13 @@ func recordPushTriggers(reasons ...model.TriggerReason) {
 	}
 }
 
-func recordSendError(metric monitoring.Metric, err error) {
+func recordSendError(xdsType string, conId string, metric monitoring.Metric, err error) {
 	s, ok := status.FromError(err)
 	// Unavailable or canceled code will be sent when a connection is closing down. This is very normal,
 	// due to the XDS connection being dropped every 30 minutes, or a pod shutting down.
 	isError := s.Code() != codes.Unavailable && s.Code() != codes.Canceled
 	if !ok || isError {
+		adsLog.Warnf("%s: Send failure %s: %v", xdsType, conId, err)
 		metric.Increment()
 	}
 }

--- a/pilot/pkg/proxy/envoy/v2/monitoring.go
+++ b/pilot/pkg/proxy/envoy/v2/monitoring.go
@@ -170,13 +170,13 @@ func recordPushTriggers(reasons ...model.TriggerReason) {
 	}
 }
 
-func recordSendError(xdsType string, conId string, metric monitoring.Metric, err error) {
+func recordSendError(xdsType string, conID string, metric monitoring.Metric, err error) {
 	s, ok := status.FromError(err)
 	// Unavailable or canceled code will be sent when a connection is closing down. This is very normal,
 	// due to the XDS connection being dropped every 30 minutes, or a pod shutting down.
 	isError := s.Code() != codes.Unavailable && s.Code() != codes.Canceled
 	if !ok || isError {
-		adsLog.Warnf("%s: Send failure %s: %v", xdsType, conId, err)
+		adsLog.Warnf("%s: Send failure %s: %v", xdsType, conID, err)
 		metric.Increment()
 	}
 }

--- a/pilot/pkg/proxy/envoy/v2/rds.go
+++ b/pilot/pkg/proxy/envoy/v2/rds.go
@@ -44,8 +44,7 @@ func (s *DiscoveryServer) pushRoute(con *XdsConnection, push *model.PushContext,
 	err := con.send(response)
 	rdsPushTime.Record(time.Since(pushStart).Seconds())
 	if err != nil {
-		adsLog.Warnf("RDS: Send failure for node:%v: %v", con.node.ID, err)
-		recordSendError(rdsSendErrPushes, err)
+		recordSendError("RDS", con.ConID, rdsSendErrPushes, err)
 		return err
 	}
 	rdsPushes.Increment()


### PR DESCRIPTION
We already filter these from metrics, should filter from logs as well.
This means the connection is disconnecting without errror; we already
log these at info levels so we aren't even losing any log info here just
reducing spam



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure