### PR TITLE
Disable spammy gRPC logs

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -17,12 +17,14 @@ package main
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"os"
 	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
+	"google.golang.org/grpc/grpclog"
 
 	"istio.io/istio/pkg/dns"
 
@@ -126,6 +128,7 @@ var (
 			if err := log.Configure(loggingOptions); err != nil {
 				return err
 			}
+			grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard))
 
 			// Extract pod variables.
 			podName := podNameVar.Get()

--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -16,11 +16,13 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
+	"google.golang.org/grpc/grpclog"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/pkg/collateral"
@@ -63,6 +65,7 @@ var (
 			if err := log.Configure(loggingOptions); err != nil {
 				return err
 			}
+			grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard))
 
 			spiffe.SetTrustDomain(spiffe.DetermineTrustDomain(serverArgs.Config.ControllerOptions.TrustDomain, hasKubeRegistry()))
 


### PR DESCRIPTION
Currently, on a connection failure to CA, we log messages like
```
2020-06-08T23:52:39.466564Z     info    Subchannel Connectivity change to CONNECTING
2020-06-08T23:52:39.466642Z     info    Subchannel picks a new address "localhost:15012" to connect
2020-06-08T23:52:39.466789Z     info    pickfirstBalancer: HandleSubConnStateChange: 0xc000a3a2f0, {CONNECTING <nil>}
2020-06-08T23:52:39.466860Z     info    Channel Connectivity change to CONNECTING
2020-06-08T23:52:39.468138Z     info    grpc: addrConn.createTransport failed to connect to {localhost:15012  <nil> 0 <nil>}. Err: connection error: desc = "transport: Error while dialing dial tcp [::1]:15012: connect: connection refused". Reconnecting...
2020-06-08T23:52:39.468194Z     info    Subchannel Connectivity change to TRANSIENT_FAILURE
2020-06-08T23:52:39.468321Z     info    pickfirstBalancer: HandleSubConnStateChange: 0xc000a3a2f0, {TRANSIENT_FAILURE connection error: desc = "transport: Error while dialing dial tcp [::1]:15012: connect: connection refused"}
2020-06-08T23:52:39.468359Z     info    Channel Connectivity change to TRANSIENT_FAILURE
2020-06-08T23:52:39.591539Z     warn    cache   resource:default request:4f4ac8af-b0a6-4c4d-a5b6-fb79881fa896 CSR failed with error: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp [::1]:15012: connect: connection refused", retry in 400 millisec
2020-06-08T23:52:39.591741Z     error   citadelclient   Failed to create certificate: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp [::1]:15012: connect: connection refused"
```
A few problems: there are 10 log lines for a single issue, and most of them have absolutely no context, nor are they good user faciung log messages. We already handle all gRPC level errors with our own contextual and user friendly(ish) errors, so we should just stick to those.