### PR TITLE
refactor: move pilot/security test dep out of mixer

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/eds_sh_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_sh_test.go
@@ -26,7 +26,6 @@ import (
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 
-	testenv "istio.io/istio/mixer/test/client/env"
 	"istio.io/istio/pilot/pkg/bootstrap"
 	"istio.io/istio/pilot/pkg/model"
 	v2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
@@ -225,7 +224,7 @@ func verifySplitHorizonResponse(t *testing.T, network string, sidecarID string, 
 func initSplitHorizonTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) {
 	initMutex.Lock()
 	defer initMutex.Unlock()
-	testEnv = testenv.NewTestSetup(testenv.XDSTest, t)
+	testEnv = env.NewTestSetup(env.XDSTest, t)
 	server, tearDown := util.EnsureTestServer()
 
 	testEnv.Ports().PilotGrpcPort = uint16(util.MockPilotGrpcPort)

--- a/pilot/pkg/proxy/envoy/v2/lds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/lds_test.go
@@ -30,7 +30,6 @@ import (
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/util/gogoprotomarshal"
 
-	testenv "istio.io/istio/mixer/test/client/env"
 	"istio.io/istio/pilot/pkg/bootstrap"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/adsc"
@@ -196,7 +195,7 @@ func TestLDSWithDefaultSidecar(t *testing.T) {
 		args.Mesh.ConfigFile = env.IstioSrc + "/tests/testdata/networking/sidecar-ns-scope/mesh.yaml"
 		args.Service.Registries = []string{}
 	})
-	testEnv = testenv.NewTestSetup(testenv.SidecarTest, t)
+	testEnv = env.NewTestSetup(env.SidecarTest, t)
 	testEnv.Ports().PilotGrpcPort = uint16(util.MockPilotGrpcPort)
 	testEnv.Ports().PilotHTTPPort = uint16(util.MockPilotHTTPPort)
 	testEnv.IstioSrc = env.IstioSrc
@@ -257,7 +256,7 @@ func TestLDSWithIngressGateway(t *testing.T) {
 		args.Mesh.ConfigFile = env.IstioSrc + "/tests/testdata/networking/ingress-gateway/mesh.yaml"
 		args.Service.Registries = []string{}
 	})
-	testEnv = testenv.NewTestSetup(testenv.GatewayTest, t)
+	testEnv = env.NewTestSetup(env.GatewayTest, t)
 	testEnv.Ports().PilotGrpcPort = uint16(util.MockPilotGrpcPort)
 	testEnv.Ports().PilotHTTPPort = uint16(util.MockPilotHTTPPort)
 	testEnv.IstioSrc = env.IstioSrc
@@ -381,7 +380,7 @@ func TestLDSWithSidecarForWorkloadWithoutService(t *testing.T) {
 	registry := memServiceDiscovery(server, t)
 	registry.AddWorkload("98.1.1.1", labels.Instance{"app": "consumeronly"}) // These labels must match the sidecars workload selector
 
-	testEnv = testenv.NewTestSetup(testenv.SidecarConsumerOnlyTest, t)
+	testEnv = env.NewTestSetup(env.SidecarConsumerOnlyTest, t)
 	testEnv.Ports().PilotGrpcPort = uint16(util.MockPilotGrpcPort)
 	testEnv.Ports().PilotHTTPPort = uint16(util.MockPilotHTTPPort)
 	testEnv.IstioSrc = env.IstioSrc
@@ -460,7 +459,7 @@ func TestLDSEnvoyFilterWithWorkloadSelector(t *testing.T) {
 	registry.AddWorkload("98.1.1.2", labels.Instance{"app": "no-envoyfilter-test-app"})
 	registry.AddWorkload("98.1.1.3", labels.Instance{})
 
-	testEnv = testenv.NewTestSetup(testenv.SidecarConsumerOnlyTest, t)
+	testEnv = env.NewTestSetup(env.SidecarConsumerOnlyTest, t)
 	testEnv.Ports().PilotGrpcPort = uint16(util.MockPilotGrpcPort)
 	testEnv.Ports().PilotHTTPPort = uint16(util.MockPilotHTTPPort)
 	testEnv.IstioSrc = env.IstioSrc

--- a/pkg/test/env/envoy.go
+++ b/pkg/test/env/envoy.go
@@ -1,0 +1,116 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"path/filepath"
+	"time"
+
+	"istio.io/istio/pkg/envoy"
+	"istio.io/pkg/env"
+)
+
+const (
+	liveTimeout = 10 * time.Second
+	waitTimeout = 3 * time.Second
+)
+
+// newEnvoy creates a new Envoy struct and starts envoy.
+func (s *TestSetup) newEnvoy() (envoy.Instance, error) {
+	confPath := filepath.Join(IstioOut, fmt.Sprintf("config.conf.%v.yaml", s.ports.AdminPort))
+	log.Printf("Envoy config: in %v\n", confPath)
+	if err := s.CreateEnvoyConf(confPath); err != nil {
+		return nil, err
+	}
+
+	debugLevel := env.RegisterStringVar("ENVOY_DEBUG", "info", "Specifies the debug level for Envoy.").Get()
+
+	options := []envoy.Option{
+		envoy.ConfigPath(confPath),
+		envoy.DrainDuration(1 * time.Second),
+	}
+	if s.stress {
+		options = append(options, envoy.Concurrency(10))
+	} else {
+		// debug is far too verbose.
+		options = append(options,
+			envoy.LogLevel(debugLevel),
+			envoy.Concurrency(1))
+	}
+	if s.disableHotRestart {
+		options = append(options, envoy.DisableHotRestart(true))
+	} else {
+		options = append(options,
+			envoy.BaseID(uint32(s.testName)),
+			envoy.ParentShutdownDuration(1*time.Second),
+			envoy.Epoch(s.epoch))
+	}
+	if s.EnvoyParams != nil {
+		o, err := envoy.NewOptions(s.EnvoyParams...)
+		if err != nil {
+			return nil, err
+		}
+		options = append(options, o...)
+	}
+	/* #nosec */
+	// Since we are possible running in a container, the OS may be different that what we are building (we build for host OS),
+	// we need to use the local container's OS bin found in LOCAL_OUT
+	envoyPath := filepath.Join(LocalOut, "envoy")
+	if path, exists := env.RegisterStringVar("ENVOY_PATH", "", "Specifies the path to an Envoy binary.").Lookup(); exists {
+		envoyPath = path
+	}
+	i, err := envoy.New(envoy.Config{
+		Name:            fmt.Sprintf("envoy-%d", uint32(s.testName)),
+		AdminPort:       uint32(s.ports.AdminPort),
+		BinaryPath:      envoyPath,
+		WorkingDir:      s.Dir,
+		SkipBaseIDClose: true,
+		Options:         options,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return i, nil
+}
+
+// startEnvoy starts the envoy process
+func startEnvoy(e envoy.Instance) error {
+	return e.Start(context.Background()).WaitLive().WithTimeout(liveTimeout).Do()
+}
+
+// stopEnvoy stops the envoy process
+func stopEnvoy(e envoy.Instance) error {
+	log.Printf("stop envoy ...\n")
+	if e == nil {
+		return nil
+	}
+	err := e.ShutdownAndWait().WithTimeout(waitTimeout).Do()
+	if err == context.DeadlineExceeded {
+		return e.KillAndWait().WithTimeout(waitTimeout).Do()
+	}
+	return err
+}
+
+// removeEnvoySharedMemory removes shared memory left by Envoy
+func removeEnvoySharedMemory(e envoy.Instance) {
+	if err := e.BaseID().Close(); err != nil {
+		log.Printf("failed to remove Envoy's shared memory: %s\n", err)
+	} else {
+		log.Printf("removed Envoy's shared memory\n")
+	}
+}

--- a/pkg/test/env/envoy_conf.go
+++ b/pkg/test/env/envoy_conf.go
@@ -1,0 +1,177 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/proto"
+)
+
+const envoyConfTemplYAML = `
+admin:
+  access_log_path: {{.AccessLogPath}}
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: {{.Ports.AdminPort}}
+static_resources:
+  clusters:
+  - name: backend
+    connect_timeout: 5s
+    type: STATIC
+    hosts:
+    - socket_address:
+        address: 127.0.0.1
+        port_value: {{.Ports.BackendPort}}
+  - name: loop
+    connect_timeout: 5s
+    type: STATIC
+    hosts:
+    - socket_address:
+        address: 127.0.0.1
+        port_value: {{.Ports.ServerProxyPort}}
+  - name: extra_server
+    http2_protocol_options: {}
+    connect_timeout: 5s
+    type: STATIC
+    hosts:
+    - socket_address:
+        address: 127.0.0.1
+        port_value: {{.Ports.ExtraPort}}
+    circuit_breakers:
+      thresholds:
+      - max_connections: 10000
+        max_pending_requests: 10000
+        max_requests: 10000
+        max_retries: 3
+  listeners:
+  - name: server
+    address:
+      socket_address:
+        address: 127.0.0.1
+        port_value: {{.Ports.ServerProxyPort}}
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        config:
+          codec_type: AUTO
+          stat_prefix: inbound_http
+          access_log:
+          - name: envoy.file_access_log
+            config:
+              path: {{.AccessLogPath}}
+          http_filters:
+          - name: envoy.router
+          route_config:
+            name: backend
+            virtual_hosts:
+            - name: backend
+              domains: ["*"]
+              routes:
+              - match:
+                  prefix: /
+                route:
+                  cluster: backend
+                  timeout: 0s
+  - name: client
+    address:
+      socket_address:
+        address: 127.0.0.1
+        port_value: {{.Ports.ClientProxyPort}}
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        config:
+          codec_type: AUTO
+          stat_prefix: outbound_http
+          access_log:
+          - name: envoy.file_access_log
+            config:
+              path: {{.AccessLogPath}}
+          http_filters:
+          - name: envoy.router
+          route_config:
+            name: loop
+            virtual_hosts:
+            - name: loop
+              domains: ["*"]
+              routes:
+              - match:
+                  prefix: /
+                route:
+                  cluster: loop
+                  timeout: 0s
+  - name: tcp_server
+    address:
+      socket_address:
+        address: 127.0.0.1
+        port_value: {{.Ports.TCPProxyPort}}
+    filter_chains:
+    - filters:
+      - name: envoy.tcp_proxy
+        config:
+          stat_prefix: inbound_tcp
+          cluster: backend
+`
+
+// CreateEnvoyConf create envoy config.
+func (s *TestSetup) CreateEnvoyConf(path string) error {
+	if s.stress {
+		s.AccessLogPath = "/dev/null"
+	}
+
+	confTmpl := envoyConfTemplYAML
+	if s.EnvoyTemplate != "" {
+		confTmpl = s.EnvoyTemplate
+	}
+
+	tmpl, err := template.New("test").Funcs(template.FuncMap{
+		"toJSON": toJSON,
+		"indent": indent,
+	}).Parse(confTmpl)
+	if err != nil {
+		return fmt.Errorf("failed to parse config template: %v", err)
+	}
+	tmpl.Funcs(template.FuncMap{})
+
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("failed to create file %v: %v", path, err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	return tmpl.Execute(f, s)
+}
+
+func toJSON(mixerFilterConfig proto.Message) string {
+	m := jsonpb.Marshaler{OrigName: true}
+	str, err := m.MarshalToString(mixerFilterConfig)
+	if err != nil {
+		return ""
+	}
+	return str
+}
+
+func indent(n int, s string) string {
+	pad := strings.Repeat(" ", n)
+	return pad + strings.Replace(s, "\n", "\n"+pad, -1)
+}

--- a/pkg/test/env/http_client.go
+++ b/pkg/test/env/http_client.go
@@ -1,0 +1,174 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"fortio.org/fortio/fhttp"
+)
+
+const (
+	// HTTP client time out.
+	httpTimeOut = 5 * time.Second
+
+	// Maximum number of ping the server to wait.
+	maxAttempts = 30
+)
+
+// HTTPGet send GET
+func HTTPGet(url string) (code int, respBody string, err error) {
+	log.Println("HTTP GET", url)
+	client := &http.Client{Timeout: httpTimeOut}
+	resp, err := client.Get(url)
+	if err != nil {
+		log.Println(err)
+		return 0, "", err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Println(err)
+		return 0, "", err
+	}
+	respBody = string(body)
+	code = resp.StatusCode
+	log.Println(respBody)
+	return code, respBody, nil
+}
+
+// HTTPPost sends POST
+func HTTPPost(url string, contentType string, reqBody string) (code int, respBody string, err error) {
+	log.Println("HTTP POST", url)
+	client := &http.Client{Timeout: httpTimeOut}
+	resp, err := client.Post(url, contentType, strings.NewReader(reqBody))
+	if err != nil {
+		log.Println(err)
+		return 0, "", err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Println(err)
+		return 0, "", err
+	}
+	respBody = string(body)
+	code = resp.StatusCode
+	log.Println(fhttp.DebugSummary(body, 512))
+	return code, respBody, nil
+}
+
+// ShortLiveHTTPPost send HTTP without keepalive
+func ShortLiveHTTPPost(url string, contentType string, reqBody string) (code int, respBody string, err error) {
+	log.Println("Short live HTTP POST", url)
+	tr := &http.Transport{
+		DisableKeepAlives: true,
+	}
+	client := &http.Client{Transport: tr}
+	resp, err := client.Post(url, contentType, strings.NewReader(reqBody))
+	if err != nil {
+		log.Println(err)
+		return 0, "", err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Println(err)
+		return 0, "", err
+	}
+	respBody = string(body)
+	code = resp.StatusCode
+	log.Println(respBody)
+	return code, respBody, nil
+}
+
+// HTTPGetWithHeaders send HTTP with headers
+func HTTPGetWithHeaders(l string, headers map[string]string) (code int, respBody string, err error) {
+	log.Println("HTTP GET with headers: ", l)
+	client := &http.Client{Timeout: httpTimeOut}
+	req := http.Request{}
+
+	req.Header = map[string][]string{}
+	for k, v := range headers {
+		req.Header[k] = []string{v}
+	}
+	req.Method = http.MethodGet
+	req.URL, err = url.Parse(l)
+	if err != nil {
+		log.Println(err)
+		return 0, "", err
+	}
+
+	resp, err := client.Do(&req)
+	if err != nil {
+		log.Println(err)
+		return 0, "", err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Println(err)
+		return 0, "", err
+	}
+	respBody = string(body)
+	code = resp.StatusCode
+	log.Println(respBody)
+	return code, respBody, nil
+}
+
+// WaitForHTTPServer waits for a HTTP server
+func WaitForHTTPServer(url string) error {
+	for i := 0; i < maxAttempts; i++ {
+		log.Println("Pinging URL: ", url)
+		code, _, err := HTTPGet(url)
+		if err == nil && code == http.StatusOK {
+			log.Println("Server is up and running...")
+			return nil
+		}
+		log.Println("Will wait 200ms and try again.")
+		time.Sleep(200 * time.Millisecond)
+	}
+	return fmt.Errorf("timeout waiting for server startup")
+}
+
+// WaitForPort waits for a TCP port
+func WaitForPort(port uint16) {
+	serverPort := fmt.Sprintf("localhost:%v", port)
+	for i := 0; i < maxAttempts; i++ {
+		log.Println("Pinging port: ", serverPort)
+		_, err := net.Dial("tcp", serverPort)
+		if err == nil {
+			log.Println("The port is up and running...")
+			return
+		}
+		log.Println("Wait 200ms and try again.")
+		time.Sleep(200 * time.Millisecond)
+	}
+	log.Println("Give up the wait, continue the test...")
+}
+
+// IsPortUsed checks if a port is used
+func IsPortUsed(port uint16) bool {
+	serverPort := fmt.Sprintf("localhost:%v", port)
+	_, err := net.DialTimeout("tcp", serverPort, 100*time.Millisecond)
+	return err == nil
+}

--- a/pkg/test/env/http_server.go
+++ b/pkg/test/env/http_server.go
@@ -1,0 +1,178 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// If HTTP header has non empty FailHeader,
+// HTTP server will fail the request with 400 with FailBody in the response body.
+const (
+	FailHeader = "x-istio-backend-fail"
+	FailBody   = "Bad request from backend."
+)
+
+const publicKey = `
+{
+    "keys": [
+        {
+            "alg": "RS256",
+            "e": "AQAB",
+            "kid": "62a93512c9ee4c7f8067b5a216dade2763d32a47",
+            "kty": "RSA",
+            "n": "` +
+	"0YWnm_eplO9BFtXszMRQNL5UtZ8HJdTH2jK7vjs4XdLkPW7YBkkm_2xNgcaVpkW0VT2l4mU3KftR-6" +
+	"s3Oa5Rnz5BrWEUkCTVVolR7VYksfqIB2I_x5yZHdOiomMTcm3DheUUCgbJRv5OKRnNqszA4xHn3tA3" +
+	"Ry8VO3X7BgKZYAUh9fyZTFLlkeAh0-bLK5zvqCmKW5QgDIXSxUTJxPjZCgfx1vmAfGqaJb-nvmrORX" +
+	"Q6L284c73DUL7mnt6wj3H6tVqPKA27j56N0TB1Hfx4ja6Slr8S4EB3F1luYhATa1PKUSH8mYDW11Ho" +
+	"lzZmTQpRoLV8ZoHbHEaTfqX_aYahIw" +
+	`",
+            "use": "sig"
+        },
+        {
+            "alg": "RS256",
+            "e": "AQAB",
+            "kid": "b3319a147514df7ee5e4bcdee51350cc890cc89e",
+            "kty": "RSA",
+            "n": "` +
+	"qDi7Tx4DhNvPQsl1ofxxc2ePQFcs-L0mXYo6TGS64CY_2WmOtvYlcLNZjhuddZVV2X88m0MfwaSA16w" +
+	"E-RiKM9hqo5EY8BPXj57CMiYAyiHuQPp1yayjMgoE1P2jvp4eqF-BTillGJt5W5RuXti9uqfMtCQdag" +
+	"B8EC3MNRuU_KdeLgBy3lS3oo4LOYd-74kRBVZbk2wnmmb7IhP9OoLc1-7-9qU1uhpDxmE6JwBau0mDS" +
+	"wMnYDS4G_ML17dC-ZDtLd1i24STUw39KH0pcSdfFbL2NtEZdNeam1DDdk0iUtJSPZliUHJBI_pj8M-2" +
+	"Mn_oA8jBuI8YKwBqYkZCN1I95Q" +
+	`",
+            "use": "sig"
+        }
+    ]
+}
+`
+
+// HTTPServer stores data for a HTTP server.
+type HTTPServer struct {
+	port uint16
+	lis  net.Listener
+
+	reqHeaders http.Header
+	mu         sync.Mutex
+}
+
+func pubkeyHandler(w http.ResponseWriter, _ *http.Request) {
+	_, _ = fmt.Fprintf(w, "%v", publicKey)
+}
+
+// handle handles a request and sends response. If ?delay=n is in request URL, then sleeps for
+// n second and sends response.
+func (s *HTTPServer) handle(w http.ResponseWriter, r *http.Request) {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Fail if there is such header.
+	if r.Header.Get(FailHeader) != "" {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(FailBody))
+		return
+	}
+
+	// echo back the Content-Type and Content-Length in the response
+	for _, k := range []string{"Content-Type", "Content-Length"} {
+		if v := r.Header.Get(k); v != "" {
+			w.Header().Set(k, v)
+		}
+	}
+
+	if delay := r.URL.Query().Get("delay"); delay != "" {
+		delaySeconds, err := strconv.ParseInt(delay, 10, 64)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("Bad request parameter: delay"))
+			return
+		}
+		time.Sleep(time.Duration(delaySeconds) * time.Second)
+	}
+
+	w.WriteHeader(http.StatusOK)
+
+	reqHeaders := make(http.Header)
+	reqHeaders[":method"] = []string{r.Method}
+	reqHeaders[":authority"] = []string{r.Host}
+	reqHeaders[":path"] = []string{r.URL.String()}
+	for name, headers := range r.Header {
+		reqHeaders[name] = append(reqHeaders[name], headers...)
+	}
+
+	s.mu.Lock()
+	s.reqHeaders = reqHeaders
+	s.mu.Unlock()
+
+	_, _ = w.Write(body)
+}
+
+// NewHTTPServer creates a new HTTP server.
+func NewHTTPServer(port uint16) (*HTTPServer, error) {
+	log.Printf("Http server listening on port %v\n", port)
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		log.Fatal(err)
+		return nil, err
+	}
+	return &HTTPServer{
+		port: port,
+		lis:  lis,
+	}, nil
+}
+
+// Start starts the server
+func (s *HTTPServer) Start() <-chan error {
+	errCh := make(chan error)
+	go func() {
+		http.HandleFunc("/", s.handle)
+		http.HandleFunc("/pubkey", pubkeyHandler)
+		errCh <- http.Serve(s.lis, nil)
+	}()
+	go func() {
+		url := fmt.Sprintf("http://localhost:%v/echo", s.port)
+		errCh <- WaitForHTTPServer(url)
+	}()
+
+	return errCh
+}
+
+// Stop shutdown the server
+func (s *HTTPServer) Stop() {
+	log.Printf("Close HTTP server\n")
+	_ = s.lis.Close()
+	log.Printf("Close HTTP server -- Done\n")
+}
+
+// LastRequestHeaders returns the headers from the last request and clears the value
+func (s *HTTPServer) LastRequestHeaders() http.Header {
+	s.mu.Lock()
+	out := s.reqHeaders
+	s.reqHeaders = nil
+	s.mu.Unlock()
+
+	return out
+}

--- a/pkg/test/env/ports.go
+++ b/pkg/test/env/ports.go
@@ -1,0 +1,150 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"log"
+)
+
+// Dynamic port allocation scheme
+// In order to run the tests in parallel. Each test should use unique ports
+// Each test has a unique test_name, its ports will be allocated based on that name
+
+// All tests should be listed here to get their test ids
+const (
+	FailedRequestTest uint16 = iota
+	FaultInjectTest
+	NetworkFailureTest
+	XDSTest
+	IstioAuthnTestOriginRejectNoJwt
+	IstioAuthnTestPeerRejectNoJwt
+	IstioAuthnTestPeerRejectNoMtls
+	IstioAuthnTestPeerRejectNoTLS
+	RouteDirectiveTest
+	DynamicAttributeTest
+	DynamicListenerTest
+	PilotPluginTest
+	PilotPluginTCPTest
+	PilotPluginTLSTest
+	PilotMCPTest
+	RbacGlobalPermissiveTest
+	RbacPolicyPermissiveTest
+	GatewayTest
+	SidecarTest
+	SidecarConsumerOnlyTest
+	TracingHeaderTest
+	STSTest
+	STSCacheTest
+	STSRenewTest
+	STSFailureTest
+	STSTimeoutTest
+	STSServerCacheTest
+	STSShortLivedCacheTest
+	SDSTest
+	SDSCertRotation
+	CSRFailure
+	BadCSRResponse
+
+	// The number of total tests. has to be the last one.
+	maxTestNum
+)
+
+const (
+	portBase uint16 = 20000
+	// Maximum number of ports used in each test.
+	portNum uint16 = 8
+	// Number of ports used by Envoy in each test.
+	envoyPortNum uint16 = 4
+)
+
+// Ports stores all used ports
+type Ports struct {
+	ClientProxyPort uint16
+	ServerProxyPort uint16
+	TCPProxyPort    uint16
+	AdminPort       uint16
+	BackendPort     uint16
+	DiscoveryPort   uint16
+	STSPort         uint16
+	ExtraPort       uint16
+
+	// Pilot ports, used when testing mixer-pilot integration.
+	PilotGrpcPort uint16
+	PilotHTTPPort uint16
+}
+
+func allocPortBase(name uint16) uint16 {
+	base := portBase + name*portNum
+	for i := 0; i < 10; i++ {
+		if allPortFree(base, portNum) {
+			return base
+		}
+		base += maxTestNum * portNum
+	}
+	log.Println("could not find free ports, continue the test...")
+	return base
+}
+
+func allocEnvoyPortBase(name uint16) uint16 {
+	base := portBase + name*portNum
+	for i := 0; i < 10; i++ {
+		if allPortFree(base, envoyPortNum) {
+			return base
+		}
+		base += maxTestNum * portNum
+	}
+	log.Println("could not find free ports, continue the test...")
+	return base
+}
+
+func allPortFree(base uint16, ports uint16) bool {
+	for port := base; port < base+ports; port++ {
+		if IsPortUsed(port) {
+			log.Println("port is used ", port)
+			return false
+		}
+	}
+	return true
+}
+
+// NewPorts allocate all ports based on test id.
+func NewPorts(name uint16) *Ports {
+	base := allocPortBase(name)
+	return &Ports{
+		ClientProxyPort: base,
+		ServerProxyPort: base + 1,
+		TCPProxyPort:    base + 2,
+		AdminPort:       base + 3,
+		ExtraPort:       base + 4,
+		BackendPort:     base + 5,
+		DiscoveryPort:   base + 6,
+		STSPort:         base + 7,
+	}
+}
+
+// NewEnvoyPorts allocate ports for Envoy
+func NewEnvoyPorts(ports *Ports, name uint16) *Ports {
+	base := allocEnvoyPortBase(name)
+	return &Ports{
+		ClientProxyPort: base,
+		ServerProxyPort: base + 1,
+		TCPProxyPort:    base + 2,
+		AdminPort:       base + 3,
+		BackendPort:     ports.BackendPort,
+		DiscoveryPort:   ports.DiscoveryPort,
+		STSPort:         ports.STSPort,
+		ExtraPort:       ports.ExtraPort,
+	}
+}

--- a/pkg/test/env/setup.go
+++ b/pkg/test/env/setup.go
@@ -1,0 +1,394 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"testing"
+	"time"
+
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	"github.com/golang/protobuf/jsonpb"
+
+	// Import all XDS config types
+	_ "istio.io/istio/pkg/config/xds"
+
+	"istio.io/istio/pkg/envoy"
+)
+
+// TestSetup store data for a test.
+type TestSetup struct {
+	t     *testing.T
+	epoch int
+	ports *Ports
+
+	envoy             envoy.Instance
+	backend           *HTTPServer
+	testName          uint16
+	stress            bool
+	noProxy           bool
+	noBackend         bool
+	disableHotRestart bool
+	checkDict         bool
+	silentlyStopProxy bool
+
+	// EnvoyTemplate is the bootstrap config used by envoy.
+	EnvoyTemplate string
+
+	// EnvoyParams contain extra envoy parameters to pass in the CLI (cluster, node)
+	EnvoyParams []string
+
+	// EnvoyConfigOpt allows passing additional parameters to the EnvoyTemplate
+	EnvoyConfigOpt map[string]interface{}
+
+	// IstioSrc is the base directory of istio sources. May be set for finding testdata or
+	// other files in the source tree
+	IstioSrc string
+
+	// IstioOut is the base output directory.
+	IstioOut string
+
+	// AccessLogPath is the access log path for Envoy
+	AccessLogPath string
+
+	// Dir is the working dir for envoy
+	Dir string
+}
+
+// NewTestSetup creates a new test setup
+// "name" has to be defined in ports.go
+func NewTestSetup(name uint16, t *testing.T) *TestSetup {
+	return &TestSetup{
+		t:             t,
+		ports:         NewPorts(name),
+		testName:      name,
+		AccessLogPath: "/tmp/envoy-access.log",
+	}
+}
+
+// Ports get ports object
+func (s *TestSetup) Ports() *Ports {
+	return s.ports
+}
+
+// SDSPath gets SDS path. The path does not change after proxy restarts.
+func (s *TestSetup) SDSPath() string {
+	return fmt.Sprintf("/tmp/sdstestudspath.%v", s.ports.STSPort)
+}
+
+// JWTTokenPath gets JWT token path. The path does not change after proxy restarts.
+func (s *TestSetup) JWTTokenPath() string {
+	return fmt.Sprintf("/tmp/envoy-token-%v.jwt", s.ports.STSPort)
+}
+
+// CACertPath gets CA cert file path. The path does not change after proxy restarts.
+func (s *TestSetup) CACertPath() string {
+	return fmt.Sprintf("/tmp/ca-certificates-%v.crt", s.ports.STSPort)
+}
+
+// SetStress set the stress flag
+func (s *TestSetup) SetStress(stress bool) {
+	s.stress = stress
+}
+
+// SetCheckDict set the checkDict flag
+func (s *TestSetup) SetCheckDict(checkDict bool) {
+	s.checkDict = checkDict
+}
+
+// SilentlyStopProxy ignores errors when stop proxy
+func (s *TestSetup) SilentlyStopProxy(silent bool) {
+	s.silentlyStopProxy = silent
+}
+
+// SetDisableHotRestart sets whether disable the HotRestart feature of Envoy
+func (s *TestSetup) SetDisableHotRestart(disable bool) {
+	s.disableHotRestart = disable
+}
+
+// SetNoProxy set NoProxy flag
+func (s *TestSetup) SetNoProxy(no bool) {
+	s.noProxy = no
+}
+
+// SetNoBackend sets no backend flag
+func (s *TestSetup) SetNoBackend(no bool) {
+	s.noBackend = no
+}
+
+// SetUp setups Envoy and Backend server for test.
+func (s *TestSetup) SetUp() error {
+	var err error
+	s.envoy, err = s.newEnvoy()
+	if err != nil {
+		log.Printf("unable to create Envoy %v", err)
+		return err
+	}
+
+	err = startEnvoy(s.envoy)
+	if err != nil {
+		return err
+	}
+
+	if !s.noBackend {
+		s.backend, err = NewHTTPServer(s.ports.BackendPort)
+		if err != nil {
+			log.Printf("unable to create HTTP server %v", err)
+		} else {
+			errCh := s.backend.Start()
+			if err = <-errCh; err != nil {
+				log.Fatalf("backend server start failed %v", err)
+			}
+		}
+	}
+
+	s.WaitEnvoyReady()
+
+	return nil
+}
+
+// TearDown shutdown the servers.
+func (s *TestSetup) TearDown() {
+	if err := stopEnvoy(s.envoy); err != nil && !s.silentlyStopProxy {
+		s.t.Errorf("error quitting envoy: %v", err)
+	}
+	removeEnvoySharedMemory(s.envoy)
+
+	if s.backend != nil {
+		s.backend.Stop()
+	}
+}
+
+// LastRequestHeaders returns last backend request headers
+func (s *TestSetup) LastRequestHeaders() http.Header {
+	if s.backend != nil {
+		return s.backend.LastRequestHeaders()
+	}
+	return nil
+}
+
+// ReStartEnvoy restarts Envoy
+func (s *TestSetup) ReStartEnvoy() {
+	// don't stop envoy before starting the new one since we use hot restart
+	oldEnvoy := s.envoy
+	s.ports = NewEnvoyPorts(s.ports, s.testName)
+	log.Printf("new allocated ports are %v:", s.ports)
+	var err error
+	s.epoch++
+	s.envoy, err = s.newEnvoy()
+	if err != nil {
+		s.t.Errorf("unable to re-start envoy %v", err)
+		return
+	}
+
+	err = startEnvoy(s.envoy)
+	if err != nil {
+		s.t.Fatalf("unable to re-start envoy %v", err)
+	}
+
+	s.WaitEnvoyReady()
+
+	_ = stopEnvoy(oldEnvoy)
+}
+
+// WaitForStatsUpdateAndGetStats waits for waitDuration seconds to let Envoy update stats, and sends
+// request to Envoy for stats. Returns stats response.
+func (s *TestSetup) WaitForStatsUpdateAndGetStats(waitDuration int) (string, error) {
+	time.Sleep(time.Duration(waitDuration) * time.Second)
+	statsURL := fmt.Sprintf("http://localhost:%d/stats?format=json&usedonly", s.Ports().AdminPort)
+	code, respBody, err := HTTPGet(statsURL)
+	if err != nil {
+		return "", fmt.Errorf("sending stats request returns an error: %v", err)
+	}
+	if code != 200 {
+		return "", fmt.Errorf("sending stats request returns unexpected status code: %d", code)
+	}
+	return respBody, nil
+}
+
+// GetStatsMap fetches Envoy stats with retry, and returns stats in a map.
+func (s *TestSetup) GetStatsMap() (map[string]uint64, error) {
+	delay := 200 * time.Millisecond
+	total := 3 * time.Second
+	var errGet error
+	var code int
+	var statsJSON string
+	for attempt := 0; attempt < int(total/delay); attempt++ {
+		statsURL := fmt.Sprintf("http://localhost:%d/stats?format=json&usedonly", s.Ports().AdminPort)
+		code, statsJSON, errGet = HTTPGet(statsURL)
+		if errGet != nil {
+			log.Printf("sending stats request returns an error: %v", errGet)
+		} else if code != 200 {
+			log.Printf("sending stats request returns unexpected status code: %d", code)
+		} else {
+			return s.unmarshalStats(statsJSON), nil
+		}
+		time.Sleep(delay)
+	}
+	return nil, fmt.Errorf("failed to get stats, err: %v, code: %d", errGet, code)
+}
+
+type statEntry struct {
+	Name  string      `json:"name"`
+	Value json.Number `json:"value"`
+}
+
+type stats struct {
+	StatList []statEntry `json:"stats"`
+}
+
+// WaitEnvoyReady waits until envoy receives and applies all config
+func (s *TestSetup) WaitEnvoyReady() {
+	// Sometimes on CI, connection is refused even when envoy reports warm clusters and listeners...
+	// Inject a 1 second delay to force readiness
+	time.Sleep(1 * time.Second)
+
+	delay := 200 * time.Millisecond
+	total := 3 * time.Second
+	var stats map[string]uint64
+	for attempt := 0; attempt < int(total/delay); attempt++ {
+		statsURL := fmt.Sprintf("http://localhost:%d/stats?format=json&usedonly", s.Ports().AdminPort)
+		code, respBody, errGet := HTTPGet(statsURL)
+		if errGet == nil && code == 200 {
+			stats = s.unmarshalStats(respBody)
+			warmingListeners, hasListeners := stats["listener_manager.total_listeners_warming"]
+			warmingClusters, hasClusters := stats["cluster_manager.warming_clusters"]
+			if hasListeners && hasClusters && warmingListeners == 0 && warmingClusters == 0 {
+				return
+			}
+		}
+		time.Sleep(delay)
+	}
+
+	s.t.Fatalf("envoy failed to get ready: %v", stats)
+}
+
+// UnmarshalStats Unmarshals Envoy stats from JSON format into a map, where stats name is
+// key, and stats value is value.
+func (s *TestSetup) unmarshalStats(statsJSON string) map[string]uint64 {
+	statsMap := make(map[string]uint64)
+
+	var statsArray stats
+	if err := json.Unmarshal([]byte(statsJSON), &statsArray); err != nil {
+		s.t.Fatalf("unable to unmarshal stats from json: %v", err)
+	}
+
+	for _, v := range statsArray.StatList {
+		if v.Value == "" {
+			continue
+		}
+		tmp, err := v.Value.Float64()
+		if err != nil {
+			s.t.Fatalf("unable to convert json.Number from stats: %v", err)
+		}
+		statsMap[v.Name] = uint64(tmp)
+	}
+	return statsMap
+}
+
+// VerifyStats verifies Envoy stats.
+func (s *TestSetup) VerifyStats(expectedStats map[string]uint64) {
+	s.t.Helper()
+
+	check := func(actualStatsMap map[string]uint64) error {
+		for eStatsName, eStatsValue := range expectedStats {
+			aStatsValue, ok := actualStatsMap[eStatsName]
+			if !ok && eStatsValue != 0 {
+				return fmt.Errorf("failed to find expected stat %s", eStatsName)
+			}
+			if aStatsValue != eStatsValue {
+				return fmt.Errorf("stats %s does not match. expected vs actual: %d vs %d",
+					eStatsName, eStatsValue, aStatsValue)
+			}
+
+			log.Printf("stat %s is matched. value is %d", eStatsName, eStatsValue)
+		}
+		return nil
+	}
+
+	delay := 200 * time.Millisecond
+	total := 3 * time.Second
+
+	var err error
+	for attempt := 0; attempt < int(total/delay); attempt++ {
+		statsURL := fmt.Sprintf("http://localhost:%d/stats?format=json&usedonly", s.Ports().AdminPort)
+		code, respBody, errGet := HTTPGet(statsURL)
+		if errGet != nil {
+			log.Printf("sending stats request returns an error: %v", errGet)
+		} else if code != 200 {
+			log.Printf("sending stats request returns unexpected status code: %d", code)
+		} else {
+			actualStatsMap := s.unmarshalStats(respBody)
+			if err = check(actualStatsMap); err == nil {
+				return
+			}
+			log.Printf("failed to verify stats: %v", err)
+		}
+		time.Sleep(delay)
+	}
+	s.t.Errorf("failed to find expected stats: %v", err)
+}
+
+// VerifyStatsLT verifies that Envoy stats contains stat expectedStat, whose value is less than
+// expectedStatVal.
+func (s *TestSetup) VerifyStatsLT(actualStats string, expectedStat string, expectedStatVal uint64) {
+	s.t.Helper()
+	actualStatsMap := s.unmarshalStats(actualStats)
+
+	aStatsValue, ok := actualStatsMap[expectedStat]
+	if !ok {
+		s.t.Fatalf("Failed to find expected Stat %s\n", expectedStat)
+	} else if aStatsValue >= expectedStatVal {
+		s.t.Fatalf("Stat %s does not match. Expected value < %d, actual stat value is %d",
+			expectedStat, expectedStatVal, aStatsValue)
+	} else {
+		log.Printf("stat %s is matched. %d < %d", expectedStat, aStatsValue, expectedStatVal)
+	}
+}
+
+// go-control-plane requires v2 XDS types, when we are using v3 internally
+// nolint: interfacer
+func CastRouteToV2(r *route.RouteConfiguration) *v2.RouteConfiguration {
+	s, err := (&jsonpb.Marshaler{OrigName: true}).MarshalToString(r)
+	if err != nil {
+		panic(err.Error())
+	}
+	v2route := &v2.RouteConfiguration{}
+	err = jsonpb.UnmarshalString(s, v2route)
+	if err != nil {
+		panic(err.Error())
+	}
+	return v2route
+}
+
+// go-control-plane requires v2 XDS types, when we are using v3 internally
+// nolint: interfacer
+func CastListenerToV2(r *listener.Listener) *v2.Listener {
+	s, err := (&jsonpb.Marshaler{OrigName: true}).MarshalToString(r)
+	if err != nil {
+		panic(err.Error())
+	}
+	v2Listener := &v2.Listener{}
+	err = jsonpb.UnmarshalString(s, v2Listener)
+	if err != nil {
+		panic(err.Error())
+	}
+	return v2Listener
+}

--- a/security/pkg/nodeagent/test/cert_rotation/rotation_test.go
+++ b/security/pkg/nodeagent/test/cert_rotation/rotation_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"istio.io/istio/mixer/test/client/env"
+	"istio.io/istio/pkg/test/env"
 	sdsTest "istio.io/istio/security/pkg/nodeagent/test"
 )
 

--- a/security/pkg/nodeagent/test/csr_failure/csr_test.go
+++ b/security/pkg/nodeagent/test/csr_failure/csr_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"istio.io/istio/mixer/test/client/env"
+	"istio.io/istio/pkg/test/env"
 	sdsTest "istio.io/istio/security/pkg/nodeagent/test"
 )
 

--- a/security/pkg/nodeagent/test/empty_certchain/empty_cert_test.go
+++ b/security/pkg/nodeagent/test/empty_certchain/empty_cert_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"istio.io/istio/mixer/test/client/env"
+	"istio.io/istio/pkg/test/env"
 	sdsTest "istio.io/istio/security/pkg/nodeagent/test"
 )
 

--- a/security/pkg/nodeagent/test/success_sds/sds_test.go
+++ b/security/pkg/nodeagent/test/success_sds/sds_test.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"testing"
 
-	"istio.io/istio/mixer/test/client/env"
+	"istio.io/istio/pkg/test/env"
 	sdsTest "istio.io/istio/security/pkg/nodeagent/test"
 )
 

--- a/security/pkg/nodeagent/test/testdata/bootstrap.yaml
+++ b/security/pkg/nodeagent/test/testdata/bootstrap.yaml
@@ -44,7 +44,7 @@ static_resources:
                 api_type: GRPC
                 grpc_services:
                 - envoy_grpc:
-                    cluster_name: sds-grpc        
+                    cluster_name: sds-grpc
   - name: sds-grpc
     type: STATIC
     http2_protocol_options: {}

--- a/security/pkg/stsservice/test/failure_sts_token_fetch/token_failure_test.go
+++ b/security/pkg/stsservice/test/failure_sts_token_fetch/token_failure_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/onsi/gomega"
 
-	testID "istio.io/istio/mixer/test/client/env"
+	testID "istio.io/istio/pkg/test/env"
 	xdsService "istio.io/istio/security/pkg/stsservice/mock"
 	stsTest "istio.io/istio/security/pkg/stsservice/test"
 )

--- a/security/pkg/stsservice/test/proxy_cached_sts_token/proxy_cached_token_test.go
+++ b/security/pkg/stsservice/test/proxy_cached_sts_token/proxy_cached_token_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/onsi/gomega"
 
-	testID "istio.io/istio/mixer/test/client/env"
+	testID "istio.io/istio/pkg/test/env"
 	xdsService "istio.io/istio/security/pkg/stsservice/mock"
 	stsTest "istio.io/istio/security/pkg/stsservice/test"
 )

--- a/security/pkg/stsservice/test/renew_sts_token/renew_token_test.go
+++ b/security/pkg/stsservice/test/renew_sts_token/renew_token_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/onsi/gomega"
 
-	testID "istio.io/istio/mixer/test/client/env"
+	testID "istio.io/istio/pkg/test/env"
 	xdsService "istio.io/istio/security/pkg/stsservice/mock"
 	stsTest "istio.io/istio/security/pkg/stsservice/test"
 )

--- a/security/pkg/stsservice/test/server_cached_short_lived_sts_token/short_lived_cached_token_test.go
+++ b/security/pkg/stsservice/test/server_cached_short_lived_sts_token/short_lived_cached_token_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/onsi/gomega"
 
-	testID "istio.io/istio/mixer/test/client/env"
+	testID "istio.io/istio/pkg/test/env"
 	xdsService "istio.io/istio/security/pkg/stsservice/mock"
 	stsTest "istio.io/istio/security/pkg/stsservice/test"
 )

--- a/security/pkg/stsservice/test/server_cached_sts_token/server_cached_token_test.go
+++ b/security/pkg/stsservice/test/server_cached_sts_token/server_cached_token_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/onsi/gomega"
 
-	testID "istio.io/istio/mixer/test/client/env"
+	testID "istio.io/istio/pkg/test/env"
 	xdsService "istio.io/istio/security/pkg/stsservice/mock"
 	stsTest "istio.io/istio/security/pkg/stsservice/test"
 )

--- a/security/pkg/stsservice/test/sts_fetch_timeout/sts_timeout_test.go
+++ b/security/pkg/stsservice/test/sts_fetch_timeout/sts_timeout_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/onsi/gomega"
 
-	testID "istio.io/istio/mixer/test/client/env"
+	testID "istio.io/istio/pkg/test/env"
 	xdsService "istio.io/istio/security/pkg/stsservice/mock"
 	stsTest "istio.io/istio/security/pkg/stsservice/test"
 )

--- a/security/pkg/stsservice/test/success_sts/proxy_sts_test.go
+++ b/security/pkg/stsservice/test/success_sts/proxy_sts_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/onsi/gomega"
 
-	"istio.io/istio/mixer/test/client/env"
+	"istio.io/istio/pkg/test/env"
 	xdsService "istio.io/istio/security/pkg/stsservice/mock"
 	stsTest "istio.io/istio/security/pkg/stsservice/test"
 )

--- a/tests/testdata/bootstrap_tmpl.json
+++ b/tests/testdata/bootstrap_tmpl.json
@@ -149,7 +149,7 @@
     ]
   },
     {
-        "name": "mixertcpproxy",
+        "name": "tcpproxy",
         "address": {
           "socket_address": {
             "address": "0.0.0.0",
@@ -163,7 +163,7 @@
                 "name": "envoy.tcp_proxy",
                 "typed_config": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                  "stat_prefix": "mixertcpproxy",
+                  "stat_prefix": "tcpproxy",
                   "cluster": "service1"
                 }
               }
@@ -357,25 +357,6 @@
       ],
       "http2_protocol_options": {}
       },
-      {
-        "name": "mixer_server",
-        "type": "STRICT_DNS",
-        "connect_timeout": {
-        "seconds": 5,
-        "nanos": 0
-        },
-        "lb_policy": "ROUND_ROBIN",
-        "hosts": [
-        {
-          "socket_address": {
-          "address": "127.0.0.1",
-          "port_value": {{.Ports.MixerPort}}
-        }
-        }
-        ],
-        "http2_protocol_options": {}
-      }
-
     ]
   }
 }


### PR DESCRIPTION
This PR copies the testing deps for pilot and security out of the `mixer/` package and into the `pkg/test/env` package. It then updates the impacted tests to point at the new package.

This PR is part one (of many) in removing Mixer from the codebase. The impacted tests should probably be rewritten to use a more modern Istio framework for testing (and/or use case labelling), but that is beyond the scope of this PR.

NOTE: No new code is added in this PR. The `env` package is copied over from `mixer/` tests, with the mixer-specific bits cut out.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
