### PR TITLE
remove CI scope logger and use Framework instead

### DIFF
--- a/pkg/test/docker/container.go
+++ b/pkg/test/docker/container.go
@@ -29,7 +29,6 @@ import (
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/go-connections/nat"
 	"github.com/hashicorp/go-multierror"
-
 	"istio.io/istio/pkg/test/scopes"
 )
 
@@ -81,7 +80,7 @@ func NewContainer(dockerClient *client.Client, config ContainerConfig) (*Contain
 	}
 	networkName := config.Network.Name
 
-	scopes.CI.Infof("Creating Docker container for image %s in network %s", config.Image, networkName)
+	scopes.Framework.Infof("Creating Docker container for image %s in network %s", config.Image, networkName)
 	exposedPorts := make(nat.PortSet)
 	for k := range config.PortMap {
 		exposedPorts[toNatPort(k)] = struct{}{}
@@ -144,7 +143,7 @@ func NewContainer(dockerClient *client.Client, config ContainerConfig) (*Contain
 		}
 		config.PortMap[ContainerPort(port.Int())] = HostPort(hp)
 	}
-	scopes.CI.Infof("Docker container %s (image=%s) created in network %s", resp.ID, config.Image, networkName)
+	scopes.Framework.Infof("Docker container %s (image=%s) created in network %s", resp.ID, config.Image, networkName)
 	return c, nil
 }
 
@@ -228,7 +227,7 @@ func (c *Container) Logs() (string, error) {
 
 // Close stops and removes this container.
 func (c *Container) Close() error {
-	scopes.CI.Infof("Closing Docker container %s", c.id)
+	scopes.Framework.Infof("Closing Docker container %s", c.id)
 	// docker stop will send SIGTERM to the root process. In our case, this is the echo process not Istio
 	// To avoid 10s shutdown on every container, we set the time out to 0s instead.
 	instant := time.Duration(0)

--- a/pkg/test/docker/network.go
+++ b/pkg/test/docker/network.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
-
 	"istio.io/istio/pkg/test/scopes"
 )
 
@@ -44,7 +43,7 @@ type Network struct {
 
 // NewNetwork creates a new user-defined Docker network.
 func NewNetwork(dockerClient *client.Client, cfg NetworkConfig) (out *Network, err error) {
-	scopes.CI.Infof("Creating Docker network %s", cfg.Name)
+	scopes.Framework.Infof("Creating Docker network %s", cfg.Name)
 	resp, err := dockerClient.NetworkCreate(context.Background(), cfg.Name, types.NetworkCreate{
 		CheckDuplicate: true,
 		Labels:         cfg.Labels,
@@ -53,7 +52,7 @@ func NewNetwork(dockerClient *client.Client, cfg NetworkConfig) (out *Network, e
 		return nil, err
 	}
 
-	scopes.CI.Infof("Docker network %s created (ID=%s)", cfg.Name, resp.ID)
+	scopes.Framework.Infof("Docker network %s created (ID=%s)", cfg.Name, resp.ID)
 
 	n := &Network{
 		NetworkConfig: cfg,
@@ -80,6 +79,6 @@ func NewNetwork(dockerClient *client.Client, cfg NetworkConfig) (out *Network, e
 
 // Close removes this network. All attached containers must already have been stopped.
 func (n *Network) Close() error {
-	scopes.CI.Infof("Closing Docker network %s (ID=%s)", n.Name, n.id)
+	scopes.Framework.Infof("Closing Docker network %s (ID=%s)", n.Name, n.id)
 	return n.dockerClient.NetworkRemove(context.Background(), n.id)
 }

--- a/pkg/test/framework/components/bookinfo/kube.go
+++ b/pkg/test/framework/components/bookinfo/kube.go
@@ -54,14 +54,14 @@ func deploy(ctx resource.Context, cfg Config) (undeployFunc func(), err error) {
 	}
 
 	name := string(cfg.Cfg)
-	scopes.CI.Infof("=== BEGIN: Deployment %q ===", name)
+	scopes.Framework.Infof("=== BEGIN: Deployment %q ===", name)
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("deployment %q failed: %v", name, err) // nolint:golint
 			scopes.Framework.Errorf("Error deploying %q: %v", name, err)
-			scopes.CI.Errorf("=== FAILED: Deployment %q ===", name)
+			scopes.Framework.Errorf("=== FAILED: Deployment %q ===", name)
 		} else {
-			scopes.CI.Infof("=== SUCCEEDED: Deployment %q ===", name)
+			scopes.Framework.Infof("=== SUCCEEDED: Deployment %q ===", name)
 		}
 	}()
 

--- a/pkg/test/framework/components/echo/docker/instance.go
+++ b/pkg/test/framework/components/echo/docker/instance.go
@@ -80,7 +80,7 @@ func newInstance(ctx resource.Context, cfg echo.Config) (out *instance, err erro
 	var dumpDir string
 	dumpDir, err = ctx.CreateTmpDirectory(cfg.FQDN())
 	if err != nil {
-		scopes.CI.Errorf("Unable to create output directory for %s: %v", cfg.FQDN(), err)
+		scopes.Framework.Errorf("Unable to create output directory for %s: %v", cfg.FQDN(), err)
 		return
 	}
 
@@ -216,7 +216,7 @@ func (i *instance) CallOrFail(t test.Failer, opts echo.CallOptions) appEcho.Pars
 }
 
 func (i *instance) Dump() {
-	scopes.CI.Errorf("=== Dumping state for Echo %s..,", i.cfg.FQDN())
+	scopes.Framework.Errorf("=== Dumping state for Echo %s..,", i.cfg.FQDN())
 
 	for _, w := range i.workloads {
 		if w != nil {

--- a/pkg/test/framework/components/echo/docker/workload.go
+++ b/pkg/test/framework/components/echo/docker/workload.go
@@ -256,15 +256,15 @@ func (w *workload) Dump() {
 		return
 	}
 
-	scopes.CI.Errorf("=== Dumping state for Echo container %s to:\n%s", w.container.Name, w.dumpDir)
+	scopes.Framework.Errorf("=== Dumping state for Echo container %s to:\n%s", w.container.Name, w.dumpDir)
 	l, err := w.container.Logs()
 	if err != nil {
-		scopes.CI.Errorf("Unable to get logs for Echo container %s: %v", w.container.Name, err)
+		scopes.Framework.Errorf("Unable to get logs for Echo container %s: %v", w.container.Name, err)
 	}
 
 	fname := filepath.Join(w.dumpDir, "echo.log")
 	if err = ioutil.WriteFile(fname, []byte(l), os.ModePerm); err != nil {
-		scopes.CI.Errorf("Unable to write logs for Echo container %s: %v", w.container.Name, err)
+		scopes.Framework.Errorf("Unable to write logs for Echo container %s: %v", w.container.Name, err)
 	}
 
 	if w.sidecar != nil {
@@ -277,14 +277,14 @@ func (w *workload) Dump() {
 		for _, srcFile := range srcFiles {
 			result, err := w.container.Exec(context.Background(), "cat", srcFile)
 			if err != nil {
-				scopes.CI.Errorf("Unable to retrieve %s for Echo container %s: %v", srcFile, w.container.Name, err)
+				scopes.Framework.Errorf("Unable to retrieve %s for Echo container %s: %v", srcFile, w.container.Name, err)
 				continue
 			}
 
 			base := filepath.Base(srcFile)
 			fname = filepath.Join(w.dumpDir, base)
 			if err = ioutil.WriteFile(fname, result.StdOut, os.ModePerm); err != nil {
-				scopes.CI.Errorf("Unable to write %s for Echo container %s: %v", base, w.container.Name, err)
+				scopes.Framework.Errorf("Unable to write %s for Echo container %s: %v", base, w.container.Name, err)
 			}
 		}
 
@@ -301,7 +301,7 @@ func (w *workload) Dump() {
 			}
 		}
 		if err != nil {
-			scopes.CI.Errorf("Unable to retrieve config_dump for Echo container %s: %v", w.container.Name, err)
+			scopes.Framework.Errorf("Unable to retrieve config_dump for Echo container %s: %v", w.container.Name, err)
 		}
 	}
 }

--- a/pkg/test/framework/components/environment/kube/kube.go
+++ b/pkg/test/framework/components/environment/kube/kube.go
@@ -36,7 +36,7 @@ var _ resource.Environment = &Environment{}
 
 // New returns a new Kubernetes environment
 func New(ctx resource.Context, s *Settings) (resource.Environment, error) {
-	scopes.CI.Infof("Test Framework Kubernetes environment Settings:\n%s", s)
+	scopes.Framework.Infof("Test Framework Kubernetes environment Settings:\n%s", s)
 
 	workDir, err := ctx.CreateTmpDirectory("env-kube")
 	if err != nil {

--- a/pkg/test/framework/components/istio/istio.go
+++ b/pkg/test/framework/components/istio/istio.go
@@ -53,10 +53,10 @@ func Setup(i *Instance, cfn SetupConfigFn, ctxFns ...SetupContextFn) resource.Se
 				if ctxFn != nil {
 					err := ctxFn(ctx)
 					if err != nil {
-						scopes.CI.Infof("=== FAILED: context setup function [err=%v] ===", err)
+						scopes.Framework.Infof("=== FAILED: context setup function [err=%v] ===", err)
 						return err
 					}
-					scopes.CI.Info("=== SUCCESS: context setup function ===")
+					scopes.Framework.Info("=== SUCCESS: context setup function ===")
 				}
 			}
 			ins, err := Deploy(ctx, &cfg)
@@ -83,12 +83,12 @@ func Deploy(ctx resource.Context, cfg *Config) (Instance, error) {
 	}
 
 	var err error
-	scopes.CI.Infof("=== BEGIN: Deploy Istio [Suite=%s] ===", ctx.Settings().TestID)
+	scopes.Framework.Infof("=== BEGIN: Deploy Istio [Suite=%s] ===", ctx.Settings().TestID)
 	defer func() {
 		if err != nil {
-			scopes.CI.Infof("=== FAILED: Deploy Istio [Suite=%s] ===", ctx.Settings().TestID)
+			scopes.Framework.Infof("=== FAILED: Deploy Istio [Suite=%s] ===", ctx.Settings().TestID)
 		} else {
-			scopes.CI.Infof("=== SUCCEEDED: Deploy Istio [Suite=%s]===", ctx.Settings().TestID)
+			scopes.Framework.Infof("=== SUCCEEDED: Deploy Istio [Suite=%s]===", ctx.Settings().TestID)
 		}
 	}()
 

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -96,8 +96,8 @@ var leaderElectionConfigMaps = []string{
 }
 
 func (i *operatorComponent) Close() (err error) {
-	scopes.CI.Infof("=== BEGIN: Cleanup Istio [Suite=%s] ===", i.ctx.Settings().TestID)
-	defer scopes.CI.Infof("=== DONE: Cleanup Istio [Suite=%s] ===", i.ctx.Settings().TestID)
+	scopes.Framework.Infof("=== BEGIN: Cleanup Istio [Suite=%s] ===", i.ctx.Settings().TestID)
+	defer scopes.Framework.Infof("=== DONE: Cleanup Istio [Suite=%s] ===", i.ctx.Settings().TestID)
 	if i.settings.DeployIstio {
 		for _, cluster := range i.environment.KubeClusters {
 			if e := cluster.DeleteContents("", removeCRDs(i.installManifest[cluster.Name()])); e != nil {
@@ -123,12 +123,12 @@ func (i *operatorComponent) Close() (err error) {
 }
 
 func (i *operatorComponent) Dump() {
-	scopes.CI.Errorf("=== Dumping Istio Deployment State...")
+	scopes.Framework.Errorf("=== Dumping Istio Deployment State...")
 
 	for _, cluster := range i.environment.KubeClusters {
 		d, err := i.ctx.CreateTmpDirectory(fmt.Sprintf("istio-state-%s", cluster.Name()))
 		if err != nil {
-			scopes.CI.Errorf("Unable to create directory for dumping Istio contents: %v", err)
+			scopes.Framework.Errorf("Unable to create directory for dumping Istio contents: %v", err)
 			return
 		}
 		cluster.DumpPods(d, i.settings.SystemNamespace)
@@ -136,9 +136,9 @@ func (i *operatorComponent) Dump() {
 }
 
 func deploy(ctx resource.Context, env *kube.Environment, cfg Config) (Instance, error) {
-	scopes.CI.Infof("=== Istio Component Config ===")
-	scopes.CI.Infof("\n%s", cfg.String())
-	scopes.CI.Infof("================================")
+	scopes.Framework.Infof("=== Istio Component Config ===")
+	scopes.Framework.Infof("\n%s", cfg.String())
+	scopes.Framework.Infof("================================")
 
 	i := &operatorComponent{
 		environment:     env,
@@ -232,7 +232,7 @@ func deploy(ctx resource.Context, env *kube.Environment, cfg Config) (Instance, 
 }
 
 func createCrossNetworkGateway(cluster kube.Cluster, cfg Config) error {
-	scopes.CI.Infof("Setting up cross-network-gateway in cluster: %s namespace: %s", cluster.Name(), cfg.SystemNamespace)
+	scopes.Framework.Infof("Setting up cross-network-gateway in cluster: %s namespace: %s", cluster.Name(), cfg.SystemNamespace)
 	_, err := cluster.ApplyContents(cfg.SystemNamespace, fmt.Sprintf(`
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
@@ -333,7 +333,7 @@ func deployControlPlane(c *operatorComponent, cfg Config, cluster kube.Cluster, 
 		"--skip-confirmation",
 	}
 	cmd = append(cmd, installSettings...)
-	scopes.CI.Infof("Running istio control plane on cluster %s %v", cluster.Name(), cmd)
+	scopes.Framework.Infof("Running istio control plane on cluster %s %v", cluster.Name(), cmd)
 	if _, _, err := istioCtl.Invoke(cmd); err != nil {
 		return fmt.Errorf("manifest apply failed: %v", err)
 	}
@@ -414,7 +414,7 @@ func createRemoteSecret(ctx resource.Context, cluster kube.Cluster) (string, err
 		"--name", cluster.Name(),
 	}
 
-	scopes.CI.Infof("Creating remote secret for cluster cluster %d %v", cluster.Index(), cmd)
+	scopes.Framework.Infof("Creating remote secret for cluster cluster %d %v", cluster.Index(), cmd)
 	out, _, err := istioCtl.Invoke(cmd)
 	if err != nil {
 		return "", fmt.Errorf("create remote secret failed for cluster %d: %v", cluster.Index(), err)
@@ -461,13 +461,13 @@ func deployCACerts(workDir string, env *kube.Environment, cfg Config) error {
 
 		// Create the system namespace.
 		if err := cluster.CreateNamespace(cfg.SystemNamespace, ""); err != nil {
-			scopes.CI.Infof("failed creating namespace %s on cluster %s. This can happen when deploying "+
+			scopes.Framework.Infof("failed creating namespace %s on cluster %s. This can happen when deploying "+
 				"multiple control planes. Error: %v", cfg.SystemNamespace, cluster.Name(), err)
 		}
 
 		// Create the secret for the cacerts.
 		if err := cluster.CreateSecret(cfg.SystemNamespace, secret); err != nil {
-			scopes.CI.Infof("failed to create CA secrets on cluster %s. This can happen when deploying "+
+			scopes.Framework.Infof("failed to create CA secrets on cluster %s. This can happen when deploying "+
 				"multiple control planes. Error: %v", cluster.Name(), err)
 		}
 	}

--- a/pkg/test/framework/components/istio/util.go
+++ b/pkg/test/framework/components/istio/util.go
@@ -56,7 +56,7 @@ func waitForValidationWebhook(accessor *kube.Accessor, cfg Config) error {
 		}
 	}()
 
-	scopes.CI.Info("Creating dummy rule to check for validation webhook readiness")
+	scopes.Framework.Info("Creating dummy rule to check for validation webhook readiness")
 	return retry.UntilSuccess(func() error {
 		_, err := accessor.ApplyContents("", dummyValidationRule)
 		if err == nil {

--- a/pkg/test/framework/components/mixer/native.go
+++ b/pkg/test/framework/components/mixer/native.go
@@ -63,13 +63,13 @@ func newNative(ctx resource.Context, _ Config) (Instance, error) {
 	}
 
 	var err error
-	scopes.CI.Info("=== BEGIN: Starting local Mixer ===")
+	scopes.Framework.Info("=== BEGIN: Starting local Mixer ===")
 	defer func() {
 		if err != nil {
-			scopes.CI.Infof("=== FAILED: Start local Mixer ===")
+			scopes.Framework.Infof("=== FAILED: Start local Mixer ===")
 			_ = n.Close()
 		} else {
-			scopes.CI.Infof("=== SUCCEEDED: Start local Mixer ===")
+			scopes.Framework.Infof("=== SUCCEEDED: Start local Mixer ===")
 		}
 	}()
 

--- a/pkg/test/framework/components/namespace/kube.go
+++ b/pkg/test/framework/components/namespace/kube.go
@@ -46,11 +46,11 @@ type kubeNamespace struct {
 }
 
 func (n *kubeNamespace) Dump() {
-	scopes.CI.Errorf("=== Dumping Namespace %s State...", n.name)
+	scopes.Framework.Errorf("=== Dumping Namespace %s State...", n.name)
 
 	d, err := n.ctx.CreateTmpDirectory(n.name + "-state")
 	if err != nil {
-		scopes.CI.Errorf("Unable to create directory for dumping %s contents: %v", n.name, err)
+		scopes.Framework.Errorf("Unable to create directory for dumping %s contents: %v", n.name, err)
 		return
 	}
 

--- a/pkg/test/framework/components/policybackend/kube.go
+++ b/pkg/test/framework/components/policybackend/kube.go
@@ -172,13 +172,13 @@ func newKube(ctx resource.Context, cfg Config) (Instance, error) {
 	c.id = ctx.TrackResource(c)
 
 	var err error
-	scopes.CI.Infof("=== BEGIN: PolicyBackend Deployment ===")
+	scopes.Framework.Infof("=== BEGIN: PolicyBackend Deployment ===")
 	defer func() {
 		if err != nil {
-			scopes.CI.Infof("=== FAILED: PolicyBackend Deployment ===")
+			scopes.Framework.Infof("=== FAILED: PolicyBackend Deployment ===")
 			_ = c.Close()
 		} else {
-			scopes.CI.Infof("=== SUCCEEDED: PolicyBackend Deployment ===")
+			scopes.Framework.Infof("=== SUCCEEDED: PolicyBackend Deployment ===")
 		}
 	}()
 
@@ -209,21 +209,21 @@ func newKube(ctx resource.Context, cfg Config) (Instance, error) {
 
 	c.deployment = testKube.NewYamlContentDeployment(c.namespace.Name(), yamlContent, c.cluster.Accessor)
 	if err = c.deployment.Deploy(false); err != nil {
-		scopes.CI.Info("Error applying PolicyBackend deployment config")
+		scopes.Framework.Info("Error applying PolicyBackend deployment config")
 		return nil, err
 	}
 
 	podFetchFunc := c.cluster.NewSinglePodFetch(c.namespace.Name(), "app=policy-backend", "version=test")
 	pods, err := c.cluster.WaitUntilPodsAreReady(podFetchFunc)
 	if err != nil {
-		scopes.CI.Infof("Error waiting for PolicyBackend pod to become running: %v", err)
+		scopes.Framework.Infof("Error waiting for PolicyBackend pod to become running: %v", err)
 		return nil, err
 	}
 	pod := pods[0]
 
 	var svc *kubeApiCore.Service
 	if svc, _, err = c.cluster.WaitUntilServiceEndpointsAreReady(c.namespace.Name(), "policy-backend"); err != nil {
-		scopes.CI.Infof("Error waiting for PolicyBackend service to be available: %v", err)
+		scopes.Framework.Infof("Error waiting for PolicyBackend service to be available: %v", err)
 		return nil, err
 	}
 
@@ -232,17 +232,17 @@ func newKube(ctx resource.Context, cfg Config) (Instance, error) {
 
 	if c.forwarder, err = c.cluster.NewPortForwarder(
 		pod, 0, uint16(svc.Spec.Ports[0].TargetPort.IntValue())); err != nil {
-		scopes.CI.Infof("Error setting up PortForwarder for PolicyBackend: %v", err)
+		scopes.Framework.Infof("Error setting up PortForwarder for PolicyBackend: %v", err)
 		return nil, err
 	}
 
 	if err = c.forwarder.Start(); err != nil {
-		scopes.CI.Infof("Error starting PortForwarder for PolicyBackend: %v", err)
+		scopes.Framework.Infof("Error starting PortForwarder for PolicyBackend: %v", err)
 		return nil, err
 	}
 
 	if c.client.controller, err = policy.NewController(c.forwarder.Address()); err != nil {
-		scopes.CI.Infof("Error starting Controller for PolicyBackend: %v", err)
+		scopes.Framework.Infof("Error starting Controller for PolicyBackend: %v", err)
 		return nil, err
 	}
 
@@ -257,7 +257,7 @@ func (c *kubeComponent) CreateConfigSnippet(name string, _ string, am AdapterMod
 		handler := fmt.Sprintf(outOfProcessHandlerKube, c.namespace.Name(), c.namespace.Name(), c.namespace.Name())
 		return handler
 	default:
-		scopes.CI.Errorf("Error generating config snippet for policy backend: unsupported adapter mode")
+		scopes.Framework.Errorf("Error generating config snippet for policy backend: unsupported adapter mode")
 		return ""
 	}
 }
@@ -282,7 +282,7 @@ func (c *kubeComponent) Close() (err error) {
 func (c *kubeComponent) Dump() {
 	workDir, err := c.ctx.CreateTmpDirectory("policy-backend-state")
 	if err != nil {
-		scopes.CI.Errorf("Unable to create dump folder for policy-backend-state: %v", err)
+		scopes.Framework.Errorf("Unable to create dump folder for policy-backend-state: %v", err)
 		return
 	}
 	c.cluster.DumpPods(workDir, c.namespace.Name(),

--- a/pkg/test/framework/components/policybackend/native.go
+++ b/pkg/test/framework/components/policybackend/native.go
@@ -96,13 +96,13 @@ func newNative(ctx resource.Context) (Instance, error) {
 	c.id = ctx.TrackResource(c)
 
 	var err error
-	scopes.CI.Infof("=== BEGIN: Start local PolicyBackend ===")
+	scopes.Framework.Infof("=== BEGIN: Start local PolicyBackend ===")
 	defer func() {
 		if err != nil {
-			scopes.CI.Infof("=== FAILED: Start local PolicyBackend ===")
+			scopes.Framework.Infof("=== FAILED: Start local PolicyBackend ===")
 			_ = c.Close()
 		} else {
-			scopes.CI.Infof("=== SUCCEEDED: Start local PolicyBackend ===")
+			scopes.Framework.Infof("=== SUCCEEDED: Start local PolicyBackend ===")
 		}
 	}()
 
@@ -135,7 +135,7 @@ func (c *nativeComponent) CreateConfigSnippet(name string, namespace string, am 
 	case OutOfProcess:
 		return fmt.Sprintf(outOfProcessHandlerNative, c.backend.Port(), c.backend.Port())
 	default:
-		scopes.CI.Errorf("Error generating config snippet for policy backend: unsupported adapter mode")
+		scopes.Framework.Errorf("Error generating config snippet for policy backend: unsupported adapter mode")
 		return ""
 	}
 }

--- a/pkg/test/framework/components/redis/kube.go
+++ b/pkg/test/framework/components/redis/kube.go
@@ -49,14 +49,14 @@ func newKube(ctx resource.Context, cfg Config) (Instance, error) {
 	}
 	c.id = ctx.TrackResource(c)
 	var err error
-	scopes.CI.Info("=== BEGIN: Deploy Redis ===")
+	scopes.Framework.Info("=== BEGIN: Deploy Redis ===")
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("redis deployment failed: %v", err) // nolint:golint
-			scopes.CI.Infof("=== FAILED: Deploy Redis ===")
+			scopes.Framework.Infof("=== FAILED: Deploy Redis ===")
 			_ = c.Close()
 		} else {
-			scopes.CI.Info("=== SUCCEEDED: Deploy Redis ===")
+			scopes.Framework.Info("=== SUCCEEDED: Deploy Redis ===")
 		}
 	}()
 
@@ -112,7 +112,7 @@ func (c *kubeComponent) ID() resource.ID {
 
 // Close implements io.Closer.
 func (c *kubeComponent) Close() error {
-	scopes.CI.Infof("Deleting Redis Install")
+	scopes.Framework.Infof("Deleting Redis Install")
 	_ = c.cluster.DeleteNamespace(redisNamespace)
 	_ = c.cluster.WaitForNamespaceDeletion(redisNamespace)
 	return nil

--- a/pkg/test/framework/components/stackdriver/kube.go
+++ b/pkg/test/framework/components/stackdriver/kube.go
@@ -57,14 +57,14 @@ func newKube(ctx resource.Context, cfg Config) (Instance, error) {
 	}
 	c.id = ctx.TrackResource(c)
 	var err error
-	scopes.CI.Info("=== BEGIN: Deploy Stackdriver ===")
+	scopes.Framework.Info("=== BEGIN: Deploy Stackdriver ===")
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("stackdriver deployment failed: %v", err) // nolint:golint
-			scopes.CI.Infof("=== FAILED: Deploy Stackdriver ===")
+			scopes.Framework.Infof("=== FAILED: Deploy Stackdriver ===")
 			_ = c.Close()
 		} else {
-			scopes.CI.Info("=== SUCCEEDED: Deploy Stackdriver ===")
+			scopes.Framework.Info("=== SUCCEEDED: Deploy Stackdriver ===")
 		}
 	}()
 

--- a/pkg/test/framework/logging.go
+++ b/pkg/test/framework/logging.go
@@ -39,9 +39,9 @@ func configureLogging(ciMode bool) error {
 	o := *logOptionsFromCommandline
 
 	if ciMode {
-		o.SetOutputLevel(scopes.CI.Name(), log.InfoLevel)
+		o.SetOutputLevel(scopes.Framework.Name(), log.DebugLevel)
 	} else {
-		o.SetOutputLevel(scopes.CI.Name(), log.NoneLevel)
+		o.SetOutputLevel(scopes.Framework.Name(), log.NoneLevel)
 	}
 
 	return log.Configure(&o)

--- a/pkg/test/framework/suite.go
+++ b/pkg/test/framework/suite.go
@@ -98,7 +98,7 @@ func newSuite(testID string, fn mRunFn, osExit func(int), getSettingsFn getSetti
 // EnvironmentFactory sets a custom function used for creating the resource.Environment for this Suite.
 func (s *Suite) EnvironmentFactory(fn resource.EnvironmentFactory) *Suite {
 	if fn != nil && s.envFactory != nil {
-		scopes.CI.Warn("EnvironmentFactory overridden multiple times for Suite")
+		scopes.Framework.Warn("EnvironmentFactory overridden multiple times for Suite")
 	}
 	s.envFactory = fn
 	return s
@@ -301,22 +301,22 @@ func (s *Suite) run() (errLevel int) {
 
 	defer func() {
 		end := time.Now()
-		scopes.CI.Infof("=== Suite %q run time: %v ===", ctx.Settings().TestID, end.Sub(start))
+		scopes.Framework.Infof("=== Suite %q run time: %v ===", ctx.Settings().TestID, end.Sub(start))
 	}()
 
 	attempt := 0
 	for attempt <= ctx.settings.Retries {
 		attempt++
-		scopes.CI.Infof("=== BEGIN: Test Run: '%s' ===", ctx.Settings().TestID)
+		scopes.Framework.Infof("=== BEGIN: Test Run: '%s' ===", ctx.Settings().TestID)
 		errLevel = s.mRun(ctx)
 		if errLevel == 0 {
-			scopes.CI.Infof("=== DONE: Test Run: '%s' ===", ctx.Settings().TestID)
+			scopes.Framework.Infof("=== DONE: Test Run: '%s' ===", ctx.Settings().TestID)
 			break
 		} else {
-			scopes.CI.Infof("=== FAILED: Test Run: '%s' (exitCode: %v) ===",
+			scopes.Framework.Infof("=== FAILED: Test Run: '%s' (exitCode: %v) ===",
 				ctx.Settings().TestID, errLevel)
 			if attempt <= ctx.settings.Retries {
-				scopes.CI.Warnf("=== RETRY: Test Run: '%s' ===", ctx.Settings().TestID)
+				scopes.Framework.Warnf("=== RETRY: Test Run: '%s' ===", ctx.Settings().TestID)
 			}
 		}
 	}
@@ -357,7 +357,7 @@ func (s *Suite) writeOutput() {
 }
 
 func (s *Suite) runSetupFns(ctx SuiteContext) (err error) {
-	scopes.CI.Infof("=== BEGIN: Setup: '%s' ===", ctx.Settings().TestID)
+	scopes.Framework.Infof("=== BEGIN: Setup: '%s' ===", ctx.Settings().TestID)
 
 	// Run all the require functions first, then the setup functions.
 	setupFns := append(append([]resource.SetupFn{}, s.requireFns...), s.setupFns...)
@@ -366,7 +366,7 @@ func (s *Suite) runSetupFns(ctx SuiteContext) (err error) {
 		err := s.runSetupFn(fn, ctx)
 		if err != nil {
 			scopes.Framework.Errorf("Test setup error: %v", err)
-			scopes.CI.Infof("=== FAILED: Setup: '%s' (%v) ===", ctx.Settings().TestID, err)
+			scopes.Framework.Infof("=== FAILED: Setup: '%s' (%v) ===", ctx.Settings().TestID, err)
 			return err
 		}
 
@@ -374,7 +374,7 @@ func (s *Suite) runSetupFns(ctx SuiteContext) (err error) {
 			return nil
 		}
 	}
-	scopes.CI.Infof("=== DONE: Setup: '%s' ===", ctx.Settings().TestID)
+	scopes.Framework.Infof("=== DONE: Setup: '%s' ===", ctx.Settings().TestID)
 	return nil
 }
 
@@ -404,9 +404,9 @@ func initRuntime(s *Suite) error {
 		return err
 	}
 
-	scopes.CI.Infof("=== Test Framework Settings ===")
-	scopes.CI.Info(settings.String())
-	scopes.CI.Infof("===============================")
+	scopes.Framework.Infof("=== Test Framework Settings ===")
+	scopes.Framework.Info(settings.String())
+	scopes.Framework.Infof("===============================")
 
 	// Ensure that the work dir is set.
 	if err := os.MkdirAll(settings.RunDir(), os.ModePerm); err != nil {

--- a/pkg/test/framework/test.go
+++ b/pkg/test/framework/test.go
@@ -22,13 +22,13 @@ import (
 	"time"
 
 	"istio.io/istio/pkg/test/env"
+	"istio.io/istio/pkg/test/scopes"
 
 	"istio.io/pkg/log"
 
 	"istio.io/istio/pkg/test/framework/features"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource/environment"
-	"istio.io/istio/pkg/test/scopes"
 )
 
 // Test allows the test author to specify test-related metadata in a fluent-style, before commencing execution.
@@ -263,7 +263,7 @@ func (t *Test) doRun(ctx *testContext, fn func(ctx TestContext), parallel bool) 
 
 	start := time.Now()
 
-	scopes.CI.Infof("=== BEGIN: Test: '%s[%s]' ===", rt.suiteContext().Settings().TestID, t.goTest.Name())
+	scopes.Framework.Infof("=== BEGIN: Test: '%s[%s]' ===", rt.suiteContext().Settings().TestID, t.goTest.Name())
 	defer func() {
 		doneFn := func() {
 			message := "passed"
@@ -271,7 +271,7 @@ func (t *Test) doRun(ctx *testContext, fn func(ctx TestContext), parallel bool) 
 				message = "failed"
 			}
 			end := time.Now()
-			scopes.CI.Infof("=== DONE (%s):  Test: '%s[%s] (%v)' ===",
+			scopes.Framework.Infof("=== DONE (%s):  Test: '%s[%s] (%v)' ===",
 				message,
 				rt.suiteContext().Settings().TestID,
 				t.goTest.Name(),

--- a/pkg/test/kube/accessor.go
+++ b/pkg/test/kube/accessor.go
@@ -236,7 +236,7 @@ func (a *Accessor) WaitUntilPodsAreReady(fetchFunc PodFetchFunc, opts ...retry.O
 	var pods []kubeApiCore.Pod
 	_, err := retry.Do(func() (interface{}, bool, error) {
 
-		scopes.CI.Infof("Checking pods ready...")
+		scopes.Framework.Infof("Checking pods ready...")
 
 		fetched, err := a.CheckPodsAreReady(fetchFunc)
 		if err != nil {
@@ -251,11 +251,11 @@ func (a *Accessor) WaitUntilPodsAreReady(fetchFunc PodFetchFunc, opts ...retry.O
 
 // CheckPodsAreReady checks whether the pods that are selected by the given function is in ready state or not.
 func (a *Accessor) CheckPodsAreReady(fetchFunc PodFetchFunc) ([]kubeApiCore.Pod, error) {
-	scopes.CI.Infof("Checking pods ready...")
+	scopes.Framework.Infof("Checking pods ready...")
 
 	fetched, err := fetchFunc()
 	if err != nil {
-		scopes.CI.Infof("Failed retrieving pods: %v", err)
+		scopes.Framework.Infof("Failed retrieving pods: %v", err)
 		return nil, err
 	}
 
@@ -265,7 +265,7 @@ func (a *Accessor) CheckPodsAreReady(fetchFunc PodFetchFunc) ([]kubeApiCore.Pod,
 			msg = e.Error()
 			err = multierror.Append(err, fmt.Errorf("%s/%s: %s", p.Namespace, p.Name, msg))
 		}
-		scopes.CI.Infof("  [%2d] %45s %15s (%v)", i, p.Name, p.Status.Phase, msg)
+		scopes.Framework.Infof("  [%2d] %45s %15s (%v)", i, p.Name, p.Status.Phase, msg)
 	}
 
 	if err != nil {
@@ -281,7 +281,7 @@ func (a *Accessor) WaitUntilPodsAreDeleted(fetchFunc PodFetchFunc, opts ...retry
 
 		pods, err := fetchFunc()
 		if err != nil {
-			scopes.CI.Infof("Failed retrieving pods: %v", err)
+			scopes.Framework.Infof("Failed retrieving pods: %v", err)
 			return nil, false, err
 		}
 
@@ -744,9 +744,9 @@ func (a *Accessor) applyInternal(namespace string, files []string, dryRun bool) 
 
 func (a *Accessor) applyFile(namespace string, file string, dryRun bool) error {
 	if dryRun {
-		scopes.CI.Infof("Applying YAML file (DryRun mode): %v", file)
+		scopes.Framework.Infof("Applying YAML file (DryRun mode): %v", file)
 	} else {
-		scopes.CI.Infof("Applying YAML file: %v", file)
+		scopes.Framework.Infof("Applying YAML file: %v", file)
 	}
 
 	dynamicClient, err := a.clientFactory.DynamicClient()
@@ -810,7 +810,7 @@ func (a *Accessor) applyFile(namespace string, file string, dryRun bool) error {
 	if err := opts.Run(); err != nil {
 		// Concatenate the stdout and stderr
 		s := stdout.String() + stderr.String()
-		scopes.CI.Infof("(FAILED) Executing kubectl apply: %s (err: %v): %s", file, err, s)
+		scopes.Framework.Infof("(FAILED) Executing kubectl apply: %s (err: %v): %s", file, err, s)
 		return fmt.Errorf("%v: %s", err, s)
 	}
 	return nil
@@ -844,7 +844,7 @@ func (a *Accessor) deleteInternal(namespace string, files []string) (err error) 
 }
 
 func (a *Accessor) deleteFile(namespace string, file string) error {
-	scopes.CI.Infof("Deleting YAML file: %v", file)
+	scopes.Framework.Infof("Deleting YAML file: %v", file)
 	// Create the options.
 	streams, _, stdout, stderr := genericclioptions.NewTestIOStreams()
 
@@ -907,7 +907,7 @@ func (a *Accessor) deleteFile(namespace string, file string) error {
 	if err := opts.RunDelete(a.clientFactory); err != nil {
 		// Concatenate the stdout and stderr
 		s := stdout.String() + stderr.String()
-		scopes.CI.Infof("(FAILED) Executing kubectl delete: %s (err: %v): %s", file, err, s)
+		scopes.Framework.Infof("(FAILED) Executing kubectl delete: %s (err: %v): %s", file, err, s)
 		return fmt.Errorf("%v: %s", err, s)
 	}
 	return nil
@@ -955,7 +955,7 @@ func (a *Accessor) Logs(namespace string, pod string, container string, previous
 
 	if err != nil {
 		// Concatenate the stdout and stderr
-		scopes.CI.Infof("(FAILED) Executing kubectl logs (ns: %s, pod: %s, container: %s) (err: %v): %s",
+		scopes.Framework.Infof("(FAILED) Executing kubectl logs (ns: %s, pod: %s, container: %s) (err: %v): %s",
 			namespace, pod, container, err, s)
 		return s, fmt.Errorf("%v: %s", err, s)
 	}
@@ -1017,7 +1017,7 @@ func (a *Accessor) Exec(namespace, podName, containerName, command string) (stri
 
 	combined := stdout.String() + stderr.String()
 	if err != nil {
-		scopes.CI.Infof("(FAILED) Executing kubectl exec (ns: %s, pod: %s, container: %s, command: %s: %v: %s",
+		scopes.Framework.Infof("(FAILED) Executing kubectl exec (ns: %s, pod: %s, container: %s, command: %s: %v: %s",
 			namespace, podName, containerName, command, err, combined)
 		return combined, err
 	}
@@ -1210,11 +1210,11 @@ func removeEmptyFiles(files []string) []string {
 func isEmptyFile(f string) bool {
 	fileInfo, err := os.Stat(f)
 	if err != nil {
-		scopes.CI.Warnf("Error stating YAML file %s: %v", f, err)
+		scopes.Framework.Warnf("Error stating YAML file %s: %v", f, err)
 		return true
 	}
 	if fileInfo.Size() == 0 {
-		scopes.CI.Warnf("Unable to process empty YAML file: %s", f)
+		scopes.Framework.Warnf("Unable to process empty YAML file: %s", f)
 		return true
 	}
 	return false

--- a/pkg/test/kube/deployment.go
+++ b/pkg/test/kube/deployment.go
@@ -50,7 +50,7 @@ func (d *Deployment) Deploy(wait bool, opts ...retry.Option) (err error) {
 
 	if wait {
 		if _, err := d.accessor.WaitUntilPodsAreReady(d.accessor.NewPodFetch(d.namespace), opts...); err != nil {
-			scopes.CI.Errorf("Wait for Istio pods failed: %v", err)
+			scopes.Framework.Errorf("Wait for Istio pods failed: %v", err)
 			return err
 		}
 	}
@@ -67,11 +67,11 @@ func (d *Deployment) Delete(wait bool, opts ...retry.Option) (err error) {
 		}
 	} else if d.yamlFilePath != "" {
 		if err = d.accessor.Delete(d.namespace, d.yamlFilePath); err != nil {
-			scopes.CI.Warnf("Error deleting deployment: %v", err)
+			scopes.Framework.Warnf("Error deleting deployment: %v", err)
 		}
 	} else {
 		if err = d.accessor.DeleteContents(d.namespace, d.yamlContents); err != nil {
-			scopes.CI.Warnf("Error deleting deployment: %v", err)
+			scopes.Framework.Warnf("Error deleting deployment: %v", err)
 		}
 	}
 
@@ -79,7 +79,7 @@ func (d *Deployment) Delete(wait bool, opts ...retry.Option) (err error) {
 		// TODO: Just for waiting for deployment namespace deletion may not be enough. There are CRDs
 		// and roles/rolebindings in other parts of the system as well. We should also wait for deletion of them.
 		if e := d.accessor.WaitForNamespaceDeletion(d.namespace, opts...); e != nil {
-			scopes.CI.Warnf("Error waiting for environment deletion: %v", e)
+			scopes.Framework.Warnf("Error waiting for environment deletion: %v", e)
 			err = multierror.Append(err, e)
 		}
 	}

--- a/pkg/test/kube/dump.go
+++ b/pkg/test/kube/dump.go
@@ -21,9 +21,8 @@ import (
 	"path"
 
 	"github.com/gogo/protobuf/jsonpb"
-	kubeApiCore "k8s.io/api/core/v1"
-
 	"istio.io/istio/pkg/test/scopes"
+	kubeApiCore "k8s.io/api/core/v1"
 )
 
 // podDumper will dump information from all the pods into the given workDir.
@@ -45,7 +44,7 @@ func (a *Accessor) DumpPods(workDir, namespace string, dumpers ...podDumper) {
 
 	pods, err := a.GetPods(namespace)
 	if err != nil {
-		scopes.CI.Errorf("Error getting pods list via kubectl: %v", err)
+		scopes.Framework.Errorf("Error getting pods list via kubectl: %v", err)
 		return
 	}
 
@@ -59,7 +58,7 @@ func (a *Accessor) podsOrFetch(pods []kubeApiCore.Pod, namespace string) []kubeA
 		var err error
 		pods, err = a.GetPods(namespace)
 		if err != nil {
-			scopes.CI.Errorf("Error getting pods list via kubectl: %v", err)
+			scopes.Framework.Errorf("Error getting pods list via kubectl: %v", err)
 			return nil
 		}
 	}
@@ -77,14 +76,14 @@ func (a *Accessor) DumpPodState(workDir string, namespace string, pods ...kubeAp
 	for _, pod := range pods {
 		str, err := marshaler.MarshalToString(&pod)
 		if err != nil {
-			scopes.CI.Errorf("Error marshaling pod state for output: %v", err)
+			scopes.Framework.Errorf("Error marshaling pod state for output: %v", err)
 			continue
 		}
 
 		outPath := path.Join(workDir, fmt.Sprintf("pod_%s_%s.yaml", namespace, pod.Name))
 
 		if err := ioutil.WriteFile(outPath, []byte(str), os.ModePerm); err != nil {
-			scopes.CI.Infof("Error writing out pod state to file: %v", err)
+			scopes.Framework.Infof("Error writing out pod state to file: %v", err)
 		}
 	}
 }
@@ -100,7 +99,7 @@ func (a *Accessor) DumpPodEvents(workDir, namespace string, pods ...kubeApiCore.
 	for _, pod := range pods {
 		events, err := a.GetEvents(namespace, pod.Name)
 		if err != nil {
-			scopes.CI.Errorf("Error getting events list for pod %s/%s via kubectl: %v", namespace, pod.Name, err)
+			scopes.Framework.Errorf("Error getting events list for pod %s/%s via kubectl: %v", namespace, pod.Name, err)
 			return
 		}
 
@@ -110,7 +109,7 @@ func (a *Accessor) DumpPodEvents(workDir, namespace string, pods ...kubeApiCore.
 		for _, event := range events {
 			eventStr, err := marshaler.MarshalToString(&event)
 			if err != nil {
-				scopes.CI.Errorf("Error marshaling pod event for output: %v", err)
+				scopes.Framework.Errorf("Error marshaling pod event for output: %v", err)
 				continue
 			}
 
@@ -119,7 +118,7 @@ func (a *Accessor) DumpPodEvents(workDir, namespace string, pods ...kubeApiCore.
 		}
 
 		if err := ioutil.WriteFile(outPath, []byte(eventsStr), os.ModePerm); err != nil {
-			scopes.CI.Infof("Error writing out pod events to file: %v", err)
+			scopes.Framework.Infof("Error writing out pod events to file: %v", err)
 		}
 	}
 }
@@ -134,13 +133,13 @@ func (a *Accessor) DumpPodLogs(workDir, namespace string, pods ...kubeApiCore.Po
 		for _, container := range containers {
 			l, err := a.Logs(pod.Namespace, pod.Name, container.Name, false /* previousLog */)
 			if err != nil {
-				scopes.CI.Errorf("Unable to get logs for pod/container: %s/%s/%s", pod.Namespace, pod.Name, container.Name)
+				scopes.Framework.Errorf("Unable to get logs for pod/container: %s/%s/%s", pod.Namespace, pod.Name, container.Name)
 				continue
 			}
 
 			fname := path.Join(workDir, fmt.Sprintf("%s-%s.log", pod.Name, container.Name))
 			if err = ioutil.WriteFile(fname, []byte(l), os.ModePerm); err != nil {
-				scopes.CI.Errorf("Unable to write logs for pod/container: %s/%s/%s", pod.Namespace, pod.Name, container.Name)
+				scopes.Framework.Errorf("Unable to write logs for pod/container: %s/%s/%s", pod.Namespace, pod.Name, container.Name)
 			}
 		}
 	}
@@ -161,19 +160,19 @@ func (a *Accessor) DumpPodProxies(workDir, namespace string, pods ...kubeApiCore
 			if cfgDump, err := a.Exec(pod.Namespace, pod.Name, container.Name, "pilot-agent request GET config_dump"); err == nil {
 				fname := path.Join(workDir, fmt.Sprintf("%s-%s.config.json", pod.Name, container.Name))
 				if err = ioutil.WriteFile(fname, []byte(cfgDump), os.ModePerm); err != nil {
-					scopes.CI.Errorf("Unable to write config dump for pod/container: %s/%s/%s", pod.Namespace, pod.Name, container.Name)
+					scopes.Framework.Errorf("Unable to write config dump for pod/container: %s/%s/%s", pod.Namespace, pod.Name, container.Name)
 				}
 			} else {
-				scopes.CI.Errorf("Unable to get istio-proxy config dump for pod: %s/%s", pod.Namespace, pod.Name)
+				scopes.Framework.Errorf("Unable to get istio-proxy config dump for pod: %s/%s", pod.Namespace, pod.Name)
 			}
 
 			if cfgDump, err := a.Exec(pod.Namespace, pod.Name, container.Name, "pilot-agent request GET clusters"); err == nil {
 				fname := path.Join(workDir, fmt.Sprintf("%s-%s.clusters.txt", pod.Name, container.Name))
 				if err = ioutil.WriteFile(fname, []byte(cfgDump), os.ModePerm); err != nil {
-					scopes.CI.Errorf("Unable to write clusters for pod/container: %s/%s/%s", pod.Namespace, pod.Name, container.Name)
+					scopes.Framework.Errorf("Unable to write clusters for pod/container: %s/%s/%s", pod.Namespace, pod.Name, container.Name)
 				}
 			} else {
-				scopes.CI.Errorf("Unable to get istio-proxy clusters for pod: %s/%s", pod.Namespace, pod.Name)
+				scopes.Framework.Errorf("Unable to get istio-proxy clusters for pod: %s/%s", pod.Namespace, pod.Name)
 			}
 		}
 	}

--- a/pkg/test/scopes/scopes.go
+++ b/pkg/test/scopes/scopes.go
@@ -19,7 +19,4 @@ import "istio.io/pkg/log"
 var (
 	// Framework is the general logging scope for the framework.
 	Framework = log.RegisterScope("tf", "General scope for the test framework", 0)
-
-	// CI system specific logging scope.
-	CI = log.RegisterScope("ci", "Scope for normal log reporting to be used in CI systems", 0)
 )

--- a/tests/integration/operator/switch_cr_test.go
+++ b/tests/integration/operator/switch_cr_test.go
@@ -108,7 +108,7 @@ func TestController(t *testing.T) {
 			installWithCRFile(t, ctx, cs, s, istioCtl, "demo")
 			// cleanup created resources
 			t.Cleanup(func() {
-				scopes.CI.Infof("cleaning up resources")
+				scopes.Framework.Infof("cleaning up resources")
 				if err := cs.Delete(IstioNamespace, iopCRFile); err != nil {
 					t.Errorf("faild to delete test IstioOperator CR: %v", err)
 				}
@@ -121,7 +121,7 @@ func TestController(t *testing.T) {
 
 // checkInstallStatus check the status of IstioOperator CR from the cluster
 func checkInstallStatus(cs kube.Cluster) error {
-	scopes.CI.Infof("checking IstioOperator CR status")
+	scopes.Framework.Infof("checking IstioOperator CR status")
 	gvr := schema.GroupVersionResource{
 		Group:    "install.istio.io",
 		Version:  "v1alpha1",
@@ -178,7 +178,7 @@ func checkInstallStatus(cs kube.Cluster) error {
 
 func installWithCRFile(t *testing.T, ctx resource.Context, cs kube.Cluster, s *image.Settings,
 	istioCtl istioctl.Instance, profileName string) {
-	scopes.CI.Infof(fmt.Sprintf("=== install istio with profile: %s===\n", profileName))
+	scopes.Framework.Infof(fmt.Sprintf("=== install istio with profile: %s===\n", profileName))
 	metadataYAML := `
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
@@ -209,7 +209,7 @@ spec:
 // verifyInstallation verify IOP CR status and compare in-cluster resources with generated ones.
 func verifyInstallation(t *testing.T, ctx resource.Context,
 	istioCtl istioctl.Instance, profileName string, cs kube.Cluster) {
-	scopes.CI.Infof("=== verifying istio installation === ")
+	scopes.Framework.Infof("=== verifying istio installation === ")
 	if err := checkInstallStatus(cs); err != nil {
 		t.Fatalf("IstioOperator status not healthy: %v", err)
 	}
@@ -222,11 +222,11 @@ func verifyInstallation(t *testing.T, ctx resource.Context,
 		t.Fatalf("in cluster resources does not match with the generated ones: %v", err)
 	}
 	sanityCheck(t, ctx)
-	scopes.CI.Infof("=== succeeded ===")
+	scopes.Framework.Infof("=== succeeded ===")
 }
 
 func sanityCheck(t *testing.T, ctx resource.Context) {
-	scopes.CI.Infof("running sanity test")
+	scopes.Framework.Infof("running sanity test")
 	var client, server echo.Instance
 	test := namespace.NewOrFail(t, ctx, namespace.Config{
 		Prefix: "default",

--- a/tests/integration/pilot/locality/distribute_test.go
+++ b/tests/integration/pilot/locality/distribute_test.go
@@ -89,7 +89,7 @@ func TestDistribute(t *testing.T) {
 					"b": 20,
 					"c": 80,
 				})
-				scopes.CI.Errorf("%v: ", e)
+				scopes.Framework.Errorf("%v: ", e)
 				return e
 			}, retry.Timeout(time.Second*5)); err != nil {
 				ctx.Fatal(err)
@@ -118,7 +118,7 @@ func TestDistribute(t *testing.T) {
 					"b": 33,
 					"c": 33,
 				})
-				scopes.CI.Errorf("%v: ", e)
+				scopes.Framework.Errorf("%v: ", e)
 				return e
 			}, retry.Delay(time.Second*5)); err != nil {
 				ctx.Fatal(err)

--- a/tests/integration/pilot/sidecar_api_test.go
+++ b/tests/integration/pilot/sidecar_api_test.go
@@ -72,7 +72,7 @@ func TestSidecarListeners(t *testing.T) {
 			}
 			defer func() {
 				if err := ctx.DeleteConfigDir("", path); err != nil {
-					scopes.CI.Errorf("failed to delete directory: %v", err)
+					scopes.Framework.Errorf("failed to delete directory: %v", err)
 				}
 			}()
 

--- a/tests/integration/telemetry/dashboard_test.go
+++ b/tests/integration/telemetry/dashboard_test.go
@@ -203,7 +203,7 @@ func checkMetric(p prometheus.Instance, query string, excluded []string) error {
 		}
 	} else {
 		if numSamples != 0 {
-			scopes.CI.Infof("Filtered out metric '%v', but got samples: %v", query, value)
+			scopes.Framework.Infof("Filtered out metric '%v', but got samples: %v", query, value)
 		}
 	}
 	return nil


### PR DESCRIPTION
Please provide a description for what this PR is for.

Resolves: https://github.com/istio/istio/issues/24376

There were two scoped loggers defined, `CI` and `Framework`, no clear definition of when one should be used over the other.  Removed CI logger, and modified the `"--istio.test.ci` flag to configure `Framework` logger to either Debug or None

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ X ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
