### PR TITLE
pilot integration tests use all configured clusters

### DIFF
--- a/pkg/test/framework/components/echo/config.go
+++ b/pkg/test/framework/components/echo/config.go
@@ -87,6 +87,10 @@ type Config struct {
 
 	// The image name to be used to pull the image for the VM. `DeployAsVM` must be enabled.
 	VMImage string
+
+	// SetupFn will run after any internal modification to the config to give the user a chance
+	// to apply final setup before deploying.
+	SetupFn func(*Config)
 }
 
 // SubsetConfig is the config for a group of Subsets (e.g. Kubernetes deployment).

--- a/pkg/test/framework/components/echo/echo.go
+++ b/pkg/test/framework/components/echo/echo.go
@@ -16,6 +16,7 @@ package echo
 
 import (
 	"context"
+	"strings"
 
 	envoyAdmin "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
 	dto "github.com/prometheus/client_model/go"
@@ -183,6 +184,12 @@ func (r Result) Get(filter func(Instance) bool) Result {
 		}
 	}
 	return out
+}
+
+func (r Result) GetByServiceNamePrefix(prefix string) Result {
+	return r.Get(func(i Instance) bool {
+		return strings.HasPrefix(i.Config().Service, prefix)
+	})
 }
 
 func (r Result) GetByServiceName(service string) Result {

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -23,14 +23,10 @@ import (
 
 	"github.com/Masterminds/sprig"
 
-	"istio.io/istio/pkg/test/framework/resource"
-
 	"istio.io/istio/pkg/test/framework/components/echo"
-	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/image"
 	"istio.io/istio/pkg/test/framework/resource"
-	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/test/util/tmpl"
 )
@@ -338,7 +334,11 @@ func generateYAMLWithSettings(ctx resource.Context, cfg echo.Config,
 	if cfg.DeployAsVM {
 		var addr net.TCPAddr
 		err = retry.UntilSuccess(func() error {
-			addr, err = istio.GetRemoteDiscoveryAddress(ctx, "istio-system", cluster)
+			var i istio.Instance
+			if err := ctx.GetResource(&i); err != nil {
+				return err
+			}
+			addr, err = istio.GetRemoteDiscoveryAddress(ctx, i.Settings().SystemNamespace, cluster)
 			return err
 		}, retry.Timeout(time.Minute))
 		if err != nil {

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/Masterminds/sprig"
 
+	"istio.io/istio/pkg/test/framework/resource"
+
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/istio"
@@ -334,19 +336,9 @@ func generateYAMLWithSettings(ctx resource.Context, cfg echo.Config,
 
 	var vmImage, istiodIP, istiodPort string
 	if cfg.DeployAsVM {
-		s, err := kube.NewSettingsFromCommandLine()
-		if err != nil {
-			return "", "", err
-		}
-		cpCluster, err := ctx.Environment().(*kube.Environment).GetControlPlaneCluster(cluster)
-		if err != nil {
-			scopes.Framework.Errorf("failed getting control-plane for cluster %d; trying to use it as a control-plane cluster", cluster.Index())
-			cpCluster = cluster
-		}
-
 		var addr net.TCPAddr
 		err = retry.UntilSuccess(func() error {
-			addr, err = istio.GetRemoteDiscoveryAddress("istio-system", cpCluster.(kube.Cluster), s.Minikube)
+			addr, err = istio.GetRemoteDiscoveryAddress(ctx, "istio-system", cluster)
 			return err
 		}, retry.Timeout(time.Minute))
 		if err != nil {

--- a/pkg/test/framework/components/echo/kube/deployment_test.go
+++ b/pkg/test/framework/components/echo/kube/deployment_test.go
@@ -139,7 +139,7 @@ func TestDeploymentYAML(t *testing.T) {
 			tc.config.Cluster = resource.FakeCluster{
 				NameValue: "cluster-0",
 			}
-			serviceYAML, deploymentYAML, err := generateYAMLWithSettings(tc.config, settings, kube.Cluster{})
+			serviceYAML, deploymentYAML, err := generateYAMLWithSettings(nil, tc.config, settings, kube.Cluster{})
 			if err != nil {
 				t.Errorf("failed to generate yaml %v", err)
 			}

--- a/pkg/test/framework/components/echo/kube/instance.go
+++ b/pkg/test/framework/components/echo/kube/instance.go
@@ -87,7 +87,7 @@ func newInstance(ctx resource.Context, cfg echo.Config) (out *instance, err erro
 	}
 
 	// Generate the service and deployment YAML.
-	serviceYAML, deploymentYAML, err := generateYAML(cfg, c.cluster)
+	serviceYAML, deploymentYAML, err := generateYAML(ctx, cfg, c.cluster)
 	if err != nil {
 		return nil, fmt.Errorf("generate yaml: %v", err)
 	}

--- a/pkg/test/framework/components/environment/kube/flags.go
+++ b/pkg/test/framework/components/environment/kube/flags.go
@@ -201,7 +201,10 @@ func init() {
 	flag.StringVar(&kubeConfigs, "istio.test.kube.config", strings.Join(settingsFromCommandLine.KubeConfig, ":"),
 		"A comma-separated list of paths to kube config files for cluster environments (default is current kube context)")
 	flag.BoolVar(&settingsFromCommandLine.Minikube, "istio.test.kube.minikube", settingsFromCommandLine.Minikube,
-		"Indicates that the target environment is Minikube. Used by Ingress component to obtain the right IP address..")
+		"Indicates that the target environment is Minikube. Used by to obtain the right IP address for ingress gateway.")
+	flag.BoolVar(&settingsFromCommandLine.Metallb, "istio.test.kube.metallb", settingsFromCommandLine.Minikube,
+		"Indicates that the target environment is running MetalLB to add External IP support. Used by to obtain the "+
+			"right IP address for ingress gateway.")
 	flag.StringVar(&controlPlaneTopology, "istio.test.kube.controlPlaneTopology",
 		"", "Specifies the mapping for each cluster to the cluster hosting its control plane. The value is a "+
 			"comma-separated list of the form <clusterIndex>:<controlPlaneClusterIndex>, where the indexes refer to the order in which "+

--- a/pkg/test/framework/components/environment/kube/flags.go
+++ b/pkg/test/framework/components/environment/kube/flags.go
@@ -200,11 +200,10 @@ func defaultKubeConfig() string {
 func init() {
 	flag.StringVar(&kubeConfigs, "istio.test.kube.config", strings.Join(settingsFromCommandLine.KubeConfig, ":"),
 		"A comma-separated list of paths to kube config files for cluster environments (default is current kube context)")
-	flag.BoolVar(&settingsFromCommandLine.Minikube, "istio.test.kube.minikube", settingsFromCommandLine.Minikube,
-		"Indicates that the target environment is Minikube. Used by to obtain the right IP address for ingress gateway.")
-	flag.BoolVar(&settingsFromCommandLine.Metallb, "istio.test.kube.metallb", settingsFromCommandLine.Minikube,
-		"Indicates that the target environment is running MetalLB to add External IP support. Used by to obtain the "+
-			"right IP address for ingress gateway.")
+	flag.BoolVar(&settingsFromCommandLine.NoLoadBalancer, "istio.test.kube.minikube", settingsFromCommandLine.NoLoadBalancer,
+		"(legacy) Indicates that the target environment does not support External Loadbalancers. Used by to obtain the right IP address for ingress gateway.")
+	flag.BoolVar(&settingsFromCommandLine.NoLoadBalancer, "istio.test.kube.noloadbalancer", settingsFromCommandLine.NoLoadBalancer,
+		"Indicates that the target environment does not support External Loadbalancers. Used by to obtain the right IP address for ingress gateway.")
 	flag.StringVar(&controlPlaneTopology, "istio.test.kube.controlPlaneTopology",
 		"", "Specifies the mapping for each cluster to the cluster hosting its control plane. The value is a "+
 			"comma-separated list of the form <clusterIndex>:<controlPlaneClusterIndex>, where the indexes refer to the order in which "+

--- a/pkg/test/framework/components/environment/kube/flags.go
+++ b/pkg/test/framework/components/environment/kube/flags.go
@@ -46,8 +46,8 @@ func NewSettingsFromCommandLine() (*Settings, error) {
 	if !flag.Parsed() {
 		panic("flag.Parse must be called before this function")
 	}
-
 	s := settingsFromCommandLine.clone()
+	s.NoLoadBalancer = s.NoLoadBalancer || s.minikube
 
 	var err error
 	s.KubeConfig, err = parseKubeConfigs(kubeConfigs)
@@ -200,9 +200,9 @@ func defaultKubeConfig() string {
 func init() {
 	flag.StringVar(&kubeConfigs, "istio.test.kube.config", strings.Join(settingsFromCommandLine.KubeConfig, ":"),
 		"A comma-separated list of paths to kube config files for cluster environments (default is current kube context)")
-	flag.BoolVar(&settingsFromCommandLine.NoLoadBalancer, "istio.test.kube.minikube", settingsFromCommandLine.NoLoadBalancer,
-		"(legacy) Indicates that the target environment does not support External Loadbalancers. Used by to obtain the right IP address for ingress gateway.")
-	flag.BoolVar(&settingsFromCommandLine.NoLoadBalancer, "istio.test.kube.noloadbalancer", settingsFromCommandLine.NoLoadBalancer,
+	flag.BoolVar(&settingsFromCommandLine.minikube, "istio.test.kube.minikube", settingsFromCommandLine.NoLoadBalancer,
+		"Indicates that the target environment does not support External Loadbalancers. Used by to obtain the right IP address for ingress gateway. (legacy, use lbunsupported)")
+	flag.BoolVar(&settingsFromCommandLine.NoLoadBalancer, "istio.test.kube.lbunsupported", settingsFromCommandLine.NoLoadBalancer,
 		"Indicates that the target environment does not support External Loadbalancers. Used by to obtain the right IP address for ingress gateway.")
 	flag.StringVar(&controlPlaneTopology, "istio.test.kube.controlPlaneTopology",
 		"", "Specifies the mapping for each cluster to the cluster hosting its control plane. The value is a "+

--- a/pkg/test/framework/components/environment/kube/settings.go
+++ b/pkg/test/framework/components/environment/kube/settings.go
@@ -37,9 +37,12 @@ type Settings struct {
 	// instances for interacting with clusters. If not specified, the clients will be created from KubeConfig.
 	ClientFactoryFunc ClientFactoryFunc
 
-	// Indicates that the Ingress Gateway is not available. This typically happens in Minikube. The Ingress
+	// NoLoadBalancer indicates that the Ingress Gateway is not available. This typically happens in minikube. The Ingress
 	// component will fall back to node-port in this case.
 	NoLoadBalancer bool
+
+	// minikube is the legacy version of the NoLoadBalancer flag.
+	minikube bool
 
 	// ControlPlaneTopology maps each cluster to the cluster that runs its control plane. For replicated control
 	// plane cases (where each cluster has its own control plane), the cluster will map to itself (e.g. 0->0).

--- a/pkg/test/framework/components/environment/kube/settings.go
+++ b/pkg/test/framework/components/environment/kube/settings.go
@@ -19,10 +19,9 @@ import (
 	"fmt"
 
 	istioKube "istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/framework/resource/environment"
 	"istio.io/istio/pkg/test/scopes"
-
-	"istio.io/istio/pkg/test/framework/resource"
 )
 
 // ClientFactoryFunc is a transformation function that creates k8s clients
@@ -40,10 +39,7 @@ type Settings struct {
 
 	// Indicates that the Ingress Gateway is not available. This typically happens in Minikube. The Ingress
 	// component will fall back to node-port in this case.
-	Minikube bool
-
-	// Indicates that issues caused by minikube/kind have been worked around and should not fall back to node-port.
-	Metallb bool
+	NoLoadBalancer bool
 
 	// ControlPlaneTopology maps each cluster to the cluster that runs its control plane. For replicated control
 	// plane cases (where each cluster has its own control plane), the cluster will map to itself (e.g. 0->0).
@@ -83,12 +79,6 @@ func (s *Settings) GetControlPlaneClusters() map[resource.ClusterIndex]bool {
 	return out
 }
 
-// SupportsExternalIP returns whether or not Services will acquire a public ip. If not, NodePort and host IP must be
-// used to workaround this.
-func (s *Settings) SupportsExternalIP() bool {
-	return !s.Minikube || s.Metallb
-}
-
 // NewClients creates the kubernetes clients for interacting with the configured clusters.
 func (s *Settings) NewClients() ([]istioKube.ExtendedClient, error) {
 	newClientsFn := s.ClientFactoryFunc
@@ -111,7 +101,7 @@ func (s *Settings) String() string {
 	result := ""
 
 	result += fmt.Sprintf("KubeConfig:           %s\n", s.KubeConfig)
-	result += fmt.Sprintf("MiniKubeIngress:      %v\n", s.Minikube)
+	result += fmt.Sprintf("NoExternalLoadBalancer:      %v\n", s.NoLoadBalancer)
 	result += fmt.Sprintf("ControlPlaneTopology: %v\n", s.ControlPlaneTopology)
 	result += fmt.Sprintf("NetworkTopology:      %v\n", s.networkTopology)
 

--- a/pkg/test/framework/components/environment/kube/settings.go
+++ b/pkg/test/framework/components/environment/kube/settings.go
@@ -42,6 +42,9 @@ type Settings struct {
 	// component will fall back to node-port in this case.
 	Minikube bool
 
+	// Indicates that issues caused by minikube/kind have been worked around and should not fall back to node-port.
+	Metallb bool
+
 	// ControlPlaneTopology maps each cluster to the cluster that runs its control plane. For replicated control
 	// plane cases (where each cluster has its own control plane), the cluster will map to itself (e.g. 0->0).
 	ControlPlaneTopology map[resource.ClusterIndex]resource.ClusterIndex
@@ -78,6 +81,12 @@ func (s *Settings) GetControlPlaneClusters() map[resource.ClusterIndex]bool {
 		out[controlPlaneClusterIndex] = true
 	}
 	return out
+}
+
+// SupportsExternalIP returns whether or not Services will acquire a public ip. If not, NodePort and host IP must be
+// used to workaround this.
+func (s *Settings) SupportsExternalIP() bool {
+	return !s.Minikube || s.Metallb
 }
 
 // NewClients creates the kubernetes clients for interacting with the configured clusters.

--- a/pkg/test/framework/components/ingress/ingress.go
+++ b/pkg/test/framework/components/ingress/ingress.go
@@ -85,13 +85,13 @@ type Instance interface {
 	resource.Resource
 
 	// HTTPAddress returns the external HTTP address of the ingress gateway (or the NodePort address,
-	// when running under Minikube).
+	// when running with NoLoadBalancer).
 	HTTPAddress() net.TCPAddr
 	// HTTPSAddress returns the external HTTPS address of the ingress gateway (or the
-	// NodePort address, when running under Minikube).
+	// NodePort address, when running with NoLoadBalancer).
 	HTTPSAddress() net.TCPAddr
 	// TCPAddress returns the external TCP address of the ingress gateway (or the NodePort address,
-	// when running under Minikube).
+	// when running with NoLoadBalancer).
 	TCPAddress() net.TCPAddr
 
 	//  Call makes a call through ingress.

--- a/pkg/test/framework/components/ingress/kube.go
+++ b/pkg/test/framework/components/ingress/kube.go
@@ -63,7 +63,7 @@ type kubeComponent struct {
 func (c *kubeComponent) getAddressInner(ns string, port int) (interface{}, bool, error) {
 	// environments that don't support assigning external IPs (e.g. kind without metallb) can workaround
 	// by using host ip + NodePort
-	if !c.env.Settings().SupportsExternalIP() {
+	if c.env.Settings().NoLoadBalancer {
 		pods, err := c.cluster.PodsForSelector(context.TODO(), ns, fmt.Sprintf("istio=%s", istioLabel))
 		if err != nil {
 			return nil, false, err

--- a/pkg/test/framework/components/ingress/kube.go
+++ b/pkg/test/framework/components/ingress/kube.go
@@ -61,9 +61,9 @@ type kubeComponent struct {
 
 // getHTTPAddressInner returns the ingress gateway address for plain text http requests.
 func (c *kubeComponent) getAddressInner(ns string, port int) (interface{}, bool, error) {
-	// In Minikube, we don't have the ingress gateway. Instead we do a little bit of trickery to to get the Node
-	// port.
-	if c.env.Settings().Minikube {
+	// environments that don't support assigning external IPs (e.g. kind without metallb) can workaround
+	// by using host ip + NodePort
+	if !c.env.Settings().SupportsExternalIP() {
 		pods, err := c.cluster.PodsForSelector(context.TODO(), ns, fmt.Sprintf("istio=%s", istioLabel))
 		if err != nil {
 			return nil, false, err

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -568,14 +568,8 @@ func configureDirectAPIServiceAccessForCluster(ctx resource.Context, env *kube.E
 	if err != nil {
 		return fmt.Errorf("failed creating remote secret for cluster %s: %v", cluster.Name(), err)
 	}
-	// Copy this secret to all control plane clusters.
-	for _, remote := range env.ControlPlaneClusters() {
-		remote := remote.(kube.Cluster)
-		if cluster.Index() != remote.Index() {
-			if err := ctx.Config(remote).ApplyYAML(cfg.SystemNamespace, secret); err != nil {
-				return fmt.Errorf("failed applying remote secret to cluster %s: %v", remote.Name(), err)
-			}
-		}
+	if err := ctx.Config(env.ControlPlaneClusters(cluster)...).ApplyYAML(cfg.SystemNamespace, secret); err != nil {
+		return fmt.Errorf("failed applying remote secret to clusters: %v", err)
 	}
 	return nil
 }

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -212,7 +212,7 @@ func deploy(ctx resource.Context, env *kube.Environment, cfg Config) (Instance, 
 	if isCentralIstio(env, cfg) {
 		for _, cluster := range env.KubeClusters {
 			if env.IsControlPlaneCluster(cluster) {
-				if err := patchIstiodCustomHost(cfg, cluster); err != nil {
+				if err := patchIstiodCustomHost(ctx, cfg, cluster); err != nil {
 					return nil, err
 				}
 			}
@@ -280,11 +280,11 @@ func deploy(ctx resource.Context, env *kube.Environment, cfg Config) (Instance, 
 	return i, nil
 }
 
-func patchIstiodCustomHost(cfg Config, cluster resource.Cluster) error {
+func patchIstiodCustomHost(ctx resource.Context, cfg Config, cluster resource.Cluster) error {
 	var remoteIstiodAddress net.TCPAddr
 	if err := retry.UntilSuccess(func() error {
 		var err error
-		remoteIstiodAddress, err = GetRemoteDiscoveryAddress(cfg.SystemNamespace, cluster, false)
+		remoteIstiodAddress, err = GetRemoteDiscoveryAddress(ctx, cfg.SystemNamespace, cluster)
 		return err
 	}, retry.Timeout(1*time.Minute)); err != nil {
 		return fmt.Errorf("failed getting the istiod address for cluster %s: %v", cluster.Name(), err)
@@ -447,7 +447,7 @@ func deployControlPlane(c *operatorComponent, cfg Config, cluster resource.Clust
 			var remoteIstiodAddress net.TCPAddr
 			if err := retry.UntilSuccess(func() error {
 				var err error
-				remoteIstiodAddress, err = GetRemoteDiscoveryAddress(cfg.SystemNamespace, controlPlaneCluster, false)
+				remoteIstiodAddress, err = GetRemoteDiscoveryAddress(cfg.SystemNamespace, controlPlaneCluster)
 				return err
 			}, retry.Timeout(1*time.Minute)); err != nil {
 				return fmt.Errorf("failed getting the istiod address for cluster %s: %v", controlPlaneCluster.Name(), err)

--- a/pkg/test/framework/components/istio/util.go
+++ b/pkg/test/framework/components/istio/util.go
@@ -78,7 +78,7 @@ func GetRemoteDiscoveryAddress(ctx resource.Context, namespace string, cluster r
 	}
 	cpCluster := cpResCluster.(kubeenv.Cluster)
 
-	// TODO(landow) deal with ingress circular endpoint; only unique code here is getting the control-plane cluster
+	// TODO(landow) deal with ingress circular dependency; only unique code here is getting the control-plane cluster
 
 	svc, err := cpCluster.CoreV1().Services(namespace).Get(context.TODO(), igwServiceName, kubeApiMeta.GetOptions{})
 	if err != nil {
@@ -87,7 +87,7 @@ func GetRemoteDiscoveryAddress(ctx resource.Context, namespace string, cluster r
 
 	// environments that don't support assigning external IPs (e.g. kind without metallb) can workaround
 	// by using host ip + NodePort
-	if !env.Settings().SupportsExternalIP() {
+	if env.Settings().NoLoadBalancer {
 		pods, err := cpCluster.PodsForSelector(context.TODO(), namespace, "istio=ingressgateway")
 		if err != nil {
 			return net.TCPAddr{}, err

--- a/pkg/test/framework/features/features.yaml
+++ b/pkg/test/framework/features/features.yaml
@@ -38,6 +38,7 @@ features:
     routing:
     short-circuiting:
     mirroring:
+    shifting:
   usability:
     observability:
       status:

--- a/pkg/test/framework/features/features.yaml
+++ b/pkg/test/framework/features/features.yaml
@@ -39,6 +39,7 @@ features:
     short-circuiting:
     mirroring:
     shifting:
+    expansion:
   usability:
     observability:
       status:

--- a/pkg/test/framework/resource/environment.go
+++ b/pkg/test/framework/resource/environment.go
@@ -42,6 +42,9 @@ type Environment interface {
 	// Clusters in this Environment. There will always be at least one.
 	Clusters() []Cluster
 
+	// GetControlPlaneCluster returns the cluster running the control plane for the given cluster based on the ControlPlaneTopology.
+	GetControlPlaneCluster(Cluster) (Cluster, error)
+
 	// Case calls the given function if this environment has the given name.
 	Case(e environment.Name, fn func())
 }
@@ -83,6 +86,10 @@ func (f FakeEnvironment) Clusters() []Cluster {
 		}
 	}
 	return out
+}
+
+func (f FakeEnvironment) GetControlPlaneCluster(cluster Cluster) (Cluster, error) {
+	return cluster, nil
 }
 
 func (f FakeEnvironment) Case(environment.Name, func()) {

--- a/pkg/test/framework/resource/environment.go
+++ b/pkg/test/framework/resource/environment.go
@@ -39,8 +39,13 @@ type Environment interface {
 	// IsMulticluster is a utility method that indicates whether there are multiple Clusters available.
 	IsMulticluster() bool
 
+	// IsMultinetwork returns true if there are multiple networks in the cluster topology
+	IsMultinetwork() bool
+
 	// Clusters in this Environment. There will always be at least one.
 	Clusters() []Cluster
+
+	ControlPlaneClusters(excludedClusters ...Cluster) []Cluster
 
 	// GetControlPlaneCluster returns the cluster running the control plane for the given cluster based on the ControlPlaneTopology.
 	GetControlPlaneCluster(Cluster) (Cluster, error)
@@ -67,6 +72,10 @@ func (f FakeEnvironment) IsMulticluster() bool {
 	return f.NumClusters > 1
 }
 
+func (f FakeEnvironment) IsMultinetwork() bool {
+	return false
+}
+
 func (f FakeEnvironment) ID() ID {
 	return FakeID(f.IDValue)
 }
@@ -86,6 +95,10 @@ func (f FakeEnvironment) Clusters() []Cluster {
 		}
 	}
 	return out
+}
+
+func (f FakeEnvironment) ControlPlaneClusters(excludedClusters ...Cluster) []Cluster {
+	return f.Clusters()
 }
 
 func (f FakeEnvironment) GetControlPlaneCluster(cluster Cluster) (Cluster, error) {

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -87,7 +87,7 @@ while (( "$#" )); do
   esac
 done
 
-# KinD will not have a LoadBalancer, so we need to disable it
+# KinD setup by lib.sh will install metallb to support LoadBalancer with external IPss
 export TEST_ENV=kind
 
 # See https://kind.sigs.k8s.io/docs/user/quick-start/#loading-an-image-into-your-cluster
@@ -119,11 +119,11 @@ if [[ -z "${SKIP_SETUP:-}" ]]; then
   if [[ "${TOPOLOGY}" == "SINGLE_CLUSTER" ]]; then
     time setup_kind_cluster "${IP_FAMILY}" "${NODE_IMAGE:-}"
   else
+    export TEST_ENV=kind_metallb
     # TODO: Support IPv6 multicluster
     time setup_kind_clusters "${TOPOLOGY}" "${NODE_IMAGE:-}"
 
     # Set the kube configs to point to the clusters.
-    export INTEGRATION_TEST_FLAGS="--istio.test.kube.metallb"
     export INTEGRATION_TEST_KUBECONFIG="${CLUSTER1_KUBECONFIG},${CLUSTER2_KUBECONFIG},${CLUSTER3_KUBECONFIG}"
     export INTEGRATION_TEST_NETWORKS="0:test-network-0,1:test-network-0,2:test-network-1"
     export INTEGRATION_TEST_CONTROLPLANE_TOPOLOGY="0:0,1:0,2:2"

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -125,6 +125,7 @@ if [[ -z "${SKIP_SETUP:-}" ]]; then
     # Set the kube configs to point to the clusters.
     export INTEGRATION_TEST_KUBECONFIG="${CLUSTER1_KUBECONFIG},${CLUSTER2_KUBECONFIG},${CLUSTER3_KUBECONFIG}"
     export INTEGRATION_TEST_NETWORKS="0:test-network-0,1:test-network-0,2:test-network-1"
+    export INTEGRATION_TEST_CONTROLPLANE_TOPOLOGY="0:0,1:0,2:2"
   fi
 fi
 

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -123,6 +123,7 @@ if [[ -z "${SKIP_SETUP:-}" ]]; then
     time setup_kind_clusters "${TOPOLOGY}" "${NODE_IMAGE:-}"
 
     # Set the kube configs to point to the clusters.
+    export INTEGRATION_TEST_FLAGS="--istio.test.kube.metallb"
     export INTEGRATION_TEST_KUBECONFIG="${CLUSTER1_KUBECONFIG},${CLUSTER2_KUBECONFIG},${CLUSTER3_KUBECONFIG}"
     export INTEGRATION_TEST_NETWORKS="0:test-network-0,1:test-network-0,2:test-network-1"
     export INTEGRATION_TEST_CONTROLPLANE_TOPOLOGY="0:0,1:0,2:2"

--- a/tests/integration/multicluster/helper.go
+++ b/tests/integration/multicluster/helper.go
@@ -23,6 +23,7 @@ import (
 	"istio.io/istio/pkg/test/echo/client"
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/components/pilot"
 	"istio.io/istio/pkg/test/framework/resource"
@@ -33,6 +34,30 @@ var (
 	retryTimeout = time.Second * 30
 	retryDelay   = time.Millisecond * 100
 )
+
+// SetupPilots populates a non-nil map from cluster indices to pilot component instances.
+// Returns an error if used in a non-kubernetes environment.
+func SetupPilots(pilots *[]pilot.Instance) resource.SetupFn {
+	return func(ctx resource.Context) error {
+		env := ctx.Environment().(*kube.Environment)
+		p := make([]pilot.Instance, len(env.KubeClusters))
+		for _, c := range env.KubeClusters {
+			cp, err := env.GetControlPlaneCluster(c)
+			if err != nil {
+				return err
+			}
+			if inst := p[cp.Index()]; inst == nil {
+				p[cp.Index()], err = pilot.New(ctx, pilot.Config{Cluster: cp})
+				if err != nil {
+					return fmt.Errorf("error creating pilot instance for cluster %d: %v", cp.Index(), err)
+				}
+			}
+			p[c.Index()] = p[cp.Index()]
+		}
+		*pilots = p
+		return nil
+	}
+}
 
 func Setup(controlPlaneValues *string, clusterLocalNS, mcReachabilityNS *namespace.Instance) func(ctx resource.Context) error {
 	return func(ctx resource.Context) (err error) {

--- a/tests/integration/multicluster/multimaster/main_test.go
+++ b/tests/integration/multicluster/multimaster/main_test.go
@@ -20,6 +20,7 @@ import (
 	"istio.io/istio/tests/integration/multicluster"
 
 	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/components/pilot"
@@ -40,6 +41,14 @@ func TestMain(m *testing.M) {
 		Label(label.Multicluster).
 		RequireMinClusters(2).
 		Setup(multicluster.Setup(&controlPlaneValues, &clusterLocalNS, &mcReachabilityNS)).
+		Setup(kube.Setup(func(s *kube.Settings) {
+			// Make all clusters independent
+			s.ControlPlaneTopology = make(map[resource.ClusterIndex]resource.ClusterIndex)
+			for i := 0; i < len(s.KubeConfig); i++ {
+				idx := resource.ClusterIndex(i)
+				s.ControlPlaneTopology[idx] = idx
+			}
+		})).
 		Setup(istio.Setup(&ist, func(cfg *istio.Config) {
 			// Set the control plane values on the config.
 			cfg.ControlPlaneValues = controlPlaneValues

--- a/tests/integration/multicluster/multimaster/main_test.go
+++ b/tests/integration/multicluster/multimaster/main_test.go
@@ -53,17 +53,7 @@ func TestMain(m *testing.M) {
 			// Set the control plane values on the config.
 			cfg.ControlPlaneValues = controlPlaneValues
 		})).
-		Setup(func(ctx resource.Context) (err error) {
-			pilots = make([]pilot.Instance, len(ctx.Environment().Clusters()))
-			for i, cluster := range ctx.Environment().Clusters() {
-				if pilots[i], err = pilot.New(ctx, pilot.Config{
-					Cluster: cluster,
-				}); err != nil {
-					return err
-				}
-			}
-			return nil
-		}).
+		Setup(multicluster.SetupPilots(&pilots)).
 		Run()
 }
 

--- a/tests/integration/multicluster/remote/main_test.go
+++ b/tests/integration/multicluster/remote/main_test.go
@@ -54,17 +54,7 @@ func TestMain(m *testing.M) {
 			// Set the control plane values on the config.
 			cfg.ControlPlaneValues = controlPlaneValues
 		})).
-		Setup(func(ctx resource.Context) (err error) {
-			pilots = make([]pilot.Instance, len(ctx.Environment().Clusters()))
-			for i, cluster := range ctx.Environment().Clusters() {
-				if pilots[i], err = pilot.New(ctx, pilot.Config{
-					Cluster: cluster,
-				}); err != nil {
-					return err
-				}
-			}
-			return nil
-		}).
+		Setup(multicluster.SetupPilots(&pilots)).
 		Run()
 }
 

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -75,6 +75,7 @@ Next Step: Add related labels to the deployment to align with Istio's requiremen
 
 func TestWait(t *testing.T) {
 	framework.NewTest(t).
+		RequiresSingleCluster().
 		Run(func(ctx framework.TestContext) {
 			ns := namespace.NewOrFail(t, ctx, namespace.Config{
 				Prefix: "default",
@@ -94,7 +95,7 @@ spec:
     - destination: 
         host: reviews
 `)
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{Cluster: ctx.Environment().Clusters()[0]})
 			istioCtl.InvokeOrFail(t, []string{"x", "wait", "VirtualService", "reviews." + ns.Name()})
 		})
 }
@@ -104,11 +105,11 @@ spec:
 func TestVersion(t *testing.T) {
 	framework.
 		NewTest(t).
+		RequiresSingleCluster().
 		Run(func(ctx framework.TestContext) {
 			cfg := i.Settings()
 
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
-
+			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{Cluster: ctx.Environment().Clusters()[0]})
 			args := []string{"version", "--remote=true", fmt.Sprintf("--istioNamespace=%s", cfg.SystemNamespace)}
 
 			output, _ := istioCtl.InvokeOrFail(t, args)
@@ -144,6 +145,7 @@ func TestVersion(t *testing.T) {
 
 func TestDescribe(t *testing.T) {
 	framework.NewTest(t).
+		RequiresSingleCluster().
 		RunParallel(func(ctx framework.TestContext) {
 			ns := namespace.NewOrFail(ctx, ctx, namespace.Config{
 				Prefix: "istioctl-describe",
@@ -152,16 +154,17 @@ func TestDescribe(t *testing.T) {
 
 			deployment := file.AsStringOrFail(t, "../istioctl/testdata/a.yaml")
 			ctx.Config().ApplyYAMLOrFail(t, ns.Name(), deployment)
+			cluster := ctx.Environment().Clusters()[0]
 
 			var a echo.Instance
 			echoboot.NewBuilderOrFail(ctx, ctx).
-				With(&a, echoConfig(ns, "a")).
+				With(&a, echoConfig(ns, "a", cluster)).
 				BuildOrFail(ctx)
 
 			if err := a.WaitUntilCallable(a); err != nil {
 				t.Fatal(err)
 			}
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{Cluster: ctx.Environment().Clusters()[0]})
 
 			podID, err := getPodID(a)
 			if err != nil {
@@ -204,6 +207,7 @@ func getPodID(i echo.Instance) (string, error) {
 
 func TestAddToAndRemoveFromMesh(t *testing.T) {
 	framework.NewTest(t).
+		RequiresSingleCluster().
 		RunParallel(func(ctx framework.TestContext) {
 			ns := namespace.NewOrFail(t, ctx, namespace.Config{
 				Prefix: "istioctl-add-to-mesh",
@@ -212,10 +216,10 @@ func TestAddToAndRemoveFromMesh(t *testing.T) {
 
 			var a echo.Instance
 			echoboot.NewBuilderOrFail(ctx, ctx).
-				With(&a, echoConfig(ns, "a")).
+				With(&a, echoConfig(ns, "a", ctx.Environment().Clusters()[0])).
 				BuildOrFail(ctx)
 
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{Cluster: ctx.Environment().Clusters()[0]})
 
 			var output string
 			var args []string
@@ -242,6 +246,7 @@ func TestAddToAndRemoveFromMesh(t *testing.T) {
 
 func TestProxyConfig(t *testing.T) {
 	framework.NewTest(t).
+		RequiresSingleCluster().
 		Run(func(ctx framework.TestContext) {
 			ns := namespace.NewOrFail(ctx, ctx, namespace.Config{
 				Prefix: "istioctl-pc",
@@ -250,10 +255,10 @@ func TestProxyConfig(t *testing.T) {
 
 			var a echo.Instance
 			echoboot.NewBuilderOrFail(ctx, ctx).
-				With(&a, echoConfig(ns, "a")).
+				With(&a, echoConfig(ns, "a", ctx.Environment().Clusters()[0])).
 				BuildOrFail(ctx)
 
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{Cluster: ctx.Environment().Clusters()[0]})
 
 			podID, err := getPodID(a)
 			if err != nil {
@@ -315,6 +320,7 @@ func jsonUnmarshallOrFail(t *testing.T, context, s string) interface{} {
 
 func TestProxyStatus(t *testing.T) {
 	framework.NewTest(t).
+		RequiresSingleCluster().
 		Run(func(ctx framework.TestContext) {
 			ns := namespace.NewOrFail(ctx, ctx, namespace.Config{
 				Prefix: "istioctl-ps",
@@ -323,10 +329,10 @@ func TestProxyStatus(t *testing.T) {
 
 			var a echo.Instance
 			echoboot.NewBuilderOrFail(ctx, ctx).
-				With(&a, echoConfig(ns, "a")).
+				With(&a, echoConfig(ns, "a", ctx.Environment().Clusters()[0])).
 				BuildOrFail(ctx)
 
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{Cluster: ctx.Environment().Clusters()[0]})
 
 			podID, err := getPodID(a)
 			if err != nil {
@@ -354,6 +360,7 @@ func TestProxyStatus(t *testing.T) {
 
 func TestAuthZCheck(t *testing.T) {
 	framework.NewTest(t).
+		RequiresSingleCluster().
 		Run(func(ctx framework.TestContext) {
 			ns := namespace.NewOrFail(ctx, ctx, namespace.Config{
 				Prefix: "istioctl-authz",
@@ -365,10 +372,10 @@ func TestAuthZCheck(t *testing.T) {
 
 			var a echo.Instance
 			echoboot.NewBuilderOrFail(ctx, ctx).
-				With(&a, echoConfig(ns, "a")).
+				With(&a, echoConfig(ns, "a", ctx.Environment().Clusters()[0])).
 				BuildOrFail(ctx)
 
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{Cluster: ctx.Environment().Clusters()[0]})
 
 			podID, err := getPodID(a)
 			if err != nil {

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -95,7 +95,7 @@ spec:
     - destination: 
         host: reviews
 `)
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{Cluster: ctx.Environment().Clusters()[0]})
+			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
 			istioCtl.InvokeOrFail(t, []string{"x", "wait", "VirtualService", "reviews." + ns.Name()})
 		})
 }
@@ -109,7 +109,7 @@ func TestVersion(t *testing.T) {
 		Run(func(ctx framework.TestContext) {
 			cfg := i.Settings()
 
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{Cluster: ctx.Environment().Clusters()[0]})
+			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
 			args := []string{"version", "--remote=true", fmt.Sprintf("--istioNamespace=%s", cfg.SystemNamespace)}
 
 			output, _ := istioCtl.InvokeOrFail(t, args)
@@ -154,17 +154,16 @@ func TestDescribe(t *testing.T) {
 
 			deployment := file.AsStringOrFail(t, "../istioctl/testdata/a.yaml")
 			ctx.Config().ApplyYAMLOrFail(t, ns.Name(), deployment)
-			cluster := ctx.Environment().Clusters()[0]
 
 			var a echo.Instance
 			echoboot.NewBuilderOrFail(ctx, ctx).
-				With(&a, echoConfig(ns, "a", cluster)).
+				With(&a, echoConfig(ns, "a")).
 				BuildOrFail(ctx)
 
 			if err := a.WaitUntilCallable(a); err != nil {
 				t.Fatal(err)
 			}
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{Cluster: ctx.Environment().Clusters()[0]})
+			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
 
 			podID, err := getPodID(a)
 			if err != nil {
@@ -216,10 +215,10 @@ func TestAddToAndRemoveFromMesh(t *testing.T) {
 
 			var a echo.Instance
 			echoboot.NewBuilderOrFail(ctx, ctx).
-				With(&a, echoConfig(ns, "a", ctx.Environment().Clusters()[0])).
+				With(&a, echoConfig(ns, "a")).
 				BuildOrFail(ctx)
 
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{Cluster: ctx.Environment().Clusters()[0]})
+			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
 
 			var output string
 			var args []string
@@ -255,10 +254,10 @@ func TestProxyConfig(t *testing.T) {
 
 			var a echo.Instance
 			echoboot.NewBuilderOrFail(ctx, ctx).
-				With(&a, echoConfig(ns, "a", ctx.Environment().Clusters()[0])).
+				With(&a, echoConfig(ns, "a")).
 				BuildOrFail(ctx)
 
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{Cluster: ctx.Environment().Clusters()[0]})
+			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
 
 			podID, err := getPodID(a)
 			if err != nil {
@@ -329,10 +328,10 @@ func TestProxyStatus(t *testing.T) {
 
 			var a echo.Instance
 			echoboot.NewBuilderOrFail(ctx, ctx).
-				With(&a, echoConfig(ns, "a", ctx.Environment().Clusters()[0])).
+				With(&a, echoConfig(ns, "a")).
 				BuildOrFail(ctx)
 
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{Cluster: ctx.Environment().Clusters()[0]})
+			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
 
 			podID, err := getPodID(a)
 			if err != nil {
@@ -372,10 +371,10 @@ func TestAuthZCheck(t *testing.T) {
 
 			var a echo.Instance
 			echoboot.NewBuilderOrFail(ctx, ctx).
-				With(&a, echoConfig(ns, "a", ctx.Environment().Clusters()[0])).
+				With(&a, echoConfig(ns, "a")).
 				BuildOrFail(ctx)
 
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{Cluster: ctx.Environment().Clusters()[0]})
+			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
 
 			podID, err := getPodID(a)
 			if err != nil {

--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -50,7 +50,15 @@ values:
 		Run()
 }
 
-func echoConfig(ns namespace.Instance, name string, cluster resource.Cluster) echo.Config {
+func echoConfig(ns namespace.Instance, name string) echo.Config {
+	return echoConfigForCluster(ns, name, nil)
+}
+
+func echoConfigForCluster(ns namespace.Instance, name string, cluster resource.Cluster) echo.Config {
+	p := pilots[0]
+	if cluster != nil {
+		p = pilots[cluster.Index()]
+	}
 	return echo.Config{
 		Service:   name,
 		Namespace: ns,
@@ -64,6 +72,6 @@ func echoConfig(ns namespace.Instance, name string, cluster resource.Cluster) ec
 			},
 		},
 		Subsets: []echo.SubsetConfig{{}},
-		Pilot:   pilots[cluster.Index()],
+		Pilot:   p,
 	}
 }

--- a/tests/integration/pilot/meshnetwork/main_test.go
+++ b/tests/integration/pilot/meshnetwork/main_test.go
@@ -133,10 +133,9 @@ func TestAsymmetricMeshNetworkWithGatewayIP(t *testing.T) {
 			})
 
 			// First setup the VM service and its endpoints
-			for _, cp := range ctx.Environment().ControlPlaneClusters() {
-				if err := ctx.Config(cp).ApplyYAML(ns.Name(), VMService); err != nil {
-					t.Fatal(err)
-				}
+			if err := ctx.Config(ctx.Environment().ControlPlaneClusters()...).
+				ApplyYAML(ns.Name(), VMService); err != nil {
+				t.Fatal(err)
 			}
 
 			// Now setup a K8S service in each cluster

--- a/tests/integration/pilot/mirror_test.go
+++ b/tests/integration/pilot/mirror_test.go
@@ -32,6 +32,7 @@ import (
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/util/file"
 	"istio.io/istio/pkg/test/util/tmpl"
@@ -39,7 +40,8 @@ import (
 )
 
 //	Virtual service topology
-//
+//                                  in each cluster
+//                                /                  \
 //	    a                      b                     c
 //	|-------|             |-------|    mirror   |-------|
 //	| Host0 | ----------> | Host1 | ----------> | Host2 |
@@ -52,6 +54,16 @@ type VirtualServiceMirrorConfig struct {
 	Absent     bool
 	Percent    float64
 	MirrorHost string
+	TargetHost string
+}
+
+// ExternalServiceMirrorConfig sets up a Sidecar and ServiceEntry to prevent mirrored service from being called directly.
+type ExternalServiceMirrorConfig struct {
+	Namespace     string
+	Domain        string
+	MirrorHost    string
+	MirrorAddress string
+	TargetHost    string
 }
 
 type testCaseMirror struct {
@@ -64,8 +76,9 @@ type testCaseMirror struct {
 type mirrorTestOptions struct {
 	t              *testing.T
 	cases          []testCaseMirror
-	mirrorHost     string
-	fnInjectConfig func(ns namespace.Instance, ctx resource.Context, instances [3]echo.Instance)
+	mirrorHostFmt  string
+	fnInjectConfig func(ns namespace.Instance, ctx resource.Context, mirrorHost string, client, target, mirrored echo.Instance) (cleanup func())
+	skipCondition  func(src kube.Cluster, dest kube.Cluster) (string, bool)
 }
 
 var (
@@ -112,44 +125,7 @@ func TestMirroring(t *testing.T) {
 // Thus when "a" tries to mirror to the external service, it is actually connecting to "c" (which is not part of the
 // mesh because of the Sidecar), then we can inspect "c" logs to verify the requests were properly mirrored.
 
-const (
-	fakeExternalURL = "external-website-url-just-for-testing.extension"
-
-	serviceEntry = `
-apiVersion: networking.istio.io/v1alpha3
-kind: ServiceEntry
-metadata:
-  name: external-service
-spec:
-  hosts:
-  - %s
-  location: MESH_EXTERNAL
-  ports:
-  - name: http
-    number: 80
-    protocol: HTTP
-  - name: grpc
-    number: 7070
-    protocol: GRPC
-  resolution: STATIC
-  endpoints:
-  - address: %s
-`
-
-	sidecar = `
-apiVersion: networking.istio.io/v1alpha3
-kind: Sidecar
-metadata:
-  name: restrict-to-service-entry
-spec:
-  egress:
-  - hosts:
-    - "./b.%s.svc.%s"
-    - "*/%s"
-  outboundTrafficPolicy:
-    mode: REGISTRY_ONLY
-`
-)
+const fakeExternalURL = "external-website-url-just-for-testing-%d.extension"
 
 func TestMirroringExternalService(t *testing.T) {
 	cases := []testCaseMirror{
@@ -162,15 +138,29 @@ func TestMirroringExternalService(t *testing.T) {
 	}
 
 	runMirrorTest(mirrorTestOptions{
-		t:          t,
-		cases:      cases,
-		mirrorHost: fakeExternalURL,
-		fnInjectConfig: func(ns namespace.Instance, ctx resource.Context, instances [3]echo.Instance) {
-			ctx.Config().ApplyYAMLOrFail(t, ns.Name(), fmt.Sprintf(sidecar, ns.Name(),
-				instances[1].Config().Domain, fakeExternalURL))
-			ctx.Config().ApplyYAMLOrFail(t, ns.Name(), fmt.Sprintf(serviceEntry, fakeExternalURL, instances[2].Address()))
-			if err := outboundtrafficpolicy.WaitUntilNotCallable(instances[0], instances[2]); err != nil {
+		t:             t,
+		cases:         cases,
+		mirrorHostFmt: fakeExternalURL,
+		skipCondition: func(src, dest kube.Cluster) (string, bool) {
+			// TODO make the fake "external website" via ServiceEntry work with the cross-network gateway
+			return "external service via ServiceEntry doesn't work across networks", src.NetworkName() != dest.NetworkName()
+		},
+		fnInjectConfig: func(ns namespace.Instance, ctx resource.Context, mirrorHost string, client, target, mirrored echo.Instance) (cleanup func()) {
+			cfg := ExternalServiceMirrorConfig{
+				Namespace:     ns.Name(),
+				Domain:        target.Config().Domain,
+				MirrorHost:    mirrorHost,
+				MirrorAddress: mirrored.Address(),
+				TargetHost:    target.Config().Service,
+			}
+			deployment := tmpl.EvaluateOrFail(t,
+				file.AsStringOrFail(t, "testdata/traffic-mirroring-external-serviceentry.yaml"), cfg)
+			ctx.Config().ApplyYAMLOrFail(t, ns.Name(), deployment)
+			if err := outboundtrafficpolicy.WaitUntilNotCallable(client, mirrored); err != nil {
 				t.Fatalf("failed to apply sidecar, %v", err)
+			}
+			return func() {
+				ctx.Config().DeleteYAMLOrFail(t, ns.Name(), deployment)
 			}
 		},
 	})
@@ -179,66 +169,92 @@ func TestMirroringExternalService(t *testing.T) {
 func runMirrorTest(options mirrorTestOptions) {
 	framework.
 		NewTest(options.t).
-		RequiresSingleCluster().
 		Run(func(ctx framework.TestContext) {
 			ns := namespace.NewOrFail(options.t, ctx, namespace.Config{
 				Prefix: "mirroring",
 				Inject: true,
 			})
 
-			var instances [3]echo.Instance
-			echoboot.NewBuilderOrFail(options.t, ctx).
-				With(&instances[0], echoConfig(ns, "a")). // client
-				With(&instances[1], echoConfig(ns, "b")). // target
-				With(&instances[2], echoConfig(ns, "c")). // receives mirrored requests
-				BuildOrFail(options.t)
-
-			if options.fnInjectConfig != nil {
-				options.fnInjectConfig(ns, ctx, instances)
+			builder := echoboot.NewBuilderOrFail(options.t, ctx)
+			clusterInstances := make([][3]echo.Instance, len(ctx.Environment().Clusters()))
+			for _, c := range ctx.Environment().Clusters() {
+				clusterInstances[c.Index()] = [3]echo.Instance{}
+				builder = builder.
+					With(&clusterInstances[c.Index()][0], echoConfig(ns, fmt.Sprintf("a-%d", c.Index()), c)). // client
+					With(&clusterInstances[c.Index()][1], echoConfig(ns, fmt.Sprintf("b-%d", c.Index()), c)). // target
+					With(&clusterInstances[c.Index()][2], echoConfig(ns, fmt.Sprintf("c-%d", c.Index()), c))  // receives mirrored requests
 			}
+			builder.BuildOrFail(options.t)
 
-			for _, c := range options.cases {
-				options.t.Run(c.name, func(t *testing.T) {
-					mirrorHost := options.mirrorHost
-					if len(mirrorHost) == 0 {
-						mirrorHost = instances[2].Config().Service
-					}
-					vsc := VirtualServiceMirrorConfig{
-						c.name,
-						ns.Name(),
-						c.absent,
-						c.percentage,
-						mirrorHost,
-					}
-
-					deployment := tmpl.EvaluateOrFail(t,
-						file.AsStringOrFail(t, "testdata/traffic-mirroring-template.yaml"), vsc)
-					ctx.Config().ApplyYAMLOrFail(t, ns.Name(), deployment)
-					defer ctx.Config().DeleteYAMLOrFail(t, ns.Name(), deployment)
-
-					for _, proto := range mirrorProtocols {
-						t.Run(string(proto), func(t *testing.T) {
-							retry.UntilSuccessOrFail(t, func() error {
-								testID := util.RandomString(16)
-								if err := sendTrafficMirror(instances, proto, testID); err != nil {
-									return err
+			for _, srcCluster := range ctx.Environment().Clusters() {
+				for _, dstCluster := range ctx.Environment().Clusters() {
+					for _, c := range options.cases {
+						options.t.Run(c.name, func(t *testing.T) {
+							if options.skipCondition != nil {
+								if msg, skip := options.skipCondition(srcCluster.(kube.Cluster), dstCluster.(kube.Cluster)); skip {
+									t.Skip(msg)
 								}
+							}
 
-								if err := verifyTrafficMirror(instances, c, testID); err != nil {
-									return err
-								}
-								return nil
-							}, retry.Delay(time.Second))
+							client := clusterInstances[srcCluster.Index()][0]
+							target := clusterInstances[dstCluster.Index()][1]
+							mirrored := clusterInstances[dstCluster.Index()][2]
+
+							mirrorHost := mirrored.Config().Service
+							if len(options.mirrorHostFmt) > 0 {
+								mirrorHost = fmt.Sprintf(options.mirrorHostFmt, dstCluster.Index())
+							}
+							vsc := VirtualServiceMirrorConfig{
+								Name:       c.name,
+								Namespace:  ns.Name(),
+								Absent:     c.absent,
+								Percent:    c.percentage,
+								MirrorHost: mirrorHost,
+								TargetHost: clusterInstances[dstCluster.Index()][1].Config().Service,
+							}
+
+							if options.fnInjectConfig != nil {
+								cleanup := options.fnInjectConfig(ns, ctx, mirrorHost, client, target, mirrored)
+								defer cleanup()
+							}
+
+							deployment := tmpl.EvaluateOrFail(t,
+								file.AsStringOrFail(t, "testdata/traffic-mirroring-template.yaml"), vsc)
+							ctx.Config().ApplyYAMLOrFail(t, ns.Name(), deployment)
+							defer ctx.Config().DeleteYAMLOrFail(t, ns.Name(), deployment)
+
+							for _, proto := range mirrorProtocols {
+								t.Run(fmt.Sprintf("%d->%d %s", srcCluster.Index(), dstCluster.Index(), proto), func(t *testing.T) {
+									retry.UntilSuccessOrFail(t, func() error {
+										testID := fmt.Sprintf("%s_%d_%d_%s_%s",
+											options.t.Name(),
+											srcCluster.Index(),
+											dstCluster.Index(),
+											proto,
+											util.RandomString(8),
+										)
+
+										if err := sendTrafficMirror(client, target, proto, testID); err != nil {
+											return err
+										}
+
+										if err := verifyTrafficMirror(target, mirrored, c, testID); err != nil {
+											return err
+										}
+										return nil
+									}, retry.Delay(time.Second))
+								})
+							}
 						})
 					}
-				})
+				}
 			}
 		})
 }
 
-func sendTrafficMirror(instances [3]echo.Instance, proto protocol.Instance, testID string) error {
+func sendTrafficMirror(client, target echo.Instance, proto protocol.Instance, testID string) error {
 	options := echo.CallOptions{
-		Target:   instances[1],
+		Target:   target,
 		Count:    50,
 		PortName: strings.ToLower(string(proto)),
 	}
@@ -251,7 +267,7 @@ func sendTrafficMirror(instances [3]echo.Instance, proto protocol.Instance, test
 		return fmt.Errorf("protocol not supported in mirror testing: %s", proto)
 	}
 
-	_, err := instances[0].Call(options)
+	_, err := client.Call(options)
 	if err != nil {
 		return err
 	}
@@ -259,13 +275,13 @@ func sendTrafficMirror(instances [3]echo.Instance, proto protocol.Instance, test
 	return nil
 }
 
-func verifyTrafficMirror(instances [3]echo.Instance, tc testCaseMirror, testID string) error {
-	countB, err := logCount(instances[1], testID)
+func verifyTrafficMirror(target, mirrored echo.Instance, tc testCaseMirror, testID string) error {
+	countB, err := logCount(target, testID)
 	if err != nil {
 		return err
 	}
 
-	countC, err := logCount(instances[2], testID)
+	countC, err := logCount(mirrored, testID)
 	if err != nil {
 		return err
 	}

--- a/tests/integration/pilot/mirror_test.go
+++ b/tests/integration/pilot/mirror_test.go
@@ -179,6 +179,7 @@ func TestMirroringExternalService(t *testing.T) {
 func runMirrorTest(options mirrorTestOptions) {
 	framework.
 		NewTest(options.t).
+		RequiresSingleCluster().
 		Run(func(ctx framework.TestContext) {
 			ns := namespace.NewOrFail(options.t, ctx, namespace.Config{
 				Prefix: "mirroring",

--- a/tests/integration/pilot/mirror_test.go
+++ b/tests/integration/pilot/mirror_test.go
@@ -180,9 +180,9 @@ func runMirrorTest(options mirrorTestOptions) {
 			for _, c := range ctx.Environment().Clusters() {
 				clusterInstances[c.Index()] = [3]echo.Instance{}
 				builder = builder.
-					With(&clusterInstances[c.Index()][0], echoConfig(ns, fmt.Sprintf("a-%d", c.Index()), c)). // client
-					With(&clusterInstances[c.Index()][1], echoConfig(ns, fmt.Sprintf("b-%d", c.Index()), c)). // target
-					With(&clusterInstances[c.Index()][2], echoConfig(ns, fmt.Sprintf("c-%d", c.Index()), c))  // receives mirrored requests
+					With(&clusterInstances[c.Index()][0], echoConfigForCluster(ns, fmt.Sprintf("a-%d", c.Index()), c)). // client
+					With(&clusterInstances[c.Index()][1], echoConfigForCluster(ns, fmt.Sprintf("b-%d", c.Index()), c)). // target
+					With(&clusterInstances[c.Index()][2], echoConfigForCluster(ns, fmt.Sprintf("c-%d", c.Index()), c))  // receives mirrored requests
 			}
 			builder.BuildOrFail(options.t)
 

--- a/tests/integration/pilot/ping_test.go
+++ b/tests/integration/pilot/ping_test.go
@@ -30,6 +30,10 @@ import (
 	"istio.io/pkg/log"
 )
 
+type appSet struct {
+	inoutUnitedApp0, inoutUnitedApp1, inoutSplitApp0, inoutSplitApp1 echo.Instance
+}
+
 type appConnectionPair struct {
 	src, dst echo.Instance
 }
@@ -40,11 +44,9 @@ type callOptions struct {
 }
 
 func TestReachability(t *testing.T) {
-	framework.NewTest(t).
-		RequiresSingleCluster().
-		Run(func(ctx framework.TestContext) {
-			doTest(t, ctx)
-		})
+	framework.NewTest(t).Run(func(ctx framework.TestContext) {
+		doTest(t, ctx)
+	})
 }
 
 func doTest(t *testing.T, ctx framework.TestContext) {
@@ -72,59 +74,71 @@ func doTest(t *testing.T, ctx framework.TestContext) {
 		},
 	}
 
-	p := pilots[0]
-	var inoutUnitedApp0, inoutUnitedApp1, inoutSplitApp0, inoutSplitApp1 echo.Instance
-	echoboot.NewBuilderOrFail(t, ctx).
-		With(&inoutSplitApp0, echo.Config{
-			Service:             "inoutsplitapp0",
-			Namespace:           ns,
-			Ports:               ports,
-			Subsets:             []echo.SubsetConfig{{}},
-			Pilot:               p,
-			IncludeInboundPorts: "*",
-		}).
-		With(&inoutSplitApp1, echo.Config{
-			Service:             "inoutsplitapp1",
-			Namespace:           ns,
-			Subsets:             []echo.SubsetConfig{{}},
-			Ports:               ports,
-			Pilot:               p,
-			IncludeInboundPorts: "*",
-		}).
-		With(
-			&inoutUnitedApp0, echo.Config{
+	builder := echoboot.NewBuilderOrFail(t, ctx)
+	apps := make([]appSet, len(ctx.Environment().Clusters()))
+	for _, c := range ctx.Environment().Clusters() {
+		builder = builder.
+			With(&apps[c.Index()].inoutSplitApp0, echo.Config{
+				Service:             "inoutsplitapp0",
+				Namespace:           ns,
+				Ports:               ports,
+				Subsets:             []echo.SubsetConfig{{}},
+				Pilot:               pilots[c.Index()],
+				Cluster:             c,
+				IncludeInboundPorts: "*",
+			}).
+			With(&apps[c.Index()].inoutSplitApp1, echo.Config{
+				Service:             "inoutsplitapp1",
+				Namespace:           ns,
+				Subsets:             []echo.SubsetConfig{{}},
+				Ports:               ports,
+				Pilot:               pilots[c.Index()],
+				Cluster:             c,
+				IncludeInboundPorts: "*",
+			}).
+			With(&apps[c.Index()].inoutUnitedApp0, echo.Config{
 				Service:   "inoutunitedapp0",
 				Namespace: ns,
 				Subsets:   []echo.SubsetConfig{{}},
 				Ports:     ports,
-				Pilot:     p,
+				Pilot:     pilots[c.Index()],
+				Cluster:   c,
 			}).
-		With(&inoutUnitedApp1, echo.Config{
-			Service:   "inoutunitedapp1",
-			Namespace: ns,
-			Subsets:   []echo.SubsetConfig{{}},
-			Ports:     ports,
-			Pilot:     p,
-		}).
-		BuildOrFail(ctx)
+			With(&apps[c.Index()].inoutUnitedApp1, echo.Config{
+				Service:   "inoutunitedapp1",
+				Namespace: ns,
+				Subsets:   []echo.SubsetConfig{{}},
+				Ports:     ports,
+				Pilot:     pilots[c.Index()],
+				Cluster:   c,
+			})
+	}
+	builder.BuildOrFail(ctx)
 
-	inoutUnitedApp0.WaitUntilCallableOrFail(t, inoutUnitedApp1)
-	log.Infof("%s app ready: %s", ctx.Name(), inoutSplitApp0.Config().Service)
-	inoutSplitApp0.WaitUntilCallableOrFail(t, inoutUnitedApp1)
-	log.Infof("%s app ready: %s", ctx.Name(), inoutSplitApp0.Config().Service)
+	var connectivityPairs []appConnectionPair
+	for _, src := range ctx.Environment().Clusters() {
+		for _, dst := range ctx.Environment().Clusters() {
+			inoutUnitedApp0, inoutSplitApp0 := apps[src.Index()].inoutUnitedApp0, apps[src.Index()].inoutSplitApp0
+			inoutUnitedApp1 := apps[dst.Index()].inoutUnitedApp1
+			inoutUnitedApp0.WaitUntilCallableOrFail(t, inoutUnitedApp1)
+			log.Infof("%s app ready: %s", ctx.Name(), inoutSplitApp0.Config().Service)
+			inoutSplitApp0.WaitUntilCallableOrFail(t, inoutUnitedApp1)
+			log.Infof("%s app ready: %s", ctx.Name(), inoutSplitApp0.Config().Service)
 
-	connectivityPairs := []appConnectionPair{
-		// source is inout united
-		{inoutUnitedApp0, inoutUnitedApp1},
-		{inoutUnitedApp0, inoutSplitApp1},
+			connectivityPairs = append(connectivityPairs,
+				// source is inout united
+				appConnectionPair{apps[src.Index()].inoutUnitedApp0, apps[dst.Index()].inoutUnitedApp1},
+				appConnectionPair{apps[src.Index()].inoutUnitedApp0, apps[dst.Index()].inoutSplitApp1},
 
-		// source is inout split
-		{inoutSplitApp0, inoutUnitedApp1},
-		{inoutSplitApp0, inoutSplitApp1},
+				// source is inout split
+				appConnectionPair{apps[src.Index()].inoutSplitApp0, apps[dst.Index()].inoutUnitedApp1},
+				appConnectionPair{apps[src.Index()].inoutSplitApp0, apps[dst.Index()].inoutSplitApp1},
 
-		// self connectivity (is it required?)
-		{inoutUnitedApp0, inoutUnitedApp0},
-		{inoutSplitApp0, inoutSplitApp0},
+				// self connectivity (is it required?)
+				appConnectionPair{apps[src.Index()].inoutUnitedApp0, apps[dst.Index()].inoutUnitedApp0},
+				appConnectionPair{apps[src.Index()].inoutSplitApp0, apps[dst.Index()].inoutSplitApp0},
+			)
+		}
 	}
 
 	// TODO(yxue): support sending raw TCP traffic instead of HTTP
@@ -150,12 +164,11 @@ func doTest(t *testing.T, ctx framework.TestContext) {
 				pair.dst.Config().Service,
 				connChecker.Options.PortName)
 
-			t.Run(subTestName,
-				func(t *testing.T) {
-					retry.UntilSuccessOrFail(t, connChecker.Check,
-						retry.Delay(time.Second),
-						retry.Timeout(10*time.Second))
-				})
+			ctx.NewSubTest(subTestName).RunParallel(func(ctx framework.TestContext) {
+				retry.UntilSuccessOrFail(ctx, connChecker.Check,
+					retry.Delay(time.Second),
+					retry.Timeout(10*time.Second))
+			})
 		}
 	}
 }

--- a/tests/integration/pilot/ping_test.go
+++ b/tests/integration/pilot/ping_test.go
@@ -40,9 +40,11 @@ type callOptions struct {
 }
 
 func TestReachability(t *testing.T) {
-	framework.NewTest(t).Run(func(ctx framework.TestContext) {
-		doTest(t, ctx)
-	})
+	framework.NewTest(t).
+		RequiresSingleCluster().
+		Run(func(ctx framework.TestContext) {
+			doTest(t, ctx)
+		})
 }
 
 func doTest(t *testing.T, ctx framework.TestContext) {
@@ -70,6 +72,7 @@ func doTest(t *testing.T, ctx framework.TestContext) {
 		},
 	}
 
+	p := pilots[0]
 	var inoutUnitedApp0, inoutUnitedApp1, inoutSplitApp0, inoutSplitApp1 echo.Instance
 	echoboot.NewBuilderOrFail(t, ctx).
 		With(&inoutSplitApp0, echo.Config{

--- a/tests/integration/pilot/protocol_sniffing_test.go
+++ b/tests/integration/pilot/protocol_sniffing_test.go
@@ -33,9 +33,11 @@ import (
 )
 
 func TestSniffing(t *testing.T) {
-	framework.NewTest(t).Run(func(ctx framework.TestContext) {
-		runTest(t, ctx)
-	})
+	framework.NewTest(t).
+		RequiresSingleCluster().
+		Run(func(ctx framework.TestContext) {
+			runTest(t, ctx)
+		})
 }
 
 func runTest(t *testing.T, ctx framework.TestContext) {
@@ -75,6 +77,7 @@ func runTest(t *testing.T, ctx framework.TestContext) {
 		},
 	}
 
+	p := pilots[0]
 	var fromWithSidecar, fromWithoutSidecar, to echo.Instance
 	echoboot.NewBuilderOrFail(t, ctx).
 		With(&fromWithSidecar, echo.Config{

--- a/tests/integration/pilot/routing_test.go
+++ b/tests/integration/pilot/routing_test.go
@@ -30,6 +30,7 @@ import (
 func TestTrafficRouting(t *testing.T) {
 	framework.
 		NewTest(t).
+		RequiresSingleCluster().
 		Run(func(ctx framework.TestContext) {
 			ns := namespace.NewOrFail(t, ctx, namespace.Config{
 				Prefix: "traffic-routing",
@@ -38,8 +39,8 @@ func TestTrafficRouting(t *testing.T) {
 
 			var client, server echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&client, echoConfig(ns, "client")).
-				With(&server, echoConfig(ns, "server")).
+				With(&client, echoConfig(ns, "client", ctx.Environment().Clusters()[0])).
+				With(&server, echoConfig(ns, "server", ctx.Environment().Clusters()[0])).
 				BuildOrFail(t)
 
 			cases := []struct {

--- a/tests/integration/pilot/routing_test.go
+++ b/tests/integration/pilot/routing_test.go
@@ -47,8 +47,8 @@ func TestTrafficRouting(t *testing.T) {
 			builder := echoboot.NewBuilderOrFail(t, ctx)
 			for _, c := range ctx.Environment().Clusters() {
 				builder = builder.
-					With(&clusterServices[c.Index()][0], echoConfig(ns, fmt.Sprintf("client-%d", c.Index()), c)).
-					With(&clusterServices[c.Index()][1], echoConfig(ns, fmt.Sprintf("server-%d", c.Index()), c))
+					With(&clusterServices[c.Index()][0], echoConfigForCluster(ns, fmt.Sprintf("client-%d", c.Index()), c)).
+					With(&clusterServices[c.Index()][1], echoConfigForCluster(ns, fmt.Sprintf("server-%d", c.Index()), c))
 			}
 			builder.BuildOrFail(t)
 

--- a/tests/integration/pilot/scope_serviceentry_dns_test.go
+++ b/tests/integration/pilot/scope_serviceentry_dns_test.go
@@ -32,52 +32,56 @@ import (
 )
 
 func TestServiceEntryDNS(t *testing.T) {
-	framework.Run(t, func(ctx framework.TestContext) {
-		configFn := func(c sidecarscope.Config) sidecarscope.Config {
-			c.Resolution = "DNS"
-			return c
-		}
-		p, nodeID := sidecarscope.SetupTest(t, ctx, configFn)
+	framework.NewTest(t).
+		RequiresSingleCluster().
+		Run(func(ctx framework.TestContext) {
+			configFn := func(c sidecarscope.Config) sidecarscope.Config {
+				c.Resolution = "DNS"
+				return c
+			}
+			p, nodeID := sidecarscope.SetupTest(t, ctx, configFn)
 
-		req := &discovery.DiscoveryRequest{
-			Node: &core.Node{
-				Id: nodeID.ServiceNode(),
-			},
-			TypeUrl: v3.ClusterType,
-		}
+			req := &discovery.DiscoveryRequest{
+				Node: &core.Node{
+					Id: nodeID.ServiceNode(),
+				},
+				TypeUrl: v3.ClusterType,
+			}
 
-		if err := p.StartDiscovery(req); err != nil {
-			t.Fatal(err)
-		}
-		if err := p.WatchDiscovery(time.Second*5, checkEndpoint("app.com")); err != nil {
-			t.Fatal(err)
-		}
-	})
+			if err := p.StartDiscovery(req); err != nil {
+				t.Fatal(err)
+			}
+			if err := p.WatchDiscovery(time.Second*5, checkEndpoint("app.com")); err != nil {
+				t.Fatal(err)
+			}
+		})
 }
 
 func TestServiceEntryDNSNoSelfImport(t *testing.T) {
-	framework.Run(t, func(ctx framework.TestContext) {
-		configFn := func(c sidecarscope.Config) sidecarscope.Config {
-			c.Resolution = "DNS"
-			c.ImportedNamespaces = []string{c.IncludedNamespace + "/*"}
-			return c
-		}
-		p, nodeID := sidecarscope.SetupTest(t, ctx, configFn)
+	framework.NewTest(t).
+		RequiresSingleCluster().
+		Run(func(ctx framework.TestContext) {
+			configFn := func(c sidecarscope.Config) sidecarscope.Config {
+				c.Resolution = "DNS"
+				c.ImportedNamespaces = []string{c.IncludedNamespace + "/*"}
+				return c
+			}
+			p, nodeID := sidecarscope.SetupTest(t, ctx, configFn)
 
-		req := &discovery.DiscoveryRequest{
-			Node: &core.Node{
-				Id: nodeID.ServiceNode(),
-			},
-			TypeUrl: v3.ClusterType,
-		}
+			req := &discovery.DiscoveryRequest{
+				Node: &core.Node{
+					Id: nodeID.ServiceNode(),
+				},
+				TypeUrl: v3.ClusterType,
+			}
 
-		if err := p.StartDiscovery(req); err != nil {
-			t.Fatal(err)
-		}
-		if err := p.WatchDiscovery(time.Second*5, checkEndpoint("included.com")); err != nil {
-			t.Fatal(err)
-		}
-	})
+			if err := p.StartDiscovery(req); err != nil {
+				t.Fatal(err)
+			}
+			if err := p.WatchDiscovery(time.Second*5, checkEndpoint("included.com")); err != nil {
+				t.Fatal(err)
+			}
+		})
 }
 
 func checkEndpoint(name string) func(resp *discovery.DiscoveryResponse) (success bool, e error) {

--- a/tests/integration/pilot/sidecar_api_test.go
+++ b/tests/integration/pilot/sidecar_api_test.go
@@ -45,6 +45,7 @@ func mustReadFile(t *testing.T, f string) string {
 func TestSidecarListeners(t *testing.T) {
 	framework.
 		NewTest(t).
+		RequiresSingleCluster().
 		Run(func(ctx framework.TestContext) {
 
 			// Simulate proxy identity of a sidecar ...
@@ -56,6 +57,8 @@ func TestSidecarListeners(t *testing.T) {
 				DNSDomain:    "testns.cluster.local",
 				IstioVersion: model.MaxIstioVersion,
 			}
+
+			p := pilots[0]
 
 			// Start the xDS stream containing the listeners for this node
 			p.StartDiscoveryOrFail(t, pilot.NewDiscoveryRequest(nodeID.ServiceNode(), v3.ListenerType))

--- a/tests/integration/pilot/testdata/traffic-mirroring-external-serviceentry.yaml
+++ b/tests/integration/pilot/testdata/traffic-mirroring-external-serviceentry.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: external-service
+spec:
+  hosts:
+    - {{.MirrorHost}}
+  location: MESH_EXTERNAL
+  ports:
+    - name: http
+      number: 80
+      protocol: HTTP
+    - name: grpc
+      number: 7070
+      protocol: GRPC
+  resolution: STATIC
+  endpoints:
+    - address: {{.MirrorAddress}}
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Sidecar
+metadata:
+  name: restrict-to-service-entry
+spec:
+  egress:
+    - hosts:
+        - "./{{.TargetHost}}.{{.Namespace}}.svc.{{.Domain}}"
+        - "*/{{.MirrorHost}}"
+  outboundTrafficPolicy:
+    mode: REGISTRY_ONLY

--- a/tests/integration/pilot/testdata/traffic-mirroring-template.yaml
+++ b/tests/integration/pilot/testdata/traffic-mirroring-template.yaml
@@ -5,11 +5,11 @@ metadata:
   namespace: {{.Namespace}}
 spec:
   hosts:
-    - b
+    - {{.TargetHost}}
   http:
     - route:
         - destination:
-            host: b
+            host: {{.TargetHost}}
       mirror:
         host: {{.MirrorHost}}
 {{- if not .Absent }}

--- a/tests/integration/pilot/testdata/traffic-shifting.yaml
+++ b/tests/integration/pilot/testdata/traffic-shifting.yaml
@@ -5,15 +5,9 @@ metadata:
   namespace: {{.Namespace}}
 spec:
   hosts:
-    - {{.Host0}}
+    - {{.TargetHost}}
   http:
-    - route:
+    - route:{{ range $i,$h := .Hosts }}
         - destination:
-            host: {{.Host0}}
-          weight: {{.Weight0}}
-        - destination:
-            host: {{.Host1}}
-          weight: {{.Weight1}}
-        - destination:
-            host: {{.Host2}}
-          weight: {{.Weight2}}
+            host: {{$h}}
+          weight: {{ index $.Weights $i }}{{ end }}

--- a/tests/integration/security/mtls_healthcheck_test.go
+++ b/tests/integration/security/mtls_healthcheck_test.go
@@ -88,7 +88,7 @@ spec:
 	if !rewrite {
 		cfg.ReadinessTimeout = time.Second * 15
 	}
-	err := echoboot.NewBuilderOrFail(t, ctx).
+	_, err := echoboot.NewBuilderOrFail(t, ctx).
 		With(&healthcheck, cfg).
 		Build()
 	gotSuccess := err == nil

--- a/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
@@ -222,7 +222,7 @@ func testSetup(ctx resource.Context) (err error) {
 	if err != nil {
 		return
 	}
-	err = builder.
+	_, err = builder.
 		With(&clt, echo.Config{
 			Service:   "clt",
 			Namespace: getEchoNamespaceInstance(),

--- a/tests/integration/telemetry/stats/prometheus/http/stats.go
+++ b/tests/integration/telemetry/stats/prometheus/http/stats.go
@@ -105,7 +105,7 @@ func TestSetup(ctx resource.Context) (err error) {
 	if err != nil {
 		return
 	}
-	err = b.
+	_, err = b.
 		With(&client, echo.Config{
 			Service:   "client",
 			Namespace: appNsInst,

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -58,6 +58,12 @@ ifneq ($(_INTEGRATION_TEST_NETWORKS),)
     _INTEGRATION_TEST_FLAGS += --istio.test.kube.networkTopology=$(_INTEGRATION_TEST_NETWORKS)
 endif
 
+# If $(INTEGRATION_TEST_CONTROLPLANE_TOPOLOGY) is set, add the networkTopology flag
+_INTEGRATION_TEST_CONTROLPLANE_TOPOLOGY ?= $(INTEGRATION_TEST_CONTROLPLANE_TOPOLOGY)
+ifneq ($(_INTEGRATION_TEST_CONTROLPLANE_TOPOLOGY),)
+    _INTEGRATION_TEST_FLAGS += --istio.test.kube.controlPlaneTopology=$(_INTEGRATION_TEST_CONTROLPLANE_TOPOLOGY)
+endif
+
 test.integration.analyze: | $(JUNIT_REPORT)
 	$(GO) test -p 1 ${T} ./tests/integration/... -timeout 30m \
 	--istio.test.analyze \

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -13,11 +13,11 @@ ifneq ($(CI),)
 endif
 
 ifeq ($(TEST_ENV),minikube)
-    _INTEGRATION_TEST_FLAGS += --istio.test.kube.minikube
+    _INTEGRATION_TEST_FLAGS += --istio.test.kube.noloadbalancer
 else ifeq ($(TEST_ENV),minikube-none)
-    _INTEGRATION_TEST_FLAGS += --istio.test.kube.minikube
+    _INTEGRATION_TEST_FLAGS += --istio.test.kube.noloadbalancer
 else ifeq ($(TEST_ENV),kind)
-    _INTEGRATION_TEST_FLAGS += --istio.test.kube.minikube
+    _INTEGRATION_TEST_FLAGS += --istio.test.kube.noloadbalancer
 endif
 
 ifneq ($(ARTIFACTS),)

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -13,11 +13,11 @@ ifneq ($(CI),)
 endif
 
 ifeq ($(TEST_ENV),minikube)
-    _INTEGRATION_TEST_FLAGS += --istio.test.kube.noloadbalancer
+    _INTEGRATION_TEST_FLAGS += --istio.test.kube.lbunsupported
 else ifeq ($(TEST_ENV),minikube-none)
-    _INTEGRATION_TEST_FLAGS += --istio.test.kube.noloadbalancer
+    _INTEGRATION_TEST_FLAGS += --istio.test.kube.lbunsupported
 else ifeq ($(TEST_ENV),kind)
-    _INTEGRATION_TEST_FLAGS += --istio.test.kube.noloadbalancer
+    _INTEGRATION_TEST_FLAGS += --istio.test.kube.lbunsupported
 endif
 
 ifneq ($(ARTIFACTS),)


### PR DESCRIPTION
New PR: https://github.com/istio/istio/pull/25923


Converts tests under tests/integration/pilot to utilize all clusters in the test environment. The target is currently hidden. 

[integ-pilot-multicluster-tests_istio/30](https://prow.istio.io/view/gcs/istio-prow/pr-logs/pull/istio_istio/24549/integ-pilot-multicluster-tests_istio/30) took 18 mins and has all traffic tests + meshnetwork test converted. 

Note: each commit is well scoped - much easier to review commit-by-commit. Willing to breakout into smaller PRs but some portion of this will be needed as the "base"


The progress of converting tests, broken down by suite below. 

#### pilot
traffic:
- [X] TestReachability
- [X] TestMirroring
- [X] TestMirroringExternalService
- [X] TestSniffing
- [X] TestTrafficRouting
- [ ] TestTrafficShifting (simpler to make a multicluster specific test)
- [X] TestCrossClusterTrafficShifting

#### pilot_meshnetwork
- [X] TestAsymmetricMeshNetworkWithGatewayIP (VM discovers all ingress gateways, pods on all clusters discover VM) (need to confirm CI passed)

istioctl:
- [ ] TestTrafficShifting
- [ ] TestVersion
- [ ] TestDescribe
- [ ] TestWait
- [ ] TestAuthZCheck
- [ ] TestProxyConfig
- [ ] TestProxyStatus

Sidecar:
- [ ] TestAddToAndRemoveFromMesh
- [ ] TestServiceEntryDNS
- [ ] TestServiceEntryDNSNoSelfImport
- [ ] TestServiceEntryStatic
- [ ] TestSidecarListeners
- [ ] TestSidecarScopeIngressListener

#### pilot_revisions
- [ ] TestMultiRevision


#### pilot_locality
- [ ] TestDistribute
- [ ] TestFailover
- [ ] TestPrioritized


#### pilot_analysis
- [ ] TestAnalysisWritesStatus

#### pilot_ingress
- [ ] TestGateway
- [ ] TestIngress

	
#### pilot_cni
- [ ] TestCNIReachability

#### pilot_vm
- [ ] TestVmOS
- [ ] TestVmOSPost
