### PR TITLE
Fix SDS memory leak

### DIFF
--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -226,7 +226,6 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 
 	go receiveThread(con, reqChannel, &receiveError)
 
-	var node *core.Node
 	for {
 		// Block until a request is received.
 		select {
@@ -235,12 +234,6 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 				// Remote side closed connection.
 				sdsServiceLog.Errorf("Remote side closed connection")
 				return receiveError
-			}
-
-			if discReq.Node == nil {
-				discReq.Node = node
-			} else {
-				node = discReq.Node
 			}
 
 			resourceName, err := getResourceName(discReq)


### PR DESCRIPTION
Current we indefinitely hold onto DiscoveryRequests which are pretty
large. With a large number of secrets, this adds up. With 1000 secrets
this brought memory down from 57609k -> 21935k.

Every request includes the node anyways so no need to store it

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
