### PR TITLE
"istioctl analyze" new warnings for Sidecar fields are being used

### DIFF
--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -86,6 +86,10 @@ var testGrid = []testCase{
 		analyzer:   &deprecation.FieldAnalyzer{},
 		expected: []message{
 			{msg.Deprecated, "VirtualService productpage.foo"},
+			{msg.Deprecated, "Sidecar no-selector.default"},
+			{msg.Deprecated, "Sidecar no-selector.default"},
+			{msg.Deprecated, "Sidecar no-selector.default"},
+			{msg.Deprecated, "Sidecar no-selector.default"},
 		},
 	},
 	{

--- a/galley/pkg/config/analysis/analyzers/testdata/deprecation.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/deprecation.yaml
@@ -25,3 +25,28 @@ spec:
       delay:
         percent: 50
 ---
+apiVersion: networking.istio.io/v1alpha3
+kind: Sidecar
+metadata:
+  name: no-selector
+  namespace: default
+spec:
+  ingress:
+  - port:
+      number: 9080
+    localhostClientTls:
+      mode: SIMPLE
+    defaultEndpoint: unix:///var/run/some.sock
+  egress:
+  - hosts:
+    - "./*"
+    localhostServerTls:
+      mode: SIMPLE
+  outboundTrafficPolicy:
+    mode: ALLOW_ANY
+    egressProxy:
+      host: example
+      port:
+        number: 9080
+  localhost:
+    clientTls:


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/19355

As far as I can tell those are the only fields still in the API but newly hidden for 1.7.

Requesting @nrjpoddar because he wrote the commit that removed them https://github.com/istio/api/pull/1437