### PR TITLE
Use debian-10 distroless base image

### DIFF
--- a/mixer/docker/Dockerfile.mixer
+++ b/mixer/docker/Dockerfile.mixer
@@ -10,7 +10,7 @@ FROM docker.io/istio/base:${BASE_VERSION} as default
 USER 1337:1337
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
-FROM gcr.io/distroless/static@sha256:23aa732bba4c8618c0d97c26a72a32997363d591807b0d4c31b0bbc8a774bddf as distroless
+FROM gcr.io/distroless/static-debian10@sha256:4433370ec2b3b97b338674b4de5ffaef8ce5a38d1c9c0cb82403304b8718cde9 as distroless
 WORKDIR /
 
 # This will build the final image based on either default or distroless from above

--- a/mixer/docker/Dockerfile.mixer_codegen
+++ b/mixer/docker/Dockerfile.mixer_codegen
@@ -10,7 +10,7 @@ FROM docker.io/istio/base:${BASE_VERSION} as default
 USER 1337:1337
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
-FROM gcr.io/distroless/static@sha256:23aa732bba4c8618c0d97c26a72a32997363d591807b0d4c31b0bbc8a774bddf as distroless
+FROM gcr.io/distroless/static-debian10@sha256:4433370ec2b3b97b338674b4de5ffaef8ce5a38d1c9c0cb82403304b8718cde9 as distroless
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006

--- a/mixer/docker/Dockerfile.test_policybackend
+++ b/mixer/docker/Dockerfile.test_policybackend
@@ -8,7 +8,7 @@ ARG BASE_VERSION=latest
 FROM docker.io/istio/base:${BASE_VERSION} as default
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
-FROM gcr.io/distroless/static@sha256:c6d5981545ce1406d33e61434c61e9452dad93ecd8397c41e89036ef977a88f4 as distroless
+FROM gcr.io/distroless/static-debian10@sha256:4433370ec2b3b97b338674b4de5ffaef8ce5a38d1c9c0cb82403304b8718cde9 as distroless
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006

--- a/mixer/test/listbackend/cmd/Dockerfile
+++ b/mixer/test/listbackend/cmd/Dockerfile
@@ -21,7 +21,7 @@ ARG BASE_DISTRIBUTION=default
 FROM scratch as default
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
-FROM gcr.io/distroless/static@sha256:c6d5981545ce1406d33e61434c61e9452dad93ecd8397c41e89036ef977a88f4 as distroless
+FROM gcr.io/distroless/static-debian10@sha256:4433370ec2b3b97b338674b4de5ffaef8ce5a38d1c9c0cb82403304b8718cde9 as distroless
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006

--- a/mixer/test/prometheus/cmd/Dockerfile
+++ b/mixer/test/prometheus/cmd/Dockerfile
@@ -21,7 +21,7 @@ ARG BASE_DISTRIBUTION=default
 FROM scratch as default
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
-FROM gcr.io/distroless/static@sha256:c6d5981545ce1406d33e61434c61e9452dad93ecd8397c41e89036ef977a88f4 as distroless
+FROM gcr.io/distroless/static-debian10@sha256:4433370ec2b3b97b338674b4de5ffaef8ce5a38d1c9c0cb82403304b8718cde9 as distroless
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006

--- a/operator/docker/Dockerfile.operator
+++ b/operator/docker/Dockerfile.operator
@@ -9,7 +9,7 @@ FROM docker.io/istio/base:${BASE_VERSION} as default
 
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
-FROM gcr.io/distroless/static@sha256:23aa732bba4c8618c0d97c26a72a32997363d591807b0d4c31b0bbc8a774bddf as distroless
+FROM gcr.io/distroless/static-debian10@sha256:4433370ec2b3b97b338674b4de5ffaef8ce5a38d1c9c0cb82403304b8718cde9 as distroless
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006

--- a/pilot/docker/Dockerfile.pilot
+++ b/pilot/docker/Dockerfile.pilot
@@ -10,7 +10,7 @@ FROM docker.io/istio/base:${BASE_VERSION} as default
 USER 1337:1337
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
-FROM gcr.io/distroless/static@sha256:23aa732bba4c8618c0d97c26a72a32997363d591807b0d4c31b0bbc8a774bddf as distroless
+FROM gcr.io/distroless/static-debian10@sha256:4433370ec2b3b97b338674b4de5ffaef8ce5a38d1c9c0cb82403304b8718cde9 as distroless
 WORKDIR /
 
 # This will build the final image based on either default or distroless from above

--- a/samples/tcp-echo/src/Dockerfile
+++ b/samples/tcp-echo/src/Dockerfile
@@ -27,7 +27,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o tcp-echo main.go
 FROM scratch as default
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
-FROM gcr.io/distroless/static@sha256:c6d5981545ce1406d33e61434c61e9452dad93ecd8397c41e89036ef977a88f4 as distroless
+FROM gcr.io/distroless/static-debian10@sha256:4433370ec2b3b97b338674b4de5ffaef8ce5a38d1c9c0cb82403304b8718cde9 as distroless
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006


### PR DESCRIPTION
Adds debian-10 distroless base images: issue #19531 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ X ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
