### PR TITLE
Operator chart parameterize resource requests

### DIFF
--- a/manifests/charts/istio-operator/templates/deployment.yaml
+++ b/manifests/charts/istio-operator/templates/deployment.yaml
@@ -22,12 +22,7 @@ spec:
           - server
           imagePullPolicy: IfNotPresent
           resources:
-            limits:
-              cpu: 200m
-              memory: 256Mi
-            requests:
-              cpu: 50m
-              memory: 128Mi
+{{ toYaml .Values.operator.resources | trim | indent 12 }}
           env:
             - name: WATCH_NAMESPACE
               value: {{.Values.istioNamespace}}

--- a/manifests/charts/istio-operator/values.yaml
+++ b/manifests/charts/istio-operator/values.yaml
@@ -6,3 +6,14 @@ waitForResourcesTimeout: 300s
 
 # Used for helm2 to add the CRDs to templates.
 enableCRDTemplates: false
+
+# Operator resource defaults
+operator:
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 50m
+      memory: 128Mi
+


### PR DESCRIPTION
Allow to configure the ram and CPU limits of the operator chart in the values.yaml. Solves #24498. 

This is my first PR on Istio, so my apologies if the style is not correct. I've allowed edits from maintainers.