### PR TITLE
[Test Framework] Accessor cleanup

### DIFF
--- a/pkg/test/framework/components/echo/kube/builder.go
+++ b/pkg/test/framework/components/echo/kube/builder.go
@@ -23,6 +23,7 @@ import (
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/kube"
 	"istio.io/istio/pkg/test/util/retry"
 
 	kubeCore "k8s.io/api/core/v1"
@@ -112,7 +113,7 @@ func (b *builder) initializeInstances(instances []echo.Instance) error {
 				selector = "istio.io/test-vm"
 			}
 			// Wait until all the pods are ready for this service
-			fetch := cluster.NewPodMustFetch(serviceNamespace, fmt.Sprintf("%s=%s", selector, serviceName))
+			fetch := kube.NewPodMustFetch(cluster.Accessor, serviceNamespace, fmt.Sprintf("%s=%s", selector, serviceName))
 			pods, err := cluster.WaitUntilPodsAreReady(fetch, retry.Timeout(timeout))
 			if err != nil {
 				aggregateErrMux.Lock()

--- a/pkg/test/framework/components/environment/kube/cluster.go
+++ b/pkg/test/framework/components/environment/kube/cluster.go
@@ -31,7 +31,7 @@ var _ resource.Cluster = Cluster{}
 
 // Cluster for a Kubernetes cluster. Provides access via a kube.Accessor.
 type Cluster struct {
-	*kube.Accessor
+	kube.Accessor
 	filename    string
 	networkName string
 	index       resource.ClusterIndex

--- a/pkg/test/framework/components/environment/kube/settings.go
+++ b/pkg/test/framework/components/environment/kube/settings.go
@@ -26,7 +26,7 @@ import (
 
 // ClientFactoryFunc is a transformation function that creates the k8s client factories
 // from the provided k8s config files.
-type AccessorFactoryFunc func(kubeConfig string, workDir string) (*kube.Accessor, error)
+type AccessorFactoryFunc func(kubeConfig string, workDir string) (kube.Accessor, error)
 
 // Settings provide kube-specific Settings from flags.
 type Settings struct {

--- a/pkg/test/framework/components/ingress/kube.go
+++ b/pkg/test/framework/components/ingress/kube.go
@@ -15,6 +15,7 @@
 package ingress
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -25,6 +26,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	kubeApiMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
@@ -77,7 +80,7 @@ func (c *kubeComponent) getAddressInner(ns string, port int) (interface{}, bool,
 			return nil, false, fmt.Errorf("no Host IP available on the ingress node yet")
 		}
 
-		svc, err := c.cluster.GetService(ns, serviceName)
+		svc, err := c.cluster.CoreV1().Services(ns).Get(context.TODO(), serviceName, kubeApiMeta.GetOptions{})
 		if err != nil {
 			return nil, false, err
 		}
@@ -102,7 +105,7 @@ func (c *kubeComponent) getAddressInner(ns string, port int) (interface{}, bool,
 	}
 
 	// Otherwise, get the load balancer IP.
-	svc, err := c.cluster.GetService(ns, serviceName)
+	svc, err := c.cluster.CoreV1().Services(ns).Get(context.TODO(), serviceName, kubeApiMeta.GetOptions{})
 	if err != nil {
 		return nil, false, err
 	}
@@ -134,7 +137,7 @@ func getHTTPSAddressInner(env *kube.Environment, ns string) (interface{}, bool, 
 			return nil, false, fmt.Errorf("no Host IP available on the ingress node yet")
 		}
 
-		svc, err := env.KubeClusters[0].GetService(ns, serviceName)
+		svc, err := env.KubeClusters[0].CoreV1().Services(ns).Get(context.TODO(), serviceName, kubeApiMeta.GetOptions{})
 		if err != nil {
 			return nil, false, err
 		}
@@ -158,7 +161,7 @@ func getHTTPSAddressInner(env *kube.Environment, ns string) (interface{}, bool, 
 		return net.TCPAddr{IP: net.ParseIP(ip), Port: int(nodePort)}, true, nil
 	}
 
-	svc, err := env.KubeClusters[0].GetService(ns, serviceName)
+	svc, err := env.KubeClusters[0].CoreV1().Services(ns).Get(context.TODO(), serviceName, kubeApiMeta.GetOptions{})
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -15,6 +15,7 @@
 package istio
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -26,8 +27,11 @@ import (
 	"strings"
 	"time"
 
+	kubeApiMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/pilot/pkg/leaderelection"
+	kube2 "istio.io/istio/pkg/test/kube"
 
 	"istio.io/api/mesh/v1alpha1"
 
@@ -105,7 +109,8 @@ func (i *operatorComponent) Close() (err error) {
 			}
 			// Clean up dynamic leader election locks. This allows new test suites to become the leader without waiting 30s
 			for _, cm := range leaderElectionConfigMaps {
-				if e := cluster.DeleteConfigMap(cm, i.settings.SystemNamespace); e != nil {
+				if e := cluster.CoreV1().ConfigMaps(i.settings.SystemNamespace).Delete(context.TODO(), cm,
+					kubeApiMeta.DeleteOptions{}); e != nil {
 					err = multierror.Append(err, e)
 				}
 			}
@@ -131,7 +136,7 @@ func (i *operatorComponent) Dump() {
 			scopes.Framework.Errorf("Unable to create directory for dumping Istio contents: %v", err)
 			return
 		}
-		cluster.DumpPods(d, i.settings.SystemNamespace)
+		kube2.DumpPods(cluster, d, i.settings.SystemNamespace)
 	}
 }
 
@@ -460,13 +465,14 @@ func deployCACerts(workDir string, env *kube.Environment, cfg Config) error {
 		}
 
 		// Create the system namespace.
-		if err := cluster.CreateNamespace(cfg.SystemNamespace, ""); err != nil {
+		if err := cluster.CreateNamespaceWithLabels(cfg.SystemNamespace, "", nil); err != nil {
 			scopes.Framework.Infof("failed creating namespace %s on cluster %s. This can happen when deploying "+
 				"multiple control planes. Error: %v", cfg.SystemNamespace, cluster.Name(), err)
 		}
 
 		// Create the secret for the cacerts.
-		if err := cluster.CreateSecret(cfg.SystemNamespace, secret); err != nil {
+		if _, err := cluster.CoreV1().Secrets(cfg.SystemNamespace).Create(context.TODO(), secret,
+			kubeApiMeta.CreateOptions{}); err != nil {
 			scopes.Framework.Infof("failed to create CA secrets on cluster %s. This can happen when deploying "+
 				"multiple control planes. Error: %v", cluster.Name(), err)
 		}

--- a/pkg/test/framework/components/istio/util.go
+++ b/pkg/test/framework/components/istio/util.go
@@ -15,9 +15,12 @@
 package istio
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"time"
+
+	kubeApiMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	kubeenv "istio.io/istio/pkg/test/framework/components/environment/kube"
 
@@ -47,7 +50,7 @@ var (
 	discoveryPort  = 15012
 )
 
-func waitForValidationWebhook(accessor *kube.Accessor, cfg Config) error {
+func waitForValidationWebhook(accessor kube.Accessor, cfg Config) error {
 	dummyValidationRule := fmt.Sprintf(dummyValidationRuleTemplate, cfg.SystemNamespace)
 	defer func() {
 		e := accessor.DeleteContents("", dummyValidationRule)
@@ -68,7 +71,7 @@ func waitForValidationWebhook(accessor *kube.Accessor, cfg Config) error {
 }
 
 func GetRemoteDiscoveryAddress(namespace string, cluster kubeenv.Cluster, useNodePort bool) (net.TCPAddr, error) {
-	svc, err := cluster.GetService(namespace, igwServiceName)
+	svc, err := cluster.CoreV1().Services(namespace).Get(context.TODO(), igwServiceName, kubeApiMeta.GetOptions{})
 	if err != nil {
 		return net.TCPAddr{}, err
 	}

--- a/pkg/test/framework/components/namespace/kube.go
+++ b/pkg/test/framework/components/namespace/kube.go
@@ -28,6 +28,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/resource"
+	kube2 "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/pkg/test/scopes"
 )
 
@@ -55,7 +56,7 @@ func (n *kubeNamespace) Dump() {
 	}
 
 	for _, cluster := range n.env.KubeClusters {
-		cluster.DumpPods(d, n.name)
+		kube2.DumpPods(cluster, d, n.name)
 	}
 }
 

--- a/pkg/test/framework/components/pilot/kube.go
+++ b/pkg/test/framework/components/pilot/kube.go
@@ -15,11 +15,13 @@
 package pilot
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
 
 	"github.com/hashicorp/go-multierror"
+	kubeApiMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/istio"
@@ -50,7 +52,7 @@ func newKube(ctx resource.Context, cfg Config) (Instance, error) {
 	}
 	ns := icfg.ConfigNamespace
 
-	fetchFn := c.cluster.NewSinglePodFetch(ns, "istio=pilot")
+	fetchFn := testKube.NewSinglePodFetch(c.cluster.Accessor, ns, "istio=pilot")
 	pods, err := c.cluster.WaitUntilPodsAreReady(fetchFn)
 	if err != nil {
 		return nil, err
@@ -120,7 +122,7 @@ func (c *kubeComponent) Close() (err error) {
 }
 
 func (c *kubeComponent) getGrpcPort(ns string) (uint16, error) {
-	svc, err := c.cluster.GetService(ns, pilotService)
+	svc, err := c.cluster.CoreV1().Services(ns).Get(context.TODO(), pilotService, kubeApiMeta.GetOptions{})
 	if err != nil {
 		return 0, fmt.Errorf("failed to retrieve service %s: %v", pilotService, err)
 	}

--- a/pkg/test/framework/components/policybackend/kube.go
+++ b/pkg/test/framework/components/policybackend/kube.go
@@ -213,7 +213,7 @@ func newKube(ctx resource.Context, cfg Config) (Instance, error) {
 		return nil, err
 	}
 
-	podFetchFunc := c.cluster.NewSinglePodFetch(c.namespace.Name(), "app=policy-backend", "version=test")
+	podFetchFunc := testKube.NewSinglePodFetch(c.cluster.Accessor, c.namespace.Name(), "app=policy-backend", "version=test")
 	pods, err := c.cluster.WaitUntilPodsAreReady(podFetchFunc)
 	if err != nil {
 		scopes.Framework.Infof("Error waiting for PolicyBackend pod to become running: %v", err)
@@ -285,8 +285,8 @@ func (c *kubeComponent) Dump() {
 		scopes.Framework.Errorf("Unable to create dump folder for policy-backend-state: %v", err)
 		return
 	}
-	c.cluster.DumpPods(workDir, c.namespace.Name(),
-		c.cluster.DumpPodEvents,
-		c.cluster.DumpPodLogs,
+	testKube.DumpPods(c.cluster, workDir, c.namespace.Name(),
+		testKube.DumpPodEvents,
+		testKube.DumpPodLogs,
 	)
 }

--- a/pkg/test/framework/components/prometheus/kube.go
+++ b/pkg/test/framework/components/prometheus/kube.go
@@ -26,6 +26,7 @@ import (
 	prometheusApi "github.com/prometheus/client_golang/api"
 	prometheusApiV1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
+	kubeApiMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/env"
@@ -108,14 +109,14 @@ func newKube(ctx resource.Context, cfgIn Config) (Instance, error) {
 			return removePrometheus(ctx, cfg.TelemetryNamespace)
 		}
 	}
-	fetchFn := c.cluster.NewSinglePodFetch(cfg.TelemetryNamespace, fmt.Sprintf("app=%s", appName))
+	fetchFn := testKube.NewSinglePodFetch(c.cluster.Accessor, cfg.TelemetryNamespace, fmt.Sprintf("app=%s", appName))
 	pods, err := c.cluster.WaitUntilPodsAreReady(fetchFn)
 	if err != nil {
 		return nil, err
 	}
 	pod := pods[0]
 
-	svc, err := c.cluster.GetService(cfg.TelemetryNamespace, serviceName)
+	svc, err := c.cluster.CoreV1().Services(cfg.TelemetryNamespace).Get(context.TODO(), serviceName, kubeApiMeta.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/test/framework/components/redis/kube.go
+++ b/pkg/test/framework/components/redis/kube.go
@@ -24,6 +24,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/image"
 	"istio.io/istio/pkg/test/framework/resource"
+	kube2 "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/test/util/tmpl"
 )
@@ -98,7 +99,7 @@ func newKube(ctx resource.Context, cfg Config) (Instance, error) {
 		return nil, fmt.Errorf("failed to apply rendered %s, err: %v", environ.RedisInstallFilePath, err)
 	}
 
-	fetchFn := c.cluster.NewPodFetch(c.ns.Name(), "app=redis")
+	fetchFn := kube2.NewPodFetch(c.cluster.Accessor, c.ns.Name(), "app=redis")
 	if _, err := c.cluster.WaitUntilPodsAreReady(fetchFn); err != nil {
 		return nil, err
 	}

--- a/pkg/test/framework/components/stackdriver/kube.go
+++ b/pkg/test/framework/components/stackdriver/kube.go
@@ -85,7 +85,7 @@ func newKube(ctx resource.Context, cfg Config) (Instance, error) {
 		return nil, fmt.Errorf("failed to apply rendered %s, err: %v", environ.StackdriverInstallFilePath, err)
 	}
 
-	fetchFn := c.cluster.NewSinglePodFetch(c.ns.Name(), "app=stackdriver")
+	fetchFn := testKube.NewSinglePodFetch(c.cluster.Accessor, c.ns.Name(), "app=stackdriver")
 	pods, err := c.cluster.WaitUntilPodsAreReady(fetchFn)
 	if err != nil {
 		return nil, err

--- a/pkg/test/framework/components/zipkin/kube.go
+++ b/pkg/test/framework/components/zipkin/kube.go
@@ -97,7 +97,7 @@ func newKube(ctx resource.Context, cfgIn Config) (Instance, error) {
 		_ = removeZipkin(ctx, cfg.TelemetryNamespace)
 	}
 
-	fetchFn := c.cluster.NewSinglePodFetch(cfg.SystemNamespace, fmt.Sprintf("app=%s", appName))
+	fetchFn := testKube.NewSinglePodFetch(c.cluster.Accessor, cfg.SystemNamespace, fmt.Sprintf("app=%s", appName))
 	pods, err := c.cluster.WaitUntilPodsAreReady(fetchFn)
 	if err != nil {
 		return nil, err

--- a/pkg/test/kube/accessor.go
+++ b/pkg/test/kube/accessor.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -27,14 +28,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/hashicorp/go-multierror"
-	kubeApiAdmissions "k8s.io/api/admissionregistration/v1beta1"
-	appsv1 "k8s.io/api/apps/v1"
-	authenticationv1 "k8s.io/api/authentication/v1"
-	"k8s.io/api/autoscaling/v2beta1"
 	kubeApiCore "k8s.io/api/core/v1"
-	"k8s.io/api/policy/v1beta1"
-	v1 "k8s.io/api/rbac/v1"
-	kubeApiExt "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	kubeExtClient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/errors"
 	kubeApiMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,14 +41,12 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
-	kubeClientCore "k8s.io/client-go/kubernetes/typed/core/v1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // Needed for auth
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/kubectl/pkg/cmd/apply"
 	"k8s.io/kubectl/pkg/cmd/delete"
-	"k8s.io/kubectl/pkg/cmd/logs"
 	"k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/polymorphichelpers"
 
 	istioKube "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test"
@@ -74,24 +66,109 @@ var (
 
 // Accessor is a helper for accessing Kubernetes programmatically. It bundles some of the high-level
 // operations that is frequently used by the test framework.
-type Accessor struct {
+type Accessor interface {
+	kubernetes.Interface
+
+	// RESTConfig returns the Kubernetes rest config used to configure the clients.
+	RESTConfig() *rest.Config
+
+	// Ext returns the API extensions client.
+	Ext() kubeExtClient.Interface
+
+	// NewPortForwarder creates a new port forwarder.
+	NewPortForwarder(pod kubeApiCore.Pod, localPort, remotePort uint16) (PortForwarder, error)
+
+	// GetPods returns pods in the given namespace, based on the selectors. If no selectors are given, then
+	// all pods are returned.
+	GetPods(namespace string, selectors ...string) ([]kubeApiCore.Pod, error)
+
+	// GetEvents returns events in the given namespace, based on the involvedObject.
+	GetEvents(namespace string, involvedObject string) ([]kubeApiCore.Event, error)
+
+	// WaitUntilPodsAreReady waits until the pod with the name/namespace is in ready state.
+	WaitUntilPodsAreReady(fetchFunc PodFetchFunc, opts ...retry.Option) ([]kubeApiCore.Pod, error)
+
+	// CheckPodsAreReady checks whether the pods that are selected by the given function is in ready state or not.
+	CheckPodsAreReady(fetchFunc PodFetchFunc) ([]kubeApiCore.Pod, error)
+
+	// WaitUntilServiceEndpointsAreReady will wait until the service with the given name/namespace is present, and have at least
+	// one usable endpoint.
+	WaitUntilServiceEndpointsAreReady(ns string, name string, opts ...retry.Option) (*kubeApiCore.Service, *kubeApiCore.Endpoints, error)
+
+	// WaitForSecretToExist waits for the given secret up to the given waitTime.
+	WaitForSecretToExist(namespace, name string, waitTime time.Duration) (*kubeApiCore.Secret, error)
+
+	// WaitForSecretToExistOrFail calls WaitForSecretToExist and fails the given test.Failer if an error occurs.
+	WaitForSecretToExistOrFail(t test.Failer, namespace, name string, waitTime time.Duration) *kubeApiCore.Secret
+
+	// GetKubernetesVersion returns the Kubernetes server version
+	GetKubernetesVersion() (*version.Info, error)
+
+	// CreateNamespaceWithLabels with the specified name, sidecar-injection behavior, and labels
+	CreateNamespaceWithLabels(ns string, istioTestingAnnotation string, labels map[string]string) error
+
+	// NamespaceExists returns true if the given namespace exists.
+	NamespaceExists(ns string) bool
+
+	// DeleteNamespace with the given name
+	DeleteNamespace(ns string) error
+
+	// WaitForNamespaceDeletion waits until a namespace is deleted.
+	WaitForNamespaceDeletion(ns string, opts ...retry.Option) error
+
+	// GetUnstructured returns an unstructured k8s resource object based on the provided schema, namespace, and name.
+	GetUnstructured(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error)
+
+	// DeleteUnstructured deletes an unstructured k8s resource object based on the provided schema, namespace, and name.
+	DeleteUnstructured(gvr schema.GroupVersionResource, namespace, name string) error
+
+	// ApplyContents applies the given config contents using kubectl.
+	ApplyContents(namespace string, contents string) ([]string, error)
+
+	// ApplyContentsDryRun applies the given config contents using kubectl with DryRun mode.
+	ApplyContentsDryRun(namespace string, contents string) ([]string, error)
+
+	// Apply applies the config in the given filename using kubectl.
+	Apply(namespace string, filename string) error
+
+	// ApplyDryRun applies the config in the given filename using kubectl with DryRun mode.
+	ApplyDryRun(namespace string, filename string) error
+
+	// DeleteContents deletes the given config contents using kubectl.
+	DeleteContents(namespace string, contents string) error
+
+	// Delete the config in the given filename using kubectl.
+	Delete(namespace string, filename string) error
+
+	// Logs calls the logs command for the specified pod, with -c, if container is specified.
+	Logs(namespace string, pod string, container string, previousLog bool) (string, error)
+
+	// Exec executes the provided command on the specified pod/container.
+	Exec(namespace, podName, containerName, command string) (string, error)
+}
+
+var _ Accessor = &accessorImpl{}
+
+type accessorImpl struct {
+	kubernetes.Interface
+
 	clientFactory util.Factory
 	baseDir       string
 	workDir       string
 	workDirMutex  sync.Mutex
-	clientSet     kubernetes.Interface
+	restConfig    *rest.Config
 	extSet        *kubeExtClient.Clientset
 	dynamicClient dynamic.Interface
 }
 
 // NewAccessor returns a new Accessor from a kube config file.
-func NewAccessor(kubeConfig string, baseWorkDir string) (*Accessor, error) {
+func NewAccessor(kubeConfig string, baseWorkDir string) (Accessor, error) {
 	clientFactory := istioKube.NewClientFactory(istioKube.BuildClientCmd(kubeConfig, ""), "")
 	return NewAccessorForClientFactory(clientFactory, baseWorkDir)
 }
 
 // NewAccessorForClientFactory creates a new Accessor from a ClientConfig.
-func NewAccessorForClientFactory(clientFactory util.Factory, baseWorkDir string) (*Accessor, error) {
+func NewAccessorForClientFactory(clientFactory util.Factory, baseWorkDir string) (Accessor, error) {
 	clientSet, err := clientFactory.KubernetesClientSet()
 	if err != nil {
 		return nil, err
@@ -112,25 +189,36 @@ func NewAccessorForClientFactory(clientFactory util.Factory, baseWorkDir string)
 		return nil, err
 	}
 
-	return &Accessor{
+	return &accessorImpl{
+		Interface:     clientSet,
 		clientFactory: clientFactory,
-		clientSet:     clientSet,
+		restConfig:    restConfig,
 		extSet:        extSet,
 		dynamicClient: dynamicClient,
 		baseDir:       baseWorkDir,
 	}, nil
 }
 
-// NewPortForwarder creates a new port forwarder.
-func (a *Accessor) NewPortForwarder(pod kubeApiCore.Pod, localPort, remotePort uint16) (PortForwarder, error) {
-	return newPortForwarder(a.clientFactory, pod, localPort, remotePort)
+// RESTConfig returns the Kubernetes rest config used to configure the clients.
+func (a *accessorImpl) RESTConfig() *rest.Config {
+	return a.restConfig
+}
+
+// Ext returns the API extensions client.
+func (a *accessorImpl) Ext() kubeExtClient.Interface {
+	return a.extSet
+}
+
+// NewPortForwarder creates a new port forwarder for the given pod.
+func (a *accessorImpl) NewPortForwarder(pod kubeApiCore.Pod, localPort, remotePort uint16) (PortForwarder, error) {
+	return NewPortForwarder(a.restConfig, pod, localPort, remotePort)
 }
 
 // GetPods returns pods in the given namespace, based on the selectors. If no selectors are given, then
 // all pods are returned.
-func (a *Accessor) GetPods(namespace string, selectors ...string) ([]kubeApiCore.Pod, error) {
+func (a *accessorImpl) GetPods(namespace string, selectors ...string) ([]kubeApiCore.Pod, error) {
 	s := strings.Join(selectors, ",")
-	list, err := a.clientSet.CoreV1().Pods(namespace).List(context.TODO(), kubeApiMeta.ListOptions{LabelSelector: s})
+	list, err := a.CoreV1().Pods(namespace).List(context.TODO(), kubeApiMeta.ListOptions{LabelSelector: s})
 
 	if err != nil {
 		return []kubeApiCore.Pod{}, err
@@ -139,21 +227,10 @@ func (a *Accessor) GetPods(namespace string, selectors ...string) ([]kubeApiCore
 	return list.Items, nil
 }
 
-func (a *Accessor) GetDeployments(namespace string, selectors ...string) ([]appsv1.Deployment, error) {
-	s := strings.Join(selectors, ",")
-	list, err := a.clientSet.AppsV1().Deployments(namespace).List(context.TODO(), kubeApiMeta.ListOptions{LabelSelector: s})
-
-	if err != nil {
-		return []appsv1.Deployment{}, err
-	}
-
-	return list.Items, nil
-}
-
 // GetEvents returns events in the given namespace, based on the involvedObject.
-func (a *Accessor) GetEvents(namespace string, involvedObject string) ([]kubeApiCore.Event, error) {
+func (a *accessorImpl) GetEvents(namespace string, involvedObject string) ([]kubeApiCore.Event, error) {
 	s := "involvedObject.name=" + involvedObject
-	list, err := a.clientSet.CoreV1().Events(namespace).List(context.TODO(), kubeApiMeta.ListOptions{FieldSelector: s})
+	list, err := a.CoreV1().Events(namespace).List(context.TODO(), kubeApiMeta.ListOptions{FieldSelector: s})
 
 	if err != nil {
 		return []kubeApiCore.Event{}, err
@@ -162,77 +239,8 @@ func (a *Accessor) GetEvents(namespace string, involvedObject string) ([]kubeApi
 	return list.Items, nil
 }
 
-// GetPod returns the pod with the given namespace and name.
-func (a *Accessor) GetPod(namespace, name string) (kubeApiCore.Pod, error) {
-	v, err := a.clientSet.CoreV1().
-		Pods(namespace).Get(context.TODO(), name, kubeApiMeta.GetOptions{})
-	if err != nil {
-		return kubeApiCore.Pod{}, err
-	}
-	return *v, nil
-}
-
-// DeletePod deletes the given pod.
-func (a *Accessor) DeletePod(namespace, name string) error {
-	return a.clientSet.CoreV1().Pods(namespace).Delete(context.TODO(), name, kubeApiMeta.DeleteOptions{})
-}
-
-// FindPodBySelectors returns the first matching pod, given a namespace and a set of selectors.
-func (a *Accessor) FindPodBySelectors(namespace string, selectors ...string) (kubeApiCore.Pod, error) {
-	list, err := a.GetPods(namespace, selectors...)
-	if err != nil {
-		return kubeApiCore.Pod{}, err
-	}
-
-	if len(list) == 0 {
-		return kubeApiCore.Pod{}, fmt.Errorf("no matching pod found for selectors: %v", selectors)
-	}
-
-	if len(list) > 1 {
-		scopes.Framework.Warnf("More than one pod found matching selectors: %v", selectors)
-	}
-
-	return list[0], nil
-}
-
-// PodFetchFunc fetches pods from the Accessor.
-type PodFetchFunc func() ([]kubeApiCore.Pod, error)
-
-// NewPodFetch creates a new PodFetchFunction that fetches all pods matching the namespace and label selectors.
-func (a *Accessor) NewPodFetch(namespace string, selectors ...string) PodFetchFunc {
-	return func() ([]kubeApiCore.Pod, error) {
-		return a.GetPods(namespace, selectors...)
-	}
-}
-
-// NewPodMustFetch creates a new PodFetchFunction that fetches all pods matching the namespace and label selectors.
-// If no pods are found, an error is returned
-func (a *Accessor) NewPodMustFetch(namespace string, selectors ...string) PodFetchFunc {
-	return func() ([]kubeApiCore.Pod, error) {
-		pods, err := a.GetPods(namespace, selectors...)
-		if err != nil {
-			return nil, err
-		}
-		if len(pods) == 0 {
-			return nil, fmt.Errorf("no pods found for %v", selectors)
-		}
-		return pods, nil
-	}
-}
-
-// NewSinglePodFetch creates a new PodFetchFunction that fetches a single pod matching the given label selectors.
-func (a *Accessor) NewSinglePodFetch(namespace string, selectors ...string) PodFetchFunc {
-	return func() ([]kubeApiCore.Pod, error) {
-		pod, err := a.FindPodBySelectors(namespace, selectors...)
-		if err != nil {
-			return nil, err
-		}
-		return []kubeApiCore.Pod{pod}, nil
-	}
-}
-
 // WaitUntilPodsAreReady waits until the pod with the name/namespace is in ready state.
-func (a *Accessor) WaitUntilPodsAreReady(fetchFunc PodFetchFunc, opts ...retry.Option) ([]kubeApiCore.Pod, error) {
+func (a *accessorImpl) WaitUntilPodsAreReady(fetchFunc PodFetchFunc, opts ...retry.Option) ([]kubeApiCore.Pod, error) {
 	var pods []kubeApiCore.Pod
 	_, err := retry.Do(func() (interface{}, bool, error) {
 
@@ -250,7 +258,7 @@ func (a *Accessor) WaitUntilPodsAreReady(fetchFunc PodFetchFunc, opts ...retry.O
 }
 
 // CheckPodsAreReady checks whether the pods that are selected by the given function is in ready state or not.
-func (a *Accessor) CheckPodsAreReady(fetchFunc PodFetchFunc) ([]kubeApiCore.Pod, error) {
+func (a *accessorImpl) CheckPodsAreReady(fetchFunc PodFetchFunc) ([]kubeApiCore.Pod, error) {
 	scopes.Framework.Infof("Checking pods ready...")
 
 	fetched, err := fetchFunc()
@@ -275,84 +283,19 @@ func (a *Accessor) CheckPodsAreReady(fetchFunc PodFetchFunc) ([]kubeApiCore.Pod,
 	return fetched, nil
 }
 
-// WaitUntilPodsAreDeleted waits until the pod with the name/namespace no longer exist.
-func (a *Accessor) WaitUntilPodsAreDeleted(fetchFunc PodFetchFunc, opts ...retry.Option) error {
-	_, err := retry.Do(func() (interface{}, bool, error) {
-
-		pods, err := fetchFunc()
-		if err != nil {
-			scopes.Framework.Infof("Failed retrieving pods: %v", err)
-			return nil, false, err
-		}
-
-		if len(pods) == 0 {
-			// All pods have been deleted.
-			return nil, true, nil
-		}
-
-		return nil, false, fmt.Errorf("failed waiting to delete pod %s/%s", pods[0].Namespace, pods[0].Name)
-	}, newRetryOptions(opts...)...)
-
-	return err
-}
-
-// DeleteDeployment deletes the given deployment.
-func (a *Accessor) DeleteDeployment(ns string, name string) error {
-	return a.clientSet.AppsV1().Deployments(ns).Delete(context.TODO(), name, *deleteOptionsForeground())
-}
-
-// WaitUntilDeploymentIsReady waits until the deployment with the name/namespace is in ready state.
-func (a *Accessor) WaitUntilDeploymentIsReady(ns string, name string, opts ...retry.Option) error {
-	_, err := retry.Do(func() (interface{}, bool, error) {
-
-		deployment, err := a.clientSet.AppsV1().Deployments(ns).Get(context.TODO(), name, kubeApiMeta.GetOptions{})
-		if err != nil {
-			if !errors.IsNotFound(err) {
-				return nil, true, err
-			}
-		}
-
-		ready := deployment.Status.ReadyReplicas == deployment.Status.UnavailableReplicas+deployment.Status.AvailableReplicas
-
-		return nil, ready, nil
-	}, newRetryOptions(opts...)...)
-
-	return err
-}
-
-// WaitUntilDaemonSetIsReady waits until the deployment with the name/namespace is in ready state.
-func (a *Accessor) WaitUntilDaemonSetIsReady(ns string, name string, opts ...retry.Option) error {
-	_, err := retry.Do(func() (interface{}, bool, error) {
-
-		daemonSet, err := a.clientSet.AppsV1().DaemonSets(ns).Get(context.TODO(), name, kubeApiMeta.GetOptions{})
-		if err != nil {
-			if !errors.IsNotFound(err) {
-				return nil, true, err
-			}
-		}
-
-		ready := daemonSet.Status.NumberReady == daemonSet.Status.DesiredNumberScheduled
-
-		return nil, ready, nil
-	}, newRetryOptions(opts...)...)
-
-	return err
-}
-
 // WaitUntilServiceEndpointsAreReady will wait until the service with the given name/namespace is present, and have at least
 // one usable endpoint.
-func (a *Accessor) WaitUntilServiceEndpointsAreReady(ns string, name string,
+func (a *accessorImpl) WaitUntilServiceEndpointsAreReady(ns string, name string,
 	opts ...retry.Option) (*kubeApiCore.Service, *kubeApiCore.Endpoints, error) {
 	var service *kubeApiCore.Service
 	var endpoints *kubeApiCore.Endpoints
 	err := retry.UntilSuccess(func() error {
-
-		s, err := a.GetService(ns, name)
+		s, err := a.CoreV1().Services(ns).Get(context.TODO(), name, kubeApiMeta.GetOptions{})
 		if err != nil {
 			return err
 		}
 
-		eps, err := a.GetEndpoints(ns, name, kubeApiMeta.GetOptions{})
+		eps, err := a.CoreV1().Endpoints(ns).Get(context.TODO(), name, kubeApiMeta.GetOptions{})
 		if err != nil {
 			return err
 		}
@@ -377,129 +320,9 @@ func (a *Accessor) WaitUntilServiceEndpointsAreReady(ns string, name string,
 	return service, endpoints, nil
 }
 
-// DeleteMutatingWebhook deletes the mutating webhook with the given name.
-func (a *Accessor) DeleteMutatingWebhook(name string) error {
-	return a.clientSet.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Delete(context.TODO(),
-		name, *deleteOptionsForeground())
-}
-
-// DeleteValidatingWebhook deletes the validating webhook with the given name.
-func (a *Accessor) DeleteValidatingWebhook(name string) error {
-	return a.clientSet.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Delete(context.TODO(),
-		name, *deleteOptionsForeground())
-}
-
-// WaitForValidatingWebhookDeletion waits for the validating webhook with the given name to be garbage collected by kubernetes.
-func (a *Accessor) WaitForValidatingWebhookDeletion(name string, opts ...retry.Option) error {
-	_, err := retry.Do(func() (interface{}, bool, error) {
-		if a.ValidatingWebhookConfigurationExists(name) {
-			return nil, false, fmt.Errorf("validating webhook not deleted: %s", name)
-		}
-
-		// It no longer exists ... success.
-		return nil, true, nil
-	}, newRetryOptions(opts...)...)
-
-	return err
-}
-
-// ValidatingWebhookConfigurationExists indicates whether a validating webhook with the given name exists.
-func (a *Accessor) ValidatingWebhookConfigurationExists(name string) bool {
-	_, err := a.clientSet.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Get(context.TODO(),
-		name, kubeApiMeta.GetOptions{})
-	return err == nil
-}
-
-// MutatingWebhookConfigurationExists indicates whether a mutating webhook with the given name exists.
-func (a *Accessor) MutatingWebhookConfigurationExists(name string) bool {
-	_, err := a.clientSet.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(context.TODO(),
-		name, kubeApiMeta.GetOptions{})
-	return err == nil
-}
-
-// GetValidatingWebhookConfiguration returns the specified ValidatingWebhookConfiguration.
-func (a *Accessor) GetValidatingWebhookConfiguration(name string) (*kubeApiAdmissions.ValidatingWebhookConfiguration, error) {
-	whc, err := a.clientSet.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Get(context.TODO(),
-		name, kubeApiMeta.GetOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("could not get validating webhook config: %s", name)
-	}
-	return whc, nil
-}
-
-// UpdateValidatingWebhookConfiguration updates the specified ValidatingWebhookConfiguration.
-func (a *Accessor) UpdateValidatingWebhookConfiguration(config *kubeApiAdmissions.ValidatingWebhookConfiguration) error {
-	if _, err := a.clientSet.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Update(context.TODO(),
-		config, kubeApiMeta.UpdateOptions{}); err != nil {
-		return fmt.Errorf("could not update validating webhook config: %s", config.Name)
-	}
-	return nil
-}
-
-// GetCustomResourceDefinitions gets the CRDs
-func (a *Accessor) GetCustomResourceDefinitions() ([]kubeApiExt.CustomResourceDefinition, error) {
-	crd, err := a.extSet.ApiextensionsV1beta1().CustomResourceDefinitions().List(context.TODO(), kubeApiMeta.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-	return crd.Items, nil
-}
-
-// GetCustomResourceDefinition gets the CRD with the given name
-func (a *Accessor) GetCustomResourceDefinition(name string) (*kubeApiExt.CustomResourceDefinition, error) {
-	return a.extSet.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), name, kubeApiMeta.GetOptions{})
-}
-
-// DeleteCustomResourceDefinitions deletes the CRD with the given name.
-func (a *Accessor) DeleteCustomResourceDefinitions(name string) error {
-	return a.extSet.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(context.TODO(), name, *deleteOptionsForeground())
-}
-
-// GetPodDisruptionBudget gets the PodDisruptionBudget with the given name
-func (a *Accessor) GetPodDisruptionBudget(ns, name string) (*v1beta1.PodDisruptionBudget, error) {
-	return a.clientSet.PolicyV1beta1().PodDisruptionBudgets(ns).Get(context.TODO(), name, kubeApiMeta.GetOptions{})
-}
-
-// GetHorizontalPodAutoscaler gets the HorizontalPodAutoscaler with the given name
-func (a *Accessor) GetHorizontalPodAutoscaler(ns, name string) (*v2beta1.HorizontalPodAutoscaler, error) {
-	return a.clientSet.AutoscalingV2beta1().HorizontalPodAutoscalers(ns).Get(context.TODO(), name, kubeApiMeta.GetOptions{})
-}
-
-// GetService returns the service entry with the given name/namespace.
-func (a *Accessor) GetService(ns string, name string) (*kubeApiCore.Service, error) {
-	return a.clientSet.CoreV1().Services(ns).Get(context.TODO(), name, kubeApiMeta.GetOptions{})
-}
-
-// GetDeployment returns the deployment with the given name/namespace.
-func (a *Accessor) GetDeployment(ns string, name string) (*appsv1.Deployment, error) {
-	return a.clientSet.AppsV1().Deployments(ns).Get(context.TODO(), name, kubeApiMeta.GetOptions{})
-}
-
-// GetSecret returns secret resource with the given namespace.
-func (a *Accessor) GetSecret(ns string) kubeClientCore.SecretInterface {
-	return a.clientSet.CoreV1().Secrets(ns)
-}
-
-// GetConfigMap returns the config resource with the given name and namespace.
-func (a *Accessor) GetConfigMap(name, ns string) (*kubeApiCore.ConfigMap, error) {
-	return a.clientSet.CoreV1().ConfigMaps(ns).Get(context.TODO(), name, kubeApiMeta.GetOptions{})
-}
-
-// DeleteConfigMap deletes the config resource with the given name and namespace.
-func (a *Accessor) DeleteConfigMap(name, ns string) error {
-	return a.clientSet.CoreV1().ConfigMaps(ns).Delete(context.TODO(), name, kubeApiMeta.DeleteOptions{})
-}
-
-// CreateSecret takes the representation of a secret and creates it in the given namespace.
-// Returns an error if there is any.
-func (a *Accessor) CreateSecret(namespace string, secret *kubeApiCore.Secret) (err error) {
-	_, err = a.clientSet.CoreV1().Secrets(namespace).Create(context.TODO(), secret, kubeApiMeta.CreateOptions{})
-	return err
-}
-
 // WaitForSecretToExist waits for the given secret up to the given waitTime.
-func (a *Accessor) WaitForSecretToExist(namespace, name string, waitTime time.Duration) (*kubeApiCore.Secret, error) {
-	secret := a.GetSecret(namespace)
+func (a *accessorImpl) WaitForSecretToExist(namespace, name string, waitTime time.Duration) (*kubeApiCore.Secret, error) {
+	secret := a.CoreV1().Secrets(namespace)
 
 	watch, err := secret.Watch(context.TODO(), kubeApiMeta.ListOptions{})
 	if err != nil {
@@ -523,7 +346,7 @@ func (a *Accessor) WaitForSecretToExist(namespace, name string, waitTime time.Du
 }
 
 // WaitForSecretToExistOrFail calls WaitForSecretToExist and fails the given test.Failer if an error occurs.
-func (a *Accessor) WaitForSecretToExistOrFail(t test.Failer, namespace, name string,
+func (a *accessorImpl) WaitForSecretToExistOrFail(t test.Failer, namespace, name string,
 	waitTime time.Duration) *kubeApiCore.Secret {
 	t.Helper()
 	s, err := a.WaitForSecretToExist(namespace, name, waitTime)
@@ -533,52 +356,24 @@ func (a *Accessor) WaitForSecretToExistOrFail(t test.Failer, namespace, name str
 	return s
 }
 
-// DeleteSecret deletes secret by name in namespace.
-func (a *Accessor) DeleteSecret(namespace, name string) (err error) {
-	var immediate int64
-	err = a.clientSet.CoreV1().Secrets(namespace).Delete(context.TODO(), name, kubeApiMeta.DeleteOptions{GracePeriodSeconds: &immediate})
-	return err
-}
-
-func (a *Accessor) GetServiceAccount(namespace, name string) (*kubeApiCore.ServiceAccount, error) {
-	return a.clientSet.CoreV1().ServiceAccounts(namespace).Get(context.TODO(), name, kubeApiMeta.GetOptions{})
-}
-
 // GetKubernetesVersion returns the Kubernetes server version
-func (a *Accessor) GetKubernetesVersion() (*version.Info, error) {
+func (a *accessorImpl) GetKubernetesVersion() (*version.Info, error) {
 	return a.extSet.ServerVersion()
 }
 
-// GetEndpoints returns the endpoints for the given service.
-func (a *Accessor) GetEndpoints(ns, service string, options kubeApiMeta.GetOptions) (*kubeApiCore.Endpoints, error) {
-	return a.clientSet.CoreV1().Endpoints(ns).Get(context.TODO(), service, options)
-}
-
-// CreateNamespace with the given name. Also adds an "istio-testing" annotation.
-func (a *Accessor) CreateNamespace(ns string, istioTestingAnnotation string) error {
-	scopes.Framework.Debugf("Creating namespace: %s", ns)
-
-	n := a.newNamespace(ns, istioTestingAnnotation)
-
-	_, err := a.clientSet.CoreV1().Namespaces().Create(context.TODO(), &n, kubeApiMeta.CreateOptions{})
-	return err
-}
-
 // CreateNamespaceWithLabels with the specified name, sidecar-injection behavior, and labels
-func (a *Accessor) CreateNamespaceWithLabels(ns string, istioTestingAnnotation string, labels map[string]string) error {
+func (a *accessorImpl) CreateNamespaceWithLabels(ns string, istioTestingAnnotation string, labels map[string]string) error {
 	scopes.Framework.Debugf("Creating namespace %s ns with labels %v", ns, labels)
 
 	n := a.newNamespaceWithLabels(ns, istioTestingAnnotation, labels)
-	_, err := a.clientSet.CoreV1().Namespaces().Create(context.TODO(), &n, kubeApiMeta.CreateOptions{})
+	_, err := a.CoreV1().Namespaces().Create(context.TODO(), &n, kubeApiMeta.CreateOptions{})
 	return err
 }
 
-func (a *Accessor) newNamespace(ns string, istioTestingAnnotation string) kubeApiCore.Namespace {
-	n := a.newNamespaceWithLabels(ns, istioTestingAnnotation, make(map[string]string))
-	return n
-}
-
-func (a *Accessor) newNamespaceWithLabels(ns string, istioTestingAnnotation string, labels map[string]string) kubeApiCore.Namespace {
+func (a *accessorImpl) newNamespaceWithLabels(ns string, istioTestingAnnotation string, labels map[string]string) kubeApiCore.Namespace {
+	if labels == nil {
+		labels = make(map[string]string)
+	}
 	n := kubeApiCore.Namespace{
 		ObjectMeta: kubeApiMeta.ObjectMeta{
 			Name:   ns,
@@ -592,8 +387,8 @@ func (a *Accessor) newNamespaceWithLabels(ns string, istioTestingAnnotation stri
 }
 
 // NamespaceExists returns true if the given namespace exists.
-func (a *Accessor) NamespaceExists(ns string) bool {
-	allNs, err := a.clientSet.CoreV1().Namespaces().List(context.TODO(), kubeApiMeta.ListOptions{})
+func (a *accessorImpl) NamespaceExists(ns string) bool {
+	allNs, err := a.CoreV1().Namespaces().List(context.TODO(), kubeApiMeta.ListOptions{})
 	if err != nil {
 		return false
 	}
@@ -606,15 +401,15 @@ func (a *Accessor) NamespaceExists(ns string) bool {
 }
 
 // DeleteNamespace with the given name
-func (a *Accessor) DeleteNamespace(ns string) error {
+func (a *accessorImpl) DeleteNamespace(ns string) error {
 	scopes.Framework.Debugf("Deleting namespace: %s", ns)
-	return a.clientSet.CoreV1().Namespaces().Delete(context.TODO(), ns, *deleteOptionsForeground())
+	return a.CoreV1().Namespaces().Delete(context.TODO(), ns, *deleteOptionsForeground())
 }
 
 // WaitForNamespaceDeletion waits until a namespace is deleted.
-func (a *Accessor) WaitForNamespaceDeletion(ns string, opts ...retry.Option) error {
+func (a *accessorImpl) WaitForNamespaceDeletion(ns string, opts ...retry.Option) error {
 	_, err := retry.Do(func() (interface{}, bool, error) {
-		_, err2 := a.clientSet.CoreV1().Namespaces().Get(context.TODO(), ns, kubeApiMeta.GetOptions{})
+		_, err2 := a.CoreV1().Namespaces().Get(context.TODO(), ns, kubeApiMeta.GetOptions{})
 		if err2 == nil {
 			return nil, false, nil
 		}
@@ -629,50 +424,8 @@ func (a *Accessor) WaitForNamespaceDeletion(ns string, opts ...retry.Option) err
 	return err
 }
 
-// GetNamespace returns the K8s namespaceresource with the given name.
-func (a *Accessor) GetNamespace(ns string) (*kubeApiCore.Namespace, error) {
-	n, err := a.clientSet.CoreV1().Namespaces().Get(context.TODO(), ns, kubeApiMeta.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	return n, nil
-}
-
-// DeleteClusterRole deletes a ClusterRole with the given name
-func (a *Accessor) DeleteClusterRole(role string) error {
-	scopes.Framework.Debugf("Deleting ClusterRole: %s", role)
-	return a.clientSet.RbacV1().ClusterRoles().Delete(context.TODO(), role, *deleteOptionsForeground())
-}
-
-// GetClusterRole gets a ClusterRole with the given name
-func (a *Accessor) GetClusterRole(role string) (*v1.ClusterRole, error) {
-	return a.clientSet.RbacV1().ClusterRoles().Get(context.TODO(), role, kubeApiMeta.GetOptions{})
-}
-
-// GetClusterRoleBinding gets a ClusterRoleBinding with the given name
-func (a *Accessor) GetClusterRoleBinding(role string) (*v1.ClusterRoleBinding, error) {
-	return a.clientSet.RbacV1().ClusterRoleBindings().Get(context.TODO(), role, kubeApiMeta.GetOptions{})
-}
-
-// CreateNamespace with the given name. Also adds an "istio-testing" annotation.
-func (a *Accessor) CreateServiceAccountToken(ns string, serviceAccount string) (string, error) {
-	scopes.Framework.Debugf("Creating service account token for: %s/%s", ns, serviceAccount)
-
-	token, err := a.clientSet.CoreV1().ServiceAccounts(ns).CreateToken(context.TODO(), serviceAccount, &authenticationv1.TokenRequest{
-		Spec: authenticationv1.TokenRequestSpec{
-			Audiences: []string{"istio-ca"},
-		},
-	}, kubeApiMeta.CreateOptions{})
-
-	if err != nil {
-		return "", err
-	}
-	return token.Status.Token, nil
-}
-
 // GetUnstructured returns an unstructured k8s resource object based on the provided schema, namespace, and name.
-func (a *Accessor) GetUnstructured(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+func (a *accessorImpl) GetUnstructured(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
 	u, err := a.dynamicClient.Resource(gvr).Namespace(namespace).Get(context.TODO(), name, kubeApiMeta.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get resource %v of type %v: %v", name, gvr, err)
@@ -682,7 +435,7 @@ func (a *Accessor) GetUnstructured(gvr schema.GroupVersionResource, namespace, n
 }
 
 // DeleteUnstructured deletes an unstructured k8s resource object based on the provided schema, namespace, and name.
-func (a *Accessor) DeleteUnstructured(gvr schema.GroupVersionResource, namespace, name string) error {
+func (a *accessorImpl) DeleteUnstructured(gvr schema.GroupVersionResource, namespace, name string) error {
 	if err := a.dynamicClient.Resource(gvr).Namespace(namespace).Delete(context.TODO(), name, kubeApiMeta.DeleteOptions{}); err != nil {
 		return fmt.Errorf("failed to delete resource %v of type %v: %v", name, gvr, err)
 	}
@@ -690,27 +443,27 @@ func (a *Accessor) DeleteUnstructured(gvr schema.GroupVersionResource, namespace
 }
 
 // ApplyContents applies the given config contents using kubectl.
-func (a *Accessor) ApplyContents(namespace string, contents string) ([]string, error) {
+func (a *accessorImpl) ApplyContents(namespace string, contents string) ([]string, error) {
 	return a.applyContents(namespace, contents, false)
 }
 
 // ApplyContentsDryRun applies the given config contents using kubectl with DryRun mode.
-func (a *Accessor) ApplyContentsDryRun(namespace string, contents string) ([]string, error) {
+func (a *accessorImpl) ApplyContentsDryRun(namespace string, contents string) ([]string, error) {
 	return a.applyContents(namespace, contents, true)
 }
 
 // Apply applies the config in the given filename using kubectl.
-func (a *Accessor) Apply(namespace string, filename string) error {
+func (a *accessorImpl) Apply(namespace string, filename string) error {
 	return a.apply(namespace, filename, false)
 }
 
 // ApplyDryRun applies the config in the given filename using kubectl with DryRun mode.
-func (a *Accessor) ApplyDryRun(namespace string, filename string) error {
+func (a *accessorImpl) ApplyDryRun(namespace string, filename string) error {
 	return a.apply(namespace, filename, true)
 }
 
 // applyContents applies the given config contents using kubectl.
-func (a *Accessor) applyContents(namespace string, contents string, dryRun bool) ([]string, error) {
+func (a *accessorImpl) applyContents(namespace string, contents string, dryRun bool) ([]string, error) {
 	files, err := a.contentsToFileList(contents, "accessor_applyc")
 	if err != nil {
 		return nil, err
@@ -724,7 +477,7 @@ func (a *Accessor) applyContents(namespace string, contents string, dryRun bool)
 }
 
 // apply the config in the given filename using kubectl.
-func (a *Accessor) apply(namespace string, filename string, dryRun bool) error {
+func (a *accessorImpl) apply(namespace string, filename string, dryRun bool) error {
 	files, err := a.fileToFileList(filename)
 	if err != nil {
 		return err
@@ -733,7 +486,7 @@ func (a *Accessor) apply(namespace string, filename string, dryRun bool) error {
 	return a.applyInternal(namespace, files, dryRun)
 }
 
-func (a *Accessor) applyInternal(namespace string, files []string, dryRun bool) error {
+func (a *accessorImpl) applyInternal(namespace string, files []string, dryRun bool) error {
 	for _, f := range removeEmptyFiles(files) {
 		if err := a.applyFile(namespace, f, dryRun); err != nil {
 			return err
@@ -742,7 +495,7 @@ func (a *Accessor) applyInternal(namespace string, files []string, dryRun bool) 
 	return nil
 }
 
-func (a *Accessor) applyFile(namespace string, file string, dryRun bool) error {
+func (a *accessorImpl) applyFile(namespace string, file string, dryRun bool) error {
 	if dryRun {
 		scopes.Framework.Infof("Applying YAML file (DryRun mode): %v", file)
 	} else {
@@ -817,7 +570,7 @@ func (a *Accessor) applyFile(namespace string, file string, dryRun bool) error {
 }
 
 // DeleteContents deletes the given config contents using kubectl.
-func (a *Accessor) DeleteContents(namespace string, contents string) error {
+func (a *accessorImpl) DeleteContents(namespace string, contents string) error {
 	files, err := a.contentsToFileList(contents, "accessor_deletec")
 	if err != nil {
 		return err
@@ -827,7 +580,7 @@ func (a *Accessor) DeleteContents(namespace string, contents string) error {
 }
 
 // Delete the config in the given filename using kubectl.
-func (a *Accessor) Delete(namespace string, filename string) error {
+func (a *accessorImpl) Delete(namespace string, filename string) error {
 	files, err := a.fileToFileList(filename)
 	if err != nil {
 		return err
@@ -836,14 +589,14 @@ func (a *Accessor) Delete(namespace string, filename string) error {
 	return a.deleteInternal(namespace, files)
 }
 
-func (a *Accessor) deleteInternal(namespace string, files []string) (err error) {
+func (a *accessorImpl) deleteInternal(namespace string, files []string) (err error) {
 	for _, f := range removeEmptyFiles(files) {
 		err = multierror.Append(err, a.deleteFile(namespace, f)).ErrorOrNil()
 	}
 	return err
 }
 
-func (a *Accessor) deleteFile(namespace string, file string) error {
+func (a *accessorImpl) deleteFile(namespace string, file string) error {
 	scopes.Framework.Infof("Deleting YAML file: %v", file)
 	// Create the options.
 	streams, _, stdout, stderr := genericclioptions.NewTestIOStreams()
@@ -914,58 +667,30 @@ func (a *Accessor) deleteFile(namespace string, file string) error {
 }
 
 // Logs calls the logs command for the specified pod, with -c, if container is specified.
-func (a *Accessor) Logs(namespace string, pod string, container string, previousLog bool) (string, error) {
-	streams, _, stdout, stderr := genericclioptions.NewTestIOStreams()
-	containerNameSpecified := len(container) > 0
-	opts := logs.NewLogsOptions(streams, !containerNameSpecified)
-	opts.Container = container
-	opts.ContainerNameSpecified = containerNameSpecified
-	opts.Previous = previousLog
-	opts.ResourceArg = pod
-	opts.Resources = []string{pod}
-	opts.Namespace = namespace
-	opts.ConsumeRequestFn = logs.DefaultConsumeRequest
-
-	var err error
-	opts.Options, err = opts.ToLogOptions()
+func (a *accessorImpl) Logs(namespace string, pod string, container string, previousLog bool) (string, error) {
+	opts := &kubeApiCore.PodLogOptions{
+		Container: container,
+		Previous:  previousLog,
+	}
+	res, err := a.CoreV1().Pods(namespace).GetLogs(pod, opts).Stream(context.TODO())
 	if err != nil {
 		return "", err
 	}
+	defer func() {
+		_ = res.Close()
+	}()
 
-	opts.RESTClientGetter = a.clientFactory
-	opts.LogsForObject = polymorphichelpers.LogsForObjectFn
-
-	builder := a.clientFactory.NewBuilder().
-		WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
-		NamespaceParam(opts.Namespace).DefaultNamespace().
-		SingleResourceType().
-		ResourceNames("pods", pod)
-
-	infos, err := builder.Do().Infos()
-	if err != nil {
+	builder := &strings.Builder{}
+	if _, err = io.Copy(builder, res); err != nil {
 		return "", err
 	}
-	if len(infos) != 1 {
-		return "", fmt.Errorf("expected a resource")
-	}
-	opts.Object = infos[0].Object
 
-	err = opts.RunLogs()
-	s := stdout.String() + stderr.String()
-
-	if err != nil {
-		// Concatenate the stdout and stderr
-		scopes.Framework.Infof("(FAILED) Executing kubectl logs (ns: %s, pod: %s, container: %s) (err: %v): %s",
-			namespace, pod, container, err, s)
-		return s, fmt.Errorf("%v: %s", err, s)
-	}
-
-	return s, nil
+	return builder.String(), nil
 }
 
 // Exec executes the provided command on the specified pod/container.
-func (a *Accessor) Exec(namespace, podName, containerName, command string) (string, error) {
-	pod, err := a.clientSet.CoreV1().Pods(namespace).Get(context.TODO(),
+func (a *accessorImpl) Exec(namespace, podName, containerName, command string) (string, error) {
+	pod, err := a.CoreV1().Pods(namespace).Get(context.TODO(),
 		podName, kubeApiMeta.GetOptions{})
 	if err != nil {
 		return "", err
@@ -1006,7 +731,11 @@ func (a *Accessor) Exec(namespace, podName, containerName, command string) (stri
 			Stdout:    true,
 			Stderr:    true,
 		}, scheme.ParameterCodec)
-	exec, err := remotecommand.NewSPDYExecutor(restConfig, "POST", request.URL())
+	wrapper, upgrader, err := roundTripperFor(restConfig)
+	if err != nil {
+		return "", err
+	}
+	exec, err := remotecommand.NewSPDYExecutorForTransports(wrapper, upgrader, "POST", request.URL())
 	if err != nil {
 		return "", err
 	}
@@ -1026,7 +755,7 @@ func (a *Accessor) Exec(namespace, podName, containerName, command string) (stri
 }
 
 // getWorkDir lazy-creates the working directory for the accessor.
-func (a *Accessor) getWorkDir() (string, error) {
+func (a *accessorImpl) getWorkDir() (string, error) {
 	a.workDirMutex.Lock()
 	defer a.workDirMutex.Unlock()
 
@@ -1041,7 +770,7 @@ func (a *Accessor) getWorkDir() (string, error) {
 	return workDir, nil
 }
 
-func (a *Accessor) fileToFileList(filename string) ([]string, error) {
+func (a *accessorImpl) fileToFileList(filename string) ([]string, error) {
 	content, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err
@@ -1064,7 +793,7 @@ func filenameWithoutExtension(fullPath string) string {
 	return strings.TrimSuffix(f, filepath.Ext(fullPath))
 }
 
-func (a *Accessor) contentsToFileList(contents, filenamePrefix string) ([]string, error) {
+func (a *accessorImpl) contentsToFileList(contents, filenamePrefix string) ([]string, error) {
 	files, err := a.splitContentsToFiles(contents, filenamePrefix)
 	if err != nil {
 		return nil, err
@@ -1080,7 +809,7 @@ func (a *Accessor) contentsToFileList(contents, filenamePrefix string) ([]string
 	return files, nil
 }
 
-func (a *Accessor) writeContentsToTempFile(contents string) (filename string, err error) {
+func (a *accessorImpl) writeContentsToTempFile(contents string) (filename string, err error) {
 	defer func() {
 		if err != nil && filename != "" {
 			_ = os.Remove(filename)
@@ -1105,7 +834,7 @@ func (a *Accessor) writeContentsToTempFile(contents string) (filename string, er
 	return
 }
 
-func (a *Accessor) splitContentsToFiles(content, filenamePrefix string) ([]string, error) {
+func (a *accessorImpl) splitContentsToFiles(content, filenamePrefix string) ([]string, error) {
 	cfgs := yml.SplitString(content)
 
 	namespacesAndCrds := &yamlDoc{

--- a/pkg/test/kube/deployment.go
+++ b/pkg/test/kube/deployment.go
@@ -24,7 +24,7 @@ import (
 // Deployment is a utility that absracts the operation of deploying and deleting
 // Kubernetes deployments.
 type Deployment struct {
-	accessor *Accessor
+	accessor Accessor
 
 	// The deployment namespace.
 	namespace string
@@ -49,7 +49,7 @@ func (d *Deployment) Deploy(wait bool, opts ...retry.Option) (err error) {
 	}
 
 	if wait {
-		if _, err := d.accessor.WaitUntilPodsAreReady(d.accessor.NewPodFetch(d.namespace), opts...); err != nil {
+		if _, err := d.accessor.WaitUntilPodsAreReady(NewPodFetch(d.accessor, d.namespace), opts...); err != nil {
 			scopes.Framework.Errorf("Wait for Istio pods failed: %v", err)
 			return err
 		}
@@ -88,7 +88,7 @@ func (d *Deployment) Delete(wait bool, opts ...retry.Option) (err error) {
 }
 
 // NewYamlContentDeployment creates a new deployment from the contents of a yaml document.
-func NewYamlContentDeployment(namespace, yamlContents string, a *Accessor) *Deployment {
+func NewYamlContentDeployment(namespace, yamlContents string, a Accessor) *Deployment {
 	return &Deployment{
 		accessor:     a,
 		namespace:    namespace,

--- a/pkg/test/kube/pods.go
+++ b/pkg/test/kube/pods.go
@@ -1,0 +1,68 @@
+//  Copyright Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package kube
+
+import (
+	"fmt"
+
+	kubeApiCore "k8s.io/api/core/v1"
+
+	"istio.io/istio/pkg/test/scopes"
+)
+
+// PodFetchFunc fetches pods from the Accessor.
+type PodFetchFunc func() ([]kubeApiCore.Pod, error)
+
+// NewPodFetch creates a new PodFetchFunction that fetches all pods matching the namespace and label selectors.
+func NewPodFetch(a Accessor, namespace string, selectors ...string) PodFetchFunc {
+	return func() ([]kubeApiCore.Pod, error) {
+		return a.GetPods(namespace, selectors...)
+	}
+}
+
+// NewSinglePodFetch creates a new PodFetchFunction that fetches a single pod matching the given label selectors.
+func NewSinglePodFetch(a Accessor, namespace string, selectors ...string) PodFetchFunc {
+	return func() ([]kubeApiCore.Pod, error) {
+		list, err := a.GetPods(namespace, selectors...)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(list) == 0 {
+			return nil, fmt.Errorf("no matching pod found for selectors: %v", selectors)
+		}
+
+		if len(list) > 1 {
+			scopes.Framework.Warnf("More than one pod found matching selectors: %v", selectors)
+		}
+
+		return []kubeApiCore.Pod{list[0]}, nil
+	}
+}
+
+// NewPodMustFetch creates a new PodFetchFunction that fetches all pods matching the namespace and label selectors.
+// If no pods are found, an error is returned
+func NewPodMustFetch(a Accessor, namespace string, selectors ...string) PodFetchFunc {
+	return func() ([]kubeApiCore.Pod, error) {
+		pods, err := a.GetPods(namespace, selectors...)
+		if err != nil {
+			return nil, err
+		}
+		if len(pods) == 0 {
+			return nil, fmt.Errorf("no pods found for %v", selectors)
+		}
+		return pods, nil
+	}
+}

--- a/pkg/test/kube/spdy.go
+++ b/pkg/test/kube/spdy.go
@@ -1,0 +1,47 @@
+//  Copyright Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package kube
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+
+	spdyStream "k8s.io/apimachinery/pkg/util/httpstream/spdy"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/transport/spdy"
+)
+
+// roundTripperFor creates a SPDY upgrader that will work over custom transports.
+func roundTripperFor(restConfig *rest.Config) (http.RoundTripper, spdy.Upgrader, error) {
+	// Get the TLS config.
+	tlsConfig, err := rest.TLSConfigFor(restConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed getting TLS config: %w", err)
+	}
+	if tlsConfig == nil && restConfig.Transport != nil {
+		// If using a custom transport, skip server verification on the upgrade.
+		tlsConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+	}
+
+	upgrader := spdyStream.NewRoundTripper(tlsConfig, true, false)
+	wrapper, err := rest.HTTPWrappersForConfig(restConfig, upgrader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed creating SPDY upgrade wrapper: %w", err)
+	}
+	return wrapper, upgrader, nil
+}

--- a/tests/integration/galley/namespace_test.go
+++ b/tests/integration/galley/namespace_test.go
@@ -15,7 +15,10 @@
 package galley
 
 import (
+	"context"
 	"testing"
+
+	kubeApiMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/namespace"
@@ -39,7 +42,7 @@ func TestNamespace(t *testing.T) {
 				t.Fatalf("The namespace %q should have existed.", ns.Name())
 			}
 
-			n, err := cluster.GetNamespace(ns.Name())
+			n, err := cluster.CoreV1().Namespaces().Get(context.TODO(), ns.Name(), kubeApiMeta.GetOptions{})
 			if err != nil {
 				t.Fatalf("Error getting the namespace(%q): %v", ns.Name(), err)
 			}

--- a/tests/integration/galley/webhook_test.go
+++ b/tests/integration/galley/webhook_test.go
@@ -15,11 +15,14 @@
 package galley
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
 
 	kubeApiAdmission "k8s.io/api/admissionregistration/v1beta1"
+	kubeApiMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
@@ -41,7 +44,7 @@ func TestWebhook(t *testing.T) {
 			// clear the updated fields and verify istiod updates them
 
 			retry.UntilSuccessOrFail(t, func() error {
-				got, err := env.KubeClusters[0].GetValidatingWebhookConfiguration(vwcName)
+				got, err := getValidatingWebhookConfiguration(env.KubeClusters[0], vwcName)
 				if err != nil {
 					return fmt.Errorf("error getting initial webhook: %v", err)
 				}
@@ -54,11 +57,15 @@ func TestWebhook(t *testing.T) {
 				ignore := kubeApiAdmission.Ignore // can't take the address of a constant
 				updated.Webhooks[0].FailurePolicy = &ignore
 
-				return env.KubeClusters[0].UpdateValidatingWebhookConfiguration(updated)
+				if _, err := env.KubeClusters[0].AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Update(context.TODO(),
+					updated, kubeApiMeta.UpdateOptions{}); err != nil {
+					return fmt.Errorf("could not update validating webhook config: %s", updated.Name)
+				}
+				return nil
 			})
 
 			retry.UntilSuccessOrFail(t, func() error {
-				got, err := env.KubeClusters[0].GetValidatingWebhookConfiguration(vwcName)
+				got, err := getValidatingWebhookConfiguration(env.KubeClusters[0], vwcName)
 				if err != nil {
 					t.Fatalf("error getting initial webhook: %v", err)
 				}
@@ -68,6 +75,15 @@ func TestWebhook(t *testing.T) {
 				return nil
 			})
 		})
+}
+
+func getValidatingWebhookConfiguration(client kubernetes.Interface, name string) (*kubeApiAdmission.ValidatingWebhookConfiguration, error) {
+	whc, err := client.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Get(context.TODO(),
+		name, kubeApiMeta.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("could not get validating webhook config: %s", name)
+	}
+	return whc, nil
 }
 
 func verifyValidatingWebhookConfiguration(c *kubeApiAdmission.ValidatingWebhookConfiguration) error {

--- a/tests/integration/pilot/cni/cni_test.go
+++ b/tests/integration/pilot/cni/cni_test.go
@@ -24,6 +24,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/components/pilot"
 	"istio.io/istio/pkg/test/framework/resource/environment"
+	kube2 "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/tests/integration/security/util/reachability"
 )
 
@@ -56,7 +57,7 @@ func TestCNIReachability(t *testing.T) {
 		Run(func(ctx framework.TestContext) {
 			kenv := ctx.Environment().(*kube.Environment)
 			cluster := kenv.KubeClusters[0]
-			_, err := cluster.WaitUntilPodsAreReady(cluster.NewSinglePodFetch("kube-system", "k8s-app=istio-cni-node"))
+			_, err := cluster.WaitUntilPodsAreReady(kube2.NewSinglePodFetch(cluster.Accessor, "kube-system", "k8s-app=istio-cni-node"))
 			if err != nil {
 				ctx.Fatal(err)
 			}

--- a/tests/integration/security/chiron/dns_cert_test.go
+++ b/tests/integration/security/chiron/dns_cert_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
@@ -116,8 +117,8 @@ func TestDNSCertificate(t *testing.T) {
 			// Test certificate regeneration: if a DNS certificate is deleted, Chiron will regenerate it.
 			ctx.NewSubTest("regenerateDNSCertificates").
 				Run(func(ctx framework.TestContext) {
-					_ = cluster.DeleteSecret(istioNs, galleySecretName)
-					_ = cluster.DeleteSecret(istioNs, sidecarInjectorSecretName)
+					_ = deleteSecret(cluster, istioNs, galleySecretName)
+					_ = deleteSecret(cluster, istioNs, sidecarInjectorSecretName)
 					// Sleep 5 seconds for the certificate regeneration to take place.
 					ctx.Log(`sleep 5 seconds for the certificate regeneration to take place ...`)
 					time.Sleep(5 * time.Second)
@@ -133,7 +134,7 @@ func TestDNSCertificate(t *testing.T) {
 			ctx.NewSubTest("rotateDNSCertificatesWhenCAUpdated").
 				Run(func(ctx framework.TestContext) {
 					galleySecret.Data[controller.RootCertID] = []byte(caCertUpdated)
-					if _, err := cluster.GetSecret(istioNs).Update(context.TODO(), galleySecret, metav1.UpdateOptions{}); err != nil {
+					if _, err := cluster.CoreV1().Secrets(istioNs).Update(context.TODO(), galleySecret, metav1.UpdateOptions{}); err != nil {
 						ctx.Fatalf("failed to update secret (%s:%s), error: %s", istioNs, galleySecret.Name, err)
 					}
 					// Sleep 5 seconds for the certificate rotation to take place.
@@ -152,7 +153,7 @@ func TestDNSCertificate(t *testing.T) {
 			ctx.NewSubTest("rotateDNSCertificatesWhenCertExpired").
 				Run(func(ctx framework.TestContext) {
 					sidecarInjectorSecret.Data[controller.CertChainID] = []byte(certExpired)
-					if _, err := cluster.GetSecret(istioNs).Update(context.TODO(), sidecarInjectorSecret, metav1.UpdateOptions{}); err != nil {
+					if _, err := cluster.CoreV1().Secrets(istioNs).Update(context.TODO(), sidecarInjectorSecret, metav1.UpdateOptions{}); err != nil {
 						ctx.Fatalf("failed to update secret (%s:%s), error: %s", istioNs, sidecarInjectorSecret.Name, err)
 					}
 					// Sleep 5 seconds for the certificate rotation to take place.
@@ -169,4 +170,10 @@ func TestDNSCertificate(t *testing.T) {
 					}
 				})
 		})
+}
+
+func deleteSecret(client kubernetes.Interface, namespace, name string) (err error) {
+	var immediate int64
+	err = client.CoreV1().Secrets(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{GracePeriodSeconds: &immediate})
+	return err
 }

--- a/tests/integration/security/mtlscert_pluginca_securenaming/mtlscert_pluginca_securenaming_test.go
+++ b/tests/integration/security/mtlscert_pluginca_securenaming/mtlscert_pluginca_securenaming_test.go
@@ -15,11 +15,14 @@
 package mtlscertplugincasecurenaming
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strings"
 	"testing"
 	"time"
+
+	kubeApiMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/test/echo/common/scheme"
@@ -225,7 +228,8 @@ func verifyCertificatesWithPluginCA(t *testing.T, dump string) {
 func checkCACert(testCtx framework.TestContext, t *testing.T, testNamespace namespace.Instance) error {
 	configMapName := "istio-ca-root-cert"
 	env := testCtx.Environment().(*kube.Environment)
-	cm, err := env.KubeClusters[0].GetConfigMap(configMapName, testNamespace.Name())
+	cm, err := env.KubeClusters[0].CoreV1().ConfigMaps(testNamespace.Name()).Get(context.TODO(), configMapName,
+		kubeApiMeta.GetOptions{})
 	if err != nil {
 		return err
 	}

--- a/tests/integration/security/util/cert/cert.go
+++ b/tests/integration/security/util/cert/cert.go
@@ -102,7 +102,7 @@ func CreateCASecret(ctx resource.Context) error {
 		},
 	}
 
-	err = kubeAccessor.CreateSecret(systemNs.Name(), secret)
+	_, err = kubeAccessor.CoreV1().Secrets(systemNs.Name()).Create(context.TODO(), secret, metav1.CreateOptions{})
 	if err != nil {
 		return err
 	}
@@ -113,7 +113,8 @@ func CreateCASecret(ctx resource.Context) error {
 	// the resources from a previous integration test are not deleted.
 	configMapName := "istio-ca-root-cert"
 	kEnv := ctx.Environment().(*kube.Environment)
-	err = kEnv.KubeClusters[0].DeleteConfigMap(configMapName, systemNs.Name())
+	err = kEnv.KubeClusters[0].CoreV1().ConfigMaps(systemNs.Name()).Delete(context.TODO(), configMapName,
+		metav1.DeleteOptions{})
 	if err == nil {
 		log.Infof("configmap %v is deleted", configMapName)
 	} else {

--- a/tests/integration/telemetry/dashboard_test.go
+++ b/tests/integration/telemetry/dashboard_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	kubeApiMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/pkg/log"
 
@@ -126,7 +127,8 @@ func TestDashboard(t *testing.T) {
 			for _, d := range dashboards {
 				d := d
 				ctx.NewSubTest(d.name).RunParallel(func(t framework.TestContext) {
-					cm, err := kenv.KubeClusters[0].GetConfigMap(d.configmap, i.Settings().TelemetryNamespace)
+					cm, err := kenv.KubeClusters[0].CoreV1().ConfigMaps(i.Settings().TelemetryNamespace).Get(
+						context.TODO(), d.configmap, kubeApiMeta.GetOptions{})
 					if err != nil {
 						t.Fatalf("Failed to find dashboard %v: %v", d.configmap, err)
 					}


### PR DESCRIPTION
Overview of the changes:

1. Making Accessor an interface. This will allow it to be embedded in other interfaces. This will be leveraged in later PRs, which will clean up other parts of the test framework.

2. Accessor now implements kubernetes.Interface, which is the main client interface.

3. Removing many Accessor methods which added little value over the kubernetes.Interface methods.

4. Use built-in k8s client methods for getting pod logs.

5. If a custom transport was specified in the rest.Config, uses insecure mode when performing the spdy upgrade (used by exec and port forwarding). Without this, the spdy upgrade is given a nil TLSConfig which results in a failure to verify the server. There may be a better work-around, but we can revisit later.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure