### PR TITLE
expose values.tracing.jaeger.storageSize

### DIFF
--- a/manifests/charts/istio-telemetry/tracing/templates/pvc.yaml
+++ b/manifests/charts/istio-telemetry/tracing/templates/pvc.yaml
@@ -14,6 +14,6 @@ spec:
     - {{ .Values.tracing.jaeger.accessMode }}
   resources:
     requests:
-      storage: 5Gi
+      storage: {{ .Values.tracing.jaeger.storageSize }}
 {{- end }}
 {{- end }}

--- a/manifests/charts/istio-telemetry/tracing/values.yaml
+++ b/manifests/charts/istio-telemetry/tracing/values.yaml
@@ -43,6 +43,7 @@ tracing:
     spanStorageType: badger
     persist: false
     storageClassName: ""
+    storageSize: 5Gi
     accessMode: ReadWriteMany
     podAnnotations: {}
 


### PR DESCRIPTION
Currently manifests/charts/istio-telemetry/tracing/templates/pvc.yaml is hard-coded to 5Gi, and some scenarios require more storage space


[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[X] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure