### PR TITLE
xds: rename tests

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/cds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/cds_test.go
@@ -26,7 +26,7 @@ func TestCDS(t *testing.T) {
 	_, tearDown := initLocalPilotTestEnv(t)
 	defer tearDown()
 
-	cdsr, cancel, err := connectADS(util.MockPilotGrpcAddr)
+	cdsr, cancel, err := connectADSv2(util.MockPilotGrpcAddr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pilot/pkg/proxy/envoy/v2/debug_test.go
+++ b/pilot/pkg/proxy/envoy/v2/debug_test.go
@@ -33,7 +33,7 @@ func TestSyncz(t *testing.T) {
 		s, tearDown := initLocalPilotTestEnv(t)
 		defer tearDown()
 
-		adsstr, cancel, err := connectADS(util.MockPilotGrpcAddr)
+		adsstr, cancel, err := connectADSv2(util.MockPilotGrpcAddr)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -59,7 +59,7 @@ func TestSyncz(t *testing.T) {
 			t.Fatal(err)
 		}
 		for i := 0; i < 3; i++ {
-			_, err := adsReceive(adsstr, 5*time.Second)
+			_, err := adsReceivev2(adsstr, 5*time.Second)
 			if err != nil {
 				t.Fatal("Recv failed", err)
 			}
@@ -67,7 +67,7 @@ func TestSyncz(t *testing.T) {
 		if err := sendRDSReq(sidecarID(app3Ip, "syncApp"), []string{"80", "8080"}, "", adsstr); err != nil {
 			t.Fatal(err)
 		}
-		rdsResponse, err := adsReceive(adsstr, 5*time.Second)
+		rdsResponse, err := adsReceivev2(adsstr, 5*time.Second)
 		if err != nil {
 			t.Fatal("Recv failed", err)
 		}
@@ -82,7 +82,7 @@ func TestSyncz(t *testing.T) {
 		s, tearDown := initLocalPilotTestEnv(t)
 		defer tearDown()
 
-		adsstr, cancel, err := connectADS(util.MockPilotGrpcAddr)
+		adsstr, cancel, err := connectADSv2(util.MockPilotGrpcAddr)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -107,7 +107,7 @@ func TestSyncz(t *testing.T) {
 			t.Fatal(err)
 		}
 		for i := 0; i < 3; i++ {
-			_, err := adsReceive(adsstr, 5*time.Second)
+			_, err := adsReceivev2(adsstr, 5*time.Second)
 			if err != nil {
 				t.Fatal("Recv failed", err)
 			}
@@ -115,7 +115,7 @@ func TestSyncz(t *testing.T) {
 		if err := sendRDSReq(sidecarID(app3Ip, "syncApp2"), []string{"80", "8080"}, "", adsstr); err != nil {
 			t.Fatal(err)
 		}
-		rdsResponse, err := adsReceive(adsstr, 5*time.Second)
+		rdsResponse, err := adsReceivev2(adsstr, 5*time.Second)
 		if err != nil {
 			t.Fatal("Recv failed", err)
 		}
@@ -217,7 +217,7 @@ func TestConfigDump(t *testing.T) {
 			s, tearDown := initLocalPilotTestEnv(t)
 			defer tearDown()
 
-			envoy, cancel, err := connectADS(util.MockPilotGrpcAddr)
+			envoy, cancel, err := connectADSv2(util.MockPilotGrpcAddr)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -233,15 +233,15 @@ func TestConfigDump(t *testing.T) {
 				t.Fatal(err)
 			}
 			// Expect CDS, LDS, then RDS
-			_, err = adsReceive(envoy, 5*time.Second)
+			_, err = adsReceivev2(envoy, 5*time.Second)
 			if err != nil {
 				t.Fatal("Recv cds failed", err)
 			}
-			_, err = adsReceive(envoy, 5*time.Second)
+			_, err = adsReceivev2(envoy, 5*time.Second)
 			if err != nil {
 				t.Fatal("Recv lds failed", err)
 			}
-			_, err = adsReceive(envoy, 5*time.Second)
+			_, err = adsReceivev2(envoy, 5*time.Second)
 			if err != nil {
 				t.Fatal("Recv rds failed", err)
 			}

--- a/pilot/pkg/proxy/envoy/v2/eds_sh_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_sh_test.go
@@ -160,7 +160,7 @@ func TestSplitHorizonEds(t *testing.T) {
 // Tests whether an EDS response from the provided network matches the expected results
 func verifySplitHorizonResponse(t *testing.T, network string, sidecarID string, expected expectedResults) {
 	t.Helper()
-	edsstr, cancel, err := connectADSV3(util.MockPilotGrpcAddr)
+	edsstr, cancel, err := connectADS(util.MockPilotGrpcAddr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -175,7 +175,7 @@ func verifySplitHorizonResponse(t *testing.T, network string, sidecarID string, 
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = adsReceiveV3(edsstr, 5*time.Second)
+	_, err = adsReceive(edsstr, 5*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -184,7 +184,7 @@ func verifySplitHorizonResponse(t *testing.T, network string, sidecarID string, 
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := adsReceiveV3(edsstr, 5*time.Second)
+	res, err := adsReceive(edsstr, 5*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pilot/pkg/proxy/envoy/v2/eds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_test.go
@@ -570,7 +570,7 @@ func multipleRequest(server *bootstrap.Server, inc bool, nclients,
 	// Bad client - will not read any response. This triggers Write to block, which should
 	// be detected
 	// This is not using adsc, which consumes the events automatically.
-	ads, cancel, err := connectADS(util.MockPilotGrpcAddr)
+	ads, cancel, err := connectADSv2(util.MockPilotGrpcAddr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pilot/pkg/proxy/envoy/v2/lds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/lds_test.go
@@ -312,7 +312,7 @@ func TestLDS(t *testing.T) {
 	defer tearDown()
 
 	t.Run("sidecar", func(t *testing.T) {
-		ldsr, cancel, err := connectADS(util.MockPilotGrpcAddr)
+		ldsr, cancel, err := connectADSv2(util.MockPilotGrpcAddr)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -338,7 +338,7 @@ func TestLDS(t *testing.T) {
 
 	// 'router' or 'gateway' type of listener
 	t.Run("gateway", func(t *testing.T) {
-		ldsr, cancel, err := connectADS(util.MockPilotGrpcAddr)
+		ldsr, cancel, err := connectADSv2(util.MockPilotGrpcAddr)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pilot/pkg/proxy/envoy/v2/rds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/rds_test.go
@@ -54,7 +54,7 @@ func TestRDS(t *testing.T) {
 
 	for idx, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rdsr, cancel, err := connectADS(util.MockPilotGrpcAddr)
+			rdsr, cancel, err := connectADSv2(util.MockPilotGrpcAddr)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
This is a precursor to moving tests over to v3. This PR just renames the base functions
connectADS -> connectADSv2 and connectADSV3 -> ConnectADS. Same for send and receive functions.

Once this is merged, will follow-up with moving tests to v3 gradually.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
