### PR TITLE
manifests: run istiocoredns as nonroot.

### DIFF
--- a/manifests/charts/istiocoredns/templates/deployment.yaml
+++ b/manifests/charts/istiocoredns/templates/deployment.yaml
@@ -27,6 +27,16 @@ spec:
 {{ toYaml .Values.istiocoredns.podAnnotations | indent 8 }}
         {{- end }}
     spec:
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        privileged: false
+        runAsGroup: 1337
+        fsGroup: 1337
+        runAsNonRoot: true
+        runAsUser: 1337
       serviceAccountName: istiocoredns-service-account
 {{- if .Values.global.priorityClassName }}
       priorityClassName: "{{ .Values.global.priorityClassName }}"


### PR DESCRIPTION
Solving in part of #24614 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
