### PR TITLE
Fix configurations for using custom CA.

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -588,7 +588,7 @@ func (s *Server) initSecureDiscoveryService(args *PilotArgs, port string) error 
 
 	cfg := &tls.Config{
 		GetCertificate: s.getIstiodCertificate,
-		ClientAuth:     tls.VerifyClientCertIfGiven,
+		ClientAuth:     tls.NoClientCert,
 		ClientCAs:      root,
 	}
 

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -592,6 +592,10 @@ func (s *Server) initSecureDiscoveryService(args *PilotArgs, port string) error 
 		ClientCAs:      root,
 	}
 
+	if features.XDSAuth {
+		cfg.ClientAuth = tls.VerifyClientCertIfGiven
+	}
+
 	tlsCreds := credentials.NewTLS(cfg)
 
 	// Default is 15012 - istio-agent relies on this as a default to distinguish what cert auth to expect.

--- a/pkg/istio-agent/sds-agent.go
+++ b/pkg/istio-agent/sds-agent.go
@@ -524,6 +524,7 @@ func applyEnvVars() {
 	workloadSdsCacheOptions.SecretTTL = secretTTLEnv
 	workloadSdsCacheOptions.SecretRotationGracePeriodRatio = secretRotationGracePeriodRatioEnv
 	workloadSdsCacheOptions.RotationInterval = secretRotationIntervalEnv
+	workloadSdsCacheOptions.TrustDomain = trustDomainEnv
 	workloadSdsCacheOptions.InitialBackoffInMilliSec = int64(initialBackoffInMilliSecEnv)
 	// Disable the secret eviction for istio agent.
 	workloadSdsCacheOptions.EvictionDuration = 0


### PR DESCRIPTION
Please provide a description for what this PR is for.
Fixing two bugs:
1. Setting TrustDomain CA configuration into istio-agent SDS cache.
2. Use the `features.XDSAuth` to control client TLS certificate authentication enablement.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ X ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
