### PR TITLE
update deprecated message type

### DIFF
--- a/operator/pkg/apis/istio/v1alpha1/validation/validation.go
+++ b/operator/pkg/apis/istio/v1alpha1/validation/validation.go
@@ -108,11 +108,10 @@ func deprecatedSettingsMessage(iop *v1alpha1.IstioOperatorSpec) string {
 		// the types, but since this is deprecated this is easier
 		v, f, _ := tpath.GetFromStructPath(iop, d.old)
 		if f {
-			switch v.(type) {
+			switch t := v.(type) {
 			// need to do conversion for bool value defined in IstioOperator component spec.
 			case *v1alpha1.BoolValueForPB:
-				value := v.(*v1alpha1.BoolValueForPB)
-				v = value.Value
+				v = t.Value
 			}
 			if v != d.def {
 				messages = append(messages, fmt.Sprintf("! %s is deprecated; use %s instead", firstCharsToLower(d.old), d.new))
@@ -132,10 +131,9 @@ func deprecatedSettingsMessage(iop *v1alpha1.IstioOperatorSpec) string {
 	for _, d := range mixerDeprecations {
 		v, f, _ := tpath.GetFromStructPath(iop, d.old)
 		if f {
-			switch v.(type) {
+			switch t := v.(type) {
 			case *v1alpha1.BoolValueForPB:
-				value := v.(*v1alpha1.BoolValueForPB)
-				v = value.Value
+				v = t.Value
 			}
 			if v != d.def {
 				useMixerSettings = true

--- a/operator/pkg/apis/istio/v1alpha1/validation/validation.go
+++ b/operator/pkg/apis/istio/v1alpha1/validation/validation.go
@@ -107,8 +107,16 @@ func deprecatedSettingsMessage(iop *v1alpha1.IstioOperatorSpec) string {
 		// Grafana is a special case where its just an interface{}. A better fix would probably be defining
 		// the types, but since this is deprecated this is easier
 		v, f, _ := tpath.GetFromStructPath(iop, d.old)
-		if f && v != d.def {
-			messages = append(messages, fmt.Sprintf("! %s is deprecated; use %s instead", firstCharsToLower(d.old), d.new))
+		if f {
+			switch v.(type) {
+			// need to do conversion for bool value defined in IstioOperator component spec.
+			case *v1alpha1.BoolValueForPB:
+				value := v.(*v1alpha1.BoolValueForPB)
+				v = value.Value
+			}
+			if v != d.def {
+				messages = append(messages, fmt.Sprintf("! %s is deprecated; use %s instead", firstCharsToLower(d.old), d.new))
+			}
 		}
 	}
 	mixerDeprecations := []deprecatedSettings{
@@ -123,9 +131,16 @@ func deprecatedSettingsMessage(iop *v1alpha1.IstioOperatorSpec) string {
 	mds := []string{}
 	for _, d := range mixerDeprecations {
 		v, f, _ := tpath.GetFromStructPath(iop, d.old)
-		if f && v != d.def {
-			useMixerSettings = true
-			mds = append(mds, d.old)
+		if f {
+			switch v.(type) {
+			case *v1alpha1.BoolValueForPB:
+				value := v.(*v1alpha1.BoolValueForPB)
+				v = value.Value
+			}
+			if v != d.def {
+				useMixerSettings = true
+				mds = append(mds, d.old)
+			}
 		}
 	}
 	const mixerDeprecatedMessage = "! %s is deprecated. Mixer is deprecated and will be removed" +

--- a/operator/pkg/apis/istio/v1alpha1/validation/validation_test.go
+++ b/operator/pkg/apis/istio/v1alpha1/validation/validation_test.go
@@ -77,6 +77,25 @@ func TestValidateConfig(t *testing.T) {
 				" Mixer is deprecated and will be removed from Istio with the 1.8 release." +
 				" Please consult our docs on the replacement.",
 		},
+		{
+			name: "default_mixer_settings",
+			value: &v1alpha12.IstioOperatorSpec{
+				Values: map[string]interface{}{
+					"telemetry": map[string]interface{}{
+						"v1": map[string]interface{}{"enabled": false},
+					},
+				},
+				Components: &v1alpha12.IstioComponentSetSpec{
+					Telemetry: &v1alpha12.ComponentSpec{
+						Enabled: &v1alpha12.BoolValueForPB{BoolValue: types.BoolValue{Value: false}},
+					},
+					Policy: &v1alpha12.ComponentSpec{
+						Enabled: &v1alpha12.BoolValueForPB{BoolValue: types.BoolValue{Value: false}},
+					},
+				},
+			},
+			warnings: "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
need to do conversion for bool value defined in IstioOperator component spec, for those defined in values or addonComponent spec it is not needed
