### PR TITLE
Make ratelimiting test less flaky

### DIFF
--- a/tests/integration/mixer/policy/ratelimiting_test.go
+++ b/tests/integration/mixer/policy/ratelimiting_test.go
@@ -21,6 +21,7 @@ import (
 	"path"
 	"strings"
 	"testing"
+	"time"
 
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework"
@@ -34,7 +35,6 @@ import (
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/util/retry"
 	util "istio.io/istio/tests/integration/mixer"
-	"time"
 )
 
 var (

--- a/tests/integration/mixer/policy/ratelimiting_test.go
+++ b/tests/integration/mixer/policy/ratelimiting_test.go
@@ -106,10 +106,9 @@ func testRedisQuota(t *testing.T, config bookinfo.ConfigFile, destinationService
 				totalReqs, res.ActualQPS, succReqs, succReqs/actualDuration, badReqs, res.RetCodes)
 
 			// We expect to receive 250 429's as the rate limit is set to allow 50 requests in 30s.
-			// Thus, to make test less flaky, we just wait to validate that we receive atlease 250
-			// requests reported from prometheus.
+			// Waiting to receive 50 requests.
 			got429s, _ := util.FetchRequestCount(t, prom, destinationService, "", bookInfoNameSpaceStr,
-				250)
+				50)
 			if got429s == 0 {
 				attributes := []string{fmt.Sprintf("%s=\"%s\"", util.GetDestinationLabel(),
 					util.Fqdn(destinationService, bookInfoNameSpaceStr)),

--- a/tests/integration/mixer/policy/ratelimiting_test.go
+++ b/tests/integration/mixer/policy/ratelimiting_test.go
@@ -105,11 +105,11 @@ func testRedisQuota(t *testing.T, config bookinfo.ConfigFile, destinationService
 			t.Logf("Fortio Summary: %d reqs (%f rps, %f 200s (%f rps), %d 400s - %+v)",
 				totalReqs, res.ActualQPS, succReqs, succReqs/actualDuration, badReqs, res.RetCodes)
 
-			// We expect to receive 50 429's as the rate limit is set to allow 50 requests in 30s.
-			// Thus, to make test less flaky, we just wait to validate that we receive atlease 50
+			// We expect to receive 250 429's as the rate limit is set to allow 50 requests in 30s.
+			// Thus, to make test less flaky, we just wait to validate that we receive atlease 250
 			// requests reported from prometheus.
 			got429s, _ := util.FetchRequestCount(t, prom, destinationService, "", bookInfoNameSpaceStr,
-				50)
+				250)
 			if got429s == 0 {
 				attributes := []string{fmt.Sprintf("%s=\"%s\"", util.GetDestinationLabel(),
 					util.Fqdn(destinationService, bookInfoNameSpaceStr)),
@@ -121,7 +121,6 @@ func testRedisQuota(t *testing.T, config bookinfo.ConfigFile, destinationService
 			}
 			return nil
 		}, retry.Delay(3*time.Second), retry.Timeout(80*time.Second))
-
 	})
 }
 

--- a/tests/integration/mixer/policy/ratelimiting_test.go
+++ b/tests/integration/mixer/policy/ratelimiting_test.go
@@ -102,8 +102,11 @@ func testRedisQuota(t *testing.T, config bookinfo.ConfigFile, destinationService
 		t.Logf("Fortio Summary: %d reqs (%f rps, %f 200s (%f rps), %d 400s - %+v)",
 			totalReqs, res.ActualQPS, succReqs, succReqs/actualDuration, badReqs, res.RetCodes)
 
+		// We expect to receive 50 429's as the rate limit is set to allow 50 requests in 30s.
+		// Thus, to make test less flaky, we just wait to validate that we receive atlease 50
+		// requests reported from prometheus.
 		got429s, _ := util.FetchRequestCount(t, prom, destinationService, "", bookInfoNameSpaceStr,
-			0)
+			50)
 		if got429s == 0 {
 			attributes := []string{fmt.Sprintf("%s=\"%s\"", util.GetDestinationLabel(),
 				util.Fqdn(destinationService, bookInfoNameSpaceStr)),

--- a/tests/integration/mixer/policy/ratelimiting_test.go
+++ b/tests/integration/mixer/policy/ratelimiting_test.go
@@ -32,7 +32,9 @@ import (
 	"istio.io/istio/pkg/test/framework/components/redis"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/util/retry"
 	util "istio.io/istio/tests/integration/mixer"
+	"time"
 )
 
 var (
@@ -92,30 +94,33 @@ func testRedisQuota(t *testing.T, config bookinfo.ConfigFile, destinationService
 		defer deleteConfigOrFail(t, config, ctx)
 		util.AllowRuleSync(t)
 
-		res := util.SendTraffic(ing, t, "Sending traffic...", "", "", 300)
-		totalReqs := res.DurationHistogram.Count
-		succReqs := float64(res.RetCodes[http.StatusOK])
-		badReqs := res.RetCodes[http.StatusBadRequest]
-		actualDuration := res.ActualDuration.Seconds() // can be a bit more than requested
+		retry.UntilSuccessOrFail(t, func() error {
+			res := util.SendTraffic(ing, t, "Sending traffic...", "", "", 300)
+			totalReqs := res.DurationHistogram.Count
+			succReqs := float64(res.RetCodes[http.StatusOK])
+			badReqs := res.RetCodes[http.StatusBadRequest]
+			actualDuration := res.ActualDuration.Seconds() // can be a bit more than requested
 
-		t.Log("Successfully sent request(s) to /productpage; checking metrics...")
-		t.Logf("Fortio Summary: %d reqs (%f rps, %f 200s (%f rps), %d 400s - %+v)",
-			totalReqs, res.ActualQPS, succReqs, succReqs/actualDuration, badReqs, res.RetCodes)
+			t.Log("Successfully sent request(s) to /productpage; checking metrics...")
+			t.Logf("Fortio Summary: %d reqs (%f rps, %f 200s (%f rps), %d 400s - %+v)",
+				totalReqs, res.ActualQPS, succReqs, succReqs/actualDuration, badReqs, res.RetCodes)
 
-		// We expect to receive 50 429's as the rate limit is set to allow 50 requests in 30s.
-		// Thus, to make test less flaky, we just wait to validate that we receive atlease 50
-		// requests reported from prometheus.
-		got429s, _ := util.FetchRequestCount(t, prom, destinationService, "", bookInfoNameSpaceStr,
-			50)
-		if got429s == 0 {
-			attributes := []string{fmt.Sprintf("%s=\"%s\"", util.GetDestinationLabel(),
-				util.Fqdn(destinationService, bookInfoNameSpaceStr)),
-				fmt.Sprintf("%s=\"%d\"", util.GetResponseCodeLabel(), 429),
-				fmt.Sprintf("%s=\"%s\"", util.GetReporterCodeLabel(), "destination")}
-			t.Logf("prometheus values for istio_requests_total for 429's:\n%s",
-				util.PromDumpWithAttributes(prom, "istio_requests_total", attributes))
-			t.Errorf("Could not find 429s")
-		}
+			// We expect to receive 50 429's as the rate limit is set to allow 50 requests in 30s.
+			// Thus, to make test less flaky, we just wait to validate that we receive atlease 50
+			// requests reported from prometheus.
+			got429s, _ := util.FetchRequestCount(t, prom, destinationService, "", bookInfoNameSpaceStr,
+				50)
+			if got429s == 0 {
+				attributes := []string{fmt.Sprintf("%s=\"%s\"", util.GetDestinationLabel(),
+					util.Fqdn(destinationService, bookInfoNameSpaceStr)),
+					fmt.Sprintf("%s=\"%d\"", util.GetResponseCodeLabel(), 429),
+					fmt.Sprintf("%s=\"%s\"", util.GetReporterCodeLabel(), "destination")}
+				t.Logf("prometheus values for istio_requests_total for 429's:\n%s",
+					util.PromDumpWithAttributes(prom, "istio_requests_total", attributes))
+				return fmt.Errorf("Could not find 429s")
+			}
+			return nil
+		}, retry.Delay(3*time.Second), retry.Timeout(80*time.Second))
 
 	})
 }

--- a/tests/integration/mixer/policy/ratelimiting_test.go
+++ b/tests/integration/mixer/policy/ratelimiting_test.go
@@ -93,9 +93,6 @@ func testRedisQuota(t *testing.T, config bookinfo.ConfigFile, destinationService
 		util.AllowRuleSync(t)
 
 		res := util.SendTraffic(ing, t, "Sending traffic...", "", "", 300)
-		_, _ = util.FetchRequestCount(t, prom, destinationService, "",
-			bookInfoNameSpaceStr, 300)
-
 		totalReqs := res.DurationHistogram.Count
 		succReqs := float64(res.RetCodes[http.StatusOK])
 		badReqs := res.RetCodes[http.StatusBadRequest]
@@ -106,7 +103,7 @@ func testRedisQuota(t *testing.T, config bookinfo.ConfigFile, destinationService
 			totalReqs, res.ActualQPS, succReqs, succReqs/actualDuration, badReqs, res.RetCodes)
 
 		got429s, _ := util.FetchRequestCount(t, prom, destinationService, "", bookInfoNameSpaceStr,
-			300)
+			0)
 		if got429s == 0 {
 			attributes := []string{fmt.Sprintf("%s=\"%s\"", util.GetDestinationLabel(),
 				util.Fqdn(destinationService, bookInfoNameSpaceStr)),


### PR DESCRIPTION
Make ratelimiting test less flaky

From the logs, test fails because prometheus only reported around 290 total requests and we wait to receive full 300 requests sent. Thus, removing this hard limit to make test less flaky.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure