### PR TITLE
xds: move cds and lds tests to v3

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/cds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/cds_test.go
@@ -14,11 +14,9 @@
 package v2_test
 
 import (
-	"io/ioutil"
 	"testing"
 
-	"istio.io/istio/pkg/test/env"
-	"istio.io/istio/pkg/util/gogoprotomarshal"
+	v3 "istio.io/istio/pilot/pkg/proxy/envoy/v3"
 	"istio.io/istio/tests/util"
 )
 
@@ -42,16 +40,10 @@ func TestCDS(t *testing.T) {
 		return
 	}
 
-	strResponse, _ := gogoprotomarshal.ToJSONWithIndent(res, " ")
-	_ = ioutil.WriteFile(env.IstioOut+"/cdsv2_sidecar.json", []byte(strResponse), 0644)
-
-	t.Log("CDS response", strResponse)
 	if len(res.Resources) == 0 {
 		t.Fatal("No response")
 	}
-
-	// TODO: dump the response resources, compare with some golden once it's stable
-	// check that each mocked service and destination rule has a corresponding resource
-
-	// TODO: dynamic checks ( see EDS )
+	if res.Resources[0].GetTypeUrl() != v3.ClusterType {
+		t.Fatalf("Unexpected type url. want: %v, got: %v", v3.ClusterType, res.Resources[0].GetTypeUrl())
+	}
 }

--- a/pilot/pkg/proxy/envoy/v2/init_test.go
+++ b/pilot/pkg/proxy/envoy/v2/init_test.go
@@ -230,14 +230,14 @@ func sendLDSReqv2(node string, client AdsClientv2) error {
 	return sendXdsv2(node, client, v2.ListenerType, "")
 }
 
-func sendLDSReqWithLabels(node string, ldsclient AdsClientv2, labels map[string]string) error {
-	err := ldsclient.Send(&xdsapi.DiscoveryRequest{
+func sendLDSReqWithLabels(node string, ldsclient AdsClient, labels map[string]string) error {
+	err := ldsclient.Send(&discovery.DiscoveryRequest{
 		ResponseNonce: time.Now().String(),
-		Node: &corev2.Node{
+		Node: &corev3.Node{
 			Id:       node,
 			Metadata: model.NodeMetadata{Labels: labels}.ToStruct(),
 		},
-		TypeUrl: v2.ListenerType})
+		TypeUrl: v3.ListenerType})
 	if err != nil {
 		return fmt.Errorf("LDS request failed: %s", err)
 	}


### PR DESCRIPTION
Moves CDS and LDS tests to v3

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
