### PR TITLE
GCP instance labels support

### DIFF
--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -530,11 +530,11 @@ func getNodeMetaData(envs []string, plat platform.Environment, nodeIPs []string,
 
 // Extracts instance labels for the platform into model.NodeMetadata.Labels
 // only if not running on Kubernetes
-func extractInstanceLabels(plat platform.Environment, meta *model.NodeMetadata) {
-	if plat == nil || meta == nil || plat.IsKubernetes(meta) {
+func extractInstanceLabels(plat platform.Environment, meta *model.BootstrapNodeMetadata) {
+	if plat == nil || meta == nil || plat.IsKubernetes() {
 		return
 	}
-	instanceLabels := plat.Labels(meta)
+	instanceLabels := plat.Labels()
 	if meta.Labels == nil {
 		meta.Labels = map[string]string{}
 	}

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -535,11 +535,10 @@ func extractInstanceLabels(plat platform.Environment, meta *model.NodeMetadata) 
 	}
 	instanceLabels := plat.Labels(meta.PlatformMetadata)
 	if meta.Labels == nil {
-		meta.Labels = instanceLabels
-	} else {
-		for k, v := range instanceLabels {
-			meta.Labels[k] = v
-		}
+		meta.Labels = map[string]string{}
+	}
+	for k, v := range instanceLabels {
+		meta.Labels[k] = v
 	}
 }
 

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -533,7 +533,7 @@ func extractInstanceLabels(plat platform.Environment, meta *model.NodeMetadata) 
 	if plat == nil || meta == nil {
 		return
 	}
-	instanceLabels := plat.Labels()
+	instanceLabels := plat.Labels(meta.PlatformMetadata)
 	if meta.Labels == nil {
 		meta.Labels = instanceLabels
 	} else {

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -529,11 +529,12 @@ func getNodeMetaData(envs []string, plat platform.Environment, nodeIPs []string,
 }
 
 // Extracts instance labels for the platform into model.NodeMetadata.Labels
+// only if not running on Kubernetes
 func extractInstanceLabels(plat platform.Environment, meta *model.NodeMetadata) {
-	if plat == nil || meta == nil {
+	if plat == nil || meta == nil || plat.IsKubernetes(meta) {
 		return
 	}
-	instanceLabels := plat.Labels(meta.PlatformMetadata)
+	instanceLabels := plat.Labels(meta)
 	if meta.Labels == nil {
 		meta.Labels = map[string]string{}
 	}

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -508,6 +508,9 @@ func getNodeMetaData(envs []string, plat platform.Environment, nodeIPs []string,
 
 	meta.ProxyConfig = (*model.NodeMetaProxyConfig)(pc)
 
+	// Add all instance labels with lower precedence than pod labels
+	extractInstanceLabels(plat, meta)
+
 	// Add all pod labels found from filesystem
 	// These are typically volume mounted by the downward API
 	lbls, err := readPodLabels()
@@ -523,6 +526,21 @@ func getNodeMetaData(envs []string, plat platform.Environment, nodeIPs []string,
 	}
 
 	return meta, untypedMeta, nil
+}
+
+// Extracts instance labels for the platform into model.NodeMetadata.Labels
+func extractInstanceLabels(plat platform.Environment, meta *model.NodeMetadata) {
+	if plat == nil || meta == nil {
+		return
+	}
+	instanceLabels := plat.Labels()
+	if meta.Labels == nil {
+		meta.Labels = instanceLabels
+	} else {
+		for k, v := range instanceLabels {
+			meta.Labels[k] = v
+		}
+	}
 }
 
 func readPodLabels() (map[string]string, error) {

--- a/pkg/bootstrap/instance_test.go
+++ b/pkg/bootstrap/instance_test.go
@@ -682,6 +682,6 @@ func (f *fakePlatform) Locality() *core.Locality {
 	return &core.Locality{}
 }
 
-func (f *fakePlatform) Labels() map[string]string {
+func (f *fakePlatform) Labels(md map[string]string) map[string]string {
 	return f.labels
 }

--- a/pkg/bootstrap/instance_test.go
+++ b/pkg/bootstrap/instance_test.go
@@ -670,7 +670,8 @@ func mergeMap(to map[string]string, from map[string]string) {
 type fakePlatform struct {
 	platform.Environment
 
-	meta map[string]string
+	meta   map[string]string
+	labels map[string]string
 }
 
 func (f *fakePlatform) Metadata() map[string]string {
@@ -679,4 +680,8 @@ func (f *fakePlatform) Metadata() map[string]string {
 
 func (f *fakePlatform) Locality() *core.Locality {
 	return &core.Locality{}
+}
+
+func (f *fakePlatform) Labels() map[string]string {
+	return f.labels
 }

--- a/pkg/bootstrap/instance_test.go
+++ b/pkg/bootstrap/instance_test.go
@@ -45,6 +45,7 @@ import (
 	"istio.io/api/annotation"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 
+	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/test/util"
 	"istio.io/istio/pkg/bootstrap/platform"
 )
@@ -682,6 +683,10 @@ func (f *fakePlatform) Locality() *core.Locality {
 	return &core.Locality{}
 }
 
-func (f *fakePlatform) Labels(md map[string]string) map[string]string {
+func (f *fakePlatform) Labels(meta *model.NodeMetadata) map[string]string {
 	return f.labels
+}
+
+func (f *fakePlatform) IsKubernetes(meta *model.NodeMetadata) bool {
+	return true
 }

--- a/pkg/bootstrap/instance_test.go
+++ b/pkg/bootstrap/instance_test.go
@@ -45,7 +45,6 @@ import (
 	"istio.io/api/annotation"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 
-	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/test/util"
 	"istio.io/istio/pkg/bootstrap/platform"
 )
@@ -683,10 +682,10 @@ func (f *fakePlatform) Locality() *core.Locality {
 	return &core.Locality{}
 }
 
-func (f *fakePlatform) Labels(meta *model.NodeMetadata) map[string]string {
+func (f *fakePlatform) Labels() map[string]string {
 	return f.labels
 }
 
-func (f *fakePlatform) IsKubernetes(meta *model.NodeMetadata) bool {
+func (f *fakePlatform) IsKubernetes() bool {
 	return true
 }

--- a/pkg/bootstrap/platform/aws.go
+++ b/pkg/bootstrap/platform/aws.go
@@ -88,7 +88,7 @@ func (a *awsEnv) Locality() *core.Locality {
 	}
 }
 
-func (a *awsEnv) Labels() map[string]string {
+func (a *awsEnv) Labels(md map[string]string) map[string]string {
 	return map[string]string{}
 }
 

--- a/pkg/bootstrap/platform/aws.go
+++ b/pkg/bootstrap/platform/aws.go
@@ -22,8 +22,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-
-	"istio.io/istio/pilot/pkg/model"
 )
 
 const (
@@ -90,11 +88,11 @@ func (a *awsEnv) Locality() *core.Locality {
 	}
 }
 
-func (a *awsEnv) Labels(meta *model.NodeMetadata) map[string]string {
+func (a *awsEnv) Labels() map[string]string {
 	return map[string]string{}
 }
 
-func (a *awsEnv) IsKubernetes(meta *model.NodeMetadata) bool {
+func (a *awsEnv) IsKubernetes() bool {
 	return true
 }
 

--- a/pkg/bootstrap/platform/aws.go
+++ b/pkg/bootstrap/platform/aws.go
@@ -22,6 +22,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+
+	"istio.io/istio/pilot/pkg/model"
 )
 
 const (
@@ -88,8 +90,12 @@ func (a *awsEnv) Locality() *core.Locality {
 	}
 }
 
-func (a *awsEnv) Labels(md map[string]string) map[string]string {
+func (a *awsEnv) Labels(meta *model.NodeMetadata) map[string]string {
 	return map[string]string{}
+}
+
+func (a *awsEnv) IsKubernetes(meta *model.NodeMetadata) bool {
+	return true
 }
 
 func getEC2MetadataClient() *ec2metadata.EC2Metadata {

--- a/pkg/bootstrap/platform/aws.go
+++ b/pkg/bootstrap/platform/aws.go
@@ -88,6 +88,10 @@ func (a *awsEnv) Locality() *core.Locality {
 	}
 }
 
+func (a *awsEnv) Labels() map[string]string {
+	return map[string]string{}
+}
+
 func getEC2MetadataClient() *ec2metadata.EC2Metadata {
 	sess, err := session.NewSession(&aws.Config{
 		// eliminate retries to prevent 20s wait for Available() on non-aws platforms.

--- a/pkg/bootstrap/platform/azure.go
+++ b/pkg/bootstrap/platform/azure.go
@@ -157,6 +157,14 @@ func (e *azureEnv) Locality() *core.Locality {
 	return &l
 }
 
+func (e *azureEnv) Labels() map[string]string {
+	return map[string]string{}
+}
+
+func (e *azureEnv) IsKubernetes() bool {
+	return true
+}
+
 func (e *azureEnv) azureMetadata() string {
 	return azureMetadataFn(e.APIVersion)
 }

--- a/pkg/bootstrap/platform/gcp.go
+++ b/pkg/bootstrap/platform/gcp.go
@@ -33,15 +33,14 @@ import (
 )
 
 const (
-	GCPProject            = "gcp_project"
-	GCPProjectNumber      = "gcp_project_number"
-	GCPCluster            = "gcp_gke_cluster_name"
-	GCPLocation           = "gcp_location"
-	GCEInstance           = "gcp_gce_instance"
-	GCEInstanceID         = "gcp_gce_instance_id"
-	GCEInstanceTemplate   = "gcp_gce_instance_template"
-	GCEInstanceCreatedBy  = "gcp_gce_instance_created_by"
-	KubernetesServiceHost = "KUBERNETES_SERVICE_HOST"
+	GCPProject           = "gcp_project"
+	GCPProjectNumber     = "gcp_project_number"
+	GCPCluster           = "gcp_gke_cluster_name"
+	GCPLocation          = "gcp_location"
+	GCEInstance          = "gcp_gce_instance"
+	GCEInstanceID        = "gcp_gce_instance_id"
+	GCEInstanceTemplate  = "gcp_gce_instance_template"
+	GCEInstanceCreatedBy = "gcp_gce_instance_created_by"
 )
 
 var (
@@ -119,12 +118,12 @@ func (e *gcpEnv) Metadata() map[string]string {
 	if gcpMetadataVar.Get() == "" && !shouldFillMetadata() {
 		return md
 	}
+
+	e.Lock()
+	defer e.Unlock()
 	if e.metadata != nil {
 		return e.metadata
 	}
-	e.Lock()
-	defer e.Unlock()
-
 	envPid, envNPid, envCN, envLoc := parseGCPMetadata()
 	if envPid != "" {
 		md[GCPProject] = envPid
@@ -231,7 +230,7 @@ func (e *gcpEnv) Labels() map[string]string {
 	var instanceLabels map[string]string
 	go func() {
 		// use explicit credentials with compute.instances.get IAM permissions
-		creds, err := google.FindDefaultCredentials(ctx, compute.CloudPlatformScope)
+		creds, err := google.FindDefaultCredentials(ctx, compute.ComputeReadonlyScope)
 		if err != nil {
 			log.Warnf("failed to find default credentials: %v", err)
 			success <- false

--- a/pkg/bootstrap/platform/gcp.go
+++ b/pkg/bootstrap/platform/gcp.go
@@ -48,64 +48,56 @@ var (
 )
 
 var (
-	clusterNameFn = func(e *gcpEnv) (string, error) {
-		f := func() (string, error) { return metadata.InstanceAttributeValue("cluster-name") }
-		return getCacheMetadata(&e.clusterName, f)
-	}
-	clusterLocationFn = func(e *gcpEnv) (string, error) {
-		f := func() (string, error) { return metadata.InstanceAttributeValue("cluster-location") }
-		if location, err := getCacheMetadata(&e.location, f); err == nil {
-			return location, nil
+	clusterNameFn = func() (string, error) {
+		cn, err := metadata.InstanceAttributeValue("cluster-name")
+		if err != nil {
+			return "", err
 		}
-		return getCacheMetadata(&e.location, metadata.Zone)
+		return cn, nil
 	}
-	instanceNameFn = func(e *gcpEnv) (string, error) {
-		return getCacheMetadata(&e.instanceName, metadata.InstanceName)
+	clusterLocationFn = func() (string, error) {
+		cl, err := metadata.InstanceAttributeValue("cluster-location")
+		if err == nil {
+			return cl, nil
+		}
+		return metadata.Zone()
 	}
-	instanceTemplateFn = func(e *gcpEnv) (string, error) {
-		f := func() (string, error) { return metadata.InstanceAttributeValue("instance-template") }
-		return getCacheMetadata(&e.instanceTemplate, f)
+	instanceNameFn = func() (string, error) {
+		in, err := metadata.InstanceName()
+		if err != nil {
+			return "", err
+		}
+		return in, nil
 	}
-	createdByFn = func(e *gcpEnv) (string, error) {
-		f := func() (string, error) { return metadata.InstanceAttributeValue("created-by") }
-		return getCacheMetadata(&e.instanceTemplate, f)
+	instanceTemplateFn = func() (string, error) {
+		it, err := metadata.InstanceAttributeValue("instance-template")
+		if err != nil {
+			return "", err
+		}
+		return it, nil
 	}
-	shouldFillMetadata = metadata.OnGCE
-	projectIDFn        = func(e *gcpEnv) (string, error) {
-		return getCacheMetadata(&e.projectID, metadata.ProjectID)
-	}
-	numericProjectIDFn = func(e *gcpEnv) (string, error) {
-		return getCacheMetadata(&e.numericProjectID, metadata.NumericProjectID)
-	}
-	instanceIDFn = func(e *gcpEnv) (string, error) {
-		return getCacheMetadata(&e.instanceID, metadata.InstanceID)
+	createdByFn = func() (string, error) {
+		cb, err := metadata.InstanceAttributeValue("created-by")
+		if err != nil {
+			return "", err
+		}
+		return cb, nil
 	}
 )
 
 type shouldFillFn func() bool
-type metadataFn func(e *gcpEnv) (string, error)
+type metadataFn func() (string, error)
 
 type gcpEnv struct {
-	projectID        string
-	numericProjectID string
-	location         string
-	clusterName      string
-	instanceName     string
-	instanceID       string
-	instanceTemplate string
-	createdBy        string
-}
-
-// Helper for compute metadata getters. Caches and returns f() if valid.
-func getCacheMetadata(s *string, f func() (string, error)) (string, error) {
-	if *s == "" {
-		attr, err := f()
-		if err != nil {
-			return "", err
-		}
-		*s = attr
-	}
-	return *s, nil
+	shouldFillMetadata shouldFillFn
+	projectIDFn        metadataFn
+	numericProjectIDFn metadataFn
+	locationFn         metadataFn
+	clusterNameFn      metadataFn
+	instanceNameFn     metadataFn
+	instanceIDFn       metadataFn
+	instanceTemplateFn metadataFn
+	createdByFn        metadataFn
 }
 
 // IsGCP returns whether or not the platform for bootstrapping is Google Cloud Platform.
@@ -121,7 +113,17 @@ func IsGCP() bool {
 // Metadata returned by the GCP Environment is taken from the GCE metadata
 // service.
 func NewGCP() Environment {
-	return &gcpEnv{}
+	return &gcpEnv{
+		shouldFillMetadata: metadata.OnGCE,
+		projectIDFn:        metadata.ProjectID,
+		numericProjectIDFn: metadata.NumericProjectID,
+		locationFn:         clusterLocationFn,
+		clusterNameFn:      clusterNameFn,
+		instanceNameFn:     instanceNameFn,
+		instanceIDFn:       metadata.InstanceID,
+		instanceTemplateFn: instanceTemplateFn,
+		createdByFn:        createdByFn,
+	}
 }
 
 // Metadata returns GCP environmental data, including project, cluster name, and
@@ -131,45 +133,40 @@ func (e *gcpEnv) Metadata() map[string]string {
 	if e == nil {
 		return md
 	}
-	if gcpMetadataVar.Get() == "" && !shouldFillMetadata() {
+	if gcpMetadataVar.Get() == "" && !e.shouldFillMetadata() {
 		return md
 	}
 	envPid, envNPid, envCN, envLoc := parseGCPMetadata()
-	// Cache environment variables into GCPEnv over metadata
 	if envPid != "" {
 		md[GCPProject] = envPid
-		e.projectID = envPid
-	} else if pid, err := projectIDFn(e); err == nil {
+	} else if pid, err := e.projectIDFn(); err == nil {
 		md[GCPProject] = pid
 	}
 	if envNPid != "" {
 		md[GCPProjectNumber] = envNPid
-		e.numericProjectID = envNPid
-	} else if npid, err := numericProjectIDFn(e); err == nil {
+	} else if npid, err := e.numericProjectIDFn(); err == nil {
 		md[GCPProjectNumber] = npid
 	}
 	if envLoc != "" {
 		md[GCPLocation] = envLoc
-		e.location = envLocation
-	} else if l, err := clusterLocationFn(e); err == nil {
+	} else if l, err := e.locationFn(); err == nil {
 		md[GCPLocation] = l
 	}
 	if envCN != "" {
 		md[GCPCluster] = envCN
-		e.clusterName = envCN
-	} else if cn, err := clusterNameFn(e); err == nil {
+	} else if cn, err := e.clusterNameFn(); err == nil {
 		md[GCPCluster] = cn
 	}
-	if in, err := instanceNameFn(e); err == nil {
+	if in, err := e.instanceNameFn(); err == nil {
 		md[GCEInstance] = in
 	}
-	if id, err := instanceIDFn(e); err == nil {
+	if id, err := e.instanceIDFn(); err == nil {
 		md[GCEInstanceID] = id
 	}
-	if it, err := instanceTemplateFn(e); err == nil {
+	if it, err := e.instanceTemplateFn(); err == nil {
 		md[GCEInstanceTemplate] = it
 	}
-	if cb, err := createdByFn(e); err == nil {
+	if cb, err := e.createdByFn(); err == nil {
 		md[GCEInstanceCreatedBy] = cb
 	}
 	return md
@@ -232,9 +229,28 @@ func (e *gcpEnv) Locality() *core.Locality {
 	return &l
 }
 
+var (
+	mdOnce   sync.Once
+	project  string
+	zone     string
+	instance string
+	cluster  string
+)
+
+// Retrieves needed metadata strictly from the Google Compute API
+func getMetadataAttributes(e *gcpEnv) {
+	mdOnce.Do(func() {
+		project, _ = e.projectIDFn()
+		zone, _ = e.locationFn()
+		instance, _ = e.instanceNameFn()
+		cluster, _ = e.clusterNameFn()
+	})
+}
+
 // Labels attempts to retrieve the GCE instance labels within the timeout
 // Requires read access to the Compute API (compute.instances.get)
 func (e *gcpEnv) Labels() map[string]string {
+	getMetadataAttributes(e)
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 
@@ -256,10 +272,7 @@ func (e *gcpEnv) Labels() map[string]string {
 			return
 		}
 		// instance.Labels is nil if no labels are present
-		projectID, _ := projectIDFn(e)
-		location, _ := clusterLocationFn(e)
-		instanceName, _ := instanceNameFn(e)
-		instanceObj, err := computeService.Instances.Get(projectID, location, instanceName).Do()
+		instanceObj, err := computeService.Instances.Get(project, zone, instance).Do()
 		if err != nil {
 			log.Warnf("unable to retrieve instance: %v", err)
 			success <- false
@@ -283,7 +296,7 @@ const KubernetesServiceHost = "KUBERNETES_SERVICE_HOST"
 
 // Checks metadata to see if GKE metadata or Kubernetes env vars exist
 func (e *gcpEnv) IsKubernetes() bool {
-	clusterName, _ := clusterNameFn(e)
+	getMetadataAttributes(e)
 	_, onKubernetes := os.LookupEnv(KubernetesServiceHost)
-	return clusterName != "" || onKubernetes
+	return cluster != "" || onKubernetes
 }

--- a/pkg/bootstrap/platform/gcp_test.go
+++ b/pkg/bootstrap/platform/gcp_test.go
@@ -209,7 +209,7 @@ func TestGCPMetadata(t *testing.T) {
 			for e, v := range tt.env {
 				os.Setenv(e, v)
 			}
-			once = sync.Once{}
+			envOnce = sync.Once{}
 			mg := gcpEnv{tt.shouldFill, tt.projectIDFn, tt.numericProjectIDFn, tt.locationFn, tt.clusterNameFn, tt.instanceNameFn, tt.instanceIDFn,
 				tt.instanceTemplateFn, tt.instanceCreatedByFn}
 			got := mg.Metadata()

--- a/pkg/bootstrap/platform/gcp_test.go
+++ b/pkg/bootstrap/platform/gcp_test.go
@@ -41,28 +41,28 @@ func TestGCPMetadata(t *testing.T) {
 		{
 			"should not fill",
 			func() bool { return false },
-			func(e *gcpEnv) (string, error) { return "pid", nil },
-			func(e *gcpEnv) (string, error) { return "npid", nil },
-			func(e *gcpEnv) (string, error) { return "location", nil },
-			func(e *gcpEnv) (string, error) { return "cluster", nil },
-			func(e *gcpEnv) (string, error) { return "instanceName", nil },
-			func(e *gcpEnv) (string, error) { return "instance", nil },
-			func(e *gcpEnv) (string, error) { return "instanceTemplate", nil },
-			func(e *gcpEnv) (string, error) { return "createdBy", nil },
+			func() (string, error) { return "pid", nil },
+			func() (string, error) { return "npid", nil },
+			func() (string, error) { return "location", nil },
+			func() (string, error) { return "cluster", nil },
+			func() (string, error) { return "instanceName", nil },
+			func() (string, error) { return "instance", nil },
+			func() (string, error) { return "instanceTemplate", nil },
+			func() (string, error) { return "createdBy", nil },
 			map[string]string{},
 			map[string]string{},
 		},
 		{
 			"should fill",
 			func() bool { return true },
-			func(e *gcpEnv) (string, error) { return "pid", nil },
-			func(e *gcpEnv) (string, error) { return "npid", nil },
-			func(e *gcpEnv) (string, error) { return "location", nil },
-			func(e *gcpEnv) (string, error) { return "cluster", nil },
-			func(e *gcpEnv) (string, error) { return "instanceName", nil },
-			func(e *gcpEnv) (string, error) { return "instance", nil },
-			func(e *gcpEnv) (string, error) { return "instanceTemplate", nil },
-			func(e *gcpEnv) (string, error) { return "createdBy", nil },
+			func() (string, error) { return "pid", nil },
+			func() (string, error) { return "npid", nil },
+			func() (string, error) { return "location", nil },
+			func() (string, error) { return "cluster", nil },
+			func() (string, error) { return "instanceName", nil },
+			func() (string, error) { return "instance", nil },
+			func() (string, error) { return "instanceTemplate", nil },
+			func() (string, error) { return "createdBy", nil },
 			map[string]string{},
 			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCPCluster: "cluster", GCEInstance: "instanceName",
 				GCEInstanceID: "instance", GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
@@ -70,14 +70,14 @@ func TestGCPMetadata(t *testing.T) {
 		{
 			"project id error",
 			func() bool { return true },
-			func(e *gcpEnv) (string, error) { return "", errors.New("error") },
-			func(e *gcpEnv) (string, error) { return "npid", nil },
-			func(e *gcpEnv) (string, error) { return "location", nil },
-			func(e *gcpEnv) (string, error) { return "cluster", nil },
-			func(e *gcpEnv) (string, error) { return "instanceName", nil },
-			func(e *gcpEnv) (string, error) { return "instance", nil },
-			func(e *gcpEnv) (string, error) { return "instanceTemplate", nil },
-			func(e *gcpEnv) (string, error) { return "createdBy", nil },
+			func() (string, error) { return "", errors.New("error") },
+			func() (string, error) { return "npid", nil },
+			func() (string, error) { return "location", nil },
+			func() (string, error) { return "cluster", nil },
+			func() (string, error) { return "instanceName", nil },
+			func() (string, error) { return "instance", nil },
+			func() (string, error) { return "instanceTemplate", nil },
+			func() (string, error) { return "createdBy", nil },
 			map[string]string{},
 			map[string]string{GCPLocation: "location", GCPProjectNumber: "npid", GCPCluster: "cluster", GCEInstance: "instanceName", GCEInstanceID: "instance",
 				GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
@@ -85,14 +85,14 @@ func TestGCPMetadata(t *testing.T) {
 		{
 			"numeric project id error",
 			func() bool { return true },
-			func(e *gcpEnv) (string, error) { return "pid", nil },
-			func(e *gcpEnv) (string, error) { return "", errors.New("error") },
-			func(e *gcpEnv) (string, error) { return "location", nil },
-			func(e *gcpEnv) (string, error) { return "cluster", nil },
-			func(e *gcpEnv) (string, error) { return "instanceName", nil },
-			func(e *gcpEnv) (string, error) { return "instance", nil },
-			func(e *gcpEnv) (string, error) { return "instanceTemplate", nil },
-			func(e *gcpEnv) (string, error) { return "createdBy", nil },
+			func() (string, error) { return "pid", nil },
+			func() (string, error) { return "", errors.New("error") },
+			func() (string, error) { return "location", nil },
+			func() (string, error) { return "cluster", nil },
+			func() (string, error) { return "instanceName", nil },
+			func() (string, error) { return "instance", nil },
+			func() (string, error) { return "instanceTemplate", nil },
+			func() (string, error) { return "createdBy", nil },
 			map[string]string{},
 			map[string]string{GCPLocation: "location", GCPProject: "pid", GCPCluster: "cluster", GCEInstance: "instanceName", GCEInstanceID: "instance",
 				GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
@@ -100,14 +100,14 @@ func TestGCPMetadata(t *testing.T) {
 		{
 			"location error",
 			func() bool { return true },
-			func(e *gcpEnv) (string, error) { return "pid", nil },
-			func(e *gcpEnv) (string, error) { return "npid", nil },
-			func(e *gcpEnv) (string, error) { return "location", errors.New("error") },
-			func(e *gcpEnv) (string, error) { return "cluster", nil },
-			func(e *gcpEnv) (string, error) { return "instanceName", nil },
-			func(e *gcpEnv) (string, error) { return "instance", nil },
-			func(e *gcpEnv) (string, error) { return "instanceTemplate", nil },
-			func(e *gcpEnv) (string, error) { return "createdBy", nil },
+			func() (string, error) { return "pid", nil },
+			func() (string, error) { return "npid", nil },
+			func() (string, error) { return "location", errors.New("error") },
+			func() (string, error) { return "cluster", nil },
+			func() (string, error) { return "instanceName", nil },
+			func() (string, error) { return "instance", nil },
+			func() (string, error) { return "instanceTemplate", nil },
+			func() (string, error) { return "createdBy", nil },
 			map[string]string{},
 			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPCluster: "cluster", GCEInstance: "instanceName", GCEInstanceID: "instance",
 				GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
@@ -115,14 +115,14 @@ func TestGCPMetadata(t *testing.T) {
 		{
 			"cluster name error",
 			func() bool { return true },
-			func(e *gcpEnv) (string, error) { return "pid", nil },
-			func(e *gcpEnv) (string, error) { return "npid", nil },
-			func(e *gcpEnv) (string, error) { return "location", nil },
-			func(e *gcpEnv) (string, error) { return "cluster", errors.New("error") },
-			func(e *gcpEnv) (string, error) { return "instanceName", nil },
-			func(e *gcpEnv) (string, error) { return "instance", nil },
-			func(e *gcpEnv) (string, error) { return "instanceTemplate", nil },
-			func(e *gcpEnv) (string, error) { return "createdBy", nil },
+			func() (string, error) { return "pid", nil },
+			func() (string, error) { return "npid", nil },
+			func() (string, error) { return "location", nil },
+			func() (string, error) { return "cluster", errors.New("error") },
+			func() (string, error) { return "instanceName", nil },
+			func() (string, error) { return "instance", nil },
+			func() (string, error) { return "instanceTemplate", nil },
+			func() (string, error) { return "createdBy", nil },
 			map[string]string{},
 			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCEInstance: "instanceName", GCEInstanceID: "instance",
 				GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
@@ -130,14 +130,14 @@ func TestGCPMetadata(t *testing.T) {
 		{
 			"instance name error",
 			func() bool { return true },
-			func(e *gcpEnv) (string, error) { return "pid", nil },
-			func(e *gcpEnv) (string, error) { return "npid", nil },
-			func(e *gcpEnv) (string, error) { return "location", nil },
-			func(e *gcpEnv) (string, error) { return "cluster", nil },
-			func(e *gcpEnv) (string, error) { return "instanceName", errors.New("error") },
-			func(e *gcpEnv) (string, error) { return "instance", nil },
-			func(e *gcpEnv) (string, error) { return "instanceTemplate", nil },
-			func(e *gcpEnv) (string, error) { return "createdBy", nil },
+			func() (string, error) { return "pid", nil },
+			func() (string, error) { return "npid", nil },
+			func() (string, error) { return "location", nil },
+			func() (string, error) { return "cluster", nil },
+			func() (string, error) { return "instanceName", errors.New("error") },
+			func() (string, error) { return "instance", nil },
+			func() (string, error) { return "instanceTemplate", nil },
+			func() (string, error) { return "createdBy", nil },
 			map[string]string{},
 			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCPCluster: "cluster", GCEInstanceID: "instance",
 				GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
@@ -145,14 +145,14 @@ func TestGCPMetadata(t *testing.T) {
 		{
 			"instance id error",
 			func() bool { return true },
-			func(e *gcpEnv) (string, error) { return "pid", nil },
-			func(e *gcpEnv) (string, error) { return "npid", nil },
-			func(e *gcpEnv) (string, error) { return "location", nil },
-			func(e *gcpEnv) (string, error) { return "cluster", nil },
-			func(e *gcpEnv) (string, error) { return "instanceName", nil },
-			func(e *gcpEnv) (string, error) { return "", errors.New("error") },
-			func(e *gcpEnv) (string, error) { return "instanceTemplate", nil },
-			func(e *gcpEnv) (string, error) { return "createdBy", nil },
+			func() (string, error) { return "pid", nil },
+			func() (string, error) { return "npid", nil },
+			func() (string, error) { return "location", nil },
+			func() (string, error) { return "cluster", nil },
+			func() (string, error) { return "instanceName", nil },
+			func() (string, error) { return "", errors.New("error") },
+			func() (string, error) { return "instanceTemplate", nil },
+			func() (string, error) { return "createdBy", nil },
 			map[string]string{},
 			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCPCluster: "cluster", GCEInstance: "instanceName",
 				GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
@@ -160,14 +160,14 @@ func TestGCPMetadata(t *testing.T) {
 		{
 			"instance template error",
 			func() bool { return true },
-			func(e *gcpEnv) (string, error) { return "pid", nil },
-			func(e *gcpEnv) (string, error) { return "npid", nil },
-			func(e *gcpEnv) (string, error) { return "location", nil },
-			func(e *gcpEnv) (string, error) { return "cluster", nil },
-			func(e *gcpEnv) (string, error) { return "instanceName", nil },
-			func(e *gcpEnv) (string, error) { return "instance", nil },
-			func(e *gcpEnv) (string, error) { return "", errors.New("error") },
-			func(e *gcpEnv) (string, error) { return "createdBy", nil },
+			func() (string, error) { return "pid", nil },
+			func() (string, error) { return "npid", nil },
+			func() (string, error) { return "location", nil },
+			func() (string, error) { return "cluster", nil },
+			func() (string, error) { return "instanceName", nil },
+			func() (string, error) { return "instance", nil },
+			func() (string, error) { return "", errors.New("error") },
+			func() (string, error) { return "createdBy", nil },
 			map[string]string{},
 			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCPCluster: "cluster", GCEInstance: "instanceName",
 				GCEInstanceID: "instance", GCEInstanceCreatedBy: "createdBy"},
@@ -175,14 +175,14 @@ func TestGCPMetadata(t *testing.T) {
 		{
 			"instance created by error",
 			func() bool { return true },
-			func(e *gcpEnv) (string, error) { return "pid", nil },
-			func(e *gcpEnv) (string, error) { return "npid", nil },
-			func(e *gcpEnv) (string, error) { return "location", nil },
-			func(e *gcpEnv) (string, error) { return "cluster", nil },
-			func(e *gcpEnv) (string, error) { return "instanceName", nil },
-			func(e *gcpEnv) (string, error) { return "instance", nil },
-			func(e *gcpEnv) (string, error) { return "instanceTemplate", nil },
-			func(e *gcpEnv) (string, error) { return "", errors.New("error") },
+			func() (string, error) { return "pid", nil },
+			func() (string, error) { return "npid", nil },
+			func() (string, error) { return "location", nil },
+			func() (string, error) { return "cluster", nil },
+			func() (string, error) { return "instanceName", nil },
+			func() (string, error) { return "instance", nil },
+			func() (string, error) { return "instanceTemplate", nil },
+			func() (string, error) { return "", errors.New("error") },
 			map[string]string{},
 			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCPCluster: "cluster", GCEInstance: "instanceName",
 				GCEInstanceID: "instance", GCEInstanceTemplate: "instanceTemplate"},
@@ -190,14 +190,14 @@ func TestGCPMetadata(t *testing.T) {
 		{
 			"use env variable",
 			func() bool { return true },
-			func(e *gcpEnv) (string, error) { return "pid", nil },
-			func(e *gcpEnv) (string, error) { return "npid", nil },
-			func(e *gcpEnv) (string, error) { return "location", nil },
-			func(e *gcpEnv) (string, error) { return "cluster", nil },
-			func(e *gcpEnv) (string, error) { return "instanceName", nil },
-			func(e *gcpEnv) (string, error) { return "instance", nil },
-			func(e *gcpEnv) (string, error) { return "instanceTemplate", nil },
-			func(e *gcpEnv) (string, error) { return "createdBy", nil },
+			func() (string, error) { return "pid", nil },
+			func() (string, error) { return "npid", nil },
+			func() (string, error) { return "location", nil },
+			func() (string, error) { return "cluster", nil },
+			func() (string, error) { return "instanceName", nil },
+			func() (string, error) { return "instance", nil },
+			func() (string, error) { return "instanceTemplate", nil },
+			func() (string, error) { return "createdBy", nil },
 			map[string]string{"GCP_METADATA": "env_pid|env_pn|env_cluster|env_location"},
 			map[string]string{GCPProject: "env_pid", GCPProjectNumber: "env_pn", GCPLocation: "env_location", GCPCluster: "env_cluster",
 				GCEInstance: "instanceName", GCEInstanceID: "instance", GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
@@ -210,38 +210,11 @@ func TestGCPMetadata(t *testing.T) {
 				os.Setenv(e, v)
 			}
 			envOnce = sync.Once{}
-			e := gcpEnv{}
-			shouldFillMetadata, projectIDFn, numericProjectIDFn, clusterLocationFn, clusterNameFn, instanceNameFn, instanceIDFn, instanceTemplateFn, createdByFn =
-				tt.shouldFill, tt.projectIDFn, tt.numericProjectIDFn, tt.locationFn, tt.clusterNameFn, tt.instanceNameFn, tt.instanceIDFn, tt.instanceTemplateFn,
-				tt.instanceCreatedByFn
-			got := e.Metadata()
+			mg := gcpEnv{tt.shouldFill, tt.projectIDFn, tt.numericProjectIDFn, tt.locationFn, tt.clusterNameFn, tt.instanceNameFn, tt.instanceIDFn,
+				tt.instanceTemplateFn, tt.instanceCreatedByFn}
+			got := mg.Metadata()
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("gcpEnv.Metadata() => '%v'; want '%v'", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestCacheMetadata(t *testing.T) {
-	tests := []struct {
-		name string
-		fVal string
-		fErr error
-		want string
-	}{
-		{"ignore bad response", "err", errors.New("err"), ""},
-		{"properly update field", "test1", nil, "test1"},
-		{"return cached val", "ignore", nil, "test1"},
-	}
-
-	// Use same gcpEnv for sequential tests
-	e := gcpEnv{}
-	for idx, tt := range tests {
-		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
-			f := func() (string, error) { return tt.fVal, tt.fErr }
-			cb, _ := getCacheMetadata(&e.createdBy, f)
-			if cb != tt.want || e.createdBy != tt.want {
-				t.Errorf("getCacheMetadata() => returned: '%v', attribute: '%v'; want '%v'", cb, e.createdBy, tt.want)
 			}
 		})
 	}

--- a/pkg/bootstrap/platform/gcp_test.go
+++ b/pkg/bootstrap/platform/gcp_test.go
@@ -31,6 +31,7 @@ func TestGCPMetadata(t *testing.T) {
 		numericProjectIDFn  metadataFn
 		locationFn          metadataFn
 		clusterNameFn       metadataFn
+		instanceNameFn      metadataFn
 		instanceIDFn        metadataFn
 		instanceTemplateFn  metadataFn
 		instanceCreatedByFn metadataFn
@@ -44,6 +45,7 @@ func TestGCPMetadata(t *testing.T) {
 			func() (string, error) { return "npid", nil },
 			func() (string, error) { return "location", nil },
 			func() (string, error) { return "cluster", nil },
+			func() (string, error) { return "instanceName", nil },
 			func() (string, error) { return "instance", nil },
 			func() (string, error) { return "instanceTemplate", nil },
 			func() (string, error) { return "createdBy", nil },
@@ -57,12 +59,13 @@ func TestGCPMetadata(t *testing.T) {
 			func() (string, error) { return "npid", nil },
 			func() (string, error) { return "location", nil },
 			func() (string, error) { return "cluster", nil },
+			func() (string, error) { return "instanceName", nil },
 			func() (string, error) { return "instance", nil },
 			func() (string, error) { return "instanceTemplate", nil },
 			func() (string, error) { return "createdBy", nil },
 			map[string]string{},
-			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCPCluster: "cluster", GCEInstanceID: "instance",
-				GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
+			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCPCluster: "cluster", GCEInstance: "instanceName",
+				GCEInstanceID: "instance", GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
 		},
 		{
 			"project id error",
@@ -71,11 +74,12 @@ func TestGCPMetadata(t *testing.T) {
 			func() (string, error) { return "npid", nil },
 			func() (string, error) { return "location", nil },
 			func() (string, error) { return "cluster", nil },
+			func() (string, error) { return "instanceName", nil },
 			func() (string, error) { return "instance", nil },
 			func() (string, error) { return "instanceTemplate", nil },
 			func() (string, error) { return "createdBy", nil },
 			map[string]string{},
-			map[string]string{GCPLocation: "location", GCPProjectNumber: "npid", GCPCluster: "cluster", GCEInstanceID: "instance",
+			map[string]string{GCPLocation: "location", GCPProjectNumber: "npid", GCPCluster: "cluster", GCEInstance: "instanceName", GCEInstanceID: "instance",
 				GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
 		},
 		{
@@ -85,11 +89,12 @@ func TestGCPMetadata(t *testing.T) {
 			func() (string, error) { return "", errors.New("error") },
 			func() (string, error) { return "location", nil },
 			func() (string, error) { return "cluster", nil },
+			func() (string, error) { return "instanceName", nil },
 			func() (string, error) { return "instance", nil },
 			func() (string, error) { return "instanceTemplate", nil },
 			func() (string, error) { return "createdBy", nil },
 			map[string]string{},
-			map[string]string{GCPLocation: "location", GCPProject: "pid", GCPCluster: "cluster", GCEInstanceID: "instance",
+			map[string]string{GCPLocation: "location", GCPProject: "pid", GCPCluster: "cluster", GCEInstance: "instanceName", GCEInstanceID: "instance",
 				GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
 		},
 		{
@@ -99,11 +104,12 @@ func TestGCPMetadata(t *testing.T) {
 			func() (string, error) { return "npid", nil },
 			func() (string, error) { return "location", errors.New("error") },
 			func() (string, error) { return "cluster", nil },
+			func() (string, error) { return "instanceName", nil },
 			func() (string, error) { return "instance", nil },
 			func() (string, error) { return "instanceTemplate", nil },
 			func() (string, error) { return "createdBy", nil },
 			map[string]string{},
-			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPCluster: "cluster", GCEInstanceID: "instance",
+			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPCluster: "cluster", GCEInstance: "instanceName", GCEInstanceID: "instance",
 				GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
 		},
 		{
@@ -113,11 +119,27 @@ func TestGCPMetadata(t *testing.T) {
 			func() (string, error) { return "npid", nil },
 			func() (string, error) { return "location", nil },
 			func() (string, error) { return "cluster", errors.New("error") },
+			func() (string, error) { return "instanceName", nil },
 			func() (string, error) { return "instance", nil },
 			func() (string, error) { return "instanceTemplate", nil },
 			func() (string, error) { return "createdBy", nil },
 			map[string]string{},
-			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCEInstanceID: "instance",
+			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCEInstance: "instanceName", GCEInstanceID: "instance",
+				GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
+		},
+		{
+			"instance name error",
+			func() bool { return true },
+			func() (string, error) { return "pid", nil },
+			func() (string, error) { return "npid", nil },
+			func() (string, error) { return "location", nil },
+			func() (string, error) { return "cluster", nil },
+			func() (string, error) { return "instanceName", errors.New("error") },
+			func() (string, error) { return "instance", nil },
+			func() (string, error) { return "instanceTemplate", nil },
+			func() (string, error) { return "createdBy", nil },
+			map[string]string{},
+			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCPCluster: "cluster", GCEInstanceID: "instance",
 				GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
 		},
 		{
@@ -127,11 +149,12 @@ func TestGCPMetadata(t *testing.T) {
 			func() (string, error) { return "npid", nil },
 			func() (string, error) { return "location", nil },
 			func() (string, error) { return "cluster", nil },
+			func() (string, error) { return "instanceName", nil },
 			func() (string, error) { return "", errors.New("error") },
 			func() (string, error) { return "instanceTemplate", nil },
 			func() (string, error) { return "createdBy", nil },
 			map[string]string{},
-			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCPCluster: "cluster",
+			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCPCluster: "cluster", GCEInstance: "instanceName",
 				GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
 		},
 		{
@@ -141,11 +164,12 @@ func TestGCPMetadata(t *testing.T) {
 			func() (string, error) { return "npid", nil },
 			func() (string, error) { return "location", nil },
 			func() (string, error) { return "cluster", nil },
+			func() (string, error) { return "instanceName", nil },
 			func() (string, error) { return "instance", nil },
 			func() (string, error) { return "", errors.New("error") },
 			func() (string, error) { return "createdBy", nil },
 			map[string]string{},
-			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCPCluster: "cluster",
+			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCPCluster: "cluster", GCEInstance: "instanceName",
 				GCEInstanceID: "instance", GCEInstanceCreatedBy: "createdBy"},
 		},
 		{
@@ -155,11 +179,12 @@ func TestGCPMetadata(t *testing.T) {
 			func() (string, error) { return "npid", nil },
 			func() (string, error) { return "location", nil },
 			func() (string, error) { return "cluster", nil },
+			func() (string, error) { return "instanceName", nil },
 			func() (string, error) { return "instance", nil },
 			func() (string, error) { return "instanceTemplate", nil },
 			func() (string, error) { return "", errors.New("error") },
 			map[string]string{},
-			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCPCluster: "cluster",
+			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCPCluster: "cluster", GCEInstance: "instanceName",
 				GCEInstanceID: "instance", GCEInstanceTemplate: "instanceTemplate"},
 		},
 		{
@@ -169,12 +194,13 @@ func TestGCPMetadata(t *testing.T) {
 			func() (string, error) { return "npid", nil },
 			func() (string, error) { return "location", nil },
 			func() (string, error) { return "cluster", nil },
+			func() (string, error) { return "instanceName", nil },
 			func() (string, error) { return "instance", nil },
 			func() (string, error) { return "instanceTemplate", nil },
 			func() (string, error) { return "createdBy", nil },
 			map[string]string{"GCP_METADATA": "env_pid|env_pn|env_cluster|env_location"},
-			map[string]string{GCPProject: "env_pid", GCPProjectNumber: "env_pn", GCPLocation: "env_location", GCPCluster: "env_cluster", GCEInstanceID: "instance",
-				GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
+			map[string]string{GCPProject: "env_pid", GCPProjectNumber: "env_pn", GCPLocation: "env_location", GCPCluster: "env_cluster",
+				GCEInstance: "instanceName", GCEInstanceID: "instance", GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
 		},
 	}
 
@@ -184,7 +210,7 @@ func TestGCPMetadata(t *testing.T) {
 				os.Setenv(e, v)
 			}
 			once = sync.Once{}
-			mg := gcpEnv{tt.shouldFill, tt.projectIDFn, tt.numericProjectIDFn, tt.locationFn, tt.clusterNameFn, tt.instanceIDFn,
+			mg := gcpEnv{tt.shouldFill, tt.projectIDFn, tt.numericProjectIDFn, tt.locationFn, tt.clusterNameFn, tt.instanceNameFn, tt.instanceIDFn,
 				tt.instanceTemplateFn, tt.instanceCreatedByFn}
 			got := mg.Metadata()
 			if !reflect.DeepEqual(got, tt.want) {

--- a/pkg/bootstrap/platform/gcp_test.go
+++ b/pkg/bootstrap/platform/gcp_test.go
@@ -41,28 +41,28 @@ func TestGCPMetadata(t *testing.T) {
 		{
 			"should not fill",
 			func() bool { return false },
-			func() (string, error) { return "pid", nil },
-			func() (string, error) { return "npid", nil },
-			func() (string, error) { return "location", nil },
-			func() (string, error) { return "cluster", nil },
-			func() (string, error) { return "instanceName", nil },
-			func() (string, error) { return "instance", nil },
-			func() (string, error) { return "instanceTemplate", nil },
-			func() (string, error) { return "createdBy", nil },
+			func(e *gcpEnv) (string, error) { return "pid", nil },
+			func(e *gcpEnv) (string, error) { return "npid", nil },
+			func(e *gcpEnv) (string, error) { return "location", nil },
+			func(e *gcpEnv) (string, error) { return "cluster", nil },
+			func(e *gcpEnv) (string, error) { return "instanceName", nil },
+			func(e *gcpEnv) (string, error) { return "instance", nil },
+			func(e *gcpEnv) (string, error) { return "instanceTemplate", nil },
+			func(e *gcpEnv) (string, error) { return "createdBy", nil },
 			map[string]string{},
 			map[string]string{},
 		},
 		{
 			"should fill",
 			func() bool { return true },
-			func() (string, error) { return "pid", nil },
-			func() (string, error) { return "npid", nil },
-			func() (string, error) { return "location", nil },
-			func() (string, error) { return "cluster", nil },
-			func() (string, error) { return "instanceName", nil },
-			func() (string, error) { return "instance", nil },
-			func() (string, error) { return "instanceTemplate", nil },
-			func() (string, error) { return "createdBy", nil },
+			func(e *gcpEnv) (string, error) { return "pid", nil },
+			func(e *gcpEnv) (string, error) { return "npid", nil },
+			func(e *gcpEnv) (string, error) { return "location", nil },
+			func(e *gcpEnv) (string, error) { return "cluster", nil },
+			func(e *gcpEnv) (string, error) { return "instanceName", nil },
+			func(e *gcpEnv) (string, error) { return "instance", nil },
+			func(e *gcpEnv) (string, error) { return "instanceTemplate", nil },
+			func(e *gcpEnv) (string, error) { return "createdBy", nil },
 			map[string]string{},
 			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCPCluster: "cluster", GCEInstance: "instanceName",
 				GCEInstanceID: "instance", GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
@@ -70,14 +70,14 @@ func TestGCPMetadata(t *testing.T) {
 		{
 			"project id error",
 			func() bool { return true },
-			func() (string, error) { return "", errors.New("error") },
-			func() (string, error) { return "npid", nil },
-			func() (string, error) { return "location", nil },
-			func() (string, error) { return "cluster", nil },
-			func() (string, error) { return "instanceName", nil },
-			func() (string, error) { return "instance", nil },
-			func() (string, error) { return "instanceTemplate", nil },
-			func() (string, error) { return "createdBy", nil },
+			func(e *gcpEnv) (string, error) { return "", errors.New("error") },
+			func(e *gcpEnv) (string, error) { return "npid", nil },
+			func(e *gcpEnv) (string, error) { return "location", nil },
+			func(e *gcpEnv) (string, error) { return "cluster", nil },
+			func(e *gcpEnv) (string, error) { return "instanceName", nil },
+			func(e *gcpEnv) (string, error) { return "instance", nil },
+			func(e *gcpEnv) (string, error) { return "instanceTemplate", nil },
+			func(e *gcpEnv) (string, error) { return "createdBy", nil },
 			map[string]string{},
 			map[string]string{GCPLocation: "location", GCPProjectNumber: "npid", GCPCluster: "cluster", GCEInstance: "instanceName", GCEInstanceID: "instance",
 				GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
@@ -85,14 +85,14 @@ func TestGCPMetadata(t *testing.T) {
 		{
 			"numeric project id error",
 			func() bool { return true },
-			func() (string, error) { return "pid", nil },
-			func() (string, error) { return "", errors.New("error") },
-			func() (string, error) { return "location", nil },
-			func() (string, error) { return "cluster", nil },
-			func() (string, error) { return "instanceName", nil },
-			func() (string, error) { return "instance", nil },
-			func() (string, error) { return "instanceTemplate", nil },
-			func() (string, error) { return "createdBy", nil },
+			func(e *gcpEnv) (string, error) { return "pid", nil },
+			func(e *gcpEnv) (string, error) { return "", errors.New("error") },
+			func(e *gcpEnv) (string, error) { return "location", nil },
+			func(e *gcpEnv) (string, error) { return "cluster", nil },
+			func(e *gcpEnv) (string, error) { return "instanceName", nil },
+			func(e *gcpEnv) (string, error) { return "instance", nil },
+			func(e *gcpEnv) (string, error) { return "instanceTemplate", nil },
+			func(e *gcpEnv) (string, error) { return "createdBy", nil },
 			map[string]string{},
 			map[string]string{GCPLocation: "location", GCPProject: "pid", GCPCluster: "cluster", GCEInstance: "instanceName", GCEInstanceID: "instance",
 				GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
@@ -100,14 +100,14 @@ func TestGCPMetadata(t *testing.T) {
 		{
 			"location error",
 			func() bool { return true },
-			func() (string, error) { return "pid", nil },
-			func() (string, error) { return "npid", nil },
-			func() (string, error) { return "location", errors.New("error") },
-			func() (string, error) { return "cluster", nil },
-			func() (string, error) { return "instanceName", nil },
-			func() (string, error) { return "instance", nil },
-			func() (string, error) { return "instanceTemplate", nil },
-			func() (string, error) { return "createdBy", nil },
+			func(e *gcpEnv) (string, error) { return "pid", nil },
+			func(e *gcpEnv) (string, error) { return "npid", nil },
+			func(e *gcpEnv) (string, error) { return "location", errors.New("error") },
+			func(e *gcpEnv) (string, error) { return "cluster", nil },
+			func(e *gcpEnv) (string, error) { return "instanceName", nil },
+			func(e *gcpEnv) (string, error) { return "instance", nil },
+			func(e *gcpEnv) (string, error) { return "instanceTemplate", nil },
+			func(e *gcpEnv) (string, error) { return "createdBy", nil },
 			map[string]string{},
 			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPCluster: "cluster", GCEInstance: "instanceName", GCEInstanceID: "instance",
 				GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
@@ -115,14 +115,14 @@ func TestGCPMetadata(t *testing.T) {
 		{
 			"cluster name error",
 			func() bool { return true },
-			func() (string, error) { return "pid", nil },
-			func() (string, error) { return "npid", nil },
-			func() (string, error) { return "location", nil },
-			func() (string, error) { return "cluster", errors.New("error") },
-			func() (string, error) { return "instanceName", nil },
-			func() (string, error) { return "instance", nil },
-			func() (string, error) { return "instanceTemplate", nil },
-			func() (string, error) { return "createdBy", nil },
+			func(e *gcpEnv) (string, error) { return "pid", nil },
+			func(e *gcpEnv) (string, error) { return "npid", nil },
+			func(e *gcpEnv) (string, error) { return "location", nil },
+			func(e *gcpEnv) (string, error) { return "cluster", errors.New("error") },
+			func(e *gcpEnv) (string, error) { return "instanceName", nil },
+			func(e *gcpEnv) (string, error) { return "instance", nil },
+			func(e *gcpEnv) (string, error) { return "instanceTemplate", nil },
+			func(e *gcpEnv) (string, error) { return "createdBy", nil },
 			map[string]string{},
 			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCEInstance: "instanceName", GCEInstanceID: "instance",
 				GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
@@ -130,14 +130,14 @@ func TestGCPMetadata(t *testing.T) {
 		{
 			"instance name error",
 			func() bool { return true },
-			func() (string, error) { return "pid", nil },
-			func() (string, error) { return "npid", nil },
-			func() (string, error) { return "location", nil },
-			func() (string, error) { return "cluster", nil },
-			func() (string, error) { return "instanceName", errors.New("error") },
-			func() (string, error) { return "instance", nil },
-			func() (string, error) { return "instanceTemplate", nil },
-			func() (string, error) { return "createdBy", nil },
+			func(e *gcpEnv) (string, error) { return "pid", nil },
+			func(e *gcpEnv) (string, error) { return "npid", nil },
+			func(e *gcpEnv) (string, error) { return "location", nil },
+			func(e *gcpEnv) (string, error) { return "cluster", nil },
+			func(e *gcpEnv) (string, error) { return "instanceName", errors.New("error") },
+			func(e *gcpEnv) (string, error) { return "instance", nil },
+			func(e *gcpEnv) (string, error) { return "instanceTemplate", nil },
+			func(e *gcpEnv) (string, error) { return "createdBy", nil },
 			map[string]string{},
 			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCPCluster: "cluster", GCEInstanceID: "instance",
 				GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
@@ -145,14 +145,14 @@ func TestGCPMetadata(t *testing.T) {
 		{
 			"instance id error",
 			func() bool { return true },
-			func() (string, error) { return "pid", nil },
-			func() (string, error) { return "npid", nil },
-			func() (string, error) { return "location", nil },
-			func() (string, error) { return "cluster", nil },
-			func() (string, error) { return "instanceName", nil },
-			func() (string, error) { return "", errors.New("error") },
-			func() (string, error) { return "instanceTemplate", nil },
-			func() (string, error) { return "createdBy", nil },
+			func(e *gcpEnv) (string, error) { return "pid", nil },
+			func(e *gcpEnv) (string, error) { return "npid", nil },
+			func(e *gcpEnv) (string, error) { return "location", nil },
+			func(e *gcpEnv) (string, error) { return "cluster", nil },
+			func(e *gcpEnv) (string, error) { return "instanceName", nil },
+			func(e *gcpEnv) (string, error) { return "", errors.New("error") },
+			func(e *gcpEnv) (string, error) { return "instanceTemplate", nil },
+			func(e *gcpEnv) (string, error) { return "createdBy", nil },
 			map[string]string{},
 			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCPCluster: "cluster", GCEInstance: "instanceName",
 				GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
@@ -160,14 +160,14 @@ func TestGCPMetadata(t *testing.T) {
 		{
 			"instance template error",
 			func() bool { return true },
-			func() (string, error) { return "pid", nil },
-			func() (string, error) { return "npid", nil },
-			func() (string, error) { return "location", nil },
-			func() (string, error) { return "cluster", nil },
-			func() (string, error) { return "instanceName", nil },
-			func() (string, error) { return "instance", nil },
-			func() (string, error) { return "", errors.New("error") },
-			func() (string, error) { return "createdBy", nil },
+			func(e *gcpEnv) (string, error) { return "pid", nil },
+			func(e *gcpEnv) (string, error) { return "npid", nil },
+			func(e *gcpEnv) (string, error) { return "location", nil },
+			func(e *gcpEnv) (string, error) { return "cluster", nil },
+			func(e *gcpEnv) (string, error) { return "instanceName", nil },
+			func(e *gcpEnv) (string, error) { return "instance", nil },
+			func(e *gcpEnv) (string, error) { return "", errors.New("error") },
+			func(e *gcpEnv) (string, error) { return "createdBy", nil },
 			map[string]string{},
 			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCPCluster: "cluster", GCEInstance: "instanceName",
 				GCEInstanceID: "instance", GCEInstanceCreatedBy: "createdBy"},
@@ -175,14 +175,14 @@ func TestGCPMetadata(t *testing.T) {
 		{
 			"instance created by error",
 			func() bool { return true },
-			func() (string, error) { return "pid", nil },
-			func() (string, error) { return "npid", nil },
-			func() (string, error) { return "location", nil },
-			func() (string, error) { return "cluster", nil },
-			func() (string, error) { return "instanceName", nil },
-			func() (string, error) { return "instance", nil },
-			func() (string, error) { return "instanceTemplate", nil },
-			func() (string, error) { return "", errors.New("error") },
+			func(e *gcpEnv) (string, error) { return "pid", nil },
+			func(e *gcpEnv) (string, error) { return "npid", nil },
+			func(e *gcpEnv) (string, error) { return "location", nil },
+			func(e *gcpEnv) (string, error) { return "cluster", nil },
+			func(e *gcpEnv) (string, error) { return "instanceName", nil },
+			func(e *gcpEnv) (string, error) { return "instance", nil },
+			func(e *gcpEnv) (string, error) { return "instanceTemplate", nil },
+			func(e *gcpEnv) (string, error) { return "", errors.New("error") },
 			map[string]string{},
 			map[string]string{GCPProject: "pid", GCPProjectNumber: "npid", GCPLocation: "location", GCPCluster: "cluster", GCEInstance: "instanceName",
 				GCEInstanceID: "instance", GCEInstanceTemplate: "instanceTemplate"},
@@ -190,14 +190,14 @@ func TestGCPMetadata(t *testing.T) {
 		{
 			"use env variable",
 			func() bool { return true },
-			func() (string, error) { return "pid", nil },
-			func() (string, error) { return "npid", nil },
-			func() (string, error) { return "location", nil },
-			func() (string, error) { return "cluster", nil },
-			func() (string, error) { return "instanceName", nil },
-			func() (string, error) { return "instance", nil },
-			func() (string, error) { return "instanceTemplate", nil },
-			func() (string, error) { return "createdBy", nil },
+			func(e *gcpEnv) (string, error) { return "pid", nil },
+			func(e *gcpEnv) (string, error) { return "npid", nil },
+			func(e *gcpEnv) (string, error) { return "location", nil },
+			func(e *gcpEnv) (string, error) { return "cluster", nil },
+			func(e *gcpEnv) (string, error) { return "instanceName", nil },
+			func(e *gcpEnv) (string, error) { return "instance", nil },
+			func(e *gcpEnv) (string, error) { return "instanceTemplate", nil },
+			func(e *gcpEnv) (string, error) { return "createdBy", nil },
 			map[string]string{"GCP_METADATA": "env_pid|env_pn|env_cluster|env_location"},
 			map[string]string{GCPProject: "env_pid", GCPProjectNumber: "env_pn", GCPLocation: "env_location", GCPCluster: "env_cluster",
 				GCEInstance: "instanceName", GCEInstanceID: "instance", GCEInstanceTemplate: "instanceTemplate", GCEInstanceCreatedBy: "createdBy"},
@@ -210,11 +210,38 @@ func TestGCPMetadata(t *testing.T) {
 				os.Setenv(e, v)
 			}
 			envOnce = sync.Once{}
-			mg := gcpEnv{tt.shouldFill, tt.projectIDFn, tt.numericProjectIDFn, tt.locationFn, tt.clusterNameFn, tt.instanceNameFn, tt.instanceIDFn,
-				tt.instanceTemplateFn, tt.instanceCreatedByFn}
-			got := mg.Metadata()
+			e := gcpEnv{}
+			shouldFillMetadata, projectIDFn, numericProjectIDFn, clusterLocationFn, clusterNameFn, instanceNameFn, instanceIDFn, instanceTemplateFn, createdByFn =
+				tt.shouldFill, tt.projectIDFn, tt.numericProjectIDFn, tt.locationFn, tt.clusterNameFn, tt.instanceNameFn, tt.instanceIDFn, tt.instanceTemplateFn,
+				tt.instanceCreatedByFn
+			got := e.Metadata()
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("gcpEnv.Metadata() => '%v'; want '%v'", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCacheMetadata(t *testing.T) {
+	tests := []struct {
+		name string
+		fVal string
+		fErr error
+		want string
+	}{
+		{"ignore bad response", "err", errors.New("err"), ""},
+		{"properly update field", "test1", nil, "test1"},
+		{"return cached val", "ignore", nil, "test1"},
+	}
+
+	// Use same gcpEnv for sequential tests
+	e := gcpEnv{}
+	for idx, tt := range tests {
+		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
+			f := func() (string, error) { return tt.fVal, tt.fErr }
+			cb, _ := getCacheMetadata(&e.createdBy, f)
+			if cb != tt.want || e.createdBy != tt.want {
+				t.Errorf("getCacheMetadata() => returned: '%v', attribute: '%v'; want '%v'", cb, e.createdBy, tt.want)
 			}
 		})
 	}

--- a/pkg/bootstrap/platform/gcp_test.go
+++ b/pkg/bootstrap/platform/gcp_test.go
@@ -217,7 +217,9 @@ func TestGCPMetadata(t *testing.T) {
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("gcpEnv.Metadata() => '%v'; want '%v'", got, tt.want)
 			}
-			os.Clearenv()
+			for e := range tt.env {
+				os.Unsetenv(e)
+			}
 			envOnce, envPid, envNpid, envCluster, envLocation = sync.Once{}, "", "", "", ""
 		})
 	}
@@ -278,7 +280,6 @@ func TestMetadataCache(t *testing.T) {
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("gcpEnv.Metadata() => '%v'; want '%v'", got, tt.want)
 			}
-			os.Clearenv()
 			envOnce, envPid, envNpid, envCluster, envLocation = sync.Once{}, "", "", "", ""
 		})
 	}

--- a/pkg/bootstrap/platform/platform.go
+++ b/pkg/bootstrap/platform/platform.go
@@ -30,6 +30,10 @@ type Environment interface {
 	// Locality returns the run location for the bootstrap transformed from the
 	// platform-specific representation into the Envoy Locality schema.
 	Locality() *core.Locality
+
+	// Labels returns a collection of labels that exist on the underlying
+	// instance, structured as a map for label name to values.
+	Labels() map[string]string
 }
 
 // Unknown provides a default platform environment for cases in which the platform
@@ -44,4 +48,9 @@ func (*Unknown) Metadata() map[string]string {
 // Locality returns an empty core.Locality struct.
 func (*Unknown) Locality() *core.Locality {
 	return &core.Locality{}
+}
+
+// Labels returns an empty map.
+func (*Unknown) Labels() map[string]string {
+	return map[string]string{}
 }

--- a/pkg/bootstrap/platform/platform.go
+++ b/pkg/bootstrap/platform/platform.go
@@ -33,7 +33,7 @@ type Environment interface {
 
 	// Labels returns a collection of labels that exist on the underlying
 	// instance, structured as a map for label name to values.
-	Labels() map[string]string
+	Labels(md map[string]string) map[string]string
 }
 
 // Unknown provides a default platform environment for cases in which the platform
@@ -51,6 +51,6 @@ func (*Unknown) Locality() *core.Locality {
 }
 
 // Labels returns an empty map.
-func (*Unknown) Labels() map[string]string {
+func (*Unknown) Labels(md map[string]string) map[string]string {
 	return map[string]string{}
 }

--- a/pkg/bootstrap/platform/platform.go
+++ b/pkg/bootstrap/platform/platform.go
@@ -16,6 +16,8 @@ package platform
 
 import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+
+	"istio.io/istio/pilot/pkg/model"
 )
 
 // Environment provides information for the platform on which the bootstrapping
@@ -33,7 +35,10 @@ type Environment interface {
 
 	// Labels returns a collection of labels that exist on the underlying
 	// instance, structured as a map for label name to values.
-	Labels(md map[string]string) map[string]string
+	Labels(meta *model.NodeMetadata) map[string]string
+
+	// IsKubernetes determines if running on Kubernetes
+	IsKubernetes(meta *model.NodeMetadata) bool
 }
 
 // Unknown provides a default platform environment for cases in which the platform
@@ -51,6 +56,11 @@ func (*Unknown) Locality() *core.Locality {
 }
 
 // Labels returns an empty map.
-func (*Unknown) Labels(md map[string]string) map[string]string {
+func (*Unknown) Labels(meta *model.NodeMetadata) map[string]string {
 	return map[string]string{}
+}
+
+// IsKubernetes is true to avoid label collisions
+func (*Unknown) IsKubernetes(meta *model.NodeMetadata) bool {
+	return true
 }

--- a/pkg/bootstrap/platform/platform.go
+++ b/pkg/bootstrap/platform/platform.go
@@ -16,8 +16,6 @@ package platform
 
 import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-
-	"istio.io/istio/pilot/pkg/model"
 )
 
 // Environment provides information for the platform on which the bootstrapping
@@ -35,10 +33,10 @@ type Environment interface {
 
 	// Labels returns a collection of labels that exist on the underlying
 	// instance, structured as a map for label name to values.
-	Labels(meta *model.NodeMetadata) map[string]string
+	Labels() map[string]string
 
 	// IsKubernetes determines if running on Kubernetes
-	IsKubernetes(meta *model.NodeMetadata) bool
+	IsKubernetes() bool
 }
 
 // Unknown provides a default platform environment for cases in which the platform
@@ -56,11 +54,11 @@ func (*Unknown) Locality() *core.Locality {
 }
 
 // Labels returns an empty map.
-func (*Unknown) Labels(meta *model.NodeMetadata) map[string]string {
+func (*Unknown) Labels() map[string]string {
 	return map[string]string{}
 }
 
 // IsKubernetes is true to avoid label collisions
-func (*Unknown) IsKubernetes(meta *model.NodeMetadata) bool {
+func (*Unknown) IsKubernetes() bool {
 	return true
 }

--- a/pkg/bootstrap/platform/platform.go
+++ b/pkg/bootstrap/platform/platform.go
@@ -18,6 +18,10 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 )
 
+const (
+	KubernetesServiceHost = "KUBERNETES_SERVICE_HOST"
+)
+
 // Environment provides information for the platform on which the bootstrapping
 // is taking place.
 type Environment interface {


### PR DESCRIPTION
Added Labels and IsKubernetes to the platform interface along with actual functionality for GCP.
IsKubernetes defaults to true for all platforms except GCP so that instance labels are retrieved only when not running on Kubernetes.
Verified functionality by deploying istio and checking the configdump for the properly populated (or ignored) GCP instance labels

[X] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
