### PR TITLE
Fix Test Flake - Bump Port

### DIFF
--- a/pilot/pkg/networking/apigen/apigen_test.go
+++ b/pilot/pkg/networking/apigen/apigen_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 var (
-	grpcAddr         = "127.0.0.1:14057"
+	grpcAddr         = "127.0.0.1:14056"
 	grpcUpstreamAddr = grpcAddr
 )
 
@@ -46,7 +46,7 @@ func initDS() *xds.Server {
 	sd.SetEndpoints("fortio1.fortio.svc.cluster.local", "", []*model.IstioEndpoint{
 		{
 			Address:         "127.0.0.1",
-			EndpointPort:    uint32(14057),
+			EndpointPort:    uint32(14056),
 			ServicePortName: "http-main",
 		},
 	})

--- a/pilot/pkg/networking/apigen/apigen_test.go
+++ b/pilot/pkg/networking/apigen/apigen_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 var (
-	grpcAddr         = "127.0.0.1:14056"
+	grpcAddr         = "127.0.0.1:14057"
 	grpcUpstreamAddr = grpcAddr
 )
 
@@ -46,7 +46,7 @@ func initDS() *xds.Server {
 	sd.SetEndpoints("fortio1.fortio.svc.cluster.local", "", []*model.IstioEndpoint{
 		{
 			Address:         "127.0.0.1",
-			EndpointPort:    uint32(14056),
+			EndpointPort:    uint32(14057),
 			ServicePortName: "http-main",
 		},
 	})

--- a/pilot/pkg/networking/grpcgen/grpcgen_test.go
+++ b/pilot/pkg/networking/grpcgen/grpcgen_test.go
@@ -40,10 +40,10 @@ import (
 )
 
 var (
-	grpcAddr = "127.0.0.1:14056"
+	grpcAddr = "127.0.0.1:14057"
 
 	// Address of the Istiod gRPC service, used in tests.
-	istiodSvcAddr = "istiod.istio-system.svc.cluster.local:14056"
+	istiodSvcAddr = "istiod.istio-system.svc.cluster.local:14057"
 )
 
 func TestGRPC(t *testing.T) {
@@ -55,11 +55,11 @@ func TestGRPC(t *testing.T) {
 	sd := ds.DiscoveryServer.MemRegistry
 	sd.AddHTTPService("fortio1.fortio.svc.cluster.local", "10.10.10.1", 8081)
 
-	sd.AddHTTPService("istiod.istio-system.svc.cluster.local", "10.10.10.2", 14056)
+	sd.AddHTTPService("istiod.istio-system.svc.cluster.local", "10.10.10.2", 14057)
 	sd.SetEndpoints("istiod.istio-system.svc.cluster.local", "", []*model.IstioEndpoint{
 		{
 			Address:         "127.0.0.1",
-			EndpointPort:    uint32(14056),
+			EndpointPort:    uint32(14057),
 			ServicePortName: "http-main",
 		},
 	})
@@ -82,7 +82,7 @@ func TestGRPC(t *testing.T) {
 			Addresses: []string{"1.2.3.4"},
 
 			Ports: []*networking.Port{
-				{Number: 14056, Name: "grpc-insecure", Protocol: "http"},
+				{Number: 14057, Name: "grpc-insecure", Protocol: "http"},
 			},
 
 			Endpoints: []*networking.WorkloadEntry{
@@ -136,7 +136,7 @@ func TestGRPC(t *testing.T) {
 	})
 
 	t.Run("gRPC-dial", func(t *testing.T) {
-		conn, err := grpc.Dial("xds-experimental:///istiod.istio-system.svc.cluster.local:14056", grpc.WithInsecure())
+		conn, err := grpc.Dial("xds-experimental:///istiod.istio-system.svc.cluster.local:14057", grpc.WithInsecure())
 		if err != nil {
 			t.Fatal("XDS gRPC", err)
 		}

--- a/pilot/pkg/networking/grpcgen/testdata/xds_bootstrap.json
+++ b/pilot/pkg/networking/grpcgen/testdata/xds_bootstrap.json
@@ -1,7 +1,7 @@
 {
   "xds_servers": [
     {
-    "server_uri": "localhost:14056"
+    "server_uri": "localhost:14057"
     }
   ],
   "node": {


### PR DESCRIPTION
[ X] Networking

Fixes #24681. Not sure if this is the right way to do it, my assumption is that tests `grpcgen_test.go` and `apigen_test.go` are being run on the same machine concurrently. I just bumped up the port number.

To avoid future errors like this, in our critical services, maybe we should implement some sort of interface that returns a callback to the port that is available, if the default port is not available, especially for testing. If we use it across tests, then we wouldn't have these errors anymore.