### PR TITLE
Sort pods during lookup by IP

### DIFF
--- a/mixer/adapter/kubernetesenv/cache.go
+++ b/mixer/adapter/kubernetesenv/cache.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -145,21 +144,22 @@ func (c *controllerImpl) Pod(podKey string) (*v1.Pod, bool) {
 		return nil, false
 	}
 	if len(objs) > 0 {
-		pods := []*v1.Pod{}
+		maxCreationTime := metav1.NewTime(time.Time{})
+		var latestPod *v1.Pod
 		for _, obj := range objs {
 			pod, ok := obj.(*v1.Pod)
 			if !ok {
 				return nil, false
 			}
-			pods = append(pods, pod)
+			// If Pods associated with completed Jobs exist, there can be a case
+			// where more than 1 Pod is found during lookup, and we should
+			// always pick the latest created Pod out of the lot.
+			if maxCreationTime.Before(&pod.CreationTimestamp) {
+				maxCreationTime = pod.CreationTimestamp
+				latestPod = pod
+			}
 		}
-		// If Pods associated with completed Jobs exist, there can be a case where
-		// more than 1 Pod is found during lookup, and we should always pick the
-		// latest created Pod out of the lot.
-		sort.SliceStable(pods, func(i, j int) bool {
-			return pods[j].CreationTimestamp.Before(&pods[i].CreationTimestamp)
-		})
-		return pods[0], true
+		return latestPod, true
 	}
 	item, exists, err := indexer.GetByKey(podKey)
 	if !exists || err != nil {

--- a/mixer/adapter/kubernetesenv/cache.go
+++ b/mixer/adapter/kubernetesenv/cache.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -144,11 +145,21 @@ func (c *controllerImpl) Pod(podKey string) (*v1.Pod, bool) {
 		return nil, false
 	}
 	if len(objs) > 0 {
-		pod, ok := objs[0].(*v1.Pod)
-		if !ok {
-			return nil, false
+		pods := []*v1.Pod{}
+		for _, obj := range objs {
+			pod, ok := obj.(*v1.Pod)
+			if !ok {
+				return nil, false
+			}
+			pods = append(pods, pod)
 		}
-		return pod, true
+		// If Pods associated with completed Jobs exist, there can be a case where
+		// more than 1 Pod is found during lookup, and we should always pick the
+		// latest created Pod out of the lot.
+		sort.SliceStable(pods, func(i, j int) bool {
+			return pods[j].CreationTimestamp.Before(&pods[i].CreationTimestamp)
+		})
+		return pods[0], true
 	}
 	item, exists, err := indexer.GetByKey(podKey)
 	if !exists || err != nil {

--- a/mixer/adapter/kubernetesenv/cache.go
+++ b/mixer/adapter/kubernetesenv/cache.go
@@ -144,9 +144,8 @@ func (c *controllerImpl) Pod(podKey string) (*v1.Pod, bool) {
 		return nil, false
 	}
 	if len(objs) > 0 {
-		maxCreationTime := metav1.NewTime(time.Time{})
 		var latestPod *v1.Pod
-		for _, obj := range objs {
+		for i, obj := range objs {
 			pod, ok := obj.(*v1.Pod)
 			if !ok {
 				return nil, false
@@ -154,8 +153,7 @@ func (c *controllerImpl) Pod(podKey string) (*v1.Pod, bool) {
 			// If Pods associated with completed Jobs exist, there can be a case
 			// where more than 1 Pod is found during lookup, and we should
 			// always pick the latest created Pod out of the lot.
-			if maxCreationTime.Before(&pod.CreationTimestamp) {
-				maxCreationTime = pod.CreationTimestamp
+			if i == 0 || latestPod.CreationTimestamp.Before(&pod.CreationTimestamp) {
 				latestPod = pod
 			}
 		}


### PR DESCRIPTION
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[X] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

It was observed that Mixer would incorrectly return source names when it did lookups by IP (generally for TCP traffic) and when there were more than 1 pods with the same IP (can be possible where pods exist for completed jobs along with another pod that's actually the source). The fix here is to sort the pods by `creationTimestamp` during lookup and return the latest pod.