### PR TITLE
tf cleanup: remove suite name

### DIFF
--- a/pkg/test/framework/integration/main_test.go
+++ b/pkg/test/framework/integration/main_test.go
@@ -21,5 +21,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	framework.NewSuite("framework_test", m).Run()
+	framework.NewSuite(m).Run()
 }

--- a/pkg/test/framework/suite.go
+++ b/pkg/test/framework/suite.go
@@ -111,7 +111,7 @@ func deriveSuiteName(caller string) string {
 }
 
 // NewSuite returns a new suite instance.
-func NewSuite(testID string, m *testing.M) *Suite {
+func NewSuite(m *testing.M) *Suite {
 	_, f, _, _ := goruntime.Caller(1)
 	return newSuite(deriveSuiteName(f),
 		func(_ *suiteContext) int {

--- a/tests/integration/framework/framework_test.go
+++ b/tests/integration/framework/framework_test.go
@@ -34,7 +34,7 @@ func TestMain(m *testing.M) {
 	// Start your call with framework.NewSuite, which creates a new framework.Suite instance that you can configure
 	// before starting tests.
 	framework.
-		NewSuite("framework_test", m).
+		NewSuite(m).
 
 		// Labels that apply to the whole suite can be specified here.
 		Label(label.CustomSetup).

--- a/tests/integration/galley/main_test.go
+++ b/tests/integration/galley/main_test.go
@@ -29,7 +29,7 @@ var (
 
 func TestMain(m *testing.M) {
 	framework.
-		NewSuite("galley_test", m).
+		NewSuite(m).
 		Setup(istio.Setup(nil, nil)).
 		Setup(func(ctx resource.Context) error {
 			cluster = ctx.Environment().Clusters()[0].(kube.Cluster)

--- a/tests/integration/mixer/main_test.go
+++ b/tests/integration/mixer/main_test.go
@@ -28,7 +28,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	framework.NewSuite("mixer_test", m).
+	framework.NewSuite(m).
 		Label(label.CustomSetup).
 		RequireSingleCluster().
 		Setup(istio.Setup(&ist, func(cfg *istio.Config) {

--- a/tests/integration/mixer/outboundtrafficpolicy/traffic_test.go
+++ b/tests/integration/mixer/outboundtrafficpolicy/traffic_test.go
@@ -30,7 +30,7 @@ var (
 
 func TestMain(m *testing.M) {
 	var ist istio.Instance
-	framework.NewSuite("outbound_traffic_policy_mixer", m).
+	framework.NewSuite(m).
 		RequireSingleCluster().
 		Label(label.CustomSetup).
 		Setup(istio.Setup(&ist, setupConfig)).

--- a/tests/integration/mixer/policy/ratelimiting_test.go
+++ b/tests/integration/mixer/policy/ratelimiting_test.go
@@ -149,7 +149,7 @@ func deleteConfigOrFail(t *testing.T, config string, ctx resource.Context) {
 
 func TestMain(m *testing.M) {
 	framework.
-		NewSuite("mixer_policy_ratelimit", m).
+		NewSuite(m).
 		Label(label.CustomSetup).
 		RequireSingleCluster().
 		Setup(istio.Setup(&ist, func(cfg *istio.Config) {

--- a/tests/integration/mixer/telemetry/logs/accesslog_test.go
+++ b/tests/integration/mixer/telemetry/logs/accesslog_test.go
@@ -66,7 +66,7 @@ func TestIstioAccessLog(t *testing.T) {
 
 func TestMain(m *testing.M) {
 	framework.
-		NewSuite("mixer_telemetry_logs", m).
+		NewSuite(m).
 		RequireSingleCluster().
 		Label(label.CustomSetup).
 		Setup(istio.Setup(&ist, func(cfg *istio.Config) {

--- a/tests/integration/mixer/telemetry/metrics/scenarios_test.go
+++ b/tests/integration/mixer/telemetry/metrics/scenarios_test.go
@@ -179,7 +179,7 @@ func TestTcpMetric(t *testing.T) {
 
 func TestMain(m *testing.M) {
 	framework.
-		NewSuite("mixer_telemetry_metrics", m).
+		NewSuite(m).
 		RequireSingleCluster().
 		Label(label.CustomSetup).
 		Setup(istio.Setup(&ist, func(cfg *istio.Config) {

--- a/tests/integration/multicluster/centralistio/main_test.go
+++ b/tests/integration/multicluster/centralistio/main_test.go
@@ -37,7 +37,7 @@ var (
 
 func TestMain(m *testing.M) {
 	framework.
-		NewSuite("multicluster/centralistio", m).
+		NewSuite(m).
 		Label(label.Multicluster).
 		RequireMinClusters(2).
 		Setup(multicluster.Setup(&controlPlaneValues, &clusterLocalNS, &mcReachabilityNS)).

--- a/tests/integration/multicluster/multimaster/main_test.go
+++ b/tests/integration/multicluster/multimaster/main_test.go
@@ -36,7 +36,7 @@ var (
 
 func TestMain(m *testing.M) {
 	framework.
-		NewSuite("multicluster/multimaster", m).
+		NewSuite(m).
 		Label(label.Multicluster).
 		RequireMinClusters(2).
 		Setup(multicluster.Setup(&controlPlaneValues, &clusterLocalNS, &mcReachabilityNS)).

--- a/tests/integration/multicluster/remote/main_test.go
+++ b/tests/integration/multicluster/remote/main_test.go
@@ -38,7 +38,7 @@ var (
 
 func TestMain(m *testing.M) {
 	framework.
-		NewSuite("multicluster/remote", m).
+		NewSuite(m).
 		Label(label.Multicluster).
 		RequireMinClusters(2).
 		Setup(multicluster.Setup(&controlPlaneValues, &clusterLocalNS, &mcReachabilityNS)).

--- a/tests/integration/operator/main_test.go
+++ b/tests/integration/operator/main_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestMain(m *testing.M) {
 	framework.
-		NewSuite("operator_controller", m).
+		NewSuite(m).
 		RequireSingleCluster().
 		Run()
 }

--- a/tests/integration/pilot/analysis/main_test.go
+++ b/tests/integration/pilot/analysis/main_test.go
@@ -26,7 +26,7 @@ import (
 // here to reuse a single install across tests.
 func TestMain(m *testing.M) {
 	framework.
-		NewSuite("pilot_analysis_test", m).
+		NewSuite(m).
 		RequireSingleCluster().
 		Setup(istio.Setup(nil, func(cfg *istio.Config) {
 			cfg.ControlPlaneValues = `

--- a/tests/integration/pilot/cni/cni_test.go
+++ b/tests/integration/pilot/cni/cni_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestMain(m *testing.M) {
 	framework.
-		NewSuite("cni", m).
+		NewSuite(m).
 		RequireSingleCluster().
 		Setup(istio.Setup(nil, func(cfg *istio.Config) {
 			cfg.ControlPlaneValues = `

--- a/tests/integration/pilot/ingress/ingress_test.go
+++ b/tests/integration/pilot/ingress/ingress_test.go
@@ -45,7 +45,7 @@ var (
 // here to reuse a single install across tests.
 func TestMain(m *testing.M) {
 	framework.
-		NewSuite("pilot_test", m).
+		NewSuite(m).
 		Label(label.CustomSetup).
 
 		// IngressClass is only present in 1.18+

--- a/tests/integration/pilot/locality/main_test.go
+++ b/tests/integration/pilot/locality/main_test.go
@@ -183,7 +183,7 @@ func init() {
 }
 
 func TestMain(m *testing.M) {
-	framework.NewSuite("locality_prioritized_failover_loadbalancing", m).
+	framework.NewSuite(m).
 		RequireSingleCluster().
 		Label(label.CustomSetup).
 		Setup(istio.Setup(&ist, nil)).

--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -33,7 +33,7 @@ var (
 // here to reuse a single install across tests.
 func TestMain(m *testing.M) {
 	framework.
-		NewSuite("pilot_test", m).
+		NewSuite(m).
 		RequireSingleCluster().
 		Setup(istio.Setup(&i, nil)).
 		Setup(func(ctx resource.Context) (err error) {

--- a/tests/integration/pilot/meshnetwork/main_test.go
+++ b/tests/integration/pilot/meshnetwork/main_test.go
@@ -69,7 +69,7 @@ var (
 
 func TestMain(m *testing.M) {
 	framework.
-		NewSuite("meshnetwork_test", m).
+		NewSuite(m).
 		RequireSingleCluster().
 		Label(label.CustomSetup).
 		Setup(istio.Setup(&i, setupConfig)).

--- a/tests/integration/pilot/revisions/revisions_test.go
+++ b/tests/integration/pilot/revisions/revisions_test.go
@@ -34,7 +34,7 @@ import (
 // here to reuse a single install across tests.
 func TestMain(m *testing.M) {
 	framework.
-		NewSuite("pilot_test", m).
+		NewSuite(m).
 		RequireSingleCluster().
 		Setup(istio.Setup(nil, func(cfg *istio.Config) {
 			cfg.ControlPlaneValues = `

--- a/tests/integration/pilot/vm/vm_test.go
+++ b/tests/integration/pilot/vm/vm_test.go
@@ -36,7 +36,7 @@ var ns namespace.Instance
 // with no Service, no DNS, no service account, etc to simulate a VM.
 func TestMain(m *testing.M) {
 	framework.
-		NewSuite("vm_test", m).
+		NewSuite(m).
 		RequireSingleCluster().
 		Setup(func(ctx resource.Context) error {
 			var err error

--- a/tests/integration/qualification/main_test.go
+++ b/tests/integration/qualification/main_test.go
@@ -27,7 +27,7 @@ var (
 
 func TestMain(m *testing.M) {
 	framework.
-		NewSuite("qualification", m).
+		NewSuite(m).
 		RequireSingleCluster().
 		Setup(istio.Setup(&ist, nil)).
 		Run()

--- a/tests/integration/security/cert_provision_prometheus/cert_provision_prometheus_test.go
+++ b/tests/integration/security/cert_provision_prometheus/cert_provision_prometheus_test.go
@@ -63,7 +63,7 @@ func validateCertDir(out string) error {
 
 func TestMain(m *testing.M) {
 	framework.
-		NewSuite("cert_provision_prometheus", m).
+		NewSuite(m).
 		RequireSingleCluster().
 		Label(label.CustomSetup).
 		Setup(istio.Setup(&ist, setupConfig)).

--- a/tests/integration/security/chiron/main_test.go
+++ b/tests/integration/security/chiron/main_test.go
@@ -29,7 +29,7 @@ var (
 func TestMain(m *testing.M) {
 	// Integration test for provisioning DNS certificates.
 	// TODO (lei-tang): investigate whether this test can be moved to integration/security.
-	framework.NewSuite("dns_certificate_test", m).
+	framework.NewSuite(m).
 		RequireSingleCluster().
 		Label(label.CustomSetup).
 		Setup(istio.Setup(&inst, setupConfig)).

--- a/tests/integration/security/main_test.go
+++ b/tests/integration/security/main_test.go
@@ -31,7 +31,7 @@ var (
 
 func TestMain(m *testing.M) {
 	framework.
-		NewSuite("security", m).
+		NewSuite(m).
 		RequireSingleCluster().
 		Setup(istio.Setup(&ist, setupConfig)).
 		Setup(func(ctx resource.Context) (err error) {

--- a/tests/integration/security/mtls_first_party_jwt/main_test.go
+++ b/tests/integration/security/mtls_first_party_jwt/main_test.go
@@ -31,7 +31,7 @@ var (
 
 func TestMain(m *testing.M) {
 	framework.
-		NewSuite("mtls_first_party_jwt", m).
+		NewSuite(m).
 		RequireSingleCluster().
 		Label(label.CustomSetup).
 		Setup(istio.Setup(&inst, setupConfig)).

--- a/tests/integration/security/mtlscert_pluginca_securenaming/main_test.go
+++ b/tests/integration/security/mtlscert_pluginca_securenaming/main_test.go
@@ -39,7 +39,7 @@ func TestMain(m *testing.M) {
 	//   is used for data plane to control plane TLS authentication.
 	// - Secure naming information is respected in the mTLS handshake.
 	framework.
-		NewSuite("mtlscert_pluginca_securenaming_test", m).
+		NewSuite(m).
 		// k8s is required because the plugin CA key and certificate are stored in a k8s secret.
 
 		RequireSingleCluster().

--- a/tests/integration/security/mtlsk8sca/main_test.go
+++ b/tests/integration/security/mtlsk8sca/main_test.go
@@ -31,7 +31,7 @@ var (
 
 func TestMain(m *testing.M) {
 	framework.
-		NewSuite("mtls_k8s_ca", m).
+		NewSuite(m).
 		RequireSingleCluster().
 		Label(label.CustomSetup).
 		Setup(istio.Setup(&inst, setupConfig)).

--- a/tests/integration/security/sds_egress/main_test.go
+++ b/tests/integration/security/sds_egress/main_test.go
@@ -33,7 +33,7 @@ var (
 
 func TestMain(m *testing.M) {
 	framework.
-		NewSuite("sds_egress_workload_mtls_istio_mutual_test", m).
+		NewSuite(m).
 		Skip("https://github.com/istio/istio/issues/17933").
 		Label(label.CustomSetup).
 

--- a/tests/integration/security/sds_ingress/ingress_test.go
+++ b/tests/integration/security/sds_ingress/ingress_test.go
@@ -30,7 +30,7 @@ var (
 func TestMain(m *testing.M) {
 	// Integration test for the ingress SDS Gateway flow.
 	framework.
-		NewSuite("sds_ingress", m).
+		NewSuite(m).
 		RequireSingleCluster().
 		Setup(istio.Setup(&inst, nil)).
 		Run()

--- a/tests/integration/security/sds_ingress_k8sca/main_test.go
+++ b/tests/integration/security/sds_ingress_k8sca/main_test.go
@@ -30,7 +30,7 @@ func TestMain(m *testing.M) {
 	// Integration test for the ingress SDS multiple Gateway flow when
 	// the control plane certificate provider is k8s CA.
 	framework.
-		NewSuite("sds_ingress_k8sca", m).
+		NewSuite(m).
 		RequireSingleCluster().
 		Setup(istio.Setup(&inst, setupConfig)).
 		Run()

--- a/tests/integration/security/sds_vault_flow/main_test.go
+++ b/tests/integration/security/sds_vault_flow/main_test.go
@@ -50,7 +50,7 @@ var (
 func TestMain(m *testing.M) {
 	// Integration test for the SDS Vault CA flow, as well as mutual TLS
 	// with the certificates issued by the SDS Vault CA flow.
-	framework.NewSuite("sds_vault_flow_test", m).
+	framework.NewSuite(m).
 		Label(label.CustomSetup).
 		Skip("https://github.com/istio/istio/issues/17572").
 		// SDS requires Kubernetes 1.13

--- a/tests/integration/security/webhook/webhook_test.go
+++ b/tests/integration/security/webhook/webhook_test.go
@@ -32,7 +32,7 @@ var (
 
 func TestMain(m *testing.M) {
 	framework.
-		NewSuite("istioctl_webhook_test", m).
+		NewSuite(m).
 		Label(label.CustomSetup).
 		RequireSingleCluster().
 		// Deploy Istio

--- a/tests/integration/telemetry/main_test.go
+++ b/tests/integration/telemetry/main_test.go
@@ -33,7 +33,7 @@ var (
 
 func TestMain(m *testing.M) {
 	framework.
-		NewSuite("telemetry_test", m).
+		NewSuite(m).
 		RequireSingleCluster().
 		Label(label.CustomSetup).
 		Setup(istio.Setup(&i, func(cfg *istio.Config) {

--- a/tests/integration/telemetry/outboundtrafficpolicy/traffic_test.go
+++ b/tests/integration/telemetry/outboundtrafficpolicy/traffic_test.go
@@ -30,7 +30,7 @@ var (
 
 func TestMain(m *testing.M) {
 	var ist istio.Instance
-	framework.NewSuite("outbound_traffic_policy", m).
+	framework.NewSuite(m).
 		RequireSingleCluster().
 		Label(label.CustomSetup).
 		Setup(istio.Setup(&ist, setupConfig)).

--- a/tests/integration/telemetry/requestclassification/requestclassification_test.go
+++ b/tests/integration/telemetry/requestclassification/requestclassification_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	framework.NewSuite("request_classification_test", m).Run()
+	framework.NewSuite(m).Run()
 }
 
 func TestRequestClassification(t *testing.T) {

--- a/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
@@ -172,7 +172,7 @@ func TestStackdriverMonitoring(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	framework.NewSuite("stackdriver_filter_test", m).
+	framework.NewSuite(m).
 		RequireSingleCluster().
 		Label(label.CustomSetup).
 		Setup(istio.Setup(getIstioInstance(), setupConfig)).

--- a/tests/integration/telemetry/stats/prometheus/http/nullvm/stats_filter_test.go
+++ b/tests/integration/telemetry/stats/prometheus/http/nullvm/stats_filter_test.go
@@ -34,7 +34,7 @@ func TestStatsFilter(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	framework.NewSuite("stats_filter_test", m).
+	framework.NewSuite(m).
 		RequireSingleCluster().
 		Label(label.CustomSetup).
 		Setup(istio.Setup(common.GetIstioInstance(), setupConfig)).

--- a/tests/integration/telemetry/stats/prometheus/http/wasm/stats_wasm_filter_test.go
+++ b/tests/integration/telemetry/stats/prometheus/http/wasm/stats_wasm_filter_test.go
@@ -35,7 +35,7 @@ func TestWasmStatsFilter(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	framework.NewSuite("stats_filter_wasm_test", m).
+	framework.NewSuite(m).
 		RequireSingleCluster().
 		Label(label.CustomSetup).
 		Setup(istio.Setup(common.GetIstioInstance(), setupConfig)).

--- a/tests/integration/telemetry/stats/prometheus/istioctl/istioctl_metrics_test.go
+++ b/tests/integration/telemetry/stats/prometheus/istioctl/istioctl_metrics_test.go
@@ -49,7 +49,7 @@ func TestIstioctlMetrics(t *testing.T) {
 // is added to istioctl experimental metrics and support for non-default
 // output formats is added.
 func TestMain(m *testing.M) {
-	framework.NewSuite("istioctl_metrics_test", m).
+	framework.NewSuite(m).
 		RequireSingleCluster().
 		Label(label.CustomSetup).
 		Setup(istio.Setup(http.GetIstioInstance(), setupConfig)).

--- a/tests/integration/telemetry/stats/prometheus/tcp/stats_tcp_filter_test.go
+++ b/tests/integration/telemetry/stats/prometheus/tcp/stats_tcp_filter_test.go
@@ -96,7 +96,7 @@ func TestTcpMetric(t *testing.T) { // nolint:interfacer
 
 func TestMain(m *testing.M) {
 	framework.
-		NewSuite("stats_tcp_filter", m).
+		NewSuite(m).
 		RequireSingleCluster().
 		Label(label.CustomSetup).
 		Setup(istio.Setup(&ist, setupConfig)).

--- a/tests/integration/telemetry/tracing/clienttracing/client_tracing_test.go
+++ b/tests/integration/telemetry/tracing/clienttracing/client_tracing_test.go
@@ -67,7 +67,7 @@ func TestClientTracing(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	framework.NewSuite("client_tracing_test", m).
+	framework.NewSuite(m).
 		RequireSingleCluster().
 		Label(label.CustomSetup).
 		Setup(istio.Setup(tracing.GetIstioInstance(), setupConfig)).

--- a/tests/integration/telemetry/tracing/servertracing/tracing_test.go
+++ b/tests/integration/telemetry/tracing/servertracing/tracing_test.go
@@ -55,7 +55,7 @@ func TestProxyTracing(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	framework.NewSuite("tracing_test", m).
+	framework.NewSuite(m).
 		RequireSingleCluster().
 		Label(label.CustomSetup).
 		Setup(istio.Setup(tracing.GetIstioInstance(), setupConfig)).


### PR DESCRIPTION
This is currently doing nothing - we auto derive this now, but didn't
clean up the method signature



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure