### PR TITLE
[Test Framework] Restore environment creation override

### DIFF
--- a/pkg/kube/client_config.go
+++ b/pkg/kube/client_config.go
@@ -34,6 +34,13 @@ type clientConfig struct {
 	restConfig rest.Config
 }
 
+// NewClientConfigForRestConfig creates a new k8s clientcmd.ClientConfig from the given rest.Config.
+func NewClientConfigForRestConfig(restConfig *rest.Config) clientcmd.ClientConfig {
+	return &clientConfig{
+		restConfig: *restConfig,
+	}
+}
+
 func (c *clientConfig) RawConfig() (api.Config, error) {
 	cfg := api.Config{
 		Kind:        "Config",

--- a/pkg/test/framework/resource/environment.go
+++ b/pkg/test/framework/resource/environment.go
@@ -20,8 +20,8 @@ import (
 	"istio.io/istio/pkg/test/framework/resource/environment"
 )
 
-// EnvironmentFactory is a function that creates an Environment by name.
-type EnvironmentFactory func(name string, ctx Context) (Environment, error)
+// EnvironmentFactory creates an Environment.
+type EnvironmentFactory func(ctx Context) (Environment, error)
 
 // Environment is the ambient environment that the test runs in.
 type Environment interface {

--- a/pkg/test/framework/resource/settings.go
+++ b/pkg/test/framework/resource/settings.go
@@ -19,10 +19,9 @@ import (
 	"path"
 	"strings"
 
-	"istio.io/istio/pkg/test/framework/label"
-	"istio.io/istio/pkg/test/framework/resource/environment"
-
 	"github.com/google/uuid"
+
+	"istio.io/istio/pkg/test/framework/label"
 )
 
 const (
@@ -36,9 +35,6 @@ type Settings struct {
 	TestID string
 
 	RunID uuid.UUID
-
-	// Environment to run the tests in. By default, a local environment will be used.
-	Environment string
 
 	// Do not cleanup the resources after the test run.
 	NoCleanup bool
@@ -91,8 +87,7 @@ func (s *Settings) Clone() *Settings {
 // DefaultSettings returns a default settings instance.
 func DefaultSettings() *Settings {
 	return &Settings{
-		Environment: environment.DefaultName().String(),
-		RunID:       uuid.New(),
+		RunID: uuid.New(),
 	}
 }
 
@@ -100,7 +95,6 @@ func DefaultSettings() *Settings {
 func (s *Settings) String() string {
 	result := ""
 
-	result += fmt.Sprintf("Environment:       %v\n", s.Environment)
 	result += fmt.Sprintf("TestID:            %s\n", s.TestID)
 	result += fmt.Sprintf("RunID:             %s\n", s.RunID.String())
 	result += fmt.Sprintf("NoCleanup:         %v\n", s.NoCleanup)

--- a/pkg/test/framework/suite_test.go
+++ b/pkg/test/framework/suite_test.go
@@ -55,7 +55,7 @@ func cleanupRT() {
 // Create a bogus environment for testing. This can be removed when "environments" are removed
 func newTestSuite(testID string, fn mRunFn, osExit func(int), getSettingsFn getSettingsFunc) *Suite {
 	s := newSuite(testID, fn, osExit, getSettingsFn)
-	s.envFactory = func(name string, ctx resource.Context) (resource.Environment, error) {
+	s.envFactory = func(ctx resource.Context) (resource.Environment, error) {
 		return fakeEnvironment{}, nil
 	}
 	return s
@@ -416,7 +416,7 @@ func TestSuite_GetResource(t *testing.T) {
 
 func newFakeEnvironmentFactory(numClusters int) resource.EnvironmentFactory {
 	e := fakeEnvironment{numClusters: numClusters}
-	return func(name string, ctx resource.Context) (resource.Environment, error) {
+	return func(ctx resource.Context) (resource.Environment, error) {
 		return e, nil
 	}
 }

--- a/pkg/test/framework/suitecontext.go
+++ b/pkg/test/framework/suitecontext.go
@@ -74,7 +74,7 @@ func newSuiteContext(s *resource.Settings, envFn resource.EnvironmentFactory, la
 		contextNames: make(map[string]struct{}),
 	}
 
-	env, err := envFn(s.Environment, c)
+	env, err := envFn(c)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This was accidentally removed in #24149. This is currently the only mechanism available for overriding cluster accessor creation with custom transports.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure