### PR TITLE
Add gen-charts warning message to all paths

### DIFF
--- a/operator/pkg/helm/vfs_renderer.go
+++ b/operator/pkg/helm/vfs_renderer.go
@@ -79,6 +79,9 @@ func (h *VFSRenderer) RenderManifest(values string) (string, error) {
 
 // LoadValuesVFS loads the compiled in file corresponding to the given profile name.
 func LoadValuesVFS(profileName string) (string, error) {
+	if err := CheckCompiledInCharts(); err != nil {
+		return "", err
+	}
 	path := filepath.Join(profilesRoot, BuiltinProfileToFilename(profileName))
 	scope.Infof("Loading values from compiled in VFS at path %s", path)
 	b, err := vfs.ReadFile(path)
@@ -86,6 +89,9 @@ func LoadValuesVFS(profileName string) (string, error) {
 }
 
 func LoadValues(profileName string, chartsDir string) (string, error) {
+	if err := CheckCompiledInCharts(); err != nil {
+		return "", err
+	}
 	path := filepath.Join(chartsDir, profilesRoot, BuiltinProfileToFilename(profileName))
 	scope.Infof("Loading values at path %s", path)
 	b, err := ioutil.ReadFile(path)
@@ -93,6 +99,9 @@ func LoadValues(profileName string, chartsDir string) (string, error) {
 }
 
 func readProfiles(chartsDir string) (map[string]bool, error) {
+	if err := CheckCompiledInCharts(); err != nil {
+		return nil, err
+	}
 	profiles := map[string]bool{}
 	switch chartsDir {
 	case "":

--- a/operator/pkg/helm/vfs_renderer.go
+++ b/operator/pkg/helm/vfs_renderer.go
@@ -89,9 +89,6 @@ func LoadValuesVFS(profileName string) (string, error) {
 }
 
 func LoadValues(profileName string, chartsDir string) (string, error) {
-	if err := CheckCompiledInCharts(); err != nil {
-		return "", err
-	}
 	path := filepath.Join(chartsDir, profilesRoot, BuiltinProfileToFilename(profileName))
 	scope.Infof("Loading values at path %s", path)
 	b, err := ioutil.ReadFile(path)
@@ -99,12 +96,12 @@ func LoadValues(profileName string, chartsDir string) (string, error) {
 }
 
 func readProfiles(chartsDir string) (map[string]bool, error) {
-	if err := CheckCompiledInCharts(); err != nil {
-		return nil, err
-	}
 	profiles := map[string]bool{}
 	switch chartsDir {
 	case "":
+		if err := CheckCompiledInCharts(); err != nil {
+			return nil, err
+		}
 		profilePaths, err := vfs.ReadDir(chartsDir)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read profiles: %v", err)

--- a/operator/pkg/helm/vfs_renderer.go
+++ b/operator/pkg/helm/vfs_renderer.go
@@ -178,7 +178,8 @@ func ListProfiles(charts string) ([]string, error) {
 // binaries using go build instead of make and tries to use compiled in charts.
 func CheckCompiledInCharts() error {
 	if _, err := vfs.Stat(ChartsSubdirName); err != nil {
-		return fmt.Errorf("compiled in charts not found in this development build, use --charts with local charts instead or run make gen-charts and rebuild istioctl")
+		return fmt.Errorf("compiled in charts not found in this development build, use --charts with " +
+			"local charts instead (e.g. istioctl install --charts manifests/) or run make gen-charts and rebuild istioctl")
 	}
 	return nil
 }

--- a/operator/pkg/helm/vfs_renderer.go
+++ b/operator/pkg/helm/vfs_renderer.go
@@ -178,7 +178,7 @@ func ListProfiles(charts string) ([]string, error) {
 // binaries using go build instead of make and tries to use compiled in charts.
 func CheckCompiledInCharts() error {
 	if _, err := vfs.Stat(ChartsSubdirName); err != nil {
-		return fmt.Errorf("compiled in charts not found in this development build, use --charts with local charts instead or run make gen-charts")
+		return fmt.Errorf("compiled in charts not found in this development build, use --charts with local charts instead or run make gen-charts and rebuild istioctl")
 	}
 	return nil
 }


### PR DESCRIPTION
Prints Error: failed to read profiles: compiled in charts not found in this development build, use --charts with local charts instead or run make gen-charts
when trying to run manifest commands with stub assets.gen.go.