### PR TITLE
[Test Framework] Fix generated testID for BUILD_WITH_CONTAINER=1

### DIFF
--- a/pkg/test/framework/suite_test.go
+++ b/pkg/test/framework/suite_test.go
@@ -414,6 +414,42 @@ func TestSuite_GetResource(t *testing.T) {
 	})
 }
 
+func TestDeriveSuiteName(t *testing.T) {
+	cases := []struct {
+		caller   string
+		expected string
+	}{
+		{
+			caller:   "/home/me/go/src/istio.io/istio/some/path/mytest.go",
+			expected: "some_path",
+		},
+		{
+			caller:   "/home/me/go/src/istio.io/istio.io/some/path/mytest.go",
+			expected: "some_path",
+		},
+		{
+			caller:   "/home/me/go/src/istio.io/istio/tests/integration/some/path/mytest.go",
+			expected: "some_path",
+		},
+		{
+			caller:   "/work/some/path/mytest.go",
+			expected: "some_path",
+		},
+		{
+			caller:   "/work/tests/integration/some/path/mytest.go",
+			expected: "some_path",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.caller, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			actual := deriveSuiteName(c.caller)
+			g.Expect(actual).To(Equal(c.expected))
+		})
+	}
+}
+
 func newFakeEnvironmentFactory(numClusters int) resource.EnvironmentFactory {
 	e := fakeEnvironment{numClusters: numClusters}
 	return func(ctx resource.Context) (resource.Environment, error) {


### PR DESCRIPTION
When running with BUILD_WITH_CONTAINER=1, the Istio code is stored under `/work`. The logic in the test ID generation specifically looks for paths containing `istio.io/istio`, which is not found in this case. The path stripping logic is therefore skipped entirely, resulting in a testID of the form "_work_...".

The whitelist for feature label enforcement is unfortunately coupled to the form of the test IDs. This results in whitelisted tests failing due to feature label enforcement when BUILD_WITH_CONTAINER=1.

This PR changes the logic to use regexes and includes paths for "/work" as a work-around.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure