### PR TITLE
listener: add grpc status filter for outbound http connection manager

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1830,9 +1830,7 @@ func buildHTTPConnectionManager(pluginParams *plugin.InputParams, httpOpts *http
 		filters = append(filters, xdsfilters.GrpcWeb)
 	}
 
-	if pluginParams.ServiceInstance != nil &&
-		pluginParams.ServiceInstance.ServicePort != nil &&
-		pluginParams.ServiceInstance.ServicePort.Protocol == protocol.GRPC {
+	if pluginParams.Port != nil && pluginParams.Port.Protocol.IsGRPC() {
 		filters = append(filters, &hcm.HttpFilter{
 			Name: wellknown.HTTPGRPCStats,
 			ConfigType: &hcm.HttpFilter_TypedConfig{


### PR DESCRIPTION
Currently gRPC status filter is only added for inbound connection manager. This PR adds to outbound connection manager as well

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
