### PR TITLE
Subject: Fix bug(#24776) the pilot reporter.distributionEventQueue de…

### DIFF
--- a/pilot/pkg/status/reporter.go
+++ b/pilot/pkg/status/reporter.go
@@ -82,7 +82,7 @@ func (r *Reporter) Start(clientSet kubernetes.Interface, namespace string, store
 	if r.UpdateInterval == 0 {
 		r.UpdateInterval = 500 * time.Millisecond
 	}
-	r.distributionEventQueue = make(chan distributionEvent, 100_000)
+	r.distributionEventQueue = make(chan distributionEvent, 100000)
 	r.status = make(map[string]string)
 	r.reverseStatus = make(map[string][]string)
 	r.inProgressResources = make(map[string]*inProgressEntry)


### PR DESCRIPTION
the pilot reporter.distributionEventQueue default length is wrong as 100_000

Description:
+ the default value should be 100000



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[X] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure