### PR TITLE
Stop using buildx for docker.save

### DIFF
--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -232,8 +232,7 @@ dockerx.save: dockerx $(ISTIO_DOCKER_TAR)
 		   ); \
 	 ))
 
-#docker.save: $(DOCKER_TAR_TARGETS) # Legacy target when used with old docker versions
-docker.save: dockerx.save
+docker.save: $(DOCKER_TAR_TARGETS)
 
 # for each docker.XXX target create a push.docker.XXX target that pushes
 # the local docker image to another hub


### PR DESCRIPTION
This is broken on docker 19.03.2 which is what our CI uses. Its not
much, if at all, slow it seems.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure