### PR TITLE
pkg/kube/inject: use real MeshConfig for injection tests

### DIFF
--- a/pkg/kube/inject/inject_test.go
+++ b/pkg/kube/inject/inject_test.go
@@ -302,11 +302,10 @@ func TestIntoResourceFile(t *testing.T) {
 		testName := fmt.Sprintf("[%02d] %s", i, c.want)
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
-			m := mesh.DefaultMeshConfig()
+			sidecarTemplate, valuesConfig, m := loadInjectionSettings(t, c.setFlags, c.inFilePath)
 			if c.mesh != nil {
-				c.mesh(&m)
+				c.mesh(m)
 			}
-			sidecarTemplate, valuesConfig := loadInjectionConfigMap(t, c.setFlags, c.inFilePath)
 			inputFilePath := "testdata/inject/" + c.in
 			wantFilePath := "testdata/inject/" + c.want
 			in, err := os.Open(inputFilePath)
@@ -315,7 +314,7 @@ func TestIntoResourceFile(t *testing.T) {
 			}
 			defer func() { _ = in.Close() }()
 			var got bytes.Buffer
-			if err = IntoResourceFile(sidecarTemplate.Template, valuesConfig, "", &m, in, &got); err != nil {
+			if err = IntoResourceFile(sidecarTemplate.Template, valuesConfig, "", m, in, &got); err != nil {
 				t.Fatalf("IntoResourceFile(%v) returned an error: %v", inputFilePath, err)
 			}
 
@@ -414,8 +413,7 @@ func TestRewriteAppProbe(t *testing.T) {
 	for i, c := range cases {
 		testName := fmt.Sprintf("[%02d] %s", i, c.want)
 		t.Run(testName, func(t *testing.T) {
-			m := mesh.DefaultMeshConfig()
-			sidecarTemplate, valuesConfig := loadInjectionConfigMap(t, nil, "")
+			sidecarTemplate, valuesConfig, m := loadInjectionSettings(t, nil, "")
 			inputFilePath := "testdata/inject/app_probe/" + c.in
 			wantFilePath := "testdata/inject/app_probe/" + c.want
 			in, err := os.Open(inputFilePath)
@@ -424,7 +422,7 @@ func TestRewriteAppProbe(t *testing.T) {
 			}
 			defer func() { _ = in.Close() }()
 			var got bytes.Buffer
-			if err = IntoResourceFile(sidecarTemplate.Template, valuesConfig, "", &m, in, &got); err != nil {
+			if err = IntoResourceFile(sidecarTemplate.Template, valuesConfig, "", m, in, &got); err != nil {
 				t.Fatalf("IntoResourceFile(%v) returned an error: %v", inputFilePath, err)
 			}
 
@@ -469,7 +467,7 @@ func TestInvalidAnnotations(t *testing.T) {
 	m := mesh.DefaultMeshConfig()
 	for _, c := range cases {
 		t.Run(c.annotation, func(t *testing.T) {
-			sidecarTemplate, valuesConfig := loadInjectionConfigMap(t, nil, "")
+			sidecarTemplate, valuesConfig, _ := loadInjectionSettings(t, nil, "")
 			inputFilePath := "testdata/inject/" + c.in
 			in, err := os.Open(inputFilePath)
 			if err != nil {

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -107,7 +107,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -133,6 +133,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"httpGet":{"port":80}},"/app-health/hello/readyz":{"httpGet":{"port":3333}},"/app-health/world/livez":{"httpGet":{"port":90}}}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -196,6 +197,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -104,7 +104,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -130,6 +130,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-proxy
@@ -191,6 +192,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
@@ -106,7 +106,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -129,6 +129,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"httpGet":{"port":80}},"/app-health/hello/readyz":{"httpGet":{"port":3333}},"/app-health/world/livez":{"httpGet":{"port":90}}}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -192,6 +193,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
@@ -87,7 +87,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -108,6 +108,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/readyz":{"httpGet":{"path":"/ip","port":8000}}}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -171,6 +172,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
@@ -107,7 +107,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -130,6 +130,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"httpGet":{"port":80}},"/app-health/hello/readyz":{"httpGet":{"port":3333,"scheme":"HTTPS"}},"/app-health/world/livez":{"httpGet":{"port":90}}}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -193,6 +194,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
@@ -87,7 +87,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -108,6 +108,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/readyz":{"httpGet":{"port":80}}}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -171,6 +172,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
@@ -91,7 +91,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -112,6 +112,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"httpGet":{"port":80}},"/app-health/hello/readyz":{"httpGet":{"port":3333}}}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -175,6 +176,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
@@ -106,7 +106,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -129,6 +129,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"httpGet":{"port":80}},"/app-health/hello/readyz":{"httpGet":{"port":3333}},"/app-health/world/livez":{"httpGet":{"port":90}}}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -192,6 +193,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
@@ -87,7 +87,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -108,6 +108,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/readyz":{"httpGet":{"port":3333}}}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -171,6 +172,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/app_probe/startup_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/startup_live.yaml.injected
@@ -106,7 +106,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -129,6 +129,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"httpGet":{"port":80}},"/app-health/hello/startupz":{"httpGet":{"port":3333}},"/app-health/world/livez":{"httpGet":{"port":90}}}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -192,6 +193,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/app_probe/startup_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/startup_only.yaml.injected
@@ -87,7 +87,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -108,6 +108,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/startupz":{"httpGet":{"port":3333}}}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -171,6 +172,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/app_probe/startup_ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/startup_ready_live.yaml.injected
@@ -114,7 +114,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -137,6 +137,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/livez":{"httpGet":{"port":80}},"/app-health/hello/readyz":{"httpGet":{"port":3333}},"/app-health/hello/startupz":{"httpGet":{"port":3333}},"/app-health/world/livez":{"httpGet":{"port":90}},"/app-health/world/startupz":{"httpGet":{"port":90}}}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -200,6 +201,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
@@ -97,7 +97,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -120,6 +120,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{"/app-health/hello/readyz":{"httpGet":{"path":"/ip","port":8000}},"/app-health/world/readyz":{"httpGet":{"path":"/ipv6","port":9000}}}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -183,6 +184,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -104,6 +104,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -167,6 +168,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -104,6 +104,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -167,6 +168,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -104,6 +104,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -167,6 +168,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -77,7 +77,7 @@ spec:
                   fieldPath: metadata.labels['service.istio.io/canonical-revision']
             - name: PROXY_CONFIG
               value: |
-                {}
+                {"proxyMetadata":{"DNS_AGENT":""}}
             - name: ISTIO_META_POD_PORTS
               value: |-
                 [
@@ -97,6 +97,7 @@ spec:
               value: kubernetes://apis/batch/v2alpha1/namespaces/default/cronjobs/hellocron
             - name: ISTIO_META_MESH_ID
               value: cluster.local
+            - name: DNS_AGENT
             - name: ISTIO_KUBE_APP_PROBERS
               value: '{}'
             image: gcr.io/istio-testing/proxyv2:latest
@@ -160,6 +161,8 @@ spec:
             - '*'
             - -d
             - 15090,15021,15020
+            env:
+            - name: DNS_AGENT
             image: gcr.io/istio-testing/proxyv2:latest
             imagePullPolicy: Always
             name: istio-init

--- a/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -102,6 +102,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/daemonsets/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -165,6 +166,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -96,7 +96,7 @@ items:
                 fieldPath: metadata.labels['service.istio.io/canonical-revision']
           - name: PROXY_CONFIG
             value: |
-              {}
+              {"proxyMetadata":{"DNS_AGENT":""}}
           - name: ISTIO_META_POD_PORTS
             value: |-
               [
@@ -117,6 +117,7 @@ items:
             value: kubernetes://apis/apps.openshift.io/v1/namespaces/default/deploymentconfigs/hello
           - name: ISTIO_META_MESH_ID
             value: cluster.local
+          - name: DNS_AGENT
           - name: ISTIO_KUBE_APP_PROBERS
             value: '{}'
           image: gcr.io/istio-testing/proxyv2:latest
@@ -180,6 +181,8 @@ items:
           - '*'
           - -d
           - 15090,15021,15020
+          env:
+          - name: DNS_AGENT
           image: gcr.io/istio-testing/proxyv2:latest
           imagePullPolicy: Always
           name: istio-init

--- a/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -102,6 +102,7 @@ spec:
           value: kubernetes://apis/apps.openshift.io/v1/namespaces/default/deploymentconfigs/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -165,6 +166,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
@@ -84,7 +84,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -108,6 +108,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -171,6 +172,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -104,6 +104,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -167,6 +168,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"drainDuration":"23s","parentShutdownDuration":"42s"}
+            {"drainDuration":"23s","parentShutdownDuration":"42s","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -104,6 +104,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -167,6 +168,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -100,7 +100,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -120,6 +120,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/frontend
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -183,6 +184,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -104,6 +104,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -167,6 +168,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-cncf-networks.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-cncf-networks.yaml.injected
@@ -84,7 +84,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -105,6 +105,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -170,6 +171,8 @@ spec:
         - 15090,15021,15020
         - --run-validation
         - --skip-rule-apply
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-validation

--- a/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -104,6 +104,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -167,6 +168,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks.yaml.injected
@@ -84,7 +84,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -108,6 +108,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -173,6 +174,8 @@ spec:
         - 15090,15021,15020
         - --run-validation
         - --skip-rule-apply
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-validation

--- a/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
@@ -84,7 +84,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -108,6 +108,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -171,6 +172,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-image-secrets-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-image-secrets-in-values.yaml.injected
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -104,6 +104,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -169,6 +170,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -104,6 +104,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -170,6 +171,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -104,6 +104,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -167,6 +168,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -85,7 +85,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -106,6 +106,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello-v1
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -169,6 +170,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init
@@ -308,7 +311,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -329,6 +332,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello-v2
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -392,6 +396,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-multiple-image-secrets.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multiple-image-secrets.yaml.injected
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -104,6 +104,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -170,6 +171,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -84,7 +84,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -105,6 +105,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/test/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -168,6 +169,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -104,6 +104,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -167,6 +168,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Never
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -84,7 +84,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -108,6 +108,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: docker.io/istio/proxy2_debug:unittest
@@ -171,6 +172,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -104,6 +104,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -171,6 +172,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"interceptionMode":"TPROXY"}
+            {"interceptionMode":"TPROXY","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -104,6 +104,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -169,6 +170,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -104,6 +104,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -169,6 +170,8 @@ spec:
         - 15090,15021,15020
         - --run-validation
         - --skip-rule-apply
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-validation

--- a/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -104,6 +104,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -167,6 +168,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -95,6 +95,7 @@ spec:
           value: kubernetes://apis/batch/v1/namespaces/default/jobs/pi
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -158,6 +159,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -84,7 +84,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -108,6 +108,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -173,6 +174,8 @@ spec:
         - 15090,15021,123
         - -k
         - net1
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -84,7 +84,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -108,6 +108,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -173,6 +174,8 @@ spec:
         - 15090,15021,15020
         - -k
         - net1,net2
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -101,7 +101,7 @@ items:
                 fieldPath: metadata.labels['service.istio.io/canonical-revision']
           - name: PROXY_CONFIG
             value: |
-              {}
+              {"proxyMetadata":{"DNS_AGENT":""}}
           - name: ISTIO_META_POD_PORTS
             value: |-
               [
@@ -121,6 +121,7 @@ items:
             value: kubernetes://apis/apps/v1/namespaces/default/deployments/frontend
           - name: ISTIO_META_MESH_ID
             value: cluster.local
+          - name: DNS_AGENT
           - name: ISTIO_KUBE_APP_PROBERS
             value: '{}'
           image: gcr.io/istio-testing/proxyv2:latest
@@ -184,6 +185,8 @@ items:
           - '*'
           - -d
           - 15090,15021,15020
+          env:
+          - name: DNS_AGENT
           image: gcr.io/istio-testing/proxyv2:latest
           imagePullPolicy: Always
           name: istio-init

--- a/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -87,7 +87,7 @@ items:
                 fieldPath: metadata.labels['service.istio.io/canonical-revision']
           - name: PROXY_CONFIG
             value: |
-              {}
+              {"proxyMetadata":{"DNS_AGENT":""}}
           - name: ISTIO_META_POD_PORTS
             value: |-
               [
@@ -108,6 +108,7 @@ items:
             value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello-v1
           - name: ISTIO_META_MESH_ID
             value: cluster.local
+          - name: DNS_AGENT
           - name: ISTIO_KUBE_APP_PROBERS
             value: '{}'
           image: gcr.io/istio-testing/proxyv2:latest
@@ -171,6 +172,8 @@ items:
           - '*'
           - -d
           - 15090,15021,15020
+          env:
+          - name: DNS_AGENT
           image: gcr.io/istio-testing/proxyv2:latest
           imagePullPolicy: Always
           name: istio-init
@@ -309,7 +312,7 @@ items:
                 fieldPath: metadata.labels['service.istio.io/canonical-revision']
           - name: PROXY_CONFIG
             value: |
-              {}
+              {"proxyMetadata":{"DNS_AGENT":""}}
           - name: ISTIO_META_POD_PORTS
             value: |-
               [
@@ -330,6 +333,7 @@ items:
             value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello-v2
           - name: ISTIO_META_MESH_ID
             value: cluster.local
+          - name: DNS_AGENT
           - name: ISTIO_KUBE_APP_PROBERS
             value: '{}'
           image: gcr.io/istio-testing/proxyv2:latest
@@ -393,6 +397,8 @@ items:
           - '*'
           - -d
           - 15090,15021,15020
+          env:
+          - name: DNS_AGENT
           image: gcr.io/istio-testing/proxyv2:latest
           imagePullPolicy: Always
           name: istio-init

--- a/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
@@ -85,7 +85,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -108,6 +108,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/app
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -171,6 +172,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -104,6 +104,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -181,6 +182,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -69,7 +69,7 @@ spec:
           fieldPath: metadata.labels['service.istio.io/canonical-revision']
     - name: PROXY_CONFIG
       value: |
-        {}
+        {"proxyMetadata":{"DNS_AGENT":""}}
     - name: ISTIO_META_POD_PORTS
       value: |-
         [
@@ -90,6 +90,7 @@ spec:
       value: kubernetes://apis/v1/namespaces/default/pods/hellopod
     - name: ISTIO_META_MESH_ID
       value: cluster.local
+    - name: DNS_AGENT
     - name: ISTIO_KUBE_APP_PROBERS
       value: '{}'
     image: gcr.io/istio-testing/proxyv2:latest
@@ -153,6 +154,8 @@ spec:
     - '*'
     - -d
     - 15090,15021,15020
+    env:
+    - name: DNS_AGENT
     image: gcr.io/istio-testing/proxyv2:latest
     imagePullPolicy: Always
     name: istio-init

--- a/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -99,6 +99,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/replicasets/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -162,6 +163,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -77,7 +77,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -98,6 +98,7 @@ spec:
           value: kubernetes://apis/v1/namespaces/default/replicationcontrollers/nginx
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -161,6 +162,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -86,7 +86,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -107,6 +107,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/statefulsets/hello
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -170,6 +171,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -84,7 +84,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -108,6 +108,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/statusPort
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -171,6 +172,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,123
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -79,7 +79,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -100,6 +100,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/statusPort
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -163,6 +164,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,123
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -80,7 +80,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -104,6 +104,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/traffic
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -167,6 +168,8 @@ spec:
         - ""
         - -d
         - 15090,15021,4,5,6,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -80,7 +80,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -104,6 +104,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/traffic
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -167,6 +168,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,4,5,6,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -79,7 +79,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -100,6 +100,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/traffic
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -163,6 +164,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,15020
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -80,7 +80,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -101,6 +101,7 @@ spec:
           value: kubernetes://apis/apps/v1/namespaces/default/deployments/traffic
         - name: ISTIO_META_MESH_ID
           value: cluster.local
+        - name: DNS_AGENT
         - name: ISTIO_KUBE_APP_PROBERS
           value: '{}'
         image: gcr.io/istio-testing/proxyv2:latest
@@ -157,6 +158,8 @@ spec:
         - '*'
         - -d
         - 15090,15021,4,5,6
+        env:
+        - name: DNS_AGENT
         image: gcr.io/istio-testing/proxyv2:latest
         imagePullPolicy: Always
         name: istio-init

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -820,13 +820,13 @@ func createTestWebhookFromHelmConfigMap(t *testing.T) (*Webhook, func()) {
 	t.Helper()
 	// Load the config map with Helm. This simulates what will be done at runtime, by replacing function calls and
 	// variables and generating a new configmap for use by the injection logic.
-	sidecarTemplate, values := loadInjectionConfigMap(t, nil, "")
+	sidecarTemplate, values, _ := loadInjectionSettings(t, nil, "")
 	return createTestWebhook(t, sidecarTemplate, values)
 }
 
-// loadInjectionConfigMap will render the charts using the operator, with given yaml overrides.
+// loadInjectionSettings will render the charts using the operator, with given yaml overrides.
 // This allows us to fully simulate what will actually happen at run time.
-func loadInjectionConfigMap(t testing.TB, setFlags []string, inFilePath string) (template *Config, values string) {
+func loadInjectionSettings(t testing.TB, setFlags []string, inFilePath string) (template *Config, values string, meshConfig *meshconfig.MeshConfig) {
 	t.Helper()
 	// add --set installPackagePath=<path to charts snapshot>
 	setFlags = append(setFlags, "installPackagePath="+defaultInstallPackageDir())
@@ -860,20 +860,38 @@ func loadInjectionConfigMap(t testing.TB, setFlags []string, inFilePath string) 
 				if !ok {
 					t.Fatalf("failed to config %v", data)
 				}
-				values, ok := data["values"].(string)
+				values, ok = data["values"].(string)
 				if !ok {
 					t.Fatalf("failed to config %v", data)
 				}
-				injectConfig := &Config{}
-				if err := yaml.Unmarshal([]byte(config), injectConfig); err != nil {
+				template = &Config{}
+				if err := yaml.Unmarshal([]byte(config), template); err != nil {
 					t.Fatalf("failed to unmarshal injectionConfig: %v", err)
 				}
-				return injectConfig, values
+				if meshConfig != nil {
+					return template, values, meshConfig
+				}
+			} else if out.GetName() == "istio" && (out.GroupVersionKind() == schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}) {
+				data, ok := out.Object["data"].(map[string]interface{})
+				if !ok {
+					t.Fatalf("failed to convert %v", out)
+				}
+				meshdata, ok := data["mesh"].(string)
+				if !ok {
+					t.Fatalf("failed to get meshconfig %v", data)
+				}
+				meshConfig, err = mesh.ApplyMeshConfig(meshdata, mesh.DefaultMeshConfig())
+				if err != nil {
+					t.Fatalf("failed to unmarshal meshconfig: %v", err)
+				}
+				if template != nil {
+					return template, values, meshConfig
+				}
 			}
 		}
 	}
 	t.Fatal("could not find injection template")
-	return nil, ""
+	return nil, "", nil
 }
 
 func splitYamlFile(yamlFile string, t *testing.T) [][]byte {
@@ -1145,7 +1163,7 @@ func createWebhook(t testing.TB, cfg *Config) (*Webhook, func()) {
 		cleanup()
 		t.Fatalf("Could not marshal test injection config: %v", err)
 	}
-	_, values := loadInjectionConfigMap(t, nil, "")
+	_, values, _ := loadInjectionSettings(t, nil, "")
 	var (
 		configFile     = filepath.Join(dir, "config-file.yaml")
 		valuesFile     = filepath.Join(dir, "values-file.yaml")
@@ -1416,7 +1434,7 @@ func testSideCarInjectorMetrics(t *testing.T, wh *Webhook) {
 }
 
 func BenchmarkInjectServe(b *testing.B) {
-	sidecarTemplate, _ := loadInjectionConfigMap(b, nil, "")
+	sidecarTemplate, _, _ := loadInjectionSettings(b, nil, "")
 	wh, cleanup := createWebhook(b, sidecarTemplate)
 	defer cleanup()
 


### PR DESCRIPTION
Now, the injection tests not only pick up the 'real' (ie same as when installing) injection template, but also the real meshConfig from the ConfigMaps generated by the charts. Note that this adds one `env` var (DNS_AGENT) to the golden files, but that should not be a problem as this also exists in production deployments.

This is a precursor to another PR I'm working on: I want to try and move more injection settings from `.Values.` into ProxyConfig, possibly enabling us to remove the `values: ` section from the injection configmap altogether.