### PR TITLE
Add package for gvk short names

### DIFF
--- a/istioctl/cmd/describe.go
+++ b/istioctl/cmd/describe.go
@@ -57,7 +57,7 @@ import (
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
-	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/inject"
 )
@@ -968,7 +968,7 @@ func printIngressInfo(writer io.Writer, matchingServices []v1.Service, podsLabel
 			drName, drNamespace, err := getIstioDestinationRuleNameForSvc(&cd, svc, port.Port)
 			var dr *model.Config
 			if err == nil && drName != "" && drNamespace != "" {
-				dr = configClient.Get(collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(), drName, drNamespace)
+				dr = configClient.Get(gvk.DestinationRule, drName, drNamespace)
 				if dr != nil {
 					matchingSubsets, nonmatchingSubsets = getDestRuleSubsets(*dr, podsLabels)
 				} else {
@@ -980,7 +980,7 @@ func printIngressInfo(writer io.Writer, matchingServices []v1.Service, podsLabel
 
 			vsName, vsNamespace, err := getIstioVirtualServiceNameForSvc(&cd, svc, port.Port)
 			if err == nil && vsName != "" && vsNamespace != "" {
-				vs := configClient.Get(collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(), vsName, vsNamespace)
+				vs := configClient.Get(gvk.VirtualService, vsName, vsNamespace)
 				if vs != nil {
 					if row == 0 {
 						fmt.Fprintf(writer, "\n")
@@ -1201,7 +1201,7 @@ func describePodServices(writer io.Writer, kubeClient kube.Client, configClient 
 			}
 			var dr *model.Config
 			if err == nil && drName != "" && drNamespace != "" {
-				dr = configClient.Get(collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(), drName, drNamespace)
+				dr = configClient.Get(gvk.DestinationRule, drName, drNamespace)
 				if dr != nil {
 					if len(svc.Spec.Ports) > 1 {
 						// If there is more than one port, prefix each DR by the port it applies to
@@ -1218,7 +1218,7 @@ func describePodServices(writer io.Writer, kubeClient kube.Client, configClient 
 
 			vsName, vsNamespace, err := getIstioVirtualServiceNameForSvc(&cd, svc, port.Port)
 			if err == nil && vsName != "" && vsNamespace != "" {
-				vs := configClient.Get(collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(), vsName, vsNamespace)
+				vs := configClient.Get(gvk.VirtualService, vsName, vsNamespace)
 				if vs != nil {
 					if len(svc.Spec.Ports) > 1 {
 						// If there is more than one port, prefix each DR by the port it applies to

--- a/istioctl/cmd/sidecar-bootstrap.go
+++ b/istioctl/cmd/sidecar-bootstrap.go
@@ -44,7 +44,7 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 
 	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/security/pkg/k8s/secret"
 	"istio.io/istio/security/pkg/pki/util"
@@ -67,8 +67,6 @@ var (
 	sshPort           int
 	sshUser           string
 	startIstio        bool
-
-	workloadKind = collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind()
 )
 
 type workloadEntryAddressKeys struct {
@@ -96,7 +94,7 @@ func fetchSingleWorkloadEntry(workloadName string, client model.ConfigStore) ([]
 		return nil, "", fmt.Errorf("workload name: %s is not in the format: workloadName.Namespace", workloadName)
 	}
 
-	we := client.Get(workloadKind, workloadSplit[0], workloadSplit[1])
+	we := client.Get(gvk.WorkloadEntry, workloadSplit[0], workloadSplit[1])
 	if we == nil {
 		return nil, "", fmt.Errorf("workload entry: %s in namespace: %s was not found", workloadSplit[0], workloadSplit[1])
 	}
@@ -105,7 +103,7 @@ func fetchSingleWorkloadEntry(workloadName string, client model.ConfigStore) ([]
 }
 
 func fetchAllWorkloadEntries(client model.ConfigStore) ([]model.Config, string, error) {
-	list, err := client.List(workloadKind, namespace)
+	list, err := client.List(gvk.WorkloadEntry, namespace)
 	return list, namespace, err
 }
 

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -63,6 +63,7 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/dns"
 	"istio.io/istio/pkg/jwt"
 	istiokeepalive "istio.io/istio/pkg/keepalive"
@@ -701,7 +702,7 @@ func (s *Server) initRegistryEventHandlers() error {
 		pushReq := &model.PushRequest{
 			Full: true,
 			ConfigsUpdated: map[model.ConfigKey]struct{}{{
-				Kind:      model.ServiceEntryKind,
+				Kind:      gvk.ServiceEntry,
 				Name:      string(svc.Hostname),
 				Namespace: svc.Attributes.Namespace,
 			}: {}},
@@ -720,7 +721,7 @@ func (s *Server) initRegistryEventHandlers() error {
 		s.EnvoyXdsServer.ConfigUpdate(&model.PushRequest{
 			Full: true,
 			ConfigsUpdated: map[model.ConfigKey]struct{}{{
-				Kind:      model.ServiceEntryKind,
+				Kind:      gvk.ServiceEntry,
 				Name:      string(si.Service.Hostname),
 				Namespace: si.Service.Attributes.Namespace,
 			}: {}},

--- a/pilot/pkg/config/kube/gateway/controller.go
+++ b/pilot/pkg/config/kube/gateway/controller.go
@@ -28,14 +28,13 @@ import (
 	controller2 "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/resource"
 
 	"istio.io/istio/pilot/pkg/model"
 )
 
 var (
-	vsType             = collections.IstioNetworkingV1Alpha3Virtualservices.Resource()
-	gatewayType        = collections.IstioNetworkingV1Alpha3Gateways.Resource()
 	errUnsupportedOp   = fmt.Errorf("unsupported operation: the gateway config store is a read-only view")
 	errUnsupportedType = fmt.Errorf("unsupported type: this operation only supports gateway & virtual service resource type")
 	_                  = svc.HTTPRoute{}
@@ -72,7 +71,7 @@ func (c controller) Get(typ resource.GroupVersionKind, name, namespace string) *
 }
 
 func (c controller) List(typ resource.GroupVersionKind, namespace string) ([]model.Config, error) {
-	if typ != gatewayType.GroupVersionKind() && typ != vsType.GroupVersionKind() {
+	if typ != gvk.Gateway && typ != gvk.VirtualService {
 		return nil, errUnsupportedType
 	}
 
@@ -117,9 +116,9 @@ func (c controller) List(typ resource.GroupVersionKind, namespace string) ([]mod
 	output := convertResources(input)
 
 	switch typ {
-	case gatewayType.GroupVersionKind():
+	case gvk.Gateway:
 		return output.Gateway, nil
-	case vsType.GroupVersionKind():
+	case gvk.VirtualService:
 		return output.VirtualService, nil
 	}
 	return nil, errUnsupportedOp

--- a/pilot/pkg/config/kube/gateway/controller_test.go
+++ b/pilot/pkg/config/kube/gateway/controller_test.go
@@ -28,6 +28,7 @@ import (
 	controller2 "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/resource"
 )
 
@@ -101,7 +102,6 @@ func TestListGatewayResourceType(t *testing.T) {
 
 	gwClassType := collections.K8SServiceApisV1Alpha1Gatewayclasses.Resource()
 	gwSpecType := collections.K8SServiceApisV1Alpha1Gateways.Resource()
-	gwType := collections.IstioNetworkingV1Alpha3Gateways.Resource()
 	k8sHTTPRouteType := collections.K8SServiceApisV1Alpha1Httproutes.Resource()
 
 	store.Create(model.Config{
@@ -112,14 +112,16 @@ func TestListGatewayResourceType(t *testing.T) {
 		},
 		Spec: gatewayClassSpec,
 	})
-	store.Create(model.Config{
+	if _, err := store.Create(model.Config{
 		ConfigMeta: model.ConfigMeta{
 			GroupVersionKind: gwSpecType.GroupVersionKind(),
 			Name:             "gwspec",
 			Namespace:        "ns1",
 		},
 		Spec: gatewaySpec,
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 	store.Create(model.Config{
 		ConfigMeta: model.ConfigMeta{
 			GroupVersionKind: k8sHTTPRouteType.GroupVersionKind(),
@@ -129,11 +131,11 @@ func TestListGatewayResourceType(t *testing.T) {
 		Spec: httpRouteSpec,
 	})
 
-	cfg, err := controller.List(gwType.GroupVersionKind(), "ns1")
+	cfg, err := controller.List(gvk.Gateway, "ns1")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(cfg).To(HaveLen(1))
 	for _, c := range cfg {
-		g.Expect(c.GroupVersionKind).To(Equal(gwType.GroupVersionKind()))
+		g.Expect(c.GroupVersionKind).To(Equal(gvk.Gateway))
 		g.Expect(c.Name).To(Equal("gwspec" + "-" + constants.KubernetesGatewayName))
 		g.Expect(c.Namespace).To(Equal("ns1"))
 		g.Expect(c.Spec).To(Equal(expectedgw))
@@ -149,7 +151,6 @@ func TestListVirtualServiceResourceType(t *testing.T) {
 
 	gwClassType := collections.K8SServiceApisV1Alpha1Gatewayclasses.Resource()
 	gwSpecType := collections.K8SServiceApisV1Alpha1Gateways.Resource()
-	vsType = collections.IstioNetworkingV1Alpha3Virtualservices.Resource()
 	k8sHTTPRouteType := collections.K8SServiceApisV1Alpha1Httproutes.Resource()
 
 	store.Create(model.Config{
@@ -177,11 +178,11 @@ func TestListVirtualServiceResourceType(t *testing.T) {
 		Spec: httpRouteSpec,
 	})
 
-	cfg, err := controller.List(vsType.GroupVersionKind(), "ns1")
+	cfg, err := controller.List(gvk.VirtualService, "ns1")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(cfg).To(HaveLen(1))
 	for _, c := range cfg {
-		g.Expect(c.GroupVersionKind).To(Equal(vsType.GroupVersionKind()))
+		g.Expect(c.GroupVersionKind).To(Equal(gvk.VirtualService))
 		g.Expect(c.Name).To(Equal("test-cluster-local-http-route-" + constants.KubernetesGatewayName))
 		g.Expect(c.Namespace).To(Equal("ns1"))
 		g.Expect(c.Spec).To(Equal(expectedvs))

--- a/pilot/pkg/config/kube/gateway/conversion_test.go
+++ b/pilot/pkg/config/kube/gateway/conversion_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ghodss/yaml"
 
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
 
 	"istio.io/istio/pilot/pkg/config/kube/crd"
 	"istio.io/istio/pilot/pkg/model"
@@ -59,9 +60,9 @@ func splitOutput(configs []model.Config) IstioResources {
 	}
 	for _, c := range configs {
 		switch c.GroupVersionKind {
-		case gatewayType.GroupVersionKind():
+		case gvk.Gateway:
 			out.Gateway = append(out.Gateway, c)
-		case vsType.GroupVersionKind():
+		case gvk.VirtualService:
 			out.VirtualService = append(out.VirtualService, c)
 		}
 	}

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -47,6 +47,7 @@ import (
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/istio/pkg/listwatch"
 	"istio.io/istio/pkg/queue"
@@ -80,9 +81,6 @@ var (
 	schemas = collection.SchemasFor(
 		collections.IstioNetworkingV1Alpha3Virtualservices,
 		collections.IstioNetworkingV1Alpha3Gateways)
-
-	virtualServiceGvk = collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind()
-	gatewayGvk        = collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind()
 )
 
 // Control needs RBAC permissions to write to Pods.
@@ -223,14 +221,14 @@ func (c *controller) onEvent(obj interface{}, event model.Event) error {
 	for _, f := range c.virtualServiceHandlers {
 		f(model.Config{}, model.Config{
 			ConfigMeta: model.ConfigMeta{
-				GroupVersionKind: virtualServiceGvk,
+				GroupVersionKind: gvk.VirtualService,
 			},
 		}, event)
 	}
 	for _, f := range c.gatewayHandlers {
 		f(model.Config{}, model.Config{
 			ConfigMeta: model.ConfigMeta{
-				GroupVersionKind: gatewayGvk,
+				GroupVersionKind: gvk.Gateway,
 			},
 		}, event)
 	}
@@ -240,9 +238,9 @@ func (c *controller) onEvent(obj interface{}, event model.Event) error {
 
 func (c *controller) RegisterEventHandler(kind resource.GroupVersionKind, f func(model.Config, model.Config, model.Event)) {
 	switch kind {
-	case virtualServiceGvk:
+	case gvk.VirtualService:
 		c.virtualServiceHandlers = append(c.virtualServiceHandlers, f)
-	case gatewayGvk:
+	case gvk.Gateway:
 		c.gatewayHandlers = append(c.gatewayHandlers, f)
 	}
 }
@@ -290,8 +288,8 @@ func (c *controller) Get(typ resource.GroupVersionKind, name, namespace string) 
 }
 
 func (c *controller) List(typ resource.GroupVersionKind, namespace string) ([]model.Config, error) {
-	if typ != collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind() &&
-		typ != collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind() {
+	if typ != gvk.Gateway &&
+		typ != gvk.VirtualService {
 		return nil, errUnsupportedOp
 	}
 
@@ -313,15 +311,15 @@ func (c *controller) List(typ resource.GroupVersionKind, namespace string) ([]mo
 		}
 
 		switch typ {
-		case virtualServiceGvk:
+		case gvk.VirtualService:
 			ConvertIngressVirtualService(*ingress, c.domainSuffix, ingressByHost)
-		case gatewayGvk:
+		case gvk.Gateway:
 			gateways := ConvertIngressV1alpha3(*ingress, c.meshWatcher.Mesh(), c.domainSuffix)
 			out = append(out, gateways)
 		}
 	}
 
-	if typ == virtualServiceGvk {
+	if typ == gvk.VirtualService {
 		for _, obj := range ingressByHost {
 			out = append(out, *obj)
 		}

--- a/pilot/pkg/config/kube/ingress/conversion.go
+++ b/pilot/pkg/config/kube/ingress/conversion.go
@@ -33,6 +33,7 @@ import (
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/config/schema/gvk"
 )
 
 const (
@@ -120,7 +121,7 @@ func ConvertIngressV1alpha3(ingress v1beta1.Ingress, mesh *meshconfig.MeshConfig
 
 	gatewayConfig := model.Config{
 		ConfigMeta: model.ConfigMeta{
-			GroupVersionKind: gatewayGvk,
+			GroupVersionKind: gvk.Gateway,
 			Name:             ingress.Name + "-" + constants.IstioIngressGatewayName,
 			Namespace:        ingressNamespace,
 			Domain:           domainSuffix,
@@ -199,7 +200,7 @@ func ConvertIngressVirtualService(ingress v1beta1.Ingress, domainSuffix string, 
 
 		virtualServiceConfig := model.Config{
 			ConfigMeta: model.ConfigMeta{
-				GroupVersionKind: virtualServiceGvk,
+				GroupVersionKind: gvk.VirtualService,
 				Name:             namePrefix + "-" + ingress.Name + "-" + constants.IstioIngressGatewayName,
 				Namespace:        ingress.Namespace,
 				Domain:           domainSuffix,

--- a/pilot/pkg/config/monitor/monitor_test.go
+++ b/pilot/pkg/config/monitor/monitor_test.go
@@ -27,15 +27,14 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
 )
-
-var gatewayGvk = collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind()
 
 var createConfigSet = []*model.Config{
 	{
 		ConfigMeta: model.ConfigMeta{
 			Name:             "magic",
-			GroupVersionKind: gatewayGvk,
+			GroupVersionKind: gvk.Gateway,
 		},
 		Spec: &networking.Gateway{
 			Servers: []*networking.Server{
@@ -56,7 +55,7 @@ var updateConfigSet = []*model.Config{
 	{
 		ConfigMeta: model.ConfigMeta{
 			Name:             "magic",
-			GroupVersionKind: gatewayGvk,
+			GroupVersionKind: gvk.Gateway,
 		},
 		Spec: &networking.Gateway{
 			Servers: []*networking.Server{
@@ -110,7 +109,7 @@ func TestMonitorForChange(t *testing.T) {
 		}
 	}()
 	g.Eventually(func() error {
-		c, err := store.List(gatewayGvk, "")
+		c, err := store.List(gvk.Gateway, "")
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		if len(c) != 1 {
@@ -125,7 +124,7 @@ func TestMonitorForChange(t *testing.T) {
 	}).Should(gomega.Succeed())
 
 	g.Eventually(func() error {
-		c, err := store.List(gatewayGvk, "")
+		c, err := store.List(gvk.Gateway, "")
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 		if len(c) == 0 {
 			return errors.New("no config")
@@ -140,7 +139,7 @@ func TestMonitorForChange(t *testing.T) {
 	}).Should(gomega.Succeed())
 
 	g.Eventually(func() ([]model.Config, error) {
-		return store.List(gatewayGvk, "")
+		return store.List(gvk.Gateway, "")
 	}).Should(gomega.HaveLen(0))
 
 }
@@ -187,7 +186,7 @@ func TestMonitorForError(t *testing.T) {
 	//nil data return and error return keeps the existing data aka createConfigSet
 	<-delay
 	g.Eventually(func() error {
-		c, err := store.List(gatewayGvk, "")
+		c, err := store.List(gvk.Gateway, "")
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		if len(c) != 1 {

--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -22,6 +22,7 @@ import (
 
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
 )
 
 // MutualTLSMode is the mutule TLS mode specified by authentication policy.
@@ -90,7 +91,7 @@ func initAuthenticationPolicies(env *Environment) (*AuthenticationPolicies, erro
 	}
 
 	if configs, err := env.List(
-		collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind(), NamespaceAll); err == nil {
+		gvk.RequestAuthentication, NamespaceAll); err == nil {
 		sortConfigByCreationTime(configs)
 		policy.addRequestAuthentication(configs)
 	} else {
@@ -98,7 +99,7 @@ func initAuthenticationPolicies(env *Environment) (*AuthenticationPolicies, erro
 	}
 
 	if configs, err := env.List(
-		collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind(), NamespaceAll); err == nil {
+		gvk.PeerAuthentication, NamespaceAll); err == nil {
 		policy.addPeerAuthentication(configs)
 	} else {
 		return nil, err

--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -28,6 +28,7 @@ import (
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
 )
 
 const (
@@ -35,9 +36,7 @@ const (
 )
 
 var (
-	peerAuthenticationGvk    = collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind()
-	requestAuthenticationGvk = collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind()
-	baseTimestamp            = time.Date(2020, 2, 2, 2, 2, 2, 0, time.UTC)
+	baseTimestamp = time.Date(2020, 2, 2, 2, 2, 2, 0, time.UTC)
 )
 
 func TestSdsCertificateConfigFromResourceName(t *testing.T) {
@@ -127,7 +126,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			wantRequestAuthn: []*Config{
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind: requestAuthenticationGvk,
+						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "foo",
 					},
@@ -135,7 +134,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 				},
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind: requestAuthenticationGvk,
+						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "istio-config",
 					},
@@ -145,7 +144,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			wantPeerAuthn: []*Config{
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind:  peerAuthenticationGvk,
+						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
 						Namespace:         "foo",
@@ -158,7 +157,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 				},
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind:  peerAuthenticationGvk,
+						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
 						Namespace:         "istio-config",
@@ -179,7 +178,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			wantRequestAuthn: []*Config{
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind: requestAuthenticationGvk,
+						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "bar",
 					},
@@ -187,7 +186,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 				},
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind: requestAuthenticationGvk,
+						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "istio-config",
 					},
@@ -197,7 +196,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			wantPeerAuthn: []*Config{
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind:  peerAuthenticationGvk,
+						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
 						Namespace:         "istio-config",
@@ -218,7 +217,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			wantRequestAuthn: []*Config{
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind: requestAuthenticationGvk,
+						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "istio-config",
 					},
@@ -228,7 +227,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			wantPeerAuthn: []*Config{
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind:  peerAuthenticationGvk,
+						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
 						Namespace:         "istio-config",
@@ -249,7 +248,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			wantRequestAuthn: []*Config{
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind: requestAuthenticationGvk,
+						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "foo",
 					},
@@ -257,7 +256,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 				},
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind: requestAuthenticationGvk,
+						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "with-selector",
 						Namespace:        "foo",
 					},
@@ -272,7 +271,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 				},
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind: requestAuthenticationGvk,
+						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "istio-config",
 					},
@@ -280,7 +279,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 				},
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind: requestAuthenticationGvk,
+						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "global-with-selector",
 						Namespace:        "istio-config",
 					},
@@ -296,7 +295,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			wantPeerAuthn: []*Config{
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind:  peerAuthenticationGvk,
+						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
 						Namespace:         "foo",
@@ -309,7 +308,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 				},
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind:  peerAuthenticationGvk,
+						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "peer-with-selector",
 						Namespace:         "foo",
@@ -327,7 +326,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 				},
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind:  peerAuthenticationGvk,
+						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
 						Namespace:         "istio-config",
@@ -348,7 +347,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			wantRequestAuthn: []*Config{
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind: requestAuthenticationGvk,
+						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "bar",
 					},
@@ -356,7 +355,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 				},
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind: requestAuthenticationGvk,
+						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "istio-config",
 					},
@@ -364,7 +363,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 				},
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind: requestAuthenticationGvk,
+						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "global-with-selector",
 						Namespace:        "istio-config",
 					},
@@ -380,7 +379,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			wantPeerAuthn: []*Config{
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind:  peerAuthenticationGvk,
+						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
 						Namespace:         "istio-config",
@@ -401,7 +400,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			wantRequestAuthn: []*Config{
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind: requestAuthenticationGvk,
+						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "foo",
 					},
@@ -409,7 +408,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 				},
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind: requestAuthenticationGvk,
+						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "istio-config",
 					},
@@ -417,7 +416,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 				},
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind: requestAuthenticationGvk,
+						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "global-with-selector",
 						Namespace:        "istio-config",
 					},
@@ -433,7 +432,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			wantPeerAuthn: []*Config{
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind:  peerAuthenticationGvk,
+						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
 						Namespace:         "foo",
@@ -446,7 +445,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 				},
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind:  peerAuthenticationGvk,
+						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
 						Namespace:         "istio-config",
@@ -494,7 +493,7 @@ func TestGetPoliciesForWorkloadWithoutMeshPeerAuthn(t *testing.T) {
 			wantPeerAuthn: []*Config{
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind:  peerAuthenticationGvk,
+						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
 						Namespace:         "foo",
@@ -529,7 +528,7 @@ func TestGetPoliciesForWorkloadWithoutMeshPeerAuthn(t *testing.T) {
 			wantPeerAuthn: []*Config{
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind:  peerAuthenticationGvk,
+						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
 						Namespace:         "foo",
@@ -542,7 +541,7 @@ func TestGetPoliciesForWorkloadWithoutMeshPeerAuthn(t *testing.T) {
 				},
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind:  peerAuthenticationGvk,
+						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "peer-with-selector",
 						Namespace:         "foo",
@@ -575,7 +574,7 @@ func TestGetPoliciesForWorkloadWithoutMeshPeerAuthn(t *testing.T) {
 			wantPeerAuthn: []*Config{
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind:  peerAuthenticationGvk,
+						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
 						Namespace:         "foo",
@@ -627,7 +626,7 @@ func TestGetPoliciesForWorkloadWithJwksResolver(t *testing.T) {
 			wantRequestAuthn: []*Config{
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind: requestAuthenticationGvk,
+						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        rootNamespace,
 					},
@@ -649,7 +648,7 @@ func TestGetPoliciesForWorkloadWithJwksResolver(t *testing.T) {
 			wantRequestAuthn: []*Config{
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind: requestAuthenticationGvk,
+						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        rootNamespace,
 					},
@@ -664,7 +663,7 @@ func TestGetPoliciesForWorkloadWithJwksResolver(t *testing.T) {
 				},
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind: requestAuthenticationGvk,
+						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "global-with-selector",
 						Namespace:        rootNamespace,
 					},
@@ -694,7 +693,7 @@ func TestGetPoliciesForWorkloadWithJwksResolver(t *testing.T) {
 			wantRequestAuthn: []*Config{
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind: requestAuthenticationGvk,
+						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "with-selector",
 						Namespace:        "foo",
 					},
@@ -719,7 +718,7 @@ func TestGetPoliciesForWorkloadWithJwksResolver(t *testing.T) {
 				},
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind: requestAuthenticationGvk,
+						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        rootNamespace,
 					},
@@ -734,7 +733,7 @@ func TestGetPoliciesForWorkloadWithJwksResolver(t *testing.T) {
 				},
 				{
 					ConfigMeta: ConfigMeta{
-						GroupVersionKind: requestAuthenticationGvk,
+						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "global-with-selector",
 						Namespace:        rootNamespace,
 					},

--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -31,7 +31,7 @@ import (
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/schema/collection"
-	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/resource"
 )
 
@@ -381,7 +381,7 @@ func MakeIstioStore(store ConfigStore) IstioConfigStore {
 }
 
 func (store *istioConfigStore) ServiceEntries() []Config {
-	serviceEntries, err := store.List(collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind(), NamespaceAll)
+	serviceEntries, err := store.List(gvk.ServiceEntry, NamespaceAll)
 	if err != nil {
 		return nil
 	}
@@ -404,7 +404,7 @@ func sortConfigByCreationTime(configs []Config) {
 }
 
 func (store *istioConfigStore) Gateways(workloadLabels labels.Collection) []Config {
-	configs, err := store.List(collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind(), NamespaceAll)
+	configs, err := store.List(gvk.Gateway, NamespaceAll)
 	if err != nil {
 		return nil
 	}
@@ -533,14 +533,14 @@ func filterQuotaSpecsByDestination(hostname host.Name, bindings []Config, specs 
 // associated with destination service instances.
 func (store *istioConfigStore) QuotaSpecByDestination(hostname host.Name) []Config {
 	log.Debugf("QuotaSpecByDestination(%v)", hostname)
-	bindings, err := store.List(collections.IstioMixerV1ConfigClientQuotaspecbindings.Resource().GroupVersionKind(), NamespaceAll)
+	bindings, err := store.List(gvk.QuotaSpecBinding, NamespaceAll)
 	if err != nil {
 		log.Warnf("Unable to fetch QuotaSpecBindings: %v", err)
 		return nil
 	}
 
 	log.Debugf("QuotaSpecByDestination bindings[%d] %v", len(bindings), bindings)
-	specs, err := store.List(collections.IstioMixerV1ConfigClientQuotaspecs.Resource().GroupVersionKind(), NamespaceAll)
+	specs, err := store.List(gvk.QuotaSpec, NamespaceAll)
 	if err != nil {
 		log.Warnf("Unable to fetch QuotaSpecs: %v", err)
 		return nil
@@ -552,7 +552,7 @@ func (store *istioConfigStore) QuotaSpecByDestination(hostname host.Name) []Conf
 }
 
 func (store *istioConfigStore) AuthorizationPolicies(namespace string) []Config {
-	authorizationPolicies, err := store.List(collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind(), namespace)
+	authorizationPolicies, err := store.List(gvk.AuthorizationPolicy, namespace)
 	if err != nil {
 		log.Errorf("failed to get AuthorizationPolicy in namespace %s: %v", namespace, err)
 		return nil

--- a/pilot/pkg/model/config_test.go
+++ b/pilot/pkg/model/config_test.go
@@ -33,6 +33,7 @@ import (
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/resource"
 )
 
@@ -384,7 +385,7 @@ func TestIstioConfigStore_QuotaSpecByDestination(t *testing.T) {
 	ns := "ns1"
 	l := &fakeStore{
 		cfg: map[resource.GroupVersionKind][]model.Config{
-			collections.IstioMixerV1ConfigClientQuotaspecbindings.Resource().GroupVersionKind(): {
+			gvk.QuotaSpecBinding: {
 				{
 					ConfigMeta: model.ConfigMeta{
 						Namespace: ns,
@@ -408,7 +409,7 @@ func TestIstioConfigStore_QuotaSpecByDestination(t *testing.T) {
 					},
 				},
 			},
-			collections.IstioMixerV1ConfigClientQuotaspecs.Resource().GroupVersionKind(): {
+			gvk.QuotaSpec: {
 				{
 					ConfigMeta: model.ConfigMeta{
 						Name:      "request-count",
@@ -490,7 +491,7 @@ func TestIstioConfigStore_ServiceEntries(t *testing.T) {
 	ns := "ns1"
 	l := &fakeStore{
 		cfg: map[resource.GroupVersionKind][]model.Config{
-			collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind(): {
+			gvk.ServiceEntry: {
 				{
 					ConfigMeta: model.ConfigMeta{
 						Name:      "request-count-1",
@@ -508,7 +509,7 @@ func TestIstioConfigStore_ServiceEntries(t *testing.T) {
 					},
 				},
 			},
-			collections.IstioMixerV1ConfigClientQuotaspecs.Resource().GroupVersionKind(): {
+			gvk.QuotaSpec: {
 				{
 					ConfigMeta: model.ConfigMeta{
 						Name:      "request-count-2",
@@ -568,7 +569,7 @@ func TestIstioConfigStore_Gateway(t *testing.T) {
 
 	l := &fakeStore{
 		cfg: map[resource.GroupVersionKind][]model.Config{
-			collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind(): {gw1, gw2, gw3},
+			gvk.Gateway: {gw1, gw2, gw3},
 		},
 	}
 	ii := model.MakeIstioStore(l)

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -32,6 +32,7 @@ import (
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/visibility"
 )
 
@@ -242,12 +243,6 @@ const (
 	UnknownTrigger TriggerReason = "unknown"
 	// Describes a push triggered for debugging
 	DebugTrigger TriggerReason = "debug"
-)
-
-var (
-	ServiceEntryKind    = collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind()
-	VirtualServiceKind  = collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind()
-	DestinationRuleKind = collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind()
 )
 
 // Merge two update requests together
@@ -900,25 +895,25 @@ func (ps *PushContext) updateContext(
 
 	for conf := range pushReq.ConfigsUpdated {
 		switch conf.Kind {
-		case ServiceEntryKind:
+		case gvk.ServiceEntry:
 			servicesChanged = true
-		case DestinationRuleKind:
+		case gvk.DestinationRule:
 			destinationRulesChanged = true
-		case VirtualServiceKind:
+		case gvk.VirtualService:
 			virtualServicesChanged = true
-		case collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind():
+		case gvk.Gateway:
 			gatewayChanged = true
-		case collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind():
+		case gvk.Sidecar:
 			sidecarsChanged = true
-		case collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind():
+		case gvk.EnvoyFilter:
 			envoyFiltersChanged = true
-		case collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind():
+		case gvk.AuthorizationPolicy:
 			authzChanged = true
-		case collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind(),
-			collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind():
+		case gvk.RequestAuthentication,
+			gvk.PeerAuthentication:
 			authnChanged = true
-		case collections.IstioMixerV1ConfigClientQuotaspecbindings.Resource().GroupVersionKind(),
-			collections.IstioMixerV1ConfigClientQuotaspecs.Resource().GroupVersionKind():
+		case gvk.QuotaSpecBinding,
+			gvk.QuotaSpec:
 			quotasChanged = true
 		case collections.K8SServiceApisV1Alpha1Trafficsplits.Resource().GroupVersionKind(),
 			collections.K8SServiceApisV1Alpha1Httproutes.Resource().GroupVersionKind(),
@@ -1110,7 +1105,7 @@ func (ps *PushContext) initVirtualServices(env *Environment) error {
 	ps.privateVirtualServicesByNamespace = map[string][]Config{}
 	ps.virtualServicesExportedToNamespace = map[string][]Config{}
 	ps.publicVirtualServices = []Config{}
-	virtualServices, err := env.List(collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(), NamespaceAll)
+	virtualServices, err := env.List(gvk.VirtualService, NamespaceAll)
 	if err != nil {
 		return err
 	}
@@ -1286,7 +1281,7 @@ func (ps *PushContext) initDefaultExportMaps() {
 // with the proxy and derive listeners/routes/clusters based on the sidecar
 // scope.
 func (ps *PushContext) initSidecarScopes(env *Environment) error {
-	sidecarConfigs, err := env.List(collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind(), NamespaceAll)
+	sidecarConfigs, err := env.List(gvk.Sidecar, NamespaceAll)
 	if err != nil {
 		return err
 	}
@@ -1348,7 +1343,7 @@ func (ps *PushContext) initSidecarScopes(env *Environment) error {
 
 // Split out of DestinationRule expensive conversions - once per push.
 func (ps *PushContext) initDestinationRules(env *Environment) error {
-	configs, err := env.List(collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(), NamespaceAll)
+	configs, err := env.List(gvk.DestinationRule, NamespaceAll)
 	if err != nil {
 		return err
 	}
@@ -1448,7 +1443,7 @@ func (ps *PushContext) initAuthorizationPolicies(env *Environment) error {
 
 // pre computes envoy filters per namespace
 func (ps *PushContext) initEnvoyFilters(env *Environment) error {
-	envoyFilterConfigs, err := env.List(collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind(), NamespaceAll)
+	envoyFilterConfigs, err := env.List(gvk.EnvoyFilter, NamespaceAll)
 	if err != nil {
 		return err
 	}
@@ -1531,7 +1526,7 @@ func (ps *PushContext) EnvoyFilters(proxy *Proxy) *EnvoyFilterWrapper {
 
 // pre computes gateways per namespace
 func (ps *PushContext) initGateways(env *Environment) error {
-	gatewayConfigs, err := env.List(collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind(), NamespaceAll)
+	gatewayConfigs, err := env.List(gvk.Gateway, NamespaceAll)
 	if err != nil {
 		return err
 	}
@@ -1665,13 +1660,13 @@ func (ps *PushContext) initClusterLocalHosts(e *Environment) {
 
 func (ps *PushContext) initQuotaSpecs(env *Environment) error {
 	var err error
-	ps.QuotaSpec, err = env.List(collections.IstioMixerV1ConfigClientQuotaspecs.Resource().GroupVersionKind(), NamespaceAll)
+	ps.QuotaSpec, err = env.List(gvk.QuotaSpec, NamespaceAll)
 	return err
 }
 
 func (ps *PushContext) initQuotaSpecBindings(env *Environment) error {
 	var err error
-	ps.QuotaSpecBinding, err = env.List(collections.IstioMixerV1ConfigClientQuotaspecbindings.Resource().GroupVersionKind(), NamespaceAll)
+	ps.QuotaSpecBinding, err = env.List(gvk.QuotaSpecBinding, NamespaceAll)
 	return err
 }
 

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/resource"
 
 	"istio.io/istio/pkg/config/constants"
@@ -33,9 +34,9 @@ const (
 )
 
 var sidecarScopeKnownConfigTypes = map[resource.GroupVersionKind]struct{}{
-	ServiceEntryKind:    {},
-	VirtualServiceKind:  {},
-	DestinationRuleKind: {},
+	gvk.ServiceEntry:    {},
+	gvk.VirtualService:  {},
+	gvk.DestinationRule: {},
 }
 
 // SidecarScope is a wrapper over the Sidecar resource with some
@@ -167,7 +168,7 @@ func DefaultSidecarScopeForNamespace(ps *PushContext, configNamespace string) *S
 			out.destinationRules[s.Hostname] = dr
 		}
 		out.AddConfigDependencies(ConfigKey{
-			Kind:      ServiceEntryKind,
+			Kind:      gvk.ServiceEntry,
 			Name:      string(s.Hostname),
 			Namespace: s.Attributes.Namespace,
 		})
@@ -175,7 +176,7 @@ func DefaultSidecarScopeForNamespace(ps *PushContext, configNamespace string) *S
 
 	for _, dr := range out.destinationRules {
 		out.AddConfigDependencies(ConfigKey{
-			Kind:      DestinationRuleKind,
+			Kind:      gvk.DestinationRule,
 			Name:      dr.Name,
 			Namespace: dr.Namespace,
 		})
@@ -184,7 +185,7 @@ func DefaultSidecarScopeForNamespace(ps *PushContext, configNamespace string) *S
 	for _, el := range out.EgressListeners {
 		for _, vs := range el.virtualServices {
 			out.AddConfigDependencies(ConfigKey{
-				Kind:      VirtualServiceKind,
+				Kind:      gvk.VirtualService,
 				Name:      vs.Name,
 				Namespace: vs.Namespace,
 			})
@@ -232,7 +233,7 @@ func ConvertToSidecarScope(ps *PushContext, sidecarConfig *Config, configNamespa
 		if foundSvc, found := servicesAdded[s.Hostname]; !found {
 			servicesAdded[s.Hostname] = s
 			out.AddConfigDependencies(ConfigKey{
-				Kind:      ServiceEntryKind,
+				Kind:      gvk.ServiceEntry,
 				Name:      string(s.Hostname),
 				Namespace: s.Attributes.Namespace,
 			})
@@ -269,7 +270,7 @@ func ConvertToSidecarScope(ps *PushContext, sidecarConfig *Config, configNamespa
 		for _, vs := range listener.virtualServices {
 			v := vs.Spec.(*networking.VirtualService)
 			out.AddConfigDependencies(ConfigKey{
-				Kind:      VirtualServiceKind,
+				Kind:      gvk.VirtualService,
 				Name:      vs.Name,
 				Namespace: vs.Namespace,
 			})
@@ -313,7 +314,7 @@ func ConvertToSidecarScope(ps *PushContext, sidecarConfig *Config, configNamespa
 		if dr != nil {
 			out.destinationRules[s.Hostname] = dr
 			out.AddConfigDependencies(ConfigKey{
-				Kind:      DestinationRuleKind,
+				Kind:      gvk.DestinationRule,
 				Name:      dr.Name,
 				Namespace: dr.Namespace,
 			})

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
 
 	"istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
@@ -1211,9 +1212,9 @@ func TestContainsEgressDependencies(t *testing.T) {
 
 	allContains := func(ns string, contains bool) map[ConfigKey]bool {
 		return map[ConfigKey]bool{
-			{ServiceEntryKind, svcName, ns}:   contains,
-			{VirtualServiceKind, vsName, ns}:  contains,
-			{DestinationRuleKind, drName, ns}: contains,
+			{gvk.ServiceEntry, svcName, ns}:   contains,
+			{gvk.VirtualService, vsName, ns}:  contains,
+			{gvk.DestinationRule, drName, ns}: contains,
 		}
 	}
 

--- a/pilot/pkg/networking/apigen/apigen.go
+++ b/pilot/pkg/networking/apigen/apigen.go
@@ -21,6 +21,7 @@ import (
 	golangany "github.com/golang/protobuf/ptypes/any"
 
 	"istio.io/istio/pilot/pkg/serviceregistry"
+	"istio.io/istio/pkg/config/schema/gvk"
 
 	mcp "istio.io/api/mcp/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
@@ -65,15 +66,15 @@ func (g *APIGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *
 	// The actual type in the Any should be a real proto - which is based on the generated package name.
 	// For example: type is for Any is 'type.googlepis.com/istio.networking.v1alpha3.EnvoyFilter
 	// We use: networking.istio.io/v1alpha3/EnvoyFilter
-	gvk := strings.SplitN(w.TypeUrl, "/", 3)
-	if len(gvk) == 3 {
+	kind := strings.SplitN(w.TypeUrl, "/", 3)
+	if len(kind) == 3 {
 		// TODO: extra validation may be needed - at least logging that a resource
 		// of unknown type was requested. This should not be an error - maybe client asks
 		// for a valid CRD we just don't know about. An empty set indicates we have no such config.
 		rgvk := resource.GroupVersionKind{
-			Group:   gvk[0],
-			Version: gvk[1],
-			Kind:    gvk[2],
+			Group:   kind[0],
+			Version: kind[1],
+			Kind:    kind[2],
 		}
 		if w.TypeUrl == collections.IstioMeshV1Alpha1MeshConfig.Resource().GroupVersionKind().String() {
 			meshAny, err := gogotypes.MarshalAny(push.Mesh)

--- a/pilot/pkg/networking/apigen/apigen.go
+++ b/pilot/pkg/networking/apigen/apigen.go
@@ -118,7 +118,7 @@ func (g *APIGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *
 
 		// TODO: MeshConfig, current dynamic ProxyConfig (for this proxy), Networks
 
-		if w.TypeUrl == collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind().String() {
+		if w.TypeUrl == gvk.ServiceEntry.String() {
 			// Include 'synthetic' SE - but without the endpoints. Used to generate CDS, LDS.
 			// EDS is pass-through.
 			svcs := push.Services(proxy)

--- a/pilot/pkg/networking/apigen/apigen_test.go
+++ b/pilot/pkg/networking/apigen/apigen_test.go
@@ -27,6 +27,7 @@ import (
 	"istio.io/istio/pilot/pkg/proxy/envoy/xds"
 	"istio.io/istio/pkg/adsc"
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
 
 	_ "google.golang.org/grpc/xds/experimental" // To install the xds resolvers and balancers.
 )
@@ -89,7 +90,7 @@ func TestAPIGen(t *testing.T) {
 
 		adscConn.WatchConfig()
 
-		_, err = adscConn.WaitVersion(10*time.Second, collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind().String(), "")
+		_, err = adscConn.WaitVersion(10*time.Second, gvk.ServiceEntry.String(), "")
 		if err != nil {
 			t.Fatal("Failed to receive lds", err)
 		}
@@ -98,7 +99,7 @@ func TestAPIGen(t *testing.T) {
 		for _, se := range ses {
 			t.Log(se)
 		}
-		sec, _ := adscConn.Store.List(collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind(), "")
+		sec, _ := adscConn.Store.List(gvk.EnvoyFilter, "")
 		for _, se := range sec {
 			t.Log(se)
 		}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -35,6 +35,7 @@ import (
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/resource"
 )
 
@@ -212,7 +213,7 @@ func TestApplyDestinationRule(t *testing.T) {
 
 			configStore := &fakes.IstioConfigStore{
 				ListStub: func(typ resource.GroupVersionKind, namespace string) (configs []model.Config, e error) {
-					if typ == collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind() {
+					if typ == gvk.DestinationRule {
 						if tt.destRule != nil {
 							return []model.Config{
 								{ConfigMeta: model.ConfigMeta{

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -50,6 +50,7 @@ import (
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/resource"
 )
 
@@ -373,7 +374,7 @@ func buildTestClustersWithProxyMetadataWithIps(serviceHostname string, serviceRe
 
 	configStore := &fakes.IstioConfigStore{
 		ListStub: func(typ resource.GroupVersionKind, namespace string) (configs []model.Config, e error) {
-			if typ == collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind() {
+			if typ == gvk.DestinationRule {
 				return []model.Config{
 					{ConfigMeta: model.ConfigMeta{
 						GroupVersionKind: collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(),
@@ -382,7 +383,7 @@ func buildTestClustersWithProxyMetadataWithIps(serviceHostname string, serviceRe
 						Spec: destRule,
 					}}, nil
 			}
-			if typ == collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind() && peerAuthn != nil {
+			if typ == gvk.PeerAuthentication && peerAuthn != nil {
 				policyName := "default"
 				if peerAuthn.Selector != nil {
 					policyName = "acme"
@@ -1964,7 +1965,7 @@ func TestBuildInboundClustersPortLevelCircuitBreakerThresholds(t *testing.T) {
 
 			configStore := &fakes.IstioConfigStore{
 				ListStub: func(typ resource.GroupVersionKind, namespace string) (configs []model.Config, e error) {
-					if typ == collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind() {
+					if typ == gvk.DestinationRule {
 						return []model.Config{
 							{ConfigMeta: model.ConfigMeta{
 								GroupVersionKind: collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(),

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
@@ -45,7 +45,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/fakes"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pkg/config/mesh"
-	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/istio/pkg/test/env"
 )
@@ -62,7 +62,7 @@ var (
 func buildEnvoyFilterConfigStore(configPatches []*networking.EnvoyFilter_EnvoyConfigObjectPatch) *fakes.IstioConfigStore {
 	return &fakes.IstioConfigStore{
 		ListStub: func(kind resource.GroupVersionKind, namespace string) (configs []model.Config, e error) {
-			if kind == collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind() {
+			if kind == gvk.EnvoyFilter {
 				// to emulate returning multiple envoy filter configs
 				for i, cp := range configPatches {
 					configs = append(configs, model.Config{

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -36,6 +36,7 @@ import (
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/istio/pkg/proto"
 )
@@ -1121,9 +1122,9 @@ func buildEnv(t *testing.T, gateways []pilot_model.Config, virtualServices []pil
 	configStore.GatewaysReturns(gateways)
 	configStore.ListStub = func(kind resource.GroupVersionKind, namespace string) (configs []pilot_model.Config, e error) {
 		switch kind {
-		case collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind():
+		case gvk.VirtualService:
 			return virtualServices, nil
-		case collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind():
+		case gvk.Gateway:
 			return gateways, nil
 		default:
 			return nil, nil

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
@@ -34,7 +34,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/util"
 	xdsfilters "istio.io/istio/pilot/pkg/proxy/envoy/filters"
 	"istio.io/istio/pkg/config/protocol"
-	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/resource"
 )
 
@@ -588,7 +588,7 @@ func buildPatchStruct(config string) *types.Struct {
 func buildEnvoyFilterConfigStore(configPatches []*networking.EnvoyFilter_EnvoyConfigObjectPatch) *fakes.IstioConfigStore {
 	return &fakes.IstioConfigStore{
 		ListStub: func(kind resource.GroupVersionKind, namespace string) (configs []model.Config, e error) {
-			if kind == collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind() {
+			if kind == gvk.EnvoyFilter {
 				// to emulate returning multiple envoy filter configs
 				for i, cp := range configPatches {
 					configs = append(configs, model.Config{

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -56,6 +56,7 @@ import (
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/resource"
 )
 
@@ -2313,13 +2314,13 @@ func buildListenerEnvWithVirtualServices(services []*model.Service, virtualServi
 	configStore := &fakes.IstioConfigStore{
 		ListStub: func(kind resource.GroupVersionKind, namespace string) (configs []model.Config, e error) {
 			switch kind {
-			case collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind():
+			case gvk.VirtualService:
 				result := make([]model.Config, len(virtualServices))
 				for i := range virtualServices {
 					result[i] = *virtualServices[i]
 				}
 				return result, nil
-			case collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind():
+			case gvk.EnvoyFilter:
 				return []model.Config{envoyFilter}, nil
 			default:
 				return nil, nil
@@ -2580,7 +2581,7 @@ func TestOutboundRateLimitedThriftListenerConfig(t *testing.T) {
 
 	configStore := &fakes.IstioConfigStore{
 		ListStub: func(kind resource.GroupVersionKind, s string) (configs []model.Config, err error) {
-			if kind.String() == collections.IstioMixerV1ConfigClientQuotaspecs.Resource().GroupVersionKind().String() {
+			if kind.String() == gvk.QuotaSpec.String() {
 				return []model.Config{
 					{
 						ConfigMeta: model.ConfigMeta{
@@ -2591,7 +2592,7 @@ func TestOutboundRateLimitedThriftListenerConfig(t *testing.T) {
 						Spec: quotaSpec,
 					},
 				}, nil
-			} else if kind.String() == collections.IstioMixerV1ConfigClientQuotaspecbindings.Resource().GroupVersionKind().String() {
+			} else if kind.String() == gvk.QuotaSpecBinding.String() {
 				return []model.Config{
 					{
 						ConfigMeta: model.ConfigMeta{

--- a/pilot/pkg/networking/plugin/mixer/mixer_test.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer_test.go
@@ -36,6 +36,7 @@ import (
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/resource"
 )
 
@@ -364,7 +365,7 @@ func TestModifyOutboundRouteConfig(t *testing.T) {
 	ns := "ns3"
 	l := &fakeStore{
 		cfg: map[resource.GroupVersionKind][]model.Config{
-			collections.IstioMixerV1ConfigClientQuotaspecbindings.Resource().GroupVersionKind(): {
+			gvk.QuotaSpecBinding: {
 				{
 					ConfigMeta: model.ConfigMeta{
 						Namespace: ns,
@@ -385,7 +386,7 @@ func TestModifyOutboundRouteConfig(t *testing.T) {
 					},
 				},
 			},
-			collections.IstioMixerV1ConfigClientQuotaspecs.Resource().GroupVersionKind(): {
+			gvk.QuotaSpec: {
 				{
 					ConfigMeta: model.ConfigMeta{
 						Name:      "request-count",

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -35,6 +35,7 @@ import (
 
 	istiolog "istio.io/pkg/log"
 
+	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/security/pkg/server/ca/authenticate"
 
 	"istio.io/istio/pilot/pkg/model"
@@ -654,7 +655,7 @@ func (s *DiscoveryServer) pushConnection(con *XdsConnection, pushEv *XdsEvent) e
 			adsLog.Debugf("Skipping EDS push to %v, no updates required", con.ConID)
 			return nil
 		}
-		edsUpdatedServices := model.ConfigNamesOfKind(pushEv.configsUpdated, model.ServiceEntryKind)
+		edsUpdatedServices := model.ConfigNamesOfKind(pushEv.configsUpdated, gvk.ServiceEntry)
 		// Push only EDS. This is indexed already - push immediately
 		// (may need a throttle)
 		if len(con.Clusters) > 0 && len(edsUpdatedServices) > 0 {

--- a/pilot/pkg/proxy/envoy/v2/ads_test.go
+++ b/pilot/pkg/proxy/envoy/v2/ads_test.go
@@ -31,7 +31,7 @@ import (
 	v3 "istio.io/istio/pilot/pkg/proxy/envoy/v3"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
-	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/tests/util"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
@@ -336,7 +336,7 @@ func TestAdsPushScoping(t *testing.T) {
 			hostname := host.Name(name)
 			server.EnvoyXdsServer.MemRegistry.RemoveService(hostname)
 			configsUpdated[model.ConfigKey{
-				Kind:      model.ServiceEntryKind,
+				Kind:      gvk.ServiceEntry,
 				Name:      string(hostname),
 				Namespace: ns,
 			}] = struct{}{}
@@ -360,7 +360,7 @@ func TestAdsPushScoping(t *testing.T) {
 		for _, name := range names {
 			hostname := host.Name(name)
 			configsUpdated[model.ConfigKey{
-				Kind:      model.ServiceEntryKind,
+				Kind:      gvk.ServiceEntry,
 				Name:      string(hostname),
 				Namespace: ns,
 			}] = struct{}{}
@@ -397,14 +397,14 @@ func TestAdsPushScoping(t *testing.T) {
 		}
 
 		server.EnvoyXdsServer.ConfigUpdate(&model.PushRequest{Full: false, ConfigsUpdated: map[model.ConfigKey]struct{}{
-			{Kind: model.ServiceEntryKind, Name: string(hostname), Namespace: model.IstioDefaultConfigNamespace}: {},
+			{Kind: gvk.ServiceEntry, Name: string(hostname), Namespace: model.IstioDefaultConfigNamespace}: {},
 		}})
 	}
 
 	addVirtualService := func(i int, hosts ...string) {
 		if _, err := server.EnvoyXdsServer.MemConfigController.Create(model.Config{
 			ConfigMeta: model.ConfigMeta{
-				GroupVersionKind: model.VirtualServiceKind,
+				GroupVersionKind: gvk.VirtualService,
 				Name:             fmt.Sprintf("vs%d", i), Namespace: model.IstioDefaultConfigNamespace},
 			Spec: &networking.VirtualService{
 				Hosts: hosts,
@@ -420,12 +420,12 @@ func TestAdsPushScoping(t *testing.T) {
 		}
 	}
 	removeVirtualService := func(i int) {
-		server.EnvoyXdsServer.MemConfigController.Delete(model.VirtualServiceKind, fmt.Sprintf("vs%d", i), model.IstioDefaultConfigNamespace)
+		server.EnvoyXdsServer.MemConfigController.Delete(gvk.VirtualService, fmt.Sprintf("vs%d", i), model.IstioDefaultConfigNamespace)
 	}
 	addDestinationRule := func(i int, host string) {
 		if _, err := server.EnvoyXdsServer.MemConfigController.Create(model.Config{
 			ConfigMeta: model.ConfigMeta{
-				GroupVersionKind: model.DestinationRuleKind,
+				GroupVersionKind: gvk.DestinationRule,
 				Name:             fmt.Sprintf("dr%d", i), Namespace: model.IstioDefaultConfigNamespace},
 			Spec: &networking.DestinationRule{
 				Host:     host,
@@ -436,7 +436,7 @@ func TestAdsPushScoping(t *testing.T) {
 		}
 	}
 	removeDestinationRule := func(i int) {
-		server.EnvoyXdsServer.MemConfigController.Delete(model.DestinationRuleKind, fmt.Sprintf("dr%d", i), model.IstioDefaultConfigNamespace)
+		server.EnvoyXdsServer.MemConfigController.Delete(gvk.DestinationRule, fmt.Sprintf("dr%d", i), model.IstioDefaultConfigNamespace)
 	}
 
 	sc := &networking.Sidecar{
@@ -446,10 +446,9 @@ func TestAdsPushScoping(t *testing.T) {
 			},
 		},
 	}
-	sidecarKind := collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind()
 	if _, err := server.EnvoyXdsServer.MemConfigController.Create(model.Config{
 		ConfigMeta: model.ConfigMeta{
-			GroupVersionKind: sidecarKind,
+			GroupVersionKind: gvk.Sidecar,
 			Name:             "sc", Namespace: model.IstioDefaultConfigNamespace},
 		Spec: sc,
 	}); err != nil {

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -34,6 +34,7 @@ import (
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/config/schema/gvk"
 )
 
 // EDS returns the list of endpoints (IP:port and in future labels) associated with a real
@@ -150,7 +151,7 @@ func (s *DiscoveryServer) SvcUpdate(cluster, hostname string, namespace string, 
 // Only clusters that changed are updated/pushed.
 func (s *DiscoveryServer) edsIncremental(version string, req *model.PushRequest) {
 	adsLog.Infof("XDS:EDSInc Pushing:%s Services:%v ConnectedEndpoints:%d",
-		version, model.ConfigNamesOfKind(req.ConfigsUpdated, model.ServiceEntryKind), s.adsClientCount())
+		version, model.ConfigNamesOfKind(req.ConfigsUpdated, gvk.ServiceEntry), s.adsClientCount())
 	s.startPush(req)
 }
 
@@ -167,7 +168,7 @@ func (s *DiscoveryServer) EDSUpdate(clusterID, serviceName string, namespace str
 	s.ConfigUpdate(&model.PushRequest{
 		Full: fp,
 		ConfigsUpdated: map[model.ConfigKey]struct{}{{
-			Kind:      model.ServiceEntryKind,
+			Kind:      gvk.ServiceEntry,
 			Name:      serviceName,
 			Namespace: namespace,
 		}: {}},
@@ -399,7 +400,7 @@ func (eds *EdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w
 
 	var edsUpdatedServices map[string]struct{} = nil
 	if updates != nil {
-		edsUpdatedServices = model.ConfigNamesOfKind(updates, model.ServiceEntryKind)
+		edsUpdatedServices = model.ConfigNamesOfKind(updates, gvk.ServiceEntry)
 	}
 	// All clusters that this endpoint is watching. For 1.0 - it's typically all clusters in the mesh.
 	// For 1.1+Sidecar - it's the small set of explicitly imported clusters, using the isolated DestinationRules

--- a/pilot/pkg/proxy/envoy/v2/eds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_test.go
@@ -37,6 +37,7 @@ import (
 	"istio.io/istio/pkg/adsc"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/tests/util"
 )
@@ -383,7 +384,7 @@ func testOverlappingPorts(server *bootstrap.Server, adsc *adsc.ADSC, t *testing.
 	server.EnvoyXdsServer.Push(&model.PushRequest{
 		Full: true,
 		ConfigsUpdated: map[model.ConfigKey]struct{}{{
-			Kind: model.ServiceEntryKind,
+			Kind: gvk.ServiceEntry,
 			Name: "overlapping.cluster.local",
 		}: {}}})
 	_, _ = adsc.Wait(5 * time.Second)
@@ -654,7 +655,7 @@ func multipleRequest(server *bootstrap.Server, inc bool, nclients,
 			server.EnvoyXdsServer.AdsPushAll(strconv.Itoa(j), &model.PushRequest{
 				Full: false,
 				ConfigsUpdated: map[model.ConfigKey]struct{}{{
-					Kind: model.ServiceEntryKind,
+					Kind: gvk.ServiceEntry,
 					Name: edsIncSvc,
 				}: {}},
 				Push: server.EnvoyXdsServer.Env.PushContext,

--- a/pilot/pkg/proxy/envoy/v2/pushqueue_test.go
+++ b/pilot/pkg/proxy/envoy/v2/pushqueue_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config/schema/gvk"
 )
 
 // Helper function to remove an item or timeout and return nil if there are no pending pushes
@@ -144,7 +145,7 @@ func TestProxyQueue(t *testing.T) {
 		p.Enqueue(proxies[0], &model.PushRequest{
 			Full: false,
 			ConfigsUpdated: map[model.ConfigKey]struct{}{{
-				Kind: model.ServiceEntryKind,
+				Kind: gvk.ServiceEntry,
 				Name: "foo",
 			}: {}},
 			Start: firstTime,
@@ -153,7 +154,7 @@ func TestProxyQueue(t *testing.T) {
 		p.Enqueue(proxies[0], &model.PushRequest{
 			Full: false,
 			ConfigsUpdated: map[model.ConfigKey]struct{}{{
-				Kind:      model.ServiceEntryKind,
+				Kind:      gvk.ServiceEntry,
 				Name:      "bar",
 				Namespace: "ns1",
 			}: {}},
@@ -165,16 +166,16 @@ func TestProxyQueue(t *testing.T) {
 			t.Errorf("Expected start time to be %v, got %v", firstTime, info.Start)
 		}
 		expectedEds := map[model.ConfigKey]struct{}{{
-			Kind:      model.ServiceEntryKind,
+			Kind:      gvk.ServiceEntry,
 			Name:      "foo",
 			Namespace: "",
 		}: {}, {
-			Kind:      model.ServiceEntryKind,
+			Kind:      gvk.ServiceEntry,
 			Name:      "bar",
 			Namespace: "ns1",
 		}: {}}
-		if !reflect.DeepEqual(model.ConfigsOfKind(info.ConfigsUpdated, model.ServiceEntryKind), expectedEds) {
-			t.Errorf("Expected EdsUpdates to be %v, got %v", expectedEds, model.ConfigsOfKind(info.ConfigsUpdated, model.ServiceEntryKind))
+		if !reflect.DeepEqual(model.ConfigsOfKind(info.ConfigsUpdated, gvk.ServiceEntry), expectedEds) {
+			t.Errorf("Expected EdsUpdates to be %v, got %v", expectedEds, model.ConfigsOfKind(info.ConfigsUpdated, gvk.ServiceEntry))
 		}
 		if info.Full != false {
 			t.Errorf("Expected full to be false, got true")
@@ -227,7 +228,7 @@ func TestProxyQueue(t *testing.T) {
 				for _, pr := range proxies {
 					p.Enqueue(pr, &model.PushRequest{
 						ConfigsUpdated: map[model.ConfigKey]struct{}{{
-							Kind: model.ServiceEntryKind,
+							Kind: gvk.ServiceEntry,
 							Name: fmt.Sprintf("%d", eds),
 						}: {}}})
 				}
@@ -239,7 +240,7 @@ func TestProxyQueue(t *testing.T) {
 		go func() {
 			for {
 				con, info := p.Dequeue()
-				for eds := range model.ConfigNamesOfKind(info.ConfigsUpdated, model.ServiceEntryKind) {
+				for eds := range model.ConfigNamesOfKind(info.ConfigsUpdated, gvk.ServiceEntry) {
 					mu.Lock()
 					delete(expected, key(con, eds))
 					mu.Unlock()

--- a/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go
@@ -24,6 +24,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
+	"istio.io/istio/pkg/config/schema/gvk"
 )
 
 // Pilot can get EDS information from Kubernetes from two mutually exclusive sources, Endpoints and
@@ -64,7 +65,7 @@ func processEndpointEvent(c *Controller, epc kubeEndpointsController, name strin
 					Full: true,
 					// TODO: extend and set service instance type, so no need to re-init push context
 					ConfigsUpdated: map[model.ConfigKey]struct{}{{
-						Kind:      model.ServiceEntryKind,
+						Kind:      gvk.ServiceEntry,
 						Name:      svc.Name,
 						Namespace: svc.Namespace,
 					}: {}},

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -30,6 +30,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	"istio.io/istio/pkg/config/mesh"
+	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/kube/secretcontroller"
 )
 
@@ -185,7 +186,7 @@ func (m *Multicluster) updateHandler(svc *model.Service) {
 		req := &model.PushRequest{
 			Full: true,
 			ConfigsUpdated: map[model.ConfigKey]struct{}{{
-				Kind:      model.ServiceEntryKind,
+				Kind:      gvk.ServiceEntry,
 				Name:      string(svc.Hostname),
 				Namespace: svc.Attributes.Namespace,
 			}: {}},

--- a/pilot/pkg/serviceregistry/mcp/controller.go
+++ b/pilot/pkg/serviceregistry/mcp/controller.go
@@ -32,6 +32,7 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/istio/pkg/mcp/sink"
 )
@@ -231,7 +232,7 @@ func (c *controller) Apply(change *sink.Change) error {
 	c.configStoreMu.Unlock()
 	c.sync(change.Collection)
 
-	if kind == collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind() {
+	if kind == gvk.ServiceEntry {
 		c.serviceEntryEvents(innerStore, prevStore)
 	} else if c.options.XDSUpdater != nil {
 		c.options.XDSUpdater.ConfigUpdate(&model.PushRequest{
@@ -332,7 +333,7 @@ func (c *controller) sync(collection string) {
 
 func (c *controller) serviceEntryEvents(currentStore, prevStore map[string]map[string]*model.Config) {
 	dispatch := func(prev model.Config, model model.Config, event model.Event) {}
-	if handlers, ok := c.eventHandlers[collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind()]; ok {
+	if handlers, ok := c.eventHandlers[gvk.ServiceEntry]; ok {
 		dispatch = func(prev model.Config, config model.Config, event model.Event) {
 			log.Debugf("MCP event dispatch: key=%v event=%v", config.Key(), event.String())
 			for _, handler := range handlers {

--- a/pilot/pkg/serviceregistry/mcp/controller_test.go
+++ b/pilot/pkg/serviceregistry/mcp/controller_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	. "github.com/onsi/gomega"
 
+	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/resource"
 
 	mcpapi "istio.io/api/mcp/v1alpha1"
@@ -36,10 +37,6 @@ import (
 )
 
 var (
-	gatewayGvk        = collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind()
-	serviceEntryGvk   = collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind()
-	virtualServiceGvk = collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind()
-
 	gateway = &networking.Gateway{
 		Servers: []*networking.Server{
 			{
@@ -125,7 +122,7 @@ func TestOptions(t *testing.T) {
 	err := controller.Apply(change)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	c, err := controller.List(serviceEntryGvk, "")
+	c, err := controller.List(gvk.ServiceEntry, "")
 	g.Expect(c).ToNot(BeNil())
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(c[0].Domain).To(Equal(testControllerOptions.DomainSuffix))
@@ -159,7 +156,7 @@ func TestListCorrectTypeNoData(t *testing.T) {
 	g := NewGomegaWithT(t)
 	controller := mcp.NewController(testControllerOptions)
 
-	c, err := controller.List(virtualServiceGvk,
+	c, err := controller.List(gvk.VirtualService,
 		"some-phony-name-space.com")
 	g.Expect(c).To(BeNil())
 	g.Expect(err).ToNot(HaveOccurred())
@@ -186,12 +183,12 @@ func TestListAllNameSpace(t *testing.T) {
 	err := controller.Apply(change)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	c, err := controller.List(gatewayGvk, "")
+	c, err := controller.List(gvk.Gateway, "")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(len(c)).To(Equal(3))
 
 	for _, conf := range c {
-		g.Expect(conf.GroupVersionKind).To(Equal(gatewayGvk))
+		g.Expect(conf.GroupVersionKind).To(Equal(gvk.Gateway))
 		if conf.Name == "some-gateway1" {
 			g.Expect(conf.Spec).To(Equal(message))
 			g.Expect(conf.Namespace).To(Equal("namespace1"))
@@ -225,12 +222,12 @@ func TestListSpecificNameSpace(t *testing.T) {
 	err := controller.Apply(change)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	c, err := controller.List(gatewayGvk, "namespace1")
+	c, err := controller.List(gvk.Gateway, "namespace1")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(len(c)).To(Equal(2))
 
 	for _, conf := range c {
-		g.Expect(conf.GroupVersionKind).To(Equal(gatewayGvk))
+		g.Expect(conf.GroupVersionKind).To(Equal(gvk.Gateway))
 		g.Expect(conf.Namespace).To(Equal("namespace1"))
 		if conf.Name == "some-gateway1" {
 			g.Expect(conf.Spec).To(Equal(message))
@@ -290,11 +287,11 @@ func TestApplyValidTypeWithNoNamespace(t *testing.T) {
 		err = controller.Apply(change)
 		g.Expect(err).ToNot(HaveOccurred())
 
-		c, err := controller.List(gatewayGvk, "")
+		c, err := controller.List(gvk.Gateway, "")
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(len(c)).To(Equal(1))
 		g.Expect(c[0].Name).To(Equal("some-gateway"))
-		g.Expect(c[0].GroupVersionKind).To(Equal(gatewayGvk))
+		g.Expect(c[0].GroupVersionKind).To(Equal(gvk.Gateway))
 		g.Expect(c[0].Spec).To(Equal(message))
 		g.Expect(c[0].Spec).To(ContainSubstring(fmt.Sprintf("number:%d", port)))
 	}
@@ -318,11 +315,11 @@ func TestApplyMetadataNameIncludesNamespace(t *testing.T) {
 	err := controller.Apply(change)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	c, err := controller.List(gatewayGvk, "istio-namespace")
+	c, err := controller.List(gvk.Gateway, "istio-namespace")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(len(c)).To(Equal(1))
 	g.Expect(c[0].Name).To(Equal("some-gateway"))
-	g.Expect(c[0].GroupVersionKind).To(Equal(gatewayGvk))
+	g.Expect(c[0].GroupVersionKind).To(Equal(gvk.Gateway))
 	g.Expect(c[0].Spec).To(Equal(message))
 }
 
@@ -342,11 +339,11 @@ func TestApplyMetadataNameWithoutNamespace(t *testing.T) {
 	err := controller.Apply(change)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	c, err := controller.List(gatewayGvk, "")
+	c, err := controller.List(gvk.Gateway, "")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(len(c)).To(Equal(1))
 	g.Expect(c[0].Name).To(Equal("some-gateway"))
-	g.Expect(c[0].GroupVersionKind).To(Equal(gatewayGvk))
+	g.Expect(c[0].GroupVersionKind).To(Equal(gvk.Gateway))
 	g.Expect(c[0].Spec).To(Equal(message))
 }
 
@@ -368,11 +365,11 @@ func TestApplyChangeNoObjects(t *testing.T) {
 
 	err := controller.Apply(change)
 	g.Expect(err).ToNot(HaveOccurred())
-	c, err := controller.List(gatewayGvk, "")
+	c, err := controller.List(gvk.Gateway, "")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(len(c)).To(Equal(1))
 	g.Expect(c[0].Name).To(Equal("some-gateway"))
-	g.Expect(c[0].GroupVersionKind).To(Equal(gatewayGvk))
+	g.Expect(c[0].GroupVersionKind).To(Equal(gvk.Gateway))
 	g.Expect(c[0].Spec).To(Equal(message))
 
 	change = convertToChange([]proto.Message{},
@@ -382,7 +379,7 @@ func TestApplyChangeNoObjects(t *testing.T) {
 
 	err = controller.Apply(change)
 	g.Expect(err).ToNot(HaveOccurred())
-	c, err = controller.List(gatewayGvk, "")
+	c, err = controller.List(gvk.Gateway, "")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(len(c)).To(Equal(0))
 }
@@ -428,7 +425,7 @@ func TestInvalidResource(t *testing.T) {
 	err := controller.Apply(change)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	entries, err := controller.List(gatewayGvk, "")
+	entries, err := controller.List(gvk.Gateway, "")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(entries).To(HaveLen(0))
 }
@@ -452,7 +449,7 @@ func TestInvalidResource_BadTimestamp(t *testing.T) {
 	err := controller.Apply(change)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	entries, err := controller.List(gatewayGvk, "")
+	entries, err := controller.List(gvk.Gateway, "")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(entries).To(HaveLen(0))
 }
@@ -469,7 +466,7 @@ func TestEventHandler(t *testing.T) {
 		model.EventUpdate: {},
 		model.EventDelete: {},
 	}
-	controller.RegisterEventHandler(serviceEntryGvk, func(_, m model.Config, e model.Event) {
+	controller.RegisterEventHandler(gvk.ServiceEntry, func(_, m model.Config, e model.Event) {
 		gotEvents[e][makeName(m.Namespace, m.Name)] = m
 	})
 
@@ -501,7 +498,7 @@ func TestEventHandler(t *testing.T) {
 	makeServiceEntryModel := func(name, host, version string) model.Config {
 		return model.Config{
 			ConfigMeta: model.ConfigMeta{
-				GroupVersionKind:  serviceEntryGvk,
+				GroupVersionKind:  gvk.ServiceEntry,
 				Name:              name,
 				Namespace:         "default",
 				Domain:            "cluster.local",
@@ -758,7 +755,7 @@ func TestApplyIncrementalChangeRemove(t *testing.T) {
 	err := controller.Apply(change)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	entries, err := controller.List(gatewayGvk, "")
+	entries, err := controller.List(gvk.Gateway, "")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(entries).To(HaveLen(1))
 	g.Expect(entries[0].Name).To(Equal("test-gateway"))
@@ -776,7 +773,7 @@ func TestApplyIncrementalChangeRemove(t *testing.T) {
 	err = controller.Apply(change)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	entries, err = controller.List(gatewayGvk, "")
+	entries, err = controller.List(gvk.Gateway, "")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(entries).To(HaveLen(2))
 
@@ -784,7 +781,7 @@ func TestApplyIncrementalChangeRemove(t *testing.T) {
 	g.Expect(update).To(Equal("ConfigUpdate"))
 
 	for _, gw := range entries {
-		g.Expect(gw.GroupVersionKind).To(Equal(gatewayGvk))
+		g.Expect(gw.GroupVersionKind).To(Equal(gvk.Gateway))
 		switch gw.Name {
 		case "test-gateway":
 			g.Expect(gw.Spec).To(Equal(message))
@@ -803,7 +800,7 @@ func TestApplyIncrementalChangeRemove(t *testing.T) {
 	err = controller.Apply(change)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	entries, err = controller.List(gatewayGvk, "")
+	entries, err = controller.List(gvk.Gateway, "")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(entries).To(HaveLen(1))
 	g.Expect(entries[0].Name).To(Equal("test-gateway2"))
@@ -831,7 +828,7 @@ func TestApplyIncrementalChange(t *testing.T) {
 	err := controller.Apply(change)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	entries, err := controller.List(gatewayGvk, "")
+	entries, err := controller.List(gvk.Gateway, "")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(entries).To(HaveLen(1))
 	g.Expect(entries[0].Name).To(Equal("test-gateway"))
@@ -849,12 +846,12 @@ func TestApplyIncrementalChange(t *testing.T) {
 	err = controller.Apply(change)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	entries, err = controller.List(gatewayGvk, "")
+	entries, err = controller.List(gvk.Gateway, "")
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(entries).To(HaveLen(2))
 
 	for _, gw := range entries {
-		g.Expect(gw.GroupVersionKind).To(Equal(gatewayGvk))
+		g.Expect(gw.GroupVersionKind).To(Equal(gvk.Gateway))
 		switch gw.Name {
 		case "test-gateway":
 			g.Expect(gw.Spec).To(Equal(message))

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -20,13 +20,13 @@ import (
 
 	"istio.io/api/label"
 	networking "istio.io/api/networking/v1alpha3"
-	"istio.io/istio/pkg/config/schema/collections"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/visibility"
 	"istio.io/istio/pkg/spiffe"
 )
@@ -47,7 +47,7 @@ func convertPort(port *networking.Port) *model.Port {
 // See convertServices() for the reverse conversion, used by Istio to handle ServiceEntry configs.
 // See kube.ConvertService for the conversion from K8S to internal Service.
 func ServiceToServiceEntry(svc *model.Service) *model.Config {
-	gvk := collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind()
+	gvk := gvk.ServiceEntry
 	se := &networking.ServiceEntry{
 		// Host is fully qualified: name, namespace, domainSuffix
 		Hosts: []string{string(svc.Hostname)},

--- a/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
@@ -29,13 +29,14 @@ import (
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/spiffe"
 )
 
 var GlobalTime = time.Now()
 var httpNone = &model.Config{
 	ConfigMeta: model.ConfigMeta{
-		GroupVersionKind:  serviceEntryKind,
+		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "httpNone",
 		Namespace:         "httpNone",
 		Domain:            "svc.cluster.local",
@@ -54,7 +55,7 @@ var httpNone = &model.Config{
 
 var tcpNone = &model.Config{
 	ConfigMeta: model.ConfigMeta{
-		GroupVersionKind:  serviceEntryKind,
+		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "tcpNone",
 		Namespace:         "tcpNone",
 		CreationTimestamp: GlobalTime,
@@ -72,7 +73,7 @@ var tcpNone = &model.Config{
 
 var httpStatic = &model.Config{
 	ConfigMeta: model.ConfigMeta{
-		GroupVersionKind:  serviceEntryKind,
+		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "httpStatic",
 		Namespace:         "httpStatic",
 		CreationTimestamp: GlobalTime,
@@ -108,7 +109,7 @@ var httpStatic = &model.Config{
 // Shares the same host as httpStatic, but adds some endpoints. We expect these to be merge
 var httpStaticOverlay = &model.Config{
 	ConfigMeta: model.ConfigMeta{
-		GroupVersionKind:  serviceEntryKind,
+		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "httpStaticOverlay",
 		Namespace:         "httpStatic",
 		CreationTimestamp: GlobalTime,
@@ -131,7 +132,7 @@ var httpStaticOverlay = &model.Config{
 
 var httpDNSnoEndpoints = &model.Config{
 	ConfigMeta: model.ConfigMeta{
-		GroupVersionKind:  serviceEntryKind,
+		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "httpDNSnoEndpoints",
 		Namespace:         "httpDNSnoEndpoints",
 		CreationTimestamp: GlobalTime,
@@ -150,7 +151,7 @@ var httpDNSnoEndpoints = &model.Config{
 
 var httpDNS = &model.Config{
 	ConfigMeta: model.ConfigMeta{
-		GroupVersionKind:  serviceEntryKind,
+		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "httpDNS",
 		Namespace:         "httpDNS",
 		CreationTimestamp: GlobalTime,
@@ -185,7 +186,7 @@ var httpDNS = &model.Config{
 
 var tcpDNS = &model.Config{
 	ConfigMeta: model.ConfigMeta{
-		GroupVersionKind:  serviceEntryKind,
+		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "tcpDNS",
 		Namespace:         "tcpDNS",
 		CreationTimestamp: GlobalTime,
@@ -213,7 +214,7 @@ var tcpDNS = &model.Config{
 
 var tcpStatic = &model.Config{
 	ConfigMeta: model.ConfigMeta{
-		GroupVersionKind:  serviceEntryKind,
+		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "tcpStatic",
 		Namespace:         "tcpStatic",
 		CreationTimestamp: GlobalTime,
@@ -242,7 +243,7 @@ var tcpStatic = &model.Config{
 
 var httpNoneInternal = &model.Config{
 	ConfigMeta: model.ConfigMeta{
-		GroupVersionKind:  serviceEntryKind,
+		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "httpNoneInternal",
 		Namespace:         "httpNoneInternal",
 		CreationTimestamp: GlobalTime,
@@ -261,7 +262,7 @@ var httpNoneInternal = &model.Config{
 
 var tcpNoneInternal = &model.Config{
 	ConfigMeta: model.ConfigMeta{
-		GroupVersionKind:  serviceEntryKind,
+		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "tcpNoneInternal",
 		Namespace:         "tcpNoneInternal",
 		CreationTimestamp: GlobalTime,
@@ -280,7 +281,7 @@ var tcpNoneInternal = &model.Config{
 
 var multiAddrInternal = &model.Config{
 	ConfigMeta: model.ConfigMeta{
-		GroupVersionKind:  serviceEntryKind,
+		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "multiAddrInternal",
 		Namespace:         "multiAddrInternal",
 		CreationTimestamp: GlobalTime,
@@ -299,7 +300,7 @@ var multiAddrInternal = &model.Config{
 
 var udsLocal = &model.Config{
 	ConfigMeta: model.ConfigMeta{
-		GroupVersionKind:  serviceEntryKind,
+		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "udsLocal",
 		Namespace:         "udsLocal",
 		CreationTimestamp: GlobalTime,
@@ -320,7 +321,7 @@ var udsLocal = &model.Config{
 // ServiceEntry with a selector
 var selector = &model.Config{
 	ConfigMeta: model.ConfigMeta{
-		GroupVersionKind:  serviceEntryKind,
+		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "selector",
 		Namespace:         "selector",
 		CreationTimestamp: GlobalTime,
@@ -342,7 +343,7 @@ var selector = &model.Config{
 func createWorkloadEntry(name, namespace string, spec *networking.WorkloadEntry) *model.Config {
 	return &model.Config{
 		ConfigMeta: model.ConfigMeta{
-			GroupVersionKind:  workloadEntryKind,
+			GroupVersionKind:  gvk.WorkloadEntry,
 			Name:              name,
 			Namespace:         namespace,
 			CreationTimestamp: GlobalTime,

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
@@ -32,6 +32,7 @@ import (
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/test/util/retry"
 )
@@ -242,7 +243,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 		createConfigs([]*model.Config{httpStatic}, store, t)
 		instances := baseInstances
 		expectServiceInstances(t, sd, httpStatic, 0, instances)
-		expectEvents(t, events, Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.ConfigKey]struct{}{{Kind: serviceEntryKind, Name: httpStatic.Spec.(*networking.ServiceEntry).Hosts[0], Namespace: httpStatic.Namespace}: {}}}})
+		expectEvents(t, events, Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.ConfigKey]struct{}{{Kind: gvk.ServiceEntry, Name: httpStatic.Spec.(*networking.ServiceEntry).Hosts[0], Namespace: httpStatic.Namespace}: {}}}})
 	})
 
 	t.Run("add entry", func(t *testing.T) {
@@ -251,7 +252,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 		instances := append(baseInstances,
 			makeInstance(httpStaticOverlay, "5.5.5.5", 4567, httpStaticOverlay.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"overlay": "bar"}, PlainText))
 		expectServiceInstances(t, sd, httpStatic, 0, instances)
-		expectEvents(t, events, Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.ConfigKey]struct{}{{Kind: serviceEntryKind, Name: httpStaticOverlay.Spec.(*networking.ServiceEntry).Hosts[0], Namespace: httpStaticOverlay.Namespace}: {}}}})
+		expectEvents(t, events, Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.ConfigKey]struct{}{{Kind: gvk.ServiceEntry, Name: httpStaticOverlay.Spec.(*networking.ServiceEntry).Hosts[0], Namespace: httpStaticOverlay.Namespace}: {}}}})
 	})
 
 	t.Run("add endpoint", func(t *testing.T) {
@@ -318,7 +319,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 		// This lookup is per-namespace, so we should only see the objects in the same namespace
 		expectServiceInstances(t, sd, httpStaticOverlayUpdatedNs, 0, instances)
 		// Expect a full push, as the Service has changed
-		expectEvents(t, events, Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.ConfigKey]struct{}{{Kind: serviceEntryKind, Name: httpStaticOverlayUpdatedNs.Spec.(*networking.ServiceEntry).Hosts[0], Namespace: httpStaticOverlayUpdatedNs.Namespace}: {}}}})
+		expectEvents(t, events, Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.ConfigKey]struct{}{{Kind: gvk.ServiceEntry, Name: httpStaticOverlayUpdatedNs.Spec.(*networking.ServiceEntry).Hosts[0], Namespace: httpStaticOverlayUpdatedNs.Namespace}: {}}}})
 	})
 
 	t.Run("delete entry", func(t *testing.T) {
@@ -334,7 +335,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 		// svc update is only triggered on deletion. Also expect a full push as the service has changed
 		expectEvents(t, events,
 			Event{kind: "svcupdate", host: "*.google.com", namespace: httpStaticOverlay.Namespace},
-			Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.ConfigKey]struct{}{{Kind: serviceEntryKind, Name: "*.google.com", Namespace: httpStaticOverlayUpdated.Namespace}: {}}}})
+			Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.ConfigKey]struct{}{{Kind: gvk.ServiceEntry, Name: "*.google.com", Namespace: httpStaticOverlayUpdated.Namespace}: {}}}})
 
 		// Add back the ServiceEntry, expect these instances to get added
 		createConfigs([]*model.Config{httpStaticOverlayUpdated}, store, t)
@@ -343,7 +344,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 			makeInstance(httpStaticOverlay, "6.6.6.6", 4567, httpStaticOverlay.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"other": "bar"}, PlainText))
 		expectServiceInstances(t, sd, httpStatic, 0, instances)
 		// Service change, so we need a full push
-		expectEvents(t, events, Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.ConfigKey]struct{}{{Kind: serviceEntryKind, Name: "*.google.com", Namespace: httpStaticOverlayUpdated.Namespace}: {}}}})
+		expectEvents(t, events, Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.ConfigKey]struct{}{{Kind: gvk.ServiceEntry, Name: "*.google.com", Namespace: httpStaticOverlayUpdated.Namespace}: {}}}})
 	})
 
 	t.Run("change host", func(t *testing.T) {
@@ -371,11 +372,11 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 		}
 		expectServiceInstances(t, sd, httpStaticHost, 0, instances, instances2)
 		// Service change, so we need a full push
-		expectEvents(t, events, Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.ConfigKey]struct{}{{Kind: serviceEntryKind, Name: "other.com", Namespace: httpStaticOverlayUpdated.Namespace}: {}}}}) // service added
+		expectEvents(t, events, Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.ConfigKey]struct{}{{Kind: gvk.ServiceEntry, Name: "other.com", Namespace: httpStaticOverlayUpdated.Namespace}: {}}}}) // service added
 
 		// restore this config and remove the added host.
 		createConfigs([]*model.Config{httpStaticOverlayUpdated}, store, t)
-		expectEvents(t, events, Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.ConfigKey]struct{}{{Kind: serviceEntryKind, Name: "other.com", Namespace: httpStaticOverlayUpdated.Namespace}: {}}}}) // service deleted
+		expectEvents(t, events, Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.ConfigKey]struct{}{{Kind: gvk.ServiceEntry, Name: "other.com", Namespace: httpStaticOverlayUpdated.Namespace}: {}}}}) // service deleted
 	})
 
 	t.Run("change dns endpoints", func(t *testing.T) {
@@ -409,13 +410,13 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 		expectServiceInstances(t, sd, tcpDNS, 0, instances1)
 		// Service change, so we need a full push
 		expectEvents(t, events, Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.
-			ConfigKey]struct{}{{Kind: serviceEntryKind, Name: "tcpdns.com",
+			ConfigKey]struct{}{{Kind: gvk.ServiceEntry, Name: "tcpdns.com",
 			Namespace: tcpDNS.Namespace}: {}}}}) // service added
 
 		// now update the config
 		createConfigs([]*model.Config{tcpDNSUpdated}, store, t)
 		expectEvents(t, events, Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.
-			ConfigKey]struct{}{{Kind: serviceEntryKind, Name: "tcpdns.com",
+			ConfigKey]struct{}{{Kind: gvk.ServiceEntry, Name: "tcpdns.com",
 			Namespace: tcpDNSUpdated.Namespace}: {}}}}) // service deleted
 		expectServiceInstances(t, sd, tcpDNS, 0, instances2)
 	})
@@ -435,8 +436,8 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 		createConfigs([]*model.Config{selector1}, store, t)
 		// Service change, so we need a full push
 		expectEvents(t, events, Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.ConfigKey]struct{}{
-			{Kind: serviceEntryKind, Name: "*.google.com", Namespace: selector1.Namespace}:  {},
-			{Kind: serviceEntryKind, Name: "selector1.com", Namespace: selector1.Namespace}: {},
+			{Kind: gvk.ServiceEntry, Name: "*.google.com", Namespace: selector1.Namespace}:  {},
+			{Kind: gvk.ServiceEntry, Name: "selector1.com", Namespace: selector1.Namespace}: {},
 		}}}) // service added
 
 		selector1Updated := func() *model.Config {
@@ -449,8 +450,8 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 		}()
 		createConfigs([]*model.Config{selector1Updated}, store, t)
 		expectEvents(t, events, Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.ConfigKey]struct{}{
-			{Kind: serviceEntryKind, Name: "*.google.com", Namespace: selector1.Namespace}:  {},
-			{Kind: serviceEntryKind, Name: "selector1.com", Namespace: selector1.Namespace}: {},
+			{Kind: gvk.ServiceEntry, Name: "*.google.com", Namespace: selector1.Namespace}:  {},
+			{Kind: gvk.ServiceEntry, Name: "selector1.com", Namespace: selector1.Namespace}: {},
 		}}}) // service updated
 	})
 }

--- a/pkg/config/schema/codegen/collections.go
+++ b/pkg/config/schema/codegen/collections.go
@@ -22,6 +22,23 @@ import (
 	"istio.io/istio/pkg/config/schema/ast"
 )
 
+const staticResourceTemplate = `
+// GENERATED FILE -- DO NOT EDIT
+//
+
+package {{.PackageName}}
+
+import (
+	"istio.io/istio/pkg/config/schema/collections"
+)
+
+var (
+{{- range .Entries }}
+	{{.Resource.Kind}} = collections.{{ .Collection.VariableName }}.Resource().GroupVersionKind()
+{{- end }}
+)
+`
+
 const staticCollectionsTemplate = `
 // GENERATED FILE -- DO NOT EDIT
 //
@@ -102,6 +119,39 @@ var (
 type colEntry struct {
 	Collection *ast.Collection
 	Resource   *ast.Resource
+}
+
+func WriteGvk(packageName string, m *ast.Metadata) (string, error) {
+	entries := make([]colEntry, 0, len(m.Collections))
+	for _, c := range m.Collections {
+		if !c.Pilot {
+			continue
+		}
+		r := m.FindResourceForGroupKind(c.Group, c.Kind)
+		if r == nil {
+			return "", fmt.Errorf("failed to find resource (%s/%s) for collection %s", c.Group, c.Kind, c.Name)
+		}
+
+		entries = append(entries, colEntry{
+			Collection: c,
+			Resource:   r,
+		})
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return strings.Compare(entries[i].Collection.Name, entries[j].Collection.Name) < 0
+	})
+
+	context := struct {
+		Entries     []colEntry
+		PackageName string
+	}{
+		Entries:     entries,
+		PackageName: packageName,
+	}
+
+	// Calculate the Go packages that needs to be imported for the proto types to be registered.
+	return applyTemplate(staticResourceTemplate, context)
 }
 
 // StaticCollections generates a Go file for static-importing Proto packages, so that they get registered statically.

--- a/pkg/config/schema/codegen/tools/collections.main.go
+++ b/pkg/config/schema/codegen/tools/collections.main.go
@@ -59,21 +59,18 @@ func main() {
 
 	var contents string
 
-	if pkg == "collections" {
-		contents, err = codegen.StaticCollections(pkg, m)
-		if err != nil {
-			fmt.Printf("Error applying static init template: %v", err)
-			os.Exit(-3)
-		}
-	} else if pkg == "gvk" {
+	if pkg == "gvk" {
 		contents, err = codegen.WriteGvk(pkg, m)
 		if err != nil {
 			fmt.Printf("Error applying static init template: %v", err)
 			os.Exit(-3)
 		}
 	} else {
-		fmt.Printf("unknown pkg %v\n", pkg)
-		os.Exit(-4)
+		contents, err = codegen.StaticCollections(pkg, m)
+		if err != nil {
+			fmt.Printf("Error applying static init template: %v", err)
+			os.Exit(-3)
+		}
 	}
 
 	if err = ioutil.WriteFile(output, []byte(contents), os.ModePerm); err != nil {

--- a/pkg/config/schema/codegen/tools/collections.main.go
+++ b/pkg/config/schema/codegen/tools/collections.main.go
@@ -57,10 +57,23 @@ func main() {
 		os.Exit(-4)
 	}
 
-	contents, err := codegen.StaticCollections(pkg, m)
-	if err != nil {
-		fmt.Printf("Error applying static init template: %v", err)
-		os.Exit(-3)
+	var contents string
+
+	if pkg == "collections" {
+		contents, err = codegen.StaticCollections(pkg, m)
+		if err != nil {
+			fmt.Printf("Error applying static init template: %v", err)
+			os.Exit(-3)
+		}
+	} else if pkg == "gvk" {
+		contents, err = codegen.WriteGvk(pkg, m)
+		if err != nil {
+			fmt.Printf("Error applying static init template: %v", err)
+			os.Exit(-3)
+		}
+	} else {
+		fmt.Printf("unknown pkg %v\n", pkg)
+		os.Exit(-4)
 	}
 
 	if err = ioutil.WriteFile(output, []byte(contents), os.ModePerm); err != nil {

--- a/pkg/config/schema/collections/collections.gen.go
+++ b/pkg/config/schema/collections/collections.gen.go
@@ -971,7 +971,7 @@ var (
 			Proto:         "k8s.io.service_apis.api.v1alpha1.GatewaySpec",
 			ProtoPackage:  "sigs.k8s.io/service-apis/api/v1alpha1",
 			ClusterScoped: false,
-			ValidateProto: validation.ValidateGateway,
+			ValidateProto: validation.EmptyValidate,
 		}.MustBuild(),
 	}.MustBuild()
 

--- a/pkg/config/schema/collections/collections.gen.go
+++ b/pkg/config/schema/collections/collections.gen.go
@@ -971,7 +971,7 @@ var (
 			Proto:         "k8s.io.service_apis.api.v1alpha1.GatewaySpec",
 			ProtoPackage:  "sigs.k8s.io/service-apis/api/v1alpha1",
 			ClusterScoped: false,
-			ValidateProto: validation.EmptyValidate,
+			ValidateProto: validation.ValidateGateway,
 		}.MustBuild(),
 	}.MustBuild()
 

--- a/pkg/config/schema/generate.go
+++ b/pkg/config/schema/generate.go
@@ -27,6 +27,7 @@ package schema
 // Create collection constants
 // nolint: lll
 //go:generate go run $REPO_ROOT/pkg/config/schema/codegen/tools/collections.main.go collections metadata.yaml "$REPO_ROOT/pkg/config/schema/collections/collections.gen.go"
+//go:generate go run $REPO_ROOT/pkg/config/schema/codegen/tools/collections.main.go gvk metadata.yaml "$REPO_ROOT/pkg/config/schema/gvk/resources.gen.go"
 
 // Create snapshot constants
 // nolint: lll

--- a/pkg/config/schema/gvk/resources.gen.go
+++ b/pkg/config/schema/gvk/resources.gen.go
@@ -1,0 +1,26 @@
+
+// GENERATED FILE -- DO NOT EDIT
+//
+
+package gvk
+
+import (
+	"istio.io/istio/pkg/config/schema/collections"
+)
+
+var (
+	HTTPAPISpecBinding = collections.IstioConfigV1Alpha2Httpapispecbindings.Resource().GroupVersionKind()
+	HTTPAPISpec = collections.IstioConfigV1Alpha2Httpapispecs.Resource().GroupVersionKind()
+	QuotaSpecBinding = collections.IstioMixerV1ConfigClientQuotaspecbindings.Resource().GroupVersionKind()
+	QuotaSpec = collections.IstioMixerV1ConfigClientQuotaspecs.Resource().GroupVersionKind()
+	DestinationRule = collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind()
+	EnvoyFilter = collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind()
+	Gateway = collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind()
+	ServiceEntry = collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind()
+	Sidecar = collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind()
+	VirtualService = collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind()
+	WorkloadEntry = collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind()
+	AuthorizationPolicy = collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind()
+	PeerAuthentication = collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind()
+	RequestAuthentication = collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind()
+)


### PR DESCRIPTION
Currently the path to access GVK is so long that everyone needs to
define a local variable every time they use it. This cleans things up so
the common types are easily accessible, without redefining locally. With
https://github.com/istio/istio/pull/24831 this should ease a lot of the
pain around this area



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure