### PR TITLE
[Test Framework] Allow running kind setup manually

### DIFF
--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -36,6 +36,8 @@ setup_and_export_git_sha
 
 TOPOLOGY=SINGLE_CLUSTER
 
+PARAMS=()
+
 while (( "$#" )); do
   case "$1" in
     # Node images can be found at https://github.com/kubernetes-sigs/kind/releases
@@ -54,6 +56,10 @@ while (( "$#" )); do
     ;;
     --skip-build)
       SKIP_BUILD=true
+      shift
+    ;;
+    --manual)
+      MANUAL=true
       shift
     ;;
     --topology)
@@ -124,8 +130,18 @@ if [[ -z "${SKIP_BUILD:-}" ]]; then
 fi
 
 # If a variant is defined, update the tag accordingly
-if [[ "${VARIANT:-}" != "" ]]; then
+if [[ -n "${VARIANT:-}" ]]; then
   export TAG="${TAG}-${VARIANT}"
 fi
 
-make "${PARAMS[*]}"
+# Run the test target if provided.
+if [[ -n "${PARAMS:-}" ]]; then
+  make "${PARAMS[*]}"
+fi
+
+# Check if the user is running the clusters in manual mode.
+if [[ -n "${MANUAL:-}" ]]; then
+  echo "Running cluster(s) in manual mode. Press any key to shutdown and exit..."
+  read -rsn1
+  exit 0
+fi

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -23,6 +23,8 @@ export CLUSTER_NAMES=("${CLUSTER1_NAME}" "${CLUSTER2_NAME}" "${CLUSTER3_NAME}")
 export CLUSTER_POD_SUBNETS=(10.10.0.0/16 10.20.0.0/16 10.30.0.0/16)
 export CLUSTER_SVC_SUBNETS=(10.255.10.0/24 10.255.20.0/24 10.255.30.0/24)
 
+export ARTIFACTS="${ARTIFACTS:-$(mktemp -d)}"
+
 function setup_gcloud_credentials() {
   if [[ $(command -v gcloud) ]]; then
     gcloud auth configure-docker -q
@@ -50,7 +52,6 @@ function setup_and_export_git_sha() {
     # Use the current commit.
     GIT_SHA="$(git rev-parse --verify HEAD)"
     export GIT_SHA
-    export ARTIFACTS="${ARTIFACTS:-$(mktemp -d)}"
   fi
   GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
   export GIT_BRANCH


### PR DESCRIPTION
This provides a way to start the kind environment and just let it keep running without automatically shutting down. Useful for testing/debugging locally. The test target is also now optional, so it can be run with just `./prow/integ-suite-kind.sh --manual`.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure