### PR TITLE
replace whitelist to allowlist

### DIFF
--- a/common-protos/k8s.io/api/extensions/v1beta1/generated.proto
+++ b/common-protos/k8s.io/api/extensions/v1beta1/generated.proto
@@ -865,13 +865,13 @@ message PodSecurityPolicySpec {
   // +optional
   repeated AllowedHostPath allowedHostPaths = 17;
 
-  // allowedFlexVolumes is a whitelist of allowed Flexvolumes.  Empty or nil indicates that all
+  // allowedFlexVolumes is a allowlist of allowed Flexvolumes.  Empty or nil indicates that all
   // Flexvolumes may be used.  This parameter is effective only when the usage of the Flexvolumes
   // is allowed in the "volumes" field.
   // +optional
   repeated AllowedFlexVolume allowedFlexVolumes = 18;
 
-  // AllowedCSIDrivers is a whitelist of inline CSI drivers that must be explicitly set to be embedded within a pod spec.
+  // AllowedCSIDrivers is a allowlist of inline CSI drivers that must be explicitly set to be embedded within a pod spec.
   // An empty value indicates that any CSI driver can be used for inline ephemeral volumes.
   // +optional
   repeated AllowedCSIDriver allowedCSIDrivers = 23;
@@ -879,7 +879,7 @@ message PodSecurityPolicySpec {
   // allowedUnsafeSysctls is a list of explicitly allowed unsafe sysctls, defaults to none.
   // Each entry is either a plain sysctl name or ends in "*" in which case it is considered
   // as a prefix of allowed sysctls. Single * means all unsafe sysctls are allowed.
-  // Kubelet has to whitelist all allowed unsafe sysctls explicitly to avoid rejection.
+  // Kubelet has to allowlist all allowed unsafe sysctls explicitly to avoid rejection.
   //
   // Examples:
   // e.g. "foo/*" allows "foo/bar", "foo/baz", etc.
@@ -897,7 +897,7 @@ message PodSecurityPolicySpec {
   // +optional
   repeated string forbiddenSysctls = 20;
 
-  // AllowedProcMountTypes is a whitelist of allowed ProcMountTypes.
+  // AllowedProcMountTypes is a allowlist of allowed ProcMountTypes.
   // Empty or nil indicates that only the DefaultProcMountType may be used.
   // This requires the ProcMountType feature flag to be enabled.
   // +optional
@@ -1113,7 +1113,7 @@ message RunAsUserStrategyOptions {
 // RuntimeClassStrategyOptions define the strategy that will dictate the allowable RuntimeClasses
 // for a pod.
 message RuntimeClassStrategyOptions {
-  // allowedRuntimeClassNames is a whitelist of RuntimeClass names that may be specified on a pod.
+  // allowedRuntimeClassNames is a allowlist of RuntimeClass names that may be specified on a pod.
   // A value of "*" means that any RuntimeClass name is allowed, and must be the only item in the
   // list. An empty list requires the RuntimeClassName field to be unset.
   repeated string allowedRuntimeClassNames = 1;

--- a/common-protos/k8s.io/api/policy/v1beta1/generated.proto
+++ b/common-protos/k8s.io/api/policy/v1beta1/generated.proto
@@ -292,13 +292,13 @@ message PodSecurityPolicySpec {
   // +optional
   repeated AllowedHostPath allowedHostPaths = 17;
 
-  // allowedFlexVolumes is a whitelist of allowed Flexvolumes.  Empty or nil indicates that all
+  // allowedFlexVolumes is a allowlist of allowed Flexvolumes.  Empty or nil indicates that all
   // Flexvolumes may be used.  This parameter is effective only when the usage of the Flexvolumes
   // is allowed in the "volumes" field.
   // +optional
   repeated AllowedFlexVolume allowedFlexVolumes = 18;
 
-  // AllowedCSIDrivers is a whitelist of inline CSI drivers that must be explicitly set to be embedded within a pod spec.
+  // AllowedCSIDrivers is a allowlist of inline CSI drivers that must be explicitly set to be embedded within a pod spec.
   // An empty value indicates that any CSI driver can be used for inline ephemeral volumes.
   // This is an alpha field, and is only honored if the API server enables the CSIInlineVolume feature gate.
   // +optional
@@ -307,7 +307,7 @@ message PodSecurityPolicySpec {
   // allowedUnsafeSysctls is a list of explicitly allowed unsafe sysctls, defaults to none.
   // Each entry is either a plain sysctl name or ends in "*" in which case it is considered
   // as a prefix of allowed sysctls. Single * means all unsafe sysctls are allowed.
-  // Kubelet has to whitelist all allowed unsafe sysctls explicitly to avoid rejection.
+  // Kubelet has to allowlist all allowed unsafe sysctls explicitly to avoid rejection.
   //
   // Examples:
   // e.g. "foo/*" allows "foo/bar", "foo/baz", etc.
@@ -325,7 +325,7 @@ message PodSecurityPolicySpec {
   // +optional
   repeated string forbiddenSysctls = 20;
 
-  // AllowedProcMountTypes is a whitelist of allowed ProcMountTypes.
+  // AllowedProcMountTypes is a allowlist of allowed ProcMountTypes.
   // Empty or nil indicates that only the DefaultProcMountType may be used.
   // This requires the ProcMountType feature flag to be enabled.
   // +optional
@@ -363,7 +363,7 @@ message RunAsUserStrategyOptions {
 // RuntimeClassStrategyOptions define the strategy that will dictate the allowable RuntimeClasses
 // for a pod.
 message RuntimeClassStrategyOptions {
-  // allowedRuntimeClassNames is a whitelist of RuntimeClass names that may be specified on a pod.
+  // allowedRuntimeClassNames is a allowlist of RuntimeClass names that may be specified on a pod.
   // A value of "*" means that any RuntimeClass name is allowed, and must be the only item in the
   // list. An empty list requires the RuntimeClassName field to be unset.
   repeated string allowedRuntimeClassNames = 1;

--- a/mixer/adapter/list/config/adapter.list.config.pb.html
+++ b/mixer/adapter/list/config/adapter.list.config.pb.html
@@ -1,6 +1,6 @@
 ---
 title: List
-description: Adapter that performs whitelist or blacklist checks.
+description: Adapter that performs allowlist or blacklist checks.
 location: https://istio.io/docs/reference/config/policy-and-telemetry/adapters/list.html
 layout: protoc-gen-docs
 generator: protoc-gen-docs
@@ -9,7 +9,7 @@ aliases:
   - /docs/reference/config/adapters/list.html
 number_of_entries: 2
 ---
-<p>The <code>list</code> adapter makes it possible to perform simple whitelist or blacklist
+<p>The <code>list</code> adapter makes it possible to perform simple allowlist or blacklist
 checks. You can configure the adapter with the list to check, or you can point
 it to a URL from where the list should be fetched. Lists can be simple strings,
 IP addresses, or regex patterns.</p>
@@ -117,7 +117,7 @@ No
 <td><code>blacklist</code></td>
 <td><code>bool</code></td>
 <td>
-<p>Whether the list operates as a blacklist or a whitelist.</p>
+<p>Whether the list operates as a blacklist or a allowlist.</p>
 
 </td>
 <td>


### PR DESCRIPTION
replace whitelist to allowlist.
Associating "white" with good/allowed and "black" with bad/disallowed cannot be disentangled from systemic racism. In contrast, allowlist and denylist exactly and merely describe the functions of these fields and variables.
[ ] Docs