### PR TITLE
Fix bookinfo ingress example missing styles/js

### DIFF
--- a/samples/bookinfo/platform/kube/bookinfo-ingress.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ingress.yaml
@@ -29,6 +29,10 @@ spec:
         backend:
           serviceName: productpage
           servicePort: 9080
+      - path: /static/*
+        backend:
+          serviceName: productpage
+          servicePort: 9080
       - path: /login
         backend:
           serviceName: productpage


### PR DESCRIPTION
Bookinfo example when using Ingress was missing css and javascript because `/static` pages are not served without these rules.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure