### PR TITLE
Run operator binary as nonroot

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -22,7 +22,7 @@ SHELL := /bin/bash -o pipefail
 VERSION ?= 1.7-dev
 
 # Base version of Istio image to use
-BASE_VERSION ?= 1.7-dev.1
+BASE_VERSION ?= 1.7-dev.2
 
 export GO111MODULE ?= on
 export GOPROXY ?= https://proxy.golang.org

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -28,6 +28,10 @@ RUN apt-get update && \
    && apt-get clean \
    && rm -rf  /var/log/*log /var/lib/apt/lists/* /var/log/apt/* /var/lib/dpkg/*-old /var/cache/debconf/*-old
 
+# Create nonroot user that aligns with distroless uid/gid/path
+RUN groupadd --gid 65532 nonroot && \
+    useradd --home-dir /home/nonroot --gid 65532 nonroot
+
 # Sudoers used to allow tcpdump and other debug utilities.
 RUN useradd -m --uid 1337 istio-proxy && \
     echo "istio-proxy ALL=NOPASSWD: ALL" >> /etc/sudoers

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -30,7 +30,7 @@ RUN apt-get update && \
 
 # Create nonroot user that aligns with distroless uid/gid/path
 RUN groupadd --gid 65532 nonroot && \
-    useradd --home-dir /home/nonroot --gid 65532 nonroot
+    useradd --home-dir /home/nonroot --uid 65532 --gid 65532 nonroot
 
 # Sudoers used to allow tcpdump and other debug utilities.
 RUN useradd -m --uid 1337 istio-proxy && \

--- a/operator/docker/Dockerfile.operator
+++ b/operator/docker/Dockerfile.operator
@@ -9,7 +9,7 @@ FROM docker.io/istio/base:${BASE_VERSION} as default
 
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
-FROM gcr.io/distroless/static-debian10@sha256:4433370ec2b3b97b338674b4de5ffaef8ce5a38d1c9c0cb82403304b8718cde9 as distroless
+FROM gcr.io/distroless/static-debian10:nonroot@sha256:4433370ec2b3b97b338674b4de5ffaef8ce5a38d1c9c0cb82403304b8718cde9 as distroless
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006
@@ -20,5 +20,7 @@ COPY operator /usr/local/bin/
 
 # add operator manifests
 COPY manifests/ /var/lib/istio/manifests/
+
+USER nonroot
 
 ENTRYPOINT ["/usr/local/bin/operator"]


### PR DESCRIPTION
Resolves: https://github.com/istio/istio/issues/24815

In the process, align with 65532 as UID/GID used by distroless
in base image as well as operator image.



[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure