### PR TITLE
More output columns for 'istioctl pc routes' and 'clusters'

### DIFF
--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -43,7 +43,7 @@ const (
 var (
 	fqdn, direction, subset string
 	port                    int
-	verboseListener         bool
+	verboseProxyConfig      bool
 
 	address, listenerType string
 
@@ -384,7 +384,7 @@ func proxyConfig() *cobra.Command {
 				Address: address,
 				Port:    uint32(port),
 				Type:    listenerType,
-				Verbose: verboseListener,
+				Verbose: verboseProxyConfig,
 			}
 
 			switch outputFormat {
@@ -401,7 +401,7 @@ func proxyConfig() *cobra.Command {
 	listenerConfigCmd.PersistentFlags().StringVar(&address, "address", "", "Filter listeners by address field")
 	listenerConfigCmd.PersistentFlags().StringVar(&listenerType, "type", "", "Filter listeners by type field")
 	listenerConfigCmd.PersistentFlags().IntVar(&port, "port", 0, "Filter listeners by Port field")
-	listenerConfigCmd.PersistentFlags().BoolVar(&verboseListener, "verbose", true, "Output filter chain information")
+	listenerConfigCmd.PersistentFlags().BoolVar(&verboseProxyConfig, "verbose", true, "Output more information")
 	listenerConfigCmd.PersistentFlags().StringVarP(&configDumpFile, "file", "f", "",
 		"Envoy config dump JSON file")
 
@@ -552,7 +552,8 @@ func proxyConfig() *cobra.Command {
 				return err
 			}
 			filter := configdump.RouteFilter{
-				Name: routeName,
+				Name:    routeName,
+				Verbose: verboseProxyConfig,
 			}
 			switch outputFormat {
 			case summaryOutput:
@@ -566,6 +567,7 @@ func proxyConfig() *cobra.Command {
 	}
 
 	routeConfigCmd.PersistentFlags().StringVar(&routeName, "name", "", "Filter listeners by route name field")
+	routeConfigCmd.PersistentFlags().BoolVar(&verboseProxyConfig, "verbose", true, "Output more information")
 	routeConfigCmd.PersistentFlags().StringVarP(&configDumpFile, "file", "f", "",
 		"Envoy config dump JSON file")
 

--- a/istioctl/pkg/writer/envoy/configdump/cluster.go
+++ b/istioctl/pkg/writer/envoy/configdump/cluster.go
@@ -68,7 +68,7 @@ func (c *ConfigWriter) PrintClusterSummary(filter ClusterFilter) error {
 	if err != nil {
 		return err
 	}
-	_, _ = fmt.Fprintln(w, "SERVICE FQDN\tPORT\tSUBSET\tDIRECTION\tTYPE\tDR")
+	_, _ = fmt.Fprintln(w, "SERVICE FQDN\tPORT\tSUBSET\tDIRECTION\tTYPE\tDESTINATION RULE")
 	for _, c := range clusters {
 		if filter.Verify(c) {
 			if len(strings.Split(c.Name, "|")) > 3 {

--- a/istioctl/pkg/writer/envoy/configdump/cluster.go
+++ b/istioctl/pkg/writer/envoy/configdump/cluster.go
@@ -68,7 +68,7 @@ func (c *ConfigWriter) PrintClusterSummary(filter ClusterFilter) error {
 	if err != nil {
 		return err
 	}
-	_, _ = fmt.Fprintln(w, "SERVICE FQDN\tPORT\tSUBSET\tDIRECTION\tTYPE")
+	_, _ = fmt.Fprintln(w, "SERVICE FQDN\tPORT\tSUBSET\tDIRECTION\tTYPE\tDR")
 	for _, c := range clusters {
 		if filter.Verify(c) {
 			if len(strings.Split(c.Name, "|")) > 3 {
@@ -76,9 +76,11 @@ func (c *ConfigWriter) PrintClusterSummary(filter ClusterFilter) error {
 				if subset == "" {
 					subset = "-"
 				}
-				_, _ = fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%s\n", fqdn, port, subset, direction, c.GetType())
+				_, _ = fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%s\t%s\n", fqdn, port, subset, direction, c.GetType(),
+					describeManagement(c.GetMetadata()))
 			} else {
-				_, _ = fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%s\n", c.Name, "-", "-", "-", c.GetType())
+				_, _ = fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%s\t%s\n", c.Name, "-", "-", "-", c.GetType(),
+					describeManagement(c.GetMetadata()))
 			}
 		}
 	}

--- a/istioctl/pkg/writer/envoy/configdump/route.go
+++ b/istioctl/pkg/writer/envoy/configdump/route.go
@@ -54,7 +54,7 @@ func (c *ConfigWriter) PrintRouteSummary(filter RouteFilter) error {
 	}
 	fmt.Fprintln(c.Stdout, "NOTE: This output only contains routes loaded via RDS.")
 	if filter.Verbose {
-		fmt.Fprintln(w, "NAME\tDOMAINS\tMATCH\tCONFIG\tVS")
+		fmt.Fprintln(w, "NAME\tDOMAINS\tMATCH\tCONFIG\tVIRTUAL SERVICE")
 	} else {
 		fmt.Fprintln(w, "NAME\tVIRTUAL HOSTS")
 	}

--- a/istioctl/pkg/writer/envoy/configdump/route.go
+++ b/istioctl/pkg/writer/envoy/configdump/route.go
@@ -19,18 +19,23 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 	"text/tabwriter"
 
+	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"github.com/golang/protobuf/ptypes"
+	any "github.com/golang/protobuf/ptypes/any"
 
 	protio "istio.io/istio/istioctl/pkg/util/proto"
+	pilot_util "istio.io/istio/pilot/pkg/networking/util"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 )
 
 // RouteFilter is used to pass filter information into route based config writer print functions
 type RouteFilter struct {
-	Name string
+	Name    string
+	Verbose bool
 }
 
 // Verify returns true if the passed route matches the filter fields
@@ -48,13 +53,90 @@ func (c *ConfigWriter) PrintRouteSummary(filter RouteFilter) error {
 		return err
 	}
 	fmt.Fprintln(c.Stdout, "NOTE: This output only contains routes loaded via RDS.")
-	fmt.Fprintln(w, "NAME\tVIRTUAL HOSTS")
+	if filter.Verbose {
+		fmt.Fprintln(w, "NAME\tDOMAINS\tMATCH\tCONFIG\tVS")
+	} else {
+		fmt.Fprintln(w, "NAME\tVIRTUAL HOSTS")
+	}
 	for _, route := range routes {
 		if filter.Verify(route) {
-			fmt.Fprintf(w, "%v\t%v\n", route.Name, len(route.GetVirtualHosts()))
+			if filter.Verbose {
+				for _, vhosts := range route.GetVirtualHosts() {
+					for _, r := range vhosts.Routes {
+						fmt.Fprintf(w, "%v\t%s\t%s\t%s\t%s\n",
+							route.Name,
+							describeRouteDomains(vhosts.GetDomains()),
+							describeMatch(r.GetMatch()),
+							describeConfig(r.GetTypedPerFilterConfig()),
+							describeManagement(r.GetMetadata()))
+					}
+				}
+			} else {
+				fmt.Fprintf(w, "%v\t%v\n", route.Name, len(route.GetVirtualHosts()))
+			}
 		}
 	}
 	return w.Flush()
+}
+
+func describeConfig(config map[string]*any.Any) string {
+	keys := []string{}
+	for key := range config {
+		keys = append(keys, key)
+	}
+	return strings.Join(keys, "/")
+}
+
+func describeRouteDomains(domains []string) string {
+	if len(domains) == 0 {
+		return ""
+	}
+	if len(domains) == 1 {
+		return domains[0]
+	}
+
+	// Return the shortest non-numeric domain.  Count of domains seems uninteresting.
+	candidate := domains[0]
+	for _, domain := range domains {
+		if len(domain) == 0 {
+			continue
+		}
+		firstChar := domain[0]
+		if firstChar >= '1' && firstChar <= '9' {
+			continue
+		}
+		if len(domain) < len(candidate) {
+			candidate = domain
+		}
+	}
+
+	return candidate
+}
+
+func describeManagement(metadata *envoy_config_core_v3.Metadata) string {
+	if metadata == nil {
+		return ""
+	}
+	istioMetadata, ok := metadata.FilterMetadata[pilot_util.IstioMetadataKey]
+	if !ok {
+		return ""
+	}
+	config, ok := istioMetadata.Fields["config"]
+	if !ok {
+		return ""
+	}
+	return renderConfig(config.GetStringValue())
+}
+
+func renderConfig(configPath string) string {
+	if strings.HasPrefix(configPath, "/apis/networking.istio.io/v1alpha3/namespaces/") {
+		pieces := strings.Split(configPath, "/")
+		if len(pieces) != 8 {
+			return ""
+		}
+		return fmt.Sprintf("%s.%s", pieces[7], pieces[5])
+	}
+	return "<unknown>"
 }
 
 // PrintRouteDump prints the relevant routes in the config dump to the ConfigWriter stdout

--- a/istioctl/pkg/writer/envoy/configdump/route.go
+++ b/istioctl/pkg/writer/envoy/configdump/route.go
@@ -25,7 +25,6 @@ import (
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"github.com/golang/protobuf/ptypes"
-	any "github.com/golang/protobuf/ptypes/any"
 
 	protio "istio.io/istio/istioctl/pkg/util/proto"
 	pilot_util "istio.io/istio/pilot/pkg/networking/util"
@@ -54,7 +53,7 @@ func (c *ConfigWriter) PrintRouteSummary(filter RouteFilter) error {
 	}
 	fmt.Fprintln(c.Stdout, "NOTE: This output only contains routes loaded via RDS.")
 	if filter.Verbose {
-		fmt.Fprintln(w, "NAME\tDOMAINS\tMATCH\tCONFIG\tVIRTUAL SERVICE")
+		fmt.Fprintln(w, "NAME\tDOMAINS\tMATCH\tVIRTUAL SERVICE")
 	} else {
 		fmt.Fprintln(w, "NAME\tVIRTUAL HOSTS")
 	}
@@ -64,11 +63,10 @@ func (c *ConfigWriter) PrintRouteSummary(filter RouteFilter) error {
 				for _, vhosts := range route.GetVirtualHosts() {
 					for _, r := range vhosts.Routes {
 						if !isPassthrough(r.GetAction()) {
-							fmt.Fprintf(w, "%v\t%s\t%s\t%s\t%s\n",
+							fmt.Fprintf(w, "%v\t%s\t%s\t%s\n",
 								route.Name,
 								describeRouteDomains(vhosts.GetDomains()),
 								describeMatch(r.GetMatch()),
-								describeConfig(r.GetTypedPerFilterConfig()),
 								describeManagement(r.GetMetadata()))
 						}
 					}
@@ -79,14 +77,6 @@ func (c *ConfigWriter) PrintRouteSummary(filter RouteFilter) error {
 		}
 	}
 	return w.Flush()
-}
-
-func describeConfig(config map[string]*any.Any) string {
-	keys := []string{}
-	for key := range config {
-		keys = append(keys, key)
-	}
-	return strings.Join(keys, "/")
 }
 
 func describeRouteDomains(domains []string) string {


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/23987 by providing one line per virtual-host-route instead of one line per-overall route.  New columns DOMAINS, MATCH, CONFIG, and VS (virtual service) supply information.

The previous output is still available if `--verbose=false` is specified.

The previous version shows
```
NAME        VIRTUAL HOSTS
http.80     1
            1
            1
```

The new version shows

```
NAME                                  DOMAINS     MATCH                  VIRTUAL SERVICE
http.80                               *           /productpage           bookinfo.default
http.80                               *           /static*               bookinfo.default
http.80                               *           /login                 bookinfo.default
http.80                               *           /logout                bookinfo.default
http.80                               *           /api/v1/products*      bookinfo.default
https.443.https.mygateway.default     *           /*                     
                                      *           /healthz/ready*        
                                      *           /stats/prometheus*     
```

The 'CONFIG' column is empty here but indicates non-vanilla situations with values like `envoy.fault`.

The output is a bit wide for pods within the mesh:

```
NAME                                                                                 DOMAINS                                                        MATCH                  VIRTUAL SERVICE
istio-ingressgateway.istio-system.svc.cluster.local:15021                            istio-ingressgateway.istio-system                              /*                     
15014                                                                                istiod.istio-system                                            /*                     
kube-dns.kube-system.svc.cluster.local:9153                                          kube-dns.kube-system                                           /*                     
public-crf2795d8b4d834ee593f06f52f2289261-alb1.kube-system.svc.cluster.local:80      public-crf2795d8b4d834ee593f06f52f2289261-alb1.kube-system     /*                     
dashboard-metrics-scraper.kube-system.svc.cluster.local:8000                         dashboard-metrics-scraper.kube-system                          /*                     
9080                                                                                 details                                                        /*                     details.default
9080                                                                                 productpage                                                    /*                     productpage.default
9080                                                                                 ratings                                                        /*                     ratings.default
9080                                                                                 reviews                                                        /*                     reviews.default
metrics-server.kube-system.svc.cluster.local:443                                     metrics-server.kube-system                                     /*                     
public-crf2795d8b4d834ee593f06f52f2289261-alb1.kube-system.svc.cluster.local:443     public-crf2795d8b4d834ee593f06f52f2289261-alb1.kube-system     /*                     
istiod.istio-system.svc.cluster.local:853                                            istiod.istio-system                                            /*                     
tiller-deploy.kube-system.svc.cluster.local:44134                                    tiller-deploy.kube-system                                      /*                     
9090                                                                                 prometheus.istio-system                                        /*                     
15010                                                                                istiod.istio-system                                            /*                     
kubernetes-dashboard.kube-system.svc.cluster.local:443                               kubernetes-dashboard.kube-system                               /*                     
50051                                                                                addon-catalog-source.ibm-system                                /*                     
8000                                                                                 dashboard-metrics-scraper.kube-system                          /*                     
8000                                                                                 httpbin                                                        /                      httpbin.default
8000                                                                                 httpbin                                                        /*                     httpbin.default
80                                                                                   details.default.svc.cluster.local                              /*                     details.default
80                                                                                   httpbin.default.svc.cluster.local                              /                      httpbin.default
80                                                                                   httpbin.default.svc.cluster.local                              /*                     httpbin.default
80                                                                                   ibm-k8s-controller-default-backend.kube-system                 /*                     
80                                                                                   istio-ingressgateway.istio-system                              /*                     
80                                                                                   productpage.default.svc.cluster.local                          /*                     productpage.default
80                                                                                   public-crf2795d8b4d834ee593f06f52f2289261-alb1.kube-system     /*                     
80                                                                                   ratings.default.svc.cluster.local                              /*                     ratings.default
80                                                                                   reviews.default.svc.cluster.local                              /*                     reviews.default
8081                                                                                 olm-operator-metrics.ibm-system                                /*                     
inbound|8000|http|httpbin.default.svc.cluster.local                                  *                                                              /*                     
inbound|8000|http|httpbin.default.svc.cluster.local                                  *                                                              /*                     
                                                                                     *                                                              /stats/prometheus*     
InboundPassthroughClusterIpv6                                                        *                                                              /*                     
inbound|8000|http|httpbin.default.svc.cluster.local                                  *                                                              /*                     
inbound|8000|http|httpbin.default.svc.cluster.local                                  *                                                              /*                     
InboundPassthroughClusterIpv6                                                        *                                                              /*                     
InboundPassthroughClusterIpv4                                                        *                                                              /*                     
InboundPassthroughClusterIpv4                                                        *                                                              /*                     
                                                                                     *                                                              /healthz/ready*        
```

An earlier version included information about the cluster, with a CLUSTER column and values such as "=> details.bookinfo.svc.cluster.local:9080" and "balance 20%/80%".  This made the output too wide for pods on the mesh although it looked nice on the ingress.

See comment below for the new output of `pc clusters`.