### PR TITLE
Fix test cleanup of RunParallel

### DIFF
--- a/pkg/test/framework/features/features.yaml
+++ b/pkg/test/framework/features/features.yaml
@@ -63,3 +63,7 @@ features:
       central-istiod:
       multimaster:
       remote:
+  # describes internal build and testing infrastrcuture
+  infrastructure:
+    # the testing framework
+    framework:

--- a/pkg/test/framework/integration/framework_test.go
+++ b/pkg/test/framework/integration/framework_test.go
@@ -15,9 +15,12 @@
 package integration
 
 import (
+	"fmt"
 	"sync"
 	"testing"
 	"time"
+
+	"go.uber.org/atomic"
 
 	"istio.io/istio/pkg/test/framework"
 )
@@ -89,4 +92,50 @@ func TestParallel(t *testing.T) {
 	assertClosedBefore(t, l2d, l1b)
 	assertClosedBefore(t, l1a, top)
 	assertClosedBefore(t, l1b, top)
+}
+
+// Validate that cleanup is done synchronously for asynchronous tests
+func TestParallelWhenDone(t *testing.T) {
+	errors := make(chan error, 10)
+	framework.NewTest(t).
+		Run(func(ctx framework.TestContext) {
+			runCheck(ctx, errors, "root")
+			ctx.NewSubTest("nested-serial").Run(func(ctx framework.TestContext) {
+				runCheck(ctx, errors, "nested-serial")
+			})
+			ctx.NewSubTest("nested-parallel").RunParallel(func(ctx framework.TestContext) {
+				runCheck(ctx, errors, "nested-parallel")
+			})
+		})
+
+	for {
+		select {
+		case e := <-errors:
+			t.Error(e)
+		default:
+			return
+		}
+	}
+}
+
+func runCheck(ctx framework.TestContext, errors chan error, name string) {
+	currentTest := atomic.NewString("")
+	for _, c := range []string{"a", "b", "c"} {
+		c := c
+		ctx.NewSubTest(c).Run(func(ctx framework.TestContext) {
+			// Store the test name. We will check this in WhenDone to ensure we call finish cleanup before the next test runs
+			currentTest.Store(c)
+			ctx.WhenDone(func() error {
+				time.Sleep(time.Millisecond * 100)
+				if ct := currentTest.Load(); ct != c {
+					errors <- fmt.Errorf("expected current test for %s to be %s but was %s", name, c, ct)
+				}
+				return nil
+			})
+			for _, st := range []string{"p1", "p2"} {
+				ctx.NewSubTest(st).
+					RunParallel(func(ctx framework.TestContext) {})
+			}
+		})
+	}
 }

--- a/pkg/test/framework/integration/framework_test.go
+++ b/pkg/test/framework/integration/framework_test.go
@@ -97,7 +97,7 @@ func TestParallel(t *testing.T) {
 // Validate that cleanup is done synchronously for asynchronous tests
 func TestParallelWhenDone(t *testing.T) {
 	errors := make(chan error, 10)
-	framework.NewTest(t).
+	framework.NewTest(t).Features("infrastructure.framework").
 		Run(func(ctx framework.TestContext) {
 			runCheck(ctx, errors, "root")
 			ctx.NewSubTest("nested-serial").Run(func(ctx framework.TestContext) {

--- a/pkg/test/framework/test.go
+++ b/pkg/test/framework/test.go
@@ -208,7 +208,7 @@ func (t *Test) runInternal(fn func(ctx TestContext), parallel bool) {
 	}
 	suiteName := t.s.settings.TestID
 	if len(t.featureLabels) < 1 && !features.GlobalWhitelist.Contains(suiteName, myGoTest.Name()) {
-		myGoTest.Logf("Detected new test %s in suite %s with no feature labels.  "+
+		myGoTest.Fatalf("Detected new test %s in suite %s with no feature labels.  "+
 			"See istio/istio/pkg/test/framework/features/README.md", myGoTest.Name(), suiteName)
 	}
 

--- a/pkg/test/framework/testcontext.go
+++ b/pkg/test/framework/testcontext.go
@@ -22,6 +22,7 @@ import (
 	"path"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/errors"
@@ -100,7 +101,48 @@ type testContext struct {
 	workDir string
 }
 
+// Before executing a new context, we should wait for existing contexts to terminate if they are NOT parents of this context.
+// This is to workaround termination of functions run with RunParallel. When this is used, child tests will not run until the parent
+// has terminated. This means that the parent cannot synchronously cleanup, or it would block its children. However, if we do async cleanup,
+// then new tests can unexpectedly start during the cleanup of another. This may lead to odd results, like a test cleanup undoing the setup of a future test.
+// To workaround this, we maintain a set of all contexts currently terminating. Before starting the context, we will search this set;
+// if any non-parent contexts are found, we will wait.
+func waitForParents(test *Test) {
+	iterations := 0
+	for {
+		iterations++
+		done := true
+		globalParentLock.Range(func(key, value interface{}) bool {
+			k := key.(*Test)
+			current := test
+			for current != nil {
+				if current == k {
+					return true
+				}
+				current = current.parent
+
+			}
+			// We found an item in the list, and we are *not* a child of it. This means another test hierarchy has exclusive access right now
+			// Wait until they are finished before proceeding
+			done = false
+			return true
+		})
+		if done {
+			return
+		}
+		time.Sleep(time.Millisecond * 50)
+		// Add some logging in case something locks up so we can debug
+		if iterations%10 == 0 {
+			globalParentLock.Range(func(key, value interface{}) bool {
+				scopes.Framework.Warnf("Stuck waiting for parent test suites to terminate... %v is blocking", key.(*Test).goTest.Name())
+				return true
+			})
+		}
+	}
+}
+
 func newTestContext(test *Test, goTest *testing.T, s *suiteContext, parentScope *scope, labels label.Set) *testContext {
+	waitForParents(test)
 	id := s.allocateContextID(goTest.Name())
 
 	allLabels := s.suiteLabels.Merge(labels)


### PR DESCRIPTION
I am guessing this will solve
https://github.com/istio/istio/issues/24028

I am not proud of this solution, but I spent quite a few hours on this
and its the best I could come up with. The sequencing here is quite
complicated...



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure