### PR TITLE
Potential bug in tests.mk file

### DIFF
--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -32,7 +32,7 @@ ifneq ($(TAG),)
     _INTEGRATION_TEST_FLAGS += --istio.test.tag=$(TAG)
 endif
 
-_INTEGRATION_TEST_SELECT_FLAG = --istio.test.select=-postsubmit,-flaky,-multicluster
+_INTEGRATION_TEST_SELECT_FLAGS = --istio.test.select=-postsubmit,-flaky,-multicluster
 ifneq ($(TEST_SELECT),)
     _INTEGRATION_TEST_SELECT_FLAGS += --istio.test.select=$(TEST_SELECT)
 endif

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -32,9 +32,9 @@ ifneq ($(TAG),)
     _INTEGRATION_TEST_FLAGS += --istio.test.tag=$(TAG)
 endif
 
-_INTEGRATION_TEST_SELECT_FLAGS = --istio.test.select=-postsubmit,-flaky,-multicluster
-ifneq ($(TEST_SELECT),)
-    _INTEGRATION_TEST_SELECT_FLAGS += --istio.test.select=$(TEST_SELECT)
+_INTEGRATION_TEST_SELECT_FLAGS ?= --istio.test.select=$(TEST_SELECT)
+ifeq ($(TEST_SELECT),)
+    _INTEGRATION_TEST_SELECT_FLAGS = --istio.test.select=-postsubmit,-flaky,-multicluster
 endif
 
 # $(INTEGRATION_TEST_KUBECONFIG) overrides all kube config settings.


### PR DESCRIPTION
This PR aims to fix a potential bug in tests.mk file (#24909). This PR should be reviewed together with https://github.com/istio/test-infra/pull/2727. The default value of `_INTEGRATION_TEST_SELECT_FLAGS` is updated to be the env variable `TEST_SELECT` from [here](https://github.com/istio/test-infra/blob/master/prow/config/jobs/istio.yaml). If TEST_SELECT is not provided, such as post-submit tests `integ-k8s-116`, `integ-k8s-117` and `integ-k8s-119`, the test select flags will be set to `-postsubmit,-flaky,-multicluster`

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure