### PR TITLE
Extend traffic shifting test to include VM tests

### DIFF
--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -17,6 +17,10 @@ package pilot
 import (
 	"testing"
 
+	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/pilot"
@@ -49,4 +53,21 @@ values:
 			return nil
 		}).
 		Run()
+}
+
+func echoConfig(ns namespace.Instance, name string) echo.Config {
+	return echo.Config{
+		Service:   name,
+		Namespace: ns,
+		Ports: []echo.Port{
+			{
+				Name:     "http",
+				Protocol: protocol.HTTP,
+				// We use a port > 1024 to not require root
+				InstancePort: 8090,
+			},
+		},
+		Subsets: []echo.SubsetConfig{{}},
+		Pilot:   p,
+	}
 }

--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -35,7 +35,13 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
 		RequireSingleCluster().
-		Setup(istio.Setup(&i, nil)).
+		Setup(istio.Setup(&i, func(cfg *istio.Config) {
+			cfg.ControlPlaneValues = `
+values:
+  global:
+    meshExpansion:
+      enabled: true`
+		})).
 		Setup(func(ctx resource.Context) (err error) {
 			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
 				return err

--- a/tests/integration/pilot/traffic_shifting_test.go
+++ b/tests/integration/pilot/traffic_shifting_test.go
@@ -77,15 +77,12 @@ func TestTrafficShifting(t *testing.T) {
 // VM image version is default to ubuntu:bionic
 // All other images will be tested in post-submit to reduce runtime
 func TestVMTrafficShifting(t *testing.T) {
-	testcases := []string{"app_sidecar_ubuntu_bionic"}
-	trafficShifting(t, testcases)
+	trafficShifting(t, []string{DefaultVMImage})
 }
 
 // Test case for post-submit to test all OS types/versions
 func TestVMTrafficShiftingPost(t *testing.T) {
-	testcases := []string{"app_sidecar_ubuntu_xenial", "app_sidecar_ubuntu_focal", "app_sidecar_ubuntu_bionic",
-		"app_sidecar_debian_9", "app_sidecar_debian_10"}
-	trafficShifting(t, testcases, label.Postsubmit) // mark it to be post-submit
+	trafficShifting(t, GetSupportedOSVersion(), label.Postsubmit) // mark it to be post-submit
 }
 
 func trafficShifting(t *testing.T, vmImages []string, label ...label.Instance) {

--- a/tests/integration/pilot/traffic_shifting_test.go
+++ b/tests/integration/pilot/traffic_shifting_test.go
@@ -177,7 +177,6 @@ func echoConfig(ns namespace.Instance, name string, vmImage ...string) echo.Conf
 				Protocol: protocol.HTTP,
 				// We use a port > 1024 to not require root
 				InstancePort: 8090,
-				ServicePort:  8090,
 			},
 		},
 		Subsets:    []echo.SubsetConfig{{}},

--- a/tests/integration/pilot/traffic_shifting_test.go
+++ b/tests/integration/pilot/traffic_shifting_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"istio.io/istio/pkg/test/framework/label"
+
 	"istio.io/istio/pkg/test/util/retry"
 
 	"istio.io/istio/pkg/config/protocol"
@@ -66,57 +68,106 @@ type VirtualServiceConfig struct {
 	Weight2   int32
 }
 
+// Test case for regular echo instances
 func TestTrafficShifting(t *testing.T) {
+	trafficShifting(t, []string{}) // pass empty list to indicate no VM
+}
+
+// Test case for VM traffic shifting. Client a will sent requests to 3 VMs
+// VM image version is default to ubuntu:bionic
+// All other images will be tested in post-submit to reduce runtime
+func TestVMTrafficShifting(t *testing.T) {
+	testcases := []string{"app_sidecar_ubuntu_bionic"}
+	trafficShifting(t, testcases)
+}
+
+// Test case for post-submit to test all OS types/versions
+func TestVMTrafficShiftingPost(t *testing.T) {
+	testcases := []string{"app_sidecar_ubuntu_xenial", "app_sidecar_ubuntu_focal", "app_sidecar_ubuntu_bionic",
+		"app_sidecar_debian_9", "app_sidecar_debian_10"}
+	trafficShifting(t, testcases, label.Postsubmit) // mark it to be post-submit
+}
+
+func trafficShifting(t *testing.T, vmImages []string, label ...label.Instance) {
 	// Traffic distribution
 	weights := map[string][]int32{
 		"20-80":    {20, 80},
 		"50-50":    {50, 50},
 		"33-33-34": {33, 33, 34},
 	}
-
 	framework.
 		NewTest(t).
+		Features("traffic.routing").
+		Label(label...).
 		Run(func(ctx framework.TestContext) {
 			ns := namespace.NewOrFail(t, ctx, namespace.Config{
 				Prefix: "traffic-shifting",
 				Inject: true,
 			})
 
-			var instances [4]echo.Instance
+			// placeholder to ensure the test to run for non-vm tests
+			if len(vmImages) == 0 {
+				vmImages = append(vmImages, "")
+			}
+
+			// continue using this one client to call different version of hosts
+			var client echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&instances[0], echoConfig(ns, "a")).
-				With(&instances[1], echoConfig(ns, "b")).
-				With(&instances[2], echoConfig(ns, "c")).
-				With(&instances[3], echoConfig(ns, "d")).
+				With(&client, echoConfig(ns, "a")).
 				BuildOrFail(t)
 
-			hosts := []string{"b", "c", "d"}
+			// build and test with set of VM instances
+			for i, vmImage := range vmImages {
+				if vmImage != "" {
+					t.Logf("Running as VMs. Testing %v", vmImage)
+				}
 
-			for k, v := range weights {
-				t.Run(k, func(t *testing.T) {
-					v = append(v, make([]int32, 3-len(v))...)
+				// build instances with their image name
+				var instances [3]echo.Instance
+				hosts := []string{fmt.Sprintf("b-%v", i),
+					fmt.Sprintf("c-%v", i),
+					fmt.Sprintf("d-%v", i)}
+				echoboot.NewBuilderOrFail(t, ctx).
+					With(&instances[0], echoConfig(ns, hosts[0], vmImage)).
+					With(&instances[1], echoConfig(ns, hosts[1], vmImage)).
+					With(&instances[2], echoConfig(ns, hosts[2], vmImage)).
+					BuildOrFail(t)
 
-					vsc := VirtualServiceConfig{
-						"traffic-shifting-rule",
-						hosts[0],
-						hosts[1],
-						hosts[2],
-						ns.Name(),
-						v[0],
-						v[1],
-						v[2],
-					}
+				// traverse the weights and apply the VirtualService
+				for k, v := range weights {
+					t.Run(k, func(t *testing.T) {
+						v = append(v, make([]int32, 3-len(v))...)
 
-					deployment := tmpl.EvaluateOrFail(t, file.AsStringOrFail(t, "testdata/traffic-shifting.yaml"), vsc)
-					ctx.ApplyConfigOrFail(t, ns.Name(), deployment)
+						vsc := VirtualServiceConfig{
+							"traffic-shifting-rule",
+							hosts[0],
+							hosts[1],
+							hosts[2],
+							ns.Name(),
+							v[0],
+							v[1],
+							v[2],
+						}
 
-					sendTraffic(t, 100, instances[0], instances[1], hosts, v, errorThreshold)
-				})
+						deployment := tmpl.EvaluateOrFail(t, file.AsStringOrFail(t, "testdata/traffic-shifting.yaml"), vsc)
+						ctx.ApplyConfigOrFail(t, ns.Name(), deployment)
+
+						sendTraffic(t, 100, client, instances[0], hosts, v, errorThreshold)
+					})
+				}
 			}
 		})
 }
 
-func echoConfig(ns namespace.Instance, name string) echo.Config {
+// Echo config helper function. If no vmImage or empty string is provided, non-vm pod will be created
+// Else, it will create a VM pod using the vmImage.
+func echoConfig(ns namespace.Instance, name string, vmImage ...string) echo.Config {
+	deployAsVM := false
+	vmImageName := ""
+	if len(vmImage) > 0 && vmImage[0] != "" {
+		deployAsVM = true
+		vmImageName = vmImage[0]
+	}
 	return echo.Config{
 		Service:   name,
 		Namespace: ns,
@@ -126,10 +177,13 @@ func echoConfig(ns namespace.Instance, name string) echo.Config {
 				Protocol: protocol.HTTP,
 				// We use a port > 1024 to not require root
 				InstancePort: 8090,
+				ServicePort:  8090,
 			},
 		},
-		Subsets: []echo.SubsetConfig{{}},
-		Pilot:   p,
+		Subsets:    []echo.SubsetConfig{{}},
+		Pilot:      p,
+		DeployAsVM: deployAsVM,
+		VMImage:    vmImageName,
 	}
 }
 

--- a/tests/integration/pilot/traffic_shifting_test.go
+++ b/tests/integration/pilot/traffic_shifting_test.go
@@ -129,6 +129,9 @@ func echoVMConfig(ns namespace.Instance, name string, vmImage ...string) echo.Co
 	config := echoConfig(ns, name)
 	config.DeployAsVM = image != ""
 	config.VMImage = image
+	
+	// This is necessary because there exists a bug in WorkloadEntry
+	// The ServicePort has to be the same with the InstancePort
 	config.Ports[0].ServicePort = config.Ports[0].InstancePort
 	return config
 }

--- a/tests/integration/pilot/traffic_shifting_test.go
+++ b/tests/integration/pilot/traffic_shifting_test.go
@@ -129,7 +129,7 @@ func echoVMConfig(ns namespace.Instance, name string, vmImage ...string) echo.Co
 	config := echoConfig(ns, name)
 	config.DeployAsVM = image != ""
 	config.VMImage = image
-	
+
 	// This is necessary because there exists a bug in WorkloadEntry
 	// The ServicePort has to be the same with the InstancePort
 	config.Ports[0].ServicePort = config.Ports[0].InstancePort

--- a/tests/integration/pilot/util.go
+++ b/tests/integration/pilot/util.go
@@ -1,0 +1,26 @@
+/*
+ * // Copyright Istio Authors
+ * //
+ * // Licensed under the Apache License, Version 2.0 (the "License");
+ * // you may not use this file except in compliance with the License.
+ * // You may obtain a copy of the License at
+ * //
+ * //     http://www.apache.org/licenses/LICENSE-2.0
+ * //
+ * // Unless required by applicable law or agreed to in writing, software
+ * // distributed under the License is distributed on an "AS IS" BASIS,
+ * // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * // See the License for the specific language governing permissions and
+ * // limitations under the License.
+ */
+
+package pilot
+
+const (
+	DefaultVMImage = "app_sidecar_ubuntu_bionic"
+)
+
+func GetSupportedOSVersion() []string {
+	return []string{"app_sidecar_ubuntu_xenial", "app_sidecar_ubuntu_focal", "app_sidecar_ubuntu_bionic",
+		"app_sidecar_debian_9", "app_sidecar_debian_10"}
+}

--- a/tests/integration/pilot/vm/util.go
+++ b/tests/integration/pilot/vm/util.go
@@ -14,7 +14,7 @@
  * // limitations under the License.
  */
 
-package pilot
+package vm
 
 const (
 	DefaultVMImage = "app_sidecar_ubuntu_bionic"

--- a/tests/integration/pilot/vm/vm_test.go
+++ b/tests/integration/pilot/vm/vm_test.go
@@ -28,20 +28,20 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
 	"istio.io/istio/pkg/test/util/retry"
+	util "istio.io/istio/tests/integration/pilot"
 )
 
 // Test wrapper for the VM OS version test. This test will run in pre-submit
 // to avoid building and testing all OS images
 func TestVmOS(t *testing.T) {
-	vmImages := []string{"app_sidecar_ubuntu_bionic"}
+	vmImages := []string{util.DefaultVMImage}
 	VMTestBody(t, vmImages)
 }
 
 // Post-submit test wrapper to test against all OS images. These images will be build
 // in post-submit to reduce the runtime of prow/lib.sh
 func TestVmOSPost(t *testing.T) {
-	vmImages := []string{"app_sidecar_ubuntu_xenial", "app_sidecar_ubuntu_focal", "app_sidecar_ubuntu_bionic",
-		"app_sidecar_debian_9", "app_sidecar_debian_10"}
+	vmImages := util.GetSupportedOSVersion()
 	VMTestBody(t, vmImages, label.Postsubmit)
 }
 

--- a/tests/integration/pilot/vm/vm_test.go
+++ b/tests/integration/pilot/vm/vm_test.go
@@ -28,20 +28,19 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
 	"istio.io/istio/pkg/test/util/retry"
-	util "istio.io/istio/tests/integration/pilot"
 )
 
 // Test wrapper for the VM OS version test. This test will run in pre-submit
 // to avoid building and testing all OS images
 func TestVmOS(t *testing.T) {
-	vmImages := []string{util.DefaultVMImage}
+	vmImages := []string{DefaultVMImage}
 	VMTestBody(t, vmImages)
 }
 
 // Post-submit test wrapper to test against all OS images. These images will be build
 // in post-submit to reduce the runtime of prow/lib.sh
 func TestVmOSPost(t *testing.T) {
-	vmImages := util.GetSupportedOSVersion()
+	vmImages := GetSupportedOSVersion()
 	VMTestBody(t, vmImages, label.Postsubmit)
 }
 


### PR DESCRIPTION
This PR extends pilot/traffic_shifting.go test to include tests for VMs. This test keeps the original non-vm tests, and added pre- and post-submit tests. 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
