### PR TITLE
removing second unnecessary check for empty path since it was never used

### DIFF
--- a/operator/pkg/tpath/struct.go
+++ b/operator/pkg/tpath/struct.go
@@ -41,9 +41,7 @@ func getFromStructPath(node interface{}, path util.Path) (interface{}, bool, err
 	val := reflect.ValueOf(node)
 	kind := reflect.TypeOf(node).Kind()
 	var structElems reflect.Value
-	if len(path) == 0 {
-		return nil, false, fmt.Errorf("getFromStructPath path %s, unsupported leaf type %T", path, node)
-	}
+
 	switch kind {
 	case reflect.Map:
 		if path[0] == "" {


### PR DESCRIPTION
This PR contains a small code cleanup in the tpath package in operator. The function getFromStructPath has 2 checks for the parameter path to see if it's empty or not without any operation on path in between. As a result, the second empty path check is never entered. This can be seen by the code coverage as well. I have removed the second check


[X] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure