### PR TITLE
Fix pilot tests sharing mutable global state

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -227,6 +227,7 @@ func TestApplyDestinationRule(t *testing.T) {
 			}
 			env := newTestEnvironment(serviceDiscovery, testMesh, configStore)
 
+			proxy := getProxy()
 			proxy.SetSidecarScope(env.PushContext)
 
 			cb := NewClusterBuilder(tt.proxy, env.PushContext)
@@ -417,6 +418,7 @@ func TestBuildDefaultCluster(t *testing.T) {
 			configStore := &fakes.IstioConfigStore{}
 			env := newTestEnvironment(serviceDiscovery, testMesh, configStore)
 
+			proxy := getProxy()
 			proxy.SetSidecarScope(env.PushContext)
 
 			cb := NewClusterBuilder(&model.Proxy{}, env.PushContext)

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -2415,7 +2415,6 @@ func TestBuildStaticClusterWithNoEndPoint(t *testing.T) {
 	}
 
 	serviceDiscovery := memory.NewServiceDiscovery([]*model.Service{service})
-	proxy.ServiceInstances = []*model.ServiceInstance{}
 
 	configStore := &fakes.IstioConfigStore{}
 	proxy := &model.Proxy{

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -902,6 +902,7 @@ func testSidecarRDSVHosts(t *testing.T, services []*model.Service,
 	if registryOnly {
 		env.Mesh().OutboundTrafficPolicy = &meshapi.MeshConfig_OutboundTrafficPolicy{Mode: meshapi.MeshConfig_OutboundTrafficPolicy_REGISTRY_ONLY}
 	}
+	proxy := getProxy()
 	if sidecarConfig == nil {
 		proxy.SidecarScope = model.DefaultSidecarScopeForNamespace(env.PushContext, "not-default")
 	} else {
@@ -909,7 +910,7 @@ func testSidecarRDSVHosts(t *testing.T, services []*model.Service,
 	}
 
 	vHostCache := make(map[int][]*route.VirtualHost)
-	routeCfg := configgen.buildSidecarOutboundHTTPRouteConfig(&proxy, env.PushContext, routeName, vHostCache)
+	routeCfg := configgen.buildSidecarOutboundHTTPRouteConfig(proxy, env.PushContext, routeName, vHostCache)
 	if routeCfg == nil {
 		t.Fatalf("got nil route for %s", routeName)
 	}

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter_test.go
@@ -209,10 +209,11 @@ func TestOutboundNetworkFilterStatPrefix(t *testing.T) {
 			env.PushContext.InitContext(&env, nil, nil)
 			env.PushContext.Mesh.OutboundClusterStatName = tt.statPattern
 
+			proxy := getProxy()
 			proxy.IstioVersion = model.ParseIstioVersion(proxy.Metadata.IstioVersion)
 			proxy.SidecarScope = model.DefaultSidecarScopeForNamespace(env.PushContext, "not-default")
 
-			listeners := buildOutboundNetworkFilters(&proxy, tt.routes, env.PushContext, &model.Port{Port: 9999}, model.ConfigMeta{Name: "test.com", Namespace: "ns"})
+			listeners := buildOutboundNetworkFilters(proxy, tt.routes, env.PushContext, &model.Port{Port: 9999}, model.ConfigMeta{Name: "test.com", Namespace: "ns"})
 			tcp := &tcp.TcpProxy{}
 			ptypes.UnmarshalAny(listeners[0].GetTypedConfig(), tcp)
 			if tcp.StatPrefix != tt.expectedStatPrefix {


### PR DESCRIPTION
Currently all of these test modify the same proxy object. Instead, we
should copy it each time we use.

Related: https://github.com/istio/istio/issues/24824