### PR TITLE
enable status flag is not fully honoured

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -322,16 +322,17 @@ func (s *Server) initInprocessAnalysisController(args *PilotArgs) error {
 }
 
 func (s *Server) initStatusController(args *PilotArgs, writeStatus bool) {
-	s.statusReporter = &status.Reporter{
-		UpdateInterval: time.Millisecond * 500, // TODO: use args here?
-		PodName:        args.PodName,
-	}
-	s.addTerminatingStartFunc(func(stop <-chan struct{}) error {
-		s.statusReporter.Start(s.kubeClient, args.Namespace, s.configController, writeStatus, stop)
-		return nil
-	})
-	s.EnvoyXdsServer.StatusReporter = s.statusReporter
 	if writeStatus {
+		s.statusReporter = &status.Reporter{
+			UpdateInterval: time.Millisecond * 500, // TODO: use args here?
+			PodName:        args.PodName,
+		}
+		s.addTerminatingStartFunc(func(stop <-chan struct{}) error {
+			s.statusReporter.Start(s.kubeClient, args.Namespace, s.configController, writeStatus, stop)
+			return nil
+		})
+		s.EnvoyXdsServer.StatusReporter = s.statusReporter
+
 		s.addTerminatingStartFunc(func(stop <-chan struct{}) error {
 			leaderelection.
 				NewLeaderElection(args.Namespace, args.PodName, leaderelection.StatusController, s.kubeClient).

--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -15,7 +15,6 @@
 package pilot
 
 import (
-	"os"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
@@ -33,7 +32,6 @@ var (
 // If a test requires a custom install it should go into its own package, otherwise it should go
 // here to reuse a single install across tests.
 func TestMain(m *testing.M) {
-	os.Setenv("PILOT_ENABLE_STATUS", "true")
 	framework.
 		NewSuite(m).
 		RequireSingleCluster().

--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -15,6 +15,7 @@
 package pilot
 
 import (
+	"os"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
@@ -32,6 +33,7 @@ var (
 // If a test requires a custom install it should go into its own package, otherwise it should go
 // here to reuse a single install across tests.
 func TestMain(m *testing.M) {
+	os.Setenv("PILOT_ENABLE_STATUS", "true")
 	framework.
 		NewSuite(m).
 		RequireSingleCluster().


### PR DESCRIPTION
Even though  `PILOT_ENABLE_STATUS` is set to false, we create status reporter and status is published because most of the code checks if `StatusReporter != nil ` and pushes the status. This PR creates status reporter only when it is enabled.
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
