### PR TITLE
Use port-forward instead of exec to get control plane version

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -321,11 +321,6 @@ func (c *client) GetIstioPods(ctx context.Context, namespace string, params map[
 	return list.Items, nil
 }
 
-type podDetail struct {
-	binary    string
-	container string
-}
-
 func (c *client) GetIstioVersions(ctx context.Context, namespace string) (*version.MeshInfo, error) {
 	pods, err := c.GetIstioPods(ctx, namespace, map[string]string{
 		"labelSelector": "istio,istio!=ingressgateway,istio!=egressgateway,istio!=ilbgateway",


### PR DESCRIPTION
This provides a bit of performance improvement and security.

It lets us address questions related to https://github.com/istio/istio/issues/24331

- Currently Pilot provides XDS on 15012 and /version on 15014.  Can we combine these?
- Should there be a gRPC version endpoint?  Should it look like XDS Events or something else