### PR TITLE
prow setup: create kind network with ipmasq

### DIFF
--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -197,7 +197,9 @@ function setup_kind_clusters() {
   KUBECONFIG_DIR="$(mktemp -d)"
 
   # The kind tool will error when trying to create clusters in paralell unless we create the network first
-  docker network inspect kind > /dev/null 2>&1 || docker network create kind
+  # TODO remove this when kind support creating multiple clusters in parallel - this will break ipv6
+  docker network inspect kind > /dev/null 2>&1 || docker network create -d=bridge -o com.docker.network.bridge.enable_ip_masquerade=true kind
+
 
   # Trap replaces any previous trap's, so we need to explicitly cleanup both clusters here
   trap cleanup_kind_clusters EXIT


### PR DESCRIPTION
When setting up multiple kind clusters for in the prow scripts we create a `kind` network as a workaround to issues running `kind create cluster` in parallel. This makes our `docker network create` more similar to what kind does [here](https://github.com/kubernetes-sigs/kind/blob/7620a6b488866a57cac5e73fc4540c348c6437d0/pkg/cluster/internal/providers/docker/network.go#L101) 


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
