### PR TITLE
Add  targetUri in stackdriver_grpc_service

### DIFF
--- a/install/gcp/bootstrap/gcp_envoy_bootstrap.json
+++ b/install/gcp/bootstrap/gcp_envoy_bootstrap.json
@@ -125,6 +125,7 @@
       {{ if .sts_port }}
       "stackdriver_grpc_service": {
         "google_grpc": {
+          "target_uri": "cloudtrace.googleapis.com",
           "stat_prefix": "oc_stackdriver_tracer",
           "channel_credentials": {
             "ssl_credentials": {

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -579,6 +579,7 @@
       {{ if .sts_port }}
       "stackdriver_grpc_service": {
         "google_grpc": {
+          "target_uri": "cloudtrace.googleapis.com",
           "stat_prefix": "oc_stackdriver_tracer",
           "channel_credentials": {
             "ssl_credentials": {


### PR DESCRIPTION
Add  targetUri in stackdriver_grpc_service

TODO: Make this an  option, so it can be configured
Signed-off-by: gargnupur <gargnupur@google.com>


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ X] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure