### PR TITLE
'istioctl x describe' Don't consider it a problem if no destination rule is found

### DIFF
--- a/istioctl/cmd/describe.go
+++ b/istioctl/cmd/describe.go
@@ -787,7 +787,7 @@ func getIstioConfig(metadata *envoy_api_core.Metadata) (string, error) {
 // getIstioConfigNameForSvc returns name, namespace
 func getIstioDestinationRuleNameForSvc(cd *configdump.Wrapper, svc v1.Service, port int32) (string, string, error) {
 	path, err := getIstioDestinationRulePathForSvc(cd, svc, port)
-	if err != nil {
+	if err != nil || path == "" {
 		return "", "", err
 	}
 


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/24946

The problem was introduced with https://github.com/istio/istio/pull/23962/files#diff-ff5de02ffe7a166c1116286636b575a3R1200 .

It was confusing that the code returned an err if no DR existed, so instead of undoing the logging I made the function a bit cleaner.
