### PR TITLE
Lock down the operator process security context

### DIFF
--- a/manifests/charts/istio-operator/templates/deployment.yaml
+++ b/manifests/charts/istio-operator/templates/deployment.yaml
@@ -27,6 +27,9 @@ spec:
               - ALL
             privileged: false
             readOnlyRootFilesystem: true
+            runAsGroup: 1337
+            runAsUser: 1337
+            runAsNonRoot: true
           imagePullPolicy: IfNotPresent
           resources:
 {{ toYaml .Values.operator.resources | trim | indent 12 }}

--- a/manifests/charts/istio-operator/templates/deployment.yaml
+++ b/manifests/charts/istio-operator/templates/deployment.yaml
@@ -20,6 +20,13 @@ spec:
           command:
           - operator
           - server
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
           imagePullPolicy: IfNotPresent
           resources:
 {{ toYaml .Values.operator.resources | trim | indent 12 }}


### PR DESCRIPTION
1. Ensure the filesystem is readonly
2. Disable any privilege escalation
3. Drop all capabilities



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure