### PR TITLE
Metadata exchange wasm filter state objects name change

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -288,8 +288,7 @@ var (
 	// We need to propagate these as part of access log service stream
 	// Logging them by default on the console may be an issue as the base64 encoded string is bound to be a big one.
 	// But end users can certainly configure it on their own via the meshConfig using the %FILTERSTATE% macro.
-	envoyWasmStateToLog = []string{"envoy.wasm.metadata_exchange.upstream", "envoy.wasm.metadata_exchange.upstream_id",
-		"envoy.wasm.metadata_exchange.downstream", "envoy.wasm.metadata_exchange.downstream_id"}
+	envoyWasmStateToLog = []string{"wasm.upstream_peer", "wasm.upstream_peer_id", "wasm.downstream_peer", "wasm.downstream_peer_id"}
 
 	// EnvoyJSONLogFormat13 map of values for envoy json based access logs for Istio 1.3 onwards
 	EnvoyJSONLogFormat = &structpb.Struct{


### PR DESCRIPTION
In line with the changes in the istio proxy repo, changing the names in listener.go from 
filter_state_objects_to_log": [
            "envoy.wasm.metadata_exchange.upstream",
            "envoy.wasm.metadata_exchange.upstream_id",
            "envoy.wasm.metadata_exchange.downstream",
            "envoy.wasm.metadata_exchange.downstream_id"
           ]

to

filter_state_objects_to_log": [
            "wasm.upstream_peer",
            "wasm.upstream_peer_id",
            "wasm.downstream_peer",
            "wasm.downstream_peer_id"
           ] 


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure