### PR TITLE
Update the base image versions to latest for bookinfo sample

### DIFF
--- a/samples/bookinfo/platform/consul/bookinfo.yaml
+++ b/samples/bookinfo/platform/consul/bookinfo.yaml
@@ -16,7 +16,7 @@
 version: '2'
 services:
   details-v1:
-    image: docker.io/istio/examples-bookinfo-details-v1:1.16.1
+    image: docker.io/istio/examples-bookinfo-details-v1:1.16.2
     networks:
       istiomesh:
     dns:
@@ -33,7 +33,7 @@ services:
       - "9080"
 
   ratings-v1:
-    image: docker.io/istio/examples-bookinfo-ratings-v1:1.16.1
+    image: docker.io/istio/examples-bookinfo-ratings-v1:1.16.2
     networks:
       istiomesh:
     dns:
@@ -50,7 +50,7 @@ services:
       - "9080"
 
   reviews-v1:
-    image: docker.io/istio/examples-bookinfo-reviews-v1:1.16.1
+    image: docker.io/istio/examples-bookinfo-reviews-v1:1.16.2
     networks:
       istiomesh:
     dns:
@@ -68,7 +68,7 @@ services:
       - "9080"
 
   reviews-v2:
-    image: docker.io/istio/examples-bookinfo-reviews-v2:1.16.1
+    image: docker.io/istio/examples-bookinfo-reviews-v2:1.16.2
     networks:
       istiomesh:
     dns:
@@ -86,7 +86,7 @@ services:
       - "9080"
 
   reviews-v3:
-    image: docker.io/istio/examples-bookinfo-reviews-v3:1.16.1
+    image: docker.io/istio/examples-bookinfo-reviews-v3:1.16.2
     networks:
       istiomesh:
     dns:
@@ -104,7 +104,7 @@ services:
       - "9080"
 
   productpage-v1:
-    image: docker.io/istio/examples-bookinfo-productpage-v1:1.16.1
+    image: docker.io/istio/examples-bookinfo-productpage-v1:1.16.2
     networks:
       istiomesh:
         ipv4_address: 172.28.0.14

--- a/samples/bookinfo/platform/kube/bookinfo-db.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-db.yaml
@@ -46,7 +46,7 @@ spec:
     spec:
       containers:
       - name: mongodb 
-        image: docker.io/istio/examples-bookinfo-mongodb:1.16.1
+        image: docker.io/istio/examples-bookinfo-mongodb:1.16.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 27017
@@ -55,5 +55,5 @@ spec:
           mountPath: /data/db
       volumes:
       - name: data-db
-        emptyDir:
+        emptyDir: {}
 ---

--- a/samples/bookinfo/platform/kube/bookinfo-details-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-details-v2.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: docker.io/istio/examples-bookinfo-details-v2:1.16.1
+        image: docker.io/istio/examples-bookinfo-details-v2:1.16.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-details.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-details.yaml
@@ -49,7 +49,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: docker.io/istio/examples-bookinfo-details-v1:1.16.1
+        image: docker.io/istio/examples-bookinfo-details-v1:1.16.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-mysql.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-mysql.yaml
@@ -58,7 +58,7 @@ spec:
     spec:
       containers:
       - name: mysqldb
-        image: docker.io/istio/examples-bookinfo-mysqldb:1.16.1
+        image: docker.io/istio/examples-bookinfo-mysqldb:1.16.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3306
@@ -74,5 +74,5 @@ spec:
           mountPath: /var/lib/mysql
       volumes:
       - name: var-lib-mysql
-        emptyDir:
+        emptyDir: {}
 ---

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-vm.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-vm.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: docker.io/istio/examples-bookinfo-ratings-v2:1.16.1
+        image: docker.io/istio/examples-bookinfo-ratings-v2:1.16.2
         imagePullPolicy: IfNotPresent
         env:
           # This assumes you registered your mysql vm as

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: docker.io/istio/examples-bookinfo-ratings-v2:1.16.1
+        image: docker.io/istio/examples-bookinfo-ratings-v2:1.16.2
         imagePullPolicy: IfNotPresent
         env:
           # ratings-v2 will use mongodb as the default db backend.

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: bookinfo-ratings-v2
       containers:
       - name: ratings
-        image: docker.io/istio/examples-bookinfo-ratings-v2:1.16.1
+        image: docker.io/istio/examples-bookinfo-ratings-v2:1.16.2
         imagePullPolicy: IfNotPresent
         env:
           # ratings-v2 will use mongodb as the default db backend.

--- a/samples/bookinfo/platform/kube/bookinfo-ratings.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings.yaml
@@ -49,7 +49,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: docker.io/istio/examples-bookinfo-ratings-v1:1.16.1
+        image: docker.io/istio/examples-bookinfo-ratings-v1:1.16.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-reviews-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-reviews-v2.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: docker.io/istio/examples-bookinfo-reviews-v2:1.16.1
+        image: docker.io/istio/examples-bookinfo-reviews-v2:1.16.2
         imagePullPolicy: IfNotPresent
         env:
         - name: LOG_DIR

--- a/samples/bookinfo/platform/kube/bookinfo.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo.yaml
@@ -72,7 +72,7 @@ spec:
       serviceAccountName: bookinfo-details
       containers:
       - name: details
-        image: docker.io/istio/examples-bookinfo-details-v1:1.16.1
+        image: docker.io/istio/examples-bookinfo-details-v1:1.16.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -123,7 +123,7 @@ spec:
       serviceAccountName: bookinfo-ratings
       containers:
       - name: ratings
-        image: docker.io/istio/examples-bookinfo-ratings-v1:1.16.1
+        image: docker.io/istio/examples-bookinfo-ratings-v1:1.16.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -174,7 +174,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: docker.io/istio/examples-bookinfo-reviews-v1:1.16.1
+        image: docker.io/istio/examples-bookinfo-reviews-v1:1.16.2
         imagePullPolicy: IfNotPresent
         env:
         - name: LOG_DIR
@@ -214,7 +214,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: docker.io/istio/examples-bookinfo-reviews-v2:1.16.1
+        image: docker.io/istio/examples-bookinfo-reviews-v2:1.16.2
         imagePullPolicy: IfNotPresent
         env:
         - name: LOG_DIR
@@ -254,7 +254,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: docker.io/istio/examples-bookinfo-reviews-v3:1.16.1
+        image: docker.io/istio/examples-bookinfo-reviews-v3:1.16.2
         imagePullPolicy: IfNotPresent
         env:
         - name: LOG_DIR
@@ -318,7 +318,7 @@ spec:
       serviceAccountName: bookinfo-productpage
       containers:
       - name: productpage
-        image: docker.io/istio/examples-bookinfo-productpage-v1:1.16.1
+        image: docker.io/istio/examples-bookinfo-productpage-v1:1.16.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/src/details/Dockerfile
+++ b/samples/bookinfo/src/details/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM ruby:2.7-rc-slim
+FROM ruby:2.7.1-slim
 
 COPY details.rb /opt/microservices/
 

--- a/samples/bookinfo/src/mongodb/Dockerfile
+++ b/samples/bookinfo/src/mongodb/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM mongo:4.0.12-xenial
+FROM mongo:4.0.19-xenial
 WORKDIR /app/data/
 COPY ratings_data.json /app/data/
 COPY script.sh /docker-entrypoint-initdb.d/

--- a/samples/bookinfo/src/mysql/Dockerfile
+++ b/samples/bookinfo/src/mysql/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM mysql:8.0.17
+FROM mysql:8.0.20
 # MYSQL_ROOT_PASSWORD must be supplied as an env var
 
 COPY ./mysqldb-init.sql /docker-entrypoint-initdb.d

--- a/samples/bookinfo/src/productpage/Dockerfile
+++ b/samples/bookinfo/src/productpage/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM python:3.7.4-slim
+FROM python:3.7.7-slim
 
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt

--- a/samples/bookinfo/src/productpage/productpage.py
+++ b/samples/bookinfo/src/productpage/productpage.py
@@ -382,4 +382,6 @@ if __name__ == '__main__':
 
     p = int(sys.argv[1])
     logging.info("start at port %s" % (p))
-    app.run(host='::', port=p, debug=True, threaded=True)
+    # Python does not work on an IPv6 only host
+    # https://bugs.python.org/issue10414
+    app.run(host='0.0.0.0', port=p, debug=True, threaded=True)

--- a/samples/bookinfo/src/ratings/Dockerfile
+++ b/samples/bookinfo/src/ratings/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM node:12.18.0-slim
+FROM node:12.18.1-slim
 
 COPY package.json /opt/microservices/
 COPY ratings.js /opt/microservices/

--- a/samples/bookinfo/src/reviews/reviews-wlpcfg/Dockerfile
+++ b/samples/bookinfo/src/reviews/reviews-wlpcfg/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM websphere-liberty:19.0.0.6-javaee8
+FROM websphere-liberty:20.0.0.6-full-java8-ibmjava
 
 ENV SERVERDIRNAME reviews
 


### PR DESCRIPTION
Last updated year ago https://github.com/istio/istio/pull/16556.

Not upgraded python version to the latest `3.8.3` because of some dependency issues, it was failing locally.

Referenced https://github.com/istio/istio/pull/24304 for updating tag

