### PR TITLE
Fixes 24969. Fix eds endpoint selection for subsets with no or empty …

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -789,6 +789,9 @@ func (ps *PushContext) SubsetToLabels(proxy *Proxy, subsetName string, hostname 
 	rule := cfg.Spec.(*networking.DestinationRule)
 	for _, subset := range rule.Subsets {
 		if subset.Name == subsetName {
+			if len(subset.Labels) == 0 {
+				return nil
+			}
 			return []labels.Instance{subset.Labels}
 		}
 	}

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -16,12 +16,12 @@ package model
 
 import (
 	"fmt"
-	"github.com/google/go-cmp/cmp"
 	"reflect"
 	"regexp"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	"fmt"
+	"github.com/google/go-cmp/cmp"
 	"reflect"
 	"regexp"
 	"testing"
@@ -445,6 +446,78 @@ func TestSetDestinationRule(t *testing.T) {
 
 	if len(subsetsExport) != 4 {
 		t.Errorf("want %d, but got %d", 4, len(subsetsExport))
+	}
+}
+
+func TestSubsetToLabels(t *testing.T) {
+	ps := NewPushContext()
+	ps.defaultDestinationRuleExportTo = map[visibility.Instance]bool{visibility.Public: true}
+	ps.Mesh = &meshconfig.MeshConfig{
+		RootNamespace: "istio-system",
+	}
+	testhost := "httpbin.org"
+	destinationRuleNamespace1 := Config{
+		ConfigMeta: ConfigMeta{
+			Name:      "rule1",
+			Namespace: "test",
+		},
+		Spec: &networking.DestinationRule{
+			Host: testhost,
+			Subsets: []*networking.Subset{
+				{
+					Name: "subset1",
+				},
+				{
+					Name:   "subset2",
+					Labels: map[string]string{},
+				},
+				{
+					Name: "subset3",
+					Labels: map[string]string{
+						"a": "b",
+					},
+				},
+			},
+		},
+	}
+	proxy := &Proxy{
+		Metadata:        &NodeMetadata{IstioVersion: "1.6.0"},
+		ConfigNamespace: "test",
+	}
+
+	ps.SetDestinationRules([]Config{destinationRuleNamespace1})
+
+	for _, test := range []struct {
+		name     string
+		subset   string
+		expected labels.Collection
+	}{
+		{
+			name:     "No labels",
+			subset:   "subset1",
+			expected: nil,
+		},
+		{
+			name:     "Empty labels",
+			subset:   "subset2",
+			expected: nil,
+		},
+		{
+			name:   "With labels",
+			subset: "subset3",
+			expected: labels.Collection{
+				{
+					"a": "b",
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			labelsCollection := ps.SubsetToLabels(proxy, test.subset, host.Name(testhost))
+			if cmp.Diff(labelsCollection, test.expected) != "" {
+				t.Errorf("want %v, but got %v", test.expected, labelsCollection)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
…subset labels



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

This PR fixes the behavior reported in #24969.
Currently, when a DestinationRule has a subset with no label selector it is treated as an array of label.Instance with one element, `nil`.

When computing the endpoints for EDS in `DiscoveryServer.loadAssignmentsForClusterIsolated()` that match this subset there is a special handling for label selectors with no elements which results in all endpoints accepted:
https://github.com/istio/istio/blob/2fa151ab385999535517c489165164a8deb650b1/pkg/config/labels/collection.go#L23-L37

But when c contains a single element `nil`, then the function always returns false when the endpoint also has no label, resulting in no endpoints assigned to that cluster.
(I didn't test it, but I would assume that if an endpoint has at least one label that the code should panic in line 32 on a nil dereference)

The fix handles no or an empty label selector on the subset as `nil` instead of of `[]labels.Instance{nil}`