### PR TITLE
Ignore base image vulnerabilities during release testing

### DIFF
--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -49,8 +49,8 @@ MANIFEST=$(cat <<EOF
 version: ${VERSION}
 docker: ${DOCKER_HUB}
 directory: ${WORK_DIR}
-dependencies:
 ignoreVulnerability: true
+dependencies:
 ${DEPENDENCIES:-$(cat <<EOD
   istio:
     localpath: ${ROOT}

--- a/prow/release-commit.sh
+++ b/prow/release-commit.sh
@@ -50,6 +50,7 @@ version: ${VERSION}
 docker: ${DOCKER_HUB}
 directory: ${WORK_DIR}
 dependencies:
+ignoreVulnerability: true
 ${DEPENDENCIES:-$(cat <<EOD
   istio:
     localpath: ${ROOT}


### PR DESCRIPTION

I'll create the PR to prevent a base image vulnerability from failing the release test.

Is there any discussion that relates to if there should be a failure in this case. I would say no unless we had some automation in place to build/push new images so the pipeline wouldn't be stopped until someone was available. If automation was in place, then failing this test might make sense.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure