### PR TITLE
Azure Platform Support

### DIFF
--- a/pkg/bootstrap/platform/azure.go
+++ b/pkg/bootstrap/platform/azure.go
@@ -168,12 +168,13 @@ func (e *azureEnv) azureName() string {
 	return ""
 }
 
+// Returns the Azure tags prefixed by "azure_"
 func (e *azureEnv) azureTags() map[string]string {
 	tags := map[string]string{}
 	if at, ok := e.computeMetadata["tags"]; ok && len(at.(string)) > 0 {
 		for _, tag := range strings.Split(at.(string), ";") {
 			kv := strings.Split(tag, ":")
-			tags[kv[0]] = kv[1]
+			tags["azure_"+kv[0]] = kv[1]
 		}
 	}
 	return tags

--- a/pkg/bootstrap/platform/azure.go
+++ b/pkg/bootstrap/platform/azure.go
@@ -1,0 +1,189 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package platform
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+
+	"istio.io/pkg/log"
+)
+
+const (
+	AzureMetadataEndpoint = "http://169.254.169.254"
+	InstanceUrl           = AzureMetadataEndpoint + "/metadata/instance"
+	DefaultAPIVersion     = "2019-08-15"
+	SysVendorPath         = "/sys/class/dmi/id/sys_vendor"
+	MicrosoftIdentifier   = "Microsoft Corporation"
+)
+
+var (
+	// Attempts to update the API version
+	updateAPIVersion = func(e *azureEnv) {
+		for _, version := range getAPIVersions() {
+			if strings.Compare(version, e.APIVersion) > 0 {
+				e.APIVersion = version
+			}
+		}
+	}
+	getAPIVersions = func() []string {
+		versions := []string{}
+		client := http.Client{Timeout: defaultTimeout}
+		req, err := http.NewRequest("GET", InstanceUrl, nil)
+		if err != nil {
+			log.Warnf("Failed to create HTTP request: %v", err)
+			return versions
+		}
+		req.Header.Add("Metadata", "True")
+
+		response, err := client.Do(req)
+		if err != nil {
+			log.Warnf("HTTP request failed: %v", err)
+			return versions
+		}
+		if response.StatusCode != http.StatusOK {
+			log.Warnf("HTTP request unsuccessful with status: %v", response.Status)
+		}
+		defer response.Body.Close()
+		body, err := ioutil.ReadAll(response.Body)
+		if err != nil {
+			log.Warnf("Could not read response body: %v", err)
+			return versions
+		}
+		bodyJson := &map[string]interface{}{}
+		if err = json.Unmarshal(body, bodyJson); err != nil {
+			log.Warnf("Could not unmarshal response: %v:", err)
+			return versions
+		}
+		if newestVersions, ok := (*bodyJson)["newest-versions"]; ok {
+			versions = newestVersions.([]string)
+		}
+		return versions
+	}
+
+	// Retrieves Azure instance metadata and stores it in the Azure environment
+	// Uses the default timeout for the HTTP get request
+	azureMetadataFn = func(e *azureEnv) {
+		metadata := &map[string]interface{}{}
+		body := []byte(getAzureMetadata())
+		if err := json.Unmarshal(body, metadata); err != nil {
+			log.Warnf("Could not unmarshal response: %v:", err)
+			return
+		}
+		if computeMetadata, ok := (*metadata)["compute"]; ok {
+			e.computeMetadata = computeMetadata.(map[string]interface{})
+		}
+		if networkMetadata, ok := (*metadata)["network"]; ok {
+			e.networkMetadata = networkMetadata.(map[string]interface{})
+		}
+	}
+	getAzureMetadata = func() string {
+		client := &http.Client{Timeout: defaultTimeout}
+		req, err := http.NewRequest("GET", InstanceUrl, nil)
+		if err != nil {
+			log.Warnf("Failed to create HTTP request: %v", err)
+			return ""
+		}
+		req.Header.Add("Metadata", "True")
+		query := req.URL.Query()
+		query.Add("api-version", DefaultAPIVersion)
+		query.Add("format", "json")
+		req.URL.RawQuery = query.Encode()
+
+		response, err := client.Do(req)
+		if err != nil {
+			log.Warnf("HTTP request failed: %v", err)
+			return ""
+		}
+		if response.StatusCode != http.StatusOK {
+			log.Warnf("HTTP request unsuccessful with status: %v", response.Status)
+		}
+		defer response.Body.Close()
+		body, err := ioutil.ReadAll(response.Body)
+		if err != nil {
+			log.Warnf("Could not read response body: %v", err)
+			return ""
+		}
+		return string(body)
+	}
+
+	azureTagsFn = func(e *azureEnv) map[string]string {
+		tags := map[string]string{}
+		if at, ok := e.computeMetadata["tags"]; ok && len(at.(string)) > 0 {
+			for _, tag := range strings.Split(at.(string), ";") {
+				kv := strings.Split(tag, ":")
+				tags[kv[0]] = kv[1]
+			}
+		}
+		return tags
+	}
+	azureLocationFn = func(e *azureEnv) string {
+		if al, ok := e.computeMetadata["location"]; ok {
+			return al.(string)
+		}
+		return ""
+	}
+	azureZoneFn = func(e *azureEnv) string {
+		if az, ok := e.computeMetadata["zone"]; ok {
+			return az.(string)
+		}
+		return ""
+	}
+)
+
+type azureEnv struct {
+	APIVersion      string
+	computeMetadata map[string]interface{}
+	networkMetadata map[string]interface{}
+}
+
+// IsAzure returns whether or not the platform for bootstrapping is Azure
+func IsAzure() bool {
+	sysVendor, err := ioutil.ReadFile(SysVendorPath)
+	if err != nil {
+		log.Warnf("Error reading sys_vendor in Azure platform detection: %v", err)
+	}
+	return strings.Contains(string(sysVendor), MicrosoftIdentifier)
+}
+
+// NewAzure returns a platform environment for Azure
+func NewAzure() Environment {
+	e := &azureEnv{APIVersion: DefaultAPIVersion}
+	updateAPIVersion(e)
+	azureMetadataFn(e)
+	return e
+}
+
+// Metadata returns Azure instance metadata
+// Must be run from within an Azure VM
+func (e *azureEnv) Metadata() map[string]string {
+	md := map[string]string{}
+	for k, v := range azureTagsFn(e) {
+		md[k] = v
+	}
+	return md
+}
+
+// Locality returns the region and zone
+func (e *azureEnv) Locality() *core.Locality {
+	var l core.Locality
+	l.Region = azureLocationFn(e)
+	l.Zone = azureZoneFn(e)
+	return &l
+}

--- a/pkg/bootstrap/platform/azure.go
+++ b/pkg/bootstrap/platform/azure.go
@@ -33,7 +33,9 @@ const (
 	SysVendorPath          = "/sys/class/dmi/id/sys_vendor"
 	MicrosoftIdentifier    = "Microsoft Corporation"
 
-	AzureName = "azure_name"
+	AzureName     = "azure_name"
+	AzureLocation = "azure_location"
+	AzureVMID     = "azure_vm_id"
 )
 
 var (
@@ -43,6 +45,7 @@ var (
 	azureMetadataFn = func(e *azureEnv) string {
 		return metadataRequest(fmt.Sprintf("api-version=%s", e.APIVersion))
 	}
+
 	azureNameFn = func(e *azureEnv) string {
 		if an, ok := e.computeMetadata["name"]; ok {
 			return an.(string)
@@ -68,6 +71,12 @@ var (
 	azureZoneFn = func(e *azureEnv) string {
 		if az, ok := e.computeMetadata["zone"]; ok {
 			return az.(string)
+		}
+		return ""
+	}
+	azureVMIDFn = func(e *azureEnv) string {
+		if aid, ok := e.computeMetadata["vmId"]; ok {
+			return aid.(string)
 		}
 		return ""
 	}
@@ -160,7 +169,15 @@ func stringToJSON(s string) map[string]interface{} {
 // Returns Azure instance metadata. Must be run on an Azure VM
 func (e *azureEnv) Metadata() map[string]string {
 	md := map[string]string{}
-	md[AzureName] = azureNameFn(e)
+	if an := azureNameFn(e); an != "" {
+		md[AzureName] = an
+	}
+	if al := azureLocationFn(e); al != "" {
+		md[AzureLocation] = al
+	}
+	if aid := azureVMIDFn(e); aid != "" {
+		md[AzureVMID] = aid
+	}
 	for k, v := range azureTagsFn(e) {
 		md[k] = v
 	}

--- a/pkg/bootstrap/platform/azure.go
+++ b/pkg/bootstrap/platform/azure.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	AzureMetadataEndpoint = "http://169.254.169.254"
-	InstanceUrl           = AzureMetadataEndpoint + "/metadata/instance"
+	InstanceURL           = AzureMetadataEndpoint + "/metadata/instance"
 	DefaultAPIVersion     = "2019-08-15"
 	SysVendorPath         = "/sys/class/dmi/id/sys_vendor"
 	MicrosoftIdentifier   = "Microsoft Corporation"
@@ -86,8 +86,8 @@ func IsAzure() bool {
 // Attempts to update the API version
 func updateAPIVersion() {
 	updateVersionOnce.Do(func() {
-		bodyJson := stringToJson(getAPIVersions())
-		if newestVersions, ok := bodyJson["newest-versions"]; ok {
+		bodyJSON := stringToJSON(getAPIVersions())
+		if newestVersions, ok := bodyJSON["newest-versions"]; ok {
 			for _, version := range newestVersions.([]interface{}) {
 				if strings.Compare(version.(string), APIVersion) > 0 {
 					APIVersion = version.(string)
@@ -107,11 +107,11 @@ func NewAzure() Environment {
 
 // Retrieves Azure instance metadata response body stores it in the Azure environment
 func (e *azureEnv) getMetadata() {
-	bodyJson := stringToJson(getAzureMetadata())
-	if computeMetadata, ok := bodyJson["compute"]; ok {
+	bodyJSON := stringToJSON(getAzureMetadata())
+	if computeMetadata, ok := bodyJSON["compute"]; ok {
 		e.computeMetadata = computeMetadata.(map[string]interface{})
 	}
-	if networkMetadata, ok := bodyJson["network"]; ok {
+	if networkMetadata, ok := bodyJSON["network"]; ok {
 		e.networkMetadata = networkMetadata.(map[string]interface{})
 	}
 }
@@ -120,7 +120,7 @@ func (e *azureEnv) getMetadata() {
 // Uses the default timeout for the HTTP get request
 func metadataRequest(query string) string {
 	client := http.Client{Timeout: defaultTimeout}
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s?%s", InstanceUrl, query), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s?%s", InstanceURL, query), nil)
 	if err != nil {
 		log.Warnf("Failed to create HTTP request: %v", err)
 		return ""
@@ -144,12 +144,12 @@ func metadataRequest(query string) string {
 	return string(body)
 }
 
-func stringToJson(s string) map[string]interface{} {
-	var sJson map[string]interface{}
-	if err := json.Unmarshal([]byte(s), &sJson); err != nil {
+func stringToJSON(s string) map[string]interface{} {
+	var stringJSON map[string]interface{}
+	if err := json.Unmarshal([]byte(s), &stringJSON); err != nil {
 		log.Warnf("Could not unmarshal response: %v:", err)
 	}
-	return sJson
+	return stringJSON
 }
 
 // Returns Azure instance metadata. Must be run on an Azure VM

--- a/pkg/bootstrap/platform/azure_test.go
+++ b/pkg/bootstrap/platform/azure_test.go
@@ -65,7 +65,7 @@ func TestAzureMetadata(t *testing.T) {
 	}{
 		{"ignore empty response", "", map[string]string{}},
 		{"parse fields", MockMetadata,
-			map[string]string{"Department": "IT", "Environment": "Prod", "Role": "WorkerRole",
+			map[string]string{"azure_Department": "IT", "azure_Environment": "Prod", "azure_Role": "WorkerRole",
 				AzureName: "negasonic", AzureLocation: "centralus", AzureVMID: "13f56399-bd52-4150-9748-7190aae1ff21"}},
 	}
 

--- a/pkg/bootstrap/platform/azure_test.go
+++ b/pkg/bootstrap/platform/azure_test.go
@@ -1,0 +1,37 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package platform
+
+import (
+	"testing"
+)
+
+func mockVersion() []string {
+	return []string{"9999-12-31"}
+}
+
+// Returns a sample response json (from Microsoft API documentation)
+func mockMetadata() string {
+	mockJson := "{\n  \"compute\": {\n    \"azEnvironment\": \"AzurePublicCloud\",\n    \"customData\": \"\",\n    \"location\": \"centralus\",\n    \"name\": \"negasonic\",\n    \"offer\": \"lampstack\",\n    \"osType\": \"Linux\",\n    \"placementGroupId\": \"\",\n    \"plan\": {\n        \"name\": \"5-6\",\n        \"product\": \"lampstack\",\n        \"publisher\": \"bitnami\"\n    },\n    \"platformFaultDomain\": \"0\",\n    \"platformUpdateDomain\": \"0\",\n    \"provider\": \"Microsoft.Compute\",\n    \"publicKeys\": [],\n    \"publisher\": \"bitnami\",\n    \"resourceGroupName\": \"myrg\",\n    \"resourceId\": \"/subscriptions/xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx/resourceGroups/myrg/providers/Microsoft.Compute/virtualMachines/negasonic\",\n    \"sku\": \"5-6\",\n    \"storageProfile\": {\n        \"dataDisks\": [\n          {\n            \"caching\": \"None\",\n            \"createOption\": \"Empty\",\n            \"diskSizeGB\": \"1024\",\n            \"image\": {\n              \"uri\": \"\"\n            },\n            \"lun\": \"0\",\n            \"managedDisk\": {\n              \"id\": \"/subscriptions/xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx/resourceGroups/macikgo-test-may-23/providers/Microsoft.Compute/disks/exampledatadiskname\",\n              \"storageAccountType\": \"Standard_LRS\"\n            },\n            \"name\": \"exampledatadiskname\",\n            \"vhd\": {\n              \"uri\": \"\"\n            },\n            \"writeAcceleratorEnabled\": \"false\"\n          }\n        ],\n        \"imageReference\": {\n          \"id\": \"\",\n          \"offer\": \"UbuntuServer\",\n          \"publisher\": \"Canonical\",\n          \"sku\": \"16.04.0-LTS\",\n          \"version\": \"latest\"\n        },\n        \"osDisk\": {\n          \"caching\": \"ReadWrite\",\n          \"createOption\": \"FromImage\",\n          \"diskSizeGB\": \"30\",\n          \"diffDiskSettings\": {\n            \"option\": \"Local\"\n          },\n          \"encryptionSettings\": {\n            \"enabled\": \"false\"\n          },\n          \"image\": {\n            \"uri\": \"\"\n          },\n          \"managedDisk\": {\n            \"id\": \"/subscriptions/xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx/resourceGroups/macikgo-test-may-23/providers/Microsoft.Compute/disks/exampleosdiskname\",\n            \"storageAccountType\": \"Standard_LRS\"\n          },\n          \"name\": \"exampleosdiskname\",\n          \"osType\": \"Linux\",\n          \"vhd\": {\n            \"uri\": \"\"\n          },\n          \"writeAcceleratorEnabled\": \"false\"\n        }\n    },\n    \"subscriptionId\": \"xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx\",\n    \"tags\": \"Department:IT;Environment:Prod;Role:WorkerRole\",\n    \"version\": \"7.1.1902271506\",\n    \"vmId\": \"13f56399-bd52-4150-9748-7190aae1ff21\",\n    \"vmScaleSetName\": \"\",\n    \"vmSize\": \"Standard_A1_v2\",\n    \"zone\": \"1\"\n  },\n  \"network\": {\n    \"interface\": [\n      {\n        \"ipv4\": {\n          \"ipAddress\": [\n            {\n              \"privateIpAddress\": \"10.1.2.5\",\n              \"publicIpAddress\": \"X.X.X.X\"\n            }\n          ],\n          \"subnet\": [\n            {\n              \"address\": \"10.1.2.0\",\n              \"prefix\": \"24\"\n            }\n          ]\n        },\n        \"ipv6\": {\n          \"ipAddress\": []\n        },\n        \"macAddress\": \"000D3A36DDED\"\n      }\n    ]\n  }\n}"
+	return mockJson
+}
+
+func TestAzureMetadata(t *testing.T) {
+	getAPIVersions = mockVersion
+	getAzureMetadata = mockMetadata
+	e := NewAzure()
+	e.Metadata()
+	e.Locality()
+}

--- a/pkg/bootstrap/platform/azure_test.go
+++ b/pkg/bootstrap/platform/azure_test.go
@@ -15,23 +15,75 @@
 package platform
 
 import (
+	"fmt"
+	"reflect"
+	"sync"
 	"testing"
+
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 )
 
-func mockVersion() []string {
-	return []string{"9999-12-31"}
-}
+// Mock responses for Azure Metadata (based on Microsoft API documentation samples)
+// https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service
+const (
+	MockVersionsTemplate = "{\"error\": \"Bad request. api-version was not specified in the request\",\"newest-versions\": [\"%s\"]}"
+	MockMetadata         = "{\"compute\": {\"location\": \"centralus\", \"name\": \"negasonic\", \"tags\": \"Department:IT;Environment:Prod;Role:WorkerRole\", \"vmId\": \"13f56399-bd52-4150-9748-7190aae1ff21\", \"zone\": \"1\"}}"
+)
 
-// Returns a sample response json (from Microsoft API documentation)
-func mockMetadata() string {
-	mockJson := "{\n  \"compute\": {\n    \"azEnvironment\": \"AzurePublicCloud\",\n    \"customData\": \"\",\n    \"location\": \"centralus\",\n    \"name\": \"negasonic\",\n    \"offer\": \"lampstack\",\n    \"osType\": \"Linux\",\n    \"placementGroupId\": \"\",\n    \"plan\": {\n        \"name\": \"5-6\",\n        \"product\": \"lampstack\",\n        \"publisher\": \"bitnami\"\n    },\n    \"platformFaultDomain\": \"0\",\n    \"platformUpdateDomain\": \"0\",\n    \"provider\": \"Microsoft.Compute\",\n    \"publicKeys\": [],\n    \"publisher\": \"bitnami\",\n    \"resourceGroupName\": \"myrg\",\n    \"resourceId\": \"/subscriptions/xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx/resourceGroups/myrg/providers/Microsoft.Compute/virtualMachines/negasonic\",\n    \"sku\": \"5-6\",\n    \"storageProfile\": {\n        \"dataDisks\": [\n          {\n            \"caching\": \"None\",\n            \"createOption\": \"Empty\",\n            \"diskSizeGB\": \"1024\",\n            \"image\": {\n              \"uri\": \"\"\n            },\n            \"lun\": \"0\",\n            \"managedDisk\": {\n              \"id\": \"/subscriptions/xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx/resourceGroups/macikgo-test-may-23/providers/Microsoft.Compute/disks/exampledatadiskname\",\n              \"storageAccountType\": \"Standard_LRS\"\n            },\n            \"name\": \"exampledatadiskname\",\n            \"vhd\": {\n              \"uri\": \"\"\n            },\n            \"writeAcceleratorEnabled\": \"false\"\n          }\n        ],\n        \"imageReference\": {\n          \"id\": \"\",\n          \"offer\": \"UbuntuServer\",\n          \"publisher\": \"Canonical\",\n          \"sku\": \"16.04.0-LTS\",\n          \"version\": \"latest\"\n        },\n        \"osDisk\": {\n          \"caching\": \"ReadWrite\",\n          \"createOption\": \"FromImage\",\n          \"diskSizeGB\": \"30\",\n          \"diffDiskSettings\": {\n            \"option\": \"Local\"\n          },\n          \"encryptionSettings\": {\n            \"enabled\": \"false\"\n          },\n          \"image\": {\n            \"uri\": \"\"\n          },\n          \"managedDisk\": {\n            \"id\": \"/subscriptions/xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx/resourceGroups/macikgo-test-may-23/providers/Microsoft.Compute/disks/exampleosdiskname\",\n            \"storageAccountType\": \"Standard_LRS\"\n          },\n          \"name\": \"exampleosdiskname\",\n          \"osType\": \"Linux\",\n          \"vhd\": {\n            \"uri\": \"\"\n          },\n          \"writeAcceleratorEnabled\": \"false\"\n        }\n    },\n    \"subscriptionId\": \"xxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx\",\n    \"tags\": \"Department:IT;Environment:Prod;Role:WorkerRole\",\n    \"version\": \"7.1.1902271506\",\n    \"vmId\": \"13f56399-bd52-4150-9748-7190aae1ff21\",\n    \"vmScaleSetName\": \"\",\n    \"vmSize\": \"Standard_A1_v2\",\n    \"zone\": \"1\"\n  },\n  \"network\": {\n    \"interface\": [\n      {\n        \"ipv4\": {\n          \"ipAddress\": [\n            {\n              \"privateIpAddress\": \"10.1.2.5\",\n              \"publicIpAddress\": \"X.X.X.X\"\n            }\n          ],\n          \"subnet\": [\n            {\n              \"address\": \"10.1.2.0\",\n              \"prefix\": \"24\"\n            }\n          ]\n        },\n        \"ipv6\": {\n          \"ipAddress\": []\n        },\n        \"macAddress\": \"000D3A36DDED\"\n      }\n    ]\n  }\n}"
-	return mockJson
+func TestVersionUpdate(t *testing.T) {
+	oldGetAPIVersions, oldAPIVersion := getAPIVersions, APIVersion
+	defer func() { getAPIVersions, APIVersion = oldGetAPIVersions, oldAPIVersion }()
+	MinDate, MaxDate := "0000-00-00", "9999-12-31"
+	tests := []struct {
+		name     string
+		response string
+		version  string
+	}{
+		{"ignore empty response", "", oldAPIVersion},
+		{"ignore smaller version", fmt.Sprintf(MockVersionsTemplate, MinDate), oldAPIVersion},
+		{"ignore no version", fmt.Sprintf(MockVersionsTemplate, ""), oldAPIVersion},
+		{"use larger version", fmt.Sprintf(MockVersionsTemplate, MaxDate), MaxDate},
+	}
+
+	for idx, tt := range tests {
+		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
+			getAPIVersions = func() string { return tt.response }
+			updateVersionOnce = sync.Once{}
+			updateAPIVersion()
+			if APIVersion != tt.version {
+				t.Errorf("updateAPIVersion() => '%v'; want '%v'", APIVersion, tt.version)
+			}
+		})
+	}
 }
 
 func TestAzureMetadata(t *testing.T) {
-	getAPIVersions = mockVersion
-	getAzureMetadata = mockMetadata
-	e := NewAzure()
-	e.Metadata()
-	e.Locality()
+	oldGetAPIVersions, oldGetAzureMetadata := getAPIVersions, getAzureMetadata
+	defer func() { getAPIVersions, getAzureMetadata = oldGetAPIVersions, oldGetAzureMetadata }()
+	tests := []struct {
+		name     string
+		response string
+		metadata map[string]string
+		locality core.Locality
+	}{
+		{"ignore empty response", "", map[string]string{}, core.Locality{}},
+		{"parse fields", MockMetadata,
+			map[string]string{"Department": "IT", "Environment": "Prod", "Role": "WorkerRole"},
+			core.Locality{Region: "centralus", Zone: "1"}},
+	}
+
+	// Prevent actual requests to metadata server for updating the API version
+	getAPIVersions = func() string { return "" }
+	for idx, tt := range tests {
+		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
+			getAzureMetadata = func() string { return tt.response }
+			e := NewAzure()
+			if metadata := e.Metadata(); !reflect.DeepEqual(metadata, tt.metadata) {
+				t.Errorf("Metadata() => '%v'; want '%v'", metadata, tt.metadata)
+			}
+			if locality := *e.Locality(); !reflect.DeepEqual(locality, tt.locality) {
+				t.Errorf("Locality() => '%v'; want '%v'", locality, tt.locality)
+			}
+		})
+	}
 }

--- a/pkg/bootstrap/platform/azure_test.go
+++ b/pkg/bootstrap/platform/azure_test.go
@@ -23,9 +23,9 @@ import (
 // Mock responses for Azure Metadata (based on Microsoft API documentation samples)
 // https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service
 const (
-	MockVersionsTemplate = "{\"error\": \"Bad request. api-version was not specified in the request\",\"newest-versions\": [\"%s\"]}"
-	MockMetadata         = "{\"compute\": {\"location\": \"centralus\", \"name\": \"negasonic\", \"tags\": \"Department:IT;Environment:Prod;Role:WorkerRole\", " +
-		"\"vmId\": \"13f56399-bd52-4150-9748-7190aae1ff21\", \"zone\": \"1\"}}"
+	MockVersionsTemplate = `{"error": "Bad request. api-version was not specified in the request","newest-versions": ["%s"]}`
+	MockMetadata         = `{"compute": {"location": "centralus", "name": "negasonic", "tags": "Department:IT;Environment:Prod;Role:WorkerRole", ` +
+		`"vmId": "13f56399-bd52-4150-9748-7190aae1ff21", "zone": "1"}}`
 )
 
 func TestAzureVersionUpdate(t *testing.T) {
@@ -73,7 +73,7 @@ func TestAzureMetadata(t *testing.T) {
 	azureAPIVersionsFn = func() string { return "" }
 	for idx, tt := range tests {
 		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
-			azureMetadataFn = func(e *azureEnv) string { return tt.response }
+			azureMetadataFn = func(string) string { return tt.response }
 			e := NewAzure()
 			if metadata := e.Metadata(); !reflect.DeepEqual(metadata, tt.metadata) {
 				t.Errorf("Metadata() => '%v'; want '%v'", metadata, tt.metadata)

--- a/pkg/bootstrap/platform/azure_test.go
+++ b/pkg/bootstrap/platform/azure_test.go
@@ -64,7 +64,9 @@ func TestAzureMetadata(t *testing.T) {
 		metadata map[string]string
 	}{
 		{"ignore empty response", "", map[string]string{}},
-		{"parse fields", MockMetadata, map[string]string{"Department": "IT", "Environment": "Prod", "Role": "WorkerRole"}},
+		{"parse fields", MockMetadata,
+			map[string]string{"Department": "IT", "Environment": "Prod", "Role": "WorkerRole",
+				AzureName: "negasonic", AzureLocation: "centralus", AzureVMID: "13f56399-bd52-4150-9748-7190aae1ff21"}},
 	}
 
 	// Prevent actual requests to metadata server for updating the API version

--- a/pkg/bootstrap/platform/azure_test.go
+++ b/pkg/bootstrap/platform/azure_test.go
@@ -19,15 +19,14 @@ import (
 	"reflect"
 	"sync"
 	"testing"
-
-	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 )
 
 // Mock responses for Azure Metadata (based on Microsoft API documentation samples)
 // https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service
 const (
 	MockVersionsTemplate = "{\"error\": \"Bad request. api-version was not specified in the request\",\"newest-versions\": [\"%s\"]}"
-	MockMetadata         = "{\"compute\": {\"location\": \"centralus\", \"name\": \"negasonic\", \"tags\": \"Department:IT;Environment:Prod;Role:WorkerRole\", \"vmId\": \"13f56399-bd52-4150-9748-7190aae1ff21\", \"zone\": \"1\"}}"
+	MockMetadata         = "{\"compute\": {\"location\": \"centralus\", \"name\": \"negasonic\", \"tags\": \"Department:IT;Environment:Prod;Role:WorkerRole\", " +
+		"\"vmId\": \"13f56399-bd52-4150-9748-7190aae1ff21\", \"zone\": \"1\"}}"
 )
 
 func TestVersionUpdate(t *testing.T) {
@@ -64,12 +63,9 @@ func TestAzureMetadata(t *testing.T) {
 		name     string
 		response string
 		metadata map[string]string
-		locality core.Locality
 	}{
-		{"ignore empty response", "", map[string]string{}, core.Locality{}},
-		{"parse fields", MockMetadata,
-			map[string]string{"Department": "IT", "Environment": "Prod", "Role": "WorkerRole"},
-			core.Locality{Region: "centralus", Zone: "1"}},
+		{"ignore empty response", "", map[string]string{}},
+		{"parse fields", MockMetadata, map[string]string{"Department": "IT", "Environment": "Prod", "Role": "WorkerRole"}},
 	}
 
 	// Prevent actual requests to metadata server for updating the API version
@@ -80,9 +76,6 @@ func TestAzureMetadata(t *testing.T) {
 			e := NewAzure()
 			if metadata := e.Metadata(); !reflect.DeepEqual(metadata, tt.metadata) {
 				t.Errorf("Metadata() => '%v'; want '%v'", metadata, tt.metadata)
-			}
-			if locality := *e.Locality(); !reflect.DeepEqual(locality, tt.locality) {
-				t.Errorf("Locality() => '%v'; want '%v'", locality, tt.locality)
 			}
 		})
 	}

--- a/pkg/bootstrap/platform/discovery.go
+++ b/pkg/bootstrap/platform/discovery.go
@@ -20,6 +20,7 @@ import (
 )
 
 const defaultTimeout = 5 * time.Second
+const Platforms = 3
 
 // Discover attempts to discover the host platform, defaulting to
 // `Unknown` if a platform cannot be discovered.
@@ -30,11 +31,11 @@ func Discover() Environment {
 // DiscoverWithTimeout attempts to discover the host platform, defaulting to
 // `Unknown` after the provided timeout.
 func DiscoverWithTimeout(timeout time.Duration) Environment {
-	plat := make(chan Environment, 2) // sized to match number of platform goroutines
+	plat := make(chan Environment, Platforms) // sized to match number of platform goroutines
 	done := make(chan bool)
 
 	var wg sync.WaitGroup
-	wg.Add(2) // check GCP and AWS
+	wg.Add(Platforms) // check GCP, AWS, and Azure
 
 	go func() {
 		if IsGCP() {
@@ -46,6 +47,13 @@ func DiscoverWithTimeout(timeout time.Duration) Environment {
 	go func() {
 		if IsAWS() {
 			plat <- NewAWS()
+		}
+		wg.Done()
+	}()
+
+	go func() {
+		if IsAzure() {
+			plat <- NewAzure()
 		}
 		wg.Done()
 	}()


### PR DESCRIPTION
Support for the Azure platform with a few metadata attributes extracted as proof of functionality.
Checked that retrieved metadata and locality are as expected in comparison to the API curl request described on https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service

Metadata() is incomplete at the moment, but azure_name, azure_location, and azure_vm_id are basic attributes that have been added in. The others are parsed from the tags field. An example of the metadata:

      "PLATFORM_METADATA": {
       "azure_vm_id": "5376324d-0cd7-4e3a-b350-d967eb74d097",
       "azure_location": "centralus",
       "orchestrator": "Kubernetes",
       "creationSource": "aks-aks-nodepool1-34440236-vmss",
       "azure_name": "aks-nodepool1-34440236-vmss_0",
       "poolName": "nodepool1",
       "resourceNameSuffix": "34440236",
       "aksEngineVersion": "v0.47.0-aks-gomod-63-aks"
      },

[X ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure