### PR TITLE
Drop requests from 100 -> 50 for locality tests

### DIFF
--- a/tests/integration/pilot/locality/distribute_test.go
+++ b/tests/integration/pilot/locality/distribute_test.go
@@ -84,8 +84,8 @@ func TestDistribute(t *testing.T) {
 
 			if err := retry.UntilSuccess(func() error {
 				e := sendTraffic(a, fakeHostname, map[string]int{
-					"b": 20,
-					"c": 80,
+					"b": 10,
+					"c": 40,
 				})
 				scopes.Framework.Errorf("%v: ", e)
 				return e
@@ -112,9 +112,9 @@ func TestDistribute(t *testing.T) {
 
 			if err := retry.UntilSuccess(func() error {
 				e := sendTraffic(a, fakeHostname, map[string]int{
-					"a": 33,
-					"b": 33,
-					"c": 33,
+					"a": 17,
+					"b": 17,
+					"c": 17,
 				})
 				scopes.Framework.Errorf("%v: ", e)
 				return e

--- a/tests/integration/pilot/locality/main_test.go
+++ b/tests/integration/pilot/locality/main_test.go
@@ -40,7 +40,7 @@ import (
 )
 
 const (
-	sendCount = 100
+	sendCount = 50
 
 	deploymentYAML = `
 apiVersion: networking.istio.io/v1alpha3
@@ -308,7 +308,7 @@ func sendTraffic(from echo.Instance, host string, expected map[string]int) error
 	}
 	for svc, reqs := range got {
 		expect := expected[svc]
-		if !almostEquals(reqs, expect, 5) {
+		if !almostEquals(reqs, expect, 3) {
 			return fmt.Errorf("unexpected request distribution. Expected: %+v, got: %+v", expected, got)
 		}
 	}


### PR DESCRIPTION
Sending 100 requests at once seems to overwhelm CI sometimes:
https://github.com/istio/istio/issues/25010

Trying to drop it down a bit



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure