### PR TITLE
Log framework scope even without CI flag

### DIFF
--- a/pkg/test/framework/logging.go
+++ b/pkg/test/framework/logging.go
@@ -40,8 +40,6 @@ func configureLogging(ciMode bool) error {
 
 	if ciMode {
 		o.SetOutputLevel(scopes.Framework.Name(), log.DebugLevel)
-	} else {
-		o.SetOutputLevel(scopes.Framework.Name(), log.NoneLevel)
 	}
 
 	return log.Configure(&o)


### PR DESCRIPTION
This way users still see some level of logging. They can always disable
it explicitly if, for whatever reason, they want no logs.

The context here its impossible to run with framework:info currently,
which is my preferred log level



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure