### PR TITLE
Fixes 24969. Fix eds endpoint selection for subsets with no or empty …

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -792,6 +792,9 @@ func (ps *PushContext) SubsetToLabels(proxy *Proxy, subsetName string, hostname 
 	rule := cfg.Spec.(*networking.DestinationRule)
 	for _, subset := range rule.Subsets {
 		if subset.Name == subsetName {
+			if len(subset.Labels) == 0 {
+				return nil
+			}
 			return []labels.Instance{subset.Labels}
 		}
 	}


### PR DESCRIPTION
…subset labels



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

This PR fixes the behavior reported in #24969.
Currently, when a DestinationRule has a subset with no label selector it is treated as an array of label.Instance with one element, `nil`.

When computing the endpoints for EDS in `DiscoveryServer.loadAssignmentsForClusterIsolated()` that match this subset there is a special handling for label selectors with no elements which results in all endpoints accepted:
https://github.com/istio/istio/blob/2fa151ab385999535517c489165164a8deb650b1/pkg/config/labels/collection.go#L23-L37

But when c contains a single element `nil`, then the function always returns false when the endpoint also has no label, resulting in no endpoints assigned to that cluster.
(I didn't test it, but I would assume that if an endpoint has at least one label that the code should panic in line 32 on a nil dereference)

The fix handles no or an empty label selector on the subset as `nil` instead of of `[]labels.Instance{nil}`

Note: I already opened #24970 which targeted the release-1.6 branch. 
This PR is for master which seems to show the same problem.