### PR TITLE
Update go to 1.14 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module istio.io/istio
 
-go 1.13
+go 1.14
 
 replace github.com/golang/glog => github.com/istio/glog v0.0.0-20190424172949-d7cfb6fa2ccd
 


### PR DESCRIPTION
[Build tools ](https://github.com/istio/tools/pull/872) uses `1.14.2` and most of the breakages are fixed in https://github.com/istio/istio/issues/21567 so I think it's safe to move from `1.13` to `1.14`.
