### PR TITLE
Update go version for tcp-echo sample and rpm build

### DIFF
--- a/samples/tcp-echo/src/Dockerfile
+++ b/samples/tcp-echo/src/Dockerfile
@@ -16,7 +16,7 @@
 ARG BASE_DISTRIBUTION=default
 
 # build a tcp-echo binary using the golang container
-FROM golang:1.14 as builder
+FROM golang:1.14.2 as builder
 WORKDIR /go/src/istio.io/tcp-echo-server/
 COPY main.go .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o tcp-echo main.go

--- a/samples/tcp-echo/src/Dockerfile
+++ b/samples/tcp-echo/src/Dockerfile
@@ -16,7 +16,7 @@
 ARG BASE_DISTRIBUTION=default
 
 # build a tcp-echo binary using the golang container
-FROM golang:1.12 as builder
+FROM golang:1.14 as builder
 WORKDIR /go/src/istio.io/tcp-echo-server/
 COPY main.go .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o tcp-echo main.go

--- a/tools/packaging/rpm/Dockerfile.build
+++ b/tools/packaging/rpm/Dockerfile.build
@@ -9,7 +9,7 @@ RUN yum install -y centos-release-scl epel-release && \
     yum clean all
 
 # Install go (go package in yum repositories is too old)
-RUN curl -o /root/go.tar.gz https://dl.google.com/go/go1.13.4.linux-amd64.tar.gz && \
+RUN curl -o /root/go.tar.gz https://dl.google.com/go/go1.14.2.linux-amd64.tar.gz && \
     tar zxf /root/go.tar.gz -C /usr/local
 ENV GOROOT=/usr/local/go \
     PATH=/usr/local/go/bin:/opt/rh/rh-git218/root/usr/bin:/opt/rh/devtoolset-7/root/usr/bin:/opt/llvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${PATH}


### PR DESCRIPTION
Few leftovers go version update found during https://github.com/istio/istio/pull/25022. I wasn't able to test rpm build, I think @jwendell can help here ?
