### PR TITLE
Align helm and istioctl settings

### DIFF
--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -93,8 +93,10 @@ spec:
             {{- range $key, $val := $gateway.ports }}
             - containerPort: {{ $val.targetPort | default $val.port }}
             {{- end }}
+            {{- if $.Values.global.meshExpansion.enabled }}
             {{- range $key, $val := $gateway.meshExpansionPorts }}
             - containerPort: {{ $val.targetPort | default $val.port }}
+            {{- end }}
             {{- end }}
             - containerPort: 15090
               protocol: TCP

--- a/manifests/charts/global.yaml
+++ b/manifests/charts/global.yaml
@@ -27,8 +27,6 @@ global:
 
   policyNamespace: istio-system
 
-  configRootNamespace: istio-system
-
   ## End new settings
   ## After this line we have the old Istio settings.
 
@@ -123,8 +121,8 @@ global:
     image: proxyv2
     resources:
       limits:
-        cpu: 100m
-        memory: 50Mi
+        cpu: 2000m
+        memory: 1024Mi
       requests:
         cpu: 10m
         memory: 10Mi
@@ -400,11 +398,11 @@ meshConfig:
   defaultConfig:
     proxyMetadata: {}
     tracing:
-      tlsSettings:
-        mode: DISABLE # DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
-        clientCertificate: # example: /etc/istio/tracer/cert-chain.pem
-        privateKey:        # example: /etc/istio/tracer/key.pem
-        caCertificates:    # example: /etc/istio/tracer/root-cert.pem
-        sni:               # example: tracer.somedomain
-        subjectAltNames: []
+#      tlsSettings:
+#        mode: DISABLE # DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
+#        clientCertificate: # example: /etc/istio/tracer/cert-chain.pem
+#        privateKey:        # example: /etc/istio/tracer/key.pem
+#        caCertificates:    # example: /etc/istio/tracer/root-cert.pem
+#        sni:               # example: tracer.somedomain
+#        subjectAltNames: []
         # - tracer.somedomain

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -38,13 +38,6 @@ data:
       proxyMetadata:
         DNS_AGENT: ""
       tracing:
-        tlsSettings:
-          caCertificates: null
-          clientCertificate: null
-          mode: DISABLE
-          privateKey: null
-          sni: null
-          subjectAltNames: []
         zipkin:
           address: zipkin.istio-system:9411
     disableMixerHttpReports: true
@@ -73,7 +66,6 @@ data:
         },
         "caAddress": "",
         "centralIstiod": false,
-        "configRootNamespace": "istio-system",
         "configValidation": true,
         "controlPlaneSecurityEnabled": true,
         "createRemoteSvcEndpoints": false,
@@ -152,8 +144,8 @@ data:
           "image": "proxyv2",
           "resources": {
             "limits": {
-              "cpu": "100m",
-              "memory": "50Mi"
+              "cpu": "2000m",
+              "memory": "1024Mi"
             },
             "requests": {
               "cpu": "10m",
@@ -205,7 +197,8 @@ data:
         "objectSelector": {
           "autoInject": true,
           "enabled": false
-        }
+        },
+        "rewriteAppHTTPProbe": true
       }
     }
 
@@ -756,8 +749,8 @@ spec:
             httpGet:
               path: /ready
               port: 8080
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            initialDelaySeconds: 1
+            periodSeconds: 3
             timeoutSeconds: 5
           env:
           - name: REVISION

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -97,8 +97,8 @@ spec:
             httpGet:
               path: /ready
               port: 8080
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            initialDelaySeconds: 1
+            periodSeconds: 3
             timeoutSeconds: 5
           env:
           - name: REVISION

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -132,6 +132,8 @@ sidecarInjectorWebhook:
     enabled: false
     autoInject: true
 
+  rewriteAppHTTPProbe: true
+
 telemetry:
   enabled: true
   v1:

--- a/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -20,7 +20,6 @@ data:
         },
         "caAddress": "",
         "centralIstiod": false,
-        "configRootNamespace": "istio-system",
         "configValidation": true,
         "controlPlaneSecurityEnabled": true,
         "createRemoteSvcEndpoints": false,
@@ -99,8 +98,8 @@ data:
           "image": "proxyv2",
           "resources": {
             "limits": {
-              "cpu": "100m",
-              "memory": "50Mi"
+              "cpu": "2000m",
+              "memory": "1024Mi"
             },
             "requests": {
               "cpu": "10m",

--- a/manifests/profiles/default.yaml
+++ b/manifests/profiles/default.yaml
@@ -416,18 +416,12 @@ spec:
         zvpn: {}
         env: {}
         meshExpansionPorts:
-          - port: 15011
-            targetPort: 15011
-            name: tcp-pilot-grpc-tls
-          - port: 15012
-            targetPort: 15012
-            name: tcp-istiod
-          - port: 8060
-            targetPort: 8060
-            name: tcp-citadel-grpc-tls
-          - port: 853
-            targetPort: 8853
-            name: tcp-dns-tls
+        - port: 15012
+          targetPort: 15012
+          name: tcp-istiod
+        - port: 853
+          targetPort: 8853
+          name: tcp-dns-tls
         secretVolumes:
           - name: ingressgateway-certs
             secretName: istio-ingressgateway-certs


### PR DESCRIPTION
We really need a way to do this automatically/use a single source of truth. But for now, we do it manually


For future reference: I ran
```
alias normalize="toJson | jq 'sort_by(.apiVersion, .Kind, .metadata.name)'| toYaml"
ik manifest generate -d manifests > /tmp/istioctl
helm3 template istio --include-crds -f manifests/charts/global.yaml manifests/charts/base > /tmp/helm
helm3 template istio --namespace istio-system manifests/charts/istio-control/istio-discovery \
		-f manifests/charts/global.yaml >> /tmp/helm
helm3 template istio --namespace istio-system manifests/charts/gateways/istio-ingress \
		-f manifests/charts/global.yaml >> /tmp/helm
vimdiff <(cat /tmp/istioctl | normalize)  <(cat /tmp/helm | normalize)
vimdiff <(cat /tmp/istioctl| k grep ConfigMap/istio-sidecar-injector.istio-system) <(cat /tmp/helm| k grep ConfigMap/istio-sidecar-injector.istio-system)
```