### PR TITLE
Use a common kubeclient/shared informer throughout Istiod

### DIFF
--- a/istioctl/cmd/authz.go
+++ b/istioctl/cmd/authz.go
@@ -111,7 +111,7 @@ func getConfigDumpFromFile(filename string) (*configdump.Wrapper, error) {
 }
 
 func getConfigDumpFromPod(podName, podNamespace string) (*configdump.Wrapper, error) {
-	kubeClient, err := kube.NewClientForConfig(kube.BuildClientCmd(kubeconfig, configContext), "")
+	kubeClient, err := kube.NewExtendedClient(kube.BuildClientCmd(kubeconfig, configContext), "")
 	if err != nil {
 		return nil, err
 	}

--- a/istioctl/cmd/dashboard.go
+++ b/istioctl/cmd/dashboard.go
@@ -312,7 +312,7 @@ func controlZDashCmd() *cobra.Command {
 
 // portForward first tries to forward localhost:remotePort to podName:remotePort, falls back to dynamic local port
 func portForward(podName, namespace, flavor, urlFormat, localAddress string, remotePort int,
-	client kube.Client, writer io.Writer) error {
+	client kube.ExtendedClient, writer io.Writer) error {
 
 	// port preference:
 	// - If --listenPort is specified, use it

--- a/istioctl/cmd/dashboard_test.go
+++ b/istioctl/cmd/dashboard_test.go
@@ -117,10 +117,10 @@ func TestDashboard(t *testing.T) {
 	}
 }
 
-func mockExecClientDashboard(_, _, _ string) (kube.Client, error) {
+func mockExecClientDashboard(_, _, _ string) (kube.ExtendedClient, error) {
 	return testKube.MockClient{}, nil
 }
 
-func mockEnvoyClientDashboard(_, _ string) (kube.Client, error) {
+func mockEnvoyClientDashboard(_, _ string) (kube.ExtendedClient, error) {
 	return testKube.MockClient{}, nil
 }

--- a/istioctl/cmd/describe.go
+++ b/istioctl/cmd/describe.go
@@ -923,7 +923,7 @@ func printVirtualService(writer io.Writer, virtualSvc model.Config, svc v1.Servi
 	}
 }
 
-func printIngressInfo(writer io.Writer, matchingServices []v1.Service, podsLabels []k8s_labels.Set, kubeClient kubernetes.Interface, configClient model.ConfigStore, client kube.Client) error { // nolint: lll
+func printIngressInfo(writer io.Writer, matchingServices []v1.Service, podsLabels []k8s_labels.Set, kubeClient kubernetes.Interface, configClient model.ConfigStore, client kube.ExtendedClient) error { // nolint: lll
 
 	pods, err := kubeClient.CoreV1().Pods(istioNamespace).List(context.TODO(), metav1.ListOptions{
 		LabelSelector: "istio=ingressgateway",
@@ -1168,7 +1168,7 @@ THIS COMMAND IS STILL UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
 	return cmd
 }
 
-func describePodServices(writer io.Writer, kubeClient kube.Client, configClient model.ConfigStore, pod *v1.Pod, matchingServices []v1.Service, podsLabels []k8s_labels.Set) error { // nolint: lll
+func describePodServices(writer io.Writer, kubeClient kube.ExtendedClient, configClient model.ConfigStore, pod *v1.Pod, matchingServices []v1.Service, podsLabels []k8s_labels.Set) error { // nolint: lll
 	var err error
 
 	byConfigDump, err := kubeClient.EnvoyDo(context.TODO(), pod.ObjectMeta.Name, pod.ObjectMeta.Namespace, "GET", "config_dump", nil)

--- a/istioctl/cmd/metrics_test.go
+++ b/istioctl/cmd/metrics_test.go
@@ -40,7 +40,7 @@ type mockPromAPI struct {
 	cannedResponse map[string]prometheus_model.Value
 }
 
-func mockExecClientAuthNoPilot(_, _, _ string) (kube.Client, error) {
+func mockExecClientAuthNoPilot(_, _, _ string) (kube.ExtendedClient, error) {
 	return &testKube.MockClient{}, nil
 }
 
@@ -85,7 +85,7 @@ func TestMetrics(t *testing.T) {
 	}
 }
 
-func mockPortForwardClientAuthPrometheus(_, _, _ string) (kube.Client, error) {
+func mockPortForwardClientAuthPrometheus(_, _, _ string) (kube.ExtendedClient, error) {
 	return &testKube.MockClient{
 		DiscoverablePods: map[string]map[string]*v1.PodList{
 			"istio-system": {

--- a/istioctl/cmd/proxyconfig_test.go
+++ b/istioctl/cmd/proxyconfig_test.go
@@ -160,8 +160,8 @@ func verifyExecTestOutput(t *testing.T, c execTestCase) {
 // mockClientExecFactoryGenerator generates a function with the same signature as
 // kubernetes.NewExecClient() that returns a mock client.
 // nolint: lll
-func mockClientExecFactoryGenerator(testResults map[string][]byte) func(kubeconfig, configContext string, _ string) (kube.Client, error) {
-	outFactory := func(_, _ string, _ string) (kube.Client, error) {
+func mockClientExecFactoryGenerator(testResults map[string][]byte) func(kubeconfig, configContext string, _ string) (kube.ExtendedClient, error) {
+	outFactory := func(_, _ string, _ string) (kube.ExtendedClient, error) {
 		return testKube.MockClient{
 			Results: testResults,
 		}, nil
@@ -170,8 +170,8 @@ func mockClientExecFactoryGenerator(testResults map[string][]byte) func(kubeconf
 	return outFactory
 }
 
-func mockEnvoyClientFactoryGenerator(testResults map[string][]byte) func(kubeconfig, configContext string) (kube.Client, error) {
-	outFactory := func(_, _ string) (kube.Client, error) {
+func mockEnvoyClientFactoryGenerator(testResults map[string][]byte) func(kubeconfig, configContext string) (kube.ExtendedClient, error) {
+	outFactory := func(_, _ string) (kube.ExtendedClient, error) {
 		return testKube.MockClient{
 			Results: testResults,
 		}, nil

--- a/istioctl/cmd/proxystatus.go
+++ b/istioctl/cmd/proxystatus.go
@@ -82,10 +82,10 @@ Retrieves last sent and last acknowledged xDS sync from Pilot to each Envoy in t
 	return statusCmd
 }
 
-func newKubeClientWithRevision(kubeconfig, configContext string, revision string) (kube.Client, error) {
-	return kube.NewClientForConfig(kube.BuildClientCmd(kubeconfig, configContext), revision)
+func newKubeClientWithRevision(kubeconfig, configContext string, revision string) (kube.ExtendedClient, error) {
+	return kube.NewExtendedClient(kube.BuildClientCmd(kubeconfig, configContext), revision)
 }
 
-func newKubeClient(kubeconfig, configContext string) (kube.Client, error) {
+func newKubeClient(kubeconfig, configContext string) (kube.ExtendedClient, error) {
 	return newKubeClientWithRevision(kubeconfig, configContext, "")
 }

--- a/istioctl/cmd/version_test.go
+++ b/istioctl/cmd/version_test.go
@@ -72,7 +72,7 @@ func TestVersion(t *testing.T) {
 	}
 }
 
-func mockExecClientVersionTest(_, _ string, _ string) (kube.Client, error) {
+func mockExecClientVersionTest(_, _ string, _ string) (kube.ExtendedClient, error) {
 	return testKube.MockClient{
 		IstioVersions: &meshInfo,
 	}, nil

--- a/mixer/adapter/kubernetesenv/kubernetesenv.go
+++ b/mixer/adapter/kubernetesenv/kubernetesenv.go
@@ -33,19 +33,19 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/dynamic"
 	k8s "k8s.io/client-go/kubernetes"
-	kubemeta "k8s.io/client-go/metadata"
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // needed for auth
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"istio.io/pkg/env"
 
 	"istio.io/istio/mixer/adapter/kubernetesenv/config"
 	ktmpl "istio.io/istio/mixer/adapter/kubernetesenv/template"
 	"istio.io/istio/mixer/adapter/metadata"
 	"istio.io/istio/mixer/pkg/adapter"
+	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/secretcontroller"
-	"istio.io/pkg/env"
 )
 
 const (
@@ -372,8 +372,8 @@ func newKubernetesClient(kubeconfigPath string, env adapter.Env) (k8s.Interface,
 	return k8s.NewForConfig(config)
 }
 
-func (b *builder) createCacheController(k8sInterface k8s.Interface, _ kubemeta.Interface, _ dynamic.Interface, clusterID string) error {
-	controller, err := runNewController(b, k8sInterface, b.kubeHandler.env)
+func (b *builder) createCacheController(clients kube.Client, clusterID string) error {
+	controller, err := runNewController(b, clients.Kube(), b.kubeHandler.env)
 	if err == nil {
 		b.Lock()
 		b.controllers[clusterID] = controller
@@ -390,11 +390,11 @@ func (b *builder) createCacheController(k8sInterface k8s.Interface, _ kubemeta.I
 	return b.kubeHandler.env.Logger().Errorf("error on creating remote controller %s err = %v", clusterID, err)
 }
 
-func (b *builder) updateCacheController(k8sInterface k8s.Interface, _ kubemeta.Interface, _ dynamic.Interface, clusterID string) error {
+func (b *builder) updateCacheController(clients kube.Client, clusterID string) error {
 	if err := b.deleteCacheController(clusterID); err != nil {
 		return err
 	}
-	return b.createCacheController(k8sInterface, nil, nil, clusterID)
+	return b.createCacheController(clients, clusterID)
 }
 
 func (b *builder) deleteCacheController(clusterID string) error {

--- a/mixer/adapter/kubernetesenv/kubernetesenv_norace_test.go
+++ b/mixer/adapter/kubernetesenv/kubernetesenv_norace_test.go
@@ -26,17 +26,15 @@ import (
 
 	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/pkg/adapter/test"
+	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/secretcontroller"
 )
 
 // This test is skipped by the build tag !race due to https://github.com/istio/istio/issues/15610
 func Test_KubeSecretController(t *testing.T) {
-	secretcontroller.LoadKubeConfig = mockLoadKubeConfig
-	secretcontroller.ValidateClientConfig = mockValidateClientConfig
-	secretcontroller.CreateInterfaceFromClusterConfig = mockCreateInterfaceFromClusterConfig
-	secretcontroller.CreateMetadataInterfaceFromClusterConfig = mockCreateMetaInterfaceFromClusterConfig
-	secretcontroller.CreateDynamicInterfaceFromClusterConfig = mockCreateDynamicInterfaceFromClusterConfig
-
+	secretcontroller.BuildClientsFromConfig = func(kubeConfig []byte) (kube.Client, error) {
+		return kube.NewFakeClient(), nil
+	}
 	clientset := fake.NewSimpleClientset()
 	b := newBuilder(func(string, adapter.Env) (kubernetes.Interface, error) {
 		return clientset, nil

--- a/mixer/adapter/kubernetesenv/kubernetesenv_test.go
+++ b/mixer/adapter/kubernetesenv/kubernetesenv_test.go
@@ -27,13 +27,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/dynamic"
-	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/metadata"
-	metafake "k8s.io/client-go/metadata/fake"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	"istio.io/istio/mixer/adapter/kubernetesenv/config"
 	kubernetes_apa_tmpl "istio.io/istio/mixer/adapter/kubernetesenv/template"
@@ -518,30 +513,6 @@ func verifyControllers(t *testing.T, b *builder, expectedControllerCount int, ti
 		defer b.Unlock()
 		return len(b.controllers) == expectedControllerCount
 	})
-}
-
-func mockLoadKubeConfig(_ []byte) (*clientcmdapi.Config, error) {
-	return &clientcmdapi.Config{}, nil
-}
-
-func mockValidateClientConfig(_ clientcmdapi.Config) error {
-	return nil
-}
-
-func mockCreateInterfaceFromClusterConfig(_ *clientcmdapi.Config) (kubernetes.Interface, error) {
-	return fake.NewSimpleClientset(), nil
-}
-
-func mockCreateMetaInterfaceFromClusterConfig(_ *clientcmdapi.Config) (metadata.Interface, error) {
-	scheme := runtime.NewScheme()
-	metav1.AddMetaToScheme(scheme)
-	return metafake.NewSimpleMetadataClient(scheme), nil
-}
-
-func mockCreateDynamicInterfaceFromClusterConfig(_ *clientcmdapi.Config) (dynamic.Interface, error) {
-	scheme := runtime.NewScheme()
-	metav1.AddMetaToScheme(scheme)
-	return dynamicfake.NewSimpleDynamicClient(scheme), nil
 }
 
 // Kubernetes Runtime Object for Tests

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -339,7 +339,7 @@ func (s *Server) initStatusController(args *PilotArgs, writeStatus bool) {
 					controller := &status.DistributionController{
 						QPS:   float32(features.StatusQPS),
 						Burst: features.StatusBurst}
-					controller.Start(s.kubeConfig, args.Namespace, stop)
+					controller.Start(s.kubeRestConfig, args.Namespace, stop)
 				}).Run(stop)
 			return nil
 		})

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -406,7 +406,7 @@ func (s *Server) initKubeClient(args *PilotArgs) error {
 			return fmt.Errorf("failed creating kube config: %v", err)
 		}
 
-		s.kubeClients, err = kubelib.NewClient(s.kubeRestConfig)
+		s.kubeClients, err = kubelib.NewClient(kubelib.NewClientConfigForRestConfig(s.kubeRestConfig))
 		// TODO deprecate kubeClient, replace with kubeClients
 		if err != nil {
 			return fmt.Errorf("failed creating kube client: %v", err)

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -33,7 +33,6 @@ import (
 
 	"k8s.io/client-go/kubernetes"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
@@ -121,13 +120,14 @@ type Server struct {
 	clusterID   string
 	environment *model.Environment
 
-	kubeConfig   *rest.Config
+	kubeConfig  *rest.Config
+	kubeClients kubelib.Client
+	// DEPRECATED. Use kubeClients
 	kubeClient   kubernetes.Interface
 	kubeRegistry *kubecontroller.Controller
 	multicluster *kubecontroller.Multicluster
 
 	configController  model.ConfigStoreCache
-	metadataClient    metadata.Interface
 	ConfigStores      []model.ConfigStoreCache
 	serviceEntryStore *serviceentry.ServiceEntryStore
 
@@ -301,6 +301,14 @@ func NewServer(args *PilotArgs) (*Server, error) {
 		_, _ = ctrlz.Run(args.CtrlZOptions, nil)
 	}
 
+	// This must be last, otherwise we will not know which informers to register
+	if s.kubeClients != nil {
+		s.addStartFunc(func(stop <-chan struct{}) error {
+			s.kubeClients.RunAndWait(stop)
+			return nil
+		})
+	}
+
 	return s, nil
 }
 
@@ -390,22 +398,18 @@ func (s *Server) initKubeClient(args *PilotArgs) error {
 	if hasKubeRegistry(args.RegistryOptions.Registries) {
 		var err error
 		// Used by validation
-		s.kubeConfig, err = kubelib.BuildClientConfig(args.RegistryOptions.KubeConfig, "")
+		s.kubeConfig, err = kubelib.DefaultRestConfig(args.RegistryOptions.KubeConfig, "")
 		if err != nil {
 			return fmt.Errorf("failed creating kube config: %v", err)
 		}
-		s.kubeClient, err = kubelib.CreateClientset(args.RegistryOptions.KubeConfig, "", func(config *rest.Config) {
-			config.QPS = 20
-			config.Burst = 40
-		})
+		s.kubeConfig.QPS = 20
+		s.kubeConfig.Burst = 40
+		s.kubeClients, err = kubelib.NewClient(s.kubeConfig)
+		// TODO deprecate kubeClient, replace with kubeClients
 		if err != nil {
 			return fmt.Errorf("failed creating kube client: %v", err)
 		}
-
-		s.metadataClient, err = kubelib.CreateMetadataClient(args.RegistryOptions.KubeConfig, "")
-		if err != nil {
-			return fmt.Errorf("failed creating kube metadata client: %v", err)
-		}
+		s.kubeClient = s.kubeClients.Kube()
 	}
 
 	return nil

--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -96,8 +96,7 @@ func (s *Server) initKubeRegistry(serviceControllers *aggregate.Controller, args
 		args.RegistryOptions.KubeOptions.EndpointMode = kubecontroller.EndpointsOnly
 	}
 
-	kubeRegistry := kubecontroller.NewController(s.kubeClients, args.RegistryOptions.KubeOptions,
-	)
+	kubeRegistry := kubecontroller.NewController(s.kubeClients, args.RegistryOptions.KubeOptions)
 	s.kubeRegistry = kubeRegistry
 	serviceControllers.AddRegistry(kubeRegistry)
 	return

--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -95,7 +95,9 @@ func (s *Server) initKubeRegistry(serviceControllers *aggregate.Controller, args
 	} else {
 		args.RegistryOptions.KubeOptions.EndpointMode = kubecontroller.EndpointsOnly
 	}
-	kubeRegistry := kubecontroller.NewController(s.kubeClient, s.metadataClient, args.RegistryOptions.KubeOptions)
+
+	kubeRegistry := kubecontroller.NewController(s.kubeClients, args.RegistryOptions.KubeOptions,
+	)
 	s.kubeRegistry = kubeRegistry
 	serviceControllers.AddRegistry(kubeRegistry)
 	return

--- a/pilot/pkg/bootstrap/validation.go
+++ b/pilot/pkg/bootstrap/validation.go
@@ -65,7 +65,7 @@ func (s *Server) initConfigValidation(args *PilotArgs) error {
 
 	if webhookConfigName := validationWebhookConfigName.Get(); webhookConfigName != "" {
 		var dynamicInterface dynamic.Interface
-		if s.kubeClient == nil || s.kubeConfig == nil {
+		if s.kubeClient == nil || s.kubeRestConfig == nil {
 			iface, err := kube.NewInterfacesFromConfigFile(args.RegistryOptions.KubeConfig)
 			if err != nil {
 				return err
@@ -80,7 +80,7 @@ func (s *Server) initConfigValidation(args *PilotArgs) error {
 				return err
 			}
 		} else {
-			dynamicInterface, err = dynamic.NewForConfig(s.kubeConfig)
+			dynamicInterface, err = dynamic.NewForConfig(s.kubeRestConfig)
 			if err != nil {
 				return err
 			}

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -242,7 +242,7 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 	c.nodeMetadataInformer = kubeClient.MetadataInformer().ForResource(v1.SchemeGroupVersion.WithResource("nodes")).Informer()
 	// This is for getting the node IPs of a selected set of nodes
 	c.filteredNodeInformer = kubeClient.KubeInformer().Core().V1().Nodes().Informer()
-	c.metadataClient = kubeClient.MetadataClient()
+	c.metadataClient = kubeClient.Metadata()
 	registerHandlers(c.filteredNodeInformer, c.queue, "Nodes", reflect.DeepEqual, c.onNodeEvent)
 
 	c.pods = newPodCache(c, kubeClient.KubeInformer().Core().V1().Pods())

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -22,7 +22,6 @@ import (
 	"net"
 	"reflect"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -31,15 +30,11 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klabels "k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/watch"
-	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	listerv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/metadata"
-	"k8s.io/client-go/metadata/metadatainformer"
 	"k8s.io/client-go/tools/cache"
 
 	"istio.io/pkg/log"
@@ -53,7 +48,7 @@ import (
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/protocol"
-	"istio.io/istio/pkg/listwatch"
+	kubelib "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/queue"
 )
 
@@ -213,17 +208,13 @@ type Controller struct {
 
 // NewController creates a new Kubernetes controller
 // Created by bootstrap and multicluster (see secretcontroler).
-func NewController(client kubernetes.Interface, metadataClient metadata.Interface, options Options) *Controller {
-	log.Infof("Service controller watching namespace %q for services, endpoints, nodes and pods, refresh %s",
-		options.WatchedNamespaces, options.ResyncPeriod)
-
-	watchedNamespaceList := strings.Split(options.WatchedNamespaces, ",")
+func NewController(kubeClient kubelib.Client, options Options) *Controller {
+	log.Infof("Starting Kubernetes service registry")
 
 	// The queue requires a time duration for a retry delay after a handler error
 	c := &Controller{
 		domainSuffix:                 options.DomainSuffix,
-		client:                       client,
-		metadataClient:               metadataClient,
+		client:                       kubeClient.Kube(),
 		queue:                        queue.NewQueue(1 * time.Second),
 		clusterID:                    options.ClusterID,
 		xdsUpdater:                   options.XDSUpdater,
@@ -236,40 +227,25 @@ func NewController(client kubernetes.Interface, metadataClient metadata.Interfac
 		metrics:                      options.Metrics,
 	}
 
-	svcMlw := listwatch.MultiNamespaceListerWatcher(watchedNamespaceList, func(namespace string) cache.ListerWatcher {
-		return &cache.ListWatch{
-			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
-				return client.CoreV1().Services(namespace).List(context.TODO(), opts)
-			},
-			WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-				return client.CoreV1().Services(namespace).Watch(context.TODO(), opts)
-			},
-		}
-	})
-
-	c.serviceInformer = cache.NewSharedIndexInformer(svcMlw, &v1.Service{}, options.ResyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-	c.serviceLister = listerv1.NewServiceLister(c.serviceInformer.GetIndexer())
+	c.serviceInformer = kubeClient.KubeInformer().Core().V1().Services().Informer()
+	c.serviceLister = kubeClient.KubeInformer().Core().V1().Services().Lister()
 	registerHandlers(c.serviceInformer, c.queue, "Services", reflect.DeepEqual, c.onServiceEvent)
 
 	switch options.EndpointMode {
 	case EndpointsOnly:
-		c.endpoints = newEndpointsController(c, options)
+		c.endpoints = newEndpointsController(c, kubeClient.KubeInformer().Core().V1().Endpoints())
 	case EndpointSliceOnly:
-		c.endpoints = newEndpointSliceController(c, options)
+		c.endpoints = newEndpointSliceController(c, kubeClient.KubeInformer().Discovery().V1alpha1().EndpointSlices())
 	}
 
 	// This is for getting the pod to node mapping, so that we can get the pod's locality.
-	metadataSharedInformer := metadatainformer.NewSharedInformerFactory(metadataClient, options.ResyncPeriod)
-	nodeResource := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "nodes"}
-	c.nodeMetadataInformer = metadataSharedInformer.ForResource(nodeResource).Informer()
+	c.nodeMetadataInformer = kubeClient.MetadataInformer().ForResource(v1.SchemeGroupVersion.WithResource("nodes")).Informer()
 	// This is for getting the node IPs of a selected set of nodes
-	c.filteredNodeInformer = coreinformers.NewFilteredNodeInformer(client, options.ResyncPeriod,
-		cache.Indexers{},
-		func(options *metav1.ListOptions) {})
+	c.filteredNodeInformer = kubeClient.KubeInformer().Core().V1().Nodes().Informer()
+	c.metadataClient = kubeClient.MetadataClient()
 	registerHandlers(c.filteredNodeInformer, c.queue, "Nodes", reflect.DeepEqual, c.onNodeEvent)
 
-	c.pods = newPodCache(c, options)
+	c.pods = newPodCache(c, kubeClient.KubeInformer().Core().V1().Pods())
 	registerHandlers(c.pods.informer, c.queue, "Pods", reflect.DeepEqual, c.pods.onEvent)
 
 	return c
@@ -517,17 +493,10 @@ func (c *Controller) Run(stop <-chan struct{}) {
 		c.queue.Run(stop)
 	}()
 
-	go c.serviceInformer.Run(stop)
-	go c.pods.informer.Run(stop)
-	go c.nodeMetadataInformer.Run(stop)
-	go c.filteredNodeInformer.Run(stop)
-
 	// To avoid endpoints without labels or ports, wait for sync.
 	cache.WaitForCacheSync(stop, c.nodeMetadataInformer.HasSynced, c.filteredNodeInformer.HasSynced,
 		c.pods.informer.HasSynced,
 		c.serviceInformer.HasSynced)
-
-	go c.endpoints.Run(stop)
 
 	<-stop
 	log.Infof("Controller terminated")

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -175,6 +175,7 @@ func newFakeControllerWithOptions(opts fakeControllerOptions) (*Controller, *Fak
 	// Run in initiation to prevent calling each test
 	// TODO: fix it, so we can remove `stop` channel
 	go c.Run(c.stop)
+	clients.RunAndWait(c.stop)
 	// Wait for the caches to sync, otherwise we may hit race conditions where events are dropped
 	cache.WaitForCacheSync(c.stop, c.nodeMetadataInformer.HasSynced, c.pods.informer.HasSynced,
 		c.serviceInformer.HasSynced)

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -27,11 +27,9 @@ import (
 	coreV1 "k8s.io/api/core/v1"
 	discoveryv1alpha1 "k8s.io/api/discovery/v1alpha1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/fake"
 	metafake "k8s.io/client-go/metadata/fake"
 	"k8s.io/client-go/tools/cache"
 
@@ -45,6 +43,7 @@ import (
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/protocol"
+	kubelib "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/test"
 )
@@ -154,12 +153,8 @@ type fakeControllerOptions struct {
 func newFakeControllerWithOptions(opts fakeControllerOptions) (*Controller, *FakeXdsUpdater) {
 	fx := NewFakeXDS()
 
-	clientSet := fake.NewSimpleClientset()
-	scheme := runtime.NewScheme()
-	metaV1.AddMetaToScheme(scheme)
-	metadataClient := metafake.NewSimpleMetadataClient(scheme)
-
-	c := NewController(clientSet, metadataClient, Options{
+	clients := kubelib.NewFakeClient()
+	options := Options{
 		WatchedNamespaces: opts.watchedNamespaces, // default is all namespaces
 		ResyncPeriod:      resync,
 		DomainSuffix:      domainSuffix,
@@ -168,8 +163,8 @@ func newFakeControllerWithOptions(opts fakeControllerOptions) (*Controller, *Fak
 		NetworksWatcher:   opts.networksWatcher,
 		EndpointMode:      opts.mode,
 		ClusterID:         opts.clusterID,
-	})
-
+	}
+	c := NewController(clients, options)
 	if opts.instanceHandler != nil {
 		_ = c.AppendInstanceHandler(opts.instanceHandler)
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -139,7 +139,7 @@ func (m *Multicluster) AddMemberCluster(clients kubelib.Client, clusterID string
 		nc := NewNamespaceController(m.fetchCaRoot, options, clients.Kube())
 		go nc.Run(stopCh)
 		go webhooks.PatchCertLoop(features.InjectionWebhookConfigName.Get(), webhookName, m.caBundlePath, clients.Kube(), stopCh)
-		valicationWebhookController := webhooks.CreateValidationWebhookController(clients.Kube(), clients.DynamicClient(), webhookConfigName,
+		valicationWebhookController := webhooks.CreateValidationWebhookController(clients.Kube(), clients.Dynamic(), webhookConfigName,
 			m.secretNamespace, m.caBundlePath, true)
 		if valicationWebhookController != nil {
 			go valicationWebhookController.Start(stopCh)

--- a/pilot/pkg/serviceregistry/kube/controller/pod_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod_test.go
@@ -188,9 +188,6 @@ func testPodCache(t *testing.T) {
 		generatePod("128.0.0.1", "cpod1", "nsa", "", "", map[string]string{"app": "test-app"}, map[string]string{}),
 		generatePod("128.0.0.2", "cpod2", "nsa", "", "", map[string]string{"app": "prod-app-1"}, map[string]string{}),
 		generatePod("128.0.0.3", "cpod3", "nsb", "", "", map[string]string{"app": "prod-app-2"}, map[string]string{}),
-
-		// Pods in namespaces not watched by the controller.
-		generatePod("128.0.0.4", "cpod4", "nsc", "", "", map[string]string{"app": "prod-app-3"}, map[string]string{}),
 	}
 	cache.WaitForCacheSync(c.stop, c.nodeMetadataInformer.HasSynced, c.pods.informer.HasSynced,
 		c.serviceInformer.HasSynced, c.endpoints.HasSynced)
@@ -240,7 +237,7 @@ func TestPodCacheEvents(t *testing.T) {
 	defer c.Stop()
 
 	ns := "default"
-	podCache := newPodCache(c, Options{WatchedNamespaces: ns})
+	podCache := c.pods
 
 	f := podCache.onEvent
 

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -27,16 +27,20 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
-	kubeApiCore "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	kubeExtClient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	kubeApiMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeVersion "k8s.io/apimachinery/pkg/version"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/metadata"
+	"k8s.io/client-go/metadata/metadatainformer"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/remotecommand"
@@ -55,10 +59,13 @@ const (
 	fieldManager        = "istio-kube-client"
 )
 
-// Client is a helper for common Kubernetes client operations
+// Client is a helper for common Kubernetes client operations. This contains various different kubernetes
+// clients using a shared config. It is expected that all of Istiod can share the same set of clients and
+// informers. Sharing informers is especially important for load on the API server/Istiod itself.
 type Client interface {
+	// TODO - stop embedding this, it will conflict with future additions. Use Kube() instead is preferred
+	// TODO - add istio/client-go and service-apis
 	kubernetes.Interface
-
 	// RESTConfig returns the Kubernetes rest.Config used to configure the clients.
 	RESTConfig() *rest.Config
 
@@ -68,9 +75,32 @@ type Client interface {
 	// Ext returns the API extensions client.
 	Ext() kubeExtClient.Interface
 
+	// Kube returns the core kube client
+	Kube() kubernetes.Interface
+
 	// Dynamic client.
 	Dynamic() dynamic.Interface
 
+	// MetadataClient returns the Metadata kube client.
+	MetadataClient() metadata.Interface
+
+	// KubeInformer returns an informer for core kube client
+	KubeInformer() informers.SharedInformerFactory
+
+	// DynamicInformer returns an informer for dynamic client
+	DynamicInformer() dynamicinformer.DynamicSharedInformerFactory
+
+	// MetadataInformer returns an informer for metadata client
+	MetadataInformer() metadatainformer.SharedInformerFactory
+
+	// RunAndWait starts all informers and waits for their caches to sync.
+	// Warning: this must be called AFTER .Informer() is called, which will register the informer.
+	RunAndWait(stop <-chan struct{})
+}
+
+// ExtendedClient is an extended client with additional helpers/functionality for Istioctl and testing.
+type ExtendedClient interface {
+	Client
 	// Revision of the Istio control plane.
 	Revision() string
 
@@ -87,10 +117,10 @@ type Client interface {
 	GetIstioVersions(ctx context.Context, namespace string) (*version.MeshInfo, error)
 
 	// PodsForSelector finds pods matching selector.
-	PodsForSelector(ctx context.Context, namespace string, labelSelectors ...string) (*kubeApiCore.PodList, error)
+	PodsForSelector(ctx context.Context, namespace string, labelSelectors ...string) (*v1.PodList, error)
 
 	// GetIstioPods retrieves the pod objects for Istio deployments
-	GetIstioPods(ctx context.Context, namespace string, params map[string]string) ([]kubeApiCore.Pod, error)
+	GetIstioPods(ctx context.Context, namespace string, params map[string]string) ([]v1.Pod, error)
 
 	// PodExec takes a command and the pod data to run the command in the specified pod.
 	PodExec(podName, podNamespace, container string, command string) (stdout string, stderr string, err error)
@@ -114,52 +144,140 @@ type Client interface {
 	// DeleteYAMLFilesDryRun performs a dry run for deleting the resources in the given YAML files.
 	DeleteYAMLFilesDryRun(namespace string, yamlFiles ...string) error
 }
+//
+//var _ Client = &client{}
+//var _ ExtendedClient = &client{}
 
-var _ Client = &client{}
+const resyncInterval = 0
+
+//func NewFakeClient() Client {
+//	var c client
+//	c.Interface = fake.NewSimpleClientset()
+//	c.kubeInformer = informers.NewSharedInformerFactory(c.Interface, resyncInterval)
+//
+//	s := runtime.NewScheme()
+//	if err := metav1.AddMetaToScheme(s); err != nil {
+//		panic(err.Error())
+//	}
+//	c.metadata = metadatafake.NewSimpleMetadataClient(s)
+//	c.metadataInformer = metadatainformer.NewSharedInformerFactory(c.metadata, resyncInterval)
+//
+//	c.dynamic = dynamicfake.NewSimpleDynamicClient(s)
+//	c.dynamicInformer = dynamicinformer.NewDynamicSharedInformerFactory(c.dynamic, resyncInterval)
+//
+//	return &c
+//}
 
 // Client is a helper wrapper around the Kube RESTClient for istioctl -> Pilot/Envoy/Mesh related things
 type client struct {
-	*kubernetes.Clientset
+	kubernetes.Interface
 	clientFactory util.Factory
 	restClient    *rest.RESTClient
 	config        *rest.Config
 	extSet        *kubeExtClient.Clientset
 	revision      string
+	*rest.RESTClient
+
+	kubeInformer informers.SharedInformerFactory
+
+	dynamic         dynamic.Interface
+	dynamicInformer dynamicinformer.DynamicSharedInformerFactory
+
+	metadata         metadata.Interface
+	metadataInformer metadatainformer.SharedInformerFactory
 }
 
-// NewClient creates a Kubernetes client from the given factory. The "revision" parameter
+// newClientInternal creates a Kubernetes client from the given factory. The "revision" parameter
 // controls the behavior of GetIstioPods, by selecting a specific revision of the control plane.
-func NewClient(clientFactory util.Factory, revision string) (Client, error) {
-	restConfig, err := clientFactory.ToRESTConfig()
+func newClientInternal(clientFactory util.Factory, revision string) (*client, error) {
+	var c client
+	var err error
+	c.clientFactory = clientFactory
+	c.revision = revision
+	c.config, err = clientFactory.ToRESTConfig()
 	if err != nil {
 		return nil, err
 	}
-	restClient, err := clientFactory.RESTClient()
+	c.restClient, err = clientFactory.RESTClient()
 	if err != nil {
 		return nil, err
 	}
-	clientSet, err := kubernetes.NewForConfig(restConfig)
+
+	c.Interface, err = kubernetes.NewForConfig(c.config)
 	if err != nil {
 		return nil, err
 	}
-	extSet, err := kubeExtClient.NewForConfig(restConfig)
+	c.kubeInformer = informers.NewSharedInformerFactory(c.Interface, resyncInterval)
+
+	c.metadata, err = metadata.NewForConfig(c.config)
 	if err != nil {
 		return nil, err
 	}
-	return &client{
-		clientFactory: clientFactory,
-		Clientset:     clientSet,
-		restClient:    restClient,
-		config:        restConfig,
-		extSet:        extSet,
-		revision:      revision,
-	}, nil
+	c.metadataInformer = metadatainformer.NewSharedInformerFactory(c.metadata, resyncInterval)
+
+	c.dynamic, err = dynamic.NewForConfig(c.config)
+	if err != nil {
+		return nil, err
+	}
+	c.dynamicInformer = dynamicinformer.NewDynamicSharedInformerFactory(c.dynamic, resyncInterval)
+
+	c.extSet, err = kubeExtClient.NewForConfig(c.config)
+	if err != nil {
+		return nil, err
+	}
+	return &c, nil
 }
 
-// NewClient creates a Kubernetes client from the given ClientConfig. The "revision" parameter
+// NewExtendedClient creates a Kubernetes client from the given ClientConfig. The "revision" parameter
 // controls the behavior of GetIstioPods, by selecting a specific revision of the control plane.
-func NewClientForConfig(clientConfig clientcmd.ClientConfig, revision string) (Client, error) {
-	return NewClient(newClientFactory(clientConfig), revision)
+func NewExtendedClient(clientConfig clientcmd.ClientConfig, revision string) (ExtendedClient, error) {
+	return newClientInternal(newClientFactory(clientConfig), revision)
+}
+
+// NewClient creates a Kubernetes client from the given ClientConfig.
+func NewClient(clientConfig clientcmd.ClientConfig) (Client, error) {
+	return newClientInternal(newClientFactory(clientConfig), "")
+}
+
+// NewIstioctlClient is a constructor for the client wrapper that supports dual/multiple control plans
+func NewIstioctlClient(config *rest.Config, revision string) (ExtendedClient, error) {
+	//return newClientInternal(config, revision)
+	return nil, nil
+}
+
+func (c *client) Kube() kubernetes.Interface {
+	return c
+}
+
+func (c *client) DynamicClient() dynamic.Interface {
+	return c.dynamic
+}
+
+func (c *client) MetadataClient() metadata.Interface {
+	return c.metadata
+}
+
+func (c *client) KubeInformer() informers.SharedInformerFactory {
+	return c.kubeInformer
+}
+
+func (c *client) DynamicInformer() dynamicinformer.DynamicSharedInformerFactory {
+	return c.dynamicInformer
+}
+
+func (c *client) MetadataInformer() metadatainformer.SharedInformerFactory {
+	return c.metadataInformer
+}
+
+// RunAndWait starts all informers and waits for their caches to sync.
+// Warning: this must be called AFTER .Informer() is called, which will register the informer.
+func (c *client) RunAndWait(stop <-chan struct{}) {
+	c.kubeInformer.Start(stop)
+	c.dynamicInformer.Start(stop)
+	c.metadataInformer.Start(stop)
+	c.kubeInformer.WaitForCacheSync(stop)
+	c.dynamicInformer.WaitForCacheSync(stop)
+	c.metadataInformer.WaitForCacheSync(stop)
 }
 
 func (c *client) RESTConfig() *rest.Config {
@@ -175,13 +293,7 @@ func (c *client) Ext() kubeExtClient.Interface {
 }
 
 func (c *client) Dynamic() dynamic.Interface {
-	// Create the dynamic client as-needed, so that we don't pre-maturely cache the server-side schemas.
-	out, err := c.clientFactory.DynamicClient()
-	if err != nil {
-		// This should never happen.
-		panic(err)
-	}
-	return out
+	return c.dynamic
 }
 
 func (c *client) Revision() string {
@@ -211,7 +323,7 @@ func (c *client) PodExec(podName, podNamespace, container string, command string
 		Namespace(podNamespace).
 		SubResource("exec").
 		Param("container", container).
-		VersionedParams(&kubeApiCore.PodExecOptions{
+		VersionedParams(&v1.PodExecOptions{
 			Container: container,
 			Command:   commandFields,
 			Stdin:     false,
@@ -243,7 +355,7 @@ func (c *client) PodExec(podName, podNamespace, container string, command string
 }
 
 func (c *client) PodLogs(ctx context.Context, podName, podNamespace, container string, previousLog bool) (string, error) {
-	opts := &kubeApiCore.PodLogOptions{
+	opts := &v1.PodLogOptions{
 		Container: container,
 		Previous:  previousLog,
 	}
@@ -337,7 +449,7 @@ func (c *client) EnvoyDo(ctx context.Context, podName, podNamespace, method, pat
 	return out, nil
 }
 
-func (c *client) GetIstioPods(ctx context.Context, namespace string, params map[string]string) ([]kubeApiCore.Pod, error) {
+func (c *client) GetIstioPods(ctx context.Context, namespace string, params map[string]string) ([]v1.Pod, error) {
 	if c.revision != "" {
 		labelSelector, ok := params["labelSelector"]
 		if ok {
@@ -358,7 +470,7 @@ func (c *client) GetIstioPods(ctx context.Context, namespace string, params map[
 	if res.Error() != nil {
 		return nil, fmt.Errorf("unable to retrieve Pods: %v", res.Error())
 	}
-	list := &kubeApiCore.PodList{}
+	list := &v1.PodList{}
 	if err := res.Into(list); err != nil {
 		return nil, fmt.Errorf("unable to parse PodList: %v", res.Error())
 	}
@@ -413,8 +525,8 @@ func (c *client) NewPortForwarder(podName, ns, localAddress string, localPort in
 	return newPortForwarder(c.config, podName, ns, localAddress, localPort, podPort)
 }
 
-func (c *client) PodsForSelector(ctx context.Context, namespace string, labelSelectors ...string) (*kubeApiCore.PodList, error) {
-	return c.CoreV1().Pods(namespace).List(ctx, kubeApiMeta.ListOptions{
+func (c *client) PodsForSelector(ctx context.Context, namespace string, labelSelectors ...string) (*v1.PodList, error) {
+	return c.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: strings.Join(labelSelectors, ","),
 	})
 }

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -198,6 +198,7 @@ func newClientInternal(clientFactory util.Factory, revision string) (*client, er
 	var c client
 	var err error
 
+	c.clientFactory = clientFactory
 	c.revision = revision
 
 	c.restClient, err = clientFactory.RESTClient()
@@ -243,8 +244,8 @@ func NewExtendedClient(clientConfig clientcmd.ClientConfig, revision string) (Ex
 }
 
 // NewClient creates a Kubernetes client from the given rest config.
-func NewClient(config *rest.Config) (Client, error) {
-	return newClientInternal(newClientFactory(NewClientConfigForRestConfig(config)), "")
+func NewClient(clientConfig clientcmd.ClientConfig) (Client, error) {
+	return newClientInternal(newClientFactory(clientConfig), "")
 }
 
 func (c *client) RESTConfig() *rest.Config {

--- a/pkg/kube/secretcontroller/secretcontroller.go
+++ b/pkg/kube/secretcontroller/secretcontroller.go
@@ -244,7 +244,11 @@ var BuildClientsFromConfig = func(kubeConfig []byte) (kube.Client, error) {
 	}
 
 	clientConfig := clientcmd.NewDefaultClientConfig(*rawConfig, &clientcmd.ConfigOverrides{})
-	clients, err := kube.NewClient(clientConfig)
+	restConfig, err := clientConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	clients, err := kube.NewClient(restConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create kube clients: %v", err)
 	}

--- a/pkg/kube/secretcontroller/secretcontroller.go
+++ b/pkg/kube/secretcontroller/secretcontroller.go
@@ -244,11 +244,8 @@ var BuildClientsFromConfig = func(kubeConfig []byte) (kube.Client, error) {
 	}
 
 	clientConfig := clientcmd.NewDefaultClientConfig(*rawConfig, &clientcmd.ConfigOverrides{})
-	restConfig, err := clientConfig.ClientConfig()
-	if err != nil {
-		return nil, err
-	}
-	clients, err := kube.NewClient(restConfig)
+
+	clients, err := kube.NewClient(clientConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create kube clients: %v", err)
 	}

--- a/pkg/kube/secretcontroller/secretcontroller.go
+++ b/pkg/kube/secretcontroller/secretcontroller.go
@@ -29,9 +29,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/workqueue"
@@ -47,28 +45,11 @@ const (
 	maxRetries = 5
 )
 
-// LoadKubeConfig is a unit test override variable for loading the k8s config.
-// DO NOT USE - TEST ONLY.
-var LoadKubeConfig = clientcmd.Load
-
-var ValidateClientConfig = clientcmd.Validate
-
-// CreateInterfaceFromClusterConfig is a unit test override variable for interface create.
-// DO NOT USE - TEST ONLY.
-var CreateInterfaceFromClusterConfig = kube.CreateInterfaceFromClusterConfig
-
-// CreateMetadataInterfaceFromClusterConfig is a unit test override variable for interface create.
-// DO NOT USE - TEST ONLY.
-var CreateMetadataInterfaceFromClusterConfig = kube.CreateMetadataInterfaceFromClusterConfig
-
-//CreateDynamicInterfaceFromClusterConfig is helper function to create dynamic interface
-var CreateDynamicInterfaceFromClusterConfig = kube.CreateDynamicInterfaceFromClusterConfig
-
 // addSecretCallback prototype for the add secret callback function.
-type addSecretCallback func(clientset kubernetes.Interface, metadataClient metadata.Interface, dynamicClient dynamic.Interface, dataKey string) error
+type addSecretCallback func(clients kube.Client, dataKey string) error
 
 // updateSecretCallback prototype for the update secret callback function.
-type updateSecretCallback func(clientset kubernetes.Interface, metadataClient metadata.Interface, dynamicClient dynamic.Interface, dataKey string) error
+type updateSecretCallback func(clients kube.Client, dataKey string) error
 
 // removeSecretCallback prototype for the remove secret callback function.
 type removeSecretCallback func(dataKey string) error
@@ -85,13 +66,11 @@ type Controller struct {
 	removeCallback removeSecretCallback
 }
 
-// RemoteCluster defines cluster structZZ
+// RemoteCluster defines cluster struct
 type RemoteCluster struct {
-	secretName     string
-	client         kubernetes.Interface
-	metadataClient metadata.Interface
-	dynamicClient  dynamic.Interface
-	kubeConfigSha  [sha256.Size]byte
+	secretName    string
+	clients       kube.Client
+	kubeConfigSha [sha256.Size]byte
 }
 
 // ClusterStore is a collection of clusters
@@ -249,40 +228,38 @@ func (c *Controller) processItem(secretName string) error {
 	return nil
 }
 
-func createRemoteCluster(kubeConfig []byte, secretName string) (*RemoteCluster, error) {
+// BuildClientsFromConfig creates kube.Clients from the provided kubeconfig. This is overiden for testing only
+var BuildClientsFromConfig = func(kubeConfig []byte) (kube.Client, error) {
 	if len(kubeConfig) == 0 {
 		return nil, errors.New("kubeconfig is empty")
 	}
 
-	clientConfig, err := LoadKubeConfig(kubeConfig)
+	rawConfig, err := clientcmd.Load(kubeConfig)
 	if err != nil {
 		return nil, fmt.Errorf("kubeconfig cannot be loaded: %v", err)
 	}
 
-	if err := ValidateClientConfig(*clientConfig); err != nil {
+	if err := clientcmd.Validate(*rawConfig); err != nil {
 		return nil, fmt.Errorf("kubeconfig is not valid: %v", err)
 	}
 
-	client, err := CreateInterfaceFromClusterConfig(clientConfig)
+	clientConfig := clientcmd.NewDefaultClientConfig(*rawConfig, &clientcmd.ConfigOverrides{})
+	clients, err := kube.NewClient(clientConfig)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't create client interface: %v", err)
+		return nil, fmt.Errorf("failed to create kube clients: %v", err)
 	}
+	return clients, nil
+}
 
-	metadataClient, err := CreateMetadataInterfaceFromClusterConfig(clientConfig)
+func createRemoteCluster(kubeConfig []byte, secretName string) (*RemoteCluster, error) {
+	clients, err := BuildClientsFromConfig(kubeConfig)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't create metadata client interface: %v", err)
-	}
-
-	dynamicClient, err := CreateDynamicInterfaceFromClusterConfig(clientConfig)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't create dynamic client interface: %v", err)
+		return nil, err
 	}
 	return &RemoteCluster{
-		secretName:     secretName,
-		client:         client,
-		metadataClient: metadataClient,
-		dynamicClient:  dynamicClient,
-		kubeConfigSha:  sha256.Sum256(kubeConfig),
+		secretName:    secretName,
+		clients:       clients,
+		kubeConfigSha: sha256.Sum256(kubeConfig),
 	}, nil
 }
 
@@ -300,7 +277,7 @@ func (c *Controller) addMemberCluster(secretName string, s *corev1.Secret) {
 			}
 
 			c.cs.remoteClusters[clusterID] = remoteCluster
-			if err := c.addCallback(remoteCluster.client, remoteCluster.metadataClient, remoteCluster.dynamicClient, clusterID); err != nil {
+			if err := c.addCallback(remoteCluster.clients, clusterID); err != nil {
 				log.Errorf("Error creating cluster_id=%s from secret %v: %v",
 					clusterID, secretName, err)
 			}
@@ -324,7 +301,7 @@ func (c *Controller) addMemberCluster(secretName string, s *corev1.Secret) {
 					continue
 				}
 				c.cs.remoteClusters[clusterID] = remoteCluster
-				if err := c.updateCallback(remoteCluster.client, remoteCluster.metadataClient, remoteCluster.dynamicClient, clusterID); err != nil {
+				if err := c.updateCallback(remoteCluster.clients, clusterID); err != nil {
 					log.Errorf("Error updating cluster_id from secret=%v: %s %v",
 						clusterID, secretName, err)
 				}

--- a/pkg/kube/secretcontroller/secretcontroller_test.go
+++ b/pkg/kube/secretcontroller/secretcontroller_test.go
@@ -24,42 +24,13 @@ import (
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/metadata"
-	metafake "k8s.io/client-go/metadata/fake"
 	"k8s.io/client-go/tools/cache"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
-	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"istio.io/istio/pkg/kube"
 )
 
 const secretNamespace string = "istio-system"
-
-func mockLoadKubeConfig(_ []byte) (*clientcmdapi.Config, error) {
-	return &clientcmdapi.Config{}, nil
-}
-
-func mockValidateClientConfig(_ clientcmdapi.Config) error {
-	return nil
-}
-
-func mockCreateInterfaceFromClusterConfig(_ *clientcmdapi.Config) (kubernetes.Interface, error) {
-	return fake.NewSimpleClientset(), nil
-}
-
-func mockCreateMetadataInterfaceFromClusterConfig(_ *clientcmdapi.Config) (metadata.Interface, error) {
-	scheme := runtime.NewScheme()
-	metav1.AddMetaToScheme(scheme)
-	return metafake.NewSimpleMetadataClient(scheme), nil
-}
-
-func mockCreateDynamicInterfaceFromClusterConfig(_ *clientcmdapi.Config) (dynamic.Interface, error) {
-	scheme := runtime.NewScheme()
-	return dynamicfake.NewSimpleDynamicClient(scheme), nil
-}
 
 func makeSecret(secret, clusterID string, kubeconfig []byte) *v1.Secret {
 	return &v1.Secret{
@@ -83,14 +54,14 @@ var (
 	deleted string
 )
 
-func addCallback(_ kubernetes.Interface, _ metadata.Interface, _ dynamic.Interface, id string) error {
+func addCallback(_ kube.Client, id string) error {
 	mu.Lock()
 	defer mu.Unlock()
 	added = id
 	return nil
 }
 
-func updateCallback(_ kubernetes.Interface, _ metadata.Interface, _ dynamic.Interface, id string) error {
+func updateCallback(_ kube.Client, id string) error {
 	mu.Lock()
 	defer mu.Unlock()
 	updated = id
@@ -110,12 +81,9 @@ func resetCallbackData() {
 }
 
 func Test_SecretController(t *testing.T) {
-	LoadKubeConfig = mockLoadKubeConfig
-	ValidateClientConfig = mockValidateClientConfig
-	CreateInterfaceFromClusterConfig = mockCreateInterfaceFromClusterConfig
-	CreateMetadataInterfaceFromClusterConfig = mockCreateMetadataInterfaceFromClusterConfig
-	CreateDynamicInterfaceFromClusterConfig = mockCreateDynamicInterfaceFromClusterConfig
-
+	BuildClientsFromConfig = func(kubeConfig []byte) (kube.Client, error) {
+		return kube.NewFakeClient(), nil
+	}
 	clientset := fake.NewSimpleClientset()
 
 	var (

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -20,14 +20,11 @@ import (
 
 	kubeApiCore "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/metadata"
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // allow out of cluster authentication
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 // BuildClientConfig builds a client rest config from a kubeconfig filepath and context.
@@ -81,55 +78,6 @@ func CreateClientset(kubeconfig, context string, fns ...func(*rest.Config)) (*ku
 		fn(c)
 	}
 	return kubernetes.NewForConfig(c)
-}
-
-// CreateMetadataClient is a helper function that builds a kubernetes metadata client from a kubeconfig
-// filepath. See `BuildClientConfig` for kubeconfig loading rules.
-func CreateMetadataClient(kubeconfig, context string, fns ...func(*rest.Config)) (metadata.Interface, error) {
-	c, err := BuildClientConfig(kubeconfig, context)
-	if err != nil {
-		return nil, err
-	}
-	for _, fn := range fns {
-		fn(c)
-	}
-	return metadata.NewForConfig(c)
-}
-
-// CreateInterfaceFromClusterConfig is a helper function to create Kubernetes interface from in memory cluster config struct
-func CreateInterfaceFromClusterConfig(clusterConfig *clientcmdapi.Config) (kubernetes.Interface, error) {
-	return createInterface(clusterConfig)
-}
-
-// createInterface is new function which creates rest config and kubernetes interface
-// from passed cluster's config struct
-func createInterface(clusterConfig *clientcmdapi.Config) (kubernetes.Interface, error) {
-	clientConfig := clientcmd.NewDefaultClientConfig(*clusterConfig, &clientcmd.ConfigOverrides{})
-	restConfig, err := clientConfig.ClientConfig()
-	if err != nil {
-		return nil, err
-	}
-	return kubernetes.NewForConfig(restConfig)
-}
-
-// CreateMetadataInterfaceFromClusterConfig is a helper function to create Kubernetes metadata interface from in memory cluster config struct
-func CreateMetadataInterfaceFromClusterConfig(clusterConfig *clientcmdapi.Config) (metadata.Interface, error) {
-	clientConfig := clientcmd.NewDefaultClientConfig(*clusterConfig, &clientcmd.ConfigOverrides{})
-	restConfig, err := clientConfig.ClientConfig()
-	if err != nil {
-		return nil, err
-	}
-	return metadata.NewForConfig(restConfig)
-}
-
-// CreateDynamicInterfaceFromClusterConfig is a helper function to create Kubernetes dynamic interface from in memory cluster config struct
-func CreateDynamicInterfaceFromClusterConfig(clusterConfig *clientcmdapi.Config) (dynamic.Interface, error) {
-	clientConfig := clientcmd.NewDefaultClientConfig(*clusterConfig, &clientcmd.ConfigOverrides{})
-	restConfig, err := clientConfig.ClientConfig()
-	if err != nil {
-		return nil, err
-	}
-	return dynamic.NewForConfig(restConfig)
 }
 
 // DefaultRestConfig returns the rest.Config for the given kube config file and context.

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -81,12 +81,18 @@ func CreateClientset(kubeconfig, context string, fns ...func(*rest.Config)) (*ku
 }
 
 // DefaultRestConfig returns the rest.Config for the given kube config file and context.
-func DefaultRestConfig(kubeconfig, configContext string) (*rest.Config, error) {
+func DefaultRestConfig(kubeconfig, configContext string, fns ...func(*rest.Config)) (*rest.Config, error) {
 	config, err := BuildClientConfig(kubeconfig, configContext)
 	if err != nil {
 		return nil, err
 	}
-	return SetRestDefaults(config), nil
+	config = SetRestDefaults(config)
+
+	for _, fn := range fns {
+		fn(config)
+	}
+
+	return config, nil
 }
 
 // SetRestDefaults is a helper function that sets default values for the given rest.Config.

--- a/pkg/test/framework/components/environment/kube/cluster.go
+++ b/pkg/test/framework/components/environment/kube/cluster.go
@@ -26,7 +26,7 @@ var _ resource.Cluster = Cluster{}
 
 // Cluster for a Kubernetes cluster. Provides access via a kube.Client.
 type Cluster struct {
-	kube.Client
+	kube.ExtendedClient
 	filename    string
 	networkName string
 	index       resource.ClusterIndex

--- a/pkg/test/framework/components/environment/kube/kube.go
+++ b/pkg/test/framework/components/environment/kube/kube.go
@@ -54,10 +54,10 @@ func New(ctx resource.Context, s *Settings) (resource.Environment, error) {
 		client := clients[i]
 		clusterIndex := resource.ClusterIndex(i)
 		e.KubeClusters = append(e.KubeClusters, Cluster{
-			networkName: s.networkTopology[clusterIndex],
-			filename:    s.KubeConfig[i],
-			index:       clusterIndex,
-			Client:      client,
+			networkName:    s.networkTopology[clusterIndex],
+			filename:       s.KubeConfig[i],
+			index:          clusterIndex,
+			ExtendedClient: client,
 		})
 	}
 

--- a/pkg/test/framework/components/environment/kube/settings.go
+++ b/pkg/test/framework/components/environment/kube/settings.go
@@ -27,7 +27,7 @@ import (
 
 // ClientFactoryFunc is a transformation function that creates k8s clients
 // from the provided k8s config files.
-type ClientFactoryFunc func(kubeConfigs []string) ([]istioKube.Client, error)
+type ClientFactoryFunc func(kubeConfigs []string) ([]istioKube.ExtendedClient, error)
 
 // Settings provide kube-specific Settings from flags.
 type Settings struct {
@@ -81,7 +81,7 @@ func (s *Settings) GetControlPlaneClusters() map[resource.ClusterIndex]bool {
 }
 
 // NewClients creates the kubernetes clients for interacting with the configured clusters.
-func (s *Settings) NewClients() ([]istioKube.Client, error) {
+func (s *Settings) NewClients() ([]istioKube.ExtendedClient, error) {
 	newClientsFn := s.ClientFactoryFunc
 	if newClientsFn == nil {
 		newClientsFn = newClients
@@ -109,11 +109,11 @@ func (s *Settings) String() string {
 	return result
 }
 
-func newClients(kubeConfigs []string) ([]istioKube.Client, error) {
-	out := make([]istioKube.Client, 0, len(kubeConfigs))
+func newClients(kubeConfigs []string) ([]istioKube.ExtendedClient, error) {
+	out := make([]istioKube.ExtendedClient, 0, len(kubeConfigs))
 	for _, cfg := range kubeConfigs {
 		if len(cfg) > 0 {
-			a, err := istioKube.NewClientForConfig(istioKube.BuildClientCmd(cfg, ""), "")
+			a, err := istioKube.NewExtendedClient(istioKube.BuildClientCmd(cfg, ""), "")
 			if err != nil {
 				return nil, fmt.Errorf("client setup: %v", err)
 			}

--- a/pkg/test/framework/resource/cluster.go
+++ b/pkg/test/framework/resource/cluster.go
@@ -26,7 +26,7 @@ type ClusterIndex int
 // Cluster in a multicluster environment.
 type Cluster interface {
 	fmt.Stringer
-	kube.Client
+	kube.ExtendedClient
 
 	// Name of this cluster
 	Name() string
@@ -51,7 +51,7 @@ var _ Cluster = FakeCluster{}
 
 // FakeCluster used for testing.
 type FakeCluster struct {
-	kube.Client
+	kube.ExtendedClient
 
 	NameValue        string
 	NetworkNameValue string

--- a/pkg/test/kube/dump.go
+++ b/pkg/test/kube/dump.go
@@ -34,11 +34,11 @@ import (
 
 // podDumper will dump information from all the pods into the given workDir.
 // If no pods are provided, client will be used to fetch all the pods in a namespace.
-type podDumper func(a kube.Client, workDir string, namespace string, pods ...kubeApiCore.Pod)
+type podDumper func(a kube.ExtendedClient, workDir string, namespace string, pods ...kubeApiCore.Pod)
 
 // DumpPods runs each dumper with all the pods in the given namespace.
 // If no dumpers are provided, their resource state, events, container logs and Envoy information will be dumped.
-func DumpPods(a kube.Client, workDir, namespace string, dumpers ...podDumper) {
+func DumpPods(a kube.ExtendedClient, workDir, namespace string, dumpers ...podDumper) {
 	if len(dumpers) == 0 {
 		dumpers = []podDumper{
 			DumpPodState,
@@ -72,7 +72,7 @@ func podsOrFetch(a kube.Client, pods []kubeApiCore.Pod, namespace string) []kube
 }
 
 // DumpPodState dumps the pod state for either the provided pods or all pods in the namespace if none are provided.
-func DumpPodState(a kube.Client, workDir string, namespace string, pods ...kubeApiCore.Pod) {
+func DumpPodState(a kube.ExtendedClient, workDir string, namespace string, pods ...kubeApiCore.Pod) {
 	pods = podsOrFetch(a, pods, namespace)
 
 	marshaler := jsonpb.Marshaler{
@@ -95,7 +95,7 @@ func DumpPodState(a kube.Client, workDir string, namespace string, pods ...kubeA
 }
 
 // DumpPodEvents dumps the pod events for either the provided pods or all pods in the namespace if none are provided.
-func DumpPodEvents(a kube.Client, workDir, namespace string, pods ...kubeApiCore.Pod) {
+func DumpPodEvents(a kube.ExtendedClient, workDir, namespace string, pods ...kubeApiCore.Pod) {
 	pods = podsOrFetch(a, pods, namespace)
 
 	marshaler := jsonpb.Marshaler{
@@ -134,7 +134,7 @@ func DumpPodEvents(a kube.Client, workDir, namespace string, pods ...kubeApiCore
 
 // DumpPodLogs will dump logs from each container in each of the provided pods
 // or all pods in the namespace if none are provided.
-func DumpPodLogs(a kube.Client, workDir, namespace string, pods ...kubeApiCore.Pod) {
+func DumpPodLogs(a kube.ExtendedClient, workDir, namespace string, pods ...kubeApiCore.Pod) {
 	pods = podsOrFetch(a, pods, namespace)
 
 	for _, pod := range pods {
@@ -178,7 +178,7 @@ func DumpPodLogs(a kube.Client, workDir, namespace string, pods ...kubeApiCore.P
 
 // DumpPodProxies will dump Envoy proxy config and clusters in each of the provided pods
 // or all pods in the namespace if none are provided.
-func DumpPodProxies(a kube.Client, workDir, namespace string, pods ...kubeApiCore.Pod) {
+func DumpPodProxies(a kube.ExtendedClient, workDir, namespace string, pods ...kubeApiCore.Pod) {
 	pods = podsOrFetch(a, pods, namespace)
 
 	for _, pod := range pods {

--- a/pkg/test/kube/mock_client.go
+++ b/pkg/test/kube/mock_client.go
@@ -22,8 +22,11 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	kubeVersion "k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/metadata"
+	"k8s.io/client-go/metadata/metadatainformer"
 	"k8s.io/client-go/rest"
 
 	"istio.io/pkg/version"
@@ -43,6 +46,26 @@ type MockClient struct {
 	RevisionValue    string
 	ConfigValue      *rest.Config
 	IstioVersions    *version.MeshInfo
+}
+
+func (c MockClient) Metadata() metadata.Interface {
+	panic("not used in mock")
+}
+
+func (c MockClient) KubeInformer() informers.SharedInformerFactory {
+	panic("not used in mock")
+}
+
+func (c MockClient) DynamicInformer() dynamicinformer.DynamicSharedInformerFactory {
+	panic("not used in mock")
+}
+
+func (c MockClient) MetadataInformer() metadatainformer.SharedInformerFactory {
+	panic("not used in mock")
+}
+
+func (c MockClient) RunAndWait(stop <-chan struct{}) {
+	panic("not used in mock")
 }
 
 func (c MockClient) Kube() kubernetes.Interface {

--- a/pkg/test/kube/mock_client.go
+++ b/pkg/test/kube/mock_client.go
@@ -23,6 +23,7 @@ import (
 	kubeVersion "k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/rest"
 
 	"istio.io/pkg/version"
@@ -30,7 +31,7 @@ import (
 	"istio.io/istio/pkg/kube"
 )
 
-var _ kube.Client = MockClient{}
+var _ kube.ExtendedClient = MockClient{}
 
 // MockClient for tests that rely on kube.Client.
 type MockClient struct {
@@ -42,6 +43,18 @@ type MockClient struct {
 	RevisionValue    string
 	ConfigValue      *rest.Config
 	IstioVersions    *version.MeshInfo
+}
+
+func (c MockClient) Kube() kubernetes.Interface {
+	return c.Clientset
+}
+
+func (c MockClient) DynamicClient() dynamic.Interface {
+	panic("not used in mock")
+}
+
+func (c MockClient) MetadataClient() metadata.Interface {
+	panic("not used in mock")
 }
 
 func (c MockClient) AllDiscoveryDo(_ context.Context, _, _ string) (map[string][]byte, error) {

--- a/pkg/test/kube/util.go
+++ b/pkg/test/kube/util.go
@@ -40,7 +40,7 @@ var (
 type PodFetchFunc func() ([]kubeApiCore.Pod, error)
 
 // NewPodFetch creates a new PodFetchFunction that fetches all pods matching the namespace and label selectors.
-func NewPodFetch(a istioKube.Client, namespace string, selectors ...string) PodFetchFunc {
+func NewPodFetch(a istioKube.ExtendedClient, namespace string, selectors ...string) PodFetchFunc {
 	return func() ([]kubeApiCore.Pod, error) {
 		pods, err := a.PodsForSelector(context.TODO(), namespace, selectors...)
 		if err != nil {
@@ -51,7 +51,7 @@ func NewPodFetch(a istioKube.Client, namespace string, selectors ...string) PodF
 }
 
 // NewSinglePodFetch creates a new PodFetchFunction that fetches a single pod matching the given label selectors.
-func NewSinglePodFetch(a istioKube.Client, namespace string, selectors ...string) PodFetchFunc {
+func NewSinglePodFetch(a istioKube.ExtendedClient, namespace string, selectors ...string) PodFetchFunc {
 	return func() ([]kubeApiCore.Pod, error) {
 		pods, err := a.PodsForSelector(context.TODO(), namespace, selectors...)
 		if err != nil {
@@ -72,7 +72,7 @@ func NewSinglePodFetch(a istioKube.Client, namespace string, selectors ...string
 
 // NewPodMustFetch creates a new PodFetchFunction that fetches all pods matching the namespace and label selectors.
 // If no pods are found, an error is returned
-func NewPodMustFetch(a istioKube.Client, namespace string, selectors ...string) PodFetchFunc {
+func NewPodMustFetch(a istioKube.ExtendedClient, namespace string, selectors ...string) PodFetchFunc {
 	return func() ([]kubeApiCore.Pod, error) {
 		pods, err := a.PodsForSelector(context.TODO(), namespace, selectors...)
 		if err != nil {

--- a/tests/integration/operator/switch_cr_test.go
+++ b/tests/integration/operator/switch_cr_test.go
@@ -130,7 +130,7 @@ func TestController(t *testing.T) {
 }
 
 // checkInstallStatus check the status of IstioOperator CR from the cluster
-func checkInstallStatus(cs istioKube.Client) error {
+func checkInstallStatus(cs istioKube.ExtendedClient) error {
 	scopes.Framework.Infof("checking IstioOperator CR status")
 	gvr := schema.GroupVersionResource{
 		Group:    "install.istio.io",


### PR DESCRIPTION
Initial step for https://github.com/istio/istio/issues/24640

This adds a common `kube.Clients` struct to hold all informers/client we need across the project. All informers are shared, so PRs like https://github.com/istio/istio/pull/24843/files which add Service reading to another part of the code can do so for "free" -- currently almost every controller, which we have many of, creates their own informers which adds additional load on Istiod and Kubernetes.

As part of the initial PR, I have only moved over the kube service registry (and multicluster, as its tied to the kube service registry). This is only to get early feedback and not have a 10k line PR - I will have additional followups moving everything to the new model. In the mean time, the overhead of the informers is identical before and after this PR - we do not have any fewer informers, but we also don't create more.

The structure here is inspired by kube/controller-manager, cert-manager, and contour, all of which I feel like have pretty well structured projects and follow the "best practices" for interacting with kube libraries (especially controller-manager)