### PR TITLE
Fix the typo in the envoyMetricsService deprecation message

### DIFF
--- a/operator/pkg/apis/istio/v1alpha1/validation/validation.go
+++ b/operator/pkg/apis/istio/v1alpha1/validation/validation.go
@@ -89,7 +89,7 @@ func deprecatedSettingsMessage(iop *v1alpha1.IstioOperatorSpec) string {
 		{"Values.global.proxy.accessLogEncoding", "meshConfig.accessLogEncoding", valuesv1alpha1.AccessLogEncoding_JSON},
 		{"Values.global.proxy.concurrency", "meshConfig.concurrency", uint32(0)},
 		{"Values.global.proxy.envoyAccessLogService", "meshConfig.envoyAccessLogService", nil},
-		{"Values.global.proxy.envoyMetricsService", "meshConfig.envoyMetricsService", nil},
+		{"Values.global.proxy.envoyMetricsService", "meshConfig.defaultConfig.envoyMetricsService", nil},
 		{"Values.global.proxy.protocolDetectionTimeout", "meshConfig.protocolDetectionTimeout", ""},
 		{"Values.pilot.ingress", "meshConfig.ingressService, meshConfig.ingressControllerMode, and meshConfig.ingressClass", nil},
 		{"Values.global.mtls.enabled", "the PeerAuthentication resource", nil},


### PR DESCRIPTION
Fix #24872 as mentioned in [#24872 (comment)](https://github.com/istio/istio/issues/24872#issuecomment-647707032).