### PR TITLE
Add unit test of CSR request to server unit test to test cliencertauthenticator works correctly

### DIFF
--- a/security/pkg/server/ca/authenticate/cert_authenticator_test.go
+++ b/security/pkg/server/ca/authenticate/cert_authenticator_test.go
@@ -38,6 +38,7 @@ func (ai mockAuthInfo) AuthType() string {
 }
 
 func TestAuthenticate_clientCertAuthenticator(t *testing.T) {
+	t.Logf("TestAuthenticate_clientCertAuthenticator")
 	callerID := "test.identity"
 	ids := []util.Identity{
 		{Type: util.TypeURI, Value: []byte(callerID)},

--- a/security/pkg/server/ca/authenticate/cert_authenticator_test.go
+++ b/security/pkg/server/ca/authenticate/cert_authenticator_test.go
@@ -38,7 +38,6 @@ func (ai mockAuthInfo) AuthType() string {
 }
 
 func TestAuthenticate_clientCertAuthenticator(t *testing.T) {
-	t.Logf("TestAuthenticate_clientCertAuthenticator")
 	callerID := "test.identity"
 	ids := []util.Identity{
 		{Type: util.TypeURI, Value: []byte(callerID)},

--- a/security/pkg/server/ca/server_test.go
+++ b/security/pkg/server/ca/server_test.go
@@ -116,33 +116,33 @@ func TestCreateCertificateE2EUsingClientCertAuthenticator(t *testing.T) {
 	testCerts := map[string]struct {
 		certChain          [][]*x509.Certificate
 		caller             *authenticate.Caller
-		authenticateErrMsg string
 		fakeAuthInfo       *mockAuthInfo
 		code               codes.Code
 		ipAddr             *net.IPAddr
 	}{
+		//no client certificate is presented
 		"No client certificate": {
 			certChain:          nil,
 			caller:             nil,
-			authenticateErrMsg: "no client certificate is presented",
 			ipAddr:             mockIPAddr,
 			code:               codes.Unauthenticated,
 		},
+		//"unsupported auth type: not-tls"
 		"Unsupported auth type": {
 			certChain:          nil,
 			caller:             nil,
-			authenticateErrMsg: "unsupported auth type: \"not-tls\"",
 			fakeAuthInfo:       &mockAuthInfo{"not-tls"},
 			ipAddr:             mockIPAddr,
 			code:               codes.Unauthenticated,
 		},
+		//no cert chain presented
 		"Empty cert chain": {
 			certChain:          [][]*x509.Certificate{},
 			caller:             nil,
-			authenticateErrMsg: "no verified chain is found",
 			ipAddr:             mockIPAddr,
 			code:               codes.Unauthenticated,
 		},
+		//certificate misses the the SAN field
 		"Certificate has no SAN": {
 			certChain: [][]*x509.Certificate{
 				{
@@ -151,10 +151,10 @@ func TestCreateCertificateE2EUsingClientCertAuthenticator(t *testing.T) {
 					},
 				},
 			},
-			authenticateErrMsg: "the SAN extension does not exist",
 			ipAddr:             mockIPAddr,
 			code:               codes.Unauthenticated,
 		},
+		//successful testcase with valid client certificate
 		"With client certificate": {
 			certChain: [][]*x509.Certificate{
 				{

--- a/security/pkg/server/ca/server_test.go
+++ b/security/pkg/server/ca/server_test.go
@@ -114,33 +114,33 @@ func TestCreateCertificateE2EUsingClientCertAuthenticator(t *testing.T) {
 	mockCertChain := []string{"cert", "cert_chain", "root_cert"}
 	mockIPAddr := &net.IPAddr{IP: net.IPv4(192, 168, 1, 1)}
 	testCerts := map[string]struct {
-		certChain          [][]*x509.Certificate
-		caller             *authenticate.Caller
-		fakeAuthInfo       *mockAuthInfo
-		code               codes.Code
-		ipAddr             *net.IPAddr
+		certChain    [][]*x509.Certificate
+		caller       *authenticate.Caller
+		fakeAuthInfo *mockAuthInfo
+		code         codes.Code
+		ipAddr       *net.IPAddr
 	}{
 		//no client certificate is presented
 		"No client certificate": {
-			certChain:          nil,
-			caller:             nil,
-			ipAddr:             mockIPAddr,
-			code:               codes.Unauthenticated,
+			certChain: nil,
+			caller:    nil,
+			ipAddr:    mockIPAddr,
+			code:      codes.Unauthenticated,
 		},
 		//"unsupported auth type: not-tls"
 		"Unsupported auth type": {
-			certChain:          nil,
-			caller:             nil,
-			fakeAuthInfo:       &mockAuthInfo{"not-tls"},
-			ipAddr:             mockIPAddr,
-			code:               codes.Unauthenticated,
+			certChain:    nil,
+			caller:       nil,
+			fakeAuthInfo: &mockAuthInfo{"not-tls"},
+			ipAddr:       mockIPAddr,
+			code:         codes.Unauthenticated,
 		},
 		//no cert chain presented
 		"Empty cert chain": {
-			certChain:          [][]*x509.Certificate{},
-			caller:             nil,
-			ipAddr:             mockIPAddr,
-			code:               codes.Unauthenticated,
+			certChain: [][]*x509.Certificate{},
+			caller:    nil,
+			ipAddr:    mockIPAddr,
+			code:      codes.Unauthenticated,
 		},
 		//certificate misses the the SAN field
 		"Certificate has no SAN": {
@@ -151,8 +151,8 @@ func TestCreateCertificateE2EUsingClientCertAuthenticator(t *testing.T) {
 					},
 				},
 			},
-			ipAddr:             mockIPAddr,
-			code:               codes.Unauthenticated,
+			ipAddr: mockIPAddr,
+			code:   codes.Unauthenticated,
 		},
 		//successful testcase with valid client certificate
 		"With client certificate": {

--- a/security/pkg/server/ca/server_test.go
+++ b/security/pkg/server/ca/server_test.go
@@ -112,7 +112,7 @@ func TestCreateCertificateE2EUsingClientCertAuthenticator(t *testing.T) {
 		monitoring:     newMonitoringMetrics(),
 	}
 	mockCertChain := []string{"cert", "cert_chain", "root_cert"}
-	mockIpAddr := &net.IPAddr{IP: net.IPv4(192, 168, 1, 1)}
+	mockIPAddr := &net.IPAddr{IP: net.IPv4(192, 168, 1, 1)}
 	testCerts := map[string]struct {
 		certChain          [][]*x509.Certificate
 		caller             *authenticate.Caller
@@ -125,7 +125,7 @@ func TestCreateCertificateE2EUsingClientCertAuthenticator(t *testing.T) {
 			certChain:          nil,
 			caller:             nil,
 			authenticateErrMsg: "no client certificate is presented",
-			ipAddr:             mockIpAddr,
+			ipAddr:             mockIPAddr,
 			code:               codes.Unauthenticated,
 		},
 		"Unsupported auth type": {
@@ -133,14 +133,14 @@ func TestCreateCertificateE2EUsingClientCertAuthenticator(t *testing.T) {
 			caller:             nil,
 			authenticateErrMsg: "unsupported auth type: \"not-tls\"",
 			fakeAuthInfo:       &mockAuthInfo{"not-tls"},
-			ipAddr:             mockIpAddr,
+			ipAddr:             mockIPAddr,
 			code:               codes.Unauthenticated,
 		},
 		"Empty cert chain": {
 			certChain:          [][]*x509.Certificate{},
 			caller:             nil,
 			authenticateErrMsg: "no verified chain is found",
-			ipAddr:             mockIpAddr,
+			ipAddr:             mockIPAddr,
 			code:               codes.Unauthenticated,
 		},
 		"Certificate has no SAN": {
@@ -152,7 +152,7 @@ func TestCreateCertificateE2EUsingClientCertAuthenticator(t *testing.T) {
 				},
 			},
 			authenticateErrMsg: "the SAN extension does not exist",
-			ipAddr:             mockIpAddr,
+			ipAddr:             mockIPAddr,
 			code:               codes.Unauthenticated,
 		},
 		"With client certificate": {
@@ -164,7 +164,7 @@ func TestCreateCertificateE2EUsingClientCertAuthenticator(t *testing.T) {
 				},
 			},
 			caller: &authenticate.Caller{Identities: []string{callerID}},
-			ipAddr: mockIpAddr,
+			ipAddr: mockIPAddr,
 			code:   codes.OK,
 		},
 	}

--- a/security/pkg/server/ca/server_test.go
+++ b/security/pkg/server/ca/server_test.go
@@ -17,15 +17,21 @@ package ca
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"fmt"
+	"net"
 	"os"
 	"testing"
 	"time"
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 	"k8s.io/client-go/kubernetes/fake"
+
+	"istio.io/istio/security/pkg/pki/util"
 
 	"istio.io/istio/pkg/jwt"
 	"istio.io/istio/security/pkg/pki/ca"
@@ -68,6 +74,130 @@ func (authn *mockAuthenticator) Authenticate(ctx context.Context) (*authenticate
 		AuthSource: authn.authSource,
 		Identities: authn.identities,
 	}, nil
+}
+
+type mockAuthInfo struct {
+	authType string
+}
+
+func (ai mockAuthInfo) AuthType() string {
+	return ai.authType
+}
+
+func TestCreateCertificateE2EWithCertificates(t *testing.T) {
+	callerID := "test.identity"
+	ids := []util.Identity{
+		{Type: util.TypeURI, Value: []byte(callerID)},
+	}
+	sanExt, err := util.BuildSANExtension(ids)
+	if err != nil {
+		t.Error(err)
+	}
+	auth := &authenticate.ClientCertAuthenticator{}
+
+	server := &Server{
+		ca: &mockca.FakeCA{
+			SignedCert: []byte("cert"),
+			KeyCertBundle: &mockutil.FakeKeyCertBundle{
+				CertChainBytes: []byte("cert_chain"),
+				RootCertBytes:  []byte("root_cert"),
+			},
+		},
+		hostnames:      []string{"hostname"},
+		port:           8080,
+		Authenticators: []authenticate.Authenticator{auth},
+		monitoring:     newMonitoringMetrics(),
+	}
+	mockCertChain := []string{"cert", "cert_chain", "root_cert"}
+	testCerts := map[string]struct {
+		certChain          [][]*x509.Certificate
+		caller             *authenticate.Caller
+		authenticateErrMsg string
+		fakeAuthInfo       *mockAuthInfo
+		code               codes.Code
+		ipAddr             *net.IPAddr
+	}{
+		"No client certificate": {
+			certChain:          nil,
+			caller:             nil,
+			authenticateErrMsg: "no client certificate is presentedssss",
+			ipAddr:             &net.IPAddr{IP: net.IPv4(192, 168, 1, 1)},
+			code:               codes.Unauthenticated,
+		},
+		"Unsupported auth type": {
+			certChain:          nil,
+			caller:             nil,
+			authenticateErrMsg: "unsupported auth type: \"not-tls\"",
+			fakeAuthInfo:       &mockAuthInfo{"not-tls"},
+			ipAddr:             &net.IPAddr{IP: net.IPv4(192, 168, 1, 1)},
+			code:               codes.Unauthenticated,
+		},
+		"Empty cert chain": {
+			certChain:          [][]*x509.Certificate{},
+			caller:             nil,
+			authenticateErrMsg: "no verified chain is found",
+			ipAddr:             &net.IPAddr{IP: net.IPv4(192, 168, 1, 1)},
+			code:               codes.Unauthenticated,
+		},
+		"Certificate has no SAN": {
+			certChain: [][]*x509.Certificate{
+				{
+					{
+						Version: 1,
+					},
+				},
+			},
+			authenticateErrMsg: "the SAN extension does not exist",
+			ipAddr:             &net.IPAddr{IP: net.IPv4(192, 168, 1, 1)},
+			code:               codes.Unauthenticated,
+		},
+		"With client certificate": {
+			certChain: [][]*x509.Certificate{
+				{
+					{
+						Extensions: []pkix.Extension{*sanExt},
+					},
+				},
+			},
+			caller: &authenticate.Caller{Identities: []string{callerID}},
+			ipAddr: &net.IPAddr{IP: net.IPv4(192, 168, 1, 1)},
+			code:   codes.OK,
+		},
+	}
+
+	for id, c := range testCerts {
+		request := &pb.IstioCertificateRequest{Csr: "dumb CSR"}
+		ctx := context.Background()
+		if c.certChain != nil && len(c.certChain) != 0 {
+			tlsInfo := credentials.TLSInfo{
+				State: tls.ConnectionState{VerifiedChains: c.certChain},
+			}
+			p := &peer.Peer{Addr: c.ipAddr, AuthInfo: tlsInfo}
+			ctx = peer.NewContext(ctx, p)
+		}
+		if c.fakeAuthInfo != nil {
+			ctx = peer.NewContext(ctx, &peer.Peer{Addr: c.ipAddr, AuthInfo: c.fakeAuthInfo})
+		}
+		response, err := server.CreateCertificate(ctx, request)
+
+		s, _ := status.FromError(err)
+		code := s.Code()
+
+		if code != c.code {
+			t.Errorf("Case %s: expecting code to be (%d) but got (%d): %s", id, c.code, code, s.Message())
+		} else if c.code == codes.OK {
+			if len(response.CertChain) != len(mockCertChain) {
+				t.Errorf("Case %s: expecting cert chain length to be (%d) but got (%d)",
+					id, len(mockCertChain), len(response.CertChain))
+			}
+			for i, v := range response.CertChain {
+				if v != mockCertChain[i] {
+					t.Errorf("Case %s: expecting cert to be (%s) but got (%s) at position [%d] of cert chain.",
+						id, mockCertChain, v, i)
+				}
+			}
+		}
+	}
 }
 
 func TestCreateCertificate(t *testing.T) {


### PR DESCRIPTION
Add unit test of CSR request to server to test cliencertauthenticator works correctly


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure