### PR TITLE
Avoid include binary metadata in echo app grpc response

### DIFF
--- a/pkg/test/echo/server/endpoint/grpc.go
+++ b/pkg/test/echo/server/endpoint/grpc.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -129,6 +130,9 @@ func (h *grpcHandler) Echo(ctx context.Context, req *proto.EchoRequest) (*proto.
 	md, ok := metadata.FromIncomingContext(ctx)
 	if ok {
 		for key, values := range md {
+			if strings.HasSuffix(key, "-bin") {
+				continue
+			}
 			field := response.Field(key)
 			if key == ":authority" {
 				field = response.HostField


### PR DESCRIPTION


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure