### PR TITLE
Send envoy.config.core.v3.ControlPlane proto with experimental XDS

### DIFF
--- a/pilot/pkg/xds/adapter.go
+++ b/pilot/pkg/xds/adapter.go
@@ -62,18 +62,26 @@ func UpgradeV2Request(v2Req *xdsapi.DiscoveryRequest) *discovery.DiscoveryReques
 	}
 }
 
-// Convert from v3 to v2
+// DowngradeV3Response converts from v3 to v2
 func DowngradeV3Response(v3Resp *discovery.DiscoveryResponse) *xdsapi.DiscoveryResponse {
 	if v3Resp == nil {
 		return nil
 	}
 	return &xdsapi.DiscoveryResponse{
-		VersionInfo: v3Resp.VersionInfo,
-		Resources:   v3Resp.Resources,
-		Canary:      v3Resp.Canary,
-		TypeUrl:     v3Resp.TypeUrl,
-		Nonce:       v3Resp.Nonce,
+		ControlPlane: convertToV2ControlPlane(v3Resp.ControlPlane),
+		VersionInfo:  v3Resp.VersionInfo,
+		Resources:    v3Resp.Resources,
+		Canary:       v3Resp.Canary,
+		TypeUrl:      v3Resp.TypeUrl,
+		Nonce:        v3Resp.Nonce,
 	}
+}
+
+func convertToV2ControlPlane(cp *corev3.ControlPlane) *corev2.ControlPlane {
+	if cp == nil {
+		return nil
+	}
+	return &corev2.ControlPlane{Identifier: cp.Identifier}
 }
 
 func convertToV3Node(node *corev2.Node) *corev3.Node {

--- a/pilot/pkg/xds/gen2.go
+++ b/pilot/pkg/xds/gen2.go
@@ -31,7 +31,7 @@ import (
 
 // IstioControlPlaneInstance defines the format Istio uses for when creating Envoy config.core.v3.ControlPlane.identifier
 type IstioControlPlaneInstance struct {
-	// The Istio Pilot component type (e.g. "pilot")
+	// The Istio component type (e.g. "istiod")
 	Component string
 	// The ID of the component instance
 	ID string
@@ -112,10 +112,10 @@ func ControlPlane() *corev3.ControlPlane {
 }
 
 func init() {
-	// The Pod Name (Pilot identity) is in PilotArgs, but not reachable globally nor from DiscoveryServer
+	// The Pod Name (instance identity) is in PilotArgs, but not reachable globally nor from DiscoveryServer
 	podName := env.RegisterStringVar("POD_NAME", "", "").Get()
 	byVersion, err := json.Marshal(IstioControlPlaneInstance{
-		Component: "pilot",
+		Component: "istiod",
 		ID:        podName,
 		Info:      istioversion.Info,
 	})

--- a/pilot/pkg/xds/gen2.go
+++ b/pilot/pkg/xds/gen2.go
@@ -29,6 +29,16 @@ import (
 
 // gen2 provides experimental support for extended generation mechanism.
 
+// IstioControlPlaneInstance defines the format Istio uses for when creating Envoy config.core.v3.ControlPlane.identifier
+type IstioControlPlaneInstance struct {
+	// The Istio Pilot component type (e.g. "pilot")
+	Component string
+	// The ID of the component instance
+	ID string
+	// The Istio version
+	Info istioversion.BuildInfo
+}
+
 var (
 	controlPlane *corev3.ControlPlane
 )
@@ -104,10 +114,10 @@ func ControlPlane() *corev3.ControlPlane {
 func init() {
 	// The Pod Name (Pilot identity) is in PilotArgs, but not reachable globally nor from DiscoveryServer
 	podName := env.RegisterStringVar("POD_NAME", "", "").Get()
-	byVersion, err := json.Marshal(map[string]interface{}{
-		"component": "pilot",
-		"id":        podName,
-		"info":      istioversion.Info,
+	byVersion, err := json.Marshal(IstioControlPlaneInstance{
+		Component: "pilot",
+		ID:        podName,
+		Info:      istioversion.Info,
 	})
 	if err != nil {
 		adsLog.Warnf("XDS: Could not serialize control plane id: %v", err)


### PR DESCRIPTION
This PR adds a new field to XDS responses from gen2 (for example, istio.io/connections)

```
  "controlPlane": {
    "identifier": "{\"component\":\"pilot\",\"id\":\"istiod-123456-1234\",\"info\":{\"version\":\"937e5ccc577c72971ed41c90dc791ce9caa0f6c5-dirty\",\"revision\":\"937e5ccc577c72971ed41c90dc791ce9caa0f6c5-dirty\",\"golang_version\":\"go1.14.2\",\"status\":\"Modified\",\"tag\":\"1.6.0-alpha.2-610-g937e5ccc5\"}}"
  }
```

The format of identifier is wrapped JSON.

There are two purposes.  I propose to use the version as a replacement for istiod.istio-system:15014/version because that endpoint is not available under central Istiod 
 (the issue is https://github.com/istio/istio/issues/24331 )

The pod name is there for debugging -- if we get an XDS response with this, to let us identify which pod sent it.