### PR TITLE
test framework: analyze test metadata without running them

### DIFF
--- a/pkg/test/framework/analyzer.go
+++ b/pkg/test/framework/analyzer.go
@@ -122,6 +122,7 @@ func (s *suiteAnalyzer) run() int {
 func (s *suiteAnalyzer) track() *suiteAnalysis {
 	return &suiteAnalysis{
 		SuiteID:          s.testID,
+		SkipReason:       s.skip,
 		Labels:           s.labels.All(),
 		MultiCluster:     s.maxClusters != 1,
 		MultiClusterOnly: s.minCusters > 1,

--- a/pkg/test/framework/analyzer.go
+++ b/pkg/test/framework/analyzer.go
@@ -35,6 +35,7 @@ type commonAnalyzer struct {
 func newCommonAnalyzer() commonAnalyzer {
 	return commonAnalyzer{
 		labels:      label.NewSet(),
+		skip:        "",
 		minCusters:  1,
 		maxClusters: -1,
 	}

--- a/pkg/test/framework/analyzer.go
+++ b/pkg/test/framework/analyzer.go
@@ -1,14 +1,29 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package framework
 
 import (
+	"strings"
+	"testing"
+
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework/features"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/pkg/log"
-	"strings"
-	"testing"
 )
 
 type commonAnalyzer struct {

--- a/pkg/test/framework/analyzer.go
+++ b/pkg/test/framework/analyzer.go
@@ -1,0 +1,84 @@
+package framework
+
+import (
+	"istio.io/istio/pkg/test/framework/features"
+	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+type suiteAnalyzer struct {
+	
+}
+
+func (s *suiteAnalyzer) EnvironmentFactory(fn resource.EnvironmentFactory) Suite {
+	panic("implement me")
+}
+
+func (s *suiteAnalyzer) Label(labels ...label.Instance) Suite {
+	panic("implement me")
+}
+
+func (s *suiteAnalyzer) Skip(reason string) Suite {
+	panic("implement me")
+}
+
+func (s *suiteAnalyzer) RequireMinClusters(minClusters int) Suite {
+	panic("implement me")
+}
+
+func (s *suiteAnalyzer) RequireMaxClusters(maxClusters int) Suite {
+	panic("implement me")
+}
+
+func (s *suiteAnalyzer) RequireSingleCluster() Suite {
+	panic("implement me")
+}
+
+func (s *suiteAnalyzer) RequireEnvironmentVersion(version string) Suite {
+	panic("implement me")
+}
+
+func (s *suiteAnalyzer) Setup(fn resource.SetupFn) Suite {
+	panic("implement me")
+}
+
+func (s *suiteAnalyzer) Run() {
+	panic("implement me")
+}
+
+type testAnalyzer struct {
+
+}
+
+func (t *testAnalyzer) Label(labels ...label.Instance) Test {
+	panic("implement me")
+}
+
+func (t *testAnalyzer) Features(feats ...features.Feature) Test {
+	panic("implement me")
+}
+
+func (t *testAnalyzer) NotImplementedYet(features ...features.Feature) Test {
+	panic("implement me")
+}
+
+func (t *testAnalyzer) RequiresMinClusters(minClusters int) Test {
+	panic("implement me")
+}
+
+func (t *testAnalyzer) RequiresMaxClusters(maxClusters int) Test {
+	panic("implement me")
+}
+
+func (t *testAnalyzer) RequiresSingleCluster(maxClusters int) Test {
+	panic("implement me")
+}
+
+func (t *testAnalyzer) Run(fn func(ctx TestContext)) {
+	panic("implement me")
+}
+
+func (t *testAnalyzer) RunParallel(fn func(ctx TestContext)) {
+	panic("implement me")
+}
+

--- a/pkg/test/framework/analyzer_runtime.go
+++ b/pkg/test/framework/analyzer_runtime.go
@@ -1,15 +1,31 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package framework
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
-	"istio.io/istio/pkg/test/framework/features"
-	"istio.io/istio/pkg/test/framework/label"
-	"istio.io/istio/pkg/test/scopes"
 	"os"
 	"path"
 	"sync"
+
+	"gopkg.in/yaml.v2"
+
+	"istio.io/istio/pkg/test/framework/features"
+	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/scopes"
 )
 
 var (

--- a/pkg/test/framework/analyzer_runtime.go
+++ b/pkg/test/framework/analyzer_runtime.go
@@ -15,6 +15,7 @@
 package framework
 
 import (
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -35,7 +36,14 @@ var (
 )
 
 func init() {
-	analyzeMode = os.Getenv("ANALYZE_TESTS") != ""
+	flag.BoolVar(&analyzeMode, "istio.test.analyze", os.Getenv("ANALYZE_TESTS") != "", "Analyzes tests without actually running them")
+}
+
+func analyze() bool {
+	if !flag.Parsed() {
+		flag.Parse()
+	}
+	return analyzeMode
 }
 
 // initAnalysis sets up analysis for a single suite. If an analysis is already running,

--- a/pkg/test/framework/analyzer_runtime.go
+++ b/pkg/test/framework/analyzer_runtime.go
@@ -1,7 +1,14 @@
 package framework
 
 import (
+	"fmt"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+	"istio.io/istio/pkg/test/framework/features"
+	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/scopes"
 	"os"
+	"path"
 	"sync"
 )
 
@@ -24,26 +31,58 @@ func initAnalysis(a *suiteAnalysis) {
 
 // finishAnalysis marks the analysis for a suite as done and dumps the results.
 func finishAnalysis() {
-	// TODO dump
+	scopes.Framework.Infof("=== DONE: Analysis of %s ===", analysis.SuiteID)
+
+	dumpAnalysis()
 	analysis = nil
 	analysisMu.Unlock()
 }
 
+func dumpAnalysis() {
+	s, err := getSettings(analysis.SuiteID)
+	if err != nil {
+		scopes.Framework.Errorf("failed to get settings for %s: %v", analysis.SuiteID, err)
+	}
+	if err := os.MkdirAll(s.RunDir(), os.ModePerm); err != nil {
+		scopes.Framework.Errorf("failed to marshal analysis for %s: %v", analysis.SuiteID, err)
+		return
+	}
+
+	marshalled, err := yaml.Marshal(analysis)
+	if err != nil {
+		scopes.Framework.Errorf("failed to marshal analysis for %s: %v", analysis.SuiteID, err)
+		return
+	}
+	scopes.Framework.Info("\n" + string(marshalled))
+
+	outPath := path.Join(s.RunDir(), fmt.Sprintf("%s_analysis.yaml", analysis.SuiteID))
+	if err := ioutil.WriteFile(outPath, marshalled, 0666); err != nil {
+		scopes.Framework.Errorf("failed writing analysis to file for %s: %v", analysis.SuiteID, err)
+		return
+	}
+	scopes.Framework.Infof("Wrote analysis to %s", outPath)
+}
+
 // suiteAnalysis captures the results of analyzing a Suite
 type suiteAnalysis struct {
-	ID string
-
-	testMu sync.Mutex
-	tests  []*testAnalysis
+	SuiteID       string
+	Labels        []label.Instance
+	SingleCluster bool
+	MultiCluster  bool
+	Tests         []*testAnalysis
 }
 
 func (s *suiteAnalysis) addTest(test *testAnalysis) {
-	s.testMu.Lock()
-	defer s.testMu.Unlock()
-	s.tests = append(s.tests, test)
+	s.Tests = append(s.Tests, test)
 }
 
 // suiteAnalysis captures the results of analyzing a Test
 type testAnalysis struct {
-	ID string
+	TestID         string
+	Labels         []label.Instance
+	Features       map[features.Feature][]string
+	Valid          bool
+	SingleCluster  bool
+	MultiCluster   bool
+	NotImplemented bool
 }

--- a/pkg/test/framework/analyzer_runtime.go
+++ b/pkg/test/framework/analyzer_runtime.go
@@ -60,19 +60,19 @@ func dumpAnalysis() {
 		scopes.Framework.Errorf("failed to get settings for %s: %v", analysis.SuiteID, err)
 	}
 	if err := os.MkdirAll(s.RunDir(), os.ModePerm); err != nil {
-		scopes.Framework.Errorf("failed to marshal analysis for %s: %v", analysis.SuiteID, err)
+		scopes.Framework.Errorf("failed to create analysis directory for %s: %v", analysis.SuiteID, err)
 		return
 	}
 
-	marshalled, err := yaml.Marshal(analysis)
+	marshaled, err := yaml.Marshal(analysis)
 	if err != nil {
-		scopes.Framework.Errorf("failed to marshal analysis for %s: %v", analysis.SuiteID, err)
+		scopes.Framework.Errorf("failed to marshaled analysis for %s: %v", analysis.SuiteID, err)
 		return
 	}
-	scopes.Framework.Info("\n" + string(marshalled))
+	scopes.Framework.Info("\n" + string(marshaled))
 
 	outPath := path.Join(s.RunDir(), fmt.Sprintf("%s_analysis.yaml", analysis.SuiteID))
-	if err := ioutil.WriteFile(outPath, marshalled, 0666); err != nil {
+	if err := ioutil.WriteFile(outPath, marshaled, 0666); err != nil {
 		scopes.Framework.Errorf("failed writing analysis to file for %s: %v", analysis.SuiteID, err)
 		return
 	}
@@ -81,24 +81,25 @@ func dumpAnalysis() {
 
 // suiteAnalysis captures the results of analyzing a Suite
 type suiteAnalysis struct {
-	SuiteID       string
-	Labels        []label.Instance
-	SingleCluster bool
-	MultiCluster  bool
-	Tests         []*testAnalysis
+	SuiteID          string                   `yaml:"suiteID"`
+	SkipReason       string                   `yaml:"skipReason,omitempty"`
+	Labels           []label.Instance         `yaml:"labels,omitempty"`
+	MultiCluster     bool                     `yaml:"multicluster,omitempty"`
+	MultiClusterOnly bool                     `yaml:"multiclusterOnly,omitempty"`
+	Tests            map[string]*testAnalysis `yaml:"tests"`
 }
 
-func (s *suiteAnalysis) addTest(test *testAnalysis) {
-	s.Tests = append(s.Tests, test)
+func (s *suiteAnalysis) addTest(id string, test *testAnalysis) {
+	s.Tests[id] = test
 }
 
 // suiteAnalysis captures the results of analyzing a Test
 type testAnalysis struct {
-	TestID         string
-	Labels         []label.Instance
-	Features       map[features.Feature][]string
-	Valid          bool
-	SingleCluster  bool
-	MultiCluster   bool
-	NotImplemented bool
+	SkipReason       string                        `yaml:"skipReason,omitempty"`
+	Labels           []label.Instance              `yaml:"labels,omitempty"`
+	Features         map[features.Feature][]string `yaml:"features,omitempty"`
+	Invalid          bool                          `yaml:"invalid,omitempty"`
+	MultiCluster     bool                          `yaml:"multicluster,omitempty"`
+	MultiClusterOnly bool                          `yaml:"multiclusterOnly,omitempty"`
+	NotImplemented   bool                          `yaml:"notImplemented,omitempty"`
 }

--- a/pkg/test/framework/analyzer_runtime.go
+++ b/pkg/test/framework/analyzer_runtime.go
@@ -1,0 +1,49 @@
+package framework
+
+import (
+	"os"
+	"sync"
+)
+
+var (
+	analyzeMode bool
+	analysis    *suiteAnalysis
+	analysisMu  sync.Mutex
+)
+
+func init() {
+	analyzeMode = os.Getenv("ANALYZE_TESTS") != ""
+}
+
+// initAnalysis sets up analysis for a single suite. If an analysis is already running,
+// it will block until finishAnalysis is called.
+func initAnalysis(a *suiteAnalysis) {
+	analysisMu.Lock()
+	analysis = a
+}
+
+// finishAnalysis marks the analysis for a suite as done and dumps the results.
+func finishAnalysis() {
+	// TODO dump
+	analysis = nil
+	analysisMu.Unlock()
+}
+
+// suiteAnalysis captures the results of analyzing a Suite
+type suiteAnalysis struct {
+	ID string
+
+	testMu sync.Mutex
+	tests  []*testAnalysis
+}
+
+func (s *suiteAnalysis) addTest(test *testAnalysis) {
+	s.testMu.Lock()
+	defer s.testMu.Unlock()
+	s.tests = append(s.tests, test)
+}
+
+// suiteAnalysis captures the results of analyzing a Test
+type testAnalysis struct {
+	ID string
+}

--- a/pkg/test/framework/operations.go
+++ b/pkg/test/framework/operations.go
@@ -32,7 +32,7 @@ func NewContext(goTest *testing.T, labels ...label.Instance) TestContext {
 }
 
 // newRootContext creates a new TestContext that has no parent. Delegates to the global runtime.
-func newRootContext(test *Test, goTest *testing.T, labels ...label.Instance) *testContext {
+func newRootContext(test *testImpl, goTest *testing.T, labels ...label.Instance) *testContext {
 	rtMu.Lock()
 	defer rtMu.Unlock()
 

--- a/pkg/test/framework/runtime.go
+++ b/pkg/test/framework/runtime.go
@@ -50,7 +50,7 @@ func (i *runtime) suiteContext() *suiteContext {
 }
 
 // newRootContext creates and returns a new testContext with no parent.
-func (i *runtime) newRootContext(test *Test, goTest *testing.T, labels label.Set) *testContext {
+func (i *runtime) newRootContext(test *testImpl, goTest *testing.T, labels label.Set) *testContext {
 	return newTestContext(test, goTest, i.context, nil, labels)
 }
 

--- a/pkg/test/framework/suite.go
+++ b/pkg/test/framework/suite.go
@@ -136,9 +136,19 @@ func deriveSuiteName(caller string) string {
 
 // NewSuite returns a new suite instance.
 func NewSuite(m *testing.M) Suite {
-	// TODO check for analyze mode
 	_, f, _, _ := goruntime.Caller(1)
-	return newSuite(deriveSuiteName(f),
+	suiteName := deriveSuiteName(f)
+
+	if analyzeMode {
+		return newSuiteAnalyzer(
+			suiteName,
+			func(_ *suiteContext) int {
+				return m.Run()
+			},
+			os.Exit)
+	}
+
+	return newSuite(suiteName,
 		func(_ *suiteContext) int {
 			return m.Run()
 		},

--- a/pkg/test/framework/suite.go
+++ b/pkg/test/framework/suite.go
@@ -136,6 +136,7 @@ func deriveSuiteName(caller string) string {
 
 // NewSuite returns a new suite instance.
 func NewSuite(m *testing.M) Suite {
+	// TODO check for analyze mode
 	_, f, _, _ := goruntime.Caller(1)
 	return newSuite(deriveSuiteName(f),
 		func(_ *suiteContext) int {

--- a/pkg/test/framework/suite.go
+++ b/pkg/test/framework/suite.go
@@ -156,7 +156,7 @@ func NewSuite(m *testing.M) Suite {
 		getSettings)
 }
 
-func newSuite(testID string, fn mRunFn, osExit func(int), getSettingsFn getSettingsFunc) Suite {
+func newSuite(testID string, fn mRunFn, osExit func(int), getSettingsFn getSettingsFunc) *suiteImpl {
 	s := &suiteImpl{
 		testID:      testID,
 		mRun:        fn,

--- a/pkg/test/framework/suite.go
+++ b/pkg/test/framework/suite.go
@@ -139,7 +139,7 @@ func NewSuite(m *testing.M) Suite {
 	_, f, _, _ := goruntime.Caller(1)
 	suiteName := deriveSuiteName(f)
 
-	if analyzeMode {
+	if analyze() {
 		return newSuiteAnalyzer(
 			suiteName,
 			func(_ *suiteContext) int {

--- a/pkg/test/framework/suite_test.go
+++ b/pkg/test/framework/suite_test.go
@@ -53,7 +53,7 @@ func cleanupRT() {
 }
 
 // Create a bogus environment for testing. This can be removed when "environments" are removed
-func newTestSuite(testID string, fn mRunFn, osExit func(int), getSettingsFn getSettingsFunc) *Suite {
+func newTestSuite(testID string, fn mRunFn, osExit func(int), getSettingsFn getSettingsFunc) *suiteImpl {
 	s := newSuite(testID, fn, osExit, getSettingsFn)
 	s.envFactory = func(ctx resource.Context) (resource.Environment, error) {
 		return fakeEnvironment{}, nil

--- a/pkg/test/framework/suitecontext.go
+++ b/pkg/test/framework/suitecontext.go
@@ -236,7 +236,7 @@ type TestOutcome struct {
 	FeatureLabels map[features.Feature][]string
 }
 
-func (s *suiteContext) registerOutcome(test *Test) {
+func (s *suiteContext) registerOutcome(test *testImpl) {
 	s.outcomeMu.Lock()
 	defer s.outcomeMu.Unlock()
 	o := Passed

--- a/pkg/test/framework/test.go
+++ b/pkg/test/framework/test.go
@@ -42,7 +42,7 @@ type Test interface {
 	// Otherwise it stops test execution and skips the test.
 	RequiresMaxClusters(maxClusters int) Test
 	// RequiresSingleCluster this a utility that requires the min/max clusters to both = 1.
-	RequiresSingleCluster(maxClusters int) Test
+	RequiresSingleCluster() Test
 	// Run the test, supplied as a lambda.
 	Run(fn func(ctx TestContext))
 	// RunParallel runs this test in parallel with other children of the same parent test/suite. Under the hood,
@@ -94,7 +94,6 @@ type Test interface {
 	RunParallel(fn func(ctx TestContext))
 }
 
-
 // Test allows the test author to specify test-related metadata in a fluent-style, before commencing execution.
 type testImpl struct {
 	// name to be used when creating a Golang test. Only used for subtests.
@@ -124,6 +123,7 @@ var globalParentLock = new(sync.Map)
 
 // NewTest returns a new test wrapper for running a single test.
 func NewTest(t *testing.T) Test {
+	// TODO check for analyze mode
 	rtMu.Lock()
 	defer rtMu.Unlock()
 
@@ -184,7 +184,7 @@ func (t *testImpl) RequiresMaxClusters(maxClusters int) Test {
 	return t
 }
 
-func (t *testImpl) RequiresSingleCluster(maxClusters int) Test {
+func (t *testImpl) RequiresSingleCluster() Test {
 	return t.RequiresMaxClusters(1).RequiresMinClusters(1)
 }
 

--- a/pkg/test/framework/test.go
+++ b/pkg/test/framework/test.go
@@ -213,19 +213,6 @@ func (t *testImpl) runInternal(fn func(ctx TestContext), parallel bool) {
 		return
 	}
 
-	// TODO: should we also block new cases?
-	var myGoTest *testing.T
-	if t.goTest != nil {
-		myGoTest = t.goTest
-	} else {
-		myGoTest = t.parent.goTest
-	}
-	suiteName := t.s.settings.TestID
-	if len(t.featureLabels) < 1 && !features.GlobalWhitelist.Contains(suiteName, myGoTest.Name()) {
-		myGoTest.Fatalf("Detected new test %s in suite %s with no feature labels.  "+
-			"See istio/istio/pkg/test/framework/features/README.md", myGoTest.Name(), suiteName)
-	}
-
 	if t.parent != nil {
 		// Create a new subtest under the parent's test.
 		parentGoTest := t.parent.goTest

--- a/pkg/test/framework/test.go
+++ b/pkg/test/framework/test.go
@@ -123,7 +123,7 @@ var globalParentLock = new(sync.Map)
 
 // NewTest returns a new test wrapper for running a single test.
 func NewTest(t *testing.T) Test {
-	if analyzeMode {
+	if analyze() {
 		return newTestAnalyzer(t)
 	}
 	rtMu.Lock()

--- a/pkg/test/framework/test.go
+++ b/pkg/test/framework/test.go
@@ -123,7 +123,9 @@ var globalParentLock = new(sync.Map)
 
 // NewTest returns a new test wrapper for running a single test.
 func NewTest(t *testing.T) Test {
-	// TODO check for analyze mode
+	if analyzeMode {
+		return newTestAnalyzer(t)
+	}
 	rtMu.Lock()
 	defer rtMu.Unlock()
 

--- a/pkg/test/framework/testcontext.go
+++ b/pkg/test/framework/testcontext.go
@@ -42,7 +42,7 @@ type TestContext interface {
 	// create their own Golang *testing.T with the name provided.
 	//
 	// If this TestContext was not created by a Test or if that Test is not running, this method will panic.
-	NewSubTest(name string) *testImpl
+	NewSubTest(name string) Test
 
 	// WorkDir allocated for this test.
 	WorkDir() string
@@ -297,7 +297,7 @@ func (c *testContext) newChildContext(test *testImpl) *testContext {
 	return newTestContext(test, test.goTest, c.suite, c.scope, label.NewSet(test.labels...))
 }
 
-func (c *testContext) NewSubTest(name string) *testImpl {
+func (c *testContext) NewSubTest(name string) Test {
 	if c.test == nil {
 		panic(fmt.Sprintf("Attempting to create subtest %s from a TestContext with no associated Test", name))
 	}

--- a/pkg/test/framework/testcontext.go
+++ b/pkg/test/framework/testcontext.go
@@ -42,7 +42,7 @@ type TestContext interface {
 	// create their own Golang *testing.T with the name provided.
 	//
 	// If this TestContext was not created by a Test or if that Test is not running, this method will panic.
-	NewSubTest(name string) *Test
+	NewSubTest(name string) *testImpl
 
 	// WorkDir allocated for this test.
 	WorkDir() string
@@ -86,7 +86,7 @@ type testContext struct {
 	id string
 
 	// The currently running Test. Non-nil if this context was created by a Test
-	test *Test
+	test *testImpl
 
 	// The underlying Go testing.T for this context.
 	*testing.T
@@ -107,13 +107,13 @@ type testContext struct {
 // then new tests can unexpectedly start during the cleanup of another. This may lead to odd results, like a test cleanup undoing the setup of a future test.
 // To workaround this, we maintain a set of all contexts currently terminating. Before starting the context, we will search this set;
 // if any non-parent contexts are found, we will wait.
-func waitForParents(test *Test) {
+func waitForParents(test *testImpl) {
 	iterations := 0
 	for {
 		iterations++
 		done := true
 		globalParentLock.Range(func(key, value interface{}) bool {
-			k := key.(*Test)
+			k := key.(*testImpl)
 			current := test
 			for current != nil {
 				if current == k {
@@ -134,14 +134,14 @@ func waitForParents(test *Test) {
 		// Add some logging in case something locks up so we can debug
 		if iterations%10 == 0 {
 			globalParentLock.Range(func(key, value interface{}) bool {
-				scopes.Framework.Warnf("Stuck waiting for parent test suites to terminate... %v is blocking", key.(*Test).goTest.Name())
+				scopes.Framework.Warnf("Stuck waiting for parent test suites to terminate... %v is blocking", key.(*testImpl).goTest.Name())
 				return true
 			})
 		}
 	}
 }
 
-func newTestContext(test *Test, goTest *testing.T, s *suiteContext, parentScope *scope, labels label.Set) *testContext {
+func newTestContext(test *testImpl, goTest *testing.T, s *suiteContext, parentScope *scope, labels label.Set) *testContext {
 	waitForParents(test)
 	id := s.allocateContextID(goTest.Name())
 
@@ -293,11 +293,11 @@ func (c *testContext) RequireOrSkip(envName environment.Name) {
 	}
 }
 
-func (c *testContext) newChildContext(test *Test) *testContext {
+func (c *testContext) newChildContext(test *testImpl) *testContext {
 	return newTestContext(test, test.goTest, c.suite, c.scope, label.NewSet(test.labels...))
 }
 
-func (c *testContext) NewSubTest(name string) *Test {
+func (c *testContext) NewSubTest(name string) *testImpl {
 	if c.test == nil {
 		panic(fmt.Sprintf("Attempting to create subtest %s from a TestContext with no associated Test", name))
 	}
@@ -306,7 +306,7 @@ func (c *testContext) NewSubTest(name string) *Test {
 		panic(fmt.Sprintf("Attempting to create subtest %s before running parent", name))
 	}
 
-	return &Test{
+	return &testImpl{
 		name:          name,
 		parent:        c.test,
 		s:             c.test.s,

--- a/tests/integration/galley/namespace_test.go
+++ b/tests/integration/galley/namespace_test.go
@@ -51,7 +51,7 @@ func TestNamespace(t *testing.T) {
 			}
 		})
 
-	if !noCleanup {
+	if !noCleanup && cluster.Accessor != nil {
 		// Check after run to see that the namespace is gone.
 		if err := cluster.WaitForNamespaceDeletion(namespaceName); err != nil {
 			t.Fatalf("WaitiForNamespaceDeletion failed: %v", err)

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -58,6 +58,11 @@ ifneq ($(_INTEGRATION_TEST_NETWORKS),)
     _INTEGRATION_TEST_FLAGS += --istio.test.kube.networkTopology=$(_INTEGRATION_TEST_NETWORKS)
 endif
 
+test.integration.analyze: | $(JUNIT_REPORT)
+	$(GO) test -p 1 ${T} ./tests/integration/... -timeout 30m \
+	--istio.test.analyze \
+	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
+
 # Generate integration test targets for kubernetes environment.
 test.integration.%.kube: | $(JUNIT_REPORT)
 	$(GO) test -p 1 ${T} ./tests/integration/$(subst .,/,$*)/... -timeout 30m \


### PR DESCRIPTION
When trying to quickly iterate locally; adding subtests to existing whitelisted tests (see mirrorTest) will trigger a failure. Small annoyance, but easy to run into.

As part of https://github.com/istio/istio/issues/24581 I needed a good way to track whether or not a test supported multicluster; that didn't fit cleanly into the feature labels. 

This will also help enumerate existing tests which tests need feature labels added. 

When running tests with `ANALYZE_TESTS` env var set (can move this to `--istio.test.analyze`) they will finish nearly instantly (doesn't actually run the test) and produce YAML that tells us:
  - Validity (right now the only thing that invalidates is the lack of feature label/whitelist)
  - Allows single-cluster (minClusters < 2)
  - Allows multi-cluster (maxClusters != 1)
  - Marked not-implemented
  - Features
  - Labels 

Rus using go-test, reimplements the `framework.Suite` and `framework.Test` so no changes are required to existing tests. Invalid tests will be marked as failed. Would be simple to add a prow-job that does test meta-validation, separate from actually running tests. 

Example Output:

```yaml
suiteID: pilot
tests:
  TestAddToAndRemoveFromMesh: {}
  TestAuthZCheck: {}
  TestDescribe: {}
  TestMirroring: {}
  TestMirroringExternalService: {}
  TestProxyConfig: {}
  TestProxyStatus: {}
  TestReachability: {}
  TestServiceEntryDNS: {}
  TestServiceEntryDNSNoSelfImport: {}
  TestServiceEntryStatic: {}
  TestSidecarListeners: {}
  TestSidecarScopeIngressListener: {}
  TestSniffing: {}
  TestTrafficRouting: {}
  TestTrafficShifting: {}
  TestVersion: {}
  TestWait: {}
```

Example output (with multicluster tests and feature labels):

```yaml
suiteID: pilot
multicluster: true
tests:
  TestAddToAndRemoveFromMesh: {}
  TestAuthZCheck: {}
  TestDescribe: {}
  TestMirroring:
    multicluster: true
  TestMirroringExternalService:
    multicluster: true
  TestProxyConfig: {}
  TestProxyStatus: {}
  TestReachability:
    multicluster: true
  TestServiceEntryDNS:
    multicluster: true
  TestServiceEntryDNSNoSelfImport:
    multicluster: true
  TestServiceEntryStatic:
    multicluster: true
  TestSidecarListeners: {}
  TestSidecarScopeIngressListener:
    multicluster: true
  TestSniffing:
    multicluster: true
  TestTrafficRouting:
    features:
      traffic.routing:
      - ""
    multicluster: true
  TestTrafficShifting: {}
  TestVersion: {}
  TestWait: {}
```
