### PR TITLE
cherry-pick: istio iptables filters empty values

### DIFF
--- a/tools/istio-iptables/pkg/cmd/run.go
+++ b/tools/istio-iptables/pkg/cmd/run.go
@@ -48,11 +48,22 @@ type NetworkRange struct {
 	IPNets     []*net.IPNet
 }
 
+func filterEmpty(strs []string) []string {
+	filtered := make([]string, 0, len(strs))
+	for _, s := range strs {
+		if s == "" {
+			continue
+		}
+		filtered = append(filtered, s)
+	}
+	return filtered
+}
+
 func split(s string) []string {
 	if s == "" {
 		return nil
 	}
-	return strings.Split(s, ",")
+	return filterEmpty(strings.Split(s, ","))
 }
 
 func (iptConfigurator *IptablesConfigurator) separateV4V6(cidrList string) (NetworkRange, NetworkRange, error) {

--- a/tools/istio-iptables/pkg/cmd/run_test.go
+++ b/tools/istio-iptables/pkg/cmd/run_test.go
@@ -157,7 +157,7 @@ func TestHandleInboundIpv6RulesWithWildcardRanges(t *testing.T) {
 func TestHandleInboundIpv6RulesWithIpNets(t *testing.T) {
 	cfg := constructTestConfig()
 	cfg.InboundPortsInclude = "4000,5000"
-	cfg.InboundPortsExclude = "6000,7000"
+	cfg.InboundPortsExclude = "6000,7000,"
 	cfg.KubevirtInterfaces = "eth0,eth1"
 	cfg.EnableInboundIPv6 = true
 


### PR DESCRIPTION
closes https://github.com/istio/istio/issues/25000

This PR only pulls in the iptables gen fix, curious what differences there may be in templates/template-locations for 1.5? 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
