### PR TITLE
Optimize ResolveGatewayName

### DIFF
--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -330,17 +330,17 @@ func resolveGatewayName(gwname string, meta ConfigMeta) string {
 	if !strings.Contains(gwname, "/") {
 		if !strings.Contains(gwname, ".") {
 			// we have a short name. Resolve to a gateway in same namespace
-			out = fmt.Sprintf("%s/%s", meta.Namespace, gwname)
+			out = meta.Namespace + "/" + gwname
 		} else {
 			// parse namespace from FQDN. This is very hacky, but meant for backward compatibility only
-			parts := strings.Split(gwname, ".")
-			out = fmt.Sprintf("%s/%s", parts[1], parts[0])
+			i := strings.Index(gwname, ".")
+			out = gwname[i+1:] + "/" + gwname[:i]
 		}
 	} else {
 		// remove the . from ./gateway and substitute it with the namespace name
-		parts := strings.Split(gwname, "/")
-		if parts[0] == "." {
-			out = fmt.Sprintf("%s/%s", meta.Namespace, parts[1])
+		i := strings.Index(gwname, "/")
+		if gwname[:i] == "." {
+			out = meta.Namespace + "/" + gwname[i+1:]
 		}
 	}
 	return out

--- a/pilot/pkg/model/virtualservice_test.go
+++ b/pilot/pkg/model/virtualservice_test.go
@@ -15,6 +15,7 @@
 package model
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -1600,5 +1601,55 @@ func TestFuzzMergeHttpMatchRequest(t *testing.T) {
 
 	if !reflect.DeepEqual(merged, root) {
 		t.Errorf("%s", cmp.Diff(merged, root))
+	}
+}
+
+var gatewayNameTests = []struct {
+	gateway   string
+	namespace string
+	resolved  string
+}{
+	{
+		"./gateway",
+		"default",
+		"default/gateway",
+	},
+	{
+		"gateway",
+		"default",
+		"default/gateway",
+	},
+	{
+		"default/gateway",
+		"foo",
+		"default/gateway",
+	},
+	{
+		"gateway.default",
+		"default",
+		"default/gateway",
+	},
+	{
+		"gateway.default",
+		"foo",
+		"default/gateway",
+	},
+}
+
+func TestResolveGatewayName(t *testing.T) {
+	for _, tt := range gatewayNameTests {
+		t.Run(fmt.Sprintf("%s-%s", tt.gateway, tt.namespace), func(t *testing.T) {
+			if got := resolveGatewayName(tt.gateway, ConfigMeta{Namespace: tt.namespace}); got != tt.resolved {
+				t.Fatalf("expected %q got %q", tt.resolved, got)
+			}
+		})
+	}
+}
+
+func BenchmarkResolveGatewayName(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, tt := range gatewayNameTests {
+			_ = resolveGatewayName(tt.gateway, ConfigMeta{Namespace: tt.namespace})
+		}
 	}
 }


### PR DESCRIPTION
In large clusters this has been shown to uses ~20% of CPU and ~10%/60% of
allocations  in terms of byes/number leading to huge GC trashing

BenchmarkResolveGatewayName/old-8               10342688
1222 ns/op             320 B/op         16 allocs/op
BenchmarkResolveGatewayName/new-8               39173893
322 ns/op              64 B/op          4 allocs/op



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure