### PR TITLE
security integration tests use all configured clusters

### DIFF
--- a/tests/integration/security/filebased_tls_origination/destination_rule_tls_test.go
+++ b/tests/integration/security/filebased_tls_origination/destination_rule_tls_test.go
@@ -94,6 +94,7 @@ spec:
 						Service:   fmt.Sprintf("client-%d", c.Index()),
 						Namespace: ns,
 						Ports:     []echo.Port{},
+						// TODO rebase on main multicluster testing branch, these are unused anyway
 						// Pilot:     pilots[c.Index()],
 						Subsets: []echo.SubsetConfig{{
 							Version: "v1",
@@ -128,6 +129,7 @@ spec:
 								TLS:          true,
 							},
 						},
+						// TODO rebase on main multicluster testing branch, these are unused anyway
 						// Pilot: pilots[c.Index()],
 						// Set up TLS certs on the server. This will make the server listen with these credentials.
 						TLSSettings: serverTLSSettings,

--- a/tests/integration/security/filebased_tls_origination/egress_gateway_origination_test.go
+++ b/tests/integration/security/filebased_tls_origination/egress_gateway_origination_test.go
@@ -56,6 +56,7 @@ func mustReadCert(t *testing.T, f string) string {
 // are routed securely through the egress gateway and that the TLS origination happens at the gateway.
 func TestEgressGatewayTls(t *testing.T) {
 	framework.NewTest(t).
+		RequiresSingleCluster(1).
 		Features("security.egress.tls.filebased").
 		Run(func(ctx framework.TestContext) {
 			ctx.RequireOrSkip(environment.Kube)

--- a/tests/integration/security/filebased_tls_origination/main_test.go
+++ b/tests/integration/security/filebased_tls_origination/main_test.go
@@ -15,15 +15,14 @@
 package filebasedtlsorigination
 
 import (
-	"testing"
-
+	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/tests/integration/security/util/cert"
+	"testing"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/pilot"
 	"istio.io/istio/pkg/test/framework/label"
-	"istio.io/istio/pkg/test/framework/resource"
 )
 
 var (
@@ -38,7 +37,6 @@ func TestMain(m *testing.M) {
 
 		// SDS requires Kubernetes 1.13
 		RequireEnvironmentVersion("1.13").
-		RequireSingleCluster().
 		Label("CustomSetup").
 		Setup(istio.Setup(&inst, setupConfig, cert.CreateCustomEgressSecret)).
 		Setup(func(ctx resource.Context) (err error) {
@@ -59,8 +57,6 @@ func setupConfig(cfg *istio.Config) {
 components:
   egressGateways:
   - enabled: true
-  ingressGateways:
-  - enabled: false
 values:
    gateways:
       istio-egressgateway:
@@ -68,5 +64,10 @@ values:
          - name: client-custom-certs
            secretName: egress-gw-cacerts
            mountPath: /etc/certs/custom
+`
+	cfg.RemoteClusterValues = `
+components:
+  egressGateways:
+  - enabled: false
 `
 }

--- a/tests/integration/security/util/cert/cert.go
+++ b/tests/integration/security/util/cert/cert.go
@@ -154,7 +154,6 @@ func CreateCustomEgressSecret(ctx resource.Context) error {
 		return err
 	}
 
-	kubeAccessor := ctx.Environment().(*kube.Environment).KubeClusters[0]
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -168,9 +167,11 @@ func CreateCustomEgressSecret(ctx resource.Context) error {
 		},
 	}
 
-	_, err = kubeAccessor.CoreV1().Secrets(systemNs.Name()).Create(context.TODO(), secret, metav1.CreateOptions{})
-	if err != nil {
-		return err
+	for _, kubeAccessor := range ctx.Environment().(*kube.Environment).KubeClusters {
+		_, err = kubeAccessor.CoreV1().Secrets(systemNs.Name()).Create(context.TODO(), secret, metav1.CreateOptions{})
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Part of https://github.com/istio/istio/issues/25054

Similar to https://github.com/istio/istio/pull/24549 I'm converting security integration tests to utilize all clusters configured in the test-framework. 

Before this has value, a Prow job will need to be created. The changes so far (TestDestinationRuleTLS) pass on my local machine against 3 GKE clusters, multiple control-plane clusters and a remote cluster on two networks.

List of converted tests:

- [X] TestDestinationRuleTLS

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
