### PR TITLE
xds: lint fixes

### DIFF
--- a/pilot/pkg/xds/ads_common.go
+++ b/pilot/pkg/xds/ads_common.go
@@ -29,7 +29,7 @@ var configKindAffectedProxyTypes = map[resource.GroupVersionKind][]model.NodeTyp
 
 // ConfigAffectsProxy checks if a pushEv will affect a specified proxy. That means whether the push will be performed
 // towards the proxy.
-func ConfigAffectsProxy(pushEv *XdsEvent, proxy *model.Proxy) bool {
+func ConfigAffectsProxy(pushEv *Event, proxy *model.Proxy) bool {
 	// Empty changes means "all" to get a backward compatibility.
 	if len(pushEv.configsUpdated) == 0 {
 		return true
@@ -64,7 +64,7 @@ func ConfigAffectsProxy(pushEv *XdsEvent, proxy *model.Proxy) bool {
 }
 
 // ProxyNeedsPush check if a proxy needs push for this push event.
-func ProxyNeedsPush(proxy *model.Proxy, pushEv *XdsEvent) bool {
+func ProxyNeedsPush(proxy *model.Proxy, pushEv *Event) bool {
 	if ConfigAffectsProxy(pushEv, proxy) {
 		return true
 	}
@@ -84,19 +84,18 @@ func ProxyNeedsPush(proxy *model.Proxy, pushEv *XdsEvent) bool {
 	return false
 }
 
-// nolint
-type XdsType int
+type Type int
 
 const (
-	CDS XdsType = iota
+	CDS Type = iota
 	EDS
 	LDS
 	RDS
 )
 
 // TODO: merge with ProxyNeedsPush
-func PushTypeFor(proxy *model.Proxy, pushEv *XdsEvent) map[XdsType]bool {
-	out := map[XdsType]bool{}
+func PushTypeFor(proxy *model.Proxy, pushEv *Event) map[Type]bool {
+	out := map[Type]bool{}
 
 	// In case configTypes is not set, for example mesh configuration updated.
 	// If push scoping is not enabled, we push all xds

--- a/pilot/pkg/xds/ads_common_test.go
+++ b/pilot/pkg/xds/ads_common_test.go
@@ -132,7 +132,7 @@ func TestProxyNeedsPush(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			pushEv := &XdsEvent{configsUpdated: tt.configs}
+			pushEv := &Event{configsUpdated: tt.configs}
 			got := ProxyNeedsPush(tt.proxy, pushEv)
 			if got != tt.want {
 				t.Fatalf("Got needs push = %v, expected %v", got, tt.want)
@@ -149,105 +149,105 @@ func TestPushTypeFor(t *testing.T) {
 		name        string
 		proxy       *model.Proxy
 		configTypes []resource.GroupVersionKind
-		expect      map[XdsType]bool
+		expect      map[Type]bool
 	}{
 		{
 			name:        "configTypes is empty",
 			proxy:       sidecar,
 			configTypes: nil,
-			expect:      map[XdsType]bool{CDS: true, EDS: true, LDS: true, RDS: true},
+			expect:      map[Type]bool{CDS: true, EDS: true, LDS: true, RDS: true},
 		},
 		{
 			name:        "configTypes is empty",
 			proxy:       gateway,
 			configTypes: nil,
-			expect:      map[XdsType]bool{CDS: true, EDS: true, LDS: true, RDS: true},
+			expect:      map[Type]bool{CDS: true, EDS: true, LDS: true, RDS: true},
 		},
 		{
 			name:        "sidecar updated for sidecar proxy",
 			proxy:       sidecar,
 			configTypes: []resource.GroupVersionKind{gvk.Sidecar},
-			expect:      map[XdsType]bool{CDS: true, EDS: true, LDS: true, RDS: true},
+			expect:      map[Type]bool{CDS: true, EDS: true, LDS: true, RDS: true},
 		},
 		{
 			name:        "sidecar updated for gateway proxy",
 			proxy:       gateway,
 			configTypes: []resource.GroupVersionKind{gvk.Sidecar},
-			expect:      map[XdsType]bool{},
+			expect:      map[Type]bool{},
 		},
 		{
 			name:        "quotaSpec updated for sidecar proxy",
 			proxy:       sidecar,
 			configTypes: []resource.GroupVersionKind{gvk.QuotaSpec},
-			expect:      map[XdsType]bool{LDS: true, RDS: true},
+			expect:      map[Type]bool{LDS: true, RDS: true},
 		},
 		{
 			name:        "quotaSpec updated for gateway",
 			proxy:       gateway,
 			configTypes: []resource.GroupVersionKind{gvk.QuotaSpec},
-			expect:      map[XdsType]bool{},
+			expect:      map[Type]bool{},
 		},
 		{
 			name:        "authorizationpolicy updated",
 			proxy:       sidecar,
 			configTypes: []resource.GroupVersionKind{gvk.AuthorizationPolicy},
-			expect:      map[XdsType]bool{LDS: true},
+			expect:      map[Type]bool{LDS: true},
 		},
 		{
 			name:        "authorizationpolicy updated",
 			proxy:       gateway,
 			configTypes: []resource.GroupVersionKind{gvk.AuthorizationPolicy},
-			expect:      map[XdsType]bool{LDS: true},
+			expect:      map[Type]bool{LDS: true},
 		},
 		{
 			name:        "unknown type updated",
 			proxy:       sidecar,
 			configTypes: []resource.GroupVersionKind{{Kind: "unknown"}},
-			expect:      map[XdsType]bool{CDS: true, EDS: true, LDS: true, RDS: true},
+			expect:      map[Type]bool{CDS: true, EDS: true, LDS: true, RDS: true},
 		},
 		{
 			name:        "unknown type updated",
 			proxy:       gateway,
 			configTypes: []resource.GroupVersionKind{},
-			expect:      map[XdsType]bool{CDS: true, EDS: true, LDS: true, RDS: true},
+			expect:      map[Type]bool{CDS: true, EDS: true, LDS: true, RDS: true},
 		},
 		{
 			name:  "gateway and virtualservice updated for gateway proxy",
 			proxy: gateway,
 			configTypes: []resource.GroupVersionKind{gvk.Gateway,
 				gvk.VirtualService},
-			expect: map[XdsType]bool{LDS: true, RDS: true},
+			expect: map[Type]bool{LDS: true, RDS: true},
 		},
 		{
 			name:  "virtualservice and destinationrule updated",
 			proxy: sidecar,
 			configTypes: []resource.GroupVersionKind{gvk.DestinationRule,
 				gvk.VirtualService},
-			expect: map[XdsType]bool{CDS: true, EDS: true, LDS: true, RDS: true},
+			expect: map[Type]bool{CDS: true, EDS: true, LDS: true, RDS: true},
 		},
 		{
 			name:        "requestauthentication updated",
 			proxy:       sidecar,
 			configTypes: []resource.GroupVersionKind{gvk.RequestAuthentication},
-			expect:      map[XdsType]bool{LDS: true},
+			expect:      map[Type]bool{LDS: true},
 		},
 		{
 			name:        "requestauthentication updated",
 			proxy:       gateway,
 			configTypes: []resource.GroupVersionKind{gvk.RequestAuthentication},
-			expect:      map[XdsType]bool{LDS: true},
+			expect:      map[Type]bool{LDS: true},
 		},
 		{
 			name:        "peerauthentication updated",
 			proxy:       sidecar,
 			configTypes: []resource.GroupVersionKind{gvk.PeerAuthentication},
-			expect:      map[XdsType]bool{CDS: true, EDS: true, LDS: true},
+			expect:      map[Type]bool{CDS: true, EDS: true, LDS: true},
 		},
 		{
 			name:        "peerauthentication updated",
 			proxy:       gateway,
 			configTypes: []resource.GroupVersionKind{gvk.PeerAuthentication},
-			expect:      map[XdsType]bool{CDS: true, EDS: true, LDS: true},
+			expect:      map[Type]bool{CDS: true, EDS: true, LDS: true},
 		},
 	}
 
@@ -261,7 +261,7 @@ func TestPushTypeFor(t *testing.T) {
 					Namespace: "ns",
 				}] = struct{}{}
 			}
-			pushEv := &XdsEvent{configsUpdated: cfgs}
+			pushEv := &Event{configsUpdated: cfgs}
 			out := PushTypeFor(tt.proxy, pushEv)
 			if !reflect.DeepEqual(out, tt.expect) {
 				t.Errorf("expected: %v, but got %v", tt.expect, out)

--- a/pilot/pkg/xds/cds.go
+++ b/pilot/pkg/xds/cds.go
@@ -47,7 +47,7 @@ func cdsDiscoveryResponse(response []*cluster.Cluster, noncePrefix, typeURL stri
 	return out
 }
 
-func (s *DiscoveryServer) pushCds(con *XdsConnection, push *model.PushContext, version string) error {
+func (s *DiscoveryServer) pushCds(con *Connection, push *model.PushContext, version string) error {
 	// TODO: Modify interface to take services, and config instead of making library query registry
 	pushStart := time.Now()
 	rawClusters := s.ConfigGenerator.BuildClusters(con.node, push)

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -472,7 +472,7 @@ func (s *DiscoveryServer) ConfigDump(w http.ResponseWriter, req *http.Request) {
 
 // configDump converts the connection internal state into an Envoy Admin API config dump proto
 // It is used in debugging to create a consistent object for comparison between Envoy and Pilot outputs
-func (s *DiscoveryServer) configDump(conn *XdsConnection) (*adminapi.ConfigDump, error) {
+func (s *DiscoveryServer) configDump(conn *Connection) (*adminapi.ConfigDump, error) {
 	dynamicActiveClusters := make([]*adminapi.ClustersConfigDump_DynamicCluster, 0)
 	clusters := s.ConfigGenerator.BuildClusters(conn.node, s.globalPushContext())
 
@@ -606,7 +606,7 @@ func (s *DiscoveryServer) edsz(w http.ResponseWriter, req *http.Request) {
 	if req.Form.Get("push") != "" {
 		AdsPushAll(s)
 	}
-	var con *XdsConnection
+	var con *Connection
 	if proxyID := req.URL.Query().Get("proxyID"); proxyID != "" {
 		con = s.getProxyConnection(proxyID)
 		// We can't guarantee the Pilot we are connected to has a connection to the proxy we requested
@@ -665,7 +665,7 @@ func (s *DiscoveryServer) cdsz(w http.ResponseWriter, req *http.Request) {
 	s.adsClientsMutex.RUnlock()
 }
 
-func printListeners(w io.Writer, c *XdsConnection) {
+func printListeners(w io.Writer, c *Connection) {
 	comma := false
 	for _, ls := range c.LDSListeners {
 		if ls == nil {
@@ -685,7 +685,7 @@ func printListeners(w io.Writer, c *XdsConnection) {
 	}
 }
 
-func printClusters(w io.Writer, c *XdsConnection) {
+func printClusters(w io.Writer, c *Connection) {
 	comma := false
 	for _, cl := range c.CDSClusters {
 		if cl == nil {
@@ -705,7 +705,7 @@ func printClusters(w io.Writer, c *XdsConnection) {
 	}
 }
 
-func printRoutes(w io.Writer, c *XdsConnection) {
+func printRoutes(w io.Writer, c *Connection) {
 	comma := false
 	for _, rt := range c.RouteConfigs {
 		if rt == nil {
@@ -725,7 +725,7 @@ func printRoutes(w io.Writer, c *XdsConnection) {
 	}
 }
 
-func (s *DiscoveryServer) getProxyConnection(proxyID string) *XdsConnection {
+func (s *DiscoveryServer) getProxyConnection(proxyID string) *Connection {
 	s.adsClientsMutex.RLock()
 	defer s.adsClientsMutex.RUnlock()
 

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -116,7 +116,7 @@ type DiscoveryServer struct {
 	debugHandlers map[string]string
 
 	// adsClients reflect active gRPC channels, for both ADS and EDS.
-	adsClients      map[string]*XdsConnection
+	adsClients      map[string]*Connection
 	adsClientsMutex sync.RWMutex
 
 	StatusReporter DistributionStatusCache
@@ -159,7 +159,7 @@ func NewDiscoveryServer(env *model.Environment, plugins []string) *DiscoveryServ
 		pushQueue:               NewPushQueue(),
 		DebugConfigs:            features.DebugConfigs,
 		debugHandlers:           map[string]string{},
-		adsClients:              map[string]*XdsConnection{},
+		adsClients:              map[string]*Connection{},
 	}
 
 	if features.XDSAuth {
@@ -418,7 +418,7 @@ func doSendPushes(stopCh <-chan struct{}, semaphore chan struct{}, queue *PushQu
 			proxiesQueueTime.Record(time.Since(info.Start).Seconds())
 
 			go func() {
-				pushEv := &XdsEvent{
+				pushEv := &Event{
 					full:           info.Full,
 					push:           info.Push,
 					done:           doneFunc,

--- a/pilot/pkg/xds/discovery_test.go
+++ b/pilot/pkg/xds/discovery_test.go
@@ -31,12 +31,12 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 )
 
-func createProxies(n int) []*XdsConnection {
-	proxies := make([]*XdsConnection, 0, n)
+func createProxies(n int) []*Connection {
+	proxies := make([]*Connection, 0, n)
 	for p := 0; p < n; p++ {
-		proxies = append(proxies, &XdsConnection{
+		proxies = append(proxies, &Connection{
 			ConID:       fmt.Sprintf("proxy-%v", p),
-			pushChannel: make(chan *XdsEvent),
+			pushChannel: make(chan *Event),
 			stream:      &fakeStream{},
 		})
 	}

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -310,15 +310,15 @@ func (s *DiscoveryServer) loadAssignmentsForClusterIsolated(proxy *model.Proxy, 
 		return buildEmptyClusterLoadAssignment(clusterName)
 	}
 
-	// Service resolution type might have changed and Cluster may be still in the EDS cluster list of "XdsConnection.Clusters".
+	// Service resolution type might have changed and Cluster may be still in the EDS cluster list of "Connection.Clusters".
 	// This can happen if a ServiceEntry's resolution is changed from STATIC to DNS which changes the Envoy cluster type from
 	// EDS to STRICT_DNS. When pushEds is called before Envoy sends the updated cluster list via Endpoint request which in turn
-	// will update "XdsConnection.Clusters", we might accidentally send EDS updates for STRICT_DNS cluster. This check gaurds
+	// will update "Connection.Clusters", we might accidentally send EDS updates for STRICT_DNS cluster. This check gaurds
 	// against such behavior and returns nil. When the updated cluster warms up in Envoy, it would update with new endpoints
 	// automatically.
 	// Gateways use EDS for Passthrough cluster. So we should allow Passthrough here.
 	if svc.Resolution == model.DNSLB {
-		adsLog.Infof("XdsConnection has %s in its eds clusters but its resolution now is updated to %v, skipping it.", clusterName, svc.Resolution)
+		adsLog.Infof("%s has %s in its eds clusters but its resolution now is updated to %v, skipping it.", proxy.ID, clusterName, svc.Resolution)
 		return nil
 	}
 
@@ -418,7 +418,7 @@ func (eds *EdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w
 
 // pushEds is pushing EDS updates for a single connection. Called the first time
 // a client connects, for incremental updates and for full periodic updates.
-func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection, version string, edsUpdatedServices map[string]struct{}) error {
+func (s *DiscoveryServer) pushEds(push *model.PushContext, con *Connection, version string, edsUpdatedServices map[string]struct{}) error {
 	pushStart := time.Now()
 	loadAssignments := make([]*endpoint.ClusterLoadAssignment, 0)
 	endpoints := 0

--- a/pilot/pkg/xds/ep_filters_test.go
+++ b/pilot/pkg/xds/ep_filters_test.go
@@ -73,7 +73,7 @@ func TestEndpointsByNetworkFilter(t *testing.T) {
 	tests := []struct {
 		name      string
 		endpoints []*endpoint.LocalityLbEndpoints
-		conn      *XdsConnection
+		conn      *Connection
 		env       *model.Environment
 		want      []LocLbEpInfo
 	}{
@@ -255,7 +255,7 @@ func TestEndpointsByNetworkFilter_RegistryServiceName(t *testing.T) {
 	tests := []struct {
 		name      string
 		endpoints []*endpoint.LocalityLbEndpoints
-		conn      *XdsConnection
+		conn      *Connection
 		env       *model.Environment
 		want      []LocLbEpInfo
 	}{
@@ -433,7 +433,7 @@ func TestEndpointsByNetworkFilter_SkipLBWithHostname(t *testing.T) {
 	tests := []struct {
 		name      string
 		endpoints []*endpoint.LocalityLbEndpoints
-		conn      *XdsConnection
+		conn      *Connection
 		env       *model.Environment
 		want      []LocLbEpInfo
 	}{
@@ -561,8 +561,8 @@ func TestEndpointsByNetworkFilter_SkipLBWithHostname(t *testing.T) {
 	}
 }
 
-func xdsConnection(network string) *XdsConnection {
-	return &XdsConnection{
+func xdsConnection(network string) *Connection {
+	return &Connection{
 		node: &model.Proxy{
 			Metadata: &model.NodeMetadata{Network: network},
 		},

--- a/pilot/pkg/xds/gen2.go
+++ b/pilot/pkg/xds/gen2.go
@@ -27,7 +27,7 @@ import (
 
 // handleReqAck checks if the message is an ack/nack and handles it, returning true.
 // If false, the request should be processed by calling the generator.
-func (s *DiscoveryServer) handleReqAck(con *XdsConnection, discReq *discovery.DiscoveryRequest) (*model.WatchedResource, bool) {
+func (s *DiscoveryServer) handleReqAck(con *Connection, discReq *discovery.DiscoveryRequest) (*model.WatchedResource, bool) {
 
 	// All NACKs should have ErrorDetail set !
 	// Relying on versionCode != sentVersionCode as nack is less reliable.
@@ -89,7 +89,7 @@ func (s *DiscoveryServer) handleReqAck(con *XdsConnection, discReq *discovery.Di
 }
 
 // handleCustomGenerator uses model.Generator to generate the response.
-func (s *DiscoveryServer) handleCustomGenerator(con *XdsConnection, req *discovery.DiscoveryRequest) error {
+func (s *DiscoveryServer) handleCustomGenerator(con *Connection, req *discovery.DiscoveryRequest) error {
 	w, isAck := s.handleReqAck(con, req)
 	if isAck {
 		return nil
@@ -138,7 +138,7 @@ func (s *DiscoveryServer) handleCustomGenerator(con *XdsConnection, req *discove
 
 // Called for config updates.
 // Will not be called if ProxyNeedsPush returns false - ie. if the update
-func (s *DiscoveryServer) pushGeneratorV2(con *XdsConnection, push *model.PushContext,
+func (s *DiscoveryServer) pushGeneratorV2(con *Connection, push *model.PushContext,
 	currentVersion string, w *model.WatchedResource, updates model.XdsUpdates) error {
 	// TODO: generators may send incremental changes if both sides agree on the protocol.
 	// This is specific to each generator type.

--- a/pilot/pkg/xds/internalgen.go
+++ b/pilot/pkg/xds/internalgen.go
@@ -44,7 +44,7 @@ type InternalGen struct {
 	// On new connect, use version to send recent events since last update.
 }
 
-func (sg *InternalGen) OnConnect(con *XdsConnection) {
+func (sg *InternalGen) OnConnect(con *Connection) {
 	if con.xdsNode.Metadata != nil && con.xdsNode.Metadata.Fields != nil {
 		con.xdsNode.Metadata.Fields["istiod"] = &structpb.Value{
 			Kind: &structpb.Value_StringValue{
@@ -60,7 +60,7 @@ func (sg *InternalGen) OnConnect(con *XdsConnection) {
 	sg.startPush(TypeURLConnections, []proto.Message{con.xdsNode})
 }
 
-func (sg *InternalGen) OnDisconnect(con *XdsConnection) {
+func (sg *InternalGen) OnDisconnect(con *Connection) {
 	sg.startPush(TypeURLDisconnect, []proto.Message{con.xdsNode})
 
 	if con.xdsNode.Metadata != nil && con.xdsNode.Metadata.Fields != nil {
@@ -89,7 +89,7 @@ func (sg *InternalGen) startPush(typeURL string, data []proto.Message) {
 	// the same connection table
 	sg.Server.adsClientsMutex.RLock()
 	// Create a temp map to avoid locking the add/remove
-	pending := []*XdsConnection{}
+	pending := []*Connection{}
 	for _, v := range sg.Server.adsClients {
 		if v.node.Active[typeURL] != nil {
 			pending = append(pending, v)

--- a/pilot/pkg/xds/lds.go
+++ b/pilot/pkg/xds/lds.go
@@ -24,7 +24,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/util"
 )
 
-func (s *DiscoveryServer) pushLds(con *XdsConnection, push *model.PushContext, version string) error {
+func (s *DiscoveryServer) pushLds(con *Connection, push *model.PushContext, version string) error {
 	// TODO: Modify interface to take services, and config instead of making library query registry
 	pushStart := time.Now()
 	rawListeners := s.ConfigGenerator.BuildListeners(con.node, push)

--- a/pilot/pkg/xds/pushqueue_test.go
+++ b/pilot/pkg/xds/pushqueue_test.go
@@ -26,8 +26,8 @@ import (
 )
 
 // Helper function to remove an item or timeout and return nil if there are no pending pushes
-func getWithTimeout(p *PushQueue) *XdsConnection {
-	done := make(chan *XdsConnection)
+func getWithTimeout(p *PushQueue) *Connection {
+	done := make(chan *Connection)
 	go func() {
 		con, _ := p.Dequeue()
 		done <- con
@@ -54,9 +54,9 @@ func ExpectTimeout(t *testing.T, p *PushQueue) {
 	}
 }
 
-func ExpectDequeue(t *testing.T, p *PushQueue, expected *XdsConnection) {
+func ExpectDequeue(t *testing.T, p *PushQueue, expected *Connection) {
 	t.Helper()
-	result := make(chan *XdsConnection)
+	result := make(chan *Connection)
 	go func() {
 		con, _ := p.Dequeue()
 		result <- con
@@ -72,9 +72,9 @@ func ExpectDequeue(t *testing.T, p *PushQueue, expected *XdsConnection) {
 }
 
 func TestProxyQueue(t *testing.T) {
-	proxies := make([]*XdsConnection, 0, 100)
+	proxies := make([]*Connection, 0, 100)
 	for p := 0; p < 100; p++ {
-		proxies = append(proxies, &XdsConnection{ConID: fmt.Sprintf("proxy-%d", p)})
+		proxies = append(proxies, &Connection{ConID: fmt.Sprintf("proxy-%d", p)})
 	}
 
 	t.Run("simple add and remove", func(t *testing.T) {
@@ -186,7 +186,7 @@ func TestProxyQueue(t *testing.T) {
 		p := NewPushQueue()
 		wg := &sync.WaitGroup{}
 		wg.Add(2)
-		respChannel := make(chan *XdsConnection, 2)
+		respChannel := make(chan *Connection, 2)
 		go func() {
 			respChannel <- getWithTimeout(p)
 			wg.Done()
@@ -213,7 +213,7 @@ func TestProxyQueue(t *testing.T) {
 
 	t.Run("concurrent", func(t *testing.T) {
 		p := NewPushQueue()
-		key := func(p *XdsConnection, eds string) string { return fmt.Sprintf("%s~%s", p.ConID, eds) }
+		key := func(p *Connection, eds string) string { return fmt.Sprintf("%s~%s", p.ConID, eds) }
 
 		// We will trigger many pushes for eds services to each proxy. In the end we will expect
 		// all of these to be dequeue, but order is not deterministic.

--- a/pilot/pkg/xds/rds.go
+++ b/pilot/pkg/xds/rds.go
@@ -27,7 +27,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/util"
 )
 
-func (s *DiscoveryServer) pushRoute(con *XdsConnection, push *model.PushContext, version string) error {
+func (s *DiscoveryServer) pushRoute(con *Connection, push *model.PushContext, version string) error {
 	pushStart := time.Now()
 	rawRoutes := s.ConfigGenerator.BuildHTTPRoutes(con.node, push, con.Routes)
 	if s.DebugConfigs {


### PR DESCRIPTION
Fixes lint issues introduced in #24837 
- Rename `XdsConnection` -> `Connection`
- Rename `XdsEvent` -> `Event`
- Rename `XdsType` -> `Type`

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
