### PR TITLE
Remove CEXLCompatibility Mutex

### DIFF
--- a/mixer/pkg/lang/cel/builder_test.go
+++ b/mixer/pkg/lang/cel/builder_test.go
@@ -35,15 +35,13 @@ import (
 	"istio.io/pkg/attribute"
 )
 
-func compatTest(test ilt.TestInfo, mutex sync.Locker) func(t *testing.T) {
+func compatTest(test ilt.TestInfo) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
 
 		finder := attribute.NewFinder(test.Conf())
 		builder := NewBuilder(finder, LegacySyntaxCEL)
-		mutex.Lock()
 		ex, typ, err := builder.Compile(test.E)
-		mutex.Unlock()
 
 		if err != nil {
 			if test.CompileErr != "" {
@@ -100,15 +98,12 @@ func compatTest(test ilt.TestInfo, mutex sync.Locker) func(t *testing.T) {
 }
 
 func TestCEXLCompatibility(t *testing.T) {
-	//TODO remove the mutex once CEL data race is fixed
-	//ref: https://github.com/google/cel-go/issues/175
-	mutex := &sync.Mutex{}
 	for _, test := range ilt.TestData {
 		if test.E == "" {
 			continue
 		}
 
-		t.Run(test.TestName(), compatTest(test, mutex))
+		t.Run(test.TestName(), compatTest(test))
 	}
 }
 


### PR DESCRIPTION
https://github.com/google/cel-go/issues/175 - required us to use a mutex in the test until it was fixed, and now it is fixed.

Found this while looking at #25063 - looking into it.

[X ] Configuration Infrastructure
[X ] Installation
