### PR TITLE
Initial XDS-based (experimental) version subcommand

### DIFF
--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -69,6 +69,7 @@ func defaultLogOptions() *log.Options {
 	o.SetOutputLevel("installer", log.WarnLevel)
 	o.SetOutputLevel("translator", log.WarnLevel)
 	o.SetOutputLevel("kube", log.ErrorLevel)
+	o.SetOutputLevel("adsc", log.WarnLevel)
 	o.SetOutputLevel("default", log.WarnLevel)
 
 	return o
@@ -149,6 +150,8 @@ debug and diagnose their Istio mesh.
 	experimentalCmd.AddCommand(softGraduatedCmd(Analyze()))
 	experimentalCmd.AddCommand(vmBootstrapCommand())
 	experimentalCmd.AddCommand(waitCmd())
+
+	experimentalCmd.AddCommand(xdsVersionCommand())
 
 	postInstallCmd.AddCommand(Webhook())
 	experimentalCmd.AddCommand(postInstallCmd)

--- a/istioctl/cmd/version.go
+++ b/istioctl/cmd/version.go
@@ -20,9 +20,8 @@ import (
 	"fmt"
 	"os"
 
-	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	envoy_corev2 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	xdsapi "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/golang/protobuf/ptypes"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/spf13/cobra"
@@ -149,6 +148,25 @@ func xdsVersionCommand() *cobra.Command {
 		}
 		return nil
 	}
+	versionCmd.Example = `# Retrieve version information directly from XDS, without security
+istioctl x version --xds-address localhost:15012
+
+# Retrieve version information directly from XDS, with security
+# (the certificates must be retrieved before this step)
+istioctl x version --xds-address localhost:15010 --cert-dir ~/.istio-certs
+
+# Retrieve version information via XDS from all Istio pods in a Kubernetes cluster
+# (without security)
+istioctl x version --xds-port 15010
+
+# Retrieve version information via XDS from all Istio pods in a Kubernetes cluster
+# (the certificates must be retrieved before this step)
+istioctl x version --cert-dir ~/.istio-certs
+
+# Retrieve version information via XDS from default control plane Istio pods
+# in a Kubernetes cluster, without security
+istioctl x version --xds-label istio.io/rev=default --xds-port 15010
+`
 
 	versionCmd.Flags().VisitAll(func(flag *pflag.Flag) {
 		if flag.Name == "short" {
@@ -173,7 +191,7 @@ func xdsVersionCommand() *cobra.Command {
 func xdsRemoteVersionWrapper(opts *clioptions.ControlPlaneOptions, centralOpts *clioptions.CentralControlPlaneOptions, outXDS **xdsapi.DiscoveryResponse) func() (*istioVersion.MeshInfo, error) {
 	return func() (*istioVersion.MeshInfo, error) {
 		xdsRequest := xdsapi.DiscoveryRequest{
-			Node: &envoy_corev2.Node{
+			Node: &envoy_corev3.Node{
 				Id: "sidecar~0.0.0.0~debug~cluster.local",
 			},
 			TypeUrl: "istio.io/connections",

--- a/istioctl/pkg/clioptions/central.go
+++ b/istioctl/pkg/clioptions/central.go
@@ -27,8 +27,11 @@ type CentralControlPlaneOptions struct {
 	// Xds is XDS endpoint, e.g. localhost:15010.
 	Xds string
 
-	// XdsLabel is a Kubernetes label on the Istiod service
-	XdsLabel string
+	// XdsPodLabel is a Kubernetes label on the Istiod pods
+	XdsPodLabel string
+
+	// XdsPodPort is a port exposing XDS (typically 15010 or 15012)
+	XdsPodPort int
 
 	// CertDir is the local directory containing certificates
 	CertDir string
@@ -43,16 +46,18 @@ func (o *CentralControlPlaneOptions) AttachControlPlaneFlags(cmd *cobra.Command)
 	cmd.PersistentFlags().StringVar(&o.Xds, "xds-address", "",
 		"XDS Endpoint")
 	cmd.PersistentFlags().StringVar(&o.CertDir, "cert-dir", "",
-		"XDS Endpoint certificates (UNIMPLEMENTED)")
-	cmd.PersistentFlags().StringVar(&o.XdsLabel, "xds-label", "",
-		"Istio XDS service label")
+		"XDS Endpoint certificate directory")
+	cmd.PersistentFlags().StringVar(&o.XdsPodLabel, "xds-label", "",
+		"Istiod pod label selector")
+	cmd.PersistentFlags().IntVar(&o.XdsPodPort, "xds-port", 15012,
+		"Istiod pod port")
 	cmd.PersistentFlags().DurationVar(&o.Timeout, "timeout", time.Second*30,
 		"the duration to wait before failing")
 }
 
 // ValidateControlPlaneFlags checks arguments for valid values and combinations
 func (o *CentralControlPlaneOptions) ValidateControlPlaneFlags() error {
-	if o.Xds != "" && o.XdsLabel != "" {
+	if o.Xds != "" && o.XdsPodLabel != "" {
 		return fmt.Errorf("either --xds-address or --xds-label, not both")
 	}
 	return nil

--- a/istioctl/pkg/clioptions/central.go
+++ b/istioctl/pkg/clioptions/central.go
@@ -1,0 +1,62 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clioptions
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// CentralControlPlaneOptions holds options common to all subcommands
+// that invoke Istiod via xDS REST endpoint
+type CentralControlPlaneOptions struct {
+	// Xds is XDS endpoint, e.g. localhost:15010.
+	Xds string
+
+	// XdsLabel is a Kubernetes label on the Istiod service
+	XdsLabel string
+
+	// CertDir is the local directory containing certificates
+	CertDir string
+
+	// Timeout is how long to wait before giving up on XDS
+	Timeout time.Duration
+}
+
+// AttachControlPlaneFlags attaches control-plane flags to a Cobra command.
+// (Currently just --endpoint)
+func (o *CentralControlPlaneOptions) AttachControlPlaneFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringVar(&o.Xds, "xds-address", "",
+		"XDS Endpoint")
+	cmd.PersistentFlags().StringVar(&o.CertDir, "cert-dir", "",
+		"XDS Endpoint certificates (UNIMPLEMENTED)")
+	cmd.PersistentFlags().StringVar(&o.XdsLabel, "xds-label", "istio=pilot",
+		"Istio XDS service label")
+	cmd.PersistentFlags().DurationVar(&o.Timeout, "timeout", time.Second*30,
+		"the duration to wait before failing")
+}
+
+// ValidateControlPlaneFlags checks arguments for valid values and combinations
+func (o *CentralControlPlaneOptions) ValidateControlPlaneFlags() error {
+	if o.Xds != "" && o.XdsLabel != "" {
+		return fmt.Errorf("either --xds-address or --xds-label, not both")
+	}
+	if o.XdsLabel != "" {
+		return fmt.Errorf("--xds-label not implemented")
+	}
+	return nil
+}

--- a/istioctl/pkg/clioptions/central.go
+++ b/istioctl/pkg/clioptions/central.go
@@ -44,7 +44,7 @@ func (o *CentralControlPlaneOptions) AttachControlPlaneFlags(cmd *cobra.Command)
 		"XDS Endpoint")
 	cmd.PersistentFlags().StringVar(&o.CertDir, "cert-dir", "",
 		"XDS Endpoint certificates (UNIMPLEMENTED)")
-	cmd.PersistentFlags().StringVar(&o.XdsLabel, "xds-label", "istio=pilot",
+	cmd.PersistentFlags().StringVar(&o.XdsLabel, "xds-label", "",
 		"Istio XDS service label")
 	cmd.PersistentFlags().DurationVar(&o.Timeout, "timeout", time.Second*30,
 		"the duration to wait before failing")
@@ -54,9 +54,6 @@ func (o *CentralControlPlaneOptions) AttachControlPlaneFlags(cmd *cobra.Command)
 func (o *CentralControlPlaneOptions) ValidateControlPlaneFlags() error {
 	if o.Xds != "" && o.XdsLabel != "" {
 		return fmt.Errorf("either --xds-address or --xds-label, not both")
-	}
-	if o.XdsLabel != "" {
-		return fmt.Errorf("--xds-label not implemented")
 	}
 	return nil
 }

--- a/istioctl/pkg/multixds/gather.go
+++ b/istioctl/pkg/multixds/gather.go
@@ -1,0 +1,93 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, ~ 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multixds
+
+// multixds knows how to target either central Istiod or all the Istiod pods on a cluster.
+
+import (
+	"context"
+	"fmt"
+
+	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+
+	"istio.io/istio/istioctl/pkg/clioptions"
+	"istio.io/istio/istioctl/pkg/xds"
+	"istio.io/istio/pkg/kube"
+)
+
+// RequestAndProcessXds merges XDS responses from 1 central or 1..N local XDS servers
+// nolint: lll
+func RequestAndProcessXds(dr *xdsapi.DiscoveryRequest, centralOpts *clioptions.CentralControlPlaneOptions, istioNamespace string, kubeClient kube.Client) (*xdsapi.DiscoveryResponse, error) {
+
+	// If Central Istiod case, just call it
+	if centralOpts.Xds != "" {
+		return xds.GetXdsResponse(dr, centralOpts)
+	}
+
+	// Self-administered case.  Find all Istiods in revision using K8s, port-forward and call each in turn
+	responses, err := queryEachShard(dr, istioNamespace, kubeClient, centralOpts)
+	if err != nil {
+		return nil, err
+	}
+	return mergeShards(responses)
+}
+
+// nolint: lll
+func queryEachShard(dr *xdsapi.DiscoveryRequest, istioNamespace string, kubeClient kube.Client, centralOpts *clioptions.CentralControlPlaneOptions) ([]*xdsapi.DiscoveryResponse, error) {
+	pods, err := kubeClient.GetIstioPods(context.TODO(), istioNamespace, map[string]string{
+		"labelSelector": centralOpts.XdsLabel,
+		"fieldSelector": "status.phase=Running",
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(pods) == 0 {
+		return nil, fmt.Errorf("no running Istio pods in %q", istioNamespace)
+	}
+
+	responses := []*xdsapi.DiscoveryResponse{}
+	for _, pod := range pods {
+		// TODO Use 15012
+		fw, err := kubeClient.NewPortForwarder(pod.Name, pod.Namespace, "localhost", 0, 15010)
+		if err != nil {
+			return nil, err
+		}
+		err = fw.Start()
+		if err != nil {
+			return nil, err
+		}
+		defer fw.Close()
+		response, err := xds.GetXdsResponse(dr, &clioptions.CentralControlPlaneOptions{
+			Xds:     fw.Address(),
+			CertDir: centralOpts.CertDir,
+			Timeout: centralOpts.Timeout,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("could not get XDS from discovery pod %q: %v", pod.Name, err)
+		}
+		responses = append(responses, response)
+	}
+	return responses, nil
+}
+
+func mergeShards(responses []*xdsapi.DiscoveryResponse) (*xdsapi.DiscoveryResponse, error) {
+	retval := xdsapi.DiscoveryResponse{}
+
+	for _, response := range responses {
+		retval.Resources = append(retval.Resources, response.Resources...)
+	}
+
+	return &retval, nil
+}

--- a/istioctl/pkg/multixds/gather.go
+++ b/istioctl/pkg/multixds/gather.go
@@ -1,6 +1,6 @@
-// Copyright Istio Authors
+// Copyright Istio Authors.
 //
-// Licensed under the Apache License, ~ 2.0 (the "License");
+// Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //

--- a/istioctl/pkg/xds/client.go
+++ b/istioctl/pkg/xds/client.go
@@ -19,7 +19,7 @@ package xds
 import (
 	"fmt"
 
-	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	xdsapi "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
 	"istio.io/istio/istioctl/pkg/clioptions"
 	"istio.io/istio/pilot/pkg/model"

--- a/istioctl/pkg/xds/client.go
+++ b/istioctl/pkg/xds/client.go
@@ -1,0 +1,51 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xds
+
+// xds uses ADSC to call XDS
+
+import (
+	"fmt"
+
+	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+
+	"istio.io/istio/istioctl/pkg/clioptions"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/adsc"
+)
+
+// GetXdsResponse opens a gRPC connection to opts.xds and waits for a single response
+func GetXdsResponse(dr *xdsapi.DiscoveryRequest, opts *clioptions.CentralControlPlaneOptions) (*xdsapi.DiscoveryResponse, error) {
+	adscConn, err := adsc.Dial(opts.Xds, opts.CertDir, &adsc.Config{
+		Meta: model.NodeMetadata{
+			Generator: "event",
+		}.ToStruct(),
+
+		// TODO I tried and failed to add DialOptions here and have ADSC
+		// pass them down so that I could add gRPC Interceptors for logging
+		// and debugging.
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not dial: %w", err)
+	}
+
+	err = adscConn.Send(dr)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := adscConn.WaitVersion(opts.Timeout, dr.TypeUrl, "")
+	return response, err
+}


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/24331

This command creates an experimental `istioctl x version` subcommand.  The output is identical to `istioctl version`.  The command uses XDS instead of /debug and /version.

The command will show incorrect values for the control plane unless https://github.com/istio/istio/pull/25042 is also merged.  Ideally that PR will merge first.