### PR TITLE
Bug Fix missing HTTP2 ALPN for UpstreamTLSContext

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -1055,6 +1055,11 @@ func applyUpstreamTLSSettings(opts *buildClusterOpts, tls *networking.ClientTLSS
 				ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(res.GetRootResourceName(), opts.push.Mesh.SdsUdsPath),
 			},
 		}
+
+		if c.Http2ProtocolOptions != nil {
+			// This is HTTP/2 cluster, advertise it with ALPN.
+			tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNH2Only
+		}
 	case networking.ClientTLSSettings_MUTUAL:
 		if tls.ClientCertificate == "" || tls.PrivateKey == "" {
 			log.Errorf("failed to apply tls setting for %s: client certificate and private key must not be empty",

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -2191,10 +2191,10 @@ func TestApplyUpstreamTLSSettings(t *testing.T) {
 		Sni:               "custom.foo.com",
 	}
 	simpleTLSSettingsWithCerts := &networking.ClientTLSSettings{
-		Mode:              networking.ClientTLSSettings_SIMPLE,
-		CaCertificates:    constants.DefaultRootCert,
-		SubjectAltNames:   []string{"custom.foo.com"},
-		Sni:               "custom.foo.com",
+		Mode:            networking.ClientTLSSettings_SIMPLE,
+		CaCertificates:  constants.DefaultRootCert,
+		SubjectAltNames: []string{"custom.foo.com"},
+		Sni:             "custom.foo.com",
 	}
 
 	http2ProtocolOptions := &core.Http2ProtocolOptions{
@@ -2265,7 +2265,7 @@ func TestApplyUpstreamTLSSettings(t *testing.T) {
 					t.Fatalf("expected alpn list nil as not h2 or Istio_Mutual TLS Setting; got %v", got)
 				}
 				if got := ctx.GetSni(); got != simpleTLSSettingsWithCerts.Sni {
-					t.Fatalf("expected TLSContext SNI %v; got %v",simpleTLSSettingsWithCerts.Sni, got)
+					t.Fatalf("expected TLSContext SNI %v; got %v", simpleTLSSettingsWithCerts.Sni, got)
 				}
 			},
 		},
@@ -2286,7 +2286,7 @@ func TestApplyUpstreamTLSSettings(t *testing.T) {
 					t.Fatalf("expected alpn list %v; got %v", util.ALPNH2Only, got)
 				}
 				if got := ctx.GetSni(); got != simpleTLSSettingsWithCerts.Sni {
-					t.Fatalf("expected TLSContext SNI %v; got %v",simpleTLSSettingsWithCerts.Sni, got)
+					t.Fatalf("expected TLSContext SNI %v; got %v", simpleTLSSettingsWithCerts.Sni, got)
 				}
 			},
 		},
@@ -2310,7 +2310,7 @@ func TestApplyUpstreamTLSSettings(t *testing.T) {
 					t.Fatalf("expected alpn list nil as not h2 or Istio_Mutual TLS Setting; got %v", got)
 				}
 				if got := ctx.GetSni(); got != mutualTLSSettingsWithCerts.Sni {
-					t.Fatalf("expected TLSContext SNI %v; got %v",mutualTLSSettingsWithCerts.Sni, got)
+					t.Fatalf("expected TLSContext SNI %v; got %v", mutualTLSSettingsWithCerts.Sni, got)
 				}
 			},
 		},
@@ -2335,7 +2335,7 @@ func TestApplyUpstreamTLSSettings(t *testing.T) {
 					t.Fatalf("expected alpn list %v; got %v", util.ALPNH2Only, got)
 				}
 				if got := ctx.GetSni(); got != mutualTLSSettingsWithCerts.Sni {
-					t.Fatalf("expected TLSContext SNI %v; got %v",mutualTLSSettingsWithCerts.Sni, got)
+					t.Fatalf("expected TLSContext SNI %v; got %v", mutualTLSSettingsWithCerts.Sni, got)
 				}
 			},
 		},

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -2182,11 +2182,17 @@ func TestApplyUpstreamTLSSettings(t *testing.T) {
 		SubjectAltNames:   []string{"custom.foo.com"},
 		Sni:               "custom.foo.com",
 	}
-	mutualTLSSettings := &networking.ClientTLSSettings{
+	mutualTLSSettingsWithCerts := &networking.ClientTLSSettings{
 		Mode:              networking.ClientTLSSettings_MUTUAL,
 		CaCertificates:    constants.DefaultRootCert,
 		ClientCertificate: constants.DefaultCertChain,
 		PrivateKey:        constants.DefaultKey,
+		SubjectAltNames:   []string{"custom.foo.com"},
+		Sni:               "custom.foo.com",
+	}
+	simpleTLSSettingsWithCerts := &networking.ClientTLSSettings{
+		Mode:              networking.ClientTLSSettings_SIMPLE,
+		CaCertificates:    constants.DefaultRootCert,
 		SubjectAltNames:   []string{"custom.foo.com"},
 		Sni:               "custom.foo.com",
 	}
@@ -2244,15 +2250,56 @@ func TestApplyUpstreamTLSSettings(t *testing.T) {
 			},
 		},
 		{
-			name:                       "user specified mutual tls",
+			name:                       "user specified simple tls",
 			mtlsCtx:                    userSupplied,
 			discoveryType:              cluster.Cluster_EDS,
-			tls:                        mutualTLSSettings,
+			tls:                        simpleTLSSettingsWithCerts,
 			expectTransportSocket:      true,
 			expectTransportSocketMatch: false,
 			validateTLSContext: func(t *testing.T, ctx *tls.UpstreamTlsContext) {
-				rootName := "file-root:" + mutualTLSSettings.CaCertificates
-				certName := fmt.Sprintf("file-cert:%s~%s", mutualTLSSettings.ClientCertificate, mutualTLSSettings.PrivateKey)
+				rootName := "file-root:" + mutualTLSSettingsWithCerts.CaCertificates
+				if got := ctx.CommonTlsContext.GetCombinedValidationContext().GetValidationContextSdsSecretConfig().GetName(); rootName != got {
+					t.Fatalf("expected root name %v got %v", rootName, got)
+				}
+				if got := ctx.CommonTlsContext.GetAlpnProtocols(); got != nil {
+					t.Fatalf("expected alpn list nil as not h2 or Istio_Mutual TLS Setting; got %v", got)
+				}
+				if got := ctx.GetSni(); got != simpleTLSSettingsWithCerts.Sni {
+					t.Fatalf("expected TLSContext SNI %v; got %v",simpleTLSSettingsWithCerts.Sni, got)
+				}
+			},
+		},
+		{
+			name:                       "user specified simple tls with h2",
+			mtlsCtx:                    userSupplied,
+			discoveryType:              cluster.Cluster_EDS,
+			tls:                        simpleTLSSettingsWithCerts,
+			expectTransportSocket:      true,
+			expectTransportSocketMatch: false,
+			http2ProtocolOptions:       http2ProtocolOptions,
+			validateTLSContext: func(t *testing.T, ctx *tls.UpstreamTlsContext) {
+				rootName := "file-root:" + mutualTLSSettingsWithCerts.CaCertificates
+				if got := ctx.CommonTlsContext.GetCombinedValidationContext().GetValidationContextSdsSecretConfig().GetName(); rootName != got {
+					t.Fatalf("expected root name %v got %v", rootName, got)
+				}
+				if got := ctx.CommonTlsContext.GetAlpnProtocols(); !reflect.DeepEqual(got, util.ALPNH2Only) {
+					t.Fatalf("expected alpn list %v; got %v", util.ALPNH2Only, got)
+				}
+				if got := ctx.GetSni(); got != simpleTLSSettingsWithCerts.Sni {
+					t.Fatalf("expected TLSContext SNI %v; got %v",simpleTLSSettingsWithCerts.Sni, got)
+				}
+			},
+		},
+		{
+			name:                       "user specified mutual tls",
+			mtlsCtx:                    userSupplied,
+			discoveryType:              cluster.Cluster_EDS,
+			tls:                        mutualTLSSettingsWithCerts,
+			expectTransportSocket:      true,
+			expectTransportSocketMatch: false,
+			validateTLSContext: func(t *testing.T, ctx *tls.UpstreamTlsContext) {
+				rootName := "file-root:" + mutualTLSSettingsWithCerts.CaCertificates
+				certName := fmt.Sprintf("file-cert:%s~%s", mutualTLSSettingsWithCerts.ClientCertificate, mutualTLSSettingsWithCerts.PrivateKey)
 				if got := ctx.CommonTlsContext.GetCombinedValidationContext().GetValidationContextSdsSecretConfig().GetName(); rootName != got {
 					t.Fatalf("expected root name %v got %v", rootName, got)
 				}
@@ -2262,19 +2309,22 @@ func TestApplyUpstreamTLSSettings(t *testing.T) {
 				if got := ctx.CommonTlsContext.GetAlpnProtocols(); got != nil {
 					t.Fatalf("expected alpn list nil as not h2 or Istio_Mutual TLS Setting; got %v", got)
 				}
+				if got := ctx.GetSni(); got != mutualTLSSettingsWithCerts.Sni {
+					t.Fatalf("expected TLSContext SNI %v; got %v",mutualTLSSettingsWithCerts.Sni, got)
+				}
 			},
 		},
 		{
 			name:                       "user specified mutual tls with h2",
 			mtlsCtx:                    userSupplied,
 			discoveryType:              cluster.Cluster_EDS,
-			tls:                        mutualTLSSettings,
+			tls:                        mutualTLSSettingsWithCerts,
 			expectTransportSocket:      true,
 			expectTransportSocketMatch: false,
 			http2ProtocolOptions:       http2ProtocolOptions,
 			validateTLSContext: func(t *testing.T, ctx *tls.UpstreamTlsContext) {
-				rootName := "file-root:" + mutualTLSSettings.CaCertificates
-				certName := fmt.Sprintf("file-cert:%s~%s", mutualTLSSettings.ClientCertificate, mutualTLSSettings.PrivateKey)
+				rootName := "file-root:" + mutualTLSSettingsWithCerts.CaCertificates
+				certName := fmt.Sprintf("file-cert:%s~%s", mutualTLSSettingsWithCerts.ClientCertificate, mutualTLSSettingsWithCerts.PrivateKey)
 				if got := ctx.CommonTlsContext.GetCombinedValidationContext().GetValidationContextSdsSecretConfig().GetName(); rootName != got {
 					t.Fatalf("expected root name %v got %v", rootName, got)
 				}
@@ -2283,6 +2333,9 @@ func TestApplyUpstreamTLSSettings(t *testing.T) {
 				}
 				if got := ctx.CommonTlsContext.GetAlpnProtocols(); !reflect.DeepEqual(got, util.ALPNH2Only) {
 					t.Fatalf("expected alpn list %v; got %v", util.ALPNH2Only, got)
+				}
+				if got := ctx.GetSni(); got != mutualTLSSettingsWithCerts.Sni {
+					t.Fatalf("expected TLSContext SNI %v; got %v",mutualTLSSettingsWithCerts.Sni, got)
 				}
 			},
 		},


### PR DESCRIPTION
For HTTP2 cluster, ALPNH2Only was not being set in SIMPLE mode. Added more unit tests to cover this as well as SNI 
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
