### PR TITLE
Security changes for testing

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -212,8 +212,13 @@ var (
 			} else {
 				log.Info("Using existing certs")
 			}
-			sa := istio_agent.NewSDSAgent(proxyConfig.DiscoveryAddress, proxyConfig.ControlPlaneAuthPolicy == meshconfig.AuthenticationPolicy_MUTUAL_TLS,
-				pilotCertProvider, jwtPath, outputKeyCertToDir, clusterIDVar.Get())
+
+			sa := istio_agent.NewAgent(&proxyConfig, &istio_agent.AgentConfig{
+				PilotCertProvider:  pilotCertProvider,
+				JWTPath:            jwtPath,
+				OutputKeyCertToDir: outputKeyCertToDir,
+				ClusterID:          clusterIDVar.Get(),
+			})
 
 			// Connection to Istiod secure port
 			if sa.RequireCerts {

--- a/pilot/pkg/bootstrap/certcontroller.go
+++ b/pilot/pkg/bootstrap/certcontroller.go
@@ -145,7 +145,7 @@ func (s *Server) initDNSCerts(hostname, customHost, namespace string) error {
 		s.caBundlePath = defaultCACertPath
 	} else if features.PilotCertProvider.Get() == IstiodCAProvider {
 		log.Infof("Generating istiod-signed cert for %v", names)
-		certChain, keyPEM, err = s.ca.GenKeyCert(names, SelfSignedCACertTTL.Get())
+		certChain, keyPEM, err = s.CA.GenKeyCert(names, SelfSignedCACertTTL.Get())
 
 		signingKeyFile := path.Join(LocalCertDir.Get(), "ca-key.pem")
 		// check if signing key file exists the cert dir
@@ -160,7 +160,7 @@ func (s *Server) initDNSCerts(hostname, customHost, namespace string) error {
 			// We have direct access to the self-signed
 			internalSelfSignedRootPath := path.Join(dnsCertDir, "self-signed-root.pem")
 
-			rootCert := s.ca.GetCAKeyCertBundle().GetRootCertPem()
+			rootCert := s.CA.GetCAKeyCertBundle().GetRootCertPem()
 			if err = ioutil.WriteFile(internalSelfSignedRootPath, rootCert, 0600); err != nil {
 				return err
 			}
@@ -172,7 +172,7 @@ func (s *Server) initDNSCerts(hostname, customHost, namespace string) error {
 						case <-stop:
 							return
 						case <-time.After(controller.NamespaceResyncPeriod):
-							newRootCert := s.ca.GetCAKeyCertBundle().GetRootCertPem()
+							newRootCert := s.CA.GetCAKeyCertBundle().GetRootCertPem()
 							if !bytes.Equal(rootCert, newRootCert) {
 								rootCert = newRootCert
 								if err = ioutil.WriteFile(internalSelfSignedRootPath, rootCert, 0600); err != nil {

--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -28,8 +28,6 @@ import (
 
 	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 
-	"istio.io/istio/pkg/jwt"
-
 	"istio.io/istio/pilot/pkg/features"
 
 	"google.golang.org/grpc"
@@ -131,27 +129,16 @@ func (s *Server) EnableCA() bool {
 	if !features.EnableCAServer {
 		return false
 	}
+	// Log if we're using self-signed certs without K8S, in debug mode
 	if s.kubeClient == nil {
-		// No k8s - no self-signed certs.
-		// TODO: implement it using a local directory, for non-k8s env.
+		// Without K8S the user needs to have the private key in a local file.
+		// If that is missing - we'll generate an in-memory root for testing, and warn.
 		signingKeyFile := path.Join(LocalCertDir.Get(), "ca-key.pem")
 		if _, err := os.Stat(signingKeyFile); err != nil {
-			log.Warnf("kubeclient is nil and %v not found; disable the K8S CA functionality", signingKeyFile)
-			return false
-		}
-		log.Info("Using local CA, no K8S Secrets")
-		return true
-	}
-	if _, err := ioutil.ReadFile(s.jwtPath); err != nil {
-		// for debug we may want to override this by setting trustedIssuer explicitly.
-		// If TOKEN_ISSUER is set, we ignore the lack of mounted JWT token, it means user is using
-		// an external OIDC provider to validate the tokens, and istiod lack of a JWT doesn't indicate a problem.
-		if features.JwtPolicy.Get() == jwt.PolicyThirdParty && trustedIssuer.Get() == "" {
-			log.Warnf("istiod running without access to K8S tokens (jwt path %v). CA will run to support VMs ",
-				s.jwtPath)
-			return true
+			log.Warnf("Will use in-memory root CA, no K8S access and no ca key file ", signingKeyFile)
 		}
 	}
+
 	return true
 }
 
@@ -271,7 +258,7 @@ func (s *Server) initPublicKey() error {
 			// We have direct access to the self-signed
 			internalSelfSignedRootPath := path.Join(dnsCertDir, "self-signed-root.pem")
 
-			rootCert := s.ca.GetCAKeyCertBundle().GetRootCertPem()
+			rootCert := s.CA.GetCAKeyCertBundle().GetRootCertPem()
 			if err = ioutil.WriteFile(internalSelfSignedRootPath, rootCert, 0600); err != nil {
 				return err
 			}
@@ -284,7 +271,7 @@ func (s *Server) initPublicKey() error {
 						case <-stop:
 							return
 						case <-time.After(controller.NamespaceResyncPeriod):
-							newRootCert := s.ca.GetCAKeyCertBundle().GetRootCertPem()
+							newRootCert := s.CA.GetCAKeyCertBundle().GetRootCertPem()
 							if !bytes.Equal(rootCert, newRootCert) {
 								rootCert = newRootCert
 								if err = ioutil.WriteFile(internalSelfSignedRootPath, rootCert, 0600); err != nil {
@@ -308,6 +295,10 @@ func (s *Server) initPublicKey() error {
 	return nil
 }
 
+// createIstioCA initializes the Istio CA signing functionality.
+// - for 'plugged in', uses ./etc/cacert directory, mounted from 'cacerts' secret in k8s.
+//   Inside, the key/cert are 'ca-key.pem' and 'ca-cert.pem'. The root cert signing the intermeidate is root-cert.pem,
+//   which may contain multiple roots. A 'cert-chain.pem' file has the full cert chain.
 func (s *Server) createIstioCA(client corev1.CoreV1Interface, opts *CAOptions) (*ca.IstioCA, error) {
 	var caOpts *ca.IstioCAOptions
 	var err error
@@ -317,6 +308,8 @@ func (s *Server) createIstioCA(client corev1.CoreV1Interface, opts *CAOptions) (
 		maxCertTTL = SelfSignedCACertTTL.Get()
 	}
 
+	// In pods, this is the optional 'cacerts' Secret.
+	// TODO: also check for key.pem ( for interop )
 	signingKeyFile := path.Join(LocalCertDir.Get(), "ca-key.pem")
 
 	// If not found, will default to ca-cert.pem. May contain multiple roots.
@@ -327,16 +320,8 @@ func (s *Server) createIstioCA(client corev1.CoreV1Interface, opts *CAOptions) (
 		rootCertFile = ""
 	}
 
-	if _, err := os.Stat(signingKeyFile); err != nil {
+	if _, err := os.Stat(signingKeyFile); err != nil && client != nil {
 		// The user-provided certs are missing - create a self-signed cert.
-		// If we are not in K8S - no CA
-		// TODO: generate self-signed files in the /etc/cacert for non-k8s
-		if client == nil {
-			// This is mainly used in testing.
-			log.Warna("Missing root CA key in non-k8s environment. Certificate signing and TLS will be off")
-			return nil, nil
-		}
-
 		log.Info("Use self-signed certificate as the CA certificate")
 		spiffe.SetTrustDomain(opts.TrustDomain)
 		// Abort after 20 minutes.
@@ -359,7 +344,11 @@ func (s *Server) createIstioCA(client corev1.CoreV1Interface, opts *CAOptions) (
 			return nil, fmt.Errorf("failed to create a self-signed istiod CA: %v", err)
 		}
 	} else {
-		log.Info("Use local CA certificate")
+		if err == nil {
+			log.Info("Use local CA certificate")
+		} else {
+			log.Info("Use local self-signed CA certificate")
+		}
 
 		// The cert corresponding to the key, self-signed or chain.
 		// rootCertFile will be added at the end, if present, to form 'rootCerts'.

--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -135,7 +135,7 @@ func (s *Server) EnableCA() bool {
 		// If that is missing - we'll generate an in-memory root for testing, and warn.
 		signingKeyFile := path.Join(LocalCertDir.Get(), "ca-key.pem")
 		if _, err := os.Stat(signingKeyFile); err != nil {
-			log.Warnf("Will use in-memory root CA, no K8S access and no ca key file ", signingKeyFile)
+			log.Warnf("Will use in-memory root CA, no K8S access and no ca key file %s", signingKeyFile)
 		}
 	}
 

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -152,7 +152,7 @@ type Server struct {
 	fileWatcher filewatcher.FileWatcher
 
 	certController *chiron.WebhookController
-	ca             *ca.IstioCA
+	CA             *ca.IstioCA
 	// path to the caBundle that signs the DNS certs. This should be agnostic to provider.
 	caBundlePath string
 	certMu       sync.Mutex
@@ -281,7 +281,7 @@ func NewServer(args *PilotArgs) (*Server, error) {
 	// TODO(irisdingbj):add integration test after centralIstiod finished
 	args.RegistryOptions.KubeOptions.FetchCaRoot = nil
 	args.RegistryOptions.KubeOptions.CABundlePath = s.caBundlePath
-	if features.CentralIstioD && s.ca != nil && s.ca.GetCAKeyCertBundle() != nil {
+	if features.CentralIstioD && s.CA != nil && s.CA.GetCAKeyCertBundle() != nil {
 		args.RegistryOptions.KubeOptions.FetchCaRoot = s.fetchCARoot
 	}
 
@@ -555,7 +555,7 @@ func (s *Server) initDNSTLSListener(dns string, tlsOptions TLSOptions) error {
 		return nil
 	}
 	// Mainly for tests.
-	if !hasCustomTLSCerts(tlsOptions) && s.ca == nil {
+	if !hasCustomTLSCerts(tlsOptions) && s.CA == nil {
 		return nil
 	}
 
@@ -906,7 +906,7 @@ func (s *Server) getCertKeyPaths(tlsOptions TLSOptions) (string, string) {
 
 // setPeerCertVerifier sets up a SPIFFE certificate verifier with the current istiod configuration.
 func (s *Server) setPeerCertVerifier(tlsOptions TLSOptions) error {
-	if tlsOptions.CaCertFile == "" && s.ca == nil && features.SpiffeBundleEndpoints == "" {
+	if tlsOptions.CaCertFile == "" && s.CA == nil && features.SpiffeBundleEndpoints == "" {
 		// Running locally without configured certs - no TLS mode
 		return nil
 	}
@@ -917,8 +917,8 @@ func (s *Server) setPeerCertVerifier(tlsOptions TLSOptions) error {
 		if rootCertBytes, err = ioutil.ReadFile(tlsOptions.CaCertFile); err != nil {
 			return err
 		}
-	} else if s.ca != nil {
-		rootCertBytes = s.ca.GetCAKeyCertBundle().GetRootCertPem()
+	} else if s.CA != nil {
+		rootCertBytes = s.CA.GetCAKeyCertBundle().GetRootCertPem()
 	}
 
 	if len(rootCertBytes) != 0 {
@@ -976,7 +976,7 @@ func (s *Server) initControllers(args *PilotArgs) error {
 
 // initNamespaceController initializes namespace controller to sync config map.
 func (s *Server) initNamespaceController(args *PilotArgs) {
-	if s.ca != nil && s.kubeClient != nil {
+	if s.CA != nil && s.kubeClient != nil {
 		s.addTerminatingStartFunc(func(stop <-chan struct{}) error {
 			leaderelection.
 				NewLeaderElection(args.Namespace, args.PodName, leaderelection.NamespaceController, s.kubeClient).
@@ -1032,7 +1032,7 @@ func (s *Server) maybeCreateCA(caOpts *CAOptions) error {
 			corev1 = s.kubeClient.CoreV1()
 		}
 		// May return nil, if the CA is missing required configs - This is not an error.
-		if s.ca, err = s.createIstioCA(corev1, caOpts); err != nil {
+		if s.CA, err = s.createIstioCA(corev1, caOpts); err != nil {
 			return fmt.Errorf("failed to create CA: %v", err)
 		}
 		if err = s.initPublicKey(); err != nil {
@@ -1044,10 +1044,10 @@ func (s *Server) maybeCreateCA(caOpts *CAOptions) error {
 
 // startCA starts the CA server if configured.
 func (s *Server) startCA(caOpts *CAOptions) {
-	if s.ca != nil {
+	if s.CA != nil {
 		s.addStartFunc(func(stop <-chan struct{}) error {
 			log.Infof("staring CA")
-			s.RunCA(s.secureGrpcServer, s.ca, caOpts)
+			s.RunCA(s.secureGrpcServer, s.CA, caOpts)
 			return nil
 		})
 	}
@@ -1055,7 +1055,7 @@ func (s *Server) startCA(caOpts *CAOptions) {
 
 func (s *Server) fetchCARoot() map[string]string {
 	return map[string]string{
-		constants.CACertNamespaceConfigMapDataName: string(s.ca.GetCAKeyCertBundle().GetRootCertPem()),
+		constants.CACertNamespaceConfigMapDataName: string(s.CA.GetCAKeyCertBundle().GetRootCertPem()),
 	}
 }
 

--- a/pilot/pkg/networking/apigen/apigen_test.go
+++ b/pilot/pkg/networking/apigen/apigen_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	xdsapi "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
 	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/model"

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -197,6 +197,7 @@ type Controller struct {
 	// map of node name and its address+labels - this is the only thing we need from nodes
 	// for vm to k8s or cross cluster. When node port services select specific nodes by labels,
 	// we run through the label selectors here to pick only ones that we need.
+	// Only nodes with ExternalIP addresses are included in this map !
 	nodeInfoMap map[string]kubernetesNode
 	// externalNameSvcInstanceMap stores hostname ==> instance, is used to store instances for ExternalName k8s services
 	externalNameSvcInstanceMap map[host.Name][]*model.ServiceInstance

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -161,10 +161,10 @@ func isExpectedGRPCError(err error) bool {
 func receiveThread(con *Connection, reqChannel chan *discovery.DiscoveryRequest, errP *error) {
 	defer close(reqChannel) // indicates close of the remote side.
 	for {
+		req, err := con.stream.Recv()
 		con.mu.RLock()
 		cid := con.ConID
 		con.mu.RUnlock()
-		req, err := con.stream.Recv()
 		if err != nil {
 			if isExpectedGRPCError(err) {
 				con.mu.RLock()

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -161,23 +161,26 @@ func isExpectedGRPCError(err error) bool {
 func receiveThread(con *Connection, reqChannel chan *discovery.DiscoveryRequest, errP *error) {
 	defer close(reqChannel) // indicates close of the remote side.
 	for {
+		con.mu.RLock()
+		cid := con.ConID
+		con.mu.RUnlock()
 		req, err := con.stream.Recv()
 		if err != nil {
 			if isExpectedGRPCError(err) {
 				con.mu.RLock()
-				adsLog.Infof("ADS: %q %s terminated %v", con.PeerAddr, con.ConID, err)
+				adsLog.Infof("ADS: %q %s terminated %v", con.PeerAddr, cid, err)
 				con.mu.RUnlock()
 				return
 			}
 			*errP = err
-			adsLog.Errorf("ADS: %q %s terminated with error: %v", con.PeerAddr, con.ConID, err)
+			adsLog.Errorf("ADS: %q %s terminated with error: %v", con.PeerAddr, cid, err)
 			totalXDSInternalErrors.Increment()
 			return
 		}
 		select {
 		case reqChannel <- req:
 		case <-con.stream.Context().Done():
-			adsLog.Infof("ADS: %q %s terminated with stream closed", con.PeerAddr, con.ConID)
+			adsLog.Infof("ADS: %q %s terminated with stream closed", con.PeerAddr, cid)
 			return
 		}
 	}

--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -14,6 +14,7 @@
 package xds_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -21,6 +22,10 @@ import (
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/golang/protobuf/proto"
+
+	"istio.io/istio/security/pkg/nodeagent/cache"
+
+	secretmodel "istio.io/istio/security/pkg/nodeagent/model"
 
 	networking "istio.io/api/networking/v1alpha3"
 
@@ -32,6 +37,7 @@ import (
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/tests/util"
 
@@ -42,6 +48,74 @@ const (
 	routeA = "http.80"
 	routeB = "https.443.https.my-gateway.testns"
 )
+
+type clientSecrets struct {
+	secretmodel.SecretItem
+}
+
+func (sc *clientSecrets) GenerateSecret(ctx context.Context, connectionID, resourceName, token string) (*secretmodel.SecretItem, error) {
+	return &sc.SecretItem, nil
+}
+
+// ShouldWaitForIngressGatewaySecret indicates whether a valid ingress gateway secret is expected.
+func (sc *clientSecrets) ShouldWaitForIngressGatewaySecret(connectionID, resourceName, token string, fileMountedCertsOnly bool) bool {
+	return false
+}
+
+// TODO: must fix SDS, it uses existence to detect it's an ACK !!
+func (sc *clientSecrets) SecretExist(connectionID, resourceName, token, version string) bool {
+	return false
+}
+
+// DeleteSecret deletes a secret by its key from cache.
+func (sc *clientSecrets) DeleteSecret(connectionID, resourceName string) {
+}
+
+// TestAgent will start istiod with TLS enabled, use the istio-agent to connect, and then
+// use the ADSC to connect to the agent proxy.
+func TestAgent(t *testing.T) {
+	// Start Istiod
+	bs, tearDown := initLocalPilotTestEnv(t)
+	defer tearDown()
+
+	// TODO: when authz is implemented, verify labels are checked.
+	cert, key, err := bs.CA.GenKeyCert([]string{"spiffe://cluster.local/fake.test"}, 1*time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	creds := &clientSecrets{
+		secretmodel.SecretItem{
+			PrivateKey:       key,
+			CertificateChain: cert,
+			RootCert:         bs.CA.GetCAKeyCertBundle().GetRootCertPem(),
+		},
+	}
+
+
+	t.Run("adscTLSDirect", func(t *testing.T) {
+		testAdscTLS(t, creds)
+	})
+
+}
+
+// testAdscTLS tests that ADSC helper can connect using TLS to Istiod
+func testAdscTLS(t *testing.T, creds cache.SecretManager) {
+	// connect to the local XDS proxy - it's using a transient port.
+	ldsr, err := adsc.Dial(util.MockPilotSGrpcAddr, "",
+		&adsc.Config{
+			IP:        "10.11.10.1",
+			Namespace: "test",
+			Secrets:   creds,
+			Watch: []string{
+				v3.ClusterType,
+				collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind().String()},
+		})
+	if err != nil {
+		t.Fatal("Failed to connect", err)
+	}
+	defer ldsr.Close()
+}
 
 func TestInternalEvents(t *testing.T) {
 	_, tearDown := initLocalPilotTestEnv(t)

--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -92,7 +92,6 @@ func TestAgent(t *testing.T) {
 		},
 	}
 
-
 	t.Run("adscTLSDirect", func(t *testing.T) {
 		testAdscTLS(t, creds)
 	})

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -124,6 +124,7 @@ type DiscoveryServer struct {
 	// Authenticators for XDS requests. Should be same/subset of the CA authenticators.
 	Authenticators []authenticate.Authenticator
 
+	// InternalGen is notified of connect/disconnect/nack on all connections
 	InternalGen *InternalGen
 }
 

--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -33,7 +33,7 @@ import (
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	
+
 	"istio.io/istio/pilot/pkg/serviceregistry/memory"
 
 	"istio.io/istio/pilot/pkg/networking/util"
@@ -459,6 +459,7 @@ func (a *ADSC) handleRecv() {
 			}
 			a.Mesh = m
 			if a.LocalCacheDir != "" {
+				// TODO: use jsonpb
 				strResponse, err := json.MarshalIndent(m, "  ", "  ")
 				if err != nil {
 					continue

--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -26,10 +26,15 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cenkalti/backoff"
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	xdsapi "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	
+	"istio.io/istio/pilot/pkg/serviceregistry/memory"
 
 	"istio.io/istio/pilot/pkg/networking/util"
 	v2 "istio.io/istio/pilot/pkg/xds/v2"
@@ -43,12 +48,15 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes/any"
 	pstruct "github.com/golang/protobuf/ptypes/struct"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
 	mcp "istio.io/api/mcp/v1alpha1"
 	"istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/security/pkg/nodeagent/cache"
+
 	"istio.io/pkg/log"
 
 	"istio.io/istio/pilot/pkg/model"
@@ -74,9 +82,19 @@ type Config struct {
 	IP string
 
 	// CertDir is the directory where mTLS certs are configured.
-	// If empty, an insecure connection will be used.
-	// TODO: also allow passing in-memory certs.
+	// If CertDir and Secret are empty, an insecure connection will be used.
+	// TODO: implement SecretManager for cert dir
 	CertDir string
+
+	// Secrets is the interface used for getting keys and rootCA.
+	Secrets cache.SecretManager
+
+	// For getting the certificate, using same code as SDS server.
+	// Either the JWTPath or the certs must be present.
+	JWTPath string
+
+	// XDSSAN is the expected SAN of the XDS server. If not set, the ProxyConfig.DiscoveryAddress is used.
+	XDSSAN string
 
 	// Watch is a list of resources to watch, represented as URLs (for new XDS resource naming)
 	// or type URLs.
@@ -86,6 +104,13 @@ type Config struct {
 	// If empty reconnect will not be attempted.
 	// TODO: client will use exponential backoff to reconnect.
 	InitialReconnectDelay time.Duration
+
+	// backoffPolicy determines the reconnect policy. Based on MCP client.
+	BackoffPolicy backoff.BackOff
+
+	// ResponseHandler will be called on each DiscoveryResponse.
+	// TODO: mirror Generator, allow adding handler per type
+	ResponseHandler ResponseHandler
 }
 
 // ADSC implements a basic client for ADS, for use in stress tests and tools
@@ -93,15 +118,14 @@ type Config struct {
 type ADSC struct {
 	// Stream is the GRPC connection stream, allowing direct GRPC send operations.
 	// Set after Dial is called.
-	stream ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient
+	stream xdsapi.AggregatedDiscoveryService_StreamAggregatedResourcesClient
 
 	conn *grpc.ClientConn
 
 	// NodeID is the node identity sent to Pilot.
 	nodeID string
 
-	certDir string
-	url     string
+	url string
 
 	watchTime time.Time
 
@@ -145,6 +169,9 @@ type ADSC struct {
 	// Retrieved configurations can be stored using the common istio model interface.
 	Store model.IstioConfigStore
 
+	// Retrieved endpoints can be stored in the memory registry. This is used for CDS and EDS responses.
+	Registry *memory.ServiceDiscovery
+
 	// LocalCacheDir is set to a base name used to save fetched resources.
 	// If set, each update will be saved.
 	// TODO: also load at startup - so we can support warm up in init-container, and survive
@@ -158,6 +185,14 @@ type ADSC struct {
 
 	// sendNodeMeta is set to true if the connection is new - and we need to send node meta.,
 	sendNodeMeta bool
+
+	sync   map[string]time.Time
+	syncCh chan string
+	m      sync.RWMutex
+}
+
+type ResponseHandler interface {
+	HandleResponse(con *ADSC, response *xdsapi.DiscoveryResponse)
 }
 
 const (
@@ -173,6 +208,24 @@ var (
 	adscLog = log.RegisterScope("adsc", "adsc debugging", 0)
 )
 
+// New creates a new ADSC, maintaining a connection to an XDS server.
+// Will:
+// - get certificate using the Secret provider, if CertRequired
+// - connect to the XDS server specified in ProxyConfig
+// - send initial request for watched resources
+// - wait for respose from XDS server
+// - on success, start a background thread to maintain the connection, with exp. backoff.
+func New(proxyConfig *v1alpha1.ProxyConfig, opts *Config) (*ADSC, error) {
+	// We want to reconnect
+	if opts.BackoffPolicy == nil {
+		opts.BackoffPolicy = backoff.NewExponentialBackOff()
+	}
+
+	adsc, err := Dial(proxyConfig.DiscoveryAddress, "", opts)
+
+	return adsc, err
+}
+
 // Dial connects to a ADS server, with optional MTLS authentication if a cert dir is specified.
 func Dial(url string, certDir string, opts *Config) (*ADSC, error) {
 	if opts == nil {
@@ -182,11 +235,12 @@ func Dial(url string, certDir string, opts *Config) (*ADSC, error) {
 		Updates:     make(chan string, 100),
 		XDSUpdates:  make(chan *xdsapi.DiscoveryResponse, 100),
 		VersionInfo: map[string]string{},
-		certDir:     certDir,
 		url:         url,
 		Received:    map[string]*xdsapi.DiscoveryResponse{},
 		RecvWg:      sync.WaitGroup{},
 		cfg:         opts,
+		syncCh:      make(chan string, len(collections.Pilot.All())),
+		sync:        map[string]time.Time{},
 	}
 	if certDir != "" {
 		opts.CertDir = certDir
@@ -235,26 +289,60 @@ func getPrivateIPIfAvailable() net.IP {
 	return net.IPv4zero
 }
 
-func tlsConfig(certDir string) (*tls.Config, error) {
-	clientCert, err := tls.LoadX509KeyPair(certDir+"/cert-chain.pem",
-		certDir+"/key.pem")
-	if err != nil {
-		return nil, err
+func (a *ADSC) tlsConfig() (*tls.Config, error) {
+	var clientCert tls.Certificate
+	var serverCABytes []byte
+	var err error
+
+	if a.cfg.Secrets != nil {
+		tok, err := ioutil.ReadFile(a.cfg.JWTPath)
+		if err != nil {
+			log.Infof("Failed to get credential token: %v", err)
+			tok = []byte("")
+		}
+
+		key, err := a.cfg.Secrets.GenerateSecret(context.Background(), "agent",
+			cache.WorkloadKeyCertResourceName, string(tok))
+		if err != nil {
+			return nil, err
+		}
+		clientCert, err = tls.X509KeyPair(key.CertificateChain, key.PrivateKey)
+		if err != nil {
+			return nil, err
+		}
+		// This is a bit crazy - we could just use the file
+		rootCA, err := a.cfg.Secrets.GenerateSecret(context.Background(), "agent",
+			cache.RootCertReqResourceName, string(tok))
+		if err != nil {
+			return nil, err
+		}
+
+		serverCABytes = rootCA.RootCert
+	} else {
+		clientCert, err = tls.LoadX509KeyPair(a.cfg.CertDir+"/cert-chain.pem",
+			a.cfg.CertDir+"/key.pem")
+		if err != nil {
+			return nil, err
+		}
+		serverCABytes, err = ioutil.ReadFile(a.cfg.CertDir + "/root-cert.pem")
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	serverCABytes, err := ioutil.ReadFile(certDir + "/root-cert.pem")
-	if err != nil {
-		return nil, err
-	}
 	serverCAs := x509.NewCertPool()
 	if ok := serverCAs.AppendCertsFromPEM(serverCABytes); !ok {
 		return nil, err
 	}
 
+	shost, _, _ := net.SplitHostPort(a.url)
+	if a.cfg.XDSSAN != "" {
+		shost = a.cfg.XDSSAN
+	}
 	return &tls.Config{
 		Certificates: []tls.Certificate{clientCert},
 		RootCAs:      serverCAs,
-		ServerName:   "istio-pilot.istio-system",
+		ServerName:   shost,
 		VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 			return nil
 		},
@@ -273,8 +361,8 @@ func (a *ADSC) Run() error {
 
 	// TODO: pass version info, nonce properly
 	var err error
-	if len(a.certDir) > 0 {
-		tlsCfg, err := tlsConfig(a.certDir)
+	if len(a.cfg.CertDir) > 0 || a.cfg.Secrets != nil {
+		tlsCfg, err := a.tlsConfig()
 		if err != nil {
 			return err
 		}
@@ -295,7 +383,7 @@ func (a *ADSC) Run() error {
 		}
 	}
 
-	xds := ads.NewAggregatedDiscoveryServiceClient(a.conn)
+	xds := xdsapi.NewAggregatedDiscoveryServiceClient(a.conn)
 	edsstr, err := xds.StreamAggregatedResources(context.Background())
 	if err != nil {
 		return err
@@ -314,22 +402,55 @@ func (a *ADSC) Run() error {
 	return nil
 }
 
+// HasSyncedConfig returns true if MCP configs have synced
+func (a *ADSC) hasSynced() bool {
+	for _, s := range collections.Pilot.All() {
+		a.m.RLock()
+		t := a.sync[s.Resource().GroupVersionKind().String()]
+		a.m.RUnlock()
+		if t.IsZero() {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *ADSC) reconnect() {
+	err := a.Run()
+	if err == nil {
+		a.cfg.BackoffPolicy.Reset()
+	} else {
+		time.AfterFunc(a.cfg.BackoffPolicy.NextBackOff(), a.reconnect)
+	}
+}
+
 func (a *ADSC) handleRecv() {
 	for {
 		var err error
 		msg, err := a.stream.Recv()
 		if err != nil {
 			adscLog.Infof("Connection closed for node %v with err: %v", a.nodeID, err)
-			a.RecvWg.Done()
-			a.Close()
-			a.WaitClear()
-			a.Updates <- ""
-			a.XDSUpdates <- nil
+			// if 'reconnect' enabled - schedule a new Run
+			if a.cfg.BackoffPolicy != nil {
+				time.AfterFunc(a.cfg.BackoffPolicy.NextBackOff(), a.reconnect)
+			} else {
+				a.RecvWg.Done()
+				a.Close()
+				a.WaitClear()
+				a.Updates <- ""
+				a.XDSUpdates <- nil
+			}
 			return
 		}
 
 		// Group-value-kind - used for high level api generator.
 		gvk := strings.SplitN(msg.TypeUrl, "/", 3)
+
+		adscLog.Infoa("Received ", a.url, " type ", msg.TypeUrl,
+			" cnt=", len(msg.Resources), " nonce=", msg.Nonce)
+		if a.cfg.ResponseHandler != nil {
+			a.cfg.ResponseHandler.HandleResponse(a, msg)
+		}
 
 		if msg.TypeUrl == collections.IstioMeshV1Alpha1MeshConfig.Resource().GroupVersionKind().String() &&
 			len(msg.Resources) > 0 {
@@ -353,6 +474,7 @@ func (a *ADSC) handleRecv() {
 			continue
 		}
 
+		// Process the resources.
 		listeners := []*listener.Listener{}
 		clusters := []*cluster.Cluster{}
 		routes := []*route.RouteConfiguration{}
@@ -366,6 +488,18 @@ func (a *ADSC) handleRecv() {
 					ll := &listener.Listener{}
 					_ = proto.Unmarshal(valBytes, ll)
 					listeners = append(listeners, ll)
+				}
+			case v3.ListenerType:
+				{
+					ll := &listener.Listener{}
+					_ = proto.Unmarshal(valBytes, ll)
+					listeners = append(listeners, ll)
+				}
+			case v2.ClusterType:
+				{
+					cl := &cluster.Cluster{}
+					_ = proto.Unmarshal(valBytes, cl)
+					clusters = append(clusters, cl)
 				}
 
 			case v3.ClusterType:
@@ -381,7 +515,18 @@ func (a *ADSC) handleRecv() {
 					_ = proto.Unmarshal(valBytes, el)
 					eds = append(eds, el)
 				}
-
+			case v2.EndpointType:
+				{
+					el := &endpoint.ClusterLoadAssignment{}
+					_ = proto.Unmarshal(valBytes, el)
+					eds = append(eds, el)
+				}
+			case v3.RouteType:
+				{
+					rl := &route.RouteConfiguration{}
+					_ = proto.Unmarshal(valBytes, rl)
+					routes = append(routes, rl)
+				}
 			case v2.RouteType:
 				{
 					rl := &route.RouteConfiguration{}
@@ -390,57 +535,14 @@ func (a *ADSC) handleRecv() {
 				}
 
 			default:
-				if len(gvk) != 3 {
-					continue
-				}
-				// Generic - fill up the store
-				if a.Store != nil {
-					m := &mcp.Resource{}
-					err = types.UnmarshalAny(&types.Any{
-						TypeUrl: rsc.TypeUrl,
-						Value:   rsc.Value,
-					}, m)
-					if err != nil {
-						continue
-					}
-					val, err := mcpToPilot(m)
-					if err != nil {
-						continue
-					}
-					val.GroupVersionKind = resource.GroupVersionKind{gvk[0], gvk[1], gvk[2]}
-					if err != nil {
-						adscLog.Warna("Invalid data ", err, " ", string(valBytes))
-					} else {
-						cfg := a.Store.Get(val.GroupVersionKind, val.Name, val.Namespace)
-						if cfg == nil {
-							_, err = a.Store.Create(*val)
-							if err != nil {
-								continue
-							}
-						} else {
-							_, err = a.Store.Update(*val)
-							if err != nil {
-								continue
-							}
-						}
-					}
-					if a.LocalCacheDir != "" {
-						strResponse, err := json.MarshalIndent(val, "  ", "  ")
-						if err != nil {
-							continue
-						}
-						err = ioutil.WriteFile(a.LocalCacheDir+"_res."+
-							val.GroupVersionKind.Kind+"."+val.Namespace+"."+val.Name+".json", strResponse, 0644)
-						if err != nil {
-							continue
-						}
-					}
-				}
+				_ = a.handleMCP(gvk, rsc, valBytes)
 			}
 		}
 
 		// If we got no resource - still save to the store with empty name/namespace, to notify sync
 		// This scheme also allows us to chunk large responses !
+
+		// TODO: add hook to inject nacks
 
 		a.mutex.Lock()
 		a.Received[msg.TypeUrl] = msg
@@ -893,6 +995,26 @@ func (a *ADSC) WatchConfig() {
 	}
 }
 
+// WaitConfigSync will wait for the memory controller to sync.
+func (a *ADSC) WaitConfigSync(max time.Duration) bool {
+	// TODO: when adding support for multiple config controllers (matching MCP), make sure the
+	// new stores support reporting sync events on the syncCh, to avoid the sleep loop from MCP.
+	if a.hasSynced() {
+		return true
+	}
+	maxCh := time.After(max)
+	for {
+		select {
+		case <-a.syncCh:
+			if a.hasSynced() {
+				return true
+			}
+		case <-maxCh:
+			return a.hasSynced()
+		}
+	}
+}
+
 func (a *ADSC) sendRsc(typeurl string, rsc []string) {
 	_ = a.stream.Send(&xdsapi.DiscoveryRequest{
 		ResponseNonce: "",
@@ -951,4 +1073,55 @@ func (a *ADSC) GetEndpoints() map[string]*endpoint.ClusterLoadAssignment {
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 	return a.eds
+}
+
+func (a *ADSC) handleMCP(gvk []string, rsc *any.Any, valBytes []byte) error {
+	if len(gvk) != 3 {
+		return nil // Not MCP
+	}
+	// Generic - fill up the store
+	if a.Store != nil {
+		m := &mcp.Resource{}
+		err := types.UnmarshalAny(&types.Any{
+			TypeUrl: rsc.TypeUrl,
+			Value:   rsc.Value,
+		}, m)
+		if err != nil {
+			return err
+		}
+		val, err := mcpToPilot(m)
+		if err != nil {
+			return err
+		}
+		val.GroupVersionKind = resource.GroupVersionKind{gvk[0], gvk[1], gvk[2]}
+		if err != nil {
+			adscLog.Warna("Invalid data ", err, " ", string(valBytes))
+		} else {
+			cfg := a.Store.Get(val.GroupVersionKind, val.Name, val.Namespace)
+			if cfg == nil {
+				_, err = a.Store.Create(*val)
+				if err != nil {
+					return err
+				}
+			} else {
+				_, err = a.Store.Update(*val)
+				if err != nil {
+					return err
+				}
+			}
+		}
+		if a.LocalCacheDir != "" {
+			strResponse, err := json.MarshalIndent(val, "  ", "  ")
+			if err != nil {
+				return err
+			}
+			err = ioutil.WriteFile(a.LocalCacheDir+"_res."+
+				val.GroupVersionKind.Kind+"."+val.Namespace+"."+val.Name+".json", strResponse, 0644)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }

--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -41,9 +41,6 @@ import (
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pkg/config/schema/resource"
 
-	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	ads "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/conversion"
 	"github.com/gogo/protobuf/types"
 	"github.com/golang/protobuf/jsonpb"
@@ -535,7 +532,10 @@ func (a *ADSC) handleRecv() {
 				}
 
 			default:
-				_ = a.handleMCP(gvk, rsc, valBytes)
+				err = a.handleMCP(gvk, rsc, valBytes)
+				if err != nil {
+					log.Warnf("Error handling received MCP config ", err)
+				}
 			}
 		}
 

--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -534,7 +534,7 @@ func (a *ADSC) handleRecv() {
 			default:
 				err = a.handleMCP(gvk, rsc, valBytes)
 				if err != nil {
-					log.Warnf("Error handling received MCP config ", err)
+					log.Warnf("Error handling received MCP config %v", err)
 				}
 			}
 		}

--- a/pkg/adsc/adsc_test.go
+++ b/pkg/adsc/adsc_test.go
@@ -22,8 +22,6 @@ import (
 	"testing"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	ads "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/testing/protocmp"

--- a/pkg/adsc/adsc_test.go
+++ b/pkg/adsc/adsc_test.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"testing"
 
+	xdsapi "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	ads "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	"github.com/google/go-cmp/cmp"
@@ -30,13 +31,13 @@ import (
 
 type testAdscRunServer struct{}
 
-var StreamHandler func(stream ads.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error
+var StreamHandler func(stream xdsapi.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error
 
-func (t *testAdscRunServer) StreamAggregatedResources(stream ads.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
+func (t *testAdscRunServer) StreamAggregatedResources(stream xdsapi.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
 	return StreamHandler(stream)
 }
 
-func (t *testAdscRunServer) DeltaAggregatedResources(ads.AggregatedDiscoveryService_DeltaAggregatedResourcesServer) error {
+func (t *testAdscRunServer) DeltaAggregatedResources(xdsapi.AggregatedDiscoveryService_DeltaAggregatedResourcesServer) error {
 	return nil
 }
 
@@ -45,55 +46,53 @@ func TestADSC_Run(t *testing.T) {
 		desc                 string
 		inAdsc               *ADSC
 		port                 uint32
-		streamHandler        func(server ads.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error
+		streamHandler        func(server xdsapi.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error
 		expectedADSResources *ADSC
 	}{
 		{
 			desc: "stream-no-resources",
 			inAdsc: &ADSC{
-				certDir:    "",
 				url:        "127.0.0.1:49133",
-				Received:   make(map[string]*v2.DiscoveryResponse),
+				Received:   make(map[string]*xdsapi.DiscoveryResponse),
 				Updates:    make(chan string),
-				XDSUpdates: make(chan *v2.DiscoveryResponse),
+				XDSUpdates: make(chan *xdsapi.DiscoveryResponse),
 				RecvWg:     sync.WaitGroup{},
 				cfg: &Config{
 					Watch: make([]string, 0),
 				},
 			},
 			port: uint32(49133),
-			streamHandler: func(server ads.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
+			streamHandler: func(server xdsapi.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
 				return nil
 			},
 			expectedADSResources: &ADSC{
-				Received: map[string]*v2.DiscoveryResponse{},
+				Received: map[string]*xdsapi.DiscoveryResponse{},
 			},
 		},
 		{
 			desc: "stream-2-unnamed-resources",
 			inAdsc: &ADSC{
-				certDir:    "",
 				url:        "127.0.0.1:49133",
-				Received:   make(map[string]*v2.DiscoveryResponse),
+				Received:   make(map[string]*xdsapi.DiscoveryResponse),
 				Updates:    make(chan string),
-				XDSUpdates: make(chan *v2.DiscoveryResponse),
+				XDSUpdates: make(chan *xdsapi.DiscoveryResponse),
 				RecvWg:     sync.WaitGroup{},
 				cfg: &Config{
 					Watch: make([]string, 0),
 				},
 			},
 			port: uint32(49133),
-			streamHandler: func(stream ads.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
-				_ = stream.Send(&v2.DiscoveryResponse{
+			streamHandler: func(stream xdsapi.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
+				_ = stream.Send(&xdsapi.DiscoveryResponse{
 					TypeUrl: "foo",
 				})
-				_ = stream.Send(&v2.DiscoveryResponse{
+				_ = stream.Send(&xdsapi.DiscoveryResponse{
 					TypeUrl: "bar",
 				})
 				return nil
 			},
 			expectedADSResources: &ADSC{
-				Received: map[string]*v2.DiscoveryResponse{
+				Received: map[string]*xdsapi.DiscoveryResponse{
 					"foo": {
 						TypeUrl: "foo",
 					},
@@ -114,7 +113,7 @@ func TestADSC_Run(t *testing.T) {
 				t.Errorf("Unable to listen on port %v with tcp err %v", tt.port, err)
 			}
 			xds := grpc.NewServer()
-			ads.RegisterAggregatedDiscoveryServiceServer(xds, new(testAdscRunServer))
+			xdsapi.RegisterAggregatedDiscoveryServiceServer(xds, new(testAdscRunServer))
 			go func() {
 				err = xds.Serve(l)
 				if err != nil {

--- a/pkg/istio-agent/sds-agent_test.go
+++ b/pkg/istio-agent/sds-agent_test.go
@@ -16,17 +16,24 @@ package istioagent
 
 import (
 	"testing"
+
+	mesh "istio.io/api/mesh/v1alpha1"
 )
 
-// Validate that SDSAgent comes up without errors when configured with file mounted certs.
+// Validate that Agent comes up without errors when configured with file mounted certs.
 func TestSDSAgentWithFileMountedCerts(t *testing.T) {
 	fm := fileMountedCertsEnv
 	fileMountedCertsEnv = true
 	defer func() { fileMountedCertsEnv = fm }()
 	// Validate that SDS server can start without any error.
-	sa := NewSDSAgent("istiod.istio-system:15012", false, "custom", "", "", "kubernetes")
+	sa := NewAgent(&mesh.ProxyConfig{
+		DiscoveryAddress: "istiod.istio-system:15010",
+	}, &AgentConfig{
+		PilotCertProvider: "custom",
+		ClusterID:         "kubernetes",
+	})
 	_, err := sa.Start(true, "test")
 	if err != nil {
-		t.Fatalf("Unexpected error starting SDSAgent %v", err)
+		t.Fatalf("Unexpected error starting Agent %v", err)
 	}
 }

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -135,6 +135,9 @@ type Options struct {
 // SecretManager defines secrets management interface which is used by SDS.
 type SecretManager interface {
 	// GenerateSecret generates new secret and cache the secret.
+	// Current implementation constructs the SAN based on the token's 'sub'
+	// claim, expected to be in the K8S format. No other JWTs are currently supported
+	// due to client logic. If JWT is missing/invalid, the resourceName is used.
 	GenerateSecret(ctx context.Context, connectionID, resourceName, token string) (*model.SecretItem, error)
 
 	// ShouldWaitForIngressGatewaySecret indicates whether a valid ingress gateway secret is expected.

--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -107,9 +107,6 @@ type Options struct {
 	// Whether to generate PKCS#8 private keys.
 	Pkcs8Keys bool
 
-	// PilotCertProvider is the provider of the Pilot certificate.
-	PilotCertProvider string
-
 	// JWTPath is the path for the JWT token
 	JWTPath string
 

--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -21,6 +21,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -196,6 +197,33 @@ func NewPluggedCertIstioCAOptions(certChainFile, signingCertFile, signingKeyFile
 		DefaultCertTTL: defaultCertTTL,
 		MaxCertTTL:     maxCertTTL,
 	}
+	if _, err := os.Stat(signingKeyFile); err != nil {
+		// self generating for testing or local, non-k8s run
+		options := util.CertOptions{
+			TTL:          3650 * 24 * time.Hour, // TODO: pass the flag here as well (or pass MeshConfig )
+			Org:          "cluster.local",       // TODO: pass trustDomain ( or better - pass MeshConfig )
+			IsCA:         true,
+			IsSelfSigned: true,
+			RSAKeySize:   caKeySize,
+			IsDualUse:    true, // hardcoded to true for K8S as well
+		}
+		pemCert, pemKey, ckErr := util.GenCertKeyFromOptions(options)
+		if ckErr != nil {
+			return nil, fmt.Errorf("unable to generate CA cert and key for self-signed CA (%v)", ckErr)
+		}
+
+		rootCerts, err := util.AppendRootCerts(pemCert, rootCertFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to append root certificates (%v)", err)
+		}
+
+		if caOpts.KeyCertBundle, err = util.NewVerifiedKeyCertBundleFromPem(pemCert, pemKey, nil, rootCerts); err != nil {
+			return nil, fmt.Errorf("failed to create CA KeyCertBundle (%v)", err)
+		}
+
+		return caOpts, nil
+	}
+
 	if caOpts.KeyCertBundle, err = util.NewVerifiedKeyCertBundleFromFile(
 		signingCertFile, signingKeyFile, certChainFile, rootCertFile); err != nil {
 		return nil, fmt.Errorf("failed to create CA KeyCertBundle (%v)", err)

--- a/tests/util/pilot_server.go
+++ b/tests/util/pilot_server.go
@@ -38,6 +38,8 @@ var (
 	// MockPilotGrpcAddr is the address to be used for grpc connections.
 	MockPilotGrpcAddr string
 
+	MockPilotSGrpcAddr string
+
 	// MockPilotHTTPPort is the dynamic port for pilot http
 	MockPilotHTTPPort int
 
@@ -81,6 +83,10 @@ func setup(additionalArgs ...func(*bootstrap.PilotArgs)) (*bootstrap.Server, Tea
 	}
 	defer meshFile.Close()
 	meshConfig := mesh.DefaultMeshConfig()
+
+	// Secure GRPC address
+	meshConfig.DefaultConfig.DiscoveryAddress = "localhost:15012"
+
 	meshConfig.EnableAutoMtls.Value = false
 	tearFunc := func() {
 		os.Remove(meshFile.Name())
@@ -138,6 +144,12 @@ func setup(additionalArgs ...func(*bootstrap.PilotArgs)) (*bootstrap.Server, Tea
 	}
 	MockPilotGrpcAddr = "localhost:" + port
 	MockPilotGrpcPort, _ = strconv.Atoi(port)
+
+	_, port, err = net.SplitHostPort(s.SecureGrpcListener.Addr().String())
+	if err != nil {
+		return nil, nil, err
+	}
+	MockPilotSGrpcAddr = "localhost:" + port
 
 	// Wait a bit for the server to come up.
 	err = wait.Poll(500*time.Millisecond, 5*time.Second, func() (bool, error) {


### PR DESCRIPTION
- If istiod is started without access to K8S, for example by tests - generate and in memory self-signed root,
so tests or local use with mTLS is possible

- Update ADSC support for mTLS connections and envoy v3, part of improving the testing abilities.
Since v2 is deprecated it seems better to switch the test as well. I know the change on security is mixed and 
unrelated to v3 - but it's pretty hard to split the PR by line, and all changes to ADSC are related to 'improved testing' 

Extracted from PR#24398, to split it in smaller pieces.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
