### PR TITLE
Documentation to extend VM tests

### DIFF
--- a/tests/integration/pilot/vm/README.md
+++ b/tests/integration/pilot/vm/README.md
@@ -1,8 +1,8 @@
 # Writing Tests for VMs
 
-Support for including VMs in the integration tests has been added to the framework. 
-This document describes the integration and extension mechanisms to exercise VM related code. 
-The primary goals are to test VM-related code & ensure it works on a range of supported OS types and versions.  
+Support for including VMs in the integration tests has been added to the framework.
+This document describes the integration and extension mechanisms to exercise VM related code.
+The primary goals are to test VM-related code & ensure it works on a range of supported OS types and versions.
 
 **Note: We currently use mock/simulated VMs for testing purposes. In the future, the testing might switch
 to utilize actual compute instances from different providers.**
@@ -11,6 +11,7 @@ to utilize actual compute instances from different providers.**
 
 To deploy an echo instance as a VM just set `DeployAsVm` to be true in `echo.Config`
 and `VMImage` to be any image available from `GetSupportedOSVersion`. For example,
+
 ```
 ports := []echo.Port{
    {
@@ -30,25 +31,28 @@ echo.Config{
    VMImage:    "app_sidecar_ubuntu_bionic"
 }
 ```
+
 Note that due to a bug in WorkloadEntry, we need to set the ServicePort to be the same as the InstancePort, as shown in
 the comments. There is a default image and one could reference it with `DefaultVMImage` so that it's easier to maintain
-if the supported OSes were to change. We have [additional images](https://github.com/istio/istio/blob/d89c6a624cfd0962e2ed25238ec671baebda0ca5/tests/integration/pilot/vm/util.go#L23) 
-that are built in the post-submit jobs, jobs that only run after a PR is merged. 
-Info regarding adding extra images could be found in the next section. 
+if the supported OSes were to change. We have [additional images](https://github.com/istio/istio/blob/d89c6a624cfd0962e2ed25238ec671baebda0ca5/tests/integration/pilot/vm/util.go#L23)
+that are built in the post-submit jobs, jobs that only run after a PR is merged.
+Info regarding adding extra images could be found in the next section.
 If `VMImage` is not provided while `DeployAsVM` is on, it will default the Docker image to be `DefaultVMImage`.
 
 ## Adding Docker Images
-We list the supported OSes in [util.go](https://github.com/istio/istio/blob/d89c6a624cfd0962e2ed25238ec671baebda0ca5/tests/integration/pilot/vm/util.go#L23) 
-and the images will be created in [prow/lib.sh](https://github.com/istio/istio/blob/master/prow/lib.sh). 
-We will only build `ubuntu:bionic` for pre-submit jobs and build all others for post-submit jobs only to save time for CI/CD. 
+
+We list the supported OSes in [util.go](https://github.com/istio/istio/blob/d89c6a624cfd0962e2ed25238ec671baebda0ca5/tests/integration/pilot/vm/util.go#L23)
+and the images will be created in [prow/lib.sh](https://github.com/istio/istio/blob/master/prow/lib.sh).
+We will only build `ubuntu:bionic` for pre-submit jobs and build all others for post-submit jobs only to save time for CI/CD.
 To add more images for testing, simply modify [tools/istio-docker.mk](https://github.com/istio/istio/blob/master/tools/istio-docker.mk)
-to add more targets. `prow/lib.sh` would have to be updated as well to build the images on the fly in prow. 
-If you are writing a test that would need multiple images, the test needs to be labeled as `PostSubmit`, or it 
+to add more targets. `prow/lib.sh` would have to be updated as well to build the images on the fly in prow.
+If you are writing a test that would need multiple images, the test needs to be labeled as `PostSubmit`, or it
 will fail since the images other than default won't be built in pre-submit jobs.
 
 ## VM Deployment
-The deployment of VM involves steps from the [documentation](https://istio.io/latest/docs/examples/virtual-machines/single-network/) for the VM onboarding process. 
+
+The deployment of VM involves steps from the [documentation](https://istio.io/latest/docs/examples/virtual-machines/single-network/) for the VM onboarding process.
 We need to specify the IP address of the `Istiod` so that the VM could form a connection to Istio.
-During the deployment of the Docker images, we would also manually edit the `/etc/hosts` for the VMs to send requests to the 
+During the deployment of the Docker images, we would also manually edit the `/etc/hosts` for the VMs to send requests to the
 pods in the cluster, as shown [here](https://github.com/istio/istio/blob/9eff11ae3c6271ee06ee6d4d57a22a33749614a4/pkg/test/framework/components/echo/kube/deployment.go#L233-L234).
-Test cases that require the VM to send requests to other pods would have to add additional lines to the hosts. 
+Test cases that require the VM to send requests to other pods would have to add additional lines to the hosts.

--- a/tests/integration/pilot/vm/README.md
+++ b/tests/integration/pilot/vm/README.md
@@ -1,13 +1,15 @@
-
 # Writing Tests for VMs
 
-This README serves as a documentation for those who would continue writing and extending tests for VMs.
+Support for including VMs in the integration tests has been added to the framework. 
+This document describes the integration and extension mechanisms to exercise VM related code. 
+The primary goals are to test VM-related code & ensure it works on a range of supported OS types and versions.  
+
 **Note: We currently use mock/simulated VMs for testing purposes. In the future, the testing might switch
 to utilize actual compute instances from different providers.**
 
-## Deploy an echo instance as a VM
+## Deploy an Echo Instance as a VM
 
-In most cases, deploying an echo instance as a VM is as simple as setting `DeployAsVm` to be true in `echo.Config`
+To deploy an echo instance as a VM just set `DeployAsVm` to be true in `echo.Config`
 and `VMImage` to be any image available from `GetSupportedOSVersion`. For example,
 ```
 ports := []echo.Port{
@@ -29,24 +31,24 @@ echo.Config{
 }
 ```
 Note that due to a bug in WorkloadEntry, we need to set the ServicePort to be the same as the InstancePort, as shown in
-the comments. To make it easier in most cases, we have a const variable called `DefaultVMImage` to help maintenance
-and reference. More utility functions and variables could be added to the util file. Currently, we set `DefaultVMImage`
-to be `ubuntu:bionic`, but it is subject to change. If `VMImage` is not
-provided while `DeployAsVM` is on, it will default the Docker image to be `DefaultVMImage`. For pre-submit jobs, the
-only image available would be `ubuntu:bionic`, and all other images would be built in post-submit jobs. More information
-could be found in the next section.
+the comments. There is a default image and one could reference it with `DefaultVMImage` so that it's easier to maintain
+if the supported OSes were to change. We have [additional images](https://github.com/istio/istio/blob/d89c6a624cfd0962e2ed25238ec671baebda0ca5/tests/integration/pilot/vm/util.go#L23) 
+that are built in the post-submit jobs, jobs that only run after a PR is merged. 
+Info regarding adding extra images could be found in the next section. 
+If `VMImage` is not provided while `DeployAsVM` is on, it will default the Docker image to be `DefaultVMImage`.
 
-## Adding Docker images
-Current, we test the VMs with `ubuntu:xenial`, `ubuntu:bionic`, `ubuntu:focal`, `debian:9` and `debian:10`. The images
-will be created from [prow/lib.sh](https://github.com/istio/istio/blob/master/prow/lib.sh). We will only build
-`ubuntu:bionic` for pre-submit jobs and build all others for post-submit jobs only to save time for CI/CD. To add more
-images for testing, simply modify [tools/istio-docker.mk](https://github.com/istio/istio/blob/master/tools/istio-docker.mk)
-to add more targets. `prow/lib.sh` would have to be updated as well to build the images in prow. If you are writing
-a test that would need multiple images, the test needs to be labeled as `PostSubmit`, or it will fail since the
-images won't be built in pre-submit jobs.
+## Adding Docker Images
+We list the supported OSes in [util.go](https://github.com/istio/istio/blob/d89c6a624cfd0962e2ed25238ec671baebda0ca5/tests/integration/pilot/vm/util.go#L23) 
+and the images will be created in [prow/lib.sh](https://github.com/istio/istio/blob/master/prow/lib.sh). 
+We will only build `ubuntu:bionic` for pre-submit jobs and build all others for post-submit jobs only to save time for CI/CD. 
+To add more images for testing, simply modify [tools/istio-docker.mk](https://github.com/istio/istio/blob/master/tools/istio-docker.mk)
+to add more targets. `prow/lib.sh` would have to be updated as well to build the images on the fly in prow. 
+If you are writing a test that would need multiple images, the test needs to be labeled as `PostSubmit`, or it 
+will fail since the images other than default won't be built in pre-submit jobs.
 
-## DNS Resolution
-Currently, VMs resolving DNS does not happen automatically. During the build stage of the Docker images, we manually
-edit the `/etc/hosts` for the VMs to send requests to the pods in the cluster as shown [here](https://github.com/istio/istio/blob/9eff11ae3c6271ee06ee6d4d57a22a33749614a4/pkg/test/framework/components/echo/kube/deployment.go#L233-L234).
-Until we have a better way of resolving DNS, this remains a workaround for the VMs to connect to the cluster and `Istiod`.
-
+## VM Deployment
+The deployment of VM involves steps from the [documentation](https://istio.io/latest/docs/examples/virtual-machines/single-network/) for the VM onboarding process. 
+We need to specify the IP address of the `Istiod` so that the VM could form a connection to Istio.
+During the deployment of the Docker images, we would also manually edit the `/etc/hosts` for the VMs to send requests to the 
+pods in the cluster, as shown [here](https://github.com/istio/istio/blob/9eff11ae3c6271ee06ee6d4d57a22a33749614a4/pkg/test/framework/components/echo/kube/deployment.go#L233-L234).
+Test cases that require the VM to send requests to other pods would have to add additional lines to the hosts. 

--- a/tests/integration/pilot/vm/README.md
+++ b/tests/integration/pilot/vm/README.md
@@ -8,22 +8,24 @@ The primary goals are to test VM-related code & ensure it works on a range of su
 to utilize actual compute instances from different providers.**
 
 ## Overview
+
 This section describes the scenarios in which one might want to add a VM test:
 1. Testing existing core Istio features such as traffic management, security, telemetry, etc. for **VMs**
 2. Supporting new OS images for VMs
 3. Testing onboarding tools (iptables, certs, istio-sidecar, etc.) and workflows (services, DNS, etc.) to enmesh a VM
 
 ## Secenario 1: Testing VM-related Istio Code
-To test VMs' connectivity, security and telemetry, we deploy a regular Echo instance as VM. A VM
-Echo instance will simulate a VM, disabling kube-dns, Service Account mount, etc. For more information 
-around VM onboarding, refer this [doc](https://istio.io/latest/docs/examples/virtual-machines/single-network/). 
 
+We normally test Istio using Echo application. To test VMs' connectivity, security and telemetry,
+we deploy a regular Echo instance as VM. A VM Echo instance will simulate a VM, disabling kube-dns,
+Service Account mount, etc. For more information around VM onboarding,
+refer to this [doc](https://istio.io/latest/docs/examples/virtual-machines/single-network/).
 
-To deploy an echo instance as a VM 
-1. Set the port for the VMs. Note that due to a bug in WorkloadEntry, 
+To deploy an echo instance as a VM
+1. Set the ports for the VMs. Note that due to a bug in WorkloadEntry,
 we need to set the ServicePort to be the same as the InstancePort
 2. Set `DeployAsVm` to be true in `echo.Config`
-3. Set `VMImage` to be any image available from `GetSupportedOSVersion` in [util.go](https://github.com/istio/istio/blob/master/tests/integration/pilot/vm/util.go). 
+3. Set `VMImage` to be any image available from `GetSupportedOSVersion` in [util.go](https://github.com/istio/istio/blob/master/tests/integration/pilot/vm/util.go).
 
 For example,
 
@@ -59,26 +61,28 @@ We list the supported OSes in [util.go](https://github.com/istio/istio/blob/mast
 and the images will be created in [prow/lib.sh](https://github.com/istio/istio/blob/master/prow/lib.sh).
 
 To add additional supported images for testing:
-1. Modify [tools/istio-docker.mk](https://github.com/istio/istio/blob/master/tools/istio-docker.mk) to add more 
+1. Modify [tools/istio-docker.mk](https://github.com/istio/istio/blob/master/tools/istio-docker.mk) to add more
 build targets. See other build targets for references. Basically, one needs to specify the OS image name and version,
-and pass it to the Dockerfile. 
-2. Modify `prow/lib.sh` by adding images to the targets so that the image could be built on fly for CI/CD. 
-3. (Optional) Modify the `DefaultVMImage` in `util.go` in case the default supported image changes.
+and pass it to the Dockerfile.
+2. Modify `prow/lib.sh` by adding images to the targets so that the image could be built on fly for CI/CD.
+3. Add the images to `util.go` to be tested in PostSubmit jobs.
+4. (Optional) Modify the `DefaultVMImage` in `util.go` in case the default supported image changes.
 
 **Note: We will only build `ubuntu:bionic` (default) for pre-submit jobs and build all others for post-submit jobs
-to save time in CI/CD. If you are writing a test that would need multiple images, the test 
-needs to be labeled as `PostSubmit`, or it will fail since the images other than default won't be built 
+to save time in CI/CD. If you are writing a test that would need multiple images, the test
+needs to be labeled as `PostSubmit`, or it will fail since the images other than default won't be built
 in pre-submit jobs.**
 
 ## Scenario 3: Testing VM Onboarding & Enmeshing
+
 Detailed steps to onboard a VM could be found in this [documentation](https://istio.io/latest/docs/examples/virtual-machines/single-network/) for the VM onboarding process.
 
 In a nutshell, steps for the VM to participate in the mesh involves:
-1. Install the certificates 
+1. Install the certificates
 2. Edit `/etc/hosts` for the VM to know the IP addresss of `Istiod`
 3. Start the istio-sidecar.deb file
 4. Generate workload entries for the VM
 
-Currently, these steps are pre-configured and built in the deployment. However, each of them could be tested 
-by tweaking the [VM deployment template](https://github.com/istio/istio/blob/master/pkg/test/framework/components/echo/kube/deployment.go#L193). 
+Currently, these steps are pre-configured and built in the deployment. However, each of them could be tested
+by tweaking the [VM deployment template](https://github.com/istio/istio/blob/master/pkg/test/framework/components/echo/kube/deployment.go#L193).
 

--- a/tests/integration/pilot/vm/README.md
+++ b/tests/integration/pilot/vm/README.md
@@ -1,0 +1,52 @@
+
+# Writing Tests for VMs
+
+This README serves as a documentation for those who would continue writing and extending tests for VMs.
+**Note: We currently use mock/simulated VMs for testing purposes. In the future, the testing might switch
+to utilize actual compute instances from different providers.**
+
+## Deploy an echo instance as a VM
+
+In most cases, deploying an echo instance as a VM is as simple as setting `DeployAsVm` to be true in `echo.Config`
+and `VMImage` to be any image available from `GetSupportedOSVersion`. For example,
+```
+ports := []echo.Port{
+   {
+       Name:     "http",
+       Protocol: protocol.HTTP,
+       // Due to a bug in WorkloadEntry, service port must equal target port for now
+       InstancePort: 8090,
+       ServicePort:  8090,
+   },
+}
+echo.Config{
+   Service:    "vm",
+   Namespace:  "virtual-machine",
+   Ports:      ports,
+   Pilot:      p,
+   DeployAsVM: true,
+   VMImage:    "app_sidecar_ubuntu_bionic"
+}
+```
+Note that due to a bug in WorkloadEntry, we need to set the ServicePort to be the same as the InstancePort, as shown in
+the comments. To make it easier in most cases, we have a const variable called `DefaultVMImage` to help maintenance
+and reference. More utility functions and variables could be added to the util file. Currently, we set `DefaultVMImage`
+to be `ubuntu:bionic`, but it is subject to change. If `VMImage` is not
+provided while `DeployAsVM` is on, it will default the Docker image to be `DefaultVMImage`. For pre-submit jobs, the
+only image available would be `ubuntu:bionic`, and all other images would be built in post-submit jobs. More information
+could be found in the next section.
+
+## Adding Docker images
+Current, we test the VMs with `ubuntu:xenial`, `ubuntu:bionic`, `ubuntu:focal`, `debian:9` and `debian:10`. The images
+will be created from [prow/lib.sh](https://github.com/istio/istio/blob/master/prow/lib.sh). We will only build
+`ubuntu:bionic` for pre-submit jobs and build all others for post-submit jobs only to save time for CI/CD. To add more
+images for testing, simply modify [tools/istio-docker.mk](https://github.com/istio/istio/blob/master/tools/istio-docker.mk)
+to add more targets. `prow/lib.sh` would have to be updated as well to build the images in prow. If you are writing
+a test that would need multiple images, the test needs to be labeled as `PostSubmit`, or it will fail since the
+images won't be built in pre-submit jobs.
+
+## DNS Resolution
+Currently, VMs resolving DNS does not happen automatically. During the build stage of the Docker images, we manually
+edit the `/etc/hosts` for the VMs to send requests to the pods in the cluster as shown [here](https://github.com/istio/istio/blob/9eff11ae3c6271ee06ee6d4d57a22a33749614a4/pkg/test/framework/components/echo/kube/deployment.go#L233-L234).
+Until we have a better way of resolving DNS, this remains a workaround for the VMs to connect to the cluster and `Istiod`.
+

--- a/tests/integration/pilot/vm/README.md
+++ b/tests/integration/pilot/vm/README.md
@@ -7,10 +7,25 @@ The primary goals are to test VM-related code & ensure it works on a range of su
 **Note: We currently use mock/simulated VMs for testing purposes. In the future, the testing might switch
 to utilize actual compute instances from different providers.**
 
-## Deploy an Echo Instance as a VM
+## Overview
+This section describes the scenarios in which one might want to add a VM test:
+1. Testing existing core Istio features such as traffic management, security, telemetry, etc. for **VMs**
+2. Supporting new OS images for VMs
+3. Testing onboarding tools (iptables, certs, istio-sidecar, etc.) and workflows (services, DNS, etc.) to enmesh a VM
 
-To deploy an echo instance as a VM just set `DeployAsVm` to be true in `echo.Config`
-and `VMImage` to be any image available from `GetSupportedOSVersion`. For example,
+## Secenario 1: Testing VM-related Istio Code
+To test VMs' connectivity, security and telemetry, we deploy a regular Echo instance as VM. A VM
+Echo instance will simulate a VM, disabling kube-dns, Service Account mount, etc. For more information 
+around VM onboarding, refer this [doc](https://istio.io/latest/docs/examples/virtual-machines/single-network/). 
+
+
+To deploy an echo instance as a VM 
+1. Set the port for the VMs. Note that due to a bug in WorkloadEntry, 
+we need to set the ServicePort to be the same as the InstancePort
+2. Set `DeployAsVm` to be true in `echo.Config`
+3. Set `VMImage` to be any image available from `GetSupportedOSVersion` in [util.go](https://github.com/istio/istio/blob/master/tests/integration/pilot/vm/util.go). 
+
+For example,
 
 ```go
 ports := []echo.Port{
@@ -32,27 +47,38 @@ echo.Config{
 }
 ```
 
-Note that due to a bug in WorkloadEntry, we need to set the ServicePort to be the same as the InstancePort, as shown in
-the comments. There is a default image and one could reference it with `DefaultVMImage` so that it's easier to maintain
-if the supported OSes were to change. We have [additional images](https://github.com/istio/istio/blob/d89c6a624cfd0962e2ed25238ec671baebda0ca5/tests/integration/pilot/vm/util.go#L23)
+There is a default image and one could reference it with `DefaultVMImage` so that it's easier to maintain
+if the supported OSes were to change. We have [additional images](https://github.com/istio/istio/blob/master/tests/integration/pilot/vm/util.go)
 that are built in the post-submit jobs, jobs that only run after a PR is merged.
 Info regarding adding extra images could be found in the next section.
 If `VMImage` is not provided while `DeployAsVM` is on, it will default the Docker image to be `DefaultVMImage`.
 
-## Adding Docker Images
+## Scenario 2: Supporting More OS Images
 
-We list the supported OSes in [util.go](https://github.com/istio/istio/blob/d89c6a624cfd0962e2ed25238ec671baebda0ca5/tests/integration/pilot/vm/util.go#L23)
+We list the supported OSes in [util.go](https://github.com/istio/istio/blob/master/tests/integration/pilot/vm/util.go)
 and the images will be created in [prow/lib.sh](https://github.com/istio/istio/blob/master/prow/lib.sh).
-We will only build `ubuntu:bionic` for pre-submit jobs and build all others for post-submit jobs only to save time for CI/CD.
-To add more images for testing, simply modify [tools/istio-docker.mk](https://github.com/istio/istio/blob/master/tools/istio-docker.mk)
-to add more targets. `prow/lib.sh` would have to be updated as well to build the images on the fly in prow.
-If you are writing a test that would need multiple images, the test needs to be labeled as `PostSubmit`, or it
-will fail since the images other than default won't be built in pre-submit jobs.
 
-## VM Deployment
+To add additional supported images for testing:
+1. Modify [tools/istio-docker.mk](https://github.com/istio/istio/blob/master/tools/istio-docker.mk) to add more 
+build targets. See other build targets for references. Basically, one needs to specify the OS image name and version,
+and pass it to the Dockerfile. 
+2. Modify `prow/lib.sh` by adding images to the targets so that the image could be built on fly for CI/CD. 
+3. (Optional) Modify the `DefaultVMImage` in `util.go` in case the default supported image changes.
 
-The deployment of VM involves steps from the [documentation](https://istio.io/latest/docs/examples/virtual-machines/single-network/) for the VM onboarding process.
-We need to specify the IP address of the `Istiod` so that the VM could form a connection to Istio.
-During the deployment of the Docker images, we would also manually edit the `/etc/hosts` for the VMs to send requests to the
-pods in the cluster, as shown [here](https://github.com/istio/istio/blob/9eff11ae3c6271ee06ee6d4d57a22a33749614a4/pkg/test/framework/components/echo/kube/deployment.go#L233-L234).
-Test cases that require the VM to send requests to other pods would have to add additional lines to the hosts.
+**Note: We will only build `ubuntu:bionic` (default) for pre-submit jobs and build all others for post-submit jobs
+to save time in CI/CD. If you are writing a test that would need multiple images, the test 
+needs to be labeled as `PostSubmit`, or it will fail since the images other than default won't be built 
+in pre-submit jobs.**
+
+## Scenario 3: Testing VM Onboarding & Enmeshing
+Detailed steps to onboard a VM could be found in this [documentation](https://istio.io/latest/docs/examples/virtual-machines/single-network/) for the VM onboarding process.
+
+In a nutshell, steps for the VM to participate in the mesh involves:
+1. Install the certificates 
+2. Edit `/etc/hosts` for the VM to know the IP addresss of `Istiod`
+3. Start the istio-sidecar.deb file
+4. Generate workload entries for the VM
+
+Currently, these steps are pre-configured and built in the deployment. However, each of them could be tested 
+by tweaking the [VM deployment template](https://github.com/istio/istio/blob/master/pkg/test/framework/components/echo/kube/deployment.go#L193). 
+

--- a/tests/integration/pilot/vm/README.md
+++ b/tests/integration/pilot/vm/README.md
@@ -12,7 +12,7 @@ to utilize actual compute instances from different providers.**
 To deploy an echo instance as a VM just set `DeployAsVm` to be true in `echo.Config`
 and `VMImage` to be any image available from `GetSupportedOSVersion`. For example,
 
-```
+```go
 ports := []echo.Port{
    {
        Name:     "http",

--- a/tests/integration/pilot/vm/README.md
+++ b/tests/integration/pilot/vm/README.md
@@ -45,17 +45,17 @@ echo.Config{
    Ports:      ports,
    Pilot:      p,
    DeployAsVM: true,
-   VMImage:    "app_sidecar_ubuntu_bionic"
+   VMImage:    vm.DefaultVMImage
 }
 ```
 
-The default image referenced with `DefaultVMImage` should be used in most cases. If you want to use additional images
-please reference [next section](#add_more_images).
-We have [additional images](https://github.com/istio/istio/blob/master/tests/integration/pilot/vm/util.go)
-that are built in the post-submit jobs.
+The default image referenced with `DefaultVMImage` from `vm` package should be used in all pre-submit tests since
+only the default image would be built in pre-submit stage. Using additional images are only possible in
+post-submit stage as shown in the [next section](#add_more_images).
+A complete list of supported additional images can be found in [`util.go`](https://github.com/istio/istio/blob/master/tests/integration/pilot/vm/util.go).
 If `VMImage` is not provided while `DeployAsVM` is on, it will default the Docker image to be `DefaultVMImage`.
 
-## <a id="add_more_images">Scenario 2: Supporting More OS Images</a>
+## <a id="add_more_images">Scenario 2: Supporting Additional OS Images</a>
 
 We list the supported OSes in [util.go](https://github.com/istio/istio/blob/master/tests/integration/pilot/vm/util.go)
 and the images will be created in [prow/lib.sh](https://github.com/istio/istio/blob/master/prow/lib.sh).
@@ -75,7 +75,7 @@ to save time in CI/CD.**
 
 ## Scenario 3: Testing VM Onboarding & Enmeshing
 
-Detailed steps to onboard a VM could be found in this [documentation](https://istio.io/latest/docs/examples/virtual-machines/single-network/) for the VM onboarding process.
+Detailed steps to onboard a VM could be found in [VM onboarding documentation](https://istio.io/latest/docs/examples/virtual-machines/single-network/).
 
 Currently, these steps are pre-configured and built in the deployment. However, each of them could be tested
 by tweaking the [VM deployment template](https://github.com/istio/istio/blob/master/pkg/test/framework/components/echo/kube/deployment.go#L193).

--- a/tests/integration/pilot/vm/README.md
+++ b/tests/integration/pilot/vm/README.md
@@ -1,15 +1,16 @@
 # Writing Tests for VMs
 
-Support for including VMs in the integration tests has been added to the framework.
 This document describes the integration and extension mechanisms to exercise VM related code.
-The primary goals are to test VM-related code & ensure it works on a range of supported OS types and versions.
+The primary goals are to:
+1. Test VM-related Istio code so that newly submitted commits won't break VM support
+1. Ensure the code works on a range of supported OS types and versions.
 
 **Note: We currently use mock/simulated VMs for testing purposes. In the future, the testing might switch
 to utilize actual compute instances from different providers.**
 
 ## Overview
 
-This section describes the scenarios in which one might want to add a VM test:
+Scenarios in which one might want to add a VM test in this doc:
 1. Testing existing core Istio features such as traffic management, security, telemetry, etc. for **VMs**
 1. Supporting new OS images for VMs
 1. Testing onboarding tools (iptables, certs, istio-sidecar, etc.) and workflows (services, DNS, etc.) to enmesh a VM
@@ -50,11 +51,11 @@ echo.Config{
 
 The default image referenced with `DefaultVMImage` from `vm` package should be used for all pre-submit tests since
 this is the only image available in the pre-submit stage. Using additional images are only possible in
-post-submit tests as shown in the [next section](#add_more_images).
+post-submit tests as shown in the [next section](#scenario-2-supporting-additional-os-images ).
 A complete list of supported additional images can be found in [`util.go`](https://github.com/istio/istio/blob/master/tests/integration/pilot/vm/util.go).
 If `VMImage` is not provided while `DeployAsVM` is on, it will default the Docker image to be `DefaultVMImage`.
 
-## <a id="add_more_images">Scenario 2: Supporting Additional OS Images</a>
+## Scenario 2: Supporting Additional OS Images
 
 We list the supported OSes in [util.go](https://github.com/istio/istio/blob/master/tests/integration/pilot/vm/util.go)
 and the images will be created in [prow/lib.sh](https://github.com/istio/istio/blob/master/prow/lib.sh).

--- a/tests/integration/pilot/vm/README.md
+++ b/tests/integration/pilot/vm/README.md
@@ -16,8 +16,8 @@ This section describes the scenarios in which one might want to add a VM test:
 
 ## Secenario 1: Testing VM-related Istio Code
 
-Most integration tests in Istio use the Echo application. To test connectivity, security and telemetry for a VM 
-in the mesh, we deploy an instance of the Echo application as a VM resource. A VM Echo instance will simulate a VM, 
+Most integration tests in Istio use the Echo application. To test connectivity, security and telemetry for a VM
+in the mesh, we deploy an instance of the Echo application as a VM resource. A VM Echo instance will simulate a VM,
 disabling kube-dns, Service Account mount, etc. For more information around VM onboarding,
 refer to this [doc](https://istio.io/latest/docs/examples/virtual-machines/single-network/).
 
@@ -50,7 +50,7 @@ echo.Config{
 ```
 
 The default image referenced with `DefaultVMImage` should be used in most cases. If you want to use additional images
-please reference [next section](#add_more_images). 
+please reference [next section](#add_more_images).
 We have [additional images](https://github.com/istio/istio/blob/master/tests/integration/pilot/vm/util.go)
 that are built in the post-submit jobs.
 If `VMImage` is not provided while `DeployAsVM` is on, it will default the Docker image to be `DefaultVMImage`.
@@ -62,7 +62,7 @@ and the images will be created in [prow/lib.sh](https://github.com/istio/istio/b
 
 To add additional supported images for testing:
 1. Modify [tools/istio-docker.mk](https://github.com/istio/istio/blob/master/tools/istio-docker.mk) to add more
-build targets. Specify the OS image name and version in the Makefile, and it will be passed to the Dockerfile. 
+build targets. Specify the OS image name and version in the Makefile, and it will be passed to the Dockerfile.
 See other build targets for references.
 1. Modify `prow/lib.sh` by adding images to the targets to build images for CI/CD.
 1. Add the images to `util.go` to be tested in PostSubmit jobs.

--- a/tests/integration/pilot/vm/README.md
+++ b/tests/integration/pilot/vm/README.md
@@ -22,10 +22,10 @@ disabling kube-dns, Service Account mount, etc. For more information around VM o
 refer to this [doc](https://istio.io/latest/docs/examples/virtual-machines/single-network/).
 
 To deploy an echo instance as a VM
-1. Set the ports for the VMs. Note that due to a bug in WorkloadEntry,
-we need to set the ServicePort to be the same as the InstancePort
-1. Set `DeployAsVm` to be true in `echo.Config`
+1. Set the ports for the VMs.
+1. Set `DeployAsVm` to be true in `echo.Config`.
 1. Set `VMImage` to be any image available from `GetSupportedOSVersion` in [util.go](https://github.com/istio/istio/blob/master/tests/integration/pilot/vm/util.go).
+We used DefaultVMImage in the example.
 
 For example,
 
@@ -34,7 +34,6 @@ ports := []echo.Port{
    {
        Name:     "http",
        Protocol: protocol.HTTP,
-       // Due to a bug in WorkloadEntry, service port must equal target port for now
        InstancePort: 8090,
        ServicePort:  8090,
    },
@@ -49,9 +48,9 @@ echo.Config{
 }
 ```
 
-The default image referenced with `DefaultVMImage` from `vm` package should be used in all pre-submit tests since
-only the default image would be built in pre-submit stage. Using additional images are only possible in
-post-submit stage as shown in the [next section](#add_more_images).
+The default image referenced with `DefaultVMImage` from `vm` package should be used for all pre-submit tests since
+this is the only image available in the pre-submit stage. Using additional images are only possible in
+post-submit tests as shown in the [next section](#add_more_images).
 A complete list of supported additional images can be found in [`util.go`](https://github.com/istio/istio/blob/master/tests/integration/pilot/vm/util.go).
 If `VMImage` is not provided while `DeployAsVM` is on, it will default the Docker image to be `DefaultVMImage`.
 
@@ -70,8 +69,6 @@ See other build targets for references.
 
 **Note: We will only build default image for pre-submit jobs and build all others for post-submit jobs
 to save time in CI/CD.**
-
-**Pre-submit tests only support the default image. If additional images are needed please run as a post-submit jobs.**
 
 ## Scenario 3: Testing VM Onboarding & Enmeshing
 

--- a/tests/integration/pilot/vm/README.md
+++ b/tests/integration/pilot/vm/README.md
@@ -11,21 +11,21 @@ to utilize actual compute instances from different providers.**
 
 This section describes the scenarios in which one might want to add a VM test:
 1. Testing existing core Istio features such as traffic management, security, telemetry, etc. for **VMs**
-2. Supporting new OS images for VMs
-3. Testing onboarding tools (iptables, certs, istio-sidecar, etc.) and workflows (services, DNS, etc.) to enmesh a VM
+1. Supporting new OS images for VMs
+1. Testing onboarding tools (iptables, certs, istio-sidecar, etc.) and workflows (services, DNS, etc.) to enmesh a VM
 
 ## Secenario 1: Testing VM-related Istio Code
 
-We normally test Istio using Echo application. To test VMs' connectivity, security and telemetry,
-we deploy a regular Echo instance as VM. A VM Echo instance will simulate a VM, disabling kube-dns,
-Service Account mount, etc. For more information around VM onboarding,
+Most integration tests in Istio use the Echo application. To test connectivity, security and telemetry for a VM 
+in the mesh, we deploy an instance of the Echo application as a VM resource. A VM Echo instance will simulate a VM, 
+disabling kube-dns, Service Account mount, etc. For more information around VM onboarding,
 refer to this [doc](https://istio.io/latest/docs/examples/virtual-machines/single-network/).
 
 To deploy an echo instance as a VM
 1. Set the ports for the VMs. Note that due to a bug in WorkloadEntry,
 we need to set the ServicePort to be the same as the InstancePort
-2. Set `DeployAsVm` to be true in `echo.Config`
-3. Set `VMImage` to be any image available from `GetSupportedOSVersion` in [util.go](https://github.com/istio/istio/blob/master/tests/integration/pilot/vm/util.go).
+1. Set `DeployAsVm` to be true in `echo.Config`
+1. Set `VMImage` to be any image available from `GetSupportedOSVersion` in [util.go](https://github.com/istio/istio/blob/master/tests/integration/pilot/vm/util.go).
 
 For example,
 
@@ -49,39 +49,33 @@ echo.Config{
 }
 ```
 
-There is a default image and one could reference it with `DefaultVMImage` so that it's easier to maintain
-if the supported OSes were to change. We have [additional images](https://github.com/istio/istio/blob/master/tests/integration/pilot/vm/util.go)
-that are built in the post-submit jobs, jobs that only run after a PR is merged.
-Info regarding adding extra images could be found in the next section.
+The default image referenced with `DefaultVMImage` should be used in most cases. If you want to use additional images
+please reference [next section](#add_more_images). 
+We have [additional images](https://github.com/istio/istio/blob/master/tests/integration/pilot/vm/util.go)
+that are built in the post-submit jobs.
 If `VMImage` is not provided while `DeployAsVM` is on, it will default the Docker image to be `DefaultVMImage`.
 
-## Scenario 2: Supporting More OS Images
+## <a id="add_more_images">Scenario 2: Supporting More OS Images</a>
 
 We list the supported OSes in [util.go](https://github.com/istio/istio/blob/master/tests/integration/pilot/vm/util.go)
 and the images will be created in [prow/lib.sh](https://github.com/istio/istio/blob/master/prow/lib.sh).
 
 To add additional supported images for testing:
 1. Modify [tools/istio-docker.mk](https://github.com/istio/istio/blob/master/tools/istio-docker.mk) to add more
-build targets. See other build targets for references. Basically, one needs to specify the OS image name and version,
-and pass it to the Dockerfile.
-2. Modify `prow/lib.sh` by adding images to the targets so that the image could be built on fly for CI/CD.
-3. Add the images to `util.go` to be tested in PostSubmit jobs.
-4. (Optional) Modify the `DefaultVMImage` in `util.go` in case the default supported image changes.
+build targets. Specify the OS image name and version in the Makefile, and it will be passed to the Dockerfile. 
+See other build targets for references.
+1. Modify `prow/lib.sh` by adding images to the targets to build images for CI/CD.
+1. Add the images to `util.go` to be tested in PostSubmit jobs.
+1. (Optional) Modify the `DefaultVMImage` in `util.go` in case the default supported image changes.
 
-**Note: We will only build `ubuntu:bionic` (default) for pre-submit jobs and build all others for post-submit jobs
-to save time in CI/CD. If you are writing a test that would need multiple images, the test
-needs to be labeled as `PostSubmit`, or it will fail since the images other than default won't be built
-in pre-submit jobs.**
+**Note: We will only build default image for pre-submit jobs and build all others for post-submit jobs
+to save time in CI/CD.**
+
+**Pre-submit tests only support the default image. If additional images are needed please run as a post-submit jobs.**
 
 ## Scenario 3: Testing VM Onboarding & Enmeshing
 
 Detailed steps to onboard a VM could be found in this [documentation](https://istio.io/latest/docs/examples/virtual-machines/single-network/) for the VM onboarding process.
-
-In a nutshell, steps for the VM to participate in the mesh involves:
-1. Install the certificates
-2. Edit `/etc/hosts` for the VM to know the IP addresss of `Istiod`
-3. Start the istio-sidecar.deb file
-4. Generate workload entries for the VM
 
 Currently, these steps are pre-configured and built in the deployment. However, each of them could be tested
 by tweaking the [VM deployment template](https://github.com/istio/istio/blob/master/pkg/test/framework/components/echo/kube/deployment.go#L193).


### PR DESCRIPTION
This adds the first README.md to the VM testing for others who would like to continue writing and extending VM tests.
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
