### PR TITLE
Improvements to XDS benchmarks

### DIFF
--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -257,7 +257,16 @@ func routesFromListeners(ll []*listener.Listener) []string {
 
 var testCases = []ConfigInput{
 	{
+		// Gateways provides an example config for a large Ingress deployment. This will create N
+		// virtual services and gateways, where routing is determined by hostname, meaning we generate N routes for HTTPS.
 		Name:      "gateways",
+		Services:  1000,
+		ProxyType: model.Router,
+	},
+	{
+		// Gateways-shared provides an example config for a large Ingress deployment. This will create N
+		// virtual services and gateways, where routing is determined by path. This means there will be a single large route.
+		Name:      "gateways-shared",
 		Services:  1000,
 		ProxyType: model.Router,
 	},

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -188,6 +188,7 @@ func setupTest(t testing.TB, config ConfigInput) (*model.Environment, core.Confi
 			Labels: map[string]string{
 				"istio.io/benchmark": "true",
 			},
+			IstioVersion: "1.6.0",
 		},
 		// TODO: if you update this, make sure telemetry.yaml is also updated
 		IstioVersion:    &model.IstioVersion{Major: 1, Minor: 6},

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -17,30 +17,27 @@ package xds
 import (
 	"bytes"
 	"fmt"
-	"html/template"
-	"net"
 	"path"
 	"testing"
+	"text/template"
 	"time"
 
+	"github.com/Masterminds/sprig"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-
-	"istio.io/istio/pilot/pkg/config/kube/crd"
-	v2 "istio.io/istio/pilot/pkg/xds/v2"
-	"istio.io/istio/pkg/test"
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
+	"istio.io/pkg/env"
 
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/golang/protobuf/ptypes"
 
-	"istio.io/istio/pilot/pkg/networking/plugin"
-	"istio.io/istio/pilot/pkg/serviceregistry/mock"
-	"istio.io/istio/pkg/config/host"
-	"istio.io/istio/pkg/config/protocol"
-
+	"istio.io/istio/pilot/pkg/config/kube/crd"
 	"istio.io/istio/pilot/pkg/networking/core"
+	"istio.io/istio/pilot/pkg/networking/plugin"
+	v2 "istio.io/istio/pilot/pkg/xds/v2"
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/pkg/log"
@@ -49,7 +46,6 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/loadbalancer"
 	"istio.io/istio/pilot/pkg/networking/util"
-	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
@@ -72,12 +68,7 @@ func SetupDiscoveryServer(t testing.TB, cfgs ...model.Config) *DiscoveryServer {
 	serviceControllers := aggregate.NewController()
 	serviceEntryStore := serviceentry.NewServiceDiscovery(configController, istioConfigStore, s)
 	go configController.Run(make(chan struct{}))
-	serviceEntryRegistry := serviceregistry.Simple{
-		ProviderID:       "External",
-		Controller:       serviceEntryStore,
-		ServiceDiscovery: serviceEntryStore,
-	}
-	serviceControllers.AddRegistry(serviceEntryRegistry)
+	serviceControllers.AddRegistry(serviceEntryStore)
 
 	env.IstioConfigStore = istioConfigStore
 	env.ServiceDiscovery = serviceControllers
@@ -123,59 +114,24 @@ func createEndpoints(numEndpoints int, numServices int) []model.Config {
 	return result
 }
 
-func getNextIP(current string) string {
-	i := net.ParseIP(current).To4()
-	v := uint(i[0])<<24 + uint(i[1])<<16 + uint(i[2])<<8 + uint(i[3])
-	v++
-	v3 := byte(v & 0xFF)
-	v2 := byte((v >> 8) & 0xFF)
-	v1 := byte((v >> 16) & 0xFF)
-	v0 := byte((v >> 24) & 0xFF)
-	ret := net.IPv4(v0, v1, v2, v3)
-	return ret.String()
-}
-
-func buildTestEnv(t test.Failer, cfg []model.Config, input ConfigInput) model.Environment {
-	svcs := map[host.Name]*model.Service{}
-	ip := "1.1.1.1"
-	for _, svc := range input.Services {
-		hn := host.Name(svc)
-		s := &model.Service{
-			Ports: []*model.Port{{
-				Name:     "http",
-				Port:     80,
-				Protocol: protocol.HTTP,
-			}, {
-				Name:     "tcp",
-				Port:     81,
-				Protocol: protocol.TCP,
-			}, {
-				Name:     "https",
-				Port:     443,
-				Protocol: protocol.HTTPS,
-			}, {
-				Name:     "auto",
-				Port:     83,
-				Protocol: protocol.Unsupported,
-			}},
-			Hostname: hn,
-			Address:  ip,
-		}
-		svcs[hn] = s
-		ip = getNextIP(ip)
-	}
-	serviceDiscovery := mock.NewDiscovery(svcs, 1)
-
-	configStore := memory.Make(collections.Pilot)
-	for _, cfg := range cfg {
+func buildTestEnv(t testing.TB, cfgs []model.Config, input ConfigInput) *model.Environment {
+	configStore := memory.MakeWithLedger(collections.Pilot, &model.DisabledLedger{}, true)
+	for _, cfg := range cfgs {
 		if _, err := configStore.Create(cfg); err != nil {
 			t.Fatalf("failed to create config %v: %v", cfg.Name, err)
 		}
-
 	}
 
+	stop := make(chan struct{})
+	t.Cleanup(func() {
+		close(stop)
+	})
+	configController := memory.NewController(configStore)
+	go configController.Run(stop)
+	serviceDiscovery := serviceentry.NewServiceDiscovery(configController, model.MakeIstioStore(configStore), &FakeXdsUpdater{})
+
 	m := mesh.DefaultMeshConfig()
-	env := model.Environment{
+	env := &model.Environment{
 		PushContext:      model.NewPushContext(),
 		ServiceDiscovery: serviceDiscovery,
 		IstioConfigStore: model.MakeIstioStore(configStore),
@@ -185,53 +141,95 @@ func buildTestEnv(t test.Failer, cfg []model.Config, input ConfigInput) model.En
 	return env
 }
 
+type FakeXdsUpdater struct {
+}
+
+func (fx *FakeXdsUpdater) EDSUpdate(_, _ string, _ string, _ []*model.IstioEndpoint) error {
+	return nil
+}
+
+func (fx *FakeXdsUpdater) ConfigUpdate(_ *model.PushRequest) {
+}
+
+func (fx *FakeXdsUpdater) ProxyUpdate(_, _ string) {
+}
+
+func (fx *FakeXdsUpdater) SvcUpdate(_, _ string, _ string, _ model.Event) {
+}
+
 // ConfigInput defines inputs passed to the test config templates
 // This allows tests to do things like create a virtual service for each service, for example
 type ConfigInput struct {
-	// A list of hostname of allservices
-	Services []string
+	// Name of the test
+	Name string
+	// Name of the test config file to use. If not set, <Name> is used
+	ConfigName string
+	// Number of services to make
+	Services int
+	// Type of proxy to generate configs for
+	ProxyType model.NodeType
 }
 
-// Setup test builds a mock test environment.
-// TODO make this configurable with Istio config, different service setups, etc
-func setupTest(t test.Failer, testName string) (model.Environment, core.ConfigGenerator, model.Proxy) {
-	proxy := model.Proxy{
-		Type:        model.SidecarProxy,
+// Setup test builds a mock test environment. Note: push context is not initialized, to be able to benchmark separately
+// most should just call setupAndInitializeTest
+func setupTest(t testing.TB, config ConfigInput) (*model.Environment, core.ConfigGenerator, *model.Proxy) {
+	proxyType := config.ProxyType
+	if proxyType == "" {
+		proxyType = model.SidecarProxy
+	}
+	proxy := &model.Proxy{
+		Type:        proxyType,
 		IPAddresses: []string{"1.1.1.1"},
 		ID:          "v0.default",
 		DNSDomain:   "default.example.org",
 		Metadata: &model.NodeMetadata{
 			Namespace: "not-default",
+			Labels: map[string]string{
+				"istio.io/benchmark": "true",
+			},
 		},
+		// TODO: if you update this, make sure telemetry.yaml is also updated
 		IstioVersion:    &model.IstioVersion{Major: 1, Minor: 6},
 		ConfigNamespace: "not-default",
 	}
 
-	numServices := 100
-	services := []string{}
-	for i := 0; i < numServices; i++ {
-		hn := fmt.Sprintf("service-%d.namespace.svc.cluster.local", i)
-		services = append(services, hn)
+	configName := config.ConfigName
+	if configName == "" {
+		configName = config.Name
 	}
-	tmpl, err := template.ParseFiles(path.Join("testdata", "benchmarks", testName+".yaml"))
-	if err != nil {
-		t.Fatalf("failed to read config: %v", err)
-	}
+	tmpl := template.Must(template.New("").Funcs(sprig.TxtFuncMap()).ParseFiles(path.Join("testdata", "benchmarks", configName+".yaml")))
 	var buf bytes.Buffer
-	input := ConfigInput{Services: services}
-	if err := tmpl.Execute(&buf, input); err != nil {
+	if err := tmpl.ExecuteTemplate(&buf, configName+".yaml", config); err != nil {
 		t.Fatalf("failed to execute template: %v", err)
 	}
 	configs, _, err := crd.ParseInputs(buf.String())
 	if err != nil {
 		t.Fatalf("failed to read config: %v", err)
 	}
+	// setup default namespace if not defined
+	for i, c := range configs {
+		if c.Namespace == "" {
+			c.Namespace = "default"
+		}
+		configs[i] = c
+	}
+	env := buildTestEnv(t, configs, config)
 
-	env := buildTestEnv(t, configs, input)
-	env.PushContext.InitContext(&env, nil, nil)
-	proxy.SetSidecarScope(env.PushContext)
 	configgen := core.NewConfigGenerator([]string{plugin.Authn, plugin.Authz, plugin.Health, plugin.Mixer})
 	return env, configgen, proxy
+}
+
+func setupAndInitializeTest(t testing.TB, config ConfigInput) (*model.Environment, core.ConfigGenerator, *model.Proxy) {
+	env, configggen, proxy := setupTest(t, config)
+	initPushContext(env, proxy)
+	return env, configggen, proxy
+}
+
+func initPushContext(env *model.Environment, proxy *model.Proxy) {
+	env.PushContext.InitContext(env, nil, nil)
+	proxy.SetSidecarScope(env.PushContext)
+	proxy.SetGatewaysForProxy(env.PushContext)
+	proxy.SetServiceInstances(env.ServiceDiscovery)
 }
 
 func routesFromListeners(ll []*listener.Listener) []string {
@@ -256,71 +254,125 @@ func routesFromListeners(ll []*listener.Listener) []string {
 	return routes
 }
 
-var testCases = []string{
-	"empty",
-	"telemetry",
-	"virtualservice",
+var testCases = []ConfigInput{
+	{
+		Name:      "gateways",
+		Services:  1000,
+		ProxyType: model.Router,
+	},
+	{
+		Name:     "empty",
+		Services: 100,
+	},
+	{
+		Name:     "telemetry",
+		Services: 100,
+	},
+	{
+		Name:     "virtualservice",
+		Services: 100,
+	},
+}
+
+var debugGeneration = env.RegisterBoolVar("DEBUG_CONFIG_DUMP", false, "if enabled, print a full config dump of the generated config")
+
+// Add additional debug info for a test
+func logDebug(b *testing.B, m *discovery.DiscoveryResponse) {
+	b.Helper()
+	b.StopTimer()
+
+	if debugGeneration.Get() {
+		s, err := (&jsonpb.Marshaler{Indent: "  "}).MarshalToString(m)
+		if err != nil {
+			b.Fatal(err)
+		}
+		// Cannot use b.Logf, it truncates
+		log.Infof("Generated: %s", s)
+	}
+	bytes, err := proto.Marshal(m)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportMetric(float64(len(bytes))/1000, "kb/msg")
+	b.ReportMetric(float64(len(m.Resources)), "resources/msg")
+	b.StartTimer()
+}
+
+func BenchmarkInitPushContext(b *testing.B) {
+	for _, tt := range testCases {
+		b.Run(tt.Name, func(b *testing.B) {
+			env, _, proxy := setupTest(b, tt)
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				initPushContext(env, proxy)
+			}
+		})
+	}
 }
 
 func BenchmarkRouteGeneration(b *testing.B) {
 	for _, tt := range testCases {
-		b.Run(tt, func(b *testing.B) {
-			env, configgen, proxy := setupTest(b, tt)
+		b.Run(tt.Name, func(b *testing.B) {
+			env, configgen, proxy := setupAndInitializeTest(b, tt)
 			// To determine which routes to generate, first gen listeners once (not part of benchmark) and extract routes
-			l := configgen.BuildListeners(&proxy, env.PushContext)
+			l := configgen.BuildListeners(proxy, env.PushContext)
 			routeNames := routesFromListeners(l)
 			if len(routeNames) == 0 {
-				b.Fatal("Got no route names! ")
+				b.Fatal("Got no route names!")
 			}
 			b.ResetTimer()
 			var response *discovery.DiscoveryResponse
 			for n := 0; n < b.N; n++ {
-				r := configgen.BuildHTTPRoutes(&proxy, env.PushContext, routeNames)
+				r := configgen.BuildHTTPRoutes(proxy, env.PushContext, routeNames)
+				if len(r) == 0 {
+					b.Fatal("Got no routes!")
+				}
 				response = routeDiscoveryResponse(r, "", "", v2.RouteType)
 			}
-			_ = response
+			logDebug(b, response)
 		})
 	}
 }
 
 func BenchmarkClusterGeneration(b *testing.B) {
 	for _, tt := range testCases {
-		b.Run(tt, func(b *testing.B) {
-			env, configgen, proxy := setupTest(b, tt)
+		b.Run(tt.Name, func(b *testing.B) {
+			env, configgen, proxy := setupAndInitializeTest(b, tt)
 			b.ResetTimer()
-			var response interface{}
+			var response *discovery.DiscoveryResponse
 			for n := 0; n < b.N; n++ {
-				c := configgen.BuildClusters(&proxy, env.PushContext)
+				c := configgen.BuildClusters(proxy, env.PushContext)
 				if len(c) == 0 {
-					b.Fatal("Got no clusters! ")
+					b.Fatal("Got no clusters!")
 				}
 				response = cdsDiscoveryResponse(c, "", v3.ClusterType)
 			}
-			_ = response
+			logDebug(b, response)
 		})
 	}
 }
 
 func BenchmarkListenerGeneration(b *testing.B) {
 	for _, tt := range testCases {
-		b.Run(tt, func(b *testing.B) {
-			env, configgen, proxy := setupTest(b, tt)
+		b.Run(tt.Name, func(b *testing.B) {
+			env, configgen, proxy := setupAndInitializeTest(b, tt)
 			b.ResetTimer()
-			var response interface{}
+			var response *discovery.DiscoveryResponse
 			for n := 0; n < b.N; n++ {
-				l := configgen.BuildListeners(&proxy, env.PushContext)
+				l := configgen.BuildListeners(proxy, env.PushContext)
 				if len(l) == 0 {
-					b.Fatal("Got no clusters! ")
+					b.Fatal("Got no listeners!")
 				}
 				response = ldsDiscoveryResponse(l, "", "", v3.ListenerType)
 			}
-			_ = response
+			logDebug(b, response)
 		})
 	}
 }
 
 // BenchmarkEDS measures performance of EDS config generation
 // TODO Add more variables, such as different services
+// TODO make this align more with the other generation tests
 func BenchmarkEndpointGeneration(b *testing.B) {
 	tests := []struct {
 		endpoints int

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
+
 	"istio.io/pkg/env"
 
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
@@ -114,7 +115,7 @@ func createEndpoints(numEndpoints int, numServices int) []model.Config {
 	return result
 }
 
-func buildTestEnv(t testing.TB, cfgs []model.Config, input ConfigInput) *model.Environment {
+func buildTestEnv(t testing.TB, cfgs []model.Config) *model.Environment {
 	configStore := memory.MakeWithLedger(collections.Pilot, &model.DisabledLedger{}, true)
 	for _, cfg := range cfgs {
 		if _, err := configStore.Create(cfg); err != nil {
@@ -183,14 +184,14 @@ func setupTest(t testing.TB, config ConfigInput) (*model.Environment, core.Confi
 		ID:          "v0.default",
 		DNSDomain:   "default.example.org",
 		Metadata: &model.NodeMetadata{
-			Namespace: "not-default",
+			Namespace: "default",
 			Labels: map[string]string{
 				"istio.io/benchmark": "true",
 			},
 		},
 		// TODO: if you update this, make sure telemetry.yaml is also updated
 		IstioVersion:    &model.IstioVersion{Major: 1, Minor: 6},
-		ConfigNamespace: "not-default",
+		ConfigNamespace: "default",
 	}
 
 	configName := config.ConfigName
@@ -213,7 +214,7 @@ func setupTest(t testing.TB, config ConfigInput) (*model.Environment, core.Confi
 		}
 		configs[i] = c
 	}
-	env := buildTestEnv(t, configs, config)
+	env := buildTestEnv(t, configs)
 
 	configgen := core.NewConfigGenerator([]string{plugin.Authn, plugin.Authz, plugin.Health, plugin.Mixer})
 	return env, configgen, proxy

--- a/pilot/pkg/xds/testdata/benchmarks/empty.yaml
+++ b/pilot/pkg/xds/testdata/benchmarks/empty.yaml
@@ -1,0 +1,51 @@
+# Set up a Service associated with our proxy, which will run as 1.1.1.1 IP
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: proxy-service-instance
+spec:
+  hosts:
+  - example.com
+  ports:
+  - number: 80
+    name: http
+    protocol: HTTP
+  - number: 7070
+    name: tcp
+    protocol: TCP
+  - number: 443
+    name: https
+    protocol: HTTPS
+  - number: 9090
+    name: auto
+    protocol: ""
+  resolution: STATIC
+  endpoints:
+  - address: 1.1.1.1
+---
+# Set up .Services number of services. Each will have 4 ports (one for each protocol)
+{{- range $i := until .Services }}
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: service-{{$i}}
+spec:
+  hosts:
+  - random-{{$i}}.host.example
+  ports:
+  - number: 80
+    name: http
+    protocol: HTTP
+  - number: 7070
+    name: tcp
+    protocol: TCP
+  - number: 443
+    name: https
+    protocol: HTTPS
+  - number: 9090
+    name: auto
+  resolution: STATIC
+  endpoints:
+  - address: 1.2.3.4
+---
+{{- end }}

--- a/pilot/pkg/xds/testdata/benchmarks/gateways-shared.yaml
+++ b/pilot/pkg/xds/testdata/benchmarks/gateways-shared.yaml
@@ -19,31 +19,10 @@ spec:
     labels:
       istio.io/benchmark: "true"
 ---
-{{- range $i := until .Services }}
-apiVersion: networking.istio.io/v1alpha3
-kind: VirtualService
-metadata:
-  name: vs-{{$i}}
-  namespace: gateway
-spec:
-  hosts:
-  - random-a-{{$i}}.host.example
-  - random-b-{{$i}}.host.example
-  - random-c-{{$i}}.host.example
-  gateways:
-  - gateway/gateway-{{$i}}
-  http:
-  - match:
-    - uri:
-        prefix: "/route-{{$i}}"
-    route:
-    - destination:
-        host: random-{{$i}}.host.example
----
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
-  name: gateway-{{$i}}
+  name: gateway
   namespace: gateway
 spec:
   selector:
@@ -54,19 +33,50 @@ spec:
       name: http
       protocol: HTTP
     hosts:
-    - random-a-{{$i}}.host.example
-    - random-b-{{$i}}.host.example
-    - random-c-{{$i}}.host.example
+    - random-1.host.example
+    - random-2.host.example
+    - random-3.host.example
   - port:
       number: 443
       name: https
       protocol: HTTPS
     hosts:
-    - random-a-{{$i}}.host.example
-    - random-b-{{$i}}.host.example
-    - random-c-{{$i}}.host.example
+    - random-1.host.example
+    - random-2.host.example
+    - random-3.host.example
     tls:
       mode: ISTIO_MUTUAL
+---
+{{- range $i := until .Services }}
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: vs-{{$i}}
+  namespace: gateway
+spec:
+  hosts:
+  - random-1.host.example
+  - random-2.host.example
+  - random-3.host.example
+  gateways:
+  - gateway/gateway
+  http:
+  - match:
+    - uri:
+        prefix: "/route-a-{{$i}}"
+    - uri:
+        prefix: "/route-b-{{$i}}"
+    - uri:
+        prefix: "/route-c-{{$i}}"
+    - uri:
+        prefix: "/route-d-{{$i}}"
+    - uri:
+        prefix: "/route-e-{{$i}}"
+    - uri:
+        prefix: "/route-f-{{$i}}"
+    route:
+    - destination:
+        host: random-{{$i}}.host.example
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry

--- a/pilot/pkg/xds/testdata/benchmarks/gateways.yaml
+++ b/pilot/pkg/xds/testdata/benchmarks/gateways.yaml
@@ -10,31 +10,57 @@ spec:
   - number: 80
     name: http
     protocol: HTTP
+  - number: 443
+    name: https
+    protocol: HTTPS
   resolution: STATIC
   endpoints:
   - address: 1.1.1.1
+    labels:
+      istio.io/benchmark: "true"
 ---
-# Set up .Services VirtualServices, each pointing to a different Service
 {{- range $i := until .Services }}
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: vs-{{$i}}
+  namespace: gateway
 spec:
   hosts:
-    - random-{{$i}}.host.example
+  - random-{{$i}}.host.example
+  gateways:
+  - gateway/gateway-{{$i}}
   http:
-  - name: "match-route"
-    match:
+  - match:
     - uri:
-        prefix: "/foo"
-    - uri:
-        regex: "/bar"
-    rewrite:
-      uri: "/new-url"
+        prefix: "/route-{{$i}}"
     route:
-      - destination:
-          host: random-{{$i}}.host.example
+    - destination:
+        host: random-{{$i}}.host.example
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: gateway-{{$i}}
+  namespace: gateway
+spec:
+  selector:
+    istio.io/benchmark: "true"
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "random-{{$i}}.host.example"
+  - port:
+      number: 443
+      name: https
+      protocol: HTTPS
+    hosts:
+    - "random-{{$i}}.host.example"
+    tls:
+      mode: ISTIO_MUTUAL
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry

--- a/pilot/pkg/xds/testdata/benchmarks/telemetry.yaml
+++ b/pilot/pkg/xds/testdata/benchmarks/telemetry.yaml
@@ -1,4 +1,54 @@
-
+# Set up a Service associated with our proxy, which will run as 1.1.1.1 IP
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: proxy-service-instance
+spec:
+  hosts:
+  - example.com
+  ports:
+  - number: 80
+    name: http
+    protocol: HTTP
+  - number: 7070
+    name: tcp
+    protocol: TCP
+  - number: 443
+    name: https
+    protocol: HTTPS
+  - number: 9090
+    name: auto
+    protocol: ""
+  resolution: STATIC
+  endpoints:
+  - address: 1.1.1.1
+---
+# Set up .Services number of services. Each will have 4 ports (one for each protocol)
+  {{- range $i := until .Services }}
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: service-{{$i}}
+spec:
+  hosts:
+  - random-{{$i}}.host.example
+  ports:
+  - number: 80
+    name: http
+    protocol: HTTP
+  - number: 7070
+    name: tcp
+    protocol: TCP
+  - number: 443
+    name: https
+    protocol: HTTPS
+  - number: 9090
+    name: auto
+  resolution: STATIC
+  endpoints:
+  - address: 1.2.3.4
+---
+  {{- end }}
 
 
 apiVersion: networking.istio.io/v1alpha3


### PR DESCRIPTION
* Add new test for gateways. This is motivated by
https://github.com/istio/istio/issues/25116
* Make the tests more flexible/explicit. All config is now in the test
files. This does make the test a bit larger, as we define the
Services and service instance in each test, but its more flexible and
explicit so I think its worth it
* Add more debugability. Tests now report the XDS size(in bytes and # of
resources), and with a flag can do a configdump.
* Add a test for push context initialization. This can help us make
decisions about what makes sense to put in push context and what
doesn't, as push context is essentially a cache.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure