### PR TITLE
Don't initialize multiple default sidecars for ns

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -27,6 +27,7 @@ import (
 	"istio.io/pkg/monitoring"
 
 	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pilot/pkg/util/sets"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
@@ -1333,11 +1334,15 @@ func (ps *PushContext) initSidecarScopes(env *Environment) error {
 	// build sidecar scopes for namespaces that do not have a non-workloadSelector sidecar CRD object.
 	// Derive the sidecar scope from the root namespace's sidecar object if present. Else fallback
 	// to the default Istio behavior mimicked by the DefaultSidecarScopeForNamespace function.
+	namespaces := sets.NewSet()
 	for _, nsMap := range ps.ServiceByHostnameAndNamespace {
 		for ns := range nsMap {
-			if _, exist := sidecarsWithoutSelectorByNamespace[ns]; !exist {
-				ps.sidecarsByNamespace[ns] = append(ps.sidecarsByNamespace[ns], ConvertToSidecarScope(ps, rootNSConfig, ns))
-			}
+			namespaces.Insert(ns)
+		}
+	}
+	for ns := range namespaces {
+		if _, exist := sidecarsWithoutSelectorByNamespace[ns]; !exist {
+			ps.sidecarsByNamespace[ns] = append(ps.sidecarsByNamespace[ns], ConvertToSidecarScope(ps, rootNSConfig, ns))
 		}
 	}
 


### PR DESCRIPTION
Currently, we initalize a default sidecar scope for each *service* -
but the scopes only differ by namespace. Instead, we can just create one
per namespace required.
```
name                              old time/op  new time/op
InitPushContext/gateways-8        5.90ms ± 0%  3.17ms ± 0%
InitPushContext/empty-8            268ns ± 0%   245ns ± 0%
InitPushContext/telemetry-8        273ns ± 0%   247ns ± 0%
InitPushContext/virtualservice-8   163ns ± 0%   149ns ± 0%
```
I often see this codepath using a large chunk of Pilot CPU in real world
tests, so I think the change is significant in these cases.

Benchmarking built on https://github.com/istio/istio/pull/25117



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure