### PR TITLE
Drop excessive RBAC permissions

### DIFF
--- a/manifests/charts/base/files/gen-istio-cluster.yaml
+++ b/manifests/charts/base/files/gen-istio-cluster.yaml
@@ -4586,8 +4586,6 @@ metadata:
     release: istio
 ---
 # Source: base/templates/clusterrole.yaml
-# Dedicated cluster role - istiod will use fewer dangerous permissions ( secret access in particular ).
-# TODO: separate cluster role with the minimal set of permissions needed for a 'tenant' Istiod
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -4606,12 +4604,6 @@ rules:
     resources: ["validatingwebhookconfigurations"]
     verbs: ["get", "list", "watch", "update"]
 
-  # permissions to verify the webhook is ready and rejecting
-  # invalid config. We use --server-dry-run so no config is persisted.
-  - apiGroups: ["networking.istio.io"]
-    verbs: ["create"]
-    resources: ["gateways"]
-
   # istio configuration
   - apiGroups: ["config.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io"]
     verbs: ["get", "watch", "list"]
@@ -4623,9 +4615,6 @@ rules:
     verbs: ["get", "list", "watch"]
 
   # discovery and routing
-  - apiGroups: ["extensions","apps"]
-    resources: ["deployments"]
-    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["pods", "nodes", "services", "namespaces", "endpoints"]
     verbs: ["get", "list", "watch"]
@@ -4664,14 +4653,6 @@ rules:
   - apiGroups: ["authentication.k8s.io"]
     resources: ["tokenreviews"]
     verbs: ["create"]
-
-  # TODO: remove, no longer needed at cluster
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["create", "get", "watch", "list", "update", "delete"]
-  - apiGroups: [""]
-    resources: ["serviceaccounts"]
-    verbs: ["get", "watch", "list"]
 
   # Use for Kubernetes Service APIs
   - apiGroups: ["networking.x-k8s.io"]
@@ -4729,6 +4710,56 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
+  name: istiod-istio-system
+subjects:
+  - kind: ServiceAccount
+    name: istiod-service-account
+    namespace: istio-system
+---
+# Source: base/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: istiod-istio-system
+  namespace: istio-system
+  labels:
+    app: istiod
+    release: istio
+rules:
+# permissions to verify the webhook is ready and rejecting
+# invalid config. We use --server-dry-run so no config is persisted.
+- apiGroups: ["networking.istio.io"]
+  verbs: ["create"]
+  resources: ["gateways"]
+
+# Needed for multicluster secret reading
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "watch", "list"]
+
+# For storing CA secret
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames:
+    - "istio-ca-secret"
+  verbs: ["create", "get", "watch", "list", "update", "delete"]
+# Cannot use resource name with create, so split it off
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create"]
+---
+# Source: base/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: istiod-istio-system
+  namespace: istio-system
+  labels:
+    app: pilot
+    release: istio
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
   name: istiod-istio-system
 subjects:
   - kind: ServiceAccount

--- a/manifests/charts/base/files/gen-istio-cluster.yaml
+++ b/manifests/charts/base/files/gen-istio-cluster.yaml
@@ -4740,13 +4740,8 @@ rules:
 # For storing CA secret
 - apiGroups: [""]
   resources: ["secrets"]
-  resourceNames:
-    - "istio-ca-secret"
+  # TODO lock this down to istio-ca-cert if not using the DNS cert mesh config
   verbs: ["create", "get", "watch", "list", "update", "delete"]
-# Cannot use resource name with create, so split it off
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["create"]
 ---
 # Source: base/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/charts/base/templates/clusterrole.yaml
+++ b/manifests/charts/base/templates/clusterrole.yaml
@@ -54,8 +54,9 @@ rules:
     resources: ["*"]
 {{- if .Values.global.istiod.enableAnalysis }}
   - apiGroups: ["config.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io"]
-    verbs: ["get", "watch", "list"]
-    resources: ["*/status"]
+    verbs: ["update"]
+    # TODO: should be on just */status but wildcard is not supported
+    resources: ["*"]
 {{- end }}
 
   # auto-detect installed CRD definitions

--- a/manifests/charts/base/templates/clusterrole.yaml
+++ b/manifests/charts/base/templates/clusterrole.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -22,13 +21,8 @@ rules:
 # For storing CA secret
 - apiGroups: [""]
   resources: ["secrets"]
-  resourceNames:
-    - "istio-ca-secret"
+  # TODO lock this down to istio-ca-cert if not using the DNS cert mesh config
   verbs: ["create", "get", "watch", "list", "update", "delete"]
-# Cannot use resource name with create, so split it off
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/manifests/charts/base/templates/clusterrole.yaml
+++ b/manifests/charts/base/templates/clusterrole.yaml
@@ -1,5 +1,35 @@
-# Dedicated cluster role - istiod will use fewer dangerous permissions ( secret access in particular ).
-# TODO: separate cluster role with the minimal set of permissions needed for a 'tenant' Istiod
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: istiod-{{ .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
+  labels:
+    app: istiod
+    release: {{ .Release.Name }}
+rules:
+# permissions to verify the webhook is ready and rejecting
+# invalid config. We use --server-dry-run so no config is persisted.
+- apiGroups: ["networking.istio.io"]
+  verbs: ["create"]
+  resources: ["gateways"]
+
+# Needed for multicluster secret reading
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "watch", "list"]
+
+# For storing CA secret
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames:
+    - "istio-ca-secret"
+  verbs: ["create", "get", "watch", "list", "update", "delete"]
+# Cannot use resource name with create, so split it off
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create"]
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -18,20 +48,15 @@ rules:
     resources: ["validatingwebhookconfigurations"]
     verbs: ["get", "list", "watch", "update"]
 
-  # permissions to verify the webhook is ready and rejecting
-  # invalid config. We use --server-dry-run so no config is persisted.
-  - apiGroups: ["networking.istio.io"]
-    verbs: ["create"]
-    resources: ["gateways"]
-
   # istio configuration
   - apiGroups: ["config.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io"]
-{{- if .Values.global.istiod.enableAnalysis }}
-    verbs: ["get", "watch", "list", "update"]
-{{- else }}
     verbs: ["get", "watch", "list"]
-{{- end }}
     resources: ["*"]
+{{- if .Values.global.istiod.enableAnalysis }}
+  - apiGroups: ["config.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io"]
+    verbs: ["get", "watch", "list"]
+    resources: ["*/status"]
+{{- end }}
 
   # auto-detect installed CRD definitions
   - apiGroups: ["apiextensions.k8s.io"]
@@ -39,9 +64,6 @@ rules:
     verbs: ["get", "list", "watch"]
 
   # discovery and routing
-  - apiGroups: ["extensions","apps"]
-    resources: ["deployments"]
-    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["pods", "nodes", "services", "namespaces", "endpoints"]
     verbs: ["get", "list", "watch"]
@@ -88,14 +110,6 @@ rules:
   - apiGroups: ["authentication.k8s.io"]
     resources: ["tokenreviews"]
     verbs: ["create"]
-
-  # TODO: remove, no longer needed at cluster
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["create", "get", "watch", "list", "update", "delete"]
-  - apiGroups: [""]
-    resources: ["serviceaccounts"]
-    verbs: ["get", "watch", "list"]
 
   # Use for Kubernetes Service APIs
   - apiGroups: ["networking.x-k8s.io"]

--- a/manifests/charts/base/templates/clusterrolebinding.yaml
+++ b/manifests/charts/base/templates/clusterrolebinding.yaml
@@ -30,3 +30,20 @@ subjects:
     name: istiod-service-account
     namespace: {{ .Values.global.istioNamespace }}
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: istiod-{{ .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
+  labels:
+    app: pilot
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: istiod-{{ .Values.global.istioNamespace }}
+subjects:
+  - kind: ServiceAccount
+    name: istiod-service-account
+    namespace: {{ .Values.global.istioNamespace }}
+---


### PR DESCRIPTION
This splits out some istio-system scoped permissions we need to Roles
rather than ClusterRoles



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure