### PR TITLE
namespace controller: use shared informer

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1000,13 +1000,16 @@ func (s *Server) initNamespaceController(args *PilotArgs) {
 		s.addTerminatingStartFunc(func(stop <-chan struct{}) error {
 			leaderelection.
 				NewLeaderElection(args.Namespace, args.PodName, leaderelection.NamespaceController, s.kubeClients.Kube()).
-				AddRunFunction(func(stop <-chan struct{}) {
+				AddRunFunction(func(leaderStop <-chan struct{}) {
 					log.Infof("Starting namespace controller")
 					nc := kubecontroller.NewNamespaceController(s.fetchCARoot, s.kubeClients)
 					// Start informers again. This fixes the case where informers for namespace do not start,
 					// as we create them only after acquiring the leader lock
+					// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are
+					// basically lazy loading the informer, if we stop it when we lose the lock we will never
+					// recreate it again.
 					s.kubeClients.RunAndWait(stop)
-					nc.Run(stop)
+					nc.Run(leaderStop)
 				}).
 				Run(stop)
 			return nil

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -996,19 +996,19 @@ func (s *Server) initControllers(args *PilotArgs) error {
 
 // initNamespaceController initializes namespace controller to sync config map.
 func (s *Server) initNamespaceController(args *PilotArgs) {
-	if s.CA != nil && s.kubeClients != nil {
+	if s.CA != nil && s.kubeClient != nil {
 		s.addTerminatingStartFunc(func(stop <-chan struct{}) error {
 			leaderelection.
-				NewLeaderElection(args.Namespace, args.PodName, leaderelection.NamespaceController, s.kubeClients.Kube()).
+				NewLeaderElection(args.Namespace, args.PodName, leaderelection.NamespaceController, s.kubeClient.Kube()).
 				AddRunFunction(func(leaderStop <-chan struct{}) {
 					log.Infof("Starting namespace controller")
-					nc := kubecontroller.NewNamespaceController(s.fetchCARoot, s.kubeClients)
+					nc := kubecontroller.NewNamespaceController(s.fetchCARoot, s.kubeClient)
 					// Start informers again. This fixes the case where informers for namespace do not start,
 					// as we create them only after acquiring the leader lock
 					// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are
 					// basically lazy loading the informer, if we stop it when we lose the lock we will never
 					// recreate it again.
-					s.kubeClients.RunAndWait(stop)
+					s.kubeClient.RunAndWait(stop)
 					nc.Run(leaderStop)
 				}).
 				Run(stop)

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -136,7 +136,7 @@ func (m *Multicluster) AddMemberCluster(clients kubelib.Client, clusterID string
 	go kubectl.Run(stopCh)
 	webhookConfigName := strings.ReplaceAll(validationWebhookConfigNameTemplate, validationWebhookConfigNameTemplateVar, m.secretNamespace)
 	if m.fetchCaRoot != nil {
-		nc := NewNamespaceController(m.fetchCaRoot, options, clients.Kube())
+		nc := NewNamespaceController(m.fetchCaRoot, clients)
 		go nc.Run(stopCh)
 		go webhooks.PatchCertLoop(features.InjectionWebhookConfigName.Get(), webhookName, m.caBundlePath, clients.Kube(), stopCh)
 		valicationWebhookController := webhooks.CreateValidationWebhookController(clients.Kube(), clients.Dynamic(), webhookConfigName,

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
@@ -17,22 +17,16 @@ package controller
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/watch"
-	informer "k8s.io/client-go/informers/core/v1"
-	"k8s.io/client-go/kubernetes"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
 
 	"istio.io/pkg/log"
 
-	"istio.io/istio/pkg/listwatch"
+	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/queue"
 	certutil "istio.io/istio/security/pkg/util"
 )
@@ -56,59 +50,42 @@ type NamespaceController struct {
 	getData func() map[string]string
 	client  corev1.CoreV1Interface
 
-	queue queue.Instance
-
-	// Controller and store for namespace objects
-	namespaceController cache.Controller
-	// Controller and store for ConfigMap objects
-	configMapController cache.Controller
+	queue              queue.Instance
+	namespacesInformer cache.SharedInformer
+	configMapInformer  cache.SharedInformer
 }
 
 // NewNamespaceController returns a pointer to a newly constructed NamespaceController instance.
-func NewNamespaceController(data func() map[string]string, options Options, kubeClient kubernetes.Interface) *NamespaceController {
+func NewNamespaceController(data func() map[string]string, kubeClient kube.Client) *NamespaceController {
 	c := &NamespaceController{
 		getData: data,
 		client:  kubeClient.CoreV1(),
 		queue:   queue.NewQueue(time.Second),
 	}
 
-	watchedNamespaceList := strings.Split(options.WatchedNamespaces, ",")
-
-	mlw := listwatch.MultiNamespaceListerWatcher(watchedNamespaceList, func(namespace string) cache.ListerWatcher {
-		return &cache.ListWatch{
-			ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
-				opts.LabelSelector = fields.SelectorFromSet(configMapLabel).String()
-				return kubeClient.CoreV1().ConfigMaps(namespace).List(context.TODO(), opts)
-			},
-			WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-				opts.LabelSelector = fields.SelectorFromSet(configMapLabel).String()
-				return kubeClient.CoreV1().ConfigMaps(namespace).Watch(context.TODO(), opts)
-			},
-		}
-	})
-
-	configmapInformer := cache.NewSharedIndexInformer(mlw, &v1.ConfigMap{}, options.ResyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-
-	configmapInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		UpdateFunc: func(oldObj, newObj interface{}) {
+	c.configMapInformer = kubeClient.KubeInformer().Core().V1().ConfigMaps().Informer()
+	c.configMapInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(_, obj interface{}) {
+			cm, err := convertToConfigMap(obj)
+			if err != nil {
+				log.Errorf("failed to convert to configmap: %v", err)
+			}
+			// This is a change to a configmap we don't watch, ignore it
+			if cm.Name != CACertNamespaceConfigMap {
+				return
+			}
 			c.queue.Push(func() error {
-				return c.configMapChange(newObj)
+				return c.configMapChange(cm)
 			})
 		},
 		DeleteFunc: func(obj interface{}) {
-			cm, ok := obj.(*v1.ConfigMap)
-			if !ok {
-				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-				if !ok {
-					log.Errorf("error decoding object, invalid type")
-					return
-				}
-				cm, ok = tombstone.Obj.(*v1.ConfigMap)
-				if !ok {
-					log.Errorf("error decoding object tombstone, invalid type")
-					return
-				}
+			cm, err := convertToConfigMap(obj)
+			if err != nil {
+				log.Errorf("failed to convert to configmap: %v", err)
+			}
+			// This is a change to a configmap we don't watch, ignore it
+			if cm.Name != CACertNamespaceConfigMap {
+				return
 			}
 			c.queue.Push(func() error {
 				ns, err := kubeClient.CoreV1().Namespaces().Get(context.TODO(), cm.Namespace, metav1.GetOptions{})
@@ -124,31 +101,27 @@ func NewNamespaceController(data func() map[string]string, options Options, kube
 			})
 		},
 	})
-	c.configMapController = configmapInformer
 
-	namespaceInformer := informer.NewNamespaceInformer(kubeClient, options.ResyncPeriod, cache.Indexers{})
-	namespaceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	c.namespacesInformer = kubeClient.KubeInformer().Core().V1().Namespaces().Informer()
+	c.namespacesInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			c.queue.Push(func() error {
-				return c.namespaceChange(obj)
+				return c.namespaceChange(obj.(*v1.Namespace))
 			})
 		},
 		UpdateFunc: func(_, obj interface{}) {
 			c.queue.Push(func() error {
-				return c.namespaceChange(obj)
+				return c.namespaceChange(obj.(*v1.Namespace))
 			})
 		},
 	})
-	c.namespaceController = namespaceInformer
 
 	return c
 }
 
 // Run starts the NamespaceController until a value is sent to stopCh.
 func (nc *NamespaceController) Run(stopCh <-chan struct{}) {
-	go nc.namespaceController.Run(stopCh)
-	go nc.configMapController.Run(stopCh)
-	cache.WaitForCacheSync(stopCh, nc.namespaceController.HasSynced, nc.configMapController.HasSynced)
+	cache.WaitForCacheSync(stopCh, nc.namespacesInformer.HasSynced, nc.configMapInformer.HasSynced)
 	log.Infof("Namespace controller started")
 	go nc.queue.Run(stopCh)
 }
@@ -167,23 +140,32 @@ func (nc *NamespaceController) insertDataForNamespace(ns string) error {
 
 // On namespace change, update the config map.
 // If terminating, this will be skipped
-func (nc *NamespaceController) namespaceChange(obj interface{}) error {
-	ns, ok := obj.(*v1.Namespace)
-
-	if ok && ns.Status.Phase != v1.NamespaceTerminating {
+func (nc *NamespaceController) namespaceChange(ns *v1.Namespace) error {
+	if ns.Status.Phase != v1.NamespaceTerminating {
 		return nc.insertDataForNamespace(ns.Name)
 	}
 	return nil
 }
 
 // When a config map is changed, merge the data into the configmap
-func (nc *NamespaceController) configMapChange(obj interface{}) error {
-	cm, ok := obj.(*v1.ConfigMap)
-
-	if ok {
-		if err := certutil.UpdateDataInConfigMap(nc.client, cm.DeepCopy(), nc.getData()); err != nil {
-			return fmt.Errorf("error when inserting CA cert to configmap %v: %v", cm.Name, err)
-		}
+func (nc *NamespaceController) configMapChange(cm *v1.ConfigMap) error {
+	if err := certutil.UpdateDataInConfigMap(nc.client, cm.DeepCopy(), nc.getData()); err != nil {
+		return fmt.Errorf("error when inserting CA cert to configmap %v: %v", cm.Name, err)
 	}
 	return nil
+}
+
+func convertToConfigMap(obj interface{}) (*v1.ConfigMap, error) {
+	cm, ok := obj.(*v1.ConfigMap)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			return nil, fmt.Errorf("couldn't get object from tombstone %#v", obj)
+		}
+		cm, ok = tombstone.Obj.(*v1.ConfigMap)
+		if !ok {
+			return nil, fmt.Errorf("tombstone contained object that is not a ConfigMap %#v", obj)
+		}
+	}
+	return cm, nil
 }

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
@@ -23,20 +23,22 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes"
 
+	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/security/pkg/util"
 )
 
 func TestNamespaceController(t *testing.T) {
-	client := fake.NewSimpleClientset()
+	client := kube.NewFakeClient()
 	testdata := map[string]string{"key": "value"}
 	nc := NewNamespaceController(func() map[string]string {
 		return testdata
-	}, Options{}, client)
+	}, client)
 
 	stop := make(chan struct{})
+	client.RunAndWait(stop)
 	nc.Run(stop)
 
 	createNamespace(t, client, "foo")
@@ -52,14 +54,14 @@ func TestNamespaceController(t *testing.T) {
 	expectConfigMap(t, client, "foo", testdata)
 }
 
-func deleteConfigMap(t *testing.T, client *fake.Clientset, ns string) {
+func deleteConfigMap(t *testing.T, client kubernetes.Interface, ns string) {
 	t.Helper()
 	if err := client.CoreV1().ConfigMaps(ns).Delete(context.TODO(), CACertNamespaceConfigMap, metav1.DeleteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func createNamespace(t *testing.T, client *fake.Clientset, ns string) {
+func createNamespace(t *testing.T, client kubernetes.Interface, ns string) {
 	t.Helper()
 	if _, err := client.CoreV1().Namespaces().Create(context.TODO(), &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: ns},
@@ -68,7 +70,7 @@ func createNamespace(t *testing.T, client *fake.Clientset, ns string) {
 	}
 }
 
-func expectConfigMap(t *testing.T, client *fake.Clientset, ns string, data map[string]string) {
+func expectConfigMap(t *testing.T, client kubernetes.Interface, ns string, data map[string]string) {
 	t.Helper()
 	retry.UntilSuccessOrFail(t, func() error {
 		cm, err := client.CoreV1().ConfigMaps(ns).Get(context.TODO(), CACertNamespaceConfigMap, metav1.GetOptions{})


### PR DESCRIPTION
This updates the namespace controller to use the new shared informers. This is a perf optimization to minimize the number of watches we open to the api server.

Part of https://github.com/istio/istio/issues/24640