### PR TITLE
ingress controller: use shared informers

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -126,7 +126,6 @@ func (s *Server) initConfigController(args *PilotArgs) error {
 						// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are
 						// basically lazy loading the informer, if we stop it when we lose the lock we will never
 						// recreate it again.
-						log.Errorf("howardjohn: prestart")
 						s.kubeClients.RunAndWait(stop)
 						log.Infof("Starting ingress controller")
 						ingressSyncer.Run(leaderStop)

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/client-go/informers"
 	"k8s.io/client-go/informers/networking/v1beta1"
 
 	"istio.io/pkg/ledger"
@@ -46,6 +45,7 @@ import (
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/resource"
+	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/queue"
 )
 
@@ -85,16 +85,15 @@ type controller struct {
 	meshWatcher  mesh.Holder
 	domainSuffix string
 
-	client                 kubernetes.Interface
 	queue                  queue.Instance
-	ingressInformer        cache.SharedIndexInformer
 	virtualServiceHandlers []func(model.Config, model.Config, model.Event)
 	gatewayHandlers        []func(model.Config, model.Config, model.Event)
+
+	ingressInformer cache.SharedInformer
+	serviceInformer cache.SharedInformer
+	serviceLister   listerv1.ServiceLister
 	// May be nil if ingress class is not supported in the cluster
 	classes v1beta1.IngressClassInformer
-
-	serviceInformer cache.SharedIndexInformer
-	serviceLister   listerv1.ServiceLister
 }
 
 var (
@@ -120,7 +119,7 @@ func ingressClassSupported(client kubernetes.Interface) bool {
 }
 
 // NewController creates a new Kubernetes controller
-func NewController(client kubernetes.Interface, meshWatcher mesh.Holder,
+func NewController(client kube.Client, meshWatcher mesh.Holder,
 	options kubecontroller.Options) model.ConfigStoreCache {
 
 	// queue requires a time duration for a retry delay after a handler error
@@ -130,17 +129,14 @@ func NewController(client kubernetes.Interface, meshWatcher mesh.Holder,
 		ingressNamespace = constants.IstioIngressNamespace
 	}
 
-	sharedInformerFactory := informers.NewSharedInformerFactoryWithOptions(client, options.ResyncPeriod,
-		informers.WithNamespace(options.WatchedNamespaces))
-
-	ingressInformer := sharedInformerFactory.Networking().V1beta1().Ingresses().Informer()
+	ingressInformer := client.KubeInformer().Networking().V1beta1().Ingresses().Informer()
 	log.Infof("Ingress controller watching namespaces %q", options.WatchedNamespaces)
 
-	serviceInformer := sharedInformerFactory.Core().V1().Services()
+	serviceInformer := client.KubeInformer().Core().V1().Services()
 
 	var classes v1beta1.IngressClassInformer
 	if ingressClassSupported(client) {
-		classes = sharedInformerFactory.Networking().V1beta1().IngressClasses()
+		classes = client.KubeInformer().Networking().V1beta1().IngressClasses()
 	} else {
 		log.Infof("Skipping IngressClass, resource not supported")
 	}
@@ -148,7 +144,6 @@ func NewController(client kubernetes.Interface, meshWatcher mesh.Holder,
 	c := &controller{
 		meshWatcher:     meshWatcher,
 		domainSuffix:    options.DomainSuffix,
-		client:          client,
 		queue:           q,
 		ingressInformer: ingressInformer,
 		classes:         classes,

--- a/pilot/pkg/config/kube/ingress/conversion_test.go
+++ b/pilot/pkg/config/kube/ingress/conversion_test.go
@@ -234,10 +234,8 @@ func TestConversion(t *testing.T) {
 	}
 
 	for n, cfg := range cfgs {
-
 		vs := cfg.Spec.(*networking.VirtualService)
 
-		t.Log(vs)
 		if n == "my.host.com" {
 			if vs.Hosts[0] != "my.host.com" {
 				t.Error("Unexpected host", vs)

--- a/pilot/pkg/config/kube/ingress/status.go
+++ b/pilot/pkg/config/kube/ingress/status.go
@@ -25,17 +25,15 @@ import (
 	"k8s.io/api/networking/v1beta1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
+	listerv1 "k8s.io/client-go/listers/core/v1"
+	listerv1beta1 "k8s.io/client-go/listers/networking/v1beta1"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
-	controller2 "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
-	"istio.io/istio/pkg/listwatch"
+	kubelib "istio.io/istio/pkg/kube"
 	queue2 "istio.io/istio/pkg/queue"
 
 	"istio.io/pkg/log"
@@ -55,22 +53,22 @@ type StatusSyncer struct {
 	// Name of service (ingressgateway default) to find the IP
 	ingressService string
 
-	queue    queue2.Instance
-	informer cache.SharedIndexInformer
+	queue         queue2.Instance
+	ingressLister listerv1beta1.IngressLister
+	podLister     listerv1.PodLister
+	serviceLister listerv1.ServiceLister
+	nodeLister    listerv1.NodeLister
 }
 
 // Run the syncer until stopCh is closed
 func (s *StatusSyncer) Run(stopCh <-chan struct{}) {
 	go s.queue.Run(stopCh)
 	go s.runUpdateStatus(stopCh)
-	go s.informer.Run(stopCh)
 	<-stopCh
 }
 
 // NewStatusSyncer creates a new instance
-func NewStatusSyncer(mesh *meshconfig.MeshConfig,
-	client kubernetes.Interface,
-	options controller2.Options) (*StatusSyncer, error) {
+func NewStatusSyncer(mesh *meshconfig.MeshConfig, client kubelib.Client) (*StatusSyncer, error) {
 
 	// we need to use the defined ingress class to allow multiple leaders
 	// in order to update information about ingress status
@@ -79,25 +77,12 @@ func NewStatusSyncer(mesh *meshconfig.MeshConfig,
 	// queue requires a time duration for a retry delay after a handler error
 	queue := queue2.NewQueue(1 * time.Second)
 
-	watchedNamespaceList := strings.Split(options.WatchedNamespaces, ",")
-
-	mlw := listwatch.MultiNamespaceListerWatcher(watchedNamespaceList, func(namespace string) cache.ListerWatcher {
-		return &cache.ListWatch{
-			ListFunc: func(opts metaV1.ListOptions) (runtime.Object, error) {
-				return client.NetworkingV1beta1().Ingresses(namespace).List(context.TODO(), opts)
-			},
-			WatchFunc: func(opts metaV1.ListOptions) (watch.Interface, error) {
-				return client.NetworkingV1beta1().Ingresses(namespace).Watch(context.TODO(), opts)
-			},
-		}
-	})
-
-	informer := cache.NewSharedIndexInformer(mlw, &v1beta1.Ingress{}, options.ResyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-
 	st := StatusSyncer{
 		client:              client,
-		informer:            informer,
+		ingressLister:       client.KubeInformer().Networking().V1beta1().Ingresses().Lister(),
+		podLister:           client.KubeInformer().Core().V1().Pods().Lister(),
+		serviceLister:       client.KubeInformer().Core().V1().Services().Lister(),
+		nodeLister:          client.KubeInformer().Core().V1().Nodes().Lister(),
 		queue:               queue,
 		ingressClass:        ingressClass,
 		defaultIngressClass: defaultIngressClass,
@@ -142,9 +127,11 @@ func (s *StatusSyncer) runUpdateStatus(stop <-chan struct{}) {
 
 // updateStatus updates ingress status with the list of IP
 func (s *StatusSyncer) updateStatus(status []coreV1.LoadBalancerIngress) error {
-	ingressStore := s.informer.GetStore()
-	for _, obj := range ingressStore.List() {
-		currIng := obj.(*v1beta1.Ingress)
+	l, err := s.ingressLister.List(labels.Everything())
+	if err != nil {
+		return err
+	}
+	for _, currIng := range l {
 		if !classIsValid(currIng, s.ingressClass, s.defaultIngressClass) {
 			continue
 		}
@@ -160,8 +147,7 @@ func (s *StatusSyncer) updateStatus(status []coreV1.LoadBalancerIngress) error {
 
 		currIng.Status.LoadBalancer.Ingress = status
 
-		ingClient := s.client.NetworkingV1beta1().Ingresses(currIng.Namespace)
-		_, err := ingClient.UpdateStatus(context.TODO(), currIng, metaV1.UpdateOptions{})
+		_, err := s.client.NetworkingV1beta1().Ingresses(currIng.Namespace).UpdateStatus(context.TODO(), currIng, metaV1.UpdateOptions{})
 		if err != nil {
 			log.Warnf("error updating ingress status: %v", err)
 		}
@@ -176,7 +162,7 @@ func (s *StatusSyncer) runningAddresses(ingressNs string) ([]string, error) {
 	addrs := make([]string, 0)
 
 	if s.ingressService != "" {
-		svc, err := s.client.CoreV1().Services(ingressNs).Get(context.TODO(), s.ingressService, metaV1.GetOptions{})
+		svc, err := s.serviceLister.Services(ingressNs).Get(s.ingressService)
 		if err != nil {
 			return nil, err
 		}
@@ -199,22 +185,19 @@ func (s *StatusSyncer) runningAddresses(ingressNs string) ([]string, error) {
 	}
 
 	// get information about all the pods running the ingress controller (gateway)
-	pods, err := s.client.CoreV1().Pods(ingressNamespace).List(context.TODO(), metaV1.ListOptions{
-		// TODO: make it a const or maybe setting ( unless we remove k8s ingress support first)
-		LabelSelector: labels.SelectorFromSet(map[string]string{"app": "ingressgateway"}).String(),
-	})
+	pods, err := s.podLister.Pods(ingressNamespace).List(labels.SelectorFromSet(map[string]string{"app": "ingressgateway"}))
 	if err != nil {
 		return nil, err
 	}
 
-	for _, pod := range pods.Items {
+	for _, pod := range pods {
 		// only Running pods are valid
 		if pod.Status.Phase != coreV1.PodRunning {
 			continue
 		}
 
 		// Find node external IP
-		node, err := s.client.CoreV1().Nodes().Get(context.TODO(), pod.Spec.NodeName, metaV1.GetOptions{})
+		node, err := s.nodeLister.Get(pod.Spec.NodeName)
 		if err != nil {
 			continue
 		}

--- a/pilot/pkg/config/kube/ingress/status_test.go
+++ b/pilot/pkg/config/kube/ingress/status_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"os"
 	"testing"
-	"time"
 
 	coreV1 "k8s.io/api/core/v1"
 	ingress "k8s.io/api/networking/v1beta1"

--- a/pilot/pkg/config/kube/ingress/status_test.go
+++ b/pilot/pkg/config/kube/ingress/status_test.go
@@ -37,7 +37,6 @@ var (
 	hostname      = "foo.bar.com"
 	nodeIP        = "10.0.0.2"
 	testNamespace = "test"
-	resync        = time.Second
 )
 
 func makeAnnotatedIngress(annotation string) *ingress.Ingress {


### PR DESCRIPTION
This is a perf optimization to minimize the number of watches we open to the api server.

Part of #24640