### PR TITLE
 Move istio CRD reader to shared informers

### DIFF
--- a/istioctl/cmd/deprecated_cmd.go
+++ b/istioctl/cmd/deprecated_cmd.go
@@ -48,6 +48,7 @@ func newConfigStore() (model.ConfigStore, error) {
 	stop := make(chan struct{})
 	// TODO: replace with direct istio/client-go usage so we don't have to do this part
 	go client.Run(stop)
+	kclient.RunAndWait(stop)
 	cache.WaitForCacheSync(stop, client.HasSynced)
 
 	return client, nil

--- a/istioctl/cmd/deprecated_cmd.go
+++ b/istioctl/cmd/deprecated_cmd.go
@@ -35,8 +35,12 @@ func newConfigStore() (model.ConfigStore, error) {
 	if err != nil {
 		return nil, err
 	}
+	kclient, err := kubecfg.NewClient(kubecfg.NewClientConfigForRestConfig(cfg))
+	if err != nil {
+		return nil, err
+	}
 
-	client, err := crdclient.NewForConfig(cfg, &model.DisabledLedger{}, "", controller2.Options{DomainSuffix: ""})
+	client, err := crdclient.New(kclient, &model.DisabledLedger{}, "", controller2.Options{DomainSuffix: ""})
 	if err != nil {
 		return nil, err
 	}

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -29,23 +29,18 @@ import (
 	"time"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
-	"k8s.io/client-go/tools/cache"
-	serviceapisclient "sigs.k8s.io/service-apis/pkg/client/clientset/versioned"
-	serviceapisinformers "sigs.k8s.io/service-apis/pkg/client/informers/externalversions"
-
-	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"  // import GKE cluster authentication plugin
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc" // import OIDC cluster authentication plugin, e.g. for Tectonic
-	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	serviceapisclient "sigs.k8s.io/service-apis/pkg/client/clientset/versioned"
 
 	"istio.io/api/label"
 	istioclient "istio.io/client-go/pkg/clientset/versioned"
-	istioinformers "istio.io/client-go/pkg/informers/externalversions"
-
 	"istio.io/pkg/ledger"
 	"istio.io/pkg/log"
 
@@ -55,6 +50,7 @@ import (
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/resource"
+	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/queue"
 )
 
@@ -137,32 +133,7 @@ func (cl *Client) HasSynced() bool {
 	return true
 }
 
-// NewForConfig creates a client to the Kubernetes API using a rest config.
-func NewForConfig(cfg *rest.Config, configLedger ledger.Ledger,
-	revision string, options controller2.Options) (model.ConfigStoreCache, error) {
-	ic, err := istioclient.NewForConfig(cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	crdClient, err := apiextensionsclient.NewForConfig(cfg)
-	if err != nil {
-		return nil, err
-	}
-	sc, err := serviceapisclient.NewForConfig(cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	return New(ic, sc, crdClient, configLedger, revision, options)
-}
-
-func New(istioClient istioclient.Interface, serviceApisClient serviceapisclient.Interface, crdClient apiextensionsclient.Interface, configLedger ledger.Ledger,
-	revision string, options controller2.Options) (model.ConfigStoreCache, error) {
-
-	istioInformers := istioinformers.NewSharedInformerFactory(istioClient, options.ResyncPeriod)
-	serviceAPIInformers := serviceapisinformers.NewSharedInformerFactory(serviceApisClient, options.ResyncPeriod)
-
+func New(client kube.Client, configLedger ledger.Ledger, revision string, options controller2.Options) (model.ConfigStoreCache, error) {
 	out := &Client{
 		domainSuffix:      options.DomainSuffix,
 		configLedger:      configLedger,
@@ -170,10 +141,10 @@ func New(istioClient istioclient.Interface, serviceApisClient serviceapisclient.
 		revision:          revision,
 		queue:             queue.NewQueue(1 * time.Second),
 		kinds:             map[resource.GroupVersionKind]*cacheHandler{},
-		istioClient:       istioClient,
-		serviceApisClient: serviceApisClient,
+		istioClient:       client.Istio(),
+		serviceApisClient: client.ServiceApis(),
 	}
-	known := knownCRDs(crdClient)
+	known := knownCRDs(client.Ext())
 	for _, s := range out.schemas.All() {
 		// From the spec: "Its name MUST be in the format <.spec.name>.<.spec.group>."
 		name := fmt.Sprintf("%s.%s", s.Resource().Plural(), s.Resource().Group())
@@ -181,9 +152,9 @@ func New(istioClient istioclient.Interface, serviceApisClient serviceapisclient.
 			var i informers.GenericInformer
 			var err error
 			if s.Resource().Group() == "networking.x-k8s.io" {
-				i, err = serviceAPIInformers.ForResource(s.Resource().GroupVersionResource())
+				i, err = client.ServiceApisInformer().ForResource(s.Resource().GroupVersionResource())
 			} else {
-				i, err = istioInformers.ForResource(s.Resource().GroupVersionResource())
+				i, err = client.IstioInformer().ForResource(s.Resource().GroupVersionResource())
 			}
 			if err != nil {
 				return nil, err

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -115,10 +115,6 @@ func (cl *Client) Run(stop <-chan struct{}) {
 		cl.queue.Run(stop)
 	}()
 
-	for _, ctl := range cl.kinds {
-		go ctl.informer.Run(stop)
-	}
-
 	<-stop
 	log.Info("controller terminated")
 }

--- a/pilot/pkg/config/kube/crdclient/client_test.go
+++ b/pilot/pkg/config/kube/crdclient/client_test.go
@@ -25,32 +25,25 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
-	extfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
-
-	servicefake "sigs.k8s.io/service-apis/pkg/client/clientset/versioned/fake"
-
-	istiofake "istio.io/client-go/pkg/clientset/versioned/fake"
-
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/util/retry"
 )
 
 func makeClient(t *testing.T, schemas collection.Schemas) model.ConfigStoreCache {
-	fakeClient := istiofake.NewSimpleClientset()
-	extFake := extfake.NewSimpleClientset()
-	sFake := servicefake.NewSimpleClientset()
+	fake := kube.NewFakeClient()
 	for _, s := range schemas.All() {
-		extFake.ApiextensionsV1beta1().CustomResourceDefinitions().Create(context.TODO(), &v1beta1.CustomResourceDefinition{
+		fake.Ext().ApiextensionsV1beta1().CustomResourceDefinitions().Create(context.TODO(), &v1beta1.CustomResourceDefinition{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: fmt.Sprintf("%s.%s", s.Resource().Plural(), s.Resource().Group()),
 			},
 		}, metav1.CreateOptions{})
 	}
 	stop := make(chan struct{})
-	config, err := New(fakeClient, sFake, extFake, &model.DisabledLedger{}, "", controller.Options{})
+	config, err := New(fake, &model.DisabledLedger{}, "", controller.Options{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pilot/pkg/config/kube/crdclient/client_test.go
+++ b/pilot/pkg/config/kube/crdclient/client_test.go
@@ -48,6 +48,7 @@ func makeClient(t *testing.T, schemas collection.Schemas) model.ConfigStoreCache
 		t.Fatal(err)
 	}
 	go config.Run(stop)
+	fake.RunAndWait(stop)
 	cache.WaitForCacheSync(stop, config.HasSynced)
 	t.Cleanup(func() {
 		close(stop)

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -360,9 +360,13 @@ func (c *client) RunAndWait(stop <-chan struct{}) {
 	c.kubeInformer.Start(stop)
 	c.dynamicInformer.Start(stop)
 	c.metadataInformer.Start(stop)
+	c.istioInformer.Start(stop)
+	c.serviceapisInformers.Start(stop)
 	c.kubeInformer.WaitForCacheSync(stop)
 	c.dynamicInformer.WaitForCacheSync(stop)
 	c.metadataInformer.WaitForCacheSync(stop)
+	c.istioInformer.WaitForCacheSync(stop)
+	c.serviceapisInformers.WaitForCacheSync(stop)
 }
 
 func (c *client) Revision() string {

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	v1 "k8s.io/api/core/v1"
-	extclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	kubeExtClient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	extfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -214,7 +213,7 @@ type client struct {
 
 	config *rest.Config
 
-	extSet        extclient.Interface
+	extSet        kubeExtClient.Interface
 	versionClient discovery.ServerVersionInterface
 
 	kubeInformer informers.SharedInformerFactory

--- a/pkg/test/kube/mock_client.go
+++ b/pkg/test/kube/mock_client.go
@@ -28,6 +28,11 @@ import (
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/metadata/metadatainformer"
 	"k8s.io/client-go/rest"
+	serviceapisclient "sigs.k8s.io/service-apis/pkg/client/clientset/versioned"
+	serviceapisinformer "sigs.k8s.io/service-apis/pkg/client/informers/externalversions"
+
+	istioclient "istio.io/client-go/pkg/clientset/versioned"
+	istioinformer "istio.io/client-go/pkg/informers/externalversions"
 
 	"istio.io/pkg/version"
 
@@ -46,6 +51,22 @@ type MockClient struct {
 	RevisionValue    string
 	ConfigValue      *rest.Config
 	IstioVersions    *version.MeshInfo
+}
+
+func (c MockClient) Istio() istioclient.Interface {
+	panic("not used in mock")
+}
+
+func (c MockClient) ServiceApis() serviceapisclient.Interface {
+	panic("not used in mock")
+}
+
+func (c MockClient) IstioInformer() istioinformer.SharedInformerFactory {
+	panic("not used in mock")
+}
+
+func (c MockClient) ServiceApisInformer() serviceapisinformer.SharedInformerFactory {
+	panic("not used in mock")
 }
 
 func (c MockClient) Metadata() metadata.Interface {


### PR DESCRIPTION
This is a perf optimization to minimize the number of watches we open to the api server.

Part of #24640