### PR TITLE
Move validation webhook to shared informers

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -139,7 +139,7 @@ func (m *Multicluster) AddMemberCluster(clients kubelib.Client, clusterID string
 		nc := NewNamespaceController(m.fetchCaRoot, options, clients.Kube())
 		go nc.Run(stopCh)
 		go webhooks.PatchCertLoop(features.InjectionWebhookConfigName.Get(), webhookName, m.caBundlePath, clients.Kube(), stopCh)
-		valicationWebhookController := webhooks.CreateValidationWebhookController(clients.Kube(), clients.Dynamic(), webhookConfigName,
+		valicationWebhookController := webhooks.CreateValidationWebhookController(clients, webhookConfigName,
 			m.secretNamespace, m.caBundlePath, true)
 		if valicationWebhookController != nil {
 			go valicationWebhookController.Start(stopCh)

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -178,6 +178,7 @@ const resyncInterval = 0
 func NewFakeClient() Client {
 	var c client
 	c.Interface = fake.NewSimpleClientset()
+	c.kube = c.Interface
 	c.kubeInformer = informers.NewSharedInformerFactory(c.Interface, resyncInterval)
 
 	s := runtime.NewScheme()
@@ -216,6 +217,7 @@ type client struct {
 	extSet        kubeExtClient.Interface
 	versionClient discovery.ServerVersionInterface
 
+	kube         kubernetes.Interface
 	kubeInformer informers.SharedInformerFactory
 
 	dynamic         dynamic.Interface
@@ -250,6 +252,7 @@ func newClientInternal(clientFactory util.Factory, revision string) (*client, er
 	}
 
 	c.Interface, err = kubernetes.NewForConfig(c.config)
+	c.kube = c.Interface
 	if err != nil {
 		return nil, err
 	}
@@ -318,7 +321,7 @@ func (c *client) Dynamic() dynamic.Interface {
 }
 
 func (c *client) Kube() kubernetes.Interface {
-	return c
+	return c.kube
 }
 
 func (c *client) Metadata() metadata.Interface {

--- a/pkg/webhooks/webhookpatch.go
+++ b/pkg/webhooks/webhookpatch.go
@@ -28,11 +28,11 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	admissionregistrationv1beta1client "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1"
 	"k8s.io/client-go/tools/cache"
 
+	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/webhooks/validation/controller"
 
 	"istio.io/pkg/log"
@@ -166,7 +166,7 @@ func doPatch(cs kubernetes.Interface, webhookConfigName, webhookName string, caC
 	return false
 }
 
-func CreateValidationWebhookController(client kubernetes.Interface, dynamicInterface dynamic.Interface,
+func CreateValidationWebhookController(client kube.Client,
 	webhookConfigName, ns, caBundlePath string, remote bool) *controller.Controller {
 	o := controller.Options{
 		WatchedNamespace:    ns,
@@ -175,7 +175,7 @@ func CreateValidationWebhookController(client kubernetes.Interface, dynamicInter
 		ServiceName:         "istiod",
 		RemoteWebhookConfig: remote,
 	}
-	whController, err := controller.New(o, client, dynamicInterface)
+	whController, err := controller.New(o, client)
 	if err != nil {
 		log.Errorf("failed to create validationWebhookController controller: %v", err)
 	}


### PR DESCRIPTION
This is a perf optimization to minimize the number of watches we open to the api server.

Part of #24640