### PR TITLE
fix: get resource from scope traverses parents

### DIFF
--- a/pkg/test/framework/resource/context.go
+++ b/pkg/test/framework/resource/context.go
@@ -53,8 +53,9 @@ type Context interface {
 
 	// GetResource accepts either a *T or *[]*T where T implements Resource.
 	// For a non-slice pointer, the value will be assigned to the first matching resource.
-	// For a slice pointer, the matching resources will be appended.
+	// For a slice pointer, the matching resources from this scope and its parent(s) will be appended.
 	// If ref is not a pointer, an error will be returned.
+	// If there is no match for a non-slice pointer, an error will be returned.
 	GetResource(ref interface{}) error
 
 	// The Environment in which the tests run

--- a/pkg/test/framework/scope.go
+++ b/pkg/test/framework/scope.go
@@ -104,6 +104,16 @@ func (s *scope) get(ref interface{}) error {
 		}
 	}
 
+	if s.parent != nil {
+		// either didn't find the value or need to continue filling the slice
+		return s.parent.get(ref)
+	}
+
+	if refVal.Kind() != reflect.Slice {
+		// didn't find the non-slice value
+		return fmt.Errorf("no %v in context", targetT)
+	}
+
 	return nil
 }
 

--- a/pkg/test/framework/scope_test.go
+++ b/pkg/test/framework/scope_test.go
@@ -1,0 +1,82 @@
+package framework
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+func TestGet_Struct(t *testing.T) {
+	res := &resource.FakeResource{
+		IDValue: "my-fake-resource",
+	}
+
+	tests := map[string]struct {
+		setup    func() *scope
+		expError error
+	}{
+		"exists": {
+			setup: func() *scope {
+				scope := newScope("s", nil)
+				scope.add(res, &resourceID{id: res.IDValue})
+				return scope
+			},
+		},
+		"parent": {
+			setup: func() *scope {
+				p := newScope("p", nil)
+				p.add(res, &resourceID{id: res.IDValue})
+				scope := newScope("s", p)
+				return scope
+			},
+		},
+		"missing": {
+			setup:    func() *scope { return newScope("s", nil) },
+			expError: fmt.Errorf("no framework.OtherInterface in context"),
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			scope := tt.setup()
+			var got OtherInterface
+			err := scope.get(&got)
+			if tt.expError == nil {
+				g.Expect(err).To(BeNil())
+				g.Expect(got).To(Equal(res))
+			} else {
+				g.Expect(err).To(Equal(tt.expError))
+			}
+		})
+	}
+}
+
+func TestGet_Slice(t *testing.T) {
+	exp := []*resource.FakeResource{
+		{
+			IDValue:    "child-resource",
+			OtherValue: "child",
+		},
+		{
+			IDValue:    "parent-resource",
+			OtherValue: "parent",
+		},
+	}
+
+	g := NewGomegaWithT(t)
+	parent := newScope("parent", nil)
+	parent.add(exp[1], &resourceID{id: exp[1].IDValue})
+	child := newScope("child", parent)
+	child.add(exp[0], &resourceID{id: exp[0].IDValue})
+	var got []OtherInterface
+	err := child.get(&got)
+	g.Expect(err).To(BeNil())
+	g.Expect(got).To(HaveLen(len(exp)))
+	for i, res := range exp {
+		g.Expect(got[i]).To(Equal(res))
+	}
+}

--- a/pkg/test/framework/scope_test.go
+++ b/pkg/test/framework/scope_test.go
@@ -1,3 +1,17 @@
+//  Copyright Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 package framework
 
 import (

--- a/pkg/test/framework/testcontext.go
+++ b/pkg/test/framework/testcontext.go
@@ -189,10 +189,7 @@ func (c *testContext) TrackResource(r resource.Resource) resource.ID {
 }
 
 func (c *testContext) GetResource(ref interface{}) error {
-	if err := c.scope.get(ref); err != nil {
-		return c.suite.GetResource(ref)
-	}
-	return nil
+	return c.scope.get(ref)
 }
 
 func (c *testContext) WorkDir() string {


### PR DESCRIPTION
The main fix here is that Context.GetResource should return an error. The fact that it didn't made it so we wouldn't check the suite scope in TestContext.

The other fix/enhancement is that all parent scopes will be traversed. For slices, that means resources in the entire scope ancestry will be collected. 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
