### PR TITLE
pilot: fix n^2 scaling behavior with gateways

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -599,7 +599,7 @@ func (ps *PushContext) Services(proxy *Proxy) []*Service {
 // This replaces store.VirtualServices. Used only by the gateways
 // Sidecars use the egressListener.VirtualServices().
 func (ps *PushContext) VirtualServicesForGateway(proxy *Proxy, gateway string) []Config {
-	res := ps.privateVirtualServicesByNamespaceAndGateway[proxy.ConfigNamespace][gateway][:]
+	res := ps.privateVirtualServicesByNamespaceAndGateway[proxy.ConfigNamespace][gateway]
 	res = append(res, ps.virtualServicesExportedToNamespaceByGateway[proxy.ConfigNamespace][gateway]...)
 	res = append(res, ps.publicVirtualServicesByGateway[gateway]...)
 	return res

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -91,13 +91,13 @@ type PushContext struct {
 	QuotaSpecBinding []Config `json:"-"`
 
 	// VirtualService related
-	// this contains all the virtual services with exportTo "." and current namespace
-	privateVirtualServicesByNamespace map[string][]Config
 	// This contains all virtual services visible to this namespace extracted from
-	// exportTos that explicitly contained this namespace.
-	virtualServicesExportedToNamespace map[string][]Config
-	// This contains all virtual services whose exportTo is "*"
-	publicVirtualServices []Config
+	// exportTos that explicitly contained this namespace. The keys are namespace,gateway.
+	virtualServicesExportedToNamespaceByGateway map[string]map[string][]Config
+	// this contains all the virtual services with exportTo "." and current namespace. The keys are namespace,gateway.
+	privateVirtualServicesByNamespaceAndGateway map[string]map[string][]Config
+	// This contains all virtual services whose exportTo is "*", keyed by gateway
+	publicVirtualServicesByGateway map[string][]Config
 
 	// destination rules are of three types:
 	//  namespaceLocalDestRules: all public/private dest rules pertaining to a service defined in a given namespace
@@ -443,21 +443,21 @@ func init() {
 func NewPushContext() *PushContext {
 	// TODO: detect push in progress, don't update status if set
 	return &PushContext{
-		publicServices:                     []*Service{},
-		privateServicesByNamespace:         map[string][]*Service{},
-		servicesExportedToNamespace:        map[string][]*Service{},
-		publicVirtualServices:              []Config{},
-		privateVirtualServicesByNamespace:  map[string][]Config{},
-		virtualServicesExportedToNamespace: map[string][]Config{},
-		namespaceLocalDestRules:            map[string]*processedDestRules{},
-		exportedDestRulesByNamespace:       map[string]*processedDestRules{},
-		sidecarsByNamespace:                map[string][]*SidecarScope{},
-		envoyFiltersByNamespace:            map[string][]*EnvoyFilterWrapper{},
-		gatewaysByNamespace:                map[string][]Config{},
-		allGateways:                        []Config{},
-		ServiceByHostnameAndNamespace:      map[host.Name]map[string]*Service{},
-		ProxyStatus:                        map[string]map[string]ProxyPushStatus{},
-		ServiceAccounts:                    map[host.Name]map[int][]string{},
+		publicServices:                              []*Service{},
+		privateServicesByNamespace:                  map[string][]*Service{},
+		servicesExportedToNamespace:                 map[string][]*Service{},
+		publicVirtualServicesByGateway:              map[string][]Config{},
+		privateVirtualServicesByNamespaceAndGateway: map[string]map[string][]Config{},
+		virtualServicesExportedToNamespaceByGateway: map[string]map[string][]Config{},
+		namespaceLocalDestRules:                     map[string]*processedDestRules{},
+		exportedDestRulesByNamespace:                map[string]*processedDestRules{},
+		sidecarsByNamespace:                         map[string][]*SidecarScope{},
+		envoyFiltersByNamespace:                     map[string][]*EnvoyFilterWrapper{},
+		gatewaysByNamespace:                         map[string][]Config{},
+		allGateways:                                 []Config{},
+		ServiceByHostnameAndNamespace:               map[host.Name]map[string]*Service{},
+		ProxyStatus:                                 map[string]map[string]ProxyPushStatus{},
+		ServiceAccounts:                             map[host.Name]map[int][]string{},
 	}
 }
 
@@ -529,8 +529,6 @@ func virtualServiceDestinations(v *networking.VirtualService) []*networking.Dest
 // GatewayServices returns the set of services which are referred from the proxy gateways.
 func (ps *PushContext) GatewayServices(proxy *Proxy) []*Service {
 	svcs := ps.Services(proxy)
-	// gateway set.
-	gateways := map[string]bool{}
 	// host set.
 	hostsFromGateways := map[string]struct{}{}
 
@@ -541,19 +539,16 @@ func (ps *PushContext) GatewayServices(proxy *Proxy) []*Service {
 	}
 
 	for _, gw := range proxy.MergedGateway.GatewayNameForServer {
-		gateways[gw] = true
-	}
-	log.Debugf("GatewayServices: gateway %v has following gw resources:%v", proxy.ID, gateways)
+		for _, vsConfig := range ps.VirtualServicesForGateway(proxy, gw) {
+			vs, ok := vsConfig.Spec.(*networking.VirtualService)
+			if !ok { // should never happen
+				log.Errorf("Failed in getting a virtual service: %v", vsConfig.Labels)
+				return svcs
+			}
 
-	for _, vsConfig := range ps.VirtualServices(proxy, gateways) {
-		vs, ok := vsConfig.Spec.(*networking.VirtualService)
-		if !ok { // should never happen
-			log.Errorf("Failed in getting a virtual service: %v", vsConfig.Labels)
-			return svcs
-		}
-
-		for _, d := range virtualServiceDestinations(vs) {
-			hostsFromGateways[d.Host] = struct{}{}
+			for _, d := range virtualServiceDestinations(vs) {
+				hostsFromGateways[d.Host] = struct{}{}
+			}
 		}
 	}
 
@@ -603,46 +598,11 @@ func (ps *PushContext) Services(proxy *Proxy) []*Service {
 // VirtualServices lists all virtual services bound to the specified gateways
 // This replaces store.VirtualServices. Used only by the gateways
 // Sidecars use the egressListener.VirtualServices().
-func (ps *PushContext) VirtualServices(proxy *Proxy, gateways map[string]bool) []Config {
-	configs := make([]Config, 0)
-	out := make([]Config, 0)
-
-	// filter out virtual services not reachable
-	// First add private virtual services and explicitly exportedTo virtual services
-	if proxy == nil {
-		for _, virtualSvcs := range ps.privateVirtualServicesByNamespace {
-			configs = append(configs, virtualSvcs...)
-		}
-	} else {
-		configs = append(configs, ps.privateVirtualServicesByNamespace[proxy.ConfigNamespace]...)
-		configs = append(configs, ps.virtualServicesExportedToNamespace[proxy.ConfigNamespace]...)
-	}
-	// Second add public virtual services.
-	configs = append(configs, ps.publicVirtualServices...)
-
-	for _, cfg := range configs {
-		rule := cfg.Spec.(*networking.VirtualService)
-		if len(rule.Gateways) == 0 {
-			// This rule applies only to IstioMeshGateway
-			if _, ok := gateways[constants.IstioMeshGateway]; ok {
-				out = append(out, cfg)
-			}
-		} else {
-			for _, g := range rule.Gateways {
-				// note: Gateway names do _not_ use wildcard matching, so we do not use Name.Matches here
-				if _, ok := gateways[resolveGatewayName(g, cfg.ConfigMeta)]; ok {
-					out = append(out, cfg)
-					break
-				} else if _, ok := gateways[g]; ok && g == constants.IstioMeshGateway {
-					// "mesh" gateway cannot be expanded into FQDN
-					out = append(out, cfg)
-					break
-				}
-			}
-		}
-	}
-
-	return out
+func (ps *PushContext) VirtualServicesForGateway(proxy *Proxy, gateway string) []Config {
+	res := ps.privateVirtualServicesByNamespaceAndGateway[proxy.ConfigNamespace][gateway][:]
+	res = append(res, ps.virtualServicesExportedToNamespaceByGateway[proxy.ConfigNamespace][gateway]...)
+	res = append(res, ps.publicVirtualServicesByGateway[gateway]...)
+	return res
 }
 
 // getSidecarScope returns a SidecarScope object associated with the
@@ -947,9 +907,9 @@ func (ps *PushContext) updateContext(
 			return err
 		}
 	} else {
-		ps.privateVirtualServicesByNamespace = oldPushContext.privateVirtualServicesByNamespace
-		ps.virtualServicesExportedToNamespace = oldPushContext.virtualServicesExportedToNamespace
-		ps.publicVirtualServices = oldPushContext.publicVirtualServices
+		ps.virtualServicesExportedToNamespaceByGateway = oldPushContext.virtualServicesExportedToNamespaceByGateway
+		ps.privateVirtualServicesByNamespaceAndGateway = oldPushContext.privateVirtualServicesByNamespaceAndGateway
+		ps.publicVirtualServicesByGateway = oldPushContext.publicVirtualServicesByGateway
 	}
 
 	if destinationRulesChanged {
@@ -1106,9 +1066,10 @@ func (ps *PushContext) initAuthnPolicies(env *Environment) error {
 
 // Caches list of virtual services
 func (ps *PushContext) initVirtualServices(env *Environment) error {
-	ps.privateVirtualServicesByNamespace = map[string][]Config{}
-	ps.virtualServicesExportedToNamespace = map[string][]Config{}
-	ps.publicVirtualServices = []Config{}
+	ps.virtualServicesExportedToNamespaceByGateway = map[string]map[string][]Config{}
+	ps.privateVirtualServicesByNamespaceAndGateway = map[string]map[string][]Config{}
+	ps.publicVirtualServicesByGateway = map[string][]Config{}
+
 	virtualServices, err := env.List(gvk.VirtualService, NamespaceAll)
 	if err != nil {
 		return err
@@ -1134,79 +1095,28 @@ func (ps *PushContext) initVirtualServices(env *Environment) error {
 
 	// convert all shortnames in virtual services into FQDNs
 	for _, r := range vservices {
-		rule := r.Spec.(*networking.VirtualService)
-		// resolve top level hosts
-		for i, h := range rule.Hosts {
-			rule.Hosts[i] = string(ResolveShortnameToFQDN(h, r.ConfigMeta))
-		}
-		// resolve gateways to bind to
-		for i, g := range rule.Gateways {
-			if g != constants.IstioMeshGateway {
-				rule.Gateways[i] = resolveGatewayName(g, r.ConfigMeta)
-			}
-		}
-		// resolve host in http route.destination, route.mirror
-		for _, d := range rule.Http {
-			for _, m := range d.Match {
-				for i, g := range m.Gateways {
-					if g != constants.IstioMeshGateway {
-						m.Gateways[i] = resolveGatewayName(g, r.ConfigMeta)
-					}
-				}
-			}
-			for _, w := range d.Route {
-				if w.Destination != nil {
-					w.Destination.Host = string(ResolveShortnameToFQDN(w.Destination.Host, r.ConfigMeta))
-				}
-			}
-			if d.Mirror != nil {
-				d.Mirror.Host = string(ResolveShortnameToFQDN(d.Mirror.Host, r.ConfigMeta))
-			}
-		}
-		// resolve host in tcp route.destination
-		for _, d := range rule.Tcp {
-			for _, m := range d.Match {
-				for i, g := range m.Gateways {
-					if g != constants.IstioMeshGateway {
-						m.Gateways[i] = resolveGatewayName(g, r.ConfigMeta)
-					}
-				}
-			}
-			for _, w := range d.Route {
-				if w.Destination != nil {
-					w.Destination.Host = string(ResolveShortnameToFQDN(w.Destination.Host, r.ConfigMeta))
-				}
-			}
-		}
-		//resolve host in tls route.destination
-		for _, tls := range rule.Tls {
-			for _, m := range tls.Match {
-				for i, g := range m.Gateways {
-					if g != constants.IstioMeshGateway {
-						m.Gateways[i] = resolveGatewayName(g, r.ConfigMeta)
-					}
-				}
-			}
-			for _, w := range tls.Route {
-				if w.Destination != nil {
-					w.Destination.Host = string(ResolveShortnameToFQDN(w.Destination.Host, r.ConfigMeta))
-				}
-			}
-		}
+		resolveVirtualServiceShortnames(r.Spec.(*networking.VirtualService), r.ConfigMeta)
 	}
 
 	for _, virtualService := range vservices {
 		ns := virtualService.Namespace
 		rule := virtualService.Spec.(*networking.VirtualService)
+		gwNames := getGatewayNames(rule, virtualService.ConfigMeta)
 		if len(rule.ExportTo) == 0 {
 			// No exportTo in virtualService. Use the global default
 			// We only honor ., *
 			if ps.defaultVirtualServiceExportTo[visibility.Private] {
+				if _, f := ps.privateVirtualServicesByNamespaceAndGateway[ns]; !f {
+					ps.privateVirtualServicesByNamespaceAndGateway[ns] = map[string][]Config{}
+				}
 				// add to local namespace only
-				ps.privateVirtualServicesByNamespace[ns] =
-					append(ps.privateVirtualServicesByNamespace[ns], virtualService)
+				for _, gw := range gwNames {
+					ps.privateVirtualServicesByNamespaceAndGateway[ns][gw] = append(ps.privateVirtualServicesByNamespaceAndGateway[ns][gw], virtualService)
+				}
 			} else if ps.defaultVirtualServiceExportTo[visibility.Public] {
-				ps.publicVirtualServices = append(ps.publicVirtualServices, virtualService)
+				for _, gw := range gwNames {
+					ps.publicVirtualServicesByGateway[gw] = append(ps.publicVirtualServicesByGateway[gw], virtualService)
+				}
 			}
 		} else {
 			exportToMap := make(map[visibility.Instance]bool)
@@ -1217,7 +1127,9 @@ func (ps *PushContext) initVirtualServices(env *Environment) error {
 			// if vs has exportTo *, make public and ignore all other exportTos
 			// if vs has exportTo ., replace with current namespace
 			if exportToMap[visibility.Public] {
-				ps.publicVirtualServices = append(ps.publicVirtualServices, virtualService)
+				for _, gw := range gwNames {
+					ps.publicVirtualServicesByGateway[gw] = append(ps.publicVirtualServicesByGateway[gw], virtualService)
+				}
 				continue
 			} else if exportToMap[visibility.None] {
 				// not possible
@@ -1226,13 +1138,22 @@ func (ps *PushContext) initVirtualServices(env *Environment) error {
 				// . or other namespaces
 				for exportTo := range exportToMap {
 					if exportTo == visibility.Private || string(exportTo) == ns {
-						// exportTo with same namespace is effectively private
-						ps.privateVirtualServicesByNamespace[ns] =
-							append(ps.privateVirtualServicesByNamespace[ns], virtualService)
+						if _, f := ps.privateVirtualServicesByNamespaceAndGateway[ns]; !f {
+							ps.privateVirtualServicesByNamespaceAndGateway[ns] = map[string][]Config{}
+						}
+						// add to local namespace only
+						for _, gw := range gwNames {
+							ps.privateVirtualServicesByNamespaceAndGateway[ns][gw] = append(ps.privateVirtualServicesByNamespaceAndGateway[ns][gw], virtualService)
+						}
 					} else {
-						// exportTo is a specific target namespace
-						ps.virtualServicesExportedToNamespace[string(exportTo)] =
-							append(ps.virtualServicesExportedToNamespace[string(exportTo)], virtualService)
+						if _, f := ps.virtualServicesExportedToNamespaceByGateway[string(exportTo)]; !f {
+							ps.virtualServicesExportedToNamespaceByGateway[string(exportTo)] = map[string][]Config{}
+						}
+						// add to local namespace only
+						for _, gw := range gwNames {
+							ps.virtualServicesExportedToNamespaceByGateway[string(exportTo)][gw] =
+								append(ps.virtualServicesExportedToNamespaceByGateway[string(exportTo)][gw], virtualService)
+						}
 					}
 				}
 			}
@@ -1240,6 +1161,24 @@ func (ps *PushContext) initVirtualServices(env *Environment) error {
 	}
 
 	return nil
+}
+
+var meshGateways = []string{constants.IstioMeshGateway}
+
+func getGatewayNames(vs *networking.VirtualService, meta ConfigMeta) []string {
+	if len(vs.Gateways) == 0 {
+		return meshGateways
+	}
+	res := make([]string, 0, len(vs.Gateways))
+	for _, g := range vs.Gateways {
+		if g == constants.IstioMeshGateway {
+			res = append(res, constants.IstioMeshGateway)
+		} else {
+			name := resolveGatewayName(g, meta)
+			res = append(res, name)
+		}
+	}
+	return res
 }
 
 func (ps *PushContext) initDefaultExportMaps() {

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -150,8 +150,7 @@ func DefaultSidecarScopeForNamespace(ps *PushContext, configNamespace string) *S
 	}
 	defaultEgressListener.services = ps.Services(&dummyNode)
 
-	meshGateway := map[string]bool{constants.IstioMeshGateway: true}
-	defaultEgressListener.virtualServices = ps.VirtualServices(&dummyNode, meshGateway)
+	defaultEgressListener.virtualServices = ps.VirtualServicesForGateway(&dummyNode, constants.IstioMeshGateway)
 
 	out := &SidecarScope{
 		EgressListeners:    []*IstioEgressListenerWrapper{defaultEgressListener},
@@ -366,8 +365,7 @@ func convertIstioListenerToWrapper(ps *PushContext, configNamespace string,
 		ConfigNamespace: configNamespace,
 	}
 
-	meshGateway := map[string]bool{constants.IstioMeshGateway: true}
-	out.virtualServices = out.selectVirtualServices(ps.VirtualServices(&dummyNode, meshGateway))
+	out.virtualServices = out.selectVirtualServices(ps.VirtualServicesForGateway(&dummyNode, constants.IstioMeshGateway))
 	out.services = out.selectServices(ps.Services(&dummyNode), configNamespace)
 
 	return out

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
 
@@ -1012,7 +1013,7 @@ func TestCreateSidecarScope(t *testing.T) {
 				}
 			}
 			if tt.virtualServices != nil {
-				ps.publicVirtualServices = append(ps.publicVirtualServices, tt.virtualServices...)
+				ps.publicVirtualServicesByGateway[constants.IstioMeshGateway] = append(ps.publicVirtualServicesByGateway[constants.IstioMeshGateway], tt.virtualServices...)
 			}
 
 			sidecarConfig := tt.sidecarConfig
@@ -1278,7 +1279,7 @@ func TestContainsEgressDependencies(t *testing.T) {
 				},
 			}
 			ps.publicServices = append(ps.publicServices, services...)
-			ps.publicVirtualServices = append(ps.publicVirtualServices, virtualServices...)
+			ps.publicVirtualServicesByGateway[constants.IstioMeshGateway] = append(ps.publicVirtualServicesByGateway[constants.IstioMeshGateway], virtualServices...)
 			ps.SetDestinationRules(destinationRules)
 			sidecarScope := ConvertToSidecarScope(ps, cfg, "default")
 			if len(tt.egress) == 0 {

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -117,7 +117,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(
 				} else {
 					// passthrough or tcp, yields multiple filter chains
 					tcpChainOpts := configgen.createGatewayTCPFilterChainOpts(node, push,
-						server, map[string]bool{mergedGateway.GatewayNameForServer[server]: true})
+						server, mergedGateway.GatewayNameForServer[server])
 					filterChainOpts = append(filterChainOpts, tcpChainOpts...)
 					for i := 0; i < len(tcpChainOpts); i++ {
 						filterChains = append(filterChains, istionetworking.FilterChain{ListenerProtocol: istionetworking.ListenerProtocolTCP})
@@ -231,11 +231,10 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 			}
 			continue
 		}
-		virtualServices := push.VirtualServices(node, map[string]bool{gatewayName: true})
+		virtualServices := push.VirtualServicesForGateway(node, gatewayName)
 
 		// TODO: if there are no virtual services for this server, setup a 404
 		// But get rid of the 404 when we encounter another virtual service for another Gateway server with same hostname
-
 		for _, virtualService := range virtualServices {
 			virtualServiceHosts := host.NewNames(virtualService.Spec.(*networking.VirtualService).Hosts)
 			serverHosts := host.NamesForNamespace(server.Hosts, virtualService.Namespace)
@@ -505,7 +504,7 @@ func convertTLSProtocol(in networking.ServerTLSSettings_TLSProtocol) tls.TlsPara
 
 func (configgen *ConfigGeneratorImpl) createGatewayTCPFilterChainOpts(
 	node *model.Proxy, push *model.PushContext, server *networking.Server,
-	gatewaysForWorkload map[string]bool) []*filterChainOpts {
+	gatewayName string) []*filterChainOpts {
 
 	// We have a TCP/TLS server. This could be TLS termination (user specifies server.TLS with simple/mutual)
 	// or opaque TCP (server.TLS is nil). or it could be a TLS passthrough with SNI based routing.
@@ -513,7 +512,7 @@ func (configgen *ConfigGeneratorImpl) createGatewayTCPFilterChainOpts(
 	// This is opaque TCP server. Find matching virtual services with TCP blocks and forward
 	if server.Tls == nil {
 		if filters := buildGatewayNetworkFiltersFromTCPRoutes(node,
-			push, server, gatewaysForWorkload); len(filters) > 0 {
+			push, server, gatewayName); len(filters) > 0 {
 			return []*filterChainOpts{
 				{
 					sniHosts:       nil,
@@ -527,7 +526,7 @@ func (configgen *ConfigGeneratorImpl) createGatewayTCPFilterChainOpts(
 		// and forward to backend
 		// Validation ensures that non-passthrough servers will have certs
 		if filters := buildGatewayNetworkFiltersFromTCPRoutes(node,
-			push, server, gatewaysForWorkload); len(filters) > 0 {
+			push, server, gatewayName); len(filters) > 0 {
 			return []*filterChainOpts{
 				{
 					sniHosts:       getSNIHostsForServer(server),
@@ -538,7 +537,7 @@ func (configgen *ConfigGeneratorImpl) createGatewayTCPFilterChainOpts(
 		}
 	} else {
 		// Passthrough server.
-		return buildGatewayNetworkFiltersFromTLSRoutes(node, push, server, gatewaysForWorkload)
+		return buildGatewayNetworkFiltersFromTLSRoutes(node, push, server, gatewayName)
 	}
 
 	return []*filterChainOpts{}
@@ -547,8 +546,7 @@ func (configgen *ConfigGeneratorImpl) createGatewayTCPFilterChainOpts(
 // buildGatewayNetworkFiltersFromTCPRoutes builds tcp proxy routes for all VirtualServices with TCP blocks.
 // It first obtains all virtual services bound to the set of Gateways for this workload, filters them by this
 // server's port and hostnames, and produces network filters for each destination from the filtered services.
-func buildGatewayNetworkFiltersFromTCPRoutes(node *model.Proxy, push *model.PushContext, server *networking.Server,
-	gatewaysForWorkload map[string]bool) []*listener.Filter {
+func buildGatewayNetworkFiltersFromTCPRoutes(node *model.Proxy, push *model.PushContext, server *networking.Server, gateway string) []*listener.Filter {
 	port := &model.Port{
 		Name:     server.Port.Name,
 		Port:     int(server.Port.Number),
@@ -560,7 +558,7 @@ func buildGatewayNetworkFiltersFromTCPRoutes(node *model.Proxy, push *model.Push
 		gatewayServerHosts[host.Name(hostname)] = true
 	}
 
-	virtualServices := push.VirtualServices(node, gatewaysForWorkload)
+	virtualServices := push.VirtualServicesForGateway(node, gateway)
 	for _, v := range virtualServices {
 		vsvc := v.Spec.(*networking.VirtualService)
 		// We have two cases here:
@@ -577,7 +575,7 @@ func buildGatewayNetworkFiltersFromTCPRoutes(node *model.Proxy, push *model.Push
 		// For the moment, there can be only one match that succeeds
 		// based on the match port/server port and the gateway name
 		for _, tcp := range vsvc.Tcp {
-			if l4MultiMatch(tcp.Match, server, gatewaysForWorkload) {
+			if l4MultiMatch(tcp.Match, server, gateway) {
 				return buildOutboundNetworkFilters(node, tcp.Route, push, port, v.ConfigMeta)
 			}
 		}
@@ -590,7 +588,7 @@ func buildGatewayNetworkFiltersFromTCPRoutes(node *model.Proxy, push *model.Push
 // It first obtains all virtual services bound to the set of Gateways for this workload, filters them by this
 // server's port and hostnames, and produces network filters for each destination from the filtered services
 func buildGatewayNetworkFiltersFromTLSRoutes(node *model.Proxy, push *model.PushContext, server *networking.Server,
-	gatewaysForWorkload map[string]bool) []*filterChainOpts {
+	gatewayName string) []*filterChainOpts {
 	port := &model.Port{
 		Name:     server.Port.Name,
 		Port:     int(server.Port.Number),
@@ -612,7 +610,7 @@ func buildGatewayNetworkFiltersFromTLSRoutes(node *model.Proxy, push *model.Push
 			networkFilters: buildOutboundAutoPassthroughFilterStack(push, node, port),
 		})
 	} else {
-		virtualServices := push.VirtualServices(node, gatewaysForWorkload)
+		virtualServices := push.VirtualServicesForGateway(node, gatewayName)
 		for _, v := range virtualServices {
 			vsvc := v.Spec.(*networking.VirtualService)
 			// We have two cases here:
@@ -632,7 +630,7 @@ func buildGatewayNetworkFiltersFromTLSRoutes(node *model.Proxy, push *model.Push
 			// chain matches
 			for _, tls := range vsvc.Tls {
 				for _, match := range tls.Match {
-					if l4SingleMatch(convertTLSMatchToL4Match(match), server, gatewaysForWorkload) {
+					if l4SingleMatch(convertTLSMatchToL4Match(match), server, gatewayName) {
 						// the sni hosts in the match will become part of a filter chain match
 						filterChains = append(filterChains, &filterChainOpts{
 							sniHosts:       match.SniHosts,
@@ -687,11 +685,11 @@ func convertTLSMatchToL4Match(tlsMatch *networking.TLSMatchAttributes) *networki
 	}
 }
 
-func l4MultiMatch(predicates []*networking.L4MatchAttributes, server *networking.Server, gatewaysForWorkload map[string]bool) bool {
+func l4MultiMatch(predicates []*networking.L4MatchAttributes, server *networking.Server, gateway string) bool {
 	// NB from proto definitions: each set of predicates is OR'd together; inside of a predicate all conditions are AND'd.
 	// This means we can return as soon as we get any match of an entire predicate.
 	for _, match := range predicates {
-		if l4SingleMatch(match, server, gatewaysForWorkload) {
+		if l4SingleMatch(match, server, gateway) {
 			return true
 		}
 	}
@@ -699,9 +697,9 @@ func l4MultiMatch(predicates []*networking.L4MatchAttributes, server *networking
 	return len(predicates) == 0
 }
 
-func l4SingleMatch(match *networking.L4MatchAttributes, server *networking.Server, gatewaysForWorkload map[string]bool) bool {
+func l4SingleMatch(match *networking.L4MatchAttributes, server *networking.Server, gateway string) bool {
 	// if there's no gateway predicate, gatewayMatch is true; otherwise we match against the gateways for this workload
-	return isPortMatch(match.Port, server) && isGatewayMatch(gatewaysForWorkload, match.Gateways)
+	return isPortMatch(match.Port, server) && isGatewayMatch(gateway, match.Gateways)
 }
 
 func isPortMatch(port uint32, server *networking.Server) bool {
@@ -713,15 +711,19 @@ func isPortMatch(port uint32, server *networking.Server) bool {
 	return portMatch
 }
 
-func isGatewayMatch(gatewaysForWorkload map[string]bool, gatewayNames []string) bool {
+func isGatewayMatch(gateway string, gatewayNames []string) bool {
 	// if there's no gateway predicate, gatewayMatch is true; otherwise we match against the gateways for this workload
-	gatewayMatch := len(gatewayNames) == 0
+	if len(gatewayNames) == 0 {
+		return true
+	}
 	if len(gatewayNames) > 0 {
 		for _, gatewayName := range gatewayNames {
-			gatewayMatch = gatewayMatch || gatewaysForWorkload[gatewayName]
+			if gatewayName == gateway {
+				return true
+			}
 		}
 	}
-	return gatewayMatch
+	return false
 }
 
 func getSNIHostsForServer(server *networking.Server) []string {


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/25116

Against current master
```
name                               old time/op        new time/op        delta
InitPushContext/gateways-6               4.27ms ± 1%        4.03ms ± 1%   -5.59%  (p=0.008 n=5+5)
InitPushContext/gateways-shared-6         662µs ± 1%         465µs ± 1%  -29.75%  (p=0.008 n=5+5)
InitPushContext/empty-6                   302ns ± 2%         298ns ± 2%     ~     (p=0.222 n=5+5)
InitPushContext/telemetry-6               298ns ± 2%         298ns ± 3%     ~     (p=0.635 n=5+5)
InitPushContext/virtualservice-6          168ns ± 4%         171ns ± 2%     ~     (p=0.183 n=5+5)
RouteGeneration/gateways-6                387ms ± 1%         112ms ± 1%  -71.03%  (p=0.008 n=5+5)
RouteGeneration/gateways-shared-6         462ms ± 3%         453ms ± 3%     ~     (p=0.222 n=5+5)
RouteGeneration/empty-6                   841µs ± 2%         835µs ± 5%     ~     (p=0.310 n=5+5)
RouteGeneration/telemetry-6               851µs ± 3%         851µs ± 3%     ~     (p=1.000 n=5+5)
RouteGeneration/virtualservice-6         2.01ms ± 2%        1.99ms ± 2%     ~     (p=0.310 n=5+5)
```

Currently, we store all of the virtual services in a list. Then for each route (1 per gateway) we traverse over each virtual service: https://github.com/istio/istio/blob/f467d22f165ed39d996a45049ffa2d26234596f3/pilot/pkg/networking/core/v1alpha3/gateway.go#L218. Basically we have O(VS*GW) scaling. This ultimately leads to enormous config gen times for RDS, GC thrashing, etc - a single generation for RDS for *one* ingress with 2k gateways/virtual services took over 30s seconds

This change optimizes the model to make it O(VS+GW). We store virtual services keyed by gateway, so we can do a quick lookup. This ultimately helps with non-gateway as well, as we can lookup the mesh gateway quickly as well.

Interestingly, the code is currently logically setup like this, just not performance wise - VirtualService takes in a set of gateways to get virtual services for, but the set always has exactly one element.