### PR TITLE
pilot: incremental EDS requests

### DIFF
--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -35,6 +35,7 @@ import (
 
 	istiolog "istio.io/pkg/log"
 
+	"istio.io/istio/pilot/pkg/util/sets"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/security/pkg/server/ca/authenticate"
 
@@ -463,9 +464,10 @@ func (s *DiscoveryServer) handleEds(con *Connection, discReq *discovery.Discover
 		return nil
 	}
 
+	changed := listDifference(clusters, con.Clusters)
 	con.Clusters = clusters
 	adsLog.Debugf("ADS:EDS: REQ %s clusters:%d", con.ConID, len(con.Clusters))
-	err := s.pushEds(s.globalPushContext(), con, versionInfo(), nil)
+	err := s.pushEds(s.globalPushContext(), con, versionInfo(), nil, changed)
 	if err != nil {
 		return err
 	}
@@ -516,6 +518,12 @@ func (s *DiscoveryServer) handleRds(con *Connection, discReq *discovery.Discover
 		return err
 	}
 	return nil
+}
+
+// listDifference returns a - b
+func listDifference(a []string, b []string) sets.Set {
+	clusterSet := sets.NewSet(a...)
+	return clusterSet.Difference(sets.NewSet(b...))
 }
 
 // listEqualUnordered checks that two lists contain all the same elements
@@ -663,7 +671,7 @@ func (s *DiscoveryServer) pushConnection(con *Connection, pushEv *Event) error {
 		// Push only EDS. This is indexed already - push immediately
 		// (may need a throttle)
 		if len(con.Clusters) > 0 && len(edsUpdatedServices) > 0 {
-			if err := s.pushEds(pushEv.push, con, versionInfo(), edsUpdatedServices); err != nil {
+			if err := s.pushEds(pushEv.push, con, versionInfo(), edsUpdatedServices, nil); err != nil {
 				return err
 			}
 		}
@@ -724,7 +732,7 @@ func (s *DiscoveryServer) pushConnection(con *Connection, pushEv *Event) error {
 	}
 
 	if len(con.Clusters) > 0 && pushTypes[EDS] {
-		err := s.pushEds(pushEv.push, con, currentVersion, nil)
+		err := s.pushEds(pushEv.push, con, currentVersion, nil, nil)
 		if err != nil {
 			return err
 		}

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -427,8 +427,10 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *Connection, vers
 	// All clusters that this endpoint is watching. For 1.0 - it's typically all clusters in the mesh.
 	// For 1.1+Sidecar - it's the small set of explicitly imported clusters, using the isolated DestinationRules
 	for _, clusterName := range con.Clusters {
-		if _, f := updatedClusters[clusterName]; !f {
-			continue
+		if updatedClusters != nil {
+			if _, f := updatedClusters[clusterName]; !f {
+				continue
+			}
 		}
 		l := s.generateEndpoints(clusterName, con.node, push, edsUpdatedServices)
 		if l == nil {

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -418,7 +418,8 @@ func (eds *EdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w
 
 // pushEds is pushing EDS updates for a single connection. Called the first time
 // a client connects, for incremental updates and for full periodic updates.
-func (s *DiscoveryServer) pushEds(push *model.PushContext, con *Connection, version string, edsUpdatedServices map[string]struct{}, updatedClusters map[string]struct{}) error {
+func (s *DiscoveryServer) pushEds(push *model.PushContext, con *Connection, version string,
+	edsUpdatedServices map[string]struct{}, updatedClusters map[string]struct{}) error {
 	pushStart := time.Now()
 	loadAssignments := make([]*endpoint.ClusterLoadAssignment, 0)
 	endpoints := 0
@@ -428,6 +429,9 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *Connection, vers
 	// For 1.1+Sidecar - it's the small set of explicitly imported clusters, using the isolated DestinationRules
 	for _, clusterName := range con.Clusters {
 		if updatedClusters != nil {
+			// If a cluster is in this map, we will skip it. This occurs when doing an incremental update.
+			// Generally edsUpdatedServices will be set for incremental push, and updatedClusters set for
+			// incremental request.
 			if _, f := updatedClusters[clusterName]; !f {
 				continue
 			}


### PR DESCRIPTION
Currently when an EDS request comes in, we respond with endpoints for all clusters. This changes to just send back the newly requested items.
This helps with a common case where we trigger a push for a new service. First with push CDS (new cluster), then EDS, then envoy does an EDS request and we respond with the entire EDS again. Instead ,we can just send back the requested cluster.

The same can be done with RDS: https://github.com/istio/istio/pull/25165