### PR TITLE
Trigger endpoint update when pod comes in

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -74,14 +74,22 @@ var (
 		monitoring.WithLabels(typeTag, eventTag),
 	)
 
+	// This is deprecated in favor of `pilot_k8s_endpoints_pending_pod`, which is a gauge indicating the number of
+	// currently missing pods. This helps distinguish transient errors from permanent ones
 	endpointsWithNoPods = monitoring.NewSum(
 		"pilot_k8s_endpoints_with_no_pods",
 		"Endpoints that does not have any corresponding pods.")
+
+	endpointsPendingPodUpdate = monitoring.NewGauge(
+		"pilot_k8s_endpoints_pending_pod",
+		"Number of endpoints that do not currently have any corresponding pods.",
+	)
 )
 
 func init() {
 	monitoring.MustRegister(k8sEvents)
 	monitoring.MustRegister(endpointsWithNoPods)
+	monitoring.MustRegister(endpointsPendingPodUpdate)
 }
 
 func incrementEvent(kind, event string) {

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -245,19 +245,13 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 	registerHandlers(c.nodeInformer, c.queue, "Nodes", reflect.DeepEqual, c.onNodeEvent)
 
 	c.pods = newPodCache(c, kubeClient.KubeInformer().Core().V1().Pods(), func(key string) {
-		// todo endpoint slice
-		epc := c.endpoints.(*endpointsController)
-		item, exists, err := epc.informer.GetStore().GetByKey(key)
-		if err != nil {
-			log.Errorf("got error on endpoint update: %v", err)
-		}
-		if !exists {
-			log.Errorf("howardjohn: looked up %v, does not exist", key)
-			// must be stale, do nothing
+		item, exists, err := c.endpoints.getInformer().GetStore().GetByKey(key)
+		if err != nil || !exists {
+			log.Debugf("Endpoint %v lookup failed, skipping stale endpoint", key)
 			return
 		}
 		c.queue.Push(func() error {
-			return epc.onEvent(item, model.EventUpdate)
+			return c.endpoints.onEvent(item, model.EventUpdate)
 		})
 	})
 	registerHandlers(c.pods.informer, c.queue, "Pods", reflect.DeepEqual, c.pods.onEvent)

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -74,6 +74,7 @@ var (
 		monitoring.WithLabels(typeTag, eventTag),
 	)
 
+	// nolint: gocritic
 	// This is deprecated in favor of `pilot_k8s_endpoints_pending_pod`, which is a gauge indicating the number of
 	// currently missing pods. This helps distinguish transient errors from permanent ones
 	endpointsWithNoPods = monitoring.NewSum(

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -1655,6 +1655,8 @@ func TestEndpointUpdateBeforePodUpdate(t *testing.T) {
 			assertPendingResync := func(expected int) {
 				t.Helper()
 				retry.UntilSuccessOrFail(t, func() error {
+					controller.pods.RLock()
+					defer controller.pods.RUnlock()
 					if len(controller.pods.needResync) != expected {
 						return fmt.Errorf("expected %d pods needing resync, got %d", expected, len(controller.pods.needResync))
 					}

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -26,6 +26,7 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	coreV1 "k8s.io/api/core/v1"
 	discoveryv1alpha1 "k8s.io/api/discovery/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
@@ -44,6 +45,7 @@ import (
 	kubelib "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/retry"
 )
 
 const (
@@ -425,7 +427,7 @@ func TestController_GetPodLocality(t *testing.T) {
 			for _, pod := range tc.pods {
 				if err := waitForPod(controller, pod.Status.PodIP); err != nil {
 					// Ideally we would fail here, but there is a bug in Kubernetes fake client where
-					// it occasionally just does not update informer at all. Rather than skipping the entire test, we will
+					// it occasionally just does not update getInformer at all. Rather than skipping the entire test, we will
 					// just skip it if we encounter this condition. Because it happens rarely, we should still
 					// get coverage 99% of the time.
 					t.Skip("https://github.com/kubernetes/kubernetes/issues/88508")
@@ -1219,7 +1221,12 @@ func createEndpoints(controller *Controller, name, namespace string, portNames, 
 		}},
 	}
 	if _, err := controller.client.CoreV1().Endpoints(namespace).Create(context.TODO(), endpoint, metaV1.CreateOptions{}); err != nil {
-		t.Fatalf("failed to create endpoints %s in namespace %s (error %v)", name, namespace, err)
+		if errors.IsAlreadyExists(err) {
+			_, err = controller.client.CoreV1().Endpoints(namespace).Update(context.TODO(), endpoint, metaV1.UpdateOptions{})
+		}
+		if err != nil {
+			t.Fatalf("failed to create endpoints %s in namespace %s (error %v)", name, namespace, err)
+		}
 	}
 
 	// Create endpoint slice as well
@@ -1240,12 +1247,22 @@ func createEndpoints(controller *Controller, name, namespace string, portNames, 
 		Endpoints: []discoveryv1alpha1.Endpoint{
 			{
 				Addresses: ips,
+				TargetRef: &coreV1.ObjectReference{
+					Kind:      "Pod",
+					Name:      name,
+					Namespace: namespace,
+				},
 			},
 		},
 		Ports: esps,
 	}
 	if _, err := controller.client.DiscoveryV1alpha1().EndpointSlices(namespace).Create(context.TODO(), endpointSlice, metaV1.CreateOptions{}); err != nil {
-		t.Errorf("failed to create endpoint slice %s in namespace %s (error %v)", name, namespace, err)
+		if errors.IsAlreadyExists(err) {
+			_, err = controller.client.DiscoveryV1alpha1().EndpointSlices(namespace).Update(context.TODO(), endpointSlice, metaV1.UpdateOptions{})
+		}
+		if err != nil {
+			t.Fatalf("failed to create endpoint slice %s in namespace %s (error %v)", name, namespace, err)
+		}
 	}
 }
 
@@ -1583,58 +1600,121 @@ func TestEndpointUpdateBeforePodUpdate(t *testing.T) {
 			controller, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: mode})
 			// Setup kube caches
 			defer controller.Stop()
-			pod1 := generatePod("172.0.1.1", "pod1", "nsA", "", "node1", map[string]string{"app": "prod-app"}, map[string]string{})
-			pod2 := generatePod("172.0.1.2", "pod2", "nsA", "", "node2", map[string]string{"app": "prod-app"}, map[string]string{})
-
-			pods := []*coreV1.Pod{pod1, pod2}
-			nodes := []*coreV1.Node{
-				generateNode("node1", map[string]string{NodeZoneLabel: "zone1", NodeRegionLabel: "region1", IstioSubzoneLabel: "subzone1"}),
-				generateNode("node2", map[string]string{NodeZoneLabel: "zone2", NodeRegionLabel: "region2", IstioSubzoneLabel: "subzone2"}),
-			}
-			addNodes(t, controller, nodes...)
-			addPods(t, controller, pods...)
-			for _, pod := range pods {
+			addNodes(t, controller, generateNode("node1", map[string]string{NodeZoneLabel: "zone1", NodeRegionLabel: "region1", IstioSubzoneLabel: "subzone1"}))
+			// Setup help functions to make the test more explicit
+			addPod := func(name, ip string) {
+				pod := generatePod(ip, name, "nsA", "", "node1", map[string]string{"app": "prod-app"}, map[string]string{})
+				addPods(t, controller, pod)
 				if err := waitForPod(controller, pod.Status.PodIP); err != nil {
 					t.Fatalf("wait for pod err: %v", err)
 				}
 				// pod first time occur will trigger proxy push
 				if ev := fx.Wait("proxy"); ev == nil {
-					t.Fatal("Timeout creating service")
+					t.Fatal("Timeout creating pod")
 				}
 			}
-			// create service
-			createService(controller, "pod1", "nsA", nil,
-				[]int32{8080}, map[string]string{"app": "prod-app"}, t)
-			if ev := fx.Wait("service"); ev == nil {
-				t.Fatal("Timeout creating service")
+			deletePod := func(name, ip string) {
+				if err := controller.client.CoreV1().Pods("nsA").Delete(context.TODO(), name, metaV1.DeleteOptions{}); err != nil {
+					t.Fatal(err)
+				}
+				retry.UntilSuccessOrFail(t, func() error {
+					controller.pods.RLock()
+					defer controller.pods.RUnlock()
+					if _, ok := controller.pods.podsByIP[ip]; ok {
+						return fmt.Errorf("pod still present")
+					}
+					return nil
+				}, retry.Timeout(time.Second))
+			}
+			addService := func(name string) {
+				// create service
+				createService(controller, name, "nsA", nil,
+					[]int32{8080}, map[string]string{"app": "prod-app"}, t)
+				if ev := fx.Wait("service"); ev == nil {
+					t.Fatal("Timeout creating service")
+				}
+
+			}
+			addEndpoint := func(svcName string, ips ...string) {
+				createEndpoints(controller, svcName, "nsA", []string{"tcp-port"}, ips, t)
+			}
+			assertEndpointsEvent := func(expected ...string) {
+				t.Helper()
+				ev := fx.Wait("eds")
+				if ev == nil {
+					t.Fatalf("Timeout incremental eds")
+				}
+				ips := []string{}
+				for _, e := range ev.Endpoints {
+					ips = append(ips, e.Address)
+				}
+				if !reflect.DeepEqual(expected, ips) {
+					t.Fatalf("expected ips %v, got %v", expected, ips)
+				}
+			}
+			assertPendingResync := func(expected int) {
+				t.Helper()
+				retry.UntilSuccessOrFail(t, func() error {
+					if len(controller.pods.needResync) != expected {
+						return fmt.Errorf("expected %d pods needing resync, got %d", expected, len(controller.pods.needResync))
+					}
+					return nil
+				}, retry.Timeout(time.Second))
 			}
 
-			// Create Endpoints for pod1 and validate that EDS is triggered.
-			pod1Ips := []string{"172.0.1.1"}
-			portNames := []string{"tcp-port"}
-			createEndpoints(controller, "pod1", "nsA", portNames, pod1Ips, t)
-			if ev := fx.Wait("eds"); ev == nil {
-				t.Fatalf("Timeout incremental eds")
+			// standard ordering
+			addService("svc")
+			addPod("pod1", "172.0.1.1")
+			addEndpoint("svc", "172.0.1.1")
+			assertEndpointsEvent("172.0.1.1")
+			fx.Clear()
+
+			// Create the endpoint, then later add the pod. Should eventually get an update for
+			addEndpoint("svc", "172.0.1.1", "172.0.1.2")
+			assertEndpointsEvent("172.0.1.1")
+			fx.Clear()
+			addPod("pod2", "172.0.1.2")
+			assertEndpointsEvent("172.0.1.1", "172.0.1.2")
+
+			// Delete a pod before the endpoint
+			addEndpoint("svc", "172.0.1.1")
+			deletePod("pod2", "172.0.1.2")
+			assertEndpointsEvent("172.0.1.1")
+			fx.Clear()
+
+			// add another service
+			addService("other")
+			// Add endpoints for the new service, and the old one. Both should be missing the last IP
+			addEndpoint("other", "172.0.1.1", "172.0.1.2")
+			addEndpoint("svc", "172.0.1.1", "172.0.1.2")
+			assertEndpointsEvent("172.0.1.1")
+			assertEndpointsEvent("172.0.1.1")
+			fx.Clear()
+			// Add the pod, expect the endpoints update for both
+			addPod("pod2", "172.0.1.2")
+			assertEndpointsEvent("172.0.1.1", "172.0.1.2")
+			assertEndpointsEvent("172.0.1.1", "172.0.1.2")
+
+			// Check for memory leaks
+			assertPendingResync(0)
+			addEndpoint("svc", "172.0.1.1", "172.0.1.2", "172.0.1.3")
+			// This is really an implementation detail here - but checking to sanity check our test
+			assertPendingResync(1)
+			// Remove the endpoint again, with no pod events in between. Should have no memory leaks
+			addEndpoint("svc", "172.0.1.1", "172.0.1.2")
+			// TODO this case would leak
+			//assertPendingResync(0)
+
+			// completely remove the endpoint
+			addEndpoint("svc", "172.0.1.1", "172.0.1.2", "172.0.1.3")
+			assertPendingResync(1)
+			if err := controller.client.CoreV1().Endpoints("nsA").Delete(context.TODO(), "svc", metaV1.DeleteOptions{}); err != nil {
+				t.Fatal(err)
 			}
-
-			// Now delete pod2, from PodCache and send Endpoints. This simulates the case that endpoint comes
-			// when PodCache does not yet have entry for the pod.
-			_ = controller.pods.onEvent(pod2, model.EventDelete)
-
-			// create service
-			createService(controller, "pod2", "nsA", nil,
-				[]int32{8080}, map[string]string{"app": "prod-app"}, t)
-			if ev := fx.Wait("service"); ev == nil {
-				t.Fatal("Timeout creating service")
+			if err := controller.client.DiscoveryV1alpha1().EndpointSlices("nsA").Delete(context.TODO(), "svc", metaV1.DeleteOptions{}); err != nil {
+				t.Fatal(err)
 			}
-
-			pod2Ips := []string{"172.0.1.2"}
-			createEndpoints(controller, "pod2", "nsA", portNames, pod2Ips, t)
-
-			// Validate that EDS is triggered with endpoints.
-			if ev := fx.Wait("eds"); ev == nil {
-				t.Fatalf("Timeout incremental eds")
-			}
+			assertPendingResync(0)
 		})
 	}
 }

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -427,7 +427,7 @@ func TestController_GetPodLocality(t *testing.T) {
 			for _, pod := range tc.pods {
 				if err := waitForPod(controller, pod.Status.PodIP); err != nil {
 					// Ideally we would fail here, but there is a bug in Kubernetes fake client where
-					// it occasionally just does not update getInformer at all. Rather than skipping the entire test, we will
+					// it occasionally just does not update informer at all. Rather than skipping the entire test, we will
 					// just skip it if we encounter this condition. Because it happens rarely, we should still
 					// get coverage 99% of the time.
 					t.Skip("https://github.com/kubernetes/kubernetes/issues/88508")

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -1671,7 +1671,7 @@ func TestEndpointUpdateBeforePodUpdate(t *testing.T) {
 			assertEndpointsEvent("172.0.1.1")
 			fx.Clear()
 
-			// Create the endpoint, then later add the pod. Should eventually get an update for
+			// Create the endpoint, then later add the pod. Should eventually get an update for the endpoint
 			addEndpoint("svc", "172.0.1.1", "172.0.1.2")
 			assertEndpointsEvent("172.0.1.1")
 			fx.Clear()

--- a/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go
@@ -56,7 +56,7 @@ func (e *kubeEndpoints) Run(stopCh <-chan struct{}) {
 
 // processEndpointEvent triggers the config update.
 func processEndpointEvent(c *Controller, epc kubeEndpointsController, name string, namespace string, event model.Event, ep interface{}) error {
-	log.Debugf("Handle event %s for endpoint %s in namespace %s", event, name, namespace)
+	log.Infof("howardjohn: Handle event %s for endpoint %s in namespace %s", event, name, namespace)
 	if features.EnableHeadlessService {
 		if svc, _ := c.serviceLister.Services(namespace).Get(name); svc != nil {
 			// if the service is headless service, trigger a full push.

--- a/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go
@@ -33,10 +33,14 @@ import (
 type kubeEndpointsController interface {
 	HasSynced() bool
 	Run(stopCh <-chan struct{})
+	getInformer() cache.SharedIndexInformer
+	onEvent(curr interface{}, event model.Event) error
 	InstancesByPort(c *Controller, svc *model.Service, reqSvcPort int,
 		labelsList labels.Collection) ([]*model.ServiceInstance, error)
 	GetProxyServiceInstances(c *Controller, proxy *model.Proxy) []*model.ServiceInstance
 	buildIstioEndpoints(ep interface{}, host host.Name) []*model.IstioEndpoint
+	// forgetEndpoint does internal bookkeeping on a deleted endpoint
+	forgetEndpoint(endpoint interface{})
 	getServiceInfo(ep interface{}) (host.Name, string, string)
 }
 
@@ -56,7 +60,6 @@ func (e *kubeEndpoints) Run(stopCh <-chan struct{}) {
 
 // processEndpointEvent triggers the config update.
 func processEndpointEvent(c *Controller, epc kubeEndpointsController, name string, namespace string, event model.Event, ep interface{}) error {
-	log.Infof("howardjohn: Handle event %s for endpoint %s in namespace %s", event, name, namespace)
 	if features.EnableHeadlessService {
 		if svc, _ := c.serviceLister.Services(namespace).Get(name); svc != nil {
 			// if the service is headless service, trigger a full push.
@@ -96,6 +99,8 @@ func updateEDS(c *Controller, epc kubeEndpointsController, ep interface{}, event
 	var endpoints []*model.IstioEndpoint
 	if event != model.EventDelete {
 		endpoints = epc.buildIstioEndpoints(ep, host)
+	} else {
+		epc.forgetEndpoint(ep)
 	}
 	fep := c.collectAllForeignEndpoints(svc)
 	_ = c.xdsUpdater.EDSUpdate(c.clusterID, string(host), ns, append(endpoints, fep...))

--- a/pilot/pkg/serviceregistry/kube/controller/endpoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoints.go
@@ -201,7 +201,7 @@ func (e *endpointsController) buildIstioEndpoints(endpoint interface{}, host hos
 			pod := e.c.pods.getPodByIP(ea.IP)
 			if pod == nil {
 				// This means, the endpoint event has arrived before pod event. This might happen because
-				// PodCache is eventually consistent. We should try to get the pod from kube-api server.
+				// PodCache is eventually consistent.
 				if ea.TargetRef != nil && ea.TargetRef.Kind == "Pod" {
 					// There is a small chance getInformer may have the pod, but it hasn't made its way to the PodCache yet
 					// This is due to the shared queue. Try the getInformer store first

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -54,6 +54,10 @@ func newEndpointSliceController(c *Controller, informer v1alpha1.EndpointSliceIn
 	return out
 }
 
+func (esc *endpointSliceController) getInformer() cache.SharedIndexInformer {
+	return esc.informer
+}
+
 func (esc *endpointSliceController) onEvent(curr interface{}, event model.Event) error {
 	if err := esc.c.checkReadyForEvents(); err != nil {
 		return err
@@ -143,8 +147,19 @@ func sliceServiceInstances(c *Controller, ep *discoveryv1alpha1.EndpointSlice, p
 	return out
 }
 
+func (esc *endpointSliceController) forgetEndpoint(endpoint interface{}) {
+	slice := endpoint.(*discoveryv1alpha1.EndpointSlice)
+	key := kube.KeyFunc(slice.Name, slice.Namespace)
+	for _, e := range slice.Endpoints {
+		for _, a := range e.Addresses {
+			esc.c.pods.dropNeedsUpdate(key, a)
+		}
+	}
+}
+
 func (esc *endpointSliceController) buildIstioEndpoints(es interface{}, host host.Name) []*model.IstioEndpoint {
 	slice := es.(*discoveryv1alpha1.EndpointSlice)
+	key := kube.KeyFunc(slice.Name, slice.Namespace)
 	endpoints := make([]*model.IstioEndpoint, 0)
 	for _, e := range slice.Endpoints {
 		if e.Conditions.Ready != nil && !*e.Conditions.Ready {
@@ -154,20 +169,26 @@ func (esc *endpointSliceController) buildIstioEndpoints(es interface{}, host hos
 		for _, a := range e.Addresses {
 			pod := esc.c.pods.getPodByIP(a)
 			if pod == nil {
-				// This can not happen in usual case
+				// This means, the endpoint event has arrived before pod event. This might happen because
+				// PodCache is eventually consistent. We should try to get the pod from kube-api server.
 				if e.TargetRef != nil && e.TargetRef.Kind == "Pod" {
-					pod = esc.c.pods.getPod(e.TargetRef.Name, e.TargetRef.Namespace)
-					if pod == nil {
+					// There is a small chance getInformer may have the pod, but it hasn't made its way to the PodCache yet
+					// This is due to the shared queue. Try the getInformer store first
+					podFromInformer, f, err := esc.c.pods.informer.GetStore().GetByKey(key)
+					if err != nil || !f {
 						// If pod is still not available, this an unusual case.
 						endpointsWithNoPods.Increment()
 						log.Errorf("Endpoint without pod %s %s.%s", a, host, slice.Namespace)
 						if esc.c.metrics != nil {
 							esc.c.metrics.AddMetric(model.EndpointNoPod, string(host), nil, a)
 						}
+						// Tell pod cache we want to get an update when this pod arrives
+						esc.c.pods.recordNeedsUpdate(key, a)
 						continue
+					} else {
+						pod = podFromInformer.(*v1.Pod)
 					}
 				}
-				// For service without selector, maybe there are no related pods
 			}
 
 			builder := esc.newEndpointBuilder(pod, e)

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -170,7 +170,7 @@ func (esc *endpointSliceController) buildIstioEndpoints(es interface{}, host hos
 			pod := esc.c.pods.getPodByIP(a)
 			if pod == nil {
 				// This means, the endpoint event has arrived before pod event. This might happen because
-				// PodCache is eventually consistent. We should try to get the pod from kube-api server.
+				// PodCache is eventually consistent.
 				if e.TargetRef != nil && e.TargetRef.Kind == "Pod" {
 					// There is a small chance getInformer may have the pod, but it hasn't made its way to the PodCache yet
 					// This is due to the shared queue. Try the getInformer store first

--- a/pilot/pkg/serviceregistry/kube/controller/pod.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod.go
@@ -28,6 +28,7 @@ import (
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
+	"istio.io/istio/pilot/pkg/util/sets"
 )
 
 // PodCache is an eventually consistent pod cache
@@ -43,15 +44,21 @@ type PodCache struct {
 	// pod cache if a pod changes IP.
 	IPByPods map[string]string
 
+	// map of IP to endpoint names
+	needResync     map[string]sets.Set
+	endpointUpdate func(string)
+
 	c *Controller
 }
 
-func newPodCache(c *Controller, informer coreinformers.PodInformer) *PodCache {
+func newPodCache(c *Controller, informer coreinformers.PodInformer, endpointUpdate func(string)) *PodCache {
 	out := &PodCache{
-		informer: informer.Informer(),
-		c:        c,
-		podsByIP: make(map[string]string),
-		IPByPods: make(map[string]string),
+		informer:       informer.Informer(),
+		c:              c,
+		podsByIP:       make(map[string]string),
+		IPByPods:       make(map[string]string),
+		needResync:     make(map[string]sets.Set),
+		endpointUpdate: endpointUpdate,
 	}
 
 	return out
@@ -80,7 +87,7 @@ func (pc *PodCache) onEvent(curr interface{}, ev model.Event) error {
 	// via UpdateStatus.
 
 	if len(ip) > 0 {
-		log.Debugf("Handling event %s for pod %s (%v) in namespace %s -> %v", ev, pod.Name, pod.Status.Phase, pod.Namespace, ip)
+		log.Infof("howardjohn: Handling event %s for pod %s (%v) in namespace %s -> %v", ev, pod.Name, pod.Status.Phase, pod.Namespace, ip)
 		key := kube.KeyFunc(pod.Name, pod.Namespace)
 		switch ev {
 		case model.EventAdd:
@@ -136,7 +143,25 @@ func (pc *PodCache) update(ip, key string) {
 	pc.podsByIP[ip] = key
 	pc.IPByPods[key] = ip
 
+	if endpointsToUpdate, f := pc.needResync[ip]; f {
+		delete(pc.needResync, ip)
+		for ep := range endpointsToUpdate {
+			log.Errorf("howardjohn: triggering update for %v", ep)
+			pc.endpointUpdate(ep)
+		}
+	}
+
 	pc.proxyUpdates(ip)
+}
+
+func (pc *PodCache) recordNeedsUpdate(key, ip string) {
+	pc.RLock()
+	defer pc.RUnlock()
+	if _, f := pc.needResync[ip]; !f {
+		pc.needResync[ip] = sets.NewSet(key)
+	} else {
+		pc.needResync[ip].Insert(key)
+	}
 }
 
 func (pc *PodCache) proxyUpdates(ip string) {
@@ -174,4 +199,13 @@ func (pc *PodCache) getPod(name string, namespace string) *v1.Pod {
 		return nil
 	}
 	return pod
+}
+
+func (pc *PodCache) dropNeedsUpdate(key string, ip string) {
+	pc.RLock()
+	defer pc.RUnlock()
+	delete(pc.needResync[ip], key)
+	if len(pc.needResync[ip]) == 0 {
+		delete(pc.needResync, ip)
+	}
 }

--- a/pilot/pkg/serviceregistry/kube/controller/pod.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod.go
@@ -153,8 +153,8 @@ func (pc *PodCache) update(ip, key string) {
 }
 
 func (pc *PodCache) recordNeedsUpdate(key, ip string) {
-	pc.RLock()
-	defer pc.RUnlock()
+	pc.Lock()
+	defer pc.Unlock()
 	if _, f := pc.needResync[ip]; !f {
 		pc.needResync[ip] = sets.NewSet(key)
 	} else {
@@ -200,8 +200,8 @@ func (pc *PodCache) getPod(name string, namespace string) *v1.Pod {
 }
 
 func (pc *PodCache) dropNeedsUpdate(key string, ip string) {
-	pc.RLock()
-	defer pc.RUnlock()
+	pc.Lock()
+	defer pc.Unlock()
 	delete(pc.needResync[ip], key)
 	if len(pc.needResync[ip]) == 0 {
 		delete(pc.needResync, ip)

--- a/pilot/pkg/serviceregistry/kube/controller/pod.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod.go
@@ -160,6 +160,7 @@ func (pc *PodCache) recordNeedsUpdate(key, ip string) {
 	} else {
 		pc.needResync[ip].Insert(key)
 	}
+	endpointsPendingPodUpdate.Record(float64(len(pc.needResync)))
 }
 
 func (pc *PodCache) proxyUpdates(ip string) {
@@ -206,4 +207,5 @@ func (pc *PodCache) dropNeedsUpdate(key string, ip string) {
 	if len(pc.needResync[ip]) == 0 {
 		delete(pc.needResync, ip)
 	}
+	endpointsPendingPodUpdate.Record(float64(len(pc.needResync)))
 }

--- a/pilot/pkg/serviceregistry/kube/controller/pod.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod.go
@@ -87,7 +87,6 @@ func (pc *PodCache) onEvent(curr interface{}, ev model.Event) error {
 	// via UpdateStatus.
 
 	if len(ip) > 0 {
-		log.Infof("howardjohn: Handling event %s for pod %s (%v) in namespace %s -> %v", ev, pod.Name, pod.Status.Phase, pod.Namespace, ip)
 		key := kube.KeyFunc(pod.Name, pod.Namespace)
 		switch ev {
 		case model.EventAdd:
@@ -146,7 +145,6 @@ func (pc *PodCache) update(ip, key string) {
 	if endpointsToUpdate, f := pc.needResync[ip]; f {
 		delete(pc.needResync, ip)
 		for ep := range endpointsToUpdate {
-			log.Errorf("howardjohn: triggering update for %v", ep)
 			pc.endpointUpdate(ep)
 		}
 	}


### PR DESCRIPTION
@ramaraochavali @nrjpoddar what do you think? The basic idea is we record any pods we are missing. When those pods in later, we re-add the endpoint to the queue.

TODO: there is still a memory leak if the pod never comes