### PR TITLE
Fix ingress crash on shutdown

### DIFF
--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -258,11 +258,6 @@ func (c *controller) Run(stop <-chan struct{}) {
 		cache.WaitForCacheSync(stop, c.HasSynced)
 		c.queue.Run(stop)
 	}()
-	go c.ingressInformer.Run(stop)
-	go c.serviceInformer.Run(stop)
-	if c.classes != nil {
-		go c.classes.Informer().Run(stop)
-	}
 	<-stop
 }
 

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -137,6 +137,8 @@ func NewController(client kube.Client, meshWatcher mesh.Holder,
 	var classes v1beta1.IngressClassInformer
 	if ingressClassSupported(client) {
 		classes = client.KubeInformer().Networking().V1beta1().IngressClasses()
+		// Register the informer now, so it will be properly started
+		_ = classes.Informer()
 	} else {
 		log.Infof("Skipping IngressClass, resource not supported")
 	}


### PR DESCRIPTION
Currently this will panic when pilot exits; we should not run the
informers ourselves anymore, as they can only call .Run() one time and
they are shared. This is already called later at the top level



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure