### PR TITLE
Move injector to shared kube client

### DIFF
--- a/pilot/pkg/bootstrap/sidecarinjector.go
+++ b/pilot/pkg/bootstrap/sidecarinjector.go
@@ -69,7 +69,7 @@ func (s *Server) initSidecarInjector(args *PilotArgs) (*inject.Webhook, error) {
 			if hasCustomTLSCerts(args.ServerOptions.TLSOptions) {
 				caBundlePath = args.ServerOptions.TLSOptions.CaCertFile
 			}
-			webhooks.PatchCertLoop(features.InjectionWebhookConfigName.Get(), webhookName, caBundlePath, s.kubeClient, stop)
+			webhooks.PatchCertLoop(features.InjectionWebhookConfigName.Get(), webhookName, caBundlePath, s.kubeClients, stop)
 			return nil
 		})
 	}


### PR DESCRIPTION
This one is almost a NOP, as injection has a watch on a single object. I
think the best thing to do here is to create a new informer?



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure