### PR TITLE
Fix bookinfo/reviews Gradle build

### DIFF
--- a/samples/bookinfo/src/build-services.sh
+++ b/samples/bookinfo/src/build-services.sh
@@ -42,7 +42,7 @@ popd
 
 pushd "$SCRIPTDIR/reviews"
   #java build the app.
-  docker run --rm -u root -v "$(pwd)":/home/gradle/project -w /home/gradle/project gradle:4.8.1 gradle clean build
+  docker run --rm -u root -v "$(pwd)":/home/gradle/project -w /home/gradle/project gradle:4.8.1 gradle build
   pushd reviews-wlpcfg
     #plain build -- no ratings
     docker build --pull -t "${PREFIX}/examples-bookinfo-reviews-v1:${VERSION}" -t "${PREFIX}/examples-bookinfo-reviews-v1:latest" --build-arg service_version=v1 .


### PR DESCRIPTION
Running `src/build-services.sh` fails for the `reviews` service. I propose removing the `clean` target as it is not defined:

```
Welcome to Gradle 4.8.1!

Here are the highlights of this release:
 - Dependency locking
 - Maven Publish and Ivy Publish plugins improved and marked stable
 - Incremental annotation processing enhancements
 - APIs to configure tasks at creation time

For more details see https://docs.gradle.org/4.8.1/release-notes.html

Starting a Gradle Daemon (subsequent builds will be faster)

FAILURE: Build failed with an exception.

* What went wrong:
Task 'clean' not found in root project 'project'.

* Try:
Run gradle tasks to get a list of available tasks. Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 2s
```



[ ] Configuration Infrastructure
[X] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[X] Developer Infrastructure