### PR TITLE
Add env to support RSA Key size for Istio self signed CA certificates

### DIFF
--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -112,6 +112,9 @@ var (
 
 	audience = env.RegisterStringVar("AUDIENCE", "",
 		"Expected audience in the tokens. ")
+
+	caRSAKeySize = env.RegisterIntVar("CITADEL_SELF_SIGNED_CA_RSA_KEY_SIZE", 2048,
+		"Specify the RSA key size to use for self-signed Istio CA certificates.")
 )
 
 type CAOptions struct {
@@ -339,7 +342,7 @@ func (s *Server) createIstioCA(client corev1.CoreV1Interface, opts *CAOptions) (
 			selfSignedRootCertCheckInterval.Get(), workloadCertTTL.Get(),
 			maxCertTTL, opts.TrustDomain, true,
 			opts.Namespace, -1, client, rootCertFile,
-			enableJitterForRootCertRotator.Get())
+			enableJitterForRootCertRotator.Get(), caRSAKeySize.Get())
 		if err != nil {
 			return nil, fmt.Errorf("failed to create a self-signed istiod CA: %v", err)
 		}
@@ -358,7 +361,7 @@ func (s *Server) createIstioCA(client corev1.CoreV1Interface, opts *CAOptions) (
 		s.caBundlePath = certChainFile
 
 		caOpts, err = ca.NewPluggedCertIstioCAOptions(certChainFile, signingCertFile, signingKeyFile,
-			rootCertFile, workloadCertTTL.Get(), maxCertTTL)
+			rootCertFile, workloadCertTTL.Get(), maxCertTTL, caRSAKeySize.Get())
 		if err != nil {
 			return nil, fmt.Errorf("failed to create an istiod CA: %v", err)
 		}

--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -56,9 +56,6 @@ const (
 	// ServiceAccountNameAnnotationKey is the key to specify corresponding service account in the annotation of K8s secrets.
 	ServiceAccountNameAnnotationKey = "istio.io/service-account.name"
 
-	// The size of a private key for a self-signed Istio CA.
-	caKeySize = 2048
-
 	// The standard key size to use when generating an RSA private key
 	rsaKeySize = 2048
 )
@@ -82,6 +79,7 @@ type IstioCAOptions struct {
 
 	DefaultCertTTL time.Duration
 	MaxCertTTL     time.Duration
+	CARSAKeySize   int
 
 	KeyCertBundle util.KeyCertBundle
 
@@ -97,7 +95,7 @@ func NewSelfSignedIstioCAOptions(ctx context.Context,
 	rootCertGracePeriodPercentile int, caCertTTL, rootCertCheckInverval, defaultCertTTL,
 	maxCertTTL time.Duration, org string, dualUse bool, namespace string,
 	readCertRetryInterval time.Duration, client corev1.CoreV1Interface,
-	rootCertFile string, enableJitter bool) (caOpts *IstioCAOptions, err error) {
+	rootCertFile string, enableJitter bool, caRSAKeySize int) (caOpts *IstioCAOptions, err error) {
 	// For the first time the CA is up, if readSigningCertOnly is unset,
 	// it generates a self-signed key/cert pair and write it to CASecret.
 	// For subsequent restart, CA will reads key/cert from CASecret.
@@ -144,7 +142,7 @@ func NewSelfSignedIstioCAOptions(ctx context.Context,
 			Org:          org,
 			IsCA:         true,
 			IsSelfSigned: true,
-			RSAKeySize:   caKeySize,
+			RSAKeySize:   caRSAKeySize,
 			IsDualUse:    dualUse,
 		}
 		pemCert, pemKey, ckErr := util.GenCertKeyFromOptions(options)
@@ -185,11 +183,12 @@ func NewSelfSignedIstioCAOptions(ctx context.Context,
 
 // NewPluggedCertIstioCAOptions returns a new IstioCAOptions instance using given certificate.
 func NewPluggedCertIstioCAOptions(certChainFile, signingCertFile, signingKeyFile, rootCertFile string,
-	defaultCertTTL, maxCertTTL time.Duration) (caOpts *IstioCAOptions, err error) {
+	defaultCertTTL, maxCertTTL time.Duration, caRSAKeySize int) (caOpts *IstioCAOptions, err error) {
 	caOpts = &IstioCAOptions{
 		CAType:         pluggedCertCA,
 		DefaultCertTTL: defaultCertTTL,
 		MaxCertTTL:     maxCertTTL,
+		CARSAKeySize:   caRSAKeySize,
 	}
 	if _, err := os.Stat(signingKeyFile); err != nil {
 		// self generating for testing or local, non-k8s run
@@ -198,7 +197,7 @@ func NewPluggedCertIstioCAOptions(certChainFile, signingCertFile, signingKeyFile
 			Org:          "cluster.local",       // TODO: pass trustDomain ( or better - pass MeshConfig )
 			IsCA:         true,
 			IsSelfSigned: true,
-			RSAKeySize:   caKeySize,
+			RSAKeySize:   caRSAKeySize,
 			IsDualUse:    true, // hardcoded to true for K8S as well
 		}
 		pemCert, pemKey, ckErr := util.GenCertKeyFromOptions(options)
@@ -249,6 +248,7 @@ func NewPluggedCertIstioCAOptions(certChainFile, signingCertFile, signingKeyFile
 type IstioCA struct {
 	defaultCertTTL time.Duration
 	maxCertTTL     time.Duration
+	caRSAKeySize   int
 
 	keyCertBundle util.KeyCertBundle
 
@@ -265,6 +265,7 @@ func NewIstioCA(opts *IstioCAOptions) (*IstioCA, error) {
 		maxCertTTL:    opts.MaxCertTTL,
 		keyCertBundle: opts.KeyCertBundle,
 		livenessProbe: probe.NewProbe(),
+		caRSAKeySize:   opts.CARSAKeySize,
 	}
 
 	if opts.CAType == selfSignedCA && opts.RotatorConfig.CheckInterval > time.Duration(0) {

--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -265,7 +265,7 @@ func NewIstioCA(opts *IstioCAOptions) (*IstioCA, error) {
 		maxCertTTL:    opts.MaxCertTTL,
 		keyCertBundle: opts.KeyCertBundle,
 		livenessProbe: probe.NewProbe(),
-		caRSAKeySize:   opts.CARSAKeySize,
+		caRSAKeySize:  opts.CARSAKeySize,
 	}
 
 	if opts.CAType == selfSignedCA && opts.RotatorConfig.CheckInterval > time.Duration(0) {

--- a/security/pkg/pki/ca/ca_test.go
+++ b/security/pkg/pki/ca/ca_test.go
@@ -95,11 +95,12 @@ func TestCreateSelfSignedIstioCAWithoutSecret(t *testing.T) {
 	client := fake.NewSimpleClientset()
 	rootCertFile := ""
 	rootCertCheckInverval := time.Hour
+	rsaKeySize := 2048
 
 	caopts, err := NewSelfSignedIstioCAOptions(context.Background(),
 		0, caCertTTL, rootCertCheckInverval, defaultCertTTL,
 		maxCertTTL, org, false, caNamespace, -1, client.CoreV1(),
-		rootCertFile, false)
+		rootCertFile, false, rsaKeySize)
 	if err != nil {
 		t.Fatalf("Failed to create a self-signed CA Options: %v", err)
 	}
@@ -171,11 +172,12 @@ func TestCreateSelfSignedIstioCAWithSecret(t *testing.T) {
 	caNamespace := "default"
 	const rootCertFile = ""
 	rootCertCheckInverval := time.Hour
+	rsaKeySize := 2048
 
 	caopts, err := NewSelfSignedIstioCAOptions(context.Background(),
 		0, caCertTTL, rootCertCheckInverval, defaultCertTTL, maxCertTTL,
 		org, false, caNamespace, -1, client.CoreV1(),
-		rootCertFile, false)
+		rootCertFile, false, rsaKeySize)
 	if err != nil {
 		t.Fatalf("Failed to create a self-signed CA Options: %v", err)
 	}
@@ -221,6 +223,7 @@ func TestCreateSelfSignedIstioCAReadSigningCertOnly(t *testing.T) {
 	caNamespace := "default"
 	const rootCertFile = ""
 	rootCertCheckInverval := time.Hour
+	rsaKeySize := 2048
 
 	client := fake.NewSimpleClientset()
 
@@ -230,7 +233,7 @@ func TestCreateSelfSignedIstioCAReadSigningCertOnly(t *testing.T) {
 	defer cancel0()
 	_, err := NewSelfSignedIstioCAOptions(ctx0, 0,
 		caCertTTL, defaultCertTTL, rootCertCheckInverval, maxCertTTL, org, false,
-		caNamespace, time.Millisecond*10, client.CoreV1(), rootCertFile, false)
+		caNamespace, time.Millisecond*10, client.CoreV1(), rootCertFile, false, rsaKeySize)
 	if err == nil {
 		t.Errorf("Expected error, but succeeded.")
 	} else if err.Error() != expectedErr {
@@ -249,7 +252,7 @@ func TestCreateSelfSignedIstioCAReadSigningCertOnly(t *testing.T) {
 	defer cancel1()
 	caopts, err := NewSelfSignedIstioCAOptions(ctx1, 0,
 		caCertTTL, defaultCertTTL, rootCertCheckInverval, maxCertTTL, org, false,
-		caNamespace, time.Millisecond*10, client.CoreV1(), rootCertFile, false)
+		caNamespace, time.Millisecond*10, client.CoreV1(), rootCertFile, false, rsaKeySize)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -287,12 +290,13 @@ func TestCreatePluggedCertCA(t *testing.T) {
 	certChainFile := "../testdata/multilevelpki/int2-cert-chain.pem"
 	signingCertFile := "../testdata/multilevelpki/int2-cert.pem"
 	signingKeyFile := "../testdata/multilevelpki/int2-key.pem"
+	rsaKeySize := 2048
 
 	defaultWorkloadCertTTL := 99999 * time.Hour
 	maxWorkloadCertTTL := time.Hour
 
 	caopts, err := NewPluggedCertIstioCAOptions(certChainFile, signingCertFile, signingKeyFile, rootCertFile,
-		defaultWorkloadCertTTL, maxWorkloadCertTTL)
+		defaultWorkloadCertTTL, maxWorkloadCertTTL, rsaKeySize)
 	if err != nil {
 		t.Fatalf("Failed to create a plugged-cert CA Options: %v", err)
 	}
@@ -560,12 +564,13 @@ func TestSignWithCertChain(t *testing.T) {
 	certChainFile := "../testdata/multilevelpki/int-cert-chain.pem"
 	signingCertFile := "../testdata/multilevelpki/int-cert.pem"
 	signingKeyFile := "../testdata/multilevelpki/int-key.pem"
+	rsaKeySize := 2048
 
 	defaultWorkloadCertTTL := 30 * time.Minute
 	maxWorkloadCertTTL := time.Hour
 
 	caopts, err := NewPluggedCertIstioCAOptions(certChainFile, signingCertFile, signingKeyFile, rootCertFile,
-		defaultWorkloadCertTTL, maxWorkloadCertTTL)
+		defaultWorkloadCertTTL, maxWorkloadCertTTL, rsaKeySize)
 	if err != nil {
 		t.Fatalf("Failed to create a plugged-cert CA Options: %v", err)
 	}
@@ -626,10 +631,11 @@ func TestGenKeyCert(t *testing.T) {
 	}
 	defaultWorkloadCertTTL := 30 * time.Minute
 	maxWorkloadCertTTL := 3650 * 24 * time.Hour
+	rsaKeySize := 2048
 
 	for id, tc := range cases {
 		caopts, err := NewPluggedCertIstioCAOptions(tc.certChainFile, tc.signingCertFile, tc.signingKeyFile, tc.rootCertFile,
-			defaultWorkloadCertTTL, maxWorkloadCertTTL)
+			defaultWorkloadCertTTL, maxWorkloadCertTTL, rsaKeySize)
 		if err != nil {
 			t.Fatalf("%s: failed to create a plugged-cert CA Options: %v", id, err)
 		}

--- a/security/pkg/pki/ca/selfsignedcarootcertrotator.go
+++ b/security/pkg/pki/ca/selfsignedcarootcertrotator.go
@@ -172,7 +172,7 @@ func (rotator *SelfSignedCARootCertRotator) checkAndRotateRootCertForSigningCert
 		Org:           rotator.config.org,
 		IsCA:          true,
 		IsSelfSigned:  true,
-		RSAKeySize:    caKeySize,
+		RSAKeySize:    rotator.ca.caRSAKeySize,
 		IsDualUse:     rotator.config.dualUse,
 	}
 	// options should be consistent with the one used in NewSelfSignedIstioCAOptions().

--- a/security/pkg/pki/ca/selfsignedcarootcertrotator_test.go
+++ b/security/pkg/pki/ca/selfsignedcarootcertrotator_test.go
@@ -238,7 +238,7 @@ func TestKeyCertBundleReloadInRootCertRotatorForSigningCitadel(t *testing.T) {
 		Org:           rotator.config.org,
 		IsCA:          true,
 		IsSelfSigned:  true,
-		RSAKeySize:    caKeySize,
+		RSAKeySize:    rotator.ca.caRSAKeySize,
 		IsDualUse:     rotator.config.dualUse,
 	}
 	pemCert, pemKey, ckErr := util.GenRootCertFromExistingKey(options)
@@ -329,11 +329,12 @@ func getDefaultSelfSignedIstioCAOptions(fclient *fake.Clientset) *IstioCAOptions
 	}
 	rootCertFile := ""
 	rootCertCheckInverval := time.Hour
+	rsaKeySize := 2048
 
 	caopts, _ := NewSelfSignedIstioCAOptions(context.Background(),
 		cmd.DefaultRootCertGracePeriodPercentile, caCertTTL,
 		rootCertCheckInverval, defaultCertTTL, maxCertTTL, org, false,
-		caNamespace, -1, client, rootCertFile, false)
+		caNamespace, -1, client, rootCertFile, false, rsaKeySize)
 	return caopts
 }
 

--- a/security/pkg/server/ca/server_test.go
+++ b/security/pkg/server/ca/server_test.go
@@ -451,10 +451,11 @@ func TestGetServerCertificate(t *testing.T) {
 
 	defaultWorkloadCertTTL := 30 * time.Minute
 	maxWorkloadCertTTL := time.Hour
+	rsaKeySize := 2048
 
 	for id, tc := range cases {
 		caopts, err := ca.NewPluggedCertIstioCAOptions(tc.certChainFile, tc.signingCertFile, tc.signingKeyFile, tc.rootCertFile,
-			defaultWorkloadCertTTL, maxWorkloadCertTTL)
+			defaultWorkloadCertTTL, maxWorkloadCertTTL, rsaKeySize)
 		if err != nil {
 			t.Fatalf("%s: Failed to create a plugged-cert CA Options: %v", id, err)
 		}


### PR DESCRIPTION
When user specifies env `CITADEL_CA_RSA_KEY_SIZE` that key size is used to
generate Istio CA certificates allowing for finer control of security.

Part of a bigger effort to specify later Key parameters (e.g. RSA Key sizes for CSRs, type of Signature algorithm).


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure