### PR TITLE
istioctl --xds-san and --insecure options for testing XDS

### DIFF
--- a/istioctl/pkg/clioptions/central.go
+++ b/istioctl/pkg/clioptions/central.go
@@ -38,6 +38,9 @@ type CentralControlPlaneOptions struct {
 
 	// Timeout is how long to wait before giving up on XDS
 	Timeout time.Duration
+
+	// InsecureSkipVerify skips client verification the server's certificate chain and host name.
+	InsecureSkipVerify bool
 }
 
 // AttachControlPlaneFlags attaches control-plane flags to a Cobra command.
@@ -53,6 +56,8 @@ func (o *CentralControlPlaneOptions) AttachControlPlaneFlags(cmd *cobra.Command)
 		"Istiod pod port")
 	cmd.PersistentFlags().DurationVar(&o.Timeout, "timeout", time.Second*30,
 		"the duration to wait before failing")
+	cmd.PersistentFlags().BoolVar(&o.InsecureSkipVerify, "insecure", false,
+		"Skip server certificate and domain verification. (NOT SECURE!)")
 }
 
 // ValidateControlPlaneFlags checks arguments for valid values and combinations

--- a/istioctl/pkg/clioptions/central.go
+++ b/istioctl/pkg/clioptions/central.go
@@ -41,6 +41,9 @@ type CentralControlPlaneOptions struct {
 
 	// InsecureSkipVerify skips client verification the server's certificate chain and host name.
 	InsecureSkipVerify bool
+
+	// XDSSAN is the expected Subject Alternative Name of the XDS server
+	XDSSAN string
 }
 
 // AttachControlPlaneFlags attaches control-plane flags to a Cobra command.
@@ -56,6 +59,8 @@ func (o *CentralControlPlaneOptions) AttachControlPlaneFlags(cmd *cobra.Command)
 		"Istiod pod port")
 	cmd.PersistentFlags().DurationVar(&o.Timeout, "timeout", time.Second*30,
 		"the duration to wait before failing")
+	cmd.PersistentFlags().StringVar(&o.XDSSAN, "xds-san", "",
+		"XDS Subject Alternative Name (for example istiod.istio-system.svc)")
 	cmd.PersistentFlags().BoolVar(&o.InsecureSkipVerify, "insecure", false,
 		"Skip server certificate and domain verification. (NOT SECURE!)")
 }

--- a/istioctl/pkg/multixds/gather.go
+++ b/istioctl/pkg/multixds/gather.go
@@ -74,9 +74,9 @@ func queryEachShard(dr *xdsapi.DiscoveryRequest, istioNamespace string, kubeClie
 		defer fw.Close()
 		response, err := xds.GetXdsResponse(dr, &clioptions.CentralControlPlaneOptions{
 			Xds:                fw.Address(),
+			InsecureSkipVerify: true, // (Client certs won't be good for fw.Address())
 			CertDir:            centralOpts.CertDir,
 			Timeout:            centralOpts.Timeout,
-			InsecureSkipVerify: centralOpts.InsecureSkipVerify,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("could not get XDS from discovery pod %q: %v", pod.Name, err)

--- a/istioctl/pkg/multixds/gather.go
+++ b/istioctl/pkg/multixds/gather.go
@@ -73,9 +73,10 @@ func queryEachShard(dr *xdsapi.DiscoveryRequest, istioNamespace string, kubeClie
 		}
 		defer fw.Close()
 		response, err := xds.GetXdsResponse(dr, &clioptions.CentralControlPlaneOptions{
-			Xds:     fw.Address(),
-			CertDir: centralOpts.CertDir,
-			Timeout: centralOpts.Timeout,
+			Xds:                fw.Address(),
+			CertDir:            centralOpts.CertDir,
+			Timeout:            centralOpts.Timeout,
+			InsecureSkipVerify: centralOpts.InsecureSkipVerify,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("could not get XDS from discovery pod %q: %v", pod.Name, err)

--- a/istioctl/pkg/xds/client.go
+++ b/istioctl/pkg/xds/client.go
@@ -33,6 +33,7 @@ func GetXdsResponse(dr *xdsapi.DiscoveryRequest, opts *clioptions.CentralControl
 			Generator: "event",
 		}.ToStruct(),
 		InsecureSkipVerify: opts.InsecureSkipVerify,
+		XDSSAN:             opts.XDSSAN,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("could not dial: %w", err)

--- a/istioctl/pkg/xds/client.go
+++ b/istioctl/pkg/xds/client.go
@@ -32,10 +32,7 @@ func GetXdsResponse(dr *xdsapi.DiscoveryRequest, opts *clioptions.CentralControl
 		Meta: model.NodeMetadata{
 			Generator: "event",
 		}.ToStruct(),
-
-		// TODO I tried and failed to add DialOptions here and have ADSC
-		// pass them down so that I could add gRPC Interceptors for logging
-		// and debugging.
+		InsecureSkipVerify: opts.InsecureSkipVerify,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("could not dial: %w", err)

--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -93,6 +93,9 @@ type Config struct {
 	// XDSSAN is the expected SAN of the XDS server. If not set, the ProxyConfig.DiscoveryAddress is used.
 	XDSSAN string
 
+	// InsecureSkipVerify skips client verification the server's certificate chain and host name.
+	InsecureSkipVerify bool
+
 	// Watch is a list of resources to watch, represented as URLs (for new XDS resource naming)
 	// or type URLs.
 	Watch []string
@@ -343,6 +346,7 @@ func (a *ADSC) tlsConfig() (*tls.Config, error) {
 		VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 			return nil
 		},
+		InsecureSkipVerify: a.cfg.InsecureSkipVerify,
 	}, nil
 }
 


### PR DESCRIPTION
Adds `--insecure` option to `istioctl x verify`.  This debugging option works the same as `--insecure` on _grpcurl_.