### PR TITLE
Log XDS client rejections due to SPIFFE

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -592,10 +592,16 @@ func (s *Server) initSecureDiscoveryService(args *PilotArgs, port string) error 
 	log.Info("initializing secure discovery service")
 
 	cfg := &tls.Config{
-		GetCertificate:        s.getIstiodCertificate,
-		ClientAuth:            tls.VerifyClientCertIfGiven,
-		ClientCAs:             s.peerCertVerifier.GetGeneralCertPool(),
-		VerifyPeerCertificate: s.peerCertVerifier.VerifyPeerCert,
+		GetCertificate: s.getIstiodCertificate,
+		ClientAuth:     tls.VerifyClientCertIfGiven,
+		ClientCAs:      s.peerCertVerifier.GetGeneralCertPool(),
+		VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+			err := s.peerCertVerifier.VerifyPeerCert(rawCerts, verifiedChains)
+			if err != nil {
+				log.Infof("Could not verify certificate: %v", err)
+			}
+			return err
+		},
 	}
 
 	tlsCreds := credentials.NewTLS(cfg)

--- a/pkg/spiffe/spiffe.go
+++ b/pkg/spiffe/spiffe.go
@@ -275,7 +275,6 @@ func (v *PeerCertVerifier) VerifyPeerCert(rawCerts [][]byte, _ [][]*x509.Certifi
 	spiffeLog.Debugf("Verifying %d peer certificates", len(rawCerts))
 	if len(rawCerts) == 0 {
 		// Peer doesn't present a certificate. Just skip. Other authn methods may be used.
-		spiffeLog.Infof("Peer didn't present certificate")
 		return nil
 	}
 	var peerCert *x509.Certificate

--- a/pkg/spiffe/spiffe.go
+++ b/pkg/spiffe/spiffe.go
@@ -272,7 +272,6 @@ func (v *PeerCertVerifier) AddMappings(certMap map[string][]*x509.Certificate) {
 // VerifyPeerCert is an implementation of tls.Config.VerifyPeerCertificate.
 // It verifies the peer certificate using the root certificates associated with its trust domain.
 func (v *PeerCertVerifier) VerifyPeerCert(rawCerts [][]byte, _ [][]*x509.Certificate) error {
-	spiffeLog.Debugf("Verifying %d peer certificates", len(rawCerts))
 	if len(rawCerts) == 0 {
 		// Peer doesn't present a certificate. Just skip. Other authn methods may be used.
 		return nil
@@ -282,7 +281,6 @@ func (v *PeerCertVerifier) VerifyPeerCert(rawCerts [][]byte, _ [][]*x509.Certifi
 	for id, rawCert := range rawCerts {
 		cert, err := x509.ParseCertificate(rawCert)
 		if err != nil {
-			spiffeLog.Infof("Couldn't parse peer certificate %d", id)
 			return err
 		}
 		if id == 0 {
@@ -292,17 +290,14 @@ func (v *PeerCertVerifier) VerifyPeerCert(rawCerts [][]byte, _ [][]*x509.Certifi
 		}
 	}
 	if len(peerCert.URIs) != 1 {
-		spiffeLog.Infof("Peer certificate does not contain 1 URI type SAN, detected %d\n", len(peerCert.URIs))
 		return fmt.Errorf("peer certificate does not contain 1 URI type SAN, detected %d", len(peerCert.URIs))
 	}
 	trustDomain, err := GetTrustDomainFromURISAN(peerCert.URIs[0].String())
 	if err != nil {
-		spiffeLog.Infof("Couldn't get trust domain from %s", peerCert.URIs[0].String())
 		return err
 	}
 	rootCertPool, ok := v.certPools[trustDomain]
 	if !ok {
-		spiffeLog.Infof("No cert pool found for trust domain %s", trustDomain)
 		return fmt.Errorf("no cert pool found for trust domain %s", trustDomain)
 	}
 
@@ -310,8 +305,5 @@ func (v *PeerCertVerifier) VerifyPeerCert(rawCerts [][]byte, _ [][]*x509.Certifi
 		Roots:         rootCertPool,
 		Intermediates: intCertPool,
 	})
-	if err != nil {
-		spiffeLog.Infof("Couldn't verify peer certificate: %v", err)
-	}
 	return err
 }


### PR DESCRIPTION
Adds logging of SPIFFE-related reasons for rejecting a client.

Logs at INFO level.

While testing I was frustrated because totally bogus requests (e.g. grpcurl -insecure) logged failure:
```
error	ads	Failed to authenticate client &{[::1]:57854 {{772 true false 4865 h2 true localhost [] [] [] [] 0x1410950 []} {PrivacyAndIntegrity}}}
```

... but near successes logged nothing.  This change ensures something will be logged if an XDS client connection is rejected for a SPIFFE reason.