### PR TITLE
Fix agent starting when using ECC_SIGNATURE_ALGORITHM

### DIFF
--- a/pkg/istio-agent/sds-agent.go
+++ b/pkg/istio-agent/sds-agent.go
@@ -510,7 +510,6 @@ func (sa *Agent) newSecretCache(serverOptions sds.Options) (workloadSecretCache 
 
 	workloadSdsCacheOptions.TrustDomain = serverOptions.TrustDomain
 	workloadSdsCacheOptions.Pkcs8Keys = serverOptions.Pkcs8Keys
-	workloadSdsCacheOptions.ECCSigAlg = serverOptions.ECCSigAlg
 	workloadSdsCacheOptions.OutputKeyCertToDir = serverOptions.OutputKeyCertToDir
 
 	return
@@ -553,6 +552,7 @@ func applyEnvVars() {
 	serverOptions.Pkcs8Keys = pkcs8KeysEnv
 	serverOptions.ECCSigAlg = eccSigAlgEnv
 	serverOptions.RecycleInterval = staledConnectionRecycleIntervalEnv
+	workloadSdsCacheOptions.ECCSigAlg = eccSigAlgEnv
 	workloadSdsCacheOptions.SecretTTL = secretTTLEnv
 	workloadSdsCacheOptions.SecretRotationGracePeriodRatio = secretRotationGracePeriodRatioEnv
 	workloadSdsCacheOptions.RotationInterval = secretRotationIntervalEnv


### PR DESCRIPTION
Issue: Regression from 1.6.0 to 1.6.1. When ECC_SIGNATURE_ALGORITHM was being
set the secret cache was being created without the proper settings.

https://github.com/istio/istio/blob/master/pkg/istio-agent/sds-agent.go#L384 creates the secret cache, but this is not set until https://github.com/istio/istio/blob/master/pkg/istio-agent/sds-agent.go#L513

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
