### PR TITLE
Fix Istioctl upgrade with dry-run options

### DIFF
--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -210,20 +210,27 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 		return fmt.Errorf("failed to apply the Istio Control Plane specs. Error: %v", err)
 	}
 
-	// Waits for the upgrade to complete by periodically comparing the each
-	// component version to the target version.
-	err = waitUpgradeComplete(kubeClient, istioNamespace, targetVersion, l)
-	if err != nil {
-		return fmt.Errorf("failed to wait for the upgrade to complete. Error: %v", err)
+	if !rootArgs.dryRun {
+		// Waits for the upgrade to complete by periodically comparing the each
+		// component version to the target version.
+		err = waitUpgradeComplete(kubeClient, istioNamespace, targetVersion, l)
+		if err != nil {
+			return fmt.Errorf("failed to wait for the upgrade to complete. Error: %v", err)
+		}
+
+		// Read the upgraded Istio version from the the cluster
+		upgradeVer, err := retrieveControlPlaneVersion(kubeClient, istioNamespace, l)
+		if err != nil {
+			return fmt.Errorf("failed to read the upgraded Istio version. Error: %v", err)
+		}
+
+		l.LogAndPrintf("Success. Now the Istio control plane is running at version %v.\n", upgradeVer)
+	} else {
+		l.LogAndPrintf("Upgrade rollout completed. " +
+			"All Istio control plane pods are running on the target version.\n\n")
+		l.LogAndPrintf("Success. Now the Istio control plane is running at version %v.\n", targetVersion)
 	}
 
-	// Read the upgraded Istio version from the the cluster
-	upgradeVer, err := retrieveControlPlaneVersion(kubeClient, istioNamespace, l)
-	if err != nil {
-		return fmt.Errorf("failed to read the upgraded Istio version. Error: %v", err)
-	}
-
-	l.LogAndPrintf("Success. Now the Istio control plane is running at version %v.\n", upgradeVer)
 	l.LogAndPrintf(upgradeSidecarMessage)
 	return nil
 }


### PR DESCRIPTION
Fix Istioctl upgrade with dry-run options that keep checking component version.

https://github.com/istio/istio/issues/24865
https://discuss.istio.io/t/istioctl-1-6-3-upgrade-with-dry-run-option-keep-checking-component-version/7194

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure
