### PR TITLE
Do not trigger push to Gateways when Sidecar object changes

### DIFF
--- a/pilot/pkg/xds/ads_common.go
+++ b/pilot/pkg/xds/ads_common.go
@@ -22,7 +22,9 @@ import (
 
 // configKindAffectedProxyTypes contains known config types which will affect certain node types.
 var configKindAffectedProxyTypes = map[resource.GroupVersionKind][]model.NodeType{
-	gvk.Gateway:          {model.Router},
+	gvk.Gateway: {model.Router},
+	gvk.Sidecar: {model.SidecarProxy},
+
 	gvk.QuotaSpec:        {model.SidecarProxy},
 	gvk.QuotaSpecBinding: {model.SidecarProxy},
 }


### PR DESCRIPTION
Sidecar has no effect on gateways, no need to trigger a push



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure