### PR TITLE
Fix non k8s registry check

### DIFF
--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -211,7 +211,7 @@ func (s *DiscoveryServer) getNonK8sRegistries() []serviceregistry.Instance {
 	}
 
 	for _, registry := range registries {
-		if registry.Provider() != serviceregistry.Kubernetes && registry.Provider() != serviceregistry.External {
+		if registry.Provider() != serviceregistry.Kubernetes {
 			nonK8sRegistries = append(nonK8sRegistries, registry)
 		}
 	}

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -211,7 +211,7 @@ func (s *DiscoveryServer) getNonK8sRegistries() []serviceregistry.Instance {
 	}
 
 	for _, registry := range registries {
-		if registry.Provider() != serviceregistry.Kubernetes || registry.Provider() != serviceregistry.External {
+		if registry.Provider() != serviceregistry.Kubernetes && registry.Provider() != serviceregistry.External {
 			nonK8sRegistries = append(nonK8sRegistries, registry)
 		}
 	}

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -100,10 +100,15 @@ func buildEnvoyLbEndpoint(e *model.IstioEndpoint, push *model.PushContext) *endp
 // it with a model where DiscoveryServer keeps track of all endpoint registries
 // directly, and calls them one by one.
 func (s *DiscoveryServer) UpdateServiceShards(push *model.PushContext) error {
+	registries := s.getNonK8sRegistries()
+	// Short circuit now to avoid the call to Services
+	if len(registries) == 0 {
+		return nil
+	}
 	// Each registry acts as a shard - we don't want to combine them because some
 	// may individually update their endpoints incrementally
 	for _, svc := range push.Services(nil) {
-		for _, registry := range s.getNonK8sRegistries() {
+		for _, registry := range registries {
 			// skip the service in case this svc does not belong to the registry.
 			if svc.Attributes.ServiceRegistry != string(registry.Provider()) {
 				continue


### PR DESCRIPTION
Fixes regression caused by https://github.com/istio/istio/pull/24487

The `||` check is always true, should instead be `&&`.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure