### PR TITLE
dns: Deadlock fix and performance improvements.

### DIFF
--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -310,7 +310,7 @@ func (h *IstioDNS) ServeDNSTLS(w dns.ResponseWriter, r *dns.Msg) {
 	// By using this code, the latency is around 800us - with ~400 us in istiod
 	origID := r.MsgHdr.Id
 	var key uint16
-	ch := make(chan *dns.Msg)
+	ch := make(chan *dns.Msg, 1)
 	h.m.Lock()
 	h.outID++
 	key = h.outID

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -347,13 +347,14 @@ func (h *IstioDNS) ServeDNSTLS(w dns.ResponseWriter, r *dns.Msg) {
 		return
 	}
 
-	to := time.After(2 * time.Second)
+	to := time.NewTimer(2 * time.Second)
 	select {
 	case m := <-ch:
+		to.Stop()
 		m.MsgHdr.Id = origID
 		response = m
 		_ = w.WriteMsg(m)
-	case <-to:
+	case <-to.C:
 		return
 	}
 	if false {


### PR DESCRIPTION

The pkg/dns/dns.go implementation is currently leaking timers, and has a channel send/receive deadlock race. The included commits address both the resource waste as well as eliminate the potential for a deadlock.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[X] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure