### PR TITLE
Move UpstreamTLSContext Generation to separate function and extend test coverage

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -1013,11 +1013,7 @@ func buildUpstreamClusterTLSContext(opts *buildClusterOpts, tls *networking.Clie
 		}
 
 		tlsContext = &auth.UpstreamTlsContext{
-			CommonTlsContext: &auth.CommonTlsContext{
-				ValidationContextType: &auth.CommonTlsContext_ValidationContext{
-					ValidationContext: certValidationContext,
-				},
-			},
+			CommonTlsContext: &auth.CommonTlsContext{},
 			Sni: tls.Sni,
 		}
 		tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -1014,7 +1014,7 @@ func buildUpstreamClusterTLSContext(opts *buildClusterOpts, tls *networking.Clie
 
 		tlsContext = &auth.UpstreamTlsContext{
 			CommonTlsContext: &auth.CommonTlsContext{},
-			Sni: tls.Sni,
+			Sni:              tls.Sni,
 		}
 		tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
 			CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{


### PR DESCRIPTION
UpstreamTLSContext generation function just how we have a separate function for building downstream TLS context. This logic is quite extensive and needs to be decoupled into it's own function and TLS context needs to be tested separately. These changes were made in https://github.com/istio/istio/pull/25202 but git diff for this isn't pretty and makes it hard to review. So I've decoupled the moving to separate function logic here and will later rebase these changes in #25202 .  Ref:https://github.com/istio/istio/issues/14039