### PR TITLE
(test): add fake for GCE Metadata Server

### DIFF
--- a/pkg/test/fakes/gce_metadata_server/Dockerfile
+++ b/pkg/test/fakes/gce_metadata_server/Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+COPY ./main /gce-metadata-server
+EXPOSE 8080
+CMD ["/gce-metadata-server"]

--- a/pkg/test/fakes/gce_metadata_server/Makefile
+++ b/pkg/test/fakes/gce_metadata_server/Makefile
@@ -1,0 +1,33 @@
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.PHONY: build_and_push clean all
+
+MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+MD_PATH := $(dir $(MKFILE_PATH))
+IMG := gcr.io/istio-testing/fake-gce-metadata
+
+# NOTE: TAG should be updated whenever changes are made in this directory
+# This should also be updated in dependent components
+TAG := 1.0
+
+all: build_and_push clean
+
+build_and_push:
+	cd $(MD_PATH) && GOOS=linux GOARCH=amd64 go build main.go
+	docker build $(MD_PATH) -t $(IMG):$(TAG)
+	docker push $(IMG):$(TAG)
+
+clean:
+	rm $(MD_PATH)/main

--- a/pkg/test/fakes/gce_metadata_server/Makefile
+++ b/pkg/test/fakes/gce_metadata_server/Makefile
@@ -25,7 +25,7 @@ TAG := 1.0
 all: build_and_push clean
 
 build_and_push:
-	cd $(MD_PATH) && GOOS=linux GOARCH=amd64 go build main.go
+	cd $(MD_PATH) && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -tags netgo -ldflags '-w -extldflags "-static"' main.go
 	docker build $(MD_PATH) -t $(IMG):$(TAG)
 	docker push $(IMG):$(TAG)
 

--- a/pkg/test/fakes/gce_metadata_server/main.go
+++ b/pkg/test/fakes/gce_metadata_server/main.go
@@ -1,0 +1,127 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/gorilla/mux"
+)
+
+const (
+	addr = ":8080"
+
+	projID     = "test-project"
+	projNumber = "123456789"
+	instance   = "test-instance"
+	instID     = "987654321"
+
+	metaPrefix     = "/computeMetadata/v1"
+	projIDPath     = metaPrefix + "/project/project-id"
+	projNumberPath = metaPrefix + "/project/numeric-project-id"
+	instIDPath     = metaPrefix + "/instance/id"
+	instancePath   = metaPrefix + "/instance/name"
+	attrKey        = "attribute"
+	attrPath       = metaPrefix + "/instance/attributes/{" + attrKey + "}"
+)
+
+var (
+	hostHeaders = []string{"metadata", "metadata.google.internal", "169.254.169.254"}
+
+	instAttrs = map[string]string{
+		"cluster-name":      "test-cluster",
+		"cluster-location":  "us-west1-c",
+		"instance-template": "some-template",
+		"created-by":        "some-creator",
+	}
+)
+
+func checkMetadataHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		fmt.Println("request for: " + r.URL.Path)
+		w.Header().Add("Server", "Metadata Server for VM (Fake)")
+		w.Header().Add("Metadata-Flavor", "Google")
+
+		hasHostHeader := false
+		for _, a := range hostHeaders {
+			if a == r.Host {
+				hasHostHeader = true
+			}
+		}
+
+		if !hasHostHeader {
+			http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+			w.Header().Set("Content-Type", "text/html; charset=UTF-8")
+			return
+		}
+		flavor := r.Header.Get("Metadata-Flavor")
+		if flavor == "" && r.RequestURI != "/" {
+			http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+			w.Header().Set("Content-Type", "text/html; charset=UTF-8")
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func handleAttrs(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+
+	if val, ok := instAttrs[vars[attrKey]]; ok {
+		fmt.Fprint(w, val)
+		return
+	}
+
+	fmt.Fprint(w, http.StatusNotFound)
+}
+
+func main() {
+
+	r := mux.NewRouter()
+	r.Use(checkMetadataHeaders)
+	r.HandleFunc(projIDPath, func(w http.ResponseWriter, r *http.Request) { fmt.Fprint(w, projID) }).Methods("GET")
+	r.HandleFunc(projNumberPath, func(w http.ResponseWriter, r *http.Request) { fmt.Fprint(w, projNumber) }).Methods("GET")
+	r.HandleFunc(instIDPath, func(w http.ResponseWriter, r *http.Request) { fmt.Fprint(w, instID) }).Methods("GET")
+	r.HandleFunc(instancePath, func(w http.ResponseWriter, r *http.Request) { fmt.Fprint(w, instance) }).Methods("GET")
+	r.HandleFunc(attrPath, handleAttrs).Methods("GET")
+	http.Handle("/", r)
+
+	srv := &http.Server{Addr: addr}
+
+	done := make(chan os.Signal, 1)
+	signal.Notify(done, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		if err := srv.ListenAndServe(); err != http.ErrServerClosed {
+			log.Fatalf("listen: %v\n", err)
+		}
+	}()
+
+	fmt.Println("GCE metadata server started (" + addr + ")")
+	<-done
+	fmt.Println("GCE metadata server stopped.")
+
+	if err := srv.Shutdown(context.Background()); err != nil {
+		log.Fatalf("GCE Metadata Shutdown Failed: %+v", err)
+	}
+}


### PR DESCRIPTION
This PR establishes a basic fake for a GCE Metadata server. At the moment, nothing currently uses this fake. The intention is to use this in VM testing to provide simulation of GCE environment for testing purposes. The initial use of this will be for e2e telemetry tests on VMs.

The `Makefile` and `Dockerfile` are provided to allow easy creation of new images when required. It is NOT expected that these will need to be used at any frequency.

/cc @justinwei2 @howardjohn 

[ X ] Policies and Telemetry
[ X ] Test and Release
