### PR TITLE
eds: compare service accounts for existing endpoint shards only

### DIFF
--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -212,11 +212,14 @@ func (s *DiscoveryServer) edsUpdate(clusterID, serviceName string, namespace str
 	}
 
 	ep.mutex.Lock()
-	if !serviceAccounts.Equals(ep.ServiceAccounts) {
-		adsLog.Debugf("Updating service accounts now, svc %v, before service account %v, after %v",
-			serviceName, ep.ServiceAccounts, serviceAccounts)
-		adsLog.Infof("Full push, service accounts changed, %v", serviceName)
-		fullPush = true
+	// For existing endpoints, we need to do full push if service accounts change.
+	if !created {
+		if !serviceAccounts.Equals(ep.ServiceAccounts) {
+			adsLog.Debugf("Updating service accounts now, svc %v, before service account %v, after %v",
+				serviceName, ep.ServiceAccounts, serviceAccounts)
+			adsLog.Infof("Full push, service accounts changed, %v", serviceName)
+			fullPush = true
+		}
 	}
 	ep.Shards[clusterID] = istioEndpoints
 	ep.ServiceAccounts = serviceAccounts


### PR DESCRIPTION
If endpoint shard is newly created (that means new service) we any way do a full push. So we do not have to compare service accounts. This PR skips that

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
