### PR TITLE
istioctl: add command to manage logging levels for istiod

### DIFF
--- a/istioctl/cmd/dashboard_test.go
+++ b/istioctl/cmd/dashboard_test.go
@@ -45,8 +45,8 @@ func TestDashboard(t *testing.T) {
 		},
 		{ // case 3
 			args:           strings.Split("dashboard controlz pod-123456-7890", " "),
-			expectedRegexp: regexp.MustCompile(".*MockClient doesn't implement port forwarding"),
-			wantException:  true,
+			expectedRegexp: regexp.MustCompile(".*http://localhost:3456"),
+			wantException:  false,
 		},
 		{ // case 4
 			args:           strings.Split("dashboard envoy", " "),
@@ -55,8 +55,8 @@ func TestDashboard(t *testing.T) {
 		},
 		{ // case 5
 			args:           strings.Split("dashboard envoy pod-123456-7890", " "),
-			expectedRegexp: regexp.MustCompile(".*MockClient doesn't implement port forwarding"),
-			wantException:  true,
+			expectedRegexp: regexp.MustCompile("http://localhost:3456"),
+			wantException:  false,
 		},
 		{ // case 6
 			args:           strings.Split("dashboard grafana", " "),

--- a/istioctl/cmd/istiodconfig.go
+++ b/istioctl/cmd/istiodconfig.go
@@ -1,0 +1,495 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/spf13/cobra"
+
+	"istio.io/istio/istioctl/pkg/clioptions"
+	"istio.io/istio/istioctl/pkg/util/handlers"
+	"istio.io/pkg/log"
+)
+
+type flagState interface {
+	run() (string, error)
+}
+
+var _ flagState = (*resetState)(nil)
+var _ flagState = (*logLevelState)(nil)
+var _ flagState = (*stackTraceLevelState)(nil)
+var _ flagState = (*getAllLogLevelsState)(nil)
+
+type resetState struct {
+	client *ControlzClient
+}
+
+func (rs *resetState) run() (string, error) {
+
+	const (
+		defaultOutputLevel     = "info"
+		defaultStackTraceLevel = "none"
+	)
+	allScopes, err := rs.client.GetScopes()
+	if err != nil {
+		return "", fmt.Errorf("could not get all scopes: %v", err)
+	}
+	var defaultScopes []*ScopeInfo
+	for _, scope := range allScopes {
+		defaultScopes = append(defaultScopes, &ScopeInfo{
+			Name:            scope.Name,
+			OutputLevel:     defaultOutputLevel,
+			StackTraceLevel: defaultStackTraceLevel,
+		})
+	}
+	err = rs.client.PutScopes(defaultScopes)
+	if err != nil {
+		return "", err
+	}
+
+	return "", nil
+}
+
+type logLevelState struct {
+	client         *ControlzClient
+	outputLogLevel string
+}
+
+func (ll *logLevelState) run() (string, error) {
+	scopeInfos, err := newScopeInfosFromScopeLevelPairs(ll.outputLogLevel)
+	if err != nil {
+		return "", err
+	}
+	err = ll.client.PutScopes(scopeInfos)
+	if err != nil {
+		return "", err
+	}
+	return "", nil
+}
+
+type stackTraceLevelState struct {
+	client          *ControlzClient
+	stackTraceLevel string
+}
+
+func (stl *stackTraceLevelState) run() (string, error) {
+	scopeInfos, err := newScopeInfosFromScopeStackTraceLevelPairs(stl.stackTraceLevel)
+	if err != nil {
+		return "", err
+	}
+	err = stl.client.PutScopes(scopeInfos)
+	if err != nil {
+		return "", err
+	}
+	return "", nil
+}
+
+type getAllLogLevelsState struct {
+	client       *ControlzClient
+	outputFormat string
+}
+
+func (ga *getAllLogLevelsState) run() (string, error) {
+
+	type scopeLogLevel struct {
+		ScopeName string `json:"scope_name"`
+		LogLevel  string `json:"log_level"`
+	}
+	allScopes, err := ga.client.GetScopes()
+	sort.Slice(allScopes, func(i, j int) bool {
+		return allScopes[i].Name < allScopes[j].Name
+	})
+	if err != nil {
+		return "", fmt.Errorf("could not get scopes information: %v", err)
+	}
+	var resultScopeLogLevel []*scopeLogLevel
+	for _, scope := range allScopes {
+		resultScopeLogLevel = append(resultScopeLogLevel, &scopeLogLevel{ScopeName: scope.Name, LogLevel: scope.OutputLevel})
+	}
+	var output strings.Builder
+	switch ga.outputFormat {
+	case "short":
+		output.Write([]byte("active_scopes:\n"))
+		for _, sll := range resultScopeLogLevel {
+			_, _ = fmt.Fprintf(&output, "  %s:%s\n", sll.ScopeName, sll.LogLevel)
+		}
+	case "json":
+		outputBytes, err := json.MarshalIndent(&resultScopeLogLevel, "", "  ")
+		outputBytes = append(outputBytes, []byte("\n")...)
+		if err != nil {
+			return "", err
+		}
+		output.Write(outputBytes)
+	default:
+		return "", fmt.Errorf("output format %q not supported", ga.outputFormat)
+	}
+	return output.String(), nil
+}
+
+type istiodConfigLog struct {
+	state flagState
+}
+
+func (id *istiodConfigLog) execute() (string, error) {
+	output, err := id.state.run()
+	return output, err
+}
+
+func chooseClientFlag(ctrzClient *ControlzClient, reset bool, outputLogLevel, stackTraceLevel, outputFormat string) *istiodConfigLog {
+	if reset {
+		return &istiodConfigLog{state: &resetState{ctrzClient}}
+	} else if outputLogLevel != "" {
+		return &istiodConfigLog{state: &logLevelState{
+			client:         ctrzClient,
+			outputLogLevel: outputLogLevel,
+		}}
+	} else if stackTraceLevel != "" {
+		return &istiodConfigLog{state: &stackTraceLevelState{
+			client:          ctrzClient,
+			stackTraceLevel: stackTraceLevel,
+		}}
+	} else {
+		return &istiodConfigLog{state: &getAllLogLevelsState{
+			client:       ctrzClient,
+			outputFormat: outputFormat,
+		}}
+	}
+}
+
+type ScopeInfo struct {
+	Name            string `json:"name"`
+	Description     string `json:"description,omitempty"`
+	OutputLevel     string `json:"output_level,omitempty"`
+	StackTraceLevel string `json:"stack_trace_level,omitempty"`
+	LogCallers      bool   `json:"log_callers,omitempty"`
+}
+
+type ScopeLevelPair struct {
+	scope    string
+	logLevel string
+}
+
+type scopeStackTraceLevelPair ScopeLevelPair
+
+func newScopeLevelPair(slp, validationPattern string) (*ScopeLevelPair, error) {
+
+	matched, err := regexp.MatchString(validationPattern, slp)
+	if err != nil {
+		return nil, err
+	}
+	if !matched {
+		return nil, fmt.Errorf("pattern %s did not match", slp)
+	}
+	scopeLogLevel := strings.Split(slp, ":")
+	s := &ScopeLevelPair{
+		scope:    scopeLogLevel[0],
+		logLevel: scopeLogLevel[1],
+	}
+	return s, nil
+}
+
+func newScopeInfosFromScopeLevelPairs(scopeLevelPairs string) ([]*ScopeInfo, error) {
+	slParis := strings.Split(scopeLevelPairs, ",")
+	var scopeInfos []*ScopeInfo
+	for _, slp := range slParis {
+		sl, err := newScopeLevelPair(slp, validationPattern)
+		if err != nil {
+			return nil, err
+		}
+		si := &ScopeInfo{
+			Name:        sl.scope,
+			OutputLevel: sl.logLevel,
+		}
+		scopeInfos = append(scopeInfos, si)
+	}
+	return scopeInfos, nil
+}
+
+func newScopeStackTraceLevelPair(sslp, validationPattern string) (*scopeStackTraceLevelPair, error) {
+	matched, err := regexp.MatchString(validationPattern, sslp)
+	if err != nil {
+		return nil, err
+	}
+	if !matched {
+		return nil, fmt.Errorf("pattern %s did not match", sslp)
+	}
+	scopeStackTraceLevel := strings.Split(sslp, ":")
+	ss := &scopeStackTraceLevelPair{
+		scope:    scopeStackTraceLevel[0],
+		logLevel: scopeStackTraceLevel[1],
+	}
+	return ss, nil
+}
+
+func newScopeInfosFromScopeStackTraceLevelPairs(scopeStackTraceLevelPairs string) ([]*ScopeInfo, error) {
+	sslPairs := strings.Split(scopeStackTraceLevelPairs, ",")
+	var scopeInfos []*ScopeInfo
+	for _, sslp := range sslPairs {
+		slp, err := newScopeStackTraceLevelPair(sslp, validationPattern)
+		if err != nil {
+			return nil, err
+		}
+		si := &ScopeInfo{
+			Name:            slp.scope,
+			StackTraceLevel: slp.logLevel,
+		}
+		scopeInfos = append(scopeInfos, si)
+	}
+	return scopeInfos, nil
+}
+
+type ControlzClient struct {
+	baseURL    *url.URL
+	httpClient *http.Client
+}
+
+func (c *ControlzClient) GetScopes() ([]*ScopeInfo, error) {
+	var scopeInfos []*ScopeInfo
+	resp, err := c.httpClient.Get(c.baseURL.String())
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("request not successful %s", resp.Status)
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&scopeInfos)
+	if err != nil {
+		return nil, fmt.Errorf("cannot deserialize response %s", err)
+	}
+	return scopeInfos, nil
+}
+
+func (c *ControlzClient) PutScope(scope *ScopeInfo) error {
+	var jsonScopeInfo bytes.Buffer
+	err := json.NewEncoder(&jsonScopeInfo).Encode(scope)
+	if err != nil {
+		return fmt.Errorf("cannot serialize scope %+v", *scope)
+	}
+	req, err := http.NewRequest(http.MethodPut, c.baseURL.String()+"/"+scope.Name, &jsonScopeInfo)
+	if err != nil {
+		return err
+	}
+	defer req.Body.Close()
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted {
+		return fmt.Errorf("cannot update resource %s, got status %s", scope.Name, resp.Status)
+	}
+	return nil
+}
+
+func (c *ControlzClient) PutScopes(scopes []*ScopeInfo) error {
+
+	var ch = make(chan struct {
+		err       error
+		scopeName string
+	}, len(scopes))
+	var wg sync.WaitGroup
+	for _, scope := range scopes {
+		wg.Add(1)
+		go func(si *ScopeInfo) {
+			defer wg.Done()
+			err := c.PutScope(si)
+			ch <- struct {
+				err       error
+				scopeName string
+			}{err: err, scopeName: si.Name}
+		}(scope)
+	}
+	wg.Wait()
+	close(ch)
+	for result := range ch {
+		if result.err != nil {
+			return fmt.Errorf("failed updating Scope %s: %v", result.scopeName, result.err)
+
+		}
+	}
+	return nil
+
+}
+
+func (c *ControlzClient) GetScope(scope string) (*ScopeInfo, error) {
+	var s ScopeInfo
+	resp, err := http.Get(c.baseURL.String() + "/" + scope)
+	if err != nil {
+		return &s, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return &s, fmt.Errorf("request not successful %s: ", resp.Status)
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&s)
+	if err != nil {
+		return &s, fmt.Errorf("cannot deserialize response: %s", err)
+	}
+	return &s, nil
+}
+
+var (
+	istiodLabelSelector = ""
+	istiodReset         = false
+	validationPattern   = `^\w+:(debug|error|warn|info|debug)`
+)
+
+func istiodLogCmd() *cobra.Command {
+	var opts clioptions.ControlPlaneOptions
+	var outputLogLevel = ""
+	var stackTraceLevel = ""
+
+	// output format (yaml or short)
+	var outputFormat = "short"
+
+	logCmd := &cobra.Command{
+		Use:   "log [<pod-name>] [--level <scope>:<level>][--stack-trace-level <scope>:<level>]|[-r|--reset]|[--output|-o short|yaml]",
+		Short: "Manage istiod logging.",
+		Long:  "Retrieve or update logging levels of istiod components.",
+		Example: ` # Retrieve information about istiod logging levels.
+  istioctl istiod-config log [<pod-name>]
+
+  # Update levels of the specified loggers.
+  istioctl istiod-config log --level ads:debug,authorization:debug
+
+  # Reset levels of all the loggers to default value (info).
+  istioctl istiod-config log -r
+`,
+		Aliases: []string{"o"},
+		Args: func(logCmd *cobra.Command, args []string) error {
+			if istiodReset && outputLogLevel != "" {
+				logCmd.Println(logCmd.UsageString())
+				return fmt.Errorf("--level cannot be combined with --reset")
+			}
+			if istiodReset && stackTraceLevel != "" {
+				logCmd.Println(logCmd.UsageString())
+				return fmt.Errorf("--stack-trace-level cannot be combined with --reset")
+			}
+			return nil
+		},
+		RunE: func(logCmd *cobra.Command, args []string) error {
+			client, err := kubeClientWithRevision(kubeconfig, configContext, opts.Revision)
+			if err != nil {
+				return fmt.Errorf("failed to create k8s client: %v", err)
+			}
+
+			var podName, ns string
+			if len(args) == 0 {
+				pl, err := client.PodsForSelector(context.TODO(), handlers.HandleNamespace(istioNamespace, defaultNamespace), istiodLabelSelector)
+				if err != nil {
+					return fmt.Errorf("not able to locate pod with selector %s: %v", istiodLabelSelector, err)
+				}
+
+				if len(pl.Items) < 1 {
+					return errors.New("no pods found")
+				}
+
+				if len(pl.Items) > 1 {
+					log.Warnf("more than 1 pods fits selector: %s; will use pod: %s", istiodLabelSelector, pl.Items[0].Name)
+				}
+
+				// only use the first pod in the list
+				podName = pl.Items[0].Name
+				ns = pl.Items[0].Namespace
+			} else if len(args) == 1 {
+				podName, ns = args[0], istioNamespace
+			}
+
+			portForwarder, err := client.NewPortForwarder(podName, ns, bindAddress, 0, controlZport)
+			if err != nil {
+				return fmt.Errorf("could not build port forwarder for ControlZ %s: %v", podName, err)
+			}
+			defer portForwarder.Close()
+			err = portForwarder.Start()
+			if err != nil {
+				return fmt.Errorf("could not start port forwarder for ControlZ %s: %v", podName, err)
+			}
+
+			ctrlzClient := &ControlzClient{
+				baseURL: &url.URL{
+					Scheme: "http",
+					Host:   portForwarder.Address(),
+					Path:   "scopej",
+				},
+				httpClient: &http.Client{},
+			}
+			istiodConfigCmd := chooseClientFlag(ctrlzClient, istiodReset, outputLogLevel, stackTraceLevel, outputFormat)
+			output, err := istiodConfigCmd.execute()
+			if output != "" {
+				_, err := logCmd.OutOrStdout().Write([]byte(output))
+				if err != nil {
+					return err
+				}
+			}
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	logCmd.PersistentFlags().BoolVarP(&istiodReset, "reset", "r", istiodReset, "Reset levels to default value. (info)")
+	logCmd.PersistentFlags().IntVar(&controlZport, "ctrlz_port", 9876, "ControlZ port")
+	logCmd.PersistentFlags().StringVar(&outputLogLevel, "level", outputLogLevel,
+		"Comma-separated list of output logging level for scopes in format <scope>:<level>[,<scope>:<level>,...]"+
+			"Possible values for <level>: none, error, warn, info, debug")
+	logCmd.PersistentFlags().StringVar(&stackTraceLevel, "stack-trace-level", stackTraceLevel,
+		"Comma-separated list of stack trace level  for scopes in format <scope>:<stack-trace-level>[,<scope>:<stack-trace-level>,...] "+
+			"Possible values for <stack-trace-level>: none, error, warn, info, debug")
+	logCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o",
+		outputFormat, "Output format: one of json|short")
+	return logCmd
+}
+
+func istiodConfig() *cobra.Command {
+
+	istiodConfigCmd := &cobra.Command{
+		Use:   "istiod-config",
+		Short: "Manage control plane (istiod) configuration",
+		Long:  "A group of commands used to manage istiod configuration",
+		Example: ` # Retrieve information about istiod configuration.
+  istioctl istiod-config <log>`,
+		Aliases: []string{"idc"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.HelpFunc()(cmd, args)
+			if len(args) != 0 {
+				return fmt.Errorf("unknown subcommand %q", args[0])
+			}
+
+			return nil
+		},
+	}
+
+	istiodLog := istiodLogCmd()
+	istiodConfigCmd.AddCommand(istiodLog)
+	istiodConfigCmd.PersistentFlags().StringVarP(&istiodLabelSelector, "selector", "l", "app=istiod", "label selector")
+
+	return istiodConfigCmd
+}

--- a/istioctl/cmd/istiodconfig_test.go
+++ b/istioctl/cmd/istiodconfig_test.go
@@ -1,0 +1,295 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestCtlPlaneConfig(t *testing.T) {
+
+	istiodConfigMap := map[string][]byte{
+		"istiod-7b69ff6f8c-fvjvw": []byte("active_scopes:\n  ads:info"),
+	}
+
+	cases := []execTestCase{
+		{
+			args:           strings.Split("istiod-config", " "),
+			expectedString: "Manage istiod logging",
+		},
+		{
+			args:           strings.Split("idc", " "),
+			expectedString: "Manage istiod logging",
+		},
+		{
+			args:           strings.Split("idc log -l app=invalid", " "),
+			expectedString: "no pods found",
+			wantException:  true,
+		},
+		{
+			args:           strings.Split("idc log", " "),
+			expectedString: "no pods found",
+			wantException:  true,
+		},
+		{
+			execClientConfig: istiodConfigMap,
+			args:             strings.Split("idc log istiod-7b69ff6f8c-fvjvw --level invalid", " "),
+			expectedString:   "pattern invalid did not match",
+			wantException:    true,
+		},
+		{
+			execClientConfig: istiodConfigMap,
+			args:             strings.Split("idc log istiod-7b69ff6f8c-fvjvw --stack-trace-level invalid", " "),
+			expectedString:   "pattern invalid did not match",
+			wantException:    true,
+		},
+		{
+			args:           strings.Split("idc log --reset --level invalid", " "),
+			expectedString: "--level cannot be combined with --reset",
+			wantException:  true,
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case %d %s", i, strings.Join(c.args, " ")), func(t *testing.T) {
+			verifyExecTestOutput(t, c)
+		})
+	}
+}
+
+func Test_newScopeLevelPair(t *testing.T) {
+	var validationPattern = `^\w+:(debug|error|warn|info|debug)`
+	type args struct {
+		slp               string
+		validationPattern string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *ScopeLevelPair
+		wantErr bool
+	}{
+		{
+			name:    "Fail when logs scope-level pair don't match pattern",
+			args:    args{validationPattern: validationPattern, slp: "invalid:pattern"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := newScopeLevelPair(tt.args.slp, tt.args.validationPattern)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("newScopeLevelPair() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("newScopeLevelPair() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_newScopeStackTraceLevelPair(t *testing.T) {
+	var validationPattern = `^\w+:(debug|error|warn|info|debug)`
+	type args struct {
+		sslp              string
+		validationPattern string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *scopeStackTraceLevelPair
+		wantErr bool
+	}{
+		{
+			name:    "Fail when logs scope-level pair don't match pattern",
+			args:    args{validationPattern: validationPattern, sslp: "invalid:pattern"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := newScopeStackTraceLevelPair(tt.args.sslp, tt.args.validationPattern)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("newScopeStackTraceLevelPair() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("newScopeStackTraceLevelPair() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_chooseClientFlag(t *testing.T) {
+	url, _ := url.Parse("http://localhost/scopej/resource")
+
+	ctrzClient := &ControlzClient{
+		baseURL:    url,
+		httpClient: &http.Client{},
+	}
+
+	type args struct {
+		ctrzClient      *ControlzClient
+		reset           bool
+		outputLogLevel  string
+		stackTraceLevel string
+		outputFormat    string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *istiodConfigLog
+	}{
+		{
+			name: "given --reset flag return reset command",
+			args: args{
+				ctrzClient:      ctrzClient,
+				reset:           true,
+				outputLogLevel:  "",
+				stackTraceLevel: "",
+				outputFormat:    "",
+			},
+			want: &istiodConfigLog{state: &resetState{
+				client: ctrzClient,
+			}},
+		},
+		{
+			name: "given --level flag return outputLogLevel command",
+			args: args{
+				ctrzClient:      ctrzClient,
+				reset:           false,
+				outputLogLevel:  "resource:info",
+				stackTraceLevel: "",
+				outputFormat:    "",
+			},
+			want: &istiodConfigLog{state: &logLevelState{
+				client:         ctrzClient,
+				outputLogLevel: "resource:info",
+			}},
+		},
+		{
+			name: "given --stack-trace-level flag return stackTraceLevelState",
+			args: args{
+				ctrzClient:      ctrzClient,
+				reset:           false,
+				outputLogLevel:  "",
+				stackTraceLevel: "resource:info",
+				outputFormat:    "",
+			},
+			want: &istiodConfigLog{
+				state: &stackTraceLevelState{
+					client:          ctrzClient,
+					stackTraceLevel: "resource:info",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := chooseClientFlag(tt.args.ctrzClient, tt.args.reset, tt.args.outputLogLevel,
+				tt.args.stackTraceLevel, tt.args.outputFormat); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("chooseClientFlag() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func resourceHandler(writer http.ResponseWriter, request *http.Request) {
+	const getResponse = `{"name":"resource","description":"Core resource model scope","output_level":"info","stack_trace_level":"none","log_callers":false}`
+
+	switch request.Method {
+	case http.MethodGet:
+		_, _ = writer.Write([]byte(getResponse))
+	}
+}
+
+func adsHandler(writer http.ResponseWriter, request *http.Request) {
+	const getResponse = `{"name":"ads","description":"ads debugging","output_level":"info","stack_trace_level":"none","log_callers":false}`
+
+	switch request.Method {
+	case http.MethodGet:
+		_, _ = writer.Write([]byte(getResponse))
+
+	}
+}
+func setupHTTPServer() (*httptest.Server, *url.URL) {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/scopej/ads", adsHandler)
+	handler.HandleFunc("/scopej/resource", resourceHandler)
+	server := httptest.NewServer(handler)
+	url, _ := url.Parse(server.URL)
+	return server, url
+}
+
+func Test_flagState_run(t *testing.T) {
+
+	server, url := setupHTTPServer()
+	defer server.Close()
+
+	ctrzClientNoScopejHandler := &ControlzClient{
+		baseURL:    url,
+		httpClient: &http.Client{},
+	}
+	tests := []struct {
+		name    string
+		state   flagState
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "resetState.run() should throw an error if the /scopej endpoint is missing",
+			state:   &resetState{client: ctrzClientNoScopejHandler},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "logLevelState.run() should throw an error if the /scopej endpoint is missing",
+			state: &logLevelState{
+				client:         ctrzClientNoScopejHandler,
+				outputLogLevel: "test:debug",
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "stackTraceLevelState.run() should throw an error if the /scopej endpoint is missing",
+			state: &stackTraceLevelState{
+				client:          ctrzClientNoScopejHandler,
+				stackTraceLevel: "test:debug",
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.state.run()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("run() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("run() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/istioctl/cmd/metrics_test.go
+++ b/istioctl/cmd/metrics_test.go
@@ -70,7 +70,7 @@ func TestMetrics(t *testing.T) {
 	cases := []testCase{
 		{ // case 0
 			args:           strings.Split("experimental metrics details", " "),
-			expectedRegexp: regexp.MustCompile("Error: could not build port forwarder for prometheus"),
+			expectedRegexp: regexp.MustCompile("could not build metrics for workload"),
 			wantException:  true,
 		},
 	}

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -212,6 +212,7 @@ debug and diagnose their Istio mesh.
 
 	rootCmd.AddCommand(experimentalCmd)
 	rootCmd.AddCommand(proxyConfig())
+	rootCmd.AddCommand(istiodConfig())
 
 	rootCmd.AddCommand(install.NewVerifyCommand())
 	experimentalCmd.AddCommand(install.NewPrecheckCommand())

--- a/pkg/test/kube/mock_client.go
+++ b/pkg/test/kube/mock_client.go
@@ -45,6 +45,25 @@ import (
 
 var _ kube.ExtendedClient = MockClient{}
 
+type MockPortForwarder struct {
+}
+
+func (m MockPortForwarder) Start() error {
+	return nil
+}
+
+func (m MockPortForwarder) Address() string {
+	return "localhost:3456"
+}
+
+func (m MockPortForwarder) Close() {
+}
+
+func (m MockPortForwarder) WaitForStop() {
+}
+
+var _ kube.PortForwarder = MockPortForwarder{}
+
 // MockClient for tests that rely on kube.Client.
 type MockClient struct {
 	kubernetes.Interface
@@ -198,7 +217,7 @@ func (c MockClient) PodLogs(_ context.Context, _ string, _ string, _ string, _ b
 }
 
 func (c MockClient) NewPortForwarder(_, _, _ string, _, _ int) (kube.PortForwarder, error) {
-	return nil, fmt.Errorf("TODO MockClient doesn't implement port forwarding")
+	return MockPortForwarder{}, nil
 }
 
 // UtilFactory mock's kubectl's utility factory.  This code sets up a fake factory,

--- a/releasenotes/notes/istiod-config.yaml
+++ b/releasenotes/notes/istiod-config.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue:
+  - 25276
+releaseNotes:
+ - |
+   **Added** New command `istioctl istiod-config log` to enable managing logging levels
+   of `istiod` components.
+


### PR DESCRIPTION
Currently there is `istioctl pc log` command for Envoy proxy.
This changes adds similar functionalities for `istiod` through
`controlz` API.

Implements #24922



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ x ] User Experience
[ ] Developer Infrastructure