### PR TITLE
Log CRD client messages under a scope

### DIFF
--- a/pilot/pkg/config/kube/crdclient/cache_handler.go
+++ b/pilot/pkg/config/kube/crdclient/cache_handler.go
@@ -47,7 +47,7 @@ func (h *cacheHandler) onEvent(old interface{}, curr interface{}, event model.Ev
 
 	currItem, ok := curr.(runtime.Object)
 	if !ok {
-		log.Warnf("New Object can not be converted to runtime Object %v, is type %T", curr, curr)
+		scope.Warnf("New Object can not be converted to runtime Object %v, is type %T", curr, curr)
 		return nil
 	}
 	currConfig := *TranslateObject(currItem, h.schema.Resource().GroupVersionKind(), h.client.domainSuffix)

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -92,7 +92,7 @@ func (cl *Client) checkReadyForEvents(curr interface{}) error {
 	}
 	_, err := cache.DeletionHandlingMetaNamespaceKeyFunc(curr)
 	if err != nil {
-		log.Infof("Error retrieving key: %v", err)
+		scope.Infof("Error retrieving key: %v", err)
 	}
 	return nil
 }
@@ -108,7 +108,7 @@ func (cl *Client) RegisterEventHandler(kind resource.GroupVersionKind, handler f
 
 // Start the queue and all informers. Callers should  wait for HasSynced() before depending on results.
 func (cl *Client) Run(stop <-chan struct{}) {
-	log.Infoa("Starting Pilot K8S CRD controller")
+	scope.Infoa("Starting Pilot K8S CRD controller")
 
 	go func() {
 		cache.WaitForCacheSync(stop, cl.HasSynced)
@@ -116,13 +116,13 @@ func (cl *Client) Run(stop <-chan struct{}) {
 	}()
 
 	<-stop
-	log.Info("controller terminated")
+	scope.Info("controller terminated")
 }
 
 func (cl *Client) HasSynced() bool {
 	for kind, ctl := range cl.kinds {
 		if !ctl.informer.HasSynced() {
-			log.Infof("controller %q is syncing...", kind)
+			scope.Infof("controller %q is syncing...", kind)
 			return false
 		}
 	}
@@ -157,7 +157,7 @@ func New(client kube.Client, configLedger ledger.Ledger, revision string, option
 			}
 			out.kinds[s.Resource().GroupVersionKind()] = createCacheHandler(out, s, i)
 		} else {
-			log.Warnf("Skipping CRD %v as it is not present", s.Resource().GroupVersionKind())
+			scope.Warnf("Skipping CRD %v as it is not present", s.Resource().GroupVersionKind())
 		}
 	}
 
@@ -284,7 +284,7 @@ func knownCRDs(crdClient apiextensionsclient.Interface) map[string]struct{} {
 		if err == nil {
 			break
 		}
-		log.Errorf("failed to list CRDs: %v", err)
+		scope.Errorf("failed to list CRDs: %v", err)
 		time.Sleep(delay)
 		delay *= 2
 		if delay > maxDelay {
@@ -302,7 +302,7 @@ func knownCRDs(crdClient apiextensionsclient.Interface) map[string]struct{} {
 func TranslateObject(r runtime.Object, gvk resource.GroupVersionKind, domainSuffix string) *model.Config {
 	translateFunc, f := translationMap[gvk]
 	if !f {
-		log.Errorf("unknown type %v", gvk)
+		scope.Errorf("unknown type %v", gvk)
 		return nil
 	}
 	c := translateFunc(r)

--- a/pilot/pkg/config/kube/crdclient/metrics.go
+++ b/pilot/pkg/config/kube/crdclient/metrics.go
@@ -15,7 +15,6 @@
 package crdclient
 
 import (
-	"istio.io/pkg/log"
 	"istio.io/pkg/monitoring"
 
 	"istio.io/istio/pilot/pkg/model"
@@ -50,7 +49,7 @@ func incrementEvent(kind, event string) {
 
 func handleValidationFailure(obj *model.Config, err error) {
 	key := obj.Namespace + "/" + obj.Name
-	log.Debugf("CRD validation failed: %s (%v): %v", key, obj.GroupVersionKind, err)
+	scope.Debugf("CRD validation failed: %s (%v): %v", key, obj.GroupVersionKind, err)
 	k8sErrors.With(nameTag.Value(key)).Record(1)
 
 	k8sTotalErrors.Increment()


### PR DESCRIPTION
Discovered while diagnosing https://github.com/istio/istio/issues/25271

Messages like `Skipping CRD networking.x-k8s.io/v1alpha1/GatewayClass as it is not present` should be logged under a scope so that they can be tracked or suppressed.
