### PR TITLE
Add version label to `pilot_xds`  metric

### DIFF
--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -802,21 +802,20 @@ func (s *DiscoveryServer) addCon(conID string, con *Connection) {
 	s.adsClientsMutex.Lock()
 	defer s.adsClientsMutex.Unlock()
 	s.adsClients[conID] = con
-	xdsClients.Record(float64(len(s.adsClients)))
+	xdsClients.With(versionTag.Value(con.node.Metadata.IstioVersion)).Increment()
 }
 
 func (s *DiscoveryServer) removeCon(conID string) {
 	s.adsClientsMutex.Lock()
 	defer s.adsClientsMutex.Unlock()
 
-	if _, exist := s.adsClients[conID]; !exist {
+	if con, exist := s.adsClients[conID]; !exist {
 		adsLog.Errorf("ADS: Removing connection for non-existing node:%v.", conID)
 		totalXDSInternalErrors.Increment()
 	} else {
 		delete(s.adsClients, conID)
+		xdsClients.With(versionTag.Value(con.node.Metadata.IstioVersion)).Decrement()
 	}
-
-	xdsClients.Record(float64(len(s.adsClients)))
 	if s.StatusReporter != nil {
 		go s.StatusReporter.RegisterDisconnect(conID, AllEventTypes)
 	}

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -802,7 +802,7 @@ func (s *DiscoveryServer) addCon(conID string, con *Connection) {
 	s.adsClientsMutex.Lock()
 	defer s.adsClientsMutex.Unlock()
 	s.adsClients[conID] = con
-	xdsClients.With(versionTag.Value(con.node.Metadata.IstioVersion)).Increment()
+	recordXDSClients(con.node.Metadata.IstioVersion, 1)
 }
 
 func (s *DiscoveryServer) removeCon(conID string) {
@@ -814,7 +814,7 @@ func (s *DiscoveryServer) removeCon(conID string) {
 		totalXDSInternalErrors.Increment()
 	} else {
 		delete(s.adsClients, conID)
-		xdsClients.With(versionTag.Value(con.node.Metadata.IstioVersion)).Decrement()
+		recordXDSClients(con.node.Metadata.IstioVersion, -1)
 	}
 	if s.StatusReporter != nil {
 		go s.StatusReporter.RegisterDisconnect(conID, AllEventTypes)

--- a/pilot/pkg/xds/monitoring.go
+++ b/pilot/pkg/xds/monitoring.go
@@ -14,6 +14,8 @@
 package xds
 
 import (
+	"sync"
+
 	"google.golang.org/grpc/codes"
 
 	"istio.io/istio/pilot/pkg/model"
@@ -83,11 +85,13 @@ var (
 
 	// TODO: Update all the resource stats in separate routine
 	// virtual services, destination rules, gateways, etc.
-	xdsClients = monitoring.NewSum(
+	xdsClients = monitoring.NewGauge(
 		"pilot_xds",
 		"Number of endpoints connected to this pilot using XDS.",
 		monitoring.WithLabels(versionTag),
 	)
+	xdsClientTrackerMutex                    = &sync.Mutex{}
+	xdsClientTracker      map[string]float64 = make(map[string]float64)
 
 	xdsResponseWriteTimeouts = monitoring.NewSum(
 		"pilot_xds_write_timeout",
@@ -166,6 +170,13 @@ var (
 	inboundServiceUpdates = inboundUpdates.With(typeTag.Value("svc"))
 	inboundServiceDeletes = inboundUpdates.With(typeTag.Value("svcdelete"))
 )
+
+func recordXDSClients(version string, delta float64) {
+	xdsClientTrackerMutex.Lock()
+	defer xdsClientTrackerMutex.Unlock()
+	xdsClientTracker[version] += delta
+	xdsClients.With(versionTag.Value(version)).Record(xdsClientTracker[version])
+}
 
 func recordPushTriggers(reasons ...model.TriggerReason) {
 	for _, r := range reasons {

--- a/pilot/pkg/xds/monitoring.go
+++ b/pilot/pkg/xds/monitoring.go
@@ -28,6 +28,7 @@ var (
 	clusterTag = monitoring.MustCreateLabel("cluster")
 	nodeTag    = monitoring.MustCreateLabel("node")
 	typeTag    = monitoring.MustCreateLabel("type")
+	versionTag = monitoring.MustCreateLabel("version")
 
 	cdsReject = monitoring.NewGauge(
 		"pilot_xds_cds_reject",
@@ -82,9 +83,10 @@ var (
 
 	// TODO: Update all the resource stats in separate routine
 	// virtual services, destination rules, gateways, etc.
-	xdsClients = monitoring.NewGauge(
+	xdsClients = monitoring.NewSum(
 		"pilot_xds",
 		"Number of endpoints connected to this pilot using XDS.",
+		monitoring.WithLabels(versionTag),
 	)
 
 	xdsResponseWriteTimeouts = monitoring.NewSum(


### PR DESCRIPTION
Signed-off-by: Liam White <liam@tetrate.io>

Adds a version label to `pilot_xds` to give more information on data plane versions with needing to scrape the entire data plane.

See https://istio.slack.com/archives/C38CF1PEC/p1594141641327900 for background.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[x] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
