### PR TITLE
tests: remove pilot from echo config

### DIFF
--- a/pkg/test/framework/components/echo/config.go
+++ b/pkg/test/framework/components/echo/config.go
@@ -20,7 +20,6 @@ import (
 
 	"istio.io/istio/pkg/test/echo/common"
 	"istio.io/istio/pkg/test/framework/components/namespace"
-	"istio.io/istio/pkg/test/framework/components/pilot"
 	"istio.io/istio/pkg/test/framework/resource"
 )
 
@@ -32,9 +31,6 @@ type Config struct {
 
 	// Domain of the echo Instance. If not provided, a default will be selected.
 	Domain string
-
-	// Pilot component reference (may be required, depending on the environment/configuration).
-	Pilot pilot.Instance
 
 	// Service indicates the service name of the Echo application.
 	Service string

--- a/tests/integration/multicluster/centralistio/main_test.go
+++ b/tests/integration/multicluster/centralistio/main_test.go
@@ -100,9 +100,9 @@ values:
 }
 
 func TestMulticlusterReachability(t *testing.T) {
-	multicluster.ReachabilityTest(t, mcReachabilityNS, pilots, "installation.multicluster.central-istiod")
+	multicluster.ReachabilityTest(t, mcReachabilityNS, "installation.multicluster.central-istiod")
 }
 
 func TestClusterLocalService(t *testing.T) {
-	multicluster.ClusterLocalTest(t, clusterLocalNS, pilots, "installation.multicluster.central-istiod")
+	multicluster.ClusterLocalTest(t, clusterLocalNS, "installation.multicluster.central-istiod")
 }

--- a/tests/integration/multicluster/cluster_local.go
+++ b/tests/integration/multicluster/cluster_local.go
@@ -22,14 +22,13 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
 	"istio.io/istio/pkg/test/framework/components/namespace"
-	"istio.io/istio/pkg/test/framework/components/pilot"
 	"istio.io/istio/pkg/test/framework/features"
 	"istio.io/istio/pkg/test/framework/label"
 )
 
 // ClusterLocalTest tests that traffic works within a local cluster while in a multicluster configuration
 // clusterLocalNS have been configured in meshConfig.serviceSettings to be clusterLocal.
-func ClusterLocalTest(t *testing.T, clusterLocalNS namespace.Instance, pilots []pilot.Instance, feature features.Feature) {
+func ClusterLocalTest(t *testing.T, clusterLocalNS namespace.Instance, feature features.Feature) {
 	framework.NewTest(t).
 		Features(feature).
 		Run(func(ctx framework.TestContext) {
@@ -46,14 +45,14 @@ func ClusterLocalTest(t *testing.T, clusterLocalNS namespace.Instance, pilots []
 							srcName, dstName := fmt.Sprintf("src-%d", i), fmt.Sprintf("dst-%d", i)
 							var src, dst echo.Instance
 							builder := echoboot.NewBuilderOrFail(ctx, ctx).
-								With(&src, newEchoConfig(srcName, clusterLocalNS, local, pilots)).
-								With(&dst, newEchoConfig(dstName, clusterLocalNS, local, pilots))
+								With(&src, newEchoConfig(srcName, clusterLocalNS, local)).
+								With(&dst, newEchoConfig(dstName, clusterLocalNS, local))
 							for j, remoteCluster := range clusters {
 								if i == j {
 									continue
 								}
 								var ref echo.Instance
-								builder = builder.With(&ref, newEchoConfig(dstName, clusterLocalNS, remoteCluster, pilots))
+								builder = builder.With(&ref, newEchoConfig(dstName, clusterLocalNS, remoteCluster))
 							}
 							builder.BuildOrFail(ctx)
 

--- a/tests/integration/multicluster/helper.go
+++ b/tests/integration/multicluster/helper.go
@@ -24,7 +24,6 @@ import (
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/namespace"
-	"istio.io/istio/pkg/test/framework/components/pilot"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/util/retry"
 )
@@ -60,7 +59,7 @@ values:
 	}
 }
 
-func newEchoConfig(service string, ns namespace.Instance, cluster resource.Cluster, pilots []pilot.Instance) echo.Config {
+func newEchoConfig(service string, ns namespace.Instance, cluster resource.Cluster) echo.Config {
 	return echo.Config{
 		Service:        service,
 		Namespace:      ns,

--- a/tests/integration/multicluster/helper.go
+++ b/tests/integration/multicluster/helper.go
@@ -62,7 +62,6 @@ values:
 
 func newEchoConfig(service string, ns namespace.Instance, cluster resource.Cluster, pilots []pilot.Instance) echo.Config {
 	return echo.Config{
-		Pilot:          pilots[cluster.Index()],
 		Service:        service,
 		Namespace:      ns,
 		Cluster:        cluster,

--- a/tests/integration/multicluster/multimaster/main_test.go
+++ b/tests/integration/multicluster/multimaster/main_test.go
@@ -59,13 +59,13 @@ func TestMain(m *testing.M) {
 }
 
 func TestMulticlusterReachability(t *testing.T) {
-	multicluster.ReachabilityTest(t, mcReachabilityNS, pilots, "installation.multicluster.multimaster")
+	multicluster.ReachabilityTest(t, mcReachabilityNS, "installation.multicluster.multimaster")
 }
 
 func TestClusterLocalService(t *testing.T) {
-	multicluster.ClusterLocalTest(t, clusterLocalNS, pilots, "installation.multicluster.multimaster")
+	multicluster.ClusterLocalTest(t, clusterLocalNS, "installation.multicluster.multimaster")
 }
 
 func TestTelemetry(t *testing.T) {
-	multicluster.TelemetryTest(t, mcReachabilityNS, pilots, "installation.multicluster.multimaster")
+	multicluster.TelemetryTest(t, mcReachabilityNS, "installation.multicluster.multimaster")
 }

--- a/tests/integration/multicluster/reachability.go
+++ b/tests/integration/multicluster/reachability.go
@@ -22,7 +22,6 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
 	"istio.io/istio/pkg/test/framework/components/namespace"
-	"istio.io/istio/pkg/test/framework/components/pilot"
 	"istio.io/istio/pkg/test/framework/features"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
@@ -31,7 +30,7 @@ import (
 const mcReachabilitySvcPerCluster = 3
 
 // ReachabilityTest tests that services in 2 different clusters can talk to each other.
-func ReachabilityTest(t *testing.T, ns namespace.Instance, pilots []pilot.Instance, feature features.Feature) {
+func ReachabilityTest(t *testing.T, ns namespace.Instance, feature features.Feature) {
 	framework.NewTest(t).
 		Label(label.Multicluster).
 		Features(feature).
@@ -51,7 +50,7 @@ func ReachabilityTest(t *testing.T, ns namespace.Instance, pilots []pilot.Instan
 							var instance echo.Instance
 							ref := &instance
 							svcName := fmt.Sprintf("echo-%d-%d", cluster.Index(), i)
-							builder = builder.With(ref, newEchoConfig(svcName, ns, cluster, pilots))
+							builder = builder.With(ref, newEchoConfig(svcName, ns, cluster))
 							services[cluster.Index()] = append(services[cluster.Index()], ref)
 						}
 					}

--- a/tests/integration/multicluster/remote/main_test.go
+++ b/tests/integration/multicluster/remote/main_test.go
@@ -69,13 +69,13 @@ func TestMain(m *testing.M) {
 }
 
 func TestMulticlusterReachability(t *testing.T) {
-	multicluster.ReachabilityTest(t, mcReachabilityNS, pilots, "installation.multicluster.remote")
+	multicluster.ReachabilityTest(t, mcReachabilityNS, "installation.multicluster.remote")
 }
 
 func TestClusterLocalService(t *testing.T) {
-	multicluster.ClusterLocalTest(t, clusterLocalNS, pilots, "installation.multicluster.remote")
+	multicluster.ClusterLocalTest(t, clusterLocalNS, "installation.multicluster.remote")
 }
 
 func TestTelemetry(t *testing.T) {
-	multicluster.TelemetryTest(t, mcReachabilityNS, pilots, "installation.multicluster.remote")
+	multicluster.TelemetryTest(t, mcReachabilityNS, "installation.multicluster.remote")
 }

--- a/tests/integration/multicluster/telemetry.go
+++ b/tests/integration/multicluster/telemetry.go
@@ -23,7 +23,6 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
 	"istio.io/istio/pkg/test/framework/components/namespace"
-	"istio.io/istio/pkg/test/framework/components/pilot"
 	"istio.io/istio/pkg/test/framework/features"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
@@ -31,7 +30,7 @@ import (
 
 // TelemetryTest validates that source and destination labels are collected
 // for multicluster traffic.
-func TelemetryTest(t *testing.T, ns namespace.Instance, pilots []pilot.Instance, feature features.Feature) {
+func TelemetryTest(t *testing.T, ns namespace.Instance, feature features.Feature) {
 	framework.NewTest(t).
 		Label(label.Multicluster).
 		Features(feature).
@@ -45,7 +44,7 @@ func TelemetryTest(t *testing.T, ns namespace.Instance, pilots []pilot.Instance,
 						var instance echo.Instance
 						ref := &instance
 						svcName := fmt.Sprintf("echo-%d", cluster.Index())
-						builder = builder.With(ref, newEchoConfig(svcName, ns, cluster, pilots))
+						builder = builder.With(ref, newEchoConfig(svcName, ns, cluster))
 						services[cluster.Index()] = append(services[cluster.Index()], ref)
 					}
 					builder.BuildOrFail(ctx)

--- a/tests/integration/pilot/ingress/ingress_test.go
+++ b/tests/integration/pilot/ingress/ingress_test.go
@@ -28,7 +28,6 @@ import (
 	"istio.io/istio/pkg/test/framework/components/ingress"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/namespace"
-	"istio.io/istio/pkg/test/framework/components/pilot"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/util/retry"
@@ -36,7 +35,6 @@ import (
 
 var (
 	i    istio.Instance
-	p    pilot.Instance
 	ingr ingress.Instance
 )
 
@@ -61,9 +59,6 @@ func TestMain(m *testing.M) {
 			cfg.Values["pilot.env.PILOT_ENABLED_SERVICE_APIS"] = "true"
 		})).
 		Setup(func(ctx resource.Context) (err error) {
-			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
-				return err
-			}
 			if ingr, err = ingress.New(ctx, ingress.Config{
 				Istio: i,
 			}); err != nil {
@@ -88,7 +83,6 @@ func TestGateway(t *testing.T) {
 					Service:   "server",
 					Namespace: ns,
 					Subsets:   []echo.SubsetConfig{{}},
-					Pilot:     p,
 					Ports: []echo.Port{
 						{
 							Name:     "http",
@@ -179,7 +173,6 @@ func TestIngress(t *testing.T) {
 					Service:   "server",
 					Namespace: ns,
 					Subsets:   []echo.SubsetConfig{{}},
-					Pilot:     p,
 					Ports: []echo.Port{
 						{
 							Name:     "http-test-port",

--- a/tests/integration/pilot/locality/main_test.go
+++ b/tests/integration/pilot/locality/main_test.go
@@ -32,7 +32,6 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/namespace"
-	"istio.io/istio/pkg/test/framework/components/pilot"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/util/retry"
@@ -158,7 +157,6 @@ var (
 	expectAllTrafficToB = map[string]int{"b": sendCount}
 
 	ist istio.Instance
-	p   pilot.Instance
 	r   *rand.Rand
 )
 
@@ -188,9 +186,6 @@ func TestMain(m *testing.M) {
 		Label(label.CustomSetup).
 		Setup(istio.Setup(&ist, nil)).
 		Setup(func(ctx resource.Context) (err error) {
-			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
-				return err
-			}
 			r = rand.New(rand.NewSource(time.Now().UnixNano()))
 			return nil
 		}).
@@ -212,7 +207,6 @@ func echoConfig(ns namespace.Instance, name string) echo.Config {
 				InstancePort: 8090,
 			},
 		},
-		Pilot: p,
 	}
 }
 

--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -68,6 +68,5 @@ func echoConfig(ns namespace.Instance, name string) echo.Config {
 			},
 		},
 		Subsets: []echo.SubsetConfig{{}},
-		Pilot:   p,
 	}
 }

--- a/tests/integration/pilot/meshnetwork/main_test.go
+++ b/tests/integration/pilot/meshnetwork/main_test.go
@@ -127,7 +127,6 @@ func TestAsymmetricMeshNetworkWithGatewayIP(t *testing.T) {
 				Service:   "server",
 				Namespace: ns,
 				Subsets:   []echo.SubsetConfig{{}},
-				Pilot:     p,
 				Ports: []echo.Port{
 					{
 						Name:        "http",

--- a/tests/integration/pilot/ping_test.go
+++ b/tests/integration/pilot/ping_test.go
@@ -77,7 +77,6 @@ func doTest(t *testing.T, ctx framework.TestContext) {
 			Namespace:           ns,
 			Ports:               ports,
 			Subsets:             []echo.SubsetConfig{{}},
-			Pilot:               p,
 			IncludeInboundPorts: "*",
 		}).
 		With(&inoutSplitApp1, echo.Config{
@@ -85,7 +84,6 @@ func doTest(t *testing.T, ctx framework.TestContext) {
 			Namespace:           ns,
 			Subsets:             []echo.SubsetConfig{{}},
 			Ports:               ports,
-			Pilot:               p,
 			IncludeInboundPorts: "*",
 		}).
 		With(
@@ -94,14 +92,12 @@ func doTest(t *testing.T, ctx framework.TestContext) {
 				Namespace: ns,
 				Subsets:   []echo.SubsetConfig{{}},
 				Ports:     ports,
-				Pilot:     p,
 			}).
 		With(&inoutUnitedApp1, echo.Config{
 			Service:   "inoutunitedapp1",
 			Namespace: ns,
 			Subsets:   []echo.SubsetConfig{{}},
 			Ports:     ports,
-			Pilot:     p,
 		}).
 		BuildOrFail(ctx)
 

--- a/tests/integration/pilot/protocol_sniffing_test.go
+++ b/tests/integration/pilot/protocol_sniffing_test.go
@@ -82,13 +82,11 @@ func runTest(t *testing.T, ctx framework.TestContext) {
 			Namespace: ns,
 			Ports:     ports,
 			Subsets:   []echo.SubsetConfig{{}},
-			Pilot:     p,
 		}).
 		With(&fromWithoutSidecar, echo.Config{
 			Service:   "from-without-sidecar",
 			Namespace: ns,
 			Ports:     ports,
-			Pilot:     p,
 			Subsets: []echo.SubsetConfig{
 				{
 					Annotations: map[echo.Annotation]*echo.AnnotationValue{
@@ -103,7 +101,6 @@ func runTest(t *testing.T, ctx framework.TestContext) {
 			Namespace: ns,
 			Subsets:   []echo.SubsetConfig{{}},
 			Ports:     ports,
-			Pilot:     p,
 		}).
 		BuildOrFail(ctx)
 

--- a/tests/integration/pilot/vm/main_test.go
+++ b/tests/integration/pilot/vm/main_test.go
@@ -21,13 +21,10 @@ import (
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
-	"istio.io/istio/pkg/test/framework/components/pilot"
-	"istio.io/istio/pkg/test/framework/resource"
 )
 
 var (
 	i  istio.Instance
-	p  pilot.Instance
 	ns namespace.Instance
 )
 
@@ -44,11 +41,5 @@ values:
     meshExpansion:
       enabled: true`
 		})).
-		Setup(func(ctx resource.Context) (err error) {
-			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
-				return err
-			}
-			return nil
-		}).
 		Run()
 }

--- a/tests/integration/pilot/vm/vm_test.go
+++ b/tests/integration/pilot/vm/vm_test.go
@@ -97,7 +97,6 @@ spec:
 					Service:   clusterServiceHostname,
 					Namespace: ns,
 					Ports:     ports,
-					Pilot:     p,
 				}).
 				BuildOrFail(t)
 
@@ -106,7 +105,6 @@ spec:
 					Service:   headlessServiceHostname,
 					Namespace: ns,
 					Ports:     ports,
-					Pilot:     p,
 					Headless:  true,
 				}).
 				BuildOrFail(t)
@@ -119,7 +117,6 @@ spec:
 						Service:    fmt.Sprintf("vm-%v", i),
 						Namespace:  ns,
 						Ports:      ports,
-						Pilot:      p,
 						DeployAsVM: true,
 						VMImage:    vmImage,
 					}).

--- a/tests/integration/pilot/vm/vm_traffic_shifting_test.go
+++ b/tests/integration/pilot/vm/vm_traffic_shifting_test.go
@@ -73,13 +73,11 @@ func TestTrafficShifting(t *testing.T) {
 					Service:   "client",
 					Namespace: ns,
 					Ports:     ports,
-					Pilot:     p,
 				}).
 				With(&vm, echo.Config{
 					Service:    "vm",
 					Namespace:  ns,
 					Ports:      ports,
-					Pilot:      p,
 					DeployAsVM: true,
 					VMImage:    DefaultVMImage,
 				}).
@@ -90,7 +88,6 @@ func TestTrafficShifting(t *testing.T) {
 					Service:    "vm",
 					Namespace:  ns,
 					Ports:      ports,
-					Pilot:      p,
 					DeployAsVM: false,
 					Version:    "v2",
 					Subsets: []echo.SubsetConfig{

--- a/tests/integration/security/authorization_test.go
+++ b/tests/integration/security/authorization_test.go
@@ -531,7 +531,6 @@ func TestAuthorization_EgressGateway(t *testing.T) {
 							ServicePort: 8090,
 						},
 					},
-					Pilot: p,
 				}).
 				BuildOrFail(t)
 
@@ -638,7 +637,6 @@ func TestAuthorization_TCP(t *testing.T) {
 				With(&a, echo.Config{
 					Subsets:        []echo.SubsetConfig{{}},
 					Namespace:      ns,
-					Pilot:          p,
 					Service:        "a",
 					Ports:          ports,
 					ServiceAccount: true,
@@ -646,7 +644,6 @@ func TestAuthorization_TCP(t *testing.T) {
 				With(&b, echo.Config{
 					Namespace:      ns,
 					Subsets:        []echo.SubsetConfig{{}},
-					Pilot:          p,
 					Service:        "b",
 					Ports:          ports,
 					ServiceAccount: true,
@@ -654,7 +651,6 @@ func TestAuthorization_TCP(t *testing.T) {
 				With(&c, echo.Config{
 					Namespace:      ns,
 					Subsets:        []echo.SubsetConfig{{}},
-					Pilot:          p,
 					Service:        "c",
 					Ports:          ports,
 					ServiceAccount: true,
@@ -662,14 +658,12 @@ func TestAuthorization_TCP(t *testing.T) {
 				With(&d, echo.Config{
 					Namespace:      ns,
 					Subsets:        []echo.SubsetConfig{{}},
-					Pilot:          p,
 					Service:        "d",
 					Ports:          ports,
 					ServiceAccount: true,
 				}).
 				With(&e, echo.Config{
 					Namespace:      ns,
-					Pilot:          p,
 					Service:        "e",
 					Ports:          ports,
 					ServiceAccount: true,
@@ -766,7 +760,6 @@ func TestAuthorization_Conditions(t *testing.T) {
 							InstancePort: portC,
 						},
 					},
-					Pilot: p,
 				}).
 				BuildOrFail(t)
 
@@ -933,14 +926,12 @@ func TestAuthorization_Path(t *testing.T) {
 					Namespace: ns,
 					Subsets:   []echo.SubsetConfig{{}},
 					Ports:     ports,
-					Pilot:     p,
 				}).
 				With(&b, echo.Config{
 					Service:   "b",
 					Namespace: ns,
 					Subsets:   []echo.SubsetConfig{{}},
 					Ports:     ports,
-					Pilot:     p,
 				}).
 				BuildOrFail(t)
 

--- a/tests/integration/security/authorization_test.go
+++ b/tests/integration/security/authorization_test.go
@@ -61,9 +61,9 @@ func TestAuthorization_mTLS(t *testing.T) {
 
 			var a, b, c echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&a, util.EchoConfig("a", ns, false, nil, p)).
-				With(&b, util.EchoConfig("b", ns, false, nil, p)).
-				With(&c, util.EchoConfig("c", ns2, false, nil, p)).
+				With(&a, util.EchoConfig("a", ns, false, nil)).
+				With(&b, util.EchoConfig("b", ns, false, nil)).
+				With(&c, util.EchoConfig("c", ns2, false, nil)).
 				BuildOrFail(t)
 
 			newTestCase := func(from echo.Instance, path string, expectAllowed bool) rbacUtil.TestCase {
@@ -120,10 +120,10 @@ func TestAuthorization_JWT(t *testing.T) {
 
 			var a, b, c, d echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&a, util.EchoConfig("a", ns, false, nil, p)).
-				With(&b, util.EchoConfig("b", ns, false, nil, p)).
-				With(&c, util.EchoConfig("c", ns, false, nil, p)).
-				With(&d, util.EchoConfig("d", ns, false, nil, p)).
+				With(&a, util.EchoConfig("a", ns, false, nil)).
+				With(&b, util.EchoConfig("b", ns, false, nil)).
+				With(&c, util.EchoConfig("c", ns, false, nil)).
+				With(&d, util.EchoConfig("d", ns, false, nil)).
 				BuildOrFail(t)
 
 			newTestCase := func(target echo.Instance, namePrefix string, jwt string, path string, expectAllowed bool) rbacUtil.TestCase {
@@ -195,10 +195,10 @@ func TestAuthorization_WorkloadSelector(t *testing.T) {
 
 			var a, bInNS1, cInNS1, cInNS2 echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&a, util.EchoConfig("a", ns1, false, nil, p)).
-				With(&bInNS1, util.EchoConfig("b", ns1, false, nil, p)).
-				With(&cInNS1, util.EchoConfig("c", ns1, false, nil, p)).
-				With(&cInNS2, util.EchoConfig("c", ns2, false, nil, p)).
+				With(&a, util.EchoConfig("a", ns1, false, nil)).
+				With(&bInNS1, util.EchoConfig("b", ns1, false, nil)).
+				With(&cInNS1, util.EchoConfig("c", ns1, false, nil)).
+				With(&cInNS2, util.EchoConfig("c", ns2, false, nil)).
 				BuildOrFail(t)
 
 			newTestCase := func(namePrefix string, target echo.Instance, path string, expectAllowed bool) rbacUtil.TestCase {
@@ -276,9 +276,9 @@ func TestAuthorization_Deny(t *testing.T) {
 
 			var a, b, c echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&a, util.EchoConfig("a", ns, false, nil, p)).
-				With(&b, util.EchoConfig("b", ns, false, nil, p)).
-				With(&c, util.EchoConfig("c", ns, false, nil, p)).
+				With(&a, util.EchoConfig("a", ns, false, nil)).
+				With(&b, util.EchoConfig("b", ns, false, nil)).
+				With(&c, util.EchoConfig("c", ns, false, nil)).
 				BuildOrFail(t)
 
 			newTestCase := func(target echo.Instance, path string, expectAllowed bool) rbacUtil.TestCase {
@@ -367,11 +367,11 @@ func TestAuthorization_NegativeMatch(t *testing.T) {
 
 			var a, b, c, d, x echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&a, util.EchoConfig("a", ns, false, nil, p)).
-				With(&b, util.EchoConfig("b", ns, false, nil, p)).
-				With(&c, util.EchoConfig("c", ns, false, nil, p)).
-				With(&d, util.EchoConfig("d", ns, false, nil, p)).
-				With(&x, util.EchoConfig("x", ns2, false, nil, p)).
+				With(&a, util.EchoConfig("a", ns, false, nil)).
+				With(&b, util.EchoConfig("b", ns, false, nil)).
+				With(&c, util.EchoConfig("c", ns, false, nil)).
+				With(&d, util.EchoConfig("d", ns, false, nil)).
+				With(&x, util.EchoConfig("x", ns2, false, nil)).
 				BuildOrFail(t)
 
 			newTestCase := func(from, target echo.Instance, path string, expectAllowed bool) rbacUtil.TestCase {
@@ -447,7 +447,7 @@ func TestAuthorization_IngressGateway(t *testing.T) {
 
 			var b echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&b, util.EchoConfig("b", ns, false, nil, p)).
+				With(&b, util.EchoConfig("b", ns, false, nil)).
 				BuildOrFail(t)
 
 			var ingr ingress.Instance
@@ -519,7 +519,7 @@ func TestAuthorization_EgressGateway(t *testing.T) {
 
 			var a, b echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&a, util.EchoConfig("a", ns, false, nil, p)).
+				With(&a, util.EchoConfig("a", ns, false, nil)).
 				With(&b, echo.Config{
 					Service:   "b",
 					Namespace: ns,
@@ -633,7 +633,7 @@ func TestAuthorization_TCP(t *testing.T) {
 				},
 			}
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&x, util.EchoConfig("x", ns2, false, nil, p)).
+				With(&x, util.EchoConfig("x", ns2, false, nil)).
 				With(&a, echo.Config{
 					Subsets:        []echo.SubsetConfig{{}},
 					Namespace:      ns,
@@ -747,8 +747,8 @@ func TestAuthorization_Conditions(t *testing.T) {
 			portC := 8090
 			var a, b, c echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&a, util.EchoConfig("a", nsA, false, nil, p)).
-				With(&b, util.EchoConfig("b", nsB, false, nil, p)).
+				With(&a, util.EchoConfig("a", nsA, false, nil)).
+				With(&b, util.EchoConfig("b", nsB, false, nil)).
 				With(&c, echo.Config{
 					Service:   "c",
 					Namespace: nsC,
@@ -847,10 +847,10 @@ func TestAuthorization_GRPC(t *testing.T) {
 			})
 			var a, b, c, d echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&a, util.EchoConfig("a", ns, false, nil, p)).
-				With(&b, util.EchoConfig("b", ns, false, nil, p)).
-				With(&c, util.EchoConfig("c", ns, false, nil, p)).
-				With(&d, util.EchoConfig("d", ns, false, nil, p)).
+				With(&a, util.EchoConfig("a", ns, false, nil)).
+				With(&b, util.EchoConfig("b", ns, false, nil)).
+				With(&c, util.EchoConfig("c", ns, false, nil)).
+				With(&d, util.EchoConfig("d", ns, false, nil)).
 				BuildOrFail(t)
 
 			cases := []rbacUtil.TestCase{

--- a/tests/integration/security/filebased_tls_origination/destination_rule_tls_test.go
+++ b/tests/integration/security/filebased_tls_origination/destination_rule_tls_test.go
@@ -76,7 +76,6 @@ spec:
 					Service:   "client",
 					Namespace: ns,
 					Ports:     []echo.Port{},
-					Pilot:     p,
 					Subsets: []echo.SubsetConfig{{
 						Version: "v1",
 						// Set up custom annotations to mount the certs. We will re-use the configmap created by "server"
@@ -110,7 +109,6 @@ spec:
 							TLS:          true,
 						},
 					},
-					Pilot: p,
 					// Set up TLS certs on the server. This will make the server listen with these credentials.
 					TLSSettings: &common.TLSSettings{
 						RootCert:   mustReadFile(t, "root-cert.pem"),

--- a/tests/integration/security/filebased_tls_origination/egress_gateway_origination_test.go
+++ b/tests/integration/security/filebased_tls_origination/egress_gateway_origination_test.go
@@ -268,7 +268,6 @@ func setupEcho(t *testing.T, ctx resource.Context) (echo.Instance, echo.Instance
 		With(&internalClient, echo.Config{
 			Service:   "client",
 			Namespace: appsNamespace,
-			Pilot:     p,
 			Ports:     []echo.Port{},
 			Subsets: []echo.SubsetConfig{{
 				Version: "v1",
@@ -294,7 +293,6 @@ func setupEcho(t *testing.T, ctx resource.Context) (echo.Instance, echo.Instance
 					TLS:          true,
 				},
 			},
-			Pilot: p,
 			// Set up TLS certs on the server. This will make the server listen with these credentials.
 			TLSSettings: &common.TLSSettings{
 				// Echo has these test certs baked into the docker image

--- a/tests/integration/security/filebased_tls_origination/main_test.go
+++ b/tests/integration/security/filebased_tls_origination/main_test.go
@@ -21,14 +21,11 @@ import (
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
-	"istio.io/istio/pkg/test/framework/components/pilot"
 	"istio.io/istio/pkg/test/framework/label"
-	"istio.io/istio/pkg/test/framework/resource"
 )
 
 var (
 	inst istio.Instance
-	p    pilot.Instance
 )
 
 func TestMain(m *testing.M) {
@@ -41,12 +38,6 @@ func TestMain(m *testing.M) {
 		RequireSingleCluster().
 		Label("CustomSetup").
 		Setup(istio.Setup(&inst, setupConfig, cert.CreateCustomEgressSecret)).
-		Setup(func(ctx resource.Context) (err error) {
-			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
-				return err
-			}
-			return nil
-		}).
 		Run()
 
 }

--- a/tests/integration/security/jwt_test.go
+++ b/tests/integration/security/jwt_test.go
@@ -65,11 +65,11 @@ func TestRequestAuthentication(t *testing.T) {
 
 			var a, b, c, d, e echo.Instance
 			echoboot.NewBuilderOrFail(ctx, ctx).
-				With(&a, util.EchoConfig("a", ns, false, nil, p)).
-				With(&b, util.EchoConfig("b", ns, false, nil, p)).
-				With(&c, util.EchoConfig("c", ns, false, nil, p)).
-				With(&d, util.EchoConfig("d", ns, false, nil, p)).
-				With(&e, util.EchoConfig("e", ns, false, nil, p)).
+				With(&a, util.EchoConfig("a", ns, false, nil)).
+				With(&b, util.EchoConfig("b", ns, false, nil)).
+				With(&c, util.EchoConfig("c", ns, false, nil)).
+				With(&d, util.EchoConfig("d", ns, false, nil)).
+				With(&e, util.EchoConfig("e", ns, false, nil)).
 				BuildOrFail(t)
 
 			testCases := []authn.TestCase{
@@ -308,8 +308,8 @@ func TestIngressRequestAuthentication(t *testing.T) {
 
 			var a, b echo.Instance
 			echoboot.NewBuilderOrFail(ctx, ctx).
-				With(&a, util.EchoConfig("a", ns, false, nil, p)).
-				With(&b, util.EchoConfig("b", ns, false, nil, p)).
+				With(&a, util.EchoConfig("a", ns, false, nil)).
+				With(&b, util.EchoConfig("b", ns, false, nil)).
 				BuildOrFail(t)
 
 			// These test cases verify in-mesh traffic doesn't need tokens.

--- a/tests/integration/security/mtls_healthcheck_test.go
+++ b/tests/integration/security/mtls_healthcheck_test.go
@@ -71,7 +71,6 @@ spec:
 	cfg := echo.Config{
 		Namespace: ns,
 		Service:   name,
-		Pilot:     p,
 		Ports: []echo.Port{{
 			Name:         "http-8080",
 			Protocol:     protocol.HTTP,

--- a/tests/integration/security/mtlscert_pluginca_securenaming/mtlscert_pluginca_securenaming_test.go
+++ b/tests/integration/security/mtlscert_pluginca_securenaming/mtlscert_pluginca_securenaming_test.go
@@ -118,8 +118,8 @@ func TestMTLSCertPluginCASecureNaming(t *testing.T) {
 			}, retry.Delay(time.Second), retry.Timeout(10*time.Second))
 			var a, b echo.Instance
 			echoboot.NewBuilderOrFail(ctx, ctx).
-				With(&a, util.EchoConfig("a", testNamespace, false, nil, p)).
-				With(&b, util.EchoConfig("b", testNamespace, false, nil, p)).
+				With(&a, util.EchoConfig("a", testNamespace, false, nil)).
+				With(&b, util.EchoConfig("b", testNamespace, false, nil)).
 				BuildOrFail(t)
 
 			ctx.NewSubTest("mTLS cert validation with plugin CA").

--- a/tests/integration/security/pass_through_filter_chain_test.go
+++ b/tests/integration/security/pass_through_filter_chain_test.go
@@ -55,7 +55,6 @@ func TestPassThroughFilterChain(t *testing.T) {
 					Service:   service,
 					Namespace: ns,
 					Subsets:   []echo.SubsetConfig{{}},
-					Pilot:     p,
 					Ports: []echo.Port{
 						{
 							Name:     "grpc",

--- a/tests/integration/security/sds_egress/sds_istio_mutual_egress_test.go
+++ b/tests/integration/security/sds_egress/sds_istio_mutual_egress_test.go
@@ -89,7 +89,7 @@ func doIstioMutualTest(
 	ctx framework.TestContext, ns namespace.Instance, configPath, expectedResp string) {
 	var client echo.Instance
 	echoboot.NewBuilderOrFail(ctx, ctx).
-		With(&client, util.EchoConfig("client", ns, false, nil, p)).
+		With(&client, util.EchoConfig("client", ns, false, nil)).
 		BuildOrFail(ctx)
 	ctx.Config().ApplyYAMLOrFail(ctx, ns.Name(), file.AsStringOrFail(ctx, configPath))
 	defer ctx.Config().DeleteYAMLOrFail(ctx, ns.Name(), file.AsStringOrFail(ctx, configPath))

--- a/tests/integration/security/sds_vault_flow/sds_vault_flow_test.go
+++ b/tests/integration/security/sds_vault_flow/sds_vault_flow_test.go
@@ -51,8 +51,8 @@ func TestSdsVaultCaFlow(t *testing.T) {
 
 			var a, b echo.Instance
 			echoboot.NewBuilderOrFail(t, ctx).
-				With(&a, util.EchoConfig("a", ns, false, nil, p)).
-				With(&b, util.EchoConfig("b", ns, false, nil, p)).
+				With(&a, util.EchoConfig("a", ns, false, nil)).
+				With(&b, util.EchoConfig("b", ns, false, nil)).
 				BuildOrFail(t)
 
 			checkers := []connection.Checker{

--- a/tests/integration/security/util/framework.go
+++ b/tests/integration/security/util/framework.go
@@ -18,10 +18,9 @@ import (
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/namespace"
-	"istio.io/istio/pkg/test/framework/components/pilot"
 )
 
-func EchoConfig(name string, ns namespace.Instance, headless bool, annos echo.Annotations, p pilot.Instance) echo.Config {
+func EchoConfig(name string, ns namespace.Instance, headless bool, annos echo.Annotations) echo.Config {
 	out := echo.Config{
 		Service:        name,
 		Namespace:      ns,

--- a/tests/integration/security/util/framework.go
+++ b/tests/integration/security/util/framework.go
@@ -49,7 +49,6 @@ func EchoConfig(name string, ns namespace.Instance, headless bool, annos echo.An
 				Protocol: protocol.GRPC,
 			},
 		},
-		Pilot: p,
 	}
 
 	// for headless service with selector, the port and target port must be equal

--- a/tests/integration/security/util/reachability/context.go
+++ b/tests/integration/security/util/reachability/context.go
@@ -79,7 +79,7 @@ func CreateContext(ctx framework.TestContext, p pilot.Instance, buildVM bool) Co
 	var a, b, multiVersion, headless, naked, vmInstance echo.Instance
 
 	// Multi-version specific setup
-	cfg := util.EchoConfig("multiversion", ns, false, nil, p)
+	cfg := util.EchoConfig("multiversion", ns, false, nil)
 	cfg.Subsets = []echo.SubsetConfig{
 		// Istio deployment, with sidecar.
 		{
@@ -93,7 +93,7 @@ func CreateContext(ctx framework.TestContext, p pilot.Instance, buildVM bool) Co
 	}
 
 	// VM specific setup
-	vmCfg := util.EchoConfig("vm", ns, false, nil, p)
+	vmCfg := util.EchoConfig("vm", ns, false, nil)
 
 	// for test cases that have `buildVM` off, vm will function like a regular pod
 	vmCfg.DeployAsVM = buildVM
@@ -101,12 +101,12 @@ func CreateContext(ctx framework.TestContext, p pilot.Instance, buildVM bool) Co
 	vmCfg.Ports[0].ServicePort = vmCfg.Ports[0].InstancePort
 
 	echoboot.NewBuilderOrFail(ctx, ctx).
-		With(&a, util.EchoConfig("a", ns, false, nil, p)).
-		With(&b, util.EchoConfig("b", ns, false, nil, p)).
+		With(&a, util.EchoConfig("a", ns, false, nil)).
+		With(&b, util.EchoConfig("b", ns, false, nil)).
 		With(&multiVersion, cfg).
-		With(&headless, util.EchoConfig("headless", ns, true, nil, p)).
+		With(&headless, util.EchoConfig("headless", ns, true, nil)).
 		With(&naked, util.EchoConfig("naked", ns, false, echo.NewAnnotations().
-			SetBool(echo.SidecarInject, false), p)).
+			SetBool(echo.SidecarInject, false))).
 		With(&vmInstance, vmCfg).
 		BuildOrFail(ctx)
 

--- a/tests/integration/telemetry/dashboard_test.go
+++ b/tests/integration/telemetry/dashboard_test.go
@@ -303,7 +303,6 @@ func setupDashboardTest(t framework.TestContext) {
 		NewBuilderOrFail(t, t).
 		With(&instance, echo.Config{
 			Service:   "server",
-			Pilot:     p,
 			Namespace: ns,
 			Subsets:   []echo.SubsetConfig{{}},
 			Ports: []echo.Port{

--- a/tests/integration/telemetry/main_test.go
+++ b/tests/integration/telemetry/main_test.go
@@ -20,14 +20,12 @@ import (
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/ingress"
 	"istio.io/istio/pkg/test/framework/components/istio"
-	"istio.io/istio/pkg/test/framework/components/pilot"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
 )
 
 var (
 	i    istio.Instance
-	p    pilot.Instance
 	ingr ingress.Instance
 )
 
@@ -60,9 +58,6 @@ components:
             name: tcp`
 		})).
 		Setup(func(ctx resource.Context) (err error) {
-			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
-				return err
-			}
 			if ingr, err = ingress.New(ctx, ingress.Config{
 				Istio: i,
 			}); err != nil {

--- a/tests/integration/telemetry/outboundtrafficpolicy/helper.go
+++ b/tests/integration/telemetry/outboundtrafficpolicy/helper.go
@@ -320,13 +320,11 @@ func setupEcho(t *testing.T, ctx resource.Context, mode TrafficPolicy) (echo.Ins
 			Service:   "client",
 			Namespace: appsNamespace,
 			Subsets:   []echo.SubsetConfig{{}},
-			Pilot:     p,
 		}).
 		With(&dest, echo.Config{
 			Service:   "destination",
 			Namespace: appsNamespace,
 			Subsets:   []echo.SubsetConfig{{Annotations: echo.NewAnnotations().SetBool(echo.SidecarInject, false)}},
-			Pilot:     p,
 			Ports: []echo.Port{
 				{
 					// Plain HTTP port, will match no listeners and fall through

--- a/tests/integration/telemetry/outboundtrafficpolicy/helper.go
+++ b/tests/integration/telemetry/outboundtrafficpolicy/helper.go
@@ -34,7 +34,6 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/namespace"
-	"istio.io/istio/pkg/test/framework/components/pilot"
 	"istio.io/istio/pkg/test/framework/components/prometheus"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/util/retry"
@@ -303,8 +302,6 @@ func RunExternalRequest(cases []*TestCase, prometheus prometheus.Instance, mode 
 }
 
 func setupEcho(t *testing.T, ctx resource.Context, mode TrafficPolicy) (echo.Instance, echo.Instance) {
-	p := pilot.NewOrFail(t, ctx, pilot.Config{})
-
 	appsNamespace := namespace.NewOrFail(t, ctx, namespace.Config{
 		Prefix: "app",
 		Inject: true,

--- a/tests/integration/telemetry/stats/prometheus/http/stats.go
+++ b/tests/integration/telemetry/stats/prometheus/http/stats.go
@@ -22,7 +22,6 @@ import (
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
-	"istio.io/istio/pkg/test/framework/components/pilot"
 	"istio.io/istio/pkg/test/framework/features"
 
 	"istio.io/istio/pkg/test/framework"
@@ -39,7 +38,6 @@ var (
 	client, server echo.Instance
 	ist            istio.Instance
 	appNsInst      namespace.Instance
-	pilotInst      pilot.Instance
 	promInst       prometheus.Instance
 )
 
@@ -97,9 +95,6 @@ func TestSetup(ctx resource.Context) (err error) {
 	if err != nil {
 		return
 	}
-	if pilotInst, err = pilot.New(ctx, pilot.Config{}); err != nil {
-		return err
-	}
 
 	b, err := echoboot.NewBuilder(ctx)
 	if err != nil {
@@ -111,7 +106,6 @@ func TestSetup(ctx resource.Context) (err error) {
 			Namespace: appNsInst,
 			Ports:     nil,
 			Subsets:   []echo.SubsetConfig{{}},
-			Pilot:     pilotInst,
 		}).
 		With(&server, echo.Config{
 			Service:   "server",
@@ -124,7 +118,6 @@ func TestSetup(ctx resource.Context) (err error) {
 					InstancePort: 8090,
 				},
 			},
-			Pilot: pilotInst,
 		}).
 		Build()
 	if err != nil {


### PR DESCRIPTION
After removing the "native" environment, echo configs don't use the Pilot instance passed to them. This cleans up effectively dead code in integration tests. 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
