### PR TITLE
feat(testing): Add GCE Metadata Server component

### DIFF
--- a/pkg/test/env/istio.go
+++ b/pkg/test/env/istio.go
@@ -89,6 +89,9 @@ var (
 
 	// StackdriverInstallFilePath is the stackdriver installation file.
 	StackdriverInstallFilePath = path.Join(IstioSrc, "pkg/test/framework/components/stackdriver/stackdriver.yaml")
+
+	// GCEMetadataServerInstallFilePath is the GCE Metadata Server installation file.
+	GCEMetadataServerInstallFilePath = path.Join(IstioSrc, "pkg/test/framework/components/gcemetadata/gce_metadata_server.yaml")
 )
 
 func getDefaultIstioSrc() string {

--- a/pkg/test/framework/components/gcemetadata/gce_metadata_server.yaml
+++ b/pkg/test/framework/components/gcemetadata/gce_metadata_server.yaml
@@ -1,0 +1,46 @@
+# Copyright Istio Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+apiVersion: v1
+kind: Service
+metadata:
+  name: gce-metadata-server
+  labels:
+    app: gce-metadata
+spec:
+  ports:
+  - name: http
+    port: 8080
+  selector:
+    app: gce-metadata
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gce-metadata-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gce-metadata
+  template:
+    metadata:
+      labels:
+        app: gce-metadata
+    spec:
+      containers:
+      - image: gcr.io/istio-testing/fake-gce-metadata:1.0
+        imagePullPolicy: Always
+        name: gce-metadata
+        ports:
+        - containerPort: 8080

--- a/pkg/test/framework/components/gcemetadata/gcemetadata.go
+++ b/pkg/test/framework/components/gcemetadata/gcemetadata.go
@@ -1,0 +1,56 @@
+//  Copyright Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// Package gcemetadata provides basic utilities around configuring the fake
+// GCE Metadata Server component for integration testing.
+package gcemetadata
+
+import (
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/framework/resource/environment"
+)
+
+// Instance represents a deployed GCE Metadata Server app instance.
+type Instance interface {
+	// Address is the IP Address of the service provided by the fake GCE
+	// Metadata Server.
+	Address() string
+}
+
+// Config defines the options for creating an fake GCE Metadata Server component.
+type Config struct {
+	// Cluster to be used in a multicluster environment
+	Cluster resource.Cluster
+}
+
+// New returns a new instance of stackdriver.
+func New(ctx resource.Context, c Config) (i Instance, err error) {
+	err = resource.UnsupportedEnvironment(ctx.Environment())
+	ctx.Environment().Case(environment.Kube, func() {
+		i, err = newKube(ctx, c)
+	})
+	return
+}
+
+// NewOrFail returns a new GCE Metadata Server instance or fails test.
+func NewOrFail(t test.Failer, ctx resource.Context, c Config) Instance {
+	t.Helper()
+	i, err := New(ctx, c)
+	if err != nil {
+		t.Fatalf("gcemetadata.NewOrFail: %v", err)
+	}
+
+	return i
+}

--- a/pkg/test/framework/components/gcemetadata/kube.go
+++ b/pkg/test/framework/components/gcemetadata/kube.go
@@ -28,8 +28,7 @@ import (
 )
 
 const (
-	ns   = "gce-metadata"
-	port = 8080
+	ns = "gce-metadata"
 )
 
 var (

--- a/pkg/test/framework/components/gcemetadata/kube.go
+++ b/pkg/test/framework/components/gcemetadata/kube.go
@@ -1,0 +1,111 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcemetadata
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	environ "istio.io/istio/pkg/test/env"
+	"istio.io/istio/pkg/test/framework/components/environment/kube"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/resource"
+	testKube "istio.io/istio/pkg/test/kube"
+	"istio.io/istio/pkg/test/scopes"
+)
+
+const (
+	ns   = "gce-metadata"
+	port = 8080
+)
+
+var (
+	_ Instance  = &kubeComponent{}
+	_ io.Closer = &kubeComponent{}
+)
+
+type kubeComponent struct {
+	id        resource.ID
+	ns        namespace.Instance
+	cluster   kube.Cluster
+	clusterIP string
+}
+
+func newKube(ctx resource.Context, cfg Config) (Instance, error) {
+	c := &kubeComponent{
+		cluster: kube.ClusterOrDefault(cfg.Cluster, ctx.Environment()),
+	}
+	c.id = ctx.TrackResource(c)
+	var err error
+	scopes.Framework.Info("=== BEGIN: Deploy GCE Metadata Server ===")
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("gcemetadata deployment failed: %v", err) // nolint:golint
+			scopes.Framework.Infof("=== FAILED: Deploy GCE Metadata Server ===")
+			_ = c.Close()
+		} else {
+			scopes.Framework.Info("=== SUCCEEDED: Deploy GCE Metadata Server ===")
+		}
+	}()
+
+	c.ns, err = namespace.New(ctx, namespace.Config{
+		Prefix: ns,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not create %q namespace for GCE Metadata Server install; err: %v", ns, err)
+	}
+
+	// apply YAML
+	yamlContent, err := ioutil.ReadFile(environ.GCEMetadataServerInstallFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %q, err: %v", environ.GCEMetadataServerInstallFilePath, err)
+	}
+
+	if _, err := c.cluster.ApplyContents(c.ns.Name(), string(yamlContent)); err != nil {
+		return nil, fmt.Errorf("failed to apply rendered %q, err: %v", environ.GCEMetadataServerInstallFilePath, err)
+	}
+
+	fetchFn := testKube.NewSinglePodFetch(c.cluster.Accessor, c.ns.Name(), "app=gce-metadata")
+	_, err = c.cluster.WaitUntilPodsAreReady(fetchFn)
+	if err != nil {
+		return nil, err
+	}
+
+	// Now retrieve the service information to find the ClusterIP
+	s, err := c.cluster.CoreV1().Services(c.ns.Name()).Get(context.TODO(), "gce-metadata-server", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	c.clusterIP = s.Spec.ClusterIP
+
+	return c, nil
+}
+
+func (c *kubeComponent) ID() resource.ID {
+	return c.id
+}
+
+// Close implements io.Closer.
+func (c *kubeComponent) Close() error {
+	return nil
+}
+
+func (c *kubeComponent) Address() string {
+	return c.clusterIP
+}


### PR DESCRIPTION
Adds a testing component for a GCE Metadata Server.

This will enable the integration testing of GCP platform bootstrapping for VMs. Right now, there is no configurability provided, but this can be expanded in the future to provide configuration of the test server to match testing needs.

This is a follow-on PR to: https://github.com/istio/istio/pull/25264. Future PRs will include the use of this component in the setup, etc.

[ X ] Test and Release
