### PR TITLE
Add roundtrip fuzzing tests for our CRDs

### DIFF
--- a/pilot/pkg/config/kube/crd/config_test.go
+++ b/pilot/pkg/config/kube/crd/config_test.go
@@ -15,13 +15,134 @@
 package crd_test
 
 import (
+	"math/rand"
 	"reflect"
+	"regexp"
 	"testing"
+	"time"
 
+	"github.com/gogo/protobuf/types"
+	fuzz "github.com/google/gofuzz"
+	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
+	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
+
+	authentication "istio.io/api/authentication/v1alpha1"
+	mixer "istio.io/api/mixer/v1"
+	mixerclient "istio.io/api/mixer/v1/config/client"
+	networking "istio.io/api/networking/v1alpha3"
+	policy "istio.io/api/policy/v1beta1"
+	clientconfig "istio.io/client-go/pkg/apis/config/v1alpha2"
+	clientnetworkingalpha "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	clientnetworkingbeta "istio.io/client-go/pkg/apis/networking/v1beta1"
+	clientsecurity "istio.io/client-go/pkg/apis/security/v1beta1"
+
+	metafuzzer "k8s.io/apimachinery/pkg/apis/meta/fuzzer"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+
+	"istio.io/istio/pilot/pkg/config/kube/crd/roundtrip"
+	"istio.io/istio/pkg/config/schema/collections"
 
 	"istio.io/istio/pilot/pkg/config/kube/crd"
 )
+
+// This test exercises round tripping of marshalling/unmarshalling of all of our CRDs, based on fuzzing
+// This approach is heavily adopted from Kubernetes own fuzzing of their resources.
+func TestRoundtripFuzzing(t *testing.T) {
+	scheme := runtime.NewScheme()
+	clientnetworkingalpha.AddToScheme(scheme)
+	clientnetworkingbeta.AddToScheme(scheme)
+	clientconfig.AddToScheme(scheme)
+	clientsecurity.AddToScheme(scheme)
+
+	fuzzerFuncs := fuzzer.MergeFuzzerFuncs(metafuzzer.Funcs, fixProtoFuzzer)
+	codecs := serializer.NewCodecFactory(scheme)
+	seed := time.Now().UTC().UnixNano()
+	fz := fuzzer.
+		FuzzerFor(fuzzerFuncs, rand.NewSource(seed), codecs).
+		SkipFieldsWithPattern(regexp.MustCompile(`^XXX_`))
+
+	for _, r := range collections.Pilot.All() {
+		t.Run(r.VariableName(), func(t *testing.T) {
+			gvk := r.Resource().GroupVersionKind()
+			kgvk := schema.GroupVersionKind{
+				Group:   gvk.Group,
+				Version: gvk.Version,
+				Kind:    gvk.Kind,
+			}
+			roundtrip.RoundTripSpecificKind(t, kgvk, scheme, fz)
+		})
+	}
+}
+
+// Some proto types cause issues with the fuzzing. These custom fuzzers basically just skip anything with issues
+func fixProtoFuzzer(codecs runtimeserializer.CodecFactory) []interface{} {
+	return []interface{}{
+		// This will generate invalid durations - the ranges on the seconds/nanoseconds is bounded
+		func(pb *types.Duration, c fuzz.Continue) {
+			*pb = types.Duration{}
+		},
+		// Cannot handle enums, or interfaces in general. See https://github.com/google/gofuzz/issues/27
+		// TODO this effectively skips all of these. We should have real fuzzing occur here, just need to add custom logic
+		// for the interface types.
+		func(x *networking.LoadBalancerSettings, c fuzz.Continue) {
+			*x = networking.LoadBalancerSettings{}
+		},
+		func(t *mixerclient.APIKey, c fuzz.Continue) {
+			*t = mixerclient.APIKey{}
+		},
+		func(t *mixer.Attributes_AttributeValue, c fuzz.Continue) {
+			*t = mixer.Attributes_AttributeValue{}
+		},
+		func(t *policy.Authentication, c fuzz.Continue) {
+			*t = policy.Authentication{}
+		},
+		func(t *networking.EnvoyFilter_EnvoyConfigObjectMatch, c fuzz.Continue) {
+			*t = networking.EnvoyFilter_EnvoyConfigObjectMatch{}
+		},
+		func(t *mixerclient.HTTPAPISpecPattern, c fuzz.Continue) {
+			*t = mixerclient.HTTPAPISpecPattern{}
+		},
+		func(t *networking.HTTPFaultInjection_Abort, c fuzz.Continue) {
+			*t = networking.HTTPFaultInjection_Abort{}
+		},
+		func(t *networking.HTTPFaultInjection_Delay, c fuzz.Continue) {
+			*t = networking.HTTPFaultInjection_Delay{}
+		},
+		func(t *networking.LoadBalancerSettings, c fuzz.Continue) {
+			*t = networking.LoadBalancerSettings{}
+		},
+		func(t *networking.LoadBalancerSettings_ConsistentHashLB, c fuzz.Continue) {
+			*t = networking.LoadBalancerSettings_ConsistentHashLB{}
+		},
+		func(t *authentication.PeerAuthenticationMethod, c fuzz.Continue) {
+			*t = authentication.PeerAuthenticationMethod{}
+		},
+		func(t *networking.PortSelector, c fuzz.Continue) {
+			*t = networking.PortSelector{}
+		},
+		func(t *networking.StringMatch, c fuzz.Continue) {
+			*t = networking.StringMatch{}
+		},
+		func(t *mixerclient.StringMatch, c fuzz.Continue) {
+			*t = mixerclient.StringMatch{}
+		},
+		func(t *authentication.StringMatch, c fuzz.Continue) {
+			*t = authentication.StringMatch{}
+		},
+		func(t *policy.Tls, c fuzz.Continue) {
+			*t = policy.Tls{}
+		},
+		func(t *policy.Value, c fuzz.Continue) {
+			*t = policy.Value{}
+		},
+		func(t *types.Value, c fuzz.Continue) {
+			*t = types.Value{Kind: &types.Value_StringValue{StringValue: ""}}
+		},
+	}
+}
 
 func TestKind(t *testing.T) {
 	obj := crd.IstioKind{}

--- a/pilot/pkg/config/kube/crd/config_test.go
+++ b/pilot/pkg/config/kube/crd/config_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gogo/protobuf/types"
 	fuzz "github.com/google/gofuzz"
 	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
-	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 
 	authentication "istio.io/api/authentication/v1alpha1"
 	mixer "istio.io/api/mixer/v1"
@@ -48,7 +47,7 @@ import (
 	"istio.io/istio/pilot/pkg/config/kube/crd"
 )
 
-// This test exercises round tripping of marshalling/unmarshalling of all of our CRDs, based on fuzzing
+// This test exercises round tripping of marshaling/unmarshaling of all of our CRDs, based on fuzzing
 // This approach is heavily adopted from Kubernetes own fuzzing of their resources.
 func TestRoundtripFuzzing(t *testing.T) {
 	scheme := runtime.NewScheme()
@@ -72,13 +71,13 @@ func TestRoundtripFuzzing(t *testing.T) {
 				Version: gvk.Version,
 				Kind:    gvk.Kind,
 			}
-			roundtrip.RoundTripSpecificKind(t, kgvk, scheme, fz)
+			roundtrip.SpecificKind(t, kgvk, scheme, fz)
 		})
 	}
 }
 
 // Some proto types cause issues with the fuzzing. These custom fuzzers basically just skip anything with issues
-func fixProtoFuzzer(codecs runtimeserializer.CodecFactory) []interface{} {
+func fixProtoFuzzer(codecs serializer.CodecFactory) []interface{} {
 	return []interface{}{
 		// This will generate invalid durations - the ranges on the seconds/nanoseconds is bounded
 		func(pb *types.Duration, c fuzz.Continue) {

--- a/pilot/pkg/config/kube/crd/roundtrip/roundtrip.go
+++ b/pilot/pkg/config/kube/crd/roundtrip/roundtrip.go
@@ -39,7 +39,7 @@ import (
 // This is heavily inspired/copied from https://github.com/kubernetes/apimachinery/blob/master/pkg/api/apitesting/roundtrip/roundtrip.go
 // A fork was required to support Istio types. Unlike Kubernetes, which has "normal" go structs, Istio types are protobufs
 // Part of this means that each field has a bunch of internal proto stuff, like XXX_sizecache. This does not get roundtripped properly,
-// and we do not care that it doesn't. As a result, we switch the comparision to use go-cmp/cmp which can handle this.
+// and we do not care that it doesn't. As a result, we switch the comparison to use go-cmp/cmp which can handle this.
 
 type InstallFunc func(scheme *runtime.Scheme)
 

--- a/pilot/pkg/config/kube/crd/roundtrip/roundtrip.go
+++ b/pilot/pkg/config/kube/crd/roundtrip/roundtrip.go
@@ -1,0 +1,299 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package roundtrip
+
+import (
+	"bytes"
+	"encoding/hex"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	gogoproto "github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/proto"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	fuzz "github.com/google/gofuzz"
+	flag "github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// This is heavily inspired/copied from https://github.com/kubernetes/apimachinery/blob/master/pkg/api/apitesting/roundtrip/roundtrip.go
+// A fork was required to support Istio types. Unlike Kubernetes, which has "normal" go structs, Istio types are protobufs
+// Part of this means that each field has a bunch of internal proto stuff, like XXX_sizecache. This does not get roundtripped properly,
+// and we do not care that it doesn't. As a result, we switch the comparisions to use go-cmp/cmp which can handle this.
+
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+type InstallFunc func(scheme *runtime.Scheme)
+
+var FuzzIters = flag.Int("fuzz-iters", 100, "How many fuzzing iterations to do.")
+
+// globalNonRoundTrippableTypes are kinds that are effectively reserved across all GroupVersions
+// They don't roundtrip
+var globalNonRoundTrippableTypes = sets.NewString(
+	"ExportOptions",
+	"GetOptions",
+	// WatchEvent does not include kind and version and can only be deserialized
+	// implicitly (if the caller expects the specific object). The watch call defines
+	// the schema by content type, rather than via kind/version included in each
+	// object.
+	"WatchEvent",
+	// ListOptions is now part of the meta group
+	"ListOptions",
+	// Delete options is only read in metav1
+	"DeleteOptions",
+)
+
+func RoundTripSpecificKind(t *testing.T, gvk schema.GroupVersionKind, scheme *runtime.Scheme, fuzzer *fuzz.Fuzzer) {
+	// Try a few times, since runTest uses random values.
+	for i := 0; i < *FuzzIters; i++ {
+		roundTripOfExternalType(t, scheme, fuzzer, gvk)
+		if t.Failed() {
+			break
+		}
+	}
+}
+
+// fuzzInternalObject fuzzes an arbitrary runtime object using the appropriate
+// fuzzer registered with the apitesting package.
+func fuzzInternalObject(t *testing.T, fuzzer *fuzz.Fuzzer, object runtime.Object) runtime.Object {
+	fuzzer.Fuzz(object)
+
+	j, err := apimeta.TypeAccessor(object)
+	if err != nil {
+		t.Fatalf("Unexpected error %v for %#v", err, object)
+	}
+	j.SetKind("")
+	j.SetAPIVersion("")
+
+	return object
+}
+
+func roundTripOfExternalType(t *testing.T, scheme *runtime.Scheme, fuzzer *fuzz.Fuzzer, externalGVK schema.GroupVersionKind) {
+	object, err := scheme.New(externalGVK)
+	if err != nil {
+		t.Fatalf("Couldn't make a %v? %v", externalGVK, err)
+	}
+	typeAcc, err := apimeta.TypeAccessor(object)
+	if err != nil {
+		t.Fatalf("%q is not a TypeMeta and cannot be tested - add it to nonRoundTrippableInternalTypes: %v", externalGVK, err)
+	}
+
+	fuzzInternalObject(t, fuzzer, object)
+
+	typeAcc.SetKind(externalGVK.Kind)
+	typeAcc.SetAPIVersion(externalGVK.GroupVersion().String())
+
+	roundTrip(t, scheme, json.NewSerializer(json.DefaultMetaFactory, scheme, scheme, false), object)
+}
+func equateAlways(_, _ interface{}) bool { return true }
+
+var cmpOptions = []cmp.Option{
+	//cmp.Comparer(func(a, b resource.Quantity) bool {
+	//	return a.Cmp(b) == 0
+	//}),
+	//cmp.Comparer(func(a, b metav1.MicroTime) bool {
+	//	return a.UTC() == b.UTC()
+	//}),
+	//cmp.Comparer(func(a, b metav1.Time) bool {
+	//	return a.UTC() == b.UTC()
+	//}),
+	//cmp.Comparer(func(a, b labels.Selector) bool {
+	//	return a.String() == b.String()
+	//}),
+	//cmp.Comparer(func(a, b fields.Selector) bool {
+	//	return a.String() == b.String()
+	//}),
+	// Kubernetes will fuzz this for us
+	cmp.Comparer(func(a, b metav1.ObjectMeta) bool {
+		return true
+	}),
+	// Allow comparing protobufs
+	cmp.Comparer(gogoproto.Equal),
+	// Allow nil == empty list or map
+	cmpopts.EquateEmpty(),
+}
+
+// roundTrip applies a single round-trip test to the given runtime object
+// using the given codec.  The round-trip test ensures that an object can be
+// deep-copied, converted, marshaled and back without loss of data.
+//
+// For internal types this means
+//
+//   internal -> external -> json/protobuf -> external -> internal.
+//
+// For external types this means
+//
+//   external -> json/protobuf -> external.
+func roundTrip(t *testing.T, scheme *runtime.Scheme, codec runtime.Codec, object runtime.Object) {
+	printer := spew.ConfigState{DisableMethods: true}
+	original := object
+
+	// deep copy the original object
+	object = object.DeepCopyObject()
+	name := reflect.TypeOf(object).Elem().Name()
+	if diff := cmp.Diff(original, object, cmpOptions...); diff != "" {
+		t.Errorf("%v: DeepCopy altered the object, diff: %v", name, diff)
+		t.Errorf("%s", spew.Sdump(original))
+		t.Errorf("%s", spew.Sdump(object))
+		return
+	}
+
+	// encode (serialize) the deep copy using the provided codec
+	data, err := runtime.Encode(codec, object)
+	if err != nil {
+		if runtime.IsNotRegisteredError(err) {
+			t.Logf("%v: not registered: %v (%s)", name, err, printer.Sprintf("%#v", object))
+		} else {
+			t.Errorf("%v: %v (%s)", name, err, printer.Sprintf("%#v", object))
+		}
+		return
+	}
+
+	// ensure that the deep copy is equal to the original; neither the deep
+	// copy or conversion should alter the object
+	// TODO eliminate this global
+	if diff := cmp.Diff(original, object, cmpOptions...); diff != "" {
+		t.Errorf("%v: encode altered the object, diff: %v", name, diff)
+		return
+	}
+
+	// encode (serialize) a second time to verify that it was not varying
+	secondData, err := runtime.Encode(codec, object)
+	if err != nil {
+		if runtime.IsNotRegisteredError(err) {
+			t.Logf("%v: not registered: %v (%s)", name, err, printer.Sprintf("%#v", object))
+		} else {
+			t.Errorf("%v: %v (%s)", name, err, printer.Sprintf("%#v", object))
+		}
+		return
+	}
+
+	// serialization to the wire must be stable to ensure that we don't write twice to the DB
+	// when the object hasn't changed.
+	if !bytes.Equal(data, secondData) {
+		t.Errorf("%v: serialization is not stable: %s", name, printer.Sprintf("%#v", object))
+	}
+
+	// decode (deserialize) the encoded data back into an object
+	obj2, err := runtime.Decode(codec, data)
+	if err != nil {
+		t.Errorf("%v: %v\nCodec: %#v\nData: %s\nSource: %#v", name, err, codec, dataAsString(data), printer.Sprintf("%#v", object))
+		panic("failed")
+	}
+
+	// ensure that the object produced from decoding the encoded data is equal
+	// to the original object
+	if diff := cmp.Diff(original, obj2, cmpOptions...); diff != "" {
+		t.Errorf("%v: diff: %v\nCodec: %#v\nSource:\n\n%#v\n\nEncoded:\n\n%s\n\nFinal:\n\n%#v", name, diff, codec, printer.Sprintf("%#v", original), dataAsString(data), printer.Sprintf("%#v", obj2))
+		return
+	}
+
+	// decode the encoded data into a new object (instead of letting the codec
+	// create a new object)
+	obj3 := reflect.New(reflect.TypeOf(object).Elem()).Interface().(runtime.Object)
+	if err := runtime.DecodeInto(codec, data, obj3); err != nil {
+		t.Errorf("%v: %v", name, err)
+		return
+	}
+
+	// special case for kinds which are internal and external at the same time (many in meta.k8s.io are). For those
+	// runtime.DecodeInto above will return the external variant and set the APIVersion and kind, while the input
+	// object might be internal. Hence, we clear those values for obj3 for that case to correctly compare.
+	intAndExt, err := internalAndExternalKind(scheme, object)
+	if err != nil {
+		t.Errorf("%v: %v", name, err)
+		return
+	}
+	if intAndExt {
+		typeAcc, err := apimeta.TypeAccessor(object)
+		if err != nil {
+			t.Fatalf("%v: error accessing TypeMeta: %v", name, err)
+		}
+		if len(typeAcc.GetAPIVersion()) == 0 {
+			typeAcc, err := apimeta.TypeAccessor(obj3)
+			if err != nil {
+				t.Fatalf("%v: error accessing TypeMeta: %v", name, err)
+			}
+			typeAcc.SetAPIVersion("")
+			typeAcc.SetKind("")
+		}
+	}
+
+	// ensure that the new runtime object is equal to the original after being
+	// decoded into
+	if diff := cmp.Diff(original, obj3, cmpOptions...); diff != "" {
+		t.Errorf("%v: diff: %v\nCodec: %#v", name, diff, codec)
+		return
+	}
+
+	// do structure-preserving fuzzing of the deep-copied object. If it shares anything with the original,
+	// the deep-copy was actually only a shallow copy. Then original and obj3 will be different after fuzzing.
+	// NOTE: we use the encoding+decoding here as an alternative, guaranteed deep-copy to compare against.
+	fuzzer.ValueFuzz(object)
+	if diff := cmp.Diff(original, obj3, cmpOptions...); diff != "" {
+		t.Errorf("%v: fuzzing a copy altered the original, diff: %v", name, diff)
+		return
+	}
+}
+
+func internalAndExternalKind(scheme *runtime.Scheme, object runtime.Object) (bool, error) {
+	kinds, _, err := scheme.ObjectKinds(object)
+	if err != nil {
+		return false, err
+	}
+	internal, external := false, false
+	for _, k := range kinds {
+		if k.Version == runtime.APIVersionInternal {
+			internal = true
+		} else {
+			external = true
+		}
+	}
+	return internal && external, nil
+}
+
+// dataAsString returns the given byte array as a string; handles detecting
+// protocol buffers.
+func dataAsString(data []byte) string {
+	dataString := string(data)
+	if !strings.HasPrefix(dataString, "{") {
+		dataString = "\n" + hex.Dump(data)
+		proto.NewBuffer(make([]byte, 0, 1024)).DebugPrint("decoded object", data)
+	}
+	return dataString
+}


### PR DESCRIPTION
For https://github.com/istio/istio/issues/14935

I explicitly tested this would have caught two bugs we have had around
CRD pruning (one currently blocking istio/api update)



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure