### PR TITLE
Optimize performance for large numbers of services

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -83,6 +83,7 @@ type PushContext struct {
 
 	// ServiceByHostnameAndNamespace has all services, indexed by hostname then namespace.
 	ServiceByHostnameAndNamespace map[host.Name]map[string]*Service `json:"-"`
+	ServiceByHostname             map[host.Name]*Service            `json:"-"`
 	// ServiceAccounts contains a map of hostname and port to service accounts.
 	ServiceAccounts map[host.Name]map[int][]string `json:"-"`
 	// QuotaSpec has all quota specs
@@ -456,6 +457,7 @@ func NewPushContext() *PushContext {
 		gatewaysByNamespace:                         map[string][]Config{},
 		allGateways:                                 []Config{},
 		ServiceByHostnameAndNamespace:               map[host.Name]map[string]*Service{},
+		ServiceByHostname:                           map[host.Name]*Service{},
 		ProxyStatus:                                 map[string]map[string]ProxyPushStatus{},
 		ServiceAccounts:                             map[host.Name]map[int][]string{},
 	}
@@ -899,6 +901,7 @@ func (ps *PushContext) updateContext(
 		ps.servicesExportedToNamespace = oldPushContext.servicesExportedToNamespace
 		ps.publicServices = oldPushContext.publicServices
 		ps.ServiceByHostnameAndNamespace = oldPushContext.ServiceByHostnameAndNamespace
+		ps.ServiceByHostname = oldPushContext.ServiceByHostname
 		ps.ServiceAccounts = oldPushContext.ServiceAccounts
 	}
 
@@ -1023,6 +1026,7 @@ func (ps *PushContext) initServiceRegistry(env *Environment) error {
 			ps.ServiceByHostnameAndNamespace[s.Hostname] = map[string]*Service{}
 		}
 		ps.ServiceByHostnameAndNamespace[s.Hostname][s.Attributes.Namespace] = s
+		ps.ServiceByHostname[s.Hostname] = s
 	}
 
 	ps.initServiceAccounts(env, allServices)

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -373,9 +373,11 @@ func convertIstioListenerToWrapper(ps *PushContext, configNamespace string,
 
 // ServiceForHostname returns the service associated with a given hostname following SidecarScope
 func (sc *SidecarScope) ServiceForHostname(hostname host.Name, serviceByHostname map[host.Name]map[string]*Service) *Service {
+	byHostname := serviceByHostname[hostname]
 	// SidecarScope shouldn't be null here. If it is, we can't disambiguate the hostname to use for a namespace,
 	// so the selection must be undefined.
-	if sc == nil {
+	// As an optimization, if there is only 1 hostname we will return that one to avoid iterating over services.
+	if sc == nil || len(byHostname) == 1 {
 		for _, service := range serviceByHostname[hostname] {
 			return service
 		}

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -185,8 +185,6 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(
 func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Proxy, push *model.PushContext,
 	routeName string) *route.RouteConfiguration {
 
-	services := push.Services(node)
-
 	if node.MergedGateway == nil {
 		log.Debuga("buildGatewayRoutes: no gateways for router ", node.ID)
 		return nil
@@ -207,10 +205,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 	servers := merged.ServersByRouteName[routeName]
 	port := int(servers[0].Port.Number) // all these servers are for the same routeName, and therefore same port
 
-	nameToServiceMap := make(map[host.Name]*model.Service, len(services))
-	for _, svc := range services {
-		nameToServiceMap[svc.Hostname] = svc
-	}
+	nameToServiceMap := push.ServiceByHostname
 
 	vHostDedupMap := make(map[host.Name]*route.VirtualHost)
 	for _, server := range servers {

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -576,6 +576,9 @@ func (b SortHeaderValueOption) Swap(i, j int) {
 
 // translateAppendHeaders translates headers
 func translateAppendHeaders(headers map[string]string, appendFlag bool) []*core.HeaderValueOption {
+	if len(headers) == 0 {
+		return nil
+	}
 	headerValueOptionList := make([]*core.HeaderValueOption, 0, len(headers))
 	for key, value := range headers {
 		headerValueOptionList = append(headerValueOptionList, &core.HeaderValueOption{

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -251,6 +251,9 @@ func GogoDurationToDuration(d *types.Duration) *duration.Duration {
 // Envoy computes a hash of RDS to see if things have changed - hash is affected by order of elements in the filter. Therefore
 // we sort virtual hosts by name before handing them back so the ordering is stable across HTTP Route Configs.
 func SortVirtualHosts(hosts []*route.VirtualHost) {
+	if len(hosts) < 2 {
+		return
+	}
 	sort.SliceStable(hosts, func(i, j int) bool {
 		return hosts[i].Name < hosts[j].Name
 	})


### PR DESCRIPTION
```
name                                  old time/op        new time/op        delta
ListEquals-6                                16.3µs ± 1%        16.1µs ± 2%     ~     (p=0.421 n=5+5)
InitPushContext/gateways-6                  4.07ms ± 1%        4.09ms ± 2%     ~     (p=0.222 n=5+5)
InitPushContext/gateways-shared-6            454µs ± 1%         450µs ± 2%     ~     (p=0.690 n=5+5)
InitPushContext/empty-6                      290ns ± 3%         287ns ± 1%     ~     (p=0.548 n=5+5)
InitPushContext/telemetry-6                  290ns ± 1%         292ns ± 2%     ~     (p=0.460 n=5+5)
InitPushContext/virtualservice-6             165ns ± 4%         162ns ± 1%     ~     (p=0.079 n=5+5)
RouteGeneration/gateways-6                   111ms ± 1%          43ms ± 2%  -61.04%  (p=0.008 n=5+5)
RouteGeneration/gateways-shared-6            457ms ± 2%         453ms ± 3%     ~     (p=0.548 n=5+5)
RouteGeneration/empty-6                      845µs ± 2%         846µs ± 2%     ~     (p=1.000 n=5+5)
RouteGeneration/telemetry-6                  868µs ± 3%         867µs ± 3%     ~     (p=1.000 n=5+5)
RouteGeneration/virtualservice-6            1.98ms ± 1%        1.88ms ± 1%   -5.25%  (p=0.008 n=5+5)
ClusterGeneration/gateways-6                3.51ms ± 1%        3.55ms ± 1%     ~     (p=0.222 n=5+5)
ClusterGeneration/gateways-shared-6         3.53ms ± 1%        3.56ms ± 1%     ~     (p=0.421 n=5+5)
ClusterGeneration/empty-6                   1.51ms ± 1%        1.50ms ± 2%     ~     (p=0.841 n=5+5)
ClusterGeneration/telemetry-6               1.92ms ± 2%        1.91ms ± 2%     ~     (p=1.000 n=5+5)
ClusterGeneration/virtualservice-6           363µs ± 1%         363µs ± 2%     ~     (p=0.841 n=5+5)
ListenerGeneration/gateways-6               10.4ms ± 3%        10.5ms ± 1%     ~     (p=0.690 n=5+5)
ListenerGeneration/gateways-shared-6        24.6µs ± 2%        24.7µs ± 1%     ~     (p=1.000 n=5+5)
ListenerGeneration/empty-6                  1.42ms ± 2%        1.40ms ± 2%     ~     (p=0.310 n=5+5)
ListenerGeneration/telemetry-6              1.58ms ± 1%        1.59ms ± 1%     ~     (p=0.095 n=5+5)
ListenerGeneration/virtualservice-6          101µs ± 1%         101µs ± 1%     ~     (p=0.841 n=5+5)
EndpointGeneration/100/1-6                  82.7µs ± 3%        82.2µs ± 2%     ~     (p=0.548 n=5+5)
EndpointGeneration/1000/1-6                  697µs ± 9%         713µs ± 5%     ~     (p=0.841 n=5+5)
EndpointGeneration/10000/1-6                6.92ms ±11%        6.98ms ± 8%     ~     (p=1.000 n=5+5)
EndpointGeneration/100/100-6                7.30ms ±12%        7.43ms ± 6%     ~     (p=0.421 n=5+5)
EndpointGeneration/1000/100-6               74.5ms ± 9%        73.7ms ± 9%     ~     (p=1.000 n=5+5)
EndpointGeneration/10000/100-6               1.07s ±23%         1.00s ±35%     ~     (p=0.421 n=5+5)

name                                  old alloc/op       new alloc/op       delta
ListEquals-6                                5.70kB ± 0%        5.70kB ± 0%     ~     (p=0.444 n=5+5)
InitPushContext/gateways-6                  2.18MB ± 0%        2.18MB ± 0%     ~     (p=0.056 n=5+5)
InitPushContext/gateways-shared-6            399kB ± 0%         399kB ± 0%     ~     (p=0.579 n=5+5)
InitPushContext/empty-6                      96.0B ± 0%         96.0B ± 0%     ~     (all equal)
InitPushContext/telemetry-6                  96.0B ± 0%         96.0B ± 0%     ~     (all equal)
InitPushContext/virtualservice-6             40.0B ± 0%         40.0B ± 0%     ~     (all equal)
RouteGeneration/gateways-6                  81.8MB ± 0%        15.7MB ± 0%  -80.84%  (p=0.008 n=5+5)
RouteGeneration/gateways-shared-6            226MB ± 0%         222MB ± 0%   -1.42%  (p=0.016 n=4+5)
RouteGeneration/empty-6                      567kB ± 0%         567kB ± 0%   -0.01%  (p=0.032 n=5+5)
RouteGeneration/telemetry-6                  569kB ± 0%         569kB ± 0%   -0.01%  (p=0.016 n=5+5)
RouteGeneration/virtualservice-6             928kB ± 0%         877kB ± 0%   -5.52%  (p=0.008 n=5+5)
ClusterGeneration/gateways-6                1.99MB ± 0%        1.99MB ± 0%     ~     (p=0.841 n=5+5)
ClusterGeneration/gateways-shared-6         1.99MB ± 0%        1.99MB ± 0%     ~     (p=0.222 n=5+5)
ClusterGeneration/empty-6                    819kB ± 0%         818kB ± 0%     ~     (p=0.095 n=5+5)
ClusterGeneration/telemetry-6               1.05MB ± 0%        1.05MB ± 0%     ~     (p=0.222 n=5+5)
ClusterGeneration/virtualservice-6           202kB ± 0%         202kB ± 0%     ~     (p=0.286 n=5+4)
ListenerGeneration/gateways-6               5.21MB ± 0%        5.21MB ± 0%     ~     (p=0.657 n=4+4)
ListenerGeneration/gateways-shared-6        11.4kB ± 0%        11.4kB ± 0%     ~     (all equal)
ListenerGeneration/empty-6                   755kB ± 0%         755kB ± 0%     ~     (p=0.230 n=5+5)
ListenerGeneration/telemetry-6               817kB ± 0%         817kB ± 0%     ~     (p=1.000 n=5+5)
ListenerGeneration/virtualservice-6         55.5kB ± 0%        55.5kB ± 0%     ~     (all equal)
EndpointGeneration/100/1-6                  6.60kB ± 0%        6.60kB ± 0%     ~     (all equal)
EndpointGeneration/1000/1-6                 38.7kB ± 0%        38.7kB ± 0%     ~     (p=0.333 n=5+5)
EndpointGeneration/10000/1-6                 388kB ± 1%         388kB ± 1%     ~     (p=0.690 n=5+5)
EndpointGeneration/100/100-6                 664kB ± 0%         664kB ± 0%     ~     (p=0.889 n=5+5)
EndpointGeneration/1000/100-6               6.45MB ± 2%        6.49MB ± 3%     ~     (p=1.000 n=5+5)
EndpointGeneration/10000/100-6               360MB ±34%         319MB ±38%     ~     (p=0.500 n=5+5)

name                                  old allocs/op      new allocs/op      delta
ListEquals-6                                  5.00 ± 0%          5.00 ± 0%     ~     (all equal)
InitPushContext/gateways-6                   26.5k ± 0%         26.5k ± 0%     ~     (p=0.325 n=5+5)
InitPushContext/gateways-shared-6              118 ± 0%           119 ± 1%     ~     (p=0.238 n=4+5)
InitPushContext/empty-6                       3.00 ± 0%          3.00 ± 0%     ~     (all equal)
InitPushContext/telemetry-6                   3.00 ± 0%          3.00 ± 0%     ~     (all equal)
InitPushContext/virtualservice-6              2.00 ± 0%          2.00 ± 0%     ~     (all equal)
RouteGeneration/gateways-6                    218k ± 0%          199k ± 0%   -8.71%  (p=0.008 n=5+5)
RouteGeneration/gateways-shared-6            1.00M ± 0%         0.91M ± 0%   -9.56%  (p=0.029 n=4+4)
RouteGeneration/empty-6                      5.79k ± 0%         5.79k ± 0%   -0.02%  (p=0.008 n=5+5)
RouteGeneration/telemetry-6                  5.83k ± 0%         5.83k ± 0%   -0.02%  (p=0.008 n=5+5)
RouteGeneration/virtualservice-6             12.9k ± 0%         11.3k ± 0%  -12.40%  (p=0.008 n=5+5)
ClusterGeneration/gateways-6                 27.1k ± 0%         27.1k ± 0%     ~     (all equal)
ClusterGeneration/gateways-shared-6          27.1k ± 0%         27.1k ± 0%     ~     (all equal)
ClusterGeneration/empty-6                    11.3k ± 0%         11.3k ± 0%   -0.01%  (p=0.000 n=5+4)
ClusterGeneration/telemetry-6                13.4k ± 0%         13.4k ± 0%     ~     (all equal)
ClusterGeneration/virtualservice-6           2.81k ± 0%         2.81k ± 0%     ~     (all equal)
ListenerGeneration/gateways-6                59.1k ± 0%         59.1k ± 0%     ~     (all equal)
ListenerGeneration/gateways-shared-6           160 ± 0%           160 ± 0%     ~     (all equal)
ListenerGeneration/empty-6                   14.4k ± 0%         14.4k ± 0%     ~     (all equal)
ListenerGeneration/telemetry-6               15.0k ± 0%         15.0k ± 0%     ~     (all equal)
ListenerGeneration/virtualservice-6            780 ± 0%           780 ± 0%     ~     (all equal)
EndpointGeneration/100/1-6                    61.0 ± 0%          61.0 ± 0%     ~     (all equal)
EndpointGeneration/1000/1-6                   65.0 ± 0%          65.6 ± 1%     ~     (p=0.238 n=4+5)
EndpointGeneration/10000/1-6                   546 ±12%           542 ± 9%     ~     (p=0.738 n=5+5)
EndpointGeneration/100/100-6                 6.12k ± 0%         6.12k ± 1%     ~     (p=0.889 n=5+5)
EndpointGeneration/1000/100-6                57.6k ± 3%         58.4k ± 7%     ~     (p=0.921 n=5+5)
EndpointGeneration/10000/100-6               6.41M ±37%         5.61M ±43%     ~     (p=1.000 n=5+5)
```

This is not just microbenchmark improvements, in a real cluster:

![2020-07-07_19-39-27](https://user-images.githubusercontent.com/623453/86868483-9faa1d80-c089-11ea-9659-d38891362821.png)

Far left green = `master`. Far right blue = this PR. Ignore the stuff in between, it was WIP stuff.