### PR TITLE
Fix missing CRDs in client

### DIFF
--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -234,7 +234,7 @@ func (cl *Client) Delete(typ resource.GroupVersionKind, name, namespace string) 
 func (cl *Client) List(kind resource.GroupVersionKind, namespace string) ([]model.Config, error) {
 	h, f := cl.kinds[kind]
 	if !f {
-		return nil, fmt.Errorf("unrecognized type: %s", kind)
+		return nil, nil
 	}
 
 	list, err := h.lister(namespace).List(klabels.Everything())


### PR DESCRIPTION
When moving to istio/client-go, there was regression in behavior when a
CRD was missing. Previously we return nil, now we return error.

Old code:
https://github.com/istio/istio/blob/release-1.6/pilot/pkg/config/kube/crd/controller/controller.go#L425



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure