### PR TITLE
ads: use watched resourcenames instead of clusters and routes

### DIFF
--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -81,15 +81,8 @@ type Connection struct {
 	RouteConfigs map[string]*route.RouteConfiguration `json:"-"`
 	CDSClusters  []*cluster.Cluster
 
-	// TODO(ramaraochavali): Remove Clusters and Routes - use resource names in WatchedResource instead.
-	// current list of clusters monitored by the client
-	Clusters []string
-
 	// Both ADS and EDS streams implement this interface
 	stream DiscoveryStream
-
-	// Routes is the list of watched Routes.
-	Routes []string
 
 	// TODO(ramaraochavali): Remove LDSWatch and CDSWatch. Dervice it from Active map.
 	// LDSWatch is set if the remote server is watching Listeners
@@ -125,7 +118,6 @@ func newConnection(peerAddr string, stream DiscoveryStream) *Connection {
 	return &Connection{
 		pushChannel:  make(chan *Event),
 		PeerAddr:     peerAddr,
-		Clusters:     []string{},
 		Connect:      time.Now(),
 		stream:       stream,
 		LDSListeners: []*listener.Listener{},
@@ -389,8 +381,8 @@ func (s *DiscoveryServer) handleEds(con *Connection, discReq *discovery.Discover
 	if discReq.ResourceNames == nil && discReq.ResponseNonce != "" {
 		return nil
 	}
-	con.Clusters = discReq.ResourceNames
-	adsLog.Debugf("ADS:EDS: REQ %s clusters:%d", con.ConID, len(con.Clusters))
+	con.node.Active[v3.EndpointShortType].ResourceNames = discReq.ResourceNames
+	adsLog.Infof("ADS:EDS: REQ %s clusters:%d", con.ConID, len(con.Clusters()))
 	err := s.pushEds(s.globalPushContext(), con, versionInfo(), nil)
 	if err != nil {
 		return err
@@ -402,8 +394,7 @@ func (s *DiscoveryServer) handleRds(con *Connection, discReq *discovery.Discover
 	if !s.shouldRespond(con, rdsReject, discReq) {
 		return nil
 	}
-	con.Routes = discReq.ResourceNames
-	adsLog.Debugf("ADS:RDS: REQ %s routes:%d", con.ConID, len(con.Routes))
+	adsLog.Debugf("ADS:RDS: REQ %s routes:%d", con.ConID, len(con.Routes()))
 	err := s.pushRoute(con, s.globalPushContext(), versionInfo())
 	if err != nil {
 		return err
@@ -451,13 +442,17 @@ func (s *DiscoveryServer) shouldRespond(con *Connection, rejectMetric monitoring
 	// If it comes here, that means nonce match. This an ACK. We should record
 	// the ack details and respond if there is a change in resource names.
 	con.mu.Lock()
-	if con.node.Active[stype] == nil {
+	// This will be the case, if Envoy disconnects from a pilot instance and connects to another instance.
+	if previousInfo == nil {
 		con.node.Active[stype] = &model.WatchedResource{TypeUrl: request.TypeUrl, ResourceNames: request.ResourceNames}
 	}
 	previousResources := con.node.Active[stype].ResourceNames
 	con.node.Active[stype].VersionAcked = request.VersionInfo
 	con.node.Active[stype].NonceAcked = request.ResponseNonce
-	con.node.Active[stype].ResourceNames = request.ResourceNames
+	// This does not typically happen but needed till adsc responds with proper resource names.
+	if con.node.Active[stype].ResourceNames != nil {
+		con.node.Active[stype].ResourceNames = request.ResourceNames
+	}
 	con.mu.Unlock()
 
 	// Envoy can send two DiscoveryRequests with same version and nonce when it detects
@@ -615,7 +610,7 @@ func (s *DiscoveryServer) pushConnection(con *Connection, pushEv *Event) error {
 		edsUpdatedServices := model.ConfigNamesOfKind(pushEv.configsUpdated, gvk.ServiceEntry)
 		// Push only EDS. This is indexed already - push immediately
 		// (may need a throttle)
-		if len(con.Clusters) > 0 && len(edsUpdatedServices) > 0 {
+		if len(con.Clusters()) > 0 && len(edsUpdatedServices) > 0 {
 			if err := s.pushEds(pushEv.push, con, versionInfo(), edsUpdatedServices); err != nil {
 				return err
 			}
@@ -676,7 +671,7 @@ func (s *DiscoveryServer) pushConnection(con *Connection, pushEv *Event) error {
 		s.StatusReporter.RegisterEvent(con.ConID, ClusterEventType, pushEv.noncePrefix)
 	}
 
-	if len(con.Clusters) > 0 && pushTypes[EDS] {
+	if len(con.Clusters()) > 0 && pushTypes[EDS] {
 		err := s.pushEds(pushEv.push, con, currentVersion, nil)
 		if err != nil {
 			return err
@@ -692,7 +687,7 @@ func (s *DiscoveryServer) pushConnection(con *Connection, pushEv *Event) error {
 	} else if s.StatusReporter != nil {
 		s.StatusReporter.RegisterEvent(con.ConID, ListenerEventType, pushEv.noncePrefix)
 	}
-	if len(con.Routes) > 0 && pushTypes[RDS] {
+	if len(con.Routes()) > 0 && pushTypes[RDS] {
 		err := s.pushRoute(con, pushEv.push, currentVersion)
 		if err != nil {
 			return err
@@ -863,4 +858,18 @@ func (conn *Connection) NonceSent(stype string) string {
 		return conn.node.Active[stype].NonceSent
 	}
 	return ""
+}
+
+func (conn *Connection) Clusters() []string {
+	if conn.node.Active != nil && conn.node.Active[v3.EndpointShortType] != nil {
+		return conn.node.Active[v3.EndpointShortType].ResourceNames
+	}
+	return []string{}
+}
+
+func (conn *Connection) Routes() []string {
+	if conn.node.Active != nil && conn.node.Active[v3.RouteShortType] != nil {
+		return conn.node.Active[v3.RouteShortType].ResourceNames
+	}
+	return []string{}
 }

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -382,7 +382,7 @@ func (s *DiscoveryServer) handleEds(con *Connection, discReq *discovery.Discover
 		return nil
 	}
 	con.node.Active[v3.EndpointShortType].ResourceNames = discReq.ResourceNames
-	adsLog.Infof("ADS:EDS: REQ %s clusters:%d", con.ConID, len(con.Clusters()))
+	adsLog.Debugf("ADS:EDS: REQ %s clusters:%d", con.ConID, len(con.Clusters()))
 	err := s.pushEds(s.globalPushContext(), con, versionInfo(), nil)
 	if err != nil {
 		return err

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -513,7 +513,7 @@ func (s *DiscoveryServer) configDump(conn *Connection) (*adminapi.ConfigDump, er
 		return nil, err
 	}
 
-	routes := s.ConfigGenerator.BuildHTTPRoutes(conn.node, s.globalPushContext(), conn.Routes)
+	routes := s.ConfigGenerator.BuildHTTPRoutes(conn.node, s.globalPushContext(), conn.Routes())
 	routeConfigAny := util.MessageToAny(&adminapi.RoutesConfigDump{})
 	if len(routes) > 0 {
 		dynamicRouteConfig := make([]*adminapi.RoutesConfigDump_DynamicRouteConfig, 0)
@@ -625,7 +625,7 @@ func (s *DiscoveryServer) edsz(w http.ResponseWriter, req *http.Request) {
 
 	comma := false
 	_, _ = fmt.Fprintln(w, "[")
-	for _, clusterName := range con.Clusters {
+	for _, clusterName := range con.Clusters() {
 		if comma {
 			_, _ = fmt.Fprint(w, ",\n")
 		} else {

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -434,7 +434,7 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *Connection, vers
 
 	// All clusters that this endpoint is watching. For 1.0 - it's typically all clusters in the mesh.
 	// For 1.1+Sidecar - it's the small set of explicitly imported clusters, using the isolated DestinationRules
-	for _, clusterName := range con.Clusters {
+	for _, clusterName := range con.Clusters() {
 
 		l := s.generateEndpoints(clusterName, con.node, push, edsUpdatedServices)
 		if l == nil {
@@ -462,10 +462,10 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *Connection, vers
 
 	if edsUpdatedServices == nil {
 		adsLog.Infof("EDS: PUSH for node:%s clusters:%d endpoints:%d empty:%v",
-			con.node.ID, len(con.Clusters), endpoints, empty)
+			con.node.ID, len(con.Clusters()), endpoints, empty)
 	} else {
 		adsLog.Debugf("EDS: PUSH INC for node:%s clusters:%d endpoints:%d empty:%v",
-			con.node.ID, len(con.Clusters), endpoints, empty)
+			con.node.ID, len(con.Clusters()), endpoints, empty)
 	}
 	return nil
 }

--- a/pilot/pkg/xds/eds_sh_test.go
+++ b/pilot/pkg/xds/eds_sh_test.go
@@ -324,7 +324,6 @@ func sendCDSReqWithMetadata(node string, metadata *structpb.Struct, edsstr disco
 func sendEDSReqWithMetadata(clusters []string, node string, metadata *structpb.Struct,
 	edsstr discovery.AggregatedDiscoveryService_StreamAggregatedResourcesClient) error {
 	err := edsstr.Send(&discovery.DiscoveryRequest{
-		ResponseNonce: time.Now().String(),
 		Node: &core.Node{
 			Id:       node,
 			Metadata: metadata,

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -96,7 +96,7 @@ func TestEds(t *testing.T) {
 	// 30% faster than 1.0 config style. Keeping the test to track fixes and
 	// verify we fix the regression.
 	t.Run("MultipleRequest08", func(t *testing.T) {
-		// TODO: bump back up to 50 - regression in msater
+		// TODO: bump back up to 50 - regression in master
 		multipleRequest(server, false, 20, 5, 20*time.Second,
 			map[string]string{}, t)
 	})

--- a/pilot/pkg/xds/rds.go
+++ b/pilot/pkg/xds/rds.go
@@ -29,7 +29,7 @@ import (
 
 func (s *DiscoveryServer) pushRoute(con *Connection, push *model.PushContext, version string) error {
 	pushStart := time.Now()
-	rawRoutes := s.ConfigGenerator.BuildHTTPRoutes(con.node, push, con.Routes)
+	rawRoutes := s.ConfigGenerator.BuildHTTPRoutes(con.node, push, con.Routes())
 	if s.DebugConfigs {
 		for _, r := range rawRoutes {
 			con.RouteConfigs[r.Name] = r


### PR DESCRIPTION
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
