### PR TITLE
Add unit test for mode/authentication to cover ConstructSdsSecretConfigWithCustomUds, ConstructValidationContext, ApplyCustomSDSToCommonTLSContext

### DIFF
--- a/pilot/pkg/security/model/authentication_test.go
+++ b/pilot/pkg/security/model/authentication_test.go
@@ -214,7 +214,7 @@ func TestApplyToCommonTLSContext(t *testing.T) {
 		name       string
 		sdsUdsPath string
 		node       *model.Proxy
-		expected     *auth.CommonTlsContext
+		expected   *auth.CommonTlsContext
 	}{
 		{
 			name:       "MTLSStrict using SDS",
@@ -409,12 +409,12 @@ func TestApplyToCommonTLSContext(t *testing.T) {
 	}
 }
 
-func TestApplyCustomSDSToCommonTLSContext(t *testing.T) {
+func TestApplyCustomSDSToServerCommonTLSContext(t *testing.T) {
 	testCases := []struct {
 		name       string
 		sdsUdsPath string
 		tlsOpts    *networking.ServerTLSSettings
-		expected     *auth.CommonTlsContext
+		expected   *auth.CommonTlsContext
 	}{
 		{
 			name:       "static certificate validation without SubjectAltNames",
@@ -625,7 +625,7 @@ func TestApplyCustomSDSToCommonTLSContext(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			tlsContext := &auth.CommonTlsContext{}
-			ApplyCustomSDSToCommonTLSContext(tlsContext, test.tlsOpts, test.sdsUdsPath)
+			ApplyCustomSDSToServerCommonTLSContext(tlsContext, test.tlsOpts, test.sdsUdsPath)
 
 			if !cmp.Equal(tlsContext, test.expected, protocmp.Transform()) {
 				t.Errorf("got(%#v), want(%#v)\n", spew.Sdump(tlsContext), spew.Sdump(test.expected))

--- a/pilot/pkg/security/model/authentication_test.go
+++ b/pilot/pkg/security/model/authentication_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestConstructSdsSecretConfigWithCustomUds(t *testing.T) {
-	cases := []struct {
+	testCases := []struct {
 		name           string
 		serviceAccount string
 		sdsUdsPath     string
@@ -77,7 +77,7 @@ func TestConstructSdsSecretConfigWithCustomUds(t *testing.T) {
 		},
 	}
 
-	for _, c := range cases {
+	for _, c := range testCases {
 		t.Run(c.name, func(t *testing.T) {
 			if got := ConstructSdsSecretConfigWithCustomUds(c.serviceAccount, c.sdsUdsPath); !cmp.Equal(got, c.expected, protocmp.Transform()) {
 				t.Errorf("ConstructSdsSecretConfigWithCustomUds: got(%#v), want(%#v)\n", got, c.expected)
@@ -87,20 +87,7 @@ func TestConstructSdsSecretConfigWithCustomUds(t *testing.T) {
 }
 
 func TestConstructSdsSecretConfig(t *testing.T) {
-	gRPCConfig := &core.GrpcService_GoogleGrpc{
-		TargetUri:  "/tmp/sdsuds.sock",
-		StatPrefix: SDSStatPrefix,
-		ChannelCredentials: &core.GrpcService_GoogleGrpc_ChannelCredentials{
-			CredentialSpecifier: &core.GrpcService_GoogleGrpc_ChannelCredentials_LocalCredentials{
-				LocalCredentials: &core.GrpcService_GoogleGrpc_GoogleLocalCredentials{},
-			},
-		},
-	}
-
-	gRPCConfig.CredentialsFactoryName = FileBasedMetadataPlugName
-	gRPCConfig.CallCredentials = ConstructgRPCCallCredentials(K8sSATrustworthyJwtFileName, K8sSAJwtTokenHeaderKey)
-
-	cases := []struct {
+	testCases := []struct {
 		name           string
 		serviceAccount string
 		sdsUdsPath     string
@@ -143,7 +130,7 @@ func TestConstructSdsSecretConfig(t *testing.T) {
 		},
 	}
 
-	for _, c := range cases {
+	for _, c := range testCases {
 		t.Run(c.name, func(t *testing.T) {
 			if got := ConstructSdsSecretConfig(c.serviceAccount, c.sdsUdsPath); !cmp.Equal(got, c.expected, protocmp.Transform()) {
 				t.Errorf("ConstructSdsSecretConfig: got(%#v), want(%#v)\n", got, c.expected)

--- a/pilot/pkg/security/model/authentication_test.go
+++ b/pilot/pkg/security/model/authentication_test.go
@@ -15,112 +15,30 @@
 package model
 
 import (
-	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
 
+	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 )
 
-func TestConstructSdsSecretConfig(t *testing.T) {
-	gRPCConfig := &core.GrpcService_GoogleGrpc{
-		TargetUri:  "/tmp/sdsuds.sock",
-		StatPrefix: SDSStatPrefix,
-		ChannelCredentials: &core.GrpcService_GoogleGrpc_ChannelCredentials{
-			CredentialSpecifier: &core.GrpcService_GoogleGrpc_ChannelCredentials_LocalCredentials{
-				LocalCredentials: &core.GrpcService_GoogleGrpc_GoogleLocalCredentials{},
-			},
-		},
-	}
-
-	gRPCConfig.CredentialsFactoryName = FileBasedMetadataPlugName
-	gRPCConfig.CallCredentials = ConstructgRPCCallCredentials(K8sSATrustworthyJwtFileName, K8sSAJwtTokenHeaderKey)
-
-	cases := []struct {
-		serviceAccount string
-		sdsUdsPath     string
-		expected       *auth.SdsSecretConfig
-	}{
-		{
-			serviceAccount: "spiffe://cluster.local/ns/bar/sa/foo",
-			sdsUdsPath:     "/tmp/sdsuds.sock",
-			expected: &auth.SdsSecretConfig{
-				Name: "spiffe://cluster.local/ns/bar/sa/foo",
-				SdsConfig: &core.ConfigSource{
-					InitialFetchTimeout: features.InitialFetchTimeout,
-					ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
-						ApiConfigSource: &core.ApiConfigSource{
-							ApiType: core.ApiConfigSource_GRPC,
-							GrpcServices: []*core.GrpcService{
-								{
-									TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
-										EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: SDSClusterName},
-									},
-								},
-							},
-							RefreshDelay: nil,
-						},
-					},
-				},
-			},
-		},
-		{
-			serviceAccount: "spiffe://cluster.local/ns/bar/sa/foo",
-			sdsUdsPath:     "/tmp/sdsuds.sock",
-			expected: &auth.SdsSecretConfig{
-				Name: "spiffe://cluster.local/ns/bar/sa/foo",
-				SdsConfig: &core.ConfigSource{
-					InitialFetchTimeout: features.InitialFetchTimeout,
-					ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
-						ApiConfigSource: &core.ApiConfigSource{
-							ApiType: core.ApiConfigSource_GRPC,
-							GrpcServices: []*core.GrpcService{
-								{
-									TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
-										EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: SDSClusterName},
-									},
-								},
-							},
-							RefreshDelay: nil,
-						},
-					},
-				},
-			},
-		},
-		{
-			serviceAccount: "",
-			sdsUdsPath:     "/tmp/sdsuds.sock",
-			expected:       nil,
-		},
-		{
-			serviceAccount: "",
-			sdsUdsPath:     "spiffe://cluster.local/ns/bar/sa/foo",
-			expected:       nil,
-		},
-	}
-
-	for _, c := range cases {
-		if got := ConstructSdsSecretConfig(c.serviceAccount, c.sdsUdsPath); !reflect.DeepEqual(got, c.expected) {
-			t.Errorf("ConstructSdsSecretConfig: got(%#v) != want(%#v)\n", got, c.expected)
-			fmt.Println(got)
-			fmt.Println(c.expected)
-		}
-	}
-}
-
 func TestConstructSdsSecretConfigWithCustomUds(t *testing.T) {
 	cases := []struct {
+		name           string
 		serviceAccount string
 		sdsUdsPath     string
 		expected       *auth.SdsSecretConfig
 	}{
 		{
+			name:           "CustomUds with serviceAccount and sdsUdsPath",
 			serviceAccount: "spiffe://cluster.local/ns/bar/sa/foo",
 			sdsUdsPath:     "/tmp/sdsuds.sock",
 			expected: &auth.SdsSecretConfig{
@@ -140,18 +58,19 @@ func TestConstructSdsSecretConfigWithCustomUds(t *testing.T) {
 									},
 								},
 							},
-							RefreshDelay: nil,
 						},
 					},
 				},
 			},
 		},
 		{
+			name:           "CustomUds without service account",
 			serviceAccount: "",
 			sdsUdsPath:     "/tmp/sdsuds.sock",
 			expected:       nil,
 		},
 		{
+			name:           "CustomUds without sdsUdsPath",
 			serviceAccount: "spiffe://cluster.local/ns/bar/sa/foo",
 			sdsUdsPath:     "",
 			expected:       nil,
@@ -159,9 +78,157 @@ func TestConstructSdsSecretConfigWithCustomUds(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		if got := ConstructSdsSecretConfigWithCustomUds(c.serviceAccount, c.sdsUdsPath); !reflect.DeepEqual(got, c.expected) {
-			t.Errorf("ConstructSdsSecretConfig: got(%#v) != want(%#v)\n", got, c.expected)
-		}
+		t.Run(c.name, func(t *testing.T) {
+			if got := ConstructSdsSecretConfigWithCustomUds(c.serviceAccount, c.sdsUdsPath); !cmp.Equal(got, c.expected, protocmp.Transform()) {
+				t.Errorf("ConstructSdsSecretConfigWithCustomUds: got(%#v), want(%#v)\n", got, c.expected)
+			}
+		})
+	}
+}
+
+func TestConstructSdsSecretConfig(t *testing.T) {
+	gRPCConfig := &core.GrpcService_GoogleGrpc{
+		TargetUri:  "/tmp/sdsuds.sock",
+		StatPrefix: SDSStatPrefix,
+		ChannelCredentials: &core.GrpcService_GoogleGrpc_ChannelCredentials{
+			CredentialSpecifier: &core.GrpcService_GoogleGrpc_ChannelCredentials_LocalCredentials{
+				LocalCredentials: &core.GrpcService_GoogleGrpc_GoogleLocalCredentials{},
+			},
+		},
+	}
+
+	gRPCConfig.CredentialsFactoryName = FileBasedMetadataPlugName
+	gRPCConfig.CallCredentials = ConstructgRPCCallCredentials(K8sSATrustworthyJwtFileName, K8sSAJwtTokenHeaderKey)
+
+	cases := []struct {
+		name           string
+		serviceAccount string
+		sdsUdsPath     string
+		expected       *auth.SdsSecretConfig
+	}{
+		{
+			name:           "ConstructSdsSecretConfig",
+			serviceAccount: "spiffe://cluster.local/ns/bar/sa/foo",
+			sdsUdsPath:     "/tmp/sdsuds.sock",
+			expected: &auth.SdsSecretConfig{
+				Name: "spiffe://cluster.local/ns/bar/sa/foo",
+				SdsConfig: &core.ConfigSource{
+					InitialFetchTimeout: features.InitialFetchTimeout,
+					ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+						ApiConfigSource: &core.ApiConfigSource{
+							ApiType: core.ApiConfigSource_GRPC,
+							GrpcServices: []*core.GrpcService{
+								{
+									TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
+										EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: SDSClusterName},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:           "ConstructSdsSecretConfig",
+			serviceAccount: "spiffe://cluster.local/ns/bar/sa/foo",
+			sdsUdsPath:     "/tmp/sdsuds.sock",
+			expected: &auth.SdsSecretConfig{
+				Name: "spiffe://cluster.local/ns/bar/sa/foo",
+				SdsConfig: &core.ConfigSource{
+					InitialFetchTimeout: features.InitialFetchTimeout,
+					ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+						ApiConfigSource: &core.ApiConfigSource{
+							ApiType: core.ApiConfigSource_GRPC,
+							GrpcServices: []*core.GrpcService{
+								{
+									TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
+										EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: SDSClusterName},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:           "ConstructSdsSecretConfig without serviceAccount",
+			serviceAccount: "",
+			sdsUdsPath:     "/tmp/sdsuds.sock",
+			expected:       nil,
+		},
+		{
+			name:           "ConstructSdsSecretConfig without serviceAccount",
+			serviceAccount: "",
+			sdsUdsPath:     "spiffe://cluster.local/ns/bar/sa/foo",
+			expected:       nil,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ConstructSdsSecretConfig(c.serviceAccount, c.sdsUdsPath); !cmp.Equal(got, c.expected, protocmp.Transform()) {
+				t.Errorf("ConstructSdsSecretConfig: got(%#v), want(%#v)\n", got, c.expected)
+			}
+		})
+	}
+}
+
+func TestConstructValidationContext(t *testing.T) {
+	testCases := []struct {
+		name            string
+		rootCAFilePath  string
+		subjectAltNames []string
+		expected        *auth.CommonTlsContext_ValidationContext
+	}{
+		{
+			name:            "default_ca",
+			rootCAFilePath:  "/root/ca",
+			subjectAltNames: []string{"SystemCACertificates.keychain", "SystemRootCertificates.keychain"},
+			expected: &auth.CommonTlsContext_ValidationContext{
+				ValidationContext: &auth.CertificateValidationContext{
+					TrustedCa: &core.DataSource{
+						Specifier: &core.DataSource_Filename{
+							Filename: "/root/ca",
+						},
+					},
+					MatchSubjectAltNames: []*matcher.StringMatcher{
+						{
+							MatchPattern: &matcher.StringMatcher_Exact{
+								Exact: "SystemCACertificates.keychain",
+							},
+						},
+						{
+							MatchPattern: &matcher.StringMatcher_Exact{
+								Exact: "SystemRootCertificates.keychain",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:           "default_ca no subjectAltNames",
+			rootCAFilePath: "/root/ca",
+			expected: &auth.CommonTlsContext_ValidationContext{
+				ValidationContext: &auth.CertificateValidationContext{
+					TrustedCa: &core.DataSource{
+						Specifier: &core.DataSource_Filename{
+							Filename: "/root/ca",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range testCases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ConstructValidationContext(c.rootCAFilePath, c.subjectAltNames); !cmp.Equal(got, c.expected, protocmp.Transform()) {
+				t.Errorf("ConstructValidationContext: got(%#v), want(%#v)\n", got, c.expected)
+			}
+		})
 	}
 }
 
@@ -358,8 +425,233 @@ func TestApplyToCommonTLSContext(t *testing.T) {
 			tlsContext := &auth.CommonTlsContext{}
 			ApplyToCommonTLSContext(tlsContext, test.node.Metadata, test.sdsUdsPath, []string{})
 
-			if !reflect.DeepEqual(tlsContext, test.result) {
-				t.Errorf("got() = %v, want %v", spew.Sdump(tlsContext), spew.Sdump(test.result))
+			if !cmp.Equal(tlsContext, test.result, protocmp.Transform()) {
+				t.Errorf("got(%#v), want(%#v)\n", spew.Sdump(tlsContext), spew.Sdump(test.result))
+			}
+		})
+	}
+}
+
+func TestApplyCustomSDSToCommonTLSContext(t *testing.T) {
+	testCases := []struct {
+		name       string
+		sdsUdsPath string
+		tlsOpts    *networking.ServerTLSSettings
+		result     *auth.CommonTlsContext
+	}{
+		{
+			name:       "static certificate validation without SubjectAltNames ",
+			sdsUdsPath: "/tmp/sdsuds.sock",
+			tlsOpts: &networking.ServerTLSSettings{
+				CredentialName: "spiffe://cluster.local/ns/bar/sa/foo",
+				Mode:           networking.ServerTLSSettings_SIMPLE,
+			},
+			result: &auth.CommonTlsContext{
+				TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
+					{
+						Name: "spiffe://cluster.local/ns/bar/sa/foo",
+						SdsConfig: &core.ConfigSource{
+							InitialFetchTimeout: features.InitialFetchTimeout,
+							ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+								ApiConfigSource: &core.ApiConfigSource{
+									ApiType: core.ApiConfigSource_GRPC,
+									GrpcServices: []*core.GrpcService{
+										{
+											TargetSpecifier: &core.GrpcService_GoogleGrpc_{
+												GoogleGrpc: &core.GrpcService_GoogleGrpc{
+													TargetUri:  "/tmp/sdsuds.sock",
+													StatPrefix: SDSStatPrefix,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "static certificate validation with SubjectAltNames ",
+			sdsUdsPath: "/tmp/sdsuds.sock",
+			tlsOpts: &networking.ServerTLSSettings{
+				CredentialName:  "spiffe://cluster.local/ns/bar/sa/foo",
+				Mode:            networking.ServerTLSSettings_PASSTHROUGH,
+				SubjectAltNames: []string{"SystemCACertificates.keychain", "SystemRootCertificates.keychain"},
+			},
+			result: &auth.CommonTlsContext{
+				TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
+					{
+						Name: "spiffe://cluster.local/ns/bar/sa/foo",
+						SdsConfig: &core.ConfigSource{
+							InitialFetchTimeout: features.InitialFetchTimeout,
+							ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+								ApiConfigSource: &core.ApiConfigSource{
+									ApiType: core.ApiConfigSource_GRPC,
+									GrpcServices: []*core.GrpcService{
+										{
+											TargetSpecifier: &core.GrpcService_GoogleGrpc_{
+												GoogleGrpc: &core.GrpcService_GoogleGrpc{
+													TargetUri:  "/tmp/sdsuds.sock",
+													StatPrefix: SDSStatPrefix,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ValidationContextType: &auth.CommonTlsContext_ValidationContext{
+					ValidationContext: &auth.CertificateValidationContext{
+						MatchSubjectAltNames: []*matcher.StringMatcher{
+							{
+								MatchPattern: &matcher.StringMatcher_Exact{
+									Exact: "SystemCACertificates.keychain",
+								},
+							},
+							{
+								MatchPattern: &matcher.StringMatcher_Exact{
+									Exact: "SystemRootCertificates.keychain",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "ServerTLSSettings_MUTUAL mode without SubjectAltNames ",
+			sdsUdsPath: "/tmp/sdsuds.sock",
+			tlsOpts: &networking.ServerTLSSettings{
+				CredentialName: "spiffe://cluster.local/ns/bar/sa/foo",
+				Mode:           networking.ServerTLSSettings_MUTUAL,
+			},
+			result: &auth.CommonTlsContext{
+				TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
+					{
+						Name: "spiffe://cluster.local/ns/bar/sa/foo",
+						SdsConfig: &core.ConfigSource{
+							InitialFetchTimeout: features.InitialFetchTimeout,
+							ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+								ApiConfigSource: &core.ApiConfigSource{
+									ApiType: core.ApiConfigSource_GRPC,
+									GrpcServices: []*core.GrpcService{
+										{
+											TargetSpecifier: &core.GrpcService_GoogleGrpc_{
+												GoogleGrpc: &core.GrpcService_GoogleGrpc{
+													TargetUri:  "/tmp/sdsuds.sock",
+													StatPrefix: "sdsstat",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ValidationContextType: &auth.CommonTlsContext_CombinedValidationContext{
+					CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
+						DefaultValidationContext: &auth.CertificateValidationContext{},
+						ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
+							Name: "spiffe://cluster.local/ns/bar/sa/foo-cacert",
+							SdsConfig: &core.ConfigSource{
+								InitialFetchTimeout: features.InitialFetchTimeout,
+								ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+									ApiConfigSource: &core.ApiConfigSource{
+										ApiType: core.ApiConfigSource_GRPC,
+										GrpcServices: []*core.GrpcService{
+											{
+												TargetSpecifier: &core.GrpcService_GoogleGrpc_{
+													GoogleGrpc: &core.GrpcService_GoogleGrpc{
+														TargetUri:  "/tmp/sdsuds.sock",
+														StatPrefix: "sdsstat",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "ServerTLSSettings_MUTUAL mode with SubjectAltNames ",
+			sdsUdsPath: "/tmp/sdsuds.sock",
+			tlsOpts: &networking.ServerTLSSettings{
+				CredentialName:  "spiffe://cluster.local/ns/bar/sa/foo",
+				Mode:            networking.ServerTLSSettings_MUTUAL,
+				SubjectAltNames: []string{"SystemCACertificates.keychain", "SystemRootCertificates.keychain"},
+			},
+			result: &auth.CommonTlsContext{
+				TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
+					{
+						Name: "spiffe://cluster.local/ns/bar/sa/foo",
+						SdsConfig: &core.ConfigSource{
+							InitialFetchTimeout: features.InitialFetchTimeout,
+							ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+								ApiConfigSource: &core.ApiConfigSource{
+									ApiType: core.ApiConfigSource_GRPC,
+									GrpcServices: []*core.GrpcService{
+										{
+											TargetSpecifier: &core.GrpcService_GoogleGrpc_{
+												GoogleGrpc: &core.GrpcService_GoogleGrpc{
+													TargetUri:  "/tmp/sdsuds.sock",
+													StatPrefix: "sdsstat",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ValidationContextType: &auth.CommonTlsContext_CombinedValidationContext{
+					CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
+						DefaultValidationContext: &auth.CertificateValidationContext{
+							MatchSubjectAltNames: util.StringToExactMatch([]string{"SystemCACertificates.keychain", "SystemRootCertificates.keychain"}),
+						},
+						ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
+							Name: "spiffe://cluster.local/ns/bar/sa/foo-cacert",
+							SdsConfig: &core.ConfigSource{
+								InitialFetchTimeout: features.InitialFetchTimeout,
+								ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+									ApiConfigSource: &core.ApiConfigSource{
+										ApiType: core.ApiConfigSource_GRPC,
+										GrpcServices: []*core.GrpcService{
+											{
+												TargetSpecifier: &core.GrpcService_GoogleGrpc_{
+													GoogleGrpc: &core.GrpcService_GoogleGrpc{
+														TargetUri:  "/tmp/sdsuds.sock",
+														StatPrefix: "sdsstat",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			tlsContext := &auth.CommonTlsContext{}
+			ApplyCustomSDSToCommonTLSContext(tlsContext, test.tlsOpts, test.sdsUdsPath)
+
+			if !cmp.Equal(tlsContext, test.result, protocmp.Transform()) {
+				t.Errorf("got(%#v), want(%#v)\n", spew.Sdump(tlsContext), spew.Sdump(test.result))
 			}
 		})
 	}


### PR DESCRIPTION
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
