### PR TITLE
update pilot to istiod for istioctl proxy-status

### DIFF
--- a/istioctl/cmd/proxystatus.go
+++ b/istioctl/cmd/proxystatus.go
@@ -34,13 +34,13 @@ func statusCommand() *cobra.Command {
 		Use:   "proxy-status [<pod-name[.namespace]>]",
 		Short: "Retrieves the synchronization status of each Envoy in the mesh [kube only]",
 		Long: `
-Retrieves last sent and last acknowledged xDS sync from Pilot to each Envoy in the mesh
+Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in the mesh
 
 `,
 		Example: `# Retrieve sync status for all Envoys in a mesh
 	istioctl proxy-status
 
-# Retrieve sync diff for a single Envoy and Pilot
+# Retrieve sync diff for a single Envoy and Istiod
 	istioctl proxy-status istio-egressgateway-59585c5b9c-ndc59.istio-system
 `,
 		Aliases: []string{"ps"},
@@ -58,11 +58,11 @@ Retrieves last sent and last acknowledged xDS sync from Pilot to each Envoy in t
 				}
 
 				path = fmt.Sprintf("/debug/config_dump?proxyID=%s.%s", podName, ns)
-				pilotDumps, err := kubeClient.AllDiscoveryDo(context.TODO(), istioNamespace, path)
+				istiodDumps, err := kubeClient.AllDiscoveryDo(context.TODO(), istioNamespace, path)
 				if err != nil {
 					return err
 				}
-				c, err := compare.NewComparator(c.OutOrStdout(), pilotDumps, envoyDump)
+				c, err := compare.NewComparator(c.OutOrStdout(), istiodDumps, envoyDump)
 				if err != nil {
 					return err
 				}

--- a/istioctl/cmd/proxystatus_test.go
+++ b/istioctl/cmd/proxystatus_test.go
@@ -24,11 +24,11 @@ func TestProxyStatus(t *testing.T) {
 	cases := []execTestCase{
 		{ // case 0
 			args:           strings.Split("proxy-status", " "),
-			expectedString: "NAME     CDS     LDS     EDS     RDS     PILOT",
+			expectedString: "NAME     CDS     LDS     EDS     RDS     ISTIOD",
 		},
 		{ // case 1 short name "ps"
 			args:           strings.Split("ps", " "),
-			expectedString: "NAME     CDS     LDS     EDS     RDS     PILOT",
+			expectedString: "NAME     CDS     LDS     EDS     RDS     ISTIOD",
 		},
 		{ // case 5: supplying nonexistent pod name should result in error with --sds flag
 			args:          strings.Split("proxy-status random-gibberish-podname-61789237418234", " "),
@@ -36,7 +36,7 @@ func TestProxyStatus(t *testing.T) {
 		},
 		{ // case 6: new --revision argument
 			args:           strings.Split("proxy-status --revision canary", " "),
-			expectedString: "NAME     CDS     LDS     EDS     RDS     PILOT",
+			expectedString: "NAME     CDS     LDS     EDS     RDS     ISTIOD",
 		},
 	}
 

--- a/istioctl/pkg/writer/compare/cluster.go
+++ b/istioctl/pkg/writer/compare/cluster.go
@@ -22,25 +22,25 @@ import (
 	"github.com/pmezard/go-difflib/difflib"
 )
 
-// ClusterDiff prints a diff between Pilot and Envoy clusters to the passed writer
+// ClusterDiff prints a diff between Istiod and Envoy clusters to the passed writer
 func (c *Comparator) ClusterDiff() error {
 	jsonm := &jsonpb.Marshaler{Indent: "   "}
-	envoyBytes, pilotBytes := &bytes.Buffer{}, &bytes.Buffer{}
+	envoyBytes, istiodBytes := &bytes.Buffer{}, &bytes.Buffer{}
 	envoyClusterDump, err := c.envoy.GetDynamicClusterDump(true)
 	if err != nil {
 		envoyBytes.WriteString(err.Error())
 	} else if err := jsonm.Marshal(envoyBytes, envoyClusterDump); err != nil {
 		return err
 	}
-	pilotClusterDump, err := c.pilot.GetDynamicClusterDump(true)
+	istiodClusterDump, err := c.istiod.GetDynamicClusterDump(true)
 	if err != nil {
-		pilotBytes.WriteString(err.Error())
-	} else if err := jsonm.Marshal(pilotBytes, pilotClusterDump); err != nil {
+		istiodBytes.WriteString(err.Error())
+	} else if err := jsonm.Marshal(istiodBytes, istiodClusterDump); err != nil {
 		return err
 	}
 	diff := difflib.UnifiedDiff{
-		FromFile: "Pilot Clusters",
-		A:        difflib.SplitLines(pilotBytes.String()),
+		FromFile: "Istiod Clusters",
+		A:        difflib.SplitLines(istiodBytes.String()),
 		ToFile:   "Envoy Clusters",
 		B:        difflib.SplitLines(envoyBytes.String()),
 		Context:  c.context,

--- a/istioctl/pkg/writer/compare/comparator.go
+++ b/istioctl/pkg/writer/compare/comparator.go
@@ -22,28 +22,28 @@ import (
 	"istio.io/istio/istioctl/pkg/util/configdump"
 )
 
-// Comparator diffs between a config dump from Pilot and one from Envoy
+// Comparator diffs between a config dump from Istiod and one from Envoy
 type Comparator struct {
-	envoy, pilot *configdump.Wrapper
-	w            io.Writer
-	context      int
-	location     string
+	envoy, istiod *configdump.Wrapper
+	w             io.Writer
+	context       int
+	location      string
 }
 
 // NewComparator is a comparator constructor
-func NewComparator(w io.Writer, pilotResponses map[string][]byte, envoyResponse []byte) (*Comparator, error) {
+func NewComparator(w io.Writer, istiodResponses map[string][]byte, envoyResponse []byte) (*Comparator, error) {
 	c := &Comparator{}
-	for _, resp := range pilotResponses {
-		pilotDump := &configdump.Wrapper{}
-		err := json.Unmarshal(resp, pilotDump)
+	for _, resp := range istiodResponses {
+		istiodDump := &configdump.Wrapper{}
+		err := json.Unmarshal(resp, istiodDump)
 		if err != nil {
 			continue
 		}
-		c.pilot = pilotDump
+		c.istiod = istiodDump
 		break
 	}
-	if c.pilot == nil {
-		return nil, fmt.Errorf("unable to find config dump in Pilot responses")
+	if c.istiod == nil {
+		return nil, fmt.Errorf("unable to find config dump in Istiod responses")
 	}
 	envoyDump := &configdump.Wrapper{}
 	err := json.Unmarshal(envoyResponse, envoyDump)
@@ -57,7 +57,7 @@ func NewComparator(w io.Writer, pilotResponses map[string][]byte, envoyResponse 
 	return c, nil
 }
 
-// Diff prints a diff between Pilot and Envoy to the passed writer
+// Diff prints a diff between Istiod and Envoy to the passed writer
 func (c *Comparator) Diff() error {
 	if err := c.ClusterDiff(); err != nil {
 		return err

--- a/istioctl/pkg/writer/compare/listener.go
+++ b/istioctl/pkg/writer/compare/listener.go
@@ -22,25 +22,25 @@ import (
 	"github.com/pmezard/go-difflib/difflib"
 )
 
-// ListenerDiff prints a diff between Pilot and Envoy listeners to the passed writer
+// ListenerDiff prints a diff between Istiod and Envoy listeners to the passed writer
 func (c *Comparator) ListenerDiff() error {
 	jsonm := &jsonpb.Marshaler{Indent: "   "}
-	envoyBytes, pilotBytes := &bytes.Buffer{}, &bytes.Buffer{}
+	envoyBytes, istiodBytes := &bytes.Buffer{}, &bytes.Buffer{}
 	envoyListenerDump, err := c.envoy.GetDynamicListenerDump(true)
 	if err != nil {
 		envoyBytes.WriteString(err.Error())
 	} else if err := jsonm.Marshal(envoyBytes, envoyListenerDump); err != nil {
 		return err
 	}
-	pilotListenerDump, err := c.pilot.GetDynamicListenerDump(true)
+	istiodListenerDump, err := c.istiod.GetDynamicListenerDump(true)
 	if err != nil {
-		pilotBytes.WriteString(err.Error())
-	} else if err := jsonm.Marshal(pilotBytes, pilotListenerDump); err != nil {
+		istiodBytes.WriteString(err.Error())
+	} else if err := jsonm.Marshal(istiodBytes, istiodListenerDump); err != nil {
 		return err
 	}
 	diff := difflib.UnifiedDiff{
-		FromFile: "Pilot Listeners",
-		A:        difflib.SplitLines(pilotBytes.String()),
+		FromFile: "Istiod Listeners",
+		A:        difflib.SplitLines(istiodBytes.String()),
 		ToFile:   "Envoy Listeners",
 		B:        difflib.SplitLines(envoyBytes.String()),
 		Context:  c.context,

--- a/istioctl/pkg/writer/compare/route.go
+++ b/istioctl/pkg/writer/compare/route.go
@@ -23,25 +23,25 @@ import (
 	"github.com/pmezard/go-difflib/difflib"
 )
 
-// RouteDiff prints a diff between Pilot and Envoy routes to the passed writer
+// RouteDiff prints a diff between Istiod and Envoy routes to the passed writer
 func (c *Comparator) RouteDiff() error {
 	jsonm := &jsonpb.Marshaler{Indent: "   "}
-	envoyBytes, pilotBytes := &bytes.Buffer{}, &bytes.Buffer{}
+	envoyBytes, istiodBytes := &bytes.Buffer{}, &bytes.Buffer{}
 	envoyRouteDump, err := c.envoy.GetDynamicRouteDump(true)
 	if err != nil {
 		envoyBytes.WriteString(err.Error())
 	} else if err := jsonm.Marshal(envoyBytes, envoyRouteDump); err != nil {
 		return err
 	}
-	pilotRouteDump, err := c.pilot.GetDynamicRouteDump(true)
+	istiodRouteDump, err := c.istiod.GetDynamicRouteDump(true)
 	if err != nil {
-		pilotBytes.WriteString(err.Error())
-	} else if err := jsonm.Marshal(pilotBytes, pilotRouteDump); err != nil {
+		istiodBytes.WriteString(err.Error())
+	} else if err := jsonm.Marshal(istiodBytes, istiodRouteDump); err != nil {
 		return err
 	}
 	diff := difflib.UnifiedDiff{
-		FromFile: "Pilot Routes",
-		A:        difflib.SplitLines(pilotBytes.String()),
+		FromFile: "Istiod Routes",
+		A:        difflib.SplitLines(istiodBytes.String()),
 		ToFile:   "Envoy Routes",
 		B:        difflib.SplitLines(envoyBytes.String()),
 		Context:  c.context,

--- a/istioctl/pkg/writer/pilot/status.go
+++ b/istioctl/pkg/writer/pilot/status.go
@@ -67,7 +67,7 @@ func (s *StatusWriter) PrintSingle(statuses map[string][]byte, proxyName string)
 
 func (s *StatusWriter) setupStatusPrint(statuses map[string][]byte) (*tabwriter.Writer, []*writerStatus, error) {
 	w := new(tabwriter.Writer).Init(s.Writer, 0, 8, 5, ' ', 0)
-	_, _ = fmt.Fprintln(w, "NAME\tCDS\tLDS\tEDS\tRDS\tPILOT\tVERSION")
+	_, _ = fmt.Fprintln(w, "NAME\tCDS\tLDS\tEDS\tRDS\tISTIOD\tVERSION")
 	var fullStatus []*writerStatus
 	for pilot, status := range statuses {
 		var ss []*writerStatus

--- a/istioctl/pkg/writer/pilot/status_test.go
+++ b/istioctl/pkg/writer/pilot/status_test.go
@@ -43,25 +43,25 @@ func TestStatusWriter_PrintAll(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "prints multiple pilot inputs to buffer in alphabetical order by pod name",
+			name: "prints multiple istiod inputs to buffer in alphabetical order by pod name",
 			input: map[string][]xds.SyncStatus{
-				"pilot1": statusInput1(),
-				"pilot2": statusInput2(),
-				"pilot3": statusInput3(),
+				"istiod1": statusInput1(),
+				"istiod2": statusInput2(),
+				"istiod3": statusInput3(),
 			},
 			want: "testdata/multiStatusMultiPilot.txt",
 		},
 		{
-			name: "prints single pilot input to buffer in alphabetical order by pod name",
+			name: "prints single istiod input to buffer in alphabetical order by pod name",
 			input: map[string][]xds.SyncStatus{
-				"pilot1": append(statusInput1(), statusInput2()...),
+				"istiod1": append(statusInput1(), statusInput2()...),
 			},
 			want: "testdata/multiStatusSinglePilot.txt",
 		},
 		{
 			name: "error if given non-syncstatus info",
 			input: map[string][]xds.SyncStatus{
-				"pilot1": {},
+				"istiod1": {},
 			},
 			wantErr: true,
 		},
@@ -75,9 +75,9 @@ func TestStatusWriter_PrintAll(t *testing.T) {
 				b, _ := json.Marshal(ss)
 				input[key] = b
 			}
-			if len(tt.input["pilot1"]) == 0 {
+			if len(tt.input["istiod1"]) == 0 {
 				input = map[string][]byte{
-					"pilot1": []byte(`gobbledygook`),
+					"istiod1": []byte(`gobbledygook`),
 				}
 			}
 			err := sw.PrintAll(input)
@@ -103,18 +103,18 @@ func TestStatusWriter_PrintSingle(t *testing.T) {
 		wantErr   bool
 	}{
 		{
-			name: "prints multiple pilot inputs to buffer filtering for pod",
+			name: "prints multiple istiod inputs to buffer filtering for pod",
 			input: map[string][]xds.SyncStatus{
-				"pilot1": statusInput1(),
-				"pilot2": statusInput2(),
+				"istiod1": statusInput1(),
+				"istiod2": statusInput2(),
 			},
 			filterPod: "proxy2",
 			want:      "testdata/singleStatus.txt",
 		},
 		{
-			name: "single pilot input to buffer filtering for pod",
+			name: "single istiod input to buffer filtering for pod",
 			input: map[string][]xds.SyncStatus{
-				"pilot2": append(statusInput1(), statusInput2()...),
+				"istiod2": append(statusInput1(), statusInput2()...),
 			},
 			filterPod: "proxy2",
 			want:      "testdata/singleStatus.txt",
@@ -122,7 +122,7 @@ func TestStatusWriter_PrintSingle(t *testing.T) {
 		{
 			name: "fallback to proxy version",
 			input: map[string][]xds.SyncStatus{
-				"pilot2": statusInputProxyVersion(),
+				"istiod2": statusInputProxyVersion(),
 			},
 			filterPod: "proxy2",
 			want:      "testdata/singleStatusFallback.txt",
@@ -130,7 +130,7 @@ func TestStatusWriter_PrintSingle(t *testing.T) {
 		{
 			name: "error if given non-syncstatus info",
 			input: map[string][]xds.SyncStatus{
-				"pilot1": {},
+				"istiod1": {},
 			},
 			wantErr: true,
 		},
@@ -144,9 +144,9 @@ func TestStatusWriter_PrintSingle(t *testing.T) {
 				b, _ := json.Marshal(ss)
 				input[key] = b
 			}
-			if len(tt.input["pilot1"]) == 0 && len(tt.input["pilot2"]) == 0 {
+			if len(tt.input["istiod1"]) == 0 && len(tt.input["istiod2"]) == 0 {
 				input = map[string][]byte{
-					"pilot1": []byte(`gobbledygook`),
+					"istiod1": []byte(`gobbledygook`),
 				}
 			}
 			err := sw.PrintSingle(input, tt.filterPod)

--- a/istioctl/pkg/writer/pilot/testdata/multiStatusMultiPilot.txt
+++ b/istioctl/pkg/writer/pilot/testdata/multiStatusMultiPilot.txt
@@ -1,5 +1,5 @@
-NAME       CDS                            LDS          EDS                            RDS          PILOT      VERSION
-proxy1     STALE                          SYNCED       SYNCED                         NOT SENT     pilot1     1.1
-proxy2     STALE                          SYNCED       STALE                          SYNCED       pilot2     1.1
-proxy3     STALE (Never Acknowledged)     NOT SENT     STALE (Never Acknowledged)     SYNCED       pilot3     1.1
+NAME       CDS                            LDS          EDS                            RDS          ISTIOD      VERSION
+proxy1     STALE                          SYNCED       SYNCED                         NOT SENT     istiod1     1.1
+proxy2     STALE                          SYNCED       STALE                          SYNCED       istiod2     1.1
+proxy3     STALE (Never Acknowledged)     NOT SENT     STALE (Never Acknowledged)     SYNCED       istiod3     1.1
 

--- a/istioctl/pkg/writer/pilot/testdata/multiStatusSinglePilot.txt
+++ b/istioctl/pkg/writer/pilot/testdata/multiStatusSinglePilot.txt
@@ -1,3 +1,3 @@
-NAME       CDS       LDS        EDS        RDS          PILOT      VERSION
-proxy1     STALE     SYNCED     SYNCED     NOT SENT     pilot1     1.1
-proxy2     STALE     SYNCED     STALE      SYNCED       pilot1     1.1
+NAME       CDS       LDS        EDS        RDS          ISTIOD      VERSION
+proxy1     STALE     SYNCED     SYNCED     NOT SENT     istiod1     1.1
+proxy2     STALE     SYNCED     STALE      SYNCED       istiod1     1.1

--- a/istioctl/pkg/writer/pilot/testdata/singleStatus.txt
+++ b/istioctl/pkg/writer/pilot/testdata/singleStatus.txt
@@ -1,2 +1,2 @@
-NAME       CDS       LDS        EDS       RDS        PILOT      VERSION
-proxy2     STALE     SYNCED     STALE     SYNCED     pilot2     1.1
+NAME       CDS       LDS        EDS       RDS        ISTIOD      VERSION
+proxy2     STALE     SYNCED     STALE     SYNCED     istiod2     1.1

--- a/istioctl/pkg/writer/pilot/testdata/singleStatusFallback.txt
+++ b/istioctl/pkg/writer/pilot/testdata/singleStatusFallback.txt
@@ -1,2 +1,2 @@
-NAME       CDS       LDS        EDS       RDS        PILOT      VERSION
-proxy2     STALE     SYNCED     STALE     SYNCED     pilot2     1.1*
+NAME       CDS       LDS        EDS       RDS        ISTIOD      VERSION
+proxy2     STALE     SYNCED     STALE     SYNCED     istiod2     1.1*


### PR DESCRIPTION
Refactor and update output of `istioctl proxy-status`

Old output with (**PILOT**)
```
$ $GOPATH/src/istio.io/istio/out/linux_amd64/istioctl proxy-status
NAME                                                   CDS        LDS        EDS        RDS          PILOT                      VERSION
details-v1-558b8b4b76-h9jbz.default                    SYNCED     SYNCED     SYNCED     SYNCED       istiod-6cf8d4f9cb-zsk5v     1.6.0
istio-ingressgateway-66c994c45c-brfkd.istio-system     SYNCED     SYNCED     SYNCED     NOT SENT     istiod-6cf8d4f9cb-zsk5v     1.6.0
productpage-v1-6987489c74-wchxv.default                SYNCED     SYNCED     SYNCED     SYNCED       istiod-6cf8d4f9cb-zsk5v     1.6.0
prometheus-7bdc59c94d-g65j5.istio-system               SYNCED     SYNCED     SYNCED     SYNCED       istiod-6cf8d4f9cb-zsk5v     1.6.0
ratings-v1-7dc98c7588-46hkx.default                    SYNCED     SYNCED     SYNCED     SYNCED       istiod-6cf8d4f9cb-zsk5v     1.6.0
reviews-v1-7f99cc4496-9hwts.default                    SYNCED     SYNCED     SYNCED     SYNCED       istiod-6cf8d4f9cb-zsk5v     1.6.0
reviews-v2-7d79d5bd5d-6xt29.default                    SYNCED     SYNCED     SYNCED     SYNCED       istiod-6cf8d4f9cb-zsk5v     1.6.0
reviews-v3-7dbcdcbc56-gr66x.default                    SYNCED     SYNCED     SYNCED     SYNCED       istiod-6cf8d4f9cb-zsk5v     1.6.0
```

New output with (**ISTIOD**)
```
$ $GOPATH/src/istio.io/istio/out/linux_amd64/istioctl proxy-status
NAME                                                   CDS        LDS        EDS        RDS          ISTIOD                      VERSION
details-v1-558b8b4b76-h9jbz.default                    SYNCED     SYNCED     SYNCED     SYNCED       istiod-6cf8d4f9cb-zsk5v     1.6.4
istio-ingressgateway-66c994c45c-brfkd.istio-system     SYNCED     SYNCED     SYNCED     NOT SENT     istiod-6cf8d4f9cb-zsk5v     1.6.4
productpage-v1-6987489c74-wchxv.default                SYNCED     SYNCED     SYNCED     SYNCED       istiod-6cf8d4f9cb-zsk5v     1.6.4
prometheus-7bdc59c94d-g65j5.istio-system               SYNCED     SYNCED     SYNCED     SYNCED       istiod-6cf8d4f9cb-zsk5v     1.6.4
ratings-v1-7dc98c7588-46hkx.default                    SYNCED     SYNCED     SYNCED     SYNCED       istiod-6cf8d4f9cb-zsk5v     1.6.4
reviews-v1-7f99cc4496-9hwts.default                    SYNCED     SYNCED     SYNCED     SYNCED       istiod-6cf8d4f9cb-zsk5v     1.6.4
reviews-v2-7d79d5bd5d-6xt29.default                    SYNCED     SYNCED     SYNCED     SYNCED       istiod-6cf8d4f9cb-zsk5v     1.6.4
reviews-v3-7dbcdcbc56-gr66x.default                    SYNCED     SYNCED     SYNCED     SYNCED       istiod-6cf8d4f9cb-zsk5v     1.6.4
```

Also updated output for proxy ID.

Old output
```
$ $GOPATH/src/istio.io/istio/out/linux_amd64/istioctl proxy-status details-v1-558b8b4b76-h9jbz.default
--- Pilot Clusters
+++ Envoy Clusters
```
New output
```
$ $GOPATH/src/istio.io/istio/out/linux_amd64/istioctl proxy-status details-v1-558b8b4b76-h9jbz.default
--- Istiod Clusters
+++ Envoy Clusters
```