### PR TITLE
Fix VM test flakes

### DIFF
--- a/pkg/test/framework/components/echo/kube/instance.go
+++ b/pkg/test/framework/components/echo/kube/instance.go
@@ -139,11 +139,11 @@ func newInstance(ctx resource.Context, cfg echo.Config) (out *instance, err erro
 			}
 			for _, vmPod := range pods.Items {
 				if vmPod.Status.PodIP == "" {
-					return fmt.Errorf("empty pod ip")
+					return fmt.Errorf("empty pod ip for pod %v", vmPod.Name)
 				}
 			}
 			return nil
-		}); err != nil {
+		}, retry.Timeout(cfg.ReadinessTimeout)); err != nil {
 			return nil, err
 		}
 		serviceAccount := cfg.Service


### PR DESCRIPTION
Example failure:
https://prow.istio.io/view/gcs/istio-prow/pr-logs/pull/istio_istio/25294/integ-ipv6-k8s-tests_istio/1732

What happens is the pod startup just takes a while due to a fresh image
pull. We only wait 30s here - instead we should wait for the full
readiness timeout.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure