### PR TITLE
Reduce length of envoy logs

### DIFF
--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -118,6 +118,7 @@ func (e *envoy) args(fname string, epoch int, bootstrapConfig string) []string {
 		"--service-node", e.Node,
 		"--max-obj-name-len", fmt.Sprint(e.Config.StatNameLength),
 		"--local-address-ip-version", proxyLocalAddressType,
+		"--log-format-prefix-with-location", "0",
 		// format is like `2020-04-07T16:52:30.471425Z     info    envoy config   ...message..
 		// this matches Istio log format
 		"--log-format", "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n\t%v",

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -60,6 +60,7 @@ func TestEnvoyArgs(t *testing.T) {
 		"--service-node", "my-node",
 		"--max-obj-name-len", fmt.Sprint(proxyConfig.StatNameLength),
 		"--local-address-ip-version", "v4",
+		"--log-format-prefix-with-location", "0",
 		"--log-format", "%Y-%m-%dT%T.%fZ\t%l\tenvoy %n\t%v",
 		"-l", "trace",
 		"--component-log-level", "misc:error",


### PR DESCRIPTION
before:
```
2020-07-08T09:05:19.592489Z     info    envoy upstream  [bazel-out/k8-opt/bin/external/envoy/source/server/lds_api.cc:78] lds: add/update listener '0.0.0.0_8090'
2020-07-08T09:05:19.592833Z     info    envoy upstream  [bazel-out/k8-opt/bin/external/envoy/source/server/lds_api.cc:78] lds: add/update listener '10.96.0.10_9153'
2020-07-08T09:05:19.593176Z     info    envoy upstream  [bazel-out/k8-opt/bin/external/envoy/source/server/lds_api.cc:78] lds: add/update listener '10.111.165.28_853'
2020-07-08T09:05:19.593263Z     info    envoy upstream  [bazel-out/k8-opt/bin/external/envoy/source/server/lds_api.cc:78] lds: add/update listener 'virtualOutbound'
2020-07-08T09:05:19.599121Z     info    envoy upstream  [bazel-out/k8-opt/bin/external/envoy/source/server/lds_api.cc:78] lds: add/update listener 'virtualInbound'
2020-07-08T09:05:19.601397Z     info    envoy config    [bazel-out/k8-opt/bin/external/envoy/source/server/listener_manager_impl.cc:844] all dependencies initialized. starting workers
^C2020-07-08T09:05:21.124027Z   warning envoy main      [bazel-out/k8-opt/bin/external/envoy/source/server/server.cc:582] caught SIGINT
2020-07-08T09:05:21.124089Z     info    envoy main      [bazel-out/k8-opt/bin/external/envoy/source/server/server.cc:699] shutting down server instance
2020-07-08T09:05:21.124131Z     info    envoy main      [bazel-out/k8-opt/bin/external/envoy/source/server/server.cc:646] main dispatch loop exited
2020-07-08T16:05:21.124185Z     info    Status server has successfully terminated
2020-07-08T16:05:21.124210Z     info    Agent draining Proxy
2020-07-08T16:05:21.124231Z     info    Watcher has successfully terminated
```

A bunch of long lines that don't fit on my screen

After:

```
2020-07-08T09:04:30.897793Z     info    envoy upstream  lds: add/update listener '0.0.0.0_8090'
2020-07-08T09:04:30.898225Z     info    envoy upstream  lds: add/update listener 'virtualOutbound'
2020-07-08T09:04:30.921333Z     info    envoy upstream  lds: add/update listener 'virtualInbound'
2020-07-08T09:04:30.925863Z     info    envoy config    all dependencies initialized. starting workers
^C2020-07-08T09:04:59.869155Z   warning envoy main      caught SIGINT
2020-07-08T09:04:59.869217Z     info    envoy main      shutting down server instance
2020-07-08T09:04:59.869271Z     info    envoy main      main dispatch loop exited
2020-07-08T16:04:59.869254Z     info    Status server has successfully terminated
2020-07-08T16:04:59.869280Z     info    Agent draining Proxy
2020-07-08T16:04:59.869299Z     info    Watcher has successfully terminated
```

Short and consistent with the agent logs