### PR TITLE
De-dup send traffic and decouple traffic shifting

### DIFF
--- a/pkg/test/framework/features/features.yaml
+++ b/pkg/test/framework/features/features.yaml
@@ -35,6 +35,7 @@ features:
   # features relating to controlling the traffic of the service mesh.
   traffic:
     reachability:
+    shifting:
     routing:
     short-circuiting:
     mirroring:

--- a/tests/integration/pilot/traffic_shifting_test.go
+++ b/tests/integration/pilot/traffic_shifting_test.go
@@ -15,13 +15,7 @@
 package pilot
 
 import (
-	"fmt"
-	"math"
-	"strings"
 	"testing"
-	"time"
-
-	"istio.io/istio/pkg/test/util/retry"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
@@ -29,6 +23,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/util/file"
 	"istio.io/istio/pkg/test/util/tmpl"
+	"istio.io/istio/tests/integration/pilot/vm"
 )
 
 //	Virtual service topology
@@ -111,46 +106,8 @@ func TestTrafficShifting(t *testing.T) {
 					deployment := tmpl.EvaluateOrFail(t, file.AsStringOrFail(t, "testdata/traffic-shifting.yaml"), vsc)
 					ctx.Config().ApplyYAMLOrFail(t, ns.Name(), deployment)
 
-					sendTraffic(t, 100, instances[0], instances[1], hosts, v, errorThreshold)
+					vm.SendTraffic(t, 100, instances[0], instances[1], hosts, v, errorThreshold)
 				})
 			}
 		})
-}
-
-func sendTraffic(t *testing.T, batchSize int, from, to echo.Instance, hosts []string, weight []int32, errorThreshold float64) {
-	t.Helper()
-	// Send `batchSize` requests and ensure they are distributed as expected.
-	retry.UntilSuccessOrFail(t, func() error {
-		resp, err := from.Call(echo.CallOptions{
-			Target:   to,
-			PortName: "http",
-			Count:    batchSize,
-		})
-		if err != nil {
-			return fmt.Errorf("error during call: %v", err)
-		}
-		var totalRequests int
-		hitCount := map[string]int{}
-		for _, r := range resp {
-			for _, h := range hosts {
-				if strings.HasPrefix(r.Hostname, h+"-") {
-					hitCount[h]++
-					totalRequests++
-					break
-				}
-			}
-		}
-
-		for i, v := range hosts {
-			percentOfTrafficToHost := float64(hitCount[v]) * 100.0 / float64(totalRequests)
-			deltaFromExpected := math.Abs(float64(weight[i]) - percentOfTrafficToHost)
-			if errorThreshold-deltaFromExpected < 0 {
-				return fmt.Errorf("unexpected traffic weight for host %v. Expected %d%%, got %g%% (thresold: %g%%)",
-					v, weight[i], percentOfTrafficToHost, errorThreshold)
-			}
-			t.Logf("Got expected traffic weight for host %v. Expected %d%%, got %g%% (thresold: %g%%)",
-				v, weight[i], percentOfTrafficToHost, errorThreshold)
-		}
-		return nil
-	}, retry.Delay(time.Second))
 }

--- a/tests/integration/pilot/vm/vm_test.go
+++ b/tests/integration/pilot/vm/vm_test.go
@@ -17,17 +17,13 @@ package vm
 import (
 	"context"
 	"fmt"
-	"math"
 	"testing"
 	"time"
 
 	"istio.io/istio/pkg/test/echo/common/response"
 	epb "istio.io/istio/pkg/test/echo/proto"
-	"istio.io/istio/pkg/test/framework/label"
-	"istio.io/istio/pkg/test/util/file"
-	"istio.io/istio/pkg/test/util/tmpl"
-
 	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/label"
 
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/framework"
@@ -35,16 +31,6 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
 	"istio.io/istio/pkg/test/util/retry"
 )
-
-type TrafficShiftConfig struct {
-	Name      string
-	Namespace string
-	Host      string
-	Subset0   string
-	Subset1   string
-	Weight0   int32
-	Weight1   int32
-}
 
 // Test wrapper for the VM OS version test. This test will run in pre-submit
 // to avoid building and testing all OS images
@@ -212,80 +198,6 @@ spec:
 						ctx.Errorf("expected status %s but got %s", response.StatusCodeOK, resp.Code)
 					}
 				})
-
-				// now launch another proper k8s pod for the same VM service, such that the VM service is made
-				// of a pod and a VM. Set the subset for this pod to v2 so that we can check traffic shift
-				echoboot.NewBuilderOrFail(t, ctx).
-					With(&vm, echo.Config{
-						Service:    fmt.Sprintf("vm-%v", i),
-						Namespace:  ns,
-						Ports:      ports,
-						Pilot:      p,
-						DeployAsVM: false,
-						Version:    "v2", // WHY?
-						Subsets: []echo.SubsetConfig{
-							{
-								Version: "v2",
-							},
-						},
-					}).
-					BuildOrFail(t)
-
-				ctx.NewSubTest(fmt.Sprintf("traffic shifts for workload entries %v",
-					vmImages[i])).Run(func(ctx framework.TestContext) {
-
-					vsc := TrafficShiftConfig{
-						"traffic-shifting-rule-wle",
-						ns.Name(),
-						fmt.Sprintf("vm-%v", i),
-						"v1",
-						"v2",
-						50,
-						50,
-					}
-					deployment := tmpl.EvaluateOrFail(t, file.AsStringOrFail(t, "testdata/traffic-shifting.yaml"), vsc)
-					ctx.Config().ApplyYAMLOrFail(t, ns.Name(), deployment)
-					sendTraffic(t, 100, k8sClusterIPService, vm, []string{"v1", "v2"}, []int32{50, 50}, 10.0)
-				})
 			}
 		})
-}
-
-// TODO: dedup from main traffic shift test
-func sendTraffic(t *testing.T, batchSize int, from, to echo.Instance, versions []string, weight []int32, errorThreshold float64) {
-	t.Helper()
-	// Send `batchSize` requests and ensure they are distributed as expected.
-	retry.UntilSuccessOrFail(t, func() error {
-		resp, err := from.Call(echo.CallOptions{
-			Target:   to,
-			PortName: "http",
-			Count:    batchSize,
-		})
-		if err != nil {
-			return fmt.Errorf("error during call: %v", err)
-		}
-		var totalRequests int
-		hitCount := map[string]int{}
-		for _, r := range resp {
-			for _, v := range versions {
-				if r.Version == v {
-					hitCount[v]++
-					totalRequests++
-					break
-				}
-			}
-		}
-
-		for i, v := range versions {
-			percentOfTrafficToVersion := float64(hitCount[v]) * 100.0 / float64(totalRequests)
-			deltaFromExpected := math.Abs(float64(weight[i]) - percentOfTrafficToVersion)
-			if errorThreshold-deltaFromExpected < 0 {
-				return fmt.Errorf("unexpected traffic weight for version %v. Expected %d%%, got %g%% (thresold: %g%%)",
-					v, weight[i], percentOfTrafficToVersion, errorThreshold)
-			}
-			t.Logf("Got expected traffic weight for version %v. Expected %d%%, got %g%% (thresold: %g%%)",
-				v, weight[i], percentOfTrafficToVersion, errorThreshold)
-		}
-		return nil
-	}, retry.Delay(time.Second))
 }

--- a/tests/integration/pilot/vm/vm_traffic_shifting_test.go
+++ b/tests/integration/pilot/vm/vm_traffic_shifting_test.go
@@ -1,0 +1,122 @@
+/*
+ * // Copyright Istio Authors
+ * //
+ * // Licensed under the Apache License, Version 2.0 (the "License");
+ * // you may not use this file except in compliance with the License.
+ * // You may obtain a copy of the License at
+ * //
+ * //     http://www.apache.org/licenses/LICENSE-2.0
+ * //
+ * // Unless required by applicable law or agreed to in writing, software
+ * // distributed under the License is distributed on an "AS IS" BASIS,
+ * // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * // See the License for the specific language governing permissions and
+ * // limitations under the License.
+ */
+
+package vm
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/util/file"
+	"istio.io/istio/pkg/test/util/tmpl"
+)
+
+const (
+	// Error threshold. For example, we expect 25% traffic, traffic distribution within [15%, 35%] is accepted.
+	errorThreshold = 10.0
+)
+
+type TrafficShiftConfig struct {
+	Name      string
+	Namespace string
+	Host      string
+	Subset0   string
+	Subset1   string
+	Weight0   int32
+	Weight1   int32
+}
+
+func TestTrafficShifting(t *testing.T) {
+	// now launch another proper k8s pod for the same VM service, such that the VM service is made
+	// of a pod and a VM. Set the subset for this pod to v2 so that we can check traffic shift
+	// Traffic distribution
+	weights := map[string][]int32{
+		"20-80": {20, 80},
+		"50-50": {50, 50},
+	}
+	framework.
+		NewTest(t).
+		Features("traffic.shifting").
+		Run(func(ctx framework.TestContext) {
+			ns = namespace.NewOrFail(t, ctx, namespace.Config{
+				Prefix: "vm-traffic-shifting",
+				Inject: true,
+			})
+
+			ports := []echo.Port{
+				{
+					Name:     "http",
+					Protocol: protocol.HTTP,
+					// Due to a bug in WorkloadEntry, service port must equal target port for now
+					InstancePort: 8090,
+					ServicePort:  8090,
+				},
+			}
+
+			var client, vm echo.Instance
+			echoboot.NewBuilderOrFail(t, ctx).
+				With(&client, echo.Config{
+					Service:   "client",
+					Namespace: ns,
+					Ports:     ports,
+					Pilot:     p,
+				}).
+				With(&vm, echo.Config{
+					Service:    "vm",
+					Namespace:  ns,
+					Ports:      ports,
+					Pilot:      p,
+					DeployAsVM: true,
+					VMImage:    DefaultVMImage,
+				}).
+				With(&vm, echo.Config{ // add a regular pod to the same service as subset
+					Service:    "vm",
+					Namespace:  ns,
+					Ports:      ports,
+					Pilot:      p,
+					DeployAsVM: false,
+					Version:    "v2",
+					Subsets: []echo.SubsetConfig{
+						{
+							Version: "v2",
+						},
+					},
+				}).
+				BuildOrFail(t)
+
+			for k, v := range weights {
+				ctx.NewSubTest(k).
+					Run(func(ctx framework.TestContext) {
+						vsc := TrafficShiftConfig{
+							"traffic-shifting-rule-wle",
+							ns.Name(),
+							"vm",
+							"v1",
+							"v2",
+							v[0],
+							v[1],
+						}
+						deployment := tmpl.EvaluateOrFail(t, file.AsStringOrFail(t, "testdata/traffic-shifting.yaml"), vsc)
+						ctx.Config().ApplyYAMLOrFail(t, ns.Name(), deployment)
+						SendTraffic(t, 100, client, vm, []string{"v1", "v2"}, v, errorThreshold)
+					})
+			}
+		})
+}

--- a/tests/integration/pilot/vm/vm_traffic_shifting_test.go
+++ b/tests/integration/pilot/vm/vm_traffic_shifting_test.go
@@ -44,9 +44,6 @@ type TrafficShiftConfig struct {
 }
 
 func TestTrafficShifting(t *testing.T) {
-	// now launch another proper k8s pod for the same VM service, such that the VM service is made
-	// of a pod and a VM. Set the subset for this pod to v2 so that we can check traffic shift
-	// Traffic distribution
 	weights := map[string][]int32{
 		"20-80": {20, 80},
 		"50-50": {50, 50},
@@ -86,7 +83,10 @@ func TestTrafficShifting(t *testing.T) {
 					DeployAsVM: true,
 					VMImage:    DefaultVMImage,
 				}).
-				With(&vm, echo.Config{ // add a regular pod to the same service as subset
+				// now launch another proper k8s pod for the same VM service, such that the VM service is made
+				// of a pod and a VM. Set the subset for this pod to v2 so that we can check traffic shift
+				// Traffic distribution
+				With(&vm, echo.Config{
 					Service:    "vm",
 					Namespace:  ns,
 					Ports:      ports,


### PR DESCRIPTION
This PR aims to address the TODO left in TestVmOS. This moves the function `sendTraffic` to the util file, and create a new test to decouple the traffic shifting from `vm_test.go`. This might be clearer and TestVmOS could focus on performing reachability checks. 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
