### PR TITLE
feat(testing): Add VM-based Stackdriver tests for metrics and logs.

### DIFF
--- a/pkg/test/framework/components/echo/config.go
+++ b/pkg/test/framework/components/echo/config.go
@@ -83,6 +83,9 @@ type Config struct {
 
 	// The image name to be used to pull the image for the VM. `DeployAsVM` must be enabled.
 	VMImage string
+
+	// The set of environment variables to set for `DeployAsVM` instances.
+	VMEnvironment map[string]string
 }
 
 // SubsetConfig is the config for a group of Subsets (e.g. Kubernetes deployment).

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -266,6 +266,10 @@ spec:
           value: "ALL"
         - name: ISTIO_NAMESPACE # start.sh reads this and converts to POD_NAMESPACE
           value: {{ $.Namespace }}
+        {{- range $name, $value := $.Environment }}
+        - name: {{ $name }}
+          value: "{{ $value }}"
+        {{- end }}
         readinessProbe:
           httpGet:
             path: /healthz/ready
@@ -390,6 +394,7 @@ func generateYAMLWithSettings(cfg echo.Config, settings *image.Settings,
 			"IstiodIP":   istiodIP,
 			"IstiodPort": istiodPort,
 		},
+		"Environment": cfg.VMEnvironment,
 	}
 
 	serviceYAML, err = tmpl.Execute(serviceTemplate, params)

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -316,7 +316,7 @@ func initIOPFile(cfg Config, env *kube.Environment, iopFile string, valuesYaml s
 
 	operatorCfg := &pkgAPI.IstioOperator{}
 	if err := gogoprotomarshal.ApplyYAML(operatorYaml, operatorCfg); err != nil {
-		return fmt.Errorf("failed to unmsarshal base iop: %v", err)
+		return fmt.Errorf("failed to unmarshal base iop: %v, %v", err, operatorYaml)
 	}
 	var values = &pkgAPI.Values{}
 	if operatorCfg.Spec.Values != nil {
@@ -325,7 +325,7 @@ func initIOPFile(cfg Config, env *kube.Environment, iopFile string, valuesYaml s
 			return fmt.Errorf("failed to marshal base values: %v", err)
 		}
 		if err := gogoprotomarshal.ApplyYAML(string(valuesYml), values); err != nil {
-			return fmt.Errorf("failed to unmsarshal base values: %v", err)
+			return fmt.Errorf("failed to unmarshal base values: %v", err)
 		}
 	}
 

--- a/pkg/test/framework/components/stackdriver/kube.go
+++ b/pkg/test/framework/components/stackdriver/kube.go
@@ -32,6 +32,7 @@ import (
 	ltype "google.golang.org/genproto/googleapis/logging/type"
 	loggingpb "google.golang.org/genproto/googleapis/logging/v2"
 	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
+	kubeApiCore "k8s.io/api/core/v1"
 )
 
 const (
@@ -49,6 +50,7 @@ type kubeComponent struct {
 	ns        namespace.Instance
 	forwarder istioKube.PortForwarder
 	cluster   resource.Cluster
+	address   string
 }
 
 func newKube(ctx resource.Context, cfg Config) (Instance, error) {
@@ -97,6 +99,15 @@ func newKube(ctx resource.Context, cfg Config) (Instance, error) {
 	}
 	c.forwarder = forwarder
 	scopes.Framework.Debugf("initialized stackdriver port forwarder: %v", forwarder.Address())
+
+	var svc *kubeApiCore.Service
+	if svc, _, err = testKube.WaitUntilServiceEndpointsAreReady(c.cluster, c.ns.Name(), "stackdriver"); err != nil {
+		scopes.Framework.Infof("Error waiting for Stackdriver service to be available: %v", err)
+		return nil, err
+	}
+
+	c.address = fmt.Sprintf("%s:%d", svc.Spec.ClusterIP, svc.Spec.Ports[0].TargetPort.IntVal)
+	scopes.Framework.Infof("Stackdriver in-cluster address: %s", c.address)
 
 	return c, nil
 }
@@ -176,4 +187,8 @@ func (c *kubeComponent) Close() error {
 
 func (c *kubeComponent) GetStackdriverNamespace() string {
 	return c.ns.Name()
+}
+
+func (c *kubeComponent) Address() string {
+	return c.address
 }

--- a/pkg/test/framework/components/stackdriver/stackdriver.go
+++ b/pkg/test/framework/components/stackdriver/stackdriver.go
@@ -24,6 +24,7 @@ import (
 
 // Instance represents a deployed Stackdriver app instance in a Kubernetes cluster.
 type Instance interface {
+	Address() string
 	// Gets the namespace in which stackdriver is deployed.
 	GetStackdriverNamespace() string
 	ListTimeSeries() ([]*monitoringpb.TimeSeries, error)

--- a/pkg/test/framework/features/features.yaml
+++ b/pkg/test/framework/features/features.yaml
@@ -18,6 +18,7 @@ features:
   # features that relate to measuring or exploring your service mesh or the services which comprise it.
   observability:
     telemetry:
+      stackdriver:
       stats:
         prometheus:
           customize-metric:

--- a/tests/integration/telemetry/stackdriver/vm/main_test.go
+++ b/tests/integration/telemetry/stackdriver/vm/main_test.go
@@ -1,0 +1,130 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vm
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/gcemetadata"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/components/stackdriver"
+	"istio.io/istio/pkg/test/util/tmpl"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/pilot"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+const (
+	stackdriverBootstrapOverride = "../testdata/custom_bootstrap.yaml.tmpl"
+	serverRequestCount           = "testdata/server_request_count.json.tmpl"
+	clientRequestCount           = "testdata/client_request_count.json.tmpl"
+	serverLogEntry               = "testdata/server_access_log.json.tmpl"
+	sdBootstrapConfigMap         = "stackdriver-bootstrap-config"
+)
+
+var (
+	i       istio.Instance
+	p       pilot.Instance
+	ns      namespace.Instance
+	gceInst gcemetadata.Instance
+	sdInst  stackdriver.Instance
+	srv     echo.Instance
+	clt     echo.Instance
+	vmEnv   map[string]string
+)
+
+// Testing telemetry with VM mesh expansion on a simulated GCE instance.
+// Rather than deal with the infra to get a real VM, we will use a pod
+// with no Service, no DNS, no service account, etc to simulate a VM.
+//
+// This test setup borrows heavily from the following packages:
+// - tests/integration/pilot/vm
+// - tests/integration/telemetry/stackdriver
+func TestMain(m *testing.M) {
+	framework.
+		NewSuite(m).
+		RequireSingleCluster().
+		Setup(istio.Setup(&i, func(cfg *istio.Config) {
+			cfg.ControlPlaneValues = `
+values:
+  global:
+    meshExpansion:
+      enabled: true`
+			cfg.Values["telemetry.enabled"] = "true"
+			cfg.Values["telemetry.v1.enabled"] = "false"
+			cfg.Values["telemetry.v2.enabled"] = "true"
+			cfg.Values["telemetry.v2.stackdriver.enabled"] = "true"
+			cfg.Values["telemetry.v2.stackdriver.logging"] = "true"
+		})).
+		Setup(func(ctx resource.Context) (err error) {
+			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
+				return err
+			}
+			return nil
+		}).
+		Setup(testSetup).
+		Run()
+}
+
+func testSetup(ctx resource.Context) (err error) {
+	ns, err = namespace.New(ctx, namespace.Config{
+		Prefix: "istio-echo",
+		Inject: true,
+	})
+	if err != nil {
+		return
+	}
+
+	gceInst, err = gcemetadata.New(ctx, gcemetadata.Config{})
+	if err != nil {
+		return
+	}
+
+	sdInst, err = stackdriver.New(ctx, stackdriver.Config{})
+	if err != nil {
+		return
+	}
+
+	templateBytes, err := ioutil.ReadFile(stackdriverBootstrapOverride)
+	if err != nil {
+		return
+	}
+	sdBootstrap, err := tmpl.Evaluate(string(templateBytes), map[string]interface{}{
+		"StackdriverNamespace": sdInst.GetStackdriverNamespace(),
+		"EchoNamespace":        ns.Name(),
+	})
+	if err != nil {
+		return
+	}
+
+	err = ctx.Config().ApplyYAML(ns.Name(), sdBootstrap)
+
+	vmLabelsJSON := "{\\\"service.istio.io/canonical-name\\\":\\\"vm-server\\\",\\\"service.istio.io/canonical-revision\\\":\\\"v1\\\"}"
+
+	vmEnv = map[string]string{
+		"ISTIO_META_INSECURE_STACKDRIVER_ENDPOINT":               sdInst.Address(),
+		"ISTIO_META_STACKDRIVER_MONITORING_EXPORT_INTERVAL_SECS": "10",
+		"ISTIO_META_MESH_ID":                                     "test-mesh",
+		"ISTIO_META_WORKLOAD_NAME":                               "vm-server-v1",
+		"ISTIO_METAJSON_LABELS":                                  vmLabelsJSON,
+		"GCE_METADATA_HOST":                                      gceInst.Address(),
+	}
+
+	return
+}

--- a/tests/integration/telemetry/stackdriver/vm/testdata/client_request_count.json.tmpl
+++ b/tests/integration/telemetry/stackdriver/vm/testdata/client_request_count.json.tmpl
@@ -1,0 +1,29 @@
+{
+    "metric": {
+       "type": "istio.io/service/client/request_count",
+       "labels": {
+          "destination_canonical_revision": "v1",
+          "destination_canonical_service_name": "vm-server",
+          "destination_canonical_service_namespace": "{{ .EchoNamespace }}",
+          "destination_owner": "//compute.googleapis.com/some-creator",
+          "destination_port": "8090",
+          "destination_principal": "spiffe://cluster.local/ns/{{ .EchoNamespace }}/sa/default",
+          "destination_service_name": "server",
+          "destination_service_namespace": "{{ .EchoNamespace }}",
+          "destination_workload_name": "vm-server-v1",
+          "destination_workload_namespace": "{{ .EchoNamespace }}",
+          "mesh_uid": "test-mesh",
+          "request_operation": "GET",
+          "request_protocol": "http",
+          "response_code": "200",
+          "service_authentication_policy": "",
+          "source_canonical_revision": "v1",
+          "source_canonical_service_name": "client",
+          "source_canonical_service_namespace": "{{ .EchoNamespace }}",
+          "source_owner": "kubernetes://apis/apps/v1/namespaces/{{ .EchoNamespace }}/deployments/client-v1",
+          "source_principal": "spiffe://cluster.local/ns/{{ .EchoNamespace }}/sa/default",
+          "source_workload_name": "client-v1",
+          "source_workload_namespace": "{{ .EchoNamespace }}"
+       }
+    }
+}

--- a/tests/integration/telemetry/stackdriver/vm/testdata/server_access_log.json.tmpl
+++ b/tests/integration/telemetry/stackdriver/vm/testdata/server_access_log.json.tmpl
@@ -1,0 +1,27 @@
+{
+    "http_request": {
+        "request_method": "GET",
+        "request_url": "http://server.{{ .EchoNamespace }}.svc.cluster.local:8090/",
+        "protocol": "http",
+        "status": "200"
+    },
+    "labels": {
+        "destination_canonical_revision": "v1",
+        "destination_canonical_service": "vm-server",
+        "destination_namespace": "{{ .EchoNamespace }}",
+        "destination_principal": "spiffe://cluster.local/ns/{{ .EchoNamespace }}/sa/default",
+        "destination_service_host": "server.{{ .EchoNamespace }}.svc.cluster.local",
+        "destination_workload": "vm-server-v1",
+        "mesh_uid": "test-mesh",
+        "response_flag": "-",
+        "service_authentication_policy": "MUTUAL_TLS",
+        "source_app": "client",
+        "source_canonical_revision": "v1",
+        "source_canonical_service": "client",
+        "source_namespace": "{{ .EchoNamespace }}",
+        "source_principal": "spiffe://cluster.local/ns/{{ .EchoNamespace }}/sa/default",
+        "source_version": "v1",
+        "source_workload": "client-v1",
+        "protocol": "http"
+    }
+}

--- a/tests/integration/telemetry/stackdriver/vm/testdata/server_request_count.json.tmpl
+++ b/tests/integration/telemetry/stackdriver/vm/testdata/server_request_count.json.tmpl
@@ -1,0 +1,29 @@
+{
+    "metric": {
+       "type": "istio.io/service/server/request_count",
+       "labels": {
+          "destination_canonical_revision": "v1",
+          "destination_canonical_service_name": "vm-server",
+          "destination_canonical_service_namespace": "{{ .EchoNamespace }}",
+          "destination_owner": "//compute.googleapis.com/some-creator",
+          "destination_port": "8090",
+          "destination_principal": "spiffe://cluster.local/ns/{{ .EchoNamespace }}/sa/default",
+          "destination_service_name": "server",
+          "destination_service_namespace": "{{ .EchoNamespace }}",
+          "destination_workload_name": "vm-server-v1",
+          "destination_workload_namespace": "{{ .EchoNamespace }}",
+          "mesh_uid": "test-mesh",
+          "request_operation": "GET",
+          "request_protocol": "http",
+          "response_code": "200",
+          "service_authentication_policy": "MUTUAL_TLS",
+          "source_canonical_revision": "v1",
+          "source_canonical_service_name": "client",
+          "source_canonical_service_namespace": "{{ .EchoNamespace }}",
+          "source_owner": "kubernetes://apis/apps/v1/namespaces/{{ .EchoNamespace }}/deployments/client-v1",
+          "source_principal": "spiffe://cluster.local/ns/{{ .EchoNamespace }}/sa/default",
+          "source_workload_name": "client-v1",
+          "source_workload_namespace": "{{ .EchoNamespace }}"
+       }
+    }
+}

--- a/tests/integration/telemetry/stackdriver/vm/vm_test.go
+++ b/tests/integration/telemetry/stackdriver/vm/vm_test.go
@@ -76,7 +76,6 @@ spec:
 					Service:   "client",
 					Namespace: ns,
 					Ports:     ports,
-					Pilot:     p,
 					Subsets: []echo.SubsetConfig{
 						{
 							Annotations: map[echo.Annotation]*echo.AnnotationValue{
@@ -94,7 +93,6 @@ spec:
 					Service:       "server",
 					Namespace:     ns,
 					Ports:         ports,
-					Pilot:         p,
 					DeployAsVM:    true,
 					VMImage:       vm.DefaultVMImage,
 					VMEnvironment: vmEnv,

--- a/tests/integration/telemetry/stackdriver/vm/vm_test.go
+++ b/tests/integration/telemetry/stackdriver/vm/vm_test.go
@@ -1,0 +1,205 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vm
+
+import (
+	"fmt"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/jsonpb"
+	loggingpb "google.golang.org/genproto/googleapis/logging/v2"
+	monitoring "google.golang.org/genproto/googleapis/monitoring/v3"
+	"google.golang.org/protobuf/proto"
+
+	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/istio/pkg/test/util/tmpl"
+)
+
+func TestVMTelemetry(t *testing.T) {
+	framework.
+		NewTest(t).
+		Features("traffic.reachability"). // use stackdriver vm telemetry feature
+		Run(func(ctx framework.TestContext) {
+			// Set up strict mTLS. This gives a bit more assurance the calls are actually going through envoy,
+			// and certs are set up correctly.
+			ctx.Config().ApplyYAMLOrFail(ctx, ns.Name(), `
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+spec:
+  mtls:
+    mode: STRICT
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: send-mtls
+spec:
+  host: "*.svc.cluster.local"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+`)
+			ports := []echo.Port{
+				{
+					Name:     "http",
+					Protocol: protocol.HTTP,
+					// Due to a bug in WorkloadEntry, service port must equal target port for now
+					InstancePort: 8090,
+					ServicePort:  8090,
+				},
+			}
+
+			// builder to build the instances iteratively
+			echoboot.NewBuilderOrFail(t, ctx).
+				With(&clt, echo.Config{
+					Service:   "client",
+					Namespace: ns,
+					Ports:     ports,
+					Pilot:     p,
+					Subsets: []echo.SubsetConfig{
+						{
+							Annotations: map[echo.Annotation]*echo.AnnotationValue{
+								echo.SidecarBootstrapOverride: {
+									Value: sdBootstrapConfigMap,
+								},
+							},
+						},
+					},
+				}).
+				BuildOrFail(t)
+
+			echoboot.NewBuilderOrFail(t, ctx).
+				With(&srv, echo.Config{
+					Service:       "server",
+					Namespace:     ns,
+					Ports:         ports,
+					Pilot:         p,
+					DeployAsVM:    true,
+					VMImage:       "app_sidecar_ubuntu_bionic",
+					VMEnvironment: vmEnv,
+				}).
+				BuildOrFail(t)
+
+			srvReceived := false
+			cltReceived := false
+			logReceived := false
+			retry.UntilSuccessOrFail(t, func() error {
+				_, err := clt.Call(echo.CallOptions{
+					Target:   srv,
+					PortName: "http",
+					Count:    1,
+				})
+				if err != nil {
+					return err
+				}
+				// Verify stackdriver metrics
+				wantClt, wantSrv, err := getWantRequestCountTS()
+				if err != nil {
+					return err
+				}
+				// Traverse all time series received and compare with expected client and server time series.
+				ts, err := sdInst.ListTimeSeries()
+				if err != nil {
+					return err
+				}
+				for _, tt := range ts {
+					if proto.Equal(tt, &wantSrv) {
+						srvReceived = true
+					}
+					if proto.Equal(tt, &wantClt) {
+						cltReceived = true
+					}
+				}
+
+				// Verify log entry
+				wantLog, err := getWantServerLogEntry()
+				if err != nil {
+					return fmt.Errorf("failed to parse wanted log entry: %v", err)
+				}
+				// Traverse all log entries received and compare with expected server log entry.
+				entries, err := sdInst.ListLogEntries()
+				if err != nil {
+					return fmt.Errorf("failed to get received log entries: %v", err)
+				}
+				for _, l := range entries {
+					if proto.Equal(l, &wantLog) {
+						logReceived = true
+					}
+				}
+
+				// Check if both client and server side request count metrics are received
+				if !srvReceived || !cltReceived {
+					return fmt.Errorf("stackdriver server does not received expected server or client request count, server %v client %v", srvReceived, cltReceived)
+				}
+				if !logReceived {
+					return fmt.Errorf("stackdriver server does not received expected log entry")
+				}
+				return nil
+			}, retry.Delay(3*time.Second), retry.Timeout(40*time.Second))
+		})
+}
+
+func getWantRequestCountTS() (cltRequestCount, srvRequestCount monitoring.TimeSeries, err error) {
+	srvRequestCountTmpl, err := ioutil.ReadFile(serverRequestCount)
+	if err != nil {
+		return
+	}
+	sr, err := tmpl.Evaluate(string(srvRequestCountTmpl), map[string]interface{}{
+		"EchoNamespace": ns.Name(),
+	})
+	if err != nil {
+		return
+	}
+	if err = jsonpb.UnmarshalString(sr, &srvRequestCount); err != nil {
+		return
+	}
+	cltRequestCountTmpl, err := ioutil.ReadFile(clientRequestCount)
+	if err != nil {
+		return
+	}
+	cr, err := tmpl.Evaluate(string(cltRequestCountTmpl), map[string]interface{}{
+		"EchoNamespace": ns.Name(),
+	})
+	if err != nil {
+		return
+	}
+	err = jsonpb.UnmarshalString(cr, &cltRequestCount)
+	return
+}
+
+func getWantServerLogEntry() (srvLogEntry loggingpb.LogEntry, err error) {
+	srvlogEntryTmpl, err := ioutil.ReadFile(serverLogEntry)
+	if err != nil {
+		return
+	}
+	sr, err := tmpl.Evaluate(string(srvlogEntryTmpl), map[string]interface{}{
+		"EchoNamespace": ns.Name(),
+	})
+	if err != nil {
+		return
+	}
+	if err = jsonpb.UnmarshalString(sr, &srvLogEntry); err != nil {
+		return
+	}
+	return
+}

--- a/tests/integration/telemetry/stackdriver/vm/vm_test.go
+++ b/tests/integration/telemetry/stackdriver/vm/vm_test.go
@@ -31,6 +31,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/test/util/tmpl"
+	"istio.io/istio/tests/integration/pilot/vm"
 )
 
 func TestVMTelemetry(t *testing.T) {
@@ -95,7 +96,7 @@ spec:
 					Ports:         ports,
 					Pilot:         p,
 					DeployAsVM:    true,
-					VMImage:       "app_sidecar_ubuntu_bionic",
+					VMImage:       vm.DefaultVMImage,
 					VMEnvironment: vmEnv,
 				}).
 				BuildOrFail(t)

--- a/tests/integration/telemetry/stackdriver/vm/vm_test.go
+++ b/tests/integration/telemetry/stackdriver/vm/vm_test.go
@@ -37,7 +37,7 @@ import (
 func TestVMTelemetry(t *testing.T) {
 	framework.
 		NewTest(t).
-		Features("traffic.reachability"). // use stackdriver vm telemetry feature
+		Features("observability.telemetry.stackdriver").
 		Run(func(ctx framework.TestContext) {
 			// Set up strict mTLS. This gives a bit more assurance the calls are actually going through envoy,
 			// and certs are set up correctly.


### PR DESCRIPTION
This PR adds an initial test of Stackdriver telemetry function for VMs. In particular, it exercises metrics and logging paths for a server running on a VM.

This is part of a larger push to validate telemetry function in VM environments.

A few notes:
- avoids VM DNS issues by directly referencing the fake Stackdriver and GCE Metadata servers by cluster IP (and not names).
- does not validate proper Monitored Resource usage (must be done in a follow-on effort).
- uses `http` requests for now (as opposed to the `grpc` in existing Stackdriver tests).

Future improvements:
- validate traces and edges
- validate MR (`gce_instance`)
- use VM simplification work for VM setup

Local results:

```bash
$ HUB=gcr.io/istio-testing TAG=1.7-dev go test ./tests/integration/telemetry/stackdriver/vm/... --istio.test.ci
ok      istio.io/istio/tests/integration/telemetry/stackdriver/vm       52.444s
```

[ X ] Policies and Telemetry
[ X ] Test and Release
