### PR TITLE
XDS-based replacement for /debug/syncz

### DIFF
--- a/istioctl/cmd/proxystatus.go
+++ b/istioctl/cmd/proxystatus.go
@@ -16,15 +16,26 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"text/tabwriter"
 
+	envoy_corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	xdsapi "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	xdsstatus "github.com/envoyproxy/go-control-plane/envoy/service/status/v3"
+	"github.com/golang/protobuf/ptypes"
 	"github.com/spf13/cobra"
 
 	"istio.io/istio/istioctl/pkg/clioptions"
+	"istio.io/istio/istioctl/pkg/multixds"
 	"istio.io/istio/istioctl/pkg/util/handlers"
 	"istio.io/istio/istioctl/pkg/writer/compare"
 	"istio.io/istio/istioctl/pkg/writer/pilot"
+	"istio.io/istio/pilot/pkg/xds"
 	"istio.io/istio/pkg/kube"
+	"istio.io/pkg/log"
+	istioVersion "istio.io/pkg/version"
 )
 
 func statusCommand() *cobra.Command {
@@ -88,4 +99,123 @@ func newKubeClientWithRevision(kubeconfig, configContext string, revision string
 
 func newKubeClient(kubeconfig, configContext string) (kube.ExtendedClient, error) {
 	return newKubeClientWithRevision(kubeconfig, configContext, "")
+}
+
+func xdsStatusCommand() *cobra.Command {
+	var opts clioptions.ControlPlaneOptions
+	var centralOpts clioptions.CentralControlPlaneOptions
+
+	statusCmd := &cobra.Command{
+		Use:   "proxy-status [<pod-name[.namespace]>]",
+		Short: "Retrieves the synchronization status of each Envoy in the mesh",
+		Long: `
+Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in the mesh
+
+`,
+		Example: `# Retrieve sync status for all Envoys in a mesh
+	istioctl proxy-status
+
+# Retrieve sync diff for a single Envoy and Istiod
+	istioctl proxy-status istio-egressgateway-59585c5b9c-ndc59.istio-system
+`,
+		Aliases: []string{"ps"},
+		RunE: func(c *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return fmt.Errorf("status of single pod unimplemented") // TODO
+			}
+
+			xdsRequest := xdsapi.DiscoveryRequest{
+				Node: &envoy_corev3.Node{
+					Id: "debug~0.0.0.0~istioctl~cluster.local",
+				},
+				TypeUrl: "istio.io/debug/syncz",
+			}
+			kubeClient, err := kubeClientWithRevision(kubeconfig, configContext, opts.Revision)
+			if err != nil {
+				return err
+			}
+			// TODO Currently multixds doesn't reveal all Pod IDs, it merges them.  Don't do that.
+			xdsResponse, err := multixds.RequestAndProcessXds(&xdsRequest, &centralOpts, istioNamespace, kubeClient)
+			if err != nil {
+				return err
+			}
+			if len(xdsResponse.Resources) == 0 {
+				return fmt.Errorf("no proxies found on ")
+			}
+			return printAllStatuses(xdsResponse, c.OutOrStdout())
+		},
+	}
+
+	opts.AttachControlPlaneFlags(statusCmd)
+	centralOpts.AttachControlPlaneFlags(statusCmd)
+
+	return statusCmd
+}
+
+func printAllStatuses(dr *xdsapi.DiscoveryResponse, writer io.Writer) error {
+	w := new(tabwriter.Writer).Init(writer, 0, 8, 5, ' ', 0)
+	_, _ = fmt.Fprintln(w, "NAME\tCDS\tLDS\tEDS\tRDS\tISTIOD\tVERSION")
+	for _, resource := range dr.Resources {
+		switch resource.TypeUrl {
+		case "type.googleapis.com/envoy.service.status.v3.ClientConfig":
+			clientConfig := xdsstatus.ClientConfig{}
+			err := ptypes.UnmarshalAny(resource, &clientConfig)
+			if err != nil {
+				return fmt.Errorf("could not unmarshal ClientConfig: %w", err)
+			}
+			name := clientConfig.GetNode().GetId()
+			cds, lds, eds, rds := getSyncStatus(clientConfig.GetXdsConfig())
+			cp := cpInfo(dr)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", name, cds, lds, eds, rds, cp.ID, cp.Info.Version)
+		default:
+			return fmt.Errorf("/debug/syncz unexpected resource type %q", resource.TypeUrl)
+		}
+	}
+	return w.Flush()
+}
+
+// TODO merge with code in version.go
+func cpInfo(xdsResponse *xdsapi.DiscoveryResponse) xds.IstioControlPlaneInstance {
+	if xdsResponse.ControlPlane == nil {
+		return xds.IstioControlPlaneInstance{
+			Component: "MISSING",
+			ID:        "MISSING",
+			Info: istioVersion.BuildInfo{
+				Version: "MISSING CP ID",
+			},
+		}
+	}
+
+	cpID := xds.IstioControlPlaneInstance{}
+	err := json.Unmarshal([]byte(xdsResponse.ControlPlane.Identifier), &cpID)
+	if err != nil {
+		return xds.IstioControlPlaneInstance{
+			Component: "INVALID",
+			ID:        "INVALID",
+			Info: istioVersion.BuildInfo{
+				Version: "INVALID CP ID",
+			},
+		}
+	}
+	return cpID
+}
+
+func getSyncStatus(configs []*xdsstatus.PerXdsConfig) (cds, lds, eds, rds string) {
+	for _, config := range configs {
+		switch val := config.PerXdsConfig.(type) {
+		case *xdsstatus.PerXdsConfig_ListenerConfig:
+			lds = config.Status.String()
+		case *xdsstatus.PerXdsConfig_ClusterConfig:
+			cds = config.Status.String()
+		case *xdsstatus.PerXdsConfig_RouteConfig:
+			rds = config.Status.String()
+		case *xdsstatus.PerXdsConfig_EndpointConfig:
+			eds = config.Status.String()
+		case *xdsstatus.PerXdsConfig_ScopedRouteConfig:
+			// ignore; Istiod doesn't send these
+		default:
+			log.Infof("PerXdsConfig unexpected type %T\n", val)
+		}
+	}
+	return
 }

--- a/istioctl/cmd/proxystatus.go
+++ b/istioctl/cmd/proxystatus.go
@@ -123,16 +123,17 @@ Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in 
 				path := "config_dump"
 				envoyDump, err := kubeClient.EnvoyDo(context.TODO(), podName, ns, "GET", path, nil)
 				if err != nil {
-					return err
+					return fmt.Errorf("could not contact sidecar: %w", err)
 				}
 
 				xdsRequest := xdsapi.DiscoveryRequest{
+					ResourceNames: []string{fmt.Sprintf("%s.%s", podName, ns)},
 					Node: &envoy_corev3.Node{
 						Id: "debug~0.0.0.0~istioctl~cluster.local",
 					},
-					TypeUrl: fmt.Sprintf("%s?proxyID=%s.%s", pilotxds.TypeDebugConfigDump, podName, ns),
+					TypeUrl: pilotxds.TypeDebugConfigDump,
 				}
-				xdsResponses, err := multixds.AllRequestAndProcessXds(&xdsRequest, &centralOpts, istioNamespace, kubeClient)
+				xdsResponses, err := multixds.FirstRequestAndProcessXds(&xdsRequest, &centralOpts, istioNamespace, kubeClient)
 				if err != nil {
 					return err
 				}

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -151,6 +151,7 @@ debug and diagnose their Istio mesh.
 	experimentalCmd.AddCommand(waitCmd())
 
 	experimentalCmd.AddCommand(xdsVersionCommand())
+	experimentalCmd.AddCommand(xdsStatusCommand())
 
 	postInstallCmd.AddCommand(Webhook())
 	experimentalCmd.AddCommand(postInstallCmd)

--- a/istioctl/pkg/writer/pilot/status.go
+++ b/istioctl/pkg/writer/pilot/status.go
@@ -22,10 +22,16 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	xdsapi "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	xdsstatus "github.com/envoyproxy/go-control-plane/envoy/service/status/v3"
+	"github.com/golang/protobuf/ptypes"
+
+	"istio.io/istio/istioctl/pkg/multixds"
 	"istio.io/istio/pilot/pkg/xds"
+	"istio.io/pkg/log"
 )
 
-// StatusWriter enables printing of sync status using multiple []byte Pilot responses
+// StatusWriter enables printing of sync status using multiple []byte Istiod responses
 type StatusWriter struct {
 	Writer io.Writer
 }
@@ -33,6 +39,21 @@ type StatusWriter struct {
 type writerStatus struct {
 	pilot string
 	xds.SyncStatus
+}
+
+// XdsStatusWriter enables printing of sync status using multiple xdsapi.DiscoveryResponse Istiod responses
+type XdsStatusWriter struct {
+	Writer io.Writer
+}
+
+type xdsWriterStatus struct {
+	proxyID        string
+	istiodID       string
+	istiodVersion  string
+	clusterStatus  string
+	listenerStatus string
+	routeStatus    string
+	endpointStatus string
 }
 
 // PrintAll takes a slice of Pilot syncz responses and outputs them using a tabwriter
@@ -116,4 +137,87 @@ func xdsStatus(sent, acked string) string {
 	}
 	// Since the Nonce changes to uuid, so there is no more any time diff info
 	return "STALE"
+}
+
+// PrintAll takes a slice of Istiod syncz responses and outputs them using a tabwriter
+func (s *XdsStatusWriter) PrintAll(statuses map[string]*xdsapi.DiscoveryResponse) error {
+	w, fullStatus, err := s.setupStatusPrint(statuses)
+	if err != nil {
+		return err
+	}
+	for _, status := range fullStatus {
+		if err := xdsStatusPrintln(w, status); err != nil {
+			return err
+		}
+	}
+	return w.Flush()
+}
+
+func (s *XdsStatusWriter) setupStatusPrint(drs map[string]*xdsapi.DiscoveryResponse) (*tabwriter.Writer, []*xdsWriterStatus, error) {
+	// Gather the statuses before printing so they may be sorted
+	var fullStatus []*xdsWriterStatus
+	for _, dr := range drs {
+		for _, resource := range dr.Resources {
+			switch resource.TypeUrl {
+			case "type.googleapis.com/envoy.service.status.v3.ClientConfig":
+				clientConfig := xdsstatus.ClientConfig{}
+				err := ptypes.UnmarshalAny(resource, &clientConfig)
+				if err != nil {
+					return nil, nil, fmt.Errorf("could not unmarshal ClientConfig: %w", err)
+				}
+				cds, lds, eds, rds := getSyncStatus(clientConfig.GetXdsConfig())
+				cp := multixds.CpInfo(dr)
+				fullStatus = append(fullStatus, &xdsWriterStatus{
+					proxyID:        clientConfig.GetNode().GetId(),
+					istiodID:       cp.ID,
+					istiodVersion:  cp.Info.Version,
+					clusterStatus:  cds,
+					listenerStatus: lds,
+					routeStatus:    rds,
+					endpointStatus: eds,
+				})
+			default:
+				return nil, nil, fmt.Errorf("/debug/syncz unexpected resource type %q", resource.TypeUrl)
+			}
+		}
+	}
+	if len(fullStatus) == 0 {
+		return nil, nil, fmt.Errorf("no proxies found (checked %d istiods)", len(drs))
+	}
+
+	w := new(tabwriter.Writer).Init(s.Writer, 0, 8, 5, ' ', 0)
+	_, _ = fmt.Fprintln(w, "NAME\tCDS\tLDS\tEDS\tRDS\tISTIOD\tVERSION")
+
+	sort.Slice(fullStatus, func(i, j int) bool {
+		return fullStatus[i].proxyID < fullStatus[j].proxyID
+	})
+	return w, fullStatus, nil
+}
+
+func xdsStatusPrintln(w io.Writer, status *xdsWriterStatus) error {
+	_, _ = fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
+		status.proxyID,
+		status.clusterStatus, status.listenerStatus, status.endpointStatus, status.routeStatus,
+		status.istiodID, status.istiodVersion)
+	return nil
+}
+
+func getSyncStatus(configs []*xdsstatus.PerXdsConfig) (cds, lds, eds, rds string) {
+	for _, config := range configs {
+		switch val := config.PerXdsConfig.(type) {
+		case *xdsstatus.PerXdsConfig_ListenerConfig:
+			lds = config.Status.String()
+		case *xdsstatus.PerXdsConfig_ClusterConfig:
+			cds = config.Status.String()
+		case *xdsstatus.PerXdsConfig_RouteConfig:
+			rds = config.Status.String()
+		case *xdsstatus.PerXdsConfig_EndpointConfig:
+			eds = config.Status.String()
+		case *xdsstatus.PerXdsConfig_ScopedRouteConfig:
+			// ignore; Istiod doesn't send these
+		default:
+			log.Infof("PerXdsConfig unexpected type %T\n", val)
+		}
+	}
+	return
 }

--- a/istioctl/pkg/writer/pilot/status.go
+++ b/istioctl/pkg/writer/pilot/status.go
@@ -195,11 +195,11 @@ func (s *XdsStatusWriter) setupStatusPrint(drs map[string]*xdsapi.DiscoveryRespo
 }
 
 func xdsStatusPrintln(w io.Writer, status *xdsWriterStatus) error {
-	_, _ = fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
+	_, err := fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
 		status.proxyID,
 		status.clusterStatus, status.listenerStatus, status.endpointStatus, status.routeStatus,
 		status.istiodID, status.istiodVersion)
-	return nil
+	return err
 }
 
 func getSyncStatus(configs []*xdsstatus.PerXdsConfig) (cds, lds, eds, rds string) {

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -731,7 +731,6 @@ func (s *DiscoveryServer) getProxyConnection(proxyID string) *Connection {
 	defer s.adsClientsMutex.RUnlock()
 
 	for conID := range s.adsClients {
-
 		if strings.Contains(conID, proxyID) {
 			return s.adsClients[conID]
 		}

--- a/pilot/pkg/xds/internalgen.go
+++ b/pilot/pkg/xds/internalgen.go
@@ -178,9 +178,9 @@ func debugSyncz(sg *InternalGen) []*any.Any {
 				case pilot_xds_v3.ListenerShortType:
 					pxc.PerXdsConfig = &status.PerXdsConfig_ListenerConfig{}
 				case pilot_xds_v3.RouteShortType:
-					pxc.PerXdsConfig = &status.PerXdsConfig_EndpointConfig{}
+					pxc.PerXdsConfig = &status.PerXdsConfig_RouteConfig{}
 				case pilot_xds_v3.EndpointShortType:
-					pxc.PerXdsConfig = &status.PerXdsConfig_ListenerConfig{}
+					pxc.PerXdsConfig = &status.PerXdsConfig_EndpointConfig{}
 				case pilot_xds_v3.ClusterShortType:
 					pxc.PerXdsConfig = &status.PerXdsConfig_ClusterConfig{}
 				default:

--- a/pilot/pkg/xds/internalgen.go
+++ b/pilot/pkg/xds/internalgen.go
@@ -167,13 +167,13 @@ func (sg *InternalGen) Generate(proxy *model.Proxy, push *model.PushContext, w *
 		res = sg.debugSyncz()
 	case TypeDebugConfigDump:
 		if len(w.ResourceNames) == 0 {
-			log.Infof("istio.io/debug/config_dump without ResourceName")
+			log.Infof("%s without ResourceName", TypeDebugConfigDump)
 			break
 		}
 		var err error
 		res, err = sg.debugConfigDump(w.ResourceNames[0])
 		if err != nil {
-			log.Infof("istio.io/debug/config_dump failed: %v", err)
+			log.Infof("%s failed: %v", TypeDebugConfigDump, err)
 			break
 		}
 	}


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/25373 .

This provides similar function to Istio's /debug/syncz (the variant that returns all proxies)

The response is in CSDS format.

To test this, do `istioctl x ps --xds-address localhost:15010`.  The response is nearly identical to the original:

```
NAME                                                   CDS        LDS        EDS          RDS          ISTIOD                      VERSION
productpage-v1-7f4cc988c6-fmnfj.default                SYNCED     SYNCED     NOT_SENT     NOT_SENT     istiod-79bb4ccbfd-jw9d6     ad6880c4d6a9994f9823291423771258e3b9749d-dirty
test-1.default                                                                                         istiod-79bb4ccbfd-jw9d6     ad6880c4d6a9994f9823291423771258e3b9749d-dirty
istio-ingressgateway-6ccfd9c4d6-j87zl.istio-system     SYNCED     SYNCED     NOT_SENT     NOT_SENT     istiod-79bb4ccbfd-jw9d6     ad6880c4d6a9994f9823291423771258e3b9749d-dirty
prometheus-57486867f5-xkggp.istio-system               SYNCED     SYNCED     NOT_SENT     NOT_SENT     istiod-79bb4ccbfd-jw9d6     ad6880c4d6a9994f9823291423771258e3b9749d-dirty
details-v1-78db589446-wjbqh.default                    SYNCED     SYNCED     NOT_SENT     NOT_SENT     istiod-79bb4ccbfd-jw9d6     ad6880c4d6a9994f9823291423771258e3b9749d-dirty
```

The only difference is the `VERSION`, which is `1.7-dev` in the original.  (This may have something to do with my code to create an Envoy controlPlane description.  It is unrelated to the new code.)

The returned data is one ClientStatusResponse per "resource". https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/status/v3/csds.proto#service-status-v3-clientconfig format.  I don't return all possible values, just the node ID and statuses.

cc @costinm , @therealmitchconnors , @howardjohn 