### PR TITLE
Fix default builtin profile path when chartsDir is empty 

### DIFF
--- a/operator/pkg/helm/helm.go
+++ b/operator/pkg/helm/helm.go
@@ -306,7 +306,7 @@ func GetProfileYAML(installPackagePath, profileOrPath string) (string, error) {
 		return "", fmt.Errorf("failed to read profiles: %v", err)
 	}
 	// If charts are a file path and profile is a name like default, transform it to the file path.
-	if profiles[profileOrPath] {
+	if profiles[profileOrPath] && installPackagePath != "" {
 		profileOrPath = filepath.Join(installPackagePath, "profiles", profileOrPath+".yaml")
 	}
 	// This contains the IstioOperator CR.

--- a/operator/pkg/helm/vfs_renderer.go
+++ b/operator/pkg/helm/vfs_renderer.go
@@ -102,7 +102,7 @@ func readProfiles(chartsDir string) (map[string]bool, error) {
 		if err := CheckCompiledInCharts(); err != nil {
 			return nil, err
 		}
-		profilePaths, err := vfs.ReadDir(chartsDir)
+		profilePaths, err := vfs.ReadDir(filepath.Join(chartsDir, profilesRoot))
 		if err != nil {
 			return nil, fmt.Errorf("failed to read profiles: %v", err)
 		}


### PR DESCRIPTION
Fix https://github.com/istio/istio/issues/25291.

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
