### PR TITLE
Fix tombstone recovery bug in Galley

### DIFF
--- a/galley/pkg/config/source/kube/apiserver/watcher.go
+++ b/galley/pkg/config/source/kube/apiserver/watcher.go
@@ -107,17 +107,17 @@ func (w *watcher) dispatch(h event.Handler) {
 }
 
 func (w *watcher) handleEvent(c event.Kind, obj interface{}) {
-	object, ok := obj.(metav1.Object)
-	if !ok {
-		if obj = tombstone.RecoverResource(obj); object != nil {
+	if _, ok := obj.(metav1.Object); !ok {
+		recoveredObject := tombstone.RecoverResource(obj)
+		if recoveredObject == nil {
 			// Tombstone recovery failed.
 			scope.Source.Warnf("Unable to extract object for event: %v", obj)
 			return
 		}
-		obj = object
+		obj = recoveredObject
 	}
 
-	object = w.adapter.ExtractObject(obj)
+	object := w.adapter.ExtractObject(obj)
 	res, err := w.adapter.ExtractResource(obj)
 	if err != nil {
 		scope.Source.Warnf("unable to extract resource: %v: %e", obj, err)


### PR DESCRIPTION
The logic for recovering the tombstone here is confusing and seems wrong. The result of `tombstone.RecoverResource()` will be nil if there is an error -- it's not returning an error value.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure
