### PR TITLE
Better handle vendored trees

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -346,7 +346,7 @@ refresh-goldens:
 
 update-golden: refresh-goldens
 
-gen: go-gen mirror-licenses format update-crds operator-proto sync-configs-from-istiod gen-kustomize update-golden ## Update all generated code.
+gen: mod-download-go go-gen mirror-licenses format update-crds operator-proto sync-configs-from-istiod gen-kustomize update-golden ## Update all generated code.
 
 check-no-modify:
 	@bin/check_no_modify.sh

--- a/bin/protoc.sh
+++ b/bin/protoc.sh
@@ -21,7 +21,7 @@ fi
 
 RETRY_COUNT=3
 
-api=$(go list -m -f "{{.Dir}}" istio.io/api)
+api=$(go list -mod=readonly -m -f "{{.Dir}}" istio.io/api)
 
 # This occasionally flakes out, so have a simple retry loop
 for (( i=1; i <= RETRY_COUNT; i++ )); do

--- a/mixer/pkg/attribute/generate_word_list.sh
+++ b/mixer/pkg/attribute/generate_word_list.sh
@@ -14,5 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-istio_api=$(go list -m -f "{{.Dir}}" istio.io/api)
+istio_api=$(go list -mod=readonly -m -f "{{.Dir}}" istio.io/api)
 ./generate_word_list.py "${istio_api}/mixer/v1/global_dictionary.yaml" list.gen.go


### PR DESCRIPTION
By making sure `-mod=vendor` is not used or assumed as default
when there is a vendor/ directory.

`make gen` also needs the dependencies to be downloaded in the go cache (commands
like `go list -m all` do not work with `-mod=vendor`).