### PR TITLE
removed secret dumps and deprecated --export from dump_kubernetes.sh

### DIFF
--- a/tools/dump_kubernetes.sh
+++ b/tools/dump_kubernetes.sh
@@ -47,6 +47,7 @@ usage() {
   error '  -l, --label              if set, dump logs only for pods with given labels e.g. "-l app=pilot -l istio=galley"'
   error '  -n, --namespace          if set, dump logs only for pods in the given namespaces e.g. "-n default -n istio-system"'
   error '  --error-if-nasty-logs    if present, exit with 255 if any logs'
+  error '  --add-full-secrets       also dump Secrets, not just the Secret names'
   error '                               contain errors'
   exit 1
 }
@@ -78,6 +79,10 @@ parse_args() {
         local should_check_logs_for_errors=true
         shift # Shift past flag.
         ;;
+      --add-full-secrets)
+        local full_secret="-o yaml"
+        shift # Shift past flag.
+        ;;
       -m|--max-bytes)
         max_bytes="${2}"
         shift 2
@@ -98,8 +103,9 @@ parse_args() {
 
   readonly OUT_DIR="${out_dir:-istio-dump}"
   readonly SHOULD_ARCHIVE="${should_archive:-false}"
-  readonly QUIET="${quiet:-false}"
+  readonly QUIET="${quiet:-"false"}"
   readonly SHOULD_CHECK_LOGS_FOR_ERRORS="${should_check_logs_for_errors:-false}"
+  readonly FULLSECRETS="${full_secret}"
   readonly LOG_DIR="${OUT_DIR}/logs"
   readonly RESOURCES_FILE="${OUT_DIR}/resources.yaml"
   readonly ISTIO_RESOURCES_FILE="${OUT_DIR}/istio-resources.yaml"
@@ -246,9 +252,13 @@ dump_kubernetes_resources() {
 
   mkdir -p "${OUT_DIR}"
   # Only works in Kubernetes 1.8.0 and above.
-  kubectl get --all-namespaces --export \
-      all,jobs,ingresses,endpoints,customresourcedefinitions,configmaps,secrets,events \
+  kubectl get --all-namespaces \
+      all,jobs,ingresses,endpoints,customresourcedefinitions,configmaps,events \
       -o yaml > "${RESOURCES_FILE}"
+
+  echo -e "---\nkind: Secret\n---\n" >> "${RESOURCES_FILE}"
+  kubectl get --all-namespaces \
+      secrets ${FULLSECRETS} >> "${RESOURCES_FILE}"
 }
 
 dump_istio_custom_resource_definitions() {

--- a/tools/dump_kubernetes.sh
+++ b/tools/dump_kubernetes.sh
@@ -258,7 +258,7 @@ dump_kubernetes_resources() {
 
   echo -e "---\nkind: Secret\n---\n" >> "${RESOURCES_FILE}"
   kubectl get --all-namespaces \
-      secrets ${FULLSECRETS} >> "${RESOURCES_FILE}"
+      secrets "${FULLSECRETS}" >> "${RESOURCES_FILE}"
 }
 
 dump_istio_custom_resource_definitions() {


### PR DESCRIPTION
While the comment in the `dump_kubernetes.sh` script (`dump... secrets (names only)`) let you think it's secure to dump and share your cluster's config dump,  the full cluster's secrets are dumped. This is a high security risk for users who may share their root certs and maybe other sensible informations.

This PR effectively only dump secret's name (kubectl get secret --all-namespaces).It also add an option `--add-full-secrets` in case you really want that. 
It also remove the `--export` keyword that is deprecated for quite some time.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure