### PR TITLE
Added template for release notes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -40,6 +40,7 @@ Makefile*                                                        @istio/wg-test-
 /pkg/webhooks/                                                   @istio/wg-environments-maintainers
 /prow/                                                           @istio/wg-test-and-release-maintainers
 /release/                                                        @istio/wg-test-and-release-maintainers
+/releasenotes/                                                   @istio/wg-test-and-release-maintainers
 /samples/                                                        @istio/wg-docs-maintainers
 /samples/addons                                                  @istio/wg-policies-and-telemetry-maintainers @istio/wg-environments-maintainers
 /security/                                                       @istio/wg-security-maintainers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -40,7 +40,7 @@ Makefile*                                                        @istio/wg-test-
 /pkg/webhooks/                                                   @istio/wg-environments-maintainers
 /prow/                                                           @istio/wg-test-and-release-maintainers
 /release/                                                        @istio/wg-test-and-release-maintainers
-/releasenotes/                                                   @istio/wg-test-and-release-maintainers
+/releasenotes/                                                   @istio/wg-test-and-release-maintainers @istio/release-managers
 /samples/                                                        @istio/wg-docs-maintainers
 /samples/addons                                                  @istio/wg-policies-and-telemetry-maintainers @istio/wg-environments-maintainers
 /security/                                                       @istio/wg-security-maintainers

--- a/releasenotes/template.yaml
+++ b/releasenotes/template.yaml
@@ -1,0 +1,36 @@
+# This YAML file describes the format for specifying a release notes entry for Istio.
+# This should be filled in for all user facing changes.
+
+# Kind describes the type of change that this represents. 
+# Valid Values are:
+# - BugFix -- Describes a bug fixed
+# - SecurityFix -- Used to specify that this change represents a security fix. 
+# - Feature -- Used to specify a new feature that has been added. 
+# - Test -- Used to describe additional testing added. This file is optional for
+# tests, but included for completeness.
+Kind: BugFix
+
+# Area describes the area that this change affects. 
+# Valid values are:
+# - TrafficManagement
+# - Security
+# - Telemetry
+# - Installation
+# - istioctl
+# - Documentation
+Area:
+
+# Issue is a (potentially comma separated list) of GitHub issues resolved by this issue.
+Issue: 
+
+# ReleaseNotes is a markdown listing of any user facing changes. This will appear in the
+# release notes.
+ReleaseNotes:
+
+# UpgradNotes is a markdown listing of any changes that will affect the upgrade
+# process. This will appear in the release notes. 
+UpgradeNotes:
+
+# SecurityNotes is a markdown listing of any changes related to the security of
+# Istio.
+SecurityNotes:

--- a/releasenotes/template.yaml
+++ b/releasenotes/template.yaml
@@ -27,7 +27,7 @@ Issue:
 # release notes.
 ReleaseNotes:
 
-# UpgradNotes is a markdown listing of any changes that will affect the upgrade
+# UpgradeNotes is a markdown listing of any changes that will affect the upgrade
 # process. This will appear in the release notes. 
 UpgradeNotes:
 

--- a/releasenotes/template.yaml
+++ b/releasenotes/template.yaml
@@ -8,7 +8,7 @@
 # - Feature -- Used to specify a new feature that has been added. 
 # - Test -- Used to describe additional testing added. This file is optional for
 # tests, but included for completeness.
-Kind: BugFix
+Kind: 
 
 # Area describes the area that this change affects. 
 # Valid values are:
@@ -20,7 +20,7 @@ Kind: BugFix
 # - Documentation
 Area:
 
-# Issue is a (potentially comma separated list) of GitHub issues resolved by this issue.
+# Issue is a (potentially comma separated list) of GitHub issues resolved in this note.
 Issue: 
 
 # ReleaseNotes is a markdown listing of any user facing changes. This will appear in the

--- a/releasenotes/template.yaml
+++ b/releasenotes/template.yaml
@@ -1,36 +1,36 @@
 # This YAML file describes the format for specifying a release notes entry for Istio.
 # This should be filled in for all user facing changes.
 
-# Kind describes the type of change that this represents. 
+# kind describes the type of change that this represents. 
 # Valid Values are:
-# - BugFix -- Describes a bug fixed
-# - SecurityFix -- Used to specify that this change represents a security fix. 
-# - Feature -- Used to specify a new feature that has been added. 
-# - Test -- Used to describe additional testing added. This file is optional for
+# - bug-fix -- Used to specify that this change represents a bug fix. 
+# - security-fix -- Used to specify that this change represents a security fix. 
+# - feature -- Used to specify a new feature that has been added. 
+# - test -- Used to describe additional testing added. This file is optional for
 # tests, but included for completeness.
-Kind: 
+kind: 
 
-# Area describes the area that this change affects. 
+# area describes the area that this change affects. 
 # Valid values are:
-# - TrafficManagement
-# - Security
-# - Telemetry
-# - Installation
+# - traffic-management
+# - security
+# - telemetry
+# - installation
 # - istioctl
-# - Documentation
-Area:
+# - documentation
+area:
 
-# Issue is a (potentially comma separated list) of GitHub issues resolved in this note.
-Issue: 
+# issue is a (potentially comma separated list) of GitHub issues resolved in this note.
+issue: 
 
-# ReleaseNotes is a markdown listing of any user facing changes. This will appear in the
+# releaseNotes is a markdown listing of any user facing changes. This will appear in the
 # release notes.
-ReleaseNotes:
+releaseNotes:
 
-# UpgradeNotes is a markdown listing of any changes that will affect the upgrade
+# upgradeNotes is a markdown listing of any changes that will affect the upgrade
 # process. This will appear in the release notes. 
-UpgradeNotes:
+upgradeNotes:
 
-# SecurityNotes is a markdown listing of any changes related to the security of
+# securityNotes is a markdown listing of any changes related to the security of
 # Istio.
-SecurityNotes:
+securityNotes:

--- a/releasenotes/template.yaml
+++ b/releasenotes/template.yaml
@@ -7,7 +7,7 @@
 # - security-fix -- Used to specify that this change represents a security fix. 
 # - feature -- Used to specify a new feature that has been added. 
 # - test -- Used to describe additional testing added. This file is optional for
-# tests, but included for completeness.
+#   tests, but included for completeness.
 kind: 
 
 # area describes the area that this change affects. 


### PR DESCRIPTION
This is the first step towards automating the release notes process. This presents a template that we will link to in a prow job. This will be expected to be filled in for *all* user facing changes. 

Part of https://github.com/istio/istio/issues/23622


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure