### PR TITLE
optimize CombineVHostRoutes

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -252,7 +252,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 				if vHost, exists := vHostDedupMap[hostname]; exists {
 					// before merging this virtual service's routes, make sure that the existing one is not a tls redirect host
 					if vHost.RequireTls == route.VirtualHost_NONE {
-						vHost.Routes = istio_route.CombineVHostRoutes(vHost.Routes, routes)
+						vHost.Routes = append(vHost.Routes, routes...)
 					}
 				} else {
 					newVHost := &route.VirtualHost{
@@ -291,6 +291,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 	} else {
 		virtualHosts = make([]*route.VirtualHost, 0, len(vHostDedupMap))
 		for _, v := range vHostDedupMap {
+			v.Routes = istio_route.SortVHostRoutes(v.Routes)
 			virtualHosts = append(virtualHosts, v)
 		}
 	}

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -291,7 +291,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 	} else {
 		virtualHosts = make([]*route.VirtualHost, 0, len(vHostDedupMap))
 		for _, v := range vHostDedupMap {
-			v.Routes = istio_route.SortVHostRoutes(v.Routes)
+			v.Routes = istio_route.CombineVHostRoutes(v.Routes)
 			virtualHosts = append(virtualHosts, v)
 		}
 	}

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -208,7 +208,6 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 	nameToServiceMap := push.ServiceByHostname
 
 	vHostDedupMap := make(map[host.Name]*route.VirtualHost)
-	routesForHost := map[host.Name][][]*route.Route{}
 	for _, server := range servers {
 		gatewayName := merged.GatewayNameForServer[server]
 		if server.Tls != nil && server.Tls.HttpsRedirect {
@@ -250,17 +249,19 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 			}
 
 			for _, hostname := range intersectingHosts {
-				if _, exists := vHostDedupMap[hostname]; !exists {
+				if vHost, exists := vHostDedupMap[hostname]; exists {
+					// before merging this virtual service's routes, make sure that the existing one is not a tls redirect host
+					if vHost.RequireTls == route.VirtualHost_NONE {
+						vHost.Routes = append(vHost.Routes, routes...)
+					}
+				} else {
 					newVHost := &route.VirtualHost{
 						Name:                       domainName(string(hostname), port),
 						Domains:                    buildGatewayVirtualHostDomains(string(hostname)),
+						Routes:                     routes,
 						IncludeRequestAttemptCount: true,
 					}
 					vHostDedupMap[hostname] = newVHost
-				}
-				// before merging this virtual service's routes, make sure that the existing one is not a tls redirect host
-				if vHostDedupMap[hostname].RequireTls == route.VirtualHost_NONE {
-					routesForHost[hostname] = append(routesForHost[hostname], routes)
 				}
 			}
 		}
@@ -289,8 +290,8 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 		virtualHosts[0].Routes[0].Name = istio_route.DefaultRouteName
 	} else {
 		virtualHosts = make([]*route.VirtualHost, 0, len(vHostDedupMap))
-		for k, v := range vHostDedupMap {
-			v.Routes = istio_route.CombineVHostRoutes(routesForHost[k]...)
+		for _, v := range vHostDedupMap {
+			v.Routes = istio_route.SortVHostRoutes(v.Routes)
 			virtualHosts = append(virtualHosts, v)
 		}
 	}

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -1069,45 +1069,25 @@ func isCatchAllMatch(m *networking.HTTPMatchRequest) bool {
 	return catchall && len(m.Headers) == 0 && len(m.QueryParams) == 0
 }
 
-// CombineVHostRoutes semi concatenates two Vhost's routes into a single route set.
+// CombineVHostRoutes semi concatenates Vhost's routes into a single route set.
 // Moves the catch all routes alone to the end, while retaining
 // the relative order of other routes in the concatenated route.
 // Assumes that the virtual services that generated first and second are ordered by
 // time.
-func CombineVHostRoutes(first []*route.Route, second []*route.Route) []*route.Route {
-	allroutes := make([]*route.Route, 0, len(first)+len(second))
-	catchAllRoutes := make([]*route.Route, 0)
-
-	for _, f := range first {
-		if isCatchAllRoute(f) {
-			catchAllRoutes = append(catchAllRoutes, f)
-		} else {
-			allroutes = append(allroutes, f)
-		}
+func CombineVHostRoutes(routeSets ...[]*route.Route) []*route.Route {
+	l := 0
+	for _, rs := range routeSets {
+		l += len(rs)
 	}
-
-	for _, s := range second {
-		if isCatchAllRoute(s) {
-			catchAllRoutes = append(catchAllRoutes, s)
-		} else {
-			allroutes = append(allroutes, s)
-		}
-	}
-
-	allroutes = append(allroutes, catchAllRoutes...)
-	return allroutes
-}
-
-// SortVHostRoutes moves catchAllRoutes to the end while retaining
-// the relative order of other routes.
-func SortVHostRoutes(routes []*route.Route) []*route.Route {
-	allroutes := make([]*route.Route, 0, len(routes))
+	allroutes := make([]*route.Route, 0, l)
 	catchAllRoutes := make([]*route.Route, 0)
-	for _, r := range routes {
-		if isCatchAllRoute(r) {
-			catchAllRoutes = append(catchAllRoutes, r)
-		} else {
-			allroutes = append(allroutes, r)
+	for _, routes := range routeSets {
+		for _, r := range routes {
+			if isCatchAllRoute(r) {
+				catchAllRoutes = append(catchAllRoutes, r)
+			} else {
+				allroutes = append(allroutes, r)
+			}
 		}
 	}
 	return append(allroutes, catchAllRoutes...)

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -1069,28 +1069,26 @@ func isCatchAllMatch(m *networking.HTTPMatchRequest) bool {
 	return catchall && len(m.Headers) == 0 && len(m.QueryParams) == 0
 }
 
-// CombineVHostRoutes semi concatenates two Vhost's routes into a single route set.
+// CombineVHostRoutes semi concatenates sets of Vhost routes into a single route set.
 // Moves the catch all routes alone to the end, while retaining
 // the relative order of other routes in the concatenated route.
 // Assumes that the virtual services that generated first and second are ordered by
 // time.
-func CombineVHostRoutes(first []*route.Route, second []*route.Route) []*route.Route {
-	allroutes := make([]*route.Route, 0, len(first)+len(second))
-	catchAllRoutes := make([]*route.Route, 0)
-
-	for _, f := range first {
-		if isCatchAllRoute(f) {
-			catchAllRoutes = append(catchAllRoutes, f)
-		} else {
-			allroutes = append(allroutes, f)
-		}
+func CombineVHostRoutes(routeSets ...[]*route.Route) []*route.Route {
+	l := 0
+	for _, r := range routeSets {
+		l += len(r)
 	}
 
-	for _, s := range second {
-		if isCatchAllRoute(s) {
-			catchAllRoutes = append(catchAllRoutes, s)
-		} else {
-			allroutes = append(allroutes, s)
+	allroutes := make([]*route.Route, 0, l)
+	catchAllRoutes := make([]*route.Route, 0)
+	for _, routes := range routeSets {
+		for _, r := range routes {
+			if isCatchAllRoute(r) {
+				catchAllRoutes = append(catchAllRoutes, r)
+			} else {
+				allroutes = append(allroutes, r)
+			}
 		}
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -1098,6 +1098,21 @@ func CombineVHostRoutes(first []*route.Route, second []*route.Route) []*route.Ro
 	return allroutes
 }
 
+// SortVHostRoutes moves catchAllRoutes to the end while retaining
+// the relative order of other routes.
+func SortVHostRoutes(routes []*route.Route) []*route.Route {
+	allroutes := make([]*route.Route, 0, len(routes))
+	catchAllRoutes := make([]*route.Route, 0)
+	for _, r := range routes {
+		if isCatchAllRoute(r) {
+			catchAllRoutes = append(catchAllRoutes, r)
+		} else {
+			allroutes = append(allroutes, r)
+		}
+	}
+	return append(allroutes, catchAllRoutes...)
+}
+
 // isCatchAllRoute returns true if an Envoy route is a catchall route otherwise false.
 func isCatchAllRoute(r *route.Route) bool {
 	catchall := false

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -1069,26 +1069,28 @@ func isCatchAllMatch(m *networking.HTTPMatchRequest) bool {
 	return catchall && len(m.Headers) == 0 && len(m.QueryParams) == 0
 }
 
-// CombineVHostRoutes semi concatenates sets of Vhost routes into a single route set.
+// CombineVHostRoutes semi concatenates two Vhost's routes into a single route set.
 // Moves the catch all routes alone to the end, while retaining
 // the relative order of other routes in the concatenated route.
 // Assumes that the virtual services that generated first and second are ordered by
 // time.
-func CombineVHostRoutes(routeSets ...[]*route.Route) []*route.Route {
-	l := 0
-	for _, r := range routeSets {
-		l += len(r)
+func CombineVHostRoutes(first []*route.Route, second []*route.Route) []*route.Route {
+	allroutes := make([]*route.Route, 0, len(first)+len(second))
+	catchAllRoutes := make([]*route.Route, 0)
+
+	for _, f := range first {
+		if isCatchAllRoute(f) {
+			catchAllRoutes = append(catchAllRoutes, f)
+		} else {
+			allroutes = append(allroutes, f)
+		}
 	}
 
-	allroutes := make([]*route.Route, 0, l)
-	catchAllRoutes := make([]*route.Route, 0)
-	for _, routes := range routeSets {
-		for _, r := range routes {
-			if isCatchAllRoute(r) {
-				catchAllRoutes = append(catchAllRoutes, r)
-			} else {
-				allroutes = append(allroutes, r)
-			}
+	for _, s := range second {
+		if isCatchAllRoute(s) {
+			catchAllRoutes = append(catchAllRoutes, s)
+		} else {
+			allroutes = append(allroutes, s)
 		}
 	}
 


### PR DESCRIPTION
Moves the expensive sorting part of the merge after all appends are complete. 
Goes from m*n to m+n for merging. 

<table class='benchstat '>
<tr class='configs'><th><th>master (7d9e726d4c)<th>548e4acba0<th>06047384a7</th>
<tbody>
<tr><th><th colspan='3' class='metric'>time/op
<tr>
    <td>RouteGeneration/gateways-12<td>38.0ms ± 1%<td>38.4ms ± 2%<td>40.1ms ± 1%
<tr>
    <td><b>RouteGeneration/gateways-shared-12</b><td><b style="color: red">364ms ± 7%</b><td><b>173ms ± 2%</b><td><b>177ms ± 1%</b>
<tr>
    <td>RouteGeneration/empty-12<td>676µs ± 2%<td>680µs ± 2%<td>679µs ± 1%
<tr>
    <td>RouteGeneration/telemetry-12<td>686µs ± 1%<td>691µs ± 1%<td>695µs ± 2%
<tr>
    <td>RouteGeneration/virtualservice-12<td>1.57ms ± 2%<td>1.55ms ± 1%<td>1.55ms ± 1%
</tbody>
</table>

### 3 -> 12 hosts

**master vs new (with 12)**
```
name                                old time/op        new time/op        delta
RouteGeneration/gateways-shared-12         1.93s ±13%         0.60s ± 3%  -68.88%  (p=0.008 n=5+5)
```

**master with 3 vs 12**
```
RouteGeneration/gateways-shared-12         364ms ± 7%        1930ms ±13%  +429.87%  (p=0.008 n=5+5)
```

**new with 3 vs 12 **
```
RouteGeneration/gateways-shared-12         173ms ± 2%         601ms ± 3%  +247.63%  (p=0.008 n=5+5)
```

### 1000 -> 2000 Services
**master with 1000 vs 2000**
```
RouteGeneration/gateways-shared-12         372ms ± 2%        1240ms ±17%  +233.60%  (p=0.008 n=5+5)
```

**new with 1000 vs 2000**
```
RouteGeneration/gateways-shared-12         178ms ± 3%         360ms ± 2%  +102.25%  (p=0.008 n=5+5)
```

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[] Networking
[X] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
