### PR TITLE
Partial revert of Drop excessive RBAC permissions (#25121)

### DIFF
--- a/manifests/charts/base/files/gen-istio-cluster.yaml
+++ b/manifests/charts/base/files/gen-istio-cluster.yaml
@@ -4658,6 +4658,11 @@ rules:
   - apiGroups: ["networking.x-k8s.io"]
     resources: ["*"]
     verbs: ["get", "watch", "list"]
+
+  # Needed for multicluster secret reading, possibly ingress certs in the future
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "watch", "list"]
 ---
 # Source: base/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -4731,11 +4736,6 @@ rules:
 - apiGroups: ["networking.istio.io"]
   verbs: ["create"]
   resources: ["gateways"]
-
-# Needed for multicluster secret reading
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get", "watch", "list"]
 
 # For storing CA secret
 - apiGroups: [""]

--- a/manifests/charts/base/templates/clusterrole.yaml
+++ b/manifests/charts/base/templates/clusterrole.yaml
@@ -13,11 +13,6 @@ rules:
   verbs: ["create"]
   resources: ["gateways"]
 
-# Needed for multicluster secret reading
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get", "watch", "list"]
-
 # For storing CA secret
 - apiGroups: [""]
   resources: ["secrets"]
@@ -110,6 +105,12 @@ rules:
   - apiGroups: ["networking.x-k8s.io"]
     resources: ["*"]
     verbs: ["get", "watch", "list"]
+
+  # Needed for multicluster secret reading, possibly ingress certs in the future
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "watch", "list"]
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
The initial PR was likely over-ambitious and removed some use cases for cross namespace secret reading such as https://github.com/istio/istio/issues/24667 and possibly multicluster secrets