### PR TITLE
always put sidecars to front of containers list in pods

### DIFF
--- a/istioctl/cmd/testdata/deployment/hello.yaml.injected
+++ b/istioctl/cmd/testdata/deployment/hello.yaml.injected
@@ -24,14 +24,14 @@ spec:
         track: stable
     spec:
       containers:
+      - image: docker.io/istio/proxy_debug:unittest
+        name: istio-proxy
+        resources: {}
       - image: fake.docker.io/google-samples/hello-go-gke:1.0
         name: hello
         ports:
         - containerPort: 80
           name: http
-        resources: {}
-      - image: docker.io/istio/proxy_debug:unittest
-        name: istio-proxy
         resources: {}
       initContainers:
       - image: docker.io/istio/proxy_init:unittest-test

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -29,35 +29,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        livenessProbe:
-          httpGet:
-            path: /app-health/hello/livez
-            port: 15020
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        readinessProbe:
-          httpGet:
-            path: /app-health/hello/readyz
-            port: 15020
-        resources: {}
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        livenessProbe:
-          httpGet:
-            path: /app-health/world/livez
-            port: 15020
-        name: world
-        ports:
-        - containerPort: 90
-          name: http
-        readinessProbe:
-          exec:
-            command:
-            - cat
-            - /tmp/healthy
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -176,6 +147,35 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        livenessProbe:
+          httpGet:
+            path: /app-health/hello/livez
+            port: 15020
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /app-health/hello/readyz
+            port: 15020
+        resources: {}
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        livenessProbe:
+          httpGet:
+            path: /app-health/world/livez
+            port: 15020
+        name: world
+        ports:
+        - containerPort: 90
+          name: http
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/healthy
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -29,32 +29,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        livenessProbe:
-          httpGet:
-            port: http
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        readinessProbe:
-          httpGet:
-            port: 3333
-        resources: {}
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        livenessProbe:
-          httpGet:
-            port: http
-        name: world
-        ports:
-        - containerPort: 90
-          name: http
-        readinessProbe:
-          exec:
-            command:
-            - cat
-            - /tmp/healthy
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -171,6 +145,32 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        livenessProbe:
+          httpGet:
+            port: http
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        readinessProbe:
+          httpGet:
+            port: 3333
+        resources: {}
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        livenessProbe:
+          httpGet:
+            port: http
+        name: world
+        ports:
+        - containerPort: 90
+          name: http
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/healthy
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
@@ -28,35 +28,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        livenessProbe:
-          httpGet:
-            path: /app-health/hello/livez
-            port: 15020
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        readinessProbe:
-          httpGet:
-            path: /app-health/hello/readyz
-            port: 15020
-        resources: {}
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        livenessProbe:
-          httpGet:
-            path: /app-health/world/livez
-            port: 15020
-        name: world
-        ports:
-        - containerPort: 90
-          name: http
-        readinessProbe:
-          exec:
-            command:
-            - cat
-            - /tmp/healthy
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -172,6 +143,35 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        livenessProbe:
+          httpGet:
+            path: /app-health/hello/livez
+            port: 15020
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /app-health/hello/readyz
+            port: 15020
+        resources: {}
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        livenessProbe:
+          httpGet:
+            path: /app-health/world/livez
+            port: 15020
+        name: world
+        ports:
+        - containerPort: 90
+          name: http
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/healthy
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
@@ -28,16 +28,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        readinessProbe:
-          httpGet:
-            path: /app-health/hello/readyz
-            port: 15020
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -151,6 +141,16 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /app-health/hello/readyz
+            port: 15020
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
@@ -28,36 +28,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        livenessProbe:
-          httpGet:
-            path: /app-health/hello/livez
-            port: 15020
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        readinessProbe:
-          httpGet:
-            path: /app-health/hello/readyz
-            port: 15020
-            scheme: HTTP
-        resources: {}
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        livenessProbe:
-          httpGet:
-            path: /app-health/world/livez
-            port: 15020
-        name: world
-        ports:
-        - containerPort: 90
-          name: http
-        readinessProbe:
-          exec:
-            command:
-            - cat
-            - /tmp/healthy
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -173,6 +143,36 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        livenessProbe:
+          httpGet:
+            path: /app-health/hello/livez
+            port: 15020
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /app-health/hello/readyz
+            port: 15020
+            scheme: HTTP
+        resources: {}
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        livenessProbe:
+          httpGet:
+            path: /app-health/world/livez
+            port: 15020
+        name: world
+        ports:
+        - containerPort: 90
+          name: http
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/healthy
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
@@ -28,16 +28,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        readinessProbe:
-          httpGet:
-            path: /app-health/hello/readyz
-            port: 15020
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -151,6 +141,16 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /app-health/hello/readyz
+            port: 15020
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
@@ -28,20 +28,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        livenessProbe:
-          httpGet:
-            path: /app-health/hello/livez
-            port: 15020
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        readinessProbe:
-          httpGet:
-            path: /app-health/hello/readyz
-            port: 15020
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -155,6 +141,20 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        livenessProbe:
+          httpGet:
+            path: /app-health/hello/livez
+            port: 15020
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /app-health/hello/readyz
+            port: 15020
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
@@ -28,35 +28,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        livenessProbe:
-          httpGet:
-            path: /app-health/hello/livez
-            port: 15020
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        readinessProbe:
-          httpGet:
-            path: /app-health/hello/readyz
-            port: 15020
-        resources: {}
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        livenessProbe:
-          httpGet:
-            path: /app-health/world/livez
-            port: 15020
-        name: world
-        ports:
-        - containerPort: 90
-          name: http
-        readinessProbe:
-          exec:
-            command:
-            - cat
-            - /tmp/healthy
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -172,6 +143,35 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        livenessProbe:
+          httpGet:
+            path: /app-health/hello/livez
+            port: 15020
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /app-health/hello/readyz
+            port: 15020
+        resources: {}
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        livenessProbe:
+          httpGet:
+            path: /app-health/world/livez
+            port: 15020
+        name: world
+        ports:
+        - containerPort: 90
+          name: http
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/healthy
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
@@ -28,16 +28,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        readinessProbe:
-          httpGet:
-            path: /app-health/hello/readyz
-            port: 15020
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -151,6 +141,16 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /app-health/hello/readyz
+            port: 15020
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/app_probe/startup_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/startup_live.yaml.injected
@@ -28,35 +28,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        livenessProbe:
-          httpGet:
-            path: /app-health/hello/livez
-            port: 15020
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
-        startupProbe:
-          httpGet:
-            path: /app-health/hello/startupz
-            port: 15020
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        livenessProbe:
-          httpGet:
-            path: /app-health/world/livez
-            port: 15020
-        name: world
-        ports:
-        - containerPort: 90
-          name: http
-        resources: {}
-        startupProbe:
-          exec:
-            command:
-            - cat
-            - /tmp/healthy
       - args:
         - proxy
         - sidecar
@@ -172,6 +143,35 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        livenessProbe:
+          httpGet:
+            path: /app-health/hello/livez
+            port: 15020
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
+        startupProbe:
+          httpGet:
+            path: /app-health/hello/startupz
+            port: 15020
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        livenessProbe:
+          httpGet:
+            path: /app-health/world/livez
+            port: 15020
+        name: world
+        ports:
+        - containerPort: 90
+          name: http
+        resources: {}
+        startupProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/healthy
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/app_probe/startup_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/startup_only.yaml.injected
@@ -28,16 +28,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
-        startupProbe:
-          httpGet:
-            path: /app-health/hello/startupz
-            port: 15020
       - args:
         - proxy
         - sidecar
@@ -151,6 +141,16 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
+        startupProbe:
+          httpGet:
+            path: /app-health/hello/startupz
+            port: 15020
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/app_probe/startup_ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/startup_ready_live.yaml.injected
@@ -28,43 +28,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        livenessProbe:
-          httpGet:
-            path: /app-health/hello/livez
-            port: 15020
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        readinessProbe:
-          httpGet:
-            path: /app-health/hello/readyz
-            port: 15020
-        resources: {}
-        startupProbe:
-          httpGet:
-            path: /app-health/hello/startupz
-            port: 15020
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        livenessProbe:
-          httpGet:
-            path: /app-health/world/livez
-            port: 15020
-        name: world
-        ports:
-        - containerPort: 90
-          name: http
-        readinessProbe:
-          exec:
-            command:
-            - cat
-            - /tmp/healthy
-        resources: {}
-        startupProbe:
-          httpGet:
-            path: /app-health/world/startupz
-            port: 15020
       - args:
         - proxy
         - sidecar
@@ -180,6 +143,43 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        livenessProbe:
+          httpGet:
+            path: /app-health/hello/livez
+            port: 15020
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /app-health/hello/readyz
+            port: 15020
+        resources: {}
+        startupProbe:
+          httpGet:
+            path: /app-health/hello/startupz
+            port: 15020
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        livenessProbe:
+          httpGet:
+            path: /app-health/world/livez
+            port: 15020
+        name: world
+        ports:
+        - containerPort: 90
+          name: http
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/healthy
+        resources: {}
+        startupProbe:
+          httpGet:
+            path: /app-health/world/startupz
+            port: 15020
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
@@ -28,26 +28,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        readinessProbe:
-          httpGet:
-            path: /app-health/hello/readyz
-            port: 15020
-        resources: {}
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: world
-        ports:
-        - containerPort: 90
-          name: http
-        readinessProbe:
-          httpGet:
-            path: /app-health/world/readyz
-            port: 15020
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -163,6 +143,26 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /app-health/hello/readyz
+            port: 15020
+        resources: {}
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: world
+        ports:
+        - containerPort: 90
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /app-health/world/readyz
+            port: 15020
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
@@ -28,12 +28,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -147,6 +141,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -28,12 +28,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -147,6 +141,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -28,12 +28,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -147,6 +141,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -22,13 +22,6 @@ spec:
         spec:
           containers:
           - args:
-            - /bin/sh
-            - -c
-            - date; echo Hello from the Kubernetes cluster
-            image: busybox
-            name: hello
-            resources: {}
-          - args:
             - proxy
             - sidecar
             - --domain
@@ -140,6 +133,13 @@ spec:
               name: istio-token
             - mountPath: /etc/istio/pod
               name: istio-podinfo
+          - args:
+            - /bin/sh
+            - -c
+            - date; echo Hello from the Kubernetes cluster
+            image: busybox
+            name: hello
+            resources: {}
           initContainers:
           - args:
             - istio-iptables

--- a/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -26,12 +26,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -145,6 +139,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -41,12 +41,6 @@ items:
           track: stable
       spec:
         containers:
-        - image: fake.docker.io/google-samples/hello-go-gke:1.0
-          name: hello
-          ports:
-          - containerPort: 80
-            name: http
-          resources: {}
         - args:
           - proxy
           - sidecar
@@ -160,6 +154,12 @@ items:
             name: istio-token
           - mountPath: /etc/istio/pod
             name: istio-podinfo
+        - image: fake.docker.io/google-samples/hello-go-gke:1.0
+          name: hello
+          ports:
+          - containerPort: 80
+            name: http
+          resources: {}
         initContainers:
         - args:
           - istio-iptables

--- a/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -26,12 +26,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -145,6 +139,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
@@ -29,12 +29,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -151,6 +145,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -28,12 +28,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -147,6 +141,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -28,12 +28,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -147,6 +141,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -41,16 +41,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-frontend:1.0
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /usr/sbin/nginx
-              - -s
-              - quit
-        name: nginx
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -163,6 +153,16 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-frontend:1.0
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /usr/sbin/nginx
+              - -s
+              - quit
+        name: nginx
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -28,12 +28,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -147,6 +141,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/hello-cncf-networks.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-cncf-networks.yaml.injected
@@ -29,12 +29,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -148,6 +142,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
@@ -28,12 +28,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -147,6 +141,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks.yaml.injected
@@ -29,12 +29,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -151,6 +145,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
@@ -29,12 +29,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -151,6 +145,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/hello-image-secrets-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-image-secrets-in-values.yaml.injected
@@ -28,12 +28,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -147,6 +141,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       imagePullSecrets:
       - name: barSecret
       initContainers:

--- a/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
@@ -28,12 +28,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -150,6 +144,12 @@ spec:
           readOnly: true
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
@@ -28,12 +28,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -147,6 +141,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -30,12 +30,6 @@ spec:
         version: v1
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -149,6 +143,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables
@@ -254,12 +254,6 @@ spec:
         version: v2
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 81
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -373,6 +367,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 81
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/hello-multiple-image-secrets.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multiple-image-secrets.yaml.injected
@@ -28,12 +28,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -147,6 +141,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       imagePullSecrets:
       - name: fooSecret
       - name: barSecret

--- a/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -29,12 +29,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -148,6 +142,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -28,12 +28,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -147,6 +141,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -29,12 +29,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -151,6 +145,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
@@ -28,12 +28,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -147,6 +141,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       dnsConfig:
         searches:
         - global

--- a/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -28,12 +28,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -149,6 +143,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
@@ -28,12 +28,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -147,6 +141,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -28,12 +28,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -147,6 +141,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -18,14 +18,6 @@ spec:
       name: pi
     spec:
       containers:
-      - command:
-        - perl
-        - -Mbignum=bpi
-        - -wle
-        - print bpi(2000)
-        image: perl
-        name: pi
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -138,6 +130,14 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - command:
+        - perl
+        - -Mbignum=bpi
+        - -wle
+        - print bpi(2000)
+        image: perl
+        name: pi
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -29,12 +29,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -151,6 +145,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -29,12 +29,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -151,6 +145,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -42,16 +42,6 @@ items:
           track: stable
       spec:
         containers:
-        - image: fake.docker.io/google-samples/hello-frontend:1.0
-          lifecycle:
-            preStop:
-              exec:
-                command:
-                - /usr/sbin/nginx
-                - -s
-                - quit
-          name: nginx
-          resources: {}
         - args:
           - proxy
           - sidecar
@@ -164,6 +154,16 @@ items:
             name: istio-token
           - mountPath: /etc/istio/pod
             name: istio-podinfo
+        - image: fake.docker.io/google-samples/hello-frontend:1.0
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /usr/sbin/nginx
+                - -s
+                - quit
+          name: nginx
+          resources: {}
         initContainers:
         - args:
           - istio-iptables

--- a/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -32,12 +32,6 @@ items:
           version: v1
       spec:
         containers:
-        - image: fake.docker.io/google-samples/hello-go-gke:1.0
-          name: hello
-          ports:
-          - containerPort: 80
-            name: http
-          resources: {}
         - args:
           - proxy
           - sidecar
@@ -151,6 +145,12 @@ items:
             name: istio-token
           - mountPath: /etc/istio/pod
             name: istio-podinfo
+        - image: fake.docker.io/google-samples/hello-go-gke:1.0
+          name: hello
+          ports:
+          - containerPort: 80
+            name: http
+          resources: {}
         initContainers:
         - args:
           - istio-iptables
@@ -255,12 +255,6 @@ items:
           version: v2
       spec:
         containers:
-        - image: fake.docker.io/google-samples/hello-go-gke:1.0
-          name: hello
-          ports:
-          - containerPort: 81
-            name: http
-          resources: {}
         - args:
           - proxy
           - sidecar
@@ -374,6 +368,12 @@ items:
             name: istio-token
           - mountPath: /etc/istio/pod
             name: istio-podinfo
+        - image: fake.docker.io/google-samples/hello-go-gke:1.0
+          name: hello
+          ports:
+          - containerPort: 81
+            name: http
+          resources: {}
         initContainers:
         - args:
           - istio-iptables

--- a/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
@@ -24,18 +24,6 @@ spec:
         security.istio.io/tlsMode: istio
     spec:
       containers:
-      - image: image
-        name: name1
-        resources: {}
-      - image: alpine
-        name: name2
-        ports:
-        - containerPort: 123
-          name: foo
-        resources: {}
-      - image: alpine
-        name: name3
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -151,6 +139,18 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: image
+        name: name1
+        resources: {}
+      - image: alpine
+        name: name2
+        ports:
+        - containerPort: 123
+          name: foo
+        resources: {}
+      - image: alpine
+        name: name3
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -28,12 +28,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -147,6 +141,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - command:
         - sh

--- a/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -14,12 +14,6 @@ metadata:
   name: hellopod
 spec:
   containers:
-  - image: fake.docker.io/google-samples/hello-go-gke:1.0
-    name: hello
-    ports:
-    - containerPort: 80
-      name: http
-    resources: {}
   - args:
     - proxy
     - sidecar
@@ -133,6 +127,12 @@ spec:
       name: istio-token
     - mountPath: /etc/istio/pod
       name: istio-podinfo
+  - image: fake.docker.io/google-samples/hello-go-gke:1.0
+    name: hello
+    ports:
+    - containerPort: 80
+      name: http
+    resources: {}
   initContainers:
   - args:
     - istio-iptables

--- a/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -23,12 +23,6 @@ spec:
         security.istio.io/tlsMode: istio
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -142,6 +136,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -23,11 +23,6 @@ spec:
       name: nginx
     spec:
       containers:
-      - image: nginx
-        name: nginx
-        ports:
-        - containerPort: 80
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -141,6 +136,11 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: nginx
+        name: nginx
+        ports:
+        - containerPort: 80
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -28,15 +28,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
-        volumeMounts:
-        - mountPath: /var/lib/data
-          name: data
       - args:
         - proxy
         - sidecar
@@ -150,6 +141,15 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
+        volumeMounts:
+        - mountPath: /var/lib/data
+          name: data
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -29,12 +29,6 @@ spec:
         security.istio.io/tlsMode: istio
     spec:
       containers:
-      - image: fake.docker.io/google-samples/traffic-go-gke:1.0
-        name: status
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -151,6 +145,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/traffic-go-gke:1.0
+        name: status
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/status_annotations_zeroport.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations_zeroport.yaml.injected
@@ -28,12 +28,6 @@ spec:
         security.istio.io/tlsMode: istio
     spec:
       containers:
-      - image: fake.docker.io/google-samples/traffic-go-gke:1.0
-        name: status
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -143,6 +137,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/traffic-go-gke:1.0
+        name: status
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -24,12 +24,6 @@ spec:
         security.istio.io/tlsMode: istio
     spec:
       containers:
-      - image: fake.docker.io/google-samples/traffic-go-gke:1.0
-        name: status
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -143,6 +137,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/traffic-go-gke:1.0
+        name: status
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -25,12 +25,6 @@ spec:
         security.istio.io/tlsMode: istio
     spec:
       containers:
-      - image: fake.docker.io/google-samples/traffic-go-gke:1.0
-        name: traffic
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -147,6 +141,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/traffic-go-gke:1.0
+        name: traffic
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -25,12 +25,6 @@ spec:
         security.istio.io/tlsMode: istio
     spec:
       containers:
-      - image: fake.docker.io/google-samples/traffic-go-gke:1.0
-        name: traffic
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -147,6 +141,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/traffic-go-gke:1.0
+        name: traffic
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -32,12 +32,6 @@ spec:
         security.istio.io/tlsMode: istio
     spec:
       containers:
-      - image: fake.docker.io/google-samples/traffic-go-gke:1.0
-        name: traffic
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -151,6 +145,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/traffic-go-gke:1.0
+        name: traffic
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -24,12 +24,6 @@ spec:
         security.istio.io/tlsMode: istio
     spec:
       containers:
-      - image: fake.docker.io/google-samples/traffic-go-gke:1.0
-        name: traffic
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -143,6 +137,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/traffic-go-gke:1.0
+        name: traffic
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -25,12 +25,6 @@ spec:
         security.istio.io/tlsMode: istio
     spec:
       containers:
-      - image: fake.docker.io/google-samples/traffic-go-gke:1.0
-        name: traffic
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -137,6 +131,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/traffic-go-gke:1.0
+        name: traffic
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject.patch
@@ -10,7 +10,7 @@
   },
   {
     "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/spec/containers/0",
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_nosidecar_rewrite.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_nosidecar_rewrite.patch
@@ -14,7 +14,7 @@
   },
   {
     "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/spec/containers/0",
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite.patch
@@ -18,7 +18,7 @@
   },
   {
     "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/spec/containers/0",
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_disabled_via_annotation.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_disabled_via_annotation.patch
@@ -10,7 +10,7 @@
   },
   {
     "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/spec/containers/0",
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_enabled_via_annotation.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_enabled_via_annotation.patch
@@ -18,7 +18,7 @@
   },
   {
     "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/spec/containers/0",
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_https_probe_rewrite.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_https_probe_rewrite.patch
@@ -18,7 +18,7 @@
   },
   {
     "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/spec/containers/0",
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_injectorAnnotations.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_injectorAnnotations.patch
@@ -10,7 +10,7 @@
   },
   {
     "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/spec/containers/0",
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_mtls_not_ready.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_mtls_not_ready.patch
@@ -10,7 +10,7 @@
   },
   {
     "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/spec/containers/0",
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_imagePullSecrets.patch
@@ -10,7 +10,7 @@
   },
   {
     "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/spec/containers/0",
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers.patch
@@ -12,7 +12,7 @@
   },
   {
     "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/spec/containers/0",
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_imagePullSecrets.patch
@@ -12,7 +12,7 @@
   },
   {
     "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/spec/containers/0",
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes.patch
@@ -12,7 +12,7 @@
   },
   {
     "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/spec/containers/0",
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes_imagePullSecrets.patch
@@ -12,7 +12,7 @@
   },
   {
     "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/spec/containers/0",
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes.patch
@@ -10,7 +10,7 @@
   },
   {
     "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/spec/containers/0",
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes_imagePullSecrets.patch
@@ -10,7 +10,7 @@
   },
   {
     "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/spec/containers/0",
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_probe_rewrite_timeout_retention.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_probe_rewrite_timeout_retention.patch
@@ -18,7 +18,7 @@
   },
   {
     "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/spec/containers/0",
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace.patch
@@ -22,7 +22,7 @@
   },
   {
     "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/spec/containers/0",
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace_backwards_compat.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace_backwards_compat.patch
@@ -26,7 +26,7 @@
   },
   {
     "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/spec/containers/0",
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_validationOrder.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_validationOrder.patch
@@ -19,7 +19,7 @@
   },
   {
     "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/spec/containers/0",
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",

--- a/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
@@ -28,12 +28,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -142,6 +136,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
@@ -27,12 +27,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -141,6 +135,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig-with-canonical-service-label.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig-with-canonical-service-label.yaml.injected
@@ -27,12 +27,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -141,6 +135,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
@@ -27,12 +27,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -141,6 +135,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
@@ -29,16 +29,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-frontend:1.0
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /usr/sbin/nginx
-              - -s
-              - quit
-        name: nginx
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -146,6 +136,16 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-frontend:1.0
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /usr/sbin/nginx
+              - -s
+              - quit
+        name: nginx
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
@@ -29,12 +29,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -143,6 +137,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/webhook/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-mtls-not-ready.yaml.injected
@@ -29,12 +29,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -143,6 +137,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
@@ -31,12 +31,6 @@ spec:
         version: v1
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -145,6 +139,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables
@@ -250,12 +250,6 @@ spec:
         version: v2
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 81
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -364,6 +358,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 81
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
@@ -29,35 +29,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        livenessProbe:
-          httpGet:
-            path: /app-health/hello/livez
-            port: 15020
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        readinessProbe:
-          httpGet:
-            path: /app-health/hello/readyz
-            port: 15020
-        resources: {}
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        livenessProbe:
-          httpGet:
-            path: /app-health/world/livez
-            port: 15020
-        name: world
-        ports:
-        - containerPort: 90
-          name: http
-        readinessProbe:
-          exec:
-            command:
-            - cat
-            - /tmp/healthy
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -128,18 +99,19 @@ spec:
           value: '{"/app-health/hello/livez":{"httpGet":{"port":80}},"/app-health/hello/readyz":{"httpGet":{"port":3333}},"/app-health/world/livez":{"httpGet":{"port":90}}}'
         image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /app-health/hello/livez
+            port: 15020
         name: istio-proxy
         ports:
         - containerPort: 15090
           name: http-envoy-prom
           protocol: TCP
         readinessProbe:
-          failureThreshold: 30
           httpGet:
-            path: /healthz/ready
-            port: 15021
-          initialDelaySeconds: 1
-          periodSeconds: 2
+            path: /app-health/hello/readyz
+            port: 15020
         resources:
           limits:
             cpu: "2"
@@ -168,6 +140,33 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        livenessProbe:
+          httpGet:
+            path: /app-health/world/livez
+            port: 15020
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        readinessProbe:
+          httpGet:
+            port: 3333
+        resources: {}
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        livenessProbe:
+          httpGet:
+            port: http
+        name: world
+        ports:
+        - containerPort: 90
+          name: http
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/healthy
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/webhook/job.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/job.yaml.injected
@@ -22,14 +22,6 @@ spec:
       name: pi
     spec:
       containers:
-      - command:
-        - perl
-        - -Mbignum=bpi
-        - -wle
-        - print bpi(2000)
-        image: perl
-        name: pi
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -141,6 +133,14 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - command:
+        - perl
+        - -Mbignum=bpi
+        - -wle
+        - print bpi(2000)
+        image: perl
+        name: pi
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
@@ -29,16 +29,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-frontend:1.0
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /usr/sbin/nginx
-              - -s
-              - quit
-        name: nginx
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -146,6 +136,16 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-frontend:1.0
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /usr/sbin/nginx
+              - -s
+              - quit
+        name: nginx
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/webhook/list.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/list.yaml.injected
@@ -31,12 +31,6 @@ spec:
         version: v1
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -145,6 +139,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables
@@ -250,12 +250,6 @@ spec:
         version: v2
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 81
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -364,6 +358,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 81
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
@@ -25,12 +25,6 @@ spec:
         service.istio.io/canonical-revision: latest
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -139,6 +133,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
@@ -24,11 +24,6 @@ spec:
       name: nginx
     spec:
       containers:
-      - image: nginx
-        name: nginx
-        ports:
-        - containerPort: 80
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -141,6 +136,11 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: nginx
+        name: nginx
+        ports:
+        - containerPort: 80
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
@@ -29,12 +29,6 @@ spec:
         service.istio.io/canonical-revision: latest
     spec:
       containers:
-      - image: fake.docker.io/google-samples/traffic-go-gke:1.0
-        name: resource
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -143,6 +137,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/traffic-go-gke:1.0
+        name: resource
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
@@ -29,15 +29,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: hello
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
-        volumeMounts:
-        - mountPath: /var/lib/data
-          name: data
       - args:
         - proxy
         - sidecar
@@ -146,6 +137,15 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
+        volumeMounts:
+        - mountPath: /var/lib/data
+          name: data
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
@@ -30,12 +30,6 @@ spec:
         service.istio.io/canonical-revision: latest
     spec:
       containers:
-      - image: fake.docker.io/google-samples/traffic-go-gke:1.0
-        name: status
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -144,6 +138,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/traffic-go-gke:1.0
+        name: status
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
@@ -29,12 +29,6 @@ spec:
         service.istio.io/canonical-revision: latest
     spec:
       containers:
-      - image: fake.docker.io/google-samples/traffic-go-gke:1.0
-        name: traffic
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -143,6 +137,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/traffic-go-gke:1.0
+        name: traffic
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
@@ -29,12 +29,6 @@ spec:
         service.istio.io/canonical-revision: latest
     spec:
       containers:
-      - image: fake.docker.io/google-samples/traffic-go-gke:1.0
-        name: traffic
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -143,6 +137,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/traffic-go-gke:1.0
+        name: traffic
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
@@ -30,12 +30,6 @@ spec:
         service.istio.io/canonical-revision: latest
     spec:
       containers:
-      - image: fake.docker.io/google-samples/traffic-go-gke:1.0
-        name: traffic
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -144,6 +138,12 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
+      - image: fake.docker.io/google-samples/traffic-go-gke:1.0
+        name: traffic
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
@@ -31,12 +31,6 @@ spec:
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-go-gke:1.0
-        name: user-volume
-        ports:
-        - containerPort: 80
-          name: http
-        resources: {}
       - args:
         - proxy
         - sidecar
@@ -150,6 +144,12 @@ spec:
           readOnly: true
         - mountPath: /mnt/volume-2
           name: user-volume-2
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: user-volume
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -340,7 +340,7 @@ func addContainer(target, added []corev1.Container, basePath string) (patch []rf
 		if first {
 			first = false
 			value = []corev1.Container{add}
-		} else if add.Name == "istio-validation" {
+		} else if shouldBeInjectedInFront(add) {
 			path += "/0"
 		} else {
 			path += "/-"
@@ -352,6 +352,17 @@ func addContainer(target, added []corev1.Container, basePath string) (patch []rf
 		})
 	}
 	return patch
+}
+
+func shouldBeInjectedInFront(container corev1.Container) bool {
+	switch container.Name {
+	case ValidationContainerName:
+		return true
+	case ProxyContainerName:
+		return true
+	default:
+		return false
+	}
 }
 
 func addSecurityContext(target *corev1.PodSecurityContext, basePath string) (patch []rfc6902PatchOperation) {

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -1226,7 +1226,7 @@ func TestRunAndServe(t *testing.T) {
    },
    {
       "op":"add",
-      "path":"/spec/containers/-",
+      "path":"/spec/containers/0",
       "value":{
          "name":"istio-proxy",
          "resources":{


### PR DESCRIPTION
It is known that Kubelet performs the startup of containers of a Pod in the order that they are provided. Putting sidecars to the front of the list is a default that is safe enough. 

This is based on @luksa's PR #24737 


[X] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure