### PR TITLE
Expose more of istioctl as library

### DIFF
--- a/operator/cmd/mesh/manifest-generate.go
+++ b/operator/cmd/mesh/manifest-generate.go
@@ -127,9 +127,9 @@ func manifestGenerate(args *rootArgs, mgArgs *manifestGenerateArgs, logopts *log
 // representation of path-values passed through the --set flag.
 // If force is set, validation errors will not cause processing to abort but will result in warnings going to the
 // supplied logger.
-func GenManifests(inFilename []string, setFlags []string, force bool,
+func GenManifests(inFilename []string, setOverlay []string, force bool,
 	kubeConfig *rest.Config, l clog.Logger) (name.ManifestMap, *v1alpha1.IstioOperatorSpec, error) {
-	mergedYAML, _, err := GenerateConfig(inFilename, setFlags, force, kubeConfig, l)
+	mergedYAML, _, err := GenerateConfig(inFilename, setOverlay, force, kubeConfig, l)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/operator/cmd/mesh/profile-common.go
+++ b/operator/cmd/mesh/profile-common.go
@@ -47,18 +47,18 @@ import (
 // Otherwise it will be the compiled in profile YAMLs.
 // In step 3, the remaining fields in the same user overlay are applied on the resulting profile base.
 // The force flag causes validation errors not to abort but only emit log/console warnings.
-func GenerateConfig(inFilenames []string, setFlags []string, force bool, kubeConfig *rest.Config,
+func GenerateConfig(inFilenames, setOverlay []string, force bool, kubeConfig *rest.Config,
 	l clog.Logger) (string, *v1alpha1.IstioOperatorSpec, error) {
-	if err := validateSetFlags(setFlags); err != nil {
+	if err := validateSetFlags(setOverlay); err != nil {
 		return "", nil, err
 	}
 
-	fy, profile, err := readYamlProfile(inFilenames, setFlags, force, l)
+	fy, profile, err := readYamlProfile(inFilenames, setOverlay, force, l)
 	if err != nil {
 		return "", nil, err
 	}
 
-	iopsString, iops, err := genIOPSFromProfile(profile, fy, setFlags, force, kubeConfig, l)
+	iopsString, iops, err := genIOPSFromProfile(profile, fy, setOverlay, force, kubeConfig, l)
 	if err != nil {
 		return "", nil, err
 	}

--- a/operator/cmd/mesh/shared.go
+++ b/operator/cmd/mesh/shared.go
@@ -28,12 +28,11 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"istio.io/pkg/log"
 
 	"istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/cache"
@@ -41,7 +40,7 @@ import (
 	"istio.io/istio/operator/pkg/name"
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/operator/pkg/util/clog"
-	"istio.io/pkg/log"
+	"istio.io/istio/pkg/kube"
 )
 
 var (
@@ -101,7 +100,7 @@ func readLayeredYAMLs(filenames []string, stdinReader io.Reader) (string, error)
 
 // confirm waits for a user to confirm with the supplied message.
 func confirm(msg string, writer io.Writer) bool {
-	fmt.Fprintf(writer, "%s ", msg)
+	_, _ = fmt.Fprintf(writer, "%s ", msg)
 
 	var response string
 	_, err := fmt.Scanln(&response)
@@ -116,77 +115,15 @@ func confirm(msg string, writer io.Writer) bool {
 	return false
 }
 
-// K8sConfig creates a rest.Config, Clientset and controller runtime Client from the given kubeconfig path and context.
-func K8sConfig(kubeConfigPath string, context string) (*rest.Config, *kubernetes.Clientset, client.Client, error) {
-	restConfig, clientset, err := InitK8SRestClient(kubeConfigPath, context)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	// We are running a one-off command locally, so we don't need to worry too much about rate limitting
-	// Bumping this up greatly decreases install time
-	restConfig.QPS = 50
-	restConfig.Burst = 100
-	client, err := client.New(restConfig, client.Options{Scheme: scheme.Scheme})
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	return restConfig, clientset, client, nil
-}
-
-// InitK8SRestClient creates a rest.Config qne Clientset from the given kubeconfig path and context.
-func InitK8SRestClient(kubeconfig, kubeContext string) (*rest.Config, *kubernetes.Clientset, error) {
-	restConfig, err := defaultRestConfig(kubeconfig, kubeContext)
-	if err != nil {
-		return nil, nil, err
-	}
-	clientset, err := kubernetes.NewForConfig(restConfig)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return restConfig, clientset, nil
-}
-
-func defaultRestConfig(kubeconfig, kubeContext string) (*rest.Config, error) {
-	config, err := BuildClientConfig(kubeconfig, kubeContext)
+func k8sClient(kubeConfigPath string, context string) (kube.Client, error) {
+	restCfg, err := kube.DefaultRestConfig(kubeConfigPath, context, func(config *rest.Config) {
+		config.QPS = 50
+		config.Burst = 100
+	})
 	if err != nil {
 		return nil, err
 	}
-	config.APIPath = "/api"
-	config.GroupVersion = &v1.SchemeGroupVersion
-	config.NegotiatedSerializer = serializer.WithoutConversionCodecFactory{CodecFactory: scheme.Codecs}
-	return config, nil
-}
-
-// BuildClientConfig is a helper function that builds client config from a kubeconfig filepath.
-// It overrides the current context with the one provided (empty to use default).
-//
-// This is a modified version of k8s.io/client-go/tools/clientcmd/BuildConfigFromFlags with the
-// difference that it loads default configs if not running in-cluster.
-func BuildClientConfig(kubeconfig, context string) (*rest.Config, error) {
-	if kubeconfig != "" {
-		info, err := os.Stat(kubeconfig)
-		if err != nil || info.Size() == 0 {
-			// If the specified kubeconfig doesn't exists / empty file / any other error
-			// from file stat, fall back to default
-			kubeconfig = ""
-		}
-	}
-
-	//Config loading rules:
-	// 1. kubeconfig if it not empty string
-	// 2. In cluster config if running in-cluster
-	// 3. Config(s) in KUBECONFIG environment variable
-	// 4. Use $HOME/.kube/config
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
-	loadingRules.ExplicitPath = kubeconfig
-	configOverrides := &clientcmd.ConfigOverrides{
-		ClusterDefaults: clientcmd.ClusterDefaults,
-		CurrentContext:  context,
-	}
-
-	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides).ClientConfig()
+	return kube.NewClient(kube.NewClientConfigForRestConfig(restCfg))
 }
 
 // applyOptions contains the startup options for applying the manifest.

--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -37,6 +37,8 @@ import (
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/operator/pkg/util/clog"
 	pkgversion "istio.io/istio/operator/pkg/version"
+	"istio.io/istio/pkg/kube"
+
 	"istio.io/pkg/log"
 )
 
@@ -128,7 +130,7 @@ func UpgradeCmd() *cobra.Command {
 // upgrade is the main function for Upgrade command
 func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 	// Create a kube client from args.kubeConfigPath and  args.context
-	kubeClient, err := NewClient(args.kubeConfigPath, args.context)
+	client, err := k8sClient(args.kubeConfigPath, args.context)
 	if err != nil {
 		return fmt.Errorf("failed to connect Kubernetes API server, error: %v", err)
 	}
@@ -154,13 +156,13 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 	istioNamespace := iop.Namespace(targetIOPS)
 
 	// Read the current Istio version from the the cluster
-	currentVersion, err := retrieveControlPlaneVersion(kubeClient, istioNamespace, l)
+	currentVersion, err := retrieveControlPlaneVersion(client, istioNamespace, l)
 	if err != nil && !args.force {
 		return fmt.Errorf("failed to read the current Istio version, error: %v", err)
 	}
 
 	// Check if the upgrade currentVersion -> targetVersion is supported
-	err = checkSupportedVersions(kubeClient, currentVersion)
+	err = checkSupportedVersions(client, currentVersion)
 	if err != nil && !args.force {
 		return fmt.Errorf("upgrade version check failed: %v -> %v. Error: %v",
 			currentVersion, targetVersion, err)
@@ -205,7 +207,7 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 
 	// Apply the Istio Control Plane specs reading from inFilenames to the cluster
 	err = ApplyManifests(applyFlagAliases(args.set, args.manifestsPath, ""), args.inFilenames, args.force, rootArgs.dryRun,
-		args.kubeConfigPath, args.context, args.readinessTimeout, l)
+		client, args.readinessTimeout, l)
 	if err != nil {
 		return fmt.Errorf("failed to apply the Istio Control Plane specs. Error: %v", err)
 	}
@@ -213,13 +215,13 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 	if !rootArgs.dryRun {
 		// Waits for the upgrade to complete by periodically comparing the each
 		// component version to the target version.
-		err = waitUpgradeComplete(kubeClient, istioNamespace, targetVersion, l)
+		err = waitUpgradeComplete(client, istioNamespace, targetVersion, l)
 		if err != nil {
 			return fmt.Errorf("failed to wait for the upgrade to complete. Error: %v", err)
 		}
 
 		// Read the upgraded Istio version from the the cluster
-		upgradeVer, err := retrieveControlPlaneVersion(kubeClient, istioNamespace, l)
+		upgradeVer, err := retrieveControlPlaneVersion(client, istioNamespace, l)
 		if err != nil {
 			return fmt.Errorf("failed to read the upgraded Istio version. Error: %v", err)
 		}
@@ -263,7 +265,7 @@ func waitForConfirmation(skipConfirmation bool, l clog.Logger) {
 
 var SupportedIstioVersions, _ = goversion.NewConstraint(">=1.6.0, <1.8")
 
-func checkSupportedVersions(kubeClient *Client, currentVersion string) error {
+func checkSupportedVersions(client kube.Client, currentVersion string) error {
 	curGoVersion, err := goversion.NewVersion(currentVersion)
 	if err != nil {
 		return fmt.Errorf("failed to parse the current version %q: %v", currentVersion, err)
@@ -273,12 +275,12 @@ func checkSupportedVersions(kubeClient *Client, currentVersion string) error {
 		return fmt.Errorf("upgrade is currently not supported from version: %v", currentVersion)
 	}
 
-	return kubeClient.CheckUnsupportedAlphaSecurityCRD()
+	return CheckUnsupportedAlphaSecurityCRD(client)
 }
 
 // retrieveControlPlaneVersion retrieves the version number from the Istio control plane
-func retrieveControlPlaneVersion(kubeClient ExecClient, istioNamespace string, l clog.Logger) (string, error) {
-	cv, e := kubeClient.GetIstioVersions(istioNamespace)
+func retrieveControlPlaneVersion(client kube.Client, istioNamespace string, l clog.Logger) (string, error) {
+	cv, e := GetIstioVersions(client.REST(), istioNamespace)
 	if e != nil {
 		return "", fmt.Errorf("failed to retrieve Istio control plane version, error: %v", e)
 	}
@@ -301,10 +303,10 @@ func retrieveControlPlaneVersion(kubeClient ExecClient, istioNamespace string, l
 
 // waitUpgradeComplete waits for the upgrade to complete by periodically comparing the current component version
 // to the target version.
-func waitUpgradeComplete(kubeClient ExecClient, istioNamespace string, targetVer string, l clog.Logger) error {
+func waitUpgradeComplete(client kube.Client, istioNamespace string, targetVer string, l clog.Logger) error {
 	for i := 1; i <= upgradeWaitCheckVerMaxAttempts; i++ {
 		sleepSeconds(upgradeWaitSecCheckVerPerLoop)
-		cv, e := kubeClient.GetIstioVersions(istioNamespace)
+		cv, e := GetIstioVersions(client.REST(), istioNamespace)
 		if e != nil {
 			l.LogAndPrintf("Failed to retrieve Istio control plane version, error: %v", e)
 			continue
@@ -359,12 +361,6 @@ func identicalVersions(cv []ComponentVersion) bool {
 	return true
 }
 
-// Client is a helper wrapper around the Kube RESTClient for istioctl -> Pilot/Envoy/Mesh related things
-type Client struct {
-	Config *rest.Config
-	*rest.RESTClient
-}
-
 // ComponentVersion is a pair of component name and version
 type ComponentVersion struct {
 	Component string
@@ -377,30 +373,9 @@ func (cv ComponentVersion) String() string {
 		cv.Component, cv.Pod.GetName(), cv.Version)
 }
 
-// ExecClient is an interface for remote execution
-type ExecClient interface {
-	GetIstioVersions(namespace string) ([]ComponentVersion, error)
-	GetPods(namespace string, params map[string]string) (*v1.PodList, error)
-	PodsForSelector(namespace, labelSelector string) (*v1.PodList, error)
-	ConfigMapForSelector(namespace, labelSelector string) (*v1.ConfigMapList, error)
-}
-
-// NewClient is the constructor for the client wrapper
-func NewClient(kubeconfig, configContext string) (*Client, error) {
-	config, err := defaultRestConfig(kubeconfig, configContext)
-	if err != nil {
-		return nil, err
-	}
-	restClient, err := rest.RESTClientFor(config)
-	if err != nil {
-		return nil, err
-	}
-	return &Client{config, restClient}, nil
-}
-
 // GetIstioVersions gets the version for each Istio component
-func (client *Client) GetIstioVersions(namespace string) ([]ComponentVersion, error) {
-	pods, err := client.GetPods(namespace, map[string]string{
+func GetIstioVersions(client rest.Interface, namespace string) ([]ComponentVersion, error) {
+	pods, err := GetPods(client, namespace, map[string]string{
 		"labelSelector": "istio",
 		"fieldSelector": "status.phase=Running",
 	})
@@ -466,18 +441,8 @@ func parseTag(image string) (string, error) {
 	}
 }
 
-func (client *Client) PodsForSelector(namespace, labelSelector string) (*v1.PodList, error) {
-	pods, err := client.GetPods(namespace, map[string]string{
-		"labelSelector": labelSelector,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve pods, error: %v", err)
-	}
-	return pods, nil
-}
-
 // GetPods retrieves the pod objects for Istio deployments
-func (client *Client) GetPods(namespace string, params map[string]string) (*v1.PodList, error) {
+func GetPods(client rest.Interface, namespace string, params map[string]string) (*v1.PodList, error) {
 	req := client.Get().
 		Resource("pods").
 		Namespace(namespace)
@@ -496,17 +461,8 @@ func (client *Client) GetPods(namespace string, params map[string]string) (*v1.P
 	return list, nil
 }
 
-func (client *Client) ConfigMapForSelector(namespace, labelSelector string) (*v1.ConfigMapList, error) {
-	cmGet := client.Get().Resource("configmaps").Namespace(namespace).Param("labelSelector", labelSelector)
-	obj, err := cmGet.Do(context.TODO()).Get()
-	if err != nil {
-		return nil, fmt.Errorf("failed retrieving configmap: %v", err)
-	}
-	return obj.(*v1.ConfigMapList), nil
-}
-
-func (client *Client) CheckUnsupportedAlphaSecurityCRD() error {
-	c, err := client_v1beta1.NewForConfig(client.Config)
+func CheckUnsupportedAlphaSecurityCRD(client kube.Client) error {
+	c, err := client_v1beta1.NewForConfig(client.RESTConfig())
 	if err != nil {
 		return err
 	}
@@ -540,7 +496,7 @@ func (client *Client) CheckUnsupportedAlphaSecurityCRD() error {
 		}
 
 		parts := strings.Split(crd, ".")
-		cmd := client.Get().AbsPath("apis", strings.Join(parts[1:], "."), "v1alpha1", parts[0])
+		cmd := client.REST().Get().AbsPath("apis", strings.Join(parts[1:], "."), "v1alpha1", parts[0])
 		obj, err := cmd.DoRaw(context.TODO())
 		if err != nil {
 			log.Errorf("failed to get resources for crd %s: %v", crd, err)

--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -201,6 +201,7 @@ func DefaultConfig(ctx resource.Context) (Config, error) {
 }
 
 // DefaultConfigOrFail calls DefaultConfig and fails t if an error occurs.
+// nolint: interfacer
 func DefaultConfigOrFail(t test.Failer, ctx resource.Context) Config {
 	cfg, err := DefaultConfig(ctx)
 	if err != nil {

--- a/pkg/test/kube/mock_client.go
+++ b/pkg/test/kube/mock_client.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/metadata/metadatainformer"
 	"k8s.io/client-go/rest"
+	controllerRuntime "sigs.k8s.io/controller-runtime/pkg/client"
 	serviceapisclient "sigs.k8s.io/service-apis/pkg/client/clientset/versioned"
 	serviceapisinformer "sigs.k8s.io/service-apis/pkg/client/informers/externalversions"
 
@@ -51,6 +52,10 @@ type MockClient struct {
 	RevisionValue    string
 	ConfigValue      *rest.Config
 	IstioVersions    *version.MeshInfo
+}
+
+func (c MockClient) Controller() controllerRuntime.Client {
+	panic("implement me")
 }
 
 func (c MockClient) Istio() istioclient.Interface {


### PR DESCRIPTION
This is another step toward removing the istioctl test component.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure