### PR TITLE
Extend multi-cluster with VM testing

### DIFF
--- a/tests/integration/multicluster/helper.go
+++ b/tests/integration/multicluster/helper.go
@@ -50,7 +50,7 @@ func Setup(controlPlaneValues *string, clusterLocalNS, mcReachabilityNS *namespa
 values:
   global:
     meshExpansion:
-      enabled: true:
+      enabled: true
 values:
   meshConfig:
     serviceSettings: 

--- a/tests/integration/multicluster/helper.go
+++ b/tests/integration/multicluster/helper.go
@@ -48,6 +48,10 @@ func Setup(controlPlaneValues *string, clusterLocalNS, mcReachabilityNS *namespa
 		// Set the cluster-local namespaces in the mesh config.
 		*controlPlaneValues = fmt.Sprintf(`
 values:
+  global:
+    meshExpansion:
+      enabled: true:
+values:
   meshConfig:
     serviceSettings: 
       - settings:

--- a/tests/integration/multicluster/reachability.go
+++ b/tests/integration/multicluster/reachability.go
@@ -80,7 +80,7 @@ func ReachabilityTest(t *testing.T, ns namespace.Instance, pilots []pilot.Instan
 					// respect to len(clusters) * svcPerCluster.
 					for _, srcServices := range services {
 						for _, src := range srcServices {
-							for i, dstServices := range services {
+							for _, dstServices := range services {
 								src := *src
 								dest := *dstServices[0]
 								subTestName := fmt.Sprintf("%s->%s://%s:%s%s",


### PR DESCRIPTION
This PR aims to add VM to the multicluster testing. 
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
