### PR TITLE
networking: add better transport security iptables rules

### DIFF
--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -86,6 +86,7 @@ func constructConfig() *config.Config {
 		RestoreFormat:           viper.GetBool(constants.RestoreFormat),
 		ProxyPort:               viper.GetString(constants.EnvoyPort),
 		InboundCapturePort:      viper.GetString(constants.InboundCapturePort),
+		InboundTunnelPort:       viper.GetString(constants.InboundTunnelPort),
 		ProxyUID:                viper.GetString(constants.ProxyUID),
 		ProxyGID:                viper.GetString(constants.ProxyGID),
 		InboundInterceptionMode: viper.GetString(constants.InboundInterceptionMode),
@@ -161,6 +162,7 @@ func init() {
 
 	var envoyPort = "15001"
 	var inboundPort = "15006"
+	var inboundTunnelPort = "15008"
 
 	rootCmd.Flags().StringP(constants.EnvoyPort, "p", "", "Specify the envoy port to which redirect all TCP traffic (default $ENVOY_PORT = 15001)")
 	if err := viper.BindPFlag(constants.EnvoyPort, rootCmd.Flags().Lookup(constants.EnvoyPort)); err != nil {
@@ -174,6 +176,13 @@ func init() {
 		handleError(err)
 	}
 	viper.SetDefault(constants.InboundCapturePort, inboundPort)
+
+	rootCmd.Flags().StringP(constants.InboundTunnelPort, "e", "",
+		"Specify the istio tunnel port for inbound tcp traffic (default $INBOUND_TUNNEL_PORT = 15008)")
+	if err := viper.BindPFlag(constants.InboundTunnelPort, rootCmd.Flags().Lookup(constants.InboundTunnelPort)); err != nil {
+		handleError(err)
+	}
+	viper.SetDefault(constants.InboundTunnelPort, inboundTunnelPort)
 
 	rootCmd.Flags().StringP(constants.ProxyUID, "u", "",
 		"Specify the UID of the user for which the redirection is not applied. Typically, this is the UID of the proxy container")

--- a/tools/istio-iptables/pkg/cmd/run.go
+++ b/tools/istio-iptables/pkg/cmd/run.go
@@ -197,7 +197,8 @@ func (iptConfigurator *IptablesConfigurator) handleInboundPortsInclude() {
 func (iptConfigurator *IptablesConfigurator) handleInboundIpv6Rules(ipv6RangesExclude NetworkRange, ipv6RangesInclude NetworkRange) {
 	var table string
 	// Create a new chain for to hit tunnel port directly.
-	iptConfigurator.iptables.AppendRuleV6(constants.ISTIOINBOUND, constants.NAT, "-p", constants.TCP, "--dport", iptConfigurator.cfg.InboundTunnelPort, "-j", constants.RETURN)
+	iptConfigurator.iptables.AppendRuleV6(constants.ISTIOINBOUND, constants.NAT, "-p", constants.TCP, "--dport",
+		iptConfigurator.cfg.InboundTunnelPort, "-j", constants.RETURN)
 	// Create a new chain for redirecting outbound traffic to the common Envoy port.
 	// In both chains, '-j RETURN' bypasses Envoy and '-j ISTIOREDIRECT'
 	// redirects to Envoy.
@@ -370,7 +371,8 @@ func (iptConfigurator *IptablesConfigurator) run() {
 	}
 
 	// Create a new chain for to hit tunnel port directly. Envoy will be listening on port acting as VPN tunnel.
-	iptConfigurator.iptables.AppendRuleV4(constants.ISTIOINBOUND, constants.NAT, "-p", constants.TCP, "--dport", iptConfigurator.cfg.InboundTunnelPort, "-j", constants.RETURN)
+	iptConfigurator.iptables.AppendRuleV4(constants.ISTIOINBOUND, constants.NAT, "-p", constants.TCP, "--dport",
+		iptConfigurator.cfg.InboundTunnelPort, "-j", constants.RETURN)
 
 	// Create a new chain for redirecting outbound traffic to the common Envoy port.
 	// In both chains, '-j RETURN' bypasses Envoy and '-j ISTIOREDIRECT'

--- a/tools/istio-iptables/pkg/cmd/run.go
+++ b/tools/istio-iptables/pkg/cmd/run.go
@@ -196,6 +196,8 @@ func (iptConfigurator *IptablesConfigurator) handleInboundPortsInclude() {
 
 func (iptConfigurator *IptablesConfigurator) handleInboundIpv6Rules(ipv6RangesExclude NetworkRange, ipv6RangesInclude NetworkRange) {
 	var table string
+	// Create a new chain for to hit tunnel port directly.
+	iptConfigurator.iptables.AppendRuleV6(constants.ISTIOINBOUND, constants.NAT, "-p", constants.TCP, "--dport", iptConfigurator.cfg.InboundTunnelPort, "-j", constants.RETURN)
 	// Create a new chain for redirecting outbound traffic to the common Envoy port.
 	// In both chains, '-j RETURN' bypasses Envoy and '-j ISTIOREDIRECT'
 	// redirects to Envoy.
@@ -367,6 +369,9 @@ func (iptConfigurator *IptablesConfigurator) run() {
 		iptConfigurator.ext.RunOrFail(constants.IP, "-6", "addr", "add", "::6/128", "dev", "lo")
 	}
 
+	// Create a new chain for to hit tunnel port directly. Envoy will be listening on port acting as VPN tunnel.
+	iptConfigurator.iptables.AppendRuleV4(constants.ISTIOINBOUND, constants.NAT, "-p", constants.TCP, "--dport", iptConfigurator.cfg.InboundTunnelPort, "-j", constants.RETURN)
+
 	// Create a new chain for redirecting outbound traffic to the common Envoy port.
 	// In both chains, '-j RETURN' bypasses Envoy and '-j ISTIOREDIRECT'
 	// redirects to Envoy.
@@ -374,6 +379,8 @@ func (iptConfigurator *IptablesConfigurator) run() {
 		constants.ISTIOREDIRECT, constants.NAT, "-p", constants.TCP, "-j", constants.REDIRECT, "--to-ports", iptConfigurator.cfg.ProxyPort)
 	if redirectDNS {
 		iptConfigurator.iptables.AppendRuleV4(
+			constants.ISTIOREDIRECT, constants.NAT, "-p", constants.UDP, "-j", constants.REDIRECT, "--to-ports", dnsTargetPort)
+		iptConfigurator.iptables.AppendRuleV6(
 			constants.ISTIOREDIRECT, constants.NAT, "-p", constants.UDP, "-j", constants.REDIRECT, "--to-ports", dnsTargetPort)
 	}
 

--- a/tools/istio-iptables/pkg/cmd/run_test.go
+++ b/tools/istio-iptables/pkg/cmd/run_test.go
@@ -30,6 +30,7 @@ func constructTestConfig() *config.Config {
 		RestoreFormat:           true,
 		ProxyPort:               "15001",
 		InboundCapturePort:      "15006",
+		InboundTunnelPort:       "15008",
 		ProxyUID:                constants.DefaultProxyUID,
 		ProxyGID:                constants.DefaultProxyUID,
 		InboundInterceptionMode: "",
@@ -59,9 +60,11 @@ func TestHandleInboundIpv6RulesWithEmptyInboundPorts(t *testing.T) {
 	iptConfigurator.handleInboundIpv6Rules(ipv6Range, ipv6Range)
 	actual := FormatIptablesCommands(iptConfigurator.iptables.BuildV6())
 	expected := []string{
+		"ip6tables -t nat -N ISTIO_INBOUND",
 		"ip6tables -t nat -N ISTIO_REDIRECT",
 		"ip6tables -t nat -N ISTIO_IN_REDIRECT",
 		"ip6tables -t nat -N ISTIO_OUTPUT",
+		"ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN",
 		"ip6tables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001",
 		"ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006",
 		"ip6tables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT",
@@ -93,9 +96,11 @@ func TestRulesWithIpRange(t *testing.T) {
 	iptConfigurator.run()
 	actual := FormatIptablesCommands(iptConfigurator.iptables.BuildV4())
 	expected := []string{
+		"iptables -t nat -N ISTIO_INBOUND",
 		"iptables -t nat -N ISTIO_REDIRECT",
 		"iptables -t nat -N ISTIO_IN_REDIRECT",
 		"iptables -t nat -N ISTIO_OUTPUT",
+		"iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN",
 		"iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001",
 		"iptables -t nat -A ISTIO_REDIRECT -p udp -j REDIRECT --to-ports 15013",
 		"iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006",
@@ -137,8 +142,11 @@ func TestHandleInboundIpv6RulesWithInboundPorts(t *testing.T) {
 	iptConfigurator.handleInboundIpv6Rules(ipv6Range, ipv6Range)
 	actual := FormatIptablesCommands(iptConfigurator.iptables.BuildV6())
 	expected := []string{
-		"ip6tables -t nat -N ISTIO_REDIRECT", "ip6tables -t nat -N ISTIO_IN_REDIRECT",
-		"ip6tables -t nat -N ISTIO_INBOUND", "ip6tables -t nat -N ISTIO_OUTPUT",
+		"ip6tables -t nat -N ISTIO_INBOUND",
+		"ip6tables -t nat -N ISTIO_REDIRECT",
+		"ip6tables -t nat -N ISTIO_IN_REDIRECT",
+		"ip6tables -t nat -N ISTIO_OUTPUT",
+		"ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN",
 		"ip6tables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001",
 		"ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006",
 		"ip6tables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND",
@@ -173,10 +181,11 @@ func TestHandleInboundIpv6RulesWithWildcardRanges(t *testing.T) {
 	iptConfigurator.handleInboundIpv6Rules(ipv6Range, ipv6Range)
 	actual := FormatIptablesCommands(iptConfigurator.iptables.BuildV6())
 	expected := []string{
+		"ip6tables -t nat -N ISTIO_INBOUND",
 		"ip6tables -t nat -N ISTIO_REDIRECT",
 		"ip6tables -t nat -N ISTIO_IN_REDIRECT",
-		"ip6tables -t nat -N ISTIO_INBOUND",
 		"ip6tables -t nat -N ISTIO_OUTPUT",
+		"ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN",
 		"ip6tables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001",
 		"ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006",
 		"ip6tables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND",
@@ -216,8 +225,11 @@ func TestHandleInboundIpv6RulesWithIpNets(t *testing.T) {
 	iptConfigurator.handleInboundIpv6Rules(ipv6Range, ipv6Range)
 	actual := FormatIptablesCommands(iptConfigurator.iptables.BuildV6())
 	expected := []string{
-		"ip6tables -t nat -N ISTIO_REDIRECT", "ip6tables -t nat -N ISTIO_IN_REDIRECT",
-		"ip6tables -t nat -N ISTIO_INBOUND", "ip6tables -t nat -N ISTIO_OUTPUT",
+		"ip6tables -t nat -N ISTIO_INBOUND",
+		"ip6tables -t nat -N ISTIO_REDIRECT",
+		"ip6tables -t nat -N ISTIO_IN_REDIRECT",
+		"ip6tables -t nat -N ISTIO_OUTPUT",
+		"ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN",
 		"ip6tables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001",
 		"ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006",
 		"ip6tables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND",
@@ -261,8 +273,11 @@ func TestHandleInboundIpv6RulesWithUidGid(t *testing.T) {
 	iptConfigurator.handleInboundIpv6Rules(ipv6Range, ipv6Range)
 	actual := FormatIptablesCommands(iptConfigurator.iptables.BuildV6())
 	expected := []string{
-		"ip6tables -t nat -N ISTIO_REDIRECT", "ip6tables -t nat -N ISTIO_IN_REDIRECT",
-		"ip6tables -t nat -N ISTIO_INBOUND", "ip6tables -t nat -N ISTIO_OUTPUT",
+		"ip6tables -t nat -N ISTIO_INBOUND",
+		"ip6tables -t nat -N ISTIO_REDIRECT",
+		"ip6tables -t nat -N ISTIO_IN_REDIRECT",
+		"ip6tables -t nat -N ISTIO_OUTPUT",
+		"ip6tables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN",
 		"ip6tables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001",
 		"ip6tables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006",
 		"ip6tables -t nat -A PREROUTING -p tcp -j ISTIO_INBOUND",
@@ -577,9 +592,11 @@ func TestHandleInboundIpv4RulesWithUidGid(t *testing.T) {
 	iptConfigurator.run()
 	actual := FormatIptablesCommands(iptConfigurator.iptables.BuildV4())
 	expected := []string{
+		"iptables -t nat -N ISTIO_INBOUND",
 		"iptables -t nat -N ISTIO_REDIRECT",
 		"iptables -t nat -N ISTIO_IN_REDIRECT",
 		"iptables -t nat -N ISTIO_OUTPUT",
+		"iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN",
 		"iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001",
 		"iptables -t nat -A ISTIO_REDIRECT -p udp -j REDIRECT --to-ports 15053",
 		"iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006",
@@ -641,9 +658,11 @@ func TestRulesWithLoopbackIpInOutboundIpRanges(t *testing.T) {
 	iptConfigurator.run()
 	actual := FormatIptablesCommands(iptConfigurator.iptables.BuildV4())
 	expected := []string{
+		"iptables -t nat -N ISTIO_INBOUND",
 		"iptables -t nat -N ISTIO_REDIRECT",
 		"iptables -t nat -N ISTIO_IN_REDIRECT",
 		"iptables -t nat -N ISTIO_OUTPUT",
+		"iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN",
 		"iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001",
 		"iptables -t nat -A ISTIO_REDIRECT -p udp -j REDIRECT --to-ports 15013",
 		"iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006",

--- a/tools/istio-iptables/pkg/config/config.go
+++ b/tools/istio-iptables/pkg/config/config.go
@@ -27,6 +27,7 @@ import (
 type Config struct {
 	ProxyPort               string        `json:"PROXY_PORT"`
 	InboundCapturePort      string        `json:"INBOUND_CAPTURE_PORT"`
+	InboundTunnelPort       string        `json:"INBOUND_TUNNEL_PORT"`
 	ProxyUID                string        `json:"PROXY_UID"`
 	ProxyGID                string        `json:"PROXY_GID"`
 	InboundInterceptionMode string        `json:"INBOUND_INTERCEPTION_MODE"`
@@ -61,6 +62,7 @@ func (c *Config) Print() {
 	fmt.Println("----------")
 	fmt.Printf("PROXY_PORT=%s\n", c.ProxyPort)
 	fmt.Printf("PROXY_INBOUND_CAPTURE_PORT=%s\n", c.InboundCapturePort)
+	fmt.Printf("PROXY_TUNNEL_PORT=%s\n", c.InboundTunnelPort)
 	fmt.Printf("PROXY_UID=%s\n", c.ProxyUID)
 	fmt.Printf("PROXY_GID=%s\n", c.ProxyGID)
 	fmt.Printf("INBOUND_INTERCEPTION_MODE=%s\n", c.InboundInterceptionMode)

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -76,6 +76,7 @@ const (
 	LocalOutboundPortsExclude = "istio-local-outbound-ports-exclude"
 	EnvoyPort                 = "envoy-port"
 	InboundCapturePort        = "inbound-capture-port"
+	InboundTunnelPort         = "inbound-tunnel-port"
 	ProxyUID                  = "proxy-uid"
 	ProxyGID                  = "proxy-gid"
 	KubeVirtInterfaces        = "kube-virt-interfaces"


### PR DESCRIPTION
150XX ports are reserved for istio

Reserve port 15008 for not capture. Expecting 
Follow up:
Pilot generates inbound http2 listener on 15008 with enforced istio certs. for sidecar envoy.
Pilot generates outbound cluster to connect 15008 endpoint.

Part of #24540