### PR TITLE
gateway charts should not depend on global.yaml

### DIFF
--- a/manifests/charts/gateways/istio-egress/values.yaml
+++ b/manifests/charts/gateways/istio-egress/values.yaml
@@ -281,3 +281,17 @@ global:
   #   kubernetes: cluster.local
   #   else:  default dns domain
   trustDomain: "cluster.local"
+
+meshConfig:
+  enablePrometheusMerge: true
+  defaultConfig:
+    proxyMetadata: {}
+    tracing:
+    #      tlsSettings:
+    #        mode: DISABLE # DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
+    #        clientCertificate: # example: /etc/istio/tracer/cert-chain.pem
+    #        privateKey:        # example: /etc/istio/tracer/key.pem
+    #        caCertificates:    # example: /etc/istio/tracer/root-cert.pem
+    #        sni:               # example: tracer.somedomain
+    #        subjectAltNames: []
+    # - tracer.somedomain

--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -310,3 +310,17 @@ global:
   #   kubernetes: cluster.local
   #   else:  default dns domain
   trustDomain: "cluster.local"
+
+meshConfig:
+  enablePrometheusMerge: true
+  defaultConfig:
+    proxyMetadata: {}
+    tracing:
+    #      tlsSettings:
+    #        mode: DISABLE # DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
+    #        clientCertificate: # example: /etc/istio/tracer/cert-chain.pem
+    #        privateKey:        # example: /etc/istio/tracer/key.pem
+    #        caCertificates:    # example: /etc/istio/tracer/root-cert.pem
+    #        sni:               # example: tracer.somedomain
+    #        subjectAltNames: []
+    # - tracer.somedomain


### PR DESCRIPTION
Fix: Missing meshConfig for both ingress and egress

Follow up to https://github.com/istio/istio/pull/25260

Task for https://github.com/istio/istio/issues/25184

Find all occurrences of .Values.global in istio-discovery chart
  `rg -o -e ".Values.global(\.\w+)*" | awk -F\: '{print $2}' | sort -u`

Take values from global.yaml into values.yaml

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
