### PR TITLE
Use MUTUAL_TLS for ControlPlaneAuthPolicy in default ProxyConfig

### DIFF
--- a/pkg/config/mesh/mesh.go
+++ b/pkg/config/mesh/mesh.go
@@ -54,7 +54,7 @@ func DefaultProxyConfig() meshconfig.ProxyConfig {
 		TerminationDrainDuration: types.DurationProto(5 * time.Second),
 		ProxyAdminPort:           15000,
 		Concurrency:              &types.Int32Value{Value: 2},
-		ControlPlaneAuthPolicy:   meshconfig.AuthenticationPolicy_NONE,
+		ControlPlaneAuthPolicy:   meshconfig.AuthenticationPolicy_MUTUAL_TLS,
 		DiscoveryAddress:         "istiod.istio-system.svc:15012",
 		Tracing: &meshconfig.Tracing{
 			Tracer: &meshconfig.Tracing_Zipkin_{

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -355,7 +355,7 @@ func TestValidateProxyConfig(t *testing.T) {
 		StatsdUdpAddress:       "istio-statsd-prom-bridge.istio-system:9125",
 		EnvoyMetricsService:    &meshconfig.RemoteService{Address: "metrics-service.istio-system:15000"},
 		EnvoyAccessLogService:  &meshconfig.RemoteService{Address: "accesslog-service.istio-system:15000"},
-		ControlPlaneAuthPolicy: 1,
+		ControlPlaneAuthPolicy: meshconfig.AuthenticationPolicy_MUTUAL_TLS,
 		Tracing:                nil,
 	}
 

--- a/pkg/kube/inject/inject_test.go
+++ b/pkg/kube/inject/inject_test.go
@@ -587,17 +587,17 @@ func TestCleanProxyConfig(t *testing.T) {
 		{
 			"default",
 			mesh.DefaultProxyConfig(),
-			`{}`,
+			`{"controlPlaneAuthPolicy":"MUTUAL_TLS"}`,
 		},
 		{
 			"explicit default",
 			explicit,
-			`{}`,
+			`{"controlPlaneAuthPolicy":"MUTUAL_TLS"}`,
 		},
 		{
 			"overrides",
 			overrides,
-			`{"configPath":"/foo/bar","drainDuration":"7s","proxyMetadata":{"foo":"barr"}}`,
+			`{"configPath":"/foo/bar","drainDuration":"7s","controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"foo":"barr"}}`,
 		},
 	}
 	for _, tt := range cases {

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -105,7 +105,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -102,7 +102,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-probes.yaml.injected
@@ -104,7 +104,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/hello-readiness.yaml.injected
@@ -85,7 +85,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/https-probes.yaml.injected
@@ -105,7 +105,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/named_port.yaml.injected
@@ -85,7 +85,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/one_container.yaml.injected
@@ -89,7 +89,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/ready_live.yaml.injected
@@ -104,7 +104,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/ready_only.yaml.injected
@@ -85,7 +85,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/app_probe/startup_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/startup_live.yaml.injected
@@ -104,7 +104,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/app_probe/startup_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/startup_only.yaml.injected
@@ -85,7 +85,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/app_probe/startup_ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/startup_ready_live.yaml.injected
@@ -112,7 +112,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/app_probe/two_container.yaml.injected
@@ -95,7 +95,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -75,7 +75,7 @@ spec:
                   fieldPath: metadata.labels['service.istio.io/canonical-revision']
             - name: PROXY_CONFIG
               value: |
-                {"proxyMetadata":{"DNS_AGENT":""}}
+                {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
             - name: ISTIO_META_POD_PORTS
               value: |-
                 [

--- a/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -79,7 +79,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -94,7 +94,7 @@ items:
                 fieldPath: metadata.labels['service.istio.io/canonical-revision']
           - name: PROXY_CONFIG
             value: |
-              {"proxyMetadata":{"DNS_AGENT":""}}
+              {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
           - name: ISTIO_META_POD_PORTS
             value: |-
               [

--- a/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -79,7 +79,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"drainDuration":"23s","parentShutdownDuration":"42s","proxyMetadata":{"DNS_AGENT":""}}
+            {"drainDuration":"23s","parentShutdownDuration":"42s","controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -98,7 +98,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/hello-cncf-networks.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-cncf-networks.yaml.injected
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks.yaml.injected
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/hello-image-secrets-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-image-secrets-in-values.yaml.injected
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -307,7 +307,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/hello-multiple-image-secrets.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multiple-image-secrets.yaml.injected
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"interceptionMode":"TPROXY","proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","interceptionMode":"TPROXY","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -73,7 +73,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -99,7 +99,7 @@ items:
                 fieldPath: metadata.labels['service.istio.io/canonical-revision']
           - name: PROXY_CONFIG
             value: |
-              {"proxyMetadata":{"DNS_AGENT":""}}
+              {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
           - name: ISTIO_META_POD_PORTS
             value: |-
               [

--- a/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -85,7 +85,7 @@ items:
                 fieldPath: metadata.labels['service.istio.io/canonical-revision']
           - name: PROXY_CONFIG
             value: |
-              {"proxyMetadata":{"DNS_AGENT":""}}
+              {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
           - name: ISTIO_META_POD_PORTS
             value: |-
               [
@@ -308,7 +308,7 @@ items:
                 fieldPath: metadata.labels['service.istio.io/canonical-revision']
           - name: PROXY_CONFIG
             value: |
-              {"proxyMetadata":{"DNS_AGENT":""}}
+              {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
           - name: ISTIO_META_POD_PORTS
             value: |-
               [

--- a/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -67,7 +67,7 @@ spec:
           fieldPath: metadata.labels['service.istio.io/canonical-revision']
     - name: PROXY_CONFIG
       value: |
-        {"proxyMetadata":{"DNS_AGENT":""}}
+        {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
     - name: ISTIO_META_POD_PORTS
       value: |-
         [

--- a/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -76,7 +76,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -84,7 +84,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/status_annotations_zeroport.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations_zeroport.yaml.injected
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -77,7 +77,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -85,7 +85,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"discoveryAddress":"foo:123","concurrency":0,"proxyMetadata":{"FOO":"bar"}}
+            {"discoveryAddress":"foo:123","controlPlaneAuthPolicy":"MUTUAL_TLS","concurrency":0,"proxyMetadata":{"FOO":"bar"}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -77,7 +77,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {"proxyMetadata":{"DNS_AGENT":""}}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS","proxyMetadata":{"DNS_AGENT":""}}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS"}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
@@ -80,7 +80,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS"}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig-with-canonical-service-label.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig-with-canonical-service-label.yaml.injected
@@ -80,7 +80,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS"}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
@@ -80,7 +80,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS"}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
@@ -86,7 +86,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS"}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS"}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-mtls-not-ready.yaml.injected
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS"}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
@@ -84,7 +84,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS"}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -303,7 +303,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS"}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
@@ -105,7 +105,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS"}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/job.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/job.yaml.injected
@@ -77,7 +77,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS"}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
@@ -86,7 +86,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS"}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/list.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/list.yaml.injected
@@ -84,7 +84,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS"}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
@@ -303,7 +303,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS"}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS"}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
@@ -76,7 +76,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS"}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS"}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
@@ -85,7 +85,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS"}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS"}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS"}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS"}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS"}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [

--- a/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
+++ b/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
@@ -84,7 +84,7 @@ spec:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         - name: PROXY_CONFIG
           value: |
-            {}
+            {"controlPlaneAuthPolicy":"MUTUAL_TLS"}
         - name: ISTIO_META_POD_PORTS
           value: |-
             [


### PR DESCRIPTION
Based on https://github.com/istio/api/pull/1493#discussion_r447717857, the default for `ControlPlaneAuthPolicy` is encrypted.

Not sure if PR should also include injected yamls.

```
$ make clean gen
$ make refresh-goldens
```
 
Ref PR:
https://github.com/istio/api/pull/1503
https://github.com/istio/api/pull/1493
