### PR TITLE
Make IngressGateway Namespace configurable for Test Framework

### DIFF
--- a/pkg/test/framework/components/ingress/ingress.go
+++ b/pkg/test/framework/components/ingress/ingress.go
@@ -25,6 +25,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/framework/resource/environment"
+	"istio.io/istio/pkg/test/framework/components/namespace"
 )
 
 // CallType defines ingress gateway type
@@ -108,6 +109,8 @@ type Config struct {
 	IngressType CallType
 	// Cluster to be used in a multicluster environment
 	Cluster resource.Cluster
+	// Namespace to deploy ingress util to, overrides cfg.IngressNamespace if specified
+	Namespace namespace.Instance
 }
 
 // CallResponse is the result of a call made through Istio Ingress.

--- a/pkg/test/framework/components/ingress/ingress.go
+++ b/pkg/test/framework/components/ingress/ingress.go
@@ -23,9 +23,9 @@ import (
 
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/framework/resource/environment"
-	"istio.io/istio/pkg/test/framework/components/namespace"
 )
 
 // CallType defines ingress gateway type

--- a/pkg/test/framework/components/ingress/kube.go
+++ b/pkg/test/framework/components/ingress/kube.go
@@ -177,7 +177,11 @@ func getHTTPSAddressInner(env *kube.Environment, ns string) (interface{}, bool, 
 func newKube(ctx resource.Context, cfg Config) Instance {
 	c := &kubeComponent{}
 	c.id = ctx.TrackResource(c)
-	c.namespace = cfg.Istio.Settings().IngressNamespace
+	if cfg.Namespace != nil {
+		c.namespace = cfg.Namespace.Name()
+	} else {
+		c.namespace = cfg.Istio.Settings().IngressNamespace
+	}
 	c.env = ctx.Environment().(*kube.Environment)
 	c.cluster = resource.ClusterOrDefault(cfg.Cluster, ctx.Environment())
 


### PR DESCRIPTION
Makes namespace to deploy service to be used as ingress gateway configurable. Good use case is when we try to simulate traffic to go out side the default mesh and accept ingress in a different namespace than istio-system during testing