### PR TITLE
test analyzer does not fail unlabeled tests when suite is skipped

### DIFF
--- a/pkg/test/framework/analyzer.go
+++ b/pkg/test/framework/analyzer.go
@@ -204,7 +204,7 @@ func (t *testAnalyzer) Run(_ func(ctx TestContext)) {
 	t.hasRun = true
 
 	// don't fail tests that would otherwise be skipped
-	if t.skip != "" {
+	if analysis.SkipReason != "" || t.skip != "" {
 		return
 	}
 

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -58,8 +58,10 @@ ifneq ($(_INTEGRATION_TEST_NETWORKS),)
     _INTEGRATION_TEST_FLAGS += --istio.test.kube.networkTopology=$(_INTEGRATION_TEST_NETWORKS)
 endif
 
-test.integration.analyze: | $(JUNIT_REPORT)
-	$(GO) test -p 1 ${T} ./tests/integration/... -timeout 30m \
+test.integration.analyze: test.integration...analyze
+
+test.integration.%.analyze: | $(JUNIT_REPORT)
+	$(GO) test -p 1 ${T} ./tests/integration/$(subst .,/,$*)/... -timeout 30m \
 	--istio.test.analyze \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
 


### PR DESCRIPTION
- fix for unnecessary failures
- add target for analyzing subdirectory

`make test.integration.analyze` passes, should be able to bring back https://github.com/istio/test-infra/pull/2744 job

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
