### PR TITLE
sidecar scope matches ns for envoy filter and authn/z

### DIFF
--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -41,10 +41,10 @@ var (
 	}
 
 	sidecarScopeNamespaceConfigTypes = map[resource.GroupVersionKind]struct{}{
-		gvk.Sidecar: {},
-		gvk.EnvoyFilter: {},
-		gvk.AuthorizationPolicy: {},
-		gvk.PeerAuthentication: {},
+		gvk.Sidecar:               {},
+		gvk.EnvoyFilter:           {},
+		gvk.AuthorizationPolicy:   {},
+		gvk.PeerAuthentication:    {},
 		gvk.RequestAuthentication: {},
 	}
 )

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -42,6 +42,10 @@ var (
 
 	sidecarScopeNamespaceConfigTypes = map[resource.GroupVersionKind]struct{}{
 		gvk.Sidecar: {},
+		gvk.EnvoyFilter: {},
+		gvk.AuthorizationPolicy: {},
+		gvk.PeerAuthentication: {},
+		gvk.RequestAuthentication: {},
 	}
 )
 

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -44,7 +44,6 @@ var (
 		gvk.Sidecar:               {},
 		gvk.EnvoyFilter:           {},
 		gvk.AuthorizationPolicy:   {},
-		gvk.PeerAuthentication:    {},
 		gvk.RequestAuthentication: {},
 	}
 )

--- a/pilot/pkg/xds/ads_common_test.go
+++ b/pilot/pkg/xds/ads_common_test.go
@@ -125,7 +125,7 @@ func TestProxyNeedsPush(t *testing.T) {
 	}
 
 	sidecarNamespaceScopeTypes := []resource.GroupVersionKind{
-		gvk.Sidecar, gvk.EnvoyFilter, gvk.AuthorizationPolicy, gvk.PeerAuthentication, gvk.RequestAuthentication,
+		gvk.Sidecar, gvk.EnvoyFilter, gvk.AuthorizationPolicy, gvk.RequestAuthentication,
 	}
 	for _, kind := range sidecarNamespaceScopeTypes {
 		cases = append(cases,

--- a/pilot/pkg/xds/ads_common_test.go
+++ b/pilot/pkg/xds/ads_common_test.go
@@ -95,14 +95,6 @@ func TestProxyNeedsPush(t *testing.T) {
 			{
 				Kind: gvk.QuotaSpec,
 				Name: generalName, Namespace: nsName}: {}}, false},
-		{"sidecar config in same namespace", sidecar, map[model.ConfigKey]struct{}{
-			{
-				Kind: gvk.Sidecar,
-				Name: scName, Namespace: nsName}: {}}, true},
-		{"sidecar config in different namespace", sidecar, map[model.ConfigKey]struct{}{
-			{
-				Kind: gvk.Sidecar,
-				Name: scName, Namespace: "ns2"}: {}}, false},
 		{"invalid config for sidecar", sidecar, map[model.ConfigKey]struct{}{
 			{
 				Kind: resource.GroupVersionKind{Kind: invalidKind}, Name: generalName, Namespace: nsName}: {}},
@@ -130,6 +122,26 @@ func TestProxyNeedsPush(t *testing.T) {
 			configs: map[model.ConfigKey]struct{}{{Kind: kind, Name: name + invalidNameSuffix, Namespace: nsName}: {}},
 			want:    false,
 		})
+	}
+
+	sidecarNamespaceScopeTypes := []resource.GroupVersionKind{
+		gvk.Sidecar, gvk.EnvoyFilter, gvk.AuthorizationPolicy, gvk.PeerAuthentication, gvk.RequestAuthentication,
+	}
+	for _, kind := range sidecarNamespaceScopeTypes {
+		cases = append(cases,
+			Case{
+				name:    fmt.Sprintf("%s config for sidecar in same namespace", kind.Kind),
+				proxy:   sidecar,
+				configs: map[model.ConfigKey]struct{}{{Kind: kind, Name: generalName, Namespace: nsName}: {}},
+				want:    true,
+			},
+			Case{
+				name:    fmt.Sprintf("%s config for sidecar in different namespace", kind.Kind),
+				proxy:   sidecar,
+				configs: map[model.ConfigKey]struct{}{{Kind: kind, Name: generalName, Namespace: "invalid-namespace"}: {}},
+				want:    false,
+			},
+		)
 	}
 
 	// tests for kind-affect-proxy.


### PR DESCRIPTION
Continuation of https://github.com/istio/istio/pull/25403 for https://github.com/istio/istio/issues/25364

Adds the following to the list of "namespace scope" resources for a sidecar:
- EnvoyFilter
- AuthorizationPolicy
- ~PeerAuthentication~ will have issues
- RequestAuthentication

Still need to validate this scoping is accurate for these resource types. 