### PR TITLE
tests: allow pilot suite to run with more than one cluster

### DIFF
--- a/pkg/test/framework/components/istio/istio.go
+++ b/pkg/test/framework/components/istio/istio.go
@@ -15,6 +15,7 @@
 package istio
 
 import (
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/scopes"
@@ -32,6 +33,24 @@ type SetupConfigFn func(cfg *Config)
 
 // SetupContextFn is a setup function that uses Context for configuration.
 type SetupContextFn func(ctx resource.Context) error
+
+// Get returns the Istio component from the context. If there is none an error is returned.
+func Get(ctx resource.Context) (Instance, error) {
+	var i Instance
+	if err := ctx.GetResource(&i); err != nil {
+		return nil, err
+	}
+	return i, nil
+}
+
+// GetOrFail returns the Istio component from the context. If there is none the test is failed.
+func GetOrFail(f test.Failer, ctx resource.Context) Instance {
+	i, err := Get(ctx)
+	if err != nil {
+		f.Fatal(err)
+	}
+	return i
+}
 
 // Setup is a setup function that will deploy Istio on Kubernetes environment
 func Setup(i *Instance, cfn SetupConfigFn, ctxFns ...SetupContextFn) resource.SetupFn {

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -127,6 +127,7 @@ if [[ -z "${SKIP_SETUP:-}" ]]; then
     # Set the kube configs to point to the clusters.
     export INTEGRATION_TEST_KUBECONFIG="${CLUSTER1_KUBECONFIG},${CLUSTER2_KUBECONFIG},${CLUSTER3_KUBECONFIG}"
     export INTEGRATION_TEST_NETWORKS="0:test-network-0,1:test-network-0,2:test-network-1"
+    export INTEGRATION_TEST_CONTROLPLANE_TOPOLOGY="0:0,1:0,2:2"
   fi
 fi
 

--- a/tests/integration/multicluster/helper.go
+++ b/tests/integration/multicluster/helper.go
@@ -23,7 +23,6 @@ import (
 	"istio.io/istio/pkg/test/echo/client"
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework/components/echo"
-	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/util/retry"
@@ -33,30 +32,6 @@ var (
 	retryTimeout = time.Second * 30
 	retryDelay   = time.Millisecond * 100
 )
-
-// SetupPilots populates a non-nil map from cluster indices to pilot component instances.
-// Returns an error if used in a non-kubernetes environment.
-func SetupPilots(pilots *[]pilot.Instance) resource.SetupFn {
-	return func(ctx resource.Context) error {
-		env := ctx.Environment().(*kube.Environment)
-		p := make([]pilot.Instance, len(env.KubeClusters))
-		for _, c := range env.KubeClusters {
-			cp, err := env.GetControlPlaneCluster(c)
-			if err != nil {
-				return err
-			}
-			if inst := p[cp.Index()]; inst == nil {
-				p[cp.Index()], err = pilot.New(ctx, pilot.Config{Cluster: cp})
-				if err != nil {
-					return fmt.Errorf("error creating pilot instance for cluster %d: %v", cp.Index(), err)
-				}
-			}
-			p[c.Index()] = p[cp.Index()]
-		}
-		*pilots = p
-		return nil
-	}
-}
 
 func Setup(controlPlaneValues *string, clusterLocalNS, mcReachabilityNS *namespace.Instance) func(ctx resource.Context) error {
 	return func(ctx resource.Context) (err error) {

--- a/tests/integration/multicluster/helper.go
+++ b/tests/integration/multicluster/helper.go
@@ -23,6 +23,7 @@ import (
 	"istio.io/istio/pkg/test/echo/client"
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/util/retry"
@@ -32,6 +33,30 @@ var (
 	retryTimeout = time.Second * 30
 	retryDelay   = time.Millisecond * 100
 )
+
+// SetupPilots populates a non-nil map from cluster indices to pilot component instances.
+// Returns an error if used in a non-kubernetes environment.
+func SetupPilots(pilots *[]pilot.Instance) resource.SetupFn {
+	return func(ctx resource.Context) error {
+		env := ctx.Environment().(*kube.Environment)
+		p := make([]pilot.Instance, len(env.KubeClusters))
+		for _, c := range env.KubeClusters {
+			cp, err := env.GetControlPlaneCluster(c)
+			if err != nil {
+				return err
+			}
+			if inst := p[cp.Index()]; inst == nil {
+				p[cp.Index()], err = pilot.New(ctx, pilot.Config{Cluster: cp})
+				if err != nil {
+					return fmt.Errorf("error creating pilot instance for cluster %d: %v", cp.Index(), err)
+				}
+			}
+			p[c.Index()] = p[cp.Index()]
+		}
+		*pilots = p
+		return nil
+	}
+}
 
 func Setup(controlPlaneValues *string, clusterLocalNS, mcReachabilityNS *namespace.Instance) func(ctx resource.Context) error {
 	return func(ctx resource.Context) (err error) {

--- a/tests/integration/multicluster/multimaster/main_test.go
+++ b/tests/integration/multicluster/multimaster/main_test.go
@@ -20,6 +20,7 @@ import (
 	"istio.io/istio/tests/integration/multicluster"
 
 	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/components/pilot"
@@ -40,6 +41,14 @@ func TestMain(m *testing.M) {
 		Label(label.Multicluster).
 		RequireMinClusters(2).
 		Setup(multicluster.Setup(&controlPlaneValues, &clusterLocalNS, &mcReachabilityNS)).
+		Setup(kube.Setup(func(s *kube.Settings) {
+			// Make all clusters independent
+			s.ControlPlaneTopology = make(map[resource.ClusterIndex]resource.ClusterIndex)
+			for i := 0; i < len(s.KubeConfig); i++ {
+				idx := resource.ClusterIndex(i)
+				s.ControlPlaneTopology[idx] = idx
+			}
+		})).
 		Setup(istio.Setup(&ist, func(cfg *istio.Config) {
 			// Set the control plane values on the config.
 			cfg.ControlPlaneValues = controlPlaneValues

--- a/tests/integration/multicluster/multimaster/main_test.go
+++ b/tests/integration/multicluster/multimaster/main_test.go
@@ -53,17 +53,7 @@ func TestMain(m *testing.M) {
 			// Set the control plane values on the config.
 			cfg.ControlPlaneValues = controlPlaneValues
 		})).
-		Setup(func(ctx resource.Context) (err error) {
-			pilots = make([]pilot.Instance, len(ctx.Environment().Clusters()))
-			for i, cluster := range ctx.Environment().Clusters() {
-				if pilots[i], err = pilot.New(ctx, pilot.Config{
-					Cluster: cluster,
-				}); err != nil {
-					return err
-				}
-			}
-			return nil
-		}).
+		Setup(multicluster.SetupPilots(&pilots)).
 		Run()
 }
 

--- a/tests/integration/multicluster/multimaster/main_test.go
+++ b/tests/integration/multicluster/multimaster/main_test.go
@@ -23,14 +23,12 @@ import (
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/namespace"
-	"istio.io/istio/pkg/test/framework/components/pilot"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
 )
 
 var (
 	ist                              istio.Instance
-	pilots                           []pilot.Instance
 	clusterLocalNS, mcReachabilityNS namespace.Instance
 	controlPlaneValues               string
 )
@@ -53,7 +51,6 @@ func TestMain(m *testing.M) {
 			// Set the control plane values on the config.
 			cfg.ControlPlaneValues = controlPlaneValues
 		})).
-		Setup(pilot.Setup(&pilots, pilot.Config{})).
 		Run()
 }
 

--- a/tests/integration/multicluster/multimaster/main_test.go
+++ b/tests/integration/multicluster/multimaster/main_test.go
@@ -53,7 +53,7 @@ func TestMain(m *testing.M) {
 			// Set the control plane values on the config.
 			cfg.ControlPlaneValues = controlPlaneValues
 		})).
-		Setup(multicluster.SetupPilots(&pilots)).
+		Setup(pilot.Setup(&pilots, pilot.Config{})).
 		Run()
 }
 

--- a/tests/integration/multicluster/remote/main_test.go
+++ b/tests/integration/multicluster/remote/main_test.go
@@ -54,17 +54,7 @@ func TestMain(m *testing.M) {
 			// Set the control plane values on the config.
 			cfg.ControlPlaneValues = controlPlaneValues
 		})).
-		Setup(func(ctx resource.Context) (err error) {
-			pilots = make([]pilot.Instance, len(ctx.Environment().Clusters()))
-			for i, cluster := range ctx.Environment().Clusters() {
-				if pilots[i], err = pilot.New(ctx, pilot.Config{
-					Cluster: cluster,
-				}); err != nil {
-					return err
-				}
-			}
-			return nil
-		}).
+		Setup(multicluster.SetupPilots(&pilots)).
 		Run()
 }
 

--- a/tests/integration/multicluster/remote/main_test.go
+++ b/tests/integration/multicluster/remote/main_test.go
@@ -24,7 +24,6 @@ import (
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/namespace"
-	"istio.io/istio/pkg/test/framework/components/pilot"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
 )

--- a/tests/integration/multicluster/remote/main_test.go
+++ b/tests/integration/multicluster/remote/main_test.go
@@ -31,7 +31,6 @@ import (
 
 var (
 	ist                              istio.Instance
-	pilots                           []pilot.Instance
 	clusterLocalNS, mcReachabilityNS namespace.Instance
 	controlPlaneValues               string
 )
@@ -54,7 +53,6 @@ func TestMain(m *testing.M) {
 			// Set the control plane values on the config.
 			cfg.ControlPlaneValues = controlPlaneValues
 		})).
-		Setup(pilot.Setup(&pilots, pilot.Config{})).
 		Run()
 }
 

--- a/tests/integration/multicluster/remote/main_test.go
+++ b/tests/integration/multicluster/remote/main_test.go
@@ -54,7 +54,7 @@ func TestMain(m *testing.M) {
 			// Set the control plane values on the config.
 			cfg.ControlPlaneValues = controlPlaneValues
 		})).
-		Setup(multicluster.SetupPilots(&pilots)).
+		Setup(pilot.Setup(&pilots, pilot.Config{})).
 		Run()
 }
 

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -118,6 +118,7 @@ Next Step: Add related labels to the deployment to align with Istio's requiremen
 
 func TestWait(t *testing.T) {
 	framework.NewTest(t).Features("usability.observability.wait").
+		RequiresSingleCluster().
 		Run(func(ctx framework.TestContext) {
 			ns := namespace.NewOrFail(t, ctx, namespace.Config{
 				Prefix: "default",
@@ -137,7 +138,7 @@ spec:
     - destination: 
         host: reviews
 `)
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{Cluster: ctx.Environment().Clusters()[0]})
 			istioCtl.InvokeOrFail(t, []string{"x", "wait", "VirtualService", "reviews." + ns.Name()})
 		})
 }
@@ -147,11 +148,11 @@ spec:
 func TestVersion(t *testing.T) {
 	framework.
 		NewTest(t).Features("usability.observability.version").
+		RequiresSingleCluster().
 		Run(func(ctx framework.TestContext) {
 			cfg := i.Settings()
 
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
-
+			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{Cluster: ctx.Environment().Clusters()[0]})
 			args := []string{"version", "--remote=true", fmt.Sprintf("--istioNamespace=%s", cfg.SystemNamespace)}
 
 			output, _ := istioCtl.InvokeOrFail(t, args)
@@ -169,6 +170,7 @@ func TestVersion(t *testing.T) {
 
 func TestDescribe(t *testing.T) {
 	framework.NewTest(t).Features("usability.observability.describe").
+		RequiresSingleCluster().
 		Run(func(ctx framework.TestContext) {
 			deployment := file.AsStringOrFail(t, "../istioctl/testdata/a.yaml")
 			ctx.Config().ApplyYAMLOrFail(t, echoNamespace.Name(), deployment)
@@ -229,6 +231,7 @@ func getPodID(i echo.Instance) (string, error) {
 
 func TestAddToAndRemoveFromMesh(t *testing.T) {
 	framework.NewTest(t).Features("usability.helpers.add-to-mesh", "usability.helpers.remove-from-mesh").
+		RequiresSingleCluster().
 		RunParallel(func(ctx framework.TestContext) {
 			ns := namespace.NewOrFail(t, ctx, namespace.Config{
 				Prefix: "istioctl-add-to-mesh",
@@ -240,7 +243,7 @@ func TestAddToAndRemoveFromMesh(t *testing.T) {
 				With(&a, echoConfig(ns, "a")).
 				BuildOrFail(ctx)
 
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{Cluster: ctx.Environment().Clusters()[0]})
 
 			var output string
 			var args []string
@@ -267,6 +270,7 @@ func TestAddToAndRemoveFromMesh(t *testing.T) {
 
 func TestProxyConfig(t *testing.T) {
 	framework.NewTest(t).Features("usability.observability.proxy-config").
+		RequiresSingleCluster().
 		Run(func(ctx framework.TestContext) {
 			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
 
@@ -330,6 +334,7 @@ func jsonUnmarshallOrFail(t *testing.T, context, s string) interface{} {
 
 func TestProxyStatus(t *testing.T) {
 	framework.NewTest(t).Features("usability.observability.proxy-status").
+		RequiresSingleCluster().
 		Run(func(ctx framework.TestContext) {
 			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
 
@@ -373,12 +378,13 @@ func TestProxyStatus(t *testing.T) {
 
 func TestAuthZCheck(t *testing.T) {
 	framework.NewTest(t).Features("usability.observability.authz-check").
+		RequiresSingleCluster().
 		Run(func(ctx framework.TestContext) {
 			authPol := file.AsStringOrFail(t, "../istioctl/testdata/authz-a.yaml")
 			ctx.Config().ApplyYAMLOrFail(t, echoNamespace.Name(), authPol)
 			defer ctx.Config().DeleteYAMLOrFail(t, echoNamespace.Name(), authPol)
 
-			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
+			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{Cluster: ctx.Environment().Clusters()[0]})
 
 			podID, err := getPodID(a)
 			if err != nil {

--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -19,19 +19,16 @@ import (
 	"testing"
 
 	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
-	"istio.io/istio/pkg/test/framework/components/namespace"
-
-	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
-	"istio.io/istio/pkg/test/framework/components/pilot"
+	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/resource"
 )
 
 var (
 	i istio.Instance
-	p pilot.Instance
 
 	// Namespace echo apps will be deployed
 	echoNamespace namespace.Instance
@@ -53,7 +50,6 @@ var (
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
-		RequireSingleCluster().
 		Setup(istio.Setup(&i, func(cfg *istio.Config) {
 			cfg.ControlPlaneValues = `
 values:
@@ -61,12 +57,6 @@ values:
     meshExpansion:
       enabled: true`
 		})).
-		Setup(func(ctx resource.Context) (err error) {
-			if p, err = pilot.New(ctx, pilot.Config{}); err != nil {
-				return err
-			}
-			return nil
-		}).
 		Setup(func(ctx resource.Context) error {
 			var err error
 			// TODO: allow using an existing namespace to allow repeated runs with 0 setup

--- a/tests/integration/pilot/mirror_test.go
+++ b/tests/integration/pilot/mirror_test.go
@@ -179,6 +179,7 @@ func TestMirroringExternalService(t *testing.T) {
 func runMirrorTest(options mirrorTestOptions) {
 	framework.
 		NewTest(options.t).
+		RequiresSingleCluster().
 		Run(func(ctx framework.TestContext) {
 			ns := namespace.NewOrFail(options.t, ctx, namespace.Config{
 				Prefix: "mirroring",

--- a/tests/integration/pilot/routing_test.go
+++ b/tests/integration/pilot/routing_test.go
@@ -182,6 +182,7 @@ func protocolSniffingCases() []TrafficTestCase {
 func TestTraffic(t *testing.T) {
 	framework.
 		NewTest(t).
+		RequiresSingleCluster().
 		Run(func(ctx framework.TestContext) {
 			cases := []TrafficTestCase{}
 			cases = append(cases, virtualServiceCases()...)

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -58,6 +58,12 @@ ifneq ($(_INTEGRATION_TEST_NETWORKS),)
     _INTEGRATION_TEST_FLAGS += --istio.test.kube.networkTopology=$(_INTEGRATION_TEST_NETWORKS)
 endif
 
+# If $(INTEGRATION_TEST_CONTROLPLANE_TOPOLOGY) is set, add the networkTopology flag
+_INTEGRATION_TEST_CONTROLPLANE_TOPOLOGY ?= $(INTEGRATION_TEST_CONTROLPLANE_TOPOLOGY)
+ifneq ($(_INTEGRATION_TEST_CONTROLPLANE_TOPOLOGY),)
+    _INTEGRATION_TEST_FLAGS += --istio.test.kube.controlPlaneTopology=$(_INTEGRATION_TEST_CONTROLPLANE_TOPOLOGY)
+endif
+
 test.integration.analyze: test.integration...analyze
 
 test.integration.%.analyze: | $(JUNIT_REPORT)


### PR DESCRIPTION
Split the first few commits out from https://github.com/istio/istio/pull/24549 as a first step in breaking up that PR

This PR shouldn't change the behavior of any tests. It just allows us to run `integ-pilot-multicluster-tests_istio` without the whole suite being skipped and incrementally convert pilot tests in separate PRs. 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
