### PR TITLE
WIP: Enable initial auto registration of VMs

### DIFF
--- a/manifests/charts/base/files/gen-istio-cluster.yaml
+++ b/manifests/charts/base/files/gen-istio-cluster.yaml
@@ -3390,6 +3390,9 @@ rules:
   - apiGroups: ["config.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io"]
     verbs: ["get", "watch", "list"]
     resources: ["*"]
+  - apiGroups: ["networking.istio.io"]
+    verbs: ["get", "watch", "list", "update", "create", "delete"]
+    resources: ["workloadentries"]
 
   # auto-detect installed CRD definitions
   - apiGroups: ["apiextensions.k8s.io"]

--- a/manifests/charts/base/templates/clusterrole.yaml
+++ b/manifests/charts/base/templates/clusterrole.yaml
@@ -26,6 +26,9 @@ rules:
     # TODO: should be on just */status but wildcard is not supported
     resources: ["*"]
 {{- end }}
+  - apiGroups: ["networking.istio.io"]
+    verbs: ["get", "watch", "list", "update", "create", "delete"]
+    resources: ["workloadentries"]
 
   # auto-detect installed CRD definitions
   - apiGroups: ["apiextensions.k8s.io"]

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -234,6 +234,11 @@ func NewServer(args *PilotArgs) (*Server, error) {
 		return nil, err
 	}
 
+	if features.EnableAutoRegistration {
+		// TODO maybe aggregate store should allow create so we don't need this hack
+		s.XDSServer.InternalGen.Store = s.ConfigStores[0]
+	}
+
 	s.initJwtPolicy()
 
 	// Options based on the current 'defaults' in istio.

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -203,6 +203,14 @@ var (
 			"users to interrogate which envoy has which config from the debug interface.",
 	).Get()
 
+	EnableAutoRegistration = env.RegisterBoolVar(
+		"ENABLE_AUTO_REGISTRATION",
+		true,
+		"If enabled, Istiod will automatically register connected proxies with the service registry. "+
+			"This is especially useful for VM workloads which are not already a part of the Kubernetes service registry. "+
+			"WARNING: this feature is highly experimental, and does not handle authorization, proper lifecycle management, or scalability. For testing only.",
+	).Get()
+
 	DistributionHistoryRetention = env.RegisterDurationVar(
 		"PILOT_DISTRIBUTION_HISTORY_RETENTION",
 		time.Minute*1,

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -487,6 +487,9 @@ type NodeMetadata struct {
 	// ProxyXDSViaAgent indicates that xds data is being proxied via the agent
 	ProxyXDSViaAgent string `json:"PROXY_XDS_VIA_AGENT,omitempty"`
 
+	// AutoRegister will enable auto registration of the connected endpoint to the service registry
+	AutoRegister StringBool `json:"AUTO_REGISTER,omitempty"`
+
 	// Contains a copy of the raw metadata. This is needed to lookup arbitrary values.
 	// If a value is known ahead of time it should be added to the struct rather than reading from here,
 	Raw map[string]interface{} `json:"-"`

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -446,6 +446,8 @@ func (s *DiscoveryServer) initProxy(node *core.Node) (*model.Proxy, error) {
 	// Update the config namespace associated with this proxy
 	proxy.ConfigNamespace = model.GetProxyConfigNamespace(proxy)
 
+	s.InternalGen.RegisterWorkload(proxy)
+
 	if err = s.setProxyState(proxy, s.globalPushContext()); err != nil {
 		return nil, err
 	}

--- a/pkg/test/framework/components/echo/config.go
+++ b/pkg/test/framework/components/echo/config.go
@@ -80,6 +80,9 @@ type Config struct {
 	// If enabled, dns capture will be enabled on the VM (assuming DeployAsVM is true).
 	DNSCaptureOnVM bool
 
+	// If enabled, the VM will be automatically registered. If disabled, a workload entry will be manually created.
+	AutoRegister bool
+
 	// The image name to be used to pull the image for the VM. `DeployAsVM` must be enabled.
 	VMImage string
 

--- a/releasenotes/notes/vm-auto-registration.yaml
+++ b/releasenotes/notes/vm-auto-registration.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: environments
+releaseNotes:
+- |
+  **Added** support for automatically registering Virtual Machines as `WorkloadEntry`s upon connection. This
+  is experimental and disabled by default. It can be configured by setting `ENABLE_AUTO_REGISTRATION` as an environment
+  variable in Istiod.

--- a/tests/integration/telemetry/stackdriver/vm/main_test.go
+++ b/tests/integration/telemetry/stackdriver/vm/main_test.go
@@ -101,7 +101,7 @@ func testSetup(ctx resource.Context) (err error) {
 
 	err = ctx.Config().ApplyYAML(ns.Name(), sdBootstrap)
 
-	vmLabelsJSON := "{\\\"service.istio.io/canonical-name\\\":\\\"vm-server\\\",\\\"service.istio.io/canonical-revision\\\":\\\"v1\\\"}"
+	vmLabelsJSON := `{"service.istio.io/canonical-name":"vm-server","service.istio.io/canonical-revision":"v1"}`
 
 	vmEnv = map[string]string{
 		"ISTIO_META_INSECURE_STACKDRIVER_ENDPOINT":               sdInst.Address(),


### PR DESCRIPTION
This is an early implementation of https://docs.google.com/document/d/10TyPy-6bOs0_7JljGpc2RneDdsaR9GktjwwaaVbz6fs, without proper authorization or garbage collection/grace periods, intended to get early testing. Should not merge until I make it off by default