### PR TITLE
Add SDS service

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -602,6 +602,10 @@ func (s *Server) initSecureDiscoveryService(args *PilotArgs) error {
 	}
 	log.Info("initializing secure discovery service")
 
+	// TODO: this is too tightly coupled to Spiffee, Istio
+	// networking supports other types of certificates, we do
+	// not require spiffee - just default to it.
+
 	cfg := &tls.Config{
 		GetCertificate: s.getIstiodCertificate,
 		ClientAuth:     tls.VerifyClientCertIfGiven,

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -230,6 +230,11 @@ type Proxy struct {
 		RDS string
 		LDS string
 	}
+
+	// Set to the list of peer authenticated IDs
+	// ( SANs ). The common case is a single spiffee identity,
+	// but for JWT it can be a 'sub' of any type.
+	PeerAuthnIDs []string
 }
 
 // WatchedResource tracks an active DiscoveryRequest subscription.

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -269,6 +269,9 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream discovery.AggregatedD
 	}
 
 	con := newConnection(peerAddr, stream)
+	if ids != nil {
+		con.node.PeerAuthnIDs = ids
+	}
 
 	// Do not call: defer close(con.pushChannel). The push channel will be garbage collected
 	// when the connection is no longer used. Closing the channel can cause subtle race conditions

--- a/pilot/pkg/xds/authentication.go
+++ b/pilot/pkg/xds/authentication.go
@@ -44,6 +44,10 @@ func (s *DiscoveryServer) authenticate(ctx context.Context) ([]string, error) {
 	if _, ok := peerInfo.AuthInfo.(credentials.TLSInfo); !ok {
 		return nil, nil
 	}
+
+	// TODO: move the trust domain verification post-auth,
+	// and check the namespace as well (we only get ns in the first
+	// request).
 	for _, authn := range s.Authenticators {
 		u, err := authn.Authenticate(ctx)
 		// If one authenticator passes, return


### PR DESCRIPTION
Part of moving SDS to istiod. 

Note that normal generators will apply. 

Next step is to add the Generator interface to the code handling secrets. 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
