### PR TITLE
Rename AuthWhiteList and AuthBlackList variables

### DIFF
--- a/pkg/mcp/server/listchecker.go
+++ b/pkg/mcp/server/listchecker.go
@@ -45,10 +45,10 @@ func (*AllowAllChecker) Check(credentials.AuthInfo) error { return nil }
 type AuthListMode bool
 
 const (
-	// AuthDenylist indicates that the list should work as a black list
+	// AuthDenylist indicates that the list should work as a deny list
 	AuthDenylist AuthListMode = false
 
-	// AuthAllowlist indicates that the list should work as a white list
+	// AuthAllowlist indicates that the list should work as an allowlist
 	AuthAllowlist AuthListMode = true
 )
 
@@ -166,9 +166,9 @@ func (l *ListAuthChecker) String() string {
 	result := ""
 	switch l.mode {
 	case AuthAllowlist:
-		result += "Mode: whitelist\n"
+		result += "Mode: allowlist\n"
 	case AuthDenylist:
-		result += "Mode: blacklist\n"
+		result += "Mode: denylist\n"
 	}
 
 	result += "Known ids:\n"
@@ -225,7 +225,7 @@ func (l *ListAuthChecker) check(authInfo credentials.AuthInfo) error {
 						return nil
 					case AuthDenylist:
 						scope.Infof("Blocking access from peer with id: %s", id)
-						return fmt.Errorf("id is blacklisted: %s", id)
+						return fmt.Errorf("id is denylisted: %s", id)
 					}
 				}
 			}

--- a/pkg/mcp/server/listchecker_test.go
+++ b/pkg/mcp/server/listchecker_test.go
@@ -127,7 +127,7 @@ func TestListAuthChecker(t *testing.T) {
 			ids:    []string{"foo"},
 		},
 		{
-			name: "blacklist allow",
+			name: "denylist allow",
 			mode: AuthDenylist,
 			authInfo: credentials.TLSInfo{
 				State: tls.ConnectionState{VerifiedChains: [][]*x509.Certificate{{{}}}},
@@ -138,7 +138,7 @@ func TestListAuthChecker(t *testing.T) {
 			allowed: []string{"foo", "bar", "baz"},
 		},
 		{
-			name: "blacklist block",
+			name: "denylist block",
 			mode: AuthDenylist,
 			authInfo: credentials.TLSInfo{
 				State: tls.ConnectionState{VerifiedChains: [][]*x509.Certificate{{{}}}},
@@ -146,7 +146,7 @@ func TestListAuthChecker(t *testing.T) {
 			extractIDsFn: func(exts []pkix.Extension) ([]string, error) {
 				return []string{"foo"}, nil
 			},
-			err:     "id is blacklisted: foo",
+			err:     "id is denylisted: foo",
 			ids:     []string{"foo"},
 			allowed: []string{"bar", "baz"},
 		},

--- a/pkg/mcp/server/listchecker_test.go
+++ b/pkg/mcp/server/listchecker_test.go
@@ -50,14 +50,14 @@ func TestListAuthChecker(t *testing.T) {
 		},
 		{
 			name:     "empty tlsinfo",
-			mode:     AuthWhiteList,
+			mode:     AuthAllowlist,
 			authInfo: credentials.TLSInfo{},
 			err:      "no allowed identity found in peer's authentication info",
 			ids:      []string{"foo"},
 		},
 		{
 			name: "empty cert chain",
-			mode: AuthWhiteList,
+			mode: AuthAllowlist,
 			authInfo: credentials.TLSInfo{
 				State: tls.ConnectionState{VerifiedChains: [][]*x509.Certificate{{{}}}},
 			},
@@ -67,7 +67,7 @@ func TestListAuthChecker(t *testing.T) {
 		},
 		{
 			name: "error extracting ids",
-			mode: AuthWhiteList,
+			mode: AuthAllowlist,
 			authInfo: credentials.TLSInfo{
 				State: tls.ConnectionState{VerifiedChains: [][]*x509.Certificate{{{}}}},
 			},
@@ -79,7 +79,7 @@ func TestListAuthChecker(t *testing.T) {
 		},
 		{
 			name: "id mismatch",
-			mode: AuthWhiteList,
+			mode: AuthAllowlist,
 			authInfo: credentials.TLSInfo{
 				State: tls.ConnectionState{VerifiedChains: [][]*x509.Certificate{{{}}}},
 			},
@@ -91,7 +91,7 @@ func TestListAuthChecker(t *testing.T) {
 		},
 		{
 			name: "success",
-			mode: AuthWhiteList,
+			mode: AuthAllowlist,
 			authInfo: credentials.TLSInfo{
 				State: tls.ConnectionState{VerifiedChains: [][]*x509.Certificate{{{}}}},
 			},
@@ -103,7 +103,7 @@ func TestListAuthChecker(t *testing.T) {
 		},
 		{
 			name: "success with Set()",
-			mode: AuthWhiteList,
+			mode: AuthAllowlist,
 			authInfo: credentials.TLSInfo{
 				State: tls.ConnectionState{VerifiedChains: [][]*x509.Certificate{{{}}}},
 			},
@@ -115,7 +115,7 @@ func TestListAuthChecker(t *testing.T) {
 		},
 		{
 			name: "removed",
-			mode: AuthWhiteList,
+			mode: AuthAllowlist,
 			authInfo: credentials.TLSInfo{
 				State: tls.ConnectionState{VerifiedChains: [][]*x509.Certificate{{{}}}},
 			},
@@ -128,7 +128,7 @@ func TestListAuthChecker(t *testing.T) {
 		},
 		{
 			name: "blacklist allow",
-			mode: AuthBlackList,
+			mode: AuthDenylist,
 			authInfo: credentials.TLSInfo{
 				State: tls.ConnectionState{VerifiedChains: [][]*x509.Certificate{{{}}}},
 			},
@@ -139,7 +139,7 @@ func TestListAuthChecker(t *testing.T) {
 		},
 		{
 			name: "blacklist block",
-			mode: AuthBlackList,
+			mode: AuthDenylist,
 			authInfo: credentials.TLSInfo{
 				State: tls.ConnectionState{VerifiedChains: [][]*x509.Certificate{{{}}}},
 			},
@@ -184,7 +184,7 @@ func TestListAuthChecker(t *testing.T) {
 			}
 
 			for _, id := range testCase.allowed {
-				if testCase.mode == AuthWhiteList {
+				if testCase.mode == AuthAllowlist {
 					if !c.Allowed(id) {
 						t.Fatalf("Allowed(%v) failed", id)
 					}
@@ -228,12 +228,12 @@ func TestListAuthChecker_Allowed(t *testing.T) {
 		expect bool
 		mode   AuthListMode
 	}{
-		{mode: AuthBlackList, testid: "foo", expect: true},
-		{mode: AuthBlackList, id: "foo", testid: "foo", expect: false},
-		{mode: AuthBlackList, id: "foo", testid: "bar", expect: true},
-		{mode: AuthWhiteList, testid: "foo", expect: false},
-		{mode: AuthWhiteList, id: "foo", testid: "foo", expect: true},
-		{mode: AuthWhiteList, id: "foo", testid: "bar", expect: false},
+		{mode: AuthDenylist, testid: "foo", expect: true},
+		{mode: AuthDenylist, id: "foo", testid: "foo", expect: false},
+		{mode: AuthDenylist, id: "foo", testid: "bar", expect: true},
+		{mode: AuthAllowlist, testid: "foo", expect: false},
+		{mode: AuthAllowlist, id: "foo", testid: "foo", expect: true},
+		{mode: AuthAllowlist, id: "foo", testid: "bar", expect: false},
 	}
 
 	for i, c := range cases {
@@ -261,7 +261,7 @@ func TestListAuthChecker_String(t *testing.T) {
 	}()
 
 	options := DefaultListAuthCheckerOptions()
-	options.AuthMode = AuthBlackList
+	options.AuthMode = AuthDenylist
 	c := NewListAuthChecker(options)
 
 	c.Set("1", "2", "3")
@@ -269,7 +269,7 @@ func TestListAuthChecker_String(t *testing.T) {
 	// Make sure it doesn't crash
 	_ = c.String()
 
-	c.SetMode(AuthWhiteList)
+	c.SetMode(AuthAllowlist)
 
 	// Make sure it doesn't crash
 	_ = c.String()


### PR DESCRIPTION
As part of #25381

The contents of `ListAuthChecker.String()` aren't tested, making this seem safe

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure