### PR TITLE
Split mirrors into separate path in virtualservice analyzers

### DIFF
--- a/galley/pkg/config/analysis/analyzers/virtualservice/destinationhosts.go
+++ b/galley/pkg/config/analysis/analyzers/virtualservice/destinationhosts.go
@@ -75,6 +75,16 @@ func (a *DestinationHostAnalyzer) analyzeVirtualService(r *resource.Instance, ct
 		}
 		checkServiceEntryPorts(ctx, r, d, s)
 	}
+
+	for _, d := range getHTTPMirrorDestinations(vs) {
+		s := util.GetDestinationHost(r.Metadata.FullName.Namespace, d.GetHost(), serviceEntryHosts)
+		if s == nil {
+			ctx.Report(collections.IstioNetworkingV1Alpha3Virtualservices.Name(),
+				msg.NewReferencedResourceNotFound(r, "mirror host", d.GetHost()))
+			continue
+		}
+		checkServiceEntryPorts(ctx, r, d, s)
+	}
 }
 
 func checkServiceEntryPorts(ctx analysis.Context, r *resource.Instance, d *v1alpha3.Destination, s *v1alpha3.ServiceEntry) {

--- a/galley/pkg/config/analysis/analyzers/virtualservice/destinationrules.go
+++ b/galley/pkg/config/analysis/analyzers/virtualservice/destinationrules.go
@@ -61,12 +61,17 @@ func (d *DestinationRuleAnalyzer) analyzeVirtualService(r *resource.Instance, ct
 	vs := r.Message.(*v1alpha3.VirtualService)
 	ns := r.Metadata.FullName.Namespace
 
-	destinations := getRouteDestinations(vs)
-
-	for _, destination := range destinations {
+	for _, destination := range getRouteDestinations(vs) {
 		if !d.checkDestinationSubset(ns, destination, destHostsAndSubsets) {
 			ctx.Report(collections.IstioNetworkingV1Alpha3Virtualservices.Name(),
 				msg.NewReferencedResourceNotFound(r, "host+subset in destinationrule", fmt.Sprintf("%s+%s", destination.GetHost(), destination.GetSubset())))
+		}
+	}
+
+	for _, destination := range getHTTPMirrorDestinations(vs) {
+		if !d.checkDestinationSubset(ns, destination, destHostsAndSubsets) {
+			ctx.Report(collections.IstioNetworkingV1Alpha3Virtualservices.Name(),
+				msg.NewReferencedResourceNotFound(r, "mirror+subset in destinationrule", fmt.Sprintf("%s+%s", destination.GetHost(), destination.GetSubset())))
 		}
 	}
 }

--- a/galley/pkg/config/analysis/analyzers/virtualservice/util.go
+++ b/galley/pkg/config/analysis/analyzers/virtualservice/util.go
@@ -34,9 +34,16 @@ func getRouteDestinations(vs *v1alpha3.VirtualService) []*v1alpha3.Destination {
 		for _, rd := range r.GetRoute() {
 			destinations = append(destinations, rd.GetDestination())
 		}
-		// If there is a mirror destination, check it too
-		m := r.GetMirror()
-		if m != nil {
+	}
+
+	return destinations
+}
+
+func getHTTPMirrorDestinations(vs *v1alpha3.VirtualService) []*v1alpha3.Destination {
+	var destinations []*v1alpha3.Destination
+
+	for _, r := range vs.GetHttp() {
+		if m := r.GetMirror(); m != nil {
 			destinations = append(destinations, m)
 		}
 	}


### PR DESCRIPTION
Fixes #25440, unblocks #22872. Changes mirror hosts to be distinct from other hosts.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure
