### PR TITLE
Fix breakage in istioctl manifest apply

### DIFF
--- a/operator/cmd/mesh/manifest-generate.go
+++ b/operator/cmd/mesh/manifest-generate.go
@@ -129,7 +129,12 @@ func manifestGenerate(args *rootArgs, mgArgs *manifestGenerateArgs, logopts *log
 // supplied logger.
 func GenManifests(inFilename []string, setOverlay []string, force bool,
 	kubeConfig *rest.Config, l clog.Logger) (name.ManifestMap, *v1alpha1.IstioOperatorSpec, error) {
-	mergedYAML, _, err := GenerateConfig(inFilename, setOverlay, force, kubeConfig, l)
+	mergedYAML, _, err := GenerateConfig(GenerateConfigOptions{
+		InFilenames: inFilename,
+		SetOverlay:  setOverlay,
+		Force:       force,
+		KubeConfig:  kubeConfig,
+	}, l)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -650,7 +650,10 @@ func TestLDFlags(t *testing.T) {
 	version.DockerInfo.Hub = "testHub"
 	version.DockerInfo.Tag = "testTag"
 	l := clog.NewConsoleLogger(os.Stdout, os.Stderr, installerScope)
-	_, iops, err := GenerateConfig(nil, []string{"installPackagePath=" + string(liveCharts)}, true, nil, l)
+	_, iops, err := GenerateConfig(GenerateConfigOptions{
+		SetOverlay: []string{"installPackagePath=" + string(liveCharts)},
+		Force:      true,
+	}, l)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/operator/cmd/mesh/profile-common.go
+++ b/operator/cmd/mesh/profile-common.go
@@ -36,6 +36,14 @@ import (
 	pkgversion "istio.io/pkg/version"
 )
 
+// GenerateConfigOptions provides options for the generate command.
+type GenerateConfigOptions struct {
+	InFilenames []string
+	SetOverlay  []string
+	Force       bool
+	KubeConfig  *rest.Config
+}
+
 // GenerateConfig creates an IstioOperatorSpec from the following sources, overlaid sequentially:
 // 1. Compiled in base, or optionally base from paths pointing to one or multiple ICP/IOP files at inFilenames.
 // 2. Profile overlay, if non-default overlay is selected. This also comes either from compiled in or path specified in IOP contained in inFilenames.
@@ -47,18 +55,17 @@ import (
 // Otherwise it will be the compiled in profile YAMLs.
 // In step 3, the remaining fields in the same user overlay are applied on the resulting profile base.
 // The force flag causes validation errors not to abort but only emit log/console warnings.
-func GenerateConfig(inFilenames, setOverlay []string, force bool, kubeConfig *rest.Config,
-	l clog.Logger) (string, *v1alpha1.IstioOperatorSpec, error) {
-	if err := validateSetFlags(setOverlay); err != nil {
+func GenerateConfig(opts GenerateConfigOptions, l clog.Logger) (string, *v1alpha1.IstioOperatorSpec, error) {
+	if err := validateSetFlags(opts.SetOverlay); err != nil {
 		return "", nil, err
 	}
 
-	fy, profile, err := readYamlProfile(inFilenames, setOverlay, force, l)
+	fy, profile, err := readYamlProfile(opts.InFilenames, opts.SetOverlay, opts.Force, l)
 	if err != nil {
 		return "", nil, err
 	}
 
-	iopsString, iops, err := genIOPSFromProfile(profile, fy, setOverlay, force, kubeConfig, l)
+	iopsString, iops, err := genIOPSFromProfile(profile, fy, opts.SetOverlay, opts.Force, opts.KubeConfig, l)
 	if err != nil {
 		return "", nil, err
 	}

--- a/operator/cmd/mesh/profile-dump.go
+++ b/operator/cmd/mesh/profile-dump.go
@@ -129,8 +129,11 @@ func profileDump(args []string, rootArgs *rootArgs, pdArgs *profileDumpArgs, l c
 	if len(args) == 1 {
 		setFlags = append(setFlags, "profile="+args[0])
 	}
-
-	y, _, err := GenerateConfig(pdArgs.inFilenames, setFlags, true, nil, l)
+	y, _, err := GenerateConfig(GenerateConfigOptions{
+		InFilenames: pdArgs.inFilenames,
+		SetOverlay:  setFlags,
+		Force:       true,
+	}, l)
 	if err != nil {
 		return err
 	}

--- a/operator/cmd/mesh/shared.go
+++ b/operator/cmd/mesh/shared.go
@@ -161,7 +161,9 @@ func getCRAndNamespaceFromFile(filePath string, l clog.Logger) (customResource s
 		return "", "", nil
 	}
 
-	_, mergedIOPS, err := GenerateConfig([]string{filePath}, nil, false, nil, l)
+	_, mergedIOPS, err := GenerateConfig(GenerateConfigOptions{
+		InFilenames: []string{filePath},
+	}, l)
 	if err != nil {
 		return "", "", err
 	}

--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -136,7 +136,11 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 	}
 	setFlags := applyFlagAliases(args.set, args.manifestsPath, "")
 	// Generate IOPS parseObjectSetFromManifest
-	targetIOPSYaml, targetIOPS, err := GenerateConfig(args.inFilenames, setFlags, args.force, nil, l)
+	targetIOPSYaml, targetIOPS, err := GenerateConfig(GenerateConfigOptions{
+		InFilenames: args.inFilenames,
+		SetOverlay:  setFlags,
+		Force:       args.force,
+	}, l)
 	if err != nil {
 		return fmt.Errorf("failed to generate Istio configs from file %s, error: %s", args.inFilenames, err)
 	}
@@ -206,8 +210,14 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 	waitForConfirmation(args.skipConfirmation, l)
 
 	// Apply the Istio Control Plane specs reading from inFilenames to the cluster
-	err = ApplyManifests(applyFlagAliases(args.set, args.manifestsPath, ""), args.inFilenames, args.force, rootArgs.dryRun,
-		client, args.readinessTimeout, l)
+	err = ApplyManifests(ApplyManifestsOptions{
+		Client:      nil,
+		InFilenames: args.inFilenames,
+		SetOverlay:  applyFlagAliases(args.set, args.manifestsPath, ""),
+		Force:       args.force,
+		DryRun:      rootArgs.dryRun,
+		WaitTimeout: args.readinessTimeout,
+	}, l)
 	if err != nil {
 		return fmt.Errorf("failed to apply the Istio Control Plane specs. Error: %v", err)
 	}

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -498,7 +498,14 @@ func applyManifest(ctx resource.Context, inFiles, setOverlay []string, cluster r
 	}
 
 	scopes.Framework.Infof("Running istio control plane on cluster %s", cluster.Name())
-	err = mesh.ApplyManifests(inFiles, setOverlay, false, false, cluster, 300*time.Second, l)
+	err = mesh.ApplyManifests(mesh.ApplyManifestsOptions{
+		Client:      cluster,
+		InFilenames: inFiles,
+		SetOverlay:  setOverlay,
+		Force:       false,
+		DryRun:      false,
+		WaitTimeout: 300 * time.Second,
+	}, l)
 	if err != nil {
 		return fmt.Errorf("manifest apply failed: %v", err)
 	}


### PR DESCRIPTION
This was introduced by #25384. The issue was that the parameter order was swapped in order to be consistent with GenerateConfig (and a few other places). There was apparently no test coverage for this beyond the integration test framework's usage when installing istio. Unfortunately, we don't want to use the commands directly there because the use of flags interferes with the ability to install multiple control planes in parallel.

Fixing the issue by swapping to a structure for the parameter to avoid similar breakage in the future.

Fixes #25447



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure