### PR TITLE
Don't complain about unknown keys on in-cluster IOP

### DIFF
--- a/istioctl/pkg/install/pre-check.go
+++ b/istioctl/pkg/install/pre-check.go
@@ -472,7 +472,7 @@ func getIOPFromFile(filename string) (*operator_v1alpha1.IstioOperator, error) {
 
 	un.SetCreationTimestamp(meta_v1.Time{}) // UnmarshalIstioOperator chokes on these
 	by := util.ToYAML(un)
-	iop, err := operator_istio.UnmarshalIstioOperator(by)
+	iop, err := operator_istio.UnmarshalIstioOperator(by, true)
 	if err != nil {
 		return nil, err
 	}

--- a/istioctl/pkg/validate/validate.go
+++ b/istioctl/pkg/validate/validate.go
@@ -186,7 +186,7 @@ func (v *validator) validateResource(istioNamespace string, un *unstructured.Uns
 			// and ask operator code to check.
 			un.SetCreationTimestamp(metav1.Time{}) // UnmarshalIstioOperator chokes on these
 			by := util.ToYAML(un)
-			iop, err := operator_istio.UnmarshalIstioOperator(by)
+			iop, err := operator_istio.UnmarshalIstioOperator(by, false)
 			if err != nil {
 				return err
 			}

--- a/operator/pkg/apis/istio/common.go
+++ b/operator/pkg/apis/istio/common.go
@@ -38,9 +38,9 @@ func UnmarshalAndValidateIOPS(iopsYAML string) (*v1alpha1.IstioOperatorSpec, err
 }
 
 // UnmarshalIstioOperator unmarshals a string containing IstioOperator YAML.
-func UnmarshalIstioOperator(iopYAML string) (*operator_v1alpha1.IstioOperator, error) {
+func UnmarshalIstioOperator(iopYAML string, allowUnknownField bool) (*operator_v1alpha1.IstioOperator, error) {
 	iop := &operator_v1alpha1.IstioOperator{}
-	if err := util.UnmarshalWithJSONPB(iopYAML, iop, false); err != nil {
+	if err := util.UnmarshalWithJSONPB(iopYAML, iop, allowUnknownField); err != nil {
 		return nil, fmt.Errorf("could not unmarshal: %s\n\nYAML:\n%s", err, iopYAML)
 	}
 	return iop, nil

--- a/operator/pkg/helm/vfs_renderer.go
+++ b/operator/pkg/helm/vfs_renderer.go
@@ -176,7 +176,7 @@ func ListProfiles(charts string) ([]string, error) {
 func CheckCompiledInCharts() error {
 	if _, err := vfs.Stat(ChartsSubdirName); err != nil {
 		return fmt.Errorf("compiled in charts not found in this development build, use --manifests with " +
-			"local charts instead (e.g. istioctl install --charts manifests/) or run make gen-charts and rebuild istioctl")
+			"local charts instead (e.g. istioctl install --manifests manifests/) or run make gen-charts and rebuild istioctl")
 	}
 	return nil
 }


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/25194

This PR does two things.

First, it relaxes the in-cluster IOP read, so that it doesn't freak out if passed a cluster with a value such as spec.components.citadel.

Second it adds `--manifests <dir>` for `istioctl verify-install`, which is needed to allow dev builds to be tested.
