### PR TITLE
Track deprecated Istio types

### DIFF
--- a/galley/pkg/config/testing/basicmeta/collections.gen.go
+++ b/galley/pkg/config/testing/basicmeta/collections.gen.go
@@ -67,4 +67,8 @@ var (
 	// PilotServiceApi contains only collections used by Pilot, including experimental Service Api.
 	PilotServiceApi = collection.NewSchemasBuilder().
 			Build()
+
+	// Deprecated contains only collections used by that will soon be used by nothing.
+	Deprecated = collection.NewSchemasBuilder().
+			Build()
 )

--- a/galley/pkg/config/testing/k8smeta/collections.gen.go
+++ b/galley/pkg/config/testing/k8smeta/collections.gen.go
@@ -164,4 +164,8 @@ var (
 	// PilotServiceApi contains only collections used by Pilot, including experimental Service Api.
 	PilotServiceApi = collection.NewSchemasBuilder().
 			Build()
+
+	// Deprecated contains only collections used by that will soon be used by nothing.
+	Deprecated = collection.NewSchemasBuilder().
+			Build()
 )

--- a/pkg/config/schema/ast/ast.go
+++ b/pkg/config/schema/ast/ast.go
@@ -46,6 +46,7 @@ type Collection struct {
 	Kind         string `json:"kind"`
 	Disabled     bool   `json:"disabled"`
 	Pilot        bool   `json:"pilot"`
+	Deprecated   bool   `json:"deprecated"`
 }
 
 // Snapshot metadata. Describes the snapshots that should be produced.

--- a/pkg/config/schema/codegen/collections.go
+++ b/pkg/config/schema/codegen/collections.go
@@ -113,6 +113,15 @@ var (
 		{{- end}}
 	{{- end }}
 		Build()
+
+	// Deprecated contains only collections used by that will soon be used by nothing.
+	Deprecated = collection.NewSchemasBuilder().
+	{{- range .Entries }}
+		{{- if .Collection.Deprecated }}
+		MustAdd({{ .Collection.VariableName }}).
+		{{- end}}
+	{{- end }}
+		Build()
 )
 `
 

--- a/pkg/config/schema/codegen/collections_test.go
+++ b/pkg/config/schema/codegen/collections_test.go
@@ -145,6 +145,10 @@ var (
 	// PilotServiceApi contains only collections used by Pilot, including experimental Service Api.
 	PilotServiceApi = collection.NewSchemasBuilder().
 		Build()
+
+	// Deprecated contains only collections used by that will soon be used by nothing.
+	Deprecated = collection.NewSchemasBuilder().
+		Build()
 )
 `,
 		},

--- a/pkg/config/schema/collections/collections.gen.go
+++ b/pkg/config/schema/collections/collections.gen.go
@@ -1195,4 +1195,16 @@ var (
 			MustAdd(K8SServiceApisV1Alpha1Tcproutes).
 			MustAdd(K8SServiceApisV1Alpha1Trafficsplits).
 			Build()
+
+	// Deprecated contains only collections used by that will soon be used by nothing.
+	Deprecated = collection.NewSchemasBuilder().
+			MustAdd(IstioConfigV1Alpha2Adapters).
+			MustAdd(IstioConfigV1Alpha2Httpapispecbindings).
+			MustAdd(IstioConfigV1Alpha2Httpapispecs).
+			MustAdd(IstioConfigV1Alpha2Templates).
+			MustAdd(IstioPolicyV1Beta1Attributemanifests).
+			MustAdd(IstioPolicyV1Beta1Handlers).
+			MustAdd(IstioPolicyV1Beta1Instances).
+			MustAdd(IstioPolicyV1Beta1Rules).
+			Build()
 )

--- a/pkg/config/schema/collections/collections.gen.go
+++ b/pkg/config/schema/collections/collections.gen.go
@@ -1202,6 +1202,8 @@ var (
 			MustAdd(IstioConfigV1Alpha2Httpapispecbindings).
 			MustAdd(IstioConfigV1Alpha2Httpapispecs).
 			MustAdd(IstioConfigV1Alpha2Templates).
+			MustAdd(IstioMixerV1ConfigClientQuotaspecbindings).
+			MustAdd(IstioMixerV1ConfigClientQuotaspecs).
 			MustAdd(IstioPolicyV1Beta1Attributemanifests).
 			MustAdd(IstioPolicyV1Beta1Handlers).
 			MustAdd(IstioPolicyV1Beta1Instances).

--- a/pkg/config/schema/metadata.gen.go
+++ b/pkg/config/schema/metadata.gen.go
@@ -78,20 +78,24 @@ collections:
   - name: "istio/config/v1alpha2/adapters"
     kind: "adapter"
     group: "config.istio.io"
+    deprecated: true
 
   - name: "istio/config/v1alpha2/httpapispecs"
     kind: "HTTPAPISpec"
     group: "config.istio.io"
     pilot: true
+    deprecated: true
 
   - name: "istio/config/v1alpha2/httpapispecbindings"
     kind: "HTTPAPISpecBinding"
     group: "config.istio.io"
     pilot: true
+    deprecated: true
 
   - name: "istio/config/v1alpha2/templates"
     kind: "template"
     group: "config.istio.io"
+    deprecated: true
 
   - name: "istio/mesh/v1alpha1/MeshConfig"
     kind: "MeshConfig"
@@ -149,18 +153,22 @@ collections:
   - name: "istio/policy/v1beta1/attributemanifests"
     kind: "attributemanifest"
     group: "config.istio.io"
+    deprecated: true
 
   - name: "istio/policy/v1beta1/instances"
     kind: "instance"
     group: "config.istio.io"
+    deprecated: true
 
   - name: "istio/policy/v1beta1/handlers"
     kind: "handler"
     group: "config.istio.io"
+    deprecated: true
 
   - name: "istio/policy/v1beta1/rules"
     kind: "rule"
     group: "config.istio.io"
+    deprecated: true
 
   - name: "istio/security/v1beta1/authorizationpolicies"
     kind: "AuthorizationPolicy"

--- a/pkg/config/schema/metadata.gen.go
+++ b/pkg/config/schema/metadata.gen.go
@@ -109,11 +109,13 @@ collections:
     kind: "QuotaSpec"
     group: "config.istio.io"
     pilot: true
+    deprecated: true
 
   - name: "istio/mixer/v1/config/client/quotaspecbindings"
     kind: "QuotaSpecBinding"
     group: "config.istio.io"
     pilot: true
+    deprecated: true
 
   - name: "istio/networking/v1alpha3/destinationrules"
     kind: "DestinationRule"

--- a/pkg/config/schema/metadata.yaml
+++ b/pkg/config/schema/metadata.yaml
@@ -54,11 +54,13 @@ collections:
     kind: "QuotaSpec"
     group: "config.istio.io"
     pilot: true
+    deprecated: true
 
   - name: "istio/mixer/v1/config/client/quotaspecbindings"
     kind: "QuotaSpecBinding"
     group: "config.istio.io"
     pilot: true
+    deprecated: true
 
   - name: "istio/networking/v1alpha3/destinationrules"
     kind: "DestinationRule"

--- a/pkg/config/schema/metadata.yaml
+++ b/pkg/config/schema/metadata.yaml
@@ -23,20 +23,24 @@ collections:
   - name: "istio/config/v1alpha2/adapters"
     kind: "adapter"
     group: "config.istio.io"
+    deprecated: true
 
   - name: "istio/config/v1alpha2/httpapispecs"
     kind: "HTTPAPISpec"
     group: "config.istio.io"
     pilot: true
+    deprecated: true
 
   - name: "istio/config/v1alpha2/httpapispecbindings"
     kind: "HTTPAPISpecBinding"
     group: "config.istio.io"
     pilot: true
+    deprecated: true
 
   - name: "istio/config/v1alpha2/templates"
     kind: "template"
     group: "config.istio.io"
+    deprecated: true
 
   - name: "istio/mesh/v1alpha1/MeshConfig"
     kind: "MeshConfig"
@@ -94,18 +98,22 @@ collections:
   - name: "istio/policy/v1beta1/attributemanifests"
     kind: "attributemanifest"
     group: "config.istio.io"
+    deprecated: true
 
   - name: "istio/policy/v1beta1/instances"
     kind: "instance"
     group: "config.istio.io"
+    deprecated: true
 
   - name: "istio/policy/v1beta1/handlers"
     kind: "handler"
     group: "config.istio.io"
+    deprecated: true
 
   - name: "istio/policy/v1beta1/rules"
     kind: "rule"
     group: "config.istio.io"
+    deprecated: true
 
   - name: "istio/security/v1beta1/authorizationpolicies"
     kind: "AuthorizationPolicy"


### PR DESCRIPTION
This PR is an experiment.  The idea is to mark deprecated Istio types in the schema, and use that information in the deprecation analyzer.

If approved this would be used in conjunction with a second PR to enable the `istioctl analyze` for https://github.com/istio/istio/issues/24471 .