### PR TITLE
Cleanup RequireCerts from SDS Agent

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -280,11 +280,6 @@ var (
 			sa := istio_agent.NewAgent(&proxyConfig,
 				&istio_agent.AgentConfig{}, secOpts)
 
-			// Connection to Istiod secure port
-			if sa.RequireCerts {
-				proxyConfig.ControlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS
-			}
-
 			var pilotSAN, mixerSAN []string
 			if proxyConfig.ControlPlaneAuthPolicy == meshconfig.AuthenticationPolicy_MUTUAL_TLS {
 				setSpiffeTrustDomain(podNamespace, role.DNSDomain)

--- a/pkg/istio-agent/sds-agent.go
+++ b/pkg/istio-agent/sds-agent.go
@@ -92,11 +92,6 @@ type Agent struct {
 	// CertPath is set with the location of the certs, or empty if mounted certs are not present.
 	CertsPath string
 
-	// RequireCerts is set if the agent requires certificates:
-	// - if controlPlaneAuthEnabled is set
-	// - port of discovery server is not 15010 (the plain text default).
-	RequireCerts bool
-
 	// RootCert is the CA root certificate. It is loaded part of detecting the
 	// SDS operating mode - may be the Citadel CA, Kubernentes CA or a custom
 	// CA. If not set it should be assumed we are using a public certificate (like ACME).
@@ -169,11 +164,6 @@ func NewAgent(proxyConfig *mesh.ProxyConfig, cfg *AgentConfig, sopts *security.O
 
 	sa.SDSAddress = "unix:" + LocalSDS
 
-	_, discPort, err := net.SplitHostPort(discAddr)
-	if err != nil {
-		log.Fatalf("Invalid discovery address %v %v", discAddr, err)
-	}
-
 	// Auth logic for istio-agent to Cert provider:
 	// - if PROV_CERT is set, it'll be included in the TLS context sent to the server
 	//   This is a 'provisioning certificate' - long lived, managed by a tool, exchanged for
@@ -207,21 +197,15 @@ func NewAgent(proxyConfig *mesh.ProxyConfig, cfg *AgentConfig, sopts *security.O
 		sa.secOpts.CAEndpoint = discAddr
 	}
 
-	// TODO: tls should be required in all cases except ":15010" port - it is mainly for debugging/tests.
-	if proxyConfig.ControlPlaneAuthPolicy == mesh.AuthenticationPolicy_MUTUAL_TLS {
-		sa.RequireCerts = true
-	}
-
-	// Istiod uses a fixed, defined port for K8S-signed certificates.
-	// TODO do not special case port 15012
-	if discPort == "15012" {
-		sa.RequireCerts = true
-	}
-
 	// Next to the envoy config, writeable dir (mounted as mem)
 	sa.secOpts.WorkloadUDSPath = LocalSDS
 	sa.secOpts.CertsDir = sa.CertsPath
-	sa.secOpts.TLSEnabled = sa.RequireCerts
+	// Set TLSEnabled if the ControlPlaneAuthPolicy is set to MUTUAL_TLS
+	if sa.proxyConfig.ControlPlaneAuthPolicy == mesh.AuthenticationPolicy_MUTUAL_TLS {
+		sa.secOpts.TLSEnabled = true
+	} else {
+		sa.secOpts.TLSEnabled = false
+	}
 	// If proxy is using file mounted certs, JWT token is not needed.
 	if sa.secOpts.FileMountedCerts {
 		sa.secOpts.UseLocalJWT = false

--- a/pkg/istio-agent/xds-agent.go
+++ b/pkg/istio-agent/xds-agent.go
@@ -125,10 +125,13 @@ func (sa *Agent) startXDS(proxyConfig *meshconfig.ProxyConfig, secrets security.
 		XDSSAN:          discHost,
 		ResponseHandler: sa.proxyGen,
 	}
-	if sa.RequireCerts {
+
+	// Set Secrets and JWTPath if the default ControlPlaneAuthPolicy is MUTUAL_TLS
+	if sa.proxyConfig.ControlPlaneAuthPolicy == meshconfig.AuthenticationPolicy_MUTUAL_TLS {
 		cfg.Secrets = secrets
 		cfg.JWTPath = sa.secOpts.JWTPath
 	}
+
 	ads, err := adsc.New(proxyConfig, cfg)
 	if err != nil {
 		// Error to be handled by caller - probably by exit if


### PR DESCRIPTION
Based on https://github.com/istio/istio/pull/25411#pullrequestreview-446234102, As the default `ControlPlaneAuthPolicy` is `MUTUAL_TLS`. There is no need for setting `RequireCerts` in SDS Agent.

Ref PR:
https://github.com/istio/istio/pull/25411
https://github.com/istio/api/pull/1493