### PR TITLE
gateway: do not compute snihosts for service repeatedly

### DIFF
--- a/pilot/pkg/model/gateway.go
+++ b/pilot/pkg/model/gateway.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -47,6 +48,9 @@ type MergedGateway struct {
 	// Inverse of ServersByRouteName. Returning this as part of merge result allows to keep route name generation logic
 	// encapsulated within the model and, as a side effect, to avoid generating route names twice.
 	RouteNamesByServer map[*networking.Server]string
+
+	// SNIHostsByServer maps server to SNI Hosts so that recomputation is avoided on listener generation.
+	SNIHostsByServer map[*networking.Server][]string
 }
 
 var (
@@ -81,6 +85,7 @@ func MergeGateways(gateways ...Config) *MergedGateway {
 	routeNamesByServer := make(map[*networking.Server]string)
 	gatewayNameForServer := make(map[*networking.Server]string)
 	tlsHostsByPort := map[uint32]map[string]struct{}{} // port -> host -> exists
+	sniHostsByServer := make(map[*networking.Server][]string)
 
 	log.Debugf("MergeGateways: merging %d gateways", len(gateways))
 	for _, gatewayConfig := range gateways {
@@ -95,6 +100,7 @@ func MergeGateways(gateways ...Config) *MergedGateway {
 			log.Debugf("MergeGateways: gateway %q processing server %v", gatewayName, s.Hosts)
 			p := protocol.Parse(s.Port.Protocol)
 
+			sniHostsByServer[s] = getSNIHostsForServer(s)
 			if s.Tls != nil {
 				// Envoy will reject config that has multiple filter chain matches with the same matching rules
 				// To avoid this, we need to make sure we don't have duplicated hosts, which will become
@@ -200,11 +206,37 @@ func MergeGateways(gateways ...Config) *MergedGateway {
 		GatewayNameForServer: gatewayNameForServer,
 		ServersByRouteName:   serversByRouteName,
 		RouteNamesByServer:   routeNamesByServer,
+		SNIHostsByServer:     sniHostsByServer,
 	}
 }
 
 func canMergeProtocols(current protocol.Instance, p protocol.Instance) bool {
 	return (current.IsHTTP() || current == p) && p.IsHTTP()
+}
+
+func getSNIHostsForServer(server *networking.Server) []string {
+	if server.Tls == nil {
+		return nil
+	}
+	// sanitize the server hosts as it could contain hosts of form ns/host
+	sniHosts := make(map[string]bool)
+	for _, h := range server.Hosts {
+		if strings.Contains(h, "/") {
+			parts := strings.Split(h, "/")
+			h = parts[1]
+		}
+		// do not add hosts, that have already been added
+		if !sniHosts[h] {
+			sniHosts[h] = true
+		}
+	}
+	sniHostsSlice := make([]string, 0, len(sniHosts))
+	for host := range sniHosts {
+		sniHostsSlice = append(sniHostsSlice, host)
+	}
+	sort.Strings(sniHostsSlice)
+
+	return sniHostsSlice
 }
 
 // checkDuplicates returns all of the hosts provided that are already known

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -16,7 +16,6 @@ package v1alpha3
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -380,7 +379,7 @@ func (configgen *ConfigGeneratorImpl) createGatewayHTTPFilterChainOpts(
 		// This works because we validate that only HTTPS servers can have same port but still different port names
 		// and that no two non-HTTPS servers can be on same port or share port names.
 		// Validation is done per gateway and also during merging
-		sniHosts:   getSNIHostsForServer(server),
+		sniHosts:   node.MergedGateway.SNIHostsByServer[server],
 		tlsContext: buildGatewayListenerTLSContext(server, sdsPath, node.Metadata),
 		httpOpts: &httpListenerOpts{
 			rds:              routeName,
@@ -525,7 +524,7 @@ func (configgen *ConfigGeneratorImpl) createGatewayTCPFilterChainOpts(
 			push, server, gatewayName); len(filters) > 0 {
 			return []*filterChainOpts{
 				{
-					sniHosts:       getSNIHostsForServer(server),
+					sniHosts:       node.MergedGateway.SNIHostsByServer[server],
 					tlsContext:     buildGatewayListenerTLSContext(server, push.Mesh.SdsUdsPath, node.Metadata),
 					networkFilters: filters,
 				},
@@ -601,7 +600,7 @@ func buildGatewayNetworkFiltersFromTLSRoutes(node *model.Proxy, push *model.Push
 	if server.Tls.Mode == networking.ServerTLSSettings_AUTO_PASSTHROUGH {
 		// auto passthrough does not require virtual services. It sets up envoy.filters.network.sni_cluster filter
 		filterChains = append(filterChains, &filterChainOpts{
-			sniHosts:       getSNIHostsForServer(server),
+			sniHosts:       node.MergedGateway.SNIHostsByServer[server],
 			tlsContext:     nil, // NO TLS context because this is passthrough
 			networkFilters: buildOutboundAutoPassthroughFilterStack(push, node, port),
 		})
@@ -720,31 +719,6 @@ func isGatewayMatch(gateway string, gatewayNames []string) bool {
 		}
 	}
 	return false
-}
-
-func getSNIHostsForServer(server *networking.Server) []string {
-	if server.Tls == nil {
-		return nil
-	}
-	// sanitize the server hosts as it could contain hosts of form ns/host
-	sniHosts := make(map[string]bool)
-	for _, h := range server.Hosts {
-		if strings.Contains(h, "/") {
-			parts := strings.Split(h, "/")
-			h = parts[1]
-		}
-		// do not add hosts, that have already been added
-		if !sniHosts[h] {
-			sniHosts[h] = true
-		}
-	}
-	sniHostsSlice := make([]string, 0, len(sniHosts))
-	for host := range sniHosts {
-		sniHostsSlice = append(sniHostsSlice, host)
-	}
-	sort.Strings(sniHostsSlice)
-
-	return sniHostsSlice
 }
 
 func buildGatewayVirtualHostDomains(hostname string) []string {


### PR DESCRIPTION
Store SniHosts by Server in MergedGateway to avoid recomputation of sni hosts per server
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
