### PR TITLE
cleanup ingress test component

### DIFF
--- a/pkg/test/framework/components/ingress/kube.go
+++ b/pkg/test/framework/components/ingress/kube.go
@@ -74,7 +74,7 @@ func (c *kubeComponent) getAddressInner(ns string, port int) (interface{}, bool,
 			return nil, false, fmt.Errorf("no ingress pod found")
 		}
 
-		scopes.Framework.Debugf("Found pod: \n%v\n", pods.Items[0])
+		scopes.Framework.Debugf("Found pod: \n%v\n", pods.Items[0].Name)
 		ip := pods.Items[0].Status.HostIP
 		if ip == "" {
 			return nil, false, fmt.Errorf("no Host IP available on the ingress node yet")
@@ -131,7 +131,7 @@ func getHTTPSAddressInner(env *kube.Environment, ns string) (interface{}, bool, 
 			return nil, false, fmt.Errorf("no ingress pod found")
 		}
 
-		scopes.Framework.Debugf("Found pod: \n%+v\n", pods.Items[0])
+		scopes.Framework.Debugf("Found pod: \n%+v\n", pods.Items[0].Name)
 		ip := pods.Items[0].Status.HostIP
 		if ip == "" {
 			return nil, false, fmt.Errorf("no Host IP available on the ingress node yet")

--- a/pkg/test/framework/components/ingress/kube.go
+++ b/pkg/test/framework/components/ingress/kube.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	corev1 "k8s.io/api/core/v1"
 	"net"
 	"net/http"
 	"strconv"

--- a/pkg/test/framework/components/ingress/kube.go
+++ b/pkg/test/framework/components/ingress/kube.go
@@ -123,62 +123,6 @@ func (c *kubeComponent) getAddressInner(ns string, port int) (interface{}, bool,
 	return net.TCPAddr{IP: net.ParseIP(ip), Port: port}, true, nil
 }
 
-// getHTTPSAddressInner returns the ingress gateway address for https requests.
-func getHTTPSAddressInner(env *kube.Environment, ns string) (interface{}, bool, error) {
-	if env.Settings().Minikube {
-		pods, err := env.KubeClusters[0].PodsForSelector(context.TODO(), ns, fmt.Sprintf("istio=%s", istioLabel))
-		if err != nil {
-			return nil, false, err
-		}
-
-		scopes.Framework.Debugf("Querying ingress, pods:\n%+v\n", pods.Items)
-		if len(pods.Items) == 0 {
-			return nil, false, fmt.Errorf("no ingress pod found")
-		}
-
-		scopes.Framework.Debugf("Found pod: \n%+v\n", pods.Items[0].Name)
-		ip := pods.Items[0].Status.HostIP
-		if ip == "" {
-			return nil, false, fmt.Errorf("no Host IP available on the ingress node yet")
-		}
-
-		svc, err := env.KubeClusters[0].CoreV1().Services(ns).Get(context.TODO(), serviceName, kubeApiMeta.GetOptions{})
-		if err != nil {
-			return nil, false, err
-		}
-
-		scopes.Framework.Debugf("Found service for the gateway:\n%+v\n", svc)
-		if len(svc.Spec.Ports) == 0 {
-			return nil, false, fmt.Errorf("no ports found in service: %s/%s", ns, "istio-ingressgateway")
-		}
-
-		var nodePort int32
-		for _, svcPort := range svc.Spec.Ports {
-			if svcPort.Protocol == "TCP" && svcPort.Port == 443 {
-				nodePort = svcPort.NodePort
-				break
-			}
-		}
-		if nodePort == 0 {
-			return nil, false, fmt.Errorf("no port 80 found in service: %s/%s", ns, "istio-ingressgateway")
-		}
-
-		return net.TCPAddr{IP: net.ParseIP(ip), Port: int(nodePort)}, true, nil
-	}
-
-	svc, err := env.KubeClusters[0].CoreV1().Services(ns).Get(context.TODO(), serviceName, kubeApiMeta.GetOptions{})
-	if err != nil {
-		return nil, false, err
-	}
-
-	if len(svc.Status.LoadBalancer.Ingress) == 0 || svc.Status.LoadBalancer.Ingress[0].IP == "" {
-		return nil, false, fmt.Errorf("service ingress is not available yet: %s/%s", svc.Namespace, svc.Name)
-	}
-
-	ip := svc.Status.LoadBalancer.Ingress[0].IP
-	return net.TCPAddr{IP: net.ParseIP(ip), Port: 443}, true, nil
-}
-
 func newKube(ctx resource.Context, cfg Config) Instance {
 	c := &kubeComponent{}
 	c.id = ctx.TrackResource(c)
@@ -218,7 +162,7 @@ func (c *kubeComponent) TCPAddress() net.TCPAddr {
 // HTTPSAddress returns HTTPS IP address and port number of ingress gateway.
 func (c *kubeComponent) HTTPSAddress() net.TCPAddr {
 	address, err := retry.Do(func() (interface{}, bool, error) {
-		return getHTTPSAddressInner(c.env, c.namespace)
+		return c.getAddressInner(c.namespace, 443)
 	}, retryTimeout, retryDelay)
 	if err != nil {
 		return net.TCPAddr{}

--- a/pkg/test/framework/components/ingress/kube.go
+++ b/pkg/test/framework/components/ingress/kube.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	corev1 "k8s.io/api/core/v1"
 	"net"
 	"net/http"
 	"strconv"
@@ -69,7 +70,11 @@ func (c *kubeComponent) getAddressInner(ns string, port int) (interface{}, bool,
 			return nil, false, err
 		}
 
-		scopes.Framework.Debugf("Querying ingress, pods:\n%v\n", pods)
+		names := make([]string, 0, len(pods.Items))
+		for _, p := range pods.Items {
+			names = append(names, p.Name)
+		}
+		scopes.Framework.Debugf("Querying ingress, pods:\n%v\n", names)
 		if len(pods.Items) == 0 {
 			return nil, false, fmt.Errorf("no ingress pod found")
 		}


### PR DESCRIPTION
- massive log lines with the entire k8s api object(s) now just print the names
- remove duplicated code for getHTTPAddressInner

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
