### PR TITLE
Increase timeout for benchtest

### DIFF
--- a/prow/benchtest.sh
+++ b/prow/benchtest.sh
@@ -38,7 +38,7 @@ COMPARE_GIT_SHA="${COMPARE_GIT_SHA:-${PULL_BASE_SHA:-${GIT_SHA}}}"
 case "${1}" in
   run)
     shift
-    benchmarkjunit "$@" -l "${REPORT_PLAINTEXT}" --output="${REPORT_JUNIT}" --test-arg "--benchmem" --test-arg "--count=${BENCHMARK_COUNT}" --test-arg " --test-arg "--test.timeout=30m"
+    benchmarkjunit "$@" -l "${REPORT_PLAINTEXT}" --output="${REPORT_JUNIT}" --test-arg "--benchmem" --test-arg "--count=${BENCHMARK_COUNT}" --test-arg "--test.timeout=30m"
     # Print out the results as well for ease of debugging, so they are in the logs instead of just output
     cat "${REPORT_PLAINTEXT}"
     ;;

--- a/prow/benchtest.sh
+++ b/prow/benchtest.sh
@@ -38,7 +38,7 @@ COMPARE_GIT_SHA="${COMPARE_GIT_SHA:-${PULL_BASE_SHA:-${GIT_SHA}}}"
 case "${1}" in
   run)
     shift
-    benchmarkjunit "$@" -l "${REPORT_PLAINTEXT}" --output="${REPORT_JUNIT}" --test-arg "--benchmem" --test-arg "--count" --test-arg "${BENCHMARK_COUNT}"
+    benchmarkjunit "$@" -l "${REPORT_PLAINTEXT}" --output="${REPORT_JUNIT}" --test-arg "--benchmem" --test-arg "--count=${BENCHMARK_COUNT}" --test-arg " --test-arg "--test.timeout=30m"
     # Print out the results as well for ease of debugging, so they are in the logs instead of just output
     cat "${REPORT_PLAINTEXT}"
     ;;


### PR DESCRIPTION
Sometimes it goes too long:
https://storage.googleapis.com/istio-prow/logs/benchmark-report_istio_postsubmit/40/artifacts/benchmark-log.txt



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure