### PR TITLE
echo retries GetRemoteDiscoveryAddress

### DIFF
--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -16,6 +16,8 @@ package kube
 
 import (
 	"fmt"
+	"istio.io/istio/pkg/test/util/retry"
+	"net"
 	"strconv"
 	"text/template"
 
@@ -342,7 +344,12 @@ func generateYAMLWithSettings(cfg echo.Config, settings *image.Settings,
 		if err != nil {
 			return "", "", err
 		}
-		addr, err := istio.GetRemoteDiscoveryAddress("istio-system", cluster, s.Minikube)
+		var addr net.TCPAddr
+		err = retry.UntilSuccess(func() error {
+			var err error
+			addr, err = istio.GetRemoteDiscoveryAddress("istio-system", cluster, s.Minikube)
+			return err
+		})
 		if err != nil {
 			return "", "", err
 		}

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -16,7 +16,6 @@ package kube
 
 import (
 	"fmt"
-	"istio.io/istio/pkg/test/util/retry"
 	"net"
 	"strconv"
 	"text/template"
@@ -28,6 +27,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/image"
 	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/test/util/tmpl"
 )
 


### PR DESCRIPTION
local dev improvement

This fails when I run on real k8s clusters unless there is some time between the Istio deploy and the VM test. Works fine in CI because MetalLB assigns external IPs pretty much instantly. 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
