### PR TITLE
Auth filters: allow specify mTLS mode not through endpoint port

### DIFF
--- a/pilot/pkg/networking/plugin/authn/authentication.go
+++ b/pilot/pkg/networking/plugin/authn/authentication.go
@@ -38,7 +38,7 @@ func NewPlugin() plugin.Plugin {
 
 // OnInboundFilterChains setups filter chains based on the authentication policy.
 func (Plugin) OnInboundFilterChains(in *plugin.InputParams) []networking.FilterChain {
-	var tlsGetter authn.TlsModeGetter = authn.StrictTlsModeValue{}
+	var tlsGetter authn.TLSModeGetter = authn.StrictTLSModeValue{}
 	if in.ServiceInstance != nil {
 		tlsGetter = authn.NewTlsPortNumber(in.ServiceInstance.Endpoint.EndpointPort)
 	}
@@ -75,7 +75,7 @@ func buildFilter(in *plugin.InputParams, mutable *networking.MutableObjects) err
 	if mutable.Listener == nil || (len(mutable.Listener.FilterChains) != len(mutable.FilterChains)) {
 		return fmt.Errorf("expected same number of filter chains in listener (%d) and mutable (%d)", len(mutable.Listener.FilterChains), len(mutable.FilterChains))
 	}
-	var tlsGetter authn.TlsModeGetter = authn.StrictTlsModeValue{}
+	var tlsGetter authn.TLSModeGetter = authn.StrictTLSModeValue{}
 	if in.ServiceInstance != nil {
 		tlsGetter = authn.NewTlsPortNumber(in.ServiceInstance.Endpoint.EndpointPort)
 	}

--- a/pilot/pkg/networking/plugin/authn/authentication.go
+++ b/pilot/pkg/networking/plugin/authn/authentication.go
@@ -42,8 +42,7 @@ func (Plugin) OnInboundFilterChains(in *plugin.InputParams) []networking.FilterC
 	if in.ServiceInstance != nil {
 		tlsGetter = authn.NewTLSPortNumber(in.ServiceInstance.Endpoint.EndpointPort)
 	}
-	return factory.NewPolicyApplier(in.Push,
-		in.ServiceInstance, in.Node.Metadata.Namespace, labels.Collection{in.Node.Metadata.Labels}).InboundFilterChain(
+	return factory.NewPolicyApplier(in.Push, in.Node.Metadata.Namespace, labels.Collection{in.Node.Metadata.Labels}).InboundFilterChain(
 		tlsGetter, in.Push.Mesh.SdsUdsPath, in.Node, in.ListenerProtocol)
 }
 
@@ -71,7 +70,7 @@ func (Plugin) OnInboundListener(in *plugin.InputParams, mutable *networking.Muta
 
 func buildFilter(in *plugin.InputParams, mutable *networking.MutableObjects) error {
 	ns := in.Node.Metadata.Namespace
-	applier := factory.NewPolicyApplier(in.Push, in.ServiceInstance, ns, labels.Collection{in.Node.Metadata.Labels})
+	applier := factory.NewPolicyApplier(in.Push, ns, labels.Collection{in.Node.Metadata.Labels})
 	if mutable.Listener == nil || (len(mutable.Listener.FilterChains) != len(mutable.FilterChains)) {
 		return fmt.Errorf("expected same number of filter chains in listener (%d) and mutable (%d)", len(mutable.Listener.FilterChains), len(mutable.FilterChains))
 	}
@@ -123,7 +122,7 @@ func (Plugin) OnInboundPassthrough(in *plugin.InputParams, mutable *networking.M
 // OnInboundPassthroughFilterChains is called for plugin to update the pass through filter chain.
 func (Plugin) OnInboundPassthroughFilterChains(in *plugin.InputParams) []networking.FilterChain {
 	// Pass nil for ServiceInstance so that we never consider any alpha policy for the pass through filter chain.
-	applier := factory.NewPolicyApplier(in.Push, nil /* ServiceInstance */, in.Node.Metadata.Namespace, labels.Collection{in.Node.Metadata.Labels})
+	applier := factory.NewPolicyApplier(in.Push, in.Node.Metadata.Namespace, labels.Collection{in.Node.Metadata.Labels})
 	// Pass 0 for endpointPort so that it never matches any port-level policy.
 	return applier.InboundFilterChain(authn.NewTLSPortNumber(0), in.Push.Mesh.SdsUdsPath, in.Node, in.ListenerProtocol)
 }

--- a/pilot/pkg/networking/plugin/authn/authentication.go
+++ b/pilot/pkg/networking/plugin/authn/authentication.go
@@ -40,7 +40,7 @@ func NewPlugin() plugin.Plugin {
 func (Plugin) OnInboundFilterChains(in *plugin.InputParams) []networking.FilterChain {
 	var tlsGetter authn.TLSModeGetter = authn.StrictTLSModeValue{}
 	if in.ServiceInstance != nil {
-		tlsGetter = authn.NewTlsPortNumber(in.ServiceInstance.Endpoint.EndpointPort)
+		tlsGetter = authn.NewTLSPortNumber(in.ServiceInstance.Endpoint.EndpointPort)
 	}
 	return factory.NewPolicyApplier(in.Push,
 		in.ServiceInstance, in.Node.Metadata.Namespace, labels.Collection{in.Node.Metadata.Labels}).InboundFilterChain(
@@ -77,7 +77,7 @@ func buildFilter(in *plugin.InputParams, mutable *networking.MutableObjects) err
 	}
 	var tlsGetter authn.TLSModeGetter = authn.StrictTLSModeValue{}
 	if in.ServiceInstance != nil {
-		tlsGetter = authn.NewTlsPortNumber(in.ServiceInstance.Endpoint.EndpointPort)
+		tlsGetter = authn.NewTLSPortNumber(in.ServiceInstance.Endpoint.EndpointPort)
 	}
 	for i := range mutable.Listener.FilterChains {
 		if in.ListenerProtocol == networking.ListenerProtocolHTTP || mutable.FilterChains[i].ListenerProtocol == networking.ListenerProtocolHTTP {
@@ -125,5 +125,5 @@ func (Plugin) OnInboundPassthroughFilterChains(in *plugin.InputParams) []network
 	// Pass nil for ServiceInstance so that we never consider any alpha policy for the pass through filter chain.
 	applier := factory.NewPolicyApplier(in.Push, nil /* ServiceInstance */, in.Node.Metadata.Namespace, labels.Collection{in.Node.Metadata.Labels})
 	// Pass 0 for endpointPort so that it never matches any port-level policy.
-	return applier.InboundFilterChain(authn.NewTlsPortNumber(0), in.Push.Mesh.SdsUdsPath, in.Node, in.ListenerProtocol)
+	return applier.InboundFilterChain(authn.NewTLSPortNumber(0), in.Push.Mesh.SdsUdsPath, in.Node, in.ListenerProtocol)
 }

--- a/pilot/pkg/security/authn/factory/factory.go
+++ b/pilot/pkg/security/authn/factory/factory.go
@@ -23,8 +23,7 @@ import (
 
 // NewPolicyApplier returns the appropriate (policy) applier, depends on the versions of the policy exists
 // for the given service instance.
-func NewPolicyApplier(push *model.PushContext,
-	serviceInstance *model.ServiceInstance, namespace string, labels labels.Collection) authn.PolicyApplier {
+func NewPolicyApplier(push *model.PushContext, _ *model.ServiceInstance, namespace string, labels labels.Collection) authn.PolicyApplier {
 	return v1beta1.NewPolicyApplier(
 		push.AuthnBetaPolicies.GetRootNamespace(),
 		push.AuthnBetaPolicies.GetJwtPoliciesForWorkload(namespace, labels),

--- a/pilot/pkg/security/authn/factory/factory.go
+++ b/pilot/pkg/security/authn/factory/factory.go
@@ -23,7 +23,7 @@ import (
 
 // NewPolicyApplier returns the appropriate (policy) applier, depends on the versions of the policy exists
 // for the given service instance.
-func NewPolicyApplier(push *model.PushContext, _ *model.ServiceInstance, namespace string, labels labels.Collection) authn.PolicyApplier {
+func NewPolicyApplier(push *model.PushContext, namespace string, labels labels.Collection) authn.PolicyApplier {
 	return v1beta1.NewPolicyApplier(
 		push.AuthnBetaPolicies.GetRootNamespace(),
 		push.AuthnBetaPolicies.GetJwtPoliciesForWorkload(namespace, labels),

--- a/pilot/pkg/security/authn/policy_applier.go
+++ b/pilot/pkg/security/authn/policy_applier.go
@@ -32,7 +32,7 @@ type TLSPortNumber struct {
 func (p TLSPortNumber) Get(a PolicyApplier) model.MutualTLSMode {
 	return a.GetMutualTLSMode(p.port)
 }
-func NewTlsPortNumber(p uint32) TLSPortNumber {
+func NewTLSPortNumber(p uint32) TLSPortNumber {
 	return TLSPortNumber{p}
 }
 

--- a/pilot/pkg/security/authn/policy_applier.go
+++ b/pilot/pkg/security/authn/policy_applier.go
@@ -21,25 +21,25 @@ import (
 	"istio.io/istio/pilot/pkg/networking"
 )
 
-type TlsModeGetter interface {
+type TLSModeGetter interface {
 	Get(PolicyApplier) model.MutualTLSMode
 }
 
-type TlsPortNumber struct {
+type TLSPortNumber struct {
 	port uint32
 }
 
-func (p TlsPortNumber) Get(a PolicyApplier) model.MutualTLSMode {
+func (p TLSPortNumber) Get(a PolicyApplier) model.MutualTLSMode {
 	return a.GetMutualTLSMode(p.port)
 }
-func NewTlsPortNumber(p uint32) TlsPortNumber {
-	return TlsPortNumber{p}
+func NewTlsPortNumber(p uint32) TLSPortNumber {
+	return TLSPortNumber{p}
 }
 
-type StrictTlsModeValue struct {
+type StrictTLSModeValue struct {
 }
 
-func (v StrictTlsModeValue) Get(PolicyApplier) model.MutualTLSMode {
+func (v StrictTLSModeValue) Get(PolicyApplier) model.MutualTLSMode {
 	return model.MTLSStrict
 }
 
@@ -48,7 +48,7 @@ func (v StrictTlsModeValue) Get(PolicyApplier) model.MutualTLSMode {
 type PolicyApplier interface {
 	// InboundFilterChain returns inbound filter chain(s) for the given endpoint (aka workload) port to
 	// enforce the underlying authentication policy.
-	InboundFilterChain(tlsModeGetter TlsModeGetter, sdsUdsPath string, node *model.Proxy,
+	InboundFilterChain(tlsModeGetter TLSModeGetter, sdsUdsPath string, node *model.Proxy,
 		listenerProtocol networking.ListenerProtocol) []networking.FilterChain
 
 	// AuthNFilter returns the JWT HTTP filter to enforce the underlying authentication policy.
@@ -57,7 +57,7 @@ type PolicyApplier interface {
 
 	// AuthNFilter returns the (authn) HTTP filter to enforce the underlying authentication policy.
 	// It may return nil, if no authentication is needed.
-	AuthNFilter(proxyType model.NodeType, tlsModeGetter TlsModeGetter) *http_conn.HttpFilter
+	AuthNFilter(proxyType model.NodeType, tlsModeGetter TLSModeGetter) *http_conn.HttpFilter
 
 	// Return the MutualTLSMode given the endpoint port.
 	GetMutualTLSMode(endpointPort uint32) model.MutualTLSMode

--- a/pilot/pkg/security/authn/v1beta1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier.go
@@ -79,7 +79,7 @@ func defaultAuthnFilter() *authn_filter.FilterConfig {
 	}
 }
 
-func (a *v1beta1PolicyApplier) setAuthnFilterForPeerAuthn(proxyType model.NodeType, port uint32, config *authn_filter.FilterConfig) *authn_filter.FilterConfig {
+func (a *v1beta1PolicyApplier) setAuthnFilterForPeerAuthn(proxyType model.NodeType, tlsModeGetter authn.TlsModeGetter, config *authn_filter.FilterConfig) *authn_filter.FilterConfig {
 	if proxyType != model.SidecarProxy {
 		authnLog.Debugf("AuthnFilter: skip setting peer for type %v", proxyType)
 		return config
@@ -91,7 +91,7 @@ func (a *v1beta1PolicyApplier) setAuthnFilterForPeerAuthn(proxyType model.NodeTy
 	p := config.Policy
 	p.Peers = []*authn_alpha.PeerAuthenticationMethod{}
 
-	effectiveMTLSMode := a.getMutualTLSModeForPort(port)
+	effectiveMTLSMode := tlsModeGetter.Get(a)
 	if effectiveMTLSMode == model.MTLSPermissive || effectiveMTLSMode == model.MTLSStrict {
 		mode := authn_alpha.MutualTls_PERMISSIVE
 		if effectiveMTLSMode == model.MTLSStrict {
@@ -149,11 +149,11 @@ func (a *v1beta1PolicyApplier) setAuthnFilterForRequestAuthn(config *authn_filte
 // - If PeerAuthentication is used, it overwrite the settings for peer principal validation and extraction based on the new API.
 // - If RequestAuthentication is used, it overwrite the settings for request principal validation and extraction based on the new API.
 // - If RequestAuthentication is used, principal binding is always set to ORIGIN.
-func (a *v1beta1PolicyApplier) AuthNFilter(proxyType model.NodeType, port uint32) *http_conn.HttpFilter {
+func (a *v1beta1PolicyApplier) AuthNFilter(proxyType model.NodeType, tlsModeGetter authn.TlsModeGetter) *http_conn.HttpFilter {
 	var filterConfigProto *authn_filter.FilterConfig
 
 	// Override the config with peer authentication, if applicable.
-	filterConfigProto = a.setAuthnFilterForPeerAuthn(proxyType, port, filterConfigProto)
+	filterConfigProto = a.setAuthnFilterForPeerAuthn(proxyType, tlsModeGetter, filterConfigProto)
 	// Override the config with request authentication, if applicable.
 	filterConfigProto = a.setAuthnFilterForRequestAuthn(filterConfigProto)
 
@@ -167,10 +167,10 @@ func (a *v1beta1PolicyApplier) AuthNFilter(proxyType model.NodeType, port uint32
 	}
 }
 
-func (a *v1beta1PolicyApplier) InboundFilterChain(endpointPort uint32, sdsUdsPath string, node *model.Proxy,
+func (a *v1beta1PolicyApplier) InboundFilterChain(tlsModeGetter authn.TlsModeGetter, sdsUdsPath string, node *model.Proxy,
 	listenerProtocol networking.ListenerProtocol) []networking.FilterChain {
-	effectiveMTLSMode := a.getMutualTLSModeForPort(endpointPort)
-	authnLog.Debugf("InboundFilterChain: build inbound filter change for %v:%d in %s mode", node.ID, endpointPort, effectiveMTLSMode)
+	effectiveMTLSMode := tlsModeGetter.Get(a)
+	authnLog.Debugf("InboundFilterChain: build inbound filter change for %v:%v in %s mode", node.ID, tlsModeGetter, effectiveMTLSMode)
 	return authn_utils.BuildInboundFilterChain(effectiveMTLSMode, sdsUdsPath, node, listenerProtocol)
 }
 
@@ -332,7 +332,7 @@ func convertToEnvoyJwtConfig(jwtRules []*v1beta1.JWTRule) *envoy_jwt.JwtAuthenti
 	}
 }
 
-func (a *v1beta1PolicyApplier) getMutualTLSModeForPort(endpointPort uint32) model.MutualTLSMode {
+func (a *v1beta1PolicyApplier) GetMutualTLSMode(endpointPort uint32) model.MutualTLSMode {
 	if a.consolidatedPeerPolicy == nil {
 		return model.MTLSPermissive
 	}

--- a/pilot/pkg/security/authn/v1beta1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier.go
@@ -79,7 +79,7 @@ func defaultAuthnFilter() *authn_filter.FilterConfig {
 	}
 }
 
-func (a *v1beta1PolicyApplier) setAuthnFilterForPeerAuthn(proxyType model.NodeType, tlsModeGetter authn.TlsModeGetter, config *authn_filter.FilterConfig) *authn_filter.FilterConfig {
+func (a *v1beta1PolicyApplier) setAuthnFilterForPeerAuthn(proxyType model.NodeType, tlsModeGetter authn.TLSModeGetter, config *authn_filter.FilterConfig) *authn_filter.FilterConfig {
 	if proxyType != model.SidecarProxy {
 		authnLog.Debugf("AuthnFilter: skip setting peer for type %v", proxyType)
 		return config
@@ -149,7 +149,7 @@ func (a *v1beta1PolicyApplier) setAuthnFilterForRequestAuthn(config *authn_filte
 // - If PeerAuthentication is used, it overwrite the settings for peer principal validation and extraction based on the new API.
 // - If RequestAuthentication is used, it overwrite the settings for request principal validation and extraction based on the new API.
 // - If RequestAuthentication is used, principal binding is always set to ORIGIN.
-func (a *v1beta1PolicyApplier) AuthNFilter(proxyType model.NodeType, tlsModeGetter authn.TlsModeGetter) *http_conn.HttpFilter {
+func (a *v1beta1PolicyApplier) AuthNFilter(proxyType model.NodeType, tlsModeGetter authn.TLSModeGetter) *http_conn.HttpFilter {
 	var filterConfigProto *authn_filter.FilterConfig
 
 	// Override the config with peer authentication, if applicable.
@@ -167,7 +167,7 @@ func (a *v1beta1PolicyApplier) AuthNFilter(proxyType model.NodeType, tlsModeGett
 	}
 }
 
-func (a *v1beta1PolicyApplier) InboundFilterChain(tlsModeGetter authn.TlsModeGetter, sdsUdsPath string, node *model.Proxy,
+func (a *v1beta1PolicyApplier) InboundFilterChain(tlsModeGetter authn.TLSModeGetter, sdsUdsPath string, node *model.Proxy,
 	listenerProtocol networking.ListenerProtocol) []networking.FilterChain {
 	effectiveMTLSMode := tlsModeGetter.Get(a)
 	authnLog.Debugf("InboundFilterChain: build inbound filter change for %v:%v in %s mode", node.ID, tlsModeGetter, effectiveMTLSMode)

--- a/pilot/pkg/security/authn/v1beta1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier.go
@@ -79,7 +79,8 @@ func defaultAuthnFilter() *authn_filter.FilterConfig {
 	}
 }
 
-func (a *v1beta1PolicyApplier) setAuthnFilterForPeerAuthn(proxyType model.NodeType, tlsModeGetter authn.TLSModeGetter, config *authn_filter.FilterConfig) *authn_filter.FilterConfig {
+func (a *v1beta1PolicyApplier) setAuthnFilterForPeerAuthn(proxyType model.NodeType, tlsModeGetter authn.TLSModeGetter,
+	config *authn_filter.FilterConfig) *authn_filter.FilterConfig {
 	if proxyType != model.SidecarProxy {
 		authnLog.Debugf("AuthnFilter: skip setting peer for type %v", proxyType)
 		return config

--- a/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
@@ -1202,7 +1202,7 @@ func TestAuthnFilterConfig(t *testing.T) {
 			if c.isGateway {
 				proxyType = model.Router
 			}
-			got := NewPolicyApplier("root-namespace", c.jwtIn, c.peerIn).AuthNFilter(proxyType, authn.NewTlsPortNumber(80))
+			got := NewPolicyApplier("root-namespace", c.jwtIn, c.peerIn).AuthNFilter(proxyType, authn.NewTLSPortNumber(80))
 			if !reflect.DeepEqual(c.expected, got) {
 				t.Errorf("got:\n%v\nwanted:\n%v\n", humanReadableAuthnFilterDump(got), humanReadableAuthnFilterDump(c.expected))
 			}
@@ -1448,7 +1448,7 @@ func TestOnInboundFilterChain(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := NewPolicyApplier("root-namespace", nil, tc.peerPolicies).InboundFilterChain(
-				authn.NewTlsPortNumber(8080),
+				authn.NewTLSPortNumber(8080),
 				tc.sdsUdsPath,
 				testNode,
 				networking.ListenerProtocolAuto,

--- a/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
@@ -2061,7 +2061,7 @@ func TestOnInboundFilterChainWhenSpecifiedStrictTLS(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := NewPolicyApplier("root-namespace", nil, tc.peerPolicies).InboundFilterChain(
-				authn.StrictTlsModeValue{},
+				authn.StrictTLSModeValue{},
 				"", // sdsUdsPath,
 				testNode,
 				networking.ListenerProtocolHTTP,


### PR DESCRIPTION
#24540

The goal of Better transport security is to create a tunnel inbound listener and *enforce mTLS for all inbound traffic there*.

Ideally we eventually push all traffic to that listener but at this moment we consider only HTTP traffic.
 
This PR allows to create an authn filter not attached to any endpoint port.

Follow up: utilize the nil ServiceInstance when building the filter chain for BTS tunnel listener.
Signed-off-by: Yuchen Dai <silentdai@gmail.com>

[x] Security

