### PR TITLE
Optimize memory usage of SDS cluster config generation

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -936,7 +936,7 @@ func buildUpstreamClusterTLSContext(opts *buildClusterOpts, tls *networking.Clie
 	c := opts.cluster
 	proxy := opts.proxy
 
-	tlsContext := &auth.UpstreamTlsContext{}
+	var tlsContext *auth.UpstreamTlsContext
 
 	switch tls.Mode {
 	case networking.ClientTLSSettings_DISABLE:

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -976,13 +976,12 @@ func buildUpstreamClusterTLSContext(opts *buildClusterOpts, tls *networking.Clie
 			}
 		} else {
 			tlsContext.CommonTlsContext.TlsCertificateSdsSecretConfigs = append(tlsContext.CommonTlsContext.TlsCertificateSdsSecretConfigs,
-				authn_model.ConstructSdsSecretConfig(authn_model.SDSDefaultResourceName, opts.push.Mesh.SdsUdsPath, node.RequestedTypes.CDS))
+				authn_model.ConstructSdsSecretConfig(authn_model.SDSDefaultResourceName, node.RequestedTypes.CDS))
 
 			tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
 				CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
-					DefaultValidationContext: &auth.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch(tls.SubjectAltNames)},
-					ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(authn_model.SDSRootResourceName,
-						opts.push.Mesh.SdsUdsPath, node.RequestedTypes.CDS),
+					DefaultValidationContext:         &auth.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch(tls.SubjectAltNames)},
+					ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(authn_model.SDSRootResourceName, node.RequestedTypes.CDS),
 				},
 			}
 		}
@@ -1051,7 +1050,7 @@ func buildUpstreamClusterTLSContext(opts *buildClusterOpts, tls *networking.Clie
 			tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
 				CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
 					DefaultValidationContext:         &auth.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch(tls.SubjectAltNames)},
-					ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(res.GetRootResourceName(), opts.push.Mesh.SdsUdsPath, node.RequestedTypes.CDS),
+					ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(res.GetRootResourceName(), node.RequestedTypes.CDS),
 				},
 			}
 		}
@@ -1118,7 +1117,7 @@ func buildUpstreamClusterTLSContext(opts *buildClusterOpts, tls *networking.Clie
 				CaCertificatePath: model.GetOrDefault(proxy.Metadata.TLSClientRootCert, tls.CaCertificates),
 			}
 			tlsContext.CommonTlsContext.TlsCertificateSdsSecretConfigs = append(tlsContext.CommonTlsContext.TlsCertificateSdsSecretConfigs,
-				authn_model.ConstructSdsSecretConfig(res.GetResourceName(), opts.push.Mesh.SdsUdsPath, node.RequestedTypes.CDS))
+				authn_model.ConstructSdsSecretConfig(res.GetResourceName(), node.RequestedTypes.CDS))
 
 			// If tls.CaCertificate or CaCertificate in Metadata isn't configured don't set up RootSdsSecretConfig
 			if res.GetRootResourceName() == "" {
@@ -1128,7 +1127,7 @@ func buildUpstreamClusterTLSContext(opts *buildClusterOpts, tls *networking.Clie
 				tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
 					CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
 						DefaultValidationContext:         &auth.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch(tls.SubjectAltNames)},
-						ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(res.GetRootResourceName(), opts.push.Mesh.SdsUdsPath, node.RequestedTypes.CDS),
+						ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(res.GetRootResourceName(), node.RequestedTypes.CDS),
 					},
 				}
 			}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -22,6 +22,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+
 	authn_model "istio.io/istio/pilot/pkg/security/model"
 
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -2485,6 +2488,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 											},
 										},
 									},
+									ResourceApiVersion:  core.ApiVersion_V3,
 									InitialFetchTimeout: features.InitialFetchTimeout,
 								},
 							},
@@ -2507,6 +2511,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 												},
 											},
 										},
+										ResourceApiVersion:  core.ApiVersion_V3,
 										InitialFetchTimeout: features.InitialFetchTimeout,
 									},
 								},
@@ -2605,6 +2610,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 												},
 											},
 										},
+										ResourceApiVersion:  core.ApiVersion_V3,
 										InitialFetchTimeout: features.InitialFetchTimeout,
 									},
 								},
@@ -2669,6 +2675,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 												},
 											},
 										},
+										ResourceApiVersion:  core.ApiVersion_V3,
 										InitialFetchTimeout: features.InitialFetchTimeout,
 									},
 								},
@@ -2735,6 +2742,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 												},
 											},
 										},
+										ResourceApiVersion:  core.ApiVersion_V3,
 										InitialFetchTimeout: features.InitialFetchTimeout,
 									},
 								},
@@ -3020,6 +3028,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 											},
 										},
 									},
+									ResourceApiVersion:  core.ApiVersion_V3,
 									InitialFetchTimeout: features.InitialFetchTimeout,
 								},
 							},
@@ -3085,6 +3094,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 											},
 										},
 									},
+									ResourceApiVersion:  core.ApiVersion_V3,
 									InitialFetchTimeout: features.InitialFetchTimeout,
 								},
 							},
@@ -3107,6 +3117,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 												},
 											},
 										},
+										ResourceApiVersion:  core.ApiVersion_V3,
 										InitialFetchTimeout: features.InitialFetchTimeout,
 									},
 								},
@@ -3420,12 +3431,14 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		ret, err := buildUpstreamClusterTLSContext(tc.opts, tc.tls, tc.node, tc.certValidationContext)
-		if err != nil && tc.result.err == nil || err == nil && tc.result.err != nil {
-			t.Errorf("test case %s: expecting:\n err=%v but got err=%v", tc.name, tc.result.err, err)
-		} else if !reflect.DeepEqual(tc.result.tlsContext, ret) {
-			t.Errorf("test case %s: expecting:\n %v but got:\n %v", tc.name, tc.result.tlsContext, ret)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			ret, err := buildUpstreamClusterTLSContext(tc.opts, tc.tls, tc.node, tc.certValidationContext)
+			if err != nil && tc.result.err == nil || err == nil && tc.result.err != nil {
+				t.Errorf("expecting:\n err=%v but got err=%v", tc.result.err, err)
+			} else if diff := cmp.Diff(tc.result.tlsContext, ret, protocmp.Transform()); diff != "" {
+				t.Errorf("got diff: `%v", diff)
+			}
+		})
 	}
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -22,6 +22,8 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	networking "istio.io/api/networking/v1alpha3"
 
@@ -556,10 +558,12 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		ret := buildGatewayListenerTLSContext(tc.server, tc.sdsPath, &pilot_model.NodeMetadata{SdsEnabled: true}, v3.ListenerType)
-		if !reflect.DeepEqual(tc.result, ret) {
-			t.Errorf("test case %s: expecting:\n %v but got:\n %v", tc.name, tc.result, ret)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			ret := buildGatewayListenerTLSContext(tc.server, tc.sdsPath, &pilot_model.NodeMetadata{SdsEnabled: true}, v3.ListenerType)
+			if diff := cmp.Diff(tc.result, ret, protocmp.Transform()); diff != "" {
+				t.Errorf("got diff: %v", diff)
+			}
+		})
 	}
 }
 

--- a/pilot/pkg/security/model/authentication.go
+++ b/pilot/pkg/security/model/authentication.go
@@ -111,10 +111,61 @@ func ConstructSdsSecretConfigWithCustomUds(name, sdsUdsPath, requestedType strin
 	return cfg
 }
 
+// Preconfigured SDS configs to avoid excessive memory allocations
+var (
+	defaultV3SDSConfig = &tls.SdsSecretConfig{
+		Name: SDSDefaultResourceName,
+		SdsConfig: &core.ConfigSource{
+			ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+				ApiConfigSource: &core.ApiConfigSource{
+					ApiType: core.ApiConfigSource_GRPC,
+					GrpcServices: []*core.GrpcService{
+						{
+							TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
+								EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: SDSClusterName},
+							},
+						},
+					},
+				},
+			},
+			ResourceApiVersion:  core.ApiVersion_V3,
+			InitialFetchTimeout: features.InitialFetchTimeout,
+		},
+	}
+	rootV3SDSConfig = &tls.SdsSecretConfig{
+		Name: SDSRootResourceName,
+		SdsConfig: &core.ConfigSource{
+			ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+				ApiConfigSource: &core.ApiConfigSource{
+					ApiType: core.ApiConfigSource_GRPC,
+					GrpcServices: []*core.GrpcService{
+						{
+							TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
+								EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: SDSClusterName},
+							},
+						},
+					},
+				},
+			},
+			ResourceApiVersion:  core.ApiVersion_V3,
+			InitialFetchTimeout: features.InitialFetchTimeout,
+		},
+	}
+)
+
 // ConstructSdsSecretConfig constructs SDS Secret Configuration for workload proxy.
-func ConstructSdsSecretConfig(name, sdsUdsPath, requestedType string) *tls.SdsSecretConfig {
-	if name == "" || sdsUdsPath == "" {
+func ConstructSdsSecretConfig(name, requestedType string) *tls.SdsSecretConfig {
+	if name == "" {
 		return nil
+	}
+
+	useV3 := requestedType == v3.ClusterType || requestedType == v3.ListenerType || requestedType == ""
+
+	if name == SDSDefaultResourceName && useV3 {
+		return defaultV3SDSConfig
+	}
+	if name == SDSRootResourceName && useV3 {
+		return rootV3SDSConfig
 	}
 
 	cfg := &tls.SdsSecretConfig{
@@ -135,7 +186,7 @@ func ConstructSdsSecretConfig(name, sdsUdsPath, requestedType string) *tls.SdsSe
 			InitialFetchTimeout: features.InitialFetchTimeout,
 		},
 	}
-	if requestedType == v3.ClusterType || requestedType == v3.ListenerType {
+	if useV3 {
 		// For v3 clusters/listeners, send v3 secrets
 		cfg.SdsConfig.ResourceApiVersion = core.ApiVersion_V3
 	}
@@ -177,13 +228,12 @@ func ApplyToCommonTLSContext(tlsContext *tls.CommonTlsContext, metadata *model.N
 		// configure server listeners with SDS.
 		tlsContext.ValidationContextType = &tls.CommonTlsContext_CombinedValidationContext{
 			CombinedValidationContext: &tls.CommonTlsContext_CombinedCertificateValidationContext{
-				DefaultValidationContext: &tls.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch(subjectAltNames)},
-				ValidationContextSdsSecretConfig: ConstructSdsSecretConfig(
-					model.GetOrDefault(res.GetRootResourceName(), SDSRootResourceName), sdsPath, resourceType),
+				DefaultValidationContext:         &tls.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch(subjectAltNames)},
+				ValidationContextSdsSecretConfig: ConstructSdsSecretConfig(model.GetOrDefault(res.GetRootResourceName(), SDSRootResourceName), resourceType),
 			},
 		}
 		tlsContext.TlsCertificateSdsSecretConfigs = []*tls.SdsSecretConfig{
-			ConstructSdsSecretConfig(model.GetOrDefault(res.GetResourceName(), SDSDefaultResourceName), sdsPath, resourceType),
+			ConstructSdsSecretConfig(model.GetOrDefault(res.GetResourceName(), SDSDefaultResourceName), resourceType),
 		}
 	} else {
 		// TODO(ramaraochavali): Clean this codepath later as we default to SDS.

--- a/pilot/pkg/security/model/authentication_test.go
+++ b/pilot/pkg/security/model/authentication_test.go
@@ -135,7 +135,7 @@ func TestConstructSdsSecretConfig(t *testing.T) {
 
 	for _, c := range testCases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := ConstructSdsSecretConfig(c.serviceAccount, c.sdsUdsPath, v3.ListenerType); !cmp.Equal(got, c.expected, protocmp.Transform()) {
+			if got := ConstructSdsSecretConfig(c.serviceAccount, v3.ListenerType); !cmp.Equal(got, c.expected, protocmp.Transform()) {
 				t.Errorf("ConstructSdsSecretConfig: got(%#v), want(%#v)\n", got, c.expected)
 			}
 		})

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -188,7 +188,8 @@ func setupTest(t testing.TB, config ConfigInput) (*model.Environment, core.Confi
 			Labels: map[string]string{
 				"istio.io/benchmark": "true",
 			},
-			IstioVersion: "1.6.0",
+			IstioVersion: "1.7.0",
+			SdsEnabled:   true,
 		},
 		// TODO: if you update this, make sure telemetry.yaml is also updated
 		IstioVersion:    &model.IstioVersion{Major: 1, Minor: 6},
@@ -219,9 +220,12 @@ func getConfigs(t testing.TB, input ConfigInput) []model.Config {
 	if err := tmpl.ExecuteTemplate(&buf, configName+".yaml", input); err != nil {
 		t.Fatalf("failed to execute template: %v", err)
 	}
-	configs, _, err := crd.ParseInputs(buf.String())
+	configs, badKinds, err := crd.ParseInputs(buf.String())
 	if err != nil {
 		t.Fatalf("failed to read config: %v", err)
+	}
+	if len(badKinds) != 0 {
+		t.Fatalf("Got unknown resources: %v", badKinds)
 	}
 	// setup default namespace if not defined
 	for i, c := range configs {
@@ -286,6 +290,10 @@ var testCases = []ConfigInput{
 	},
 	{
 		Name:     "empty",
+		Services: 100,
+	},
+	{
+		Name:     "tls",
 		Services: 100,
 	},
 	{

--- a/pilot/pkg/xds/testdata/benchmarks/tls.yaml
+++ b/pilot/pkg/xds/testdata/benchmarks/tls.yaml
@@ -1,0 +1,69 @@
+# Set up a Service associated with our proxy, which will run as 1.1.1.1 IP
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: proxy-service-instance
+spec:
+  hosts:
+  - example.com
+  ports:
+  - number: 80
+    name: http
+    protocol: HTTP
+  - number: 7070
+    name: tcp
+    protocol: TCP
+  - number: 443
+    name: https
+    protocol: HTTPS
+  - number: 9090
+    name: auto
+    protocol: ""
+  resolution: STATIC
+  endpoints:
+  - address: 1.1.1.1
+---
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+spec:
+  mtls:
+    mode: STRICT
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: use-mtls
+spec:
+  host: "*.host.example"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+---
+# Set up .Services number of services. Each will have 4 ports (one for each protocol)
+{{- range $i := until .Services }}
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: service-{{$i}}
+spec:
+  hosts:
+  - random-{{$i}}.host.example
+  ports:
+  - number: 80
+    name: http
+    protocol: HTTP
+  - number: 7070
+    name: tcp
+    protocol: TCP
+  - number: 443
+    name: https
+    protocol: HTTPS
+  - number: 9090
+    name: auto
+  resolution: STATIC
+  endpoints:
+  - address: 1.2.3.4
+---
+{{- end }}

--- a/pkg/bootstrap/option/convert.go
+++ b/pkg/bootstrap/option/convert.go
@@ -37,7 +37,6 @@ import (
 	"istio.io/istio/pilot/pkg/networking/util"
 	authn_model "istio.io/istio/pilot/pkg/security/model"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
-	"istio.io/istio/pkg/config/mesh"
 )
 
 //TransportSocket wraps UpstreamTLSContext
@@ -107,7 +106,7 @@ func tlsContextConvert(tls *networkingAPI.ClientTLSSettings, sniName string, met
 		tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
 			CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
 				DefaultValidationContext:         &auth.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch(tls.SubjectAltNames)},
-				ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(res.GetRootResourceName(), mesh.DefaultSdsUdsPath, requestedType),
+				ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(res.GetRootResourceName(), requestedType),
 			},
 		}
 		tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNH2Only
@@ -119,24 +118,24 @@ func tlsContextConvert(tls *networkingAPI.ClientTLSSettings, sniName string, met
 		}
 		if len(res.GetResourceName()) > 0 {
 			tlsContext.CommonTlsContext.TlsCertificateSdsSecretConfigs = append(tlsContext.CommonTlsContext.TlsCertificateSdsSecretConfigs,
-				authn_model.ConstructSdsSecretConfig(res.GetResourceName(), mesh.DefaultSdsUdsPath, requestedType))
+				authn_model.ConstructSdsSecretConfig(res.GetResourceName(), requestedType))
 		}
 
 		tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
 			CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
 				DefaultValidationContext:         &auth.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch(tls.SubjectAltNames)},
-				ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(res.GetRootResourceName(), mesh.DefaultSdsUdsPath, requestedType),
+				ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(res.GetRootResourceName(), requestedType),
 			},
 		}
 		tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNH2Only
 	case networkingAPI.ClientTLSSettings_ISTIO_MUTUAL:
 		tlsContext.CommonTlsContext.TlsCertificateSdsSecretConfigs = append(tlsContext.CommonTlsContext.TlsCertificateSdsSecretConfigs,
-			authn_model.ConstructSdsSecretConfig(authn_model.SDSDefaultResourceName, mesh.DefaultSdsUdsPath, requestedType))
+			authn_model.ConstructSdsSecretConfig(authn_model.SDSDefaultResourceName, requestedType))
 
 		tlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
 			CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
 				DefaultValidationContext:         &auth.CertificateValidationContext{MatchSubjectAltNames: util.StringToExactMatch(tls.SubjectAltNames)},
-				ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(authn_model.SDSRootResourceName, mesh.DefaultSdsUdsPath, requestedType),
+				ValidationContextSdsSecretConfig: authn_model.ConstructSdsSecretConfig(authn_model.SDSRootResourceName, requestedType),
 			},
 		}
 		tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNInMeshH2


### PR DESCRIPTION
```
$ benchstat /tmp/{old,new}
name                                 old time/op        new time/op        delta
ClusterGeneration/gateways-8               3.59ms ± 8%        3.79ms ±17%     ~     (p=0.548 n=5+5)
ClusterGeneration/gateways-shared-8        3.77ms ± 3%        3.83ms ±15%     ~     (p=0.548 n=5+5)
ClusterGeneration/empty-8                  1.69ms ±10%        1.80ms ±11%     ~     (p=0.421 n=5+5)
ClusterGeneration/tls-8                    5.91ms ±11%        5.18ms ± 2%  -12.34%  (p=0.016 n=5+4)
ClusterGeneration/telemetry-8              1.59ms ± 2%        1.62ms ± 4%     ~     (p=0.421 n=5+5)
ClusterGeneration/virtualservice-8          420µs ± 5%         391µs ± 2%   -6.91%  (p=0.008 n=5+5)

name                                 old alloc/op       new alloc/op       delta
ClusterGeneration/gateways-8               1.99MB ± 0%        1.99MB ± 0%     ~     (p=0.421 n=5+5)
ClusterGeneration/gateways-shared-8        1.99MB ± 0%        1.99MB ± 0%     ~     (p=0.222 n=5+5)
ClusterGeneration/empty-8                   819kB ± 0%         819kB ± 0%     ~     (p=1.000 n=5+5)
ClusterGeneration/tls-8                    2.54MB ± 0%        2.18MB ± 0%  -14.30%  (p=0.008 n=5+5)
ClusterGeneration/telemetry-8               820kB ± 0%         820kB ± 0%     ~     (p=0.556 n=4+5)
ClusterGeneration/virtualservice-8          202kB ± 0%         202kB ± 0%     ~     (p=0.452 n=5+5)

name                                 old allocs/op      new allocs/op      delta
ClusterGeneration/gateways-8                27.1k ± 0%         27.1k ± 0%     ~     (all equal)
ClusterGeneration/gateways-shared-8         27.1k ± 0%         27.1k ± 0%     ~     (all equal)
ClusterGeneration/empty-8                   11.3k ± 0%         11.3k ± 0%     ~     (all equal)
ClusterGeneration/tls-8                     34.5k ± 0%         28.1k ± 0%  -18.54%  (p=0.008 n=5+5)
ClusterGeneration/telemetry-8               11.3k ± 0%         11.3k ± 0%     ~     (p=0.444 n=5+5)
ClusterGeneration/virtualservice-8          2.81k ± 0%         2.81k ± 0%     ~     (all equal)
```