### PR TITLE
Disable SDS Config generation for Sidecar Proxy when CredentialName is set

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -1016,7 +1016,7 @@ func buildUpstreamClusterTLSContext(opts *buildClusterOpts, tls *networking.Clie
 		}
 
 	case networking.ClientTLSSettings_SIMPLE:
-		if tls.CredentialName != "" && proxy.Type == model.Router  {
+		if tls.CredentialName != "" && proxy.Type == model.Router {
 			tlsContext = &auth.UpstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{},
 				Sni:              tls.Sni,

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -1016,7 +1016,7 @@ func buildUpstreamClusterTLSContext(opts *buildClusterOpts, tls *networking.Clie
 		}
 
 	case networking.ClientTLSSettings_SIMPLE:
-		if tls.CredentialName != "" {
+		if tls.CredentialName != "" && proxy.Type == model.Router  {
 			tlsContext = &auth.UpstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{},
 				Sni:              tls.Sni,
@@ -1062,7 +1062,7 @@ func buildUpstreamClusterTLSContext(opts *buildClusterOpts, tls *networking.Clie
 		}
 
 	case networking.ClientTLSSettings_MUTUAL:
-		if tls.CredentialName != "" {
+		if tls.CredentialName != "" && proxy.Type == model.Router {
 			tlsContext = &auth.UpstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{},
 				Sni:              tls.Sni,

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -3126,6 +3126,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 				},
 				proxy: &model.Proxy{
 					Metadata: &model.NodeMetadata{},
+					Type: model.Router,
 				},
 				push: &model.PushContext{
 					Mesh: &meshconfig.MeshConfig{
@@ -3191,6 +3192,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 				},
 				proxy: &model.Proxy{
 					Metadata: &model.NodeMetadata{},
+					Type: model.Router,
 				},
 				push: &model.PushContext{
 					Mesh: &meshconfig.MeshConfig{
@@ -3253,6 +3255,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 				},
 				proxy: &model.Proxy{
 					Metadata: &model.NodeMetadata{},
+					Type: model.Router,
 				},
 				push: &model.PushContext{
 					Mesh: &meshconfig.MeshConfig{
@@ -3341,6 +3344,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 				},
 				proxy: &model.Proxy{
 					Metadata: &model.NodeMetadata{},
+					Type: model.Router,
 				},
 				push: &model.PushContext{
 					Mesh: &meshconfig.MeshConfig{

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -3126,7 +3126,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 				},
 				proxy: &model.Proxy{
 					Metadata: &model.NodeMetadata{},
-					Type: model.Router,
+					Type:     model.Router,
 				},
 				push: &model.PushContext{
 					Mesh: &meshconfig.MeshConfig{
@@ -3192,7 +3192,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 				},
 				proxy: &model.Proxy{
 					Metadata: &model.NodeMetadata{},
-					Type: model.Router,
+					Type:     model.Router,
 				},
 				push: &model.PushContext{
 					Mesh: &meshconfig.MeshConfig{
@@ -3255,7 +3255,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 				},
 				proxy: &model.Proxy{
 					Metadata: &model.NodeMetadata{},
-					Type: model.Router,
+					Type:     model.Router,
 				},
 				push: &model.PushContext{
 					Mesh: &meshconfig.MeshConfig{
@@ -3344,7 +3344,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 				},
 				proxy: &model.Proxy{
 					Metadata: &model.NodeMetadata{},
-					Type: model.Router,
+					Type:     model.Router,
 				},
 				push: &model.PushContext{
 					Mesh: &meshconfig.MeshConfig{


### PR DESCRIPTION
Generating secret watching SDS config is useless and incorrect in case when the proxy is of type Sidecar