### PR TITLE
Optimize DR lookup in EDS

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -597,6 +597,22 @@ func (ps *PushContext) Services(proxy *Proxy) []*Service {
 	return out
 }
 
+// ServiceForHostname returns the service associated with a given hostname following SidecarScope
+func (ps *PushContext) ServiceForHostname(proxy *Proxy, hostname host.Name) *Service {
+	if proxy != nil && proxy.SidecarScope != nil {
+		return proxy.SidecarScope.servicesByHostname[hostname]
+	}
+
+	// SidecarScope shouldn't be null here. If it is, we can't disambiguate the hostname to use for a namespace,
+	// so the selection must be undefined.
+	for _, service := range ps.ServiceByHostnameAndNamespace[hostname] {
+		return service
+	}
+
+	// No service found
+	return nil
+}
+
 // VirtualServices lists all virtual services bound to the specified gateways
 // This replaces store.VirtualServices. Used only by the gateways
 // Sidecars use the egressListener.VirtualServices().

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -675,6 +675,10 @@ func (ps *PushContext) getSidecarScope(proxy *Proxy, workloadLabels labels.Colle
 
 // DestinationRule returns a destination rule for a service name in a given domain.
 func (ps *PushContext) DestinationRule(proxy *Proxy, service *Service) *Config {
+	if service == nil {
+		return nil
+	}
+
 	// If proxy has a sidecar scope that is user supplied, then get the destination rules from the sidecar scope
 	// sidecarScope.config is nil if there is no sidecar scope for the namespace
 	if proxy.SidecarScope != nil && proxy.Type == SidecarProxy {

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -393,15 +393,6 @@ func convertIstioListenerToWrapper(ps *PushContext, configNamespace string,
 	return out
 }
 
-// ServiceForHostname returns the service associated with a given hostname following SidecarScope
-func (sc *SidecarScope) ServiceForHostname(hostname host.Name) *Service {
-	if sc == nil {
-		return nil
-	}
-
-	return sc.servicesByHostname[hostname]
-}
-
 // Services returns the list of services imported across all egress listeners by this
 // Sidecar config
 func (sc *SidecarScope) Services() []*Service {

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -80,7 +80,8 @@ type SidecarScope struct {
 	HasCustomIngressListeners bool
 
 	// Union of services imported across all egress listeners for use by CDS code.
-	services []*Service
+	services           []*Service
+	servicesByHostname map[host.Name]*Service
 
 	// Destination rules imported across all egress listeners. This
 	// contains the computed set based on public/private destination rules
@@ -171,6 +172,7 @@ func DefaultSidecarScopeForNamespace(ps *PushContext, configNamespace string) *S
 		EgressListeners:    []*IstioEgressListenerWrapper{defaultEgressListener},
 		services:           defaultEgressListener.services,
 		destinationRules:   make(map[host.Name]*Config),
+		servicesByHostname: make(map[host.Name]*Service),
 		configDependencies: make(map[uint32]struct{}),
 		RootNamespace:      ps.Mesh.RootNamespace,
 	}
@@ -179,6 +181,7 @@ func DefaultSidecarScopeForNamespace(ps *PushContext, configNamespace string) *S
 	// this config namespace) will see, identify all the destinationRules
 	// that these services need
 	for _, s := range out.services {
+		out.servicesByHostname[s.Hostname] = s
 		if dr := ps.DestinationRule(&dummyNode, s); dr != nil {
 			out.destinationRules[s.Hostname] = dr
 		}
@@ -324,8 +327,10 @@ func ConvertToSidecarScope(ps *PushContext, sidecarConfig *Config, configNamespa
 	// Now that we have all the services that sidecars using this scope (in
 	// this config namespace) will see, identify all the destinationRules
 	// that these services need
+	out.servicesByHostname = make(map[host.Name]*Service)
 	out.destinationRules = make(map[host.Name]*Config)
 	for _, s := range out.services {
+		out.servicesByHostname[s.Hostname] = s
 		dr := ps.DestinationRule(&dummyNode, s)
 		if dr != nil {
 			out.destinationRules[s.Hostname] = dr
@@ -389,25 +394,8 @@ func convertIstioListenerToWrapper(ps *PushContext, configNamespace string,
 }
 
 // ServiceForHostname returns the service associated with a given hostname following SidecarScope
-func (sc *SidecarScope) ServiceForHostname(hostname host.Name, serviceByHostname map[host.Name]map[string]*Service) *Service {
-	byHostname := serviceByHostname[hostname]
-	// SidecarScope shouldn't be null here. If it is, we can't disambiguate the hostname to use for a namespace,
-	// so the selection must be undefined.
-	// As an optimization, if there is only 1 hostname we will return that one to avoid iterating over services.
-	if sc == nil || len(byHostname) == 1 {
-		for _, service := range serviceByHostname[hostname] {
-			return service
-		}
-	}
-
-	// Search through in scope services. SidecarScope will already have scoped the services to ensure
-	// that the right service will be chosen here
-	for _, s := range sc.Services() {
-		if s.Hostname == hostname {
-			return s
-		}
-	}
-	return nil
+func (sc *SidecarScope) ServiceForHostname(hostname host.Name) *Service {
+	return sc.servicesByHostname[hostname]
 }
 
 // Services returns the list of services imported across all egress listeners by this

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -395,6 +395,10 @@ func convertIstioListenerToWrapper(ps *PushContext, configNamespace string,
 
 // ServiceForHostname returns the service associated with a given hostname following SidecarScope
 func (sc *SidecarScope) ServiceForHostname(hostname host.Name) *Service {
+	if sc == nil {
+		return nil
+	}
+
 	return sc.servicesByHostname[hostname]
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -129,7 +129,7 @@ func buildOutboundNetworkFiltersWithWeightedClusters(node *model.Proxy, routes [
 	}
 
 	for _, route := range routes {
-		service := node.SidecarScope.ServiceForHostname(host.Name(route.Destination.Host))
+		service := push.ServiceForHostname(node, host.Name(route.Destination.Host))
 		if route.Weight > 0 {
 			clusterName := istio_route.GetDestinationCluster(route.Destination, service, port.Port)
 			clusterSpecifier.WeightedClusters.Clusters = append(clusterSpecifier.WeightedClusters.Clusters, &tcp.TcpProxy_WeightedCluster_ClusterWeight{
@@ -185,7 +185,7 @@ func buildOutboundNetworkFilters(node *model.Proxy,
 	routes []*networking.RouteDestination, push *model.PushContext,
 	port *model.Port, configMeta model.ConfigMeta) []*listener.Filter {
 	if len(routes) == 1 {
-		service := node.SidecarScope.ServiceForHostname(host.Name(routes[0].Destination.Host))
+		service := push.ServiceForHostname(node, host.Name(routes[0].Destination.Host))
 		clusterName := istio_route.GetDestinationCluster(routes[0].Destination, service, port.Port)
 		statPrefix := clusterName
 		// If stat name is configured, build the stat prefix from configured pattern.

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -129,7 +129,7 @@ func buildOutboundNetworkFiltersWithWeightedClusters(node *model.Proxy, routes [
 	}
 
 	for _, route := range routes {
-		service := node.SidecarScope.ServiceForHostname(host.Name(route.Destination.Host), push.ServiceByHostnameAndNamespace)
+		service := node.SidecarScope.ServiceForHostname(host.Name(route.Destination.Host))
 		if route.Weight > 0 {
 			clusterName := istio_route.GetDestinationCluster(route.Destination, service, port.Port)
 			clusterSpecifier.WeightedClusters.Clusters = append(clusterSpecifier.WeightedClusters.Clusters, &tcp.TcpProxy_WeightedCluster_ClusterWeight{
@@ -185,7 +185,7 @@ func buildOutboundNetworkFilters(node *model.Proxy,
 	routes []*networking.RouteDestination, push *model.PushContext,
 	port *model.Port, configMeta model.ConfigMeta) []*listener.Filter {
 	if len(routes) == 1 {
-		service := node.SidecarScope.ServiceForHostname(host.Name(routes[0].Destination.Host), push.ServiceByHostnameAndNamespace)
+		service := node.SidecarScope.ServiceForHostname(host.Name(routes[0].Destination.Host))
 		clusterName := istio_route.GetDestinationCluster(routes[0].Destination, service, port.Port)
 		statPrefix := clusterName
 		// If stat name is configured, build the stat prefix from configured pattern.

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -509,14 +509,14 @@ func modifyOutboundRouteConfig(in *plugin.InputParams, virtualHostname string, h
 			if hostname == "" && upstreams.Cluster == util.PassthroughCluster {
 				attrs = addVirtualDestinationServiceAttributes(make(attributes), util.PassthroughCluster)
 			} else {
-				svc := in.Node.SidecarScope.ServiceForHostname(hostname)
+				svc := in.Push.ServiceForHostname(in.Node, hostname)
 				attrs = addDestinationServiceAttributes(make(attributes), svc)
 			}
 			addFilterConfigToRoute(in, httpRoute, attrs, getQuotaSpec(in, hostname, isPolicyCheckDisabled))
 		case *route.RouteAction_WeightedClusters:
 			for _, weighted := range upstreams.WeightedClusters.Clusters {
 				_, _, hostname, _ := model.ParseSubsetKey(weighted.Name)
-				svc := in.Node.SidecarScope.ServiceForHostname(hostname)
+				svc := in.Push.ServiceForHostname(in.Node, hostname)
 				attrs := addDestinationServiceAttributes(make(attributes), svc)
 				weighted.TypedPerFilterConfig = addTypedServiceConfig(weighted.TypedPerFilterConfig, &mpb.ServiceConfig{
 					DisableCheckCalls: isPolicyCheckDisabled,

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -509,14 +509,14 @@ func modifyOutboundRouteConfig(push *model.PushContext, in *plugin.InputParams, 
 			if hostname == "" && upstreams.Cluster == util.PassthroughCluster {
 				attrs = addVirtualDestinationServiceAttributes(make(attributes), util.PassthroughCluster)
 			} else {
-				svc := in.Node.SidecarScope.ServiceForHostname(hostname, push.ServiceByHostnameAndNamespace)
+				svc := in.Node.SidecarScope.ServiceForHostname(hostname)
 				attrs = addDestinationServiceAttributes(make(attributes), svc)
 			}
 			addFilterConfigToRoute(in, httpRoute, attrs, getQuotaSpec(in, hostname, isPolicyCheckDisabled))
 		case *route.RouteAction_WeightedClusters:
 			for _, weighted := range upstreams.WeightedClusters.Clusters {
 				_, _, hostname, _ := model.ParseSubsetKey(weighted.Name)
-				svc := in.Node.SidecarScope.ServiceForHostname(hostname, push.ServiceByHostnameAndNamespace)
+				svc := in.Node.SidecarScope.ServiceForHostname(hostname)
 				attrs := addDestinationServiceAttributes(make(attributes), svc)
 				weighted.TypedPerFilterConfig = addTypedServiceConfig(weighted.TypedPerFilterConfig, &mpb.ServiceConfig{
 					DisableCheckCalls: isPolicyCheckDisabled,

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -318,7 +318,7 @@ func (mixerplugin) OnOutboundRouteConfiguration(in *plugin.InputParams, routeCon
 	for i := 0; i < len(routeConfiguration.VirtualHosts); i++ {
 		virtualHost := routeConfiguration.VirtualHosts[i]
 		for j := 0; j < len(virtualHost.Routes); j++ {
-			virtualHost.Routes[j] = modifyOutboundRouteConfig(in.Push, in, virtualHost.Name, virtualHost.Routes[j])
+			virtualHost.Routes[j] = modifyOutboundRouteConfig(in, virtualHost.Name, virtualHost.Routes[j])
 		}
 		routeConfiguration.VirtualHosts[i] = virtualHost
 	}
@@ -492,7 +492,7 @@ func addFilterConfigToRoute(in *plugin.InputParams, httpRoute *route.Route, attr
 	})
 }
 
-func modifyOutboundRouteConfig(push *model.PushContext, in *plugin.InputParams, virtualHostname string, httpRoute *route.Route) *route.Route {
+func modifyOutboundRouteConfig(in *plugin.InputParams, virtualHostname string, httpRoute *route.Route) *route.Route {
 	isPolicyCheckDisabled := disablePolicyChecks(outbound, in.Push.Mesh, in.Node)
 	// default config, to be overridden by per-weighted cluster
 	httpRoute.TypedPerFilterConfig = addTypedServiceConfig(httpRoute.TypedPerFilterConfig, &mpb.ServiceConfig{

--- a/pilot/pkg/networking/plugin/mixer/mixer_test.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer_test.go
@@ -419,11 +419,10 @@ func TestModifyOutboundRouteConfig(t *testing.T) {
 		},
 	}
 	cases := []struct {
-		serviceByHostnameAndNamespace map[host.Name]map[string]*model.Service
-		push                          *model.PushContext
-		node                          *model.Proxy
-		httpRoute                     *route.Route
-		quotaSpec                     []*mccpb.QuotaSpec
+		push      *model.PushContext
+		node      *model.Proxy
+		httpRoute *route.Route
+		quotaSpec []*mccpb.QuotaSpec
 	}{
 		{
 			push: &model.PushContext{
@@ -440,11 +439,6 @@ func TestModifyOutboundRouteConfig(t *testing.T) {
 				Action: &route.Route_Route{Route: &route.RouteAction{
 					ClusterSpecifier: &route.RouteAction_Cluster{Cluster: "outbound|||svc.ns3.svc.cluster.local"},
 				}}},
-			serviceByHostnameAndNamespace: map[host.Name]map[string]*model.Service{
-				host.Name("svc.ns3"): {
-					"ns3": &svc,
-				},
-			},
 			quotaSpec: []*mccpb.QuotaSpec{{
 				Rules: []*mccpb.QuotaRule{{Quotas: []*mccpb.Quota{{Quota: "requestcount", Charge: 100}}}},
 			}},
@@ -464,17 +458,9 @@ func TestModifyOutboundRouteConfig(t *testing.T) {
 				Action: &route.Route_Route{Route: &route.RouteAction{
 					ClusterSpecifier: &route.RouteAction_Cluster{Cluster: "outbound|||a.ns3.svc.cluster.local"},
 				}}},
-			serviceByHostnameAndNamespace: map[host.Name]map[string]*model.Service{
-				host.Name("a.ns3"): {
-					"ns3": &svc,
-				},
-			},
 		},
 	}
 	for _, c := range cases {
-		push := &model.PushContext{
-			ServiceByHostnameAndNamespace: c.serviceByHostnameAndNamespace,
-		}
 		c.node.SetSidecarScope(c.push)
 		in := plugin.InputParams{
 			Push: c.push,

--- a/pilot/pkg/networking/plugin/mixer/mixer_test.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer_test.go
@@ -480,7 +480,7 @@ func TestModifyOutboundRouteConfig(t *testing.T) {
 			Push: c.push,
 			Node: c.node,
 		}
-		tc := modifyOutboundRouteConfig(push, &in, "", c.httpRoute)
+		tc := modifyOutboundRouteConfig(&in, "", c.httpRoute)
 
 		mixerSvcConfigAny := tc.TypedPerFilterConfig["mixer"]
 		mixerSvcConfig := &mccpb.ServiceConfig{}

--- a/pilot/pkg/networking/plugin/mixer/mixer_test.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer_test.go
@@ -32,7 +32,6 @@ import (
 	istionetworking "istio.io/istio/pilot/pkg/networking"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	mccpb "istio.io/istio/pilot/pkg/networking/plugin/mixer/client"
-	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
@@ -410,14 +409,6 @@ func TestModifyOutboundRouteConfig(t *testing.T) {
 	}
 	ii := model.MakeIstioStore(l)
 	mesh := mesh.DefaultMeshConfig()
-	svc := model.Service{
-		Hostname: "svc.ns3",
-		Attributes: model.ServiceAttributes{
-			Name:      "svc",
-			Namespace: ns,
-			UID:       "istio://ns3/services/svc",
-		},
-	}
 	cases := []struct {
 		push      *model.PushContext
 		node      *model.Proxy

--- a/pilot/pkg/networking/plugin/mixer/mixer_test.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer_test.go
@@ -475,6 +475,7 @@ func TestModifyOutboundRouteConfig(t *testing.T) {
 		push := &model.PushContext{
 			ServiceByHostnameAndNamespace: c.serviceByHostnameAndNamespace,
 		}
+		c.node.SetSidecarScope(c.push)
 		in := plugin.InputParams{
 			Push: c.push,
 			Node: c.node,

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -35,18 +35,15 @@ import (
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/golang/protobuf/ptypes"
 
-	"istio.io/istio/pilot/pkg/config/kube/crd"
-	"istio.io/istio/pilot/pkg/networking/core"
-	"istio.io/istio/pilot/pkg/networking/plugin"
-	v2 "istio.io/istio/pilot/pkg/xds/v2"
-
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/pkg/log"
 
+	"istio.io/istio/pilot/pkg/config/kube/crd"
+	"istio.io/istio/pilot/pkg/networking/core"
+	"istio.io/istio/pilot/pkg/networking/plugin"
+
 	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/loadbalancer"
-	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
@@ -351,7 +348,7 @@ func BenchmarkRouteGeneration(b *testing.B) {
 				if len(r) == 0 {
 					b.Fatal("Got no routes!")
 				}
-				response = routeDiscoveryResponse(r, "", "", v2.RouteType)
+				response = routeDiscoveryResponse(r, "", "", v3.RouteType)
 			}
 			logDebug(b, response)
 		})
@@ -402,11 +399,10 @@ func BenchmarkEndpointGeneration(b *testing.B) {
 		endpoints int
 		services  int
 	}{
-		{100, 1},
+		{1, 100},
+		{10, 10},
+		{100, 10},
 		{1000, 1},
-		{10000, 1},
-		{100, 100},
-		{1000, 100},
 	}
 	adsLog.SetOutputLevel(log.WarnLevel)
 	var response interface{}
@@ -424,23 +420,12 @@ func BenchmarkEndpointGeneration(b *testing.B) {
 			proxy.SetSidecarScope(push)
 			b.ResetTimer()
 			for n := 0; n < b.N; n++ {
-				// This should correlate to pushEds()
-				// TODO directly call pushEeds, but mock/skip the grpc send
-
 				loadAssignments := make([]*endpoint.ClusterLoadAssignment, 0)
 				for svc := 0; svc < tt.services; svc++ {
-					l := s.loadAssignmentsForClusterIsolated(proxy, push, fmt.Sprintf("outbound|80||foo-%d.com", svc))
-
-					if l == nil {
-						continue
-					}
-
-					l = util.CloneClusterLoadAssignment(l)
-
-					loadbalancer.ApplyLocalityLBSetting(proxy.Locality, l, s.Env.Mesh().LocalityLbSetting, true)
+					l := s.generateEndpoints(fmt.Sprintf("outbound|80||foo-%d.com", svc), proxy, push, nil)
 					loadAssignments = append(loadAssignments, l)
 				}
-				response = endpointDiscoveryResponse(loadAssignments, version, push.Version, v2.EndpointType)
+				response = endpointDiscoveryResponse(loadAssignments, version, push.Version, v3.EndpointType)
 			}
 		})
 	}

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -310,7 +310,7 @@ func (s *DiscoveryServer) loadAssignmentsForClusterIsolated(proxy *model.Proxy, 
 	subsetLabels := push.SubsetToLabels(proxy, subsetName, hostname)
 
 	push.Mutex.Lock()
-	svc := proxy.SidecarScope.ServiceForHostname(hostname)
+	svc := push.ServiceForHostname(proxy, hostname)
 	push.Mutex.Unlock()
 	if svc == nil {
 		// Shouldn't happen here
@@ -473,7 +473,7 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *Connection, vers
 // getDestinationRule gets the DestinationRule for a given hostname. As an optimization, this also gets the service port,
 // which is needed to access the traffic policy from the destination rule.
 func getDestinationRule(push *model.PushContext, proxy *model.Proxy, hostname host.Name) *networkingapi.DestinationRule {
-	cfg := push.DestinationRule(proxy, proxy.SidecarScope.ServiceForHostname(hostname))
+	cfg := push.DestinationRule(proxy, push.ServiceForHostname(proxy, hostname))
 	if cfg != nil {
 		return cfg.Spec.(*networkingapi.DestinationRule)
 	}

--- a/releasenotes/25519.yaml
+++ b/releasenotes/25519.yaml
@@ -1,7 +1,0 @@
-apiVersion: release-notes/v1
-kind: bug-fix
-area: telemetry
-issue: 25154
-releaseNotes: |
-  Removed the `pilot_xds_eds_instances` and `pilot_xds_eds_all_locality_endpoints` Istiod metrics, which were not
-  accurate.

--- a/releasenotes/25519.yaml
+++ b/releasenotes/25519.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v1
+kind: bug-fix
+area: telemetry
+issue: 25154
+releaseNotes: |
+  Removed the `pilot_xds_eds_instances` and `pilot_xds_eds_all_locality_endpoints` Istiod metrics, which were not
+  accurate.


### PR DESCRIPTION
```
name                         old time/op    new time/op    delta
EndpointGeneration/1/100-8      257µs ±16%     157µs ±11%  -39.00%  (p=0.008 n=5+5)
EndpointGeneration/10/10-8      100µs ± 9%     102µs ±14%     ~     (p=0.841 n=5+5)
EndpointGeneration/100/10-8     590µs ±13%     626µs ±11%     ~     (p=0.310 n=5+5)
EndpointGeneration/1000/1-8     869µs ± 8%     940µs ± 7%     ~     (p=0.095 n=5+5)

name                         old alloc/op   new alloc/op   delta
EndpointGeneration/1/100-8     75.1kB ± 0%    75.1kB ± 0%     ~     (p=0.357 n=5+5)
EndpointGeneration/10/10-8     22.2kB ± 0%    22.2kB ± 0%     ~     (p=0.095 n=5+5)
EndpointGeneration/100/10-8    41.9kB ± 0%    42.0kB ± 0%     ~     (p=0.730 n=5+5)
EndpointGeneration/1000/1-8    37.7kB ± 3%    37.9kB ± 1%     ~     (p=0.690 n=5+5)

name                         old allocs/op  new allocs/op  delta
EndpointGeneration/1/100-8      1.30k ± 0%     1.30k ± 0%     ~     (all equal)
EndpointGeneration/10/10-8        395 ± 0%       395 ± 0%     ~     (all equal)
EndpointGeneration/100/10-8       401 ± 1%       401 ± 0%     ~     (p=0.730 n=5+5)
EndpointGeneration/1000/1-8      62.0 ± 0%      62.0 ± 0%     ~     (all equal)

```

The -39% is dramatically understated due to the n^2 behavior of the test. I couldn't get the benchmarks to use more than 100 services as it quickly got so slow the benchmark wouldn't finish. Real cluster dropping from 26 CPUs to 6 CPUs:
![2020-14-07_15-42-03](https://user-images.githubusercontent.com/623453/87483465-a0dacd80-c5e8-11ea-8010-e1da39c897ff.png)
