### PR TITLE
Remove inaccurate and non-performant EDS metrics

### DIFF
--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -606,8 +606,6 @@ func buildLocalityLbEndpointsFromShards(
 		push.AddMetric(model.ProxyStatusClusterNoInstances, clusterName, nil, "")
 	}
 
-	updateEdsStats(locEps, clusterName)
-
 	return locEps
 }
 
@@ -616,13 +614,4 @@ func buildEmptyClusterLoadAssignment(clusterName string) *endpoint.ClusterLoadAs
 	return &endpoint.ClusterLoadAssignment{
 		ClusterName: clusterName,
 	}
-}
-
-func updateEdsStats(locEps []*endpoint.LocalityLbEndpoints, cluster string) {
-	edsInstances.With(clusterTag.Value(cluster)).Record(float64(len(locEps)))
-	epc := 0
-	for _, locLbEps := range locEps {
-		epc += len(locLbEps.GetLbEndpoints())
-	}
-	edsAllLocalityEndpoints.With(clusterTag.Value(cluster)).Record(float64(epc))
 }

--- a/pilot/pkg/xds/monitoring.go
+++ b/pilot/pkg/xds/monitoring.go
@@ -27,7 +27,6 @@ import (
 
 var (
 	errTag     = monitoring.MustCreateLabel("err")
-	clusterTag = monitoring.MustCreateLabel("cluster")
 	nodeTag    = monitoring.MustCreateLabel("node")
 	typeTag    = monitoring.MustCreateLabel("type")
 	versionTag = monitoring.MustCreateLabel("version")

--- a/pilot/pkg/xds/monitoring.go
+++ b/pilot/pkg/xds/monitoring.go
@@ -44,18 +44,6 @@ var (
 		monitoring.WithLabels(nodeTag, errTag),
 	)
 
-	edsInstances = monitoring.NewGauge(
-		"pilot_xds_eds_instances",
-		"Instances for each cluster(grouped by locality), as of last push. Zero instances is an error.",
-		monitoring.WithLabels(clusterTag),
-	)
-
-	edsAllLocalityEndpoints = monitoring.NewGauge(
-		"pilot_xds_eds_all_locality_endpoints",
-		"Network endpoints for each cluster(across all localities), as of last push. Zero endpoints is an error.",
-		monitoring.WithLabels(clusterTag),
-	)
-
 	ldsReject = monitoring.NewGauge(
 		"pilot_xds_lds_reject",
 		"Pilot rejected LDS.",
@@ -206,8 +194,6 @@ func init() {
 		edsReject,
 		ldsReject,
 		rdsReject,
-		edsInstances,
-		edsAllLocalityEndpoints,
 		xdsExpiredNonce,
 		totalXDSRejects,
 		monServices,

--- a/releasenotes/25519.yaml
+++ b/releasenotes/25519.yaml
@@ -3,5 +3,5 @@ kind: bug-fix
 area: telemetry
 issue: 25154
 releaseNotes: |
-  Removed the `pilot_xds_eds_instances` and `pilot_xds_eds_all_locality_endpoints` Istiod metrics, which were not
+  *Removed* the `pilot_xds_eds_instances` and `pilot_xds_eds_all_locality_endpoints` Istiod metrics, which were not
   accurate.

--- a/releasenotes/25519.yaml
+++ b/releasenotes/25519.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v1
+kind: bug-fix
+area: telemetry
+issue: 25154
+releaseNotes: |
+  Removed the `pilot_xds_eds_instances` and `pilot_xds_eds_all_locality_endpoints` Istiod metrics, which were not
+  accurate.


### PR DESCRIPTION
```
name                           old time/op    new time/op    delta
EndpointGeneration/100/1-8       94.3µs ± 7%    89.7µs ±17%     ~     (p=0.635 n=3+3)
EndpointGeneration/1000/1-8       855µs ± 2%     822µs ± 3%     ~     (p=0.125 n=3+3)
EndpointGeneration/10000/1-8     7.62ms ± 6%    7.14ms ± 3%     ~     (p=0.162 n=3+3)
EndpointGeneration/100/100-8      714µs ± 3%     665µs ± 7%     ~     (p=0.156 n=3+3)
EndpointGeneration/1000/100-8    5.17ms ± 7%    6.45ms ±20%     ~     (p=0.193 n=3+3)

name                           old alloc/op   new alloc/op   delta
EndpointGeneration/100/1-8       6.59kB ± 0%    4.69kB ± 0%  -28.90%  (p=0.000 n=3+3)
EndpointGeneration/1000/1-8      37.9kB ± 0%    35.9kB ± 0%   -5.29%  (p=0.000 n=3+3)
EndpointGeneration/10000/1-8      312kB ± 5%     304kB ± 3%     ~     (p=0.434 n=3+3)
EndpointGeneration/100/100-8     89.9kB ± 0%    78.5kB ± 0%  -12.76%  (p=0.000 n=3+3)
EndpointGeneration/1000/100-8     569kB ± 4%     533kB ± 9%     ~     (p=0.310 n=3+3)

name                           old allocs/op  new allocs/op  delta
EndpointGeneration/100/1-8         60.7 ± 1%      21.0 ± 0%  -65.38%  (p=0.000 n=3+3)
EndpointGeneration/1000/1-8        60.7 ± 1%      21.0 ± 0%  -65.38%  (p=0.000 n=3+3)
EndpointGeneration/10000/1-8       63.3 ± 3%      29.0 ± 0%  -54.21%  (p=0.001 n=3+3)
EndpointGeneration/100/100-8      1.20k ± 0%     0.96k ± 0%     ~     (zero variance)
EndpointGeneration/1000/100-8     4.38k ± 6%     3.90k ±14%     ~     (p=0.225 n=3+3)
```

These metrics are both extremely costly and are actually not accurate. The metric tries to give a global view of the number of endpoints in a Service - this is wrong by definition, as each proxy will have a different view of EDS based on sidecar/network.

https://github.com/istio/istio/issues/25154