### PR TITLE
refactor pod lookup code

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -255,8 +255,12 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 
 	c.pods = newPodCache(c, kubeClient.KubeInformer().Core().V1().Pods(), func(key string) {
 		item, exists, err := c.endpoints.getInformer().GetStore().GetByKey(key)
-		if err != nil || !exists {
-			log.Debugf("Endpoint %v lookup failed, skipping stale endpoint", key)
+		if err != nil {
+			log.Debugf("Endpoint %v lookup failed with error %v, skipping stale endpoint", key, err)
+			return
+		}
+		if !exists {
+			log.Debugf("Endpoint %v not found, skipping stale endpoint", key)
 			return
 		}
 		c.queue.Push(func() error {

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -1592,7 +1592,7 @@ func TestEndpointUpdate(t *testing.T) {
 	}
 }
 
-// Validates that when Pilot sees Endpoint before the corresponding Pod, it loads Pod from K8S and proceed.
+// Validates that when Pilot sees Endpoint before the corresponding Pod, it triggers endpoint event on pod event.
 func TestEndpointUpdateBeforePodUpdate(t *testing.T) {
 	for mode, name := range EndpointModeNames {
 		mode := mode

--- a/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go
@@ -16,12 +16,14 @@ package controller
 
 import (
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
 	"istio.io/pkg/log"
 
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/schema/gvk"
@@ -97,10 +99,10 @@ func updateEDS(c *Controller, epc kubeEndpointsController, ep interface{}, event
 
 	log.Debugf("Handle EDS endpoint %s in namespace %s", svcName, ns)
 	var endpoints []*model.IstioEndpoint
-	if event != model.EventDelete {
-		endpoints = epc.buildIstioEndpoints(ep, host)
-	} else {
+	if event == model.EventDelete {
 		epc.forgetEndpoint(ep)
+	} else {
+		endpoints = epc.buildIstioEndpoints(ep, host)
 	}
 	fep := c.collectAllForeignEndpoints(svc)
 	_ = c.xdsUpdater.EDSUpdate(c.clusterID, string(host), ns, append(endpoints, fep...))
@@ -115,4 +117,33 @@ func updateEDS(c *Controller, epc kubeEndpointsController, ep interface{}, event
 			handler(si, event)
 		}
 	}
+}
+
+func getPod(c *Controller, ip string, ep *metav1.ObjectMeta, targetRef *v1.ObjectReference, host host.Name) *v1.Pod {
+	pod := c.pods.getPodByIP(ip)
+	if pod != nil {
+		return pod
+	}
+	// This means, the endpoint event has arrived before pod event.
+	// This might happen because PodCache is eventually consistent.
+	if targetRef != nil && targetRef.Kind == "Pod" {
+		key := kube.KeyFunc(targetRef.Name, targetRef.Namespace)
+		// There is a small chance getInformer may have the pod, but it hasn't
+		// made its way to the PodCache yet as it a shared queue.
+		podFromInformer, f, err := c.pods.informer.GetStore().GetByKey(key)
+		if err != nil || !f {
+			log.Debugf("Endpoint without pod %s %s.%s error: %v", ip, ep.Name, ep.Namespace, err)
+			endpointsWithNoPods.Increment()
+			if c.metrics != nil {
+				c.metrics.AddMetric(model.EndpointNoPod, string(host), nil, ip)
+			}
+			// Tell pod cache we want to queue the endpoint event when this pod arrives.
+			epkey := kube.KeyFunc(ep.Name, ep.Namespace)
+			c.pods.queueEndpointEventOnPodArrival(epkey, ip)
+			return nil
+		} else {
+			pod = podFromInformer.(*v1.Pod)
+		}
+	}
+	return pod
 }

--- a/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go
@@ -141,9 +141,8 @@ func getPod(c *Controller, ip string, ep *metav1.ObjectMeta, targetRef *v1.Objec
 			epkey := kube.KeyFunc(ep.Name, ep.Namespace)
 			c.pods.queueEndpointEventOnPodArrival(epkey, ip)
 			return nil
-		} else {
-			pod = podFromInformer.(*v1.Pod)
 		}
+		pod = podFromInformer.(*v1.Pod)
 	}
 	return pod
 }

--- a/pilot/pkg/serviceregistry/kube/controller/endpoints.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoints.go
@@ -16,6 +16,7 @@ package controller
 
 import (
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klabels "k8s.io/apimachinery/pkg/labels"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	listerv1 "k8s.io/client-go/listers/core/v1"
@@ -187,7 +188,7 @@ func (e *endpointsController) forgetEndpoint(endpoint interface{}) {
 	key := kube.KeyFunc(ep.Name, ep.Namespace)
 	for _, ss := range ep.Subsets {
 		for _, ea := range ss.Addresses {
-			e.c.pods.dropNeedsUpdate(key, ea.IP)
+			e.c.pods.endpointDeleted(key, ea.IP)
 		}
 	}
 }
@@ -195,37 +196,15 @@ func (e *endpointsController) forgetEndpoint(endpoint interface{}) {
 func (e *endpointsController) buildIstioEndpoints(endpoint interface{}, host host.Name) []*model.IstioEndpoint {
 	endpoints := make([]*model.IstioEndpoint, 0)
 	ep := endpoint.(*v1.Endpoints)
-	key := kube.KeyFunc(ep.Name, ep.Namespace)
 	for _, ss := range ep.Subsets {
 		for _, ea := range ss.Addresses {
-			pod := e.c.pods.getPodByIP(ea.IP)
+			pod := getPod(e.c, ea.IP, &metav1.ObjectMeta{Name: ep.Name, Namespace: ep.Namespace}, ea.TargetRef, host)
 			if pod == nil {
-				// This means, the endpoint event has arrived before pod event. This might happen because
-				// PodCache is eventually consistent.
-				if ea.TargetRef != nil && ea.TargetRef.Kind == "Pod" {
-					// There is a small chance getInformer may have the pod, but it hasn't made its way to the PodCache yet
-					// This is due to the shared queue. Try the getInformer store first
-					podFromInformer, f, err := e.c.pods.informer.GetStore().GetByKey(key)
-					if err != nil || !f {
-						// If pod is still not available, this an unusual case.
-						endpointsWithNoPods.Increment()
-						log.Errorf("Endpoint without pod %s %s.%s", ea.IP, ep.Name, ep.Namespace)
-						if e.c.metrics != nil {
-							e.c.metrics.AddMetric(model.EndpointNoPod, string(host), nil, ea.IP)
-						}
-						// Tell pod cache we want to get an update when this pod arrives
-						e.c.pods.recordNeedsUpdate(key, ea.IP)
-						continue
-					} else {
-						pod = podFromInformer.(*v1.Pod)
-					}
-				}
+				continue
 			}
-
 			builder := NewEndpointBuilder(e.c, pod)
 
-			// EDS and ServiceEntry use name for service port - ADS will need to
-			// map to numbers.
+			// EDS and ServiceEntry use name for service port - ADS will need to map to numbers.
 			for _, port := range ss.Ports {
 				istioEndpoint := builder.buildIstioEndpoint(ea.IP, port.Port, port.Name)
 				endpoints = append(endpoints, istioEndpoint)

--- a/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointslice.go
@@ -20,6 +20,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	discoveryv1alpha1 "k8s.io/api/discovery/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/informers/discovery/v1alpha1"
 	discoverylister "k8s.io/client-go/listers/discovery/v1alpha1"
@@ -152,14 +153,13 @@ func (esc *endpointSliceController) forgetEndpoint(endpoint interface{}) {
 	key := kube.KeyFunc(slice.Name, slice.Namespace)
 	for _, e := range slice.Endpoints {
 		for _, a := range e.Addresses {
-			esc.c.pods.dropNeedsUpdate(key, a)
+			esc.c.pods.endpointDeleted(key, a)
 		}
 	}
 }
 
 func (esc *endpointSliceController) buildIstioEndpoints(es interface{}, host host.Name) []*model.IstioEndpoint {
 	slice := es.(*discoveryv1alpha1.EndpointSlice)
-	key := kube.KeyFunc(slice.Name, slice.Namespace)
 	endpoints := make([]*model.IstioEndpoint, 0)
 	for _, e := range slice.Endpoints {
 		if e.Conditions.Ready != nil && !*e.Conditions.Ready {
@@ -167,33 +167,12 @@ func (esc *endpointSliceController) buildIstioEndpoints(es interface{}, host hos
 			continue
 		}
 		for _, a := range e.Addresses {
-			pod := esc.c.pods.getPodByIP(a)
+			pod := getPod(esc.c, a, &metav1.ObjectMeta{Name: slice.Name, Namespace: slice.Namespace}, e.TargetRef, host)
 			if pod == nil {
-				// This means, the endpoint event has arrived before pod event. This might happen because
-				// PodCache is eventually consistent.
-				if e.TargetRef != nil && e.TargetRef.Kind == "Pod" {
-					// There is a small chance getInformer may have the pod, but it hasn't made its way to the PodCache yet
-					// This is due to the shared queue. Try the getInformer store first
-					podFromInformer, f, err := esc.c.pods.informer.GetStore().GetByKey(key)
-					if err != nil || !f {
-						// If pod is still not available, this an unusual case.
-						endpointsWithNoPods.Increment()
-						log.Errorf("Endpoint without pod %s %s.%s", a, host, slice.Namespace)
-						if esc.c.metrics != nil {
-							esc.c.metrics.AddMetric(model.EndpointNoPod, string(host), nil, a)
-						}
-						// Tell pod cache we want to get an update when this pod arrives
-						esc.c.pods.recordNeedsUpdate(key, a)
-						continue
-					} else {
-						pod = podFromInformer.(*v1.Pod)
-					}
-				}
+				continue
 			}
-
 			builder := esc.newEndpointBuilder(pod, e)
-			// EDS and ServiceEntry use name for service port - ADS will need to
-			// map to numbers.
+			// EDS and ServiceEntry use name for service port - ADS will need to map to numbers.
 			for _, port := range slice.Ports {
 				var portNum int32
 				if port.Port != nil {

--- a/pilot/pkg/serviceregistry/kube/controller/pod.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod.go
@@ -15,16 +15,12 @@
 package controller
 
 import (
-	"context"
 	"fmt"
 	"sync"
 
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/cache"
-
-	"istio.io/pkg/log"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
@@ -44,21 +40,23 @@ type PodCache struct {
 	// pod cache if a pod changes IP.
 	IPByPods map[string]string
 
-	// map of IP to endpoint names
-	needResync     map[string]sets.Set
-	endpointUpdate func(string)
+	// needResync is map of IP to endpoint names. This is used to requeue endpoint
+	// events when pod event comes. This typically happens when pod is not available
+	// in podCache when endpoint event comes.
+	needResync         map[string]sets.Set
+	queueEndpointEvent func(string)
 
 	c *Controller
 }
 
-func newPodCache(c *Controller, informer coreinformers.PodInformer, endpointUpdate func(string)) *PodCache {
+func newPodCache(c *Controller, informer coreinformers.PodInformer, queueEndpointEvent func(string)) *PodCache {
 	out := &PodCache{
-		informer:       informer.Informer(),
-		c:              c,
-		podsByIP:       make(map[string]string),
-		IPByPods:       make(map[string]string),
-		needResync:     make(map[string]sets.Set),
-		endpointUpdate: endpointUpdate,
+		informer:           informer.Informer(),
+		c:                  c,
+		podsByIP:           make(map[string]string),
+		IPByPods:           make(map[string]string),
+		needResync:         make(map[string]sets.Set),
+		queueEndpointEvent: queueEndpointEvent,
 	}
 
 	return out
@@ -145,20 +143,33 @@ func (pc *PodCache) update(ip, key string) {
 	if endpointsToUpdate, f := pc.needResync[ip]; f {
 		delete(pc.needResync, ip)
 		for ep := range endpointsToUpdate {
-			pc.endpointUpdate(ep)
+			pc.queueEndpointEvent(ep)
 		}
 	}
 
 	pc.proxyUpdates(ip)
 }
 
-func (pc *PodCache) recordNeedsUpdate(key, ip string) {
+// queueEndpointEventOnPodArrival registers this endpoint and queues endpoint event
+// when the corresponding pod arrives.
+func (pc *PodCache) queueEndpointEventOnPodArrival(key, ip string) {
 	pc.Lock()
 	defer pc.Unlock()
 	if _, f := pc.needResync[ip]; !f {
 		pc.needResync[ip] = sets.NewSet(key)
 	} else {
 		pc.needResync[ip].Insert(key)
+	}
+	endpointsPendingPodUpdate.Record(float64(len(pc.needResync)))
+}
+
+// endpointDeleted cleans up endpoint from resync endpoint list.
+func (pc *PodCache) endpointDeleted(key string, ip string) {
+	pc.Lock()
+	defer pc.Unlock()
+	delete(pc.needResync[ip], key)
+	if len(pc.needResync[ip]) == 0 {
+		delete(pc.needResync, ip)
 	}
 	endpointsPendingPodUpdate.Record(float64(len(pc.needResync)))
 }
@@ -188,24 +199,4 @@ func (pc *PodCache) getPodByIP(addr string) *v1.Pod {
 		return nil
 	}
 	return item.(*v1.Pod)
-}
-
-// getPod loads the pod from k8s.
-func (pc *PodCache) getPod(name string, namespace string) *v1.Pod {
-	pod, err := pc.c.client.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-	if err != nil {
-		log.Warnf("failed to get pod %s/%s from kube-apiserver: %v", namespace, name, err)
-		return nil
-	}
-	return pod
-}
-
-func (pc *PodCache) dropNeedsUpdate(key string, ip string) {
-	pc.Lock()
-	defer pc.Unlock()
-	delete(pc.needResync[ip], key)
-	if len(pc.needResync[ip]) == 0 {
-		delete(pc.needResync, ip)
-	}
-	endpointsPendingPodUpdate.Record(float64(len(pc.needResync)))
 }


### PR DESCRIPTION
The pod lookup exists in endpoint and endpoint slice - This PR refactors it. Also there was a bug in key used while getting pod from shared informer (was using endpoint key instead of pod key) - fixed that. Renamed some functions.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
