### PR TITLE
optimize memory usage (#25531)

### DIFF
--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	"fmt"
+	"hash/crc32"
 	"sort"
 	"strings"
 	"time"
@@ -46,6 +47,16 @@ type ConfigKey struct {
 	Kind      resource.GroupVersionKind
 	Name      string
 	Namespace string
+}
+
+func (key ConfigKey) HashCode() uint32 {
+	var result uint32
+	result = 31*result + crc32.ChecksumIEEE([]byte(key.Kind.Kind))
+	result = 31*result + crc32.ChecksumIEEE([]byte(key.Kind.Version))
+	result = 31*result + crc32.ChecksumIEEE([]byte(key.Kind.Group))
+	result = 31*result + crc32.ChecksumIEEE([]byte(key.Namespace))
+	result = 31*result + crc32.ChecksumIEEE([]byte(key.Name))
+	return result
 }
 
 // ConfigsOfKind extracts configs of the specified kind.


### PR DESCRIPTION
Use ConfigKey for map keys will waste too much memory.

Before Optimize:

![image](https://user-images.githubusercontent.com/1676951/87531112-cf79a680-c6c3-11ea-975b-d48131d8df77.png)

After Optimize

![image](https://user-images.githubusercontent.com/1676951/87531121-d4d6f100-c6c3-11ea-951d-c1c933511477.png)


[x] Performance and Scalability