### PR TITLE
[WIP] do not append transport socket matches for egress gateway istio mtls

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -905,7 +905,9 @@ func applyUpstreamTLSSettings(opts *buildClusterOpts, tls *networking.ClientTLSS
 	// Apply auto mtls to clusters excluding these kind of headless service
 	if c.GetType() != cluster.Cluster_ORIGINAL_DST {
 		// convert to transport socket matcher if the mode was auto detected
-		if tls.Mode == networking.ClientTLSSettings_ISTIO_MUTUAL && mtlsCtxType == autoDetected {
+		if tls.Mode == networking.ClientTLSSettings_ISTIO_MUTUAL && mtlsCtxType == autoDetected &&
+			!strings.Contains(opts.cluster.Name, "istio-egressgateway") {
+
 			transportSocket := c.TransportSocket
 			c.TransportSocket = nil
 			c.TransportSocketMatches = []*cluster.Cluster_TransportSocketMatch{


### PR DESCRIPTION
Please provide a description for what this PR is for.

One possible fix to: https://github.com/istio/istio/issues/23910

Egress gateway does not have the `security.istio.io/tlsMode: istio`, and currently if ISTIO_MUTUAL is specified as the tls mode in the DestinationRule (see [here](https://github.com/istio/istio/issues/23910#issuecomment-644172882)), sidecar proxies are configured with TransPortSocketMatch for that label and expect istio-egressgateway to have it.

However, if the `security.istio.io/tlsMode: istio` label is added to egress gateway, it does not have a listener configured with MUTUAL_TLS port, so auto-mtls is broken by default unless a Gateway resource is explicitly defined with the port

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ X ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
