### PR TITLE
Pin number of CPUs for benchmark

### DIFF
--- a/prow/benchtest.sh
+++ b/prow/benchtest.sh
@@ -27,6 +27,7 @@ set -eux
 GCS_BENCHMARK_DIR="${GCS_BENCHMARK_DIR:-istio-prow/benchmarks}"
 
 BENCHMARK_COUNT="${BENCHMARK_COUNT:-5}"
+BENCHMARK_CPUS="${BENCHMARK_CPUS:-8}"
 
 REPORT_JUNIT="${REPORT_JUNIT:-${ARTIFACTS}/junit_benchmarks.xml}"
 REPORT_PLAINTEXT="${REPORT_PLAINTEXT:-${ARTIFACTS}/benchmark-log.txt}"
@@ -38,7 +39,11 @@ COMPARE_GIT_SHA="${COMPARE_GIT_SHA:-${PULL_BASE_SHA:-${GIT_SHA}}}"
 case "${1}" in
   run)
     shift
-    benchmarkjunit "$@" -l "${REPORT_PLAINTEXT}" --output="${REPORT_JUNIT}" --test-arg "--benchmem" --test-arg "--count=${BENCHMARK_COUNT}" --test-arg "--test.timeout=30m"
+    benchmarkjunit "$@" -l "${REPORT_PLAINTEXT}" --output="${REPORT_JUNIT}" \
+      --test-arg "--benchmem" \
+      --test-arg "--count=${BENCHMARK_COUNT}" \
+      --test-arg "--cpu=${BENCHMARK_CPUS}" \
+      --test-arg "--test.timeout=30m"
     # Print out the results as well for ease of debugging, so they are in the logs instead of just output
     cat "${REPORT_PLAINTEXT}"
     ;;


### PR DESCRIPTION
Right now its using 16 CPUs but is limited to 8. I think this leads to
flaky results

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
