### PR TITLE
[pilot/gateway] controller: fix range iterator issue

### DIFF
--- a/pilot/pkg/config/kube/gateway/controller.go
+++ b/pilot/pkg/config/kube/gateway/controller.go
@@ -101,8 +101,8 @@ func (c controller) List(typ resource.GroupVersionKind, namespace string) ([]mod
 		return nil, fmt.Errorf("failed to list type Namespaces: %v", err)
 	}
 	namespaces := map[string]*corev1.Namespace{}
-	for _, ns := range nsl.Items {
-		namespaces[ns.Name] = &ns
+	for i, ns := range nsl.Items {
+		namespaces[ns.Name] = &nsl.Items[i]
 	}
 	input := &KubernetesResources{
 		GatewayClass: gatewayClass,


### PR DESCRIPTION
Signed-off-by: Gaurav Singh <gaurav1086@gmail.com>

Please provide a description for what this PR is for.

Go uses the same address variable while iterating in a range, so use a copy when using its address, otherwise we end up using the last value for all iterations.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[X ] Developer Infrastructure
