### PR TITLE
[pilot] ReconcileStatuses: fix iterator range issue

### DIFF
--- a/pilot/pkg/status/state.go
+++ b/pilot/pkg/status/state.go
@@ -256,7 +256,7 @@ func ReconcileStatuses(current map[string]interface{}, desired Progress, clock c
 	conditionIndex := -1
 	for i, c := range currentStatus.Conditions {
 		if c.Type == Reconciled {
-			currentCondition = &c
+			currentCondition = &currentStatus.Conditions[i]
 			conditionIndex = i
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Gaurav Singh <gaurav1086@gmail.com>

Go uses the same address variable while iterating in a range, so use a copy when using its address, otherwise we end up using the last value for all iterations.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[X ] Developer Infrastructure