### PR TITLE
[pilot/sidecar_test] TestSidecarOutboundTrafficPolicy: fix range iterator issue

### DIFF
--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -1407,10 +1407,10 @@ outboundTrafficPolicy:
 		},
 	}
 
-	for _, test := range tests {
+	for i, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ps := NewPushContext()
-			ps.Mesh = &test.meshConfig
+			ps.Mesh = &tests[i].meshConfig
 
 			var sidecarScope *SidecarScope
 			if test.sidecar == nil {


### PR DESCRIPTION
Signed-off-by: Gaurav Singh <gaurav1086@gmail.com>

Please provide a description for what this PR is for.
Go uses the same address variable while iterating in a range, so use a copy when using its address, otherwise we end up using the last value for all iterations.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[X ] Developer Infrastructure
