### PR TITLE
prototype(testing): experimental monitoring interface for allowing swapping of metrics backends

### DIFF
--- a/pkg/test/env/istio.go
+++ b/pkg/test/env/istio.go
@@ -88,7 +88,7 @@ var (
 	RedisInstallFilePath = path.Join(IstioSrc, "pkg/test/framework/components/redis/redis.yaml")
 
 	// StackdriverInstallFilePath is the stackdriver installation file.
-	StackdriverInstallFilePath = path.Join(IstioSrc, "pkg/test/framework/components/stackdriver/stackdriver.yaml")
+	StackdriverInstallFilePath = path.Join(IstioSrc, "pkg/test/framework/components/monitoring/stackdriver/stackdriver.yaml")
 
 	// GCEMetadataServerInstallFilePath is the GCE Metadata Server installation file.
 	GCEMetadataServerInstallFilePath = path.Join(IstioSrc, "pkg/test/framework/components/gcemetadata/gce_metadata_server.yaml")

--- a/pkg/test/framework/components/monitoring/monitoring.go
+++ b/pkg/test/framework/components/monitoring/monitoring.go
@@ -1,0 +1,81 @@
+package monitoring
+
+import (
+	"context"
+	"net"
+)
+
+// This tag contains the mappings to the labels used in various
+// backends for the data. Current known backends: prom, stackdriver.
+const TagName = "istio"
+
+type Workload struct {
+	IPAddress         net.IP `istio:"prom=ip"`
+	Name              string `istio:"prom=workload,stackdriver=workload_name"`
+	Namespace         string `istio:"prom=workload_namespace,stackdriver=workload_namespace"`
+	Owner             string `istio:"stackdriver=owner"`
+	App               string `istio:"prom=app,stackdriver=canonical_service_name"` // should these (app, version) be removed for duplication?
+	Version           string `istio:"prom=version,stackdriver=canonical_revision"`
+	Principal         string `istio:"prom=principal,stackdriver=principal"`
+	CanonicalService  string `istio:"prom=canonical_service,stackdriver=canonical_service_name"`
+	CanonicalRevision string `istio:"prom=canonical_revision,stackdriver=canonical_revision"`
+	InstanceName      string
+	Location          string
+	Container         string
+	Port              string `istio:"stackdriver=port"`
+}
+
+type Protocol int
+
+const (
+	UnknownProtocol Protocol = iota
+	HTTP
+	GRPC
+	TCP
+)
+
+type Request struct {
+	Protocol                    Protocol `istio:"prom=protocol,stackdriver=request_protocol"`
+	ResponseCode                string   `istio:"prom=response_code,stackdriver=response_code"`
+	ResponseFlags               string   `istio:"prom=response_flags"`
+	DestinationService          string   `istio:"prom=destination_service"`
+	DestinationServiceName      string   `istio:"prom=destination_service_name,stackdriver=destination_service_name"`
+	DestinationServiceNamespace string   `istio:"prom=destination_service_namespace,stackdriver=destination_service_namespace"`
+}
+
+type SecurityPolicy string
+
+const (
+	UnknownSecurityPolicy SecurityPolicy = "unknown"
+	NoSecurityPolicy                     = "none"
+	MutualTLS                            = "mutual_tls" // this is probably going to be an issue, need to toLower() or toUpper in appropriate place
+)
+
+type TrafficContext struct {
+	MeshUID                  string         `istio:"stackdriver=mesh_uid`
+	Reporter                 string         `istio:"prom=reporter"`
+	SourceCluster            string         `istio:"prom=source_cluster"`
+	DestinationCluster       string         `istio:"prom=destination_cluster"`
+	ConnectionSecurityPolicy SecurityPolicy `istio:"prom=connection_security_policy,stackdriver=service_authentication_policy"`
+}
+
+type TrafficDimensions struct {
+	Source      Workload
+	Destination Workload
+	Request     Request
+	Context     TrafficContext
+}
+
+type MetricsService interface {
+	// Requests returns the number of recorded requests matching the dimensions
+	// passed in.
+	Requests(context.Context, TrafficDimensions) (float64, error)
+
+	// probably need a break-glass Query(ctx, string) (float64, error) method
+	// if this was going to be expanded.
+
+	// not sure quite what the control-plane metrics querying should look like
+	// yet. Those tend to be less about dimensions, and more about the individual
+	// stat. May be enough to have methods like: ProxyConvergenceTime(), etc.,
+	// as needed.
+}

--- a/pkg/test/framework/components/monitoring/prometheus/kube.go
+++ b/pkg/test/framework/components/monitoring/prometheus/kube.go
@@ -1,0 +1,230 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheus
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"time"
+
+	prometheusApi "github.com/prometheus/client_golang/api"
+	prometheusApiV1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	kubeApiMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	istioKube "istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/test/env"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/monitoring"
+	"istio.io/istio/pkg/test/framework/resource"
+	testKube "istio.io/istio/pkg/test/kube"
+	"istio.io/istio/pkg/test/scopes"
+	"istio.io/istio/pkg/test/util/retry"
+)
+
+const (
+	serviceName = "prometheus"
+	appName     = "prometheus"
+)
+
+var (
+	retryTimeout = retry.Timeout(time.Second * 120)
+	retryDelay   = retry.Delay(time.Second * 5)
+
+	_ Instance = &kubeComponent{}
+	// _ io.Closer = &kubeComponent{}
+)
+
+type kubeComponent struct {
+	id resource.ID
+
+	api       prometheusApiV1.API
+	forwarder istioKube.PortForwarder
+	cluster   resource.Cluster
+	cleanup   func() error
+}
+
+func getPrometheusYaml() (string, error) {
+	yamlBytes, err := ioutil.ReadFile(filepath.Join(env.IstioSrc, "samples/addons/prometheus.yaml"))
+	if err != nil {
+		return "", err
+	}
+	yaml := string(yamlBytes)
+	// For faster tests, drop scrape interval
+	yaml = strings.ReplaceAll(yaml, "scrape_interval: 15s", "scrape_interval: 5s")
+	yaml = strings.ReplaceAll(yaml, "scrape_timeout: 10s", "scrape_timeout: 5s")
+	return yaml, nil
+}
+
+func installPrometheus(ctx resource.Context, ns string) error {
+	yaml, err := getPrometheusYaml()
+	if err != nil {
+		return err
+	}
+	return ctx.Config().ApplyYAML(ns, yaml)
+}
+
+func removePrometheus(ctx resource.Context, ns string) error {
+	yaml, err := getPrometheusYaml()
+	if err != nil {
+		return err
+	}
+	return ctx.Config().DeleteYAML(ns, yaml)
+}
+
+func newKube(ctx resource.Context, cfgIn Config) (Instance, error) {
+	c := &kubeComponent{
+		cluster: resource.ClusterOrDefault(cfgIn.Cluster, ctx.Environment()),
+	}
+	c.id = ctx.TrackResource(c)
+	// Find the Prometheus pod and service, and start forwarding a local port.
+	cfg, err := istio.DefaultConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if !cfgIn.SkipDeploy {
+		if err := installPrometheus(ctx, cfg.TelemetryNamespace); err != nil {
+			return nil, err
+		}
+
+		c.cleanup = func() error {
+			return removePrometheus(ctx, cfg.TelemetryNamespace)
+		}
+	}
+	fetchFn := testKube.NewSinglePodFetch(c.cluster, cfg.TelemetryNamespace, fmt.Sprintf("app=%s", appName))
+	pods, err := testKube.WaitUntilPodsAreReady(fetchFn)
+	if err != nil {
+		return nil, err
+	}
+	pod := pods[0]
+
+	svc, err := c.cluster.CoreV1().Services(cfg.TelemetryNamespace).Get(context.TODO(), serviceName, kubeApiMeta.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	port := uint16(svc.Spec.Ports[0].Port)
+
+	forwarder, err := c.cluster.NewPortForwarder(pod.Name, pod.Namespace, "", 0, int(port))
+	if err != nil {
+		return nil, err
+	}
+
+	if err := forwarder.Start(); err != nil {
+		return nil, err
+	}
+	c.forwarder = forwarder
+	scopes.Framework.Debugf("initialized Prometheus port forwarder: %v", forwarder.Address())
+
+	address := fmt.Sprintf("http://%s", forwarder.Address())
+	var client prometheusApi.Client
+	client, err = prometheusApi.NewClient(prometheusApi.Config{Address: address})
+	if err != nil {
+		return nil, err
+	}
+
+	c.api = prometheusApiV1.NewAPI(client)
+
+	return c, nil
+}
+
+func (c *kubeComponent) ID() resource.ID {
+	return c.id
+}
+
+func (c *kubeComponent) Requests(ctx context.Context, dims monitoring.TrafficDimensions) (float64, error) {
+	query := buildQuery(dims)
+
+	//fmt.Println("QUERY: ", query)
+	val, warnings, err := c.api.Query(ctx, query, time.Now())
+	if err != nil {
+		return 0, fmt.Errorf("failure issuing requests query %q: %v", query, err)
+	}
+
+	for _, warning := range warnings {
+		fmt.Println("warning: ", warning)
+	}
+
+	if val.Type() != model.ValVector {
+		return 0, fmt.Errorf("value not a model.Vector; was %s", val.Type().String())
+	}
+
+	value := val.(model.Vector)
+	valueCount := 0.0
+	for _, sample := range value {
+		valueCount += float64(sample.Value)
+	}
+
+	return valueCount, nil
+}
+
+func buildQuery(dims monitoring.TrafficDimensions) string {
+	var sumClause strings.Builder
+	var queryBody strings.Builder
+	trafficCtx := dims.Context
+	v := reflect.ValueOf(trafficCtx)
+	addDimensionsForValue(v, &sumClause, &queryBody)
+	v = reflect.ValueOf(dims.Request)
+	addDimensionsForValue(v, &sumClause, &queryBody)
+	v = reflect.ValueOf(dims.Destination)
+	addDimensionsWithPrefix(v, "destination_", &sumClause, &queryBody)
+	v = reflect.ValueOf(dims.Source)
+	addDimensionsWithPrefix(v, "source_", &sumClause, &queryBody)
+
+	sc := strings.TrimSuffix(sumClause.String(), ",")
+	qb := strings.TrimSuffix(queryBody.String(), ",")
+
+	return fmt.Sprintf("sum by (%s) (istio_requests_total{%s})", sc, qb)
+}
+
+func addDimensionsForValue(v reflect.Value, sumClause, queryBody *strings.Builder) {
+	addDimensionsWithPrefix(v, "", sumClause, queryBody)
+}
+
+func addDimensionsWithPrefix(v reflect.Value, prefix string, sumClause, queryBody *strings.Builder) {
+	for i := 0; i < v.NumField(); i++ {
+		tag := v.Type().Field(i).Tag.Get(monitoring.TagName)
+		// Skip if tag is not defined or ignored
+		if tag == "" || tag == "-" {
+			continue
+		}
+
+		strVal, ok := v.Field(i).Interface().(string)
+		if !ok || strVal == "" {
+			continue
+		}
+		addDimension(tag, prefix, strVal, sumClause, queryBody)
+	}
+}
+
+func addDimension(tag, prefix, dimension string, sumClause, queryBody *strings.Builder) {
+	var label string
+	args := strings.Split(tag, ",")
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "prom=") {
+			label = strings.TrimPrefix(arg, "prom=")
+			break
+		}
+	}
+	if label == "" {
+		return
+	}
+	sumClause.WriteString(prefix + label + ",")
+	queryBody.WriteString(fmt.Sprintf("%s%s=~\"%s\",", prefix, label, dimension))
+}

--- a/pkg/test/framework/components/monitoring/prometheus/prometheus.go
+++ b/pkg/test/framework/components/monitoring/prometheus/prometheus.go
@@ -1,0 +1,41 @@
+package prometheus
+
+import (
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/framework/components/monitoring"
+	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/framework/resource/environment"
+)
+
+type Instance interface {
+	resource.Resource
+	monitoring.MetricsService
+}
+
+type Config struct {
+	// Cluster to be used in a multicluster environment
+	Cluster resource.Cluster
+
+	// If true, connect to an existing prometheus rather than creating a new one
+	SkipDeploy bool
+}
+
+// New returns a new instance of echo.
+func New(ctx resource.Context, c Config) (i Instance, err error) {
+	err = resource.UnsupportedEnvironment(ctx.Environment())
+	ctx.Environment().Case(environment.Kube, func() {
+		i, err = newKube(ctx, c)
+	})
+	return
+}
+
+// NewOrFail returns a new Prometheus instance or fails test.
+func NewOrFail(t test.Failer, ctx resource.Context, c Config) Instance {
+	t.Helper()
+	i, err := New(ctx, c)
+	if err != nil {
+		t.Fatalf("prometheus.NewOrFail: %v", err)
+	}
+
+	return i
+}

--- a/pkg/test/framework/components/monitoring/stackdriver/kube.go
+++ b/pkg/test/framework/components/monitoring/stackdriver/kube.go
@@ -1,0 +1,302 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stackdriver
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"strings"
+	"time"
+
+	istioKube "istio.io/istio/pkg/kube"
+	environ "istio.io/istio/pkg/test/env"
+	"istio.io/istio/pkg/test/framework/components/monitoring"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/resource"
+	testKube "istio.io/istio/pkg/test/kube"
+	"istio.io/istio/pkg/test/scopes"
+
+	jsonpb "github.com/golang/protobuf/jsonpb"
+	monitoredres "google.golang.org/genproto/googleapis/api/monitoredres"
+	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
+)
+
+const (
+	stackdriverNamespace = "istio-stackdriver"
+	stackdriverPort      = 8091
+)
+
+var (
+	_ Instance  = &kubeComponent{}
+	_ io.Closer = &kubeComponent{}
+)
+
+type kubeComponent struct {
+	id        resource.ID
+	ns        namespace.Instance
+	forwarder istioKube.PortForwarder
+	cluster   resource.Cluster
+}
+
+func newKube(ctx resource.Context, cfg Config) (Instance, error) {
+	c := &kubeComponent{
+		cluster: resource.ClusterOrDefault(cfg.Cluster, ctx.Environment()),
+	}
+	c.id = ctx.TrackResource(c)
+	var err error
+	scopes.Framework.Info("=== BEGIN: Deploy Stackdriver ===")
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("stackdriver deployment failed: %v", err) // nolint:golint
+			scopes.Framework.Infof("=== FAILED: Deploy Stackdriver ===")
+			_ = c.Close()
+		} else {
+			scopes.Framework.Info("=== SUCCEEDED: Deploy Stackdriver ===")
+		}
+	}()
+
+	c.ns, err = namespace.New(ctx, namespace.Config{
+		Prefix: stackdriverNamespace,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not create %s Namespace for Stackdriver install; err:%v", stackdriverNamespace, err)
+	}
+
+	// apply stackdriver YAML
+	if err := c.cluster.ApplyYAMLFiles(c.ns.Name(), environ.StackdriverInstallFilePath); err != nil {
+		return nil, fmt.Errorf("failed to apply rendered %s, err: %v", environ.StackdriverInstallFilePath, err)
+	}
+
+	fetchFn := testKube.NewSinglePodFetch(c.cluster, c.ns.Name(), "app=stackdriver")
+	pods, err := testKube.WaitUntilPodsAreReady(fetchFn)
+	if err != nil {
+		return nil, err
+	}
+	pod := pods[0]
+
+	forwarder, err := c.cluster.NewPortForwarder(pod.Name, pod.Namespace, "", 0, stackdriverPort)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := forwarder.Start(); err != nil {
+		return nil, err
+	}
+	c.forwarder = forwarder
+	scopes.Framework.Debugf("initialized stackdriver port forwarder: %v", forwarder.Address())
+
+	return c, nil
+}
+
+func (c *kubeComponent) ListTimeSeries() ([]*monitoringpb.TimeSeries, error) {
+	client := http.Client{
+		Timeout: 5 * time.Second,
+	}
+	resp, err := client.Get("http://" + c.forwarder.Address() + "/timeseries")
+	if err != nil {
+		return []*monitoringpb.TimeSeries{}, err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return []*monitoringpb.TimeSeries{}, err
+	}
+	var r monitoringpb.ListTimeSeriesResponse
+	err = jsonpb.UnmarshalString(string(body), &r)
+	if err != nil {
+		return []*monitoringpb.TimeSeries{}, err
+	}
+	var ret []*monitoringpb.TimeSeries
+	for _, t := range r.TimeSeries {
+		ret = append(ret, t)
+	}
+	return ret, nil
+}
+
+func (c *kubeComponent) ID() resource.ID {
+	return c.id
+}
+
+// Close implements io.Closer.
+func (c *kubeComponent) Close() error {
+	return nil
+}
+
+func (c *kubeComponent) GetStackdriverNamespace() string {
+	return c.ns.Name()
+}
+
+func monitoredResourceTemplate(dims monitoring.TrafficDimensions) *monitoredres.MonitoredResource {
+	mr := &monitoredres.MonitoredResource{Labels: make(map[string]string)}
+
+	// we'd have to figure out some way of determining `gce_instance`
+	if dims.Context.Reporter == "source" {
+		mr.Type = "k8s_pod"
+
+		if dims.Context.SourceCluster != "" {
+			mr.Labels["cluster_name"] = dims.Context.SourceCluster
+		}
+		if dims.Source.Location != "" {
+			mr.Labels["location"] = dims.Source.Location
+		}
+		if dims.Source.Namespace != "" {
+			mr.Labels["namespace_name"] = dims.Source.Namespace
+		}
+		if dims.Source.InstanceName != "" {
+			mr.Labels["pod_name"] = dims.Source.InstanceName
+		}
+
+		return mr
+	}
+
+	mr.Type = "k8s_container"
+	if dims.Context.DestinationCluster != "" {
+		mr.Labels["cluster_name"] = dims.Context.DestinationCluster
+	}
+	if dims.Destination.Location != "" {
+		mr.Labels["location"] = dims.Destination.Location
+	}
+	if dims.Destination.Namespace != "" {
+		mr.Labels["namespace_name"] = dims.Destination.Namespace
+	}
+	if dims.Destination.InstanceName != "" {
+		mr.Labels["pod_name"] = dims.Destination.InstanceName
+	}
+	if dims.Destination.Container != "" {
+		mr.Labels["container_name"] = dims.Destination.Container
+	}
+	return mr
+}
+
+func metricLabels(dims monitoring.TrafficDimensions) map[string]string {
+	l := make(map[string]string)
+
+	v := reflect.ValueOf(dims.Context)
+	for k, v := range labelsForValue(v) {
+		l[k] = v
+	}
+	v = reflect.ValueOf(dims.Request)
+	for k, v := range labelsForValue(v) {
+		l[k] = v
+	}
+	v = reflect.ValueOf(dims.Destination)
+	for k, v := range labelsForValueWithPrefix(v, "destination_") {
+		l[k] = v
+	}
+	v = reflect.ValueOf(dims.Source)
+	for k, v := range labelsForValueWithPrefix(v, "source_") {
+		l[k] = v
+	}
+
+	return l
+}
+
+func (c *kubeComponent) Requests(ctx context.Context, dims monitoring.TrafficDimensions) (float64, error) {
+
+	wantMetricType := "istio.io/service/server/request_count"
+	if dims.Context.Reporter == "source" {
+		wantMetricType = "istio.io/service/client/request_count"
+	}
+
+	wantMR := monitoredResourceTemplate(dims)
+	wantLabels := metricLabels(dims)
+
+	timeseries, err := c.ListTimeSeries()
+	if err != nil {
+		return 0, fmt.Errorf("failure retrieving time-series: %v", err)
+	}
+	var sum int64
+	for _, ts := range timeseries {
+		if ts.Metric.Type != wantMetricType {
+			continue
+		}
+		res := ts.Resource
+		if res == nil {
+			continue
+		}
+		if res.Type != wantMR.Type {
+			continue
+		}
+		found := true
+		for k, v := range wantMR.Labels {
+			if res.Labels[k] != v {
+				found = false
+				break
+			}
+		}
+		if !found {
+			continue
+		}
+		for k, v := range wantLabels {
+			if ts.Metric.Labels[k] != v {
+				found = false
+				break
+			}
+		}
+		if !found {
+			continue
+		}
+		for _, point := range ts.Points {
+			val := point.Value
+			v := val.GetInt64Value()
+			sum += v
+		}
+	}
+	return float64(sum), nil
+}
+
+func labelsForValue(v reflect.Value) map[string]string {
+	return labelsForValueWithPrefix(v, "")
+}
+
+func labelsForValueWithPrefix(v reflect.Value, prefix string) map[string]string {
+	l := make(map[string]string)
+	for i := 0; i < v.NumField(); i++ {
+		tag := v.Type().Field(i).Tag.Get(monitoring.TagName)
+		// Skip if tag is not defined or ignored
+		if tag == "" || tag == "-" {
+			continue
+		}
+
+		strVal, ok := v.Field(i).Interface().(string)
+		if !ok || strVal == "" {
+			continue
+		}
+
+		label := label(tag, prefix)
+		if label == "" {
+			fmt.Printf("empty label for %s", v.Type().Field(i).Name)
+			continue
+		}
+		l[label] = strVal
+	}
+	return l
+}
+
+func label(tag, prefix string) string {
+	var label string
+	args := strings.Split(tag, ",")
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "stackdriver=") {
+			label = strings.TrimPrefix(arg, "stackdriver=")
+			break
+		}
+	}
+	return prefix + label
+}

--- a/pkg/test/framework/components/monitoring/stackdriver/stackdriver.go
+++ b/pkg/test/framework/components/monitoring/stackdriver/stackdriver.go
@@ -1,0 +1,54 @@
+//  Copyright Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package stackdriver
+
+import (
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/framework/components/monitoring"
+	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/framework/resource/environment"
+)
+
+// Instance represents a deployed Stackdriver app instance in a Kubernetes cluster.
+type Instance interface {
+	monitoring.MetricsService
+	// Gets the namespace in which stackdriver is deployed.
+	GetStackdriverNamespace() string
+}
+
+type Config struct {
+	// Cluster to be used in a multicluster environment
+	Cluster resource.Cluster
+}
+
+// New returns a new instance of stackdriver.
+func New(ctx resource.Context, c Config) (i Instance, err error) {
+	err = resource.UnsupportedEnvironment(ctx.Environment())
+	ctx.Environment().Case(environment.Kube, func() {
+		i, err = newKube(ctx, c)
+	})
+	return
+}
+
+// NewOrFail returns a new Stackdriver instance or fails test.
+func NewOrFail(t test.Failer, ctx resource.Context, c Config) Instance {
+	t.Helper()
+	i, err := New(ctx, c)
+	if err != nil {
+		t.Fatalf("stackdriver.NewOrFail: %v", err)
+	}
+
+	return i
+}

--- a/pkg/test/framework/components/monitoring/stackdriver/stackdriver.yaml
+++ b/pkg/test/framework/components/monitoring/stackdriver/stackdriver.yaml
@@ -1,0 +1,49 @@
+# Copyright 2020 Istio Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+apiVersion: v1
+kind: Service
+metadata:
+  name: stackdriver
+  labels:
+    app: stackdriver
+spec:
+  ports:
+  - name: grpc
+    port: 8090
+  - name: http
+    port: 8091
+  selector:
+    app: stackdriver
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stackdriver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: stackdriver
+  template:
+    metadata:
+      labels:
+        app: stackdriver
+    spec:
+      containers:
+      - image: gcr.io/istio-testing/fake-stackdriver:2.0
+        imagePullPolicy: Always
+        name: stackdriver
+        ports:
+        - containerPort: 8090
+        - containerPort: 8091

--- a/pkg/test/framework/features/features.yaml
+++ b/pkg/test/framework/features/features.yaml
@@ -19,6 +19,7 @@ features:
   observability:
     telemetry:
       stats:
+        standard-metrics:
         prometheus:
           customize-metric:
           merge:

--- a/tests/integration/telemetry/standardmetrics/standardmetrics_test.go
+++ b/tests/integration/telemetry/standardmetrics/standardmetrics_test.go
@@ -1,0 +1,226 @@
+package standardmetrics
+
+import (
+	"context"
+	"errors"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/monitoring"
+	"istio.io/istio/pkg/test/framework/components/monitoring/prometheus"
+	"istio.io/istio/pkg/test/framework/components/monitoring/stackdriver"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/istio/pkg/test/util/tmpl"
+)
+
+var (
+	client, server echo.Instance
+	ist            istio.Instance
+	echoNsInst     namespace.Instance
+	sdInst         stackdriver.Instance
+	promInst       prometheus.Instance
+)
+
+const (
+	stackdriverBootstrapOverride = "../stackdriver/testdata/custom_bootstrap.yaml.tmpl"
+	// serverRequestCount           = "../stackdriver/testdata/server_request_count.json.tmpl"
+	// clientRequestCount           = "testdata/client_request_count.json.tmpl"
+	// serverLogEntry               = "testdata/server_access_log.json.tmpl"
+	sdBootstrapConfigMap = "stackdriver-bootstrap-config"
+)
+
+func TestMain(m *testing.M) {
+	framework.NewSuite(m).
+		RequireSingleCluster().
+		Label(label.CustomSetup).
+		Setup(istio.Setup(istioInstance(), setupConfig)).
+		Setup(testSetup).
+		Run()
+}
+
+// istioInstance gets Istio instance.
+func istioInstance() *istio.Instance {
+	return &ist
+}
+
+// appNamespace gets bookinfo instance.
+func appNamespace() namespace.Instance {
+	return echoNsInst
+}
+
+func expectedDimensions(namespace string) monitoring.TrafficDimensions {
+	return monitoring.TrafficDimensions{
+		Request: monitoring.Request{
+			Protocol:                    monitoring.HTTP,
+			ResponseCode:                "200",
+			DestinationService:          "server." + namespace + ".svc.cluster.local",
+			DestinationServiceName:      "server",
+			DestinationServiceNamespace: namespace,
+		},
+		Context: monitoring.TrafficContext{},
+		Destination: monitoring.Workload{
+			App:       "server",
+			Version:   "v1",
+			Namespace: namespace,
+		},
+		Source: monitoring.Workload{
+			App:       "client",
+			Version:   "v1",
+			Name:      "client-v1",
+			Namespace: namespace,
+		},
+	}
+}
+
+func sendTraffic() error {
+	_, err := client.Call(echo.CallOptions{
+		Target:   server,
+		PortName: "http",
+	})
+	return err
+}
+
+func TestStandardMetrics(t *testing.T) {
+	framework.NewTest(t).
+		Features("observability.telemetry.stats.standard-metrics").
+		Run(func(ctx framework.TestContext) {
+			baseDims := expectedDimensions(echoNsInst.Name())
+			cases := []struct {
+				name     string
+				querySvc monitoring.MetricsService
+			}{
+				{"prometheus", promInst},
+				{"stackdriver", sdInst},
+			}
+
+			retry.UntilSuccessOrFail(t, func() error {
+				if err := sendTraffic(); err != nil {
+					return err
+				}
+				for _, v := range cases {
+					ctx.NewSubTest(v.name).
+						Run(func(ctx framework.TestContext) {
+							retry.UntilSuccessOrFail(ctx, func() error {
+								// Query client side metrics
+								baseDims.Context.Reporter = "source"
+								got, err := v.querySvc.Requests(context.Background(), baseDims)
+								if err != nil {
+									t.Logf("could not validate client requests: %v", err)
+									return err
+								}
+								if want := 1.0; got < want {
+									t.Logf("Requests(%q) => %f, want more than %f", baseDims, got, want)
+									return errors.New("bad number of client requests")
+								}
+								// Query server side metrics
+								baseDims.Context.Reporter = "destination"
+								got, err = v.querySvc.Requests(context.Background(), baseDims)
+								if err != nil {
+									t.Logf("could not validate server requests: %v", err)
+									return err
+								}
+								if want := 1.0; got < want {
+									t.Logf("Requests(%q) => %f, want more than %f", baseDims, got, want)
+									return errors.New("bad number of server requests")
+								}
+								return nil
+							}, retry.Delay(10*time.Second), retry.Timeout(80*time.Second))
+						})
+				}
+				return nil
+			}, retry.Delay(3*time.Second), retry.Timeout(160*time.Second))
+		})
+}
+
+func setupConfig(cfg *istio.Config) {
+	if cfg == nil {
+		return
+	}
+	cfg.Values["telemetry.v2.stackdriver.enabled"] = "true"
+}
+
+// testSetup set up bookinfo app for stats testing.
+func testSetup(ctx resource.Context) (err error) {
+	echoNsInst, err = namespace.New(ctx, namespace.Config{
+		Prefix: "istio-echo",
+		Inject: true,
+	})
+	if err != nil {
+		return
+	}
+	promInst, err = prometheus.New(ctx, prometheus.Config{})
+	if err != nil {
+		return
+	}
+
+	sdInst, err = stackdriver.New(ctx, stackdriver.Config{})
+	if err != nil {
+		return
+	}
+	templateBytes, err := ioutil.ReadFile(stackdriverBootstrapOverride)
+	if err != nil {
+		return
+	}
+	sdBootstrap, err := tmpl.Evaluate(string(templateBytes), map[string]interface{}{
+		"StackdriverNamespace": sdInst.GetStackdriverNamespace(),
+		"EchoNamespace":        echoNsInst.Name(),
+	})
+	if err != nil {
+		return
+	}
+
+	err = ctx.Config().ApplyYAML(echoNsInst.Name(), sdBootstrap)
+	if err != nil {
+		return
+	}
+	builder, err := echoboot.NewBuilder(ctx)
+	if err != nil {
+		return
+	}
+	err = builder.
+		With(&client, echo.Config{
+			Service:   "client",
+			Namespace: echoNsInst,
+			Subsets: []echo.SubsetConfig{
+				{
+					Annotations: map[echo.Annotation]*echo.AnnotationValue{
+						echo.SidecarBootstrapOverride: {
+							Value: sdBootstrapConfigMap,
+						},
+					},
+				},
+			}}).
+		With(&server, echo.Config{
+			Service:   "server",
+			Namespace: echoNsInst,
+			Ports: []echo.Port{
+				{
+					Name:         "http",
+					Protocol:     protocol.HTTP,
+					InstancePort: 8090,
+				},
+			},
+			Subsets: []echo.SubsetConfig{
+				{
+					Annotations: map[echo.Annotation]*echo.AnnotationValue{
+						echo.SidecarBootstrapOverride: {
+							Value: sdBootstrapConfigMap,
+						},
+					},
+				},
+			}}).
+		Build()
+	if err != nil {
+		return
+	}
+	return nil
+}


### PR DESCRIPTION
WIP: This PR is experimental, and meant to only provide a rough prototype solution for discussion. 

In various forums, there have been requests for unified testing interface to cover various monitoring backends (for metrics, logs, and traces). The idea was that such an interface would allow swapping in different backends without changing the tests or the logic.

In this prototype, I've focused on sketching out how this might work for metrics. We can expect to use any one of prometheus, fake stackdriver, and real stackdriver for testing purposes.

The crux of this prototype is in: `pkg/test/framework/components/monitoring/monitoring.go`. The actual example test is `TestStandardMetrics` (in `tests/integration/telemetry/standardmetrics/standardmetrics_test.go`). It consists of two sub-tests, one for prometheus and one for fake stackdriver, both using the same logic. The rest of this PR is largely copy-pasted code from existing test setups.

To avoid completely designing and implementing a new query language, I attempted to find some commonality in the form of a `TrafficDimensions` struct, which is ~equivalent to Envoy's `AttributeContext`, but with some Istio tweaks. This can be passed into a set of curated interface methods (here just `Requests`) and translated to backend queries without too much wrangling.

For now, this leaves aside the need to provide a similar abstraction for control-plane metrics.

There are probably other ways to handle it -- and perhaps more elegant. This way does lends itself to easy json serialization if we want to continue with template files for validation, etc., and should be relatively understandable for the rest of the community.

My hope is that this PR either inspires better ideas for a common layer or can provide a decent head-start when the time comes to pursue such a goal in earnest.

Another way of doing this would be to provide a singular `Query()` method, and have the queries delivered based on component name from a testdata repo somewhere. That would eliminate the need for translation, at the cost of a proliferation of template files and/or query strings. It would also require each dev to understand each query language.

Proof that this works:

```shell
$ HUB=gcr.io/istio-testing TAG=1.7-dev go test ./tests/integration/telemetry/standardmetrics --istio.test.ci --istio.test.nocleanup
ok      istio.io/istio/tests/integration/telemetry/standardmetrics      42.652s
```

/cc @nmittler @gargnupur @mandarjog 

[ X ] Policies and Telemetry
[ X ] Test and Release
