### PR TITLE
Use precompiled wasm images

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -214,6 +214,8 @@ for plugin in stats metadata_exchange
 do
   FILTER_WASM_URL="${ISTIO_ENVOY_BASE_URL}/${plugin}-${ISTIO_ENVOY_VERSION}.wasm"
   download_wasm_if_necessary "${FILTER_WASM_URL}" "${WASM_RELEASE_DIR}"/"${plugin//_/-}"-filter.wasm
+  FILTER_WASM_URL="${ISTIO_ENVOY_BASE_URL}/${plugin}-${ISTIO_ENVOY_VERSION}.compiled.wasm"
+  download_wasm_if_necessary "${FILTER_WASM_URL}" "${WASM_RELEASE_DIR}"/"${plugin//_/-}"-filter.compiled.wasm
 done
 
 # Copy native envoy binary to ISTIO_OUT

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1160,6 +1160,7 @@ spec:
                       inline_string: "envoy.wasm.stats"
 ---
 # Source: istio-discovery/templates/telemetryv2_1.7.yaml
+# Note: metadata exchange filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -1171,7 +1172,61 @@ spec:
   configPatches:
     - applyTo: HTTP_FILTER
       match:
-        context: ANY # inbound, outbound, and gateway
+        context: SIDECAR_INBOUND
+        proxy:
+          proxyVersion: '^1\.7.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.metadata_exchange
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                configuration:
+                  "@type": "type.googleapis.com/google.protobuf.StringValue"
+                  value: |
+                    {}
+                vm_config:
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: envoy.wasm.metadata_exchange
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_OUTBOUND
+        proxy:
+          proxyVersion: '^1\.7.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.metadata_exchange
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                configuration:
+                  "@type": "type.googleapis.com/google.protobuf.StringValue"
+                  value: |
+                    {}
+                vm_config:
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: envoy.wasm.metadata_exchange
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
         proxy:
           proxyVersion: '^1\.7.*'
         listener:
@@ -1256,6 +1311,7 @@ spec:
                 protocol: istio-peer-exchange
 ---
 # Source: istio-discovery/templates/telemetryv2_1.7.yaml
+# Note: http stats filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -1370,6 +1426,7 @@ spec:
                       inline_string: envoy.wasm.stats
 ---
 # Source: istio-discovery/templates/telemetryv2_1.7.yaml
+# Note: tcp stats filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1534,6 +1534,7 @@ spec:
                       inline_string: "envoy.wasm.stats"
 ---
 # Source: istio-discovery/templates/telemetryv2_1.8.yaml
+# Note: metadata exchange filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -1545,7 +1546,61 @@ spec:
   configPatches:
     - applyTo: HTTP_FILTER
       match:
-        context: ANY # inbound, outbound, and gateway
+        context: SIDECAR_INBOUND
+        proxy:
+          proxyVersion: '^1\.8.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.metadata_exchange
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                configuration:
+                  "@type": "type.googleapis.com/google.protobuf.StringValue"
+                  value: |
+                    {}
+                vm_config:
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: envoy.wasm.metadata_exchange
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_OUTBOUND
+        proxy:
+          proxyVersion: '^1\.8.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.metadata_exchange
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                configuration:
+                  "@type": "type.googleapis.com/google.protobuf.StringValue"
+                  value: |
+                    {}
+                vm_config:
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: envoy.wasm.metadata_exchange
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
         proxy:
           proxyVersion: '^1\.8.*'
         listener:
@@ -1630,6 +1685,7 @@ spec:
                 protocol: istio-peer-exchange
 ---
 # Source: istio-discovery/templates/telemetryv2_1.8.yaml
+# Note: http stats filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -1744,6 +1800,7 @@ spec:
                       inline_string: envoy.wasm.stats
 ---
 # Source: istio-discovery/templates/telemetryv2_1.8.yaml
+# Note: tcp stats filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.7.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.7.yaml
@@ -37,6 +37,7 @@ spec:
                 vm_config:
                   {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
                       filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
@@ -163,9 +164,10 @@ spec:
                   vm_id: stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
+                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -213,9 +215,10 @@ spec:
                   vm_id: stats_inbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
+                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -264,9 +267,10 @@ spec:
                   vm_id: stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
+                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -326,9 +330,10 @@ spec:
                   vm_id: tcp_stats_inbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
+                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -374,9 +379,10 @@ spec:
                   vm_id: tcp_stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
+                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -422,9 +428,10 @@ spec:
                   vm_id: tcp_stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
+                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.7.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.7.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.telemetry.enabled .Values.telemetry.v2.enabled }}
+# Note: metadata exchange filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -14,7 +15,7 @@ spec:
   configPatches:
     - applyTo: HTTP_FILTER
       match:
-        context: ANY # inbound, outbound, and gateway
+        context: SIDECAR_INBOUND
         proxy:
           proxyVersion: '^1\.7.*'
         listener:
@@ -47,6 +48,68 @@ spec:
                     local:
                       inline_string: envoy.wasm.metadata_exchange
                   {{- end }}
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_OUTBOUND
+        proxy:
+          proxyVersion: '^1\.7.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.metadata_exchange
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                configuration:
+                  "@type": "type.googleapis.com/google.protobuf.StringValue"
+                  value: |
+                    {}
+                vm_config:
+                  {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
+                  runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
+                  code:
+                    local:
+                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
+                  {{- else }}
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: envoy.wasm.metadata_exchange
+                  {{- end }}
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        proxy:
+          proxyVersion: '^1\.7.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.metadata_exchange
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                configuration:
+                  "@type": "type.googleapis.com/google.protobuf.StringValue"
+                  value: |
+                    {}
+                vm_config:
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: envoy.wasm.metadata_exchange
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -109,6 +172,7 @@ spec:
               value:
                 protocol: istio-peer-exchange
 ---
+# Note: http stats filter is wasm enabled only in sidecars.
 {{- if .Values.telemetry.v2.prometheus.enabled }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -265,19 +329,12 @@ spec:
                     }
                 vm_config:
                   vm_id: stats_outbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
-                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: envoy.wasm.stats
-                  {{- end }}
 ---
+# Note: tcp stats filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -426,18 +483,10 @@ spec:
                     }
                 vm_config:
                   vm_id: tcp_stats_outbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
-                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: "envoy.wasm.stats"
-                  {{- end }}
 ---
 
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.7.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.7.yaml
@@ -39,7 +39,7 @@ spec:
                   runtime: envoy.wasm.runtime.v8
                   code:
                     local:
-                      filename: /etc/istio/extensions/metadata-exchange-filter.wasm
+                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.8.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.8.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.telemetry.enabled .Values.telemetry.v2.enabled }}
+# Note: metadata exchange filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -14,7 +15,7 @@ spec:
   configPatches:
     - applyTo: HTTP_FILTER
       match:
-        context: ANY # inbound, outbound, and gateway
+        context: SIDECAR_INBOUND
         proxy:
           proxyVersion: '^1\.8.*'
         listener:
@@ -37,15 +38,78 @@ spec:
                 vm_config:
                   {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/metadata-exchange-filter.wasm
+                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: envoy.wasm.metadata_exchange
                   {{- end }}
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_OUTBOUND
+        proxy:
+          proxyVersion: '^1\.8.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.metadata_exchange
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                configuration:
+                  "@type": "type.googleapis.com/google.protobuf.StringValue"
+                  value: |
+                    {}
+                vm_config:
+                  {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
+                  runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
+                  code:
+                    local:
+                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
+                  {{- else }}
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: envoy.wasm.metadata_exchange
+                  {{- end }}
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        proxy:
+          proxyVersion: '^1\.8.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.metadata_exchange
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                configuration:
+                  "@type": "type.googleapis.com/google.protobuf.StringValue"
+                  value: |
+                    {}
+                vm_config:
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: envoy.wasm.metadata_exchange
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -108,6 +172,7 @@ spec:
               value:
                 protocol: istio-peer-exchange
 ---
+# Note: http stats filter is wasm enabled only in sidecars.
 {{- if .Values.telemetry.v2.prometheus.enabled }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -163,9 +228,10 @@ spec:
                   vm_id: stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
+                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -213,9 +279,10 @@ spec:
                   vm_id: stats_inbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
+                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -262,18 +329,12 @@ spec:
                     }
                 vm_config:
                   vm_id: stats_outbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
-                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: envoy.wasm.stats
-                  {{- end }}
 ---
+# Note: tcp stats filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -326,9 +387,10 @@ spec:
                   vm_id: tcp_stats_inbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
+                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -374,9 +436,10 @@ spec:
                   vm_id: tcp_stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
+                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -420,17 +483,10 @@ spec:
                     }
                 vm_config:
                   vm_id: tcp_stats_outbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
-                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: "envoy.wasm.stats"
-                  {{- end }}
 ---
 
 {{- end }}

--- a/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: istio
-  namespace: service-graph00
+  namespace: default
   labels:
     istio.io/rev: default
     release: istiod-remote
@@ -16,7 +16,7 @@ data:
 
   mesh: |-
     defaultConfig:
-      discoveryAddress: istiod.service-graph00.svc:15012
+      discoveryAddress: istiod.default.svc:15012
       proxyMetadata:
         DNS_AGENT: ""
       tracing:
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: istio-sidecar-injector
-  namespace: service-graph00
+  namespace: default
   labels:
     istio.io/rev: default
     release: istiod-remote
@@ -633,7 +633,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: istio-sidecar-injector-service-graph00
+  name: istio-sidecar-injector-default
   labels:
     istio.io/rev: default
     app: sidecar-injector

--- a/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: istio
-  namespace: default
+  namespace: service-graph00
   labels:
     istio.io/rev: default
     release: istiod-remote
@@ -16,7 +16,7 @@ data:
 
   mesh: |-
     defaultConfig:
-      discoveryAddress: istiod.default.svc:15012
+      discoveryAddress: istiod.service-graph00.svc:15012
       proxyMetadata:
         DNS_AGENT: ""
       tracing:
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: istio-sidecar-injector
-  namespace: default
+  namespace: service-graph00
   labels:
     istio.io/rev: default
     release: istiod-remote
@@ -633,7 +633,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: istio-sidecar-injector-default
+  name: istio-sidecar-injector-service-graph00
   labels:
     istio.io/rev: default
     app: sidecar-injector

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.7.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.7.yaml
@@ -39,7 +39,7 @@ spec:
                   runtime: envoy.wasm.runtime.v8
                   code:
                     local:
-                      filename: /etc/istio/extensions/metadata-exchange-filter.wasm
+                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -165,7 +165,7 @@ spec:
                   runtime: envoy.wasm.runtime.v8
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
+                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -215,7 +215,7 @@ spec:
                   runtime: envoy.wasm.runtime.v8
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
+                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -266,7 +266,7 @@ spec:
                   runtime: envoy.wasm.runtime.v8
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
+                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -328,7 +328,7 @@ spec:
                   runtime: envoy.wasm.runtime.v8
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
+                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -376,7 +376,7 @@ spec:
                   runtime: envoy.wasm.runtime.v8
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
+                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -424,7 +424,7 @@ spec:
                   runtime: envoy.wasm.runtime.v8
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
+                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.7.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.7.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.telemetry.enabled .Values.telemetry.v2.enabled }}
+# Note: metadata exchange filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -14,7 +15,7 @@ spec:
   configPatches:
     - applyTo: HTTP_FILTER
       match:
-        context: ANY # inbound, outbound, and gateway
+        context: SIDECAR_INBOUND
         proxy:
           proxyVersion: '^1\.7.*'
         listener:
@@ -47,6 +48,68 @@ spec:
                     local:
                       inline_string: envoy.wasm.metadata_exchange
                   {{- end }}
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_OUTBOUND
+        proxy:
+          proxyVersion: '^1\.7.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.metadata_exchange
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                configuration:
+                  "@type": "type.googleapis.com/google.protobuf.StringValue"
+                  value: |
+                    {}
+                vm_config:
+                  {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
+                  runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
+                  code:
+                    local:
+                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
+                  {{- else }}
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: envoy.wasm.metadata_exchange
+                  {{- end }}
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        proxy:
+          proxyVersion: '^1\.7.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.metadata_exchange
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                configuration:
+                  "@type": "type.googleapis.com/google.protobuf.StringValue"
+                  value: |
+                    {}
+                vm_config:
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: envoy.wasm.metadata_exchange
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -109,6 +172,7 @@ spec:
               value:
                 protocol: istio-peer-exchange
 ---
+# Note: http stats filter is wasm enabled only in sidecars.
 {{- if .Values.telemetry.v2.prometheus.enabled }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -265,19 +329,12 @@ spec:
                     }
                 vm_config:
                   vm_id: stats_outbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
-                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: envoy.wasm.stats
-                  {{- end }}
 ---
+# Note: tcp stats filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -426,18 +483,10 @@ spec:
                     }
                 vm_config:
                   vm_id: tcp_stats_outbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
-                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: "envoy.wasm.stats"
-                  {{- end }}
 ---
 
 {{- end }}

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.7.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.7.yaml
@@ -37,6 +37,7 @@ spec:
                 vm_config:
                   {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
                       filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
@@ -163,6 +164,7 @@ spec:
                   vm_id: stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
                       filename: /etc/istio/extensions/stats-filter.compiled.wasm
@@ -213,6 +215,7 @@ spec:
                   vm_id: stats_inbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
                       filename: /etc/istio/extensions/stats-filter.compiled.wasm
@@ -264,6 +267,7 @@ spec:
                   vm_id: stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
                       filename: /etc/istio/extensions/stats-filter.compiled.wasm
@@ -326,6 +330,7 @@ spec:
                   vm_id: tcp_stats_inbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
                       filename: /etc/istio/extensions/stats-filter.compiled.wasm
@@ -374,6 +379,7 @@ spec:
                   vm_id: tcp_stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
                       filename: /etc/istio/extensions/stats-filter.compiled.wasm
@@ -422,6 +428,7 @@ spec:
                   vm_id: tcp_stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
                       filename: /etc/istio/extensions/stats-filter.compiled.wasm

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.8.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.8.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.telemetry.enabled .Values.telemetry.v2.enabled }}
+# Note: metadata exchange filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -14,7 +15,7 @@ spec:
   configPatches:
     - applyTo: HTTP_FILTER
       match:
-        context: ANY # inbound, outbound, and gateway
+        context: SIDECAR_INBOUND
         proxy:
           proxyVersion: '^1\.8.*'
         listener:
@@ -37,15 +38,78 @@ spec:
                 vm_config:
                   {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/metadata-exchange-filter.wasm
+                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: envoy.wasm.metadata_exchange
                   {{- end }}
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_OUTBOUND
+        proxy:
+          proxyVersion: '^1\.8.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.metadata_exchange
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                configuration:
+                  "@type": "type.googleapis.com/google.protobuf.StringValue"
+                  value: |
+                    {}
+                vm_config:
+                  {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
+                  runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
+                  code:
+                    local:
+                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
+                  {{- else }}
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: envoy.wasm.metadata_exchange
+                  {{- end }}
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        proxy:
+          proxyVersion: '^1\.8.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.metadata_exchange
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                configuration:
+                  "@type": "type.googleapis.com/google.protobuf.StringValue"
+                  value: |
+                    {}
+                vm_config:
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: envoy.wasm.metadata_exchange
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -108,6 +172,7 @@ spec:
               value:
                 protocol: istio-peer-exchange
 ---
+# Note: http stats filter is wasm enabled only in sidecars.
 {{- if .Values.telemetry.v2.prometheus.enabled }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -163,9 +228,10 @@ spec:
                   vm_id: stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
+                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -213,9 +279,10 @@ spec:
                   vm_id: stats_inbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
+                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -262,18 +329,12 @@ spec:
                     }
                 vm_config:
                   vm_id: stats_outbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
-                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: envoy.wasm.stats
-                  {{- end }}
 ---
+# Note: tcp stats filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -326,9 +387,10 @@ spec:
                   vm_id: tcp_stats_inbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
+                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -374,9 +436,10 @@ spec:
                   vm_id: tcp_stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
+                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -420,17 +483,10 @@ spec:
                     }
                 vm_config:
                   vm_id: tcp_stats_outbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
-                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: "envoy.wasm.stats"
-                  {{- end }}
 ---
 
 {{- end }}

--- a/manifests/profiles/default.yaml
+++ b/manifests/profiles/default.yaml
@@ -251,8 +251,10 @@ spec:
       enabled: true
       v2:
         enabled: true
-        metadataExchange: {}
+        metadataExchange:
+          wasmEnabled: true
         prometheus:
+          wasmEnabled: true
           enabled: true
         stackdriver:
           enabled: false

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -49,7 +49,9 @@ COPY pilot-agent /usr/local/bin/pilot-agent
 COPY envoy_policy.yaml.tmpl /var/lib/istio/envoy/envoy_policy.yaml.tmpl
 
 COPY stats-filter.wasm /etc/istio/extensions/stats-filter.wasm
+COPY stats-filter.compiled.wasm /etc/istio/extensions/stats-filter.compiled.wasm
 COPY metadata-exchange-filter.wasm /etc/istio/extensions/metadata-exchange-filter.wasm
+COPY metadata-exchange-filter.compiled.wasm /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
 
 # The pilot-agent will bootstrap Envoy.
 ENTRYPOINT ["/usr/local/bin/pilot-agent"]

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -248,7 +248,7 @@ spec:
           sudo sh -c 'echo "{{$.VM.IstiodIP}} istiod.istio-system.svc" >> /etc/hosts'
 
           # TODO: run with systemctl?
-          export ISTIO_AGENT_FLAGS="--concurrency 2"
+          export ISTIO_AGENT_FLAGS="--concurrency 2 --proxyLogLevel=debug"
           sudo -E /usr/local/bin/istio-start.sh&
           /usr/local/bin/server --cluster "{{ $cluster }}" --version "{{ $subset.Version }}" \
 {{- range $i, $p := $.ContainerPorts }}

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -248,6 +248,7 @@ spec:
           sudo sh -c 'echo "{{$.VM.IstiodIP}} istiod.istio-system.svc" >> /etc/hosts'
 
           # TODO: run with systemctl?
+          export ISTIO_AGENT_FLAGS="--concurrency 2"
           sudo -E /usr/local/bin/istio-start.sh&
           /usr/local/bin/server --cluster "{{ $cluster }}" --version "{{ $subset.Version }}" \
 {{- range $i, $p := $.ContainerPorts }}

--- a/tests/integration/pilot/routing_test.go
+++ b/tests/integration/pilot/routing_test.go
@@ -209,16 +209,16 @@ func vmTestCases(vm echo.Instance) []TrafficTestCase {
 			to:   vm,
 		},
 		{
-			name: "dns: VM to k8s cluster IP service fqdn host",
-			from: vm,
-			to:   apps.podA,
-			host: apps.podA.Config().FQDN(),
-		},
-		{
 			name: "dns: VM to k8s cluster IP service name.namespace host",
 			from: vm,
 			to:   apps.podA,
 			host: apps.podA.Config().Service + "." + apps.namespace.Name(),
+		},
+		{
+			name: "dns: VM to k8s cluster IP service fqdn host",
+			from: vm,
+			to:   apps.podA,
+			host: apps.podA.Config().FQDN(),
 		},
 		{
 			name: "dns: VM to k8s cluster IP service short name host",

--- a/tests/integration/pilot/routing_test.go
+++ b/tests/integration/pilot/routing_test.go
@@ -218,7 +218,7 @@ func vmTestCases(vm echo.Instance) []TrafficTestCase {
 			name: "dns: VM to k8s cluster IP service fqdn host",
 			from: vm,
 			to:   apps.podA,
-			host: apps.podA.Config().FQDN(),
+			host: apps.podA.Config().FQDN() + ".",
 		},
 		{
 			name: "dns: VM to k8s cluster IP service short name host",
@@ -230,6 +230,7 @@ func vmTestCases(vm echo.Instance) []TrafficTestCase {
 			name: "dns: VM to k8s headless service",
 			from: vm,
 			to:   apps.headless,
+			host: apps.headless.Config().FQDN() + ".",
 		},
 	}
 	cases := []TrafficTestCase{}

--- a/tests/integration/telemetry/stats/prometheus/http/nullvm/stats_filter_test.go
+++ b/tests/integration/telemetry/stats/prometheus/http/nullvm/stats_filter_test.go
@@ -37,7 +37,16 @@ func TestMain(m *testing.M) {
 	framework.NewSuite(m).
 		RequireSingleCluster().
 		Label(label.CustomSetup).
-		Setup(istio.Setup(common.GetIstioInstance(), nil)).
+		Setup(istio.Setup(common.GetIstioInstance(), setupConfig)).
 		Setup(common.TestSetup).
 		Run()
+}
+
+func setupConfig(cfg *istio.Config) {
+	if cfg == nil {
+		return
+	}
+	// enable telemetry v2 with nullvm
+	cfg.Values["telemetry.v2.metadataExchange.wasmEnabled"] = "false"
+	cfg.Values["telemetry.v2.prometheus.wasmEnabled"] = "false"
 }

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -78,7 +78,9 @@ ${ISTIO_ENVOY_BOOTSTRAP_CONFIG_DIR}/envoy_bootstrap.json: ${ISTIO_ENVOY_BOOTSTRA
 
 # rule for wasm extensions.
 $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/stats-filter.wasm: init
+$(ISTIO_ENVOY_LINUX_RELEASE_DIR)/stats-filter.compiled.wasm: init
 $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/metadata-exchange-filter.wasm: init
+$(ISTIO_ENVOY_LINUX_RELEASE_DIR)/metadata-exchange-filter.compiled.wasm: init
 
 # Default proxy image.
 docker.proxyv2: BUILD_PRE=&& chmod 755 ${SIDECAR} pilot-agent
@@ -90,7 +92,9 @@ docker.proxyv2: $(ISTIO_OUT_LINUX)/pilot-agent
 docker.proxyv2: pilot/docker/Dockerfile.proxyv2
 docker.proxyv2: pilot/docker/envoy_policy.yaml.tmpl
 docker.proxyv2: $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/stats-filter.wasm
+docker.proxyv2: $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/stats-filter.compiled.wasm
 docker.proxyv2: $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/metadata-exchange-filter.wasm
+docker.proxyv2: $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/metadata-exchange-filter.compiled.wasm
 	$(DOCKER_RULE)
 
 docker.pilot: BUILD_PRE=&& chmod 755 pilot-discovery cacert.pem

--- a/tools/packaging/packaging.mk
+++ b/tools/packaging/packaging.mk
@@ -12,6 +12,9 @@ deb: ${ISTIO_OUT_LINUX}/release/istio-sidecar.deb ${ISTIO_OUT_LINUX}/release/ist
 # Base directory for istio binaries. Likely to change !
 ISTIO_DEB_BIN=/usr/local/bin
 
+# Home directory of istio-proxy user. It is symlinked /etc/istio --> /var/lib/istio
+ISTIO_PROXY_HOME=/var/lib/istio
+
 ISTIO_DEB_DEPS:=pilot-discovery istioctl
 ISTIO_FILES:=
 $(foreach DEP,$(ISTIO_DEB_DEPS),\
@@ -35,6 +38,13 @@ $(foreach DEST,$(ISTIO_DEB_DEST),\
 
 SIDECAR_FILES+=${REPO_ROOT}/tools/packaging/common/envoy_bootstrap.json=/var/lib/istio/envoy/envoy_bootstrap_tmpl.json
 
+ISTIO_EXTENSIONS:=stats-filter.wasm \
+                  stats-filter.compiled.wasm \
+                  metadata-exchange-filter.wasm \
+                  metadata-exchange-filter.compiled.wasm
+
+$(foreach EXT,$(ISTIO_EXTENSIONS),\
+        $(eval SIDECAR_FILES+=${ISTIO_ENVOY_LINUX_RELEASE_DIR}/$(EXT)=$(ISTIO_PROXY_HOME)/extensions/$(EXT)))
 
 # original name used in 0.2 - will be updated to 'istio.deb' since it now includes all istio binaries.
 SIDECAR_PACKAGE_NAME ?= istio-sidecar


### PR DESCRIPTION
1. Use wasm images for stats and mx
2. Use precompiled wasm to remove initial cpu spike.

Note: This is done in anticipation of stats mx meeting performance and stability bar.
If it does not, we will change the default back to non wasm.

Will add a release note if we decide to keep the new defaults.