### PR TITLE
iptables: fix dns rules on v4 only system

### DIFF
--- a/tools/istio-iptables/pkg/cmd/run.go
+++ b/tools/istio-iptables/pkg/cmd/run.go
@@ -382,8 +382,10 @@ func (iptConfigurator *IptablesConfigurator) run() {
 	if redirectDNS {
 		iptConfigurator.iptables.AppendRuleV4(
 			constants.ISTIOREDIRECT, constants.NAT, "-p", constants.UDP, "-j", constants.REDIRECT, "--to-ports", dnsTargetPort)
-		iptConfigurator.iptables.AppendRuleV6(
-			constants.ISTIOREDIRECT, constants.NAT, "-p", constants.UDP, "-j", constants.REDIRECT, "--to-ports", dnsTargetPort)
+		if iptConfigurator.cfg.EnableInboundIPv6 {
+			iptConfigurator.iptables.AppendRuleV6(
+				constants.ISTIOREDIRECT, constants.NAT, "-p", constants.UDP, "-j", constants.REDIRECT, "--to-ports", dnsTargetPort)
+		}
 	}
 
 	// Use this chain also for redirecting inbound traffic to the common Envoy port

--- a/tools/istio-iptables/pkg/cmd/run_test.go
+++ b/tools/istio-iptables/pkg/cmd/run_test.go
@@ -623,6 +623,23 @@ func TestHandleInboundIpv4RulesWithUidGid(t *testing.T) {
 	}
 }
 
+func TestGenerateEmptyV6ConfigOnV4OnlyEnv(t *testing.T) {
+	cfg := constructConfig()
+	cfg.DryRun = true
+	dnsCaptureByEnvoy.DefaultValue = ""
+	dnsCaptureByAgent.DefaultValue = "ALL"
+	iptConfigurator := NewIptablesConfigurator(cfg, &dep.StdoutStubDependencies{})
+	iptConfigurator.cfg.EnableInboundIPv6 = false
+	iptConfigurator.cfg.ProxyGID = "1,2"
+	iptConfigurator.cfg.ProxyUID = "3,4"
+	iptConfigurator.run()
+	actual := FormatIptablesCommands(iptConfigurator.iptables.BuildV6())
+	expected := []string{}
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("Output mismatch.\nExpected: empty\nActual: %#v", actual)
+	}
+}
+
 func TestHandleOutboundPortsIncludeWithOutboundPorts(t *testing.T) {
 	cfg := constructTestConfig()
 	cfg.OutboundPortsInclude = "32000,31000"


### PR DESCRIPTION
iptables should not build any v6 rules on v4 only system.

Signed-off-by: Yuchen Dai <silentdai@gmail.com>

fix #25289

#24538