### PR TITLE
enhance and fix Makefile to generate certs

### DIFF
--- a/tools/certs/Makefile
+++ b/tools/certs/Makefile
@@ -1,9 +1,8 @@
 .SUFFIXES: .csr .pem .conf
 .PRECIOUS: %/ca-key.pem %/ca-cert.pem %/cert-chain.pem
 .PRECIOUS: %/selfSigned-ca-key.pem %/selfSigned-ca-cert.pem %/selfSigned-ca-cert-chain.pem
-.PRECIOUS: root-cert.csr root-ca.conf %/cluster-ca.csr %/intermediate.conf %/selfSigned-cluster-ca.csr
 .PRECIOUS: %/selfSigned-workload-cert-chain.pem %/selfSigned-workload-cert.pem
-.PRECIOUS: %/workload-cert.pem %/key.pem %/workload-cert-chain.pem %/workload.conf %/workload.csr
+.PRECIOUS: %/workload-cert.pem %/key.pem %/workload-cert-chain.pem
 .SECONDARY: root-cert.csr root-ca.conf %/cluster-ca.csr %/intermediate.conf
 
 .DEFAULT_GOAL := help
@@ -15,6 +14,7 @@ ROOTCA_KEYSZ ?= 4096
 ROOTCA_ORG ?= Istio
 ROOTCA_CN ?= Root CA
 KUBECONFIG ?= $(HOME)/.kube/config
+ISTIO_NAMESPACE ?= istio-system
 # Additional variables are defined in root-ca.conf target below.
 
 #------------------------------------------------------------------------
@@ -30,7 +30,19 @@ INTERMEDIATE_SAN_DNS ?= istiod.istio-system.svc
 # variables: workload certs: eg VM
 WORKLOAD_DAYS ?= 1
 SERVICE_ACCOUNT ?= default
+WORKLOAD_CN ?= Workload
 
+#------------------------------------------------------------------------
+# variables: files to clean
+FILES_TO_CLEAN+=k8s-root-cert.pem \
+                 k8s-root-cert.srl  \
+                 k8s-root-key.pem root-ca.conf root-cert.csr root-cert.pem root-cert.srl root-key.pem
+#------------------------------------------------------------------------
+# clean
+.PHONY: clean
+
+clean: ## Cleans all the intermediate files and folders previously generated.
+	@rm -f $(FILES_TO_CLEAN)
 #------------------------------------------------------------------------
 ##help:		print this help message
 .PHONY: help
@@ -45,16 +57,17 @@ rawcluster := $(shell kubectl config current-context)
 cluster := $(subst /,-,$(rawcluster))
 pwd := $(shell pwd)
 export KUBECONFIG
+
 fetch-root-ca:
 	@echo "fetching root ca from k8s cluster: "$(cluster)""
-	@@mkdir -p $(pwd)/$(cluster)
-	@res=$(shell kubectl get secret istio-ca-secret  -n istio-system >/dev/null 2>&1;  echo $$?)
+	@mkdir -p $(pwd)/$(cluster)
+	@res=$(shell kubectl get secret istio-ca-secret  -n  $(ISTIO-NAMESPACE) >/dev/null 2>&1;  echo $$?)
 ifeq ($(res), 1)
-	@kubectl get secret cacerts  -n istio-system -o "jsonpath={.data['ca-cert\.pem']}" | base64 -d > $(cluster)/k8s-root-cert.pem
-	@kubectl get secret cacerts  -n istio-system -o "jsonpath={.data['ca-key\.pem']}" | base64 -d > $(cluster)/k8s-root-key.pem
+	@kubectl get secret cacerts   -n  $(ISTIO_NAMESPACE) -o "jsonpath={.data['ca-cert\.pem']}" | base64 -d > $(cluster)/k8s-root-cert.pem
+	@kubectl get secret cacerts  -n  $(ISTIO_NAMESPACE) -o "jsonpath={.data['ca-key\.pem']}" | base64 -d > $(cluster)/k8s-root-key.pem
 else
-	@kubectl get secret istio-ca-secret  -n istio-system -o "jsonpath={.data['ca-cert\.pem']}" | base64 -d > $(cluster)/k8s-root-cert.pem
-	@kubectl get secret istio-ca-secret  -n istio-system -o "jsonpath={.data['ca-key\.pem']}" | base64 -d > $(cluster)/k8s-root-key.pem
+	@kubectl get secret istio-ca-secret   -n  $(ISTIO_NAMESPACE) -o "jsonpath={.data['ca-cert\.pem']}" | base64 -d > $(cluster)/k8s-root-cert.pem
+	@kubectl get secret istio-ca-secret   -n  $(ISTIO_NAMESPACE) -o "jsonpath={.data['ca-key\.pem']}" | base64 -d > $(cluster)/k8s-root-key.pem
 endif
 
 k8s-root-cert.pem:
@@ -62,8 +75,6 @@ k8s-root-cert.pem:
 
 k8s-root-key.pem:
 	@cat $(cluster)/k8s-root-key.pem > $@
-
-
 #------------------------------------------------------------------------
 ##root-ca:	generate root CA files (key and certifcate) in current directory.
 .PHONY: root-ca
@@ -104,16 +115,18 @@ root-key.pem:
 
 
 #------------------------------------------------------------------------
-##<name>-cacerts-k8s:	generate intermediate certificates for a cluster or VM with <name> signed with istio root cert from the specified k8s cluster and store them under <name> directory
+##<name>-cacerts-k8s: generate intermediate certificates for a cluster or VM with <name> signed with istio root cert from the specified k8s cluster and store them under <name> directory
 .PHONY: %-cacerts-k8s
 
-%-cacerts-k8s: %/cert-chain.pem k8s-root-cert.pem
-	@echo "Intermediate certs stored in $(dir $<)"
-	@cp k8s-root-cert.pem $(dir $<)/root-cert.pem
+%-cacerts-k8s: %/cert-chain.pem
+	@make clean
+	@echo "done"
 
 %/cert-chain.pem: %/ca-cert.pem k8s-root-cert.pem
 	@echo "generating $@"
 	@cat $^ > $@
+	@echo "Intermediate certs stored in $(dir $<)"
+	@cp k8s-root-cert.pem $(dir $<)/root-cert.pem
 
 %/ca-cert.pem: %/cluster-ca.csr k8s-root-key.pem k8s-root-cert.pem
 	@echo "generating $@"
@@ -137,12 +150,15 @@ root-key.pem:
 .PHONY: %-cacerts-selfSigned
 
 %-cacerts-selfSigned: %/selfSigned-ca-cert-chain.pem root-cert.pem
-	@echo "Intermediate inputs stored in $(dir $<)"
-	@cp root-cert.pem $(dir $<)
+	@make clean
+	@echo "done"
 
 %/selfSigned-ca-cert-chain.pem: %/selfSigned-ca-cert.pem root-cert.pem
 	@echo "generating $@"
 	@cat $^ > $@
+	@echo "Intermediate inputs stored in $(dir $<)"
+	@cp root-cert.pem $(dir $<)
+
 
 %/selfSigned-ca-cert.pem: %/selfSigned-cluster-ca.csr root-key.pem root-cert.pem
 	@echo "generating $@"
@@ -187,14 +203,16 @@ root-key.pem:
 ##<namespace>-certs-selfSigned: generate intermediate certificates and sign certificates for a virtual machine connected to the namespace `<namespace> using serviceAccount `$SERVICE_ACCOUNT` using self signed root certs.
 .PHONY: %-certs-selfSigned
 
-%-certs-selfSigned:
-%-certs-selfSigned: %/selfSigned-ca-cert-chain.pem  %/selfSigned-workload-cert-chain.pem root-cert.pem
-	@echo "Intermediate and workload certs stored in $(dir $<)"
-	@cp root-cert.pem $(dir $<)
+%-certs-selfSigned: %/selfSigned-workload-cert-chain.pem root-cert.pem
+	@make clean
+	@echo "done"
 
-%/selfSigned-workload-cert-chain.pem: %/selfSigned-workload-cert.pem %/selfSigned-ca-cert.pem root-cert.pem
+%/selfSigned-workload-cert-chain.pem: root-cert.pem %/selfSigned-ca-cert.pem %/selfSigned-workload-cert.pem	
 	@echo "generating $@"
 	@cat $^ > $@
+	@echo "Intermediate and workload certs stored in $(dir $<)"
+	@cp root-cert.pem $(dir $@)/root-cert.pem
+
 
 %/selfSigned-workload-cert.pem: %/workload.csr
 	@echo "generating $@"
@@ -235,20 +253,22 @@ root-key.pem:
 	@echo "DNS.1 = spiffe://cluster.local/ns/$(L)sa/$(SERVICE_ACCOUNT)" >> $@
 	@echo "[ req_dn ]" >> $@
 	@echo "O = $(INTERMEDIATE_ORG)" >> $@
-	@echo "CN = $(INTERMEDIATE_CN)" >> $@
+	@echo "CN = $(WORKLOAD_CN)" >> $@
 	@echo "L = $(L:/=)" >> $@
 
 #------------------------------------------------------------------------
 ##<namespace>-certs-k8s: generate intermediate certificates and sign certificates for a virtual machine connected to the namespace `<namespace> using serviceAccount `$SERVICE_ACCOUNT` using root cert from k8s cluster.
 .PHONY: %-certs-k8s
 
-%-certs-k8s: %/cert-chain.pem k8s-root-cert.pem %/workload-cert-chain.pem
-	@echo "Intermediate and workload certs stored in $(dir $<)"
-	@cp k8s-root-cert.pem $(dir $<)/root-cert.pem
+%-certs-k8s: %/workload-cert-chain.pem k8s-root-cert.pem
+	@make clean
+	@echo "done"
 
-%/workload-cert-chain.pem: %/workload-cert.pem %/ca-cert.pem k8s-root-cert.pem k8s-root-key.pem
+%/workload-cert-chain.pem: k8s-root-cert.pem %/ca-cert.pem %/workload-cert.pem
 	@echo "generating $@"
 	@cat $^ > $@
+	@echo "Intermediate and workload certs stored in $(dir $<)"
+	@cp k8s-root-cert.pem $(dir $@)/root-cert.pem
 
 %/workload-cert.pem: %/workload.csr
 	@echo "generating $@"


### PR DESCRIPTION
- fix issues that switching cluster fails to generate correct certs.
- fix issue that if old certs exists will prevent new certs generated
- add function to support define `ISTIO_NAMESPACE` in case istio is not installed into `istio-system` namespace. 
- remove unused intermediate files