### PR TITLE
fix broken multicluster tests

### DIFF
--- a/istioctl/cmd/config_test.go
+++ b/istioctl/cmd/config_test.go
@@ -31,14 +31,14 @@ func TestConfigList(t *testing.T) {
 		},
 		{ // case 1
 			args: strings.Split("experimental config list", " "),
-			expectedOutput: `FLAG                    VALUE            FROM
-cert-dir                                 default
-insecure                                 default
-istioNamespace                           default
-prefer-experimental                      default
-xds-address                              default
-xds-port                15012            default
-xds-san                                  default
+			expectedOutput: `FLAG                    VALUE     FROM
+cert-dir                          default
+insecure                          default
+istioNamespace                    default
+prefer-experimental               default
+xds-address                       default
+xds-port                15012     default
+xds-san                           default
 `,
 			wantException: false,
 		},

--- a/istioctl/cmd/config_test.go
+++ b/istioctl/cmd/config_test.go
@@ -34,7 +34,7 @@ func TestConfigList(t *testing.T) {
 			expectedOutput: `FLAG                    VALUE            FROM
 cert-dir                                 default
 insecure                                 default
-istioNamespace          istio-system     default
+istioNamespace                           default
 prefer-experimental                      default
 xds-address                              default
 xds-port                15012            default

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -139,8 +139,7 @@ debug and diagnose their Istio mesh.
 	rootCmd.PersistentFlags().StringVar(&configContext, "context", "",
 		"The name of the kubeconfig context to use")
 
-	viper.SetDefault("istioNamespace", controller.IstioNamespace)
-	rootCmd.PersistentFlags().StringVarP(&istioNamespace, "istioNamespace", "i", viper.GetString("istioNamespace"),
+	rootCmd.PersistentFlags().StringVarP(&istioNamespace, "istioNamespace", "i", controller.IstioNamespace,
 		"Istio system namespace")
 
 	rootCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", v1.NamespaceAll,

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -196,10 +196,10 @@ func deploy(ctx resource.Context, env *kube.Environment, cfg Config) (Instance, 
 	}
 
 	// Deploy the Istio control plane(s)
+	errG := multierror.Group{}
 	for _, cluster := range env.KubeClusters {
 		if env.IsControlPlaneCluster(cluster) {
 			cluster := cluster
-			errG := multierror.Group{}
 			errG.Go(func() error {
 				if err := deployControlPlane(i, cfg, cluster, iopFile); err != nil {
 					return fmt.Errorf("failed deploying control plane to cluster %s: %v", cluster.Name(), err)
@@ -211,10 +211,11 @@ func deploy(ctx resource.Context, env *kube.Environment, cfg Config) (Instance, 
 					return patchIstiodCustomHost(cfg, cluster)
 				})
 			}
-			if errs := errG.Wait(); errs != nil {
-				return nil, fmt.Errorf("%d errors occurred deploying control plane clusters: %v", errs.Len(), errs.ErrorOrNil())
-			}
 		}
+	}
+
+	if errs := errG.Wait(); errs != nil {
+		return nil, fmt.Errorf("%d errors occurred deploying control plane clusters: %v", errs.Len(), errs.ErrorOrNil())
 	}
 
 	// Wait for all of the control planes to be started before deploying remote clusters
@@ -227,13 +228,20 @@ func deploy(ctx resource.Context, env *kube.Environment, cfg Config) (Instance, 
 	}
 
 	// Deploy Istio to remote clusters
+	errG = multierror.Group{}
 	for _, cluster := range env.KubeClusters {
 		if !env.IsControlPlaneCluster(cluster) {
 			cluster := cluster
-			if err := deployControlPlane(i, cfg, cluster, remoteIopFile); err != nil {
-				return nil, fmt.Errorf("failed deploying control plane to cluster %s: %v", cluster.Name(), err)
-			}
+			errG.Go(func() error {
+				if err := deployControlPlane(i, cfg, cluster, remoteIopFile); err != nil {
+					return fmt.Errorf("failed deploying control plane to cluster %s: %v", cluster.Name(), err)
+				}
+				return nil
+			})
 		}
+	}
+	if errs := errG.Wait(); errs != nil {
+		return nil, fmt.Errorf("%d errors occurred deploying remote clusters: %v", errs.Len(), errs.ErrorOrNil())
 	}
 
 	if env.IsMulticluster() && !isCentralIstio(env, cfg) {


### PR DESCRIPTION
Temporarily rolling back part of #25280 which causes a concurrent map write panic when deploying istio in parallel for multicluster tests. 
https://github.com/istio/istio/blob/a09277852d82e6b13eacd87003a822c232081b03/istioctl/cmd/root.go#L142

A proper fix adding locking to the viper package is incoming if we think that's worth it.

https://prow.istio.io/view/gcs/istio-prow/pr-logs/pull/istio_istio/25612/integ-multicluster-k8s-tests_istio/6961
https://prow.istio.io/view/gcs/istio-prow/pr-logs/pull/istio_istio/25631/integ-multicluster-k8s-tests_istio/6956

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
