### PR TITLE
Cherrypick 24566 - update proxy readiness probe to port 15021 and cleanup demo profile.

### DIFF
--- a/manifests/profiles/demo.yaml
+++ b/manifests/profiles/demo.yaml
@@ -28,8 +28,8 @@ spec:
             # Note that AWS ELB will by default perform health checks on the first port
             # on this list. Setting this to the health check port will ensure that health
             # checks always work. https://github.com/istio/istio/issues/12503
-            - port: 15020
-              targetPort: 15020
+            - port: 15021
+              targetPort: 15021
               name: status-port
             - port: 80
               targetPort: 8080
@@ -45,36 +45,9 @@ spec:
               targetPort: 15443
               name: tls
 
-    policy:
-      enabled: false
-      k8s:
-        resources:
-          requests:
-            cpu: 10m
-            memory: 100Mi
-
-    telemetry:
-      k8s:
-        resources:
-          requests:
-            cpu: 50m
-            memory: 100Mi
-
     pilot:
       k8s:
         env:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.name
-          - name: POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.namespace
-          - name: GODEBUG
-            value: gctrace=1
           - name: PILOT_TRACE_SAMPLING
             value: "100"
           - name: CONFIG_NAMESPACE
@@ -102,24 +75,6 @@ spec:
 
     pilot:
       autoscaleEnabled: false
-
-    mixer:
-      adapters:
-        useAdapterCRDs: false
-        kubernetesenv:
-          enabled: true
-        prometheus:
-          enabled: true
-          metricsExpiryDuration: 10m
-        stackdriver:
-          enabled: false
-        stdio:
-          enabled: true
-          outputAsJson: false
-      policy:
-        autoscaleEnabled: false
-      telemetry:
-        autoscaleEnabled: false
 
     gateways:
       istio-egressgateway:


### PR DESCRIPTION
Please provide a description for what this PR is for.

resolve: https://github.com/istio/istio/issues/25626
cherrypick https://github.com/istio/istio/pull/24566

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
