### PR TITLE
Disable debug logging in CI

### DIFF
--- a/pkg/test/framework/logging.go
+++ b/pkg/test/framework/logging.go
@@ -20,7 +20,6 @@ import (
 
 	"google.golang.org/grpc/grpclog"
 
-	"istio.io/istio/pkg/test/scopes"
 	"istio.io/pkg/log"
 )
 
@@ -38,13 +37,11 @@ func init() {
 		flag.BoolVar)
 }
 
-func configureLogging(ciMode bool) error {
+func configureLogging() error {
 	o := *logOptionsFromCommandline
 
-	if ciMode {
-		o.SetOutputLevel(scopes.Framework.Name(), log.DebugLevel)
-	}
 	o.LogGrpc = false
 	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard))
+
 	return log.Configure(&o)
 }

--- a/pkg/test/framework/suite.go
+++ b/pkg/test/framework/suite.go
@@ -453,7 +453,7 @@ func initRuntime(s *suiteImpl) error {
 		environmentFactory = newEnvironment
 	}
 
-	if err := configureLogging(settings.CIMode); err != nil {
+	if err := configureLogging(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This may just be personal preference, but in my opinion the debug
logging obscures the logs we want to look for during failures, and I
often find people who are not experts in the integration tests being
confused by them.

Up until ~1 month ago we did not have debug logging, which I think was
the right move personally.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
