### PR TITLE
verify if namespace exists during bookinfo cleanup

### DIFF
--- a/samples/bookinfo/platform/kube/cleanup.sh
+++ b/samples/bookinfo/platform/kube/cleanup.sh
@@ -24,7 +24,7 @@ fi
 
 # verify if the namespace exists, otherwise use default namespace
 if [[ -n ${NAMESPACE} ]];then
-  ns=$(kubectl get namespace ${NAMESPACE} --no-headers --output=go-template={{.metadata.name}} 2>/dev/null)
+  ns=$(kubectl get namespace "${NAMESPACE}" --no-headers --output=go-template="{{.metadata.name}}" 2>/dev/null)
   if [[ -z ${ns} ]];then
     echo "NAMESPACE ${NAMESPACE} not found."
     NAMESPACE=default

--- a/samples/bookinfo/platform/kube/cleanup.sh
+++ b/samples/bookinfo/platform/kube/cleanup.sh
@@ -22,6 +22,16 @@ if [[ -t 0 && -z ${NAMESPACE} ]];then
   read -r NAMESPACE
 fi
 
+# verify if the namespace exists, otherwise use default namespace
+if [[ -n ${NAMESPACE} ]];then
+  ns=$(kubectl get namespace ${NAMESPACE} --no-headers --output=go-template={{.metadata.name}} 2>/dev/null)
+  if [[ -z ${ns} ]];then
+    echo "NAMESPACE ${NAMESPACE} not found."
+    NAMESPACE=default
+  fi
+fi
+
+# if no namesapce is provided, use default namespace
 if [[ -z ${NAMESPACE} ]];then
   NAMESPACE=default
 fi
@@ -56,5 +66,8 @@ else
     exit ${ret}
   fi
 fi
+
+# wait for 30 sec for bookinfo to clean up
+sleep 30
 
 echo "Application cleanup successful"


### PR DESCRIPTION
This PR checks if the namespace is available and if it does not, script assume the default namespace. It also waits for `30s` before cleanup exists.

**Before**:
If the user provides an invalid namespace, bookinfo cleanup runs and shows successful cleanup. 
```
$ samples/bookinfo/platform/kube/cleanup.sh
namespace ? [default] y
using NAMESPACE=y
Application cleanup may take up to one minute
Application cleanup successful
```
When you check pods, it shows the pods are still running.
```
$ kubectl get pods
NAME                              READY   STATUS             RESTARTS   AGE
details-v1-6c9f8bcbcb-2n7b5       2/2     Running            0          120m
productpage-v1-7df7cb7f86-ks2qb   1/2     CrashLoopBackOff   26         120m
ratings-v1-65cff55fb8-f2cr4       2/2     Running            0          120m
reviews-v1-7bccdbbf96-sfvsv       2/2     Running            0          120m
reviews-v2-7c9685df46-dv7fp       2/2     Running            0          120m
reviews-v3-58fc46b64-4l8t6        2/2     Running            0          120m
```

**After**:
```
$ samples/bookinfo/platform/kube/cleanup.sh
namespace ? [default] y
NAMESPACE y not found.
using NAMESPACE=default
Application cleanup may take up to one minute
service "details" deleted
serviceaccount "bookinfo-details" deleted
deployment.apps "details-v1" deleted
service "ratings" deleted
serviceaccount "bookinfo-ratings" deleted
deployment.apps "ratings-v1" deleted
service "reviews" deleted
serviceaccount "bookinfo-reviews" deleted
deployment.apps "reviews-v1" deleted
deployment.apps "reviews-v2" deleted
deployment.apps "reviews-v3" deleted
service "productpage" deleted
serviceaccount "bookinfo-productpage" deleted
deployment.apps "productpage-v1" deleted
...
Application cleanup successful
```

```
$ kubectl get pods
No resources found in default namespace.
```