### PR TITLE
make QPS and Burst values configurable via pilot features

### DIFF
--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -66,6 +66,8 @@ var (
 		RunE: func(c *cobra.Command, args []string) error {
 			serverArgs.Config.DistributionTrackingEnabled = features.EnableDistributionTracking
 			serverArgs.Config.DistributionCacheRetention = features.DistributionHistoryRetention
+			serverArgs.Config.ControllerOptions.KubernetesAPIQPS = float32(features.KubernetesAPIQPS.Get())
+			serverArgs.Config.ControllerOptions.KubernetesAPIBurst = features.KubernetesAPIBurst.Get()
 			cmd.PrintFlags(c.Flags())
 			if err := log.Configure(loggingOptions); err != nil {
 				return err

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -402,8 +402,8 @@ func (s *Server) initKubeClient(args *PilotArgs) error {
 	if hasKubeRegistry(args.Service.Registries) {
 		var err error
 		s.kubeClient, err = kubelib.CreateClientset(args.Config.KubeConfig, "", func(config *rest.Config) {
-			config.QPS = 20
-			config.Burst = 40
+			config.QPS = args.Config.ControllerOptions.KubernetesAPIQPS
+			config.Burst = args.Config.ControllerOptions.KubernetesAPIBurst
 		})
 		if err != nil {
 			return fmt.Errorf("failed creating kube client: %v", err)

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -304,4 +304,10 @@ var (
 
 	ClusterName = env.RegisterStringVar("CLUSTER_ID", "Kubernetes",
 		"Defines the cluster and service registry that this Istiod instance belongs to")
+
+	KubernetesAPIQPS = env.RegisterFloatVar("KUBERNETES_API_QPS", 20.0,
+		"Maximum QPS when communicating with the kubernetes API")
+
+	KubernetesAPIBurst = env.RegisterIntVar("KUBERNETES_API_BURST", 40,
+		"Maximum burst for throttle when communicating with the kubernetes API")
 )

--- a/pilot/pkg/features/pilot_test.go
+++ b/pilot/pkg/features/pilot_test.go
@@ -76,3 +76,81 @@ func Test_TerminationDrainDuration(t *testing.T) {
 		})
 	}
 }
+
+func Test_KubernetesAPIQPS(t *testing.T) {
+	tests := []struct {
+		name      string
+		setEnvVar bool
+		envVar    string
+		want      float64
+	}{
+		{
+			name:      "Returns 100 when env var is set to 100",
+			setEnvVar: true,
+			envVar:    "100",
+			want:      100.0,
+		},
+		{
+			name:      "Returns 20.0 when when no env var set",
+			setEnvVar: false,
+			want:      20.0,
+		},
+		{
+			name:      "Returns 20.0 when env var is empty string",
+			setEnvVar: true,
+			envVar:    "",
+			want:      20.0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setEnvVar {
+				os.Setenv(KubernetesAPIQPS.Name, tt.envVar)
+			} else {
+				os.Unsetenv(KubernetesAPIQPS.Name)
+			}
+			if got := KubernetesAPIQPS.Get(); got != tt.want {
+				t.Errorf("KubernetesAPIQPS.Get() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_KubernetesAPIBurst(t *testing.T) {
+	tests := []struct {
+		name      string
+		setEnvVar bool
+		envVar    string
+		want      int
+	}{
+		{
+			name:      "Returns 100 when env var is set to 100",
+			setEnvVar: true,
+			envVar:    "100",
+			want:      100,
+		},
+		{
+			name:      "Returns 40 when when no env var set",
+			setEnvVar: false,
+			want:      40,
+		},
+		{
+			name:      "Returns 40 when env var is empty string",
+			setEnvVar: true,
+			envVar:    "",
+			want:      40,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setEnvVar {
+				os.Setenv(KubernetesAPIBurst.Name, tt.envVar)
+			} else {
+				os.Unsetenv(KubernetesAPIBurst.Name)
+			}
+			if got := KubernetesAPIBurst.Get(); got != tt.want {
+				t.Errorf("KubernetesAPIBurst.Get() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -120,6 +120,12 @@ type Options struct {
 
 	// EndpointMode decides what source to use to get endpoint information
 	EndpointMode EndpointMode
+
+	// Maximum QPS when communicating with kubernetes API
+	KubernetesAPIQPS float32
+
+	// Maximum burst for throttle when communicating with the kubernetes API
+	KubernetesAPIBurst int
 }
 
 // EndpointMode decides what source to use to get endpoint information


### PR DESCRIPTION
Make QPS and Burst for kubernetes values configurable via pilot features

[X] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
