### PR TITLE
Move Viper default setting to init()

### DIFF
--- a/istioctl/cmd/config_test.go
+++ b/istioctl/cmd/config_test.go
@@ -31,14 +31,14 @@ func TestConfigList(t *testing.T) {
 		},
 		{ // case 1
 			args: strings.Split("experimental config list", " "),
-			expectedOutput: `FLAG                    VALUE     FROM
-cert-dir                          default
-insecure                          default
-istioNamespace                    default
-prefer-experimental               default
-xds-address                       default
-xds-port                15012     default
-xds-san                           default
+			expectedOutput: `FLAG                    VALUE            FROM
+cert-dir                                 default
+insecure                                 default
+istioNamespace          istio-system     default
+prefer-experimental                      default
+xds-address                              default
+xds-port                15012            default
+xds-san                                  default
 `,
 			wantException: false,
 		},

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -118,6 +118,11 @@ func ConfigAndEnvProcessing() error {
 	return nil
 }
 
+func init() {
+	viper.SetDefault("istioNamespace", controller.IstioNamespace)
+	viper.SetDefault("xds-port", 15012)
+}
+
 // GetRootCmd returns the root of the cobra command-tree.
 func GetRootCmd(args []string) *cobra.Command {
 	rootCmd := &cobra.Command{
@@ -139,7 +144,7 @@ debug and diagnose their Istio mesh.
 	rootCmd.PersistentFlags().StringVar(&configContext, "context", "",
 		"The name of the kubeconfig context to use")
 
-	rootCmd.PersistentFlags().StringVarP(&istioNamespace, "istioNamespace", "i", controller.IstioNamespace,
+	rootCmd.PersistentFlags().StringVarP(&istioNamespace, "istioNamespace", "i", viper.GetString("istioNamespace"),
 		"Istio system namespace")
 
 	rootCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", v1.NamespaceAll,

--- a/istioctl/pkg/clioptions/central.go
+++ b/istioctl/pkg/clioptions/central.go
@@ -51,8 +51,6 @@ type CentralControlPlaneOptions struct {
 // (Currently just --endpoint)
 func (o *CentralControlPlaneOptions) AttachControlPlaneFlags(cmd *cobra.Command) {
 
-	viper.SetDefault("xds-port", 15012)
-
 	cmd.PersistentFlags().StringVar(&o.Xds, "xds-address", viper.GetString("XDS-ADDRESS"),
 		"XDS Endpoint")
 	cmd.PersistentFlags().StringVar(&o.CertDir, "cert-dir", viper.GetString("CERT-DIR"),


### PR DESCRIPTION
Restore the functionality removed in https://github.com/istio/istio/pull/25633

The PR follows the example of _tools/istio-iptables/pkg/cmd/root.go_ setting the defaults in an `init()` so it is guaranteed to occur exactly once during a run.