### PR TITLE
fix spelling mistake in file init.sh

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -208,7 +208,7 @@ else
   ISTIO_ENVOY_NATIVE_PATH=${ISTIO_ENVOY_LINUX_RELEASE_PATH}
 fi
 
-# Donwload WebAssembly plugin files
+# Download WebAssembly plugin files
 WASM_RELEASE_DIR=${ISTIO_ENVOY_LINUX_RELEASE_DIR}
 for plugin in stats metadata_exchange
 do


### PR DESCRIPTION
Proposing a very small change for a spelling mistake in /bin/init.sh;

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
