### PR TITLE
Add liveness and readiness endpoints for the install CNI process

### DIFF
--- a/cni/pkg/install-cni/cmd/root.go
+++ b/cni/pkg/install-cni/cmd/root.go
@@ -40,7 +40,9 @@ var rootCmd = &cobra.Command{
 			return
 		}
 
-		installer := install.NewInstaller(cfg)
+		isReady := install.StartServer()
+
+		installer := install.NewInstaller(cfg, isReady)
 
 		if err = installer.Run(ctx); err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {

--- a/cni/pkg/install-cni/pkg/constants/constants.go
+++ b/cni/pkg/install-cni/pkg/constants/constants.go
@@ -20,7 +20,6 @@ const (
 	CNINetDir            = "cni-net-dir"
 	CNIConfName          = "cni-conf-name"
 	ChainedCNIPlugin     = "chained-cni-plugin"
-	Sleep                = "sleep"
 	CNINetworkConfigFile = "cni-network-config-file"
 	CNINetworkConfig     = "cni-network-config"
 	LogLevel             = "log-level"

--- a/cni/pkg/install-cni/pkg/constants/constants.go
+++ b/cni/pkg/install-cni/pkg/constants/constants.go
@@ -39,4 +39,9 @@ const (
 	SecondaryBinDir       = "/host/secondary-bin-dir"
 	ServiceAccountPath    = "/var/run/secrets/kubernetes.io/serviceaccount"
 	DefaultKubeconfigMode = 0600
+
+	// K8s liveness and readiness endpoints
+	LivenessEndpoint  = "/healthz"
+	ReadinessEndpoint = "/readyz"
+	Port              = "8000"
 )

--- a/cni/pkg/install-cni/pkg/install/install_test.go
+++ b/cni/pkg/install-cni/pkg/install/install_test.go
@@ -15,11 +15,16 @@
 package install
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"istio.io/istio/cni/pkg/install-cni/pkg/config"
 	"istio.io/istio/cni/pkg/install-cni/pkg/util"
@@ -105,6 +110,139 @@ func TestCheckInstall(t *testing.T) {
 			err = checkInstall(cfg, filepath.Join(tempDir, c.cniConfigFilename))
 			if (c.expectedFailure && err == nil) || (!c.expectedFailure && err != nil) {
 				t.Fatalf("expected failure: %t, got %v", c.expectedFailure, err)
+			}
+		})
+	}
+}
+
+func TestSleepCheckInstall(t *testing.T) {
+	cases := []struct {
+		name                  string
+		chainedCNIPlugin      bool
+		cniConfigFilename     string
+		invalidConfigFilename string
+		validConfigFilename   string
+	}{
+		{
+			name:                  "chained CNI plugin",
+			chainedCNIPlugin:      true,
+			cniConfigFilename:     "plugins.conflist",
+			invalidConfigFilename: "list.conflist",
+			validConfigFilename:   "list.conflist.golden",
+		},
+		{
+			name:                "standalone CNI plugin",
+			cniConfigFilename:   "istio-cni.conf",
+			validConfigFilename: "istio-cni.conf",
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// Create temp directory for files
+			tempDir, err := ioutil.TempDir("", fmt.Sprintf("test-case-%d-", i))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				if err := os.RemoveAll(tempDir); err != nil {
+					t.Fatal(err)
+				}
+			}()
+
+			// Initialize parameters
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			cfg := &config.Config{
+				MountedCNINetDir: tempDir,
+				ChainedCNIPlugin: c.chainedCNIPlugin,
+			}
+			cniConfigFilepath := filepath.Join(tempDir, c.cniConfigFilename)
+			isReady := &atomic.Value{}
+			SetNotReady(isReady)
+
+			if len(c.invalidConfigFilename) > 0 {
+				// Copy an invalid config file into tempDir
+				if err = util.AtomicCopy(filepath.Join("testdata", c.invalidConfigFilename), tempDir, c.cniConfigFilename); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			t.Log("Expecting an invalid configuration log:")
+			if err = sleepCheckInstall(ctx, cfg, cniConfigFilepath, isReady); err != nil {
+				t.Fatalf("error should be nil due to invalid config, got: %v", err)
+			}
+			assert.Falsef(t, isReady.Load().(bool), "isReady should still be false")
+
+			if len(c.invalidConfigFilename) > 0 {
+				if err = os.Remove(cniConfigFilepath); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// Copy an valid config file into tempDir
+			if err = util.AtomicCopy(filepath.Join("testdata", c.validConfigFilename), tempDir, c.cniConfigFilename); err != nil {
+				t.Fatal(err)
+			}
+
+			// Listen for isReady to be set to true
+			ticker := time.NewTicker(500 * time.Millisecond)
+			defer ticker.Stop()
+			readyChan := make(chan bool)
+			go func(ctx context.Context, tick <-chan time.Time) {
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case <-tick:
+						if isReady.Load().(bool) {
+							readyChan <- true
+						}
+					}
+				}
+			}(ctx, ticker.C)
+
+			// Listen to sleepCheckInstall return value
+			// Should detect a valid configuration and wait indefinitely for a file modification
+			errChan := make(chan error)
+			go func(ctx context.Context, cfg *config.Config, cniConfigFilepath string, isReady *atomic.Value) {
+				errChan <- sleepCheckInstall(ctx, cfg, cniConfigFilepath, isReady)
+			}(ctx, cfg, cniConfigFilepath, isReady)
+
+			select {
+			case <-readyChan:
+				assert.Truef(t, isReady.Load().(bool), "isReady should have been set to true")
+			case err = <-errChan:
+				if err == nil {
+					t.Fatal("invalid configuration detected")
+				}
+				t.Fatal(err)
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out waiting for isReady to be set to true")
+			}
+
+			// Remove Istio CNI's config
+			t.Log("Expecting an invalid configuration log:")
+			if len(c.invalidConfigFilename) > 0 {
+				if err = util.AtomicCopy(filepath.Join("testdata", c.invalidConfigFilename), tempDir, c.cniConfigFilename); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				if err = os.Remove(cniConfigFilepath); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			select {
+			case err = <-errChan:
+				if err != nil {
+					// An invalid configuration should return nil
+					// Either an invalid config did not return nil (which is an issue) or an unexpected error occurred
+					t.Fatal(err)
+				}
+				assert.Falsef(t, isReady.Load().(bool), "isReady should have been set to false after returning from sleepCheckInstall")
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out waiting for invalid configuration to be detected")
 			}
 		})
 	}

--- a/cni/pkg/install-cni/pkg/install/server.go
+++ b/cni/pkg/install-cni/pkg/install/server.go
@@ -1,0 +1,69 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package install
+
+import (
+	"net/http"
+	"sync/atomic"
+
+	"istio.io/istio/cni/pkg/install-cni/pkg/constants"
+	"istio.io/pkg/log"
+)
+
+// StartServer initializes and starts a web server that exposes liveness and readiness endpoints at port 8000.
+func StartServer() *atomic.Value {
+	router := http.NewServeMux()
+	isReady := initRouter(router)
+
+	go func() {
+		log.Fatala(http.ListenAndServe(":"+constants.Port, router))
+	}()
+
+	return isReady
+}
+
+// Sets isReady to true.
+func SetReady(isReady *atomic.Value) {
+	isReady.Store(true)
+}
+
+// Sets isReady to false.
+func SetNotReady(isReady *atomic.Value) {
+	isReady.Store(false)
+}
+
+func initRouter(router *http.ServeMux) *atomic.Value {
+	isReady := &atomic.Value{}
+	isReady.Store(false)
+
+	router.HandleFunc(constants.LivenessEndpoint, healthz)
+	router.HandleFunc(constants.ReadinessEndpoint, readyz(isReady))
+
+	return isReady
+}
+
+func healthz(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+func readyz(isReady *atomic.Value) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		if isReady == nil || !isReady.Load().(bool) {
+			http.Error(w, http.StatusText(http.StatusServiceUnavailable), http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}
+}

--- a/cni/pkg/install-cni/pkg/install/server_test.go
+++ b/cni/pkg/install-cni/pkg/install/server_test.go
@@ -1,0 +1,61 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package install
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"istio.io/istio/cni/pkg/install-cni/pkg/constants"
+)
+
+func TestServer(t *testing.T) {
+	router := http.NewServeMux()
+	isReady := initRouter(router)
+
+	assert.Falsef(t, isReady.Load().(bool), "isReady should be initialized to false")
+
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	makeReq(t, server.URL, constants.LivenessEndpoint, http.StatusOK)
+	makeReq(t, server.URL, constants.ReadinessEndpoint, http.StatusServiceUnavailable)
+
+	SetReady(isReady)
+	assert.Truef(t, isReady.Load().(bool), "isReady should be set to true")
+
+	makeReq(t, server.URL, constants.LivenessEndpoint, http.StatusOK)
+	makeReq(t, server.URL, constants.ReadinessEndpoint, http.StatusOK)
+
+	SetNotReady(isReady)
+	assert.Falsef(t, isReady.Load().(bool), "isReady should be set to false")
+
+	makeReq(t, server.URL, constants.LivenessEndpoint, http.StatusOK)
+	makeReq(t, server.URL, constants.ReadinessEndpoint, http.StatusServiceUnavailable)
+}
+
+func makeReq(t *testing.T, url, endpoint string, expectedStatusCode int) {
+	t.Helper()
+	res, err := http.Get(url + endpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.StatusCode != expectedStatusCode {
+		t.Fatalf("expected status code from %s: %d, got: %d", endpoint, expectedStatusCode, res.StatusCode)
+	}
+}

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -61,6 +61,15 @@ spec:
 {{- if or .Values.cni.pullPolicy .Values.global.imagePullPolicy }}
           imagePullPolicy: {{ .Values.cni.pullPolicy | default .Values.global.imagePullPolicy }}
 {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8000
+            initialDelaySeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8000
           command: ["install-cni"]
           env:
 {{- if .Values.cni.cniConfFileName }}


### PR DESCRIPTION
Adds /healthz and /readyz endpoints mentioned in [this comment](https://github.com/istio/istio/issues/24775#issuecomment-646117766).

> - /healthz indicates that the installer binary is running
> - /readyz indicates that the installer binary has installed the configuration, and that CNI is ready to start processing pods. We can use this in CNI race condition mitigations.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
