### PR TITLE
Add stableNamespaces option to test framework

### DIFF
--- a/pkg/test/framework/components/namespace/namespace.go
+++ b/pkg/test/framework/components/namespace/namespace.go
@@ -54,6 +54,9 @@ func ClaimOrFail(t test.Failer, ctx resource.Context, name string) Instance {
 
 // New creates a new Namespace in all clusters.
 func New(ctx resource.Context, nsConfig Config) (i Instance, err error) {
+	if ctx.Settings().StableNamespaces {
+		return Claim(ctx, nsConfig.Prefix, nsConfig.Inject)
+	}
 	return newKube(ctx, &nsConfig)
 }
 

--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -71,6 +71,9 @@ func init() {
 	flag.IntVar(&settingsFromCommandLine.Retries, "istio.test.retries", settingsFromCommandLine.Retries,
 		"Number of times to retry tests")
 
+	flag.BoolVar(&settingsFromCommandLine.StableNamespaces, "istio.test.stableNamespaces", settingsFromCommandLine.StableNamespaces,
+		"If set, will use consistent namespace rather than randomly generated. Useful with nocleanup to develop tests.")
+
 	flag.BoolVar(&settingsFromCommandLine.FailOnDeprecation, "istio.test.deprecation_failure", settingsFromCommandLine.FailOnDeprecation,
 		"Make tests fail if any usage of deprecated stuff (e.g. Envoy flags) is detected.")
 }

--- a/pkg/test/framework/resource/settings.go
+++ b/pkg/test/framework/resource/settings.go
@@ -53,6 +53,10 @@ type Settings struct {
 	// This should not be depended on as a primary means for reducing test flakes.
 	Retries int
 
+	// If enabled, namespaces will be reused rather than created with dynamic names each time.
+	// This is useful when combined with NoCleanup, to allow quickly iterating on tests.
+	StableNamespaces bool
+
 	// The label selector that the user has specified.
 	SelectorString string
 


### PR DESCRIPTION
Especially combined with https://github.com/istio/istio/pull/25636, this
makes local test development *much* faster. There is a basically no
overhead of test setup, so most tests which are of the form apply
config,send traffic, check result can run completely in under 1s.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
