### PR TITLE
add discovery host as sni host to xds-grpc cluster

### DIFF
--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -94,6 +94,7 @@ type Config struct {
 	OutlierLogPath      string
 	PilotCertProvider   string
 	ProvCert            string
+	DiscoveryHost       string
 }
 
 // newTemplateParams creates a new template configuration for the given configuration.
@@ -122,7 +123,8 @@ func (cfg Config) toTemplateParams() (map[string]interface{}, error) {
 		option.DisableReportCalls(cfg.DisableReportCalls),
 		option.PilotCertProvider(cfg.PilotCertProvider),
 		option.OutlierLogPath(cfg.OutlierLogPath),
-		option.ProvCert(cfg.ProvCert))
+		option.ProvCert(cfg.ProvCert),
+		option.DiscoveryHost(cfg.DiscoveryHost))
 
 	if cfg.STSPort > 0 {
 		opts = append(opts,

--- a/pkg/bootstrap/option/instances.go
+++ b/pkg/bootstrap/option/instances.go
@@ -244,3 +244,7 @@ func STSEnabled(value bool) Instance {
 func ProvCert(value string) Instance {
 	return newOption("provisioned_cert", value)
 }
+
+func DiscoveryHost(value string) Instance {
+	return newOption("discovery_host", value)
+}

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -154,7 +154,6 @@ func (e *envoy) Run(config interface{}, epoch int, abort <-chan error) error {
 		fname = e.Config.CustomConfigFile
 	} else {
 		discHost := strings.Split(e.Config.DiscoveryAddress, ":")[0]
-		log.Infof("discHost is %s", discHost)
 		out, err := bootstrap.New(bootstrap.Config{
 			Node:                e.Node,
 			Proxy:               &e.Config,

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"strings"
 	"time"
 
 	envoyAdmin "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
@@ -152,6 +153,8 @@ func (e *envoy) Run(config interface{}, epoch int, abort <-chan error) error {
 		// there is a custom configuration. Don't write our own config - but keep watching the certs.
 		fname = e.Config.CustomConfigFile
 	} else {
+		discHost := strings.Split(e.Config.DiscoveryAddress, ":")[0]
+		log.Infof("discHost is %s", discHost)
 		out, err := bootstrap.New(bootstrap.Config{
 			Node:                e.Node,
 			Proxy:               &e.Config,
@@ -168,6 +171,7 @@ func (e *envoy) Run(config interface{}, epoch int, abort <-chan error) error {
 			OutlierLogPath:      e.OutlierLogPath,
 			PilotCertProvider:   e.PilotCertProvider,
 			ProvCert:            e.ProvCert,
+			DiscoveryHost:       discHost,
 		}).CreateFileForEpoch(epoch)
 		if err != nil {
 			log.Errora("Failed to generate bootstrap config: ", err)

--- a/releasenotes/notes/add-sni-host.yaml
+++ b/releasenotes/notes/add-sni-host.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: networking
+issue:
+- 25691
+releaseNotes: |
+  *Fixed* SNI host routing issue when user uses sniHosts match in virtual service

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -231,6 +231,7 @@
           "name": "envoy.transport_sockets.tls",
           "typed_config": {
             "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "sni": "{{ .discovery_host }}",
             "common_tls_context": {
               "alpn_protocols": [
                 "h2"


### PR DESCRIPTION
Please provide a description for what this PR is for.
To enable SNI/TLS based routing to function properly, for example:

```
apiVersion: networking.istio.io/v1alpha3
kind: Gateway
metadata:
  name: istiod3
  namespace: istio3
spec:
  selector:
    istio: ingressgateway
  servers:
    - port:
        number: 15012
        protocol: tls
        name: TLS-XDS
      tls:
        mode: PASSTHROUGH
      hosts:
      - "istiod3.mycluster.appdomain.cloud"
---
apiVersion: networking.istio.io/v1alpha3
kind: VirtualService
metadata:
    name: istiod3-vs
    namespace: istio3
spec:
    hosts:
    - istiod3.mycluster.appdomain.cloud
    gateways:
    - istiod3
    tls:
    - match:
      - port: 15012
        sniHosts:
        - istiod3.mycluster.appdomain.cloud
      route:
      - destination:
          host: istiod
          port:
            number: 15012
```

cc @howardjohn @irisdingbj @nmittler @frankbu 
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
