### PR TITLE
Add multi-namespace informer factories

### DIFF
--- a/istioctl/cmd/authz.go
+++ b/istioctl/cmd/authz.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"istio.io/istio/istioctl/pkg/authz"
 	"istio.io/istio/istioctl/pkg/util/configdump"
 	"istio.io/istio/istioctl/pkg/util/handlers"
@@ -111,7 +113,7 @@ func getConfigDumpFromFile(filename string) (*configdump.Wrapper, error) {
 }
 
 func getConfigDumpFromPod(podName, podNamespace string) (*configdump.Wrapper, error) {
-	kubeClient, err := kube.NewExtendedClient(kube.BuildClientCmd(kubeconfig, configContext), "")
+	kubeClient, err := kube.NewExtendedClient(kube.BuildClientCmd(kubeconfig, configContext), "", []string{metav1.NamespaceAll})
 	if err != nil {
 		return nil, err
 	}

--- a/istioctl/cmd/deprecated_cmd.go
+++ b/istioctl/cmd/deprecated_cmd.go
@@ -20,6 +20,7 @@ import (
 	istioclient "istio.io/client-go/pkg/clientset/versioned"
 
 	kubecfg "istio.io/istio/pkg/kube"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
@@ -32,7 +33,7 @@ func newConfigStore() (istioclient.Interface, error) {
 	if err != nil {
 		return nil, err
 	}
-	kclient, err := kubecfg.NewClient(kubecfg.NewClientConfigForRestConfig(cfg))
+	kclient, err := kubecfg.NewClient(kubecfg.NewClientConfigForRestConfig(cfg), []string{metav1.NamespaceAll})
 	if err != nil {
 		return nil, err
 	}

--- a/istioctl/cmd/proxystatus.go
+++ b/istioctl/cmd/proxystatus.go
@@ -26,6 +26,8 @@ import (
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/spf13/cobra"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"istio.io/istio/istioctl/pkg/clioptions"
 	"istio.io/istio/istioctl/pkg/multixds"
 	"istio.io/istio/istioctl/pkg/util/handlers"
@@ -131,7 +133,7 @@ func readConfigFile(filename string) ([]byte, error) {
 }
 
 func newKubeClientWithRevision(kubeconfig, configContext string, revision string) (kube.ExtendedClient, error) {
-	return kube.NewExtendedClient(kube.BuildClientCmd(kubeconfig, configContext), revision)
+	return kube.NewExtendedClient(kube.BuildClientCmd(kubeconfig, configContext), revision, []string{metav1.NamespaceAll})
 }
 
 func newKubeClient(kubeconfig, configContext string) (kube.ExtendedClient, error) {

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -24,6 +24,7 @@ import (
 	"net"
 	"net/http"
 	"path"
+	"strings"
 	"sync"
 	"time"
 
@@ -417,7 +418,8 @@ func (s *Server) initKubeClient(args *PilotArgs) error {
 			return fmt.Errorf("failed creating kube config: %v", err)
 		}
 
-		s.kubeClient, err = kubelib.NewClient(kubelib.NewClientConfigForRestConfig(s.kubeRestConfig))
+		namespaces := strings.Split(args.RegistryOptions.KubeOptions.WatchedNamespaces, ",")
+		s.kubeClient, err = kubelib.NewClient(kubelib.NewClientConfigForRestConfig(s.kubeRestConfig), namespaces)
 		if err != nil {
 			return fmt.Errorf("failed creating kube client: %v", err)
 		}

--- a/pkg/kube/informer.go
+++ b/pkg/kube/informer.go
@@ -1,0 +1,295 @@
+package kube
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"sync"
+	"time"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+)
+
+type InformerFactory interface {
+	Start(stopCh <-chan struct{})
+	ForResource(resource schema.GroupVersionResource) (InformerLister, error)
+	WaitForCacheSync(stopCh <-chan struct{})
+}
+
+type Informer interface {
+	AddEventHandler(handler cache.ResourceEventHandler)
+	AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration)
+	AddIndexers(indexers cache.Indexers) error
+	HasSynced() bool
+}
+
+type Lister interface {
+	List(out runtime.Object, opts ...ListOption) error
+	Get(key types.NamespacedName, out runtime.Object) error
+}
+
+type InformerLister interface {
+	Informer
+	Lister
+}
+
+type multiNamespaceInformerFactory struct {
+	namespaceToFactory map[string]informers.SharedInformerFactory
+}
+
+var _ InformerFactory = &multiNamespaceInformerFactory{}
+
+type NewInformerFactoryFunc func(namespace string) informers.SharedInformerFactory
+
+func NewInformerFactory(namespaces []string, f NewInformerFactoryFunc) (InformerFactory, error) {
+	// TOOD(bison): Dedupe namespaces and check for metav1.NamespaceAll.
+	if len(namespaces) < 1 {
+		return nil, errors.New("must provide at least one namespace, which may be metav1.NamespaceAll")
+	}
+
+	factory := &multiNamespaceInformerFactory{
+		namespaceToFactory: make(map[string]informers.SharedInformerFactory),
+	}
+
+	for _, ns := range namespaces {
+		factory.namespaceToFactory[ns] = f(ns)
+	}
+
+	return factory, nil
+}
+
+func (f *multiNamespaceInformerFactory) ForResource(resource schema.GroupVersionResource) (InformerLister, error) {
+	informer := &multiNamespaceInformer{
+		namespaceToInformer: make(map[string]cache.SharedIndexInformer),
+		resource:            resource,
+	}
+
+	for ns, factory := range f.namespaceToFactory {
+		genericInformer, err := factory.ForResource(resource)
+		if err != nil {
+			return nil, err
+		}
+
+		informer.namespaceToInformer[ns] = genericInformer.Informer()
+	}
+
+	return informer, nil
+}
+
+func (f *multiNamespaceInformerFactory) Start(stopCh <-chan struct{}) {
+	for _, factory := range f.namespaceToFactory {
+		factory.Start(stopCh)
+	}
+}
+
+func (f *multiNamespaceInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) {
+	var wg sync.WaitGroup
+
+	for i := range f.namespaceToFactory {
+		factory := f.namespaceToFactory[i]
+		wg.Add(1)
+		go func() {
+			factory.WaitForCacheSync(stopCh)
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+}
+
+type multiNamespaceInformer struct {
+	namespaceToInformer map[string]cache.SharedIndexInformer
+	resource            schema.GroupVersionResource
+}
+
+var _ Informer = &multiNamespaceInformer{}
+
+// AddEventHandler adds the handler to each namespaced informer.
+func (i *multiNamespaceInformer) AddEventHandler(handler cache.ResourceEventHandler) {
+	for _, informer := range i.namespaceToInformer {
+		informer.AddEventHandler(handler)
+	}
+}
+
+// AddEventHandlerWithResyncPeriod adds the handler with a resync period to each
+// namespaced informer.
+func (i *multiNamespaceInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) {
+	for _, informer := range i.namespaceToInformer {
+		informer.AddEventHandlerWithResyncPeriod(handler, resyncPeriod)
+	}
+}
+
+// AddIndexers adds the indexer for each namespaced informer.
+func (i *multiNamespaceInformer) AddIndexers(indexers cache.Indexers) error {
+	for _, informer := range i.namespaceToInformer {
+		err := informer.AddIndexers(indexers)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// HasSynced checks if each namespaced informer has synced.
+func (i *multiNamespaceInformer) HasSynced() bool {
+	for _, informer := range i.namespaceToInformer {
+		if ok := informer.HasSynced(); !ok {
+			return ok
+		}
+	}
+	return true
+}
+
+// Get fetches the object names by the given key, and places it in out.
+func (i *multiNamespaceInformer) Get(key types.NamespacedName, out runtime.Object) error {
+	indexer, err := i.indexerForNamespace(key.Namespace)
+	if err != nil {
+		return err
+	}
+
+	obj, exists, err := indexer.GetByKey(key.String())
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		return kerrors.NewNotFound(i.resource.GroupResource(), key.String())
+	}
+
+	outVal := reflect.ValueOf(out)
+	objVal := reflect.ValueOf(obj)
+	if !objVal.Type().AssignableTo(outVal.Type()) {
+		return fmt.Errorf("cache had type %s, but %s was asked for", objVal.Type(), outVal.Type())
+	}
+	reflect.Indirect(outVal).Set(reflect.Indirect(objVal))
+
+	// TODO(bison): Set GroupVersionKind?
+	// out.GetObjectKind().SetGroupVersionKind(groupVersionKind)
+
+	return nil
+}
+
+type ListOptions struct {
+	namespace string
+	selector  labels.Selector
+}
+
+func DefaultListOptions() *ListOptions {
+	return &ListOptions{
+		selector:  labels.Everything(),
+		namespace: metav1.NamespaceAll,
+	}
+}
+
+func (l *ListOptions) ApplyOptions(opts ...ListOption) *ListOptions {
+	for _, opt := range opts {
+		opt.ApplyToList(l)
+	}
+
+	return l
+}
+
+type ListOption interface {
+	ApplyToList(*ListOptions)
+}
+
+type InNamespace string
+
+func (n InNamespace) ApplyToList(opts *ListOptions) {
+	opts.namespace = string(n)
+}
+
+type MatchingLabelsSelector struct {
+	labels.Selector
+}
+
+func (m MatchingLabelsSelector) ApplyToList(opts *ListOptions) {
+	opts.selector = m
+}
+
+// List will list all objects in the informers' caches, across all watched
+// namespaces, matching the given label selector and set them in the Items field
+// of the provided list object.
+func (i *multiNamespaceInformer) List(out runtime.Object, opts ...ListOption) error {
+	listOpts := DefaultListOptions().ApplyOptions(opts...)
+
+	var objects []interface{}
+	var err error
+
+	if listOpts.namespace != "" {
+		if objects, err = i.listNamespace(listOpts.namespace, listOpts.selector); err != nil {
+			return err
+		}
+	} else {
+		if objects, err = i.listAllNamespaces(listOpts.selector); err != nil {
+			return err
+		}
+	}
+
+	runtimeObjects := make([]runtime.Object, 0, len(objects))
+
+	for _, obj := range objects {
+		runtimeObj, ok := obj.(runtime.Object)
+		if !ok {
+			return fmt.Errorf("cache contained %T, which is not an Object", obj)
+		}
+		runtimeObjects = append(runtimeObjects, runtimeObj)
+	}
+
+	return apimeta.SetList(out, runtimeObjects)
+}
+
+// listAllNamespaces lists objects across all namespaces the informer knows about.
+func (i *multiNamespaceInformer) listAllNamespaces(s labels.Selector) ([]interface{}, error) {
+	var objects []interface{}
+
+	for ns := range i.namespaceToInformer {
+		objs, err := i.listNamespace(ns, s)
+		if err != nil {
+			return nil, err
+		}
+
+		objects = append(objects, objs...)
+	}
+
+	return objects, nil
+}
+
+// listNamespace lists all objects in the given namespace matching the label selector.
+func (i *multiNamespaceInformer) listNamespace(ns string, s labels.Selector) ([]interface{}, error) {
+	var objects []interface{}
+
+	indexer, err := i.indexerForNamespace(ns)
+	if err != nil {
+		return nil, err
+	}
+
+	cache.ListAllByNamespace(indexer, ns, s, func(obj interface{}) {
+		objects = append(objects, obj)
+	})
+
+	return objects, nil
+}
+
+// indexerForNamespace returns the indexer from the informer for the given namespace.
+func (i *multiNamespaceInformer) indexerForNamespace(ns string) (cache.Indexer, error) {
+	var indexer cache.Indexer
+
+	if informer, ok := i.namespaceToInformer[metav1.NamespaceAll]; ok {
+		indexer = informer.GetIndexer() // Use the informer for all namespaces.
+	} else if informer, ok := i.namespaceToInformer[ns]; ok {
+		indexer = informer.GetIndexer() // Use the namespace specific informer.
+	} else {
+		return nil, fmt.Errorf("namespace %q not found in cache", ns)
+	}
+
+	return indexer, nil
+}

--- a/pkg/kube/secretcontroller/secretcontroller.go
+++ b/pkg/kube/secretcontroller/secretcontroller.go
@@ -245,7 +245,7 @@ var BuildClientsFromConfig = func(kubeConfig []byte) (kube.Client, error) {
 
 	clientConfig := clientcmd.NewDefaultClientConfig(*rawConfig, &clientcmd.ConfigOverrides{})
 
-	clients, err := kube.NewClient(clientConfig)
+	clients, err := kube.NewClient(clientConfig, []string{meta_v1.NamespaceAll})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create kube clients: %v", err)
 	}

--- a/pkg/proxy/proxyinfo.go
+++ b/pkg/proxy/proxyinfo.go
@@ -19,6 +19,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"istio.io/istio/pilot/pkg/xds"
 	"istio.io/istio/pkg/kube"
 	istioVersion "istio.io/pkg/version"
@@ -32,7 +34,7 @@ type sidecarSyncStatus struct {
 
 // GetProxyInfo retrieves infos of proxies that connect to the Istio control plane of specific revision.
 func GetProxyInfo(kubeconfig, configContext, revision, istioNamespace string) (*[]istioVersion.ProxyInfo, error) {
-	kubeClient, err := kube.NewExtendedClient(kube.BuildClientCmd(kubeconfig, configContext), revision)
+	kubeClient, err := kube.NewExtendedClient(kube.BuildClientCmd(kubeconfig, configContext), revision, []string{metav1.NamespaceAll})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/test/framework/components/environment/kube/settings.go
+++ b/pkg/test/framework/components/environment/kube/settings.go
@@ -18,6 +18,8 @@ import (
 	"errors"
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	istioKube "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test/framework/resource"
 )
@@ -105,7 +107,7 @@ func newClients(kubeConfigs []string) ([]istioKube.ExtendedClient, error) {
 	out := make([]istioKube.ExtendedClient, 0, len(kubeConfigs))
 	for _, cfg := range kubeConfigs {
 		if len(cfg) > 0 {
-			a, err := istioKube.NewExtendedClient(istioKube.BuildClientCmd(cfg, ""), "")
+			a, err := istioKube.NewExtendedClient(istioKube.BuildClientCmd(cfg, ""), "", []string{metav1.NamespaceAll})
 			if err != nil {
 				return nil, fmt.Errorf("client setup: %v", err)
 			}


### PR DESCRIPTION
This is very much a draft / experiment to see how we might be able to get the support for watching a limited set of namespaces working again after the discussion in #24640.

This adds `multiNamespaceInformerFactory` and `multiNamespaceInformer` types in the new Kube client package. They essentially wrap the existing types and map individual namespaces to factories and informers, then present a scoped-down version of the interfaces for these. This is based on what controller-runtime does -- see [here](https://github.com/kubernetes-sigs/controller-runtime/blob/v0.6.1/pkg/cache/multi_namespace_cache.go).

I initially wanted to just use controller-runtime directly, but their cache implementation takes a `rest.Config` in order to create a dynamic `RESTMapper` which I think makes a lot of things harder to test for Istio.

Anyway, I think what's here basically works, and is fairly straight forward, though the API for `List()` and `Get()` is a little unfortunate. Although, it's basically the same as what controller-runtime exposes. Some alternatives may be:

- Expose a [GenericLister](https://godoc.org/k8s.io/client-go/tools/cache#GenericLister) instead. This has the disadvantage of only returning `runtime.Object`, so converting those and dealing with errors is up to callers -- probably not what we want.
- Maintain typed versions of these multi-namespace informers for the types we need. We may also be able to generate these fairly easily with a modified [informer-gen](https://github.com/kubernetes/code-generator/tree/v0.18.6/cmd/informer-gen).
- Require callers to list and fetch directly from the API server. Probably not acceptable for performance reasons of course.

Hoping to get feedback on whether this is worth pursuing, or if anyone has other suggestions.