### PR TITLE
Analyze deprecated crs

### DIFF
--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -91,6 +91,7 @@ var testGrid = []testCase{
 			{msg.Deprecated, "Sidecar no-selector.default"},
 			{msg.Deprecated, "Sidecar no-selector.default"},
 			{msg.Deprecated, "Sidecar no-selector.default"},
+			{msg.Deprecated, "QuotaSpec request-count.istio-system"},
 		},
 	},
 	{

--- a/galley/pkg/config/analysis/analyzers/deprecation/deprecation.go
+++ b/galley/pkg/config/analysis/analyzers/deprecation/deprecation.go
@@ -17,13 +17,14 @@ package deprecation
 import (
 	"fmt"
 
+	k8sext_v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
 	"istio.io/api/networking/v1alpha3"
 	"istio.io/istio/galley/pkg/config/analysis"
 	"istio.io/istio/galley/pkg/config/analysis/msg"
 	"istio.io/istio/pkg/config/resource"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
-	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
 // FieldAnalyzer checks for deprecated Istio types and fields
@@ -31,22 +32,22 @@ type FieldAnalyzer struct{}
 
 var (
 	// Tracks Istio CRDs removed from manifests/charts/base/crds/crd-all.gen.yaml
-	deprecatedCRDs = []v1.CustomResourceDefinitionSpec{
+	deprecatedCRDs = []k8sext_v1.CustomResourceDefinitionSpec{
 		{
 			Group: "rbac.istio.io",
-			Names: v1.CustomResourceDefinitionNames{Kind: "ClusterRbacConfig"},
+			Names: k8sext_v1.CustomResourceDefinitionNames{Kind: "ClusterRbacConfig"},
 		},
 		{
 			Group: "rbac.istio.io",
-			Names: v1.CustomResourceDefinitionNames{Kind: "RbacConfig"},
+			Names: k8sext_v1.CustomResourceDefinitionNames{Kind: "RbacConfig"},
 		},
 		{
 			Group: "rbac.istio.io",
-			Names: v1.CustomResourceDefinitionNames{Kind: "ServiceRole"},
+			Names: k8sext_v1.CustomResourceDefinitionNames{Kind: "ServiceRole"},
 		},
 		{
 			Group: "rbac.istio.io",
-			Names: v1.CustomResourceDefinitionNames{Kind: "ServiceRoleBinding"},
+			Names: k8sext_v1.CustomResourceDefinitionNames{Kind: "ServiceRoleBinding"},
 		},
 	}
 )
@@ -95,7 +96,7 @@ func (fa *FieldAnalyzer) Analyze(ctx analysis.Context) {
 }
 
 func (*FieldAnalyzer) analyzeCRD(r *resource.Instance, ctx analysis.Context) {
-	crd := r.Message.(*v1.CustomResourceDefinitionSpec)
+	crd := r.Message.(*k8sext_v1.CustomResourceDefinitionSpec)
 	for _, depCRD := range deprecatedCRDs {
 		if crd.Group == depCRD.Group && crd.Names.Kind == depCRD.Names.Kind {
 			ctx.Report(collections.K8SApiextensionsK8SIoV1Customresourcedefinitions.Name(),

--- a/galley/pkg/config/analysis/analyzers/testdata/deprecation.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/deprecation.yaml
@@ -50,3 +50,14 @@ spec:
         number: 9080
   localhost:
     clientTls:
+---
+apiVersion: config.istio.io/v1alpha2
+kind: QuotaSpec
+metadata:
+  name: request-count
+  namespace: istio-system
+spec:
+  rules:
+  - quotas:
+    - charge: 1
+      quota: requestcount

--- a/pkg/config/schema/metadata.gen.go
+++ b/pkg/config/schema/metadata.gen.go
@@ -382,6 +382,16 @@ snapshots:
       - "k8s/core/v1/secrets"
       - "k8s/core/v1/services"
       - "k8s/core/v1/configmaps"
+      - "istio/config/v1alpha2/adapters"
+      - "istio/config/v1alpha2/httpapispecbindings"
+      - "istio/config/v1alpha2/httpapispecs"
+      - "istio/config/v1alpha2/templates"
+      - "istio/mixer/v1/config/client/quotaspecbindings"
+      - "istio/mixer/v1/config/client/quotaspecs"
+      - "istio/policy/v1beta1/attributemanifests"
+      - "istio/policy/v1beta1/handlers"
+      - "istio/policy/v1beta1/instances"
+      - "istio/policy/v1beta1/rules"
 
 # Configuration for resource types.
 resources:

--- a/pkg/config/schema/metadata.yaml
+++ b/pkg/config/schema/metadata.yaml
@@ -327,6 +327,16 @@ snapshots:
       - "k8s/core/v1/secrets"
       - "k8s/core/v1/services"
       - "k8s/core/v1/configmaps"
+      - "istio/config/v1alpha2/adapters"
+      - "istio/config/v1alpha2/httpapispecbindings"
+      - "istio/config/v1alpha2/httpapispecs"
+      - "istio/config/v1alpha2/templates"
+      - "istio/mixer/v1/config/client/quotaspecbindings"
+      - "istio/mixer/v1/config/client/quotaspecs"
+      - "istio/policy/v1beta1/attributemanifests"
+      - "istio/policy/v1beta1/handlers"
+      - "istio/policy/v1beta1/instances"
+      - "istio/policy/v1beta1/rules"
 
 # Configuration for resource types.
 resources:

--- a/releasenotes/notes/24471.yaml
+++ b/releasenotes/notes/24471.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue: 24471
+
+releaseNotes: |
+  *Added* 
+  - 'istioctl analyze' now warns if deprecated mixer resources are present


### PR DESCRIPTION
For https://github.com/istio/istio/issues/24471

Incorporates the mixer deprecations into `istioctl analyze`

This PR also introduces warnings if the user has CRDs for RBAC that should no longer be present.