### PR TITLE
test kube ServiceRegistry in xds_test

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -48,7 +48,6 @@ import (
 
 const (
 	testService = "test"
-	resync      = 1 * time.Second
 )
 
 func TestServices(t *testing.T) {
@@ -84,7 +83,7 @@ func TestServices(t *testing.T) {
 			t.Parallel()
 			ns := "ns-test"
 
-			hostname := kube.ServiceHostname(testService, ns, domainSuffix)
+			hostname := kube.ServiceHostname(testService, ns, defaultFakeDomainSuffix)
 
 			var sds model.ServiceDiscovery = ctl
 			// "test", ports: http-example on 80
@@ -153,7 +152,7 @@ func TestServices(t *testing.T) {
 				t.Fatalf("Endpoint with IP 10.11.1.2 is expected to be in network2 but get: %s", ep[1].Endpoint.Network)
 			}
 
-			missing := kube.ServiceHostname("does-not-exist", ns, domainSuffix)
+			missing := kube.ServiceHostname("does-not-exist", ns, defaultFakeDomainSuffix)
 			svc, err = sds.GetService(missing)
 			if err != nil {
 				t.Fatalf("GetService(%q) encountered unexpected error: %v", missing, err)
@@ -394,7 +393,7 @@ func TestGetProxyServiceInstances(t *testing.T) {
 				t.Fatalf("GetProxyServiceInstances() expected 1 instance, got %d", len(serviceInstances))
 			}
 
-			hostname := kube.ServiceHostname("svc1", "nsa", domainSuffix)
+			hostname := kube.ServiceHostname("svc1", "nsa", defaultFakeDomainSuffix)
 			if serviceInstances[0].Service.Hostname != hostname {
 				t.Fatalf("GetProxyServiceInstances() wrong service instance returned => hostname %q, want %q",
 					serviceInstances[0].Service.Hostname, hostname)
@@ -740,7 +739,7 @@ func TestGetProxyServiceInstancesWithMultiIPsAndTargetPorts(t *testing.T) {
 
 func TestController_GetIstioServiceAccounts(t *testing.T) {
 	oldTrustDomain := spiffe.GetTrustDomain()
-	spiffe.SetTrustDomain(domainSuffix)
+	spiffe.SetTrustDomain(defaultFakeDomainSuffix)
 	defer spiffe.SetTrustDomain(oldTrustDomain)
 
 	for mode, name := range EndpointModeNames {
@@ -787,7 +786,7 @@ func TestController_GetIstioServiceAccounts(t *testing.T) {
 			// We expect only one EDS update with Endpoints.
 			<-fx.Events
 
-			hostname := kube.ServiceHostname("svc1", "nsA", domainSuffix)
+			hostname := kube.ServiceHostname("svc1", "nsA", defaultFakeDomainSuffix)
 			svc, err := controller.GetService(hostname)
 			if err != nil {
 				t.Fatalf("failed to get service: %v", err)
@@ -803,7 +802,7 @@ func TestController_GetIstioServiceAccounts(t *testing.T) {
 				t.Fatalf("Unexpected service accounts %v (expecting %v)", sa, expected)
 			}
 
-			hostname = kube.ServiceHostname("svc2", "nsA", domainSuffix)
+			hostname = kube.ServiceHostname("svc2", "nsA", defaultFakeDomainSuffix)
 			svc, err = controller.GetService(hostname)
 			if err != nil {
 				t.Fatalf("failed to get service: %v", err)
@@ -843,7 +842,7 @@ func TestController_Service(t *testing.T) {
 
 			expectedSvcList := []*model.Service{
 				{
-					Hostname: kube.ServiceHostname("svc1", "nsA", domainSuffix),
+					Hostname: kube.ServiceHostname("svc1", "nsA", defaultFakeDomainSuffix),
 					Address:  "10.0.0.1",
 					Ports: model.PortList{
 						&model.Port{
@@ -854,7 +853,7 @@ func TestController_Service(t *testing.T) {
 					},
 				},
 				{
-					Hostname: kube.ServiceHostname("svc2", "nsA", domainSuffix),
+					Hostname: kube.ServiceHostname("svc2", "nsA", defaultFakeDomainSuffix),
 					Address:  "10.0.0.1",
 					Ports: model.PortList{
 						&model.Port{
@@ -865,7 +864,7 @@ func TestController_Service(t *testing.T) {
 					},
 				},
 				{
-					Hostname: kube.ServiceHostname("svc3", "nsA", domainSuffix),
+					Hostname: kube.ServiceHostname("svc3", "nsA", defaultFakeDomainSuffix),
 					Address:  "10.0.0.1",
 					Ports: model.PortList{
 						&model.Port{
@@ -876,7 +875,7 @@ func TestController_Service(t *testing.T) {
 					},
 				},
 				{
-					Hostname: kube.ServiceHostname("svc4", "nsA", domainSuffix),
+					Hostname: kube.ServiceHostname("svc4", "nsA", defaultFakeDomainSuffix),
 					Address:  "10.0.0.1",
 					Ports: model.PortList{
 						&model.Port{
@@ -952,18 +951,18 @@ func TestController_ExternalNameService(t *testing.T) {
 
 			k8sSvcs := []*coreV1.Service{
 				createExternalNameService(controller, "svc1", "nsA",
-					[]int32{8080}, "test-app-1.test.svc."+domainSuffix, t, fx.Events),
+					[]int32{8080}, "test-app-1.test.svc."+defaultFakeDomainSuffix, t, fx.Events),
 				createExternalNameService(controller, "svc2", "nsA",
-					[]int32{8081}, "test-app-2.test.svc."+domainSuffix, t, fx.Events),
+					[]int32{8081}, "test-app-2.test.svc."+defaultFakeDomainSuffix, t, fx.Events),
 				createExternalNameService(controller, "svc3", "nsA",
-					[]int32{8082}, "test-app-3.test.pod."+domainSuffix, t, fx.Events),
+					[]int32{8082}, "test-app-3.test.pod."+defaultFakeDomainSuffix, t, fx.Events),
 				createExternalNameService(controller, "svc4", "nsA",
 					[]int32{8083}, "g.co", t, fx.Events),
 			}
 
 			expectedSvcList := []*model.Service{
 				{
-					Hostname: kube.ServiceHostname("svc1", "nsA", domainSuffix),
+					Hostname: kube.ServiceHostname("svc1", "nsA", defaultFakeDomainSuffix),
 					Ports: model.PortList{
 						&model.Port{
 							Name:     "tcp-port",
@@ -975,7 +974,7 @@ func TestController_ExternalNameService(t *testing.T) {
 					Resolution:   model.DNSLB,
 				},
 				{
-					Hostname: kube.ServiceHostname("svc2", "nsA", domainSuffix),
+					Hostname: kube.ServiceHostname("svc2", "nsA", defaultFakeDomainSuffix),
 					Ports: model.PortList{
 						&model.Port{
 							Name:     "tcp-port",
@@ -987,7 +986,7 @@ func TestController_ExternalNameService(t *testing.T) {
 					Resolution:   model.DNSLB,
 				},
 				{
-					Hostname: kube.ServiceHostname("svc3", "nsA", domainSuffix),
+					Hostname: kube.ServiceHostname("svc3", "nsA", defaultFakeDomainSuffix),
 					Ports: model.PortList{
 						&model.Port{
 							Name:     "tcp-port",
@@ -999,7 +998,7 @@ func TestController_ExternalNameService(t *testing.T) {
 					Resolution:   model.DNSLB,
 				},
 				{
-					Hostname: kube.ServiceHostname("svc4", "nsA", domainSuffix),
+					Hostname: kube.ServiceHostname("svc4", "nsA", defaultFakeDomainSuffix),
 					Ports: model.PortList{
 						&model.Port{
 							Name:     "tcp-port",

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -30,7 +30,6 @@ import (
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
 
 	"istio.io/api/annotation"
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -42,144 +41,15 @@ import (
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/protocol"
-	kubelib "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/retry"
 )
 
 const (
-	testService  = "test"
-	resync       = 1 * time.Second
-	domainSuffix = "company.com"
+	testService = "test"
+	resync      = 1 * time.Second
 )
-
-func (fx *FakeXdsUpdater) ConfigUpdate(*model.PushRequest) {
-	select {
-	case fx.Events <- XdsEvent{Type: "xds"}:
-	default:
-	}
-}
-
-func (fx *FakeXdsUpdater) ProxyUpdate(_, _ string) {
-	select {
-	case fx.Events <- XdsEvent{Type: "proxy"}:
-	default:
-	}
-}
-
-// FakeXdsUpdater is used to test the registry.
-type FakeXdsUpdater struct {
-	// Events tracks notifications received by the updater
-	Events chan XdsEvent
-}
-
-// XdsEvent is used to watch XdsEvents
-type XdsEvent struct {
-	// Type of the event
-	Type string
-
-	// The id of the event
-	ID string
-
-	// The endpoints associated with an EDS push if any
-	Endpoints []*model.IstioEndpoint
-}
-
-// NewFakeXDS creates a XdsUpdater reporting events via a channel.
-func NewFakeXDS() *FakeXdsUpdater {
-	return &FakeXdsUpdater{
-		Events: make(chan XdsEvent, 100),
-	}
-}
-
-func (fx *FakeXdsUpdater) EDSUpdate(_, hostname string, _ string, entry []*model.IstioEndpoint) error {
-	if len(entry) > 0 {
-		select {
-		case fx.Events <- XdsEvent{Type: "eds", ID: hostname, Endpoints: entry}:
-		default:
-		}
-
-	}
-	return nil
-}
-
-// SvcUpdate is called when a service port mapping definition is updated.
-// This interface is WIP - labels, annotations and other changes to service may be
-// updated to force a EDS and CDS recomputation and incremental push, as it doesn't affect
-// LDS/RDS.
-func (fx *FakeXdsUpdater) SvcUpdate(_, hostname string, _ string, _ model.Event) {
-	select {
-	case fx.Events <- XdsEvent{Type: "service", ID: hostname}:
-	default:
-	}
-}
-
-func (fx *FakeXdsUpdater) Wait(et string) *XdsEvent {
-	for {
-		select {
-		case e := <-fx.Events:
-			if e.Type == et {
-				return &e
-			}
-			continue
-		case <-time.After(5 * time.Second):
-			return nil
-		}
-	}
-}
-
-// Clear any pending event
-func (fx *FakeXdsUpdater) Clear() {
-	wait := true
-	for wait {
-		select {
-		case <-fx.Events:
-		default:
-			wait = false
-		}
-	}
-}
-
-type fakeControllerOptions struct {
-	networksWatcher   mesh.NetworksWatcher
-	serviceHandler    func(service *model.Service, event model.Event)
-	instanceHandler   func(instance *model.ServiceInstance, event model.Event)
-	mode              EndpointMode
-	clusterID         string
-	watchedNamespaces string
-}
-
-func newFakeControllerWithOptions(opts fakeControllerOptions) (*Controller, *FakeXdsUpdater) {
-	fx := NewFakeXDS()
-
-	clients := kubelib.NewFakeClient()
-	options := Options{
-		WatchedNamespaces: opts.watchedNamespaces, // default is all namespaces
-		ResyncPeriod:      resync,
-		DomainSuffix:      domainSuffix,
-		XDSUpdater:        fx,
-		Metrics:           &model.Environment{},
-		NetworksWatcher:   opts.networksWatcher,
-		EndpointMode:      opts.mode,
-		ClusterID:         opts.clusterID,
-	}
-	c := NewController(clients, options)
-	if opts.instanceHandler != nil {
-		_ = c.AppendInstanceHandler(opts.instanceHandler)
-	}
-	if opts.serviceHandler != nil {
-		_ = c.AppendServiceHandler(opts.serviceHandler)
-	}
-	c.stop = make(chan struct{})
-	// Run in initiation to prevent calling each test
-	// TODO: fix it, so we can remove `stop` channel
-	go c.Run(c.stop)
-	clients.RunAndWait(c.stop)
-	// Wait for the caches to sync, otherwise we may hit race conditions where events are dropped
-	cache.WaitForCacheSync(c.stop, c.pods.informer.HasSynced, c.serviceInformer.HasSynced, c.endpoints.HasSynced)
-	return c, fx
-}
 
 func TestServices(t *testing.T) {
 
@@ -209,7 +79,7 @@ func TestServices(t *testing.T) {
 	for mode, name := range EndpointModeNames {
 		mode := mode
 		t.Run(name, func(t *testing.T) {
-			ctl, fx := newFakeControllerWithOptions(fakeControllerOptions{networksWatcher: networksWatcher, mode: mode})
+			ctl, fx := NewFakeControllerWithOptions(FakeControllerOptions{NetworksWatcher: networksWatcher, Mode: mode})
 			defer ctl.Stop()
 			t.Parallel()
 			ns := "ns-test"
@@ -420,7 +290,7 @@ func TestController_GetPodLocality(t *testing.T) {
 			t.Parallel()
 			// Setup kube caches
 			// Pod locality only matters for Endpoints
-			controller, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: EndpointsOnly})
+			controller, fx := NewFakeControllerWithOptions(FakeControllerOptions{Mode: EndpointsOnly})
 			defer controller.Stop()
 			addNodes(t, controller, tc.nodes...)
 			addPods(t, controller, tc.pods...)
@@ -459,9 +329,9 @@ func TestGetProxyServiceInstances(t *testing.T) {
 	for mode, name := range EndpointModeNames {
 		mode := mode
 		t.Run(name, func(t *testing.T) {
-			controller, fx := newFakeControllerWithOptions(fakeControllerOptions{
-				mode:      mode,
-				clusterID: clusterID,
+			controller, fx := NewFakeControllerWithOptions(FakeControllerOptions{
+				Mode:      mode,
+				ClusterID: clusterID,
 			})
 			defer controller.Stop()
 			p := generatePod("128.0.0.1", "pod1", "nsa", "foo", "node1", map[string]string{"app": "test-app"}, map[string]string{})
@@ -837,7 +707,7 @@ func TestGetProxyServiceInstancesWithMultiIPsAndTargetPorts(t *testing.T) {
 			mode := mode
 			t.Run(fmt.Sprintf("%s_%s", c.name, name), func(t *testing.T) {
 				// Setup kube caches
-				controller, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: mode})
+				controller, fx := NewFakeControllerWithOptions(FakeControllerOptions{Mode: mode})
 				defer controller.Stop()
 				addPods(t, controller, c.pods...)
 				for _, pod := range c.pods {
@@ -876,7 +746,7 @@ func TestController_GetIstioServiceAccounts(t *testing.T) {
 	for mode, name := range EndpointModeNames {
 		mode := mode
 		t.Run(name, func(t *testing.T) {
-			controller, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: mode})
+			controller, fx := NewFakeControllerWithOptions(FakeControllerOptions{Mode: mode})
 			defer controller.Stop()
 
 			sa1 := "acct1"
@@ -950,7 +820,7 @@ func TestController_Service(t *testing.T) {
 	for mode, name := range EndpointModeNames {
 		mode := mode
 		t.Run(name, func(t *testing.T) {
-			controller, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: mode})
+			controller, fx := NewFakeControllerWithOptions(FakeControllerOptions{Mode: mode})
 			defer controller.Stop()
 			// Use a timeout to keep the test from hanging.
 
@@ -1041,7 +911,7 @@ func TestExternalNameServiceInstances(t *testing.T) {
 	for mode, name := range EndpointModeNames {
 		mode := mode
 		t.Run(name, func(t *testing.T) {
-			controller, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: mode})
+			controller, fx := NewFakeControllerWithOptions(FakeControllerOptions{Mode: mode})
 			defer controller.Stop()
 			createExternalNameService(controller, "svc5", "nsA",
 				[]int32{1, 2, 3}, "foo.co", t, fx.Events)
@@ -1069,9 +939,9 @@ func TestController_ExternalNameService(t *testing.T) {
 		mode := mode
 		t.Run(name, func(t *testing.T) {
 			deleteWg := sync.WaitGroup{}
-			controller, fx := newFakeControllerWithOptions(fakeControllerOptions{
-				mode: mode,
-				serviceHandler: func(_ *model.Service, e model.Event) {
+			controller, fx := NewFakeControllerWithOptions(FakeControllerOptions{
+				Mode: mode,
+				ServiceHandler: func(_ *model.Service, e model.Event) {
 					if e == model.EventDelete {
 						deleteWg.Done()
 					}
@@ -1403,7 +1273,7 @@ func createServiceWithoutClusterIP(controller *Controller, name, namespace strin
 
 // nolint: unparam
 func createExternalNameService(controller *Controller, name, namespace string,
-	ports []int32, externalName string, t *testing.T, xdsEvents <-chan XdsEvent) *coreV1.Service {
+	ports []int32, externalName string, t *testing.T, xdsEvents <-chan FakeXdsEvent) *coreV1.Service {
 
 	defer func() {
 		<-xdsEvents
@@ -1436,7 +1306,7 @@ func createExternalNameService(controller *Controller, name, namespace string,
 	return service
 }
 
-func deleteExternalNameService(controller *Controller, name, namespace string, t *testing.T, xdsEvents <-chan XdsEvent) {
+func deleteExternalNameService(controller *Controller, name, namespace string, t *testing.T, xdsEvents <-chan FakeXdsEvent) {
 
 	defer func() {
 		<-xdsEvents
@@ -1531,7 +1401,7 @@ func TestEndpointUpdate(t *testing.T) {
 	for mode, name := range EndpointModeNames {
 		mode := mode
 		t.Run(name, func(t *testing.T) {
-			controller, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: mode})
+			controller, fx := NewFakeControllerWithOptions(FakeControllerOptions{Mode: mode})
 			defer controller.Stop()
 
 			pod1 := generatePod("128.0.0.1", "pod1", "nsA", "", "node1", map[string]string{"app": "prod-app"}, map[string]string{})
@@ -1597,7 +1467,7 @@ func TestEndpointUpdateBeforePodUpdate(t *testing.T) {
 	for mode, name := range EndpointModeNames {
 		mode := mode
 		t.Run(name, func(t *testing.T) {
-			controller, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: mode})
+			controller, fx := NewFakeControllerWithOptions(FakeControllerOptions{Mode: mode})
 			// Setup kube caches
 			defer controller.Stop()
 			addNodes(t, controller, generateNode("node1", map[string]string{NodeZoneLabel: "zone1", NodeRegionLabel: "region1", IstioSubzoneLabel: "subzone1"}))
@@ -1722,7 +1592,7 @@ func TestEndpointUpdateBeforePodUpdate(t *testing.T) {
 }
 
 func TestWorkloadInstanceHandlerMultipleEndpoints(t *testing.T) {
-	controller, fx := newFakeControllerWithOptions(fakeControllerOptions{})
+	controller, fx := NewFakeControllerWithOptions(FakeControllerOptions{})
 	defer controller.Stop()
 
 	// Create an initial pod with a service, and endpoint.

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -905,6 +905,7 @@ func TestController_Service(t *testing.T) {
 		})
 	}
 }
+
 //
 func TestExternalNameServiceInstances(t *testing.T) {
 	for mode, name := range EndpointModeNames {

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -1063,7 +1063,7 @@ func TestController_ExternalNameService(t *testing.T) {
 	}
 }
 
-func createEndpoints(controller *Controller, name, namespace string, portNames, ips []string, t *testing.T) {
+func createEndpoints(controller *FakeController, name, namespace string, portNames, ips []string, t *testing.T) {
 	var portNum int32 = 1001
 	eas := make([]coreV1.EndpointAddress, 0)
 	for _, ip := range ips {
@@ -1135,7 +1135,7 @@ func createEndpoints(controller *Controller, name, namespace string, portNames, 
 	}
 }
 
-func updateEndpoints(controller *Controller, name, namespace string, portNames, ips []string, t *testing.T) {
+func updateEndpoints(controller *FakeController, name, namespace string, portNames, ips []string, t *testing.T) {
 	var portNum int32 = 1001
 	eas := make([]coreV1.EndpointAddress, 0)
 	for _, ip := range ips {
@@ -1186,7 +1186,7 @@ func updateEndpoints(controller *Controller, name, namespace string, portNames, 
 	}
 }
 
-func createServiceWithTargetPorts(controller *Controller, name, namespace string, annotations map[string]string,
+func createServiceWithTargetPorts(controller *FakeController, name, namespace string, annotations map[string]string,
 	svcPorts []coreV1.ServicePort, selector map[string]string, t *testing.T) {
 	service := &coreV1.Service{
 		ObjectMeta: metaV1.ObjectMeta{
@@ -1384,7 +1384,7 @@ func generateNode(name string, labels map[string]string) *coreV1.Node {
 	}
 }
 
-func addNodes(t *testing.T, controller *Controller, nodes ...*coreV1.Node) {
+func addNodes(t *testing.T, controller *FakeController, nodes ...*coreV1.Node) {
 	fakeClient := controller.client
 
 	for _, node := range nodes {

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -905,7 +905,7 @@ func TestController_Service(t *testing.T) {
 		})
 	}
 }
-
+//
 func TestExternalNameServiceInstances(t *testing.T) {
 	for mode, name := range EndpointModeNames {
 		mode := mode
@@ -1208,7 +1208,7 @@ func createServiceWithTargetPorts(controller *Controller, name, namespace string
 	}
 }
 
-func createService(controller *Controller, name, namespace string, annotations map[string]string,
+func createService(controller *FakeController, name, namespace string, annotations map[string]string,
 	ports []int32, selector map[string]string, t *testing.T) {
 
 	svcPorts := make([]coreV1.ServicePort, 0)
@@ -1239,7 +1239,7 @@ func createService(controller *Controller, name, namespace string, annotations m
 	}
 }
 
-func createServiceWithoutClusterIP(controller *Controller, name, namespace string, annotations map[string]string,
+func createServiceWithoutClusterIP(controller *FakeController, name, namespace string, annotations map[string]string,
 	ports []int32, selector map[string]string, t *testing.T) {
 
 	svcPorts := make([]coreV1.ServicePort, 0)
@@ -1271,7 +1271,7 @@ func createServiceWithoutClusterIP(controller *Controller, name, namespace strin
 }
 
 // nolint: unparam
-func createExternalNameService(controller *Controller, name, namespace string,
+func createExternalNameService(controller *FakeController, name, namespace string,
 	ports []int32, externalName string, t *testing.T, xdsEvents <-chan FakeXdsEvent) *coreV1.Service {
 
 	defer func() {
@@ -1305,7 +1305,7 @@ func createExternalNameService(controller *Controller, name, namespace string,
 	return service
 }
 
-func deleteExternalNameService(controller *Controller, name, namespace string, t *testing.T, xdsEvents <-chan FakeXdsEvent) {
+func deleteExternalNameService(controller *FakeController, name, namespace string, t *testing.T, xdsEvents <-chan FakeXdsEvent) {
 
 	defer func() {
 		<-xdsEvents
@@ -1317,7 +1317,7 @@ func deleteExternalNameService(controller *Controller, name, namespace string, t
 	}
 }
 
-func addPods(t *testing.T, controller *Controller, pods ...*coreV1.Pod) {
+func addPods(t *testing.T, controller *FakeController, pods ...*coreV1.Pod) {
 	for _, pod := range pods {
 		p, _ := controller.client.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metaV1.GetOptions{})
 		var newPod *coreV1.Pod

--- a/pilot/pkg/serviceregistry/kube/controller/fake.go
+++ b/pilot/pkg/serviceregistry/kube/controller/fake.go
@@ -16,10 +16,10 @@ package controller
 
 import (
 	"errors"
-	
+	"time"
+
 	klabels "k8s.io/apimachinery/pkg/labels"
 	listerv1 "k8s.io/client-go/listers/core/v1"
-	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"

--- a/pilot/pkg/serviceregistry/kube/controller/fake.go
+++ b/pilot/pkg/serviceregistry/kube/controller/fake.go
@@ -15,7 +15,8 @@
 package controller
 
 import (
-	"fmt"
+	"errors"
+	
 	klabels "k8s.io/apimachinery/pkg/labels"
 	listerv1 "k8s.io/client-go/listers/core/v1"
 	"time"
@@ -139,7 +140,7 @@ type FakeController struct {
 func (f *FakeController) ResyncEndpoints() error {
 	e, ok := f.endpoints.(*endpointsController)
 	if !ok {
-		return fmt.Errorf("ResyncEndpoints only works for Endpoints mode")
+		return errors.New("cannot run ResyncEndpoints; EndpointsMode must be EndpointsOnly")
 	}
 	eps, err := listerv1.NewEndpointsLister(e.informer.GetIndexer()).List(klabels.Everything())
 	if err != nil {

--- a/pilot/pkg/serviceregistry/kube/controller/pod_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod_test.go
@@ -152,14 +152,14 @@ func TestIPReuse(t *testing.T) {
 	}
 }
 
-func createPod(t *testing.T, c *Controller, ip, name string) {
+func createPod(t *testing.T, c *FakeController, ip, name string) {
 	addPods(t, c, generatePod(ip, name, "ns", "1", "", map[string]string{}, map[string]string{}))
 	if err := waitForPod(c, ip); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func waitForPod(c *Controller, ip string) error {
+func waitForPod(c *FakeController, ip string) error {
 	return wait.Poll(10*time.Millisecond, 5*time.Second, func() (bool, error) {
 		c.pods.RLock()
 		defer c.pods.RUnlock()

--- a/pilot/pkg/serviceregistry/kube/controller/pod_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod_test.go
@@ -108,7 +108,7 @@ func TestPodCache(t *testing.T) {
 
 // Regression test for https://github.com/istio/istio/issues/20676
 func TestIPReuse(t *testing.T) {
-	c, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: EndpointsOnly})
+	c, fx := NewFakeControllerWithOptions(FakeControllerOptions{Mode: EndpointsOnly})
 	defer c.Stop()
 	initTestEnv(t, c.client, fx)
 
@@ -171,9 +171,9 @@ func waitForPod(c *Controller, ip string) error {
 }
 
 func testPodCache(t *testing.T) {
-	c, fx := newFakeControllerWithOptions(fakeControllerOptions{
-		mode:              EndpointsOnly,
-		watchedNamespaces: "nsa,nsb",
+	c, fx := NewFakeControllerWithOptions(FakeControllerOptions{
+		Mode:              EndpointsOnly,
+		WatchedNamespaces: "nsa,nsb",
 	})
 	defer c.Stop()
 
@@ -227,7 +227,7 @@ func testPodCache(t *testing.T) {
 // Checks that events from the watcher create the proper internal structures
 func TestPodCacheEvents(t *testing.T) {
 	t.Parallel()
-	c, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: EndpointsOnly})
+	c, fx := NewFakeControllerWithOptions(FakeControllerOptions{Mode: EndpointsOnly})
 	defer c.Stop()
 
 	ns := "default"

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -81,16 +81,20 @@ func getObjects(t test.Failer, opts FakeOptions) []runtime.Object {
 	if len(opts.Objects) > 0 {
 		return ensureNode(t, opts.Objects)
 	}
-	decode := scheme.Codecs.UniversalDeserializer().Decode
-	objectStrs := strings.Split(opts.ObjectString, "---")
-	objects := make([]runtime.Object, 0, len(objectStrs))
-	for _, s := range objectStrs {
-		o, _, err := decode([]byte(s), nil, nil)
-		if err != nil {
-			t.Fatalf("failed deserializing kubernetes object: %v", err)
+
+	objects := make([]runtime.Object, 0)
+	if len(opts.ObjectString) > 0 {
+		decode := scheme.Codecs.UniversalDeserializer().Decode
+		objectStrs := strings.Split(opts.ObjectString, "---")
+		for _, s := range objectStrs {
+			o, _, err := decode([]byte(s), nil, nil)
+			if err != nil {
+				t.Fatalf("failed deserializing kubernetes object: %v", err)
+			}
+			objects = append(objects, o)
 		}
-		objects = append(objects, o)
 	}
+
 	return ensureNode(t, objects)
 }
 

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -16,6 +16,7 @@ package xds
 
 import (
 	"bytes"
+	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
 	"reflect"
 	"strings"
 	"text/template"
@@ -47,7 +48,6 @@ import (
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	kube "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
-	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/test"
@@ -192,7 +192,8 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	env.Watcher = mesh.NewFixedWatcher(m)
 	env.NetworksWatcher = mesh.NewFixedNetworksWatcher(opts.MeshNetworks)
 
-	serviceDiscovery.AddRegistry(serviceentry.NewServiceDiscovery(configController, model.MakeIstioStore(configStore), s))
+	se := serviceentry.NewServiceDiscovery(configController, model.MakeIstioStore(configStore), s)
+	serviceDiscovery.AddRegistry(se)
 	k8s, _ := kube.NewFakeControllerWithOptions(kube.FakeControllerOptions{
 		Objects:      objects,
 		ClusterID:    "Kubernetes",
@@ -206,7 +207,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 			t.Fatalf("failed to create config %v: %v", cfg.Name, err)
 		}
 	}
-	serviceDiscovery.ResyncEDS()
+	se.ResyncEDS()
 
 	if err := env.PushContext.InitContext(env, nil, nil); err != nil {
 		t.Fatal(err)

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -160,7 +160,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		close(stop)
 	})
 	configs := getConfigs(t, opts)
-	objects := getObjects(t, opts)
+	k8sObjects := getObjects(t, opts)
 	configStore := memory.MakeWithLedger(collections.Pilot, &model.DisabledLedger{}, true)
 	env := &model.Environment{}
 	plugins := []string{plugin.Authn, plugin.Authz, plugin.Health}
@@ -195,7 +195,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	se := serviceentry.NewServiceDiscovery(configController, model.MakeIstioStore(configStore), s)
 	serviceDiscovery.AddRegistry(se)
 	k8s, _ := kube.NewFakeControllerWithOptions(kube.FakeControllerOptions{
-		Objects:         objects,
+		Objects:         k8sObjects,
 		ClusterID:       "Kubernetes",
 		DomainSuffix:    "cluster.local",
 		XDSUpdater:      s,
@@ -208,7 +208,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		}
 	}
 	se.ResyncEDS()
-
+	_ = k8s.ResyncEndpoints()
 	if err := env.PushContext.InitContext(env, nil, nil); err != nil {
 		t.Fatal(err)
 	}

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -16,7 +16,6 @@ package xds
 
 import (
 	"bytes"
-	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
 	"reflect"
 	"strings"
 	"text/template"
@@ -48,6 +47,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	kube "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
+	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/test"
@@ -195,10 +195,10 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	se := serviceentry.NewServiceDiscovery(configController, model.MakeIstioStore(configStore), s)
 	serviceDiscovery.AddRegistry(se)
 	k8s, _ := kube.NewFakeControllerWithOptions(kube.FakeControllerOptions{
-		Objects:      objects,
-		ClusterID:    "Kubernetes",
-		DomainSuffix: "cluster.local",
-		XDSUpdater:   s,
+		Objects:         objects,
+		ClusterID:       "Kubernetes",
+		DomainSuffix:    "cluster.local",
+		XDSUpdater:      s,
 		NetworksWatcher: env,
 	})
 	serviceDiscovery.AddRegistry(k8s)

--- a/pilot/pkg/xds/xds_test.go
+++ b/pilot/pkg/xds/xds_test.go
@@ -301,7 +301,7 @@ func TestSidecarListeners(t *testing.T) {
 
 func TestMeshNetworking(t *testing.T) {
 	s := NewFakeDiscoveryServer(t, FakeOptions{
-		ObjectString: `
+		KubernetesObjectString: `
 apiVersion: v1
 kind: Pod
 metadata:

--- a/pilot/pkg/xds/xds_test.go
+++ b/pilot/pkg/xds/xds_test.go
@@ -16,7 +16,6 @@ package xds
 
 import (
 	"io/ioutil"
-	"istio.io/istio/pkg/config/labels"
 	"path"
 	"testing"
 
@@ -25,6 +24,7 @@ import (
 	meshconfig "istio.io/api/mesh/v1alpha1"
 
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/util/structpath"

--- a/pilot/pkg/xds/xds_test.go
+++ b/pilot/pkg/xds/xds_test.go
@@ -414,7 +414,7 @@ spec:
 		},
 	})
 	vm := s.SetupProxy(&model.Proxy{
-		ID: "vm",
+		ID:              "vm",
 		IPAddresses:     []string{"10.10.10.10"},
 		ConfigNamespace: "default",
 		Metadata: &model.NodeMetadata{

--- a/pilot/pkg/xds/xds_test.go
+++ b/pilot/pkg/xds/xds_test.go
@@ -15,10 +15,11 @@
 package xds
 
 import (
-	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"io/ioutil"
 	"path"
 	"testing"
+
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 

--- a/pilot/pkg/xds/xds_test.go
+++ b/pilot/pkg/xds/xds_test.go
@@ -315,6 +315,7 @@ metadata:
   name: kubeapp
   namespace: pod
 spec:
+  clusterIP: 1.2.3.4
   selector:
     app: kubeapp
   ports:
@@ -391,7 +392,6 @@ spec:
 			InterceptionMode: "NONE",
 		},
 	})
-
 	assertListEqual(t, ExtractEndpoints(s.Endpoints(pod))["outbound|7070||httpbin.com"], []string{"10.10.10.10"})
 	assertListEqual(t, ExtractEndpoints(s.Endpoints(pod))["outbound|80||kubeapp.pod.svc.cluster.local"], []string{"10.10.10.20"})
 	assertListEqual(t, ExtractEndpoints(s.Endpoints(vm))["outbound|80||kubeapp.pod.svc.cluster.local"], []string{"2.2.2.2"})

--- a/pilot/pkg/xds/xds_test.go
+++ b/pilot/pkg/xds/xds_test.go
@@ -15,11 +15,10 @@
 package xds
 
 import (
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"io/ioutil"
 	"path"
 	"testing"
-
-	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 
@@ -394,8 +393,8 @@ spec:
 	})
 
 	assertListEqual(t, ExtractEndpoints(s.Endpoints(pod))["outbound|7070||httpbin.com"], []string{"10.10.10.10"})
-	assertListEqual(t, ExtractEndpoints(s.Endpoints(pod))["outbound|80||pod.pod.svc.cluster.local"], []string{"10.10.10.20"})
-	assertListEqual(t, ExtractEndpoints(s.Endpoints(vm))["outbound|80||pod.pod.svc.cluster.local"], []string{"2.2.2.2"})
+	assertListEqual(t, ExtractEndpoints(s.Endpoints(pod))["outbound|80||kubeapp.pod.svc.cluster.local"], []string{"10.10.10.20"})
+	assertListEqual(t, ExtractEndpoints(s.Endpoints(vm))["outbound|80||kubeapp.pod.svc.cluster.local"], []string{"2.2.2.2"})
 }
 
 func TestEgressProxy(t *testing.T) {

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -175,9 +175,9 @@ var _ ExtendedClient = &client{}
 
 const resyncInterval = 0
 
-func NewFakeClient() Client {
+func NewFakeClient(objects ...runtime.Object) Client {
 	var c client
-	c.Interface = fake.NewSimpleClientset()
+	c.Interface = fake.NewSimpleClientset(objects...)
 	c.kube = c.Interface
 	c.kubeInformer = informers.NewSharedInformerFactory(c.Interface, resyncInterval)
 


### PR DESCRIPTION
Expands on https://github.com/istio/istio/pull/25655 to allow testing kube serviceregistry logic

- FakeDiscoveryServer uses an aggregate service registry with ServiceEntry and Kube
- Kube registry uses faked client with hardcoded objects
- MeshNetworks test uses kube registry

The following coverage via xds_test was 0. Converting only one test, MeshNetworks, gets us some solid coverage of the kube regsitry. 

file | statistics
-- | --
controller.go | 34.5% statements
endpoint_builder.go | 90.9% statements
endpointcontroller.go | 60.5% statements
endpoints.go | 23% statements
endpointslice.go | 0% statements
fake.go | 43.1% statements
multicluster.go | 0% statements
namespacecontroller.go | 0% statements
network.go | 40% statements
pod.go | 20.5% statements
util.go | 26.8% statements



To get a test to work with eds you must have:
- A pod selected by a service with an endpoint
- Ports on the pod/service/endpoint
- ClusterIP must be set on the Service 

Minimal example:
```golang
NewFakeDiscoveryServer(t, FakeOptions{
		ObjectString: `
apiVersion: v1
kind: Pod
metadata:
  name: kubeapp-1234
  namespace: pod
  labels:
    app: kubeapp
---
apiVersion: v1
kind: Service
metadata:
  name: kubeapp
  namespace: pod
spec:
  clusterIP: 1.2.3.4
  selector:
    app: kubeapp
  ports:
  - port: 80
    name: http
    protocol: TCP
---
apiVersion: v1
kind: Endpoints
metadata:
  name: kubeapp
  namespace: pod
  labels:
    app: kubeapp
subsets:
- addresses:
  - ip: 10.10.10.20
    targetRef:
      kind: Pod
      name: kubeapp-1234
      namespace: pod
  ports:
  - port: 80
    name: http
    protocol: TCP
`,
})
```

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
