### PR TITLE
Call ApplyTrafficPolicy once per cluster

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -917,10 +917,6 @@ func applyUpstreamTLSSettings(opts *buildClusterOpts, tls *networking.ClientTLSS
 				},
 				defaultTransportSocketMatch,
 			}
-		} else {
-			// Since previous calls to applyTrafficPolicy may have set TransportSocketMatches for a subset cluster
-			// make sure they are reset.  See https://github.com/istio/istio/issues/23910
-			c.TransportSocketMatches = nil
 		}
 	}
 }

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -409,7 +409,7 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusterForPortOrUDS(pluginPara
 	if cfg != nil {
 		destinationRule := cfg.Spec.(*networking.DestinationRule)
 		if destinationRule.TrafficPolicy != nil {
-			connectionPool, _, _, _ := SelectTrafficPolicyComponents(destinationRule.TrafficPolicy, instance.ServicePort)
+			connectionPool, _, _, _ := selectTrafficPolicyComponents(MergeTrafficPolicy(nil, destinationRule.TrafficPolicy, instance.ServicePort))
 			// only connection pool settings make sense on the inbound path.
 			// upstream TLS settings/outlier detection/load balancer don't apply here.
 			applyConnectionPool(pluginParams.Push, localCluster, connectionPool)
@@ -505,29 +505,16 @@ func buildIstioMutualTLS(serviceAccounts []string, sni string, proxy *model.Prox
 }
 
 // SelectTrafficPolicyComponents returns the components of TrafficPolicy that should be used for given port.
-func SelectTrafficPolicyComponents(policy *networking.TrafficPolicy, port *model.Port) (
+func selectTrafficPolicyComponents(policy *networking.TrafficPolicy) (
 	*networking.ConnectionPoolSettings, *networking.OutlierDetection, *networking.LoadBalancerSettings, *networking.ClientTLSSettings) {
 	if policy == nil {
 		return nil, nil, nil, nil
 	}
-	// Default to traffic policy's settings.
 	connectionPool := policy.ConnectionPool
 	outlierDetection := policy.OutlierDetection
 	loadBalancer := policy.LoadBalancer
 	tls := policy.Tls
 
-	// Check if port level overrides exist, if yes override with them.
-	if port != nil && len(policy.PortLevelSettings) > 0 {
-		for _, p := range policy.PortLevelSettings {
-			if p.Port != nil && uint32(port.Port) == p.Port.Number {
-				connectionPool = p.ConnectionPool
-				outlierDetection = p.OutlierDetection
-				loadBalancer = p.LoadBalancer
-				tls = p.Tls
-				break
-			}
-		}
-	}
 	return connectionPool, outlierDetection, loadBalancer, tls
 }
 
@@ -633,7 +620,7 @@ func setH2Options(cluster *cluster.Cluster) {
 }
 
 func applyTrafficPolicy(opts buildClusterOpts) {
-	connectionPool, outlierDetection, loadBalancer, tls := SelectTrafficPolicyComponents(opts.policy, opts.port)
+	connectionPool, outlierDetection, loadBalancer, tls := selectTrafficPolicyComponents(opts.policy)
 	applyH2Upgrade(opts, connectionPool)
 	applyConnectionPool(opts.push, opts.cluster, connectionPool)
 	applyOutlierDetection(opts.cluster, outlierDetection)

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -147,6 +147,13 @@ func MergeTrafficPolicy(original, subsetPolicy *networking.TrafficPolicy, port *
 		return original
 	}
 
+	// Sanity check that top-level port level settings have already been merged for the given port
+	if original != nil && len(original.PortLevelSettings) != 0 {
+		original = MergeTrafficPolicy(nil, original, port)
+	}
+
+	// use DeepCopy to avoid modifying DestinationRule in push_context directly during cluster build steps
+	// for example: TLS context is currently modified as part of auto-mtls and ISTIO_MUTUAL logic
 	mergedPolicy := original.DeepCopy()
 	if mergedPolicy == nil {
 		mergedPolicy = &networking.TrafficPolicy{}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -260,6 +260,275 @@ func compareClusters(t *testing.T, ec *cluster.Cluster, gc *cluster.Cluster) {
 	}
 }
 
+func TestMergeTrafficPolicy(t *testing.T) {
+	cases := []struct {
+		name     string
+		original *networking.TrafficPolicy
+		subset   *networking.TrafficPolicy
+		port     *model.Port
+		expected *networking.TrafficPolicy
+	}{
+		{
+			name:     "all nil policies",
+			original: nil,
+			subset:   nil,
+			port:     nil,
+			expected: nil,
+		},
+		{
+			name: "no subset policy",
+			original: &networking.TrafficPolicy{
+				ConnectionPool: &networking.ConnectionPoolSettings{
+					Http: &networking.ConnectionPoolSettings_HTTPSettings{
+						MaxRetries: 10,
+					},
+				},
+			},
+			subset: nil,
+			port:   nil,
+			expected: &networking.TrafficPolicy{
+				ConnectionPool: &networking.ConnectionPoolSettings{
+					Http: &networking.ConnectionPoolSettings_HTTPSettings{
+						MaxRetries: 10,
+					},
+				},
+			},
+		},
+		{
+			name:     "no parent policy",
+			original: nil,
+			subset: &networking.TrafficPolicy{
+				ConnectionPool: &networking.ConnectionPoolSettings{
+					Http: &networking.ConnectionPoolSettings_HTTPSettings{
+						MaxRetries: 10,
+					},
+				},
+			},
+			port: nil,
+			expected: &networking.TrafficPolicy{
+				ConnectionPool: &networking.ConnectionPoolSettings{
+					Http: &networking.ConnectionPoolSettings_HTTPSettings{
+						MaxRetries: 10,
+					},
+				},
+			},
+		},
+		{
+			name: "merge non-conflicting fields",
+			original: &networking.TrafficPolicy{
+				Tls: &networking.ClientTLSSettings{
+					Mode: networking.ClientTLSSettings_ISTIO_MUTUAL,
+				},
+			},
+			subset: &networking.TrafficPolicy{
+				ConnectionPool: &networking.ConnectionPoolSettings{
+					Http: &networking.ConnectionPoolSettings_HTTPSettings{
+						MaxRetries: 10,
+					},
+				},
+			},
+			port: nil,
+			expected: &networking.TrafficPolicy{
+				ConnectionPool: &networking.ConnectionPoolSettings{
+					Http: &networking.ConnectionPoolSettings_HTTPSettings{
+						MaxRetries: 10,
+					},
+				},
+				Tls: &networking.ClientTLSSettings{
+					Mode: networking.ClientTLSSettings_ISTIO_MUTUAL,
+				},
+			},
+		},
+		{
+			name: "subset overwrite top-level fields",
+			original: &networking.TrafficPolicy{
+				Tls: &networking.ClientTLSSettings{
+					Mode: networking.ClientTLSSettings_ISTIO_MUTUAL,
+				},
+				ConnectionPool: &networking.ConnectionPoolSettings{
+					Http: &networking.ConnectionPoolSettings_HTTPSettings{
+						MaxRetries: 10,
+					},
+				},
+			},
+			subset: &networking.TrafficPolicy{
+				Tls: &networking.ClientTLSSettings{
+					Mode: networking.ClientTLSSettings_SIMPLE,
+				},
+			},
+			port: nil,
+			expected: &networking.TrafficPolicy{
+				Tls: &networking.ClientTLSSettings{
+					Mode: networking.ClientTLSSettings_SIMPLE,
+				},
+				ConnectionPool: &networking.ConnectionPoolSettings{
+					Http: &networking.ConnectionPoolSettings_HTTPSettings{
+						MaxRetries: 10,
+					},
+				},
+			},
+		},
+		{
+			name:     "merge port level policy, and do not inherit top-level fields",
+			original: nil,
+			subset: &networking.TrafficPolicy{
+				LoadBalancer: &networking.LoadBalancerSettings{
+					LbPolicy: &networking.LoadBalancerSettings_Simple{
+						Simple: networking.LoadBalancerSettings_ROUND_ROBIN,
+					},
+				},
+				ConnectionPool: &networking.ConnectionPoolSettings{
+					Http: &networking.ConnectionPoolSettings_HTTPSettings{
+						MaxRetries: 10,
+					},
+				},
+				PortLevelSettings: []*networking.TrafficPolicy_PortTrafficPolicy{
+					{
+						Port: &networking.PortSelector{
+							Number: 8080,
+						},
+						LoadBalancer: &networking.LoadBalancerSettings{
+							LbPolicy: &networking.LoadBalancerSettings_Simple{
+								Simple: networking.LoadBalancerSettings_LEAST_CONN,
+							},
+						},
+					},
+				},
+			},
+			port: &model.Port{Port: 8080},
+			expected: &networking.TrafficPolicy{
+				LoadBalancer: &networking.LoadBalancerSettings{
+					LbPolicy: &networking.LoadBalancerSettings_Simple{
+						Simple: networking.LoadBalancerSettings_LEAST_CONN,
+					},
+				},
+			},
+		},
+		{
+			name: "merge port level policy, and do not inherit top-level fields",
+			original: &networking.TrafficPolicy{
+				LoadBalancer: &networking.LoadBalancerSettings{
+					LbPolicy: &networking.LoadBalancerSettings_Simple{
+						Simple: networking.LoadBalancerSettings_ROUND_ROBIN,
+					},
+				},
+				OutlierDetection: &networking.OutlierDetection{
+					ConsecutiveErrors: 20,
+				},
+				PortLevelSettings: []*networking.TrafficPolicy_PortTrafficPolicy{
+					{
+						Port: &networking.PortSelector{
+							Number: 8080,
+						},
+						OutlierDetection: &networking.OutlierDetection{
+							ConsecutiveErrors: 15,
+						},
+					},
+				},
+			},
+			subset: &networking.TrafficPolicy{
+				LoadBalancer: &networking.LoadBalancerSettings{
+					LbPolicy: &networking.LoadBalancerSettings_Simple{
+						Simple: networking.LoadBalancerSettings_ROUND_ROBIN,
+					},
+				},
+				ConnectionPool: &networking.ConnectionPoolSettings{
+					Http: &networking.ConnectionPoolSettings_HTTPSettings{
+						MaxRetries: 10,
+					},
+				},
+				PortLevelSettings: []*networking.TrafficPolicy_PortTrafficPolicy{
+					{
+						Port: &networking.PortSelector{
+							Number: 8080,
+						},
+						OutlierDetection: &networking.OutlierDetection{
+							ConsecutiveErrors: 13,
+						},
+					},
+				},
+			},
+			port: &model.Port{Port: 8080},
+			expected: &networking.TrafficPolicy{
+				OutlierDetection: &networking.OutlierDetection{
+					ConsecutiveErrors: 13,
+				},
+			},
+		},
+		{
+			name: "default cluster, non-matching port selector",
+			original: &networking.TrafficPolicy{
+				LoadBalancer: &networking.LoadBalancerSettings{
+					LbPolicy: &networking.LoadBalancerSettings_Simple{
+						Simple: networking.LoadBalancerSettings_ROUND_ROBIN,
+					},
+				},
+				OutlierDetection: &networking.OutlierDetection{
+					ConsecutiveErrors: 20,
+				},
+				PortLevelSettings: []*networking.TrafficPolicy_PortTrafficPolicy{
+					{
+						Port: &networking.PortSelector{
+							Number: 8080,
+						},
+						OutlierDetection: &networking.OutlierDetection{
+							ConsecutiveErrors: 15,
+						},
+					},
+				},
+			},
+			subset: &networking.TrafficPolicy{
+				LoadBalancer: &networking.LoadBalancerSettings{
+					LbPolicy: &networking.LoadBalancerSettings_Simple{
+						Simple: networking.LoadBalancerSettings_ROUND_ROBIN,
+					},
+				},
+				ConnectionPool: &networking.ConnectionPoolSettings{
+					Http: &networking.ConnectionPoolSettings_HTTPSettings{
+						MaxRetries: 10,
+					},
+				},
+				PortLevelSettings: []*networking.TrafficPolicy_PortTrafficPolicy{
+					{
+						Port: &networking.PortSelector{
+							Number: 8080,
+						},
+						OutlierDetection: &networking.OutlierDetection{
+							ConsecutiveErrors: 13,
+						},
+					},
+				},
+			},
+			port: &model.Port{Port: 9090},
+			expected: &networking.TrafficPolicy{
+				LoadBalancer: &networking.LoadBalancerSettings{
+					LbPolicy: &networking.LoadBalancerSettings_Simple{
+						Simple: networking.LoadBalancerSettings_ROUND_ROBIN,
+					},
+				},
+				ConnectionPool: &networking.ConnectionPoolSettings{
+					Http: &networking.ConnectionPoolSettings_HTTPSettings{
+						MaxRetries: 10,
+					},
+				},
+				OutlierDetection: &networking.OutlierDetection{
+					ConsecutiveErrors: 20,
+				},
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := MergeTrafficPolicy(tt.original, tt.subset, tt.port)
+			if !reflect.DeepEqual(policy, tt.expected) {
+				t.Errorf("Unexpected merged TrafficPolicy. want %v, got %v", tt.expected, policy)
+			}
+		})
+	}
+
+}
+
 func TestApplyEdsConfig(t *testing.T) {
 	cases := []struct {
 		name       string

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -615,6 +615,12 @@ func TestBuildClustersWithMutualTlsAndNodeMetadataCertfileOverrides(t *testing.T
 		if strings.Contains(c.Name, "outbound") {
 			actualOutboundClusterCount++
 			tlsContext := getTLSContext(t, c)
+			if c.Name == "outbound|8080|foobar|foo.example.org" {
+				// per the docs: default values will be applied to fields omitted in port-level traffic policies rather than inheriting
+				// settings specified at the destination level
+				g.Expect(tlsContext).To(BeNil())
+				continue
+			}
 			g.Expect(tlsContext).NotTo(BeNil())
 
 			tlsCerts := tlsContext.CommonTlsContext.TlsCertificates

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -499,9 +499,11 @@ func getOutlierDetectionAndLoadBalancerSettings(push *model.PushContext, proxy *
 		}
 	}
 
-	lbSettings = policy.LoadBalancer
-	if policy.OutlierDetection != nil {
-		outlierDetectionEnabled = true
+	if policy != nil {
+		lbSettings = policy.LoadBalancer
+		if policy.OutlierDetection != nil {
+			outlierDetectionEnabled = true
+		}
 	}
 
 	return outlierDetectionEnabled, lbSettings


### PR DESCRIPTION

Please provide a description for what this PR is for.

Follow-up to discussion here: https://github.com/istio/istio/pull/25588#discussion_r456217149

Call applyTrafficPolicy once per cluster to avoid leftover cluster configuration settings from previous calls not getting properly set/unset.

includes a bug fix for DestinationRules of the following type:
```
apiVersion: networking.istio.io/v1alpha3
kind: DestinationRule
metadata:
  name: bookinfo-ratings
spec:
  host: "*.example.org"
  trafficPolicy:
    tls:
      mode: MUTUAL,
      clientCertificate: "/defaultCert.pem"
      privateKey: "/defaultPrivateKey.pem"
      caCertificates: "/defaultCaCert.pem"
  subsets:
  - name: foobar
    trafficPolicy:
      portLevelSettings:
        port:
          number: 8080
```

Cluster `outbound|8080|foobar|foo.example.org` was actually getting configured with a TLS context during first pass through `applyTrafficPolicy` and never getting unset.  According to docs ([ref](https://preliminary.istio.io/latest/docs/reference/config/networking/destination-rule/#TrafficPolicy)) inheritance is not supported for PortLevelSettings :
> Note that port level settings will override the destination-level settings. Traffic settings specified at the destination-level will not be inherited when overridden by port-level settings, i.e. default values will be applied to fields omitted in port-level traffic policies.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ X ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
