### PR TITLE
update cluster loading rule comment

### DIFF
--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -53,8 +53,8 @@ func BuildClientCmd(kubeconfig, context string) clientcmd.ClientConfig {
 
 	//Config loading rules:
 	// 1. kubeconfig if it not empty string
-	// 2. In cluster config if running in-cluster
-	// 3. Config(s) in KUBECONFIG environment variable
+	// 2. Config(s) in KUBECONFIG environment variable
+	// 3. In cluster config if running in-cluster
 	// 4. Use $HOME/.kube/config
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig


### PR DESCRIPTION
the kubeconfig env var is checked first prior to use in cluster k8s config.

tested this pretty extensively with central istiod single cluster: https://github.com/istio/istio/wiki/Central-Istiod-single-cluster-steps

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ x  ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
