### PR TITLE
Remove deprecated manifest apply for 1.7

### DIFF
--- a/istioctl/pkg/install/pre-check.go
+++ b/istioctl/pkg/install/pre-check.go
@@ -435,7 +435,7 @@ func NewPrecheckCommand() *cobra.Command {
 func findIstios(client dynamic.Interface) ([]istioInstall, error) {
 	retval := make([]istioInstall, 0)
 
-	// First, look for IstioOperator CRs left by 'istioctl manifest apply' or 'kubectl apply'
+	// First, look for IstioOperator CRs left by 'istioctl install' or 'kubectl apply'
 	iops, err := allOperatorsInCluster(client)
 	if err != nil {
 		return retval, err

--- a/operator/README.md
+++ b/operator/README.md
@@ -135,7 +135,7 @@ dlv debug --headless --listen=:2345 --api-version=2 -- server
 ### Relationship between the CLI and controller
 
 The CLI and controller share the same API and codebase for generating manifests from the API. You can think of the
-controller as the CLI command `istioctl manifest apply` running in a loop in a pod in the cluster and using the config
+controller as the CLI command `istioctl install` running in a loop in a pod in the cluster and using the config
 from the in-cluster IstioOperator custom resource (CR).
 There are two major differences:
 
@@ -183,7 +183,7 @@ The following command generates the manifests and applies them in the correct de
 dependencies to have the needed CRDs available:
 
 ```bash
-istioctl manifest apply
+istioctl install
 ```
 
 #### Review the values of a configuration profile
@@ -449,7 +449,7 @@ the spec.
 
 The controller shares the same API as the operator CLI, so it's possible to install any of the above examples as a CR
 in the cluster in the istio-system namespace and the controller will react to it with the same outcome as running
-`istioctl manifest apply -f <path-to-custom-resource-file>`.
+`istioctl install -f <path-to-custom-resource-file>`.
 
 ## Architecture
 

--- a/operator/cmd/mesh/manifest-apply.go
+++ b/operator/cmd/mesh/manifest-apply.go
@@ -38,7 +38,7 @@ const (
 	installedSpecCRPrefix = "installed-state"
 )
 
-type manifestApplyArgs struct {
+type installArgs struct {
 	// inFilenames is an array of paths to the input IstioOperator CR files.
 	inFilenames []string
 	// kubeConfigPath is the path to kube config file.
@@ -62,7 +62,7 @@ type manifestApplyArgs struct {
 	revision string
 }
 
-func addManifestApplyFlags(cmd *cobra.Command, args *manifestApplyArgs) {
+func addInstallFlags(cmd *cobra.Command, args *installArgs) {
 	cmd.PersistentFlags().StringSliceVarP(&args.inFilenames, "filename", "f", nil, filenameFlagHelpStr)
 	cmd.PersistentFlags().StringVarP(&args.kubeConfigPath, "kubeconfig", "c", "", "Path to kube config.")
 	cmd.PersistentFlags().StringVar(&args.context, "context", "", "The name of the kubeconfig context to use.")
@@ -76,36 +76,12 @@ func addManifestApplyFlags(cmd *cobra.Command, args *manifestApplyArgs) {
 	cmd.PersistentFlags().StringVarP(&args.revision, "revision", "r", "", revisionFlagHelpStr)
 }
 
-func manifestApplyCmd(rootArgs *rootArgs, maArgs *manifestApplyArgs, logOpts *log.Options) *cobra.Command {
-	return &cobra.Command{
-		Use:   "apply",
-		Short: "Applies an Istio manifest, installing or reconfiguring Istio on a cluster. Deprecated, use 'istioctl install' instead.",
-		Long:  "The apply subcommand generates an Istio install manifest and applies it to a cluster. Deprecated, use 'istioctl install' instead.",
-		// nolint: lll
-		Example: `  # Apply a default Istio installation
-  istioctl manifest apply
-
-  # Enable grafana dashboard
-  istioctl manifest apply --set values.grafana.enabled=true
-
-  # Generate the demo profile and don't wait for confirmation
-  istioctl manifest apply --set profile=demo --skip-confirmation
-
-  # To override a setting that includes dots, escape them with a backslash (\).  Your shell may require enclosing quotes.
-  istioctl manifest apply --set "values.sidecarInjectorWebhook.injectedAnnotations.container\.apparmor\.security\.beta\.kubernetes\.io/istio-proxy=runtime/default"
-`,
-		Args: cobra.ExactArgs(0),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runApplyCmd(cmd, rootArgs, maArgs, logOpts)
-		}}
-}
-
-// InstallCmd in an alias for manifest apply.
+// InstallCmd generates an Istio install manifest and applies it to a cluster
 func InstallCmd(logOpts *log.Options) *cobra.Command {
 	rootArgs := &rootArgs{}
-	macArgs := &manifestApplyArgs{}
+	iArgs := &installArgs{}
 
-	mac := &cobra.Command{
+	ic := &cobra.Command{
 		Use:   "install",
 		Short: "Applies an Istio manifest, installing or reconfiguring Istio on a cluster.",
 		Long:  "The install generates an Istio install manifest and applies it to a cluster.",
@@ -124,18 +100,18 @@ func InstallCmd(logOpts *log.Options) *cobra.Command {
 `,
 		Args: cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runApplyCmd(cmd, rootArgs, macArgs, logOpts)
+			return runApplyCmd(cmd, rootArgs, iArgs, logOpts)
 		}}
 
-	addFlags(mac, rootArgs)
-	addManifestApplyFlags(mac, macArgs)
-	return mac
+	addFlags(ic, rootArgs)
+	addInstallFlags(ic, iArgs)
+	return ic
 }
 
-func runApplyCmd(cmd *cobra.Command, rootArgs *rootArgs, maArgs *manifestApplyArgs, logOpts *log.Options) error {
+func runApplyCmd(cmd *cobra.Command, rootArgs *rootArgs, iArgs *installArgs, logOpts *log.Options) error {
 	l := clog.NewConsoleLogger(cmd.OutOrStdout(), cmd.ErrOrStderr(), installerScope)
-	// Warn users if they use `manifest apply` without any config args.
-	if len(maArgs.inFilenames) == 0 && len(maArgs.set) == 0 && !rootArgs.dryRun && !maArgs.skipConfirmation {
+	// Warn users if they use `istioctl install` without any config args.
+	if len(iArgs.inFilenames) == 0 && len(iArgs.set) == 0 && !rootArgs.dryRun && !iArgs.skipConfirmation {
 		if !confirm("This will install the default Istio profile into the cluster. Proceed? (y/N)", cmd.OutOrStdout()) {
 			cmd.Print("Cancelled.\n")
 			os.Exit(1)
@@ -144,19 +120,19 @@ func runApplyCmd(cmd *cobra.Command, rootArgs *rootArgs, maArgs *manifestApplyAr
 	if err := configLogs(logOpts); err != nil {
 		return fmt.Errorf("could not configure logs: %s", err)
 	}
-	if err := ApplyManifests(applyFlagAliases(maArgs.set, maArgs.manifestsPath, maArgs.revision), maArgs.inFilenames, maArgs.force, rootArgs.dryRun,
-		maArgs.kubeConfigPath, maArgs.context, maArgs.readinessTimeout, l); err != nil {
-		return fmt.Errorf("failed to apply manifests: %v", err)
+	if err := InstallManifests(applyFlagAliases(iArgs.set, iArgs.manifestsPath, iArgs.revision), iArgs.inFilenames, iArgs.force, rootArgs.dryRun,
+		iArgs.kubeConfigPath, iArgs.context, iArgs.readinessTimeout, l); err != nil {
+		return fmt.Errorf("failed to install manifests: %v", err)
 	}
 
 	return nil
 }
 
-// ApplyManifests generates manifests from the given input files and --set flag overlays and applies them to the
+// InstallManifests generates manifests from the given input files and --set flag overlays and applies them to the
 // cluster. See GenManifests for more description of the manifest generation process.
 //  force   validation warnings are written to logger but command is not aborted
 //  dryRun  all operations are done but nothing is written
-func ApplyManifests(setOverlay []string, inFilenames []string, force bool, dryRun bool,
+func InstallManifests(setOverlay []string, inFilenames []string, force bool, dryRun bool,
 	kubeConfigPath string, context string, waitTimeout time.Duration, l clog.Logger) error {
 
 	restConfig, clientset, client, err := K8sConfig(kubeConfigPath, context)

--- a/operator/cmd/mesh/manifest-apply.go
+++ b/operator/cmd/mesh/manifest-apply.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	// installedSpecCRPrefix is the prefix of any IstioOperator CR stored in the cluster that is a copy of the CR used
-	// in the last manifest apply operation.
+	// in the last install operation.
 	installedSpecCRPrefix = "installed-state"
 )
 

--- a/operator/cmd/mesh/manifest.go
+++ b/operator/cmd/mesh/manifest.go
@@ -30,26 +30,23 @@ func ManifestCmd(logOpts *log.Options) *cobra.Command {
 
 	mgcArgs := &manifestGenerateArgs{}
 	mdcArgs := &manifestDiffArgs{}
-	macArgs := &manifestApplyArgs{}
 
 	args := &rootArgs{}
 
 	mgc := manifestGenerateCmd(args, mgcArgs, logOpts)
 	mdc := manifestDiffCmd(args, mdcArgs)
-	mac := manifestApplyCmd(args, macArgs, logOpts)
+	ic := InstallCmd(logOpts)
 
 	addFlags(mc, args)
 	addFlags(mgc, args)
 	addFlags(mdc, args)
-	addFlags(mac, args)
 
 	addManifestGenerateFlags(mgc, mgcArgs)
 	addManifestDiffFlags(mdc, mdcArgs)
-	addManifestApplyFlags(mac, macArgs)
 
 	mc.AddCommand(mgc)
 	mc.AddCommand(mdc)
-	mc.AddCommand(mac)
+	mc.AddCommand(ic)
 
 	return mc
 }

--- a/operator/cmd/mesh/profile.go
+++ b/operator/cmd/mesh/profile.go
@@ -25,7 +25,7 @@ func ProfileCmd() *cobra.Command {
 		Short: "Commands related to Istio configuration profiles",
 		Long:  "The profile subcommand lists, dumps or diffs Istio configuration profiles.",
 		Example: "istioctl profile list\n" +
-			"istioctl manifest apply --set profile=demo  # Use a profile from the list",
+			"istioctl install --set profile=demo  # Use a profile from the list",
 	}
 
 	pdArgs := &profileDumpArgs{}

--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -205,7 +205,7 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 	waitForConfirmation(args.skipConfirmation, l)
 
 	// Apply the Istio Control Plane specs reading from inFilenames to the cluster
-	err = ApplyManifests(applyFlagAliases(args.set, args.manifestsPath, ""), args.inFilenames, args.force, rootArgs.dryRun,
+	err = InstallManifests(applyFlagAliases(args.set, args.manifestsPath, ""), args.inFilenames, args.force, rootArgs.dryRun,
 		args.kubeConfigPath, args.context, args.readinessTimeout, l)
 	if err != nil {
 		return fmt.Errorf("failed to apply the Istio Control Plane specs. Error: %v", err)

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -523,15 +523,15 @@ func applyManifest(c *operatorComponent, installSettings []string, istioCtl isti
 	}
 	c.saveInstallManifest(clusterName, out)
 
-	// Actually run the manifest apply command
+	// Actually run the install command
 	cmd := []string{
-		"manifest", "apply",
+		"install",
 		"--skip-confirmation",
 	}
 	cmd = append(cmd, installSettings...)
 	scopes.Framework.Infof("Running istio control plane on cluster %s %v", clusterName, cmd)
 	if _, _, err := istioCtl.Invoke(cmd); err != nil {
-		return fmt.Errorf("manifest apply failed: %v", err)
+		return fmt.Errorf("install failed: %v", err)
 	}
 	return nil
 }

--- a/releasenotes/notes/25737.yaml
+++ b/releasenotes/notes/25737.yaml
@@ -4,5 +4,4 @@ area: istioctl
 issue:
   - 25737
 releaseNotes: |
-  *Removed* 
-  - 'istioctl manifest apply' the simpler install command replaces manifest apply.
+  *Removed* `istioctl manifest apply`. The simpler `install` command replaces manifest apply.

--- a/releasenotes/notes/25737.yaml
+++ b/releasenotes/notes/25737.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue:
+  - 25737
+releaseNotes: |
+  *Removed* 
+  - 'istioctl manifest apply' the simpler install command replaces manifest apply.

--- a/samples/multicluster/setup-mesh.sh
+++ b/samples/multicluster/setup-mesh.sh
@@ -176,7 +176,7 @@ apply_istio_control_plane() {
 
   # TODO remove the hub/tag or make it optional and parameterize it.
   ic x multicluster generate -f "${MESH_TOPOLOGY_FILENAME}" --from "${BASE_FILENAME}" > "${WORKDIR}/istio-${CONTEXT}.yaml"
-  ic manifest apply -f "${WORKDIR}/istio-${CONTEXT}.yaml"
+  ic install -f "${WORKDIR}/istio-${CONTEXT}.yaml"
 }
 
 # TODO(ayj) - remove when the istioctl supports the --wait-for-gateway option


### PR DESCRIPTION
> In Istio 1.6, the simpler install command replaces manifest apply, which is deprecated and will be removed in 1.7

[Install](https://istio.io/latest/docs/setup/install/istioctl/#install-istio-using-the-default-profile) replaces [apply](https://github.com/istio/istio.io/pull/7502) command.

More Info:
https://github.com/istio/istio/pull/22563
https://github.com/istio/istio.io/pull/7396

