### PR TITLE
DestinationRule Analyzer against no caCertificates

### DIFF
--- a/galley/pkg/config/analysis/analyzers/all.go
+++ b/galley/pkg/config/analysis/analyzers/all.go
@@ -20,6 +20,7 @@ import (
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/authz"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/deployment"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/deprecation"
+	"istio.io/istio/galley/pkg/config/analysis/analyzers/destinationrule"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/gateway"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/injection"
 	"istio.io/istio/galley/pkg/config/analysis/analyzers/multicluster"
@@ -50,6 +51,7 @@ func All() []analysis.Analyzer {
 		&virtualservice.DestinationRuleAnalyzer{},
 		&virtualservice.GatewayAnalyzer{},
 		&virtualservice.RegexAnalyzer{},
+		&destinationrule.CaCertificateAnalyzer{},
 	}
 
 	analyzers = append(analyzers, schema.AllValidationAnalyzers()...)

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"istio.io/istio/galley/pkg/config/analysis/analyzers/destinationrule"
+
 	. "github.com/onsi/gomega"
 
 	"istio.io/pkg/log"
@@ -312,6 +314,76 @@ var testGrid = []testCase{
 			{msg.ReferencedResourceNotFound, "AuthorizationPolicy httpbin-bogus-not-ns.httpbin"},
 			{msg.ReferencedResourceNotFound, "AuthorizationPolicy httpbin-bogus-not-ns.httpbin"},
 		},
+	},
+	{
+		name: "destinationrule with no cacert, simple at destinationlevel",
+		inputFiles: []string{
+			"testdata/destinationrule-simple-destination.yaml",
+		},
+		analyzer: &destinationrule.CaCertificateAnalyzer{},
+		expected: []message{
+			{msg.NoServerCertificateVerificationDestinationLevel, "DestinationRule db-tls"},
+		},
+	},
+	{
+		name: "destinationrule with no cacert, mutual at destinationlevel",
+		inputFiles: []string{
+			"testdata/destinationrule-mutual-destination.yaml",
+		},
+		analyzer: &destinationrule.CaCertificateAnalyzer{},
+		expected: []message{
+			{msg.NoServerCertificateVerificationDestinationLevel, "DestinationRule db-mtls"},
+		},
+	},
+	{
+		name: "destinationrule with no cacert, simple at portlevel",
+		inputFiles: []string{
+			"testdata/destinationrule-simple-port.yaml",
+		},
+		analyzer: &destinationrule.CaCertificateAnalyzer{},
+		expected: []message{
+			{msg.NoServerCertificateVerificationPortLevel, "DestinationRule db-tls"},
+		},
+	},
+	{
+		name: "destinationrule with no cacert, mutual at portlevel",
+		inputFiles: []string{
+			"testdata/destinationrule-mutual-port.yaml",
+		},
+		analyzer: &destinationrule.CaCertificateAnalyzer{},
+		expected: []message{
+			{msg.NoServerCertificateVerificationPortLevel, "DestinationRule db-mtls"},
+		},
+	},
+	{
+		name: "destinationrule with no cacert, mutual at destinationlevel and simple at port level",
+		inputFiles: []string{
+			"testdata/destinationrule-compound-simple-mutual.yaml",
+		},
+		analyzer: &destinationrule.CaCertificateAnalyzer{},
+		expected: []message{
+			{msg.NoServerCertificateVerificationDestinationLevel, "DestinationRule db-mtls"},
+			{msg.NoServerCertificateVerificationPortLevel, "DestinationRule db-mtls"},
+		},
+	},
+	{
+		name: "destinationrule with no cacert, simple at destinationlevel and mutual at port level",
+		inputFiles: []string{
+			"testdata/destinationrule-compound-mutual-simple.yaml",
+		},
+		analyzer: &destinationrule.CaCertificateAnalyzer{},
+		expected: []message{
+			{msg.NoServerCertificateVerificationPortLevel, "DestinationRule db-mtls"},
+			{msg.NoServerCertificateVerificationDestinationLevel, "DestinationRule db-mtls"},
+		},
+	},
+	{
+		name: "destinationrule with both cacerts",
+		inputFiles: []string{
+			"testdata/destinationrule-with-ca.yaml",
+		},
+		analyzer: &destinationrule.CaCertificateAnalyzer{},
+		expected: []message{},
 	},
 }
 

--- a/galley/pkg/config/analysis/analyzers/destinationrule/ca-certificates.go
+++ b/galley/pkg/config/analysis/analyzers/destinationrule/ca-certificates.go
@@ -1,0 +1,72 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package destinationrule
+
+import (
+	"istio.io/api/networking/v1alpha3"
+
+	"istio.io/istio/galley/pkg/config/analysis"
+	"istio.io/istio/galley/pkg/config/analysis/msg"
+	"istio.io/istio/pkg/config/resource"
+	"istio.io/istio/pkg/config/schema/collection"
+	"istio.io/istio/pkg/config/schema/collections"
+)
+
+// CaCertificateAnalyzer checks if CaCertificate is set in case mode is SIMPLE/MUTUAL
+type CaCertificateAnalyzer struct{}
+
+var _ analysis.Analyzer = &CaCertificateAnalyzer{}
+
+func (c *CaCertificateAnalyzer) Metadata() analysis.Metadata {
+	return analysis.Metadata{
+		Name:        "destinationrule.CaCertificateAnalyzer",
+		Description: "Checks if caCertificates is set when TLS mode is SIMPLE/MUTUAL",
+		Inputs: collection.Names{
+			collections.IstioNetworkingV1Alpha3Destinationrules.Name(),
+		},
+	}
+}
+
+func (c *CaCertificateAnalyzer) Analyze(ctx analysis.Context) {
+	ctx.ForEach(collections.IstioNetworkingV1Alpha3Destinationrules.Name(), func(r *resource.Instance) bool {
+		c.analyzeDestinationRule(r, ctx)
+		return true
+	})
+}
+
+func (c *CaCertificateAnalyzer) analyzeDestinationRule(r *resource.Instance, ctx analysis.Context) {
+	dr := r.Message.(*v1alpha3.DestinationRule)
+	drNs := r.Metadata.FullName.Namespace
+	drName := r.Metadata.FullName.String()
+	mode := dr.GetTrafficPolicy().GetTls().GetMode()
+
+	if mode == v1alpha3.ClientTLSSettings_SIMPLE || mode == v1alpha3.ClientTLSSettings_MUTUAL {
+		if dr.GetTrafficPolicy().GetTls().GetCaCertificates() == "" {
+			ctx.Report(collections.IstioNetworkingV1Alpha3Destinationrules.Name(), msg.NewNoServerCertificateVerificationDestinationLevel(r, drName,
+				drNs.String(), mode.String(), dr.GetHost()))
+		}
+	}
+	portSettings := dr.TrafficPolicy.GetPortLevelSettings()
+
+	for _, p := range portSettings {
+		mode = p.GetTls().GetMode()
+		if mode == v1alpha3.ClientTLSSettings_SIMPLE || mode == v1alpha3.ClientTLSSettings_MUTUAL {
+			if p.GetTls().GetCaCertificates() == "" {
+				ctx.Report(collections.IstioNetworkingV1Alpha3Destinationrules.Name(), msg.NewNoServerCertificateVerificationPortLevel(r, drName,
+					drNs.String(), mode.String(), dr.GetHost(), p.GetPort().String()))
+			}
+		}
+	}
+}

--- a/galley/pkg/config/analysis/analyzers/testdata/destinationrule-compound-mutual-simple.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/destinationrule-compound-mutual-simple.yaml
@@ -1,0 +1,21 @@
+# No caCertificates when mode is simple at destination level and MUTUAL at port level
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: db-mtls
+spec:
+  host: mydbserver.prod.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: SIMPLE
+      clientCertificate: /etc/certs/myclientcert.pem
+      privateKey: /etc/certs/client_private_key.pem
+    portLevelSettings:
+      - port:
+          number: 443
+        tls:
+          mode: MUTUAL
+          clientCertificate: /etc/certs/myclientcert.pem
+          privateKey: /etc/certs/client_private_key.pem
+          sni: my-nginx.mesh-external.svc.cluster.local
+

--- a/galley/pkg/config/analysis/analyzers/testdata/destinationrule-compound-simple-mutual.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/destinationrule-compound-simple-mutual.yaml
@@ -1,0 +1,21 @@
+# No caCertificates when mode is simple at destination level
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: db-mtls
+spec:
+  host: mydbserver.prod.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: MUTUAL
+      clientCertificate: /etc/certs/myclientcert.pem
+      privateKey: /etc/certs/client_private_key.pem
+    portLevelSettings:
+    - port:
+        number: 443
+      tls:
+        mode: SIMPLE
+        clientCertificate: /etc/certs/myclientcert.pem
+        privateKey: /etc/certs/client_private_key.pem
+        sni: my-nginx.mesh-external.svc.cluster.local
+

--- a/galley/pkg/config/analysis/analyzers/testdata/destinationrule-mutual-destination.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/destinationrule-mutual-destination.yaml
@@ -1,0 +1,12 @@
+# No caCertificates when mode is mutual at destination level
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: db-mtls
+spec:
+  host: mydbserver.prod.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: MUTUAL
+      clientCertificate: /etc/certs/myclientcert.pem
+      privateKey: /etc/certs/client_private_key.pem

--- a/galley/pkg/config/analysis/analyzers/testdata/destinationrule-mutual-port.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/destinationrule-mutual-port.yaml
@@ -1,0 +1,16 @@
+# No caCertificates when mode is mutual at port level
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: db-mtls
+spec:
+  host: mydbserver.prod.svc.cluster.local
+  trafficPolicy:
+    portLevelSettings:
+      - port:
+          number: 443
+        tls:
+          mode: MUTUAL
+          clientCertificate: /etc/certs/myclientcert.pem
+          privateKey: /etc/certs/client_private_key.pem
+          sni: my-nginx.mesh-external.svc.cluster.local

--- a/galley/pkg/config/analysis/analyzers/testdata/destinationrule-simple-destination.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/destinationrule-simple-destination.yaml
@@ -1,0 +1,12 @@
+# No caCertificates when mode is simple at destination level
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: db-tls
+spec:
+  host: mydbserver.prod.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: SIMPLE
+      clientCertificate: /etc/certs/myclientcert.pem
+      privateKey: /etc/certs/client_private_key.pem

--- a/galley/pkg/config/analysis/analyzers/testdata/destinationrule-simple-port.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/destinationrule-simple-port.yaml
@@ -1,0 +1,16 @@
+# No caCertificates when mode is simple at port level
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: db-tls
+spec:
+  host: mydbserver.prod.svc.cluster.local
+  trafficPolicy:
+    portLevelSettings:
+      - port:
+          number: 443
+        tls:
+          mode: SIMPLE
+          clientCertificate: /etc/certs/myclientcert.pem
+          privateKey: /etc/certs/client_private_key.pem
+          sni: my-nginx.mesh-external.svc.cluster.local

--- a/galley/pkg/config/analysis/analyzers/testdata/destinationrule-with-ca.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/destinationrule-with-ca.yaml
@@ -1,0 +1,22 @@
+#  caCertificates when mode is mutual at destination level and simple at port level
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: db-mtls
+spec:
+  host: mydbserver.prod.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: MUTUAL
+      clientCertificate: /etc/certs/myclientcert.pem
+      privateKey: /etc/certs/client_private_key.pem
+      caCertificates: /etc/certs/root.pem
+    portLevelSettings:
+      - port:
+          number: 443
+        tls:
+          mode: SIMPLE
+          clientCertificate: /etc/certs/myclientcert.pem
+          privateKey: /etc/certs/client_private_key.pem
+          caCertificates: /etc/certs/root.pem
+          sni: my-nginx.mesh-external.svc.cluster.local

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -120,6 +120,14 @@ var (
 	// NoMatchingWorkloadsFound defines a diag.MessageType for message "NoMatchingWorkloadsFound".
 	// Description: There aren't workloads matching the resource labels
 	NoMatchingWorkloadsFound = diag.NewMessageType(diag.Warning, "IST0127", "No matching workloads for this resource with the following labels: %s")
+
+	// NoServerCertificateVerificationDestinationLevel defines a diag.MessageType for message "NoServerCertificateVerificationDestinationLevel".
+	// Description: No caCertificates are set in DestinationRule, this results in no verification of presented server certificate.
+	NoServerCertificateVerificationDestinationLevel = diag.NewMessageType(diag.Error, "IST0128", "DestinationRule %s in namespace %s has TLS mode set to %s but no caCertificates are set to validate server identity for host: %s")
+
+	// NoServerCertificateVerificationPortLevel defines a diag.MessageType for message "NoServerCertificateVerificationPortLevel".
+	// Description: No caCertificates are set in DestinationRule, this results in no verification of presented server certificate for traffic to a given port.
+	NoServerCertificateVerificationPortLevel = diag.NewMessageType(diag.Error, "IST0129", "DestinationRule %s in namespace %s has TLS mode set to %s but no caCertificates are set to validate server identity for host: %s at port %s")
 )
 
 // All returns a list of all known message types.
@@ -153,6 +161,8 @@ func All() []*diag.MessageType {
 		InvalidAnnotation,
 		UnknownMeshNetworksServiceRegistry,
 		NoMatchingWorkloadsFound,
+		NoServerCertificateVerificationDestinationLevel,
+		NoServerCertificateVerificationPortLevel,
 	}
 }
 
@@ -429,5 +439,30 @@ func NewNoMatchingWorkloadsFound(r *resource.Instance, labels string) diag.Messa
 		NoMatchingWorkloadsFound,
 		r,
 		labels,
+	)
+}
+
+// NewNoServerCertificateVerificationDestinationLevel returns a new diag.Message based on NoServerCertificateVerificationDestinationLevel.
+func NewNoServerCertificateVerificationDestinationLevel(r *resource.Instance, destinationrule string, namespace string, mode string, host string) diag.Message {
+	return diag.NewMessage(
+		NoServerCertificateVerificationDestinationLevel,
+		r,
+		destinationrule,
+		namespace,
+		mode,
+		host,
+	)
+}
+
+// NewNoServerCertificateVerificationPortLevel returns a new diag.Message based on NoServerCertificateVerificationPortLevel.
+func NewNoServerCertificateVerificationPortLevel(r *resource.Instance, destinationrule string, namespace string, mode string, host string, port string) diag.Message {
+	return diag.NewMessage(
+		NoServerCertificateVerificationPortLevel,
+		r,
+		destinationrule,
+		namespace,
+		mode,
+		host,
+		port,
 	)
 }

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -297,3 +297,35 @@ messages:
     args:
       - name: labels
         type: string
+
+  - name: "NoServerCertificateVerificationDestinationLevel"
+    code: IST0128
+    level: Error
+    description: "No caCertificates are set in DestinationRule, this results in no verification of presented server certificate."
+    template: "DestinationRule %s in namespace %s has TLS mode set to %s but no caCertificates are set to validate server identity for host: %s"
+    args:
+      - name: destinationrule
+        type: string
+      - name: namespace
+        type: string
+      - name: mode
+        type: string
+      - name: host
+        type: string
+
+  - name: "NoServerCertificateVerificationPortLevel"
+    code: IST0129
+    level: Error
+    description: "No caCertificates are set in DestinationRule, this results in no verification of presented server certificate for traffic to a given port."
+    template: "DestinationRule %s in namespace %s has TLS mode set to %s but no caCertificates are set to validate server identity for host: %s at port %s"
+    args:
+      - name: destinationrule
+        type: string
+      - name: namespace
+        type: string
+      - name: mode
+        type: string
+      - name: host
+        type: string
+      - name: port
+        type: string

--- a/releasenotes/notes/dr-analyzer.yaml
+++ b/releasenotes/notes/dr-analyzer.yaml
@@ -1,0 +1,5 @@
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+releaseNotes: |
+  *Added* Analyzer warning for DestinationRule not using CaCertificates to validate server identity.

--- a/releasenotes/notes/dr-analyzer.yaml
+++ b/releasenotes/notes/dr-analyzer.yaml
@@ -1,7 +1,7 @@
 apiVersion: release-notes/v2
 kind: feature
 area: networking
-releaseNotes: |
+securityNotes: |
   *Added* Analyzer warning for DestinationRule not using CaCertificates to validate server identity.
 upgradeNotes: |
-  Upgrade istioctl to help find this warning when using `istioctl analyze`.
+  Upgrade istioctl to help find DestinationRule configurations with no CaCertificates to validate server identity when using `istioctl analyze`.

--- a/releasenotes/notes/dr-analyzer.yaml
+++ b/releasenotes/notes/dr-analyzer.yaml
@@ -3,3 +3,5 @@ kind: feature
 area: networking
 releaseNotes: |
   *Added* Analyzer warning for DestinationRule not using CaCertificates to validate server identity.
+upgradeNotes: |
+  Upgrade istioctl to help find this vulnerability.

--- a/releasenotes/notes/dr-analyzer.yaml
+++ b/releasenotes/notes/dr-analyzer.yaml
@@ -4,4 +4,4 @@ area: networking
 releaseNotes: |
   *Added* Analyzer warning for DestinationRule not using CaCertificates to validate server identity.
 upgradeNotes: |
-  Upgrade istioctl to help find this vulnerability.
+  Upgrade istioctl to help find this warning when using `istioctl analyze`.


### PR DESCRIPTION
#Ref: https://github.com/istio/istio/issues/25652

Cherrypick to 1.6 and 1.5(if analyzer exists)

edit: Analyzer exists in 1.5, so we can cherrypick to 1.5 too
