### PR TITLE
Add release-notes-none autolabel

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,3 +13,10 @@ put an X in all the areas that this PR affects.
 [ ] Test and Release
 [ ] User Experience
 [ ] Developer Infrastructure
+
+
+Pull Request Attributes
+
+Please check any characteristics that apply to this pull request. 
+
+[ ] Does not have any changes that may affect Istio users.


### PR DESCRIPTION
Please provide a description for what this PR is for.

This pull request adds a checkbox to the pull request template that can be checked if the pull request doesn't have any user facing changes.  If this checkbox is checked, the release-notes-none label will be applied and the PR will not ask for release notes. This will allow anyone to skip adding a PR to release notes even if they don't have permission to add labels. 

Related to: https://github.com/istio/bots/pull/239/files



This will look like: 

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

Pull Request Attributes

Please check any characteristics that apply to this pull request.

[x] Does not have any changes that may affect Istio users.