### PR TITLE
multicluster pilot tests

### DIFF
--- a/pkg/test/framework/analyzer.go
+++ b/pkg/test/framework/analyzer.go
@@ -47,6 +47,7 @@ type suiteAnalyzer struct {
 	osExit func(int)
 
 	commonAnalyzer
+	skipLabels         label.Set
 	envFactoryCalls    int
 	requiredEnvVersion string
 }
@@ -70,6 +71,11 @@ func (s *suiteAnalyzer) EnvironmentFactory(fn resource.EnvironmentFactory) Suite
 
 func (s *suiteAnalyzer) Label(labels ...label.Instance) Suite {
 	s.labels = s.labels.Add(labels...)
+	return s
+}
+
+func (s *suiteAnalyzer) SkipLabel(labels ...label.Instance) Suite {
+	s.skipLabels = s.skipLabels.Add(labels...)
 	return s
 }
 
@@ -125,6 +131,7 @@ func (s *suiteAnalyzer) track() *suiteAnalysis {
 		SuiteID:          s.testID,
 		SkipReason:       s.skip,
 		Labels:           s.labels.All(),
+		SkipLabels:       s.skipLabels.All(),
 		MultiCluster:     s.maxClusters != 1,
 		MultiClusterOnly: s.minCusters > 1,
 		Tests:            map[string]*testAnalysis{},

--- a/pkg/test/framework/analyzer_runtime.go
+++ b/pkg/test/framework/analyzer_runtime.go
@@ -92,6 +92,7 @@ type suiteAnalysis struct {
 	SuiteID          string                   `yaml:"suiteID"`
 	SkipReason       string                   `yaml:"skipReason,omitempty"`
 	Labels           []label.Instance         `yaml:"labels,omitempty"`
+	SkipLabels       []label.Instance         `yaml:"skipLabels,omitempty"`
 	MultiCluster     bool                     `yaml:"multicluster,omitempty"`
 	MultiClusterOnly bool                     `yaml:"multiclusterOnly,omitempty"`
 	Tests            map[string]*testAnalysis `yaml:"tests"`

--- a/pkg/test/framework/features/features.yaml
+++ b/pkg/test/framework/features/features.yaml
@@ -36,6 +36,7 @@ features:
   # features relating to controlling the traffic of the service mesh.
   traffic:
     reachability:
+      vm:
     shifting:
     routing:
     short-circuiting:

--- a/pkg/test/framework/features/features.yaml
+++ b/pkg/test/framework/features/features.yaml
@@ -41,6 +41,7 @@ features:
     routing:
     short-circuiting:
     mirroring:
+      external:
     ingress:
       loadbalancing:
   usability:

--- a/pkg/test/framework/features/features.yaml
+++ b/pkg/test/framework/features/features.yaml
@@ -36,12 +36,10 @@ features:
   # features relating to controlling the traffic of the service mesh.
   traffic:
     reachability:
-      vm:
     shifting:
     routing:
     short-circuiting:
     mirroring:
-      external:
     ingress:
       loadbalancing:
   usability:

--- a/pkg/test/framework/suite.go
+++ b/pkg/test/framework/suite.go
@@ -302,7 +302,7 @@ func (s *suiteImpl) run() (errLevel int) {
 
 	// Before starting, check whether the current set of labels & label selectors will ever allow us to run tests.
 	// if not, simply exit now.
-	if ctx.Settings().Selector.Selects(s.skipLabels) {
+	if len(s.skipLabels) > 0 && ctx.Settings().Selector.Selects(s.skipLabels) {
 		s.Skip(fmt.Sprintf("Skip Label match: skipLabels=%v, selector=%v",
 			s.skipLabels,
 			ctx.Settings().Selector))

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -180,7 +180,7 @@ func TestDescribe(t *testing.T) {
 			// run in parallel.
 			retry.UntilSuccessOrFail(ctx, func() error {
 				args := []string{"--namespace=dummy",
-					"x", "describe", "svc", fmt.Sprintf("%s.%s", apps.podA.Config().Service, apps.namespace.Name())}
+					"x", "describe", "svc", fmt.Sprintf("%s.%s", apps.podA[0].Config().Service, apps.namespace.Name())}
 				output, _, err := istioCtl.Invoke(args)
 				if err != nil {
 					return err
@@ -192,7 +192,7 @@ func TestDescribe(t *testing.T) {
 			}, retry.Timeout(time.Second*5))
 
 			retry.UntilSuccessOrFail(ctx, func() error {
-				podID, err := getPodID(apps.podA)
+				podID, err := getPodID(apps.podA[0])
 				if err != nil {
 					return fmt.Errorf("could not get Pod ID: %v", err)
 				}
@@ -270,7 +270,7 @@ func TestProxyConfig(t *testing.T) {
 		Run(func(ctx framework.TestContext) {
 			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
 
-			podID, err := getPodID(apps.podA)
+			podID, err := getPodID(apps.podA[0])
 			if err != nil {
 				ctx.Fatalf("Could not get Pod ID: %v", err)
 			}
@@ -334,7 +334,7 @@ func TestProxyStatus(t *testing.T) {
 		Run(func(ctx framework.TestContext) {
 			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
 
-			podID, err := getPodID(apps.podA)
+			podID, err := getPodID(apps.podA[0])
 			if err != nil {
 				ctx.Fatalf("Could not get Pod ID: %v", err)
 			}
@@ -382,7 +382,7 @@ func TestAuthZCheck(t *testing.T) {
 
 			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{Cluster: ctx.Environment().Clusters()[0]})
 
-			podID, err := getPodID(apps.podA)
+			podID, err := getPodID(apps.podA[0])
 			if err != nil {
 				ctx.Fatalf("Could not get Pod ID: %v", err)
 			}

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -39,70 +39,70 @@ import (
 )
 
 var (
-	describeSvcAOutput = regexp.MustCompile(`Service: a\..*
+	describeSvcAOutput = regexp.MustCompile(`Service: a-0\..*
    Port: http 80/HTTP targets pod port 18080
    Port: grpc 7070/GRPC targets pod port 17070
    Port: tcp 9090/TCP targets pod port 19090
    Port: auto-tcp 9091/UnsupportedProtocol targets pod port 19091
    Port: auto-http 81/UnsupportedProtocol targets pod port 18081
    Port: auto-grpc 7071/UnsupportedProtocol targets pod port 17071
-80 DestinationRule: a\..* for "a"
+80 DestinationRule: a-0\..* for "a-0"
    Matching subsets: v1
    No Traffic Policy
-80 VirtualService: a\..*
+80 VirtualService: a-0\..*
    when headers are end-user=jason
 80 RBAC policies: ns\[.*\]-policy\[integ-test\]-rule\[0\]
-7070 DestinationRule: a\..* for "a"
+7070 DestinationRule: a-0\..* for "a-0"
    Matching subsets: v1
    No Traffic Policy
-7070 VirtualService: a\..*
+7070 VirtualService: a-0\..*
    when headers are end-user=jason
 7070 RBAC policies: ns\[.*\]-policy\[integ-test\]-rule\[0\]
-9090 DestinationRule: a\..* for "a"
+9090 DestinationRule: a-0\..* for "a-0"
    Matching subsets: v1
    No Traffic Policy
 9090 RBAC policies: ns\[.*\]-policy\[integ-test\]-rule\[0\]
-9091 DestinationRule: a\..* for "a"
+9091 DestinationRule: a-0\..* for "a-0"
    Matching subsets: v1
    No Traffic Policy
-81 DestinationRule: a\..* for "a"
+81 DestinationRule: a-0\..* for "a-0"
    Matching subsets: v1
    No Traffic Policy
-7071 DestinationRule: a\..* for "a"
+7071 DestinationRule: a-0\..* for "a-0"
    Matching subsets: v1
    No Traffic Policy
 `)
 
-	describePodAOutput = regexp.MustCompile(`Service: a\..*
+	describePodAOutput = regexp.MustCompile(`Service: a-0\..*
    Port: http 80/HTTP targets pod port 18080
    Port: grpc 7070/GRPC targets pod port 17070
    Port: tcp 9090/TCP targets pod port 19090
    Port: auto-tcp 9091/UnsupportedProtocol targets pod port 19091
    Port: auto-http 81/UnsupportedProtocol targets pod port 18081
    Port: auto-grpc 7071/UnsupportedProtocol targets pod port 17071
-80 DestinationRule: a\..* for "a"
+80 DestinationRule: a-0\..* for "a-0"
    Matching subsets: v1
    No Traffic Policy
-80 VirtualService: a\..*
+80 VirtualService: a-0\..*
    when headers are end-user=jason
 80 RBAC policies: ns\[.*\]-policy\[integ-test\]-rule\[0\]
-7070 DestinationRule: a\..* for "a"
+7070 DestinationRule: a-0\..* for "a-0"
    Matching subsets: v1
    No Traffic Policy
-7070 VirtualService: a\..*
+7070 VirtualService: a-0\..*
    when headers are end-user=jason
 7070 RBAC policies: ns\[.*\]-policy\[integ-test\]-rule\[0\]
-9090 DestinationRule: a\..* for "a"
+9090 DestinationRule: a-0\..* for "a-0"
    Matching subsets: v1
    No Traffic Policy
 9090 RBAC policies: ns\[.*\]-policy\[integ-test\]-rule\[0\]
-9091 DestinationRule: a\..* for "a"
+9091 DestinationRule: a-0\..* for "a-0"
    Matching subsets: v1
    No Traffic Policy
-81 DestinationRule: a\..* for "a"
+81 DestinationRule: a-0\..* for "a-0"
    Matching subsets: v1
    No Traffic Policy
-7071 DestinationRule: a\..* for "a"
+7071 DestinationRule: a-0\..* for "a-0"
    Matching subsets: v1
    No Traffic Policy
 `)
@@ -236,7 +236,7 @@ func TestAddToAndRemoveFromMesh(t *testing.T) {
 
 			var a echo.Instance
 			echoboot.NewBuilder(ctx).
-				With(&a, echoConfig(ns, "a")).
+				With(&a, echoConfig(ns, "a-0")).
 				BuildOrFail(ctx)
 
 			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{Cluster: ctx.Environment().Clusters()[0]})
@@ -247,7 +247,7 @@ func TestAddToAndRemoveFromMesh(t *testing.T) {
 
 			// able to remove from mesh when the deployment is auto injected
 			args = []string{fmt.Sprintf("--namespace=%s", ns.Name()),
-				"x", "remove-from-mesh", "service", "a"}
+				"x", "remove-from-mesh", "service", "a-0"}
 			output, _ = istioCtl.InvokeOrFail(t, args)
 			g.Expect(output).To(gomega.MatchRegexp(removeFromMeshPodAOutput))
 
@@ -258,7 +258,7 @@ func TestAddToAndRemoveFromMesh(t *testing.T) {
 			}
 
 			args = []string{fmt.Sprintf("--namespace=%s", ns.Name()),
-				"x", "add-to-mesh", "service", "a"}
+				"x", "add-to-mesh", "service", "a-0"}
 			output, _ = istioCtl.InvokeOrFail(t, args)
 			g.Expect(output).To(gomega.MatchRegexp(addToMeshPodAOutput))
 		})

--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -55,6 +55,8 @@ type EchoDeployments struct {
 	podA echo.Instances
 	// Standard echo app to be used by tests
 	podB echo.Instances
+	// Standard echo app to be used by tests
+	podC echo.Instances
 	// Headless echo app to be used by tests
 	headless echo.Instances
 	// Echo app to be used by tests, with no sidecar injected
@@ -111,6 +113,13 @@ values:
 						Cluster:   c,
 					}).
 					With(nil, echo.Config{
+						Service:   fmt.Sprintf("c-%d", c.Index()),
+						Namespace: apps.namespace,
+						Ports:     echoPorts,
+						Subsets:   []echo.SubsetConfig{{}},
+						Cluster:   c,
+					}).
+					With(nil, echo.Config{
 						Service:   fmt.Sprintf("headless-%d", c.Index()),
 						Headless:  true,
 						Namespace: apps.namespace,
@@ -147,6 +156,7 @@ values:
 			}
 			apps.podA = echos.Match(echo.ServicePrefix("a-"))
 			apps.podB = echos.Match(echo.ServicePrefix("b-"))
+			apps.podC = echos.Match(echo.ServicePrefix("c-"))
 			apps.headless = echos.Match(echo.ServicePrefix("headless-"))
 			apps.naked = echos.Match(echo.ServicePrefix("naked-"))
 			apps.vmA = echos.Match(echo.ServicePrefix("vm-a-"))

--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -15,6 +15,7 @@
 package pilot
 
 import (
+	"istio.io/istio/pkg/test/framework/label"
 	"strconv"
 	"testing"
 
@@ -67,6 +68,7 @@ type EchoDeployments struct {
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
+		SkipLabel(label.Multicluster).
 		Setup(istio.Setup(&i, func(cfg *istio.Config) {
 			cfg.ControlPlaneValues = `
 values:

--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -15,7 +15,6 @@
 package pilot
 
 import (
-	"istio.io/istio/pkg/test/framework/label"
 	"strconv"
 	"testing"
 
@@ -25,6 +24,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
 )
 

--- a/tests/integration/pilot/mirror_test.go
+++ b/tests/integration/pilot/mirror_test.go
@@ -144,7 +144,7 @@ const (
 func TestMirroringExternalService(t *testing.T) {
 	framework.
 		NewTest(t).
-		Features("traffic.mirroring.external").
+		Features("traffic.mirroring").
 		Run(func(ctx framework.TestContext) {
 			cases := []testCaseMirror{
 				{

--- a/tests/integration/pilot/mirror_test.go
+++ b/tests/integration/pilot/mirror_test.go
@@ -85,6 +85,7 @@ var (
 func TestMirroring(t *testing.T) {
 	framework.
 		NewTest(t).
+		Features("traffic.mirroring").
 		Run(func(ctx framework.TestContext) {
 			cases := []testCaseMirror{
 				{
@@ -143,6 +144,7 @@ const (
 func TestMirroringExternalService(t *testing.T) {
 	framework.
 		NewTest(t).
+		Features("traffic.mirroring.external").
 		Run(func(ctx framework.TestContext) {
 			cases := []testCaseMirror{
 				{

--- a/tests/integration/pilot/mirror_test.go
+++ b/tests/integration/pilot/mirror_test.go
@@ -111,14 +111,16 @@ func TestMirroring(t *testing.T) {
 			}
 			for _, src := range ctx.Clusters() {
 				for _, dst := range ctx.Clusters() {
-					runMirrorTest(mirrorTestOptions{
-						ctx:   ctx,
-						cases: cases,
-						instances: [3]echo.Instance{
-							apps.podA.GetOrFail(t, echo.InCluster(src)),
-							apps.podB.GetOrFail(t, echo.InCluster(dst)),
-							apps.podC.GetOrFail(t, echo.InCluster(dst)),
-						},
+					ctx.NewSubTest(fmt.Sprintf("%s->%s", src.Name(), dst.Name())).Run(func(ctx framework.TestContext) {
+						runMirrorTest(mirrorTestOptions{
+							ctx:   ctx,
+							cases: cases,
+							instances: [3]echo.Instance{
+								apps.podA.GetOrFail(t, echo.InCluster(src)),
+								apps.podB.GetOrFail(t, echo.InCluster(dst)),
+								apps.podC.GetOrFail(t, echo.InCluster(dst)),
+							},
+						})
 					})
 				}
 			}

--- a/tests/integration/pilot/routing_test.go
+++ b/tests/integration/pilot/routing_test.go
@@ -210,7 +210,7 @@ func vmTestCases(ctx framework.TestContext, vm echo.Instances) []TrafficTestCase
 	testCases := map[string][]vmTestCase{}
 	for _, src := range ctx.Clusters() {
 		for _, dst := range ctx.Clusters() {
-			srcVm := vm.GetOrFail(ctx, echo.InCluster(src))
+			srcVM := vm.GetOrFail(ctx, echo.InCluster(src))
 			dstA := apps.podA.GetOrFail(ctx, echo.InCluster(dst))
 			testCases[fmt.Sprintf("%s-%s", src.Name(), dst.Name())] = []vmTestCase{
 				{
@@ -220,25 +220,25 @@ func vmTestCases(ctx framework.TestContext, vm echo.Instances) []TrafficTestCase
 				},
 				{
 					name: "dns: VM to k8s cluster IP service fqdn host",
-					from: srcVm,
+					from: srcVM,
 					to:   dstA,
 					host: dstA.Config().FQDN(),
 				},
 				{
 					name: "dns: VM to k8s cluster IP service name.namespace host",
-					from: srcVm,
+					from: srcVM,
 					to:   dstA,
 					host: dstA.Config().Service + "." + apps.namespace.Name(),
 				},
 				{
 					name: "dns: VM to k8s cluster IP service short name host",
-					from: srcVm,
+					from: srcVM,
 					to:   dstA,
 					host: dstA.Config().Service,
 				},
 				{
 					name: "dns: VM to k8s headless service",
-					from: srcVm,
+					from: srcVM,
 					to:   apps.headless.GetOrFail(ctx, echo.InCluster(dst)),
 				},
 			}

--- a/tests/integration/pilot/routing_test.go
+++ b/tests/integration/pilot/routing_test.go
@@ -256,7 +256,7 @@ func vmTestCases(ctx framework.TestContext, vm echo.Instances) []TrafficTestCase
 			c := c
 			cases = append(cases, TrafficTestCase{
 				name:     fmt.Sprintf("%s_%s", name, c.name),
-				features: []features.Feature{"traffic.reachability.vm"},
+				features: []features.Feature{"traffic.reachability"},
 				call: func() (echoclient.ParsedResponses, error) {
 					return c.from.Call(echo.CallOptions{
 						Target:   c.to,

--- a/tests/integration/pilot/routing_test.go
+++ b/tests/integration/pilot/routing_test.go
@@ -276,7 +276,6 @@ func vmTestCases(ctx framework.TestContext, vm echo.Instances) []TrafficTestCase
 func TestTraffic(t *testing.T) {
 	framework.
 		NewTest(t).
-		Features("traffic").
 		RequiresSingleCluster().
 		Run(func(ctx framework.TestContext) {
 			cases := map[string][]TrafficTestCase{}

--- a/tests/integration/pilot/routing_test.go
+++ b/tests/integration/pilot/routing_test.go
@@ -16,7 +16,6 @@ package pilot
 
 import (
 	"fmt"
-	"istio.io/istio/pkg/test/framework/features"
 	"strings"
 	"testing"
 	"time"
@@ -25,6 +24,7 @@ import (
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/features"
 	"istio.io/istio/pkg/test/util/retry"
 )
 

--- a/tests/integration/pilot/routing_test.go
+++ b/tests/integration/pilot/routing_test.go
@@ -41,22 +41,22 @@ func virtualServiceCases() []TrafficTestCase {
 			cases = append(cases,
 				TrafficTestCase{
 					name: "added header",
-					config: `
+					config: fmt.Sprintf(`
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: default
 spec:
   hosts:
-  - b
+  - %s
   http:
   - route:
     - destination:
-        host: b
+        host: %s
     headers:
       request:
         add:
-          istio-custom-header: user-defined-value`,
+          istio-custom-header: user-defined-value`, b.Config().Service, b.Config().Service),
 					call: func() (echoclient.ParsedResponses, error) {
 						return a.Call(echo.CallOptions{Target: b, PortName: "http"})
 					},
@@ -69,14 +69,14 @@ spec:
 				},
 				TrafficTestCase{
 					name: "redirect",
-					config: `
+					config: fmt.Sprintf(`
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: default
 spec:
   hosts:
-    - b
+    - %s
   http:
   - match:
     - uri:
@@ -88,7 +88,7 @@ spec:
         exact: /new/path
     route:
     - destination:
-        host: b`,
+        host: %s`, b.Config().Service, b.Config().Service),
 					call: func() (echoclient.ParsedResponses, error) {
 						return a.Call(echo.CallOptions{Target: b, PortName: "http"})
 					},

--- a/tests/integration/pilot/testdata/a.yaml
+++ b/tests/integration/pilot/testdata/a.yaml
@@ -1,10 +1,10 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: a
+  name: a-0
 spec:
   hosts:
-  - a
+  - a-0
   http:
   # (This 'match' clause started as a work-around, because WaitUntilCallable() times out if
   # all destinations have a subset.  We are now using it for testing.)
@@ -14,19 +14,19 @@ spec:
           exact: jason
     route:
     - destination:
-        host: a
+        host: a-0
   # Fallthrough
   - route:
     - destination:
-        host: a
+        host: a-0
         subset: v1
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
-  name: a
+  name: a-0
 spec:
-  host: a
+  host: a-0
   subsets:
   - name: v1
     labels:

--- a/tests/integration/pilot/testdata/traffic-mirroring-external-template.yaml
+++ b/tests/integration/pilot/testdata/traffic-mirroring-external-template.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: external-service
+spec:
+  hosts:
+    - {{.MirrorHost}}
+  location: MESH_EXTERNAL
+  ports:
+    - name: http
+      number: 80
+      protocol: HTTP
+    - name: grpc
+      number: 7070
+      protocol: GRPC
+  resolution: STATIC
+  endpoints:
+    - address: {{.MirrorAddress}}
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Sidecar
+metadata:
+  name: restrict-to-service-entry
+spec:
+  egress:
+    - hosts:
+        - "./{{.TargetHost}}.{{.Namespace}}.svc.{{.Domain}}"
+        - "*/{{.MirrorHost}}"
+  outboundTrafficPolicy:
+    mode: REGISTRY_ONLY

--- a/tests/integration/pilot/testdata/traffic-mirroring-template.yaml
+++ b/tests/integration/pilot/testdata/traffic-mirroring-template.yaml
@@ -5,11 +5,11 @@ metadata:
   namespace: {{.Namespace}}
 spec:
   hosts:
-    - b
+    - {{.TargetHost}}
   http:
     - route:
         - destination:
-            host: b
+            host: {{.TargetHost}}
       mirror:
         host: {{.MirrorHost}}
 {{- if not .Absent }}

--- a/tests/integration/pilot/vm_test.go
+++ b/tests/integration/pilot/vm_test.go
@@ -53,7 +53,7 @@ func TestVmOSPost(t *testing.T) {
 
 			for i, image := range images {
 				ctx.NewSubTest(image).Run(func(ctx framework.TestContext) {
-					for _, tt := range vmTestCases(instances[i]) {
+					for _, tt := range vmTestCases(ctx, echo.Instances{instances[i]}) {
 						ExecuteTrafficTest(ctx, tt)
 					}
 				})


### PR DESCRIPTION
New PR: https://github.com/istio/istio/pull/25923

Converts all tests in the root of integration/pilot to use multicluster

- Mirroring test cleans up config, allowing us to use package-wide echo instances. 
- Mirroring test runs in multicluster
- Routing/Sniffing tests run in multicluster

Results of hidden MC Pilot job here: https://prow.istio.io/?pull=25774&job=integ-pilot-multicluster-tests_istio

~~Final passing job: https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/25774/integ-pilot-multicluster-tests_istio/44~~
A lot of changes to these tests in other PRs have happened since that job was run. 

This PR has https://github.com/istio/istio/pull/25774 pulled in - avoid running setup for Pilot suite in the multicluster job. 