### PR TITLE
Create dynamic release tar URL for verify and upgrade msg

### DIFF
--- a/operator/cmd/mesh/root.go
+++ b/operator/cmd/mesh/root.go
@@ -25,14 +25,16 @@ import (
 )
 
 const (
+	baseVersion    = binversion.OperatorCodeBaseVersion
+	releaseURL     = `https://github.com/istio/istio/releases/download/` + baseVersion + `/istio-` + baseVersion + `-linux-amd64.tar.gz`
 	setFlagHelpStr = `Override an IstioOperator value, e.g. to choose a profile
 (--set profile=demo), enable or disable components (--set components.policy.enabled=true), or override Istio
 settings (--set values.grafana.enabled=true). See documentation for more info:
 https://istio.io/docs/reference/config/istio.operator.v1alpha1/#IstioOperatorSpec`
 	// ManifestsFlagHelpStr is the command line description for --manifests
 	ManifestsFlagHelpStr = `Specify a path to a directory of charts and profiles
-(e.g. ~/Downloads/istio-1.6.0/manifests)
-or release tar URL (e.g. https://github.com/istio/istio/releases/download/1.6.0/istio-1.6.0-linux-amd64.tar.gz).
+(e.g. ~/Downloads/istio-` + baseVersion + `/manifests)
+or release tar URL (e.g. ` + releaseURL + `).
 `
 	ChartsDeprecatedStr         = "Deprecated, use --manifests instead."
 	revisionFlagHelpStr         = `Target control plane revision for the command.`


### PR DESCRIPTION
With every new major release, the release tar URL needs to be [updated manually](https://github.com/istio/istio/pull/24092) which is used during `verify` and `upgrade` which causes issues if missed updating. see  https://github.com/istio/istio/issues/24029 and https://github.com/istio/istio/issues/23726

This PR makes release tar URL dynamic based on `OperatorCodeBaseVersion` which gets [bumped with new releases](https://github.com/istio/istio/pull/25742/files#diff-920b8fa91d9d428d6b521b8b56fa5f81R23). 

It generates the following message.

With `OperatorCodeBaseVersion = 1.7.0`
```
Specify a path to a directory of charts and profiles
(e.g. ~/Downloads/istio-1.7.0/manifests)
or release tar URL (e.g. https://github.com/istio/istio/releases/download/1.7.0/istio-1.7.0-linux-amd64.tar.gz).
```
With `OperatorCodeBaseVersion = 1.6.0`
```
Specify a path to a directory of charts and profiles
(e.g. ~/Downloads/istio-1.6.0/manifests)
or release tar URL (e.g. https://github.com/istio/istio/releases/download/1.6.0/istio-1.6.0-linux-amd64.tar.gz).
```