### PR TITLE
test: replace deprecated function `NewGomegaWithT` with `NewWithT` in all tests

### DIFF
--- a/galley/pkg/config/analysis/analyzer_test.go
+++ b/galley/pkg/config/analysis/analyzer_test.go
@@ -56,7 +56,7 @@ func (ctx *context) ForEach(collection.Name, IteratorFn)                        
 func (ctx *context) Canceled() bool                                             { return false }
 
 func TestCombinedAnalyzer(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	col1 := newSchema("col1")
 	col2 := newSchema("col2")
@@ -90,7 +90,7 @@ func TestCombinedAnalyzer(t *testing.T) {
 }
 
 func TestGetDisabledOutputs(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	in1 := newSchema("in1")
 	in2 := newSchema("in2")

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -330,7 +330,7 @@ func TestAnalyzers(t *testing.T) {
 	for _, tc := range testGrid {
 		tc := tc // Capture range variable so subtests work correctly
 		t.Run(tc.name, func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			// Set up a hook to record which collections are accessed by each analyzer
 			analyzerName := tc.analyzer.Metadata().Name
@@ -360,7 +360,7 @@ func TestAnalyzers(t *testing.T) {
 	// Verify that the collections actually accessed during testing actually match
 	// the collections declared as inputs for each of the analyzers
 	t.Run("CheckMetadataInputs", func(t *testing.T) {
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 	outer:
 		for _, a := range All() {
 			analyzerName := a.Metadata().Name
@@ -390,7 +390,7 @@ func TestAnalyzers(t *testing.T) {
 
 // Verify that all of the analyzers tested here are also registered in All()
 func TestAnalyzersInAll(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	var allNames []string
 	for _, a := range All() {
@@ -403,7 +403,7 @@ func TestAnalyzersInAll(t *testing.T) {
 }
 
 func TestAnalyzersHaveUniqueNames(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	existingNames := make(map[string]struct{})
 	for _, a := range All() {
@@ -421,7 +421,7 @@ func TestAnalyzersHaveUniqueNames(t *testing.T) {
 }
 
 func TestAnalyzersHaveDescription(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	for _, a := range All() {
 		g.Expect(a.Metadata().Description).ToNot(Equal(""))

--- a/galley/pkg/config/analysis/analyzers/schema/validation_test.go
+++ b/galley/pkg/config/analysis/analyzers/schema/validation_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func TestCorrectArgs(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	m1 := &v1alpha3.VirtualService{}
 
@@ -81,12 +81,12 @@ func TestSchemaValidationWrapper(t *testing.T) {
 	a := ValidationAnalyzer{s: testSchema}
 
 	t.Run("CheckMetadataInputs", func(t *testing.T) {
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 		g.Expect(a.Metadata().Inputs).To(ConsistOf(testCol))
 	})
 
 	t.Run("NoErrors", func(t *testing.T) {
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 		ctx := &fixtures.Context{
 			Resources: []*resource.Instance{
 				{
@@ -99,7 +99,7 @@ func TestSchemaValidationWrapper(t *testing.T) {
 	})
 
 	t.Run("SingleError", func(t *testing.T) {
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 
 		ctx := &fixtures.Context{
 			Resources: []*resource.Instance{
@@ -115,7 +115,7 @@ func TestSchemaValidationWrapper(t *testing.T) {
 	})
 
 	t.Run("MultiError", func(t *testing.T) {
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 		ctx := &fixtures.Context{
 			Resources: []*resource.Instance{
 				{

--- a/galley/pkg/config/analysis/analyzers/util/exportto_test.go
+++ b/galley/pkg/config/analysis/analyzers/util/exportto_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestIsExportToAllNamespaces(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	// Empty array
 	g.Expect(IsExportToAllNamespaces(nil)).To(Equal(true))

--- a/galley/pkg/config/analysis/analyzers/util/hosts_test.go
+++ b/galley/pkg/config/analysis/analyzers/util/hosts_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestGetResourceNameFromHost(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	// FQDN, same namespace
 	g.Expect(GetResourceNameFromHost("default", "foo.default.svc.cluster.local")).To(Equal(resource.NewFullName("default", "foo")))
@@ -36,7 +36,7 @@ func TestGetResourceNameFromHost(t *testing.T) {
 }
 
 func TestGetScopedFqdnHostname(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	// FQDN, same namespace, local scope
 	g.Expect(NewScopedFqdn("default", "default", "foo.default.svc.cluster.local")).To(Equal(ScopedFqdn("default/foo.default.svc.cluster.local")))
@@ -68,7 +68,7 @@ func TestGetScopedFqdnHostname(t *testing.T) {
 }
 
 func TestScopedFqdn_GetScopeAndFqdn(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	ns, fqdn := ScopedFqdn("default/reviews.default.svc.cluster.local").GetScopeAndFqdn()
 	g.Expect(ns).To(Equal("default"))

--- a/galley/pkg/config/analysis/diag/message_test.go
+++ b/galley/pkg/config/analysis/diag/message_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestMessage_String(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	mt := NewMessageType(Error, "IST-0042", "Cheese type not found: %q")
 	m := NewMessage(mt, nil, "Feta")
 
@@ -32,7 +32,7 @@ func TestMessage_String(t *testing.T) {
 }
 
 func TestMessageWithResource_String(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	mt := NewMessageType(Error, "IST-0042", "Cheese type not found: %q")
 	m := NewMessage(mt, &resource.Instance{Origin: testOrigin{name: "toppings/cheese", ref: testReference{"path/to/file"}}}, "Feta")
 
@@ -40,7 +40,7 @@ func TestMessageWithResource_String(t *testing.T) {
 }
 
 func TestMessage_Unstructured(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	mt := NewMessageType(Error, "IST-0042", "Cheese type not found: %q")
 	m := NewMessage(mt, nil, "Feta")
 
@@ -54,7 +54,7 @@ func TestMessage_Unstructured(t *testing.T) {
 }
 
 func TestMessageWithDocRef(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	mt := NewMessageType(Error, "IST-0042", "Cheese type not found: %q")
 	m := NewMessage(mt, nil, "Feta")
 	m.DocRef = "test-ref"
@@ -62,7 +62,7 @@ func TestMessageWithDocRef(t *testing.T) {
 }
 
 func TestMessage_JSON(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	mt := NewMessageType(Error, "IST-0042", "Cheese type not found: %q")
 	m := NewMessage(mt, &resource.Instance{Origin: testOrigin{name: "toppings/cheese", ref: testReference{"path/to/file"}}}, "Feta")
 

--- a/galley/pkg/config/analysis/diag/messages_test.go
+++ b/galley/pkg/config/analysis/diag/messages_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestMessages_Sort(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	firstMsg := NewMessage(
 		NewMessageType(Error, "B1", "Template: %q"),
@@ -60,7 +60,7 @@ func TestMessages_Sort(t *testing.T) {
 }
 
 func TestMessages_SortWithNilOrigin(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	firstMsg := NewMessage(
 		NewMessageType(Error, "B1", "Template: %q"),
@@ -87,7 +87,7 @@ func TestMessages_SortWithNilOrigin(t *testing.T) {
 }
 
 func TestMessages_SortedCopy(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	firstMsg := NewMessage(
 		NewMessageType(Error, "B1", "Template: %q"),

--- a/galley/pkg/config/analysis/local/analyze_test.go
+++ b/galley/pkg/config/analysis/local/analyze_test.go
@@ -70,7 +70,7 @@ func (a *testAnalyzer) Analyze(ctx analysis.Context) {
 }
 
 func TestAbortWithNoSources(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	cancel := make(chan struct{})
 
@@ -80,7 +80,7 @@ func TestAbortWithNoSources(t *testing.T) {
 }
 
 func TestAnalyzersRun(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	cancel := make(chan struct{})
 
@@ -110,7 +110,7 @@ func TestAnalyzersRun(t *testing.T) {
 }
 
 func TestFilterOutputByNamespace(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	cancel := make(chan struct{})
 
@@ -135,7 +135,7 @@ func TestFilterOutputByNamespace(t *testing.T) {
 }
 
 func TestAddRunningKubeSource(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	mk := mock.NewKube()
 
@@ -149,7 +149,7 @@ func TestAddRunningKubeSource(t *testing.T) {
 }
 
 func TestAddRunningKubeSourceWithIstioMeshConfigMap(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	istioNamespace := resource.Namespace("istio-system")
 
@@ -184,7 +184,7 @@ func TestAddRunningKubeSourceWithIstioMeshConfigMap(t *testing.T) {
 }
 
 func TestAddReaderKubeSource(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	sa := NewSourceAnalyzer(basicmeta.MustGet(), blankCombinedAnalyzer, "", "", nil, false, timeout)
 
@@ -208,7 +208,7 @@ func TestAddReaderKubeSource(t *testing.T) {
 }
 
 func TestAddReaderKubeSourceSkipsBadEntries(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	sa := NewSourceAnalyzer(basicmeta.MustGet(), blankCombinedAnalyzer, "", "", nil, false, timeout)
 
@@ -221,7 +221,7 @@ func TestAddReaderKubeSourceSkipsBadEntries(t *testing.T) {
 }
 
 func TestDefaultResourcesRespectsMeshConfig(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	sa := NewSourceAnalyzer(basicmeta.MustGet(), blankCombinedAnalyzer, "", "", nil, false, timeout)
 
@@ -245,7 +245,7 @@ func TestDefaultResourcesRespectsMeshConfig(t *testing.T) {
 }
 
 func TestResourceFiltering(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	// Set up mock apiServer so we can peek at the options it gets started with
 	prevApiserverNew := apiserverNew

--- a/galley/pkg/config/analysis/local/source_test.go
+++ b/galley/pkg/config/analysis/local/source_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestBasicSingleSource(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s1 := &fixtures.Source{}
 
@@ -47,7 +47,7 @@ func TestBasicSingleSource(t *testing.T) {
 }
 
 func TestWaitAndCombineFullSync(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s1 := &fixtures.Source{}
 	s2 := &fixtures.Source{}
@@ -81,7 +81,7 @@ func TestWaitAndCombineFullSync(t *testing.T) {
 }
 
 func TestPrecedence(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s1 := &fixtures.Source{}
 	s2 := &fixtures.Source{}

--- a/galley/pkg/config/collection/instance_test.go
+++ b/galley/pkg/config/collection/instance_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestInstance_Basics(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	inst := collection.New(basicmeta.K8SCollection1)
 
@@ -83,7 +83,7 @@ func TestInstance_Basics(t *testing.T) {
 }
 
 func TestInstance_Clone(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	inst := collection.New(basicmeta.K8SCollection1)
 	inst.Set(data.EntryN1I1V1)
@@ -116,7 +116,7 @@ func TestInstance_Clone(t *testing.T) {
 }
 
 func TestInstance_ForEach_False(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	inst := collection.New(basicmeta.K8SCollection1)
 	inst.Set(data.EntryN1I1V2)
@@ -139,7 +139,7 @@ func TestInstance_ForEach_False(t *testing.T) {
 }
 
 func TestInstance_Get(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	inst := collection.New(basicmeta.K8SCollection1)
 	inst.Set(data.EntryN1I1V1)

--- a/galley/pkg/config/collection/set_test.go
+++ b/galley/pkg/config/collection/set_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestNewSet(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := coll.NewSet(collection.NewSchemasBuilder().MustAdd(basicmeta.K8SCollection1).MustAdd(basicmeta.Collection2).Build())
 
@@ -39,7 +39,7 @@ func TestNewSet(t *testing.T) {
 }
 
 func TestNewSetFromCollections(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s1 := coll.New(basicmeta.K8SCollection1)
 	g.Expect(s1).NotTo(BeNil())
@@ -58,7 +58,7 @@ func TestNewSetFromCollections(t *testing.T) {
 }
 
 func TestSet_Clone(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s1 := coll.New(basicmeta.K8SCollection1)
 	g.Expect(s1).NotTo(BeNil())
@@ -79,7 +79,7 @@ func TestSet_Clone(t *testing.T) {
 }
 
 func TestSet_Names(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s1 := coll.New(basicmeta.K8SCollection1)
 	s2 := coll.New(basicmeta.Collection2)

--- a/galley/pkg/config/mesh/defaults_test.go
+++ b/galley/pkg/config/mesh/defaults_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestDefaults(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	m := DefaultMeshConfig()
 	expect := mesh.DefaultMeshConfig()

--- a/galley/pkg/config/mesh/fs_test.go
+++ b/galley/pkg/config/mesh/fs_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 func TestFsSource_NoInitialFile(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	file := setupDir(t, nil)
 
@@ -76,7 +76,7 @@ func TestFsSource_NoInitialFile(t *testing.T) {
 }
 
 func TestFsSource_NoInitialFile_UpdateAfterStart(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	file := setupDir(t, nil)
 
@@ -130,7 +130,7 @@ func TestFsSource_NoInitialFile_UpdateAfterStart(t *testing.T) {
 }
 
 func TestFsSource_InitialFile_UpdateAfterStart(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	mcfg := DefaultMeshConfig()
 	mcfg.IngressClass = "foo"
@@ -186,7 +186,7 @@ func TestFsSource_InitialFile_UpdateAfterStart(t *testing.T) {
 }
 
 func TestFsSource_InitialFile(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	mcfg := DefaultMeshConfig()
 	mcfg.IngressClass = "foo"
@@ -229,7 +229,7 @@ func TestFsSource_InitialFile(t *testing.T) {
 }
 
 func TestFsSource_StartStopStart(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	mcfg := DefaultMeshConfig()
 	mcfg.IngressClass = "foo"
@@ -278,7 +278,7 @@ func TestFsSource_StartStopStart(t *testing.T) {
 }
 
 func TestFsSource_FileRemoved_NoChange(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	mcfg := DefaultMeshConfig()
 	mcfg.IngressClass = "foo"
@@ -327,7 +327,7 @@ func TestFsSource_FileRemoved_NoChange(t *testing.T) {
 
 func TestFsSource_BogusFile_NoChange(t *testing.T) {
 	t.Skip("https://github.com/istio/istio/issues/15987")
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	mcfg := DefaultMeshConfig()
 	mcfg.IngressClass = "foo"
@@ -376,7 +376,7 @@ func TestFsSource_BogusFile_NoChange(t *testing.T) {
 }
 
 func setupDir(t *testing.T, m *v1alpha1.MeshConfig) string {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	p, err := ioutil.TempDir(os.TempDir(), t.Name())
 	g.Expect(err).To(BeNil())
@@ -390,7 +390,7 @@ func setupDir(t *testing.T, m *v1alpha1.MeshConfig) string {
 }
 
 func writeMeshCfg(t *testing.T, file string, m *v1alpha1.MeshConfig) { // nolint:interfacer
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	s, err := (&jsonpb.Marshaler{Indent: "  "}).MarshalToString(m)
 	g.Expect(err).To(BeNil())
 	err = ioutil.WriteFile(file, []byte(s), os.ModePerm)
@@ -398,7 +398,7 @@ func writeMeshCfg(t *testing.T, file string, m *v1alpha1.MeshConfig) { // nolint
 }
 
 func TestFsSource_InvalidPath(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	file := setupDir(t, nil)
 	file = path.Join(file, "bogus")
@@ -408,7 +408,7 @@ func TestFsSource_InvalidPath(t *testing.T) {
 }
 
 func TestFsSource_YamlToJSONError(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	mcfg := DefaultMeshConfig()
 	mcfg.IngressClass = "foo"

--- a/galley/pkg/config/mesh/inmemory_test.go
+++ b/galley/pkg/config/mesh/inmemory_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestInMemorySource_Empty(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := NewInmemoryMeshCfg()
 
@@ -43,7 +43,7 @@ func TestInMemorySource_Empty(t *testing.T) {
 }
 
 func TestInMemorySource_SetBeforeStart(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := NewInmemoryMeshCfg()
 
@@ -80,7 +80,7 @@ func TestInMemorySource_SetBeforeStart(t *testing.T) {
 }
 
 func TestInMemorySource_SetAfterStart(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := NewInmemoryMeshCfg()
 
@@ -117,7 +117,7 @@ func TestInMemorySource_SetAfterStart(t *testing.T) {
 }
 
 func TestInMemorySource_DoubleStart(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := NewInmemoryMeshCfg()
 
@@ -155,7 +155,7 @@ func TestInMemorySource_DoubleStart(t *testing.T) {
 }
 
 func TestInMemorySource_StartStop(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := NewInmemoryMeshCfg()
 

--- a/galley/pkg/config/processing/runtime_test.go
+++ b/galley/pkg/config/processing/runtime_test.go
@@ -40,7 +40,7 @@ func init() {
 }
 
 func TestRuntime_Startup_NoMeshConfig(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	f := initFixture()
 	f.rt.Start()
@@ -58,7 +58,7 @@ func TestRuntime_Startup_NoMeshConfig(t *testing.T) {
 }
 
 func TestRuntime_Startup_MeshConfig_Arrives_No_Resources(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	f := initFixture()
 	f.rt.Start()
@@ -75,7 +75,7 @@ func TestRuntime_Startup_MeshConfig_Arrives_No_Resources(t *testing.T) {
 }
 
 func TestRuntime_Startup_MeshConfig_Arrives(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	f := initFixture()
 	f.rt.Start()
@@ -101,7 +101,7 @@ func TestRuntime_Startup_MeshConfig_Arrives(t *testing.T) {
 }
 
 func TestRuntime_Startup_Stop(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	f := initFixture()
 	f.rt.Start()
@@ -122,7 +122,7 @@ func TestRuntime_Startup_Stop(t *testing.T) {
 }
 
 func TestRuntime_Start_Start_Stop(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	f := initFixture()
 	f.rt.Start()
@@ -143,7 +143,7 @@ func TestRuntime_Start_Start_Stop(t *testing.T) {
 }
 
 func TestRuntime_Start_Stop_Stop(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	f := initFixture()
 	f.rt.Start()
@@ -165,7 +165,7 @@ func TestRuntime_Start_Stop_Stop(t *testing.T) {
 }
 
 func TestRuntime_MeshConfig_Causing_Restart(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	f := initFixture()
 	f.rt.Start()
@@ -210,7 +210,7 @@ func TestRuntime_MeshConfig_Causing_Restart(t *testing.T) {
 }
 
 func TestRuntime_Event_Before_Start(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	f := initFixture()
 
@@ -226,7 +226,7 @@ func TestRuntime_Event_Before_Start(t *testing.T) {
 }
 
 func TestRuntime_Stop_WhileStarting(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	f := newFixture()
 	f.meshsrc = nil
@@ -253,7 +253,7 @@ func TestRuntime_Stop_WhileStarting(t *testing.T) {
 }
 
 func TestRuntime_Reset_WhileStarting(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	f := newFixture()
 	f.meshsrc = nil
@@ -283,7 +283,7 @@ func TestRuntime_Reset_WhileStarting(t *testing.T) {
 }
 
 func TestRuntime_MeshEvent_WhileBuffering(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	f := newFixture()
 	f.meshsrc = nil
@@ -305,7 +305,7 @@ func TestRuntime_MeshEvent_WhileBuffering(t *testing.T) {
 }
 
 func TestRuntime_MeshEvent_WhileRunning(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	f := initFixture()
 	f.rt.Start()

--- a/galley/pkg/config/processing/snapshotter/analyzingdistributor_test.go
+++ b/galley/pkg/config/processing/snapshotter/analyzingdistributor_test.go
@@ -120,7 +120,7 @@ func (a *analyzerMock) getAnalyzeCalls() []*Snapshot {
 }
 
 func TestAnalyzeAndDistributeSnapshots(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	u := &updaterMock{}
 	a := &analyzerMock{
@@ -187,7 +187,7 @@ func TestAnalyzeAndDistributeSnapshots(t *testing.T) {
 }
 
 func TestAnalyzeNamespaceMessageHasNoResource(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	u := &updaterMock{waitTimeout: 1 * time.Second}
 	a := &analyzerMock{
@@ -217,7 +217,7 @@ func TestAnalyzeNamespaceMessageHasNoResource(t *testing.T) {
 }
 
 func TestAnalyzeNamespaceMessageHasOriginWithNoNamespace(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	u := &updaterMock{waitTimeout: 1 * time.Second}
 	a := &analyzerMock{
@@ -253,7 +253,7 @@ func TestAnalyzeNamespaceMessageHasOriginWithNoNamespace(t *testing.T) {
 }
 
 func TestAnalyzeSortsMessages(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	u := &updaterMock{waitTimeout: 1 * time.Second}
 	r1 := &resource.Instance{
@@ -298,7 +298,7 @@ func TestAnalyzeSortsMessages(t *testing.T) {
 }
 
 func TestAnalyzeSuppressesMessages(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	u := &updaterMock{waitTimeout: 1 * time.Second}
 	r1 := &resource.Instance{
@@ -349,7 +349,7 @@ func TestAnalyzeSuppressesMessages(t *testing.T) {
 }
 
 func TestAnalyzeSuppressesMessagesWithWildcards(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	u := &updaterMock{waitTimeout: 1 * time.Second}
 	// r1 and r2 have the same prefix, but r3 does not
@@ -452,7 +452,7 @@ func TestAnalyzeSuppressesMessagesWhenResourceIsAnnotated(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 			u := &updaterMock{waitTimeout: 1 * time.Second}
 			r := &resource.Instance{
 				Metadata: resource.Metadata{

--- a/galley/pkg/config/processing/snapshotter/snapshot_test.go
+++ b/galley/pkg/config/processing/snapshotter/snapshot_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestSnapshot_Basics(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	set := coll.NewSet(collection.NewSchemasBuilder().MustAdd(basicmeta.K8SCollection1).Build())
 	set.Collection(basicmeta.K8SCollection1.Name()).Set(data.EntryN1I1V1)
@@ -51,7 +51,7 @@ func TestSnapshot_Basics(t *testing.T) {
 }
 
 func TestSnapshot_SerializeError(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	set := coll.NewSet(collection.NewSchemasBuilder().MustAdd(basicmeta.K8SCollection1).Build())
 	e := data.Event1Col1AddItem1.Resource.Clone()
@@ -64,7 +64,7 @@ func TestSnapshot_SerializeError(t *testing.T) {
 }
 
 func TestSnapshot_WrongCollection(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	set := coll.NewSet(collection.NewSchemasBuilder().MustAdd(basicmeta.K8SCollection1).Build())
 	set.Collection(basicmeta.K8SCollection1.Name()).Set(data.Event1Col1AddItem1.Resource)

--- a/galley/pkg/config/processing/snapshotter/snapshotter_test.go
+++ b/galley/pkg/config/processing/snapshotter/snapshotter_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestSnapshotter_Basic(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	tr := fixtures.NewTransformer(
 		collection.NewSchemasBuilder().MustAdd(basicmeta.K8SCollection1).Build(),
@@ -87,7 +87,7 @@ func TestSnapshotter_Basic(t *testing.T) {
 }
 
 func TestSnapshotter_SnapshotMismatch(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	tr := fixtures.NewTransformer(
 		collection.NewSchemasBuilder().MustAdd(basicmeta.K8SCollection1).Build(),
@@ -119,7 +119,7 @@ func TestSnapshotter_SnapshotMismatch(t *testing.T) {
 
 // All collections should be synced before any snapshots are made available
 func TestSnapshotterWaitForAllSync(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	tr := fixtures.NewTransformer(
 		collection.NewSchemasBuilder().MustAdd(basicmeta.K8SCollection1).MustAdd(basicmeta.Collection2).Build(),

--- a/galley/pkg/config/processing/snapshotter/statusupdater_test.go
+++ b/galley/pkg/config/processing/snapshotter/statusupdater_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestInMemoryStatusUpdaterWriteThenWait(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	su := &InMemoryStatusUpdater{WaitTimeout: 1 * time.Second}
 
@@ -40,7 +40,7 @@ func TestInMemoryStatusUpdaterWriteThenWait(t *testing.T) {
 }
 
 func TestInMemoryStatusUpdaterWriteNothingThenWait(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	su := &InMemoryStatusUpdater{WaitTimeout: 1 * time.Second}
 
@@ -54,7 +54,7 @@ func TestInMemoryStatusUpdaterWriteNothingThenWait(t *testing.T) {
 }
 
 func TestInMemoryStatusUpdaterWaitThenWrite(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	su := &InMemoryStatusUpdater{WaitTimeout: 1 * time.Second}
 
@@ -73,7 +73,7 @@ func TestInMemoryStatusUpdaterWaitThenWrite(t *testing.T) {
 }
 
 func TestInMemoryStatusUpdaterTimesOut(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	su := &InMemoryStatusUpdater{WaitTimeout: 0}
 
@@ -84,7 +84,7 @@ func TestInMemoryStatusUpdaterTimesOut(t *testing.T) {
 }
 
 func TestInMemoryStatusUpdaterCancelled(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	su := &InMemoryStatusUpdater{WaitTimeout: 1 * time.Second}
 

--- a/galley/pkg/config/processing/snapshotter/strategy/create_test.go
+++ b/galley/pkg/config/processing/snapshotter/strategy/create_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestCreate_Immediate(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s, err := Create(immediate)
 	g.Expect(err).To(BeNil())
@@ -31,7 +31,7 @@ func TestCreate_Immediate(t *testing.T) {
 }
 
 func TestCreate_Debounce(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s, err := Create(debounce)
 	g.Expect(err).To(BeNil())
@@ -40,7 +40,7 @@ func TestCreate_Debounce(t *testing.T) {
 }
 
 func TestCreate_Unknown(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	_, err := Create("foo")
 	g.Expect(err).NotTo(BeNil())

--- a/galley/pkg/config/processing/snapshotter/strategy/debounce_test.go
+++ b/galley/pkg/config/processing/snapshotter/strategy/debounce_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestStrategy_StartStop(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := NewDebounce(time.Minute, time.Millisecond*500)
 
@@ -42,7 +42,7 @@ func TestStrategy_StartStop(t *testing.T) {
 }
 
 func TestStrategy_DoubleStart(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := NewDebounce(time.Minute, time.Millisecond*500)
 
@@ -59,7 +59,7 @@ func TestStrategy_DoubleStart(t *testing.T) {
 }
 
 func TestStrategy_DoubleStop(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := NewDebounce(time.Hour, time.Millisecond*500)
 
@@ -74,7 +74,7 @@ func TestStrategy_DoubleStop(t *testing.T) {
 }
 
 func TestStrategy_ChangeBeforeStart(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := NewDebounce(time.Millisecond*100, time.Millisecond)
 	s.OnChange()
@@ -91,7 +91,7 @@ func TestStrategy_ChangeBeforeStart(t *testing.T) {
 }
 
 func TestStrategy_FireEvent(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := NewDebounce(time.Millisecond*200, time.Millisecond*100)
 
@@ -108,7 +108,7 @@ func TestStrategy_FireEvent(t *testing.T) {
 }
 
 func TestStrategy_StopBeforeMaxTimeout(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := NewDebounce(time.Second*5, time.Second)
 
@@ -125,7 +125,7 @@ func TestStrategy_StopBeforeMaxTimeout(t *testing.T) {
 }
 
 func TestStrategy_ChangeBeforeQuiesce(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := NewDebounce(time.Second*5, time.Second)
 
@@ -144,7 +144,7 @@ func TestStrategy_ChangeBeforeQuiesce(t *testing.T) {
 }
 
 func TestStrategy_MaxTimeout(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := NewDebounce(time.Second, time.Millisecond*500)
 
@@ -163,7 +163,7 @@ func TestStrategy_MaxTimeout(t *testing.T) {
 }
 
 func TestStrategy_NewWithDefaults(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	s := NewDebounceWithDefaults()
 	g.Expect(s.quiesceDuration).To(Equal(defaultQuiesceDuration))
 	g.Expect(s.maxWaitDuration).To(Equal(defaultMaxWaitDuration))

--- a/galley/pkg/config/processing/snapshotter/strategy/immediate_test.go
+++ b/galley/pkg/config/processing/snapshotter/strategy/immediate_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestNewImmediate(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	s := NewImmediate()
 
 	var changed bool

--- a/galley/pkg/config/processing/transformer/provider_test.go
+++ b/galley/pkg/config/processing/transformer/provider_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestSimpleTransformerProvider(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	input := basicmeta.K8SCollection1
 	output := basicmeta.Collection2

--- a/galley/pkg/config/processor/build_test.go
+++ b/galley/pkg/config/processor/build_test.go
@@ -48,7 +48,7 @@ spec:
 `
 
 func TestProcessor(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	meshSrc := mesh.NewInmemoryMeshCfg()
 	src := inmemory.NewKubeSource(schema.MustGet().KubeCollections())

--- a/galley/pkg/config/processor/groups/groups_test.go
+++ b/galley/pkg/config/processor/groups/groups_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestDefault(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	actual := groups.IndexFunction("bogus", nil)
 	g.Expect(actual).To(Equal(groups.Default))
 }

--- a/galley/pkg/config/processor/transforms/direct/create_test.go
+++ b/galley/pkg/config/processor/transforms/direct/create_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestDirect_Input_Output(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	xform, _, _ := setup(g)
 
@@ -37,7 +37,7 @@ func TestDirect_Input_Output(t *testing.T) {
 }
 
 func TestDirect_AddSync(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	xform, src, acc := setup(g)
 
@@ -53,7 +53,7 @@ func TestDirect_AddSync(t *testing.T) {
 }
 
 func TestDirect_SyncAdd(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	xform, src, acc := setup(g)
 
@@ -69,7 +69,7 @@ func TestDirect_SyncAdd(t *testing.T) {
 }
 
 func TestDirect_AddUpdateDelete(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	xform, src, acc := setup(g)
 
@@ -90,7 +90,7 @@ func TestDirect_AddUpdateDelete(t *testing.T) {
 }
 
 func TestDirect_SyncReset(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	xform, src, acc := setup(g)
 
@@ -107,7 +107,7 @@ func TestDirect_SyncReset(t *testing.T) {
 }
 
 func TestDirect_InvalidEventKind(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	xform, src, acc := setup(g)
 
@@ -123,7 +123,7 @@ func TestDirect_InvalidEventKind(t *testing.T) {
 }
 
 func TestDirect_NoListeners(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	xforms := GetProviders(basicmeta.MustGet()).Create(processing.ProcessorOptions{})
 	g.Expect(xforms).To(HaveLen(1))
@@ -143,7 +143,7 @@ func TestDirect_NoListeners(t *testing.T) {
 }
 
 func TestDirect_DoubleStart(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	xform, src, acc := setup(g)
 
@@ -161,7 +161,7 @@ func TestDirect_DoubleStart(t *testing.T) {
 }
 
 func TestDirect_DoubleStop(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	xform, src, acc := setup(g)
 
@@ -184,7 +184,7 @@ func TestDirect_DoubleStop(t *testing.T) {
 }
 
 func TestDirect_StartStopStartStop(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	xform, src, acc := setup(g)
 
@@ -218,7 +218,7 @@ func TestDirect_StartStopStartStop(t *testing.T) {
 }
 
 func TestDirect_InvalidEvent(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	xform, src, acc := setup(g)
 

--- a/galley/pkg/config/source/inmemory/collection_test.go
+++ b/galley/pkg/config/source/inmemory/collection_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestCollection_Start_Empty(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	col := NewCollection(basicmeta.K8SCollection1)
 	acc := &fixtures.Accumulator{}
@@ -44,7 +44,7 @@ func TestCollection_Start_Empty(t *testing.T) {
 }
 
 func TestCollection_Start_Element(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	old := scope.Source.GetOutputLevel()
 	defer func() {
@@ -65,7 +65,7 @@ func TestCollection_Start_Element(t *testing.T) {
 }
 
 func TestCollection_Update(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	col := NewCollection(basicmeta.K8SCollection1)
 	acc := &fixtures.Accumulator{}
@@ -86,7 +86,7 @@ func TestCollection_Update(t *testing.T) {
 }
 
 func TestCollection_Delete(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	col := NewCollection(basicmeta.K8SCollection1)
 	acc := &fixtures.Accumulator{}
@@ -107,7 +107,7 @@ func TestCollection_Delete(t *testing.T) {
 }
 
 func TestCollection_Delete_NoItem(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	col := NewCollection(basicmeta.K8SCollection1)
 	acc := &fixtures.Accumulator{}
@@ -127,7 +127,7 @@ func TestCollection_Delete_NoItem(t *testing.T) {
 }
 
 func TestCollection_Clear_BeforeStart(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	col := NewCollection(basicmeta.K8SCollection1)
 	acc := &fixtures.Accumulator{}
@@ -145,7 +145,7 @@ func TestCollection_Clear_BeforeStart(t *testing.T) {
 }
 
 func TestCollection_Clear_AfterStart(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	col := NewCollection(basicmeta.K8SCollection1)
 	acc := &fixtures.Accumulator{}
@@ -169,7 +169,7 @@ func TestCollection_Clear_AfterStart(t *testing.T) {
 }
 
 func TestCollection_StopStart(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	col := NewCollection(basicmeta.K8SCollection1)
 	acc := &fixtures.Accumulator{}
@@ -192,7 +192,7 @@ func TestCollection_StopStart(t *testing.T) {
 }
 
 func TestCollection_AllSorted(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	col := NewCollection(basicmeta.K8SCollection1)
 

--- a/galley/pkg/config/source/inmemory/source_test.go
+++ b/galley/pkg/config/source/inmemory/source_test.go
@@ -34,7 +34,7 @@ var (
 )
 
 func TestInMemory_Register_Empty(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	i := New(cols)
 	h := &fixtures.Accumulator{}
@@ -53,7 +53,7 @@ func TestInMemory_Register_Empty(t *testing.T) {
 }
 
 func TestInMemory_Set_BeforeSync(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	r := &resource.Instance{
 		Metadata: resource.Metadata{
@@ -87,7 +87,7 @@ func TestInMemory_Set_BeforeSync(t *testing.T) {
 }
 
 func TestInMemory_Set_Add(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	r := &resource.Instance{
 		Metadata: resource.Metadata{
@@ -131,7 +131,7 @@ func TestInMemory_Set_Add(t *testing.T) {
 }
 
 func TestInMemory_Set_Update(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	r1 := &resource.Instance{
 		Metadata: resource.Metadata{
@@ -188,7 +188,7 @@ func TestInMemory_Set_Update(t *testing.T) {
 }
 
 func TestInMemory_Clear_BeforeSync(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	i := New(cols)
 	i.Get(basicmeta.K8SCollection1.Name()).Set(data.EntryN1I1V1)
@@ -212,7 +212,7 @@ func TestInMemory_Clear_BeforeSync(t *testing.T) {
 }
 
 func TestInMemory_Clear_AfterSync(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	i := New(cols)
 	i.Get(basicmeta.K8SCollection1.Name()).Set(data.EntryN1I1V1)
@@ -238,7 +238,7 @@ func TestInMemory_Clear_AfterSync(t *testing.T) {
 }
 
 func TestInMemory_DoubleStart(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	i := New(cols)
 	h := &fixtures.Accumulator{}
@@ -258,7 +258,7 @@ func TestInMemory_DoubleStart(t *testing.T) {
 }
 
 func TestInMemory_DoubleStop(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	i := New(cols)
 	h := &fixtures.Accumulator{}

--- a/galley/pkg/config/source/kube/apiserver/source_builtin_test.go
+++ b/galley/pkg/config/source/kube/apiserver/source_builtin_test.go
@@ -60,7 +60,7 @@ var (
 )
 
 func TestBasic(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	// Set the log level to debug for codecov.
 	prevLevel := setDebugLogLevel()
@@ -101,7 +101,7 @@ func TestBasic(t *testing.T) {
 }
 
 func TestNodes(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	// Set the log level to debug for codecov.
 	prevLevel := setDebugLogLevel()
@@ -169,7 +169,7 @@ func TestNodes(t *testing.T) {
 }
 
 func TestPods(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	// Set the log level to debug for codecov.
 	prevLevel := setDebugLogLevel()
@@ -247,7 +247,7 @@ func TestPods(t *testing.T) {
 }
 
 func TestServices(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	// Set the log level to debug for codecov.
 	prevLevel := setDebugLogLevel()
@@ -320,7 +320,7 @@ func TestServices(t *testing.T) {
 }
 
 func TestEndpoints(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	// Set the log level to debug for codecov.
 	prevLevel := setDebugLogLevel()

--- a/galley/pkg/config/source/kube/apiserver/source_dynamic_test.go
+++ b/galley/pkg/config/source/kube/apiserver/source_dynamic_test.go
@@ -74,7 +74,7 @@ func TestStartTwice(t *testing.T) {
 }
 
 func TestStartStop_WithStatusCtl(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	// Create the source
 	w, _, cl := createMocks()
@@ -106,7 +106,7 @@ func TestStopTwiceShouldSucceed(t *testing.T) {
 }
 
 func TestReport(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	// Create the source
 	w, _, cl := createMocks()
@@ -133,7 +133,7 @@ func TestReport(t *testing.T) {
 }
 
 func TestEvents(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	w, wcrd, cl := createMocks()
 	defer wcrd.Stop()
@@ -195,7 +195,7 @@ func TestEvents(t *testing.T) {
 }
 
 func TestEvents_WatchUpdatesStatusCtl(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	w, wcrd, cl := createMocks()
 	defer wcrd.Stop()
@@ -300,7 +300,7 @@ func TestEvents_CRDEventAfterFullSync(t *testing.T) {
 }
 
 func TestEvents_NonAddEvent(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	w, wcrd, cl := createMocks()
 	defer wcrd.Stop()
@@ -326,7 +326,7 @@ func TestEvents_NonAddEvent(t *testing.T) {
 }
 
 func TestEvents_NoneForDisabled(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	w, wcrd, cl := createMocks()
 	defer wcrd.Stop()
@@ -399,7 +399,7 @@ func TestSource_WatcherFailsCreatingInformer(t *testing.T) {
 }
 
 func TestUpdateMessage_NoStatusController_Panic(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	defer func() {
 		r := recover()

--- a/galley/pkg/config/source/kube/apiserver/status/controller_test.go
+++ b/galley/pkg/config/source/kube/apiserver/status/controller_test.go
@@ -36,7 +36,7 @@ import (
 const subfield = "testMessages"
 
 func TestBasicStartStop(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	c := NewController(subfield)
 	k, cl := setupClient()
@@ -49,7 +49,7 @@ func TestBasicStartStop(t *testing.T) {
 }
 
 func TestDoubleStart(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	c := NewController(subfield)
 	k, cl := setupClient()
@@ -63,7 +63,7 @@ func TestDoubleStart(t *testing.T) {
 }
 
 func TestDoubleStop(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	c := NewController(subfield)
 	k, cl := setupClient()
@@ -76,7 +76,7 @@ func TestDoubleStop(t *testing.T) {
 }
 
 func TestNoReconcilation(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	c := NewController(subfield)
 	k, cl := setupClient()
@@ -89,7 +89,7 @@ func TestNoReconcilation(t *testing.T) {
 }
 
 func TestBasicReconcilation_BeforeUpdate(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	c := NewController(subfield)
 
@@ -117,7 +117,7 @@ func TestBasicReconcilation_BeforeUpdate(t *testing.T) {
 }
 
 func TestBasicReconcilation_AfterUpdate(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	c := NewController(subfield)
 
@@ -146,7 +146,7 @@ func TestBasicReconcilation_AfterUpdate(t *testing.T) {
 }
 
 func TestBasicReconcilation_AfterUpdate_Othersubfield(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	c := NewController(subfield)
 
@@ -181,7 +181,7 @@ func TestBasicReconcilation_AfterUpdate_Othersubfield(t *testing.T) {
 }
 
 func TestBasicReconcilation_NewStatus(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	c := NewController(subfield)
 
@@ -220,7 +220,7 @@ func TestBasicReconcilation_NewStatus(t *testing.T) {
 }
 
 func TestBasicReconcilation_NewStatusOldNonMap(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	c := NewController(subfield)
 
@@ -259,7 +259,7 @@ func TestBasicReconcilation_NewStatusOldNonMap(t *testing.T) {
 }
 
 func TestBasicReconcilation_UpdateError(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	c := NewController(subfield)
 
@@ -295,7 +295,7 @@ func TestBasicReconcilation_UpdateError(t *testing.T) {
 }
 
 func TestBasicReconcilation_GetError(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	c := NewController(subfield)
 
@@ -326,7 +326,7 @@ func TestBasicReconcilation_GetError(t *testing.T) {
 }
 
 func TestBasicReconcilation_VersionMismatch(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	c := NewController(subfield)
 

--- a/galley/pkg/config/source/kube/apiserver/status/state_test.go
+++ b/galley/pkg/config/source/kube/apiserver/status/state_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestState_SetLastKnown_NoEntry(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := newState()
 	s.applyMessages(NewMessageSet()) // start reconciliation
@@ -51,7 +51,7 @@ func TestState_SetLastKnown_NoEntry(t *testing.T) {
 }
 
 func TestState_SetLastKnown_NoReconciliation(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := newState()
 	s.setObserved(basicmeta.K8SCollection1.Name(), data.EntryN1I1V1.Metadata.FullName, data.EntryN1I1V1.Metadata.Version, "foo")
@@ -60,7 +60,7 @@ func TestState_SetLastKnown_NoReconciliation(t *testing.T) {
 }
 
 func TestState_SetLastKnown_TwoEntries(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := newState()
 	s.applyMessages(NewMessageSet()) // start reconciliation
@@ -91,7 +91,7 @@ func TestState_SetLastKnown_TwoEntries(t *testing.T) {
 }
 
 func TestState_SetLastKnown_ExistingEntry(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := newState()
 	s.applyMessages(NewMessageSet()) // start reconciliation
@@ -113,7 +113,7 @@ func TestState_SetLastKnown_ExistingEntry(t *testing.T) {
 }
 
 func TestState_ClearLastKnown_NoEntry(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := newState()
 	s.applyMessages(NewMessageSet()) // start reconciliation
@@ -126,7 +126,7 @@ func TestState_ClearLastKnown_NoEntry(t *testing.T) {
 }
 
 func TestState_ClearLastKnown_ExistingEntry(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := newState()
 	s.applyMessages(NewMessageSet()) // start reconciliation
@@ -150,7 +150,7 @@ func TestState_ClearLastKnown_ExistingEntry(t *testing.T) {
 }
 
 func TestState_Quiesce_PendingWork(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := newState()
 	s.applyMessages(NewMessageSet()) // start reconciliation
@@ -164,7 +164,7 @@ func TestState_Quiesce_PendingWork(t *testing.T) {
 }
 
 func TestState_Quiesce_WaitingForWork(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := newState()
 
@@ -187,7 +187,7 @@ func TestState_Quiesce_WaitingForWork(t *testing.T) {
 }
 
 func TestState_ApplyMessages_New(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := newState()
 
@@ -216,7 +216,7 @@ func TestState_ApplyMessages_New(t *testing.T) {
 }
 
 func TestState_ApplyMessages_AgainstExistingUnappliedState(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := newState()
 	s.applyMessages(NewMessageSet()) // start reconciliation
@@ -251,7 +251,7 @@ func TestState_ApplyMessages_AgainstExistingUnappliedState(t *testing.T) {
 }
 
 func TestState_ClearMessages_AgainstAppliedState(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := newState()
 	s.applyMessages(NewMessageSet()) // start reconciliation
@@ -274,7 +274,7 @@ func TestState_ClearMessages_AgainstAppliedState(t *testing.T) {
 }
 
 func TestState_ClearMessages_AgainstAppliedEmptyState(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := newState()
 	s.applyMessages(NewMessageSet()) // start reconciliation

--- a/galley/pkg/config/source/kube/apiserver/tombstone/recover_test.go
+++ b/galley/pkg/config/source/kube/apiserver/tombstone/recover_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestRecoverySuccessful(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	expected := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "mynode",
@@ -40,13 +40,13 @@ func TestRecoverySuccessful(t *testing.T) {
 }
 
 func TestUnkownTypeShouldFail(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	obj := tombstone.RecoverResource(&struct{}{})
 	g.Expect(obj).To(BeNil())
 }
 
 func TestUnkownTombstoneObjectShouldFail(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	obj := tombstone.RecoverResource(cache.DeletedFinalStateUnknown{
 		Obj: &struct{}{},
 	})

--- a/galley/pkg/config/source/kube/inmemory/kubesource_test.go
+++ b/galley/pkg/config/source/kube/inmemory/kubesource_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestKubeSource_ApplyContent(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s, acc := setupKubeSource()
 	s.Start()
@@ -52,7 +52,7 @@ func TestKubeSource_ApplyContent(t *testing.T) {
 }
 
 func TestKubeSource_ApplyContent_BeforeStart(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s, acc := setupKubeSource()
 	defer s.Stop()
@@ -75,7 +75,7 @@ func TestKubeSource_ApplyContent_BeforeStart(t *testing.T) {
 }
 
 func TestKubeSource_ApplyContent_Unchanged0Add1(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s, acc := setupKubeSource()
 	s.Start()
@@ -115,7 +115,7 @@ func TestKubeSource_ApplyContent_Unchanged0Add1(t *testing.T) {
 }
 
 func TestKubeSource_RemoveContent(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s, acc := setupKubeSource()
 	s.Start()
@@ -158,7 +158,7 @@ func TestKubeSource_RemoveContent(t *testing.T) {
 }
 
 func TestKubeSource_Clear(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s, acc := setupKubeSource()
 	s.Start()
@@ -193,7 +193,7 @@ func TestKubeSource_Clear(t *testing.T) {
 }
 
 func TestKubeSource_UnparseableSegment(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s, _ := setupKubeSource()
 	s.Start()
@@ -209,7 +209,7 @@ func TestKubeSource_UnparseableSegment(t *testing.T) {
 }
 
 func TestKubeSource_Unrecognized(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s, _ := setupKubeSource()
 	s.Start()
@@ -225,7 +225,7 @@ func TestKubeSource_Unrecognized(t *testing.T) {
 }
 
 func TestKubeSource_UnparseableResource(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s, _ := setupKubeSource()
 	s.Start()
@@ -240,7 +240,7 @@ func TestKubeSource_UnparseableResource(t *testing.T) {
 }
 
 func TestKubeSource_NonStringKey(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s, _ := setupKubeSource()
 	s.Start()
@@ -255,7 +255,7 @@ func TestKubeSource_NonStringKey(t *testing.T) {
 }
 
 func TestKubeSource_Service(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s, _ := setupKubeSourceWithK8sMeta()
 	s.Start()
@@ -270,7 +270,7 @@ func TestKubeSource_Service(t *testing.T) {
 }
 
 func TestSameNameDifferentKind(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	meta := basicmeta.MustGet2().KubeCollections()
 	col1 := meta.MustFind(basicmeta.K8SCollection1.Name().String())
@@ -294,7 +294,7 @@ func TestSameNameDifferentKind(t *testing.T) {
 }
 
 func TestKubeSource_DefaultNamespace(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s, _ := setupKubeSource()
 	s.Start()
@@ -314,7 +314,7 @@ func TestKubeSource_DefaultNamespace(t *testing.T) {
 }
 
 func TestKubeSource_DefaultNamespaceSkipClusterScoped(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := NewKubeSource(basicmeta.MustGet2().KubeCollections())
 	acc := &fixtures.Accumulator{}
@@ -334,7 +334,7 @@ func TestKubeSource_DefaultNamespaceSkipClusterScoped(t *testing.T) {
 }
 
 func TestKubeSource_CanHandleDocumentSeparatorInComments(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s, _ := setupKubeSource()
 	s.Start()

--- a/galley/pkg/config/source/kube/interfaces_test.go
+++ b/galley/pkg/config/source/kube/interfaces_test.go
@@ -39,7 +39,7 @@ func TestCreateConfig(t *testing.T) {
 }
 
 func TestNewKubeWithInvalidConfigFileShouldFail(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	_, err := kube.NewInterfacesFromConfigFile("badconfigfile")
 	g.Expect(err).ToNot(BeNil())
 }

--- a/galley/pkg/config/source/kube/rt/dynamic_test.go
+++ b/galley/pkg/config/source/kube/rt/dynamic_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func TestParseDynamic(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	input, err := yaml.ToJSON([]byte(data.YamlN1I1V1))
 	g.Expect(err).To(BeNil())
 	objMeta, objResource := parseDynamic(t, input, "Kind1")
@@ -53,13 +53,13 @@ func TestExtractObjectDynamic(t *testing.T) {
 		t.Run(r.Resource().Kind(), func(t *testing.T) {
 			t.Run("WrongTypeShouldReturnNil", func(t *testing.T) {
 				out := a.ExtractObject(struct{}{})
-				g := NewGomegaWithT(t)
+				g := NewWithT(t)
 				g.Expect(out).To(BeNil())
 			})
 
 			t.Run("Success", func(t *testing.T) {
 				out := a.ExtractObject(&unstructured.Unstructured{})
-				g := NewGomegaWithT(t)
+				g := NewWithT(t)
 				g.Expect(out).ToNot(BeNil())
 			})
 		})
@@ -73,13 +73,13 @@ func TestExtractResourceDynamic(t *testing.T) {
 		t.Run(r.Resource().Kind(), func(t *testing.T) {
 			t.Run("WrongTypeShouldReturnNil", func(t *testing.T) {
 				_, err := a.ExtractResource(struct{}{})
-				g := NewGomegaWithT(t)
+				g := NewWithT(t)
 				g.Expect(err).NotTo(BeNil())
 			})
 
 			t.Run("Success", func(t *testing.T) {
 				out, err := a.ExtractResource(&unstructured.Unstructured{})
-				g := NewGomegaWithT(t)
+				g := NewWithT(t)
 				g.Expect(err).To(BeNil())
 				g.Expect(out).ToNot(BeNil())
 			})
@@ -89,7 +89,7 @@ func TestExtractResourceDynamic(t *testing.T) {
 
 func parseDynamic(t *testing.T, input []byte, kind string) (metaV1.Object, proto.Message) {
 	t.Helper()
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	pr := rt.DefaultProvider()
 	a := pr.GetAdapter(basicmeta.MustGet().KubeCollections().MustFindByGroupVersionKind(resource.GroupVersionKind{

--- a/galley/pkg/config/source/kube/rt/known_test.go
+++ b/galley/pkg/config/source/kube/rt/known_test.go
@@ -35,7 +35,7 @@ import (
 
 func TestParse(t *testing.T) {
 	t.Run("Endpoints", func(t *testing.T) {
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 		input := data.GetEndpoints()
 
 		objMeta, objResource := parse(t, []byte(input), "", "Endpoints", "v1")
@@ -49,7 +49,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("Namespace", func(t *testing.T) {
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 		input := data.GetNamespace()
 
 		objMeta, objResource := parse(t, []byte(input), "", "Namespace", "v1")
@@ -63,7 +63,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("Ingress", func(t *testing.T) {
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 		input := data.GetIngress()
 
 		objMeta, objResource := parse(t, []byte(input), "extensions", "Ingress", "v1beta1")
@@ -77,7 +77,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("Node", func(t *testing.T) {
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 		input := data.GetNode()
 
 		objMeta, objResource := parse(t, []byte(input), "", "Node", "v1")
@@ -91,7 +91,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("Pod", func(t *testing.T) {
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 		input := data.GetPod()
 
 		objMeta, objResource := parse(t, []byte(input), "", "Pod", "v1")
@@ -105,7 +105,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("Service", func(t *testing.T) {
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 		input := data.GetService()
 
 		objMeta, objResource := parse(t, []byte(input), "", "Service", "v1")
@@ -119,7 +119,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("Deployment", func(t *testing.T) {
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 		input := data.GetDeployment()
 
 		objMeta, objResource := parse(t, []byte(input), "apps", "Deployment", "v1")
@@ -141,13 +141,13 @@ func TestExtractObject(t *testing.T) {
 		t.Run(r.Resource().Kind(), func(t *testing.T) {
 			t.Run("WrongTypeShouldReturnNil", func(t *testing.T) {
 				out := a.ExtractObject(struct{}{})
-				g := NewGomegaWithT(t)
+				g := NewWithT(t)
 				g.Expect(out).To(BeNil())
 			})
 
 			t.Run("Success", func(t *testing.T) {
 				out := a.ExtractObject(empty(r.Resource().Kind()))
-				g := NewGomegaWithT(t)
+				g := NewWithT(t)
 				g.Expect(out).ToNot(BeNil())
 			})
 		})
@@ -161,13 +161,13 @@ func TestExtractResource(t *testing.T) {
 		t.Run(r.Resource().Kind(), func(t *testing.T) {
 			t.Run("WrongTypeShouldReturnNil", func(t *testing.T) {
 				_, err := a.ExtractResource(struct{}{})
-				g := NewGomegaWithT(t)
+				g := NewWithT(t)
 				g.Expect(err).NotTo(BeNil())
 			})
 
 			t.Run("Success", func(t *testing.T) {
 				out, err := a.ExtractResource(empty(r.Resource().Kind()))
-				g := NewGomegaWithT(t)
+				g := NewWithT(t)
 				g.Expect(err).To(BeNil())
 				g.Expect(out).ToNot(BeNil())
 			})
@@ -177,7 +177,7 @@ func TestExtractResource(t *testing.T) {
 
 func parse(t *testing.T, input []byte, group, kind, version string) (metaV1.Object, proto.Message) {
 	t.Helper()
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	pr := rt.DefaultProvider()
 	a := pr.GetAdapter(k8smeta.MustGet().KubeCollections().MustFindByGroupVersionKind(resource.GroupVersionKind{

--- a/galley/pkg/config/source/kube/rt/origin_test.go
+++ b/galley/pkg/config/source/kube/rt/origin_test.go
@@ -55,7 +55,7 @@ func TestPositionString(t *testing.T) {
 	}
 	for i, tc := range testcases {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			p := Position{Filename: tc.filename, Line: tc.line}
 			g.Expect(p.String()).To(Equal(tc.output))

--- a/galley/pkg/config/source/mcp/origin_test.go
+++ b/galley/pkg/config/source/mcp/origin_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestOrigin(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	o := resource.Origin(origin("hello"))
 	g.Expect(o.Namespace()).Should(Equal(resource.Namespace("")))

--- a/galley/pkg/config/source/mcp/source_test.go
+++ b/galley/pkg/config/source/mcp/source_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestApplyUnknownCollection(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := NewSource(collection.SchemasFor())
 	s.Start()
@@ -38,7 +38,7 @@ func TestApplyUnknownCollection(t *testing.T) {
 }
 
 func TestApply(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := NewSource(collection.SchemasFor(testCollection))
 	s.Start()

--- a/galley/pkg/config/testing/fixtures/accumulator_test.go
+++ b/galley/pkg/config/testing/fixtures/accumulator_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestAccumulator(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 
 	a := &Accumulator{}
 
@@ -40,7 +40,7 @@ func TestAccumulator(t *testing.T) {
 }
 
 func TestAccumulator_Clear(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 
 	a := &Accumulator{}
 

--- a/galley/pkg/config/testing/fixtures/expect.go
+++ b/galley/pkg/config/testing/fixtures/expect.go
@@ -118,7 +118,7 @@ func ExpectNone(t *testing.T, acc *Accumulator) {
 // ExpectFilter works similar to Expect, except it filters out events based on the given function.
 func ExpectFilter(t *testing.T, acc *Accumulator, fn FilterFn, expected ...event.Event) {
 	t.Helper()
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 
 	wrapFn := func() []event.Event {
 		e := acc.Events()

--- a/galley/pkg/config/testing/fixtures/filters_test.go
+++ b/galley/pkg/config/testing/fixtures/filters_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestNoVersions(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	events := []event.Event{data.Event1Col1AddItem1}
 	g.Expect(events[0].Resource.Metadata.Version).NotTo(Equal(resource.Version("")))
@@ -35,7 +35,7 @@ func TestNoVersions(t *testing.T) {
 }
 
 func TestNoFullSync(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	events := []event.Event{data.Event1Col1AddItem1, data.Event1Col1Synced, data.Event2Col1AddItem2}
 	events = fixtures.NoFullSync(events)
@@ -45,7 +45,7 @@ func TestNoFullSync(t *testing.T) {
 }
 
 func TestSort(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	events := []event.Event{data.Event2Col1AddItem2, data.Event1Col1Synced, data.Event1Col1AddItem1}
 	events = fixtures.Sort(events)
@@ -55,7 +55,7 @@ func TestSort(t *testing.T) {
 }
 
 func TestChain(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	events := []event.Event{data.Event2Col1AddItem2, data.Event1Col1Synced, data.Event1Col1AddItem1}
 	fn := fixtures.Chain(fixtures.Sort, fixtures.NoFullSync, fixtures.NoVersions)

--- a/galley/pkg/config/testing/fixtures/listener_test.go
+++ b/galley/pkg/config/testing/fixtures/listener_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestDispatcher(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 
 	d := &Listener{}
 

--- a/galley/pkg/config/testing/fixtures/source_test.go
+++ b/galley/pkg/config/testing/fixtures/source_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestSource(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 
 	s := &Source{}
 
@@ -36,7 +36,7 @@ func TestSource(t *testing.T) {
 }
 
 func TestSource_Dispatch(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 
 	a := &Accumulator{}
 
@@ -48,7 +48,7 @@ func TestSource_Dispatch(t *testing.T) {
 }
 
 func TestSource_Handle(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 
 	s := &Source{}
 

--- a/galley/pkg/config/util/kubeyaml/kubeyaml_test.go
+++ b/galley/pkg/config/util/kubeyaml/kubeyaml_test.go
@@ -83,7 +83,7 @@ yaml: foo`,
 func TestJoinBytes(t *testing.T) {
 	for i, c := range joinCases {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			var by [][]byte
 			for _, s := range c.split {
@@ -99,7 +99,7 @@ func TestJoinBytes(t *testing.T) {
 func TestJoinString(t *testing.T) {
 	for i, c := range joinCases {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			actual := JoinString(c.split...)
 
@@ -128,7 +128,7 @@ func TestLineNumber(t *testing.T) {
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			reader := bufio.NewReader(strings.NewReader(tc.input))
 			decoder := NewYAMLReader(reader)

--- a/galley/pkg/config/util/pb/proto_test.go
+++ b/galley/pkg/config/util/pb/proto_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestToProto_Success(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	data := map[string]interface{}{
 		"foo": "bar",
@@ -47,7 +47,7 @@ func TestToProto_Success(t *testing.T) {
 }
 
 func TestToProto_UnknownFields(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	data := map[string]interface{}{
 		"foo": "bar",
@@ -63,7 +63,7 @@ func TestToProto_UnknownFields(t *testing.T) {
 }
 
 func TestToProto_Error(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	data := map[string]interface{}{
 		"value": 23,

--- a/galley/pkg/server/components/processing_test.go
+++ b/galley/pkg/server/components/processing_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 func TestProcessing_StartErrors(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	defer resetPatchTable()
 
 loop:
@@ -87,7 +87,7 @@ loop:
 }
 
 func TestProcessing_Basic(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	resetPatchTable()
 	defer resetPatchTable()
 

--- a/istioctl/cmd/analyze_test.go
+++ b/istioctl/cmd/analyze_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestErrorOnIssuesFound(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	msgs := []diag.Message{
 		diag.NewMessage(
@@ -44,7 +44,7 @@ func TestErrorOnIssuesFound(t *testing.T) {
 }
 
 func TestNoErrorIfMessageLevelsBelowThreshold(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	msgs := []diag.Message{
 		diag.NewMessage(

--- a/istioctl/pkg/multicluster/cluster_test.go
+++ b/istioctl/pkg/multicluster/cluster_test.go
@@ -543,7 +543,7 @@ func serviceStatus(addresses ...address) *v1.ServiceStatus {
 }
 
 func TestReadIngressGatewayAddresses(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	applyTestCases := []struct {
 		in      *v1.ServiceStatus

--- a/istioctl/pkg/multicluster/remote_secret_test.go
+++ b/istioctl/pkg/multicluster/remote_secret_test.go
@@ -652,7 +652,7 @@ users:
 }
 
 func TestRemoteSecretOptions(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	o := RemoteSecretOptions{}
 	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -78,7 +78,7 @@ type testGroup []struct {
 }
 
 func TestManifestGenerateComponentHubTag(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	objs, err := runManifestCommands("component_hub_tag", "", liveCharts)
 	if err != nil {
@@ -115,7 +115,7 @@ func TestManifestGenerateComponentHubTag(t *testing.T) {
 }
 
 func TestManifestGenerateGateways(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	flags := "-s components.ingressGateways.[0].k8s.resources.requests.memory=999Mi " +
 		"-s components.ingressGateways.[name:user-ingressgateway].k8s.resources.requests.cpu=555m"
@@ -170,7 +170,7 @@ func TestManifestGenerateGateways(t *testing.T) {
 }
 
 func TestManifestGenerateIstiodRemote(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	objss, err := runManifestCommands("istiod_remote", "", liveCharts)
 	if err != nil {
@@ -211,7 +211,7 @@ func TestManifestGenerateIstiodRemote(t *testing.T) {
 }
 
 func TestManifestGenerateAllOff(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	m, _, err := generateManifest("all_off", "", liveCharts)
 	if err != nil {
 		t.Fatal(err)
@@ -224,7 +224,7 @@ func TestManifestGenerateAllOff(t *testing.T) {
 }
 
 func TestManifestGenerateFlagsMinimalProfile(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	// Change profile from empty to minimal using flag.
 	m, _, err := generateManifest("empty", "-s profile=minimal", liveCharts)
 	if err != nil {
@@ -239,7 +239,7 @@ func TestManifestGenerateFlagsMinimalProfile(t *testing.T) {
 }
 
 func TestManifestGenerateFlagsSetHubTag(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	m, _, err := generateManifest("minimal", "-s hub=foo -s tag=bar", liveCharts)
 	if err != nil {
 		t.Fatal(err)
@@ -256,7 +256,7 @@ func TestManifestGenerateFlagsSetHubTag(t *testing.T) {
 }
 
 func TestManifestGenerateFlagsSetValues(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	m, _, err := generateManifest("default", "-s values.global.proxy.image=myproxy -s values.global.proxy.includeIPRanges=172.30.0.0/16,172.21.0.0/16", liveCharts)
 	if err != nil {
 		t.Fatal(err)

--- a/pilot/cmd/pilot-agent/main_test.go
+++ b/pilot/cmd/pilot-agent/main_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestPilotDefaultDomainKubernetes(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 	role = &model.Proxy{}
 	role.DNSDomain = ""
 	registryID = serviceregistry.Kubernetes
@@ -35,7 +35,7 @@ func TestPilotDefaultDomainKubernetes(t *testing.T) {
 }
 
 func TestPilotDefaultDomainConsul(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 	role := &model.Proxy{}
 	role.DNSDomain = ""
 	registryID = serviceregistry.Consul
@@ -46,7 +46,7 @@ func TestPilotDefaultDomainConsul(t *testing.T) {
 }
 
 func TestPilotDefaultDomainOthers(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 	role = &model.Proxy{}
 	role.DNSDomain = ""
 	registryID = serviceregistry.Mock
@@ -57,7 +57,7 @@ func TestPilotDefaultDomainOthers(t *testing.T) {
 }
 
 func TestPilotDomain(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 	role.DNSDomain = "my.domain"
 	registryID = serviceregistry.Mock
 

--- a/pilot/cmd/pilot-agent/status/ready/probe_test.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe_test.go
@@ -31,7 +31,7 @@ var (
 )
 
 func TestEnvoyStatsCompleteAndSuccessful(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	server := createAndStartServer(liveServerStats)
 	defer server.Close()
@@ -109,7 +109,7 @@ server.state: 0`,
 }
 
 func TestEnvoyInitializing(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	server := createAndStartServer(initServerStats)
 	defer server.Close()
@@ -121,7 +121,7 @@ func TestEnvoyInitializing(t *testing.T) {
 }
 
 func TestEnvoyNoClusterManagerStats(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	server := createAndStartServer(onlyServerStats)
 	defer server.Close()
@@ -133,7 +133,7 @@ func TestEnvoyNoClusterManagerStats(t *testing.T) {
 }
 
 func TestEnvoyNoServerStats(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	server := createAndStartServer(noServerStats)
 	defer server.Close()

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -86,7 +86,7 @@ func TestReloadIstiodCert(t *testing.T) {
 		t.Fatalf("WriteFile(%v) failed: %v", tlsOptions.KeyFile, err)
 	}
 
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	// Validate that istiod cert is updated.
 	g.Eventually(func() bool {
@@ -153,7 +153,7 @@ func TestNewServer(t *testing.T) {
 				p.ShutdownDuration = 1 * time.Millisecond
 			})
 
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 			s, err := NewServer(args)
 			g.Expect(err).To(Succeed())
 

--- a/pilot/pkg/config/aggregate/config_test.go
+++ b/pilot/pkg/config/aggregate/config_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestAggregateStoreBasicMake(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 
 	schema1 := collections.K8SServiceApisV1Alpha1Httproutes
 	schema2 := collections.K8SServiceApisV1Alpha1Gatewayclasses
@@ -52,7 +52,7 @@ func TestAggregateStoreBasicMake(t *testing.T) {
 }
 
 func TestAggregateStoreMakeValidationFailure(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 
 	store1 := memory.Make(collection.SchemasFor(schemaFor("SomeConfig", "broken message name")))
 
@@ -64,7 +64,7 @@ func TestAggregateStoreMakeValidationFailure(t *testing.T) {
 }
 
 func TestAggregateStoreGet(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 
 	store1 := memory.Make(collection.SchemasFor(collections.K8SServiceApisV1Alpha1Gatewayclasses))
 	store2 := memory.Make(collection.SchemasFor(collections.K8SServiceApisV1Alpha1Gatewayclasses))
@@ -88,7 +88,7 @@ func TestAggregateStoreGet(t *testing.T) {
 }
 
 func TestAggregateStoreList(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 
 	store1 := memory.Make(collection.SchemasFor(collections.K8SServiceApisV1Alpha1Httproutes))
 	store2 := memory.Make(collection.SchemasFor(collections.K8SServiceApisV1Alpha1Httproutes))
@@ -121,7 +121,7 @@ func TestAggregateStoreList(t *testing.T) {
 }
 
 func TestAggregateStoreFails(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 
 	store1 := memory.Make(collection.SchemasFor(schemaFor("OtherConfig", "istio.networking.v1alpha3.Gateway")))
 
@@ -131,14 +131,14 @@ func TestAggregateStoreFails(t *testing.T) {
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	t.Run("Fails to Delete", func(t *testing.T) {
-		g := gomega.NewGomegaWithT(t)
+		g := gomega.NewWithT(t)
 
 		err = store.Delete(resource.GroupVersionKind{Kind: "not"}, "gonna", "work")
 		g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("unsupported operation")))
 	})
 
 	t.Run("Fails to Create", func(t *testing.T) {
-		g := gomega.NewGomegaWithT(t)
+		g := gomega.NewWithT(t)
 
 		c, err := store.Create(model.Config{})
 		g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("unsupported operation")))
@@ -146,7 +146,7 @@ func TestAggregateStoreFails(t *testing.T) {
 	})
 
 	t.Run("Fails to Update", func(t *testing.T) {
-		g := gomega.NewGomegaWithT(t)
+		g := gomega.NewWithT(t)
 
 		c, err := store.Update(model.Config{})
 		g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("unsupported operation")))

--- a/pilot/pkg/config/kube/gateway/controller_test.go
+++ b/pilot/pkg/config/kube/gateway/controller_test.go
@@ -82,7 +82,7 @@ var (
 )
 
 func TestListInvalidGroupVersionKind(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	clientSet := fake.NewSimpleClientset()
 	store := memory.NewController(memory.Make(collections.All))
 	controller := NewController(clientSet, store, controller2.Options{})
@@ -94,7 +94,7 @@ func TestListInvalidGroupVersionKind(t *testing.T) {
 }
 
 func TestListGatewayResourceType(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	clientSet := fake.NewSimpleClientset()
 	store := memory.NewController(memory.Make(collections.All))
@@ -143,7 +143,7 @@ func TestListGatewayResourceType(t *testing.T) {
 }
 
 func TestListVirtualServiceResourceType(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	clientSet := fake.NewSimpleClientset()
 	store := memory.NewController(memory.Make(collections.All))

--- a/pilot/pkg/config/monitor/file_snapshot_test.go
+++ b/pilot/pkg/config/monitor/file_snapshot_test.go
@@ -61,7 +61,7 @@ spec:
 `
 
 func TestFileSnapshotNoFilter(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 
 	ts := &testState{
 		ConfigFiles: map[string][]byte{"gateway.yml": []byte(gatewayYAML)},
@@ -83,7 +83,7 @@ func TestFileSnapshotNoFilter(t *testing.T) {
 }
 
 func TestFileSnapshotWithFilter(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 
 	ts := &testState{
 		ConfigFiles: map[string][]byte{
@@ -105,7 +105,7 @@ func TestFileSnapshotWithFilter(t *testing.T) {
 }
 
 func TestFileSnapshotSorting(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 
 	ts := &testState{
 		ConfigFiles: map[string][]byte{

--- a/pilot/pkg/config/monitor/monitor_test.go
+++ b/pilot/pkg/config/monitor/monitor_test.go
@@ -73,7 +73,7 @@ var updateConfigSet = []*model.Config{
 }
 
 func TestMonitorForChange(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 
 	store := memory.Make(collection.SchemasFor(collections.IstioNetworkingV1Alpha3Gateways))
 
@@ -145,7 +145,7 @@ func TestMonitorForChange(t *testing.T) {
 }
 
 func TestMonitorForError(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 
 	store := memory.Make(collection.SchemasFor(collections.IstioNetworkingV1Alpha3Gateways))
 

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -914,7 +914,7 @@ func TestIsClusterLocal(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			env := &Environment{Watcher: mesh.NewFixedWatcher(&c.m)}
 			push := &PushContext{

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -100,7 +100,7 @@ func TestHTTPCircuitBreakerThresholds(t *testing.T) {
 			testName = "override"
 		}
 		t.Run(testName, func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 			clusters, err := buildTestClusters("*.example.org", 0, model.SidecarProxy, nil, testMesh,
 				&networking.DestinationRule{
 					Host: "*.example.org",
@@ -135,7 +135,7 @@ func TestHTTPCircuitBreakerThresholds(t *testing.T) {
 }
 
 func TestCommonHttpProtocolOptions(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	cases := []struct {
 		direction                  model.TrafficDirection
@@ -450,7 +450,7 @@ func buildTestClustersWithProxyMetadataWithIps(serviceHostname string, serviceRe
 }
 
 func TestBuildGatewayClustersWithRingHashLb(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	ttl := types.Duration{Nanos: 100}
 	clusters, err := buildTestClusters("*.example.org", 0, model.Router, nil, testMesh,
@@ -484,7 +484,7 @@ func TestBuildGatewayClustersWithRingHashLb(t *testing.T) {
 }
 
 func TestBuildGatewayClustersWithRingHashLbDefaultMinRingSize(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	ttl := types.Duration{Nanos: 100}
 	clusters, err := buildTestClusters("*.example.org", 0, model.Router, nil, testMesh,
@@ -541,7 +541,7 @@ func withClusterLocalHosts(m meshconfig.MeshConfig, hosts ...string) meshconfig.
 }
 
 func TestBuildSidecarClustersWithIstioMutualAndSNI(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	clusters, err := buildSniTestClustersForSidecar("foo.com")
 	g.Expect(err).NotTo(HaveOccurred())
@@ -567,7 +567,7 @@ func TestBuildClustersWithMutualTlsAndNodeMetadataCertfileOverrides(t *testing.T
 	expectedClientCertPath := "/clientCertFromNodeMetadata.pem"
 	expectedRootCertPath := "/clientRootCertFromNodeMetadata.pem"
 
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	envoyMetadata := &model.NodeMetadata{
 		TLSClientCertChain: expectedClientCertPath,
@@ -673,7 +673,7 @@ func buildSniTestClustersWithMetadata(sniValue string, typ model.NodeType, meta 
 }
 
 func TestBuildSidecarClustersWithMeshWideTCPKeepalive(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	// Do not set tcp_keepalive anywhere
 	clusters, err := buildTestClustersWithTCPKeepalive(None)
@@ -775,7 +775,7 @@ func buildTestClustersWithTCPKeepalive(configType ConfigType) ([]*cluster.Cluste
 }
 
 func TestClusterMetadata(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	destRule := &networking.DestinationRule{
 		Host: "*.example.org",
@@ -1031,7 +1031,7 @@ func TestConditionallyConvertToIstioMtls(t *testing.T) {
 }
 
 func TestDisablePanicThresholdAsDefault(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	outliers := []*networking.OutlierDetection{
 		// Unset MinHealthPercent
@@ -1058,7 +1058,7 @@ func TestDisablePanicThresholdAsDefault(t *testing.T) {
 }
 
 func TestApplyOutlierDetection(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	tests := []struct {
 		name string
@@ -1154,7 +1154,7 @@ func TestApplyOutlierDetection(t *testing.T) {
 }
 
 func TestStatNamePattern(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	statConfigMesh := meshconfig.MeshConfig{
 		ConnectTimeout: &types.Duration{
@@ -1179,7 +1179,7 @@ func TestStatNamePattern(t *testing.T) {
 }
 
 func TestDuplicateClusters(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	clusters, err := buildTestClusters("*.example.org", model.DNSLB, model.SidecarProxy,
 		&core.Locality{}, testMesh,
@@ -1191,7 +1191,7 @@ func TestDuplicateClusters(t *testing.T) {
 }
 
 func TestSidecarLocalityLB(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	// Distribute locality loadbalancing setting
 	testMesh.LocalityLbSetting = &networking.LocalityLoadBalancerSetting{
 		Distribute: []*networking.LocalityLoadBalancerSetting_Distribute{
@@ -1280,7 +1280,7 @@ func TestSidecarLocalityLB(t *testing.T) {
 }
 
 func TestLocalityLBDestinationRuleOverride(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	// Distribute locality loadbalancing setting
 	testMesh.LocalityLbSetting = &networking.LocalityLoadBalancerSetting{
 		Distribute: []*networking.LocalityLoadBalancerSetting_Distribute{
@@ -1344,7 +1344,7 @@ func TestLocalityLBDestinationRuleOverride(t *testing.T) {
 }
 
 func TestGatewayLocalityLB(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	// Distribute locality loadbalancing setting
 	testMesh.LocalityLbSetting = &networking.LocalityLoadBalancerSetting{
 		Distribute: []*networking.LocalityLoadBalancerSetting_Distribute{
@@ -1502,7 +1502,7 @@ func TestFindServiceInstanceForIngressListener(t *testing.T) {
 }
 
 func TestClusterDiscoveryTypeAndLbPolicyRoundRobin(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	clusters, err := buildTestClusters("*.example.org", model.Passthrough, model.SidecarProxy, nil, testMesh,
 		&networking.DestinationRule{
@@ -1522,7 +1522,7 @@ func TestClusterDiscoveryTypeAndLbPolicyRoundRobin(t *testing.T) {
 }
 
 func TestClusterDiscoveryTypeAndLbPolicyPassthrough(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	clusters, err := buildTestClusters("*.example.org", model.ClientSideLB, model.SidecarProxy, nil, testMesh,
 		&networking.DestinationRule{
@@ -1543,7 +1543,7 @@ func TestClusterDiscoveryTypeAndLbPolicyPassthrough(t *testing.T) {
 }
 
 func TestBuildClustersDefaultCircuitBreakerThresholds(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	configgen := NewConfigGenerator([]plugin.Plugin{})
 	serviceDiscovery := memregistry.NewServiceDiscovery(nil)
@@ -1566,7 +1566,7 @@ func TestBuildClustersDefaultCircuitBreakerThresholds(t *testing.T) {
 }
 
 func TestBuildInboundClustersDefaultCircuitBreakerThresholds(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	configgen := NewConfigGenerator([]plugin.Plugin{})
 	serviceDiscovery := memregistry.NewServiceDiscovery(nil)
@@ -1613,7 +1613,7 @@ func TestBuildInboundClustersDefaultCircuitBreakerThresholds(t *testing.T) {
 }
 
 func TestBuildInboundClustersPortLevelCircuitBreakerThresholds(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	proxy := &model.Proxy{
 		Metadata:     &model.NodeMetadata{},
@@ -1752,7 +1752,7 @@ func TestBuildInboundClustersPortLevelCircuitBreakerThresholds(t *testing.T) {
 }
 
 func TestRedisProtocolWithPassThroughResolutionAtGateway(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	configgen := NewConfigGenerator([]plugin.Plugin{})
 
@@ -1787,7 +1787,7 @@ func TestRedisProtocolWithPassThroughResolutionAtGateway(t *testing.T) {
 }
 
 func TestRedisProtocolClusterAtGateway(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	configgen := NewConfigGenerator([]plugin.Plugin{})
 
@@ -1832,7 +1832,7 @@ func TestRedisProtocolClusterAtGateway(t *testing.T) {
 }
 
 func TestAutoMTLSClusterSubsets(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	destRule := &networking.DestinationRule{
 		Host: TestServiceNHostname,
@@ -1879,7 +1879,7 @@ func TestAutoMTLSClusterSubsets(t *testing.T) {
 }
 
 func TestAutoMTLSClusterIgnoreWorkloadLevelPeerAuthn(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	destRule := &networking.DestinationRule{
 		Host: TestServiceNHostname,
@@ -3547,7 +3547,7 @@ func getTLSContext(t *testing.T, c *cluster.Cluster) *tls.UpstreamTlsContext {
 }
 
 func TestBuildStaticClusterWithNoEndPoint(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	cfg := NewConfigGenerator([]plugin.Plugin{})
 	service := &model.Service{

--- a/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer_test.go
@@ -80,7 +80,7 @@ func TestApplyLocalitySetting(t *testing.T) {
 	})
 
 	t.Run("Failover: all priorities", func(t *testing.T) {
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 		env := buildEnvForClustersWithFailover()
 		cluster := buildFakeCluster()
 		ApplyLocalityLBSetting(locality, cluster.LoadAssignment, env.Mesh().LocalityLbSetting, true)
@@ -106,7 +106,7 @@ func TestApplyLocalitySetting(t *testing.T) {
 	})
 
 	t.Run("Failover: priorities with gaps", func(t *testing.T) {
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 		env := buildEnvForClustersWithFailover()
 		cluster := buildSmallCluster()
 		ApplyLocalityLBSetting(locality, cluster.LoadAssignment, env.Mesh().LocalityLbSetting, true)
@@ -132,7 +132,7 @@ func TestApplyLocalitySetting(t *testing.T) {
 	})
 
 	t.Run("Failover: priorities with some nil localities", func(t *testing.T) {
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 		env := buildEnvForClustersWithFailover()
 		cluster := buildSmallClusterWithNilLocalities()
 		ApplyLocalityLBSetting(locality, cluster.LoadAssignment, env.Mesh().LocalityLbSetting, true)
@@ -159,7 +159,7 @@ func TestApplyLocalitySetting(t *testing.T) {
 	})
 
 	t.Run("Failover: with locality lb disabled", func(t *testing.T) {
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 		cluster := buildSmallClusterWithNilLocalities()
 		lbsetting := &networking.LocalityLoadBalancerSetting{
 			Enabled: &types.BoolValue{Value: false},

--- a/pilot/pkg/networking/core/v1alpha3/route/retry/retry_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/retry/retry_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func TestNilRetryShouldReturnDefault(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	// Create a route where no retry policy has been explicitly set.
 	route := networking.HTTPRoute{}
@@ -43,7 +43,7 @@ func TestNilRetryShouldReturnDefault(t *testing.T) {
 }
 
 func TestZeroAttemptsShouldReturnNilPolicy(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	// Create a route with a retry policy with zero attempts configured.
 	route := networking.HTTPRoute{
@@ -58,7 +58,7 @@ func TestZeroAttemptsShouldReturnNilPolicy(t *testing.T) {
 }
 
 func TestRetryWithAllFieldsSet(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	// Create a route with a retry policy with zero attempts configured.
 	route := networking.HTTPRoute{
@@ -81,7 +81,7 @@ func TestRetryWithAllFieldsSet(t *testing.T) {
 }
 
 func TestRetryOnWithEmptyParts(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	// Create a route with a retry policy with zero attempts configured.
 	route := networking.HTTPRoute{
@@ -99,7 +99,7 @@ func TestRetryOnWithEmptyParts(t *testing.T) {
 }
 
 func TestRetryOnWithWhitespace(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	// Create a route with a retry policy with zero attempts configured.
 	route := networking.HTTPRoute{
@@ -117,7 +117,7 @@ func TestRetryOnWithWhitespace(t *testing.T) {
 }
 
 func TestRetryOnContainingStatusCodes(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	// Create a route with a retry policy with zero attempts configured.
 	route := networking.HTTPRoute{
@@ -134,7 +134,7 @@ func TestRetryOnContainingStatusCodes(t *testing.T) {
 }
 
 func TestRetryOnWithInvalidStatusCodesShouldAddToRetryOn(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	// Create a route with a retry policy with zero attempts configured.
 	route := networking.HTTPRoute{
@@ -151,7 +151,7 @@ func TestRetryOnWithInvalidStatusCodesShouldAddToRetryOn(t *testing.T) {
 }
 
 func TestMissingRetryOnShouldReturnDefaults(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	// Create a route with a retry policy with zero attempts configured.
 	route := networking.HTTPRoute{
@@ -167,7 +167,7 @@ func TestMissingRetryOnShouldReturnDefaults(t *testing.T) {
 }
 
 func TestMissingPerTryTimeoutShouldReturnNil(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	// Create a route with a retry policy with zero attempts configured.
 	route := networking.HTTPRoute{
@@ -182,7 +182,7 @@ func TestMissingPerTryTimeoutShouldReturnNil(t *testing.T) {
 }
 
 func TestRetryRemoteLocalities(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	// Create a route with a retry policy with RetryRemoteLocalities enabled.
 	route := networking.HTTPRoute{

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -76,7 +76,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	gatewayNames := map[string]bool{"some-gateway": true}
 
 	t.Run("for virtual service", func(t *testing.T) {
-		g := gomega.NewGomegaWithT(t)
+		g := gomega.NewWithT(t)
 
 		os.Setenv("ISTIO_DEFAULT_REQUEST_TIMEOUT", "0ms")
 		defer os.Unsetenv("ISTIO_DEFAULT_REQUEST_TIMEOUT")
@@ -97,7 +97,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	})
 
 	t.Run("for virtual service with changed default timeout", func(t *testing.T) {
-		g := gomega.NewGomegaWithT(t)
+		g := gomega.NewWithT(t)
 
 		dt := features.DefaultRequestTimeout
 		features.DefaultRequestTimeout = ptypes.DurationProto(1 * time.Second)
@@ -119,7 +119,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	})
 
 	t.Run("for virtual service with timeout", func(t *testing.T) {
-		g := gomega.NewGomegaWithT(t)
+		g := gomega.NewWithT(t)
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node, nil, virtualServiceWithTimeout, serviceRegistry, 8080, gatewayNames)
 		// Valiate routes.
@@ -137,7 +137,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	})
 
 	t.Run("for virtual service with disabled timeout", func(t *testing.T) {
-		g := gomega.NewGomegaWithT(t)
+		g := gomega.NewWithT(t)
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node, nil, virtualServiceWithTimeoutDisabled, serviceRegistry, 8080, gatewayNames)
 		// Valiate routes.
@@ -154,7 +154,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	})
 
 	t.Run("for virtual service with catch all route", func(t *testing.T) {
-		g := gomega.NewGomegaWithT(t)
+		g := gomega.NewWithT(t)
 		routes, err := route.BuildHTTPRoutesForVirtualService(node, nil, virtualServiceWithCatchAllRoute, serviceRegistry, 8080, gatewayNames)
 		// Valiate routes.
 		for _, r := range routes {
@@ -167,7 +167,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	})
 
 	t.Run("for virtual service with top level catch all route", func(t *testing.T) {
-		g := gomega.NewGomegaWithT(t)
+		g := gomega.NewWithT(t)
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node, nil, virtualServiceWithCatchAllRouteWeightedDestination, serviceRegistry, 8080, gatewayNames)
 		// Valiate routes.
@@ -181,7 +181,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	})
 
 	t.Run("for virtual service with multi prefix catch all route", func(t *testing.T) {
-		g := gomega.NewGomegaWithT(t)
+		g := gomega.NewWithT(t)
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node, nil, virtualServiceWithCatchAllMultiPrefixRoute, serviceRegistry, 8080, gatewayNames)
 		// Valiate routes.
@@ -195,7 +195,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	})
 
 	t.Run("for virtual service with regex matching on URI", func(t *testing.T) {
-		g := gomega.NewGomegaWithT(t)
+		g := gomega.NewWithT(t)
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node, nil, virtualServiceWithRegexMatchingOnURI, serviceRegistry, 8080, gatewayNames)
 		// Valiate routes.
@@ -212,7 +212,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	})
 
 	t.Run("for virtual service with regex matching on URI with 1.6 proxy", func(t *testing.T) {
-		g := gomega.NewGomegaWithT(t)
+		g := gomega.NewWithT(t)
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node16, nil, virtualServiceWithRegexMatchingOnURI, serviceRegistry, 8080, gatewayNames)
 		// Valiate routes.
@@ -229,7 +229,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	})
 
 	t.Run("for virtual service with regex matching on header", func(t *testing.T) {
-		g := gomega.NewGomegaWithT(t)
+		g := gomega.NewWithT(t)
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node, nil, virtualServiceWithRegexMatchingOnHeader, serviceRegistry, 8080, gatewayNames)
 		// Valiate routes.
@@ -244,7 +244,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	})
 
 	t.Run("for virtual service with regex matching on without_header", func(t *testing.T) {
-		g := gomega.NewGomegaWithT(t)
+		g := gomega.NewWithT(t)
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node, nil, virtualServiceWithRegexMatchingOnWithoutHeader, serviceRegistry, 8080, gatewayNames)
 		// Valiate routes.
@@ -260,7 +260,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	})
 
 	t.Run("for virtual service with presence matching on header", func(t *testing.T) {
-		g := gomega.NewGomegaWithT(t)
+		g := gomega.NewWithT(t)
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node, nil, virtualServiceWithPresentMatchingOnHeader, serviceRegistry, 8080, gatewayNames)
 		// Valiate routes.
@@ -277,7 +277,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	})
 
 	t.Run("for virtual service with presence matching on header and without_header", func(t *testing.T) {
-		g := gomega.NewGomegaWithT(t)
+		g := gomega.NewWithT(t)
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node, nil, virtualServiceWithPresentMatchingOnWithoutHeader, serviceRegistry, 8080, gatewayNames)
 		// Valiate routes.
@@ -298,7 +298,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		cset := createVirtualServiceWithRegexMatchingForAllCasesOnHeader()
 
 		for _, c := range cset {
-			g := gomega.NewGomegaWithT(t)
+			g := gomega.NewWithT(t)
 			routes, err := route.BuildHTTPRoutesForVirtualService(node, nil, *c, serviceRegistry, 8080, gatewayNames)
 			// Valiate routes.
 			for _, r := range routes {
@@ -315,7 +315,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	})
 
 	t.Run("for virtual service with source namespace matching", func(t *testing.T) {
-		g := gomega.NewGomegaWithT(t)
+		g := gomega.NewWithT(t)
 
 		fooNode := *node
 		fooNode.Metadata = &model.NodeMetadata{
@@ -344,7 +344,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	})
 
 	t.Run("for virtual service with ring hash", func(t *testing.T) {
-		g := gomega.NewGomegaWithT(t)
+		g := gomega.NewWithT(t)
 
 		ttl := types.Duration{Nanos: 100}
 		meshConfig := mesh.DefaultMeshConfig()
@@ -399,7 +399,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	})
 
 	t.Run("for virtual service with query param based ring hash", func(t *testing.T) {
-		g := gomega.NewGomegaWithT(t)
+		g := gomega.NewWithT(t)
 
 		meshConfig := mesh.DefaultMeshConfig()
 		push := &model.PushContext{
@@ -449,7 +449,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	})
 
 	t.Run("for virtual service with subsets with ring hash", func(t *testing.T) {
-		g := gomega.NewGomegaWithT(t)
+		g := gomega.NewWithT(t)
 
 		virtualService := model.Config{
 			ConfigMeta: model.ConfigMeta{
@@ -498,7 +498,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	})
 
 	t.Run("for virtual service with subsets with port level settings with ring hash", func(t *testing.T) {
-		g := gomega.NewGomegaWithT(t)
+		g := gomega.NewWithT(t)
 
 		virtualService := model.Config{ConfigMeta: model.ConfigMeta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
@@ -544,7 +544,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	})
 
 	t.Run("for virtual service with subsets and top level traffic policy with ring hash", func(t *testing.T) {
-		g := gomega.NewGomegaWithT(t)
+		g := gomega.NewWithT(t)
 
 		virtualService := model.Config{
 			ConfigMeta: model.ConfigMeta{
@@ -594,7 +594,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	})
 
 	t.Run("port selector based traffic policy", func(t *testing.T) {
-		g := gomega.NewGomegaWithT(t)
+		g := gomega.NewWithT(t)
 
 		meshConfig := mesh.DefaultMeshConfig()
 		push := &model.PushContext{
@@ -633,7 +633,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	})
 
 	t.Run("for header operations", func(t *testing.T) {
-		g := gomega.NewGomegaWithT(t)
+		g := gomega.NewWithT(t)
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node, nil, virtualServiceWithHeaderOperations,
 			serviceRegistry, 8080, gatewayNames)
@@ -718,7 +718,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	})
 
 	t.Run("for redirect code", func(t *testing.T) {
-		g := gomega.NewGomegaWithT(t)
+		g := gomega.NewWithT(t)
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node, nil, virtualServiceWithRedirect,
 			serviceRegistry, 8080, gatewayNames)
@@ -737,7 +737,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	})
 
 	t.Run("for redirect and header manipulation", func(t *testing.T) {
-		g := gomega.NewGomegaWithT(t)
+		g := gomega.NewWithT(t)
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node, nil, virtualServiceWithRedirectAndSetHeader,
 			serviceRegistry, 8080, gatewayNames)
@@ -761,7 +761,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	})
 
 	t.Run("for no virtualservice but has destinationrule with consistentHash loadbalancer", func(t *testing.T) {
-		g := gomega.NewGomegaWithT(t)
+		g := gomega.NewWithT(t)
 		meshConfig := mesh.DefaultMeshConfig()
 		push := &model.PushContext{
 			Mesh: &meshConfig,
@@ -778,7 +778,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(vhosts[0].Routes[0].Action.(*envoyroute.Route_Route).Route.HashPolicy).NotTo(gomega.BeNil())
 	})
 	t.Run("for no virtualservice but has destinationrule with portLevel consistentHash loadbalancer", func(t *testing.T) {
-		g := gomega.NewGomegaWithT(t)
+		g := gomega.NewWithT(t)
 		meshConfig := mesh.DefaultMeshConfig()
 		push := &model.PushContext{
 			Mesh: &meshConfig,

--- a/pilot/pkg/serviceregistry/mcp/controller_test.go
+++ b/pilot/pkg/serviceregistry/mcp/controller_test.go
@@ -105,7 +105,7 @@ var (
 )
 
 func TestOptions(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	controller := mcp.NewController(testControllerOptions)
 
@@ -129,21 +129,21 @@ func TestOptions(t *testing.T) {
 }
 
 func TestHasSynced(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	controller := mcp.NewController(testControllerOptions)
 
 	g.Expect(controller.HasSynced()).To(BeFalse())
 }
 
 func TestConfigDescriptor(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	controller := mcp.NewController(testControllerOptions)
 	schemas := controller.Schemas()
 	g.Expect(schemas.CollectionNames()).Should(ConsistOf(collections.Pilot.CollectionNames()))
 }
 
 func TestListInvalidType(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	controller := mcp.NewController(testControllerOptions)
 
 	c, err := controller.List(resource.GroupVersionKind{Kind: "bad-type"}, "some-phony-name-space.com")
@@ -153,7 +153,7 @@ func TestListInvalidType(t *testing.T) {
 }
 
 func TestListCorrectTypeNoData(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	controller := mcp.NewController(testControllerOptions)
 
 	c, err := controller.List(gvk.VirtualService,
@@ -163,7 +163,7 @@ func TestListCorrectTypeNoData(t *testing.T) {
 }
 
 func TestListAllNameSpace(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	fx := NewFakeXDS()
 	testControllerOptions.XDSUpdater = fx
@@ -204,7 +204,7 @@ func TestListAllNameSpace(t *testing.T) {
 }
 
 func TestListSpecificNameSpace(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	controller := mcp.NewController(testControllerOptions)
 
 	messages := convertToResources(g,
@@ -239,7 +239,7 @@ func TestListSpecificNameSpace(t *testing.T) {
 }
 
 func TestApplyInvalidType(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	controller := mcp.NewController(testControllerOptions)
 
 	message := convertToResource(g,
@@ -257,7 +257,7 @@ func TestApplyInvalidType(t *testing.T) {
 }
 
 func TestApplyValidTypeWithNoNamespace(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	controller := mcp.NewController(testControllerOptions)
 
 	var createAndCheckGateway = func(g *GomegaWithT, controller mcp.Controller, port uint32) {
@@ -300,7 +300,7 @@ func TestApplyValidTypeWithNoNamespace(t *testing.T) {
 }
 
 func TestApplyMetadataNameIncludesNamespace(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	controller := mcp.NewController(testControllerOptions)
 
 	message := convertToResource(g,
@@ -324,7 +324,7 @@ func TestApplyMetadataNameIncludesNamespace(t *testing.T) {
 }
 
 func TestApplyMetadataNameWithoutNamespace(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	controller := mcp.NewController(testControllerOptions)
 
 	message := convertToResource(g,
@@ -348,7 +348,7 @@ func TestApplyMetadataNameWithoutNamespace(t *testing.T) {
 }
 
 func TestApplyChangeNoObjects(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	fx := NewFakeXDS()
 	testControllerOptions.XDSUpdater = fx
@@ -385,7 +385,7 @@ func TestApplyChangeNoObjects(t *testing.T) {
 }
 
 func TestApplyConfigUpdate(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	fx := NewFakeXDS()
 	testControllerOptions.XDSUpdater = fx
@@ -408,7 +408,7 @@ func TestApplyConfigUpdate(t *testing.T) {
 }
 
 func TestInvalidResource(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	controller := mcp.NewController(testControllerOptions)
 
 	gw := proto.Clone(gateway).(*networking.Gateway)
@@ -431,7 +431,7 @@ func TestInvalidResource(t *testing.T) {
 }
 
 func TestInvalidResource_BadTimestamp(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	controller := mcp.NewController(testControllerOptions)
 
 	message := convertToResource(g, collections.IstioNetworkingV1Alpha3Gateways.Resource().Proto(), gateway)
@@ -738,7 +738,7 @@ func (f *FakeXdsUpdater) ProxyUpdate(_, _ string) {
 }
 
 func TestApplyIncrementalChangeRemove(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	fx := NewFakeXDS()
 	testControllerOptions.XDSUpdater = fx
@@ -811,7 +811,7 @@ func TestApplyIncrementalChangeRemove(t *testing.T) {
 }
 
 func TestApplyIncrementalChange(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	fx := NewFakeXDS()
 	testControllerOptions.XDSUpdater = fx

--- a/pkg/bootstrap/option/instances_test.go
+++ b/pkg/bootstrap/option/instances_test.go
@@ -696,7 +696,7 @@ func TestOptions(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.testName, func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			params, err := option.NewTemplateParams(c.option)
 			if c.expectError {

--- a/pkg/config/event/buffer_test.go
+++ b/pkg/config/event/buffer_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestBuffer_Basics(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := &fixtures.Source{}
 	acc := &fixtures.Accumulator{}
@@ -46,7 +46,7 @@ func TestBuffer_Basics(t *testing.T) {
 }
 
 func TestBuffer_Clear(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := &fixtures.Source{}
 	acc := &fixtures.Accumulator{}
@@ -63,7 +63,7 @@ func TestBuffer_Clear(t *testing.T) {
 }
 
 func TestBuffer_DoubleProcess(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := &fixtures.Source{}
 	acc := &fixtures.Accumulator{}
@@ -100,7 +100,7 @@ func TestBuffer_DoubleProcess(t *testing.T) {
 }
 
 func TestBuffer_Stress(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := &fixtures.Source{}
 	acc := &fixtures.Accumulator{}

--- a/pkg/config/event/event_test.go
+++ b/pkg/config/event/event_test.go
@@ -69,7 +69,7 @@ func TestEvent_String(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run("", func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 			actual := tc.i.String()
 			g.Expect(strings.TrimSpace(actual)).To(Equal(strings.TrimSpace(tc.exp)))
 		})
@@ -117,7 +117,7 @@ func TestEvent_DetailedString(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run("", func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 			actual := tc.i.String()
 			actual = strings.TrimSpace(actual)
 			expected := strings.TrimSpace(tc.prefix)
@@ -127,7 +127,7 @@ func TestEvent_DetailedString(t *testing.T) {
 }
 
 func TestEvent_Clone(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	r := resource.Instance{
 		Metadata: resource.Metadata{
@@ -146,7 +146,7 @@ func TestEvent_Clone(t *testing.T) {
 }
 
 func TestEvent_FullSyncFor(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	e := event.FullSyncFor(data.Boo)
 
@@ -158,7 +158,7 @@ func TestEvent_FullSyncFor(t *testing.T) {
 }
 
 func TestEvent_AddFor(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	r := resource.Instance{
 		Metadata: resource.Metadata{
@@ -182,7 +182,7 @@ func TestEvent_AddFor(t *testing.T) {
 }
 
 func TestEvent_UpdateFor(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	r := resource.Instance{
 		Metadata: resource.Metadata{
@@ -206,7 +206,7 @@ func TestEvent_UpdateFor(t *testing.T) {
 }
 
 func TestEvent_DeleteFor(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	n := resource.NewFullName("ns1", "rs1")
 	v := resource.Version("v1")
@@ -226,7 +226,7 @@ func TestEvent_DeleteFor(t *testing.T) {
 }
 
 func TestEvent_UpdateForResource(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	r := resource.Instance{
 		Metadata: resource.Metadata{
@@ -250,7 +250,7 @@ func TestEvent_UpdateForResource(t *testing.T) {
 }
 
 func TestEvent_IsSource(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	e := event.Event{
 		Kind:   event.Deleted,
 		Source: data.Boo,
@@ -260,7 +260,7 @@ func TestEvent_IsSource(t *testing.T) {
 }
 
 func TestEvent_IsSourceAny(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	e := event.Event{
 		Kind:   event.Deleted,
 		Source: data.Boo,
@@ -271,7 +271,7 @@ func TestEvent_IsSourceAny(t *testing.T) {
 }
 
 func TestEvent_WithSource(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	oldCol := data.Boo
 	e := event.Event{
 		Kind:   event.Deleted,
@@ -284,7 +284,7 @@ func TestEvent_WithSource(t *testing.T) {
 }
 
 func TestEvent_WithSource_Reset(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	e := event.Event{
 		Kind: event.Reset,
 	}

--- a/pkg/config/event/handler_test.go
+++ b/pkg/config/event/handler_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestHandlerFromFn(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	var received event.Event
 	h := event.HandlerFromFn(func(e event.Event) {
 		received = e
@@ -44,7 +44,7 @@ func TestHandlerFromFn(t *testing.T) {
 }
 
 func TestHandlers(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	var received1 event.Event
 	h1 := event.HandlerFromFn(func(e event.Event) {
@@ -74,7 +74,7 @@ func TestHandlers(t *testing.T) {
 }
 
 func TestCombineHandlers(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	var received1 event.Event
 	h1 := event.HandlerFromFn(func(e event.Event) {
@@ -102,7 +102,7 @@ func TestCombineHandlers(t *testing.T) {
 }
 
 func TestCombineHandlers_Nil1(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	var received1 event.Event
 	h1 := event.HandlerFromFn(func(e event.Event) {
@@ -124,7 +124,7 @@ func TestCombineHandlers_Nil1(t *testing.T) {
 }
 
 func TestCombineHandlers_Nil2(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	var received1 event.Event
 	h1 := event.HandlerFromFn(func(e event.Event) {
@@ -146,7 +146,7 @@ func TestCombineHandlers_Nil2(t *testing.T) {
 }
 
 func TestCombineHandlers_MultipleHandlers(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	var received1 event.Event
 	h1 := event.HandlerFromFn(func(e event.Event) {

--- a/pkg/config/event/handlers_test.go
+++ b/pkg/config/event/handlers_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestHandlers_Handle_Zero(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	hs := &event.Handlers{}
 	g.Expect(hs.Size()).To(Equal(0))
 
@@ -33,7 +33,7 @@ func TestHandlers_Handle_Zero(t *testing.T) {
 }
 
 func TestHandlers_Handle_One(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	hs := &event.Handlers{}
 
@@ -48,7 +48,7 @@ func TestHandlers_Handle_One(t *testing.T) {
 }
 
 func TestHandlers_Handle_Multiple(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	hs := &event.Handlers{}
 
@@ -69,7 +69,7 @@ func TestHandlers_Handle_Multiple(t *testing.T) {
 }
 
 func TestHandlers_Handle_Multiple_MultipleEvents(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	hs := &event.Handlers{}
 
@@ -89,7 +89,7 @@ func TestHandlers_Handle_Multiple_MultipleEvents(t *testing.T) {
 }
 
 func TestHandlers_CombineHandlers_SentinelFirst(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	h1 := event.SentinelHandler()
 	h2 := &fixtures.Accumulator{}
@@ -106,7 +106,7 @@ func TestHandlers_CombineHandlers_SentinelFirst(t *testing.T) {
 }
 
 func TestHandlers_CombineHandlers_SentinelSecond(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	h1 := &fixtures.Accumulator{}
 	h2 := event.SentinelHandler()

--- a/pkg/config/event/queue_test.go
+++ b/pkg/config/event/queue_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestQueue_Empty(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	q := &queue{}
 
@@ -37,7 +37,7 @@ func TestQueue_Empty(t *testing.T) {
 }
 
 func TestQueueWrapEmpty(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	for i := 0; i < 100; i++ {
 		a := wrap(i, 0)
@@ -53,7 +53,7 @@ func TestQueue_Expand_And_Use(t *testing.T) {
 	popCtr := 0
 	for max := 1; max < 513; max++ {
 		t.Run(fmt.Sprintf("M%d", max), func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			g.Expect(q.isEmpty()).To(BeTrue())
 			g.Expect(q.size()).To(Equal(0))

--- a/pkg/config/event/router_test.go
+++ b/pkg/config/event/router_test.go
@@ -33,7 +33,7 @@ func TestRouter_Empty(t *testing.T) {
 }
 
 func TestRouter_Single_Handle(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := event.NewRouter()
 	acc := &fixtures.Accumulator{}
@@ -44,7 +44,7 @@ func TestRouter_Single_Handle(t *testing.T) {
 }
 
 func TestRouter_Single_Handle_AddToNil(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	var s event.Router
 	acc := &fixtures.Accumulator{}
@@ -55,7 +55,7 @@ func TestRouter_Single_Handle_AddToNil(t *testing.T) {
 }
 
 func TestRouter_Single_Handle_NoMatch(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := event.NewRouter()
 	acc := &fixtures.Accumulator{}
@@ -66,7 +66,7 @@ func TestRouter_Single_Handle_NoMatch(t *testing.T) {
 }
 
 func TestRouter_Single_MultiListener(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := event.NewRouter()
 	acc1 := &fixtures.Accumulator{}
@@ -80,7 +80,7 @@ func TestRouter_Single_MultiListener(t *testing.T) {
 }
 
 func TestRouter_Single_Broadcast(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := event.NewRouter()
 	acc := &fixtures.Accumulator{}
@@ -91,7 +91,7 @@ func TestRouter_Single_Broadcast(t *testing.T) {
 }
 
 func TestRouter_Multi_Handle(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := event.NewRouter()
 	acc1 := &fixtures.Accumulator{}
@@ -109,7 +109,7 @@ func TestRouter_Multi_Handle(t *testing.T) {
 }
 
 func TestRouter_Multi_NoTarget(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := event.NewRouter()
 	acc1 := &fixtures.Accumulator{}
@@ -123,7 +123,7 @@ func TestRouter_Multi_NoTarget(t *testing.T) {
 }
 
 func TestRouter_Multi_Broadcast(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := event.NewRouter()
 	acc1 := &fixtures.Accumulator{}
@@ -140,7 +140,7 @@ func TestRouter_Multi_Broadcast(t *testing.T) {
 }
 
 func TestRouter_Multi_Unknown_Panic(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	defer func() {
 		r := recover()

--- a/pkg/config/event/source_test.go
+++ b/pkg/config/event/source_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestMergeSources_Basic(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s1 := &fixtures.Source{}
 	s2 := &fixtures.Source{}
@@ -47,7 +47,7 @@ func TestMergeSources_Basic(t *testing.T) {
 }
 
 func TestMergeSources_Composite(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s1 := &fixtures.Source{}
 	s2a := &fixtures.Source{}

--- a/pkg/config/event/transformer_test.go
+++ b/pkg/config/event/transformer_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestTransformer_Basics(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	inputs := collection.NewSchemasBuilder().MustAdd(data.Foo).MustAdd(data.Bar).Build()
 	outputs := collection.NewSchemasBuilder().MustAdd(data.Boo).MustAdd(data.Baz).Build()
@@ -55,7 +55,7 @@ func TestTransformer_Basics(t *testing.T) {
 }
 
 func TestTransformer_Selection(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	inputs := collection.NewSchemasBuilder().MustAdd(data.Foo).MustAdd(data.Bar).Build()
 	outputs := collection.NewSchemasBuilder().MustAdd(data.Boo).MustAdd(data.Baz).Build()
@@ -95,7 +95,7 @@ func TestTransformer_Selection(t *testing.T) {
 }
 
 func TestTransformer_InvalidEvent(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	inputs := collection.NewSchemasBuilder().MustAdd(data.Foo).Build()
 	outputs := collection.NewSchemasBuilder().MustAdd(data.Bar).Build()
@@ -124,7 +124,7 @@ func TestTransformer_InvalidEvent(t *testing.T) {
 }
 
 func TestTransformer_Reset(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	inputs := collection.NewSchemasBuilder().MustAdd(data.Foo).Build()
 	outputs := collection.NewSchemasBuilder().MustAdd(data.Bar).MustAdd(data.Baz).Build()
@@ -160,7 +160,7 @@ func TestTransformer_Reset(t *testing.T) {
 }
 
 func TestTransformer_FullSync(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	inputs := collection.NewSchemasBuilder().MustAdd(data.Foo).MustAdd(data.Bar).Build()
 	outputs := collection.NewSchemasBuilder().MustAdd(data.Boo).MustAdd(data.Baz).Build()

--- a/pkg/config/mesh/networks_watcher_test.go
+++ b/pkg/config/mesh/networks_watcher_test.go
@@ -27,13 +27,13 @@ import (
 )
 
 func TestNewNetworksWatcherWithBadInputShouldFail(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	_, err := mesh.NewNetworksWatcher(filewatcher.NewWatcher(), "")
 	g.Expect(err).ToNot(BeNil())
 }
 
 func TestNetworksWatcherShouldNotifyHandlers(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	path := newTempFile(t)
 	defer removeSilent(path)

--- a/pkg/config/mesh/watcher_test.go
+++ b/pkg/config/mesh/watcher_test.go
@@ -33,13 +33,13 @@ import (
 )
 
 func TestNewWatcherWithBadInputShouldFail(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	_, err := mesh.NewWatcher(filewatcher.NewWatcher(), "")
 	g.Expect(err).ToNot(BeNil())
 }
 
 func TestWatcherShouldNotifyHandlers(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	path := newTempFile(t)
 	defer removeSilent(path)

--- a/pkg/config/resource/instance_test.go
+++ b/pkg/config/resource/instance_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestInstance_IsEmpty_False(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	e := Instance{
 		Message: &types.Empty{},
@@ -32,14 +32,14 @@ func TestInstance_IsEmpty_False(t *testing.T) {
 }
 
 func TestInstance_IsEmpty_True(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	e := Instance{}
 
 	g.Expect(e.IsEmpty()).To(BeTrue())
 }
 
 func TestInstance_Clone_Empty(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	e := &Instance{}
 
 	c := e.Clone()
@@ -47,7 +47,7 @@ func TestInstance_Clone_Empty(t *testing.T) {
 }
 
 func TestInstance_Clone_NonEmpty(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	e := &Instance{
 		Message: &types.Empty{},

--- a/pkg/config/resource/metadata_test.go
+++ b/pkg/config/resource/metadata_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestMetadata_Clone_NilMaps(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	m := Metadata{
 		FullName: NewFullName("ns1", "rs1"),
@@ -33,7 +33,7 @@ func TestMetadata_Clone_NilMaps(t *testing.T) {
 }
 
 func TestMetadata_Clone_NonNilMaps(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	m := Metadata{
 		FullName:    NewFullName("ns1", "rs1"),

--- a/pkg/config/resource/stringmap_test.go
+++ b/pkg/config/resource/stringmap_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestStringMap_Clone_Nil(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	var s StringMap
 
@@ -30,7 +30,7 @@ func TestStringMap_Clone_Nil(t *testing.T) {
 }
 
 func TestStringMap_Clone_NonNil(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	var s StringMap = map[string]string{
 		"foo": "bar",
@@ -43,7 +43,7 @@ func TestStringMap_Clone_NonNil(t *testing.T) {
 }
 
 func TestStringMap_CloneOrCreate_Nil(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	var s StringMap
 
@@ -53,7 +53,7 @@ func TestStringMap_CloneOrCreate_Nil(t *testing.T) {
 }
 
 func TestStringMap_CloneOrCreate_NonNil(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	var s StringMap = map[string]string{
 		"foo": "bar",
@@ -66,7 +66,7 @@ func TestStringMap_CloneOrCreate_NonNil(t *testing.T) {
 }
 
 func TestStringMap_Delete_NonNil(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	var s StringMap = map[string]string{
 		"foo": "bar",
@@ -78,7 +78,7 @@ func TestStringMap_Delete_NonNil(t *testing.T) {
 }
 
 func TestStringMap_Delete_Nil(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	var s StringMap
 

--- a/pkg/config/schema/ast/ast_test.go
+++ b/pkg/config/schema/ast/ast_test.go
@@ -98,7 +98,7 @@ transforms:
 
 	for _, c := range cases {
 		t.Run("", func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 			actual, err := Parse(c.input)
 			g.Expect(err).To(BeNil())
 			g.Expect(actual).To(Equal(c.expected))
@@ -135,7 +135,7 @@ transforms:
 
 	for _, c := range cases {
 		t.Run("", func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 			_, err := Parse(c)
 			g.Expect(err).NotTo(BeNil())
 		})
@@ -171,7 +171,7 @@ transforms:
 	expectedCalls := 3
 	for i := 0; i < expectedCalls; i++ {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			var cur int
 			jsonUnmarshal = func(data []byte, v interface{}) error {

--- a/pkg/config/schema/codegen/collections_test.go
+++ b/pkg/config/schema/codegen/collections_test.go
@@ -156,7 +156,7 @@ var (
 
 	for _, c := range cases {
 		t.Run("", func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			s, err := StaticCollections(c.packageName, c.m)
 			if c.err != "" {

--- a/pkg/config/schema/codegen/common_test.go
+++ b/pkg/config/schema/codegen/common_test.go
@@ -49,7 +49,7 @@ func TestCommentBlock(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 			output := commentBlock(c.input, c.indentTabs)
 			g.Expect(output).To(Equal(c.expected))
 		})
@@ -119,7 +119,7 @@ func TestWordWrap(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 			output := wordWrap(c.input, c.maxLineLength)
 			g.Expect(output).To(Equal(c.expected))
 		})

--- a/pkg/config/schema/codegen/snapshots_test.go
+++ b/pkg/config/schema/codegen/snapshots_test.go
@@ -73,7 +73,7 @@ func SnapshotNames() []string {
 
 	for _, c := range cases {
 		t.Run("", func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			s, err := StaticSnapshots(c.packageName, &ast.Metadata{
 				Snapshots: c.snapshots,

--- a/pkg/config/schema/codegen/staticinit_test.go
+++ b/pkg/config/schema/codegen/staticinit_test.go
@@ -55,7 +55,7 @@ import (
 
 	for _, c := range cases {
 		t.Run("", func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			m := ast.Metadata{}
 			for _, p := range c.packages {
@@ -74,7 +74,7 @@ import (
 }
 
 func TestApplyTemplate_Error(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	_, err := applyTemplate(staticCollectionsTemplate, struct{}{})
 	g.Expect(err).ToNot(BeNil())

--- a/pkg/config/schema/collection/name_test.go
+++ b/pkg/config/schema/collection/name_test.go
@@ -21,14 +21,14 @@ import (
 )
 
 func TestNewName(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	c := NewName("c1")
 	g.Expect(c.String()).To(Equal("c1"))
 }
 
 func TestNewName_Invalid(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	defer func() {
 		r := recover()
 		g.Expect(r).NotTo(BeNil())
@@ -38,7 +38,7 @@ func TestNewName_Invalid(t *testing.T) {
 }
 
 func TestName_String(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	c := NewName("c1")
 
 	g.Expect(c.String()).To(Equal("c1"))
@@ -58,7 +58,7 @@ func TestIsValidName_Valid(t *testing.T) {
 
 	for _, d := range data {
 		t.Run(d, func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 			b := IsValidName(d)
 			g.Expect(b).To(BeTrue())
 		})
@@ -77,7 +77,7 @@ func TestIsValidName_Invalid(t *testing.T) {
 
 	for _, d := range data {
 		t.Run(d, func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 			b := IsValidName(d)
 			g.Expect(b).To(BeFalse())
 		})

--- a/pkg/config/schema/collection/names_test.go
+++ b/pkg/config/schema/collection/names_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestNames_Clone(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	n := collection.Names{basicmeta.K8SCollection1.Name(), basicmeta.Collection2.Name()}
 
@@ -34,7 +34,7 @@ func TestNames_Clone(t *testing.T) {
 }
 
 func TestNames_Sort(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	n := collection.Names{data.Foo.Name(), data.Baz.Name(), data.Bar.Name()}
 	expected := collection.Names{data.Bar.Name(), data.Baz.Name(), data.Foo.Name()}

--- a/pkg/config/schema/collection/schema_test.go
+++ b/pkg/config/schema/collection/schema_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestSchema_NewSchema(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s, err := collection.Builder{
 		Name:     "foo",
@@ -37,7 +37,7 @@ func TestSchema_NewSchema(t *testing.T) {
 }
 
 func TestSchema_NewSchema_Error(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	_, err := collection.Builder{
 		Name:     "$",
@@ -47,7 +47,7 @@ func TestSchema_NewSchema_Error(t *testing.T) {
 }
 
 func TestSchema_MustNewSchema(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	defer func() {
 		r := recover()
 		g.Expect(r).To(BeNil())
@@ -63,7 +63,7 @@ func TestSchema_MustNewSchema(t *testing.T) {
 }
 
 func TestSchema_MustNewSchema_Error(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	defer func() {
 		r := recover()
 		g.Expect(r).NotTo(BeNil())
@@ -79,7 +79,7 @@ func TestSchema_MustNewSchema_Error(t *testing.T) {
 }
 
 func TestSchema_String(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := collection.Builder{
 		Name: "foo",

--- a/pkg/config/schema/collection/schemas_test.go
+++ b/pkg/config/schema/collection/schemas_test.go
@@ -41,7 +41,7 @@ var (
 )
 
 func TestSchemas_Basic(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := collection.Builder{
 		Name:     "foo",
@@ -54,7 +54,7 @@ func TestSchemas_Basic(t *testing.T) {
 }
 
 func TestSchemas_MustAdd(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	defer func() {
 		r := recover()
 		g.Expect(r).To(BeNil())
@@ -69,7 +69,7 @@ func TestSchemas_MustAdd(t *testing.T) {
 }
 
 func TestSchemas_MustRegister_Panic(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	defer func() {
 		r := recover()
 		g.Expect(r).NotTo(BeNil())
@@ -85,7 +85,7 @@ func TestSchemas_MustRegister_Panic(t *testing.T) {
 }
 
 func TestSchemas_Find(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := collection.Builder{
 		Name:     "foo",
@@ -103,7 +103,7 @@ func TestSchemas_Find(t *testing.T) {
 }
 
 func TestSchemas_MustFind(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	defer func() {
 		r := recover()
 		g.Expect(r).To(BeNil())
@@ -124,7 +124,7 @@ func TestSchemas_MustFind(t *testing.T) {
 }
 
 func TestSchemas_MustFind_Panic(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	defer func() {
 		r := recover()
 		g.Expect(r).NotTo(BeNil())
@@ -144,7 +144,7 @@ func TestSchemas_MustFind_Panic(t *testing.T) {
 }
 
 func TestSchema_FindByGroupVersionKind(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := collection.Builder{
 		Name: "foo",
@@ -177,7 +177,7 @@ func TestSchema_FindByGroupVersionKind(t *testing.T) {
 }
 
 func TestSchema_MustFindByGroupVersionKind(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	b := collection.NewSchemasBuilder()
 
 	s := collection.Builder{
@@ -204,7 +204,7 @@ func TestSchema_MustFindByGroupVersionKind(t *testing.T) {
 }
 
 func TestSchema_MustFindByGroupVersionKind_Panic(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	defer func() {
 		r := recover()
@@ -220,7 +220,7 @@ func TestSchema_MustFindByGroupVersionKind_Panic(t *testing.T) {
 }
 
 func TestSchemas_CollectionNames(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	b := collection.NewSchemasBuilder()
 
 	s1 := collection.Builder{
@@ -240,7 +240,7 @@ func TestSchemas_CollectionNames(t *testing.T) {
 }
 
 func TestSchemas_Kinds(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := collection.SchemasFor(
 		collection.Builder{
@@ -293,7 +293,7 @@ func TestSchemas_Validate(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 			b := collection.NewSchemasBuilder()
 			for _, s := range c.schemas {
 				b.MustAdd(s)
@@ -309,7 +309,7 @@ func TestSchemas_Validate(t *testing.T) {
 }
 
 func TestSchemas_Validate_Error(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	b := collection.NewSchemasBuilder()
 
 	s1 := collection.Builder{
@@ -371,7 +371,7 @@ func TestSchemas_ForEach(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 			actual := c.actual()
 			g.Expect(actual).To(Equal(c.expected))
 		})
@@ -379,7 +379,7 @@ func TestSchemas_ForEach(t *testing.T) {
 }
 
 func TestSchemas_Remove(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	foo := collection.Builder{
 		Name:     "foo",
@@ -401,7 +401,7 @@ func TestSchemas_Remove(t *testing.T) {
 }
 
 func TestSchemas_Add(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	foo := collection.Builder{
 		Name:     "foo",

--- a/pkg/config/schema/resource/schema_test.go
+++ b/pkg/config/schema/resource/schema_test.go
@@ -72,7 +72,7 @@ func TestValidate(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			err := c.b.BuildNoValidate().Validate()
 			if c.expectError {
@@ -134,7 +134,7 @@ func TestBuild(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			_, err := c.b.Build()
 			if c.expectError {
@@ -180,14 +180,14 @@ func TestCanonicalName(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 			g.Expect(c.s.GroupVersionKind().String()).To(Equal(c.expected))
 		})
 	}
 }
 
 func TestNewProtoInstance(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := Builder{
 		Kind:         "Empty",
@@ -202,7 +202,7 @@ func TestNewProtoInstance(t *testing.T) {
 }
 
 func TestMustNewProtoInstance_Panic_Nil(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	defer func() {
 		r := recover()
 		g.Expect(r).NotTo(BeNil())
@@ -225,7 +225,7 @@ func TestMustNewProtoInstance_Panic_Nil(t *testing.T) {
 }
 
 func TestNewProtoInstance_Panic_NonProto(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	defer func() {
 		r := recover()
 		g.Expect(r).NotTo(BeNil())
@@ -249,7 +249,7 @@ func TestNewProtoInstance_Panic_NonProto(t *testing.T) {
 }
 
 func TestString(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s := Builder{
 		Kind:         "Empty",

--- a/pkg/config/schema/schema_test.go
+++ b/pkg/config/schema/schema_test.go
@@ -121,7 +121,7 @@ transforms:
 
 	for _, c := range cases {
 		t.Run("", func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			actual, err := ParseAndBuild(c.Input)
 			g.Expect(err).To(BeNil())
@@ -259,7 +259,7 @@ transforms:
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			_, err := ParseAndBuild(c.input)
 			g.Expect(err).ToNot(BeNil())
@@ -299,7 +299,7 @@ transforms:
 `
 
 func TestSchemaBasic(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	s, err := ParseAndBuild(input)
 	g.Expect(err).To(BeNil())
@@ -358,7 +358,7 @@ func TestSchemaBasic(t *testing.T) {
 }
 
 func TestSchema_DirectTransform_Panic(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	defer func() {
 		r := recover()
@@ -372,7 +372,7 @@ func TestSchema_DirectTransform_Panic(t *testing.T) {
 }
 
 func TestBuild_UnknownTransform(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	a := &ast.Metadata{
 		TransformSettings: []ast.TransformSettings{

--- a/pkg/envoy/agent_test.go
+++ b/pkg/envoy/agent_test.go
@@ -114,7 +114,7 @@ func TestStartDrain(t *testing.T) {
 
 // TestWaitForLive tests that a hot restart will not occur until after a previous epoch goes live.
 func TestWaitForLive(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -169,7 +169,7 @@ func TestWaitForLive(t *testing.T) {
 }
 
 func TestExitDuringWaitForLive(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/envoy/instance_test.go
+++ b/pkg/envoy/instance_test.go
@@ -39,14 +39,14 @@ var (
 )
 
 func TestNewWithoutConfigShouldFail(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	_, err := envoy.New(envoy.Config{})
 	g.Expect(err).ToNot(BeNil())
 }
 
 func TestNewWithDuplicateOptionsShouldFail(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	h := newBootstrapHelper(t)
 	defer h.Close()
@@ -61,7 +61,7 @@ func TestNewWithDuplicateOptionsShouldFail(t *testing.T) {
 }
 
 func TestNewWithInvalidOptionShouldFail(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	_, err := envoy.New(envoy.Config{
 		BinaryPath: testEnvoy.FindBinaryOrFail(t),
@@ -71,7 +71,7 @@ func TestNewWithInvalidOptionShouldFail(t *testing.T) {
 }
 
 func TestNewWithoutAdminPortShouldFail(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	_, err := envoy.New(envoy.Config{
 		BinaryPath: testEnvoy.FindBinaryOrFail(t),
@@ -81,7 +81,7 @@ func TestNewWithoutAdminPortShouldFail(t *testing.T) {
 }
 
 func TestNewWithoutBinaryPathShouldFail(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	h := newBootstrapHelper(t)
 	defer h.Close()
@@ -93,7 +93,7 @@ func TestNewWithoutBinaryPathShouldFail(t *testing.T) {
 }
 
 func TestNewWithConfigPathShouldSucceed(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	h := newBootstrapHelper(t)
 	defer h.Close()
@@ -107,7 +107,7 @@ func TestNewWithConfigPathShouldSucceed(t *testing.T) {
 }
 
 func TestNewWithConfigYamlShouldSucceed(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	h := newBootstrapHelper(t)
 	defer h.Close()
@@ -141,7 +141,7 @@ func TestStartWithBadBinaryShouldFail(t *testing.T) {
 func TestStartEnvoyShouldSucceed(t *testing.T) {
 	runLinuxOnly(t)
 
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	h := newBootstrapHelper(t)
 	defer h.Close()
@@ -184,7 +184,7 @@ func TestStartTwiceShouldDoNothing(t *testing.T) {
 func TestHotRestartTwiceShouldFail(t *testing.T) {
 	runLinuxOnly(t)
 
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	h := newBootstrapHelper(t)
 	defer h.Close()
@@ -209,7 +209,7 @@ func TestHotRestartTwiceShouldFail(t *testing.T) {
 func TestHotRestart(t *testing.T) {
 	runLinuxOnly(t)
 
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	h := newBootstrapHelper(t)
 	defer h.Close()
@@ -250,7 +250,7 @@ func TestHotRestart(t *testing.T) {
 func TestCommandLineArgs(t *testing.T) {
 	runLinuxOnly(t)
 
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	h := newBootstrapHelper(t)
 	defer h.Close()
@@ -315,7 +315,7 @@ func TestCommandLineArgs(t *testing.T) {
 func TestShutdown(t *testing.T) {
 	runLinuxOnly(t)
 
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	h := newBootstrapHelper(t)
 	defer h.Close()
@@ -341,7 +341,7 @@ func TestShutdown(t *testing.T) {
 func TestKillEnvoy(t *testing.T) {
 	runLinuxOnly(t)
 
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	h := newBootstrapHelper(t)
 	defer h.Close()
@@ -391,7 +391,7 @@ func TestCancelContext(t *testing.T) {
 func TestConfigDump(t *testing.T) {
 	runLinuxOnly(t)
 
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	h := newBootstrapHelper(t)
 	defer h.Close()

--- a/pkg/envoy/options_test.go
+++ b/pkg/envoy/options_test.go
@@ -28,7 +28,7 @@ var (
 )
 
 func TestNewOptions(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	args := []string{"--config-path", testConfigPath, "--k2", "v2", "--k3"}
 	actuals, err := envoy.NewOptions(args...)
@@ -39,7 +39,7 @@ func TestNewOptions(t *testing.T) {
 }
 
 func TestNewOptionsWithoutConfigPathShouldFail(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	args := []string{"--k2", "v2", "--k3"}
 	actuals, err := envoy.NewOptions(args...)
@@ -48,7 +48,7 @@ func TestNewOptionsWithoutConfigPathShouldFail(t *testing.T) {
 }
 
 func TestNewOptionsWithInvalidFlagShouldFail(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	args := []string{"--config-path", testConfigPath, "--k1", "v1", "k2", "v2"}
 	_, err := envoy.NewOptions(args...)
@@ -56,7 +56,7 @@ func TestNewOptionsWithInvalidFlagShouldFail(t *testing.T) {
 }
 
 func TestNewOptionsWithDuplicateFlagShouldFail(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	args := []string{"--config-path", testConfigPath, "--k1", "v1", "--k1", "v2"}
 	actuals, err := envoy.NewOptions(args...)
@@ -65,7 +65,7 @@ func TestNewOptionsWithDuplicateFlagShouldFail(t *testing.T) {
 }
 
 func TestDuplicateOptions(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	options := envoy.Options{envoy.ConfigYaml("{a:b}"), envoy.ConfigYaml("{a:b}")}
 	g.Expect(options.Validate()).ToNot(BeNil())
@@ -166,7 +166,7 @@ func TestGoodOptions(t *testing.T) {
 	for _, c := range cases {
 		c := c
 		t.Run(c.name, func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 			g.Expect(c.options.Validate()).To(BeNil())
 			g.Expect(c.options.ToArgs()).To(Equal(c.expectedArgs))
 		})
@@ -174,13 +174,13 @@ func TestGoodOptions(t *testing.T) {
 }
 
 func TestInvalidLogLevel(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	options := envoy.Options{envoy.ConfigYaml("{}"), envoy.LogLevel("bad")}
 	g.Expect(options.Validate()).ToNot(BeNil())
 }
 
 func TestInvalidComponentLogLevels(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	options := envoy.Options{envoy.ConfigYaml("{}"), envoy.ComponentLogLevels{
 		envoy.ComponentLogLevel{
 			Name:  "a",
@@ -191,54 +191,54 @@ func TestInvalidComponentLogLevels(t *testing.T) {
 }
 
 func TestInvalidLocalAddressIPVersion(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	options := envoy.Options{envoy.ConfigYaml("{}"), envoy.LocalAddressIPVersion("bad")}
 	g.Expect(options.Validate()).ToNot(BeNil())
 }
 
 func TestInvalidConfigPath(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	options := envoy.Options{envoy.ConfigPath("bad/file/path")}
 	g.Expect(options.Validate()).ToNot(BeNil())
 }
 
 func TestInvalidBaseID(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	actuals, err := envoy.NewOptions("--config-path", testConfigPath, "--base-id", "bad-int-value")
 	g.Expect(err).To(BeNil())
 	g.Expect(actuals.Validate()).ToNot(BeNil())
 }
 
 func TestInvalidConcurrency(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	actuals, err := envoy.NewOptions("--config-path", testConfigPath, "--concurrency", "bad-int-value")
 	g.Expect(err).To(BeNil())
 	g.Expect(actuals.Validate()).ToNot(BeNil())
 }
 
 func TestInvalidRestartEpoch(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	actuals, err := envoy.NewOptions("--config-path", testConfigPath, "--restart-epoch", "bad-int-value")
 	g.Expect(err).To(BeNil())
 	g.Expect(actuals.Validate()).ToNot(BeNil())
 }
 
 func TestInvalidDrainDuration(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	actuals, err := envoy.NewOptions("--config-path", testConfigPath, "--drain-time-s", "bad-int-value")
 	g.Expect(err).To(BeNil())
 	g.Expect(actuals.Validate()).ToNot(BeNil())
 }
 
 func TestInvalidParentShutdownDuration(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	actuals, err := envoy.NewOptions("--config-path", testConfigPath, "--parent-shutdown-time-s", "bad-int-value")
 	g.Expect(err).To(BeNil())
 	g.Expect(actuals.Validate()).ToNot(BeNil())
 }
 
 func TestGenerateBaseID(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	baseID := envoy.GenerateBaseID()
 	expected := []string{"--config-yaml", "{}", "--base-id", baseID.FlagValue()}
@@ -248,7 +248,7 @@ func TestGenerateBaseID(t *testing.T) {
 }
 
 func TestParseComponentLogLevels(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	expected := envoy.ComponentLogLevels{
 		envoy.ComponentLogLevel{
 			Name:  "a",

--- a/pkg/test/framework/scope_test.go
+++ b/pkg/test/framework/scope_test.go
@@ -55,7 +55,7 @@ func TestGet_Struct(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 			scope := tt.setup()
 			var got OtherInterface
 			err := scope.get(&got)
@@ -81,7 +81,7 @@ func TestGet_Slice(t *testing.T) {
 		},
 	}
 
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	parent := newScope("parent", nil)
 	parent.add(exp[1], &resourceID{id: exp[1].IDValue})
 	child := newScope("child", parent)

--- a/pkg/test/framework/suite_test.go
+++ b/pkg/test/framework/suite_test.go
@@ -61,7 +61,7 @@ func newTestSuite(testID string, fn mRunFn, osExit func(int), getSettingsFn getS
 
 func TestSuite_Basic(t *testing.T) {
 	defer cleanupRT()
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	var runCalled bool
 	var runSkipped bool
@@ -85,7 +85,7 @@ func TestSuite_Basic(t *testing.T) {
 
 func TestSuite_Label_SuiteFilter(t *testing.T) {
 	defer cleanupRT()
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	var runSkipped bool
 	runFn := func(ctx *suiteContext) int {
@@ -107,7 +107,7 @@ func TestSuite_Label_SuiteFilter(t *testing.T) {
 
 func TestSuite_Label_SuiteAllow(t *testing.T) {
 	defer cleanupRT()
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	var runCalled bool
 	var runSkipped bool
@@ -199,7 +199,7 @@ func TestSuite_RequireMinMaxClusters(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			defer cleanupRT()
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			var runCalled bool
 			var runSkipped bool
@@ -235,7 +235,7 @@ func TestSuite_RequireMinMaxClusters(t *testing.T) {
 
 func TestSuite_Setup(t *testing.T) {
 	defer cleanupRT()
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	var runCalled bool
 	var runSkipped bool
@@ -261,7 +261,7 @@ func TestSuite_Setup(t *testing.T) {
 
 func TestSuite_SetupFail(t *testing.T) {
 	defer cleanupRT()
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	var runCalled bool
 	runFn := func(ctx *suiteContext) int {
@@ -284,7 +284,7 @@ func TestSuite_SetupFail(t *testing.T) {
 
 func TestSuite_SetupFail_Dump(t *testing.T) {
 	defer cleanupRT()
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	var runCalled bool
 	runFn := func(_ *suiteContext) int {
@@ -310,7 +310,7 @@ func TestSuite_SetupFail_Dump(t *testing.T) {
 
 func TestSuite_DoubleInit_Error(t *testing.T) {
 	defer cleanupRT()
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	var waitForRun1 sync.WaitGroup
 	waitForRun1.Add(1)
@@ -376,7 +376,7 @@ func TestSuite_GetResource(t *testing.T) {
 	}
 
 	t.Run("struct reference", func(t *testing.T) {
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 		var ref *resource.FakeResource
 		tracked := &resource.FakeResource{IDValue: "1"}
 		// notice that we pass **fakeCluster:
@@ -387,7 +387,7 @@ func TestSuite_GetResource(t *testing.T) {
 		g.Expect(tracked).To(Equal(ref))
 	})
 	t.Run("interface reference", func(t *testing.T) {
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 		var ref OtherInterface
 		tracked := &resource.FakeResource{IDValue: "1"}
 		err := act(&ref, tracked)
@@ -395,7 +395,7 @@ func TestSuite_GetResource(t *testing.T) {
 		g.Expect(tracked).To(Equal(ref))
 	})
 	t.Run("slice reference", func(t *testing.T) {
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 		existing := &resource.FakeResource{IDValue: "1"}
 		tracked := &resource.FakeResource{IDValue: "2"}
 		ref := []OtherInterface{existing}
@@ -406,7 +406,7 @@ func TestSuite_GetResource(t *testing.T) {
 		g.Expect(tracked).To(Equal(ref[1]))
 	})
 	t.Run("non pointer ref", func(t *testing.T) {
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 		err := act(resource.FakeResource{}, &resource.FakeResource{})
 		g.Expect(err).NotTo(BeNil())
 	})
@@ -441,7 +441,7 @@ func TestDeriveSuiteName(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.caller, func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 			actual := deriveSuiteName(c.caller)
 			g.Expect(actual).To(Equal(c.expected))
 		})

--- a/pkg/test/util/yml/cache_test.go
+++ b/pkg/test/util/yml/cache_test.go
@@ -73,7 +73,7 @@ spec:
 )
 
 func TestCache_Apply_Basic(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	d, err := ioutil.TempDir(os.TempDir(), t.Name())
 	g.Expect(err).To(BeNil())
 	t.Logf("Test Dir: %q", d)
@@ -125,7 +125,7 @@ func TestCache_Apply_Basic(t *testing.T) {
 }
 
 func TestCache_Apply_MultiPart(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	d, err := ioutil.TempDir(os.TempDir(), t.Name())
 	g.Expect(err).To(BeNil())
 	t.Logf("Test Dir: %q", d)
@@ -173,7 +173,7 @@ func TestCache_Apply_MultiPart(t *testing.T) {
 }
 
 func TestCache_Apply_Add_Update(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	d, err := ioutil.TempDir(os.TempDir(), t.Name())
 	g.Expect(err).To(BeNil())
 	t.Logf("Test Dir: %q", d)
@@ -206,7 +206,7 @@ func TestCache_Apply_Add_Update(t *testing.T) {
 }
 
 func TestCache_Apply_SameContent(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	d, err := ioutil.TempDir(os.TempDir(), t.Name())
 	g.Expect(err).To(BeNil())
 	t.Logf("Test Dir: %q", d)
@@ -232,7 +232,7 @@ func TestCache_Apply_SameContent(t *testing.T) {
 }
 
 func TestCache_Clear(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	d, err := ioutil.TempDir(os.TempDir(), t.Name())
 	g.Expect(err).To(BeNil())
 	t.Logf("Test Dir: %q", d)
@@ -257,7 +257,7 @@ func TestCache_Clear(t *testing.T) {
 }
 
 func TestCache_GetFileFor_Empty(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	d, err := ioutil.TempDir(os.TempDir(), t.Name())
 	g.Expect(err).To(BeNil())
 	t.Logf("Test Dir: %q", d)
@@ -269,7 +269,7 @@ func TestCache_GetFileFor_Empty(t *testing.T) {
 }
 
 func TestCache_Delete(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	d, err := ioutil.TempDir(os.TempDir(), t.Name())
 	g.Expect(err).To(BeNil())
 	t.Logf("Test Dir: %q", d)
@@ -300,7 +300,7 @@ func TestCache_Delete(t *testing.T) {
 }
 
 func TestCache_Delete_Missing(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	d, err := ioutil.TempDir(os.TempDir(), t.Name())
 	g.Expect(err).To(BeNil())
 	t.Logf("Test Dir: %q", d)

--- a/pkg/test/util/yml/parts_test.go
+++ b/pkg/test/util/yml/parts_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestEmptyDoc(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	yaml := `
 `
@@ -83,7 +83,7 @@ b
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			parts := yml.SplitString(c.doc)
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 			g.Expect(parts).To(Equal(expected))
 		})
 	}
@@ -103,7 +103,7 @@ b
     b2`,
 	}
 
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	parts := yml.SplitString(doc)
 	g.Expect(parts).To(Equal(expected))
 }
@@ -129,7 +129,7 @@ b
 ---
 b`
 
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	doc := yml.JoinString(parts...)
 	g.Expect(doc).To(Equal(expected))
 }

--- a/pkg/util/strcase/camelcase_test.go
+++ b/pkg/util/strcase/camelcase_test.go
@@ -42,7 +42,7 @@ func TestCamelCase(t *testing.T) {
 
 	for k, v := range cases {
 		t.Run(k, func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			a := strcase.CamelCase(k)
 			g.Expect(a).To(Equal(v))
@@ -62,7 +62,7 @@ func TestCamelCaseToKebabCase(t *testing.T) {
 
 	for k, v := range cases {
 		t.Run(k, func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			a := strcase.CamelCaseToKebabCase(k)
 			g.Expect(a).To(Equal(v))

--- a/pkg/webhooks/validation/controller/controller_test.go
+++ b/pkg/webhooks/validation/controller/controller_test.go
@@ -258,7 +258,7 @@ func reconcileHelper(t *testing.T, c *fakeController) {
 }
 
 func TestGreenfield(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	c := createTestController(t)
 
 	// install adds the webhook config with fail open policy
@@ -300,7 +300,7 @@ func TestGreenfield(t *testing.T) {
 }
 
 func TestCABundleChange(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	c := createTestController(t)
 
 	_, _ = c.ValidatingWebhookConfigurations().Create(context.TODO(), unpatchedWebhookConfig, kubeApiMeta.CreateOptions{})

--- a/tests/integration/galley/analyze_test.go
+++ b/tests/integration/galley/analyze_test.go
@@ -48,7 +48,7 @@ func TestEmptyCluster(t *testing.T) {
 	framework.
 		NewTest(t).
 		Run(func(ctx framework.TestContext) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			ns := namespace.NewOrFail(t, ctx, namespace.Config{
 				Prefix: "istioctl-analyze",
@@ -69,7 +69,7 @@ func TestFileOnly(t *testing.T) {
 	framework.
 		NewTest(t).
 		Run(func(ctx framework.TestContext) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			ns := namespace.NewOrFail(t, ctx, namespace.Config{
 				Prefix: "istioctl-analyze",
@@ -94,7 +94,7 @@ func TestDirectoryWithoutRecursion(t *testing.T) {
 	framework.
 		NewTest(t).
 		Run(func(ctx framework.TestContext) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			ns := namespace.NewOrFail(t, ctx, namespace.Config{
 				Prefix: "istioctl-analyze",
@@ -117,7 +117,7 @@ func TestDirectoryWithRecursion(t *testing.T) {
 	framework.
 		NewTest(t).
 		Run(func(ctx framework.TestContext) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			ns := namespace.NewOrFail(t, ctx, namespace.Config{
 				Prefix: "istioctl-analyze",
@@ -137,7 +137,7 @@ func TestInvalidFileError(t *testing.T) {
 	framework.
 		NewTest(t).
 		Run(func(ctx framework.TestContext) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			ns := namespace.NewOrFail(t, ctx, namespace.Config{
 				Prefix: "istioctl-analyze",
@@ -164,7 +164,7 @@ func TestJsonInputFile(t *testing.T) {
 	framework.
 		NewTest(t).
 		Run(func(ctx framework.TestContext) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			ns := namespace.NewOrFail(t, ctx, namespace.Config{
 				Prefix: "istioctl-analyze",
@@ -185,7 +185,7 @@ func TestJsonOutput(t *testing.T) {
 	framework.
 		NewTest(t).
 		Run(func(ctx framework.TestContext) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			ns := namespace.NewOrFail(t, ctx, namespace.Config{
 				Prefix: "istioctl-analyze",
@@ -226,7 +226,7 @@ func TestKubeOnly(t *testing.T) {
 	framework.
 		NewTest(t).
 		Run(func(ctx framework.TestContext) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			ns := namespace.NewOrFail(t, ctx, namespace.Config{
 				Prefix: "istioctl-analyze",
@@ -248,7 +248,7 @@ func TestFileAndKubeCombined(t *testing.T) {
 	framework.
 		NewTest(t).
 		Run(func(ctx framework.TestContext) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			ns := namespace.NewOrFail(t, ctx, namespace.Config{
 				Prefix: "istioctl-analyze",
@@ -271,7 +271,7 @@ func TestAllNamespaces(t *testing.T) {
 	framework.
 		NewTest(t).
 		Run(func(ctx framework.TestContext) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			ns1 := namespace.NewOrFail(t, ctx, namespace.Config{
 				Prefix: "istioctl-analyze-1",
@@ -313,7 +313,7 @@ func TestTimeout(t *testing.T) {
 	framework.
 		NewTest(t).
 		Run(func(ctx framework.TestContext) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			ns := namespace.NewOrFail(t, ctx, namespace.Config{
 				Prefix: "istioctl-analyze",

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -247,7 +247,7 @@ func TestAddToAndRemoveFromMesh(t *testing.T) {
 
 			var output string
 			var args []string
-			g := gomega.NewGomegaWithT(t)
+			g := gomega.NewWithT(t)
 
 			// able to remove from mesh when the deployment is auto injected
 			args = []string{fmt.Sprintf("--namespace=%s", ns.Name()),
@@ -281,7 +281,7 @@ func TestProxyConfig(t *testing.T) {
 
 			var output string
 			var args []string
-			g := gomega.NewGomegaWithT(t)
+			g := gomega.NewWithT(t)
 
 			args = []string{"--namespace=dummy",
 				"pc", "bootstrap", fmt.Sprintf("%s.%s", podID, echoNamespace.Name())}
@@ -345,7 +345,7 @@ func TestProxyStatus(t *testing.T) {
 
 			var output string
 			var args []string
-			g := gomega.NewGomegaWithT(t)
+			g := gomega.NewWithT(t)
 
 			args = []string{"proxy-status"}
 			output, _ = istioCtl.InvokeOrFail(t, args)


### PR DESCRIPTION
Function `NewGomegaWithT` is deprecated in favor of `NewWithT`, just replace `NewGomegaWithT` with `NewWithT` in all tests.

https://github.com/onsi/gomega/blob/904ac6ab26e9a888bdff3467eea03b6122a1c027/gomega_dsl.go#L374-L377


Signed-off-by: Liu Ming <hit_oak_tree@126.com>

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
