### PR TITLE
Update min k8 supported version for istio 1.8

### DIFF
--- a/istioctl/pkg/install/pre-check.go
+++ b/istioctl/pkg/install/pre-check.go
@@ -46,7 +46,7 @@ import (
 const (
 	// Minimum K8 version required to run latest version of Istio
 	// https://istio.io/docs/setup/platform-setup/
-	minK8SVersion = "1.16"
+	minK8SVersion = "1.17"
 )
 
 var (

--- a/istioctl/pkg/install/pre-check_test.go
+++ b/istioctl/pkg/install/pre-check_test.go
@@ -38,20 +38,20 @@ type testcase struct {
 }
 
 var (
-	version1_16 = &version.Info{
+	version1_17 = &version.Info{
 		Major:      "1",
-		Minor:      "16",
-		GitVersion: "1.16",
+		Minor:      "17",
+		GitVersion: "1.17",
 	}
 	version1_8 = &version.Info{
 		Major:      "1",
 		Minor:      "8",
 		GitVersion: "1.8",
 	}
-	version1_16GKE = &version.Info{
+	version1_17GKE = &version.Info{
 		Major:      "1",
-		Minor:      "16+",
-		GitVersion: "v1.16.7-gke.10",
+		Minor:      "17+",
+		GitVersion: "v1.17.7-gke.10",
 	}
 	version1_8GKE = &version.Info{
 		Major:      "1",
@@ -86,7 +86,7 @@ func TestPreCheck(t *testing.T) {
 		{
 			description: "Valid Kubernetes Version against GKE",
 			config: &mockClientExecPreCheckConfig{
-				version:   version1_16GKE,
+				version:   version1_17GKE,
 				namespace: "test",
 			},
 			expectedException: false,
@@ -101,21 +101,21 @@ func TestPreCheck(t *testing.T) {
 		},
 		{description: "Invalid Istio System",
 			config: &mockClientExecPreCheckConfig{
-				version:   version1_16,
+				version:   version1_17,
 				namespace: "istio-system",
 			},
 			expectedException: false, // It is fine to precheck an existing namespace; we might be installing canary control plane
 		},
 		{description: "Valid Istio System",
 			config: &mockClientExecPreCheckConfig{
-				version:   version1_16,
+				version:   version1_17,
 				namespace: "test",
 			},
 			expectedException: false,
 		},
 		{description: "Lacking Permission",
 			config: &mockClientExecPreCheckConfig{
-				version:   version1_16,
+				version:   version1_17,
 				namespace: "test",
 				authConfig: &authorizationapi.SelfSubjectAccessReview{
 					Spec: authorizationapi.SelfSubjectAccessReviewSpec{
@@ -133,7 +133,7 @@ func TestPreCheck(t *testing.T) {
 		},
 		{description: "Valid Case",
 			config: &mockClientExecPreCheckConfig{
-				version:   version1_16,
+				version:   version1_17,
 				namespace: "test",
 			},
 		},

--- a/releasenotes/notes/min-k8-ver-for-1.8.yaml
+++ b/releasenotes/notes/min-k8-ver-for-1.8.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue:
+- 25793
+releaseNotes: |
+  *Added* Istio 1.8 supports kubernetes versions 1.17 to 1.19.


### PR DESCRIPTION
The minimum supported k8 version for `Istio 1.8` is `1.17-1.19` (3 versions). Ref: https://github.com/istio/istio/pull/24134#issuecomment-634690848

For `1.7` support.
https://github.com/istio/istio/pull/24167
https://github.com/istio/istio.io/pull/7422
