### PR TITLE
Avoid caching test results for integ tests

### DIFF
--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -112,7 +112,7 @@ fi
 export IP_FAMILY="${IP_FAMILY:-ipv4}"
 
 # Setup junit report and verbose logging
-export T="${T:-"-v"}"
+export T="${T:-"-v -count=1"}"
 export CI="true"
 
 make init


### PR DESCRIPTION
This is to avoid duplicating this logic on every job as we add a
https://github.com/istio/test-infra/pull/2832 build cache to the jobs

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
