### PR TITLE
[release-1.6] Fixing broken CNI tests

### DIFF
--- a/tests/integration/pilot/cni/cni_test.go
+++ b/tests/integration/pilot/cni/cni_test.go
@@ -39,7 +39,7 @@ components:
   cni:
      enabled: true
      hub: gcr.io/istio-testing
-     tag: latest
+     tag: 1.6-dev
      namespace: kube-system
 `
 		})).


### PR DESCRIPTION
Fixing broken CNI tests in release-1.6 branch, by changing CNI image tags from latest to 1.6-dev in tests.