### PR TITLE
[release-1.5] Fixing broken CNI tests

### DIFF
--- a/tests/integration/pilot/cni/cni_test.go
+++ b/tests/integration/pilot/cni/cni_test.go
@@ -38,7 +38,7 @@ components:
 values:
   cni:
      hub: gcr.io/istio-testing
-     tag: latest
+     tag: 1.5-dev
 `
 		})).
 		Run()


### PR DESCRIPTION
Fixing broken CNI tests in release-1.5 branch, by changing CNI image tags from latest to 1.5-dev in tests.