### PR TITLE
No Block on gRPC connection

### DIFF
--- a/pkg/test/echo/server/forwarder/protocol.go
+++ b/pkg/test/echo/server/forwarder/protocol.go
@@ -121,8 +121,7 @@ func newProtocol(cfg Config) (protocol, error) {
 		grpcConn, err := cfg.Dialer.GRPC(ctx,
 			address,
 			security,
-			grpc.WithAuthority(authority),
-			grpc.WithBlock())
+			grpc.WithAuthority(authority))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
In negative testing this ends up stalling for 2s (connect timeout),
which adds up quickly. Instead, we can stop blocking and just let the
call fail when the call is made. The end result is the same without a
huge delay.

This brings each instance of the reachability tests (which we have many
of) from 20s to 2s

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
