### PR TITLE
use install to replace deprecated manifest apply command for integration test.

### DIFF
--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -523,9 +523,9 @@ func applyManifest(c *operatorComponent, installSettings []string, istioCtl isti
 	}
 	c.saveInstallManifest(clusterName, out)
 
-	// Actually run the manifest apply command
+	// Actually run the install command
 	cmd := []string{
-		"manifest", "apply",
+		"install",
 		"--skip-confirmation",
 	}
 	cmd = append(cmd, installSettings...)


### PR DESCRIPTION
Please provide a description for what this PR is for.

`manifest apply` command is deprecated and will be removed in 1.7

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ X ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
