### PR TITLE
Do not enable auto mtls when cluster type is `Cluster_ORIGINAL_DST` (…

### DIFF
--- a/tests/integration/pilot/cni/cni_test.go
+++ b/tests/integration/pilot/cni/cni_test.go
@@ -80,6 +80,10 @@ func TestCNIReachability(t *testing.T) {
 					Namespace:           systemNM,
 					RequiredEnvironment: environment.Kube,
 					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						// Exclude headless naked service, because it is no sidecar
+						if src == rctx.HeadlessNaked || opts.Target == rctx.HeadlessNaked {
+							return false
+						}
 						// Exclude calls to the headless TCP port.
 						if opts.Target == rctx.Headless && opts.PortName == "tcp" {
 							return false

--- a/tests/integration/security/mtls_first_party_jwt/strict_test.go
+++ b/tests/integration/security/mtls_first_party_jwt/strict_test.go
@@ -47,7 +47,7 @@ func TestMtlsStrictK8sCA(t *testing.T) {
 						// Exclude calls to the headless service.
 						// Auto mtls does not apply to headless service, because for headless service
 						// the cluster discovery type is ORIGINAL_DST, and it will not apply upstream tls setting
-						return opts.Target != rctx.Headless
+						return !rctx.IsHeadless(opts.Target)
 					},
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
 						// When mTLS is in STRICT mode, DR's TLS settings are default to mTLS so the result would
@@ -58,7 +58,7 @@ func TestMtlsStrictK8sCA(t *testing.T) {
 						}
 
 						// If source is naked, and destination is not, expect failure.
-						return !(src == rctx.Naked && opts.Target != rctx.Naked)
+						return !(rctx.IsNaked(src) && !rctx.IsNaked(opts.Target))
 					},
 				},
 				{

--- a/tests/integration/security/mtlsk8sca/strict_test.go
+++ b/tests/integration/security/mtlsk8sca/strict_test.go
@@ -47,7 +47,7 @@ func TestMtlsStrictK8sCA(t *testing.T) {
 						// Exclude calls to the headless service.
 						// Auto mtls does not apply to headless service, because for headless service
 						// the cluster discovery type is ORIGINAL_DST, and it will not apply upstream tls setting
-						return opts.Target != rctx.Headless
+						return !rctx.IsHeadless(opts.Target)
 					},
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
 						// When mTLS is in STRICT mode, DR's TLS settings are default to mTLS so the result would
@@ -58,7 +58,7 @@ func TestMtlsStrictK8sCA(t *testing.T) {
 						}
 
 						// If source is naked, and destination is not, expect failure.
-						return !(src == rctx.Naked && opts.Target != rctx.Naked)
+						return !(rctx.IsNaked(src) && !rctx.IsNaked(opts.Target))
 					},
 				},
 				{


### PR DESCRIPTION
…#24319)
fix: #25523