### PR TITLE
test framework: allow skipping suite for labels

### DIFF
--- a/pkg/test/framework/analyzer.go
+++ b/pkg/test/framework/analyzer.go
@@ -47,6 +47,7 @@ type suiteAnalyzer struct {
 	osExit func(int)
 
 	commonAnalyzer
+	skipLabels         label.Set
 	envFactoryCalls    int
 	requiredEnvVersion string
 }
@@ -70,6 +71,11 @@ func (s *suiteAnalyzer) EnvironmentFactory(fn resource.EnvironmentFactory) Suite
 
 func (s *suiteAnalyzer) Label(labels ...label.Instance) Suite {
 	s.labels = s.labels.Add(labels...)
+	return s
+}
+
+func (s *suiteAnalyzer) SkipLabel(labels ...label.Instance) Suite {
+	s.skipLabels = s.skipLabels.Add(labels...)
 	return s
 }
 
@@ -125,6 +131,7 @@ func (s *suiteAnalyzer) track() *suiteAnalysis {
 		SuiteID:          s.testID,
 		SkipReason:       s.skip,
 		Labels:           s.labels.All(),
+		SkipLabels:       s.skipLabels.All(),
 		MultiCluster:     s.maxClusters != 1,
 		MultiClusterOnly: s.minCusters > 1,
 		Tests:            map[string]*testAnalysis{},

--- a/pkg/test/framework/analyzer_runtime.go
+++ b/pkg/test/framework/analyzer_runtime.go
@@ -92,6 +92,7 @@ type suiteAnalysis struct {
 	SuiteID          string                   `yaml:"suiteID"`
 	SkipReason       string                   `yaml:"skipReason,omitempty"`
 	Labels           []label.Instance         `yaml:"labels,omitempty"`
+	SkipLabels       []label.Instance         `yaml:"skipLabels,omitempty"`
 	MultiCluster     bool                     `yaml:"multicluster,omitempty"`
 	MultiClusterOnly bool                     `yaml:"multiclusterOnly,omitempty"`
 	Tests            map[string]*testAnalysis `yaml:"tests"`

--- a/pkg/test/framework/suite.go
+++ b/pkg/test/framework/suite.go
@@ -302,7 +302,7 @@ func (s *suiteImpl) run() (errLevel int) {
 
 	// Before starting, check whether the current set of labels & label selectors will ever allow us to run tests.
 	// if not, simply exit now.
-	if ctx.Settings().Selector.Selects(s.skipLabels) {
+	if len(s.skipLabels) > 0 && ctx.Settings().Selector.Selects(s.skipLabels) {
 		s.Skip(fmt.Sprintf("Skip Label match: skipLabels=%v, selector=%v",
 			s.skipLabels,
 			ctx.Settings().Selector))

--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -27,6 +27,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/ingress"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
 )
 
@@ -80,6 +81,7 @@ type EchoDeployments struct {
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
+		SkipLabel(label.Multicluster).
 		Setup(func(ctx resource.Context) (err error) {
 			crd, err := ioutil.ReadFile("testdata/service-apis-crd.yaml")
 			if err != nil {


### PR DESCRIPTION
With #25432 the setup for the pilot suite will start running in the multicluster job. All of the individual tests will still be skipped, regardless of the `RequiresSingleCluster` because we check label Excludes at the suite-level, and Selects (both includes(+)/excludes(-) for the test level).

We still need the behavior described above so that we can add a Label to a test without adding it to the parent suite - for example we want the pilot suite to run in presubmit, but a subset of of the tests in that suite should be postsubmit only. 

This change allows us to skip a suite if a label selector is present by explicitly marking it with `suite.SkipLabel(...)`

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
