### PR TITLE
added grpc keepalive params to envoy bootstrap template for gcp

### DIFF
--- a/install/gcp/bootstrap/gcp_envoy_bootstrap.json
+++ b/install/gcp/bootstrap/gcp_envoy_bootstrap.json
@@ -47,6 +47,19 @@
             {{ else }}
               "google_compute_engine": {}
             {{ end }}
+            },
+            "channel_args": {
+              "args": {
+                "grpc.http2.max_pings_without_data": {
+                  "int_value": 0
+                },
+                "grpc.keepalive_time_ms": {
+                  "int_value": 10000
+                },
+                "grpc.keepalive_timeout_ms": {
+                  "int_value": 20000
+                }
+              }
             }
           },
           "initial_metadata": [
@@ -89,6 +102,19 @@
             {{ else }}
               "google_compute_engine": {}
             {{ end }}
+            },
+            "channel_args": {
+              "args": {
+                "grpc.http2.max_pings_without_data": {
+                  "int_value": 0
+                },
+                "grpc.keepalive_time_ms": {
+                  "int_value": 10000
+                },
+                "grpc.keepalive_timeout_ms": {
+                  "int_value": 20000
+                }
+              }
             }
           },
           "initial_metadata": [


### PR DESCRIPTION
Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

Added `channel_args` to envoy bootstrap template for gcp to address [TCP half open issue](https://github.com/envoyproxy/envoy/issues/5173#issuecomment-471224265)

/cc @fuqianggao
Signed-off-by: Yutong Li <yutongli@google.com>