### PR TITLE
Skip Ingress test on unsupported k8s versions

### DIFF
--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -97,11 +97,23 @@ spec:
 		})
 }
 
+func skipIfIngressClassUnsupported(ctx framework.TestContext) {
+	ver, err := ctx.Clusters().Default().GetKubernetesVersion()
+	if err != nil {
+		ctx.Fatalf("failed to get Kubernetes version: %v", err)
+	}
+	serverVersion := fmt.Sprintf("%s.%s", ver.Major, ver.Minor)
+	if serverVersion < "1.18" {
+		ctx.Skip("IngressClass not supported")
+	}
+}
+
 // TestIngress tests that we can route using standard Kubernetes Ingress objects.
 func TestIngress(t *testing.T) {
 	framework.
 		NewTest(t).
 		Run(func(ctx framework.TestContext) {
+			skipIfIngressClassUnsupported(ctx)
 			// Set up secret contain some TLS certs for *.example.com
 			// we will define one for foo.example.com and one for bar.example.com, to ensure both can co-exist
 			credName := "k8s-ingress-secret-foo"


### PR DESCRIPTION
Regression from https://github.com/istio/istio/pull/25819 that fails in our old k8s version postsubmit tests