### PR TITLE
typo: Fix typo in psfile.yaml release note

### DIFF
--- a/releasenotes/notes/psfile.yaml
+++ b/releasenotes/notes/psfile.yaml
@@ -1,6 +1,6 @@
 apiVersion: release-notes/v2
 kind: feature
-area: istioctlS
+area: istioctl
 releaseNotes: |
   *Added*
   - Allow proxy-status for non-K8s workloads with --file


### PR DESCRIPTION
In #25627 there was a typo of `istioctlS` instead of `istioctl`.  This
resolves that as well as ensuring the file ends with a newline (as all
of the other release notes do).

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
