### PR TITLE
[release-1.6] Add missing telemetry.loadshedding.* options to mixer container args

### DIFF
--- a/manifests/charts/istio-telemetry/mixer-telemetry/templates/deployment.yaml
+++ b/manifests/charts/istio-telemetry/mixer-telemetry/templates/deployment.yaml
@@ -132,6 +132,10 @@ spec:
           {{- else }}
           - --trace_zipkin_url=http://zipkin.{{ .Values.global.telemetryNamespace }}:9411/api/v1/spans
           {{- end }}
+          - --averageLatencyThreshold
+          - {{ .Values.mixer.telemetry.loadshedding.latencyThreshold }}
+          - --loadsheddingMode
+          - {{ .Values.mixer.telemetry.loadshedding.mode }}
         env:
         - name: POD_NAMESPACE
           valueFrom:


### PR DESCRIPTION
Note: I reopened #25565 and changed the target branch to istio release 1.6

Simply imports missing parts from https://github.com/istio/istio/blob/1.5.8/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml#L276

.proto and profiles/ have already these values

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
