### PR TITLE
fix kubecontroller flake in XDS tests

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/fake.go
+++ b/pilot/pkg/serviceregistry/kube/controller/fake.go
@@ -140,6 +140,9 @@ type FakeController struct {
 }
 
 func (f *FakeController) ResyncEndpoints() error {
+	// TODO this workaround fixes a flake that indicates a real issue.
+	// TODO(cont) See https://github.com/istio/istio/issues/24117 and https://github.com/istio/istio/pull/24339
+
 	e, ok := f.endpoints.(*endpointsController)
 	if !ok {
 		return errors.New("cannot run ResyncEndpoints; EndpointsMode must be EndpointsOnly")

--- a/pilot/pkg/serviceregistry/kube/controller/fake.go
+++ b/pilot/pkg/serviceregistry/kube/controller/fake.go
@@ -153,6 +153,8 @@ func (f *FakeController) ResyncEndpoints() error {
 		// endpoint updates are skipped when the service is not there yet
 		if host, svc, ns := e.getServiceInfo(ep); host != "" {
 			_ = retry.UntilSuccess(func() error {
+				f.RLock()
+				defer f.RUnlock()
 				if f.servicesMap[host] == nil {
 					return fmt.Errorf("waiting for service %s in %s to be populated", svc, ns)
 				}


### PR DESCRIPTION
For the kube Controller there is a race between Services being loaded and Endpoints being built. This was causing test flakes, fixes https://github.com/istio/istio/issues/25863.

```
$ go test -run TestMeshNetworking -count=20 -race
...
PASS
ok      istio.io/istio/pilot/pkg/xds    11.519s

$ go test -run TestMeshNetworking -count=100
...
PASS
ok      istio.io/istio/pilot/pkg/xds    16.917s
```

This PR is a workaround that waits for the related service before force-syncing the endpoint. Should we look into handling this elsewhere by retrying the endpoint event or attempting to wait for the service? Maybe just on controller init? 

https://github.com/istio/istio/blob/78fa9a988acdda70785b0dd5b1ea1b30cb89e1bc/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go#L96

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
