### PR TITLE
Avoid Sidecar Cluster Config Generation for UpstreamClusters when CredentialName is set

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -926,6 +926,14 @@ func buildUpstreamClusterTLSContext(opts *buildClusterOpts, tls *networking.Clie
 	c := opts.cluster
 	proxy := opts.proxy
 
+	// Hack to avoid egress sds cluster config generation for sidecar when
+	// CredentialName is set in DestinationRule
+	if tls.CredentialName != "" && proxy.Type == model.SidecarProxy {
+		if tls.Mode == networking.ClientTLSSettings_SIMPLE || tls.Mode == networking.ClientTLSSettings_MUTUAL {
+			return nil, nil
+		}
+	}
+
 	var tlsContext *auth.UpstreamTlsContext
 
 	switch tls.Mode {
@@ -1004,7 +1012,7 @@ func buildUpstreamClusterTLSContext(opts *buildClusterOpts, tls *networking.Clie
 			}
 		}
 	case networking.ClientTLSSettings_SIMPLE:
-		if tls.CredentialName != "" && proxy.Type == model.Router {
+		if tls.CredentialName != "" {
 			tlsContext = &auth.UpstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{},
 				Sni:              tls.Sni,
@@ -1050,7 +1058,7 @@ func buildUpstreamClusterTLSContext(opts *buildClusterOpts, tls *networking.Clie
 		}
 
 	case networking.ClientTLSSettings_MUTUAL:
-		if tls.CredentialName != "" && proxy.Type == model.Router {
+		if tls.CredentialName != "" {
 			tlsContext = &auth.UpstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{},
 				Sni:              tls.Sni,

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -3518,6 +3518,50 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 				err: nil,
 			},
 		},
+		{
+			name: "tls mode MUTUAL, credentialName is set with proxy type Sidecar",
+			opts: &buildClusterOpts{
+				cluster: &cluster.Cluster{
+					Name: "test-cluster",
+				},
+				proxy: &model.Proxy{
+					Metadata: &model.NodeMetadata{},
+					Type:     model.SidecarProxy,
+				},
+			},
+			tls: &networking.ClientTLSSettings{
+				Mode:              networking.ClientTLSSettings_MUTUAL,
+				CredentialName:    "fake-cred",
+			},
+			node:                  &model.Proxy{},
+			certValidationContext: &tls.CertificateValidationContext{},
+			result: expectedResult{
+				nil,
+				nil,
+			},
+		},
+		{
+			name: "tls mode SIMPLE, credentialName is set with proxy type Sidecar",
+			opts: &buildClusterOpts{
+				cluster: &cluster.Cluster{
+					Name: "test-cluster",
+				},
+				proxy: &model.Proxy{
+					Metadata: &model.NodeMetadata{},
+					Type:     model.SidecarProxy,
+				},
+			},
+			tls: &networking.ClientTLSSettings{
+				Mode:              networking.ClientTLSSettings_SIMPLE,
+				CredentialName:    "fake-cred",
+			},
+			node:                  &model.Proxy{},
+			certValidationContext: &tls.CertificateValidationContext{},
+			result: expectedResult{
+				nil,
+				nil,
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -3530,8 +3530,8 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 				},
 			},
 			tls: &networking.ClientTLSSettings{
-				Mode:              networking.ClientTLSSettings_MUTUAL,
-				CredentialName:    "fake-cred",
+				Mode:           networking.ClientTLSSettings_MUTUAL,
+				CredentialName: "fake-cred",
 			},
 			node:                  &model.Proxy{},
 			certValidationContext: &tls.CertificateValidationContext{},
@@ -3552,8 +3552,8 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 				},
 			},
 			tls: &networking.ClientTLSSettings{
-				Mode:              networking.ClientTLSSettings_SIMPLE,
-				CredentialName:    "fake-cred",
+				Mode:           networking.ClientTLSSettings_SIMPLE,
+				CredentialName: "fake-cred",
 			},
 			node:                  &model.Proxy{},
 			certValidationContext: &tls.CertificateValidationContext{},


### PR DESCRIPTION
The solution in https://github.com/istio/istio/pull/25517 was slightly incomplete. As it doesn't avoid TLS generation error later in the function. Right now if 1000 DR are deployed with credentials, we'll see 1000 Errors in istiod logs regarding absence of tls.privatekey and tls.clientcert