### PR TITLE
disable logging in benchmarks

### DIFF
--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -85,7 +85,15 @@ var testCases = []ConfigInput{
 	},
 }
 
+func disableLogging() {
+	adsLog.SetOutputLevel(log.NoneLevel)
+	o := log.DefaultOptions()
+	o.SetOutputLevel(log.DefaultScopeName, log.NoneLevel)
+	_ = log.Configure(o)
+}
+
 func BenchmarkInitPushContext(b *testing.B) {
+	disableLogging()
 	for _, tt := range testCases {
 		b.Run(tt.Name, func(b *testing.B) {
 			s, proxy := setupTest(b, tt)
@@ -98,6 +106,8 @@ func BenchmarkInitPushContext(b *testing.B) {
 }
 
 func BenchmarkRouteGeneration(b *testing.B) {
+	disableLogging()
+
 	for _, tt := range testCases {
 		b.Run(tt.Name, func(b *testing.B) {
 			s, proxy := setupAndInitializeTest(b, tt)
@@ -122,6 +132,7 @@ func BenchmarkRouteGeneration(b *testing.B) {
 }
 
 func BenchmarkClusterGeneration(b *testing.B) {
+	disableLogging()
 	for _, tt := range testCases {
 		b.Run(tt.Name, func(b *testing.B) {
 			s, proxy := setupAndInitializeTest(b, tt)
@@ -140,6 +151,7 @@ func BenchmarkClusterGeneration(b *testing.B) {
 }
 
 func BenchmarkListenerGeneration(b *testing.B) {
+	disableLogging()
 	for _, tt := range testCases {
 		b.Run(tt.Name, func(b *testing.B) {
 			s, proxy := setupAndInitializeTest(b, tt)
@@ -160,6 +172,7 @@ func BenchmarkListenerGeneration(b *testing.B) {
 // BenchmarkEDS measures performance of EDS config generation
 // TODO Add more variables, such as different services
 func BenchmarkEndpointGeneration(b *testing.B) {
+	disableLogging()
 	tests := []struct {
 		endpoints int
 		services  int
@@ -169,7 +182,7 @@ func BenchmarkEndpointGeneration(b *testing.B) {
 		{100, 10},
 		{1000, 1},
 	}
-	adsLog.SetOutputLevel(log.WarnLevel)
+
 	var response *discovery.DiscoveryResponse
 	for _, tt := range tests {
 		b.Run(fmt.Sprintf("%d/%d", tt.endpoints, tt.services), func(b *testing.B) {

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -86,10 +86,9 @@ var testCases = []ConfigInput{
 }
 
 func disableLogging() {
-	adsLog.SetOutputLevel(log.NoneLevel)
-	o := log.DefaultOptions()
-	o.SetOutputLevel(log.DefaultScopeName, log.NoneLevel)
-	_ = log.Configure(o)
+	for _, s := range log.Scopes() {
+		s.SetOutputLevel(log.NoneLevel)
+	}
 }
 
 func BenchmarkInitPushContext(b *testing.B) {


### PR DESCRIPTION
Fixes output below:

```
~/g/s/i/istio ❯❯❯ go test ./pilot/pkg/xds -bench=Generation -run='XXX'  -count='5
2020-07-27T20:34:54.767663Z     info    Initializing Kubernetes service registry "Kubernetes"
goos: darwin
goarch: amd64
pkg: istio.io/istio/pilot/pkg/xds
BenchmarkRouteGeneration/gateways-12            2020-07-27T20:34:54.979403Z     info    Initializing Kubernetes service registry "Kubernetes"
      25          45712393 ns/op              2733 kb/msg             1001 resources/msg
BenchmarkRouteGeneration/gateways-12            2020-07-27T20:34:56.281291Z     info    Initializing Kubernetes service registry "Kubernetes"
2020-07-27T20:34:56.485913Z     info    Initializing Kubernetes service registry "Kubernetes"
      24          48634769 ns/op              2733 kb/msg             1001 resources/msg
BenchmarkRouteGeneration/gateways-12            2020-07-27T20:34:57.816107Z     info    Initializing Kubernetes service registry "Kubernetes"
2020-07-27T20:34:58.055051Z     info    Initializing Kubernetes service registry "Kubernetes"
      21          58341421 ns/op              2733 kb/msg             1001 resources/msg
BenchmarkRouteGeneration/gateways-12            2020-07-27T20:34:59.458508Z     info    Initializing Kubernetes service registry "Kubernetes"
 2020-07-27T20:34:59.685946Z    info    Initializing Kubernetes service registry "Kubernetes"
2020-07-27T20:35:00.846470Z     info    Initializing Kubernetes service registry "Kubernetes"
      24          46322328 ns/op              2733 kb/msg             1001 resources/msg
BenchmarkRouteGeneration/gateways-12            2020-07-27T20:35:02.127261Z     info    Initializing Kubernetes service registry "Kubernetes"
2020-07-27T20:35:02.349872Z     info    Initializing Kubernetes service registry "Kubernetes"
      26          47525746 ns/op              2733 kb/msg             1001 resources/msg
2020-07-27T20:35:04.198068Z     info    Initializing Kubernetes service registry "Kubernetes"
```


