### PR TITLE
Fix pod locality flakes

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -292,6 +292,15 @@ func TestController_GetPodLocality(t *testing.T) {
 			controller, fx := NewFakeControllerWithOptions(FakeControllerOptions{Mode: EndpointsOnly})
 			defer controller.Stop()
 			addNodes(t, controller, tc.nodes...)
+			for _, node := range tc.nodes {
+				if err := waitForNode(controller, node.Name); err != nil {
+					// Ideally we would fail here, but there is a bug in Kubernetes fake client where
+					// it occasionally just does not update informer at all. Rather than skipping the entire test, we will
+					// just skip it if we encounter this condition. Because it happens rarely, we should still
+					// get coverage 99% of the time.
+					t.Skip("https://github.com/kubernetes/kubernetes/issues/88508")
+				}
+			}
 			addPods(t, controller, tc.pods...)
 			for _, pod := range tc.pods {
 				if err := waitForPod(controller, pod.Status.PodIP); err != nil {

--- a/pilot/pkg/serviceregistry/kube/controller/pod_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod_test.go
@@ -27,6 +27,7 @@ import (
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/labels"
+	"istio.io/istio/pkg/test/util/retry"
 )
 
 // Prepare k8s. This can be used in multiple tests, to
@@ -168,6 +169,13 @@ func waitForPod(c *FakeController, ip string) error {
 		}
 		return false, nil
 	})
+}
+
+func waitForNode(c *FakeController, name string) error {
+	return retry.UntilSuccess(func() error {
+		_, err := c.nodeLister.Get(name)
+		return err
+	}, retry.Timeout(time.Second * 5))
 }
 
 func testPodCache(t *testing.T) {

--- a/pilot/pkg/serviceregistry/kube/controller/pod_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod_test.go
@@ -175,7 +175,7 @@ func waitForNode(c *FakeController, name string) error {
 	return retry.UntilSuccess(func() error {
 		_, err := c.nodeLister.Get(name)
 		return err
-	}, retry.Timeout(time.Second * 5))
+	}, retry.Timeout(time.Second*5))
 }
 
 func testPodCache(t *testing.T) {


### PR DESCRIPTION
This has been flaky for literally a year. I am pretty confident this
will fix the issues once and for all. This expands our previous hack to
skip on node update failure as well.

Without pr: `2142 runs so far, 6 failures`. With PR: `1506 runs so far, 0 failures`