### PR TITLE
quote jq path in prow metallb setup

### DIFF
--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -303,7 +303,7 @@ function install_metallb() {
 
   if [ -z "${METALLB_IPS[*]}" ]; then
     # Take IPs from the end of the docker kind network subnet to use for MetalLB IPs
-    DOCKER_KIND_SUBNET="$(docker inspect kind | jq .[0].IPAM.Config[0].Subnet -r)"
+    DOCKER_KIND_SUBNET="$(docker inspect kind | jq '.[0].IPAM.Config[0].Subnet' -r)"
     METALLB_IPS=()
     while read -r ip; do
       METALLB_IPS+=("$ip")


### PR DESCRIPTION
fixes a small issue on zsh `install_metallb:9: no matches found: .[0].IPAM.Config[0].Subnet` when trying to 
```
source prow/lib.sh
install_metallb $KUBECONFIG
```

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
