### PR TITLE
operator: add ownerReferences to generated resources

### DIFF
--- a/operator/pkg/helmreconciler/apply.go
+++ b/operator/pkg/helmreconciler/apply.go
@@ -94,7 +94,7 @@ func (h *HelmReconciler) ApplyManifest(manifest name.Manifest) (object.K8sObject
 		objList.Sort(object.DefaultObjectOrder())
 		for _, obj := range objList {
 			obju := obj.UnstructuredObject()
-			if err := h.applyLabelsAndAnnotations(obju, cname); err != nil {
+			if err := h.applyMetadata(obju, cname); err != nil {
 				return nil, 0, err
 			}
 			if err := h.ApplyObject(obj.UnstructuredObject()); err != nil {

--- a/operator/pkg/helmreconciler/prune.go
+++ b/operator/pkg/helmreconciler/prune.go
@@ -217,7 +217,7 @@ func (h *HelmReconciler) DeleteControlPlaneByManifests(manifestMap name.Manifest
 				continue
 			}
 			obju := obj.UnstructuredObject()
-			if err := h.applyLabelsAndAnnotations(obju, cn); err != nil {
+			if err := h.applyMetadata(obju, cn); err != nil {
 				return err
 			}
 			unstructuredObjects.Items = append(unstructuredObjects.Items, *obju)

--- a/operator/pkg/helmreconciler/prune_test.go
+++ b/operator/pkg/helmreconciler/prune_test.go
@@ -92,8 +92,8 @@ func applyResourcesIntoCluster(t *testing.T, h *HelmReconciler, manifestMap name
 		}
 		for _, obj := range objects {
 			obju := obj.UnstructuredObject()
-			if err := h.applyLabelsAndAnnotations(obju, cn); err != nil {
-				t.Errorf("failed to apply label and annotations: %v", err)
+			if err := h.applyMetadata(obju, cn); err != nil {
+				t.Errorf("failed to apply metadata: %v", err)
 			}
 			if err := h.ApplyObject(obj.UnstructuredObject()); err != nil {
 				t.Errorf("HelmReconciler.ApplyObject() error = %v", err)

--- a/operator/pkg/util/ownerreference.go
+++ b/operator/pkg/util/ownerreference.go
@@ -55,7 +55,7 @@ func upsertOwnerRef(ref metav1.OwnerReference, object metav1.Object) {
 	object.SetOwnerReferences(owners)
 }
 
-// SetLabel is a helper function which sets the specified label and value on te specified object.
+// SetOwnerReference is a helper function which sets the specified OwnerReferences on te specified object.
 func SetOwnerReference(resource runtime.Object, ownerRef metav1.OwnerReference) error {
 	resourceAccessor, err := meta.Accessor(resource)
 	if err != nil {

--- a/operator/pkg/util/ownerreference.go
+++ b/operator/pkg/util/ownerreference.go
@@ -1,0 +1,71 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func referSameObject(a, b metav1.OwnerReference) bool {
+	aGV, err := schema.ParseGroupVersion(a.APIVersion)
+	if err != nil {
+		return false
+	}
+
+	bGV, err := schema.ParseGroupVersion(b.APIVersion)
+	if err != nil {
+		return false
+	}
+
+	return aGV.Group == bGV.Group && a.Kind == b.Kind && a.Name == b.Name
+}
+
+func indexOwnerRef(ownerReferences []metav1.OwnerReference, ref metav1.OwnerReference) int {
+	for index, r := range ownerReferences {
+		if referSameObject(r, ref) {
+			return index
+		}
+	}
+	return -1
+}
+
+func upsertOwnerRef(ref metav1.OwnerReference, object metav1.Object) {
+	owners := object.GetOwnerReferences()
+	idx := indexOwnerRef(owners, ref)
+	if idx == -1 {
+		owners = append(owners, ref)
+	} else {
+		owners[idx] = ref
+	}
+	object.SetOwnerReferences(owners)
+}
+
+// SetLabel is a helper function which sets the specified label and value on te specified object.
+func SetOwnerReference(resource runtime.Object, ownerRef metav1.OwnerReference) error {
+	resourceAccessor, err := meta.Accessor(resource)
+	if err != nil {
+		return err
+	}
+	ownerRefs := resourceAccessor.GetOwnerReferences()
+	if ownerRefs == nil {
+		ownerRefs = []metav1.OwnerReference{}
+	}
+	ownerRefs = append(ownerRefs, ownerRef)
+	resourceAccessor.SetOwnerReferences(ownerRefs)
+	return nil
+}


### PR DESCRIPTION
Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure

Some opensource tools like ArgoCD has dependencies to the `ownerReferences` metadata for resources created in operator-pattern.