### PR TITLE
convert pilot tests to use all clusters

### DIFF
--- a/pkg/test/echo/client/parsedresponse.go
+++ b/pkg/test/echo/client/parsedresponse.go
@@ -247,15 +247,15 @@ func (r ParsedResponses) Count(text string) int {
 	return count
 }
 
-// Hits returns the number of responess passing the given checker function.
-func (r ParsedResponses) Hits(f func(r *ParsedResponse) bool) int {
-	count := 0
-	for _, c := range r {
-		if f(c) {
-			count++
+// Match returns a subset of ParsedResponses that match the given predicate.
+func (r ParsedResponses) Match(f func(r *ParsedResponse) bool) ParsedResponses {
+	var matched []*ParsedResponse
+	for _, rr := range r {
+		if f(rr) {
+			matched = append(matched, rr)
 		}
 	}
-	return count
+	return matched
 }
 
 func (r ParsedResponses) String() string {

--- a/pkg/test/echo/client/parsedresponse.go
+++ b/pkg/test/echo/client/parsedresponse.go
@@ -16,6 +16,7 @@ package client
 
 import (
 	"fmt"
+	"istio.io/istio/pkg/test/framework/resource"
 	"regexp"
 	"strconv"
 	"strings"
@@ -180,18 +181,18 @@ func (r ParsedResponses) clusterDistribution() map[string]int {
 // CheckReachedClusters returns an error if there wasn't at least one response from each of the given clusters.
 // This can be used in combination with echo.Instances.Clusters(), for example:
 //     echoA[0].CallOrFail(t, ...).CheckReachedClusters(echoB.Clusters())
-func (r ParsedResponses) CheckReachedClusters(clusterNames []string) error {
+func (r ParsedResponses) CheckReachedClusters(clusters resource.Clusters) error {
 	hits := r.clusterDistribution()
 	exp := map[string]struct{}{}
-	for _, expCluster := range clusterNames {
-		exp[expCluster] = struct{}{}
-		if hits[expCluster] == 0 {
-			return fmt.Errorf("did not reach all of %v, got %v", clusterNames, hits)
+	for _, expCluster := range clusters {
+		exp[expCluster.Name()] = struct{}{}
+		if hits[expCluster.Name()] == 0 {
+			return fmt.Errorf("did not reach all of %v, got %v", clusters, hits)
 		}
 	}
 	for hitCluster := range hits {
 		if _, ok := exp[hitCluster]; !ok {
-			return fmt.Errorf("reached cluster not in %v, got %v", clusterNames, hits)
+			return fmt.Errorf("reached cluster not in %v, got %v", clusters, hits)
 		}
 	}
 	return nil

--- a/pkg/test/echo/client/parsedresponse.go
+++ b/pkg/test/echo/client/parsedresponse.go
@@ -16,7 +16,6 @@ package client
 
 import (
 	"fmt"
-	"istio.io/istio/pkg/test/framework/resource"
 	"regexp"
 	"strconv"
 	"strings"
@@ -26,6 +25,7 @@ import (
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/echo/common/response"
 	"istio.io/istio/pkg/test/echo/proto"
+	"istio.io/istio/pkg/test/framework/resource"
 )
 
 var (

--- a/pkg/test/echo/client/parsedresponse.go
+++ b/pkg/test/echo/client/parsedresponse.go
@@ -182,9 +182,16 @@ func (r ParsedResponses) clusterDistribution() map[string]int {
 //     echoA[0].CallOrFail(t, ...).CheckReachedClusters(echoB.Clusters())
 func (r ParsedResponses) CheckReachedClusters(clusterNames []string) error {
 	hits := r.clusterDistribution()
+	exp := map[string]struct{}{}
 	for _, expCluster := range clusterNames {
+		exp[expCluster] = struct{}{}
 		if hits[expCluster] == 0 {
 			return fmt.Errorf("did not reach all of %v, got %v", clusterNames, hits)
+		}
+	}
+	for hitCluster := range hits {
+		if _, ok := exp[hitCluster]; !ok {
+			return fmt.Errorf("reached cluster not in %v, got %v", clusterNames, hits)
 		}
 	}
 	return nil

--- a/pkg/test/framework/components/echo/instances.go
+++ b/pkg/test/framework/components/echo/instances.go
@@ -25,6 +25,19 @@ import (
 // Instances contains the instances created by the builder with methods for filtering
 type Instances []Instance
 
+// Clusters returns a list of cluster names that the instances are deployed in
+func (i Instances) Clusters() []string {
+	clusters := map[string]struct{}{}
+	for _, instance := range i {
+		clusters[instance.Config().Cluster.Name()] = struct{}{}
+	}
+	out := make([]string, 0, len(clusters))
+	for name := range clusters {
+		out = append(out, name)
+	}
+	return out
+}
+
 // Matcher is used to filter matching instances
 type Matcher func(Instance) bool
 
@@ -57,6 +70,13 @@ func InCluster(c resource.Cluster) Matcher {
 	}
 }
 
+// InNetwork matches instances deployed in the given network.
+func InNetwork(n string) Matcher {
+	return func(i Instance) bool {
+		return i.Config().Cluster.NetworkName() == n
+	}
+}
+
 // Match filters instances that matcher the given Matcher
 func (i Instances) Match(matches Matcher) Instances {
 	out := make(Instances, 0)
@@ -83,4 +103,16 @@ func (i Instances) GetOrFail(t test.Failer, matches Matcher) Instance {
 		t.Fatal(err)
 	}
 	return res
+}
+
+func (i Instances) Contains(instances ...Instance) bool {
+	matches := i.Match(func(instance Instance) bool {
+		for _, ii := range instances {
+			if ii == instance {
+				return true
+			}
+		}
+		return false
+	})
+	return len(matches) > 0
 }

--- a/pkg/test/framework/components/echo/instances.go
+++ b/pkg/test/framework/components/echo/instances.go
@@ -26,14 +26,14 @@ import (
 type Instances []Instance
 
 // Clusters returns a list of cluster names that the instances are deployed in
-func (i Instances) Clusters() []string {
-	clusters := map[string]struct{}{}
+func (i Instances) Clusters() resource.Clusters {
+	clusters := map[string]resource.Cluster{}
 	for _, instance := range i {
-		clusters[instance.Config().Cluster.Name()] = struct{}{}
+		clusters[instance.Config().Cluster.Name()] = instance.Config().Cluster
 	}
-	out := make([]string, 0, len(clusters))
-	for name := range clusters {
-		out = append(out, name)
+	out := make(resource.Clusters, 0, len(clusters))
+	for _, c := range clusters {
+		out = append(out, c)
 	}
 	return out
 }

--- a/pkg/test/framework/components/echo/kube/instance.go
+++ b/pkg/test/framework/components/echo/kube/instance.go
@@ -168,12 +168,13 @@ metadata:
 spec:
   address: %s
   serviceAccount: %s
+  network: %q
   labels:
     app: %s
     version: %s
-`, vmPod.Name, vmPod.Status.PodIP, serviceAccount, cfg.Service, vmPod.Labels["istio.io/test-vm-version"])
+`, vmPod.Name, vmPod.Status.PodIP, serviceAccount, cfg.Cluster.NetworkName(), cfg.Service, vmPod.Labels["istio.io/test-vm-version"])
 			// Deploy the workload entry.
-			if err = ctx.Config(c.cluster).ApplyYAML(cfg.Namespace.Name(), wle); err != nil {
+			if err = ctx.Config().ApplyYAML(cfg.Namespace.Name(), wle); err != nil {
 				return nil, fmt.Errorf("failed deploying workload entry: %v", err)
 			}
 		}

--- a/pkg/test/framework/resource/cluster.go
+++ b/pkg/test/framework/resource/cluster.go
@@ -45,6 +45,23 @@ func (c Clusters) GetOrDefault(cluster Cluster) Cluster {
 	return c.Default()
 }
 
+// Names returns the deduped list of names of the clusters.
+func (c Clusters) Names() []string {
+	dedup := map[string]struct{}{}
+	for _, cc := range c {
+		dedup[cc.Name()] = struct{}{}
+	}
+	var names []string
+	for n := range dedup {
+		names = append(names, n)
+	}
+	return names
+}
+
+func (c Clusters) String() string {
+	return fmt.Sprintf("%v", c.Names())
+}
+
 // Cluster in a multicluster environment.
 type Cluster interface {
 	fmt.Stringer

--- a/pkg/test/framework/resource/environment.go
+++ b/pkg/test/framework/resource/environment.go
@@ -32,6 +32,8 @@ type Environment interface {
 
 	// Clusters in this Environment. There will always be at least one.
 	Clusters() Clusters
+
+	IsMultinetwork() bool
 }
 
 var _ Environment = FakeEnvironment{}
@@ -45,6 +47,10 @@ type FakeEnvironment struct {
 
 func (f FakeEnvironment) ID() ID {
 	return FakeID(f.IDValue)
+}
+
+func (f FakeEnvironment) IsMultinetwork() bool {
+	return false
 }
 
 func (f FakeEnvironment) EnvironmentName() string {

--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -245,6 +245,7 @@ spec:
 				ctx.NewSubTest(tt.name).Run(func(t framework.TestContext) {
 					retry.UntilSuccessOrFail(t, func() error {
 						resp, err := ingr.Call(tt.call)
+						// TODO check all clusters were hit
 						if err != nil {
 							return err
 						}

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -201,7 +201,7 @@ func TestDescribe(t *testing.T) {
 			// run in parallel.
 			retry.UntilSuccessOrFail(ctx, func() error {
 				args := []string{"--namespace=dummy",
-					"x", "describe", "svc", fmt.Sprintf("%s.%s", apps.podA.Config().Service, apps.namespace.Name())}
+					"x", "describe", "svc", fmt.Sprintf("%s.%s", podASvc, apps.namespace.Name())}
 				output, _, err := istioCtl.Invoke(args)
 				if err != nil {
 					return err
@@ -213,7 +213,7 @@ func TestDescribe(t *testing.T) {
 			}, retry.Timeout(time.Second*5))
 
 			retry.UntilSuccessOrFail(ctx, func() error {
-				podID, err := getPodID(apps.podA)
+				podID, err := getPodID(apps.podA[0])
 				if err != nil {
 					return fmt.Errorf("could not get Pod ID: %v", err)
 				}
@@ -291,7 +291,7 @@ func TestProxyConfig(t *testing.T) {
 		Run(func(ctx framework.TestContext) {
 			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
 
-			podID, err := getPodID(apps.podA)
+			podID, err := getPodID(apps.podA[0])
 			if err != nil {
 				ctx.Fatalf("Could not get Pod ID: %v", err)
 			}
@@ -368,7 +368,7 @@ func TestProxyStatus(t *testing.T) {
 		Run(func(ctx framework.TestContext) {
 			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
 
-			podID, err := getPodID(apps.podA)
+			podID, err := getPodID(apps.podA[0])
 			if err != nil {
 				ctx.Fatalf("Could not get Pod ID: %v", err)
 			}
@@ -418,7 +418,7 @@ func TestAuthZCheck(t *testing.T) {
 
 			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{Cluster: ctx.Environment().Clusters()[0]})
 
-			podID, err := getPodID(apps.podA)
+			podID, err := getPodID(apps.podA[0])
 			if err != nil {
 				ctx.Fatalf("Could not get Pod ID: %v", err)
 			}

--- a/tests/integration/pilot/locality_test.go
+++ b/tests/integration/pilot/locality_test.go
@@ -111,20 +111,20 @@ func TestLocality(t *testing.T) {
 					LocalityInput{
 						LocalitySetting: localityFailover,
 						Resolution:      "DNS",
-						Local:           apps.podB.Config().Service,
-						Remote:          apps.podC.Config().Service,
+						Local:           podBSvc,
+						Remote:          podCSvc,
 					},
-					expectAllTrafficTo(apps.podB.Config().Service),
+					expectAllTrafficTo(podBSvc),
 				},
 				{
 					"Prioritized/EDS",
 					LocalityInput{
 						LocalitySetting: localityFailover,
 						Resolution:      "STATIC",
-						Local:           apps.podC.Address(),
-						Remote:          apps.podB.Address(),
+						Local:           apps.podC[0].Address(),
+						Remote:          apps.podB[0].Address(),
 					},
-					expectAllTrafficTo(apps.podC.Config().Service),
+					expectAllTrafficTo(podCSvc),
 				},
 				{
 					"Failover/CDS",
@@ -132,10 +132,10 @@ func TestLocality(t *testing.T) {
 						LocalitySetting: localityFailover,
 						Resolution:      "DNS",
 						Local:           "fake-should-fail.example.com",
-						NearLocal:       apps.podB.Config().Service,
-						Remote:          apps.podC.Config().Service,
+						NearLocal:       podBSvc,
+						Remote:          podCSvc,
 					},
-					expectAllTrafficTo(apps.podB.Config().Service),
+					expectAllTrafficTo(podBSvc),
 				},
 				{
 					"Failover/EDS",
@@ -143,23 +143,23 @@ func TestLocality(t *testing.T) {
 						LocalitySetting: localityFailover,
 						Resolution:      "STATIC",
 						Local:           "10.10.10.10",
-						NearLocal:       apps.podC.Address(),
-						Remote:          apps.podB.Address(),
+						NearLocal:       apps.podC[0].Address(),
+						Remote:          apps.podB[0].Address(),
 					},
-					expectAllTrafficTo(apps.podC.Config().Service),
+					expectAllTrafficTo(podCSvc),
 				},
 				{
 					"Distribute/CDS",
 					LocalityInput{
 						LocalitySetting: localityDistribute,
 						Resolution:      "DNS",
-						Local:           apps.podC.Config().Service,
-						NearLocal:       apps.podB.Config().Service,
+						Local:           podCSvc,
+						NearLocal:       podBSvc,
 						Remote:          "fake-should-fail.example.com",
 					},
 					map[string]int{
-						apps.podB.Config().Service: sendCount * .8,
-						apps.podC.Config().Service: sendCount * .2,
+						podBSvc: sendCount * .8,
+						podCSvc: sendCount * .2,
 					},
 				},
 				{
@@ -167,13 +167,13 @@ func TestLocality(t *testing.T) {
 					LocalityInput{
 						LocalitySetting: localityDistribute,
 						Resolution:      "STATIC",
-						Local:           apps.podB.Address(),
-						NearLocal:       apps.podC.Address(),
+						Local:           apps.podB[0].Address(),
+						NearLocal:       apps.podC[0].Address(),
 						Remote:          "10.10.10.10",
 					},
 					map[string]int{
-						apps.podC.Config().Service: sendCount * .8,
-						apps.podB.Config().Service: sendCount * .2,
+						podCSvc: sendCount * .8,
+						podBSvc: sendCount * .2,
 					},
 				},
 			}
@@ -183,7 +183,7 @@ func TestLocality(t *testing.T) {
 					tt.input.Host = hostname
 					applyAndCleanup(ctx, apps.namespace.Name(), runTemplate(ctx, localityTemplate, tt.input))
 					retry.UntilSuccessOrFail(ctx, func() error {
-						return sendTraffic(apps.podA, hostname, tt.expected)
+						return sendTraffic(apps.podA[0], hostname, tt.expected)
 					}, retry.Delay(250*time.Millisecond))
 				})
 			}

--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -52,6 +52,16 @@ var (
 	}
 )
 
+const (
+	podASvc     = "a"
+	podBSvc     = "b"
+	podCSvc     = "c"
+	vmASvc      = "vm-a"
+	headlessSvc = "headless"
+	nakedSvc    = "naked"
+	externalSvc = "external"
+)
+
 type EchoDeployments struct {
 	// Namespace echo apps will be deployed
 	namespace namespace.Instance
@@ -59,22 +69,24 @@ type EchoDeployments struct {
 	externalNamespace namespace.Instance
 
 	// Standard echo app to be used by tests
-	podA echo.Instance
+	podA echo.Instances
 	// Standard echo app to be used by tests
-	podB echo.Instance
+	podB echo.Instances
 	// Standard echo app to be used by tests
-	podC echo.Instance
+	podC echo.Instances
 	// Headless echo app to be used by tests
-	headless echo.Instance
+	headless echo.Instances
 	// Echo app to be used by tests, with no sidecar injected
-	naked echo.Instance
-	// A virtual machine echo app
+	naked echo.Instances
+	// A virtual machine echo app (only deployed to one cluster)
 	vmA echo.Instance
 
 	// Echo app to be used by tests, with no sidecar injected
-	external echo.Instance
+	external echo.Instances
 	// Fake hostname of external service
 	externalHost string
+
+	all echo.Instances
 }
 
 // TestMain defines the entrypoint for pilot tests using a standard Istio installation.
@@ -146,72 +158,88 @@ values:
 				p.ServicePort = p.InstancePort
 				headlessPorts[i] = p
 			}
-			if _, err := echoboot.NewBuilder(ctx).
-				With(&apps.podA, echo.Config{
-					Service:   "a",
-					Namespace: apps.namespace,
-					Ports:     echoPorts,
-					Subsets:   []echo.SubsetConfig{{}},
-					Locality:  "region.zone.subzone",
-				}).
-				With(&apps.podB, echo.Config{
-					Service:   "b",
-					Namespace: apps.namespace,
-					Ports:     echoPorts,
-					Subsets:   []echo.SubsetConfig{{}},
-				}).
-				With(&apps.podC, echo.Config{
-					Service:   "c",
-					Namespace: apps.namespace,
-					Ports:     echoPorts,
-					Subsets:   []echo.SubsetConfig{{}},
-				}).
-				With(&apps.headless, echo.Config{
-					Service:   "headless",
-					Headless:  true,
-					Namespace: apps.namespace,
-					Ports:     headlessPorts,
-					Subsets:   []echo.SubsetConfig{{}},
-				}).
-				With(&apps.vmA, echo.Config{
-					Service:    "vm-a",
-					Namespace:  apps.namespace,
-					Ports:      echoPorts,
-					DeployAsVM: true,
-					Subsets:    []echo.SubsetConfig{{}},
-				}).
-				With(&apps.naked, echo.Config{
-					Service:   "naked",
-					Namespace: apps.namespace,
-					Ports:     echoPorts,
-					Subsets: []echo.SubsetConfig{
-						{
-							Annotations: map[echo.Annotation]*echo.AnnotationValue{
-								echo.SidecarInject: {
-									Value: strconv.FormatBool(false)},
+			builder := echoboot.NewBuilder(ctx)
+			for _, c := range ctx.Environment().Clusters() {
+				builder.
+					With(nil, echo.Config{
+						Service:   podASvc,
+						Namespace: apps.namespace,
+						Ports:     echoPorts,
+						Subsets:   []echo.SubsetConfig{{}},
+						Locality:  "region.zone.subzone",
+						Cluster:   c,
+					}).
+					With(nil, echo.Config{
+						Service:   podBSvc,
+						Namespace: apps.namespace,
+						Ports:     echoPorts,
+						Subsets:   []echo.SubsetConfig{{}},
+						Cluster:   c,
+					}).
+					With(nil, echo.Config{
+						Service:   podCSvc,
+						Namespace: apps.namespace,
+						Ports:     echoPorts,
+						Subsets:   []echo.SubsetConfig{{}},
+						Cluster:   c,
+					}).
+					With(nil, echo.Config{
+						Service:   headlessSvc,
+						Headless:  true,
+						Namespace: apps.namespace,
+						Ports:     headlessPorts,
+						Subsets:   []echo.SubsetConfig{{}},
+						Cluster:   c,
+					}).
+					With(nil, echo.Config{
+						Service:   nakedSvc,
+						Namespace: apps.namespace,
+						Ports:     echoPorts,
+						Subsets: []echo.SubsetConfig{
+							{
+								Annotations: map[echo.Annotation]*echo.AnnotationValue{
+									echo.SidecarInject: {
+										Value: strconv.FormatBool(false)},
+								},
 							},
 						},
-					},
-				}).Build(); err != nil {
-				return err
-			}
-			if _, err := echoboot.NewBuilder(ctx).
-				With(&apps.external, echo.Config{
-					Service:   "external",
-					Namespace: apps.externalNamespace,
-					Ports:     echoPorts,
-					Subsets: []echo.SubsetConfig{
-						{
-							Annotations: map[echo.Annotation]*echo.AnnotationValue{
-								echo.SidecarInject: {
-									Value: strconv.FormatBool(false)},
+						Cluster: c,
+					}).
+					With(nil, echo.Config{
+						Service:   externalSvc,
+						Namespace: apps.externalNamespace,
+						Ports:     echoPorts,
+						Subsets: []echo.SubsetConfig{
+							{
+								Annotations: map[echo.Annotation]*echo.AnnotationValue{
+									echo.SidecarInject: {
+										Value: strconv.FormatBool(false)},
+								},
 							},
 						},
-					},
-				}).
-				Build(); err != nil {
+						Cluster: c,
+					})
+
+			}
+			echos, err := builder.With(&apps.vmA, echo.Config{
+				Service:    vmASvc,
+				Namespace:  apps.namespace,
+				Ports:      echoPorts,
+				DeployAsVM: true,
+				Subsets:    []echo.SubsetConfig{{}},
+				Cluster:    ctx.Clusters().Default(),
+			}).Build()
+			if err != nil {
 				return err
 			}
+			apps.all = echos
+			apps.podA = echos.Match(echo.Service(podASvc))
+			apps.podB = echos.Match(echo.Service(podBSvc))
+			apps.podC = echos.Match(echo.Service(podCSvc))
+			apps.headless = echos.Match(echo.Service(headlessSvc))
+			apps.naked = echos.Match(echo.Service(nakedSvc))
+			apps.external = echos.Match(echo.Service(externalSvc))
+
 			return nil
 		}).
 		Setup(func(ctx resource.Context) (err error) {

--- a/tests/integration/pilot/mirror_test.go
+++ b/tests/integration/pilot/mirror_test.go
@@ -170,7 +170,7 @@ func runMirrorTest(t *testing.T, options mirrorTestOptions) {
 func sendTrafficMirror(from, to echo.Instance, proto protocol.Instance, testID string) error {
 	options := echo.CallOptions{
 		Target:   to,
-		Count:    250,
+		Count:    100,
 		PortName: strings.ToLower(string(proto)),
 	}
 	switch proto {

--- a/tests/integration/pilot/mirror_test.go
+++ b/tests/integration/pilot/mirror_test.go
@@ -15,7 +15,6 @@
 package pilot
 
 import (
-	"context"
 	"fmt"
 	"math"
 	"strings"
@@ -193,12 +192,12 @@ func sendTrafficMirror(from, to echo.Instance, proto protocol.Instance, testID s
 }
 
 func verifyTrafficMirror(dest, mirror echo.Instances, tc testCaseMirror, testID string) error {
-	countsB, countB, err := logCount(dest, testID)
+	countB, err := logCount(dest, testID)
 	if err != nil {
 		return err
 	}
 
-	countsC, countC, err := logCount(mirror, testID)
+	countC, err := logCount(mirror, testID)
 	if err != nil {
 		return err
 	}
@@ -217,32 +216,33 @@ func verifyTrafficMirror(dest, mirror echo.Instances, tc testCaseMirror, testID 
 			tc.percentage, actualPercent, tc.threshold, testID)
 	}
 
-	if tc.percentage < 100 {
-		if len(countsB) < len(dest.Clusters()) {
-			merr = multierror.Append(merr, fmt.Errorf("expected original destination in all clusters to be reached, but got: %v", countsB))
-		}
-	}
-	if tc.percentage > 0 {
-		if len(countsC) < len(mirror.Clusters()) {
-			merr = multierror.Append(merr, fmt.Errorf("expected mirror destination in all clusters to be reached, but got: %v", countsC))
-		}
-	}
+	// TODO(landow) fix cross-network weighting issues
+	//if tc.percentage < 100 {
+	//	if len(countsB) < len(dest.Clusters()) {
+	//		merr = multierror.Append(merr, fmt.Errorf("expected original destination in all clusters to be reached, but got: %v", countsB))
+	//	}
+	//}
+	//if tc.percentage > 0 {
+	//	if len(countsC) < len(mirror.Clusters()) {
+	//		merr = multierror.Append(merr, fmt.Errorf("expected mirror destination in all clusters to be reached, but got: %v", countsC))
+	//	}
+	//}
 
 	return merr.ErrorOrNil()
 }
 
-func logCount(instances echo.Instances, testID string) (counts map[string]float64, total float64, err error) {
-	counts = map[string]float64{}
+func logCount(instances echo.Instances, testID string) (float64, error) {
+	counts := map[string]float64{}
 	for _, instance := range instances {
 		workloads, err := instance.Workloads()
 		if err != nil {
-			return nil, -1, fmt.Errorf("failed to get Subsets: %v", err)
+			return -1, fmt.Errorf("failed to get Subsets: %v", err)
 		}
 		var logs string
 		for _, w := range workloads {
 			l, err := w.Logs()
 			if err != nil {
-				return nil, -1, fmt.Errorf("failed getting logs: %v", err)
+				return -1, fmt.Errorf("failed getting logs: %v", err)
 			}
 			logs += l
 		}
@@ -250,9 +250,10 @@ func logCount(instances echo.Instances, testID string) (counts map[string]float6
 			counts[instance.Config().Cluster.Name()] = c
 		}
 	}
-	total = 0
+	var total float64
 	for _, c := range counts {
 		total += c
 	}
-	return counts, total, nil
+	// TODO(landow) return counts for cross-cluster load balancing validation
+	return total, nil
 }

--- a/tests/integration/pilot/mirror_test.go
+++ b/tests/integration/pilot/mirror_test.go
@@ -26,7 +26,6 @@ import (
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
-	"istio.io/istio/pkg/test/kube"
 	"istio.io/istio/pkg/test/util/file"
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/test/util/tmpl"

--- a/tests/integration/pilot/mirror_test.go
+++ b/tests/integration/pilot/mirror_test.go
@@ -160,7 +160,7 @@ func runMirrorTest(t *testing.T, options mirrorTestOptions) {
 											expected = apps.podC
 										}
 
-										return verifyTrafficMirror(podA, apps.podB, expected, res, c, testID)
+										return verifyTrafficMirror(apps.podB, expected, res, c, testID)
 									}, retry.Delay(time.Second))
 								})
 							}
@@ -188,7 +188,7 @@ func sendTrafficMirror(from, to echo.Instance, proto protocol.Instance, testID s
 	return from.Call(options)
 }
 
-func verifyTrafficMirror(source echo.Instance, dest, mirror echo.Instances, res client.ParsedResponses, tc testCaseMirror, testID string) error {
+func verifyTrafficMirror(dest, mirror echo.Instances, res client.ParsedResponses, tc testCaseMirror, testID string) error {
 	// TODO(landow) we can probably look at ParsedResposne instead of using logs
 	countB, err := logCount(dest, testID)
 	if err != nil {

--- a/tests/integration/pilot/routing_test.go
+++ b/tests/integration/pilot/routing_test.go
@@ -266,7 +266,6 @@ spec:
 			},
 		}
 
-		splittingCallCount := len(apps.podB) * 100
 		for _, split := range splits {
 			split := split
 			cases = append(cases, TrafficTestCase{
@@ -292,16 +291,14 @@ spec:
       weight: %d
 `, split[podBSvc], split[nakedSvc], split[vmASvc]),
 				call: func() (echoclient.ParsedResponses, error) {
-					return podA.Call(echo.CallOptions{Target: apps.podB[0], PortName: "http", Count: splittingCallCount})
+					return podA.Call(echo.CallOptions{Target: apps.podB[0], PortName: "http", Count: 100})
 				},
 				validator: func(responses echoclient.ParsedResponses) error {
 					if err := responses.CheckOK(); err != nil {
 						return err
 					}
 					errorThreshold := 10
-					for host, expPercent := range split {
-						pct := float32(expPercent) / 100
-						exp := int(pct * float32(splittingCallCount))
+					for host, exp := range split {
 						hits := responses.Hits(func(r *echoclient.ParsedResponse) bool {
 							return strings.HasPrefix(r.Hostname, host+"-")
 						})

--- a/tests/integration/pilot/routing_test.go
+++ b/tests/integration/pilot/routing_test.go
@@ -267,6 +267,7 @@ spec:
 		}
 
 		if ctx.Environment().IsMultinetwork() {
+			// TODO(#26517) fix multinetwork with non-sidecar pods, for now just go to pods that support mTLS
 			splits = []map[string]int{
 				{
 					podBSvc:  60,
@@ -360,7 +361,7 @@ func protocolSniffingCases(ctx framework.TestContext) []TrafficTestCase {
 			}
 
 			if !ctx.Environment().IsMultinetwork() {
-				// TODO(landow) fix multinetwork issues with non-sidecar pods, for now only test this in single-network
+				// TODO(#26517) fix multinetwork with non-sidecar pods, for now only test this in single-network
 				// the filter below assumes we fix this by restricting cross-network for non-sidecars
 				apps.naked.Match(echo.InNetwork(client.Config().Cluster.NetworkName()))
 			}
@@ -554,7 +555,6 @@ func serverFirstTestCases() []TrafficTestCase {
 					})
 				},
 				validator: func(responses echoclient.ParsedResponses) error {
-					var x = 1
 					return responses.CheckOK()
 				},
 				expectFailure: !c.success,

--- a/tests/integration/pilot/routing_test.go
+++ b/tests/integration/pilot/routing_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 // callsPerCluster is used to ensure cross-cluster load balancing has a chance to work
-const callsPerCluster = 20
+const callsPerCluster = 10
 
 type TrafficTestCase struct {
 	name   string

--- a/tests/integration/pilot/routing_test.go
+++ b/tests/integration/pilot/routing_test.go
@@ -309,10 +309,10 @@ spec:
 							return fmt.Errorf("expected %v calls to %q, got %v", exp, host, hits)
 						}
 						// since we're changing where traffic goes, make sure we don't break cross-cluster load balancing
-						// TODO(landow) if we can fix cross-network weights, ensure even distribution across clusters
 						if err := responses.CheckReachedClusters(apps.all.Match(echo.Service(host)).Clusters()); err != nil {
 							return err
 						}
+						// TODO(landow) add res.CheckEqualClusterTraffic() when cross-network weighting is fixed
 					}
 					return nil
 				},

--- a/tests/integration/pilot/routing_test.go
+++ b/tests/integration/pilot/routing_test.go
@@ -363,7 +363,7 @@ func protocolSniffingCases(ctx framework.TestContext) []TrafficTestCase {
 			if !ctx.Environment().IsMultinetwork() {
 				// TODO(#26517) fix multinetwork with non-sidecar pods, for now only test this in single-network
 				// the filter below assumes we fix this by restricting cross-network for non-sidecars
-				apps.naked.Match(echo.InNetwork(client.Config().Cluster.NetworkName()))
+				destinationSets = append(destinationSets, apps.naked.Match(echo.InNetwork(client.Config().Cluster.NetworkName())))
 			}
 
 			for _, destinations := range destinationSets {

--- a/tests/integration/pilot/routing_test.go
+++ b/tests/integration/pilot/routing_test.go
@@ -270,12 +270,12 @@ spec:
 			// TODO(#26517) fix multinetwork with non-sidecar pods, for now just go to pods that support mTLS
 			splits = []map[string]int{
 				{
-					podBSvc:  60,
-					vmASvc:   40,
+					podBSvc: 60,
+					vmASvc:  40,
 				},
 				{
-					podBSvc:  80,
-					vmASvc:   20,
+					podBSvc: 80,
+					vmASvc:  20,
 				},
 			}
 		}

--- a/tests/integration/pilot/routing_test.go
+++ b/tests/integration/pilot/routing_test.go
@@ -544,7 +544,6 @@ func TestTraffic(t *testing.T) {
 	framework.
 		NewTest(t).
 		Features("traffic.routing", "traffic.reachability", "traffic.shifting").
-		RequiresSingleCluster().
 		Run(func(ctx framework.TestContext) {
 			cases := map[string][]TrafficTestCase{}
 			cases["virtualservice"] = virtualServiceCases()

--- a/tests/integration/pilot/routing_test.go
+++ b/tests/integration/pilot/routing_test.go
@@ -52,7 +52,7 @@ type TrafficCall struct {
 	expectFailure bool
 }
 
-func virtualServiceCases() []TrafficTestCase {
+func virtualServiceCases(ctx framework.TestContext) []TrafficTestCase {
 	var cases []TrafficTestCase
 	callCount := callsPerCluster * len(apps.podB)
 	for _, podA := range apps.podA {
@@ -266,6 +266,19 @@ spec:
 			},
 		}
 
+		if ctx.Environment().IsMultinetwork() {
+			splits = []map[string]int{
+				{
+					podBSvc:  60,
+					vmASvc:   40,
+				},
+				{
+					podBSvc:  80,
+					vmASvc:   20,
+				},
+			}
+		}
+
 		for _, split := range splits {
 			split := split
 			cases = append(cases, TrafficTestCase{
@@ -334,7 +347,6 @@ func expectString(got, expected, help string) error {
 
 // Todo merge with security TestReachability code
 func protocolSniffingCases(ctx framework.TestContext) []TrafficTestCase {
-
 
 	cases := []TrafficTestCase{}
 	// TODO add VMs to clients when DNS works for VMs.
@@ -559,7 +571,7 @@ func TestTraffic(t *testing.T) {
 		Features("traffic.routing", "traffic.reachability", "traffic.shifting").
 		Run(func(ctx framework.TestContext) {
 			cases := map[string][]TrafficTestCase{}
-			cases["virtualservice"] = virtualServiceCases()
+			cases["virtualservice"] = virtualServiceCases(ctx)
 			cases["sniffing"] = protocolSniffingCases(ctx)
 			cases["serverfirst"] = serverFirstTestCases()
 			cases["vm"] = vmTestCases(apps.vmA)

--- a/tests/integration/pilot/vm_test.go
+++ b/tests/integration/pilot/vm_test.go
@@ -33,7 +33,6 @@ func GetAdditionVMImages() []string {
 func TestVmOSPost(t *testing.T) {
 	framework.
 		NewTest(t).
-		RequiresSingleCluster().
 		Features("traffic.reachability").
 		Label(label.Postsubmit).
 		Run(func(ctx framework.TestContext) {
@@ -53,7 +52,8 @@ func TestVmOSPost(t *testing.T) {
 			b.BuildOrFail(ctx)
 
 			for i, image := range images {
-				ctx.NewSubTest(image).Run(func(ctx framework.TestContext) {
+				i, image := i, image
+				ctx.NewSubTest(image).RunParallel(func(ctx framework.TestContext) {
 					for _, tt := range vmTestCases(instances[i]) {
 						ExecuteTrafficTest(ctx, tt)
 					}


### PR DESCRIPTION
- Echos are deployed to every cluster (except VMs)
- Additional subtest per-cluster as "source"; increase echo call count to reach all clusters. 
- Tests that affect routing also check for all clusters to be hit
- Discovered that multi-network causes traffic to be unequally distributed across clusters (https://github.com/istio/istio/issues/26293)

[Passing run #1](https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/25923/integ-pilot-multicluster-tests_istio/88) 
[Passing run #2](https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/25923/integ-pilot-multicluster-tests_istio/89)
[Passing run #3](https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/25923/integ-pilot-multicluster-tests_istio/90)
[Passing run #4](https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/25923/integ-pilot-multicluster-tests_istio/93)
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
