### PR TITLE
Allow fetching workload labels from WE metadata

### DIFF
--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -369,9 +369,13 @@ func convertWorkloadInstanceToServiceInstance(workloadInstance *model.IstioEndpo
 // port names) and the namespace - k8s will consume this service instance when selecting workload entries
 func convertWorkloadEntryToWorkloadInstance(namespace string, cfg model.Config) *model.WorkloadInstance {
 	we := cfg.Spec.(*networking.WorkloadEntry)
-	labels := cfg.Labels
-	if len(we.Labels) > 0 {
-		labels = we.Labels
+	// we will merge labels from metadata with spec, with precedence to the metadata
+	labels := map[string]string{}
+	for k, v := range we.Labels {
+		labels[k] = v
+	}
+	for k, v := range cfg.Labels {
+		labels[k] = v
 	}
 	addr := we.GetAddress()
 	if strings.HasPrefix(addr, model.UnixAddressPrefix) {

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -367,8 +367,12 @@ func convertWorkloadInstanceToServiceInstance(workloadInstance *model.IstioEndpo
 
 // Convenience function to convert a workloadEntry into a ServiceInstance object encoding the endpoint (without service
 // port names) and the namespace - k8s will consume this service instance when selecting workload entries
-func convertWorkloadEntryToWorkloadInstance(namespace string,
-	we *networking.WorkloadEntry) *model.WorkloadInstance {
+func convertWorkloadEntryToWorkloadInstance(namespace string, cfg model.Config) *model.WorkloadInstance {
+	we := cfg.Spec.(*networking.WorkloadEntry)
+	labels := cfg.Labels
+	if len(we.Labels) > 0 {
+		labels = we.Labels
+	}
 	addr := we.GetAddress()
 	if strings.HasPrefix(addr, model.UnixAddressPrefix) {
 		// k8s can't use uds for service objects
@@ -392,7 +396,7 @@ func convertWorkloadEntryToWorkloadInstance(namespace string,
 				Label: we.Locality,
 			},
 			LbWeight:       we.Weight,
-			Labels:         we.Labels,
+			Labels:         labels,
 			TLSMode:        tlsMode,
 			ServiceAccount: sa,
 		},

--- a/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
@@ -818,7 +818,7 @@ func TestConvertWorkloadEntryToWorkloadInstance(t *testing.T) {
 			},
 		},
 		{
-			name:      "metadata labels only overriden",
+			name:      "labels merge",
 			namespace: "ns1",
 			wle: model.Config{
 				ConfigMeta: model.ConfigMeta{
@@ -837,7 +837,10 @@ func TestConvertWorkloadEntryToWorkloadInstance(t *testing.T) {
 			out: &model.WorkloadInstance{
 				Namespace: "ns1",
 				Endpoint: &model.IstioEndpoint{
-					Labels:         labels,
+					Labels: map[string]string{
+						"my-label": "bar",
+						"app":      "wle",
+					},
 					Address:        "1.1.1.1",
 					ServiceAccount: "spiffe://cluster.local/ns/ns1/sa/scooby",
 					TLSMode:        "istio",

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
@@ -109,7 +109,7 @@ func (s *ServiceEntryStore) workloadEntryHandler(old, curr model.Config, event m
 
 	// fire off the k8s handlers
 	if len(s.workloadHandlers) > 0 {
-		si := convertWorkloadEntryToWorkloadInstance(curr.Namespace, wle)
+		si := convertWorkloadEntryToWorkloadInstance(curr.Namespace, curr)
 		if si != nil {
 			for _, h := range s.workloadHandlers {
 				h(si, event)


### PR DESCRIPTION
Logic will be:
* If spec.labels is present, use those
* If not, use metadata.labels

Fixes https://github.com/istio/istio/issues/23947