### PR TITLE
Close connections in echo

### DIFF
--- a/pkg/test/echo/server/endpoint/grpc.go
+++ b/pkg/test/echo/server/endpoint/grpc.go
@@ -173,6 +173,7 @@ func (h *grpcHandler) ForwardEcho(ctx context.Context, req *proto.ForwardEchoReq
 	if err != nil {
 		return nil, err
 	}
+	defer instance.Close()
 
 	return instance.Run(ctx)
 }

--- a/pkg/test/echo/server/forwarder/http.go
+++ b/pkg/test/echo/server/forwarder/http.go
@@ -116,5 +116,6 @@ func (c *httpProtocol) makeRequest(ctx context.Context, req *request) (string, e
 }
 
 func (c *httpProtocol) Close() error {
+	c.client.CloseIdleConnections()
 	return nil
 }

--- a/pkg/test/echo/server/forwarder/protocol.go
+++ b/pkg/test/echo/server/forwarder/protocol.go
@@ -74,6 +74,10 @@ func newProtocol(cfg Config) (protocol, error) {
 		proto := &httpProtocol{
 			client: &http.Client{
 				Transport: &http.Transport{
+					// We are creating a Transport on each ForwardEcho request. Transport is what holds connections,
+					// so this means every ForwardEcho request will create a new connection. Without setting an idle timeout,
+					// we would never close these connections.
+					IdleConnTimeout: time.Second,
 					TLSClientConfig: &tls.Config{
 						InsecureSkipVerify: true,
 					},


### PR DESCRIPTION
Currently, every ForwardEcho request leaks a connection. I originally
thought we should fix it to reuse connections, but I think its probably
best we don't, as I worry that would lead to cases where we are using an
old connection that has different properties (strict vs plain text, for
example) that leads to unexpected test results



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure