### PR TITLE
[release-1.6] Increase default proto sniffing timeout to 5s

### DIFF
--- a/manifests/charts/global.yaml
+++ b/manifests/charts/global.yaml
@@ -124,7 +124,7 @@ global:
     # the specified period, defaulting to non mTLS plain TCP
     # traffic. Set this field to tweak the period that Envoy will wait
     # for the client to send the first bits of data. (MUST BE >=1ms)
-    protocolDetectionTimeout: 100ms
+    protocolDetectionTimeout: 5000ms
 
     #If set to true, istio-proxy container will have privileged securityContext
     privileged: false

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -71,7 +71,7 @@ data:
       enabled: true
     outboundTrafficPolicy:
       mode: ALLOW_ANY
-    protocolDetectionTimeout: 100ms
+    protocolDetectionTimeout: 5000ms
     reportBatchMaxEntries: 100
     reportBatchMaxTime: 1s
     sdsUdsPath: unix:/etc/istio/proxy/SDS
@@ -218,7 +218,7 @@ data:
           "includeIPRanges": "*",
           "logLevel": "warning",
           "privileged": false,
-          "protocolDetectionTimeout": "100ms",
+          "protocolDetectionTimeout": "5000ms",
           "readinessFailureThreshold": 30,
           "readinessInitialDelaySeconds": 1,
           "readinessPeriodSeconds": 2,

--- a/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -139,7 +139,7 @@ data:
           "includeIPRanges": "*",
           "logLevel": "warning",
           "privileged": false,
-          "protocolDetectionTimeout": "100ms",
+          "protocolDetectionTimeout": "5000ms",
           "readinessFailureThreshold": 30,
           "readinessInitialDelaySeconds": 1,
           "readinessPeriodSeconds": 2,


### PR DESCRIPTION

https://github.com/istio/istio/issues/24379

We've adjusted the default value in pilot runtime to 5s in 1.6.5: https://github.com/istio/istio/commit/0ac15a91fe72dff58f758ef7abad194dd785ba0a, However it does not take effect because it is overridden by protocolDetectionTimeout in global value.

This is already the default in master and release-1.7, this global value has already been removed there.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure