### PR TITLE
[release-1.7] Fix deprecated setting in demo profile

### DIFF
--- a/manifests/profiles/demo.yaml
+++ b/manifests/profiles/demo.yaml
@@ -3,7 +3,6 @@ kind: IstioOperator
 spec:
   meshConfig:
     accessLogFile: /dev/stdout
-    disablePolicyChecks: false
   components:
     egressGateways:
     - name: istio-egressgateway

--- a/operator/pkg/apis/istio/v1alpha1/validation/validation.go
+++ b/operator/pkg/apis/istio/v1alpha1/validation/validation.go
@@ -47,7 +47,7 @@ func ValidateConfig(failOnMissingValidation bool, iopls *v1alpha1.IstioOperatorS
 	if err := util.UnmarshalValuesWithJSONPB(iopvalString, values, true); err != nil {
 		return util.NewErrs(err), ""
 	}
-	validationErrors = util.AppendErrs(validationErrors, validateSubTypes(reflect.ValueOf(values).Elem(), failOnMissingValidation, values, iopls))
+	validationErrors = util.AppendErrs(validationErrors, ValidateSubTypes(reflect.ValueOf(values).Elem(), failOnMissingValidation, values, iopls))
 	// TODO: change back to return err when have other validation cases, warning for automtls check only.
 	if err := validateFeatures(values, iopls).ToError(); err != nil {
 		warningMessage = fmt.Sprintf("feature validation warning: %v\n", err.Error())
@@ -156,7 +156,7 @@ func validateFeatures(_ *valuesv1alpha1.Values, _ *v1alpha1.IstioOperatorSpec) u
 	return nil
 }
 
-func validateSubTypes(e reflect.Value, failOnMissingValidation bool, values *valuesv1alpha1.Values, iopls *v1alpha1.IstioOperatorSpec) util.Errors {
+func ValidateSubTypes(e reflect.Value, failOnMissingValidation bool, values *valuesv1alpha1.Values, iopls *v1alpha1.IstioOperatorSpec) util.Errors {
 	// Dealing with receiver pointer and receiver value
 	ptr := e
 	k := e.Kind()
@@ -205,7 +205,7 @@ func validateSubTypes(e reflect.Value, failOnMissingValidation bool, values *val
 		if util.IsNilOrInvalidValue(val) {
 			continue
 		}
-		validationErrors = append(validationErrors, validateSubTypes(e.Field(i), failOnMissingValidation, values, iopls)...)
+		validationErrors = append(validationErrors, ValidateSubTypes(e.Field(i), failOnMissingValidation, values, iopls)...)
 	}
 
 	return validationErrors
@@ -214,7 +214,7 @@ func validateSubTypes(e reflect.Value, failOnMissingValidation bool, values *val
 func processSlice(e reflect.Value, failOnMissingValidation bool, values *valuesv1alpha1.Values, iopls *v1alpha1.IstioOperatorSpec) util.Errors {
 	var validationErrors util.Errors
 	for i := 0; i < e.Len(); i++ {
-		validationErrors = append(validationErrors, validateSubTypes(e.Index(i), failOnMissingValidation, values, iopls)...)
+		validationErrors = append(validationErrors, ValidateSubTypes(e.Index(i), failOnMissingValidation, values, iopls)...)
 	}
 
 	return validationErrors
@@ -224,7 +224,7 @@ func processMap(e reflect.Value, failOnMissingValidation bool, values *valuesv1a
 	var validationErrors util.Errors
 	for _, k := range e.MapKeys() {
 		v := e.MapIndex(k)
-		validationErrors = append(validationErrors, validateSubTypes(v, failOnMissingValidation, values, iopls)...)
+		validationErrors = append(validationErrors, ValidateSubTypes(v, failOnMissingValidation, values, iopls)...)
 	}
 
 	return validationErrors

--- a/operator/pkg/apis/istio/v1alpha1/validation/validation_test.go
+++ b/operator/pkg/apis/istio/v1alpha1/validation/validation_test.go
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package validation
+package validation_test
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -23,6 +24,10 @@ import (
 	v1alpha12 "istio.io/api/operator/v1alpha1"
 
 	"istio.io/istio/operator/pkg/apis/istio/v1alpha1"
+	"istio.io/istio/operator/pkg/apis/istio/v1alpha1/validation"
+	"istio.io/istio/operator/pkg/helm"
+	"istio.io/istio/operator/pkg/manifest"
+	"istio.io/istio/pkg/test/env"
 )
 
 func TestValidateConfig(t *testing.T) {
@@ -99,12 +104,39 @@ func TestValidateConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err, warnings := ValidateConfig(false, tt.value)
+			err, warnings := validation.ValidateConfig(false, tt.value)
 			if err != nil {
 				t.Fatal(err)
 			}
 			if tt.warnings != warnings {
 				t.Fatalf("expected warnings: %q got %q", tt.warnings, warnings)
+			}
+		})
+	}
+}
+
+func TestValidateProfiles(t *testing.T) {
+	manifests := filepath.Join(env.IstioSrc, helm.OperatorSubdirFilePath)
+	profiles, err := helm.ListProfiles(manifests)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(profiles) < 2 {
+		// Just ensure we find some profiles, in case this code breaks
+		t.Fatalf("Maybe have failed getting profiles, got %v", profiles)
+	}
+	for _, tt := range profiles {
+		t.Run(tt, func(t *testing.T) {
+			_, s, err := manifest.GenIOPSFromProfile(tt, "", []string{"installPackagePath=" + manifests}, false, nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			verr, warnings := validation.ValidateConfig(false, s)
+			if verr != nil {
+				t.Fatalf("got error validating: %v", verr)
+			}
+			if warnings != "" {
+				t.Fatalf("got warning validating: %v", warnings)
 			}
 		})
 	}
@@ -133,7 +165,7 @@ func TestValidate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		err := validateSubTypes(reflect.ValueOf(tt.toValidate).Elem(), false, tt.toValidate, nil)
+		err := validation.ValidateSubTypes(reflect.ValueOf(tt.toValidate).Elem(), false, tt.toValidate, nil)
 		if len(err) != 0 && tt.validated {
 			t.Fatalf("Test %s failed with errors: %+v but supposed to succeed", tt.name, err)
 		}


### PR DESCRIPTION
Partial backport of a massive PR in master. This fixes the deprecation
warning when installing with demo profile, and adds a regression test.
this has no impact on the generated manifests; the option does nothing.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure