### PR TITLE
TestGetCNIConfigFilepath: fix goroutine leak

### DIFF
--- a/cni/pkg/install-cni/pkg/install/cniconfig_test.go
+++ b/cni/pkg/install-cni/pkg/install/cniconfig_test.go
@@ -236,7 +236,7 @@ func TestGetCNIConfigFilepath(t *testing.T) {
 			// Call with goroutine to test fsnotify watcher
 			parent, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			resultChan, errChan := make(chan string), make(chan error)
+			resultChan, errChan := make(chan string, 1), make(chan error, 1)
 			go func(resultChan chan string, errChan chan error, ctx context.Context, cfg pluginConfig) {
 				result, err := getCNIConfigFilepath(ctx, cfg)
 				if err != nil {


### PR DESCRIPTION
Signed-off-by: Gaurav Singh <gaurav1086@gmail.com>

This PR fixes the goroutine leak in TestGetCNIConfigFilepath(). If the goroutine times out, then it will block on the channels resultChan and errChan since there would not be corresponding reader. To fix this, use a buffered channel.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[X ] Developer Infrastructure