### PR TITLE
Move X-Controllers init outside of leader election callback

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -107,12 +107,6 @@ func (s *Server) initConfigController(args *PilotArgs) error {
 			log.Warnf("Disabled ingress status syncer due to %v", err)
 		} else {
 			s.addTerminatingStartFunc(func(stop <-chan struct{}) error {
-				// Start informers again. This fixes the case where informers for namespace do not start,
-				// as we create them only after acquiring the leader lock
-				// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are
-				// basically lazy loading the informer, if we stop it when we lose the lock we will never
-				// recreate it again.
-				s.kubeClient.RunAndWait(stop)
 				le := leaderelection.NewLeaderElection(args.Namespace, args.PodName, leaderelection.IngressController, s.kubeClient.Kube())
 				le.AddRunFunction(func(leaderStop <-chan struct{}) {
 					log.Infof("Starting ingress controller")

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -107,19 +107,18 @@ func (s *Server) initConfigController(args *PilotArgs) error {
 			log.Warnf("Disabled ingress status syncer due to %v", err)
 		} else {
 			s.addTerminatingStartFunc(func(stop <-chan struct{}) error {
-				leaderelection.
-					NewLeaderElection(args.Namespace, args.PodName, leaderelection.IngressController, s.kubeClient.Kube()).
-					AddRunFunction(func(leaderStop <-chan struct{}) {
-						// Start informers again. This fixes the case where informers for namespace do not start,
-						// as we create them only after acquiring the leader lock
-						// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are
-						// basically lazy loading the informer, if we stop it when we lose the lock we will never
-						// recreate it again.
-						s.kubeClient.RunAndWait(stop)
-						log.Infof("Starting ingress controller")
-						ingressSyncer.Run(leaderStop)
-					}).
-					Run(stop)
+				// Start informers again. This fixes the case where informers for namespace do not start,
+				// as we create them only after acquiring the leader lock
+				// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are
+				// basically lazy loading the informer, if we stop it when we lose the lock we will never
+				// recreate it again.
+				s.kubeClient.RunAndWait(stop)
+				le := leaderelection.NewLeaderElection(args.Namespace, args.PodName, leaderelection.IngressController, s.kubeClient.Kube())
+				le.AddRunFunction(func(leaderStop <-chan struct{}) {
+					log.Infof("Starting ingress controller")
+					ingressSyncer.Run(leaderStop)
+				})
+				le.Run(stop)
 				return nil
 			})
 		}

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1005,13 +1005,6 @@ func (s *Server) initNamespaceController(args *PilotArgs) {
 		// create namespace controller
 		nsController := kubecontroller.NewNamespaceController(s.fetchCARoot, s.kubeClient)
 		s.addTerminatingStartFunc(func(stop <-chan struct{}) error {
-			// Start informers again. This fixes the case where informers for namespace do not start,
-			// as we create them only after acquiring the leader lock
-			// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are
-			// basically lazy loading the informer, if we stop it when we lose the lock we will never
-			// recreate it again.
-			s.kubeClient.RunAndWait(stop)
-
 			le := leaderelection.NewLeaderElection(args.Namespace, args.PodName, leaderelection.NamespaceController, s.kubeClient.Kube())
 			le.AddRunFunction(func(leaderStop <-chan struct{}) {
 				nsController.Run(leaderStop)

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -1002,21 +1002,21 @@ func (s *Server) initControllers(args *PilotArgs) error {
 // initNamespaceController initializes namespace controller to sync config map.
 func (s *Server) initNamespaceController(args *PilotArgs) {
 	if s.CA != nil && s.kubeClient != nil {
+		// create namespace controller
+		nsController := kubecontroller.NewNamespaceController(s.fetchCARoot, s.kubeClient)
 		s.addTerminatingStartFunc(func(stop <-chan struct{}) error {
-			leaderelection.
-				NewLeaderElection(args.Namespace, args.PodName, leaderelection.NamespaceController, s.kubeClient.Kube()).
-				AddRunFunction(func(leaderStop <-chan struct{}) {
-					log.Infof("Starting namespace controller")
-					nc := kubecontroller.NewNamespaceController(s.fetchCARoot, s.kubeClient)
-					// Start informers again. This fixes the case where informers for namespace do not start,
-					// as we create them only after acquiring the leader lock
-					// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are
-					// basically lazy loading the informer, if we stop it when we lose the lock we will never
-					// recreate it again.
-					s.kubeClient.RunAndWait(stop)
-					nc.Run(leaderStop)
-				}).
-				Run(stop)
+			// Start informers again. This fixes the case where informers for namespace do not start,
+			// as we create them only after acquiring the leader lock
+			// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are
+			// basically lazy loading the informer, if we stop it when we lose the lock we will never
+			// recreate it again.
+			s.kubeClient.RunAndWait(stop)
+
+			le := leaderelection.NewLeaderElection(args.Namespace, args.PodName, leaderelection.NamespaceController, s.kubeClient.Kube())
+			le.AddRunFunction(func(leaderStop <-chan struct{}) {
+				nsController.Run(leaderStop)
+			})
+			le.Run(stop)
 			return nil
 		})
 	}

--- a/pilot/pkg/bootstrap/validation.go
+++ b/pilot/pkg/bootstrap/validation.go
@@ -73,18 +73,12 @@ func (s *Server) initConfigValidation(args *PilotArgs) error {
 			WebhookConfigName: webhookConfigName,
 			ServiceName:       "istiod",
 		}
+		whController, err := controller.New(o, s.kubeClient)
+		if err != nil {
+			log.Errorf("failed to start validation controller: %v", err)
+			return err
+		}
 		s.addTerminatingStartFunc(func(stop <-chan struct{}) error {
-			whController, err := controller.New(o, s.kubeClient)
-			if err != nil {
-				log.Errorf("failed to start validation controller: %v", err)
-				return err
-			}
-			// Start informers again. This fixes the case where informers for namespace do not start,
-			// as we create them only after acquiring the leader lock
-			// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are
-			// basically lazy loading the informer, if we stop it when we lose the lock we will never
-			// recreate it again.
-			s.kubeClient.RunAndWait(stop)
 			le := leaderelection.NewLeaderElection(args.Namespace, args.PodName, leaderelection.ValidationController, s.kubeClient)
 			le.AddRunFunction(func(leaderStop <-chan struct{}) {
 				log.Infof("Starting validation controller")

--- a/pilot/pkg/config/kube/ingress/status.go
+++ b/pilot/pkg/config/kube/ingress/status.go
@@ -34,7 +34,7 @@ import (
 
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	kubelib "istio.io/istio/pkg/kube"
-	queue2 "istio.io/istio/pkg/queue"
+	"istio.io/istio/pkg/queue"
 
 	"istio.io/pkg/log"
 )
@@ -53,7 +53,7 @@ type StatusSyncer struct {
 	// Name of service (ingressgateway default) to find the IP
 	ingressService string
 
-	queue         queue2.Instance
+	queue         queue.Instance
 	ingressLister listerv1beta1.IngressLister
 	podLister     listerv1.PodLister
 	serviceLister listerv1.ServiceLister
@@ -74,7 +74,7 @@ func NewStatusSyncer(mesh *meshconfig.MeshConfig, client kubelib.Client) (*Statu
 	ingressClass, defaultIngressClass := convertIngressControllerMode(mesh.IngressControllerMode, mesh.IngressClass)
 
 	// queue requires a time duration for a retry delay after a handler error
-	queue := queue2.NewQueue(1 * time.Second)
+	q := queue.NewQueue(1 * time.Second)
 
 	st := StatusSyncer{
 		client:              client,
@@ -82,7 +82,7 @@ func NewStatusSyncer(mesh *meshconfig.MeshConfig, client kubelib.Client) (*Statu
 		podLister:           client.KubeInformer().Core().V1().Pods().Lister(),
 		serviceLister:       client.KubeInformer().Core().V1().Services().Lister(),
 		nodeLister:          client.KubeInformer().Core().V1().Nodes().Lister(),
-		queue:               queue,
+		queue:               q,
 		ingressClass:        ingressClass,
 		defaultIngressClass: defaultIngressClass,
 		ingressService:      mesh.IngressService,

--- a/pilot/pkg/config/kube/ingress/status.go
+++ b/pilot/pkg/config/kube/ingress/status.go
@@ -64,7 +64,6 @@ type StatusSyncer struct {
 func (s *StatusSyncer) Run(stopCh <-chan struct{}) {
 	go s.queue.Run(stopCh)
 	go s.runUpdateStatus(stopCh)
-	<-stopCh
 }
 
 // NewStatusSyncer creates a new instance

--- a/pilot/pkg/status/state.go
+++ b/pilot/pkg/status/state.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
 
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -36,6 +37,8 @@ import (
 	"k8s.io/utils/clock"
 
 	"istio.io/pkg/log"
+
+	"istio.io/istio/pilot/pkg/features"
 )
 
 var scope = log.RegisterScope("status",
@@ -56,54 +59,57 @@ type DistributionController struct {
 	CurrentState     map[Resource]map[string]Progress
 	ObservationTime  map[string]time.Time
 	UpdateInterval   time.Duration
-	client           dynamic.Interface
+	dynamicClient    dynamic.Interface
+	kubeClient       kubernetes.Interface
 	clock            clock.Clock
 	knownResources   map[schema.GroupVersionResource]dynamic.NamespaceableResourceInterface
 	currentlyWriting ResourceLock
 	StaleInterval    time.Duration
-	QPS              float32
-	Burst            int
+	cmInformer       cache.SharedIndexInformer
 }
 
-func (c *DistributionController) Start(restConfig *rest.Config, namespace string, stop <-chan struct{}) {
-	scope.Info("Starting status leader controller")
-	// default UpdateInterval
-	if c.UpdateInterval == 0 {
-		c.UpdateInterval = 200 * time.Millisecond
+func NewController(restConfig rest.Config, namespace string) *DistributionController {
+	c := &DistributionController{
+		CurrentState:    make(map[Resource]map[string]Progress),
+		ObservationTime: make(map[string]time.Time),
+		knownResources:  make(map[schema.GroupVersionResource]dynamic.NamespaceableResourceInterface),
+		UpdateInterval:  200 * time.Millisecond,
+		StaleInterval:   time.Minute,
+		clock:           clock.RealClock{},
 	}
-	// default StaleInterval
-	if c.StaleInterval == 0 {
-		c.StaleInterval = time.Minute
-	}
-	if c.clock == nil {
-		c.clock = clock.RealClock{}
-	}
-	c.CurrentState = make(map[Resource]map[string]Progress)
-	c.ObservationTime = make(map[string]time.Time)
-	c.knownResources = make(map[schema.GroupVersionResource]dynamic.NamespaceableResourceInterface)
 
-	// client-go defaults to 5 QPS, with 10 Boost, which is insufficient for updating status on all the config
+	// dynamicClient-go defaults to 5 QPS, with 10 Boost, which is insufficient for updating status on all the config
 	// in the mesh.  These values can be configured using environment variables for tuning (see pilot/pkg/features)
-	restConfig.QPS = c.QPS
-	restConfig.Burst = c.Burst
+	restConfig.QPS = float32(features.StatusQPS)
+	restConfig.Burst = features.StatusBurst
 	var err error
-	if c.client, err = dynamic.NewForConfig(restConfig); err != nil {
+	if c.dynamicClient, err = dynamic.NewForConfig(&restConfig); err != nil {
 		scope.Fatalf("Could not connect to kubernetes: %s", err)
 	}
-	// create watch
-	i := informers.NewSharedInformerFactoryWithOptions(kubernetes.NewForConfigOrDie(restConfig), 1*time.Minute,
+
+	// configmap informer
+	i := informers.NewSharedInformerFactoryWithOptions(kubernetes.NewForConfigOrDie(&restConfig), 1*time.Minute,
 		informers.WithNamespace(namespace),
 		informers.WithTweakListOptions(func(listOptions *metav1.ListOptions) {
 			listOptions.LabelSelector = labels.Set(map[string]string{labelKey: "true"}).AsSelector().String()
 		})).
 		Core().V1().ConfigMaps()
+	c.cmInformer = i.Informer()
 	i.Informer().AddEventHandler(&DistroReportHandler{dc: c})
+
+	return c
+}
+
+func (c *DistributionController) Start(stop <-chan struct{}) {
+	scope.Info("Starting status leader controller")
+
 	// this will list all existing configmaps, as well as updates, right?
 	ctx := NewIstioContext(stop)
-	go i.Informer().Run(ctx.Done())
+	go c.cmInformer.Run(ctx.Done())
 
-	//create Status Writer
+	//  create Status Writer
 	t := c.clock.Tick(c.UpdateInterval)
+
 	go func() {
 		for {
 			select {
@@ -158,7 +164,7 @@ func (c *DistributionController) initK8sResource(gvr schema.GroupVersionResource
 	if result, ok := c.knownResources[gvr]; ok {
 		return result
 	}
-	result = c.client.Resource(gvr)
+	result = c.dynamicClient.Resource(gvr)
 	c.knownResources[gvr] = result
 	return
 }

--- a/pilot/pkg/status/state.go
+++ b/pilot/pkg/status/state.go
@@ -60,7 +60,6 @@ type DistributionController struct {
 	ObservationTime  map[string]time.Time
 	UpdateInterval   time.Duration
 	dynamicClient    dynamic.Interface
-	kubeClient       kubernetes.Interface
 	clock            clock.Clock
 	knownResources   map[schema.GroupVersionResource]dynamic.NamespaceableResourceInterface
 	currentlyWriting ResourceLock

--- a/pkg/queue/instance.go
+++ b/pkg/queue/instance.go
@@ -49,6 +49,7 @@ func NewQueue(errorDelay time.Duration) Instance {
 	}
 }
 
+// Push enqueue an item
 func (q *queueImpl) Push(item Task) {
 	q.cond.L.Lock()
 	defer q.cond.L.Unlock()
@@ -58,7 +59,13 @@ func (q *queueImpl) Push(item Task) {
 	q.cond.Signal()
 }
 
+// Run start the task handler, which should be in a separate go routine.
+// The queue can be closed via stop channel. However when it is being closed,
+// the left elements in the queue will be processed.
+// Note: The queue can be rerun after closed.
 func (q *queueImpl) Run(stop <-chan struct{}) {
+	// enable rerun the queue
+	q.closing = false
 	go func() {
 		<-stop
 		q.cond.L.Lock()

--- a/pkg/queue/instance.go
+++ b/pkg/queue/instance.go
@@ -65,7 +65,9 @@ func (q *queueImpl) Push(item Task) {
 // Note: The queue can be rerun after closed.
 func (q *queueImpl) Run(stop <-chan struct{}) {
 	// enable rerun the queue
+	q.cond.L.Lock()
 	q.closing = false
+	q.cond.L.Unlock()
 	go func() {
 		<-stop
 		q.cond.L.Lock()

--- a/pkg/queue/instance.go
+++ b/pkg/queue/instance.go
@@ -33,10 +33,15 @@ type Instance interface {
 }
 
 type queueImpl struct {
-	delay   time.Duration
-	tasks   []Task
-	cond    *sync.Cond
+	delay time.Duration
+	tasks []Task
+	cond  *sync.Cond
+	// closing indicates whether the queue is being closed
 	closing bool
+
+	mutex sync.RWMutex
+	// closed indicates whether the queue is not run or closed
+	closed bool
 }
 
 // NewQueue instantiates a queue with a processing function
@@ -45,11 +50,12 @@ func NewQueue(errorDelay time.Duration) Instance {
 		delay:   errorDelay,
 		tasks:   make([]Task, 0),
 		closing: false,
+		closed:  true,
 		cond:    sync.NewCond(&sync.Mutex{}),
 	}
 }
 
-// Push enqueue an item
+// Push enqueues a task
 func (q *queueImpl) Push(item Task) {
 	q.cond.L.Lock()
 	defer q.cond.L.Unlock()
@@ -62,8 +68,23 @@ func (q *queueImpl) Push(item Task) {
 // Run start the task handler, which should be in a separate go routine.
 // The queue can be closed via stop channel. However when it is being closed,
 // the left elements in the queue will be processed.
-// Note: The queue can be rerun after closed.
+// Note: The queue can be rerun only after closed.
 func (q *queueImpl) Run(stop <-chan struct{}) {
+	q.mutex.Lock()
+	if !q.closed {
+		q.mutex.Unlock()
+		panic("queue can not be run twice")
+	}
+	q.closed = false
+	q.mutex.Unlock()
+
+	defer func() {
+		q.mutex.Lock()
+		// set closed status
+		q.closed = true
+		q.mutex.Unlock()
+	}()
+
 	// enable rerun the queue
 	q.cond.L.Lock()
 	q.closing = false

--- a/pkg/queue/instance_test.go
+++ b/pkg/queue/instance_test.go
@@ -154,7 +154,7 @@ func TestRerun(t *testing.T) {
 	go q.Run(stop)
 
 	// Wait for queue rerun
-	time.Sleep(1 * time.Microsecond)
+	time.Sleep(1 * time.Millisecond)
 	// Push a task
 	q.Push(func() error {
 		notifyCh <- struct{}{}

--- a/pkg/queue/instance_test.go
+++ b/pkg/queue/instance_test.go
@@ -113,3 +113,56 @@ func TestResourceFree(t *testing.T) {
 		t.Log("queue return.")
 	}
 }
+
+func TestRerun(t *testing.T) {
+	q := NewQueue(1 * time.Microsecond)
+
+	notifyCh := make(chan struct{})
+
+	// Push a task
+	q.Push(func() error {
+		notifyCh <- struct{}{}
+		return nil
+	})
+
+	stop := make(chan struct{})
+	go q.Run(stop)
+	select {
+	case <-time.After(200 * time.Millisecond):
+		t.Error("task should be processed")
+	case <-notifyCh:
+	}
+	// close queue
+	close(stop)
+
+	// wait for queue closed
+	time.Sleep(1 * time.Microsecond)
+	// Push a task
+	q.Push(func() error {
+		notifyCh <- struct{}{}
+		return nil
+	})
+	select {
+	case <-time.After(200 * time.Millisecond):
+	case <-notifyCh:
+		t.Errorf("closed queue should not process task")
+	}
+
+	stop = make(chan struct{})
+	defer close(stop)
+	// re run queue
+	go q.Run(stop)
+
+	// Wait for queue rerun
+	time.Sleep(1 * time.Microsecond)
+	// Push a task
+	q.Push(func() error {
+		notifyCh <- struct{}{}
+		return nil
+	})
+	select {
+	case <-time.After(200 * time.Millisecond):
+		t.Error("task should be processed")
+	case <-notifyCh:
+	}
+}

--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -317,6 +317,7 @@ func (c *Controller) processNextWorkItem() (cont bool) {
 
 	// return false when leader lost in case go routine leak.
 	if req.description == QuitSignal {
+		c.queue.Forget(req)
 		return false
 	}
 


### PR DESCRIPTION
Based on #25529

This reduces the cost of initiating namespace controller, status controller, webhook controller during leader lost and reacquired 