### PR TITLE
refactor: dont import istio.io/api/policy

### DIFF
--- a/pkg/config/schema/fuzz_test.go
+++ b/pkg/config/schema/fuzz_test.go
@@ -27,7 +27,6 @@ import (
 
 	authentication "istio.io/api/authentication/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
-	policy "istio.io/api/policy/v1beta1"
 	clientnetworkingalpha "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	clientnetworkingbeta "istio.io/client-go/pkg/apis/networking/v1beta1"
 	clientsecurity "istio.io/client-go/pkg/apis/security/v1beta1"
@@ -128,9 +127,6 @@ func fixProtoFuzzer(codecs serializer.CodecFactory) []interface{} {
 		func(x *networking.LoadBalancerSettings, c fuzz.Continue) {
 			*x = networking.LoadBalancerSettings{}
 		},
-		func(t *policy.Authentication, c fuzz.Continue) {
-			*t = policy.Authentication{}
-		},
 		func(t *networking.EnvoyFilter_EnvoyConfigObjectMatch, c fuzz.Continue) {
 			*t = networking.EnvoyFilter_EnvoyConfigObjectMatch{}
 		},
@@ -157,12 +153,6 @@ func fixProtoFuzzer(codecs serializer.CodecFactory) []interface{} {
 		},
 		func(t *authentication.StringMatch, c fuzz.Continue) {
 			*t = authentication.StringMatch{}
-		},
-		func(t *policy.Tls, c fuzz.Continue) {
-			*t = policy.Tls{}
-		},
-		func(t *policy.Value, c fuzz.Continue) {
-			*t = policy.Value{}
 		},
 		func(t *types.Value, c fuzz.Continue) {
 			*t = types.Value{Kind: &types.Value_StringValue{StringValue: ""}}


### PR DESCRIPTION
`istio.io/api/policy` has been removed from `istio.io/api`

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
