### PR TITLE
refactor: switch to more efficient IstioOperator conversion

### DIFF
--- a/istioctl/pkg/install/pre-check.go
+++ b/istioctl/pkg/install/pre-check.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 	authorizationapi "k8s.io/api/authorization/v1beta1"
 	v1 "k8s.io/api/core/v1"
@@ -37,9 +37,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"istio.io/istio/istioctl/pkg/clioptions"
-	operator_istio "istio.io/istio/operator/pkg/apis/istio"
 	operator_v1alpha1 "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
-	"istio.io/istio/operator/pkg/util"
+	"istio.io/istio/operator/pkg/object"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 )
 
@@ -470,13 +469,7 @@ func getIOPFromFile(filename string) (*operator_v1alpha1.IstioOperator, error) {
 	// usual conversion not available.  Convert unstructured to string
 	// and ask operator code to unmarshal.
 
-	un.SetCreationTimestamp(meta_v1.Time{}) // UnmarshalIstioOperator chokes on these
-	by := util.ToYAML(un)
-	iop, err := operator_istio.UnmarshalIstioOperator(by, true)
-	if err != nil {
-		return nil, err
-	}
-	return iop, nil
+	return object.ConvertUnstructuredToIstioOperator(content)
 }
 
 func namespaceExists(ns string, restClientGetter genericclioptions.RESTClientGetter) (bool, error) {

--- a/istioctl/pkg/install/verify.go
+++ b/istioctl/pkg/install/verify.go
@@ -37,6 +37,7 @@ import (
 	"istio.io/istio/operator/cmd/mesh"
 	"istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/controlplane"
+	"istio.io/istio/operator/pkg/object"
 	"istio.io/istio/operator/pkg/translate"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 	"istio.io/istio/pkg/config/schema"
@@ -180,7 +181,7 @@ func verifyPostInstall(enableVerbose bool, istioNamespaceFlag string,
 			// usual conversion not available.  Convert unstructured to string
 			// and ask operator code to unmarshal.
 
-			iop, err := convertToIstioOperator(un.Object)
+			iop, err := object.ConvertUnstructuredToIstioOperator(un.Object)
 			if err != nil {
 				return err
 			}
@@ -416,7 +417,7 @@ func operatorFromCluster(istioNamespaceFlag string, revision string, restClientG
 		return nil, err
 	}
 	for _, un := range ul.Items {
-		iop, err := convertToIstioOperator(un.Object)
+		iop, err := object.ConvertUnstructuredToIstioOperator(un.Object)
 		if err != nil {
 			return nil, err
 		}
@@ -425,15 +426,6 @@ func operatorFromCluster(istioNamespaceFlag string, revision string, restClientG
 		}
 	}
 	return nil, fmt.Errorf("control plane revision %q not found", revision)
-}
-
-func convertToIstioOperator(obj map[string]interface{}) (*v1alpha1.IstioOperator, error) {
-	out := &v1alpha1.IstioOperator{}
-	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj, out)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
 }
 
 // Find all IstioOperator in the cluster.
@@ -446,7 +438,7 @@ func allOperatorsInCluster(client dynamic.Interface) ([]*v1alpha1.IstioOperator,
 	}
 	retval := make([]*v1alpha1.IstioOperator, 0)
 	for _, un := range ul.Items {
-		iop, err := convertToIstioOperator(un.Object)
+		iop, err := object.ConvertUnstructuredToIstioOperator(un.Object)
 		if err != nil {
 			return nil, err
 		}

--- a/istioctl/pkg/install/verify_test.go
+++ b/istioctl/pkg/install/verify_test.go
@@ -19,9 +19,6 @@ import (
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
-	"istio.io/api/operator/v1alpha1"
 )
 
 var (
@@ -97,39 +94,6 @@ var (
 			},
 		},
 	}
-
-	sampleIOP = unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"kind":       "IstioOperator",
-			"apiVersion": "install.istio.io/v1alpha1",
-			"metadata": map[string]interface{}{
-				"name":              "installed-state",
-				"namespace":         "istio-system",
-				"creationTimestamp": "2020-07-29T07:08:55Z",
-				"managedFields": []map[string]interface{}{
-					{
-						"fieldsType": "FieldsV1",
-						"fieldsV1": map[string]interface{}{
-							"f:metadata": map[string]interface{}{},
-						},
-						"manager":   "istioctl",
-						"operation": "Update",
-						"time":      "2020-07-29T07:09:05Z",
-					},
-				},
-			},
-			"spec": map[string]interface{}{
-				"profile": "default",
-			},
-			"status": map[string]interface{}{
-				"status": "HEALTHY",
-				"componentStatus": map[string]interface{}{
-					"Base": map[string]interface{}{
-						"status": "HEALTHY",
-					},
-				},
-			},
-		}}
 )
 
 func TestGetDeploymentStatus(t *testing.T) {
@@ -231,25 +195,5 @@ func TestFindResourceInSpec(t *testing.T) {
 				tt.Fatalf("unexpected plural from kind: got %v want %v", plural, c.plural)
 			}
 		})
-	}
-}
-
-func TestIstioOperatorConversion(t *testing.T) {
-	out, err := convertToIstioOperator(sampleIOP.Object)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if out.Status.Status != v1alpha1.InstallStatus_HEALTHY || out.GetCreationTimestamp().Unix() == 0 {
-		t.Fatal("Failed to unmarshal")
-	}
-}
-
-func BenchmarkConvertIstioOperator(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		_, err := convertToIstioOperator(sampleIOP.Object)
-		if err != nil {
-			b.Fatal(err)
-		}
 	}
 }

--- a/istioctl/pkg/validate/validate.go
+++ b/istioctl/pkg/validate/validate.go
@@ -25,13 +25,13 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	operator_istio "istio.io/istio/operator/pkg/apis/istio"
+	"istio.io/pkg/log"
+
 	"istio.io/istio/operator/pkg/name"
-	"istio.io/istio/operator/pkg/util"
+	"istio.io/istio/operator/pkg/object"
 	operator_validate "istio.io/istio/operator/pkg/validate"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
@@ -40,7 +40,6 @@ import (
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/istio/pkg/util/gogoprotomarshal"
-	"istio.io/pkg/log"
 )
 
 var (
@@ -142,9 +141,7 @@ func (v *validator) validateResource(istioNamespace string, un *unstructured.Uns
 			// IstioOperator isn't part of pkg/config/schema/collections,
 			// usual conversion not available.  Convert unstructured to string
 			// and ask operator code to check.
-			un.SetCreationTimestamp(metav1.Time{}) // UnmarshalIstioOperator chokes on these
-			by := util.ToYAML(un)
-			iop, err := operator_istio.UnmarshalIstioOperator(by, false)
+			iop, err := object.ConvertUnstructuredToIstioOperator(un.Object)
 			if err != nil {
 				return err
 			}

--- a/operator/pkg/apis/istio/common.go
+++ b/operator/pkg/apis/istio/common.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"istio.io/api/operator/v1alpha1"
+
 	operator_v1alpha1 "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/operator/pkg/validate"
@@ -38,6 +39,7 @@ func UnmarshalAndValidateIOPS(iopsYAML string) (*v1alpha1.IstioOperatorSpec, err
 }
 
 // UnmarshalIstioOperator unmarshals a string containing IstioOperator YAML.
+// Deprecated: use object.ConvertUnstructuredToIstioOperator instead
 func UnmarshalIstioOperator(iopYAML string, allowUnknownField bool) (*operator_v1alpha1.IstioOperator, error) {
 	iop := &operator_v1alpha1.IstioOperator{}
 	if err := util.UnmarshalWithJSONPB(iopYAML, iop, allowUnknownField); err != nil {

--- a/operator/pkg/object/objects.go
+++ b/operator/pkg/object/objects.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 
@@ -507,4 +508,14 @@ func AllObjectHashes(m string) map[string]bool {
 	}
 
 	return ret
+}
+
+// ConvertUnstructuredToIstioOperator converts unstructured object to IstioOperator.
+func ConvertUnstructuredToIstioOperator(obj map[string]interface{}) (*v1alpha1.IstioOperator, error) {
+	iop := &v1alpha1.IstioOperator{}
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj, iop)
+	if err != nil {
+		return nil, err
+	}
+	return iop, nil
 }


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>

Deprecates `UnmarshalIstioOperator` and switch to `object.ConvertUnstructuredToIstioOperator` which is more efficient.

This is a follow-up PR of #25913.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[x] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure