### PR TITLE
fix NodePort services for meshNetworks gateway

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/util.go
+++ b/pilot/pkg/serviceregistry/kube/controller/util.go
@@ -191,6 +191,5 @@ func nodeEquals(a, b kubernetesNode) bool {
 }
 
 func isNodePortGatewayService(svc *v1.Service) bool {
-	_, ok := svc.Annotations[kube.NodeSelectorAnnotation]
-	return ok && svc.Spec.Type == v1.ServiceTypeNodePort
+	return svc.Spec.Type == v1.ServiceTypeNodePort
 }

--- a/pilot/pkg/serviceregistry/kube/controller/util.go
+++ b/pilot/pkg/serviceregistry/kube/controller/util.go
@@ -191,5 +191,6 @@ func nodeEquals(a, b kubernetesNode) bool {
 }
 
 func isNodePortGatewayService(svc *v1.Service) bool {
-	return svc.Spec.Type == v1.ServiceTypeNodePort
+	_, ok := svc.Annotations[kube.NodeSelectorAnnotation]
+	return ok && svc.Spec.Type == v1.ServiceTypeNodePort
 }

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -118,7 +118,7 @@ func ConvertService(svc coreV1.Service, domainSuffix string, clusterID string) *
 
 	switch svc.Spec.Type {
 	case coreV1.ServiceTypeNodePort:
-		if _, ok := svc.Annotations[NodeSelectorAnnotation]; ok {
+		if _, ok := svc.Annotations[NodeSelectorAnnotation]; !ok {
 			// only do this for istio ingress-gateway services
 			break
 		}

--- a/pilot/pkg/xds/xds_test.go
+++ b/pilot/pkg/xds/xds_test.go
@@ -17,7 +17,6 @@ package xds
 import (
 	"fmt"
 	"io/ioutil"
-	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"path"
 	"testing"
 
@@ -31,6 +30,7 @@ import (
 	meshconfig "istio.io/api/mesh/v1alpha1"
 
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/env"

--- a/pilot/pkg/xds/xds_test.go
+++ b/pilot/pkg/xds/xds_test.go
@@ -22,6 +22,11 @@ import (
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/rand"
+
 	meshconfig "istio.io/api/mesh/v1alpha1"
 
 	"istio.io/istio/pilot/pkg/model"
@@ -301,50 +306,73 @@ func TestSidecarListeners(t *testing.T) {
 }
 
 func TestMeshNetworking(t *testing.T) {
-	s := NewFakeDiscoveryServer(t, FakeOptions{
-		KubernetesObjectString: `
-apiVersion: v1
-kind: Pod
-metadata:
-  name: kubeapp-1234
-  namespace: pod
-  labels:
-    app: kubeapp
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: kubeapp
-  namespace: pod
-spec:
-  clusterIP: 1.2.3.4
-  selector:
-    app: kubeapp
-  ports:
-  - port: 80
-    name: http
-    protocol: TCP
----
-apiVersion: v1
-kind: Endpoints
-metadata:
-  name: kubeapp
-  namespace: pod
-  labels:
-    app: kubeapp
-subsets:
-- addresses:
-  - ip: 10.10.10.20
-    targetRef:
-      kind: Pod
-      name: kubeapp-1234
-      namespace: pod
-  ports:
-  - port: 80
-    name: http
-    protocol: TCP
-`,
-		ConfigString: `
+	ingresses := []*corev1.Service{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "istio-ingressgateway",
+				Namespace: "istio-system",
+			},
+			Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+			Status: corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{{IP: "2.2.2.2"}}},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "istio-ingressgateway",
+				Namespace: "istio-system",
+			},
+			Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeNodePort, Ports: []corev1.ServicePort{{Port: 15443, NodePort: 25443}}},
+			Status: corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{{IP: "8.8.8.8"}}}, // 2.2.2.2 should be found on the node
+			},
+		},
+	}
+
+	meshNetworkConfigs := map[string]*meshconfig.MeshNetworks{
+		"gateway-address": {Networks: map[string]*meshconfig.Network{
+			// Explicitly set address
+			"network-1": {
+				Endpoints: []*meshconfig.Network_NetworkEndpoints{{
+					Ne: &meshconfig.Network_NetworkEndpoints_FromRegistry{FromRegistry: "Kubernetes"},
+				}},
+				Gateways: []*meshconfig.Network_IstioNetworkGateway{{
+					Gw:   &meshconfig.Network_IstioNetworkGateway_Address{Address: "2.2.2.2"},
+					Port: 15443,
+				}},
+			},
+		}},
+		"gateway-registryServiceName": {Networks: map[string]*meshconfig.Network{
+			// Address from service
+			"network-1": {
+				Endpoints: []*meshconfig.Network_NetworkEndpoints{{
+					Ne: &meshconfig.Network_NetworkEndpoints_FromRegistry{FromRegistry: "Kubernetes"},
+				}},
+				Gateways: []*meshconfig.Network_IstioNetworkGateway{{
+					Gw: &meshconfig.Network_IstioNetworkGateway_RegistryServiceName{
+						RegistryServiceName: "istio-ingressgateway.istio-system.svc.cluster.local",
+					},
+					Port: 15443,
+				}},
+			},
+		}},
+	}
+
+	for _, ingr := range ingresses {
+		t.Run(string(ingr.Spec.Type), func(t *testing.T) {
+			for name, networkConfig := range meshNetworkConfigs {
+				t.Run(name, func(t *testing.T) {
+
+					var k8sObjects []runtime.Object
+					k8sObjects = append(k8sObjects,
+						// NodePort ingress needs this
+						&corev1.Node{Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeExternalIP, Address: "2.2.2.2"}}}},
+						ingr)
+					k8sObjects = append(k8sObjects, fakePodService(fakeServiceOpts{name: "kubeapp", ns: "pod", ip: "10.10.10.20"})...)
+
+					s := NewFakeDiscoveryServer(t, FakeOptions{
+						KubernetesObjects: k8sObjects,
+						ConfigString: `
 apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
@@ -384,82 +412,75 @@ spec:
       app: httpbin
     network: vm
 `,
-		MeshNetworks: &meshconfig.MeshNetworks{Networks: map[string]*meshconfig.Network{
-			"network-1": {
-				Endpoints: []*meshconfig.Network_NetworkEndpoints{{
-					Ne: &meshconfig.Network_NetworkEndpoints_FromRegistry{FromRegistry: "Kubernetes"},
-				}},
-				Gateways: []*meshconfig.Network_IstioNetworkGateway{{
-					Gw:       &meshconfig.Network_IstioNetworkGateway_Address{Address: "2.2.2.2"},
-					Port:     15443,
-					Locality: "",
-				}},
-			},
-		}},
-	})
-	se := s.SetupProxy(&model.Proxy{
-		ID: "se-pod.pod",
-		Metadata: &model.NodeMetadata{
-			Network:   "network-1",
-			ClusterID: "Kubernetes",
-			Labels:    labels.Instance{"app": "se-pod"},
-		},
-	})
-	pod := s.SetupProxy(&model.Proxy{
-		ID: "kubeapp-1234.pod",
-		Metadata: &model.NodeMetadata{
-			Network:   "network-1",
-			ClusterID: "Kubernetes",
-			Labels:    labels.Instance{"app": "kubeapp"},
-		},
-	})
-	vm := s.SetupProxy(&model.Proxy{
-		ID:              "vm",
-		IPAddresses:     []string{"10.10.10.10"},
-		ConfigNamespace: "default",
-		Metadata: &model.NodeMetadata{
-			Network:          "vm",
-			InterceptionMode: "NONE",
-		},
-	})
+						MeshNetworks: networkConfig,
+					})
+					se := s.SetupProxy(&model.Proxy{
+						ID: "se-pod.pod",
+						Metadata: &model.NodeMetadata{
+							Network:   "network-1",
+							ClusterID: "Kubernetes",
+							Labels:    labels.Instance{"app": "se-pod"},
+						},
+					})
+					pod := s.SetupProxy(&model.Proxy{
+						ID: "kubeapp-1234.pod",
+						Metadata: &model.NodeMetadata{
+							Network:   "network-1",
+							ClusterID: "Kubernetes",
+							Labels:    labels.Instance{"app": "kubeapp"},
+						},
+					})
+					vm := s.SetupProxy(&model.Proxy{
+						ID:              "vm",
+						IPAddresses:     []string{"10.10.10.10"},
+						ConfigNamespace: "default",
+						Metadata: &model.NodeMetadata{
+							Network:          "vm",
+							InterceptionMode: "NONE",
+						},
+					})
 
-	tests := []struct {
-		p      *model.Proxy
-		expect map[string]string
-	}{
-		{
-			p: pod,
-			expect: map[string]string{
-				"outbound|7070||httpbin.com":                 "10.10.10.10",
-				"outbound|80||kubeapp.pod.svc.cluster.local": "10.10.10.20",
-				"outbound|80||se-pod.pod.svc.cluster.local":  "10.10.10.30",
-			},
-		},
-		{
-			p: se,
-			expect: map[string]string{
-				"outbound|7070||httpbin.com":                 "10.10.10.10",
-				"outbound|80||kubeapp.pod.svc.cluster.local": "10.10.10.20",
-				"outbound|80||se-pod.pod.svc.cluster.local":  "10.10.10.30",
-			},
-		},
-		{
-			p: vm,
-			expect: map[string]string{
-				"outbound|7070||httpbin.com":                 "10.10.10.10",
-				"outbound|80||kubeapp.pod.svc.cluster.local": "2.2.2.2",
-				"outbound|80||se-pod.pod.svc.cluster.local":  "2.2.2.2",
-			},
-		},
-	}
+					tests := []struct {
+						p      *model.Proxy
+						expect map[string]string
+					}{
+						{
+							p: pod,
+							expect: map[string]string{
+								"outbound|7070||httpbin.com":                 "10.10.10.10",
+								"outbound|80||kubeapp.pod.svc.cluster.local": "10.10.10.20",
+								"outbound|80||se-pod.pod.svc.cluster.local":  "10.10.10.30",
+							},
+						},
+						{
+							p: se,
+							expect: map[string]string{
+								"outbound|7070||httpbin.com":                 "10.10.10.10",
+								"outbound|80||kubeapp.pod.svc.cluster.local": "10.10.10.20",
+								"outbound|80||se-pod.pod.svc.cluster.local":  "10.10.10.30",
+							},
+						},
+						{
+							p: vm,
+							expect: map[string]string{
+								"outbound|7070||httpbin.com":                 "10.10.10.10",
+								"outbound|80||kubeapp.pod.svc.cluster.local": "2.2.2.2",
+								"outbound|80||se-pod.pod.svc.cluster.local":  "2.2.2.2",
+							},
+						},
+					}
 
-	for _, tt := range tests {
-		eps := ExtractEndpoints(s.Endpoints(tt.p))
-		for c, ip := range tt.expect {
-			t.Run(fmt.Sprintf("%s from %s", c, vm.ID), func(t *testing.T) {
-				assertListEqual(t, eps[c], []string{ip})
-			})
-		}
+					for _, tt := range tests {
+						eps := ExtractEndpoints(s.Endpoints(tt.p))
+						for c, ip := range tt.expect {
+							t.Run(fmt.Sprintf("%s from %s", c, tt.p.ID), func(t *testing.T) {
+								assertListEqual(t, eps[c], []string{ip})
+							})
+						}
+					}
+				})
+			}
+		})
 	}
 }
 
@@ -547,6 +568,75 @@ spec:
 	}
 	if !found {
 		t.Fatalf("failed to find expected fallthrough route")
+	}
+}
+
+type fakeServiceOpts struct {
+	name         string
+	ns           string
+	ip           string
+	podLabels    labels.Instance
+	servicePorts []corev1.ServicePort
+}
+
+// fakePodService build the minimal k8s objects required to discover one endpoint.
+// If servicePorts is empty a default of http-80 will be used.
+func fakePodService(opts fakeServiceOpts) []runtime.Object {
+	baseMeta := metav1.ObjectMeta{
+		Name:      opts.name,
+		Labels:    labels.Instance{"app": opts.name},
+		Namespace: opts.ns,
+	}
+	podMeta := baseMeta
+	podMeta.Name = opts.name + "-" + rand.String(4)
+	for k, v := range opts.podLabels {
+		podMeta.Labels[k] = v
+	}
+
+	if len(opts.servicePorts) == 0 {
+		opts.servicePorts = []corev1.ServicePort{{
+			Port:     80,
+			Name:     "http",
+			Protocol: corev1.ProtocolTCP,
+		}}
+	}
+	var endpointPorts []corev1.EndpointPort
+	for _, sp := range opts.servicePorts {
+		endpointPorts = append(endpointPorts, corev1.EndpointPort{
+			Name:        sp.Name,
+			Port:        sp.Port,
+			Protocol:    sp.Protocol,
+			AppProtocol: sp.AppProtocol,
+		})
+	}
+
+	return []runtime.Object{
+		&corev1.Pod{
+			ObjectMeta: podMeta,
+		},
+		&corev1.Service{
+			ObjectMeta: baseMeta,
+			Spec: corev1.ServiceSpec{
+				ClusterIP: "1.2.3.4", // just can't be 0.0.0.0/ClusterIPNone
+				Selector:  baseMeta.Labels,
+				Ports:     opts.servicePorts,
+			},
+		},
+		&corev1.Endpoints{
+			ObjectMeta: baseMeta,
+			Subsets: []corev1.EndpointSubset{{
+				Addresses: []corev1.EndpointAddress{{
+					IP: opts.ip,
+					TargetRef: &corev1.ObjectReference{
+						APIVersion: "v1",
+						Kind:       "Pod",
+						Name:       podMeta.Name,
+						Namespace:  podMeta.Namespace,
+					},
+				}},
+				Ports: endpointPorts,
+			}},
+		},
 	}
 }
 

--- a/pilot/pkg/xds/xds_test.go
+++ b/pilot/pkg/xds/xds_test.go
@@ -17,6 +17,7 @@ package xds
 import (
 	"fmt"
 	"io/ioutil"
+	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"path"
 	"testing"
 
@@ -319,8 +320,9 @@ func TestMeshNetworking(t *testing.T) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "istio-ingressgateway",
-				Namespace: "istio-system",
+				Name:        "istio-ingressgateway",
+				Namespace:   "istio-system",
+				Annotations: map[string]string{kube.NodeSelectorAnnotation: "{}"},
 			},
 			Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeNodePort, Ports: []corev1.ServicePort{{Port: 15443, NodePort: 25443}}},
 			Status: corev1.ServiceStatus{

--- a/releasenotes/notes/fix-nodeport-meshnetwork.yaml
+++ b/releasenotes/notes/fix-nodeport-meshnetwork.yaml
@@ -1,0 +1,5 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes: |
+  *Fixed* an issue preventing NodePort services from being used as the `registryServiceName` in `meshNetworks`.


### PR DESCRIPTION
The following skips building nodePort mappings if the nodeSelector annotation is set:
https://github.com/istio/istio/blob/312ac4e0c37f0339c4f6b1608ee594d059ff7944/pilot/pkg/serviceregistry/kube/conversion.go#L121

Then when we decide whether or not to grab node addresses for the service, we make sure it _is_ set:

https://github.com/istio/istio/blob/07232fcb2989492f68b76f92c4ac24c3ff986f1f/pilot/pkg/serviceregistry/kube/controller/util.go#L194

IIUC this prevents actually using these NodePort services for meshNetworks gateways. Either the first or second check should be changed to match the other. I've added a test to validate things are built properly. The test fails without the fix. Do we expect this annotation to be set on all IGW? 


The [new tests pass](https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/25990/unit-tests_istio/17822) when not requiring the annotation as well as at the current commit, where we require the annotation in both places. 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
