### PR TITLE
Disable wasm test in VM

### DIFF
--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -89,6 +89,8 @@ func TestMain(m *testing.M) {
 			return ctx.Config().ApplyYAML("", string(crd))
 		}).
 		Setup(istio.Setup(&i, func(cfg *istio.Config) {
+			cfg.Values["telemetry.v2.metadataExchange.wasmEnabled"] = "false"
+			cfg.Values["telemetry.v2.prometheus.wasmEnabled"] = "false"
 			cfg.ControlPlaneValues = `
 values:
   global:


### PR DESCRIPTION
This fixes the post submit failure, while we debug why VM tests fail with wasm.

There was no cheap way to disable this just for VM test and keep it for the rest since everything uses the same testMain.