### PR TITLE
Refactored task clean in bookinfo reviews app

### DIFF
--- a/samples/bookinfo/src/reviews/reviews-wlpcfg/build.gradle
+++ b/samples/bookinfo/src/reviews/reviews-wlpcfg/build.gradle
@@ -16,8 +16,4 @@ task build(dependsOn: ['copyApplication']){
 
 task clean {
     delete "servers/LibertyProjectServer/apps"
-    delete "servers/LibertyProjectServer/lib"
-    delete "servers/LibertyProjectServer/logs"
-    delete "servers/LibertyProjectServer/workarea"
-    delete "servers/LibertyProjectServer/resources"
 }


### PR DESCRIPTION
Refactored task clean of gradle file for reviews-wlfcfg
Description: `gradle build` creates only apps folder in servers/LibertyProjectServer/ directory whereas in `gradle clean` task, directories lib, logs, workarea, resources is getting cleaned up. So removed these lines as a part of `gradle clean` task.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ X] User Experience
[ ] Developer Infrastructure