### PR TITLE
Pilot unit test improvements

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -90,12 +90,6 @@ func (s *Server) initConfigController(args *PilotArgs) error {
 		}
 	}
 
-	// Used for tests.
-	memStore := memory.Make(collections.Pilot)
-	memConfigController := memory.NewController(memStore)
-	s.ConfigStores = append(s.ConfigStores, memConfigController)
-	s.EnvoyXdsServer.MemConfigController = memConfigController
-
 	// If running in ingress mode (requires k8s), wrap the config controller.
 	if hasKubeRegistry(args.RegistryOptions.Registries) && meshConfig.IngressControllerMode != meshconfig.MeshConfig_OFF {
 		// Wrap the config controller with a cache.

--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -91,6 +91,7 @@ func (s *Server) initKubeRegistry(serviceControllers *aggregate.Controller, args
 		args.RegistryOptions.KubeOptions.EndpointMode = kubecontroller.EndpointsOnly
 	}
 
+	log.Infof("Initializing Kubernetes service registry %q", args.RegistryOptions.KubeOptions.ClusterID)
 	kubeRegistry := kubecontroller.NewController(s.kubeClient, args.RegistryOptions.KubeOptions)
 	s.kubeRegistry = kubeRegistry
 	serviceControllers.AddRegistry(kubeRegistry)

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -220,8 +220,6 @@ type Controller struct {
 // NewController creates a new Kubernetes controller
 // Created by bootstrap and multicluster (see secretcontroler).
 func NewController(kubeClient kubelib.Client, options Options) *Controller {
-	log.Infof("Initializing Kubernetes service registry %q", options.ClusterID)
-
 	// The queue requires a time duration for a retry delay after a handler error
 	c := &Controller{
 		domainSuffix:               options.DomainSuffix,

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -122,6 +122,7 @@ func (m *Multicluster) AddMemberCluster(clients kubelib.Client, clusterID string
 		NetworksWatcher:   m.networksWatcher,
 		Metrics:           m.metrics,
 	}
+	log.Infof("Initializing Kubernetes service registry %q", options.ClusterID)
 	kubectl := NewController(clients, options)
 
 	remoteKubeController.Controller = kubectl

--- a/pilot/pkg/xds/cds_test.go
+++ b/pilot/pkg/xds/cds_test.go
@@ -16,25 +16,19 @@ package xds_test
 import (
 	"testing"
 
+	"istio.io/istio/pilot/pkg/xds"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
-	"istio.io/istio/tests/util"
 )
 
 func TestCDS(t *testing.T) {
-	_, tearDown := initLocalPilotTestEnv(t)
-	defer tearDown()
+	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+	adscon := s.ConnectADS()
 
-	cdsr, cancel, err := connectADS(util.MockPilotGrpcAddr)
+	err := sendCDSReq(sidecarID(app3Ip, "app3"), adscon)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	err = sendCDSReq(sidecarID(app3Ip, "app3"), cdsr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cancel()
-	res, err := cdsr.Recv()
+	res, err := adscon.Recv()
 	if err != nil {
 		t.Fatal("Failed to receive CDS", err)
 		return

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -110,7 +110,7 @@ func (s *DiscoveryServer) InitDebug(mux *http.ServeMux, sctl *aggregate.Controll
 
 	mux.HandleFunc("/debug", s.Debug)
 
-	s.addDebugHandler(mux, "/debug/edsz", "Status and debug interface for EDS", s.edsz)
+	s.addDebugHandler(mux, "/debug/edsz", "Status and debug interface for EDS", s.Edsz)
 	s.addDebugHandler(mux, "/debug/adsz", "Status and debug interface for ADS", s.adsz)
 	s.addDebugHandler(mux, "/debug/adsz?push=true", "Initiates push of the current state to all connected endpoints", s.adsz)
 	s.addDebugHandler(mux, "/debug/cdsz", "Status and debug interface for CDS", s.cdsz)
@@ -602,9 +602,9 @@ func (s *DiscoveryServer) Debug(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(200)
 }
 
-// edsz implements a status and debug interface for EDS.
+// Edsz implements a status and debug interface for EDS.
 // It is mapped to /debug/edsz on the monitor port (15014).
-func (s *DiscoveryServer) edsz(w http.ResponseWriter, req *http.Request) {
+func (s *DiscoveryServer) Edsz(w http.ResponseWriter, req *http.Request) {
 	_ = req.ParseForm()
 	w.Header().Add("Content-Type", "application/json")
 

--- a/pilot/pkg/xds/eds_sh_test.go
+++ b/pilot/pkg/xds/eds_sh_test.go
@@ -25,15 +25,14 @@ import (
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 
-	"istio.io/istio/pilot/pkg/bootstrap"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
+	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	"istio.io/istio/pilot/pkg/serviceregistry/memory"
+	"istio.io/istio/pilot/pkg/xds"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/protocol"
-	"istio.io/istio/pkg/test/env"
-	"istio.io/istio/tests/util"
 )
 
 // Testing the Split Horizon EDS.
@@ -49,24 +48,23 @@ type expectedResults struct {
 // the Split Horizon EDS - all local endpoints + endpoint per remote network that also has
 // endpoints for the service.
 func TestSplitHorizonEds(t *testing.T) {
-	server, tearDown := initSplitHorizonTestEnv(t)
-	defer tearDown()
+	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 
 	// Set up a cluster registry for network 1 with 1 instance for the service 'service5'
 	// Network has 1 gateway
-	initRegistry(server, 1, []string{"159.122.219.1"}, 1)
+	initRegistry(s, 1, []string{"159.122.219.1"}, 1)
 	// Set up a cluster registry for network 2 with 2 instances for the service 'service5'
 	// Network has 1 gateway
-	initRegistry(server, 2, []string{"159.122.219.2"}, 2)
+	initRegistry(s, 2, []string{"159.122.219.2"}, 2)
 	// Set up a cluster registry for network 3 with 3 instances for the service 'service5'
 	// Network has 2 gateways
-	initRegistry(server, 3, []string{"159.122.219.3", "179.114.119.3"}, 3)
+	initRegistry(s, 3, []string{"159.122.219.3", "179.114.119.3"}, 3)
 	// Set up a cluster registry for network 4 with 4 instances for the service 'service5'
 	// but without any gateway, which is treated as accessible directly.
-	initRegistry(server, 4, []string{}, 4)
+	initRegistry(s, 4, []string{}, 4)
 
 	// Push contexts needs to be updated
-	server.EnvoyXdsServer.ConfigUpdate(&model.PushRequest{Full: true})
+	s.Discovery.ConfigUpdate(&model.PushRequest{Full: true})
 	time.Sleep(time.Millisecond * 200) // give time for cache to clear
 
 	tests := []struct {
@@ -151,39 +149,35 @@ func TestSplitHorizonEds(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.network, func(t *testing.T) {
-			verifySplitHorizonResponse(t, tt.network, tt.sidecarID, tt.want)
+			verifySplitHorizonResponse(t, s, tt.network, tt.sidecarID, tt.want)
 		})
 	}
 }
 
 // Tests whether an EDS response from the provided network matches the expected results
-func verifySplitHorizonResponse(t *testing.T, network string, sidecarID string, expected expectedResults) {
+func verifySplitHorizonResponse(t *testing.T, s *xds.FakeDiscoveryServer, network string, sidecarID string, expected expectedResults) {
 	t.Helper()
-	edsstr, cancel, err := connectADS(util.MockPilotGrpcAddr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cancel()
+	adscon := s.ConnectADS()
 
 	metadata := &structpb.Struct{Fields: map[string]*structpb.Value{
 		"ISTIO_VERSION": {Kind: &structpb.Value_StringValue{StringValue: "1.3"}},
 		"NETWORK":       {Kind: &structpb.Value_StringValue{StringValue: network}},
 	}}
 
-	err = sendCDSReqWithMetadata(sidecarID, metadata, edsstr)
+	err := sendCDSReqWithMetadata(sidecarID, metadata, adscon)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = adsReceive(edsstr, 5*time.Second)
+	_, err = adsReceive(adscon, 5*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = sendEDSReqWithMetadata([]string{"outbound|1080||service5.default.svc.cluster.local"}, sidecarID, metadata, edsstr)
+	err = sendEDSReqWithMetadata([]string{"outbound|1080||service5.default.svc.cluster.local"}, sidecarID, metadata, adscon)
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := adsReceive(edsstr, 5*time.Second)
+	res, err := adsReceive(adscon, 5*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -219,29 +213,15 @@ func verifySplitHorizonResponse(t *testing.T, network string, sidecarID string, 
 	}
 }
 
-func initSplitHorizonTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) {
-	initMutex.Lock()
-	defer initMutex.Unlock()
-	testEnv = env.NewTestSetup(env.XDSTest, t)
-	server, tearDown := util.EnsureTestServer()
-
-	testEnv.Ports().PilotGrpcPort = uint16(util.MockPilotGrpcPort)
-	testEnv.Ports().PilotHTTPPort = uint16(util.MockPilotHTTPPort)
-	testEnv.IstioSrc = env.IstioSrc
-	testEnv.IstioOut = env.IstioOut
-
-	return server, tearDown
-}
-
 // initRegistry creates and initializes a memory registry that holds a single
 // service with the provided amount of endpoints. It also creates a service for
 // the ingress with the provided external IP
-func initRegistry(server *bootstrap.Server, clusterNum int, gatewaysIP []string, numOfEndpoints int) {
+func initRegistry(server *xds.FakeDiscoveryServer, clusterNum int, gatewaysIP []string, numOfEndpoints int) {
 	id := fmt.Sprintf("network%d", clusterNum)
 	memRegistry := memory.NewServiceDiscovery(nil)
-	memRegistry.EDSUpdater = server.EnvoyXdsServer
+	memRegistry.EDSUpdater = server.Discovery
 
-	server.ServiceController().AddRegistry(serviceregistry.Simple{
+	server.Env.ServiceDiscovery.(*aggregate.Controller).AddRegistry(serviceregistry.Simple{
 		ClusterID:        id,
 		ProviderID:       serviceregistry.Mock,
 		ServiceDiscovery: memRegistry,
@@ -251,8 +231,8 @@ func initRegistry(server *bootstrap.Server, clusterNum int, gatewaysIP []string,
 	gws := make([]*meshconfig.Network_IstioNetworkGateway, 0)
 	for _, gatewayIP := range gatewaysIP {
 		if gatewayIP != "" {
-			if server.EnvoyXdsServer.Env.Networks() == nil {
-				server.EnvoyXdsServer.Env.NetworksWatcher = mesh.NewFixedNetworksWatcher(&meshconfig.MeshNetworks{
+			if server.Env.Networks() == nil {
+				server.Env.NetworksWatcher = mesh.NewFixedNetworksWatcher(&meshconfig.MeshNetworks{
 					Networks: map[string]*meshconfig.Network{},
 				})
 			}
@@ -267,7 +247,7 @@ func initRegistry(server *bootstrap.Server, clusterNum int, gatewaysIP []string,
 	}
 
 	if len(gws) != 0 {
-		server.EnvoyXdsServer.Env.Networks().Networks[id] = &meshconfig.Network{
+		server.Env.Networks().Networks[id] = &meshconfig.Network{
 			Gateways: gws,
 		}
 	}

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -588,7 +588,7 @@ func multipleRequest(s *xds.FakeDiscoveryServer, inc bool, nclients,
 			defer wg.Done()
 			// Connect and get initial response
 			adscConn := s.Connect(&model.Proxy{IPAddresses: []string{fmt.Sprintf("1.1.1.%d", id)}}, nil, nil)
-			_, err = adscConn.Wait(15*time.Second, "rds")
+			_, err := adscConn.Wait(15*time.Second, "rds")
 			if err != nil {
 				errChan <- errors.New("failed to get initial rds: " + err.Error())
 				wgConnect.Done()

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -20,6 +20,8 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"net/http/httptest"
+	"path/filepath"
 	"reflect"
 	"runtime"
 	"strconv"
@@ -31,9 +33,9 @@ import (
 
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 
-	"istio.io/istio/pilot/pkg/bootstrap"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/xds"
+	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pkg/adsc"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
@@ -54,50 +56,47 @@ const (
 )
 
 func TestEds(t *testing.T) {
-	server, tearDown := localPilotTestEnv(t, func(server *bootstrap.Server) {
-		// will be checked in the direct request test
-		addUdsEndpoint(server)
+	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{ConfigString: mustReadFile(t, "tests/testdata/config/destination-rule-locality.yaml")})
+	addUdsEndpoint(s)
 
-		// enable locality load balancing and add relevant endpoints in order to test
-		addLocalityEndpoints(server, "locality.cluster.local")
-		addLocalityEndpoints(server, "locality-no-outlier-detection.cluster.local")
+	// enable locality load balancing and add relevant endpoints in order to test
+	addLocalityEndpoints(s, "locality.cluster.local")
+	addLocalityEndpoints(s, "locality-no-outlier-detection.cluster.local")
 
-		// Add the test ads clients to list of service instances in order to test the context dependent locality coloring.
-		addTestClientEndpoints(server)
+	// Add the test ads clients to list of service instances in order to test the context dependent locality coloring.
+	addTestClientEndpoints(s)
 
-		server.EnvoyXdsServer.MemRegistry.AddHTTPService(edsIncSvc, edsIncVip, 8080)
-		server.EnvoyXdsServer.MemRegistry.SetEndpoints(edsIncSvc, "",
-			newEndpointWithAccount("127.0.0.1", "hello-sa", "v1"))
-	})
-	defer tearDown()
+	s.Discovery.MemRegistry.AddHTTPService(edsIncSvc, edsIncVip, 8080)
+	s.Discovery.MemRegistry.SetEndpoints(edsIncSvc, "",
+		newEndpointWithAccount("127.0.0.1", "hello-sa", "v1"))
 
-	adscConn := adsConnectAndWait(t, 0x0a0a0a0a)
-	defer adscConn.Close()
-	adscConn2 := adsConnectAndWait(t, 0x0a0a0a0b)
-	defer adscConn2.Close()
+	adscConn := s.Connect(&model.Proxy{IPAddresses: []string{"10.10.10.10"}}, nil, watchEds)
+	adscConn2 := s.Connect(&model.Proxy{IPAddresses: []string{"10.10.10.11"}}, nil, watchEds)
 
 	t.Run("TCPEndpoints", func(t *testing.T) {
 		testTCPEndpoints("127.0.0.1", adscConn, t)
-		testEdsz(t, "test-1.default")
+	})
+	t.Run("edsz", func(t *testing.T) {
+		testEdsz(t, s, "test-1.default")
 	})
 	t.Run("LocalityPrioritizedEndpoints", func(t *testing.T) {
 		testLocalityPrioritizedEndpoints(adscConn, adscConn2, t)
 	})
 	t.Run("UDSEndpoints", func(t *testing.T) {
-		testUdsEndpoints(server, adscConn, t)
+		testUdsEndpoints(adscConn, t)
 	})
 	t.Run("PushIncremental", func(t *testing.T) {
-		edsUpdateInc(server, adscConn, t)
+		edsUpdateInc(s, adscConn, t)
 	})
 	t.Run("Push", func(t *testing.T) {
-		edsUpdates(server, adscConn, t)
+		edsUpdates(s, adscConn, t)
 	})
 	t.Run("MultipleRequest", func(t *testing.T) {
-		multipleRequest(server, false, 20, 5, 20*time.Second, nil, t)
+		multipleRequest(s, false, 20, 5, 5*time.Second, nil, t)
 	})
 	// 5 pushes for 100 clients, using EDS incremental only.
 	t.Run("MultipleRequestIncremental", func(t *testing.T) {
-		multipleRequest(server, true, 20, 5, 20*time.Second, nil, t)
+		multipleRequest(s, true, 20, 5, 5*time.Second, nil, t)
 	})
 	t.Run("CDSSave", func(t *testing.T) {
 		// Moved from cds_test, using new client
@@ -111,12 +110,38 @@ func TestEds(t *testing.T) {
 	})
 }
 
-func TestEdsWeightedServiceEntry(t *testing.T) {
-	_, tearDown := initLocalPilotTestEnv(t)
-	defer tearDown()
+func mustReadFile(t *testing.T, fpaths ...string) string {
+	result := ""
+	for _, fpath := range fpaths {
+		bytes, err := ioutil.ReadFile(filepath.Join(env.IstioSrc, fpath))
+		if err != nil {
+			t.Fatal(err)
+		}
+		result += "---\n"
+		result += string(bytes)
+	}
+	return result
+}
+func mustReadfolder(t *testing.T, folder string) string {
+	result := ""
+	f, err := ioutil.ReadDir(filepath.Join(env.IstioSrc, folder))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, fpath := range f {
+		bytes, err := ioutil.ReadFile(filepath.Join(env.IstioSrc, folder, fpath.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		result += "---\n"
+		result += string(bytes)
+	}
+	return result
+}
 
-	adscConn := adsConnectAndWait(t, 0x0a0a0a0a)
-	defer adscConn.Close()
+func TestEdsWeightedServiceEntry(t *testing.T) {
+	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{ConfigString: mustReadFile(t, "tests/testdata/config/static-weighted-se.yaml")})
+	adscConn := s.Connect(nil, nil, watchEds)
 	endpoints := adscConn.GetEndpoints()
 	lbe, f := endpoints["outbound|80||weighted.static.svc.cluster.local"]
 	if !f || len(lbe.Endpoints) == 0 {
@@ -141,38 +166,34 @@ func TestEdsWeightedServiceEntry(t *testing.T) {
 	}
 }
 
+var watchEds = []string{v3.ClusterType, v3.EndpointType}
+var watchAll = []string{v3.ClusterType, v3.EndpointType, v3.ListenerType, v3.RouteType}
+
 func TestEDSOverlapping(t *testing.T) {
-	server, tearDown := localPilotTestEnv(t, func(server *bootstrap.Server) {
-		// add endpoints with multiple ports with the same port number.
-		addOverlappingEndpoints(server)
-	})
-	defer tearDown()
-
-	adscConn := adsConnectAndWait(t, 0x0a0a0a0a)
-	defer adscConn.Close()
-
-	testOverlappingPorts(server, adscConn, t)
+	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+	addOverlappingEndpoints(s)
+	adscon := s.Connect(nil, nil, watchEds)
+	testOverlappingPorts(s, adscon, t)
 }
 
 // Validates the behavior when Service resolution type is updated after initial EDS push.
 // See https://github.com/istio/istio/issues/18355 for more details.
 func TestEDSServiceResolutionUpdate(t *testing.T) {
-	server, tearDown := localPilotTestEnv(t, func(server *bootstrap.Server) {
-		// add a eds type of cluster with static end points.
-		addEdsCluster(server, "edsdns.svc.cluster.local", "http", "10.0.0.53", 8080)
-	})
-	defer tearDown()
+	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+	addEdsCluster(s, "edsdns.svc.cluster.local", "http", "10.0.0.53", 8080)
+	addEdsCluster(s, "other.local", "http", "1.1.1.1", 8080)
 
-	adscConn := adsConnectAndWait(t, 0x0a0a0a0a)
-	defer adscConn.Close()
+	adscConn := s.Connect(nil, nil, watchAll)
 
 	// Validate that endpoints are pushed correctly.
 	testEndpoints("10.0.0.53", "outbound|8080||edsdns.svc.cluster.local", adscConn, t)
 
 	// Now update the service resolution to DNSLB with a DNS endpoint.
-	updateServiceResolution(server)
+	updateServiceResolution(s)
 
-	_, _ = adscConn.Wait(5*time.Second, "eds")
+	if _, err := adscConn.Wait(5*time.Second, "eds"); err != nil {
+		t.Fatal(err)
+	}
 
 	// Validate that endpoints are skipped.
 	lbe := adscConn.GetEndpoints()["outbound|8080||edsdns.svc.cluster.local"]
@@ -183,29 +204,25 @@ func TestEDSServiceResolutionUpdate(t *testing.T) {
 
 // Validate that when endpoints of a service flipflop between 1 and 0 does not trigger a full push.
 func TestEndpointFlipFlops(t *testing.T) {
-	server, tearDown := localPilotTestEnv(t, func(server *bootstrap.Server) {
-		// add a eds type of cluster with static end points.
-		addEdsCluster(server, "flipflop.com", "http", "10.0.0.53", 8080)
-	})
-	defer tearDown()
+	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+	addEdsCluster(s, "flipflop.com", "http", "10.0.0.53", 8080)
 
-	adscConn := adsConnectAndWait(t, 0x0a0a0a0a)
-	defer adscConn.Close()
+	adscConn := s.Connect(nil, nil, watchAll)
 
 	// Validate that endpoints are pushed correctly.
 	testEndpoints("10.0.0.53", "outbound|8080||flipflop.com", adscConn, t)
 
 	// Clear the endpoint and validate it does not trigger a full push.
-	server.EnvoyXdsServer.MemRegistry.SetEndpoints("flipflop.com", "", []*model.IstioEndpoint{})
+	s.Discovery.MemRegistry.SetEndpoints("flipflop.com", "", []*model.IstioEndpoint{})
 
-	upd, _ := adscConn.Wait(5 * time.Second)
+	upd, _ := adscConn.Wait(5*time.Second, "eds")
 
 	if contains(upd, "cds") {
 		t.Fatalf("Expecting only EDS update as part of a partial push. But received CDS also %v", upd)
 	}
 
 	if len(upd) > 0 && !contains(upd, "eds") {
-		t.Fatalf("Expecting EDS push as part of a partial push. But did not receive %v", upd)
+		t.Fatalf("Expecting EDS push as part of a partial push. But received %v", upd)
 	}
 
 	lbe := adscConn.GetEndpoints()["outbound|8080||flipflop.com"]
@@ -214,12 +231,12 @@ func TestEndpointFlipFlops(t *testing.T) {
 	}
 
 	// Validate that keys in service still exist in EndpointShardsByService - this prevents full push.
-	if len(server.EnvoyXdsServer.EndpointShardsByService["flipflop.com"]) == 0 {
-		t.Fatalf("Expected service key %s to be present in EndpointShardsByService. But missing %v", "flipflop.com", server.EnvoyXdsServer.EndpointShardsByService)
+	if len(s.Discovery.EndpointShardsByService["flipflop.com"]) == 0 {
+		t.Fatalf("Expected service key %s to be present in EndpointShardsByService. But missing %v", "flipflop.com", s.Discovery.EndpointShardsByService)
 	}
 
 	// Set the endpoints again and validate it does not trigger full push.
-	server.EnvoyXdsServer.MemRegistry.SetEndpoints("flipflop.com", "",
+	s.Discovery.MemRegistry.SetEndpoints("flipflop.com", "",
 		[]*model.IstioEndpoint{
 			{
 				Address:         "10.10.1.1",
@@ -242,28 +259,24 @@ func TestEndpointFlipFlops(t *testing.T) {
 
 // Validate that deleting a service clears entries from EndpointShardsByService.
 func TestDeleteService(t *testing.T) {
-	server, tearDown := localPilotTestEnv(t, func(server *bootstrap.Server) {
-		// add a eds type of cluster with static end points.
-		addEdsCluster(server, "removeservice.com", "http", "10.0.0.53", 8080)
-	})
-	defer tearDown()
+	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+	addEdsCluster(s, "removeservice.com", "http", "10.0.0.53", 8080)
 
-	adscConn := adsConnectAndWait(t, 0x0a0a0a0a)
-	defer adscConn.Close()
+	adscConn := s.Connect(nil, nil, watchEds)
 
 	// Validate that endpoints are pushed correctly.
 	testEndpoints("10.0.0.53", "outbound|8080||removeservice.com", adscConn, t)
 
-	server.EnvoyXdsServer.MemRegistry.RemoveService("removeservice.com")
+	s.Discovery.MemRegistry.RemoveService("removeservice.com")
 
-	if len(server.EnvoyXdsServer.EndpointShardsByService["removeservice.com"]) != 0 {
+	if len(s.Discovery.EndpointShardsByService["removeservice.com"]) != 0 {
 		t.Fatalf("Expected service key %s to be deleted in EndpointShardsByService. But is still there %v",
-			"removeservice.com", server.EnvoyXdsServer.EndpointShardsByService)
+			"removeservice.com", s.Discovery.EndpointShardsByService)
 	}
 }
 
-func fullPush(server *bootstrap.Server) {
-	server.EnvoyXdsServer.Push(&model.PushRequest{Full: true})
+func fullPush(s *xds.FakeDiscoveryServer) {
+	s.Discovery.Push(&model.PushRequest{Full: true})
 }
 
 func adsConnectAndWait(t *testing.T, ip int) *adsc.ADSC {
@@ -285,8 +298,8 @@ func adsConnectAndWait(t *testing.T, ip int) *adsc.ADSC {
 	return adscConn
 }
 
-func addTestClientEndpoints(server *bootstrap.Server) {
-	server.EnvoyXdsServer.MemRegistry.AddService("test-1.default", &model.Service{
+func addTestClientEndpoints(server *xds.FakeDiscoveryServer) {
+	server.Discovery.MemRegistry.AddService("test-1.default", &model.Service{
 		Hostname: "test-1.default",
 		Ports: model.PortList{
 			{
@@ -296,7 +309,7 @@ func addTestClientEndpoints(server *bootstrap.Server) {
 			},
 		},
 	})
-	server.EnvoyXdsServer.MemRegistry.AddInstance("test-1.default", &model.ServiceInstance{
+	server.Discovery.MemRegistry.AddInstance("test-1.default", &model.ServiceInstance{
 		Endpoint: &model.IstioEndpoint{
 			Address:         "10.10.10.10",
 			ServicePortName: "http",
@@ -309,7 +322,7 @@ func addTestClientEndpoints(server *bootstrap.Server) {
 			Protocol: protocol.HTTP,
 		},
 	})
-	server.EnvoyXdsServer.MemRegistry.AddInstance("test-1.default", &model.ServiceInstance{
+	server.Discovery.MemRegistry.AddInstance("test-1.default", &model.ServiceInstance{
 		Endpoint: &model.IstioEndpoint{
 			Address:         "10.10.10.11",
 			ServicePortName: "http",
@@ -369,11 +382,11 @@ func testLocalityPrioritizedEndpoints(adsc *adsc.ADSC, adsc2 *adsc.ADSC, t *test
 
 // Tests that Services with multiple ports sharing the same port number are properly sent endpoints.
 // Real world use case for this is kube-dns, which uses port 53 for TCP and UDP.
-func testOverlappingPorts(server *bootstrap.Server, adsc *adsc.ADSC, t *testing.T) {
+func testOverlappingPorts(s *xds.FakeDiscoveryServer, adsc *adsc.ADSC, t *testing.T) {
 	// Test initial state
 	testEndpoints("10.0.0.53", "outbound|53||overlapping.cluster.local", adsc, t)
 
-	server.EnvoyXdsServer.Push(&model.PushRequest{
+	s.Discovery.Push(&model.PushRequest{
 		Full: true,
 		ConfigsUpdated: map[model.ConfigKey]struct{}{{
 			Kind: gvk.ServiceEntry,
@@ -420,7 +433,7 @@ func verifyLocalityPriorities(proxyLocality string, eps []*endpoint.LocalityLbEn
 }
 
 // Verify server sends UDS endpoints
-func testUdsEndpoints(_ *bootstrap.Server, adsc *adsc.ADSC, t *testing.T) {
+func testUdsEndpoints(adsc *adsc.ADSC, t *testing.T) {
 	// Check the UDS endpoint ( used to be separate test - but using old unused GRPC method)
 	// The new test also verifies CDS is pusing the UDS cluster, since adsc.eds is
 	// populated using CDS response
@@ -441,12 +454,12 @@ func testUdsEndpoints(_ *bootstrap.Server, adsc *adsc.ADSC, t *testing.T) {
 }
 
 // Update
-func edsUpdates(server *bootstrap.Server, adsc *adsc.ADSC, t *testing.T) {
+func edsUpdates(s *xds.FakeDiscoveryServer, adsc *adsc.ADSC, t *testing.T) {
 	// Old style (non-incremental)
-	server.EnvoyXdsServer.MemRegistry.SetEndpoints(edsIncSvc, "",
+	s.Discovery.MemRegistry.SetEndpoints(edsIncSvc, "",
 		newEndpointWithAccount("127.0.0.3", "hello-sa", "v1"))
 
-	xds.AdsPushAll(server.EnvoyXdsServer)
+	xds.AdsPushAll(s.Discovery)
 
 	// will trigger recompute and push
 
@@ -470,7 +483,7 @@ func edsFullUpdateCheck(adsc *adsc.ADSC, t *testing.T) {
 // - just endpoint changes -> incremental
 // - service account changes -> full ( in future: CDS only )
 // - label changes -> full
-func edsUpdateInc(server *bootstrap.Server, adsc *adsc.ADSC, t *testing.T) {
+func edsUpdateInc(s *xds.FakeDiscoveryServer, adsc *adsc.ADSC, t *testing.T) {
 
 	// TODO: set endpoints for a different cluster (new shard)
 
@@ -481,7 +494,7 @@ func edsUpdateInc(server *bootstrap.Server, adsc *adsc.ADSC, t *testing.T) {
 
 	// Equivalent with the event generated by K8S watching the Service.
 	// Will trigger a push.
-	server.EnvoyXdsServer.MemRegistry.SetEndpoints(edsIncSvc, "",
+	s.Discovery.MemRegistry.SetEndpoints(edsIncSvc, "",
 		newEndpointWithAccount("127.0.0.2", "hello-sa", "v1"))
 
 	upd, err := adsc.Wait(5 * time.Second)
@@ -495,14 +508,14 @@ func edsUpdateInc(server *bootstrap.Server, adsc *adsc.ADSC, t *testing.T) {
 	testTCPEndpoints("127.0.0.2", adsc, t)
 
 	// Update the endpoint with different SA - expect full
-	server.EnvoyXdsServer.MemRegistry.SetEndpoints(edsIncSvc, "",
+	s.Discovery.MemRegistry.SetEndpoints(edsIncSvc, "",
 		newEndpointWithAccount("127.0.0.3", "account2", "v1"))
 
 	edsFullUpdateCheck(adsc, t)
 	testTCPEndpoints("127.0.0.3", adsc, t)
 
 	// Update the endpoint again, no SA change - expect incremental
-	server.EnvoyXdsServer.MemRegistry.SetEndpoints(edsIncSvc, "",
+	s.Discovery.MemRegistry.SetEndpoints(edsIncSvc, "",
 		newEndpointWithAccount("127.0.0.4", "account2", "v1"))
 
 	upd, err = adsc.Wait(5 * time.Second)
@@ -515,13 +528,13 @@ func edsUpdateInc(server *bootstrap.Server, adsc *adsc.ADSC, t *testing.T) {
 	testTCPEndpoints("127.0.0.4", adsc, t)
 
 	// Update the endpoint to original SA - expect full
-	server.EnvoyXdsServer.MemRegistry.SetEndpoints(edsIncSvc, "",
+	s.Discovery.MemRegistry.SetEndpoints(edsIncSvc, "",
 		newEndpointWithAccount("127.0.0.2", "hello-sa", "v1"))
 	edsFullUpdateCheck(adsc, t)
 	testTCPEndpoints("127.0.0.2", adsc, t)
 
 	// Update the endpoint again, no label change - expect incremental
-	server.EnvoyXdsServer.MemRegistry.SetEndpoints(edsIncSvc, "",
+	s.Discovery.MemRegistry.SetEndpoints(edsIncSvc, "",
 		newEndpointWithAccount("127.0.0.5", "hello-sa", "v1"))
 
 	upd, err = adsc.Wait(5 * time.Second)
@@ -534,7 +547,7 @@ func edsUpdateInc(server *bootstrap.Server, adsc *adsc.ADSC, t *testing.T) {
 	testTCPEndpoints("127.0.0.5", adsc, t)
 
 	// Wipe out all endpoints - expect full
-	server.EnvoyXdsServer.MemRegistry.SetEndpoints(edsIncSvc, "", []*model.IstioEndpoint{})
+	s.Discovery.MemRegistry.SetEndpoints(edsIncSvc, "", []*model.IstioEndpoint{})
 
 	if upd, err := adsc.Wait(15*time.Second, "eds"); err != nil {
 		t.Fatal("Expecting EDS update as part of a partial push", err, upd)
@@ -549,7 +562,7 @@ func edsUpdateInc(server *bootstrap.Server, adsc *adsc.ADSC, t *testing.T) {
 // Make a direct EDS grpc request to pilot, verify the result is as expected.
 // This test includes a 'bad client' regression test, which fails to read on the
 // stream.
-func multipleRequest(server *bootstrap.Server, inc bool, nclients,
+func multipleRequest(s *xds.FakeDiscoveryServer, inc bool, nclients,
 	nPushes int, to time.Duration, _ map[string]string, t *testing.T) {
 	wgConnect := &sync.WaitGroup{}
 	wg := &sync.WaitGroup{}
@@ -558,15 +571,11 @@ func multipleRequest(server *bootstrap.Server, inc bool, nclients,
 	// Bad client - will not read any response. This triggers Write to block, which should
 	// be detected
 	// This is not using adsc, which consumes the events automatically.
-	ads, cancel, err := connectADS(util.MockPilotGrpcAddr)
+	ads := s.ConnectADS()
+	err := sendCDSReq(sidecarID(testIP(0x0a120001), "app3"), ads)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = sendCDSReq(sidecarID(testIP(0x0a120001), "app3"), ads)
-	if err != nil {
-		t.Fatal(err)
-	}
-	cancel()
 
 	n := nclients
 	wg.Add(n)
@@ -578,16 +587,7 @@ func multipleRequest(server *bootstrap.Server, inc bool, nclients,
 		go func(id int) {
 			defer wg.Done()
 			// Connect and get initial response
-			adscConn, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.Config{
-				IP: testIP(uint32(0x0a100000 + id)),
-			})
-			if err != nil {
-				errChan <- errors.New("failed to connect" + err.Error())
-				wgConnect.Done()
-				return
-			}
-			defer adscConn.Close()
-			adscConn.Watch()
+			adscConn := s.Connect(&model.Proxy{IPAddresses: []string{fmt.Sprintf("1.1.1.%d", id)}}, nil, nil)
 			_, err = adscConn.Wait(15*time.Second, "rds")
 			if err != nil {
 				errChan <- errors.New("failed to get initial rds: " + err.Error())
@@ -644,16 +644,16 @@ func multipleRequest(server *bootstrap.Server, inc bool, nclients,
 	for j := 0; j < nPushes; j++ {
 		if inc {
 			// This will be throttled - we want to trigger a single push
-			server.EnvoyXdsServer.AdsPushAll(strconv.Itoa(j), &model.PushRequest{
+			s.Discovery.AdsPushAll(strconv.Itoa(j), &model.PushRequest{
 				Full: false,
 				ConfigsUpdated: map[model.ConfigKey]struct{}{{
 					Kind: gvk.ServiceEntry,
 					Name: edsIncSvc,
 				}: {}},
-				Push: server.EnvoyXdsServer.Env.PushContext,
+				Push: s.Discovery.Env.PushContext,
 			})
 		} else {
-			xds.AdsPushAll(server.EnvoyXdsServer)
+			xds.AdsPushAll(s.Discovery)
 		}
 		log.Println("Push done ", j)
 	}
@@ -690,8 +690,8 @@ func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
 
 const udsPath = "/var/run/test/socket"
 
-func addUdsEndpoint(server *bootstrap.Server) {
-	server.EnvoyXdsServer.MemRegistry.AddService("localuds.cluster.local", &model.Service{
+func addUdsEndpoint(s *xds.FakeDiscoveryServer) {
+	s.Discovery.MemRegistry.AddService("localuds.cluster.local", &model.Service{
 		Hostname: "localuds.cluster.local",
 		Ports: model.PortList{
 			{
@@ -703,7 +703,7 @@ func addUdsEndpoint(server *bootstrap.Server) {
 		MeshExternal: true,
 		Resolution:   model.ClientSideLB,
 	})
-	server.EnvoyXdsServer.MemRegistry.AddInstance("localuds.cluster.local", &model.ServiceInstance{
+	s.Discovery.MemRegistry.AddInstance("localuds.cluster.local", &model.ServiceInstance{
 		Endpoint: &model.IstioEndpoint{
 			Address:         udsPath,
 			EndpointPort:    0,
@@ -717,10 +717,16 @@ func addUdsEndpoint(server *bootstrap.Server) {
 			Protocol: protocol.GRPC,
 		},
 	})
+
+	pushReq := &model.PushRequest{
+		Full:   true,
+		Reason: []model.TriggerReason{model.ConfigUpdate},
+	}
+	s.Discovery.ConfigUpdate(pushReq)
 }
 
-func addLocalityEndpoints(server *bootstrap.Server, hostname host.Name) {
-	server.EnvoyXdsServer.MemRegistry.AddService(hostname, &model.Service{
+func addLocalityEndpoints(server *xds.FakeDiscoveryServer, hostname host.Name) {
+	server.Discovery.MemRegistry.AddService(hostname, &model.Service{
 		Hostname: hostname,
 		Ports: model.PortList{
 			{
@@ -740,7 +746,7 @@ func addLocalityEndpoints(server *bootstrap.Server, hostname host.Name) {
 		"region2/zone2/subzone2",
 	}
 	for i, locality := range localities {
-		server.EnvoyXdsServer.MemRegistry.AddInstance(hostname, &model.ServiceInstance{
+		server.Discovery.MemRegistry.AddInstance(hostname, &model.ServiceInstance{
 			Endpoint: &model.IstioEndpoint{
 				Address:         fmt.Sprintf("10.0.0.%v", i),
 				EndpointPort:    80,
@@ -756,8 +762,9 @@ func addLocalityEndpoints(server *bootstrap.Server, hostname host.Name) {
 	}
 }
 
-func addEdsCluster(server *bootstrap.Server, hostName string, portName string, address string, port int) {
-	server.EnvoyXdsServer.MemRegistry.AddService(host.Name(hostName), &model.Service{
+// nolint: unparam
+func addEdsCluster(s *xds.FakeDiscoveryServer, hostName string, portName string, address string, port int) {
+	s.Discovery.MemRegistry.AddService(host.Name(hostName), &model.Service{
 		Hostname: host.Name(hostName),
 		Ports: model.PortList{
 			{
@@ -768,7 +775,7 @@ func addEdsCluster(server *bootstrap.Server, hostName string, portName string, a
 		},
 	})
 
-	server.EnvoyXdsServer.MemRegistry.AddInstance(host.Name(hostName), &model.ServiceInstance{
+	s.Discovery.MemRegistry.AddInstance(host.Name(hostName), &model.ServiceInstance{
 		Endpoint: &model.IstioEndpoint{
 			Address:         address,
 			EndpointPort:    uint32(port),
@@ -780,10 +787,11 @@ func addEdsCluster(server *bootstrap.Server, hostName string, portName string, a
 			Protocol: protocol.HTTP,
 		},
 	})
+	fullPush(s)
 }
 
-func updateServiceResolution(server *bootstrap.Server) {
-	server.EnvoyXdsServer.MemRegistry.AddService("edsdns.svc.cluster.local", &model.Service{
+func updateServiceResolution(s *xds.FakeDiscoveryServer) {
+	s.Discovery.MemRegistry.AddService("edsdns.svc.cluster.local", &model.Service{
 		Hostname: "edsdns.svc.cluster.local",
 		Ports: model.PortList{
 			{
@@ -795,7 +803,7 @@ func updateServiceResolution(server *bootstrap.Server) {
 		Resolution: model.DNSLB,
 	})
 
-	server.EnvoyXdsServer.MemRegistry.AddInstance("edsdns.svc.cluster.local", &model.ServiceInstance{
+	s.Discovery.MemRegistry.AddInstance("edsdns.svc.cluster.local", &model.ServiceInstance{
 		Endpoint: &model.IstioEndpoint{
 			Address:         "somevip.com",
 			EndpointPort:    8080,
@@ -808,11 +816,11 @@ func updateServiceResolution(server *bootstrap.Server) {
 		},
 	})
 
-	fullPush(server)
+	fullPush(s)
 }
 
-func addOverlappingEndpoints(server *bootstrap.Server) {
-	server.EnvoyXdsServer.MemRegistry.AddService("overlapping.cluster.local", &model.Service{
+func addOverlappingEndpoints(s *xds.FakeDiscoveryServer) {
+	s.Discovery.MemRegistry.AddService("overlapping.cluster.local", &model.Service{
 		Hostname: "overlapping.cluster.local",
 		Ports: model.PortList{
 			{
@@ -827,7 +835,7 @@ func addOverlappingEndpoints(server *bootstrap.Server) {
 			},
 		},
 	})
-	server.EnvoyXdsServer.MemRegistry.AddInstance("overlapping.cluster.local", &model.ServiceInstance{
+	s.Discovery.MemRegistry.AddInstance("overlapping.cluster.local", &model.ServiceInstance{
 		Endpoint: &model.IstioEndpoint{
 			Address:         "10.0.0.53",
 			EndpointPort:    53,
@@ -839,6 +847,7 @@ func addOverlappingEndpoints(server *bootstrap.Server) {
 			Protocol: protocol.TCP,
 		},
 	})
+	fullPush(s)
 }
 
 // Verify the endpoint debug interface is installed and returns some string.
@@ -846,13 +855,16 @@ func addOverlappingEndpoints(server *bootstrap.Server) {
 // TODO: use this in integration tests.
 // TODO: refine the output
 // TODO: dump the ServiceInstances as well
-func testEdsz(t *testing.T, proxyID string) {
-	edszURL := fmt.Sprintf("http://localhost:%d/debug/edsz?proxyID=%s", testEnv.Ports().PilotHTTPPort, proxyID)
-	res, err := http.Get(edszURL)
+func testEdsz(t *testing.T, s *xds.FakeDiscoveryServer, proxyID string) {
+	req, err := http.NewRequest("GET", "/debug/edsz?proxyID="+proxyID, nil)
 	if err != nil {
-		t.Fatalf("Failed to fetch %s", edszURL)
+		t.Fatal(err)
 	}
-	data, err := ioutil.ReadAll(res.Body)
+	rr := httptest.NewRecorder()
+	debug := http.HandlerFunc(s.Discovery.Edsz)
+	debug.ServeHTTP(rr, req)
+
+	data, err := ioutil.ReadAll(rr.Body)
 	if err != nil {
 		t.Fatalf("Failed to read /edsz")
 	}

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -253,6 +253,8 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		t.Fatal(err)
 	}
 
+	s.updateMutex.RLock()
+	defer s.updateMutex.RUnlock()
 	fake := &FakeDiscoveryServer{
 		t:           t,
 		Store:       configController,

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -16,9 +16,12 @@ package xds
 
 import (
 	"bytes"
+	"context"
+	"net"
 	"reflect"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/Masterminds/sprig"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
@@ -30,7 +33,8 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
-
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/test/bufconn"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 
@@ -41,12 +45,17 @@ import (
 
 	"istio.io/istio/pilot/pkg/config/kube/crd"
 	"istio.io/istio/pilot/pkg/config/memory"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	kube "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
+	memregistry "istio.io/istio/pilot/pkg/serviceregistry/memory"
 	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
+	v3 "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pkg/adsc"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/test"
@@ -74,6 +83,7 @@ type FakeDiscoveryServer struct {
 	Discovery   *DiscoveryServer
 	PushContext *model.PushContext
 	Env         *model.Environment
+	listener    *bufconn.Listener
 }
 
 func getKubernetesObjects(t test.Failer, opts FakeOptions) []runtime.Object {
@@ -110,12 +120,9 @@ func getConfigs(t test.Failer, opts FakeOptions) []model.Config {
 		}
 		configStr = buf.String()
 	}
-	configs, badKinds, err := crd.ParseInputs(configStr)
+	configs, _, err := crd.ParseInputs(configStr)
 	if err != nil {
 		t.Fatalf("failed to read config: %v", err)
-	}
-	if len(badKinds) != 0 {
-		t.Fatalf("Got unknown resources: %v", badKinds)
 	}
 	// setup default namespace if not defined
 	for i, c := range configs {
@@ -132,23 +139,19 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	t.Cleanup(func() {
 		close(stop)
 	})
+
 	configs := getConfigs(t, opts)
 	k8sObjects := getKubernetesObjects(t, opts)
 	configStore := memory.MakeWithLedger(collections.Pilot, &model.DisabledLedger{}, true)
 	env := &model.Environment{}
 	plugins := []string{plugin.Authn, plugin.Authz, plugin.Health}
+
 	s := NewDiscoveryServer(env, plugins)
-	go func() {
-		for {
-			select {
-			// Read and drop events. This prevents the channel from getting backed up
-			// In the future, we can likely track these for use in tests
-			case <-s.pushChannel:
-			case <-stop:
-				return
-			}
-		}
-	}()
+	// Disable debounce to reduce test times
+	s.debounceOptions.debounceAfter = 0
+	s.MemRegistry = memregistry.NewServiceDiscovery(nil)
+	s.MemRegistry.EDSUpdater = s
+
 	configController := memory.NewSyncController(configStore)
 	go configController.Run(stop)
 
@@ -183,11 +186,70 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	if err := s.UpdateServiceShards(env.PushContext); err != nil {
 		t.Fatal(err)
 	}
-	se.ResyncEDS()
-	if err := k8s.ResyncEndpoints(); err != nil {
+	if err := env.PushContext.InitContext(env, nil, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := env.PushContext.InitContext(env, nil, nil); err != nil {
+
+	s.MemRegistry.ClusterID = string(serviceregistry.Mock)
+	serviceDiscovery.AddRegistry(serviceregistry.Simple{
+		ClusterID:        string(serviceregistry.Mock),
+		ProviderID:       serviceregistry.Mock,
+		ServiceDiscovery: s.MemRegistry,
+		Controller:       s.MemRegistry.Controller,
+	})
+
+	// Setup config handlers
+	// TODO code re-use from server.go
+	configHandler := func(_, curr model.Config, event model.Event) {
+		pushReq := &model.PushRequest{
+			Full: true,
+			ConfigsUpdated: map[model.ConfigKey]struct{}{{
+				Kind:      curr.GroupVersionKind,
+				Name:      curr.Name,
+				Namespace: curr.Namespace,
+			}: {}},
+			Reason: []model.TriggerReason{model.ConfigUpdate},
+		}
+		s.ConfigUpdate(pushReq)
+	}
+	schemas := collections.Pilot.All()
+	if features.EnableServiceApis {
+		schemas = collections.PilotServiceApi.All()
+	}
+	for _, schema := range schemas {
+		// This resource type was handled in external/servicediscovery.go, no need to rehandle here.
+		if schema.Resource().GroupVersionKind() == collections.IstioNetworkingV1Alpha3Serviceentries.
+			Resource().GroupVersionKind() {
+			continue
+		}
+		if schema.Resource().GroupVersionKind() == collections.IstioNetworkingV1Alpha3Workloadentries.
+			Resource().GroupVersionKind() {
+			continue
+		}
+
+		configController.RegisterEventHandler(schema.Resource().GroupVersionKind(), configHandler)
+	}
+
+	// Start in memory gRPC listener
+	buffer := 1024 * 1024
+	listener := bufconn.Listen(buffer)
+	grpcServer := grpc.NewServer()
+	s.Register(grpcServer)
+	go func() {
+		if err := grpcServer.Serve(listener); err != nil && err != grpc.ErrServerStopped {
+			t.Fatal(err)
+		}
+	}()
+	t.Cleanup(func() {
+		grpcServer.Stop()
+	})
+
+	// Start the discovery server
+	s.CachesSynced()
+	s.Start(stop)
+
+	se.ResyncEDS()
+	if err := k8s.ResyncEndpoints(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -197,8 +259,65 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		Discovery:   s,
 		PushContext: env.PushContext,
 		Env:         env,
+		listener:    listener,
 	}
 	return fake
+}
+
+// ConnectADS starts an ADS connection to the server. It will automatically be cleaned up when the test ends
+func (f *FakeDiscoveryServer) ConnectADS() discovery.AggregatedDiscoveryService_StreamAggregatedResourcesClient {
+	conn, err := grpc.Dial("buffcon", grpc.WithInsecure(), grpc.WithBlock(), grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+		return f.listener.Dial()
+	}))
+	if err != nil {
+		f.t.Fatalf("failed to connect: %v", err)
+	}
+	xds := discovery.NewAggregatedDiscoveryServiceClient(conn)
+	client, err := xds.StreamAggregatedResources(context.Background())
+	if err != nil {
+		f.t.Fatalf("stream resources failed: %s", err)
+	}
+	f.t.Cleanup(func() {
+		_ = client.CloseSend()
+		_ = conn.Close()
+	})
+	return client
+}
+
+// ConnectADS starts an ADS connection to the server using adsc. It will automatically be cleaned up when the test ends
+// watch can be configured to determine the resources to watch initially, and wait can be configured to determine what
+// resources we should initially wait for.
+func (f *FakeDiscoveryServer) Connect(p *model.Proxy, watch []string, wait []string) *adsc.ADSC {
+	f.t.Helper()
+	p = f.SetupProxy(p)
+	if watch == nil {
+		watch = []string{v3.ClusterType}
+	}
+	if wait == nil {
+		watch = []string{v3.ClusterType}
+	}
+	adscConn, err := adsc.Dial("buffcon", "", &adsc.Config{
+		IP:        p.IPAddresses[0],
+		Meta:      p.Metadata.ToStruct(),
+		Namespace: p.ConfigNamespace,
+		Watch:     watch,
+		GrpcOpts: []grpc.DialOption{grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return f.listener.Dial()
+		})},
+	})
+	if err != nil {
+		f.t.Fatalf("Error connecting: %v", err)
+	}
+	if len(wait) > 0 {
+		_, err = adscConn.Wait(10*time.Second, wait...)
+		if err != nil {
+			f.t.Fatalf("Error getting initial for %v config: %v", wait, err)
+		}
+	}
+	f.t.Cleanup(func() {
+		adscConn.Close()
+	})
+	return adscConn
 }
 
 // SetupProxy initializes a proxy for the current environment. This should generally be used when creating
@@ -225,6 +344,9 @@ func (f *FakeDiscoveryServer) SetupProxy(p *model.Proxy) *model.Proxy {
 		p.IPAddresses = []string{"1.1.1.1"}
 	}
 	// Initialize data structures
+
+	f.Discovery.updateMutex.RLock()
+	defer f.Discovery.updateMutex.RUnlock()
 	p.SetSidecarScope(f.Discovery.Env.PushContext)
 	p.SetGatewaysForProxy(f.Discovery.Env.PushContext)
 	if err := p.SetServiceInstances(f.Discovery.Env.ServiceDiscovery); err != nil {

--- a/pilot/pkg/xds/init_test.go
+++ b/pilot/pkg/xds/init_test.go
@@ -14,7 +14,6 @@
 package xds_test
 
 import (
-	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -27,16 +26,11 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 
-	"istio.io/istio/pkg/adsc"
-
 	"istio.io/istio/pilot/pkg/model"
 
 	"google.golang.org/genproto/googleapis/rpc/status"
-	"google.golang.org/grpc"
 
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
-
-	"istio.io/istio/tests/util"
 )
 
 type AdsClient discovery.AggregatedDiscoveryService_StreamAggregatedResourcesClient
@@ -64,47 +58,6 @@ func testIP(id uint32) string {
 	ipb := []byte{0, 0, 0, 0}
 	binary.BigEndian.PutUint32(ipb, id)
 	return net.IP(ipb).String()
-}
-
-// connectADSC creates a connection using ASDC client.
-// If certDir is specified, will use MTLS.
-// This has more functionality than 'raw' grpc connection, including
-// sending a more realistic mode metadata.
-func connectADSC(url string, cfg *adsc.Config) (*adsc.ADSC, util.TearDownFunc, error) {
-	if cfg == nil {
-		cfg = &adsc.Config{}
-	}
-
-	if cfg.IP == "" {
-		cfg.IP = "10.11.0.1"
-	}
-
-	// Fill in defaults
-	if cfg.Namespace == "" {
-		cfg.Namespace = "none"
-	}
-
-	adsc, err := adsc.Dial(url, cfg.CertDir, cfg)
-	return adsc, func() {
-		adsc.Close()
-	}, err
-}
-
-func connectADS(url string) (AdsClient, util.TearDownFunc, error) {
-	conn, err := grpc.Dial(url, grpc.WithInsecure(), grpc.WithBlock())
-	if err != nil {
-		return nil, nil, fmt.Errorf("GRPC dial failed: %s", err)
-	}
-	xds := discovery.NewAggregatedDiscoveryServiceClient(conn)
-	client, err := xds.StreamAggregatedResources(context.Background())
-	if err != nil {
-		return nil, nil, fmt.Errorf("stream resources failed: %s", err)
-	}
-
-	return client, func() {
-		_ = client.CloseSend()
-		_ = conn.Close()
-	}, nil
 }
 
 func adsReceive(ads AdsClient, to time.Duration) (*discovery.DiscoveryResponse, error) {

--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -115,6 +115,8 @@ type Config struct {
 
 	// TODO: remove the duplication - all security settings belong here.
 	SecOpts *security.Options
+
+	GrpcOpts []grpc.DialOption
 }
 
 // ADSC implements a basic client for ADS, for use in stress tests and tools
@@ -130,6 +132,8 @@ type ADSC struct {
 	nodeID string
 
 	url string
+
+	grpcOpts []grpc.DialOption
 
 	watchTime time.Time
 
@@ -235,6 +239,7 @@ func Dial(url string, certDir string, opts *Config) (*ADSC, error) {
 		cfg:         opts,
 		syncCh:      make(chan string, len(collections.Pilot.All())),
 		sync:        map[string]time.Time{},
+		grpcOpts:    opts.GrpcOpts,
 	}
 	if certDir != "" {
 		opts.CertDir = certDir
@@ -369,28 +374,22 @@ func (a *ADSC) Close() {
 // Run will run one connection to the ADS client.
 func (a *ADSC) Run() error {
 	var err error
+
+	opts := a.grpcOpts
 	if len(a.cfg.CertDir) > 0 || a.cfg.Secrets != nil {
 		tlsCfg, err := a.tlsConfig()
 		if err != nil {
 			return err
 		}
 		creds := credentials.NewTLS(tlsCfg)
-
-		opts := []grpc.DialOption{
-			// Verify Pilot cert and service account
-			grpc.WithTransportCredentials(creds),
-		}
-		a.conn, err = grpc.Dial(a.url, opts...)
-		if err != nil {
-			return err
-		}
+		opts = append(opts, grpc.WithTransportCredentials(creds))
 	} else {
-		a.conn, err = grpc.Dial(a.url, grpc.WithInsecure())
-		if err != nil {
-			return err
-		}
+		opts = append(opts, grpc.WithInsecure())
 	}
-
+	a.conn, err = grpc.Dial(a.url, opts...)
+	if err != nil {
+		return err
+	}
 	xds := discovery.NewAggregatedDiscoveryServiceClient(a.conn)
 	edsstr, err := xds.StreamAggregatedResources(context.Background())
 	if err != nil {
@@ -417,7 +416,7 @@ func (a *ADSC) hasSynced() bool {
 		t := a.sync[s.Resource().GroupVersionKind().String()]
 		a.mutex.RUnlock()
 		if t.IsZero() {
-			log.Warn("NOT SYNCE" + s.Resource().GroupVersionKind().String())
+			log.Warnf("Not synced: %v", s.Resource().GroupVersionKind().String())
 			return false
 		}
 	}
@@ -526,6 +525,7 @@ func (a *ADSC) handleRecv() {
 		if len(gvk) == 3 {
 			gt := resource.GroupVersionKind{Group: gvk[0], Version: gvk[1], Kind: gvk[2]}
 			a.sync[gt.String()] = time.Now()
+			a.syncCh <- gt.String()
 		}
 		a.Received[msg.TypeUrl] = msg
 		a.ack(msg)
@@ -893,6 +893,14 @@ func (a *ADSC) Wait(to time.Duration, updates ...string) ([]string, error) {
 				delete(want, "eds")
 			case v3.RouteType:
 				delete(want, "rds")
+			case "lds":
+				delete(want, v3.ListenerType)
+			case "cds":
+				delete(want, v3.ClusterType)
+			case "eds":
+				delete(want, v3.EndpointType)
+			case "rds":
+				delete(want, v3.RouteType)
 			}
 			delete(want, toDelete)
 			got = append(got, t)


### PR DESCRIPTION
Currently, pilot tests generally spin up a full bootstrap.Server, which has a lot of overhead. This changes to use the minimal fake server, using an in memory buffcon listener

Additionally, there are various fixes for tests - comments inline

Before: 80s
After: 35s (still way too long)

