### PR TITLE
Add a cache for EDS responses

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -322,4 +322,7 @@ var (
 			"No need to configure this for root certificates issued via Istiod or web-PKI based root certificates. "+
 			"Use || between <trustdomain, endpoint> tuples. Use | as delimiter between trust domain and endpoint in "+
 			"each tuple. For example: foo|https://url/for/foo||bar|https://url/for/bar").Get()
+
+	EnableEDSCaching = env.RegisterBoolVar("PILOT_ENABLE_EDS_CACHE", true,
+		"If true, Pilot will cache EDS responses.").Get()
 )

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -713,6 +713,14 @@ func AdsPushAll(s *DiscoveryServer) {
 // Primary code path is from v1 discoveryService.clearCache(), which is added as a handler
 // to the model ConfigStorageCache and Controller.
 func (s *DiscoveryServer) AdsPushAll(version string, req *model.PushRequest) {
+	// If we don't know what updated, cannot safely cache. Clear the whole cache
+	if len(req.ConfigsUpdated) == 0 {
+		s.cache.ClearAll()
+	} else {
+		// Otherwise, just clear the updated configs
+		s.cache.ClearHostnames(model.ConfigsOfKind(req.ConfigsUpdated, gvk.ServiceEntry))
+		s.cache.ClearDestinationRules(model.ConfigsOfKind(req.ConfigsUpdated, gvk.DestinationRule))
+	}
 	if !req.Full {
 		adsLog.Infof("XDS:EDSInc Pushing:%s Services:%v ConnectedEndpoints:%d",
 			version, model.ConfigNamesOfKind(req.ConfigsUpdated, gvk.ServiceEntry), s.adsClientCount())

--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -19,14 +19,17 @@ import (
 	"testing"
 	"time"
 
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"github.com/golang/protobuf/proto"
 
 	mesh "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/util/sets"
 	"istio.io/istio/pilot/pkg/xds"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/pkg/adsc"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
@@ -965,4 +968,95 @@ func unmarshallRoute(value []byte) (*route.RouteConfiguration, error) {
 		return nil, err
 	}
 	return route, nil
+}
+
+func TestXdsCache(t *testing.T) {
+	makeEndpoint := func(addr []*networking.WorkloadEntry) model.Config {
+		return model.Config{
+			ConfigMeta: model.ConfigMeta{
+				Name:             "service",
+				Namespace:        "default",
+				GroupVersionKind: gvk.ServiceEntry,
+			},
+			Spec: &networking.ServiceEntry{
+				Hosts: []string{"foo.com"},
+				Ports: []*networking.Port{{
+					Number:   80,
+					Protocol: "HTTP",
+					Name:     "http",
+				}},
+				Resolution: networking.ServiceEntry_STATIC,
+				Endpoints:  addr,
+			},
+		}
+	}
+	assertEndpoints := func(a *adsc.ADSC, addr ...string) {
+		t.Helper()
+		got := sets.NewSet(xdstest.ExtractEndpoints(a.GetEndpoints()["outbound|80||foo.com"])...)
+		want := sets.NewSet(addr...)
+
+		if !got.Equals(want) {
+			t.Fatalf("invalid endpoints, got %v want %v", got, addr)
+		}
+	}
+
+	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
+		Configs: []model.Config{makeEndpoint([]*networking.WorkloadEntry{{Address: "1.2.3.4", Locality: "region/zone"}, {Address: "1.2.3.5", Locality: "notmatch"}})},
+	})
+	ads := s.Connect(&model.Proxy{Locality: &core.Locality{Region: "region"}}, nil, watchAll)
+
+	assertEndpoints(ads, "1.2.3.4", "1.2.3.5")
+	t.Logf("endpoints: %+v", ads.GetEndpoints())
+
+	if _, err := s.Store.Update(makeEndpoint([]*networking.WorkloadEntry{{Address: "1.2.3.6", Locality: "region/zone"}, {Address: "1.2.3.5", Locality: "notmatch"}})); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ads.Wait(time.Second*5, v3.EndpointType); err != nil {
+		t.Fatal(err)
+	}
+	assertEndpoints(ads, "1.2.3.6", "1.2.3.5")
+	t.Logf("endpoints: %+v", ads.GetEndpoints())
+
+	ads.WaitClear()
+	if _, err := s.Store.Create(model.Config{
+		ConfigMeta: model.ConfigMeta{
+			Name:             "service",
+			Namespace:        "default",
+			GroupVersionKind: gvk.DestinationRule,
+		},
+		Spec: &networking.DestinationRule{
+			Host: "foo.com",
+			TrafficPolicy: &networking.TrafficPolicy{
+				OutlierDetection: &networking.OutlierDetection{},
+			},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ads.Wait(time.Second*5, v3.EndpointType); err != nil {
+		t.Fatal(err)
+	}
+	assertEndpoints(ads, "1.2.3.6", "1.2.3.5")
+	found := false
+	for _, ep := range ads.GetEndpoints()["outbound|80||foo.com"].Endpoints {
+		if ep.Priority == 1 {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("locality did not update")
+	}
+	t.Logf("endpoints: %+v", ads.GetEndpoints())
+	ads.WaitClear()
+
+	ep := makeEndpoint([]*networking.WorkloadEntry{{Address: "1.2.3.6", Locality: "region/zone"}, {Address: "1.2.3.5", Locality: "notmatch"}})
+	ep.Spec.(*networking.ServiceEntry).Resolution = networking.ServiceEntry_DNS
+	if _, err := s.Store.Update(ep); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ads.Wait(time.Second*5, v3.EndpointType); err != nil {
+		t.Fatal(err)
+	}
+	assertEndpoints(ads)
+	t.Logf("endpoints: %+v", ads.GetEndpoints())
 }

--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -1008,7 +1008,10 @@ func TestXdsCache(t *testing.T) {
 	assertEndpoints(ads, "1.2.3.4", "1.2.3.5")
 	t.Logf("endpoints: %+v", ads.GetEndpoints())
 
-	if _, err := s.Store.Update(makeEndpoint([]*networking.WorkloadEntry{{Address: "1.2.3.6", Locality: "region/zone"}, {Address: "1.2.3.5", Locality: "notmatch"}})); err != nil {
+	if _, err := s.Store.Update(makeEndpoint([]*networking.WorkloadEntry{
+		{Address: "1.2.3.6", Locality: "region/zone"},
+		{Address: "1.2.3.5", Locality: "notmatch"},
+	})); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := ads.Wait(time.Second*5, v3.EndpointType); err != nil {

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -23,14 +23,15 @@ import (
 	"time"
 
 	"github.com/Masterminds/sprig"
-	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes/any"
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/config/kube/crd"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/pkg/env"
@@ -199,10 +200,10 @@ func BenchmarkEndpointGeneration(b *testing.B) {
 			proxy.SetSidecarScope(push)
 			b.ResetTimer()
 			for n := 0; n < b.N; n++ {
-				loadAssignments := make([]*endpoint.ClusterLoadAssignment, 0)
+				loadAssignments := make([]*any.Any, 0)
 				for svc := 0; svc < tt.services; svc++ {
 					l := s.Discovery.generateEndpoints(NewEndpointBuilder(fmt.Sprintf("outbound|80||foo-%d.com", svc), proxy, push))
-					loadAssignments = append(loadAssignments, l)
+					loadAssignments = append(loadAssignments, util.MessageToAny(l))
 				}
 				response = endpointDiscoveryResponse(loadAssignments, version, push.Version)
 			}

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -122,6 +122,9 @@ type DiscoveryServer struct {
 	serverReady bool
 
 	debounceOptions debounceOptions
+
+	// Cache for XDS resources
+	cache Cache
 }
 
 // EndpointShards holds the set of endpoint shards of a service. Registries update
@@ -162,6 +165,7 @@ func NewDiscoveryServer(env *model.Environment, plugins []string) *DiscoveryServ
 			debounceMax:       features.DebounceMax,
 			enableEDSDebounce: features.EnableEDSDebounce.Get(),
 		},
+		cache: DisabledCache{},
 	}
 
 	// Flush cached discovery responses when detecting jwt public key change.
@@ -170,6 +174,10 @@ func NewDiscoveryServer(env *model.Environment, plugins []string) *DiscoveryServ
 	}
 
 	out.initGenerators()
+
+	if features.EnableEDSCaching {
+		out.cache = NewInMemoryCache()
+	}
 
 	return out
 }

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -306,6 +306,7 @@ func (f *FakeDiscoveryServer) Connect(p *model.Proxy, watch []string, wait []str
 	adscConn, err := adsc.Dial("buffcon", "", &adsc.Config{
 		IP:        p.IPAddresses[0],
 		Meta:      p.Metadata.ToStruct(),
+		Locality:  p.Locality,
 		Namespace: p.ConfigNamespace,
 		Watch:     watch,
 		GrpcOpts: []grpc.DialOption{grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {

--- a/pilot/pkg/xds/xds_cache.go
+++ b/pilot/pkg/xds/xds_cache.go
@@ -1,0 +1,150 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xds
+
+import (
+	"sync"
+
+	"github.com/golang/protobuf/ptypes/any"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/util/sets"
+	"istio.io/istio/pkg/config/host"
+)
+
+// Cache interface defines a store for caching XDS responses
+// Note this is currently only for EDS, and will need some modifications to support other types
+// All operations are thread safe
+type Cache interface {
+	Insert(key EndpointBuilder, value *any.Any)
+	Get(key EndpointBuilder) (*any.Any, bool)
+	ClearDestinationRules(map[model.ConfigKey]struct{})
+	ClearHostnames(map[model.ConfigKey]struct{})
+	ClearAll()
+	// Keys returns all currently configured keys. This is for testing/debug only
+	Keys() []string
+}
+
+type inMemoryCache struct {
+	store                map[string]*any.Any
+	hostIndex            map[host.Name]sets.Set
+	destinationRuleIndex map[string]sets.Set
+	mu                   sync.RWMutex
+}
+
+var _ Cache = &inMemoryCache{}
+
+func NewInMemoryCache() Cache {
+	return &inMemoryCache{
+		store:                map[string]*any.Any{},
+		hostIndex:            map[host.Name]sets.Set{},
+		destinationRuleIndex: map[string]sets.Set{},
+	}
+}
+
+func (c *inMemoryCache) Insert(key EndpointBuilder, value *any.Any) {
+	// If service is not defined, we cannot do any caching as we will not have a way to invalidate the results
+	// Service being nil means the EDS will be empty anyways, so not much lost here
+	if key.service == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	k := key.Key()
+	c.store[k] = value
+	if c.hostIndex[key.service.Hostname] == nil {
+		c.hostIndex[key.service.Hostname] = sets.NewSet()
+	}
+	c.hostIndex[key.service.Hostname].Insert(k)
+	if dr := key.destinationRule; dr != nil {
+		dkey := dr.Name + "/" + dr.Namespace
+		if c.destinationRuleIndex[dkey] == nil {
+			c.destinationRuleIndex[dkey] = sets.NewSet()
+		}
+		c.destinationRuleIndex[dkey].Insert(k)
+	}
+}
+
+func (c *inMemoryCache) Get(key EndpointBuilder) (*any.Any, bool) {
+	if key.service == nil {
+		return nil, false
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	k, f := c.store[key.Key()]
+	return k, f
+}
+
+func (c *inMemoryCache) ClearHostnames(hostsUpdated map[model.ConfigKey]struct{}) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for h := range hostsUpdated {
+		referenced := c.hostIndex[host.Name(h.Name)]
+		delete(c.hostIndex, host.Name(h.Name))
+		for keys := range referenced {
+			delete(c.store, keys)
+		}
+	}
+}
+
+func (c *inMemoryCache) ClearDestinationRules(destinationRulesUpdate map[model.ConfigKey]struct{}) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for d := range destinationRulesUpdate {
+		key := d.Name + "/" + d.Namespace
+		referenced := c.destinationRuleIndex[key]
+		delete(c.destinationRuleIndex, key)
+		for keys := range referenced {
+			delete(c.store, keys)
+		}
+	}
+}
+
+func (c *inMemoryCache) ClearAll() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.store = map[string]*any.Any{}
+	c.hostIndex = map[host.Name]sets.Set{}
+	c.destinationRuleIndex = map[string]sets.Set{}
+}
+
+func (c *inMemoryCache) Keys() []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	keys := []string{}
+	for k := range c.store {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// DisabledCache is a cache that is always empty
+type DisabledCache struct{}
+
+var _ Cache = &DisabledCache{}
+
+func (d DisabledCache) Insert(EndpointBuilder, *any.Any) {}
+
+func (d DisabledCache) Get(EndpointBuilder) (*any.Any, bool) {
+	return nil, false
+}
+
+func (d DisabledCache) ClearDestinationRules(map[model.ConfigKey]struct{}) {}
+
+func (d DisabledCache) ClearHostnames(map[model.ConfigKey]struct{}) {}
+
+func (d DisabledCache) ClearAll() {}
+
+func (c DisabledCache) Keys() []string { return nil }

--- a/pilot/pkg/xds/xds_cache.go
+++ b/pilot/pkg/xds/xds_cache.go
@@ -147,4 +147,4 @@ func (d DisabledCache) ClearHostnames(map[model.ConfigKey]struct{}) {}
 
 func (d DisabledCache) ClearAll() {}
 
-func (c DisabledCache) Keys() []string { return nil }
+func (d DisabledCache) Keys() []string { return nil }

--- a/pilot/pkg/xds/xds_cache_test.go
+++ b/pilot/pkg/xds/xds_cache_test.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package xds
 
 import (

--- a/pilot/pkg/xds/xds_cache_test.go
+++ b/pilot/pkg/xds/xds_cache_test.go
@@ -50,7 +50,7 @@ func TestInMemoryCache(t *testing.T) {
 		if got, _ := c.Get(ep1); got != any2 {
 			t.Fatalf("unexpected result: %v, want %v", got, any2)
 		}
-		c.ClearHostnames(map[model.ConfigKey]struct{}{model.ConfigKey{Name: "foo.com"}: {}})
+		c.ClearHostnames(map[model.ConfigKey]struct{}{{Name: "foo.com"}: {}})
 		if _, f := c.Get(ep1); f {
 			t.Fatalf("unexpected result, found key when not expected: %v", c.Keys())
 		}
@@ -67,7 +67,7 @@ func TestInMemoryCache(t *testing.T) {
 		if got, _ := c.Get(ep2); got != any2 {
 			t.Fatalf("unexpected result: %v, want %v", got, any2)
 		}
-		c.ClearHostnames(map[model.ConfigKey]struct{}{model.ConfigKey{Name: "foo.com"}: {}})
+		c.ClearHostnames(map[model.ConfigKey]struct{}{{Name: "foo.com"}: {}})
 		if _, f := c.Get(ep1); f {
 			t.Fatalf("unexpected result, found key when not expected: %v", c.Keys())
 		}
@@ -91,14 +91,14 @@ func TestInMemoryCache(t *testing.T) {
 		if got, _ := c.Get(ep2); got != any2 {
 			t.Fatalf("unexpected result: %v, want %v", got, any2)
 		}
-		c.ClearDestinationRules(map[model.ConfigKey]struct{}{model.ConfigKey{Name: "a", Namespace: "b"}: {}})
+		c.ClearDestinationRules(map[model.ConfigKey]struct{}{{Name: "a", Namespace: "b"}: {}})
 		if _, f := c.Get(ep1); f {
 			t.Fatalf("unexpected result, found key when not expected: %v", c.Keys())
 		}
 		if got, _ := c.Get(ep2); got != any2 {
 			t.Fatalf("unexpected result: %v, want %v", got, any2)
 		}
-		c.ClearDestinationRules(map[model.ConfigKey]struct{}{model.ConfigKey{Name: "b", Namespace: "b"}: {}})
+		c.ClearDestinationRules(map[model.ConfigKey]struct{}{{Name: "b", Namespace: "b"}: {}})
 		if _, f := c.Get(ep1); f {
 			t.Fatalf("unexpected result, found key when not expected: %v", c.Keys())
 		}

--- a/pilot/pkg/xds/xds_cache_test.go
+++ b/pilot/pkg/xds/xds_cache_test.go
@@ -1,0 +1,112 @@
+package xds
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/golang/protobuf/ptypes/any"
+
+	"istio.io/istio/pilot/pkg/model"
+)
+
+var (
+	any1 = &any.Any{TypeUrl: "foo"}
+	any2 = &any.Any{TypeUrl: "bar"}
+)
+
+func TestInMemoryCache(t *testing.T) {
+	ep1 := EndpointBuilder{
+		clusterName: "outbound|1||foo.com",
+		service:     &model.Service{Hostname: "foo.com"},
+	}
+	ep2 := EndpointBuilder{
+		clusterName: "outbound|2||foo.com",
+		service:     &model.Service{Hostname: "foo.com"},
+	}
+	t.Run("simple", func(t *testing.T) {
+		c := NewInMemoryCache()
+		c.Insert(ep1, any1)
+		if !reflect.DeepEqual(c.Keys(), []string{ep1.Key()}) {
+			t.Fatalf("unexpected keys: %v, want %v", c.Keys(), ep1.Key())
+		}
+		if got, _ := c.Get(ep1); got != any1 {
+			t.Fatalf("unexpected result: %v, want %v", got, any1)
+		}
+		c.Insert(ep1, any2)
+		if got, _ := c.Get(ep1); got != any2 {
+			t.Fatalf("unexpected result: %v, want %v", got, any2)
+		}
+		c.ClearHostnames(map[model.ConfigKey]struct{}{model.ConfigKey{Name: "foo.com"}: {}})
+		if _, f := c.Get(ep1); f {
+			t.Fatalf("unexpected result, found key when not expected: %v", c.Keys())
+		}
+	})
+
+	t.Run("multiple hostnames", func(t *testing.T) {
+		c := NewInMemoryCache()
+		c.Insert(ep1, any1)
+		c.Insert(ep2, any2)
+
+		if got, _ := c.Get(ep1); got != any1 {
+			t.Fatalf("unexpected result: %v, want %v", got, any1)
+		}
+		if got, _ := c.Get(ep2); got != any2 {
+			t.Fatalf("unexpected result: %v, want %v", got, any2)
+		}
+		c.ClearHostnames(map[model.ConfigKey]struct{}{model.ConfigKey{Name: "foo.com"}: {}})
+		if _, f := c.Get(ep1); f {
+			t.Fatalf("unexpected result, found key when not expected: %v", c.Keys())
+		}
+		if _, f := c.Get(ep2); f {
+			t.Fatalf("unexpected result, found key when not expected: %v", c.Keys())
+		}
+	})
+
+	t.Run("multiple destinationRules", func(t *testing.T) {
+		c := NewInMemoryCache()
+		ep1 := ep1
+		ep1.destinationRule = &model.Config{ConfigMeta: model.ConfigMeta{Name: "a", Namespace: "b"}}
+		ep2 := ep2
+		ep2.destinationRule = &model.Config{ConfigMeta: model.ConfigMeta{Name: "b", Namespace: "b"}}
+		c.Insert(ep1, any1)
+		c.Insert(ep2, any2)
+
+		if got, _ := c.Get(ep1); got != any1 {
+			t.Fatalf("unexpected result: %v, want %v", got, any1)
+		}
+		if got, _ := c.Get(ep2); got != any2 {
+			t.Fatalf("unexpected result: %v, want %v", got, any2)
+		}
+		c.ClearDestinationRules(map[model.ConfigKey]struct{}{model.ConfigKey{Name: "a", Namespace: "b"}: {}})
+		if _, f := c.Get(ep1); f {
+			t.Fatalf("unexpected result, found key when not expected: %v", c.Keys())
+		}
+		if got, _ := c.Get(ep2); got != any2 {
+			t.Fatalf("unexpected result: %v, want %v", got, any2)
+		}
+		c.ClearDestinationRules(map[model.ConfigKey]struct{}{model.ConfigKey{Name: "b", Namespace: "b"}: {}})
+		if _, f := c.Get(ep1); f {
+			t.Fatalf("unexpected result, found key when not expected: %v", c.Keys())
+		}
+		if _, f := c.Get(ep2); f {
+			t.Fatalf("unexpected result, found key when not expected: %v", c.Keys())
+		}
+	})
+
+	t.Run("clear all", func(t *testing.T) {
+		c := NewInMemoryCache()
+		c.Insert(ep1, any1)
+		c.Insert(ep2, any2)
+
+		c.ClearAll()
+		if len(c.Keys()) != 0 {
+			t.Fatalf("expected no keys, got: %v", c.Keys())
+		}
+		if _, f := c.Get(ep1); f {
+			t.Fatalf("unexpected result, found key when not expected: %v", c.Keys())
+		}
+		if _, f := c.Get(ep2); f {
+			t.Fatalf("unexpected result, found key when not expected: %v", c.Keys())
+		}
+	})
+}

--- a/pilot/pkg/xds/xds_test.go
+++ b/pilot/pkg/xds/xds_test.go
@@ -193,7 +193,7 @@ func TestServiceScoping(t *testing.T) {
 		})
 		proxy := s.SetupProxy(baseProxy())
 
-		endpoints := xdstest.ExtractEndpoints(s.Endpoints(proxy))
+		endpoints := xdstest.ExtractLoadAssignments(s.Endpoints(proxy))
 		if !listEqualUnordered(endpoints["outbound|80||app.com"], []string{"1.1.1.1"}) {
 			t.Fatalf("expected 1.1.1.1, got %v", endpoints["outbound|80||app.com"])
 		}
@@ -472,7 +472,7 @@ spec:
 					}
 
 					for _, tt := range tests {
-						eps := xdstest.ExtractEndpoints(s.Endpoints(tt.p))
+						eps := xdstest.ExtractLoadAssignments(s.Endpoints(tt.p))
 						for c, ip := range tt.expect {
 							t.Run(fmt.Sprintf("%s from %s", c, tt.p.ID), func(t *testing.T) {
 								assertListEqual(t, eps[c], []string{ip})

--- a/pilot/test/xdstest/extract.go
+++ b/pilot/test/xdstest/extract.go
@@ -86,19 +86,28 @@ func ExtractTCPProxy(t test.Failer, fcs *listener.FilterChain) *tcpproxy.TcpProx
 	return nil
 }
 
-func ExtractEndpoints(endpoints []*endpoint.ClusterLoadAssignment) map[string][]string {
+func ExtractLoadAssignments(clas []*endpoint.ClusterLoadAssignment) map[string][]string {
 	got := map[string][]string{}
-	for _, cla := range endpoints {
+	for _, cla := range clas {
 		if cla == nil {
 			continue
 		}
-		for _, ep := range cla.Endpoints {
-			for _, lb := range ep.LbEndpoints {
-				if lb.GetEndpoint().Address.GetSocketAddress() != nil {
-					got[cla.ClusterName] = append(got[cla.ClusterName], lb.GetEndpoint().Address.GetSocketAddress().Address)
-				} else {
-					got[cla.ClusterName] = append(got[cla.ClusterName], lb.GetEndpoint().Address.GetPipe().Path)
-				}
+		got[cla.ClusterName] = append(got[cla.ClusterName], ExtractEndpoints(cla)...)
+	}
+	return got
+}
+
+func ExtractEndpoints(cla *endpoint.ClusterLoadAssignment) []string {
+	if cla == nil {
+		return nil
+	}
+	got := []string{}
+	for _, ep := range cla.Endpoints {
+		for _, lb := range ep.LbEndpoints {
+			if lb.GetEndpoint().Address.GetSocketAddress() != nil {
+				got = append(got, lb.GetEndpoint().Address.GetSocketAddress().Address)
+			} else {
+				got = append(got, lb.GetEndpoint().Address.GetPipe().Path)
 			}
 		}
 	}
@@ -119,7 +128,7 @@ func ExtractClusterEndpoints(clusters []*cluster.Cluster) map[string][]string {
 	for _, c := range clusters {
 		cla = append(cla, c.LoadAssignment)
 	}
-	return ExtractEndpoints(cla)
+	return ExtractLoadAssignments(cla)
 }
 
 func ExtractEdsClusterNames(cl []*cluster.Cluster) []string {

--- a/pilot/test/xdstest/extract.go
+++ b/pilot/test/xdstest/extract.go
@@ -86,9 +86,9 @@ func ExtractTCPProxy(t test.Failer, fcs *listener.FilterChain) *tcpproxy.TcpProx
 	return nil
 }
 
-func ExtractLoadAssignments(clas []*endpoint.ClusterLoadAssignment) map[string][]string {
+func ExtractLoadAssignments(cla []*endpoint.ClusterLoadAssignment) map[string][]string {
 	got := map[string][]string{}
-	for _, cla := range clas {
+	for _, cla := range cla {
 		if cla == nil {
 			continue
 		}

--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -67,6 +67,8 @@ type Config struct {
 	// Meta includes additional metadata for the node
 	Meta *pstruct.Struct
 
+	Locality *core.Locality
+
 	// NodeType defaults to sidecar. "ingress" and "router" are also supported.
 	NodeType string
 
@@ -192,8 +194,9 @@ type ADSC struct {
 	// sendNodeMeta is set to true if the connection is new - and we need to send node meta.,
 	sendNodeMeta bool
 
-	sync   map[string]time.Time
-	syncCh chan string
+	sync     map[string]time.Time
+	syncCh   chan string
+	Locality *core.Locality
 }
 
 type ResponseHandler interface {
@@ -255,6 +258,7 @@ func Dial(url string, certDir string, opts *Config) (*ADSC, error) {
 		opts.Workload = "test-1"
 	}
 	adsc.Metadata = opts.Meta
+	adsc.Locality = opts.Locality
 
 	adsc.nodeID = fmt.Sprintf("%s~%s~%s.%s~%s.svc.cluster.local", opts.NodeType, opts.IP,
 		opts.Workload, opts.Namespace, opts.Namespace)
@@ -524,16 +528,14 @@ func (a *ADSC) handleRecv() {
 		// This scheme also allows us to chunk large responses !
 
 		// TODO: add hook to inject nacks
-		if len(listeners) > 0 {
-			a.handleLDS(listeners)
-		}
-		if len(clusters) > 0 {
+		switch msg.TypeUrl {
+		case v3.ClusterType:
 			a.handleCDS(clusters)
-		}
-		if len(eds) > 0 {
+		case v3.EndpointType:
 			a.handleEDS(eds)
-		}
-		if len(routes) > 0 {
+		case v3.ListenerType:
+			a.handleLDS(listeners)
+		case v3.RouteType:
 			a.handleRDS(routes)
 		}
 
@@ -757,7 +759,8 @@ func (a *ADSC) handleCDS(ll []*cluster.Cluster) {
 
 func (a *ADSC) node() *core.Node {
 	n := &core.Node{
-		Id: a.nodeID,
+		Id:       a.nodeID,
+		Locality: a.Locality,
 	}
 	if a.Metadata == nil {
 		n.Metadata = &pstruct.Struct{

--- a/releasenotes/notes/eds-cache.yaml
+++ b/releasenotes/notes/eds-cache.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+releaseNotes: |
+  *Added* experimental caching for endpoints, to support large scale clusters. This feature is disabled by default and can
+  be enabled by setting the `PILOT_ENABLE_EDS_CACHE` environment variable in Istiod.


### PR DESCRIPTION
This is on by default for tests only, will probably be disabled prior to merge

The idea here is to cache EDS responses. Cache invalidation is on a per hostname basis.

Likely bugs that need to be considered before turning this on:
* Probably leaks memory
* Probably some edge cases where we do not invalidate properly

Note: the reason this PR is so small is I had a PR a couple weeks ago preparing for this: #25598

Performance impact on a cluster with 2.5k pods with a split of 1, 5, and 25 replica services:

CPU: 5 vCPU -> 1.5 vCPU
![2020-14-08_10-17-53](https://user-images.githubusercontent.com/623453/90275637-76627700-de17-11ea-9779-3182e02ab018.png)
Heap: no change
![2020-14-08_10-17-59](https://user-images.githubusercontent.com/623453/90275636-76627700-de17-11ea-8a06-6f3151b99aa9.png)
Stack, interestingly, goes from 70mb -> 120mb. Not sure why, the pprof will not show stack usage
![2020-14-08_10-18-04](https://user-images.githubusercontent.com/623453/90275635-75c9e080-de17-11ea-80f1-84e7908b27ea.png)