### PR TITLE
Move meshExpansion to ControlPlaneValues in tests

### DIFF
--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -479,10 +479,7 @@ func deployControlPlane(c *operatorComponent, cfg Config, cluster resource.Clust
 				"--set", "values.global.network="+networkName)
 		}
 
-		if c.environment.IsControlPlaneCluster(cluster) {
-			// Expose Istiod through ingress to allow remote clusters to connect
-			installSettings = append(installSettings, "--set", "values.global.meshExpansion.enabled=true")
-		} else {
+		if !c.environment.IsControlPlaneCluster(cluster) {
 			installSettings = append(installSettings, "--set", "profile=remote")
 			remoteIstiodAddress, err := c.RemoteDiscoveryAddressFor(cluster)
 			if err != nil {

--- a/tests/integration/multicluster/base/main_test.go
+++ b/tests/integration/multicluster/base/main_test.go
@@ -39,7 +39,10 @@ func TestMain(m *testing.M) {
 		Setup(multicluster.Setup(&controlPlaneValues, &clusterLocalNS, &mcReachabilityNS)).
 		Setup(istio.Setup(&ist, func(cfg *istio.Config) {
 			// Set the control plane values on the config.
-			cfg.ControlPlaneValues = controlPlaneValues
+			cfg.ControlPlaneValues = controlPlaneValues + `
+  global:
+    meshExpansion:
+      enabled: true`
 		})).
 		Run()
 }

--- a/tests/integration/multicluster/centralistio/main_test.go
+++ b/tests/integration/multicluster/centralistio/main_test.go
@@ -63,6 +63,8 @@ func TestMain(m *testing.M) {
         targetPort: 15012
         name: tcp-istiod
   global:
+    meshExpansion:
+      enabled: true
     centralIstiod: true
     caAddress: istiod.istio-system.svc:15012`
 			cfg.RemoteClusterValues = `


### PR DESCRIPTION
Part of #25933. The intent is to next add another multicluster test that doesn't use meshExpansion

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

[X] Does not have any changes that may affect Istio users.