### PR TITLE
move v2 registration out of main path

### DIFF
--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -68,7 +68,7 @@ func init() {
 	enableEDSDebounce = features.EnableEDSDebounce.Get()
 }
 
-// DiscoveryServer is Pilot's gRPC implementation for Envoy's v2 xds APIs
+// DiscoveryServer is Pilot's gRPC implementation for Envoy's xds APIs
 type DiscoveryServer struct {
 	// Env is the model environment.
 	Env *model.Environment
@@ -190,6 +190,9 @@ func NewDiscoveryServer(env *model.Environment, plugins []string) *DiscoveryServ
 func (s *DiscoveryServer) Register(rpcs *grpc.Server) {
 	// Register v3 server
 	discovery.RegisterAggregatedDiscoveryServiceServer(rpcs, s)
+}
+
+func (s *DiscoveryServer) RegisterLegacyv2(rpcs *grpc.Server) {
 	// Register v2 server just for compatibility with gRPC. When gRPC v3 comes out, we can drop this
 	discoveryv2.RegisterAggregatedDiscoveryServiceServer(rpcs, s.createV2Adapter())
 }

--- a/pilot/pkg/xds/simple.go
+++ b/pilot/pkg/xds/simple.go
@@ -151,6 +151,7 @@ func (s *SimpleServer) StartGRPC(addr string) error {
 	}
 	gs := grpc.NewServer()
 	s.DiscoveryServer.Register(gs)
+	s.DiscoveryServer.RegisterLegacyv2(gs)
 	reflection.Register(gs)
 	s.GRPCListener = lis
 	go func() {


### PR DESCRIPTION
Moves v2 registration to a separate function which is invoked only for gRPC.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
