### PR TITLE
WIP: debug, w/ dns RES_OPTIONS=ndots:1, w/o compiled.wasm

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -214,8 +214,6 @@ for plugin in stats metadata_exchange
 do
   FILTER_WASM_URL="${ISTIO_ENVOY_BASE_URL}/${plugin}-${ISTIO_ENVOY_VERSION}.wasm"
   download_wasm_if_necessary "${FILTER_WASM_URL}" "${WASM_RELEASE_DIR}"/"${plugin//_/-}"-filter.wasm
-  FILTER_WASM_URL="${ISTIO_ENVOY_BASE_URL}/${plugin}-${ISTIO_ENVOY_VERSION}.compiled.wasm"
-  download_wasm_if_necessary "${FILTER_WASM_URL}" "${WASM_RELEASE_DIR}"/"${plugin//_/-}"-filter.compiled.wasm
 done
 
 # Copy native envoy binary to ISTIO_OUT

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1168,7 +1168,6 @@ spec:
                       inline_string: "envoy.wasm.stats"
 ---
 # Source: istio-discovery/templates/telemetryv2_1.7.yaml
-# Note: metadata exchange filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -1180,61 +1179,7 @@ spec:
   configPatches:
     - applyTo: HTTP_FILTER
       match:
-        context: SIDECAR_INBOUND
-        proxy:
-          proxyVersion: '^1\.7.*'
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.http_connection_manager"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.metadata_exchange
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
-            value:
-              config:
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {}
-                vm_config:
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.metadata_exchange
-    - applyTo: HTTP_FILTER
-      match:
-        context: SIDECAR_OUTBOUND
-        proxy:
-          proxyVersion: '^1\.7.*'
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.http_connection_manager"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.metadata_exchange
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
-            value:
-              config:
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {}
-                vm_config:
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.metadata_exchange
-    - applyTo: HTTP_FILTER
-      match:
-        context: GATEWAY
+        context: ANY # inbound, outbound, and gateway
         proxy:
           proxyVersion: '^1\.7.*'
         listener:
@@ -1319,7 +1264,6 @@ spec:
                 protocol: istio-peer-exchange
 ---
 # Source: istio-discovery/templates/telemetryv2_1.7.yaml
-# Note: http stats filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -1434,7 +1378,6 @@ spec:
                       inline_string: envoy.wasm.stats
 ---
 # Source: istio-discovery/templates/telemetryv2_1.7.yaml
-# Note: tcp stats filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -1542,7 +1485,6 @@ spec:
                       inline_string: "envoy.wasm.stats"
 ---
 # Source: istio-discovery/templates/telemetryv2_1.8.yaml
-# Note: metadata exchange filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -1554,61 +1496,7 @@ spec:
   configPatches:
     - applyTo: HTTP_FILTER
       match:
-        context: SIDECAR_INBOUND
-        proxy:
-          proxyVersion: '^1\.8.*'
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.http_connection_manager"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.metadata_exchange
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
-            value:
-              config:
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {}
-                vm_config:
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.metadata_exchange
-    - applyTo: HTTP_FILTER
-      match:
-        context: SIDECAR_OUTBOUND
-        proxy:
-          proxyVersion: '^1\.8.*'
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.http_connection_manager"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.metadata_exchange
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
-            value:
-              config:
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {}
-                vm_config:
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.metadata_exchange
-    - applyTo: HTTP_FILTER
-      match:
-        context: GATEWAY
+        context: ANY # inbound, outbound, and gateway
         proxy:
           proxyVersion: '^1\.8.*'
         listener:
@@ -1693,7 +1581,6 @@ spec:
                 protocol: istio-peer-exchange
 ---
 # Source: istio-discovery/templates/telemetryv2_1.8.yaml
-# Note: http stats filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -1808,7 +1695,6 @@ spec:
                       inline_string: envoy.wasm.stats
 ---
 # Source: istio-discovery/templates/telemetryv2_1.8.yaml
-# Note: tcp stats filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -409,11 +409,11 @@ data:
             fieldRef:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         # To prevent Envoy from unnecessarily trying to run through DNS search domains first
-        # for every DNS query. ndots 0 forces it to resolve the hostname as is first before
+        # for every DNS query. ndots 1 forces it to resolve a host like example.com as is first before
         # appending the DNS search domains to the query.
         # This environment variable is used by c-ares DNS library that envoy uses.
         - name: RES_OPTIONS
-          value: "options ndots:0"
+          value: "options ndots:1"
         - name: PROXY_CONFIG
           value: |
                  {{ protoToJSON .ProxyConfig }}

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -408,12 +408,14 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
+        {{- if .ProxyConfig.ProxyMetadata.ISTIO_META_DNS_CAPTURE }}
         # To prevent Envoy from unnecessarily trying to run through DNS search domains first
         # for every DNS query. ndots 1 forces it to resolve a host like example.com as is first before
         # appending the DNS search domains to the query.
         # This environment variable is used by c-ares DNS library that envoy uses.
         - name: RES_OPTIONS
           value: "options ndots:1"
+        {{- end }}
         - name: PROXY_CONFIG
           value: |
                  {{ protoToJSON .ProxyConfig }}

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -408,6 +408,12 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
+        # To prevent Envoy from unnecessarily trying to run through DNS search domains first
+        # for every DNS query. ndots 0 forces it to resolve the hostname as is first before
+        # appending the DNS search domains to the query.
+        # This environment variable is used by c-ares DNS library that envoy uses.
+        - name: RES_OPTIONS
+          value: "options ndots:0"
         - name: PROXY_CONFIG
           value: |
                  {{ protoToJSON .ProxyConfig }}
@@ -565,12 +571,6 @@ data:
           {{ toYaml $value | indent 4 }}
           {{ end }}
           {{- end }}
-      {{- if .ProxyConfig.ProxyMetadata.ISTIO_META_DNS_CAPTURE }}
-      dnsConfig:
-        options:
-        - name: "ndots"
-          value: "4"
-      {{- end }}
       volumes:
       {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
       - name: custom-bootstrap-volume

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -201,11 +201,11 @@ template: |
         fieldRef:
           fieldPath: metadata.labels['service.istio.io/canonical-revision']
     # To prevent Envoy from unnecessarily trying to run through DNS search domains first
-    # for every DNS query. ndots 0 forces it to resolve the hostname as is first before
+    # for every DNS query. ndots 1 forces it to resolve a host like example.com as is first before
     # appending the DNS search domains to the query.
     # This environment variable is used by c-ares DNS library that envoy uses.
     - name: RES_OPTIONS
-      value: "options ndots:0"
+      value: "options ndots:1"
     - name: PROXY_CONFIG
       value: |
              {{ protoToJSON .ProxyConfig }}

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -200,12 +200,14 @@ template: |
       valueFrom:
         fieldRef:
           fieldPath: metadata.labels['service.istio.io/canonical-revision']
+    {{- if .ProxyConfig.ProxyMetadata.ISTIO_META_DNS_CAPTURE }}
     # To prevent Envoy from unnecessarily trying to run through DNS search domains first
     # for every DNS query. ndots 1 forces it to resolve a host like example.com as is first before
     # appending the DNS search domains to the query.
     # This environment variable is used by c-ares DNS library that envoy uses.
     - name: RES_OPTIONS
       value: "options ndots:1"
+    {{- end }}
     - name: PROXY_CONFIG
       value: |
              {{ protoToJSON .ProxyConfig }}

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -200,6 +200,12 @@ template: |
       valueFrom:
         fieldRef:
           fieldPath: metadata.labels['service.istio.io/canonical-revision']
+    # To prevent Envoy from unnecessarily trying to run through DNS search domains first
+    # for every DNS query. ndots 0 forces it to resolve the hostname as is first before
+    # appending the DNS search domains to the query.
+    # This environment variable is used by c-ares DNS library that envoy uses.
+    - name: RES_OPTIONS
+      value: "options ndots:0"
     - name: PROXY_CONFIG
       value: |
              {{ protoToJSON .ProxyConfig }}
@@ -357,12 +363,6 @@ template: |
       {{ toYaml $value | indent 4 }}
       {{ end }}
       {{- end }}
-  {{- if .ProxyConfig.ProxyMetadata.ISTIO_META_DNS_CAPTURE }}
-  dnsConfig:
-    options:
-    - name: "ndots"
-      value: "4"
-  {{- end }}
   volumes:
   {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
   - name: custom-bootstrap-volume

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.7.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.7.yaml
@@ -1,5 +1,4 @@
 {{- if and .Values.telemetry.enabled .Values.telemetry.v2.enabled }}
-# Note: metadata exchange filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -15,7 +14,7 @@ spec:
   configPatches:
     - applyTo: HTTP_FILTER
       match:
-        context: SIDECAR_INBOUND
+        context: ANY # inbound, outbound, and gateway
         proxy:
           proxyVersion: '^1\.7.*'
         listener:
@@ -38,78 +37,15 @@ spec:
                 vm_config:
                   {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
+                      filename: /etc/istio/extensions/metadata-exchange-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: envoy.wasm.metadata_exchange
                   {{- end }}
-    - applyTo: HTTP_FILTER
-      match:
-        context: SIDECAR_OUTBOUND
-        proxy:
-          proxyVersion: '^1\.7.*'
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.http_connection_manager"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.metadata_exchange
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
-            value:
-              config:
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {}
-                vm_config:
-                  {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
-                  {{- else }}
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.metadata_exchange
-                  {{- end }}
-    - applyTo: HTTP_FILTER
-      match:
-        context: GATEWAY
-        proxy:
-          proxyVersion: '^1\.7.*'
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.http_connection_manager"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.metadata_exchange
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
-            value:
-              config:
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {}
-                vm_config:
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.metadata_exchange
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -172,7 +108,6 @@ spec:
               value:
                 protocol: istio-peer-exchange
 ---
-# Note: http stats filter is wasm enabled only in sidecars.
 {{- if .Values.telemetry.v2.prometheus.enabled }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -228,10 +163,9 @@ spec:
                   vm_id: stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -279,10 +213,9 @@ spec:
                   vm_id: stats_inbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -329,12 +262,18 @@ spec:
                     }
                 vm_config:
                   vm_id: stats_outbound
+                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
+                  runtime: envoy.wasm.runtime.v8
+                  code:
+                    local:
+                      filename: /etc/istio/extensions/stats-filter.wasm
+                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: envoy.wasm.stats
+                  {{- end }}
 ---
-# Note: tcp stats filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -387,10 +326,9 @@ spec:
                   vm_id: tcp_stats_inbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -436,10 +374,9 @@ spec:
                   vm_id: tcp_stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -483,10 +420,17 @@ spec:
                     }
                 vm_config:
                   vm_id: tcp_stats_outbound
+                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
+                  runtime: envoy.wasm.runtime.v8
+                  code:
+                    local:
+                      filename: /etc/istio/extensions/stats-filter.wasm
+                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: "envoy.wasm.stats"
+                  {{- end }}
 ---
 
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.8.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.8.yaml
@@ -1,5 +1,4 @@
 {{- if and .Values.telemetry.enabled .Values.telemetry.v2.enabled }}
-# Note: metadata exchange filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -15,7 +14,7 @@ spec:
   configPatches:
     - applyTo: HTTP_FILTER
       match:
-        context: SIDECAR_INBOUND
+        context: ANY # inbound, outbound, and gateway
         proxy:
           proxyVersion: '^1\.8.*'
         listener:
@@ -38,78 +37,15 @@ spec:
                 vm_config:
                   {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
+                      filename: /etc/istio/extensions/metadata-exchange-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: envoy.wasm.metadata_exchange
                   {{- end }}
-    - applyTo: HTTP_FILTER
-      match:
-        context: SIDECAR_OUTBOUND
-        proxy:
-          proxyVersion: '^1\.8.*'
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.http_connection_manager"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.metadata_exchange
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
-            value:
-              config:
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {}
-                vm_config:
-                  {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
-                  {{- else }}
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.metadata_exchange
-                  {{- end }}
-    - applyTo: HTTP_FILTER
-      match:
-        context: GATEWAY
-        proxy:
-          proxyVersion: '^1\.8.*'
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.http_connection_manager"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.metadata_exchange
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
-            value:
-              config:
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {}
-                vm_config:
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.metadata_exchange
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -172,7 +108,6 @@ spec:
               value:
                 protocol: istio-peer-exchange
 ---
-# Note: http stats filter is wasm enabled only in sidecars.
 {{- if .Values.telemetry.v2.prometheus.enabled }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -228,10 +163,9 @@ spec:
                   vm_id: stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -279,10 +213,9 @@ spec:
                   vm_id: stats_inbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -329,12 +262,18 @@ spec:
                     }
                 vm_config:
                   vm_id: stats_outbound
+                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
+                  runtime: envoy.wasm.runtime.v8
+                  code:
+                    local:
+                      filename: /etc/istio/extensions/stats-filter.wasm
+                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: envoy.wasm.stats
+                  {{- end }}
 ---
-# Note: tcp stats filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -387,10 +326,9 @@ spec:
                   vm_id: tcp_stats_inbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -436,10 +374,9 @@ spec:
                   vm_id: tcp_stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -483,10 +420,17 @@ spec:
                     }
                 vm_config:
                   vm_id: tcp_stats_outbound
+                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
+                  runtime: envoy.wasm.runtime.v8
+                  code:
+                    local:
+                      filename: /etc/istio/extensions/stats-filter.wasm
+                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: "envoy.wasm.stats"
+                  {{- end }}
 ---
 
 {{- end }}

--- a/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -391,11 +391,11 @@ data:
             fieldRef:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
         # To prevent Envoy from unnecessarily trying to run through DNS search domains first
-        # for every DNS query. ndots 0 forces it to resolve the hostname as is first before
+        # for every DNS query. ndots 1 forces it to resolve a host like example.com as is first before
         # appending the DNS search domains to the query.
         # This environment variable is used by c-ares DNS library that envoy uses.
         - name: RES_OPTIONS
-          value: "options ndots:0"
+          value: "options ndots:1"
         - name: PROXY_CONFIG
           value: |
                  {{ protoToJSON .ProxyConfig }}

--- a/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -390,12 +390,14 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
+        {{- if .ProxyConfig.ProxyMetadata.ISTIO_META_DNS_CAPTURE }}
         # To prevent Envoy from unnecessarily trying to run through DNS search domains first
         # for every DNS query. ndots 1 forces it to resolve a host like example.com as is first before
         # appending the DNS search domains to the query.
         # This environment variable is used by c-ares DNS library that envoy uses.
         - name: RES_OPTIONS
           value: "options ndots:1"
+        {{- end }}
         - name: PROXY_CONFIG
           value: |
                  {{ protoToJSON .ProxyConfig }}

--- a/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -390,6 +390,12 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: metadata.labels['service.istio.io/canonical-revision']
+        # To prevent Envoy from unnecessarily trying to run through DNS search domains first
+        # for every DNS query. ndots 0 forces it to resolve the hostname as is first before
+        # appending the DNS search domains to the query.
+        # This environment variable is used by c-ares DNS library that envoy uses.
+        - name: RES_OPTIONS
+          value: "options ndots:0"
         - name: PROXY_CONFIG
           value: |
                  {{ protoToJSON .ProxyConfig }}
@@ -547,12 +553,6 @@ data:
           {{ toYaml $value | indent 4 }}
           {{ end }}
           {{- end }}
-      {{- if .ProxyConfig.ProxyMetadata.ISTIO_META_DNS_CAPTURE }}
-      dnsConfig:
-        options:
-        - name: "ndots"
-          value: "4"
-      {{- end }}
       volumes:
       {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
       - name: custom-bootstrap-volume

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -201,11 +201,11 @@ template: |
         fieldRef:
           fieldPath: metadata.labels['service.istio.io/canonical-revision']
     # To prevent Envoy from unnecessarily trying to run through DNS search domains first
-    # for every DNS query. ndots 0 forces it to resolve the hostname as is first before
+    # for every DNS query. ndots 1 forces it to resolve a host like example.com as is first before
     # appending the DNS search domains to the query.
     # This environment variable is used by c-ares DNS library that envoy uses.
     - name: RES_OPTIONS
-      value: "options ndots:0"
+      value: "options ndots:1"
     - name: PROXY_CONFIG
       value: |
              {{ protoToJSON .ProxyConfig }}

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -200,12 +200,14 @@ template: |
       valueFrom:
         fieldRef:
           fieldPath: metadata.labels['service.istio.io/canonical-revision']
+    {{- if .ProxyConfig.ProxyMetadata.ISTIO_META_DNS_CAPTURE }}
     # To prevent Envoy from unnecessarily trying to run through DNS search domains first
     # for every DNS query. ndots 1 forces it to resolve a host like example.com as is first before
     # appending the DNS search domains to the query.
     # This environment variable is used by c-ares DNS library that envoy uses.
     - name: RES_OPTIONS
       value: "options ndots:1"
+    {{- end }}
     - name: PROXY_CONFIG
       value: |
              {{ protoToJSON .ProxyConfig }}

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -200,6 +200,12 @@ template: |
       valueFrom:
         fieldRef:
           fieldPath: metadata.labels['service.istio.io/canonical-revision']
+    # To prevent Envoy from unnecessarily trying to run through DNS search domains first
+    # for every DNS query. ndots 0 forces it to resolve the hostname as is first before
+    # appending the DNS search domains to the query.
+    # This environment variable is used by c-ares DNS library that envoy uses.
+    - name: RES_OPTIONS
+      value: "options ndots:0"
     - name: PROXY_CONFIG
       value: |
              {{ protoToJSON .ProxyConfig }}
@@ -357,12 +363,6 @@ template: |
       {{ toYaml $value | indent 4 }}
       {{ end }}
       {{- end }}
-  {{- if .ProxyConfig.ProxyMetadata.ISTIO_META_DNS_CAPTURE }}
-  dnsConfig:
-    options:
-    - name: "ndots"
-      value: "4"
-  {{- end }}
   volumes:
   {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
   - name: custom-bootstrap-volume

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.7.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.7.yaml
@@ -1,5 +1,4 @@
 {{- if and .Values.telemetry.enabled .Values.telemetry.v2.enabled }}
-# Note: metadata exchange filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -15,7 +14,7 @@ spec:
   configPatches:
     - applyTo: HTTP_FILTER
       match:
-        context: SIDECAR_INBOUND
+        context: ANY # inbound, outbound, and gateway
         proxy:
           proxyVersion: '^1\.7.*'
         listener:
@@ -38,78 +37,15 @@ spec:
                 vm_config:
                   {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
+                      filename: /etc/istio/extensions/metadata-exchange-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: envoy.wasm.metadata_exchange
                   {{- end }}
-    - applyTo: HTTP_FILTER
-      match:
-        context: SIDECAR_OUTBOUND
-        proxy:
-          proxyVersion: '^1\.7.*'
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.http_connection_manager"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.metadata_exchange
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
-            value:
-              config:
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {}
-                vm_config:
-                  {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
-                  {{- else }}
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.metadata_exchange
-                  {{- end }}
-    - applyTo: HTTP_FILTER
-      match:
-        context: GATEWAY
-        proxy:
-          proxyVersion: '^1\.7.*'
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.http_connection_manager"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.metadata_exchange
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
-            value:
-              config:
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {}
-                vm_config:
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.metadata_exchange
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -172,7 +108,6 @@ spec:
               value:
                 protocol: istio-peer-exchange
 ---
-# Note: http stats filter is wasm enabled only in sidecars.
 {{- if .Values.telemetry.v2.prometheus.enabled }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -228,10 +163,9 @@ spec:
                   vm_id: stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -279,10 +213,9 @@ spec:
                   vm_id: stats_inbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -329,12 +262,18 @@ spec:
                     }
                 vm_config:
                   vm_id: stats_outbound
+                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
+                  runtime: envoy.wasm.runtime.v8
+                  code:
+                    local:
+                      filename: /etc/istio/extensions/stats-filter.wasm
+                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: envoy.wasm.stats
+                  {{- end }}
 ---
-# Note: tcp stats filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -387,10 +326,9 @@ spec:
                   vm_id: tcp_stats_inbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -436,10 +374,9 @@ spec:
                   vm_id: tcp_stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -483,10 +420,17 @@ spec:
                     }
                 vm_config:
                   vm_id: tcp_stats_outbound
+                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
+                  runtime: envoy.wasm.runtime.v8
+                  code:
+                    local:
+                      filename: /etc/istio/extensions/stats-filter.wasm
+                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: "envoy.wasm.stats"
+                  {{- end }}
 ---
 
 {{- end }}

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.8.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.8.yaml
@@ -1,5 +1,4 @@
 {{- if and .Values.telemetry.enabled .Values.telemetry.v2.enabled }}
-# Note: metadata exchange filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -15,7 +14,7 @@ spec:
   configPatches:
     - applyTo: HTTP_FILTER
       match:
-        context: SIDECAR_INBOUND
+        context: ANY # inbound, outbound, and gateway
         proxy:
           proxyVersion: '^1\.8.*'
         listener:
@@ -38,78 +37,15 @@ spec:
                 vm_config:
                   {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
+                      filename: /etc/istio/extensions/metadata-exchange-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: envoy.wasm.metadata_exchange
                   {{- end }}
-    - applyTo: HTTP_FILTER
-      match:
-        context: SIDECAR_OUTBOUND
-        proxy:
-          proxyVersion: '^1\.8.*'
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.http_connection_manager"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.metadata_exchange
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
-            value:
-              config:
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {}
-                vm_config:
-                  {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
-                  {{- else }}
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.metadata_exchange
-                  {{- end }}
-    - applyTo: HTTP_FILTER
-      match:
-        context: GATEWAY
-        proxy:
-          proxyVersion: '^1\.8.*'
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.http_connection_manager"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: istio.metadata_exchange
-          typed_config:
-            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
-            value:
-              config:
-                configuration:
-                  "@type": "type.googleapis.com/google.protobuf.StringValue"
-                  value: |
-                    {}
-                vm_config:
-                  runtime: envoy.wasm.runtime.null
-                  code:
-                    local:
-                      inline_string: envoy.wasm.metadata_exchange
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -172,7 +108,6 @@ spec:
               value:
                 protocol: istio-peer-exchange
 ---
-# Note: http stats filter is wasm enabled only in sidecars.
 {{- if .Values.telemetry.v2.prometheus.enabled }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -228,10 +163,9 @@ spec:
                   vm_id: stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -279,10 +213,9 @@ spec:
                   vm_id: stats_inbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -329,12 +262,18 @@ spec:
                     }
                 vm_config:
                   vm_id: stats_outbound
+                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
+                  runtime: envoy.wasm.runtime.v8
+                  code:
+                    local:
+                      filename: /etc/istio/extensions/stats-filter.wasm
+                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: envoy.wasm.stats
+                  {{- end }}
 ---
-# Note: tcp stats filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -387,10 +326,9 @@ spec:
                   vm_id: tcp_stats_inbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -436,10 +374,9 @@ spec:
                   vm_id: tcp_stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
-                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
+                      filename: /etc/istio/extensions/stats-filter.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -483,10 +420,17 @@ spec:
                     }
                 vm_config:
                   vm_id: tcp_stats_outbound
+                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
+                  runtime: envoy.wasm.runtime.v8
+                  code:
+                    local:
+                      filename: /etc/istio/extensions/stats-filter.wasm
+                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: "envoy.wasm.stats"
+                  {{- end }}
 ---
 
 {{- end }}

--- a/manifests/profiles/default.yaml
+++ b/manifests/profiles/default.yaml
@@ -251,10 +251,8 @@ spec:
       enabled: true
       v2:
         enabled: true
-        metadataExchange:
-          wasmEnabled: true
+        metadataExchange: {}
         prometheus:
-          wasmEnabled: true
           enabled: true
         stackdriver:
           enabled: false

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -49,9 +49,7 @@ COPY pilot-agent /usr/local/bin/pilot-agent
 COPY envoy_policy.yaml.tmpl /var/lib/istio/envoy/envoy_policy.yaml.tmpl
 
 COPY stats-filter.wasm /etc/istio/extensions/stats-filter.wasm
-COPY stats-filter.compiled.wasm /etc/istio/extensions/stats-filter.compiled.wasm
 COPY metadata-exchange-filter.wasm /etc/istio/extensions/metadata-exchange-filter.wasm
-COPY metadata-exchange-filter.compiled.wasm /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
 
 # The pilot-agent will bootstrap Envoy.
 ENTRYPOINT ["/usr/local/bin/pilot-agent"]

--- a/pkg/test/echo/client/client.go
+++ b/pkg/test/echo/client/client.go
@@ -39,7 +39,7 @@ type Instance struct {
 // New creates a new echo client.Instance that is connected to the given server address.
 func New(address string, tlsSettings *common.TLSSettings) (*Instance, error) {
 	// Connect to the GRPC (command) endpoint of 'this' app.
-	ctx, cancel := context.WithTimeout(context.Background(), common.ConnectionTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), common.ConnectionTimeout*5)
 	defer cancel()
 	dialOptions := []grpc.DialOption{grpc.WithBlock()}
 	if tlsSettings == nil {

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -254,7 +254,6 @@ spec:
           sudo sh -c 'echo "{{$.VM.IstiodIP}} istiod.istio-system.svc" >> /etc/hosts'
 
           # TODO: run with systemctl?
-          export ISTIO_AGENT_FLAGS="--concurrency 2"
           sudo -E /usr/local/bin/istio-start.sh&
           /usr/local/bin/server --cluster "{{ $cluster }}" --version "{{ $subset.Version }}" \
 {{- range $i, $p := $.ContainerPorts }}

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -221,9 +221,6 @@ spec:
         - "8.8.8.8"
         searches:
         - "com"
-        options:
-        - name: "ndots"
-          value: "1"
       # Disable service account mount, to mirror VM
       automountServiceAccountToken: false
       containers:
@@ -271,6 +268,8 @@ spec:
              "{{ $p.Port }}" \
 {{- end }}
         env:
+        - name: RES_OPTIONS
+          value: "options ndots:0"
         {{- range $name, $value := $.Environment }}
         - name: {{ $name }}
           value: "{{ $value }}"

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -269,7 +269,7 @@ spec:
 {{- end }}
         env:
         - name: RES_OPTIONS
-          value: "options ndots:0"
+          value: "options ndots:1"
         {{- range $name, $value := $.Environment }}
         - name: {{ $name }}
           value: "{{ $value }}"

--- a/releasenotes/notes/dns-capture.yaml
+++ b/releasenotes/notes/dns-capture.yaml
@@ -4,5 +4,4 @@ area: networking
 releaseNotes: |
   *Added* experimental DNS resolution directly in the sidecar to better support service entries with TCP services, multicluster DNS resolution,
   and dns resolution of Kubernetes services from VM sidecars. This feature is disabled by default and can be enabled by setting the following
-  in the Istio Operator: meshConfig.defaultConfig.proxyMetadata.ISTIO_META_DNS_CAPTURE="ALL". Setting this option will cause Istio to set the
-  `ndots` option in pod's `dnsConfig` to 4 for faster DNS resolution in common cluster setups.
+  in the Istio Operator: meshConfig.defaultConfig.proxyMetadata.ISTIO_META_DNS_CAPTURE="ALL".

--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -89,8 +89,6 @@ func TestMain(m *testing.M) {
 			return ctx.Config().ApplyYAML("", string(crd))
 		}).
 		Setup(istio.Setup(&i, func(cfg *istio.Config) {
-			cfg.Values["telemetry.v2.metadataExchange.wasmEnabled"] = "false"
-			cfg.Values["telemetry.v2.prometheus.wasmEnabled"] = "false"
 			cfg.ControlPlaneValues = `
 values:
   global:

--- a/tests/integration/pilot/routing_test.go
+++ b/tests/integration/pilot/routing_test.go
@@ -209,16 +209,16 @@ func vmTestCases(vm echo.Instance) []TrafficTestCase {
 			to:   vm,
 		},
 		{
-			name: "dns: VM to k8s cluster IP service name.namespace host",
-			from: vm,
-			to:   apps.podA,
-			host: apps.podA.Config().Service + "." + apps.namespace.Name(),
-		},
-		{
 			name: "dns: VM to k8s cluster IP service fqdn host",
 			from: vm,
 			to:   apps.podA,
 			host: apps.podA.Config().FQDN(),
+		},
+		{
+			name: "dns: VM to k8s cluster IP service name.namespace host",
+			from: vm,
+			to:   apps.podA,
+			host: apps.podA.Config().Service + "." + apps.namespace.Name(),
 		},
 		{
 			name: "dns: VM to k8s cluster IP service short name host",

--- a/tests/integration/telemetry/stats/prometheus/http/nullvm/stats_filter_test.go
+++ b/tests/integration/telemetry/stats/prometheus/http/nullvm/stats_filter_test.go
@@ -37,16 +37,7 @@ func TestMain(m *testing.M) {
 	framework.NewSuite(m).
 		RequireSingleCluster().
 		Label(label.CustomSetup).
-		Setup(istio.Setup(common.GetIstioInstance(), setupConfig)).
+		Setup(istio.Setup(common.GetIstioInstance(), nil)).
 		Setup(common.TestSetup).
 		Run()
-}
-
-func setupConfig(cfg *istio.Config) {
-	if cfg == nil {
-		return
-	}
-	// enable telemetry v2 with nullvm
-	cfg.Values["telemetry.v2.metadataExchange.wasmEnabled"] = "false"
-	cfg.Values["telemetry.v2.prometheus.wasmEnabled"] = "false"
 }

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -78,9 +78,7 @@ ${ISTIO_ENVOY_BOOTSTRAP_CONFIG_DIR}/envoy_bootstrap.json: ${ISTIO_ENVOY_BOOTSTRA
 
 # rule for wasm extensions.
 $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/stats-filter.wasm: init
-$(ISTIO_ENVOY_LINUX_RELEASE_DIR)/stats-filter.compiled.wasm: init
 $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/metadata-exchange-filter.wasm: init
-$(ISTIO_ENVOY_LINUX_RELEASE_DIR)/metadata-exchange-filter.compiled.wasm: init
 
 # Default proxy image.
 docker.proxyv2: BUILD_PRE=&& chmod 755 ${SIDECAR} pilot-agent
@@ -92,9 +90,7 @@ docker.proxyv2: $(ISTIO_OUT_LINUX)/pilot-agent
 docker.proxyv2: pilot/docker/Dockerfile.proxyv2
 docker.proxyv2: pilot/docker/envoy_policy.yaml.tmpl
 docker.proxyv2: $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/stats-filter.wasm
-docker.proxyv2: $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/stats-filter.compiled.wasm
 docker.proxyv2: $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/metadata-exchange-filter.wasm
-docker.proxyv2: $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/metadata-exchange-filter.compiled.wasm
 	$(DOCKER_RULE)
 
 docker.pilot: BUILD_PRE=&& chmod 755 pilot-discovery cacert.pem

--- a/tools/packaging/packaging.mk
+++ b/tools/packaging/packaging.mk
@@ -12,9 +12,6 @@ deb: ${ISTIO_OUT_LINUX}/release/istio-sidecar.deb ${ISTIO_OUT_LINUX}/release/ist
 # Base directory for istio binaries. Likely to change !
 ISTIO_DEB_BIN=/usr/local/bin
 
-# Home directory of istio-proxy user. It is symlinked /etc/istio --> /var/lib/istio
-ISTIO_PROXY_HOME=/var/lib/istio
-
 ISTIO_DEB_DEPS:=pilot-discovery istioctl
 ISTIO_FILES:=
 $(foreach DEP,$(ISTIO_DEB_DEPS),\
@@ -38,13 +35,6 @@ $(foreach DEST,$(ISTIO_DEB_DEST),\
 
 SIDECAR_FILES+=${REPO_ROOT}/tools/packaging/common/envoy_bootstrap.json=/var/lib/istio/envoy/envoy_bootstrap_tmpl.json
 
-ISTIO_EXTENSIONS:=stats-filter.wasm \
-                  stats-filter.compiled.wasm \
-                  metadata-exchange-filter.wasm \
-                  metadata-exchange-filter.compiled.wasm
-
-$(foreach EXT,$(ISTIO_EXTENSIONS),\
-        $(eval SIDECAR_FILES+=${ISTIO_ENVOY_LINUX_RELEASE_DIR}/$(EXT)=$(ISTIO_PROXY_HOME)/extensions/$(EXT)))
 
 # original name used in 0.2 - will be updated to 'istio.deb' since it now includes all istio binaries.
 SIDECAR_PACKAGE_NAME ?= istio-sidecar


### PR DESCRIPTION
We dont need to set the ndots for the entire pod. We can control ndots at envoy level
by setting the env var that c-ares reads.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.