### PR TITLE
[manual cherry-pick] fixing dns resolution issues (#25964)

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -19,6 +19,8 @@ RUN apt-get update && \
       knot-dnsutils \
       netcat \
       tcpdump \
+      conntrack \
+      bsdmainutils \
       net-tools \
       lsof \
       linux-tools-generic \

--- a/istioctl/pkg/util/configdump/listener.go
+++ b/istioctl/pkg/util/configdump/listener.go
@@ -33,6 +33,9 @@ func (w *Wrapper) GetDynamicListenerDump(stripVersions bool) (*adminapi.Listener
 
 	dal := make([]*adminapi.ListenersConfigDump_DynamicListener, 0)
 	for _, l := range listenerDump.DynamicListeners {
+		// If a listener was reloaded, it would contain both the active and draining state
+		// delete the draining state for proper comparison
+		l.DrainingState = nil
 		if l.ActiveState != nil {
 			dal = append(dal, l)
 		}

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -574,6 +574,12 @@ data:
           {{ toYaml $value | indent 4 }}
           {{ end }}
           {{- end }}
+      {{- if .ProxyConfig.ProxyMetadata.ISTIO_META_DNS_CAPTURE }}
+      dnsConfig:
+        options:
+        - name: "ndots"
+          value: "4"
+      {{- end }}
       volumes:
       {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
       - name: custom-bootstrap-volume

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -357,6 +357,12 @@ template: |
       {{ toYaml $value | indent 4 }}
       {{ end }}
       {{- end }}
+  {{- if .ProxyConfig.ProxyMetadata.ISTIO_META_DNS_CAPTURE }}
+  dnsConfig:
+    options:
+    - name: "ndots"
+      value: "4"
+  {{- end }}
   volumes:
   {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
   - name: custom-bootstrap-volume

--- a/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -556,6 +556,12 @@ data:
           {{ toYaml $value | indent 4 }}
           {{ end }}
           {{- end }}
+      {{- if .ProxyConfig.ProxyMetadata.ISTIO_META_DNS_CAPTURE }}
+      dnsConfig:
+        options:
+        - name: "ndots"
+          value: "4"
+      {{- end }}
       volumes:
       {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
       - name: custom-bootstrap-volume

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -357,6 +357,12 @@ template: |
       {{ toYaml $value | indent 4 }}
       {{ end }}
       {{- end }}
+  {{- if .ProxyConfig.ProxyMetadata.ISTIO_META_DNS_CAPTURE }}
+  dnsConfig:
+    options:
+    - name: "ndots"
+      value: "4"
+  {{- end }}
   volumes:
   {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
   - name: custom-bootstrap-volume

--- a/pilot/pkg/networking/core/v1alpha3/dns_listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/dns_listener.go
@@ -58,8 +58,8 @@ func (configgen *ConfigGeneratorImpl) buildSidecarDNSListener(node *model.Proxy,
 		return nil
 	}
 
-	_, localhost := getActualWildcardAndLocalHost(node)
-	address := util.BuildAddress(localhost, model.SidecarDNSListenerPort)
+	wildcard, _ := getActualWildcardAndLocalHost(node)
+	address := util.BuildAddress(wildcard, model.SidecarDNSListenerPort)
 	// Convert the address to a UDP address
 	address.GetSocketAddress().Protocol = core.SocketAddress_UDP
 

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -214,7 +214,19 @@ spec:
         istio.io/test-vm-version: {{ $subset.Version }}
     spec:
       # Disable kube-dns, to mirror VM
-      dnsPolicy: Default
+      # we set policy to none and explicitly provide a set of invalid values
+      # for nameservers, search namespaces, etc. ndots is set to 1 so that
+      # the application will first try to resolve the hostname (a, a.ns, etc.) as is
+      # before attempting to add the search namespaces.
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - "8.8.8.8"
+        searches:
+        - "com"
+        options:
+        - name: "ndots"
+          value: "1"
       # Disable service account mount, to mirror VM
       automountServiceAccountToken: false
       containers:
@@ -248,6 +260,7 @@ spec:
           sudo sh -c 'echo "{{$.VM.IstiodIP}} istiod.istio-system.svc" >> /etc/hosts'
 
           # TODO: run with systemctl?
+          export ISTIO_AGENT_FLAGS="--concurrency 2"
           sudo -E /usr/local/bin/istio-start.sh&
           /usr/local/bin/server --cluster "{{ $cluster }}" --version "{{ $subset.Version }}" \
 {{- range $i, $p := $.ContainerPorts }}

--- a/pkg/test/framework/components/echo/kube/instance.go
+++ b/pkg/test/framework/components/echo/kube/instance.go
@@ -355,7 +355,7 @@ func (c *instance) Call(opts echo.CallOptions) (appEcho.ParsedResponses, error) 
 			err = fmt.Errorf("failed calling %s->'%s://%s:%d/%s': %v",
 				c.Config().Service,
 				strings.ToLower(string(opts.Port.Protocol)),
-				opts.Target.Config().Service,
+				opts.Host,
 				opts.Port.ServicePort,
 				opts.Path,
 				err)

--- a/releasenotes/notes/dns-capture.yaml
+++ b/releasenotes/notes/dns-capture.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+releaseNotes: |
+  *Added* experimental DNS resolution directly in the sidecar to better support service entries with TCP services, multicluster DNS resolution,
+  and dns resolution of Kubernetes services from VM sidecars. This feature is disabled by default and can be enabled by setting the following
+  in the Istio Operator: meshConfig.defaultConfig.proxyMetadata.ISTIO_META_DNS_CAPTURE="ALL". Setting this option will cause Istio to set the
+  `ndots` option in pod's `dnsConfig` to 4 for faster DNS resolution in common cluster setups.

--- a/tools/istio-iptables/pkg/cmd/run.go
+++ b/tools/istio-iptables/pkg/cmd/run.go
@@ -379,14 +379,6 @@ func (iptConfigurator *IptablesConfigurator) run() {
 	// redirects to Envoy.
 	iptConfigurator.iptables.AppendRuleV4(
 		constants.ISTIOREDIRECT, constants.NAT, "-p", constants.TCP, "-j", constants.REDIRECT, "--to-ports", iptConfigurator.cfg.ProxyPort)
-	if redirectDNS {
-		iptConfigurator.iptables.AppendRuleV4(
-			constants.ISTIOREDIRECT, constants.NAT, "-p", constants.UDP, "-j", constants.REDIRECT, "--to-ports", dnsTargetPort)
-		if iptConfigurator.cfg.EnableInboundIPv6 {
-			iptConfigurator.iptables.AppendRuleV6(
-				constants.ISTIOREDIRECT, constants.NAT, "-p", constants.UDP, "-j", constants.REDIRECT, "--to-ports", dnsTargetPort)
-		}
-	}
 
 	// Use this chain also for redirecting inbound traffic to the common Envoy port
 	// when not using TPROXY.
@@ -400,9 +392,6 @@ func (iptConfigurator *IptablesConfigurator) run() {
 	// iptablesOrFail wrapper (like ufw). Current default is similar with 0.1
 	// Jump to the ISTIOOUTPUT chain from OUTPUT chain for all tcp traffic, and UDP dns (if enabled)
 	iptConfigurator.iptables.AppendRuleV4(constants.OUTPUT, constants.NAT, "-p", constants.TCP, "-j", constants.ISTIOOUTPUT)
-	if redirectDNS {
-		iptConfigurator.iptables.AppendRuleV4(constants.OUTPUT, constants.NAT, "-p", constants.UDP, "--dport", "53", "-j", constants.ISTIOOUTPUT)
-	}
 	// Apply port based exclusions. Must be applied before connections back to self are redirected.
 	if iptConfigurator.cfg.OutboundPortsExclude != "" {
 		for _, port := range split(iptConfigurator.cfg.OutboundPortsExclude) {
@@ -466,6 +455,29 @@ func (iptConfigurator *IptablesConfigurator) run() {
 	iptConfigurator.handleInboundIpv4Rules(ipv4RangesInclude)
 	if iptConfigurator.cfg.EnableInboundIPv6 {
 		iptConfigurator.handleInboundIpv6Rules(ipv6RangesExclude, ipv6RangesInclude)
+	}
+
+	if redirectDNS {
+		// Make sure that upstream DNS requests from agent/envoy dont get captured.
+		for _, uid := range split(iptConfigurator.cfg.ProxyUID) {
+			iptConfigurator.iptables.AppendRuleV4(constants.OUTPUT, constants.NAT,
+				"-p", "udp", "--dport", "53", "-m", "owner", "--uid-owner", uid, "-j", constants.RETURN)
+		}
+		for _, gid := range split(iptConfigurator.cfg.ProxyGID) {
+			// TODO: add ip6 as well
+			iptConfigurator.iptables.AppendRuleV4(constants.OUTPUT, constants.NAT,
+				"-p", "udp", "--dport", "53", "-m", "owner", "--gid-owner", gid, "-j", constants.RETURN)
+		}
+
+		// from app to agent/envoy - dnat to 127.0.0.1:port
+		iptConfigurator.iptables.AppendRuleV4(constants.OUTPUT, constants.NAT,
+			"-p", "udp", "--dport", "53",
+			"-j", "DNAT", "--to-destination", "127.0.0.1:"+dnsTargetPort)
+		// overwrite the source IP so that when envoy/agent responds to the DNS request
+		// it responds to localhost on same interface. Otherwise, the connection will not
+		// match in the kernel. Note that the dest port here should be the rewritten port.
+		iptConfigurator.iptables.AppendRuleV4(constants.POSTROUTING, constants.NAT,
+			"-p", "udp", "--dport", dnsTargetPort, "-j", "SNAT", "--to-source", "127.0.0.1")
 	}
 
 	if iptConfigurator.cfg.InboundInterceptionMode == constants.TPROXY {

--- a/tools/istio-iptables/pkg/cmd/run_test.go
+++ b/tools/istio-iptables/pkg/cmd/run_test.go
@@ -102,10 +102,8 @@ func TestRulesWithIpRange(t *testing.T) {
 		"iptables -t nat -N ISTIO_OUTPUT",
 		"iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN",
 		"iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001",
-		"iptables -t nat -A ISTIO_REDIRECT -p udp -j REDIRECT --to-ports 15013",
 		"iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006",
 		"iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT",
-		"iptables -t nat -A OUTPUT -p udp --dport 53 -j ISTIO_OUTPUT",
 		"iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN",
 		"iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT",
 		"iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 3 -j RETURN",
@@ -123,6 +121,12 @@ func TestRulesWithIpRange(t *testing.T) {
 		"iptables -t nat -A ISTIO_OUTPUT -d 1.1.0.0/16 -j RETURN",
 		"iptables -t nat -A ISTIO_OUTPUT -d 9.9.0.0/16 -j ISTIO_REDIRECT",
 		"iptables -t nat -A ISTIO_OUTPUT -j RETURN",
+		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --uid-owner 3 -j RETURN",
+		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --uid-owner 4 -j RETURN",
+		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --gid-owner 1 -j RETURN",
+		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --gid-owner 2 -j RETURN",
+		"iptables -t nat -A OUTPUT -p udp --dport 53 -j DNAT --to-destination 127.0.0.1:15013",
+		"iptables -t nat -A POSTROUTING -p udp --dport 15013 -j SNAT --to-source 127.0.0.1",
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Output mismatch. Expected: \n%#v ; Actual: \n%#v", expected, actual)
@@ -598,10 +602,8 @@ func TestHandleInboundIpv4RulesWithUidGid(t *testing.T) {
 		"iptables -t nat -N ISTIO_OUTPUT",
 		"iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN",
 		"iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001",
-		"iptables -t nat -A ISTIO_REDIRECT -p udp -j REDIRECT --to-ports 15053",
 		"iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006",
 		"iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT",
-		"iptables -t nat -A OUTPUT -p udp --dport 53 -j ISTIO_OUTPUT",
 		"iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN",
 		"iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT",
 		"iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --uid-owner 3 -j RETURN",
@@ -616,6 +618,12 @@ func TestHandleInboundIpv4RulesWithUidGid(t *testing.T) {
 		"iptables -t nat -A ISTIO_OUTPUT -o lo -m owner ! --gid-owner 2 -j RETURN",
 		"iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner 2 -j RETURN",
 		"iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN",
+		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --uid-owner 3 -j RETURN",
+		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --uid-owner 4 -j RETURN",
+		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --gid-owner 1 -j RETURN",
+		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --gid-owner 2 -j RETURN",
+		"iptables -t nat -A OUTPUT -p udp --dport 53 -j DNAT --to-destination 127.0.0.1:15053",
+		"iptables -t nat -A POSTROUTING -p udp --dport 15053 -j SNAT --to-source 127.0.0.1",
 	}
 
 	if !reflect.DeepEqual(actual, expected) {
@@ -681,10 +689,8 @@ func TestRulesWithLoopbackIpInOutboundIpRanges(t *testing.T) {
 		"iptables -t nat -N ISTIO_OUTPUT",
 		"iptables -t nat -A ISTIO_INBOUND -p tcp --dport 15008 -j RETURN",
 		"iptables -t nat -A ISTIO_REDIRECT -p tcp -j REDIRECT --to-ports 15001",
-		"iptables -t nat -A ISTIO_REDIRECT -p udp -j REDIRECT --to-ports 15013",
 		"iptables -t nat -A ISTIO_IN_REDIRECT -p tcp -j REDIRECT --to-ports 15006",
 		"iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT",
-		"iptables -t nat -A OUTPUT -p udp --dport 53 -j ISTIO_OUTPUT",
 		"iptables -t nat -A ISTIO_OUTPUT -o lo -s 127.0.0.6/32 -j RETURN",
 		"iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 3 -j ISTIO_IN_REDIRECT",
 		"iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner 3 -j RETURN",
@@ -697,6 +703,12 @@ func TestRulesWithLoopbackIpInOutboundIpRanges(t *testing.T) {
 		"iptables -t nat -A ISTIO_OUTPUT -d 127.0.0.1/32 -j RETURN",
 		"iptables -t nat -A ISTIO_OUTPUT -d 127.1.2.3/32 -j ISTIO_REDIRECT",
 		"iptables -t nat -A ISTIO_OUTPUT -j RETURN",
+		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --uid-owner 3 -j RETURN",
+		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --uid-owner 4 -j RETURN",
+		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --gid-owner 1 -j RETURN",
+		"iptables -t nat -A OUTPUT -p udp --dport 53 -m owner --gid-owner 2 -j RETURN",
+		"iptables -t nat -A OUTPUT -p udp --dport 53 -j DNAT --to-destination 127.0.0.1:15013",
+		"iptables -t nat -A POSTROUTING -p udp --dport 15013 -j SNAT --to-source 127.0.0.1",
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Output mismatch. Expected: \n%#v ; Actual: \n%#v", expected, actual)


### PR DESCRIPTION
Note: compared to master, dns capture for all k8s pods (in tests)
has been disabled in this branch.

This PR contains fixes to iptables setups that currently exists in release-1.7
for the DNS capture functionality.

There will be another followup PR that will remove the ndots change as well.