### PR TITLE
[manual cherry-pick] Add credential fetcher in istio agent (#25614)

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -52,6 +52,7 @@ import (
 	"istio.io/istio/pkg/jwt"
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/util/gogoprotomarshal"
+	"istio.io/istio/security/pkg/credentialfetcher"
 	citadel "istio.io/istio/security/pkg/nodeagent/caclient/providers/citadel"
 	stsserver "istio.io/istio/security/pkg/stsservice/server"
 	"istio.io/istio/security/pkg/stsservice/tokenmanager"
@@ -144,6 +145,8 @@ var (
 	eccSigAlgEnv        = env.RegisterStringVar("ECC_SIGNATURE_ALGORITHM", "", "The type of ECC signature algorithm to use when generating private keys").Get()
 	fileMountedCertsEnv = env.RegisterBoolVar("FILE_MOUNTED_CERTS", false, "").Get()
 	useTokenForCSREnv   = env.RegisterBoolVar("USE_TOKEN_FOR_CSR", false, "CSR requires a token").Get()
+	credFetcherTypeEnv  = env.RegisterStringVar("CREDENTIAL_FETCHER_TYPE", "",
+		"The type of the credential fetcher. Currently supported types include GoogleComputeEngine").Get()
 
 	rootCmd = &cobra.Command{
 		Use:          "pilot-agent",
@@ -261,6 +264,7 @@ var (
 				FileMountedCerts:   fileMountedCertsEnv,
 				CAEndpoint:         caEndpointEnv,
 				UseTokenForCSR:     useTokenForCSREnv,
+				CredFetcher:        nil,
 			}
 			secOpts.PluginNames = strings.Split(pluginNamesEnv, ",")
 
@@ -281,8 +285,16 @@ var (
 			secOpts.InitialBackoffInMilliSec = int64(initialBackoffInMilliSecEnv)
 			// Disable the secret eviction for istio agent.
 			secOpts.EvictionDuration = 0
-			if citadel.ProvCert != "" {
-				secOpts.AlwaysValidTokenFlag = true
+
+			// TODO (liminw): CredFetcher is a general interface. In 1.7, we limit the use on GCE only because
+			// GCE is the only supported plugin at the moment.
+			if credFetcherTypeEnv == security.GCE {
+				credFetcher, err := credentialfetcher.NewCredFetcher(credFetcherTypeEnv, secOpts.TrustDomain, jwtPath)
+				if err != nil {
+					return fmt.Errorf("failed to create credential fetcher: %v", err)
+				}
+				log.Infof("Start credential fetcher of %s type in %s trust domain", credFetcherTypeEnv, secOpts.TrustDomain)
+				secOpts.CredFetcher = credFetcher
 			}
 
 			sa := istio_agent.NewAgent(&proxyConfig,
@@ -342,7 +354,7 @@ var (
 					localHostAddr = localHostIPv6
 				}
 				tokenManager := tokenmanager.CreateTokenManager(tokenManagerPlugin,
-					tokenmanager.Config{TrustDomain: trustDomain})
+					tokenmanager.Config{CredFetcher: secOpts.CredFetcher, TrustDomain: secOpts.TrustDomain})
 				stsServer, err := stsserver.NewServer(stsserver.Config{
 					LocalHostAddr: localHostAddr,
 					LocalPort:     stsPort,

--- a/pkg/istio-agent/sds-agent.go
+++ b/pkg/istio-agent/sds-agent.go
@@ -31,7 +31,6 @@ import (
 
 	"istio.io/istio/pilot/pkg/security/model"
 	"istio.io/istio/pkg/kube"
-
 	"istio.io/istio/security/pkg/nodeagent/cache"
 	citadel "istio.io/istio/security/pkg/nodeagent/caclient/providers/citadel"
 	gca "istio.io/istio/security/pkg/nodeagent/caclient/providers/google"
@@ -136,15 +135,15 @@ type AgentConfig struct {
 	LocalXDSAddr string
 }
 
-// NewSDSAgent wraps the logic for a local SDS. It will check if the JWT token required for local SDS is
+// NewAgent wraps the logic for a local SDS. It will check if the JWT token required for local SDS is
 // present, and set additional config options for the in-process SDS agent.
 //
 // The JWT token is currently using a pre-defined audience (istio-ca) or it must match the trust domain (WIP).
-// If the JWT token is not present - the local SDS agent can't authenticate.
+// If the JWT token is not present, and cannot be fetched through the credential fetcher - the local SDS agent can't authenticate.
 //
 // If node agent and JWT are mounted: it indicates user injected a config using hostPath, and will be used.
-//
-func NewAgent(proxyConfig *mesh.ProxyConfig, cfg *AgentConfig, sopts *security.Options) *Agent {
+func NewAgent(proxyConfig *mesh.ProxyConfig, cfg *AgentConfig,
+	sopts *security.Options) *Agent {
 	sa := &Agent{
 		proxyConfig: proxyConfig,
 		cfg:         cfg,
@@ -164,12 +163,8 @@ func NewAgent(proxyConfig *mesh.ProxyConfig, cfg *AgentConfig, sopts *security.O
 	// - if PROV_CERT is set, it'll be included in the TLS context sent to the server
 	//   This is a 'provisioning certificate' - long lived, managed by a tool, exchanged for
 	//   the short lived certs.
-	// - if a JWTPath token exists, will be included in the request.
+	// - if a JWTPath token exists, or can be fetched by credential fetcher, it will be included in the request.
 
-	if _, err := os.Stat(sa.secOpts.JWTPath); err != nil {
-		log.Warna("Missing JWT token ", sa.secOpts.JWTPath)
-		sa.secOpts.JWTPath = ""
-	}
 	// If original /etc/certs or a separate 'provisioning certs' (VM) are present,
 	// add them to the tlsContext. If server asks for them and they exist - will be provided.
 	certDir := "./etc/certs"

--- a/security/pkg/credentialfetcher/fetcher.go
+++ b/security/pkg/credentialfetcher/fetcher.go
@@ -1,0 +1,34 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// credentailfetcher fetches workload credentials through platform plugins.
+package credentialfetcher
+
+import (
+	"fmt"
+
+	"istio.io/istio/pkg/security"
+	"istio.io/istio/security/pkg/credentialfetcher/plugin"
+)
+
+func NewCredFetcher(credtype, trustdomain, jwtPath string) (security.CredFetcher, error) {
+	switch credtype {
+	case security.GCE:
+		return plugin.CreateGCEPlugin(trustdomain, jwtPath), nil
+	case security.Mock: // for test only
+		return plugin.CreateMockPlugin(), nil
+	default:
+		return nil, fmt.Errorf("invalid credential fetcher type %s", credtype)
+	}
+}

--- a/security/pkg/credentialfetcher/fetcher_test.go
+++ b/security/pkg/credentialfetcher/fetcher_test.go
@@ -1,0 +1,86 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package credentialfetcher
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/security"
+)
+
+func TestNewCredFetcher(t *testing.T) {
+	testCases := map[string]struct {
+		fetcherType   string
+		trustdomain   string
+		jwtPath       string
+		expectedErr   string
+		expectedToken string
+		expectedIdp   string
+	}{
+		"gce test": {
+			fetcherType:   security.GCE,
+			trustdomain:   "abc.svc.id.goog",
+			jwtPath:       "/var/run/secrets/tokens/istio-token",
+			expectedErr:   "", // No error when ID token auth is enabled.
+			expectedToken: "",
+			expectedIdp:   "GoogleComputeEngine",
+		},
+		"mock test": {
+			fetcherType:   security.Mock,
+			trustdomain:   "",
+			jwtPath:       "",
+			expectedErr:   "",
+			expectedToken: "test_token",
+			expectedIdp:   "fakeIDP",
+		},
+		"invalid test": {
+			fetcherType:   "foo",
+			trustdomain:   "",
+			jwtPath:       "",
+			expectedErr:   "invalid credential fetcher type foo",
+			expectedToken: "",
+			expectedIdp:   "",
+		},
+	}
+
+	for id, tc := range testCases {
+		cf, err := NewCredFetcher(
+			tc.fetcherType, tc.trustdomain, tc.jwtPath)
+		if len(tc.expectedErr) > 0 {
+			if err == nil {
+				t.Errorf("%s: succeeded. Error expected: %v", id, err)
+			} else if err.Error() != tc.expectedErr {
+				t.Errorf("%s: incorrect error message: %s VS %s",
+					id, err.Error(), tc.expectedErr)
+			}
+			continue
+		} else if err != nil {
+			t.Errorf("%s: unexpected Error: %v", id, err)
+		}
+		idp := cf.GetIdentityProvider()
+		if idp != tc.expectedIdp {
+			t.Errorf("%s: GetIdentityProvider returned %s, expected %s", id, idp, tc.expectedIdp)
+		}
+		if tc.fetcherType == security.Mock {
+			token, err := cf.GetPlatformCredential()
+			if err != nil {
+				t.Errorf("%s: unexpected error calling GetPlatformCredential: %v", id, err)
+			}
+			if token != tc.expectedToken {
+				t.Errorf("%s: GetPlatformCredential returned %s, expected %s", id, token, tc.expectedToken)
+			}
+		}
+	}
+}

--- a/security/pkg/credentialfetcher/plugin/gce.go
+++ b/security/pkg/credentialfetcher/plugin/gce.go
@@ -1,0 +1,84 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is Google plugin of credentialfetcher.
+package plugin
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"cloud.google.com/go/compute/metadata"
+
+	"istio.io/istio/pkg/security"
+	"istio.io/pkg/log"
+)
+
+var (
+	gcecredLog = log.RegisterScope("gcecred", "GCE credential fetcher for istio agent", 0)
+)
+
+// The plugin object.
+type GCEPlugin struct {
+	// aud is the unique URI agreed upon by both the instance and the system verifying the instance's identity.
+	// For more info: https://cloud.google.com/compute/docs/instances/verifying-instance-identity
+	aud string
+
+	// The location to save the identity token
+	jwtPath string
+}
+
+// CreateGCEPlugin creates a Google credential fetcher plugin. Return the pointer to the created plugin.
+func CreateGCEPlugin(audience, jwtPath string) *GCEPlugin {
+	p := &GCEPlugin{
+		aud:     audience,
+		jwtPath: jwtPath,
+	}
+	return p
+}
+
+// GetPlatformCredential fetches the GCE VM identity jwt token from its metadata server,
+// and write it to jwtPath. The local copy of the token in jwtPath is used by both
+// Envoy STS client and istio agent to fetch certificate and access token.
+// Note: this function only works in a GCE VM environment.
+func (p *GCEPlugin) GetPlatformCredential() (string, error) {
+	if p.jwtPath == "" {
+		return "", fmt.Errorf("jwtPath is unset")
+	}
+	uri := fmt.Sprintf("instance/service-accounts/default/identity?audience=%s&format=full", p.aud)
+	token, err := metadata.Get(uri)
+	if err != nil {
+		gcecredLog.Errorf("Failed to get vm identity token from metadata server: %v", err)
+		return "", err
+	}
+	gcecredLog.Debugf("Got GCE identity token: %d", len(token))
+	tokenbytes := []byte(token)
+	err = ioutil.WriteFile(p.jwtPath, tokenbytes, 0600)
+	if err != nil {
+		gcecredLog.Errorf("Encountered error when writing vm identity token: %v", err)
+		return "", err
+	}
+	return token, nil
+}
+
+// GetType returns credential fetcher type.
+func (p *GCEPlugin) GetType() string {
+	return security.GCE
+}
+
+// GetIdentityProvider returns the name of the identity provider that can authenticate the workload credential.
+// GCE idenity provider is named "GoogleComputeEngine".
+func (p *GCEPlugin) GetIdentityProvider() string {
+	return security.GCE
+}

--- a/security/pkg/credentialfetcher/plugin/mock.go
+++ b/security/pkg/credentialfetcher/plugin/mock.go
@@ -1,0 +1,52 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Test only: this is the mock plugin of credentialfetcher.
+package plugin
+
+import (
+	"istio.io/pkg/log"
+
+	"istio.io/istio/pkg/security"
+)
+
+var (
+	mockcredLog = log.RegisterScope("mockcred", "Mock credential fetcher for istio agent", 0)
+)
+
+// The plugin object.
+type MockPlugin struct {
+}
+
+// CreateMockPlugin creates a mock credential fetcher plugin. Return the pointer to the created plugin.
+func CreateMockPlugin() *MockPlugin {
+	p := &MockPlugin{}
+	return p
+}
+
+// GetPlatformCredential returns a constant token string.
+func (p *MockPlugin) GetPlatformCredential() (string, error) {
+	mockcredLog.Debugf("mock plugin returns a constant token.")
+	return "test_token", nil
+}
+
+// GetType returns credential fetcher type.
+func (p *MockPlugin) GetType() string {
+	return security.Mock
+}
+
+// GetIdentityProvider returns the name of the identity provider that can authenticate the workload credential.
+func (p *MockPlugin) GetIdentityProvider() string {
+	return "fakeIDP"
+}

--- a/security/pkg/nodeagent/cache/mock/secretcache_mock.go
+++ b/security/pkg/nodeagent/cache/mock/secretcache_mock.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"istio.io/istio/pkg/security"
 	"istio.io/istio/security/pkg/pki/util"
 )
 
@@ -120,7 +121,7 @@ func NewMockTokenExchangeServer(errors uint64) *TokenExchangeServer {
 }
 
 // ExchangeToken returns a dumb token or errors depending on the settings.
-func (s *TokenExchangeServer) ExchangeToken(context.Context, string, string) (string, time.Time, int, error) {
+func (s *TokenExchangeServer) ExchangeToken(context.Context, security.CredFetcher, string, string) (string, time.Time, int, error) {
 	s.errorCountMutex.Lock()
 	if s.errorCount < s.errors {
 		s.errorCount++

--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -218,8 +218,6 @@ func testWorkloadAgentGenerateSecret(t *testing.T, isUsingPluginProvider bool) {
 		sc.Close()
 	}()
 
-	checkBool(t, "opt.AlwaysValidTokenFlag default", opt.AlwaysValidTokenFlag, false)
-
 	conID := "proxy1-id"
 	ctx := context.Background()
 	gotSecret, err := sc.GenerateSecret(ctx, conID, WorkloadKeyCertResourceName, "jwtToken1")
@@ -231,8 +229,8 @@ func testWorkloadAgentGenerateSecret(t *testing.T, isUsingPluginProvider bool) {
 		t.Errorf("Got unexpected certificate chain #1. Got: %v, want: %v", string(got), string(want))
 	}
 
-	checkBool(t, "SecretExist", sc.SecretExist(conID, WorkloadKeyCertResourceName, "jwtToken1", gotSecret.Version), true)
-	checkBool(t, "SecretExist", sc.SecretExist(conID, WorkloadKeyCertResourceName, "nonexisttoken", gotSecret.Version), false)
+	checkBool(t, sc.SecretExist(conID, WorkloadKeyCertResourceName, "jwtToken1", gotSecret.Version), true)
+	checkBool(t, sc.SecretExist(conID, WorkloadKeyCertResourceName, "nonexisttoken", gotSecret.Version), false)
 
 	gotSecretRoot, err := sc.GenerateSecret(ctx, conID, RootCertReqResourceName, "jwtToken1")
 	if err != nil {
@@ -243,8 +241,8 @@ func testWorkloadAgentGenerateSecret(t *testing.T, isUsingPluginProvider bool) {
 		t.Errorf("Got unexpected root certificate. Got: %v\n want: %v", string(got), string(want))
 	}
 
-	checkBool(t, "SecretExist", sc.SecretExist(conID, RootCertReqResourceName, "jwtToken1", gotSecretRoot.Version), true)
-	checkBool(t, "SecretExist", sc.SecretExist(conID, RootCertReqResourceName, "nonexisttoken", gotSecretRoot.Version), false)
+	checkBool(t, sc.SecretExist(conID, RootCertReqResourceName, "jwtToken1", gotSecretRoot.Version), true)
+	checkBool(t, sc.SecretExist(conID, RootCertReqResourceName, "nonexisttoken", gotSecretRoot.Version), false)
 
 	if got, want := atomic.LoadUint64(&sc.rootCertChangedCount), uint64(0); got != want {
 		t.Errorf("Got unexpected rootCertChangedCount: Got: %v\n want: %v", got, want)
@@ -400,8 +398,8 @@ func TestGatewayAgentGenerateSecret(t *testing.T) {
 				if err := verifySecret(gotSecret, es.secret); err != nil {
 					t.Errorf("Secret verification failed: %v", err)
 				}
-				checkBool(t, "SecretExist", sc.SecretExist(c.connID, es.secret.ResourceName, "", gotSecret.Version), true)
-				checkBool(t, "SecretExist", sc.SecretExist(c.connID, "nonexistsecret", "", gotSecret.Version), false)
+				checkBool(t, sc.SecretExist(c.connID, es.secret.ResourceName, "", gotSecret.Version), true)
+				checkBool(t, sc.SecretExist(c.connID, "nonexistsecret", "", gotSecret.Version), false)
 			}
 			key := ConnKey{
 				ConnectionID: c.connID,
@@ -683,32 +681,32 @@ func TestGatewayAgentDeleteSecret(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}
-	checkBool(t, "SecretExist", sc.SecretExist(connID, k8sGenericSecretName, "", gotSecret.Version), true)
+	checkBool(t, sc.SecretExist(connID, k8sGenericSecretName, "", gotSecret.Version), true)
 
 	gotSecret, err = sc.GenerateSecret(ctx, connID, k8sGenericSecretName+"-cacert", "")
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}
-	checkBool(t, "SecretExist", sc.SecretExist(connID, k8sGenericSecretName+"-cacert", "", gotSecret.Version), true)
+	checkBool(t, sc.SecretExist(connID, k8sGenericSecretName+"-cacert", "", gotSecret.Version), true)
 
 	gotSecret, err = sc.GenerateSecret(ctx, connID, k8sTLSSecretName, "")
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}
-	checkBool(t, "SecretExist", sc.SecretExist(connID, k8sTLSSecretName, "", gotSecret.Version), true)
+	checkBool(t, sc.SecretExist(connID, k8sTLSSecretName, "", gotSecret.Version), true)
 
 	_, err = sc.GenerateSecret(ctx, connID, k8sTLSSecretName+"-cacert", "")
 	if err == nil {
 		t.Fatalf("Get unexpected secrets: %v", err)
 	}
-	checkBool(t, "SecretExist", sc.SecretExist(connID, k8sTLSSecretName+"-cacert", "", gotSecret.Version), false)
+	checkBool(t, sc.SecretExist(connID, k8sTLSSecretName+"-cacert", "", gotSecret.Version), false)
 
 	sc.DeleteK8sSecret(k8sGenericSecretName)
 	sc.DeleteK8sSecret(k8sGenericSecretName + "-cacert")
 	sc.DeleteK8sSecret(k8sTLSSecretName)
-	checkBool(t, "SecretExist", sc.SecretExist(connID, k8sGenericSecretName, "", gotSecret.Version), false)
-	checkBool(t, "SecretExist", sc.SecretExist(connID, k8sGenericSecretName+"-cacert", "", gotSecret.Version), false)
-	checkBool(t, "SecretExist", sc.SecretExist(connID, k8sTLSSecretName, "", gotSecret.Version), false)
+	checkBool(t, sc.SecretExist(connID, k8sGenericSecretName, "", gotSecret.Version), false)
+	checkBool(t, sc.SecretExist(connID, k8sGenericSecretName+"-cacert", "", gotSecret.Version), false)
+	checkBool(t, sc.SecretExist(connID, k8sTLSSecretName, "", gotSecret.Version), false)
 }
 
 // TestGatewayAgentUpdateSecret verifies that ingress gateway agent updates secret cache correctly.
@@ -726,12 +724,12 @@ func TestGatewayAgentUpdateSecret(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}
-	checkBool(t, "SecretExist", sc.SecretExist(connID, k8sGenericSecretName, "", gotSecret.Version), true)
+	checkBool(t, sc.SecretExist(connID, k8sGenericSecretName, "", gotSecret.Version), true)
 	gotSecret, err = sc.GenerateSecret(ctx, connID, k8sGenericSecretName+"-cacert", "")
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}
-	checkBool(t, "SecretExist", sc.SecretExist(connID, k8sGenericSecretName+"-cacert", "", gotSecret.Version), true)
+	checkBool(t, sc.SecretExist(connID, k8sGenericSecretName+"-cacert", "", gotSecret.Version), true)
 	newTime := gotSecret.CreatedTime.Add(time.Duration(10) * time.Second)
 	newK8sTestSecret := security.SecretItem{
 		CertificateChain: []byte("new cert chain"),
@@ -743,9 +741,9 @@ func TestGatewayAgentUpdateSecret(t *testing.T) {
 		Version:          newTime.String(),
 	}
 	sc.UpdateK8sSecret(k8sGenericSecretName, newK8sTestSecret)
-	checkBool(t, "SecretExist", sc.SecretExist(connID, k8sGenericSecretName, "", gotSecret.Version), false)
+	checkBool(t, sc.SecretExist(connID, k8sGenericSecretName, "", gotSecret.Version), false)
 	sc.UpdateK8sSecret(k8sGenericSecretName+"-cacert", newK8sTestSecret)
-	checkBool(t, "SecretExist", sc.SecretExist(connID, k8sGenericSecretName+"-cacert", "", gotSecret.Version), false)
+	checkBool(t, sc.SecretExist(connID, k8sGenericSecretName+"-cacert", "", gotSecret.Version), false)
 }
 
 func TestConstructCSRHostName(t *testing.T) {
@@ -797,18 +795,10 @@ func TestConstructCSRHostName(t *testing.T) {
 	}
 }
 
-func checkBool(t *testing.T, name string, got bool, want bool) {
+func checkBool(t *testing.T, got bool, want bool) {
 	if got != want {
-		t.Errorf("%s: got: %v, want: %v", name, got, want)
+		t.Errorf("SecretExist: got: %v, want: %v", got, want)
 	}
-}
-
-func TestSetAlwaysValidTokenFlag(t *testing.T) {
-	sc := createSecretCache()
-	defer sc.Close()
-	sc.configOptions.AlwaysValidTokenFlag = true
-	secret := security.SecretItem{}
-	checkBool(t, "isTokenExpired", sc.isTokenExpired(&secret), false)
 }
 
 func TestRootCertificateExists(t *testing.T) {
@@ -883,6 +873,7 @@ func TestWorkloadAgentGenerateSecretFromFile(t *testing.T) {
 	opt := &security.Options{
 		RotationInterval: 200 * time.Millisecond,
 		EvictionDuration: 0,
+		UseTokenForCSR:   true,
 	}
 
 	fetcher := &secretfetcher.SecretFetcher{
@@ -947,7 +938,7 @@ func TestWorkloadAgentGenerateSecretFromFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}
-	checkBool(t, "SecretExist", sc.SecretExist(conID, WorkloadKeyCertResourceName, "jwtToken1", gotSecret.Version), true)
+	checkBool(t, sc.SecretExist(conID, WorkloadKeyCertResourceName, "jwtToken1", gotSecret.Version), true)
 	expectedSecret := &security.SecretItem{
 		ResourceName:     WorkloadKeyCertResourceName,
 		CertificateChain: certchain,
@@ -968,7 +959,7 @@ func TestWorkloadAgentGenerateSecretFromFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}
-	checkBool(t, "SecretExist", sc.SecretExist(conID, RootCertReqResourceName, "jwtToken1", gotSecretRoot.Version), true)
+	checkBool(t, sc.SecretExist(conID, RootCertReqResourceName, "jwtToken1", gotSecretRoot.Version), true)
 	if got, want := atomic.LoadUint64(&sc.rootCertChangedCount), uint64(0); got != want {
 		t.Errorf("rootCertChangedCount: got: %v, want: %v", got, want)
 	}
@@ -1070,7 +1061,7 @@ func TestWorkloadAgentGenerateSecretFromFileOverSds(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}
-	checkBool(t, "SecretExist", sc.SecretExist(conID, resource, "jwtToken1", gotSecret.Version), true)
+	checkBool(t, sc.SecretExist(conID, resource, "jwtToken1", gotSecret.Version), true)
 	expectedSecret := &security.SecretItem{
 		ResourceName:     resource,
 		CertificateChain: certchain,
@@ -1091,7 +1082,7 @@ func TestWorkloadAgentGenerateSecretFromFileOverSds(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}
-	checkBool(t, "SecretExist", sc.SecretExist(conID, rootResource, "jwtToken1", gotSecretRoot.Version), true)
+	checkBool(t, sc.SecretExist(conID, rootResource, "jwtToken1", gotSecretRoot.Version), true)
 	if got, want := atomic.LoadUint64(&sc.rootCertChangedCount), uint64(0); got != want {
 		t.Errorf("rootCertChangedCount: got: %v, want: %v", got, want)
 	}
@@ -1142,7 +1133,6 @@ func TestWorkloadAgentGenerateSecretFromFileOverSdsWithBogusFiles(t *testing.T) 
 		RotationInterval: 1 * time.Millisecond,
 		EvictionDuration: 0,
 	}
-
 	sc := NewSecretCache(fetcher, notifyCb, opt)
 	defer func() {
 		sc.Close()

--- a/security/pkg/nodeagent/plugin/providers/google/stsclient/stsclient_test.go
+++ b/security/pkg/nodeagent/plugin/providers/google/stsclient/stsclient_test.go
@@ -37,7 +37,7 @@ func TestGetFederatedToken(t *testing.T) {
 		SecureTokenEndpoint = "https://securetoken.googleapis.com/v1/identitybindingtoken"
 	}()
 
-	token, _, _, err := r.ExchangeToken(context.Background(), mock.FakeTrustDomain, mock.FakeSubjectToken)
+	token, _, _, err := r.ExchangeToken(context.Background(), nil, mock.FakeTrustDomain, mock.FakeSubjectToken)
 	if err != nil {
 		t.Fatalf("failed to call exchange token %v", err)
 	}

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -32,7 +32,8 @@ import (
 
 	"istio.io/istio/pilot/pkg/xds"
 	"istio.io/istio/pkg/security"
-	"istio.io/istio/security/pkg/nodeagent/util"
+	nodeagentutil "istio.io/istio/security/pkg/nodeagent/util"
+	"istio.io/istio/security/pkg/util"
 
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	sds "github.com/envoyproxy/go-control-plane/envoy/service/secret/v3"
@@ -132,6 +133,9 @@ type sdsservice struct {
 	jwtPath string
 
 	outputKeyCertToDir string
+
+	// Credential fetcher
+	credFetcher security.CredFetcher
 }
 
 // ClientDebug represents a single SDS connection to the ndoe agent
@@ -169,6 +173,7 @@ func newSDSService(st security.SecretManager,
 		localJWT:             secOpt.UseLocalJWT,
 		jwtPath:              secOpt.JWTPath,
 		outputKeyCertToDir:   secOpt.OutputKeyCertToDir,
+		credFetcher:          secOpt.CredFetcher,
 	}
 
 	go ret.clearStaledClientsJob()
@@ -286,12 +291,12 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 			conIDresourceNamePrefix := sdsLogPrefix(resourceName)
 			if s.localJWT {
 				// Running in-process, no need to pass the token from envoy to agent as in-context - use the file
-				tok, err := ioutil.ReadFile(s.jwtPath)
+				t, err := s.getToken()
 				if err != nil {
 					sdsServiceLog.Errorf("Failed to get credential token: %v", err)
 					return err
 				}
-				token = string(tok)
+				token = t
 			} else if s.outputKeyCertToDir != "" {
 				// Using existing certs and the new SDS - skipToken case is for the old node agent.
 			} else if !s.skipToken {
@@ -350,7 +355,7 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 			}
 
 			// Output the key and cert to a directory, if some applications need to read them from local file system.
-			if err = util.OutputKeyCertToDir(s.outputKeyCertToDir, secret.PrivateKey,
+			if err = nodeagentutil.OutputKeyCertToDir(s.outputKeyCertToDir, secret.PrivateKey,
 				secret.CertificateChain, secret.RootCert); err != nil {
 				sdsServiceLog.Errorf("(%v, %v) error when output the key and cert: %v",
 					conIDresourceNamePrefix, discReq.Node.Id, err)
@@ -400,13 +405,12 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 func (s *sdsservice) FetchSecrets(ctx context.Context, discReq *discovery.DiscoveryRequest) (*discovery.DiscoveryResponse, error) {
 	token := ""
 	if s.localJWT {
-		// Running in-process, no need to pass the token from envoy to agent as in-context - use the file
-		tok, err := ioutil.ReadFile(s.jwtPath)
+		t, err := s.getToken()
 		if err != nil {
 			sdsServiceLog.Errorf("Failed to get credential token: %v", err)
 			return nil, err
 		}
-		token = string(tok)
+		token = t
 	} else if !s.skipToken {
 		t, err := getCredentialToken(ctx)
 		if err != nil {
@@ -430,13 +434,46 @@ func (s *sdsservice) FetchSecrets(ctx context.Context, discReq *discovery.Discov
 	}
 
 	// Output the key and cert to a directory, if some applications need to read them from local file system.
-	if err = util.OutputKeyCertToDir(s.outputKeyCertToDir, secret.PrivateKey,
+	if err = nodeagentutil.OutputKeyCertToDir(s.outputKeyCertToDir, secret.PrivateKey,
 		secret.CertificateChain, secret.RootCert); err != nil {
 		sdsServiceLog.Errorf("(%v) error when output the key and cert: %v",
 			connID, err)
 		return nil, err
 	}
 	return sdsDiscoveryResponse(secret, resourceName, discReq.TypeUrl)
+}
+
+func (s *sdsservice) getToken() (string, error) {
+	token := ""
+	needRenew := false
+	tok, err := ioutil.ReadFile(s.jwtPath)
+	if err != nil {
+		sdsServiceLog.Errorf("failed to get credential token: %v from path %s", err, s.jwtPath)
+		needRenew = true
+	} else {
+		tokenExpired, err := util.IsJwtExpired(string(tok), time.Now())
+		if err != nil || tokenExpired {
+			sdsServiceLog.Errorf("JWT expiration checking error: %v or token is expired %v", err, tokenExpired)
+			needRenew = true
+		} else {
+			// We have a valid token.
+			token = string(tok)
+			return token, nil
+		}
+	}
+	if needRenew {
+		if s.credFetcher != nil {
+			t, err := s.credFetcher.GetPlatformCredential()
+			if err != nil {
+				sdsServiceLog.Errorf("Failed to get credential token through credential fetcher: %v", err)
+				return "", err
+			}
+			token = t
+		} else {
+			return "", fmt.Errorf("failed to read token from path %s and cannot renew token", s.jwtPath)
+		}
+	}
+	return token, nil
 }
 
 func (s *sdsservice) Stop() {

--- a/security/pkg/nodeagent/test/setup.go
+++ b/security/pkg/nodeagent/test/setup.go
@@ -39,7 +39,12 @@ import (
 
 const (
 	proxyTokenPath = "/tmp/sds-envoy-token.jwt"
-	jwtToken       = "thisisafakejwt"
+	jwtToken       = "eyJhbGciOiJSUzI1NiIsImtpZCI6IkRIRmJwb0lVcXJZOHQyenBBMnFYZkNtcjVWTzVaRXI0UnpIVV8tZW52dlEiLCJ0eXAiOiJKV1QifQ." +
+		"eyJleHAiOjQ2ODU5ODk3MDAsImZvbyI6ImJhciIsImlhdCI6MTUzMjM4OTcwMCwiaXNzIjoidGVzdGluZ0BzZWN1cmUuaXN0aW8uaW8iLCJzdWIiOiJ0ZX" +
+		"N0aW5nQHNlY3VyZS5pc3Rpby5pbyJ9.CfNnxWP2tcnR9q0vxyxweaF3ovQYHYZl82hAUsn21bwQd9zP7c-LS9qd_vpdLG4Tn1A15NxfCjp5f7QNBUo-KC9" +
+		"PJqYpgGbaXhaGx7bEdFWjcwv3nZzvc7M__ZpaCERdwU7igUmJqYGBYQ51vr2njU9ZimyKkfDe3axcyiBZde7G6dabliUosJvvKOPcKIWPccCgefSj_GNfw" +
+		"Iip3-SsFdlR7BtbVUcqR-yv-XOxJ3Uc1MI0tz3uMiiZcyPV7sNCU4KRnemRIMHVOfuvHsU60_GhGbiSFzgPTAa9WTltbnarTbxudb_YEOx12JiwYToeX0D" +
+		"CPb43W1tzIBxgm8NxUg"
 )
 
 var rotateCertInterval time.Duration

--- a/security/pkg/stsservice/test/setup.go
+++ b/security/pkg/stsservice/test/setup.go
@@ -241,7 +241,7 @@ func (e *Env) genStsReq(stsAddr string) (req *http.Request) {
 
 func setupSTS(stsPort int, backendURL string, enableCache bool) (*stsServer.Server, *google.Plugin, error) {
 	// Create token exchange Google plugin
-	tokenExchangePlugin, _ := google.CreateTokenManagerPlugin(tokenBackend.FakeTrustDomain,
+	tokenExchangePlugin, _ := google.CreateTokenManagerPlugin(nil, tokenBackend.FakeTrustDomain,
 		tokenBackend.FakeProjectNum, tokenBackend.FakeGKEClusterURL, enableCache)
 	federatedTokenTestingEndpoint := backendURL + "/v1/identitybindingtoken"
 	accessTokenTestingEndpoint := backendURL + "/v1/projects/-/serviceAccounts/service-%s@gcp-sa-meshdataplane.iam.gserviceaccount.com:generateAccessToken"

--- a/security/pkg/stsservice/tokenmanager/google/tokenexchangeplugin.go
+++ b/security/pkg/stsservice/tokenmanager/google/tokenexchangeplugin.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 	"time"
 
+	"istio.io/istio/pkg/security"
 	"istio.io/istio/security/pkg/stsservice"
 	"istio.io/pkg/log"
 )
@@ -50,11 +51,13 @@ var (
 	// default grace period in seconds of an access token. If caching is enabled and token remaining life time is
 	// within this period, refresh access token.
 	defaultGracePeriod = 300
+	GCEProvider        = "GoogleComputeEngine"
 )
 
 // Plugin supports token exchange with Google OAuth 2.0 authorization server.
 type Plugin struct {
 	httpClient  *http.Client
+	credFetcher security.CredFetcher
 	trustDomain string
 	// tokens is the cache for fetched tokens.
 	// map key is token type, map value is tokenInfo.
@@ -69,7 +72,7 @@ type Plugin struct {
 }
 
 // CreateTokenManagerPlugin creates a plugin that fetches token from a Google OAuth 2.0 authorization server.
-func CreateTokenManagerPlugin(trustDomain, gcpProjectNumber, gkeClusterURL string, enableCache bool) (*Plugin, error) {
+func CreateTokenManagerPlugin(credFetcher security.CredFetcher, trustDomain, gcpProjectNumber, gkeClusterURL string, enableCache bool) (*Plugin, error) {
 	caCertPool, err := x509.SystemCertPool()
 	if err != nil {
 		pluginLog.Errorf("Failed to get SystemCertPool: %v", err)
@@ -84,6 +87,7 @@ func CreateTokenManagerPlugin(trustDomain, gcpProjectNumber, gkeClusterURL strin
 				},
 			},
 		},
+		credFetcher:      credFetcher,
 		trustDomain:      trustDomain,
 		gcpProjectNumber: gcpProjectNumber,
 		gkeClusterURL:    gkeClusterURL,
@@ -151,12 +155,26 @@ func (p *Plugin) useCachedToken() ([]byte, bool) {
 	return nil, false
 }
 
+// Construct the audience field for GetFederatedToken request.
+func (p *Plugin) constructAudience() string {
+	provider := ""
+	if p.credFetcher != nil {
+		provider = p.credFetcher.GetIdentityProvider()
+	}
+	// For GKE, we do not register IdentityProvider explicitly. The provider name
+	// is GKEClusterURL by default.
+	if provider == "" {
+		provider = p.gkeClusterURL
+	}
+	return fmt.Sprintf("identitynamespace:%s:%s", p.trustDomain, provider)
+}
+
 // constructFederatedTokenRequest returns an HTTP request for federated token.
 // Example of a federated token request:
 // POST https://securetoken.googleapis.com/v1/identitybindingtoken
 // Content-Type: application/json
 // {
-//    audience: <trust domain>
+//    audience: <trust domain>:<provider>
 //    grantType: urn:ietf:params:oauth:grant-type:token-exchange
 //    requestedTokenType: urn:ietf:params:oauth:token-type:access_token
 //    subjectTokenType: urn:ietf:params:oauth:token-type:jwt
@@ -168,7 +186,7 @@ func (p *Plugin) constructFederatedTokenRequest(parameters stsservice.StsRequest
 	if len(parameters.Scope) != 0 {
 		reqScope = parameters.Scope
 	}
-	aud := fmt.Sprintf("identitynamespace:%s:%s", p.trustDomain, p.gkeClusterURL)
+	aud := p.constructAudience()
 	query := map[string]string{
 		"audience":           aud,
 		"grantType":          parameters.GrantType,

--- a/security/pkg/stsservice/tokenmanager/google/tokenexchangeplugin_test.go
+++ b/security/pkg/stsservice/tokenmanager/google/tokenexchangeplugin_test.go
@@ -142,7 +142,7 @@ type testSetUp struct {
 
 // setUpTest sets up token manager, authorization server.
 func setUpTest(t *testing.T, setup testSetUp) (*Plugin, *mock.AuthorizationServer, string, string) {
-	tm, _ := CreateTokenManagerPlugin(mock.FakeTrustDomain, mock.FakeProjectNum, mock.FakeGKEClusterURL, setup.enableCache)
+	tm, _ := CreateTokenManagerPlugin(nil, mock.FakeTrustDomain, mock.FakeProjectNum, mock.FakeGKEClusterURL, setup.enableCache)
 	ms, err := mock.StartNewServer(t, mock.Config{Port: 0})
 	ms.EnableDynamicAccessToken(setup.enableDynamicToken)
 	if err != nil {

--- a/security/pkg/stsservice/tokenmanager/sts_test.go
+++ b/security/pkg/stsservice/tokenmanager/sts_test.go
@@ -122,7 +122,7 @@ func TestStsTokenSource(t *testing.T) {
 			ts := NewTokenSource(mock.FakeTrustDomain, st, "https://www.googleapis.com/auth/cloud-platform")
 
 			// Override token manager in token source to use mock plugin
-			tokenExchangePlugin, _ := google.CreateTokenManagerPlugin(mock.FakeTrustDomain, mock.FakeProjectNum, mock.FakeGKEClusterURL, false)
+			tokenExchangePlugin, _ := google.CreateTokenManagerPlugin(nil, mock.FakeTrustDomain, mock.FakeProjectNum, mock.FakeGKEClusterURL, false)
 			tokenManager := CreateTokenManager(GoogleTokenExchange,
 				Config{TrustDomain: mock.FakeTrustDomain})
 			tokenManager.(*TokenManager).SetPlugin(tokenExchangePlugin)
@@ -267,13 +267,14 @@ func setUpTestComponents(t *testing.T, setup testSetUp) (*stsServer.Server, *moc
 		t.Fatalf("failed to start a mock server: %v", err)
 	}
 	// Create token exchange Google plugin
-	tokenExchangePlugin, _ := google.CreateTokenManagerPlugin(mock.FakeTrustDomain, mock.FakeProjectNum, mock.FakeGKEClusterURL, setup.enableCache)
+	tokenExchangePlugin, _ := google.CreateTokenManagerPlugin(nil, mock.FakeTrustDomain, mock.FakeProjectNum,
+		mock.FakeGKEClusterURL, setup.enableCache)
 	federatedTokenTestingEndpoint := mockServer.URL + "/v1/identitybindingtoken"
 	accessTokenTestingEndpoint := mockServer.URL + "/v1/projects/-/serviceAccounts/service-%s@gcp-sa-meshdataplane.iam.gserviceaccount.com:generateAccessToken"
 	tokenExchangePlugin.SetEndpoints(federatedTokenTestingEndpoint, accessTokenTestingEndpoint)
 	// Create token manager
 	tokenManager := CreateTokenManager(GoogleTokenExchange,
-		Config{TrustDomain: mock.FakeTrustDomain})
+		Config{CredFetcher: nil, TrustDomain: mock.FakeTrustDomain})
 	tokenManager.(*TokenManager).SetPlugin(tokenExchangePlugin)
 	// Create STS server
 	server, _ := stsServer.NewServer(stsServer.Config{LocalHostAddr: "127.0.0.1", LocalPort: 0}, tokenManager)

--- a/security/pkg/stsservice/tokenmanager/tokenmanager.go
+++ b/security/pkg/stsservice/tokenmanager/tokenmanager.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"istio.io/istio/pkg/bootstrap/platform"
+	"istio.io/istio/pkg/security"
 	"istio.io/istio/security/pkg/stsservice"
 	"istio.io/istio/security/pkg/stsservice/tokenmanager/google"
 )
@@ -39,6 +40,7 @@ type TokenManager struct {
 }
 
 type Config struct {
+	CredFetcher security.CredFetcher
 	TrustDomain string
 }
 
@@ -82,7 +84,7 @@ func CreateTokenManager(tokenManagerType string, config Config) stsservice.Token
 		if projectInfo := getGCPProjectInfo(); len(projectInfo.Number) > 0 {
 			gkeClusterURL := fmt.Sprintf("https://container.googleapis.com/v1/projects/%s/locations/%s/clusters/%s",
 				projectInfo.id, projectInfo.clusterLocation, projectInfo.cluster)
-			if p, err := google.CreateTokenManagerPlugin(config.TrustDomain, projectInfo.Number, gkeClusterURL, true); err == nil {
+			if p, err := google.CreateTokenManagerPlugin(config.CredFetcher, config.TrustDomain, projectInfo.Number, gkeClusterURL, true); err == nil {
 				tm.plugin = p
 			}
 		}


### PR DESCRIPTION
* Add credential fetcher in istio agent.

Add credential fetcher in istio agent. Credential fetcher fetches platform specific workload credential, which is used by istio agent to provisioning certificates for workloads.