### PR TITLE
add gRPC status in fault abort

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -41,6 +41,7 @@ import (
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/util/gogo"
+	grpcutil "istio.io/istio/pkg/util/grpc"
 	"istio.io/pkg/log"
 )
 
@@ -921,8 +922,13 @@ func translateFault(in *networking.HTTPFaultInjection) *xdshttpfault.HTTPFault {
 			out.Abort.ErrorType = &xdshttpfault.FaultAbort_HttpStatus{
 				HttpStatus: uint32(a.HttpStatus),
 			}
+		case *networking.HTTPFaultInjection_Abort_GrpcStatus:
+			code := grpcutil.SupportedGRPCStatus[a.GrpcStatus]
+			out.Abort.ErrorType = &xdshttpfault.FaultAbort_GrpcStatus{
+				GrpcStatus: uint32(code),
+			}
 		default:
-			log.Warnf("Non-HTTP type abort faults are not yet supported")
+			log.Warnf("Only HTTP and gRPC type abort faults are supported")
 			out.Abort = nil
 		}
 	}

--- a/pilot/pkg/networking/core/v1alpha3/route/route_internal_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_internal_test.go
@@ -20,9 +20,12 @@ import (
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	xdsfault "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/common/fault/v3"
+	xdshttpfault "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/fault/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	xdstype "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/ptypes/duration"
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
@@ -598,6 +601,121 @@ func TestSourceMatchHTTP(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := sourceMatchHTTP(tt.args.match, tt.args.proxyLabels, tt.args.gatewayNames, tt.args.proxyNamespace); got != tt.want {
 				t.Errorf("sourceMatchHTTP() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTranslateFault(t *testing.T) {
+	cases := []struct {
+		name  string
+		fault *networking.HTTPFaultInjection
+		want  *xdshttpfault.HTTPFault
+	}{
+		{
+			name: "http delay",
+			fault: &networking.HTTPFaultInjection{
+				Delay: &networking.HTTPFaultInjection_Delay{
+					HttpDelayType: &networking.HTTPFaultInjection_Delay_FixedDelay{
+						FixedDelay: &types.Duration{
+							Seconds: int64(3),
+						},
+					},
+					Percentage: &networking.Percent{
+						Value: float64(50),
+					},
+				},
+			},
+			want: &xdshttpfault.HTTPFault{
+				Delay: &xdsfault.FaultDelay{
+					Percentage: &xdstype.FractionalPercent{
+						Numerator:   uint32(50 * 10000),
+						Denominator: xdstype.FractionalPercent_MILLION,
+					},
+					FaultDelaySecifier: &xdsfault.FaultDelay_FixedDelay{
+						FixedDelay: &duration.Duration{
+							Seconds: int64(3),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "grpc abort",
+			fault: &networking.HTTPFaultInjection{
+				Abort: &networking.HTTPFaultInjection_Abort{
+					ErrorType: &networking.HTTPFaultInjection_Abort_GrpcStatus{
+						GrpcStatus: "DEADLINE_EXCEEDED",
+					},
+					Percentage: &networking.Percent{
+						Value: float64(50),
+					},
+				},
+			},
+			want: &xdshttpfault.HTTPFault{
+				Abort: &xdshttpfault.FaultAbort{
+					Percentage: &xdstype.FractionalPercent{
+						Numerator:   uint32(50 * 10000),
+						Denominator: xdstype.FractionalPercent_MILLION,
+					},
+					ErrorType: &xdshttpfault.FaultAbort_GrpcStatus{
+						GrpcStatus: uint32(4),
+					},
+				},
+			},
+		},
+		{
+			name: "both delay and abort",
+			fault: &networking.HTTPFaultInjection{
+				Delay: &networking.HTTPFaultInjection_Delay{
+					HttpDelayType: &networking.HTTPFaultInjection_Delay_FixedDelay{
+						FixedDelay: &types.Duration{
+							Seconds: int64(3),
+						},
+					},
+					Percentage: &networking.Percent{
+						Value: float64(50),
+					},
+				},
+				Abort: &networking.HTTPFaultInjection_Abort{
+					ErrorType: &networking.HTTPFaultInjection_Abort_GrpcStatus{
+						GrpcStatus: "DEADLINE_EXCEEDED",
+					},
+					Percentage: &networking.Percent{
+						Value: float64(50),
+					},
+				},
+			},
+			want: &xdshttpfault.HTTPFault{
+				Delay: &xdsfault.FaultDelay{
+					Percentage: &xdstype.FractionalPercent{
+						Numerator:   uint32(50 * 10000),
+						Denominator: xdstype.FractionalPercent_MILLION,
+					},
+					FaultDelaySecifier: &xdsfault.FaultDelay_FixedDelay{
+						FixedDelay: &duration.Duration{
+							Seconds: int64(3),
+						},
+					},
+				},
+				Abort: &xdshttpfault.FaultAbort{
+					Percentage: &xdstype.FractionalPercent{
+						Numerator:   uint32(50 * 10000),
+						Denominator: xdstype.FractionalPercent_MILLION,
+					},
+					ErrorType: &xdshttpfault.FaultAbort_GrpcStatus{
+						GrpcStatus: uint32(4),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			tf := translateFault(tt.fault)
+			if !reflect.DeepEqual(tf, tt.want) {
+				t.Errorf("Unexpected translate fault want %v, got %v", tt.want, tf)
 			}
 		})
 	}

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -1337,6 +1337,45 @@ func TestValidateHTTPFaultInjectionAbort(t *testing.T) {
 				HttpStatus: 200,
 			},
 		}, valid: false},
+
+		{name: "grpc: nil", in: nil, valid: true},
+		{name: "grpc: valid", in: &networking.HTTPFaultInjection_Abort{
+			Percentage: &networking.Percent{
+				Value: 20,
+			},
+			ErrorType: &networking.HTTPFaultInjection_Abort_GrpcStatus{
+				GrpcStatus: "DEADLINE_EXCEEDED",
+			},
+		}, valid: true},
+		{name: "grpc: valid default", in: &networking.HTTPFaultInjection_Abort{
+			ErrorType: &networking.HTTPFaultInjection_Abort_GrpcStatus{
+				GrpcStatus: "DEADLINE_EXCEEDED",
+			},
+		}, valid: true},
+		{name: "grpc: invalid status", in: &networking.HTTPFaultInjection_Abort{
+			Percentage: &networking.Percent{
+				Value: 20,
+			},
+			ErrorType: &networking.HTTPFaultInjection_Abort_GrpcStatus{
+				GrpcStatus: "BAD_STATUS",
+			},
+		}, valid: false},
+		{name: "grpc: valid percentage", in: &networking.HTTPFaultInjection_Abort{
+			Percentage: &networking.Percent{
+				Value: 0.001,
+			},
+			ErrorType: &networking.HTTPFaultInjection_Abort_GrpcStatus{
+				GrpcStatus: "DEADLINE_EXCEEDED",
+			},
+		}, valid: true},
+		{name: "grpc: invalid fractional percent", in: &networking.HTTPFaultInjection_Abort{
+			Percentage: &networking.Percent{
+				Value: -10.0,
+			},
+			ErrorType: &networking.HTTPFaultInjection_Abort_GrpcStatus{
+				GrpcStatus: "DEADLINE_EXCEEDED",
+			},
+		}, valid: false},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/util/grpc/grpc.go
+++ b/pkg/util/grpc/grpc.go
@@ -1,0 +1,42 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpc
+
+import (
+	"google.golang.org/grpc/codes"
+)
+
+var (
+	// SupportedGRPCStatus contains golang supported gRPC status: https://github.com/grpc/grpc-go/blob/master/codes/codes.go
+	SupportedGRPCStatus = map[string]codes.Code{
+		"OK":                  codes.OK,
+		"CANCELLED":           codes.Canceled,
+		"UNKNOWN":             codes.Unknown,
+		"INVALID_ARGUMENT":    codes.InvalidArgument,
+		"DEADLINE_EXCEEDED":   codes.DeadlineExceeded,
+		"NOT_FOUND":           codes.NotFound,
+		"ALREADY_EXISTS":      codes.AlreadyExists,
+		"PERMISSION_DENIED":   codes.PermissionDenied,
+		"RESOURCE_EXHAUSTED":  codes.ResourceExhausted,
+		"FAILED_PRECONDITION": codes.FailedPrecondition,
+		"ABORTED":             codes.Aborted,
+		"OUT_OF_RANGE":        codes.OutOfRange,
+		"UNIMPLEMENTED":       codes.Unimplemented,
+		"INTERNAL":            codes.Internal,
+		"UNAVAILABLE":         codes.Unavailable,
+		"DATA_LOSS":           codes.DataLoss,
+		"UNAUTHENTICATED":     codes.Unauthenticated,
+	}
+)


### PR DESCRIPTION
Implement of `grpc status` in `fault abort`.

e.g.

```
apiVersion: networking.istio.io/v1beta1
kind: VirtualService
...
spec:
  hosts:
  - ratings
  http:
  - fault:
      abort:
        grpcStatus: DEADLINE_EXCEEDED
        percentage:
          value: 100
```

The related api is in [istio/api:virtual_service.proto#L1816](https://github.com/istio/api/blob/master/networking/v1alpha3/virtual_service.proto#L1816) and for now it's `hide_from_docs`.

And we discuss about whether the type of `GrpcStatus` should be `string` or `uint32` in https://github.com/istio/istio/issues/24698. cc @howardjohn 



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

