### PR TITLE
Increase grpc connection timeout

### DIFF
--- a/pilot/pkg/model/config_test.go
+++ b/pilot/pkg/model/config_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 
 	networking "istio.io/api/networking/v1alpha3"
+
 	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/model"
 	mock_config "istio.io/istio/pilot/test/mock"

--- a/pkg/test/echo/client/client.go
+++ b/pkg/test/echo/client/client.go
@@ -20,6 +20,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -39,7 +40,8 @@ type Instance struct {
 // New creates a new echo client.Instance that is connected to the given server address.
 func New(address string, tlsSettings *common.TLSSettings) (*Instance, error) {
 	// Connect to the GRPC (command) endpoint of 'this' app.
-	ctx, cancel := context.WithTimeout(context.Background(), common.ConnectionTimeout)
+	// TODO: make use of common.ConnectionTimeout once it increases
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	dialOptions := []grpc.DialOption{grpc.WithBlock()}
 	if tlsSettings == nil {

--- a/pkg/test/echo/common/util.go
+++ b/pkg/test/echo/common/util.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	ConnectionTimeout     = time.Second * 2
+	ConnectionTimeout     = 5 * time.Second
 	DefaultRequestTimeout = 15 * time.Second
 	DefaultCount          = 1
 )

--- a/pkg/test/echo/common/util.go
+++ b/pkg/test/echo/common/util.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	ConnectionTimeout     = 5 * time.Second
+	ConnectionTimeout     = 2 * time.Second
 	DefaultRequestTimeout = 15 * time.Second
 	DefaultCount          = 1
 )


### PR DESCRIPTION

fix TestReachability flake

I have seen it many times, here is one 
https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/26058/integ-security-k8s-tests_istio/17637

```
2020-08-03T06:24:20.683349Z	info	tf	  [ 0]                        vm-v1-67bb7d5cf5-6j994         Running (Ready)
2020-08-03T06:24:20.683758Z	info	tf	  [ 0]                          a-v1-d476f5469-sk9q8         Running (Ready)
    TestReachability: context.go:111: initialize instances: 1 error occurred:
        	* initialize TestReachability/[*kube.instance-2]: grpc client: context deadline exceeded
        
        
2020-08-03T06:24:21.054546Z	info	tf	=== DONE (failed):  Test: 'security[TestReachability] (21.119566006s)' ===
2020-08-03T06:24:21.054571Z	error	tf	=== Dumping Namespace reachability-22-85702 State...
--- FAIL: TestReachability (23.13s)
```


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.