### PR TITLE
Add ParseToken flag

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -144,6 +144,7 @@ var (
 	useTokenForCSREnv   = env.RegisterBoolVar("USE_TOKEN_FOR_CSR", false, "CSR requires a token").Get()
 	credFetcherTypeEnv  = env.RegisterStringVar("CREDENTIAL_FETCHER_TYPE", "",
 		"The type of the credential fetcher. Currently supported types include GoogleComputeEngine").Get()
+	parseTokenEnv = env.RegisterBoolVar("PARSE_TOKEN", false, "Parse token to inspect information like expiration time").Get()
 
 	rootCmd = &cobra.Command{
 		Use:          "pilot-agent",
@@ -280,6 +281,7 @@ var (
 			secOpts.InitialBackoffInMilliSec = int64(initialBackoffInMilliSecEnv)
 			// Disable the secret eviction for istio agent.
 			secOpts.EvictionDuration = 0
+			secOpts.ParseToken = parseTokenEnv
 
 			// TODO (liminw): CredFetcher is a general interface. In 1.7, we limit the use on GCE only because
 			// GCE is the only supported plugin at the moment.

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -144,7 +144,8 @@ var (
 	useTokenForCSREnv   = env.RegisterBoolVar("USE_TOKEN_FOR_CSR", false, "CSR requires a token").Get()
 	credFetcherTypeEnv  = env.RegisterStringVar("CREDENTIAL_FETCHER_TYPE", "",
 		"The type of the credential fetcher. Currently supported types include GoogleComputeEngine").Get()
-	parseTokenEnv = env.RegisterBoolVar("PARSE_TOKEN", false, "Parse token to inspect information like expiration time").Get()
+	parseTokenEnv = env.RegisterBoolVar("PARSE_TOKEN", false,
+		"Parse token to inspect information like expiration time in proxy. This may not always be possible because token may not be a JWT.").Get()
 
 	rootCmd = &cobra.Command{
 		Use:          "pilot-agent",

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -176,6 +176,10 @@ type Options struct {
 
 	// credential fetcher.
 	CredFetcher CredFetcher
+
+	// Need to parse token to inspect information like expiration time
+	// Default is false.
+	ParseToken bool
 }
 
 // Client interface defines the clients need to implement to talk to CA for CSR.

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -940,7 +940,9 @@ func (sc *SecretCache) shouldRotate(secret *security.SecretItem) bool {
 }
 
 func (sc *SecretCache) isTokenExpired(secret *security.SecretItem) bool {
-	// skip check if the token should not be parsed in proxy
+	// Skip check if the token should not be parsed in proxy.
+	// Parsing token may not always be possible because token may not be a JWT.
+	// If ParseToken is false, we should assume token is valid and leave token validation to CA.
 	if !sc.configOptions.ParseToken {
 		return false
 	}

--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -218,6 +218,8 @@ func testWorkloadAgentGenerateSecret(t *testing.T, isUsingPluginProvider bool) {
 		sc.Close()
 	}()
 
+	checkBool(t, "opt.ParseToken default", opt.ParseToken, false)
+
 	conID := "proxy1-id"
 	ctx := context.Background()
 	gotSecret, err := sc.GenerateSecret(ctx, conID, WorkloadKeyCertResourceName, "jwtToken1")
@@ -229,8 +231,8 @@ func testWorkloadAgentGenerateSecret(t *testing.T, isUsingPluginProvider bool) {
 		t.Errorf("Got unexpected certificate chain #1. Got: %v, want: %v", string(got), string(want))
 	}
 
-	checkBool(t, sc.SecretExist(conID, WorkloadKeyCertResourceName, "jwtToken1", gotSecret.Version), true)
-	checkBool(t, sc.SecretExist(conID, WorkloadKeyCertResourceName, "nonexisttoken", gotSecret.Version), false)
+	checkBool(t, "SecretExist", sc.SecretExist(conID, WorkloadKeyCertResourceName, "jwtToken1", gotSecret.Version), true)
+	checkBool(t, "SecretExist", sc.SecretExist(conID, WorkloadKeyCertResourceName, "nonexisttoken", gotSecret.Version), false)
 
 	gotSecretRoot, err := sc.GenerateSecret(ctx, conID, RootCertReqResourceName, "jwtToken1")
 	if err != nil {
@@ -241,8 +243,8 @@ func testWorkloadAgentGenerateSecret(t *testing.T, isUsingPluginProvider bool) {
 		t.Errorf("Got unexpected root certificate. Got: %v\n want: %v", string(got), string(want))
 	}
 
-	checkBool(t, sc.SecretExist(conID, RootCertReqResourceName, "jwtToken1", gotSecretRoot.Version), true)
-	checkBool(t, sc.SecretExist(conID, RootCertReqResourceName, "nonexisttoken", gotSecretRoot.Version), false)
+	checkBool(t, "SecretExist", sc.SecretExist(conID, RootCertReqResourceName, "jwtToken1", gotSecretRoot.Version), true)
+	checkBool(t, "SecretExist", sc.SecretExist(conID, RootCertReqResourceName, "nonexisttoken", gotSecretRoot.Version), false)
 
 	if got, want := atomic.LoadUint64(&sc.rootCertChangedCount), uint64(0); got != want {
 		t.Errorf("Got unexpected rootCertChangedCount: Got: %v\n want: %v", got, want)
@@ -398,8 +400,8 @@ func TestGatewayAgentGenerateSecret(t *testing.T) {
 				if err := verifySecret(gotSecret, es.secret); err != nil {
 					t.Errorf("Secret verification failed: %v", err)
 				}
-				checkBool(t, sc.SecretExist(c.connID, es.secret.ResourceName, "", gotSecret.Version), true)
-				checkBool(t, sc.SecretExist(c.connID, "nonexistsecret", "", gotSecret.Version), false)
+				checkBool(t, "SecretExist", sc.SecretExist(c.connID, es.secret.ResourceName, "", gotSecret.Version), true)
+				checkBool(t, "SecretExist", sc.SecretExist(c.connID, "nonexistsecret", "", gotSecret.Version), false)
 			}
 			key := ConnKey{
 				ConnectionID: c.connID,
@@ -681,32 +683,32 @@ func TestGatewayAgentDeleteSecret(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}
-	checkBool(t, sc.SecretExist(connID, k8sGenericSecretName, "", gotSecret.Version), true)
+	checkBool(t, "SecretExist", sc.SecretExist(connID, k8sGenericSecretName, "", gotSecret.Version), true)
 
 	gotSecret, err = sc.GenerateSecret(ctx, connID, k8sGenericSecretName+"-cacert", "")
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}
-	checkBool(t, sc.SecretExist(connID, k8sGenericSecretName+"-cacert", "", gotSecret.Version), true)
+	checkBool(t, "SecretExist", sc.SecretExist(connID, k8sGenericSecretName+"-cacert", "", gotSecret.Version), true)
 
 	gotSecret, err = sc.GenerateSecret(ctx, connID, k8sTLSSecretName, "")
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}
-	checkBool(t, sc.SecretExist(connID, k8sTLSSecretName, "", gotSecret.Version), true)
+	checkBool(t, "SecretExist", sc.SecretExist(connID, k8sTLSSecretName, "", gotSecret.Version), true)
 
 	_, err = sc.GenerateSecret(ctx, connID, k8sTLSSecretName+"-cacert", "")
 	if err == nil {
 		t.Fatalf("Get unexpected secrets: %v", err)
 	}
-	checkBool(t, sc.SecretExist(connID, k8sTLSSecretName+"-cacert", "", gotSecret.Version), false)
+	checkBool(t, "SecretExist", sc.SecretExist(connID, k8sTLSSecretName+"-cacert", "", gotSecret.Version), false)
 
 	sc.DeleteK8sSecret(k8sGenericSecretName)
 	sc.DeleteK8sSecret(k8sGenericSecretName + "-cacert")
 	sc.DeleteK8sSecret(k8sTLSSecretName)
-	checkBool(t, sc.SecretExist(connID, k8sGenericSecretName, "", gotSecret.Version), false)
-	checkBool(t, sc.SecretExist(connID, k8sGenericSecretName+"-cacert", "", gotSecret.Version), false)
-	checkBool(t, sc.SecretExist(connID, k8sTLSSecretName, "", gotSecret.Version), false)
+	checkBool(t, "SecretExist", sc.SecretExist(connID, k8sGenericSecretName, "", gotSecret.Version), false)
+	checkBool(t, "SecretExist", sc.SecretExist(connID, k8sGenericSecretName+"-cacert", "", gotSecret.Version), false)
+	checkBool(t, "SecretExist", sc.SecretExist(connID, k8sTLSSecretName, "", gotSecret.Version), false)
 }
 
 // TestGatewayAgentUpdateSecret verifies that ingress gateway agent updates secret cache correctly.
@@ -724,12 +726,12 @@ func TestGatewayAgentUpdateSecret(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}
-	checkBool(t, sc.SecretExist(connID, k8sGenericSecretName, "", gotSecret.Version), true)
+	checkBool(t, "SecretExist", sc.SecretExist(connID, k8sGenericSecretName, "", gotSecret.Version), true)
 	gotSecret, err = sc.GenerateSecret(ctx, connID, k8sGenericSecretName+"-cacert", "")
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}
-	checkBool(t, sc.SecretExist(connID, k8sGenericSecretName+"-cacert", "", gotSecret.Version), true)
+	checkBool(t, "SecretExist", sc.SecretExist(connID, k8sGenericSecretName+"-cacert", "", gotSecret.Version), true)
 	newTime := gotSecret.CreatedTime.Add(time.Duration(10) * time.Second)
 	newK8sTestSecret := security.SecretItem{
 		CertificateChain: []byte("new cert chain"),
@@ -741,9 +743,9 @@ func TestGatewayAgentUpdateSecret(t *testing.T) {
 		Version:          newTime.String(),
 	}
 	sc.UpdateK8sSecret(k8sGenericSecretName, newK8sTestSecret)
-	checkBool(t, sc.SecretExist(connID, k8sGenericSecretName, "", gotSecret.Version), false)
+	checkBool(t, "SecretExist", sc.SecretExist(connID, k8sGenericSecretName, "", gotSecret.Version), false)
 	sc.UpdateK8sSecret(k8sGenericSecretName+"-cacert", newK8sTestSecret)
-	checkBool(t, sc.SecretExist(connID, k8sGenericSecretName+"-cacert", "", gotSecret.Version), false)
+	checkBool(t, "SecretExist", sc.SecretExist(connID, k8sGenericSecretName+"-cacert", "", gotSecret.Version), false)
 }
 
 func TestConstructCSRHostName(t *testing.T) {
@@ -795,10 +797,18 @@ func TestConstructCSRHostName(t *testing.T) {
 	}
 }
 
-func checkBool(t *testing.T, got bool, want bool) {
+func checkBool(t *testing.T, name string, got bool, want bool) {
 	if got != want {
-		t.Errorf("SecretExist: got: %v, want: %v", got, want)
+		t.Errorf("%s: got: %v, want: %v", name, got, want)
 	}
+}
+
+func TestParseTokenFlag(t *testing.T) {
+	sc := createSecretCache()
+	defer sc.Close()
+	sc.configOptions.ParseToken = false
+	secret := security.SecretItem{}
+	checkBool(t, "isTokenExpired", sc.isTokenExpired(&secret), false)
 }
 
 func TestRootCertificateExists(t *testing.T) {
@@ -874,6 +884,7 @@ func TestWorkloadAgentGenerateSecretFromFile(t *testing.T) {
 		RotationInterval: 200 * time.Millisecond,
 		EvictionDuration: 0,
 		UseTokenForCSR:   true,
+		ParseToken:       true,
 	}
 
 	fetcher := &secretfetcher.SecretFetcher{
@@ -938,7 +949,7 @@ func TestWorkloadAgentGenerateSecretFromFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}
-	checkBool(t, sc.SecretExist(conID, WorkloadKeyCertResourceName, "jwtToken1", gotSecret.Version), true)
+	checkBool(t, "SecretExist", sc.SecretExist(conID, WorkloadKeyCertResourceName, "jwtToken1", gotSecret.Version), true)
 	expectedSecret := &security.SecretItem{
 		ResourceName:     WorkloadKeyCertResourceName,
 		CertificateChain: certchain,
@@ -959,7 +970,7 @@ func TestWorkloadAgentGenerateSecretFromFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}
-	checkBool(t, sc.SecretExist(conID, RootCertReqResourceName, "jwtToken1", gotSecretRoot.Version), true)
+	checkBool(t, "SecretExist", sc.SecretExist(conID, RootCertReqResourceName, "jwtToken1", gotSecretRoot.Version), true)
 	if got, want := atomic.LoadUint64(&sc.rootCertChangedCount), uint64(0); got != want {
 		t.Errorf("rootCertChangedCount: got: %v, want: %v", got, want)
 	}
@@ -1061,7 +1072,7 @@ func TestWorkloadAgentGenerateSecretFromFileOverSds(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}
-	checkBool(t, sc.SecretExist(conID, resource, "jwtToken1", gotSecret.Version), true)
+	checkBool(t, "SecretExist", sc.SecretExist(conID, resource, "jwtToken1", gotSecret.Version), true)
 	expectedSecret := &security.SecretItem{
 		ResourceName:     resource,
 		CertificateChain: certchain,
@@ -1082,7 +1093,7 @@ func TestWorkloadAgentGenerateSecretFromFileOverSds(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}
-	checkBool(t, sc.SecretExist(conID, rootResource, "jwtToken1", gotSecretRoot.Version), true)
+	checkBool(t, "SecretExist", sc.SecretExist(conID, rootResource, "jwtToken1", gotSecretRoot.Version), true)
 	if got, want := atomic.LoadUint64(&sc.rootCertChangedCount), uint64(0); got != want {
 		t.Errorf("rootCertChangedCount: got: %v, want: %v", got, want)
 	}


### PR DESCRIPTION
1. Parsing token content only if ParseToken flag is true, this replaces the previous AlwaysValidTokenFlag (which was set incorrectly using PROV_CERT env). 
2. Simplify getToken logic.
3. Remove redundant secOps in secretCache.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.