### PR TITLE
Don't claim 'istioctl validate' is deprecated

### DIFF
--- a/istioctl/pkg/validate/validate.go
+++ b/istioctl/pkg/validate/validate.go
@@ -275,7 +275,7 @@ func NewValidateCommand(istioNamespace *string) *cobra.Command {
 
 	c := &cobra.Command{
 		Use:   "validate -f FILENAME [options]",
-		Short: "Validate Istio policy and rules (NOTE: validate is deprecated and will be removed in 1.6. Use 'istioctl analyze' to validate configuration.)",
+		Short: "Validate Istio policy and rules files",
 		Example: `
 		# Validate bookinfo-gateway.yaml
 		istioctl validate -f bookinfo-gateway.yaml


### PR DESCRIPTION
We shouldn't deprecate `istioctl validate`, because it does some things that analyzers can't yet do, such as strict YAML validation.

Resolves https://github.com/istio/istio/issues/24332 .

We still want to remove it, but not in 1.7, and maybe not in 1.8.