### PR TITLE
fix mesh network flakes

### DIFF
--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -176,10 +176,10 @@ func (c *Controller) GetService(hostname host.Name) (*model.Service, error) {
 		}
 
 		// This is K8S typically
+		service.Mutex.RLock()
 		if out == nil {
 			out = service.DeepCopy()
 		} else {
-			service.Mutex.RLock()
 			// ClusterExternalAddresses and ClusterExternalPorts are only used for getting gateway address
 			externalAddrs := service.Attributes.ClusterExternalAddresses[r.Cluster()]
 			if len(externalAddrs) > 0 {
@@ -195,8 +195,8 @@ func (c *Controller) GetService(hostname host.Name) (*model.Service, error) {
 				}
 				out.Attributes.ClusterExternalPorts[r.Cluster()] = externalPorts
 			}
-			service.Mutex.RUnlock()
 		}
+		service.Mutex.RUnlock()
 	}
 	return out, errs
 }

--- a/pilot/pkg/serviceregistry/kube/controller/fake.go
+++ b/pilot/pkg/serviceregistry/kube/controller/fake.go
@@ -15,21 +15,17 @@
 package controller
 
 import (
-	"errors"
-	"fmt"
 	"time"
-
-	klabels "k8s.io/apimachinery/pkg/labels"
-	listerv1 "k8s.io/client-go/listers/core/v1"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
 
 	kubelib "istio.io/istio/pkg/kube"
 
+	"github.com/hashicorp/go-multierror"
+
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/mesh"
-	"istio.io/istio/pkg/test/util/retry"
 )
 
 const (
@@ -139,38 +135,23 @@ type FakeController struct {
 	*Controller
 }
 
-func (f *FakeController) ResyncEndpoints() error {
+func (f *FakeController) ForceResync() error {
 	// TODO this workaround fixes a flake that indicates a real issue.
 	// TODO(cont) See https://github.com/istio/istio/issues/24117 and https://github.com/istio/istio/pull/24339
-
-	e, ok := f.endpoints.(*endpointsController)
-	if !ok {
-		return errors.New("cannot run ResyncEndpoints; EndpointsMode must be EndpointsOnly")
+	var err *multierror.Error
+	for _, s := range f.nodeInformer.GetStore().List() {
+		err = multierror.Append(err, f.onNodeEvent(s, model.EventAdd))
 	}
-	eps, err := listerv1.NewEndpointsLister(e.informer.GetIndexer()).List(klabels.Everything())
-	if err != nil {
-		return err
+	for _, s := range f.serviceInformer.GetStore().List() {
+		err = multierror.Append(err, f.onServiceEvent(s, model.EventAdd))
 	}
-	// endpoint processing may beat services
-	for _, ep := range eps {
-		// endpoint updates are skipped when the service is not there yet
-		if host, svc, ns := e.getServiceInfo(ep); host != "" {
-			_ = retry.UntilSuccess(func() error {
-				f.RLock()
-				defer f.RUnlock()
-				if f.servicesMap[host] == nil {
-					return fmt.Errorf("waiting for service %s in %s to be populated", svc, ns)
-				}
-				return nil
-			}, retry.Delay(time.Second), retry.Timeout(10*time.Second))
-		}
-
-		err = f.endpoints.onEvent(ep, model.EventAdd)
-		if err != nil {
-			return err
-		}
+	for _, s := range f.pods.informer.GetStore().List() {
+		err = multierror.Append(err, f.pods.onEvent(s, model.EventAdd))
 	}
-	return nil
+	for _, s := range f.endpoints.getInformer().GetStore().List() {
+		err = multierror.Append(err, f.endpoints.onEvent(s, model.EventAdd))
+	}
+	return err.ErrorOrNil()
 }
 
 func NewFakeControllerWithOptions(opts FakeControllerOptions) (*FakeController, *FakeXdsUpdater) {

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -183,12 +183,6 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 			t.Fatalf("failed to create config %v: %v", cfg.Name, err)
 		}
 	}
-	if err := s.UpdateServiceShards(env.PushContext); err != nil {
-		t.Fatal(err)
-	}
-	if err := env.PushContext.InitContext(env, nil, nil); err != nil {
-		t.Fatal(err)
-	}
 
 	s.MemRegistry.ClusterID = string(serviceregistry.Mock)
 	serviceDiscovery.AddRegistry(serviceregistry.Simple{
@@ -249,7 +243,14 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	s.Start(stop)
 
 	se.ResyncEDS()
-	if err := k8s.ResyncEndpoints(); err != nil {
+	if err := k8s.ForceResync(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.UpdateServiceShards(env.PushContext); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.PushContext.InitContext(env, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -247,15 +247,17 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		t.Fatal(err)
 	}
 
-	if err := s.UpdateServiceShards(env.PushContext); err != nil {
+	s.updateMutex.Lock()
+	defer s.updateMutex.Unlock()
+	ctx := model.NewPushContext()
+	if err := ctx.InitContext(env, env.PushContext, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := env.PushContext.InitContext(env, nil, nil); err != nil {
+	if err := s.UpdateServiceShards(ctx); err != nil {
 		t.Fatal(err)
 	}
+	env.PushContext = ctx
 
-	s.updateMutex.RLock()
-	defer s.updateMutex.RUnlock()
 	fake := &FakeDiscoveryServer{
 		t:           t,
 		Store:       configController,

--- a/pilot/pkg/xds/xds_test.go
+++ b/pilot/pkg/xds/xds_test.go
@@ -308,7 +308,6 @@ func TestSidecarListeners(t *testing.T) {
 }
 
 func TestMeshNetworking(t *testing.T) {
-	t.Skip("https://github.com/istio/istio/issues/26048")
 	ingresses := []*corev1.Service{
 		{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Fixes #26048

go test with -race -count=50 passes. 

* The global push context needs to be reinitialized after the force-sync. 
  * it passes sometimes because ConfigUpdate calls Push which re-init PushContext but debounce may delay that. If theres a way to check that debounce has settled we could do that instead of `InitContext`. 
* Cleaned up the ForceResync to check all resources. This was not necessary to fix the flake but may prevent future ones. 
* Fix race in aggregate controller for merging services across multiple registries


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
