### PR TITLE
Create code sample for exposing istiod through ingress and use it in tests

### DIFF
--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -127,6 +127,9 @@ type Config struct {
 	// CustomSidecarInjectorNamespace allows injecting the sidecar from the specified namespace.
 	// if the value is "", use the default sidecar injection instead.
 	CustomSidecarInjectorNamespace string
+
+	// Expose istiod through ingress, for example for multicluster or VM setups
+	ExposeIstiod bool
 }
 
 func (c *Config) IstioOperatorConfigYAML(iopYaml string) string {

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -228,12 +228,13 @@ func deploy(ctx resource.Context, env *kube.Environment, cfg Config) (Instance, 
 					return fmt.Errorf("failed deploying control plane to cluster %s: %v", cluster.Name(), err)
 				}
 
-				// Expose istiod through ingress.
-				if err := patchIngressPorts(cfg, cluster); err != nil {
-					return fmt.Errorf("failed patching ingress ports for cluster %s: %v", cluster.Name(), err)
-				}
-				if err := applyIstiodGateway(ctx, cfg, cluster); err != nil {
-					return fmt.Errorf("failed applying istiod gateway for cluster %s: %v", cluster.Name(), err)
+				if cfg.ExposeIstiod {
+					if err := patchIngressPorts(cfg, cluster); err != nil {
+						return fmt.Errorf("failed patching ingress ports for cluster %s: %v", cluster.Name(), err)
+					}
+					if err := applyIstiodGateway(ctx, cfg, cluster); err != nil {
+						return fmt.Errorf("failed applying istiod gateway for cluster %s: %v", cluster.Name(), err)
+					}
 				}
 				return nil
 			})

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -23,6 +23,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"sync"
 	"time"
 
@@ -225,6 +226,14 @@ func deploy(ctx resource.Context, env *kube.Environment, cfg Config) (Instance, 
 			errG.Go(func() error {
 				if err := deployControlPlane(i, cfg, cluster, iopFile); err != nil {
 					return fmt.Errorf("failed deploying control plane to cluster %s: %v", cluster.Name(), err)
+				}
+
+				// Expose istiod through ingress.
+				if err := patchIngressPorts(cfg, cluster); err != nil {
+					return fmt.Errorf("failed patching ingress ports for cluster %s: %v", cluster.Name(), err)
+				}
+				if err := applyIstiodGateway(ctx, cfg, cluster); err != nil {
+					return fmt.Errorf("failed applying istiod gateway for cluster %s: %v", cluster.Name(), err)
 				}
 				return nil
 			})
@@ -511,6 +520,42 @@ func deployControlPlane(c *operatorComponent, cfg Config, cluster resource.Clust
 		}
 	}
 	return applyManifest(c, installSettings, istioCtl, cluster.Name())
+}
+
+func patchIngressPorts(cfg Config, cluster resource.Cluster) error {
+	patchOptions := kubeApiMeta.PatchOptions{
+		FieldManager: "istio-ci",
+		TypeMeta: kubeApiMeta.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+	}
+	contents := `
+apiVersion: v1
+kind: Service
+spec:
+  ports:
+  - name: tcp-istiod
+    port: 15012
+    protocol: TCP
+    targetPort: 15012
+  - name: tcp-webhook
+    port: 15017
+    protocol: TCP
+    targetPort: 15017`
+	_, err := cluster.CoreV1().Services(cfg.SystemNamespace).Patch(
+		context.TODO(), "istio-ingressgateway", types.ApplyPatchType, []byte(contents), patchOptions)
+	return err
+}
+
+func applyIstiodGateway(ctx resource.Context, cfg Config, cluster resource.Cluster) error {
+	yamlBytes, err := ioutil.ReadFile(filepath.Join(env.IstioSrc, "samples/istiod-gateway/istiod-gateway.yaml"))
+	if err != nil {
+		return err
+	}
+	yaml := string(yamlBytes)
+	yaml = strings.ReplaceAll(yaml, "istio-system", cfg.SystemNamespace)
+	return ctx.Config(cluster).ApplyYAML(cfg.SystemNamespace, yaml)
 }
 
 func isCentralIstio(env *kube.Environment, cfg Config) bool {

--- a/samples/istiod-gateway/istiod-gateway.yaml
+++ b/samples/istiod-gateway/istiod-gateway.yaml
@@ -1,0 +1,65 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: meshexpansion-gateway
+  namespace: istio-system
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+    - port:
+        name: tcp-istiod
+        number: 15012
+        protocol: TCP
+      hosts:
+        - "*"
+    - port:
+        name: tcp-istiodwebhook
+        number: 15017
+        protocol: TCP
+      hosts:
+        - "*"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: meshexpansion-vs-istiod
+  namespace: istio-system
+spec:
+  hosts:
+  - istiod.istio-system.svc.cluster.local
+  gateways:
+  - meshexpansion-gateway
+  tcp:
+  - match:
+    - port: 15012
+    route:
+    - destination:
+        host: istiod.istio-system.svc.cluster.local
+        port:
+          number: 15012
+  - match:
+    - port: 15017
+    route:
+    - destination:
+        host: istiod.istio-system.svc.cluster.local
+        port:
+          number: 443
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: meshexpansion-dr-istiod
+  namespace: istio-system
+spec:
+  host: istiod.istio-system.svc.cluster.local
+  trafficPolicy:
+    portLevelSettings:
+    - port:
+        number: 15012
+      tls:
+        mode: DISABLE
+    - port:
+        number: 15017
+      tls:
+        mode: DISABLE

--- a/tests/integration/multicluster/base/main_test.go
+++ b/tests/integration/multicluster/base/main_test.go
@@ -38,6 +38,8 @@ func TestMain(m *testing.M) {
 		RequireMinClusters(2).
 		Setup(multicluster.Setup(&controlPlaneValues, &clusterLocalNS, &mcReachabilityNS)).
 		Setup(istio.Setup(&ist, func(cfg *istio.Config) {
+			cfg.ExposeIstiod = true
+
 			// Set the control plane values on the config.
 			cfg.ControlPlaneValues = controlPlaneValues
 		})).

--- a/tests/integration/multicluster/base/main_test.go
+++ b/tests/integration/multicluster/base/main_test.go
@@ -39,10 +39,7 @@ func TestMain(m *testing.M) {
 		Setup(multicluster.Setup(&controlPlaneValues, &clusterLocalNS, &mcReachabilityNS)).
 		Setup(istio.Setup(&ist, func(cfg *istio.Config) {
 			// Set the control plane values on the config.
-			cfg.ControlPlaneValues = controlPlaneValues + `
-  global:
-    meshExpansion:
-      enabled: true`
+			cfg.ControlPlaneValues = controlPlaneValues
 		})).
 		Run()
 }

--- a/tests/integration/multicluster/centralistio/main_test.go
+++ b/tests/integration/multicluster/centralistio/main_test.go
@@ -53,18 +53,7 @@ func TestMain(m *testing.M) {
 
 			// Set the control plane values on the config.
 			cfg.ControlPlaneValues = controlPlaneValues + `
-  gateways:
-    istio-ingressgateway:
-      meshExpansionPorts:
-      - port: 15017
-        targetPort: 15017
-        name: tcp-webhook
-      - port: 15012
-        targetPort: 15012
-        name: tcp-istiod
   global:
-    meshExpansion:
-      enabled: true
     centralIstiod: true
     caAddress: istiod.istio-system.svc:15012`
 			cfg.RemoteClusterValues = `

--- a/tests/integration/multicluster/centralistio/main_test.go
+++ b/tests/integration/multicluster/centralistio/main_test.go
@@ -50,6 +50,7 @@ func TestMain(m *testing.M) {
 		Setup(istio.Setup(&ist, func(cfg *istio.Config) {
 
 			cfg.Values["global.centralIstiod"] = "true"
+			cfg.ExposeIstiod = true
 
 			// Set the control plane values on the config.
 			cfg.ControlPlaneValues = controlPlaneValues + `

--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -91,6 +91,7 @@ func TestMain(m *testing.M) {
 		Setup(istio.Setup(&i, func(cfg *istio.Config) {
 			cfg.Values["telemetry.v2.metadataExchange.wasmEnabled"] = "false"
 			cfg.Values["telemetry.v2.prometheus.wasmEnabled"] = "false"
+			cfg.ExposeIstiod = true
 			cfg.ControlPlaneValues = `
 values:
   pilot:

--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -93,9 +93,6 @@ func TestMain(m *testing.M) {
 			cfg.Values["telemetry.v2.prometheus.wasmEnabled"] = "false"
 			cfg.ControlPlaneValues = `
 values:
-  global:
-    meshExpansion:
-      enabled: true
   pilot:
     env:
       PILOT_ENABLED_SERVICE_APIS: "true"`

--- a/tests/integration/security/main_test.go
+++ b/tests/integration/security/main_test.go
@@ -41,10 +41,6 @@ func setupConfig(cfg *istio.Config) {
 	rootNamespace = cfg.SystemNamespace
 
 	cfg.ControlPlaneValues = `
-values:
-  global:
-    meshExpansion:
-      enabled: true
 components:
   egressGateways:
   - enabled: true

--- a/tests/integration/security/main_test.go
+++ b/tests/integration/security/main_test.go
@@ -40,6 +40,7 @@ func setupConfig(cfg *istio.Config) {
 	}
 	rootNamespace = cfg.SystemNamespace
 
+	cfg.ExposeIstiod = true
 	cfg.ControlPlaneValues = `
 components:
   egressGateways:

--- a/tests/integration/telemetry/stackdriver/vm/main_test.go
+++ b/tests/integration/telemetry/stackdriver/vm/main_test.go
@@ -59,6 +59,7 @@ func TestMain(m *testing.M) {
 		NewSuite(m).
 		RequireSingleCluster().
 		Setup(istio.Setup(&i, func(cfg *istio.Config) {
+			cfg.ExposeIstiod = true
 			cfg.Values["telemetry.enabled"] = "true"
 			cfg.Values["telemetry.v2.enabled"] = "true"
 			cfg.Values["telemetry.v2.stackdriver.enabled"] = "true"

--- a/tests/integration/telemetry/stackdriver/vm/main_test.go
+++ b/tests/integration/telemetry/stackdriver/vm/main_test.go
@@ -59,11 +59,6 @@ func TestMain(m *testing.M) {
 		NewSuite(m).
 		RequireSingleCluster().
 		Setup(istio.Setup(&i, func(cfg *istio.Config) {
-			cfg.ControlPlaneValues = `
-values:
-  global:
-    meshExpansion:
-      enabled: true`
 			cfg.Values["telemetry.enabled"] = "true"
 			cfg.Values["telemetry.v2.enabled"] = "true"
 			cfg.Values["telemetry.v2.stackdriver.enabled"] = "true"


### PR DESCRIPTION
Part of #25933 and based on https://github.com/nmittler/istio/commit/09fbb1a4d89310b343e394cc1658f95b368c3219
The sample is meant to be used in docs on how to expose istiod through ingress for multicluster and VM setup

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

Pull Request Attributes

[X] Does not have any changes that may affect Istio users.