### PR TITLE
Fix EDS tests

### DIFF
--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -70,8 +70,8 @@ func TestEds(t *testing.T) {
 	s.Discovery.MemRegistry.SetEndpoints(edsIncSvc, "",
 		newEndpointWithAccount("127.0.0.1", "hello-sa", "v1"))
 
-	adscConn := s.Connect(&model.Proxy{IPAddresses: []string{"10.10.10.10"}}, nil, watchEds)
-	adscConn2 := s.Connect(&model.Proxy{IPAddresses: []string{"10.10.10.11"}}, nil, watchEds)
+	adscConn := s.Connect(&model.Proxy{IPAddresses: []string{"10.10.10.10"}}, nil, watchAll)
+	adscConn2 := s.Connect(&model.Proxy{IPAddresses: []string{"10.10.10.11"}}, nil, watchAll)
 
 	t.Run("TCPEndpoints", func(t *testing.T) {
 		testTCPEndpoints("127.0.0.1", adscConn, t)
@@ -362,10 +362,7 @@ func testEndpoints(expected string, cluster string, adsc *adsc.ADSC, t *testing.
 			}
 		}
 	}
-	t.Errorf("Expecting %s got %v", expected, found)
-	if len(found) != 1 {
-		t.Error("Expecting 1, got ", len(found))
-	}
+	t.Fatalf("Expecting %s got %v", expected, found)
 }
 
 func testLocalityPrioritizedEndpoints(adsc *adsc.ADSC, adsc2 *adsc.ADSC, t *testing.T) {
@@ -502,7 +499,7 @@ func edsUpdateInc(s *xds.FakeDiscoveryServer, adsc *adsc.ADSC, t *testing.T) {
 		t.Fatal("Incremental push failed", err)
 	}
 	if !reflect.DeepEqual(upd, []string{"eds"}) {
-		t.Error("Expecting EDS only update, got", upd)
+		t.Fatal("Expecting EDS only update, got", upd)
 	}
 
 	testTCPEndpoints("127.0.0.2", adsc, t)
@@ -523,7 +520,7 @@ func edsUpdateInc(s *xds.FakeDiscoveryServer, adsc *adsc.ADSC, t *testing.T) {
 		t.Fatal("Incremental push failed", err)
 	}
 	if !reflect.DeepEqual(upd, []string{"eds"}) {
-		t.Error("Expecting EDS only update, got", upd)
+		t.Fatal("Expecting EDS only update, got", upd)
 	}
 	testTCPEndpoints("127.0.0.4", adsc, t)
 
@@ -542,7 +539,7 @@ func edsUpdateInc(s *xds.FakeDiscoveryServer, adsc *adsc.ADSC, t *testing.T) {
 		t.Fatal("Incremental push failed", err)
 	}
 	if !reflect.DeepEqual(upd, []string{"eds"}) {
-		t.Error("Expecting EDS only update, got", upd)
+		t.Fatal("Expecting EDS only update, got", upd)
 	}
 	testTCPEndpoints("127.0.0.5", adsc, t)
 


### PR DESCRIPTION
Currently we wait for EDS only, which means some tests may fail later
since they get an RDS/LDS update when they are expecting EDS update. We
should wait for the full push to complete first. Ran this 100x locally
without fail



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.