### PR TITLE
fix nil pointer issue of logger during validation test

### DIFF
--- a/operator/pkg/apis/istio/v1alpha1/validation/validation_test.go
+++ b/operator/pkg/apis/istio/v1alpha1/validation/validation_test.go
@@ -15,6 +15,7 @@
 package validation_test
 
 import (
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -27,6 +28,7 @@ import (
 	"istio.io/istio/operator/pkg/apis/istio/v1alpha1/validation"
 	"istio.io/istio/operator/pkg/helm"
 	"istio.io/istio/operator/pkg/manifest"
+	"istio.io/istio/operator/pkg/util/clog"
 	"istio.io/istio/pkg/test/env"
 )
 
@@ -88,9 +90,10 @@ func TestValidateProfiles(t *testing.T) {
 		// Just ensure we find some profiles, in case this code breaks
 		t.Fatalf("Maybe have failed getting profiles, got %v", profiles)
 	}
+	l := clog.NewConsoleLogger(os.Stdout, os.Stderr, nil)
 	for _, tt := range profiles {
 		t.Run(tt, func(t *testing.T) {
-			_, s, err := manifest.GenIOPSFromProfile(tt, "", []string{"installPackagePath=" + manifests}, false, nil, nil)
+			_, s, err := manifest.GenIOPSFromProfile(tt, "", []string{"installPackagePath=" + manifests}, false, nil, l)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
we expect the test to return error when the profiles fail validation, otherwise it would exit at nil pointer error