### PR TITLE
rename EnvoyXdsServer to XDSServer

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -174,7 +174,7 @@ func (s *Server) initConfigSources(args *PilotArgs) (err error) {
 	mcpOptions := &mcp.Options{
 		DomainSuffix: args.RegistryOptions.KubeOptions.DomainSuffix,
 		ConfigLedger: buildLedger(args.RegistryOptions),
-		XDSUpdater:   s.EnvoyXdsServer,
+		XDSUpdater:   s.DiscoveryServer,
 		Revision:     args.Revision,
 	}
 	reporter := monitoring.NewStatsContext("pilot")
@@ -385,7 +385,7 @@ func (s *Server) initStatusController(args *PilotArgs, writeStatus bool) {
 		s.statusReporter.Start(s.kubeClient, args.Namespace, s.configController, writeStatus, stop)
 		return nil
 	})
-	s.EnvoyXdsServer.StatusReporter = s.statusReporter
+	s.DiscoveryServer.StatusReporter = s.statusReporter
 	if writeStatus {
 		s.addTerminatingStartFunc(func(stop <-chan struct{}) error {
 			controller := status.NewController(*s.kubeRestConfig, args.Namespace)

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -174,7 +174,7 @@ func (s *Server) initConfigSources(args *PilotArgs) (err error) {
 	mcpOptions := &mcp.Options{
 		DomainSuffix: args.RegistryOptions.KubeOptions.DomainSuffix,
 		ConfigLedger: buildLedger(args.RegistryOptions),
-		XDSUpdater:   s.DiscoveryServer,
+		XDSUpdater:   s.XDSServer,
 		Revision:     args.Revision,
 	}
 	reporter := monitoring.NewStatsContext("pilot")
@@ -385,7 +385,7 @@ func (s *Server) initStatusController(args *PilotArgs, writeStatus bool) {
 		s.statusReporter.Start(s.kubeClient, args.Namespace, s.configController, writeStatus, stop)
 		return nil
 	})
-	s.DiscoveryServer.StatusReporter = s.statusReporter
+	s.XDSServer.StatusReporter = s.statusReporter
 	if writeStatus {
 		s.addTerminatingStartFunc(func(stop <-chan struct{}) error {
 			controller := status.NewController(*s.kubeRestConfig, args.Namespace)

--- a/pilot/pkg/bootstrap/multicluster.go
+++ b/pilot/pkg/bootstrap/multicluster.go
@@ -29,7 +29,7 @@ func (s *Server) initClusterRegistries(args *PilotArgs) (err error) {
 			args.RegistryOptions.ClusterRegistriesNamespace,
 			args.RegistryOptions.KubeOptions,
 			s.ServiceController(),
-			s.DiscoveryServer,
+			s.XDSServer,
 			s.environment)
 
 		if err != nil {

--- a/pilot/pkg/bootstrap/multicluster.go
+++ b/pilot/pkg/bootstrap/multicluster.go
@@ -29,7 +29,7 @@ func (s *Server) initClusterRegistries(args *PilotArgs) (err error) {
 			args.RegistryOptions.ClusterRegistriesNamespace,
 			args.RegistryOptions.KubeOptions,
 			s.ServiceController(),
-			s.EnvoyXdsServer,
+			s.DiscoveryServer,
 			s.environment)
 
 		if err != nil {

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -108,8 +108,7 @@ type readinessProbe func() (bool, error)
 type Server struct {
 	MonitorListeningAddr net.Addr
 
-	// TODO(nmittler): Consider alternatives to exposing these directly
-	EnvoyXdsServer *xds.DiscoveryServer
+	DiscoveryServer *xds.DiscoveryServer
 
 	clusterID   string
 	environment *model.Environment
@@ -178,7 +177,7 @@ func NewServer(args *PilotArgs) (*Server, error) {
 	s := &Server{
 		clusterID:       getClusterID(args),
 		environment:     e,
-		EnvoyXdsServer:  xds.NewDiscoveryServer(e, args.Plugins),
+		DiscoveryServer: xds.NewDiscoveryServer(e, args.Plugins),
 		fileWatcher:     filewatcher.NewWatcher(),
 		httpMux:         http.NewServeMux(),
 		readinessProbes: make(map[string]readinessProbe),
@@ -300,7 +299,7 @@ func NewServer(args *PilotArgs) (*Server, error) {
 	}
 
 	s.addReadinessProbe("discovery", func() (bool, error) {
-		return s.EnvoyXdsServer.IsServerReady(), nil
+		return s.DiscoveryServer.IsServerReady(), nil
 	})
 
 	return s, nil
@@ -356,7 +355,7 @@ func (s *Server) Start(stop <-chan struct{}) error {
 
 	// Inform Discovery Server so that it can start accepting connections.
 	log.Infof("All caches have been synced up, marking server ready")
-	s.EnvoyXdsServer.CachesSynced()
+	s.DiscoveryServer.CachesSynced()
 
 	// At this point we are ready - start Http Listener so that it can respond to readiness events.
 	go func() {
@@ -454,7 +453,7 @@ func (s *Server) initIstiodAdminServer(args *PilotArgs, wh *inject.Webhook) erro
 	}
 
 	// Debug Server.
-	s.EnvoyXdsServer.InitDebug(s.httpMux, s.ServiceController(), args.ServerOptions.EnableProfiling, wh)
+	s.DiscoveryServer.InitDebug(s.httpMux, s.ServiceController(), args.ServerOptions.EnableProfiling, wh)
 
 	// Monitoring Server.
 	if err := s.initMonitor(args.ServerOptions.MonitoringAddr); err != nil {
@@ -474,7 +473,7 @@ func (s *Server) initDiscoveryService(args *PilotArgs) error {
 	// Implement EnvoyXdsServer grace shutdown
 	s.addStartFunc(func(stop <-chan struct{}) error {
 		log.Infof("Starting ADS server")
-		s.EnvoyXdsServer.Start(stop)
+		s.DiscoveryServer.Start(stop)
 		return nil
 	})
 
@@ -539,7 +538,7 @@ func (s *Server) waitForShutdown(stop <-chan struct{}) {
 func (s *Server) initGrpcServer(options *istiokeepalive.Options) {
 	grpcOptions := s.grpcServerOptions(options)
 	s.grpcServer = grpc.NewServer(grpcOptions...)
-	s.EnvoyXdsServer.Register(s.grpcServer)
+	s.DiscoveryServer.Register(s.grpcServer)
 	reflection.Register(s.grpcServer)
 }
 
@@ -629,7 +628,7 @@ func (s *Server) initSecureDiscoveryService(args *PilotArgs) error {
 	opts = append(opts, grpc.Creds(tlsCreds))
 
 	s.secureGrpcServer = grpc.NewServer(opts...)
-	s.EnvoyXdsServer.Register(s.secureGrpcServer)
+	s.DiscoveryServer.Register(s.secureGrpcServer)
 	reflection.Register(s.secureGrpcServer)
 
 	s.addStartFunc(func(stop <-chan struct{}) error {
@@ -734,7 +733,7 @@ func (s *Server) initRegistryEventHandlers() error {
 			}: {}},
 			Reason: []model.TriggerReason{model.ServiceUpdate},
 		}
-		s.EnvoyXdsServer.ConfigUpdate(pushReq)
+		s.DiscoveryServer.ConfigUpdate(pushReq)
 	}
 	if err := s.ServiceController().AppendServiceHandler(serviceHandler); err != nil {
 		return fmt.Errorf("append service handler failed: %v", err)
@@ -744,7 +743,7 @@ func (s *Server) initRegistryEventHandlers() error {
 		// TODO: This is an incomplete code. This code path is called for legacy MCP, etc.
 		// In all cases, this is simply an instance update and not a config update. So, we need to update
 		// EDS in all proxies, and do a full config push for the instance that just changed (add/update only).
-		s.EnvoyXdsServer.ConfigUpdate(&model.PushRequest{
+		s.DiscoveryServer.ConfigUpdate(&model.PushRequest{
 			Full: true,
 			ConfigsUpdated: map[model.ConfigKey]struct{}{{
 				Kind:      gvk.ServiceEntry,
@@ -776,7 +775,7 @@ func (s *Server) initRegistryEventHandlers() error {
 				}: {}},
 				Reason: []model.TriggerReason{model.ConfigUpdate},
 			}
-			s.EnvoyXdsServer.ConfigUpdate(pushReq)
+			s.DiscoveryServer.ConfigUpdate(pushReq)
 			if features.EnableStatus {
 				if event != model.EventDelete {
 					s.statusReporter.AddInProgressResource(curr)
@@ -1071,14 +1070,14 @@ func (s *Server) initMeshHandlers() {
 	// When the mesh config or networks change, do a full push.
 	s.environment.AddMeshHandler(func() {
 		// Inform ConfigGenerator about the mesh config change so that it can rebuild any cached config, before triggering full push.
-		s.EnvoyXdsServer.ConfigGenerator.MeshConfigChanged(s.environment.Mesh())
-		s.EnvoyXdsServer.ConfigUpdate(&model.PushRequest{
+		s.DiscoveryServer.ConfigGenerator.MeshConfigChanged(s.environment.Mesh())
+		s.DiscoveryServer.ConfigUpdate(&model.PushRequest{
 			Full:   true,
 			Reason: []model.TriggerReason{model.GlobalUpdate},
 		})
 	})
 	s.environment.AddNetworksHandler(func() {
-		s.EnvoyXdsServer.ConfigUpdate(&model.PushRequest{
+		s.DiscoveryServer.ConfigUpdate(&model.PushRequest{
 			Full:   true,
 			Reason: []model.TriggerReason{model.GlobalUpdate},
 		})

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -108,7 +108,7 @@ type readinessProbe func() (bool, error)
 type Server struct {
 	MonitorListeningAddr net.Addr
 
-	DiscoveryServer *xds.DiscoveryServer
+	XDSServer *xds.DiscoveryServer
 
 	clusterID   string
 	environment *model.Environment
@@ -177,7 +177,7 @@ func NewServer(args *PilotArgs) (*Server, error) {
 	s := &Server{
 		clusterID:       getClusterID(args),
 		environment:     e,
-		DiscoveryServer: xds.NewDiscoveryServer(e, args.Plugins),
+		XDSServer:       xds.NewDiscoveryServer(e, args.Plugins),
 		fileWatcher:     filewatcher.NewWatcher(),
 		httpMux:         http.NewServeMux(),
 		readinessProbes: make(map[string]readinessProbe),
@@ -299,7 +299,7 @@ func NewServer(args *PilotArgs) (*Server, error) {
 	}
 
 	s.addReadinessProbe("discovery", func() (bool, error) {
-		return s.DiscoveryServer.IsServerReady(), nil
+		return s.XDSServer.IsServerReady(), nil
 	})
 
 	return s, nil
@@ -355,7 +355,7 @@ func (s *Server) Start(stop <-chan struct{}) error {
 
 	// Inform Discovery Server so that it can start accepting connections.
 	log.Infof("All caches have been synced up, marking server ready")
-	s.DiscoveryServer.CachesSynced()
+	s.XDSServer.CachesSynced()
 
 	// At this point we are ready - start Http Listener so that it can respond to readiness events.
 	go func() {
@@ -453,7 +453,7 @@ func (s *Server) initIstiodAdminServer(args *PilotArgs, wh *inject.Webhook) erro
 	}
 
 	// Debug Server.
-	s.DiscoveryServer.InitDebug(s.httpMux, s.ServiceController(), args.ServerOptions.EnableProfiling, wh)
+	s.XDSServer.InitDebug(s.httpMux, s.ServiceController(), args.ServerOptions.EnableProfiling, wh)
 
 	// Monitoring Server.
 	if err := s.initMonitor(args.ServerOptions.MonitoringAddr); err != nil {
@@ -473,7 +473,7 @@ func (s *Server) initDiscoveryService(args *PilotArgs) error {
 	// Implement EnvoyXdsServer grace shutdown
 	s.addStartFunc(func(stop <-chan struct{}) error {
 		log.Infof("Starting ADS server")
-		s.DiscoveryServer.Start(stop)
+		s.XDSServer.Start(stop)
 		return nil
 	})
 
@@ -538,7 +538,7 @@ func (s *Server) waitForShutdown(stop <-chan struct{}) {
 func (s *Server) initGrpcServer(options *istiokeepalive.Options) {
 	grpcOptions := s.grpcServerOptions(options)
 	s.grpcServer = grpc.NewServer(grpcOptions...)
-	s.DiscoveryServer.Register(s.grpcServer)
+	s.XDSServer.Register(s.grpcServer)
 	reflection.Register(s.grpcServer)
 }
 
@@ -628,7 +628,7 @@ func (s *Server) initSecureDiscoveryService(args *PilotArgs) error {
 	opts = append(opts, grpc.Creds(tlsCreds))
 
 	s.secureGrpcServer = grpc.NewServer(opts...)
-	s.DiscoveryServer.Register(s.secureGrpcServer)
+	s.XDSServer.Register(s.secureGrpcServer)
 	reflection.Register(s.secureGrpcServer)
 
 	s.addStartFunc(func(stop <-chan struct{}) error {
@@ -733,7 +733,7 @@ func (s *Server) initRegistryEventHandlers() error {
 			}: {}},
 			Reason: []model.TriggerReason{model.ServiceUpdate},
 		}
-		s.DiscoveryServer.ConfigUpdate(pushReq)
+		s.XDSServer.ConfigUpdate(pushReq)
 	}
 	if err := s.ServiceController().AppendServiceHandler(serviceHandler); err != nil {
 		return fmt.Errorf("append service handler failed: %v", err)
@@ -743,7 +743,7 @@ func (s *Server) initRegistryEventHandlers() error {
 		// TODO: This is an incomplete code. This code path is called for legacy MCP, etc.
 		// In all cases, this is simply an instance update and not a config update. So, we need to update
 		// EDS in all proxies, and do a full config push for the instance that just changed (add/update only).
-		s.DiscoveryServer.ConfigUpdate(&model.PushRequest{
+		s.XDSServer.ConfigUpdate(&model.PushRequest{
 			Full: true,
 			ConfigsUpdated: map[model.ConfigKey]struct{}{{
 				Kind:      gvk.ServiceEntry,
@@ -775,7 +775,7 @@ func (s *Server) initRegistryEventHandlers() error {
 				}: {}},
 				Reason: []model.TriggerReason{model.ConfigUpdate},
 			}
-			s.DiscoveryServer.ConfigUpdate(pushReq)
+			s.XDSServer.ConfigUpdate(pushReq)
 			if features.EnableStatus {
 				if event != model.EventDelete {
 					s.statusReporter.AddInProgressResource(curr)
@@ -1070,14 +1070,14 @@ func (s *Server) initMeshHandlers() {
 	// When the mesh config or networks change, do a full push.
 	s.environment.AddMeshHandler(func() {
 		// Inform ConfigGenerator about the mesh config change so that it can rebuild any cached config, before triggering full push.
-		s.DiscoveryServer.ConfigGenerator.MeshConfigChanged(s.environment.Mesh())
-		s.DiscoveryServer.ConfigUpdate(&model.PushRequest{
+		s.XDSServer.ConfigGenerator.MeshConfigChanged(s.environment.Mesh())
+		s.XDSServer.ConfigUpdate(&model.PushRequest{
 			Full:   true,
 			Reason: []model.TriggerReason{model.GlobalUpdate},
 		})
 	})
 	s.environment.AddNetworksHandler(func() {
-		s.DiscoveryServer.ConfigUpdate(&model.PushRequest{
+		s.XDSServer.ConfigUpdate(&model.PushRequest{
 			Full:   true,
 			Reason: []model.TriggerReason{model.GlobalUpdate},
 		})

--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -57,7 +57,7 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 		}
 	}
 
-	s.serviceEntryStore = serviceentry.NewServiceDiscovery(s.configController, s.environment.IstioConfigStore, s.EnvoyXdsServer)
+	s.serviceEntryStore = serviceentry.NewServiceDiscovery(s.configController, s.environment.IstioConfigStore, s.DiscoveryServer)
 	serviceControllers.AddRegistry(s.serviceEntryStore)
 
 	if features.EnableServiceEntrySelectPods && s.kubeRegistry != nil {
@@ -83,7 +83,7 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 func (s *Server) initKubeRegistry(serviceControllers *aggregate.Controller, args *PilotArgs) (err error) {
 	args.RegistryOptions.KubeOptions.ClusterID = s.clusterID
 	args.RegistryOptions.KubeOptions.Metrics = s.environment
-	args.RegistryOptions.KubeOptions.XDSUpdater = s.EnvoyXdsServer
+	args.RegistryOptions.KubeOptions.XDSUpdater = s.DiscoveryServer
 	args.RegistryOptions.KubeOptions.NetworksWatcher = s.environment.NetworksWatcher
 	if features.EnableEndpointSliceController {
 		args.RegistryOptions.KubeOptions.EndpointMode = kubecontroller.EndpointSliceOnly

--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -57,7 +57,7 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 		}
 	}
 
-	s.serviceEntryStore = serviceentry.NewServiceDiscovery(s.configController, s.environment.IstioConfigStore, s.DiscoveryServer)
+	s.serviceEntryStore = serviceentry.NewServiceDiscovery(s.configController, s.environment.IstioConfigStore, s.XDSServer)
 	serviceControllers.AddRegistry(s.serviceEntryStore)
 
 	if features.EnableServiceEntrySelectPods && s.kubeRegistry != nil {
@@ -83,7 +83,7 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 func (s *Server) initKubeRegistry(serviceControllers *aggregate.Controller, args *PilotArgs) (err error) {
 	args.RegistryOptions.KubeOptions.ClusterID = s.clusterID
 	args.RegistryOptions.KubeOptions.Metrics = s.environment
-	args.RegistryOptions.KubeOptions.XDSUpdater = s.DiscoveryServer
+	args.RegistryOptions.KubeOptions.XDSUpdater = s.XDSServer
 	args.RegistryOptions.KubeOptions.NetworksWatcher = s.environment.NetworksWatcher
 	if features.EnableEndpointSliceController {
 		args.RegistryOptions.KubeOptions.EndpointMode = kubecontroller.EndpointSliceOnly

--- a/pilot/pkg/xds/lds_test.go
+++ b/pilot/pkg/xds/lds_test.go
@@ -125,7 +125,7 @@ func TestLDSIsolated(t *testing.T) {
 // TestLDS using default sidecar in root namespace
 func TestLDSWithDefaultSidecar(t *testing.T) {
 
-	server, tearDown := util.EnsureTestServer(func(args *bootstrap.PilotArgs) {
+	s, tearDown := util.EnsureTestServer(func(args *bootstrap.PilotArgs) {
 		args.Plugins = bootstrap.DefaultPlugins
 		args.RegistryOptions.FileDir = env.IstioSrc + "/tests/testdata/networking/sidecar-ns-scope"
 		args.MeshConfigFile = env.IstioSrc + "/tests/testdata/networking/sidecar-ns-scope/mesh.yaml"
@@ -137,7 +137,7 @@ func TestLDSWithDefaultSidecar(t *testing.T) {
 	testEnv.IstioSrc = env.IstioSrc
 	testEnv.IstioOut = env.IstioOut
 
-	server.XDSServer.ConfigUpdate(&model.PushRequest{Full: true})
+	s.XDSServer.ConfigUpdate(&model.PushRequest{Full: true})
 	defer tearDown()
 
 	adsResponse, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.Config{
@@ -185,7 +185,7 @@ func TestLDSWithDefaultSidecar(t *testing.T) {
 
 // TestLDS using gateways
 func TestLDSWithIngressGateway(t *testing.T) {
-	server, tearDown := util.EnsureTestServer(func(args *bootstrap.PilotArgs) {
+	s, tearDown := util.EnsureTestServer(func(args *bootstrap.PilotArgs) {
 		args.Plugins = bootstrap.DefaultPlugins
 		args.RegistryOptions.FileDir = env.IstioSrc + "/tests/testdata/networking/ingress-gateway"
 		args.MeshConfigFile = env.IstioSrc + "/tests/testdata/networking/ingress-gateway/mesh.yaml"
@@ -197,7 +197,7 @@ func TestLDSWithIngressGateway(t *testing.T) {
 	testEnv.IstioSrc = env.IstioSrc
 	testEnv.IstioOut = env.IstioOut
 
-	server.XDSServer.ConfigUpdate(&model.PushRequest{Full: true})
+	s.XDSServer.ConfigUpdate(&model.PushRequest{Full: true})
 	defer tearDown()
 
 	adsResponse, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.Config{
@@ -283,13 +283,13 @@ func TestLDS(t *testing.T) {
 
 // TestLDS using sidecar scoped on workload without Service
 func TestLDSWithSidecarForWorkloadWithoutService(t *testing.T) {
-	server, tearDown := util.EnsureTestServer(func(args *bootstrap.PilotArgs) {
+	s, tearDown := util.EnsureTestServer(func(args *bootstrap.PilotArgs) {
 		args.Plugins = bootstrap.DefaultPlugins
 		args.RegistryOptions.FileDir = env.IstioSrc + "/tests/testdata/networking/sidecar-without-service"
 		args.MeshConfigFile = env.IstioSrc + "/tests/testdata/networking/sidecar-without-service/mesh.yaml"
 		args.RegistryOptions.Registries = []string{}
 	})
-	registry := memServiceDiscovery(server, t)
+	registry := memServiceDiscovery(s, t)
 	registry.AddWorkload("98.1.1.1", labels.Instance{"app": "consumeronly"}) // These labels must match the sidecars workload selector
 
 	testEnv = env.NewTestSetup(env.SidecarConsumerOnlyTest, t)
@@ -298,7 +298,7 @@ func TestLDSWithSidecarForWorkloadWithoutService(t *testing.T) {
 	testEnv.IstioSrc = env.IstioSrc
 	testEnv.IstioOut = env.IstioOut
 
-	server.XDSServer.ConfigUpdate(&model.PushRequest{Full: true})
+	s.XDSServer.ConfigUpdate(&model.PushRequest{Full: true})
 	defer tearDown()
 
 	adsResponse, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.Config{
@@ -358,13 +358,13 @@ func TestLDSWithSidecarForWorkloadWithoutService(t *testing.T) {
 
 // TestLDS using default sidecar in root namespace
 func TestLDSEnvoyFilterWithWorkloadSelector(t *testing.T) {
-	server, tearDown := util.EnsureTestServer(func(args *bootstrap.PilotArgs) {
+	s, tearDown := util.EnsureTestServer(func(args *bootstrap.PilotArgs) {
 		args.Plugins = bootstrap.DefaultPlugins
 		args.RegistryOptions.FileDir = env.IstioSrc + "/tests/testdata/networking/envoyfilter-without-service"
 		args.MeshConfigFile = env.IstioSrc + "/tests/testdata/networking/envoyfilter-without-service/mesh.yaml"
 		args.RegistryOptions.Registries = []string{}
 	})
-	registry := memServiceDiscovery(server, t)
+	registry := memServiceDiscovery(s, t)
 	// The labels of 98.1.1.1 must match the envoyfilter workload selector
 	registry.AddWorkload("98.1.1.1", labels.Instance{"app": "envoyfilter-test-app", "some": "otherlabel"})
 	registry.AddWorkload("98.1.1.2", labels.Instance{"app": "no-envoyfilter-test-app"})
@@ -376,7 +376,7 @@ func TestLDSEnvoyFilterWithWorkloadSelector(t *testing.T) {
 	testEnv.IstioSrc = env.IstioSrc
 	testEnv.IstioOut = env.IstioOut
 
-	server.XDSServer.ConfigUpdate(&model.PushRequest{Full: true})
+	s.XDSServer.ConfigUpdate(&model.PushRequest{Full: true})
 	defer tearDown()
 
 	tests := []struct {

--- a/pilot/pkg/xds/lds_test.go
+++ b/pilot/pkg/xds/lds_test.go
@@ -137,7 +137,7 @@ func TestLDSWithDefaultSidecar(t *testing.T) {
 	testEnv.IstioSrc = env.IstioSrc
 	testEnv.IstioOut = env.IstioOut
 
-	server.DiscoveryServer.ConfigUpdate(&model.PushRequest{Full: true})
+	server.XDSServer.ConfigUpdate(&model.PushRequest{Full: true})
 	defer tearDown()
 
 	adsResponse, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.Config{
@@ -197,7 +197,7 @@ func TestLDSWithIngressGateway(t *testing.T) {
 	testEnv.IstioSrc = env.IstioSrc
 	testEnv.IstioOut = env.IstioOut
 
-	server.DiscoveryServer.ConfigUpdate(&model.PushRequest{Full: true})
+	server.XDSServer.ConfigUpdate(&model.PushRequest{Full: true})
 	defer tearDown()
 
 	adsResponse, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.Config{
@@ -298,7 +298,7 @@ func TestLDSWithSidecarForWorkloadWithoutService(t *testing.T) {
 	testEnv.IstioSrc = env.IstioSrc
 	testEnv.IstioOut = env.IstioOut
 
-	server.DiscoveryServer.ConfigUpdate(&model.PushRequest{Full: true})
+	server.XDSServer.ConfigUpdate(&model.PushRequest{Full: true})
 	defer tearDown()
 
 	adsResponse, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.Config{
@@ -376,7 +376,7 @@ func TestLDSEnvoyFilterWithWorkloadSelector(t *testing.T) {
 	testEnv.IstioSrc = env.IstioSrc
 	testEnv.IstioOut = env.IstioOut
 
-	server.DiscoveryServer.ConfigUpdate(&model.PushRequest{Full: true})
+	server.XDSServer.ConfigUpdate(&model.PushRequest{Full: true})
 	defer tearDown()
 
 	tests := []struct {

--- a/pilot/pkg/xds/lds_test.go
+++ b/pilot/pkg/xds/lds_test.go
@@ -137,7 +137,7 @@ func TestLDSWithDefaultSidecar(t *testing.T) {
 	testEnv.IstioSrc = env.IstioSrc
 	testEnv.IstioOut = env.IstioOut
 
-	server.EnvoyXdsServer.ConfigUpdate(&model.PushRequest{Full: true})
+	server.DiscoveryServer.ConfigUpdate(&model.PushRequest{Full: true})
 	defer tearDown()
 
 	adsResponse, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.Config{
@@ -197,7 +197,7 @@ func TestLDSWithIngressGateway(t *testing.T) {
 	testEnv.IstioSrc = env.IstioSrc
 	testEnv.IstioOut = env.IstioOut
 
-	server.EnvoyXdsServer.ConfigUpdate(&model.PushRequest{Full: true})
+	server.DiscoveryServer.ConfigUpdate(&model.PushRequest{Full: true})
 	defer tearDown()
 
 	adsResponse, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.Config{
@@ -298,7 +298,7 @@ func TestLDSWithSidecarForWorkloadWithoutService(t *testing.T) {
 	testEnv.IstioSrc = env.IstioSrc
 	testEnv.IstioOut = env.IstioOut
 
-	server.EnvoyXdsServer.ConfigUpdate(&model.PushRequest{Full: true})
+	server.DiscoveryServer.ConfigUpdate(&model.PushRequest{Full: true})
 	defer tearDown()
 
 	adsResponse, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.Config{
@@ -376,7 +376,7 @@ func TestLDSEnvoyFilterWithWorkloadSelector(t *testing.T) {
 	testEnv.IstioSrc = env.IstioSrc
 	testEnv.IstioOut = env.IstioOut
 
-	server.EnvoyXdsServer.ConfigUpdate(&model.PushRequest{Full: true})
+	server.DiscoveryServer.ConfigUpdate(&model.PushRequest{Full: true})
 	defer tearDown()
 
 	tests := []struct {

--- a/pilot/pkg/xds/simple_test.go
+++ b/pilot/pkg/xds/simple_test.go
@@ -144,7 +144,7 @@ func localPilotTestEnv(
 	initFunc(server)
 
 	// Trigger a push, to initiate push context with contents of registry.
-	server.DiscoveryServer.Push(&model.PushRequest{Full: true})
+	server.XDSServer.Push(&model.PushRequest{Full: true})
 
 	// Wait till a push is propagated.
 	time.Sleep(200 * time.Millisecond)
@@ -165,7 +165,7 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 	return localPilotTestEnv(t, func(server *bootstrap.Server) {
 		// Service and endpoints for hello.default - used in v1 pilot tests
 		hostname := host.Name("hello.default.svc.cluster.local")
-		server.DiscoveryServer.MemRegistry.AddService(hostname, &model.Service{
+		server.XDSServer.MemRegistry.AddService(hostname, &model.Service{
 			Hostname: hostname,
 			Address:  "10.10.0.3",
 			Ports:    testPorts(0),
@@ -175,7 +175,7 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 			},
 		})
 
-		server.DiscoveryServer.MemRegistry.SetEndpoints(string(hostname), "default", []*model.IstioEndpoint{
+		server.XDSServer.MemRegistry.SetEndpoints(string(hostname), "default", []*model.IstioEndpoint{
 			{
 				Address:         "127.0.0.1",
 				EndpointPort:    uint32(testEnv.Ports().BackendPort),
@@ -187,7 +187,7 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 
 		// "local" service points to the current host
 		hostname = "local.default.svc.cluster.local"
-		server.DiscoveryServer.MemRegistry.AddService(hostname, &model.Service{
+		server.XDSServer.MemRegistry.AddService(hostname, &model.Service{
 			Hostname: hostname,
 			Address:  "10.10.0.4",
 			Ports: []*model.Port{
@@ -202,7 +202,7 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 			},
 		})
 
-		server.DiscoveryServer.MemRegistry.SetEndpoints(string(hostname), "default", []*model.IstioEndpoint{
+		server.XDSServer.MemRegistry.SetEndpoints(string(hostname), "default", []*model.IstioEndpoint{
 			{
 				Address:         localIP,
 				EndpointPort:    uint32(testEnv.Ports().BackendPort),
@@ -214,7 +214,7 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 		// Explicit test service, in the v2 memory registry. Similar with mock.MakeService,
 		// but easier to read.
 		hostname = "service3.default.svc.cluster.local"
-		server.DiscoveryServer.MemRegistry.AddService(hostname, &model.Service{
+		server.XDSServer.MemRegistry.AddService(hostname, &model.Service{
 			Hostname: hostname,
 			Address:  "10.10.0.1",
 			Ports:    testPorts(0),
@@ -234,10 +234,10 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 			}
 		}
 
-		server.DiscoveryServer.MemRegistry.SetEndpoints(string(hostname), "default", svc3Endpoints)
+		server.XDSServer.MemRegistry.SetEndpoints(string(hostname), "default", svc3Endpoints)
 
 		// Mock ingress service
-		server.DiscoveryServer.MemRegistry.AddService("istio-ingress.istio-system.svc.cluster.local", &model.Service{
+		server.XDSServer.MemRegistry.AddService("istio-ingress.istio-system.svc.cluster.local", &model.Service{
 			Hostname: "istio-ingress.istio-system.svc.cluster.local",
 			Address:  "10.10.0.2",
 			Ports: []*model.Port{
@@ -254,7 +254,7 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 			},
 			// TODO: set attribute for this service. It may affect TestLDSIsolated as we now having service defined in istio-system namespaces
 		})
-		server.DiscoveryServer.MemRegistry.AddInstance("istio-ingress.istio-system.svc.cluster.local", &model.ServiceInstance{
+		server.XDSServer.MemRegistry.AddInstance("istio-ingress.istio-system.svc.cluster.local", &model.ServiceInstance{
 			Endpoint: &model.IstioEndpoint{
 				Address:         ingressIP,
 				EndpointPort:    80,
@@ -268,7 +268,7 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 				Protocol: protocol.HTTP,
 			},
 		})
-		server.DiscoveryServer.MemRegistry.AddInstance("istio-ingress.istio-system.svc.cluster.local", &model.ServiceInstance{
+		server.XDSServer.MemRegistry.AddInstance("istio-ingress.istio-system.svc.cluster.local", &model.ServiceInstance{
 			Endpoint: &model.IstioEndpoint{
 				Address:         ingressIP,
 				EndpointPort:    443,
@@ -285,7 +285,7 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 
 		// RouteConf Service4 is using port 80, to test that we generate multiple clusters (regression)
 		// service4 has no endpoints
-		server.DiscoveryServer.MemRegistry.AddHTTPService("service4.default.svc.cluster.local", "10.1.0.4", 80)
+		server.XDSServer.MemRegistry.AddHTTPService("service4.default.svc.cluster.local", "10.1.0.4", 80)
 	})
 }
 

--- a/pilot/pkg/xds/simple_test.go
+++ b/pilot/pkg/xds/simple_test.go
@@ -162,10 +162,10 @@ func localPilotTestEnv(
 // The server will have a set of pre-defined instances and services, and read CRDs from the
 // common tests/testdata directory.
 func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) {
-	return localPilotTestEnv(t, func(server *bootstrap.Server) {
+	return localPilotTestEnv(t, func(s *bootstrap.Server) {
 		// Service and endpoints for hello.default - used in v1 pilot tests
 		hostname := host.Name("hello.default.svc.cluster.local")
-		server.XDSServer.MemRegistry.AddService(hostname, &model.Service{
+		s.XDSServer.MemRegistry.AddService(hostname, &model.Service{
 			Hostname: hostname,
 			Address:  "10.10.0.3",
 			Ports:    testPorts(0),
@@ -175,7 +175,7 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 			},
 		})
 
-		server.XDSServer.MemRegistry.SetEndpoints(string(hostname), "default", []*model.IstioEndpoint{
+		s.XDSServer.MemRegistry.SetEndpoints(string(hostname), "default", []*model.IstioEndpoint{
 			{
 				Address:         "127.0.0.1",
 				EndpointPort:    uint32(testEnv.Ports().BackendPort),
@@ -187,7 +187,7 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 
 		// "local" service points to the current host
 		hostname = "local.default.svc.cluster.local"
-		server.XDSServer.MemRegistry.AddService(hostname, &model.Service{
+		s.XDSServer.MemRegistry.AddService(hostname, &model.Service{
 			Hostname: hostname,
 			Address:  "10.10.0.4",
 			Ports: []*model.Port{
@@ -202,7 +202,7 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 			},
 		})
 
-		server.XDSServer.MemRegistry.SetEndpoints(string(hostname), "default", []*model.IstioEndpoint{
+		s.XDSServer.MemRegistry.SetEndpoints(string(hostname), "default", []*model.IstioEndpoint{
 			{
 				Address:         localIP,
 				EndpointPort:    uint32(testEnv.Ports().BackendPort),
@@ -214,7 +214,7 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 		// Explicit test service, in the v2 memory registry. Similar with mock.MakeService,
 		// but easier to read.
 		hostname = "service3.default.svc.cluster.local"
-		server.XDSServer.MemRegistry.AddService(hostname, &model.Service{
+		s.XDSServer.MemRegistry.AddService(hostname, &model.Service{
 			Hostname: hostname,
 			Address:  "10.10.0.1",
 			Ports:    testPorts(0),
@@ -234,10 +234,10 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 			}
 		}
 
-		server.XDSServer.MemRegistry.SetEndpoints(string(hostname), "default", svc3Endpoints)
+		s.XDSServer.MemRegistry.SetEndpoints(string(hostname), "default", svc3Endpoints)
 
 		// Mock ingress service
-		server.XDSServer.MemRegistry.AddService("istio-ingress.istio-system.svc.cluster.local", &model.Service{
+		s.XDSServer.MemRegistry.AddService("istio-ingress.istio-system.svc.cluster.local", &model.Service{
 			Hostname: "istio-ingress.istio-system.svc.cluster.local",
 			Address:  "10.10.0.2",
 			Ports: []*model.Port{
@@ -254,7 +254,7 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 			},
 			// TODO: set attribute for this service. It may affect TestLDSIsolated as we now having service defined in istio-system namespaces
 		})
-		server.XDSServer.MemRegistry.AddInstance("istio-ingress.istio-system.svc.cluster.local", &model.ServiceInstance{
+		s.XDSServer.MemRegistry.AddInstance("istio-ingress.istio-system.svc.cluster.local", &model.ServiceInstance{
 			Endpoint: &model.IstioEndpoint{
 				Address:         ingressIP,
 				EndpointPort:    80,
@@ -268,7 +268,7 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 				Protocol: protocol.HTTP,
 			},
 		})
-		server.XDSServer.MemRegistry.AddInstance("istio-ingress.istio-system.svc.cluster.local", &model.ServiceInstance{
+		s.XDSServer.MemRegistry.AddInstance("istio-ingress.istio-system.svc.cluster.local", &model.ServiceInstance{
 			Endpoint: &model.IstioEndpoint{
 				Address:         ingressIP,
 				EndpointPort:    443,
@@ -285,7 +285,7 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 
 		// RouteConf Service4 is using port 80, to test that we generate multiple clusters (regression)
 		// service4 has no endpoints
-		server.XDSServer.MemRegistry.AddHTTPService("service4.default.svc.cluster.local", "10.1.0.4", 80)
+		s.XDSServer.MemRegistry.AddHTTPService("service4.default.svc.cluster.local", "10.1.0.4", 80)
 	})
 }
 

--- a/pilot/pkg/xds/simple_test.go
+++ b/pilot/pkg/xds/simple_test.go
@@ -46,7 +46,7 @@ import (
 // envoy accepts the config. Most tests are changing and checking the state of pilot.
 //
 // The pilot is accessible as pilotServer, which is an instance of bootstrap.Server.
-// The server has a field EnvoyXdsServer which is the configured instance of the XDS service.
+// The server has a field DiscoveryServer which is the configured instance of the XDS service.
 //
 // DiscoveryServer.MemRegistry has a memory registry that can be used by tests,
 // implemented in debug.go file.
@@ -144,7 +144,7 @@ func localPilotTestEnv(
 	initFunc(server)
 
 	// Trigger a push, to initiate push context with contents of registry.
-	server.EnvoyXdsServer.Push(&model.PushRequest{Full: true})
+	server.DiscoveryServer.Push(&model.PushRequest{Full: true})
 
 	// Wait till a push is propagated.
 	time.Sleep(200 * time.Millisecond)
@@ -165,7 +165,7 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 	return localPilotTestEnv(t, func(server *bootstrap.Server) {
 		// Service and endpoints for hello.default - used in v1 pilot tests
 		hostname := host.Name("hello.default.svc.cluster.local")
-		server.EnvoyXdsServer.MemRegistry.AddService(hostname, &model.Service{
+		server.DiscoveryServer.MemRegistry.AddService(hostname, &model.Service{
 			Hostname: hostname,
 			Address:  "10.10.0.3",
 			Ports:    testPorts(0),
@@ -175,7 +175,7 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 			},
 		})
 
-		server.EnvoyXdsServer.MemRegistry.SetEndpoints(string(hostname), "default", []*model.IstioEndpoint{
+		server.DiscoveryServer.MemRegistry.SetEndpoints(string(hostname), "default", []*model.IstioEndpoint{
 			{
 				Address:         "127.0.0.1",
 				EndpointPort:    uint32(testEnv.Ports().BackendPort),
@@ -187,7 +187,7 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 
 		// "local" service points to the current host
 		hostname = "local.default.svc.cluster.local"
-		server.EnvoyXdsServer.MemRegistry.AddService(hostname, &model.Service{
+		server.DiscoveryServer.MemRegistry.AddService(hostname, &model.Service{
 			Hostname: hostname,
 			Address:  "10.10.0.4",
 			Ports: []*model.Port{
@@ -202,7 +202,7 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 			},
 		})
 
-		server.EnvoyXdsServer.MemRegistry.SetEndpoints(string(hostname), "default", []*model.IstioEndpoint{
+		server.DiscoveryServer.MemRegistry.SetEndpoints(string(hostname), "default", []*model.IstioEndpoint{
 			{
 				Address:         localIP,
 				EndpointPort:    uint32(testEnv.Ports().BackendPort),
@@ -214,7 +214,7 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 		// Explicit test service, in the v2 memory registry. Similar with mock.MakeService,
 		// but easier to read.
 		hostname = "service3.default.svc.cluster.local"
-		server.EnvoyXdsServer.MemRegistry.AddService(hostname, &model.Service{
+		server.DiscoveryServer.MemRegistry.AddService(hostname, &model.Service{
 			Hostname: hostname,
 			Address:  "10.10.0.1",
 			Ports:    testPorts(0),
@@ -234,10 +234,10 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 			}
 		}
 
-		server.EnvoyXdsServer.MemRegistry.SetEndpoints(string(hostname), "default", svc3Endpoints)
+		server.DiscoveryServer.MemRegistry.SetEndpoints(string(hostname), "default", svc3Endpoints)
 
 		// Mock ingress service
-		server.EnvoyXdsServer.MemRegistry.AddService("istio-ingress.istio-system.svc.cluster.local", &model.Service{
+		server.DiscoveryServer.MemRegistry.AddService("istio-ingress.istio-system.svc.cluster.local", &model.Service{
 			Hostname: "istio-ingress.istio-system.svc.cluster.local",
 			Address:  "10.10.0.2",
 			Ports: []*model.Port{
@@ -254,7 +254,7 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 			},
 			// TODO: set attribute for this service. It may affect TestLDSIsolated as we now having service defined in istio-system namespaces
 		})
-		server.EnvoyXdsServer.MemRegistry.AddInstance("istio-ingress.istio-system.svc.cluster.local", &model.ServiceInstance{
+		server.DiscoveryServer.MemRegistry.AddInstance("istio-ingress.istio-system.svc.cluster.local", &model.ServiceInstance{
 			Endpoint: &model.IstioEndpoint{
 				Address:         ingressIP,
 				EndpointPort:    80,
@@ -268,7 +268,7 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 				Protocol: protocol.HTTP,
 			},
 		})
-		server.EnvoyXdsServer.MemRegistry.AddInstance("istio-ingress.istio-system.svc.cluster.local", &model.ServiceInstance{
+		server.DiscoveryServer.MemRegistry.AddInstance("istio-ingress.istio-system.svc.cluster.local", &model.ServiceInstance{
 			Endpoint: &model.IstioEndpoint{
 				Address:         ingressIP,
 				EndpointPort:    443,
@@ -285,7 +285,7 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 
 		// RouteConf Service4 is using port 80, to test that we generate multiple clusters (regression)
 		// service4 has no endpoints
-		server.EnvoyXdsServer.MemRegistry.AddHTTPService("service4.default.svc.cluster.local", "10.1.0.4", 80)
+		server.DiscoveryServer.MemRegistry.AddHTTPService("service4.default.svc.cluster.local", "10.1.0.4", 80)
 	})
 }
 


### PR DESCRIPTION
Rename `EnvoyXdsServer` -> 'DiscoveryServer` as it is not just for Envoy now.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ Z] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
