### PR TITLE
Add pure in-memory analyzer source

### DIFF
--- a/galley/pkg/config/analysis/local/analyze.go
+++ b/galley/pkg/config/analysis/local/analyze.go
@@ -38,9 +38,10 @@ import (
 	"istio.io/istio/galley/pkg/config/processor"
 	"istio.io/istio/galley/pkg/config/processor/transforms"
 	"istio.io/istio/galley/pkg/config/scope"
+	"istio.io/istio/galley/pkg/config/source/inmemory"
 	"istio.io/istio/galley/pkg/config/source/kube"
 	"istio.io/istio/galley/pkg/config/source/kube/apiserver"
-	"istio.io/istio/galley/pkg/config/source/kube/inmemory"
+	kube_inmemory "istio.io/istio/galley/pkg/config/source/kube/inmemory"
 	"istio.io/istio/galley/pkg/config/util/kuberesource"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/mesh"
@@ -243,7 +244,7 @@ func (sa *SourceAnalyzer) SetSuppressions(suppressions []snapshotter.AnalysisSup
 
 // AddReaderKubeSource adds a source based on the specified k8s yaml files to the current SourceAnalyzer
 func (sa *SourceAnalyzer) AddReaderKubeSource(readers []ReaderSource) error {
-	src := inmemory.NewKubeSource(sa.kubeResources)
+	src := kube_inmemory.NewKubeSource(sa.kubeResources)
 	src.SetDefaultNamespace(sa.namespace)
 
 	var errs error
@@ -291,6 +292,12 @@ func (sa *SourceAnalyzer) AddRunningKubeSource(k kube.Interfaces) {
 		Client:  k,
 		Schemas: sa.kubeResources,
 	})
+	sa.sources = append(sa.sources, precedenceSourceInput{src: src, cols: sa.kubeResources.CollectionNames()})
+}
+
+// AddInMemorySource adds a source based on user supplied in-memory configs to the current SourceAnalyzer
+// Assumes that the in memory source has same or subset of resource types that this analyzer is configured with.
+func (sa *SourceAnalyzer) AddInMemorySource(src *inmemory.Source) {
 	sa.sources = append(sa.sources, precedenceSourceInput{src: src, cols: sa.kubeResources.CollectionNames()})
 }
 

--- a/galley/pkg/config/analysis/local/analyze.go
+++ b/galley/pkg/config/analysis/local/analyze.go
@@ -297,6 +297,7 @@ func (sa *SourceAnalyzer) AddRunningKubeSource(k kube.Interfaces) {
 
 // AddInMemorySource adds a source based on user supplied in-memory configs to the current SourceAnalyzer
 // Assumes that the in memory source has same or subset of resource types that this analyzer is configured with.
+// This can be used by external users who import the analyzer as a module within their own controllers.
 func (sa *SourceAnalyzer) AddInMemorySource(src *inmemory.Source) {
 	sa.sources = append(sa.sources, precedenceSourceInput{src: src, cols: sa.kubeResources.CollectionNames()})
 }

--- a/galley/pkg/config/analysis/local/analyze_test.go
+++ b/galley/pkg/config/analysis/local/analyze_test.go
@@ -29,8 +29,9 @@ import (
 	"istio.io/istio/galley/pkg/config/analysis"
 	"istio.io/istio/galley/pkg/config/analysis/msg"
 	"istio.io/istio/galley/pkg/config/mesh"
+	"istio.io/istio/galley/pkg/config/source/inmemory"
 	"istio.io/istio/galley/pkg/config/source/kube/apiserver"
-	"istio.io/istio/galley/pkg/config/source/kube/inmemory"
+	kube_inmemory "istio.io/istio/galley/pkg/config/source/kube/inmemory"
 	"istio.io/istio/galley/pkg/config/testing/basicmeta"
 	"istio.io/istio/galley/pkg/config/testing/data"
 	"istio.io/istio/galley/pkg/config/testing/k8smeta"
@@ -134,6 +135,19 @@ func TestFilterOutputByNamespace(t *testing.T) {
 	g.Expect(result.Messages).To(ConsistOf(msg1))
 }
 
+func TestAddInMemorySource(t *testing.T) {
+	g := NewWithT(t)
+
+	sa := NewSourceAnalyzer(k8smeta.MustGet(), blankCombinedAnalyzer, "", "", nil, false, timeout)
+
+	src := inmemory.New(sa.kubeResources)
+	sa.AddInMemorySource(src)
+	g.Expect(*sa.meshCfg).To(Equal(*mesh.DefaultMeshConfig())) // Base default meshcfg
+	g.Expect(sa.meshNetworks.Networks).To(HaveLen(0))
+	g.Expect(sa.sources).To(HaveLen(1))
+	g.Expect(sa.sources[0].src).To(BeAssignableToTypeOf(&inmemory.Source{})) // Resources via in-memory server
+}
+
 func TestAddRunningKubeSource(t *testing.T) {
 	g := NewWithT(t)
 
@@ -195,7 +209,7 @@ func TestAddReaderKubeSource(t *testing.T) {
 	g.Expect(err).To(BeNil())
 	g.Expect(*sa.meshCfg).To(Equal(*mesh.DefaultMeshConfig())) // Base default meshcfg
 	g.Expect(sa.sources).To(HaveLen(1))
-	g.Expect(sa.sources[0].src).To(BeAssignableToTypeOf(&inmemory.KubeSource{})) // Resources via files
+	g.Expect(sa.sources[0].src).To(BeAssignableToTypeOf(&kube_inmemory.KubeSource{})) // Resources via files
 
 	// Note that a blank file for mesh cfg is equivalent to specifying all the defaults
 	testRootNamespace := "testNamespace"


### PR DESCRIPTION
We are using analyzers but its triggered directly from inside our code
as opposed to istioctl. Since the resources are already parsed, it does not
make sense to initiate a kube in memory source (that requires YAML strings).
Added the in-memory source as a source for the analyzer so that external
code using the analyzer as a library can import it.



[x] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x ] Does not have any changes that may affect Istio users.