### PR TITLE
Registry initial sync

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -274,6 +274,7 @@ func NewServer(args *PilotArgs) (*Server, error) {
 		args.RegistryOptions.KubeOptions.FetchCaRoot = s.fetchCARoot
 	}
 
+	// TODO(landow) ensure any multicluster registries are initialized before allowing IsServerReady to be true
 	if err := s.initClusterRegistries(args); err != nil {
 		return nil, fmt.Errorf("error initializing cluster registries: %v", err)
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/fake.go
+++ b/pilot/pkg/serviceregistry/kube/controller/fake.go
@@ -22,8 +22,6 @@ import (
 
 	kubelib "istio.io/istio/pkg/kube"
 
-	"github.com/hashicorp/go-multierror"
-
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/mesh"
 )
@@ -133,25 +131,6 @@ type FakeControllerOptions struct {
 
 type FakeController struct {
 	*Controller
-}
-
-func (f *FakeController) ForceResync() error {
-	// TODO this workaround fixes a flake that indicates a real issue.
-	// TODO(cont) See https://github.com/istio/istio/issues/24117 and https://github.com/istio/istio/pull/24339
-	var err *multierror.Error
-	for _, s := range f.nodeInformer.GetStore().List() {
-		err = multierror.Append(err, f.onNodeEvent(s, model.EventAdd))
-	}
-	for _, s := range f.serviceInformer.GetStore().List() {
-		err = multierror.Append(err, f.onServiceEvent(s, model.EventAdd))
-	}
-	for _, s := range f.pods.informer.GetStore().List() {
-		err = multierror.Append(err, f.pods.onEvent(s, model.EventAdd))
-	}
-	for _, s := range f.endpoints.getInformer().GetStore().List() {
-		err = multierror.Append(err, f.endpoints.onEvent(s, model.EventAdd))
-	}
-	return err.ErrorOrNil()
 }
 
 func NewFakeControllerWithOptions(opts FakeControllerOptions) (*FakeController, *FakeXdsUpdater) {

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -37,6 +37,7 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/cache"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 
@@ -237,6 +238,8 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	t.Cleanup(func() {
 		grpcServer.Stop()
 	})
+
+	cache.WaitForCacheSync(stop, serviceDiscovery.HasSynced)
 
 	// Start the discovery server
 	s.CachesSynced()

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -243,9 +243,6 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	s.Start(stop)
 
 	se.ResyncEDS()
-	if err := k8s.ForceResync(); err != nil {
-		t.Fatal(err)
-	}
 
 	s.updateMutex.Lock()
 	defer s.updateMutex.Unlock()


### PR DESCRIPTION
During kube controller init, Services and Endpoints can race. If the endpoint is processes before its associated service, the endpoint is dropped here:

https://github.com/istio/istio/blob/42978d0808abb710519fc0e0d9225b2b31ffbec3/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go#L96

This means any time we start istiod, there's a chance existing endpoints won't be discovered. 

See: 
https://github.com/istio/istio/issues/24117

--- 



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
