### PR TITLE
istioctl: Emit a warning if k8s version is not minimum

### DIFF
--- a/istioctl/pkg/install/k8sversion/version.go
+++ b/istioctl/pkg/install/k8sversion/version.go
@@ -1,0 +1,67 @@
+// Copyright Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sversion
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/version"
+)
+
+const (
+	// MinK8SVersion is the minimum k8s version required to run this version of Istio
+	// https://istio.io/docs/setup/platform-setup/
+	MinK8SVersion = "1.17"
+)
+
+// CheckKubernetesVersion checks if this Istio version is supported in the k8s version
+func CheckKubernetesVersion(versionInfo *version.Info) (bool, error) {
+	v, err := extractKubernetesVersion(versionInfo)
+	if err != nil {
+		return false, err
+	}
+	return parseVersion(MinK8SVersion, 4) <= parseVersion(v, 4), nil
+}
+func extractKubernetesVersion(versionInfo *version.Info) (string, error) {
+	versionMatchRE := regexp.MustCompile(`^\s*v?([0-9]+(?:\.[0-9]+)*)(.*)*$`)
+	parts := versionMatchRE.FindStringSubmatch(versionInfo.GitVersion)
+	if parts == nil {
+		return "", fmt.Errorf("could not parse %q as version", versionInfo.GitVersion)
+	}
+	numbers := parts[1]
+	components := strings.Split(numbers, ".")
+	if len(components) <= 1 {
+		return "", fmt.Errorf("the version %q is invalid", versionInfo.GitVersion)
+	}
+	v := strings.Join([]string{components[0], components[1]}, ".")
+	return v, nil
+}
+func parseVersion(s string, width int) int64 {
+	strList := strings.Split(s, ".")
+	format := fmt.Sprintf("%%s%%0%ds", width)
+	v := ""
+	for _, value := range strList {
+		v = fmt.Sprintf(format, v, value)
+	}
+	var result int64
+	var err error
+	if result, err = strconv.ParseInt(v, 10, 64); err != nil {
+		return 0
+	}
+	return result
+}

--- a/istioctl/pkg/install/pre-check.go
+++ b/istioctl/pkg/install/pre-check.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -37,16 +35,11 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"istio.io/istio/istioctl/pkg/clioptions"
+	"istio.io/istio/istioctl/pkg/install/k8sversion"
 	operator_istio "istio.io/istio/operator/pkg/apis/istio"
 	operator_v1alpha1 "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
-)
-
-const (
-	// Minimum K8 version required to run latest version of Istio
-	// https://istio.io/docs/setup/platform-setup/
-	minK8SVersion = "1.17"
 )
 
 var (
@@ -99,12 +92,12 @@ func installPreCheck(istioNamespaceFlag string, restClientGetter genericclioptio
 	fmt.Fprintf(writer, "\n")
 	fmt.Fprintf(writer, "#2. Kubernetes-version\n")
 	fmt.Fprintf(writer, "-----------------------\n")
-	res, err := checkKubernetesVersion(v)
+	res, err := k8sversion.CheckKubernetesVersion(v)
 	if err != nil {
 		errs = multierror.Append(errs, err)
 		fmt.Fprint(writer, err)
 	} else if !res {
-		msg := fmt.Sprintf("The Kubernetes API version: %v is lower than the minimum version: "+minK8SVersion, v)
+		msg := fmt.Sprintf("The Kubernetes API version: %v is lower than the minimum version: "+k8sversion.MinK8SVersion, v)
 		errs = multierror.Append(errs, errors.New(msg))
 		fmt.Fprintf(writer, msg+"\n")
 	} else {
@@ -218,42 +211,6 @@ func installPreCheck(istioNamespaceFlag string, restClientGetter genericclioptio
 	fmt.Fprintf(writer, "\n")
 	return errs
 
-}
-
-func checkKubernetesVersion(versionInfo *version.Info) (bool, error) {
-	v, err := extractKubernetesVersion(versionInfo)
-	if err != nil {
-		return false, err
-	}
-	return parseVersion(minK8SVersion, 4) <= parseVersion(v, 4), nil
-}
-func extractKubernetesVersion(versionInfo *version.Info) (string, error) {
-	versionMatchRE := regexp.MustCompile(`^\s*v?([0-9]+(?:\.[0-9]+)*)(.*)*$`)
-	parts := versionMatchRE.FindStringSubmatch(versionInfo.GitVersion)
-	if parts == nil {
-		return "", fmt.Errorf("could not parse %q as version", versionInfo.GitVersion)
-	}
-	numbers := parts[1]
-	components := strings.Split(numbers, ".")
-	if len(components) <= 1 {
-		return "", fmt.Errorf("the version %q is invalid", versionInfo.GitVersion)
-	}
-	v := strings.Join([]string{components[0], components[1]}, ".")
-	return v, nil
-}
-func parseVersion(s string, width int) int64 {
-	strList := strings.Split(s, ".")
-	format := fmt.Sprintf("%%s%%0%ds", width)
-	v := ""
-	for _, value := range strList {
-		v = fmt.Sprintf(format, v, value)
-	}
-	var result int64
-	var err error
-	if result, err = strconv.ParseInt(v, 10, 64); err != nil {
-		return 0
-	}
-	return result
 }
 
 func checkCanCreateResources(c preCheckExecClient, namespace, group, version, name string) error {

--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"istio.io/api/operator/v1alpha1"
+	"istio.io/istio/istioctl/pkg/install/k8sversion"
 	iopv1alpha1 "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/cache"
 	"istio.io/istio/operator/pkg/helmreconciler"
@@ -30,6 +31,7 @@ import (
 	"istio.io/istio/operator/pkg/util/clog"
 	"istio.io/istio/operator/pkg/util/progress"
 	"istio.io/pkg/log"
+	"istio.io/pkg/version"
 )
 
 const (
@@ -139,6 +141,22 @@ func InstallManifests(setOverlay []string, inFilenames []string, force bool, dry
 	if err != nil {
 		return err
 	}
+
+	serverVersion, err := clientset.Discovery().ServerVersion()
+	if err != nil {
+		return fmt.Errorf("error getting Kubernetes version: %w", err)
+	}
+	ok, err := k8sversion.CheckKubernetesVersion(serverVersion)
+	if err != nil {
+		return fmt.Errorf("error checking if Kubernetes version is supported: %w", err)
+	}
+	if !ok {
+		l.LogAndPrintf("\nThe Kubernetes version %s is not supported by Istio %s. The minimum supported Kubernetes version is %s.\n"+
+			"Proceeding with the installation, but you might experience problems. "+
+			"See https://istio.io/latest/docs/setup/platform-setup/ for a list of supported versions.\n",
+			serverVersion.GitVersion, version.Info.Version, k8sversion.MinK8SVersion)
+	}
+
 	_, iops, err := manifest.GenerateConfig(inFilenames, setOverlay, force, restConfig, l)
 	if err != nil {
 		return err


### PR DESCRIPTION
This is to avoid proceed with the installation and present the user
with criptograpyic messages like

`Istio core encountered an error: failed to wait for resource: failed to verify CRD creation: the server could not find the requested resource`

Closes #26141.