### PR TITLE
Deprecate meshExpansion and add ingress Service port 15012 by default

### DIFF
--- a/manifests/profiles/default.yaml
+++ b/manifests/profiles/default.yaml
@@ -64,6 +64,12 @@ spec:
             - port: 443
               targetPort: 8443
               name: https
+            - port: 15012
+              targetPort: 15012
+              name: tcp-istiod
+            - port: 15017
+              targetPort: 15017
+              name: tcp-webhook
             - port: 15443
               targetPort: 15443
               name: tls
@@ -288,12 +294,6 @@ spec:
         zvpn: {}
         env: {}
         meshExpansionPorts:
-        - port: 15012
-          targetPort: 15012
-          name: tcp-istiod
-        - port: 853
-          targetPort: 8853
-          name: tcp-dns-tls
         secretVolumes:
           - name: ingressgateway-certs
             secretName: istio-ingressgateway-certs

--- a/manifests/profiles/default.yaml
+++ b/manifests/profiles/default.yaml
@@ -293,7 +293,6 @@ spec:
         name: istio-ingressgateway
         zvpn: {}
         env: {}
-        meshExpansionPorts:
         secretVolumes:
           - name: ingressgateway-certs
             secretName: istio-ingressgateway-certs

--- a/manifests/profiles/default.yaml
+++ b/manifests/profiles/default.yaml
@@ -67,9 +67,6 @@ spec:
             - port: 15012
               targetPort: 15012
               name: tcp-istiod
-            - port: 15017
-              targetPort: 15017
-              name: tcp-webhook
             - port: 15443
               targetPort: 15443
               name: tls

--- a/operator/pkg/apis/istio/v1alpha1/validation/validation.go
+++ b/operator/pkg/apis/istio/v1alpha1/validation/validation.go
@@ -107,6 +107,8 @@ func deprecatedSettingsMessage(iop *v1alpha1.IstioOperatorSpec) string {
 		{"Values.global.tracer.stackdriver.maxNumberOfAnnotations", "meshConfig.defaultConfig.tracing.stackdriver.maxNumberOfAnnotations", 0},
 		{"Values.global.tracer.stackdriver.maxNumberOfMessageEvents", "meshConfig.defaultConfig.tracing.stackdriver.maxNumberOfMessageEvents", 0},
 		{"Values.global.tracer.datadog.address", "meshConfig.defaultConfig.tracing.datadog.address", ""},
+		{"Values.global.meshExpansion.enabled", "Gateway and other Istio networking resources, such as in samples/istiod-gateway/", false},
+		{"Values.gateways.istio-ingressgateway.meshExpansionPorts", "components.ingressGateways[name=istio-ingressgateway].k8s.service.ports", nil},
 		{"AddonComponents.grafana.Enabled", "the samples/addons/ deployments", false},
 		{"AddonComponents.tracing.Enabled", "the samples/addons/ deployments", false},
 		{"AddonComponents.kiali.Enabled", "the samples/addons/ deployments", false},

--- a/releasenotes/notes/mesh-expansion.yaml
+++ b/releasenotes/notes/mesh-expansion.yaml
@@ -1,0 +1,39 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+- 25933
+
+releaseNotes: |
+  *Added* ports 15012 and 15017 to the default list of ports for the `istio-ingressgateway` Service.
+
+  *Deprecated* installation flags
+  - `values.global.meshExpansion.enabled` in favor of user-managed config
+  - `values.gateways.istio-ingressgateway.meshExpansionPorts` in favor of `components.ingressGateways[name=istio-ingressgateway].k8s.service.ports`
+
+upgradeNotes:
+- title: Avoid use of mesh expansion installation flags
+  content: |
+    To ease setup for multicluster and virtual machines while giving more control to users, the `meshExpansion` and `meshExpansionPorts` installation flags have been deprecated, and ports 15012 and 15017 have been added to the default list of ports for the `istio-ingressgateway` Service.
+
+    For users with `values.global.meshExpansion.enabled=true`, perform the following steps before upgrading Istio:
+
+    1. Apply the code sample for exposing Istiod through ingress.
+
+       {{< text bash >}}
+       $ kubectl apply -f @samples/istiod-gateway/istiod-gateway.yaml@
+       {{< /text >}}
+
+       This removes `operator.istio.io/managed` labels from the associated Istio networking resources so that the Istio installer won't delete them. After this step, you can modify these resources freely.
+
+    1. If `components.ingressGateways[name=istio-ingressgateway].k8s.service.ports` is overridden, add port 15012 to the list of ports:
+
+       {{< text yaml >}}
+            - port: 15012
+              targetPort: 15012
+              name: tcp-istiod
+       {{< /text >}}
+
+    1. If `values.gateways.istio-ingressgateway.meshExpansionPorts` is set, move all ports to `components.ingressGateways[name=istio-ingressgateway].k8s.service.ports` if they're not already present. Then, unset this value.
+
+    1. Unset `values.global.meshExpansion.enabled`.

--- a/releasenotes/notes/mesh-expansion.yaml
+++ b/releasenotes/notes/mesh-expansion.yaml
@@ -5,7 +5,7 @@ issue:
 - 25933
 
 releaseNotes: |
-  *Added* ports 15012 and 15017 to the default list of ports for the `istio-ingressgateway` Service.
+  *Added* port 15012 to the default list of ports for the `istio-ingressgateway` Service.
 
   *Deprecated* installation flags
   - `values.global.meshExpansion.enabled` in favor of user-managed config
@@ -14,7 +14,7 @@ releaseNotes: |
 upgradeNotes:
 - title: Avoid use of mesh expansion installation flags
   content: |
-    To ease setup for multicluster and virtual machines while giving more control to users, the `meshExpansion` and `meshExpansionPorts` installation flags have been deprecated, and ports 15012 and 15017 have been added to the default list of ports for the `istio-ingressgateway` Service.
+    To ease setup for multicluster and virtual machines while giving more control to users, the `meshExpansion` and `meshExpansionPorts` installation flags have been deprecated, and port 15012 has been added to the default list of ports for the `istio-ingressgateway` Service.
 
     For users with `values.global.meshExpansion.enabled=true`, perform the following steps before upgrading Istio:
 

--- a/tests/integration/multicluster/centralistio/main_test.go
+++ b/tests/integration/multicluster/centralistio/main_test.go
@@ -53,10 +53,36 @@ func TestMain(m *testing.M) {
 			cfg.ExposeIstiod = true
 
 			// Set the control plane values on the config.
+			// For ingress, add port 15017 to the default list of ports.
 			cfg.ControlPlaneValues = controlPlaneValues + `
   global:
     centralIstiod: true
-    caAddress: istiod.istio-system.svc:15012`
+    caAddress: istiod.istio-system.svc:15012
+components:
+  ingressGateways:
+  - name: istio-ingressgateway
+    enabled: true
+    k8s:
+      service:
+        ports:
+        - port: 15021
+          targetPort: 15021
+          name: status-port
+        - port: 80
+          targetPort: 8080
+          name: http2
+        - port: 443
+          targetPort: 8443
+          name: https
+        - port: 15012
+          targetPort: 15012
+          name: tcp-istiod
+        - port: 15443
+          targetPort: 15443
+          name: tls
+        - port: 15017
+          targetPort: 15017
+          name: tcp-webhook`
 			cfg.RemoteClusterValues = `
 components:
   base:


### PR DESCRIPTION
As part of #25933. Note that the tcp-dns-tls port is unused

Removing the `ExposeIstiod` test flag is deferred to a future PR to reduce scope for this change

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure