### PR TITLE
remove istio-validation container when running istioctl rm

### DIFF
--- a/istioctl/cmd/kubeuninject.go
+++ b/istioctl/cmd/kubeuninject.go
@@ -43,6 +43,7 @@ const (
 	enableCoreDumpContainerName = "enable-core-dump"
 	envoyVolumeName             = "istio-envoy"
 	initContainerName           = "istio-init"
+	initValidationContainerName = "istio-validation"
 	jwtTokenVolumeName          = "istio-token"
 	proxyContainerName          = "istio-proxy"
 	sidecarAnnotationPrefix     = "sidecar.istio.io"
@@ -247,6 +248,7 @@ func extractObject(in runtime.Object) (interface{}, error) {
 	}
 
 	podSpec.InitContainers = removeInjectedContainers(podSpec.InitContainers, initContainerName)
+	podSpec.InitContainers = removeInjectedContainers(podSpec.InitContainers, initValidationContainerName)
 	podSpec.InitContainers = removeInjectedContainers(podSpec.InitContainers, enableCoreDumpContainerName)
 	podSpec.Containers = removeInjectedContainers(podSpec.Containers, proxyContainerName)
 	podSpec.Volumes = removeInjectedVolumes(podSpec.Volumes, envoyVolumeName)


### PR DESCRIPTION

If you're using IstioCNI and trying Istioctl remove-from-mesh, you will find that all istio-related stuff is removed from the deployment manifest except for the init-container. This PR will fix that


[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.