### PR TITLE
Add examples dir in release tar

### DIFF
--- a/operator/scripts/create_release_charts.sh
+++ b/operator/scripts/create_release_charts.sh
@@ -46,4 +46,5 @@ mkdir -p "${OUTPUT_DIR}"
 
 cp -R "${INSTALLER_DIR}/charts" "${OUTPUT_DIR}"
 cp -R "${INSTALLER_DIR}/profiles" "${OUTPUT_DIR}"
+cp -R "${INSTALLER_DIR}/examples" "${OUTPUT_DIR}"
 


### PR DESCRIPTION
To fix https://github.com/istio/istio.io/issues/7854

With `istio-1.7.0-beta.1`  `manifests/examples` directory is missing 
```
[u@master-node istio-1.7.0-beta.1]$ ls manifests/
charts  deploy  profiles
```
The `manifests/examples` directory consists of the following. Which is used with [VM examples](https://preliminary.istio.io/latest/docs/examples/virtual-machines/multi-network/#installation-steps).
```
[u@master-node istio]$ ls manifests/examples/
customresource  multicluster  user-gateway  vm
```

