### PR TITLE
Fix: VM post-submit test should be deployed with each image

### DIFF
--- a/tests/integration/pilot/vm_test.go
+++ b/tests/integration/pilot/vm_test.go
@@ -46,6 +46,7 @@ func TestVmOSPost(t *testing.T) {
 					Namespace:  apps.namespace,
 					Ports:      echoPorts,
 					DeployAsVM: true,
+					VMImage:    image,
 					Subsets:    []echo.SubsetConfig{{}},
 				})
 			}


### PR DESCRIPTION
This PR tries to fix the VM post-submit tests so that the instances could be deployed with different images. Currently the images are used only as the testcase name. 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
