### PR TITLE
Read MeshID into ProxyConfig

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -35,6 +35,7 @@ data:
   mesh: |-
     defaultConfig:
       discoveryAddress: istiod.istio-system.svc:15012
+      meshId: cluster.local
       proxyMetadata:
         DNS_AGENT: ""
       tracing:

--- a/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
@@ -5,6 +5,11 @@
     trustDomain: {{ .Values.global.trustDomain | quote }}
 
     defaultConfig:
+      {{- if .Values.global.meshID }}
+      meshId: {{ .Values.global.meshID }}
+      {{- else if .Values.global.trustDomain }}
+      meshId: {{ .Values.global.trustDomain }}
+      {{- end }}
       tracing:
       {{- if eq .Values.global.proxy.tracer "lightstep" }}
         lightstep:


### PR DESCRIPTION
Reads the meshId into the Proxyconfig from the environment variables.
Left the other templates unchanged for the moment. 

[x] Configuration Infrastructure
[x] Does not have any changes that may affect Istio users.
