### PR TITLE
[release-1.7] Extra Envoy Access Log Attribute and Bag Preprocess Fix

### DIFF
--- a/mixer/pkg/attribute/envoyProtoBag.go
+++ b/mixer/pkg/attribute/envoyProtoBag.go
@@ -168,6 +168,9 @@ func AccessLogProtoBag(msg *accesslog.StreamAccessLogsMessage, num int) *EnvoyPr
 
 	reqMap["context.proxy_error_code"] = ParseEnvoyResponseFlags(commonproperties.GetResponseFlags())
 
+	//for identifying the log type as Service Access Logs instead of Mixer Report
+	reqMap["context.reporter.type"] = "envoy_accesslog"
+
 	pb.upstreamCluster = commonproperties.GetUpstreamCluster()
 	pb.reqMap = reqMap
 	scope.Debugf("Returning bag with attributes:\n%v", pb)

--- a/mixer/pkg/attribute/envoyProtoBag.go
+++ b/mixer/pkg/attribute/envoyProtoBag.go
@@ -168,11 +168,11 @@ func AccessLogProtoBag(msg *accesslog.StreamAccessLogsMessage, num int) *EnvoyPr
 
 	reqMap["context.proxy_error_code"] = ParseEnvoyResponseFlags(commonproperties.GetResponseFlags())
 
-	//This is for identifying the log type as Service Access Logs instead of Mixer Report
-	//This is more specifically for making migration easier.
-	//In migration users will enable access log service and then after will
-	//disable Mixer Report. In the time period when both are reporting logs,
-	//this field allows users to distinguish between the two types of logs.
+	// This is for identifying the log type as Service Access Logs instead of Mixer Report
+	// This is more specifically for making migration easier.
+	// In migration users will enable access log service and then after will
+	// disable Mixer Report. In the time period when both are reporting logs,
+	// this field allows users to distinguish between the two types of logs.
 	reqMap["context.reporter.type"] = "envoy_accesslog_service"
 
 	pb.upstreamCluster = commonproperties.GetUpstreamCluster()

--- a/mixer/pkg/attribute/envoyProtoBag.go
+++ b/mixer/pkg/attribute/envoyProtoBag.go
@@ -168,8 +168,12 @@ func AccessLogProtoBag(msg *accesslog.StreamAccessLogsMessage, num int) *EnvoyPr
 
 	reqMap["context.proxy_error_code"] = ParseEnvoyResponseFlags(commonproperties.GetResponseFlags())
 
-	//for identifying the log type as Service Access Logs instead of Mixer Report
-	reqMap["context.reporter.type"] = "envoy_accesslog"
+	//This is for identifying the log type as Service Access Logs instead of Mixer Report
+	//This is more specifically for making migration easier.
+	//In migration users will enable access log service and then after will
+	//disable Mixer Report. In the time period when both are reporting logs,
+	//this field allows users to distinguish between the two types of logs.
+	reqMap["context.reporter.type"] = "envoy_accesslog_service"
 
 	pb.upstreamCluster = commonproperties.GetUpstreamCluster()
 	pb.reqMap = reqMap

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-policy/templates/config.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-policy/templates/config.yaml
@@ -267,6 +267,7 @@ spec:
     source_uid: source.uid | ""
     source_ip: source.ip | ip("0.0.0.0") # default to unspecified ip addr
     destination_uid: destination.uid | ""
+    destination_ip: destination.ip | ip("0.0.0.0")
     destination_port: destination.port | 0
   attributeBindings:
     # Fill the new attributes from the adapter produced output.


### PR DESCRIPTION
Added a new attribute to distinguish Envoy Service Access Logs from Mixer Report ones for ease of use when migrating between the two.

Since destination.uid isn't provided by ALS, it default includes destination.ip additionally for dispatcher preprocess to create bags correctly.

@bianpengyuan 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
