### PR TITLE
reload services and endpoints when networks change

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/network.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network.go
@@ -63,6 +63,11 @@ func (c *Controller) reloadNetworkLookup() {
 		}
 	}
 	c.ranger = ranger
+	// the network for endpoints are computed when we process the events; this will fix the cache
+	// TODO(landow) there may be a race between this and the full push we trigger on the networks watcher.
+	if err := c.SyncAll(); err != nil {
+		log.Errorf("one or more errors force-syncing resources: %v", err)
+	}
 }
 
 // return the mesh network for the endpoint IP. Empty string if not found.


### PR DESCRIPTION
When we update meshNetworks in the `istio` we update some fields on the controller that set the network for endpoints, but the network is only set when we first process the k8s events for these resources. The expectation is that you could change the config map and have the endpoints regenerated and pushed with the proper network. 

This PR is a bit hacky - it just reloads everything from Kubernetes. If this works then we can change it to be more fine-grained. 

Note: this problem would not effect purely label-based networks config; the design we talked about in networking-wg will trigger these updates properly. 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

cc @nmittler 

Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
