### PR TITLE
Always expose control plane istiod in tests

### DIFF
--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -127,9 +127,6 @@ type Config struct {
 	// CustomSidecarInjectorNamespace allows injecting the sidecar from the specified namespace.
 	// if the value is "", use the default sidecar injection instead.
 	CustomSidecarInjectorNamespace string
-
-	// Expose istiod through ingress, for example for multicluster or VM setups
-	ExposeIstiod bool
 }
 
 func (c *Config) IstioOperatorConfigYAML(iopYaml string) string {

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -225,11 +225,8 @@ func deploy(ctx resource.Context, env *kube.Environment, cfg Config) (Instance, 
 				if err := deployControlPlane(i, cfg, cluster, iopFile); err != nil {
 					return fmt.Errorf("failed deploying control plane to cluster %s: %v", cluster.Name(), err)
 				}
-
-				if cfg.ExposeIstiod {
-					if err := applyIstiodGateway(ctx, cfg, cluster); err != nil {
-						return fmt.Errorf("failed applying istiod gateway for cluster %s: %v", cluster.Name(), err)
-					}
+				if err := applyIstiodGateway(ctx, cfg, cluster); err != nil {
+					return fmt.Errorf("failed applying istiod gateway for cluster %s: %v", cluster.Name(), err)
 				}
 				return nil
 			})

--- a/tests/integration/multicluster/base/main_test.go
+++ b/tests/integration/multicluster/base/main_test.go
@@ -36,7 +36,6 @@ func TestMain(m *testing.M) {
 		Setup(multicluster.Setup(&appCtx)).
 		Setup(istio.Setup(&ist, func(cfg *istio.Config) {
 			cfg.ControlPlaneValues = appCtx.ControlPlaneValues
-			cfg.ExposeIstiod = true
 		})).
 		Setup(multicluster.SetupApps(&appCtx)).
 		Run()

--- a/tests/integration/multicluster/centralistio/main_test.go
+++ b/tests/integration/multicluster/centralistio/main_test.go
@@ -47,7 +47,6 @@ func TestMain(m *testing.M) {
 		Setup(istio.Setup(&ist, func(cfg *istio.Config) {
 
 			cfg.Values["global.centralIstiod"] = "true"
-			cfg.ExposeIstiod = true
 
 			// Set the control plane values on the config.
 			// For ingress, add port 15017 to the default list of ports.

--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -91,7 +91,6 @@ func TestMain(m *testing.M) {
 		Setup(istio.Setup(&i, func(cfg *istio.Config) {
 			cfg.Values["telemetry.v2.metadataExchange.wasmEnabled"] = "false"
 			cfg.Values["telemetry.v2.prometheus.wasmEnabled"] = "false"
-			cfg.ExposeIstiod = true
 			cfg.ControlPlaneValues = `
 # Add TCP port, not in the default install
 components:

--- a/tests/integration/security/main_test.go
+++ b/tests/integration/security/main_test.go
@@ -40,7 +40,6 @@ func setupConfig(cfg *istio.Config) {
 	}
 	rootNamespace = cfg.SystemNamespace
 
-	cfg.ExposeIstiod = true
 	cfg.ControlPlaneValues = `
 components:
   egressGateways:

--- a/tests/integration/telemetry/stackdriver/vm/main_test.go
+++ b/tests/integration/telemetry/stackdriver/vm/main_test.go
@@ -58,7 +58,6 @@ func TestMain(m *testing.M) {
 		NewSuite(m).
 		RequireSingleCluster().
 		Setup(istio.Setup(&i, func(cfg *istio.Config) {
-			cfg.ExposeIstiod = true
 			cfg.Values["telemetry.enabled"] = "true"
 			cfg.Values["telemetry.v2.enabled"] = "true"
 			cfg.Values["telemetry.v2.stackdriver.enabled"] = "true"


### PR DESCRIPTION
Cleanup after #26091. Adding these resources should be lightweight enough to always do this rather than having another flag

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

Pull Request Attributes

[X] Does not have any changes that may affect Istio users.