### PR TITLE
Remove dependency on google.golang.org/api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -122,7 +122,6 @@ require (
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
-	google.golang.org/api v0.29.0
 	google.golang.org/genproto v0.0.0-20200722002428-88e341933a54
 	google.golang.org/grpc v1.30.0
 	google.golang.org/protobuf v1.25.0

--- a/pkg/bootstrap/platform/gcp.go
+++ b/pkg/bootstrap/platform/gcp.go
@@ -27,6 +27,7 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
+
 	"istio.io/pkg/env"
 	"istio.io/pkg/log"
 )

--- a/pkg/bootstrap/platform/gcp.go
+++ b/pkg/bootstrap/platform/gcp.go
@@ -16,6 +16,7 @@ package platform
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"regexp"
@@ -24,10 +25,8 @@ import (
 
 	"cloud.google.com/go/compute/metadata"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	"google.golang.org/api/compute/v1"
-	"google.golang.org/api/option"
-
 	"istio.io/pkg/env"
 	"istio.io/pkg/log"
 )
@@ -218,6 +217,8 @@ func (e *gcpEnv) Locality() *core.Locality {
 	return &l
 }
 
+const ComputeReadonlyScope = "https://www.googleapis.com/auth/compute.readonly"
+
 // Labels attempts to retrieve the GCE instance labels within the timeout
 // Requires read access to the Compute API (compute.instances.get)
 func (e *gcpEnv) Labels() map[string]string {
@@ -230,26 +231,28 @@ func (e *gcpEnv) Labels() map[string]string {
 	var instanceLabels map[string]string
 	go func() {
 		// use explicit credentials with compute.instances.get IAM permissions
-		creds, err := google.FindDefaultCredentials(ctx, compute.ComputeReadonlyScope)
+		creds, err := google.FindDefaultCredentials(ctx, ComputeReadonlyScope)
 		if err != nil {
 			log.Warnf("failed to find default credentials: %v", err)
 			success <- false
 			return
 		}
-		computeService, err := compute.NewService(ctx, option.WithCredentials(creds))
+		url := fmt.Sprintf("https://compute.googleapis.com/compute/v1/projects/%s/zones/%s/instances/%s", md[GCPProject], md[GCPLocation], md[GCEInstance])
+		resp, err := oauth2.NewClient(ctx, creds.TokenSource).Get(url)
 		if err != nil {
-			log.Warnf("failed to create new service: %v", err)
+			log.Warnf("unable to retrieve instance labels: %v", err)
+			success <- false
+			return
+
+		}
+		defer resp.Body.Close()
+		instance := &GcpInstance{}
+		if err := json.NewDecoder(resp.Body).Decode(instance); err != nil {
+			log.Warnf("failed to decode response: %v", err)
 			success <- false
 			return
 		}
-		// instance.Labels is nil if no labels are present
-		instanceObj, err := computeService.Instances.Get(md[GCPProject], md[GCPLocation], md[GCEInstance]).Do()
-		if err != nil {
-			log.Warnf("unable to retrieve instance: %v", err)
-			success <- false
-			return
-		}
-		instanceLabels = instanceObj.Labels
+		instanceLabels = instance.Labels
 		success <- true
 	}()
 	select {
@@ -261,6 +264,12 @@ func (e *gcpEnv) Labels() map[string]string {
 		}
 	}
 	return labels
+}
+
+// GcpInstance the instances response. Only contains fields we care about, rest are ignored
+type GcpInstance struct {
+	// Labels: Labels to apply to this instance.
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // Checks metadata to see if GKE metadata or Kubernetes env vars exist


### PR DESCRIPTION
This dep is ~22mb, bloats the binary. See https://github.com/istio/istio/issues/26232