### PR TITLE
cleanup networks resync and add tests

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -498,18 +498,29 @@ func (c *Controller) SyncAll() error {
 		err = multierror.Append(err, c.onServiceEvent(s, model.EventAdd))
 	}
 
+	err = multierror.Append(err, c.syncPods())
+	err = multierror.Append(err, c.syncEndpoints())
+
+	return multierror.Flatten(err.ErrorOrNil())
+}
+
+func (c *Controller) syncPods() error {
+	var err *multierror.Error
 	pods := c.pods.informer.GetStore().List()
 	log.Debugf("initialzing %d pods", len(pods))
 	for _, s := range pods {
 		err = multierror.Append(err, c.pods.onEvent(s, model.EventAdd))
 	}
+	return err.ErrorOrNil()
+}
 
+func (c *Controller) syncEndpoints() error {
+	var err *multierror.Error
 	endpoints := c.endpoints.getInformer().GetStore().List()
 	log.Debugf("initialzing%d endpoints", len(endpoints))
 	for _, s := range endpoints {
 		err = multierror.Append(err, c.endpoints.onEvent(s, model.EventAdd))
 	}
-
 	return err.ErrorOrNil()
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/network.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network.go
@@ -64,9 +64,12 @@ func (c *Controller) reloadNetworkLookup() {
 	}
 	c.ranger = ranger
 	// the network for endpoints are computed when we process the events; this will fix the cache
-	// TODO(landow) there may be a race between this and the full push we trigger on the networks watcher.
-	if err := c.SyncAll(); err != nil {
-		log.Errorf("one or more errors force-syncing resources: %v", err)
+	// NOTE: this must run before the other network watcher handler that creates a force push
+	if err := c.syncPods(); err != nil {
+		log.Errorf("one or more errors force-syncing pods: %v", err)
+	}
+	if err := c.syncEndpoints(); err != nil {
+		log.Errorf("one or more errors force-syncing endpoints: %v", err)
 	}
 }
 

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -74,8 +74,8 @@ type FakeOptions struct {
 	// If provided, the ConfigString will be treated as a go template, with this as input params
 	ConfigTemplateInput interface{}
 	// If provided, this mesh config will be used
-	MeshConfig   *meshconfig.MeshConfig
-	MeshNetworks *meshconfig.MeshNetworks
+	MeshConfig      *meshconfig.MeshConfig
+	NetworksWatcher mesh.NetworksWatcher
 }
 
 type FakeDiscoveryServer struct {
@@ -167,7 +167,10 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	env.ServiceDiscovery = serviceDiscovery
 	env.IstioConfigStore = model.MakeIstioStore(configStore)
 	env.Watcher = mesh.NewFixedWatcher(m)
-	env.NetworksWatcher = mesh.NewFixedNetworksWatcher(opts.MeshNetworks)
+	if opts.NetworksWatcher == nil {
+		opts.NetworksWatcher = mesh.NewFixedNetworksWatcher(nil)
+	}
+	env.NetworksWatcher = opts.NetworksWatcher
 
 	se := serviceentry.NewServiceDiscovery(configController, model.MakeIstioStore(configStore), s)
 	serviceDiscovery.AddRegistry(se)
@@ -247,17 +250,6 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 
 	se.ResyncEDS()
 
-	s.updateMutex.Lock()
-	defer s.updateMutex.Unlock()
-	ctx := model.NewPushContext()
-	if err := ctx.InitContext(env, env.PushContext, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := s.UpdateServiceShards(ctx); err != nil {
-		t.Fatal(err)
-	}
-	env.PushContext = ctx
-
 	fake := &FakeDiscoveryServer{
 		t:           t,
 		Store:       configController,
@@ -266,7 +258,26 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		Env:         env,
 		listener:    listener,
 	}
+
+	// currently meshNetworks gateways are stored on the push context
+	fake.refreshPushContext()
+	env.AddNetworksHandler(fake.refreshPushContext)
+
 	return fake
+}
+
+func (f *FakeDiscoveryServer) refreshPushContext() {
+	f.Discovery.updateMutex.Lock()
+	defer f.Discovery.updateMutex.Unlock()
+	ctx := model.NewPushContext()
+	if err := ctx.InitContext(f.Env, f.Env.PushContext, nil); err != nil {
+		f.t.Fatal(err)
+	}
+	if err := f.Discovery.UpdateServiceShards(ctx); err != nil {
+		f.t.Fatal(err)
+	}
+	f.Env.PushContext = ctx
+	f.PushContext = ctx
 }
 
 // ConnectADS starts an ADS connection to the server. It will automatically be cleaned up when the test ends

--- a/pkg/config/mesh/networks_watcher.go
+++ b/pkg/config/mesh/networks_watcher.go
@@ -30,6 +30,7 @@ import (
 
 // NetworksHolder is a holder of a mesh networks configuration.
 type NetworksHolder interface {
+	SetNetworks(*meshconfig.MeshNetworks)
 	Networks() *meshconfig.MeshNetworks
 }
 
@@ -79,25 +80,7 @@ func NewNetworksWatcher(fileWatcher filewatcher.FileWatcher, filename string) (N
 			log.Warnf("failed to read mesh networks configuration from %q: %v", filename, err)
 			return
 		}
-
-		var handlers []func()
-
-		w.mutex.Lock()
-		if !reflect.DeepEqual(meshNetworks, w.networks) {
-			ResolveHostsInNetworksConfig(meshNetworks)
-			networksdump, _ := gogoprotomarshal.ToJSONWithIndent(meshNetworks, "    ")
-			log.Infof("mesh networks configuration updated to: %s", networksdump)
-
-			// Store the new config.
-			atomic.StorePointer((*unsafe.Pointer)(unsafe.Pointer(&w.networks)), unsafe.Pointer(meshNetworks))
-			handlers = append([]func(){}, w.handlers...)
-		}
-		w.mutex.Unlock()
-
-		// Notify the handlers of the change.
-		for _, h := range handlers {
-			h()
-		}
+		w.SetNetworks(meshNetworks)
 	})
 	return w, nil
 }
@@ -107,9 +90,33 @@ func (w *networksWatcher) Networks() *meshconfig.MeshNetworks {
 	return (*meshconfig.MeshNetworks)(atomic.LoadPointer((*unsafe.Pointer)(unsafe.Pointer(&w.networks))))
 }
 
+// SetNetworks will use the given value for mesh networks and notify all handlers of the change
+func (w *networksWatcher) SetNetworks(meshNetworks *meshconfig.MeshNetworks) {
+	var handlers []func()
+
+	w.mutex.Lock()
+	if !reflect.DeepEqual(meshNetworks, w.networks) {
+		ResolveHostsInNetworksConfig(meshNetworks)
+		networksdump, _ := gogoprotomarshal.ToJSONWithIndent(meshNetworks, "    ")
+		log.Infof("mesh networks configuration updated to: %s", networksdump)
+
+		// Store the new config.
+		atomic.StorePointer((*unsafe.Pointer)(unsafe.Pointer(&w.networks)), unsafe.Pointer(meshNetworks))
+		handlers = append([]func(){}, w.handlers...)
+	}
+	w.mutex.Unlock()
+
+	// Notify the handlers of the change.
+	for _, h := range handlers {
+		h()
+	}
+}
+
 // AddMeshHandler registers a callback handler for changes to the mesh network config.
 func (w *networksWatcher) AddNetworksHandler(h func()) {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
-	w.handlers = append(w.handlers, h)
+
+	// hack: prepend handlers; the last to be added will be run first and block other handlers
+	w.handlers = append([]func(){h}, w.handlers...)
 }


### PR DESCRIPTION
Expands on #26236 

- TestMeshNetworks:
  - reuse the fake discovery server for different MeshNetwork configs
  - init with empty mesh networks and update on each scenario
  - tested with -count 50 and -race, not flaky
- Only need to resync Pods and Endpoints
- Make sure the resync happens before we trigger the force push



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
