### PR TITLE
Use common namespace value

### DIFF
--- a/operator/cmd/mesh/operator-dump.go
+++ b/operator/cmd/mesh/operator-dump.go
@@ -36,9 +36,8 @@ func addOperatorDumpFlags(cmd *cobra.Command, args *operatorDumpArgs) {
 	}
 	cmd.PersistentFlags().StringVar(&args.common.hub, "hub", hub, HubFlagHelpStr)
 	cmd.PersistentFlags().StringVar(&args.common.tag, "tag", tag, TagFlagHelpStr)
-	cmd.PersistentFlags().StringVar(&args.common.operatorNamespace, "operatorNamespace", "istio-operator",
-		"The namespace the operator controller is installed into")
-	cmd.PersistentFlags().StringVar(&args.common.istioNamespace, "istioNamespace", "istio-system",
+	cmd.PersistentFlags().StringVar(&args.common.operatorNamespace, "operatorNamespace", operatorDefaultNamespace, OperatorNamespaceHelpstr)
+	cmd.PersistentFlags().StringVar(&args.common.istioNamespace, "istioNamespace", istioDefaultNamespace,
 		"The namespace Istio is installed into")
 	cmd.PersistentFlags().StringVarP(&args.common.manifestsPath, "charts", "", "", ChartsDeprecatedStr)
 	cmd.PersistentFlags().StringVarP(&args.common.manifestsPath, "manifests", "d", "", ManifestsFlagHelpStr)

--- a/operator/cmd/mesh/operator-init.go
+++ b/operator/cmd/mesh/operator-init.go
@@ -51,8 +51,7 @@ func addOperatorInitFlags(cmd *cobra.Command, args *operatorInitArgs) {
 	cmd.PersistentFlags().StringVar(&args.context, "context", "", ContextFlagHelpStr)
 	cmd.PersistentFlags().StringVar(&args.common.hub, "hub", hub, HubFlagHelpStr)
 	cmd.PersistentFlags().StringVar(&args.common.tag, "tag", tag, TagFlagHelpStr)
-	cmd.PersistentFlags().StringVar(&args.common.operatorNamespace, "operatorNamespace", operatorDefaultNamespace,
-		"The namespace the operator controller is installed into")
+	cmd.PersistentFlags().StringVar(&args.common.operatorNamespace, "operatorNamespace", operatorDefaultNamespace, OperatorNamespaceHelpstr)
 	cmd.PersistentFlags().StringVar(&args.common.istioNamespace, "istioNamespace", istioDefaultNamespace,
 		"The namespace Istio is installed into. Deprecated, use '--watchedNamespaces' instead.")
 	cmd.PersistentFlags().StringVar(&args.common.watchedNamespaces, "watchedNamespaces", istioDefaultNamespace,

--- a/operator/cmd/mesh/operator-remove.go
+++ b/operator/cmd/mesh/operator-remove.go
@@ -43,8 +43,7 @@ func addOperatorRemoveFlags(cmd *cobra.Command, oiArgs *operatorRemoveArgs) {
 	cmd.PersistentFlags().StringVarP(&oiArgs.kubeConfigPath, "kubeconfig", "c", "", KubeConfigFlagHelpStr)
 	cmd.PersistentFlags().StringVar(&oiArgs.context, "context", "", ContextFlagHelpStr)
 	cmd.PersistentFlags().BoolVar(&oiArgs.force, "force", false, ForceFlagHelpStr)
-	cmd.PersistentFlags().StringVar(&oiArgs.operatorNamespace, "operatorNamespace", operatorDefaultNamespace,
-		"The namespace the operator controller is installed into")
+	cmd.PersistentFlags().StringVar(&oiArgs.operatorNamespace, "operatorNamespace", operatorDefaultNamespace, OperatorNamespaceHelpstr)
 	cmd.PersistentFlags().StringVarP(&oiArgs.revision, "revision", "r", "",
 		revisionFlagHelpStr)
 }

--- a/operator/cmd/mesh/root.go
+++ b/operator/cmd/mesh/root.go
@@ -42,12 +42,13 @@ or release tar URL (e.g. ` + releaseURL + `).
 If set to true, the user is not prompted and a Yes response is assumed in all cases.`
 	filenameFlagHelpStr = `Path to file containing IstioOperator custom resource
 This flag can be specified multiple times to overlay multiple files. Multiple files are overlaid in left to right order.`
-	installationCompleteStr = `Installation complete`
-	ForceFlagHelpStr        = `Proceed even with validation errors.`
-	KubeConfigFlagHelpStr   = `Path to kube config.`
-	ContextFlagHelpStr      = `The name of the kubeconfig context to use.`
-	HubFlagHelpStr          = `The hub for the operator controller image.`
-	TagFlagHelpStr          = `The tag for the operator controller image.`
+	installationCompleteStr  = `Installation complete`
+	ForceFlagHelpStr         = `Proceed even with validation errors.`
+	KubeConfigFlagHelpStr    = `Path to kube config.`
+	ContextFlagHelpStr       = `The name of the kubeconfig context to use.`
+	HubFlagHelpStr           = `The hub for the operator controller image.`
+	TagFlagHelpStr           = `The tag for the operator controller image.`
+	OperatorNamespaceHelpstr = `The namespace the operator controller is installed into.`
 )
 
 type rootArgs struct {

--- a/operator/cmd/mesh/shared.go
+++ b/operator/cmd/mesh/shared.go
@@ -240,7 +240,7 @@ func getCRAndNamespaceFromFile(filePath string, l clog.Logger) (customResource s
 func createNamespace(cs kubernetes.Interface, namespace string) error {
 	if namespace == "" {
 		// Setup default namespace
-		namespace = "istio-system"
+		namespace = istioDefaultNamespace
 	}
 
 	ns := &v1.Namespace{ObjectMeta: v12.ObjectMeta{


### PR DESCRIPTION
This patch is similar to https://github.com/istio/istio/pull/26213 follow up https://github.com/istio/istio/pull/26217.
It changes to:
- use `OperatorNamespaceHelpstr` for common help description.
- use `operatorDefaultNamespace` and `istioDefaultNamespace` for the default namespace.

[X] Installation
[X] Does not have any changes that may affect Istio users.
