### PR TITLE
change the PARSE_TOKEN to skipParseTokenEnv and fix  the isTokenExpired logic issue 

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -144,7 +144,7 @@ var (
 	useTokenForCSREnv   = env.RegisterBoolVar("USE_TOKEN_FOR_CSR", false, "CSR requires a token").Get()
 	credFetcherTypeEnv  = env.RegisterStringVar("CREDENTIAL_FETCHER_TYPE", "",
 		"The type of the credential fetcher. Currently supported types include GoogleComputeEngine").Get()
-	parseTokenEnv = env.RegisterBoolVar("PARSE_TOKEN", false,
+	parseTokenEnv = env.RegisterBoolVar("PARSE_TOKEN", true,
 		"Parse token to inspect information like expiration time in proxy. This may not always be possible because token may not be a JWT.").Get()
 
 	rootCmd = &cobra.Command{

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -145,8 +145,8 @@ var (
 	credFetcherTypeEnv  = env.RegisterStringVar("CREDENTIAL_FETCHER_TYPE", "",
 		"The type of the credential fetcher. Currently supported types include GoogleComputeEngine").Get()
 	skipParseTokenEnv = env.RegisterBoolVar("SKIP_PARSE_TOKEN", false,
-		"Skip Parse token to inspect information like expiration time in proxy. This may be possible " +
-		"for example in vm we don't use token to rotate cert.").Get()
+		"Skip Parse token to inspect information like expiration time in proxy. This may be possible "+
+											"for example in vm we don't use token to rotate cert.").Get()
 
 	rootCmd = &cobra.Command{
 		Use:          "pilot-agent",

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -145,7 +145,8 @@ var (
 	credFetcherTypeEnv  = env.RegisterStringVar("CREDENTIAL_FETCHER_TYPE", "",
 		"The type of the credential fetcher. Currently supported types include GoogleComputeEngine").Get()
 	skipParseTokenEnv = env.RegisterBoolVar("SKIP_PARSE_TOKEN", false,
-		"Skip Parse token to inspect information like expiration time in proxy. This may not always be possible because token may not be a JWT.").Get()
+		"Skip Parse token to inspect information like expiration time in proxy. This may be possible " +
+		"for example in vm we don't use token to rotate cert.").Get()
 
 	rootCmd = &cobra.Command{
 		Use:          "pilot-agent",

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -144,8 +144,8 @@ var (
 	useTokenForCSREnv   = env.RegisterBoolVar("USE_TOKEN_FOR_CSR", false, "CSR requires a token").Get()
 	credFetcherTypeEnv  = env.RegisterStringVar("CREDENTIAL_FETCHER_TYPE", "",
 		"The type of the credential fetcher. Currently supported types include GoogleComputeEngine").Get()
-	parseTokenEnv = env.RegisterBoolVar("PARSE_TOKEN", true,
-		"Parse token to inspect information like expiration time in proxy. This may not always be possible because token may not be a JWT.").Get()
+	skipParseTokenEnv = env.RegisterBoolVar("SKIP_PARSE_TOKEN", false,
+		"Skip Parse token to inspect information like expiration time in proxy. This may not always be possible because token may not be a JWT.").Get()
 
 	rootCmd = &cobra.Command{
 		Use:          "pilot-agent",
@@ -282,7 +282,7 @@ var (
 			secOpts.InitialBackoffInMilliSec = int64(initialBackoffInMilliSecEnv)
 			// Disable the secret eviction for istio agent.
 			secOpts.EvictionDuration = 0
-			secOpts.ParseToken = parseTokenEnv
+			secOpts.SkipParseToken = skipParseTokenEnv
 
 			// TODO (liminw): CredFetcher is a general interface. In 1.7, we limit the use on GCE only because
 			// GCE is the only supported plugin at the moment.

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -146,7 +146,7 @@ var (
 		"The type of the credential fetcher. Currently supported types include GoogleComputeEngine").Get()
 	skipParseTokenEnv = env.RegisterBoolVar("SKIP_PARSE_TOKEN", false,
 		"Skip Parse token to inspect information like expiration time in proxy. This may be possible "+
-											"for example in vm we don't use token to rotate cert.").Get()
+			"for example in vm we don't use token to rotate cert.").Get()
 
 	rootCmd = &cobra.Command{
 		Use:          "pilot-agent",

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -177,9 +177,9 @@ type Options struct {
 	// credential fetcher.
 	CredFetcher CredFetcher
 
-	// Need to parse token to inspect information like expiration time
+	// whether need to skip parsing token to inspect information like expiration time
 	// Default is false.
-	ParseToken bool
+	SkipParseToken bool
 }
 
 // Client interface defines the clients need to implement to talk to CA for CSR.

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -942,8 +942,8 @@ func (sc *SecretCache) shouldRotate(secret *security.SecretItem) bool {
 func (sc *SecretCache) isTokenExpired(secret *security.SecretItem) bool {
 	// Skip check if the token should not be parsed in proxy.
 	// Parsing token may not always be possible because token may not be a JWT.
-	// If ParseToken is false, we should assume token is valid and leave token validation to CA.
-	if !sc.configOptions.ParseToken {
+	// If SkipParseToken is true, we should assume token is valid and leave token validation to CA.
+	if sc.configOptions.SkipParseToken {
 		return false
 	}
 

--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -884,7 +884,7 @@ func TestWorkloadAgentGenerateSecretFromFile(t *testing.T) {
 		RotationInterval: 200 * time.Millisecond,
 		EvictionDuration: 0,
 		UseTokenForCSR:   true,
-		SkipParseToken:       false,
+		SkipParseToken:   false,
 	}
 
 	fetcher := &secretfetcher.SecretFetcher{

--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -218,7 +218,7 @@ func testWorkloadAgentGenerateSecret(t *testing.T, isUsingPluginProvider bool) {
 		sc.Close()
 	}()
 
-	checkBool(t, "opt.ParseToken default", opt.ParseToken, false)
+	checkBool(t, "opt.SkipParseToken default", opt.SkipParseToken, false)
 
 	conID := "proxy1-id"
 	ctx := context.Background()
@@ -806,7 +806,7 @@ func checkBool(t *testing.T, name string, got bool, want bool) {
 func TestParseTokenFlag(t *testing.T) {
 	sc := createSecretCache()
 	defer sc.Close()
-	sc.configOptions.ParseToken = false
+	sc.configOptions.SkipParseToken = true
 	secret := security.SecretItem{}
 	checkBool(t, "isTokenExpired", sc.isTokenExpired(&secret), false)
 }
@@ -884,7 +884,7 @@ func TestWorkloadAgentGenerateSecretFromFile(t *testing.T) {
 		RotationInterval: 200 * time.Millisecond,
 		EvictionDuration: 0,
 		UseTokenForCSR:   true,
-		ParseToken:       true,
+		SkipParseToken:       false,
 	}
 
 	fetcher := &secretfetcher.SecretFetcher{

--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -182,6 +182,20 @@ FWy1
 		},
 		Type: "test-tls-secret",
 	}
+	fakeExpiredToken = "eyJhbGciOiJSUzI1NiIsImtpZCI6Ik5adXVfam5Zdm5xQ19ZbU54aXRycV" +
+		"gyVWo3cmZkaFplcEF2QUJpUmxmLXMifQ.eyJhdWQiOlsiaXN0aW8tY2EiXSwiZXhwIjoxNTk2Nz" +
+		"Y5MTYyLCJpYXQiOjE1OTY3Njg1NjIsImlzcyI6Imh0dHBzOi8vY29udGFpbmVyLmdvb2dsZWFwa" +
+		"XMuY29tL3YxL3Byb2plY3RzL3dpbGxpYW1saWlzdGlvdGVzdC9sb2NhdGlvbnMvdXMtd2VzdDIt" +
+		"YS9jbHVzdGVycy92bWRlYnVnIiwia3ViZXJuZXRlcy5pbyI6eyJuYW1lc3BhY2UiOiJ2bXRlc3Q" +
+		"iLCJwb2QiOnsibmFtZSI6InNsZWVwLWY4Y2JmNWI3Ni14cHBteiIsInVpZCI6IjFkMDFkMWYwLW" +
+		"VkN2UtNDVhZS1iNTAzLTFhZjAwMDMyODFkZiJ9LCJzZXJ2aWNlYWNjb3VudCI6eyJuYW1lIjoic" +
+		"2xlZXAiLCJ1aWQiOiIzYmI3ZjJkYi1mMTEzLTQxYmItOTg3OC0yYTNhODlhYjNlMjYifX0sIm5i" +
+		"ZiI6MTU5Njc2ODU2Miwic3ViIjoic3lzdGVtOnNlcnZpY2VhY2NvdW50OnZtdGVzdDpzbGVlcCJ" +
+		"9.Ekw9liKDDQgK-RSzIfb2fM0ZH6vQeBKBfA9LuH_3UcCQzKSXV_l-qST3GMmBcmrbAF8MZLcNA" +
+		"bzlwZ_lcWDAYGvHG89fA4OKSZsvG0d83_nuP9hx39qqXSdrJ_OJMTGXXHcvapCgFFMPVa59KDCe" +
+		"aHkbTjmn6v3NpJ78_Cq8VxpNBKZkrdxEZOKfyula7tWegneWwJN7r0XWKB4A6hefMV8ouGI9p0N" +
+		"JujQG96_RkbY4dMeii3Z45mI6CtnAcWZ2ph8bO-OJz83KiGwtzfWvLjrPYpo-vcS7TuPNgALFgB" +
+		"SfH9S2mnmv1eJuiAYj4HkWM0K0_GK3wIBMe-YxBEmd4w"
 )
 
 func TestWorkloadAgentGenerateSecretWithoutPluginProvider(t *testing.T) {
@@ -809,6 +823,15 @@ func TestParseTokenFlag(t *testing.T) {
 	sc.configOptions.SkipParseToken = true
 	secret := security.SecretItem{}
 	checkBool(t, "isTokenExpired", sc.isTokenExpired(&secret), false)
+}
+
+func TestExpiredToken(t *testing.T) {
+	sc := createSecretCache()
+	defer sc.Close()
+	sc.configOptions.SkipParseToken = false
+	secret := security.SecretItem{}
+	secret.Token = fakeExpiredToken
+	checkBool(t, "isTokenExpired", sc.isTokenExpired(&secret), true)
 }
 
 func TestRootCertificateExists(t *testing.T) {


### PR DESCRIPTION
ref: https://github.com/istio/istio/issues/26225

The root cause: when it needs to rotate the cert, token expiration are not validated as the logic is not set correctly in the isTokenExpired  function: 

1. k8s environment: the default value skipParseTokenEnv should be true. So it will not skip the token expire checking here
https://github.com/ist
io/istio/blob/master/security/pkg/nodeagent/cache/secretcache.go#L946

2. vm environment: skipParseTokenEnv should be set to false. As when rotate it should use cert instead of token



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.