### PR TITLE
[Release-1.7] Enable TCP Telemetry v2 export via Stackdriver filter (#25646)

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.7.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.7.yaml
@@ -554,6 +554,119 @@ spec:
                   code:
                     local: { inline_string: envoy.wasm.null.stackdriver }
 ---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: tcp-stackdriver-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  {{- if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    istio.io/rev: {{ .Values.revision | default "default" }}
+spec:
+  configPatches:
+  {{- if not .Values.telemetry.v2.stackdriver.disableOutbound }}
+  - applyTo: NETWORK_FILTER
+    match:
+      context: SIDECAR_OUTBOUND
+      proxy:
+        proxyVersion: '^1\.7.*'
+      listener:
+        filterChain:
+          filter:
+            name: "envoy.tcp_proxy"
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.stackdriver
+        typed_config:
+          "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
+          value:
+            config:
+              root_id: stackdriver_outbound
+              configuration:
+                "@type": "type.googleapis.com/google.protobuf.StringValue"
+                value: |
+                  {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
+                  {"disable_server_access_logging": {{ not .Values.telemetry.v2.stackdriver.logging }}}
+                  {{- else }}
+                  {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                  {{- end }}
+              vm_config:
+                vm_id: stackdriver_outbound
+                runtime: envoy.wasm.runtime.null
+                code:
+                  local: { inline_string: envoy.wasm.null.stackdriver }
+    {{- end }}
+  - applyTo: NETWORK_FILTER
+    match:
+      context: SIDECAR_INBOUND
+      proxy:
+        proxyVersion: '^1\.7.*'
+      listener:
+        filterChain:
+          filter:
+            name: "envoy.tcp_proxy"
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.stackdriver
+        typed_config:
+          "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
+          value:
+            config:
+              root_id: stackdriver_inbound
+              configuration:
+                "@type": "type.googleapis.com/google.protobuf.StringValue"
+                value: |
+                  {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
+                  {"disable_server_access_logging": {{ not .Values.telemetry.v2.stackdriver.logging }}}
+                  {{- else }}
+                  {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                  {{- end }}
+              vm_config:
+                vm_id: stackdriver_inbound
+                runtime: envoy.wasm.runtime.null
+                code:
+                  local: { inline_string: envoy.wasm.null.stackdriver }
+  - applyTo: NETWORK_FILTER
+    match:
+      context: GATEWAY
+      proxy:
+        proxyVersion: '^1\.7.*'
+      listener:
+        filterChain:
+          filter:
+            name: "envoy.tcp_proxy"
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.stackdriver
+        typed_config:
+          "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
+          value:
+            config:
+              root_id: stackdriver_outbound
+              configuration:
+                "@type": "type.googleapis.com/google.protobuf.StringValue"
+                value: |
+                  {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
+                  {"disable_server_access_logging": {{ not .Values.telemetry.v2.stackdriver.logging }}}
+                  {{- else }}
+                  {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                  {{- end }}
+              vm_config:
+                vm_id: stackdriver_outbound
+                runtime: envoy.wasm.runtime.null
+                code:
+                  local: { inline_string: envoy.wasm.null.stackdriver }
+---
 {{- if .Values.telemetry.v2.accessLogPolicy.enabled }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.7.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.7.yaml
@@ -554,6 +554,119 @@ spec:
                   code:
                     local: { inline_string: envoy.wasm.null.stackdriver }
 ---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: tcp-stackdriver-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  {{- if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    istio.io/rev: {{ .Values.revision | default "default" }}
+spec:
+  configPatches:
+  {{- if not .Values.telemetry.v2.stackdriver.disableOutbound }}
+  - applyTo: NETWORK_FILTER
+    match:
+      context: SIDECAR_OUTBOUND
+      proxy:
+        proxyVersion: '^1\.7.*'
+      listener:
+        filterChain:
+          filter:
+            name: "envoy.tcp_proxy"
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.stackdriver
+        typed_config:
+          "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
+          value:
+            config:
+              root_id: stackdriver_outbound
+              configuration:
+                "@type": "type.googleapis.com/google.protobuf.StringValue"
+                value: |
+                  {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
+                  {"disable_server_access_logging": {{ not .Values.telemetry.v2.stackdriver.logging }}}
+                  {{- else }}
+                  {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                  {{- end }}
+              vm_config:
+                vm_id: stackdriver_outbound
+                runtime: envoy.wasm.runtime.null
+                code:
+                  local: { inline_string: envoy.wasm.null.stackdriver }
+    {{- end }}
+  - applyTo: NETWORK_FILTER
+    match:
+      context: SIDECAR_INBOUND
+      proxy:
+        proxyVersion: '^1\.7.*'
+      listener:
+        filterChain:
+          filter:
+            name: "envoy.tcp_proxy"
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.stackdriver
+        typed_config:
+          "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
+          value:
+            config:
+              root_id: stackdriver_inbound
+              configuration:
+                "@type": "type.googleapis.com/google.protobuf.StringValue"
+                value: |
+                  {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
+                  {"disable_server_access_logging": {{ not .Values.telemetry.v2.stackdriver.logging }}}
+                  {{- else }}
+                  {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                  {{- end }}
+              vm_config:
+                vm_id: stackdriver_inbound
+                runtime: envoy.wasm.runtime.null
+                code:
+                  local: { inline_string: envoy.wasm.null.stackdriver }
+  - applyTo: NETWORK_FILTER
+    match:
+      context: GATEWAY
+      proxy:
+        proxyVersion: '^1\.7.*'
+      listener:
+        filterChain:
+          filter:
+            name: "envoy.tcp_proxy"
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.stackdriver
+        typed_config:
+          "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
+          value:
+            config:
+              root_id: stackdriver_outbound
+              configuration:
+                "@type": "type.googleapis.com/google.protobuf.StringValue"
+                value: |
+                  {{- if not .Values.telemetry.v2.stackdriver.configOverride }}
+                  {"disable_server_access_logging": {{ not .Values.telemetry.v2.stackdriver.logging }}}
+                  {{- else }}
+                  {{ toJson .Values.telemetry.v2.stackdriver.configOverride | indent 18 }}
+                  {{- end }}
+              vm_config:
+                vm_id: stackdriver_outbound
+                runtime: envoy.wasm.runtime.null
+                code:
+                  local: { inline_string: envoy.wasm.null.stackdriver }
+---
 {{- if .Values.telemetry.v2.accessLogPolicy.enabled }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter

--- a/pkg/test/framework/components/stackdriver/kube.go
+++ b/pkg/test/framework/components/stackdriver/kube.go
@@ -169,15 +169,24 @@ func (c *kubeComponent) ListLogEntries() ([]*loggingpb.LogEntry, error) {
 		// Remove fields that do not need verification
 		l.Timestamp = nil
 		l.Severity = ltype.LogSeverity_DEFAULT
-		l.HttpRequest.ResponseSize = 0
-		l.HttpRequest.RequestSize = 0
-		l.HttpRequest.ServerIp = ""
-		l.HttpRequest.RemoteIp = ""
-		l.HttpRequest.Latency = nil
+		if l.HttpRequest != nil {
+			l.HttpRequest.ResponseSize = 0
+			l.HttpRequest.RequestSize = 0
+			l.HttpRequest.ServerIp = ""
+			l.HttpRequest.RemoteIp = ""
+			l.HttpRequest.Latency = nil
+		}
 		delete(l.Labels, "request_id")
 		delete(l.Labels, "source_name")
+		delete(l.Labels, "destination_ip")
 		delete(l.Labels, "destination_name")
 		delete(l.Labels, "connection_id")
+		delete(l.Labels, "upstream_host")
+		delete(l.Labels, "connection_state")
+		delete(l.Labels, "source_ip")
+		delete(l.Labels, "source_port")
+		delete(l.Labels, "total_sent_bytes")
+		delete(l.Labels, "total_received_bytes")
 		ret = append(ret, l)
 	}
 	return ret, nil

--- a/tests/integration/telemetry/stackdriver/stackdriver_tcp_filter_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_tcp_filter_test.go
@@ -1,0 +1,54 @@
+// Copyright Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stackdriver
+
+import (
+	"testing"
+	"time"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/util/retry"
+)
+
+const (
+	tcpServerConnectionCount = "testdata/server_tcp_connection_count.json.tmpl"
+	tcpClientConnectionCount = "testdata/client_tcp_connection_count.json.tmpl"
+	tcpServerLogEntry        = "testdata/tcp_server_access_log.json.tmpl"
+)
+
+// TestTCPStackdriverMonitoring verifies that stackdriver TCP filter works.
+func TestTCPStackdriverMonitoring(t *testing.T) {
+	framework.NewTest(t).
+		Run(func(ctx framework.TestContext) {
+			retry.UntilSuccessOrFail(t, func() error {
+				_, err := clt.Call(echo.CallOptions{
+					Target:   srv,
+					PortName: "tcp",
+					Count:    1,
+				})
+				if err != nil {
+					return err
+				}
+				if err := validateMetrics(t, tcpServerConnectionCount, tcpClientConnectionCount); err != nil {
+					return err
+				}
+				if err := validateLogs(t, tcpServerLogEntry); err != nil {
+					return err
+				}
+				return nil
+			}, retry.Delay(3*time.Second), retry.Timeout(40*time.Second))
+		})
+}

--- a/tests/integration/telemetry/stackdriver/testdata/client_tcp_connection_count.json.tmpl
+++ b/tests/integration/telemetry/stackdriver/testdata/client_tcp_connection_count.json.tmpl
@@ -1,0 +1,33 @@
+{
+    "metric": {
+       "type": "istio.io/service/client/connection_open_count",
+       "labels": {
+          "destination_canonical_revision": "v1",
+          "destination_canonical_service_name": "srv",
+          "destination_canonical_service_namespace": "{{ .EchoNamespace }}",
+          "destination_owner": "kubernetes://apis/apps/v1/namespaces/{{ .EchoNamespace }}/deployments/srv-v1",
+          "destination_port": "9000",
+          "destination_principal": "spiffe://cluster.local/ns/{{ .EchoNamespace }}/sa/default",
+          "destination_service_name": "srv",
+          "destination_service_namespace": "{{ .EchoNamespace }}",
+          "destination_workload_name": "srv-v1",
+          "destination_workload_namespace": "{{ .EchoNamespace }}",
+          "mesh_uid": "test-mesh",
+          "request_protocol": "tcp",
+          "service_authentication_policy": "unknown",
+          "source_canonical_revision": "v1",
+          "source_canonical_service_name": "clt",
+          "source_canonical_service_namespace": "{{ .EchoNamespace }}",
+          "source_owner": "kubernetes://apis/apps/v1/namespaces/{{ .EchoNamespace }}/deployments/clt-v1",
+          "source_principal": "spiffe://cluster.local/ns/{{ .EchoNamespace }}/sa/default",
+          "source_workload_name": "clt-v1",
+          "source_workload_namespace": "{{ .EchoNamespace }}"
+       }
+    },
+    "resource": {
+       "labels": {
+          "namespace_name": "{{ .EchoNamespace }}"
+       },
+       "type": "k8s_pod"
+    }
+}

--- a/tests/integration/telemetry/stackdriver/testdata/server_tcp_connection_count.json.tmpl
+++ b/tests/integration/telemetry/stackdriver/testdata/server_tcp_connection_count.json.tmpl
@@ -1,0 +1,34 @@
+{
+    "metric": {
+       "type": "istio.io/service/server/connection_open_count",
+       "labels": {
+          "destination_canonical_revision": "v1",
+          "destination_canonical_service_name": "srv",
+          "destination_canonical_service_namespace": "{{ .EchoNamespace }}",
+          "destination_owner": "kubernetes://apis/apps/v1/namespaces/{{ .EchoNamespace }}/deployments/srv-v1",
+          "destination_port": "9000",
+          "destination_principal": "spiffe://cluster.local/ns/{{ .EchoNamespace }}/sa/default",
+          "destination_service_name": "srv",
+          "destination_service_namespace": "{{ .EchoNamespace }}",
+          "destination_workload_name": "srv-v1",
+          "destination_workload_namespace": "{{ .EchoNamespace }}",
+          "mesh_uid": "test-mesh",
+          "request_protocol": "tcp",
+          "source_canonical_revision": "v1",
+          "source_canonical_service_name": "clt",
+          "source_canonical_service_namespace": "{{ .EchoNamespace }}",
+          "service_authentication_policy": "MUTUAL_TLS",
+          "source_owner": "kubernetes://apis/apps/v1/namespaces/{{ .EchoNamespace }}/deployments/clt-v1",
+          "source_principal": "spiffe://cluster.local/ns/{{ .EchoNamespace }}/sa/default",
+          "source_workload_name": "clt-v1",
+          "source_workload_namespace": "{{ .EchoNamespace }}"
+       }
+    },
+    "resource": {
+       "labels": {
+          "container_name": "app",
+          "namespace_name": "{{ .EchoNamespace }}"
+       },
+       "type": "k8s_container"
+    }
+}

--- a/tests/integration/telemetry/stackdriver/testdata/tcp_server_access_log.json.tmpl
+++ b/tests/integration/telemetry/stackdriver/testdata/tcp_server_access_log.json.tmpl
@@ -1,0 +1,30 @@
+{
+    "labels": {
+        "destination_app": "srv",
+        "destination_canonical_revision": "v1",
+        "destination_canonical_service": "srv",
+        "destination_namespace": "{{ .EchoNamespace }}",
+        "destination_principal": "spiffe://cluster.local/ns/{{ .EchoNamespace }}/sa/default",
+        "destination_service_host": "srv.{{ .EchoNamespace }}.svc.cluster.local",
+        "destination_version": "v1",
+        "destination_workload": "srv-v1",
+        "destination_port": "9000",
+        "mesh_uid": "test-mesh",
+        "response_flag": "-",
+        "service_authentication_policy": "MUTUAL_TLS",
+        "source_app": "clt",
+        "source_canonical_revision": "v1",
+        "source_canonical_service": "clt",
+        "source_namespace": "{{ .EchoNamespace }}",
+        "source_principal": "spiffe://cluster.local/ns/{{ .EchoNamespace }}/sa/default",
+        "source_version": "v1",
+        "source_workload": "clt-v1",
+        "protocol": "tcp",
+        "log_sampled": "false",
+        "requested_server_name": "outbound_.9090_._.srv.{{ .EchoNamespace }}.svc.cluster.local",
+        "upstream_cluster": "inbound|9090|tcp|srv.{{ .EchoNamespace }}.svc.cluster.local",
+        "route_name": "",
+        "x-envoy-original-dst-host": "",
+        "x-envoy-original-path": ""
+    }
+}

--- a/tests/integration/telemetry/stackdriver/testdata/tcp_server_access_log.json.tmpl
+++ b/tests/integration/telemetry/stackdriver/testdata/tcp_server_access_log.json.tmpl
@@ -1,4 +1,5 @@
 {
+    "text_payload": "clt --> srv",
     "labels": {
         "destination_app": "srv",
         "destination_canonical_revision": "v1",
@@ -20,11 +21,6 @@
         "source_version": "v1",
         "source_workload": "clt-v1",
         "protocol": "tcp",
-        "log_sampled": "false",
-        "requested_server_name": "outbound_.9090_._.srv.{{ .EchoNamespace }}.svc.cluster.local",
-        "upstream_cluster": "inbound|9090|tcp|srv.{{ .EchoNamespace }}.svc.cluster.local",
-        "route_name": "",
-        "x-envoy-original-dst-host": "",
-        "x-envoy-original-path": ""
+        "log_sampled": "false"
     }
 }


### PR DESCRIPTION
Enable TCP Telemetry v2 export via Stackdriver filter (#25646)


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.