### PR TITLE
Add v1 AdmissionReview to 1.6 to be able to upgrade on k8s 1.16+

### DIFF
--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -41,6 +41,7 @@ import (
 
 	"istio.io/pkg/log"
 
+	"k8s.io/api/admission/v1"
 	"k8s.io/api/admission/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -57,6 +58,7 @@ var (
 func init() {
 	_ = corev1.AddToScheme(runtimeScheme)
 	_ = v1beta1.AddToScheme(runtimeScheme)
+	_ = v1.AddToScheme(runtimeScheme)
 }
 
 const (


### PR DESCRIPTION
Fix https://github.com/istio/istio/issues/26280

Similar to https://github.com/istio/istio/pull/26187

Background: https://github.com/kubernetes/kubernetes/issues/85681


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.