### PR TITLE
Don't specify remote profile in test framework deploy

### DIFF
--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -487,7 +487,6 @@ func deployControlPlane(c *operatorComponent, cfg Config, cluster resource.Clust
 		}
 
 		if !c.environment.IsControlPlaneCluster(cluster) {
-			installSettings = append(installSettings, "--set", "profile=remote")
 			remoteIstiodAddress, err := c.RemoteDiscoveryAddressFor(cluster)
 			if err != nil {
 				return err


### PR DESCRIPTION
This profile is now the same as the default

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

Pull Request Attributes

[X] Does not have any changes that may affect Istio users.