### PR TITLE
fix race when reloading kube controller networks

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/network.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network.go
@@ -43,6 +43,7 @@ func (c *Controller) reloadNetworkLookup() {
 
 	ranger := cidranger.NewPCTrieRanger()
 
+	c.Lock()
 	for n, v := range meshNetworks.Networks {
 		for _, ep := range v.Endpoints {
 			if ep.GetFromCidr() != "" {
@@ -63,6 +64,7 @@ func (c *Controller) reloadNetworkLookup() {
 		}
 	}
 	c.ranger = ranger
+	c.Unlock()
 	// the network for endpoints are computed when we process the events; this will fix the cache
 	// NOTE: this must run before the other network watcher handler that creates a force push
 	if err := c.syncPods(); err != nil {

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -110,7 +110,7 @@ func BenchmarkRouteGeneration(b *testing.B) {
 		b.Run(tt.Name, func(b *testing.B) {
 			s, proxy := setupAndInitializeTest(b, tt)
 			// To determine which routes to generate, first gen listeners once (not part of benchmark) and extract routes
-			l := s.Discovery.ConfigGenerator.BuildListeners(proxy, s.PushContext)
+			l := s.Discovery.ConfigGenerator.BuildListeners(proxy, s.PushContext())
 			routeNames := ExtractRoutesFromListeners(l)
 			if len(routeNames) == 0 {
 				b.Fatal("Got no route names!")
@@ -118,7 +118,7 @@ func BenchmarkRouteGeneration(b *testing.B) {
 			b.ResetTimer()
 			var response *discovery.DiscoveryResponse
 			for n := 0; n < b.N; n++ {
-				r := s.Discovery.ConfigGenerator.BuildHTTPRoutes(proxy, s.PushContext, routeNames)
+				r := s.Discovery.ConfigGenerator.BuildHTTPRoutes(proxy, s.PushContext(), routeNames)
 				if len(r) == 0 {
 					b.Fatal("Got no routes!")
 				}
@@ -137,7 +137,7 @@ func BenchmarkClusterGeneration(b *testing.B) {
 			b.ResetTimer()
 			var response *discovery.DiscoveryResponse
 			for n := 0; n < b.N; n++ {
-				c := s.Discovery.ConfigGenerator.BuildClusters(proxy, s.PushContext)
+				c := s.Discovery.ConfigGenerator.BuildClusters(proxy, s.PushContext())
 				if len(c) == 0 {
 					b.Fatal("Got no clusters!")
 				}
@@ -156,7 +156,7 @@ func BenchmarkListenerGeneration(b *testing.B) {
 			b.ResetTimer()
 			var response *discovery.DiscoveryResponse
 			for n := 0; n < b.N; n++ {
-				l := s.Discovery.ConfigGenerator.BuildListeners(proxy, s.PushContext)
+				l := s.Discovery.ConfigGenerator.BuildListeners(proxy, s.PushContext())
 				if len(l) == 0 {
 					b.Fatal("Got no listeners!")
 				}

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -284,21 +284,11 @@ func (s *DiscoveryServer) Push(req *model.PushRequest) {
 	// PushContext is reset after a config change. Previous status is
 	// saved.
 	t0 := time.Now()
-	push := model.NewPushContext()
-	if err := push.InitContext(s.Env, oldPushContext, req); err != nil {
-		adsLog.Errorf("XDS: Failed to update services: %v", err)
-		// We can't push if we can't read the data - stick with previous version.
-		pushContextErrors.Increment()
+
+	push, err := s.initPushContext(req, oldPushContext)
+	if err != nil {
 		return
 	}
-
-	if err := s.UpdateServiceShards(push); err != nil {
-		return
-	}
-
-	s.updateMutex.Lock()
-	s.Env.PushContext = push
-	s.updateMutex.Unlock()
 
 	versionLocal := time.Now().Format(time.RFC3339) + "/" + strconv.FormatUint(versionNum.Load(), 10)
 	versionNum.Inc()
@@ -462,6 +452,27 @@ func doSendPushes(stopCh <-chan struct{}, semaphore chan struct{}, queue *PushQu
 			}()
 		}
 	}
+}
+
+// initPushContext creates a global push context and stores it on the environment.
+func (s *DiscoveryServer) initPushContext(req *model.PushRequest, oldPushContext *model.PushContext) (*model.PushContext, error) {
+	push := model.NewPushContext()
+	if err := push.InitContext(s.Env, oldPushContext, req); err != nil {
+		adsLog.Errorf("XDS: Failed to update services: %v", err)
+		// We can't push if we can't read the data - stick with previous version.
+		pushContextErrors.Increment()
+		return nil, err
+	}
+
+	if err := s.UpdateServiceShards(push); err != nil {
+		return nil, err
+	}
+
+	s.updateMutex.Lock()
+	s.Env.PushContext = push
+	s.updateMutex.Unlock()
+
+	return push, nil
 }
 
 func (s *DiscoveryServer) sendPushes(stopCh <-chan struct{}) {


### PR DESCRIPTION
There is an actual race that we did not have tests covering until recently - we run `reloadNetworkLookup` during init as well as in a handler for networks watcher. It's technically possible that they could race. 

```
PASS
ok      istio.io/istio/pilot/pkg/xds    27.786s
~/g/s/i/i/p/p/xds ❯❯❯ echo !!
go test -count 100 -race -run TestMeshNet
```

Since the last tests I add require updating the global push context, we need to further synchronize access to Env.PushContext in test code that uses FakeDiscoveryServer. Originally, we copied the _first_ version of the push context to the root of the FakeServer, now we want to access the actual one on `Env`, which requires syncrhonization. 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
