### PR TITLE
Don't parse null IstioOperator overlays

### DIFF
--- a/operator/pkg/util/yaml.go
+++ b/operator/pkg/util/yaml.go
@@ -66,6 +66,10 @@ func MarshalWithJSONPB(val proto.Message) (string, error) {
 
 // UnmarshalWithJSONPB unmarshals y into out using gogo jsonpb (required for many proto defined structs).
 func UnmarshalWithJSONPB(y string, out proto.Message, allowUnknownField bool) error {
+	// Treat nothing as nothing.  If we called jsonpb.Unmarshaler it would return the same.
+	if y == "" {
+		return nil
+	}
 	jb, err := yaml.YAMLToJSON([]byte(y))
 	if err != nil {
 		return err

--- a/operator/pkg/validate/common.go
+++ b/operator/pkg/validate/common.go
@@ -277,9 +277,13 @@ func UnmarshalIOP(iopYAML string) (*v1alpha1.IstioOperator, error) {
 	if err := yaml.Unmarshal([]byte(iopYAML), &mapIOP); err != nil {
 		return nil, err
 	}
-	un := &unstructured.Unstructured{Object: mapIOP}
-	un.SetCreationTimestamp(meta_v1.Time{}) // UnmarshalIstioOperator chokes on these
-	iopYAML = util.ToYAML(un)
+	// Don't bother trying to remove the timestamp if there are no fields.
+	// This also preserves iopYAML if it is ""; we don't want iopYAML to be the string "null"
+	if len(mapIOP) > 0 {
+		un := &unstructured.Unstructured{Object: mapIOP}
+		un.SetCreationTimestamp(meta_v1.Time{}) // UnmarshalIstioOperator chokes on these
+		iopYAML = util.ToYAML(un)
+	}
 	iop := &v1alpha1.IstioOperator{}
 	if err := util.UnmarshalWithJSONPB(iopYAML, iop, false); err != nil {
 		return nil, fmt.Errorf("%s:\n\nYAML:\n%s", err, iopYAML)


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/26010

If the overlay is `""` don't try to remove K8s time fields nor try to parse with Gogo.