### PR TITLE
Allow verify-install to work if cluster has managedField enabled (default in K8s 1.18)

### DIFF
--- a/istioctl/pkg/install/verify.go
+++ b/istioctl/pkg/install/verify.go
@@ -402,7 +402,7 @@ func verifyPostInstallIstioOperator(enableVerbose bool, istioNamespaceFlag strin
 		fmt.Sprintf("generated from %s", filename),
 		restClientGetter,
 		writer,
-		iop.Spec.InstallPackagePath)
+		manifestsPath)
 	if err != nil {
 		return generatedCrds, generatedDeployments, err
 	}


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/25688

Istioctl couldn't parse the on-cluster IstioOperator, because of a time field inside a `managedField`.  I have only seen this on K8s 1.18.)

Also:
- Allow --manifests to work with -f.  This is very important if we don't an in-cluster IOP to recreate a problem.  The in-cluster IOP may have a path that doesn't exist on the machine doing the verification, e.g. /home/prow.
- Relax deployment counting.  Any deployment created by `istioctl install` is counted, not just core control plane.
