### PR TITLE
ads: move mutex to proxy

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -150,6 +151,7 @@ type XdsResourceGenerator interface {
 // In current Istio implementation nodes use a 4-parts '~' delimited ID.
 // Type~IPAddress~ID~Domain
 type Proxy struct {
+	sync.RWMutex
 
 	// Type specifies the node type. First part of the ID.
 	Type NodeType

--- a/pilot/pkg/model/context_test.go
+++ b/pilot/pkg/model/context_test.go
@@ -357,8 +357,8 @@ func TestParseMetadata(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to parse service node: %v", err)
 			}
-			if !reflect.DeepEqual(&tt.out, node) {
-				t.Errorf("Got \n%v, want \n%v", node, &tt.out)
+			if !reflect.DeepEqual(*tt.out.Metadata, *node.Metadata) {
+				t.Errorf("Got \n%v, want \n%v", *node.Metadata, *tt.out.Metadata)
 			}
 		})
 	}

--- a/pilot/pkg/model/context_test.go
+++ b/pilot/pkg/model/context_test.go
@@ -290,17 +290,17 @@ func TestParseMetadata(t *testing.T) {
 	cases := []struct {
 		name     string
 		metadata map[string]interface{}
-		out      model.Proxy
+		out      *model.Proxy
 	}{
 		{
 			name: "Basic Case",
-			out: model.Proxy{Type: "sidecar", IPAddresses: []string{"1.1.1.1"}, DNSDomain: "domain", ID: "id", IstioVersion: model.MaxIstioVersion,
+			out: &model.Proxy{Type: "sidecar", IPAddresses: []string{"1.1.1.1"}, DNSDomain: "domain", ID: "id", IstioVersion: model.MaxIstioVersion,
 				Metadata: &model.NodeMetadata{Raw: map[string]interface{}{}}},
 		},
 		{
 			name:     "Capture Arbitrary Metadata",
 			metadata: map[string]interface{}{"foo": "bar"},
-			out: model.Proxy{Type: "sidecar", IPAddresses: []string{"1.1.1.1"}, DNSDomain: "domain", ID: "id", IstioVersion: model.MaxIstioVersion,
+			out: &model.Proxy{Type: "sidecar", IPAddresses: []string{"1.1.1.1"}, DNSDomain: "domain", ID: "id", IstioVersion: model.MaxIstioVersion,
 				Metadata: &model.NodeMetadata{
 					Raw: map[string]interface{}{
 						"foo": "bar",
@@ -314,7 +314,7 @@ func TestParseMetadata(t *testing.T) {
 					"foo": "bar",
 				},
 			},
-			out: model.Proxy{Type: "sidecar", IPAddresses: []string{"1.1.1.1"}, DNSDomain: "domain", ID: "id", IstioVersion: model.MaxIstioVersion,
+			out: &model.Proxy{Type: "sidecar", IPAddresses: []string{"1.1.1.1"}, DNSDomain: "domain", ID: "id", IstioVersion: model.MaxIstioVersion,
 				Metadata: &model.NodeMetadata{
 					Raw: map[string]interface{}{
 						"LABELS": map[string]interface{}{"foo": "bar"},
@@ -328,7 +328,7 @@ func TestParseMetadata(t *testing.T) {
 			metadata: map[string]interface{}{
 				"POD_PORTS": `[{"name":"http","containerPort":8080,"protocol":"TCP"},{"name":"grpc","containerPort":8079,"protocol":"TCP"}]`,
 			},
-			out: model.Proxy{Type: "sidecar", IPAddresses: []string{"1.1.1.1"}, DNSDomain: "domain", ID: "id", IstioVersion: model.MaxIstioVersion,
+			out: &model.Proxy{Type: "sidecar", IPAddresses: []string{"1.1.1.1"}, DNSDomain: "domain", ID: "id", IstioVersion: model.MaxIstioVersion,
 				Metadata: &model.NodeMetadata{
 					Raw: map[string]interface{}{
 						"POD_PORTS": `[{"name":"http","containerPort":8080,"protocol":"TCP"},{"name":"grpc","containerPort":8079,"protocol":"TCP"}]`,

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
@@ -50,7 +50,7 @@ func getDefaultLdsEnv() *LdsEnv {
 	return &listenerEnv
 }
 
-func getDefaultProxy() model.Proxy {
+func getDefaultProxy() *model.Proxy {
 	proxy := model.Proxy{
 		Type:        model.SidecarProxy,
 		IPAddresses: []string{"1.1.1.1"},
@@ -65,7 +65,7 @@ func getDefaultProxy() model.Proxy {
 	}
 
 	proxy.DiscoverIPVersions()
-	return proxy
+	return &proxy
 }
 
 func setNilSidecarOnProxy(proxy *model.Proxy, pushContext *model.PushContext) {
@@ -95,9 +95,9 @@ func TestVirtualListenerBuilder(t *testing.T) {
 	}
 	proxy := getDefaultProxy()
 	proxy.ServiceInstances = instances
-	setNilSidecarOnProxy(&proxy, env.PushContext)
+	setNilSidecarOnProxy(proxy, env.PushContext)
 
-	builder := NewListenerBuilder(&proxy, env.PushContext)
+	builder := NewListenerBuilder(proxy, env.PushContext)
 	listeners := builder.
 		buildVirtualOutboundListener(ldsEnv.configgen).
 		getListeners()
@@ -142,10 +142,10 @@ func prepareListeners(t *testing.T, services []*model.Service, mode model.Traffi
 
 	proxy := getDefaultProxy()
 	proxy.ServiceInstances = instances
-	setInboundCaptureAllOnThisNode(&proxy, mode)
-	setNilSidecarOnProxy(&proxy, env.PushContext)
+	setInboundCaptureAllOnThisNode(proxy, mode)
+	setNilSidecarOnProxy(proxy, env.PushContext)
 
-	builder := NewListenerBuilder(&proxy, env.PushContext)
+	builder := NewListenerBuilder(proxy, env.PushContext)
 	return builder.buildSidecarInboundListeners(ldsEnv.configgen).
 		buildHTTPProxyListener(ldsEnv.configgen).
 		buildVirtualOutboundListener(ldsEnv.configgen).
@@ -425,7 +425,7 @@ func TestListenerBuilderPatchListeners(t *testing.T) {
 
 		{
 			name:        "patch add inbound and outbound listener",
-			proxy:       &sidecarProxy,
+			proxy:       sidecarProxy,
 			pushContext: env.PushContext,
 			fields: fields{
 				outboundListeners: []*listener.Listener{
@@ -453,7 +453,7 @@ func TestListenerBuilderPatchListeners(t *testing.T) {
 		},
 		{
 			name:        "patch inbound and outbound listener",
-			proxy:       &sidecarProxy,
+			proxy:       sidecarProxy,
 			pushContext: env.PushContext,
 			fields: fields{
 				outboundListeners: []*listener.Listener{
@@ -493,7 +493,7 @@ func TestListenerBuilderPatchListeners(t *testing.T) {
 		},
 		{
 			name:        "patch add gateway listener",
-			proxy:       &gatewayProxy,
+			proxy:       gatewayProxy,
 			pushContext: env.PushContext,
 			fields: fields{
 				gatewayListeners: []*listener.Listener{
@@ -516,7 +516,7 @@ func TestListenerBuilderPatchListeners(t *testing.T) {
 
 		{
 			name:        "patch gateway listener",
-			proxy:       &gatewayProxy,
+			proxy:       gatewayProxy,
 			pushContext: env.PushContext,
 			fields: fields{
 				gatewayListeners: []*listener.Listener{

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -1467,12 +1467,12 @@ func TestHttpProxyListener_Tracing(t *testing.T) {
 		name             string
 		in               *meshconfig.Tracing
 		out              *hcm.HttpConnectionManager_Tracing
-		tproxy           model.Proxy
+		tproxy           *model.Proxy
 		envPilotSampling float64
 	}{
 		{
 			name:             "random-sampling-env",
-			tproxy:           *getProxy(),
+			tproxy:           getProxy(),
 			envPilotSampling: 80.0,
 			in: &meshconfig.Tracing{
 				Tracer:           nil,
@@ -1495,7 +1495,7 @@ func TestHttpProxyListener_Tracing(t *testing.T) {
 		},
 		{
 			name:             "random-sampling-env-and-meshconfig",
-			tproxy:           *getProxy(),
+			tproxy:           getProxy(),
 			envPilotSampling: 80.0,
 			in: &meshconfig.Tracing{
 				Tracer:           nil,
@@ -1518,7 +1518,7 @@ func TestHttpProxyListener_Tracing(t *testing.T) {
 		},
 		{
 			name:             "random-sampling-too-low-env",
-			tproxy:           *getProxy(),
+			tproxy:           getProxy(),
 			envPilotSampling: -1,
 			in: &meshconfig.Tracing{
 				Tracer:           nil,
@@ -1541,7 +1541,7 @@ func TestHttpProxyListener_Tracing(t *testing.T) {
 		},
 		{
 			name:             "random-sampling-too-high-meshconfig",
-			tproxy:           *getProxy(),
+			tproxy:           getProxy(),
 			envPilotSampling: 80.0,
 			in: &meshconfig.Tracing{
 				Tracer:           nil,
@@ -1564,7 +1564,7 @@ func TestHttpProxyListener_Tracing(t *testing.T) {
 		},
 		{
 			name:             "random-sampling-too-high-env",
-			tproxy:           *getProxy(),
+			tproxy:           getProxy(),
 			envPilotSampling: 2000.0,
 			in: &meshconfig.Tracing{
 				Tracer:           nil,
@@ -1589,7 +1589,7 @@ func TestHttpProxyListener_Tracing(t *testing.T) {
 			// upstream will set the default to 256 per
 			// its documentation
 			name:   "tag-max-path-length-not-set-default",
-			tproxy: *getProxy(),
+			tproxy: getProxy(),
 			in: &meshconfig.Tracing{
 				Tracer:           nil,
 				CustomTags:       nil,
@@ -1611,7 +1611,7 @@ func TestHttpProxyListener_Tracing(t *testing.T) {
 		},
 		{
 			name:   "tag-max-path-length-set-to-1024",
-			tproxy: *getProxy(),
+			tproxy: getProxy(),
 			in: &meshconfig.Tracing{
 				Tracer:           nil,
 				CustomTags:       nil,
@@ -1635,7 +1635,7 @@ func TestHttpProxyListener_Tracing(t *testing.T) {
 		},
 		{
 			name:   "custom-tags-sidecar",
-			tproxy: *getProxy(),
+			tproxy: getProxy(),
 			in: &meshconfig.Tracing{
 				CustomTags: map[string]*meshconfig.Tracing_CustomTag{
 					"custom_tag_env": {
@@ -1707,7 +1707,7 @@ func TestHttpProxyListener_Tracing(t *testing.T) {
 		},
 		{
 			name:   "custom-tracing-gateways",
-			tproxy: proxyGateway,
+			tproxy: &proxyGateway,
 			in: &meshconfig.Tracing{
 				MaxPathTagLength: 100,
 				CustomTags: map[string]*meshconfig.Tracing_CustomTag{
@@ -1776,7 +1776,7 @@ func TestHttpProxyListener_Tracing(t *testing.T) {
 		}
 
 		tc.tproxy.SidecarScope = model.DefaultSidecarScopeForNamespace(env.PushContext, "not-default")
-		httpProxy := configgen.buildHTTPProxy(&tc.tproxy, env.PushContext)
+		httpProxy := configgen.buildHTTPProxy(tc.tproxy, env.PushContext)
 
 		f := httpProxy.FilterChains[0].Filters[0]
 		verifyHTTPConnectionManagerFilter(t, f, tc.out, tc.name)

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -319,10 +319,6 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		fooNode.Metadata = &model.NodeMetadata{
 			Namespace: "foo",
 		}
-		barNode := node
-		barNode.Metadata = &model.NodeMetadata{
-			Namespace: "bar",
-		}
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(fooNode, nil, virtualServiceMatchingOnSourceNamespace, serviceRegistry, 8080, gatewayNames)
 		// Valiate routes.
@@ -334,6 +330,11 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 		g.Expect(len(routes)).To(gomega.Equal(1))
 		g.Expect(routes[0].GetName()).To(gomega.Equal("foo"))
+
+		barNode := node
+		barNode.Metadata = &model.NodeMetadata{
+			Namespace: "bar",
+		}
 
 		routes, err = route.BuildHTTPRoutesForVirtualService(barNode, nil, virtualServiceMatchingOnSourceNamespace, serviceRegistry, 8080, gatewayNames)
 		g.Expect(err).NotTo(gomega.HaveOccurred())

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -315,16 +315,16 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	t.Run("for virtual service with source namespace matching", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
-		fooNode := *node
+		fooNode := node
 		fooNode.Metadata = &model.NodeMetadata{
 			Namespace: "foo",
 		}
-		barNode := *node
+		barNode := node
 		barNode.Metadata = &model.NodeMetadata{
 			Namespace: "bar",
 		}
 
-		routes, err := route.BuildHTTPRoutesForVirtualService(&fooNode, nil, virtualServiceMatchingOnSourceNamespace, serviceRegistry, 8080, gatewayNames)
+		routes, err := route.BuildHTTPRoutesForVirtualService(fooNode, nil, virtualServiceMatchingOnSourceNamespace, serviceRegistry, 8080, gatewayNames)
 		// Valiate routes.
 		for _, r := range routes {
 			if err := r.Validate(); err != nil {
@@ -335,7 +335,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g.Expect(len(routes)).To(gomega.Equal(1))
 		g.Expect(routes[0].GetName()).To(gomega.Equal("foo"))
 
-		routes, err = route.BuildHTTPRoutesForVirtualService(&barNode, nil, virtualServiceMatchingOnSourceNamespace, serviceRegistry, 8080, gatewayNames)
+		routes, err = route.BuildHTTPRoutesForVirtualService(barNode, nil, virtualServiceMatchingOnSourceNamespace, serviceRegistry, 8080, gatewayNames)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 		g.Expect(len(routes)).To(gomega.Equal(1))
 		g.Expect(routes[0].GetName()).To(gomega.Equal("bar"))

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -304,6 +304,10 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream discovery.AggregatedD
 			}
 
 		case pushEv := <-con.pushChannel:
+			// TODO: possible race condition: if a config change happens while the envoy
+			// was getting the initial config, between LDS and RDS, the push will miss the
+			// monitored 'routes'. Same for CDS/EDS interval. It is very tricky to handle
+			// due to the protocol - but the periodic push recovers from it.
 			err := s.pushConnection(con, pushEv)
 			pushEv.done()
 			if err != nil {

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -17,7 +17,8 @@ package xds
 import (
 	"errors"
 	"io"
-	"sync"
+	"strconv"
+	"sync/atomic"
 	"time"
 
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -44,6 +45,9 @@ var (
 	// SendTimeout is the max time to wait for a ADS send to complete. This helps detect
 	// clients in a bad state (not reading). In future it may include checking for ACK
 	SendTimeout = 5 * time.Second
+
+	// Tracks connections, increment on each new connection.
+	connectionNumber = int64(0)
 )
 
 // DiscoveryStream is an interface for ADS.
@@ -65,10 +69,8 @@ type Connection struct {
 	// Currently based on the node name and a counter.
 	ConID string
 
-	// mutex to protect changes to the node.
-	// TODO: move into model.Proxy
-	mu   sync.RWMutex
-	node *model.Proxy
+	// proxy is the proxy to which this connection is established.
+	proxy *model.Proxy
 
 	// Sending on this channel results in a push.
 	pushChannel chan *Event
@@ -78,7 +80,7 @@ type Connection struct {
 
 	// Original node metadata, to avoid unmarshal/marshal.
 	// This is included in internal events.
-	xdsNode *core.Node
+	node *core.Node
 
 	// Computed Xds data. Mainly used for debug display.
 	XdsListeners []*listener.Listener                 `json:"-"`
@@ -133,7 +135,7 @@ func isExpectedGRPCError(err error) bool {
 	return false
 }
 
-func (s *DiscoveryServer) receiveThread(con *Connection, reqChannel chan *discovery.DiscoveryRequest, errP *error) {
+func (s *DiscoveryServer) receive(con *Connection, reqChannel chan *discovery.DiscoveryRequest, errP *error) {
 	defer close(reqChannel) // indicates close of the remote side.
 	firstReq := true
 	for {
@@ -189,7 +191,7 @@ func (s *DiscoveryServer) processRequest(discReq *discovery.DiscoveryRequest, co
 
 	// Based on node metadata a different generator was selected,
 	// use it instead of the default behavior.
-	if con.node.XdsResourceGenerator != nil {
+	if con.proxy.XdsResourceGenerator != nil {
 		// Endpoints are special - will use the optimized code path.
 		err = s.handleCustomGenerator(con, discReq)
 		if err != nil {
@@ -277,7 +279,7 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream discovery.AggregatedD
 	// This also detects close.
 	var receiveError error
 	reqChannel := make(chan *discovery.DiscoveryRequest, 1)
-	go s.receiveThread(con, reqChannel, &receiveError)
+	go s.receive(con, reqChannel, &receiveError)
 
 	for {
 		// Block until either a request is received or a push is triggered.
@@ -301,16 +303,6 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream discovery.AggregatedD
 			}
 
 		case pushEv := <-con.pushChannel:
-			// It is called when config changes.
-			// This is not optimized yet - we should detect what changed based on event and only
-			// push resources that need to be pushed.
-
-			// TODO: possible race condition: if a config change happens while the envoy
-			// was getting the initial config, between LDS and RDS, the push will miss the
-			// monitored 'routes'. Same for CDS/EDS interval.
-			// It is very tricky to handle due to the protocol - but the periodic push recovers
-			// from it.
-
 			err := s.pushConnection(con, pushEv)
 			pushEv.done()
 			if err != nil {
@@ -352,7 +344,7 @@ func (s *DiscoveryServer) handleEds(con *Connection, discReq *discovery.Discover
 	if !s.shouldRespond(con, edsReject, discReq) {
 		return nil
 	}
-	con.node.Active[v3.EndpointType].ResourceNames = discReq.ResourceNames
+	con.proxy.Active[v3.EndpointType].ResourceNames = discReq.ResourceNames
 	adsLog.Debugf("ADS:EDS: REQ %s clusters:%d", con.ConID, len(con.Clusters()))
 	err := s.pushEds(s.globalPushContext(), con, versionInfo(), nil)
 	if err != nil {
@@ -365,7 +357,7 @@ func (s *DiscoveryServer) handleRds(con *Connection, discReq *discovery.Discover
 	if !s.shouldRespond(con, rdsReject, discReq) {
 		return nil
 	}
-	con.node.Active[v3.RouteType].ResourceNames = discReq.ResourceNames
+	con.proxy.Active[v3.RouteType].ResourceNames = discReq.ResourceNames
 	adsLog.Debugf("ADS:RDS: REQ %s routes:%d", con.ConID, len(con.Routes()))
 	err := s.pushRoute(con, s.globalPushContext(), versionInfo())
 	if err != nil {
@@ -385,34 +377,34 @@ func (s *DiscoveryServer) shouldRespond(con *Connection, rejectMetric monitoring
 	if request.ErrorDetail != nil {
 		errCode := codes.Code(request.ErrorDetail.Code)
 		adsLog.Warnf("ADS:%s: ACK ERROR %s %s:%s", stype, con.ConID, errCode.String(), request.ErrorDetail.GetMessage())
-		incrementXDSRejects(rejectMetric, con.node.ID, errCode.String())
+		incrementXDSRejects(rejectMetric, con.proxy.ID, errCode.String())
 		if s.InternalGen != nil {
-			s.InternalGen.OnNack(con.node, request)
+			s.InternalGen.OnNack(con.proxy, request)
 		}
 		return false
 	}
 
 	// This is first request - initialize typeUrl watches.
 	if request.ResponseNonce == "" {
-		con.mu.Lock()
-		con.node.Active[request.TypeUrl] = &model.WatchedResource{TypeUrl: request.TypeUrl}
-		con.mu.Unlock()
+		con.proxy.Lock()
+		con.proxy.Active[request.TypeUrl] = &model.WatchedResource{TypeUrl: request.TypeUrl}
+		con.proxy.Unlock()
 		return true
 	}
 
-	con.mu.RLock()
-	previousInfo := con.node.Active[request.TypeUrl]
-	con.mu.RUnlock()
+	con.proxy.RLock()
+	previousInfo := con.proxy.Active[request.TypeUrl]
+	con.proxy.RUnlock()
 
-	// If this is a case of Envoy reconnecting Istiod i.e. Istiod does not have
+	// This is a case of Envoy reconnecting Istiod i.e. Istiod does not have
 	// information about this typeUrl, but Envoy sends response nonce - either
 	// because Istiod is restarted or Envoy disconnects and reconnects.
 	// We should always respond with the current resource names.
 	if previousInfo == nil {
 		adsLog.Debugf("ADS:%s: RECONNECT %s %s %s", stype, con.ConID, request.VersionInfo, request.ResponseNonce)
-		con.mu.Lock()
-		con.node.Active[request.TypeUrl] = &model.WatchedResource{TypeUrl: request.TypeUrl, ResourceNames: request.ResourceNames}
-		con.mu.Unlock()
+		con.proxy.Lock()
+		con.proxy.Active[request.TypeUrl] = &model.WatchedResource{TypeUrl: request.TypeUrl, ResourceNames: request.ResourceNames}
+		con.proxy.Unlock()
 		return true
 	}
 
@@ -427,11 +419,11 @@ func (s *DiscoveryServer) shouldRespond(con *Connection, rejectMetric monitoring
 
 	// If it comes here, that means nonce match. This an ACK. We should record
 	// the ack details and respond if there is a change in resource names.
-	con.mu.Lock()
-	previousResources := con.node.Active[request.TypeUrl].ResourceNames
-	con.node.Active[request.TypeUrl].VersionAcked = request.VersionInfo
-	con.node.Active[request.TypeUrl].NonceAcked = request.ResponseNonce
-	con.mu.Unlock()
+	con.proxy.Lock()
+	previousResources := con.proxy.Active[request.TypeUrl].ResourceNames
+	con.proxy.Active[request.TypeUrl].VersionAcked = request.VersionInfo
+	con.proxy.Active[request.TypeUrl].NonceAcked = request.ResponseNonce
+	con.proxy.Unlock()
 
 	// Envoy can send two DiscoveryRequests with same version and nonce
 	// when it detects a new resource. We should respond if they change.
@@ -481,9 +473,9 @@ func (s *DiscoveryServer) initConnection(node *core.Node, con *Connection) error
 	}
 
 	// First request so initialize connection id and start tracking it.
-	con.node = proxy
+	con.proxy = proxy
 	con.ConID = connectionID(node.Id)
-	con.xdsNode = node
+	con.node = node
 
 	s.addCon(con.ConID, con)
 
@@ -491,6 +483,11 @@ func (s *DiscoveryServer) initConnection(node *core.Node, con *Connection) error
 		s.InternalGen.OnConnect(con)
 	}
 	return nil
+}
+
+func connectionID(node string) string {
+	id := atomic.AddInt64(&connectionNumber, 1)
+	return node + "-" + strconv.FormatInt(id, 10)
 }
 
 // initProxy initializes the Proxy from node.
@@ -511,7 +508,8 @@ func (s *DiscoveryServer) initProxy(node *core.Node) (*model.Proxy, error) {
 	}
 
 	// Get the locality from the proxy's service instances.
-	// We expect all instances to have the same IP and therefore the same locality. So its enough to look at the first instance
+	// We expect all instances to have the same IP and therefore the same locality.
+	// So its enough to look at the first instance.
 	if len(proxy.ServiceInstances) > 0 {
 		proxy.Locality = util.ConvertLocality(proxy.ServiceInstances[0].Endpoint.Locality.Label)
 	}
@@ -583,7 +581,7 @@ func (s *DiscoveryServer) DeltaAggregatedResources(stream discovery.AggregatedDi
 func (s *DiscoveryServer) pushConnection(con *Connection, pushEv *Event) error {
 	// TODO: update the service deps based on NetworkScope
 	if !pushEv.full {
-		if !ProxyNeedsPush(con.node, pushEv) {
+		if !ProxyNeedsPush(con.proxy, pushEv) {
 			adsLog.Debugf("Skipping EDS push to %v, no updates required", con.ConID)
 			return nil
 		}
@@ -599,13 +597,13 @@ func (s *DiscoveryServer) pushConnection(con *Connection, pushEv *Event) error {
 	}
 
 	// Update Proxy with current information.
-	if err := s.updateProxy(con.node, pushEv.push); err != nil {
+	if err := s.updateProxy(con.proxy, pushEv.push); err != nil {
 		return nil
 	}
 
 	// This depends on SidecarScope updates, so it should be called after SetSidecarScope.
-	if !ProxyNeedsPush(con.node, pushEv) {
-		if con.node.XdsResourceGenerator != nil {
+	if !ProxyNeedsPush(con.proxy, pushEv) {
+		if con.proxy.XdsResourceGenerator != nil {
 			// to verify if logic works on generator
 			adsLog.Infof("Skipping generator push to %v, no updates required", con.ConID)
 		} else {
@@ -631,8 +629,8 @@ func (s *DiscoveryServer) pushConnection(con *Connection, pushEv *Event) error {
 	// 'LDSWatch', etc.
 	// Each Generator is responsible for determining if the push event requires a push -
 	// returning nil if the push is not needed.
-	if con.node.XdsResourceGenerator != nil {
-		for _, w := range con.node.Active {
+	if con.proxy.XdsResourceGenerator != nil {
+		for _, w := range con.proxy.Active {
 			err := s.pushGeneratorV2(con, pushEv.push, currentVersion, w, pushEv.configsUpdated)
 			if err != nil {
 				return err
@@ -640,7 +638,7 @@ func (s *DiscoveryServer) pushConnection(con *Connection, pushEv *Event) error {
 		}
 	}
 
-	pushTypes := PushTypeFor(con.node, pushEv)
+	pushTypes := PushTypeFor(con.proxy, pushEv)
 
 	if con.Watching(v3.ClusterType) && pushTypes[CDS] {
 		err := s.pushCds(con, pushEv.push, currentVersion)
@@ -690,7 +688,7 @@ func (s *DiscoveryServer) ProxyUpdate(clusterID, ip string) {
 
 	s.adsClientsMutex.RLock()
 	for _, v := range s.adsClients {
-		if v.node.Metadata.ClusterID == clusterID && v.node.IPAddresses[0] == ip {
+		if v.proxy.Metadata.ClusterID == clusterID && v.proxy.IPAddresses[0] == ip {
 			connection = v
 			break
 		}
@@ -753,12 +751,14 @@ func (s *DiscoveryServer) startPush(req *model.PushRequest) {
 	// Push config changes, iterating over connected envoys. This cover ADS and EDS(0.7), both share
 	// the same connection table
 	s.adsClientsMutex.RLock()
+	clients := s.adsClients
+	s.adsClientsMutex.RUnlock()
+
 	// Create a temp map to avoid locking the add/remove
 	pending := []*Connection{}
-	for _, v := range s.adsClients {
+	for _, v := range clients {
 		pending = append(pending, v)
 	}
-	s.adsClientsMutex.RUnlock()
 
 	if adsLog.DebugEnabled() {
 		currentlyPending := s.pushQueue.Pending()
@@ -776,7 +776,7 @@ func (s *DiscoveryServer) addCon(conID string, con *Connection) {
 	s.adsClientsMutex.Lock()
 	defer s.adsClientsMutex.Unlock()
 	s.adsClients[conID] = con
-	recordXDSClients(con.node.Metadata.IstioVersion, 1)
+	recordXDSClients(con.proxy.Metadata.IstioVersion, 1)
 }
 
 func (s *DiscoveryServer) removeCon(conID string) {
@@ -788,7 +788,7 @@ func (s *DiscoveryServer) removeCon(conID string) {
 		totalXDSInternalErrors.Increment()
 	} else {
 		delete(s.adsClients, conID)
-		recordXDSClients(con.node.Metadata.IstioVersion, -1)
+		recordXDSClients(con.proxy.Metadata.IstioVersion, -1)
 	}
 	if s.StatusReporter != nil {
 		go s.StatusReporter.RegisterDisconnect(conID, AllEventTypes)
@@ -802,15 +802,15 @@ func (conn *Connection) send(res *discovery.DiscoveryResponse) error {
 	t := time.NewTimer(SendTimeout)
 	go func() {
 		err := conn.stream.Send(res)
-		conn.mu.Lock()
+		conn.proxy.Lock()
 		if res.Nonce != "" {
-			if conn.node.Active[res.TypeUrl] == nil {
-				conn.node.Active[res.TypeUrl] = &model.WatchedResource{TypeUrl: res.TypeUrl}
+			if conn.proxy.Active[res.TypeUrl] == nil {
+				conn.proxy.Active[res.TypeUrl] = &model.WatchedResource{TypeUrl: res.TypeUrl}
 			}
-			conn.node.Active[res.TypeUrl].NonceSent = res.Nonce
-			conn.node.Active[res.TypeUrl].VersionSent = res.VersionInfo
+			conn.proxy.Active[res.TypeUrl].NonceSent = res.Nonce
+			conn.proxy.Active[res.TypeUrl].VersionSent = res.VersionInfo
 		}
-		conn.mu.Unlock()
+		conn.proxy.Unlock()
 		done <- err
 	}()
 	select {
@@ -825,46 +825,49 @@ func (conn *Connection) send(res *discovery.DiscoveryResponse) error {
 	}
 }
 
-func (conn *Connection) NonceAcked(stype string) string {
-	conn.mu.RLock()
-	defer conn.mu.RUnlock()
-	if conn.node.Active != nil && conn.node.Active[stype] != nil {
-		return conn.node.Active[stype].NonceAcked
+// nolint
+func (conn *Connection) NonceAcked(typeUrl string) string {
+	conn.proxy.RLock()
+	defer conn.proxy.RUnlock()
+	if conn.proxy.Active != nil && conn.proxy.Active[typeUrl] != nil {
+		return conn.proxy.Active[typeUrl].NonceAcked
 	}
 	return ""
 }
 
-func (conn *Connection) NonceSent(stype string) string {
-	conn.mu.RLock()
-	defer conn.mu.RUnlock()
-	if conn.node.Active != nil && conn.node.Active[stype] != nil {
-		return conn.node.Active[stype].NonceSent
+// nolint
+func (conn *Connection) NonceSent(typeUrl string) string {
+	conn.proxy.RLock()
+	defer conn.proxy.RUnlock()
+	if conn.proxy.Active != nil && conn.proxy.Active[typeUrl] != nil {
+		return conn.proxy.Active[typeUrl].NonceSent
 	}
 	return ""
 }
 
 func (conn *Connection) Clusters() []string {
-	conn.mu.RLock()
-	defer conn.mu.RUnlock()
-	if conn.node.Active != nil && conn.node.Active[v3.EndpointType] != nil {
-		return conn.node.Active[v3.EndpointType].ResourceNames
+	conn.proxy.RLock()
+	defer conn.proxy.RUnlock()
+	if conn.proxy.Active != nil && conn.proxy.Active[v3.EndpointType] != nil {
+		return conn.proxy.Active[v3.EndpointType].ResourceNames
 	}
 	return []string{}
 }
 
 func (conn *Connection) Routes() []string {
-	conn.mu.RLock()
-	defer conn.mu.RUnlock()
-	if conn.node.Active != nil && conn.node.Active[v3.RouteType] != nil {
-		return conn.node.Active[v3.RouteType].ResourceNames
+	conn.proxy.RLock()
+	defer conn.proxy.RUnlock()
+	if conn.proxy.Active != nil && conn.proxy.Active[v3.RouteType] != nil {
+		return conn.proxy.Active[v3.RouteType].ResourceNames
 	}
 	return []string{}
 }
 
-func (conn *Connection) Watching(stype string) bool {
-	conn.mu.RLock()
-	defer conn.mu.RUnlock()
-	if conn.node.Active != nil && conn.node.Active[stype] != nil {
+// nolint
+func (conn *Connection) Watching(typeUrl string) bool {
+	conn.proxy.RLock()
+	defer conn.proxy.RUnlock()
+	if conn.proxy.Active != nil && conn.proxy.Active[typeUrl] != nil {
 		return true
 	}
 	return false

--- a/pilot/pkg/xds/cds.go
+++ b/pilot/pkg/xds/cds.go
@@ -49,7 +49,7 @@ func cdsDiscoveryResponse(response []*cluster.Cluster, noncePrefix string) *disc
 func (s *DiscoveryServer) pushCds(con *Connection, push *model.PushContext, version string) error {
 	// TODO: Modify interface to take services, and config instead of making library query registry
 	pushStart := time.Now()
-	rawClusters := s.ConfigGenerator.BuildClusters(con.node, push)
+	rawClusters := s.ConfigGenerator.BuildClusters(con.proxy, push)
 
 	if s.DebugConfigs {
 		con.XdsClusters = rawClusters
@@ -65,6 +65,6 @@ func (s *DiscoveryServer) pushCds(con *Connection, push *model.PushContext, vers
 
 	// The response can't be easily read due to 'any' marshaling.
 	adsLog.Infof("CDS: PUSH for node:%s clusters:%d services:%d version:%s",
-		con.node.ID, len(rawClusters), len(push.Services(nil)), version)
+		con.proxy.ID, len(rawClusters), len(push.Services(nil)), version)
 	return nil
 }

--- a/pilot/pkg/xds/discovery_test.go
+++ b/pilot/pkg/xds/discovery_test.go
@@ -333,7 +333,7 @@ func TestShouldRespond(t *testing.T) {
 		{
 			name: "initial request",
 			connection: &Connection{
-				node: &model.Proxy{
+				proxy: &model.Proxy{
 					Active: map[string]*model.WatchedResource{},
 				},
 			},
@@ -345,7 +345,7 @@ func TestShouldRespond(t *testing.T) {
 		{
 			name: "ack",
 			connection: &Connection{
-				node: &model.Proxy{
+				proxy: &model.Proxy{
 					Active: map[string]*model.WatchedResource{
 						v3.ClusterType: {
 							VersionSent: "v1",
@@ -364,7 +364,7 @@ func TestShouldRespond(t *testing.T) {
 		{
 			name: "nack",
 			connection: &Connection{
-				node: &model.Proxy{
+				proxy: &model.Proxy{
 					Active: map[string]*model.WatchedResource{
 						v3.ClusterType: {
 							VersionSent: "v1",
@@ -383,7 +383,7 @@ func TestShouldRespond(t *testing.T) {
 		{
 			name: "reconnect",
 			connection: &Connection{
-				node: &model.Proxy{
+				proxy: &model.Proxy{
 					Active: map[string]*model.WatchedResource{},
 				},
 			},
@@ -397,7 +397,7 @@ func TestShouldRespond(t *testing.T) {
 		{
 			name: "resources change",
 			connection: &Connection{
-				node: &model.Proxy{
+				proxy: &model.Proxy{
 					Active: map[string]*model.WatchedResource{
 						v3.EndpointType: {
 							VersionSent:   "v1",
@@ -418,7 +418,7 @@ func TestShouldRespond(t *testing.T) {
 		{
 			name: "ack with same resources",
 			connection: &Connection{
-				node: &model.Proxy{
+				proxy: &model.Proxy{
 					Active: map[string]*model.WatchedResource{
 						v3.EndpointType: {
 							VersionSent:   "v1",
@@ -447,8 +447,8 @@ func TestShouldRespond(t *testing.T) {
 				t.Fatalf("Unexpected value for response, expected %v, got %v", tt.response, response)
 			}
 			if tt.name != "reconnect" && tt.response {
-				if tt.connection.node.Active[tt.request.TypeUrl].VersionAcked != tt.request.VersionInfo &&
-					tt.connection.node.Active[tt.request.TypeUrl].NonceAcked != tt.request.ResponseNonce {
+				if tt.connection.proxy.Active[tt.request.TypeUrl].VersionAcked != tt.request.VersionInfo &&
+					tt.connection.proxy.Active[tt.request.TypeUrl].NonceAcked != tt.request.ResponseNonce {
 					t.Fatalf("Version & Nonce not updated properly")
 				}
 			}

--- a/pilot/pkg/xds/ep_filters_test.go
+++ b/pilot/pkg/xds/ep_filters_test.go
@@ -159,7 +159,7 @@ func TestEndpointsByNetworkFilter(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			push := model.NewPushContext()
 			_ = push.InitContext(tt.env, nil, nil)
-			filtered := EndpointsByNetworkFilter(push, tt.conn.node.Metadata.Network, tt.endpoints)
+			filtered := EndpointsByNetworkFilter(push, tt.conn.proxy.Metadata.Network, tt.endpoints)
 			if len(filtered) != len(tt.want) {
 				t.Errorf("Unexpected number of filtered endpoints: got %v, want %v", len(filtered), len(tt.want))
 				return
@@ -337,7 +337,7 @@ func TestEndpointsByNetworkFilter_RegistryServiceName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			push := model.NewPushContext()
 			_ = push.InitContext(tt.env, nil, nil)
-			filtered := EndpointsByNetworkFilter(push, tt.conn.node.Metadata.Network, tt.endpoints)
+			filtered := EndpointsByNetworkFilter(push, tt.conn.proxy.Metadata.Network, tt.endpoints)
 			if len(filtered) != len(tt.want) {
 				t.Errorf("Unexpected number of filtered endpoints: got %v, want %v", len(filtered), len(tt.want))
 				return
@@ -512,7 +512,7 @@ func TestEndpointsByNetworkFilter_SkipLBWithHostname(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			push := model.NewPushContext()
 			_ = push.InitContext(tt.env, nil, nil)
-			filtered := EndpointsByNetworkFilter(push, tt.conn.node.Metadata.Network, tt.endpoints)
+			filtered := EndpointsByNetworkFilter(push, tt.conn.proxy.Metadata.Network, tt.endpoints)
 			if len(filtered) != len(tt.want) {
 				t.Errorf("Unexpected number of filtered endpoints: got %v, want %v", len(filtered), len(tt.want))
 				return
@@ -562,7 +562,7 @@ func TestEndpointsByNetworkFilter_SkipLBWithHostname(t *testing.T) {
 
 func xdsConnection(network string) *Connection {
 	return &Connection{
-		node: &model.Proxy{
+		proxy: &model.Proxy{
 			Metadata: &model.NodeMetadata{Network: network},
 		},
 	}

--- a/pilot/pkg/xds/lds.go
+++ b/pilot/pkg/xds/lds.go
@@ -28,7 +28,7 @@ import (
 func (s *DiscoveryServer) pushLds(con *Connection, push *model.PushContext, version string) error {
 	// TODO: Modify interface to take services, and config instead of making library query registry
 	pushStart := time.Now()
-	rawListeners := s.ConfigGenerator.BuildListeners(con.node, push)
+	rawListeners := s.ConfigGenerator.BuildListeners(con.proxy, push)
 
 	if s.DebugConfigs {
 		con.XdsListeners = rawListeners
@@ -42,7 +42,7 @@ func (s *DiscoveryServer) pushLds(con *Connection, push *model.PushContext, vers
 	}
 	ldsPushes.Increment()
 
-	adsLog.Infof("LDS: PUSH for node:%s listeners:%d", con.node.ID, len(rawListeners))
+	adsLog.Infof("LDS: PUSH for node:%s listeners:%d", con.proxy.ID, len(rawListeners))
 	return nil
 }
 

--- a/pilot/pkg/xds/rds.go
+++ b/pilot/pkg/xds/rds.go
@@ -28,13 +28,13 @@ import (
 
 func (s *DiscoveryServer) pushRoute(con *Connection, push *model.PushContext, version string) error {
 	pushStart := time.Now()
-	rawRoutes := s.ConfigGenerator.BuildHTTPRoutes(con.node, push, con.Routes())
+	rawRoutes := s.ConfigGenerator.BuildHTTPRoutes(con.proxy, push, con.Routes())
 	if s.DebugConfigs {
 		for _, r := range rawRoutes {
 			con.XdsRoutes[r.Name] = r
 			if adsLog.DebugEnabled() {
 				resp, _ := protomarshal.ToJSONWithIndent(r, " ")
-				adsLog.Debugf("RDS: Adding route:%s for node:%v", resp, con.node.ID)
+				adsLog.Debugf("RDS: Adding route:%s for node:%v", resp, con.proxy.ID)
 			}
 		}
 	}
@@ -48,7 +48,7 @@ func (s *DiscoveryServer) pushRoute(con *Connection, push *model.PushContext, ve
 	}
 	rdsPushes.Increment()
 
-	adsLog.Infof("RDS: PUSH for node:%s routes:%d", con.node.ID, len(rawRoutes))
+	adsLog.Infof("RDS: PUSH for node:%s routes:%d", con.proxy.ID, len(rawRoutes))
 	return nil
 }
 


### PR DESCRIPTION
This PR
- Moves the `mutex` to `Proxy` from `Connection` where it is only used for protecting proxy changes
- Rename `node` -> `proxy` in `Connection`
- Minor comment fixes

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
