### PR TITLE
change monitoring address default

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -723,7 +723,7 @@ spec:
           image: "gcr.io/istio-testing/pilot:latest"
           args:
           - "discovery"
-          - --monitoringAddr=:15014
+          - --monitoringAddr=127.0.0.1:15014
           - --log_output_level=default:info
           - --domain
           - cluster.local

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
 {{- end }}
           args:
           - "discovery"
-          - --monitoringAddr=:15014
+          - --monitoringAddr=127.0.0.1:15014
 {{- if .Values.global.logging.level }}
           - --log_output_level={{ .Values.global.logging.level }}
 {{- end}}

--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -161,7 +161,7 @@ func init() {
 		"Discovery service gRPC address")
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.ServerOptions.SecureGRPCAddr, "secureGRPCAddr", ":15012",
 		"Discovery service secured gRPC address")
-	discoveryCmd.PersistentFlags().StringVar(&serverArgs.ServerOptions.MonitoringAddr, "monitoringAddr", ":15014",
+	discoveryCmd.PersistentFlags().StringVar(&serverArgs.ServerOptions.MonitoringAddr, "monitoringAddr", "127.0.0.1:15014",
 		"HTTP address to use for pilot's self-monitoring information")
 	discoveryCmd.PersistentFlags().BoolVar(&serverArgs.ServerOptions.EnableProfiling, "profile", true,
 		"Enable profiling via web interface host:port/debug/pprof")

--- a/releasenotes/notes/monitoring-addr.yaml
+++ b/releasenotes/notes/monitoring-addr.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+
+releaseNotes: |
+  *Updated* the the default monitoring address to "127.0.0.1:15014" so that it is accessible only local host for security reasons.
+  If you need access from any where please configure using "--monitoringAddr" flag on Istiod container.

--- a/releasenotes/notes/monitoring-addr.yaml
+++ b/releasenotes/notes/monitoring-addr.yaml
@@ -4,4 +4,4 @@ area: networking
 
 releaseNotes: |
   *Updated* the the default monitoring address to "127.0.0.1:15014" so that it is accessible only local host for security reasons.
-  If you need access from any where please configure using "--monitoringAddr" flag on Istiod container.
+  If you need access from any where please configure using "--monitoringAddr" flag on Istiod deployment.


### PR DESCRIPTION
Changes monitoring address to be accessible only on local host by default.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

