### PR TITLE
dont test reloading meshNetworks in xds_test

### DIFF
--- a/pilot/pkg/xds/xds_test.go
+++ b/pilot/pkg/xds/xds_test.go
@@ -368,10 +368,11 @@ func TestMeshNetworking(t *testing.T) {
 				&corev1.Node{Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeExternalIP, Address: "2.2.2.2"}}}},
 				ingr)
 			k8sObjects = append(k8sObjects, fakePodService(fakeServiceOpts{name: "kubeapp", ns: "pod", ip: "10.10.10.20"})...)
-			nw := mesh.NewFixedNetworksWatcher(nil)
-			s := NewFakeDiscoveryServer(t, FakeOptions{
-				KubernetesObjects: k8sObjects,
-				ConfigString: `
+			for name, networkConfig := range meshNetworkConfigs {
+				t.Run(name, func(t *testing.T) {
+					s := NewFakeDiscoveryServer(t, FakeOptions{
+						KubernetesObjects: k8sObjects,
+						ConfigString: `
 apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
@@ -411,13 +412,8 @@ spec:
       app: httpbin
     network: vm
 `,
-				NetworksWatcher: nw,
-			})
-			for name, networkConfig := range meshNetworkConfigs {
-				s, nw := s, nw
-				t.Run(name, func(t *testing.T) {
-					nw.SetNetworks(networkConfig)
-
+						NetworksWatcher: mesh.NewFixedNetworksWatcher(networkConfig),
+					})
 					se := s.SetupProxy(&model.Proxy{
 						ID: "se-pod.pod",
 						Metadata: &model.NodeMetadata{


### PR DESCRIPTION
Testing xds using mesh networks handlers is still somewhat flaky. This reverts to setting up a new discovery server per meshNetworks config

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
