### PR TITLE
Use common filepath for root certificate

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -293,8 +293,7 @@ var (
 				secOpts.CredFetcher = credFetcher
 			}
 
-			sa := istio_agent.NewAgent(&proxyConfig,
-				&istio_agent.AgentConfig{}, secOpts)
+			sa := istio_agent.NewAgent(&proxyConfig, &istio_agent.AgentConfig{}, secOpts)
 
 			var pilotSAN []string
 			if proxyConfig.ControlPlaneAuthPolicy == meshconfig.AuthenticationPolicy_MUTUAL_TLS {
@@ -307,7 +306,7 @@ var (
 			// Start in process SDS.
 			_, err = sa.Start(role.Type == model.SidecarProxy, podNamespaceVar.Get())
 			if err != nil {
-				log.Fatala("Failed to start in-process SDS", err)
+				log.Fatalf("Failed to start in-process SDS: %v", err)
 			}
 
 			// If we are using a custom template file (for control plane proxy, for example), configure this.
@@ -391,7 +390,6 @@ var (
 				ControlPlaneAuth:    proxyConfig.ControlPlaneAuthPolicy == meshconfig.AuthenticationPolicy_MUTUAL_TLS,
 				DisableReportCalls:  disableInternalTelemetry,
 				OutlierLogPath:      outlierLogPath,
-				PilotCertProvider:   pilotCertProvider,
 				ProvCert:            citadel.ProvCert,
 				Sidecar:             role.Type == model.SidecarProxy,
 			})

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -88,7 +88,6 @@ type Config struct {
 	ControlPlaneAuth    bool
 	DisableReportCalls  bool
 	OutlierLogPath      string
-	PilotCertProvider   string
 	ProvCert            string
 	DiscoveryHost       string
 }
@@ -116,7 +115,6 @@ func (cfg Config) toTemplateParams() (map[string]interface{}, error) {
 		option.PilotSubjectAltName(cfg.PilotSubjectAltName),
 		option.ControlPlaneAuth(cfg.ControlPlaneAuth),
 		option.DisableReportCalls(cfg.DisableReportCalls),
-		option.PilotCertProvider(cfg.PilotCertProvider),
 		option.OutlierLogPath(cfg.OutlierLogPath),
 		option.ProvCert(cfg.ProvCert),
 		option.DiscoveryHost(cfg.DiscoveryHost))

--- a/pkg/bootstrap/option/instances.go
+++ b/pkg/bootstrap/option/instances.go
@@ -216,10 +216,6 @@ func EnvoyStatsMatcherInclusionRegexp(value []string) Instance {
 	return newStringArrayOptionOrSkipIfEmpty("inclusionRegexps", value)
 }
 
-func PilotCertProvider(value string) Instance {
-	return newOption("pilot_cert_provider", value)
-}
-
 func STSPort(value int) Instance {
 	return newOption("sts_port", value)
 }

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -57,7 +57,6 @@ type ProxyConfig struct {
 	ControlPlaneAuth    bool
 	DisableReportCalls  bool
 	OutlierLogPath      string
-	PilotCertProvider   string
 	ProvCert            string
 	Sidecar             bool
 }
@@ -168,7 +167,6 @@ func (e *envoy) Run(config interface{}, epoch int, abort <-chan error) error {
 			ControlPlaneAuth:    e.ControlPlaneAuth,
 			DisableReportCalls:  e.DisableReportCalls,
 			OutlierLogPath:      e.OutlierLogPath,
-			PilotCertProvider:   e.PilotCertProvider,
 			ProvCert:            e.ProvCert,
 			DiscoveryHost:       discHost,
 		}).CreateFileForEpoch(epoch)

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -38,6 +38,10 @@ const (
 	// Credential fetcher type
 	GCE  = "GoogleComputeEngine"
 	Mock = "Mock" // testing only
+
+	KubernetesCertProvider = "kubernetes"
+	IstiodCertProvider     = "istiod"
+	CustomCertProvider     = "custom"
 )
 
 // Options provides all of the configuration parameters for secret discovery service

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -258,9 +258,7 @@
                 "trusted_ca": {
                   {{- if .provisioned_cert }}
                   "filename": "{{(printf "%s%s" .provisioned_cert "/root-cert.pem") }}"
-                  {{- else if eq .pilot_cert_provider "kubernetes" }}
-                  "filename": "./var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-                  {{- else if eq .pilot_cert_provider "istiod" }}
+                  {{- else }}
                   "filename": "./var/run/secrets/istio/root-cert.pem"
                   {{- end }}
                 },


### PR DESCRIPTION
Rather than tons of conditional logic throughout the code, use a single
wellknown path for root cert. For custom setups, we will symlink the
cert to that location



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.