### PR TITLE
Update example command to use non-deprecated flags

### DIFF
--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -89,8 +89,8 @@ func InstallCmd(logOpts *log.Options) *cobra.Command {
 		Example: `  # Apply a default Istio installation
   istioctl install
 
-  # Enable grafana dashboard
-  istioctl install --set values.grafana.enabled=true
+  # Enable Envoy's gRPC Access Log Service
+  istioctl install --set meshConfig.enableEnvoyAccessLogService=true
 
   # Generate the demo profile and don't wait for confirmation
   istioctl install --set profile=demo --skip-confirmation

--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -89,8 +89,8 @@ func InstallCmd(logOpts *log.Options) *cobra.Command {
 		Example: `  # Apply a default Istio installation
   istioctl install
 
-  # Enable Envoy's gRPC Access Log Service
-  istioctl install --set meshConfig.enableEnvoyAccessLogService=true
+  # Enable Tracing
+  istioctl install --set meshConfig.enableTracing=true
 
   # Generate the demo profile and don't wait for confirmation
   istioctl install --set profile=demo --skip-confirmation

--- a/operator/cmd/mesh/manifest-generate.go
+++ b/operator/cmd/mesh/manifest-generate.go
@@ -67,8 +67,8 @@ func manifestGenerateCmd(rootArgs *rootArgs, mgArgs *manifestGenerateArgs, logOp
 		Example: `  # Generate a default Istio installation
   istioctl manifest generate
 
-  # Enable grafana dashboard
-  istioctl manifest generate --set values.grafana.enabled=true
+  # Enable Envoy's gRPC Access Log Service
+  istioctl install --set meshConfig.enableEnvoyAccessLogService=true
 
   # Generate the demo profile
   istioctl manifest generate --set profile=demo

--- a/operator/cmd/mesh/manifest-generate.go
+++ b/operator/cmd/mesh/manifest-generate.go
@@ -67,8 +67,8 @@ func manifestGenerateCmd(rootArgs *rootArgs, mgArgs *manifestGenerateArgs, logOp
 		Example: `  # Generate a default Istio installation
   istioctl manifest generate
 
-  # Enable Envoy's gRPC Access Log Service
-  istioctl install --set meshConfig.enableEnvoyAccessLogService=true
+  # Enable Tracing
+  istioctl install --set meshConfig.enableTracing=true
 
   # Generate the demo profile
   istioctl manifest generate --set profile=demo

--- a/operator/cmd/mesh/root.go
+++ b/operator/cmd/mesh/root.go
@@ -29,7 +29,7 @@ const (
 	releaseURL     = `https://github.com/istio/istio/releases/download/` + baseVersion + `/istio-` + baseVersion + `-linux-amd64.tar.gz`
 	setFlagHelpStr = `Override an IstioOperator value, e.g. to choose a profile
 (--set profile=demo), enable or disable components (--set components.policy.enabled=true), or override Istio
-settings (--set values.grafana.enabled=true). See documentation for more info:
+settings (--set meshConfig.enableEnvoyAccessLogService=true). See documentation for more info:
 https://istio.io/docs/reference/config/istio.operator.v1alpha1/#IstioOperatorSpec`
 	// ManifestsFlagHelpStr is the command line description for --manifests
 	ManifestsFlagHelpStr = `Specify a path to a directory of charts and profiles

--- a/operator/cmd/mesh/root.go
+++ b/operator/cmd/mesh/root.go
@@ -29,7 +29,7 @@ const (
 	releaseURL     = `https://github.com/istio/istio/releases/download/` + baseVersion + `/istio-` + baseVersion + `-linux-amd64.tar.gz`
 	setFlagHelpStr = `Override an IstioOperator value, e.g. to choose a profile
 (--set profile=demo), enable or disable components (--set components.policy.enabled=true), or override Istio
-settings (--set meshConfig.enableEnvoyAccessLogService=true). See documentation for more info:
+settings (--set meshConfig.enableTracing=true). See documentation for more info:
 https://istio.io/docs/reference/config/istio.operator.v1alpha1/#IstioOperatorSpec`
 	// ManifestsFlagHelpStr is the command line description for --manifests
 	ManifestsFlagHelpStr = `Specify a path to a directory of charts and profiles


### PR DESCRIPTION
Based on https://github.com/istio/istio/pull/24567

`Grafana` is now available as an addon and can be set using the `samples/addons/grafana.yaml` deployments.
 
