### PR TITLE
Make release notes arrays

### DIFF
--- a/releasenotes/README.md
+++ b/releasenotes/README.md
@@ -20,7 +20,8 @@ area: traffic-management
 issue:
   - https://github.com/istio/istio/issues/23622
   - 23624
-releaseNotes: |
+releaseNotes: 
+- |
 *Fixed* an issue preventing the operator from recreating watched resources if they are deleted
 
 upgradeNotes:
@@ -28,7 +29,8 @@ upgradeNotes:
     content: |
       If you are using the 15020 port to check the health of your Istio ingress gateway with your Kubernetes network load balancer, change the port from 15020 to 15021.
 
-securityNotes: |
+securityNotes: 
+- |
 __[CVE-2020-15104](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15104)__:
 When validating TLS certificates, Envoy incorrectly allows a wildcard DNS Subject Alternative Name to apply to multiple subdomains. For example, with a SAN of `*.example.com`, Envoy incorrectly allows `nested.subdomain.example.com`, when it should only allow `subdomain.example.com`.
     - CVSS Score: 6.6 [AV:N/AC:H/PR:H/UI:N/S:C/C:H/I:L/A:N/E:F/RL:O/RC:C](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:H/PR:H/UI:N/S:C/C:H/I:L/A:N/E:F/RL:O/RC:C&version=3.1)

--- a/releasenotes/notes/24471.yaml
+++ b/releasenotes/notes/24471.yaml
@@ -6,4 +6,4 @@ issue:
 
 releaseNotes:
 - |
-  **Added** 'istioctl analyze' now warns if deprecated mixer resources are present
+  **Added** `istioctl analyze` now warns if deprecated mixer resources are present

--- a/releasenotes/notes/24471.yaml
+++ b/releasenotes/notes/24471.yaml
@@ -4,5 +4,6 @@ area: istioctl
 issue:
   - 24471
 
-releaseNotes: |
+releaseNotes:
+- |
   **Added** 'istioctl analyze' now warns if deprecated mixer resources are present

--- a/releasenotes/notes/24554.yaml
+++ b/releasenotes/notes/24554.yaml
@@ -6,5 +6,6 @@ issue:
 
 # releaseNotes is a markdown listing of any user facing changes. This will appear in the
 # release notes.
-releaseNotes: |
+releaseNotes:
+- |
   **Added** Enable the workload cert rotate automatically in VM

--- a/releasenotes/notes/24737.yaml
+++ b/releasenotes/notes/24737.yaml
@@ -6,7 +6,8 @@ area: traffic-management
 issue:
   - 11130
 
-releaseNotes: |
+releaseNotes:
+- |
   **Added** config option `values.global.proxy.holdApplicationUntilProxyStarts`,
   which causes the sidecar injector to inject the sidecar at the start of the
   pod's container list and configures it to block the start of all other

--- a/releasenotes/notes/25280.yaml
+++ b/releasenotes/notes/25280.yaml
@@ -6,5 +6,6 @@ issue:
 
 # releaseNotes is a markdown listing of any user facing changes. This will appear in the
 # release notes.
-releaseNotes: |
+releaseNotes:
+- |
   **Added** configuration file handling for istioctl defaults. Also added environment variable `ISTIOCONFIG` for selecting that file (default $HOME/.istioctl/config.yaml). Also added 'istioctl experimental config list' subcommand to show configured flag defaults.

--- a/releasenotes/notes/25302.yaml
+++ b/releasenotes/notes/25302.yaml
@@ -8,6 +8,7 @@ issue:
 
 # releaseNotes is a markdown listing of any user facing changes. This will appear in the
 # release notes.
-releaseNotes: |
+releaseNotes:
+- |
   *Improved* `istioctl analyze` to find the exact line number with configuration errors when analyzing yaml files.
   Before, it would return the first line of the resource with the error.

--- a/releasenotes/notes/25302.yaml
+++ b/releasenotes/notes/25302.yaml
@@ -10,5 +10,5 @@ issue:
 # release notes.
 releaseNotes:
 - |
-  *Improved* `istioctl analyze` to find the exact line number with configuration errors when analyzing yaml files.
+  **Improved** `istioctl analyze` to find the exact line number with configuration errors when analyzing yaml files.
   Before, it would return the first line of the resource with the error.

--- a/releasenotes/notes/25519.yaml
+++ b/releasenotes/notes/25519.yaml
@@ -3,6 +3,7 @@ kind: bug-fix
 area: telemetry
 issue:
 - 25154
-releaseNotes: |
+releaseNotes:
+- |
   **Removed** the `pilot_xds_eds_instances` and `pilot_xds_eds_all_locality_endpoints` Istiod metrics, which were not
   accurate.

--- a/releasenotes/notes/25669.yaml
+++ b/releasenotes/notes/25669.yaml
@@ -2,19 +2,20 @@ apiVersion: release-notes/v2
 kind: feature
 area: telemetry
 issue:
-- 25333
-- 24300
-releaseNotes: |
-  **Removed** all Mixer-related features and functionality. This is a scheduled
-  removal of a deprecated Istio services and deployments, as well as
-  Mixer-focused CRDs and component and related functionality.
+  - 25333
+  - 24300
+releaseNotes:
+  - |
+    **Removed** all Mixer-related features and functionality. This is a scheduled
+    removal of a deprecated Istio services and deployments, as well as
+    Mixer-focused CRDs and component and related functionality.
 
 upgradeNotes:
-  title: Mixer is no longer supported in Istio.
-  content: |
-    If you are using the `istio-policy` or `istio-telemetry` services, or any
-    related Mixer configuration, you will not be able to upgrade without taking
-    action to either (a) convert your existing configuration and code to the new
-    extension model for Istio or (b) using the gRPC shim developed to bridge
-    transition to the new model. For more details, please refer the docs on
-    istio.io.
+  - title: Mixer is no longer supported in Istio.
+    content: |
+      If you are using the `istio-policy` or `istio-telemetry` services, or any
+      related Mixer configuration, you will not be able to upgrade without taking
+      action to either (a) convert your existing configuration and code to the new
+      extension model for Istio or (b) using the gRPC shim developed to bridge
+      transition to the new model. For more details, please refer the docs on
+      istio.io.

--- a/releasenotes/notes/25678.yaml
+++ b/releasenotes/notes/25678.yaml
@@ -3,5 +3,6 @@ kind: bug-fix
 area: traffic-management
 issue:
 - 25678
-releaseNotes: |
+releaseNotes:
+- |
   **Fixed** remove endpoints when the new labels in `WorkloadEntry` do not match the `workloadSelector` in `ServiceEntry`.

--- a/releasenotes/notes/25737.yaml
+++ b/releasenotes/notes/25737.yaml
@@ -3,5 +3,6 @@ kind: feature
 area: istioctl
 issue:
   - 25737
-releaseNotes: |
+releaseNotes:
+- |
   **Removed** `istioctl manifest apply`. The simpler `install` command replaces manifest apply.

--- a/releasenotes/notes/25746.yaml
+++ b/releasenotes/notes/25746.yaml
@@ -3,5 +3,6 @@ kind: feature
 area: traffic-management
 issue:
 - 25744
-releaseNotes: |
+releaseNotes:
+- |
   **Added** support for injecting istio-cni into `k8s.v1.cni.cncf.io/networks` annotation with pre-existing value that uses JSON notation.

--- a/releasenotes/notes/25818.yaml
+++ b/releasenotes/notes/25818.yaml
@@ -24,12 +24,14 @@ area: security
 
 # releaseNotes is a markdown listing of any user facing changes. This will appear in the
 # release notes.
-releaseNotes: |
-  **Fixed** an issue preventing the use of source principal based authorization at Istio Gateway when the Server's TLS mode is ISTIO_MUTUAL.
+releaseNotes:
+  - |
+    **Fixed** an issue preventing the use of source principal based authorization at Istio Gateway when the Server's TLS mode is ISTIO_MUTUAL.
 
 # securityNotes is a markdown listing of any changes related to the security of
 # Istio.
-securityNotes: |
-  __Source principal validation at Gateway does not work even with ISTIO_MUTUAL TLS mode__:
+securityNotes:
+  - |
+    __Source principal validation at Gateway does not work even with ISTIO_MUTUAL TLS mode__:
     When the Gateway server's TLS mode is ISTIO_MUTUAL, Istio's authN filter is not installed on the appropriate filter chain. Consequently, any Istio Authorization policy with source principal based rules will not work when applied to a Gateway workload.
     - __CVSS Score__: 5.9 [AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:N](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:N&version=3.1)

--- a/releasenotes/notes/26001.yaml
+++ b/releasenotes/notes/26001.yaml
@@ -4,5 +4,6 @@ area: pilot
 issue:
   - 25339
 
-releaseNotes: |
+releaseNotes:
+- |
   **Added** sets timeout to fetch workload certs to 0 because workload certs are guaranteed to exist, making a timeout irrelevant.

--- a/releasenotes/notes/add-release-notes-generation.yaml
+++ b/releasenotes/notes/add-release-notes-generation.yaml
@@ -3,6 +3,7 @@ kind: feature
 area: documentation
 issue:
 - https://github.com/istio/istio/issues/23622
-releaseNotes: |
+releaseNotes:
+- |
   **Added** support for autogenerating release notes based off of a file present in the /releasenotes/notes directory.
 

--- a/releasenotes/notes/add-sni-host.yaml
+++ b/releasenotes/notes/add-sni-host.yaml
@@ -3,5 +3,6 @@ kind: bug-fix
 area: networking
 issue:
 - 25691
-releaseNotes: |
+releaseNotes:
+- |
   **Fixed** SNI host routing issue when user uses sniHosts match in virtual service

--- a/releasenotes/notes/addon-remove.yaml
+++ b/releasenotes/notes/addon-remove.yaml
@@ -3,5 +3,6 @@ kind: bug-fix
 area: telemetry
 issue:
 - 22762
-releaseNotes: |
+releaseNotes:
+- |
   **Deprecated** installation of telemetry addons by `istioctl`. These will be disabled by default, and in a future release removed entirely. More information on installing these addons can be found in the [Integrations](/docs/ops/integrations/) page.

--- a/releasenotes/notes/agent-metrics.yaml
+++ b/releasenotes/notes/agent-metrics.yaml
@@ -3,6 +3,8 @@ kind: feature
 area: telemetry
 issue:
 - 22825
-releaseNotes: |
+releaseNotes:
+- |
   **Added** Prometheus metrics to istio-agent.
+- |
   **Fixed** Prometheus [metrics merging](/docs/ops/integrations/prometheus/#option-1-metrics-merging) to not drop Envoy metrics during application failures.

--- a/releasenotes/notes/auto-mtls-headless.yaml
+++ b/releasenotes/notes/auto-mtls-headless.yaml
@@ -3,5 +3,6 @@ kind: bug-fix
 area: networking
 issue:
 - 24319
-releaseNotes: |
+releaseNotes:
+- |
   **Fixed** an issue where headless services without sidecars were incorrectly sent mTLS rtaffic

--- a/releasenotes/notes/consul.yaml
+++ b/releasenotes/notes/consul.yaml
@@ -1,5 +1,6 @@
 apiVersion: release-notes/v2
 kind: feature
 area: networking
-releaseNotes: |
+releaseNotes:
+- |
   **Removed** compiled in support for Consul service registry. Integration will be done using XDS in the future.

--- a/releasenotes/notes/crd-webhook-v1.yaml
+++ b/releasenotes/notes/crd-webhook-v1.yaml
@@ -4,10 +4,11 @@ area: installation
 issue:
 - 18771
 - 18838
-releaseNotes: |
+releaseNotes:
+ - |
   **Upgraded** the CRD and Webhook versions to `v1`.
 upgradeNotes:
-  title: Require Kubernetes 1.16+
-  content: Kubernetes 1.16+ is now required for installation.
+ - title: Require Kubernetes 1.16+
+   content: Kubernetes 1.16+ is now required for installation.
 
 

--- a/releasenotes/notes/delay-app-start.yaml
+++ b/releasenotes/notes/delay-app-start.yaml
@@ -3,7 +3,8 @@ kind: feature
 area: networking
 issue:
 - 24737
-releaseNotes: |
+releaseNotes:
+- |
   **Added** an experimental option, `.values.global.proxy.holdApplicationUntilProxyStarts`, to ensure that the proxy starts before an application.
 
 

--- a/releasenotes/notes/dns-capture.yaml
+++ b/releasenotes/notes/dns-capture.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+releaseNotes:
+- |
+  **Added** experimental DNS resolution directly in the sidecar to better support service entries with TCP services, multicluster DNS resolution,
+  and dns resolution of Kubernetes services from VM sidecars. This feature is disabled by default and can be enabled by setting the following
+  in the Istio Operator: meshConfig.defaultConfig.proxyMetadata.ISTIO_META_DNS_CAPTURE="ALL". Setting this option will cause Istio to set the
+  `ndots` option in pod's `dnsConfig` to 4 for faster DNS resolution in common cluster setups.

--- a/releasenotes/notes/dr-analyzer.yaml
+++ b/releasenotes/notes/dr-analyzer.yaml
@@ -1,5 +1,6 @@
 apiVersion: release-notes/v2
 kind: feature
 area: networking
-releaseNotes: |
+releaseNotes:
+- |
   **Added** Analyzer warning for DestinationRule not using CaCertificates to validate server identity.

--- a/releasenotes/notes/dr-sds.yaml
+++ b/releasenotes/notes/dr-sds.yaml
@@ -3,7 +3,8 @@ kind: feature
 area: networking
 issue:
 - 22019
-releaseNotes: |
+releaseNotes:
+- |
   **Improve** certificates referenced in DestinationRules to reload without a restart.
 
 

--- a/releasenotes/notes/ecc-csr.yaml
+++ b/releasenotes/notes/ecc-csr.yaml
@@ -3,5 +3,6 @@ kind: feature
 area: security
 issue:
 - 23226
-releaseNotes: |
+releaseNotes:
+- |
   **Added** support for creation of CSRs using ECC based certificates.

--- a/releasenotes/notes/endpoint-before-pod.yaml
+++ b/releasenotes/notes/endpoint-before-pod.yaml
@@ -3,5 +3,6 @@ kind: bug-fix
 area: networking
 issue:
 - 25112
-releaseNotes: |
+releaseNotes:
+- |
   **Fixed** an issue when high pod churn rate can cause Istiod to get stuck.

--- a/releasenotes/notes/envoy-filter.yaml
+++ b/releasenotes/notes/envoy-filter.yaml
@@ -2,11 +2,12 @@ apiVersion: release-notes/v2
 kind: feature
 area: networking
 
-releaseNotes: |
-  **Updated** the envoy filter names that control plane generates to meet the canonical naming standard. See https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.14.0#deprecated
+releaseNotes:
+  - |
+    **Updated** the envoy filter names that control plane generates to meet the canonical naming standard. See https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.14.0#deprecated
 
 upgradeNotes:
-    title: Use the new filter names for EnvoyFilter
+  - title: Use the new filter names for EnvoyFilter
     content: |
       If you are using EnvoyFilter API, it is recommended to change to the new filter names https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.14.0#deprecated.
       The deprecated filter names will be supported in this release for backward compatibility but will be removed in future releases.

--- a/releasenotes/notes/fix-nodeport-meshnetwork.yaml
+++ b/releasenotes/notes/fix-nodeport-meshnetwork.yaml
@@ -1,5 +1,6 @@
 apiVersion: release-notes/v2
 kind: bug-fix
 area: installation
-releaseNotes: |
+releaseNotes:
+- |
   **Fixed** an issue preventing NodePort services from being used as the `registryServiceName` in `meshNetworks`.

--- a/releasenotes/notes/ingress-named-port.yaml
+++ b/releasenotes/notes/ingress-named-port.yaml
@@ -3,5 +3,6 @@ kind: feature
 area: networking
 issue:
 - 23052
-releaseNotes: |
+releaseNotes:
+- |
   **Improved** support for Ingress by allowing named port references.

--- a/releasenotes/notes/istioctl-uninstall.yaml
+++ b/releasenotes/notes/istioctl-uninstall.yaml
@@ -3,5 +3,6 @@ kind: feature
 area: istioctl
 issue:
   - 24360
-releaseNotes: |
+releaseNotes:
+- |
   **Added** `istioctl x uninstall` command to uninstall Istio control plane.

--- a/releasenotes/notes/mesh-expansion.yaml
+++ b/releasenotes/notes/mesh-expansion.yaml
@@ -6,11 +6,9 @@ issue:
 
 releaseNotes:
 - |
-  *Added* port 15012 to the default list of ports for the `istio-ingressgateway` Service.
+  **Added** port 15012 to the default list of ports for the `istio-ingressgateway` Service.
 - |
-  *Deprecated* installation flags
-  - `values.global.meshExpansion.enabled` in favor of user-managed config
-  - `values.gateways.istio-ingressgateway.meshExpansionPorts` in favor of `components.ingressGateways[name=istio-ingressgateway].k8s.service.ports`
+  **Deprecated** installation flags `values.global.meshExpansion.enabled` in favor of user-managed config and `values.gateways.istio-ingressgateway.meshExpansionPorts` in favor of `components.ingressGateways[name=istio-ingressgateway].k8s.service.ports`
 
 upgradeNotes:
 - title: Avoid use of mesh expansion installation flags

--- a/releasenotes/notes/mesh-expansion.yaml
+++ b/releasenotes/notes/mesh-expansion.yaml
@@ -4,9 +4,10 @@ area: installation
 issue:
 - 25933
 
-releaseNotes: |
+releaseNotes:
+- |
   *Added* port 15012 to the default list of ports for the `istio-ingressgateway` Service.
-
+- |
   *Deprecated* installation flags
   - `values.global.meshExpansion.enabled` in favor of user-managed config
   - `values.gateways.istio-ingressgateway.meshExpansionPorts` in favor of `components.ingressGateways[name=istio-ingressgateway].k8s.service.ports`

--- a/releasenotes/notes/min-k8-ver-for-1.8.yaml
+++ b/releasenotes/notes/min-k8-ver-for-1.8.yaml
@@ -3,5 +3,6 @@ kind: feature
 area: installation
 issue:
 - 25793
-releaseNotes: |
+releaseNotes:
+- |
   **Added** Istio 1.8 supports kubernetes versions 1.17 to 1.19.

--- a/releasenotes/notes/nonroot-gateway.yaml
+++ b/releasenotes/notes/nonroot-gateway.yaml
@@ -3,5 +3,6 @@ kind: feature
 area: installation
 issue:
 - 23379
-releaseNotes: |
+releaseNotes:
+- |
   **Improved** gateway deployments to run as non-root by default.

--- a/releasenotes/notes/operator_revision.yaml
+++ b/releasenotes/notes/operator_revision.yaml
@@ -3,5 +3,6 @@ kind: feature
 area: istioctl
 issue:
   - 23479
-releaseNotes: |
+releaseNotes:
+- |
   **Added** `--revision` flag to `istioctl operator init` and `istioctl operator remove` commands to support multiple control plane upgrade.

--- a/releasenotes/notes/prom-rewrite.yaml
+++ b/releasenotes/notes/prom-rewrite.yaml
@@ -3,5 +3,6 @@ kind: feature
 area: telemetry
 issue:
 - 21366
-releaseNotes: |
+releaseNotes:
+- |
   **Enabled** Prometheus [metrics merging](/docs/ops/integrations/prometheus/#option-1-metrics-merging) by default.

--- a/releasenotes/notes/psfile.yaml
+++ b/releasenotes/notes/psfile.yaml
@@ -1,5 +1,6 @@
 apiVersion: release-notes/v2
 kind: feature
 area: istioctl
-releaseNotes: |
+releaseNotes:
+- |
   **Added** Allow proxy-status for non-K8s workloads with --file

--- a/releasenotes/notes/remove-addons-mixer-istioctl.yaml
+++ b/releasenotes/notes/remove-addons-mixer-istioctl.yaml
@@ -2,8 +2,10 @@ apiVersion: release-notes/v2
 kind: feature
 area: installation
 issue:
-- 23868
-- 23583
-releaseNotes: |
-  **Removed** the installation of telemetry addons (Prometheus, Grafana, Zipkin, Jaeger, Kiali) from installation by `istioctl`. See [Reworking our Addon Integrations](/blog/2020/addon-rework/) for more info.
-  **Removed** istio-telemetry and istio-policy from installation by `istioctl`.
+  - 23868
+  - 23583
+releaseNotes:
+  - |
+    **Removed** the installation of telemetry addons (Prometheus, Grafana, Zipkin, Jaeger, Kiali) from installation by `istioctl`. See [Reworking our Addon Integrations](/blog/2020/addon-rework/) for more info.
+  - |
+    **Removed** istio-telemetry and istio-policy from installation by `istioctl`.

--- a/releasenotes/notes/rpm-builds.yaml
+++ b/releasenotes/notes/rpm-builds.yaml
@@ -3,5 +3,6 @@ kind: feature
 area: installation
 issue:
 - 9117
-releaseNotes: |
+releaseNotes:
+- |
   **Added** RPM packages for running the Istio sidecar on a VM to the release.

--- a/releasenotes/notes/service-select-workload-entry.yaml
+++ b/releasenotes/notes/service-select-workload-entry.yaml
@@ -3,5 +3,6 @@ kind: feature
 area: networking
 issue:
 - 23683
-releaseNotes: |
+releaseNotes:
+- |
   **Added** support for Kubernetes Services to select WorkloadEntries.

--- a/releasenotes/notes/validate-unknown.yaml
+++ b/releasenotes/notes/validate-unknown.yaml
@@ -3,5 +3,6 @@ kind: feature
 area: istioctl
 issue:
 - 24861
-releaseNotes: |
+releaseNotes:
+- |
   **Improved** `istioctl validate` to check for unknown fields in resources.

--- a/releasenotes/notes/xds-v3.yaml
+++ b/releasenotes/notes/xds-v3.yaml
@@ -3,5 +3,6 @@ kind: feature
 area: networking
 issue:
 - 19885
-releaseNotes: |
+releaseNotes:
+- |
   **Updated** the XDS api to serve XDS v3 by default. v2 is still available for legacy sidecar connections.


### PR DESCRIPTION
Please provide a description for what this PR is for.

Some release notes contain multiple release notes. This updates the release notes schema to allow notes to be an array. Tools part is in https://github.com/istio/tools/pull/1163

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
