### PR TITLE
add forward compatibility with k8s admissions api v1 (#26312)

### DIFF
--- a/istioctl/cmd/testdata/webhook/example-mutating-webhook-config.yaml
+++ b/istioctl/cmd/testdata/webhook/example-mutating-webhook-config.yaml
@@ -26,3 +26,4 @@ webhooks:
         resources:
           - pods
     sideEffects: Unknown
+    admissionReviewVersions: ["v1beta1", "v1"]

--- a/istioctl/cmd/testdata/webhook/example-validating-webhook-config.yaml
+++ b/istioctl/cmd/testdata/webhook/example-validating-webhook-config.yaml
@@ -13,6 +13,7 @@ webhooks:
         path: /validate
     failurePolicy: Fail
     name: protovalidate.istio.io
+    admissionReviewVersions: ["v1beta1", "v1"]
     namespaceSelector:
       matchLabels:
         protovalidate-validation: enabled

--- a/manifests/charts/base/files/gen-istio-cluster.yaml
+++ b/manifests/charts/base/files/gen-istio-cluster.yaml
@@ -7004,3 +7004,4 @@ webhooks:
     # endpoint is ready.
     failurePolicy: Ignore
     sideEffects: None
+    admissionReviewVersions: ["v1beta1", "v1"]

--- a/manifests/charts/base/templates/validatingwebhookconfiguration.yaml
+++ b/manifests/charts/base/templates/validatingwebhookconfiguration.yaml
@@ -37,5 +37,6 @@ webhooks:
     # endpoint is ready.
     failurePolicy: Ignore
     sideEffects: None
+    admissionReviewVersions: ["v1beta1", "v1"]
 ---
 {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1529,6 +1529,7 @@ webhooks:
         apiVersions: ["v1"]
         resources: ["pods"]
     failurePolicy: Fail
+    admissionReviewVersions: ["v1beta1", "v1"]
     namespaceSelector:
       matchLabels:
         istio-injection: enabled

--- a/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -27,6 +27,7 @@ webhooks:
         apiVersions: ["v1"]
         resources: ["pods"]
     failurePolicy: Fail
+    admissionReviewVersions: ["v1beta1", "v1"]
     namespaceSelector:
 {{- if .Values.sidecarInjectorWebhook.enableNamespacesByDefault }}
       matchExpressions:

--- a/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -679,6 +679,8 @@ webhooks:
         apiVersions: ["v1"]
         resources: ["pods"]
     failurePolicy: Fail
+    admissionReviewVersions: ["v1beta1", "v1"]
+    sideEffects: None
     namespaceSelector:
       matchLabels:
         istio-injection: enabled

--- a/manifests/charts/istiod-remote/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istiod-remote/templates/mutatingwebhook.yaml
@@ -31,6 +31,8 @@ webhooks:
         apiVersions: ["v1"]
         resources: ["pods"]
     failurePolicy: Fail
+    admissionReviewVersions: ["v1beta1", "v1"]
+    sideEffects: None
     namespaceSelector:
 {{- if .Values.sidecarInjectorWebhook.enableNamespacesByDefault }}
       matchExpressions:

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/base/templates/validatingwebhookconfiguration.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/base/templates/validatingwebhookconfiguration.yaml
@@ -36,4 +36,5 @@ webhooks:
     # endpoint is ready.
     failurePolicy: Ignore
     sideEffects: None
+    admissionReviewVersions: ["v1beta1", "v1"]
 ---

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1923,8 +1923,6 @@ metadata:
     release: istio
 webhooks:
   - name: sidecar-injector.istio.io
-    sideEffects: None
-    admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
       service:
         name: istiod
@@ -1932,6 +1930,7 @@ webhooks:
         path: "/inject"
       caBundle: ""
     sideEffects: None
+    admissionReviewVersions: ["v1beta1", "v1"]
     rules:
       - operations: [ "CREATE" ]
         apiGroups: [""]

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -21,6 +21,7 @@ webhooks:
         path: "/inject"
       caBundle: ""
     sideEffects: None
+    admissionReviewVersions: ["v1beta1", "v1"]
     rules:
       - operations: [ "CREATE" ]
         apiGroups: [""]

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -645,6 +645,8 @@ webhooks:
         apiVersions: ["v1"]
         resources: ["pods"]
     failurePolicy: Fail
+    admissionReviewVersions: ["v1beta1", "v1"]
+    sideEffects: None
     namespaceSelector:
       matchLabels:
         istio-injection: enabled

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/templates/mutatingwebhook.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/templates/mutatingwebhook.yaml
@@ -23,16 +23,16 @@ webhooks:
         name: istiod
         namespace: {{ .Values.global.istioNamespace }}
         path: "/inject"
-      {{- end }}      
+      {{- end }}
       caBundle: {{ .Values.sidecarInjectorWebhook.caBundle }}
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1", "v1"]
     rules:
       - operations: [ "CREATE" ]
         apiGroups: [""]
         apiVersions: ["v1"]
         resources: ["pods"]
     failurePolicy: Fail
-    sideEffects: None
-    admissionReviewVersions: ["v1", "v1beta1"]
     namespaceSelector:
 {{- if .Values.sidecarInjectorWebhook.enableNamespacesByDefault }}
       matchExpressions:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -7864,6 +7864,7 @@ webhooks:
     # endpoint is ready.
     failurePolicy: Ignore
     sideEffects: None
+    admissionReviewVersions: ["v1beta1", "v1"]
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: attributemanifest
@@ -10780,6 +10781,7 @@ webhooks:
         path: "/inject"
       caBundle: ""
     sideEffects: None
+    admissionReviewVersions: ["v1beta1", "v1"]
     rules:
       - operations: [ "CREATE" ]
         apiGroups: [""]

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
@@ -7663,6 +7663,7 @@ webhooks:
     # endpoint is ready.
     failurePolicy: Ignore
     sideEffects: None
+    admissionReviewVersions: ["v1beta1", "v1"]
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -1551,6 +1551,7 @@ webhooks:
         path: "/inject"
       caBundle: ""
     sideEffects: None
+    admissionReviewVersions: ["v1beta1", "v1"]
     rules:
       - operations: [ "CREATE" ]
         apiGroups: [""]

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_kubernetes.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_kubernetes.golden.yaml
@@ -25,7 +25,10 @@ metadata:
     release: istio
   name: istio-sidecar-injector-istio-control
 webhooks:
-- clientConfig:
+- admissionReviewVersions:
+  - v1beta1
+  - v1
+  clientConfig:
     caBundle: ""
     service:
       name: foo

--- a/pkg/kube/adapter.go
+++ b/pkg/kube/adapter.go
@@ -1,0 +1,316 @@
+//  Copyright Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package kube
+
+import (
+	"github.com/pkg/errors"
+	kubeApiAdmissionv1 "k8s.io/api/admission/v1"
+	kubeApiAdmissionv1beta1 "k8s.io/api/admission/v1beta1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	// APIVersion constants
+	admissionAPIV1      = "admission.k8s.io/v1"
+	admissionAPIV1beta1 = "admission.k8s.io/v1beta1"
+
+	// Operation constants
+	Create  string = "CREATE"
+	Update  string = "UPDATE"
+	Delete  string = "DELETE"
+	Connect string = "CONNECT"
+)
+
+// AdmissionReview describes an admission review request/response.
+type AdmissionReview struct {
+	// TypeMeta describes an individual object in an API response or request
+	// with strings representing the type of the object and its API schema version.
+	// Structures that are versioned or persisted should inline TypeMeta.
+	metav1.TypeMeta `json:",inline"`
+
+	// Request describes the attributes for the admission request.
+	Request *AdmissionRequest `json:"request,omitempty"`
+
+	// Response describes the attributes for the admission response.
+	Response *AdmissionResponse `json:"response,omitempty"`
+}
+
+// AdmissionRequest describes the admission.Attributes for the admission request.
+type AdmissionRequest struct {
+
+	// UID is an identifier for the individual request/response. It allows us to distinguish instances of requests which are
+	// otherwise identical (parallel requests, requests when earlier requests did not modify etc)
+	// The UID is meant to track the round trip (request/response) between the KAS and the WebHook, not the user request.
+	// It is suitable for correlating log entries between the webhook and apiserver, for either auditing or debugging.
+	UID types.UID `json:"uid"`
+
+	// Kind is the fully-qualified type of object being submitted (for example, v1.Pod or autoscaling.v1.Scale)
+	Kind metav1.GroupVersionKind `json:"kind"`
+
+	// Resource is the fully-qualified resource being requested (for example, v1.pods)
+	Resource metav1.GroupVersionResource `json:"resource"`
+
+	// SubResource is the subresource being requested, if any (for example, "status" or "scale")
+	SubResource string `json:"subResource,omitempty"`
+	// RequestKind is the fully-qualified type of the original API request (for example, v1.Pod or autoscaling.v1.Scale).
+	// If this is specified and differs from the value in "kind", an equivalent match and conversion was performed.
+	//
+	// For example, if deployments can be modified via apps/v1 and apps/v1beta1, and a webhook registered a rule of
+	// `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]` and `matchPolicy: Equivalent`,
+	// an API request to apps/v1beta1 deployments would be converted and sent to the webhook
+	// with `kind: {group:"apps", version:"v1", kind:"Deployment"}` (matching the rule the webhook registered for),
+	// and `requestKind: {group:"apps", version:"v1beta1", kind:"Deployment"}` (indicating the kind of the original API request).
+	//
+	RequestKind *metav1.GroupVersionKind `json:"requestKind,omitempty"`
+
+	// RequestResource is the fully-qualified resource of the original API request (for example, v1.pods).
+	// If this is specified and differs from the value in "resource", an equivalent match and conversion was performed.
+	//
+	// For example, if deployments can be modified via apps/v1 and apps/v1beta1, and a webhook registered a rule of
+	// `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]` and `matchPolicy: Equivalent`,
+	// an API request to apps/v1beta1 deployments would be converted and sent to the webhook
+	// with `resource: {group:"apps", version:"v1", resource:"deployments"}` (matching the resource the webhook registered for),
+	// and `requestResource: {group:"apps", version:"v1beta1", resource:"deployments"}` (indicating the resource of the original API request).
+	//
+	RequestResource *metav1.GroupVersionResource `json:"requestResource,omitempty"`
+
+	// RequestSubResource is the name of the subresource of the original API request, if any (for example, "status" or "scale")
+	// If this is specified and differs from the value in "subResource", an equivalent match and conversion was performed.
+	RequestSubResource string `json:"requestSubResource,omitempty"`
+
+	// UserInfo is information about the requesting user
+	UserInfo authenticationv1.UserInfo `json:"userInfo"`
+
+	// Name is the name of the object as presented in the request.  On a CREATE operation, the client may omit name and
+	// rely on the server to generate the name.  If that is the case, this field will contain an empty string.
+	Name string `json:"name,omitempty"`
+
+	// Namespace is the namespace associated with the request (if any).
+	Namespace string `json:"namespace,omitempty"`
+
+	// Operation is the operation being performed. This may be different than the operation
+	// requested. e.g. a patch can result in either a CREATE or UPDATE Operation.
+	Operation string `json:"operation"`
+
+	// Object is the object from the incoming request.
+	Object runtime.RawExtension `json:"object,omitempty"`
+
+	// OldObject is the existing object. Only populated for DELETE and UPDATE requests.
+	OldObject runtime.RawExtension `json:"oldObject,omitempty"`
+
+	// DryRun indicates that modifications will definitely not be persisted for this request.
+	// Defaults to false.
+	DryRun *bool `json:"dryRun,omitempty"`
+
+	// Options is the operation option structure of the operation being performed.
+	// e.g. `meta.k8s.io/v1.DeleteOptions` or `meta.k8s.io/v1.CreateOptions`. This may be
+	// different than the options the caller provided. e.g. for a patch request the performed
+	// Operation might be a CREATE, in which case the Options will a
+	// `meta.k8s.io/v1.CreateOptions` even though the caller provided `meta.k8s.io/v1.PatchOptions`.
+	Options runtime.RawExtension `json:"options,omitempty"`
+}
+
+// AdmissionResponse describes an admission response.
+type AdmissionResponse struct {
+
+	// UID is an identifier for the individual request/response.
+	// This should be copied over from the corresponding AdmissionRequest.
+	UID types.UID `json:"uid"`
+
+	// Allowed indicates whether or not the admission request was permitted.
+	Allowed bool `json:"allowed"`
+
+	// Result contains extra details into why an admission request was denied.
+	// This field IS NOT consulted in any way if "Allowed" is "true".
+	Result *metav1.Status `json:"status,omitempty"`
+
+	// The patch body. Currently we only support "JSONPatch" which implements RFC 6902.
+	Patch []byte `json:"patch,omitempty"`
+
+	// The type of Patch. Currently we only allow "JSONPatch".
+	PatchType *string `json:"patchType,omitempty"`
+
+	// AuditAnnotations is an unstructured key value map set by remote admission controller (e.g. error=image-blacklisted).
+	// MutatingAdmissionWebhook and ValidatingAdmissionWebhook admission controller will prefix the keys with
+	// admission webhook name (e.g. imagepolicy.example.com/error=image-blacklisted). AuditAnnotations will be provided by
+	// the admission webhook to add additional context to the audit log for this request.
+	AuditAnnotations map[string]string `json:"auditAnnotations,omitempty"`
+}
+
+func AdmissionReviewKubeToAdapter(object runtime.Object) (*AdmissionReview, error) {
+	var typeMeta metav1.TypeMeta
+	var req *AdmissionRequest
+	var resp *AdmissionResponse
+	switch obj := object.(type) {
+	case *kubeApiAdmissionv1beta1.AdmissionReview:
+		typeMeta = obj.TypeMeta
+		arv1beta1Response := obj.Response
+		arv1beta1Request := obj.Request
+		if arv1beta1Response != nil {
+			resp = &AdmissionResponse{
+				UID:     arv1beta1Response.UID,
+				Allowed: arv1beta1Response.Allowed,
+				Result:  arv1beta1Response.Result,
+				Patch:   arv1beta1Response.Patch,
+			}
+			if arv1beta1Response.PatchType != nil {
+				patchType := string(*arv1beta1Response.PatchType)
+				resp.PatchType = &patchType
+			}
+		}
+		if arv1beta1Request != nil {
+			req = &AdmissionRequest{
+				UID:       arv1beta1Request.UID,
+				Kind:      arv1beta1Request.Kind,
+				Resource:  arv1beta1Request.Resource,
+				UserInfo:  arv1beta1Request.UserInfo,
+				Name:      arv1beta1Request.Name,
+				Namespace: arv1beta1Request.Namespace,
+				Operation: string(arv1beta1Request.Operation),
+				Object:    arv1beta1Request.Object,
+				OldObject: arv1beta1Request.OldObject,
+			}
+		}
+
+	case *kubeApiAdmissionv1.AdmissionReview:
+		typeMeta = obj.TypeMeta
+		arv1Response := obj.Response
+		arv1Request := obj.Request
+		if arv1Response != nil {
+			resp = &AdmissionResponse{
+				UID:     arv1Response.UID,
+				Allowed: arv1Response.Allowed,
+				Result:  arv1Response.Result,
+				Patch:   arv1Response.Patch,
+			}
+			if arv1Response.PatchType != nil {
+				patchType := string(*arv1Response.PatchType)
+				resp.PatchType = &patchType
+			}
+		}
+
+		if arv1Request != nil {
+			req = &AdmissionRequest{
+				UID:       arv1Request.UID,
+				Kind:      arv1Request.Kind,
+				Resource:  arv1Request.Resource,
+				UserInfo:  arv1Request.UserInfo,
+				Name:      arv1Request.Name,
+				Namespace: arv1Request.Namespace,
+				Operation: string(arv1Request.Operation),
+				Object:    arv1Request.Object,
+				OldObject: arv1Request.OldObject,
+			}
+		}
+
+	default:
+		return nil, errors.Errorf("unsupported type :%v", object.GetObjectKind())
+	}
+
+	return &AdmissionReview{
+		TypeMeta: typeMeta,
+		Request:  req,
+		Response: resp,
+	}, nil
+}
+
+func AdmissionReviewAdapterToKube(ar *AdmissionReview, apiVersion string) runtime.Object {
+	var res runtime.Object
+	arRequest := ar.Request
+	arResponse := ar.Response
+	if apiVersion == "" {
+		apiVersion = admissionAPIV1beta1
+	}
+	switch apiVersion {
+	case admissionAPIV1beta1:
+		arv1beta1 := kubeApiAdmissionv1beta1.AdmissionReview{}
+		if arRequest != nil {
+			arv1beta1.Request = &kubeApiAdmissionv1beta1.AdmissionRequest{
+				UID:                arRequest.UID,
+				Kind:               arRequest.Kind,
+				Resource:           arRequest.Resource,
+				SubResource:        arRequest.SubResource,
+				Name:               arRequest.Name,
+				Namespace:          arRequest.Namespace,
+				RequestKind:        arRequest.RequestKind,
+				RequestResource:    arRequest.RequestResource,
+				RequestSubResource: arRequest.RequestSubResource,
+				Operation:          kubeApiAdmissionv1beta1.Operation(arRequest.Operation),
+				UserInfo:           arRequest.UserInfo,
+				Object:             arRequest.Object,
+				OldObject:          arRequest.OldObject,
+				DryRun:             arRequest.DryRun,
+				Options:            arRequest.Options,
+			}
+		}
+		if arResponse != nil {
+			var patchType kubeApiAdmissionv1beta1.PatchType
+			if arResponse.PatchType != nil {
+				patchType = kubeApiAdmissionv1beta1.PatchType(*arResponse.PatchType)
+			}
+			arv1beta1.Response = &kubeApiAdmissionv1beta1.AdmissionResponse{
+				UID:              arResponse.UID,
+				Allowed:          arResponse.Allowed,
+				Result:           arResponse.Result,
+				Patch:            arResponse.Patch,
+				PatchType:        &patchType,
+				AuditAnnotations: arResponse.AuditAnnotations,
+			}
+		}
+		arv1beta1.TypeMeta = ar.TypeMeta
+		res = &arv1beta1
+	case admissionAPIV1:
+		arv1 := kubeApiAdmissionv1.AdmissionReview{}
+		if arRequest != nil {
+			arv1.Request = &kubeApiAdmissionv1.AdmissionRequest{
+				UID:                arRequest.UID,
+				Kind:               arRequest.Kind,
+				Resource:           arRequest.Resource,
+				SubResource:        arRequest.SubResource,
+				Name:               arRequest.Name,
+				Namespace:          arRequest.Namespace,
+				RequestKind:        arRequest.RequestKind,
+				RequestResource:    arRequest.RequestResource,
+				RequestSubResource: arRequest.RequestSubResource,
+				Operation:          kubeApiAdmissionv1.Operation(arRequest.Operation),
+				UserInfo:           arRequest.UserInfo,
+				Object:             arRequest.Object,
+				OldObject:          arRequest.OldObject,
+				DryRun:             arRequest.DryRun,
+				Options:            arRequest.Options,
+			}
+		}
+		if arResponse != nil {
+			var patchType kubeApiAdmissionv1.PatchType
+			if arResponse.PatchType != nil {
+				patchType = kubeApiAdmissionv1.PatchType(*arResponse.PatchType)
+			}
+			arv1.Response = &kubeApiAdmissionv1.AdmissionResponse{
+				UID:              arResponse.UID,
+				Allowed:          arResponse.Allowed,
+				Result:           arResponse.Result,
+				Patch:            arResponse.Patch,
+				PatchType:        &patchType,
+				AuditAnnotations: arResponse.AuditAnnotations,
+			}
+		}
+		arv1.TypeMeta = ar.TypeMeta
+		res = &arv1
+	}
+	return res
+}

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -34,29 +34,25 @@ import (
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
-	"github.com/hashicorp/go-multierror"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
-	"istio.io/api/label"
-
-	"istio.io/istio/pkg/config/mesh"
-	"istio.io/istio/pkg/config/validation"
-	"istio.io/istio/pkg/util/gogoprotomarshal"
-
-	"istio.io/api/annotation"
-	meshconfig "istio.io/api/mesh/v1alpha1"
-	"istio.io/pkg/log"
-
-	"istio.io/istio/pilot/pkg/model"
-
+	multierror "github.com/hashicorp/go-multierror"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/batch/v2alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	yamlDecoder "k8s.io/apimachinery/pkg/util/yaml"
+
+	"istio.io/api/annotation"
+	"istio.io/api/label"
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config/mesh"
+	"istio.io/istio/pkg/config/validation"
+	"istio.io/istio/pkg/util/gogoprotomarshal"
+	"istio.io/pkg/log"
 )
 
 type annotationValidationFunc func(value string) error

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -42,6 +42,7 @@ import (
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/cmd/pilot-agent/status"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/kube"
 	"istio.io/pkg/log"
 )
 
@@ -662,11 +663,11 @@ func injectionStatus(pod *corev1.Pod) *SidecarInjectionStatus {
 	}
 }
 
-func toAdmissionResponse(err error) *kubeApiAdmissionv1beta1.AdmissionResponse {
-	return &kubeApiAdmissionv1beta1.AdmissionResponse{Result: &metav1.Status{Message: err.Error()}}
+func toAdmissionResponse(err error) *kube.AdmissionResponse {
+	return &kube.AdmissionResponse{Result: &metav1.Status{Message: err.Error()}}
 }
 
-func (wh *Webhook) inject(ar *kubeApiAdmissionv1beta1.AdmissionReview, path string) *kubeApiAdmissionv1beta1.AdmissionResponse {
+func (wh *Webhook) inject(ar *kube.AdmissionReview, path string) *kube.AdmissionResponse {
 	req := ar.Request
 	var pod corev1.Pod
 	if err := json.Unmarshal(req.Object.Raw, &pod); err != nil {
@@ -689,7 +690,7 @@ func (wh *Webhook) inject(ar *kubeApiAdmissionv1beta1.AdmissionReview, path stri
 	if !injectRequired(ignoredNamespaces, wh.Config, &pod.Spec, &pod.ObjectMeta) {
 		log.Infof("Skipping %s/%s due to policy check", pod.ObjectMeta.Namespace, podName)
 		totalSkippedInjections.Increment()
-		return &kubeApiAdmissionv1beta1.AdmissionResponse{
+		return &kube.AdmissionResponse{
 			Allowed: true,
 		}
 	}
@@ -770,11 +771,11 @@ func (wh *Webhook) inject(ar *kubeApiAdmissionv1beta1.AdmissionReview, path stri
 
 	log.Debugf("AdmissionResponse: patch=%v\n", string(patchBytes))
 
-	reviewResponse := kubeApiAdmissionv1beta1.AdmissionResponse{
+	reviewResponse := kube.AdmissionResponse{
 		Allowed: true,
 		Patch:   patchBytes,
-		PatchType: func() *kubeApiAdmissionv1beta1.PatchType {
-			pt := kubeApiAdmissionv1beta1.PatchTypeJSONPatch
+		PatchType: func() *string {
+			pt := "JSONPatch"
 			return &pt
 		}(),
 	}
@@ -809,25 +810,36 @@ func (wh *Webhook) serveInject(w http.ResponseWriter, r *http.Request) {
 		path = r.URL.Path
 	}
 
-	var reviewResponse *kubeApiAdmissionv1beta1.AdmissionResponse
-	ar := kubeApiAdmissionv1beta1.AdmissionReview{}
-	if _, _, err := deserializer.Decode(body, nil, &ar); err != nil {
+	var reviewResponse *kube.AdmissionResponse
+	var obj runtime.Object
+	var ar *kube.AdmissionReview
+	if out, _, err := deserializer.Decode(body, nil, obj); err != nil {
 		handleError(fmt.Sprintf("Could not decode body: %v", err))
 		reviewResponse = toAdmissionResponse(err)
 	} else {
 		log.Debugf("AdmissionRequest for path=%s\n", path)
-		reviewResponse = wh.inject(&ar, path)
+		ar, err = kube.AdmissionReviewKubeToAdapter(out)
+		if err != nil {
+			handleError(fmt.Sprintf("Could not decode object: %v", err))
+		}
+		reviewResponse = wh.inject(ar, path)
 	}
 
-	response := kubeApiAdmissionv1beta1.AdmissionReview{}
-	if reviewResponse != nil {
-		response.Response = reviewResponse
-		if ar.Request != nil {
-			response.Response.UID = ar.Request.UID
+	response := kube.AdmissionReview{}
+	response.Response = reviewResponse
+	var responseKube runtime.Object
+	var apiVersion string
+	if ar != nil {
+		apiVersion = ar.APIVersion
+		response.TypeMeta = ar.TypeMeta
+		if response.Response != nil {
+			if ar.Request != nil {
+				response.Response.UID = ar.Request.UID
+			}
 		}
 	}
-
-	resp, err := json.Marshal(response)
+	responseKube = kube.AdmissionReviewAdapterToKube(&response, apiVersion)
+	resp, err := json.Marshal(responseKube)
 	if err != nil {
 		log.Errorf("Could not encode response: %v", err)
 		http.Error(w, fmt.Sprintf("could not encode response: %v", err), http.StatusInternalServerError)

--- a/pkg/webhooks/validation/server/monitoring.go
+++ b/pkg/webhooks/validation/server/monitoring.go
@@ -17,8 +17,7 @@ package server
 import (
 	"strconv"
 
-	kubeApiAdmission "k8s.io/api/admission/v1beta1"
-
+	"istio.io/istio/pkg/kube"
 	"istio.io/pkg/monitoring"
 )
 
@@ -73,7 +72,7 @@ func init() {
 	)
 }
 
-func reportValidationFailed(request *kubeApiAdmission.AdmissionRequest, reason string) {
+func reportValidationFailed(request *kube.AdmissionRequest, reason string) {
 	metricValidationFailed.
 		With(GroupTag.Value(request.Resource.Group)).
 		With(VersionTag.Value(request.Resource.Version)).
@@ -82,7 +81,7 @@ func reportValidationFailed(request *kubeApiAdmission.AdmissionRequest, reason s
 		Increment()
 }
 
-func reportValidationPass(request *kubeApiAdmission.AdmissionRequest) {
+func reportValidationPass(request *kube.AdmissionRequest) {
 	metricValidationPassed.
 		With(GroupTag.Value(request.Resource.Group)).
 		With(VersionTag.Value(request.Resource.Version)).

--- a/pkg/webhooks/validation/server/server.go
+++ b/pkg/webhooks/validation/server/server.go
@@ -22,20 +22,21 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/hashicorp/go-multierror"
-	kubeApiAdmission "k8s.io/api/admission/v1beta1"
+	multierror "github.com/hashicorp/go-multierror"
+	kubeApiAdmissionv1 "k8s.io/api/admission/v1"
+	kubeApiAdmissionv1beta1 "k8s.io/api/admission/v1beta1"
 	kubeApiApps "k8s.io/api/apps/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-
-	"istio.io/pkg/log"
 
 	"istio.io/istio/mixer/pkg/config/store"
 	"istio.io/istio/pilot/pkg/config/kube/crd"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/resource"
+	"istio.io/istio/pkg/kube"
+	"istio.io/pkg/log"
 )
 
 var scope = log.RegisterScope("validationServer", "validation webhook server", 0)
@@ -57,6 +58,8 @@ var (
 
 func init() {
 	_ = kubeApiApps.AddToScheme(runtimeScheme)
+	_ = kubeApiAdmissionv1.AddToScheme(runtimeScheme)
+	_ = kubeApiAdmissionv1beta1.AddToScheme(runtimeScheme)
 }
 
 // Options contains the configuration for the Istio Pilot validation
@@ -145,11 +148,11 @@ func (wh *Webhook) Run(stopCh <-chan struct{}) {
 	}
 }
 
-func toAdmissionResponse(err error) *kubeApiAdmission.AdmissionResponse {
-	return &kubeApiAdmission.AdmissionResponse{Result: &metav1.Status{Message: err.Error()}}
+func toAdmissionResponse(err error) *kube.AdmissionResponse {
+	return &kube.AdmissionResponse{Result: &metav1.Status{Message: err.Error()}}
 }
 
-type admitFunc func(*kubeApiAdmission.AdmissionRequest) *kubeApiAdmission.AdmissionResponse
+type admitFunc func(*kube.AdmissionRequest) *kube.AdmissionResponse
 
 func serve(w http.ResponseWriter, r *http.Request, admit admitFunc) {
 	var body []byte
@@ -172,23 +175,35 @@ func serve(w http.ResponseWriter, r *http.Request, admit admitFunc) {
 		return
 	}
 
-	var reviewResponse *kubeApiAdmission.AdmissionResponse
-	ar := kubeApiAdmission.AdmissionReview{}
-	if _, _, err := deserializer.Decode(body, nil, &ar); err != nil {
+	var reviewResponse *kube.AdmissionResponse
+	var obj runtime.Object
+	var ar *kube.AdmissionReview
+	if out, _, err := deserializer.Decode(body, nil, obj); err != nil {
 		reviewResponse = toAdmissionResponse(fmt.Errorf("could not decode body: %v", err))
 	} else {
-		reviewResponse = admit(ar.Request)
-	}
-
-	response := kubeApiAdmission.AdmissionReview{}
-	if reviewResponse != nil {
-		response.Response = reviewResponse
-		if ar.Request != nil {
-			response.Response.UID = ar.Request.UID
+		ar, err = kube.AdmissionReviewKubeToAdapter(out)
+		if err != nil {
+			reviewResponse = toAdmissionResponse(fmt.Errorf("could not decode object: %v", err))
+		} else {
+			reviewResponse = admit(ar.Request)
 		}
 	}
 
-	resp, err := json.Marshal(response)
+	response := kube.AdmissionReview{}
+	response.Response = reviewResponse
+	var responseKube runtime.Object
+	var apiVersion string
+	if ar != nil {
+		apiVersion = ar.APIVersion
+		response.TypeMeta = ar.TypeMeta
+		if response.Response != nil {
+			if ar.Request != nil {
+				response.Response.UID = ar.Request.UID
+			}
+		}
+	}
+	responseKube = kube.AdmissionReviewAdapterToKube(&response, apiVersion)
+	resp, err := json.Marshal(responseKube)
 	if err != nil {
 		reportValidationHTTPError(http.StatusInternalServerError)
 		http.Error(w, fmt.Sprintf("could encode response: %v", err), http.StatusInternalServerError)
@@ -212,7 +227,7 @@ func (wh *Webhook) serveValidate(w http.ResponseWriter, r *http.Request) {
 	serve(w, r, wh.validate)
 }
 
-func (wh *Webhook) validate(request *kubeApiAdmission.AdmissionRequest) *kubeApiAdmission.AdmissionResponse {
+func (wh *Webhook) validate(request *kube.AdmissionRequest) *kube.AdmissionResponse {
 	switch request.Kind.Kind {
 	case collections.IstioPolicyV1Beta1Rules.Resource().Kind(),
 		collections.IstioPolicyV1Beta1Attributemanifests.Resource().Kind(),
@@ -226,13 +241,13 @@ func (wh *Webhook) validate(request *kubeApiAdmission.AdmissionRequest) *kubeApi
 	}
 }
 
-func (wh *Webhook) admitPilot(request *kubeApiAdmission.AdmissionRequest) *kubeApiAdmission.AdmissionResponse {
+func (wh *Webhook) admitPilot(request *kube.AdmissionRequest) *kube.AdmissionResponse {
 	switch request.Operation {
-	case kubeApiAdmission.Create, kubeApiAdmission.Update:
+	case kube.Create, kube.Update:
 	default:
 		scope.Warnf("Unsupported webhook operation %v", request.Operation)
 		reportValidationFailed(request, reasonUnsupportedOperation)
-		return &kubeApiAdmission.AdmissionResponse{Allowed: true}
+		return &kube.AdmissionResponse{Allowed: true}
 	}
 
 	var obj crd.IstioKind
@@ -275,10 +290,10 @@ func (wh *Webhook) admitPilot(request *kubeApiAdmission.AdmissionRequest) *kubeA
 	}
 
 	reportValidationPass(request)
-	return &kubeApiAdmission.AdmissionResponse{Allowed: true}
+	return &kube.AdmissionResponse{Allowed: true}
 }
 
-func (wh *Webhook) admitMixer(request *kubeApiAdmission.AdmissionRequest) *kubeApiAdmission.AdmissionResponse {
+func (wh *Webhook) admitMixer(request *kube.AdmissionRequest) *kube.AdmissionResponse {
 	ev := &store.BackendEvent{
 		Key: store.Key{
 			Namespace: request.Namespace,
@@ -286,7 +301,7 @@ func (wh *Webhook) admitMixer(request *kubeApiAdmission.AdmissionRequest) *kubeA
 		},
 	}
 	switch request.Operation {
-	case kubeApiAdmission.Create, kubeApiAdmission.Update:
+	case kube.Create, kube.Update:
 		ev.Type = store.Update
 		var obj crd.IstioKind
 		if err := json.Unmarshal(request.Object.Raw, &obj); err != nil {
@@ -311,7 +326,7 @@ func (wh *Webhook) admitMixer(request *kubeApiAdmission.AdmissionRequest) *kubeA
 			return toAdmissionResponse(err)
 		}
 
-	case kubeApiAdmission.Delete:
+	case kube.Delete:
 		if request.Name == "" {
 			reportValidationFailed(request, reasonUnknownType)
 			return toAdmissionResponse(fmt.Errorf("illformed request: name not found on delete request"))
@@ -321,7 +336,7 @@ func (wh *Webhook) admitMixer(request *kubeApiAdmission.AdmissionRequest) *kubeA
 	default:
 		scope.Warnf("Unsupported webhook operation %v", request.Operation)
 		reportValidationFailed(request, reasonUnsupportedOperation)
-		return &kubeApiAdmission.AdmissionResponse{Allowed: true}
+		return &kube.AdmissionResponse{Allowed: true}
 	}
 
 	// webhook skips deletions
@@ -333,7 +348,7 @@ func (wh *Webhook) admitMixer(request *kubeApiAdmission.AdmissionRequest) *kubeA
 	}
 
 	reportValidationPass(request)
-	return &kubeApiAdmission.AdmissionResponse{Allowed: true}
+	return &kube.AdmissionResponse{Allowed: true}
 }
 
 func checkFields(raw []byte, kind string, namespace string, name string) (string, error) {

--- a/tests/integration/security/webhook/config/galley-webhook.yaml
+++ b/tests/integration/security/webhook/config/galley-webhook.yaml
@@ -87,3 +87,4 @@ webhooks:
           - templates
     failurePolicy: Fail
     sideEffects: None
+    admissionReviewVersions: ["v1beta1", "v1"]

--- a/tests/integration/security/webhook/config/sidecar-injector-webhook.yaml
+++ b/tests/integration/security/webhook/config/sidecar-injector-webhook.yaml
@@ -21,6 +21,8 @@ webhooks:
         apiVersions: ["v1"]
         resources: ["pods"]
     failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1", "v1"]
     namespaceSelector:
       matchLabels:
         istio-injection: enabled


### PR DESCRIPTION
* add forward compatibility with k8s admissions api v1

* add support for v1 and v1beta1 AdmissionReview versions

* use admission API adapter in validating webhooks

(cherry picked from commit c4a14db008d6546d27b00d7318e3100eda8e2603)

Please provide a description for what this PR is for.
Fixes #26379 

This is a manual cherrypick of PR #26312 

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[X] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
