### PR TITLE
Change sample cross-network port to 15443

### DIFF
--- a/samples/cross-network-gateway/cross-network-gateway.yaml
+++ b/samples/cross-network-gateway/cross-network-gateway.yaml
@@ -8,7 +8,7 @@ spec:
     istio: ingressgateway
   servers:
     - port:
-        number: 443
+        number: 15443
         name: tls
         protocol: TLS
       tls:


### PR DESCRIPTION
Goal is to not mix TLS and mTLS on the same port. TLS is on 443, mTLS is on 15443.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
