### PR TITLE
add cross cluster load balancing test

### DIFF
--- a/pkg/test/framework/scope.go
+++ b/pkg/test/framework/scope.go
@@ -87,8 +87,6 @@ func (s *scope) get(ref interface{}) error {
 		targetT = targetT.Elem()
 	}
 
-	target := fmt.Sprintf("%v", targetT)
-	fmt.Printf("target: %s\n", target)
 	for _, res := range s.resources {
 		if res == nil {
 			continue

--- a/tests/integration/multicluster/base/main_test.go
+++ b/tests/integration/multicluster/base/main_test.go
@@ -56,3 +56,7 @@ func TestClusterLocalService(t *testing.T) {
 func TestTelemetry(t *testing.T) {
 	multicluster.TelemetryTest(t, mcReachabilityNS, "installation.multicluster.multimaster", "installation.multicluster.remote")
 }
+
+func TestCrossClusterLoadbalancing(t *testing.T) {
+	multicluster.LoadbalancingTest(t, mcReachabilityNS, "installation.multicluster.multimaster", "installation.multicluster.remote")
+}

--- a/tests/integration/multicluster/base/main_test.go
+++ b/tests/integration/multicluster/base/main_test.go
@@ -15,6 +15,7 @@
 package base
 
 import (
+	"istio.io/istio/pkg/test/framework/resource"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
@@ -33,10 +34,14 @@ func TestMain(m *testing.M) {
 		NewSuite(m).
 		Label(label.Multicluster).
 		RequireMinClusters(2).
-		Setup(multicluster.SetupApps(apps)).
 		Setup(istio.Setup(&ist, func(cfg *istio.Config) {
 			cfg.ExposeIstiod = true
 		})).
+		Setup(func(ctx resource.Context) error {
+			var err error
+			apps, err = multicluster.SetupApps(ctx)
+			return err
+		}).
 		Run()
 }
 

--- a/tests/integration/multicluster/base/main_test.go
+++ b/tests/integration/multicluster/base/main_test.go
@@ -19,15 +19,13 @@ import (
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
-	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/tests/integration/multicluster"
 )
 
 var (
-	ist                              istio.Instance
-	clusterLocalNS, mcReachabilityNS namespace.Instance
-	controlPlaneValues               string
+	ist  istio.Instance
+	apps *multicluster.Apps
 )
 
 func TestMain(m *testing.M) {
@@ -35,28 +33,25 @@ func TestMain(m *testing.M) {
 		NewSuite(m).
 		Label(label.Multicluster).
 		RequireMinClusters(2).
-		Setup(multicluster.Setup(&controlPlaneValues, &clusterLocalNS, &mcReachabilityNS)).
+		Setup(multicluster.SetupApps(apps)).
 		Setup(istio.Setup(&ist, func(cfg *istio.Config) {
 			cfg.ExposeIstiod = true
-
-			// Set the control plane values on the config.
-			cfg.ControlPlaneValues = controlPlaneValues
 		})).
 		Run()
 }
 
 func TestMulticlusterReachability(t *testing.T) {
-	multicluster.ReachabilityTest(t, mcReachabilityNS, "installation.multicluster.multimaster", "installation.multicluster.remote")
-}
-
-func TestClusterLocalService(t *testing.T) {
-	multicluster.ClusterLocalTest(t, clusterLocalNS, "installation.multicluster.multimaster", "installation.multicluster.remote")
-}
-
-func TestTelemetry(t *testing.T) {
-	multicluster.TelemetryTest(t, mcReachabilityNS, "installation.multicluster.multimaster", "installation.multicluster.remote")
+	multicluster.ReachabilityTest(t, apps, "installation.multicluster.multimaster", "installation.multicluster.remote")
 }
 
 func TestCrossClusterLoadbalancing(t *testing.T) {
-	multicluster.LoadbalancingTest(t, mcReachabilityNS, "installation.multicluster.multimaster", "installation.multicluster.remote")
+	multicluster.LoadbalancingTest(t, apps, "installation.multicluster.multimaster", "installation.multicluster.remote")
+}
+
+func TestClusterLocalService(t *testing.T) {
+	multicluster.ClusterLocalTest(t, apps, "installation.multicluster.multimaster", "installation.multicluster.remote")
+}
+
+func TestTelemetry(t *testing.T) {
+	multicluster.TelemetryTest(t, *apps, "installation.multicluster.multimaster", "installation.multicluster.remote")
 }

--- a/tests/integration/multicluster/base/main_test.go
+++ b/tests/integration/multicluster/base/main_test.go
@@ -25,7 +25,7 @@ import (
 
 var (
 	ist    istio.Instance
-	appCtx *multicluster.AppContext
+	appCtx multicluster.AppContext
 )
 
 func TestMain(m *testing.M) {
@@ -33,12 +33,12 @@ func TestMain(m *testing.M) {
 		NewSuite(m).
 		Label(label.Multicluster).
 		RequireMinClusters(2).
-		Setup(multicluster.Setup(appCtx)).
+		Setup(multicluster.Setup(&appCtx)).
 		Setup(istio.Setup(&ist, func(cfg *istio.Config) {
 			cfg.ControlPlaneValues = appCtx.ControlPlaneValues
 			cfg.ExposeIstiod = true
 		})).
-		Setup(multicluster.SetupApps(appCtx)).
+		Setup(multicluster.SetupApps(&appCtx)).
 		Run()
 }
 

--- a/tests/integration/multicluster/base/main_test.go
+++ b/tests/integration/multicluster/base/main_test.go
@@ -17,8 +17,6 @@ package base
 import (
 	"testing"
 
-	"istio.io/istio/pkg/test/framework/resource"
-
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/label"

--- a/tests/integration/multicluster/base/main_test.go
+++ b/tests/integration/multicluster/base/main_test.go
@@ -53,5 +53,5 @@ func TestClusterLocalService(t *testing.T) {
 }
 
 func TestTelemetry(t *testing.T) {
-	multicluster.TelemetryTest(t, *apps, "installation.multicluster.multimaster", "installation.multicluster.remote")
+	multicluster.TelemetryTest(t, apps, "installation.multicluster.multimaster", "installation.multicluster.remote")
 }

--- a/tests/integration/multicluster/base/main_test.go
+++ b/tests/integration/multicluster/base/main_test.go
@@ -15,12 +15,14 @@
 package base
 
 import (
-	"istio.io/istio/pkg/test/framework/resource"
 	"testing"
+
+	"istio.io/istio/pkg/test/framework/resource"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/tests/integration/multicluster"
 )
 

--- a/tests/integration/multicluster/centralistio/main_test.go
+++ b/tests/integration/multicluster/centralistio/main_test.go
@@ -35,7 +35,6 @@ func TestMain(m *testing.M) {
 		NewSuite(m).
 		Label(label.Multicluster, label.Flaky).
 		RequireMinClusters(2).
-		Setup(multicluster.SetupApps(apps)).
 		Setup(kube.Setup(func(s *kube.Settings) {
 			// Make CentralIstiod run on first cluster, all others are remotes which use centralIstiod's pilot
 			s.ControlPlaneTopology = make(map[resource.ClusterIndex]resource.ClusterIndex)
@@ -95,6 +94,11 @@ values:
   global:
     centralIstiod: true`
 		})).
+		Setup(func(ctx resource.Context) error {
+			var err error
+			apps, err = multicluster.SetupApps(ctx)
+			return err
+		}).
 		Run()
 }
 

--- a/tests/integration/multicluster/centralistio/main_test.go
+++ b/tests/integration/multicluster/centralistio/main_test.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	ist    istio.Instance
-	appCtx *multicluster.AppContext
+	appCtx multicluster.AppContext
 )
 
 func TestMain(m *testing.M) {
@@ -35,7 +35,7 @@ func TestMain(m *testing.M) {
 		NewSuite(m).
 		Label(label.Multicluster, label.Flaky).
 		RequireMinClusters(2).
-		Setup(multicluster.Setup(appCtx)).
+		Setup(multicluster.Setup(&appCtx)).
 		Setup(kube.Setup(func(s *kube.Settings) {
 			// Make CentralIstiod run on first cluster, all others are remotes which use centralIstiod's pilot
 			s.ControlPlaneTopology = make(map[resource.ClusterIndex]resource.ClusterIndex)
@@ -95,7 +95,7 @@ values:
   global:
     centralIstiod: true`
 		})).
-		Setup(multicluster.SetupApps(appCtx)).
+		Setup(multicluster.SetupApps(&appCtx)).
 		Run()
 }
 

--- a/tests/integration/multicluster/centralistio/main_test.go
+++ b/tests/integration/multicluster/centralistio/main_test.go
@@ -20,16 +20,14 @@ import (
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/istio"
-	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/tests/integration/multicluster"
 )
 
 var (
-	ist                              istio.Instance
-	clusterLocalNS, mcReachabilityNS namespace.Instance
-	controlPlaneValues               string
+	ist  istio.Instance
+	apps *multicluster.Apps
 )
 
 func TestMain(m *testing.M) {
@@ -37,7 +35,7 @@ func TestMain(m *testing.M) {
 		NewSuite(m).
 		Label(label.Multicluster, label.Flaky).
 		RequireMinClusters(2).
-		Setup(multicluster.Setup(&controlPlaneValues, &clusterLocalNS, &mcReachabilityNS)).
+		Setup(multicluster.SetupApps(apps)).
 		Setup(kube.Setup(func(s *kube.Settings) {
 			// Make CentralIstiod run on first cluster, all others are remotes which use centralIstiod's pilot
 			s.ControlPlaneTopology = make(map[resource.ClusterIndex]resource.ClusterIndex)
@@ -53,7 +51,7 @@ func TestMain(m *testing.M) {
 
 			// Set the control plane values on the config.
 			// For ingress, add port 15017 to the default list of ports.
-			cfg.ControlPlaneValues = controlPlaneValues + `
+			cfg.ControlPlaneValues = `
   global:
     centralIstiod: true
     caAddress: istiod.istio-system.svc:15012
@@ -101,9 +99,13 @@ values:
 }
 
 func TestMulticlusterReachability(t *testing.T) {
-	multicluster.ReachabilityTest(t, mcReachabilityNS, "installation.multicluster.central-istiod")
+	multicluster.ReachabilityTest(t, apps, "installation.multicluster.central-istiod")
+}
+
+func TestCrossClusterLoadbalancing(t *testing.T) {
+	multicluster.LoadbalancingTest(t, apps, "installation.multicluster.central-istiod")
 }
 
 func TestClusterLocalService(t *testing.T) {
-	multicluster.ClusterLocalTest(t, clusterLocalNS, "installation.multicluster.central-istiod")
+	multicluster.ClusterLocalTest(t, apps, "installation.multicluster.central-istiod")
 }

--- a/tests/integration/multicluster/cluster_local.go
+++ b/tests/integration/multicluster/cluster_local.go
@@ -77,12 +77,11 @@ func ClusterLocalTest(t *testing.T, apps *Apps, features ...features.Feature) {
 }
 
 const clusterLocalConfig = `
-defaultConfig:
-  serviceSettings: 
-    - settings:
-        clusterLocal: true
-      hosts:
-      - "*.%s.svc.cluster.local"
+serviceSettings: 
+- settings:
+    clusterLocal: true
+  hosts:
+  - "*.%s.svc.cluster.local"
 `
 
 func clusterLocalMeshConfigOrFail(ctx framework.TestContext, ns namespace.Instance) map[resource.ClusterIndex]string {

--- a/tests/integration/multicluster/cluster_local.go
+++ b/tests/integration/multicluster/cluster_local.go
@@ -15,9 +15,9 @@
 package multicluster
 
 import (
-	"istio.io/istio/pkg/test/echo/client"
 	"testing"
 
+	"istio.io/istio/pkg/test/echo/client"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/features"

--- a/tests/integration/multicluster/cluster_local.go
+++ b/tests/integration/multicluster/cluster_local.go
@@ -47,7 +47,7 @@ func ClusterLocalTest(t *testing.T, apps *Apps, features ...features.Feature) {
 
 				for _, c := range ctx.Clusters() {
 					c := c
-					ctx.NewSubTest(fmt.Sprintf("%s", c.Name())).
+					ctx.NewSubTest(c.Name()).
 						Label(label.Multicluster).
 						RunParallel(func(ctx framework.TestContext) {
 							local := apps.LBEchos.GetOrFail(ctx, echo.InCluster(c))

--- a/tests/integration/multicluster/cluster_local.go
+++ b/tests/integration/multicluster/cluster_local.go
@@ -15,53 +15,113 @@
 package multicluster
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
-	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/features"
 	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/istio/pkg/util/protomarshal"
 )
 
 // ClusterLocalTest tests that traffic works within a local cluster while in a multicluster configuration
-// clusterLocalNS have been configured in meshConfig.serviceSettings to be clusterLocal.
-func ClusterLocalTest(t *testing.T, clusterLocalNS namespace.Instance, features ...features.Feature) {
+// ClusterLocalNS have been configured in meshConfig.serviceSettings to be clusterLocal.
+func ClusterLocalTest(t *testing.T, apps *Apps, features ...features.Feature) {
 	framework.NewTest(t).
 		Features(features...).
 		Run(func(ctx framework.TestContext) {
 			ctx.NewSubTest("respect-cluster-local-config").Run(func(ctx framework.TestContext) {
-				clusters := ctx.Environment().Clusters()
-				for i := range clusters {
-					i := i
-					ctx.NewSubTest(fmt.Sprintf("cluster-%d cluster local", i)).
+				// turn off cross-cluster load balancing for the namespace
+				oldMeshCfg := clusterLocalMeshConfigOrFail(ctx, apps.Namespace)
+				defer restoreMeshConfigOrFail(ctx, oldMeshCfg)
+
+				for _, c := range ctx.Clusters() {
+					c := c
+					ctx.NewSubTest(fmt.Sprintf("%s", c.Name())).
 						Label(label.Multicluster).
 						RunParallel(func(ctx framework.TestContext) {
-							local := clusters[i]
-
-							// Deploy src only in local, but dst in all clusters. dst in remote clusters shouldn't be hit
-							srcName, dstName := fmt.Sprintf("src-%d", i), fmt.Sprintf("dst-%d", i)
-							var src, dst echo.Instance
-							builder := echoboot.NewBuilder(ctx).
-								With(&src, newEchoConfig(srcName, clusterLocalNS, local)).
-								With(&dst, newEchoConfig(dstName, clusterLocalNS, local))
-							for j, remoteCluster := range clusters {
-								if i == j {
-									continue
+							local := apps.LBEchos.GetOrFail(ctx, echo.InCluster(c))
+							retry.UntilSuccessOrFail(ctx, func() error {
+								results, err := local.Call(echo.CallOptions{
+									Target:   local,
+									PortName: "http",
+									Scheme:   scheme.HTTP,
+									Count:    15,
+								})
+								if err == nil {
+									err = results.CheckOK()
 								}
-								var ref echo.Instance
-								builder = builder.With(&ref, newEchoConfig(dstName, clusterLocalNS, remoteCluster))
-							}
-							builder.BuildOrFail(ctx)
-
-							results := callOrFail(ctx, src, dst)
-
-							// Ensure that all requests went to the local cluster.
-							results.CheckClusterOrFail(ctx, local.Name())
+								if err != nil {
+									return fmt.Errorf("%s to %s:%s using %s: expected success but failed: %v",
+										local.Config().Service, local.Config().Service, "http", scheme.HTTP, err)
+								}
+								if err := results.CheckCluster(c.Name()); err != nil {
+									return err
+								}
+								return nil
+							}, retry.Timeout(retryTimeout), retry.Delay(retryDelay))
 						})
 				}
 			})
 		})
+}
+
+const clusterLocalConfig = `
+defaultConfig:
+  serviceSettings: 
+    - settings:
+        clusterLocal: true
+      hosts:
+      - "*.%s.svc.cluster.local"
+`
+
+func clusterLocalMeshConfigOrFail(ctx framework.TestContext, ns namespace.Instance) map[resource.ClusterIndex]string {
+	originals := map[resource.ClusterIndex]string{}
+	for _, c := range ctx.Clusters() {
+		cms := c.CoreV1().ConfigMaps(istio.GetOrFail(ctx, ctx).Settings().SystemNamespace)
+		cm, err := cms.Get(context.TODO(), "istio", metav1.GetOptions{})
+		if err != nil {
+			ctx.Fatal(err)
+		}
+		originals[c.Index()] = cm.Data["mesh"]
+		meshConfig := &v1alpha1.MeshConfig{}
+		if err := protomarshal.ApplyYAML(cm.Data["mesh"], meshConfig); err != nil {
+			ctx.Fatal(err)
+		}
+		if err := protomarshal.ApplyYAML(fmt.Sprintf(clusterLocalConfig, ns.Name()), meshConfig); err != nil {
+			ctx.Fatal(err)
+		}
+		cm.Data["mesh"], err = protomarshal.ToYAML(meshConfig)
+		if err != nil {
+			ctx.Fatal(err)
+		}
+		if _, err := cms.Update(context.TODO(), cm, metav1.UpdateOptions{}); err != nil {
+			ctx.Fatal(err)
+		}
+	}
+	return originals
+}
+
+func restoreMeshConfigOrFail(ctx framework.TestContext, originals map[resource.ClusterIndex]string) {
+	for _, c := range ctx.Clusters() {
+		cms := c.CoreV1().ConfigMaps(istio.GetOrFail(ctx, ctx).Settings().SystemNamespace)
+		cm, err := cms.Get(context.TODO(), "istio", metav1.GetOptions{})
+		if err != nil {
+			ctx.Fatal(err)
+		}
+		cm.Data["mesh"] = originals[c.Index()]
+		if _, err := cms.Update(context.TODO(), cm, metav1.UpdateOptions{}); err != nil {
+			ctx.Fatal(err)
+		}
+	}
 }

--- a/tests/integration/multicluster/cluster_local.go
+++ b/tests/integration/multicluster/cluster_local.go
@@ -15,112 +15,33 @@
 package multicluster
 
 import (
-	"context"
-	"fmt"
+	"istio.io/istio/pkg/test/echo/client"
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"istio.io/api/mesh/v1alpha1"
-	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
-	"istio.io/istio/pkg/test/framework/components/istio"
-	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/features"
 	"istio.io/istio/pkg/test/framework/label"
-	"istio.io/istio/pkg/test/framework/resource"
-	"istio.io/istio/pkg/test/util/retry"
-	"istio.io/istio/pkg/util/protomarshal"
 )
 
 // ClusterLocalTest tests that traffic works within a local cluster while in a multicluster configuration
 // ClusterLocalNS have been configured in meshConfig.serviceSettings to be clusterLocal.
-func ClusterLocalTest(t *testing.T, apps *Apps, features ...features.Feature) {
+func ClusterLocalTest(t *testing.T, apps *AppContext, features ...features.Feature) {
 	framework.NewTest(t).
 		Features(features...).
 		Run(func(ctx framework.TestContext) {
 			ctx.NewSubTest("respect-cluster-local-config").Run(func(ctx framework.TestContext) {
-				// turn off cross-cluster load balancing for the namespace
-				oldMeshCfg := clusterLocalMeshConfigOrFail(ctx, apps.Namespace)
-				defer restoreMeshConfigOrFail(ctx, oldMeshCfg)
-
 				for _, c := range ctx.Clusters() {
 					c := c
 					ctx.NewSubTest(c.Name()).
 						Label(label.Multicluster).
-						RunParallel(func(ctx framework.TestContext) {
-							local := apps.LBEchos.GetOrFail(ctx, echo.InCluster(c))
-							retry.UntilSuccessOrFail(ctx, func() error {
-								results, err := local.Call(echo.CallOptions{
-									Target:   local,
-									PortName: "http",
-									Scheme:   scheme.HTTP,
-									Count:    15,
-								})
-								if err == nil {
-									err = results.CheckOK()
-								}
-								if err != nil {
-									return fmt.Errorf("%s to %s:%s using %s: expected success but failed: %v",
-										local.Config().Service, local.Config().Service, "http", scheme.HTTP, err)
-								}
-								if err := results.CheckCluster(c.Name()); err != nil {
-									return err
-								}
-								return nil
-							}, retry.Timeout(retryTimeout), retry.Delay(retryDelay))
+						Run(func(ctx framework.TestContext) {
+							local := apps.LocalEchos.GetOrFail(ctx, echo.InCluster(c))
+							callOrFail(ctx, local, local, func(responses client.ParsedResponses) error {
+								return responses.CheckCluster(c.Name())
+							})
 						})
 				}
 			})
 		})
-}
-
-const clusterLocalConfig = `
-serviceSettings: 
-- settings:
-    clusterLocal: true
-  hosts:
-  - "*.%s.svc.cluster.local"
-`
-
-func clusterLocalMeshConfigOrFail(ctx framework.TestContext, ns namespace.Instance) map[resource.ClusterIndex]string {
-	originals := map[resource.ClusterIndex]string{}
-	for _, c := range ctx.Clusters() {
-		cms := c.CoreV1().ConfigMaps(istio.GetOrFail(ctx, ctx).Settings().SystemNamespace)
-		cm, err := cms.Get(context.TODO(), "istio", metav1.GetOptions{})
-		if err != nil {
-			ctx.Fatal(err)
-		}
-		originals[c.Index()] = cm.Data["mesh"]
-		meshConfig := &v1alpha1.MeshConfig{}
-		if err := protomarshal.ApplyYAML(cm.Data["mesh"], meshConfig); err != nil {
-			ctx.Fatal(err)
-		}
-		if err := protomarshal.ApplyYAML(fmt.Sprintf(clusterLocalConfig, ns.Name()), meshConfig); err != nil {
-			ctx.Fatal(err)
-		}
-		cm.Data["mesh"], err = protomarshal.ToYAML(meshConfig)
-		if err != nil {
-			ctx.Fatal(err)
-		}
-		if _, err := cms.Update(context.TODO(), cm, metav1.UpdateOptions{}); err != nil {
-			ctx.Fatal(err)
-		}
-	}
-	return originals
-}
-
-func restoreMeshConfigOrFail(ctx framework.TestContext, originals map[resource.ClusterIndex]string) {
-	for _, c := range ctx.Clusters() {
-		cms := c.CoreV1().ConfigMaps(istio.GetOrFail(ctx, ctx).Settings().SystemNamespace)
-		cm, err := cms.Get(context.TODO(), "istio", metav1.GetOptions{})
-		if err != nil {
-			ctx.Fatal(err)
-		}
-		cm.Data["mesh"] = originals[c.Index()]
-		if _, err := cms.Update(context.TODO(), cm, metav1.UpdateOptions{}); err != nil {
-			ctx.Fatal(err)
-		}
-	}
 }

--- a/tests/integration/multicluster/cluster_local.go
+++ b/tests/integration/multicluster/cluster_local.go
@@ -26,7 +26,7 @@ import (
 
 // ClusterLocalTest tests that traffic works within a local cluster while in a multicluster configuration
 // ClusterLocalNS have been configured in meshConfig.serviceSettings to be clusterLocal.
-func ClusterLocalTest(t *testing.T, apps *AppContext, features ...features.Feature) {
+func ClusterLocalTest(t *testing.T, apps AppContext, features ...features.Feature) {
 	framework.NewTest(t).
 		Features(features...).
 		Run(func(ctx framework.TestContext) {

--- a/tests/integration/multicluster/helper.go
+++ b/tests/integration/multicluster/helper.go
@@ -97,7 +97,7 @@ func callOrFail(ctx test.Failer, src, dest echo.Instance) client.ParsedResponses
 			Target:   dest,
 			PortName: "http",
 			Scheme:   scheme.HTTP,
-			Count:    5,
+			Count:    15,
 		})
 		if err == nil {
 			err = results.CheckOK()

--- a/tests/integration/multicluster/helper.go
+++ b/tests/integration/multicluster/helper.go
@@ -63,7 +63,7 @@ func SetupApps(ctx resource.Context) (*Apps, error) {
 
 	builder := echoboot.NewBuilder(ctx)
 	for _, cluster := range ctx.Clusters() {
-		builder.With(nil, newEchoConfig("echolb", apps.Namespace, c))
+		builder.With(nil, newEchoConfig("echolb", apps.Namespace, cluster))
 		for i := 0; i < uniqSvcPerCluster; i++ {
 			svcName := fmt.Sprintf("echo-%d-%d", cluster.Index(), i)
 			builder = builder.With(nil, newEchoConfig(svcName, apps.Namespace, cluster))

--- a/tests/integration/multicluster/helper.go
+++ b/tests/integration/multicluster/helper.go
@@ -16,10 +16,10 @@ package multicluster
 
 import (
 	"fmt"
+	"istio.io/istio/pkg/test/framework"
 	"time"
 
 	"istio.io/istio/pkg/config/protocol"
-	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/echo/client"
 	"istio.io/istio/pkg/test/echo/common/scheme"
 	"istio.io/istio/pkg/test/framework/components/echo"
@@ -148,7 +148,7 @@ func newEchoConfig(service string, ns namespace.Instance, cluster resource.Clust
 
 type callChecker func(client.ParsedResponses) error
 
-func callOrFail(ctx test.Failer, src, dest echo.Instance, checkers ...callChecker) client.ParsedResponses {
+func callOrFail(ctx framework.TestContext, src, dest echo.Instance, checkers ...callChecker) client.ParsedResponses {
 	ctx.Helper()
 	var results client.ParsedResponses
 	retry.UntilSuccessOrFail(ctx, func() (err error) {
@@ -156,7 +156,7 @@ func callOrFail(ctx test.Failer, src, dest echo.Instance, checkers ...callChecke
 			Target:   dest,
 			PortName: "http",
 			Scheme:   scheme.HTTP,
-			Count:    15,
+			Count:    10*len(ctx.Clusters()),
 		})
 
 		checkers = append([]callChecker{func(responses client.ParsedResponses) error {

--- a/tests/integration/multicluster/helper.go
+++ b/tests/integration/multicluster/helper.go
@@ -38,6 +38,8 @@ type AppContext struct {
 	apps
 	Namespace      namespace.Instance
 	LocalNamespace namespace.Instance
+	// ControlPlaneValues to set during istio deploy
+	ControlPlaneValues string
 }
 
 type apps struct {
@@ -47,8 +49,6 @@ type apps struct {
 	LBEchos echo.Instances
 	// LocalEchos can only be reached from the same cluster
 	LocalEchos echo.Instances
-	// ControlPlaneValues to set during istio deploy
-	ControlPlaneValues string
 }
 
 // Setup initialize app context with control plane values and namespaces

--- a/tests/integration/multicluster/helper.go
+++ b/tests/integration/multicluster/helper.go
@@ -16,12 +16,12 @@ package multicluster
 
 import (
 	"fmt"
-	"istio.io/istio/pkg/test/framework"
 	"time"
 
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/echo/client"
 	"istio.io/istio/pkg/test/echo/common/scheme"
+	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
 	"istio.io/istio/pkg/test/framework/components/namespace"
@@ -156,7 +156,7 @@ func callOrFail(ctx framework.TestContext, src, dest echo.Instance, checkers ...
 			Target:   dest,
 			PortName: "http",
 			Scheme:   scheme.HTTP,
-			Count:    10*len(ctx.Clusters()),
+			Count:    10 * len(ctx.Clusters()),
 		})
 
 		checkers = append([]callChecker{func(responses client.ParsedResponses) error {

--- a/tests/integration/multicluster/helper.go
+++ b/tests/integration/multicluster/helper.go
@@ -156,7 +156,7 @@ func callOrFail(ctx framework.TestContext, src, dest echo.Instance, checkers ...
 			Target:   dest,
 			PortName: "http",
 			Scheme:   scheme.HTTP,
-			Count:    10 * len(ctx.Clusters()),
+			Count:    20 * len(ctx.Clusters()),
 		})
 
 		checkers = append([]callChecker{func(responses client.ParsedResponses) error {

--- a/tests/integration/multicluster/helper.go
+++ b/tests/integration/multicluster/helper.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 	"time"
 
-	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
-
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/echo/client"

--- a/tests/integration/multicluster/helper.go
+++ b/tests/integration/multicluster/helper.go
@@ -77,13 +77,11 @@ values:
 	}
 }
 
-// SetupApps depoys echos. The context will be initialized with namespaces and control plane values if it hasn't already.
+// SetupApps depoys echos
 func SetupApps(appCtx *AppContext) resource.SetupFn {
 	return func(ctx resource.Context) error {
-		if appCtx == nil {
-			if err := Setup(appCtx)(ctx); err != nil {
-				return err
-			}
+		if appCtx.Namespace == nil || appCtx.LocalNamespace == nil {
+			return fmt.Errorf("namespaces not initialized; run Setup first")
 		}
 		// set up echos
 		// Running multiple instances in each cluster teases out cases where proxies inconsistently

--- a/tests/integration/multicluster/loadbalancing.go
+++ b/tests/integration/multicluster/loadbalancing.go
@@ -2,33 +2,25 @@ package multicluster
 
 import (
 	"fmt"
-	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
-	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/features"
 	"istio.io/istio/pkg/test/framework/label"
 )
 
-func LoadbalancingTest(t *testing.T, ns namespace.Instance, features ...features.Feature) {
+func LoadbalancingTest(t *testing.T, apps *Apps, features ...features.Feature) {
 	framework.NewTest(t).
 		Label(label.Multicluster).
 		Features(features...).
 		Run(func(ctx framework.TestContext) {
 			ctx.NewSubTest("reachability").
 				Run(func(ctx framework.TestContext) {
-					builder := echoboot.NewBuilder(ctx)
-					for _, c := range ctx.Clusters() {
-						builder.With(nil, newEchoConfig("echolb", ns, c))
-					}
-					echos := builder.BuildOrFail(ctx)
-
-					for _, src := range echos {
+					for _, src := range apps.LBEchos {
 						src := src
 						ctx.NewSubTest(fmt.Sprintf("from %s", src.Config().Cluster.Name())).
 							Run(func(ctx framework.TestContext) {
-								res := callOrFail(ctx, src, echos[0])
+								res := callOrFail(ctx, src, apps.LBEchos[0])
 								// verify we reached all instances by using ParsedResponse
 								clusterHits := map[string]int{}
 								for _, r := range res {

--- a/tests/integration/multicluster/loadbalancing.go
+++ b/tests/integration/multicluster/loadbalancing.go
@@ -73,12 +73,3 @@ func EquallyDistributedOrFail(ctx test.Failer, res client.ParsedResponses, echos
 	//	ctx.Fatalf("requests were not equally distributed among clusters: %v", clusterHits)
 	//}
 }
-
-func almostEquals(a, b, precision int) bool {
-	upper := a + precision
-	lower := a - precision
-	if b < lower || b > upper {
-		return false
-	}
-	return true
-}

--- a/tests/integration/multicluster/loadbalancing.go
+++ b/tests/integration/multicluster/loadbalancing.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package multicluster
 
 import (

--- a/tests/integration/multicluster/loadbalancing.go
+++ b/tests/integration/multicluster/loadbalancing.go
@@ -1,0 +1,44 @@
+package multicluster
+
+import (
+	"fmt"
+	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/features"
+	"istio.io/istio/pkg/test/framework/label"
+)
+
+func LoadbalancingTest(t *testing.T, ns namespace.Instance, features ...features.Feature) {
+	framework.NewTest(t).
+		Label(label.Multicluster).
+		Features(features...).
+		Run(func(ctx framework.TestContext) {
+			ctx.NewSubTest("reachability").
+				Run(func(ctx framework.TestContext) {
+					builder := echoboot.NewBuilder(ctx)
+					for _, c := range ctx.Clusters() {
+						builder.With(nil, newEchoConfig("echolb", ns, c))
+					}
+					echos := builder.BuildOrFail(ctx)
+
+					for _, src := range echos {
+						src := src
+						ctx.NewSubTest(fmt.Sprintf("from %s", src.Config().Cluster.Name())).
+							Run(func(ctx framework.TestContext) {
+								res := callOrFail(ctx, src, echos[0])
+								// verify we reached all instances by using ParsedResponse
+								clusterHits := map[string]int{}
+								for _, r := range res {
+									clusterHits[r.Cluster]++
+								}
+								if len(clusterHits) < len(ctx.Clusters()) {
+									ctx.Fatalf("hit %v; expected %d clusters", clusterHits, len(ctx.Clusters()))
+								}
+							})
+					}
+				})
+		})
+}

--- a/tests/integration/multicluster/loadbalancing.go
+++ b/tests/integration/multicluster/loadbalancing.go
@@ -23,7 +23,7 @@ import (
 	"istio.io/istio/pkg/test/framework/label"
 )
 
-func LoadbalancingTest(t *testing.T, apps *AppContext, features ...features.Feature) {
+func LoadbalancingTest(t *testing.T, apps AppContext, features ...features.Feature) {
 	framework.NewTest(t).
 		Label(label.Multicluster).
 		Features(features...).

--- a/tests/integration/multicluster/loadbalancing.go
+++ b/tests/integration/multicluster/loadbalancing.go
@@ -28,7 +28,7 @@ func LoadbalancingTest(t *testing.T, apps *Apps, features ...features.Feature) {
 		Label(label.Multicluster).
 		Features(features...).
 		Run(func(ctx framework.TestContext) {
-			ctx.NewSubTest("reachability").
+			ctx.NewSubTest("loadbalancing").
 				Run(func(ctx framework.TestContext) {
 					for _, src := range apps.LBEchos {
 						src := src

--- a/tests/integration/multicluster/loadbalancing.go
+++ b/tests/integration/multicluster/loadbalancing.go
@@ -23,7 +23,7 @@ import (
 	"istio.io/istio/pkg/test/framework/label"
 )
 
-func LoadbalancingTest(t *testing.T, apps *Apps, features ...features.Feature) {
+func LoadbalancingTest(t *testing.T, apps *AppContext, features ...features.Feature) {
 	framework.NewTest(t).
 		Label(label.Multicluster).
 		Features(features...).

--- a/tests/integration/multicluster/loadbalancing.go
+++ b/tests/integration/multicluster/loadbalancing.go
@@ -17,7 +17,7 @@ package multicluster
 import (
 	"fmt"
 	"testing"
-	
+
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/echo/client"
 	"istio.io/istio/pkg/test/framework"
@@ -51,18 +51,27 @@ func EquallyDistributedOrFail(ctx test.Failer, res client.ParsedResponses, echos
 	for _, r := range res {
 		clusterHits[r.Cluster]++
 	}
-	equal := true
-	expected := len(res) / len(echos)
+	// TODO(landow) this check can be removed if the other is uncommented
 	for _, inst := range echos {
 		hits := clusterHits[inst.Config().Cluster.Name()]
-		if !almostEquals(hits, expected, expected/5) {
-			equal = false
-			break
+		if hits < 1 {
+			ctx.Fatalf("expected requests to reach all clusters: %v", clusterHits)
 		}
 	}
-	if !equal {
-		ctx.Fatalf("requests were not equally distributed among clusters: %v", clusterHits)
-	}
+
+	// TODO(landow) check this when cross-network traffic weighting is fixed
+	//equal := true
+	//expected := len(res) / len(echos)
+	//for _, inst := range echos {
+	//	hits := clusterHits[inst.Config().Cluster.Name()]
+	//	if !almostEquals(hits, expected, expected/5) {
+	//		equal = false
+	//		break
+	//	}
+	//}
+	//if !equal {
+	//	ctx.Fatalf("requests were not equally distributed among clusters: %v", clusterHits)
+	//}
 }
 
 func almostEquals(a, b, precision int) bool {

--- a/tests/integration/multicluster/reachability.go
+++ b/tests/integration/multicluster/reachability.go
@@ -20,14 +20,12 @@ import (
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
-	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
-	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/features"
 	"istio.io/istio/pkg/test/framework/label"
 )
 
-// ReachabilityTest tests that services in 2 different clusters can talk to each other.
-func ReachabilityTest(t *testing.T, ns namespace.Instance, features ...features.Feature) {
+// ReachabilityTest tests that different services in 2 different clusters can talk to each other.
+func ReachabilityTest(t *testing.T, apps *Apps, features ...features.Feature) {
 	framework.NewTest(t).
 		Label(label.Multicluster).
 		Features(features...).
@@ -35,30 +33,10 @@ func ReachabilityTest(t *testing.T, ns namespace.Instance, features ...features.
 			ctx.NewSubTest("reachability").
 				Run(func(ctx framework.TestContext) {
 					clusters := ctx.Clusters()
-					// Running multiple instances in each cluster teases out cases where proxies inconsistently
-					// use wrong different discovery server. For higher numbers of clusters, we already end up
-					// running plenty of services. (see https://github.com/istio/istio/issues/23591).
-					svcPerCluster := 5 - len(clusters)
-					if svcPerCluster < 1 {
-						svcPerCluster = 1
-					}
-
-					builder := echoboot.NewBuilder(ctx)
-					for _, cluster := range clusters {
-						for i := 0; i < svcPerCluster; i++ {
-							svcName := fmt.Sprintf("echo-%d-%d", cluster.Index(), i)
-							builder = builder.With(nil, newEchoConfig(svcName, ns, cluster))
-						}
-					}
-					echos := builder.BuildOrFail(ctx)
-
-					// Now verify that all services in each cluster can hit one service in each cluster.
-					// Calling 1 service per remote cluster makes the number linear rather than quadratic with
-					// respect to len(clusters) * svcPerCluster.
-					for _, src := range echos {
+					for _, src := range apps.UniqueEchos {
 						for _, dstCluster := range clusters {
 							src := src
-							dest := echos.GetOrFail(ctx, echo.InCluster(dstCluster))
+							dest := apps.UniqueEchos.GetOrFail(ctx, echo.InCluster(dstCluster))
 							subTestName := fmt.Sprintf("%s->%s://%s:%s%s",
 								src.Config().Service,
 								"http",

--- a/tests/integration/multicluster/reachability.go
+++ b/tests/integration/multicluster/reachability.go
@@ -25,7 +25,7 @@ import (
 )
 
 // ReachabilityTest tests that different services in 2 different clusters can talk to each other.
-func ReachabilityTest(t *testing.T, apps *Apps, features ...features.Feature) {
+func ReachabilityTest(t *testing.T, apps *AppContext, features ...features.Feature) {
 	framework.NewTest(t).
 		Label(label.Multicluster).
 		Features(features...).

--- a/tests/integration/multicluster/reachability.go
+++ b/tests/integration/multicluster/reachability.go
@@ -25,7 +25,7 @@ import (
 )
 
 // ReachabilityTest tests that different services in 2 different clusters can talk to each other.
-func ReachabilityTest(t *testing.T, apps *AppContext, features ...features.Feature) {
+func ReachabilityTest(t *testing.T, apps AppContext, features ...features.Feature) {
 	framework.NewTest(t).
 		Label(label.Multicluster).
 		Features(features...).

--- a/tests/integration/multicluster/telemetry.go
+++ b/tests/integration/multicluster/telemetry.go
@@ -21,41 +21,34 @@ import (
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
-	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
-	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/features"
 	"istio.io/istio/pkg/test/framework/label"
 )
 
 // TelemetryTest validates that source and destination labels are collected
 // for multicluster traffic.
-func TelemetryTest(t *testing.T, ns namespace.Instance, features ...features.Feature) {
+func TelemetryTest(t *testing.T, apps Apps, features ...features.Feature) {
 	framework.NewTest(t).
 		Label(label.Multicluster).
 		Features(features...).
 		Run(func(ctx framework.TestContext) {
 			ctx.NewSubTest("telemetry").
 				Run(func(ctx framework.TestContext) {
-					clusters := ctx.Environment().Clusters()
-					builder := echoboot.NewBuilder(ctx)
-					for _, cluster := range clusters {
-						svcName := fmt.Sprintf("echo-%d", cluster.Index())
-						builder = builder.With(nil, newEchoConfig(svcName, ns, cluster))
-					}
-					echos := builder.BuildOrFail(ctx)
-
-					for _, src := range echos {
-						for _, dest := range echos {
+					for _, src := range ctx.Clusters() {
+						for _, dest := range ctx.Clusters() {
 							src, dest := src, dest
 							subTestName := fmt.Sprintf("%s->%s://%s:%s%s",
-								src.Config().Service,
+								src.Name(),
 								"http",
-								dest.Config().Service,
+								dest.Name(),
 								"http",
 								"/")
 
 							ctx.NewSubTest(subTestName).
 								RunParallel(func(ctx framework.TestContext) {
+									src := apps.UniqueEchos.GetOrFail(ctx, echo.InCluster(src))
+									dest := apps.UniqueEchos.GetOrFail(ctx, echo.InCluster(dest))
+
 									_ = callOrFail(ctx, src, dest)
 									validateClusterLabelsInStats(src, t)
 									validateClusterLabelsInStats(dest, t)

--- a/tests/integration/multicluster/telemetry.go
+++ b/tests/integration/multicluster/telemetry.go
@@ -27,7 +27,7 @@ import (
 
 // TelemetryTest validates that source and destination labels are collected
 // for multicluster traffic.
-func TelemetryTest(t *testing.T, apps *AppContext, features ...features.Feature) {
+func TelemetryTest(t *testing.T, apps AppContext, features ...features.Feature) {
 	framework.NewTest(t).
 		Label(label.Multicluster).
 		Features(features...).

--- a/tests/integration/multicluster/telemetry.go
+++ b/tests/integration/multicluster/telemetry.go
@@ -27,7 +27,7 @@ import (
 
 // TelemetryTest validates that source and destination labels are collected
 // for multicluster traffic.
-func TelemetryTest(t *testing.T, apps *Apps, features ...features.Feature) {
+func TelemetryTest(t *testing.T, apps *AppContext, features ...features.Feature) {
 	framework.NewTest(t).
 		Label(label.Multicluster).
 		Features(features...).

--- a/tests/integration/multicluster/telemetry.go
+++ b/tests/integration/multicluster/telemetry.go
@@ -27,7 +27,7 @@ import (
 
 // TelemetryTest validates that source and destination labels are collected
 // for multicluster traffic.
-func TelemetryTest(t *testing.T, apps Apps, features ...features.Feature) {
+func TelemetryTest(t *testing.T, apps *Apps, features ...features.Feature) {
 	framework.NewTest(t).
 		Label(label.Multicluster).
 		Features(features...).


### PR DESCRIPTION
We don't currently test that we distribute traffic between all clusters in reachability. I saw failures I _think_ are related to this in https://github.com/istio/istio/pull/25923. 

Also made it so we share echos as much as possible via an Apps struct (similar to pilot tests)

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
