### PR TITLE
cherry pick 1.7: sync initial resources in order when starting registry (#26142)

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -716,6 +716,9 @@ func (s *Server) waitForCacheSync(stop <-chan struct{}) bool {
 
 // cachesSynced checks whether caches have been synced.
 func (s *Server) cachesSynced() bool {
+	if s.multicluster != nil && !s.multicluster.HasSynced() {
+		return false
+	}
 	if !s.ServiceController().HasSynced() {
 		return false
 	}

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -305,6 +305,10 @@ func NewServer(args *PilotArgs) (*Server, error) {
 		})
 	}
 
+	s.addReadinessProbe("discovery", func() (bool, error) {
+		return s.EnvoyXdsServer.IsServerReady(), nil
+	})
+
 	return s, nil
 }
 
@@ -356,10 +360,9 @@ func (s *Server) Start(stop <-chan struct{}) error {
 		return fmt.Errorf("failed to sync cache")
 	}
 
-	// Trigger a push, so that the global push context is updated with the new config and Pilot's local Envoy
-	// also is updated with new config.
-	log.Infof("All caches have been synced up, triggering a push")
-	s.EnvoyXdsServer.Push(&model.PushRequest{Full: true})
+	// Inform Discovery Server so that it can start accepting connections.
+	log.Infof("All caches have been synced up, marking server ready")
+	s.EnvoyXdsServer.CachesSynced()
 
 	// At this point we are ready - start Http Listener so that it can respond to readiness events.
 	go func() {
@@ -703,19 +706,22 @@ func (s *Server) addTerminatingStartFunc(fn startFunc) {
 }
 
 func (s *Server) waitForCacheSync(stop <-chan struct{}) bool {
-	if !cache.WaitForCacheSync(stop, func() bool {
-		if !s.ServiceController().HasSynced() {
-			return false
-		}
-		if !s.configController.HasSynced() {
-			return false
-		}
-		return true
-	}) {
+	if !cache.WaitForCacheSync(stop, s.cachesSynced) {
 		log.Errorf("Failed waiting for cache sync")
 		return false
 	}
 
+	return true
+}
+
+// cachesSynced checks whether caches have been synced.
+func (s *Server) cachesSynced() bool {
+	if !s.ServiceController().HasSynced() {
+		return false
+	}
+	if !s.configController.HasSynced() {
+		return false
+	}
 	return true
 }
 

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -176,10 +176,10 @@ func (c *Controller) GetService(hostname host.Name) (*model.Service, error) {
 		}
 
 		// This is K8S typically
+		service.Mutex.RLock()
 		if out == nil {
 			out = service.DeepCopy()
 		} else {
-			service.Mutex.RLock()
 			// ClusterExternalAddresses and ClusterExternalPorts are only used for getting gateway address
 			externalAddrs := service.Attributes.ClusterExternalAddresses[r.Cluster()]
 			if len(externalAddrs) > 0 {
@@ -195,8 +195,8 @@ func (c *Controller) GetService(hostname host.Name) (*model.Service, error) {
 				}
 				out.Attributes.ClusterExternalPorts[r.Cluster()] = externalPorts
 			}
-			service.Mutex.RUnlock()
 		}
+		service.Mutex.RUnlock()
 	}
 	return out, errs
 }

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -30,7 +30,6 @@ import (
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
 
 	"istio.io/api/annotation"
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -42,144 +41,14 @@ import (
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/protocol"
-	kubelib "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/retry"
 )
 
 const (
-	testService  = "test"
-	resync       = 1 * time.Second
-	domainSuffix = "company.com"
+	testService = "test"
 )
-
-func (fx *FakeXdsUpdater) ConfigUpdate(*model.PushRequest) {
-	select {
-	case fx.Events <- XdsEvent{Type: "xds"}:
-	default:
-	}
-}
-
-func (fx *FakeXdsUpdater) ProxyUpdate(_, _ string) {
-	select {
-	case fx.Events <- XdsEvent{Type: "proxy"}:
-	default:
-	}
-}
-
-// FakeXdsUpdater is used to test the registry.
-type FakeXdsUpdater struct {
-	// Events tracks notifications received by the updater
-	Events chan XdsEvent
-}
-
-// XdsEvent is used to watch XdsEvents
-type XdsEvent struct {
-	// Type of the event
-	Type string
-
-	// The id of the event
-	ID string
-
-	// The endpoints associated with an EDS push if any
-	Endpoints []*model.IstioEndpoint
-}
-
-// NewFakeXDS creates a XdsUpdater reporting events via a channel.
-func NewFakeXDS() *FakeXdsUpdater {
-	return &FakeXdsUpdater{
-		Events: make(chan XdsEvent, 100),
-	}
-}
-
-func (fx *FakeXdsUpdater) EDSUpdate(_, hostname string, _ string, entry []*model.IstioEndpoint) error {
-	if len(entry) > 0 {
-		select {
-		case fx.Events <- XdsEvent{Type: "eds", ID: hostname, Endpoints: entry}:
-		default:
-		}
-
-	}
-	return nil
-}
-
-// SvcUpdate is called when a service port mapping definition is updated.
-// This interface is WIP - labels, annotations and other changes to service may be
-// updated to force a EDS and CDS recomputation and incremental push, as it doesn't affect
-// LDS/RDS.
-func (fx *FakeXdsUpdater) SvcUpdate(_, hostname string, _ string, _ model.Event) {
-	select {
-	case fx.Events <- XdsEvent{Type: "service", ID: hostname}:
-	default:
-	}
-}
-
-func (fx *FakeXdsUpdater) Wait(et string) *XdsEvent {
-	for {
-		select {
-		case e := <-fx.Events:
-			if e.Type == et {
-				return &e
-			}
-			continue
-		case <-time.After(5 * time.Second):
-			return nil
-		}
-	}
-}
-
-// Clear any pending event
-func (fx *FakeXdsUpdater) Clear() {
-	wait := true
-	for wait {
-		select {
-		case <-fx.Events:
-		default:
-			wait = false
-		}
-	}
-}
-
-type fakeControllerOptions struct {
-	networksWatcher   mesh.NetworksWatcher
-	serviceHandler    func(service *model.Service, event model.Event)
-	instanceHandler   func(instance *model.ServiceInstance, event model.Event)
-	mode              EndpointMode
-	clusterID         string
-	watchedNamespaces string
-}
-
-func newFakeControllerWithOptions(opts fakeControllerOptions) (*Controller, *FakeXdsUpdater) {
-	fx := NewFakeXDS()
-
-	clients := kubelib.NewFakeClient()
-	options := Options{
-		WatchedNamespaces: opts.watchedNamespaces, // default is all namespaces
-		ResyncPeriod:      resync,
-		DomainSuffix:      domainSuffix,
-		XDSUpdater:        fx,
-		Metrics:           &model.Environment{},
-		NetworksWatcher:   opts.networksWatcher,
-		EndpointMode:      opts.mode,
-		ClusterID:         opts.clusterID,
-	}
-	c := NewController(clients, options)
-	if opts.instanceHandler != nil {
-		_ = c.AppendInstanceHandler(opts.instanceHandler)
-	}
-	if opts.serviceHandler != nil {
-		_ = c.AppendServiceHandler(opts.serviceHandler)
-	}
-	c.stop = make(chan struct{})
-	// Run in initiation to prevent calling each test
-	// TODO: fix it, so we can remove `stop` channel
-	go c.Run(c.stop)
-	clients.RunAndWait(c.stop)
-	// Wait for the caches to sync, otherwise we may hit race conditions where events are dropped
-	cache.WaitForCacheSync(c.stop, c.pods.informer.HasSynced, c.serviceInformer.HasSynced, c.endpoints.HasSynced)
-	return c, fx
-}
 
 func TestServices(t *testing.T) {
 
@@ -209,12 +78,12 @@ func TestServices(t *testing.T) {
 	for mode, name := range EndpointModeNames {
 		mode := mode
 		t.Run(name, func(t *testing.T) {
-			ctl, fx := newFakeControllerWithOptions(fakeControllerOptions{networksWatcher: networksWatcher, mode: mode})
+			ctl, fx := NewFakeControllerWithOptions(FakeControllerOptions{NetworksWatcher: networksWatcher, Mode: mode})
 			defer ctl.Stop()
 			t.Parallel()
 			ns := "ns-test"
 
-			hostname := kube.ServiceHostname(testService, ns, domainSuffix)
+			hostname := kube.ServiceHostname(testService, ns, defaultFakeDomainSuffix)
 
 			var sds model.ServiceDiscovery = ctl
 			// "test", ports: http-example on 80
@@ -283,7 +152,7 @@ func TestServices(t *testing.T) {
 				t.Fatalf("Endpoint with IP 10.11.1.2 is expected to be in network2 but get: %s", ep[1].Endpoint.Network)
 			}
 
-			missing := kube.ServiceHostname("does-not-exist", ns, domainSuffix)
+			missing := kube.ServiceHostname("does-not-exist", ns, defaultFakeDomainSuffix)
 			svc, err = sds.GetService(missing)
 			if err != nil {
 				t.Fatalf("GetService(%q) encountered unexpected error: %v", missing, err)
@@ -420,7 +289,7 @@ func TestController_GetPodLocality(t *testing.T) {
 			t.Parallel()
 			// Setup kube caches
 			// Pod locality only matters for Endpoints
-			controller, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: EndpointsOnly})
+			controller, fx := NewFakeControllerWithOptions(FakeControllerOptions{Mode: EndpointsOnly})
 			defer controller.Stop()
 			addNodes(t, controller, tc.nodes...)
 			addPods(t, controller, tc.pods...)
@@ -459,9 +328,9 @@ func TestGetProxyServiceInstances(t *testing.T) {
 	for mode, name := range EndpointModeNames {
 		mode := mode
 		t.Run(name, func(t *testing.T) {
-			controller, fx := newFakeControllerWithOptions(fakeControllerOptions{
-				mode:      mode,
-				clusterID: clusterID,
+			controller, fx := NewFakeControllerWithOptions(FakeControllerOptions{
+				Mode:      mode,
+				ClusterID: clusterID,
 			})
 			defer controller.Stop()
 			p := generatePod("128.0.0.1", "pod1", "nsa", "foo", "node1", map[string]string{"app": "test-app"}, map[string]string{})
@@ -524,7 +393,7 @@ func TestGetProxyServiceInstances(t *testing.T) {
 				t.Fatalf("GetProxyServiceInstances() expected 1 instance, got %d", len(serviceInstances))
 			}
 
-			hostname := kube.ServiceHostname("svc1", "nsa", domainSuffix)
+			hostname := kube.ServiceHostname("svc1", "nsa", defaultFakeDomainSuffix)
 			if serviceInstances[0].Service.Hostname != hostname {
 				t.Fatalf("GetProxyServiceInstances() wrong service instance returned => hostname %q, want %q",
 					serviceInstances[0].Service.Hostname, hostname)
@@ -837,7 +706,7 @@ func TestGetProxyServiceInstancesWithMultiIPsAndTargetPorts(t *testing.T) {
 			mode := mode
 			t.Run(fmt.Sprintf("%s_%s", c.name, name), func(t *testing.T) {
 				// Setup kube caches
-				controller, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: mode})
+				controller, fx := NewFakeControllerWithOptions(FakeControllerOptions{Mode: mode})
 				defer controller.Stop()
 				addPods(t, controller, c.pods...)
 				for _, pod := range c.pods {
@@ -870,13 +739,13 @@ func TestGetProxyServiceInstancesWithMultiIPsAndTargetPorts(t *testing.T) {
 
 func TestController_GetIstioServiceAccounts(t *testing.T) {
 	oldTrustDomain := spiffe.GetTrustDomain()
-	spiffe.SetTrustDomain(domainSuffix)
+	spiffe.SetTrustDomain(defaultFakeDomainSuffix)
 	defer spiffe.SetTrustDomain(oldTrustDomain)
 
 	for mode, name := range EndpointModeNames {
 		mode := mode
 		t.Run(name, func(t *testing.T) {
-			controller, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: mode})
+			controller, fx := NewFakeControllerWithOptions(FakeControllerOptions{Mode: mode})
 			defer controller.Stop()
 
 			sa1 := "acct1"
@@ -917,7 +786,7 @@ func TestController_GetIstioServiceAccounts(t *testing.T) {
 			// We expect only one EDS update with Endpoints.
 			<-fx.Events
 
-			hostname := kube.ServiceHostname("svc1", "nsA", domainSuffix)
+			hostname := kube.ServiceHostname("svc1", "nsA", defaultFakeDomainSuffix)
 			svc, err := controller.GetService(hostname)
 			if err != nil {
 				t.Fatalf("failed to get service: %v", err)
@@ -933,7 +802,7 @@ func TestController_GetIstioServiceAccounts(t *testing.T) {
 				t.Fatalf("Unexpected service accounts %v (expecting %v)", sa, expected)
 			}
 
-			hostname = kube.ServiceHostname("svc2", "nsA", domainSuffix)
+			hostname = kube.ServiceHostname("svc2", "nsA", defaultFakeDomainSuffix)
 			svc, err = controller.GetService(hostname)
 			if err != nil {
 				t.Fatalf("failed to get service: %v", err)
@@ -950,7 +819,7 @@ func TestController_Service(t *testing.T) {
 	for mode, name := range EndpointModeNames {
 		mode := mode
 		t.Run(name, func(t *testing.T) {
-			controller, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: mode})
+			controller, fx := NewFakeControllerWithOptions(FakeControllerOptions{Mode: mode})
 			defer controller.Stop()
 			// Use a timeout to keep the test from hanging.
 
@@ -973,7 +842,7 @@ func TestController_Service(t *testing.T) {
 
 			expectedSvcList := []*model.Service{
 				{
-					Hostname: kube.ServiceHostname("svc1", "nsA", domainSuffix),
+					Hostname: kube.ServiceHostname("svc1", "nsA", defaultFakeDomainSuffix),
 					Address:  "10.0.0.1",
 					Ports: model.PortList{
 						&model.Port{
@@ -984,7 +853,7 @@ func TestController_Service(t *testing.T) {
 					},
 				},
 				{
-					Hostname: kube.ServiceHostname("svc2", "nsA", domainSuffix),
+					Hostname: kube.ServiceHostname("svc2", "nsA", defaultFakeDomainSuffix),
 					Address:  "10.0.0.1",
 					Ports: model.PortList{
 						&model.Port{
@@ -995,7 +864,7 @@ func TestController_Service(t *testing.T) {
 					},
 				},
 				{
-					Hostname: kube.ServiceHostname("svc3", "nsA", domainSuffix),
+					Hostname: kube.ServiceHostname("svc3", "nsA", defaultFakeDomainSuffix),
 					Address:  "10.0.0.1",
 					Ports: model.PortList{
 						&model.Port{
@@ -1006,7 +875,7 @@ func TestController_Service(t *testing.T) {
 					},
 				},
 				{
-					Hostname: kube.ServiceHostname("svc4", "nsA", domainSuffix),
+					Hostname: kube.ServiceHostname("svc4", "nsA", defaultFakeDomainSuffix),
 					Address:  "10.0.0.1",
 					Ports: model.PortList{
 						&model.Port{
@@ -1037,11 +906,12 @@ func TestController_Service(t *testing.T) {
 	}
 }
 
+//
 func TestExternalNameServiceInstances(t *testing.T) {
 	for mode, name := range EndpointModeNames {
 		mode := mode
 		t.Run(name, func(t *testing.T) {
-			controller, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: mode})
+			controller, fx := NewFakeControllerWithOptions(FakeControllerOptions{Mode: mode})
 			defer controller.Stop()
 			createExternalNameService(controller, "svc5", "nsA",
 				[]int32{1, 2, 3}, "foo.co", t, fx.Events)
@@ -1069,9 +939,9 @@ func TestController_ExternalNameService(t *testing.T) {
 		mode := mode
 		t.Run(name, func(t *testing.T) {
 			deleteWg := sync.WaitGroup{}
-			controller, fx := newFakeControllerWithOptions(fakeControllerOptions{
-				mode: mode,
-				serviceHandler: func(_ *model.Service, e model.Event) {
+			controller, fx := NewFakeControllerWithOptions(FakeControllerOptions{
+				Mode: mode,
+				ServiceHandler: func(_ *model.Service, e model.Event) {
 					if e == model.EventDelete {
 						deleteWg.Done()
 					}
@@ -1082,18 +952,18 @@ func TestController_ExternalNameService(t *testing.T) {
 
 			k8sSvcs := []*coreV1.Service{
 				createExternalNameService(controller, "svc1", "nsA",
-					[]int32{8080}, "test-app-1.test.svc."+domainSuffix, t, fx.Events),
+					[]int32{8080}, "test-app-1.test.svc."+defaultFakeDomainSuffix, t, fx.Events),
 				createExternalNameService(controller, "svc2", "nsA",
-					[]int32{8081}, "test-app-2.test.svc."+domainSuffix, t, fx.Events),
+					[]int32{8081}, "test-app-2.test.svc."+defaultFakeDomainSuffix, t, fx.Events),
 				createExternalNameService(controller, "svc3", "nsA",
-					[]int32{8082}, "test-app-3.test.pod."+domainSuffix, t, fx.Events),
+					[]int32{8082}, "test-app-3.test.pod."+defaultFakeDomainSuffix, t, fx.Events),
 				createExternalNameService(controller, "svc4", "nsA",
 					[]int32{8083}, "g.co", t, fx.Events),
 			}
 
 			expectedSvcList := []*model.Service{
 				{
-					Hostname: kube.ServiceHostname("svc1", "nsA", domainSuffix),
+					Hostname: kube.ServiceHostname("svc1", "nsA", defaultFakeDomainSuffix),
 					Ports: model.PortList{
 						&model.Port{
 							Name:     "tcp-port",
@@ -1105,7 +975,7 @@ func TestController_ExternalNameService(t *testing.T) {
 					Resolution:   model.DNSLB,
 				},
 				{
-					Hostname: kube.ServiceHostname("svc2", "nsA", domainSuffix),
+					Hostname: kube.ServiceHostname("svc2", "nsA", defaultFakeDomainSuffix),
 					Ports: model.PortList{
 						&model.Port{
 							Name:     "tcp-port",
@@ -1117,7 +987,7 @@ func TestController_ExternalNameService(t *testing.T) {
 					Resolution:   model.DNSLB,
 				},
 				{
-					Hostname: kube.ServiceHostname("svc3", "nsA", domainSuffix),
+					Hostname: kube.ServiceHostname("svc3", "nsA", defaultFakeDomainSuffix),
 					Ports: model.PortList{
 						&model.Port{
 							Name:     "tcp-port",
@@ -1129,7 +999,7 @@ func TestController_ExternalNameService(t *testing.T) {
 					Resolution:   model.DNSLB,
 				},
 				{
-					Hostname: kube.ServiceHostname("svc4", "nsA", domainSuffix),
+					Hostname: kube.ServiceHostname("svc4", "nsA", defaultFakeDomainSuffix),
 					Ports: model.PortList{
 						&model.Port{
 							Name:     "tcp-port",
@@ -1194,7 +1064,7 @@ func TestController_ExternalNameService(t *testing.T) {
 	}
 }
 
-func createEndpoints(controller *Controller, name, namespace string, portNames, ips []string, refs []*coreV1.ObjectReference, t *testing.T) {
+func createEndpoints(controller *FakeController, name, namespace string, portNames, ips []string, refs []*coreV1.ObjectReference, t *testing.T) {
 	if refs == nil {
 		refs = make([]*coreV1.ObjectReference, len(ips))
 	}
@@ -1263,7 +1133,7 @@ func createEndpoints(controller *Controller, name, namespace string, portNames, 
 	}
 }
 
-func updateEndpoints(controller *Controller, name, namespace string, portNames, ips []string, t *testing.T) {
+func updateEndpoints(controller *FakeController, name, namespace string, portNames, ips []string, t *testing.T) {
 	var portNum int32 = 1001
 	eas := make([]coreV1.EndpointAddress, 0)
 	for _, ip := range ips {
@@ -1314,7 +1184,7 @@ func updateEndpoints(controller *Controller, name, namespace string, portNames, 
 	}
 }
 
-func createServiceWithTargetPorts(controller *Controller, name, namespace string, annotations map[string]string,
+func createServiceWithTargetPorts(controller *FakeController, name, namespace string, annotations map[string]string,
 	svcPorts []coreV1.ServicePort, selector map[string]string, t *testing.T) {
 	service := &coreV1.Service{
 		ObjectMeta: metaV1.ObjectMeta{
@@ -1336,7 +1206,7 @@ func createServiceWithTargetPorts(controller *Controller, name, namespace string
 	}
 }
 
-func createService(controller *Controller, name, namespace string, annotations map[string]string,
+func createService(controller *FakeController, name, namespace string, annotations map[string]string,
 	ports []int32, selector map[string]string, t *testing.T) {
 
 	svcPorts := make([]coreV1.ServicePort, 0)
@@ -1367,7 +1237,7 @@ func createService(controller *Controller, name, namespace string, annotations m
 	}
 }
 
-func createServiceWithoutClusterIP(controller *Controller, name, namespace string, annotations map[string]string,
+func createServiceWithoutClusterIP(controller *FakeController, name, namespace string, annotations map[string]string,
 	ports []int32, selector map[string]string, t *testing.T) {
 
 	svcPorts := make([]coreV1.ServicePort, 0)
@@ -1399,8 +1269,8 @@ func createServiceWithoutClusterIP(controller *Controller, name, namespace strin
 }
 
 // nolint: unparam
-func createExternalNameService(controller *Controller, name, namespace string,
-	ports []int32, externalName string, t *testing.T, xdsEvents <-chan XdsEvent) *coreV1.Service {
+func createExternalNameService(controller *FakeController, name, namespace string,
+	ports []int32, externalName string, t *testing.T, xdsEvents <-chan FakeXdsEvent) *coreV1.Service {
 
 	defer func() {
 		<-xdsEvents
@@ -1433,7 +1303,7 @@ func createExternalNameService(controller *Controller, name, namespace string,
 	return service
 }
 
-func deleteExternalNameService(controller *Controller, name, namespace string, t *testing.T, xdsEvents <-chan XdsEvent) {
+func deleteExternalNameService(controller *FakeController, name, namespace string, t *testing.T, xdsEvents <-chan FakeXdsEvent) {
 
 	defer func() {
 		<-xdsEvents
@@ -1445,7 +1315,7 @@ func deleteExternalNameService(controller *Controller, name, namespace string, t
 	}
 }
 
-func addPods(t *testing.T, controller *Controller, pods ...*coreV1.Pod) {
+func addPods(t *testing.T, controller *FakeController, pods ...*coreV1.Pod) {
 	for _, pod := range pods {
 		p, _ := controller.client.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metaV1.GetOptions{})
 		var newPod *coreV1.Pod
@@ -1512,7 +1382,7 @@ func generateNode(name string, labels map[string]string) *coreV1.Node {
 	}
 }
 
-func addNodes(t *testing.T, controller *Controller, nodes ...*coreV1.Node) {
+func addNodes(t *testing.T, controller *FakeController, nodes ...*coreV1.Node) {
 	fakeClient := controller.client
 
 	for _, node := range nodes {
@@ -1528,7 +1398,7 @@ func TestEndpointUpdate(t *testing.T) {
 	for mode, name := range EndpointModeNames {
 		mode := mode
 		t.Run(name, func(t *testing.T) {
-			controller, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: mode})
+			controller, fx := NewFakeControllerWithOptions(FakeControllerOptions{Mode: mode})
 			defer controller.Stop()
 
 			pod1 := generatePod("128.0.0.1", "pod1", "nsA", "", "node1", map[string]string{"app": "prod-app"}, map[string]string{})
@@ -1594,7 +1464,7 @@ func TestEndpointUpdateBeforePodUpdate(t *testing.T) {
 	for mode, name := range EndpointModeNames {
 		mode := mode
 		t.Run(name, func(t *testing.T) {
-			controller, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: mode})
+			controller, fx := NewFakeControllerWithOptions(FakeControllerOptions{Mode: mode})
 			// Setup kube caches
 			defer controller.Stop()
 			addNodes(t, controller, generateNode("node1", map[string]string{NodeZoneLabel: "zone1", NodeRegionLabel: "region1", IstioSubzoneLabel: "subzone1"}))
@@ -1753,7 +1623,7 @@ func TestEndpointUpdateBeforePodUpdate(t *testing.T) {
 }
 
 func TestWorkloadInstanceHandlerMultipleEndpoints(t *testing.T) {
-	controller, fx := newFakeControllerWithOptions(fakeControllerOptions{})
+	controller, fx := NewFakeControllerWithOptions(FakeControllerOptions{})
 	defer controller.Stop()
 
 	// Create an initial pod with a service, and endpoint.

--- a/pilot/pkg/serviceregistry/kube/controller/fake.go
+++ b/pilot/pkg/serviceregistry/kube/controller/fake.go
@@ -1,0 +1,200 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"errors"
+	"time"
+
+	klabels "k8s.io/apimachinery/pkg/labels"
+	listerv1 "k8s.io/client-go/listers/core/v1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+
+	kubelib "istio.io/istio/pkg/kube"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config/mesh"
+)
+
+const (
+	defaultFakeDomainSuffix = "company.com"
+)
+
+// FakeXdsUpdater is used to test the registry.
+type FakeXdsUpdater struct {
+	// Events tracks notifications received by the updater
+	Events chan FakeXdsEvent
+}
+
+func (fx *FakeXdsUpdater) ConfigUpdate(*model.PushRequest) {
+	select {
+	case fx.Events <- FakeXdsEvent{Type: "xds"}:
+	default:
+	}
+}
+
+func (fx *FakeXdsUpdater) ProxyUpdate(_, _ string) {
+	select {
+	case fx.Events <- FakeXdsEvent{Type: "proxy"}:
+	default:
+	}
+}
+
+// FakeXdsEvent is used to watch XdsEvents
+type FakeXdsEvent struct {
+	// Type of the event
+	Type string
+
+	// The id of the event
+	ID string
+
+	// The endpoints associated with an EDS push if any
+	Endpoints []*model.IstioEndpoint
+}
+
+// NewFakeXDS creates a XdsUpdater reporting events via a channel.
+func NewFakeXDS() *FakeXdsUpdater {
+	return &FakeXdsUpdater{
+		Events: make(chan FakeXdsEvent, 100),
+	}
+}
+
+func (fx *FakeXdsUpdater) EDSUpdate(_, hostname string, _ string, entry []*model.IstioEndpoint) error {
+	if len(entry) > 0 {
+		select {
+		case fx.Events <- FakeXdsEvent{Type: "eds", ID: hostname, Endpoints: entry}:
+		default:
+		}
+
+	}
+	return nil
+}
+
+// SvcUpdate is called when a service port mapping definition is updated.
+// This interface is WIP - labels, annotations and other changes to service may be
+// updated to force a EDS and CDS recomputation and incremental push, as it doesn't affect
+// LDS/RDS.
+func (fx *FakeXdsUpdater) SvcUpdate(_, hostname string, _ string, _ model.Event) {
+	select {
+	case fx.Events <- FakeXdsEvent{Type: "service", ID: hostname}:
+	default:
+	}
+}
+
+func (fx *FakeXdsUpdater) Wait(et string) *FakeXdsEvent {
+	for {
+		select {
+		case e := <-fx.Events:
+			if e.Type == et {
+				return &e
+			}
+			continue
+		case <-time.After(5 * time.Second):
+			return nil
+		}
+	}
+}
+
+// Clear any pending event
+func (fx *FakeXdsUpdater) Clear() {
+	wait := true
+	for wait {
+		select {
+		case <-fx.Events:
+		default:
+			wait = false
+		}
+	}
+}
+
+type FakeControllerOptions struct {
+	Objects           []runtime.Object
+	NetworksWatcher   mesh.NetworksWatcher
+	ServiceHandler    func(service *model.Service, event model.Event)
+	InstanceHandler   func(instance *model.ServiceInstance, event model.Event)
+	Mode              EndpointMode
+	ClusterID         string
+	WatchedNamespaces string
+	DomainSuffix      string
+	XDSUpdater        model.XDSUpdater
+}
+
+type FakeController struct {
+	*Controller
+}
+
+func (f *FakeController) ResyncEndpoints() error {
+	e, ok := f.endpoints.(*endpointsController)
+	if !ok {
+		return errors.New("cannot run ResyncEndpoints; EndpointsMode must be EndpointsOnly")
+	}
+	eps, err := listerv1.NewEndpointsLister(e.informer.GetIndexer()).List(klabels.Everything())
+	if err != nil {
+		return err
+	}
+	// endpoint processing may beat services
+	for _, ep := range eps {
+		err = f.endpoints.onEvent(ep, model.EventAdd)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func NewFakeControllerWithOptions(opts FakeControllerOptions) (*FakeController, *FakeXdsUpdater) {
+	xdsUpdater := opts.XDSUpdater
+	if xdsUpdater == nil {
+		xdsUpdater = NewFakeXDS()
+	}
+
+	domainSuffix := defaultFakeDomainSuffix
+	if opts.DomainSuffix != "" {
+		domainSuffix = opts.DomainSuffix
+	}
+	clients := kubelib.NewFakeClient(opts.Objects...)
+	options := Options{
+		WatchedNamespaces: opts.WatchedNamespaces, // default is all namespaces
+		ResyncPeriod:      1 * time.Second,
+		DomainSuffix:      domainSuffix,
+		XDSUpdater:        xdsUpdater,
+		Metrics:           &model.Environment{},
+		NetworksWatcher:   opts.NetworksWatcher,
+		EndpointMode:      opts.Mode,
+		ClusterID:         opts.ClusterID,
+	}
+	c := NewController(clients, options)
+	if opts.InstanceHandler != nil {
+		_ = c.AppendInstanceHandler(opts.InstanceHandler)
+	}
+	if opts.ServiceHandler != nil {
+		_ = c.AppendServiceHandler(opts.ServiceHandler)
+	}
+	c.stop = make(chan struct{})
+	// Run in initiation to prevent calling each test
+	// TODO: fix it, so we can remove `stop` channel
+	go c.Run(c.stop)
+	clients.RunAndWait(c.stop)
+	// Wait for the caches to sync, otherwise we may hit race conditions where events are dropped
+	cache.WaitForCacheSync(c.stop, c.pods.informer.HasSynced, c.serviceInformer.HasSynced, c.endpoints.HasSynced)
+
+	var fx *FakeXdsUpdater
+	if x, ok := xdsUpdater.(*FakeXdsUpdater); ok {
+		fx = x
+	}
+	return &FakeController{c}, fx
+}

--- a/pilot/pkg/serviceregistry/kube/controller/pod_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod_test.go
@@ -108,7 +108,7 @@ func TestPodCache(t *testing.T) {
 
 // Regression test for https://github.com/istio/istio/issues/20676
 func TestIPReuse(t *testing.T) {
-	c, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: EndpointsOnly})
+	c, fx := NewFakeControllerWithOptions(FakeControllerOptions{Mode: EndpointsOnly})
 	defer c.Stop()
 	initTestEnv(t, c.client, fx)
 
@@ -152,14 +152,14 @@ func TestIPReuse(t *testing.T) {
 	}
 }
 
-func createPod(t *testing.T, c *Controller, ip, name string) {
+func createPod(t *testing.T, c *FakeController, ip, name string) {
 	addPods(t, c, generatePod(ip, name, "ns", "1", "", map[string]string{}, map[string]string{}))
 	if err := waitForPod(c, ip); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func waitForPod(c *Controller, ip string) error {
+func waitForPod(c *FakeController, ip string) error {
 	return wait.Poll(10*time.Millisecond, 5*time.Second, func() (bool, error) {
 		c.pods.RLock()
 		defer c.pods.RUnlock()
@@ -171,9 +171,9 @@ func waitForPod(c *Controller, ip string) error {
 }
 
 func testPodCache(t *testing.T) {
-	c, fx := newFakeControllerWithOptions(fakeControllerOptions{
-		mode:              EndpointsOnly,
-		watchedNamespaces: "nsa,nsb",
+	c, fx := NewFakeControllerWithOptions(FakeControllerOptions{
+		Mode:              EndpointsOnly,
+		WatchedNamespaces: "nsa,nsb",
 	})
 	defer c.Stop()
 
@@ -227,7 +227,7 @@ func testPodCache(t *testing.T) {
 // Checks that events from the watcher create the proper internal structures
 func TestPodCacheEvents(t *testing.T) {
 	t.Parallel()
-	c, fx := newFakeControllerWithOptions(fakeControllerOptions{mode: EndpointsOnly})
+	c, fx := NewFakeControllerWithOptions(FakeControllerOptions{Mode: EndpointsOnly})
 	defer c.Stop()
 
 	ns := "default"

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -118,7 +118,7 @@ func ConvertService(svc coreV1.Service, domainSuffix string, clusterID string) *
 
 	switch svc.Spec.Type {
 	case coreV1.ServiceTypeNodePort:
-		if _, ok := svc.Annotations[NodeSelectorAnnotation]; ok {
+		if _, ok := svc.Annotations[NodeSelectorAnnotation]; !ok {
 			// only do this for istio ingress-gateway services
 			break
 		}

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
@@ -438,6 +438,20 @@ type servicesWithEntry struct {
 	services []*model.Service
 }
 
+// Resync EDS will do a full EDS update. This is needed for some tests where we have many configs loaded without calling
+// the config handlers.
+// This should probably not be used in production code.
+func (s *ServiceEntryStore) ResyncEDS() {
+	s.maybeRefreshIndexes()
+	allInstances := []*model.ServiceInstance{}
+	for _, imap := range s.instances {
+		for _, i := range imap {
+			allInstances = append(allInstances, i...)
+		}
+	}
+	s.edsUpdate(allInstances)
+}
+
 // edsUpdate triggers an EDS update for the given instances
 func (s *ServiceEntryStore) edsUpdate(instances []*model.ServiceInstance) {
 	allInstances := []*model.ServiceInstance{}

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -24,135 +24,20 @@ import (
 
 	"github.com/Masterminds/sprig"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
-	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
 
 	"istio.io/pkg/env"
 
-	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
-	"github.com/golang/protobuf/ptypes"
-
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/pkg/log"
 
 	"istio.io/istio/pilot/pkg/config/kube/crd"
-	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pilot/pkg/networking/core"
-	"istio.io/istio/pilot/pkg/networking/plugin"
-	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
-	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
-	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/collections"
 )
-
-// SetupDiscoveryServer creates a DiscoveryServer with the provided configs using the mem registry
-func SetupDiscoveryServer(t testing.TB, cfgs ...model.Config) *DiscoveryServer {
-	m := mesh.DefaultMeshConfig()
-	env := &model.Environment{
-		Watcher:         mesh.NewFixedWatcher(&m),
-		NetworksWatcher: mesh.NewFixedNetworksWatcher(nil),
-		PushContext:     model.NewPushContext(),
-	}
-	s := NewDiscoveryServer(env, []string{})
-	store := memory.Make(collections.Pilot)
-	configController := memory.NewController(store)
-	istioConfigStore := model.MakeIstioStore(configController)
-	serviceControllers := aggregate.NewController()
-	serviceEntryStore := serviceentry.NewServiceDiscovery(configController, istioConfigStore, s)
-	go configController.Run(make(chan struct{}))
-	serviceControllers.AddRegistry(serviceEntryStore)
-
-	env.IstioConfigStore = istioConfigStore
-	env.ServiceDiscovery = serviceControllers
-
-	for _, cfg := range cfgs {
-		if _, err := configController.Create(cfg); err != nil {
-			t.Fatal(err)
-		}
-	}
-	if err := env.PushContext.InitContext(env, env.PushContext, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := s.UpdateServiceShards(s.globalPushContext()); err != nil {
-		t.Fatalf("Failed to update service shards: %v", err)
-	}
-	return s
-}
-
-func createEndpoints(numEndpoints int, numServices int) []model.Config {
-	result := make([]model.Config, 0, numServices)
-	for s := 0; s < numServices; s++ {
-		endpoints := make([]*networking.WorkloadEntry, 0, numEndpoints)
-		for e := 0; e < numEndpoints; e++ {
-			endpoints = append(endpoints, &networking.WorkloadEntry{Address: fmt.Sprintf("111.%d.%d.%d", e/(256*256), (e/256)%256, e%256)})
-		}
-		result = append(result, model.Config{
-			ConfigMeta: model.ConfigMeta{
-				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind(),
-				Name:              fmt.Sprintf("foo-%d", s),
-				Namespace:         "default",
-				CreationTimestamp: time.Now(),
-			},
-			Spec: &networking.ServiceEntry{
-				Hosts: []string{fmt.Sprintf("foo-%d.com", s)},
-				Ports: []*networking.Port{
-					{Number: 80, Name: "http-port", Protocol: "http"},
-				},
-				Endpoints:  endpoints,
-				Resolution: networking.ServiceEntry_STATIC,
-			},
-		})
-	}
-	return result
-}
-
-func buildTestEnv(t testing.TB, cfgs []model.Config) *model.Environment {
-	configStore := memory.MakeWithLedger(collections.Pilot, &model.DisabledLedger{}, true)
-	for _, cfg := range cfgs {
-		if _, err := configStore.Create(cfg); err != nil {
-			t.Fatalf("failed to create config %v: %v", cfg.Name, err)
-		}
-	}
-
-	stop := make(chan struct{})
-	t.Cleanup(func() {
-		close(stop)
-	})
-	configController := memory.NewController(configStore)
-	go configController.Run(stop)
-	serviceDiscovery := serviceentry.NewServiceDiscovery(configController, model.MakeIstioStore(configStore), &FakeXdsUpdater{})
-
-	m := mesh.DefaultMeshConfig()
-	env := &model.Environment{
-		PushContext:      model.NewPushContext(),
-		ServiceDiscovery: serviceDiscovery,
-		IstioConfigStore: model.MakeIstioStore(configStore),
-		Watcher:          mesh.NewFixedWatcher(&m),
-	}
-
-	return env
-}
-
-type FakeXdsUpdater struct {
-}
-
-func (fx *FakeXdsUpdater) EDSUpdate(_, _ string, _ string, _ []*model.IstioEndpoint) error {
-	return nil
-}
-
-func (fx *FakeXdsUpdater) ConfigUpdate(_ *model.PushRequest) {
-}
-
-func (fx *FakeXdsUpdater) ProxyUpdate(_, _ string) {
-}
-
-func (fx *FakeXdsUpdater) SvcUpdate(_, _ string, _ string, _ model.Event) {
-}
 
 // ConfigInput defines inputs passed to the test config templates
 // This allows tests to do things like create a virtual service for each service, for example
@@ -167,9 +52,156 @@ type ConfigInput struct {
 	ProxyType model.NodeType
 }
 
+var testCases = []ConfigInput{
+	{
+		// Gateways provides an example config for a large Ingress deployment. This will create N
+		// virtual services and gateways, where routing is determined by hostname, meaning we generate N routes for HTTPS.
+		Name:      "gateways",
+		Services:  1000,
+		ProxyType: model.Router,
+	},
+	{
+		// Gateways-shared provides an example config for a large Ingress deployment. This will create N
+		// virtual services and gateways, where routing is determined by path. This means there will be a single large route.
+		Name:      "gateways-shared",
+		Services:  1000,
+		ProxyType: model.Router,
+	},
+	{
+		Name:     "empty",
+		Services: 100,
+	},
+	{
+		Name:     "tls",
+		Services: 100,
+	},
+	{
+		Name:     "telemetry",
+		Services: 100,
+	},
+	{
+		Name:     "virtualservice",
+		Services: 100,
+	},
+}
+
+func BenchmarkInitPushContext(b *testing.B) {
+	for _, tt := range testCases {
+		b.Run(tt.Name, func(b *testing.B) {
+			s, proxy := setupTest(b, tt)
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				initPushContext(s.Env, proxy)
+			}
+		})
+	}
+}
+
+func BenchmarkRouteGeneration(b *testing.B) {
+	for _, tt := range testCases {
+		b.Run(tt.Name, func(b *testing.B) {
+			s, proxy := setupAndInitializeTest(b, tt)
+			// To determine which routes to generate, first gen listeners once (not part of benchmark) and extract routes
+			l := s.Discovery.ConfigGenerator.BuildListeners(proxy, s.PushContext)
+			routeNames := ExtractRoutesFromListeners(l)
+			if len(routeNames) == 0 {
+				b.Fatal("Got no route names!")
+			}
+			b.ResetTimer()
+			var response *discovery.DiscoveryResponse
+			for n := 0; n < b.N; n++ {
+				r := s.Discovery.ConfigGenerator.BuildHTTPRoutes(proxy, s.PushContext, routeNames)
+				if len(r) == 0 {
+					b.Fatal("Got no routes!")
+				}
+				response = routeDiscoveryResponse(r, "", "", v3.RouteType)
+			}
+			logDebug(b, response)
+		})
+	}
+}
+
+func BenchmarkClusterGeneration(b *testing.B) {
+	for _, tt := range testCases {
+		b.Run(tt.Name, func(b *testing.B) {
+			s, proxy := setupAndInitializeTest(b, tt)
+			b.ResetTimer()
+			var response *discovery.DiscoveryResponse
+			for n := 0; n < b.N; n++ {
+				c := s.Discovery.ConfigGenerator.BuildClusters(proxy, s.PushContext)
+				if len(c) == 0 {
+					b.Fatal("Got no clusters!")
+				}
+				response = cdsDiscoveryResponse(c, "", v3.ClusterType)
+			}
+			logDebug(b, response)
+		})
+	}
+}
+
+func BenchmarkListenerGeneration(b *testing.B) {
+	for _, tt := range testCases {
+		b.Run(tt.Name, func(b *testing.B) {
+			s, proxy := setupAndInitializeTest(b, tt)
+			b.ResetTimer()
+			var response *discovery.DiscoveryResponse
+			for n := 0; n < b.N; n++ {
+				l := s.Discovery.ConfigGenerator.BuildListeners(proxy, s.PushContext)
+				if len(l) == 0 {
+					b.Fatal("Got no listeners!")
+				}
+				response = ldsDiscoveryResponse(l, "", "", v3.ListenerType)
+			}
+			logDebug(b, response)
+		})
+	}
+}
+
+// BenchmarkEDS measures performance of EDS config generation
+// TODO Add more variables, such as different services
+func BenchmarkEndpointGeneration(b *testing.B) {
+	tests := []struct {
+		endpoints int
+		services  int
+	}{
+		{1, 100},
+		{10, 10},
+		{100, 10},
+		{1000, 1},
+	}
+	adsLog.SetOutputLevel(log.WarnLevel)
+	var response *discovery.DiscoveryResponse
+	for _, tt := range tests {
+		b.Run(fmt.Sprintf("%d/%d", tt.endpoints, tt.services), func(b *testing.B) {
+			s := NewFakeDiscoveryServer(b, FakeOptions{
+				Configs: createEndpoints(tt.endpoints, tt.services),
+			})
+			proxy := &model.Proxy{
+				Type:            model.SidecarProxy,
+				IPAddresses:     []string{"10.3.3.3"},
+				ID:              "random",
+				ConfigNamespace: "default",
+				Metadata:        &model.NodeMetadata{},
+			}
+			push := s.Discovery.globalPushContext()
+			proxy.SetSidecarScope(push)
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				loadAssignments := make([]*endpoint.ClusterLoadAssignment, 0)
+				for svc := 0; svc < tt.services; svc++ {
+					l := s.Discovery.generateEndpoints(createEndpointBuilder(fmt.Sprintf("outbound|80||foo-%d.com", svc), proxy, push))
+					loadAssignments = append(loadAssignments, l)
+				}
+				response = endpointDiscoveryResponse(loadAssignments, version, push.Version, v3.EndpointType)
+			}
+			logDebug(b, response)
+		})
+	}
+}
+
 // Setup test builds a mock test environment. Note: push context is not initialized, to be able to benchmark separately
 // most should just call setupAndInitializeTest
-func setupTest(t testing.TB, config ConfigInput) (*model.Environment, core.ConfigGenerator, *model.Proxy) {
+func setupTest(t testing.TB, config ConfigInput) (*FakeDiscoveryServer, *model.Proxy) {
 	proxyType := config.ProxyType
 	if proxyType == "" {
 		proxyType = model.SidecarProxy
@@ -193,10 +225,11 @@ func setupTest(t testing.TB, config ConfigInput) (*model.Environment, core.Confi
 	}
 
 	configs := getConfigsWithCache(t, config)
-	env := buildTestEnv(t, configs)
+	s := NewFakeDiscoveryServer(t, FakeOptions{
+		Configs: configs,
+	})
 
-	configgen := core.NewConfigGenerator([]string{plugin.Authn, plugin.Authz, plugin.Health, plugin.Mixer})
-	return env, configgen, proxy
+	return s, proxy
 }
 
 var configCache = map[ConfigInput][]model.Config{}
@@ -234,10 +267,10 @@ func getConfigsWithCache(t testing.TB, input ConfigInput) []model.Config {
 	return configs
 }
 
-func setupAndInitializeTest(t testing.TB, config ConfigInput) (*model.Environment, core.ConfigGenerator, *model.Proxy) {
-	env, configggen, proxy := setupTest(t, config)
-	initPushContext(env, proxy)
-	return env, configggen, proxy
+func setupAndInitializeTest(t testing.TB, config ConfigInput) (*FakeDiscoveryServer, *model.Proxy) {
+	s, proxy := setupTest(t, config)
+	initPushContext(s.Env, proxy)
+	return s, proxy
 }
 
 func initPushContext(env *model.Environment, proxy *model.Proxy) {
@@ -245,61 +278,6 @@ func initPushContext(env *model.Environment, proxy *model.Proxy) {
 	proxy.SetSidecarScope(env.PushContext)
 	proxy.SetGatewaysForProxy(env.PushContext)
 	proxy.SetServiceInstances(env.ServiceDiscovery)
-}
-
-func routesFromListeners(ll []*listener.Listener) []string {
-	routes := []string{}
-	for _, l := range ll {
-		for _, fc := range l.FilterChains {
-			for _, filter := range fc.Filters {
-				if filter.Name == wellknown.HTTPConnectionManager {
-					filter.GetTypedConfig()
-					hcon := &hcm.HttpConnectionManager{}
-					if err := ptypes.UnmarshalAny(filter.GetTypedConfig(), hcon); err != nil {
-						panic(err)
-					}
-					switch r := hcon.GetRouteSpecifier().(type) {
-					case *hcm.HttpConnectionManager_Rds:
-						routes = append(routes, r.Rds.RouteConfigName)
-					}
-				}
-			}
-		}
-	}
-	return routes
-}
-
-var testCases = []ConfigInput{
-	{
-		// Gateways provides an example config for a large Ingress deployment. This will create N
-		// virtual services and gateways, where routing is determined by hostname, meaning we generate N routes for HTTPS.
-		Name:      "gateways",
-		Services:  1000,
-		ProxyType: model.Router,
-	},
-	{
-		// Gateways-shared provides an example config for a large Ingress deployment. This will create N
-		// virtual services and gateways, where routing is determined by path. This means there will be a single large route.
-		Name:      "gateways-shared",
-		Services:  1000,
-		ProxyType: model.Router,
-	},
-	{
-		Name:     "empty",
-		Services: 100,
-	},
-	{
-		Name:     "tls",
-		Services: 100,
-	},
-	{
-		Name:     "telemetry",
-		Services: 100,
-	},
-	{
-		Name:     "virtualservice",
-		Services: 100,
-	},
 }
 
 var debugGeneration = env.RegisterBoolVar("DEBUG_CONFIG_DUMP", false, "if enabled, print a full config dump of the generated config")
@@ -326,115 +304,29 @@ func logDebug(b *testing.B, m *discovery.DiscoveryResponse) {
 	b.StartTimer()
 }
 
-func BenchmarkInitPushContext(b *testing.B) {
-	for _, tt := range testCases {
-		b.Run(tt.Name, func(b *testing.B) {
-			env, _, proxy := setupTest(b, tt)
-			b.ResetTimer()
-			for n := 0; n < b.N; n++ {
-				initPushContext(env, proxy)
-			}
+func createEndpoints(numEndpoints int, numServices int) []model.Config {
+	result := make([]model.Config, 0, numServices)
+	for s := 0; s < numServices; s++ {
+		endpoints := make([]*networking.WorkloadEntry, 0, numEndpoints)
+		for e := 0; e < numEndpoints; e++ {
+			endpoints = append(endpoints, &networking.WorkloadEntry{Address: fmt.Sprintf("111.%d.%d.%d", e/(256*256), (e/256)%256, e%256)})
+		}
+		result = append(result, model.Config{
+			ConfigMeta: model.ConfigMeta{
+				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind(),
+				Name:              fmt.Sprintf("foo-%d", s),
+				Namespace:         "default",
+				CreationTimestamp: time.Now(),
+			},
+			Spec: &networking.ServiceEntry{
+				Hosts: []string{fmt.Sprintf("foo-%d.com", s)},
+				Ports: []*networking.Port{
+					{Number: 80, Name: "http-port", Protocol: "http"},
+				},
+				Endpoints:  endpoints,
+				Resolution: networking.ServiceEntry_STATIC,
+			},
 		})
 	}
-}
-
-func BenchmarkRouteGeneration(b *testing.B) {
-	for _, tt := range testCases {
-		b.Run(tt.Name, func(b *testing.B) {
-			env, configgen, proxy := setupAndInitializeTest(b, tt)
-			// To determine which routes to generate, first gen listeners once (not part of benchmark) and extract routes
-			l := configgen.BuildListeners(proxy, env.PushContext)
-			routeNames := routesFromListeners(l)
-			if len(routeNames) == 0 {
-				b.Fatal("Got no route names!")
-			}
-			b.ResetTimer()
-			var response *discovery.DiscoveryResponse
-			for n := 0; n < b.N; n++ {
-				r := configgen.BuildHTTPRoutes(proxy, env.PushContext, routeNames)
-				if len(r) == 0 {
-					b.Fatal("Got no routes!")
-				}
-				response = routeDiscoveryResponse(r, "", "", v3.RouteType)
-			}
-			logDebug(b, response)
-		})
-	}
-}
-
-func BenchmarkClusterGeneration(b *testing.B) {
-	for _, tt := range testCases {
-		b.Run(tt.Name, func(b *testing.B) {
-			env, configgen, proxy := setupAndInitializeTest(b, tt)
-			b.ResetTimer()
-			var response *discovery.DiscoveryResponse
-			for n := 0; n < b.N; n++ {
-				c := configgen.BuildClusters(proxy, env.PushContext)
-				if len(c) == 0 {
-					b.Fatal("Got no clusters!")
-				}
-				response = cdsDiscoveryResponse(c, "", v3.ClusterType)
-			}
-			logDebug(b, response)
-		})
-	}
-}
-
-func BenchmarkListenerGeneration(b *testing.B) {
-	for _, tt := range testCases {
-		b.Run(tt.Name, func(b *testing.B) {
-			env, configgen, proxy := setupAndInitializeTest(b, tt)
-			b.ResetTimer()
-			var response *discovery.DiscoveryResponse
-			for n := 0; n < b.N; n++ {
-				l := configgen.BuildListeners(proxy, env.PushContext)
-				if len(l) == 0 {
-					b.Fatal("Got no listeners!")
-				}
-				response = ldsDiscoveryResponse(l, "", "", v3.ListenerType)
-			}
-			logDebug(b, response)
-		})
-	}
-}
-
-// BenchmarkEDS measures performance of EDS config generation
-// TODO Add more variables, such as different services
-// TODO make this align more with the other generation tests
-func BenchmarkEndpointGeneration(b *testing.B) {
-	tests := []struct {
-		endpoints int
-		services  int
-	}{
-		{1, 100},
-		{10, 10},
-		{100, 10},
-		{1000, 1},
-	}
-	adsLog.SetOutputLevel(log.WarnLevel)
-	var response interface{}
-	for _, tt := range tests {
-		b.Run(fmt.Sprintf("%d/%d", tt.endpoints, tt.services), func(b *testing.B) {
-			s := SetupDiscoveryServer(b, createEndpoints(tt.endpoints, tt.services)...)
-			proxy := &model.Proxy{
-				Type:            model.SidecarProxy,
-				IPAddresses:     []string{"10.3.3.3"},
-				ID:              "random",
-				ConfigNamespace: "default",
-				Metadata:        &model.NodeMetadata{},
-			}
-			push := s.globalPushContext()
-			proxy.SetSidecarScope(push)
-			b.ResetTimer()
-			for n := 0; n < b.N; n++ {
-				loadAssignments := make([]*endpoint.ClusterLoadAssignment, 0)
-				for svc := 0; svc < tt.services; svc++ {
-					l := s.generateEndpoints(createEndpointBuilder(fmt.Sprintf("outbound|80||foo-%d.com", svc), proxy, push))
-					loadAssignments = append(loadAssignments, l)
-				}
-				response = endpointDiscoveryResponse(loadAssignments, version, push.Version, v3.EndpointType)
-			}
-		})
-	}
-	_ = response
+	return result
 }

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -126,6 +126,9 @@ type DiscoveryServer struct {
 
 	// InternalGen is notified of connect/disconnect/nack on all connections
 	InternalGen *InternalGen
+
+	// serverReady indicates caches have been synced up and server is ready to process requests.
+	serverReady bool
 }
 
 // EndpointShards holds the set of endpoint shards of a service. Registries update
@@ -161,6 +164,7 @@ func NewDiscoveryServer(env *model.Environment, plugins []string) *DiscoveryServ
 		DebugConfigs:            features.DebugConfigs,
 		debugHandlers:           map[string]string{},
 		adsClients:              map[string]*Connection{},
+		serverReady:             false,
 	}
 
 	if features.XDSAuth {
@@ -187,6 +191,19 @@ func (s *DiscoveryServer) Register(rpcs *grpc.Server) {
 	// Register v2 and v3 servers
 	discovery.RegisterAggregatedDiscoveryServiceServer(rpcs, s)
 	discoveryv2.RegisterAggregatedDiscoveryServiceServer(rpcs, s.createV2Adapter())
+}
+
+// CachesSynced is called when caches have been synced so that server can accept connections.
+func (s *DiscoveryServer) CachesSynced() {
+	s.updateMutex.Lock()
+	s.serverReady = true
+	s.updateMutex.Unlock()
+}
+
+func (s *DiscoveryServer) IsServerReady() bool {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	return s.serverReady
 }
 
 func (s *DiscoveryServer) Start(stopCh <-chan struct{}) {

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -17,6 +17,7 @@ package xds
 import (
 	"bytes"
 	"reflect"
+	"strings"
 	"text/template"
 
 	"github.com/Masterminds/sprig"
@@ -30,6 +31,9 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+
 	meshconfig "istio.io/api/mesh/v1alpha1"
 
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -40,6 +44,8 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
+	kube "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/collections"
@@ -47,6 +53,10 @@ import (
 )
 
 type FakeOptions struct {
+	// If provided, these objects will be used directly
+	KubernetesObjects []runtime.Object
+	// If provided, the yaml string will be parsed and used as objects
+	KubernetesObjectString string
 	// If provided, these configs will be used directly
 	Configs []model.Config
 	// If provided, the yaml string will be parsed and used as configs
@@ -64,6 +74,27 @@ type FakeDiscoveryServer struct {
 	Discovery   *DiscoveryServer
 	PushContext *model.PushContext
 	Env         *model.Environment
+}
+
+func getKubernetesObjects(t test.Failer, opts FakeOptions) []runtime.Object {
+	if len(opts.KubernetesObjects) > 0 {
+		return opts.KubernetesObjects
+	}
+
+	objects := make([]runtime.Object, 0)
+	if len(opts.KubernetesObjectString) > 0 {
+		decode := scheme.Codecs.UniversalDeserializer().Decode
+		objectStrs := strings.Split(opts.KubernetesObjectString, "---")
+		for _, s := range objectStrs {
+			o, _, err := decode([]byte(s), nil, nil)
+			if err != nil {
+				t.Fatalf("failed deserializing kubernetes object: %v", err)
+			}
+			objects = append(objects, o)
+		}
+	}
+
+	return objects
 }
 
 func getConfigs(t test.Failer, opts FakeOptions) []model.Config {
@@ -102,6 +133,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		close(stop)
 	})
 	configs := getConfigs(t, opts)
+	k8sObjects := getKubernetesObjects(t, opts)
 	configStore := memory.MakeWithLedger(collections.Pilot, &model.DisabledLedger{}, true)
 	env := &model.Environment{}
 	plugins := []string{plugin.Authn, plugin.Authz, plugin.Health, plugin.Mixer}
@@ -119,13 +151,6 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	}()
 	configController := memory.NewSyncController(configStore)
 	go configController.Run(stop)
-	serviceDiscovery := serviceentry.NewServiceDiscovery(configController, model.MakeIstioStore(configStore), s)
-	for _, cfg := range configs {
-		if _, err := configStore.Create(cfg); err != nil {
-			t.Fatalf("failed to create config %v: %v", cfg.Name, err)
-		}
-	}
-	serviceDiscovery.ResyncEDS()
 
 	m := opts.MeshConfig
 	if m == nil {
@@ -133,16 +158,36 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		m = &def
 	}
 
+	serviceDiscovery := aggregate.NewController()
 	env.PushContext = model.NewPushContext()
 	env.ServiceDiscovery = serviceDiscovery
 	env.IstioConfigStore = model.MakeIstioStore(configStore)
 	env.Watcher = mesh.NewFixedWatcher(m)
 	env.NetworksWatcher = mesh.NewFixedNetworksWatcher(opts.MeshNetworks)
 
-	if err := env.PushContext.InitContext(env, nil, nil); err != nil {
-		t.Fatal(err)
+	se := serviceentry.NewServiceDiscovery(configController, model.MakeIstioStore(configStore), s)
+	serviceDiscovery.AddRegistry(se)
+	k8s, _ := kube.NewFakeControllerWithOptions(kube.FakeControllerOptions{
+		Objects:         k8sObjects,
+		ClusterID:       "Kubernetes",
+		DomainSuffix:    "cluster.local",
+		XDSUpdater:      s,
+		NetworksWatcher: env,
+	})
+	serviceDiscovery.AddRegistry(k8s)
+	for _, cfg := range configs {
+		if _, err := configStore.Create(cfg); err != nil {
+			t.Fatalf("failed to create config %v: %v", cfg.Name, err)
+		}
 	}
 	if err := s.UpdateServiceShards(env.PushContext); err != nil {
+		t.Fatal(err)
+	}
+	se.ResyncEDS()
+	if err := k8s.ResyncEndpoints(); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.PushContext.InitContext(env, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pilot/pkg/xds/simple.go
+++ b/pilot/pkg/xds/simple.go
@@ -87,6 +87,7 @@ func NewXDS() *SimpleServer {
 	env.PushContext.Mesh = env.Watcher.Mesh()
 
 	ds := NewDiscoveryServer(env, nil)
+	ds.CachesSynced()
 
 	// Config will have a fixed format:
 	// - aggregate store

--- a/pilot/pkg/xds/xds_test.go
+++ b/pilot/pkg/xds/xds_test.go
@@ -22,9 +22,15 @@ import (
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/rand"
+
 	meshconfig "istio.io/api/mesh/v1alpha1"
 
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/env"
@@ -301,50 +307,74 @@ func TestSidecarListeners(t *testing.T) {
 }
 
 func TestMeshNetworking(t *testing.T) {
-	s := NewFakeDiscoveryServer(t, FakeOptions{
-		KubernetesObjectString: `
-apiVersion: v1
-kind: Pod
-metadata:
-  name: kubeapp-1234
-  namespace: pod
-  labels:
-    app: kubeapp
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: kubeapp
-  namespace: pod
-spec:
-  clusterIP: 1.2.3.4
-  selector:
-    app: kubeapp
-  ports:
-  - port: 80
-    name: http
-    protocol: TCP
----
-apiVersion: v1
-kind: Endpoints
-metadata:
-  name: kubeapp
-  namespace: pod
-  labels:
-    app: kubeapp
-subsets:
-- addresses:
-  - ip: 10.10.10.20
-    targetRef:
-      kind: Pod
-      name: kubeapp-1234
-      namespace: pod
-  ports:
-  - port: 80
-    name: http
-    protocol: TCP
-`,
-		ConfigString: `
+	ingresses := []*corev1.Service{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "istio-ingressgateway",
+				Namespace: "istio-system",
+			},
+			Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+			Status: corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{{IP: "2.2.2.2"}}},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "istio-ingressgateway",
+				Namespace:   "istio-system",
+				Annotations: map[string]string{kube.NodeSelectorAnnotation: "{}"},
+			},
+			Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeNodePort, Ports: []corev1.ServicePort{{Port: 15443, NodePort: 25443}}},
+			Status: corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{{IP: "8.8.8.8"}}}, // 2.2.2.2 should be found on the node
+			},
+		},
+	}
+
+	meshNetworkConfigs := map[string]*meshconfig.MeshNetworks{
+		"gateway-address": {Networks: map[string]*meshconfig.Network{
+			// Explicitly set address
+			"network-1": {
+				Endpoints: []*meshconfig.Network_NetworkEndpoints{{
+					Ne: &meshconfig.Network_NetworkEndpoints_FromRegistry{FromRegistry: "Kubernetes"},
+				}},
+				Gateways: []*meshconfig.Network_IstioNetworkGateway{{
+					Gw:   &meshconfig.Network_IstioNetworkGateway_Address{Address: "2.2.2.2"},
+					Port: 15443,
+				}},
+			},
+		}},
+		"gateway-registryServiceName": {Networks: map[string]*meshconfig.Network{
+			// Address from service
+			"network-1": {
+				Endpoints: []*meshconfig.Network_NetworkEndpoints{{
+					Ne: &meshconfig.Network_NetworkEndpoints_FromRegistry{FromRegistry: "Kubernetes"},
+				}},
+				Gateways: []*meshconfig.Network_IstioNetworkGateway{{
+					Gw: &meshconfig.Network_IstioNetworkGateway_RegistryServiceName{
+						RegistryServiceName: "istio-ingressgateway.istio-system.svc.cluster.local",
+					},
+					Port: 15443,
+				}},
+			},
+		}},
+	}
+
+	for _, ingr := range ingresses {
+		t.Run(string(ingr.Spec.Type), func(t *testing.T) {
+			for name, networkConfig := range meshNetworkConfigs {
+				t.Run(name, func(t *testing.T) {
+
+					var k8sObjects []runtime.Object
+					k8sObjects = append(k8sObjects,
+						// NodePort ingress needs this
+						&corev1.Node{Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeExternalIP, Address: "2.2.2.2"}}}},
+						ingr)
+					k8sObjects = append(k8sObjects, fakePodService(fakeServiceOpts{name: "kubeapp", ns: "pod", ip: "10.10.10.20"})...)
+
+					s := NewFakeDiscoveryServer(t, FakeOptions{
+						KubernetesObjects: k8sObjects,
+						ConfigString: `
 apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
@@ -384,82 +414,75 @@ spec:
       app: httpbin
     network: vm
 `,
-		MeshNetworks: &meshconfig.MeshNetworks{Networks: map[string]*meshconfig.Network{
-			"network-1": {
-				Endpoints: []*meshconfig.Network_NetworkEndpoints{{
-					Ne: &meshconfig.Network_NetworkEndpoints_FromRegistry{FromRegistry: "Kubernetes"},
-				}},
-				Gateways: []*meshconfig.Network_IstioNetworkGateway{{
-					Gw:       &meshconfig.Network_IstioNetworkGateway_Address{Address: "2.2.2.2"},
-					Port:     15443,
-					Locality: "",
-				}},
-			},
-		}},
-	})
-	se := s.SetupProxy(&model.Proxy{
-		ID: "se-pod.pod",
-		Metadata: &model.NodeMetadata{
-			Network:   "network-1",
-			ClusterID: "Kubernetes",
-			Labels:    labels.Instance{"app": "se-pod"},
-		},
-	})
-	pod := s.SetupProxy(&model.Proxy{
-		ID: "kubeapp-1234.pod",
-		Metadata: &model.NodeMetadata{
-			Network:   "network-1",
-			ClusterID: "Kubernetes",
-			Labels:    labels.Instance{"app": "kubeapp"},
-		},
-	})
-	vm := s.SetupProxy(&model.Proxy{
-		ID:              "vm",
-		IPAddresses:     []string{"10.10.10.10"},
-		ConfigNamespace: "default",
-		Metadata: &model.NodeMetadata{
-			Network:          "vm",
-			InterceptionMode: "NONE",
-		},
-	})
+						MeshNetworks: networkConfig,
+					})
+					se := s.SetupProxy(&model.Proxy{
+						ID: "se-pod.pod",
+						Metadata: &model.NodeMetadata{
+							Network:   "network-1",
+							ClusterID: "Kubernetes",
+							Labels:    labels.Instance{"app": "se-pod"},
+						},
+					})
+					pod := s.SetupProxy(&model.Proxy{
+						ID: "kubeapp-1234.pod",
+						Metadata: &model.NodeMetadata{
+							Network:   "network-1",
+							ClusterID: "Kubernetes",
+							Labels:    labels.Instance{"app": "kubeapp"},
+						},
+					})
+					vm := s.SetupProxy(&model.Proxy{
+						ID:              "vm",
+						IPAddresses:     []string{"10.10.10.10"},
+						ConfigNamespace: "default",
+						Metadata: &model.NodeMetadata{
+							Network:          "vm",
+							InterceptionMode: "NONE",
+						},
+					})
 
-	tests := []struct {
-		p      *model.Proxy
-		expect map[string]string
-	}{
-		{
-			p: pod,
-			expect: map[string]string{
-				"outbound|7070||httpbin.com":                 "10.10.10.10",
-				"outbound|80||kubeapp.pod.svc.cluster.local": "10.10.10.20",
-				"outbound|80||se-pod.pod.svc.cluster.local":  "10.10.10.30",
-			},
-		},
-		{
-			p: se,
-			expect: map[string]string{
-				"outbound|7070||httpbin.com":                 "10.10.10.10",
-				"outbound|80||kubeapp.pod.svc.cluster.local": "10.10.10.20",
-				"outbound|80||se-pod.pod.svc.cluster.local":  "10.10.10.30",
-			},
-		},
-		{
-			p: vm,
-			expect: map[string]string{
-				"outbound|7070||httpbin.com":                 "10.10.10.10",
-				"outbound|80||kubeapp.pod.svc.cluster.local": "2.2.2.2",
-				"outbound|80||se-pod.pod.svc.cluster.local":  "2.2.2.2",
-			},
-		},
-	}
+					tests := []struct {
+						p      *model.Proxy
+						expect map[string]string
+					}{
+						{
+							p: pod,
+							expect: map[string]string{
+								"outbound|7070||httpbin.com":                 "10.10.10.10",
+								"outbound|80||kubeapp.pod.svc.cluster.local": "10.10.10.20",
+								"outbound|80||se-pod.pod.svc.cluster.local":  "10.10.10.30",
+							},
+						},
+						{
+							p: se,
+							expect: map[string]string{
+								"outbound|7070||httpbin.com":                 "10.10.10.10",
+								"outbound|80||kubeapp.pod.svc.cluster.local": "10.10.10.20",
+								"outbound|80||se-pod.pod.svc.cluster.local":  "10.10.10.30",
+							},
+						},
+						{
+							p: vm,
+							expect: map[string]string{
+								"outbound|7070||httpbin.com":                 "10.10.10.10",
+								"outbound|80||kubeapp.pod.svc.cluster.local": "2.2.2.2",
+								"outbound|80||se-pod.pod.svc.cluster.local":  "2.2.2.2",
+							},
+						},
+					}
 
-	for _, tt := range tests {
-		eps := ExtractEndpoints(s.Endpoints(tt.p))
-		for c, ip := range tt.expect {
-			t.Run(fmt.Sprintf("%s from %s", c, vm.ID), func(t *testing.T) {
-				assertListEqual(t, eps[c], []string{ip})
-			})
-		}
+					for _, tt := range tests {
+						eps := ExtractEndpoints(s.Endpoints(tt.p))
+						for c, ip := range tt.expect {
+							t.Run(fmt.Sprintf("%s from %s", c, tt.p.ID), func(t *testing.T) {
+								assertListEqual(t, eps[c], []string{ip})
+							})
+						}
+					}
+				})
+			}
+		})
 	}
 }
 
@@ -547,6 +570,75 @@ spec:
 	}
 	if !found {
 		t.Fatalf("failed to find expected fallthrough route")
+	}
+}
+
+type fakeServiceOpts struct {
+	name         string
+	ns           string
+	ip           string
+	podLabels    labels.Instance
+	servicePorts []corev1.ServicePort
+}
+
+// fakePodService build the minimal k8s objects required to discover one endpoint.
+// If servicePorts is empty a default of http-80 will be used.
+func fakePodService(opts fakeServiceOpts) []runtime.Object {
+	baseMeta := metav1.ObjectMeta{
+		Name:      opts.name,
+		Labels:    labels.Instance{"app": opts.name},
+		Namespace: opts.ns,
+	}
+	podMeta := baseMeta
+	podMeta.Name = opts.name + "-" + rand.String(4)
+	for k, v := range opts.podLabels {
+		podMeta.Labels[k] = v
+	}
+
+	if len(opts.servicePorts) == 0 {
+		opts.servicePorts = []corev1.ServicePort{{
+			Port:     80,
+			Name:     "http",
+			Protocol: corev1.ProtocolTCP,
+		}}
+	}
+	var endpointPorts []corev1.EndpointPort
+	for _, sp := range opts.servicePorts {
+		endpointPorts = append(endpointPorts, corev1.EndpointPort{
+			Name:        sp.Name,
+			Port:        sp.Port,
+			Protocol:    sp.Protocol,
+			AppProtocol: sp.AppProtocol,
+		})
+	}
+
+	return []runtime.Object{
+		&corev1.Pod{
+			ObjectMeta: podMeta,
+		},
+		&corev1.Service{
+			ObjectMeta: baseMeta,
+			Spec: corev1.ServiceSpec{
+				ClusterIP: "1.2.3.4", // just can't be 0.0.0.0/ClusterIPNone
+				Selector:  baseMeta.Labels,
+				Ports:     opts.servicePorts,
+			},
+		},
+		&corev1.Endpoints{
+			ObjectMeta: baseMeta,
+			Subsets: []corev1.EndpointSubset{{
+				Addresses: []corev1.EndpointAddress{{
+					IP: opts.ip,
+					TargetRef: &corev1.ObjectReference{
+						APIVersion: "v1",
+						Kind:       "Pod",
+						Name:       podMeta.Name,
+						Namespace:  podMeta.Namespace,
+					},
+				}},
+				Ports: endpointPorts,
+			}},
+		},
 	}
 }
 

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -175,9 +175,9 @@ var _ ExtendedClient = &client{}
 
 const resyncInterval = 0
 
-func NewFakeClient() Client {
+func NewFakeClient(objects ...runtime.Object) Client {
 	var c client
-	c.Interface = fake.NewSimpleClientset()
+	c.Interface = fake.NewSimpleClientset(objects...)
 	c.kube = c.Interface
 	c.kubeInformer = informers.NewSharedInformerFactory(c.Interface, resyncInterval)
 

--- a/pkg/kube/secretcontroller/secretcontroller.go
+++ b/pkg/kube/secretcontroller/secretcontroller.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -40,9 +41,9 @@ import (
 )
 
 const (
+	initialSyncSignal       = "INIT"
 	MultiClusterSecretLabel = "istio/multiCluster"
-
-	maxRetries = 5
+	maxRetries              = 5
 )
 
 // addSecretCallback prototype for the add secret callback function.
@@ -64,6 +65,9 @@ type Controller struct {
 	addCallback    addSecretCallback
 	updateCallback updateSecretCallback
 	removeCallback removeSecretCallback
+
+	mu          sync.RWMutex
+	initialSync bool
 }
 
 // RemoteCluster defines cluster struct
@@ -169,7 +173,15 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 		utilruntime.HandleError(fmt.Errorf("timed out waiting for caches to sync"))
 		return
 	}
+	// all secret events before this signal must be processed before we're marked "ready"
+	c.queue.Add(initialSyncSignal)
 	wait.Until(c.runWorker, 5*time.Second, stopCh)
+}
+
+func (c *Controller) HasSynced() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.initialSync
 }
 
 // StartSecretController creates the secret controller.
@@ -191,7 +203,6 @@ func (c *Controller) runWorker() {
 
 func (c *Controller) processNextItem() bool {
 	secretName, quit := c.queue.Get()
-
 	if quit {
 		return false
 	}
@@ -214,6 +225,13 @@ func (c *Controller) processNextItem() bool {
 }
 
 func (c *Controller) processItem(secretName string) error {
+	if secretName == initialSyncSignal {
+		c.mu.Lock()
+		c.initialSync = true
+		c.mu.Unlock()
+		return nil
+	}
+
 	obj, exists, err := c.informer.GetIndexer().GetByKey(secretName)
 	if err != nil {
 		return fmt.Errorf("error fetching object %s error: %v", secretName, err)

--- a/releasenotes/notes/fix-nodeport-meshnetwork.yaml
+++ b/releasenotes/notes/fix-nodeport-meshnetwork.yaml
@@ -1,0 +1,5 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+releaseNotes: |
+  *Fixed* an issue preventing NodePort services from being used as the `registryServiceName` in `meshNetworks`.


### PR DESCRIPTION
Needed several of these to deal with merge conflicts, and #25733 is a related change

* ecea62332c - sync initial resources in order when starting registry (#26142)
* ec4543d655 - fix mesh network flakes (#26085)
* d8ec4c4a1a - fix NodePort services for meshNetworks gateway (#25990)
* 87ac93277f - add: ensure envoys can only connect after caches have been synced (#25733)
* 004d8582f6 - test kube ServiceRegistry in xds_test (#25698)
* 7453483b10 - Refactor benchmark test (#25671)

-- I may be able to reduce the amount pulled in but it may not include tests/be tricky to pull the tests in. 

cc @JimmyCYJ 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure



Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
