### PR TITLE
Package precompiled wasm files and make option available

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -214,6 +214,8 @@ for plugin in stats metadata_exchange
 do
   FILTER_WASM_URL="${ISTIO_ENVOY_BASE_URL}/${plugin}-${ISTIO_ENVOY_VERSION}.wasm"
   download_wasm_if_necessary "${FILTER_WASM_URL}" "${WASM_RELEASE_DIR}"/"${plugin//_/-}"-filter.wasm
+  FILTER_WASM_URL="${ISTIO_ENVOY_BASE_URL}/${plugin}-${ISTIO_ENVOY_VERSION}.compiled.wasm"
+  download_wasm_if_necessary "${FILTER_WASM_URL}" "${WASM_RELEASE_DIR}"/"${plugin//_/-}"-filter.compiled.wasm
 done
 
 # Copy native envoy binary to ISTIO_OUT

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1187,6 +1187,7 @@ spec:
                       inline_string: "envoy.wasm.stats"
 ---
 # Source: istio-discovery/templates/telemetryv2_1.7.yaml
+# Note: metadata exchange filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -1198,7 +1199,61 @@ spec:
   configPatches:
     - applyTo: HTTP_FILTER
       match:
-        context: ANY # inbound, outbound, and gateway
+        context: SIDECAR_INBOUND
+        proxy:
+          proxyVersion: '^1\.7.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.metadata_exchange
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                configuration:
+                  "@type": "type.googleapis.com/google.protobuf.StringValue"
+                  value: |
+                    {}
+                vm_config:
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: envoy.wasm.metadata_exchange
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_OUTBOUND
+        proxy:
+          proxyVersion: '^1\.7.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.metadata_exchange
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                configuration:
+                  "@type": "type.googleapis.com/google.protobuf.StringValue"
+                  value: |
+                    {}
+                vm_config:
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: envoy.wasm.metadata_exchange
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
         proxy:
           proxyVersion: '^1\.7.*'
         listener:
@@ -1283,6 +1338,7 @@ spec:
                 protocol: istio-peer-exchange
 ---
 # Source: istio-discovery/templates/telemetryv2_1.7.yaml
+# Note: http stats filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -1397,6 +1453,7 @@ spec:
                       inline_string: envoy.wasm.stats
 ---
 # Source: istio-discovery/templates/telemetryv2_1.7.yaml
+# Note: tcp stats filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.7.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.7.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.telemetry.enabled .Values.telemetry.v2.enabled }}
+# Note: metadata exchange filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -14,7 +15,7 @@ spec:
   configPatches:
     - applyTo: HTTP_FILTER
       match:
-        context: ANY # inbound, outbound, and gateway
+        context: SIDECAR_INBOUND
         proxy:
           proxyVersion: '^1\.7.*'
         listener:
@@ -37,15 +38,78 @@ spec:
                 vm_config:
                   {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/metadata-exchange-filter.wasm
+                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: envoy.wasm.metadata_exchange
                   {{- end }}
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_OUTBOUND
+        proxy:
+          proxyVersion: '^1\.7.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.metadata_exchange
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                configuration:
+                  "@type": "type.googleapis.com/google.protobuf.StringValue"
+                  value: |
+                    {}
+                vm_config:
+                  {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
+                  runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
+                  code:
+                    local:
+                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
+                  {{- else }}
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: envoy.wasm.metadata_exchange
+                  {{- end }}
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        proxy:
+          proxyVersion: '^1\.7.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.metadata_exchange
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                configuration:
+                  "@type": "type.googleapis.com/google.protobuf.StringValue"
+                  value: |
+                    {}
+                vm_config:
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: envoy.wasm.metadata_exchange
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -108,6 +172,7 @@ spec:
               value:
                 protocol: istio-peer-exchange
 ---
+# Note: http stats filter is wasm enabled only in sidecars.
 {{- if .Values.telemetry.v2.prometheus.enabled }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -167,9 +232,10 @@ spec:
                   vm_id: stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
+                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -221,9 +287,10 @@ spec:
                   vm_id: stats_inbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
+                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -274,18 +341,12 @@ spec:
                     {{- end }}
                 vm_config:
                   vm_id: stats_outbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
-                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: envoy.wasm.stats
-                  {{- end }}
 ---
+# Note: tcp stats filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -342,9 +403,10 @@ spec:
                   vm_id: tcp_stats_inbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
+                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -394,9 +456,10 @@ spec:
                   vm_id: tcp_stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
+                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -444,17 +507,10 @@ spec:
                     {{- end }}
                 vm_config:
                   vm_id: tcp_stats_outbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
-                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: "envoy.wasm.stats"
-                  {{- end }}
 ---
 
 {{- end }}
@@ -736,6 +792,6 @@ spec:
                   code:
                     local: { inline_string: "envoy.wasm.access_log_policy" }
 ---
-{{- end }}
-{{- end }}
-{{- end }}
+{{- end}}
+{{- end}}
+{{- end}}

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.7.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.7.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.telemetry.enabled .Values.telemetry.v2.enabled }}
+# Note: metadata exchange filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -14,7 +15,7 @@ spec:
   configPatches:
     - applyTo: HTTP_FILTER
       match:
-        context: ANY # inbound, outbound, and gateway
+        context: SIDECAR_INBOUND
         proxy:
           proxyVersion: '^1\.7.*'
         listener:
@@ -37,15 +38,78 @@ spec:
                 vm_config:
                   {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/metadata-exchange-filter.wasm
+                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: envoy.wasm.metadata_exchange
                   {{- end }}
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_OUTBOUND
+        proxy:
+          proxyVersion: '^1\.7.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.metadata_exchange
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                configuration:
+                  "@type": "type.googleapis.com/google.protobuf.StringValue"
+                  value: |
+                    {}
+                vm_config:
+                  {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
+                  runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
+                  code:
+                    local:
+                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
+                  {{- else }}
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: envoy.wasm.metadata_exchange
+                  {{- end }}
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        proxy:
+          proxyVersion: '^1\.7.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.metadata_exchange
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                configuration:
+                  "@type": "type.googleapis.com/google.protobuf.StringValue"
+                  value: |
+                    {}
+                vm_config:
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: envoy.wasm.metadata_exchange
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -108,6 +172,7 @@ spec:
               value:
                 protocol: istio-peer-exchange
 ---
+# Note: http stats filter is wasm enabled only in sidecars.
 {{- if .Values.telemetry.v2.prometheus.enabled }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
@@ -167,9 +232,10 @@ spec:
                   vm_id: stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
+                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -221,9 +287,10 @@ spec:
                   vm_id: stats_inbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
+                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -274,18 +341,12 @@ spec:
                     {{- end }}
                 vm_config:
                   vm_id: stats_outbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
-                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: envoy.wasm.stats
-                  {{- end }}
 ---
+# Note: tcp stats filter is wasm enabled only in sidecars.
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -342,9 +403,10 @@ spec:
                   vm_id: tcp_stats_inbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
+                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -394,9 +456,10 @@ spec:
                   vm_id: tcp_stats_outbound
                   {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
                   runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
                   code:
                     local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
+                      filename: /etc/istio/extensions/stats-filter.compiled.wasm
                   {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
@@ -444,17 +507,10 @@ spec:
                     {{- end }}
                 vm_config:
                   vm_id: tcp_stats_outbound
-                  {{- if .Values.telemetry.v2.prometheus.wasmEnabled }}
-                  runtime: envoy.wasm.runtime.v8
-                  code:
-                    local:
-                      filename: /etc/istio/extensions/stats-filter.wasm
-                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: "envoy.wasm.stats"
-                  {{- end }}
 ---
 
 {{- end }}
@@ -736,6 +792,6 @@ spec:
                   code:
                     local: { inline_string: "envoy.wasm.access_log_policy" }
 ---
-{{- end }}
-{{- end }}
-{{- end }}
+{{- end}}
+{{- end}}
+{{- end}}

--- a/manifests/profiles/default.yaml
+++ b/manifests/profiles/default.yaml
@@ -334,9 +334,11 @@ spec:
         enabled: false
       v2:
         enabled: true
-        metadataExchange: {}
+        metadataExchange:
+          wasmEnabled: false
         prometheus:
           enabled: true
+          wasmEnabled: false
         stackdriver:
           enabled: false
           logging: false

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -49,7 +49,9 @@ COPY pilot-agent /usr/local/bin/pilot-agent
 COPY envoy_policy.yaml.tmpl /var/lib/istio/envoy/envoy_policy.yaml.tmpl
 
 COPY stats-filter.wasm /etc/istio/extensions/stats-filter.wasm
+COPY stats-filter.compiled.wasm /etc/istio/extensions/stats-filter.compiled.wasm
 COPY metadata-exchange-filter.wasm /etc/istio/extensions/metadata-exchange-filter.wasm
+COPY metadata-exchange-filter.compiled.wasm /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
 
 # The pilot-agent will bootstrap Envoy.
 ENTRYPOINT ["/usr/local/bin/pilot-agent"]

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -78,7 +78,9 @@ ${ISTIO_ENVOY_BOOTSTRAP_CONFIG_DIR}/envoy_bootstrap.json: ${ISTIO_ENVOY_BOOTSTRA
 
 # rule for wasm extensions.
 $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/stats-filter.wasm: init
+$(ISTIO_ENVOY_LINUX_RELEASE_DIR)/stats-filter.compiled.wasm: init
 $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/metadata-exchange-filter.wasm: init
+$(ISTIO_ENVOY_LINUX_RELEASE_DIR)/metadata-exchange-filter.compiled.wasm: init
 
 # Default proxy image.
 docker.proxyv2: BUILD_PRE=&& chmod 755 ${SIDECAR} pilot-agent
@@ -90,7 +92,9 @@ docker.proxyv2: $(ISTIO_OUT_LINUX)/pilot-agent
 docker.proxyv2: pilot/docker/Dockerfile.proxyv2
 docker.proxyv2: pilot/docker/envoy_policy.yaml.tmpl
 docker.proxyv2: $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/stats-filter.wasm
+docker.proxyv2: $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/stats-filter.compiled.wasm
 docker.proxyv2: $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/metadata-exchange-filter.wasm
+docker.proxyv2: $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/metadata-exchange-filter.compiled.wasm
 	$(DOCKER_RULE)
 
 docker.pilot: BUILD_PRE=&& chmod 755 pilot-discovery cacert.pem

--- a/tools/packaging/deb/istio.mk
+++ b/tools/packaging/deb/istio.mk
@@ -9,6 +9,9 @@ deb: ${ISTIO_OUT_LINUX}/release/istio-sidecar.deb ${ISTIO_OUT_LINUX}/release/ist
 # Base directory for istio binaries. Likely to change !
 ISTIO_DEB_BIN=/usr/local/bin
 
+# Home directory of istio-proxy user. It is symlinked /etc/istio --> /var/lib/istio
+ISTIO_PROXY_HOME=/var/lib/istio
+
 ISTIO_DEB_DEPS:=pilot-discovery istioctl
 ISTIO_FILES:=
 $(foreach DEP,$(ISTIO_DEB_DEPS),\
@@ -32,6 +35,13 @@ $(foreach DEST,$(ISTIO_DEB_DEST),\
 
 SIDECAR_FILES+=${REPO_ROOT}/tools/packaging/common/envoy_bootstrap.json=/var/lib/istio/envoy/envoy_bootstrap_tmpl.json
 
+ISTIO_EXTENSIONS:=stats-filter.wasm \
+                  stats-filter.compiled.wasm \
+                  metadata-exchange-filter.wasm \
+                  metadata-exchange-filter.compiled.wasm
+
+$(foreach EXT,$(ISTIO_EXTENSIONS),\
+        $(eval SIDECAR_FILES+=${ISTIO_ENVOY_LINUX_RELEASE_DIR}/$(EXT)=$(ISTIO_PROXY_HOME)/extensions/$(EXT)))
 
 # original name used in 0.2 - will be updated to 'istio.deb' since it now includes all istio binaries.
 ISTIO_DEB_NAME ?= istio-sidecar


### PR DESCRIPTION
manual cherry-pick of #25589

1. Package precompiled wasm images
2. Create `wasmEnabled` option with default `false`.

This PR *DOES NOT* turn on wasm/v8 for istio stats, but makes it available for experimentation.

@PiotrSikora @kyessenov 