### PR TITLE
remove unused field for sidecarInjectorWebhook

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -183,7 +183,6 @@ data:
       "sidecarInjectorWebhook": {
         "alwaysInjectSelector": [],
         "enableNamespacesByDefault": false,
-        "injectLabel": "istio-injection",
         "injectedAnnotations": {},
         "neverInjectSelector": [],
         "objectSelector": {

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -90,10 +90,6 @@ sidecarInjectorWebhook:
   # Only one environment should have this enabled.
   enableNamespacesByDefault: false
 
-  # If set, will use the value as injection label. The value must match the 'release' label of the injector,
-  # except when 1.2 istio-injection label is used, which must be set to "enabled".
-  injectLabel: istio-injection
-
   # Enable objectSelector to filter out pods with no need for sidecar before calling istio-sidecar-injector.
   # It is disabled by default since this function will only work after k8s v1.15.
   objectSelector:

--- a/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -165,7 +165,6 @@ data:
         "alwaysInjectSelector": [],
         "caBundle": "",
         "enableNamespacesByDefault": false,
-        "injectLabel": "istio-injection",
         "injectedAnnotations": {},
         "neverInjectSelector": [],
         "objectSelector": {

--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -46,10 +46,6 @@ sidecarInjectorWebhook:
   # Only one environment should have this enabled.
   enableNamespacesByDefault: false
 
-  # If set, will use the value as injection label. The value must match the 'release' label of the injector,
-  # except when 1.2 istio-injection label is used, which must be set to "enabled".
-  injectLabel: istio-injection
-
   # Enable objectSelector to filter out pods with no need for sidecar before calling istio-sidecar-injector.
   # It is disabled by default since this function will only work after k8s v1.15.
   objectSelector:

--- a/manifests/profiles/default.yaml
+++ b/manifests/profiles/default.yaml
@@ -301,7 +301,6 @@ spec:
     sidecarInjectorWebhook:
       enableNamespacesByDefault: false
       rewriteAppHTTPProbe: true
-      injectLabel: istio-injection
       objectSelector:
         enabled: false
         autoInject: true

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/values.yaml
@@ -90,10 +90,6 @@ sidecarInjectorWebhook:
   # Only one environment should have this enabled.
   enableNamespacesByDefault: false
 
-  # If set, will use the value as injection label. The value must match the 'release' label of the injector,
-  # except when 1.2 istio-injection label is used, which must be set to "enabled".
-  injectLabel: istio-injection
-
   # Enable objectSelector to filter out pods with no need for sidecar before calling istio-sidecar-injector.
   # It is disabled by default since this function will only work after k8s v1.15.
   objectSelector:

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/values.yaml
@@ -46,10 +46,6 @@ sidecarInjectorWebhook:
   # Only one environment should have this enabled.
   enableNamespacesByDefault: false
 
-  # If set, will use the value as injection label. The value must match the 'release' label of the injector,
-  # except when 1.2 istio-injection label is used, which must be set to "enabled".
-  injectLabel: istio-injection
-
   # Enable objectSelector to filter out pods with no need for sidecar before calling istio-sidecar-injector.
   # It is disabled by default since this function will only work after k8s v1.15.
   objectSelector:

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/profiles/default.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/profiles/default.yaml
@@ -303,7 +303,6 @@ spec:
     sidecarInjectorWebhook:
       enableNamespacesByDefault: false
       rewriteAppHTTPProbe: true
-      injectLabel: istio-injection
       objectSelector:
         enabled: false
         autoInject: true

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -8224,7 +8224,6 @@ data:
       "sidecarInjectorWebhook": {
         "alwaysInjectSelector": [],
         "enableNamespacesByDefault": false,
-        "injectLabel": "istio-injection",
         "injectedAnnotations": {},
         "neverInjectSelector": [],
         "objectSelector": {

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -1214,7 +1214,6 @@ data:
       "sidecarInjectorWebhook": {
         "alwaysInjectSelector": [],
         "enableNamespacesByDefault": false,
-        "injectLabel": "istio-injection",
         "injectedAnnotations": {},
         "neverInjectSelector": [],
         "objectSelector": {

--- a/operator/cmd/mesh/testdata/profile-dump/output/all_off.txt
+++ b/operator/cmd/mesh/testdata/profile-dump/output/all_off.txt
@@ -172,7 +172,6 @@ values.pilot.keepaliveMaxServerConnectionAge="30m"
 values.pilot.replicaCount=1
 values.pilot.traceSampling=1
 values.sidecarInjectorWebhook.enableNamespacesByDefault=false
-values.sidecarInjectorWebhook.injectLabel="istio-injection"
 values.sidecarInjectorWebhook.objectSelector.autoInject=true
 values.sidecarInjectorWebhook.objectSelector.enabled=false
 values.sidecarInjectorWebhook.rewriteAppHTTPProbe=true

--- a/operator/cmd/mesh/testdata/profile-dump/output/all_off.yaml
+++ b/operator/cmd/mesh/testdata/profile-dump/output/all_off.yaml
@@ -273,7 +273,6 @@ spec:
       traceSampling: 1
     sidecarInjectorWebhook:
       enableNamespacesByDefault: false
-      injectLabel: istio-injection
       objectSelector:
         autoInject: true
         enabled: false


### PR DESCRIPTION
resolve: https://github.com/istio/istio/issues/26376
remove unused field: `values.sidecarInjectorWebhook.injectLabel`

[ ] Configuration Infrastructure
[ ] Docs
[ X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.