### PR TITLE
remove clusters, listeners and routes in adsz endpoint

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -51,11 +51,6 @@ var (
 		"Sets the max receive buffer size of gRPC stream in bytes.",
 	).Get()
 
-	// DebugConfigs controls saving snapshots of configs for /debug/adsz.
-	// Defaults to false, can be enabled with PILOT_DEBUG_ADSZ_CONFIG=1
-	// For larger clusters it can increase memory use and GC - useful for small tests.
-	DebugConfigs = env.RegisterBoolVar("PILOT_DEBUG_ADSZ_CONFIG", false, "").Get()
-
 	// FilterGatewayClusterConfig controls if a subset of clusters(only those required) should be pushed to gateways
 	FilterGatewayClusterConfig = env.RegisterBoolVar("PILOT_FILTER_GATEWAY_CLUSTER_CONFIG", false, "").Get()
 

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -21,10 +21,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
-	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -81,11 +78,6 @@ type Connection struct {
 	// Original node metadata, to avoid unmarshal/marshal.
 	// This is included in internal events.
 	node *core.Node
-
-	// Computed Xds data. Mainly used for debug display.
-	XdsListeners []*listener.Listener                 `json:"-"`
-	XdsRoutes    map[string]*route.RouteConfiguration `json:"-"`
-	XdsClusters  []*cluster.Cluster
 }
 
 // Event represents a config or registry event that results in a push.
@@ -110,12 +102,10 @@ type Event struct {
 
 func newConnection(peerAddr string, stream DiscoveryStream) *Connection {
 	return &Connection{
-		pushChannel:  make(chan *Event),
-		PeerAddr:     peerAddr,
-		Connect:      time.Now(),
-		stream:       stream,
-		XdsListeners: []*listener.Listener{},
-		XdsRoutes:    map[string]*route.RouteConfiguration{},
+		pushChannel: make(chan *Event),
+		PeerAddr:    peerAddr,
+		Connect:     time.Now(),
+		stream:      stream,
 	}
 }
 

--- a/pilot/pkg/xds/cds.go
+++ b/pilot/pkg/xds/cds.go
@@ -51,9 +51,6 @@ func (s *DiscoveryServer) pushCds(con *Connection, push *model.PushContext, vers
 	pushStart := time.Now()
 	rawClusters := s.ConfigGenerator.BuildClusters(con.proxy, push)
 
-	if s.DebugConfigs {
-		con.XdsClusters = rawClusters
-	}
 	response := cdsDiscoveryResponse(rawClusters, push.Version)
 	err := con.send(response)
 	cdsPushTime.Record(time.Since(pushStart).Seconds())

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -18,11 +18,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
-	"io"
 	"net/http"
 	"net/http/pprof"
 	"sort"
 	"strings"
+	"time"
 
 	adminapi "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
 	"github.com/golang/protobuf/jsonpb"
@@ -84,6 +84,41 @@ var indexTmpl = template.Must(template.New("index").Parse(`<html>
 </html>
 `))
 
+// AdsClient defines the data that is displayed on "/adsz" endpoint.
+type AdsClient struct {
+	ConnectionID string    `json:"connectionId"`
+	ConnectedAt  time.Time `json:"connectedAt"`
+	PeerAddress  string    `json:"address"`
+}
+
+// AdsClients is collection of AdsClient connected to this Istiod.
+type AdsClients struct {
+	Connected []AdsClient `json:"clients"`
+}
+
+// SyncStatus is the synchronization status between Pilot and a given Envoy
+type SyncStatus struct {
+	ProxyID       string `json:"proxy,omitempty"`
+	ProxyVersion  string `json:"proxy_version,omitempty"`
+	IstioVersion  string `json:"istio_version,omitempty"`
+	ClusterSent   string `json:"cluster_sent,omitempty"`
+	ClusterAcked  string `json:"cluster_acked,omitempty"`
+	ListenerSent  string `json:"listener_sent,omitempty"`
+	ListenerAcked string `json:"listener_acked,omitempty"`
+	RouteSent     string `json:"route_sent,omitempty"`
+	RouteAcked    string `json:"route_acked,omitempty"`
+	EndpointSent  string `json:"endpoint_sent,omitempty"`
+	EndpointAcked string `json:"endpoint_acked,omitempty"`
+}
+
+// SyncedVersions shows what resourceVersion of a given resource has been acked by Envoy.
+type SyncedVersions struct {
+	ProxyID         string `json:"proxy,omitempty"`
+	ClusterVersion  string `json:"cluster_acked,omitempty"`
+	ListenerVersion string `json:"listener_acked,omitempty"`
+	RouteVersion    string `json:"route_acked,omitempty"`
+}
+
 // InitDebug initializes the debug handlers and adds a debug in-memory registry.
 func (s *DiscoveryServer) InitDebug(mux *http.ServeMux, sctl *aggregate.Controller, enableProfiling bool, webhook *inject.Webhook) {
 	// For debugging and load testing v2 we add an memory registry.
@@ -111,7 +146,6 @@ func (s *DiscoveryServer) InitDebug(mux *http.ServeMux, sctl *aggregate.Controll
 	s.addDebugHandler(mux, "/debug/edsz", "Status and debug interface for EDS", s.Edsz)
 	s.addDebugHandler(mux, "/debug/adsz", "Status and debug interface for ADS", s.adsz)
 	s.addDebugHandler(mux, "/debug/adsz?push=true", "Initiates push of the current state to all connected endpoints", s.adsz)
-	s.addDebugHandler(mux, "/debug/cdsz", "Status and debug interface for CDS", s.cdsz)
 
 	s.addDebugHandler(mux, "/debug/syncz", "Synchronization status of all Envoys connected to this Pilot instance", s.Syncz)
 	s.addDebugHandler(mux, "/debug/config_distribution", "Version status of all Envoys connected to this Pilot instance", s.distributedVersions)
@@ -134,21 +168,6 @@ func (s *DiscoveryServer) addDebugHandler(mux *http.ServeMux, path string, help 
 	handler func(http.ResponseWriter, *http.Request)) {
 	s.debugHandlers[path] = help
 	mux.HandleFunc(path, handler)
-}
-
-// SyncStatus is the synchronization status between Pilot and a given Envoy
-type SyncStatus struct {
-	ProxyID       string `json:"proxy,omitempty"`
-	ProxyVersion  string `json:"proxy_version,omitempty"`
-	IstioVersion  string `json:"istio_version,omitempty"`
-	ClusterSent   string `json:"cluster_sent,omitempty"`
-	ClusterAcked  string `json:"cluster_acked,omitempty"`
-	ListenerSent  string `json:"listener_sent,omitempty"`
-	ListenerAcked string `json:"listener_acked,omitempty"`
-	RouteSent     string `json:"route_sent,omitempty"`
-	RouteAcked    string `json:"route_acked,omitempty"`
-	EndpointSent  string `json:"endpoint_sent,omitempty"`
-	EndpointAcked string `json:"endpoint_acked,omitempty"`
 }
 
 // Syncz dumps the synchronization status of all Envoys connected to this Pilot instance
@@ -261,14 +280,6 @@ func (s *DiscoveryServer) endpointz(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 	_, _ = fmt.Fprint(w, "\n{}]\n")
-}
-
-// SyncedVersions shows what resourceVersion of a given resource has been acked by Envoy.
-type SyncedVersions struct {
-	ProxyID         string `json:"proxy,omitempty"`
-	ClusterVersion  string `json:"cluster_acked,omitempty"`
-	ListenerVersion string `json:"listener_acked,omitempty"`
-	RouteVersion    string `json:"route_acked,omitempty"`
 }
 
 func (s *DiscoveryServer) distributedVersions(w http.ResponseWriter, req *http.Request) {
@@ -419,30 +430,21 @@ func (s *DiscoveryServer) adsz(w http.ResponseWriter, req *http.Request) {
 	}
 
 	s.adsClientsMutex.RLock()
-	defer s.adsClientsMutex.RUnlock()
+	clients := s.adsClients
+	s.adsClientsMutex.RUnlock()
 
-	// Dirty json generation - because standard json is dirty (struct madness)
-	// Unfortunately we must use the jsonbp to encode part of the json - I'm sure there are
-	// better ways, but this is mainly for debugging.
-	_, _ = fmt.Fprint(w, "[\n")
-	comma := false
-	for _, c := range s.adsClients {
-		if comma {
-			_, _ = fmt.Fprint(w, ",\n")
-		} else {
-			comma = true
+	adsClients := &AdsClients{}
+	for _, c := range clients {
+		adsClient := AdsClient{
+			ConnectionID: c.ConID,
+			ConnectedAt:  c.Connect,
+			PeerAddress:  c.PeerAddr,
 		}
-		_, _ = fmt.Fprintf(w, "\n\n  {\"node\": \"%s\",\n \"addr\": \"%s\",\n \"connect\": \"%v\",\n \"listeners\":[\n", c.ConID, c.PeerAddr, c.Connect)
-		printListeners(w, c)
-		_, _ = fmt.Fprint(w, "],\n")
-		_, _ = fmt.Fprintf(w, "\"RDSRoutes\":[\n")
-		printRoutes(w, c)
-		_, _ = fmt.Fprint(w, "],\n")
-		_, _ = fmt.Fprintf(w, "\"clusters\":[\n")
-		printClusters(w, c)
-		_, _ = fmt.Fprint(w, "]}\n")
+		adsClients.Connected = append(adsClients.Connected, adsClient)
 	}
-	_, _ = fmt.Fprint(w, "]\n")
+	if b, err := json.MarshalIndent(adsClients, "  ", "  "); err == nil {
+		_, _ = w.Write(b)
+	}
 }
 
 // ConfigDump returns information in the form of the Envoy admin API config dump for the specified proxy
@@ -640,91 +642,6 @@ func (s *DiscoveryServer) Edsz(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 	_, _ = fmt.Fprintln(w, "]")
-}
-
-// cdsz implements a status and debug interface for CDS.
-// It is mapped to /debug/cdsz
-func (s *DiscoveryServer) cdsz(w http.ResponseWriter, req *http.Request) {
-	_ = req.ParseForm()
-	w.Header().Add("Content-Type", "application/json")
-
-	s.adsClientsMutex.RLock()
-
-	_, _ = fmt.Fprint(w, "[\n")
-	comma := false
-	for _, c := range s.adsClients {
-		if comma {
-			_, _ = fmt.Fprint(w, ",\n")
-		} else {
-			comma = true
-		}
-		_, _ = fmt.Fprintf(w, "\n\n  {\"node\": \"%s\", \"addr\": \"%s\", \"connect\": \"%v\",\"Clusters\":[\n", c.ConID, c.PeerAddr, c.Connect)
-		printClusters(w, c)
-		_, _ = fmt.Fprint(w, "]}\n")
-	}
-	_, _ = fmt.Fprint(w, "]\n")
-
-	s.adsClientsMutex.RUnlock()
-}
-
-func printListeners(w io.Writer, c *Connection) {
-	comma := false
-	for _, ls := range c.XdsListeners {
-		if ls == nil {
-			adsLog.Errorf("INVALID LISTENER NIL")
-			continue
-		}
-		if comma {
-			_, _ = fmt.Fprint(w, ",\n")
-		} else {
-			comma = true
-		}
-		jsonm := &jsonpb.Marshaler{Indent: "  "}
-		dbgString, _ := jsonm.MarshalToString(ls)
-		if _, err := w.Write([]byte(dbgString)); err != nil {
-			return
-		}
-	}
-}
-
-func printClusters(w io.Writer, c *Connection) {
-	comma := false
-	for _, cl := range c.XdsClusters {
-		if cl == nil {
-			adsLog.Errorf("INVALID Cluster NIL")
-			continue
-		}
-		if comma {
-			_, _ = fmt.Fprint(w, ",\n")
-		} else {
-			comma = true
-		}
-		jsonm := &jsonpb.Marshaler{Indent: "  "}
-		dbgString, _ := jsonm.MarshalToString(cl)
-		if _, err := w.Write([]byte(dbgString)); err != nil {
-			return
-		}
-	}
-}
-
-func printRoutes(w io.Writer, c *Connection) {
-	comma := false
-	for _, rt := range c.XdsRoutes {
-		if rt == nil {
-			adsLog.Errorf("INVALID ROUTE CONFIG NIL")
-			continue
-		}
-		if comma {
-			_, _ = fmt.Fprint(w, ",\n")
-		} else {
-			comma = true
-		}
-		jsonm := &jsonpb.Marshaler{Indent: "  "}
-		dbgString, _ := jsonm.MarshalToString(rt)
-		if _, err := w.Write([]byte(dbgString)); err != nil {
-			return
-		}
-	}
 }
 
 func (s *DiscoveryServer) getProxyConnection(proxyID string) *Connection {

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -87,10 +87,6 @@ type DiscoveryServer struct {
 
 	concurrentPushLimit chan struct{}
 
-	// DebugConfigs controls saving snapshots of configs for /debug/adsz.
-	// Defaults to false, can be enabled with PILOT_DEBUG_ADSZ_CONFIG=1
-	DebugConfigs bool
-
 	// mutex protecting global structs updated or read by ADS service, including ConfigsUpdated and
 	// shards.
 	mutex sync.RWMutex
@@ -158,7 +154,6 @@ func NewDiscoveryServer(env *model.Environment, plugins []string) *DiscoveryServ
 		concurrentPushLimit:     make(chan struct{}, features.PushThrottle),
 		pushChannel:             make(chan *model.PushRequest, 10),
 		pushQueue:               NewPushQueue(),
-		DebugConfigs:            features.DebugConfigs,
 		debugHandlers:           map[string]string{},
 		adsClients:              map[string]*Connection{},
 		serverReady:             false,

--- a/pilot/pkg/xds/lds.go
+++ b/pilot/pkg/xds/lds.go
@@ -30,9 +30,6 @@ func (s *DiscoveryServer) pushLds(con *Connection, push *model.PushContext, vers
 	pushStart := time.Now()
 	rawListeners := s.ConfigGenerator.BuildListeners(con.proxy, push)
 
-	if s.DebugConfigs {
-		con.XdsListeners = rawListeners
-	}
 	response := ldsDiscoveryResponse(rawListeners, version, push.Version)
 	err := con.send(response)
 	ldsPushTime.Record(time.Since(pushStart).Seconds())

--- a/pilot/pkg/xds/rds.go
+++ b/pilot/pkg/xds/rds.go
@@ -23,21 +23,11 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
-	"istio.io/istio/pkg/util/protomarshal"
 )
 
 func (s *DiscoveryServer) pushRoute(con *Connection, push *model.PushContext, version string) error {
 	pushStart := time.Now()
 	rawRoutes := s.ConfigGenerator.BuildHTTPRoutes(con.proxy, push, con.Routes())
-	if s.DebugConfigs {
-		for _, r := range rawRoutes {
-			con.XdsRoutes[r.Name] = r
-			if adsLog.DebugEnabled() {
-				resp, _ := protomarshal.ToJSONWithIndent(r, " ")
-				adsLog.Debugf("RDS: Adding route:%s for node:%v", resp, con.proxy.ID)
-			}
-		}
-	}
 
 	response := routeDiscoveryResponse(rawRoutes, version, push.Version)
 	err := con.send(response)


### PR DESCRIPTION
Removes
- clusters, listeners and routes in `adsz` endpoint as they should be available in `/config_dump`
- Removes `cdsz` endpoint as it is available in `/config_dump`

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
