### PR TITLE
Dashboard is no longer experimental

### DIFF
--- a/istioctl/cmd/dashboard_test.go
+++ b/istioctl/cmd/dashboard_test.go
@@ -84,26 +84,21 @@ func TestDashboard(t *testing.T) {
 			wantException:  true,
 		},
 		{ // case 11
-			args:           strings.Split("experimental dashboard", " "),
-			expectedOutput: "Error: (dashboard has graduated. Use `istioctl dashboard`)\n",
-			wantException:  true,
-		},
-		{ // case 12
 			args:           strings.Split("dashboard envoy --selector app=example", " "),
 			expectedRegexp: regexp.MustCompile(".*no pods found"),
 			wantException:  true,
 		},
-		{ // case 13
+		{ // case 12
 			args:           strings.Split("dashboard envoy --selector app=example pod-123456-7890", " "),
 			expectedRegexp: regexp.MustCompile(".*Error: name cannot be provided when a selector is specified"),
 			wantException:  true,
 		},
-		{ // case 14
+		{ // case 13
 			args:           strings.Split("dashboard controlz --selector app=example", " "),
 			expectedRegexp: regexp.MustCompile(".*no pods found"),
 			wantException:  true,
 		},
-		{ // case 15
+		{ // case 14
 			args:           strings.Split("dashboard controlz --selector app=example pod-123456-7890", " "),
 			expectedRegexp: regexp.MustCompile(".*Error: name cannot be provided when a selector is specified"),
 			wantException:  true,

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -215,8 +215,6 @@ debug and diagnose their Istio mesh.
 	experimentalCmd.AddCommand(install.NewPrecheckCommand())
 	experimentalCmd.AddCommand(AuthZ())
 	rootCmd.AddCommand(seeExperimentalCmd("authz"))
-	experimentalCmd.AddCommand(graduatedCmd("convert-ingress"))
-	experimentalCmd.AddCommand(graduatedCmd("dashboard"))
 	experimentalCmd.AddCommand(uninjectCommand())
 	experimentalCmd.AddCommand(metricsCmd)
 	experimentalCmd.AddCommand(describe())

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -348,18 +348,6 @@ func softGraduatedCmd(cmd *cobra.Command) *cobra.Command {
 	return &newCmd
 }
 
-// graduatedCmd is used for commands that have graduated and should not work if invoked the old way.
-func graduatedCmd(name string) *cobra.Command {
-	msg := fmt.Sprintf("(%s has graduated. Use `istioctl %s`)", name, name)
-	return &cobra.Command{
-		Use:   name,
-		Short: msg,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return errors.New(msg)
-		},
-	}
-}
-
 // seeExperimentalCmd is used for commands that have been around for a release but not graduated
 func seeExperimentalCmd(name string) *cobra.Command {
 	msg := fmt.Sprintf("(%s is experimental. Use `istioctl experimental %s`)", name, name)


### PR DESCRIPTION
The dashboard is graduated a year ago. Docs are already updated to remove `experimental` from `dashboard` commands.

Related:
https://github.com/istio/istio/pull/16571
https://github.com/istio/istio/pull/17824
