### PR TITLE
Cherry-pick 1.7: Change sample cross-network port to 15443 (#26389)

### DIFF
--- a/samples/cross-network-gateway/cross-network-gateway.yaml
+++ b/samples/cross-network-gateway/cross-network-gateway.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: cross-network-gateway
+  namespace: istio-system
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+    - port:
+        number: 15443
+        name: tls
+        protocol: TLS
+      tls:
+        mode: AUTO_PASSTHROUGH
+      hosts:
+        - "*.local"


### PR DESCRIPTION
Goal is to not mix TLS and mTLS on the same port. TLS is on 443, mTLS is on 15443.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.