### PR TITLE
Grant read permission to component in the same group

### DIFF
--- a/security/pkg/credentialfetcher/plugin/gce.go
+++ b/security/pkg/credentialfetcher/plugin/gce.go
@@ -64,7 +64,7 @@ func (p *GCEPlugin) GetPlatformCredential() (string, error) {
 	}
 	gcecredLog.Debugf("Got GCE identity token: %d", len(token))
 	tokenbytes := []byte(token)
-	err = ioutil.WriteFile(p.jwtPath, tokenbytes, 0600)
+	err = ioutil.WriteFile(p.jwtPath, tokenbytes, 0640)
 	if err != nil {
 		gcecredLog.Errorf("Encountered error when writing vm identity token: %v", err)
 		return "", err


### PR DESCRIPTION
In the VM, when envoy and sds-agent are running as different uid in the same group, envoy needs read permission 0640 to access the VM credential.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.