### PR TITLE
Fix egressgateway ports

### DIFF
--- a/manifests/profiles/default.yaml
+++ b/manifests/profiles/default.yaml
@@ -105,8 +105,10 @@ spec:
           ports:
             - port: 80
               name: http2
+              targetPort: 8080
             - port: 443
               name: https
+              targetPort: 8443
             - port: 15443
               targetPort: 15443
               name: tls


### PR DESCRIPTION
Cannot bind to port 80/443 since we run as non root by default



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.