### PR TITLE
Add authorization to XDS connection

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -308,6 +308,12 @@ var (
 	XDSAuth = env.RegisterBoolVar("XDS_AUTH", true,
 		"If true, will authenticate XDS clients.").Get()
 
+	EnableXDSAuthorization = env.RegisterBoolVar(
+		"PILOT_ENABLE_XDS_AUTHORIZATION",
+		true,
+		"If enabled, pilot will authorize XDS clients, to ensure they are acting only as namespaces they have permissions for.",
+	).Get()
+
 	EnableServiceEntrySelectPods = env.RegisterBoolVar("PILOT_ENABLE_SERVICEENTRY_SELECT_PODS", true,
 		"If enabled, service entries with selectors will select pods from the cluster. "+
 			"It is safe to disable it if you are quite sure you don't need this feature").Get()

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -308,8 +308,8 @@ var (
 	XDSAuth = env.RegisterBoolVar("XDS_AUTH", true,
 		"If true, will authenticate XDS clients.").Get()
 
-	EnableXDSAuthorization = env.RegisterBoolVar(
-		"PILOT_ENABLE_XDS_AUTHORIZATION",
+	EnableXDSIdentityCheck = env.RegisterBoolVar(
+		"PILOT_ENABLE_XDS_IDENTITY_CHECK",
 		true,
 		"If enabled, pilot will authorize XDS clients, to ensure they are acting only as namespaces they have permissions for.",
 	).Get()

--- a/pilot/pkg/security/authn/utils/utils.go
+++ b/pilot/pkg/security/authn/utils/utils.go
@@ -25,7 +25,6 @@ import (
 	authn_model "istio.io/istio/pilot/pkg/security/model"
 	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
 	protovalue "istio.io/istio/pkg/proto"
-	"istio.io/istio/pkg/spiffe"
 	"istio.io/pkg/log"
 )
 
@@ -103,13 +102,4 @@ func BuildInboundFilterChain(mTLSMode model.MutualTLSMode, sdsUdsPath string, no
 		}
 	}
 	return nil
-}
-
-// GetSAN returns the SAN used for passed in identity for mTLS.
-func GetSAN(ns string, identity string) string {
-
-	if ns != "" {
-		return spiffe.MustGenSpiffeURI(ns, identity)
-	}
-	return spiffe.GenCustomSpiffe(identity)
 }

--- a/pilot/pkg/security/authn/utils/utils_test.go
+++ b/pilot/pkg/security/authn/utils/utils_test.go
@@ -15,7 +15,6 @@
 package utils
 
 import (
-	"strings"
 	"testing"
 	"time"
 
@@ -33,10 +32,6 @@ import (
 	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
 	protovalue "istio.io/istio/pkg/proto"
 	"istio.io/istio/pkg/spiffe"
-)
-
-const (
-	expPilotSAN string = "spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"
 )
 
 func TestBuildInboundFilterChain(t *testing.T) {
@@ -362,13 +357,5 @@ func TestBuildInboundFilterChain(t *testing.T) {
 				t.Errorf("BuildInboundFilterChain() = %v", diff)
 			}
 		})
-	}
-}
-
-func TestGetPilotSAN(t *testing.T) {
-	spiffe.SetTrustDomain("cluster.local")
-	pilotSANs := GetSAN("istio-system", PilotSvcAccName)
-	if strings.Compare(pilotSANs, expPilotSAN) != 0 {
-		t.Errorf("GetPilotSAN() => expected %#v but got %#v", expPilotSAN, pilotSANs[0])
 	}
 }

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -184,12 +184,6 @@ func kubeToIstioServiceAccount(saname string, ns string) string {
 
 // SecureNamingSAN creates the secure naming used for SAN verification from pod metadata
 func SecureNamingSAN(pod *coreV1.Pod) string {
-
-	//use the identity annotation
-	if identity, exist := pod.Annotations[annotation.AlphaIdentity.Name]; exist {
-		return spiffe.GenCustomSpiffe(identity)
-	}
-
 	return spiffe.MustGenSpiffeURI(pod.Namespace, pod.Spec.ServiceAccountName)
 }
 

--- a/pilot/pkg/serviceregistry/kube/conversion_test.go
+++ b/pilot/pkg/serviceregistry/kube/conversion_test.go
@@ -406,25 +406,6 @@ func TestLBServiceConversion(t *testing.T) {
 	}
 }
 
-func TestSecureNamingSANCustomIdentity(t *testing.T) {
-
-	pod := &coreV1.Pod{}
-
-	identity := "foo"
-
-	pod.Annotations = make(map[string]string)
-	pod.Annotations[annotation.AlphaIdentity.Name] = identity
-
-	san := SecureNamingSAN(pod)
-
-	expectedSAN := fmt.Sprintf("spiffe://%v/%v", spiffe.GetTrustDomain(), identity)
-
-	if san != expectedSAN {
-		t.Fatalf("SAN match failed, SAN:%v  expectedSAN:%v", san, expectedSAN)
-	}
-
-}
-
 func TestSecureNamingSAN(t *testing.T) {
 
 	pod := &coreV1.Pod{}

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -16,6 +16,7 @@ package xds
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"strconv"
 	"sync/atomic"
@@ -28,10 +29,12 @@ import (
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/spiffe"
 	istiolog "istio.io/pkg/log"
 	"istio.io/pkg/monitoring"
 )
@@ -58,6 +61,9 @@ type DiscoveryStream interface {
 type Connection struct {
 	// PeerAddr is the address of the client, from network layer.
 	PeerAddr string
+
+	// Defines associated identities for the connection
+	Identities []string
 
 	// Time of connection, for debugging
 	Connect time.Time
@@ -234,6 +240,7 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream discovery.AggregatedD
 	}
 
 	con := newConnection(peerAddr, stream)
+	con.Identities = ids
 
 	// Do not call: defer close(con.pushChannel). The push channel will be garbage collected
 	// when the connection is no longer used. Closing the channel can cause subtle race conditions
@@ -449,12 +456,36 @@ func (s *DiscoveryServer) initConnection(node *core.Node, con *Connection) error
 	con.ConID = connectionID(node.Id)
 	con.node = node
 
+	if features.EnableXDSAuthorization {
+		if err := authorizeConnection(con); err != nil {
+			adsLog.Warnf("Unauthorized XDS: %v with identity %v: %v", con.PeerAddr, con.Identities, err)
+			return fmt.Errorf("authorization failed: %v", err)
+		}
+	}
+
 	s.addCon(con.ConID, con)
 
 	if s.InternalGen != nil {
 		s.InternalGen.OnConnect(con)
 	}
 	return nil
+}
+
+func authorizeConnection(con *Connection) error {
+	for _, rawId := range con.Identities {
+		spiffeId, err := spiffe.ParseIdentity(rawId)
+		if err != nil {
+			continue
+		}
+		if con.proxy.ConfigNamespace != "" && spiffeId.Namespace != con.proxy.ConfigNamespace {
+			continue
+		}
+		if con.proxy.Metadata.ServiceAccount != "" && spiffeId.ServiceAccount != con.proxy.Metadata.ServiceAccount {
+			continue
+		}
+		return nil
+	}
+	return fmt.Errorf("no identities (%v) matched %v/%v", con.Identities, con.proxy.ConfigNamespace, con.proxy.Metadata.ServiceAccount)
 }
 
 func connectionID(node string) string {

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -456,9 +456,9 @@ func (s *DiscoveryServer) initConnection(node *core.Node, con *Connection) error
 	con.ConID = connectionID(node.Id)
 	con.node = node
 
-	if features.EnableXDSAuthorization && con.Identities != nil {
+	if features.EnableXDSIdentityCheck && con.Identities != nil {
 		// TODO: allow locking down, rejecting unauthenticated requests.
-		if err := authorizeConnection(con); err != nil {
+		if err := checkConnectionIdentity(con); err != nil {
 			adsLog.Warnf("Unauthorized XDS: %v with identity %v: %v", con.PeerAddr, con.Identities, err)
 			return fmt.Errorf("authorization failed: %v", err)
 		}
@@ -472,7 +472,7 @@ func (s *DiscoveryServer) initConnection(node *core.Node, con *Connection) error
 	return nil
 }
 
-func authorizeConnection(con *Connection) error {
+func checkConnectionIdentity(con *Connection) error {
 	for _, rawID := range con.Identities {
 		spiffeID, err := spiffe.ParseIdentity(rawID)
 		if err != nil {

--- a/pilot/pkg/xds/authentication.go
+++ b/pilot/pkg/xds/authentication.go
@@ -52,7 +52,7 @@ func (s *DiscoveryServer) authenticate(ctx context.Context) ([]string, error) {
 	for _, authn := range s.Authenticators {
 		u, err := authn.Authenticate(ctx)
 		// If one authenticator passes, return
-		if u != nil && err == nil {
+		if u != nil && u.Identities != nil && err == nil {
 			return u.Identities, nil
 		}
 		authFailMsgs = append(authFailMsgs, fmt.Sprintf("Authenticator %s: %v", authn.AuthenticatorType(), err))

--- a/pkg/istio-agent/sds-agent.go
+++ b/pkg/istio-agent/sds-agent.go
@@ -135,6 +135,9 @@ type AgentConfig struct {
 
 	// Grpc dial options. Used for testing
 	GrpcOptions []grpc.DialOption
+
+	// Namespace to connect as
+	Namespace string
 }
 
 // NewAgent wraps the logic for a local SDS. It will check if the JWT token required for local SDS is
@@ -246,7 +249,7 @@ func (sa *Agent) Start(isSidecar bool, podNamespace string) (*sds.Server, error)
 	}
 
 	// Start the XDS client and proxy.
-	err = sa.startXDS(sa.proxyConfig, sa.WorkloadSecrets)
+	err = sa.startXDS(sa.proxyConfig, sa.WorkloadSecrets, podNamespace)
 	if err != nil {
 		return nil, fmt.Errorf("xds proxy: %v", err)
 	}

--- a/pkg/istio-agent/xds-agent.go
+++ b/pkg/istio-agent/xds-agent.go
@@ -115,7 +115,7 @@ func (sa *Agent) Close() {
 // If 'RequireCerts' is set, will attempt to get certificates. Will then attempt to connect to
 // the XDS server (istiod), and fetch the initial config. Once the config is ready, will start the
 // local XDS proxy and return.
-func (sa *Agent) startXDS(proxyConfig *meshconfig.ProxyConfig, secrets security.SecretManager) error {
+func (sa *Agent) startXDS(proxyConfig *meshconfig.ProxyConfig, secrets security.SecretManager, namespace string) error {
 	if sa.cfg.LocalXDSAddr == "" {
 		return nil
 	}
@@ -133,6 +133,7 @@ func (sa *Agent) startXDS(proxyConfig *meshconfig.ProxyConfig, secrets security.
 		XDSSAN:          discHost,
 		ResponseHandler: sa.proxyGen,
 		GrpcOpts:        sa.cfg.GrpcOptions,
+		Namespace:       namespace,
 	}
 
 	// Set Secrets and JWTPath if the default ControlPlaneAuthPolicy is MUTUAL_TLS

--- a/pkg/spiffe/spiffe.go
+++ b/pkg/spiffe/spiffe.go
@@ -34,7 +34,8 @@ import (
 const (
 	Scheme = "spiffe"
 
-	URIPrefix = Scheme + "://"
+	URIPrefix    = Scheme + "://"
+	URIPrefixLen = len(URIPrefix)
 
 	// The default SPIFFE URL value for trust domain
 	defaultTrustDomain = constants.DefaultKubernetesDomain
@@ -63,7 +64,7 @@ func ParseIdentity(s string) (Identity, error) {
 	if !strings.HasPrefix(s, URIPrefix) {
 		return Identity{}, fmt.Errorf("identity is not a spiffe format: %v", s)
 	}
-	split := strings.Split(s[9:], "/")
+	split := strings.Split(s[URIPrefixLen:], "/")
 	if len(split) != 5 {
 		return Identity{}, fmt.Errorf("identity is not a spiffe format: %v", s)
 	}

--- a/pkg/spiffe/spiffe.go
+++ b/pkg/spiffe/spiffe.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -39,10 +38,12 @@ const (
 
 	// The default SPIFFE URL value for trust domain
 	defaultTrustDomain = constants.DefaultKubernetesDomain
+
+	ServiceAccountSegment = "sa"
+	NamespaceSegment      = "ns"
 )
 
 var (
-	spiffePattern    = regexp.MustCompile(`spiffe://([^/]+)/.*$`)
 	trustDomain      = defaultTrustDomain
 	trustDomainMutex sync.RWMutex
 
@@ -51,6 +52,34 @@ var (
 
 	spiffeLog = log.RegisterScope("spiffe", "SPIFFE library logging", 0)
 )
+
+type Identity struct {
+	TrustDomain    string
+	Namespace      string
+	ServiceAccount string
+}
+
+func ParseIdentity(s string) (Identity, error) {
+	if !strings.HasPrefix(s, URIPrefix) {
+		return Identity{}, fmt.Errorf("identity is not a spiffe format: %v", s)
+	}
+	split := strings.Split(s[9:], "/")
+	if len(split) != 5 {
+		return Identity{}, fmt.Errorf("identity is not a spiffe format: %v", s)
+	}
+	if split[1] != NamespaceSegment || split[3] != ServiceAccountSegment {
+		return Identity{}, fmt.Errorf("identity is not a spiffe format: %v", s)
+	}
+	return Identity{
+		TrustDomain:    split[0],
+		Namespace:      split[2],
+		ServiceAccount: split[4],
+	}, nil
+}
+
+func (i Identity) String() string {
+	return URIPrefix + i.TrustDomain + "/ns/" + i.Namespace + "/sa/" + i.ServiceAccount
+}
 
 type bundleDoc struct {
 	jose.JSONWebKeySet
@@ -113,39 +142,26 @@ func ExpandWithTrustDomains(spiffeIdentities, trustDomainAliases []string) map[s
 	for _, id := range spiffeIdentities {
 		out[id] = struct{}{}
 		// Expand with aliases set.
-		m := spiffePattern.FindStringSubmatchIndex(id)
-		// FindStringSubmatchIndex the pairs of the match, (trust domain + the whole match string) x 2
-		// so we should see 4 index.
-		if len(m) < 4 {
-			spiffeLog.Errorf("Failed to extract SPIFFE trust domain from: %v, match %v", id, m)
+		m, err := ParseIdentity(id)
+		if err != nil {
+			spiffeLog.Errorf("Failed to extract SPIFFE trust domain from %v: %v", id, err)
 			continue
 		}
-		suffix := id[m[3]:]
 		for _, td := range trustDomainAliases {
-			nid := URIPrefix + td + suffix
-			out[nid] = struct{}{}
+			m.TrustDomain = td
+			out[m.String()] = struct{}{}
 		}
 	}
 	return out
 }
 
-// GenCustomSpiffe returns the  spiffe string that can have a custom structure
-func GenCustomSpiffe(identity string) string {
-	if identity == "" {
-		spiffeLog.Error("spiffe identity can't be empty")
-		return ""
-	}
-
-	return URIPrefix + GetTrustDomain() + "/" + identity
-}
-
 // GetTrustDomainFromURISAN extracts the trust domain part from the URI SAN in the X.509 certificate.
 func GetTrustDomainFromURISAN(uriSan string) (string, error) {
-	parsed, err := url.Parse(uriSan)
+	parsed, err := ParseIdentity(uriSan)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse URI SAN %s. Error: %v", uriSan, err)
 	}
-	return parsed.Hostname(), nil
+	return parsed.TrustDomain, nil
 }
 
 // RetrieveSpiffeBundleRootCertsFromStringInput retrieves the trusted CA certificates from a list of SPIFFE bundle endpoints.

--- a/pkg/spiffe/spiffe_test.go
+++ b/pkg/spiffe/spiffe_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/pem"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -364,36 +365,6 @@ func TestMustGenSpiffeURI(t *testing.T) {
 	}
 }
 
-func TestGenCustomSpiffe(t *testing.T) {
-	oldTrustDomain := GetTrustDomain()
-	defer SetTrustDomain(oldTrustDomain)
-
-	testCases := []struct {
-		trustDomain string
-		identity    string
-		expectedURI string
-	}{
-		{
-			identity:    "foo",
-			trustDomain: "mesh.com",
-			expectedURI: "spiffe://mesh.com/foo",
-		},
-		{
-			//identity is empty
-			trustDomain: "mesh.com",
-			expectedURI: "",
-		},
-	}
-	for id, tc := range testCases {
-		SetTrustDomain(tc.trustDomain)
-		got := GenCustomSpiffe(tc.identity)
-
-		if got != tc.expectedURI {
-			t.Errorf("Test id: %v , unexpected subject name, want %v, got %v", id, tc.expectedURI, got)
-		}
-	}
-}
-
 // The test starts one or two local servers and tests RetrieveSpiffeBundleRootCerts is able to correctly retrieve the
 // SPIFFE bundles.
 func TestRetrieveSpiffeBundleRootCertsFromStringInput(t *testing.T) {
@@ -673,13 +644,13 @@ func TestExpandWithTrustDomains(t *testing.T) {
 	}{
 		{
 			name:      "Basic",
-			spiffeURI: []string{"spiffe://cluster.local/ns/def/na/def"},
+			spiffeURI: []string{"spiffe://cluster.local/ns/def/sa/def"},
 			trustDomains: []string{
 				"foo",
 			},
 			want: map[string]struct{}{
-				"spiffe://cluster.local/ns/def/na/def": {},
-				"spiffe://foo/ns/def/na/def":           {},
+				"spiffe://cluster.local/ns/def/sa/def": {},
+				"spiffe://foo/ns/def/sa/def":           {},
 			},
 		},
 		{
@@ -696,35 +667,35 @@ func TestExpandWithTrustDomains(t *testing.T) {
 		},
 		{
 			name:         "EmptyTrustDomains",
-			spiffeURI:    []string{"spiffe://cluster.local/ns/def/na/def"},
+			spiffeURI:    []string{"spiffe://cluster.local/ns/def/sa/def"},
 			trustDomains: []string{},
 			want: map[string]struct{}{
-				"spiffe://cluster.local/ns/def/na/def": {},
+				"spiffe://cluster.local/ns/def/sa/def": {},
 			},
 		},
 		{
 			name:      "WithOriginalTrustDomain",
-			spiffeURI: []string{"spiffe://cluster.local/ns/def/na/def"},
+			spiffeURI: []string{"spiffe://cluster.local/ns/def/sa/def"},
 			trustDomains: []string{
 				"foo",
 				"cluster.local",
 			},
 			want: map[string]struct{}{
-				"spiffe://cluster.local/ns/def/na/def": {},
-				"spiffe://foo/ns/def/na/def":           {},
+				"spiffe://cluster.local/ns/def/sa/def": {},
+				"spiffe://foo/ns/def/sa/def":           {},
 			},
 		},
 		{
 			name:      "TwoIentities",
-			spiffeURI: []string{"spiffe://cluster.local/ns/def/na/def", "spiffe://cluster.local/ns/a/na/a"},
+			spiffeURI: []string{"spiffe://cluster.local/ns/def/sa/def", "spiffe://cluster.local/ns/a/sa/a"},
 			trustDomains: []string{
 				"foo",
 			},
 			want: map[string]struct{}{
-				"spiffe://cluster.local/ns/def/na/def": {},
-				"spiffe://foo/ns/def/na/def":           {},
-				"spiffe://cluster.local/ns/a/na/a":     {},
-				"spiffe://foo/ns/a/na/a":               {},
+				"spiffe://cluster.local/ns/def/sa/def": {},
+				"spiffe://foo/ns/def/sa/def":           {},
+				"spiffe://cluster.local/ns/a/sa/a":     {},
+				"spiffe://foo/ns/a/sa/a":               {},
 			},
 		},
 		{
@@ -735,7 +706,6 @@ func TestExpandWithTrustDomains(t *testing.T) {
 			},
 			want: map[string]struct{}{
 				"spiffe://cluster.local/custom-suffix": {},
-				"spiffe://foo/custom-suffix":           {},
 			},
 		},
 	}
@@ -744,6 +714,77 @@ func TestExpandWithTrustDomains(t *testing.T) {
 			got := ExpandWithTrustDomains(tc.spiffeURI, tc.trustDomains)
 			if diff := cmp.Diff(got, tc.want); diff != "" {
 				t.Errorf("unexpected expanded results: %v", diff)
+			}
+		})
+	}
+}
+
+func TestIdentity(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected *Identity
+	}{
+		{
+			"spiffe://td/ns/ns/sa/sa",
+			&Identity{
+				TrustDomain:    "td",
+				Namespace:      "ns",
+				ServiceAccount: "sa",
+			},
+		},
+		{
+			"spiffe://td.with.dots/ns/ns.with.dots/sa/sa.with.dots",
+			&Identity{
+				TrustDomain:    "td.with.dots",
+				Namespace:      "ns.with.dots",
+				ServiceAccount: "sa.with.dots",
+			},
+		},
+		{
+			// Empty ns and sa
+			"spiffe://td/ns//sa/",
+			&Identity{TrustDomain: "td", Namespace: "", ServiceAccount: ""},
+		},
+		{
+			// Missing spiffe prefix
+			"td/ns/ns/sa/sa",
+			nil,
+		},
+		{
+			// Missing SA
+			"spiffe://td/ns/ns/sa",
+			nil,
+		},
+		{
+			// Trailing /
+			"spiffe://td/ns/ns/sa/sa/",
+			nil,
+		},
+		{
+			// wrong separator /
+			"spiffe://td/ns/ns/foobar/sa/",
+			nil,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ParseIdentity(tt.input)
+			if tt.expected == nil {
+				if err == nil {
+					t.Fatalf("expected error, got %#v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, *tt.expected) {
+				t.Fatalf("expected %#v, got %#v", *tt.expected, got)
+			}
+
+			roundTrip := got.String()
+			if roundTrip != tt.input {
+				t.Fatalf("round trip failed, expected %q got %q", tt.input, roundTrip)
 			}
 		})
 	}

--- a/releasenotes/notes/xds-authz.yaml
+++ b/releasenotes/notes/xds-authz.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+releaseNotes:
+- |
+  **Added** authorization of clients when connecting to Istiod over XDS.


### PR DESCRIPTION
This adds basic authorization to the XDS connection. This consists of
extracting the identities and verifying the SA and NS are consistent
with the identity.

This is flag protected and on by default for testing - happy to turn it
off before merging.

As part of this work, I refactored some of the SPIFFE code to make it easier to extract the fields we need from a spiffe identity.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.