### PR TITLE
Update istio.io/client-go version (WorkloadGroup changes)

### DIFF
--- a/galley/testdatasets/validation/dataset.gen.go
+++ b/galley/testdatasets/validation/dataset.gen.go
@@ -15,6 +15,8 @@
 // dataset/networking-v1alpha3-VirtualService-valid.yaml
 // dataset/networking-v1alpha3-WorkloadEntry-invalid.yaml
 // dataset/networking-v1alpha3-WorkloadEntry-valid.yaml
+// dataset/networking-v1alpha3-WorkloadGroup-invalid.yaml
+// dataset/networking-v1alpha3-WorkloadGroup-valid.yaml
 // dataset/networking-v1beta-DestinationRule-invalid.yaml
 // dataset/networking-v1beta-DestinationRule-valid.yaml
 // dataset/networking-v1beta-Gateway-invalid.yaml
@@ -513,6 +515,66 @@ func datasetNetworkingV1alpha3WorkloadentryValidYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "dataset/networking-v1alpha3-WorkloadEntry-valid.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _datasetNetworkingV1alpha3WorkloadgroupInvalidYaml = []byte(`apiVersion: networking.istio.io/v1alpha3
+kind: WorkloadGroup
+metadata:
+  name: reviews
+  namespace: istio-system
+spec:
+  metadata:
+    labels:
+      app.kubernetes.io/name: reviews
+      app.kubernetes.io/version: "1.3.4"
+  template:
+`)
+
+func datasetNetworkingV1alpha3WorkloadgroupInvalidYamlBytes() ([]byte, error) {
+	return _datasetNetworkingV1alpha3WorkloadgroupInvalidYaml, nil
+}
+
+func datasetNetworkingV1alpha3WorkloadgroupInvalidYaml() (*asset, error) {
+	bytes, err := datasetNetworkingV1alpha3WorkloadgroupInvalidYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "dataset/networking-v1alpha3-WorkloadGroup-invalid.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _datasetNetworkingV1alpha3WorkloadgroupValidYaml = []byte(`apiVersion: networking.istio.io/v1alpha3
+kind: WorkloadGroup
+metadata:
+  name: reviews
+  namespace: istio-system
+spec:
+  metadata:
+    labels:
+      app.kubernetes.io/name: reviews
+      app.kubernetes.io/version: "1.3.4"
+  template:
+    ports:
+      grpc: 3550
+      http: 8080
+    serviceAccount: default
+`)
+
+func datasetNetworkingV1alpha3WorkloadgroupValidYamlBytes() ([]byte, error) {
+	return _datasetNetworkingV1alpha3WorkloadgroupValidYaml, nil
+}
+
+func datasetNetworkingV1alpha3WorkloadgroupValidYaml() (*asset, error) {
+	bytes, err := datasetNetworkingV1alpha3WorkloadgroupValidYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "dataset/networking-v1alpha3-WorkloadGroup-valid.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1053,6 +1115,8 @@ var _bindata = map[string]func() (*asset, error){
 	"dataset/networking-v1alpha3-VirtualService-valid.yaml":          datasetNetworkingV1alpha3VirtualserviceValidYaml,
 	"dataset/networking-v1alpha3-WorkloadEntry-invalid.yaml":         datasetNetworkingV1alpha3WorkloadentryInvalidYaml,
 	"dataset/networking-v1alpha3-WorkloadEntry-valid.yaml":           datasetNetworkingV1alpha3WorkloadentryValidYaml,
+	"dataset/networking-v1alpha3-WorkloadGroup-invalid.yaml":         datasetNetworkingV1alpha3WorkloadgroupInvalidYaml,
+	"dataset/networking-v1alpha3-WorkloadGroup-valid.yaml":           datasetNetworkingV1alpha3WorkloadgroupValidYaml,
 	"dataset/networking-v1beta-DestinationRule-invalid.yaml":         datasetNetworkingV1betaDestinationruleInvalidYaml,
 	"dataset/networking-v1beta-DestinationRule-valid.yaml":           datasetNetworkingV1betaDestinationruleValidYaml,
 	"dataset/networking-v1beta-Gateway-invalid.yaml":                 datasetNetworkingV1betaGatewayInvalidYaml,
@@ -1128,6 +1192,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"networking-v1alpha3-VirtualService-valid.yaml":          &bintree{datasetNetworkingV1alpha3VirtualserviceValidYaml, map[string]*bintree{}},
 		"networking-v1alpha3-WorkloadEntry-invalid.yaml":         &bintree{datasetNetworkingV1alpha3WorkloadentryInvalidYaml, map[string]*bintree{}},
 		"networking-v1alpha3-WorkloadEntry-valid.yaml":           &bintree{datasetNetworkingV1alpha3WorkloadentryValidYaml, map[string]*bintree{}},
+		"networking-v1alpha3-WorkloadGroup-invalid.yaml":         &bintree{datasetNetworkingV1alpha3WorkloadgroupInvalidYaml, map[string]*bintree{}},
+		"networking-v1alpha3-WorkloadGroup-valid.yaml":           &bintree{datasetNetworkingV1alpha3WorkloadgroupValidYaml, map[string]*bintree{}},
 		"networking-v1beta-DestinationRule-invalid.yaml":         &bintree{datasetNetworkingV1betaDestinationruleInvalidYaml, map[string]*bintree{}},
 		"networking-v1beta-DestinationRule-valid.yaml":           &bintree{datasetNetworkingV1betaDestinationruleValidYaml, map[string]*bintree{}},
 		"networking-v1beta-Gateway-invalid.yaml":                 &bintree{datasetNetworkingV1betaGatewayInvalidYaml, map[string]*bintree{}},

--- a/galley/testdatasets/validation/dataset/networking-v1alpha3-WorkloadGroup-invalid.yaml
+++ b/galley/testdatasets/validation/dataset/networking-v1alpha3-WorkloadGroup-invalid.yaml
@@ -1,0 +1,11 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: WorkloadGroup
+metadata:
+  name: reviews
+  namespace: istio-system
+spec:
+  metadata:
+    labels:
+      app.kubernetes.io/name: reviews
+      app.kubernetes.io/version: "1.3.4"
+  template:

--- a/galley/testdatasets/validation/dataset/networking-v1alpha3-WorkloadGroup-valid.yaml
+++ b/galley/testdatasets/validation/dataset/networking-v1alpha3-WorkloadGroup-valid.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: WorkloadGroup
+metadata:
+  name: reviews
+  namespace: istio-system
+spec:
+  metadata:
+    labels:
+      app.kubernetes.io/name: reviews
+      app.kubernetes.io/version: "1.3.4"
+  template:
+    ports:
+      grpc: 3550
+      http: 8080
+    serviceAccount: default

--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 	helm.sh/helm/v3 v3.2.4
 	istio.io/api v0.0.0-20200813025026-b0d73f1d2ae9
-	istio.io/client-go v0.0.0-20200807223845-61c70ad04ec9
+	istio.io/client-go v0.0.0-20200812230733-f5504d568313
 	istio.io/gogo-genproto v0.0.0-20200720193312-b523a30fe746
 	istio.io/pkg v0.0.0-20200721143030-6b837ddaf2ab
 	k8s.io/api v0.18.6

--- a/go.sum
+++ b/go.sum
@@ -1189,11 +1189,9 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4 h1:UoveltGrhghAA7ePc+e+QYDHXrBps2PqFZiHkGR/xK8=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 istio.io/api v0.0.0-20190515205759-982e5c3888c6/go.mod h1:hhLFQmpHia8zgaM37vb2ml9iS5NfNfqZGRt1pS9aVEo=
-istio.io/api v0.0.0-20200807153343-42453f1c8ffc/go.mod h1:88HN3o1fSD1jo+Z1WTLlJfMm9biopur6Ct9BFKjiB64=
+istio.io/api v0.0.0-20200812202721-24be265d41c3/go.mod h1:88HN3o1fSD1jo+Z1WTLlJfMm9biopur6Ct9BFKjiB64=
 istio.io/api v0.0.0-20200813025026-b0d73f1d2ae9 h1:VB4PeZzy8Zq/XX6lLITk7wNG3/Iden96WG8QLHnU6Dw=
 istio.io/api v0.0.0-20200813025026-b0d73f1d2ae9/go.mod h1:88HN3o1fSD1jo+Z1WTLlJfMm9biopur6Ct9BFKjiB64=
-istio.io/client-go v0.0.0-20200807223845-61c70ad04ec9 h1:wIQ5qrSBR8MZCssrIk0r7cAV+mRadn6/DucaSJ5Cwy0=
-istio.io/client-go v0.0.0-20200807223845-61c70ad04ec9/go.mod h1:5oqiJTfg7GsSYfKeix2L5vYaiAP18PNRhoOSrNziVlM=
 istio.io/client-go v0.0.0-20200812230733-f5504d568313 h1:V0lIWo5DjSEJmjIDOrDJncZbzBMTVeluO9S+OopB53A=
 istio.io/client-go v0.0.0-20200812230733-f5504d568313/go.mod h1:SO65MWt7I45dvUwuDowoiB0SVcGpfWZfUTlopvYpbZc=
 istio.io/gogo-genproto v0.0.0-20190930162913-45029607206a/go.mod h1:OzpAts7jljZceG4Vqi5/zXy/pOg1b209T3jb7Nv5wIs=

--- a/go.sum
+++ b/go.sum
@@ -1194,6 +1194,8 @@ istio.io/api v0.0.0-20200813025026-b0d73f1d2ae9 h1:VB4PeZzy8Zq/XX6lLITk7wNG3/Ide
 istio.io/api v0.0.0-20200813025026-b0d73f1d2ae9/go.mod h1:88HN3o1fSD1jo+Z1WTLlJfMm9biopur6Ct9BFKjiB64=
 istio.io/client-go v0.0.0-20200807223845-61c70ad04ec9 h1:wIQ5qrSBR8MZCssrIk0r7cAV+mRadn6/DucaSJ5Cwy0=
 istio.io/client-go v0.0.0-20200807223845-61c70ad04ec9/go.mod h1:5oqiJTfg7GsSYfKeix2L5vYaiAP18PNRhoOSrNziVlM=
+istio.io/client-go v0.0.0-20200812230733-f5504d568313 h1:V0lIWo5DjSEJmjIDOrDJncZbzBMTVeluO9S+OopB53A=
+istio.io/client-go v0.0.0-20200812230733-f5504d568313/go.mod h1:SO65MWt7I45dvUwuDowoiB0SVcGpfWZfUTlopvYpbZc=
 istio.io/gogo-genproto v0.0.0-20190930162913-45029607206a/go.mod h1:OzpAts7jljZceG4Vqi5/zXy/pOg1b209T3jb7Nv5wIs=
 istio.io/gogo-genproto v0.0.0-20200720193312-b523a30fe746 h1:vc9lyLJIoe6D6PYXCx+gxh91500gzJfW8k3mhihCGnc=
 istio.io/gogo-genproto v0.0.0-20200720193312-b523a30fe746/go.mod h1:OzpAts7jljZceG4Vqi5/zXy/pOg1b209T3jb7Nv5wIs=

--- a/pilot/pkg/config/kube/crdclient/gen/main.go
+++ b/pilot/pkg/config/kube/crdclient/gen/main.go
@@ -96,6 +96,7 @@ var (
 		"sidecars":               "Sidecars",
 		"virtualservices":        "VirtualServices",
 		"workloadentries":        "WorkloadEntries",
+		"workloadgroups":         "WorkloadGroups",
 		"authorizationpolicies":  "AuthorizationPolicies",
 		"peerauthentications":    "PeerAuthentications",
 		"requestauthentications": "RequestAuthentications",

--- a/pilot/pkg/config/kube/crdclient/types.gen.go
+++ b/pilot/pkg/config/kube/crdclient/types.gen.go
@@ -79,6 +79,11 @@ func create(ic versionedclient.Interface, sc serviceapisclient.Interface, config
 			ObjectMeta: objMeta,
 			Spec:       *(config.Spec.(*networkingv1alpha3.WorkloadEntry)),
 		}, metav1.CreateOptions{})
+	case collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind():
+		return ic.NetworkingV1alpha3().WorkloadGroups(config.Namespace).Create(context.TODO(), &clientnetworkingv1alpha3.WorkloadGroup{
+			ObjectMeta: objMeta,
+			Spec:       *(config.Spec.(*networkingv1alpha3.WorkloadGroup)),
+		}, metav1.CreateOptions{})
 	case collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind():
 		return ic.SecurityV1beta1().AuthorizationPolicies(config.Namespace).Create(context.TODO(), &clientsecurityv1beta1.AuthorizationPolicy{
 			ObjectMeta: objMeta,
@@ -156,6 +161,11 @@ func update(ic versionedclient.Interface, sc serviceapisclient.Interface, config
 			ObjectMeta: objMeta,
 			Spec:       *(config.Spec.(*networkingv1alpha3.WorkloadEntry)),
 		}, metav1.UpdateOptions{})
+	case collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind():
+		return ic.NetworkingV1alpha3().WorkloadGroups(config.Namespace).Update(context.TODO(), &clientnetworkingv1alpha3.WorkloadGroup{
+			ObjectMeta: objMeta,
+			Spec:       *(config.Spec.(*networkingv1alpha3.WorkloadGroup)),
+		}, metav1.UpdateOptions{})
 	case collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind():
 		return ic.SecurityV1beta1().AuthorizationPolicies(config.Namespace).Update(context.TODO(), &clientsecurityv1beta1.AuthorizationPolicy{
 			ObjectMeta: objMeta,
@@ -212,6 +222,8 @@ func delete(ic versionedclient.Interface, sc serviceapisclient.Interface, typ re
 		return ic.NetworkingV1alpha3().VirtualServices(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
 	case collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind():
 		return ic.NetworkingV1alpha3().WorkloadEntries(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	case collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind():
+		return ic.NetworkingV1alpha3().WorkloadGroups(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
 	case collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind():
 		return ic.SecurityV1beta1().AuthorizationPolicies(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
 	case collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind():
@@ -327,6 +339,21 @@ var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model
 		return &model.Config{
 			ConfigMeta: model.ConfigMeta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind(),
+				Name:              obj.Name,
+				Namespace:         obj.Namespace,
+				Labels:            obj.Labels,
+				Annotations:       obj.Annotations,
+				ResourceVersion:   obj.ResourceVersion,
+				CreationTimestamp: obj.CreationTimestamp.Time,
+			},
+			Spec: &obj.Spec,
+		}
+	},
+	collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+		obj := r.(*clientnetworkingv1alpha3.WorkloadGroup)
+		return &model.Config{
+			ConfigMeta: model.ConfigMeta{
+				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
 				Labels:            obj.Labels,

--- a/pkg/config/schema/collections/collections.gen.go
+++ b/pkg/config/schema/collections/collections.gen.go
@@ -173,6 +173,24 @@ var (
 		}.MustBuild(),
 	}.MustBuild()
 
+	// IstioNetworkingV1Alpha3Workloadgroups describes the collection
+	// istio/networking/v1alpha3/workloadgroups
+	IstioNetworkingV1Alpha3Workloadgroups = collection.Builder{
+		Name:         "istio/networking/v1alpha3/workloadgroups",
+		VariableName: "IstioNetworkingV1Alpha3Workloadgroups",
+		Disabled:     false,
+		Resource: resource.Builder{
+			Group:         "networking.istio.io",
+			Kind:          "WorkloadGroup",
+			Plural:        "workloadgroups",
+			Version:       "v1alpha3",
+			Proto:         "istio.networking.v1alpha3.WorkloadGroup",
+			ProtoPackage:  "istio.io/api/networking/v1alpha3",
+			ClusterScoped: false,
+			ValidateProto: validation.EmptyValidate,
+		}.MustBuild(),
+	}.MustBuild()
+
 	// IstioSecurityV1Beta1Authorizationpolicies describes the collection
 	// istio/security/v1beta1/authorizationpolicies
 	IstioSecurityV1Beta1Authorizationpolicies = collection.Builder{
@@ -525,6 +543,24 @@ var (
 		}.MustBuild(),
 	}.MustBuild()
 
+	// K8SNetworkingIstioIoV1Alpha3Workloadgroups describes the collection
+	// k8s/networking.istio.io/v1alpha3/workloadgroups
+	K8SNetworkingIstioIoV1Alpha3Workloadgroups = collection.Builder{
+		Name:         "k8s/networking.istio.io/v1alpha3/workloadgroups",
+		VariableName: "K8SNetworkingIstioIoV1Alpha3Workloadgroups",
+		Disabled:     false,
+		Resource: resource.Builder{
+			Group:         "networking.istio.io",
+			Kind:          "WorkloadGroup",
+			Plural:        "workloadgroups",
+			Version:       "v1alpha3",
+			Proto:         "istio.networking.v1alpha3.WorkloadGroup",
+			ProtoPackage:  "istio.io/api/networking/v1alpha3",
+			ClusterScoped: false,
+			ValidateProto: validation.EmptyValidate,
+		}.MustBuild(),
+	}.MustBuild()
+
 	// K8SSecurityIstioIoV1Beta1Authorizationpolicies describes the collection
 	// k8s/security.istio.io/v1beta1/authorizationpolicies
 	K8SSecurityIstioIoV1Beta1Authorizationpolicies = collection.Builder{
@@ -662,6 +698,7 @@ var (
 		MustAdd(IstioNetworkingV1Alpha3Sidecars).
 		MustAdd(IstioNetworkingV1Alpha3Virtualservices).
 		MustAdd(IstioNetworkingV1Alpha3Workloadentries).
+		MustAdd(IstioNetworkingV1Alpha3Workloadgroups).
 		MustAdd(IstioSecurityV1Beta1Authorizationpolicies).
 		MustAdd(IstioSecurityV1Beta1Peerauthentications).
 		MustAdd(IstioSecurityV1Beta1Requestauthentications).
@@ -682,6 +719,7 @@ var (
 		MustAdd(K8SNetworkingIstioIoV1Alpha3Sidecars).
 		MustAdd(K8SNetworkingIstioIoV1Alpha3Virtualservices).
 		MustAdd(K8SNetworkingIstioIoV1Alpha3Workloadentries).
+		MustAdd(K8SNetworkingIstioIoV1Alpha3Workloadgroups).
 		MustAdd(K8SSecurityIstioIoV1Beta1Authorizationpolicies).
 		MustAdd(K8SSecurityIstioIoV1Beta1Peerauthentications).
 		MustAdd(K8SSecurityIstioIoV1Beta1Requestauthentications).
@@ -702,6 +740,7 @@ var (
 		MustAdd(IstioNetworkingV1Alpha3Sidecars).
 		MustAdd(IstioNetworkingV1Alpha3Virtualservices).
 		MustAdd(IstioNetworkingV1Alpha3Workloadentries).
+		MustAdd(IstioNetworkingV1Alpha3Workloadgroups).
 		MustAdd(IstioSecurityV1Beta1Authorizationpolicies).
 		MustAdd(IstioSecurityV1Beta1Peerauthentications).
 		MustAdd(IstioSecurityV1Beta1Requestauthentications).
@@ -726,6 +765,7 @@ var (
 		MustAdd(K8SNetworkingIstioIoV1Alpha3Sidecars).
 		MustAdd(K8SNetworkingIstioIoV1Alpha3Virtualservices).
 		MustAdd(K8SNetworkingIstioIoV1Alpha3Workloadentries).
+		MustAdd(K8SNetworkingIstioIoV1Alpha3Workloadgroups).
 		MustAdd(K8SSecurityIstioIoV1Beta1Authorizationpolicies).
 		MustAdd(K8SSecurityIstioIoV1Beta1Peerauthentications).
 		MustAdd(K8SSecurityIstioIoV1Beta1Requestauthentications).
@@ -744,6 +784,7 @@ var (
 		MustAdd(IstioNetworkingV1Alpha3Sidecars).
 		MustAdd(IstioNetworkingV1Alpha3Virtualservices).
 		MustAdd(IstioNetworkingV1Alpha3Workloadentries).
+		MustAdd(IstioNetworkingV1Alpha3Workloadgroups).
 		MustAdd(IstioSecurityV1Beta1Authorizationpolicies).
 		MustAdd(IstioSecurityV1Beta1Peerauthentications).
 		MustAdd(IstioSecurityV1Beta1Requestauthentications).
@@ -758,6 +799,7 @@ var (
 			MustAdd(IstioNetworkingV1Alpha3Sidecars).
 			MustAdd(IstioNetworkingV1Alpha3Virtualservices).
 			MustAdd(IstioNetworkingV1Alpha3Workloadentries).
+			MustAdd(IstioNetworkingV1Alpha3Workloadgroups).
 			MustAdd(IstioSecurityV1Beta1Authorizationpolicies).
 			MustAdd(IstioSecurityV1Beta1Peerauthentications).
 			MustAdd(IstioSecurityV1Beta1Requestauthentications).

--- a/pkg/config/schema/gvk/resources.gen.go
+++ b/pkg/config/schema/gvk/resources.gen.go
@@ -16,6 +16,7 @@ var (
 	Sidecar = collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind()
 	VirtualService = collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind()
 	WorkloadEntry = collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind()
+	WorkloadGroup = collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind()
 	AuthorizationPolicy = collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind()
 	PeerAuthentication = collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind()
 	RequestAuthentication = collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind()

--- a/pkg/config/schema/metadata.gen.go
+++ b/pkg/config/schema/metadata.gen.go
@@ -108,6 +108,11 @@ collections:
     group: "networking.istio.io"
     pilot: true
 
+  - name: "istio/networking/v1alpha3/workloadgroups"
+    kind: "WorkloadGroup"
+    group: "networking.istio.io"
+    pilot: true
+
   - name: "istio/networking/v1alpha3/sidecars"
     kind: "Sidecar"
     group: "networking.istio.io"
@@ -213,6 +218,10 @@ collections:
     kind: "WorkloadEntry"
     group: "networking.istio.io"
 
+  - name: "k8s/networking.istio.io/v1alpha3/workloadgroups"
+    kind: "WorkloadGroup"
+    group: "networking.istio.io"
+
   - name: "k8s/networking.istio.io/v1alpha3/sidecars"
     kind: "Sidecar"
     group: "networking.istio.io"
@@ -245,6 +254,7 @@ snapshots:
       - "istio/networking/v1alpha3/gateways"
       - "istio/networking/v1alpha3/serviceentries"
       - "istio/networking/v1alpha3/workloadentries"
+      - "istio/networking/v1alpha3/workloadgroups"
       - "istio/networking/v1alpha3/sidecars"
       - "istio/networking/v1alpha3/virtualservices"
       - "istio/security/v1beta1/authorizationpolicies"
@@ -405,6 +415,14 @@ resources:
     protoPackage: "istio.io/api/networking/v1alpha3"
     description: "describes workload entries"
 
+  - kind: "WorkloadGroup"
+    plural: "workloadgroups"
+    group: "networking.istio.io"
+    version: "v1alpha3"
+    proto: "istio.networking.v1alpha3.WorkloadGroup"
+    protoPackage: "istio.io/api/networking/v1alpha3"
+    description: "describes workload groups"
+
   - kind: "DestinationRule"
     plural: "destinationrules"
     group: "networking.istio.io"
@@ -480,6 +498,7 @@ transforms:
       "k8s/networking.istio.io/v1alpha3/gateways": "istio/networking/v1alpha3/gateways"
       "k8s/networking.istio.io/v1alpha3/serviceentries": "istio/networking/v1alpha3/serviceentries"
       "k8s/networking.istio.io/v1alpha3/workloadentries": "istio/networking/v1alpha3/workloadentries"
+      "k8s/networking.istio.io/v1alpha3/workloadgroups": "istio/networking/v1alpha3/workloadgroups"
       "k8s/networking.istio.io/v1alpha3/sidecars": "istio/networking/v1alpha3/sidecars"
       "k8s/networking.istio.io/v1alpha3/virtualservices": "istio/networking/v1alpha3/virtualservices"
       "k8s/security.istio.io/v1beta1/authorizationpolicies": "istio/security/v1beta1/authorizationpolicies"

--- a/pkg/config/schema/metadata.yaml
+++ b/pkg/config/schema/metadata.yaml
@@ -53,6 +53,11 @@ collections:
     group: "networking.istio.io"
     pilot: true
 
+  - name: "istio/networking/v1alpha3/workloadgroups"
+    kind: "WorkloadGroup"
+    group: "networking.istio.io"
+    pilot: true
+
   - name: "istio/networking/v1alpha3/sidecars"
     kind: "Sidecar"
     group: "networking.istio.io"
@@ -158,6 +163,10 @@ collections:
     kind: "WorkloadEntry"
     group: "networking.istio.io"
 
+  - name: "k8s/networking.istio.io/v1alpha3/workloadgroups"
+    kind: "WorkloadGroup"
+    group: "networking.istio.io"
+
   - name: "k8s/networking.istio.io/v1alpha3/sidecars"
     kind: "Sidecar"
     group: "networking.istio.io"
@@ -190,6 +199,7 @@ snapshots:
       - "istio/networking/v1alpha3/gateways"
       - "istio/networking/v1alpha3/serviceentries"
       - "istio/networking/v1alpha3/workloadentries"
+      - "istio/networking/v1alpha3/workloadgroups"
       - "istio/networking/v1alpha3/sidecars"
       - "istio/networking/v1alpha3/virtualservices"
       - "istio/security/v1beta1/authorizationpolicies"
@@ -350,6 +360,14 @@ resources:
     protoPackage: "istio.io/api/networking/v1alpha3"
     description: "describes workload entries"
 
+  - kind: "WorkloadGroup"
+    plural: "workloadgroups"
+    group: "networking.istio.io"
+    version: "v1alpha3"
+    proto: "istio.networking.v1alpha3.WorkloadGroup"
+    protoPackage: "istio.io/api/networking/v1alpha3"
+    description: "describes workload groups"
+
   - kind: "DestinationRule"
     plural: "destinationrules"
     group: "networking.istio.io"
@@ -425,6 +443,7 @@ transforms:
       "k8s/networking.istio.io/v1alpha3/gateways": "istio/networking/v1alpha3/gateways"
       "k8s/networking.istio.io/v1alpha3/serviceentries": "istio/networking/v1alpha3/serviceentries"
       "k8s/networking.istio.io/v1alpha3/workloadentries": "istio/networking/v1alpha3/workloadentries"
+      "k8s/networking.istio.io/v1alpha3/workloadgroups": "istio/networking/v1alpha3/workloadgroups"
       "k8s/networking.istio.io/v1alpha3/sidecars": "istio/networking/v1alpha3/sidecars"
       "k8s/networking.istio.io/v1alpha3/virtualservices": "istio/networking/v1alpha3/virtualservices"
       "k8s/security.istio.io/v1beta1/authorizationpolicies": "istio/security/v1beta1/authorizationpolicies"


### PR DESCRIPTION
PR to update the istio.io/client-go version as a result of the [changes in client-go](https://github.com/istio/client-go/pull/224) and changes and [changes in api](https://github.com/istio/api/pull/1554). Also included changes to generate the WorkloadGroup schemas properly in istio.io/istio.

Not sure which category this falls under, feel free to edit if necessary.
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

[x] Does not have any changes that may affect Istio users.