### PR TITLE
server: split monitoring and readiness mux

### DIFF
--- a/pilot/pkg/bootstrap/monitoring.go
+++ b/pilot/pkg/bootstrap/monitoring.go
@@ -104,7 +104,7 @@ func (m *monitor) Close() error {
 // initMonitor initializes the configuration for the pilot monitoring server.
 func (s *Server) initMonitor(addr string) error { //nolint: unparam
 	s.addStartFunc(func(stop <-chan struct{}) error {
-		monitor, err := startMonitor(addr, s.httpMux)
+		monitor, err := startMonitor(addr, s.monitoringMux)
 		if err != nil {
 			return err
 		}

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -481,7 +481,7 @@ func (c *client) AllDiscoveryDo(ctx context.Context, istiodNamespace, path strin
 	}
 	result := map[string][]byte{}
 	for _, istiod := range istiods {
-		res, err := c.proxyGet(istiod.Name, istiod.Namespace, path, 8080).DoRaw(ctx)
+		res, err := c.proxyGet(istiod.Name, istiod.Namespace, path, 15014).DoRaw(ctx)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Currently debug/monitoring and readiness share the same mux. As a result of that the debug and monitoring handlers are also available on `8080` port. We have a requirement to not expose these debug endpoints outside of pod - So we configured monitoringAddr accodinlgy. But we can not configure httpAddr like that because it exposes readiness probe. This PR splits the mux such that debug/monitoring has one mux used by monitoring server and httpServer has a separate readinessMux.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
