### PR TITLE
add warnings for gateway during uninstall

### DIFF
--- a/operator/pkg/helmreconciler/prune.go
+++ b/operator/pkg/helmreconciler/prune.go
@@ -206,7 +206,8 @@ func (h *HelmReconciler) DeleteControlPlaneByManifests(manifestMap name.Manifest
 	cpManifestMap := make(name.ManifestMap)
 	if revision != "" {
 		labels[label.IstioRev] = revision
-	} else if !includeClusterResources {
+	}
+	if !includeClusterResources {
 		// only delete istiod resources if revision is empty and --purge flag is not true.
 		cpManifestMap[name.PilotComponentName] = manifestMap[name.PilotComponentName]
 		manifestMap = cpManifestMap

--- a/operator/pkg/object/objects.go
+++ b/operator/pkg/object/objects.go
@@ -233,10 +233,10 @@ func (os K8sObjects) Keys() []string {
 }
 
 // UnstructuredItems returns the list of items of unstructured.Unstructured.
-func (os K8sObjects) UnstructuredItems() []*unstructured.Unstructured {
-	var usList []*unstructured.Unstructured
+func (os K8sObjects) UnstructuredItems() []unstructured.Unstructured {
+	var usList []unstructured.Unstructured
 	for _, obj := range os {
-		usList = append(usList, obj.UnstructuredObject())
+		usList = append(usList, *obj.UnstructuredObject())
 	}
 	return usList
 }


### PR DESCRIPTION
Consider these scenarios for `istioctl uninstall --revision` after doing a canary upgrade
1. remove old(default) revision
   no change for behavior, cp resources would be removed, gw would not be touched because it is in place upgraded to canary revision already.
2. remove canary revision
    update in this PR, warning would be issued if gw are to be removed, because that would leave cluster in a breaking status
    
related issue: https://github.com/istio/istio/issues/26470


Summary of output:
1. remove old(default) revision `istioctl uninstall --revision default`
- If all workloads were upgraded already, then no warnings, uninstall just proceed:
- otherwise
```
There are still 5 proxies pointing to the control plane revision default
If you proceed with the uninstall, these proxies will become detached from any control plane and will not function correctly.
Proceed? (y/N) 
```

2. remove canary revision `istioctl uninstall --revision 1-7-0-fix`

```
There are still 623 proxies pointing to the control plane revision 1-7-0-fix
If you proceed with the uninstall, these proxies will become detached from any control plane and will not function correctly.
You are about to remove the following gateways: istio-ingressgateway. To avoid downtime, please quit this command and reinstall the gateway(s) with a revision that is not being removed from the cluster.
Proceed? (y/N) 
```

3. `istioctl uninstall -f iop.yaml`
Only default CP resources would be removed, gw would not be touched


