### PR TITLE
filter out cross-network non mTLS lb eps

### DIFF
--- a/pilot/pkg/xds/xds_test.go
+++ b/pilot/pkg/xds/xds_test.go
@@ -17,7 +17,6 @@ package xds
 import (
 	"fmt"
 	"io/ioutil"
-	"istio.io/api/label"
 	"path"
 	"testing"
 
@@ -28,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/rand"
 
+	"istio.io/api/label"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"

--- a/pilot/pkg/xds/xds_test.go
+++ b/pilot/pkg/xds/xds_test.go
@@ -405,6 +405,7 @@ spec:
   location: MESH_INTERNAL
   endpoints:
   - address: 10.10.10.30
+    serviceAccount: svc-acc
     labels:
       app: se-pod
     network: network-1

--- a/pilot/pkg/xds/xds_test.go
+++ b/pilot/pkg/xds/xds_test.go
@@ -376,20 +376,6 @@ func TestMeshNetworking(t *testing.T) {
 						KubernetesObjects: k8sObjects,
 						ConfigString: `
 apiVersion: networking.istio.io/v1alpha3
-kind: DestinationRule
-metadata:
-  name: mtls-se-pod
-  namespace: pod
-spec:
-  host: se-pod.pod.svc.cluster.local
-  trafficPolicy:
-    tls:
-      mode: MUTUAL
-      clientCertificate: /etc/certs/myclientcert.pem
-      privateKey: /etc/certs/client_private_key.pem
-      caCertificates: /etc/certs/rootcacerts.pem
----
-apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: se-pod

--- a/pkg/test/framework/resource/cluster.go
+++ b/pkg/test/framework/resource/cluster.go
@@ -58,6 +58,15 @@ func (c Clusters) Names() []string {
 	return names
 }
 
+// ByNetwork returns a map of network name to a subset of clusters
+func (c Clusters) ByNetwork() map[string]Clusters {
+	out := map[string]Clusters{}
+	for _, cc := range c {
+		out[cc.NetworkName()] = append(out[cc.NetworkName()], cc)
+	}
+	return out
+}
+
 func (c Clusters) String() string {
 	return fmt.Sprintf("%v", c.Names())
 }

--- a/releasenotes/notes/26486.yaml
+++ b/releasenotes/notes/26486.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+  - 26517
+releaseNotes:
+  - |
+    **Fixed** Remove bad endpoints for non-injected workloads across networks.

--- a/releasenotes/notes/26486.yaml
+++ b/releasenotes/notes/26486.yaml
@@ -5,4 +5,4 @@ issue:
   - 26517
 releaseNotes:
   - |
-    **Fixed** Remove bad endpoints for non-injected workloads across networks.
+    **Fixed** Remove unreachable endpoints for non-injected workloads across networks.

--- a/tests/integration/pilot/vm_test.go
+++ b/tests/integration/pilot/vm_test.go
@@ -48,6 +48,7 @@ func TestVmOSPost(t *testing.T) {
 					DeployAsVM: true,
 					VMImage:    image,
 					Subsets:    []echo.SubsetConfig{{}},
+					Cluster:    ctx.Clusters().Default(),
 				})
 			}
 			b.BuildOrFail(ctx)
@@ -55,7 +56,7 @@ func TestVmOSPost(t *testing.T) {
 			for i, image := range images {
 				i, image := i, image
 				ctx.NewSubTest(image).RunParallel(func(ctx framework.TestContext) {
-					for _, tt := range vmTestCases(instances[i]) {
+					for _, tt := range vmTestCases(echo.Instances{instances[i]}) {
 						ExecuteTrafficTest(ctx, tt)
 					}
 				})


### PR DESCRIPTION
When a sidecared pod in network1 tries to reach a non-sidecared pod in network2, it will result in `TLS error: 268435703:SSL routines:OPENSSL_internal:WRONG_VERSION_NUMBER`.

This is problematic in a scenario where the non-sidecared service exists in both networks. We would loadbalance between endpoints we can reach and ones we cannot. It may be possible to do TLS termination for these endpoints at the gateway, but for now we should at least remove the unreachable endpoints. 

* Don't build cross-network endpoints with tlsmode disabled. 
* Test that cross network VMs still work in integration tests
* Test that we hit all network-local non-sidecar pods in integration tests (naked service)
* Update XDS tests to set tls mode properly

pilot-multicluster test runs: [95](https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/26486/integ-pilot-multicluster-tests_istio/95) [97](https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/26486/integ-pilot-multicluster-tests_istio/97). 

Fixes https://github.com/istio/istio/issues/26517

cc @costinm @howardjohn @hzxuzhonghu 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
