### PR TITLE
Azure platform optional prefix and logging level followup

### DIFF
--- a/pkg/bootstrap/platform/azure_test.go
+++ b/pkg/bootstrap/platform/azure_test.go
@@ -66,7 +66,7 @@ func TestAzureMetadata(t *testing.T) {
 		{"ignore empty response", "", map[string]string{}},
 		{"parse fields", MockMetadata,
 			map[string]string{"azure_Department": "IT", "azure_Environment": "Prod", "azure_Role": "WorkerRole",
-				AzureName: "negasonic", AzureLocation: "centralus", AzureVMID: "13f56399-bd52-4150-9748-7190aae1ff21"}},
+				"azure_name": "negasonic", "azure_location": "centralus", "azure_vmId": "13f56399-bd52-4150-9748-7190aae1ff21"}},
 	}
 
 	// Prevent actual requests to metadata server for updating the API version

--- a/pkg/bootstrap/platform/discovery.go
+++ b/pkg/bootstrap/platform/discovery.go
@@ -20,7 +20,7 @@ import (
 )
 
 const defaultTimeout = 5 * time.Second
-const Platforms = 3
+const numPlatforms = 3
 
 // Discover attempts to discover the host platform, defaulting to
 // `Unknown` if a platform cannot be discovered.
@@ -31,11 +31,11 @@ func Discover() Environment {
 // DiscoverWithTimeout attempts to discover the host platform, defaulting to
 // `Unknown` after the provided timeout.
 func DiscoverWithTimeout(timeout time.Duration) Environment {
-	plat := make(chan Environment, Platforms) // sized to match number of platform goroutines
+	plat := make(chan Environment, numPlatforms) // sized to match number of platform goroutines
 	done := make(chan bool)
 
 	var wg sync.WaitGroup
-	wg.Add(Platforms) // check GCP, AWS, and Azure
+	wg.Add(numPlatforms) // check GCP, AWS, and Azure
 
 	go func() {
 		if IsGCP() {


### PR DESCRIPTION
Follow up to this [Azure Platform Support](https://github.com/istio/istio/pull/24995).
Main changes are allowing the prefix to be set rather than hardcoded to "azure_", and lowering logging to a debug level so it doesn't create a warning when running discovery on a non-Azure platform.

[x] Configuration Infrastructure
[x] Does not have any changes that may affect Istio users.
