### PR TITLE
Add JWT authentication to XDS server

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -61,6 +61,7 @@ import (
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/security/pkg/k8s/chiron"
 	"istio.io/istio/security/pkg/pki/ca"
+	"istio.io/istio/security/pkg/server/ca/authenticate"
 	"istio.io/pkg/ctrlz"
 	"istio.io/pkg/filewatcher"
 	"istio.io/pkg/log"
@@ -279,6 +280,20 @@ func NewServer(args *PilotArgs) (*Server, error) {
 
 	if err := s.initClusterRegistries(args); err != nil {
 		return nil, fmt.Errorf("error initializing cluster registries: %v", err)
+	}
+
+	// Notice that the order of authenticators matters, since at runtime
+	// authenticators are activated sequentially and the first successful attempt
+	// is used as the authentication result.
+	// The JWT authenticator requires the multicluster registry to be initialized, so we build this later
+	authenticators := []authenticate.Authenticator{
+		&authenticate.ClientCertAuthenticator{},
+		authenticate.NewKubeJWTAuthenticator(s.kubeClient, s.clusterID, s.multicluster.GetRemoteKubeClient, spiffe.GetTrustDomain(), features.JwtPolicy.Get()),
+	}
+
+	caOpts.Authenticators = authenticators
+	if features.XDSAuth {
+		s.XDSServer.Authenticators = authenticators
 	}
 
 	s.initDNSServer(args)

--- a/pilot/pkg/xds/authentication.go
+++ b/pilot/pkg/xds/authentication.go
@@ -22,6 +22,8 @@ import (
 
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/peer"
+
+	"istio.io/istio/pilot/pkg/features"
 )
 
 // authenticate authenticates the ADS request using the configured authenticators.
@@ -29,7 +31,7 @@ import (
 // If no authenticators are configured, or if the request is on a non-secure
 // stream ( 15010 ) - returns an empty list of principals and no errors.
 func (s *DiscoveryServer) authenticate(ctx context.Context) ([]string, error) {
-	if len(s.Authenticators) == 0 {
+	if !features.XDSAuth {
 		return nil, nil
 	}
 
@@ -56,6 +58,6 @@ func (s *DiscoveryServer) authenticate(ctx context.Context) ([]string, error) {
 		authFailMsgs = append(authFailMsgs, fmt.Sprintf("Authenticator %s: %v", authn.AuthenticatorType(), err))
 	}
 
-	adsLog.Errora("Failed to authenticate client from ", peerInfo.Addr.String(), " ", strings.Join(authFailMsgs, ";"))
+	adsLog.Errora("Failed to authenticate client from ", peerInfo.Addr.String(), " ", strings.Join(authFailMsgs, "; "))
 	return nil, errors.New("authentication failure")
 }

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -164,17 +164,6 @@ func NewDiscoveryServer(env *model.Environment, plugins []string) *DiscoveryServ
 		},
 	}
 
-	if features.XDSAuth {
-		// This is equivalent with the mTLS authentication for workload-to-workload.
-		// The GRPC server is configured in bootstrap.initSecureDiscoveryService, using the root
-		// certificate as 'ClientCAs'. To accept additional signers for client identities - add them
-		// there, will be used for CA signing as well.
-		out.Authenticators = append(out.Authenticators, &authenticate.ClientCertAuthenticator{})
-
-		// TODO: we may want to support JWT/OIDC auth as well - using the same list of auth as
-		// CA. Will require additional refactoring - probably best for 1.7.
-	}
-
 	// Flush cached discovery responses when detecting jwt public key change.
 	model.GetJwtKeyResolver().PushFunc = func() {
 		out.ConfigUpdate(&model.PushRequest{Full: true, Reason: []model.TriggerReason{model.UnknownTrigger}})

--- a/security/pkg/server/ca/server.go
+++ b/security/pkg/server/ca/server.go
@@ -15,33 +15,20 @@
 package ca
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"fmt"
-	"net"
 	"time"
 
-	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
-	"k8s.io/client-go/kubernetes"
 
 	pb "istio.io/api/security/v1alpha1"
 	caerror "istio.io/istio/security/pkg/pki/error"
 	"istio.io/istio/security/pkg/pki/util"
 	"istio.io/istio/security/pkg/server/ca/authenticate"
 	"istio.io/pkg/log"
-)
-
-// Config for Vault prototyping purpose
-const (
-	jwtPath              = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-	caCertPath           = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-	certExpirationBuffer = time.Minute
 )
 
 var serverCaLog = log.RegisterScope("serverca", "Citadel server log", 0)
@@ -62,13 +49,8 @@ type CertificateAuthority interface {
 type Server struct {
 	monitoring     monitoringMetrics
 	Authenticators []authenticate.Authenticator
-	hostnames      []string
 	ca             CertificateAuthority
 	serverCertTTL  time.Duration
-	certificate    *tls.Certificate
-	port           int
-	forCA          bool
-	grpcServer     *grpc.Server
 }
 
 func getConnectionAddress(ctx context.Context) string {
@@ -137,145 +119,22 @@ func recordCertsExpiry(keyCertBundle util.KeyCertBundle) {
 	certChainExpiryTimestamp.Record(certChainExpiry)
 }
 
-// Run starts a GRPC server on the specified port.
-func (s *Server) Run() error {
-	grpcServer := s.grpcServer
-	var listener net.Listener
-	var err error
-
-	if grpcServer == nil {
-		listener, err = net.Listen("tcp", fmt.Sprintf(":%d", s.port))
-		if err != nil {
-			return fmt.Errorf("cannot listen on port %d (error: %v)", s.port, err)
-		}
-
-		var grpcOptions []grpc.ServerOption
-		grpcOptions = append(grpcOptions, s.createTLSServerOption(), grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor))
-
-		grpcServer = grpc.NewServer(grpcOptions...)
-	}
+// Register registers a GRPC server on the specified port.
+func (s *Server) Register(grpcServer *grpc.Server) {
 	pb.RegisterIstioCertificateServiceServer(grpcServer, s)
-
-	grpc_prometheus.EnableHandlingTimeHistogram()
-	grpc_prometheus.Register(grpcServer)
-
-	if listener != nil {
-		// grpcServer.Serve() is a blocking call, so run it in a goroutine.
-		go func() {
-			serverCaLog.Infof("Starting GRPC server on port %d", s.port)
-
-			err := grpcServer.Serve(listener)
-
-			// grpcServer.Serve() always returns a non-nil error.
-			serverCaLog.Warnf("GRPC server returns an error: %v", err)
-		}()
-	}
-
-	return nil
 }
 
-// New creates a new instance of `IstioCAServiceServer`.
-func New(ca CertificateAuthority, ttl time.Duration, forCA bool,
-	hostlist []string, port int, trustDomain string, sdsEnabled bool, jwtPolicy, clusterID string) (*Server, error) {
-	return NewWithGRPC(nil, ca, ttl, forCA, hostlist, port, trustDomain, sdsEnabled, jwtPolicy, clusterID, nil, nil)
-}
-
-// New creates a new instance of `IstioCAServiceServer`, running inside an existing gRPC server.
-func NewWithGRPC(grpc *grpc.Server, ca CertificateAuthority, ttl time.Duration, forCA bool,
-	hostlist []string, port int, trustDomain string, sdsEnabled bool, jwtPolicy, clusterID string,
-	kubeClient kubernetes.Interface,
-	remoteKubeClientGetter authenticate.RemoteKubeClientGetter) (*Server, error) {
-
-	if len(hostlist) == 0 {
-		return nil, fmt.Errorf("failed to create grpc server hostlist empty")
-	}
-	// Notice that the order of authenticators matters, since at runtime
-	// authenticators are activated sequentially and the first successful attempt
-	// is used as the authentication result.
-	authenticators := []authenticate.Authenticator{&authenticate.ClientCertAuthenticator{}}
-	serverCaLog.Info("added client certificate authenticator")
-
-	// Only add k8s jwt authenticator if SDS is enabled.
-	if sdsEnabled {
-		authenticator := authenticate.NewKubeJWTAuthenticator(kubeClient, clusterID, remoteKubeClientGetter,
-			trustDomain, jwtPolicy)
-		authenticators = append(authenticators, authenticator)
-		serverCaLog.Info("added K8s JWT authenticator")
-	}
-
+// New creates a new instance of `IstioCAServiceServer`
+func New(ca CertificateAuthority, ttl time.Duration, authenticators []authenticate.Authenticator) (*Server, error) {
 	recordCertsExpiry(ca.GetCAKeyCertBundle())
 
 	server := &Server{
 		Authenticators: authenticators,
 		serverCertTTL:  ttl,
 		ca:             ca,
-		hostnames:      hostlist,
-		forCA:          forCA,
-		port:           port,
-		grpcServer:     grpc,
 		monitoring:     newMonitoringMetrics(),
 	}
 	return server, nil
-}
-
-func (s *Server) createTLSServerOption() grpc.ServerOption {
-	cp := x509.NewCertPool()
-	rootCertBytes := s.ca.GetCAKeyCertBundle().GetRootCertPem()
-	cp.AppendCertsFromPEM(rootCertBytes)
-
-	config := &tls.Config{
-		ClientCAs:  cp,
-		ClientAuth: tls.VerifyClientCertIfGiven,
-		GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
-			if s.certificate == nil || shouldRefresh(s.certificate) {
-				// Apply new certificate if there isn't one yet, or the one has become invalid.
-				newCert, err := s.getServerCertificate()
-				if err != nil {
-					return nil, fmt.Errorf("failed to apply TLS server certificate (%v)", err)
-				}
-				s.certificate = newCert
-			}
-			return s.certificate, nil
-		},
-	}
-	return grpc.Creds(credentials.NewTLS(config))
-}
-
-// getServerCertificate returns a valid server TLS certificate and the intermediate CA certificates,
-// signed by the current CA root.
-func (s *Server) getServerCertificate() (*tls.Certificate, error) {
-	opts := util.CertOptions{
-		RSAKeySize: 2048,
-	}
-
-	bundle := s.ca.GetCAKeyCertBundle()
-	if bundle != nil {
-		// cert bundles can have errors (e.g. missing SAN)
-		// that do not matter for getting the encryption type
-		_, privKey, _, _ := bundle.GetAll()
-		if util.IsSupportedECPrivateKey(privKey) {
-			opts = util.CertOptions{
-				ECSigAlg: util.EcdsaSigAlg,
-			}
-		}
-	}
-
-	// TODO the user can specify algorithm to generate for CSRs independent of CA certificate
-	csrPEM, privPEM, err := util.GenCSR(opts)
-	if err != nil {
-		return nil, err
-	}
-
-	certPEM, signErr := s.ca.SignWithCertChain(csrPEM, s.hostnames, s.serverCertTTL, false)
-	if signErr != nil {
-		return nil, signErr.(*caerror.Error)
-	}
-
-	cert, err := tls.X509KeyPair(certPEM, privPEM)
-	if err != nil {
-		return nil, err
-	}
-	return &cert, nil
 }
 
 // authenticate goes through a list of authenticators (provided client cert, k8s jwt, and ID token)
@@ -295,16 +154,4 @@ func (s *Server) authenticate(ctx context.Context) *authenticate.Caller {
 	}
 	serverCaLog.Warnf("Authentication failed for %v: %s", getConnectionAddress(ctx), errMsg)
 	return nil
-}
-
-// shouldRefresh indicates whether the given certificate should be refreshed.
-func shouldRefresh(cert *tls.Certificate) bool {
-	// Check whether there is a valid leaf certificate.
-	leaf := cert.Leaf
-	if leaf == nil {
-		return true
-	}
-
-	// Check whether the leaf certificate is about to expire.
-	return leaf.NotAfter.Add(-certExpirationBuffer).Before(time.Now())
 }

--- a/security/pkg/server/ca/server_test.go
+++ b/security/pkg/server/ca/server_test.go
@@ -20,9 +20,7 @@ import (
 	"crypto/x509/pkix"
 	"fmt"
 	"net"
-	"os"
 	"testing"
-	"time"
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
@@ -31,27 +29,12 @@ import (
 	"google.golang.org/grpc/status"
 
 	pb "istio.io/api/security/v1alpha1"
-	"istio.io/istio/pkg/jwt"
-	"istio.io/istio/security/pkg/pki/ca"
 	mockca "istio.io/istio/security/pkg/pki/ca/mock"
 	caerror "istio.io/istio/security/pkg/pki/error"
 	"istio.io/istio/security/pkg/pki/util"
 	mockutil "istio.io/istio/security/pkg/pki/util/mock"
 	"istio.io/istio/security/pkg/server/ca/authenticate"
 )
-
-const csr = `
------BEGIN CERTIFICATE REQUEST-----
-MIIBoTCCAQoCAQAwEzERMA8GA1UEChMISnVqdSBvcmcwgZ8wDQYJKoZIhvcNAQEB
-BQADgY0AMIGJAoGBANFf06eqiDx0+qD/xBAR5aMwwgaBOn6TPfSy96vOxLTsfkTg
-ir/vb8UG+F5hO6yxF+z2BgzD8LwcbKnxahoPq/aWGLw3Umcqm4wxgWKHxvtYSQDG
-w4zpmKOqgkagxbx32JXDlMpi6adUVHNvB838CiUys6IkVB0obGHnre8zmCLdAgMB
-AAGgTjBMBgkqhkiG9w0BCQ4xPzA9MDsGA1UdEQQ0MDKGMHNwaWZmZTovL3Rlc3Qu
-Y29tL25hbWVzcGFjZS9ucy9zZXJ2aWNlYWNjb3VudC9zYTANBgkqhkiG9w0BAQsF
-AAOBgQCw9dL6xRQSjdYKt7exqlTJliuNEhw/xDVGlNUbDZnT0uL3zXI//Z8tsejn
-8IFzrDtm0Z2j4BmBzNMvYBKL/4JPZ8DFywOyQqTYnGtHIkt41CNjGfqJRk8pIqVC
-hKldzzeCKNgztEvsUKVqltFZ3ZYnkj/8/Cg8zUtTkOhHOjvuig==
------END CERTIFICATE REQUEST-----`
 
 type mockAuthenticator struct {
 	authSource authenticate.AuthSource
@@ -104,8 +87,6 @@ func TestCreateCertificateE2EUsingClientCertAuthenticator(t *testing.T) {
 				RootCertBytes:  []byte("root_cert"),
 			},
 		},
-		hostnames:      []string{"hostname"},
-		port:           8080,
 		Authenticators: []authenticate.Authenticator{auth},
 		monitoring:     newMonitoringMetrics(),
 	}
@@ -257,8 +238,6 @@ func TestCreateCertificate(t *testing.T) {
 	for id, c := range testCases {
 		server := &Server{
 			ca:             c.ca,
-			hostnames:      []string{"hostname"},
-			port:           8080,
 			Authenticators: c.authenticators,
 			monitoring:     newMonitoringMetrics(),
 		}
@@ -281,203 +260,6 @@ func TestCreateCertificate(t *testing.T) {
 				}
 			}
 
-		}
-	}
-}
-
-func TestShouldRefresh(t *testing.T) {
-	now := time.Now()
-	testCases := map[string]struct {
-		cert          *tls.Certificate
-		shouldRefresh bool
-	}{
-		"No leaf cert": {
-			cert:          &tls.Certificate{},
-			shouldRefresh: true,
-		},
-		"Cert is expired": {
-			cert: &tls.Certificate{
-				Leaf: &x509.Certificate{NotAfter: now},
-			},
-			shouldRefresh: true,
-		},
-		"Cert is about to expire": {
-			cert: &tls.Certificate{
-				Leaf: &x509.Certificate{NotAfter: now.Add(5 * time.Second)},
-			},
-			shouldRefresh: true,
-		},
-		"Cert is valid": {
-			cert: &tls.Certificate{
-				Leaf: &x509.Certificate{NotAfter: now.Add(5 * time.Minute)},
-			},
-			shouldRefresh: false,
-		},
-	}
-
-	for id, tc := range testCases {
-		result := shouldRefresh(tc.cert)
-		if tc.shouldRefresh != result {
-			t.Errorf("%s: expected result is %t but got %t", id, tc.shouldRefresh, result)
-		}
-	}
-}
-
-func TestRun(t *testing.T) {
-	k8sEnv := false
-	if _, err := os.Stat(caCertPath); !os.IsNotExist(err) {
-		if _, err := os.Stat(jwtPath); !os.IsNotExist(err) {
-			k8sEnv = true
-		}
-	}
-	testCases := map[string]struct {
-		ca                        *mockca.FakeCA
-		hostname                  []string
-		port                      int
-		expectedErr               string
-		getServerCertificateError string
-		expectedAuthenticatorsLen int
-	}{
-		"Invalid listening port number": {
-			ca:          &mockca.FakeCA{SignedCert: []byte(csr)},
-			hostname:    []string{"localhost"},
-			port:        -1,
-			expectedErr: "cannot listen on port -1 (error: listen tcp: address -1: invalid port)",
-		},
-		"CA sign error": {
-			ca:                        &mockca.FakeCA{SignErr: caerror.NewError(caerror.CANotReady, fmt.Errorf("cannot sign"))},
-			hostname:                  []string{"localhost"},
-			port:                      0,
-			expectedErr:               "",
-			expectedAuthenticatorsLen: 2, // 2 when ID token authenticators are enabled.
-			getServerCertificateError: "cannot sign",
-		},
-		"Bad signed cert": {
-			ca:                        &mockca.FakeCA{SignedCert: []byte(csr)},
-			hostname:                  []string{"localhost"},
-			port:                      0,
-			expectedErr:               "",
-			expectedAuthenticatorsLen: 2, // 2 when ID token authenticators are enabled.
-			getServerCertificateError: "tls: failed to find \"CERTIFICATE\" PEM block in certificate " +
-				"input after skipping PEM blocks of the following types: [CERTIFICATE REQUEST]",
-		},
-		"Multiple hostname": {
-			ca:                        &mockca.FakeCA{SignedCert: []byte(csr)},
-			hostname:                  []string{"localhost", "fancyhost"},
-			port:                      0,
-			expectedAuthenticatorsLen: 2, // 3 when ID token authenticators are enabled.
-			getServerCertificateError: "tls: failed to find \"CERTIFICATE\" PEM block in certificate " +
-				"input after skipping PEM blocks of the following types: [CERTIFICATE REQUEST]",
-		},
-		"Empty hostnames": {
-			ca:          &mockca.FakeCA{SignedCert: []byte(csr)},
-			hostname:    []string{},
-			expectedErr: "failed to create grpc server hostlist empty",
-		},
-	}
-
-	for id, tc := range testCases {
-		if k8sEnv {
-			// K8s JWT authenticator is added in k8s env.
-			tc.expectedAuthenticatorsLen++
-		}
-		server, err := New(tc.ca, time.Hour, false, tc.hostname, tc.port, "testdomain.com", true,
-			jwt.PolicyThirdParty, "kubernetes")
-		if err == nil {
-			err = server.Run()
-		}
-		if len(tc.expectedErr) > 0 {
-			if err == nil {
-				t.Errorf("%s: Succeeded. Error expected: %v", id, err)
-			} else if err.Error() != tc.expectedErr {
-				t.Errorf("%s: incorrect error message: %s VS %s",
-					id, err.Error(), tc.expectedErr)
-			}
-			continue
-		} else if err != nil {
-			t.Fatalf("%s: Unexpected Error: %v", id, err)
-		}
-
-		if len(server.Authenticators) != tc.expectedAuthenticatorsLen {
-			t.Fatalf("%s: Unexpected Authenticators Length. Expected: %v Actual: %v",
-				id, tc.expectedAuthenticatorsLen, len(server.Authenticators))
-		}
-
-		if len(tc.hostname) != len(server.hostnames) {
-			t.Errorf("%s: unmatched number of hosts in CA server configuration. %d (expected) vs %d", id, len(tc.hostname), len(server.hostnames))
-		}
-		for i, hostname := range tc.hostname {
-			if hostname != server.hostnames[i] {
-				t.Errorf("%s: unmatched hosts in CA server configuration. %v (expected) vs %v", id, tc.hostname, server.hostnames)
-			}
-		}
-
-		_, err = server.getServerCertificate()
-		if len(tc.getServerCertificateError) > 0 {
-			if err == nil {
-				t.Errorf("%s: Succeeded. Error expected: %v", id, err)
-			} else if err.Error() != tc.getServerCertificateError {
-				t.Errorf("%s: incorrect error message: %s VS %s",
-					id, err.Error(), tc.getServerCertificateError)
-			}
-			continue
-		} else if err != nil {
-			t.Fatalf("%s: Unexpected Error: %v", id, err)
-		}
-	}
-}
-
-func TestGetServerCertificate(t *testing.T) {
-	cases := map[string]struct {
-		rootCertFile    string
-		certChainFile   string
-		signingCertFile string
-		signingKeyFile  string
-	}{
-		"RSA server cert": {
-			rootCertFile:    "../../pki/testdata/multilevelpki/root-cert.pem",
-			certChainFile:   "../../pki/testdata/multilevelpki/int2-cert-chain.pem",
-			signingCertFile: "../../pki/testdata/multilevelpki/int2-cert.pem",
-			signingKeyFile:  "../../pki/testdata/multilevelpki/int2-key.pem",
-		},
-		"ECC server cert": {
-			rootCertFile:    "../../pki/testdata/multilevelpki/ecc-root-cert.pem",
-			certChainFile:   "../../pki/testdata/multilevelpki/ecc-int2-cert-chain.pem",
-			signingCertFile: "../../pki/testdata/multilevelpki/ecc-int2-cert.pem",
-			signingKeyFile:  "../../pki/testdata/multilevelpki/ecc-int2-key.pem",
-		},
-	}
-
-	defaultWorkloadCertTTL := 30 * time.Minute
-	maxWorkloadCertTTL := time.Hour
-	rsaKeySize := 2048
-
-	for id, tc := range cases {
-		caopts, err := ca.NewPluggedCertIstioCAOptions(tc.certChainFile, tc.signingCertFile, tc.signingKeyFile, tc.rootCertFile,
-			defaultWorkloadCertTTL, maxWorkloadCertTTL, rsaKeySize)
-		if err != nil {
-			t.Fatalf("%s: Failed to create a plugged-cert CA Options: %v", id, err)
-		}
-
-		ca, err := ca.NewIstioCA(caopts)
-		if err != nil {
-			t.Errorf("%s: Got error while creating plugged-cert CA: %v", id, err)
-		}
-		if ca == nil {
-			t.Fatalf("Failed to create a plugged-cert CA.")
-		}
-
-		server, err := New(ca, time.Hour, false, []string{"localhost"}, 0,
-			"testdomain.com", true, jwt.PolicyThirdParty, "kubernetes")
-		if err != nil {
-			t.Errorf("%s: Cannot crete server: %v", id, err)
-		}
-		cert, err := server.getServerCertificate()
-		if err != nil {
-			t.Errorf("%s: getServerCertificate error: %v", id, err)
-		}
-		if len(cert.Certificate) != 4 {
-			t.Errorf("Unexpected number of certificates returned: %d (expected 4)", len(cert.Certificate))
 		}
 	}
 }


### PR DESCRIPTION
This change adds JWT authenticator to the XDS server. As part of this, there is a lot of refactoring of the CA server so we can split out the authenticators part and share the same constructor for the authenticators. There is a ton of dead code removed in the process