### PR TITLE
fix error message to use Istiod instead of pilot

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -477,7 +477,7 @@ func (c *client) AllDiscoveryDo(ctx context.Context, istiodNamespace, path strin
 		return nil, err
 	}
 	if len(istiods) == 0 {
-		return nil, errors.New("unable to find any Pilot instances")
+		return nil, errors.New("unable to find any Istiod instances")
 	}
 	result := map[string][]byte{}
 	for _, istiod := range istiods {


### PR DESCRIPTION
This is printed in `istioctl ps` when there are no istiod instances.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.