### PR TITLE
Fix validation test errors

### DIFF
--- a/galley/testdatasets/validation/dataset.gen.go
+++ b/galley/testdatasets/validation/dataset.gen.go
@@ -523,7 +523,6 @@ var _datasetNetworkingV1alpha3WorkloadgroupInvalidYaml = []byte(`apiVersion: net
 kind: WorkloadGroup
 metadata:
   name: reviews
-  namespace: istio-system
 spec:
   metadata:
     labels:
@@ -551,7 +550,6 @@ var _datasetNetworkingV1alpha3WorkloadgroupValidYaml = []byte(`apiVersion: netwo
 kind: WorkloadGroup
 metadata:
   name: reviews
-  namespace: istio-system
 spec:
   metadata:
     labels:

--- a/galley/testdatasets/validation/dataset/networking-v1alpha3-WorkloadGroup-invalid.yaml
+++ b/galley/testdatasets/validation/dataset/networking-v1alpha3-WorkloadGroup-invalid.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.istio.io/v1alpha3
 kind: WorkloadGroup
 metadata:
   name: reviews
-  namespace: istio-system
 spec:
   metadata:
     labels:

--- a/galley/testdatasets/validation/dataset/networking-v1alpha3-WorkloadGroup-valid.yaml
+++ b/galley/testdatasets/validation/dataset/networking-v1alpha3-WorkloadGroup-valid.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.istio.io/v1alpha3
 kind: WorkloadGroup
 metadata:
   name: reviews
-  namespace: istio-system
 spec:
   metadata:
     labels:

--- a/tests/integration/pilot/validation_test.go
+++ b/tests/integration/pilot/validation_test.go
@@ -101,31 +101,31 @@ func TestValidation(t *testing.T) {
 					})
 
 					applyFiles := ctx.WriteYAMLOrFail(ctx, "apply", ym)
-					err = ctx.Clusters().Default().ApplyYAMLFilesDryRun(ns.Name(), applyFiles...)
+					dryRunErr := ctx.Clusters().Default().ApplyYAMLFilesDryRun(ns.Name(), applyFiles...)
 
 					switch {
-					case err != nil && d.isValid():
-						if denied(err) {
-							ctx.Fatalf("got unexpected for valid config: %v", err)
+					case dryRunErr != nil && d.isValid():
+						if denied(dryRunErr) {
+							ctx.Fatalf("got unexpected for valid config: %v", dryRunErr)
 						} else {
-							ctx.Fatalf("got unexpected unknown error for valid config: %v", err)
+							ctx.Fatalf("got unexpected unknown error for valid config: %v", dryRunErr)
 						}
-					case err == nil && !d.isValid():
+					case dryRunErr == nil && !d.isValid():
 						ctx.Fatalf("got unexpected success for invalid config")
-					case err != nil && !d.isValid():
-						if !denied(err) {
-							ctx.Fatalf("config request denied for wrong reason: %v", err)
+					case dryRunErr != nil && !d.isValid():
+						if !denied(dryRunErr) {
+							ctx.Fatalf("config request denied for wrong reason: %v", dryRunErr)
 						}
 					}
 
 					wetRunErr := ctx.Clusters().Default().ApplyYAMLFiles(ns.Name(), applyFiles...)
 					defer func() { _ = ctx.Clusters().Default().DeleteYAMLFiles(ns.Name(), applyFiles...) }()
 
-					if err != nil && wetRunErr == nil {
-						ctx.Fatalf("dry run returned no errors, but wet run returned: %v", wetRunErr)
+					if dryRunErr != nil && wetRunErr == nil {
+						ctx.Fatalf("dry run returned error, but wet run returned none: %v", dryRunErr)
 					}
-					if err == nil && wetRunErr != nil {
-						ctx.Fatalf("wet run returned no errors, but dry run returned: %v", err)
+					if dryRunErr == nil && wetRunErr != nil {
+						ctx.Fatalf("wet run returned errors, but dry run returned none: %v", wetRunErr)
 					}
 				})
 			}


### PR DESCRIPTION
It is run in parallel but due to go loop semantics, we just test the
last element in the loop! As a result an invalid config (had namespace
in it) was merged, which meant the test failed ~1/10 times. This fixes
that and cleans up the logging a bit



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.