### PR TITLE
Allow unknown fields in the old-ver IstioOperator during istioctl upgrade

### DIFF
--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -195,7 +195,7 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 	} else {
 		currentSets = append(currentSets, "profile="+targetIOPS.Profile)
 	}
-	currentProfileIOPSYaml, _, err := manifest.GenIOPSFromProfile(profile, "", currentSets, true, nil, l)
+	currentProfileIOPSYaml, _, err := manifest.GenIOPSFromProfile(profile, "", currentSets, true, true, nil, l)
 	if err != nil {
 		return fmt.Errorf("failed to generate Istio configs from file %s for the current version: %s, error: %v",
 			args.inFilenames, currentVersion, err)

--- a/operator/pkg/apis/istio/v1alpha1/validation/validation_test.go
+++ b/operator/pkg/apis/istio/v1alpha1/validation/validation_test.go
@@ -92,7 +92,7 @@ func TestValidateProfiles(t *testing.T) {
 	l := clog.NewConsoleLogger(os.Stdout, os.Stderr, nil)
 	for _, tt := range profiles {
 		t.Run(tt, func(t *testing.T) {
-			_, s, err := manifest.GenIOPSFromProfile(tt, "", []string{"installPackagePath=" + manifests}, false, nil, l)
+			_, s, err := manifest.GenIOPSFromProfile(tt, "", []string{"installPackagePath=" + manifests}, false, false, nil, l)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/operator/pkg/manifest/shared.go
+++ b/operator/pkg/manifest/shared.go
@@ -55,7 +55,7 @@ func GenManifests(inFilename []string, setFlags []string, force bool,
 	if err != nil {
 		return nil, nil, err
 	}
-	mergedIOPS, err := unmarshalAndValidateIOPS(mergedYAML, force, l)
+	mergedIOPS, err := unmarshalAndValidateIOPS(mergedYAML, force, false, l)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -99,7 +99,7 @@ func GenerateConfig(inFilenames []string, setFlags []string, force bool, kubeCon
 		return "", nil, err
 	}
 
-	iopsString, iops, err := GenIOPSFromProfile(profile, fy, setFlags, force, kubeConfig, l)
+	iopsString, iops, err := GenIOPSFromProfile(profile, fy, setFlags, force, false, kubeConfig, l)
 
 	if err != nil {
 		return "", nil, err
@@ -118,7 +118,7 @@ func GenerateConfig(inFilenames []string, setFlags []string, force bool, kubeCon
 
 // GenIOPSFromProfile generates an IstioOperatorSpec from the given profile name or path, and overlay YAMLs from user
 // files and the --set flag. If successful, it returns an IstioOperatorSpec string and struct.
-func GenIOPSFromProfile(profileOrPath, fileOverlayYAML string, setFlags []string, skipValidation bool,
+func GenIOPSFromProfile(profileOrPath, fileOverlayYAML string, setFlags []string, skipValidation, allowUnknownField bool,
 	kubeConfig *rest.Config, l clog.Logger) (string, *v1alpha1.IstioOperatorSpec, error) {
 
 	installPackagePath, err := getInstallPackagePath(fileOverlayYAML)
@@ -195,7 +195,7 @@ func GenIOPSFromProfile(profileOrPath, fileOverlayYAML string, setFlags []string
 		return "", nil, err
 	}
 
-	finalIOPS, err := unmarshalAndValidateIOPS(outYAML, skipValidation, l)
+	finalIOPS, err := unmarshalAndValidateIOPS(outYAML, skipValidation, allowUnknownField, l)
 	if err != nil {
 		return "", nil, err
 	}
@@ -419,9 +419,9 @@ func getJwtTypeOverlay(config *rest.Config, l clog.Logger) (string, error) {
 // unmarshalAndValidateIOPS unmarshals a string containing IstioOperator YAML, validates it, and returns a struct
 // representation if successful. If force is set, validation errors are written to logger rather than causing an
 // error.
-func unmarshalAndValidateIOPS(iopsYAML string, force bool, l clog.Logger) (*v1alpha1.IstioOperatorSpec, error) {
+func unmarshalAndValidateIOPS(iopsYAML string, force, allowUnknownField bool, l clog.Logger) (*v1alpha1.IstioOperatorSpec, error) {
 	iops := &v1alpha1.IstioOperatorSpec{}
-	if err := util.UnmarshalWithJSONPB(iopsYAML, iops, false); err != nil {
+	if err := util.UnmarshalWithJSONPB(iopsYAML, iops, allowUnknownField); err != nil {
 		return nil, fmt.Errorf("could not unmarshal merged YAML: %s\n\nYAML:\n%s", err, iopsYAML)
 	}
 	if errs := validate.CheckIstioOperatorSpec(iops, true); len(errs) != 0 && !force {


### PR DESCRIPTION
Fix: #26475

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
