### PR TITLE
server: fix multiplexing on plain text port

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -480,10 +480,8 @@ func (s *Server) initDiscoveryService(args *PilotArgs) error {
 	})
 
 	s.initGrpcServer(args.KeepaliveOptions)
-	grpcListener, err := net.Listen("tcp", args.ServerOptions.GRPCAddr)
-	if err != nil {
-		return err
-	}
+	grpcListener, _ := net.Listen("tcp", args.ServerOptions.GRPCAddr)
+
 	s.GRPCListener = grpcListener
 
 	// This happens only if the GRPC port (15010) is disabled. We will multiplex


### PR DESCRIPTION
https://github.com/istio/istio/pull/26481 multiplexes gRPC on plain text port if gRPC port is off. But the place it was added is incorrect. When http server is being initialized, ` s.GRPCListener` will always be nil as it is initialized later. This PR fixes that order.
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X ] Does not have any changes that may affect Istio users.
