### PR TITLE
Add auto mtls to benchmark tests and improve memory

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -861,7 +861,7 @@ func applyUpstreamTLSSettings(opts *buildClusterOpts, tls *networking.ClientTLSS
 	c := opts.cluster
 	proxy := opts.proxy
 
-	certValidationContext := &auth.CertificateValidationContext{}
+	var certValidationContext *auth.CertificateValidationContext
 	var trustedCa *core.DataSource
 
 	// Configure root cert for UpstreamTLSContext
@@ -901,18 +901,20 @@ func applyUpstreamTLSSettings(opts *buildClusterOpts, tls *networking.ClientTLSS
 			c.TransportSocket = nil
 			c.TransportSocketMatches = []*cluster.Cluster_TransportSocketMatch{
 				{
-					Name: "tlsMode-" + model.IstioMutualTLSModeLabel,
-					Match: &structpb.Struct{
-						Fields: map[string]*structpb.Value{
-							model.TLSModeLabelShortname: {Kind: &structpb.Value_StringValue{StringValue: model.IstioMutualTLSModeLabel}},
-						},
-					},
+					Name:            "tlsMode-" + model.IstioMutualTLSModeLabel,
+					Match:           istioMtlsTransportSocketMatch,
 					TransportSocket: transportSocket,
 				},
 				defaultTransportSocketMatch,
 			}
 		}
 	}
+}
+
+var istioMtlsTransportSocketMatch = &structpb.Struct{
+	Fields: map[string]*structpb.Value{
+		model.TLSModeLabelShortname: {Kind: &structpb.Value_StringValue{StringValue: model.IstioMutualTLSModeLabel}},
+	},
 }
 
 func buildUpstreamClusterTLSContext(opts *buildClusterOpts, tls *networking.ClientTLSSettings,

--- a/pilot/pkg/xds/testdata/benchmarks/empty.yaml
+++ b/pilot/pkg/xds/testdata/benchmarks/empty.yaml
@@ -20,8 +20,11 @@ spec:
     name: auto
     protocol: ""
   resolution: STATIC
+  location: MESH_INTERNAL
   endpoints:
   - address: 1.1.1.1
+    labels:
+      security.istio.io/tlsMode: istio
 ---
 # Set up .Services number of services. Each will have 4 ports (one for each protocol)
 {{- range $i := until .Services }}
@@ -45,7 +48,10 @@ spec:
   - number: 9090
     name: auto
   resolution: STATIC
+  location: MESH_INTERNAL
   endpoints:
   - address: 1.2.3.4
+    labels:
+      security.istio.io/tlsMode: istio
 ---
 {{- end }}


### PR DESCRIPTION
```
name                       old time/op        new time/op        delta
ClusterGeneration/empty-8        4.84ms ± 0%        4.28ms ± 0%   ~     (p=1.000 n=1+1)

name                       old alloc/op       new alloc/op       delta
ClusterGeneration/empty-8        1.93MB ± 0%        1.71MB ± 0%   ~     (p=1.000 n=1+1)

name                       old allocs/op      new allocs/op      delta
ClusterGeneration/empty-8         23.4k ± 0%         21.0k ± 0%   ~     (p=1.000 n=1+1)
```

