### PR TITLE
test framework: dump entire suite when a single test fails

### DIFF
--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -151,11 +151,11 @@ func (i *operatorComponent) Close() (err error) {
 	return
 }
 
-func (i *operatorComponent) Dump() {
+func (i *operatorComponent) Dump(ctx resource.Context) {
 	scopes.Framework.Errorf("=== Dumping Istio Deployment State...")
 
 	for _, cluster := range i.environment.KubeClusters {
-		d, err := i.ctx.CreateTmpDirectory(fmt.Sprintf("istio-state-%s", cluster.Name()))
+		d, err := ctx.CreateTmpDirectory(fmt.Sprintf("istio-state-%s", cluster.Name()))
 		if err != nil {
 			scopes.Framework.Errorf("Unable to create directory for dumping Istio contents: %v", err)
 			return
@@ -588,7 +588,7 @@ func waitForControlPlane(ctx resource.Context, dumper resource.Dumper, cluster r
 	if !cfg.SkipWaitForValidationWebhook {
 		// Wait for webhook to come online. The only reliable way to do that is to see if we can submit invalid config.
 		if err := waitForValidationWebhook(ctx, cluster, cfg); err != nil {
-			dumper.Dump()
+			dumper.Dump(ctx)
 			return err
 		}
 	}

--- a/pkg/test/framework/components/namespace/kube.go
+++ b/pkg/test/framework/components/namespace/kube.go
@@ -46,10 +46,10 @@ type kubeNamespace struct {
 	ctx  resource.Context
 }
 
-func (n *kubeNamespace) Dump() {
+func (n *kubeNamespace) Dump(ctx resource.Context) {
 	scopes.Framework.Errorf("=== Dumping Namespace %s State...", n.name)
 
-	d, err := n.ctx.CreateTmpDirectory(n.name + "-state")
+	d, err := ctx.CreateTmpDirectory(n.name + "-state")
 	if err != nil {
 		scopes.Framework.Errorf("Unable to create directory for dumping %s contents: %v", n.name, err)
 		return

--- a/pkg/test/framework/resource/dumper.go
+++ b/pkg/test/framework/resource/dumper.go
@@ -17,5 +17,5 @@ package resource
 // Dumper is an interface that is implemented by all components that can dump their state. In CI, it is
 // useful to get as much context as possible when a test fails. Dumper allows dumping of state from a test.
 type Dumper interface {
-	Dump()
+	Dump(ctx Context)
 }

--- a/pkg/test/framework/runtime.go
+++ b/pkg/test/framework/runtime.go
@@ -40,8 +40,8 @@ func newRuntime(s *resource.Settings, fn resource.EnvironmentFactory, labels lab
 }
 
 // Dump state for all allocated resources.
-func (i *runtime) Dump() {
-	i.context.globalScope.dump()
+func (i *runtime) Dump(ctx resource.Context) {
+	i.context.globalScope.dump(i.context)
 }
 
 // suiteContext returns the suiteContext.

--- a/pkg/test/framework/runtime.go
+++ b/pkg/test/framework/runtime.go
@@ -41,7 +41,7 @@ func newRuntime(s *resource.Settings, fn resource.EnvironmentFactory, labels lab
 
 // Dump state for all allocated resources.
 func (i *runtime) Dump(ctx resource.Context) {
-	i.context.globalScope.dump(i.context)
+	i.context.globalScope.dump(ctx)
 }
 
 // suiteContext returns the suiteContext.

--- a/pkg/test/framework/scope.go
+++ b/pkg/test/framework/scope.go
@@ -165,15 +165,15 @@ func (s *scope) waitForDone() {
 	<-s.closeChan
 }
 
-func (s *scope) dump() {
+func (s *scope) dump(ctx resource.Context) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, c := range s.children {
-		c.dump()
+		c.dump(ctx)
 	}
 	for _, c := range s.resources {
 		if d, ok := c.(resource.Dumper); ok {
-			d.Dump()
+			d.Dump(ctx)
 		}
 	}
 }

--- a/pkg/test/framework/scope.go
+++ b/pkg/test/framework/scope.go
@@ -144,12 +144,12 @@ func (s *scope) done(nocleanup bool) error {
 				name = fmt.Sprintf("resource %v", r.ID())
 			}
 
-			scopes.Framework.Infof("Begin cleaning up %s", name)
+			scopes.Framework.Debugf("Begin cleaning up %s", name)
 			if e := c.Close(); e != nil {
-				scopes.Framework.Infof("Error cleaning up %s: %v", name, e)
+				scopes.Framework.Debugf("Error cleaning up %s: %v", name, e)
 				err = multierror.Append(err, e)
 			}
-			scopes.Framework.Infof("Cleanup complete for %s", name)
+			scopes.Framework.Debugf("Cleanup complete for %s", name)
 		}
 	}
 	s.mu.Lock()

--- a/pkg/test/framework/scope.go
+++ b/pkg/test/framework/scope.go
@@ -144,12 +144,12 @@ func (s *scope) done(nocleanup bool) error {
 				name = fmt.Sprintf("resource %v", r.ID())
 			}
 
-			scopes.Framework.Debugf("Begin cleaning up %s", name)
+			scopes.Framework.Infof("Begin cleaning up %s", name)
 			if e := c.Close(); e != nil {
-				scopes.Framework.Debugf("Error cleaning up %s: %v", name, e)
+				scopes.Framework.Infof("Error cleaning up %s: %v", name, e)
 				err = multierror.Append(err, e)
 			}
-			scopes.Framework.Debugf("Cleanup complete for %s", name)
+			scopes.Framework.Infof("Cleanup complete for %s", name)
 		}
 	}
 	s.mu.Lock()

--- a/pkg/test/framework/suite.go
+++ b/pkg/test/framework/suite.go
@@ -249,7 +249,7 @@ func (s *suiteImpl) runSetupFn(fn resource.SetupFn, ctx SuiteContext) (err error
 	defer func() {
 		// Dump if the setup function fails
 		if err != nil && ctx.Settings().CIMode {
-			rt.Dump()
+			rt.Dump(ctx)
 		}
 	}()
 	err = fn(ctx)
@@ -304,7 +304,7 @@ func (s *suiteImpl) run() (errLevel int) {
 
 	defer func() {
 		if errLevel != 0 && ctx.Settings().CIMode {
-			rt.Dump()
+			rt.Dump(ctx)
 		}
 
 		if err := rt.Close(); err != nil {

--- a/pkg/test/framework/testcontext.go
+++ b/pkg/test/framework/testcontext.go
@@ -272,7 +272,7 @@ func (c *testContext) WhenDone(fn func() error) {
 func (c *testContext) Done() {
 	if c.Failed() {
 		scopes.Framework.Debugf("Begin dumping testContext: %q", c.id)
-		c.scope.dump()
+		rt.Dump(c)
 		scopes.Framework.Debugf("Completed dumping testContext: %q", c.id)
 	}
 

--- a/pkg/test/framework/testcontext.go
+++ b/pkg/test/framework/testcontext.go
@@ -150,7 +150,7 @@ func newTestContext(test *testImpl, goTest *testing.T, s *suiteContext, parentSc
 	}
 
 	scopes.Framework.Debugf("Creating New test context")
-	workDir := path.Join(s.settings.RunDir(), goTest.Name())
+	workDir := path.Join(s.settings.RunDir(), goTest.Name(), "_test_context")
 	if err := os.MkdirAll(workDir, os.ModePerm); err != nil {
 		goTest.Fatalf("Error creating work dir %q: %v", workDir, err)
 	}

--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -149,10 +149,16 @@ func TestIngress(t *testing.T) {
 			// we will define one for foo.example.com and one for bar.example.com, to ensure both can co-exist
 			credName := "k8s-ingress-secret-foo"
 			ingressutil.CreateIngressKubeSecret(t, ctx, []string{credName}, ingress.TLS, ingressutil.IngressCredentialA, false)
-			defer ingressutil.DeleteKubeSecret(t, ctx, []string{credName})
+			ctx.WhenDone(func() error {
+				ingressutil.DeleteKubeSecret(t, ctx, []string{credName})
+				return nil
+			})
 			credName2 := "k8s-ingress-secret-bar"
 			ingressutil.CreateIngressKubeSecret(t, ctx, []string{credName2}, ingress.TLS, ingressutil.IngressCredentialB, false)
-			defer ingressutil.DeleteKubeSecret(t, ctx, []string{credName2})
+			ctx.WhenDone(func() error {
+				ingressutil.DeleteKubeSecret(t, ctx, []string{credName2})
+				return nil
+			})
 
 			if err := ctx.Config().ApplyYAML(apps.namespace.Name(), `
 apiVersion: networking.k8s.io/v1beta1

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -171,8 +171,10 @@ func TestDescribe(t *testing.T) {
 		RequiresSingleCluster().
 		Run(func(ctx framework.TestContext) {
 			deployment := file.AsStringOrFail(t, "testdata/a.yaml")
-			ctx.Config().ApplyYAMLOrFail(t, apps.namespace.Name(), deployment)
-			defer ctx.Config().DeleteYAMLOrFail(t, apps.namespace.Name(), deployment)
+			ctx.Config().ApplyYAMLOrFail(ctx, apps.namespace.Name(), deployment)
+			ctx.WhenDone(func() error {
+				return ctx.Config().DeleteYAML(apps.namespace.Name(), deployment)
+			})
 
 			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{})
 
@@ -391,8 +393,10 @@ func TestAuthZCheck(t *testing.T) {
 		RequiresSingleCluster().
 		Run(func(ctx framework.TestContext) {
 			authPol := file.AsStringOrFail(t, "testdata/authz-a.yaml")
-			ctx.Config().ApplyYAMLOrFail(t, apps.namespace.Name(), authPol)
-			defer ctx.Config().DeleteYAMLOrFail(t, apps.namespace.Name(), authPol)
+			ctx.Config().ApplyYAMLOrFail(ctx, apps.namespace.Name(), authPol)
+			ctx.WhenDone(func() error {
+				return ctx.Config().DeleteYAML(apps.namespace.Name(), authPol)
+			})
 
 			istioCtl := istioctl.NewOrFail(ctx, ctx, istioctl.Config{Cluster: ctx.Environment().Clusters()[0]})
 

--- a/tests/integration/pilot/mirror_test.go
+++ b/tests/integration/pilot/mirror_test.go
@@ -55,7 +55,6 @@ type testCaseMirror struct {
 }
 
 type mirrorTestOptions struct {
-	t          *testing.T
 	cases      []testCaseMirror
 	mirrorHost string
 }
@@ -65,33 +64,30 @@ var (
 )
 
 func TestMirroring(t *testing.T) {
-	cases := []testCaseMirror{
-		{
-			name:       "mirror-percent-absent",
-			absent:     true,
-			percentage: 100.0,
-			threshold:  0.0,
+	runMirrorTest(t, mirrorTestOptions{
+		cases: []testCaseMirror{
+			{
+				name:       "mirror-percent-absent",
+				absent:     true,
+				percentage: 100.0,
+				threshold:  0.0,
+			},
+			{
+				name:       "mirror-50",
+				percentage: 50.0,
+				threshold:  10.0,
+			},
+			{
+				name:       "mirror-10",
+				percentage: 10.0,
+				threshold:  5.0,
+			},
+			{
+				name:       "mirror-0",
+				percentage: 0.0,
+				threshold:  0.0,
+			},
 		},
-		{
-			name:       "mirror-50",
-			percentage: 50.0,
-			threshold:  10.0,
-		},
-		{
-			name:       "mirror-10",
-			percentage: 10.0,
-			threshold:  5.0,
-		},
-		{
-			name:       "mirror-0",
-			percentage: 0.0,
-			threshold:  0.0,
-		},
-	}
-
-	runMirrorTest(mirrorTestOptions{
-		t:     t,
-		cases: cases,
 	})
 }
 
@@ -104,31 +100,28 @@ func TestMirroring(t *testing.T) {
 // Thus when "a" tries to mirror to the external service, it is actually connecting to "external" (which is not part of the
 // mesh because of the Sidecar), then we can inspect "external" logs to verify the requests were properly mirrored.
 func TestMirroringExternalService(t *testing.T) {
-	cases := []testCaseMirror{
-		{
-			name:                "mirror-external",
-			absent:              true,
-			percentage:          100.0,
-			threshold:           0.0,
-			expectedDestination: apps.external,
-		},
-	}
-
-	runMirrorTest(mirrorTestOptions{
-		t:          t,
-		cases:      cases,
+	runMirrorTest(t, mirrorTestOptions{
 		mirrorHost: apps.externalHost,
+		cases: []testCaseMirror{
+			{
+				name:                "mirror-external",
+				absent:              true,
+				percentage:          100.0,
+				threshold:           0.0,
+				expectedDestination: apps.external,
+			},
+		},
 	})
 }
 
-func runMirrorTest(options mirrorTestOptions) {
+func runMirrorTest(t *testing.T, options mirrorTestOptions) {
 	framework.
-		NewTest(options.t).
+		NewTest(t).
 		Features("traffic.mirroring").
 		RequiresSingleCluster().
 		Run(func(ctx framework.TestContext) {
 			for _, c := range options.cases {
-				options.t.Run(c.name, func(t *testing.T) {
+				ctx.NewSubTest(c.name).Run(func(ctx framework.TestContext) {
 					mirrorHost := options.mirrorHost
 					if len(mirrorHost) == 0 {
 						mirrorHost = apps.podC.Config().Service
@@ -140,16 +133,16 @@ func runMirrorTest(options mirrorTestOptions) {
 						mirrorHost,
 					}
 
-					deployment := tmpl.EvaluateOrFail(t,
-						file.AsStringOrFail(t, "testdata/traffic-mirroring-template.yaml"), vsc)
+					deployment := tmpl.EvaluateOrFail(ctx,
+						file.AsStringOrFail(ctx, "testdata/traffic-mirroring-template.yaml"), vsc)
 					ctx.Config().ApplyYAMLOrFail(ctx, apps.namespace.Name(), deployment)
 					ctx.WhenDone(func() error {
 						return ctx.Config().DeleteYAML(apps.namespace.Name(), deployment)
 					})
 
 					for _, proto := range mirrorProtocols {
-						t.Run(string(proto), func(t *testing.T) {
-							retry.UntilSuccessOrFail(t, func() error {
+						ctx.NewSubTest(string(proto)).Run(func(ctx framework.TestContext) {
+							retry.UntilSuccessOrFail(ctx, func() error {
 								testID := util.RandomString(16)
 								if err := sendTrafficMirror(apps.podA, apps.podB, proto, testID); err != nil {
 									return err

--- a/tests/integration/pilot/mirror_test.go
+++ b/tests/integration/pilot/mirror_test.go
@@ -142,8 +142,10 @@ func runMirrorTest(options mirrorTestOptions) {
 
 					deployment := tmpl.EvaluateOrFail(t,
 						file.AsStringOrFail(t, "testdata/traffic-mirroring-template.yaml"), vsc)
-					ctx.Config().ApplyYAMLOrFail(t, apps.namespace.Name(), deployment)
-					defer ctx.Config().DeleteYAMLOrFail(t, apps.namespace.Name(), deployment)
+					ctx.Config().ApplyYAMLOrFail(ctx, apps.namespace.Name(), deployment)
+					ctx.WhenDone(func() error {
+						return ctx.Config().DeleteYAML(apps.namespace.Name(), deployment)
+					})
 
 					for _, proto := range mirrorProtocols {
 						t.Run(string(proto), func(t *testing.T) {

--- a/tests/integration/pilot/routing_test.go
+++ b/tests/integration/pilot/routing_test.go
@@ -428,8 +428,7 @@ func ExecuteTrafficTest(ctx framework.TestContext, tt TrafficTestCase) {
 		if len(tt.config) > 0 {
 			ctx.Config().ApplyYAMLOrFail(ctx, apps.namespace.Name(), tt.config)
 			ctx.WhenDone(func() error {
-				ctx.Config().DeleteYAMLOrFail(ctx, apps.namespace.Name(), tt.config)
-				return nil
+				return ctx.Config().DeleteYAML(apps.namespace.Name(), tt.config)
 			})
 		}
 		if tt.call != nil {

--- a/tests/integration/pilot/routing_test.go
+++ b/tests/integration/pilot/routing_test.go
@@ -71,7 +71,7 @@ spec:
 				return apps.podA.Call(echo.CallOptions{Target: apps.podB, PortName: "http"})
 			},
 			validator: func(response echoclient.ParsedResponses) error {
-				return fmt.Errorf("temp error to test dumping")
+				return expectString(response[0].RawResponse["Istio-Custom-Header"], "user-defined-value", "request header")
 			},
 		},
 		{

--- a/tests/integration/pilot/routing_test.go
+++ b/tests/integration/pilot/routing_test.go
@@ -427,7 +427,10 @@ func ExecuteTrafficTest(ctx framework.TestContext, tt TrafficTestCase) {
 	ctx.NewSubTest(tt.name).Run(func(ctx framework.TestContext) {
 		if len(tt.config) > 0 {
 			ctx.Config().ApplyYAMLOrFail(ctx, apps.namespace.Name(), tt.config)
-			defer ctx.Config().DeleteYAMLOrFail(ctx, apps.namespace.Name(), tt.config)
+			ctx.WhenDone(func() error {
+				ctx.Config().DeleteYAMLOrFail(ctx, apps.namespace.Name(), tt.config)
+				return nil
+			})
 		}
 		if tt.call != nil {
 			if tt.calls != nil {

--- a/tests/integration/pilot/routing_test.go
+++ b/tests/integration/pilot/routing_test.go
@@ -71,7 +71,7 @@ spec:
 				return apps.podA.Call(echo.CallOptions{Target: apps.podB, PortName: "http"})
 			},
 			validator: func(response echoclient.ParsedResponses) error {
-				return expectString(response[0].RawResponse["Istio-Custom-Header"], "user-defined-value", "request header")
+				return fmt.Errorf("temp error to test dumping")
 			},
 		},
 		{

--- a/tests/integration/pilot/validation_test.go
+++ b/tests/integration/pilot/validation_test.go
@@ -119,7 +119,9 @@ func TestValidation(t *testing.T) {
 					}
 
 					wetRunErr := ctx.Clusters().Default().ApplyYAMLFiles(ns.Name(), applyFiles...)
-					defer func() { _ = ctx.Clusters().Default().DeleteYAMLFiles(ns.Name(), applyFiles...) }()
+					ctx.WhenDone(func() error {
+						return ctx.Clusters().Default().DeleteYAMLFiles(ns.Name(), applyFiles...)
+					})
 
 					if err != nil && wetRunErr == nil {
 						ctx.Fatalf("dry run returned no errors, but wet run returned: %v", wetRunErr)


### PR DESCRIPTION
When a single test in a suite fails, the valuable information about the state of pods, etc. isn't dumped until the entire suite finishes. For tests that share resources at the suite level, config that may have affected the dump may be cleaned up before we dump the state. 

For example, in the link below most of the meaningful information is under _suite_context/. The individual tests only show the config that was applied rather than how it affected Envoy config.

https://gcsweb.istio.io/gcs/istio-prow/pr-logs/pull/istio_istio/25923/integ-pilot-multicluster-tests_istio/84/artifacts/pilot-12fd1f21ee014570b4e0b1e99/

With this change, the subtest directory will have a dump from before cleanup (assuming cleanup doesn't rely on defer):

https://gcsweb.istio.io/gcs/istio-prow/pr-logs/pull/istio_istio/26516/integ-pilot-k8s-tests_istio/18438/artifacts/pilot-fd7262df615944c486441c70f/TestTraffic/virtualservice/added_header/

For nested subtests, we will get a dump at each level's point-in-time pre cleanup. For example, if the following subtest fails we will see a dump where configs `a` and `b` are both applied, then one where `a` is still applied but `b` has been cleaned up. 

```go
func TestThing(t *testing.T) {
  framework.NewTest(t).Run(func(ctx framework.TestContext) {
    applyConfig(a)
    ctx.WhenDone(func() error { return deleteConfig(a) })
    
    ctx.NewSubtest("sub").Run(func(ctx framework.TestContext) {
       applyConfig(b)
       ctx.WhenDone(func() error { return deleteConfig(b) })
       // test
    })
  })
}

```

Changes:
- TestContext dumps the entire runtime context on failure
- Dump now takes a context so that we can dump to an appropriate directory. 

Documented in: https://github.com/istio/istio/wiki/Writing-Good-Tests#proper-cleanup

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
