### PR TITLE
Drain listeners gracefully

### DIFF
--- a/pkg/envoy/admin.go
+++ b/pkg/envoy/admin.go
@@ -41,7 +41,7 @@ func DrainListeners(adminPort uint32, inboundonly bool) error {
 	if inboundonly {
 		drainURL = "drain_listeners?inboundonly&graceful"
 	} else {
-		drainURL = "drain_listeners&graceful"
+		drainURL = "drain_listeners?graceful"
 	}
 	res, err := doEnvoyPost(drainURL, "", "", adminPort)
 	log.Debugf("Drain listener endpoint response : %s", res.String())

--- a/pkg/envoy/admin.go
+++ b/pkg/envoy/admin.go
@@ -39,9 +39,9 @@ func Shutdown(adminPort uint32) error {
 func DrainListeners(adminPort uint32, inboundonly bool) error {
 	var drainURL string
 	if inboundonly {
-		drainURL = "drain_listeners?inboundonly"
+		drainURL = "drain_listeners?inboundonly&graceful"
 	} else {
-		drainURL = "drain_listeners"
+		drainURL = "drain_listeners&graceful"
 	}
 	res, err := doEnvoyPost(drainURL, "", "", adminPort)
 	log.Debugf("Drain listener endpoint response : %s", res.String())


### PR DESCRIPTION
See https://github.com/envoyproxy/envoy/pull/11639/files

The old draining behavior: GOAWAY/connection: close all existing
connections, reject all new connections. This means if a connection is
established (because of slow propogationo of endpoint updates or similar
issues), it will be closed. This connection actually has a chance to
succeed, if the app has not shut down yet, or for ingress its very
likely to be ok as we know envoy is still running.

The new behavior will still goaway existing connections, but new
connections are accepted

Along with bumping up the drain to 10s, I have gotten 100% success with https://github.com/istio/istio/issues/26524; prior to this it fails every rollout