### PR TITLE
test framework: separate method for skippable test-level cleanup

### DIFF
--- a/pkg/test/framework/scope.go
+++ b/pkg/test/framework/scope.go
@@ -133,25 +133,29 @@ func (s *scope) done(nocleanup bool) error {
 	}()
 
 	var err error
-	if !nocleanup {
+	// Do reverse walk for cleanup.
+	for i := len(s.closers) - 1; i >= 0; i-- {
+		c := s.closers[i]
 
-		// Do reverse walk for cleanup.
-		for i := len(s.closers) - 1; i >= 0; i-- {
-			c := s.closers[i]
-
-			name := "lambda"
-			if r, ok := c.(resource.Resource); ok {
-				name = fmt.Sprintf("resource %v", r.ID())
+		if nocleanup {
+			if cc, ok := c.(*closer); ok && cc.canSkip {
+				continue
 			}
-
-			scopes.Framework.Debugf("Begin cleaning up %s", name)
-			if e := c.Close(); e != nil {
-				scopes.Framework.Debugf("Error cleaning up %s: %v", name, e)
-				err = multierror.Append(err, e)
-			}
-			scopes.Framework.Debugf("Cleanup complete for %s", name)
 		}
+
+		name := "lambda"
+		if r, ok := c.(resource.Resource); ok {
+			name = fmt.Sprintf("resource %v", r.ID())
+		}
+
+		scopes.Framework.Debugf("Begin cleaning up %s", name)
+		if e := c.Close(); e != nil {
+			scopes.Framework.Debugf("Error cleaning up %s: %v", name, e)
+			err = multierror.Append(err, e)
+		}
+		scopes.Framework.Debugf("Cleanup complete for %s", name)
 	}
+
 	s.mu.Lock()
 	s.resources = nil
 	s.closers = nil


### PR DESCRIPTION
Overriding the `*testing.T`'s `Cleanup` as well as adding our own `CleanupOrFail`


WhenDone will not be skipped by `--istio.test.nocleanup`. `ctx.Cleanup` or `ctx.CleanupOrFail` should be used for cleanup that can be safely skipped without affecting other tests.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
