### PR TITLE
add agent quitquitquit route to bootstrap

### DIFF
--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -555,7 +555,7 @@
                             "route": {
                               "cluster": "agent"
                             }
-                          }
+                          },
                           {
                             "match": {
                               "prefix": "/quitquitquit"

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -556,6 +556,14 @@
                               "cluster": "agent"
                             }
                           }
+                          {
+                            "match": {
+                              "prefix": "/quitquitquit"
+                            },
+                            "route": {
+                              "cluster": "agent"
+                            }
+                          }
                         ]
                       }
                     ]

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -486,7 +486,7 @@
                             "route": {
                               "cluster": "agent"
                             }
-                          }
+                          },
                           {
                             "match": {
                               "prefix": "/quitquitquit"

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -487,6 +487,14 @@
                               "cluster": "agent"
                             }
                           }
+                          {
+                            "match": {
+                              "prefix": "/quitquitquit"
+                            },
+                            "route": {
+                              "cluster": "agent"
+                            }
+                          }
                         ]
                       }
                     ]

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -486,7 +486,7 @@
                             "route": {
                               "cluster": "agent"
                             }
-                          }
+                          },
                           {
                             "match": {
                               "prefix": "/quitquitquit"

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -487,6 +487,14 @@
                               "cluster": "agent"
                             }
                           }
+                          {
+                            "match": {
+                              "prefix": "/quitquitquit"
+                            },
+                            "route": {
+                              "cluster": "agent"
+                            }
+                          }
                         ]
                       }
                     ]

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -451,6 +451,14 @@
                               "cluster": "agent"
                             }
                           }
+                          {
+                            "match": {
+                              "prefix": "/quitquitquit"
+                            },
+                            "route": {
+                              "cluster": "agent"
+                            }
+                          }
                         ]
                       }
                     ]

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -450,7 +450,7 @@
                             "route": {
                               "cluster": "agent"
                             }
-                          }
+                          },
                           {
                             "match": {
                               "prefix": "/quitquitquit"

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -514,6 +514,14 @@
                               "cluster": "agent"
                             }
                           }
+                          {
+                            "match": {
+                              "prefix": "/quitquitquit"
+                            },
+                            "route": {
+                              "cluster": "agent"
+                            }
+                          }
                         ]
                       }
                     ]

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -513,7 +513,7 @@
                             "route": {
                               "cluster": "agent"
                             }
-                          }
+                          },
                           {
                             "match": {
                               "prefix": "/quitquitquit"

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -514,6 +514,14 @@
                               "cluster": "agent"
                             }
                           }
+                          {
+                            "match": {
+                              "prefix": "/quitquitquit"
+                            },
+                            "route": {
+                              "cluster": "agent"
+                            }
+                          }
                         ]
                       }
                     ]

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -513,7 +513,7 @@
                             "route": {
                               "cluster": "agent"
                             }
-                          }
+                          },
                           {
                             "match": {
                               "prefix": "/quitquitquit"

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -465,7 +465,7 @@
                             "route": {
                               "cluster": "agent"
                             }
-                          }
+                          },
                           {
                             "match": {
                               "prefix": "/quitquitquit"

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -466,6 +466,14 @@
                               "cluster": "agent"
                             }
                           }
+                          {
+                            "match": {
+                              "prefix": "/quitquitquit"
+                            },
+                            "route": {
+                              "cluster": "agent"
+                            }
+                          }
                         ]
                       }
                     ]

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -473,6 +473,14 @@
                               "cluster": "agent"
                             }
                           }
+                          {
+                            "match": {
+                              "prefix": "/quitquitquit"
+                            },
+                            "route": {
+                              "cluster": "agent"
+                            }
+                          }
                         ]
                       }
                     ]

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -472,7 +472,7 @@
                             "route": {
                               "cluster": "agent"
                             }
-                          }
+                          },
                           {
                             "match": {
                               "prefix": "/quitquitquit"

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -473,7 +473,7 @@
                             "route": {
                               "cluster": "agent"
                             }
-                          }
+                          },
                           {
                             "match": {
                               "prefix": "/quitquitquit"

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -474,6 +474,14 @@
                               "cluster": "agent"
                             }
                           }
+                          {
+                            "match": {
+                              "prefix": "/quitquitquit"
+                            },
+                            "route": {
+                              "cluster": "agent"
+                            }
+                          }
                         ]
                       }
                     ]

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -451,6 +451,14 @@
                               "cluster": "agent"
                             }
                           }
+                          {
+                            "match": {
+                              "prefix": "/quitquitquit"
+                            },
+                            "route": {
+                              "cluster": "agent"
+                            }
+                          }
                         ]
                       }
                     ]

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -450,7 +450,7 @@
                             "route": {
                               "cluster": "agent"
                             }
-                          }
+                          },
                           {
                             "match": {
                               "prefix": "/quitquitquit"

--- a/pkg/bootstrap/testdata/tracing_tls_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_golden.json
@@ -473,7 +473,7 @@
                             "route": {
                               "cluster": "agent"
                             }
-                          }
+                          },
                           {
                             "match": {
                               "prefix": "/quitquitquit"

--- a/pkg/bootstrap/testdata/tracing_tls_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_golden.json
@@ -474,6 +474,14 @@
                               "cluster": "agent"
                             }
                           }
+                          {
+                            "match": {
+                              "prefix": "/quitquitquit"
+                            },
+                            "route": {
+                              "cluster": "agent"
+                            }
+                          }
                         ]
                       }
                     ]

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -473,6 +473,14 @@
                               "cluster": "agent"
                             }
                           }
+                          {
+                            "match": {
+                              "prefix": "/quitquitquit"
+                            },
+                            "route": {
+                              "cluster": "agent"
+                            }
+                          }
                         ]
                       }
                     ]

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -472,7 +472,7 @@
                             "route": {
                               "cluster": "agent"
                             }
-                          }
+                          },
                           {
                             "match": {
                               "prefix": "/quitquitquit"

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -526,7 +526,7 @@
                             "route": {
                               "cluster": "agent"
                             }
-                          }
+                          },
                           {
                             "match": {
                               "prefix": "/quitquitquit"

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -527,6 +527,14 @@
                               "cluster": "agent"
                             }
                           }
+                          {
+                            "match": {
+                              "prefix": "/quitquitquit"
+                            },
+                            "route": {
+                              "cluster": "agent"
+                            }
+                          }
                         ]
                       }
                     ]


### PR DESCRIPTION
`/quitquitquit` endpoint is not accessible (gives 404 now) because the agent routes does not have it.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X ] Does not have any changes that may affect Istio users.
