### PR TITLE
Expose more envoy stats by default

### DIFF
--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -45,9 +45,6 @@ const (
 	IstioMetaJSONPrefix = "ISTIO_METAJSON_"
 
 	lightstepAccessTokenBase = "lightstep_access_token.txt"
-
-	// required stats are used by readiness checks.
-	requiredEnvoyStatsMatcherInclusionPrefixes = "cluster_manager,listener_manager,server,cluster.xds-grpc,wasm"
 )
 
 var (

--- a/pkg/bootstrap/instance_test.go
+++ b/pkg/bootstrap/instance_test.go
@@ -464,7 +464,7 @@ func checkListStringMatcher(t *testing.T, got *matcher.ListStringMatcher, want [
 	sort.Strings(want)
 	sort.Strings(gotPatterns)
 	if !reflect.DeepEqual(want, gotPatterns) {
-		t.Fatalf("%s mismatch:\ngot: %s\nwant: %s", typ, gotPatterns, want)
+		t.Fatalf("%s mismatch:\ngot: %v\nwant: %v", typ, gotPatterns, want)
 	}
 }
 

--- a/releasenotes/notes/expose-more-envoy-stats.yaml
+++ b/releasenotes/notes/expose-more-envoy-stats.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+issue:
+  - 23166
+releaseNotes:
+- |
+  **Added** Expose more Envoy native stats for better visibility and debuggability. Newly exposed stats can be found [here](https://github.com/istio/istio/issues/23166#issuecomment-674687100).


### PR DESCRIPTION
context: https://github.com/istio/istio/issues/23166 and https://github.com/istio/istio/issues/23902

This PR creates and exposes more native stats for better observability and debuggability. Specifically stats with the following suffixes will be created:

* Downstream connection stats, `downstream_cx_total`, `downstream_cx_active`, `downstream_cx_http1_total`, `downstream_cx_http2_total`, `downstream_cx_http1_active`, `downstream_cx_http2_active`, `downstream_cx_destroy`, `downstream_cx_destroy_remote`, `downstream_cx_destroy_local`, `downstream_cx_destroy_local_active_rq`, `downstream_cx_destroy_remote_active_rq`

* Upstream connection stats, `upstream_cx_total`, `upstream_cx_active`, `upstream_cx_destroy_local`, `upstream_cx_destroy_remote`, `upstream_cx_destroy_local_with_active_rq`, `upstream_cx_destroy_remote_with_active_rq`, `upstream_cx_close_notify`

* HTTP request route stats, `no_route`, `no_cluster`, `rq_redirect`, `rq_total`, `rq_direct_response`, `rq_reset_after_downstream_response_started`

* Lisener debug stats suffix  `no_filter_chain_match`, `downstream_pre_cx_timeout`

* TCP metadata exchange stats suffix `alpn_protocol_not_found`, `alpn_protocol_found`, `initial_header_not_found`, `header_not_found`, `metadata_added`

An experiment is performed with these stats created by default, and CPU and memory usage diff is negligible: https://snapshot.raintank.io/dashboard/snapshot/21R8BjkvGQCNhevume5pShsJpbZD6Hbx