### PR TITLE
Remove graduted command from experimental section docs

### DIFF
--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -206,7 +206,6 @@ debug and diagnose their Istio mesh.
 
 	rootCmd.AddCommand(experimentalCmd)
 	rootCmd.AddCommand(proxyConfig())
-	rootCmd.AddCommand(Analyze())
 
 	rootCmd.AddCommand(install.NewVerifyCommand())
 	experimentalCmd.AddCommand(install.NewPrecheckCommand())
@@ -217,7 +216,7 @@ debug and diagnose their Istio mesh.
 	experimentalCmd.AddCommand(describe())
 	experimentalCmd.AddCommand(addToMeshCmd())
 	experimentalCmd.AddCommand(removeFromMeshCmd())
-	experimentalCmd.AddCommand(softGraduatedCmd(Analyze()))
+
 	experimentalCmd.AddCommand(vmBootstrapCommand())
 	experimentalCmd.AddCommand(waitCmd())
 	experimentalCmd.AddCommand(mesh.UninstallCmd(loggingOptions))
@@ -226,8 +225,9 @@ debug and diagnose their Istio mesh.
 	postInstallCmd.AddCommand(Webhook())
 	experimentalCmd.AddCommand(postInstallCmd)
 
-	proxyStatusCmd := statusCommand()
-	hideInheritedFlags(proxyStatusCmd, "namespace", "istioNamespace")
+	analyzeCmd := Analyze()
+	hideInheritedFlags(analyzeCmd, "namespace", "istioNamespace")
+	rootCmd.AddCommand(analyzeCmd)
 
 	convertIngressCmd := convertIngress()
 	hideInheritedFlags(convertIngressCmd, "namespace", "istioNamespace")
@@ -236,6 +236,12 @@ debug and diagnose their Istio mesh.
 	dashboardCmd := dashboard()
 	hideInheritedFlags(dashboardCmd, "namespace", "istioNamespace")
 	rootCmd.AddCommand(dashboardCmd)
+
+	proxyStatusCmd := statusCommand()
+	hideInheritedFlags(proxyStatusCmd, "namespace", "istioNamespace")
+
+	versionCmd := newVersionCommand()
+	hideInheritedFlags(versionCmd, "namespace", "istioNamespace")
 
 	manifestCmd := mesh.ManifestCmd(loggingOptions)
 	hideInheritedFlags(manifestCmd, "namespace", "istioNamespace")

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -347,21 +347,10 @@ func getDefaultNamespace(kubeconfig string) string {
 	return context.Namespace
 }
 
-// softGraduatedCmd is used for commands that have graduated, but we still want the old invocation to work.
-func softGraduatedCmd(cmd *cobra.Command) *cobra.Command {
-	msg := fmt.Sprintf("(%s has graduated. Use `istioctl %s`)", cmd.Name(), cmd.Name())
-
-	newCmd := *cmd
-	newCmd.Short = fmt.Sprintf("%s %s", cmd.Short, msg)
-	newCmd.RunE = func(c *cobra.Command, args []string) error {
-		fmt.Fprintln(cmd.ErrOrStderr(), msg)
-		return cmd.RunE(c, args)
-	}
-
-	return &newCmd
-}
-
 // seeExperimentalCmd is used for commands that have been around for a release but not graduated
+// Other alternative
+// for graduatedCmd see https://github.com/istio/istio/pull/26408
+// for softGraduatedCmd see https://github.com/istio/istio/pull/26563
 func seeExperimentalCmd(name string) *cobra.Command {
 	msg := fmt.Sprintf("(%s is experimental. Use `istioctl experimental %s`)", name, name)
 	return &cobra.Command{

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -206,9 +206,6 @@ debug and diagnose their Istio mesh.
 
 	rootCmd.AddCommand(experimentalCmd)
 	rootCmd.AddCommand(proxyConfig())
-
-	rootCmd.AddCommand(convertIngress())
-	rootCmd.AddCommand(dashboard())
 	rootCmd.AddCommand(Analyze())
 
 	rootCmd.AddCommand(install.NewVerifyCommand())
@@ -229,6 +226,17 @@ debug and diagnose their Istio mesh.
 	postInstallCmd.AddCommand(Webhook())
 	experimentalCmd.AddCommand(postInstallCmd)
 
+	proxyStatusCmd := statusCommand()
+	hideInheritedFlags(proxyStatusCmd, "namespace", "istioNamespace")
+
+	convertIngressCmd := convertIngress()
+	hideInheritedFlags(convertIngressCmd, "namespace", "istioNamespace")
+	rootCmd.AddCommand(convertIngressCmd)
+
+	dashboardCmd := dashboard()
+	hideInheritedFlags(dashboardCmd, "namespace", "istioNamespace")
+	rootCmd.AddCommand(dashboardCmd)
+
 	manifestCmd := mesh.ManifestCmd(loggingOptions)
 	hideInheritedFlags(manifestCmd, "namespace", "istioNamespace")
 	rootCmd.AddCommand(manifestCmd)
@@ -244,7 +252,6 @@ debug and diagnose their Istio mesh.
 
 	upgradeCmd := mesh.UpgradeCmd()
 	hideInheritedFlags(upgradeCmd, "namespace", "istioNamespace")
-	experimentalCmd.AddCommand(softGraduatedCmd(upgradeCmd))
 	rootCmd.AddCommand(upgradeCmd)
 
 	experimentalCmd.AddCommand(multicluster.NewCreateRemoteSecretCommand())

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -226,7 +226,7 @@ debug and diagnose their Istio mesh.
 	experimentalCmd.AddCommand(postInstallCmd)
 
 	analyzeCmd := Analyze()
-	hideInheritedFlags(analyzeCmd, "namespace", "istioNamespace")
+	hideInheritedFlags(analyzeCmd, "istioNamespace")
 	rootCmd.AddCommand(analyzeCmd)
 
 	convertIngressCmd := convertIngress()
@@ -238,7 +238,7 @@ debug and diagnose their Istio mesh.
 	rootCmd.AddCommand(dashboardCmd)
 
 	proxyStatusCmd := statusCommand()
-	hideInheritedFlags(proxyStatusCmd, "namespace", "istioNamespace")
+	hideInheritedFlags(proxyStatusCmd, "istioNamespace")
 
 	versionCmd := newVersionCommand()
 	hideInheritedFlags(versionCmd, "namespace", "istioNamespace")

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -237,12 +237,6 @@ debug and diagnose their Istio mesh.
 	hideInheritedFlags(dashboardCmd, "namespace", "istioNamespace")
 	rootCmd.AddCommand(dashboardCmd)
 
-	proxyStatusCmd := statusCommand()
-	hideInheritedFlags(proxyStatusCmd, "istioNamespace")
-
-	versionCmd := newVersionCommand()
-	hideInheritedFlags(versionCmd, "namespace", "istioNamespace")
-
 	manifestCmd := mesh.ManifestCmd(loggingOptions)
 	hideInheritedFlags(manifestCmd, "namespace", "istioNamespace")
 	rootCmd.AddCommand(manifestCmd)


### PR DESCRIPTION
To fix https://github.com/istio/istio.io/issues/7931

Based on https://github.com/istio/istio.io/issues/7931#issuecomment-674913422

The following are moved out of the experiment.
`analyze`  https://github.com/istio/istio/pull/19488
`convert-ingress` https://github.com/istio/istio/pull/16571
`dashboard` https://github.com/istio/istio/pull/17824, https://github.com/istio/istio/pull/26408
`upgrade` https://github.com/istio/istio/pull/19955


cc: @esnible Do suggest any other command that you think also needs to be hidden.