### PR TITLE
Show cluster for single cluster route destinations

### DIFF
--- a/istioctl/pkg/writer/envoy/configdump/listener.go
+++ b/istioctl/pkg/writer/envoy/configdump/listener.go
@@ -238,7 +238,6 @@ func retrieveListenerMatches(l *listener.Listener) []filterchain {
 func getFilterType(filters []*listener.Filter) string {
 	for _, filter := range filters {
 		if filter.Name == HTTPListener {
-
 			httpProxy := &httpConn.HttpConnectionManager{}
 			// Allow Unmarshal to work even if Envoy and istioctl are different
 			filter.GetTypedConfig().TypeUrl = "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
@@ -273,6 +272,9 @@ func getFilterType(filters []*listener.Filter) string {
 }
 
 func describeRouteConfig(route *route.RouteConfiguration) string {
+	if cluster := getMatchAllCluster(route); cluster != "" {
+		return cluster
+	}
 	vhosts := []string{}
 	for _, vh := range route.GetVirtualHosts() {
 		if describeDomains(vh) == "" {
@@ -282,6 +284,36 @@ func describeRouteConfig(route *route.RouteConfiguration) string {
 		}
 	}
 	return fmt.Sprintf("Inline Route: %s", strings.Join(vhosts, "; "))
+}
+
+// If this is a route that matches everything and forwards to a cluster, just report the cluster.
+func getMatchAllCluster(er *route.RouteConfiguration) string {
+	if len(er.GetVirtualHosts()) != 1 {
+		return ""
+	}
+	vh := er.GetVirtualHosts()[0]
+	if !reflect.DeepEqual(vh.Domains, []string{"*"}) {
+		return ""
+	}
+	if len(vh.GetRoutes()) != 1 {
+		return ""
+	}
+	r := vh.GetRoutes()[0]
+	if r.GetMatch().GetPrefix() != "/" {
+		return ""
+	}
+	a, ok := r.GetAction().(*route.Route_Route)
+	if !ok {
+		return ""
+	}
+	cl, ok := a.Route.ClusterSpecifier.(*route.RouteAction_Cluster)
+	if !ok {
+		return ""
+	}
+	if strings.Contains(cl.Cluster, "Cluster") {
+		return cl.Cluster
+	}
+	return fmt.Sprintf("Cluster: %s", cl.Cluster)
 }
 
 func describeDomains(vh *route.VirtualHost) string {


### PR DESCRIPTION
We use routes for these only because they are HTTP - they are
essentially just forwarding to a cluster, similar to TCP

```
# BEFORE
ADDRESS PORT  MATCH                                      DESTINATION
0.0.0.0 15006 Trans: tls; App: HTTP TLS; Addr: 0.0.0.0/0 Inline Route: /*
0.0.0.0 15006 Trans: tls; App: HTTP TLS; Addr: ::0/0     Inline Route: /*
0.0.0.0 15006 ALL                                        Inline Route: /*
0.0.0.0 15006 Trans: tls; Addr: ::0/0                    InboundPassthroughClusterIpv6
0.0.0.0 15006 Trans: tls; Addr: 0.0.0.0/0                InboundPassthroughClusterIpv4
# AFTER
ADDRESS PORT  MATCH                                      DESTINATION
0.0.0.0 15006 Trans: tls; Addr: ::0/0                    InboundPassthroughClusterIpv6
0.0.0.0 15006 Trans: tls; App: HTTP TLS; Addr: ::0/0     InboundPassthroughClusterIpv6
0.0.0.0 15006 Trans: tls; Addr: 0.0.0.0/0                InboundPassthroughClusterIpv4
0.0.0.0 15006 Trans: tls; App: HTTP TLS; Addr: 0.0.0.0/0 InboundPassthroughClusterIpv4
0.0.0.0 15006 ALL                                        Cluster: inbound|8080|http|echo.default.svc.cluster.local
```


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
