### PR TITLE
Fix missing port for proxy-config listener

### DIFF
--- a/istioctl/pkg/writer/envoy/configdump/listener.go
+++ b/istioctl/pkg/writer/envoy/configdump/listener.go
@@ -213,15 +213,14 @@ func retrieveListenerMatches(l *listener.Listener) []filterchain {
 		if match.DestinationPort != nil {
 			port = fmt.Sprintf(":%d", match.DestinationPort.GetValue())
 		}
-		if match.AddressSuffix != "" {
-			descrs = append(descrs, fmt.Sprintf("Addr: %s%s", match.AddressSuffix, port))
-		}
 		if len(match.PrefixRanges) > 0 {
 			pf := []string{}
 			for _, p := range match.PrefixRanges {
 				pf = append(pf, fmt.Sprintf("%s/%d", p.AddressPrefix, p.GetPrefixLen().GetValue()))
 			}
 			descrs = append(descrs, fmt.Sprintf("Addr: %s%s", strings.Join(pf, ","), port))
+		} else if port != "" {
+			descrs = append(descrs, fmt.Sprintf("Addr: *%s", port))
 		}
 		if len(descrs) == 0 {
 			descrs = []string{"ALL"}


### PR DESCRIPTION
AddressSuffix is also removed since its never used by Istio and
unimplemented by Envoy to clean up the code a bit

```
# BEFORE
ADDRESS PORT  MATCH                                      DESTINATION
0.0.0.0 15006 Trans: tls; App: HTTP TLS; Addr: 0.0.0.0/0 Inline Route: /*
0.0.0.0 15006 Trans: tls; App: HTTP TLS; Addr: ::0/0     Inline Route: /*
0.0.0.0 15006 ALL                                        Inline Route: /*
0.0.0.0 15006 Trans: tls; Addr: ::0/0                    InboundPassthroughClusterIpv6
0.0.0.0 15006 Trans: tls; Addr: 0.0.0.0/0                InboundPassthroughClusterIpv4

# AFTER
ADDRESS PORT  MATCH                                      DESTINATION
0.0.0.0 15006 Trans: tls; App: HTTP TLS; Addr: 0.0.0.0/0 Inline Route: /*
0.0.0.0 15006 Trans: tls; App: HTTP TLS; Addr: ::0/0     Inline Route: /*
0.0.0.0 15006 Addr: *:8080                               Inline Route: /*
0.0.0.0 15006 Trans: tls; Addr: ::0/0                    InboundPassthroughClusterIpv6
0.0.0.0 15006 Trans: tls; Addr: 0.0.0.0/0                InboundPassthroughClusterIpv4
```