### PR TITLE
WIP: draft sync and reporting debug info using k8s events

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -76,6 +76,8 @@ var (
 		plugin.Authz,
 		plugin.Health,
 	}
+
+	startupTime time.Time
 )
 
 const (
@@ -84,6 +86,7 @@ const (
 )
 
 func init() {
+	startupTime = time.Now()
 	// Disable gRPC tracing. It has performance impacts (See https://github.com/grpc/grpc-go/issues/695)
 	grpc.EnableTracing = false
 
@@ -396,6 +399,12 @@ func (s *Server) Start(stop <-chan struct{}) error {
 				log.Warna(err)
 			}
 		}()
+	}
+
+	if s.kubeRegistry != nil {
+		s.kubeRegistry.IstiodEvent("istio-system",
+			"istio-start",
+			fmt.Sprintf("time:%v", time.Since(startupTime)), false)
 	}
 
 	s.waitForShutdown(stop)

--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -49,6 +49,9 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 			if err := s.initKubeRegistry(serviceControllers, args); err != nil {
 				return err
 			}
+			// Initial implementation - eventually will be integrated with MC, so each cluster gets
+			// pod events.
+			s.XDSServer.XEventing = s.kubeRegistry
 		case serviceregistry.Mock:
 			s.initMockRegistry(serviceControllers)
 		default:

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -383,10 +383,6 @@ type BootstrapNodeMetadata struct {
 	// ExchangeKeys specifies a list of metadata keys that should be used for Node Metadata Exchange.
 	ExchangeKeys StringList `json:"EXCHANGE_KEYS,omitempty"`
 
-	// InstanceName is the short name for the workload instance (ex: pod name)
-	// replaces POD_NAME
-	InstanceName string `json:"NAME,omitempty"`
-
 	// WorkloadName specifies the name of the workload represented by this node.
 	WorkloadName string `json:"WORKLOAD_NAME,omitempty"`
 
@@ -490,6 +486,9 @@ type NodeMetadata struct {
 
 	// DNSCapture indicates whether the workload has enabled dns capture
 	DNSCapture string `json:"DNS_CAPTURE,omitempty"`
+
+	// InstanceName is the pod name (for K8S) or an identifier of the instance.
+	InstanceName string `json:"NAME,omitempty"`
 
 	// Contains a copy of the raw metadata. This is needed to lookup arbitrary values.
 	// If a value is known ahead of time it should be added to the struct rather than reading from here,

--- a/pilot/pkg/serviceregistry/kube/controller/pod.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod.go
@@ -46,11 +46,13 @@ type PodCache struct {
 	needResync         map[string]sets.Set
 	queueEndpointEvent func(string)
 
-	c *Controller
+	c           *Controller
+	podInformer coreinformers.PodInformer
 }
 
 func newPodCache(c *Controller, informer coreinformers.PodInformer, queueEndpointEvent func(string)) *PodCache {
 	out := &PodCache{
+		podInformer:        informer,
 		informer:           informer.Informer(),
 		c:                  c,
 		podsByIP:           make(map[string]string),

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -16,6 +16,7 @@ package xds
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"strconv"
 	"sync/atomic"
@@ -147,6 +148,13 @@ func (s *DiscoveryServer) receive(con *Connection, reqChannel chan *discovery.Di
 				if s.InternalGen != nil {
 					s.InternalGen.OnDisconnect(con)
 				}
+				if s.XEventing != nil {
+					// TODO: more info - actual instance of istiod, timestamp, etc.
+					s.XEventing.PodEvent(con.proxy.ConfigNamespace, con.proxy.Metadata.InstanceName,
+						"istio-disconnect",
+						con.ConID, false)
+				}
+
 			}()
 		}
 
@@ -465,6 +473,12 @@ func (s *DiscoveryServer) initConnection(node *core.Node, con *Connection) error
 
 	if s.InternalGen != nil {
 		s.InternalGen.OnConnect(con)
+	}
+	if s.XEventing != nil {
+		// TODO: more info - actual instance of istiod, timestamp, etc.
+		s.XEventing.PodEvent(con.proxy.ConfigNamespace, con.proxy.Metadata.InstanceName,
+			"istio-connect",
+			fmt.Sprintf("id=%s", con.ConID), false)
 	}
 	return nil
 }

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -118,11 +118,28 @@ type DiscoveryServer struct {
 	// InternalGen is notified of connect/disconnect/nack on all connections
 	InternalGen *InternalGen
 
+	XEventing XEventing
+
 	// serverReady indicates caches have been synced up and server is ready to process requests.
 	serverReady bool
 
 	debounceOptions debounceOptions
 }
+
+// XEventing is an experimental interface to propagate events. Currently implemented
+// by the primary controller.
+// TODO: support multicluster
+// TODO: better signature - needs to stay compatible with K8S Events
+type XEventing interface {
+	// IstiodEvent is an event associated with the Istiod tenant. Will be visible to all
+	// revisions. In K8S, it is associated with the tenant namespace ( since k8s tenant == namespace,
+	// and current istio deployment model has per-namespace granularity for secrets and access control).
+	IstiodEvent(ns, reason, msg string, warn bool)
+
+	// PodEvent is an event associated with a Pod - or VM equivalent.
+	PodEvent(ns, pod, reason, msg string, warn bool)
+}
+
 
 // EndpointShards holds the set of endpoint shards of a service. Registries update
 // individual shards incrementally. The shards are aggregated and split into
@@ -472,3 +489,4 @@ func (s *DiscoveryServer) initGenerators() {
 	s.Generators["api/"+TypeURLConnections] = s.InternalGen
 	s.Generators["event"] = s.InternalGen
 }
+


### PR DESCRIPTION
As mentioned in the RFC, one way to sync Istiod and report information is using K8S events. 
This is an initial implementation - just reporting the connect/disconnect and startup of istiod.

'kubectl describe pod' will show the connect/disconnect for the pod, so will kubectl get events. 

This has some limitations ( lack of source auth, possible scale ) - but it will likely be extremely useful
for central istiod. We still want to integrate with CNCF Eventing and 'proper' pubsub for large scale 
and secure replication of endpoint info. 

The code is in registry so we can start reporting events to the remote clusters as well.

I would appreciate UX ( and other ) help - feel free to take over this PR. 

Doc: https://docs.google.com/document/d/1X7DmkP10x4nEcTGpikxmvLbBTTK59B0WL3liQzVy8Ms/edit#heading=h.xw1gqgyqs5b


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
