### PR TITLE
[WIP] Remove using SPIFFE identity as DNS type in certificate SAN

### DIFF
--- a/tools/certs/Makefile
+++ b/tools/certs/Makefile
@@ -250,7 +250,6 @@ root-key.pem:
 	@echo "subjectAltName=@san" >> $@
 	@echo "[ san ]" >> $@
 	@echo "URI.1 = spiffe://cluster.local/ns/$(L)sa/$(SERVICE_ACCOUNT)" >> $@
-	@echo "DNS.1 = spiffe://cluster.local/ns/$(L)sa/$(SERVICE_ACCOUNT)" >> $@
 	@echo "[ req_dn ]" >> $@
 	@echo "O = $(INTERMEDIATE_ORG)" >> $@
 	@echo "CN = $(WORKLOAD_CN)" >> $@


### PR DESCRIPTION
Please provide a description for what this PR is for.

Remove using SPIFFE identity as DNS type in certificate SAN. It isn't a standard and is misleading. It isn't useful in Istio. 

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
