### PR TITLE
Add testing for server first protocols

### DIFF
--- a/pkg/test/framework/components/echo/common/call.go
+++ b/pkg/test/framework/components/echo/common/call.go
@@ -80,6 +80,7 @@ func CallEcho(c *client.Instance, opts *echo.CallOptions, outboundPortSelector O
 		Message:       opts.Message,
 		Http2:         opts.HTTP2,
 		Method:        opts.Method,
+		ServerFirst:   opts.Port.ServerFirst,
 	}
 
 	resp, err := c.ForwardEcho(context.Background(), req)

--- a/pkg/test/framework/components/echo/echo.go
+++ b/pkg/test/framework/components/echo/echo.go
@@ -90,6 +90,9 @@ type WorkloadPort struct {
 
 	// TLS determines whether the connection will be plain text or TLS. By default this is false (plain text).
 	TLS bool
+
+	// ServerFirst determines whether the port will use server first communication, meaning the client will not send the first byte.
+	ServerFirst bool
 }
 
 // Port exposed by an Echo Instance

--- a/pkg/test/framework/components/echo/echo.go
+++ b/pkg/test/framework/components/echo/echo.go
@@ -111,6 +111,9 @@ type Port struct {
 
 	// TLS determines whether the connection will be plain text or TLS. By default this is false (plain text).
 	TLS bool
+
+	// ServerFirst determines whether the port will use server first communication, meaning the client will not send the first byte.
+	ServerFirst bool
 }
 
 // Workload provides an interface for a single deployed echo server.

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -118,6 +118,9 @@ spec:
 {{- if $p.TLS }}
           - --tls={{ $p.Port }}
 {{- end }}
+{{- if $p.ServerFirst }}
+          - --server-first={{ $p.Port }}
+{{- end }}
 {{- end }}
 {{- range $i, $p := $.WorkloadOnlyPorts }}
 {{- if eq .Protocol "TCP" }}
@@ -128,6 +131,9 @@ spec:
           - "{{ $p.Port }}"
 {{- if $p.TLS }}
           - --tls={{ $p.Port }}
+{{- end }}
+{{- if $p.ServerFirst }}
+          - --server-first={{ $p.Port }}
 {{- end }}
 {{- end }}
           - --version
@@ -269,6 +275,9 @@ spec:
              --port \
 {{- end }}
              "{{ $p.Port }}" \
+{{- if $p.ServerFirst }}
+             --server-first={{ $p.Port }} \
+{{- end }}
 {{- end }}
         env:
         {{- range $name, $value := $.Environment }}

--- a/pkg/test/framework/components/echo/kube/instance.go
+++ b/pkg/test/framework/components/echo/kube/instance.go
@@ -225,10 +225,11 @@ func getContainerPorts(ports []echo.Port) echoCommon.PortList {
 	for _, p := range ports {
 		// Add the port to the set of application ports.
 		cport := &echoCommon.Port{
-			Name:     p.Name,
-			Protocol: p.Protocol,
-			Port:     p.InstancePort,
-			TLS:      p.TLS,
+			Name:        p.Name,
+			Protocol:    p.Protocol,
+			Port:        p.InstancePort,
+			TLS:         p.TLS,
+			ServerFirst: p.ServerFirst,
 		}
 		containerPorts = append(containerPorts, cport)
 

--- a/pkg/test/util/retry/retry.go
+++ b/pkg/test/util/retry/retry.go
@@ -124,10 +124,10 @@ func Do(fn RetriableFunc, options ...Option) (interface{}, error) {
 			}
 			if successes >= cfg.converge {
 				return result, err
-			} else {
-				// Skip delay
-				continue
 			}
+
+			// Skip delay if we have a success
+			continue
 		} else {
 			successes = 0
 		}

--- a/pkg/test/util/retry/retry.go
+++ b/pkg/test/util/retry/retry.go
@@ -124,6 +124,9 @@ func Do(fn RetriableFunc, options ...Option) (interface{}, error) {
 			}
 			if successes >= cfg.converge {
 				return result, err
+			} else {
+				// Skip delay
+				continue
 			}
 		} else {
 			successes = 0

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -44,7 +44,9 @@ var (
    Port: http 80/HTTP targets pod port 18080
    Port: grpc 7070/GRPC targets pod port 17070
    Port: tcp 9090/TCP targets pod port 19090
+   Port: tcp-server 9091/TCP targets pod port 16060
    Port: auto-tcp 9091/UnsupportedProtocol targets pod port 19091
+   Port: auto-tcp-server 9093/UnsupportedProtocol targets pod port 16061
    Port: auto-http 81/UnsupportedProtocol targets pod port 18081
    Port: auto-grpc 7071/UnsupportedProtocol targets pod port 17071
 80 DestinationRule: a\..* for "a"
@@ -78,7 +80,9 @@ var (
    Port: http 80/HTTP targets pod port 18080
    Port: grpc 7070/GRPC targets pod port 17070
    Port: tcp 9090/TCP targets pod port 19090
+   Port: tcp-server 9091/TCP targets pod port 16060
    Port: auto-tcp 9091/UnsupportedProtocol targets pod port 19091
+   Port: auto-tcp-server 9093/UnsupportedProtocol targets pod port 16061
    Port: auto-http 81/UnsupportedProtocol targets pod port 18081
    Port: auto-grpc 7071/UnsupportedProtocol targets pod port 17071
 80 DestinationRule: a\..* for "a"

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -45,7 +45,7 @@ var (
    Port: grpc 7070/GRPC targets pod port 17070
    Port: tcp 9090/TCP targets pod port 19090
    Port: tcp-server 9091/TCP targets pod port 16060
-   Port: auto-tcp 9091/UnsupportedProtocol targets pod port 19091
+   Port: auto-tcp 9092/UnsupportedProtocol targets pod port 19091
    Port: auto-tcp-server 9093/UnsupportedProtocol targets pod port 16061
    Port: auto-http 81/UnsupportedProtocol targets pod port 18081
    Port: auto-grpc 7071/UnsupportedProtocol targets pod port 17071
@@ -66,6 +66,13 @@ var (
    No Traffic Policy
 9090 RBAC policies: ns\[.*\]-policy\[integ-test\]-rule\[0\]
 9091 DestinationRule: a\..* for "a"
+   Matching subsets: v1
+   No Traffic Policy
+9091 RBAC policies: ns\[.*\]-policy\[integ-test\]-rule\[0\]
+9092 DestinationRule: a\..* for "a"
+   Matching subsets: v1
+   No Traffic Policy
+9093 DestinationRule: a\..* for "a"
    Matching subsets: v1
    No Traffic Policy
 81 DestinationRule: a\..* for "a"
@@ -81,7 +88,7 @@ var (
    Port: grpc 7070/GRPC targets pod port 17070
    Port: tcp 9090/TCP targets pod port 19090
    Port: tcp-server 9091/TCP targets pod port 16060
-   Port: auto-tcp 9091/UnsupportedProtocol targets pod port 19091
+   Port: auto-tcp 9092/UnsupportedProtocol targets pod port 19091
    Port: auto-tcp-server 9093/UnsupportedProtocol targets pod port 16061
    Port: auto-http 81/UnsupportedProtocol targets pod port 18081
    Port: auto-grpc 7071/UnsupportedProtocol targets pod port 17071
@@ -102,6 +109,13 @@ var (
    No Traffic Policy
 9090 RBAC policies: ns\[.*\]-policy\[integ-test\]-rule\[0\]
 9091 DestinationRule: a\..* for "a"
+   Matching subsets: v1
+   No Traffic Policy
+9091 RBAC policies: ns\[.*\]-policy\[integ-test\]-rule\[0\]
+9092 DestinationRule: a\..* for "a"
+   Matching subsets: v1
+   No Traffic Policy
+9093 DestinationRule: a\..* for "a"
    Matching subsets: v1
    No Traffic Policy
 81 DestinationRule: a\..* for "a"

--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -44,7 +44,9 @@ var (
 		{Name: "http", Protocol: protocol.HTTP, InstancePort: 18080},
 		{Name: "grpc", Protocol: protocol.GRPC, InstancePort: 17070},
 		{Name: "tcp", Protocol: protocol.TCP, InstancePort: 19090},
+		{Name: "tcp-server", Protocol: protocol.TCP, InstancePort: 16060, ServerFirst: true},
 		{Name: "auto-tcp", Protocol: protocol.TCP, InstancePort: 19091},
+		{Name: "auto-tcp-server", Protocol: protocol.TCP, InstancePort: 16061, ServerFirst: true},
 		{Name: "auto-http", Protocol: protocol.HTTP, InstancePort: 18081},
 		{Name: "auto-grpc", Protocol: protocol.GRPC, InstancePort: 17071},
 	}


### PR DESCRIPTION
As seen here, server first protocols are broken in most cases. This acts
as a baseline for future improvements - currently working on a design
doc that I hope will make most of these green.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.