### PR TITLE
Fix xds version set and status reporter

### DIFF
--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -558,7 +558,6 @@ func (s *DiscoveryServer) pushConnection(con *Connection, pushEv *Event) error {
 			adsLog.Debugf("Skipping EDS push to %v, no updates required", con.ConID)
 			return nil
 		}
-		eventTypes := []EventType{v3.ClusterType, v3.ListenerType, v3.RouteType}
 		edsUpdatedServices := model.ConfigNamesOfKind(pushRequest.ConfigsUpdated, gvk.ServiceEntry)
 		// Push only EDS. This is indexed already - push immediately
 		// (may need a throttle)
@@ -566,11 +565,7 @@ func (s *DiscoveryServer) pushConnection(con *Connection, pushEv *Event) error {
 			if err := s.pushEds(pushRequest.Push, con, versionInfo(), edsUpdatedServices); err != nil {
 				return err
 			}
-		} else {
-			eventTypes = append(eventTypes, v3.EndpointType)
 		}
-		// registerEvent notifies the implementer of an xDS ACK for no push ops
-		registerEvent(s.StatusReporter, con.ConID, eventTypes, pushRequest.Push.Version)
 		return nil
 	}
 
@@ -585,7 +580,7 @@ func (s *DiscoveryServer) pushConnection(con *Connection, pushEv *Event) error {
 
 	// This depends on SidecarScope updates, so it should be called after SetSidecarScope.
 	if !ProxyNeedsPush(con.proxy, pushEv) {
-		eventTypes = AllEventTypes
+		eventTypes = append(eventTypes, AllEventTypes...)
 		adsLog.Debugf("Skipping push to %v, no updates required", con.ConID)
 		return nil
 	}

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -143,7 +143,7 @@ func BenchmarkClusterGeneration(b *testing.B) {
 				if len(c) == 0 {
 					b.Fatal("Got no clusters!")
 				}
-				response = cdsDiscoveryResponse(c, "")
+				response = cdsDiscoveryResponse(c, "", "")
 			}
 			logDebug(b, response)
 		})

--- a/pilot/pkg/xds/cds.go
+++ b/pilot/pkg/xds/cds.go
@@ -26,7 +26,7 @@ import (
 )
 
 // clusters aggregate a DiscoveryResponse for pushing.
-func cdsDiscoveryResponse(response []*cluster.Cluster, noncePrefix string) *discovery.DiscoveryResponse {
+func cdsDiscoveryResponse(response []*cluster.Cluster, version, noncePrefix string) *discovery.DiscoveryResponse {
 	out := &discovery.DiscoveryResponse{
 		// All resources for CDS ought to be of the type Cluster
 		TypeUrl: v3.ClusterType,
@@ -35,7 +35,7 @@ func cdsDiscoveryResponse(response []*cluster.Cluster, noncePrefix string) *disc
 		// available to it, irrespective of whether Envoy chooses to accept or reject CDS
 		// responses. Pilot believes in eventual consistency and that at some point, Envoy
 		// will begin seeing results it deems to be good.
-		VersionInfo: versionInfo(),
+		VersionInfo: version,
 		Nonce:       nonce(noncePrefix),
 	}
 
@@ -52,7 +52,7 @@ func (s *DiscoveryServer) pushCds(con *Connection, push *model.PushContext, vers
 
 	rawClusters := s.ConfigGenerator.BuildClusters(con.proxy, push)
 
-	response := cdsDiscoveryResponse(rawClusters, push.Version)
+	response := cdsDiscoveryResponse(rawClusters, version, push.Version)
 	err := con.send(response)
 	if err != nil {
 		recordSendError("CDS", con.ConID, cdsSendErrPushes, err)


### PR DESCRIPTION
Currently, the version is not consistent across xds. 
This pr:
1. makes all cds response use the version from passed one

2. fix status reporter, record event for no ops push