### PR TITLE
Refactor SDS logic

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -1016,7 +1016,7 @@ func buildUpstreamClusterTLSContext(opts *buildClusterOpts, tls *networking.Clie
 
 			// If  credential name is specified at Destination Rule config and originating node is egress gateway, create
 			// SDS config for egress gateway to fetch key/cert at gateway agent.
-			authn_model.ApplyCustomSDSToClientCommonTLSContext(tlsContext.CommonTlsContext, tls, authn_model.GatewaySdsUdsPath)
+			authn_model.ApplyCustomSDSToClientCommonTLSContext(tlsContext.CommonTlsContext, tls)
 
 			if c.Http2ProtocolOptions != nil {
 				// This is HTTP/2 cluster, advertise it with ALPN.
@@ -1062,7 +1062,7 @@ func buildUpstreamClusterTLSContext(opts *buildClusterOpts, tls *networking.Clie
 
 			// If  credential name is specified at Destination Rule config and originating node is egress gateway, create
 			// SDS config for egress gateway to fetch key/cert at gateway agent.
-			authn_model.ApplyCustomSDSToClientCommonTLSContext(tlsContext.CommonTlsContext, tls, authn_model.GatewaySdsUdsPath)
+			authn_model.ApplyCustomSDSToClientCommonTLSContext(tlsContext.CommonTlsContext, tls)
 
 			if c.Http2ProtocolOptions != nil {
 				// This is HTTP/2 cluster, advertise it with ALPN.

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -3168,7 +3168,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 													{
 														TargetSpecifier: &core.GrpcService_GoogleGrpc_{
 															GoogleGrpc: &core.GrpcService_GoogleGrpc{
-																TargetUri:  authn_model.GatewaySdsUdsPath,
+																TargetUri:  authn_model.CredentialNameSDSUdsPath,
 																StatPrefix: authn_model.SDSStatPrefix,
 															},
 														},
@@ -3228,7 +3228,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 													{
 														TargetSpecifier: &core.GrpcService_GoogleGrpc_{
 															GoogleGrpc: &core.GrpcService_GoogleGrpc{
-																TargetUri:  authn_model.GatewaySdsUdsPath,
+																TargetUri:  authn_model.CredentialNameSDSUdsPath,
 																StatPrefix: authn_model.SDSStatPrefix,
 															},
 														},
@@ -3287,7 +3287,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 												{
 													TargetSpecifier: &core.GrpcService_GoogleGrpc_{
 														GoogleGrpc: &core.GrpcService_GoogleGrpc{
-															TargetUri:  authn_model.GatewaySdsUdsPath,
+															TargetUri:  authn_model.CredentialNameSDSUdsPath,
 															StatPrefix: authn_model.SDSStatPrefix,
 														},
 													},
@@ -3316,7 +3316,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 													{
 														TargetSpecifier: &core.GrpcService_GoogleGrpc_{
 															GoogleGrpc: &core.GrpcService_GoogleGrpc{
-																TargetUri:  authn_model.GatewaySdsUdsPath,
+																TargetUri:  authn_model.CredentialNameSDSUdsPath,
 																StatPrefix: authn_model.SDSStatPrefix,
 															},
 														},
@@ -3374,7 +3374,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 												{
 													TargetSpecifier: &core.GrpcService_GoogleGrpc_{
 														GoogleGrpc: &core.GrpcService_GoogleGrpc{
-															TargetUri:  authn_model.GatewaySdsUdsPath,
+															TargetUri:  authn_model.CredentialNameSDSUdsPath,
 															StatPrefix: authn_model.SDSStatPrefix,
 														},
 													},
@@ -3401,7 +3401,7 @@ func TestBuildUpstreamClusterTLSContext(t *testing.T) {
 													{
 														TargetSpecifier: &core.GrpcService_GoogleGrpc_{
 															GoogleGrpc: &core.GrpcService_GoogleGrpc{
-																TargetUri:  authn_model.GatewaySdsUdsPath,
+																TargetUri:  authn_model.CredentialNameSDSUdsPath,
 																StatPrefix: authn_model.SDSStatPrefix,
 															},
 														},

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -447,7 +447,7 @@ func buildGatewayListenerTLSContext(
 	if server.Tls.CredentialName != "" {
 		// If SDS is enabled at gateway, and credential name is specified at gateway config, create
 		// SDS config for gateway to fetch key/cert at gateway agent.
-		authn_model.ApplyCustomSDSToServerCommonTLSContext(ctx.CommonTlsContext, server.Tls, authn_model.GatewaySdsUdsPath)
+		authn_model.ApplyCredentialSDSToServerCommonTLSContext(ctx.CommonTlsContext, server.Tls)
 	} else if server.Tls.Mode == networking.ServerTLSSettings_ISTIO_MUTUAL {
 		authn_model.ApplyToCommonTLSContext(ctx.CommonTlsContext, metadata, sdsPath, server.Tls.SubjectAltNames, []string{})
 	} else {

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -207,7 +207,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 											{
 												TargetSpecifier: &core.GrpcService_GoogleGrpc_{
 													GoogleGrpc: &core.GrpcService_GoogleGrpc{
-														TargetUri:  model.GatewaySdsUdsPath,
+														TargetUri:  model.CredentialNameSDSUdsPath,
 														StatPrefix: model.SDSStatPrefix,
 													},
 												},
@@ -250,7 +250,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 											{
 												TargetSpecifier: &core.GrpcService_GoogleGrpc_{
 													GoogleGrpc: &core.GrpcService_GoogleGrpc{
-														TargetUri:  model.GatewaySdsUdsPath,
+														TargetUri:  model.CredentialNameSDSUdsPath,
 														StatPrefix: model.SDSStatPrefix,
 													},
 												},
@@ -362,7 +362,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 											{
 												TargetSpecifier: &core.GrpcService_GoogleGrpc_{
 													GoogleGrpc: &core.GrpcService_GoogleGrpc{
-														TargetUri:  model.GatewaySdsUdsPath,
+														TargetUri:  model.CredentialNameSDSUdsPath,
 														StatPrefix: model.SDSStatPrefix,
 													},
 												},
@@ -391,7 +391,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 												{
 													TargetSpecifier: &core.GrpcService_GoogleGrpc_{
 														GoogleGrpc: &core.GrpcService_GoogleGrpc{
-															TargetUri:  model.GatewaySdsUdsPath,
+															TargetUri:  model.CredentialNameSDSUdsPath,
 															StatPrefix: model.SDSStatPrefix,
 														},
 													},
@@ -435,7 +435,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 											{
 												TargetSpecifier: &core.GrpcService_GoogleGrpc_{
 													GoogleGrpc: &core.GrpcService_GoogleGrpc{
-														TargetUri:  model.GatewaySdsUdsPath,
+														TargetUri:  model.CredentialNameSDSUdsPath,
 														StatPrefix: model.SDSStatPrefix,
 													},
 												},
@@ -464,7 +464,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 												{
 													TargetSpecifier: &core.GrpcService_GoogleGrpc_{
 														GoogleGrpc: &core.GrpcService_GoogleGrpc{
-															TargetUri:  model.GatewaySdsUdsPath,
+															TargetUri:  model.CredentialNameSDSUdsPath,
 															StatPrefix: model.SDSStatPrefix,
 														},
 													},
@@ -508,7 +508,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 											{
 												TargetSpecifier: &core.GrpcService_GoogleGrpc_{
 													GoogleGrpc: &core.GrpcService_GoogleGrpc{
-														TargetUri:  model.GatewaySdsUdsPath,
+														TargetUri:  model.CredentialNameSDSUdsPath,
 														StatPrefix: model.SDSStatPrefix,
 													},
 												},
@@ -537,7 +537,7 @@ func TestBuildGatewayListenerTlsContext(t *testing.T) {
 												{
 													TargetSpecifier: &core.GrpcService_GoogleGrpc_{
 														GoogleGrpc: &core.GrpcService_GoogleGrpc{
-															TargetUri:  model.GatewaySdsUdsPath,
+															TargetUri:  model.CredentialNameSDSUdsPath,
 															StatPrefix: model.SDSStatPrefix,
 														},
 													},

--- a/pilot/pkg/security/model/authentication.go
+++ b/pilot/pkg/security/model/authentication.go
@@ -52,8 +52,8 @@ const (
 	// Binary header name must has suffix "-bin", according to https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md.
 	K8sSAJwtTokenHeaderKey = "istio_sds_credentials_header-bin"
 
-	// GatewaySdsUdsPath is the UDS path for ingress gateway to get credentials via SDS.
-	GatewaySdsUdsPath = "unix:./var/run/ingress_gateway/sds"
+	// CredentialNameSDSUdsPath is the UDS path for ingress gateway to get credentials via SDS.
+	CredentialNameSDSUdsPath = "unix:./var/run/ingress_gateway/sds"
 
 	// SdsCaSuffix is the suffix of the sds resource name for root CA.
 	SdsCaSuffix = "-cacert"
@@ -68,14 +68,17 @@ const (
 	AuthnFilterName = "istio_authn"
 )
 
-// ConstructSdsSecretConfigWithCustomUds constructs SDS secret configuration for ingress gateway.
-func ConstructSdsSecretConfigWithCustomUds(name, sdsUdsPath string) *tls.SdsSecretConfig {
-	if name == "" || sdsUdsPath == "" {
+// ConstructSdsSecretConfigForCredential constructs SDS secret configuration used
+// from certificates referenced by credentialName in DestinationRule or Gateway.
+// Currently this is served by a local SDS server, but in the future replaced by
+// Istiod SDS server.
+func ConstructSdsSecretConfigForCredential(name string) *tls.SdsSecretConfig {
+	if name == "" {
 		return nil
 	}
 
 	gRPCConfig := &core.GrpcService_GoogleGrpc{
-		TargetUri:  sdsUdsPath,
+		TargetUri:  CredentialNameSDSUdsPath,
 		StatPrefix: SDSStatPrefix,
 	}
 
@@ -274,11 +277,11 @@ func ApplyToCommonTLSContext(tlsContext *tls.CommonTlsContext, metadata *model.N
 
 // ApplyCustomSDSToClientCommonTLSContext applies the customized sds to CommonTlsContext
 // Used for building upstream TLS context for egress gateway's TLS/mTLS origination
-func ApplyCustomSDSToClientCommonTLSContext(tlsContext *tls.CommonTlsContext, tlsOpts *networking.ClientTLSSettings, sdsUdsPath string) {
+func ApplyCustomSDSToClientCommonTLSContext(tlsContext *tls.CommonTlsContext, tlsOpts *networking.ClientTLSSettings) {
 	if tlsOpts.Mode == networking.ClientTLSSettings_MUTUAL {
 		// create SDS config for gateway to fetch key/cert from agent.
 		tlsContext.TlsCertificateSdsSecretConfigs = []*tls.SdsSecretConfig{
-			ConstructSdsSecretConfigWithCustomUds(tlsOpts.CredentialName, sdsUdsPath),
+			ConstructSdsSecretConfigForCredential(tlsOpts.CredentialName),
 		}
 	}
 	// create SDS config for gateway to fetch certificate validation context
@@ -288,19 +291,18 @@ func ApplyCustomSDSToClientCommonTLSContext(tlsContext *tls.CommonTlsContext, tl
 	}
 	tlsContext.ValidationContextType = &tls.CommonTlsContext_CombinedValidationContext{
 		CombinedValidationContext: &tls.CommonTlsContext_CombinedCertificateValidationContext{
-			DefaultValidationContext: defaultValidationContext,
-			ValidationContextSdsSecretConfig: ConstructSdsSecretConfigWithCustomUds(
-				tlsOpts.CredentialName+SdsCaSuffix, sdsUdsPath),
+			DefaultValidationContext:         defaultValidationContext,
+			ValidationContextSdsSecretConfig: ConstructSdsSecretConfigForCredential(tlsOpts.CredentialName + SdsCaSuffix),
 		},
 	}
 }
 
-// ApplyCustomSDSToServerCommonTLSContext applies the customized sds to CommonTlsContext
+// ApplyCredentialSDSToServerCommonTLSContext applies the credentialName sds (Gateway/DestinationRule) to CommonTlsContext
 // Used for building both gateway/sidecar TLS context
-func ApplyCustomSDSToServerCommonTLSContext(tlsContext *tls.CommonTlsContext, tlsOpts *networking.ServerTLSSettings, sdsUdsPath string) {
+func ApplyCredentialSDSToServerCommonTLSContext(tlsContext *tls.CommonTlsContext, tlsOpts *networking.ServerTLSSettings) {
 	// create SDS config for gateway/sidecar to fetch key/cert from agent.
 	tlsContext.TlsCertificateSdsSecretConfigs = []*tls.SdsSecretConfig{
-		ConstructSdsSecretConfigWithCustomUds(tlsOpts.CredentialName, sdsUdsPath),
+		ConstructSdsSecretConfigForCredential(tlsOpts.CredentialName),
 	}
 	// If tls mode is MUTUAL, create SDS config for gateway/sidecar to fetch certificate validation context
 	// at gateway agent. Otherwise, use the static certificate validation context config.
@@ -312,9 +314,8 @@ func ApplyCustomSDSToServerCommonTLSContext(tlsContext *tls.CommonTlsContext, tl
 		}
 		tlsContext.ValidationContextType = &tls.CommonTlsContext_CombinedValidationContext{
 			CombinedValidationContext: &tls.CommonTlsContext_CombinedCertificateValidationContext{
-				DefaultValidationContext: defaultValidationContext,
-				ValidationContextSdsSecretConfig: ConstructSdsSecretConfigWithCustomUds(
-					tlsOpts.CredentialName+SdsCaSuffix, sdsUdsPath),
+				DefaultValidationContext:         defaultValidationContext,
+				ValidationContextSdsSecretConfig: ConstructSdsSecretConfigForCredential(tlsOpts.CredentialName + SdsCaSuffix),
 			},
 		}
 	} else if len(tlsOpts.SubjectAltNames) > 0 {

--- a/pkg/istio-agent/sds-agent.go
+++ b/pkg/istio-agent/sds-agent.go
@@ -232,7 +232,7 @@ func (sa *Agent) Start(isSidecar bool, podNamespace string) (*sds.Server, error)
 			log.Infof("Starting gateway SDS")
 			sa.secOpts.EnableGatewaySDS = true
 			// TODO: what is the setting for ingress ?
-			sa.secOpts.GatewayUDSPath = strings.TrimPrefix(model.GatewaySdsUdsPath, "unix:")
+			sa.secOpts.GatewayUDSPath = strings.TrimPrefix(model.CredentialNameSDSUdsPath, "unix:")
 			gatewaySecretCache = sa.newSecretCache(podNamespace)
 		} else {
 			log.Infof("Skipping gateway SDS")
@@ -255,7 +255,7 @@ func (sa *Agent) Start(isSidecar bool, podNamespace string) (*sds.Server, error)
 }
 
 func gatewaySdsExists() bool {
-	p := strings.TrimPrefix(model.GatewaySdsUdsPath, "unix:")
+	p := strings.TrimPrefix(model.CredentialNameSDSUdsPath, "unix:")
 	dir := path.Dir(p)
 	_, err := os.Stat(dir)
 	return !os.IsNotExist(err)


### PR DESCRIPTION
* We no longer have "custom" SDS - we have credentialName SDS (gw/dr)
and workload SDS. Rename things to align with this
* Do not pass custom UDS socket. This is a constant; treat it as such.
This makes things a bit simpler for SDS in Istiod.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
