### PR TITLE
remove-from-mesh should also restore rewritten app probes

### DIFF
--- a/istioctl/cmd/kubeuninject.go
+++ b/istioctl/cmd/kubeuninject.go
@@ -16,11 +16,13 @@ package cmd
 
 import (
 	"bufio"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"reflect"
+	"regexp"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -32,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	yamlDecoder "k8s.io/apimachinery/pkg/util/yaml"
 
+	istioStatus "istio.io/istio/pilot/cmd/pilot-agent/status"
 	"istio.io/istio/pkg/kube/inject"
 	"istio.io/pkg/log"
 )
@@ -111,6 +114,64 @@ func removeInjectedContainers(containers []corev1.Container, injectedContainerNa
 		}
 	}
 	return containers
+}
+
+func restoreAppProbes(containers []corev1.Container, probers map[string]*istioStatus.Prober) []corev1.Container {
+	re := regexp.MustCompile("/app-health/([a-z]+)/(readyz|livez|startupz)")
+	for name, prober := range probers {
+		matches := re.FindStringSubmatch(name)
+		if len(matches) == 0 {
+			continue
+		}
+		containerName := matches[1]
+		probeType := matches[2]
+		for i, c := range containers {
+			if c.Name == containerName {
+				container := c.DeepCopy()
+				switch probeType {
+				case "readyz":
+					container.ReadinessProbe = &corev1.Probe{
+						Handler: corev1.Handler{
+							HTTPGet: prober.HTTPGet,
+						},
+						TimeoutSeconds: prober.TimeoutSeconds,
+					}
+				case "livez":
+					container.LivenessProbe = &corev1.Probe{
+						Handler: corev1.Handler{
+							HTTPGet: prober.HTTPGet,
+						},
+						TimeoutSeconds: prober.TimeoutSeconds,
+					}
+				case "startupz":
+					container.StartupProbe = &corev1.Probe{
+						Handler: corev1.Handler{
+							HTTPGet: prober.HTTPGet,
+						},
+						TimeoutSeconds: prober.TimeoutSeconds,
+					}
+				}
+				containers[i] = *container
+			}
+		}
+	}
+	return containers
+}
+
+func retrieveAppProbe(containers []corev1.Container) string {
+	for _, c := range containers {
+		if c.Name != proxyContainerName {
+			continue
+		}
+
+		for _, env := range c.Env {
+			if env.Name == istioStatus.KubeAppProberEnvName {
+				return env.Value
+			}
+		}
+	}
+
+	return ""
 }
 
 // removeInjectedVolumes removes the injected volumes if exists.
@@ -244,6 +305,17 @@ func extractObject(in runtime.Object) (interface{}, error) {
 	}
 	if !sidecarInjected {
 		return out, nil
+	}
+
+	var appProbe istioStatus.KubeAppProbers
+	appProbeStr := retrieveAppProbe(podSpec.Containers)
+	if appProbeStr != "" {
+		if err := json.Unmarshal([]byte(appProbeStr), &appProbe); err != nil {
+			return nil, err
+		}
+	}
+	if appProbe != nil {
+		podSpec.Containers = restoreAppProbes(podSpec.Containers, appProbe)
 	}
 
 	podSpec.InitContainers = removeInjectedContainers(podSpec.InitContainers, initContainerName)

--- a/istioctl/cmd/kubeuninject_test.go
+++ b/istioctl/cmd/kubeuninject_test.go
@@ -98,6 +98,11 @@ func TestKubeUninject(t *testing.T) {
 				"experimental kube-uninject -f testdata/uninject/enable-core-dump.yaml.injected", " "),
 			goldenFilename: "testdata/uninject/enable-core-dump.yaml",
 		},
+		{ // case 15: restore rewritten app probes
+			args: strings.Split(
+				"experimental kube-uninject -f testdata/uninject/deploymentconfig-app-probe.yaml.injected", " "),
+			goldenFilename: "testdata/uninject/deploymentconfig-app-probe.yaml",
+		},
 	}
 
 	for i, c := range cases {

--- a/istioctl/cmd/testdata/uninject/deploymentconfig-app-probe.yaml
+++ b/istioctl/cmd/testdata/uninject/deploymentconfig-app-probe.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  creationTimestamp: null
+  name: hello
+spec:
+  replicas: 7
+  revisionHistoryLimit: 2
+  strategy:
+    resources: {}
+    type: Rolling
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      creationTimestamp: null
+      labels:
+        app: hello
+        tier: backend
+        track: stable
+    spec:
+      containers:
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          timeoutSeconds: 3
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          timeoutSeconds: 3
+        resources: {}
+  test: false
+  triggers:
+  - type: ConfigChange
+  - imageChangeParams:
+      automatic: true
+      containerNames:
+      - helloworld
+      from:
+        kind: ImageStreamTag
+        name: hello-go-gke:1.0
+    type: ImageChange
+status:
+  availableReplicas: 0
+  latestVersion: 0
+  observedGeneration: 0
+  replicas: 0
+  unavailableReplicas: 0
+  updatedReplicas: 0
+---

--- a/istioctl/cmd/testdata/uninject/deploymentconfig-app-probe.yaml.injected
+++ b/istioctl/cmd/testdata/uninject/deploymentconfig-app-probe.yaml.injected
@@ -1,0 +1,196 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  creationTimestamp: null
+  name: hello
+spec:
+  replicas: 7
+  revisionHistoryLimit: 2
+  strategy:
+    resources: {}
+    type: Rolling
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/interceptionMode: REDIRECT
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        traffic.sidecar.istio.io/excludeInboundPorts: "15020"
+        traffic.sidecar.istio.io/includeInboundPorts: "80"
+        traffic.sidecar.istio.io/includeOutboundIPRanges: '*'
+      creationTimestamp: null
+      labels:
+        app: hello
+        tier: backend
+        track: stable
+    spec:
+      containers:
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
+      - args:
+        - proxy
+        - sidecar
+        - --domain
+        - $(POD_NAMESPACE).svc.cluster.local
+        - --configPath
+        - /etc/istio/proxy
+        - --binaryPath
+        - /usr/local/bin/envoy
+        - --serviceCluster
+        - hello.$(POD_NAMESPACE)
+        - --drainDuration
+        - 45s
+        - --parentShutdownDuration
+        - 1m0s
+        - --discoveryAddress
+        - istio-pilot:15010
+        - --dnsRefreshRate
+        - 300s
+        - --connectTimeout
+        - 1s
+        - --proxyAdminPort
+        - "15000"
+        - --controlPlaneAuthPolicy
+        - NONE
+        - --statusPort
+        - "15020"
+        - --applicationPorts
+        - "80"
+        - --concurrency
+        - "2"
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_CONFIG_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
+        - name: ISTIO_META_INCLUDE_INBOUND_PORTS
+          value: "80"
+        - name: ISTIO_METAJSON_LABELS
+          value: |
+            {"app":"hello","tier":"backend","track":"stable"}
+        - name: ISTIO_KUBE_APP_PROBERS
+          value: '{"/app-health/hello/livez":{"httpGet":{"path":"/healthz","port":8080,"scheme":"HTTP"},"timeoutSeconds":3},"/app-health/hello/readyz":{"httpGet":{"path":"/healthz","port":8080,"scheme":"HTTP"},"timeoutSeconds":3}}'
+        image: docker.io/istio/proxyv2:unittest
+        imagePullPolicy: IfNotPresent
+        name: istio-proxy
+        ports:
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 30
+          httpGet:
+            path: /healthz/ready
+            port: 15020
+          initialDelaySeconds: 1
+          periodSeconds: 2
+        resources:
+          limits:
+            cpu: "2"
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
+        volumeMounts:
+        - mountPath: /etc/istio/proxy
+          name: istio-envoy
+        - mountPath: /etc/certs/
+          name: istio-certs
+          readOnly: true
+      initContainers:
+      - args:
+        - -p
+        - "15001"
+        - -u
+        - "1337"
+        - -m
+        - REDIRECT
+        - -i
+        - '*'
+        - -x
+        - ""
+        - -b
+        - "80"
+        - -d
+        - "15090,15020"
+        image: docker.io/istio/proxy_init:unittest
+        imagePullPolicy: IfNotPresent
+        name: istio-init
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_ADMIN
+            - NET_RAW
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: false
+          runAsGroup: 0
+          runAsNonRoot: false
+          runAsUser: 0
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: istio-envoy
+      - name: istio-certs
+        secret:
+          optional: true
+          secretName: istio.default
+  test: false
+  triggers:
+  - type: ConfigChange
+  - imageChangeParams:
+      automatic: true
+      containerNames:
+      - helloworld
+      from:
+        kind: ImageStreamTag
+        name: hello-go-gke:1.0
+    type: ImageChange
+status:
+  availableReplicas: 0
+  latestVersion: 0
+  observedGeneration: 0
+  replicas: 0
+  unavailableReplicas: 0
+  updatedReplicas: 0
+---


### PR DESCRIPTION
Please provide a description for what this PR is for.

Fixes #26677 

Users who enable AppProbeRewrites during istio-injection face an issue where the rewritten app probe isn't restored when executing `istioctl x remove-from-mesh deployment`. This PR fixes that

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
