### PR TITLE
Large index or -1 inserts at the end of list

### DIFF
--- a/operator/pkg/tpath/tree.go
+++ b/operator/pkg/tpath/tree.go
@@ -181,10 +181,11 @@ func getPathContext(nc *PathContext, fullPath, remainPath util.Path, createMissi
 				return nil, false, fmt.Errorf("path %s, index %s: %s", fullPath, pe, err)
 			}
 			var foundNode interface{}
-			if idx >= len(lst) {
+			if idx >= len(lst) || idx < 0 {
 				if !createMissing {
 					return nil, false, fmt.Errorf("index %d exceeds list length %d at path %s", idx, len(lst), remainPath)
 				}
+				idx = len(lst)
 				foundNode = make(map[string]interface{})
 			} else {
 				foundNode = lst[idx]

--- a/operator/pkg/tpath/tree_test.go
+++ b/operator/pkg/tpath/tree_test.go
@@ -524,20 +524,34 @@ a:
 `,
 		},
 		{
-			desc: "ExtendMoreThanOneLeafListEntry",
+			desc: "ExtendLeafListEntryLargeIndex",
 			baseYAML: `
 a:
   list:
     - v1
 `,
-			path:  `a.list.[3]`,
+			path:  `a.list.[999]`,
 			value: `v2`,
 			want: `
 a:
   list:
   - v1
-  - null
-  - null 
+  - v2
+`,
+		},
+		{
+			desc: "ExtendLeafListEntryNegativeIndex",
+			baseYAML: `
+a:
+  list:
+    - v1
+`,
+			path:  `a.list.[-1]`,
+			value: `v2`,
+			want: `
+a:
+  list:
+  - v1
   - v2
 `,
 		},
@@ -554,24 +568,6 @@ a:
 a:
   list:
   - name: foo
-  - name: bar
-`,
-		},
-		{
-			desc: "ExtendMoreThanOneLeafListEntry",
-			baseYAML: `
-a:
-  list:
-  - name: foo
-`,
-			path:  `a.list.[3].name`,
-			value: `bar`,
-			want: `
-a:
-  list:
-  - name: foo
-  - null
-  - null
   - name: bar
 `,
 		},

--- a/operator/pkg/util/path.go
+++ b/operator/pkg/util/path.go
@@ -137,7 +137,7 @@ func IsNPathElement(pe string) bool {
 	}
 
 	n, err := strconv.Atoi(pe)
-	return err == nil && n > InsertIndex
+	return err == nil && n >= InsertIndex
 }
 
 // PathKV returns the key and value string parts of the entire key/value path element.

--- a/operator/pkg/util/path_test.go
+++ b/operator/pkg/util/path_test.go
@@ -84,7 +84,7 @@ func TestIsNPathElement(t *testing.T) {
 		{
 			desc:   "negative-1",
 			in:     "[-1]",
-			expect: false,
+			expect: true,
 		},
 		{
 			desc:   "valid",


### PR DESCRIPTION
Previous behavior was to not allow -ve index and insert null entries if index was large.