### PR TITLE
Remove dns-capture.yaml release notes entry.

### DIFF
--- a/releasenotes/notes/dns-capture.yaml
+++ b/releasenotes/notes/dns-capture.yaml
@@ -1,9 +1,0 @@
-apiVersion: release-notes/v2
-kind: feature
-area: networking
-releaseNotes:
-- |
-  **Added** experimental DNS resolution directly in the sidecar to better support service entries with TCP services, multicluster DNS resolution,
-  and dns resolution of Kubernetes services from VM sidecars. This feature is disabled by default and can be enabled by setting the following
-  in the Istio Operator: meshConfig.defaultConfig.proxyMetadata.ISTIO_META_DNS_CAPTURE="ALL". Setting this option will cause Istio to set the
-  `ndots` option in pod's `dnsConfig` to 4 for faster DNS resolution in common cluster setups.


### PR DESCRIPTION
We originally was going to have DNS capture, introduced in PR 25964
However, there were testing issues, and it was reverted out of 1.7 by PR 26195

This PR merely removes the release notes entry so we don't advertise in the release notes that we have something that we don't really have.

Sean

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
