### PR TITLE
Add docs field

### DIFF
--- a/releasenotes/README.md
+++ b/releasenotes/README.md
@@ -80,7 +80,7 @@ The `docs` field should be used to list related documentation. These will be tur
 
 ### Release Notes
 
-These notes detail bug fixes, feature additions, removals, or other general content that has an impact to users. Release notes should be written in complete sentences, and the first word should be an action presented in the format `**Action**`. Acceptable actions are: `**Added**`, `**Deprecated**`, `**Enabled**`, `**Fixed**`, `**Optimized**`, `**Improved**`, `**Removed**`, **Promoted**, and `**Upgraded**`.
+These notes detail bug fixes, feature additions, removals, or other general content that has an impact to users. Release notes should be written in complete sentences, and the first word should be an action presented in the format `**Action**`. Acceptable actions are: `**Added**`, `**Deprecated**`, `**Enabled**`, `**Fixed**`, `**Optimized**`, `**Improved**`, `**Removed**`, `**Promoted**`, and `**Upgraded**`.
 
 ### Upgrade Notes
 

--- a/releasenotes/README.md
+++ b/releasenotes/README.md
@@ -5,7 +5,6 @@ Notes should be created as part of the pull request for any user facing changes.
 a release, the release notes utility will be run in order to generate a release notes file
 which will be reviewed by the release managers and documentation team.
 
-
 ## When to Add Release Notes
 
 Release notes should be added for any user facing changes. These include:
@@ -17,10 +16,10 @@ Release notes should be added for any user facing changes. These include:
 * A warning about a deprecation
 * Fix of a previous Known Issue
 
-No release notes are required for changes to: 
+No release notes are required for changes to:
 * Tests
 * Build Infrastructure
-* Fixes of bugs that have not been released. 
+* Fixes of bugs that have not been released.
 
 ## Adding a Release Note
 
@@ -76,7 +75,7 @@ While many pull requests will only fix a single GitHub issue, some pull requests
 
 ## docs
 
-The `docs` field should be used to list related documentation. These will be turned into links and appended to the note alongside the issues. 
+The `docs` field should be used to list related documentation. These will be turned into links and appended to the note alongside the issues.
 
 ### Release Notes
 

--- a/releasenotes/README.md
+++ b/releasenotes/README.md
@@ -15,6 +15,7 @@ Release notes should be added for any user facing changes. These include:
 * Change in non-functional attributes such as efficiency or availability, availability of a new platform
 * A warning about a deprecation
 * Fix of a previous Known Issue
+* Promoting features
 
 No release notes are required for changes to:
 * Tests
@@ -79,7 +80,7 @@ The `docs` field should be used to list related documentation. These will be tur
 
 ### Release Notes
 
-These notes detail bug fixes, feature additions, removals, or other general content that has an impact to users. Release notes should be written in complete sentences, and the first word should be an action presented in the format `**Action**`. Acceptable actions are: `**Added**`, `**Deprecated**`, `**Enabled**`, `**Fixed**`, `**Optimized**`, `**Improved**`, `**Removed**`, and `**Upgraded**`.
+These notes detail bug fixes, feature additions, removals, or other general content that has an impact to users. Release notes should be written in complete sentences, and the first word should be an action presented in the format `**Action**`. Acceptable actions are: `**Added**`, `**Deprecated**`, `**Enabled**`, `**Fixed**`, `**Optimized**`, `**Improved**`, `**Removed**`, **Promoted**, and `**Upgraded**`.
 
 ### Upgrade Notes
 

--- a/releasenotes/README.md
+++ b/releasenotes/README.md
@@ -5,6 +5,23 @@ Notes should be created as part of the pull request for any user facing changes.
 a release, the release notes utility will be run in order to generate a release notes file
 which will be reviewed by the release managers and documentation team.
 
+
+## When to Add Release Notes
+
+Release notes should be added for any user facing changes. These include:
+* CLI changes
+* API changes
+* Configuration schema change
+* Behavioral change
+* Change in non-functional attributes such as efficiency or availability, availability of a new platform
+* A warning about a deprecation
+* Fix of a previous Known Issue
+
+No release notes are required for changes to: 
+* Tests
+* Build Infrastructure
+* Fixes of bugs that have not been released. 
+
 ## Adding a Release Note
 
 To create a release note, create a new file in the [./notes](./notes) directory based on
@@ -27,7 +44,7 @@ docs:
 
 releaseNotes:
 - |
-*Fixed* an issue preventing the operator from recreating watched resources if they are deleted
+**Fixed** an issue preventing the operator from recreating watched resources if they are deleted
 
 upgradeNotes:
   - title: Change the readiness port of gateways

--- a/releasenotes/README.md
+++ b/releasenotes/README.md
@@ -20,6 +20,11 @@ area: traffic-management
 issue:
   - https://github.com/istio/istio/issues/23622
   - 23624
+
+docs:
+ - [usage] https://istio.io/latest/docs/tasks/traffic-management/request-routing/
+ - [reference] https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/
+
 releaseNotes:
 - |
 *Fixed* an issue preventing the operator from recreating watched resources if they are deleted
@@ -51,6 +56,10 @@ This field describes the are of Istio that the note affects. Valid values includ
 ### Issue
 
 While many pull requests will only fix a single GitHub issue, some pull requests may fix multiple issues. Please list all fixed GitHub issues. Issues written as numbers only will be interpreted as being reported against the `istio/istio` repo, while issues recorded as URLs will be read as the supplied URLs.
+
+## docs
+
+The `docs` field should be used to list related documentation. These will be turned into links and appended to the note alongside the issues. 
 
 ### Release Notes
 

--- a/releasenotes/template.yaml
+++ b/releasenotes/template.yaml
@@ -3,16 +3,16 @@ apiVersion: release-notes/v2
 # This YAML file describes the format for specifying a release notes entry for Istio.
 # This should be filled in for all user facing changes.
 
-# kind describes the type of change that this represents. 
+# kind describes the type of change that this represents.
 # Valid Values are:
-# - bug-fix -- Used to specify that this change represents a bug fix. 
-# - security-fix -- Used to specify that this change represents a security fix. 
-# - feature -- Used to specify a new feature that has been added. 
+# - bug-fix -- Used to specify that this change represents a bug fix.
+# - security-fix -- Used to specify that this change represents a security fix.
+# - feature -- Used to specify a new feature that has been added.
 # - test -- Used to describe additional testing added. This file is optional for
 #   tests, but included for completeness.
-kind: 
+kind:
 
-# area describes the area that this change affects. 
+# area describes the area that this change affects.
 # Valid values are:
 # - traffic-management
 # - security
@@ -23,17 +23,21 @@ kind:
 area:
 
 # issue is a list of GitHub issues resolved in this note.
-issue: 
+issue:
 
 # releaseNotes is a markdown listing of any user facing changes. This will appear in the
 # release notes.
 releaseNotes:
 
 # upgradeNotes is a markdown listing of any changes that will affect the upgrade
-# process. This will appear in the release notes. 
+# process. This will appear in the release notes.
 upgradeNotes:
   title:
   content:
+
+# docs is a list of related docs to the change.
+docs:
+
 
 # securityNotes is a markdown listing of any changes related to the security of
 # Istio.


### PR DESCRIPTION
One request related to the release notes schema was to add a field to specify docs. 

These links will be appended to the note. 
This is inspired by Kubernetes (https://relnotes.k8s.io/?documentation=official and https://github.com/kubernetes/kubernetes/pull/83474). 
 

For:

```
issue:
  - https://github.com/istio/istio/issues/23622
  - 23624

docs:
 - [usage] https://istio.io/latest/docs/tasks/traffic-management/request-routing/
 - [reference] https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/

releaseNotes:
- |
**Fixed** an issue preventing the operator from recreating watched resources if they are deleted

```

This would appear as: 
**Fixed** an issue preventing the operator from recreating watched resources if they are deleted  [[usage](https://istio.io/latest/docs/tasks/traffic-management/request-routing/)] [[reference](https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/)] [[issue #23622](https://github.com/istio/istio/issues/23622)] [[issue #23624](https://github.com/istio/istio/issues/23624)]



Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
