### PR TITLE
Adds update verb to operator role

### DIFF
--- a/manifests/charts/istio-operator/templates/clusterrole.yaml
+++ b/manifests/charts/istio-operator/templates/clusterrole.yaml
@@ -75,6 +75,7 @@ rules:
   verbs:
   - get
   - create
+  - update
 - apiGroups:
   - policy
   resources:


### PR DESCRIPTION
Istio operator fails to update `servicemonitor` resources when upgrading from a previous version. 


[ ] Configuration Infrastructure
[ ] Docs
[X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ X] Does not have any changes that may affect Istio users.