### PR TITLE
multi-network: gateways filter out endpoints for other gateways

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -745,22 +745,18 @@ const UnnamedNetwork = ""
 // GetNetworkView returns the networks that the proxy requested.
 // When sending EDS/CDS-with-dns-endpoints, Pilot will only send
 // endpoints corresponding to the networks that the proxy wants to see.
-// If not set, we assume that the proxy wants to see endpoints from the default
-// unnamed network.
+// If not set, we assume that the proxy wants to see endpoints in any network.
 func GetNetworkView(node *Proxy) map[string]bool {
-	if node == nil {
-		return map[string]bool{UnnamedNetwork: true}
+	if node == nil || len(node.Metadata.RequestedNetworkView) == 0 {
+		return nil
 	}
 
 	nmap := make(map[string]bool)
 	for _, n := range node.Metadata.RequestedNetworkView {
 		nmap[n] = true
 	}
+	nmap[UnnamedNetwork] = true
 
-	if len(nmap) == 0 {
-		// Proxy sees endpoints from the default unnamed network only
-		nmap[UnnamedNetwork] = true
-	}
 	return nmap
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -281,9 +281,8 @@ func (cb *ClusterBuilder) buildLocalityLbEndpoints(proxyNetworkView map[string]b
 	lbEndpoints := make(map[string][]*endpoint.LbEndpoint)
 	for _, instance := range instances {
 		// Only send endpoints from the networks in the network view requested by the proxy.
-		// The default network view assigned to the Proxy is the UnnamedNetwork (""), which matches
-		// the default network assigned to endpoints that don't have an explicit network
-		if !proxyNetworkView[instance.Endpoint.Network] {
+		// The default network view assigned to the Proxy is nil, in that case match any network.
+		if proxyNetworkView != nil && !proxyNetworkView[instance.Endpoint.Network] {
 			// Endpoint's network doesn't match the set of networks that the proxy wants to see.
 			continue
 		}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -283,7 +283,6 @@ func (cb *ClusterBuilder) buildLocalityLbEndpoints(proxyNetworkView map[string]b
 		// Only send endpoints from the networks in the network view requested by the proxy.
 		// The default network view assigned to the Proxy is nil, in that case match any network.
 		if proxyNetworkView != nil && !proxyNetworkView[instance.Endpoint.Network] {
-			// TODO(landow) does this just get handled in ep_filters later?
 			// Endpoint's network doesn't match the set of networks that the proxy wants to see.
 			continue
 		}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -283,6 +283,7 @@ func (cb *ClusterBuilder) buildLocalityLbEndpoints(proxyNetworkView map[string]b
 		// Only send endpoints from the networks in the network view requested by the proxy.
 		// The default network view assigned to the Proxy is nil, in that case match any network.
 		if proxyNetworkView != nil && !proxyNetworkView[instance.Endpoint.Network] {
+			// TODO(landow) does this just get handled in ep_filters later?
 			// Endpoint's network doesn't match the set of networks that the proxy wants to see.
 			continue
 		}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -695,6 +695,14 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 		FilterMetadata: make(map[string]*structpb.Struct),
 	}
 
+	nwMetadata := func(nw string) *core.Metadata {
+		return &core.Metadata{
+			FilterMetadata: map[string]*structpb.Struct{"istio": {Fields: map[string]*structpb.Value{
+				"network": {Kind: &structpb.Value_StringValue{StringValue: nw}},
+			}}},
+		}
+	}
+
 	cases := []struct {
 		name      string
 		mesh      meshconfig.MeshConfig
@@ -716,6 +724,7 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 							Label:     "region1/zone1/subzone1",
 						},
 						LbWeight: 30,
+						Network:  "nw-0",
 					},
 				},
 				{
@@ -729,6 +738,7 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 							Label:     "region1/zone1/subzone1",
 						},
 						LbWeight: 30,
+						Network:  "nw-1",
 					},
 				},
 				{
@@ -742,6 +752,21 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 							Label:     "region2/zone1/subzone1",
 						},
 						LbWeight: 40,
+						Network:  "",
+					},
+				},
+				{
+					Service:     service,
+					ServicePort: servicePort,
+					Endpoint: &model.IstioEndpoint{
+						Address:      "192.168.1.4",
+						EndpointPort: 10001,
+						Locality: model.Locality{
+							ClusterID: "cluster-1",
+							Label:     "region1/zone1/subzone1",
+						},
+						LbWeight: 30,
+						Network:  "filtered-out",
 					},
 				},
 			},
@@ -771,7 +796,7 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 									},
 								},
 							},
-							Metadata: emptyMetadata,
+							Metadata: nwMetadata("nw-0"),
 							LoadBalancingWeight: &wrappers.UInt32Value{
 								Value: 30,
 							},
@@ -791,7 +816,7 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 									},
 								},
 							},
-							Metadata: emptyMetadata,
+							Metadata: nwMetadata("nw-1"),
 							LoadBalancingWeight: &wrappers.UInt32Value{
 								Value: 30,
 							},
@@ -923,7 +948,12 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 			}
 
 			cb := NewClusterBuilder(cg.SetupProxy(proxy), cg.PushContext())
-			actual := cb.buildLocalityLbEndpoints(model.GetNetworkView(nil), service, 8080, nil)
+			nv := map[string]bool{
+				"nw-0":               true,
+				"nw-1":               true,
+				model.UnnamedNetwork: true,
+			}
+			actual := cb.buildLocalityLbEndpoints(nv, service, 8080, nil)
 			sortEndpoints(actual)
 			if v := cmp.Diff(tt.expected, actual, protocmp.Transform()); v != "" {
 				t.Fatalf("Expected (-) != actual (+):\n%s", v)

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -277,8 +277,8 @@ func (s *DiscoveryServer) generateEndpoints(b EndpointBuilder) *endpoint.Cluster
 
 	// If networks are set (by default they aren't) apply the Split Horizon
 	// EDS filter on the endpoints
-	if b.push.Networks != nil && len(b.push.Networks.Networks) > 0 {
-		l.Endpoints = EndpointsByNetworkFilter(b.push, b.network, l.Endpoints)
+	if b.IsMultinetwork() {
+		l.Endpoints = b.EndpointsByNetworkFilter(l.Endpoints)
 	}
 
 	// If locality aware routing is enabled, prioritize endpoints or set their lb weight.

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -277,7 +277,7 @@ func (s *DiscoveryServer) generateEndpoints(b EndpointBuilder) *endpoint.Cluster
 
 	// If networks are set (by default they aren't) apply the Split Horizon
 	// EDS filter on the endpoints
-	if b.IsMultinetwork() {
+	if b.MultinetworkConfigured() {
 		l.Endpoints = b.EndpointsByNetworkFilter(l.Endpoints)
 	}
 

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -277,7 +277,7 @@ func (s *DiscoveryServer) generateEndpoints(b EndpointBuilder) *endpoint.Cluster
 
 	// If networks are set (by default they aren't) apply the Split Horizon
 	// EDS filter on the endpoints
-	if b.MultinetworkConfigured() {
+	if b.MultiNetworkConfigured() {
 		l.Endpoints = b.EndpointsByNetworkFilter(l.Endpoints)
 	}
 

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -83,6 +83,7 @@ func (b EndpointBuilder) Key() string {
 		params = append(params, string(b.service.Hostname)+"/"+b.service.Attributes.Namespace)
 	}
 	if b.networkView != nil {
+		// TODO(landow) it's likely this would never be evicted when REQUESTED_NETWORK_VIEW changes.
 		nv := make([]string, 0, len(b.networkView))
 		for nw := range b.networkView {
 			nv = append(nv, nw)

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -31,11 +31,10 @@ import (
 
 type EndpointBuilder struct {
 	// These fields define the primary key for an endpoint, and can be used as a cache key
+	proxyName       string
 	clusterName     string
 	network         string
 	networkView     map[string]bool
-	proxyType       model.NodeType
-	routerMode      model.RouterMode
 	clusterID       string
 	locality        *core.Locality
 	destinationRule *config.Config
@@ -52,12 +51,11 @@ func NewEndpointBuilder(clusterName string, proxy *model.Proxy, push *model.Push
 	_, subsetName, hostname, port := model.ParseSubsetKey(clusterName)
 	svc := push.ServiceForHostname(proxy, hostname)
 	return EndpointBuilder{
+		proxyName:       proxy.ID,
 		clusterName:     clusterName,
 		network:         proxy.Metadata.Network,
 		networkView:     model.GetNetworkView(proxy),
 		clusterID:       proxy.Metadata.ClusterID,
-		proxyType:       proxy.Type,
-		routerMode:      proxy.GetRouterMode(),
 		locality:        proxy.Locality,
 		service:         svc,
 		destinationRule: push.DestinationRule(proxy, svc),

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -83,7 +83,6 @@ func (b EndpointBuilder) Key() string {
 		params = append(params, string(b.service.Hostname)+"/"+b.service.Attributes.Namespace)
 	}
 	if b.networkView != nil {
-		// TODO(landow) it's likely this would never be evicted when REQUESTED_NETWORK_VIEW changes.
 		nv := make([]string, 0, len(b.networkView))
 		for nw := range b.networkView {
 			nv = append(nv, nw)
@@ -94,8 +93,8 @@ func (b EndpointBuilder) Key() string {
 	return strings.Join(params, "~")
 }
 
-// MultinetworkConfigured determines if we have gateways to use for building cross-network endpoints.
-func (b *EndpointBuilder) MultinetworkConfigured() bool {
+// MultiNetworkConfigured determines if we have gateways to use for building cross-network endpoints.
+func (b *EndpointBuilder) MultiNetworkConfigured() bool {
 	return b.push.NetworkGateways() != nil
 }
 

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -32,7 +32,6 @@ import (
 
 type EndpointBuilder struct {
 	// These fields define the primary key for an endpoint, and can be used as a cache key
-	proxyName       string
 	clusterName     string
 	network         string
 	networkView     map[string]bool

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -74,7 +74,7 @@ func (b EndpointBuilder) DestinationRule() *networkingapi.DestinationRule {
 	return b.destinationRule.Spec.(*networkingapi.DestinationRule)
 }
 
-// CacheKey Functions
+// Key provides the eds cache key and should include any information that could change the way endpoints are generated.
 func (b EndpointBuilder) Key() string {
 	params := []string{b.clusterName, b.network, b.clusterID, util.LocalityToString(b.locality)}
 	if b.destinationRule != nil {
@@ -82,6 +82,11 @@ func (b EndpointBuilder) Key() string {
 	}
 	if b.service != nil {
 		params = append(params, string(b.service.Hostname)+"/"+b.service.Attributes.Namespace)
+	}
+	if b.networkView != nil {
+		for nw := range b.networkView {
+			params = append(params, nw)
+		}
 	}
 	return strings.Join(params, "~")
 }

--- a/pilot/pkg/xds/ep_filters.go
+++ b/pilot/pkg/xds/ep_filters.go
@@ -15,6 +15,7 @@
 package xds
 
 import (
+	"istio.io/pkg/log"
 	"net"
 
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
@@ -65,7 +66,11 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*endpoint.Localit
 					Value: uint32(multiples),
 				}
 				lbEndpoints = append(lbEndpoints, clonedLbEp)
-			} else if b.canViewNetwork(epNetwork) {
+			} else {
+				if !b.canViewNetwork(epNetwork) {
+					log.Infof("network view removes %s on %s from %s", b.clusterName, epNetwork, b.proxyName)
+					continue
+				}
 				if tlsMode := envoytransportSocketMetadata(lbEp, "tlsMode"); tlsMode == model.DisabledTLSModeLabel {
 					// dont allow cross-network endpoints for uninjected traffic
 					continue

--- a/pilot/pkg/xds/ep_filters.go
+++ b/pilot/pkg/xds/ep_filters.go
@@ -30,11 +30,11 @@ import (
 // sidecar network and add a gateway endpoint to remote networks that have endpoints
 // (if gateway exists and its IP is an IP and not a dns name).
 // Information for the mesh networks is provided as a MeshNetwork config map.
-func EndpointsByNetworkFilter(push *model.PushContext, proxyNetwork string, endpoints []*endpoint.LocalityLbEndpoints) []*endpoint.LocalityLbEndpoints {
+func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*endpoint.LocalityLbEndpoints) []*endpoint.LocalityLbEndpoints {
 	// calculate the multiples of weight.
 	// It is needed to normalize the LB Weight across different networks.
 	multiples := 1
-	for _, gateways := range push.NetworkGateways() {
+	for _, gateways := range b.push.NetworkGateways() {
 		if num := len(gateways); num > 0 {
 			multiples *= num
 		}
@@ -57,8 +57,7 @@ func EndpointsByNetworkFilter(push *model.PushContext, proxyNetwork string, endp
 			epNetwork := istioMetadata(lbEp, "network")
 			// This is a local endpoint or remote network endpoint
 			// but can be accessed directly from local network.
-			if epNetwork == proxyNetwork ||
-				len(push.NetworkGatewaysByNetwork(epNetwork)) == 0 {
+			if epNetwork == b.network || len(b.push.NetworkGatewaysByNetwork(epNetwork)) == 0 {
 				// Clone the endpoint so subsequent updates to the shared cache of
 				// service endpoints doesn't overwrite endpoints already in-flight.
 				clonedLbEp := proto.Clone(lbEp).(*endpoint.LbEndpoint)
@@ -66,7 +65,7 @@ func EndpointsByNetworkFilter(push *model.PushContext, proxyNetwork string, endp
 					Value: uint32(multiples),
 				}
 				lbEndpoints = append(lbEndpoints, clonedLbEp)
-			} else {
+			} else if b.canViewNetwork(epNetwork) {
 				if tlsMode := envoytransportSocketMetadata(lbEp, "tlsMode"); tlsMode == model.DisabledTLSModeLabel {
 					// dont allow cross-network endpoints for uninjected traffic
 					continue
@@ -87,7 +86,7 @@ func EndpointsByNetworkFilter(push *model.PushContext, proxyNetwork string, endp
 		// we initiate mTLS automatically to this remote gateway. Split horizon to remote gateway cannot
 		// work with plaintext
 		for network, w := range remoteEps {
-			gateways := push.NetworkGatewaysByNetwork(network)
+			gateways := b.push.NetworkGatewaysByNetwork(network)
 
 			gatewayNum := len(gateways)
 			weight := w * uint32(multiples/gatewayNum)

--- a/pilot/pkg/xds/ep_filters.go
+++ b/pilot/pkg/xds/ep_filters.go
@@ -15,7 +15,6 @@
 package xds
 
 import (
-	"istio.io/pkg/log"
 	"net"
 
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
@@ -68,7 +67,6 @@ func (b *EndpointBuilder) EndpointsByNetworkFilter(endpoints []*endpoint.Localit
 				lbEndpoints = append(lbEndpoints, clonedLbEp)
 			} else {
 				if !b.canViewNetwork(epNetwork) {
-					log.Infof("network view removes %s on %s from %s", b.clusterName, epNetwork, b.proxyName)
 					continue
 				}
 				if tlsMode := envoytransportSocketMetadata(lbEp, "tlsMode"); tlsMode == model.DisabledTLSModeLabel {

--- a/pilot/pkg/xds/ep_filters_test.go
+++ b/pilot/pkg/xds/ep_filters_test.go
@@ -159,7 +159,8 @@ func TestEndpointsByNetworkFilter(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			push := model.NewPushContext()
 			_ = push.InitContext(tt.env, nil, nil)
-			filtered := EndpointsByNetworkFilter(push, tt.conn.proxy.Metadata.Network, tt.endpoints)
+			b := NewEndpointBuilder("", tt.conn.proxy, push)
+			filtered := b.EndpointsByNetworkFilter(tt.endpoints)
 			if len(filtered) != len(tt.want) {
 				t.Errorf("Unexpected number of filtered endpoints: got %v, want %v", len(filtered), len(tt.want))
 				return
@@ -337,7 +338,8 @@ func TestEndpointsByNetworkFilter_RegistryServiceName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			push := model.NewPushContext()
 			_ = push.InitContext(tt.env, nil, nil)
-			filtered := EndpointsByNetworkFilter(push, tt.conn.proxy.Metadata.Network, tt.endpoints)
+			b := NewEndpointBuilder("", tt.conn.proxy, push)
+			filtered := b.EndpointsByNetworkFilter(tt.endpoints)
 			if len(filtered) != len(tt.want) {
 				t.Errorf("Unexpected number of filtered endpoints: got %v, want %v", len(filtered), len(tt.want))
 				return
@@ -512,7 +514,8 @@ func TestEndpointsByNetworkFilter_SkipLBWithHostname(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			push := model.NewPushContext()
 			_ = push.InitContext(tt.env, nil, nil)
-			filtered := EndpointsByNetworkFilter(push, tt.conn.proxy.Metadata.Network, tt.endpoints)
+			b := NewEndpointBuilder("", tt.conn.proxy, push)
+			filtered := b.EndpointsByNetworkFilter(tt.endpoints)
 			if len(filtered) != len(tt.want) {
 				t.Errorf("Unexpected number of filtered endpoints: got %v, want %v", len(filtered), len(tt.want))
 				return

--- a/pkg/test/framework/components/environment/kube/kube.go
+++ b/pkg/test/framework/components/environment/kube/kube.go
@@ -70,7 +70,7 @@ func (e *Environment) IsMulticluster() bool {
 	return len(e.KubeClusters) > 1
 }
 
-// MultinetworkConfigured returns true if there is more than one network name in networkTopology.
+// IsMultinetwork returns true if there is more than one network name in networkTopology.
 func (e *Environment) IsMultinetwork() bool {
 	return len(e.ClustersByNetwork()) > 1
 }

--- a/pkg/test/framework/components/environment/kube/kube.go
+++ b/pkg/test/framework/components/environment/kube/kube.go
@@ -70,7 +70,7 @@ func (e *Environment) IsMulticluster() bool {
 	return len(e.KubeClusters) > 1
 }
 
-// IsMultinetwork returns true if there is more than one network name in networkTopology.
+// MultinetworkConfigured returns true if there is more than one network name in networkTopology.
 func (e *Environment) IsMultinetwork() bool {
 	return len(e.ClustersByNetwork()) > 1
 }

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -477,8 +477,14 @@ func deployControlPlane(c *operatorComponent, cfg Config, cluster resource.Clust
 		installSettings = append(installSettings, "--set", "values.global.multiCluster.clusterName="+cluster.Name())
 
 		if networkName := cluster.NetworkName(); networkName != "" {
-			installSettings = append(installSettings, "--set", "values.global.meshID="+meshID,
-				"--set", "values.global.network="+networkName)
+			installSettings = append(installSettings,
+				"--set", "values.global.meshID="+meshID,
+				"--set", "values.global.network="+networkName,
+				// TODO(landow) remove these in favor of a dedicated cross-network gateway deployment
+				// ingress must be enabled for multi-network
+				"--set", "values.gateways.istio-ingressgateway.enabled=true",
+				// prevents gateways from calling gateways and throwing off cross-network traffic
+				"--set", "values.gateways.istio-ingressgateway.env.ISTIO_META_REQUESTED_NETWORK_VIEW="+networkName)
 		}
 
 		if !c.environment.IsControlPlaneCluster(cluster) {

--- a/pkg/test/framework/resource/cluster.go
+++ b/pkg/test/framework/resource/cluster.go
@@ -45,6 +45,16 @@ func (c Clusters) GetOrDefault(cluster Cluster) Cluster {
 	return c.Default()
 }
 
+// GetByName returns the Cluster with the given name or nil if it is not in the list.
+func (c Clusters) GetByName(name string) Cluster {
+	for _, cc := range c {
+		if cc.Name() == name {
+			return cc
+		}
+	}
+	return nil
+}
+
 // Names returns the deduped list of names of the clusters.
 func (c Clusters) Names() []string {
 	dedup := map[string]struct{}{}

--- a/tests/integration/pilot/mirror_test.go
+++ b/tests/integration/pilot/mirror_test.go
@@ -192,12 +192,12 @@ func sendTrafficMirror(from, to echo.Instance, proto protocol.Instance, testID s
 }
 
 func verifyTrafficMirror(dest, mirror echo.Instances, tc testCaseMirror, testID string) error {
-	countB, err := logCount(dest, testID)
+	countsB, countB, err := logCount(dest, testID)
 	if err != nil {
 		return err
 	}
 
-	countC, err := logCount(mirror, testID)
+	countsC, countC, err := logCount(mirror, testID)
 	if err != nil {
 		return err
 	}
@@ -216,33 +216,32 @@ func verifyTrafficMirror(dest, mirror echo.Instances, tc testCaseMirror, testID 
 			tc.percentage, actualPercent, tc.threshold, testID)
 	}
 
-	// TODO(landow) fix cross-network weighting issues
-	//if tc.percentage < 100 {
-	//	if len(countsB) < len(dest.Clusters()) {
-	//		merr = multierror.Append(merr, fmt.Errorf("expected original destination in all clusters to be reached, but got: %v", countsB))
-	//	}
-	//}
-	//if tc.percentage > 0 {
-	//	if len(countsC) < len(mirror.Clusters()) {
-	//		merr = multierror.Append(merr, fmt.Errorf("expected mirror destination in all clusters to be reached, but got: %v", countsC))
-	//	}
-	//}
+	if tc.percentage < 100 {
+		if len(countsB) < len(dest.Clusters()) {
+			merr = multierror.Append(merr, fmt.Errorf("expected original destination in all clusters to be reached, but got: %v", countsB))
+		}
+	}
+	if tc.percentage > 0 {
+		if len(countsC) < len(mirror.Clusters()) {
+			merr = multierror.Append(merr, fmt.Errorf("expected mirror destination in all clusters to be reached, but got: %v", countsC))
+		}
+	}
 
 	return merr.ErrorOrNil()
 }
 
-func logCount(instances echo.Instances, testID string) (float64, error) {
+func logCount(instances echo.Instances, testID string) (map[string]float64, float64, error) {
 	counts := map[string]float64{}
 	for _, instance := range instances {
 		workloads, err := instance.Workloads()
 		if err != nil {
-			return -1, fmt.Errorf("failed to get Subsets: %v", err)
+			return nil, -1, fmt.Errorf("failed to get Subsets: %v", err)
 		}
 		var logs string
 		for _, w := range workloads {
 			l, err := w.Logs()
 			if err != nil {
-				return -1, fmt.Errorf("failed getting logs: %v", err)
+				return nil, -1, fmt.Errorf("failed getting logs: %v", err)
 			}
 			logs += l
 		}
@@ -254,6 +253,5 @@ func logCount(instances echo.Instances, testID string) (float64, error) {
 	for _, c := range counts {
 		total += c
 	}
-	// TODO(landow) return counts for cross-cluster load balancing validation
-	return total, nil
+	return counts, total, nil
 }

--- a/tests/integration/pilot/routing_test.go
+++ b/tests/integration/pilot/routing_test.go
@@ -317,7 +317,6 @@ spec:
 						if err := hostResponses.CheckReachedClusters(hostDestinations.Clusters()); err != nil {
 							return fmt.Errorf("did not reach all clusters for %s: %v", host, err)
 						}
-						// TODO(landow) add res.CheckEqualClusterTraffic() when cross-network weighting is fixed
 					}
 					return nil
 				},


### PR DESCRIPTION
This should prevent scenarios in multi-network where a gateway sends traffic back to another gateway. It probably won't solve the problem of having equal traffic distribution. For multiple clusters in a network that each have their own gateway. 

- Default requested network view includes all networks
- The default unspecified network is always in scope
- Endpoint filters respect network view

fixes https://github.com/istio/istio/issues/26293

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
