### PR TITLE
Simplify cluster dependencies a bit

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -57,7 +57,7 @@ func (cb *ClusterBuilder) applyDestinationRule(c *cluster.Cluster, clusterMode C
 	destinationRule := castDestinationRuleOrDefault(destRule)
 
 	opts := buildClusterOpts{
-		push:        cb.push,
+		mesh:        cb.push.Mesh,
 		cluster:     c,
 		policy:      destinationRule.TrafficPolicy,
 		port:        port,
@@ -217,7 +217,7 @@ func (cb *ClusterBuilder) buildDefaultCluster(name string, discoveryType cluster
 	// For inbound clusters, the default traffic policy is used. For outbound clusters, the default traffic policy
 	// will be applied, which would be overridden by traffic policy specified in destination rule, if any.
 	opts := buildClusterOpts{
-		push:            cb.push,
+		mesh:            cb.push.Mesh,
 		cluster:         c,
 		policy:          cb.defaultTrafficPolicy(discoveryType),
 		port:            port,
@@ -353,7 +353,7 @@ func (cb *ClusterBuilder) buildDefaultPassthroughCluster() *cluster.Cluster {
 		ProtocolSelection:    cluster.Cluster_USE_DOWNSTREAM_PROTOCOL,
 	}
 	passthroughSettings := &networking.ConnectionPoolSettings{}
-	applyConnectionPool(cb.push, cluster, passthroughSettings)
+	applyConnectionPool(cb.push.Mesh, cluster, passthroughSettings)
 	return cluster
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -2162,7 +2162,7 @@ func TestApplyUpstreamTLSSettings(t *testing.T) {
 					Http2ProtocolOptions: test.http2ProtocolOptions,
 				},
 				proxy: proxy,
-				push:  push,
+				mesh:  push.Mesh,
 			}
 			applyUpstreamTLSSettings(opts, test.tls, test.mtlsCtx, proxy)
 


### PR DESCRIPTION
Don't pass the mega-struct `push`, instead just mesh config

For https://github.com/istio/istio/issues/26732