### PR TITLE
Pilot: Config deep copy bug fix

### DIFF
--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -419,13 +419,17 @@ func (store *istioConfigStore) AuthorizationPolicies(namespace string) []Config 
 func (c Config) DeepCopy() Config {
 	var clone Config
 	clone.ConfigMeta = c.ConfigMeta
-	clone.Labels = make(map[string]string)
-	clone.Annotations = make(map[string]string)
-	for k, v := range c.Labels {
-		clone.Labels[k] = v
+	if c.Labels != nil {
+		clone.Labels = make(map[string]string)
+		for k, v := range c.Labels {
+			clone.Labels[k] = v
+		}
 	}
-	for k, v := range c.Annotations {
-		clone.Annotations[k] = v
+	if c.Annotations != nil {
+		clone.Annotations = make(map[string]string)
+		for k, v := range c.Annotations {
+			clone.Annotations[k] = v
+		}
 	}
 	clone.Spec = proto.Clone(c.Spec)
 	return clone

--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -419,6 +419,14 @@ func (store *istioConfigStore) AuthorizationPolicies(namespace string) []Config 
 func (c Config) DeepCopy() Config {
 	var clone Config
 	clone.ConfigMeta = c.ConfigMeta
+	clone.Labels = make(map[string]string)
+	clone.Annotations = make(map[string]string)
+	for k, v := range c.Labels {
+		clone.Labels[k] = v
+	}
+	for k, v := range c.Annotations {
+		clone.Annotations[k] = v
+	}
 	clone.Spec = proto.Clone(c.Spec)
 	return clone
 }

--- a/pilot/pkg/model/config_test.go
+++ b/pilot/pkg/model/config_test.go
@@ -407,6 +407,8 @@ func TestDeepCopy(t *testing.T) {
 			Name:              "name1",
 			Namespace:         "zzz",
 			CreationTimestamp: time.Now(),
+			Labels:            map[string]string{"app": "test-app"},
+			Annotations:       map[string]string{"policy.istio.io/checkRetries": "3"},
 		},
 		Spec: &networking.Gateway{},
 	}
@@ -418,6 +420,13 @@ func TestDeepCopy(t *testing.T) {
 		cfg.Name == copied.Name &&
 		cfg.CreationTimestamp == copied.CreationTimestamp) {
 		t.Fatalf("cloned config is not identical")
+	}
+
+	copied.Labels["app"] = "cloned-app"
+	copied.Annotations["policy.istio.io/checkRetries"] = "0"
+	if cfg.Labels["app"] == copied.Labels["app"] ||
+		cfg.Annotations["policy.istio.io/checkRetries"] == copied.Annotations["policy.istio.io/checkRetries"] {
+		t.Fatalf("Did not deep copy labels and annotations")
 	}
 
 	// change the copied gateway to see if the original config is not effected


### PR DESCRIPTION
Fixes pilot `Config` deep copy bug. Map pointers were just being copied, so copies shared the same labels and annotations.

- [x] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

- [x] Does not have any changes that may affect Istio users.
