### PR TITLE
Increase timeout on traffic test

### DIFF
--- a/tests/integration/pilot/routing_test.go
+++ b/tests/integration/pilot/routing_test.go
@@ -380,7 +380,7 @@ func protocolSniffingCases(ctx framework.TestContext) []TrafficTestCase {
 					cases = append(cases, TrafficTestCase{
 						name: fmt.Sprintf("%v %v->%v from %s", call.port, client.Config().Service, destination.Config().Service, client.Config().Cluster.Name()),
 						call: func() (echoclient.ParsedResponses, error) {
-							return client.Call(echo.CallOptions{Target: destination, PortName: call.port, Scheme: call.scheme, Count: callCount, Timeout: time.Second})
+							return client.Call(echo.CallOptions{Target: destination, PortName: call.port, Scheme: call.scheme, Count: callCount, Timeout: time.Second * 5})
 						},
 						validator: func(responses echoclient.ParsedResponses) error {
 							return responses.CheckOK()


### PR DESCRIPTION
We send a lot of traffic all at once, causing occasional timeouts in the
CI. I can reproduce locally, with this fix it seems to pass consistently



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.