### PR TITLE
Update istio download script

### DIFF
--- a/release/downloadIstioCandidate.sh
+++ b/release/downloadIstioCandidate.sh
@@ -75,18 +75,36 @@ NAME="istio-$ISTIO_VERSION"
 URL="https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/istio-${ISTIO_VERSION}-${OSEXT}.tar.gz"
 ARCH_URL="https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/istio-${ISTIO_VERSION}-${OSEXT}-${ISTIO_ARCH}.tar.gz"
 
-if [ "${OS}" = "Linux" ] ; then
+with_arch() {
   printf "\nDownloading %s from %s ...\n" "$NAME" "$ARCH_URL"
   curl -fsLO "$ARCH_URL"
   filename="istio-${ISTIO_VERSION}-${OSEXT}-${ISTIO_ARCH}.tar.gz"
   tar -xzf "${filename}"
   rm "${filename}"
-elif [ "x${OS}" = "xDarwin" ] ; then
+}
+
+without_arch() {
   printf "\nDownloading %s from %s ..." "$NAME" "$URL"
   curl -fsLO "$URL"
   filename="istio-${ISTIO_VERSION}-${OSEXT}.tar.gz"
   tar -xzf "${filename}"
   rm "${filename}"
+}
+
+# Istio 1.6 and above support arch
+ARCH_SUPPORTED=$(echo "$ISTIO_VERSION" | awk  '{ ARCH_SUPPORTED=substr($0, 1, 3); print ARCH_SUPPORTED; }' )
+# Istio 1.5 and below do not have arch support
+ARCH_UNSUPPORTED="1.5"
+
+if [ "${OS}" = "Linux" ] ; then
+  # This checks if 1.6 <= 1.5 or 1.4 <= 1.5
+  if [ "$(expr "${ARCH_SUPPORTED}" \<= "${ARCH_UNSUPPORTED}")" -eq 1 ]; then
+    without_arch
+  else
+    with_arch
+  fi
+elif [ "x${OS}" = "xDarwin" ] ; then
+  without_arch
 else
   printf "\n\n"
   printf "Unable to download Istio %s at this moment!\n" "$ISTIO_VERSION"

--- a/release/downloadIstioCandidate.sh
+++ b/release/downloadIstioCandidate.sh
@@ -15,24 +15,21 @@
 # limitations under the License.
 
 #
-# Early version of a downloader/installer for Istio
-#
 # This file will be fetched as: curl -L https://git.io/getLatestIstio | sh -
 # so it should be pure bourne shell, not bash (and not reference other scripts)
 #
 # The script fetches the latest Istio release candidate and untars it.
-# It's derived from ../downloadIstio.sh which is for stable releases but lets
-# users do curl -L https://git.io/getLatestIstio | ISTIO_VERSION=0.3.6 sh -
-# for instance to change the version fetched.
+# You can pass variables on the command line to download a specific version
+# or to override the processor architecture. For example, to download
+# Istio 1.6.8 for the x86_64 architecture,
+# run curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.6.8 TARGET_ARCH=x86_64 sh -.
 
-# This is the latest release candidate (matches ../istio.VERSION after basic
-# sanity checks)
 
+# Determines the operating system.
 OS="$(uname)"
 if [ "x${OS}" = "xDarwin" ] ; then
   OSEXT="osx"
 else
-  # TODO we should check more/complain if not likely to work, etc...
   OSEXT="linux"
 fi
 
@@ -78,25 +75,23 @@ NAME="istio-$ISTIO_VERSION"
 URL="https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/istio-${ISTIO_VERSION}-${OSEXT}.tar.gz"
 ARCH_URL="https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/istio-${ISTIO_VERSION}-${OSEXT}-${ISTIO_ARCH}.tar.gz"
 
-printf "Downloading %s from %s ..." "$NAME" "$URL"
-if ! curl -fsLO "$URL"
-then
-  printf "Failed.\n\nTrying with TARGET_ARCH. Downloading %s from %s ...\n" "$NAME" "$ARCH_URL"
-  if ! curl -fsLO "$ARCH_URL"
-  then
-    printf "\n\n"
-    printf "Unable to download Istio %s at this moment!\n" "$ISTIO_VERSION"
-    printf "Please verify the version you are trying to download.\n\n"
-    exit
-  else
-    filename="istio-${ISTIO_VERSION}-${OSEXT}-${ISTIO_ARCH}.tar.gz"
-    tar -xzf "${filename}"
-    rm "${filename}"
-  fi
-else
+if [ "${OS}" = "Linux" ] ; then
+  printf "\nDownloading %s from %s ...\n" "$NAME" "$ARCH_URL"
+  curl -fsLO "$ARCH_URL"
+  filename="istio-${ISTIO_VERSION}-${OSEXT}-${ISTIO_ARCH}.tar.gz"
+  tar -xzf "${filename}"
+  rm "${filename}"
+elif [ "x${OS}" = "xDarwin" ] ; then
+  printf "\nDownloading %s from %s ..." "$NAME" "$URL"
+  curl -fsLO "$URL"
   filename="istio-${ISTIO_VERSION}-${OSEXT}.tar.gz"
   tar -xzf "${filename}"
   rm "${filename}"
+else
+  printf "\n\n"
+  printf "Unable to download Istio %s at this moment!\n" "$ISTIO_VERSION"
+  printf "Please verify the version you are trying to download.\n\n"
+  exit
 fi
 
 printf ""


### PR DESCRIPTION
[Release artifacts ](https://github.com/istio/istio/releases)don't have `istio-1.7.0-linux.tar.gz`. It always appends architecture for `Linux` artifacts `istio-1.7.0-linux-amd64.tar.gz`.

The old scripts will always fail in the first attempt because `istio-1.7.0-linux.tar.gz` never exists.

```
Downloading istio-1.7.0 from 
https://github.com/istio/istio/releases/download/1.7.0/istio-1.7.0-linux.tar.gz ...Failed.
```
It then retires by appending `arch`.
```
Trying with TARGET_ARCH. Downloading istio-1.7.0 from 
https://github.com/istio/istio/releases/download/1.7.0/istio-1.7.0-linux-amd64.tar.gz ...
```
**Which is not required, and we can directly call downloading istio with arch for Linux.**

**Old output:**
```
$ curl -L https://istio.io/downloadIstio | sh -
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   102  100   102    0     0    112      0 --:--:-- --:--:-- --:--:--   112
100  3888  100  3888    0     0   2869      0  0:00:01  0:00:01 --:--:--  2869
Downloading istio-1.7.0 from https://github.com/istio/istio/releases/download/1.7.0/istio-1.7.0-linux.tar.gz ...Failed.

Trying with TARGET_ARCH. Downloading istio-1.7.0 from https://github.com/istio/istio/releases/download/1.7.0/istio-1.7.0-linux-amd64.tar.gz ...

Istio 1.7.0 Download Complete!
```

**New output:**
```
$ curl -L https://istio.io/downloadIstio | sh -
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   102  100   102    0     0    112      0 --:--:-- --:--:-- --:--:--   112
100  3888  100  3888    0     0   2869      0  0:00:01  0:00:01 --:--:--  2869

Downloading istio-1.7.0 from https://github.com/istio/istio/releases/download/1.7.0/istio-1.7.0-linux-amd64.tar.gz ...

Istio 1.7.0 Download Complete!

```