### PR TITLE
Split out xds.FakeDiscoveryServer for use in configgen

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/fake.go
+++ b/pilot/pkg/networking/core/v1alpha3/fake.go
@@ -1,0 +1,272 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha3
+
+import (
+	"bytes"
+	"errors"
+	"sync"
+	"text/template"
+
+	"github.com/Masterminds/sprig/v3"
+	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pilot/pkg/config/kube/crd"
+	"istio.io/istio/pilot/pkg/config/memory"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/plugin"
+	"istio.io/istio/pilot/pkg/networking/plugin/registry"
+	"istio.io/istio/pilot/pkg/serviceregistry"
+	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
+	memregistry "istio.io/istio/pilot/pkg/serviceregistry/memory"
+	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
+	"istio.io/istio/pilot/test/xdstest"
+	"istio.io/istio/pkg/config/mesh"
+	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/util/retry"
+)
+
+type TestOptions struct {
+	// If provided, these configs will be used directly
+	Configs        []model.Config
+	ConfigPointers []*model.Config
+
+	// If provided, the yaml string will be parsed and used as configs
+	ConfigString string
+	// If provided, the ConfigString will be treated as a go template, with this as input params
+	ConfigTemplateInput interface{}
+
+	// Services to pre-populate as part of the service discovery
+	Services []*model.Service
+
+	// If provided, this mesh config will be used
+	MeshConfig      *meshconfig.MeshConfig
+	NetworksWatcher mesh.NetworksWatcher
+
+	// Additional service registries to use. A ServiceEntry and memory registry will always be created.
+	ServiceRegistries []serviceregistry.Instance
+
+	// ConfigGen plugins to use. If not set, all default plugins will be used
+	Plugins []plugin.Plugin
+
+	// Mutex used for push context access. Should generally only be used by NewFakeDiscoveryServer
+	PushContextLock *sync.RWMutex
+}
+
+type ConfigGenTest struct {
+	t                    test.Failer
+	pushContextLock      *sync.RWMutex
+	store                model.ConfigStoreCache
+	env                  *model.Environment
+	ConfigGen            *ConfigGeneratorImpl
+	MemRegistry          *memregistry.ServiceDiscovery
+	ServiceEntryRegistry *serviceentry.ServiceEntryStore
+}
+
+func NewConfigGenTest(t test.Failer, opts TestOptions) *ConfigGenTest {
+	t.Helper()
+	stop := make(chan struct{})
+	t.Cleanup(func() {
+		close(stop)
+	})
+
+	configs := getConfigs(t, opts)
+	configStore := memory.MakeWithLedger(collections.Pilot, &model.DisabledLedger{}, true)
+
+	configController := memory.NewSyncController(configStore)
+	go configController.Run(stop)
+
+	m := opts.MeshConfig
+	if m == nil {
+		def := mesh.DefaultMeshConfig()
+		m = &def
+	}
+
+	serviceDiscovery := aggregate.NewController(aggregate.Options{})
+	se := serviceentry.NewServiceDiscovery(configController, model.MakeIstioStore(configStore), &FakeXdsUpdater{})
+	// TODO allow passing in registry, for k8s, mem reigstry
+	serviceDiscovery.AddRegistry(se)
+	msd := memregistry.NewServiceDiscovery(opts.Services)
+	msd.ClusterID = string(serviceregistry.Mock)
+	serviceDiscovery.AddRegistry(serviceregistry.Simple{
+		ClusterID:        string(serviceregistry.Mock),
+		ProviderID:       serviceregistry.Mock,
+		ServiceDiscovery: msd,
+		Controller:       msd.Controller,
+	})
+	for _, reg := range opts.ServiceRegistries {
+		serviceDiscovery.AddRegistry(reg)
+	}
+
+	env := &model.Environment{}
+	env.PushContext = model.NewPushContext()
+	env.ServiceDiscovery = serviceDiscovery
+	env.IstioConfigStore = model.MakeIstioStore(configStore)
+	env.Watcher = mesh.NewFixedWatcher(m)
+	if opts.NetworksWatcher == nil {
+		opts.NetworksWatcher = mesh.NewFixedNetworksWatcher(nil)
+	}
+	env.NetworksWatcher = opts.NetworksWatcher
+
+	// Setup configuration. This should be done after registries are added so they can process events.
+	for _, cfg := range configs {
+		if _, err := configStore.Create(cfg); err != nil {
+			t.Fatalf("failed to create config %v: %v", cfg.Name, err)
+		}
+	}
+
+	// TODO allow passing event handlers for controller
+
+	retry.UntilSuccessOrFail(t, func() error {
+		if !serviceDiscovery.HasSynced() {
+			return errors.New("not synced")
+		}
+		return nil
+	})
+
+	se.ResyncEDS()
+	if err := env.PushContext.InitContext(env, nil, nil); err != nil {
+		t.Fatalf("Failed to initialize push context: %v", err)
+	}
+
+	if opts.Plugins == nil {
+		opts.Plugins = registry.NewPlugins([]string{plugin.Authn, plugin.Authz})
+	}
+
+	fake := &ConfigGenTest{
+		t:                    t,
+		store:                configController,
+		env:                  env,
+		ConfigGen:            NewConfigGenerator(opts.Plugins),
+		MemRegistry:          msd,
+		ServiceEntryRegistry: se,
+		pushContextLock:      opts.PushContextLock,
+	}
+	return fake
+}
+
+// SetupProxy initializes a proxy for the current environment. This should generally be used when creating
+// any proxy. For example, `p := SetupProxy(&model.Proxy{...})`.
+func (f *ConfigGenTest) SetupProxy(p *model.Proxy) *model.Proxy {
+	// Setup defaults
+	if p == nil {
+		p = &model.Proxy{}
+	}
+	if p.Metadata == nil {
+		p.Metadata = &model.NodeMetadata{}
+	}
+	if p.Metadata.IstioVersion == "" {
+		p.Metadata.IstioVersion = "1.8.0"
+		p.IstioVersion = model.ParseIstioVersion(p.Metadata.IstioVersion)
+	}
+	if p.Type == "" {
+		p.Type = model.SidecarProxy
+	}
+	if p.ID == "" {
+		p.ID = "app.test"
+	}
+	if len(p.IPAddresses) == 0 {
+		p.IPAddresses = []string{"1.1.1.1"}
+	}
+
+	// Initialize data structures
+	pc := f.PushContext()
+	p.SetSidecarScope(pc)
+	p.SetGatewaysForProxy(pc)
+	if err := p.SetServiceInstances(f.env.ServiceDiscovery); err != nil {
+		f.t.Fatal(err)
+	}
+	p.DiscoverIPVersions()
+	return p
+}
+
+// TODO do we need lock around push context?
+func (f *ConfigGenTest) Listeners(p *model.Proxy) []*listener.Listener {
+	return f.ConfigGen.BuildListeners(p, f.PushContext())
+}
+
+func (f *ConfigGenTest) Clusters(p *model.Proxy) []*cluster.Cluster {
+	return f.ConfigGen.BuildClusters(p, f.PushContext())
+}
+
+func (f *ConfigGenTest) Routes(p *model.Proxy) []*route.RouteConfiguration {
+	return f.ConfigGen.BuildHTTPRoutes(p, f.PushContext(), xdstest.ExtractRoutesFromListeners(f.Listeners(p)))
+}
+
+func (f *ConfigGenTest) PushContext() *model.PushContext {
+	if f.pushContextLock != nil {
+		f.pushContextLock.RLock()
+		defer f.pushContextLock.RUnlock()
+	}
+	return f.env.PushContext
+}
+
+func (f *ConfigGenTest) Env() *model.Environment {
+	return f.env
+}
+
+func (f *ConfigGenTest) Store() model.ConfigStoreCache {
+	return f.store
+}
+
+var _ model.XDSUpdater = &FakeXdsUpdater{}
+
+func getConfigs(t test.Failer, opts TestOptions) []model.Config {
+	for _, p := range opts.ConfigPointers {
+		if p != nil {
+			opts.Configs = append(opts.Configs, *p)
+		}
+	}
+	if len(opts.Configs) > 0 {
+		return opts.Configs
+	}
+	configStr := opts.ConfigString
+	if opts.ConfigTemplateInput != nil {
+		tmpl := template.Must(template.New("").Funcs(sprig.TxtFuncMap()).Parse(opts.ConfigString))
+		var buf bytes.Buffer
+		if err := tmpl.Execute(&buf, opts.ConfigTemplateInput); err != nil {
+			t.Fatalf("failed to execute template: %v", err)
+		}
+		configStr = buf.String()
+	}
+	configs, _, err := crd.ParseInputs(configStr)
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+	// setup default namespace if not defined
+	for i, c := range configs {
+		if c.Namespace == "" {
+			c.Namespace = "default"
+		}
+		configs[i] = c
+	}
+	return configs
+}
+
+type FakeXdsUpdater struct{}
+
+func (f *FakeXdsUpdater) ConfigUpdate(*model.PushRequest) {}
+
+func (f *FakeXdsUpdater) EDSUpdate(_, _, _ string, _ []*model.IstioEndpoint) {}
+
+func (f *FakeXdsUpdater) EDSCacheUpdate(_, _, _ string, _ []*model.IstioEndpoint) {}
+
+func (f *FakeXdsUpdater) SvcUpdate(_, _, _ string, _ model.Event) {}
+
+func (f *FakeXdsUpdater) ProxyUpdate(_, _ string) {}

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -420,7 +420,6 @@ func TestOutboundListenerForHeadlessServices(t *testing.T) {
 	extSvcSelector.Attributes.ServiceRegistry = serviceregistry.External
 	extSvcSelector.Attributes.LabelSelectors = map[string]string{"foo": "bar"}
 
-	p := &fakePlugin{}
 	tests := []struct {
 		name                      string
 		instances                 []*model.ServiceInstance
@@ -477,23 +476,16 @@ func TestOutboundListenerForHeadlessServices(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			configgen := NewConfigGenerator([]plugin.Plugin{p})
-
-			env := buildListenerEnv(tt.services)
-			serviceDiscovery := memregistry.NewServiceDiscovery(tt.services)
+			cg := NewConfigGenTest(t, TestOptions{
+				Services: tt.services,
+			})
 			for _, i := range tt.instances {
-				serviceDiscovery.AddInstance(i.Service.Hostname, i)
-			}
-			env.ServiceDiscovery = serviceDiscovery
-			if err := env.PushContext.InitContext(&env, nil, nil); err != nil {
-				t.Errorf("Failed to initialize push context: %v", err)
+				cg.MemRegistry.AddInstance(i.Service.Hostname, i)
 			}
 
-			proxy := getProxy()
-			proxy.SidecarScope = model.DefaultSidecarScopeForNamespace(env.PushContext, "not-default")
-			proxy.ServiceInstances = proxyInstances
+			proxy := cg.SetupProxy(nil)
 
-			listeners := configgen.buildSidecarOutboundListeners(proxy, env.PushContext)
+			listeners := cg.ConfigGen.buildSidecarOutboundListeners(proxy, cg.env.PushContext)
 			listenersToCheck := make([]string, 0)
 			for _, l := range listeners {
 				if l.Address.GetSocketAddress().GetPortValue() == 9999 {
@@ -597,8 +589,9 @@ func TestOutboundListenerConfigWithSidecarHTTPProxy(t *testing.T) {
 	p := &fakePlugin{}
 	sidecarConfig := &model.Config{
 		ConfigMeta: model.ConfigMeta{
-			Name:      "sidecar-with-http-proxy",
-			Namespace: "default",
+			Name:             "sidecar-with-http-proxy",
+			Namespace:        "not-default",
+			GroupVersionKind: gvk.Sidecar,
 		},
 		Spec: &networking.Sidecar{
 			Egress: []*networking.IstioEgressListener{
@@ -1046,8 +1039,9 @@ func testOutboundListenerConfigWithSidecar(t *testing.T, services ...*model.Serv
 	p := &fakePlugin{}
 	sidecarConfig := &model.Config{
 		ConfigMeta: model.ConfigMeta{
-			Name:      "foo",
-			Namespace: "not-default",
+			Name:             "foo",
+			Namespace:        "not-default",
+			GroupVersionKind: gvk.Sidecar,
 		},
 		Spec: &networking.Sidecar{
 			Egress: []*networking.IstioEgressListener{
@@ -1252,8 +1246,9 @@ func testOutboundListenerConfigWithSidecarWithSniffingDisabled(t *testing.T, ser
 	p := &fakePlugin{}
 	sidecarConfig := &model.Config{
 		ConfigMeta: model.ConfigMeta{
-			Name:      "foo",
-			Namespace: "not-default",
+			Name:             "foo",
+			Namespace:        "not-default",
+			GroupVersionKind: gvk.Sidecar,
 		},
 		Spec: &networking.Sidecar{
 			Egress: []*networking.IstioEgressListener{
@@ -1302,8 +1297,9 @@ func testOutboundListenerConfigWithSidecarWithUseRemoteAddress(t *testing.T, ser
 	p := &fakePlugin{}
 	sidecarConfig := &model.Config{
 		ConfigMeta: model.ConfigMeta{
-			Name:      "foo",
-			Namespace: "not-default",
+			Name:             "foo",
+			Namespace:        "not-default",
+			GroupVersionKind: gvk.Sidecar,
 		},
 		Spec: &networking.Sidecar{
 			Egress: []*networking.IstioEgressListener{
@@ -1345,8 +1341,9 @@ func testOutboundListenerConfigWithSidecarWithCaptureModeNone(t *testing.T, serv
 	p := &fakePlugin{}
 	sidecarConfig := &model.Config{
 		ConfigMeta: model.ConfigMeta{
-			Name:      "foo",
-			Namespace: "not-default",
+			Name:             "foo",
+			Namespace:        "not-default",
+			GroupVersionKind: gvk.Sidecar,
 		},
 		Spec: &networking.Sidecar{
 			Egress: []*networking.IstioEgressListener{
@@ -2075,28 +2072,12 @@ func getFilterConfig(filter *listener.Filter, out proto.Message) error {
 func buildOutboundListeners(t *testing.T, p plugin.Plugin, proxy *model.Proxy, sidecarConfig *model.Config,
 	virtualService *model.Config, services ...*model.Service) []*listener.Listener {
 	t.Helper()
-	configgen := NewConfigGenerator([]plugin.Plugin{p})
-
-	var env model.Environment
-	if virtualService != nil {
-		env = buildListenerEnvWithVirtualServices(services, []*model.Config{virtualService})
-	} else {
-		env = buildListenerEnv(services)
-	}
-
-	if err := env.PushContext.InitContext(&env, nil, nil); err != nil {
-		return nil
-	}
-
-	proxy.IstioVersion = model.ParseIstioVersion(proxy.Metadata.IstioVersion)
-	if sidecarConfig == nil {
-		proxy.SidecarScope = model.DefaultSidecarScopeForNamespace(env.PushContext, "not-default")
-	} else {
-		proxy.SidecarScope = model.ConvertToSidecarScope(env.PushContext, sidecarConfig, sidecarConfig.Namespace)
-	}
-	proxy.ServiceInstances = proxyInstances
-
-	listeners := configgen.buildSidecarOutboundListeners(proxy, env.PushContext)
+	cg := NewConfigGenTest(t, TestOptions{
+		Services:       services,
+		ConfigPointers: []*model.Config{sidecarConfig, virtualService},
+		Plugins:        []plugin.Plugin{p},
+	})
+	listeners := cg.ConfigGen.buildSidecarOutboundListeners(cg.SetupProxy(proxy), cg.env.PushContext)
 	xdstest.ValidateListeners(t, listeners)
 	return listeners
 }

--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -429,7 +429,7 @@ func TestAdsPushScoping(t *testing.T) {
 	}
 
 	addVirtualService := func(i int, hosts ...string) {
-		if _, err := s.Store.Create(model.Config{
+		if _, err := s.Store().Create(model.Config{
 			ConfigMeta: model.ConfigMeta{
 				GroupVersionKind: gvk.VirtualService,
 				Name:             fmt.Sprintf("vs%d", i), Namespace: model.IstioDefaultConfigNamespace},
@@ -447,10 +447,10 @@ func TestAdsPushScoping(t *testing.T) {
 		}
 	}
 	removeVirtualService := func(i int) {
-		s.Store.Delete(gvk.VirtualService, fmt.Sprintf("vs%d", i), model.IstioDefaultConfigNamespace)
+		s.Store().Delete(gvk.VirtualService, fmt.Sprintf("vs%d", i), model.IstioDefaultConfigNamespace)
 	}
 	addDestinationRule := func(i int, host string) {
-		if _, err := s.Store.Create(model.Config{
+		if _, err := s.Store().Create(model.Config{
 			ConfigMeta: model.ConfigMeta{
 				GroupVersionKind: gvk.DestinationRule,
 				Name:             fmt.Sprintf("dr%d", i), Namespace: model.IstioDefaultConfigNamespace},
@@ -463,7 +463,7 @@ func TestAdsPushScoping(t *testing.T) {
 		}
 	}
 	removeDestinationRule := func(i int) {
-		s.Store.Delete(gvk.DestinationRule, fmt.Sprintf("dr%d", i), model.IstioDefaultConfigNamespace)
+		s.Store().Delete(gvk.DestinationRule, fmt.Sprintf("dr%d", i), model.IstioDefaultConfigNamespace)
 	}
 
 	sc := &networking.Sidecar{
@@ -473,7 +473,7 @@ func TestAdsPushScoping(t *testing.T) {
 			},
 		},
 	}
-	if _, err := s.Store.Create(model.Config{
+	if _, err := s.Store().Create(model.Config{
 		ConfigMeta: model.ConfigMeta{
 			GroupVersionKind: gvk.Sidecar,
 			Name:             "sc", Namespace: model.IstioDefaultConfigNamespace},
@@ -1008,7 +1008,7 @@ func TestXdsCache(t *testing.T) {
 	assertEndpoints(ads, "1.2.3.4", "1.2.3.5")
 	t.Logf("endpoints: %+v", ads.GetEndpoints())
 
-	if _, err := s.Store.Update(makeEndpoint([]*networking.WorkloadEntry{
+	if _, err := s.Store().Update(makeEndpoint([]*networking.WorkloadEntry{
 		{Address: "1.2.3.6", Locality: "region/zone"},
 		{Address: "1.2.3.5", Locality: "notmatch"},
 	})); err != nil {
@@ -1021,7 +1021,7 @@ func TestXdsCache(t *testing.T) {
 	t.Logf("endpoints: %+v", ads.GetEndpoints())
 
 	ads.WaitClear()
-	if _, err := s.Store.Create(model.Config{
+	if _, err := s.Store().Create(model.Config{
 		ConfigMeta: model.ConfigMeta{
 			Name:             "service",
 			Namespace:        "default",
@@ -1054,7 +1054,7 @@ func TestXdsCache(t *testing.T) {
 
 	ep := makeEndpoint([]*networking.WorkloadEntry{{Address: "1.2.3.6", Locality: "region/zone"}, {Address: "1.2.3.5", Locality: "notmatch"}})
 	ep.Spec.(*networking.ServiceEntry).Resolution = networking.ServiceEntry_DNS
-	if _, err := s.Store.Update(ep); err != nil {
+	if _, err := s.Store().Update(ep); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := ads.Wait(time.Second*5, v3.EndpointType); err != nil {

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -100,7 +100,7 @@ func BenchmarkInitPushContext(b *testing.B) {
 			s, proxy := setupTest(b, tt)
 			b.ResetTimer()
 			for n := 0; n < b.N; n++ {
-				initPushContext(s.Env, proxy)
+				initPushContext(s.Env(), proxy)
 			}
 		})
 	}
@@ -282,7 +282,7 @@ func getConfigsWithCache(t testing.TB, input ConfigInput) []model.Config {
 
 func setupAndInitializeTest(t testing.TB, config ConfigInput) (*FakeDiscoveryServer, *model.Proxy) {
 	s, proxy := setupTest(t, config)
-	initPushContext(s.Env, proxy)
+	initPushContext(s.Env(), proxy)
 	return s, proxy
 }
 

--- a/pilot/pkg/xds/eds_sh_test.go
+++ b/pilot/pkg/xds/eds_sh_test.go
@@ -220,7 +220,7 @@ func initRegistry(server *xds.FakeDiscoveryServer, clusterNum int, gatewaysIP []
 	memRegistry := memory.NewServiceDiscovery(nil)
 	memRegistry.EDSUpdater = server.Discovery
 
-	server.Env.ServiceDiscovery.(*aggregate.Controller).AddRegistry(serviceregistry.Simple{
+	server.Env().ServiceDiscovery.(*aggregate.Controller).AddRegistry(serviceregistry.Simple{
 		ClusterID:        id,
 		ProviderID:       serviceregistry.Mock,
 		ServiceDiscovery: memRegistry,
@@ -230,8 +230,8 @@ func initRegistry(server *xds.FakeDiscoveryServer, clusterNum int, gatewaysIP []
 	gws := make([]*meshconfig.Network_IstioNetworkGateway, 0)
 	for _, gatewayIP := range gatewaysIP {
 		if gatewayIP != "" {
-			if server.Env.Networks() == nil {
-				server.Env.NetworksWatcher = mesh.NewFixedNetworksWatcher(&meshconfig.MeshNetworks{
+			if server.Env().Networks() == nil {
+				server.Env().NetworksWatcher = mesh.NewFixedNetworksWatcher(&meshconfig.MeshNetworks{
 					Networks: map[string]*meshconfig.Network{},
 				})
 			}
@@ -286,14 +286,14 @@ func initRegistry(server *xds.FakeDiscoveryServer, clusterNum int, gatewaysIP []
 }
 
 func addNetwork(server *xds.FakeDiscoveryServer, id string, network *meshconfig.Network) {
-	meshNetworks := *server.Env.Networks()
+	meshNetworks := *server.Env().Networks()
 	c := map[string]*meshconfig.Network{}
 	for k, v := range meshNetworks.Networks {
 		c[k] = v
 	}
 	c[id] = network
 	meshNetworks.Networks = c
-	server.Env.SetNetworks(&meshNetworks)
+	server.Env().SetNetworks(&meshNetworks)
 }
 
 func sendCDSReqWithMetadata(node string, metadata *structpb.Struct, edsstr discovery.AggregatedDiscoveryService_StreamAggregatedResourcesClient) error {

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -15,36 +15,25 @@
 package xds
 
 import (
-	"bytes"
 	"context"
 	"net"
 	"strings"
-	"text/template"
 	"time"
 
-	"github.com/Masterminds/sprig/v3"
-	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
-	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
-	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/cache"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
-	"istio.io/istio/pilot/pkg/config/kube/crd"
-	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/core/v1alpha3"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/serviceregistry"
-	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	kube "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
-	memregistry "istio.io/istio/pilot/pkg/serviceregistry/memory"
-	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/pkg/adsc"
@@ -70,65 +59,10 @@ type FakeOptions struct {
 }
 
 type FakeDiscoveryServer struct {
+	*v1alpha3.ConfigGenTest
 	t         test.Failer
-	Store     model.ConfigStore
 	Discovery *DiscoveryServer
-	Env       *model.Environment
 	listener  *bufconn.Listener
-}
-
-func (f *FakeDiscoveryServer) PushContext() *model.PushContext {
-	f.Discovery.updateMutex.RLock()
-	defer f.Discovery.updateMutex.RUnlock()
-	return f.Env.PushContext
-}
-
-func getKubernetesObjects(t test.Failer, opts FakeOptions) []runtime.Object {
-	if len(opts.KubernetesObjects) > 0 {
-		return opts.KubernetesObjects
-	}
-
-	objects := make([]runtime.Object, 0)
-	if len(opts.KubernetesObjectString) > 0 {
-		decode := scheme.Codecs.UniversalDeserializer().Decode
-		objectStrs := strings.Split(opts.KubernetesObjectString, "---")
-		for _, s := range objectStrs {
-			o, _, err := decode([]byte(s), nil, nil)
-			if err != nil {
-				t.Fatalf("failed deserializing kubernetes object: %v", err)
-			}
-			objects = append(objects, o)
-		}
-	}
-
-	return objects
-}
-
-func getConfigs(t test.Failer, opts FakeOptions) []model.Config {
-	if len(opts.Configs) > 0 {
-		return opts.Configs
-	}
-	configStr := opts.ConfigString
-	if opts.ConfigTemplateInput != nil {
-		tmpl := template.Must(template.New("").Funcs(sprig.TxtFuncMap()).Parse(opts.ConfigString))
-		var buf bytes.Buffer
-		if err := tmpl.Execute(&buf, opts.ConfigTemplateInput); err != nil {
-			t.Fatalf("failed to execute template: %v", err)
-		}
-		configStr = buf.String()
-	}
-	configs, _, err := crd.ParseInputs(configStr)
-	if err != nil {
-		t.Fatalf("failed to read config: %v", err)
-	}
-	// setup default namespace if not defined
-	for i, c := range configs {
-		if c.Namespace == "" {
-			c.Namespace = "default"
-		}
-		configs[i] = c
-	}
-	return configs
 }
 
 func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServer {
@@ -137,60 +71,35 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		close(stop)
 	})
 
-	configs := getConfigs(t, opts)
+	// Init with a dummy environment, since we have a circular dependency with the env creation.
+	s := NewDiscoveryServer(&model.Environment{PushContext: model.NewPushContext()}, []string{plugin.Authn, plugin.Authz})
+
 	k8sObjects := getKubernetesObjects(t, opts)
-	configStore := memory.MakeWithLedger(collections.Pilot, &model.DisabledLedger{}, true)
-	env := &model.Environment{}
-	plugins := []string{plugin.Authn, plugin.Authz, plugin.Health}
 
-	s := NewDiscoveryServer(env, plugins)
-	// Disable debounce to reduce test times
-	s.debounceOptions.debounceAfter = 0
-	s.MemRegistry = memregistry.NewServiceDiscovery(nil)
-	s.MemRegistry.EDSUpdater = s
-
-	configController := memory.NewSyncController(configStore)
-	go configController.Run(stop)
-
-	m := opts.MeshConfig
-	if m == nil {
-		def := mesh.DefaultMeshConfig()
-		m = &def
-	}
-
-	serviceDiscovery := aggregate.NewController(aggregate.Options{})
-	env.PushContext = model.NewPushContext()
-	env.ServiceDiscovery = serviceDiscovery
-	env.IstioConfigStore = model.MakeIstioStore(configStore)
-	env.Watcher = mesh.NewFixedWatcher(m)
-	if opts.NetworksWatcher == nil {
-		opts.NetworksWatcher = mesh.NewFixedNetworksWatcher(nil)
-	}
-	env.NetworksWatcher = opts.NetworksWatcher
-
-	se := serviceentry.NewServiceDiscovery(configController, model.MakeIstioStore(configStore), s)
-	serviceDiscovery.AddRegistry(se)
 	k8s, _ := kube.NewFakeControllerWithOptions(kube.FakeControllerOptions{
 		Objects:         k8sObjects,
 		ClusterID:       "Kubernetes",
 		DomainSuffix:    "cluster.local",
 		XDSUpdater:      s,
-		NetworksWatcher: env,
+		NetworksWatcher: opts.NetworksWatcher,
 	})
-	serviceDiscovery.AddRegistry(k8s)
-	for _, cfg := range configs {
-		if _, err := configStore.Create(cfg); err != nil {
-			t.Fatalf("failed to create config %v: %v", cfg.Name, err)
-		}
-	}
 
-	s.MemRegistry.ClusterID = string(serviceregistry.Mock)
-	serviceDiscovery.AddRegistry(serviceregistry.Simple{
-		ClusterID:        string(serviceregistry.Mock),
-		ProviderID:       serviceregistry.Mock,
-		ServiceDiscovery: s.MemRegistry,
-		Controller:       s.MemRegistry.Controller,
+	cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{
+		Configs:             opts.Configs,
+		ConfigString:        opts.ConfigString,
+		ConfigTemplateInput: opts.ConfigTemplateInput,
+		MeshConfig:          opts.MeshConfig,
+		NetworksWatcher:     opts.NetworksWatcher,
+		ServiceRegistries:   []serviceregistry.Instance{k8s},
+		PushContextLock:     &s.updateMutex,
 	})
+	s.updateMutex.Lock()
+	s.Env = cg.Env()
+	// Disable debounce to reduce test times
+	s.debounceOptions.debounceAfter = 0
+	s.MemRegistry = cg.MemRegistry
+	s.MemRegistry.EDSUpdater = s
+	s.updateMutex.Unlock()
 
 	// Setup config handlers
 	// TODO code re-use from server.go
@@ -221,7 +130,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 			continue
 		}
 
-		configController.RegisterEventHandler(schema.Resource().GroupVersionKind(), configHandler)
+		cg.Store().RegisterEventHandler(schema.Resource().GroupVersionKind(), configHandler)
 	}
 
 	// Start in memory gRPC listener
@@ -238,37 +147,30 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		grpcServer.Stop()
 	})
 
-	cache.WaitForCacheSync(stop, serviceDiscovery.HasSynced)
-
+	cg.ServiceEntryRegistry.XdsUpdater = s
 	// Start the discovery server
 	s.CachesSynced()
 	s.Start(stop)
-
-	se.ResyncEDS()
+	cg.ServiceEntryRegistry.ResyncEDS()
 
 	fake := &FakeDiscoveryServer{
-		t:         t,
-		Store:     configController,
-		Discovery: s,
-		Env:       env,
-		listener:  listener,
+		t:             t,
+		Discovery:     s,
+		listener:      listener,
+		ConfigGenTest: cg,
 	}
 
 	// currently meshNetworks gateways are stored on the push context
 	fake.refreshPushContext()
-	env.AddNetworksHandler(fake.refreshPushContext)
+	cg.Env().AddNetworksHandler(fake.refreshPushContext)
 
 	return fake
 }
 
-func (f *FakeDiscoveryServer) refreshPushContext() {
-	_, err := f.Discovery.initPushContext(&model.PushRequest{
-		Full:   true,
-		Reason: []model.TriggerReason{model.GlobalUpdate},
-	}, nil)
-	if err != nil {
-		f.t.Fatal(err)
-	}
+func (f *FakeDiscoveryServer) PushContext() *model.PushContext {
+	f.Discovery.updateMutex.RLock()
+	defer f.Discovery.updateMutex.RUnlock()
+	return f.Env().PushContext
 }
 
 // ConnectADS starts an ADS connection to the server. It will automatically be cleaned up when the test ends
@@ -328,57 +230,43 @@ func (f *FakeDiscoveryServer) Connect(p *model.Proxy, watch []string, wait []str
 	return adscConn
 }
 
-// SetupProxy initializes a proxy for the current environment. This should generally be used when creating
-// any proxy. For example, `p := SetupProxy(&model.Proxy{...})`.
-func (f *FakeDiscoveryServer) SetupProxy(p *model.Proxy) *model.Proxy {
-	// Setup defaults
-	if p == nil {
-		p = &model.Proxy{}
-	}
-	if p.Metadata == nil {
-		p.Metadata = &model.NodeMetadata{}
-	}
-	if p.Metadata.IstioVersion == "" {
-		p.Metadata.IstioVersion = "1.8.0"
-		p.IstioVersion = model.ParseIstioVersion(p.Metadata.IstioVersion)
-	}
-	if p.Type == "" {
-		p.Type = model.SidecarProxy
-	}
-	if p.ID == "" {
-		p.ID = "app.test"
-	}
-	if len(p.IPAddresses) == 0 {
-		p.IPAddresses = []string{"1.1.1.1"}
-	}
-	// Initialize data structures
-
-	pc := f.PushContext()
-	p.SetSidecarScope(pc)
-	p.SetGatewaysForProxy(pc)
-	if err := p.SetServiceInstances(f.Discovery.Env.ServiceDiscovery); err != nil {
-		f.t.Fatal(err)
-	}
-	p.DiscoverIPVersions()
-	return p
-}
-
-func (f *FakeDiscoveryServer) Listeners(p *model.Proxy) []*listener.Listener {
-	return f.Discovery.ConfigGenerator.BuildListeners(p, f.PushContext())
-}
-
-func (f *FakeDiscoveryServer) Clusters(p *model.Proxy) []*cluster.Cluster {
-	return f.Discovery.ConfigGenerator.BuildClusters(p, f.PushContext())
-}
-
 func (f *FakeDiscoveryServer) Endpoints(p *model.Proxy) []*endpoint.ClusterLoadAssignment {
 	loadAssignments := make([]*endpoint.ClusterLoadAssignment, 0)
+	c := f.Clusters(p)
+	_ = c
 	for _, c := range xdstest.ExtractEdsClusterNames(f.Clusters(p)) {
 		loadAssignments = append(loadAssignments, f.Discovery.generateEndpoints(NewEndpointBuilder(c, p, f.PushContext())))
 	}
 	return loadAssignments
 }
 
-func (f *FakeDiscoveryServer) Routes(p *model.Proxy) []*route.RouteConfiguration {
-	return f.Discovery.ConfigGenerator.BuildHTTPRoutes(p, f.PushContext(), xdstest.ExtractRoutesFromListeners(f.Listeners(p)))
+func (f *FakeDiscoveryServer) refreshPushContext() {
+	_, err := f.Discovery.initPushContext(&model.PushRequest{
+		Full:   true,
+		Reason: []model.TriggerReason{model.GlobalUpdate},
+	}, nil)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+}
+
+func getKubernetesObjects(t test.Failer, opts FakeOptions) []runtime.Object {
+	if len(opts.KubernetesObjects) > 0 {
+		return opts.KubernetesObjects
+	}
+
+	objects := make([]runtime.Object, 0)
+	if len(opts.KubernetesObjectString) > 0 {
+		decode := scheme.Codecs.UniversalDeserializer().Decode
+		objectStrs := strings.Split(opts.KubernetesObjectString, "---")
+		for _, s := range objectStrs {
+			o, _, err := decode([]byte(s), nil, nil)
+			if err != nil {
+				t.Fatalf("failed deserializing kubernetes object: %v", err)
+			}
+			objects = append(objects, o)
+		}
+	}
+
+	return objects
 }


### PR DESCRIPTION
We have made some major improvements to the tests in xds package.
However, we cannot reuse this in the v1alpha3 package (config gen)
because of cyclic imports.

This PR splits up the FakeDiscoveryServer. The configgen parts are
handled by a new struct in the v1alpha3 package. The XDS specific parts
are layered on top of this in the xds package. This allows both tests to
share the same interface and implementation.

As part of this PR I migrated a few tests to use this new model - I did
not do all of them to avoid making a huge PR. I might do this in a
followup if I have time, or at the very least we should encourage this
for new testing



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.