### PR TITLE
Move XDS cache to model

### DIFF
--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -124,7 +124,7 @@ type DiscoveryServer struct {
 	debounceOptions debounceOptions
 
 	// Cache for XDS resources
-	cache Cache
+	cache model.XdsCache
 }
 
 // EndpointShards holds the set of endpoint shards of a service. Registries update
@@ -165,7 +165,7 @@ func NewDiscoveryServer(env *model.Environment, plugins []string) *DiscoveryServ
 			debounceMax:       features.DebounceMax,
 			enableEDSDebounce: features.EnableEDSDebounce.Get(),
 		},
-		cache: DisabledCache{},
+		cache: model.DisabledCache{},
 	}
 
 	// Flush cached discovery responses when detecting jwt public key change.
@@ -176,7 +176,7 @@ func NewDiscoveryServer(env *model.Environment, plugins []string) *DiscoveryServ
 	out.initGenerators()
 
 	if features.EnableEDSCaching {
-		out.cache = New()
+		out.cache = model.NewXdsCache()
 	}
 
 	return out

--- a/pilot/pkg/xds/xds_cache_test.go
+++ b/pilot/pkg/xds/xds_cache_test.go
@@ -39,7 +39,7 @@ func TestInMemoryCache(t *testing.T) {
 		service:     &model.Service{Hostname: "foo.com"},
 	}
 	t.Run("simple", func(t *testing.T) {
-		c := New()
+		c := model.NewXdsCache()
 		c.Add(ep1, any1)
 		if !reflect.DeepEqual(c.Keys(), []string{ep1.Key()}) {
 			t.Fatalf("unexpected keys: %v, want %v", c.Keys(), ep1.Key())
@@ -58,7 +58,7 @@ func TestInMemoryCache(t *testing.T) {
 	})
 
 	t.Run("multiple hostnames", func(t *testing.T) {
-		c := New()
+		c := model.NewXdsCache()
 		c.Add(ep1, any1)
 		c.Add(ep2, any2)
 
@@ -78,7 +78,7 @@ func TestInMemoryCache(t *testing.T) {
 	})
 
 	t.Run("multiple destinationRules", func(t *testing.T) {
-		c := New()
+		c := model.NewXdsCache()
 		ep1 := ep1
 		ep1.destinationRule = &model.Config{ConfigMeta: model.ConfigMeta{Name: "a", Namespace: "b"}}
 		ep2 := ep2
@@ -109,7 +109,7 @@ func TestInMemoryCache(t *testing.T) {
 	})
 
 	t.Run("clear all", func(t *testing.T) {
-		c := New()
+		c := model.NewXdsCache()
 		c.Add(ep1, any1)
 		c.Add(ep2, any2)
 


### PR DESCRIPTION
the CDS/LDS/RDS cannot import the `xds` package. This moves the caching
layer up to the model so we avoid this circular import
For https://github.com/istio/istio/issues/26732