### PR TITLE
break down multicluster test suite

### DIFF
--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -465,6 +465,7 @@ func deployControlPlane(c *operatorComponent, cfg Config, cluster resource.Clust
 		"-f", iopFile,
 		"--set", "values.global.imagePullPolicy=" + s.PullPolicy,
 		"--manifests", filepath.Join(env.IstioSrc, "manifests"),
+		"--set", "values.global.multiCluster.clusterName=" + cluster.Name(),
 	}
 	// Include all user-specified values.
 	for k, v := range cfg.Values {
@@ -472,10 +473,6 @@ func deployControlPlane(c *operatorComponent, cfg Config, cluster resource.Clust
 	}
 
 	if c.environment.IsMulticluster() {
-		// Set the clusterName for the local cluster.
-		// This MUST match the clusterName in the remote secret for this cluster.
-		installSettings = append(installSettings, "--set", "values.global.multiCluster.clusterName="+cluster.Name())
-
 		if networkName := cluster.NetworkName(); networkName != "" {
 			installSettings = append(installSettings, "--set", "values.global.meshID="+meshID,
 				"--set", "values.global.network="+networkName)

--- a/pkg/test/framework/features/features.yaml
+++ b/pkg/test/framework/features/features.yaml
@@ -18,6 +18,8 @@ features:
   # features that relate to measuring or exploring your service mesh or the services which comprise it.
   observability:
     telemetry:
+      multicluster:
+        cluster-label:
       stackdriver:
       stats:
         prometheus:
@@ -83,6 +85,8 @@ features:
       uninstall_revision:
       uninstall_manifest:
       uninstall_purge:
+    # TODO multicluster installation is a framework feature/environment. The analyzer tracks if tests _can_ run in multicluster mode.
+    # TODO (cont.) but does not track which kind of multicluster.
     multicluster:
       central-istiod:
       multimaster:

--- a/pkg/test/framework/resource/cluster.go
+++ b/pkg/test/framework/resource/cluster.go
@@ -45,6 +45,16 @@ func (c Clusters) GetOrDefault(cluster Cluster) Cluster {
 	return c.Default()
 }
 
+// GetByName returns the Cluster with the given name or nil if it is not in the list.
+func (c Clusters) GetByName(name string) Cluster {
+	for _, cc := range c {
+		if cc.Name() == name {
+			return cc
+		}
+	}
+	return nil
+}
+
 // Names returns the deduped list of names of the clusters.
 func (c Clusters) Names() []string {
 	dedup := map[string]struct{}{}

--- a/tests/integration/pilot/multicluster_test.go
+++ b/tests/integration/pilot/multicluster_test.go
@@ -1,0 +1,114 @@
+// +build integ
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pilot
+
+import (
+	"fmt"
+	"testing"
+
+	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+func TestClusterLocalService(t *testing.T) {
+	framework.NewTest(t).
+		RequiresMinClusters(2).
+		Run(func(ctx framework.TestContext) {
+			ctx.NewSubTest("respect-cluster-local-config").Run(func(ctx framework.TestContext) {
+				for _, c := range ctx.Clusters() {
+					c := c
+					ctx.NewSubTest(c.Name()).
+						Run(func(ctx framework.TestContext) {
+							local := apps.local.GetOrFail(ctx, echo.InCluster(c))
+							if err := local.CallOrFail(ctx, echo.CallOptions{
+								Target:   local,
+								PortName: "http",
+								Count:    callsPerCluster,
+							}).CheckReachedClusters(resource.Clusters{c}); err != nil {
+								ctx.Fatalf("traffic was not restricted to %s: %v", c.Name(), err)
+							}
+						})
+				}
+			})
+		})
+}
+
+// TelemetryTest validates that source and destination labels are collected
+// for multicluster traffic.
+func TestClusterTelemetryLabels(t *testing.T) {
+	// TODO(landow) we can remove this when tests/integration/telemetry are converted to cover multicluster
+	framework.NewTest(t).
+		RequiresMinClusters(2).
+		Run(func(ctx framework.TestContext) {
+			ctx.NewSubTest("telemetry").
+				Run(func(ctx framework.TestContext) {
+					for _, src := range apps.podA {
+						src := src
+						ctx.NewSubTest(fmt.Sprintf("from %s", src.Config().Cluster.Name())).
+							Run(func(ctx framework.TestContext) {
+								res := src.CallOrFail(ctx, echo.CallOptions{
+									Target:   apps.podB[0],
+									PortName: "http",
+									Count:    callsPerCluster * len(apps.podB),
+								})
+
+								// check we reached all clusters before checking each cluster's stats
+								if err := res.CheckReachedClusters(apps.podB.Clusters()); err != nil {
+									ctx.Fatal(err)
+								}
+
+								for _, dest := range apps.podB {
+									validateClusterLabelsInStats(t, src, src.Config().Cluster, dest.Config().Cluster)
+									validateClusterLabelsInStats(t, dest, src.Config().Cluster, dest.Config().Cluster)
+								}
+							})
+					}
+				})
+		})
+}
+
+func validateClusterLabelsInStats(t test.Failer, svc echo.Instance, expSrc, expDst resource.Cluster) {
+	t.Helper()
+	workloads := svc.WorkloadsOrFail(t)
+	stats := workloads[0].Sidecar().StatsOrFail(t)
+
+	for _, metricName := range []string{"istio_requests_total", "istio_request_duration_milliseconds"} {
+		instances, found := stats[metricName]
+		if !found {
+			t.Fatalf("%s not found in stats: %v", metricName, stats)
+		}
+
+		for _, metric := range instances.Metric {
+			hasSourceCluster := false
+			hasDestinationCluster := false
+			for _, label := range metric.Label {
+				if label.GetName() == "source_cluster" && label.GetValue() == expSrc.Name() {
+					hasSourceCluster = true
+					continue
+				}
+				if label.GetName() == "destination_cluster" && label.GetValue() == expDst.Name() {
+					hasDestinationCluster = true
+					continue
+				}
+			}
+			if !hasSourceCluster && !hasDestinationCluster {
+				t.Fatalf("cluster labels missing for %q. labels: %v", metricName, metric.Label)
+			}
+		}
+	}
+}

--- a/tests/integration/pilot/multicluster_test.go
+++ b/tests/integration/pilot/multicluster_test.go
@@ -27,6 +27,7 @@ import (
 
 func TestClusterLocalService(t *testing.T) {
 	framework.NewTest(t).
+		Features("traffic.reachability.clusterlocal").
 		RequiresMinClusters(2).
 		Run(func(ctx framework.TestContext) {
 			ctx.NewSubTest("respect-cluster-local-config").Run(func(ctx framework.TestContext) {
@@ -53,6 +54,7 @@ func TestClusterLocalService(t *testing.T) {
 func TestClusterTelemetryLabels(t *testing.T) {
 	// TODO(landow) we can remove this when tests/integration/telemetry are converted to cover multicluster
 	framework.NewTest(t).
+		Features("observability.telemetry.multicluster.cluster-label").
 		RequiresMinClusters(2).
 		Run(func(ctx framework.TestContext) {
 			ctx.NewSubTest("telemetry").


### PR DESCRIPTION
Once we migrate these cases out of multicluster/ we can start running pilot or other jobs with multi-cluster enabled instead of a catch-all multicluster job. 

- [X] Move Reachability
- [X] Move Cross Cluster Load-Balancing
- [X] Move Cluster Local
- [x] Move Telemetry

After this lands:
- [ ] Enable pilot-multicluster prow job 
- [ ] Delete Multicluster Prow Job
- [ ] Delete tests/integration/multicluster

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
