### PR TITLE
Fix release notes to match schema

### DIFF
--- a/releasenotes/notes/25794.yaml
+++ b/releasenotes/notes/25794.yaml
@@ -8,4 +8,4 @@ releaseNotes:
 - |
   **Added** Update Istio Workload and Istio Service dashboards to improve loading time.
 - |
-  **Added** parameterise grafana dashboard 's with datasource
+  **Added** parameterise Grafana dashboards with datasource

--- a/releasenotes/notes/25794.yaml
+++ b/releasenotes/notes/25794.yaml
@@ -1,9 +1,11 @@
 apiVersion: release-notes/v2
 kind: feature
 area: telemetry
-issue: 22408
+issue:
+- "22408"
 
-releaseNotes: |
-  *Added*
-  - Update Istio Workload and Istio Service dashboards to improve loading time
-  - Parameterise grafana dashboard 's with datasource
+releaseNotes:
+- |
+  **Added** Update Istio Workload and Istio Service dashboards to improve loading time.
+- |
+  **Added** parameterise grafana dashboard 's with datasource

--- a/releasenotes/notes/26185.yaml
+++ b/releasenotes/notes/26185.yaml
@@ -5,6 +5,6 @@ area: security
 
 releaseNotes:
 - |
-  Add support for client side Envoy secure naming config when trust domain alias is used.
+  **Added** support for client side Envoy secure naming config when trust domain alias is used.
   Fix the multi cluster service discovery client SAN generation: takes all endpoints' service accounts
   into account, rather than the first found service registry.

--- a/releasenotes/notes/26185.yaml
+++ b/releasenotes/notes/26185.yaml
@@ -3,7 +3,8 @@ kind: feature
 
 area: security
 
-releaseNotes: |
+releaseNotes:
+- |
   Add support for client side Envoy secure naming config when trust domain alias is used.
   Fix the multi cluster service discovery client SAN generation: takes all endpoints' service accounts
   into account, rather than the first found service registry.

--- a/releasenotes/notes/audit-authz-policy.yaml
+++ b/releasenotes/notes/audit-authz-policy.yaml
@@ -1,8 +1,8 @@
 apiVersion: release-notes/v2
 kind: feature
 area: security
-issue: 
+issue:
   - 25591
 releaseNotes:
   - |
-    **Added** aciton 'AUDIT' to Authorization Policy that can be used to determine which requests should be audited. 
+    **Added** action 'AUDIT' to Authorization Policy that can be used to determine which requests should be audited.

--- a/releasenotes/notes/debug-handlers.yaml
+++ b/releasenotes/notes/debug-handlers.yaml
@@ -5,6 +5,6 @@ area: networking
 releaseNotes:
   - |
     **Updated** the debug handlers on HTTP are now conditionally added based environment variable ENABLE_DEBUG_ON_HTTP.
-    Setting "ENABLE_DEBUG_ON_HTTP" to false will not add debug handlers on HTTP ports and is recommended setting for 
+    Setting "ENABLE_DEBUG_ON_HTTP" to false will not add debug handlers on HTTP ports and is recommended setting for
     production. In future releases, they will be replaced with "XDS-over-TLS" instead of exposing them on HTTP interface.
 

--- a/releasenotes/notes/eds-cache.yaml
+++ b/releasenotes/notes/eds-cache.yaml
@@ -1,6 +1,7 @@
 apiVersion: release-notes/v2
 kind: feature
 area: networking
-releaseNotes: |
+releaseNotes:
+- |
   *Added* experimental caching for endpoints, to support large scale clusters. This feature is disabled by default and can
   be enabled by setting the `PILOT_ENABLE_EDS_CACHE` environment variable in Istiod.

--- a/releasenotes/notes/eds-cache.yaml
+++ b/releasenotes/notes/eds-cache.yaml
@@ -3,5 +3,5 @@ kind: feature
 area: networking
 releaseNotes:
 - |
-  *Added* experimental caching for endpoints, to support large scale clusters. This feature is disabled by default and can
+  **Added** experimental caching for endpoints, to support large scale clusters. This feature is disabled by default and can
   be enabled by setting the `PILOT_ENABLE_EDS_CACHE` environment variable in Istiod.

--- a/releasenotes/notes/envoy-filter.yaml
+++ b/releasenotes/notes/envoy-filter.yaml
@@ -4,7 +4,7 @@ area: networking
 
 releaseNotes:
   - |
-    **Updated** the envoy filter names that control plane generates to meet the canonical naming standard. See https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.14.0#deprecated
+    **Updated** the Envoy filter names that control plane generates to meet the canonical naming standard. See [Envoy's deprecation policy](https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.14.0#deprecated)
 
 upgradeNotes:
   - title: Use the new filter names for EnvoyFilter

--- a/releasenotes/notes/k8s-auth.yaml
+++ b/releasenotes/notes/k8s-auth.yaml
@@ -3,6 +3,6 @@ kind: feature
 area: security
 releaseNotes:
 - |
-       Support migration and concurrent use of regular K8S tokens as well as new K8S tokens with audience. This feature is enabled by
-       default, can be disabled by REQUIRE_3P_TOKEN environment variable in Istiod, which will require new tokens with audience. The
-       TOKEN_AUDIENCE environment variable allows customizing the checked audience, default remains istio-ca.
+  **Added** support for migration and concurrent use of regular K8S tokens as well as new K8S tokens with audience. This feature is enabled by
+  default, can be disabled by REQUIRE_3P_TOKEN environment variable in Istiod, which will require new tokens with audience. The
+  TOKEN_AUDIENCE environment variable allows customizing the checked audience, default remains istio-ca.

--- a/releasenotes/notes/k8s-auth.yaml
+++ b/releasenotes/notes/k8s-auth.yaml
@@ -1,7 +1,8 @@
 apiVersion: release-notes/v2
 kind: feature
 area: security
-releaseNotes: |
-       Support migration and concurrent use of regular K8S tokens as well as new K8S tokens with audience. This feature is enabled by 
+releaseNotes:
+- |
+       Support migration and concurrent use of regular K8S tokens as well as new K8S tokens with audience. This feature is enabled by
        default, can be disabled by REQUIRE_3P_TOKEN environment variable in Istiod, which will require new tokens with audience. The
        TOKEN_AUDIENCE environment variable allows customizing the checked audience, default remains istio-ca.

--- a/releasenotes/notes/trust-domain-validation.yaml
+++ b/releasenotes/notes/trust-domain-validation.yaml
@@ -3,6 +3,7 @@ kind: feature
 area: security
 issue:
   - 26224
-releaseNotes: |
+releaseNotes:
+- |
   *Added* Trust Domain Validation by default rejecting requests in sidecars if the request is not from same trust domain
   or if it's not in the TrustDomainAliases specified in the MeshConfig.

--- a/releasenotes/notes/update-grafana-memory-compute.yaml
+++ b/releasenotes/notes/update-grafana-memory-compute.yaml
@@ -2,7 +2,8 @@ apiVersion: release-notes/v2
 kind: feature
 area: telemetry
 
-releaseNotes: |
+releaseNotes:
+- |
   The "Control Plane Dashboard" and the "Performance Dashboard" now use `container_memory_working_set_bytes` metric
   to display memory. This metric only counts memory that *cannot be reclaimed* by the kernel even under memory pressure,
   and therefore more relevant for tracking. It is also consistent with `kubectl top`. The reported values are lower than

--- a/releasenotes/notes/update-grafana-memory-compute.yaml
+++ b/releasenotes/notes/update-grafana-memory-compute.yaml
@@ -4,7 +4,7 @@ area: telemetry
 
 releaseNotes:
 - |
-  The "Control Plane Dashboard" and the "Performance Dashboard" now use `container_memory_working_set_bytes` metric
+  **Updated** the "Control Plane Dashboard" and the "Performance Dashboard" to use the `container_memory_working_set_bytes` metric
   to display memory. This metric only counts memory that *cannot be reclaimed* by the kernel even under memory pressure,
   and therefore more relevant for tracking. It is also consistent with `kubectl top`. The reported values are lower than
   the previous values.


### PR DESCRIPTION
Preview of the release notes (additional content added that's not in 1.7). GitHub doesn't accept HTML, so I added a .txt extension. 
[minorReleaseNotes.md.html.txt](https://github.com/istio/istio/files/5124354/minorReleaseNotes.md.html.txt)

Preview of the upgrade notes:
[upgradeNotes.md.html.txt](https://github.com/istio/istio/files/5124361/upgradeNotes.md.html.txt)


This PR fixes the release notes to match the release notes schema.

Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
