### PR TITLE
relocate role rbac manifests and use the correct label

### DIFF
--- a/manifests/charts/base/files/gen-istio-cluster.yaml
+++ b/manifests/charts/base/files/gen-istio-cluster.yaml
@@ -3566,7 +3566,7 @@ subjects:
     name: istiod-service-account
     namespace: istio-system
 ---
-# Source: base/templates/clusterrole.yaml
+# Source: base/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -3588,14 +3588,14 @@ rules:
   # TODO lock this down to istio-ca-cert if not using the DNS cert mesh config
   verbs: ["create", "get", "watch", "list", "update", "delete"]
 ---
-# Source: base/templates/clusterrolebinding.yaml
+# Source: base/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: istiod-istio-system
   namespace: istio-system
   labels:
-    app: pilot
+    app: istiod
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/charts/base/templates/clusterrole.yaml
+++ b/manifests/charts/base/templates/clusterrole.yaml
@@ -1,25 +1,4 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: istiod-{{ .Values.global.istioNamespace }}
-  namespace: {{ .Values.global.istioNamespace }}
-  labels:
-    app: istiod
-    release: {{ .Release.Name }}
-rules:
-# permissions to verify the webhook is ready and rejecting
-# invalid config. We use --server-dry-run so no config is persisted.
-- apiGroups: ["networking.istio.io"]
-  verbs: ["create"]
-  resources: ["gateways"]
-
-# For storing CA secret
-- apiGroups: [""]
-  resources: ["secrets"]
-  # TODO lock this down to istio-ca-cert if not using the DNS cert mesh config
-  verbs: ["create", "get", "watch", "list", "update", "delete"]
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: istiod-{{ .Values.global.istioNamespace }}
@@ -148,4 +127,3 @@ rules:
     verbs: ["get", "list", "watch", "update"]
 {{- end}}
 ---
-

--- a/manifests/charts/base/templates/clusterrolebinding.yaml
+++ b/manifests/charts/base/templates/clusterrolebinding.yaml
@@ -30,20 +30,3 @@ subjects:
     name: istiod-service-account
     namespace: {{ .Values.global.istioNamespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: istiod-{{ .Values.global.istioNamespace }}
-  namespace: {{ .Values.global.istioNamespace }}
-  labels:
-    app: pilot
-    release: {{ .Release.Name }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: istiod-{{ .Values.global.istioNamespace }}
-subjects:
-  - kind: ServiceAccount
-    name: istiod-service-account
-    namespace: {{ .Values.global.istioNamespace }}
----

--- a/manifests/charts/base/templates/role.yaml
+++ b/manifests/charts/base/templates/role.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: istiod-{{ .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
+  labels:
+    app: istiod
+    release: {{ .Release.Name }}
+rules:
+# permissions to verify the webhook is ready and rejecting
+# invalid config. We use --server-dry-run so no config is persisted.
+- apiGroups: ["networking.istio.io"]
+  verbs: ["create"]
+  resources: ["gateways"]
+
+# For storing CA secret
+- apiGroups: [""]
+  resources: ["secrets"]
+  # TODO lock this down to istio-ca-cert if not using the DNS cert mesh config
+  verbs: ["create", "get", "watch", "list", "update", "delete"]

--- a/manifests/charts/base/templates/rolebinding.yaml
+++ b/manifests/charts/base/templates/rolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: istiod-{{ .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
+  labels:
+    app: istiod
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: istiod-{{ .Values.global.istioNamespace }}
+subjects:
+  - kind: ServiceAccount
+    name: istiod-service-account
+    namespace: {{ .Values.global.istioNamespace }}


### PR DESCRIPTION

This PR fixes two issues

i) Readability of charts. People don't expect to find roles and rolebindings in files named clusterrole.yaml and clusterrolebinding.yaml

ii) istiod rolebinding should have the `app: istiod` label instead of `app: pilot`.


[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.