### PR TITLE
Analyze duplicate VirtualService matches

### DIFF
--- a/galley/pkg/config/analysis/analyzers/all.go
+++ b/galley/pkg/config/analysis/analyzers/all.go
@@ -51,6 +51,7 @@ func All() []analysis.Analyzer {
 		&virtualservice.DestinationRuleAnalyzer{},
 		&virtualservice.GatewayAnalyzer{},
 		&virtualservice.RegexAnalyzer{},
+		&virtualservice.MatchesAnalyzer{},
 		&destinationrule.CaCertificateAnalyzer{},
 	}
 

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -398,7 +398,6 @@ var testGrid = []testCase{
 			{msg.VirtualServiceIneffectiveMatch, "VirtualService almost-duplicate-tcp-match"},
 			{msg.VirtualServiceIneffectiveMatch, "VirtualService duplicate-tcp-match"},
 
-			{msg.VirtualServiceUnreachableRule, "VirtualService tls-routing-nomatch.none"},
 			{msg.VirtualServiceUnreachableRule, "VirtualService tls-routing.none"},
 			{msg.VirtualServiceIneffectiveMatch, "VirtualService tls-routing-almostmatch.none"},
 			{msg.VirtualServiceIneffectiveMatch, "VirtualService tls-routing.none"},

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -381,6 +381,29 @@ var testGrid = []testCase{
 		analyzer: &destinationrule.CaCertificateAnalyzer{},
 		expected: []message{},
 	},
+	{
+		name: "dupmatches",
+		inputFiles: []string{
+			"testdata/virtualservice_dupmatches.yaml",
+		},
+		analyzer: &virtualservice.MatchesAnalyzer{},
+		expected: []message{
+			{msg.VirtualServiceUnreachableRule, "VirtualService duplicate-match"},
+			{msg.VirtualServiceUnreachableRule, "VirtualService sample-foo-cluster01.foo"},
+			{msg.VirtualServiceIneffectiveMatch, "VirtualService almost-duplicate-match"},
+			{msg.VirtualServiceIneffectiveMatch, "VirtualService duplicate-match"},
+
+			{msg.VirtualServiceUnreachableRule, "VirtualService duplicate-tcp-match"},
+			{msg.VirtualServiceUnreachableRule, "VirtualService duplicate-empty-tcp"},
+			{msg.VirtualServiceIneffectiveMatch, "VirtualService almost-duplicate-tcp-match"},
+			{msg.VirtualServiceIneffectiveMatch, "VirtualService duplicate-tcp-match"},
+
+			{msg.VirtualServiceUnreachableRule, "VirtualService tls-routing-nomatch.none"},
+			{msg.VirtualServiceUnreachableRule, "VirtualService tls-routing.none"},
+			{msg.VirtualServiceIneffectiveMatch, "VirtualService tls-routing-almostmatch.none"},
+			{msg.VirtualServiceIneffectiveMatch, "VirtualService tls-routing.none"},
+		},
+	},
 }
 
 // regex patterns for analyzer names that should be explicitly ignored for testing

--- a/galley/pkg/config/analysis/analyzers/testdata/virtualservice_dupmatches.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/virtualservice_dupmatches.yaml
@@ -30,13 +30,16 @@ spec:
   hosts:
   - sample.baz.svc.cluster.local
   http:
-  - match:
-    - uri:
+  - name: send /api/v1/products to sample.foo
+    match:
+    - name: prefix /api/v1/products
+      uri:
         prefix: /api/v1/products
     route:
     - destination:
         host: sample.foo.svc.cluster.local
-  - match:
+  - name: send /api/v1/products to sample.bar
+    match:
     - uri:
         prefix: /api/v1/products
     route:
@@ -58,10 +61,13 @@ spec:
     route:
     - destination:
         host: sample.foo.svc.cluster.local
-  - match:
-    - uri:
+  - name: send /api/v1/products and /potato to sample.bar
+    match:
+    - name: prefix /api/v1/products
+      uri:
         prefix: /api/v1/products
-    - uri:
+    - name: prefix /potato
+      uri:
         prefix: /potato
     route:
     - destination:
@@ -175,44 +181,26 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: tls-routing-nomatch
-  namespace: none
-spec:
-  hosts:
-  - www1.googleapis.com
-  - api1.facebook.com
-  tls:
-  - route:
-    - destination:
-        host: www1.googleapis.com
-  - route:
-    - destination:
-        host: api1.facebook.com
----
-apiVersion: networking.istio.io/v1alpha3
-kind: VirtualService
-metadata:
   name: tls-routing-almostmatch
   namespace: none
 spec:
   hosts:
-  - www1.googleapis.com
-  - api1.facebook.com
+  - www1.example.com
   tls:
   - match:
     - port: 2443
       sniHosts:
-      - www1.googleapis.com
+      - www1.example.com
     route:
     - destination:
         host: www1.googleapis.com
   - match:
     - port: 2443
       sniHosts:
-      - www1.googleapis.com
+      - www1.example.com
     - port: 8443
       sniHosts:
-      - www1.googleapis.com
+      - www1.example.com
     route:
     - destination:
         host: api1.facebook.com

--- a/galley/pkg/config/analysis/analyzers/testdata/virtualservice_dupmatches.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/virtualservice_dupmatches.yaml
@@ -1,0 +1,218 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: sample-foo-cluster01
+  namespace: foo
+spec:
+  hosts:
+  - sample.foo.svc.cluster.local
+  http:
+  - fault:
+      delay:
+        fixedDelay: 5s
+        percentage:
+          value: 100
+    route:
+    - destination:
+        host: sample.foo.svc.cluster.local
+  - mirror:
+      host: sample.bar.svc.cluster.local
+    route:
+    - destination:
+        host: sample.bar.svc.cluster.local
+        subset: v1
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: duplicate-match
+spec:
+  hosts:
+  - sample.baz.svc.cluster.local
+  http:
+  - match:
+    - uri:
+        prefix: /api/v1/products
+    route:
+    - destination:
+        host: sample.foo.svc.cluster.local
+  - match:
+    - uri:
+        prefix: /api/v1/products
+    route:
+    - destination:
+        host: sample.bar.svc.cluster.local
+        subset: v1
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: almost-duplicate-match
+spec:
+  hosts:
+  - sample.bar.svc.cluster.local
+  http:
+  - match:
+    - uri:
+        prefix: /api/v1/products
+    route:
+    - destination:
+        host: sample.foo.svc.cluster.local
+  - match:
+    - uri:
+        prefix: /api/v1/products
+    - uri:
+        prefix: /potato
+    route:
+    - destination:
+        host: sample.bar.svc.cluster.local
+        subset: v1
+---
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: duplicate-tcp-match
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - tcp-echo-gateway
+  tcp:
+  - match:
+    - port: 31400
+    route:
+    - destination:
+        host: tcp-echo
+        port:
+          number: 9000
+        subset: v1
+  - match:
+    - port: 31400
+    route:
+    - destination:
+        host: tcp-echo
+        port:
+          number: 9000
+        subset: v2
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: duplicate-empty-tcp
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - tcp-echo-gateway
+  tcp:
+  - route:
+    - destination:
+        host: tcp-echo
+        port:
+          number: 9000
+        subset: v1
+  - route:
+    - destination:
+        host: tcp-echo
+        port:
+          number: 9000
+        subset: v2
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: almost-duplicate-tcp-match
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - tcp-echo-gateway
+  tcp:
+  - match:
+    - port: 31400
+    route:
+    - destination:
+        host: tcp-echo
+        port:
+          number: 9000
+        subset: v1
+  - match:
+    - port: 31400
+    - port: 31401
+    route:
+    - destination:
+        host: tcp-echo
+        port:
+          number: 9000
+        subset: v2
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: tls-routing
+  namespace: none
+spec:
+  hosts:
+  - www1.googleapis.com
+  - api1.facebook.com
+  tls:
+  - match:
+    - port: 2443
+      sniHosts:
+      - www1.googleapis.com
+    route:
+    - destination:
+        host: www1.googleapis.com
+  - match:
+    - port: 2443
+      sniHosts:
+      - www1.googleapis.com
+    route:
+    - destination:
+        host: api1.facebook.com
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: tls-routing-nomatch
+  namespace: none
+spec:
+  hosts:
+  - www1.googleapis.com
+  - api1.facebook.com
+  tls:
+  - route:
+    - destination:
+        host: www1.googleapis.com
+  - route:
+    - destination:
+        host: api1.facebook.com
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: tls-routing-almostmatch
+  namespace: none
+spec:
+  hosts:
+  - www1.googleapis.com
+  - api1.facebook.com
+  tls:
+  - match:
+    - port: 2443
+      sniHosts:
+      - www1.googleapis.com
+    route:
+    - destination:
+        host: www1.googleapis.com
+  - match:
+    - port: 2443
+      sniHosts:
+      - www1.googleapis.com
+    - port: 8443
+      sniHosts:
+      - www1.googleapis.com
+    route:
+    - destination:
+        host: api1.facebook.com

--- a/galley/pkg/config/analysis/analyzers/virtualservice/matches.go
+++ b/galley/pkg/config/analysis/analyzers/virtualservice/matches.go
@@ -1,0 +1,175 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package virtualservice
+
+import (
+	"encoding/json"
+
+	"istio.io/api/networking/v1alpha3"
+	"istio.io/istio/galley/pkg/config/analysis"
+	"istio.io/istio/galley/pkg/config/analysis/msg"
+	"istio.io/istio/pkg/config/resource"
+	"istio.io/istio/pkg/config/schema/collection"
+	"istio.io/istio/pkg/config/schema/collections"
+)
+
+// MatchesAnalyzer checks if virtual services
+// associated with the same gateway have duplicate matches.
+type MatchesAnalyzer struct{}
+
+var _ analysis.Analyzer = &MatchesAnalyzer{}
+
+// Metadata implements Analyzer
+func (ma *MatchesAnalyzer) Metadata() analysis.Metadata {
+	return analysis.Metadata{
+		Name:        "virtualservice.MatchesAnalyzer",
+		Description: "Checks virtual services for unreachable and duplicate matches",
+		Inputs: collection.Names{
+			collections.IstioNetworkingV1Alpha3Virtualservices.Name(),
+		},
+	}
+}
+
+// Analyze implements Analyzer
+func (ma *MatchesAnalyzer) Analyze(ctx analysis.Context) {
+	ctx.ForEach(collections.IstioNetworkingV1Alpha3Virtualservices.Name(), func(r *resource.Instance) bool {
+		ma.analyzeVirtualService(r, ctx)
+		return true
+	})
+}
+
+func (ma *MatchesAnalyzer) analyzeVirtualService(r *resource.Instance, c analysis.Context) {
+	vs := r.Message.(*v1alpha3.VirtualService)
+
+	// Look for unreachable rules.  For each type (http, tls, tcp) ideally we would
+	// check to see that no rule has any *MatchRequest that is a equal or subset of a previous
+	// rules' *MatchRequest.  That *MatchRequest is "dead" and if a rule has no living
+	// *MatchRequest the rule itself is dead.
+
+	// Unfortunately we have no logic to compare *MatchRequests.
+	// Instead we just check them for having identical JSON serializations.
+
+	// Note that this code is only analyzes a single VirtualService.  TODO Look for duplicates
+	// among all the VirtualSerices on a Gateway
+
+	ma.analyzeUnreachableHTTPRules(r, c, vs.Http)
+	ma.analyzeUnreachableTCPRules(r, c, vs.Tcp)
+	ma.analyzeUnreachableTLSRules(r, c, vs.Tls)
+}
+
+func (ma *MatchesAnalyzer) analyzeUnreachableHTTPRules(r *resource.Instance, c analysis.Context, routes []*v1alpha3.HTTPRoute) {
+	matchesEncountered := make(map[string]int)
+	emptyMatchEncountered := -1
+	for rulen, route := range routes {
+		if len(route.Match) == 0 {
+			if emptyMatchEncountered >= 0 {
+				c.Report(collections.IstioNetworkingV1Alpha3Virtualservices.Name(),
+					msg.NewVirtualServiceUnreachableRule(r,
+						rulen, "only the last rule can have no matches"))
+			}
+			emptyMatchEncountered = rulen
+			continue
+		}
+
+		duplicateMatches := 0
+		for matchn, match := range route.Match {
+			dupn, ok := matchesEncountered[asJSON(match)]
+			if ok {
+				c.Report(collections.IstioNetworkingV1Alpha3Virtualservices.Name(),
+					msg.NewVirtualServiceIneffectiveMatch(r, rulen, matchn, dupn))
+				duplicateMatches++
+			} else {
+				matchesEncountered[asJSON(match)] = rulen
+			}
+		}
+		if duplicateMatches == len(route.Match) {
+			c.Report(collections.IstioNetworkingV1Alpha3Virtualservices.Name(),
+				msg.NewVirtualServiceUnreachableRule(r, rulen, "all matches used by prior rules"))
+		}
+	}
+}
+
+func (ma *MatchesAnalyzer) analyzeUnreachableTCPRules(r *resource.Instance, c analysis.Context, routes []*v1alpha3.TCPRoute) {
+	matchesEncountered := make(map[string]int)
+	emptyMatchEncountered := -1
+	for rulen, route := range routes {
+		if len(route.Match) == 0 {
+			if emptyMatchEncountered >= 0 {
+				c.Report(collections.IstioNetworkingV1Alpha3Virtualservices.Name(),
+					msg.NewVirtualServiceUnreachableRule(r,
+						rulen, "only the last rule can have no matches"))
+			}
+			emptyMatchEncountered = rulen
+			continue
+		}
+
+		duplicateMatches := 0
+		for matchn, match := range route.Match {
+			dupn, ok := matchesEncountered[asJSON(match)]
+			if ok {
+				c.Report(collections.IstioNetworkingV1Alpha3Virtualservices.Name(),
+					msg.NewVirtualServiceIneffectiveMatch(r, rulen, matchn, dupn))
+				duplicateMatches++
+			} else {
+				matchesEncountered[asJSON(match)] = rulen
+			}
+		}
+		if duplicateMatches == len(route.Match) {
+			c.Report(collections.IstioNetworkingV1Alpha3Virtualservices.Name(),
+				msg.NewVirtualServiceUnreachableRule(r, rulen, "all matches used by prior rules"))
+		}
+	}
+}
+
+func (ma *MatchesAnalyzer) analyzeUnreachableTLSRules(r *resource.Instance, c analysis.Context, routes []*v1alpha3.TLSRoute) {
+	matchesEncountered := make(map[string]int)
+	emptyMatchEncountered := -1
+	for rulen, route := range routes {
+		if len(route.Match) == 0 {
+			if emptyMatchEncountered >= 0 {
+				c.Report(collections.IstioNetworkingV1Alpha3Virtualservices.Name(),
+					msg.NewVirtualServiceUnreachableRule(r,
+						rulen, "only the last rule can have no matches"))
+			}
+			emptyMatchEncountered = rulen
+			continue
+		}
+
+		duplicateMatches := 0
+		for matchn, match := range route.Match {
+			dupn, ok := matchesEncountered[asJSON(match)]
+			if ok {
+				c.Report(collections.IstioNetworkingV1Alpha3Virtualservices.Name(),
+					msg.NewVirtualServiceIneffectiveMatch(r, rulen, matchn, dupn))
+				duplicateMatches++
+			} else {
+				matchesEncountered[asJSON(match)] = rulen
+			}
+		}
+		if duplicateMatches == len(route.Match) {
+			c.Report(collections.IstioNetworkingV1Alpha3Virtualservices.Name(),
+				msg.NewVirtualServiceUnreachableRule(r, rulen, "all matches used by prior rules"))
+		}
+	}
+}
+
+func asJSON(data interface{}) string {
+
+	b, err := json.Marshal(data)
+	if err != nil {
+		return err.Error()
+	}
+	return string(b)
+}

--- a/galley/pkg/config/analysis/analyzers/virtualservice/util.go
+++ b/galley/pkg/config/analysis/analyzers/virtualservice/util.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package virtualservice
 
 import (

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -131,11 +131,11 @@ var (
 
 	// VirtualServiceUnreachableRule defines a diag.MessageType for message "VirtualServiceUnreachableRule".
 	// Description: A VirtualService rule will never be used because a previous rule uses the same match.
-	VirtualServiceUnreachableRule = diag.NewMessageType(diag.Warning, "IST0130", "VirtualService rule %d not used (%s).")
+	VirtualServiceUnreachableRule = diag.NewMessageType(diag.Warning, "IST0130", "VirtualService rule %v not used (%s).")
 
 	// VirtualServiceIneffectiveMatch defines a diag.MessageType for message "VirtualServiceIneffectiveMatch".
 	// Description: A VirtualService rule match duplicates a match in a previous rule.
-	VirtualServiceIneffectiveMatch = diag.NewMessageType(diag.Info, "IST0131", "VirtualService rule %d match %d is not used (duplicates a match in rule %d).")
+	VirtualServiceIneffectiveMatch = diag.NewMessageType(diag.Info, "IST0131", "VirtualService rule %v match %v is not used (duplicates a match in rule %v).")
 )
 
 // All returns a list of all known message types.
@@ -478,7 +478,7 @@ func NewNoServerCertificateVerificationPortLevel(r *resource.Instance, destinati
 }
 
 // NewVirtualServiceUnreachableRule returns a new diag.Message based on VirtualServiceUnreachableRule.
-func NewVirtualServiceUnreachableRule(r *resource.Instance, ruleno int, reason string) diag.Message {
+func NewVirtualServiceUnreachableRule(r *resource.Instance, ruleno string, reason string) diag.Message {
 	return diag.NewMessage(
 		VirtualServiceUnreachableRule,
 		r,
@@ -488,7 +488,7 @@ func NewVirtualServiceUnreachableRule(r *resource.Instance, ruleno int, reason s
 }
 
 // NewVirtualServiceIneffectiveMatch returns a new diag.Message based on VirtualServiceIneffectiveMatch.
-func NewVirtualServiceIneffectiveMatch(r *resource.Instance, ruleno int, matchno int, dupno int) diag.Message {
+func NewVirtualServiceIneffectiveMatch(r *resource.Instance, ruleno string, matchno string, dupno string) diag.Message {
 	return diag.NewMessage(
 		VirtualServiceIneffectiveMatch,
 		r,

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -128,6 +128,14 @@ var (
 	// NoServerCertificateVerificationPortLevel defines a diag.MessageType for message "NoServerCertificateVerificationPortLevel".
 	// Description: No caCertificates are set in DestinationRule, this results in no verification of presented server certificate for traffic to a given port.
 	NoServerCertificateVerificationPortLevel = diag.NewMessageType(diag.Error, "IST0129", "DestinationRule %s in namespace %s has TLS mode set to %s but no caCertificates are set to validate server identity for host: %s at port %s")
+
+	// VirtualServiceUnreachableRule defines a diag.MessageType for message "VirtualServiceUnreachableRule".
+	// Description: A VirtualService rule will never be used because a previous rule uses the same match.
+	VirtualServiceUnreachableRule = diag.NewMessageType(diag.Warning, "IST0130", "VirtualService rule %d not used (%s).")
+
+	// VirtualServiceIneffectiveMatch defines a diag.MessageType for message "VirtualServiceIneffectiveMatch".
+	// Description: A VirtualService rule match duplicates a match in a previous rule.
+	VirtualServiceIneffectiveMatch = diag.NewMessageType(diag.Info, "IST0131", "VirtualService rule %d match %d is not used (duplicates a match in rule %d).")
 )
 
 // All returns a list of all known message types.
@@ -163,6 +171,8 @@ func All() []*diag.MessageType {
 		NoMatchingWorkloadsFound,
 		NoServerCertificateVerificationDestinationLevel,
 		NoServerCertificateVerificationPortLevel,
+		VirtualServiceUnreachableRule,
+		VirtualServiceIneffectiveMatch,
 	}
 }
 
@@ -464,5 +474,26 @@ func NewNoServerCertificateVerificationPortLevel(r *resource.Instance, destinati
 		mode,
 		host,
 		port,
+	)
+}
+
+// NewVirtualServiceUnreachableRule returns a new diag.Message based on VirtualServiceUnreachableRule.
+func NewVirtualServiceUnreachableRule(r *resource.Instance, ruleno int, reason string) diag.Message {
+	return diag.NewMessage(
+		VirtualServiceUnreachableRule,
+		r,
+		ruleno,
+		reason,
+	)
+}
+
+// NewVirtualServiceIneffectiveMatch returns a new diag.Message based on VirtualServiceIneffectiveMatch.
+func NewVirtualServiceIneffectiveMatch(r *resource.Instance, ruleno int, matchno int, dupno int) diag.Message {
+	return diag.NewMessage(
+		VirtualServiceIneffectiveMatch,
+		r,
+		ruleno,
+		matchno,
+		dupno,
 	)
 }

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -334,10 +334,10 @@ messages:
     code: IST0130
     level: Warning
     description: "A VirtualService rule will never be used because a previous rule uses the same match."
-    template: "VirtualService rule %d not used (%s)."
+    template: "VirtualService rule %v not used (%s)."
     args:
       - name: ruleno
-        type: int
+        type: string
       - name: reason
         type: "string"
 
@@ -345,11 +345,11 @@ messages:
     code: IST0131
     level: Info
     description: "A VirtualService rule match duplicates a match in a previous rule."
-    template: "VirtualService rule %d match %d is not used (duplicates a match in rule %d)."
+    template: "VirtualService rule %v match %v is not used (duplicates a match in rule %v)."
     args:
       - name: ruleno
-        type: int
+        type: string
       - name: matchno
-        type: int
+        type: string
       - name: dupno
-        type: int
+        type: string

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -329,3 +329,27 @@ messages:
         type: string
       - name: port
         type: string
+
+  - name: "VirtualServiceUnreachableRule"
+    code: IST0130
+    level: Warning
+    description: "A VirtualService rule will never be used because a previous rule uses the same match."
+    template: "VirtualService rule %d not used (%s)."
+    args:
+      - name: ruleno
+        type: int
+      - name: reason
+        type: "string"
+
+  - name: "VirtualServiceIneffectiveMatch"
+    code: IST0131
+    level: Info
+    description: "A VirtualService rule match duplicates a match in a previous rule."
+    template: "VirtualService rule %d match %d is not used (duplicates a match in rule %d)."
+    args:
+      - name: ruleno
+        type: int
+      - name: matchno
+        type: int
+      - name: dupno
+        type: int


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/25533
Does **NOT** resolve https://github.com/istio/istio/issues/23073 .

Messages look like:
```
Warning [IST0130] (VirtualService duplicate-match galley/pkg/config/analysis/analyzers/testdata/virtualservice_dupmatches.yaml:25) VirtualService rule 1 not used (all matches used by prior rules).
Warning [IST0130] (VirtualService sample-foo-cluster01.foo galley/pkg/config/analysis/analyzers/testdata/virtualservice_dupmatches.yaml:1) VirtualService rule 1 not used (only the last rule can have no matches).
Info [IST0131] (VirtualService almost-duplicate-match galley/pkg/config/analysis/analyzers/testdata/virtualservice_dupmatches.yaml:47) VirtualService rule 1 match 0 is not used (duplicates a match in rule 0).
Info [IST0131] (VirtualService duplicate-match galley/pkg/config/analysis/analyzers/testdata/virtualservice_dupmatches.yaml:25) VirtualService rule 1 match 0 is not used (duplicates a match in rule 0).
```