### PR TITLE
Atomically write golden file updates

### DIFF
--- a/cni/deployments/kubernetes/install/test/install_cni.go
+++ b/cni/deployments/kubernetes/install/test/install_cni.go
@@ -29,6 +29,7 @@ import (
 	"github.com/coreos/etcd/pkg/fileutil"
 
 	"istio.io/istio/cni/pkg/install-cni/pkg/util"
+	"istio.io/istio/pkg/file"
 	"istio.io/istio/pkg/test/env"
 )
 
@@ -142,7 +143,7 @@ func rmCNIConfig(cniConfigFilepath string, t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err = util.AtomicWrite(cniConfigFilepath, cniConfig, os.FileMode(0644)); err != nil {
+	if err = file.AtomicWrite(cniConfigFilepath, cniConfig, os.FileMode(0644)); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/cni/deployments/kubernetes/install/test/install_cni.go
+++ b/cni/deployments/kubernetes/install/test/install_cni.go
@@ -26,8 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/etcd/pkg/fileutil"
-
 	"istio.io/istio/cni/pkg/install-cni/pkg/util"
 	"istio.io/istio/pkg/file"
 	"istio.io/istio/pkg/test/env"
@@ -378,7 +376,7 @@ func doTest(testNum int, chainedCNIPlugin bool, wd, preConfFile, resultFileName,
 			compareConfResult(testWorkRootDir, resultFile, expectedPostCleanFile, t)
 		}
 	} else {
-		if fileutil.Exist(resultFile) {
+		if file.Exists(resultFile) {
 			t.Logf("FAIL: Istio CNI config file was not removed: %s", resultFile)
 		}
 	}

--- a/cni/pkg/install-cni/pkg/install/binaries.go
+++ b/cni/pkg/install-cni/pkg/install/binaries.go
@@ -19,8 +19,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/coreos/etcd/pkg/fileutil"
-
 	"istio.io/istio/cni/pkg/install-cni/pkg/constants"
 	"istio.io/istio/pkg/file"
 	"istio.io/pkg/log"
@@ -33,7 +31,7 @@ func copyBinaries(updateBinaries bool, skipBinaries []string) error {
 	skipBinariesSet := arrToSet(skipBinaries)
 
 	for _, targetDir := range targetDirs {
-		if fileutil.IsDirWriteable(targetDir) != nil {
+		if file.IsDirWriteable(targetDir) != nil {
 			log.Infof("Directory %s is not writable, skipping.", targetDir)
 			continue
 		}

--- a/cni/pkg/install-cni/pkg/install/binaries.go
+++ b/cni/pkg/install-cni/pkg/install/binaries.go
@@ -22,7 +22,7 @@ import (
 	"github.com/coreos/etcd/pkg/fileutil"
 
 	"istio.io/istio/cni/pkg/install-cni/pkg/constants"
-	"istio.io/istio/cni/pkg/install-cni/pkg/util"
+	"istio.io/istio/pkg/file"
 	"istio.io/pkg/log"
 )
 
@@ -43,8 +43,8 @@ func copyBinaries(updateBinaries bool, skipBinaries []string) error {
 			return err
 		}
 
-		for _, file := range files {
-			filename := file.Name()
+		for _, f := range files {
+			filename := f.Name()
 			if skipBinariesSet[filename] {
 				log.Infof("%s is in SKIP_CNI_BINARIES, skipping.", filename)
 				continue
@@ -57,7 +57,7 @@ func copyBinaries(updateBinaries bool, skipBinaries []string) error {
 			}
 
 			srcFilepath := filepath.Join(srcDir, filename)
-			err := util.AtomicCopy(srcFilepath, targetDir, filename)
+			err := file.AtomicCopy(srcFilepath, targetDir, filename)
 			if err != nil {
 				return err
 			}

--- a/cni/pkg/install-cni/pkg/install/cniconfig.go
+++ b/cni/pkg/install-cni/pkg/install/cniconfig.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 
 	"github.com/containernetworking/cni/libcni"
-	"github.com/coreos/etcd/pkg/fileutil"
 	"github.com/pkg/errors"
 
 	"istio.io/istio/cni/pkg/install-cni/pkg/config"
@@ -92,7 +91,7 @@ func createCNIConfigFile(ctx context.Context, cfg *config.Config, saToken string
 }
 
 func readCNIConfigTemplate(template cniConfigTemplate) ([]byte, error) {
-	if fileutil.Exist(template.cniNetworkConfigFile) {
+	if file.Exists(template.cniNetworkConfigFile) {
 		cniConfig, err := ioutil.ReadFile(template.cniNetworkConfigFile)
 		if err != nil {
 			return nil, err
@@ -135,7 +134,7 @@ func writeCNIConfig(ctx context.Context, cniConfig []byte, cfg pluginConfig) (st
 	}
 
 	if cfg.chainedCNIPlugin {
-		if !fileutil.Exist(cniConfigFilepath) {
+		if !file.Exists(cniConfigFilepath) {
 			return "", fmt.Errorf("CNI config file %s removed during configuration", cniConfigFilepath)
 		}
 		// This section overwrites an existing plugins list entry for istio-cni
@@ -199,11 +198,11 @@ func getCNIConfigFilepath(ctx context.Context, cfg pluginConfig) (string, error)
 
 	cniConfigFilepath := filepath.Join(cfg.mountedCNINetDir, filename)
 
-	for !fileutil.Exist(cniConfigFilepath) {
-		if strings.HasSuffix(cniConfigFilepath, ".conf") && fileutil.Exist(cniConfigFilepath+"list") {
+	for !file.Exists(cniConfigFilepath) {
+		if strings.HasSuffix(cniConfigFilepath, ".conf") && file.Exists(cniConfigFilepath+"list") {
 			log.Infof("%s doesn't exist, but %[1]slist does; Using it as the CNI config file instead.", cniConfigFilepath)
 			cniConfigFilepath += "list"
-		} else if strings.HasSuffix(cniConfigFilepath, ".conflist") && fileutil.Exist(cniConfigFilepath[:len(cniConfigFilepath)-4]) {
+		} else if strings.HasSuffix(cniConfigFilepath, ".conflist") && file.Exists(cniConfigFilepath[:len(cniConfigFilepath)-4]) {
 			log.Infof("%s doesn't exist, but %s does; Using it as the CNI config file instead.", cniConfigFilepath, cniConfigFilepath[:len(cniConfigFilepath)-4])
 			cniConfigFilepath = cniConfigFilepath[:len(cniConfigFilepath)-4]
 		} else {

--- a/cni/pkg/install-cni/pkg/install/cniconfig.go
+++ b/cni/pkg/install-cni/pkg/install/cniconfig.go
@@ -30,6 +30,7 @@ import (
 
 	"istio.io/istio/cni/pkg/install-cni/pkg/config"
 	"istio.io/istio/cni/pkg/install-cni/pkg/util"
+	"istio.io/istio/pkg/file"
 	"istio.io/pkg/log"
 )
 
@@ -148,7 +149,7 @@ func writeCNIConfig(ctx context.Context, cniConfig []byte, cfg pluginConfig) (st
 		}
 	}
 
-	if err = util.AtomicWrite(cniConfigFilepath, cniConfig, os.FileMode(0644)); err != nil {
+	if err = file.AtomicWrite(cniConfigFilepath, cniConfig, os.FileMode(0644)); err != nil {
 		return "", err
 	}
 

--- a/cni/pkg/install-cni/pkg/install/cniconfig_test.go
+++ b/cni/pkg/install-cni/pkg/install/cniconfig_test.go
@@ -26,8 +26,8 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"istio.io/istio/cni/pkg/install-cni/pkg/config"
-	"istio.io/istio/cni/pkg/install-cni/pkg/util"
 	testutils "istio.io/istio/pilot/test/util"
+	"istio.io/istio/pkg/file"
 )
 
 func TestGetDefaultCNINetwork(t *testing.T) {
@@ -214,7 +214,7 @@ func TestGetCNIConfigFilepath(t *testing.T) {
 
 			// Create existing config files if specified in test case
 			for _, filename := range c.existingConfFiles {
-				if err := util.AtomicCopy(filepath.Join("testdata", filepath.Base(filename)), tempDir, filepath.Base(filename)); err != nil {
+				if err := file.AtomicCopy(filepath.Join("testdata", filepath.Base(filename)), tempDir, filepath.Base(filename)); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -496,7 +496,7 @@ func TestCreateCNIConfigFile(t *testing.T) {
 
 				// Create existing config files if specified in test case
 				for srcFilename, targetFilename := range c.existingConfFiles {
-					if err := util.AtomicCopy(filepath.Join("testdata", srcFilename), tempDir, targetFilename); err != nil {
+					if err := file.AtomicCopy(filepath.Join("testdata", srcFilename), tempDir, targetFilename); err != nil {
 						t.Fatal(err)
 					}
 				}

--- a/cni/pkg/install-cni/pkg/install/install.go
+++ b/cni/pkg/install-cni/pkg/install/install.go
@@ -28,6 +28,7 @@ import (
 	"istio.io/istio/cni/pkg/install-cni/pkg/config"
 	"istio.io/istio/cni/pkg/install-cni/pkg/constants"
 	"istio.io/istio/cni/pkg/install-cni/pkg/util"
+	"istio.io/istio/pkg/file"
 	"istio.io/pkg/log"
 )
 
@@ -107,7 +108,7 @@ func (in *Installer) Cleanup() error {
 			if err != nil {
 				return err
 			}
-			if err = util.AtomicWrite(in.cniConfigFilepath, cniConfig, os.FileMode(0644)); err != nil {
+			if err = file.AtomicWrite(in.cniConfigFilepath, cniConfig, os.FileMode(0644)); err != nil {
 				return err
 			}
 		} else {

--- a/cni/pkg/install-cni/pkg/install/install.go
+++ b/cni/pkg/install-cni/pkg/install/install.go
@@ -22,7 +22,6 @@ import (
 	"path/filepath"
 	"sync/atomic"
 
-	"github.com/coreos/etcd/pkg/fileutil"
 	"github.com/pkg/errors"
 
 	"istio.io/istio/cni/pkg/install-cni/pkg/config"
@@ -79,7 +78,7 @@ func (in *Installer) Run(ctx context.Context) (err error) {
 // Cleanup remove Istio CNI's config, kubeconfig file, and binaries.
 func (in *Installer) Cleanup() error {
 	log.Info("Cleaning up.")
-	if len(in.cniConfigFilepath) > 0 && fileutil.Exist(in.cniConfigFilepath) {
+	if len(in.cniConfigFilepath) > 0 && file.Exists(in.cniConfigFilepath) {
 		if in.cfg.ChainedCNIPlugin {
 			log.Infof("Removing Istio CNI config from CNI config file: %s", in.cniConfigFilepath)
 
@@ -119,7 +118,7 @@ func (in *Installer) Cleanup() error {
 		}
 	}
 
-	if len(in.kubeconfigFilepath) > 0 && fileutil.Exist(in.kubeconfigFilepath) {
+	if len(in.kubeconfigFilepath) > 0 && file.Exists(in.kubeconfigFilepath) {
 		log.Infof("Removing Istio CNI kubeconfig file: %s", in.kubeconfigFilepath)
 		if err := os.Remove(in.kubeconfigFilepath); err != nil {
 			return err
@@ -127,12 +126,12 @@ func (in *Installer) Cleanup() error {
 	}
 
 	log.Info("Removing existing binaries")
-	if istioCNIBin := filepath.Join(constants.HostCNIBinDir, "istio-cni"); fileutil.Exist(istioCNIBin) {
+	if istioCNIBin := filepath.Join(constants.HostCNIBinDir, "istio-cni"); file.Exists(istioCNIBin) {
 		if err := os.Remove(istioCNIBin); err != nil {
 			return err
 		}
 	}
-	if istioIptablesBin := filepath.Join(constants.HostCNIBinDir, "istio-iptables"); fileutil.Exist(istioIptablesBin) {
+	if istioIptablesBin := filepath.Join(constants.HostCNIBinDir, "istio-iptables"); file.Exists(istioIptablesBin) {
 		if err := os.Remove(istioIptablesBin); err != nil {
 			return err
 		}
@@ -142,7 +141,7 @@ func (in *Installer) Cleanup() error {
 
 func readServiceAccountToken() (string, error) {
 	saToken := constants.ServiceAccountPath + "/token"
-	if !fileutil.Exist(saToken) {
+	if !file.Exists(saToken) {
 		return "", fmt.Errorf("service account token file %s does not exist. Is this not running within a pod?", saToken)
 	}
 
@@ -211,7 +210,7 @@ func checkInstall(cfg *config.Config, cniConfigFilepath string) error {
 		}
 	}
 
-	if !fileutil.Exist(cniConfigFilepath) {
+	if !file.Exists(cniConfigFilepath) {
 		return fmt.Errorf("CNI config file removed: %s", cniConfigFilepath)
 	}
 

--- a/cni/pkg/install-cni/pkg/install/install_test.go
+++ b/cni/pkg/install-cni/pkg/install/install_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"istio.io/istio/cni/pkg/install-cni/pkg/config"
-	"istio.io/istio/cni/pkg/install-cni/pkg/util"
+	"istio.io/istio/pkg/file"
 )
 
 func TestCheckInstall(t *testing.T) {
@@ -107,7 +107,7 @@ func TestCheckInstall(t *testing.T) {
 
 			// Create existing config files if specified in test case
 			for srcFilename, targetFilename := range c.existingConfFiles {
-				if err := util.AtomicCopy(filepath.Join("testdata", srcFilename), tempDir, targetFilename); err != nil {
+				if err := file.AtomicCopy(filepath.Join("testdata", srcFilename), tempDir, targetFilename); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -173,7 +173,7 @@ func TestSleepCheckInstall(t *testing.T) {
 
 			if len(c.invalidConfigFilename) > 0 {
 				// Copy an invalid config file into tempDir
-				if err = util.AtomicCopy(filepath.Join("testdata", c.invalidConfigFilename), tempDir, c.cniConfigFilename); err != nil {
+				if err = file.AtomicCopy(filepath.Join("testdata", c.invalidConfigFilename), tempDir, c.cniConfigFilename); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -191,7 +191,7 @@ func TestSleepCheckInstall(t *testing.T) {
 			}
 
 			// Copy a valid config file into tempDir
-			if err = util.AtomicCopy(filepath.Join("testdata", c.validConfigFilename), tempDir, c.cniConfigFilename); err != nil {
+			if err = file.AtomicCopy(filepath.Join("testdata", c.validConfigFilename), tempDir, c.cniConfigFilename); err != nil {
 				t.Fatal(err)
 			}
 
@@ -234,7 +234,7 @@ func TestSleepCheckInstall(t *testing.T) {
 			// Remove Istio CNI's config
 			t.Log("Expecting an invalid configuration log:")
 			if len(c.invalidConfigFilename) > 0 {
-				if err = util.AtomicCopy(filepath.Join("testdata", c.invalidConfigFilename), tempDir, c.cniConfigFilename); err != nil {
+				if err = file.AtomicCopy(filepath.Join("testdata", c.invalidConfigFilename), tempDir, c.cniConfigFilename); err != nil {
 					t.Fatal(err)
 				}
 			} else {

--- a/cni/pkg/install-cni/pkg/install/kubeconfig.go
+++ b/cni/pkg/install-cni/pkg/install/kubeconfig.go
@@ -22,11 +22,11 @@ import (
 	"path/filepath"
 	"text/template"
 
-	"github.com/coreos/etcd/pkg/fileutil"
 	"github.com/pkg/errors"
 
 	"istio.io/istio/cni/pkg/install-cni/pkg/config"
 	"istio.io/istio/cni/pkg/install-cni/pkg/constants"
+	"istio.io/istio/pkg/file"
 )
 
 const kubeconfigTemplate = `# Kubeconfig file for Istio CNI plugin.
@@ -88,7 +88,7 @@ func createKubeconfigFile(cfg *config.Config, saToken string) (kubeconfigFilepat
 	if cfg.SkipTLSVerify {
 		tlsConfig = "insecure-skip-tls-verify: true"
 	} else {
-		if !fileutil.Exist(caFile) {
+		if !file.Exists(caFile) {
 			return "", fmt.Errorf("file does not exist: %s", caFile)
 		}
 		var caContents []byte
@@ -114,7 +114,7 @@ func createKubeconfigFile(cfg *config.Config, saToken string) (kubeconfigFilepat
 		return
 	}
 	defer func() {
-		if fileutil.Exist(tmpFile.Name()) {
+		if file.Exists(tmpFile.Name()) {
 			if rmErr := os.Remove(tmpFile.Name()); rmErr != nil {
 				if err != nil {
 					err = errors.Wrap(err, rmErr.Error())

--- a/cni/pkg/install-cni/pkg/install/kubeconfig_test.go
+++ b/cni/pkg/install-cni/pkg/install/kubeconfig_test.go
@@ -21,12 +21,12 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/coreos/etcd/pkg/fileutil"
 	"github.com/stretchr/testify/assert"
 
 	"istio.io/istio/cni/pkg/install-cni/pkg/config"
 	"istio.io/istio/cni/pkg/install-cni/pkg/constants"
 	testutils "istio.io/istio/pilot/test/util"
+	"istio.io/istio/pkg/file"
 )
 
 const (
@@ -122,7 +122,7 @@ func TestCreateKubeconfigFile(t *testing.T) {
 				t.Fatalf("expected %s, got %s", expectedFilepath, resultFilepath)
 			}
 
-			if !fileutil.Exist(resultFilepath) {
+			if !file.Exists(resultFilepath) {
 				t.Fatalf("kubeconfig file does not exist: %s", resultFilepath)
 			}
 

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,6 @@ require (
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
 	github.com/containernetworking/cni v0.7.0-alpha1
 	github.com/containernetworking/plugins v0.7.3
-	github.com/coreos/etcd v3.3.15+incompatible
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/d4l3k/messagediff v1.2.1
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -143,8 +143,6 @@ github.com/containernetworking/cni v0.7.0-alpha1/go.mod h1:LGwApLUm2FpoOfxTDEeq8
 github.com/containernetworking/plugins v0.7.3 h1:cj32EM6IBzyqbx+qyB7Tz3lWMVtEHQJKfECNdhwZkFk=
 github.com/containernetworking/plugins v0.7.3/go.mod h1:dagHaAhNjXjT9QYOklkKJDGaQPTg4pf//FrUcJeb7FU=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
-github.com/coreos/etcd v3.3.15+incompatible h1:+9RjdC18gMxNQVvSiXvObLu29mOFmkgdsB4cRTlV+EE=
-github.com/coreos/etcd v3.3.15+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-oidc v2.1.0+incompatible h1:sdJrfw8akMnCuUlaZU3tE/uYXFgfqom8DBE9so9EBsM=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -34,6 +34,7 @@ import (
 	"istio.io/istio/operator/pkg/util/clog"
 	"istio.io/istio/operator/pkg/util/httpserver"
 	"istio.io/istio/operator/pkg/util/tgz"
+	tutil "istio.io/istio/pilot/test/util"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/pkg/version"
 )
@@ -658,12 +659,7 @@ func runTestGroup(t *testing.T, tests testGroup) {
 				}
 			}
 
-			if refreshGoldenFiles() {
-				t.Logf("Refreshing golden file for %s", outPath)
-				if err := ioutil.WriteFile(outPath, []byte(got), 0644); err != nil {
-					t.Error(err)
-				}
-			}
+			tutil.RefreshGoldenFile([]byte(got), outPath, t)
 
 			want, err := readFile(outPath)
 			if err != nil {

--- a/pilot/test/util/diff.go
+++ b/pilot/test/util/diff.go
@@ -113,6 +113,7 @@ func StripVersion(yaml []byte) []byte {
 func RefreshGoldenFile(content []byte, goldenFile string, t *testing.T) {
 	if Refresh() {
 		t.Logf("Refreshing golden file %s", goldenFile)
+		// nolint: gocritic
 		if err := AtomicWrite(goldenFile, content, 0644); err != nil {
 			t.Errorf(err.Error())
 		}
@@ -121,7 +122,7 @@ func RefreshGoldenFile(content []byte, goldenFile string, t *testing.T) {
 
 // Write atomically by writing to a temporary file in the same directory then renaming
 func AtomicWrite(path string, data []byte, mode os.FileMode) (err error) {
-	tmpFile, err := ioutil.TempFile("", filepath.Base(path)+".tmp.")
+	tmpFile, err := ioutil.TempFile(filepath.Dir(path), filepath.Base(path)+".tmp.")
 	if err != nil {
 		return
 	}

--- a/pilot/test/util/diff.go
+++ b/pilot/test/util/diff.go
@@ -16,7 +16,10 @@ package util
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -110,10 +113,36 @@ func StripVersion(yaml []byte) []byte {
 func RefreshGoldenFile(content []byte, goldenFile string, t *testing.T) {
 	if Refresh() {
 		t.Logf("Refreshing golden file %s", goldenFile)
-		if err := ioutil.WriteFile(goldenFile, content, 0644); err != nil {
+		if err := AtomicWrite(goldenFile, content, 0644); err != nil {
 			t.Errorf(err.Error())
 		}
 	}
+}
+
+// Write atomically by writing to a temporary file in the same directory then renaming
+func AtomicWrite(path string, data []byte, mode os.FileMode) (err error) {
+	tmpFile, err := ioutil.TempFile("", filepath.Base(path)+".tmp.")
+	if err != nil {
+		return
+	}
+
+	if err = os.Chmod(tmpFile.Name(), mode); err != nil {
+		return
+	}
+
+	_, err = tmpFile.Write(data)
+	if err != nil {
+		if closeErr := tmpFile.Close(); closeErr != nil {
+			err = fmt.Errorf("%v: %v", err, closeErr.Error())
+		}
+		return
+	}
+	if err = tmpFile.Close(); err != nil {
+		return
+	}
+
+	err = os.Rename(tmpFile.Name(), path)
+	return
 }
 
 // ReadFile reads the content of the given file or fails the test if an error is encountered.

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -30,7 +30,7 @@ func AtomicWrite(path string, data []byte, mode os.FileMode) (err error) {
 		return
 	}
 	defer func() {
-		if Exist(tmpFile.Name()) {
+		if Exists(tmpFile.Name()) {
 			if rmErr := os.Remove(tmpFile.Name()); rmErr != nil {
 				if err != nil {
 					err = errors.Wrap(err, rmErr.Error())
@@ -60,7 +60,23 @@ func AtomicWrite(path string, data []byte, mode os.FileMode) (err error) {
 	return
 }
 
-func Exist(name string) bool {
+func Exists(name string) bool {
 	_, err := os.Stat(name)
 	return err == nil
+}
+
+const (
+	// PrivateFileMode grants owner to read/write a file.
+	PrivateFileMode = 0600
+)
+
+// IsDirWriteable checks if dir is writable by writing and removing a file
+// to dir. It returns nil if dir is writable.
+// Inspired by etcd fileutil.
+func IsDirWriteable(dir string) error {
+	f := filepath.Join(dir, ".touch")
+	if err := ioutil.WriteFile(f, []byte(""), PrivateFileMode); err != nil {
+		return err
+	}
+	return os.Remove(f)
 }

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -1,0 +1,66 @@
+package file
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+// Copies file by reading the file then writing atomically into the target directory
+func AtomicCopy(srcFilepath, targetDir, targetFilename string) error {
+	info, err := os.Stat(srcFilepath)
+	if err != nil {
+		return err
+	}
+
+	input, err := ioutil.ReadFile(srcFilepath)
+	if err != nil {
+		return err
+	}
+
+	return AtomicWrite(filepath.Join(targetDir, targetFilename), input, info.Mode())
+}
+
+// Write atomically by writing to a temporary file in the same directory then renaming
+func AtomicWrite(path string, data []byte, mode os.FileMode) (err error) {
+	tmpFile, err := ioutil.TempFile(filepath.Dir(path), filepath.Base(path)+".tmp.")
+	if err != nil {
+		return
+	}
+	defer func() {
+		if Exist(tmpFile.Name()) {
+			if rmErr := os.Remove(tmpFile.Name()); rmErr != nil {
+				if err != nil {
+					err = errors.Wrap(err, rmErr.Error())
+				} else {
+					err = rmErr
+				}
+			}
+		}
+	}()
+
+	if err = os.Chmod(tmpFile.Name(), mode); err != nil {
+		return
+	}
+
+	_, err = tmpFile.Write(data)
+	if err != nil {
+		if closeErr := tmpFile.Close(); closeErr != nil {
+			err = errors.Wrap(err, closeErr.Error())
+		}
+		return
+	}
+	if err = tmpFile.Close(); err != nil {
+		return
+	}
+
+	err = os.Rename(tmpFile.Name(), path)
+	return
+}
+
+func Exist(name string) bool {
+	_, err := os.Stat(name)
+	return err == nil
+}

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package file
 
 import (

--- a/tools/istio-iptables/pkg/validation/linux_test.go
+++ b/tools/istio-iptables/pkg/validation/linux_test.go
@@ -17,27 +17,12 @@ package validation
 import (
 	"encoding/binary"
 	"testing"
-	"unsafe"
 )
-
-const intWidth int = int(unsafe.Sizeof(0))
-
-var byteOrder binary.ByteOrder
-
-// Inspired by etcd cpuutil
-func init() {
-	i := int(0x1)
-	if v := (*[intWidth]byte)(unsafe.Pointer(&i)); v[0] == 0 {
-		byteOrder = binary.BigEndian
-	} else {
-		byteOrder = binary.LittleEndian
-	}
-}
 
 func TestNtohs(t *testing.T) {
 	hostValue := ntohs(0xbeef)
 	expectValue := 0xbeef
-	if byteOrder == binary.LittleEndian {
+	if nativeByteOrder == binary.LittleEndian {
 		expectValue = 0xefbe
 	}
 	if hostValue != uint16(expectValue) {

--- a/tools/istio-iptables/pkg/validation/linux_test.go
+++ b/tools/istio-iptables/pkg/validation/linux_test.go
@@ -17,14 +17,27 @@ package validation
 import (
 	"encoding/binary"
 	"testing"
-
-	"github.com/coreos/etcd/pkg/cpuutil"
+	"unsafe"
 )
+
+const intWidth int = int(unsafe.Sizeof(0))
+
+var byteOrder binary.ByteOrder
+
+// Inspired by etcd cpuutil
+func init() {
+	i := int(0x1)
+	if v := (*[intWidth]byte)(unsafe.Pointer(&i)); v[0] == 0 {
+		byteOrder = binary.BigEndian
+	} else {
+		byteOrder = binary.LittleEndian
+	}
+}
 
 func TestNtohs(t *testing.T) {
 	hostValue := ntohs(0xbeef)
 	expectValue := 0xbeef
-	if cpuutil.ByteOrder().String() == binary.LittleEndian.String() {
+	if byteOrder == binary.LittleEndian {
 		expectValue = 0xefbe
 	}
 	if hostValue != uint16(expectValue) {


### PR DESCRIPTION
We have some tests running in parallel writing to the same file, which
leads to some occasional test failures. Ran this 1k times locally, it
passes 100% with my change and almost 0% without on a test of 100 tests
writing to one golden file

Example failure: https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/26774/gencheck_istio/17280