### PR TITLE
cache envoy readiness value

### DIFF
--- a/pilot/cmd/pilot-agent/status/ready/probe_test.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe_test.go
@@ -19,7 +19,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	. "github.com/onsi/gomega"
 )
@@ -146,7 +145,6 @@ func TestEnvoyNoServerStats(t *testing.T) {
 }
 
 func TestEnvoyReadinessCache(t *testing.T) {
-	readinessTTL = 1 * time.Second
 	g := NewWithT(t)
 
 	server := createAndStartServer(noServerStats)
@@ -154,7 +152,6 @@ func TestEnvoyReadinessCache(t *testing.T) {
 	err := probe.Check()
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(probe.atleastOnceReady).Should(BeFalse())
-	g.Expect(probe.readyError).To(BeNil())
 	err = probe.Check()
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(probe.atleastOnceReady).Should(BeFalse())
@@ -164,23 +161,17 @@ func TestEnvoyReadinessCache(t *testing.T) {
 	err = probe.Check()
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(probe.atleastOnceReady).Should(BeTrue())
-	g.Expect(probe.readyError).To(BeNil())
 	server.Close()
 
-	time.Sleep(2 * time.Second)
 	server = createAndStartServer(noServerStats)
 	err = probe.Check()
-	g.Expect(err).To(HaveOccurred())
-	g.Expect(probe.atleastOnceReady).Should(BeFalse())
-	g.Expect(probe.readyError).NotTo(BeNil())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(probe.atleastOnceReady).Should(BeTrue())
 	server.Close()
 
-	server = createAndStartServer(liveServerStats)
 	err = probe.Check()
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(probe.atleastOnceReady).Should(BeTrue())
-	g.Expect(probe.readyError).To(BeNil())
-	server.Close()
 }
 
 func createDefaultFuncMap(statsToReturn string) map[string]func(rw http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
Checked Envoy and confirmed with @lizan that Envoy readiness state(Server.State) will not change unless it is hot restarted or health check fails. Since we do not have both, it is safe to cache and rely on readiness probe going through Envoy for verifying Envoy is serving traffic.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X ] Does not have any changes that may affect Istio users.
