### PR TITLE
Clean up cluster tests

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -29,15 +29,14 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
 
+	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
-	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
-	memregistry "istio.io/istio/pilot/pkg/serviceregistry/memory"
+	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
-	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
 )
 
@@ -58,7 +57,7 @@ func TestApplyDestinationRule(t *testing.T) {
 		Namespace: TestServiceNamespace,
 	}
 	service := &model.Service{
-		Hostname:    host.Name("foo"),
+		Hostname:    host.Name("foo.default.svc.cluster.local"),
 		Address:     "1.1.1.1",
 		ClusterVIPs: make(map[string]string),
 		Ports:       servicePort,
@@ -72,7 +71,6 @@ func TestApplyDestinationRule(t *testing.T) {
 		clusterMode            ClusterMode
 		service                *model.Service
 		port                   *model.Port
-		proxy                  *model.Proxy
 		networkView            map[string]bool
 		destRule               *networking.DestinationRule
 		expectedSubsetClusters []*cluster.Cluster
@@ -84,7 +82,6 @@ func TestApplyDestinationRule(t *testing.T) {
 			clusterMode:            DefaultClusterMode,
 			service:                &model.Service{},
 			port:                   &model.Port{},
-			proxy:                  &model.Proxy{},
 			networkView:            map[string]bool{},
 			destRule:               nil,
 			expectedSubsetClusters: []*cluster.Cluster{},
@@ -95,10 +92,9 @@ func TestApplyDestinationRule(t *testing.T) {
 			clusterMode: DefaultClusterMode,
 			service:     service,
 			port:        servicePort[0],
-			proxy:       &model.Proxy{},
 			networkView: map[string]bool{},
 			destRule: &networking.DestinationRule{
-				Host: "foo",
+				Host: "foo.default.svc.cluster.local",
 				Subsets: []*networking.Subset{
 					{
 						Name:   "foobar",
@@ -108,10 +104,10 @@ func TestApplyDestinationRule(t *testing.T) {
 			},
 			expectedSubsetClusters: []*cluster.Cluster{
 				{
-					Name:                 "outbound|8080|foobar|foo",
+					Name:                 "outbound|8080|foobar|foo.default.svc.cluster.local",
 					ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS},
 					EdsClusterConfig: &cluster.Cluster_EdsClusterConfig{
-						ServiceName: "outbound|8080|foobar|foo",
+						ServiceName: "outbound|8080|foobar|foo.default.svc.cluster.local",
 					},
 				},
 			},
@@ -122,10 +118,9 @@ func TestApplyDestinationRule(t *testing.T) {
 			clusterMode: SniDnatClusterMode,
 			service:     service,
 			port:        servicePort[0],
-			proxy:       &model.Proxy{},
 			networkView: map[string]bool{},
 			destRule: &networking.DestinationRule{
-				Host: "foo",
+				Host: "foo.default.svc.cluster.local",
 				Subsets: []*networking.Subset{
 					{
 						Name:   "foobar",
@@ -135,10 +130,10 @@ func TestApplyDestinationRule(t *testing.T) {
 			},
 			expectedSubsetClusters: []*cluster.Cluster{
 				{
-					Name:                 "outbound_.8080_.foobar_.foo",
+					Name:                 "outbound_.8080_.foobar_.foo.default.svc.cluster.local",
 					ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS},
 					EdsClusterConfig: &cluster.Cluster_EdsClusterConfig{
-						ServiceName: "outbound_.8080_.foobar_.foo",
+						ServiceName: "outbound_.8080_.foobar_.foo.default.svc.cluster.local",
 					},
 				},
 			},
@@ -149,10 +144,9 @@ func TestApplyDestinationRule(t *testing.T) {
 			clusterMode: DefaultClusterMode,
 			service:     service,
 			port:        servicePort[0],
-			proxy:       &model.Proxy{},
 			networkView: map[string]bool{},
 			destRule: &networking.DestinationRule{
-				Host: "foo",
+				Host: "foo.default.svc.cluster.local",
 				Subsets: []*networking.Subset{
 					{
 						Name:   "foobar",
@@ -169,10 +163,10 @@ func TestApplyDestinationRule(t *testing.T) {
 			},
 			expectedSubsetClusters: []*cluster.Cluster{
 				{
-					Name:                 "outbound|8080|foobar|foo",
+					Name:                 "outbound|8080|foobar|foo.default.svc.cluster.local",
 					ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_EDS},
 					EdsClusterConfig: &cluster.Cluster_EdsClusterConfig{
-						ServiceName: "outbound|8080|foobar|foo",
+						ServiceName: "outbound|8080|foobar|foo.default.svc.cluster.local",
 					},
 					CircuitBreakers: &cluster.CircuitBreakers{
 						Thresholds: []*cluster.CircuitBreakers_Thresholds{
@@ -190,7 +184,6 @@ func TestApplyDestinationRule(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-
 			instances := []*model.ServiceInstance{
 				{
 					Service:     tt.service,
@@ -207,25 +200,23 @@ func TestApplyDestinationRule(t *testing.T) {
 				},
 			}
 
-			serviceDiscovery := memregistry.NewServiceDiscovery([]*model.Service{tt.service})
-			serviceDiscovery.WantGetProxyServiceInstances = instances
-
-			configStore := model.MakeIstioStore(memory.Make(collections.Pilot))
+			var cfg *model.Config
 			if tt.destRule != nil {
-				configStore.Create(model.Config{
+				cfg = &model.Config{
 					ConfigMeta: model.ConfigMeta{
 						GroupVersionKind: gvk.DestinationRule,
 						Name:             "acme",
+						Namespace:        "default",
 					},
 					Spec: tt.destRule,
-				})
+				}
 			}
-			env := newTestEnvironment(serviceDiscovery, testMesh, configStore)
-
-			proxy := getProxy()
-			proxy.SetSidecarScope(env.PushContext)
-
-			cb := NewClusterBuilder(tt.proxy, env.PushContext)
+			cg := NewConfigGenTest(t, TestOptions{
+				ConfigPointers: []*model.Config{cfg},
+				Services:       []*model.Service{tt.service},
+			})
+			cg.MemRegistry.WantGetProxyServiceInstances = instances
+			cb := NewClusterBuilder(cg.SetupProxy(nil), cg.PushContext())
 
 			subsetClusters := cb.applyDestinationRule(tt.cluster, tt.clusterMode, tt.service, tt.port, tt.networkView)
 			if len(subsetClusters) != len(tt.expectedSubsetClusters) {
@@ -663,20 +654,14 @@ func TestBuildDefaultCluster(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			serviceDiscovery := memregistry.NewServiceDiscovery(nil)
-			configStore := model.MakeIstioStore(memory.Make(collections.Pilot))
-			env := newTestEnvironment(serviceDiscovery, testMesh, configStore)
-
-			proxy := getProxy()
-			proxy.SetSidecarScope(env.PushContext)
-
-			cb := NewClusterBuilder(&model.Proxy{}, env.PushContext)
+			cg := NewConfigGenTest(t, TestOptions{MeshConfig: &testMesh})
+			cb := NewClusterBuilder(cg.SetupProxy(nil), cg.PushContext())
 
 			defaultCluster := cb.buildDefaultCluster(tt.clusterName, tt.discovery,
 				tt.endpoints, tt.direction, servicePort, tt.external)
 
-			if !reflect.DeepEqual(defaultCluster, tt.expectedCluster) {
-				t.Errorf("Unexpected default cluster, want %v got %v", tt.expectedCluster, defaultCluster)
+			if diff := cmp.Diff(defaultCluster, tt.expectedCluster, protocmp.Transform()); diff != "" {
+				t.Errorf("Unexpected default cluster, diff: %v", diff)
 			}
 		})
 	}
@@ -711,15 +696,13 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 
 	cases := []struct {
 		name      string
-		newEnv    func(model.ServiceDiscovery, model.IstioConfigStore) *model.Environment
+		mesh      meshconfig.MeshConfig
 		instances []*model.ServiceInstance
 		expected  []*endpoint.LocalityLbEndpoints
 	}{
 		{
 			name: "basics",
-			newEnv: func(sd model.ServiceDiscovery, cs model.IstioConfigStore) *model.Environment {
-				return newTestEnvironment(sd, testMesh, cs)
-			},
+			mesh: testMesh,
 			instances: []*model.ServiceInstance{
 				{
 					Service:     service,
@@ -850,9 +833,7 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 		},
 		{
 			name: "cluster local",
-			newEnv: func(sd model.ServiceDiscovery, cs model.IstioConfigStore) *model.Environment {
-				return newTestEnvironment(sd, withClusterLocalHosts(testMesh, "*.example.org"), cs)
-			},
+			mesh: withClusterLocalHosts(testMesh, "*.example.org"),
 			instances: []*model.ServiceInstance{
 				{
 					Service:     service,
@@ -930,20 +911,20 @@ func TestBuildLocalityLbEndpoints(t *testing.T) {
 		})
 	}
 
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			configStore := model.MakeIstioStore(memory.Make(collections.Pilot))
-			serviceDiscovery := memregistry.NewServiceDiscovery([]*model.Service{service})
-			serviceDiscovery.WantGetProxyServiceInstances = c.instances
-			for _, i := range c.instances {
-				serviceDiscovery.AddInstance(i.Service.Hostname, i)
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			cg := NewConfigGenTest(t, TestOptions{
+				MeshConfig: &tt.mesh,
+				Services:   []*model.Service{service},
+			})
+			for _, i := range tt.instances {
+				cg.MemRegistry.AddInstance(i.Service.Hostname, i)
 			}
 
-			env := c.newEnv(serviceDiscovery, configStore)
-			cb := NewClusterBuilder(proxy, env.PushContext)
+			cb := NewClusterBuilder(cg.SetupProxy(proxy), cg.PushContext())
 			actual := cb.buildLocalityLbEndpoints(model.GetNetworkView(nil), service, 8080, nil)
 			sortEndpoints(actual)
-			if v := cmp.Diff(c.expected, actual, protocmp.Transform()); v != "" {
+			if v := cmp.Diff(tt.expected, actual, protocmp.Transform()); v != "" {
 				t.Fatalf("Expected (-) != actual (+):\n%s", v)
 			}
 		})
@@ -978,17 +959,12 @@ func TestBuildPassthroughClusters(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			serviceDiscovery := memregistry.NewServiceDiscovery(nil)
-			configStore := model.MakeIstioStore(memory.Make(collections.Pilot))
-			env := newTestEnvironment(serviceDiscovery, testMesh, configStore)
-
 			proxy := &model.Proxy{IPAddresses: tt.ips}
-			proxy.SetSidecarScope(env.PushContext)
-			proxy.DiscoverIPVersions()
+			cg := NewConfigGenTest(t, TestOptions{})
 
-			cb := NewClusterBuilder(proxy, env.PushContext)
-
+			cb := NewClusterBuilder(cg.SetupProxy(proxy), cg.PushContext())
 			clusters := cb.buildInboundPassthroughClusters()
+
 			var hasIpv4, hasIpv6 bool
 			for _, c := range clusters {
 				hasIpv4 = hasIpv4 || c.Name == util.InboundPassthroughClusterIpv4
@@ -1000,9 +976,14 @@ func TestBuildPassthroughClusters(t *testing.T) {
 			if hasIpv6 != tt.ipv6Expected {
 				t.Errorf("Unexpected Ipv6 Passthrough Cluster, want %v got %v", tt.ipv6Expected, hasIpv6)
 			}
+
+			passthrough := xdstest.ExtractCluster(util.InboundPassthroughClusterIpv4, clusters)
+			if passthrough == nil {
+				passthrough = xdstest.ExtractCluster(util.InboundPassthroughClusterIpv6, clusters)
+			}
 			// Validate that Passthrough Cluster LB Policy is set correctly.
-			if clusters[0].GetType() != cluster.Cluster_ORIGINAL_DST || clusters[0].GetLbPolicy() != cluster.Cluster_CLUSTER_PROVIDED {
-				t.Errorf("Unexpected Discovery type or Lb policy, got Discovery type: %v, Lb Policy: %v", clusters[0].GetType(), clusters[0].GetLbPolicy())
+			if passthrough.GetType() != cluster.Cluster_ORIGINAL_DST || passthrough.GetLbPolicy() != cluster.Cluster_CLUSTER_PROVIDED {
+				t.Errorf("Unexpected Discovery type or Lb policy, got Discovery type: %v, Lb Policy: %v", passthrough.GetType(), passthrough.GetLbPolicy())
 			}
 		})
 	}

--- a/pilot/pkg/networking/core/v1alpha3/fake.go
+++ b/pilot/pkg/networking/core/v1alpha3/fake.go
@@ -178,6 +178,9 @@ func (f *ConfigGenTest) SetupProxy(p *model.Proxy) *model.Proxy {
 	if p.Type == "" {
 		p.Type = model.SidecarProxy
 	}
+	if p.ConfigNamespace == "" {
+		p.ConfigNamespace = "default"
+	}
 	if p.ID == "" {
 		p.ID = "app.test"
 	}

--- a/pilot/pkg/networking/core/v1alpha3/fake.go
+++ b/pilot/pkg/networking/core/v1alpha3/fake.go
@@ -53,7 +53,8 @@ type TestOptions struct {
 	ConfigTemplateInput interface{}
 
 	// Services to pre-populate as part of the service discovery
-	Services []*model.Service
+	Services  []*model.Service
+	Instances []*model.ServiceInstance
 
 	// If provided, this mesh config will be used
 	MeshConfig      *meshconfig.MeshConfig
@@ -103,6 +104,9 @@ func NewConfigGenTest(t test.Failer, opts TestOptions) *ConfigGenTest {
 	// TODO allow passing in registry, for k8s, mem reigstry
 	serviceDiscovery.AddRegistry(se)
 	msd := memregistry.NewServiceDiscovery(opts.Services)
+	for _, instance := range opts.Instances {
+		msd.AddInstance(instance.Service.Hostname, instance)
+	}
 	msd.ClusterID = string(serviceregistry.Mock)
 	serviceDiscovery.AddRegistry(serviceregistry.Simple{
 		ClusterID:        string(serviceregistry.Mock),

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
@@ -27,15 +27,12 @@ import (
 	"github.com/gogo/protobuf/types"
 
 	networking "istio.io/api/networking/v1alpha3"
-	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
-	memregistry "istio.io/istio/pilot/pkg/serviceregistry/memory"
 	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
 	"istio.io/istio/pkg/config/protocol"
-	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
 )
 
@@ -396,17 +393,10 @@ func TestListenerBuilderPatchListeners(t *testing.T) {
 			},
 		},
 	}
-	configStore := buildEnvoyFilterConfigStore(configPatches)
+	cg := NewConfigGenTest(t, TestOptions{Configs: getEnvoyFilterConfigs(configPatches)})
 
-	serviceDiscovery := memregistry.NewServiceDiscovery(nil)
-
-	env := newTestEnvironment(serviceDiscovery, testMesh, configStore)
-
-	gatewayProxy := getDefaultProxy()
-	gatewayProxy.Type = model.Router
-	gatewayProxy.SetGatewaysForProxy(env.PushContext)
-	sidecarProxy := getDefaultProxy()
-	sidecarProxy.SetSidecarScope(env.PushContext)
+	gatewayProxy := cg.SetupProxy(&model.Proxy{Type: model.Router, ConfigNamespace: "not-default"})
+	sidecarProxy := cg.SetupProxy(&model.Proxy{ConfigNamespace: "not-default"})
 	type fields struct {
 		gatewayListeners        []*listener.Listener
 		inboundListeners        []*listener.Listener
@@ -416,17 +406,15 @@ func TestListenerBuilderPatchListeners(t *testing.T) {
 		virtualInboundListener  *listener.Listener
 	}
 	tests := []struct {
-		name        string
-		proxy       *model.Proxy
-		pushContext *model.PushContext
-		fields      fields
-		want        fields
+		name   string
+		proxy  *model.Proxy
+		fields fields
+		want   fields
 	}{
 
 		{
-			name:        "patch add inbound and outbound listener",
-			proxy:       sidecarProxy,
-			pushContext: env.PushContext,
+			name:  "patch add inbound and outbound listener",
+			proxy: sidecarProxy,
 			fields: fields{
 				outboundListeners: []*listener.Listener{
 					{
@@ -452,9 +440,8 @@ func TestListenerBuilderPatchListeners(t *testing.T) {
 			},
 		},
 		{
-			name:        "patch inbound and outbound listener",
-			proxy:       sidecarProxy,
-			pushContext: env.PushContext,
+			name:  "patch inbound and outbound listener",
+			proxy: sidecarProxy,
 			fields: fields{
 				outboundListeners: []*listener.Listener{
 					{
@@ -492,9 +479,8 @@ func TestListenerBuilderPatchListeners(t *testing.T) {
 			},
 		},
 		{
-			name:        "patch add gateway listener",
-			proxy:       gatewayProxy,
-			pushContext: env.PushContext,
+			name:  "patch add gateway listener",
+			proxy: gatewayProxy,
 			fields: fields{
 				gatewayListeners: []*listener.Listener{
 					{
@@ -515,9 +501,8 @@ func TestListenerBuilderPatchListeners(t *testing.T) {
 		},
 
 		{
-			name:        "patch gateway listener",
-			proxy:       gatewayProxy,
-			pushContext: env.PushContext,
+			name:  "patch gateway listener",
+			proxy: gatewayProxy,
 			fields: fields{
 				gatewayListeners: []*listener.Listener{
 					{
@@ -554,7 +539,7 @@ func TestListenerBuilderPatchListeners(t *testing.T) {
 
 			lb := &ListenerBuilder{
 				node:                    tt.proxy,
-				push:                    tt.pushContext,
+				push:                    cg.PushContext(),
 				gatewayListeners:        tt.fields.gatewayListeners,
 				inboundListeners:        tt.fields.inboundListeners,
 				outboundListeners:       tt.fields.outboundListeners,
@@ -586,10 +571,10 @@ func buildPatchStruct(config string) *types.Struct {
 	return val
 }
 
-func buildEnvoyFilterConfigStore(configPatches []*networking.EnvoyFilter_EnvoyConfigObjectPatch) model.IstioConfigStore {
-	cs := model.MakeIstioStore(memory.Make(collections.Pilot))
+func getEnvoyFilterConfigs(configPatches []*networking.EnvoyFilter_EnvoyConfigObjectPatch) []model.Config {
+	res := []model.Config{}
 	for i, cp := range configPatches {
-		if _, err := cs.Create(model.Config{
+		res = append(res, model.Config{
 			ConfigMeta: model.ConfigMeta{
 				Name:             fmt.Sprintf("test-envoyfilter-%d", i),
 				Namespace:        "not-default",
@@ -597,9 +582,7 @@ func buildEnvoyFilterConfigStore(configPatches []*networking.EnvoyFilter_EnvoyCo
 			},
 			Spec: &networking.EnvoyFilter{
 				ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{cp},
-			}}); err != nil {
-			panic(err.Error())
-		}
+			}})
 	}
-	return cs
+	return res
 }

--- a/pilot/pkg/serviceregistry/memory/discovery.go
+++ b/pilot/pkg/serviceregistry/memory/discovery.go
@@ -157,7 +157,7 @@ func (sd *ServiceDiscovery) AddInstance(service host.Name, instance *model.Servi
 		return
 	}
 	instance.Service = svc
-	sd.ip2instance[instance.Endpoint.Address] = []*model.ServiceInstance{instance}
+	sd.ip2instance[instance.Endpoint.Address] = append(sd.ip2instance[instance.Endpoint.Address], instance)
 
 	key := fmt.Sprintf("%s:%d", service, instance.ServicePort.Port)
 	instanceList := sd.instancesByPortNum[key]

--- a/pilot/test/xdstest/extract.go
+++ b/pilot/test/xdstest/extract.go
@@ -149,6 +149,16 @@ func ExtractEdsClusterNames(cl []*cluster.Cluster) []string {
 	return res
 }
 
+func FilterClusters(cl []*cluster.Cluster, f func(c *cluster.Cluster) bool) []*cluster.Cluster {
+	res := make([]*cluster.Cluster, 0, len(cl))
+	for _, c := range cl {
+		if f(c) {
+			res = append(res, c)
+		}
+	}
+	return res
+}
+
 func ToDiscoveryResponse(p interface{}) *discovery.DiscoveryResponse {
 	slice := InterfaceSlice(p)
 	if len(slice) == 0 {


### PR DESCRIPTION
Use the new ConfigGenTest recently added. In addition, stop doing things like `clusters[7]` - reference by explicit name instead, and migrate some to table driven tests