### PR TITLE
[release-1.7] remove cni initContainers and volumes in remove-from-mesh (#26812)

### DIFF
--- a/istioctl/cmd/kubeuninject.go
+++ b/istioctl/cmd/kubeuninject.go
@@ -329,6 +329,7 @@ func extractObject(in runtime.Object) (interface{}, error) {
 	podSpec.Volumes = removeInjectedVolumes(podSpec.Volumes, certVolumeName)
 	podSpec.Volumes = removeInjectedVolumes(podSpec.Volumes, dataVolumeName)
 	podSpec.Volumes = removeInjectedVolumes(podSpec.Volumes, envoyVolumeName)
+	podSpec.Volumes = removeInjectedVolumes(podSpec.Volumes, jwtTokenVolumeName)
 	podSpec.Volumes = removeInjectedVolumes(podSpec.Volumes, pilotCertVolumeName)
 	podSpec.Volumes = removeInjectedVolumes(podSpec.Volumes, podInfoVolumeName)
 	removeDNSConfig(podSpec.DNSConfig)

--- a/istioctl/cmd/remove-from-mesh.go
+++ b/istioctl/cmd/remove-from-mesh.go
@@ -216,11 +216,15 @@ func unInjectSideCarFromDeployment(client kubernetes.Interface, deps []appsv1.De
 		}
 
 		podSpec.InitContainers = removeInjectedContainers(podSpec.InitContainers, initContainerName)
+		podSpec.InitContainers = removeInjectedContainers(podSpec.InitContainers, initValidationContainerName)
 		podSpec.InitContainers = removeInjectedContainers(podSpec.InitContainers, enableCoreDumpContainerName)
 		podSpec.Containers = removeInjectedContainers(podSpec.Containers, proxyContainerName)
-		podSpec.Volumes = removeInjectedVolumes(podSpec.Volumes, envoyVolumeName)
 		podSpec.Volumes = removeInjectedVolumes(podSpec.Volumes, certVolumeName)
+		podSpec.Volumes = removeInjectedVolumes(podSpec.Volumes, dataVolumeName)
+		podSpec.Volumes = removeInjectedVolumes(podSpec.Volumes, envoyVolumeName)
 		podSpec.Volumes = removeInjectedVolumes(podSpec.Volumes, jwtTokenVolumeName)
+		podSpec.Volumes = removeInjectedVolumes(podSpec.Volumes, pilotCertVolumeName)
+		podSpec.Volumes = removeInjectedVolumes(podSpec.Volumes, podInfoVolumeName)
 		removeDNSConfig(podSpec.DNSConfig)
 		res.Spec.Template.Spec = *podSpec
 		// If we are in an auto-inject namespace, removing the sidecar isn't enough, we

--- a/releasenotes/notes/remove-from-mesh-fix.yaml
+++ b/releasenotes/notes/remove-from-mesh-fix.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+- 26938
+releaseNotes:
+- |
+  **Fixed** remove-from-mesh does not remove the init containers when using Istio CNI


### PR DESCRIPTION
(cherry picked from commit 707b28d8b8e6dac582f55fe40403109f4d3cbb4e)

Manual cherry pick of PR #26812 


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.