### PR TITLE
Update kubeconfig flag for create-remote-secret

### DIFF
--- a/istioctl/pkg/multicluster/remote_secret.go
+++ b/istioctl/pkg/multicluster/remote_secret.go
@@ -91,16 +91,16 @@ func NewCreateRemoteSecretCommand() *cobra.Command {
 		Short: "Create a secret with credentials to allow Istio to access remote Kubernetes apiservers",
 		Example: `
 # Create a secret to access cluster c0's apiserver and install it in cluster c1.
-istioctl --Kubeconfig=c0.yaml x create-remote-secret --name c0 \
-    | kubectl --Kubeconfig=c1.yaml apply -f -
+istioctl --kubeconfig=c0.yaml x create-remote-secret --name c0 \
+    | kubectl --kubeconfig=c1.yaml apply -f -
 
 # Delete a secret that was previously installed in c1
-istioctl --Kubeconfig=c0.yaml x create-remote-secret --name c0 \
-    | kubectl --Kubeconfig=c1.yaml delete -f -
+istioctl --kubeconfig=c0.yaml x create-remote-secret --name c0 \
+    | kubectl --kubeconfig=c1.yaml delete -f -
 
 # Create a secret access a remote cluster with an auth plugin
-istioctl --Kubeconfig=c0.yaml x create-remote-secret --name c0 --auth-type=plugin --auth-plugin-name=gcp \
-    | kubectl --Kubeconfig=c1.yaml apply -f -
+istioctl --kubeconfig=c0.yaml x create-remote-secret --name c0 --auth-type=plugin --auth-plugin-name=gcp \
+    | kubectl --kubeconfig=c1.yaml apply -f -
 `,
 		Args: cobra.NoArgs,
 		RunE: func(c *cobra.Command, args []string) error {

--- a/istioctl/pkg/multicluster/remote_secret_test.go
+++ b/istioctl/pkg/multicluster/remote_secret_test.go
@@ -36,7 +36,7 @@ import (
 const (
 	testNamespace          = "istio-system-test"
 	testServiceAccountName = "test-service-account"
-	testKubeconfig         = "test-Kubeconfig"
+	testKubeconfig         = "test-kubeconfig"
 	testContext            = "test-context"
 	testNetwork            = "test-network"
 )


### PR DESCRIPTION
The flag used across all `istioctl` command is `--kubeconfig` and not `--Kubeconfig`.

https://preliminary.istio.io/latest/docs/reference/commands/istioctl/#istioctl-experimental-create-remote-secret 
