### PR TITLE
cleanup multicluster dump directories

### DIFF
--- a/pkg/test/kube/dump.go
+++ b/pkg/test/kube/dump.go
@@ -39,7 +39,7 @@ func outputPath(workDir string, cluster resource.Cluster, pod kubeApiCore.Pod, n
 	if err := os.MkdirAll(dir, os.ModeDir|0700); err != nil {
 		scopes.Framework.Warnf("failed creating directory: %s", dir)
 	}
-	return path.Join(dir, fmt.Sprintf("%s-%s_%s", pod.Name, pod.Namespace, name))
+	return path.Join(dir, fmt.Sprintf("%s_%s", pod.Name, name))
 }
 
 // DumpPods runs each dumper with all the pods in the given namespace.

--- a/pkg/test/kube/dump.go
+++ b/pkg/test/kube/dump.go
@@ -26,17 +26,25 @@ import (
 	kubeApiCore "k8s.io/api/core/v1"
 	kubeApiMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/scopes"
 )
 
 // podDumper will dump information from all the pods into the given workDir.
 // If no pods are provided, client will be used to fetch all the pods in a namespace.
-type podDumper func(a kube.ExtendedClient, workDir string, namespace string, pods ...kubeApiCore.Pod)
+type podDumper func(a resource.Cluster, workDir string, namespace string, pods ...kubeApiCore.Pod)
+
+func outputPath(workDir string, cluster resource.Cluster, pod kubeApiCore.Pod, name string) string {
+	dir := path.Join(workDir, cluster.Name())
+	if err := os.MkdirAll(dir, os.ModeDir|0700); err != nil {
+		scopes.Framework.Warnf("failed creating directory: %s", dir)
+	}
+	return path.Join(dir, fmt.Sprintf("%s-%s_%s", pod.Name, pod.Namespace, name))
+}
 
 // DumpPods runs each dumper with all the pods in the given namespace.
 // If no dumpers are provided, their resource state, events, container logs and Envoy information will be dumped.
-func DumpPods(a kube.ExtendedClient, workDir, namespace string, dumpers ...podDumper) {
+func DumpPods(a resource.Cluster, workDir, namespace string, dumpers ...podDumper) {
 	if len(dumpers) == 0 {
 		dumpers = []podDumper{
 			DumpPodState,
@@ -57,7 +65,7 @@ func DumpPods(a kube.ExtendedClient, workDir, namespace string, dumpers ...podDu
 	}
 }
 
-func podsOrFetch(a kube.Client, pods []kubeApiCore.Pod, namespace string) []kubeApiCore.Pod {
+func podsOrFetch(a resource.Cluster, pods []kubeApiCore.Pod, namespace string) []kubeApiCore.Pod {
 	if len(pods) == 0 {
 		podList, err := a.CoreV1().Pods(namespace).List(context.TODO(), kubeApiMeta.ListOptions{})
 		if err != nil {
@@ -70,8 +78,8 @@ func podsOrFetch(a kube.Client, pods []kubeApiCore.Pod, namespace string) []kube
 }
 
 // DumpPodState dumps the pod state for either the provided pods or all pods in the namespace if none are provided.
-func DumpPodState(a kube.ExtendedClient, workDir string, namespace string, pods ...kubeApiCore.Pod) {
-	pods = podsOrFetch(a, pods, namespace)
+func DumpPodState(c resource.Cluster, workDir string, namespace string, pods ...kubeApiCore.Pod) {
+	pods = podsOrFetch(c, pods, namespace)
 
 	marshaler := jsonpb.Marshaler{
 		Indent: "  ",
@@ -84,8 +92,7 @@ func DumpPodState(a kube.ExtendedClient, workDir string, namespace string, pods 
 			continue
 		}
 
-		outPath := path.Join(workDir, fmt.Sprintf("pod_%s_%s.yaml", namespace, pod.Name))
-
+		outPath := outputPath(workDir, c, pod, "pod-state.yaml")
 		if err := ioutil.WriteFile(outPath, []byte(str), os.ModePerm); err != nil {
 			scopes.Framework.Infof("Error writing out pod state to file: %v", err)
 		}
@@ -93,7 +100,7 @@ func DumpPodState(a kube.ExtendedClient, workDir string, namespace string, pods 
 }
 
 // DumpPodEvents dumps the pod events for either the provided pods or all pods in the namespace if none are provided.
-func DumpPodEvents(a kube.ExtendedClient, workDir, namespace string, pods ...kubeApiCore.Pod) {
+func DumpPodEvents(c resource.Cluster, workDir, namespace string, pods ...kubeApiCore.Pod) {
 	pods = podsOrFetch(a, pods, namespace)
 
 	marshaler := jsonpb.Marshaler{
@@ -101,7 +108,7 @@ func DumpPodEvents(a kube.ExtendedClient, workDir, namespace string, pods ...kub
 	}
 
 	for _, pod := range pods {
-		list, err := a.CoreV1().Events(namespace).List(context.TODO(),
+		list, err := c.CoreV1().Events(namespace).List(context.TODO(),
 			kubeApiMeta.ListOptions{
 				FieldSelector: "involvedObject.name=" + pod.Name,
 			})
@@ -109,8 +116,6 @@ func DumpPodEvents(a kube.ExtendedClient, workDir, namespace string, pods ...kub
 			scopes.Framework.Errorf("Error getting events list for pod %s/%s via kubectl: %v", namespace, pod.Name, err)
 			return
 		}
-
-		outPath := path.Join(workDir, fmt.Sprintf("pod_events_%s_%s.yaml", namespace, pod.Name))
 
 		eventsStr := ""
 		for _, event := range list.Items {
@@ -124,6 +129,7 @@ func DumpPodEvents(a kube.ExtendedClient, workDir, namespace string, pods ...kub
 			eventsStr += "\n"
 		}
 
+		outPath := outputPath(workDir, c, pod, "pod-events.yaml")
 		if err := ioutil.WriteFile(outPath, []byte(eventsStr), os.ModePerm); err != nil {
 			scopes.Framework.Infof("Error writing out pod events to file: %v", err)
 		}
@@ -132,7 +138,7 @@ func DumpPodEvents(a kube.ExtendedClient, workDir, namespace string, pods ...kub
 
 // DumpPodLogs will dump logs from each container in each of the provided pods
 // or all pods in the namespace if none are provided.
-func DumpPodLogs(a kube.ExtendedClient, workDir, namespace string, pods ...kubeApiCore.Pod) {
+func DumpPodLogs(c resource.Cluster, workDir, namespace string, pods ...kubeApiCore.Pod) {
 	pods = podsOrFetch(a, pods, namespace)
 
 	for _, pod := range pods {
@@ -145,15 +151,15 @@ func DumpPodLogs(a kube.ExtendedClient, workDir, namespace string, pods ...kubeA
 				continue
 			}
 
-			fname := path.Join(workDir, fmt.Sprintf("%s-%s.log", pod.Name, container.Name))
+			fname := outputPath(workDir, c, pod, fmt.Sprintf("%s.log", container.Name))
 			if err = ioutil.WriteFile(fname, []byte(l), os.ModePerm); err != nil {
 				scopes.Framework.Errorf("Unable to write logs for pod/container: %s/%s/%s", pod.Namespace, pod.Name, container.Name)
 			}
 
 			// Get envoy logs if the pod is a VM, since kubectl logs only shows the logs from iptables for VMs
 			if isVM && container.Name == "istio-proxy" {
-				if stdout, stderr, err := a.PodExec(pod.Name, pod.Namespace, container.Name, "cat /var/log/istio/istio.err.log"); err == nil {
-					fname := path.Join(workDir, fmt.Sprintf("%s-%s.envoy.err.log", pod.Name, container.Name))
+				if stdout, stderr, err := c.PodExec(pod.Name, pod.Namespace, container.Name, "cat /var/log/istio/istio.err.log"); err == nil {
+					fname := outputPath(workDir, c, pod, fmt.Sprintf("%s.envoy.err.log", container.Name))
 					if err = ioutil.WriteFile(fname, []byte(stdout+stderr), os.ModePerm); err != nil {
 						scopes.Framework.Errorf("Unable to write envoy err log for pod/container: %s/%s/%s", pod.Namespace, pod.Name, container.Name)
 					}
@@ -162,7 +168,7 @@ func DumpPodLogs(a kube.ExtendedClient, workDir, namespace string, pods ...kubeA
 				}
 
 				if stdout, stderr, err := a.PodExec(pod.Name, pod.Namespace, container.Name, "cat /var/log/istio/istio.log"); err == nil {
-					fname := path.Join(workDir, fmt.Sprintf("%s-%s.envoy.log", pod.Name, container.Name))
+					fname := outputPath(workDir, c, pod, fmt.Sprintf("%s.envoy.log", container.Name))
 					if err = ioutil.WriteFile(fname, []byte(stdout+stderr), os.ModePerm); err != nil {
 						scopes.Framework.Errorf("Unable to write envoy log for pod/container: %s/%s/%s", pod.Namespace, pod.Name, container.Name)
 					}
@@ -176,8 +182,8 @@ func DumpPodLogs(a kube.ExtendedClient, workDir, namespace string, pods ...kubeA
 
 // DumpPodProxies will dump Envoy proxy config and clusters in each of the provided pods
 // or all pods in the namespace if none are provided.
-func DumpPodProxies(a kube.ExtendedClient, workDir, namespace string, pods ...kubeApiCore.Pod) {
-	pods = podsOrFetch(a, pods, namespace)
+func DumpPodProxies(c resource.Cluster, workDir, namespace string, pods ...kubeApiCore.Pod) {
+	pods = podsOrFetch(c, pods, namespace)
 
 	for _, pod := range pods {
 		containers := append(pod.Spec.Containers, pod.Spec.InitContainers...)
@@ -186,8 +192,8 @@ func DumpPodProxies(a kube.ExtendedClient, workDir, namespace string, pods ...ku
 				continue
 			}
 
-			if cfgDump, _, err := a.PodExec(pod.Name, pod.Namespace, container.Name, "pilot-agent request GET config_dump"); err == nil {
-				fname := path.Join(workDir, fmt.Sprintf("%s-%s.config.json", pod.Name, container.Name))
+			if cfgDump, _, err := c.PodExec(pod.Name, pod.Namespace, container.Name, "pilot-agent request GET config_dump"); err == nil {
+				fname := outputPath(workDir, c, pod, "proxy-config.json")
 				if err = ioutil.WriteFile(fname, []byte(cfgDump), os.ModePerm); err != nil {
 					scopes.Framework.Errorf("Unable to write config dump for pod/container: %s/%s/%s", pod.Namespace, pod.Name, container.Name)
 				}
@@ -195,8 +201,8 @@ func DumpPodProxies(a kube.ExtendedClient, workDir, namespace string, pods ...ku
 				scopes.Framework.Errorf("Unable to get istio-proxy config dump for pod: %s/%s", pod.Namespace, pod.Name)
 			}
 
-			if cfgDump, _, err := a.PodExec(pod.Name, pod.Namespace, container.Name, "pilot-agent request GET clusters"); err == nil {
-				fname := path.Join(workDir, fmt.Sprintf("%s-%s.clusters.txt", pod.Name, container.Name))
+			if cfgDump, _, err := c.PodExec(pod.Name, pod.Namespace, container.Name, "pilot-agent request GET clusters"); err == nil {
+				fname := outputPath(workDir, c, pod, "proxy-clusters.txt")
 				if err = ioutil.WriteFile(fname, []byte(cfgDump), os.ModePerm); err != nil {
 					scopes.Framework.Errorf("Unable to write clusters for pod/container: %s/%s/%s", pod.Namespace, pod.Name, container.Name)
 				}


### PR DESCRIPTION
Makes it easier to differentiate similar services/pods across clusters

https://gcsweb.istio.io/gcs/istio-prow/pr-logs/pull/istio_istio/26835/integ-pilot-multicluster-tests_istio/279/artifacts/pilot-6948a88beb67497d94290c327/TestTraffic/sniffing/auto-tcp_a-%3ea_from_cluster-4/_test_context/echo-1-946-state936378166/

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
