### PR TITLE
bad feature labels only fail analyzer

### DIFF
--- a/pkg/test/framework/analyzer.go
+++ b/pkg/test/framework/analyzer.go
@@ -16,9 +16,10 @@ package framework
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-multierror"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/go-multierror"
 
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework/features"

--- a/pkg/test/framework/analyzer.go
+++ b/pkg/test/framework/analyzer.go
@@ -15,6 +15,8 @@
 package framework
 
 import (
+	"fmt"
+	"github.com/hashicorp/go-multierror"
 	"strings"
 	"testing"
 
@@ -154,24 +156,31 @@ func (t *testAnalyzer) Label(labels ...label.Instance) Test {
 }
 
 func (t *testAnalyzer) Features(feats ...features.Feature) Test {
+	if err := addFeatureLabels(t.featureLabels, feats...); err != nil {
+		log.Errorf(err)
+		t.goTest.FailNow()
+	}
+	return t
+}
+
+func addFeatureLabels(featureLabels map[features.Feature][]string, feats ...features.Feature) error {
 	c, err := features.BuildChecker(env.IstioSrc + "/pkg/test/framework/features/features.yaml")
 	if err != nil {
-		log.Errorf("Unable to build feature checker: %s", err)
-		t.goTest.FailNow()
-		return nil
+		return fmt.Errorf("unable to build feature checker: %v", err)
 	}
+
+	err = nil
 	for _, f := range feats {
 		check, scenario := c.Check(f)
 		if !check {
-			log.Errorf("feature %s is not present in /pkg/test/framework/features/features.yaml", f)
-			t.goTest.FailNow()
-			return nil
+			err = multierror.Append(err, fmt.Errorf("feature %s is not a leaf in /pkg/test/framework/features/features.yaml", f))
+			continue
 		}
 		// feats actually contains feature and scenario.  split them here.
 		onlyFeature := features.Feature(strings.Replace(string(f), scenario, "", 1))
-		t.featureLabels[onlyFeature] = append(t.featureLabels[onlyFeature], scenario)
+		featureLabels[onlyFeature] = append(featureLabels[onlyFeature], scenario)
 	}
-	return t
+	return err
 }
 
 func (t *testAnalyzer) NotImplementedYet(features ...features.Feature) Test {

--- a/pkg/test/framework/test.go
+++ b/pkg/test/framework/test.go
@@ -16,12 +16,10 @@ package framework
 
 import (
 	"fmt"
-	"strings"
 	"sync"
 	"testing"
 	"time"
 
-	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework/features"
 	"istio.io/istio/pkg/test/framework/label"
 	"istio.io/istio/pkg/test/scopes"
@@ -147,24 +145,10 @@ func (t *testImpl) Label(labels ...label.Instance) Test {
 }
 
 func (t *testImpl) Features(feats ...features.Feature) Test {
-	c, err := features.BuildChecker(env.IstioSrc + "/pkg/test/framework/features/features.yaml")
-	if err != nil {
-		log.Errorf("Unable to build feature checker: %s", err)
-		t.goTest.FailNow()
-		return nil
+	if err := addFeatureLabels(t.featureLabels, feats...); err != nil {
+		// test runs shouldn't fail
+		log.Errorf(err)
 	}
-	for _, f := range feats {
-		check, scenario := c.Check(f)
-		if !check {
-			log.Errorf("feature %s is not a leaf in /pkg/test/framework/features/features.yaml", f)
-			t.goTest.FailNow()
-			return nil
-		}
-		// feats actually contains feature and scenario.  split them here.
-		onlyFeature := features.Feature(strings.Replace(string(f), scenario, "", 1))
-		t.featureLabels[onlyFeature] = append(t.featureLabels[onlyFeature], scenario)
-	}
-
 	return t
 }
 


### PR DESCRIPTION
Missing feature labels won't fail an actual test, but bad feature labels will. Only the analyzer should fail, actual tests should still run but give a warning. 

The error message about using "leafs" of the features.yaml also gets moved into the analyzer in this PR. 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
