### PR TITLE
Change validation functions to take in model.Config object

### DIFF
--- a/galley/pkg/config/analysis/analyzers/schema/validation.go
+++ b/galley/pkg/config/analysis/analyzers/schema/validation.go
@@ -20,6 +20,7 @@ import (
 
 	"istio.io/istio/galley/pkg/config/analysis"
 	"istio.io/istio/galley/pkg/config/analysis/msg"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/resource"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
@@ -60,7 +61,13 @@ func (a *ValidationAnalyzer) Analyze(ctx analysis.Context) {
 		ns := r.Metadata.FullName.Namespace
 		name := r.Metadata.FullName.Name
 
-		err := a.s.Resource().ValidateConfig(string(name), string(ns), r.Message)
+		err := a.s.Resource().ValidateConfig(config.Config{
+			ConfigMeta: config.ConfigMeta{
+				Name:      string(name),
+				Namespace: string(ns),
+			},
+			Spec: r.Message,
+		})
 		if err != nil {
 			if multiErr, ok := err.(*multierror.Error); ok {
 				for _, err := range multiErr.WrappedErrors() {

--- a/galley/pkg/config/analysis/analyzers/schema/validation.go
+++ b/galley/pkg/config/analysis/analyzers/schema/validation.go
@@ -62,7 +62,7 @@ func (a *ValidationAnalyzer) Analyze(ctx analysis.Context) {
 		name := r.Metadata.FullName.Name
 
 		err := a.s.Resource().ValidateConfig(config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				Name:      string(name),
 				Namespace: string(ns),
 			},

--- a/galley/pkg/config/analysis/analyzers/schema/validation.go
+++ b/galley/pkg/config/analysis/analyzers/schema/validation.go
@@ -60,7 +60,7 @@ func (a *ValidationAnalyzer) Analyze(ctx analysis.Context) {
 		ns := r.Metadata.FullName.Namespace
 		name := r.Metadata.FullName.Name
 
-		err := a.s.Resource().ValidateProto(string(name), string(ns), r.Message)
+		err := a.s.Resource().ValidateConfig(string(name), string(ns), r.Message)
 		if err != nil {
 			if multiErr, ok := err.(*multierror.Error); ok {
 				for _, err := range multiErr.WrappedErrors() {

--- a/galley/pkg/config/source/kube/rt/dynamic_test.go
+++ b/galley/pkg/config/source/kube/rt/dynamic_test.go
@@ -27,7 +27,7 @@ import (
 	"istio.io/istio/galley/pkg/config/source/kube/rt"
 	"istio.io/istio/galley/pkg/config/testing/basicmeta"
 	"istio.io/istio/galley/pkg/config/testing/data"
-	"istio.io/istio/pkg/config/schema/resource"
+	"istio.io/istio/pkg/config"
 )
 
 func TestParseDynamic(t *testing.T) {
@@ -91,7 +91,7 @@ func parseDynamic(t *testing.T, input []byte, kind string) (metaV1.Object, proto
 	g := NewWithT(t)
 
 	pr := rt.DefaultProvider()
-	a := pr.GetAdapter(basicmeta.MustGet().KubeCollections().MustFindByGroupVersionKind(resource.GroupVersionKind{
+	a := pr.GetAdapter(basicmeta.MustGet().KubeCollections().MustFindByGroupVersionKind(config.GroupVersionKind{
 		Group:   "testdata.istio.io",
 		Version: "v1alpha1",
 		Kind:    kind,

--- a/galley/pkg/config/source/kube/rt/known_test.go
+++ b/galley/pkg/config/source/kube/rt/known_test.go
@@ -28,7 +28,7 @@ import (
 	"istio.io/istio/galley/pkg/config/source/kube/rt"
 	"istio.io/istio/galley/pkg/config/testing/data"
 	"istio.io/istio/galley/pkg/config/testing/k8smeta"
-	"istio.io/istio/pkg/config/schema/resource"
+	"istio.io/istio/pkg/config"
 )
 
 func TestParse(t *testing.T) {
@@ -178,7 +178,7 @@ func parse(t *testing.T, input []byte, group, kind, version string) (metaV1.Obje
 	g := NewWithT(t)
 
 	pr := rt.DefaultProvider()
-	a := pr.GetAdapter(k8smeta.MustGet().KubeCollections().MustFindByGroupVersionKind(resource.GroupVersionKind{
+	a := pr.GetAdapter(k8smeta.MustGet().KubeCollections().MustFindByGroupVersionKind(config.GroupVersionKind{
 		Group:   group,
 		Version: version,
 		Kind:    kind,

--- a/istioctl/cmd/convert_ingress.go
+++ b/istioctl/cmd/convert_ingress.go
@@ -30,7 +30,7 @@ import (
 	"istio.io/istio/istioctl/pkg/clioptions"
 	"istio.io/istio/istioctl/pkg/convert"
 	"istio.io/istio/pilot/pkg/config/kube/crd"
-	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/validation"
 	"istio.io/pkg/log"
@@ -58,7 +58,7 @@ func convertConfigs(readers []io.Reader, writer io.Writer, client kubernetes.Int
 		}
 	}
 
-	out := make([]model.Config, 0)
+	out := make([]config.Config, 0)
 	convertedIngresses, err := convert.IstioIngresses(ingresses, "", client)
 	if err == nil {
 		out = append(out, convertedIngresses...)
@@ -75,8 +75,8 @@ func convertConfigs(readers []io.Reader, writer io.Writer, client kubernetes.Int
 	return nil
 }
 
-func readConfigs(readers []io.Reader) ([]model.Config, []*v1beta1.Ingress, error) {
-	out := make([]model.Config, 0, len(readers))
+func readConfigs(readers []io.Reader) ([]config.Config, []*v1beta1.Ingress, error) {
+	out := make([]config.Config, 0, len(readers))
 	outIngresses := make([]*v1beta1.Ingress, 0)
 
 	for _, reader := range readers {
@@ -128,7 +128,7 @@ func readConfigs(readers []io.Reader) ([]model.Config, []*v1beta1.Ingress, error
 	return out, outIngresses, nil
 }
 
-func writeYAMLOutput(configs []model.Config, writer io.Writer) {
+func writeYAMLOutput(configs []config.Config, writer io.Writer) {
 	for i, cfg := range configs {
 		obj, err := crd.ConvertConfig(cfg)
 		if err != nil {
@@ -147,7 +147,7 @@ func writeYAMLOutput(configs []model.Config, writer io.Writer) {
 	}
 }
 
-func validateConfigs(configs []model.Config) error {
+func validateConfigs(configs []config.Config) error {
 	var errs error
 	for _, cfg := range configs {
 		if collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind() == cfg.GroupVersionKind {

--- a/istioctl/cmd/convert_ingress.go
+++ b/istioctl/cmd/convert_ingress.go
@@ -151,7 +151,7 @@ func validateConfigs(configs []config.Config) error {
 	var errs error
 	for _, cfg := range configs {
 		if collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind() == cfg.GroupVersionKind {
-			if err := validation.ValidateVirtualService(cfg.Name, cfg.Namespace, cfg.Spec); err != nil {
+			if err := validation.ValidateVirtualService(cfg); err != nil {
 				errs = multierror.Append(err, errs)
 			}
 		}

--- a/istioctl/cmd/describe.go
+++ b/istioctl/cmd/describe.go
@@ -50,6 +50,7 @@ import (
 	authz_model "istio.io/istio/pilot/pkg/security/authz/model"
 	pilotcontroller "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
@@ -293,7 +294,7 @@ func httpRouteMatchSvc(vs clientnetworking.VirtualService, route *v1alpha3.HTTPR
 	mismatchNotes := []string{}
 	match := false
 	for _, dest := range route.Route {
-		fqdn := string(model.ResolveShortnameToFQDN(dest.Destination.Host, model.ConfigMeta{Namespace: vs.Namespace}))
+		fqdn := string(model.ResolveShortnameToFQDN(dest.Destination.Host, config.ConfigMeta{Namespace: vs.Namespace}))
 		if extendFQDN(fqdn) == svcHost {
 			if dest.Destination.Subset != "" {
 				if contains(nonmatchingSubsets, dest.Destination.Subset) {
@@ -354,7 +355,7 @@ func tcpRouteMatchSvc(vs clientnetworking.VirtualService, route *v1alpha3.TCPRou
 	facts := []string{}
 	svcHost := extendFQDN(fmt.Sprintf("%s.%s", svc.ObjectMeta.Name, svc.ObjectMeta.Namespace))
 	for _, dest := range route.Route {
-		fqdn := string(model.ResolveShortnameToFQDN(dest.Destination.Host, model.ConfigMeta{Namespace: vs.Namespace}))
+		fqdn := string(model.ResolveShortnameToFQDN(dest.Destination.Host, config.ConfigMeta{Namespace: vs.Namespace}))
 		if extendFQDN(fqdn) == svcHost {
 			match = true
 		}

--- a/istioctl/cmd/describe.go
+++ b/istioctl/cmd/describe.go
@@ -294,7 +294,7 @@ func httpRouteMatchSvc(vs clientnetworking.VirtualService, route *v1alpha3.HTTPR
 	mismatchNotes := []string{}
 	match := false
 	for _, dest := range route.Route {
-		fqdn := string(model.ResolveShortnameToFQDN(dest.Destination.Host, config.ConfigMeta{Namespace: vs.Namespace}))
+		fqdn := string(model.ResolveShortnameToFQDN(dest.Destination.Host, config.Meta{Namespace: vs.Namespace}))
 		if extendFQDN(fqdn) == svcHost {
 			if dest.Destination.Subset != "" {
 				if contains(nonmatchingSubsets, dest.Destination.Subset) {
@@ -355,7 +355,7 @@ func tcpRouteMatchSvc(vs clientnetworking.VirtualService, route *v1alpha3.TCPRou
 	facts := []string{}
 	svcHost := extendFQDN(fmt.Sprintf("%s.%s", svc.ObjectMeta.Name, svc.ObjectMeta.Namespace))
 	for _, dest := range route.Route {
-		fqdn := string(model.ResolveShortnameToFQDN(dest.Destination.Host, config.ConfigMeta{Namespace: vs.Namespace}))
+		fqdn := string(model.ResolveShortnameToFQDN(dest.Destination.Host, config.Meta{Namespace: vs.Namespace}))
 		if extendFQDN(fqdn) == svcHost {
 			match = true
 		}

--- a/istioctl/cmd/wait.go
+++ b/istioctl/cmd/wait.go
@@ -30,8 +30,8 @@ import (
 
 	"istio.io/istio/istioctl/pkg/clioptions"
 	"istio.io/istio/istioctl/pkg/util/handlers"
-	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/xds"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/kube"
@@ -92,7 +92,7 @@ istioctl experimental wait --for=distribution --threshold=.99 --timeout=300 virt
 				return fmt.Errorf("unable to retrieve Kubernetes resource %s: %v", "", err)
 			}
 			resourceVersions := []string{firstVersion}
-			targetResource := model.Key(targetSchema.Resource().Kind(), nameflag, namespace)
+			targetResource := config.Key(targetSchema.Resource().Kind(), nameflag, namespace)
 			for {
 				//run the check here as soon as we start
 				// because tickers won't run immediately

--- a/istioctl/pkg/convert/ingress.go
+++ b/istioctl/pkg/convert/ingress.go
@@ -21,25 +21,25 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"istio.io/istio/pilot/pkg/config/kube/ingress"
-	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 )
 
 // IstioIngresses converts K8s extensions/v1beta1 Ingresses with Istio rules to v1alpha3 gateway and virtual service
-func IstioIngresses(ingresses []*v1beta1.Ingress, domainSuffix string, client kubernetes.Interface) ([]model.Config, error) {
+func IstioIngresses(ingresses []*v1beta1.Ingress, domainSuffix string, client kubernetes.Interface) ([]config.Config, error) {
 
 	if len(ingresses) == 0 {
-		return make([]model.Config, 0), nil
+		return make([]config.Config, 0), nil
 	}
 	if len(domainSuffix) == 0 {
 		domainSuffix = constants.DefaultKubernetesDomain
 	}
-	ingressByHost := map[string]*model.Config{}
+	ingressByHost := map[string]*config.Config{}
 	for _, ingrezz := range ingresses {
 		ingress.ConvertIngressVirtualService(*ingrezz, domainSuffix, ingressByHost, &serviceListerWrapper{client: client})
 	}
 
-	out := make([]model.Config, 0, len(ingressByHost))
+	out := make([]config.Config, 0, len(ingressByHost))
 	for _, vs := range ingressByHost {
 		// Ensure name is valid; ConvertIngressVirtualService will create a name that doesn't start with alphanumeric
 		if strings.HasPrefix(vs.Name, "-") {

--- a/istioctl/pkg/validate/validate.go
+++ b/istioctl/pkg/validate/validate.go
@@ -98,7 +98,7 @@ func (v *validator) validateResource(istioNamespace string, un *unstructured.Uns
 		if err = checkFields(un); err != nil {
 			return err
 		}
-		return schema.Resource().ValidateProto(obj.Name, obj.Namespace, obj.Spec)
+		return schema.Resource().ValidateConfig(obj.Name, obj.Namespace, obj.Spec)
 	}
 
 	var errs error

--- a/istioctl/pkg/validate/validate.go
+++ b/istioctl/pkg/validate/validate.go
@@ -348,7 +348,7 @@ func convertObjectFromUnstructured(schema collection.Schema, un *unstructured.Un
 	}
 
 	return &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind:  schema.Resource().GroupVersionKind(),
 			Name:              un.GetName(),
 			Namespace:         un.GetNamespace(),

--- a/istioctl/pkg/validate/validate.go
+++ b/istioctl/pkg/validate/validate.go
@@ -33,12 +33,11 @@ import (
 	"istio.io/istio/operator/pkg/name"
 	"istio.io/istio/operator/pkg/util"
 	operator_validate "istio.io/istio/operator/pkg/validate"
-	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
-	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/istio/pkg/url"
 	"istio.io/istio/pkg/util/gogoprotomarshal"
 	"istio.io/pkg/log"
@@ -79,7 +78,7 @@ func checkFields(un *unstructured.Unstructured) error {
 }
 
 func (v *validator) validateResource(istioNamespace string, un *unstructured.Unstructured) error {
-	gvk := resource.GroupVersionKind{
+	gvk := config.GroupVersionKind{
 		Group:   un.GroupVersionKind().Group,
 		Version: un.GroupVersionKind().Version,
 		Kind:    un.GroupVersionKind().Kind,
@@ -342,14 +341,14 @@ func handleNamespace(istioNamespace string) string {
 }
 
 // TODO(nmittler): Remove this once Pilot migrates to galley schema.
-func convertObjectFromUnstructured(schema collection.Schema, un *unstructured.Unstructured, domain string) (*model.Config, error) {
+func convertObjectFromUnstructured(schema collection.Schema, un *unstructured.Unstructured, domain string) (*config.Config, error) {
 	data, err := fromSchemaAndJSONMap(schema, un.Object["spec"])
 	if err != nil {
 		return nil, err
 	}
 
-	return &model.Config{
-		ConfigMeta: model.ConfigMeta{
+	return &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind:  schema.Resource().GroupVersionKind(),
 			Name:              un.GetName(),
 			Namespace:         un.GetNamespace(),

--- a/istioctl/pkg/validate/validate.go
+++ b/istioctl/pkg/validate/validate.go
@@ -97,7 +97,7 @@ func (v *validator) validateResource(istioNamespace string, un *unstructured.Uns
 		if err = checkFields(un); err != nil {
 			return err
 		}
-		return schema.Resource().ValidateConfig(obj.Name, obj.Namespace, obj.Spec)
+		return schema.Resource().ValidateConfig(*obj)
 	}
 
 	var errs error

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -50,6 +50,7 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
 	"istio.io/istio/pilot/pkg/status"
 	"istio.io/istio/pilot/pkg/xds"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
@@ -840,7 +841,7 @@ func (s *Server) initRegistryEventHandlers() error {
 	}
 
 	if s.configController != nil {
-		configHandler := func(_, curr model.Config, event model.Event) {
+		configHandler := func(_, curr config.Config, event model.Event) {
 			pushReq := &model.PushRequest{
 				Full: true,
 				ConfigsUpdated: map[model.ConfigKey]struct{}{{

--- a/pilot/pkg/config/aggregate/config_test.go
+++ b/pilot/pkg/config/aggregate/config_test.go
@@ -71,7 +71,7 @@ func TestAggregateStoreGet(t *testing.T) {
 	store2 := memory.Make(collection.SchemasFor(collections.K8SServiceApisV1Alpha1Gatewayclasses))
 
 	configReturn := &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: collections.K8SServiceApisV1Alpha1Gatewayclasses.Resource().GroupVersionKind(),
 			Name:             "other",
 		},
@@ -95,7 +95,7 @@ func TestAggregateStoreList(t *testing.T) {
 	store2 := memory.Make(collection.SchemasFor(collections.K8SServiceApisV1Alpha1Httproutes))
 
 	if _, err := store1.Create(config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: collections.K8SServiceApisV1Alpha1Httproutes.Resource().GroupVersionKind(),
 			Name:             "other",
 		},
@@ -103,7 +103,7 @@ func TestAggregateStoreList(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := store2.Create(config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: collections.K8SServiceApisV1Alpha1Httproutes.Resource().GroupVersionKind(),
 			Name:             "another",
 		},
@@ -181,7 +181,7 @@ func TestAggregateStoreCache(t *testing.T) {
 		})
 
 		controller1.Create(config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind: collections.K8SServiceApisV1Alpha1Httproutes.Resource().GroupVersionKind(),
 				Name:             "another",
 			},

--- a/pilot/pkg/config/aggregate/config_test.go
+++ b/pilot/pkg/config/aggregate/config_test.go
@@ -27,6 +27,7 @@ import (
 	"istio.io/istio/pilot/pkg/config/aggregate"
 	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/resource"
@@ -69,8 +70,8 @@ func TestAggregateStoreGet(t *testing.T) {
 	store1 := memory.Make(collection.SchemasFor(collections.K8SServiceApisV1Alpha1Gatewayclasses))
 	store2 := memory.Make(collection.SchemasFor(collections.K8SServiceApisV1Alpha1Gatewayclasses))
 
-	configReturn := &model.Config{
-		ConfigMeta: model.ConfigMeta{
+	configReturn := &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: collections.K8SServiceApisV1Alpha1Gatewayclasses.Resource().GroupVersionKind(),
 			Name:             "other",
 		},
@@ -93,16 +94,16 @@ func TestAggregateStoreList(t *testing.T) {
 	store1 := memory.Make(collection.SchemasFor(collections.K8SServiceApisV1Alpha1Httproutes))
 	store2 := memory.Make(collection.SchemasFor(collections.K8SServiceApisV1Alpha1Httproutes))
 
-	if _, err := store1.Create(model.Config{
-		ConfigMeta: model.ConfigMeta{
+	if _, err := store1.Create(config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: collections.K8SServiceApisV1Alpha1Httproutes.Resource().GroupVersionKind(),
 			Name:             "other",
 		},
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := store2.Create(model.Config{
-		ConfigMeta: model.ConfigMeta{
+	if _, err := store2.Create(config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: collections.K8SServiceApisV1Alpha1Httproutes.Resource().GroupVersionKind(),
 			Name:             "another",
 		},
@@ -133,14 +134,14 @@ func TestAggregateStoreFails(t *testing.T) {
 	t.Run("Fails to Delete", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
-		err = store.Delete(resource.GroupVersionKind{Kind: "not"}, "gonna", "work")
+		err = store.Delete(config.GroupVersionKind{Kind: "not"}, "gonna", "work")
 		g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("unsupported operation")))
 	})
 
 	t.Run("Fails to Create", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
-		c, err := store.Create(model.Config{})
+		c, err := store.Create(config.Config{})
 		g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("unsupported operation")))
 		g.Expect(c).To(gomega.BeEmpty())
 	})
@@ -148,7 +149,7 @@ func TestAggregateStoreFails(t *testing.T) {
 	t.Run("Fails to Update", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
-		c, err := store.Update(model.Config{})
+		c, err := store.Update(config.Config{})
 		g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("unsupported operation")))
 		g.Expect(c).To(gomega.BeEmpty())
 	})
@@ -175,12 +176,12 @@ func TestAggregateStoreCache(t *testing.T) {
 
 	t.Run("it registers an event handler", func(t *testing.T) {
 		handled := atomic.NewBool(false)
-		cacheStore.RegisterEventHandler(collections.K8SServiceApisV1Alpha1Httproutes.Resource().GroupVersionKind(), func(model.Config, model.Config, model.Event) {
+		cacheStore.RegisterEventHandler(collections.K8SServiceApisV1Alpha1Httproutes.Resource().GroupVersionKind(), func(config.Config, config.Config, model.Event) {
 			handled.Store(true)
 		})
 
-		controller1.Create(model.Config{
-			ConfigMeta: model.ConfigMeta{
+		controller1.Create(config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind: collections.K8SServiceApisV1Alpha1Httproutes.Resource().GroupVersionKind(),
 				Name:             "another",
 			},

--- a/pilot/pkg/config/kube/crd/conversion.go
+++ b/pilot/pkg/config/kube/crd/conversion.go
@@ -27,7 +27,7 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeyaml "k8s.io/apimachinery/pkg/util/yaml"
 
-	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/resource"
@@ -75,7 +75,7 @@ func FromJSONMap(s collection.Schema, data interface{}) (proto.Message, error) {
 }
 
 // ConvertObject converts an IstioObject k8s-style object to the internal configuration model.
-func ConvertObject(schema collection.Schema, object IstioObject, domain string) (*model.Config, error) {
+func ConvertObject(schema collection.Schema, object IstioObject, domain string) (*config.Config, error) {
 	js, err := json.Marshal(object.GetSpec())
 	if err != nil {
 		return nil, err
@@ -86,8 +86,8 @@ func ConvertObject(schema collection.Schema, object IstioObject, domain string) 
 	}
 	meta := object.GetObjectMeta()
 
-	return &model.Config{
-		ConfigMeta: model.ConfigMeta{
+	return &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind:  schema.Resource().GroupVersionKind(),
 			Name:              meta.Name,
 			Namespace:         meta.Namespace,
@@ -102,7 +102,7 @@ func ConvertObject(schema collection.Schema, object IstioObject, domain string) 
 }
 
 // ConvertConfig translates Istio config to k8s config JSON
-func ConvertConfig(cfg model.Config) (IstioObject, error) {
+func ConvertConfig(cfg config.Config) (IstioObject, error) {
 	spec, err := gogoprotomarshal.ToJSONMap(cfg.Spec)
 	if err != nil {
 		return nil, err
@@ -133,8 +133,8 @@ func ConvertConfig(cfg model.Config) (IstioObject, error) {
 // information to the abstract model and/or elevating k8s
 // representation to first-class type to avoid extra conversions.
 
-func parseInputsImpl(inputs string, withValidate bool) ([]model.Config, []IstioKind, error) {
-	var varr []model.Config
+func parseInputsImpl(inputs string, withValidate bool) ([]config.Config, []IstioKind, error) {
+	var varr []config.Config
 	var others []IstioKind
 	reader := bytes.NewReader([]byte(inputs))
 	var empty = IstioKind{}
@@ -187,6 +187,6 @@ func parseInputsImpl(inputs string, withValidate bool) ([]model.Config, []IstioK
 // ObjectMeta as identified by the fields in model.ConfigMeta. This
 // would typically only be a problem if a user dumps an configuration
 // object with kubectl and then re-ingests it.
-func ParseInputs(inputs string) ([]model.Config, []IstioKind, error) {
+func ParseInputs(inputs string) ([]config.Config, []IstioKind, error) {
 	return parseInputsImpl(inputs, true)
 }

--- a/pilot/pkg/config/kube/crd/conversion.go
+++ b/pilot/pkg/config/kube/crd/conversion.go
@@ -168,7 +168,7 @@ func parseInputsImpl(inputs string, withValidate bool) ([]model.Config, []IstioK
 		}
 
 		if withValidate {
-			if err := s.Resource().ValidateProto(cfg.Name, cfg.Namespace, cfg.Spec); err != nil {
+			if err := s.Resource().ValidateConfig(cfg.Name, cfg.Namespace, cfg.Spec); err != nil {
 				return nil, nil, fmt.Errorf("configuration is invalid: %v", err)
 			}
 		}

--- a/pilot/pkg/config/kube/crd/conversion.go
+++ b/pilot/pkg/config/kube/crd/conversion.go
@@ -87,7 +87,7 @@ func ConvertObject(schema collection.Schema, object IstioObject, domain string) 
 	meta := object.GetObjectMeta()
 
 	return &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind:  schema.Resource().GroupVersionKind(),
 			Name:              meta.Name,
 			Namespace:         meta.Namespace,
@@ -184,7 +184,7 @@ func parseInputsImpl(inputs string, withValidate bool) ([]config.Config, []Istio
 // response.
 //
 // NOTE: This function only decodes a subset of the complete k8s
-// ObjectMeta as identified by the fields in model.ConfigMeta. This
+// ObjectMeta as identified by the fields in model.Meta. This
 // would typically only be a problem if a user dumps an configuration
 // object with kubectl and then re-ingests it.
 func ParseInputs(inputs string) ([]config.Config, []IstioKind, error) {

--- a/pilot/pkg/config/kube/crd/conversion.go
+++ b/pilot/pkg/config/kube/crd/conversion.go
@@ -168,7 +168,7 @@ func parseInputsImpl(inputs string, withValidate bool) ([]config.Config, []Istio
 		}
 
 		if withValidate {
-			if err := s.Resource().ValidateConfig(cfg.Name, cfg.Namespace, cfg.Spec); err != nil {
+			if err := s.Resource().ValidateConfig(*cfg); err != nil {
 				return nil, nil, fmt.Errorf("configuration is invalid: %v", err)
 			}
 		}

--- a/pilot/pkg/config/kube/crd/conversion_test.go
+++ b/pilot/pkg/config/kube/crd/conversion_test.go
@@ -31,7 +31,7 @@ func TestConvert(t *testing.T) {
 		t.Errorf("error for converting object: %s", err)
 	}
 	config := config2.Config{
-		ConfigMeta: config2.ConfigMeta{
+		Meta: config2.Meta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "test",
 			Namespace:        "default",

--- a/pilot/pkg/config/kube/crd/conversion_test.go
+++ b/pilot/pkg/config/kube/crd/conversion_test.go
@@ -18,20 +18,20 @@ import (
 	"reflect"
 	"testing"
 
-	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/test/mock"
+	config2 "istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
 )
 
 func TestConvert(t *testing.T) {
-	if _, err := ConvertConfig(model.Config{}); err == nil {
+	if _, err := ConvertConfig(config2.Config{}); err == nil {
 		t.Errorf("expected error for converting empty config")
 	}
 	if _, err := ConvertObject(collections.IstioNetworkingV1Alpha3Virtualservices, &IstioKind{Spec: map[string]interface{}{"x": 1}}, "local"); err != nil {
 		t.Errorf("error for converting object: %s", err)
 	}
-	config := model.Config{
-		ConfigMeta: model.ConfigMeta{
+	config := config2.Config{
+		ConfigMeta: config2.ConfigMeta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "test",
 			Namespace:        "default",

--- a/pilot/pkg/config/kube/crdclient/cache_handler.go
+++ b/pilot/pkg/config/kube/crdclient/cache_handler.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/pkg/log"
 )
@@ -37,7 +38,7 @@ import (
 type cacheHandler struct {
 	client   *Client
 	informer cache.SharedIndexInformer
-	handlers []func(model.Config, model.Config, model.Event)
+	handlers []func(config.Config, config.Config, model.Event)
 	schema   collection.Schema
 	lister   func(namespace string) cache.GenericNamespaceLister
 }
@@ -54,7 +55,7 @@ func (h *cacheHandler) onEvent(old interface{}, curr interface{}, event model.Ev
 	}
 	currConfig := *TranslateObject(currItem, h.schema.Resource().GroupVersionKind(), h.client.domainSuffix)
 
-	var oldConfig model.Config
+	var oldConfig config.Config
 	if old != nil {
 		oldItem, ok := old.(runtime.Object)
 		if !ok {

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -195,7 +195,7 @@ func (cl *Client) Get(typ config.GroupVersionKind, name, namespace string) *conf
 	}
 	if features.EnableCRDValidation {
 		schema, _ := cl.Schemas().FindByGroupVersionKind(typ)
-		if err = schema.Resource().ValidateConfig(cfg.Name, cfg.Namespace, cfg.Spec); err != nil {
+		if err = schema.Resource().ValidateConfig(*cfg); err != nil {
 			handleValidationFailure(cfg, err)
 			return nil
 		}
@@ -251,7 +251,7 @@ func (cl *Client) List(kind config.GroupVersionKind, namespace string) ([]config
 		cfg := TranslateObject(item, kind, cl.domainSuffix)
 		if features.EnableCRDValidation {
 			schema, _ := cl.Schemas().FindByGroupVersionKind(kind)
-			if err = schema.Resource().ValidateConfig(cfg.Name, cfg.Namespace, cfg.Spec); err != nil {
+			if err = schema.Resource().ValidateConfig(*cfg); err != nil {
 				handleValidationFailure(cfg, err)
 				// DO NOT RETURN ERROR: if a single object is bad, it'll be ignored (with a log message), but
 				// the rest should still be processed.

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -195,7 +195,7 @@ func (cl *Client) Get(typ resource.GroupVersionKind, name, namespace string) *mo
 	}
 	if features.EnableCRDValidation {
 		schema, _ := cl.Schemas().FindByGroupVersionKind(typ)
-		if err = schema.Resource().ValidateProto(cfg.Name, cfg.Namespace, cfg.Spec); err != nil {
+		if err = schema.Resource().ValidateConfig(cfg.Name, cfg.Namespace, cfg.Spec); err != nil {
 			handleValidationFailure(cfg, err)
 			return nil
 		}
@@ -251,7 +251,7 @@ func (cl *Client) List(kind resource.GroupVersionKind, namespace string) ([]mode
 		cfg := TranslateObject(item, kind, cl.domainSuffix)
 		if features.EnableCRDValidation {
 			schema, _ := cl.Schemas().FindByGroupVersionKind(kind)
-			if err = schema.Resource().ValidateProto(cfg.Name, cfg.Namespace, cfg.Spec); err != nil {
+			if err = schema.Resource().ValidateConfig(cfg.Name, cfg.Namespace, cfg.Spec); err != nil {
 				handleValidationFailure(cfg, err)
 				// DO NOT RETURN ERROR: if a single object is bad, it'll be ignored (with a log message), but
 				// the rest should still be processed.

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -48,9 +48,9 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	controller2 "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
-	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/queue"
 	"istio.io/pkg/ledger"
@@ -76,7 +76,7 @@ type Client struct {
 	revision string
 
 	// kinds keeps track of all cache handlers for known types
-	kinds map[resource.GroupVersionKind]*cacheHandler
+	kinds map[config.GroupVersionKind]*cacheHandler
 	queue queue.Instance
 
 	// The istio/client-go client we will use to access objects
@@ -100,7 +100,7 @@ func (cl *Client) checkReadyForEvents(curr interface{}) error {
 	return nil
 }
 
-func (cl *Client) RegisterEventHandler(kind resource.GroupVersionKind, handler func(model.Config, model.Config, model.Event)) {
+func (cl *Client) RegisterEventHandler(kind config.GroupVersionKind, handler func(config.Config, config.Config, model.Event)) {
 	h, exists := cl.kinds[kind]
 	if !exists {
 		return
@@ -141,7 +141,7 @@ func New(client kube.Client, configLedger ledger.Ledger, revision string, option
 		schemas:           collections.PilotServiceApi,
 		revision:          revision,
 		queue:             queue.NewQueue(1 * time.Second),
-		kinds:             map[resource.GroupVersionKind]*cacheHandler{},
+		kinds:             map[config.GroupVersionKind]*cacheHandler{},
 		istioClient:       client.Istio(),
 		serviceApisClient: client.ServiceApis(),
 	}
@@ -175,7 +175,7 @@ func (cl *Client) Schemas() collection.Schemas {
 }
 
 // Get implements store interface
-func (cl *Client) Get(typ resource.GroupVersionKind, name, namespace string) *model.Config {
+func (cl *Client) Get(typ config.GroupVersionKind, name, namespace string) *config.Config {
 	h, f := cl.kinds[typ]
 	if !f {
 		scope.Warnf("unknown type: %s", typ)
@@ -205,7 +205,7 @@ func (cl *Client) Get(typ resource.GroupVersionKind, name, namespace string) *mo
 }
 
 // Create implements store interface
-func (cl *Client) Create(config model.Config) (string, error) {
+func (cl *Client) Create(config config.Config) (string, error) {
 	if config.Spec == nil {
 		return "", fmt.Errorf("nil spec for %v/%v", config.Name, config.Namespace)
 	}
@@ -218,7 +218,7 @@ func (cl *Client) Create(config model.Config) (string, error) {
 }
 
 // Update implements store interface
-func (cl *Client) Update(config model.Config) (string, error) {
+func (cl *Client) Update(config config.Config) (string, error) {
 	if config.Spec == nil {
 		return "", fmt.Errorf("nil spec for %v/%v", config.Name, config.Namespace)
 	}
@@ -231,12 +231,12 @@ func (cl *Client) Update(config model.Config) (string, error) {
 }
 
 // Delete implements store interface
-func (cl *Client) Delete(typ resource.GroupVersionKind, name, namespace string) error {
+func (cl *Client) Delete(typ config.GroupVersionKind, name, namespace string) error {
 	return delete(cl.istioClient, cl.serviceApisClient, typ, name, namespace)
 }
 
 // List implements store interface
-func (cl *Client) List(kind resource.GroupVersionKind, namespace string) ([]model.Config, error) {
+func (cl *Client) List(kind config.GroupVersionKind, namespace string) ([]config.Config, error) {
 	h, f := cl.kinds[kind]
 	if !f {
 		return nil, nil
@@ -246,7 +246,7 @@ func (cl *Client) List(kind resource.GroupVersionKind, namespace string) ([]mode
 	if err != nil {
 		return nil, err
 	}
-	out := make([]model.Config, 0, len(list))
+	out := make([]config.Config, 0, len(list))
 	for _, item := range list {
 		cfg := TranslateObject(item, kind, cl.domainSuffix)
 		if features.EnableCRDValidation {
@@ -268,7 +268,7 @@ func (cl *Client) List(kind resource.GroupVersionKind, namespace string) ([]mode
 	return out, err
 }
 
-func (cl *Client) objectInRevision(o *model.Config) bool {
+func (cl *Client) objectInRevision(o *config.Config) bool {
 	configEnv, f := o.Labels[label.IstioRev]
 	if !f {
 		// This is a global object, and always included
@@ -304,7 +304,7 @@ func knownCRDs(crdClient apiextensionsclient.Interface) map[string]struct{} {
 	return mp
 }
 
-func TranslateObject(r runtime.Object, gvk resource.GroupVersionKind, domainSuffix string) *model.Config {
+func TranslateObject(r runtime.Object, gvk config.GroupVersionKind, domainSuffix string) *config.Config {
 	translateFunc, f := translationMap[gvk]
 	if !f {
 		scope.Errorf("unknown type %v", gvk)
@@ -315,7 +315,7 @@ func TranslateObject(r runtime.Object, gvk resource.GroupVersionKind, domainSuff
 	return c
 }
 
-func getObjectMetadata(config model.Config) metav1.ObjectMeta {
+func getObjectMetadata(config config.Config) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
 		Name:        config.Name,
 		Namespace:   config.Namespace,

--- a/pilot/pkg/config/kube/crdclient/client_test.go
+++ b/pilot/pkg/config/kube/crdclient/client_test.go
@@ -27,6 +27,7 @@ import (
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/kube"
@@ -67,7 +68,7 @@ func TestClientNoCRDs(t *testing.T) {
 		return nil
 	}, retry.Timeout(time.Second))
 	r := collections.IstioNetworkingV1Alpha3Virtualservices.Resource()
-	configMeta := model.ConfigMeta{
+	configMeta := config.ConfigMeta{
 		Name:             "name",
 		Namespace:        "ns",
 		GroupVersionKind: r.GroupVersionKind(),
@@ -77,7 +78,7 @@ func TestClientNoCRDs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := store.Create(model.Config{
+	if _, err := store.Create(config.Config{
 		ConfigMeta: configMeta,
 		Spec:       pb,
 	}); err != nil {
@@ -114,7 +115,7 @@ func TestClient(t *testing.T) {
 		name := c.Resource().Kind()
 		t.Run(name, func(t *testing.T) {
 			r := c.Resource()
-			configMeta := model.ConfigMeta{
+			configMeta := config.ConfigMeta{
 				GroupVersionKind: r.GroupVersionKind(),
 				Name:             configName,
 			}
@@ -127,7 +128,7 @@ func TestClient(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if _, err := store.Create(model.Config{
+			if _, err := store.Create(config.Config{
 				ConfigMeta: configMeta,
 				Spec:       pb,
 			}); err != nil {

--- a/pilot/pkg/config/kube/crdclient/client_test.go
+++ b/pilot/pkg/config/kube/crdclient/client_test.go
@@ -68,7 +68,7 @@ func TestClientNoCRDs(t *testing.T) {
 		return nil
 	}, retry.Timeout(time.Second))
 	r := collections.IstioNetworkingV1Alpha3Virtualservices.Resource()
-	configMeta := config.ConfigMeta{
+	configMeta := config.Meta{
 		Name:             "name",
 		Namespace:        "ns",
 		GroupVersionKind: r.GroupVersionKind(),
@@ -79,8 +79,8 @@ func TestClientNoCRDs(t *testing.T) {
 	}
 
 	if _, err := store.Create(config.Config{
-		ConfigMeta: configMeta,
-		Spec:       pb,
+		Meta: configMeta,
+		Spec: pb,
 	}); err != nil {
 		t.Fatalf("Create => got %v", err)
 	}
@@ -115,7 +115,7 @@ func TestClient(t *testing.T) {
 		name := c.Resource().Kind()
 		t.Run(name, func(t *testing.T) {
 			r := c.Resource()
-			configMeta := config.ConfigMeta{
+			configMeta := config.Meta{
 				GroupVersionKind: r.GroupVersionKind(),
 				Name:             configName,
 			}
@@ -129,15 +129,15 @@ func TestClient(t *testing.T) {
 			}
 
 			if _, err := store.Create(config.Config{
-				ConfigMeta: configMeta,
-				Spec:       pb,
+				Meta: configMeta,
+				Spec: pb,
 			}); err != nil {
 				t.Fatalf("Create(%v) => got %v", name, err)
 			}
 			// Kubernetes is eventually consistent, so we allow a short time to pass before we get
 			retry.UntilSuccessOrFail(t, func() error {
 				cfg := store.Get(r.GroupVersionKind(), configName, configMeta.Namespace)
-				if cfg == nil || !reflect.DeepEqual(cfg.ConfigMeta, configMeta) {
+				if cfg == nil || !reflect.DeepEqual(cfg.Meta, configMeta) {
 					return fmt.Errorf("get(%v) => got unexpected object %v", name, cfg)
 				}
 				return nil
@@ -153,7 +153,7 @@ func TestClient(t *testing.T) {
 					return fmt.Errorf("expected 1 config, got %v", len(cfgs))
 				}
 				for _, cfg := range cfgs {
-					if !reflect.DeepEqual(cfg.ConfigMeta, configMeta) {
+					if !reflect.DeepEqual(cfg.Meta, configMeta) {
 						return fmt.Errorf("get(%v) => got %v", name, cfg)
 					}
 				}

--- a/pilot/pkg/config/kube/crdclient/gen/types.go.tmpl
+++ b/pilot/pkg/config/kube/crdclient/gen/types.go.tmpl
@@ -30,7 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	serviceapisclient "sigs.k8s.io/service-apis/pkg/client/clientset/versioned"
 
-	"istio.io/istio/pilot/pkg/model"
+	config "istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/resource"
 
@@ -42,35 +42,35 @@ import (
 	servicev1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
 )
 
-func create(ic versionedclient.Interface, sc serviceapisclient.Interface, config model.Config, objMeta metav1.ObjectMeta) (metav1.Object, error) {
-	switch config.GroupVersionKind {
+func create(ic versionedclient.Interface, sc serviceapisclient.Interface, cfg config.Config, objMeta metav1.ObjectMeta) (metav1.Object, error) {
+	switch cfg.GroupVersionKind {
 {{- range . }}
 	case collections.{{ .VariableName }}.Resource().GroupVersionKind():
-		return {{.Client}}.{{ .ClientGroupPath }}().{{ .ClientTypePath }}({{if .Namespaced}}config.Namespace{{end}}).Create(context.TODO(), &{{ .ClientImport }}.{{ .Kind }}{
+		return {{.Client}}.{{ .ClientGroupPath }}().{{ .ClientTypePath }}({{if .Namespaced}}cfg.Namespace{{end}}).Create(context.TODO(), &{{ .ClientImport }}.{{ .Kind }}{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*{{ .APIImport }}.{{ .Kind }}{{ .TypeSuffix }})),
+			Spec:       *(cfg.Spec.(*{{ .APIImport }}.{{ .Kind }}{{ .TypeSuffix }})),
 		}, metav1.CreateOptions{})
 {{- end }}
 	default:
-		return nil, fmt.Errorf("unsupported type: %v", config.GroupVersionKind)
+		return nil, fmt.Errorf("unsupported type: %v", cfg.GroupVersionKind)
 	}
 }
 
-func update(ic versionedclient.Interface, sc serviceapisclient.Interface, config model.Config, objMeta metav1.ObjectMeta) (metav1.Object, error) {
-	switch config.GroupVersionKind {
+func update(ic versionedclient.Interface, sc serviceapisclient.Interface, cfg config.Config, objMeta metav1.ObjectMeta) (metav1.Object, error) {
+	switch cfg.GroupVersionKind {
 {{- range . }}
 	case collections.{{ .VariableName }}.Resource().GroupVersionKind():
-		return {{.Client}}.{{ .ClientGroupPath }}().{{ .ClientTypePath }}({{if .Namespaced}}config.Namespace{{end}}).Update(context.TODO(), &{{ .ClientImport }}.{{ .Kind }}{
+		return {{.Client}}.{{ .ClientGroupPath }}().{{ .ClientTypePath }}({{if .Namespaced}}cfg.Namespace{{end}}).Update(context.TODO(), &{{ .ClientImport }}.{{ .Kind }}{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*{{ .APIImport }}.{{ .Kind }}{{ .TypeSuffix }})),
+			Spec:       *(cfg.Spec.(*{{ .APIImport }}.{{ .Kind }}{{ .TypeSuffix }})),
 		}, metav1.UpdateOptions{})
 {{- end }}
 	default:
-		return nil, fmt.Errorf("unsupported type: %v", config.GroupVersionKind)
+		return nil, fmt.Errorf("unsupported type: %v", cfg.GroupVersionKind)
 	}
 }
 
-func delete(ic versionedclient.Interface, sc serviceapisclient.Interface, typ resource.GroupVersionKind, name, namespace string) error {
+func delete(ic versionedclient.Interface, sc serviceapisclient.Interface, typ config.GroupVersionKind, name, namespace string) error {
 	switch typ {
 {{- range . }}
 	case collections.{{ .VariableName }}.Resource().GroupVersionKind():
@@ -81,12 +81,12 @@ func delete(ic versionedclient.Interface, sc serviceapisclient.Interface, typ re
 	}
 }
 
-var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model.Config{
+var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.Config{
 {{- range . }}
-	collections.{{ .VariableName }}.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+	collections.{{ .VariableName }}.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*{{ .ClientImport }}.{{ .Kind }})
-		return &model.Config{
-		ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+		Meta: config.Meta{
 			GroupVersionKind:  collections.{{ .VariableName }}.Resource().GroupVersionKind(),
 			Name:              obj.Name,
 			Namespace:         obj.Namespace,

--- a/pilot/pkg/config/kube/crdclient/gen/types.go.tmpl
+++ b/pilot/pkg/config/kube/crdclient/gen/types.go.tmpl
@@ -32,7 +32,6 @@ import (
 
 	config "istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
-	"istio.io/istio/pkg/config/schema/resource"
 
 	networkingv1alpha3 "istio.io/api/networking/v1alpha3"
 	securityv1beta1 "istio.io/api/security/v1beta1"

--- a/pilot/pkg/config/kube/crdclient/ledger.go
+++ b/pilot/pkg/config/kube/crdclient/ledger.go
@@ -20,7 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
-	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config"
 	"istio.io/pkg/ledger"
 	"istio.io/pkg/log"
 )
@@ -63,7 +63,7 @@ func (cl *Client) tryLedgerPut(obj interface{}, kind string) {
 		log.Errora(err)
 		return
 	}
-	key := model.Key(kind, iobj.GetName(), iobj.GetNamespace())
+	key := config.Key(kind, iobj.GetName(), iobj.GetNamespace())
 	if _, err := cl.configLedger.Put(key, iobj.GetResourceVersion()); err != nil {
 		scope.Errorf("Failed to update %s in ledger, status will be out of date.", key)
 	}
@@ -75,7 +75,7 @@ func (cl *Client) tryLedgerDelete(obj interface{}, kind string) {
 		log.Errora(err)
 		return
 	}
-	key := model.Key(kind, iobj.GetName(), iobj.GetNamespace())
+	key := config.Key(kind, iobj.GetName(), iobj.GetNamespace())
 	if err := cl.configLedger.Delete(key); err != nil {
 		scope.Errorf("Failed to delete %s in ledger, status will be out of date.", key)
 	}

--- a/pilot/pkg/config/kube/crdclient/metrics.go
+++ b/pilot/pkg/config/kube/crdclient/metrics.go
@@ -15,7 +15,7 @@
 package crdclient
 
 import (
-	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config"
 	"istio.io/pkg/monitoring"
 )
 
@@ -52,7 +52,7 @@ func incrementEvent(kind, event string) {
 	k8sEvents.With(typeTag.Value(kind), eventTag.Value(event)).Increment()
 }
 
-func handleValidationFailure(obj *model.Config, err error) {
+func handleValidationFailure(obj *config.Config, err error) {
 	key := obj.Namespace + "/" + obj.Name
 	scope.Debugf("CRD validation failed: %s (%v): %v", key, obj.GroupVersionKind, err)
 	k8sErrors.With(nameTag.Value(key)).Record(1)

--- a/pilot/pkg/config/kube/crdclient/types.gen.go
+++ b/pilot/pkg/config/kube/crdclient/types.gen.go
@@ -30,13 +30,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	serviceapisclient "sigs.k8s.io/service-apis/pkg/client/clientset/versioned"
 
+	config "istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/resource"
+
 	networkingv1alpha3 "istio.io/api/networking/v1alpha3"
 	securityv1beta1 "istio.io/api/security/v1beta1"
 	clientnetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	clientsecurityv1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
-
-	config "istio.io/istio/pkg/config"
-	"istio.io/istio/pkg/config/schema/collections"
 
 	servicev1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
 )

--- a/pilot/pkg/config/kube/crdclient/types.gen.go
+++ b/pilot/pkg/config/kube/crdclient/types.gen.go
@@ -246,7 +246,7 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 	collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientnetworkingv1alpha3.DestinationRule)
 		return &config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -261,7 +261,7 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 	collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientnetworkingv1alpha3.EnvoyFilter)
 		return &config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -276,7 +276,7 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 	collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientnetworkingv1alpha3.Gateway)
 		return &config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -291,7 +291,7 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 	collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientnetworkingv1alpha3.ServiceEntry)
 		return &config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -306,7 +306,7 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 	collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientnetworkingv1alpha3.Sidecar)
 		return &config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -321,7 +321,7 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 	collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientnetworkingv1alpha3.VirtualService)
 		return &config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -336,7 +336,7 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 	collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientnetworkingv1alpha3.WorkloadEntry)
 		return &config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -351,7 +351,7 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 	collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientnetworkingv1alpha3.WorkloadGroup)
 		return &config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -366,7 +366,7 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 	collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientsecurityv1beta1.AuthorizationPolicy)
 		return &config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -381,7 +381,7 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 	collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientsecurityv1beta1.PeerAuthentication)
 		return &config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -396,7 +396,7 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 	collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientsecurityv1beta1.RequestAuthentication)
 		return &config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -411,7 +411,7 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 	collections.K8SServiceApisV1Alpha1Gatewayclasses.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*servicev1alpha1.GatewayClass)
 		return &config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.K8SServiceApisV1Alpha1Gatewayclasses.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -426,7 +426,7 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 	collections.K8SServiceApisV1Alpha1Gateways.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*servicev1alpha1.Gateway)
 		return &config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.K8SServiceApisV1Alpha1Gateways.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -441,7 +441,7 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 	collections.K8SServiceApisV1Alpha1Httproutes.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*servicev1alpha1.HTTPRoute)
 		return &config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.K8SServiceApisV1Alpha1Httproutes.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -456,7 +456,7 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 	collections.K8SServiceApisV1Alpha1Tcproutes.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*servicev1alpha1.TCPRoute)
 		return &config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.K8SServiceApisV1Alpha1Tcproutes.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,

--- a/pilot/pkg/config/kube/crdclient/types.gen.go
+++ b/pilot/pkg/config/kube/crdclient/types.gen.go
@@ -30,19 +30,18 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	serviceapisclient "sigs.k8s.io/service-apis/pkg/client/clientset/versioned"
 
-	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pkg/config/schema/collections"
-	"istio.io/istio/pkg/config/schema/resource"
-
 	networkingv1alpha3 "istio.io/api/networking/v1alpha3"
 	securityv1beta1 "istio.io/api/security/v1beta1"
 	clientnetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	clientsecurityv1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
 
+	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/schema/collections"
+
 	servicev1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
 )
 
-func create(ic versionedclient.Interface, sc serviceapisclient.Interface, config model.Config, objMeta metav1.ObjectMeta) (metav1.Object, error) {
+func create(ic versionedclient.Interface, sc serviceapisclient.Interface, config config.Config, objMeta metav1.ObjectMeta) (metav1.Object, error) {
 	switch config.GroupVersionKind {
 	case collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind():
 		return ic.NetworkingV1alpha3().DestinationRules(config.Namespace).Create(context.TODO(), &clientnetworkingv1alpha3.DestinationRule{
@@ -124,7 +123,7 @@ func create(ic versionedclient.Interface, sc serviceapisclient.Interface, config
 	}
 }
 
-func update(ic versionedclient.Interface, sc serviceapisclient.Interface, config model.Config, objMeta metav1.ObjectMeta) (metav1.Object, error) {
+func update(ic versionedclient.Interface, sc serviceapisclient.Interface, config config.Config, objMeta metav1.ObjectMeta) (metav1.Object, error) {
 	switch config.GroupVersionKind {
 	case collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind():
 		return ic.NetworkingV1alpha3().DestinationRules(config.Namespace).Update(context.TODO(), &clientnetworkingv1alpha3.DestinationRule{
@@ -206,7 +205,7 @@ func update(ic versionedclient.Interface, sc serviceapisclient.Interface, config
 	}
 }
 
-func delete(ic versionedclient.Interface, sc serviceapisclient.Interface, typ resource.GroupVersionKind, name, namespace string) error {
+func delete(ic versionedclient.Interface, sc serviceapisclient.Interface, typ config.GroupVersionKind, name, namespace string) error {
 	switch typ {
 	case collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind():
 		return ic.NetworkingV1alpha3().DestinationRules(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
@@ -243,11 +242,11 @@ func delete(ic versionedclient.Interface, sc serviceapisclient.Interface, typ re
 	}
 }
 
-var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model.Config{
-	collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.Config{
+	collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientnetworkingv1alpha3.DestinationRule)
-		return &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -259,10 +258,10 @@ var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model
 			Spec: &obj.Spec,
 		}
 	},
-	collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+	collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientnetworkingv1alpha3.EnvoyFilter)
-		return &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -274,10 +273,10 @@ var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model
 			Spec: &obj.Spec,
 		}
 	},
-	collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+	collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientnetworkingv1alpha3.Gateway)
-		return &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -289,10 +288,10 @@ var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model
 			Spec: &obj.Spec,
 		}
 	},
-	collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+	collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientnetworkingv1alpha3.ServiceEntry)
-		return &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -304,10 +303,10 @@ var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model
 			Spec: &obj.Spec,
 		}
 	},
-	collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+	collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientnetworkingv1alpha3.Sidecar)
-		return &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -319,10 +318,10 @@ var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model
 			Spec: &obj.Spec,
 		}
 	},
-	collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+	collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientnetworkingv1alpha3.VirtualService)
-		return &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -334,10 +333,10 @@ var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model
 			Spec: &obj.Spec,
 		}
 	},
-	collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+	collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientnetworkingv1alpha3.WorkloadEntry)
-		return &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -349,10 +348,10 @@ var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model
 			Spec: &obj.Spec,
 		}
 	},
-	collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+	collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientnetworkingv1alpha3.WorkloadGroup)
-		return &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -364,10 +363,10 @@ var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model
 			Spec: &obj.Spec,
 		}
 	},
-	collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+	collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientsecurityv1beta1.AuthorizationPolicy)
-		return &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind:  collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -379,10 +378,10 @@ var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model
 			Spec: &obj.Spec,
 		}
 	},
-	collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+	collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientsecurityv1beta1.PeerAuthentication)
-		return &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind:  collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -394,10 +393,10 @@ var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model
 			Spec: &obj.Spec,
 		}
 	},
-	collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+	collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientsecurityv1beta1.RequestAuthentication)
-		return &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind:  collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -409,10 +408,10 @@ var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model
 			Spec: &obj.Spec,
 		}
 	},
-	collections.K8SServiceApisV1Alpha1Gatewayclasses.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+	collections.K8SServiceApisV1Alpha1Gatewayclasses.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*servicev1alpha1.GatewayClass)
-		return &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind:  collections.K8SServiceApisV1Alpha1Gatewayclasses.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -424,10 +423,10 @@ var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model
 			Spec: &obj.Spec,
 		}
 	},
-	collections.K8SServiceApisV1Alpha1Gateways.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+	collections.K8SServiceApisV1Alpha1Gateways.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*servicev1alpha1.Gateway)
-		return &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind:  collections.K8SServiceApisV1Alpha1Gateways.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -439,10 +438,10 @@ var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model
 			Spec: &obj.Spec,
 		}
 	},
-	collections.K8SServiceApisV1Alpha1Httproutes.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+	collections.K8SServiceApisV1Alpha1Httproutes.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*servicev1alpha1.HTTPRoute)
-		return &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind:  collections.K8SServiceApisV1Alpha1Httproutes.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -454,10 +453,10 @@ var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model
 			Spec: &obj.Spec,
 		}
 	},
-	collections.K8SServiceApisV1Alpha1Tcproutes.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+	collections.K8SServiceApisV1Alpha1Tcproutes.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*servicev1alpha1.TCPRoute)
-		return &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind:  collections.K8SServiceApisV1Alpha1Tcproutes.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,

--- a/pilot/pkg/config/kube/crdclient/types.gen.go
+++ b/pilot/pkg/config/kube/crdclient/types.gen.go
@@ -30,183 +30,182 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	serviceapisclient "sigs.k8s.io/service-apis/pkg/client/clientset/versioned"
 
-	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pkg/config/schema/collections"
-	"istio.io/istio/pkg/config/schema/resource"
-
 	networkingv1alpha3 "istio.io/api/networking/v1alpha3"
 	securityv1beta1 "istio.io/api/security/v1beta1"
 	clientnetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	clientsecurityv1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
 
+	config "istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/schema/collections"
+
 	servicev1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
 )
 
-func create(ic versionedclient.Interface, sc serviceapisclient.Interface, config model.Config, objMeta metav1.ObjectMeta) (metav1.Object, error) {
-	switch config.GroupVersionKind {
+func create(ic versionedclient.Interface, sc serviceapisclient.Interface, cfg config.Config, objMeta metav1.ObjectMeta) (metav1.Object, error) {
+	switch cfg.GroupVersionKind {
 	case collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind():
-		return ic.NetworkingV1alpha3().DestinationRules(config.Namespace).Create(context.TODO(), &clientnetworkingv1alpha3.DestinationRule{
+		return ic.NetworkingV1alpha3().DestinationRules(cfg.Namespace).Create(context.TODO(), &clientnetworkingv1alpha3.DestinationRule{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*networkingv1alpha3.DestinationRule)),
+			Spec:       *(cfg.Spec.(*networkingv1alpha3.DestinationRule)),
 		}, metav1.CreateOptions{})
 	case collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind():
-		return ic.NetworkingV1alpha3().EnvoyFilters(config.Namespace).Create(context.TODO(), &clientnetworkingv1alpha3.EnvoyFilter{
+		return ic.NetworkingV1alpha3().EnvoyFilters(cfg.Namespace).Create(context.TODO(), &clientnetworkingv1alpha3.EnvoyFilter{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*networkingv1alpha3.EnvoyFilter)),
+			Spec:       *(cfg.Spec.(*networkingv1alpha3.EnvoyFilter)),
 		}, metav1.CreateOptions{})
 	case collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind():
-		return ic.NetworkingV1alpha3().Gateways(config.Namespace).Create(context.TODO(), &clientnetworkingv1alpha3.Gateway{
+		return ic.NetworkingV1alpha3().Gateways(cfg.Namespace).Create(context.TODO(), &clientnetworkingv1alpha3.Gateway{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*networkingv1alpha3.Gateway)),
+			Spec:       *(cfg.Spec.(*networkingv1alpha3.Gateway)),
 		}, metav1.CreateOptions{})
 	case collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind():
-		return ic.NetworkingV1alpha3().ServiceEntries(config.Namespace).Create(context.TODO(), &clientnetworkingv1alpha3.ServiceEntry{
+		return ic.NetworkingV1alpha3().ServiceEntries(cfg.Namespace).Create(context.TODO(), &clientnetworkingv1alpha3.ServiceEntry{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*networkingv1alpha3.ServiceEntry)),
+			Spec:       *(cfg.Spec.(*networkingv1alpha3.ServiceEntry)),
 		}, metav1.CreateOptions{})
 	case collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind():
-		return ic.NetworkingV1alpha3().Sidecars(config.Namespace).Create(context.TODO(), &clientnetworkingv1alpha3.Sidecar{
+		return ic.NetworkingV1alpha3().Sidecars(cfg.Namespace).Create(context.TODO(), &clientnetworkingv1alpha3.Sidecar{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*networkingv1alpha3.Sidecar)),
+			Spec:       *(cfg.Spec.(*networkingv1alpha3.Sidecar)),
 		}, metav1.CreateOptions{})
 	case collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind():
-		return ic.NetworkingV1alpha3().VirtualServices(config.Namespace).Create(context.TODO(), &clientnetworkingv1alpha3.VirtualService{
+		return ic.NetworkingV1alpha3().VirtualServices(cfg.Namespace).Create(context.TODO(), &clientnetworkingv1alpha3.VirtualService{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*networkingv1alpha3.VirtualService)),
+			Spec:       *(cfg.Spec.(*networkingv1alpha3.VirtualService)),
 		}, metav1.CreateOptions{})
 	case collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind():
-		return ic.NetworkingV1alpha3().WorkloadEntries(config.Namespace).Create(context.TODO(), &clientnetworkingv1alpha3.WorkloadEntry{
+		return ic.NetworkingV1alpha3().WorkloadEntries(cfg.Namespace).Create(context.TODO(), &clientnetworkingv1alpha3.WorkloadEntry{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*networkingv1alpha3.WorkloadEntry)),
+			Spec:       *(cfg.Spec.(*networkingv1alpha3.WorkloadEntry)),
 		}, metav1.CreateOptions{})
 	case collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind():
-		return ic.NetworkingV1alpha3().WorkloadGroups(config.Namespace).Create(context.TODO(), &clientnetworkingv1alpha3.WorkloadGroup{
+		return ic.NetworkingV1alpha3().WorkloadGroups(cfg.Namespace).Create(context.TODO(), &clientnetworkingv1alpha3.WorkloadGroup{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*networkingv1alpha3.WorkloadGroup)),
+			Spec:       *(cfg.Spec.(*networkingv1alpha3.WorkloadGroup)),
 		}, metav1.CreateOptions{})
 	case collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind():
-		return ic.SecurityV1beta1().AuthorizationPolicies(config.Namespace).Create(context.TODO(), &clientsecurityv1beta1.AuthorizationPolicy{
+		return ic.SecurityV1beta1().AuthorizationPolicies(cfg.Namespace).Create(context.TODO(), &clientsecurityv1beta1.AuthorizationPolicy{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*securityv1beta1.AuthorizationPolicy)),
+			Spec:       *(cfg.Spec.(*securityv1beta1.AuthorizationPolicy)),
 		}, metav1.CreateOptions{})
 	case collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind():
-		return ic.SecurityV1beta1().PeerAuthentications(config.Namespace).Create(context.TODO(), &clientsecurityv1beta1.PeerAuthentication{
+		return ic.SecurityV1beta1().PeerAuthentications(cfg.Namespace).Create(context.TODO(), &clientsecurityv1beta1.PeerAuthentication{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*securityv1beta1.PeerAuthentication)),
+			Spec:       *(cfg.Spec.(*securityv1beta1.PeerAuthentication)),
 		}, metav1.CreateOptions{})
 	case collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind():
-		return ic.SecurityV1beta1().RequestAuthentications(config.Namespace).Create(context.TODO(), &clientsecurityv1beta1.RequestAuthentication{
+		return ic.SecurityV1beta1().RequestAuthentications(cfg.Namespace).Create(context.TODO(), &clientsecurityv1beta1.RequestAuthentication{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*securityv1beta1.RequestAuthentication)),
+			Spec:       *(cfg.Spec.(*securityv1beta1.RequestAuthentication)),
 		}, metav1.CreateOptions{})
 	case collections.K8SServiceApisV1Alpha1Gatewayclasses.Resource().GroupVersionKind():
 		return sc.NetworkingV1alpha1().GatewayClasses().Create(context.TODO(), &servicev1alpha1.GatewayClass{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*servicev1alpha1.GatewayClassSpec)),
+			Spec:       *(cfg.Spec.(*servicev1alpha1.GatewayClassSpec)),
 		}, metav1.CreateOptions{})
 	case collections.K8SServiceApisV1Alpha1Gateways.Resource().GroupVersionKind():
-		return sc.NetworkingV1alpha1().Gateways(config.Namespace).Create(context.TODO(), &servicev1alpha1.Gateway{
+		return sc.NetworkingV1alpha1().Gateways(cfg.Namespace).Create(context.TODO(), &servicev1alpha1.Gateway{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*servicev1alpha1.GatewaySpec)),
+			Spec:       *(cfg.Spec.(*servicev1alpha1.GatewaySpec)),
 		}, metav1.CreateOptions{})
 	case collections.K8SServiceApisV1Alpha1Httproutes.Resource().GroupVersionKind():
-		return sc.NetworkingV1alpha1().HTTPRoutes(config.Namespace).Create(context.TODO(), &servicev1alpha1.HTTPRoute{
+		return sc.NetworkingV1alpha1().HTTPRoutes(cfg.Namespace).Create(context.TODO(), &servicev1alpha1.HTTPRoute{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*servicev1alpha1.HTTPRouteSpec)),
+			Spec:       *(cfg.Spec.(*servicev1alpha1.HTTPRouteSpec)),
 		}, metav1.CreateOptions{})
 	case collections.K8SServiceApisV1Alpha1Tcproutes.Resource().GroupVersionKind():
-		return sc.NetworkingV1alpha1().TCPRoutes(config.Namespace).Create(context.TODO(), &servicev1alpha1.TCPRoute{
+		return sc.NetworkingV1alpha1().TCPRoutes(cfg.Namespace).Create(context.TODO(), &servicev1alpha1.TCPRoute{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*servicev1alpha1.TCPRouteSpec)),
+			Spec:       *(cfg.Spec.(*servicev1alpha1.TCPRouteSpec)),
 		}, metav1.CreateOptions{})
 	default:
-		return nil, fmt.Errorf("unsupported type: %v", config.GroupVersionKind)
+		return nil, fmt.Errorf("unsupported type: %v", cfg.GroupVersionKind)
 	}
 }
 
-func update(ic versionedclient.Interface, sc serviceapisclient.Interface, config model.Config, objMeta metav1.ObjectMeta) (metav1.Object, error) {
-	switch config.GroupVersionKind {
+func update(ic versionedclient.Interface, sc serviceapisclient.Interface, cfg config.Config, objMeta metav1.ObjectMeta) (metav1.Object, error) {
+	switch cfg.GroupVersionKind {
 	case collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind():
-		return ic.NetworkingV1alpha3().DestinationRules(config.Namespace).Update(context.TODO(), &clientnetworkingv1alpha3.DestinationRule{
+		return ic.NetworkingV1alpha3().DestinationRules(cfg.Namespace).Update(context.TODO(), &clientnetworkingv1alpha3.DestinationRule{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*networkingv1alpha3.DestinationRule)),
+			Spec:       *(cfg.Spec.(*networkingv1alpha3.DestinationRule)),
 		}, metav1.UpdateOptions{})
 	case collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind():
-		return ic.NetworkingV1alpha3().EnvoyFilters(config.Namespace).Update(context.TODO(), &clientnetworkingv1alpha3.EnvoyFilter{
+		return ic.NetworkingV1alpha3().EnvoyFilters(cfg.Namespace).Update(context.TODO(), &clientnetworkingv1alpha3.EnvoyFilter{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*networkingv1alpha3.EnvoyFilter)),
+			Spec:       *(cfg.Spec.(*networkingv1alpha3.EnvoyFilter)),
 		}, metav1.UpdateOptions{})
 	case collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind():
-		return ic.NetworkingV1alpha3().Gateways(config.Namespace).Update(context.TODO(), &clientnetworkingv1alpha3.Gateway{
+		return ic.NetworkingV1alpha3().Gateways(cfg.Namespace).Update(context.TODO(), &clientnetworkingv1alpha3.Gateway{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*networkingv1alpha3.Gateway)),
+			Spec:       *(cfg.Spec.(*networkingv1alpha3.Gateway)),
 		}, metav1.UpdateOptions{})
 	case collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind():
-		return ic.NetworkingV1alpha3().ServiceEntries(config.Namespace).Update(context.TODO(), &clientnetworkingv1alpha3.ServiceEntry{
+		return ic.NetworkingV1alpha3().ServiceEntries(cfg.Namespace).Update(context.TODO(), &clientnetworkingv1alpha3.ServiceEntry{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*networkingv1alpha3.ServiceEntry)),
+			Spec:       *(cfg.Spec.(*networkingv1alpha3.ServiceEntry)),
 		}, metav1.UpdateOptions{})
 	case collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind():
-		return ic.NetworkingV1alpha3().Sidecars(config.Namespace).Update(context.TODO(), &clientnetworkingv1alpha3.Sidecar{
+		return ic.NetworkingV1alpha3().Sidecars(cfg.Namespace).Update(context.TODO(), &clientnetworkingv1alpha3.Sidecar{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*networkingv1alpha3.Sidecar)),
+			Spec:       *(cfg.Spec.(*networkingv1alpha3.Sidecar)),
 		}, metav1.UpdateOptions{})
 	case collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind():
-		return ic.NetworkingV1alpha3().VirtualServices(config.Namespace).Update(context.TODO(), &clientnetworkingv1alpha3.VirtualService{
+		return ic.NetworkingV1alpha3().VirtualServices(cfg.Namespace).Update(context.TODO(), &clientnetworkingv1alpha3.VirtualService{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*networkingv1alpha3.VirtualService)),
+			Spec:       *(cfg.Spec.(*networkingv1alpha3.VirtualService)),
 		}, metav1.UpdateOptions{})
 	case collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind():
-		return ic.NetworkingV1alpha3().WorkloadEntries(config.Namespace).Update(context.TODO(), &clientnetworkingv1alpha3.WorkloadEntry{
+		return ic.NetworkingV1alpha3().WorkloadEntries(cfg.Namespace).Update(context.TODO(), &clientnetworkingv1alpha3.WorkloadEntry{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*networkingv1alpha3.WorkloadEntry)),
+			Spec:       *(cfg.Spec.(*networkingv1alpha3.WorkloadEntry)),
 		}, metav1.UpdateOptions{})
 	case collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind():
-		return ic.NetworkingV1alpha3().WorkloadGroups(config.Namespace).Update(context.TODO(), &clientnetworkingv1alpha3.WorkloadGroup{
+		return ic.NetworkingV1alpha3().WorkloadGroups(cfg.Namespace).Update(context.TODO(), &clientnetworkingv1alpha3.WorkloadGroup{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*networkingv1alpha3.WorkloadGroup)),
+			Spec:       *(cfg.Spec.(*networkingv1alpha3.WorkloadGroup)),
 		}, metav1.UpdateOptions{})
 	case collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind():
-		return ic.SecurityV1beta1().AuthorizationPolicies(config.Namespace).Update(context.TODO(), &clientsecurityv1beta1.AuthorizationPolicy{
+		return ic.SecurityV1beta1().AuthorizationPolicies(cfg.Namespace).Update(context.TODO(), &clientsecurityv1beta1.AuthorizationPolicy{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*securityv1beta1.AuthorizationPolicy)),
+			Spec:       *(cfg.Spec.(*securityv1beta1.AuthorizationPolicy)),
 		}, metav1.UpdateOptions{})
 	case collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind():
-		return ic.SecurityV1beta1().PeerAuthentications(config.Namespace).Update(context.TODO(), &clientsecurityv1beta1.PeerAuthentication{
+		return ic.SecurityV1beta1().PeerAuthentications(cfg.Namespace).Update(context.TODO(), &clientsecurityv1beta1.PeerAuthentication{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*securityv1beta1.PeerAuthentication)),
+			Spec:       *(cfg.Spec.(*securityv1beta1.PeerAuthentication)),
 		}, metav1.UpdateOptions{})
 	case collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind():
-		return ic.SecurityV1beta1().RequestAuthentications(config.Namespace).Update(context.TODO(), &clientsecurityv1beta1.RequestAuthentication{
+		return ic.SecurityV1beta1().RequestAuthentications(cfg.Namespace).Update(context.TODO(), &clientsecurityv1beta1.RequestAuthentication{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*securityv1beta1.RequestAuthentication)),
+			Spec:       *(cfg.Spec.(*securityv1beta1.RequestAuthentication)),
 		}, metav1.UpdateOptions{})
 	case collections.K8SServiceApisV1Alpha1Gatewayclasses.Resource().GroupVersionKind():
 		return sc.NetworkingV1alpha1().GatewayClasses().Update(context.TODO(), &servicev1alpha1.GatewayClass{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*servicev1alpha1.GatewayClassSpec)),
+			Spec:       *(cfg.Spec.(*servicev1alpha1.GatewayClassSpec)),
 		}, metav1.UpdateOptions{})
 	case collections.K8SServiceApisV1Alpha1Gateways.Resource().GroupVersionKind():
-		return sc.NetworkingV1alpha1().Gateways(config.Namespace).Update(context.TODO(), &servicev1alpha1.Gateway{
+		return sc.NetworkingV1alpha1().Gateways(cfg.Namespace).Update(context.TODO(), &servicev1alpha1.Gateway{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*servicev1alpha1.GatewaySpec)),
+			Spec:       *(cfg.Spec.(*servicev1alpha1.GatewaySpec)),
 		}, metav1.UpdateOptions{})
 	case collections.K8SServiceApisV1Alpha1Httproutes.Resource().GroupVersionKind():
-		return sc.NetworkingV1alpha1().HTTPRoutes(config.Namespace).Update(context.TODO(), &servicev1alpha1.HTTPRoute{
+		return sc.NetworkingV1alpha1().HTTPRoutes(cfg.Namespace).Update(context.TODO(), &servicev1alpha1.HTTPRoute{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*servicev1alpha1.HTTPRouteSpec)),
+			Spec:       *(cfg.Spec.(*servicev1alpha1.HTTPRouteSpec)),
 		}, metav1.UpdateOptions{})
 	case collections.K8SServiceApisV1Alpha1Tcproutes.Resource().GroupVersionKind():
-		return sc.NetworkingV1alpha1().TCPRoutes(config.Namespace).Update(context.TODO(), &servicev1alpha1.TCPRoute{
+		return sc.NetworkingV1alpha1().TCPRoutes(cfg.Namespace).Update(context.TODO(), &servicev1alpha1.TCPRoute{
 			ObjectMeta: objMeta,
-			Spec:       *(config.Spec.(*servicev1alpha1.TCPRouteSpec)),
+			Spec:       *(cfg.Spec.(*servicev1alpha1.TCPRouteSpec)),
 		}, metav1.UpdateOptions{})
 	default:
-		return nil, fmt.Errorf("unsupported type: %v", config.GroupVersionKind)
+		return nil, fmt.Errorf("unsupported type: %v", cfg.GroupVersionKind)
 	}
 }
 
-func delete(ic versionedclient.Interface, sc serviceapisclient.Interface, typ resource.GroupVersionKind, name, namespace string) error {
+func delete(ic versionedclient.Interface, sc serviceapisclient.Interface, typ config.GroupVersionKind, name, namespace string) error {
 	switch typ {
 	case collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind():
 		return ic.NetworkingV1alpha3().DestinationRules(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
@@ -243,11 +242,11 @@ func delete(ic versionedclient.Interface, sc serviceapisclient.Interface, typ re
 	}
 }
 
-var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model.Config{
-	collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.Config{
+	collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientnetworkingv1alpha3.DestinationRule)
-		return &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -259,10 +258,10 @@ var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model
 			Spec: &obj.Spec,
 		}
 	},
-	collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+	collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientnetworkingv1alpha3.EnvoyFilter)
-		return &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -274,10 +273,10 @@ var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model
 			Spec: &obj.Spec,
 		}
 	},
-	collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+	collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientnetworkingv1alpha3.Gateway)
-		return &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -289,10 +288,10 @@ var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model
 			Spec: &obj.Spec,
 		}
 	},
-	collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+	collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientnetworkingv1alpha3.ServiceEntry)
-		return &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -304,10 +303,10 @@ var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model
 			Spec: &obj.Spec,
 		}
 	},
-	collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+	collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientnetworkingv1alpha3.Sidecar)
-		return &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -319,10 +318,10 @@ var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model
 			Spec: &obj.Spec,
 		}
 	},
-	collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+	collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientnetworkingv1alpha3.VirtualService)
-		return &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -334,10 +333,10 @@ var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model
 			Spec: &obj.Spec,
 		}
 	},
-	collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+	collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientnetworkingv1alpha3.WorkloadEntry)
-		return &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -349,10 +348,10 @@ var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model
 			Spec: &obj.Spec,
 		}
 	},
-	collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+	collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientnetworkingv1alpha3.WorkloadGroup)
-		return &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -364,10 +363,10 @@ var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model
 			Spec: &obj.Spec,
 		}
 	},
-	collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+	collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientsecurityv1beta1.AuthorizationPolicy)
-		return &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -379,10 +378,10 @@ var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model
 			Spec: &obj.Spec,
 		}
 	},
-	collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+	collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientsecurityv1beta1.PeerAuthentication)
-		return &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -394,10 +393,10 @@ var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model
 			Spec: &obj.Spec,
 		}
 	},
-	collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+	collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*clientsecurityv1beta1.RequestAuthentication)
-		return &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -409,10 +408,10 @@ var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model
 			Spec: &obj.Spec,
 		}
 	},
-	collections.K8SServiceApisV1Alpha1Gatewayclasses.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+	collections.K8SServiceApisV1Alpha1Gatewayclasses.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*servicev1alpha1.GatewayClass)
-		return &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.K8SServiceApisV1Alpha1Gatewayclasses.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -424,10 +423,10 @@ var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model
 			Spec: &obj.Spec,
 		}
 	},
-	collections.K8SServiceApisV1Alpha1Gateways.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+	collections.K8SServiceApisV1Alpha1Gateways.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*servicev1alpha1.Gateway)
-		return &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.K8SServiceApisV1Alpha1Gateways.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -439,10 +438,10 @@ var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model
 			Spec: &obj.Spec,
 		}
 	},
-	collections.K8SServiceApisV1Alpha1Httproutes.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+	collections.K8SServiceApisV1Alpha1Httproutes.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*servicev1alpha1.HTTPRoute)
-		return &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.K8SServiceApisV1Alpha1Httproutes.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -454,10 +453,10 @@ var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model
 			Spec: &obj.Spec,
 		}
 	},
-	collections.K8SServiceApisV1Alpha1Tcproutes.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
+	collections.K8SServiceApisV1Alpha1Tcproutes.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
 		obj := r.(*servicev1alpha1.TCPRoute)
-		return &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		return &config.Config{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.K8SServiceApisV1Alpha1Tcproutes.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,

--- a/pilot/pkg/config/kube/crdclient/types.gen.go
+++ b/pilot/pkg/config/kube/crdclient/types.gen.go
@@ -32,7 +32,6 @@ import (
 
 	config "istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
-	"istio.io/istio/pkg/config/schema/resource"
 
 	networkingv1alpha3 "istio.io/api/networking/v1alpha3"
 	securityv1beta1 "istio.io/api/security/v1beta1"

--- a/pilot/pkg/config/kube/crdclient/types.gen.go
+++ b/pilot/pkg/config/kube/crdclient/types.gen.go
@@ -30,18 +30,19 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	serviceapisclient "sigs.k8s.io/service-apis/pkg/client/clientset/versioned"
 
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/resource"
+
 	networkingv1alpha3 "istio.io/api/networking/v1alpha3"
 	securityv1beta1 "istio.io/api/security/v1beta1"
 	clientnetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	clientsecurityv1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
 
-	"istio.io/istio/pkg/config"
-	"istio.io/istio/pkg/config/schema/collections"
-
 	servicev1alpha1 "sigs.k8s.io/service-apis/apis/v1alpha1"
 )
 
-func create(ic versionedclient.Interface, sc serviceapisclient.Interface, config config.Config, objMeta metav1.ObjectMeta) (metav1.Object, error) {
+func create(ic versionedclient.Interface, sc serviceapisclient.Interface, config model.Config, objMeta metav1.ObjectMeta) (metav1.Object, error) {
 	switch config.GroupVersionKind {
 	case collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind():
 		return ic.NetworkingV1alpha3().DestinationRules(config.Namespace).Create(context.TODO(), &clientnetworkingv1alpha3.DestinationRule{
@@ -123,7 +124,7 @@ func create(ic versionedclient.Interface, sc serviceapisclient.Interface, config
 	}
 }
 
-func update(ic versionedclient.Interface, sc serviceapisclient.Interface, config config.Config, objMeta metav1.ObjectMeta) (metav1.Object, error) {
+func update(ic versionedclient.Interface, sc serviceapisclient.Interface, config model.Config, objMeta metav1.ObjectMeta) (metav1.Object, error) {
 	switch config.GroupVersionKind {
 	case collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind():
 		return ic.NetworkingV1alpha3().DestinationRules(config.Namespace).Update(context.TODO(), &clientnetworkingv1alpha3.DestinationRule{
@@ -205,7 +206,7 @@ func update(ic versionedclient.Interface, sc serviceapisclient.Interface, config
 	}
 }
 
-func delete(ic versionedclient.Interface, sc serviceapisclient.Interface, typ config.GroupVersionKind, name, namespace string) error {
+func delete(ic versionedclient.Interface, sc serviceapisclient.Interface, typ resource.GroupVersionKind, name, namespace string) error {
 	switch typ {
 	case collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind():
 		return ic.NetworkingV1alpha3().DestinationRules(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
@@ -242,11 +243,11 @@ func delete(ic versionedclient.Interface, sc serviceapisclient.Interface, typ co
 	}
 }
 
-var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.Config{
-	collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
+var translationMap = map[resource.GroupVersionKind]func(r runtime.Object) *model.Config{
+	collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
 		obj := r.(*clientnetworkingv1alpha3.DestinationRule)
-		return &config.Config{
-			Meta: config.Meta{
+		return &model.Config{
+			ConfigMeta: model.ConfigMeta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -258,10 +259,10 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 			Spec: &obj.Spec,
 		}
 	},
-	collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
+	collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
 		obj := r.(*clientnetworkingv1alpha3.EnvoyFilter)
-		return &config.Config{
-			Meta: config.Meta{
+		return &model.Config{
+			ConfigMeta: model.ConfigMeta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -273,10 +274,10 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 			Spec: &obj.Spec,
 		}
 	},
-	collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
+	collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
 		obj := r.(*clientnetworkingv1alpha3.Gateway)
-		return &config.Config{
-			Meta: config.Meta{
+		return &model.Config{
+			ConfigMeta: model.ConfigMeta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -288,10 +289,10 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 			Spec: &obj.Spec,
 		}
 	},
-	collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
+	collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
 		obj := r.(*clientnetworkingv1alpha3.ServiceEntry)
-		return &config.Config{
-			Meta: config.Meta{
+		return &model.Config{
+			ConfigMeta: model.ConfigMeta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -303,10 +304,10 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 			Spec: &obj.Spec,
 		}
 	},
-	collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
+	collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
 		obj := r.(*clientnetworkingv1alpha3.Sidecar)
-		return &config.Config{
-			Meta: config.Meta{
+		return &model.Config{
+			ConfigMeta: model.ConfigMeta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -318,10 +319,10 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 			Spec: &obj.Spec,
 		}
 	},
-	collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
+	collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
 		obj := r.(*clientnetworkingv1alpha3.VirtualService)
-		return &config.Config{
-			Meta: config.Meta{
+		return &model.Config{
+			ConfigMeta: model.ConfigMeta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -333,10 +334,10 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 			Spec: &obj.Spec,
 		}
 	},
-	collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
+	collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
 		obj := r.(*clientnetworkingv1alpha3.WorkloadEntry)
-		return &config.Config{
-			Meta: config.Meta{
+		return &model.Config{
+			ConfigMeta: model.ConfigMeta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -348,10 +349,10 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 			Spec: &obj.Spec,
 		}
 	},
-	collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
+	collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
 		obj := r.(*clientnetworkingv1alpha3.WorkloadGroup)
-		return &config.Config{
-			Meta: config.Meta{
+		return &model.Config{
+			ConfigMeta: model.ConfigMeta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -363,10 +364,10 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 			Spec: &obj.Spec,
 		}
 	},
-	collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
+	collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
 		obj := r.(*clientsecurityv1beta1.AuthorizationPolicy)
-		return &config.Config{
-			Meta: config.Meta{
+		return &model.Config{
+			ConfigMeta: model.ConfigMeta{
 				GroupVersionKind:  collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -378,10 +379,10 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 			Spec: &obj.Spec,
 		}
 	},
-	collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
+	collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
 		obj := r.(*clientsecurityv1beta1.PeerAuthentication)
-		return &config.Config{
-			Meta: config.Meta{
+		return &model.Config{
+			ConfigMeta: model.ConfigMeta{
 				GroupVersionKind:  collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -393,10 +394,10 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 			Spec: &obj.Spec,
 		}
 	},
-	collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
+	collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
 		obj := r.(*clientsecurityv1beta1.RequestAuthentication)
-		return &config.Config{
-			Meta: config.Meta{
+		return &model.Config{
+			ConfigMeta: model.ConfigMeta{
 				GroupVersionKind:  collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -408,10 +409,10 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 			Spec: &obj.Spec,
 		}
 	},
-	collections.K8SServiceApisV1Alpha1Gatewayclasses.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
+	collections.K8SServiceApisV1Alpha1Gatewayclasses.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
 		obj := r.(*servicev1alpha1.GatewayClass)
-		return &config.Config{
-			Meta: config.Meta{
+		return &model.Config{
+			ConfigMeta: model.ConfigMeta{
 				GroupVersionKind:  collections.K8SServiceApisV1Alpha1Gatewayclasses.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -423,10 +424,10 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 			Spec: &obj.Spec,
 		}
 	},
-	collections.K8SServiceApisV1Alpha1Gateways.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
+	collections.K8SServiceApisV1Alpha1Gateways.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
 		obj := r.(*servicev1alpha1.Gateway)
-		return &config.Config{
-			Meta: config.Meta{
+		return &model.Config{
+			ConfigMeta: model.ConfigMeta{
 				GroupVersionKind:  collections.K8SServiceApisV1Alpha1Gateways.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -438,10 +439,10 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 			Spec: &obj.Spec,
 		}
 	},
-	collections.K8SServiceApisV1Alpha1Httproutes.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
+	collections.K8SServiceApisV1Alpha1Httproutes.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
 		obj := r.(*servicev1alpha1.HTTPRoute)
-		return &config.Config{
-			Meta: config.Meta{
+		return &model.Config{
+			ConfigMeta: model.ConfigMeta{
 				GroupVersionKind:  collections.K8SServiceApisV1Alpha1Httproutes.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,
@@ -453,10 +454,10 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 			Spec: &obj.Spec,
 		}
 	},
-	collections.K8SServiceApisV1Alpha1Tcproutes.Resource().GroupVersionKind(): func(r runtime.Object) *config.Config {
+	collections.K8SServiceApisV1Alpha1Tcproutes.Resource().GroupVersionKind(): func(r runtime.Object) *model.Config {
 		obj := r.(*servicev1alpha1.TCPRoute)
-		return &config.Config{
-			Meta: config.Meta{
+		return &model.Config{
+			ConfigMeta: model.ConfigMeta{
 				GroupVersionKind:  collections.K8SServiceApisV1Alpha1Tcproutes.Resource().GroupVersionKind(),
 				Name:              obj.Name,
 				Namespace:         obj.Namespace,

--- a/pilot/pkg/config/kube/gateway/controller.go
+++ b/pilot/pkg/config/kube/gateway/controller.go
@@ -25,10 +25,10 @@ import (
 
 	"istio.io/istio/pilot/pkg/model"
 	controller2 "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
-	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/pkg/ledger"
 )
 
@@ -64,11 +64,11 @@ func (c *controller) Schemas() collection.Schemas {
 	)
 }
 
-func (c controller) Get(typ resource.GroupVersionKind, name, namespace string) *model.Config {
+func (c controller) Get(typ config.GroupVersionKind, name, namespace string) *config.Config {
 	panic("get is not supported")
 }
 
-func (c controller) List(typ resource.GroupVersionKind, namespace string) ([]model.Config, error) {
+func (c controller) List(typ config.GroupVersionKind, namespace string) ([]config.Config, error) {
 	if typ != gvk.Gateway && typ != gvk.VirtualService {
 		return nil, errUnsupportedType
 	}
@@ -117,15 +117,15 @@ func (c controller) List(typ resource.GroupVersionKind, namespace string) ([]mod
 	return nil, errUnsupportedOp
 }
 
-func (c controller) Create(config model.Config) (revision string, err error) {
+func (c controller) Create(config config.Config) (revision string, err error) {
 	return "", errUnsupportedOp
 }
 
-func (c controller) Update(config model.Config) (newRevision string, err error) {
+func (c controller) Update(config config.Config) (newRevision string, err error) {
 	return "", errUnsupportedOp
 }
 
-func (c controller) Delete(typ resource.GroupVersionKind, name, namespace string) error {
+func (c controller) Delete(typ config.GroupVersionKind, name, namespace string) error {
 	return errUnsupportedOp
 }
 
@@ -137,8 +137,8 @@ func (c controller) GetResourceAtVersion(version string, key string) (resourceVe
 	return c.cache.GetResourceAtVersion(version, key)
 }
 
-func (c controller) RegisterEventHandler(typ resource.GroupVersionKind, handler func(model.Config, model.Config, model.Event)) {
-	c.cache.RegisterEventHandler(typ, func(prev, cur model.Config, event model.Event) {
+func (c controller) RegisterEventHandler(typ config.GroupVersionKind, handler func(config.Config, config.Config, model.Event)) {
+	c.cache.RegisterEventHandler(typ, func(prev, cur config.Config, event model.Event) {
 		handler(prev, cur, event)
 	})
 }

--- a/pilot/pkg/config/kube/gateway/controller_test.go
+++ b/pilot/pkg/config/kube/gateway/controller_test.go
@@ -104,7 +104,7 @@ func TestListGatewayResourceType(t *testing.T) {
 	k8sHTTPRouteType := collections.K8SServiceApisV1Alpha1Httproutes.Resource()
 
 	store.Create(config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: gwClassType.GroupVersionKind(),
 			Name:             "gwclass",
 			Namespace:        "ns1",
@@ -112,7 +112,7 @@ func TestListGatewayResourceType(t *testing.T) {
 		Spec: gatewayClassSpec,
 	})
 	if _, err := store.Create(config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: gwSpecType.GroupVersionKind(),
 			Name:             "gwspec",
 			Namespace:        "ns1",
@@ -122,7 +122,7 @@ func TestListGatewayResourceType(t *testing.T) {
 		t.Fatal(err)
 	}
 	store.Create(config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: k8sHTTPRouteType.GroupVersionKind(),
 			Name:             "http-route",
 			Namespace:        "ns1",
@@ -153,7 +153,7 @@ func TestListVirtualServiceResourceType(t *testing.T) {
 	k8sHTTPRouteType := collections.K8SServiceApisV1Alpha1Httproutes.Resource()
 
 	store.Create(config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: gwClassType.GroupVersionKind(),
 			Name:             "gwclass",
 			Namespace:        "ns1",
@@ -161,7 +161,7 @@ func TestListVirtualServiceResourceType(t *testing.T) {
 		Spec: gatewayClassSpec,
 	})
 	store.Create(config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: gwSpecType.GroupVersionKind(),
 			Name:             "gwspec",
 			Namespace:        "ns1",
@@ -169,7 +169,7 @@ func TestListVirtualServiceResourceType(t *testing.T) {
 		Spec: gatewaySpec,
 	})
 	store.Create(config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: k8sHTTPRouteType.GroupVersionKind(),
 			Name:             "http-route",
 			Namespace:        "ns1",

--- a/pilot/pkg/config/kube/gateway/controller_test.go
+++ b/pilot/pkg/config/kube/gateway/controller_test.go
@@ -23,12 +23,11 @@ import (
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/config/memory"
-	"istio.io/istio/pilot/pkg/model"
 	controller2 "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
-	"istio.io/istio/pkg/config/schema/resource"
 )
 
 var (
@@ -87,7 +86,7 @@ func TestListInvalidGroupVersionKind(t *testing.T) {
 	store := memory.NewController(memory.Make(collections.All))
 	controller := NewController(clientSet, store, controller2.Options{})
 
-	typ := resource.GroupVersionKind{Kind: "wrong-kind"}
+	typ := config.GroupVersionKind{Kind: "wrong-kind"}
 	c, err := controller.List(typ, "ns1")
 	g.Expect(c).To(HaveLen(0))
 	g.Expect(err).To(HaveOccurred())
@@ -104,16 +103,16 @@ func TestListGatewayResourceType(t *testing.T) {
 	gwSpecType := collections.K8SServiceApisV1Alpha1Gateways.Resource()
 	k8sHTTPRouteType := collections.K8SServiceApisV1Alpha1Httproutes.Resource()
 
-	store.Create(model.Config{
-		ConfigMeta: model.ConfigMeta{
+	store.Create(config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: gwClassType.GroupVersionKind(),
 			Name:             "gwclass",
 			Namespace:        "ns1",
 		},
 		Spec: gatewayClassSpec,
 	})
-	if _, err := store.Create(model.Config{
-		ConfigMeta: model.ConfigMeta{
+	if _, err := store.Create(config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: gwSpecType.GroupVersionKind(),
 			Name:             "gwspec",
 			Namespace:        "ns1",
@@ -122,8 +121,8 @@ func TestListGatewayResourceType(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	store.Create(model.Config{
-		ConfigMeta: model.ConfigMeta{
+	store.Create(config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: k8sHTTPRouteType.GroupVersionKind(),
 			Name:             "http-route",
 			Namespace:        "ns1",
@@ -153,24 +152,24 @@ func TestListVirtualServiceResourceType(t *testing.T) {
 	gwSpecType := collections.K8SServiceApisV1Alpha1Gateways.Resource()
 	k8sHTTPRouteType := collections.K8SServiceApisV1Alpha1Httproutes.Resource()
 
-	store.Create(model.Config{
-		ConfigMeta: model.ConfigMeta{
+	store.Create(config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: gwClassType.GroupVersionKind(),
 			Name:             "gwclass",
 			Namespace:        "ns1",
 		},
 		Spec: gatewayClassSpec,
 	})
-	store.Create(model.Config{
-		ConfigMeta: model.ConfigMeta{
+	store.Create(config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: gwSpecType.GroupVersionKind(),
 			Name:             "gwspec",
 			Namespace:        "ns1",
 		},
 		Spec: gatewaySpec,
 	})
-	store.Create(model.Config{
-		ConfigMeta: model.ConfigMeta{
+	store.Create(config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: k8sHTTPRouteType.GroupVersionKind(),
 			Name:             "http-route",
 			Namespace:        "ns1",

--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -206,7 +206,7 @@ func buildHTTPVirtualServices(obj config.Config, gateways []string, domain strin
 			httproutes = append(httproutes, vs)
 		}
 		vsConfig := config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind: istioVsResource.GroupVersionKind(),
 				Name:             name,
 				Namespace:        obj.Namespace,
@@ -235,7 +235,7 @@ func buildTCPVirtualService(obj config.Config, gateways []string, domain string)
 	}
 
 	vsConfig := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: istioVsResource.GroupVersionKind(),
 			Name:             fmt.Sprintf("%s-tcp-%s", obj.Name, constants.KubernetesGatewayName),
 			Namespace:        obj.Namespace,
@@ -470,7 +470,7 @@ func convertGateway(r *KubernetesResources) ([]config.Config, map[RouteKey][]str
 			}
 		}
 		gatewayConfig := config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind: istioGwResource.GroupVersionKind(),
 				Name:             name,
 				Namespace:        obj.Namespace,

--- a/pilot/pkg/config/kube/gateway/conversion.go
+++ b/pilot/pkg/config/kube/gateway/conversion.go
@@ -25,7 +25,7 @@ import (
 	k8s "sigs.k8s.io/service-apis/apis/v1alpha1"
 
 	istio "istio.io/api/networking/v1alpha3"
-	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/schema/collections"
@@ -45,17 +45,17 @@ var (
 )
 
 type KubernetesResources struct {
-	GatewayClass []model.Config
-	Gateway      []model.Config
-	HTTPRoute    []model.Config
-	TCPRoute     []model.Config
+	GatewayClass []config.Config
+	Gateway      []config.Config
+	HTTPRoute    []config.Config
+	TCPRoute     []config.Config
 	Namespaces   map[string]*corev1.Namespace
 
 	// Domain for the cluster. Typically cluster.local
 	Domain string
 }
 
-func isRouteMatch(cfg model.Config, res resource.Schema, gatewayNamespace string,
+func isRouteMatch(cfg config.Config, res resource.Schema, gatewayNamespace string,
 	routes k8s.RouteBindingSelector, namespaces map[string]*corev1.Namespace) bool {
 	if routes.Resource != res.Plural() {
 		return false
@@ -94,8 +94,8 @@ func isRouteMatch(cfg model.Config, res resource.Schema, gatewayNamespace string
 	return true
 }
 
-func (r *KubernetesResources) fetchHTTPRoutes(gatewayNamespace string, routes k8s.RouteBindingSelector) []model.Config {
-	result := []model.Config{}
+func (r *KubernetesResources) fetchHTTPRoutes(gatewayNamespace string, routes k8s.RouteBindingSelector) []config.Config {
+	result := []config.Config{}
 	for _, http := range r.HTTPRoute {
 		if isRouteMatch(http, collections.K8SServiceApisV1Alpha1Httproutes.Resource(), gatewayNamespace, routes, r.Namespaces) {
 			result = append(result, http)
@@ -104,8 +104,8 @@ func (r *KubernetesResources) fetchHTTPRoutes(gatewayNamespace string, routes k8
 	return result
 }
 
-func (r *KubernetesResources) fetchTCPRoutes(gatewayNamespace string, routes k8s.RouteBindingSelector) []model.Config {
-	result := []model.Config{}
+func (r *KubernetesResources) fetchTCPRoutes(gatewayNamespace string, routes k8s.RouteBindingSelector) []config.Config {
+	result := []config.Config{}
 	for _, http := range r.TCPRoute {
 		if isRouteMatch(http, collections.K8SServiceApisV1Alpha1Tcproutes.Resource(), gatewayNamespace, routes, r.Namespaces) {
 			result = append(result, http)
@@ -115,8 +115,8 @@ func (r *KubernetesResources) fetchTCPRoutes(gatewayNamespace string, routes k8s
 }
 
 type IstioResources struct {
-	Gateway        []model.Config
-	VirtualService []model.Config
+	Gateway        []config.Config
+	VirtualService []config.Config
 }
 
 var _ = k8s.HTTPRoute{}
@@ -132,12 +132,12 @@ func convertResources(r *KubernetesResources) IstioResources {
 
 // Unique key to identify a route
 type RouteKey struct {
-	Gvk       resource.GroupVersionKind
+	Gvk       config.GroupVersionKind
 	Name      string
 	Namespace string
 }
 
-func toRouteKey(c model.Config) RouteKey {
+func toRouteKey(c config.Config) RouteKey {
 	return RouteKey{
 		c.GroupVersionKind,
 		c.Name,
@@ -145,8 +145,8 @@ func toRouteKey(c model.Config) RouteKey {
 	}
 }
 
-func convertVirtualService(r *KubernetesResources, routeMap map[RouteKey][]string) []model.Config {
-	result := []model.Config{}
+func convertVirtualService(r *KubernetesResources, routeMap map[RouteKey][]string) []config.Config {
+	result := []config.Config{}
 	for _, obj := range r.TCPRoute {
 		gateways, f := routeMap[toRouteKey(obj)]
 		if !f {
@@ -170,8 +170,8 @@ func convertVirtualService(r *KubernetesResources, routeMap map[RouteKey][]strin
 	return result
 }
 
-func buildHTTPVirtualServices(obj model.Config, gateways []string, domain string) []model.Config {
-	result := []model.Config{}
+func buildHTTPVirtualServices(obj config.Config, gateways []string, domain string) []config.Config {
+	result := []config.Config{}
 
 	route := obj.Spec.(*k8s.HTTPRouteSpec)
 	// Matches * and "/". Currently not supported - would conflict
@@ -205,8 +205,8 @@ func buildHTTPVirtualServices(obj model.Config, gateways []string, domain string
 			}
 			httproutes = append(httproutes, vs)
 		}
-		vsConfig := model.Config{
-			ConfigMeta: model.ConfigMeta{
+		vsConfig := config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind: istioVsResource.GroupVersionKind(),
 				Name:             name,
 				Namespace:        obj.Namespace,
@@ -223,7 +223,7 @@ func buildHTTPVirtualServices(obj model.Config, gateways []string, domain string
 	return result
 }
 
-func buildTCPVirtualService(obj model.Config, gateways []string, domain string) model.Config {
+func buildTCPVirtualService(obj config.Config, gateways []string, domain string) config.Config {
 	route := obj.Spec.(*k8s.TCPRouteSpec)
 	routes := []*istio.TCPRoute{}
 	for _, r := range route.Rules {
@@ -234,8 +234,8 @@ func buildTCPVirtualService(obj model.Config, gateways []string, domain string) 
 		routes = append(routes, ir)
 	}
 
-	vsConfig := model.Config{
-		ConfigMeta: model.ConfigMeta{
+	vsConfig := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: istioVsResource.GroupVersionKind(),
 			Name:             fmt.Sprintf("%s-tcp-%s", obj.Name, constants.KubernetesGatewayName),
 			Namespace:        obj.Namespace,
@@ -430,8 +430,8 @@ func getGatewayClasses(r *KubernetesResources) map[string]struct{} {
 	return classes
 }
 
-func convertGateway(r *KubernetesResources) ([]model.Config, map[RouteKey][]string) {
-	result := []model.Config{}
+func convertGateway(r *KubernetesResources) ([]config.Config, map[RouteKey][]string) {
+	result := []config.Config{}
 	routeToGateway := map[RouteKey][]string{}
 	classes := getGatewayClasses(r)
 	for _, obj := range r.Gateway {
@@ -469,8 +469,8 @@ func convertGateway(r *KubernetesResources) ([]model.Config, map[RouteKey][]stri
 				routeToGateway[k] = append(routeToGateway[k], obj.Namespace+"/"+name)
 			}
 		}
-		gatewayConfig := model.Config{
-			ConfigMeta: model.ConfigMeta{
+		gatewayConfig := config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind: istioGwResource.GroupVersionKind(),
 				Name:             name,
 				Namespace:        obj.Namespace,

--- a/pilot/pkg/config/kube/gateway/conversion_test.go
+++ b/pilot/pkg/config/kube/gateway/conversion_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/ghodss/yaml"
 
 	"istio.io/istio/pilot/pkg/config/kube/crd"
-	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/test/util"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
 )
@@ -53,10 +53,10 @@ func TestConvertResources(t *testing.T) {
 	}
 }
 
-func splitOutput(configs []model.Config) IstioResources {
+func splitOutput(configs []config.Config) IstioResources {
 	out := IstioResources{
-		Gateway:        []model.Config{},
-		VirtualService: []model.Config{},
+		Gateway:        []config.Config{},
+		VirtualService: []config.Config{},
 	}
 	for _, c := range configs {
 		switch c.GroupVersionKind {
@@ -69,7 +69,7 @@ func splitOutput(configs []model.Config) IstioResources {
 	return out
 }
 
-func splitInput(configs []model.Config) *KubernetesResources {
+func splitInput(configs []config.Config) *KubernetesResources {
 	out := &KubernetesResources{}
 	for _, c := range configs {
 		switch c.GroupVersionKind {
@@ -86,7 +86,7 @@ func splitInput(configs []model.Config) *KubernetesResources {
 	return out
 }
 
-func readConfig(t *testing.T, filename string) []model.Config {
+func readConfig(t *testing.T, filename string) []config.Config {
 	t.Helper()
 
 	data, err := ioutil.ReadFile(filename)
@@ -101,7 +101,7 @@ func readConfig(t *testing.T, filename string) []model.Config {
 }
 
 // Print as YAML
-func marshalYaml(t *testing.T, cl []model.Config) []byte {
+func marshalYaml(t *testing.T, cl []config.Config) []byte {
 	t.Helper()
 	result := []byte{}
 	separator := []byte("---\n")

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -205,14 +205,14 @@ func (c *controller) onEvent(obj interface{}, event model.Event) error {
 	// TODO: we could be smarter here and only trigger when real changes were found
 	for _, f := range c.virtualServiceHandlers {
 		f(config.Config{}, config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind: gvk.VirtualService,
 			},
 		}, event)
 	}
 	for _, f := range c.gatewayHandlers {
 		f(config.Config{}, config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind: gvk.Gateway,
 			},
 		}, event)

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -33,12 +33,12 @@ import (
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
 	kubecontroller "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
-	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/queue"
 	"istio.io/pkg/env"
@@ -83,8 +83,8 @@ type controller struct {
 	domainSuffix string
 
 	queue                  queue.Instance
-	virtualServiceHandlers []func(model.Config, model.Config, model.Event)
-	gatewayHandlers        []func(model.Config, model.Config, model.Event)
+	virtualServiceHandlers []func(config.Config, config.Config, model.Event)
+	gatewayHandlers        []func(config.Config, config.Config, model.Event)
 
 	ingressInformer cache.SharedInformer
 	serviceInformer cache.SharedInformer
@@ -204,15 +204,15 @@ func (c *controller) onEvent(obj interface{}, event model.Event) error {
 	// Trigger updates for Gateway and VirtualService
 	// TODO: we could be smarter here and only trigger when real changes were found
 	for _, f := range c.virtualServiceHandlers {
-		f(model.Config{}, model.Config{
-			ConfigMeta: model.ConfigMeta{
+		f(config.Config{}, config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind: gvk.VirtualService,
 			},
 		}, event)
 	}
 	for _, f := range c.gatewayHandlers {
-		f(model.Config{}, model.Config{
-			ConfigMeta: model.ConfigMeta{
+		f(config.Config{}, config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind: gvk.Gateway,
 			},
 		}, event)
@@ -221,7 +221,7 @@ func (c *controller) onEvent(obj interface{}, event model.Event) error {
 	return nil
 }
 
-func (c *controller) RegisterEventHandler(kind resource.GroupVersionKind, f func(model.Config, model.Config, model.Event)) {
+func (c *controller) RegisterEventHandler(kind config.GroupVersionKind, f func(config.Config, config.Config, model.Event)) {
 	switch kind {
 	case gvk.VirtualService:
 		c.virtualServiceHandlers = append(c.virtualServiceHandlers, f)
@@ -265,19 +265,19 @@ func (c *controller) Schemas() collection.Schemas {
 	return schemas
 }
 
-func (c *controller) Get(typ resource.GroupVersionKind, name, namespace string) *model.Config {
+func (c *controller) Get(typ config.GroupVersionKind, name, namespace string) *config.Config {
 	return nil
 }
 
-func (c *controller) List(typ resource.GroupVersionKind, namespace string) ([]model.Config, error) {
+func (c *controller) List(typ config.GroupVersionKind, namespace string) ([]config.Config, error) {
 	if typ != gvk.Gateway &&
 		typ != gvk.VirtualService {
 		return nil, errUnsupportedOp
 	}
 
-	out := make([]model.Config, 0)
+	out := make([]config.Config, 0)
 
-	ingressByHost := map[string]*model.Config{}
+	ingressByHost := map[string]*config.Config{}
 
 	for _, obj := range c.ingressInformer.GetStore().List() {
 		ingress := obj.(*ingress.Ingress)
@@ -310,14 +310,14 @@ func (c *controller) List(typ resource.GroupVersionKind, namespace string) ([]mo
 	return out, nil
 }
 
-func (c *controller) Create(_ model.Config) (string, error) {
+func (c *controller) Create(_ config.Config) (string, error) {
 	return "", errUnsupportedOp
 }
 
-func (c *controller) Update(_ model.Config) (string, error) {
+func (c *controller) Update(_ config.Config) (string, error) {
 	return "", errUnsupportedOp
 }
 
-func (c *controller) Delete(_ resource.GroupVersionKind, _, _ string) error {
+func (c *controller) Delete(_ config.GroupVersionKind, _, _ string) error {
 	return errUnsupportedOp
 }

--- a/pilot/pkg/config/kube/ingress/conversion.go
+++ b/pilot/pkg/config/kube/ingress/conversion.go
@@ -28,8 +28,8 @@ import (
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
-	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/protocol"
@@ -80,7 +80,7 @@ func decodeIngressRuleName(name string) (ingressName string, ruleNum, pathNum in
 var defaultSelector = labels.Instance{constants.IstioLabel: constants.IstioIngressLabelValue}
 
 // ConvertIngressV1alpha3 converts from ingress spec to Istio Gateway
-func ConvertIngressV1alpha3(ingress v1beta1.Ingress, mesh *meshconfig.MeshConfig, domainSuffix string) model.Config {
+func ConvertIngressV1alpha3(ingress v1beta1.Ingress, mesh *meshconfig.MeshConfig, domainSuffix string) config.Config {
 	gateway := &networking.Gateway{}
 	// Setup the selector for the gateway
 	if len(mesh.IngressSelector) > 0 {
@@ -128,8 +128,8 @@ func ConvertIngressV1alpha3(ingress v1beta1.Ingress, mesh *meshconfig.MeshConfig
 		Hosts: []string{"*"},
 	})
 
-	gatewayConfig := model.Config{
-		ConfigMeta: model.ConfigMeta{
+	gatewayConfig := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: gvk.Gateway,
 			Name:             ingress.Name + "-" + constants.IstioIngressGatewayName,
 			Namespace:        ingressNamespace,
@@ -142,7 +142,7 @@ func ConvertIngressV1alpha3(ingress v1beta1.Ingress, mesh *meshconfig.MeshConfig
 }
 
 // ConvertIngressVirtualService converts from ingress spec to Istio VirtualServices
-func ConvertIngressVirtualService(ingress v1beta1.Ingress, domainSuffix string, ingressByHost map[string]*model.Config, serviceLister listerv1.ServiceLister) {
+func ConvertIngressVirtualService(ingress v1beta1.Ingress, domainSuffix string, ingressByHost map[string]*config.Config, serviceLister listerv1.ServiceLister) {
 	// Ingress allows a single host - if missing '*' is assumed
 	// We need to merge all rules with a particular host across
 	// all ingresses, and return a separate VirtualService for each
@@ -207,8 +207,8 @@ func ConvertIngressVirtualService(ingress v1beta1.Ingress, domainSuffix string, 
 
 		virtualService.Http = httpRoutes
 
-		virtualServiceConfig := model.Config{
-			ConfigMeta: model.ConfigMeta{
+		virtualServiceConfig := config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind: gvk.VirtualService,
 				Name:             namePrefix + "-" + ingress.Name + "-" + constants.IstioIngressGatewayName,
 				Namespace:        ingress.Namespace,

--- a/pilot/pkg/config/kube/ingress/conversion.go
+++ b/pilot/pkg/config/kube/ingress/conversion.go
@@ -129,7 +129,7 @@ func ConvertIngressV1alpha3(ingress v1beta1.Ingress, mesh *meshconfig.MeshConfig
 	})
 
 	gatewayConfig := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: gvk.Gateway,
 			Name:             ingress.Name + "-" + constants.IstioIngressGatewayName,
 			Namespace:        ingressNamespace,
@@ -208,7 +208,7 @@ func ConvertIngressVirtualService(ingress v1beta1.Ingress, domainSuffix string, 
 		virtualService.Http = httpRoutes
 
 		virtualServiceConfig := config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind: gvk.VirtualService,
 				Name:             namePrefix + "-" + ingress.Name + "-" + constants.IstioIngressGatewayName,
 				Namespace:        ingress.Namespace,

--- a/pilot/pkg/config/kube/ingress/conversion_test.go
+++ b/pilot/pkg/config/kube/ingress/conversion_test.go
@@ -38,8 +38,8 @@ import (
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/config/kube/crd"
-	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/test/util"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/mesh"
 )
 
@@ -55,12 +55,12 @@ func TestGoldenConversion(t *testing.T) {
 				t.Fatal(err)
 			}
 			serviceLister := createFakeLister(ctx)
-			cfgs := map[string]*model.Config{}
+			cfgs := map[string]*config.Config{}
 			for _, obj := range input {
 				ingress := obj.(*v1beta1.Ingress)
 				ConvertIngressVirtualService(*ingress, "mydomain", cfgs, serviceLister)
 			}
-			ordered := []model.Config{}
+			ordered := []config.Config{}
 			for _, v := range cfgs {
 				ordered = append(ordered, *v)
 			}
@@ -93,7 +93,7 @@ func TestGoldenConversion(t *testing.T) {
 }
 
 // Print as YAML
-func marshalYaml(t *testing.T, cl []model.Config) []byte {
+func marshalYaml(t *testing.T, cl []config.Config) []byte {
 	t.Helper()
 	result := []byte{}
 	separator := []byte("---\n")
@@ -217,7 +217,7 @@ func TestConversion(t *testing.T) {
 		},
 	}
 	serviceLister := createFakeLister(ctx)
-	cfgs := map[string]*model.Config{}
+	cfgs := map[string]*config.Config{}
 	ConvertIngressVirtualService(ingress, "mydomain", cfgs, serviceLister)
 	ConvertIngressVirtualService(ingress2, "mydomain", cfgs, serviceLister)
 
@@ -418,7 +418,7 @@ func TestNamedPortIngressConversion(t *testing.T) {
 		},
 	}
 	serviceLister := createFakeLister(ctx, service)
-	cfgs := map[string]*model.Config{}
+	cfgs := map[string]*config.Config{}
 	ConvertIngressVirtualService(ingress, "mydomain", cfgs, serviceLister)
 	if len(cfgs) != 1 {
 		t.Error("VirtualServices, expected 1 got ", len(cfgs))

--- a/pilot/pkg/config/memory/config.go
+++ b/pilot/pkg/config/memory/config.go
@@ -171,7 +171,7 @@ func (cr *store) Create(config model.Config) (string, error) {
 		return "", fmt.Errorf("unknown type %v", kind)
 	}
 	if !cr.skipValidation {
-		if err := s.Resource().ValidateProto(config.Name, config.Namespace, config.Spec); err != nil {
+		if err := s.Resource().ValidateConfig(config.Name, config.Namespace, config.Spec); err != nil {
 			return "", err
 		}
 	}
@@ -210,7 +210,7 @@ func (cr *store) Update(config model.Config) (string, error) {
 	if !ok {
 		return "", errors.New("unknown type")
 	}
-	if err := s.Resource().ValidateProto(config.Name, config.Namespace, config.Spec); err != nil {
+	if err := s.Resource().ValidateConfig(config.Name, config.Namespace, config.Spec); err != nil {
 		return "", err
 	}
 

--- a/pilot/pkg/config/memory/config.go
+++ b/pilot/pkg/config/memory/config.go
@@ -22,8 +22,8 @@ import (
 	"time"
 
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collection"
-	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/pkg/ledger"
 	"istio.io/pkg/log"
 )
@@ -48,7 +48,7 @@ func MakeWithoutValidation(schemas collection.Schemas) model.ConfigStore {
 func MakeWithLedger(schemas collection.Schemas, configLedger ledger.Ledger, skipValidation bool) model.ConfigStore {
 	out := store{
 		schemas:        schemas,
-		data:           make(map[resource.GroupVersionKind]map[string]*sync.Map),
+		data:           make(map[config.GroupVersionKind]map[string]*sync.Map),
 		ledger:         configLedger,
 		skipValidation: skipValidation,
 	}
@@ -60,7 +60,7 @@ func MakeWithLedger(schemas collection.Schemas, configLedger ledger.Ledger, skip
 
 type store struct {
 	schemas        collection.Schemas
-	data           map[resource.GroupVersionKind]map[string]*sync.Map
+	data           map[config.GroupVersionKind]map[string]*sync.Map
 	ledger         ledger.Ledger
 	skipValidation bool
 	mutex          sync.RWMutex
@@ -87,7 +87,7 @@ func (cr *store) Version() string {
 	return cr.ledger.RootHash()
 }
 
-func (cr *store) Get(kind resource.GroupVersionKind, name, namespace string) *model.Config {
+func (cr *store) Get(kind config.GroupVersionKind, name, namespace string) *config.Config {
 	cr.mutex.RLock()
 	defer cr.mutex.RUnlock()
 	_, ok := cr.data[kind]
@@ -104,23 +104,23 @@ func (cr *store) Get(kind resource.GroupVersionKind, name, namespace string) *mo
 	if !exists {
 		return nil
 	}
-	config := out.(model.Config)
+	config := out.(config.Config)
 
 	return &config
 }
 
-func (cr *store) List(kind resource.GroupVersionKind, namespace string) ([]model.Config, error) {
+func (cr *store) List(kind config.GroupVersionKind, namespace string) ([]config.Config, error) {
 	cr.mutex.RLock()
 	defer cr.mutex.RUnlock()
 	data, exists := cr.data[kind]
 	if !exists {
 		return nil, nil
 	}
-	out := make([]model.Config, 0, len(cr.data[kind]))
+	out := make([]config.Config, 0, len(cr.data[kind]))
 	if namespace == "" {
 		for _, ns := range data {
 			ns.Range(func(key, value interface{}) bool {
-				out = append(out, value.(model.Config))
+				out = append(out, value.(config.Config))
 				return true
 			})
 		}
@@ -130,14 +130,14 @@ func (cr *store) List(kind resource.GroupVersionKind, namespace string) ([]model
 			return nil, nil
 		}
 		ns.Range(func(key, value interface{}) bool {
-			out = append(out, value.(model.Config))
+			out = append(out, value.(config.Config))
 			return true
 		})
 	}
 	return out, nil
 }
 
-func (cr *store) Delete(kind resource.GroupVersionKind, name, namespace string) error {
+func (cr *store) Delete(kind config.GroupVersionKind, name, namespace string) error {
 	cr.mutex.Lock()
 	defer cr.mutex.Unlock()
 	data, ok := cr.data[kind]
@@ -154,7 +154,7 @@ func (cr *store) Delete(kind resource.GroupVersionKind, name, namespace string) 
 		return errNotFound
 	}
 
-	err := cr.ledger.Delete(model.Key(kind.Kind, name, namespace))
+	err := cr.ledger.Delete(config.Key(kind.Kind, name, namespace))
 	if err != nil {
 		log.Warnf(ledgerLogf, err)
 	}
@@ -162,7 +162,7 @@ func (cr *store) Delete(kind resource.GroupVersionKind, name, namespace string) 
 	return nil
 }
 
-func (cr *store) Create(config model.Config) (string, error) {
+func (cr *store) Create(config config.Config) (string, error) {
 	cr.mutex.Lock()
 	defer cr.mutex.Unlock()
 	kind := config.GroupVersionKind
@@ -192,7 +192,7 @@ func (cr *store) Create(config model.Config) (string, error) {
 			config.CreationTimestamp = tnow
 		}
 
-		_, err := cr.ledger.Put(model.Key(kind.Kind, config.Namespace, config.Name), config.ResourceVersion)
+		_, err := cr.ledger.Put(config.Key(kind.Kind, config.Namespace, config.Name), config.ResourceVersion)
 		if err != nil {
 			log.Warnf(ledgerLogf, err)
 		}
@@ -202,7 +202,7 @@ func (cr *store) Create(config model.Config) (string, error) {
 	return "", errAlreadyExists
 }
 
-func (cr *store) Update(config model.Config) (string, error) {
+func (cr *store) Update(config config.Config) (string, error) {
 	cr.mutex.Lock()
 	defer cr.mutex.Unlock()
 	kind := config.GroupVersionKind
@@ -226,7 +226,7 @@ func (cr *store) Update(config model.Config) (string, error) {
 
 	rev := time.Now().String()
 	config.ResourceVersion = rev
-	_, err := cr.ledger.Put(model.Key(kind.Kind, config.Namespace, config.Name), config.ResourceVersion)
+	_, err := cr.ledger.Put(config.Key(kind.Kind, config.Namespace, config.Name), config.ResourceVersion)
 	if err != nil {
 		log.Warnf(ledgerLogf, err)
 	}

--- a/pilot/pkg/config/memory/controller.go
+++ b/pilot/pkg/config/memory/controller.go
@@ -18,8 +18,8 @@ import (
 	"errors"
 
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collection"
-	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/pkg/ledger"
 )
 
@@ -48,7 +48,7 @@ func NewSyncController(cs model.ConfigStore) model.ConfigStoreCache {
 	return out
 }
 
-func (c *controller) RegisterEventHandler(kind resource.GroupVersionKind, f func(model.Config, model.Config, model.Event)) {
+func (c *controller) RegisterEventHandler(kind config.GroupVersionKind, f func(config.Config, config.Config, model.Event)) {
 	c.monitor.AppendEventHandler(kind, f)
 }
 
@@ -81,11 +81,11 @@ func (c *controller) Schemas() collection.Schemas {
 	return c.configStore.Schemas()
 }
 
-func (c *controller) Get(kind resource.GroupVersionKind, key, namespace string) *model.Config {
+func (c *controller) Get(kind config.GroupVersionKind, key, namespace string) *config.Config {
 	return c.configStore.Get(kind, key, namespace)
 }
 
-func (c *controller) Create(config model.Config) (revision string, err error) {
+func (c *controller) Create(config config.Config) (revision string, err error) {
 	if revision, err = c.configStore.Create(config); err == nil {
 		c.monitor.ScheduleProcessEvent(ConfigEvent{
 			config: config,
@@ -95,7 +95,7 @@ func (c *controller) Create(config model.Config) (revision string, err error) {
 	return
 }
 
-func (c *controller) Update(config model.Config) (newRevision string, err error) {
+func (c *controller) Update(config config.Config) (newRevision string, err error) {
 	oldconfig := c.configStore.Get(config.GroupVersionKind, config.Name, config.Namespace)
 	if newRevision, err = c.configStore.Update(config); err == nil {
 		c.monitor.ScheduleProcessEvent(ConfigEvent{
@@ -107,7 +107,7 @@ func (c *controller) Update(config model.Config) (newRevision string, err error)
 	return
 }
 
-func (c *controller) Delete(kind resource.GroupVersionKind, key, namespace string) (err error) {
+func (c *controller) Delete(kind config.GroupVersionKind, key, namespace string) (err error) {
 	if config := c.Get(kind, key, namespace); config != nil {
 		if err = c.configStore.Delete(kind, key, namespace); err == nil {
 			c.monitor.ScheduleProcessEvent(ConfigEvent{
@@ -120,6 +120,6 @@ func (c *controller) Delete(kind resource.GroupVersionKind, key, namespace strin
 	return errors.New("Delete failure: config" + key + "does not exist")
 }
 
-func (c *controller) List(kind resource.GroupVersionKind, namespace string) ([]model.Config, error) {
+func (c *controller) List(kind config.GroupVersionKind, namespace string) ([]config.Config, error) {
 	return c.configStore.List(kind, namespace)
 }

--- a/pilot/pkg/config/memory/monitor.go
+++ b/pilot/pkg/config/memory/monitor.go
@@ -16,7 +16,7 @@ package memory
 
 import (
 	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pkg/config/schema/resource"
+	config2 "istio.io/istio/pkg/config"
 	"istio.io/pkg/log"
 )
 
@@ -26,25 +26,25 @@ const (
 )
 
 // Handler specifies a function to apply on a Config for a given event type
-type Handler func(model.Config, model.Config, model.Event)
+type Handler func(config2.Config, config2.Config, model.Event)
 
 // Monitor provides methods of manipulating changes in the config store
 type Monitor interface {
 	Run(<-chan struct{})
-	AppendEventHandler(resource.GroupVersionKind, Handler)
+	AppendEventHandler(config2.GroupVersionKind, Handler)
 	ScheduleProcessEvent(ConfigEvent)
 }
 
 // ConfigEvent defines the event to be processed
 type ConfigEvent struct {
-	config model.Config
-	old    model.Config
+	config config2.Config
+	old    config2.Config
 	event  model.Event
 }
 
 type configstoreMonitor struct {
 	store    model.ConfigStore
-	handlers map[resource.GroupVersionKind][]Handler
+	handlers map[config2.GroupVersionKind][]Handler
 	eventCh  chan ConfigEvent
 	// If enabled, events will be handled synchronously
 	sync bool
@@ -62,7 +62,7 @@ func NewSyncMonitor(store model.ConfigStore) Monitor {
 
 // NewBufferedMonitor returns new Monitor implementation with the specified event buffer size
 func newBufferedMonitor(store model.ConfigStore, bufferSize int, sync bool) Monitor {
-	handlers := make(map[resource.GroupVersionKind][]Handler)
+	handlers := make(map[config2.GroupVersionKind][]Handler)
 
 	for _, s := range store.Schemas().All() {
 		handlers[s.Resource().GroupVersionKind()] = make([]Handler, 0)
@@ -109,11 +109,11 @@ func (m *configstoreMonitor) processConfigEvent(ce ConfigEvent) {
 	m.applyHandlers(ce.old, ce.config, ce.event)
 }
 
-func (m *configstoreMonitor) AppendEventHandler(typ resource.GroupVersionKind, h Handler) {
+func (m *configstoreMonitor) AppendEventHandler(typ config2.GroupVersionKind, h Handler) {
 	m.handlers[typ] = append(m.handlers[typ], h)
 }
 
-func (m *configstoreMonitor) applyHandlers(old model.Config, config model.Config, e model.Event) {
+func (m *configstoreMonitor) applyHandlers(old config2.Config, config config2.Config, e model.Event) {
 	for _, f := range m.handlers[config.GroupVersionKind] {
 		f(old, config, e)
 	}

--- a/pilot/pkg/config/memory/monitor_test.go
+++ b/pilot/pkg/config/memory/monitor_test.go
@@ -21,6 +21,7 @@ import (
 	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/test/mock"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
 )
 
@@ -46,7 +47,7 @@ func TestEventConsistency(t *testing.T) {
 
 	lock := sync.Mutex{}
 
-	controller.RegisterEventHandler(collections.Mock.Resource().GroupVersionKind(), func(_, config model.Config, event model.Event) {
+	controller.RegisterEventHandler(collections.Mock.Resource().GroupVersionKind(), func(_, config config.Config, event model.Event) {
 
 		lock.Lock()
 		tc := testConfig

--- a/pilot/pkg/config/monitor/file_snapshot.go
+++ b/pilot/pkg/config/monitor/file_snapshot.go
@@ -21,10 +21,9 @@ import (
 	"sort"
 
 	"istio.io/istio/pilot/pkg/config/kube/crd"
-	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
-	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/pkg/log"
 )
 
@@ -40,7 +39,7 @@ var (
 type FileSnapshot struct {
 	root             string
 	domainSuffix     string
-	configTypeFilter map[resource.GroupVersionKind]bool
+	configTypeFilter map[config.GroupVersionKind]bool
 }
 
 // NewFileSnapshot returns a snapshotter.
@@ -49,7 +48,7 @@ func NewFileSnapshot(root string, schemas collection.Schemas, domainSuffix strin
 	snapshot := &FileSnapshot{
 		root:             root,
 		domainSuffix:     domainSuffix,
-		configTypeFilter: make(map[resource.GroupVersionKind]bool),
+		configTypeFilter: make(map[config.GroupVersionKind]bool),
 	}
 
 	ss := schemas.All()
@@ -68,8 +67,8 @@ func NewFileSnapshot(root string, schemas collection.Schemas, domainSuffix strin
 
 // ReadConfigFiles parses files in the root directory and returns a sorted slice of
 // eligible model.Config. This can be used as a configFunc when creating a Monitor.
-func (f *FileSnapshot) ReadConfigFiles() ([]*model.Config, error) {
-	var result []*model.Config
+func (f *FileSnapshot) ReadConfigFiles() ([]*config.Config, error) {
+	var result []*config.Config
 
 	err := filepath.Walk(f.root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -107,11 +106,11 @@ func (f *FileSnapshot) ReadConfigFiles() ([]*model.Config, error) {
 }
 
 // parseInputs is identical to crd.ParseInputs, except that it returns an array of config pointers.
-func parseInputs(data []byte, domainSuffix string) ([]*model.Config, error) {
+func parseInputs(data []byte, domainSuffix string) ([]*config.Config, error) {
 	configs, _, err := crd.ParseInputs(string(data))
 
 	// Convert to an array of pointers.
-	refs := make([]*model.Config, len(configs))
+	refs := make([]*config.Config, len(configs))
 	for i := range configs {
 		refs[i] = &configs[i]
 		refs[i].Domain = domainSuffix
@@ -120,7 +119,7 @@ func parseInputs(data []byte, domainSuffix string) ([]*model.Config, error) {
 }
 
 // byKey is an array of config objects that is capable or sorting by Namespace, GroupVersionKind, and Name.
-type byKey []*model.Config
+type byKey []*config.Config
 
 func (rs byKey) Len() int {
 	return len(rs)

--- a/pilot/pkg/config/monitor/monitor.go
+++ b/pilot/pkg/config/monitor/monitor.go
@@ -146,7 +146,7 @@ func (m *Monitor) checkAndUpdate() {
 			newIndex++
 		} else {
 			// version may change without content changing
-			oldConfig.ConfigMeta.ResourceVersion = newConfig.ConfigMeta.ResourceVersion
+			oldConfig.Meta.ResourceVersion = newConfig.Meta.ResourceVersion
 			if !reflect.DeepEqual(oldConfig, newConfig) {
 				m.updateConfig(newConfig)
 			}

--- a/pilot/pkg/config/monitor/monitor.go
+++ b/pilot/pkg/config/monitor/monitor.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config"
 	"istio.io/pkg/log"
 )
 
@@ -32,8 +33,8 @@ type Monitor struct {
 	name            string
 	root            string
 	store           model.ConfigStore
-	configs         []*model.Config
-	getSnapshotFunc func() ([]*model.Config, error)
+	configs         []*config.Config
+	getSnapshotFunc func() ([]*config.Config, error)
 	// channel to trigger updates on
 	// generally set to a file watch, but used in tests as well
 	updateCh chan struct{}
@@ -42,7 +43,7 @@ type Monitor struct {
 // NewMonitor creates a Monitor and will delegate to a passed in controller.
 // The controller holds a reference to the actual store.
 // Any func that returns a []*model.Config can be used with the Monitor
-func NewMonitor(name string, delegateStore model.ConfigStore, getSnapshotFunc func() ([]*model.Config, error), root string) *Monitor {
+func NewMonitor(name string, delegateStore model.ConfigStore, getSnapshotFunc func() ([]*config.Config, error), root string) *Monitor {
 	monitor := &Monitor{
 		name:            name,
 		root:            root,
@@ -123,7 +124,7 @@ func (m *Monitor) checkAndUpdate() {
 	}
 
 	// make a deep copy of newConfigs to prevent data race
-	copyConfigs := make([]*model.Config, 0)
+	copyConfigs := make([]*config.Config, 0)
 	for _, config := range newConfigs {
 		cpy := *config
 		cpy.Spec = proto.Clone(config.Spec)
@@ -168,13 +169,13 @@ func (m *Monitor) checkAndUpdate() {
 	m.configs = copyConfigs
 }
 
-func (m *Monitor) createConfig(c *model.Config) {
+func (m *Monitor) createConfig(c *config.Config) {
 	if _, err := m.store.Create(*c); err != nil {
 		log.Warnf("Failed to create config %s %s/%s: %v (%+v)", c.GroupVersionKind, c.Namespace, c.Name, err, *c)
 	}
 }
 
-func (m *Monitor) updateConfig(c *model.Config) {
+func (m *Monitor) updateConfig(c *config.Config) {
 	// Set the resource version based on the existing config.
 	if prev := m.store.Get(c.GroupVersionKind, c.Name, c.Namespace); prev != nil {
 		c.ResourceVersion = prev.ResourceVersion
@@ -185,7 +186,7 @@ func (m *Monitor) updateConfig(c *model.Config) {
 	}
 }
 
-func (m *Monitor) deleteConfig(c *model.Config) {
+func (m *Monitor) deleteConfig(c *config.Config) {
 	if err := m.store.Delete(c.GroupVersionKind, c.Name, c.Namespace); err != nil {
 		log.Warnf("Failed to delete config (%+v): %v ", *c, err)
 	}
@@ -193,6 +194,6 @@ func (m *Monitor) deleteConfig(c *model.Config) {
 
 // compareIds compares the IDs (i.e. Namespace, GroupVersionKind, and Name) of the two configs and returns
 // 0 if a == b, -1 if a < b, and 1 if a > b. Used for sorting config arrays.
-func compareIds(a, b *model.Config) int {
+func compareIds(a, b *config.Config) int {
 	return strings.Compare(a.Key(), b.Key())
 }

--- a/pilot/pkg/config/monitor/monitor_test.go
+++ b/pilot/pkg/config/monitor/monitor_test.go
@@ -31,7 +31,7 @@ import (
 
 var createConfigSet = []*config.Config{
 	{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:             "magic",
 			GroupVersionKind: gvk.Gateway,
 		},
@@ -52,7 +52,7 @@ var createConfigSet = []*config.Config{
 
 var updateConfigSet = []*config.Config{
 	{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:             "magic",
 			GroupVersionKind: gvk.Gateway,
 		},
@@ -115,7 +115,7 @@ func TestMonitorForChange(t *testing.T) {
 			return errors.New("no configs")
 		}
 
-		if c[0].ConfigMeta.Name != "magic" {
+		if c[0].Meta.Name != "magic" {
 			return errors.New("wrong config")
 		}
 

--- a/pilot/pkg/config/monitor/monitor_test.go
+++ b/pilot/pkg/config/monitor/monitor_test.go
@@ -23,15 +23,15 @@ import (
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/config/memory"
-	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
 )
 
-var createConfigSet = []*model.Config{
+var createConfigSet = []*config.Config{
 	{
-		ConfigMeta: model.ConfigMeta{
+		ConfigMeta: config.ConfigMeta{
 			Name:             "magic",
 			GroupVersionKind: gvk.Gateway,
 		},
@@ -50,9 +50,9 @@ var createConfigSet = []*model.Config{
 	},
 }
 
-var updateConfigSet = []*model.Config{
+var updateConfigSet = []*config.Config{
 	{
-		ConfigMeta: model.ConfigMeta{
+		ConfigMeta: config.ConfigMeta{
 			Name:             "magic",
 			GroupVersionKind: gvk.Gateway,
 		},
@@ -78,11 +78,11 @@ func TestMonitorForChange(t *testing.T) {
 
 	var (
 		callCount int
-		configs   []*model.Config
+		configs   []*config.Config
 		err       error
 	)
 
-	someConfigFunc := func() ([]*model.Config, error) {
+	someConfigFunc := func() ([]*config.Config, error) {
 		switch callCount {
 		case 0:
 			configs = createConfigSet
@@ -90,7 +90,7 @@ func TestMonitorForChange(t *testing.T) {
 		case 3:
 			configs = updateConfigSet
 		case 6:
-			configs = []*model.Config{}
+			configs = []*config.Config{}
 		}
 
 		callCount++
@@ -137,7 +137,7 @@ func TestMonitorForChange(t *testing.T) {
 		return nil
 	}).Should(gomega.Succeed())
 
-	g.Eventually(func() ([]model.Config, error) {
+	g.Eventually(func() ([]config.Config, error) {
 		return store.List(gvk.Gateway, "")
 	}).Should(gomega.HaveLen(0))
 
@@ -150,13 +150,13 @@ func TestMonitorForError(t *testing.T) {
 
 	var (
 		callCount int
-		configs   []*model.Config
+		configs   []*config.Config
 		err       error
 	)
 
 	delay := make(chan struct{}, 1)
 
-	someConfigFunc := func() ([]*model.Config, error) {
+	someConfigFunc := func() ([]*config.Config, error) {
 		switch callCount {
 		case 0:
 			configs = createConfigSet

--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -24,6 +24,7 @@ import (
 	securityBeta "istio.io/api/security/v1beta1"
 	selectorpb "istio.io/api/type/v1beta1"
 	"istio.io/istio/pilot/pkg/model/test"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/collections"
@@ -114,17 +115,17 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 		name                   string
 		workloadNamespace      string
 		workloadLabels         labels.Collection
-		wantRequestAuthn       []*Config
-		wantPeerAuthn          []*Config
+		wantRequestAuthn       []*config.Config
+		wantPeerAuthn          []*config.Config
 		wantNamespaceMutualTLS MutualTLSMode
 	}{
 		{
 			name:              "Empty workload labels in foo",
 			workloadNamespace: "foo",
 			workloadLabels:    labels.Collection{},
-			wantRequestAuthn: []*Config{
+			wantRequestAuthn: []*config.Config{
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "foo",
@@ -132,7 +133,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					Spec: &securityBeta.RequestAuthentication{},
 				},
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "istio-config",
@@ -140,9 +141,9 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					Spec: &securityBeta.RequestAuthentication{},
 				},
 			},
-			wantPeerAuthn: []*Config{
+			wantPeerAuthn: []*config.Config{
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
@@ -155,7 +156,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
@@ -174,9 +175,9 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			name:              "Empty workload labels in bar",
 			workloadNamespace: "bar",
 			workloadLabels:    labels.Collection{},
-			wantRequestAuthn: []*Config{
+			wantRequestAuthn: []*config.Config{
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "bar",
@@ -184,7 +185,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					Spec: &securityBeta.RequestAuthentication{},
 				},
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "istio-config",
@@ -192,9 +193,9 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					Spec: &securityBeta.RequestAuthentication{},
 				},
 			},
-			wantPeerAuthn: []*Config{
+			wantPeerAuthn: []*config.Config{
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
@@ -213,9 +214,9 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			name:              "Empty workload labels in baz",
 			workloadNamespace: "baz",
 			workloadLabels:    labels.Collection{},
-			wantRequestAuthn: []*Config{
+			wantRequestAuthn: []*config.Config{
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "istio-config",
@@ -223,9 +224,9 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					Spec: &securityBeta.RequestAuthentication{},
 				},
 			},
-			wantPeerAuthn: []*Config{
+			wantPeerAuthn: []*config.Config{
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
@@ -244,9 +245,9 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			name:              "Match workload labels in foo",
 			workloadNamespace: "foo",
 			workloadLabels:    labels.Collection{{"app": "httpbin", "version": "v1", "other": "labels"}},
-			wantRequestAuthn: []*Config{
+			wantRequestAuthn: []*config.Config{
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "foo",
@@ -254,7 +255,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					Spec: &securityBeta.RequestAuthentication{},
 				},
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "with-selector",
 						Namespace:        "foo",
@@ -269,7 +270,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "istio-config",
@@ -277,7 +278,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					Spec: &securityBeta.RequestAuthentication{},
 				},
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "global-with-selector",
 						Namespace:        "istio-config",
@@ -291,9 +292,9 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					},
 				},
 			},
-			wantPeerAuthn: []*Config{
+			wantPeerAuthn: []*config.Config{
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
@@ -306,7 +307,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "peer-with-selector",
@@ -324,7 +325,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
@@ -343,9 +344,9 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			name:              "Match workload labels in bar",
 			workloadNamespace: "bar",
 			workloadLabels:    labels.Collection{{"app": "httpbin", "version": "v1"}},
-			wantRequestAuthn: []*Config{
+			wantRequestAuthn: []*config.Config{
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "bar",
@@ -353,7 +354,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					Spec: &securityBeta.RequestAuthentication{},
 				},
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "istio-config",
@@ -361,7 +362,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					Spec: &securityBeta.RequestAuthentication{},
 				},
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "global-with-selector",
 						Namespace:        "istio-config",
@@ -375,9 +376,9 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					},
 				},
 			},
-			wantPeerAuthn: []*Config{
+			wantPeerAuthn: []*config.Config{
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
@@ -396,9 +397,9 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			name:              "Paritial match workload labels in foo",
 			workloadNamespace: "foo",
 			workloadLabels:    labels.Collection{{"app": "httpbin"}},
-			wantRequestAuthn: []*Config{
+			wantRequestAuthn: []*config.Config{
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "foo",
@@ -406,7 +407,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					Spec: &securityBeta.RequestAuthentication{},
 				},
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "istio-config",
@@ -414,7 +415,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					Spec: &securityBeta.RequestAuthentication{},
 				},
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "global-with-selector",
 						Namespace:        "istio-config",
@@ -428,9 +429,9 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					},
 				},
 			},
-			wantPeerAuthn: []*Config{
+			wantPeerAuthn: []*config.Config{
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
@@ -443,7 +444,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
@@ -482,16 +483,16 @@ func TestGetPoliciesForWorkloadWithoutMeshPeerAuthn(t *testing.T) {
 		name                   string
 		workloadNamespace      string
 		workloadLabels         labels.Collection
-		wantPeerAuthn          []*Config
+		wantPeerAuthn          []*config.Config
 		wantNamespaceMutualTLS MutualTLSMode
 	}{
 		{
 			name:              "Empty workload labels in foo",
 			workloadNamespace: "foo",
 			workloadLabels:    labels.Collection{},
-			wantPeerAuthn: []*Config{
+			wantPeerAuthn: []*config.Config{
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
@@ -510,23 +511,23 @@ func TestGetPoliciesForWorkloadWithoutMeshPeerAuthn(t *testing.T) {
 			name:                   "Empty workload labels in bar",
 			workloadNamespace:      "bar",
 			workloadLabels:         labels.Collection{},
-			wantPeerAuthn:          []*Config{},
+			wantPeerAuthn:          []*config.Config{},
 			wantNamespaceMutualTLS: MTLSUnknown,
 		},
 		{
 			name:                   "Empty workload labels in baz",
 			workloadNamespace:      "baz",
 			workloadLabels:         labels.Collection{},
-			wantPeerAuthn:          []*Config{},
+			wantPeerAuthn:          []*config.Config{},
 			wantNamespaceMutualTLS: MTLSUnknown,
 		},
 		{
 			name:              "Match workload labels in foo",
 			workloadNamespace: "foo",
 			workloadLabels:    labels.Collection{{"app": "httpbin", "version": "v1", "other": "labels"}},
-			wantPeerAuthn: []*Config{
+			wantPeerAuthn: []*config.Config{
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
@@ -539,7 +540,7 @@ func TestGetPoliciesForWorkloadWithoutMeshPeerAuthn(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "peer-with-selector",
@@ -563,16 +564,16 @@ func TestGetPoliciesForWorkloadWithoutMeshPeerAuthn(t *testing.T) {
 			name:                   "Match workload labels in bar",
 			workloadNamespace:      "bar",
 			workloadLabels:         labels.Collection{{"app": "httpbin", "version": "v1"}},
-			wantPeerAuthn:          []*Config{},
+			wantPeerAuthn:          []*config.Config{},
 			wantNamespaceMutualTLS: MTLSUnknown,
 		},
 		{
 			name:              "Paritial match workload labels in foo",
 			workloadNamespace: "foo",
 			workloadLabels:    labels.Collection{{"app": "httpbin"}},
-			wantPeerAuthn: []*Config{
+			wantPeerAuthn: []*config.Config{
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
@@ -616,15 +617,15 @@ func TestGetPoliciesForWorkloadWithJwksResolver(t *testing.T) {
 		name              string
 		workloadNamespace string
 		workloadLabels    labels.Collection
-		wantRequestAuthn  []*Config
+		wantRequestAuthn  []*config.Config
 	}{
 		{
 			name:              "single hit",
 			workloadNamespace: "foo",
 			workloadLabels:    labels.Collection{},
-			wantRequestAuthn: []*Config{
+			wantRequestAuthn: []*config.Config{
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        rootNamespace,
@@ -644,9 +645,9 @@ func TestGetPoliciesForWorkloadWithJwksResolver(t *testing.T) {
 			name:              "double hit",
 			workloadNamespace: "foo",
 			workloadLabels:    labels.Collection{{"app": "httpbin"}},
-			wantRequestAuthn: []*Config{
+			wantRequestAuthn: []*config.Config{
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        rootNamespace,
@@ -661,7 +662,7 @@ func TestGetPoliciesForWorkloadWithJwksResolver(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "global-with-selector",
 						Namespace:        rootNamespace,
@@ -689,9 +690,9 @@ func TestGetPoliciesForWorkloadWithJwksResolver(t *testing.T) {
 			name:              "tripple hit",
 			workloadNamespace: "foo",
 			workloadLabels:    labels.Collection{{"app": "httpbin", "version": "v1"}},
-			wantRequestAuthn: []*Config{
+			wantRequestAuthn: []*config.Config{
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "with-selector",
 						Namespace:        "foo",
@@ -716,7 +717,7 @@ func TestGetPoliciesForWorkloadWithJwksResolver(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        rootNamespace,
@@ -731,7 +732,7 @@ func TestGetPoliciesForWorkloadWithJwksResolver(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "global-with-selector",
 						Namespace:        rootNamespace,
@@ -766,7 +767,7 @@ func TestGetPoliciesForWorkloadWithJwksResolver(t *testing.T) {
 	}
 }
 
-func getTestAuthenticationPolicies(configs []*Config, t *testing.T) *AuthenticationPolicies {
+func getTestAuthenticationPolicies(configs []*config.Config, t *testing.T) *AuthenticationPolicies {
 	configStore := NewFakeStore()
 	for _, cfg := range configs {
 		log.Infof("add config %s\n", cfg.Name)
@@ -786,9 +787,9 @@ func getTestAuthenticationPolicies(configs []*Config, t *testing.T) *Authenticat
 	return authnPolicy
 }
 
-func createTestRequestAuthenticationResource(name string, namespace string, selector *selectorpb.WorkloadSelector) *Config {
-	return &Config{
-		ConfigMeta: ConfigMeta{
+func createTestRequestAuthenticationResource(name string, namespace string, selector *selectorpb.WorkloadSelector) *config.Config {
+	return &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind(),
 			Name:             name,
 			Namespace:        namespace,
@@ -800,9 +801,9 @@ func createTestRequestAuthenticationResource(name string, namespace string, sele
 }
 
 func createTestPeerAuthenticationResource(name string, namespace string, timestamp time.Time,
-	selector *selectorpb.WorkloadSelector, mode securityBeta.PeerAuthentication_MutualTLS_Mode) *Config {
-	return &Config{
-		ConfigMeta: ConfigMeta{
+	selector *selectorpb.WorkloadSelector, mode securityBeta.PeerAuthentication_MutualTLS_Mode) *config.Config {
+	return &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind:  collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind(),
 			Name:              name,
 			Namespace:         namespace,
@@ -817,8 +818,8 @@ func createTestPeerAuthenticationResource(name string, namespace string, timesta
 	}
 }
 
-func createTestConfigs(withMeshPeerAuthn bool) []*Config {
-	configs := make([]*Config, 0)
+func createTestConfigs(withMeshPeerAuthn bool) []*config.Config {
+	configs := make([]*config.Config, 0)
 
 	selector := &selectorpb.WorkloadSelector{
 		MatchLabels: map[string]string{
@@ -862,7 +863,7 @@ func createTestConfigs(withMeshPeerAuthn bool) []*Config {
 	return configs
 }
 
-func addJwtRule(issuer, jwksURI, jwks string, config *Config) {
+func addJwtRule(issuer, jwksURI, jwks string, config *config.Config) {
 	spec := config.Spec.(*securityBeta.RequestAuthentication)
 	if spec.JwtRules == nil {
 		spec.JwtRules = make([]*securityBeta.JWTRule, 0)
@@ -874,8 +875,8 @@ func addJwtRule(issuer, jwksURI, jwks string, config *Config) {
 	})
 }
 
-func createNonTrivialRequestAuthnTestConfigs(issuer string) []*Config {
-	configs := make([]*Config, 0)
+func createNonTrivialRequestAuthnTestConfigs(issuer string) []*config.Config {
+	configs := make([]*config.Config, 0)
 
 	globalCfg := createTestRequestAuthenticationResource("default", rootNamespace, nil)
 	addJwtRule(issuer, "", "", globalCfg)
@@ -905,7 +906,7 @@ func createNonTrivialRequestAuthnTestConfigs(issuer string) []*Config {
 	return configs
 }
 
-func printConfigs(configs []*Config) string {
+func printConfigs(configs []*config.Config) string {
 	s := "[\n"
 	for _, c := range configs {
 		s += fmt.Sprintf("%+v\n", c)

--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -125,7 +125,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			workloadLabels:    labels.Collection{},
 			wantRequestAuthn: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "foo",
@@ -133,7 +133,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					Spec: &securityBeta.RequestAuthentication{},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "istio-config",
@@ -143,7 +143,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			},
 			wantPeerAuthn: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
@@ -156,7 +156,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
@@ -177,7 +177,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			workloadLabels:    labels.Collection{},
 			wantRequestAuthn: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "bar",
@@ -185,7 +185,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					Spec: &securityBeta.RequestAuthentication{},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "istio-config",
@@ -195,7 +195,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			},
 			wantPeerAuthn: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
@@ -216,7 +216,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			workloadLabels:    labels.Collection{},
 			wantRequestAuthn: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "istio-config",
@@ -226,7 +226,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			},
 			wantPeerAuthn: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
@@ -247,7 +247,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			workloadLabels:    labels.Collection{{"app": "httpbin", "version": "v1", "other": "labels"}},
 			wantRequestAuthn: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "foo",
@@ -255,7 +255,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					Spec: &securityBeta.RequestAuthentication{},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "with-selector",
 						Namespace:        "foo",
@@ -270,7 +270,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "istio-config",
@@ -278,7 +278,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					Spec: &securityBeta.RequestAuthentication{},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "global-with-selector",
 						Namespace:        "istio-config",
@@ -294,7 +294,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			},
 			wantPeerAuthn: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
@@ -307,7 +307,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "peer-with-selector",
@@ -325,7 +325,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
@@ -346,7 +346,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			workloadLabels:    labels.Collection{{"app": "httpbin", "version": "v1"}},
 			wantRequestAuthn: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "bar",
@@ -354,7 +354,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					Spec: &securityBeta.RequestAuthentication{},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "istio-config",
@@ -362,7 +362,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					Spec: &securityBeta.RequestAuthentication{},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "global-with-selector",
 						Namespace:        "istio-config",
@@ -378,7 +378,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			},
 			wantPeerAuthn: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
@@ -399,7 +399,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			workloadLabels:    labels.Collection{{"app": "httpbin"}},
 			wantRequestAuthn: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "foo",
@@ -407,7 +407,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					Spec: &securityBeta.RequestAuthentication{},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        "istio-config",
@@ -415,7 +415,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					Spec: &securityBeta.RequestAuthentication{},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "global-with-selector",
 						Namespace:        "istio-config",
@@ -431,7 +431,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 			},
 			wantPeerAuthn: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
@@ -444,7 +444,7 @@ func TestGetPoliciesForWorkload(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
@@ -492,7 +492,7 @@ func TestGetPoliciesForWorkloadWithoutMeshPeerAuthn(t *testing.T) {
 			workloadLabels:    labels.Collection{},
 			wantPeerAuthn: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
@@ -527,7 +527,7 @@ func TestGetPoliciesForWorkloadWithoutMeshPeerAuthn(t *testing.T) {
 			workloadLabels:    labels.Collection{{"app": "httpbin", "version": "v1", "other": "labels"}},
 			wantPeerAuthn: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
@@ -540,7 +540,7 @@ func TestGetPoliciesForWorkloadWithoutMeshPeerAuthn(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "peer-with-selector",
@@ -573,7 +573,7 @@ func TestGetPoliciesForWorkloadWithoutMeshPeerAuthn(t *testing.T) {
 			workloadLabels:    labels.Collection{{"app": "httpbin"}},
 			wantPeerAuthn: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind:  gvk.PeerAuthentication,
 						CreationTimestamp: baseTimestamp,
 						Name:              "default",
@@ -625,7 +625,7 @@ func TestGetPoliciesForWorkloadWithJwksResolver(t *testing.T) {
 			workloadLabels:    labels.Collection{},
 			wantRequestAuthn: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        rootNamespace,
@@ -647,7 +647,7 @@ func TestGetPoliciesForWorkloadWithJwksResolver(t *testing.T) {
 			workloadLabels:    labels.Collection{{"app": "httpbin"}},
 			wantRequestAuthn: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        rootNamespace,
@@ -662,7 +662,7 @@ func TestGetPoliciesForWorkloadWithJwksResolver(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "global-with-selector",
 						Namespace:        rootNamespace,
@@ -692,7 +692,7 @@ func TestGetPoliciesForWorkloadWithJwksResolver(t *testing.T) {
 			workloadLabels:    labels.Collection{{"app": "httpbin", "version": "v1"}},
 			wantRequestAuthn: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "with-selector",
 						Namespace:        "foo",
@@ -717,7 +717,7 @@ func TestGetPoliciesForWorkloadWithJwksResolver(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "default",
 						Namespace:        rootNamespace,
@@ -732,7 +732,7 @@ func TestGetPoliciesForWorkloadWithJwksResolver(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind: gvk.RequestAuthentication,
 						Name:             "global-with-selector",
 						Namespace:        rootNamespace,
@@ -789,7 +789,7 @@ func getTestAuthenticationPolicies(configs []*config.Config, t *testing.T) *Auth
 
 func createTestRequestAuthenticationResource(name string, namespace string, selector *selectorpb.WorkloadSelector) *config.Config {
 	return &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind(),
 			Name:             name,
 			Namespace:        namespace,
@@ -803,7 +803,7 @@ func createTestRequestAuthenticationResource(name string, namespace string, sele
 func createTestPeerAuthenticationResource(name string, namespace string, timestamp time.Time,
 	selector *selectorpb.WorkloadSelector, mode securityBeta.PeerAuthentication_MutualTLS_Mode) *config.Config {
 	return &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind:  collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind(),
 			Name:              name,
 			Namespace:         namespace,

--- a/pilot/pkg/model/authorization_test.go
+++ b/pilot/pkg/model/authorization_test.go
@@ -24,11 +24,11 @@ import (
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	authpb "istio.io/api/security/v1beta1"
 	selectorpb "istio.io/api/type/v1beta1"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
-	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/pkg/ledger"
 )
 
@@ -70,7 +70,7 @@ func TestAuthorizationPolicies_ListAuthorizationPolicies(t *testing.T) {
 		name           string
 		ns             string
 		workloadLabels map[string]string
-		configs        []Config
+		configs        []config.Config
 		wantDeny       []AuthorizationPolicy
 		wantAllow      []AuthorizationPolicy
 		wantAudit      []AuthorizationPolicy
@@ -83,7 +83,7 @@ func TestAuthorizationPolicies_ListAuthorizationPolicies(t *testing.T) {
 		{
 			name: "no policies in namespace foo",
 			ns:   "foo",
-			configs: []Config{
+			configs: []config.Config{
 				newConfig("authz-1", "bar", policy),
 				newConfig("authz-2", "bar", policy),
 			},
@@ -92,7 +92,7 @@ func TestAuthorizationPolicies_ListAuthorizationPolicies(t *testing.T) {
 		{
 			name: "one allow policy",
 			ns:   "bar",
-			configs: []Config{
+			configs: []config.Config{
 				newConfig("authz-1", "bar", policy),
 			},
 			wantAllow: []AuthorizationPolicy{
@@ -106,7 +106,7 @@ func TestAuthorizationPolicies_ListAuthorizationPolicies(t *testing.T) {
 		{
 			name: "one deny policy",
 			ns:   "bar",
-			configs: []Config{
+			configs: []config.Config{
 				newConfig("authz-1", "bar", denyPolicy),
 			},
 			wantDeny: []AuthorizationPolicy{
@@ -120,7 +120,7 @@ func TestAuthorizationPolicies_ListAuthorizationPolicies(t *testing.T) {
 		{
 			name: "one audit policy",
 			ns:   "bar",
-			configs: []Config{
+			configs: []config.Config{
 				newConfig("authz-1", "bar", auditPolicy),
 			},
 			wantAudit: []AuthorizationPolicy{
@@ -134,7 +134,7 @@ func TestAuthorizationPolicies_ListAuthorizationPolicies(t *testing.T) {
 		{
 			name: "two policies",
 			ns:   "bar",
-			configs: []Config{
+			configs: []config.Config{
 				newConfig("authz-1", "foo", policy),
 				newConfig("authz-1", "bar", policy),
 				newConfig("authz-2", "bar", policy),
@@ -155,7 +155,7 @@ func TestAuthorizationPolicies_ListAuthorizationPolicies(t *testing.T) {
 		{
 			name: "mixing allow, deny, and audit policies",
 			ns:   "bar",
-			configs: []Config{
+			configs: []config.Config{
 				newConfig("authz-1", "bar", policy),
 				newConfig("authz-2", "bar", denyPolicy),
 				newConfig("authz-3", "bar", auditPolicy),
@@ -195,7 +195,7 @@ func TestAuthorizationPolicies_ListAuthorizationPolicies(t *testing.T) {
 				"app":     "httpbin",
 				"version": "v1",
 			},
-			configs: []Config{
+			configs: []config.Config{
 				newConfig("authz-1", "bar", policyWithSelector),
 			},
 			wantAllow: []AuthorizationPolicy{
@@ -214,7 +214,7 @@ func TestAuthorizationPolicies_ListAuthorizationPolicies(t *testing.T) {
 				"version": "v1",
 				"env":     "dev",
 			},
-			configs: []Config{
+			configs: []config.Config{
 				newConfig("authz-1", "bar", policyWithSelector),
 			},
 			wantAllow: []AuthorizationPolicy{
@@ -232,7 +232,7 @@ func TestAuthorizationPolicies_ListAuthorizationPolicies(t *testing.T) {
 				"app":     "httpbin",
 				"version": "v2",
 			},
-			configs: []Config{
+			configs: []config.Config{
 				newConfig("authz-1", "bar", policyWithSelector),
 			},
 			wantAllow: nil,
@@ -244,7 +244,7 @@ func TestAuthorizationPolicies_ListAuthorizationPolicies(t *testing.T) {
 				"app":     "httpbin",
 				"version": "v1",
 			},
-			configs: []Config{
+			configs: []config.Config{
 				newConfig("authz-1", "bar", policyWithSelector),
 			},
 			wantAllow: nil,
@@ -252,7 +252,7 @@ func TestAuthorizationPolicies_ListAuthorizationPolicies(t *testing.T) {
 		{
 			name: "root namespace",
 			ns:   "bar",
-			configs: []Config{
+			configs: []config.Config{
 				newConfig("authz-1", "istio-config", policy),
 			},
 			wantAllow: []AuthorizationPolicy{
@@ -266,7 +266,7 @@ func TestAuthorizationPolicies_ListAuthorizationPolicies(t *testing.T) {
 		{
 			name: "root namespace equals config namespace",
 			ns:   "istio-config",
-			configs: []Config{
+			configs: []config.Config{
 				newConfig("authz-1", "istio-config", policy),
 			},
 			wantAllow: []AuthorizationPolicy{
@@ -280,7 +280,7 @@ func TestAuthorizationPolicies_ListAuthorizationPolicies(t *testing.T) {
 		{
 			name: "root namespace and config namespace",
 			ns:   "bar",
-			configs: []Config{
+			configs: []config.Config{
 				newConfig("authz-1", "istio-config", policy),
 				newConfig("authz-2", "bar", policy),
 			},
@@ -318,7 +318,7 @@ func TestAuthorizationPolicies_ListAuthorizationPolicies(t *testing.T) {
 	}
 }
 
-func createFakeAuthorizationPolicies(configs []Config, t *testing.T) *AuthorizationPolicies {
+func createFakeAuthorizationPolicies(configs []config.Config, t *testing.T) *AuthorizationPolicies {
 	store := &authzFakeStore{}
 	for _, cfg := range configs {
 		store.add(cfg)
@@ -334,9 +334,9 @@ func createFakeAuthorizationPolicies(configs []Config, t *testing.T) *Authorizat
 	return authzPolicies
 }
 
-func newConfig(name, ns string, spec proto.Message) Config {
-	return Config{
-		ConfigMeta: ConfigMeta{
+func newConfig(name, ns string, spec proto.Message) config.Config {
+	return config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind(),
 			Name:             name,
 			Namespace:        ns,
@@ -347,9 +347,9 @@ func newConfig(name, ns string, spec proto.Message) Config {
 
 type authzFakeStore struct {
 	data []struct {
-		typ resource.GroupVersionKind
+		typ config.GroupVersionKind
 		ns  string
-		cfg Config
+		cfg config.Config
 	}
 }
 
@@ -361,11 +361,11 @@ func (fs *authzFakeStore) SetLedger(ledger.Ledger) error {
 	panic("implement me")
 }
 
-func (fs *authzFakeStore) add(config Config) {
+func (fs *authzFakeStore) add(config config.Config) {
 	fs.data = append(fs.data, struct {
-		typ resource.GroupVersionKind
+		typ config.GroupVersionKind
 		ns  string
-		cfg Config
+		cfg config.Config
 	}{
 		typ: config.GroupVersionKind,
 		ns:  config.Namespace,
@@ -377,12 +377,12 @@ func (fs *authzFakeStore) Schemas() collection.Schemas {
 	return collection.SchemasFor()
 }
 
-func (fs *authzFakeStore) Get(_ resource.GroupVersionKind, _, _ string) *Config {
+func (fs *authzFakeStore) Get(_ config.GroupVersionKind, _, _ string) *config.Config {
 	return nil
 }
 
-func (fs *authzFakeStore) List(typ resource.GroupVersionKind, namespace string) ([]Config, error) {
-	var configs []Config
+func (fs *authzFakeStore) List(typ config.GroupVersionKind, namespace string) ([]config.Config, error) {
+	var configs []config.Config
 	for _, data := range fs.data {
 		if data.typ == typ {
 			if namespace != "" && data.ns == namespace {
@@ -394,14 +394,14 @@ func (fs *authzFakeStore) List(typ resource.GroupVersionKind, namespace string) 
 	return configs, nil
 }
 
-func (fs *authzFakeStore) Delete(_ resource.GroupVersionKind, _, _ string) error {
+func (fs *authzFakeStore) Delete(_ config.GroupVersionKind, _, _ string) error {
 	return fmt.Errorf("not implemented")
 }
-func (fs *authzFakeStore) Create(Config) (string, error) {
+func (fs *authzFakeStore) Create(config.Config) (string, error) {
 	return "not implemented", nil
 }
 
-func (fs *authzFakeStore) Update(Config) (string, error) {
+func (fs *authzFakeStore) Update(config.Config) (string, error) {
 	return "not implemented", nil
 }
 

--- a/pilot/pkg/model/authorization_test.go
+++ b/pilot/pkg/model/authorization_test.go
@@ -336,7 +336,7 @@ func createFakeAuthorizationPolicies(configs []config.Config, t *testing.T) *Aut
 
 func newConfig(name, ns string, spec proto.Message) config.Config {
 	return config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind(),
 			Name:             name,
 			Namespace:        ns,

--- a/pilot/pkg/model/authorization_test.go
+++ b/pilot/pkg/model/authorization_test.go
@@ -361,15 +361,15 @@ func (fs *authzFakeStore) SetLedger(ledger.Ledger) error {
 	panic("implement me")
 }
 
-func (fs *authzFakeStore) add(config config.Config) {
+func (fs *authzFakeStore) add(cfg config.Config) {
 	fs.data = append(fs.data, struct {
 		typ config.GroupVersionKind
 		ns  string
 		cfg config.Config
 	}{
-		typ: config.GroupVersionKind,
-		ns:  config.Namespace,
-		cfg: config,
+		typ: cfg.GroupVersionKind,
+		ns:  cfg.Namespace,
+		cfg: cfg,
 	})
 }
 

--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -193,7 +193,7 @@ const (
 
 // ResolveShortnameToFQDN uses metadata information to resolve a reference
 // to shortname of the service to FQDN
-func ResolveShortnameToFQDN(hostname string, meta config.ConfigMeta) host.Name {
+func ResolveShortnameToFQDN(hostname string, meta config.Meta) host.Name {
 	out := hostname
 	// Treat the wildcard hostname as fully qualified. Any other variant of a wildcard hostname will contain a `.` too,
 	// and skip the next if, so we only need to check for the literal wildcard itself.
@@ -219,7 +219,7 @@ func ResolveShortnameToFQDN(hostname string, meta config.ConfigMeta) host.Name {
 
 // resolveGatewayName uses metadata information to resolve a reference
 // to shortname of the gateway to FQDN
-func resolveGatewayName(gwname string, meta config.ConfigMeta) string {
+func resolveGatewayName(gwname string, meta config.Meta) string {
 	out := gwname
 
 	// New way of binding to a gateway in remote namespace

--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -15,21 +15,18 @@
 package model
 
 import (
-	"fmt"
 	"hash/crc32"
 	"sort"
 	"strings"
-	"time"
 
 	udpa "github.com/cncf/udpa/go/udpa/type/v1"
-	"github.com/gogo/protobuf/proto"
 
 	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/gvk"
-	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/pkg/ledger"
 )
 
@@ -41,7 +38,7 @@ var (
 // ConfigKey describe a specific config item.
 // In most cases, the name is the config's name. However, for ServiceEntry it is service's FQDN.
 type ConfigKey struct {
-	Kind      resource.GroupVersionKind
+	Kind      config.GroupVersionKind
 	Name      string
 	Namespace string
 }
@@ -57,7 +54,7 @@ func (key ConfigKey) HashCode() uint32 {
 }
 
 // ConfigsOfKind extracts configs of the specified kind.
-func ConfigsOfKind(configs map[ConfigKey]struct{}, kind resource.GroupVersionKind) map[ConfigKey]struct{} {
+func ConfigsOfKind(configs map[ConfigKey]struct{}, kind config.GroupVersionKind) map[ConfigKey]struct{} {
 	ret := make(map[ConfigKey]struct{})
 
 	for conf := range configs {
@@ -70,7 +67,7 @@ func ConfigsOfKind(configs map[ConfigKey]struct{}, kind resource.GroupVersionKin
 }
 
 // ConfigNamesOfKind extracts config names of the specified kind.
-func ConfigNamesOfKind(configs map[ConfigKey]struct{}, kind resource.GroupVersionKind) map[string]struct{} {
+func ConfigNamesOfKind(configs map[ConfigKey]struct{}, kind config.GroupVersionKind) map[string]struct{} {
 	ret := make(map[string]struct{})
 
 	for conf := range configs {
@@ -80,61 +77,6 @@ func ConfigNamesOfKind(configs map[ConfigKey]struct{}, kind resource.GroupVersio
 	}
 
 	return ret
-}
-
-// ConfigMeta is metadata attached to each configuration unit.
-// The revision is optional, and if provided, identifies the
-// last update operation on the object.
-type ConfigMeta struct {
-	// GroupVersionKind is a short configuration name that matches the content message type
-	// (e.g. "route-rule")
-	GroupVersionKind resource.GroupVersionKind `json:"type,omitempty"`
-
-	// Name is a unique immutable identifier in a namespace
-	Name string `json:"name,omitempty"`
-
-	// Namespace defines the space for names (optional for some types),
-	// applications may choose to use namespaces for a variety of purposes
-	// (security domains, fault domains, organizational domains)
-	Namespace string `json:"namespace,omitempty"`
-
-	// Domain defines the suffix of the fully qualified name past the namespace.
-	// Domain is not a part of the unique key unlike name and namespace.
-	Domain string `json:"domain,omitempty"`
-
-	// Map of string keys and values that can be used to organize and categorize
-	// (scope and select) objects.
-	Labels map[string]string `json:"labels,omitempty"`
-
-	// Annotations is an unstructured key value map stored with a resource that may be
-	// set by external tools to store and retrieve arbitrary metadata. They are not
-	// queryable and should be preserved when modifying objects.
-	Annotations map[string]string `json:"annotations,omitempty"`
-
-	// ResourceVersion is an opaque identifier for tracking updates to the config registry.
-	// The implementation may use a change index or a commit log for the revision.
-	// The config client should not make any assumptions about revisions and rely only on
-	// exact equality to implement optimistic concurrency of read-write operations.
-	//
-	// The lifetime of an object of a particular revision depends on the underlying data store.
-	// The data store may compactify old revisions in the interest of storage optimization.
-	//
-	// An empty revision carries a special meaning that the associated object has
-	// not been stored and assigned a revision.
-	ResourceVersion string `json:"resourceVersion,omitempty"`
-
-	// CreationTimestamp records the creation time
-	CreationTimestamp time.Time `json:"creationTimestamp,omitempty"`
-}
-
-// Config is a configuration unit consisting of the type of configuration, the
-// key identifier that is unique per type, and the content represented as a
-// protobuf message.
-type Config struct {
-	ConfigMeta
-
-	// Spec holds the configuration object as a gogo protobuf message
-	Spec proto.Message
 }
 
 // ConfigStore describes a set of platform agnostic APIs that must be supported
@@ -171,26 +113,26 @@ type ConfigStore interface {
 	Schemas() collection.Schemas
 
 	// Get retrieves a configuration element by a type and a key
-	Get(typ resource.GroupVersionKind, name, namespace string) *Config
+	Get(typ config.GroupVersionKind, name, namespace string) *config.Config
 
 	// List returns objects by type and namespace.
 	// Use "" for the namespace to list across namespaces.
-	List(typ resource.GroupVersionKind, namespace string) ([]Config, error)
+	List(typ config.GroupVersionKind, namespace string) ([]config.Config, error)
 
 	// Create adds a new configuration object to the store. If an object with the
 	// same name and namespace for the type already exists, the operation fails
 	// with no side effects.
-	Create(config Config) (revision string, err error)
+	Create(config config.Config) (revision string, err error)
 
 	// Update modifies an existing configuration object in the store.  Update
 	// requires that the object has been created.  Resource version prevents
 	// overriding a value that has been changed between prior _Get_ and _Put_
 	// operation to achieve optimistic concurrency. This method returns a new
 	// revision if the operation succeeds.
-	Update(config Config) (newRevision string, err error)
+	Update(config config.Config) (newRevision string, err error)
 
 	// Delete removes an object from the store by key
-	Delete(typ resource.GroupVersionKind, name, namespace string) error
+	Delete(typ config.GroupVersionKind, name, namespace string) error
 
 	Version() string
 
@@ -199,17 +141,6 @@ type ConfigStore interface {
 	GetLedger() ledger.Ledger
 
 	SetLedger(ledger.Ledger) error
-}
-
-// Key function for the configuration objects
-func Key(typ, name, namespace string) string {
-	return fmt.Sprintf("%s/%s/%s", typ, namespace, name)
-}
-
-// Key is the unique identifier for a configuration object
-// TODO: this is *not* unique - needs the version and group
-func (meta *ConfigMeta) Key() string {
-	return Key(meta.GroupVersionKind.Kind, meta.Name, meta.Namespace)
 }
 
 // ConfigStoreCache is a local fully-replicated cache of the config store.  The
@@ -230,7 +161,7 @@ type ConfigStoreCache interface {
 
 	// RegisterEventHandler adds a handler to receive config update events for a
 	// configuration type
-	RegisterEventHandler(kind resource.GroupVersionKind, handler func(Config, Config, Event))
+	RegisterEventHandler(kind config.GroupVersionKind, handler func(config.Config, config.Config, Event))
 
 	// Run until a signal is received
 	Run(stop <-chan struct{})
@@ -246,13 +177,13 @@ type IstioConfigStore interface {
 	ConfigStore
 
 	// ServiceEntries lists all service entries
-	ServiceEntries() []Config
+	ServiceEntries() []config.Config
 
 	// Gateways lists all gateways bound to the specified workload labels
-	Gateways(workloadLabels labels.Collection) []Config
+	Gateways(workloadLabels labels.Collection) []config.Config
 
 	// AuthorizationPolicies selects AuthorizationPolicies in the specified namespace.
-	AuthorizationPolicies(namespace string) []Config
+	AuthorizationPolicies(namespace string) []config.Config
 }
 
 const (
@@ -262,7 +193,7 @@ const (
 
 // ResolveShortnameToFQDN uses metadata information to resolve a reference
 // to shortname of the service to FQDN
-func ResolveShortnameToFQDN(hostname string, meta ConfigMeta) host.Name {
+func ResolveShortnameToFQDN(hostname string, meta config.ConfigMeta) host.Name {
 	out := hostname
 	// Treat the wildcard hostname as fully qualified. Any other variant of a wildcard hostname will contain a `.` too,
 	// and skip the next if, so we only need to check for the literal wildcard itself.
@@ -288,7 +219,7 @@ func ResolveShortnameToFQDN(hostname string, meta ConfigMeta) host.Name {
 
 // resolveGatewayName uses metadata information to resolve a reference
 // to shortname of the gateway to FQDN
-func resolveGatewayName(gwname string, meta ConfigMeta) string {
+func resolveGatewayName(gwname string, meta config.ConfigMeta) string {
 	out := gwname
 
 	// New way of binding to a gateway in remote namespace
@@ -351,7 +282,7 @@ func MakeIstioStore(store ConfigStore) IstioConfigStore {
 	return &istioConfigStore{store}
 }
 
-func (store *istioConfigStore) ServiceEntries() []Config {
+func (store *istioConfigStore) ServiceEntries() []config.Config {
 	serviceEntries, err := store.List(gvk.ServiceEntry, NamespaceAll)
 	if err != nil {
 		return nil
@@ -364,7 +295,7 @@ func (store *istioConfigStore) ServiceEntries() []Config {
 }
 
 // sortConfigByCreationTime sorts the list of config objects in ascending order by their creation time (if available).
-func sortConfigByCreationTime(configs []Config) {
+func sortConfigByCreationTime(configs []config.Config) {
 	sort.SliceStable(configs, func(i, j int) bool {
 		// If creation time is the same, then behavior is nondeterministic. In this case, we can
 		// pick an arbitrary but consistent ordering based on name and namespace, which is unique.
@@ -378,14 +309,14 @@ func sortConfigByCreationTime(configs []Config) {
 	})
 }
 
-func (store *istioConfigStore) Gateways(workloadLabels labels.Collection) []Config {
+func (store *istioConfigStore) Gateways(workloadLabels labels.Collection) []config.Config {
 	configs, err := store.List(gvk.Gateway, NamespaceAll)
 	if err != nil {
 		return nil
 	}
 
 	sortConfigByCreationTime(configs)
-	out := make([]Config, 0)
+	out := make([]config.Config, 0)
 	for _, cfg := range configs {
 		gateway := cfg.Spec.(*networking.Gateway)
 		if gateway.GetSelector() == nil {
@@ -406,7 +337,7 @@ func key(name, namespace string) string {
 	return name + "/" + namespace
 }
 
-func (store *istioConfigStore) AuthorizationPolicies(namespace string) []Config {
+func (store *istioConfigStore) AuthorizationPolicies(namespace string) []config.Config {
 	authorizationPolicies, err := store.List(gvk.AuthorizationPolicy, namespace)
 	if err != nil {
 		log.Errorf("failed to get AuthorizationPolicy in namespace %s: %v", namespace, err)
@@ -414,23 +345,4 @@ func (store *istioConfigStore) AuthorizationPolicies(namespace string) []Config 
 	}
 
 	return authorizationPolicies
-}
-
-func (c Config) DeepCopy() Config {
-	var clone Config
-	clone.ConfigMeta = c.ConfigMeta
-	if c.Labels != nil {
-		clone.Labels = make(map[string]string)
-		for k, v := range c.Labels {
-			clone.Labels[k] = v
-		}
-	}
-	if c.Annotations != nil {
-		clone.Annotations = make(map[string]string)
-		for k, v := range c.Annotations {
-			clone.Annotations[k] = v
-		}
-	}
-	clone.Spec = proto.Clone(c.Spec)
-	return clone
 }

--- a/pilot/pkg/model/config_test.go
+++ b/pilot/pkg/model/config_test.go
@@ -26,6 +26,7 @@ import (
 	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/model"
 	mock_config "istio.io/istio/pilot/test/mock"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/protocol"
@@ -74,7 +75,7 @@ func TestConfigDescriptor(t *testing.T) {
 	if !aExists || !reflect.DeepEqual(aType, a) {
 		t.Errorf("descriptor.GetByType(a) => got %+v, want %+v", aType, a)
 	}
-	if _, exists := schemas.FindByGroupVersionKind(resource.GroupVersionKind{Kind: "missing"}); exists {
+	if _, exists := schemas.FindByGroupVersionKind(config.GroupVersionKind{Kind: "missing"}); exists {
 		t.Error("descriptor.GetByType(missing) => got true, want false")
 	}
 
@@ -207,26 +208,26 @@ func TestConfigKey(t *testing.T) {
 func TestResolveShortnameToFQDN(t *testing.T) {
 	tests := []struct {
 		name string
-		meta model.ConfigMeta
+		meta config.ConfigMeta
 		out  host.Name
 	}{
 		{
-			"*", model.ConfigMeta{}, "*",
+			"*", config.ConfigMeta{}, "*",
 		},
 		{
-			"*", model.ConfigMeta{Namespace: "default", Domain: "cluster.local"}, "*",
+			"*", config.ConfigMeta{Namespace: "default", Domain: "cluster.local"}, "*",
 		},
 		{
-			"foo", model.ConfigMeta{Namespace: "default", Domain: "cluster.local"}, "foo.default.svc.cluster.local",
+			"foo", config.ConfigMeta{Namespace: "default", Domain: "cluster.local"}, "foo.default.svc.cluster.local",
 		},
 		{
-			"foo.bar", model.ConfigMeta{Namespace: "default", Domain: "cluster.local"}, "foo.bar",
+			"foo.bar", config.ConfigMeta{Namespace: "default", Domain: "cluster.local"}, "foo.bar",
 		},
 		{
-			"foo", model.ConfigMeta{Domain: "cluster.local"}, "foo.svc.cluster.local",
+			"foo", config.ConfigMeta{Domain: "cluster.local"}, "foo.svc.cluster.local",
 		},
 		{
-			"foo", model.ConfigMeta{Namespace: "default"}, "foo.default",
+			"foo", config.ConfigMeta{Namespace: "default"}, "foo.default",
 		},
 	}
 
@@ -308,11 +309,11 @@ func TestAuthorizationPolicies(t *testing.T) {
 
 type fakeStore struct {
 	model.ConfigStore
-	cfg map[resource.GroupVersionKind][]model.Config
+	cfg map[config.GroupVersionKind][]config.Config
 	err error
 }
 
-func (l *fakeStore) List(typ resource.GroupVersionKind, namespace string) ([]model.Config, error) {
+func (l *fakeStore) List(typ config.GroupVersionKind, namespace string) ([]config.Config, error) {
 	ret := l.cfg[typ]
 	return ret, l.err
 }
@@ -324,10 +325,10 @@ func (l *fakeStore) Schemas() collection.Schemas {
 func TestIstioConfigStore_ServiceEntries(t *testing.T) {
 	ns := "ns1"
 	l := &fakeStore{
-		cfg: map[resource.GroupVersionKind][]model.Config{
+		cfg: map[config.GroupVersionKind][]config.Config{
 			gvk.ServiceEntry: {
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:      "request-count-1",
 						Namespace: ns,
 					},
@@ -356,24 +357,24 @@ func TestIstioConfigStore_ServiceEntries(t *testing.T) {
 func TestIstioConfigStore_Gateway(t *testing.T) {
 	workloadLabels := labels.Collection{}
 	now := time.Now()
-	gw1 := model.Config{
-		ConfigMeta: model.ConfigMeta{
+	gw1 := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:              "name1",
 			Namespace:         "zzz",
 			CreationTimestamp: now,
 		},
 		Spec: &networking.Gateway{},
 	}
-	gw2 := model.Config{
-		ConfigMeta: model.ConfigMeta{
+	gw2 := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:              "name1",
 			Namespace:         "aaa",
 			CreationTimestamp: now,
 		},
 		Spec: &networking.Gateway{},
 	}
-	gw3 := model.Config{
-		ConfigMeta: model.ConfigMeta{
+	gw3 := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:              "name1",
 			Namespace:         "ns2",
 			CreationTimestamp: now.Add(time.Second * -1),
@@ -382,14 +383,14 @@ func TestIstioConfigStore_Gateway(t *testing.T) {
 	}
 
 	l := &fakeStore{
-		cfg: map[resource.GroupVersionKind][]model.Config{
+		cfg: map[config.GroupVersionKind][]config.Config{
 			gvk.Gateway: {gw1, gw2, gw3},
 		},
 	}
 	ii := model.MakeIstioStore(l)
 
 	// Gateways should be returned in a stable order
-	expectedConfig := []model.Config{
+	expectedConfig := []config.Config{
 		gw3, // first config by timestamp
 		gw2, // timestamp match with gw1, but name comes first
 		gw1, // timestamp match with gw2, but name comes last
@@ -402,8 +403,8 @@ func TestIstioConfigStore_Gateway(t *testing.T) {
 }
 
 func TestDeepCopy(t *testing.T) {
-	cfg := model.Config{
-		ConfigMeta: model.ConfigMeta{
+	cfg := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:              "name1",
 			Namespace:         "zzz",
 			CreationTimestamp: time.Now(),

--- a/pilot/pkg/model/config_test.go
+++ b/pilot/pkg/model/config_test.go
@@ -200,7 +200,7 @@ func TestLabelsEquals(t *testing.T) {
 func TestConfigKey(t *testing.T) {
 	cfg := mock_config.Make("ns", 2)
 	want := "MockConfig/ns/mock-config2"
-	if key := cfg.ConfigMeta.Key(); key != want {
+	if key := cfg.Meta.Key(); key != want {
 		t.Fatalf("config.Key() => got %q, want %q", key, want)
 	}
 }
@@ -208,26 +208,26 @@ func TestConfigKey(t *testing.T) {
 func TestResolveShortnameToFQDN(t *testing.T) {
 	tests := []struct {
 		name string
-		meta config.ConfigMeta
+		meta config.Meta
 		out  host.Name
 	}{
 		{
-			"*", config.ConfigMeta{}, "*",
+			"*", config.Meta{}, "*",
 		},
 		{
-			"*", config.ConfigMeta{Namespace: "default", Domain: "cluster.local"}, "*",
+			"*", config.Meta{Namespace: "default", Domain: "cluster.local"}, "*",
 		},
 		{
-			"foo", config.ConfigMeta{Namespace: "default", Domain: "cluster.local"}, "foo.default.svc.cluster.local",
+			"foo", config.Meta{Namespace: "default", Domain: "cluster.local"}, "foo.default.svc.cluster.local",
 		},
 		{
-			"foo.bar", config.ConfigMeta{Namespace: "default", Domain: "cluster.local"}, "foo.bar",
+			"foo.bar", config.Meta{Namespace: "default", Domain: "cluster.local"}, "foo.bar",
 		},
 		{
-			"foo", config.ConfigMeta{Domain: "cluster.local"}, "foo.svc.cluster.local",
+			"foo", config.Meta{Domain: "cluster.local"}, "foo.svc.cluster.local",
 		},
 		{
-			"foo", config.ConfigMeta{Namespace: "default"}, "foo.default",
+			"foo", config.Meta{Namespace: "default"}, "foo.default",
 		},
 	}
 
@@ -328,7 +328,7 @@ func TestIstioConfigStore_ServiceEntries(t *testing.T) {
 		cfg: map[config.GroupVersionKind][]config.Config{
 			gvk.ServiceEntry: {
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:      "request-count-1",
 						Namespace: ns,
 					},
@@ -358,7 +358,7 @@ func TestIstioConfigStore_Gateway(t *testing.T) {
 	workloadLabels := labels.Collection{}
 	now := time.Now()
 	gw1 := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:              "name1",
 			Namespace:         "zzz",
 			CreationTimestamp: now,
@@ -366,7 +366,7 @@ func TestIstioConfigStore_Gateway(t *testing.T) {
 		Spec: &networking.Gateway{},
 	}
 	gw2 := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:              "name1",
 			Namespace:         "aaa",
 			CreationTimestamp: now,
@@ -374,7 +374,7 @@ func TestIstioConfigStore_Gateway(t *testing.T) {
 		Spec: &networking.Gateway{},
 	}
 	gw3 := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:              "name1",
 			Namespace:         "ns2",
 			CreationTimestamp: now.Add(time.Second * -1),
@@ -404,7 +404,7 @@ func TestIstioConfigStore_Gateway(t *testing.T) {
 
 func TestDeepCopy(t *testing.T) {
 	cfg := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:              "name1",
 			Namespace:         "zzz",
 			CreationTimestamp: time.Now(),

--- a/pilot/pkg/model/destination_rule.go
+++ b/pilot/pkg/model/destination_rule.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/visibility"
 )
 
@@ -31,7 +32,7 @@ import (
 // 2. If the original rule did not have any top level traffic policy, traffic policies from the new rule will be
 // used.
 // 3. If the original rule did not have any exportTo, exportTo settings from the new rule will be used.
-func (ps *PushContext) mergeDestinationRule(p *processedDestRules, destRuleConfig Config, exportToMap map[visibility.Instance]bool) {
+func (ps *PushContext) mergeDestinationRule(p *processedDestRules, destRuleConfig config.Config, exportToMap map[visibility.Instance]bool) {
 	rule := destRuleConfig.Spec.(*networking.DestinationRule)
 	resolvedHost := ResolveShortnameToFQDN(rule.Host, destRuleConfig.ConfigMeta)
 

--- a/pilot/pkg/model/destination_rule.go
+++ b/pilot/pkg/model/destination_rule.go
@@ -34,7 +34,7 @@ import (
 // 3. If the original rule did not have any exportTo, exportTo settings from the new rule will be used.
 func (ps *PushContext) mergeDestinationRule(p *processedDestRules, destRuleConfig config.Config, exportToMap map[visibility.Instance]bool) {
 	rule := destRuleConfig.Spec.(*networking.DestinationRule)
-	resolvedHost := ResolveShortnameToFQDN(rule.Host, destRuleConfig.ConfigMeta)
+	resolvedHost := ResolveShortnameToFQDN(rule.Host, destRuleConfig.Meta)
 
 	if mdr, exists := p.destRule[resolvedHost]; exists {
 		// Deep copy destination rule, to prevent mutate it later when merge with a new one.

--- a/pilot/pkg/model/envoyfilter.go
+++ b/pilot/pkg/model/envoyfilter.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 
 	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/xds"
 )
@@ -58,7 +59,7 @@ var wellKnownVersions = map[string]string{
 }
 
 // convertToEnvoyFilterWrapper converts from EnvoyFilter config to EnvoyFilterWrapper object
-func convertToEnvoyFilterWrapper(local *Config) *EnvoyFilterWrapper {
+func convertToEnvoyFilterWrapper(local *config.Config) *EnvoyFilterWrapper {
 	localEnvoyFilter := local.Spec.(*networking.EnvoyFilter)
 
 	out := &EnvoyFilterWrapper{}

--- a/pilot/pkg/model/envoyfilter_test.go
+++ b/pilot/pkg/model/envoyfilter_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pkg/config"
 )
 
 // TestEnvoyFilterMatch tests the matching logic for EnvoyFilter, in particular the regex -> prefix optimization
@@ -94,8 +95,8 @@ func TestEnvoyFilterMatch(t *testing.T) {
 		},
 	}
 	for _, tt := range cases {
-		got := convertToEnvoyFilterWrapper(&Config{
-			ConfigMeta: ConfigMeta{},
+		got := convertToEnvoyFilterWrapper(&config.Config{
+			ConfigMeta: config.ConfigMeta{},
 			Spec:       tt.config,
 		})
 		if len(got.Patches[networking.EnvoyFilter_INVALID]) != 1 {

--- a/pilot/pkg/model/envoyfilter_test.go
+++ b/pilot/pkg/model/envoyfilter_test.go
@@ -96,8 +96,8 @@ func TestEnvoyFilterMatch(t *testing.T) {
 	}
 	for _, tt := range cases {
 		got := convertToEnvoyFilterWrapper(&config.Config{
-			ConfigMeta: config.ConfigMeta{},
-			Spec:       tt.config,
+			Meta: config.Meta{},
+			Spec: tt.config,
 		})
 		if len(got.Patches[networking.EnvoyFilter_INVALID]) != 1 {
 			t.Fatalf("unexpected patches: %v", got.Patches)

--- a/pilot/pkg/model/fake_store.go
+++ b/pilot/pkg/model/fake_store.go
@@ -59,13 +59,13 @@ func (s *FakeStore) List(typ config.GroupVersionKind, namespace string) ([]confi
 	return nsConfigs[namespace], nil
 }
 
-func (s *FakeStore) Create(config config.Config) (revision string, err error) {
-	configs := s.store[config.GroupVersionKind]
+func (s *FakeStore) Create(cfg config.Config) (revision string, err error) {
+	configs := s.store[cfg.GroupVersionKind]
 	if configs == nil {
 		configs = make(map[string][]config.Config)
 	}
-	configs[config.Namespace] = append(configs[config.Namespace], config)
-	s.store[config.GroupVersionKind] = configs
+	configs[cfg.Namespace] = append(configs[cfg.Namespace], cfg)
+	s.store[cfg.GroupVersionKind] = configs
 	return "", nil
 }
 

--- a/pilot/pkg/model/fake_store.go
+++ b/pilot/pkg/model/fake_store.go
@@ -17,20 +17,20 @@ package model
 import (
 	"time"
 
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
-	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/pkg/ledger"
 )
 
 type FakeStore struct {
-	store  map[resource.GroupVersionKind]map[string][]Config
+	store  map[config.GroupVersionKind]map[string][]config.Config
 	ledger ledger.Ledger
 }
 
 func NewFakeStore() *FakeStore {
 	f := FakeStore{
-		store:  make(map[resource.GroupVersionKind]map[string][]Config),
+		store:  make(map[config.GroupVersionKind]map[string][]config.Config),
 		ledger: ledger.Make(time.Minute),
 	}
 	return &f
@@ -42,14 +42,14 @@ func (s *FakeStore) Schemas() collection.Schemas {
 	return collections.Pilot
 }
 
-func (*FakeStore) Get(typ resource.GroupVersionKind, name, namespace string) *Config { return nil }
+func (*FakeStore) Get(typ config.GroupVersionKind, name, namespace string) *config.Config { return nil }
 
-func (s *FakeStore) List(typ resource.GroupVersionKind, namespace string) ([]Config, error) {
+func (s *FakeStore) List(typ config.GroupVersionKind, namespace string) ([]config.Config, error) {
 	nsConfigs := s.store[typ]
 	if nsConfigs == nil {
 		return nil, nil
 	}
-	var res []Config
+	var res []config.Config
 	if namespace == NamespaceAll {
 		for _, configs := range nsConfigs {
 			res = append(res, configs...)
@@ -59,19 +59,19 @@ func (s *FakeStore) List(typ resource.GroupVersionKind, namespace string) ([]Con
 	return nsConfigs[namespace], nil
 }
 
-func (s *FakeStore) Create(config Config) (revision string, err error) {
+func (s *FakeStore) Create(config config.Config) (revision string, err error) {
 	configs := s.store[config.GroupVersionKind]
 	if configs == nil {
-		configs = make(map[string][]Config)
+		configs = make(map[string][]config.Config)
 	}
 	configs[config.Namespace] = append(configs[config.Namespace], config)
 	s.store[config.GroupVersionKind] = configs
 	return "", nil
 }
 
-func (*FakeStore) Update(config Config) (newRevision string, err error) { return "", nil }
+func (*FakeStore) Update(config config.Config) (newRevision string, err error) { return "", nil }
 
-func (*FakeStore) Delete(typ resource.GroupVersionKind, name, namespace string) error { return nil }
+func (*FakeStore) Delete(typ config.GroupVersionKind, name, namespace string) error { return nil }
 
 func (s *FakeStore) Version() string {
 	return s.ledger.RootHash()

--- a/pilot/pkg/model/gateway.go
+++ b/pilot/pkg/model/gateway.go
@@ -22,6 +22,7 @@ import (
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/util/sets"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/gateway"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/pkg/monitoring"
@@ -74,7 +75,7 @@ func recordRejectedConfig(gatewayName string) {
 // MergeGateways combines multiple gateways targeting the same workload into a single logical Gateway.
 // Note that today any Servers in the combined gateways listening on the same port must have the same protocol.
 // If servers with different protocols attempt to listen on the same port, one of the protocols will be chosen at random.
-func MergeGateways(gateways ...Config) *MergedGateway {
+func MergeGateways(gateways ...config.Config) *MergedGateway {
 	names := make(map[string]bool, len(gateways))
 	gatewayPorts := make(map[uint32]bool)
 	servers := make(map[uint32][]*networking.Server)
@@ -291,7 +292,7 @@ func checkDuplicates(hosts []string, knownHosts map[string]struct{}) []string {
 // While we can use the same RDS route name for two servers (say HTTP and HTTPS) exposing the same set of hosts on
 // different ports, the optimization (one RDS instead of two) could quickly become useless the moment the set of
 // hosts on the two servers start differing -- necessitating the need for two different RDS routes.
-func gatewayRDSRouteName(server *networking.Server, cfg Config) string {
+func gatewayRDSRouteName(server *networking.Server, cfg config.Config) string {
 	p := protocol.Parse(server.Port.Protocol)
 	if p.IsHTTP() {
 		return fmt.Sprintf("http.%d", server.Port.Number)

--- a/pilot/pkg/model/gateway_test.go
+++ b/pilot/pkg/model/gateway_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pkg/config"
 )
 
 func TestMergeGateways(t *testing.T) {
@@ -31,56 +32,56 @@ func TestMergeGateways(t *testing.T) {
 
 	tests := []struct {
 		name               string
-		gwConfig           []Config
+		gwConfig           []config.Config
 		serversNum         int
 		serversForRouteNum map[string]int
 		gatewaysNum        int
 	}{
 		{
 			"single-server-config",
-			[]Config{gwHTTPFoo},
+			[]config.Config{gwHTTPFoo},
 			1,
 			map[string]int{"http.7": 1},
 			1,
 		},
 		{
 			"same-server-config",
-			[]Config{gwHTTPFoo, gwHTTPWildcardAlternate},
+			[]config.Config{gwHTTPFoo, gwHTTPWildcardAlternate},
 			1,
 			map[string]int{"http.7": 2},
 			2,
 		},
 		{
 			"multi-server-config",
-			[]Config{gwHTTPFoo, gwHTTPWildcardAlternate, gwHTTPWildcard},
+			[]config.Config{gwHTTPFoo, gwHTTPWildcardAlternate, gwHTTPWildcard},
 			2,
 			map[string]int{"http.7": 2, "http.8": 1},
 			3,
 		},
 		{
 			"http-tcp-server-config",
-			[]Config{gwHTTPFoo, gwTCPWildcard},
+			[]config.Config{gwHTTPFoo, gwTCPWildcard},
 			2,
 			map[string]int{"http.7": 1},
 			2,
 		},
 		{
 			"tcp-tcp-server-config",
-			[]Config{gwTCPWildcard, gwHTTPWildcard},
+			[]config.Config{gwTCPWildcard, gwHTTPWildcard},
 			1,
 			map[string]int{},
 			2,
 		},
 		{
 			"tcp-tcp-server-config",
-			[]Config{gwHTTPWildcard, gwTCPWildcard}, //order matters
+			[]config.Config{gwHTTPWildcard, gwTCPWildcard}, //order matters
 			1,
 			map[string]int{"http.8": 1},
 			2,
 		},
 		{
 			"http-http2-server-config",
-			[]Config{gwHTTPWildcard, gwHTTP2Wildcard}, //order matters
+			[]config.Config{gwHTTPWildcard, gwHTTP2Wildcard}, //order matters
 			1,
 			// http and http2 both present
 			map[string]int{"http.8": 2},
@@ -109,9 +110,9 @@ func TestMergeGateways(t *testing.T) {
 	}
 }
 
-func makeConfig(name, namespace, host, portName, portProtocol string, portNumber uint32, gw string) Config {
-	c := Config{
-		ConfigMeta: ConfigMeta{
+func makeConfig(name, namespace, host, portName, portProtocol string, portNumber uint32, gw string) config.Config {
+	c := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:      name,
 			Namespace: namespace,
 		},

--- a/pilot/pkg/model/gateway_test.go
+++ b/pilot/pkg/model/gateway_test.go
@@ -112,7 +112,7 @@ func TestMergeGateways(t *testing.T) {
 
 func makeConfig(name, namespace, host, portName, portProtocol string, portNumber uint32, gw string) config.Config {
 	c := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:      name,
 			Namespace: namespace,
 		},

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -1108,13 +1108,13 @@ func (ps *PushContext) initVirtualServices(env *Environment) error {
 
 	// convert all shortnames in virtual services into FQDNs
 	for _, r := range vservices {
-		resolveVirtualServiceShortnames(r.Spec.(*networking.VirtualService), r.ConfigMeta)
+		resolveVirtualServiceShortnames(r.Spec.(*networking.VirtualService), r.Meta)
 	}
 
 	for _, virtualService := range vservices {
 		ns := virtualService.Namespace
 		rule := virtualService.Spec.(*networking.VirtualService)
-		gwNames := getGatewayNames(rule, virtualService.ConfigMeta)
+		gwNames := getGatewayNames(rule, virtualService.Meta)
 		if len(rule.ExportTo) == 0 {
 			// No exportTo in virtualService. Use the global default
 			// We only honor ., *
@@ -1178,7 +1178,7 @@ func (ps *PushContext) initVirtualServices(env *Environment) error {
 
 var meshGateways = []string{constants.IstioMeshGateway}
 
-func getGatewayNames(vs *networking.VirtualService, meta config.ConfigMeta) []string {
+func getGatewayNames(vs *networking.VirtualService, meta config.Meta) []string {
 	if len(vs.Gateways) == 0 {
 		return meshGateways
 	}
@@ -1341,7 +1341,7 @@ func (ps *PushContext) SetDestinationRules(configs []config.Config) {
 
 	for i := range configs {
 		rule := configs[i].Spec.(*networking.DestinationRule)
-		rule.Host = string(ResolveShortnameToFQDN(rule.Host, configs[i].ConfigMeta))
+		rule.Host = string(ResolveShortnameToFQDN(rule.Host, configs[i].Meta))
 		exportToMap := make(map[visibility.Instance]bool)
 		for _, e := range rule.ExportTo {
 			exportToMap[visibility.Instance(e)] = true

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -26,6 +26,7 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/util/sets"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
@@ -89,11 +90,11 @@ type PushContext struct {
 	// VirtualService related
 	// This contains all virtual services visible to this namespace extracted from
 	// exportTos that explicitly contained this namespace. The keys are namespace,gateway.
-	virtualServicesExportedToNamespaceByGateway map[string]map[string][]Config
+	virtualServicesExportedToNamespaceByGateway map[string]map[string][]config.Config
 	// this contains all the virtual services with exportTo "." and current namespace. The keys are namespace,gateway.
-	privateVirtualServicesByNamespaceAndGateway map[string]map[string][]Config
+	privateVirtualServicesByNamespaceAndGateway map[string]map[string][]config.Config
 	// This contains all virtual services whose exportTo is "*", keyed by gateway
-	publicVirtualServicesByGateway map[string][]Config
+	publicVirtualServicesByGateway map[string][]config.Config
 
 	// destination rules are of three types:
 	//  namespaceLocalDestRules: all public/private dest rules pertaining to a service defined in a given namespace
@@ -110,8 +111,8 @@ type PushContext struct {
 	// envoy filters for each namespace including global config namespace
 	envoyFiltersByNamespace map[string][]*EnvoyFilterWrapper
 	// gateways for each namespace
-	gatewaysByNamespace map[string][]Config
-	allGateways         []Config
+	gatewaysByNamespace map[string][]config.Config
+	allGateways         []config.Config
 	////////// END ////////
 
 	// The following data is either a global index or used in the inbound path.
@@ -159,7 +160,7 @@ type processedDestRules struct {
 	// Map of dest rule host to the list of namespaces to which this destination rule has been exported to
 	exportTo map[host.Name]map[visibility.Instance]bool
 	// Map of dest rule host and the merged destination rules for that host
-	destRule map[host.Name]*Config
+	destRule map[host.Name]*config.Config
 }
 
 // XDSUpdater is used for direct updates of the xDS model and incremental push.
@@ -451,15 +452,15 @@ func NewPushContext() *PushContext {
 		publicServices:                              []*Service{},
 		privateServicesByNamespace:                  map[string][]*Service{},
 		servicesExportedToNamespace:                 map[string][]*Service{},
-		publicVirtualServicesByGateway:              map[string][]Config{},
-		privateVirtualServicesByNamespaceAndGateway: map[string]map[string][]Config{},
-		virtualServicesExportedToNamespaceByGateway: map[string]map[string][]Config{},
+		publicVirtualServicesByGateway:              map[string][]config.Config{},
+		privateVirtualServicesByNamespaceAndGateway: map[string]map[string][]config.Config{},
+		virtualServicesExportedToNamespaceByGateway: map[string]map[string][]config.Config{},
 		namespaceLocalDestRules:                     map[string]*processedDestRules{},
 		exportedDestRulesByNamespace:                map[string]*processedDestRules{},
 		sidecarsByNamespace:                         map[string][]*SidecarScope{},
 		envoyFiltersByNamespace:                     map[string][]*EnvoyFilterWrapper{},
-		gatewaysByNamespace:                         map[string][]Config{},
-		allGateways:                                 []Config{},
+		gatewaysByNamespace:                         map[string][]config.Config{},
+		allGateways:                                 []config.Config{},
 		ServiceByHostnameAndNamespace:               map[host.Name]map[string]*Service{},
 		ServiceByHostname:                           map[host.Name]*Service{},
 		ProxyStatus:                                 map[string]map[string]ProxyPushStatus{},
@@ -620,7 +621,7 @@ func (ps *PushContext) ServiceForHostname(proxy *Proxy, hostname host.Name) *Ser
 // VirtualServices lists all virtual services bound to the specified gateways
 // This replaces store.VirtualServices. Used only by the gateways
 // Sidecars use the egressListener.VirtualServices().
-func (ps *PushContext) VirtualServicesForGateway(proxy *Proxy, gateway string) []Config {
+func (ps *PushContext) VirtualServicesForGateway(proxy *Proxy, gateway string) []config.Config {
 	res := ps.privateVirtualServicesByNamespaceAndGateway[proxy.ConfigNamespace][gateway]
 	res = append(res, ps.virtualServicesExportedToNamespaceByGateway[proxy.ConfigNamespace][gateway]...)
 	res = append(res, ps.publicVirtualServicesByGateway[gateway]...)
@@ -678,7 +679,7 @@ func (ps *PushContext) getSidecarScope(proxy *Proxy, workloadLabels labels.Colle
 }
 
 // DestinationRule returns a destination rule for a service name in a given domain.
-func (ps *PushContext) DestinationRule(proxy *Proxy, service *Service) *Config {
+func (ps *PushContext) DestinationRule(proxy *Proxy, service *Service) *config.Config {
 	if service == nil {
 		return nil
 	}
@@ -751,7 +752,7 @@ func (ps *PushContext) DestinationRule(proxy *Proxy, service *Service) *Config {
 	return nil
 }
 
-func (ps *PushContext) getExportedDestinationRuleFromNamespace(owningNamespace string, hostname host.Name, clientNamespace string) *Config {
+func (ps *PushContext) getExportedDestinationRuleFromNamespace(owningNamespace string, hostname host.Name, clientNamespace string) *config.Config {
 	if ps.exportedDestRulesByNamespace[owningNamespace] != nil {
 		if specificHostname, ok := MostSpecificHostMatch(hostname, ps.exportedDestRulesByNamespace[owningNamespace].hosts); ok {
 			// Check if the dest rule for this host is actually exported to the proxy's (client) namespace
@@ -1078,9 +1079,9 @@ func (ps *PushContext) initAuthnPolicies(env *Environment) error {
 
 // Caches list of virtual services
 func (ps *PushContext) initVirtualServices(env *Environment) error {
-	ps.virtualServicesExportedToNamespaceByGateway = map[string]map[string][]Config{}
-	ps.privateVirtualServicesByNamespaceAndGateway = map[string]map[string][]Config{}
-	ps.publicVirtualServicesByGateway = map[string][]Config{}
+	ps.virtualServicesExportedToNamespaceByGateway = map[string]map[string][]config.Config{}
+	ps.privateVirtualServicesByNamespaceAndGateway = map[string]map[string][]config.Config{}
+	ps.publicVirtualServicesByGateway = map[string][]config.Config{}
 
 	virtualServices, err := env.List(gvk.VirtualService, NamespaceAll)
 	if err != nil {
@@ -1089,7 +1090,7 @@ func (ps *PushContext) initVirtualServices(env *Environment) error {
 
 	// values returned from ConfigStore.List are immutable.
 	// Therefore, we make a copy
-	vservices := make([]Config, len(virtualServices))
+	vservices := make([]config.Config, len(virtualServices))
 
 	for i := range vservices {
 		vservices[i] = virtualServices[i].DeepCopy()
@@ -1119,7 +1120,7 @@ func (ps *PushContext) initVirtualServices(env *Environment) error {
 			// We only honor ., *
 			if ps.defaultVirtualServiceExportTo[visibility.Private] {
 				if _, f := ps.privateVirtualServicesByNamespaceAndGateway[ns]; !f {
-					ps.privateVirtualServicesByNamespaceAndGateway[ns] = map[string][]Config{}
+					ps.privateVirtualServicesByNamespaceAndGateway[ns] = map[string][]config.Config{}
 				}
 				// add to local namespace only
 				for _, gw := range gwNames {
@@ -1151,7 +1152,7 @@ func (ps *PushContext) initVirtualServices(env *Environment) error {
 				for exportTo := range exportToMap {
 					if exportTo == visibility.Private || string(exportTo) == ns {
 						if _, f := ps.privateVirtualServicesByNamespaceAndGateway[ns]; !f {
-							ps.privateVirtualServicesByNamespaceAndGateway[ns] = map[string][]Config{}
+							ps.privateVirtualServicesByNamespaceAndGateway[ns] = map[string][]config.Config{}
 						}
 						// add to local namespace only
 						for _, gw := range gwNames {
@@ -1159,7 +1160,7 @@ func (ps *PushContext) initVirtualServices(env *Environment) error {
 						}
 					} else {
 						if _, f := ps.virtualServicesExportedToNamespaceByGateway[string(exportTo)]; !f {
-							ps.virtualServicesExportedToNamespaceByGateway[string(exportTo)] = map[string][]Config{}
+							ps.virtualServicesExportedToNamespaceByGateway[string(exportTo)] = map[string][]config.Config{}
 						}
 						// add to local namespace only
 						for _, gw := range gwNames {
@@ -1177,7 +1178,7 @@ func (ps *PushContext) initVirtualServices(env *Environment) error {
 
 var meshGateways = []string{constants.IstioMeshGateway}
 
-func getGatewayNames(vs *networking.VirtualService, meta ConfigMeta) []string {
+func getGatewayNames(vs *networking.VirtualService, meta config.ConfigMeta) []string {
 	if len(vs.Gateways) == 0 {
 		return meshGateways
 	}
@@ -1243,8 +1244,8 @@ func (ps *PushContext) initSidecarScopes(env *Environment) error {
 
 	sortConfigByCreationTime(sidecarConfigs)
 
-	sidecarConfigWithSelector := make([]Config, 0)
-	sidecarConfigWithoutSelector := make([]Config, 0)
+	sidecarConfigWithSelector := make([]config.Config, 0)
+	sidecarConfigWithoutSelector := make([]config.Config, 0)
 	sidecarsWithoutSelectorByNamespace := make(map[string]struct{})
 	for _, sidecarConfig := range sidecarConfigs {
 		sidecar := sidecarConfig.Spec.(*networking.Sidecar)
@@ -1257,7 +1258,7 @@ func (ps *PushContext) initSidecarScopes(env *Environment) error {
 	}
 
 	sidecarNum := len(sidecarConfigs)
-	sidecarConfigs = make([]Config, 0, sidecarNum)
+	sidecarConfigs = make([]config.Config, 0, sidecarNum)
 	sidecarConfigs = append(sidecarConfigs, sidecarConfigWithSelector...)
 	sidecarConfigs = append(sidecarConfigs, sidecarConfigWithoutSelector...)
 
@@ -1271,7 +1272,7 @@ func (ps *PushContext) initSidecarScopes(env *Environment) error {
 	// Hold reference root namespace's sidecar config
 	// Root namespace can have only one sidecar config object
 	// Currently we expect that it has no workloadSelectors
-	var rootNSConfig *Config
+	var rootNSConfig *config.Config
 	if ps.Mesh.RootNamespace != "" {
 		for _, sidecarConfig := range sidecarConfigs {
 			if sidecarConfig.Namespace == ps.Mesh.RootNamespace &&
@@ -1309,7 +1310,7 @@ func (ps *PushContext) initDestinationRules(env *Environment) error {
 
 	// values returned from ConfigStore.List are immutable.
 	// Therefore, we make a copy
-	destRules := make([]Config, len(configs))
+	destRules := make([]config.Config, len(configs))
 	for i := range destRules {
 		destRules[i] = configs[i].DeepCopy()
 	}
@@ -1322,7 +1323,7 @@ func newProcessedDestRules() *processedDestRules {
 	return &processedDestRules{
 		hosts:    make([]host.Name, 0),
 		exportTo: map[host.Name]map[visibility.Instance]bool{},
-		destRule: map[host.Name]*Config{},
+		destRule: map[host.Name]*config.Config{},
 	}
 }
 
@@ -1330,7 +1331,7 @@ func newProcessedDestRules() *processedDestRules {
 // Split out of DestinationRule expensive conversions, computed once per push.
 // This also allows tests to inject a config without having the mock.
 // This will not work properly for Sidecars, which will precompute their destination rules on init
-func (ps *PushContext) SetDestinationRules(configs []Config) {
+func (ps *PushContext) SetDestinationRules(configs []config.Config) {
 	// Sort by time first. So if two destination rule have top level traffic policies
 	// we take the first one.
 	sortConfigByCreationTime(configs)
@@ -1498,10 +1499,10 @@ func (ps *PushContext) initGateways(env *Environment) error {
 	sortConfigByCreationTime(gatewayConfigs)
 
 	ps.allGateways = gatewayConfigs
-	ps.gatewaysByNamespace = make(map[string][]Config)
+	ps.gatewaysByNamespace = make(map[string][]config.Config)
 	for _, gatewayConfig := range gatewayConfigs {
 		if _, exists := ps.gatewaysByNamespace[gatewayConfig.Namespace]; !exists {
-			ps.gatewaysByNamespace[gatewayConfig.Namespace] = make([]Config, 0)
+			ps.gatewaysByNamespace[gatewayConfig.Namespace] = make([]config.Config, 0)
 		}
 		ps.gatewaysByNamespace[gatewayConfig.Namespace] = append(ps.gatewaysByNamespace[gatewayConfig.Namespace], gatewayConfig)
 	}
@@ -1513,9 +1514,9 @@ func (ps *PushContext) mergeGateways(proxy *Proxy) *MergedGateway {
 	if proxy == nil {
 		return nil
 	}
-	out := make([]Config, 0)
+	out := make([]config.Config, 0)
 
-	var configs []Config
+	var configs []config.Config
 	if features.ScopeGatewayToNamespace {
 		configs = ps.gatewaysByNamespace[proxy.ConfigNamespace]
 	} else {

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -27,13 +27,13 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 	securityBeta "istio.io/api/security/v1beta1"
 	selectorpb "istio.io/api/type/v1beta1"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
-	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/istio/pkg/config/visibility"
 )
 
@@ -70,7 +70,7 @@ func TestMergeUpdateRequest(t *testing.T) {
 				Push:  push0,
 				Start: t0,
 				ConfigsUpdated: map[ConfigKey]struct{}{
-					{Kind: resource.GroupVersionKind{Kind: "cfg1"}, Namespace: "ns1"}: {}},
+					{Kind: config.GroupVersionKind{Kind: "cfg1"}, Namespace: "ns1"}: {}},
 				Reason: []TriggerReason{ServiceUpdate, ServiceUpdate},
 			},
 			&PushRequest{
@@ -78,7 +78,7 @@ func TestMergeUpdateRequest(t *testing.T) {
 				Push:  push1,
 				Start: t1,
 				ConfigsUpdated: map[ConfigKey]struct{}{
-					{Kind: resource.GroupVersionKind{Kind: "cfg2"}, Namespace: "ns2"}: {}},
+					{Kind: config.GroupVersionKind{Kind: "cfg2"}, Namespace: "ns2"}: {}},
 				Reason: []TriggerReason{EndpointUpdate},
 			},
 			PushRequest{
@@ -86,8 +86,8 @@ func TestMergeUpdateRequest(t *testing.T) {
 				Push:  push1,
 				Start: t0,
 				ConfigsUpdated: map[ConfigKey]struct{}{
-					{Kind: resource.GroupVersionKind{Kind: "cfg1"}, Namespace: "ns1"}: {},
-					{Kind: resource.GroupVersionKind{Kind: "cfg2"}, Namespace: "ns2"}: {}},
+					{Kind: config.GroupVersionKind{Kind: "cfg1"}, Namespace: "ns1"}: {},
+					{Kind: config.GroupVersionKind{Kind: "cfg2"}, Namespace: "ns2"}: {}},
 				Reason: []TriggerReason{ServiceUpdate, ServiceUpdate, EndpointUpdate},
 			},
 		},
@@ -95,7 +95,7 @@ func TestMergeUpdateRequest(t *testing.T) {
 			"skip config type merge: one empty",
 			&PushRequest{Full: true, ConfigsUpdated: nil},
 			&PushRequest{Full: true, ConfigsUpdated: map[ConfigKey]struct{}{{
-				Kind: resource.GroupVersionKind{Kind: "cfg2"}}: {}}},
+				Kind: config.GroupVersionKind{Kind: "cfg2"}}: {}}},
 			PushRequest{Full: true, ConfigsUpdated: nil},
 		},
 	}
@@ -257,16 +257,16 @@ func TestSidecarScope(t *testing.T) {
 		},
 		OutboundTrafficPolicy: &networking.OutboundTrafficPolicy{},
 	}
-	configWithWorkloadSelector := Config{
-		ConfigMeta: ConfigMeta{
+	configWithWorkloadSelector := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind(),
 			Name:             "foo",
 			Namespace:        "default",
 		},
 		Spec: sidecarWithWorkloadSelector,
 	}
-	rootConfig := Config{
-		ConfigMeta: ConfigMeta{
+	rootConfig := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind(),
 			Name:             "global",
 			Namespace:        "istio-system",
@@ -399,8 +399,8 @@ func TestSetDestinationRuleMerging(t *testing.T) {
 	ps := NewPushContext()
 	ps.defaultDestinationRuleExportTo = map[visibility.Instance]bool{visibility.Public: true}
 	testhost := "httpbin.org"
-	destinationRuleNamespace1 := Config{
-		ConfigMeta: ConfigMeta{
+	destinationRuleNamespace1 := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:      "rule1",
 			Namespace: "test",
 		},
@@ -416,8 +416,8 @@ func TestSetDestinationRuleMerging(t *testing.T) {
 			},
 		},
 	}
-	destinationRuleNamespace2 := Config{
-		ConfigMeta: ConfigMeta{
+	destinationRuleNamespace2 := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:      "rule2",
 			Namespace: "test",
 		},
@@ -433,7 +433,7 @@ func TestSetDestinationRuleMerging(t *testing.T) {
 			},
 		},
 	}
-	ps.SetDestinationRules([]Config{destinationRuleNamespace1, destinationRuleNamespace2})
+	ps.SetDestinationRules([]config.Config{destinationRuleNamespace1, destinationRuleNamespace2})
 	subsetsLocal := ps.namespaceLocalDestRules["test"].destRule[host.Name(testhost)].Spec.(*networking.DestinationRule).Subsets
 	subsetsExport := ps.exportedDestRulesByNamespace["test"].destRule[host.Name(testhost)].Spec.(*networking.DestinationRule).Subsets
 	if len(subsetsLocal) != 4 {
@@ -449,8 +449,8 @@ func TestSetDestinationRuleWithExportTo(t *testing.T) {
 	ps := NewPushContext()
 	ps.Mesh = &meshconfig.MeshConfig{RootNamespace: "istio-system"}
 	testhost := "httpbin.org"
-	destinationRuleNamespace1 := Config{
-		ConfigMeta: ConfigMeta{
+	destinationRuleNamespace1 := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:      "rule1",
 			Namespace: "test1",
 		},
@@ -467,8 +467,8 @@ func TestSetDestinationRuleWithExportTo(t *testing.T) {
 			},
 		},
 	}
-	destinationRuleNamespace2 := Config{
-		ConfigMeta: ConfigMeta{
+	destinationRuleNamespace2 := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:      "rule2",
 			Namespace: "test2",
 		},
@@ -485,8 +485,8 @@ func TestSetDestinationRuleWithExportTo(t *testing.T) {
 			},
 		},
 	}
-	destinationRuleNamespace3 := Config{
-		ConfigMeta: ConfigMeta{
+	destinationRuleNamespace3 := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:      "rule3",
 			Namespace: "test3",
 		},
@@ -503,8 +503,8 @@ func TestSetDestinationRuleWithExportTo(t *testing.T) {
 			},
 		},
 	}
-	destinationRuleRootNamespace := Config{
-		ConfigMeta: ConfigMeta{
+	destinationRuleRootNamespace := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:      "rule4",
 			Namespace: "istio-system",
 		},
@@ -520,8 +520,8 @@ func TestSetDestinationRuleWithExportTo(t *testing.T) {
 			},
 		},
 	}
-	destinationRuleRootNamespaceLocal := Config{
-		ConfigMeta: ConfigMeta{
+	destinationRuleRootNamespaceLocal := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:      "rule1",
 			Namespace: "istio-system",
 		},
@@ -538,7 +538,7 @@ func TestSetDestinationRuleWithExportTo(t *testing.T) {
 			},
 		},
 	}
-	ps.SetDestinationRules([]Config{destinationRuleNamespace1, destinationRuleNamespace2,
+	ps.SetDestinationRules([]config.Config{destinationRuleNamespace1, destinationRuleNamespace2,
 		destinationRuleNamespace3, destinationRuleRootNamespace, destinationRuleRootNamespaceLocal})
 	cases := []struct {
 		proxyNs     string
@@ -623,8 +623,8 @@ func TestVirtualServiceWithExportTo(t *testing.T) {
 	configStore := NewFakeStore()
 	gatewayName := "default/gateway"
 
-	rule1 := Config{
-		ConfigMeta: ConfigMeta{
+	rule1 := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:             "rule1",
 			Namespace:        "test1",
 			GroupVersionKind: gvk.VirtualService,
@@ -634,8 +634,8 @@ func TestVirtualServiceWithExportTo(t *testing.T) {
 			ExportTo: []string{".", "ns1"},
 		},
 	}
-	rule2 := Config{
-		ConfigMeta: ConfigMeta{
+	rule2 := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:             "rule2",
 			Namespace:        "test2",
 			GroupVersionKind: gvk.VirtualService,
@@ -645,8 +645,8 @@ func TestVirtualServiceWithExportTo(t *testing.T) {
 			ExportTo: []string{"test2", "ns1", "test1"},
 		},
 	}
-	rule2Gw := Config{
-		ConfigMeta: ConfigMeta{
+	rule2Gw := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:             "rule2Gw",
 			Namespace:        "test2",
 			GroupVersionKind: gvk.VirtualService,
@@ -657,8 +657,8 @@ func TestVirtualServiceWithExportTo(t *testing.T) {
 			ExportTo: []string{"test2", "ns1", "test1"},
 		},
 	}
-	rule3 := Config{
-		ConfigMeta: ConfigMeta{
+	rule3 := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:             "rule3",
 			Namespace:        "test3",
 			GroupVersionKind: gvk.VirtualService,
@@ -669,8 +669,8 @@ func TestVirtualServiceWithExportTo(t *testing.T) {
 			ExportTo: []string{"test1", "test2", "*"},
 		},
 	}
-	rule3Gw := Config{
-		ConfigMeta: ConfigMeta{
+	rule3Gw := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:             "rule3Gw",
 			Namespace:        "test3",
 			GroupVersionKind: gvk.VirtualService,
@@ -681,8 +681,8 @@ func TestVirtualServiceWithExportTo(t *testing.T) {
 			ExportTo: []string{"test1", "test2", "*"},
 		},
 	}
-	rootNS := Config{
-		ConfigMeta: ConfigMeta{
+	rootNS := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:             "zzz",
 			Namespace:        "zzz",
 			GroupVersionKind: gvk.VirtualService,
@@ -692,7 +692,7 @@ func TestVirtualServiceWithExportTo(t *testing.T) {
 		},
 	}
 
-	for _, c := range []Config{rule1, rule2, rule3, rule2Gw, rule3Gw, rootNS} {
+	for _, c := range []config.Config{rule1, rule2, rule3, rule2Gw, rule3Gw, rootNS} {
 		if _, err := configStore.Create(c); err != nil {
 			t.Fatalf("could not create %v", c.Name)
 		}

--- a/pilot/pkg/model/push_context_test.go
+++ b/pilot/pkg/model/push_context_test.go
@@ -258,7 +258,7 @@ func TestSidecarScope(t *testing.T) {
 		OutboundTrafficPolicy: &networking.OutboundTrafficPolicy{},
 	}
 	configWithWorkloadSelector := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind(),
 			Name:             "foo",
 			Namespace:        "default",
@@ -266,7 +266,7 @@ func TestSidecarScope(t *testing.T) {
 		Spec: sidecarWithWorkloadSelector,
 	}
 	rootConfig := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind(),
 			Name:             "global",
 			Namespace:        "istio-system",
@@ -400,7 +400,7 @@ func TestSetDestinationRuleMerging(t *testing.T) {
 	ps.defaultDestinationRuleExportTo = map[visibility.Instance]bool{visibility.Public: true}
 	testhost := "httpbin.org"
 	destinationRuleNamespace1 := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:      "rule1",
 			Namespace: "test",
 		},
@@ -417,7 +417,7 @@ func TestSetDestinationRuleMerging(t *testing.T) {
 		},
 	}
 	destinationRuleNamespace2 := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:      "rule2",
 			Namespace: "test",
 		},
@@ -450,7 +450,7 @@ func TestSetDestinationRuleWithExportTo(t *testing.T) {
 	ps.Mesh = &meshconfig.MeshConfig{RootNamespace: "istio-system"}
 	testhost := "httpbin.org"
 	destinationRuleNamespace1 := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:      "rule1",
 			Namespace: "test1",
 		},
@@ -468,7 +468,7 @@ func TestSetDestinationRuleWithExportTo(t *testing.T) {
 		},
 	}
 	destinationRuleNamespace2 := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:      "rule2",
 			Namespace: "test2",
 		},
@@ -486,7 +486,7 @@ func TestSetDestinationRuleWithExportTo(t *testing.T) {
 		},
 	}
 	destinationRuleNamespace3 := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:      "rule3",
 			Namespace: "test3",
 		},
@@ -504,7 +504,7 @@ func TestSetDestinationRuleWithExportTo(t *testing.T) {
 		},
 	}
 	destinationRuleRootNamespace := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:      "rule4",
 			Namespace: "istio-system",
 		},
@@ -521,7 +521,7 @@ func TestSetDestinationRuleWithExportTo(t *testing.T) {
 		},
 	}
 	destinationRuleRootNamespaceLocal := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:      "rule1",
 			Namespace: "istio-system",
 		},
@@ -624,7 +624,7 @@ func TestVirtualServiceWithExportTo(t *testing.T) {
 	gatewayName := "default/gateway"
 
 	rule1 := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:             "rule1",
 			Namespace:        "test1",
 			GroupVersionKind: gvk.VirtualService,
@@ -635,7 +635,7 @@ func TestVirtualServiceWithExportTo(t *testing.T) {
 		},
 	}
 	rule2 := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:             "rule2",
 			Namespace:        "test2",
 			GroupVersionKind: gvk.VirtualService,
@@ -646,7 +646,7 @@ func TestVirtualServiceWithExportTo(t *testing.T) {
 		},
 	}
 	rule2Gw := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:             "rule2Gw",
 			Namespace:        "test2",
 			GroupVersionKind: gvk.VirtualService,
@@ -658,7 +658,7 @@ func TestVirtualServiceWithExportTo(t *testing.T) {
 		},
 	}
 	rule3 := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:             "rule3",
 			Namespace:        "test3",
 			GroupVersionKind: gvk.VirtualService,
@@ -670,7 +670,7 @@ func TestVirtualServiceWithExportTo(t *testing.T) {
 		},
 	}
 	rule3Gw := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:             "rule3Gw",
 			Namespace:        "test3",
 			GroupVersionKind: gvk.VirtualService,
@@ -682,7 +682,7 @@ func TestVirtualServiceWithExportTo(t *testing.T) {
 		},
 	}
 	rootNS := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:             "zzz",
 			Namespace:        "zzz",
 			GroupVersionKind: gvk.VirtualService,

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -19,11 +19,11 @@ import (
 	"strings"
 
 	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
-	"istio.io/istio/pkg/config/schema/resource"
 )
 
 const (
@@ -33,13 +33,13 @@ const (
 )
 
 var (
-	sidecarScopeKnownConfigTypes = map[resource.GroupVersionKind]struct{}{
+	sidecarScopeKnownConfigTypes = map[config.GroupVersionKind]struct{}{
 		gvk.ServiceEntry:    {},
 		gvk.VirtualService:  {},
 		gvk.DestinationRule: {},
 	}
 
-	sidecarScopeNamespaceConfigTypes = map[resource.GroupVersionKind]struct{}{
+	sidecarScopeNamespaceConfigTypes = map[config.GroupVersionKind]struct{}{
 		gvk.Sidecar:               {},
 		gvk.EnvoyFilter:           {},
 		gvk.AuthorizationPolicy:   {},
@@ -65,7 +65,7 @@ var (
 type SidecarScope struct {
 	// The crd itself. Can be nil if we are constructing the default
 	// sidecar scope
-	Config *Config
+	Config *config.Config
 
 	// Set of egress listeners, and their associated services.  A sidecar
 	// scope should have either ingress/egress listeners or both.  For
@@ -92,7 +92,7 @@ type SidecarScope struct {
 	// corresponds to a service in the services array above. When computing
 	// CDS, we simply have to find the matching service and return the
 	// destination rule.
-	destinationRules map[host.Name]*Config
+	destinationRules map[host.Name]*config.Config
 
 	// OutboundTrafficPolicy defines the outbound traffic policy for this sidecar.
 	// If OutboundTrafficPolicy is ALLOW_ANY traffic to unknown destinations will
@@ -149,7 +149,7 @@ type IstioEgressListenerWrapper struct {
 	// namespace A that has some path rewrite, while listener2 could import
 	// a private virtual service for serviceA from the local namespace,
 	// with a different path rewrite or no path rewrites.
-	virtualServices []Config
+	virtualServices []config.Config
 }
 
 // DefaultSidecarScopeForNamespace is a sidecar scope object with a default catch all egress listener
@@ -168,12 +168,12 @@ func DefaultSidecarScopeForNamespace(ps *PushContext, configNamespace string) *S
 	defaultEgressListener.virtualServices = ps.VirtualServicesForGateway(&dummyNode, constants.IstioMeshGateway)
 
 	out := &SidecarScope{
-		Config: &Config{ConfigMeta: ConfigMeta{
+		Config: &config.Config{ConfigMeta: config.ConfigMeta{
 			Namespace: configNamespace,
 		}},
 		EgressListeners:    []*IstioEgressListenerWrapper{defaultEgressListener},
 		services:           defaultEgressListener.services,
-		destinationRules:   make(map[host.Name]*Config),
+		destinationRules:   make(map[host.Name]*config.Config),
 		servicesByHostname: make(map[host.Name]*Service),
 		configDependencies: make(map[uint32]struct{}),
 		RootNamespace:      ps.Mesh.RootNamespace,
@@ -222,7 +222,7 @@ func DefaultSidecarScopeForNamespace(ps *PushContext, configNamespace string) *S
 }
 
 // ConvertToSidecarScope converts from Sidecar config to SidecarScope object
-func ConvertToSidecarScope(ps *PushContext, sidecarConfig *Config, configNamespace string) *SidecarScope {
+func ConvertToSidecarScope(ps *PushContext, sidecarConfig *config.Config, configNamespace string) *SidecarScope {
 	if sidecarConfig == nil {
 		return DefaultSidecarScopeForNamespace(ps, configNamespace)
 	}
@@ -330,7 +330,7 @@ func ConvertToSidecarScope(ps *PushContext, sidecarConfig *Config, configNamespa
 	// this config namespace) will see, identify all the destinationRules
 	// that these services need
 	out.servicesByHostname = make(map[host.Name]*Service)
-	out.destinationRules = make(map[host.Name]*Config)
+	out.destinationRules = make(map[host.Name]*config.Config)
 	for _, s := range out.services {
 		out.servicesByHostname[s.Hostname] = s
 		dr := ps.DestinationRule(&dummyNode, s)
@@ -407,7 +407,7 @@ func (sc *SidecarScope) Services() []*Service {
 
 // DestinationRule returns the destination rule applicable for a given hostname
 // used by CDS code
-func (sc *SidecarScope) DestinationRule(hostname host.Name) *Config {
+func (sc *SidecarScope) DestinationRule(hostname host.Name) *config.Config {
 	if sc == nil {
 		return nil
 	}
@@ -456,7 +456,7 @@ func (ilw *IstioEgressListenerWrapper) Services() []*Service {
 
 // VirtualServices returns the list of virtual services imported by this
 // egress listener
-func (ilw *IstioEgressListenerWrapper) VirtualServices() []Config {
+func (ilw *IstioEgressListenerWrapper) VirtualServices() []config.Config {
 	return ilw.virtualServices
 }
 
@@ -504,8 +504,8 @@ func (sc *SidecarScope) AddConfigDependencies(dependencies ...ConfigKey) {
 // listener wrapper. The parent object (sidecarScope) and its listeners are
 // constructed only once and reused for every sidecar that selects this
 // sidecarScope object. Selection is based on labels at the moment.
-func (ilw *IstioEgressListenerWrapper) selectVirtualServices(virtualServices []Config) []Config {
-	importedVirtualServices := make([]Config, 0)
+func (ilw *IstioEgressListenerWrapper) selectVirtualServices(virtualServices []config.Config) []config.Config {
+	importedVirtualServices := make([]config.Config, 0)
 	for _, c := range virtualServices {
 		configNamespace := c.Namespace
 		rule := c.Spec.(*networking.VirtualService)

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -168,7 +168,7 @@ func DefaultSidecarScopeForNamespace(ps *PushContext, configNamespace string) *S
 	defaultEgressListener.virtualServices = ps.VirtualServicesForGateway(&dummyNode, constants.IstioMeshGateway)
 
 	out := &SidecarScope{
-		Config: &config.Config{ConfigMeta: config.ConfigMeta{
+		Config: &config.Config{Meta: config.Meta{
 			Namespace: configNamespace,
 		}},
 		EgressListeners:    []*IstioEgressListenerWrapper{defaultEgressListener},

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -115,7 +115,7 @@ var (
 	}
 
 	configs1 = &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
@@ -138,7 +138,7 @@ var (
 	}
 
 	configs2 = &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
@@ -146,7 +146,7 @@ var (
 	}
 
 	configs3 = &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
@@ -160,7 +160,7 @@ var (
 	}
 
 	configs4 = &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
@@ -179,7 +179,7 @@ var (
 	}
 
 	configs5 = &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
@@ -198,7 +198,7 @@ var (
 	}
 
 	configs6 = &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
@@ -225,7 +225,7 @@ var (
 	}
 
 	configs7 = &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name: "sidecar-scope-ns1-ns2",
 		},
 		Spec: &networking.Sidecar{
@@ -251,7 +251,7 @@ var (
 	}
 
 	configs8 = &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name: "different-port-name",
 		},
 		Spec: &networking.Sidecar{
@@ -269,7 +269,7 @@ var (
 	}
 
 	configs9 = &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name: "sidecar-scope-wildcards",
 		},
 		Spec: &networking.Sidecar{
@@ -295,7 +295,7 @@ var (
 	}
 
 	configs10 = &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name: "sidecar-scope-with-http-proxy",
 		},
 		Spec: &networking.Sidecar{
@@ -313,7 +313,7 @@ var (
 	}
 
 	configs11 = &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name: "sidecar-scope-with-http-proxy-match-virtual-service",
 		},
 		Spec: &networking.Sidecar{
@@ -331,7 +331,7 @@ var (
 	}
 
 	configs12 = &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name: "sidecar-scope-with-http-proxy-match-virtual-service-and-service",
 		},
 		Spec: &networking.Sidecar{
@@ -349,7 +349,7 @@ var (
 	}
 
 	configs13 = &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name: "sidecar-scope-with-illegal-host",
 		},
 		Spec: &networking.Sidecar{
@@ -612,7 +612,7 @@ var (
 
 	virtualServices1 = []config.Config{
 		{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 				Name:             "virtualbar",
 				Namespace:        "foo",
@@ -1234,7 +1234,7 @@ func TestContainsEgressDependencies(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &config.Config{
-				ConfigMeta: config.ConfigMeta{
+				Meta: config.Meta{
 					Name:      "foo",
 					Namespace: "default",
 				},
@@ -1256,7 +1256,7 @@ func TestContainsEgressDependencies(t *testing.T) {
 			}
 			virtualServices := []config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:      vsName,
 						Namespace: nsName,
 					},
@@ -1267,7 +1267,7 @@ func TestContainsEgressDependencies(t *testing.T) {
 			}
 			destinationRules := []config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:      drName,
 						Namespace: nsName,
 					},
@@ -1297,14 +1297,14 @@ func TestContainsEgressDependencies(t *testing.T) {
 func TestSidecarOutboundTrafficPolicy(t *testing.T) {
 
 	configWithoutOutboundTrafficPolicy := &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
 		Spec: &networking.Sidecar{},
 	}
 	configRegistryOnly := &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
@@ -1315,7 +1315,7 @@ func TestSidecarOutboundTrafficPolicy(t *testing.T) {
 		},
 	}
 	configAllowAny := &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -23,6 +23,7 @@ import (
 
 	"istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/mesh"
@@ -113,8 +114,8 @@ var (
 		},
 	}
 
-	configs1 = &Config{
-		ConfigMeta: ConfigMeta{
+	configs1 = &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
@@ -136,16 +137,16 @@ var (
 		},
 	}
 
-	configs2 = &Config{
-		ConfigMeta: ConfigMeta{
+	configs2 = &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
 		Spec: &networking.Sidecar{},
 	}
 
-	configs3 = &Config{
-		ConfigMeta: ConfigMeta{
+	configs3 = &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
@@ -158,8 +159,8 @@ var (
 		},
 	}
 
-	configs4 = &Config{
-		ConfigMeta: ConfigMeta{
+	configs4 = &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
@@ -177,8 +178,8 @@ var (
 		},
 	}
 
-	configs5 = &Config{
-		ConfigMeta: ConfigMeta{
+	configs5 = &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
@@ -196,8 +197,8 @@ var (
 		},
 	}
 
-	configs6 = &Config{
-		ConfigMeta: ConfigMeta{
+	configs6 = &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
@@ -223,8 +224,8 @@ var (
 		},
 	}
 
-	configs7 = &Config{
-		ConfigMeta: ConfigMeta{
+	configs7 = &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name: "sidecar-scope-ns1-ns2",
 		},
 		Spec: &networking.Sidecar{
@@ -249,8 +250,8 @@ var (
 		},
 	}
 
-	configs8 = &Config{
-		ConfigMeta: ConfigMeta{
+	configs8 = &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name: "different-port-name",
 		},
 		Spec: &networking.Sidecar{
@@ -267,8 +268,8 @@ var (
 		},
 	}
 
-	configs9 = &Config{
-		ConfigMeta: ConfigMeta{
+	configs9 = &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name: "sidecar-scope-wildcards",
 		},
 		Spec: &networking.Sidecar{
@@ -293,8 +294,8 @@ var (
 		},
 	}
 
-	configs10 = &Config{
-		ConfigMeta: ConfigMeta{
+	configs10 = &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name: "sidecar-scope-with-http-proxy",
 		},
 		Spec: &networking.Sidecar{
@@ -311,8 +312,8 @@ var (
 		},
 	}
 
-	configs11 = &Config{
-		ConfigMeta: ConfigMeta{
+	configs11 = &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name: "sidecar-scope-with-http-proxy-match-virtual-service",
 		},
 		Spec: &networking.Sidecar{
@@ -329,8 +330,8 @@ var (
 		},
 	}
 
-	configs12 = &Config{
-		ConfigMeta: ConfigMeta{
+	configs12 = &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name: "sidecar-scope-with-http-proxy-match-virtual-service-and-service",
 		},
 		Spec: &networking.Sidecar{
@@ -347,8 +348,8 @@ var (
 		},
 	}
 
-	configs13 = &Config{
-		ConfigMeta: ConfigMeta{
+	configs13 = &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name: "sidecar-scope-with-illegal-host",
 		},
 		Spec: &networking.Sidecar{
@@ -609,9 +610,9 @@ var (
 		},
 	}
 
-	virtualServices1 = []Config{
+	virtualServices1 = []config.Config{
 		{
-			ConfigMeta: ConfigMeta{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 				Name:             "virtualbar",
 				Namespace:        "foo",
@@ -632,10 +633,10 @@ var (
 func TestCreateSidecarScope(t *testing.T) {
 	tests := []struct {
 		name          string
-		sidecarConfig *Config
+		sidecarConfig *config.Config
 		// list of available service for a given proxy
 		services        []*Service
-		virtualServices []Config
+		virtualServices []config.Config
 		// list of services expected to be in the listener
 		excpectedServices []*Service
 	}{
@@ -1232,8 +1233,8 @@ func TestContainsEgressDependencies(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := &Config{
-				ConfigMeta: ConfigMeta{
+			cfg := &config.Config{
+				ConfigMeta: config.ConfigMeta{
 					Name:      "foo",
 					Namespace: "default",
 				},
@@ -1253,9 +1254,9 @@ func TestContainsEgressDependencies(t *testing.T) {
 				{Hostname: "nomatch", Attributes: ServiceAttributes{Namespace: "nomatch"}},
 				{Hostname: svcName, Attributes: ServiceAttributes{Namespace: nsName}},
 			}
-			virtualServices := []Config{
+			virtualServices := []config.Config{
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:      vsName,
 						Namespace: nsName,
 					},
@@ -1264,9 +1265,9 @@ func TestContainsEgressDependencies(t *testing.T) {
 					},
 				},
 			}
-			destinationRules := []Config{
+			destinationRules := []config.Config{
 				{
-					ConfigMeta: ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:      drName,
 						Namespace: nsName,
 					},
@@ -1295,15 +1296,15 @@ func TestContainsEgressDependencies(t *testing.T) {
 
 func TestSidecarOutboundTrafficPolicy(t *testing.T) {
 
-	configWithoutOutboundTrafficPolicy := &Config{
-		ConfigMeta: ConfigMeta{
+	configWithoutOutboundTrafficPolicy := &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
 		Spec: &networking.Sidecar{},
 	}
-	configRegistryOnly := &Config{
-		ConfigMeta: ConfigMeta{
+	configRegistryOnly := &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
@@ -1313,8 +1314,8 @@ func TestSidecarOutboundTrafficPolicy(t *testing.T) {
 			},
 		},
 	}
-	configAllowAny := &Config{
-		ConfigMeta: ConfigMeta{
+	configAllowAny := &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
@@ -1336,7 +1337,7 @@ outboundTrafficPolicy:
 	tests := []struct {
 		name                  string
 		meshConfig            v1alpha1.MeshConfig
-		sidecar               *Config
+		sidecar               *config.Config
 		outboundTrafficPolicy *networking.OutboundTrafficPolicy
 	}{
 		{

--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -26,7 +26,7 @@ import (
 	"istio.io/istio/pkg/config/visibility"
 )
 
-func resolveVirtualServiceShortnames(rule *networking.VirtualService, meta config.ConfigMeta) {
+func resolveVirtualServiceShortnames(rule *networking.VirtualService, meta config.Meta) {
 	// resolve top level hosts
 	for i, h := range rule.Hosts {
 		rule.Hosts[i] = string(ResolveShortnameToFQDN(h, meta))

--- a/pilot/pkg/model/virtualservice.go
+++ b/pilot/pkg/model/virtualservice.go
@@ -21,11 +21,12 @@ import (
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/visibility"
 )
 
-func resolveVirtualServiceShortnames(rule *networking.VirtualService, meta ConfigMeta) {
+func resolveVirtualServiceShortnames(rule *networking.VirtualService, meta config.ConfigMeta) {
 	// resolve top level hosts
 	for i, h := range rule.Hosts {
 		rule.Hosts[i] = string(ResolveShortnameToFQDN(h, meta))
@@ -86,12 +87,12 @@ func resolveVirtualServiceShortnames(rule *networking.VirtualService, meta Confi
 	}
 }
 
-func mergeVirtualServicesIfNeeded(vServices []Config, defaultExportTo map[visibility.Instance]bool) (out []Config) {
-	out = make([]Config, 0, len(vServices))
-	delegatesMap := map[string]Config{}
+func mergeVirtualServicesIfNeeded(vServices []config.Config, defaultExportTo map[visibility.Instance]bool) (out []config.Config) {
+	out = make([]config.Config, 0, len(vServices))
+	delegatesMap := map[string]config.Config{}
 	delegatesExportToMap := map[string]map[visibility.Instance]bool{}
 	// root virtualservices with delegate
-	var rootVses []Config
+	var rootVses []config.Config
 
 	// 1. classify virtualservices
 	for _, vs := range vServices {

--- a/pilot/pkg/model/virtualservice_test.go
+++ b/pilot/pkg/model/virtualservice_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestMergeVirtualServices(t *testing.T) {
 	independentVs := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "virtual-service",
 			Namespace:        "default",
@@ -57,7 +57,7 @@ func TestMergeVirtualServices(t *testing.T) {
 	}
 
 	rootVs := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "root-vs",
 			Namespace:        "istio-system",
@@ -101,7 +101,7 @@ func TestMergeVirtualServices(t *testing.T) {
 	}
 
 	oneRoot := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "root-vs",
 			Namespace:        "istio-system",
@@ -127,7 +127,7 @@ func TestMergeVirtualServices(t *testing.T) {
 	}
 
 	delegateVs := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "productpage-vs",
 			Namespace:        "default",
@@ -195,7 +195,7 @@ func TestMergeVirtualServices(t *testing.T) {
 	}
 
 	delegateVsNotExported := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "productpage-vs",
 			Namespace:        "default2",
@@ -208,7 +208,7 @@ func TestMergeVirtualServices(t *testing.T) {
 	}
 
 	mergedVs := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "root-vs",
 			Namespace:        "istio-system",
@@ -301,7 +301,7 @@ func TestMergeVirtualServices(t *testing.T) {
 
 	// invalid delegate, match condition conflicts with root
 	delegateVs2 := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "productpage-vs",
 			Namespace:        "default",
@@ -378,7 +378,7 @@ func TestMergeVirtualServices(t *testing.T) {
 	}
 
 	mergedVs2 := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "root-vs",
 			Namespace:        "istio-system",
@@ -445,7 +445,7 @@ func TestMergeVirtualServices(t *testing.T) {
 
 	// multiple routes delegate to one single sub VS
 	multiRoutes := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "root-vs",
 			Namespace:        "istio-system",
@@ -488,7 +488,7 @@ func TestMergeVirtualServices(t *testing.T) {
 	}
 
 	singleDelegate := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "productpage-vs",
 			Namespace:        "default",
@@ -515,7 +515,7 @@ func TestMergeVirtualServices(t *testing.T) {
 	}
 
 	mergedVs3 := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "root-vs",
 			Namespace:        "istio-system",
@@ -1660,7 +1660,7 @@ var gatewayNameTests = []struct {
 func TestResolveGatewayName(t *testing.T) {
 	for _, tt := range gatewayNameTests {
 		t.Run(fmt.Sprintf("%s-%s", tt.gateway, tt.namespace), func(t *testing.T) {
-			if got := resolveGatewayName(tt.gateway, config.ConfigMeta{Namespace: tt.namespace}); got != tt.resolved {
+			if got := resolveGatewayName(tt.gateway, config.Meta{Namespace: tt.namespace}); got != tt.resolved {
 				t.Fatalf("expected %q got %q", tt.resolved, got)
 			}
 		})
@@ -1670,7 +1670,7 @@ func TestResolveGatewayName(t *testing.T) {
 func BenchmarkResolveGatewayName(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		for _, tt := range gatewayNameTests {
-			_ = resolveGatewayName(tt.gateway, config.ConfigMeta{Namespace: tt.namespace})
+			_ = resolveGatewayName(tt.gateway, config.Meta{Namespace: tt.namespace})
 		}
 	}
 }

--- a/pilot/pkg/model/virtualservice_test.go
+++ b/pilot/pkg/model/virtualservice_test.go
@@ -24,13 +24,14 @@ import (
 	fuzz "github.com/google/gofuzz"
 
 	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/visibility"
 )
 
 func TestMergeVirtualServices(t *testing.T) {
-	independentVs := Config{
-		ConfigMeta: ConfigMeta{
+	independentVs := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "virtual-service",
 			Namespace:        "default",
@@ -55,8 +56,8 @@ func TestMergeVirtualServices(t *testing.T) {
 		},
 	}
 
-	rootVs := Config{
-		ConfigMeta: ConfigMeta{
+	rootVs := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "root-vs",
 			Namespace:        "istio-system",
@@ -99,8 +100,8 @@ func TestMergeVirtualServices(t *testing.T) {
 		},
 	}
 
-	oneRoot := Config{
-		ConfigMeta: ConfigMeta{
+	oneRoot := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "root-vs",
 			Namespace:        "istio-system",
@@ -125,8 +126,8 @@ func TestMergeVirtualServices(t *testing.T) {
 		},
 	}
 
-	delegateVs := Config{
-		ConfigMeta: ConfigMeta{
+	delegateVs := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "productpage-vs",
 			Namespace:        "default",
@@ -193,8 +194,8 @@ func TestMergeVirtualServices(t *testing.T) {
 		},
 	}
 
-	delegateVsNotExported := Config{
-		ConfigMeta: ConfigMeta{
+	delegateVsNotExported := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "productpage-vs",
 			Namespace:        "default2",
@@ -206,8 +207,8 @@ func TestMergeVirtualServices(t *testing.T) {
 		},
 	}
 
-	mergedVs := Config{
-		ConfigMeta: ConfigMeta{
+	mergedVs := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "root-vs",
 			Namespace:        "istio-system",
@@ -299,8 +300,8 @@ func TestMergeVirtualServices(t *testing.T) {
 	}
 
 	// invalid delegate, match condition conflicts with root
-	delegateVs2 := Config{
-		ConfigMeta: ConfigMeta{
+	delegateVs2 := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "productpage-vs",
 			Namespace:        "default",
@@ -376,8 +377,8 @@ func TestMergeVirtualServices(t *testing.T) {
 		},
 	}
 
-	mergedVs2 := Config{
-		ConfigMeta: ConfigMeta{
+	mergedVs2 := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "root-vs",
 			Namespace:        "istio-system",
@@ -443,8 +444,8 @@ func TestMergeVirtualServices(t *testing.T) {
 	}
 
 	// multiple routes delegate to one single sub VS
-	multiRoutes := Config{
-		ConfigMeta: ConfigMeta{
+	multiRoutes := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "root-vs",
 			Namespace:        "istio-system",
@@ -486,8 +487,8 @@ func TestMergeVirtualServices(t *testing.T) {
 		},
 	}
 
-	singleDelegate := Config{
-		ConfigMeta: ConfigMeta{
+	singleDelegate := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "productpage-vs",
 			Namespace:        "default",
@@ -513,8 +514,8 @@ func TestMergeVirtualServices(t *testing.T) {
 		},
 	}
 
-	mergedVs3 := Config{
-		ConfigMeta: ConfigMeta{
+	mergedVs3 := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "root-vs",
 			Namespace:        "istio-system",
@@ -572,43 +573,43 @@ func TestMergeVirtualServices(t *testing.T) {
 
 	cases := []struct {
 		name                    string
-		virtualServices         []Config
-		expectedVirtualServices []Config
+		virtualServices         []config.Config
+		expectedVirtualServices []config.Config
 	}{
 		{
 			name:                    "one independent vs",
-			virtualServices:         []Config{independentVs},
-			expectedVirtualServices: []Config{independentVs},
+			virtualServices:         []config.Config{independentVs},
+			expectedVirtualServices: []config.Config{independentVs},
 		},
 		{
 			name:                    "one root vs",
-			virtualServices:         []Config{rootVs},
-			expectedVirtualServices: []Config{oneRoot},
+			virtualServices:         []config.Config{rootVs},
+			expectedVirtualServices: []config.Config{oneRoot},
 		},
 		{
 			name:                    "one delegate vs",
-			virtualServices:         []Config{delegateVs},
-			expectedVirtualServices: []Config{},
+			virtualServices:         []config.Config{delegateVs},
+			expectedVirtualServices: []config.Config{},
 		},
 		{
 			name:                    "root and delegate vs",
-			virtualServices:         []Config{rootVs.DeepCopy(), delegateVs},
-			expectedVirtualServices: []Config{mergedVs},
+			virtualServices:         []config.Config{rootVs.DeepCopy(), delegateVs},
+			expectedVirtualServices: []config.Config{mergedVs},
 		},
 		{
 			name:                    "root and conflicted delegate vs",
-			virtualServices:         []Config{rootVs.DeepCopy(), delegateVs2},
-			expectedVirtualServices: []Config{mergedVs2},
+			virtualServices:         []config.Config{rootVs.DeepCopy(), delegateVs2},
+			expectedVirtualServices: []config.Config{mergedVs2},
 		},
 		{
 			name:                    "multiple routes delegate to one",
-			virtualServices:         []Config{multiRoutes.DeepCopy(), singleDelegate},
-			expectedVirtualServices: []Config{mergedVs3},
+			virtualServices:         []config.Config{multiRoutes.DeepCopy(), singleDelegate},
+			expectedVirtualServices: []config.Config{mergedVs3},
 		},
 		{
 			name:                    "delegate not exported to root vs namespace",
-			virtualServices:         []Config{rootVs, delegateVsNotExported},
-			expectedVirtualServices: []Config{oneRoot},
+			virtualServices:         []config.Config{rootVs, delegateVsNotExported},
+			expectedVirtualServices: []config.Config{oneRoot},
 		},
 	}
 
@@ -1659,7 +1660,7 @@ var gatewayNameTests = []struct {
 func TestResolveGatewayName(t *testing.T) {
 	for _, tt := range gatewayNameTests {
 		t.Run(fmt.Sprintf("%s-%s", tt.gateway, tt.namespace), func(t *testing.T) {
-			if got := resolveGatewayName(tt.gateway, ConfigMeta{Namespace: tt.namespace}); got != tt.resolved {
+			if got := resolveGatewayName(tt.gateway, config.ConfigMeta{Namespace: tt.namespace}); got != tt.resolved {
 				t.Fatalf("expected %q got %q", tt.resolved, got)
 			}
 		})
@@ -1669,7 +1670,7 @@ func TestResolveGatewayName(t *testing.T) {
 func BenchmarkResolveGatewayName(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		for _, tt := range gatewayNameTests {
-			_ = resolveGatewayName(tt.gateway, ConfigMeta{Namespace: tt.namespace})
+			_ = resolveGatewayName(tt.gateway, config.ConfigMeta{Namespace: tt.namespace})
 		}
 	}
 }

--- a/pilot/pkg/networking/apigen/apigen.go
+++ b/pilot/pkg/networking/apigen/apigen.go
@@ -24,9 +24,9 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
-	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/pkg/log"
 )
 
@@ -74,7 +74,7 @@ func (g *APIGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *
 	// TODO: extra validation may be needed - at least logging that a resource
 	// of unknown type was requested. This should not be an error - maybe client asks
 	// for a valid CRD we just don't know about. An empty set indicates we have no such config.
-	rgvk := resource.GroupVersionKind{
+	rgvk := config.GroupVersionKind{
 		Group:   kind[0],
 		Version: kind[1],
 		Kind:    kind[2],
@@ -154,7 +154,7 @@ func (g *APIGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w *
 
 // Convert from model.Config, which has no associated proto, to MCP Resource proto.
 // TODO: define a proto matching Config - to avoid useless superficial conversions.
-func configToResource(c *model.Config) (*mcp.Resource, error) {
+func configToResource(c *config.Config) (*mcp.Resource, error) {
 	r := &mcp.Resource{}
 
 	// MCP, K8S and Istio configs use gogo configs

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -27,6 +27,7 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/util/gogo"
 )
@@ -414,7 +415,7 @@ func (cb *ClusterBuilder) defaultTrafficPolicy(discoveryType cluster.Cluster_Dis
 
 // castDestinationRuleOrDefault returns the destination rule enclosed by the config, if not null.
 // Otherwise, return default (empty) DR.
-func castDestinationRuleOrDefault(config *model.Config) *networking.DestinationRule {
+func castDestinationRuleOrDefault(config *config.Config) *networking.DestinationRule {
 	if config != nil {
 		return config.Spec.(*networking.DestinationRule)
 	}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -86,7 +86,7 @@ func (cb *ClusterBuilder) applyDestinationRule(c *cluster.Cluster, clusterMode C
 
 	var clusterMetadata *core.Metadata
 	if destRule != nil {
-		clusterMetadata = util.BuildConfigInfoMetadata(destRule.ConfigMeta)
+		clusterMetadata = util.BuildConfigInfoMetadata(destRule.Meta)
 		c.Metadata = clusterMetadata
 	}
 	subsetClusters := make([]*cluster.Cluster, 0)
@@ -260,7 +260,7 @@ func (cb *ClusterBuilder) buildInboundClusterForPortOrUDS(instance *model.Servic
 			// only connection pool settings make sense on the inbound path.
 			// upstream TLS settings/outlier detection/load balancer don't apply here.
 			applyConnectionPool(cb.push.Mesh, localCluster, connectionPool)
-			localCluster.Metadata = util.BuildConfigInfoMetadata(cfg.ConfigMeta)
+			localCluster.Metadata = util.BuildConfigInfoMetadata(cfg.Meta)
 		}
 	}
 	return localCluster

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -204,7 +204,7 @@ func TestApplyDestinationRule(t *testing.T) {
 			var cfg *config.Config
 			if tt.destRule != nil {
 				cfg = &config.Config{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind: gvk.DestinationRule,
 						Name:             "acme",
 						Namespace:        "default",

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -35,6 +35,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/test/xdstest"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
@@ -200,10 +201,10 @@ func TestApplyDestinationRule(t *testing.T) {
 				},
 			}
 
-			var cfg *model.Config
+			var cfg *config.Config
 			if tt.destRule != nil {
-				cfg = &model.Config{
-					ConfigMeta: model.ConfigMeta{
+				cfg = &config.Config{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind: gvk.DestinationRule,
 						Name:             "acme",
 						Namespace:        "default",
@@ -212,7 +213,7 @@ func TestApplyDestinationRule(t *testing.T) {
 				}
 			}
 			cg := NewConfigGenTest(t, TestOptions{
-				ConfigPointers: []*model.Config{cfg},
+				ConfigPointers: []*config.Config{cfg},
 				Services:       []*model.Service{tt.service},
 			})
 			cg.MemRegistry.WantGetProxyServiceInstances = instances

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -342,7 +342,7 @@ func buildTestClusters(c clusterTest) []*cluster.Cluster {
 	configs := []config.Config{}
 	if c.destRule != nil {
 		configs = append(configs, config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind: gvk.DestinationRule,
 				Name:             "acme",
 			},
@@ -355,7 +355,7 @@ func buildTestClusters(c clusterTest) []*cluster.Cluster {
 			policyName = "acme"
 		}
 		configs = append(configs, config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind: gvk.PeerAuthentication,
 				Name:             policyName,
 				Namespace:        TestServiceNamespace,
@@ -1556,7 +1556,7 @@ func TestBuildInboundClustersPortLevelCircuitBreakerThresholds(t *testing.T) {
 			cfgs := []config.Config{}
 			if c.destRule != nil {
 				cfgs = append(cfgs, config.Config{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind: gvk.DestinationRule,
 						Name:             "acme",
 						Namespace:        "default",
@@ -3197,7 +3197,7 @@ func TestEnvoyFilterPatching(t *testing.T) {
 			cfgs := []config.Config{}
 			for i, c := range tt.efs {
 				cfgs = append(cfgs, config.Config{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						GroupVersionKind: gvk.EnvoyFilter,
 						Name:             fmt.Sprint(i),
 						Namespace:        "default",

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -44,6 +44,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/util"
 	authn_model "istio.io/istio/pilot/pkg/security/model"
 	"istio.io/istio/pilot/test/xdstest"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
@@ -338,10 +339,10 @@ func buildTestClusters(c clusterTest) []*cluster.Cluster {
 		},
 	}
 
-	configs := []model.Config{}
+	configs := []config.Config{}
 	if c.destRule != nil {
-		configs = append(configs, model.Config{
-			ConfigMeta: model.ConfigMeta{
+		configs = append(configs, config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind: gvk.DestinationRule,
 				Name:             "acme",
 			},
@@ -353,8 +354,8 @@ func buildTestClusters(c clusterTest) []*cluster.Cluster {
 		if c.peerAuthn.Selector != nil {
 			policyName = "acme"
 		}
-		configs = append(configs, model.Config{
-			ConfigMeta: model.ConfigMeta{
+		configs = append(configs, config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind: gvk.PeerAuthentication,
 				Name:             policyName,
 				Namespace:        TestServiceNamespace,
@@ -1552,10 +1553,10 @@ func TestBuildInboundClustersPortLevelCircuitBreakerThresholds(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			g := NewWithT(t)
-			cfgs := []model.Config{}
+			cfgs := []config.Config{}
 			if c.destRule != nil {
-				cfgs = append(cfgs, model.Config{
-					ConfigMeta: model.ConfigMeta{
+				cfgs = append(cfgs, config.Config{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind: gvk.DestinationRule,
 						Name:             "acme",
 						Namespace:        "default",
@@ -3193,10 +3194,10 @@ func TestEnvoyFilterPatching(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			cfgs := []model.Config{}
+			cfgs := []config.Config{}
 			for i, c := range tt.efs {
-				cfgs = append(cfgs, model.Config{
-					ConfigMeta: model.ConfigMeta{
+				cfgs = append(cfgs, config.Config{
+					ConfigMeta: config.ConfigMeta{
 						GroupVersionKind: gvk.EnvoyFilter,
 						Name:             fmt.Sprint(i),
 						Namespace:        "default",

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
@@ -42,6 +42,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 	memregistry "istio.io/istio/pilot/pkg/serviceregistry/memory"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
@@ -62,8 +63,8 @@ func buildEnvoyFilterConfigStore(configPatches []*networking.EnvoyFilter_EnvoyCo
 	store := model.MakeIstioStore(memory.Make(collections.Pilot))
 
 	for i, cp := range configPatches {
-		store.Create(model.Config{
-			ConfigMeta: model.ConfigMeta{
+		store.Create(config.Config{
+			ConfigMeta: config.ConfigMeta{
 				Name:             fmt.Sprintf("test-envoyfilter-%d", i),
 				Namespace:        "not-default",
 				GroupVersionKind: gvk.EnvoyFilter,

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
@@ -64,7 +64,7 @@ func buildEnvoyFilterConfigStore(configPatches []*networking.EnvoyFilter_EnvoyCo
 
 	for i, cp := range configPatches {
 		store.Create(config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				Name:             fmt.Sprintf("test-envoyfilter-%d", i),
 				Namespace:        "not-default",
 				GroupVersionKind: gvk.EnvoyFilter,

--- a/pilot/pkg/networking/core/v1alpha3/fake.go
+++ b/pilot/pkg/networking/core/v1alpha3/fake.go
@@ -36,6 +36,7 @@ import (
 	memregistry "istio.io/istio/pilot/pkg/serviceregistry/memory"
 	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
 	"istio.io/istio/pilot/test/xdstest"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/test"
@@ -44,8 +45,8 @@ import (
 
 type TestOptions struct {
 	// If provided, these configs will be used directly
-	Configs        []model.Config
-	ConfigPointers []*model.Config
+	Configs        []config.Config
+	ConfigPointers []*config.Config
 
 	// If provided, the yaml string will be parsed and used as configs
 	ConfigString string
@@ -234,7 +235,7 @@ func (f *ConfigGenTest) Store() model.ConfigStoreCache {
 
 var _ model.XDSUpdater = &FakeXdsUpdater{}
 
-func getConfigs(t test.Failer, opts TestOptions) []model.Config {
+func getConfigs(t test.Failer, opts TestOptions) []config.Config {
 	for _, p := range opts.ConfigPointers {
 		if p != nil {
 			opts.Configs = append(opts.Configs, *p)

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -576,7 +576,7 @@ func buildGatewayNetworkFiltersFromTCPRoutes(node *model.Proxy, push *model.Push
 		// based on the match port/server port and the gateway name
 		for _, tcp := range vsvc.Tcp {
 			if l4MultiMatch(tcp.Match, server, gateway) {
-				return buildOutboundNetworkFilters(node, tcp.Route, push, port, v.ConfigMeta)
+				return buildOutboundNetworkFilters(node, tcp.Route, push, port, v.Meta)
 			}
 		}
 	}
@@ -635,7 +635,7 @@ func buildGatewayNetworkFiltersFromTLSRoutes(node *model.Proxy, push *model.Push
 						filterChains = append(filterChains, &filterChainOpts{
 							sniHosts:       match.SniHosts,
 							tlsContext:     nil, // NO TLS context because this is passthrough
-							networkFilters: buildOutboundNetworkFilters(node, tls.Route, push, port, v.ConfigMeta),
+							networkFilters: buildOutboundNetworkFilters(node, tls.Route, push, port, v.Meta),
 						})
 					}
 				}

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -34,6 +34,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
 	authn_model "istio.io/istio/pilot/pkg/security/model"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/gateway"
 	"istio.io/istio/pkg/config/host"
@@ -202,7 +203,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 	nameToServiceMap := push.ServiceByHostname
 
 	gatewayRoutes := make(map[string]map[string][]*route.Route)
-	gatewayVirtualServices := make(map[string][]model.Config)
+	gatewayVirtualServices := make(map[string][]config.Config)
 	vHostDedupMap := make(map[host.Name]*route.VirtualHost)
 	for _, server := range servers {
 		gatewayName := merged.GatewayNameForServer[server]
@@ -223,7 +224,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(node *model.Pr
 			continue
 		}
 
-		var virtualServices []model.Config
+		var virtualServices []config.Config
 		var exists bool
 
 		if virtualServices, exists = gatewayVirtualServices[gatewayName]; !exists {
@@ -647,7 +648,7 @@ func buildGatewayNetworkFiltersFromTLSRoutes(node *model.Proxy, push *model.Push
 
 // Select the virtualService's hosts that match the ones specified in the gateway server's hosts
 // based on the wildcard hostname match and the namespace match
-func pickMatchingGatewayHosts(gatewayServerHosts map[host.Name]bool, virtualService model.Config) map[string]host.Name {
+func pickMatchingGatewayHosts(gatewayServerHosts map[host.Name]bool, virtualService config.Config) map[string]host.Name {
 	matchingHosts := make(map[string]host.Name)
 	virtualServiceHosts := virtualService.Spec.(*networking.VirtualService).Hosts
 	for _, vsvcHost := range virtualServiceHosts {

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -1089,7 +1089,7 @@ func TestCreateGatewayHTTPFilterChainOpts(t *testing.T) {
 
 func TestGatewayHTTPRouteConfig(t *testing.T) {
 	httpsRedirectGateway := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:             "gateway-redirect",
 			Namespace:        "default",
 			GroupVersionKind: gvk.Gateway,
@@ -1106,7 +1106,7 @@ func TestGatewayHTTPRouteConfig(t *testing.T) {
 		},
 	}
 	httpGateway := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:             "gateway",
 			Namespace:        "default",
 			GroupVersionKind: gvk.Gateway,
@@ -1140,7 +1140,7 @@ func TestGatewayHTTPRouteConfig(t *testing.T) {
 		},
 	}
 	virtualService := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: gvk.VirtualService,
 			Name:             "virtual-service",
 			Namespace:        "default",
@@ -1148,7 +1148,7 @@ func TestGatewayHTTPRouteConfig(t *testing.T) {
 		Spec: virtualServiceSpec,
 	}
 	virtualServiceCopy := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: gvk.VirtualService,
 			Name:             "virtual-service-copy",
 			Namespace:        "default",
@@ -1156,7 +1156,7 @@ func TestGatewayHTTPRouteConfig(t *testing.T) {
 		Spec: virtualServiceSpec,
 	}
 	virtualServiceWildcard := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: gvk.VirtualService,
 			Name:             "virtual-service-wildcard",
 			Namespace:        "default",
@@ -1344,7 +1344,7 @@ func TestBuildGatewayListeners(t *testing.T) {
 	for _, tt := range cases {
 		p := &fakePlugin{}
 		configgen := NewConfigGenerator([]plugin.Plugin{p})
-		env := buildEnv(t, []config.Config{{ConfigMeta: config.ConfigMeta{GroupVersionKind: gvk.Gateway}, Spec: tt.gateway}}, []config.Config{})
+		env := buildEnv(t, []config.Config{{Meta: config.Meta{GroupVersionKind: gvk.Gateway}, Spec: tt.gateway}}, []config.Config{})
 		proxyGateway.SetGatewaysForProxy(env.PushContext)
 		proxyGateway.ServiceInstances = tt.node.ServiceInstances
 		proxyGateway.DiscoverIPVersions()

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -30,6 +30,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/util/sets"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
@@ -186,7 +187,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(node *
 func (configgen *ConfigGeneratorImpl) buildSidecarOutboundVirtualHosts(node *model.Proxy, push *model.PushContext,
 	routeName string, listenerPort int) []*route.VirtualHost {
 
-	var virtualServices []model.Config
+	var virtualServices []config.Config
 	var services []*model.Service
 
 	// Get the services from the egress listener.  When sniffing is enabled, we send

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -114,7 +114,7 @@ func TestSidecarOutboundHTTPRouteConfigWithDuplicateHosts(t *testing.T) {
 	}
 
 	virtualService6 := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "acme-v3",
 			Namespace:        "not-default",
@@ -183,7 +183,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 	}
 
 	sidecarConfig := &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
@@ -236,7 +236,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 		},
 	}
 	sidecarConfigWithWildcard := &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
@@ -254,7 +254,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 		},
 	}
 	sidecarConfigWitHTTPProxy := &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
@@ -272,7 +272,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 		},
 	}
 	sidecarConfigWithRegistryOnly := &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
@@ -326,7 +326,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 		},
 	}
 	sidecarConfigWithAllowAny := &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
@@ -465,7 +465,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 		},
 	}
 	virtualService1 := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "acme2-v1",
 			Namespace:        "not-default",
@@ -473,7 +473,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 		Spec: virtualServiceSpec1,
 	}
 	virtualService2 := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "acme-v2",
 			Namespace:        "not-default",
@@ -481,7 +481,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 		Spec: virtualServiceSpec2,
 	}
 	virtualService3 := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "acme-v3",
 			Namespace:        "not-default",
@@ -489,7 +489,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 		Spec: virtualServiceSpec3,
 	}
 	virtualService4 := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "acme-v4",
 			Namespace:        "not-default",
@@ -497,7 +497,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 		Spec: virtualServiceSpec4,
 	}
 	virtualService5 := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "acme-v3",
 			Namespace:        "not-default",

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -28,6 +28,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/util/sets"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/collections"
@@ -112,8 +113,8 @@ func TestSidecarOutboundHTTPRouteConfigWithDuplicateHosts(t *testing.T) {
 		},
 	}
 
-	virtualService6 := model.Config{
-		ConfigMeta: model.ConfigMeta{
+	virtualService6 := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "acme-v3",
 			Namespace:        "not-default",
@@ -121,7 +122,7 @@ func TestSidecarOutboundHTTPRouteConfigWithDuplicateHosts(t *testing.T) {
 		Spec: virtualServiceSpec6,
 	}
 
-	virtualServices := []*model.Config{&virtualService6}
+	virtualServices := []*config.Config{&virtualService6}
 	p := &fakePlugin{}
 	configgen := NewConfigGenerator([]plugin.Plugin{p})
 
@@ -181,8 +182,8 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 		buildHTTPService("test-headless.com", visibility.Public, wildcardIP, "not-default", 8888),
 	}
 
-	sidecarConfig := &model.Config{
-		ConfigMeta: model.ConfigMeta{
+	sidecarConfig := &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
@@ -234,8 +235,8 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			},
 		},
 	}
-	sidecarConfigWithWildcard := &model.Config{
-		ConfigMeta: model.ConfigMeta{
+	sidecarConfigWithWildcard := &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
@@ -252,8 +253,8 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			},
 		},
 	}
-	sidecarConfigWitHTTPProxy := &model.Config{
-		ConfigMeta: model.ConfigMeta{
+	sidecarConfigWitHTTPProxy := &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
@@ -270,8 +271,8 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			},
 		},
 	}
-	sidecarConfigWithRegistryOnly := &model.Config{
-		ConfigMeta: model.ConfigMeta{
+	sidecarConfigWithRegistryOnly := &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
@@ -324,8 +325,8 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			},
 		},
 	}
-	sidecarConfigWithAllowAny := &model.Config{
-		ConfigMeta: model.ConfigMeta{
+	sidecarConfigWithAllowAny := &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
@@ -463,40 +464,40 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			},
 		},
 	}
-	virtualService1 := model.Config{
-		ConfigMeta: model.ConfigMeta{
+	virtualService1 := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "acme2-v1",
 			Namespace:        "not-default",
 		},
 		Spec: virtualServiceSpec1,
 	}
-	virtualService2 := model.Config{
-		ConfigMeta: model.ConfigMeta{
+	virtualService2 := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "acme-v2",
 			Namespace:        "not-default",
 		},
 		Spec: virtualServiceSpec2,
 	}
-	virtualService3 := model.Config{
-		ConfigMeta: model.ConfigMeta{
+	virtualService3 := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "acme-v3",
 			Namespace:        "not-default",
 		},
 		Spec: virtualServiceSpec3,
 	}
-	virtualService4 := model.Config{
-		ConfigMeta: model.ConfigMeta{
+	virtualService4 := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "acme-v4",
 			Namespace:        "not-default",
 		},
 		Spec: virtualServiceSpec4,
 	}
-	virtualService5 := model.Config{
-		ConfigMeta: model.ConfigMeta{
+	virtualService5 := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "acme-v3",
 			Namespace:        "not-default",
@@ -520,8 +521,8 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 	cases := []struct {
 		name                  string
 		routeName             string
-		sidecarConfig         *model.Config
-		virtualServiceConfigs []*model.Config
+		sidecarConfig         *config.Config
+		virtualServiceConfigs []*config.Config
 		// virtualHost Name and domains
 		expectedHosts map[string]map[string]bool
 		registryOnly  bool
@@ -747,7 +748,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			name:                  "no sidecar config with virtual services with duplicate entries",
 			routeName:             "60",
 			sidecarConfig:         nil,
-			virtualServiceConfigs: []*model.Config{&virtualService1, &virtualService2},
+			virtualServiceConfigs: []*config.Config{&virtualService1, &virtualService2},
 			expectedHosts: map[string]map[string]bool{
 				"test-private-2.com:60": {
 					"test-private-2.com": true, "test-private-2.com:60": true, "9.9.9.10": true, "9.9.9.10:60": true,
@@ -762,7 +763,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			name:                  "no sidecar config with virtual services with no service in registry",
 			routeName:             "80", // no service for the host in registry; use port 80 by default
 			sidecarConfig:         nil,
-			virtualServiceConfigs: []*model.Config{&virtualService3},
+			virtualServiceConfigs: []*config.Config{&virtualService3},
 			expectedHosts: map[string]map[string]bool{
 				"test-private.com:80": {
 					"test-private.com": true, "test-private.com:80": true, "9.9.9.9": true, "9.9.9.9:80": true,
@@ -795,7 +796,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			name:                  "no sidecar config with virtual services - import headless service from other namespaces: 8888",
 			routeName:             "8888",
 			sidecarConfig:         nil,
-			virtualServiceConfigs: []*model.Config{&virtualService4},
+			virtualServiceConfigs: []*config.Config{&virtualService4},
 			expectedHosts: map[string]map[string]bool{
 				"test-headless.com:8888": {
 					"test-headless.com": true, "test-headless.com:8888": true, "*.test-headless.com": true, "*.test-headless.com:8888": true,
@@ -838,7 +839,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			name:                  "wild card sidecar config, with non matching virtual service",
 			routeName:             "7443",
 			sidecarConfig:         sidecarConfigWithWildcard,
-			virtualServiceConfigs: []*model.Config{&virtualService5},
+			virtualServiceConfigs: []*config.Config{&virtualService5},
 			expectedHosts: map[string]map[string]bool{
 				"block_all": {
 					"*": true,
@@ -850,7 +851,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 			name:                  "http proxy sidecar config, with non matching virtual service",
 			routeName:             "7443",
 			sidecarConfig:         sidecarConfigWitHTTPProxy,
-			virtualServiceConfigs: []*model.Config{&virtualService5},
+			virtualServiceConfigs: []*config.Config{&virtualService5},
 			expectedHosts: map[string]map[string]bool{
 				"bookinfo.com:9999":      {"bookinfo.com:9999": true, "*.bookinfo.com:9999": true},
 				"bookinfo.com:70":        {"bookinfo.com:70": true, "*.bookinfo.com:70": true},
@@ -887,7 +888,7 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 }
 
 func testSidecarRDSVHosts(t *testing.T, services []*model.Service,
-	sidecarConfig *model.Config, virtualServices []*model.Config, routeName string,
+	sidecarConfig *config.Config, virtualServices []*config.Config, routeName string,
 	expectedHosts map[string]map[string]bool, registryOnly bool) {
 	t.Helper()
 	p := &fakePlugin{}

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -51,6 +51,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
@@ -1313,7 +1314,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundThriftListenerOptsForP
 
 func (configgen *ConfigGeneratorImpl) buildSidecarOutboundTCPListenerOptsForPortOrUDS(destinationCIDR *string, listenerMapKey *string,
 	currentListenerEntry **outboundListenerEntry, listenerOpts *buildListenerOpts, listenerMap map[string]*outboundListenerEntry,
-	virtualServices []model.Config, actualWildcard string) (bool, []*filterChainOpts) {
+	virtualServices []config.Config, actualWildcard string) (bool, []*filterChainOpts) {
 
 	// first identify the bind if its not set. Then construct the key
 	// used to lookup the listener in the conflict map.
@@ -1423,7 +1424,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundTCPListenerOptsForPort
 // (as vhosts are shipped through RDS).  TCP listeners on same port are
 // allowed only if they have different CIDR matches.
 func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListenerForPortOrUDS(node *model.Proxy, listenerOpts buildListenerOpts,
-	listenerMap map[string]*outboundListenerEntry, virtualServices []model.Config, actualWildcard string) {
+	listenerMap map[string]*outboundListenerEntry, virtualServices []config.Config, actualWildcard string) {
 	var destinationCIDR string
 	var listenerMapKey string
 	var currentListenerEntry *outboundListenerEntry

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
@@ -576,7 +576,7 @@ func getEnvoyFilterConfigs(configPatches []*networking.EnvoyFilter_EnvoyConfigOb
 	res := []config.Config{}
 	for i, cp := range configPatches {
 		res = append(res, config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				Name:             fmt.Sprintf("test-envoyfilter-%d", i),
 				Namespace:        "not-default",
 				GroupVersionKind: gvk.EnvoyFilter,

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
@@ -32,6 +32,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
 	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
 )
@@ -571,11 +572,11 @@ func buildPatchStruct(config string) *types.Struct {
 	return val
 }
 
-func getEnvoyFilterConfigs(configPatches []*networking.EnvoyFilter_EnvoyConfigObjectPatch) []model.Config {
-	res := []model.Config{}
+func getEnvoyFilterConfigs(configPatches []*networking.EnvoyFilter_EnvoyConfigObjectPatch) []config.Config {
+	res := []config.Config{}
 	for i, cp := range configPatches {
-		res = append(res, model.Config{
-			ConfigMeta: model.ConfigMeta{
+		res = append(res, config.Config{
+			ConfigMeta: config.ConfigMeta{
 				Name:             fmt.Sprintf("test-envoyfilter-%d", i),
 				Namespace:        "not-default",
 				GroupVersionKind: gvk.EnvoyFilter,

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -49,6 +49,7 @@ import (
 	memregistry "istio.io/istio/pilot/pkg/serviceregistry/memory"
 	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
 	"istio.io/istio/pilot/test/xdstest"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/protocol"
@@ -376,8 +377,8 @@ func TestOutboundListenerTCPWithVS(t *testing.T) {
 			}
 
 			p := &fakePlugin{}
-			virtualService := model.Config{
-				ConfigMeta: model.ConfigMeta{
+			virtualService := config.Config{
+				ConfigMeta: config.ConfigMeta{
 					GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 					Name:             "test_vs",
 					Namespace:        "default",
@@ -585,8 +586,8 @@ func TestOutboundTlsTrafficWithoutTimeout(t *testing.T) {
 
 func TestOutboundListenerConfigWithSidecarHTTPProxy(t *testing.T) {
 	p := &fakePlugin{}
-	sidecarConfig := &model.Config{
-		ConfigMeta: model.ConfigMeta{
+	sidecarConfig := &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:             "sidecar-with-http-proxy",
 			Namespace:        "not-default",
 			GroupVersionKind: gvk.Sidecar,
@@ -886,8 +887,8 @@ func testInboundListenerConfigWithGrpc(t *testing.T, proxy *model.Proxy, service
 func testInboundListenerConfigWithSidecar(t *testing.T, proxy *model.Proxy, services ...*model.Service) {
 	t.Helper()
 	p := &fakePlugin{}
-	sidecarConfig := &model.Config{
-		ConfigMeta: model.ConfigMeta{
+	sidecarConfig := &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
@@ -915,8 +916,8 @@ func testInboundListenerConfigWithSidecar(t *testing.T, proxy *model.Proxy, serv
 func testInboundListenerConfigWithSidecarWithoutServices(t *testing.T, proxy *model.Proxy) {
 	t.Helper()
 	p := &fakePlugin{}
-	sidecarConfig := &model.Config{
-		ConfigMeta: model.ConfigMeta{
+	sidecarConfig := &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:      "foo-without-service",
 			Namespace: "not-default",
 		},
@@ -1035,8 +1036,8 @@ func isTCPFilterChain(fc *listener.FilterChain) bool {
 func testOutboundListenerConfigWithSidecar(t *testing.T, services ...*model.Service) {
 	t.Helper()
 	p := &fakePlugin{}
-	sidecarConfig := &model.Config{
-		ConfigMeta: model.ConfigMeta{
+	sidecarConfig := &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:             "foo",
 			Namespace:        "not-default",
 			GroupVersionKind: gvk.Sidecar,
@@ -1173,8 +1174,8 @@ func testInboundListenerConfigWithoutServicesWithHTTP10Proxy(t *testing.T, proxy
 func testInboundListenerConfigWithSidecarWithHTTP10Proxy(t *testing.T, proxy *model.Proxy, services ...*model.Service) {
 	t.Helper()
 	p := &fakePlugin{}
-	sidecarConfig := &model.Config{
-		ConfigMeta: model.ConfigMeta{
+	sidecarConfig := &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
@@ -1208,8 +1209,8 @@ func testInboundListenerConfigWithSidecarWithHTTP10Proxy(t *testing.T, proxy *mo
 func testInboundListenerConfigWithSidecarWithoutServicesWithHTTP10Proxy(t *testing.T, proxy *model.Proxy) {
 	t.Helper()
 	p := &fakePlugin{}
-	sidecarConfig := &model.Config{
-		ConfigMeta: model.ConfigMeta{
+	sidecarConfig := &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:      "foo-without-service",
 			Namespace: "not-default",
 		},
@@ -1242,8 +1243,8 @@ func testInboundListenerConfigWithSidecarWithoutServicesWithHTTP10Proxy(t *testi
 func testOutboundListenerConfigWithSidecarWithSniffingDisabled(t *testing.T, services ...*model.Service) {
 	t.Helper()
 	p := &fakePlugin{}
-	sidecarConfig := &model.Config{
-		ConfigMeta: model.ConfigMeta{
+	sidecarConfig := &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:             "foo",
 			Namespace:        "not-default",
 			GroupVersionKind: gvk.Sidecar,
@@ -1293,8 +1294,8 @@ func testOutboundListenerConfigWithSidecarWithSniffingDisabled(t *testing.T, ser
 func testOutboundListenerConfigWithSidecarWithUseRemoteAddress(t *testing.T, services ...*model.Service) {
 	t.Helper()
 	p := &fakePlugin{}
-	sidecarConfig := &model.Config{
-		ConfigMeta: model.ConfigMeta{
+	sidecarConfig := &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:             "foo",
 			Namespace:        "not-default",
 			GroupVersionKind: gvk.Sidecar,
@@ -1337,8 +1338,8 @@ func testOutboundListenerConfigWithSidecarWithUseRemoteAddress(t *testing.T, ser
 func testOutboundListenerConfigWithSidecarWithCaptureModeNone(t *testing.T, services ...*model.Service) {
 	t.Helper()
 	p := &fakePlugin{}
-	sidecarConfig := &model.Config{
-		ConfigMeta: model.ConfigMeta{
+	sidecarConfig := &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:             "foo",
 			Namespace:        "not-default",
 			GroupVersionKind: gvk.Sidecar,
@@ -2039,7 +2040,7 @@ func getOldestService(services ...*model.Service) *model.Service {
 	return oldestService
 }
 
-func buildAllListeners(p plugin.Plugin, sidecarConfig *model.Config, env model.Environment) []*listener.Listener {
+func buildAllListeners(p plugin.Plugin, sidecarConfig *config.Config, env model.Environment) []*listener.Listener {
 	configgen := NewConfigGenerator([]plugin.Plugin{p})
 
 	if err := env.PushContext.InitContext(&env, nil, nil); err != nil {
@@ -2067,12 +2068,12 @@ func getFilterConfig(filter *listener.Filter, out proto.Message) error {
 	return nil
 }
 
-func buildOutboundListeners(t *testing.T, p plugin.Plugin, proxy *model.Proxy, sidecarConfig *model.Config,
-	virtualService *model.Config, services ...*model.Service) []*listener.Listener {
+func buildOutboundListeners(t *testing.T, p plugin.Plugin, proxy *model.Proxy, sidecarConfig *config.Config,
+	virtualService *config.Config, services ...*model.Service) []*listener.Listener {
 	t.Helper()
 	cg := NewConfigGenTest(t, TestOptions{
 		Services:       services,
-		ConfigPointers: []*model.Config{sidecarConfig, virtualService},
+		ConfigPointers: []*config.Config{sidecarConfig, virtualService},
 		Plugins:        []plugin.Plugin{p},
 	})
 	listeners := cg.ConfigGen.buildSidecarOutboundListeners(cg.SetupProxy(proxy), cg.env.PushContext)
@@ -2080,7 +2081,7 @@ func buildOutboundListeners(t *testing.T, p plugin.Plugin, proxy *model.Proxy, s
 	return listeners
 }
 
-func buildInboundListeners(t *testing.T, p plugin.Plugin, proxy *model.Proxy, sidecarConfig *model.Config, services ...*model.Service) []*listener.Listener {
+func buildInboundListeners(t *testing.T, p plugin.Plugin, proxy *model.Proxy, sidecarConfig *config.Config, services ...*model.Service) []*listener.Listener {
 	t.Helper()
 	configgen := NewConfigGenerator([]plugin.Plugin{p})
 	env := buildListenerEnv(services)
@@ -2267,7 +2268,7 @@ func buildListenerEnv(services []*model.Service) model.Environment {
 	return buildListenerEnvWithVirtualServices(services, nil)
 }
 
-func buildListenerEnvWithVirtualServices(services []*model.Service, virtualServices []*model.Config) model.Environment {
+func buildListenerEnvWithVirtualServices(services []*model.Service, virtualServices []*config.Config) model.Environment {
 	serviceDiscovery := memregistry.NewServiceDiscovery(services)
 
 	instances := make([]*model.ServiceInstance, 0, len(services))
@@ -2286,8 +2287,8 @@ func buildListenerEnvWithVirtualServices(services []*model.Service, virtualServi
 	// TODO stop faking this. proxy ip must match the instance IP
 	serviceDiscovery.WantGetProxyServiceInstances = instances
 
-	envoyFilter := model.Config{
-		ConfigMeta: model.ConfigMeta{
+	envoyFilter := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:             "test-envoyfilter",
 			Namespace:        "not-default",
 			GroupVersionKind: gvk.EnvoyFilter,
@@ -2532,8 +2533,8 @@ func TestOutboundRateLimitedThriftListenerConfig(t *testing.T) {
 		buildService(limitedSvcName+".default.svc.cluster.local", limitedSvcIP, protocol.Thrift, tnow)}
 
 	p := &fakePlugin{}
-	sidecarConfig := &model.Config{
-		ConfigMeta: model.ConfigMeta{
+	sidecarConfig := &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -378,7 +378,7 @@ func TestOutboundListenerTCPWithVS(t *testing.T) {
 
 			p := &fakePlugin{}
 			virtualService := config.Config{
-				ConfigMeta: config.ConfigMeta{
+				Meta: config.Meta{
 					GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 					Name:             "test_vs",
 					Namespace:        "default",
@@ -587,7 +587,7 @@ func TestOutboundTlsTrafficWithoutTimeout(t *testing.T) {
 func TestOutboundListenerConfigWithSidecarHTTPProxy(t *testing.T) {
 	p := &fakePlugin{}
 	sidecarConfig := &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:             "sidecar-with-http-proxy",
 			Namespace:        "not-default",
 			GroupVersionKind: gvk.Sidecar,
@@ -888,7 +888,7 @@ func testInboundListenerConfigWithSidecar(t *testing.T, proxy *model.Proxy, serv
 	t.Helper()
 	p := &fakePlugin{}
 	sidecarConfig := &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
@@ -917,7 +917,7 @@ func testInboundListenerConfigWithSidecarWithoutServices(t *testing.T, proxy *mo
 	t.Helper()
 	p := &fakePlugin{}
 	sidecarConfig := &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:      "foo-without-service",
 			Namespace: "not-default",
 		},
@@ -1037,7 +1037,7 @@ func testOutboundListenerConfigWithSidecar(t *testing.T, services ...*model.Serv
 	t.Helper()
 	p := &fakePlugin{}
 	sidecarConfig := &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:             "foo",
 			Namespace:        "not-default",
 			GroupVersionKind: gvk.Sidecar,
@@ -1175,7 +1175,7 @@ func testInboundListenerConfigWithSidecarWithHTTP10Proxy(t *testing.T, proxy *mo
 	t.Helper()
 	p := &fakePlugin{}
 	sidecarConfig := &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},
@@ -1210,7 +1210,7 @@ func testInboundListenerConfigWithSidecarWithoutServicesWithHTTP10Proxy(t *testi
 	t.Helper()
 	p := &fakePlugin{}
 	sidecarConfig := &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:      "foo-without-service",
 			Namespace: "not-default",
 		},
@@ -1244,7 +1244,7 @@ func testOutboundListenerConfigWithSidecarWithSniffingDisabled(t *testing.T, ser
 	t.Helper()
 	p := &fakePlugin{}
 	sidecarConfig := &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:             "foo",
 			Namespace:        "not-default",
 			GroupVersionKind: gvk.Sidecar,
@@ -1295,7 +1295,7 @@ func testOutboundListenerConfigWithSidecarWithUseRemoteAddress(t *testing.T, ser
 	t.Helper()
 	p := &fakePlugin{}
 	sidecarConfig := &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:             "foo",
 			Namespace:        "not-default",
 			GroupVersionKind: gvk.Sidecar,
@@ -1339,7 +1339,7 @@ func testOutboundListenerConfigWithSidecarWithCaptureModeNone(t *testing.T, serv
 	t.Helper()
 	p := &fakePlugin{}
 	sidecarConfig := &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:             "foo",
 			Namespace:        "not-default",
 			GroupVersionKind: gvk.Sidecar,
@@ -2288,7 +2288,7 @@ func buildListenerEnvWithVirtualServices(services []*model.Service, virtualServi
 	serviceDiscovery.WantGetProxyServiceInstances = instances
 
 	envoyFilter := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:             "test-envoyfilter",
 			Namespace:        "not-default",
 			GroupVersionKind: gvk.EnvoyFilter,
@@ -2534,7 +2534,7 @@ func TestOutboundRateLimitedThriftListenerConfig(t *testing.T) {
 
 	p := &fakePlugin{}
 	sidecarConfig := &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:      "foo",
 			Namespace: "not-default",
 		},

--- a/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer_test.go
@@ -268,7 +268,7 @@ func buildEnvForClustersWithDistribute(distribute []*networking.LocalityLoadBala
 	env.PushContext = model.NewPushContext()
 	_ = env.PushContext.InitContext(env, nil, nil)
 	env.PushContext.SetDestinationRules([]config.Config{
-		{ConfigMeta: config.ConfigMeta{
+		{Meta: config.Meta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(),
 			Name:             "acme",
 		},
@@ -325,7 +325,7 @@ func buildEnvForClustersWithFailover() *model.Environment {
 	env.PushContext = model.NewPushContext()
 	_ = env.PushContext.InitContext(env, nil, nil)
 	env.PushContext.SetDestinationRules([]config.Config{
-		{ConfigMeta: config.ConfigMeta{
+		{Meta: config.Meta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(),
 			Name:             "acme",
 		},

--- a/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer_test.go
@@ -29,6 +29,7 @@ import (
 	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/model"
 	memregistry "istio.io/istio/pilot/pkg/serviceregistry/memory"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/collections"
@@ -266,8 +267,8 @@ func buildEnvForClustersWithDistribute(distribute []*networking.LocalityLoadBala
 
 	env.PushContext = model.NewPushContext()
 	_ = env.PushContext.InitContext(env, nil, nil)
-	env.PushContext.SetDestinationRules([]model.Config{
-		{ConfigMeta: model.ConfigMeta{
+	env.PushContext.SetDestinationRules([]config.Config{
+		{ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(),
 			Name:             "acme",
 		},
@@ -323,8 +324,8 @@ func buildEnvForClustersWithFailover() *model.Environment {
 
 	env.PushContext = model.NewPushContext()
 	_ = env.PushContext.InitContext(env, nil, nil)
-	env.PushContext.SetDestinationRules([]model.Config{
-		{ConfigMeta: model.ConfigMeta{
+	env.PushContext.SetDestinationRules([]config.Config{
+		{ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(),
 			Name:             "acme",
 		},

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -34,6 +34,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	istio_route "istio.io/istio/pilot/pkg/networking/core/v1alpha3/route"
 	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
 )
@@ -109,7 +110,7 @@ func buildOutboundNetworkFiltersWithSingleDestination(push *model.PushContext, n
 // buildOutboundNetworkFiltersWithWeightedClusters takes a set of weighted
 // destination routes and builds a stack of network filters.
 func buildOutboundNetworkFiltersWithWeightedClusters(node *model.Proxy, routes []*networking.RouteDestination,
-	push *model.PushContext, port *model.Port, configMeta model.ConfigMeta) []*listener.Filter {
+	push *model.PushContext, port *model.Port, configMeta config.ConfigMeta) []*listener.Filter {
 
 	statPrefix := configMeta.Name + "." + configMeta.Namespace
 	clusterSpecifier := &tcp.TcpProxy_WeightedClusters{
@@ -182,7 +183,7 @@ func buildNetworkFiltersStack(port *model.Port, tcpFilter *listener.Filter, stat
 // filter).
 func buildOutboundNetworkFilters(node *model.Proxy,
 	routes []*networking.RouteDestination, push *model.PushContext,
-	port *model.Port, configMeta model.ConfigMeta) []*listener.Filter {
+	port *model.Port, configMeta config.ConfigMeta) []*listener.Filter {
 	if len(routes) == 1 {
 		service := push.ServiceForHostname(node, host.Name(routes[0].Destination.Host))
 		clusterName := istio_route.GetDestinationCluster(routes[0].Destination, service, port.Port)

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -110,7 +110,7 @@ func buildOutboundNetworkFiltersWithSingleDestination(push *model.PushContext, n
 // buildOutboundNetworkFiltersWithWeightedClusters takes a set of weighted
 // destination routes and builds a stack of network filters.
 func buildOutboundNetworkFiltersWithWeightedClusters(node *model.Proxy, routes []*networking.RouteDestination,
-	push *model.PushContext, port *model.Port, configMeta config.ConfigMeta) []*listener.Filter {
+	push *model.PushContext, port *model.Port, configMeta config.Meta) []*listener.Filter {
 
 	statPrefix := configMeta.Name + "." + configMeta.Namespace
 	clusterSpecifier := &tcp.TcpProxy_WeightedClusters{
@@ -183,7 +183,7 @@ func buildNetworkFiltersStack(port *model.Port, tcpFilter *listener.Filter, stat
 // filter).
 func buildOutboundNetworkFilters(node *model.Proxy,
 	routes []*networking.RouteDestination, push *model.PushContext,
-	port *model.Port, configMeta config.ConfigMeta) []*listener.Filter {
+	port *model.Port, configMeta config.Meta) []*listener.Filter {
 	if len(routes) == 1 {
 		service := push.ServiceForHostname(node, host.Name(routes[0].Destination.Host))
 		clusterName := istio_route.GetDestinationCluster(routes[0].Destination, service, port.Port)

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter_test.go
@@ -213,7 +213,7 @@ func TestOutboundNetworkFilterStatPrefix(t *testing.T) {
 			proxy.IstioVersion = model.ParseIstioVersion(proxy.Metadata.IstioVersion)
 			proxy.SidecarScope = model.DefaultSidecarScopeForNamespace(env.PushContext, "not-default")
 
-			listeners := buildOutboundNetworkFilters(proxy, tt.routes, env.PushContext, &model.Port{Port: 9999}, config.ConfigMeta{Name: "test.com", Namespace: "ns"})
+			listeners := buildOutboundNetworkFilters(proxy, tt.routes, env.PushContext, &model.Port{Port: 9999}, config.Meta{Name: "test.com", Namespace: "ns"})
 			tcp := &tcp.TcpProxy{}
 			ptypes.UnmarshalAny(listeners[0].GetTypedConfig(), tcp)
 			if tcp.StatPrefix != tt.expectedStatPrefix {

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter_test.go
@@ -25,6 +25,7 @@ import (
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/protocol"
 )
 
@@ -212,7 +213,7 @@ func TestOutboundNetworkFilterStatPrefix(t *testing.T) {
 			proxy.IstioVersion = model.ParseIstioVersion(proxy.Metadata.IstioVersion)
 			proxy.SidecarScope = model.DefaultSidecarScopeForNamespace(env.PushContext, "not-default")
 
-			listeners := buildOutboundNetworkFilters(proxy, tt.routes, env.PushContext, &model.Port{Port: 9999}, model.ConfigMeta{Name: "test.com", Namespace: "ns"})
+			listeners := buildOutboundNetworkFilters(proxy, tt.routes, env.PushContext, &model.Port{Port: 9999}, config.ConfigMeta{Name: "test.com", Namespace: "ns"})
 			tcp := &tcp.TcpProxy{}
 			ptypes.UnmarshalAny(listeners[0].GetTypedConfig(), tcp)
 			if tcp.StatPrefix != tt.expectedStatPrefix {

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -37,6 +37,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/route/retry"
 	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
@@ -88,7 +89,7 @@ func BuildSidecarVirtualHostsFromConfigAndRegistry(
 	node *model.Proxy,
 	push *model.PushContext,
 	serviceRegistry map[host.Name]*model.Service,
-	virtualServices []model.Config,
+	virtualServices []config.Config,
 	listenPort int) []VirtualHostWrapper {
 
 	out := make([]VirtualHostWrapper, 0)
@@ -141,7 +142,7 @@ func BuildSidecarVirtualHostsFromConfigAndRegistry(
 
 // separateVSHostsAndServices splits the virtual service hosts into services (if they are found in the registry) and
 // plain non-registry hostnames
-func separateVSHostsAndServices(virtualService model.Config,
+func separateVSHostsAndServices(virtualService config.Config,
 	serviceRegistry map[host.Name]*model.Service) ([]string, []*model.Service) {
 	rule := virtualService.Spec.(*networking.VirtualService)
 	hosts := make([]string, 0)
@@ -189,7 +190,7 @@ func separateVSHostsAndServices(virtualService model.Config,
 func buildSidecarVirtualHostsForVirtualService(
 	node *model.Proxy,
 	push *model.PushContext,
-	virtualService model.Config,
+	virtualService config.Config,
 	serviceRegistry map[host.Name]*model.Service,
 	listenPort int) []VirtualHostWrapper {
 	hosts, servicesInVirtualService := separateVSHostsAndServices(virtualService, serviceRegistry)
@@ -265,7 +266,7 @@ func GetDestinationCluster(destination *networking.Destination, service *model.S
 func BuildHTTPRoutesForVirtualService(
 	node *model.Proxy,
 	push *model.PushContext,
-	virtualService model.Config,
+	virtualService config.Config,
 	serviceRegistry map[host.Name]*model.Service,
 	listenPort int,
 	gatewayNames map[string]bool) ([]*route.Route, error) {
@@ -332,7 +333,7 @@ func sourceMatchHTTP(match *networking.HTTPMatchRequest, proxyLabels labels.Coll
 // translateRoute translates HTTP routes
 func translateRoute(push *model.PushContext, node *model.Proxy, in *networking.HTTPRoute,
 	match *networking.HTTPMatchRequest, port int,
-	virtualService model.Config,
+	virtualService config.Config,
 	serviceRegistry map[host.Name]*model.Service,
 	gatewayNames map[string]bool) *route.Route {
 

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -352,7 +352,7 @@ func translateRoute(push *model.PushContext, node *model.Proxy, in *networking.H
 
 	out := &route.Route{
 		Match:    translateRouteMatch(match, node),
-		Metadata: util.BuildConfigInfoMetadata(virtualService.ConfigMeta),
+		Metadata: util.BuildConfigInfoMetadata(virtualService.Meta),
 	}
 
 	routeName := in.Name

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -33,6 +33,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/route"
 	"istio.io/istio/pilot/test/xdstest"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/protocol"
@@ -257,9 +258,9 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		push := &model.PushContext{
 			Mesh: &meshConfig,
 		}
-		push.SetDestinationRules([]model.Config{
+		push.SetDestinationRules([]config.Config{
 			{
-				ConfigMeta: model.ConfigMeta{
+				ConfigMeta: config.ConfigMeta{
 					GroupVersionKind: collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(),
 					Name:             "acme",
 				},
@@ -306,9 +307,9 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		push := &model.PushContext{
 			Mesh: &meshConfig,
 		}
-		push.SetDestinationRules([]model.Config{
+		push.SetDestinationRules([]config.Config{
 			{
-				ConfigMeta: model.ConfigMeta{
+				ConfigMeta: config.ConfigMeta{
 					GroupVersionKind: collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(),
 					Name:             "acme",
 				},
@@ -347,8 +348,8 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	t.Run("for virtual service with subsets with ring hash", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
-		virtualService := model.Config{
-			ConfigMeta: model.ConfigMeta{
+		virtualService := config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 				Name:             "acme",
 			},
@@ -359,9 +360,9 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		push := &model.PushContext{
 			Mesh: &meshConfig,
 		}
-		push.SetDestinationRules([]model.Config{
+		push.SetDestinationRules([]config.Config{
 			{
-				ConfigMeta: model.ConfigMeta{
+				ConfigMeta: config.ConfigMeta{
 					GroupVersionKind: collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(),
 					Name:             "acme",
 				},
@@ -391,7 +392,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	t.Run("for virtual service with subsets with port level settings with ring hash", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
-		virtualService := model.Config{ConfigMeta: model.ConfigMeta{
+		virtualService := config.Config{ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "acme",
 		},
@@ -403,10 +404,10 @@ func TestBuildHTTPRoutes(t *testing.T) {
 			Mesh: &meshConfig,
 		}
 
-		push.SetDestinationRules([]model.Config{
+		push.SetDestinationRules([]config.Config{
 			{
 
-				ConfigMeta: model.ConfigMeta{
+				ConfigMeta: config.ConfigMeta{
 					GroupVersionKind: collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(),
 					Name:             "acme",
 				},
@@ -432,16 +433,16 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	t.Run("for virtual service with subsets and top level traffic policy with ring hash", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
-		virtualService := model.Config{
-			ConfigMeta: model.ConfigMeta{
+		virtualService := config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 				Name:             "acme",
 			},
 			Spec: virtualServiceWithSubset,
 		}
 
-		cnfg := model.Config{
-			ConfigMeta: model.ConfigMeta{
+		cnfg := config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind: collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(),
 				Name:             "acme",
 			},
@@ -455,7 +456,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 			Mesh: &meshConfig,
 		}
 
-		push.SetDestinationRules([]model.Config{
+		push.SetDestinationRules([]config.Config{
 			cnfg})
 
 		routes, err := route.BuildHTTPRoutesForVirtualService(node, push, virtualService, serviceRegistry, 8080, gatewayNames)
@@ -482,9 +483,9 @@ func TestBuildHTTPRoutes(t *testing.T) {
 			Mesh: &meshConfig,
 		}
 
-		push.SetDestinationRules([]model.Config{
+		push.SetDestinationRules([]config.Config{
 			{
-				ConfigMeta: model.ConfigMeta{
+				ConfigMeta: config.ConfigMeta{
 					GroupVersionKind: collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(),
 					Name:             "acme",
 				},
@@ -627,15 +628,15 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		push := &model.PushContext{
 			Mesh: &meshConfig,
 		}
-		push.SetDestinationRules([]model.Config{
+		push.SetDestinationRules([]config.Config{
 			{
-				ConfigMeta: model.ConfigMeta{
+				ConfigMeta: config.ConfigMeta{
 					GroupVersionKind: collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(),
 					Name:             "acme",
 				},
 				Spec: networkingDestinationRule,
 			}})
-		vhosts := route.BuildSidecarVirtualHostsFromConfigAndRegistry(node, push, serviceRegistry, []model.Config{}, 8080)
+		vhosts := route.BuildSidecarVirtualHostsFromConfigAndRegistry(node, push, serviceRegistry, []config.Config{}, 8080)
 		g.Expect(vhosts[0].Routes[0].Action.(*envoyroute.Route_Route).Route.HashPolicy).NotTo(gomega.BeNil())
 	})
 	t.Run("for no virtualservice but has destinationrule with portLevel consistentHash loadbalancer", func(t *testing.T) {
@@ -644,16 +645,16 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		push := &model.PushContext{
 			Mesh: &meshConfig,
 		}
-		push.SetDestinationRules([]model.Config{
+		push.SetDestinationRules([]config.Config{
 			{
-				ConfigMeta: model.ConfigMeta{
+				ConfigMeta: config.ConfigMeta{
 					GroupVersionKind: collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(),
 					Name:             "acme",
 				},
 				Spec: networkingDestinationRuleWithPortLevelTrafficPolicy,
 			}})
 
-		vhosts := route.BuildSidecarVirtualHostsFromConfigAndRegistry(node, push, serviceRegistry, []model.Config{}, 8080)
+		vhosts := route.BuildSidecarVirtualHostsFromConfigAndRegistry(node, push, serviceRegistry, []config.Config{}, 8080)
 
 		hashPolicy := &envoyroute.RouteAction_HashPolicy{
 			PolicySpecifier: &envoyroute.RouteAction_HashPolicy_Cookie_{
@@ -720,8 +721,8 @@ var virtualServiceWithSubsetWithPortLevelSettings = &networking.VirtualService{
 	},
 }
 
-var virtualServicePlain = model.Config{
-	ConfigMeta: model.ConfigMeta{
+var virtualServicePlain = config.Config{
+	ConfigMeta: config.ConfigMeta{
 		GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 		Name:             "acme",
 	},
@@ -746,8 +747,8 @@ var virtualServicePlain = model.Config{
 	},
 }
 
-var virtualServiceWithTimeout = model.Config{
-	ConfigMeta: model.ConfigMeta{
+var virtualServiceWithTimeout = config.Config{
+	ConfigMeta: config.ConfigMeta{
 		GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 		Name:             "acme",
 	},
@@ -775,8 +776,8 @@ var virtualServiceWithTimeout = model.Config{
 	},
 }
 
-var virtualServiceWithTimeoutDisabled = model.Config{
-	ConfigMeta: model.ConfigMeta{
+var virtualServiceWithTimeoutDisabled = config.Config{
+	ConfigMeta: config.ConfigMeta{
 		GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 		Name:             "acme",
 	},
@@ -804,8 +805,8 @@ var virtualServiceWithTimeoutDisabled = model.Config{
 	},
 }
 
-var virtualServiceWithCatchAllRoute = model.Config{
-	ConfigMeta: model.ConfigMeta{
+var virtualServiceWithCatchAllRoute = config.Config{
+	ConfigMeta: config.ConfigMeta{
 		GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 		Name:             "acme",
 	},
@@ -848,8 +849,8 @@ var virtualServiceWithCatchAllRoute = model.Config{
 	},
 }
 
-var virtualServiceWithCatchAllMultiPrefixRoute = model.Config{
-	ConfigMeta: model.ConfigMeta{
+var virtualServiceWithCatchAllMultiPrefixRoute = config.Config{
+	ConfigMeta: config.ConfigMeta{
 		GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 		Name:             "acme",
 	},
@@ -895,8 +896,8 @@ var virtualServiceWithCatchAllMultiPrefixRoute = model.Config{
 	},
 }
 
-var virtualServiceWithCatchAllRouteWeightedDestination = model.Config{
-	ConfigMeta: model.ConfigMeta{
+var virtualServiceWithCatchAllRouteWeightedDestination = config.Config{
+	ConfigMeta: config.ConfigMeta{
 		GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 		Name:             "acme",
 	},
@@ -945,8 +946,8 @@ var virtualServiceWithCatchAllRouteWeightedDestination = model.Config{
 	},
 }
 
-var virtualServiceWithHeaderOperations = model.Config{
-	ConfigMeta: model.ConfigMeta{
+var virtualServiceWithHeaderOperations = config.Config{
+	ConfigMeta: config.ConfigMeta{
 		GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 		Name:             "acme",
 	},
@@ -993,8 +994,8 @@ var virtualServiceWithHeaderOperations = model.Config{
 	},
 }
 
-var virtualServiceWithRedirect = model.Config{
-	ConfigMeta: model.ConfigMeta{
+var virtualServiceWithRedirect = config.Config{
+	ConfigMeta: config.ConfigMeta{
 		GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 		Name:             "acme",
 	},
@@ -1013,8 +1014,8 @@ var virtualServiceWithRedirect = model.Config{
 	},
 }
 
-var virtualServiceWithRedirectAndSetHeader = model.Config{
-	ConfigMeta: model.ConfigMeta{
+var virtualServiceWithRedirectAndSetHeader = config.Config{
+	ConfigMeta: config.ConfigMeta{
 		GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 		Name:             "acme",
 	},
@@ -1040,8 +1041,8 @@ var virtualServiceWithRedirectAndSetHeader = model.Config{
 	},
 }
 
-var virtualServiceWithRegexMatchingOnURI = model.Config{
-	ConfigMeta: model.ConfigMeta{
+var virtualServiceWithRegexMatchingOnURI = config.Config{
+	ConfigMeta: config.ConfigMeta{
 		GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 		Name:             "acme",
 	},
@@ -1070,8 +1071,8 @@ var virtualServiceWithRegexMatchingOnURI = model.Config{
 	},
 }
 
-var virtualServiceWithRegexMatchingOnHeader = model.Config{
-	ConfigMeta: model.ConfigMeta{
+var virtualServiceWithRegexMatchingOnHeader = config.Config{
+	ConfigMeta: config.ConfigMeta{
 		GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 		Name:             "acme",
 	},
@@ -1102,11 +1103,11 @@ var virtualServiceWithRegexMatchingOnHeader = model.Config{
 	},
 }
 
-func createVirtualServiceWithRegexMatchingForAllCasesOnHeader() []*model.Config {
-	ret := []*model.Config{}
+func createVirtualServiceWithRegexMatchingForAllCasesOnHeader() []*config.Config {
+	ret := []*config.Config{}
 	regex := "*"
-	ret = append(ret, &model.Config{
-		ConfigMeta: model.ConfigMeta{
+	ret = append(ret, &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "acme",
 		},
@@ -1140,8 +1141,8 @@ func createVirtualServiceWithRegexMatchingForAllCasesOnHeader() []*model.Config 
 	return ret
 }
 
-var virtualServiceWithRegexMatchingOnWithoutHeader = model.Config{
-	ConfigMeta: model.ConfigMeta{
+var virtualServiceWithRegexMatchingOnWithoutHeader = config.Config{
+	ConfigMeta: config.ConfigMeta{
 		GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 		Name:             "acme",
 	},
@@ -1172,8 +1173,8 @@ var virtualServiceWithRegexMatchingOnWithoutHeader = model.Config{
 	},
 }
 
-var virtualServiceWithPresentMatchingOnHeader = model.Config{
-	ConfigMeta: model.ConfigMeta{
+var virtualServiceWithPresentMatchingOnHeader = config.Config{
+	ConfigMeta: config.ConfigMeta{
 		GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 		Name:             "acme",
 	},
@@ -1200,8 +1201,8 @@ var virtualServiceWithPresentMatchingOnHeader = model.Config{
 	},
 }
 
-var virtualServiceWithPresentMatchingOnWithoutHeader = model.Config{
-	ConfigMeta: model.ConfigMeta{
+var virtualServiceWithPresentMatchingOnWithoutHeader = config.Config{
+	ConfigMeta: config.ConfigMeta{
 		GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 		Name:             "acme",
 	},
@@ -1228,8 +1229,8 @@ var virtualServiceWithPresentMatchingOnWithoutHeader = model.Config{
 	},
 }
 
-var virtualServiceMatchingOnSourceNamespace = model.Config{
-	ConfigMeta: model.ConfigMeta{
+var virtualServiceMatchingOnSourceNamespace = config.Config{
+	ConfigMeta: config.ConfigMeta{
 		GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 		Name:             "acme",
 	},

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -260,7 +260,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		}
 		push.SetDestinationRules([]config.Config{
 			{
-				ConfigMeta: config.ConfigMeta{
+				Meta: config.Meta{
 					GroupVersionKind: collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(),
 					Name:             "acme",
 				},
@@ -309,7 +309,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		}
 		push.SetDestinationRules([]config.Config{
 			{
-				ConfigMeta: config.ConfigMeta{
+				Meta: config.Meta{
 					GroupVersionKind: collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(),
 					Name:             "acme",
 				},
@@ -349,7 +349,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g := gomega.NewWithT(t)
 
 		virtualService := config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 				Name:             "acme",
 			},
@@ -362,7 +362,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		}
 		push.SetDestinationRules([]config.Config{
 			{
-				ConfigMeta: config.ConfigMeta{
+				Meta: config.Meta{
 					GroupVersionKind: collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(),
 					Name:             "acme",
 				},
@@ -392,7 +392,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	t.Run("for virtual service with subsets with port level settings with ring hash", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 
-		virtualService := config.Config{ConfigMeta: config.ConfigMeta{
+		virtualService := config.Config{Meta: config.Meta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "acme",
 		},
@@ -407,7 +407,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		push.SetDestinationRules([]config.Config{
 			{
 
-				ConfigMeta: config.ConfigMeta{
+				Meta: config.Meta{
 					GroupVersionKind: collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(),
 					Name:             "acme",
 				},
@@ -434,7 +434,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g := gomega.NewWithT(t)
 
 		virtualService := config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 				Name:             "acme",
 			},
@@ -442,7 +442,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		}
 
 		cnfg := config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind: collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(),
 				Name:             "acme",
 			},
@@ -485,7 +485,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 
 		push.SetDestinationRules([]config.Config{
 			{
-				ConfigMeta: config.ConfigMeta{
+				Meta: config.Meta{
 					GroupVersionKind: collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(),
 					Name:             "acme",
 				},
@@ -630,7 +630,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		}
 		push.SetDestinationRules([]config.Config{
 			{
-				ConfigMeta: config.ConfigMeta{
+				Meta: config.Meta{
 					GroupVersionKind: collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(),
 					Name:             "acme",
 				},
@@ -647,7 +647,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		}
 		push.SetDestinationRules([]config.Config{
 			{
-				ConfigMeta: config.ConfigMeta{
+				Meta: config.Meta{
 					GroupVersionKind: collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(),
 					Name:             "acme",
 				},
@@ -722,7 +722,7 @@ var virtualServiceWithSubsetWithPortLevelSettings = &networking.VirtualService{
 }
 
 var virtualServicePlain = config.Config{
-	ConfigMeta: config.ConfigMeta{
+	Meta: config.Meta{
 		GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 		Name:             "acme",
 	},
@@ -748,7 +748,7 @@ var virtualServicePlain = config.Config{
 }
 
 var virtualServiceWithTimeout = config.Config{
-	ConfigMeta: config.ConfigMeta{
+	Meta: config.Meta{
 		GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 		Name:             "acme",
 	},
@@ -777,7 +777,7 @@ var virtualServiceWithTimeout = config.Config{
 }
 
 var virtualServiceWithTimeoutDisabled = config.Config{
-	ConfigMeta: config.ConfigMeta{
+	Meta: config.Meta{
 		GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 		Name:             "acme",
 	},
@@ -806,7 +806,7 @@ var virtualServiceWithTimeoutDisabled = config.Config{
 }
 
 var virtualServiceWithCatchAllRoute = config.Config{
-	ConfigMeta: config.ConfigMeta{
+	Meta: config.Meta{
 		GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 		Name:             "acme",
 	},
@@ -850,7 +850,7 @@ var virtualServiceWithCatchAllRoute = config.Config{
 }
 
 var virtualServiceWithCatchAllMultiPrefixRoute = config.Config{
-	ConfigMeta: config.ConfigMeta{
+	Meta: config.Meta{
 		GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 		Name:             "acme",
 	},
@@ -897,7 +897,7 @@ var virtualServiceWithCatchAllMultiPrefixRoute = config.Config{
 }
 
 var virtualServiceWithCatchAllRouteWeightedDestination = config.Config{
-	ConfigMeta: config.ConfigMeta{
+	Meta: config.Meta{
 		GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 		Name:             "acme",
 	},
@@ -947,7 +947,7 @@ var virtualServiceWithCatchAllRouteWeightedDestination = config.Config{
 }
 
 var virtualServiceWithHeaderOperations = config.Config{
-	ConfigMeta: config.ConfigMeta{
+	Meta: config.Meta{
 		GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 		Name:             "acme",
 	},
@@ -995,7 +995,7 @@ var virtualServiceWithHeaderOperations = config.Config{
 }
 
 var virtualServiceWithRedirect = config.Config{
-	ConfigMeta: config.ConfigMeta{
+	Meta: config.Meta{
 		GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 		Name:             "acme",
 	},
@@ -1015,7 +1015,7 @@ var virtualServiceWithRedirect = config.Config{
 }
 
 var virtualServiceWithRedirectAndSetHeader = config.Config{
-	ConfigMeta: config.ConfigMeta{
+	Meta: config.Meta{
 		GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 		Name:             "acme",
 	},
@@ -1042,7 +1042,7 @@ var virtualServiceWithRedirectAndSetHeader = config.Config{
 }
 
 var virtualServiceWithRegexMatchingOnURI = config.Config{
-	ConfigMeta: config.ConfigMeta{
+	Meta: config.Meta{
 		GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 		Name:             "acme",
 	},
@@ -1072,7 +1072,7 @@ var virtualServiceWithRegexMatchingOnURI = config.Config{
 }
 
 var virtualServiceWithRegexMatchingOnHeader = config.Config{
-	ConfigMeta: config.ConfigMeta{
+	Meta: config.Meta{
 		GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 		Name:             "acme",
 	},
@@ -1107,7 +1107,7 @@ func createVirtualServiceWithRegexMatchingForAllCasesOnHeader() []*config.Config
 	ret := []*config.Config{}
 	regex := "*"
 	ret = append(ret, &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 			Name:             "acme",
 		},
@@ -1142,7 +1142,7 @@ func createVirtualServiceWithRegexMatchingForAllCasesOnHeader() []*config.Config
 }
 
 var virtualServiceWithRegexMatchingOnWithoutHeader = config.Config{
-	ConfigMeta: config.ConfigMeta{
+	Meta: config.Meta{
 		GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 		Name:             "acme",
 	},
@@ -1174,7 +1174,7 @@ var virtualServiceWithRegexMatchingOnWithoutHeader = config.Config{
 }
 
 var virtualServiceWithPresentMatchingOnHeader = config.Config{
-	ConfigMeta: config.ConfigMeta{
+	Meta: config.Meta{
 		GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 		Name:             "acme",
 	},
@@ -1202,7 +1202,7 @@ var virtualServiceWithPresentMatchingOnHeader = config.Config{
 }
 
 var virtualServiceWithPresentMatchingOnWithoutHeader = config.Config{
-	ConfigMeta: config.ConfigMeta{
+	Meta: config.Meta{
 		GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 		Name:             "acme",
 	},
@@ -1230,7 +1230,7 @@ var virtualServiceWithPresentMatchingOnWithoutHeader = config.Config{
 }
 
 var virtualServiceMatchingOnSourceNamespace = config.Config{
-	ConfigMeta: config.ConfigMeta{
+	Meta: config.Meta{
 		GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
 		Name:             "acme",
 	},

--- a/pilot/pkg/networking/core/v1alpha3/tls.go
+++ b/pilot/pkg/networking/core/v1alpha3/tls.go
@@ -144,10 +144,10 @@ func buildSidecarOutboundTLSFilterChainOpts(node *model.Proxy, push *model.PushC
 					matchHash := hashRuntimeTLSMatchPredicates(match)
 					if !matchHasBeenHandled[matchHash] {
 						out = append(out, &filterChainOpts{
-							metadata:         util.BuildConfigInfoMetadata(cfg.ConfigMeta),
+							metadata:         util.BuildConfigInfoMetadata(cfg.Meta),
 							sniHosts:         match.SniHosts,
 							destinationCIDRs: destinationCIDRs,
-							networkFilters:   buildOutboundNetworkFilters(node, tls.Route, push, listenPort, cfg.ConfigMeta),
+							networkFilters:   buildOutboundNetworkFilters(node, tls.Route, push, listenPort, cfg.Meta),
 						})
 						hasTLSMatch = true
 					}
@@ -224,9 +224,9 @@ TcpLoop:
 			if len(tcp.Match) == 0 {
 				// implicit match
 				out = append(out, &filterChainOpts{
-					metadata:         util.BuildConfigInfoMetadata(cfg.ConfigMeta),
+					metadata:         util.BuildConfigInfoMetadata(cfg.Meta),
 					destinationCIDRs: destinationCIDRs,
-					networkFilters:   buildOutboundNetworkFilters(node, tcp.Route, push, listenPort, cfg.ConfigMeta),
+					networkFilters:   buildOutboundNetworkFilters(node, tcp.Route, push, listenPort, cfg.Meta),
 				})
 				defaultRouteAdded = true
 				break TcpLoop
@@ -248,9 +248,9 @@ TcpLoop:
 					// (this is similar to virtual hosts in http) and create filter chain match accordingly.
 					if len(match.DestinationSubnets) == 0 || listenPort.Port == 0 {
 						out = append(out, &filterChainOpts{
-							metadata:         util.BuildConfigInfoMetadata(cfg.ConfigMeta),
+							metadata:         util.BuildConfigInfoMetadata(cfg.Meta),
 							destinationCIDRs: destinationCIDRs,
-							networkFilters:   buildOutboundNetworkFilters(node, tcp.Route, push, listenPort, cfg.ConfigMeta),
+							networkFilters:   buildOutboundNetworkFilters(node, tcp.Route, push, listenPort, cfg.Meta),
 						})
 						defaultRouteAdded = true
 						break TcpLoop
@@ -263,7 +263,7 @@ TcpLoop:
 			if len(virtualServiceDestinationSubnets) > 0 {
 				out = append(out, &filterChainOpts{
 					destinationCIDRs: virtualServiceDestinationSubnets,
-					networkFilters:   buildOutboundNetworkFilters(node, tcp.Route, push, listenPort, cfg.ConfigMeta),
+					networkFilters:   buildOutboundNetworkFilters(node, tcp.Route, push, listenPort, cfg.Meta),
 				})
 
 				// If at this point there is a filter chain generated with the same CIDR match as the

--- a/pilot/pkg/networking/core/v1alpha3/tls.go
+++ b/pilot/pkg/networking/core/v1alpha3/tls.go
@@ -22,6 +22,7 @@ import (
 	"istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/pkg/log"
@@ -72,8 +73,8 @@ func matchTCP(match *v1alpha3.L4MatchAttributes, proxyLabels labels.Collection, 
 }
 
 // Select the config pertaining to the service being processed.
-func getConfigsForHost(hostname host.Name, configs []model.Config) []model.Config {
-	svcConfigs := make([]model.Config, 0)
+func getConfigsForHost(hostname host.Name, configs []config.Config) []config.Config {
+	svcConfigs := make([]config.Config, 0)
 	for index := range configs {
 		virtualService := configs[index].Spec.(*v1alpha3.VirtualService)
 		for _, vsHost := range virtualService.Hosts {
@@ -93,7 +94,7 @@ func hashRuntimeTLSMatchPredicates(match *v1alpha3.TLSMatchAttributes) string {
 
 func buildSidecarOutboundTLSFilterChainOpts(node *model.Proxy, push *model.PushContext, destinationCIDR string,
 	service *model.Service, listenPort *model.Port,
-	gateways map[string]bool, configs []model.Config) []*filterChainOpts {
+	gateways map[string]bool, configs []config.Config) []*filterChainOpts {
 
 	if !listenPort.Protocol.IsTLS() {
 		return nil
@@ -203,7 +204,7 @@ func buildSidecarOutboundTLSFilterChainOpts(node *model.Proxy, push *model.PushC
 
 func buildSidecarOutboundTCPFilterChainOpts(node *model.Proxy, push *model.PushContext, destinationCIDR string,
 	service *model.Service, listenPort *model.Port,
-	gateways map[string]bool, configs []model.Config) []*filterChainOpts {
+	gateways map[string]bool, configs []config.Config) []*filterChainOpts {
 
 	if listenPort.Protocol.IsTLS() {
 		return nil
@@ -309,11 +310,11 @@ TcpLoop:
 // In the latter case, there is no service associated with this listen port. So we have to account for this
 // missing service throughout this file
 func buildSidecarOutboundTCPTLSFilterChainOpts(node *model.Proxy, push *model.PushContext,
-	configs []model.Config, destinationCIDR string, service *model.Service, listenPort *model.Port,
+	configs []config.Config, destinationCIDR string, service *model.Service, listenPort *model.Port,
 	gateways map[string]bool) []*filterChainOpts {
 
 	out := make([]*filterChainOpts, 0)
-	var svcConfigs []model.Config
+	var svcConfigs []config.Config
 	if service != nil {
 		svcConfigs = getConfigsForHost(service.Hostname, configs)
 	} else {

--- a/pilot/pkg/networking/grpcgen/grpcgen_test.go
+++ b/pilot/pkg/networking/grpcgen/grpcgen_test.go
@@ -34,6 +34,7 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/xds"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
 )
 
@@ -61,8 +62,8 @@ func TestGRPC(t *testing.T) {
 	se := collections.IstioNetworkingV1Alpha3Serviceentries.Resource()
 	store := ds.MemoryConfigStore
 
-	store.Create(model.Config{
-		ConfigMeta: model.ConfigMeta{
+	store.Create(config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: se.GroupVersionKind(),
 			Name:             "fortio",
 			Namespace:        "fortio",

--- a/pilot/pkg/networking/grpcgen/grpcgen_test.go
+++ b/pilot/pkg/networking/grpcgen/grpcgen_test.go
@@ -63,7 +63,7 @@ func TestGRPC(t *testing.T) {
 	store := ds.MemoryConfigStore
 
 	store.Create(config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: se.GroupVersionKind(),
 			Name:             "fortio",
 			Namespace:        "fortio",

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -388,7 +388,7 @@ func cloneLocalityLbEndpoints(endpoints []*endpoint.LocalityLbEndpoints) []*endp
 
 // BuildConfigInfoMetadata builds core.Metadata struct containing the
 // name.namespace of the config, the type, etc.
-func BuildConfigInfoMetadata(config config.ConfigMeta) *core.Metadata {
+func BuildConfigInfoMetadata(config config.Meta) *core.Metadata {
 	s := "/apis/" + config.GroupVersionKind.Group + "/" + config.GroupVersionKind.Version + "/namespaces/" + config.Namespace + "/" +
 		strcase.CamelCaseToKebabCase(config.GroupVersionKind.Kind) + "/" + config.Name
 	return &core.Metadata{

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -42,6 +42,7 @@ import (
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/util/strcase"
 	"istio.io/pkg/log"
@@ -387,7 +388,7 @@ func cloneLocalityLbEndpoints(endpoints []*endpoint.LocalityLbEndpoints) []*endp
 
 // BuildConfigInfoMetadata builds core.Metadata struct containing the
 // name.namespace of the config, the type, etc.
-func BuildConfigInfoMetadata(config model.ConfigMeta) *core.Metadata {
+func BuildConfigInfoMetadata(config config.ConfigMeta) *core.Metadata {
 	s := "/apis/" + config.GroupVersionKind.Group + "/" + config.GroupVersionKind.Version + "/namespaces/" + config.Namespace + "/" +
 		strcase.CamelCaseToKebabCase(config.GroupVersionKind.Kind) + "/" + config.Name
 	return &core.Metadata{

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -36,6 +36,7 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
 	proto2 "istio.io/istio/pkg/proto"
 )
@@ -348,12 +349,12 @@ func TestIsLocalityEmpty(t *testing.T) {
 func TestBuildConfigInfoMetadata(t *testing.T) {
 	cases := []struct {
 		name string
-		in   model.ConfigMeta
+		in   config.ConfigMeta
 		want *core.Metadata
 	}{
 		{
 			"destination-rule",
-			model.ConfigMeta{
+			config.ConfigMeta{
 				Name:             "svcA",
 				Namespace:        "default",
 				Domain:           "svc.cluster.local",

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -349,12 +349,12 @@ func TestIsLocalityEmpty(t *testing.T) {
 func TestBuildConfigInfoMetadata(t *testing.T) {
 	cases := []struct {
 		name string
-		in   config.ConfigMeta
+		in   config.Meta
 		want *core.Metadata
 	}{
 		{
 			"destination-rule",
-			config.ConfigMeta{
+			config.Meta{
 				Name:             "svcA",
 				Namespace:        "default",
 				Domain:           "svc.cluster.local",

--- a/pilot/pkg/security/authn/v1beta1/policy_applier.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier.go
@@ -33,6 +33,7 @@ import (
 	"istio.io/istio/pilot/pkg/security/authn"
 	authn_utils "istio.io/istio/pilot/pkg/security/authn/utils"
 	authn_model "istio.io/istio/pilot/pkg/security/model"
+	"istio.io/istio/pkg/config"
 	authn_alpha "istio.io/istio/pkg/envoy/config/authentication/v1alpha1"
 	authn_filter "istio.io/istio/pkg/envoy/config/filter/http/authn/v2alpha1"
 	"istio.io/pkg/log"
@@ -44,9 +45,9 @@ var (
 
 // Implemenation of authn.PolicyApplier with v1beta1 API.
 type v1beta1PolicyApplier struct {
-	jwtPolicies []*model.Config
+	jwtPolicies []*config.Config
 
-	peerPolices []*model.Config
+	peerPolices []*config.Config
 
 	// processedJwtRules is the consolidate JWT rules from all jwtPolicies.
 	processedJwtRules []*v1beta1.JWTRule
@@ -189,8 +190,8 @@ func (a *v1beta1PolicyApplier) InboundFilterChain(endpointPort uint32, sdsUdsPat
 
 // NewPolicyApplier returns new applier for v1beta1 authentication policies.
 func NewPolicyApplier(rootNamespace string,
-	jwtPolicies []*model.Config,
-	peerPolicies []*model.Config) authn.PolicyApplier {
+	jwtPolicies []*config.Config,
+	peerPolicies []*config.Config) authn.PolicyApplier {
 	processedJwtRules := []*v1beta1.JWTRule{}
 
 	// TODO(diemtvu) should we need to deduplicate JWT with the same issuer.
@@ -397,8 +398,8 @@ func getMutualTLSMode(mtls *v1beta1.PeerAuthentication_MutualTLS) model.MutualTL
 // - UNSET will be replaced with the setting from the parrent. I.e UNSET port-level config will be
 // replaced with config from workload-level, UNSET in workload-level config will be replaced with
 // one in namespace-level and so on.
-func composePeerAuthentication(rootNamespace string, configs []*model.Config) *v1beta1.PeerAuthentication {
-	var meshCfg, namespaceCfg, workloadCfg *model.Config
+func composePeerAuthentication(rootNamespace string, configs []*config.Config) *v1beta1.PeerAuthentication {
+	var meshCfg, namespaceCfg, workloadCfg *config.Config
 
 	for _, cfg := range configs {
 		spec := cfg.Spec.(*v1beta1.PeerAuthentication)

--- a/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
@@ -1401,7 +1401,7 @@ func TestOnInboundFilterChain(t *testing.T) {
 			name: "Multiple policies resolved to STRICT",
 			peerPolicies: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:              "now",
 						Namespace:         "my-ns",
 						CreationTimestamp: now,
@@ -1418,7 +1418,7 @@ func TestOnInboundFilterChain(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:              "later",
 						Namespace:         "my-ns",
 						CreationTimestamp: now.Add(time.Second),
@@ -1442,7 +1442,7 @@ func TestOnInboundFilterChain(t *testing.T) {
 			name: "Multiple policies resolved to PERMISSIVE",
 			peerPolicies: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:              "now",
 						Namespace:         "my-ns",
 						CreationTimestamp: now,
@@ -1459,7 +1459,7 @@ func TestOnInboundFilterChain(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:              "earlier",
 						Namespace:         "my-ns",
 						CreationTimestamp: now.Add(time.Second * -1),
@@ -1565,7 +1565,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 			name: "mesh only",
 			configs: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:      "default",
 						Namespace: "root-namespace",
 					},
@@ -1586,7 +1586,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 			name: "mesh vs namespace",
 			configs: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:      "default",
 						Namespace: "root-namespace",
 					},
@@ -1600,7 +1600,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:      "default",
 						Namespace: "my-ns",
 					},
@@ -1621,7 +1621,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 			name: "ignore non-empty selector in root namespace",
 			configs: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:      "default",
 						Namespace: "root-namespace",
 					},
@@ -1643,14 +1643,14 @@ func TestComposePeerAuthentication(t *testing.T) {
 			name: "workload vs namespace config",
 			configs: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:      "default",
 						Namespace: "my-ns",
 					},
 					Spec: &v1beta1.PeerAuthentication{},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:      "foo",
 						Namespace: "my-ns",
 					},
@@ -1673,7 +1673,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 			name: "workload vs mesh config",
 			configs: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:      "default",
 						Namespace: "my-ns",
 					},
@@ -1684,7 +1684,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:      "default",
 						Namespace: "root-namespace",
 					},
@@ -1705,7 +1705,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 			name: "multiple mesh policy",
 			configs: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:              "now",
 						Namespace:         "root-namespace",
 						CreationTimestamp: now,
@@ -1717,7 +1717,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:              "second ago",
 						Namespace:         "root-namespace",
 						CreationTimestamp: now.Add(time.Second * -1),
@@ -1729,7 +1729,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:              "second later",
 						Namespace:         "root-namespace",
 						CreationTimestamp: now.Add(time.Second * -1),
@@ -1751,7 +1751,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 			name: "multiple namespace policy",
 			configs: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:              "now",
 						Namespace:         "my-ns",
 						CreationTimestamp: now,
@@ -1763,7 +1763,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:              "second ago",
 						Namespace:         "my-ns",
 						CreationTimestamp: now.Add(time.Second * -1),
@@ -1775,7 +1775,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:              "second later",
 						Namespace:         "my-ns",
 						CreationTimestamp: now.Add(time.Second * -1),
@@ -1797,7 +1797,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 			name: "multiple workload policy",
 			configs: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:              "now",
 						Namespace:         "my-ns",
 						CreationTimestamp: now,
@@ -1814,7 +1814,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:              "second ago",
 						Namespace:         "my-ns",
 						CreationTimestamp: now.Add(time.Second * -1),
@@ -1831,7 +1831,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:              "second later",
 						Namespace:         "my-ns",
 						CreationTimestamp: now.Add(time.Second * -1),
@@ -1858,7 +1858,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 			name: "inheritance: default mesh",
 			configs: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:      "default",
 						Namespace: "root-namespace",
 					},
@@ -1879,7 +1879,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 			name: "inheritance: mesh to workload",
 			configs: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:      "default",
 						Namespace: "root-namespace",
 					},
@@ -1890,7 +1890,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:      "foo",
 						Namespace: "my-ns",
 					},
@@ -1913,7 +1913,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 			name: "inheritance: namespace to workload",
 			configs: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:      "default",
 						Namespace: "my-ns",
 					},
@@ -1924,7 +1924,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:      "foo",
 						Namespace: "my-ns",
 					},
@@ -1947,7 +1947,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 			name: "inheritance: mesh to namespace to workload",
 			configs: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:      "default",
 						Namespace: "root-namespace",
 					},
@@ -1958,7 +1958,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:      "default",
 						Namespace: "my-ns",
 					},
@@ -1969,7 +1969,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:      "foo",
 						Namespace: "my-ns",
 					},
@@ -1992,7 +1992,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 			name: "port level",
 			configs: []*config.Config{
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:      "default",
 						Namespace: "root-namespace",
 					},
@@ -2003,7 +2003,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: config.ConfigMeta{
+					Meta: config.Meta{
 						Name:      "foo",
 						Namespace: "my-ns",
 					},

--- a/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
+++ b/pilot/pkg/security/authn/v1beta1/policy_applier_test.go
@@ -36,6 +36,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking"
 	pilotutil "istio.io/istio/pilot/pkg/networking/util"
 	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
+	"istio.io/istio/pkg/config"
 	authn_alpha "istio.io/istio/pkg/envoy/config/authentication/v1alpha1"
 	authn_filter "istio.io/istio/pkg/envoy/config/filter/http/authn/v2alpha1"
 	protovalue "istio.io/istio/pkg/proto"
@@ -51,17 +52,17 @@ func TestJwtFilter(t *testing.T) {
 
 	cases := []struct {
 		name     string
-		in       []*model.Config
+		in       []*config.Config
 		expected *http_conn.HttpFilter
 	}{
 		{
 			name:     "No policy",
-			in:       []*model.Config{},
+			in:       []*config.Config{},
 			expected: nil,
 		},
 		{
 			name: "Empty policy",
-			in: []*model.Config{
+			in: []*config.Config{
 				{
 					Spec: &v1beta1.RequestAuthentication{},
 				},
@@ -70,7 +71,7 @@ func TestJwtFilter(t *testing.T) {
 		},
 		{
 			name: "Single JWT policy",
-			in: []*model.Config{
+			in: []*config.Config{
 				{
 					Spec: &v1beta1.RequestAuthentication{
 						JwtRules: []*v1beta1.JWTRule{
@@ -134,7 +135,7 @@ func TestJwtFilter(t *testing.T) {
 		},
 		{
 			name: "Multi JWTs policy",
-			in: []*model.Config{
+			in: []*config.Config{
 				{
 					Spec: &v1beta1.RequestAuthentication{
 						JwtRules: []*v1beta1.JWTRule{
@@ -267,7 +268,7 @@ func TestJwtFilter(t *testing.T) {
 		},
 		{
 			name: "JWT policy with inline Jwks",
-			in: []*model.Config{
+			in: []*config.Config{
 				{
 					Spec: &v1beta1.RequestAuthentication{
 						JwtRules: []*v1beta1.JWTRule{
@@ -331,7 +332,7 @@ func TestJwtFilter(t *testing.T) {
 		},
 		{
 			name: "JWT policy with bad Jwks URI",
-			in: []*model.Config{
+			in: []*config.Config{
 				{
 					Spec: &v1beta1.RequestAuthentication{
 						JwtRules: []*v1beta1.JWTRule{
@@ -395,7 +396,7 @@ func TestJwtFilter(t *testing.T) {
 		},
 		{
 			name: "Forward original token",
-			in: []*model.Config{
+			in: []*config.Config{
 				{
 					Spec: &v1beta1.RequestAuthentication{
 						JwtRules: []*v1beta1.JWTRule{
@@ -460,7 +461,7 @@ func TestJwtFilter(t *testing.T) {
 		},
 		{
 			name: "Output payload",
-			in: []*model.Config{
+			in: []*config.Config{
 				{
 					Spec: &v1beta1.RequestAuthentication{
 						JwtRules: []*v1beta1.JWTRule{
@@ -852,8 +853,8 @@ func TestAuthnFilterConfig(t *testing.T) {
 		name                         string
 		isGateway                    bool
 		gatewayServerUsesIstioMutual bool
-		jwtIn                        []*model.Config
-		peerIn                       []*model.Config
+		jwtIn                        []*config.Config
+		peerIn                       []*config.Config
 		expected                     *http_conn.HttpFilter
 	}{
 		{
@@ -931,7 +932,7 @@ func TestAuthnFilterConfig(t *testing.T) {
 		},
 		{
 			name: "beta-jwt",
-			jwtIn: []*model.Config{
+			jwtIn: []*config.Config{
 				{
 					Spec: &v1beta1.RequestAuthentication{
 						JwtRules: []*v1beta1.JWTRule{
@@ -975,7 +976,7 @@ func TestAuthnFilterConfig(t *testing.T) {
 		{
 			name:      "beta-jwt-for-gateway",
 			isGateway: true,
-			jwtIn: []*model.Config{
+			jwtIn: []*config.Config{
 				{
 					Spec: &v1beta1.RequestAuthentication{
 						JwtRules: []*v1beta1.JWTRule{
@@ -1011,7 +1012,7 @@ func TestAuthnFilterConfig(t *testing.T) {
 			name:                         "beta-jwt-for-gateway-with-istio-mutual",
 			isGateway:                    true,
 			gatewayServerUsesIstioMutual: true,
-			jwtIn: []*model.Config{
+			jwtIn: []*config.Config{
 				{
 					Spec: &v1beta1.RequestAuthentication{
 						JwtRules: []*v1beta1.JWTRule{
@@ -1054,7 +1055,7 @@ func TestAuthnFilterConfig(t *testing.T) {
 		},
 		{
 			name: "multi-beta-jwt",
-			jwtIn: []*model.Config{
+			jwtIn: []*config.Config{
 				{
 					Spec: &v1beta1.RequestAuthentication{
 						JwtRules: []*v1beta1.JWTRule{
@@ -1115,7 +1116,7 @@ func TestAuthnFilterConfig(t *testing.T) {
 		},
 		{
 			name: "multi-beta-jwt-sort-by-issuer-again",
-			jwtIn: []*model.Config{
+			jwtIn: []*config.Config{
 				{
 					Spec: &v1beta1.RequestAuthentication{
 						JwtRules: []*v1beta1.JWTRule{
@@ -1176,7 +1177,7 @@ func TestAuthnFilterConfig(t *testing.T) {
 		},
 		{
 			name: "beta-mtls",
-			peerIn: []*model.Config{
+			peerIn: []*config.Config{
 				{
 					Spec: &v1beta1.PeerAuthentication{
 						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
@@ -1208,7 +1209,7 @@ func TestAuthnFilterConfig(t *testing.T) {
 		{
 			name:      "beta-mtls-for-gateway-does-not-respect-mtls-configs",
 			isGateway: true,
-			peerIn: []*model.Config{
+			peerIn: []*config.Config{
 				{
 					Spec: &v1beta1.PeerAuthentication{
 						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
@@ -1221,7 +1222,7 @@ func TestAuthnFilterConfig(t *testing.T) {
 		},
 		{
 			name: "beta-mtls-skip-trust-domain",
-			peerIn: []*model.Config{
+			peerIn: []*config.Config{
 				{
 					Spec: &v1beta1.PeerAuthentication{
 						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
@@ -1345,7 +1346,7 @@ func TestOnInboundFilterChain(t *testing.T) {
 
 	cases := []struct {
 		name         string
-		peerPolicies []*model.Config
+		peerPolicies []*config.Config
 		sdsUdsPath   string
 		expected     []networking.FilterChain
 	}{
@@ -1356,7 +1357,7 @@ func TestOnInboundFilterChain(t *testing.T) {
 		},
 		{
 			name: "Single policy - disable mode",
-			peerPolicies: []*model.Config{
+			peerPolicies: []*config.Config{
 				{
 					Spec: &v1beta1.PeerAuthentication{
 						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
@@ -1370,7 +1371,7 @@ func TestOnInboundFilterChain(t *testing.T) {
 		},
 		{
 			name: "Single policy - permissive mode",
-			peerPolicies: []*model.Config{
+			peerPolicies: []*config.Config{
 				{
 					Spec: &v1beta1.PeerAuthentication{
 						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
@@ -1384,7 +1385,7 @@ func TestOnInboundFilterChain(t *testing.T) {
 		},
 		{
 			name: "Single policy - strict mode",
-			peerPolicies: []*model.Config{
+			peerPolicies: []*config.Config{
 				{
 					Spec: &v1beta1.PeerAuthentication{
 						Mtls: &v1beta1.PeerAuthentication_MutualTLS{
@@ -1398,9 +1399,9 @@ func TestOnInboundFilterChain(t *testing.T) {
 		},
 		{
 			name: "Multiple policies resolved to STRICT",
-			peerPolicies: []*model.Config{
+			peerPolicies: []*config.Config{
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:              "now",
 						Namespace:         "my-ns",
 						CreationTimestamp: now,
@@ -1417,7 +1418,7 @@ func TestOnInboundFilterChain(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:              "later",
 						Namespace:         "my-ns",
 						CreationTimestamp: now.Add(time.Second),
@@ -1439,9 +1440,9 @@ func TestOnInboundFilterChain(t *testing.T) {
 		},
 		{
 			name: "Multiple policies resolved to PERMISSIVE",
-			peerPolicies: []*model.Config{
+			peerPolicies: []*config.Config{
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:              "now",
 						Namespace:         "my-ns",
 						CreationTimestamp: now,
@@ -1458,7 +1459,7 @@ func TestOnInboundFilterChain(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:              "earlier",
 						Namespace:         "my-ns",
 						CreationTimestamp: now.Add(time.Second * -1),
@@ -1480,7 +1481,7 @@ func TestOnInboundFilterChain(t *testing.T) {
 		},
 		{
 			name: "Port level hit",
-			peerPolicies: []*model.Config{
+			peerPolicies: []*config.Config{
 				{
 					Spec: &v1beta1.PeerAuthentication{
 						Selector: &type_beta.WorkloadSelector{
@@ -1504,7 +1505,7 @@ func TestOnInboundFilterChain(t *testing.T) {
 		},
 		{
 			name: "Port level miss",
-			peerPolicies: []*model.Config{
+			peerPolicies: []*config.Config{
 				{
 					Spec: &v1beta1.PeerAuthentication{
 						Selector: &type_beta.WorkloadSelector{
@@ -1552,19 +1553,19 @@ func TestComposePeerAuthentication(t *testing.T) {
 	now := time.Now()
 	tests := []struct {
 		name    string
-		configs []*model.Config
+		configs []*config.Config
 		want    *v1beta1.PeerAuthentication
 	}{
 		{
 			name:    "no config",
-			configs: []*model.Config{},
+			configs: []*config.Config{},
 			want:    nil,
 		},
 		{
 			name: "mesh only",
-			configs: []*model.Config{
+			configs: []*config.Config{
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:      "default",
 						Namespace: "root-namespace",
 					},
@@ -1583,9 +1584,9 @@ func TestComposePeerAuthentication(t *testing.T) {
 		},
 		{
 			name: "mesh vs namespace",
-			configs: []*model.Config{
+			configs: []*config.Config{
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:      "default",
 						Namespace: "root-namespace",
 					},
@@ -1599,7 +1600,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:      "default",
 						Namespace: "my-ns",
 					},
@@ -1618,9 +1619,9 @@ func TestComposePeerAuthentication(t *testing.T) {
 		},
 		{
 			name: "ignore non-empty selector in root namespace",
-			configs: []*model.Config{
+			configs: []*config.Config{
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:      "default",
 						Namespace: "root-namespace",
 					},
@@ -1640,16 +1641,16 @@ func TestComposePeerAuthentication(t *testing.T) {
 		},
 		{
 			name: "workload vs namespace config",
-			configs: []*model.Config{
+			configs: []*config.Config{
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:      "default",
 						Namespace: "my-ns",
 					},
 					Spec: &v1beta1.PeerAuthentication{},
 				},
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:      "foo",
 						Namespace: "my-ns",
 					},
@@ -1670,9 +1671,9 @@ func TestComposePeerAuthentication(t *testing.T) {
 		},
 		{
 			name: "workload vs mesh config",
-			configs: []*model.Config{
+			configs: []*config.Config{
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:      "default",
 						Namespace: "my-ns",
 					},
@@ -1683,7 +1684,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:      "default",
 						Namespace: "root-namespace",
 					},
@@ -1702,9 +1703,9 @@ func TestComposePeerAuthentication(t *testing.T) {
 		},
 		{
 			name: "multiple mesh policy",
-			configs: []*model.Config{
+			configs: []*config.Config{
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:              "now",
 						Namespace:         "root-namespace",
 						CreationTimestamp: now,
@@ -1716,7 +1717,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:              "second ago",
 						Namespace:         "root-namespace",
 						CreationTimestamp: now.Add(time.Second * -1),
@@ -1728,7 +1729,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:              "second later",
 						Namespace:         "root-namespace",
 						CreationTimestamp: now.Add(time.Second * -1),
@@ -1748,9 +1749,9 @@ func TestComposePeerAuthentication(t *testing.T) {
 		},
 		{
 			name: "multiple namespace policy",
-			configs: []*model.Config{
+			configs: []*config.Config{
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:              "now",
 						Namespace:         "my-ns",
 						CreationTimestamp: now,
@@ -1762,7 +1763,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:              "second ago",
 						Namespace:         "my-ns",
 						CreationTimestamp: now.Add(time.Second * -1),
@@ -1774,7 +1775,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:              "second later",
 						Namespace:         "my-ns",
 						CreationTimestamp: now.Add(time.Second * -1),
@@ -1794,9 +1795,9 @@ func TestComposePeerAuthentication(t *testing.T) {
 		},
 		{
 			name: "multiple workload policy",
-			configs: []*model.Config{
+			configs: []*config.Config{
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:              "now",
 						Namespace:         "my-ns",
 						CreationTimestamp: now,
@@ -1813,7 +1814,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:              "second ago",
 						Namespace:         "my-ns",
 						CreationTimestamp: now.Add(time.Second * -1),
@@ -1830,7 +1831,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:              "second later",
 						Namespace:         "my-ns",
 						CreationTimestamp: now.Add(time.Second * -1),
@@ -1855,9 +1856,9 @@ func TestComposePeerAuthentication(t *testing.T) {
 		},
 		{
 			name: "inheritance: default mesh",
-			configs: []*model.Config{
+			configs: []*config.Config{
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:      "default",
 						Namespace: "root-namespace",
 					},
@@ -1876,9 +1877,9 @@ func TestComposePeerAuthentication(t *testing.T) {
 		},
 		{
 			name: "inheritance: mesh to workload",
-			configs: []*model.Config{
+			configs: []*config.Config{
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:      "default",
 						Namespace: "root-namespace",
 					},
@@ -1889,7 +1890,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:      "foo",
 						Namespace: "my-ns",
 					},
@@ -1910,9 +1911,9 @@ func TestComposePeerAuthentication(t *testing.T) {
 		},
 		{
 			name: "inheritance: namespace to workload",
-			configs: []*model.Config{
+			configs: []*config.Config{
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:      "default",
 						Namespace: "my-ns",
 					},
@@ -1923,7 +1924,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:      "foo",
 						Namespace: "my-ns",
 					},
@@ -1944,9 +1945,9 @@ func TestComposePeerAuthentication(t *testing.T) {
 		},
 		{
 			name: "inheritance: mesh to namespace to workload",
-			configs: []*model.Config{
+			configs: []*config.Config{
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:      "default",
 						Namespace: "root-namespace",
 					},
@@ -1957,7 +1958,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:      "default",
 						Namespace: "my-ns",
 					},
@@ -1968,7 +1969,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:      "foo",
 						Namespace: "my-ns",
 					},
@@ -1989,9 +1990,9 @@ func TestComposePeerAuthentication(t *testing.T) {
 		},
 		{
 			name: "port level",
-			configs: []*model.Config{
+			configs: []*config.Config{
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:      "default",
 						Namespace: "root-namespace",
 					},
@@ -2002,7 +2003,7 @@ func TestComposePeerAuthentication(t *testing.T) {
 					},
 				},
 				{
-					ConfigMeta: model.ConfigMeta{
+					ConfigMeta: config.ConfigMeta{
 						Name:      "foo",
 						Namespace: "my-ns",
 					},

--- a/pilot/pkg/security/authz/builder/builder_test.go
+++ b/pilot/pkg/security/authz/builder/builder_test.go
@@ -27,6 +27,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/security/trustdomain"
 	"istio.io/istio/pilot/test/util"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/util/protomarshal"
@@ -211,7 +212,7 @@ func yamlPolicy(t *testing.T, filename string) *model.AuthorizationPolicies {
 	if err != nil {
 		t.Fatalf("failde to parse CRD: %v", err)
 	}
-	var configs []*model.Config
+	var configs []*config.Config
 	for i := range c {
 		configs = append(configs, &c[i])
 	}
@@ -255,7 +256,7 @@ func convertTCP(in []*tcppb.Filter) []proto.Message {
 	return ret
 }
 
-func newAuthzPolicies(t *testing.T, policies []*model.Config) *model.AuthorizationPolicies {
+func newAuthzPolicies(t *testing.T, policies []*config.Config) *model.AuthorizationPolicies {
 	store := model.MakeIstioStore(memory.Make(collections.Pilot))
 	for _, p := range policies {
 		if _, err := store.Create(*p); err != nil {

--- a/pilot/pkg/serviceregistry/mcp/controller.go
+++ b/pilot/pkg/serviceregistry/mcp/controller.go
@@ -169,7 +169,7 @@ func (c *controller) Apply(change *sink.Change) error {
 			Spec: obj.Body,
 		}
 
-		if err := s.Resource().ValidateProto(conf.Name, conf.Namespace, conf.Spec); err != nil {
+		if err := s.Resource().ValidateConfig(conf.Name, conf.Namespace, conf.Spec); err != nil {
 			// Do not return an error, instead discard the resources so that Pilot can process the rest.
 			log.Warnf("Discarding incoming MCP resource: validation failed (%s/%s): %v", conf.Namespace, conf.Name, err)
 			continue

--- a/pilot/pkg/serviceregistry/mcp/controller.go
+++ b/pilot/pkg/serviceregistry/mcp/controller.go
@@ -156,7 +156,7 @@ func (c *controller) Apply(change *sink.Change) error {
 			}] = struct{}{}
 		}
 		conf := &config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind:  kind,
 				Name:              name,
 				Namespace:         namespace,

--- a/pilot/pkg/serviceregistry/mcp/controller.go
+++ b/pilot/pkg/serviceregistry/mcp/controller.go
@@ -26,10 +26,10 @@ import (
 	"istio.io/api/label"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
-	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/istio/pkg/mcp/sink"
 	"istio.io/pkg/ledger"
 	"istio.io/pkg/log"
@@ -61,9 +61,9 @@ type Options struct {
 type controller struct {
 	configStoreMu sync.RWMutex
 	// keys [type][namespace][name]
-	configStore   map[resource.GroupVersionKind]map[string]map[string]*model.Config
+	configStore   map[config.GroupVersionKind]map[string]map[string]*config.Config
 	options       *Options
-	eventHandlers map[resource.GroupVersionKind][]func(model.Config, model.Config, model.Event)
+	eventHandlers map[config.GroupVersionKind][]func(config.Config, config.Config, model.Event)
 	ledger        ledger.Ledger
 
 	syncedMu sync.Mutex
@@ -79,9 +79,9 @@ func NewController(options *Options) Controller {
 	}
 
 	return &controller{
-		configStore:   make(map[resource.GroupVersionKind]map[string]map[string]*model.Config),
+		configStore:   make(map[config.GroupVersionKind]map[string]map[string]*config.Config),
 		options:       options,
-		eventHandlers: make(map[resource.GroupVersionKind][]func(model.Config, model.Config, model.Event)),
+		eventHandlers: make(map[config.GroupVersionKind][]func(config.Config, config.Config, model.Event)),
 		synced:        synced,
 		ledger:        options.ConfigLedger,
 	}
@@ -93,7 +93,7 @@ func (c *controller) Schemas() collection.Schemas {
 
 // List returns all the config that is stored by type and namespace
 // if namespace is empty string it returns config for all the namespaces
-func (c *controller) List(typ resource.GroupVersionKind, namespace string) (out []model.Config, err error) {
+func (c *controller) List(typ config.GroupVersionKind, namespace string) (out []config.Config, err error) {
 	_, ok := collections.Pilot.FindByGroupVersionKind(typ)
 	if !ok {
 		return nil, fmt.Errorf("list unknown type %s", typ)
@@ -134,7 +134,7 @@ func (c *controller) Apply(change *sink.Change) error {
 	configUpdated := map[model.ConfigKey]struct{}{} // If non-incremental, we use empty configUpdated to indicate all.
 
 	// innerStore is [namespace][name]
-	innerStore := make(map[string]map[string]*model.Config)
+	innerStore := make(map[string]map[string]*config.Config)
 	for _, obj := range change.Objects {
 		namespace, name := extractNameNamespace(obj.Metadata.Name)
 
@@ -155,8 +155,8 @@ func (c *controller) Apply(change *sink.Change) error {
 				Namespace: namespace,
 			}] = struct{}{}
 		}
-		conf := &model.Config{
-			ConfigMeta: model.ConfigMeta{
+		conf := &config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind:  kind,
 				Name:              name,
 				Namespace:         namespace,
@@ -181,7 +181,7 @@ func (c *controller) Apply(change *sink.Change) error {
 			if ok {
 				namedConfig[conf.Name] = conf
 			} else {
-				innerStore[conf.Namespace] = map[string]*model.Config{
+				innerStore[conf.Namespace] = map[string]*config.Config{
 					conf.Name: conf,
 				}
 			}
@@ -205,7 +205,7 @@ func (c *controller) Apply(change *sink.Change) error {
 		}
 	}
 
-	var prevStore map[string]map[string]*model.Config
+	var prevStore map[string]map[string]*config.Config
 
 	c.configStoreMu.Lock()
 	prevStore = c.configStore[kind]
@@ -213,9 +213,9 @@ func (c *controller) Apply(change *sink.Change) error {
 	if change.Incremental {
 
 		//Although it is not a deep copy, there is no problem because the config will not be modified
-		prevCache := make(map[string]map[string]*model.Config, len(prevStore))
+		prevCache := make(map[string]map[string]*config.Config, len(prevStore))
 		for namespace, namedConfig := range prevStore {
-			prevCache[namespace] = make(map[string]*model.Config, len(namedConfig))
+			prevCache[namespace] = make(map[string]*config.Config, len(namedConfig))
 			for name, config := range namedConfig {
 				prevCache[namespace][name] = config
 			}
@@ -243,7 +243,7 @@ func (c *controller) Apply(change *sink.Change) error {
 	return nil
 }
 
-func (c *controller) objectInRevision(o *model.Config) bool {
+func (c *controller) objectInRevision(o *config.Config) bool {
 	configEnv, f := o.Labels[label.IstioRev]
 	if !f {
 		// This is a global object, and always included
@@ -274,7 +274,7 @@ func (c *controller) HasSynced() bool {
 }
 
 // RegisterEventHandler registers a handler using the type as a key
-func (c *controller) RegisterEventHandler(kind resource.GroupVersionKind, handler func(model.Config, model.Config, model.Event)) {
+func (c *controller) RegisterEventHandler(kind config.GroupVersionKind, handler func(config.Config, config.Config, model.Event)) {
 	c.eventHandlers[kind] = append(c.eventHandlers[kind], handler)
 }
 
@@ -301,25 +301,25 @@ func (c *controller) Run(<-chan struct{}) {
 }
 
 // Get is not implemented
-func (c *controller) Get(_ resource.GroupVersionKind, _, _ string) *model.Config {
+func (c *controller) Get(_ config.GroupVersionKind, _, _ string) *config.Config {
 	log.Warnf("get %s", errUnsupported)
 	return nil
 }
 
 // Update is not implemented
-func (c *controller) Update(model.Config) (newRevision string, err error) {
+func (c *controller) Update(config.Config) (newRevision string, err error) {
 	log.Warnf("update %s", errUnsupported)
 	return "", errUnsupported
 }
 
 // Create is not implemented
-func (c *controller) Create(model.Config) (revision string, err error) {
+func (c *controller) Create(config.Config) (revision string, err error) {
 	log.Warnf("create %s", errUnsupported)
 	return "", errUnsupported
 }
 
 // Delete is not implemented
-func (c *controller) Delete(_ resource.GroupVersionKind, _, _ string) error {
+func (c *controller) Delete(_ config.GroupVersionKind, _, _ string) error {
 	return errUnsupported
 }
 
@@ -329,10 +329,10 @@ func (c *controller) sync(collection string) {
 	c.syncedMu.Unlock()
 }
 
-func (c *controller) serviceEntryEvents(currentStore, prevStore map[string]map[string]*model.Config) {
-	dispatch := func(prev model.Config, model model.Config, event model.Event) {}
+func (c *controller) serviceEntryEvents(currentStore, prevStore map[string]map[string]*config.Config) {
+	dispatch := func(prev config.Config, model config.Config, event model.Event) {}
 	if handlers, ok := c.eventHandlers[gvk.ServiceEntry]; ok {
-		dispatch = func(prev model.Config, config model.Config, event model.Event) {
+		dispatch = func(prev config.Config, config config.Config, event model.Event) {
 			log.Debugf("MCP event dispatch: key=%v event=%v", config.Key(), event.String())
 			for _, handler := range handlers {
 				handler(prev, config, event)
@@ -349,10 +349,10 @@ func (c *controller) serviceEntryEvents(currentStore, prevStore map[string]map[s
 						dispatch(*prevConfig, *config, model.EventUpdate)
 					}
 				} else {
-					dispatch(model.Config{}, *config, model.EventAdd)
+					dispatch(config.Config{}, *config, model.EventAdd)
 				}
 			} else {
-				dispatch(model.Config{}, *config, model.EventAdd)
+				dispatch(config.Config{}, *config, model.EventAdd)
 			}
 		}
 	}
@@ -361,7 +361,7 @@ func (c *controller) serviceEntryEvents(currentStore, prevStore map[string]map[s
 	for namespace, prevByName := range prevStore {
 		for name, prevConfig := range prevByName {
 			if _, ok := currentStore[namespace][name]; !ok {
-				dispatch(model.Config{}, *prevConfig, model.EventDelete)
+				dispatch(config.Config{}, *prevConfig, model.EventDelete)
 			}
 		}
 	}
@@ -375,7 +375,7 @@ func extractNameNamespace(metadataName string) (string, string) {
 	return "", segments[0]
 }
 
-func (c *controller) removeConfig(kind resource.GroupVersionKind, resources []string) {
+func (c *controller) removeConfig(kind config.GroupVersionKind, resources []string) {
 	for _, fullName := range resources {
 		namespace, name := extractNameNamespace(fullName)
 		if byType, ok := c.configStore[kind]; ok {
@@ -396,7 +396,7 @@ func (c *controller) removeConfig(kind resource.GroupVersionKind, resources []st
 	}
 }
 
-func (c *controller) incrementalUpdate(kind resource.GroupVersionKind, conf map[string]map[string]*model.Config) {
+func (c *controller) incrementalUpdate(kind config.GroupVersionKind, conf map[string]map[string]*config.Config) {
 	if len(conf) == 0 {
 		return
 	}

--- a/pilot/pkg/serviceregistry/mcp/controller.go
+++ b/pilot/pkg/serviceregistry/mcp/controller.go
@@ -169,7 +169,7 @@ func (c *controller) Apply(change *sink.Change) error {
 			Spec: obj.Body,
 		}
 
-		if err := s.Resource().ValidateConfig(conf.Name, conf.Namespace, conf.Spec); err != nil {
+		if err := s.Resource().ValidateConfig(*conf); err != nil {
 			// Do not return an error, instead discard the resources so that Pilot can process the rest.
 			log.Warnf("Discarding incoming MCP resource: validation failed (%s/%s): %v", conf.Namespace, conf.Name, err)
 			continue
@@ -342,17 +342,17 @@ func (c *controller) serviceEntryEvents(currentStore, prevStore map[string]map[s
 
 	// add/update
 	for namespace, byName := range currentStore {
-		for name, config := range byName {
+		for name, cfg := range byName {
 			if prevByNamespace, ok := prevStore[namespace]; ok {
 				if prevConfig, ok := prevByNamespace[name]; ok {
-					if config.ResourceVersion != prevConfig.ResourceVersion {
-						dispatch(*prevConfig, *config, model.EventUpdate)
+					if cfg.ResourceVersion != prevConfig.ResourceVersion {
+						dispatch(*prevConfig, *cfg, model.EventUpdate)
 					}
 				} else {
-					dispatch(config.Config{}, *config, model.EventAdd)
+					dispatch(config.Config{}, *cfg, model.EventAdd)
 				}
 			} else {
-				dispatch(config.Config{}, *config, model.EventAdd)
+				dispatch(config.Config{}, *cfg, model.EventAdd)
 			}
 		}
 	}

--- a/pilot/pkg/serviceregistry/mcp/controller_test.go
+++ b/pilot/pkg/serviceregistry/mcp/controller_test.go
@@ -495,7 +495,7 @@ func TestEventHandler(t *testing.T) {
 
 	makeServiceEntryModel := func(name, host, version string) config.Config {
 		return config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind:  gvk.ServiceEntry,
 				Name:              name,
 				Namespace:         "default",

--- a/pilot/pkg/serviceregistry/mcp/controller_test.go
+++ b/pilot/pkg/serviceregistry/mcp/controller_test.go
@@ -28,9 +28,9 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/mcp"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
-	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/istio/pkg/mcp/sink"
 )
 
@@ -144,7 +144,7 @@ func TestListInvalidType(t *testing.T) {
 	g := NewWithT(t)
 	controller := mcp.NewController(testControllerOptions)
 
-	c, err := controller.List(resource.GroupVersionKind{Kind: "bad-type"}, "some-phony-name-space.com")
+	c, err := controller.List(config.GroupVersionKind{Kind: "bad-type"}, "some-phony-name-space.com")
 	g.Expect(c).To(BeNil())
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("list unknown type"))
@@ -459,12 +459,12 @@ func TestEventHandler(t *testing.T) {
 		return namespace + "/" + name
 	}
 
-	gotEvents := map[model.Event]map[string]model.Config{
+	gotEvents := map[model.Event]map[string]config.Config{
 		model.EventAdd:    {},
 		model.EventUpdate: {},
 		model.EventDelete: {},
 	}
-	controller.RegisterEventHandler(gvk.ServiceEntry, func(_, m model.Config, e model.Event) {
+	controller.RegisterEventHandler(gvk.ServiceEntry, func(_, m config.Config, e model.Event) {
 		gotEvents[e][makeName(m.Namespace, m.Name)] = m
 	})
 
@@ -493,9 +493,9 @@ func TestEventHandler(t *testing.T) {
 		}
 	}
 
-	makeServiceEntryModel := func(name, host, version string) model.Config {
-		return model.Config{
-			ConfigMeta: model.ConfigMeta{
+	makeServiceEntryModel := func(name, host, version string) config.Config {
+		return config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind:  gvk.ServiceEntry,
 				Name:              name,
 				Namespace:         "default",
@@ -513,7 +513,7 @@ func TestEventHandler(t *testing.T) {
 	steps := []struct {
 		name   string
 		change *sink.Change
-		want   map[model.Event]map[string]model.Config
+		want   map[model.Event]map[string]config.Config
 	}{
 		{
 			name: "initial add",
@@ -523,7 +523,7 @@ func TestEventHandler(t *testing.T) {
 					makeServiceEntry("foo", "foo.com", "v0"),
 				},
 			},
-			want: map[model.Event]map[string]model.Config{
+			want: map[model.Event]map[string]config.Config{
 				model.EventAdd: {
 					"default/foo": makeServiceEntryModel("foo", "foo.com", "v0"),
 				},
@@ -537,7 +537,7 @@ func TestEventHandler(t *testing.T) {
 					makeServiceEntry("foo", "foo.com", "v1"),
 				},
 			},
-			want: map[model.Event]map[string]model.Config{
+			want: map[model.Event]map[string]config.Config{
 				model.EventUpdate: {
 					"default/foo": makeServiceEntryModel("foo", "foo.com", "v1"),
 				},
@@ -552,7 +552,7 @@ func TestEventHandler(t *testing.T) {
 					makeServiceEntry("foo1", "foo1.com", "v0"),
 				},
 			},
-			want: map[model.Event]map[string]model.Config{
+			want: map[model.Event]map[string]config.Config{
 				model.EventAdd: {
 					"default/foo1": makeServiceEntryModel("foo1", "foo1.com", "v0"),
 				},
@@ -566,7 +566,7 @@ func TestEventHandler(t *testing.T) {
 					makeServiceEntry("foo1", "foo1.com", "v0"),
 				},
 			},
-			want: map[model.Event]map[string]model.Config{
+			want: map[model.Event]map[string]config.Config{
 				model.EventDelete: {
 					"default/foo": makeServiceEntryModel("foo", "foo.com", "v1"),
 				},
@@ -582,7 +582,7 @@ func TestEventHandler(t *testing.T) {
 					makeServiceEntry("foo3", "foo3.com", "v0"),
 				},
 			},
-			want: map[model.Event]map[string]model.Config{
+			want: map[model.Event]map[string]config.Config{
 				model.EventAdd: {
 					"default/foo2": makeServiceEntryModel("foo2", "foo2.com", "v0"),
 					"default/foo3": makeServiceEntryModel("foo3", "foo3.com", "v0"),
@@ -603,7 +603,7 @@ func TestEventHandler(t *testing.T) {
 					makeServiceEntry("foo5", "foo5.com", "v0"),
 				},
 			},
-			want: map[model.Event]map[string]model.Config{
+			want: map[model.Event]map[string]config.Config{
 				model.EventAdd: {
 					"default/foo4": makeServiceEntryModel("foo4", "foo4.com", "v0"),
 					"default/foo5": makeServiceEntryModel("foo5", "foo5.com", "v0"),
@@ -631,7 +631,7 @@ func TestEventHandler(t *testing.T) {
 				}
 			}
 			// clear saved events after every step
-			gotEvents = map[model.Event]map[string]model.Config{
+			gotEvents = map[model.Event]map[string]config.Config{
 				model.EventAdd:    {},
 				model.EventUpdate: {},
 				model.EventDelete: {},

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -22,6 +22,7 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
@@ -45,7 +46,7 @@ func convertPort(port *networking.Port) *model.Port {
 //
 // See convertServices() for the reverse conversion, used by Istio to handle ServiceEntry configs.
 // See kube.ConvertService for the conversion from K8S to internal Service.
-func ServiceToServiceEntry(svc *model.Service) *model.Config {
+func ServiceToServiceEntry(svc *model.Service) *config.Config {
 	gvk := gvk.ServiceEntry
 	se := &networking.ServiceEntry{
 		// Host is fully qualified: name, namespace, domainSuffix
@@ -109,8 +110,8 @@ func ServiceToServiceEntry(svc *model.Service) *model.Config {
 		})
 	}
 
-	cfg := &model.Config{
-		ConfigMeta: model.ConfigMeta{
+	cfg := &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind:  gvk,
 			Name:              "synthetic-" + svc.Attributes.Name,
 			Namespace:         svc.Attributes.Namespace,
@@ -133,7 +134,7 @@ func ServiceToServiceEntry(svc *model.Service) *model.Config {
 }
 
 // convertServices transforms a ServiceEntry config to a list of internal Service objects.
-func convertServices(cfg model.Config) []*model.Service {
+func convertServices(cfg config.Config) []*model.Service {
 	serviceEntry := cfg.Spec.(*networking.ServiceEntry)
 	creationTime := cfg.CreationTimestamp
 
@@ -289,7 +290,7 @@ func convertWorkloadEntryToServiceInstances(wle *networking.WorkloadEntry, servi
 	return out
 }
 
-func convertServiceEntryToInstances(cfg model.Config, services []*model.Service) []*model.ServiceInstance {
+func convertServiceEntryToInstances(cfg config.Config, services []*model.Service) []*model.ServiceInstance {
 	out := make([]*model.ServiceInstance, 0)
 	serviceEntry := cfg.Spec.(*networking.ServiceEntry)
 	if services == nil {
@@ -367,7 +368,7 @@ func convertWorkloadInstanceToServiceInstance(workloadInstance *model.IstioEndpo
 
 // Convenience function to convert a workloadEntry into a ServiceInstance object encoding the endpoint (without service
 // port names) and the namespace - k8s will consume this service instance when selecting workload entries
-func convertWorkloadEntryToWorkloadInstance(namespace string, cfg model.Config) *model.WorkloadInstance {
+func convertWorkloadEntryToWorkloadInstance(namespace string, cfg config.Config) *model.WorkloadInstance {
 	we := cfg.Spec.(*networking.WorkloadEntry)
 	// we will merge labels from metadata with spec, with precedence to the metadata
 	labels := map[string]string{}

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -111,7 +111,7 @@ func ServiceToServiceEntry(svc *model.Service) *config.Config {
 	}
 
 	cfg := &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind:  gvk,
 			Name:              "synthetic-" + svc.Attributes.Name,
 			Namespace:         svc.Attributes.Namespace,

--- a/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
@@ -35,7 +35,7 @@ import (
 
 var GlobalTime = time.Now()
 var httpNone = &config.Config{
-	ConfigMeta: config.ConfigMeta{
+	Meta: config.Meta{
 		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "httpNone",
 		Namespace:         "httpNone",
@@ -54,7 +54,7 @@ var httpNone = &config.Config{
 }
 
 var tcpNone = &config.Config{
-	ConfigMeta: config.ConfigMeta{
+	Meta: config.Meta{
 		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "tcpNone",
 		Namespace:         "tcpNone",
@@ -72,7 +72,7 @@ var tcpNone = &config.Config{
 }
 
 var httpStatic = &config.Config{
-	ConfigMeta: config.ConfigMeta{
+	Meta: config.Meta{
 		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "httpStatic",
 		Namespace:         "httpStatic",
@@ -108,7 +108,7 @@ var httpStatic = &config.Config{
 
 // Shares the same host as httpStatic, but adds some endpoints. We expect these to be merge
 var httpStaticOverlay = &config.Config{
-	ConfigMeta: config.ConfigMeta{
+	Meta: config.Meta{
 		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "httpStaticOverlay",
 		Namespace:         "httpStatic",
@@ -131,7 +131,7 @@ var httpStaticOverlay = &config.Config{
 }
 
 var httpDNSnoEndpoints = &config.Config{
-	ConfigMeta: config.ConfigMeta{
+	Meta: config.Meta{
 		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "httpDNSnoEndpoints",
 		Namespace:         "httpDNSnoEndpoints",
@@ -150,7 +150,7 @@ var httpDNSnoEndpoints = &config.Config{
 }
 
 var httpDNS = &config.Config{
-	ConfigMeta: config.ConfigMeta{
+	Meta: config.Meta{
 		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "httpDNS",
 		Namespace:         "httpDNS",
@@ -185,7 +185,7 @@ var httpDNS = &config.Config{
 }
 
 var tcpDNS = &config.Config{
-	ConfigMeta: config.ConfigMeta{
+	Meta: config.Meta{
 		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "tcpDNS",
 		Namespace:         "tcpDNS",
@@ -213,7 +213,7 @@ var tcpDNS = &config.Config{
 }
 
 var tcpStatic = &config.Config{
-	ConfigMeta: config.ConfigMeta{
+	Meta: config.Meta{
 		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "tcpStatic",
 		Namespace:         "tcpStatic",
@@ -242,7 +242,7 @@ var tcpStatic = &config.Config{
 }
 
 var httpNoneInternal = &config.Config{
-	ConfigMeta: config.ConfigMeta{
+	Meta: config.Meta{
 		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "httpNoneInternal",
 		Namespace:         "httpNoneInternal",
@@ -261,7 +261,7 @@ var httpNoneInternal = &config.Config{
 }
 
 var tcpNoneInternal = &config.Config{
-	ConfigMeta: config.ConfigMeta{
+	Meta: config.Meta{
 		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "tcpNoneInternal",
 		Namespace:         "tcpNoneInternal",
@@ -280,7 +280,7 @@ var tcpNoneInternal = &config.Config{
 }
 
 var multiAddrInternal = &config.Config{
-	ConfigMeta: config.ConfigMeta{
+	Meta: config.Meta{
 		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "multiAddrInternal",
 		Namespace:         "multiAddrInternal",
@@ -299,7 +299,7 @@ var multiAddrInternal = &config.Config{
 }
 
 var udsLocal = &config.Config{
-	ConfigMeta: config.ConfigMeta{
+	Meta: config.Meta{
 		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "udsLocal",
 		Namespace:         "udsLocal",
@@ -320,7 +320,7 @@ var udsLocal = &config.Config{
 
 // ServiceEntry DNS with a selector
 var selectorDNS = &config.Config{
-	ConfigMeta: config.ConfigMeta{
+	Meta: config.Meta{
 		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "selector",
 		Namespace:         "selector",
@@ -342,7 +342,7 @@ var selectorDNS = &config.Config{
 
 // ServiceEntry with a selector
 var selector = &config.Config{
-	ConfigMeta: config.ConfigMeta{
+	Meta: config.Meta{
 		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "selector",
 		Namespace:         "selector",
@@ -364,7 +364,7 @@ var selector = &config.Config{
 
 // DNS ServiceEntry with a selector
 var dnsSelector = &config.Config{
-	ConfigMeta: config.ConfigMeta{
+	Meta: config.Meta{
 		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "dns-selector",
 		Namespace:         "dns-selector",
@@ -386,7 +386,7 @@ var dnsSelector = &config.Config{
 
 func createWorkloadEntry(name, namespace string, spec *networking.WorkloadEntry) *config.Config {
 	return &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind:  gvk.WorkloadEntry,
 			Name:              name,
 			Namespace:         namespace,
@@ -843,7 +843,7 @@ func TestConvertWorkloadEntryToWorkloadInstance(t *testing.T) {
 			name:      "metadata labels only",
 			namespace: "ns1",
 			wle: config.Config{
-				ConfigMeta: config.ConfigMeta{
+				Meta: config.Meta{
 					Labels: labels,
 				},
 				Spec: &networking.WorkloadEntry{
@@ -870,7 +870,7 @@ func TestConvertWorkloadEntryToWorkloadInstance(t *testing.T) {
 			name:      "labels merge",
 			namespace: "ns1",
 			wle: config.Config{
-				ConfigMeta: config.ConfigMeta{
+				Meta: config.Meta{
 					Labels: map[string]string{
 						"my-label": "bar",
 					},

--- a/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
@@ -25,6 +25,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/test/util"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
@@ -33,8 +34,8 @@ import (
 )
 
 var GlobalTime = time.Now()
-var httpNone = &model.Config{
-	ConfigMeta: model.ConfigMeta{
+var httpNone = &config.Config{
+	ConfigMeta: config.ConfigMeta{
 		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "httpNone",
 		Namespace:         "httpNone",
@@ -52,8 +53,8 @@ var httpNone = &model.Config{
 	},
 }
 
-var tcpNone = &model.Config{
-	ConfigMeta: model.ConfigMeta{
+var tcpNone = &config.Config{
+	ConfigMeta: config.ConfigMeta{
 		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "tcpNone",
 		Namespace:         "tcpNone",
@@ -70,8 +71,8 @@ var tcpNone = &model.Config{
 	},
 }
 
-var httpStatic = &model.Config{
-	ConfigMeta: model.ConfigMeta{
+var httpStatic = &config.Config{
+	ConfigMeta: config.ConfigMeta{
 		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "httpStatic",
 		Namespace:         "httpStatic",
@@ -106,8 +107,8 @@ var httpStatic = &model.Config{
 }
 
 // Shares the same host as httpStatic, but adds some endpoints. We expect these to be merge
-var httpStaticOverlay = &model.Config{
-	ConfigMeta: model.ConfigMeta{
+var httpStaticOverlay = &config.Config{
+	ConfigMeta: config.ConfigMeta{
 		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "httpStaticOverlay",
 		Namespace:         "httpStatic",
@@ -129,8 +130,8 @@ var httpStaticOverlay = &model.Config{
 	},
 }
 
-var httpDNSnoEndpoints = &model.Config{
-	ConfigMeta: model.ConfigMeta{
+var httpDNSnoEndpoints = &config.Config{
+	ConfigMeta: config.ConfigMeta{
 		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "httpDNSnoEndpoints",
 		Namespace:         "httpDNSnoEndpoints",
@@ -148,8 +149,8 @@ var httpDNSnoEndpoints = &model.Config{
 	},
 }
 
-var httpDNS = &model.Config{
-	ConfigMeta: model.ConfigMeta{
+var httpDNS = &config.Config{
+	ConfigMeta: config.ConfigMeta{
 		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "httpDNS",
 		Namespace:         "httpDNS",
@@ -183,8 +184,8 @@ var httpDNS = &model.Config{
 	},
 }
 
-var tcpDNS = &model.Config{
-	ConfigMeta: model.ConfigMeta{
+var tcpDNS = &config.Config{
+	ConfigMeta: config.ConfigMeta{
 		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "tcpDNS",
 		Namespace:         "tcpDNS",
@@ -211,8 +212,8 @@ var tcpDNS = &model.Config{
 	},
 }
 
-var tcpStatic = &model.Config{
-	ConfigMeta: model.ConfigMeta{
+var tcpStatic = &config.Config{
+	ConfigMeta: config.ConfigMeta{
 		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "tcpStatic",
 		Namespace:         "tcpStatic",
@@ -240,8 +241,8 @@ var tcpStatic = &model.Config{
 	},
 }
 
-var httpNoneInternal = &model.Config{
-	ConfigMeta: model.ConfigMeta{
+var httpNoneInternal = &config.Config{
+	ConfigMeta: config.ConfigMeta{
 		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "httpNoneInternal",
 		Namespace:         "httpNoneInternal",
@@ -259,8 +260,8 @@ var httpNoneInternal = &model.Config{
 	},
 }
 
-var tcpNoneInternal = &model.Config{
-	ConfigMeta: model.ConfigMeta{
+var tcpNoneInternal = &config.Config{
+	ConfigMeta: config.ConfigMeta{
 		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "tcpNoneInternal",
 		Namespace:         "tcpNoneInternal",
@@ -278,8 +279,8 @@ var tcpNoneInternal = &model.Config{
 	},
 }
 
-var multiAddrInternal = &model.Config{
-	ConfigMeta: model.ConfigMeta{
+var multiAddrInternal = &config.Config{
+	ConfigMeta: config.ConfigMeta{
 		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "multiAddrInternal",
 		Namespace:         "multiAddrInternal",
@@ -297,8 +298,8 @@ var multiAddrInternal = &model.Config{
 	},
 }
 
-var udsLocal = &model.Config{
-	ConfigMeta: model.ConfigMeta{
+var udsLocal = &config.Config{
+	ConfigMeta: config.ConfigMeta{
 		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "udsLocal",
 		Namespace:         "udsLocal",
@@ -318,8 +319,8 @@ var udsLocal = &model.Config{
 }
 
 // ServiceEntry DNS with a selector
-var selectorDNS = &model.Config{
-	ConfigMeta: model.ConfigMeta{
+var selectorDNS = &config.Config{
+	ConfigMeta: config.ConfigMeta{
 		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "selector",
 		Namespace:         "selector",
@@ -340,8 +341,8 @@ var selectorDNS = &model.Config{
 }
 
 // ServiceEntry with a selector
-var selector = &model.Config{
-	ConfigMeta: model.ConfigMeta{
+var selector = &config.Config{
+	ConfigMeta: config.ConfigMeta{
 		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "selector",
 		Namespace:         "selector",
@@ -362,8 +363,8 @@ var selector = &model.Config{
 }
 
 // DNS ServiceEntry with a selector
-var dnsSelector = &model.Config{
-	ConfigMeta: model.ConfigMeta{
+var dnsSelector = &config.Config{
+	ConfigMeta: config.ConfigMeta{
 		GroupVersionKind:  gvk.ServiceEntry,
 		Name:              "dns-selector",
 		Namespace:         "dns-selector",
@@ -383,9 +384,9 @@ var dnsSelector = &model.Config{
 	},
 }
 
-func createWorkloadEntry(name, namespace string, spec *networking.WorkloadEntry) *model.Config {
-	return &model.Config{
-		ConfigMeta: model.ConfigMeta{
+func createWorkloadEntry(name, namespace string, spec *networking.WorkloadEntry) *config.Config {
+	return &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind:  gvk.WorkloadEntry,
 			Name:              name,
 			Namespace:         namespace,
@@ -447,7 +448,7 @@ const (
 )
 
 // nolint: unparam
-func makeInstanceWithServiceAccount(cfg *model.Config, address string, port int,
+func makeInstanceWithServiceAccount(cfg *config.Config, address string, port int,
 	svcPort *networking.Port, svcLabels map[string]string, serviceAccount string) *model.ServiceInstance {
 	i := makeInstance(cfg, address, port, svcPort, svcLabels, MTLSUnlabelled)
 	i.Endpoint.ServiceAccount = spiffe.MustGenSpiffeURI(i.Service.Attributes.Namespace, serviceAccount)
@@ -455,7 +456,7 @@ func makeInstanceWithServiceAccount(cfg *model.Config, address string, port int,
 }
 
 // nolint: unparam
-func makeInstance(cfg *model.Config, address string, port int,
+func makeInstance(cfg *config.Config, address string, port int,
 	svcPort *networking.Port, svcLabels map[string]string, mtlsMode MTLSMode) *model.ServiceInstance {
 	services := convertServices(*cfg)
 	svc := services[0] // default
@@ -494,7 +495,7 @@ func makeInstance(cfg *model.Config, address string, port int,
 
 func TestConvertService(t *testing.T) {
 	serviceTests := []struct {
-		externalSvc *model.Config
+		externalSvc *config.Config
 		services    []*model.Service
 	}{
 		{
@@ -584,7 +585,7 @@ func TestConvertService(t *testing.T) {
 	selectorSvc.Attributes.LabelSelectors = map[string]string{"app": "wle"}
 
 	serviceTests = append(serviceTests, struct {
-		externalSvc *model.Config
+		externalSvc *config.Config
 		services    []*model.Service
 	}{
 		externalSvc: selector,
@@ -601,7 +602,7 @@ func TestConvertService(t *testing.T) {
 
 func TestConvertInstances(t *testing.T) {
 	serviceInstanceTests := []struct {
-		externalSvc *model.Config
+		externalSvc *config.Config
 		out         []*model.ServiceInstance
 	}{
 		{
@@ -699,7 +700,7 @@ func TestConvertWorkloadEntryToServiceInstances(t *testing.T) {
 	serviceInstanceTests := []struct {
 		name string
 		wle  *networking.WorkloadEntry
-		se   *model.Config
+		se   *config.Config
 		out  []*model.ServiceInstance
 	}{
 		{
@@ -765,13 +766,13 @@ func TestConvertWorkloadEntryToWorkloadInstance(t *testing.T) {
 	workloadInstanceTests := []struct {
 		name      string
 		namespace string
-		wle       model.Config
+		wle       config.Config
 		out       *model.WorkloadInstance
 	}{
 		{
 			name:      "simple",
 			namespace: "ns1",
-			wle: model.Config{Spec: &networking.WorkloadEntry{
+			wle: config.Config{Spec: &networking.WorkloadEntry{
 				Address: "1.1.1.1",
 				Labels:  labels,
 				Ports: map[string]uint32{
@@ -795,7 +796,7 @@ func TestConvertWorkloadEntryToWorkloadInstance(t *testing.T) {
 		{
 			name:      "simple - tls mode disabled",
 			namespace: "ns1",
-			wle: model.Config{Spec: &networking.WorkloadEntry{
+			wle: config.Config{Spec: &networking.WorkloadEntry{
 				Address: "1.1.1.1",
 				Labels: map[string]string{
 					"security.istio.io/tlsMode": "disabled",
@@ -823,7 +824,7 @@ func TestConvertWorkloadEntryToWorkloadInstance(t *testing.T) {
 		{
 			name:      "unix domain socket",
 			namespace: "ns1",
-			wle: model.Config{Spec: &networking.WorkloadEntry{
+			wle: config.Config{Spec: &networking.WorkloadEntry{
 				Address:        "unix://foo/bar",
 				ServiceAccount: "scooby",
 			}},
@@ -832,7 +833,7 @@ func TestConvertWorkloadEntryToWorkloadInstance(t *testing.T) {
 		{
 			name:      "DNS address",
 			namespace: "ns1",
-			wle: model.Config{Spec: &networking.WorkloadEntry{
+			wle: config.Config{Spec: &networking.WorkloadEntry{
 				Address:        "scooby.com",
 				ServiceAccount: "scooby",
 			}},
@@ -841,8 +842,8 @@ func TestConvertWorkloadEntryToWorkloadInstance(t *testing.T) {
 		{
 			name:      "metadata labels only",
 			namespace: "ns1",
-			wle: model.Config{
-				ConfigMeta: model.ConfigMeta{
+			wle: config.Config{
+				ConfigMeta: config.ConfigMeta{
 					Labels: labels,
 				},
 				Spec: &networking.WorkloadEntry{
@@ -868,8 +869,8 @@ func TestConvertWorkloadEntryToWorkloadInstance(t *testing.T) {
 		{
 			name:      "labels merge",
 			namespace: "ns1",
-			wle: model.Config{
-				ConfigMeta: model.ConfigMeta{
+			wle: config.Config{
+				ConfigMeta: config.ConfigMeta{
 					Labels: map[string]string{
 						"my-label": "bar",
 					},

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
@@ -24,6 +24,7 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
@@ -99,7 +100,7 @@ func NewServiceDiscovery(configController model.ConfigStoreCache, store model.Is
 // kube registry controller also calls this function indirectly via the Share interface
 // When invoked via the kube registry controller, the old object is nil as the registry
 // controller does its own deduping and has no notion of object versions
-func (s *ServiceEntryStore) workloadEntryHandler(old, curr model.Config, event model.Event) {
+func (s *ServiceEntryStore) workloadEntryHandler(old, curr config.Config, event model.Event) {
 	var oldWle *networking.WorkloadEntry
 	if old.Spec != nil {
 		oldWle = old.Spec.(*networking.WorkloadEntry)
@@ -205,7 +206,7 @@ func getUpdatedConfigs(services []*model.Service) map[model.ConfigKey]struct{} {
 }
 
 // serviceEntryHandler defines the handler for service entries
-func (s *ServiceEntryStore) serviceEntryHandler(old, curr model.Config, event model.Event) {
+func (s *ServiceEntryStore) serviceEntryHandler(old, curr config.Config, event model.Event) {
 	cs := convertServices(curr)
 	configsUpdated := map[model.ConfigKey]struct{}{}
 
@@ -782,7 +783,7 @@ func servicesDiff(os []*model.Service, ns []*model.Service) ([]*model.Service, [
 }
 
 // This method compares if the selector on a service entry has changed, meaning that it needs full push.
-func selectorChanged(old, curr model.Config) bool {
+func selectorChanged(old, curr config.Config) bool {
 	o := old.Spec.(*networking.ServiceEntry)
 	n := curr.Spec.(*networking.ServiceEntry)
 	return !reflect.DeepEqual(o.WorkloadSelector, n.WorkloadSelector)

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
@@ -937,7 +937,7 @@ func TestNonServiceConfig(t *testing.T) {
 
 	// Create a non-service configuration element. This should not affect the service registry at all.
 	cfg := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind:  collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(),
 			Name:              "fakeDestinationRule",
 			Namespace:         "default",
@@ -965,7 +965,7 @@ func TestNonServiceConfig(t *testing.T) {
 // nolint: lll
 func TestServicesDiff(t *testing.T) {
 	var updatedHTTPDNS = &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind:  collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind(),
 			Name:              "httpDNS",
 			Namespace:         "httpDNS",

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
@@ -26,6 +26,7 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
@@ -36,7 +37,7 @@ import (
 	"istio.io/pkg/log"
 )
 
-func createConfigs(configs []*model.Config, store model.IstioConfigStore, t *testing.T) {
+func createConfigs(configs []*config.Config, store model.IstioConfigStore, t *testing.T) {
 	t.Helper()
 	for _, cfg := range configs {
 		_, err := store.Create(*cfg)
@@ -58,7 +59,7 @@ func callInstanceHandlers(instances []*model.WorkloadInstance, sd *ServiceEntryS
 	}
 }
 
-func deleteConfigs(configs []*model.Config, store model.IstioConfigStore, t *testing.T) {
+func deleteConfigs(configs []*config.Config, store model.IstioConfigStore, t *testing.T) {
 	t.Helper()
 	for _, cfg := range configs {
 		err := store.Delete(cfg.GroupVersionKind, cfg.Name, cfg.Namespace)
@@ -144,7 +145,7 @@ func TestServiceDiscoveryServices(t *testing.T) {
 		makeService("tcpstatic.com", "tcpStatic", "172.217.0.1", map[string]int{"tcp-444": 444}, true, model.ClientSideLB),
 	}
 
-	createConfigs([]*model.Config{httpDNS, tcpStatic}, store, t)
+	createConfigs([]*config.Config{httpDNS, tcpStatic}, store, t)
 
 	services, err := sd.Services()
 	if err != nil {
@@ -164,7 +165,7 @@ func TestServiceDiscoveryGetService(t *testing.T) {
 	store, sd, _, stopFn := initServiceDiscovery()
 	defer stopFn()
 
-	createConfigs([]*model.Config{httpDNS, tcpStatic}, store, t)
+	createConfigs([]*config.Config{httpDNS, tcpStatic}, store, t)
 
 	service, err := sd.GetService(host.Name(hostDNE))
 	if err != nil {
@@ -192,7 +193,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 	store, sd, events, stopFn := initServiceDiscovery()
 	defer stopFn()
 	// httpStaticOverlayUpdated is the same as httpStaticOverlay but with an extra endpoint added to test updates
-	httpStaticOverlayUpdated := func() *model.Config {
+	httpStaticOverlayUpdated := func() *config.Config {
 		c := httpStaticOverlay.DeepCopy()
 		se := c.Spec.(*networking.ServiceEntry)
 		se.Endpoints = append(se.Endpoints, &networking.WorkloadEntry{
@@ -202,7 +203,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 		return &c
 	}()
 	// httpStaticOverlayUpdatedInstance is the same as httpStaticOverlayUpdated but with an extra endpoint added that has the same address
-	httpStaticOverlayUpdatedInstance := func() *model.Config {
+	httpStaticOverlayUpdatedInstance := func() *config.Config {
 		c := httpStaticOverlayUpdated.DeepCopy()
 		se := c.Spec.(*networking.ServiceEntry)
 		se.Endpoints = append(se.Endpoints, &networking.WorkloadEntry{
@@ -213,14 +214,14 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 	}()
 
 	// httpStaticOverlayUpdatedNop is the same as httpStaticOverlayUpdated but with a NOP change
-	httpStaticOverlayUpdatedNop := func() *model.Config {
+	httpStaticOverlayUpdatedNop := func() *config.Config {
 		c := httpStaticOverlayUpdated.DeepCopy()
 		c.ResourceVersion = "foo"
 		return &c
 	}()
 
 	// httpStaticOverlayUpdatedNs is the same as httpStaticOverlay but with an extra endpoint and different namespace added to test updates
-	httpStaticOverlayUpdatedNs := func() *model.Config {
+	httpStaticOverlayUpdatedNs := func() *config.Config {
 		c := httpStaticOverlay.DeepCopy()
 		c.Namespace = "other"
 		se := c.Spec.(*networking.ServiceEntry)
@@ -243,7 +244,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 
 	t.Run("simple entry", func(t *testing.T) {
 		// Create a SE, expect the base instances
-		createConfigs([]*model.Config{httpStatic}, store, t)
+		createConfigs([]*config.Config{httpStatic}, store, t)
 		instances := baseInstances
 		expectServiceInstances(t, sd, httpStatic, 0, instances)
 		expectEvents(t, events,
@@ -253,7 +254,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 
 	t.Run("add entry", func(t *testing.T) {
 		// Create another SE for the same host, expect these instances to get added
-		createConfigs([]*model.Config{httpStaticOverlay}, store, t)
+		createConfigs([]*config.Config{httpStaticOverlay}, store, t)
 		instances := append(baseInstances,
 			makeInstance(httpStaticOverlay, "5.5.5.5", 4567, httpStaticOverlay.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"overlay": "bar"}, PlainText))
 		expectServiceInstances(t, sd, httpStatic, 0, instances)
@@ -264,7 +265,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 
 	t.Run("add endpoint", func(t *testing.T) {
 		// Update the SE for the same host, expect these instances to get added
-		createConfigs([]*model.Config{httpStaticOverlayUpdated}, store, t)
+		createConfigs([]*config.Config{httpStaticOverlayUpdated}, store, t)
 		instances := append(baseInstances,
 			makeInstance(httpStaticOverlay, "5.5.5.5", 4567, httpStaticOverlay.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"overlay": "bar"}, PlainText),
 			makeInstance(httpStaticOverlay, "6.6.6.6", 4567, httpStaticOverlay.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"other": "bar"}, PlainText))
@@ -272,7 +273,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 		expectEvents(t, events, Event{kind: "eds", host: "*.google.com", namespace: httpStaticOverlay.Namespace, endpoints: len(instances)})
 
 		// Make a NOP change, expect that there are no changes
-		createConfigs([]*model.Config{httpStaticOverlayUpdatedNop}, store, t)
+		createConfigs([]*config.Config{httpStaticOverlayUpdatedNop}, store, t)
 		expectServiceInstances(t, sd, httpStaticOverlayUpdatedNop, 0, instances)
 		// TODO this could trigger no changes
 		expectEvents(t, events, Event{kind: "eds", host: "*.google.com", namespace: httpStaticOverlay.Namespace, endpoints: len(instances)})
@@ -280,7 +281,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 
 	t.Run("overlapping address", func(t *testing.T) {
 		// Add another SE with an additional endpoint with a matching address
-		createConfigs([]*model.Config{httpStaticOverlayUpdatedInstance}, store, t)
+		createConfigs([]*config.Config{httpStaticOverlayUpdatedInstance}, store, t)
 		instances := append(baseInstances,
 			makeInstance(httpStaticOverlay, "5.5.5.5", 4567, httpStaticOverlay.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"overlay": "bar"}, PlainText),
 			makeInstance(httpStaticOverlay, "6.6.6.6", 4567, httpStaticOverlay.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"other": "bar"}, PlainText),
@@ -295,7 +296,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 		expectEvents(t, events, Event{kind: "eds", host: "*.google.com", namespace: httpStaticOverlay.Namespace, endpoints: len(instances)})
 
 		// Remove the additional endpoint
-		createConfigs([]*model.Config{httpStaticOverlayUpdated}, store, t)
+		createConfigs([]*config.Config{httpStaticOverlayUpdated}, store, t)
 		instances = append(baseInstances,
 			makeInstance(httpStaticOverlay, "5.5.5.5", 4567, httpStaticOverlay.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"overlay": "bar"}, PlainText),
 			makeInstance(httpStaticOverlay, "6.6.6.6", 4567, httpStaticOverlay.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"other": "bar"}, PlainText))
@@ -309,7 +310,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 
 	t.Run("update removes endpoint", func(t *testing.T) {
 		// Update the SE for the same host to remove the endpoint
-		createConfigs([]*model.Config{httpStaticOverlay}, store, t)
+		createConfigs([]*config.Config{httpStaticOverlay}, store, t)
 		instances := append(baseInstances,
 			makeInstance(httpStaticOverlay, "5.5.5.5", 4567, httpStaticOverlay.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"overlay": "bar"}, PlainText))
 		expectServiceInstances(t, sd, httpStaticOverlay, 0, instances)
@@ -319,7 +320,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 
 	t.Run("different namespace", func(t *testing.T) {
 		// Update the SE for the same host in a different ns, expect these instances to get added
-		createConfigs([]*model.Config{httpStaticOverlayUpdatedNs}, store, t)
+		createConfigs([]*config.Config{httpStaticOverlayUpdatedNs}, store, t)
 		instances := []*model.ServiceInstance{
 			makeInstance(httpStaticOverlayUpdatedNs, "5.5.5.5", 4567, httpStaticOverlayUpdatedNs.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"overlay": "bar"}, PlainText),
 			makeInstance(httpStaticOverlayUpdatedNs, "7.7.7.7", 4567, httpStaticOverlayUpdatedNs.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"namespace": "bar"}, PlainText),
@@ -334,7 +335,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 
 	t.Run("delete entry", func(t *testing.T) {
 		// Delete the additional SE, expect it to get removed
-		deleteConfigs([]*model.Config{httpStaticOverlayUpdated}, store, t)
+		deleteConfigs([]*config.Config{httpStaticOverlayUpdated}, store, t)
 		expectServiceInstances(t, sd, httpStatic, 0, baseInstances)
 		// Check the other namespace is untouched
 		instances := []*model.ServiceInstance{
@@ -348,7 +349,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 			Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.ConfigKey]struct{}{{Kind: gvk.ServiceEntry, Name: "*.google.com", Namespace: httpStaticOverlayUpdated.Namespace}: {}}}})
 
 		// Add back the ServiceEntry, expect these instances to get added
-		createConfigs([]*model.Config{httpStaticOverlayUpdated}, store, t)
+		createConfigs([]*config.Config{httpStaticOverlayUpdated}, store, t)
 		instances = append(baseInstances,
 			makeInstance(httpStaticOverlay, "5.5.5.5", 4567, httpStaticOverlay.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"overlay": "bar"}, PlainText),
 			makeInstance(httpStaticOverlay, "6.6.6.6", 4567, httpStaticOverlay.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"other": "bar"}, PlainText))
@@ -361,18 +362,18 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 
 	t.Run("change host", func(t *testing.T) {
 		// same as httpStaticOverlayUpdated but with an additional host
-		httpStaticHost := func() *model.Config {
+		httpStaticHost := func() *config.Config {
 			c := httpStaticOverlayUpdated.DeepCopy()
 			se := c.Spec.(*networking.ServiceEntry)
 			se.Hosts = append(se.Hosts, "other.com")
 			return &c
 		}()
-		createConfigs([]*model.Config{httpStaticHost}, store, t)
+		createConfigs([]*config.Config{httpStaticHost}, store, t)
 		instances := append(baseInstances,
 			makeInstance(httpStaticOverlay, "5.5.5.5", 4567, httpStaticOverlay.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"overlay": "bar"}, PlainText),
 			makeInstance(httpStaticOverlay, "6.6.6.6", 4567, httpStaticOverlay.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"other": "bar"}, PlainText))
 		// This is not applied, just to make makeInstance pick the right service.
-		otherHost := func() *model.Config {
+		otherHost := func() *config.Config {
 			c := httpStaticOverlayUpdated.DeepCopy()
 			se := c.Spec.(*networking.ServiceEntry)
 			se.Hosts = []string{"other.com"}
@@ -389,7 +390,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 			Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.ConfigKey]struct{}{{Kind: gvk.ServiceEntry, Name: "other.com", Namespace: httpStaticOverlayUpdated.Namespace}: {}}}}) // service added
 
 		// restore this config and remove the added host.
-		createConfigs([]*model.Config{httpStaticOverlayUpdated}, store, t)
+		createConfigs([]*config.Config{httpStaticOverlayUpdated}, store, t)
 		expectEvents(t, events,
 			Event{kind: "svcupdate", host: "other.com", namespace: httpStatic.Namespace},
 			Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.ConfigKey]struct{}{{Kind: gvk.ServiceEntry, Name: "other.com", Namespace: httpStaticOverlayUpdated.Namespace}: {}}}}) // service deleted
@@ -405,7 +406,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 		}
 
 		// This is not applied, just to make makeInstance pick the right service.
-		tcpDNSUpdated := func() *model.Config {
+		tcpDNSUpdated := func() *config.Config {
 			c := tcpDNS.DeepCopy()
 			se := c.Spec.(*networking.ServiceEntry)
 			se.Endpoints = []*networking.WorkloadEntry{
@@ -422,7 +423,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 				nil, MTLS),
 		}
 
-		createConfigs([]*model.Config{tcpDNS}, store, t)
+		createConfigs([]*config.Config{tcpDNS}, store, t)
 		expectServiceInstances(t, sd, tcpDNS, 0, instances1)
 		// Service change, so we need a full push
 		expectEvents(t, events,
@@ -430,7 +431,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 			Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.ConfigKey]struct{}{{Kind: gvk.ServiceEntry, Name: "tcpdns.com", Namespace: tcpDNS.Namespace}: {}}}}) // service added
 
 		// now update the config
-		createConfigs([]*model.Config{tcpDNSUpdated}, store, t)
+		createConfigs([]*config.Config{tcpDNSUpdated}, store, t)
 		expectEvents(t, events,
 			Event{kind: "xds", pushReq: &model.PushRequest{ConfigsUpdated: map[model.ConfigKey]struct{}{{Kind: gvk.ServiceEntry, Name: "tcpdns.com",
 				Namespace: tcpDNSUpdated.Namespace}: {}}}}) // service deleted
@@ -439,7 +440,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 
 	t.Run("change workload selector", func(t *testing.T) {
 		// same as selector but with an additional host
-		selector1 := func() *model.Config {
+		selector1 := func() *config.Config {
 			c := httpStaticOverlay.DeepCopy()
 			se := c.Spec.(*networking.ServiceEntry)
 			se.Hosts = append(se.Hosts, "selector1.com")
@@ -449,7 +450,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 			}
 			return &c
 		}()
-		createConfigs([]*model.Config{selector1}, store, t)
+		createConfigs([]*config.Config{selector1}, store, t)
 		// Service change, so we need a full push
 		expectEvents(t, events,
 			Event{kind: "svcupdate", host: "*.google.com", namespace: httpStaticOverlay.Namespace},
@@ -460,7 +461,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 				{Kind: gvk.ServiceEntry, Name: "selector1.com", Namespace: selector1.Namespace}: {},
 			}}}) // service added
 
-		selector1Updated := func() *model.Config {
+		selector1Updated := func() *config.Config {
 			c := selector1.DeepCopy()
 			se := c.Spec.(*networking.ServiceEntry)
 			se.WorkloadSelector = &networking.WorkloadSelector{
@@ -468,7 +469,7 @@ func TestServiceDiscoveryServiceUpdate(t *testing.T) {
 			}
 			return &c
 		}()
-		createConfigs([]*model.Config{selector1Updated}, store, t)
+		createConfigs([]*config.Config{selector1Updated}, store, t)
 		expectEvents(t, events,
 			Event{kind: "svcupdate", host: "*.google.com", namespace: httpStaticOverlay.Namespace},
 			Event{kind: "svcupdate", host: "selector1.com", namespace: httpStaticOverlay.Namespace},
@@ -506,7 +507,7 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 
 	t.Run("service entry", func(t *testing.T) {
 		// Add just the ServiceEntry with selector. We should see no instances
-		createConfigs([]*model.Config{selector}, store, t)
+		createConfigs([]*config.Config{selector}, store, t)
 		instances := []*model.ServiceInstance{}
 		expectProxyInstances(t, sd, instances, "2.2.2.2")
 		expectServiceInstances(t, sd, selector, 0, instances)
@@ -517,7 +518,7 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 
 	t.Run("add workload", func(t *testing.T) {
 		// Add a WLE, we expect this to update
-		createConfigs([]*model.Config{wle}, store, t)
+		createConfigs([]*config.Config{wle}, store, t)
 		instances := []*model.ServiceInstance{
 			makeInstanceWithServiceAccount(selector, "2.2.2.2", 444,
 				selector.Spec.(*networking.ServiceEntry).Ports[0],
@@ -534,7 +535,7 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 
 	t.Run("add dns service entry", func(t *testing.T) {
 		// Add just the ServiceEntry with selector. We should see no instances
-		createConfigs([]*model.Config{dnsSelector}, store, t)
+		createConfigs([]*config.Config{dnsSelector}, store, t)
 		instances := []*model.ServiceInstance{}
 		expectProxyInstances(t, sd, instances, "4.4.4.4")
 		expectServiceInstances(t, sd, dnsSelector, 0, instances)
@@ -545,7 +546,7 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 
 	t.Run("add dns workload", func(t *testing.T) {
 		// Add a WLE, we expect this to update
-		createConfigs([]*model.Config{dnsWle}, store, t)
+		createConfigs([]*config.Config{dnsWle}, store, t)
 		instances := []*model.ServiceInstance{
 			makeInstanceWithServiceAccount(dnsSelector, "4.4.4.4", 444,
 				selector.Spec.(*networking.ServiceEntry).Ports[0],
@@ -561,7 +562,7 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 
 	t.Run("another workload", func(t *testing.T) {
 		// Add a different WLE
-		createConfigs([]*model.Config{wle2}, store, t)
+		createConfigs([]*config.Config{wle2}, store, t)
 		instances := []*model.ServiceInstance{
 			makeInstanceWithServiceAccount(selector, "2.2.2.2", 444,
 				selector.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"app": "wle"}, "default"),
@@ -580,7 +581,7 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 
 	t.Run("deletion", func(t *testing.T) {
 		// Delete the configs, it should be gone
-		deleteConfigs([]*model.Config{wle2}, store, t)
+		deleteConfigs([]*config.Config{wle2}, store, t)
 		instances := []*model.ServiceInstance{
 			makeInstanceWithServiceAccount(selector, "2.2.2.2", 444,
 				selector.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"app": "wle"}, "default"),
@@ -592,14 +593,14 @@ func TestServiceDiscoveryWorkloadUpdate(t *testing.T) {
 		expectEvents(t, events, Event{kind: "eds", host: "selector.com", namespace: selector.Namespace, endpoints: 2})
 
 		// Delete the other config
-		deleteConfigs([]*model.Config{wle}, store, t)
+		deleteConfigs([]*config.Config{wle}, store, t)
 		instances = []*model.ServiceInstance{}
 		expectServiceInstances(t, sd, selector, 0, instances)
 		expectProxyInstances(t, sd, instances, "2.2.2.2")
 		expectEvents(t, events, Event{kind: "eds", host: "selector.com", namespace: selector.Namespace, endpoints: 0})
 
 		// Add the config back
-		createConfigs([]*model.Config{wle}, store, t)
+		createConfigs([]*config.Config{wle}, store, t)
 		instances = []*model.ServiceInstance{
 			makeInstanceWithServiceAccount(selector, "2.2.2.2", 444,
 				selector.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"app": "wle"}, "default"),
@@ -637,7 +638,7 @@ func TestServiceDiscoveryWorkloadChangeLabel(t *testing.T) {
 
 	t.Run("service entry", func(t *testing.T) {
 		// Add just the ServiceEntry with selector. We should see no instances
-		createConfigs([]*model.Config{selector}, store, t)
+		createConfigs([]*config.Config{selector}, store, t)
 		instances := []*model.ServiceInstance{}
 		expectProxyInstances(t, sd, instances, "2.2.2.2")
 		expectServiceInstances(t, sd, selector, 0, instances)
@@ -648,7 +649,7 @@ func TestServiceDiscoveryWorkloadChangeLabel(t *testing.T) {
 
 	t.Run("change label removing all", func(t *testing.T) {
 		// Add a WLE, we expect this to update
-		createConfigs([]*model.Config{wle}, store, t)
+		createConfigs([]*config.Config{wle}, store, t)
 		instances := []*model.ServiceInstance{
 			makeInstanceWithServiceAccount(selector, "2.2.2.2", 444,
 				selector.Spec.(*networking.ServiceEntry).Ports[0],
@@ -661,7 +662,7 @@ func TestServiceDiscoveryWorkloadChangeLabel(t *testing.T) {
 		expectServiceInstances(t, sd, selector, 0, instances)
 		expectEvents(t, events, Event{kind: "eds", host: "selector.com", namespace: selector.Namespace, endpoints: 2})
 
-		createConfigs([]*model.Config{wle2}, store, t)
+		createConfigs([]*config.Config{wle2}, store, t)
 		instances = []*model.ServiceInstance{}
 		expectServiceInstances(t, sd, selector, 0, instances)
 		expectProxyInstances(t, sd, instances, "2.2.2.2")
@@ -670,7 +671,7 @@ func TestServiceDiscoveryWorkloadChangeLabel(t *testing.T) {
 
 	t.Run("change label removing one", func(t *testing.T) {
 		// Add a WLE, we expect this to update
-		createConfigs([]*model.Config{wle, wle3}, store, t)
+		createConfigs([]*config.Config{wle, wle3}, store, t)
 		instances := []*model.ServiceInstance{
 			makeInstanceWithServiceAccount(selector, "2.2.2.2", 444,
 				selector.Spec.(*networking.ServiceEntry).Ports[0],
@@ -690,7 +691,7 @@ func TestServiceDiscoveryWorkloadChangeLabel(t *testing.T) {
 		expectServiceInstances(t, sd, selector, 0, instances)
 		expectEvents(t, events, Event{kind: "eds", host: "selector.com", namespace: selector.Namespace, endpoints: 2})
 
-		createConfigs([]*model.Config{wle2}, store, t)
+		createConfigs([]*config.Config{wle2}, store, t)
 		instances = []*model.ServiceInstance{
 			makeInstanceWithServiceAccount(selector, "3.3.3.3", 444,
 				selector.Spec.(*networking.ServiceEntry).Ports[0],
@@ -732,7 +733,7 @@ func TestServiceDiscoveryWorkloadInstance(t *testing.T) {
 
 	t.Run("service entry", func(t *testing.T) {
 		// Add just the ServiceEntry with selector. We should see no instances
-		createConfigs([]*model.Config{selector}, store, t)
+		createConfigs([]*config.Config{selector}, store, t)
 		instances := []*model.ServiceInstance{}
 		expectProxyInstances(t, sd, instances, "2.2.2.2")
 		expectServiceInstances(t, sd, selector, 0, instances)
@@ -866,7 +867,7 @@ func expectEvents(t *testing.T, ch chan Event, events ...Event) {
 	}
 }
 
-func expectServiceInstances(t *testing.T, sd *ServiceEntryStore, cfg *model.Config, port int, expected ...[]*model.ServiceInstance) {
+func expectServiceInstances(t *testing.T, sd *ServiceEntryStore, cfg *config.Config, port int, expected ...[]*model.ServiceInstance) {
 	t.Helper()
 	svcs := convertServices(*cfg)
 	if len(svcs) != len(expected) {
@@ -890,7 +891,7 @@ func TestServiceDiscoveryGetProxyServiceInstances(t *testing.T) {
 	store, sd, _, stopFn := initServiceDiscovery()
 	defer stopFn()
 
-	createConfigs([]*model.Config{httpStatic, tcpStatic}, store, t)
+	createConfigs([]*config.Config{httpStatic, tcpStatic}, store, t)
 
 	expectProxyInstances(t, sd, []*model.ServiceInstance{
 		makeInstance(httpStatic, "2.2.2.2", 7080, httpStatic.Spec.(*networking.ServiceEntry).Ports[0], nil, MTLS),
@@ -904,7 +905,7 @@ func TestServiceDiscoveryInstances(t *testing.T) {
 	store, sd, _, stopFn := initServiceDiscovery()
 	defer stopFn()
 
-	createConfigs([]*model.Config{httpDNS, tcpStatic}, store, t)
+	createConfigs([]*config.Config{httpDNS, tcpStatic}, store, t)
 
 	expectServiceInstances(t, sd, httpDNS, 0, []*model.ServiceInstance{
 		makeInstance(httpDNS, "us.google.com", 7080, httpDNS.Spec.(*networking.ServiceEntry).Ports[0], nil, MTLS),
@@ -921,7 +922,7 @@ func TestServiceDiscoveryInstances1Port(t *testing.T) {
 	store, sd, _, stopFn := initServiceDiscovery()
 	defer stopFn()
 
-	createConfigs([]*model.Config{httpDNS, tcpStatic}, store, t)
+	createConfigs([]*config.Config{httpDNS, tcpStatic}, store, t)
 
 	expectServiceInstances(t, sd, httpDNS, 80, []*model.ServiceInstance{
 		makeInstance(httpDNS, "us.google.com", 7080, httpDNS.Spec.(*networking.ServiceEntry).Ports[0], nil, MTLS),
@@ -935,8 +936,8 @@ func TestNonServiceConfig(t *testing.T) {
 	defer stopFn()
 
 	// Create a non-service configuration element. This should not affect the service registry at all.
-	cfg := model.Config{
-		ConfigMeta: model.ConfigMeta{
+	cfg := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind:  collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind(),
 			Name:              "fakeDestinationRule",
 			Namespace:         "default",
@@ -953,7 +954,7 @@ func TestNonServiceConfig(t *testing.T) {
 	}
 
 	// Now create some service entries and verify that it's added to the registry.
-	createConfigs([]*model.Config{httpDNS, tcpStatic}, store, t)
+	createConfigs([]*config.Config{httpDNS, tcpStatic}, store, t)
 	expectServiceInstances(t, sd, httpDNS, 80, []*model.ServiceInstance{
 		makeInstance(httpDNS, "us.google.com", 7080, httpDNS.Spec.(*networking.ServiceEntry).Ports[0], nil, MTLS),
 		makeInstance(httpDNS, "uk.google.com", 1080, httpDNS.Spec.(*networking.ServiceEntry).Ports[0], nil, MTLS),
@@ -963,8 +964,8 @@ func TestNonServiceConfig(t *testing.T) {
 
 // nolint: lll
 func TestServicesDiff(t *testing.T) {
-	var updatedHTTPDNS = &model.Config{
-		ConfigMeta: model.ConfigMeta{
+	var updatedHTTPDNS = &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind:  collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind(),
 			Name:              "httpDNS",
 			Namespace:         "httpDNS",
@@ -998,7 +999,7 @@ func TestServicesDiff(t *testing.T) {
 		},
 	}
 
-	var updatedHTTPDNSPort = func() *model.Config {
+	var updatedHTTPDNSPort = func() *config.Config {
 		c := updatedHTTPDNS.DeepCopy()
 		se := c.Spec.(*networking.ServiceEntry)
 		var ports []*networking.Port
@@ -1008,7 +1009,7 @@ func TestServicesDiff(t *testing.T) {
 		return &c
 	}()
 
-	var updatedEndpoint = func() *model.Config {
+	var updatedEndpoint = func() *config.Config {
 		c := updatedHTTPDNS.DeepCopy()
 		se := c.Spec.(*networking.ServiceEntry)
 		var endpoints []*networking.WorkloadEntry
@@ -1031,8 +1032,8 @@ func TestServicesDiff(t *testing.T) {
 
 	cases := []struct {
 		name string
-		a    *model.Config
-		b    *model.Config
+		a    *config.Config
+		b    *config.Config
 
 		added     []host.Name
 		deleted   []host.Name
@@ -1048,7 +1049,7 @@ func TestServicesDiff(t *testing.T) {
 		{
 			name: "different config",
 			a:    updatedHTTPDNS,
-			b: func() *model.Config {
+			b: func() *config.Config {
 				c := updatedHTTPDNS.DeepCopy()
 				c.Name = "httpDNS1"
 				return &c
@@ -1058,7 +1059,7 @@ func TestServicesDiff(t *testing.T) {
 		{
 			name: "different resolution",
 			a:    updatedHTTPDNS,
-			b: func() *model.Config {
+			b: func() *config.Config {
 				c := updatedHTTPDNS.DeepCopy()
 				c.Spec.(*networking.ServiceEntry).Resolution = networking.ServiceEntry_NONE
 				return &c
@@ -1068,7 +1069,7 @@ func TestServicesDiff(t *testing.T) {
 		{
 			name: "config modified with added/deleted host",
 			a:    updatedHTTPDNS,
-			b: func() *model.Config {
+			b: func() *config.Config {
 				c := updatedHTTPDNS.DeepCopy()
 				se := c.Spec.(*networking.ServiceEntry)
 				se.Hosts = []string{"*.google.com", "host.com"}

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -119,7 +119,7 @@ func TestWorkloadInstances(t *testing.T) {
 	}
 	namespace := "namespace"
 	serviceEntry := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:             "service-entry",
 			Namespace:        namespace,
 			GroupVersionKind: gvk.ServiceEntry,
@@ -155,7 +155,7 @@ func TestWorkloadInstances(t *testing.T) {
 		Status: v1.PodStatus{PodIP: "1.2.3.4"},
 	}
 	workloadEntry := config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:             "workload",
 			Namespace:        namespace,
 			GroupVersionKind: gvk.WorkloadEntry,
@@ -212,7 +212,7 @@ func TestWorkloadInstances(t *testing.T) {
 		_, wc, store, _ := setupTest(t)
 		makeIstioObject(t, store, serviceEntry)
 		makeIstioObject(t, store, config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				Name:             "workload",
 				Namespace:        namespace,
 				GroupVersionKind: gvk.WorkloadEntry,
@@ -239,7 +239,7 @@ func TestWorkloadInstances(t *testing.T) {
 	t.Run("External only with target port", func(t *testing.T) {
 		_, wc, store, _ := setupTest(t)
 		makeIstioObject(t, store, config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				Name:             "service-entry",
 				Namespace:        namespace,
 				GroupVersionKind: gvk.ServiceEntry,
@@ -301,7 +301,7 @@ func TestWorkloadInstances(t *testing.T) {
 			},
 		})
 		makeIstioObject(t, store, config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				Name:             "workload",
 				Namespace:        namespace,
 				GroupVersionKind: gvk.WorkloadEntry,
@@ -343,7 +343,7 @@ func TestWorkloadInstances(t *testing.T) {
 			},
 		})
 		makeIstioObject(t, store, config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				Name:             "workload",
 				Namespace:        namespace,
 				GroupVersionKind: gvk.WorkloadEntry,
@@ -381,7 +381,7 @@ func TestWorkloadInstances(t *testing.T) {
 	t.Run("ServiceEntry selects Pod with targetPort number", func(t *testing.T) {
 		_, wc, store, kube := setupTest(t)
 		makeIstioObject(t, store, config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				Name:             "service-entry",
 				Namespace:        namespace,
 				GroupVersionKind: gvk.ServiceEntry,

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -34,6 +34,7 @@ import (
 	kubecontroller "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
 	"istio.io/istio/pilot/test/util"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
@@ -117,8 +118,8 @@ func TestWorkloadInstances(t *testing.T) {
 		"app": "foo",
 	}
 	namespace := "namespace"
-	serviceEntry := model.Config{
-		ConfigMeta: model.ConfigMeta{
+	serviceEntry := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:             "service-entry",
 			Namespace:        namespace,
 			GroupVersionKind: gvk.ServiceEntry,
@@ -153,8 +154,8 @@ func TestWorkloadInstances(t *testing.T) {
 		},
 		Status: v1.PodStatus{PodIP: "1.2.3.4"},
 	}
-	workloadEntry := model.Config{
-		ConfigMeta: model.ConfigMeta{
+	workloadEntry := config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:             "workload",
 			Namespace:        namespace,
 			GroupVersionKind: gvk.WorkloadEntry,
@@ -210,8 +211,8 @@ func TestWorkloadInstances(t *testing.T) {
 	t.Run("External only with named port override", func(t *testing.T) {
 		_, wc, store, _ := setupTest(t)
 		makeIstioObject(t, store, serviceEntry)
-		makeIstioObject(t, store, model.Config{
-			ConfigMeta: model.ConfigMeta{
+		makeIstioObject(t, store, config.Config{
+			ConfigMeta: config.ConfigMeta{
 				Name:             "workload",
 				Namespace:        namespace,
 				GroupVersionKind: gvk.WorkloadEntry,
@@ -237,8 +238,8 @@ func TestWorkloadInstances(t *testing.T) {
 
 	t.Run("External only with target port", func(t *testing.T) {
 		_, wc, store, _ := setupTest(t)
-		makeIstioObject(t, store, model.Config{
-			ConfigMeta: model.ConfigMeta{
+		makeIstioObject(t, store, config.Config{
+			ConfigMeta: config.ConfigMeta{
 				Name:             "service-entry",
 				Namespace:        namespace,
 				GroupVersionKind: gvk.ServiceEntry,
@@ -299,8 +300,8 @@ func TestWorkloadInstances(t *testing.T) {
 				ClusterIP: "9.9.9.9",
 			},
 		})
-		makeIstioObject(t, store, model.Config{
-			ConfigMeta: model.ConfigMeta{
+		makeIstioObject(t, store, config.Config{
+			ConfigMeta: config.ConfigMeta{
 				Name:             "workload",
 				Namespace:        namespace,
 				GroupVersionKind: gvk.WorkloadEntry,
@@ -341,8 +342,8 @@ func TestWorkloadInstances(t *testing.T) {
 				ClusterIP: "9.9.9.9",
 			},
 		})
-		makeIstioObject(t, store, model.Config{
-			ConfigMeta: model.ConfigMeta{
+		makeIstioObject(t, store, config.Config{
+			ConfigMeta: config.ConfigMeta{
 				Name:             "workload",
 				Namespace:        namespace,
 				GroupVersionKind: gvk.WorkloadEntry,
@@ -379,8 +380,8 @@ func TestWorkloadInstances(t *testing.T) {
 
 	t.Run("ServiceEntry selects Pod with targetPort number", func(t *testing.T) {
 		_, wc, store, kube := setupTest(t)
-		makeIstioObject(t, store, model.Config{
-			ConfigMeta: model.ConfigMeta{
+		makeIstioObject(t, store, config.Config{
+			ConfigMeta: config.ConfigMeta{
 				Name:             "service-entry",
 				Namespace:        namespace,
 				GroupVersionKind: gvk.ServiceEntry,
@@ -548,7 +549,7 @@ func makeService(t *testing.T, c kubernetes.Interface, svc *v1.Service) {
 	}
 }
 
-func makeIstioObject(t *testing.T, c model.ConfigStore, svc model.Config) {
+func makeIstioObject(t *testing.T, c model.ConfigStore, svc config.Config) {
 	t.Helper()
 	_, err := c.Create(svc)
 	if err != nil {

--- a/pilot/pkg/status/report.go
+++ b/pilot/pkg/status/report.go
@@ -20,9 +20,8 @@ import (
 	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
-	"istio.io/istio/pkg/config/schema/resource"
 )
 
 type DistributionReport struct {
@@ -70,10 +69,10 @@ func (r Resource) String() string {
 func (r *Resource) ToModelKey() string {
 	// we have a resource here, but model keys use kind.  Use the schema to find the correct kind.
 	found, _ := collections.All.FindByPlural(r.Group, r.Version, r.Resource)
-	return model.Key(found.Resource().Kind(), r.Name, r.Namespace)
+	return config.Key(found.Resource().Kind(), r.Name, r.Namespace)
 }
 
-func ResourceFromModelConfig(c model.Config) *Resource {
+func ResourceFromModelConfig(c config.Config) *Resource {
 	gvr := GVKtoGVR(c.GroupVersionKind)
 	if gvr == nil {
 		return nil
@@ -86,7 +85,7 @@ func ResourceFromModelConfig(c model.Config) *Resource {
 	}
 }
 
-func GVKtoGVR(in resource.GroupVersionKind) *schema.GroupVersionResource {
+func GVKtoGVR(in config.GroupVersionKind) *schema.GroupVersionResource {
 	found, ok := collections.All.FindByGroupVersionKind(in)
 	if !ok {
 		return nil

--- a/pilot/pkg/status/reporter.go
+++ b/pilot/pkg/status/reporter.go
@@ -30,6 +30,7 @@ import (
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/xds"
+	"istio.io/istio/pkg/config"
 )
 
 func NewIstioContext(stop <-chan struct{}) context.Context {
@@ -188,7 +189,7 @@ func (r *Reporter) removeCompletedResource(completedResources []Resource) {
 
 // This function must be called every time a resource change is detected by pilot.  This allows us to lookup
 // only the resources we expect to be in flight, not the ones that have already distributed
-func (r *Reporter) AddInProgressResource(res model.Config) {
+func (r *Reporter) AddInProgressResource(res config.Config) {
 	myRes := ResourceFromModelConfig(res)
 	if myRes == nil {
 		scope.Errorf("Unable to locate schema for %v, will not update status.", res)
@@ -202,7 +203,7 @@ func (r *Reporter) AddInProgressResource(res model.Config) {
 	}
 }
 
-func (r *Reporter) DeleteInProgressResource(res model.Config) {
+func (r *Reporter) DeleteInProgressResource(res config.Config) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	delete(r.inProgressResources, res.Key())

--- a/pilot/pkg/status/reporter_test.go
+++ b/pilot/pkg/status/reporter_test.go
@@ -22,8 +22,8 @@ import (
 	"k8s.io/utils/clock"
 
 	"istio.io/istio/pilot/pkg/config/memory"
-	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/xds"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/pkg/ledger"
 )
@@ -65,23 +65,23 @@ func TestBuildReport(t *testing.T) {
 	r := initReporterWithoutStarting()
 	r.store = memory.Make(collections.All)
 	l := ledger.Make(time.Minute)
-	resources := []*model.Config{
+	resources := []*config.Config{
 		{
-			ConfigMeta: model.ConfigMeta{
+			ConfigMeta: config.ConfigMeta{
 				Namespace:       "default",
 				Name:            "foo",
 				ResourceVersion: "1",
 			},
 		},
 		{
-			ConfigMeta: model.ConfigMeta{
+			ConfigMeta: config.ConfigMeta{
 				Namespace:       "default",
 				Name:            "bar",
 				ResourceVersion: "1",
 			},
 		},
 		{
-			ConfigMeta: model.ConfigMeta{
+			ConfigMeta: config.ConfigMeta{
 				Namespace:       "alternate",
 				Name:            "boo",
 				ResourceVersion: "1",

--- a/pilot/pkg/status/reporter_test.go
+++ b/pilot/pkg/status/reporter_test.go
@@ -67,21 +67,21 @@ func TestBuildReport(t *testing.T) {
 	l := ledger.Make(time.Minute)
 	resources := []*config.Config{
 		{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				Namespace:       "default",
 				Name:            "foo",
 				ResourceVersion: "1",
 			},
 		},
 		{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				Namespace:       "default",
 				Name:            "bar",
 				ResourceVersion: "1",
 			},
 		},
 		{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				Namespace:       "alternate",
 				Name:            "boo",
 				ResourceVersion: "1",

--- a/pilot/pkg/xds/ads_common.go
+++ b/pilot/pkg/xds/ads_common.go
@@ -16,12 +16,12 @@ package xds
 
 import (
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/gvk"
-	"istio.io/istio/pkg/config/schema/resource"
 )
 
 // configKindAffectedProxyTypes contains known config types which will affect certain node types.
-var configKindAffectedProxyTypes = map[resource.GroupVersionKind][]model.NodeType{
+var configKindAffectedProxyTypes = map[config.GroupVersionKind][]model.NodeType{
 	gvk.Gateway: {model.Router},
 	gvk.Sidecar: {model.SidecarProxy},
 }

--- a/pilot/pkg/xds/ads_common_test.go
+++ b/pilot/pkg/xds/ads_common_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 
 	model "istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/gvk"
-	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/istio/pkg/spiffe"
 )
 
@@ -46,7 +46,7 @@ func TestProxyNeedsPush(t *testing.T) {
 		want    bool
 	}
 
-	proxyCfg := &model.Config{ConfigMeta: model.ConfigMeta{
+	proxyCfg := &config.Config{ConfigMeta: config.ConfigMeta{
 		Name:      generalName,
 		Namespace: nsName,
 	}}
@@ -56,7 +56,7 @@ func TestProxyNeedsPush(t *testing.T) {
 		SidecarScope: &model.SidecarScope{Config: proxyCfg, RootNamespace: nsRoot}}
 	gateway := &model.Proxy{Type: model.Router}
 
-	sidecarScopeKindNames := map[resource.GroupVersionKind]string{
+	sidecarScopeKindNames := map[config.GroupVersionKind]string{
 		gvk.ServiceEntry: svcName, gvk.VirtualService: vsName, gvk.DestinationRule: drName}
 	for kind, name := range sidecarScopeKindNames {
 		sidecar.SidecarScope.AddConfigDependencies(model.ConfigKey{Kind: kind, Name: name, Namespace: nsName})
@@ -89,7 +89,7 @@ func TestProxyNeedsPush(t *testing.T) {
 				Name: scName, Namespace: nsName}: {}}, false},
 		{"invalid config for sidecar", sidecar, map[model.ConfigKey]struct{}{
 			{
-				Kind: resource.GroupVersionKind{Kind: invalidKind}, Name: generalName, Namespace: nsName}: {}},
+				Kind: config.GroupVersionKind{Kind: invalidKind}, Name: generalName, Namespace: nsName}: {}},
 			true},
 		{"mixture matched and unmatched config for sidecar", sidecar, map[model.ConfigKey]struct{}{
 			{Kind: gvk.DestinationRule, Name: drName, Namespace: nsName}:                   {},
@@ -116,7 +116,7 @@ func TestProxyNeedsPush(t *testing.T) {
 		})
 	}
 
-	sidecarNamespaceScopeTypes := []resource.GroupVersionKind{
+	sidecarNamespaceScopeTypes := []config.GroupVersionKind{
 		gvk.Sidecar, gvk.EnvoyFilter, gvk.AuthorizationPolicy, gvk.RequestAuthentication,
 	}
 	for _, kind := range sidecarNamespaceScopeTypes {

--- a/pilot/pkg/xds/ads_common_test.go
+++ b/pilot/pkg/xds/ads_common_test.go
@@ -46,7 +46,7 @@ func TestProxyNeedsPush(t *testing.T) {
 		want    bool
 	}
 
-	proxyCfg := &config.Config{ConfigMeta: config.ConfigMeta{
+	proxyCfg := &config.Config{Meta: config.Meta{
 		Name:      generalName,
 		Namespace: nsName,
 	}}

--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -31,6 +31,7 @@ import (
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/pkg/adsc"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/collections"
@@ -433,8 +434,8 @@ func TestAdsPushScoping(t *testing.T) {
 	}
 
 	addVirtualService := func(i int, hosts ...string) {
-		if _, err := s.Store().Create(model.Config{
-			ConfigMeta: model.ConfigMeta{
+		if _, err := s.Store().Create(config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind: gvk.VirtualService,
 				Name:             fmt.Sprintf("vs%d", i), Namespace: model.IstioDefaultConfigNamespace},
 			Spec: &networking.VirtualService{
@@ -454,8 +455,8 @@ func TestAdsPushScoping(t *testing.T) {
 		s.Store().Delete(gvk.VirtualService, fmt.Sprintf("vs%d", i), model.IstioDefaultConfigNamespace)
 	}
 	addDestinationRule := func(i int, host string) {
-		if _, err := s.Store().Create(model.Config{
-			ConfigMeta: model.ConfigMeta{
+		if _, err := s.Store().Create(config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind: gvk.DestinationRule,
 				Name:             fmt.Sprintf("dr%d", i), Namespace: model.IstioDefaultConfigNamespace},
 			Spec: &networking.DestinationRule{
@@ -477,8 +478,8 @@ func TestAdsPushScoping(t *testing.T) {
 			},
 		},
 	}
-	if _, err := s.Store().Create(model.Config{
-		ConfigMeta: model.ConfigMeta{
+	if _, err := s.Store().Create(config.Config{
+		ConfigMeta: config.ConfigMeta{
 			GroupVersionKind: gvk.Sidecar,
 			Name:             "sc", Namespace: model.IstioDefaultConfigNamespace},
 		Spec: sc,
@@ -975,9 +976,9 @@ func unmarshallRoute(value []byte) (*route.RouteConfiguration, error) {
 }
 
 func TestXdsCache(t *testing.T) {
-	makeEndpoint := func(addr []*networking.WorkloadEntry) model.Config {
-		return model.Config{
-			ConfigMeta: model.ConfigMeta{
+	makeEndpoint := func(addr []*networking.WorkloadEntry) config.Config {
+		return config.Config{
+			ConfigMeta: config.ConfigMeta{
 				Name:             "service",
 				Namespace:        "default",
 				GroupVersionKind: gvk.ServiceEntry,
@@ -1005,7 +1006,7 @@ func TestXdsCache(t *testing.T) {
 	}
 
 	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
-		Configs: []model.Config{makeEndpoint([]*networking.WorkloadEntry{{Address: "1.2.3.4", Locality: "region/zone"}, {Address: "1.2.3.5", Locality: "notmatch"}})},
+		Configs: []config.Config{makeEndpoint([]*networking.WorkloadEntry{{Address: "1.2.3.4", Locality: "region/zone"}, {Address: "1.2.3.5", Locality: "notmatch"}})},
 	})
 	ads := s.Connect(&model.Proxy{Locality: &core.Locality{Region: "region"}}, nil, watchAll)
 
@@ -1025,8 +1026,8 @@ func TestXdsCache(t *testing.T) {
 	t.Logf("endpoints: %+v", ads.GetEndpoints())
 
 	ads.WaitClear()
-	if _, err := s.Store().Create(model.Config{
-		ConfigMeta: model.ConfigMeta{
+	if _, err := s.Store().Create(config.Config{
+		ConfigMeta: config.ConfigMeta{
 			Name:             "service",
 			Namespace:        "default",
 			GroupVersionKind: gvk.DestinationRule,

--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -435,7 +435,7 @@ func TestAdsPushScoping(t *testing.T) {
 
 	addVirtualService := func(i int, hosts ...string) {
 		if _, err := s.Store().Create(config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind: gvk.VirtualService,
 				Name:             fmt.Sprintf("vs%d", i), Namespace: model.IstioDefaultConfigNamespace},
 			Spec: &networking.VirtualService{
@@ -456,7 +456,7 @@ func TestAdsPushScoping(t *testing.T) {
 	}
 	addDestinationRule := func(i int, host string) {
 		if _, err := s.Store().Create(config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind: gvk.DestinationRule,
 				Name:             fmt.Sprintf("dr%d", i), Namespace: model.IstioDefaultConfigNamespace},
 			Spec: &networking.DestinationRule{
@@ -479,7 +479,7 @@ func TestAdsPushScoping(t *testing.T) {
 		},
 	}
 	if _, err := s.Store().Create(config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			GroupVersionKind: gvk.Sidecar,
 			Name:             "sc", Namespace: model.IstioDefaultConfigNamespace},
 		Spec: sc,
@@ -978,7 +978,7 @@ func unmarshallRoute(value []byte) (*route.RouteConfiguration, error) {
 func TestXdsCache(t *testing.T) {
 	makeEndpoint := func(addr []*networking.WorkloadEntry) config.Config {
 		return config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				Name:             "service",
 				Namespace:        "default",
 				GroupVersionKind: gvk.ServiceEntry,
@@ -1006,7 +1006,12 @@ func TestXdsCache(t *testing.T) {
 	}
 
 	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
-		Configs: []config.Config{makeEndpoint([]*networking.WorkloadEntry{{Address: "1.2.3.4", Locality: "region/zone"}, {Address: "1.2.3.5", Locality: "notmatch"}})},
+		Configs: []config.Config{
+			makeEndpoint([]*networking.WorkloadEntry{
+				{Address: "1.2.3.4", Locality: "region/zone"},
+				{Address: "1.2.3.5", Locality: "notmatch"},
+			}),
+		},
 	})
 	ads := s.Connect(&model.Proxy{Locality: &core.Locality{Region: "region"}}, nil, watchAll)
 
@@ -1027,7 +1032,7 @@ func TestXdsCache(t *testing.T) {
 
 	ads.WaitClear()
 	if _, err := s.Store().Create(config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			Name:             "service",
 			Namespace:        "default",
 			GroupVersionKind: gvk.DestinationRule,

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -33,6 +33,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/util"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pilot/test/xdstest"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/pkg/env"
 	"istio.io/pkg/log"
@@ -241,9 +242,9 @@ func setupTest(t testing.TB, config ConfigInput) (*FakeDiscoveryServer, *model.P
 	return s, proxy
 }
 
-var configCache = map[ConfigInput][]model.Config{}
+var configCache = map[ConfigInput][]config.Config{}
 
-func getConfigsWithCache(t testing.TB, input ConfigInput) []model.Config {
+func getConfigsWithCache(t testing.TB, input ConfigInput) []config.Config {
 	// Config setup is slow for large tests. Cache this and return from cache.
 	// This improves even running a single test, as go will run the full test (including setup) at least twice.
 	if cached, f := configCache[input]; f {
@@ -317,15 +318,15 @@ func logDebug(b *testing.B, m model.Resources) {
 	b.StartTimer()
 }
 
-func createEndpoints(numEndpoints int, numServices int) []model.Config {
-	result := make([]model.Config, 0, numServices)
+func createEndpoints(numEndpoints int, numServices int) []config.Config {
+	result := make([]config.Config, 0, numServices)
 	for s := 0; s < numServices; s++ {
 		endpoints := make([]*networking.WorkloadEntry, 0, numEndpoints)
 		for e := 0; e < numEndpoints; e++ {
 			endpoints = append(endpoints, &networking.WorkloadEntry{Address: fmt.Sprintf("111.%d.%d.%d", e/(256*256), (e/256)%256, e%256)})
 		}
-		result = append(result, model.Config{
-			ConfigMeta: model.ConfigMeta{
+		result = append(result, config.Config{
+			ConfigMeta: config.ConfigMeta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind(),
 				Name:              fmt.Sprintf("foo-%d", s),
 				Namespace:         "default",

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -326,7 +326,7 @@ func createEndpoints(numEndpoints int, numServices int) []config.Config {
 			endpoints = append(endpoints, &networking.WorkloadEntry{Address: fmt.Sprintf("111.%d.%d.%d", e/(256*256), (e/256)%256, e%256)})
 		}
 		result = append(result, config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				GroupVersionKind:  collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind(),
 				Name:              fmt.Sprintf("foo-%d", s),
 				Namespace:         "default",

--- a/pilot/pkg/xds/cds.go
+++ b/pilot/pkg/xds/cds.go
@@ -17,8 +17,8 @@ package xds
 import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/gvk"
-	"istio.io/istio/pkg/config/schema/resource"
 )
 
 type CdsGenerator struct {
@@ -28,7 +28,7 @@ type CdsGenerator struct {
 var _ model.XdsResourceGenerator = &CdsGenerator{}
 
 // Map of all configs that do not impact CDS
-var skippedCdsConfigs = map[resource.GroupVersionKind]struct{}{
+var skippedCdsConfigs = map[config.GroupVersionKind]struct{}{
 	// TODO: investigate if this is correct when PILOT_FILTER_GATEWAY_CLUSTER_CONFIG is set
 	gvk.Gateway:               {},
 	gvk.VirtualService:        {},

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -37,8 +37,8 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	"istio.io/istio/pilot/pkg/serviceregistry/memory"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collection"
-	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/istio/pkg/kube/inject"
 )
 
@@ -374,7 +374,7 @@ func (s *DiscoveryServer) getResourceVersion(nonce, key string, cache map[string
 }
 
 type kubernetesConfig struct {
-	model.Config
+	config.Config
 }
 
 func (k kubernetesConfig) MarshalJSON() ([]byte, error) {
@@ -408,7 +408,7 @@ func (s *DiscoveryServer) configz(w http.ResponseWriter, req *http.Request) {
 // Resource debugging.
 func (s *DiscoveryServer) resourcez(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Add("Content-Type", "application/json")
-	schemas := []resource.GroupVersionKind{}
+	schemas := []config.GroupVersionKind{}
 	s.Env.Schemas().ForEach(func(schema collection.Schema) bool {
 		schemas = append(schemas, schema.Resource().GroupVersionKind())
 		return false

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -27,10 +27,10 @@ import (
 	"istio.io/istio/pilot/pkg/util/sets"
 	v2 "istio.io/istio/pilot/pkg/xds/v2"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
-	"istio.io/istio/pkg/config/schema/resource"
 )
 
 // UpdateServiceShards will list the endpoints and create the shards.
@@ -318,7 +318,7 @@ type EdsGenerator struct {
 var _ model.XdsResourceGenerator = &EdsGenerator{}
 
 // Map of all configs that do not impact EDS
-var skippedEdsConfigs = map[resource.GroupVersionKind]struct{}{
+var skippedEdsConfigs = map[config.GroupVersionKind]struct{}{
 	gvk.Gateway:               {},
 	gvk.VirtualService:        {},
 	gvk.WorkloadGroup:         {},

--- a/pilot/pkg/xds/endpoint_builder.go
+++ b/pilot/pkg/xds/endpoint_builder.go
@@ -24,6 +24,7 @@ import (
 	networkingapi "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/schema/gvk"
 )
@@ -34,7 +35,7 @@ type EndpointBuilder struct {
 	network         string
 	clusterID       string
 	locality        *core.Locality
-	destinationRule *model.Config
+	destinationRule *config.Config
 	service         *model.Service
 
 	// These fields are provided for convenience only

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -37,6 +37,7 @@ import (
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/pkg/adsc"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/test"
@@ -48,7 +49,7 @@ type FakeOptions struct {
 	// If provided, the yaml string will be parsed and used as objects
 	KubernetesObjectString string
 	// If provided, these configs will be used directly
-	Configs []model.Config
+	Configs []config.Config
 	// If provided, the yaml string will be parsed and used as configs
 	ConfigString string
 	// If provided, the ConfigString will be treated as a go template, with this as input params
@@ -103,7 +104,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 
 	// Setup config handlers
 	// TODO code re-use from server.go
-	configHandler := func(_, curr model.Config, event model.Event) {
+	configHandler := func(_, curr config.Config, event model.Event) {
 		pushReq := &model.PushRequest{
 			Full: true,
 			ConfigsUpdated: map[model.ConfigKey]struct{}{{

--- a/pilot/pkg/xds/lds.go
+++ b/pilot/pkg/xds/lds.go
@@ -17,8 +17,8 @@ package xds
 import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/gvk"
-	"istio.io/istio/pkg/config/schema/resource"
 )
 
 type LdsGenerator struct {
@@ -28,7 +28,7 @@ type LdsGenerator struct {
 var _ model.XdsResourceGenerator = &LdsGenerator{}
 
 // Map of all configs that do not impact LDS
-var skippedLdsConfigs = map[resource.GroupVersionKind]struct{}{
+var skippedLdsConfigs = map[config.GroupVersionKind]struct{}{
 	gvk.DestinationRule: {},
 	gvk.WorkloadGroup:   {},
 }

--- a/pilot/pkg/xds/rds.go
+++ b/pilot/pkg/xds/rds.go
@@ -17,8 +17,8 @@ package xds
 import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/gvk"
-	"istio.io/istio/pkg/config/schema/resource"
 )
 
 type RdsGenerator struct {
@@ -28,7 +28,7 @@ type RdsGenerator struct {
 var _ model.XdsResourceGenerator = &RdsGenerator{}
 
 // Map of all configs that do not impact RDS
-var skippedRdsConfigs = map[resource.GroupVersionKind]struct{}{
+var skippedRdsConfigs = map[config.GroupVersionKind]struct{}{
 	gvk.WorkloadEntry:         {},
 	gvk.WorkloadGroup:         {},
 	gvk.AuthorizationPolicy:   {},

--- a/pilot/pkg/xds/xds_cache_test.go
+++ b/pilot/pkg/xds/xds_cache_test.go
@@ -81,9 +81,9 @@ func TestInMemoryCache(t *testing.T) {
 	t.Run("multiple destinationRules", func(t *testing.T) {
 		c := model.NewXdsCache()
 		ep1 := ep1
-		ep1.destinationRule = &config.Config{ConfigMeta: config.ConfigMeta{Name: "a", Namespace: "b"}}
+		ep1.destinationRule = &config.Config{Meta: config.Meta{Name: "a", Namespace: "b"}}
 		ep2 := ep2
-		ep2.destinationRule = &config.Config{ConfigMeta: config.ConfigMeta{Name: "b", Namespace: "b"}}
+		ep2.destinationRule = &config.Config{Meta: config.Meta{Name: "b", Namespace: "b"}}
 		c.Add(ep1, any1)
 		c.Add(ep2, any2)
 

--- a/pilot/pkg/xds/xds_cache_test.go
+++ b/pilot/pkg/xds/xds_cache_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/golang/protobuf/ptypes/any"
 
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/gvk"
 )
 
@@ -80,9 +81,9 @@ func TestInMemoryCache(t *testing.T) {
 	t.Run("multiple destinationRules", func(t *testing.T) {
 		c := model.NewXdsCache()
 		ep1 := ep1
-		ep1.destinationRule = &model.Config{ConfigMeta: model.ConfigMeta{Name: "a", Namespace: "b"}}
+		ep1.destinationRule = &config.Config{ConfigMeta: config.ConfigMeta{Name: "a", Namespace: "b"}}
 		ep2 := ep2
-		ep2.destinationRule = &model.Config{ConfigMeta: model.ConfigMeta{Name: "b", Namespace: "b"}}
+		ep2.destinationRule = &config.Config{ConfigMeta: config.ConfigMeta{Name: "b", Namespace: "b"}}
 		c.Add(ep1, any1)
 		c.Add(ep2, any2)
 

--- a/pilot/test/mock/config.go
+++ b/pilot/test/mock/config.go
@@ -99,7 +99,7 @@ var (
 func Make(namespace string, i int) config2.Config {
 	name := fmt.Sprintf("%s%d", "mock-config", i)
 	return config2.Config{
-		ConfigMeta: config2.ConfigMeta{
+		Meta: config2.Meta{
 			GroupVersionKind: mockGvk,
 			Name:             name,
 			Namespace:        namespace,
@@ -171,7 +171,7 @@ func CheckMapInvariant(r model.ConfigStore, t *testing.T, namespace string, n in
 	}
 
 	invalid := config2.Config{
-		ConfigMeta: config2.ConfigMeta{
+		Meta: config2.Meta{
 			GroupVersionKind: mockGvk,
 			Name:             "invalid",
 			ResourceVersion:  revs[0],
@@ -180,7 +180,7 @@ func CheckMapInvariant(r model.ConfigStore, t *testing.T, namespace string, n in
 	}
 
 	missing := config2.Config{
-		ConfigMeta: config2.ConfigMeta{
+		Meta: config2.Meta{
 			GroupVersionKind: mockGvk,
 			Name:             "missing",
 			ResourceVersion:  revs[0],
@@ -305,7 +305,7 @@ func CheckIstioConfigTypes(store model.ConfigStore, namespace string, t *testing
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			configMeta := config2.ConfigMeta{
+			configMeta := config2.Meta{
 				GroupVersionKind: c.schema.Resource().GroupVersionKind(),
 				Name:             c.configName,
 			}
@@ -314,8 +314,8 @@ func CheckIstioConfigTypes(store model.ConfigStore, namespace string, t *testing
 			}
 
 			if _, err := store.Create(config2.Config{
-				ConfigMeta: configMeta,
-				Spec:       c.spec,
+				Meta: configMeta,
+				Spec: c.spec,
 			}); err != nil {
 				t.Errorf("Post(%v) => got %v", c.name, err)
 			}
@@ -376,7 +376,7 @@ func CheckCacheFreshness(cache model.ConfigStoreCache, namespace string, t *test
 
 			log.Infof("Calling Update(%s)", config.Key())
 			revised := Make(namespace, 1)
-			revised.ConfigMeta = elt.ConfigMeta
+			revised.Meta = elt.Meta
 			if _, err := cache.Update(revised); err != nil {
 				t.Error(err)
 			}

--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -561,7 +561,7 @@ func mcpToPilot(m *mcp.Resource) (*config.Config, error) {
 		return &config.Config{}, nil
 	}
 	c := &config.Config{
-		ConfigMeta: config.ConfigMeta{
+		Meta: config.Meta{
 			ResourceVersion: m.Metadata.Version,
 			Labels:          m.Metadata.Labels,
 			Annotations:     m.Metadata.Annotations,

--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -49,8 +49,8 @@ import (
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/serviceregistry/memory"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
-	"istio.io/istio/pkg/config/schema/resource"
 	"istio.io/istio/pkg/security"
 	"istio.io/istio/security/pkg/nodeagent/cache"
 	"istio.io/pkg/log"
@@ -541,7 +541,7 @@ func (a *ADSC) handleRecv() {
 
 		a.mutex.Lock()
 		if len(gvk) == 3 {
-			gt := resource.GroupVersionKind{Group: gvk[0], Version: gvk[1], Kind: gvk[2]}
+			gt := config.GroupVersionKind{Group: gvk[0], Version: gvk[1], Kind: gvk[2]}
 			a.sync[gt.String()] = time.Now()
 			a.syncCh <- gt.String()
 		}
@@ -556,12 +556,12 @@ func (a *ADSC) handleRecv() {
 	}
 }
 
-func mcpToPilot(m *mcp.Resource) (*model.Config, error) {
+func mcpToPilot(m *mcp.Resource) (*config.Config, error) {
 	if m == nil || m.Metadata == nil {
-		return &model.Config{}, nil
+		return &config.Config{}, nil
 	}
-	c := &model.Config{
-		ConfigMeta: model.ConfigMeta{
+	c := &config.Config{
+		ConfigMeta: config.ConfigMeta{
 			ResourceVersion: m.Metadata.Version,
 			Labels:          m.Metadata.Labels,
 			Annotations:     m.Metadata.Annotations,
@@ -1115,7 +1115,7 @@ func (a *ADSC) handleMCP(gvk []string, rsc *any.Any, valBytes []byte) error {
 		adscLog.Warna("Invalid data ", err, " ", string(valBytes))
 		return err
 	}
-	val.GroupVersionKind = resource.GroupVersionKind{Group: gvk[0], Version: gvk[1], Kind: gvk[2]}
+	val.GroupVersionKind = config.GroupVersionKind{Group: gvk[0], Version: gvk[1], Kind: gvk[2]}
 	cfg := a.Store.Get(val.GroupVersionKind, val.Name, val.Namespace)
 	if cfg == nil {
 		_, err = a.Store.Create(*val)

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -1,0 +1,2 @@
+package config
+

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -1,2 +1,108 @@
 package config
 
+import (
+	"fmt"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+)
+
+// ConfigMeta is metadata attached to each configuration unit.
+// The revision is optional, and if provided, identifies the
+// last update operation on the object.
+type ConfigMeta struct {
+	// GroupVersionKind is a short configuration name that matches the content message type
+	// (e.g. "route-rule")
+	GroupVersionKind GroupVersionKind `json:"type,omitempty"`
+
+	// Name is a unique immutable identifier in a namespace
+	Name string `json:"name,omitempty"`
+
+	// Namespace defines the space for names (optional for some types),
+	// applications may choose to use namespaces for a variety of purposes
+	// (security domains, fault domains, organizational domains)
+	Namespace string `json:"namespace,omitempty"`
+
+	// Domain defines the suffix of the fully qualified name past the namespace.
+	// Domain is not a part of the unique key unlike name and namespace.
+	Domain string `json:"domain,omitempty"`
+
+	// Map of string keys and values that can be used to organize and categorize
+	// (scope and select) objects.
+	Labels map[string]string `json:"labels,omitempty"`
+
+	// Annotations is an unstructured key value map stored with a resource that may be
+	// set by external tools to store and retrieve arbitrary metadata. They are not
+	// queryable and should be preserved when modifying objects.
+	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// ResourceVersion is an opaque identifier for tracking updates to the config registry.
+	// The implementation may use a change index or a commit log for the revision.
+	// The config client should not make any assumptions about revisions and rely only on
+	// exact equality to implement optimistic concurrency of read-write operations.
+	//
+	// The lifetime of an object of a particular revision depends on the underlying data store.
+	// The data store may compactify old revisions in the interest of storage optimization.
+	//
+	// An empty revision carries a special meaning that the associated object has
+	// not been stored and assigned a revision.
+	ResourceVersion string `json:"resourceVersion,omitempty"`
+
+	// CreationTimestamp records the creation time
+	CreationTimestamp time.Time `json:"creationTimestamp,omitempty"`
+}
+
+// Config is a configuration unit consisting of the type of configuration, the
+// key identifier that is unique per type, and the content represented as a
+// protobuf message.
+type Config struct {
+	ConfigMeta
+
+	// Spec holds the configuration object as a gogo protobuf message
+	Spec proto.Message
+}
+
+// Key function for the configuration objects
+func Key(typ, name, namespace string) string {
+	return fmt.Sprintf("%s/%s/%s", typ, namespace, name)
+}
+
+// Key is the unique identifier for a configuration object
+// TODO: this is *not* unique - needs the version and group
+func (meta *ConfigMeta) Key() string {
+	return Key(meta.GroupVersionKind.Kind, meta.Name, meta.Namespace)
+}
+
+func (c Config) DeepCopy() Config {
+	var clone Config
+	clone.ConfigMeta = c.ConfigMeta
+	if c.Labels != nil {
+		clone.Labels = make(map[string]string)
+		for k, v := range c.Labels {
+			clone.Labels[k] = v
+		}
+	}
+	if c.Annotations != nil {
+		clone.Annotations = make(map[string]string)
+		for k, v := range c.Annotations {
+			clone.Annotations[k] = v
+		}
+	}
+	clone.Spec = proto.Clone(c.Spec)
+	return clone
+}
+
+var _ fmt.Stringer = GroupVersionKind{}
+
+type GroupVersionKind struct {
+	Group   string `json:"group"`
+	Version string `json:"version"`
+	Kind    string `json:"kind"`
+}
+
+func (g GroupVersionKind) String() string {
+	if g.Group == "" {
+		return "core/" + g.Version + "/" + g.Kind
+	}
+	return g.Group + "/" + g.Version + "/" + g.Kind
+}

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config
 
 import (

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -21,10 +21,10 @@ import (
 	"github.com/gogo/protobuf/proto"
 )
 
-// ConfigMeta is metadata attached to each configuration unit.
+// Meta is metadata attached to each configuration unit.
 // The revision is optional, and if provided, identifies the
 // last update operation on the object.
-type ConfigMeta struct {
+type Meta struct {
 	// GroupVersionKind is a short configuration name that matches the content message type
 	// (e.g. "route-rule")
 	GroupVersionKind GroupVersionKind `json:"type,omitempty"`
@@ -70,7 +70,7 @@ type ConfigMeta struct {
 // key identifier that is unique per type, and the content represented as a
 // protobuf message.
 type Config struct {
-	ConfigMeta
+	Meta
 
 	// Spec holds the configuration object as a gogo protobuf message
 	Spec proto.Message
@@ -83,13 +83,13 @@ func Key(typ, name, namespace string) string {
 
 // Key is the unique identifier for a configuration object
 // TODO: this is *not* unique - needs the version and group
-func (meta *ConfigMeta) Key() string {
+func (meta *Meta) Key() string {
 	return Key(meta.GroupVersionKind.Kind, meta.Name, meta.Namespace)
 }
 
 func (c Config) DeepCopy() Config {
 	var clone Config
-	clone.ConfigMeta = c.ConfigMeta
+	clone.Meta = c.Meta
 	if c.Labels != nil {
 		clone.Labels = make(map[string]string)
 		for k, v := range c.Labels {

--- a/pkg/config/schema/codegen/collections.go
+++ b/pkg/config/schema/codegen/collections.go
@@ -66,7 +66,7 @@ var (
 			Proto: "{{ .Resource.Proto }}",
 			ProtoPackage: "{{ .Resource.ProtoPackage }}",
 			ClusterScoped: {{ .Resource.ClusterScoped }},
-			ValidateProto: validation.{{ .Resource.Validate }},
+			ValidateConfig: validation.{{ .Resource.Validate }},
 		}.MustBuild(),
 	}.MustBuild()
 {{ end }}

--- a/pkg/config/schema/codegen/collections.go
+++ b/pkg/config/schema/codegen/collections.go
@@ -66,7 +66,7 @@ var (
 			Proto: "{{ .Resource.Proto }}",
 			ProtoPackage: "{{ .Resource.ProtoPackage }}",
 			ClusterScoped: {{ .Resource.ClusterScoped }},
-			ValidateConfig: validation.{{ .Resource.Validate }},
+			ValidateProto: validation.{{ .Resource.Validate }},
 		}.MustBuild(),
 	}.MustBuild()
 {{ end }}

--- a/pkg/config/schema/codegen/collections_test.go
+++ b/pkg/config/schema/codegen/collections_test.go
@@ -102,7 +102,7 @@ var (
 			Proto: "google.protobuf.Struct",
 			ProtoPackage: "github.com/gogo/protobuf/types",
 			ClusterScoped: false,
-			ValidateProto: validation.EmptyValidate,
+			ValidateConfig: validation.EmptyValidate,
 		}.MustBuild(),
 	}.MustBuild()
 
@@ -119,7 +119,7 @@ var (
 			Proto: "google.protobuf.Struct",
 			ProtoPackage: "github.com/gogo/protobuf/types",
 			ClusterScoped: true,
-			ValidateProto: validation.EmptyValidate,
+			ValidateConfig: validation.EmptyValidate,
 		}.MustBuild(),
 	}.MustBuild()
 

--- a/pkg/config/schema/codegen/collections_test.go
+++ b/pkg/config/schema/codegen/collections_test.go
@@ -102,7 +102,7 @@ var (
 			Proto: "google.protobuf.Struct",
 			ProtoPackage: "github.com/gogo/protobuf/types",
 			ClusterScoped: false,
-			ValidateConfig: validation.EmptyValidate,
+			ValidateProto: validation.EmptyValidate,
 		}.MustBuild(),
 	}.MustBuild()
 
@@ -119,7 +119,7 @@ var (
 			Proto: "google.protobuf.Struct",
 			ProtoPackage: "github.com/gogo/protobuf/types",
 			ClusterScoped: true,
-			ValidateConfig: validation.EmptyValidate,
+			ValidateProto: validation.EmptyValidate,
 		}.MustBuild(),
 	}.MustBuild()
 

--- a/pkg/config/schema/collection/schemas.go
+++ b/pkg/config/schema/collection/schemas.go
@@ -22,7 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-multierror"
 
-	"istio.io/istio/pkg/config/schema/resource"
+	"istio.io/istio/pkg/config"
 )
 
 // Schemas contains metadata about configuration resources.
@@ -110,7 +110,7 @@ func (s Schemas) MustFind(collection string) Schema {
 }
 
 // FindByKind searches and returns the first schema with the given kind
-func (s Schemas) FindByGroupVersionKind(gvk resource.GroupVersionKind) (Schema, bool) {
+func (s Schemas) FindByGroupVersionKind(gvk config.GroupVersionKind) (Schema, bool) {
 	for _, rs := range s.byAddOrder {
 		if rs.Resource().GroupVersionKind() == gvk {
 			return rs, true
@@ -134,7 +134,7 @@ func (s Schemas) FindByPlural(group, version, plural string) (Schema, bool) {
 }
 
 // MustFind calls FindByGroupVersionKind and panics if not found.
-func (s Schemas) MustFindByGroupVersionKind(gvk resource.GroupVersionKind) Schema {
+func (s Schemas) MustFindByGroupVersionKind(gvk config.GroupVersionKind) Schema {
 	r, found := s.FindByGroupVersionKind(gvk)
 	if !found {
 		panic(fmt.Sprintf("Schemas.MustFindByGroupVersionKind: unable to find %s", gvk))

--- a/pkg/config/schema/collection/schemas_test.go
+++ b/pkg/config/schema/collection/schemas_test.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/gogo/protobuf/types"
 	. "github.com/onsi/gomega"
 
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/resource"
 )
@@ -160,7 +161,7 @@ func TestSchema_FindByGroupVersionKind(t *testing.T) {
 
 	schemas := collection.SchemasFor(s)
 
-	s2, found := schemas.FindByGroupVersionKind(resource.GroupVersionKind{
+	s2, found := schemas.FindByGroupVersionKind(config.GroupVersionKind{
 		Group:   "mygroup",
 		Version: "v1",
 		Kind:    "Empty",
@@ -168,7 +169,7 @@ func TestSchema_FindByGroupVersionKind(t *testing.T) {
 	g.Expect(found).To(BeTrue())
 	g.Expect(s2).To(Equal(s))
 
-	_, found = schemas.FindByGroupVersionKind(resource.GroupVersionKind{
+	_, found = schemas.FindByGroupVersionKind(config.GroupVersionKind{
 		Group:   "fake",
 		Version: "v1",
 		Kind:    "Empty",
@@ -195,7 +196,7 @@ func TestSchema_MustFindByGroupVersionKind(t *testing.T) {
 	b.MustAdd(s)
 	schemas := b.Build()
 
-	got := schemas.MustFindByGroupVersionKind(resource.GroupVersionKind{
+	got := schemas.MustFindByGroupVersionKind(config.GroupVersionKind{
 		Group:   "mygroup",
 		Version: "v1",
 		Kind:    "Empty",
@@ -212,7 +213,7 @@ func TestSchema_MustFindByGroupVersionKind_Panic(t *testing.T) {
 	}()
 
 	schemas := collection.NewSchemasBuilder().Build()
-	_ = schemas.MustFindByGroupVersionKind(resource.GroupVersionKind{
+	_ = schemas.MustFindByGroupVersionKind(config.GroupVersionKind{
 		Group:   "mygroup",
 		Version: "v1",
 		Kind:    "Empty",

--- a/pkg/config/schema/collections/mock.go
+++ b/pkg/config/schema/collections/mock.go
@@ -17,11 +17,10 @@ package collections
 import (
 	"errors"
 
-	"github.com/gogo/protobuf/proto"
-
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/resource"
-	"istio.io/istio/pkg/test/config"
+	testconfig "istio.io/istio/pkg/test/config"
 )
 
 var (
@@ -37,8 +36,8 @@ var (
 			Version:       "v1",
 			Proto:         "test.MockConfig",
 			ProtoPackage:  "istio.io/istio/pkg/test/config",
-			ValidateProto: func(name, namespace string, msg proto.Message) error {
-				if msg.(*config.MockConfig).Key == "" {
+			ValidateProto: func(cfg config.Config) error {
+				if cfg.Spec.(*testconfig.MockConfig).Key == "" {
 					return errors.New("empty key")
 				}
 				return nil

--- a/pkg/config/schema/fuzz_test.go
+++ b/pkg/config/schema/fuzz_test.go
@@ -79,7 +79,7 @@ func TestValidationFuzzing(t *testing.T) {
 				}
 				obj := istiofuzz.Fuzz(t, kgvk, scheme, fz)
 				iobj = crdclient.TranslateObject(obj, gvk, "cluster.local")
-				_ = r.Resource().ValidateProto(iobj.Name, iobj.Namespace, iobj.Spec)
+				_ = r.Resource().ValidateConfig(iobj.Name, iobj.Namespace, iobj.Spec)
 			}
 		})
 	}

--- a/pkg/config/schema/fuzz_test.go
+++ b/pkg/config/schema/fuzz_test.go
@@ -35,7 +35,7 @@ import (
 	clientnetworkingbeta "istio.io/client-go/pkg/apis/networking/v1beta1"
 	clientsecurity "istio.io/client-go/pkg/apis/security/v1beta1"
 	"istio.io/istio/pilot/pkg/config/kube/crdclient"
-	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
 	istiofuzz "istio.io/istio/pkg/config/schema/fuzz"
 )
@@ -63,7 +63,7 @@ func TestValidationFuzzing(t *testing.T) {
 	fz := createFuzzer()
 	for _, r := range collections.Pilot.All() {
 		t.Run(r.VariableName(), func(t *testing.T) {
-			var iobj *model.Config
+			var iobj *config.Config
 			defer func() {
 				if err := recover(); err != nil {
 					logPanic(t, err)

--- a/pkg/config/schema/fuzz_test.go
+++ b/pkg/config/schema/fuzz_test.go
@@ -79,7 +79,7 @@ func TestValidationFuzzing(t *testing.T) {
 				}
 				obj := istiofuzz.Fuzz(t, kgvk, scheme, fz)
 				iobj = crdclient.TranslateObject(obj, gvk, "cluster.local")
-				_ = r.Resource().ValidateConfig(iobj.Name, iobj.Namespace, iobj.Spec)
+				_ = r.Resource().ValidateConfig(*iobj)
 			}
 		})
 	}

--- a/pkg/config/schema/resource/schema.go
+++ b/pkg/config/schema/resource/schema.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/validation"
 )
@@ -31,7 +32,7 @@ type Schema interface {
 	fmt.Stringer
 
 	// GroupVersionKind of the resource. This is the only way to uniquely identify a resource.
-	GroupVersionKind() GroupVersionKind
+	GroupVersionKind() config.GroupVersionKind
 
 	// GroupVersionResource of the resource.
 	GroupVersionResource() schema.GroupVersionResource
@@ -76,21 +77,6 @@ type Schema interface {
 	// Equal is a helper function for testing equality between Schema instances. This supports comparison
 	// with the cmp library.
 	Equal(other Schema) bool
-}
-
-type GroupVersionKind struct {
-	Group   string `json:"group"`
-	Version string `json:"version"`
-	Kind    string `json:"kind"`
-}
-
-var _ fmt.Stringer = GroupVersionKind{}
-
-func (g GroupVersionKind) String() string {
-	if g.Group == "" {
-		return "core/" + g.Version + "/" + g.Kind
-	}
-	return g.Group + "/" + g.Version + "/" + g.Kind
 }
 
 // Builder for a Schema.
@@ -149,7 +135,7 @@ func (b Builder) BuildNoValidate() Schema {
 
 	return &schemaImpl{
 		clusterScoped: b.ClusterScoped,
-		gvk: GroupVersionKind{
+		gvk: config.GroupVersionKind{
 			Group:   b.Group,
 			Version: b.Version,
 			Kind:    b.Kind,
@@ -164,7 +150,7 @@ func (b Builder) BuildNoValidate() Schema {
 
 type schemaImpl struct {
 	clusterScoped  bool
-	gvk            GroupVersionKind
+	gvk            config.GroupVersionKind
 	plural         string
 	apiVersion     string
 	proto          string
@@ -172,7 +158,7 @@ type schemaImpl struct {
 	validateConfig validation.ValidateFunc
 }
 
-func (s *schemaImpl) GroupVersionKind() GroupVersionKind {
+func (s *schemaImpl) GroupVersionKind() config.GroupVersionKind {
 	return s.gvk
 }
 
@@ -273,8 +259,8 @@ func (s *schemaImpl) Equal(o Schema) bool {
 }
 
 // FromKubernetesGVK converts a Kubernetes GVK to an Istio GVK
-func FromKubernetesGVK(in *schema.GroupVersionKind) GroupVersionKind {
-	return GroupVersionKind{
+func FromKubernetesGVK(in *schema.GroupVersionKind) config.GroupVersionKind {
+	return config.GroupVersionKind{
 		Group:   in.Group,
 		Version: in.Version,
 		Kind:    in.Kind,

--- a/pkg/config/schema/resource/schema.go
+++ b/pkg/config/schema/resource/schema.go
@@ -69,9 +69,9 @@ type Schema interface {
 	// Validate this schema.
 	Validate() error
 
-	// ValidateProto validates that the given protocol buffer message is of the correct type for this schema
+	// ValidateConfig validates that the given config message is of the correct type for this schema
 	// and that the contents are valid.
-	ValidateProto(name, namespace string, config proto.Message) error
+	ValidateConfig(name, namespace string, config proto.Message) error
 
 	// Equal is a helper function for testing equality between Schema instances. This supports comparison
 	// with the cmp library.
@@ -154,22 +154,22 @@ func (b Builder) BuildNoValidate() Schema {
 			Version: b.Version,
 			Kind:    b.Kind,
 		},
-		plural:        b.Plural,
-		apiVersion:    b.Group + "/" + b.Version,
-		proto:         b.Proto,
-		protoPackage:  b.ProtoPackage,
-		validateProto: b.ValidateProto,
+		plural:         b.Plural,
+		apiVersion:     b.Group + "/" + b.Version,
+		proto:          b.Proto,
+		protoPackage:   b.ProtoPackage,
+		validateConfig: b.ValidateProto,
 	}
 }
 
 type schemaImpl struct {
-	clusterScoped bool
-	gvk           GroupVersionKind
-	plural        string
-	apiVersion    string
-	proto         string
-	protoPackage  string
-	validateProto validation.ValidateFunc
+	clusterScoped  bool
+	gvk            GroupVersionKind
+	plural         string
+	apiVersion     string
+	proto          string
+	protoPackage   string
+	validateConfig validation.ValidateFunc
 }
 
 func (s *schemaImpl) GroupVersionKind() GroupVersionKind {
@@ -258,8 +258,8 @@ func (s *schemaImpl) MustNewProtoInstance() proto.Message {
 	return p
 }
 
-func (s *schemaImpl) ValidateProto(name, namespace string, config proto.Message) error {
-	return s.validateProto(name, namespace, config)
+func (s *schemaImpl) ValidateConfig(name, namespace string, config proto.Message) error {
+	return s.validateConfig(name, namespace, config)
 }
 
 func (s *schemaImpl) Equal(o Schema) bool {

--- a/pkg/config/schema/resource/schema.go
+++ b/pkg/config/schema/resource/schema.go
@@ -72,7 +72,7 @@ type Schema interface {
 
 	// ValidateConfig validates that the given config message is of the correct type for this schema
 	// and that the contents are valid.
-	ValidateConfig(name, namespace string, config proto.Message) error
+	ValidateConfig(cfg config.Config) error
 
 	// Equal is a helper function for testing equality between Schema instances. This supports comparison
 	// with the cmp library.
@@ -244,8 +244,8 @@ func (s *schemaImpl) MustNewProtoInstance() proto.Message {
 	return p
 }
 
-func (s *schemaImpl) ValidateConfig(name, namespace string, config proto.Message) error {
-	return s.validateConfig(name, namespace, config)
+func (s *schemaImpl) ValidateConfig(cfg config.Config) error {
+	return s.validateConfig(cfg)
 }
 
 func (s *schemaImpl) Equal(o Schema) bool {

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -33,10 +33,8 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 	security_beta "istio.io/api/security/v1beta1"
 	type_beta "istio.io/api/type/v1beta1"
-	"istio.io/pkg/log"
-
 	"istio.io/istio/pilot/pkg/features"
-	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/gateway"
 	"istio.io/istio/pkg/config/host"
@@ -45,6 +43,7 @@ import (
 	"istio.io/istio/pkg/config/security"
 	"istio.io/istio/pkg/config/visibility"
 	"istio.io/istio/pkg/config/xds"
+	"istio.io/pkg/log"
 )
 
 // Constants for duration fields
@@ -101,7 +100,7 @@ var (
 
 	// EmptyValidate is a Validate that does nothing and returns no error.
 	EmptyValidate = registerValidateFunc("EmptyValidate",
-		func(model.Config) error {
+		func(config.Config) error {
 			return nil
 		})
 
@@ -109,7 +108,7 @@ var (
 )
 
 // ValidateFunc defines a validation func for an API proto.
-type ValidateFunc func(config model.Config) error
+type ValidateFunc func(config config.Config) error
 
 // IsValidateFunc indicates whether there is a validation function with the given name.
 func IsValidateFunc(name string) bool {
@@ -273,7 +272,7 @@ func ValidateUnixAddress(addr string) error {
 
 // ValidateGateway checks gateway specifications
 var ValidateGateway = registerValidateFunc("ValidateGateway",
-	func(cfg model.Config) (errs error) {
+	func(cfg config.Config) (errs error) {
 		name := cfg.Name
 		// Gateway name must conform to the DNS label format (no dots)
 		if !labels.IsDNS1123Label(name) {
@@ -416,7 +415,7 @@ func validateTLSOptions(tls *networking.ServerTLSSettings) (errs error) {
 
 // ValidateDestinationRule checks proxy policies
 var ValidateDestinationRule = registerValidateFunc("ValidateDestinationRule",
-	func(cfg model.Config) (errs error) {
+	func(cfg config.Config) (errs error) {
 		rule, ok := cfg.Spec.(*networking.DestinationRule)
 		if !ok {
 			return fmt.Errorf("cannot cast to destination rule")
@@ -511,7 +510,7 @@ func validateAlphaWorkloadSelector(selector *networking.WorkloadSelector) error 
 
 // ValidateEnvoyFilter checks envoy filter config supplied by user
 var ValidateEnvoyFilter = registerValidateFunc("ValidateEnvoyFilter",
-	func(cfg model.Config) (errs error) {
+	func(cfg config.Config) (errs error) {
 		rule, ok := cfg.Spec.(*networking.EnvoyFilter)
 		if !ok {
 			return fmt.Errorf("cannot cast to Envoy filter")
@@ -671,7 +670,7 @@ func validateNamespaceSlashWildcardHostname(hostname string, isGateway bool) (er
 
 // ValidateSidecar checks sidecar config supplied by user
 var ValidateSidecar = registerValidateFunc("ValidateSidecar",
-	func(cfg model.Config) (errs error) {
+	func(cfg config.Config) (errs error) {
 		rule, ok := cfg.Spec.(*networking.Sidecar)
 		if !ok {
 			return fmt.Errorf("cannot cast to Sidecar")
@@ -1335,7 +1334,7 @@ func validateWorkloadSelector(selector *type_beta.WorkloadSelector) error {
 
 // ValidateAuthorizationPolicy checks that AuthorizationPolicy is well-formed.
 var ValidateAuthorizationPolicy = registerValidateFunc("ValidateAuthorizationPolicy",
-	func(cfg model.Config) error {
+	func(cfg config.Config) error {
 		in, ok := cfg.Spec.(*security_beta.AuthorizationPolicy)
 		if !ok {
 			return fmt.Errorf("cannot cast to AuthorizationPolicy")
@@ -1437,7 +1436,7 @@ var ValidateAuthorizationPolicy = registerValidateFunc("ValidateAuthorizationPol
 
 // ValidateRequestAuthentication checks that request authentication spec is well-formed.
 var ValidateRequestAuthentication = registerValidateFunc("ValidateRequestAuthentication",
-	func(cfg model.Config) error {
+	func(cfg config.Config) error {
 		in, ok := cfg.Spec.(*security_beta.RequestAuthentication)
 		if !ok {
 			return errors.New("cannot cast to RequestAuthentication")
@@ -1491,7 +1490,7 @@ func validateJwtRule(rule *security_beta.JWTRule) (errs error) {
 
 // ValidatePeerAuthentication checks that peer authentication spec is well-formed.
 var ValidatePeerAuthentication = registerValidateFunc("ValidatePeerAuthentication",
-	func(cfg model.Config) error {
+	func(cfg config.Config) error {
 		in, ok := cfg.Spec.(*security_beta.PeerAuthentication)
 		if !ok {
 			return errors.New("cannot cast to PeerAuthentication")
@@ -1523,7 +1522,7 @@ var ValidatePeerAuthentication = registerValidateFunc("ValidatePeerAuthenticatio
 
 // ValidateVirtualService checks that a v1alpha3 route rule is well-formed.
 var ValidateVirtualService = registerValidateFunc("ValidateVirtualService",
-	func(cfg model.Config) (errs error) {
+	func(cfg config.Config) (errs error) {
 		virtualService, ok := cfg.Spec.(*networking.VirtualService)
 		if !ok {
 			return errors.New("cannot cast to virtual service")
@@ -2131,7 +2130,7 @@ func validateHTTPRewrite(rewrite *networking.HTTPRewrite) error {
 
 // ValidateWorkloadEntry validates a workload entry.
 var ValidateWorkloadEntry = registerValidateFunc("ValidateWorkloadEntry",
-	func(cfg model.Config) (errs error) {
+	func(cfg config.Config) (errs error) {
 		we, ok := cfg.Spec.(*networking.WorkloadEntry)
 		if !ok {
 			return fmt.Errorf("cannot cast to workload entry")
@@ -2146,7 +2145,7 @@ var ValidateWorkloadEntry = registerValidateFunc("ValidateWorkloadEntry",
 
 // ValidateServiceEntry validates a service entry.
 var ValidateServiceEntry = registerValidateFunc("ValidateServiceEntry",
-	func(cfg model.Config) (errs error) {
+	func(cfg config.Config) (errs error) {
 		serviceEntry, ok := cfg.Spec.(*networking.ServiceEntry)
 		if !ok {
 			return fmt.Errorf("cannot cast to service entry")

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	wellknown "github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 	"github.com/hashicorp/go-multierror"
 
@@ -34,7 +33,10 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 	security_beta "istio.io/api/security/v1beta1"
 	type_beta "istio.io/api/type/v1beta1"
+	"istio.io/pkg/log"
+
 	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/gateway"
 	"istio.io/istio/pkg/config/host"
@@ -43,7 +45,6 @@ import (
 	"istio.io/istio/pkg/config/security"
 	"istio.io/istio/pkg/config/visibility"
 	"istio.io/istio/pkg/config/xds"
-	"istio.io/pkg/log"
 )
 
 // Constants for duration fields
@@ -100,7 +101,7 @@ var (
 
 	// EmptyValidate is a Validate that does nothing and returns no error.
 	EmptyValidate = registerValidateFunc("EmptyValidate",
-		func(string, string, proto.Message) error {
+		func(model.Config) error {
 			return nil
 		})
 
@@ -108,7 +109,7 @@ var (
 )
 
 // ValidateFunc defines a validation func for an API proto.
-type ValidateFunc func(name, namespace string, config proto.Message) error
+type ValidateFunc func(config model.Config) error
 
 // IsValidateFunc indicates whether there is a validation function with the given name.
 func IsValidateFunc(name string) bool {
@@ -272,14 +273,15 @@ func ValidateUnixAddress(addr string) error {
 
 // ValidateGateway checks gateway specifications
 var ValidateGateway = registerValidateFunc("ValidateGateway",
-	func(name, _ string, msg proto.Message) (errs error) {
+	func(cfg model.Config) (errs error) {
+		name := cfg.Name
 		// Gateway name must conform to the DNS label format (no dots)
 		if !labels.IsDNS1123Label(name) {
 			errs = appendErrors(errs, fmt.Errorf("invalid gateway name: %q", name))
 		}
-		value, ok := msg.(*networking.Gateway)
+		value, ok := cfg.Spec.(*networking.Gateway)
 		if !ok {
-			errs = appendErrors(errs, fmt.Errorf("cannot cast to gateway: %#v", msg))
+			errs = appendErrors(errs, fmt.Errorf("cannot cast to gateway: %#v", cfg.Spec))
 			return
 		}
 
@@ -414,8 +416,8 @@ func validateTLSOptions(tls *networking.ServerTLSSettings) (errs error) {
 
 // ValidateDestinationRule checks proxy policies
 var ValidateDestinationRule = registerValidateFunc("ValidateDestinationRule",
-	func(_, namespace string, msg proto.Message) (errs error) {
-		rule, ok := msg.(*networking.DestinationRule)
+	func(cfg model.Config) (errs error) {
+		rule, ok := cfg.Spec.(*networking.DestinationRule)
 		if !ok {
 			return fmt.Errorf("cannot cast to destination rule")
 		}
@@ -432,7 +434,7 @@ var ValidateDestinationRule = registerValidateFunc("ValidateDestinationRule",
 			errs = appendErrors(errs, validateSubset(subset))
 		}
 
-		errs = appendErrors(errs, validateExportTo(namespace, rule.ExportTo, false))
+		errs = appendErrors(errs, validateExportTo(cfg.Namespace, rule.ExportTo, false))
 		return
 	})
 
@@ -509,8 +511,8 @@ func validateAlphaWorkloadSelector(selector *networking.WorkloadSelector) error 
 
 // ValidateEnvoyFilter checks envoy filter config supplied by user
 var ValidateEnvoyFilter = registerValidateFunc("ValidateEnvoyFilter",
-	func(_, _ string, msg proto.Message) (errs error) {
-		rule, ok := msg.(*networking.EnvoyFilter)
+	func(cfg model.Config) (errs error) {
+		rule, ok := cfg.Spec.(*networking.EnvoyFilter)
 		if !ok {
 			return fmt.Errorf("cannot cast to Envoy filter")
 		}
@@ -669,8 +671,8 @@ func validateNamespaceSlashWildcardHostname(hostname string, isGateway bool) (er
 
 // ValidateSidecar checks sidecar config supplied by user
 var ValidateSidecar = registerValidateFunc("ValidateSidecar",
-	func(_, _ string, msg proto.Message) (errs error) {
-		rule, ok := msg.(*networking.Sidecar)
+	func(cfg model.Config) (errs error) {
+		rule, ok := cfg.Spec.(*networking.Sidecar)
 		if !ok {
 			return fmt.Errorf("cannot cast to Sidecar")
 		}
@@ -1333,11 +1335,13 @@ func validateWorkloadSelector(selector *type_beta.WorkloadSelector) error {
 
 // ValidateAuthorizationPolicy checks that AuthorizationPolicy is well-formed.
 var ValidateAuthorizationPolicy = registerValidateFunc("ValidateAuthorizationPolicy",
-	func(name, namespace string, msg proto.Message) error {
-		in, ok := msg.(*security_beta.AuthorizationPolicy)
+	func(cfg model.Config) error {
+		in, ok := cfg.Spec.(*security_beta.AuthorizationPolicy)
 		if !ok {
 			return fmt.Errorf("cannot cast to AuthorizationPolicy")
 		}
+		name := cfg.Name
+		namespace := cfg.Namespace
 
 		if err := validateWorkloadSelector(in.Selector); err != nil {
 			return err
@@ -1433,8 +1437,8 @@ var ValidateAuthorizationPolicy = registerValidateFunc("ValidateAuthorizationPol
 
 // ValidateRequestAuthentication checks that request authentication spec is well-formed.
 var ValidateRequestAuthentication = registerValidateFunc("ValidateRequestAuthentication",
-	func(name, namespace string, msg proto.Message) error {
-		in, ok := msg.(*security_beta.RequestAuthentication)
+	func(cfg model.Config) error {
+		in, ok := cfg.Spec.(*security_beta.RequestAuthentication)
 		if !ok {
 			return errors.New("cannot cast to RequestAuthentication")
 		}
@@ -1487,8 +1491,8 @@ func validateJwtRule(rule *security_beta.JWTRule) (errs error) {
 
 // ValidatePeerAuthentication checks that peer authentication spec is well-formed.
 var ValidatePeerAuthentication = registerValidateFunc("ValidatePeerAuthentication",
-	func(name, namespace string, msg proto.Message) error {
-		in, ok := msg.(*security_beta.PeerAuthentication)
+	func(cfg model.Config) error {
+		in, ok := cfg.Spec.(*security_beta.PeerAuthentication)
 		if !ok {
 			return errors.New("cannot cast to PeerAuthentication")
 		}
@@ -1519,8 +1523,8 @@ var ValidatePeerAuthentication = registerValidateFunc("ValidatePeerAuthenticatio
 
 // ValidateVirtualService checks that a v1alpha3 route rule is well-formed.
 var ValidateVirtualService = registerValidateFunc("ValidateVirtualService",
-	func(_, namespace string, msg proto.Message) (errs error) {
-		virtualService, ok := msg.(*networking.VirtualService)
+	func(cfg model.Config) (errs error) {
+		virtualService, ok := cfg.Spec.(*networking.VirtualService)
 		if !ok {
 			return errors.New("cannot cast to virtual service")
 		}
@@ -1613,7 +1617,7 @@ var ValidateVirtualService = registerValidateFunc("ValidateVirtualService",
 			errs = appendErrors(errs, validateTCPRoute(tcpRoute))
 		}
 
-		errs = appendErrors(errs, validateExportTo(namespace, virtualService.ExportTo, false))
+		errs = appendErrors(errs, validateExportTo(cfg.Namespace, virtualService.ExportTo, false))
 		return
 	})
 
@@ -2127,8 +2131,8 @@ func validateHTTPRewrite(rewrite *networking.HTTPRewrite) error {
 
 // ValidateWorkloadEntry validates a workload entry.
 var ValidateWorkloadEntry = registerValidateFunc("ValidateWorkloadEntry",
-	func(_, _ string, config proto.Message) (errs error) {
-		we, ok := config.(*networking.WorkloadEntry)
+	func(cfg model.Config) (errs error) {
+		we, ok := cfg.Spec.(*networking.WorkloadEntry)
 		if !ok {
 			return fmt.Errorf("cannot cast to workload entry")
 		}
@@ -2142,8 +2146,8 @@ var ValidateWorkloadEntry = registerValidateFunc("ValidateWorkloadEntry",
 
 // ValidateServiceEntry validates a service entry.
 var ValidateServiceEntry = registerValidateFunc("ValidateServiceEntry",
-	func(_, namespace string, config proto.Message) (errs error) {
-		serviceEntry, ok := config.(*networking.ServiceEntry)
+	func(cfg model.Config) (errs error) {
+		serviceEntry, ok := cfg.Spec.(*networking.ServiceEntry)
 		if !ok {
 			return fmt.Errorf("cannot cast to service entry")
 		}
@@ -2294,7 +2298,7 @@ var ValidateServiceEntry = registerValidateFunc("ValidateServiceEntry",
 				ValidatePort(int(port.Number)))
 		}
 
-		errs = appendErrors(errs, validateExportTo(namespace, serviceEntry.ExportTo, true))
+		errs = appendErrors(errs, validateExportTo(cfg.Namespace, serviceEntry.ExportTo, true))
 		return
 	})
 

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -28,6 +28,7 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 	security_beta "istio.io/api/security/v1beta1"
 	api "istio.io/api/type/v1beta1"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/constants"
 )
 
@@ -718,7 +719,13 @@ func TestValidateGateway(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateGateway(someName, someNamespace, tt.in)
+			err := ValidateGateway(config.Config{
+				ConfigMeta: config.ConfigMeta{
+					Name:      someName,
+					Namespace: someNamespace,
+				},
+				Spec: tt.in,
+			})
 			if err == nil && tt.out != "" {
 				t.Fatalf("ValidateGateway(%v) = nil, wanted %q", tt.in, tt.out)
 			} else if err != nil && tt.out == "" {
@@ -2210,7 +2217,7 @@ func TestValidateVirtualService(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := ValidateVirtualService("", "", tc.in); (err == nil) != tc.valid {
+			if err := ValidateVirtualService(config.Config{Spec: tc.in}); (err == nil) != tc.valid {
 				t.Fatalf("got valid=%v but wanted valid=%v: %v", err == nil, tc.valid, err)
 			}
 		})
@@ -2369,7 +2376,13 @@ func TestValidateDestinationRule(t *testing.T) {
 		}, valid: true},
 	}
 	for _, c := range cases {
-		if got := ValidateDestinationRule(someName, someNamespace, c.in); (got == nil) != c.valid {
+		if got := ValidateDestinationRule(config.Config{
+			ConfigMeta: config.ConfigMeta{
+				Name:      someName,
+				Namespace: someNamespace,
+			},
+			Spec: c.in,
+		}); (got == nil) != c.valid {
 			t.Errorf("ValidateDestinationRule failed on %v: got valid=%v but wanted valid=%v: %v",
 				c.name, got == nil, c.valid, got)
 		}
@@ -2961,7 +2974,13 @@ func TestValidateEnvoyFilter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateEnvoyFilter(someName, someNamespace, tt.in)
+			err := ValidateEnvoyFilter(config.Config{
+				ConfigMeta: config.ConfigMeta{
+					Name:      someName,
+					Namespace: someNamespace,
+				},
+				Spec: tt.in,
+			})
 			if err == nil && tt.error != "" {
 				t.Fatalf("ValidateEnvoyFilter(%v) = nil, wanted %q", tt.in, tt.error)
 			} else if err != nil && tt.error == "" {
@@ -3341,7 +3360,13 @@ func TestValidateServiceEntries(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := ValidateServiceEntry(someName, someNamespace, &c.in); (got == nil) != c.valid {
+			if got := ValidateServiceEntry(config.Config{
+				ConfigMeta: config.ConfigMeta{
+					Name:      someName,
+					Namespace: someNamespace,
+				},
+				Spec: &c.in,
+			}); (got == nil) != c.valid {
 				t.Errorf("ValidateServiceEntry got valid=%v but wanted valid=%v: %v",
 					got == nil, c.valid, got)
 			}
@@ -3975,7 +4000,7 @@ func TestValidateAuthorizationPolicy(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := ValidateAuthorizationPolicy("", "", c.in); (got == nil) != c.valid {
+			if got := ValidateAuthorizationPolicy(config.Config{Spec: c.in}); (got == nil) != c.valid {
 				t.Errorf("got: %v\nwant: %v", got, c.valid)
 			}
 		})
@@ -4444,7 +4469,13 @@ func TestValidateSidecar(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateSidecar("foo", "bar", tt.in)
+			err := ValidateSidecar(config.Config{
+				ConfigMeta: config.ConfigMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Spec: tt.in,
+			})
 			if err == nil && !tt.valid {
 				t.Fatalf("ValidateSidecar(%v) = true, wanted false", tt.in)
 			} else if err != nil && tt.valid {
@@ -4883,7 +4914,13 @@ func TestValidateRequestAuthentication(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := ValidateRequestAuthentication(c.configName, someNamespace, c.in); (got == nil) != c.valid {
+			if got := ValidateRequestAuthentication(config.Config{
+				ConfigMeta: config.ConfigMeta{
+					Name:      c.configName,
+					Namespace: someNamespace,
+				},
+				Spec: c.in,
+			}); (got == nil) != c.valid {
 				t.Errorf("got(%v) != want(%v)\n", got, c.valid)
 			}
 		})
@@ -4997,7 +5034,13 @@ func TestValidatePeerAuthentication(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := ValidatePeerAuthentication(c.configName, someNamespace, c.in); (got == nil) != c.valid {
+			if got := ValidatePeerAuthentication(config.Config{
+				ConfigMeta: config.ConfigMeta{
+					Name:      c.configName,
+					Namespace: someNamespace,
+				},
+				Spec: c.in,
+			}); (got == nil) != c.valid {
 				t.Errorf("got(%v) != want(%v)\n", got, c.valid)
 			}
 		})

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -720,7 +720,7 @@ func TestValidateGateway(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ValidateGateway(config.Config{
-				ConfigMeta: config.ConfigMeta{
+				Meta: config.Meta{
 					Name:      someName,
 					Namespace: someNamespace,
 				},
@@ -2377,7 +2377,7 @@ func TestValidateDestinationRule(t *testing.T) {
 	}
 	for _, c := range cases {
 		if got := ValidateDestinationRule(config.Config{
-			ConfigMeta: config.ConfigMeta{
+			Meta: config.Meta{
 				Name:      someName,
 				Namespace: someNamespace,
 			},
@@ -2975,7 +2975,7 @@ func TestValidateEnvoyFilter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ValidateEnvoyFilter(config.Config{
-				ConfigMeta: config.ConfigMeta{
+				Meta: config.Meta{
 					Name:      someName,
 					Namespace: someNamespace,
 				},
@@ -3361,7 +3361,7 @@ func TestValidateServiceEntries(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			if got := ValidateServiceEntry(config.Config{
-				ConfigMeta: config.ConfigMeta{
+				Meta: config.Meta{
 					Name:      someName,
 					Namespace: someNamespace,
 				},
@@ -4470,7 +4470,7 @@ func TestValidateSidecar(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ValidateSidecar(config.Config{
-				ConfigMeta: config.ConfigMeta{
+				Meta: config.Meta{
 					Name:      "foo",
 					Namespace: "bar",
 				},
@@ -4915,7 +4915,7 @@ func TestValidateRequestAuthentication(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			if got := ValidateRequestAuthentication(config.Config{
-				ConfigMeta: config.ConfigMeta{
+				Meta: config.Meta{
 					Name:      c.configName,
 					Namespace: someNamespace,
 				},
@@ -5035,7 +5035,7 @@ func TestValidatePeerAuthentication(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			if got := ValidatePeerAuthentication(config.Config{
-				ConfigMeta: config.ConfigMeta{
+				Meta: config.Meta{
 					Name:      c.configName,
 					Namespace: someNamespace,
 				},

--- a/pkg/config/validation/virtualservice_test.go
+++ b/pkg/config/validation/virtualservice_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/gogo/protobuf/types"
 
 	networking "istio.io/api/networking/v1alpha3"
+
+	"istio.io/istio/pkg/config"
 )
 
 func TestValidateChainingVirtualService(t *testing.T) {
@@ -140,7 +142,7 @@ func TestValidateChainingVirtualService(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := ValidateVirtualService("", "", tc.in); (err == nil) != tc.valid {
+			if err := ValidateVirtualService(config.Config{Spec: tc.in}); (err == nil) != tc.valid {
 				t.Fatalf("got valid=%v but wanted valid=%v: %v", err == nil, tc.valid, err)
 			}
 		})

--- a/pkg/config/validation/virtualservice_test.go
+++ b/pkg/config/validation/virtualservice_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/gogo/protobuf/types"
 
 	networking "istio.io/api/networking/v1alpha3"
-
 	"istio.io/istio/pkg/config"
 )
 

--- a/pkg/webhooks/validation/server/server.go
+++ b/pkg/webhooks/validation/server/server.go
@@ -257,7 +257,7 @@ func (wh *Webhook) admitPilot(request *kube.AdmissionRequest) *kube.AdmissionRes
 		return toAdmissionResponse(fmt.Errorf("error decoding configuration: %v", err))
 	}
 
-	if err := s.Resource().ValidateProto(out.Name, out.Namespace, out.Spec); err != nil {
+	if err := s.Resource().ValidateConfig(out.Name, out.Namespace, out.Spec); err != nil {
 		scope.Infof("configuration is invalid: %v", err)
 		reportValidationFailed(request, reasonInvalidConfig)
 		return toAdmissionResponse(fmt.Errorf("configuration is invalid: %v", err))

--- a/pkg/webhooks/validation/server/server.go
+++ b/pkg/webhooks/validation/server/server.go
@@ -257,7 +257,7 @@ func (wh *Webhook) admitPilot(request *kube.AdmissionRequest) *kube.AdmissionRes
 		return toAdmissionResponse(fmt.Errorf("error decoding configuration: %v", err))
 	}
 
-	if err := s.Resource().ValidateConfig(out.Name, out.Namespace, out.Spec); err != nil {
+	if err := s.Resource().ValidateConfig(*out); err != nil {
 		scope.Infof("configuration is invalid: %v", err)
 		reportValidationFailed(request, reasonInvalidConfig)
 		return toAdmissionResponse(fmt.Errorf("configuration is invalid: %v", err))


### PR DESCRIPTION
This is a dependency for https://github.com/istio/istio/issues/26889 and for future validation we want to add that takes into account object metadata (labels, annotations). Technically we could just add more parameters, but this feels much cleaner.

As a result of this change, an import loop is created. Instead of having the core model.Config object living in pilot, it ought to be in pkg/config, which avoids this loop (at the cost of a massive PR....)