### PR TITLE
Add bash helper function to find the right way to do inplace sed commands

### DIFF
--- a/common/scripts/env_tools.sh
+++ b/common/scripts/env_tools.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TODO: Use the below in every script that uses the -i option on sed
+find_inplace_sed() {
+    local tmpfile=`mktemp`
+    local POSSIBLE_INPLACE_SED_CMDS=("sed -i" "sed -i ''")
+    local sed_cmd
+    unset INPLACE_SED
+    for sed_cmd in "${POSSIBLE_INPLACE_SED_CMDS[@]}"; do
+        echo orig > ${tmpfile}
+        if eval ${sed_cmd} 's/orig/new/g' ${tmpfile} >/dev/null 2>&1 ; then
+            INPLACE_SED="${sed_cmd}"
+            break
+        fi
+    done
+    rm $tmpfile
+    if [ -z ${INPLACE_SED+x} ]; then
+        echo "Cannot find a valid inplace sed command from ${POSSIBLE_INPLACE_SED_CMDS}"
+        return 1
+    fi
+    return 0
+}

--- a/common/scripts/env_tools.sh
+++ b/common/scripts/env_tools.sh
@@ -16,20 +16,22 @@
 
 # TODO: Use the below in every script that uses the -i option on sed
 find_inplace_sed() {
-    local tmpfile=`mktemp`
-    local POSSIBLE_INPLACE_SED_CMDS=("sed -i" "sed -i ''")
+    local tmpfile
+    local POSSIBLE_INPLACE_SED_CMDS
     local sed_cmd
     unset INPLACE_SED
+    tmpfile=$(mktemp)
+    POSSIBLE_INPLACE_SED_CMDS=("sed -i" "sed -i ''")
     for sed_cmd in "${POSSIBLE_INPLACE_SED_CMDS[@]}"; do
-        echo orig > ${tmpfile}
-        if eval ${sed_cmd} 's/orig/new/g' ${tmpfile} >/dev/null 2>&1 ; then
+        echo orig > "${tmpfile}"
+        if eval "${sed_cmd}" 's/orig/new/g' "${tmpfile}" >/dev/null 2>&1 ; then
             INPLACE_SED="${sed_cmd}"
             break
         fi
     done
-    rm $tmpfile
+    rm "${tmpfile}"
     if [ -z ${INPLACE_SED+x} ]; then
-        echo "Cannot find a valid inplace sed command from ${POSSIBLE_INPLACE_SED_CMDS}"
+        echo "Cannot find a valid inplace sed command from ${POSSIBLE_INPLACE_SED_CMDS[@]}"
         return 1
     fi
     return 0

--- a/common/scripts/env_tools.sh
+++ b/common/scripts/env_tools.sh
@@ -31,7 +31,7 @@ find_inplace_sed() {
     done
     rm "${tmpfile}"
     if [ -z ${INPLACE_SED+x} ]; then
-        echo "Cannot find a valid inplace sed command from ${POSSIBLE_INPLACE_SED_CMDS[@]}"
+        echo "Cannot find a valid inplace sed command from:" "${POSSIBLE_INPLACE_SED_CMDS[@]}"
         return 1
     fi
     return 0


### PR DESCRIPTION
Because sed -i has different arguments on Mac (BSD) versus Linux (GNU), this function figures out the right invokation and puts it into an environment variable

See https://github.com/istio/istio.io/pull/8033 for the motivating reason and how I will use it in another script.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[X] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.