### PR TITLE
Respect proxy CPU/memory annotations in proxy init

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -267,11 +267,30 @@ data:
           value: "{{ $value }}"
         {{- end }}
       {{- end }}
-      {{- if .Values.global.proxy_init.resources }}
         resources:
-          {{ toYaml .Values.global.proxy_init.resources | indent 4 }}
+      {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+          requests:
+            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
+            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ end }}
+            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
+            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ end }}
+        {{- end }}
+        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+          limits:
+            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
+            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ end }}
+            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
+            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ end }}
+        {{- end }}
       {{- else }}
-        resources: {}
+        {{- if .Values.global.proxy.resources }}
+          {{ toYaml .Values.global.proxy.resources | indent 4 }}
+        {{- end }}
       {{- end }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -58,11 +58,30 @@ template: |
       value: "{{ $value }}"
     {{- end }}
   {{- end }}
-  {{- if .Values.global.proxy_init.resources }}
     resources:
-      {{ toYaml .Values.global.proxy_init.resources | indent 4 }}
+  {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+      requests:
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
+        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+        {{ end }}
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
+        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+        {{ end }}
+    {{- end }}
+    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+      limits:
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
+        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+        {{ end }}
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
+        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+        {{ end }}
+    {{- end }}
   {{- else }}
-    resources: {}
+    {{- if .Values.global.proxy.resources }}
+      {{ toYaml .Values.global.proxy.resources | indent 4 }}
+    {{- end }}
   {{- end }}
     securityContext:
       allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}

--- a/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -247,11 +247,30 @@ data:
           value: "{{ $value }}"
         {{- end }}
       {{- end }}
-      {{- if .Values.global.proxy_init.resources }}
         resources:
-          {{ toYaml .Values.global.proxy_init.resources | indent 4 }}
+      {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+          requests:
+            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
+            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ end }}
+            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
+            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ end }}
+        {{- end }}
+        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+          limits:
+            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
+            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ end }}
+            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
+            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ end }}
+        {{- end }}
       {{- else }}
-        resources: {}
+        {{- if .Values.global.proxy.resources }}
+          {{ toYaml .Values.global.proxy.resources | indent 4 }}
+        {{- end }}
       {{- end }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -58,11 +58,30 @@ template: |
       value: "{{ $value }}"
     {{- end }}
   {{- end }}
-  {{- if .Values.global.proxy_init.resources }}
     resources:
-      {{ toYaml .Values.global.proxy_init.resources | indent 4 }}
+  {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+      requests:
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
+        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+        {{ end }}
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
+        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+        {{ end }}
+    {{- end }}
+    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+      limits:
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
+        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+        {{ end }}
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
+        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+        {{ end }}
+    {{- end }}
   {{- else }}
-    resources: {}
+    {{- if .Values.global.proxy.resources }}
+      {{ toYaml .Values.global.proxy.resources | indent 4 }}
+    {{- end }}
   {{- end }}
     securityContext:
       allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -58,11 +58,30 @@ template: |
       value: "{{ $value }}"
     {{- end }}
   {{- end }}
-  {{- if .Values.global.proxy_init.resources }}
     resources:
-      {{ toYaml .Values.global.proxy_init.resources | indent 4 }}
+  {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+      requests:
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
+        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+        {{ end }}
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
+        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+        {{ end }}
+    {{- end }}
+    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+      limits:
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
+        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+        {{ end }}
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
+        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+        {{ end }}
+    {{- end }}
   {{- else }}
-    resources: {}
+    {{- if .Values.global.proxy.resources }}
+      {{ toYaml .Values.global.proxy.resources | indent 4 }}
+    {{- end }}
   {{- end }}
     securityContext:
       allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
@@ -235,7 +254,7 @@ template: |
     {{ end }}
     {{- if .DeploymentMeta.Name }}
     - name: ISTIO_META_WORKLOAD_NAME
-      value: {{ .DeploymentMeta.Name }}
+      value: "{{ .DeploymentMeta.Name }}"
     {{ end }}
     {{- if and .TypeMeta.APIVersion .DeploymentMeta.Name }}
     - name: ISTIO_META_OWNER
@@ -359,6 +378,12 @@ template: |
       {{ toYaml $value | indent 4 }}
       {{ end }}
       {{- end }}
+  {{- if .ProxyConfig.ProxyMetadata.ISTIO_META_DNS_CAPTURE }}
+  dnsConfig:
+    options:
+    - name: "ndots"
+      value: "4"
+  {{- end }}
   volumes:
   {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
   - name: custom-bootstrap-volume
@@ -416,13 +441,6 @@ template: |
     secret:
       optional: true
       secretName: lightstep.cacert
-  {{- end }}
-  {{- if .Values.global.podDNSSearchNamespaces }}
-  dnsConfig:
-    searches:
-      {{- range .Values.global.podDNSSearchNamespaces }}
-      - {{ render . }}
-      {{- end }}
   {{- end }}
   podRedirectAnnot:
   {{- if and (.Values.istio_cni.enabled) (not .Values.istio_cni.chained) }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -4954,11 +4954,30 @@ data:
           value: "{{ $value }}"
         {{- end }}
       {{- end }}
-      {{- if .Values.global.proxy_init.resources }}
         resources:
-          {{ toYaml .Values.global.proxy_init.resources | indent 4 }}
+      {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+          requests:
+            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
+            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ end }}
+            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
+            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ end }}
+        {{- end }}
+        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+          limits:
+            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
+            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ end }}
+            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
+            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ end }}
+        {{- end }}
       {{- else }}
-        resources: {}
+        {{- if .Values.global.proxy.resources }}
+          {{ toYaml .Values.global.proxy.resources | indent 4 }}
+        {{- end }}
       {{- end }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
@@ -5131,7 +5150,7 @@ data:
         {{ end }}
         {{- if .DeploymentMeta.Name }}
         - name: ISTIO_META_WORKLOAD_NAME
-          value: {{ .DeploymentMeta.Name }}
+          value: "{{ .DeploymentMeta.Name }}"
         {{ end }}
         {{- if and .TypeMeta.APIVersion .DeploymentMeta.Name }}
         - name: ISTIO_META_OWNER
@@ -5255,6 +5274,12 @@ data:
           {{ toYaml $value | indent 4 }}
           {{ end }}
           {{- end }}
+      {{- if .ProxyConfig.ProxyMetadata.ISTIO_META_DNS_CAPTURE }}
+      dnsConfig:
+        options:
+        - name: "ndots"
+          value: "4"
+      {{- end }}
       volumes:
       {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
       - name: custom-bootstrap-volume
@@ -5312,13 +5337,6 @@ data:
         secret:
           optional: true
           secretName: lightstep.cacert
-      {{- end }}
-      {{- if .Values.global.podDNSSearchNamespaces }}
-      dnsConfig:
-        searches:
-          {{- range .Values.global.podDNSSearchNamespaces }}
-          - {{ render . }}
-          {{- end }}
       {{- end }}
       podRedirectAnnot:
       {{- if and (.Values.istio_cni.enabled) (not .Values.istio_cni.chained) }}

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -1297,11 +1297,30 @@ data:
           value: "{{ $value }}"
         {{- end }}
       {{- end }}
-      {{- if .Values.global.proxy_init.resources }}
         resources:
-          {{ toYaml .Values.global.proxy_init.resources | indent 4 }}
+      {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+          requests:
+            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
+            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ end }}
+            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
+            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ end }}
+        {{- end }}
+        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+          limits:
+            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
+            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ end }}
+            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
+            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ end }}
+        {{- end }}
       {{- else }}
-        resources: {}
+        {{- if .Values.global.proxy.resources }}
+          {{ toYaml .Values.global.proxy.resources | indent 4 }}
+        {{- end }}
       {{- end }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
@@ -1474,7 +1493,7 @@ data:
         {{ end }}
         {{- if .DeploymentMeta.Name }}
         - name: ISTIO_META_WORKLOAD_NAME
-          value: {{ .DeploymentMeta.Name }}
+          value: "{{ .DeploymentMeta.Name }}"
         {{ end }}
         {{- if and .TypeMeta.APIVersion .DeploymentMeta.Name }}
         - name: ISTIO_META_OWNER
@@ -1598,6 +1617,12 @@ data:
           {{ toYaml $value | indent 4 }}
           {{ end }}
           {{- end }}
+      {{- if .ProxyConfig.ProxyMetadata.ISTIO_META_DNS_CAPTURE }}
+      dnsConfig:
+        options:
+        - name: "ndots"
+          value: "4"
+      {{- end }}
       volumes:
       {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
       - name: custom-bootstrap-volume
@@ -1655,13 +1680,6 @@ data:
         secret:
           optional: true
           secretName: lightstep.cacert
-      {{- end }}
-      {{- if .Values.global.podDNSSearchNamespaces }}
-      dnsConfig:
-        searches:
-          {{- range .Values.global.podDNSSearchNamespaces }}
-          - {{ render . }}
-          {{- end }}
       {{- end }}
       podRedirectAnnot:
       {{- if and (.Values.istio_cni.enabled) (not .Values.istio_cni.chained) }}

--- a/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -174,8 +174,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -174,8 +174,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -168,8 +168,8 @@ spec:
                 cpu: "2"
                 memory: 1Gi
               requests:
-                cpu: 10m
-                memory: 10Mi
+                cpu: 100m
+                memory: 128Mi
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:

--- a/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -172,8 +172,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -187,8 +187,8 @@ items:
               cpu: "2"
               memory: 1Gi
             requests:
-              cpu: 10m
-              memory: 10Mi
+              cpu: 100m
+              memory: 128Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-with-canonical-service-label.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-with-canonical-service-label.yaml.injected
@@ -172,8 +172,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -172,8 +172,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump-annotation.yaml.injected
@@ -178,8 +178,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -174,8 +174,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -174,8 +174,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -191,8 +191,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -174,8 +174,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/hello-cncf-networks.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-cncf-networks.yaml.injected
@@ -176,8 +176,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks-json.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks-json.yaml.injected
@@ -180,8 +180,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks.yaml.injected
@@ -180,8 +180,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/hello-image-pull-secret.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-image-pull-secret.yaml.injected
@@ -176,8 +176,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/hello-image-secrets-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-image-secrets-in-values.yaml.injected
@@ -176,8 +176,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
@@ -177,8 +177,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
@@ -174,8 +174,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -176,8 +176,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -398,8 +398,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/hello-multiple-image-secrets.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multiple-image-secrets.yaml.injected
@@ -177,8 +177,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -175,8 +175,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -174,8 +174,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -204,8 +204,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -199,8 +199,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/hello-probes.proxyHoldsApplication.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes.proxyHoldsApplication.yaml.injected
@@ -206,8 +206,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes.yaml.injected
@@ -200,8 +200,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -178,8 +178,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/hello-readiness.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-readiness.yaml.injected
@@ -180,8 +180,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
@@ -145,10 +145,6 @@ spec:
           name: istio-token
         - mountPath: /etc/istio/pod
           name: istio-podinfo
-      dnsConfig:
-        searches:
-        - global
-        - default.global
       initContainers:
       - args:
         - istio-iptables
@@ -178,8 +174,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -176,8 +176,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/hello.proxyHoldsApplication.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.proxyHoldsApplication.yaml.injected
@@ -180,8 +180,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
@@ -176,8 +176,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -174,8 +174,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/https-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/https-probes.yaml.injected
@@ -201,8 +201,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -166,8 +166,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -180,8 +180,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -180,8 +180,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -192,8 +192,8 @@ items:
               cpu: "2"
               memory: 1Gi
             requests:
-              cpu: 10m
-              memory: 10Mi
+              cpu: 100m
+              memory: 128Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -178,8 +178,8 @@ items:
               cpu: "2"
               memory: 1Gi
             requests:
-              cpu: 10m
-              memory: 10Mi
+              cpu: 100m
+              memory: 128Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -399,8 +399,8 @@ items:
               cpu: "2"
               memory: 1Gi
             requests:
-              cpu: 10m
-              memory: 10Mi
+              cpu: 100m
+              memory: 128Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
@@ -176,8 +176,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -188,8 +188,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/named_port.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/named_port.yaml.injected
@@ -180,8 +180,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/one_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/one_container.yaml.injected
@@ -184,8 +184,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -160,8 +160,8 @@ spec:
         cpu: "2"
         memory: 1Gi
       requests:
-        cpu: 10m
-        memory: 10Mi
+        cpu: 100m
+        memory: 128Mi
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:

--- a/pkg/kube/inject/testdata/inject/ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/ready_live.yaml.injected
@@ -200,8 +200,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/ready_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/ready_only.yaml.injected
@@ -180,8 +180,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -169,8 +169,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -168,8 +168,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/resource_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/resource_annotations.yaml.injected
@@ -174,11 +174,11 @@ spec:
         name: istio-init
         resources:
           limits:
-            cpu: "2"
-            memory: 1Gi
+            cpu: "1"
+            memory: 2Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 1Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/startup_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/startup_live.yaml.injected
@@ -200,8 +200,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/startup_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/startup_only.yaml.injected
@@ -180,8 +180,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/startup_ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/startup_ready_live.yaml.injected
@@ -208,8 +208,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -177,8 +177,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -178,8 +178,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/status_annotations_zeroport.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations_zeroport.yaml.injected
@@ -171,8 +171,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -170,8 +170,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -177,8 +177,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -177,8 +177,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -180,12 +180,8 @@ spec:
         imagePullPolicy: Always
         name: istio-init
         resources:
-          limits:
-            cpu: "2"
-            memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: "4"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -170,8 +170,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -163,8 +163,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/two_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/two_container.yaml.injected
@@ -191,8 +191,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/kube/inject/testdata/inject/user-volume.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/user-volume.yaml.injected
@@ -184,8 +184,8 @@ spec:
             cpu: "2"
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 10Mi
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
There is no reason to have the init container different than the
sidecar. I don't see any functional reason to make the requests bigger
than the sidecar, and there is no need to make it smaller as we will
always fit into quotas/limitrange adequately as long as we are equal to
sidecar.

For https://github.com/istio/istio/issues/26932



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.