### PR TITLE
don't set PROXY_XDS_VIA_AGENT in multicluster mode

### DIFF
--- a/pkg/test/framework/components/istio/istio.go
+++ b/pkg/test/framework/components/istio/istio.go
@@ -40,7 +40,7 @@ type Instance interface {
 }
 
 // SetupConfigFn is a setup function that specifies the overrides of the configuration to deploy Istio.
-type SetupConfigFn func(cfg *Config)
+type SetupConfigFn func(ctx resource.Context, cfg *Config)
 
 // SetupContextFn is a setup function that uses Context for configuration.
 type SetupContextFn func(ctx resource.Context) error
@@ -71,7 +71,7 @@ func Setup(i *Instance, cfn SetupConfigFn, ctxFns ...SetupContextFn) resource.Se
 			return err
 		}
 		if cfn != nil {
-			cfn(&cfg)
+			cfn(ctx, &cfg)
 		}
 		for _, ctxFn := range ctxFns {
 			if ctxFn != nil {

--- a/tests/integration/multicluster/base/main_test.go
+++ b/tests/integration/multicluster/base/main_test.go
@@ -21,6 +21,7 @@ import (
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/tests/integration/multicluster"
 )
 
@@ -35,7 +36,7 @@ func TestMain(m *testing.M) {
 		Label(label.Multicluster).
 		RequireMinClusters(2).
 		Setup(multicluster.Setup(&appCtx)).
-		Setup(istio.Setup(&ist, func(cfg *istio.Config) {
+		Setup(istio.Setup(&ist, func(_ resource.Context, cfg *istio.Config) {
 			cfg.ControlPlaneValues = appCtx.ControlPlaneValues
 		})).
 		Setup(multicluster.SetupApps(&appCtx)).

--- a/tests/integration/multicluster/centralistio/main_test.go
+++ b/tests/integration/multicluster/centralistio/main_test.go
@@ -45,7 +45,7 @@ func TestMain(m *testing.M) {
 				s.ControlPlaneTopology[resource.ClusterIndex(i)] = primaryCluster
 			}
 		})).
-		Setup(istio.Setup(&ist, func(cfg *istio.Config) {
+		Setup(istio.Setup(&ist, func(_ resource.Context, cfg *istio.Config) {
 
 			cfg.Values["global.centralIstiod"] = "true"
 

--- a/tests/integration/pilot/analysis/main_test.go
+++ b/tests/integration/pilot/analysis/main_test.go
@@ -20,6 +20,7 @@ import (
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/resource"
 )
 
 // TestMain defines the entrypoint for pilot tests using a standard Istio installation.
@@ -29,7 +30,7 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
 		RequireSingleCluster().
-		Setup(istio.Setup(nil, func(cfg *istio.Config) {
+		Setup(istio.Setup(nil, func(_ resource.Context, cfg *istio.Config) {
 			cfg.ControlPlaneValues = `
 values:
   pilot:

--- a/tests/integration/pilot/cni/cni_test.go
+++ b/tests/integration/pilot/cni/cni_test.go
@@ -23,6 +23,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/resource"
 	kube2 "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/tests/integration/security/util/reachability"
 )
@@ -31,7 +32,7 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
 		RequireSingleCluster().
-		Setup(istio.Setup(nil, func(cfg *istio.Config) {
+		Setup(istio.Setup(nil, func(_ resource.Context, cfg *istio.Config) {
 			cfg.ControlPlaneValues = `
 components:
   cni:

--- a/tests/integration/pilot/main_test.go
+++ b/tests/integration/pilot/main_test.go
@@ -103,10 +103,13 @@ func TestMain(m *testing.M) {
 			}
 			return ctx.Config().ApplyYAML("", string(crd))
 		}).
-		Setup(istio.Setup(&i, func(cfg *istio.Config) {
+		Setup(istio.Setup(&i, func(ctx resource.Context, cfg *istio.Config) {
 			cfg.Values["telemetry.v2.metadataExchange.wasmEnabled"] = "false"
 			cfg.Values["telemetry.v2.prometheus.wasmEnabled"] = "false"
-			cfg.Values["meshConfig.defaultConfig.proxyMetadata.PROXY_XDS_VIA_AGENT"] = "enable"
+			if !ctx.Clusters().IsMulticluster() {
+				// TODO make this compatible with multicluster
+				cfg.Values["meshConfig.defaultConfig.proxyMetadata.PROXY_XDS_VIA_AGENT"] = "enable"
+			}
 			cfg.ControlPlaneValues = `
 # Add TCP port, not in the default install
 components:

--- a/tests/integration/pilot/revisions/revisions_test.go
+++ b/tests/integration/pilot/revisions/revisions_test.go
@@ -25,6 +25,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/util/retry"
 )
 
@@ -35,12 +36,12 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
 		RequireSingleCluster().
-		Setup(istio.Setup(nil, func(cfg *istio.Config) {
+		Setup(istio.Setup(nil, func(_ resource.Context, cfg *istio.Config) {
 			cfg.ControlPlaneValues = `
 revision: stable
 `
 		})).
-		Setup(istio.Setup(nil, func(cfg *istio.Config) {
+		Setup(istio.Setup(nil, func(_ resource.Context, cfg *istio.Config) {
 			cfg.ControlPlaneValues = `
 profile: empty
 revision: canary

--- a/tests/integration/security/ca_custom_root/main_test.go
+++ b/tests/integration/security/ca_custom_root/main_test.go
@@ -18,12 +18,12 @@
 package cacustomroot
 
 import (
-	"istio.io/istio/pkg/test/framework/resource"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/tests/integration/security/util/cert"
 )
 

--- a/tests/integration/security/ca_custom_root/main_test.go
+++ b/tests/integration/security/ca_custom_root/main_test.go
@@ -18,6 +18,7 @@
 package cacustomroot
 
 import (
+	"istio.io/istio/pkg/test/framework/resource"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
@@ -40,7 +41,7 @@ func TestMain(m *testing.M) {
 		Run()
 }
 
-func setupConfig(cfg *istio.Config) {
+func setupConfig(_ resource.Context, cfg *istio.Config) {
 	if cfg == nil {
 		return
 	}

--- a/tests/integration/security/chiron/main_test.go
+++ b/tests/integration/security/chiron/main_test.go
@@ -16,6 +16,7 @@
 package chiron_test
 
 import (
+	"istio.io/istio/pkg/test/framework/resource"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
@@ -37,7 +38,7 @@ func TestMain(m *testing.M) {
 		Run()
 }
 
-func setupConfig(cfg *istio.Config) {
+func setupConfig(_ resource.Context, cfg *istio.Config) {
 	if cfg == nil {
 		return
 	}

--- a/tests/integration/security/chiron/main_test.go
+++ b/tests/integration/security/chiron/main_test.go
@@ -16,12 +16,12 @@
 package chiron_test
 
 import (
-	"istio.io/istio/pkg/test/framework/resource"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
 )
 
 var (

--- a/tests/integration/security/filebased_tls_origination/main_test.go
+++ b/tests/integration/security/filebased_tls_origination/main_test.go
@@ -16,6 +16,7 @@
 package filebasedtlsorigination
 
 import (
+	"istio.io/istio/pkg/test/framework/resource"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
@@ -42,7 +43,7 @@ func TestMain(m *testing.M) {
 
 }
 
-func setupConfig(cfg *istio.Config) {
+func setupConfig(_ resource.Context, cfg *istio.Config) {
 	if cfg == nil {
 		return
 	}

--- a/tests/integration/security/filebased_tls_origination/main_test.go
+++ b/tests/integration/security/filebased_tls_origination/main_test.go
@@ -16,12 +16,12 @@
 package filebasedtlsorigination
 
 import (
-	"istio.io/istio/pkg/test/framework/resource"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/tests/integration/security/util/cert"
 )
 

--- a/tests/integration/security/main_test.go
+++ b/tests/integration/security/main_test.go
@@ -20,6 +20,7 @@ import (
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/resource"
 )
 
 var (
@@ -35,7 +36,7 @@ func TestMain(m *testing.M) {
 		Run()
 }
 
-func setupConfig(cfg *istio.Config) {
+func setupConfig(_ resource.Context, cfg *istio.Config) {
 	if cfg == nil {
 		return
 	}

--- a/tests/integration/security/mtls_first_party_jwt/main_test.go
+++ b/tests/integration/security/mtls_first_party_jwt/main_test.go
@@ -16,12 +16,12 @@
 package mtlsfirstpartyjwt
 
 import (
-	"istio.io/istio/pkg/test/framework/resource"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
 )
 
 var (

--- a/tests/integration/security/mtls_first_party_jwt/main_test.go
+++ b/tests/integration/security/mtls_first_party_jwt/main_test.go
@@ -16,6 +16,7 @@
 package mtlsfirstpartyjwt
 
 import (
+	"istio.io/istio/pkg/test/framework/resource"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
@@ -36,7 +37,7 @@ func TestMain(m *testing.M) {
 		Run()
 }
 
-func setupConfig(cfg *istio.Config) {
+func setupConfig(_ resource.Context, cfg *istio.Config) {
 	if cfg == nil {
 		return
 	}

--- a/tests/integration/security/mtlsk8sca/main_test.go
+++ b/tests/integration/security/mtlsk8sca/main_test.go
@@ -16,12 +16,12 @@
 package mtlsk8sca
 
 import (
-	"istio.io/istio/pkg/test/framework/resource"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
 )
 
 var (

--- a/tests/integration/security/mtlsk8sca/main_test.go
+++ b/tests/integration/security/mtlsk8sca/main_test.go
@@ -16,6 +16,7 @@
 package mtlsk8sca
 
 import (
+	"istio.io/istio/pkg/test/framework/resource"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
@@ -36,7 +37,7 @@ func TestMain(m *testing.M) {
 		Run()
 }
 
-func setupConfig(cfg *istio.Config) {
+func setupConfig(_ resource.Context, cfg *istio.Config) {
 	if cfg == nil {
 		return
 	}

--- a/tests/integration/security/sds_egress/main_test.go
+++ b/tests/integration/security/sds_egress/main_test.go
@@ -50,7 +50,7 @@ func TestMain(m *testing.M) {
 
 }
 
-func setupConfig(cfg *istio.Config) {
+func setupConfig(_ resource.Context, cfg *istio.Config) {
 	if cfg == nil {
 		return
 	}

--- a/tests/integration/security/sds_ingress_k8sca/main_test.go
+++ b/tests/integration/security/sds_ingress_k8sca/main_test.go
@@ -16,6 +16,7 @@
 package sdsingressk8sca
 
 import (
+	"istio.io/istio/pkg/test/framework/resource"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
@@ -38,11 +39,10 @@ func TestMain(m *testing.M) {
 
 }
 
-func setupConfig(cfg *istio.Config) {
+func setupConfig(_ resource.Context, cfg *istio.Config) {
 	if cfg == nil {
 		return
 	}
-
 	cfg.ControlPlaneValues = `
 values:
   global:

--- a/tests/integration/security/sds_ingress_k8sca/main_test.go
+++ b/tests/integration/security/sds_ingress_k8sca/main_test.go
@@ -16,11 +16,11 @@
 package sdsingressk8sca
 
 import (
-	"istio.io/istio/pkg/test/framework/resource"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/tests/integration/security/sds_ingress/util"
 )
 

--- a/tests/integration/security/sds_tls_origination/main_test.go
+++ b/tests/integration/security/sds_tls_origination/main_test.go
@@ -16,12 +16,12 @@
 package sdstlsorigination
 
 import (
-	"istio.io/istio/pkg/test/framework/resource"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
 )
 
 var (

--- a/tests/integration/security/sds_tls_origination/main_test.go
+++ b/tests/integration/security/sds_tls_origination/main_test.go
@@ -16,6 +16,7 @@
 package sdstlsorigination
 
 import (
+	"istio.io/istio/pkg/test/framework/resource"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
@@ -41,7 +42,7 @@ func TestMain(m *testing.M) {
 
 }
 
-func setupConfig(cfg *istio.Config) {
+func setupConfig(_ resource.Context, cfg *istio.Config) {
 	if cfg == nil {
 		return
 	}

--- a/tests/integration/security/sds_vault_flow/main_test.go
+++ b/tests/integration/security/sds_vault_flow/main_test.go
@@ -16,6 +16,7 @@
 package sds_vault_test
 
 import (
+	"istio.io/istio/pkg/test/framework/resource"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
@@ -58,7 +59,7 @@ func TestMain(m *testing.M) {
 		Run()
 }
 
-func setupConfig(cfg *istio.Config) {
+func setupConfig(_ resource.Context, cfg *istio.Config) {
 	if cfg == nil {
 		return
 	}

--- a/tests/integration/security/sds_vault_flow/main_test.go
+++ b/tests/integration/security/sds_vault_flow/main_test.go
@@ -16,12 +16,12 @@
 package sds_vault_test
 
 import (
-	"istio.io/istio/pkg/test/framework/resource"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
 )
 
 const (

--- a/tests/integration/security/webhook/webhook_test.go
+++ b/tests/integration/security/webhook/webhook_test.go
@@ -16,7 +16,6 @@
 package istioctl
 
 import (
-	"istio.io/istio/pkg/test/framework/resource"
 	"regexp"
 	"strings"
 	"testing"
@@ -25,6 +24,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/istioctl"
 	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
 )
 
 var (

--- a/tests/integration/security/webhook/webhook_test.go
+++ b/tests/integration/security/webhook/webhook_test.go
@@ -16,6 +16,7 @@
 package istioctl
 
 import (
+	"istio.io/istio/pkg/test/framework/resource"
 	"regexp"
 	"strings"
 	"testing"
@@ -40,7 +41,7 @@ func TestMain(m *testing.M) {
 		Run()
 }
 
-func setupConfig(cfg *istio.Config) {
+func setupConfig(_ resource.Context, cfg *istio.Config) {
 	if cfg == nil {
 		return
 	}

--- a/tests/integration/telemetry/main_test.go
+++ b/tests/integration/telemetry/main_test.go
@@ -35,7 +35,7 @@ func TestMain(m *testing.M) {
 		NewSuite(m).
 		RequireSingleCluster().
 		Label(label.CustomSetup).
-		Setup(istio.Setup(&i, func(cfg *istio.Config) {
+		Setup(istio.Setup(&i, func(_ resource.Context, cfg *istio.Config) {
 			cfg.ControlPlaneValues = `
 # Add an additional TCP port, 31400
 components:

--- a/tests/integration/telemetry/outboundtrafficpolicy/traffic_test.go
+++ b/tests/integration/telemetry/outboundtrafficpolicy/traffic_test.go
@@ -39,7 +39,7 @@ func TestMain(m *testing.M) {
 		Run()
 }
 
-func setupConfig(cfg *istio.Config) {
+func setupConfig(_ resource.Context, cfg *istio.Config) {
 	if cfg == nil {
 		return
 	}

--- a/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
@@ -119,7 +119,7 @@ func TestMain(m *testing.M) {
 		Run()
 }
 
-func setupConfig(cfg *istio.Config) {
+func setupConfig(_ resource.Context, cfg *istio.Config) {
 	if cfg == nil {
 		return
 	}

--- a/tests/integration/telemetry/stackdriver/vm/main_test.go
+++ b/tests/integration/telemetry/stackdriver/vm/main_test.go
@@ -58,7 +58,7 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
 		RequireSingleCluster().
-		Setup(istio.Setup(&i, func(cfg *istio.Config) {
+		Setup(istio.Setup(&i, func(_ resource.Context, cfg *istio.Config) {
 			cfg.Values["telemetry.enabled"] = "true"
 			cfg.Values["telemetry.v2.enabled"] = "true"
 			cfg.Values["telemetry.v2.stackdriver.enabled"] = "true"

--- a/tests/integration/telemetry/stats/prometheus/http/nullvm/stats_filter_test.go
+++ b/tests/integration/telemetry/stats/prometheus/http/nullvm/stats_filter_test.go
@@ -16,13 +16,13 @@
 package nullvm
 
 import (
-	"istio.io/istio/pkg/test/framework/resource"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/features"
 	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
 	common "istio.io/istio/tests/integration/telemetry/stats/prometheus/http"
 )
 

--- a/tests/integration/telemetry/stats/prometheus/http/nullvm/stats_filter_test.go
+++ b/tests/integration/telemetry/stats/prometheus/http/nullvm/stats_filter_test.go
@@ -16,6 +16,7 @@
 package nullvm
 
 import (
+	"istio.io/istio/pkg/test/framework/resource"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
@@ -42,7 +43,7 @@ func TestMain(m *testing.M) {
 		Run()
 }
 
-func setupConfig(cfg *istio.Config) {
+func setupConfig(_ resource.Context, cfg *istio.Config) {
 	if cfg == nil {
 		return
 	}

--- a/tests/integration/telemetry/stats/prometheus/http/wasm/stats_wasm_filter_test.go
+++ b/tests/integration/telemetry/stats/prometheus/http/wasm/stats_wasm_filter_test.go
@@ -16,6 +16,7 @@
 package wasm
 
 import (
+	"istio.io/istio/pkg/test/framework/resource"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
@@ -43,7 +44,7 @@ func TestMain(m *testing.M) {
 		Run()
 }
 
-func setupConfig(cfg *istio.Config) {
+func setupConfig(_ resource.Context, cfg *istio.Config) {
 	if cfg == nil {
 		return
 	}

--- a/tests/integration/telemetry/stats/prometheus/http/wasm/stats_wasm_filter_test.go
+++ b/tests/integration/telemetry/stats/prometheus/http/wasm/stats_wasm_filter_test.go
@@ -16,13 +16,13 @@
 package wasm
 
 import (
-	"istio.io/istio/pkg/test/framework/resource"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/features"
 	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
 	common "istio.io/istio/tests/integration/telemetry/stats/prometheus/http"
 )
 

--- a/tests/integration/telemetry/tracing/clienttracing/client_tracing_test.go
+++ b/tests/integration/telemetry/tracing/clienttracing/client_tracing_test.go
@@ -18,6 +18,7 @@ package client
 import (
 	"errors"
 	"fmt"
+	"istio.io/istio/pkg/test/framework/resource"
 	"testing"
 	"time"
 
@@ -75,7 +76,7 @@ func TestMain(m *testing.M) {
 		Run()
 }
 
-func setupConfig(cfg *istio.Config) {
+func setupConfig(_ resource.Context, cfg *istio.Config) {
 	if cfg == nil {
 		return
 	}

--- a/tests/integration/telemetry/tracing/clienttracing/client_tracing_test.go
+++ b/tests/integration/telemetry/tracing/clienttracing/client_tracing_test.go
@@ -18,7 +18,6 @@ package client
 import (
 	"errors"
 	"fmt"
-	"istio.io/istio/pkg/test/framework/resource"
 	"testing"
 	"time"
 
@@ -27,6 +26,7 @@ import (
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/util/retry"
 	util "istio.io/istio/tests/integration/telemetry"
 	"istio.io/istio/tests/integration/telemetry/tracing"

--- a/tests/integration/telemetry/tracing/servertracing/tracing_test.go
+++ b/tests/integration/telemetry/tracing/servertracing/tracing_test.go
@@ -18,13 +18,13 @@ package server
 import (
 	"errors"
 	"fmt"
-	"istio.io/istio/pkg/test/framework/resource"
 	"testing"
 	"time"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/util/retry"
 	util "istio.io/istio/tests/integration/telemetry"
 	"istio.io/istio/tests/integration/telemetry/tracing"

--- a/tests/integration/telemetry/tracing/servertracing/tracing_test.go
+++ b/tests/integration/telemetry/tracing/servertracing/tracing_test.go
@@ -18,6 +18,7 @@ package server
 import (
 	"errors"
 	"fmt"
+	"istio.io/istio/pkg/test/framework/resource"
 	"testing"
 	"time"
 
@@ -64,7 +65,7 @@ func TestMain(m *testing.M) {
 		Run()
 }
 
-func setupConfig(cfg *istio.Config) {
+func setupConfig(_ resource.Context, cfg *istio.Config) {
 	if cfg == nil {
 		return
 	}


### PR DESCRIPTION
Haven't fully looked into why this breaks things yet, but it causes ingress gateway in remote clusters to not come up during multicluster setup. Their logs have:

```
2020-09-01T18:24:40.785873Z	info	xdsproxy	connecting to upstream istiod-remote.istio-system.svc:15012
2020-09-01T18:24:40.801011Z	error	xdsproxy	upstream recv error: rpc error: code = Unknown desc = authentication failure
2020-09-01T18:24:40.801140Z	error	xdsproxy	downstream recv error: rpc error: code = Canceled desc = context canceled
2020-09-01T18:24:40.801490Z	warning	envoy config	StreamAggregatedResources gRPC config stream closed: 2, authentication failure
2020-09-01T18:24:54.663487Z	warn	Envoy proxy is NOT ready: config not received from Pilot (is Pilot running?): cds updates: 0 successful, 0 rejected; lds updates: 0 successful, 0 rejected
```

After this was added, the job started failing: https://prow.istio.io/?job=integ-pilot-multicluster-tests_istio

```
✔ Istiod installed
- Processing resources for Ingress gateways.
- Processing resources for Ingress gateways. Waiting for Deployment/istio-system/istio-ingressgat...
✔ Istiod installed
- Processing resources for Ingress gateways.
- Processing resources for Ingress gateways. Waiting for Deployment/istio-system/istio-ingressgat...
✘ Ingress gateways encountered an error: failed to wait for resource: resources not ready after 5m0s: timed out waiting for the condition
Deployment/istio-system/istio-ingressgateway
- Pruning removed resources
✘ Ingress gateways encountered an error: failed to wait for resource: resources not ready after 5m0s: timed out waiting for the condition
Deployment/istio-system/istio-ingressgateway
- Pruning removed resources2020-09-01T18:29:21.427118Z	info	tf	=== FAILED: Deploy Istio [Suite=pilot] ===
2020-09-01T18:29:21.427186Z	error	tf	=== Dumping Istio Deployment State...
2020-09-01T18:29:26.464652Z	error	tf	Test setup error: 2 errors occurred deploying remote clusters: 2 errors occurred:
	* failed deploying control plane to cluster cluster-4: install failed: failed to install manifests: errors occurred during operation
	* failed deploying control plane to cluster cluster-1: install failed: failed to install manifests: errors occurred during operation

```

cc @rshriram 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
