### PR TITLE
do not run gateway secret fetcher for file mounted certs

### DIFF
--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -430,18 +430,20 @@ func (sa *Agent) newSecretCache(namespace string) (gatewaySecretCache *cache.Sec
 	}
 	// TODO: use the common init !
 	// If gateway is using file mounted certs, we do not have to setup secret fetcher.
-	cs, err := kube.CreateClientset("", "")
-	if err != nil {
-		log.Errorf("failed to create secretFetcher for gateway proxy: %v", err)
-		os.Exit(1)
+	if !sa.secOpts.FileMountedCerts {
+		cs, err := kube.CreateClientset("", "")
+		if err != nil {
+			log.Errorf("failed to create secretFetcher for gateway proxy: %v", err)
+			os.Exit(1)
+		}
+
+		gSecretFetcher.FallbackSecretName = "gateway-fallback"
+
+		gSecretFetcher.InitWithKubeClientAndNs(cs.CoreV1(), namespace)
+
+		gatewaySecretChan = make(chan struct{})
+		gSecretFetcher.Run(gatewaySecretChan)
 	}
-
-	gSecretFetcher.FallbackSecretName = "gateway-fallback"
-
-	gSecretFetcher.InitWithKubeClientAndNs(cs.CoreV1(), namespace)
-
-	gatewaySecretChan = make(chan struct{})
-	gSecretFetcher.Run(gatewaySecretChan)
 	gatewaySecretCache = cache.NewSecretCache(gSecretFetcher, sds.NotifyProxy, sa.secOpts)
 	return gatewaySecretCache
 }


### PR DESCRIPTION
This got regressed in the recent refactoring. We do not have to run gateway secret fetcher (and secret controller) if gateway is using file mounted certs.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
