### PR TITLE
tracing: add support for OpenCensus

### DIFF
--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -321,7 +321,12 @@ func getProxyConfigOptions(config *meshAPI.ProxyConfig, metadata *model.Bootstra
 				option.StackDriverMaxAnnotations(getInt64ValueOrDefault(tracer.Stackdriver.MaxNumberOfAnnotations, 200)),
 				option.StackDriverMaxAttributes(getInt64ValueOrDefault(tracer.Stackdriver.MaxNumberOfAttributes, 200)),
 				option.StackDriverMaxEvents(getInt64ValueOrDefault(tracer.Stackdriver.MaxNumberOfMessageEvents, 200)))
+		case *meshAPI.Tracing_OpenCensusAgent_:
+			c := tracer.OpenCensusAgent.Context
+			opts = append(opts, option.OpenCensusAgentAddress(tracer.OpenCensusAgent.Address),
+				option.OpenCensusAgentContexts(c))
 		}
+
 		opts = append(opts, option.TracingTLS(config.Tracing.TlsSettings, metadata, isH2))
 	}
 

--- a/pkg/bootstrap/instance_test.go
+++ b/pkg/bootstrap/instance_test.go
@@ -253,6 +253,9 @@ func TestGolden(t *testing.T) {
 			},
 		},
 		{
+			base: "tracing_opencensusagent",
+		},
+		{
 			// Specify zipkin/statsd address, similar with the default config in v1 tests
 			base: "all",
 		},

--- a/pkg/bootstrap/option/convert.go
+++ b/pkg/bootstrap/option/convert.go
@@ -29,6 +29,7 @@ import (
 	pstruct "github.com/golang/protobuf/ptypes/struct"
 	"github.com/golang/protobuf/ptypes/wrappers"
 
+	meshAPI "istio.io/api/mesh/v1alpha1"
 	networkingAPI "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
@@ -177,6 +178,32 @@ func addressConverter(addr string) convertFunc {
 func durationConverter(value *types.Duration) convertFunc {
 	return func(*instance) (interface{}, error) {
 		return value.String(), nil
+	}
+}
+
+// openCensusAgentContextConverter returns a converter that returns the list of
+// distributed trace contexts to propagate with envoy.
+func openCensusAgentContextConverter(contexts []meshAPI.Tracing_OpenCensusAgent_TraceContext) convertFunc {
+	return func(*instance) (interface{}, error) {
+		if len(contexts) == 0 {
+			return convertToJSON([]string{"TRACE_CONTEXT", "GRPC_BIN", "CLOUD_TRACE_CONTEXT", "B3"}), nil
+		}
+
+		var envoyContexts []string
+		for _, c := range contexts {
+			switch c {
+			case meshAPI.Tracing_OpenCensusAgent_W3C_TRACE_CONTEXT:
+				envoyContexts = append(envoyContexts, "TRACE_CONTEXT")
+			case meshAPI.Tracing_OpenCensusAgent_GRPC_BIN:
+				envoyContexts = append(envoyContexts, "GRPC_BIN")
+			case meshAPI.Tracing_OpenCensusAgent_CLOUD_TRACE_CONTEXT:
+				envoyContexts = append(envoyContexts, "CLOUD_TRACE_CONTEXT")
+			case meshAPI.Tracing_OpenCensusAgent_B3:
+				envoyContexts = append(envoyContexts, "B3")
+				// Ignore UNSPECIFIED
+			}
+		}
+		return convertToJSON(envoyContexts), nil
 	}
 }
 

--- a/pkg/bootstrap/option/instances.go
+++ b/pkg/bootstrap/option/instances.go
@@ -103,6 +103,15 @@ func LightstepToken(value string) Instance {
 	return newOption("lightstepToken", value)
 }
 
+func OpenCensusAgentAddress(value string) Instance {
+	return newOptionOrSkipIfZero("openCensusAgent", value)
+}
+
+func OpenCensusAgentContexts(value []meshAPI.Tracing_OpenCensusAgent_TraceContext) Instance {
+	return newOption("openCensusAgentContexts", value).
+		withConvert(openCensusAgentContextConverter(value))
+}
+
 func StackDriverEnabled(value bool) Instance {
 	return newOption("stackdriver", value)
 }

--- a/pkg/bootstrap/option/instances_test.go
+++ b/pkg/bootstrap/option/instances_test.go
@@ -205,6 +205,37 @@ func TestOptions(t *testing.T) {
 			expected: "fake",
 		},
 		{
+			testName: "openCensusAgent address",
+			key:      "openCensusAgent",
+			option:   option.OpenCensusAgentAddress("fake-ocagent"),
+			expected: "fake-ocagent",
+		},
+		{
+			testName: "openCensusAgent empty context",
+			key:      "openCensusAgentContexts",
+			option:   option.OpenCensusAgentContexts([]meshAPI.Tracing_OpenCensusAgent_TraceContext{}),
+			expected: "[\"TRACE_CONTEXT\",\"GRPC_BIN\",\"CLOUD_TRACE_CONTEXT\",\"B3\"]",
+		},
+		{
+			testName: "openCensusAgent order context",
+			key:      "openCensusAgentContexts",
+			option: option.OpenCensusAgentContexts([]meshAPI.Tracing_OpenCensusAgent_TraceContext{
+				meshAPI.Tracing_OpenCensusAgent_CLOUD_TRACE_CONTEXT,
+				meshAPI.Tracing_OpenCensusAgent_B3,
+				meshAPI.Tracing_OpenCensusAgent_GRPC_BIN,
+				meshAPI.Tracing_OpenCensusAgent_W3C_TRACE_CONTEXT,
+			}),
+			expected: "[\"CLOUD_TRACE_CONTEXT\",\"B3\",\"GRPC_BIN\",\"TRACE_CONTEXT\"]",
+		},
+		{
+			testName: "openCensusAgent one context",
+			key:      "openCensusAgentContexts",
+			option: option.OpenCensusAgentContexts([]meshAPI.Tracing_OpenCensusAgent_TraceContext{
+				meshAPI.Tracing_OpenCensusAgent_B3,
+			}),
+			expected: "[\"B3\"]",
+		},
+		{
 			testName: "stackdriver enabled",
 			key:      "stackdriver",
 			option:   option.StackDriverEnabled(true),

--- a/pkg/bootstrap/testdata/tracing_opencensusagent.proxycfg
+++ b/pkg/bootstrap/testdata/tracing_opencensusagent.proxycfg
@@ -1,0 +1,12 @@
+config_path:               "/etc/istio/proxy"
+binary_path:               "/usr/local/bin/envoy"
+service_cluster:           "istio-proxy"
+drain_duration:            {seconds: 2}
+parent_shutdown_duration:  {seconds: 3}
+discovery_address:         "istio-pilot:15010"
+proxy_admin_port:          15000
+control_plane_auth_policy: NONE
+tracing:                   { open_census_agent: { address: "dns://my-oca/endpoint", context: [1] }}
+
+# Sets all relevant options to values different than default
+

--- a/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
+++ b/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
@@ -4,7 +4,7 @@
     "cluster": "istio-proxy",
     "locality": {
     },
-    "metadata": {"EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,MESH_ID,SERVICE_ACCOUNT,CLUSTER_ID","INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","PROXY_CONFIG":{"binaryPath":"/usr/local/bin/envoy","configPath":"/tmp/bootstrap/xdsproxy","customConfigFile":"envoy_bootstrap.json","discoveryAddress":"istio-pilot:15010","drainDuration":"2s","parentShutdownDuration":"3s","proxyAdminPort":15000,"serviceCluster":"istio-proxy"}}
+    "metadata": {"EXCHANGE_KEYS":"NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,MESH_ID,SERVICE_ACCOUNT,CLUSTER_ID","INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","PROXY_CONFIG":{"binaryPath":"/usr/local/bin/envoy","configPath":"/tmp/bootstrap/tracing_opencensusagent","customConfigFile":"envoy_bootstrap.json","discoveryAddress":"istio-pilot:15010","drainDuration":"2s","parentShutdownDuration":"3s","proxyAdminPort":15000,"serviceCluster":"istio-proxy","tracing":{"openCensusAgent":{"address":"dns://my-oca/endpoint","context":["W3C_TRACE_CONTEXT"]}}}}
   },
   "layered_runtime": {
       "layers": [
@@ -327,7 +327,9 @@
       } 
        , {
         "name": "xds-grpc",
-        "type" : "STATIC",
+        "type": "STRICT_DNS",
+        "respect_dns_ttl": true,
+        "dns_lookup_family": "V4_ONLY",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
         "load_assignment": {
@@ -336,9 +338,7 @@
             "lb_endpoints": [{
               "endpoint": {
                 "address":{
-                  "pipe": {
-                    "path": "./etc/istio/proxy/XDS"
-                  }
+                  "socket_address": {"address": "istio-pilot", "port_value": 15010}
                 }
               }
             }]
@@ -472,6 +472,28 @@
         ]
       }
     ]
+  }
+  ,
+  "tracing": {
+    "http": {
+      "name": "envoy.tracers.opencensus",
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.config.trace.v3.OpenCensusConfig",
+        "ocagent_exporter_enabled": true,
+        "ocagent_address": "dns://my-oca/endpoint",
+        "incoming_trace_context": ["TRACE_CONTEXT"],
+        "outgoing_trace_context": ["TRACE_CONTEXT"],
+        "trace_config": {
+          "constant_sampler": {
+            "decision": "ALWAYS_PARENT"
+          },
+          "max_number_of_annotations": 200,
+          "max_number_of_attributes": 200,
+          "max_number_of_message_events": 200,
+          "max_number_of_links": 200
+        }
+      }
+    }
   }
   
   

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -627,6 +627,29 @@
       }
     }
   }
+  {{- else if .openCensusAgent }}
+  ,
+  "tracing": {
+    "http": {
+      "name": "envoy.tracers.opencensus",
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.config.trace.v3.OpenCensusConfig",
+        "ocagent_exporter_enabled": true,
+        "ocagent_address": "{{ .openCensusAgent }}",
+        "incoming_trace_context": {{ .openCensusAgentContexts }},
+        "outgoing_trace_context": {{ .openCensusAgentContexts }},
+        "trace_config": {
+          "constant_sampler": {
+            "decision": "ALWAYS_PARENT"
+          },
+          "max_number_of_annotations": 200,
+          "max_number_of_attributes": 200,
+          "max_number_of_message_events": 200,
+          "max_number_of_links": 200
+        }
+      }
+    }
+  }
   {{- else if .stackdriver }}
   ,
   "tracing": {


### PR DESCRIPTION

Add support for OpenCensusAgent tracing. This is similar to the existing
Stackdriver support. This is tested by adding a new tracing bootstrap
golden test comparison and by individually testing the configuration
options, similar to the existing tracers.

This implements the API from this PR:
https://github.com/istio/api/pull/1563

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[X] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
