### PR TITLE
enable error log when istio-validation exits with a non-zero code

### DIFF
--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -65,8 +65,8 @@ var rootCmd = &cobra.Command{
 			}
 			validator := validation.NewValidator(cfg, hostIP)
 
-			if validator.Run() != nil {
-				os.Exit(constants.ValidationErrorCode)
+			if err := validator.Run(); err != nil {
+				handleErrorWithCode(err, constants.ValidationErrorCode)
 			}
 		}
 	},
@@ -140,8 +140,12 @@ func getLocalIP() (net.IP, error) {
 }
 
 func handleError(err error) {
+	handleErrorWithCode(err, 1)
+}
+
+func handleErrorWithCode(err error, code int) {
 	log.Errora(err)
-	os.Exit(1)
+	os.Exit(code)
 }
 
 func init() {
@@ -303,7 +307,6 @@ func GetCommand() *cobra.Command {
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		log.Errora(err)
-		os.Exit(1)
+		handleError(err)
 	}
 }


### PR DESCRIPTION
Please provide a description of what this PR is for.

Currently, we are unable to ascertain the exact root cause of an istio-validation container failure. It would be helpful to log the error message before exiting

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
