### PR TITLE
Fix istiod logs (no istio-proxy container)

### DIFF
--- a/tools/dump_kubernetes.sh
+++ b/tools/dump_kubernetes.sh
@@ -297,7 +297,7 @@ dump_istiod_url(){
   outfile="${dname}/$(basename "${url}")-${istiod_pod}"
 
   log "Fetching ${url} from istiod"
-  kubectl -n istio-system exec -it "${istiod_pod}" -c istio-proxy -- \
+  kubectl -n istio-system exec -it "${istiod_pod}" -- \
       curl "http://localhost:8080/${url}" > "${outfile}"
 }
 


### PR DESCRIPTION
Fixes #26552 

Before:
```
./dump_kubernetes.sh
Fetching debug/configz from istiod
Error from server (BadRequest): container istio-proxy is not valid for pod istiod-6f5fd7cb8f-5gjtv
Fetching debug/endpointz from istiod
Error from server (BadRequest): container istio-proxy is not valid for pod istiod-6f5fd7cb8f-5gjtv
Fetching debug/adsz from istiod
Error from server (BadRequest): container istio-proxy is not valid for pod istiod-6f5fd7cb8f-5gjtv
Fetching debug/authenticationz from istiod
Error from server (BadRequest): container istio-proxy is not valid for pod istiod-6f5fd7cb8f-5gjtv
Fetching metrics from istiod
Error from server (BadRequest): container istio-proxy is not valid for pod istiod-6f5fd7cb8f-5gjtv
Retrieving Kubernetes resource configurations
```

After:
```
./dump_kubernetes.sh
Fetching debug/configz from istiod
Fetching debug/endpointz from istiod
Fetching debug/adsz from istiod
Fetching debug/authenticationz from istiod
Fetching metrics from istiod
Retrieving Kubernetes resource configurations
```