### PR TITLE
Support for HTTP_ROUTE array insert in EnvoyFilter

### DIFF
--- a/pilot/pkg/model/envoyfilter.go
+++ b/pilot/pkg/model/envoyfilter.go
@@ -103,9 +103,10 @@ func convertToEnvoyFilterWrapper(local *config.Config) *EnvoyFilterWrapper {
 			cpw.Operation == networking.EnvoyFilter_Patch_INSERT_BEFORE ||
 			cpw.Operation == networking.EnvoyFilter_Patch_INSERT_FIRST {
 			// insert_before, after or first is applicable only for network filter and http filter
-			// TODO: insert before/after is also applicable to http_routes
 			// convert the rest to add
-			if cpw.ApplyTo != networking.EnvoyFilter_HTTP_FILTER && cpw.ApplyTo != networking.EnvoyFilter_NETWORK_FILTER {
+			if cpw.ApplyTo != networking.EnvoyFilter_HTTP_FILTER &&
+				cpw.ApplyTo != networking.EnvoyFilter_NETWORK_FILTER &&
+				cpw.ApplyTo != networking.EnvoyFilter_HTTP_ROUTE {
 				cpw.Operation = networking.EnvoyFilter_Patch_ADD
 			}
 		}

--- a/releasenotes/notes/27084.yaml
+++ b/releasenotes/notes/27084.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: traffic-management
+issue:
+ - 26692
+
+releaseNotes:
+- |
+  **Added** support for `INSERT_FIRST`, `INSERT_BEFORE`, `INSERT_AFTER` insert operations for `HTTP_ROUTE` in EnvoyFilter


### PR DESCRIPTION
Please provide a description for what this PR is for.

Adds support for `INSERT_FIRST`, `INSERT_BEFORE`, and `INSERT_AFTER` insert operations for HTTP_ROUTE's in EnvoyFilter.  Similar to filters, the order of routes matter, so `ADD` is insufficient

part of https://github.com/istio/istio/issues/26692

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
