### PR TITLE
istioctl: allow pods to be referred to indirectly, using service/<svc> or deployment/<dep>, like kubectl

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -225,6 +225,7 @@ github.com/evanphx/json-patch v0.0.0-20190815234213-e83c0a1c26c8 h1:DM7gHzQfHwIj
 github.com/evanphx/json-patch v0.0.0-20190815234213-e83c0a1c26c8/go.mod h1:pmLOTb3x90VhIKxsA9yeQG5yfOkkKnkk1h+Ql8NDYDw=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d h1:105gxyaGwCFad8crR9dcMQWvV9Hvulu6hwUh4tWPJnM=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
+github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/istioctl/cmd/authz.go
+++ b/istioctl/cmd/authz.go
@@ -35,7 +35,7 @@ var (
 
 var (
 	checkCmd = &cobra.Command{
-		Use:   "check <pod-name>[.<pod-namespace>]",
+		Use:   "check [<type>/]<name>[.<namespace>]",
 		Short: "Check AuthorizationPolicy applied in the pod.",
 		Long: `Check prints the AuthorizationPolicy applied to a pod by directly checking
 the Envoy configuration of the pod. The command is especially useful for inspecting 

--- a/istioctl/cmd/authz.go
+++ b/istioctl/cmd/authz.go
@@ -49,6 +49,9 @@ THIS COMMAND IS STILL UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
 		Example: `  # Check AuthorizationPolicy applied to pod httpbin-88ddbcfdd-nt5jb:
   istioctl x authz check httpbin-88ddbcfdd-nt5jb
 
+  # Check AuthorizationPolicy applied to one pod under a deployment
+  istioctl proxy-status deployment/productpage-v1
+
   # Check AuthorizationPolicy from Envoy config dump file:
   istioctl x authz check -f httpbin_config_dump.json`,
 		Args: func(cmd *cobra.Command, args []string) error {
@@ -67,7 +70,16 @@ THIS COMMAND IS STILL UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
 					return fmt.Errorf("failed to get config dump from file %s: %s", configDumpFile, err)
 				}
 			} else if len(args) == 1 {
-				podName, podNamespace := handlers.InferPodInfo(args[0], handlers.HandleNamespace(namespace, defaultNamespace))
+				kubeClient, err := kubeClient(kubeconfig, configContext)
+				if err != nil {
+					return fmt.Errorf("failed to create k8s client: %w", err)
+				}
+				podName, podNamespace, err := handlers.InferPodInfoFromTypedResource(args[0],
+					handlers.HandleNamespace(namespace, defaultNamespace),
+					kubeClient.UtilFactory())
+				if err != nil {
+					return err
+				}
 				configDump, err = getConfigDumpFromPod(podName, podNamespace)
 				if err != nil {
 					return fmt.Errorf("failed to get config dump from pod %s in %s", podName, podNamespace)

--- a/istioctl/cmd/dashboard.go
+++ b/istioctl/cmd/dashboard.go
@@ -230,11 +230,16 @@ func envoyDashCmd() *cobra.Command {
 		Use:   "envoy <pod-name[.namespace]>",
 		Short: "Open Envoy admin web UI",
 		Long:  `Open the Envoy admin dashboard for a sidecar`,
-		Example: `  istioctl dashboard envoy productpage-123-456.default
+		Example: `  # Open Envoy dashboard for the productpage-123-456.default pod
+  istioctl dashboard envoy productpage-123-456.default
+
+  # Open Envoy dashboard for one pod under a deployment
+  istioctl dashboard envoy deployment/productpage-v1
 
   # with short syntax
   istioctl dash envoy productpage-123-456.default
-  istioctl d envoy productpage-123-456.default`,
+  istioctl d envoy productpage-123-456.default
+`,
 		RunE: func(c *cobra.Command, args []string) error {
 			if labelSelector == "" && len(args) < 1 {
 				c.Println(c.UsageString())
@@ -270,7 +275,12 @@ func envoyDashCmd() *cobra.Command {
 				podName = pl.Items[0].Name
 				ns = pl.Items[0].Namespace
 			} else {
-				podName, ns = handlers.InferPodInfo(args[0], handlers.HandleNamespace(namespace, defaultNamespace))
+				podName, ns, err = handlers.InferPodInfoFromTypedResource(args[0],
+					handlers.HandleNamespace(namespace, defaultNamespace),
+					client.UtilFactory())
+				if err != nil {
+					return err
+				}
 			}
 
 			return portForward(podName, ns, fmt.Sprintf("Envoy sidecar %s", podName),
@@ -288,11 +298,16 @@ func controlZDashCmd() *cobra.Command {
 		Use:   "controlz <pod-name[.namespace]>",
 		Short: "Open ControlZ web UI",
 		Long:  `Open the ControlZ web UI for a pod in the Istio control plane`,
-		Example: `  istioctl dashboard controlz pilot-123-456.istio-system
+		Example: `  # Open ControlZ web UI for the istiod-123-456.istio-system pod
+  istioctl dashboard controlz istiod-123-456.istio-system
+
+  # Open ControlZ web UI for any Istiod pod
+  istioctl dashboard controlz deployment/istiod.istio-system
 
   # with short syntax
   istioctl dash controlz pilot-123-456.istio-system
-  istioctl d controlz pilot-123-456.istio-system`,
+  istioctl d controlz pilot-123-456.istio-system
+`,
 		RunE: func(c *cobra.Command, args []string) error {
 			if labelSelector == "" && len(args) < 1 {
 				c.Println(c.UsageString())
@@ -328,7 +343,12 @@ func controlZDashCmd() *cobra.Command {
 				podName = pl.Items[0].Name
 				ns = pl.Items[0].Namespace
 			} else {
-				podName, ns = handlers.InferPodInfo(args[0], handlers.HandleNamespace(namespace, defaultNamespace))
+				podName, ns, err = handlers.InferPodInfoFromTypedResource(args[0],
+					handlers.HandleNamespace(namespace, defaultNamespace),
+					client.UtilFactory())
+				if err != nil {
+					return err
+				}
 			}
 
 			return portForward(podName, ns, fmt.Sprintf("ControlZ %s", podName),

--- a/istioctl/cmd/dashboard.go
+++ b/istioctl/cmd/dashboard.go
@@ -227,7 +227,7 @@ func zipkinDashCmd() *cobra.Command {
 // port-forward to sidecar Envoy admin port; open browser
 func envoyDashCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "envoy <pod-name[.namespace]>",
+		Use:   "envoy [<type>/]<name>[.<namespace>]",
 		Short: "Open Envoy admin web UI",
 		Long:  `Open the Envoy admin dashboard for a sidecar`,
 		Example: `  # Open Envoy dashboard for the productpage-123-456.default pod
@@ -295,7 +295,7 @@ func envoyDashCmd() *cobra.Command {
 func controlZDashCmd() *cobra.Command {
 	var opts clioptions.ControlPlaneOptions
 	cmd := &cobra.Command{
-		Use:   "controlz <pod-name[.namespace]>",
+		Use:   "controlz [<type>/]<name>[.<namespace>]",
 		Short: "Open ControlZ web UI",
 		Long:  `Open the ControlZ web UI for a pod in the Istio control plane`,
 		Example: `  # Open ControlZ web UI for the istiod-123-456.istio-system pod

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -31,6 +31,7 @@ import (
 	"istio.io/istio/istioctl/pkg/writer/envoy/configdump"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/host"
+	"istio.io/istio/pkg/kube"
 	"istio.io/pkg/log"
 )
 
@@ -299,7 +300,18 @@ func clusterConfigCmd() *cobra.Command {
 			var configWriter *configdump.ConfigWriter
 			var err error
 			if len(args) == 1 {
-				podName, ns := handlers.InferPodInfo(args[0], handlers.HandleNamespace(namespace, defaultNamespace))
+				var client kube.ExtendedClient
+				client, err = kubeClient(kubeconfig, configContext)
+				if err != nil {
+					return fmt.Errorf("failed to create k8s client: %w", err)
+				}
+				var podName, ns string
+				podName, ns, err = handlers.InferPodInfoFromTypedResource(args[0],
+					handlers.HandleNamespace(namespace, defaultNamespace),
+					client.UtilFactory())
+				if err != nil {
+					return err
+				}
 				configWriter, err = setupPodConfigdumpWriter(podName, ns, c.OutOrStdout())
 			} else {
 				configWriter, err = setupFileConfigdumpWriter(configDumpFile, c.OutOrStdout())
@@ -365,7 +377,18 @@ func listenerConfigCmd() *cobra.Command {
 			var configWriter *configdump.ConfigWriter
 			var err error
 			if len(args) == 1 {
-				podName, ns := handlers.InferPodInfo(args[0], handlers.HandleNamespace(namespace, defaultNamespace))
+				var client kube.ExtendedClient
+				client, err = kubeClient(kubeconfig, configContext)
+				if err != nil {
+					return fmt.Errorf("failed to create k8s client: %w", err)
+				}
+				var podName, ns string
+				podName, ns, err = handlers.InferPodInfoFromTypedResource(args[0],
+					handlers.HandleNamespace(namespace, defaultNamespace),
+					client.UtilFactory())
+				if err != nil {
+					return err
+				}
 				configWriter, err = setupPodConfigdumpWriter(podName, ns, c.OutOrStdout())
 			} else {
 				configWriter, err = setupFileConfigdumpWriter(configDumpFile, c.OutOrStdout())
@@ -432,7 +455,17 @@ func logCmd() *cobra.Command {
 			return nil
 		},
 		RunE: func(c *cobra.Command, args []string) error {
-			podName, ns := handlers.InferPodInfo(args[0], handlers.HandleNamespace(namespace, defaultNamespace))
+			kubeClient, err := kubeClient(kubeconfig, configContext)
+			if err != nil {
+				return fmt.Errorf("failed to create k8s client: %w", err)
+			}
+			var podName, ns string
+			podName, ns, err = handlers.InferPodInfoFromTypedResource(args[0],
+				handlers.HandleNamespace(namespace, defaultNamespace),
+				kubeClient.UtilFactory())
+			if err != nil {
+				return err
+			}
 			loggerNames, err := setupEnvoyLogConfig("", podName, ns)
 			if err != nil {
 				return err
@@ -545,7 +578,18 @@ func routeConfigCmd() *cobra.Command {
 			var configWriter *configdump.ConfigWriter
 			var err error
 			if len(args) == 1 {
-				podName, ns := handlers.InferPodInfo(args[0], handlers.HandleNamespace(namespace, defaultNamespace))
+				var client kube.ExtendedClient
+				client, err = kubeClient(kubeconfig, configContext)
+				if err != nil {
+					return fmt.Errorf("failed to create k8s client: %w", err)
+				}
+				var podName, ns string
+				podName, ns, err = handlers.InferPodInfoFromTypedResource(args[0],
+					handlers.HandleNamespace(namespace, defaultNamespace),
+					client.UtilFactory())
+				if err != nil {
+					return err
+				}
 				configWriter, err = setupPodConfigdumpWriter(podName, ns, c.OutOrStdout())
 			} else {
 				configWriter, err = setupFileConfigdumpWriter(configDumpFile, c.OutOrStdout())
@@ -612,7 +656,18 @@ func endpointConfigCmd() *cobra.Command {
 			var configWriter *clusters.ConfigWriter
 			var err error
 			if len(args) == 1 {
-				podName, ns := handlers.InferPodInfo(args[0], handlers.HandleNamespace(namespace, defaultNamespace))
+				var client kube.ExtendedClient
+				client, err = kubeClient(kubeconfig, configContext)
+				if err != nil {
+					return fmt.Errorf("failed to create k8s client: %w", err)
+				}
+				var podName, ns string
+				podName, ns, err = handlers.InferPodInfoFromTypedResource(args[0],
+					handlers.HandleNamespace(namespace, defaultNamespace),
+					client.UtilFactory())
+				if err != nil {
+					return err
+				}
 				configWriter, err = setupPodClustersWriter(podName, ns, c.OutOrStdout())
 			} else {
 				configWriter, err = setupFileClustersWriter(configDumpFile, c.OutOrStdout())
@@ -674,7 +729,18 @@ func bootstrapConfigCmd() *cobra.Command {
 			var configWriter *configdump.ConfigWriter
 			var err error
 			if len(args) == 1 {
-				podName, ns := handlers.InferPodInfo(args[0], handlers.HandleNamespace(namespace, defaultNamespace))
+				var client kube.ExtendedClient
+				client, err = kubeClient(kubeconfig, configContext)
+				if err != nil {
+					return fmt.Errorf("failed to create k8s client: %w", err)
+				}
+				var podName, ns string
+				podName, ns, err = handlers.InferPodInfoFromTypedResource(args[0],
+					handlers.HandleNamespace(namespace, defaultNamespace),
+					client.UtilFactory())
+				if err != nil {
+					return err
+				}
 				configWriter, err = setupPodConfigdumpWriter(podName, ns, c.OutOrStdout())
 			} else {
 				configWriter, err = setupFileConfigdumpWriter(configDumpFile, c.OutOrStdout())
@@ -718,7 +784,18 @@ func secretConfigCmd() *cobra.Command {
 			var configWriter *configdump.ConfigWriter
 			var err error
 			if len(args) == 1 {
-				podName, ns := handlers.InferPodInfo(args[0], handlers.HandleNamespace(namespace, defaultNamespace))
+				var client kube.ExtendedClient
+				client, err = kubeClient(kubeconfig, configContext)
+				if err != nil {
+					return fmt.Errorf("failed to create k8s client: %w", err)
+				}
+				var podName, ns string
+				podName, ns, err = handlers.InferPodInfoFromTypedResource(args[0],
+					handlers.HandleNamespace(namespace, defaultNamespace),
+					client.UtilFactory())
+				if err != nil {
+					return err
+				}
 				configWriter, err = setupPodConfigdumpWriter(podName, ns, c.OutOrStdout())
 			} else {
 				configWriter, err = setupFileConfigdumpWriter(configDumpFile, c.OutOrStdout())

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -272,7 +272,7 @@ func setupClustersEnvoyConfigWriter(debug []byte, out io.Writer) (*clusters.Conf
 
 func clusterConfigCmd() *cobra.Command {
 	clusterConfigCmd := &cobra.Command{
-		Use:   "cluster [<pod-name[.namespace]>]",
+		Use:   "cluster [<type>/]<name>[.<namespace>]",
 		Short: "Retrieves cluster configuration for the Envoy in the specified pod",
 		Long:  `Retrieve information about cluster configuration for the Envoy instance in the specified pod.`,
 		Example: `  # Retrieve summary about cluster configuration for a given pod from Envoy.
@@ -349,7 +349,7 @@ func clusterConfigCmd() *cobra.Command {
 
 func listenerConfigCmd() *cobra.Command {
 	listenerConfigCmd := &cobra.Command{
-		Use:   "listener [<pod-name[.namespace]>]",
+		Use:   "listener [<type>/]<name>[.<namespace>]",
 		Short: "Retrieves listener configuration for the Envoy in the specified pod",
 		Long:  `Retrieve information about listener configuration for the Envoy instance in the specified pod.`,
 		Example: `  # Retrieve summary about listener configuration for a given pod from Envoy.
@@ -427,7 +427,7 @@ func listenerConfigCmd() *cobra.Command {
 
 func logCmd() *cobra.Command {
 	logCmd := &cobra.Command{
-		Use:   "log <pod-name[.namespace]>",
+		Use:   "log [<type>/]<name>[.<namespace>]",
 		Short: "(experimental) Retrieves logging levels of the Envoy in the specified pod",
 		Long:  "(experimental) Retrieve information about logging levels of the Envoy instance in the specified pod, and update optionally",
 		Example: `  # Retrieve information about logging levels for a given pod from Envoy.
@@ -550,7 +550,7 @@ func logCmd() *cobra.Command {
 
 func routeConfigCmd() *cobra.Command {
 	routeConfigCmd := &cobra.Command{
-		Use:   "route [<pod-name[.namespace]>]",
+		Use:   "route [<type>/]<name>[.<namespace>]",
 		Short: "Retrieves route configuration for the Envoy in the specified pod",
 		Long:  `Retrieve information about route configuration for the Envoy instance in the specified pod.`,
 		Example: `  # Retrieve summary about route configuration for a given pod from Envoy.
@@ -623,7 +623,7 @@ func routeConfigCmd() *cobra.Command {
 
 func endpointConfigCmd() *cobra.Command {
 	endpointConfigCmd := &cobra.Command{
-		Use:   "endpoint [<pod-name[.namespace]>]",
+		Use:   "endpoint [<type>/]<name>[.<namespace>]",
 		Short: "Retrieves endpoint configuration for the Envoy in the specified pod",
 		Long:  `Retrieve information about endpoint configuration for the Envoy instance in the specified pod.`,
 		Example: `  # Retrieve full endpoint configuration for a given pod from Envoy.
@@ -707,7 +707,7 @@ func endpointConfigCmd() *cobra.Command {
 
 func bootstrapConfigCmd() *cobra.Command {
 	bootstrapConfigCmd := &cobra.Command{
-		Use:   "bootstrap [<pod-name[.namespace]>]",
+		Use:   "bootstrap [<type>/]<name>[.<namespace>]",
 		Short: "Retrieves bootstrap configuration for the Envoy in the specified pod",
 		Long:  `Retrieve information about bootstrap configuration for the Envoy instance in the specified pod.`,
 		Example: `  # Retrieve full bootstrap configuration for a given pod from Envoy.
@@ -760,7 +760,7 @@ func bootstrapConfigCmd() *cobra.Command {
 
 func secretConfigCmd() *cobra.Command {
 	secretConfigCmd := &cobra.Command{
-		Use:   "secret [<pod-name[.namespace]>]",
+		Use:   "secret [<type>/]<name>[.<namespace>]",
 		Short: "(experimental) Retrieves secret configuration for the Envoy in the specified pod",
 		Long:  `(experimental) Retrieve information about secret configuration for the Envoy instance in the specified pod.`,
 		Example: `  # Retrieve full secret configuration for a given pod from Envoy.

--- a/istioctl/cmd/proxyconfig_test.go
+++ b/istioctl/cmd/proxyconfig_test.go
@@ -109,6 +109,21 @@ func TestProxyConfig(t *testing.T) {
 			expectedString: "unable to retrieve Pod: pods \"invalid\" not found",
 			wantException:  true, // "istioctl proxy-config endpoint invalid" should fail
 		},
+		{ // supplying nonexistent deployment name should result in error
+			args:           strings.Split("proxy-config clusters deployment/random-gibberish", " "),
+			expectedString: `"deployment/random-gibberish" does not refer to a pod`,
+			wantException:  true,
+		},
+		{ // supplying nonexistent deployment name in nonexistent namespace
+			args:           strings.Split("proxy-config endpoint deployment/random-gibberish.bogus", " "),
+			expectedString: `"deployment/random-gibberish" does not refer to a pod`,
+			wantException:  true,
+		},
+		{ // supplying type that doesn't select pods should fail
+			args:           strings.Split("proxy-config listeners serviceaccount/sleep", " "),
+			expectedString: `"serviceaccount/sleep" does not refer to a pod`,
+			wantException:  true,
+		},
 	}
 
 	for i, c := range cases {

--- a/istioctl/cmd/proxystatus.go
+++ b/istioctl/cmd/proxystatus.go
@@ -50,6 +50,9 @@ Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in 
   # Retrieve sync diff for a single Envoy and Istiod
   istioctl proxy-status istio-egressgateway-59585c5b9c-ndc59.istio-system
 
+  # Retrieve sync diff between Istiod and one pod under a deployment
+  istioctl proxy-status deployment/productpage-v1
+
   # Write proxy config-dump to file, and compare to Istio control plane
   kubectl port-forward -n istio-system istio-egressgateway-59585c5b9c-ndc59 15000 &
   curl localhost:15000/config_dump > cd.json
@@ -233,8 +236,4 @@ Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in 
 	centralOpts.AttachControlPlaneFlags(statusCmd)
 
 	return statusCmd
-}
-
-func strPtr(val string) *string {
-	return &val
 }

--- a/istioctl/cmd/proxystatus.go
+++ b/istioctl/cmd/proxystatus.go
@@ -69,7 +69,12 @@ Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in 
 				return err
 			}
 			if len(args) > 0 {
-				podName, ns := handlers.InferPodInfo(args[0], handlers.HandleNamespace(namespace, defaultNamespace))
+				podName, ns, err := handlers.InferPodInfoFromTypedResource(args[0],
+					handlers.HandleNamespace(namespace, defaultNamespace),
+					kubeClient.UtilFactory())
+				if err != nil {
+					return err
+				}
 				var envoyDump []byte
 				if configDumpFile != "" {
 					envoyDump, err = readConfigFile(configDumpFile)
@@ -179,7 +184,12 @@ Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in 
 			}
 
 			if len(args) > 0 {
-				podName, ns := handlers.InferPodInfo(args[0], handlers.HandleNamespace(namespace, defaultNamespace))
+				podName, ns, err := handlers.InferPodInfoFromTypedResource(args[0],
+					handlers.HandleNamespace(namespace, defaultNamespace),
+					kubeClient.UtilFactory())
+				if err != nil {
+					return err
+				}
 				path := "config_dump"
 				envoyDump, err := kubeClient.EnvoyDo(context.TODO(), podName, ns, "GET", path, nil)
 				if err != nil {
@@ -223,4 +233,8 @@ Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in 
 	centralOpts.AttachControlPlaneFlags(statusCmd)
 
 	return statusCmd
+}
+
+func strPtr(val string) *string {
+	return &val
 }

--- a/istioctl/cmd/proxystatus.go
+++ b/istioctl/cmd/proxystatus.go
@@ -38,7 +38,7 @@ func statusCommand() *cobra.Command {
 	var opts clioptions.ControlPlaneOptions
 
 	statusCmd := &cobra.Command{
-		Use:   "proxy-status [<pod-name[.namespace]>]",
+		Use:   "proxy-status [<type>/]<name>[.<namespace>]",
 		Short: "Retrieves the synchronization status of each Envoy in the mesh [kube only]",
 		Long: `
 Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in the mesh
@@ -150,7 +150,7 @@ func xdsStatusCommand() *cobra.Command {
 	var centralOpts clioptions.CentralControlPlaneOptions
 
 	statusCmd := &cobra.Command{
-		Use:   "proxy-status [<pod-name[.namespace]>]",
+		Use:   "proxy-status [<type>/]<name>[.<namespace>]",
 		Short: "Retrieves the synchronization status of each Envoy in the mesh",
 		Long: `
 Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in the mesh

--- a/istioctl/cmd/proxystatus_test.go
+++ b/istioctl/cmd/proxystatus_test.go
@@ -30,6 +30,18 @@ func TestProxyStatus(t *testing.T) {
 			args:           strings.Split("ps", " "),
 			expectedString: "NAME     CDS     LDS     EDS     RDS     ISTIOD",
 		},
+		{ // case 2: supplying nonexistent pod name should result in error with flag
+			args:          strings.Split("proxy-status deployment/random-gibberish", " "),
+			wantException: true,
+		},
+		{ // case 3: supplying nonexistent deployment name
+			args:          strings.Split("proxy-status deployment/random-gibberish.default", " "),
+			wantException: true,
+		},
+		{ // case 4: supplying nonexistent deployment name in nonexistent namespace
+			args:          strings.Split("proxy-status deployment/random-gibberish.bogus", " "),
+			wantException: true,
+		},
 		{ // case 5: supplying nonexistent pod name should result in error with --sds flag
 			args:          strings.Split("proxy-status random-gibberish-podname-61789237418234", " "),
 			wantException: true,

--- a/istioctl/cmd/proxystatus_test.go
+++ b/istioctl/cmd/proxystatus_test.go
@@ -42,13 +42,17 @@ func TestProxyStatus(t *testing.T) {
 			args:          strings.Split("proxy-status deployment/random-gibberish.bogus", " "),
 			wantException: true,
 		},
-		{ // case 5: supplying nonexistent pod name should result in error with --sds flag
+		{ // case 5: supplying nonexistent pod name should result in error
 			args:          strings.Split("proxy-status random-gibberish-podname-61789237418234", " "),
 			wantException: true,
 		},
 		{ // case 6: new --revision argument
 			args:           strings.Split("proxy-status --revision canary", " "),
 			expectedString: "NAME     CDS     LDS     EDS     RDS     ISTIOD",
+		},
+		{ // case 7: supplying type that doesn't select pods should fail
+			args:          strings.Split("proxy-status serviceaccount/sleep", " "),
+			wantException: true,
 		},
 	}
 

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -171,6 +171,9 @@ type ExtendedClient interface {
 	// CreatePerRPCCredentials creates a gRPC bearer token provider that can create (and renew!) Istio tokens
 	CreatePerRPCCredentials(ctx context.Context, tokenNamespace, tokenServiceAccount string, audiences []string,
 		expirationSeconds int64) (credentials.PerRPCCredentials, error)
+
+	// UtilFactory returns a kubectl factory
+	UtilFactory() util.Factory
 }
 
 var _ Client = &client{}
@@ -178,6 +181,7 @@ var _ ExtendedClient = &client{}
 
 const resyncInterval = 0
 
+// NewFakeClient creates a new, fake, client
 func NewFakeClient(objects ...runtime.Object) Client {
 	var c client
 	c.Interface = fake.NewSimpleClientset(objects...)
@@ -637,6 +641,10 @@ func (c *client) ApplyYAMLFilesDryRun(namespace string, yamlFiles ...string) err
 func (c *client) CreatePerRPCCredentials(ctx context.Context, tokenNamespace, tokenServiceAccount string, audiences []string,
 	expirationSeconds int64) (credentials.PerRPCCredentials, error) {
 	return NewRPCCredentials(c, tokenNamespace, tokenServiceAccount, audiences, expirationSeconds)
+}
+
+func (c *client) UtilFactory() util.Factory {
+	return c.clientFactory
 }
 
 func (c *client) applyYAMLFile(namespace string, dryRun bool, file string) error {

--- a/pkg/test/kube/mock_client.go
+++ b/pkg/test/kube/mock_client.go
@@ -204,8 +204,6 @@ func (c MockClient) NewPortForwarder(_, _, _ string, _, _ int) (kube.PortForward
 // UtilFactory should mock kubectl's utility factory, but is unimplemented
 func (c MockClient) UtilFactory() util.Factory {
 	tf := cmdtesting.NewTestFactory()
-	// @@@ ecs TODO call tf.Cleanup() when it is time to clean up (which means the test func must be involved?)
-	// defer tf.Cleanup()
 	_, _, codec := cmdtesting.NewExternalScheme()
 	tf.UnstructuredClient = &fake.RESTClient{
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,

--- a/pkg/test/kube/mock_client.go
+++ b/pkg/test/kube/mock_client.go
@@ -17,11 +17,13 @@ package kube
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"google.golang.org/grpc/credentials"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	kubeVersion "k8s.io/apimachinery/pkg/version"
+	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/informers"
@@ -29,6 +31,9 @@ import (
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/metadata/metadatainformer"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/rest/fake"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+	"k8s.io/kubectl/pkg/cmd/util"
 	serviceapisclient "sigs.k8s.io/service-apis/pkg/client/clientset/versioned"
 	serviceapisinformer "sigs.k8s.io/service-apis/pkg/client/informers/externalversions"
 
@@ -194,4 +199,21 @@ func (c MockClient) PodLogs(_ context.Context, _ string, _ string, _ string, _ b
 
 func (c MockClient) NewPortForwarder(_, _, _ string, _, _ int) (kube.PortForwarder, error) {
 	return nil, fmt.Errorf("TODO MockClient doesn't implement port forwarding")
+}
+
+// UtilFactory should mock kubectl's utility factory, but is unimplemented
+func (c MockClient) UtilFactory() util.Factory {
+	tf := cmdtesting.NewTestFactory()
+	// @@@ ecs TODO call tf.Cleanup() when it is time to clean up (which means the test func must be involved?)
+	// defer tf.Cleanup()
+	_, _, codec := cmdtesting.NewExternalScheme()
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     cmdtesting.DefaultHeader(),
+			Body: cmdtesting.ObjBody(codec,
+				cmdtesting.NewInternalType("", "", "foo"))},
+	}
+	return tf
 }

--- a/pkg/test/kube/mock_client.go
+++ b/pkg/test/kube/mock_client.go
@@ -201,7 +201,8 @@ func (c MockClient) NewPortForwarder(_, _, _ string, _, _ int) (kube.PortForward
 	return nil, fmt.Errorf("TODO MockClient doesn't implement port forwarding")
 }
 
-// UtilFactory should mock kubectl's utility factory, but is unimplemented
+// UtilFactory mock's kubectl's utility factory.  This code sets up a fake factory,
+// similar to the one in https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/describe/describe_test.go
 func (c MockClient) UtilFactory() util.Factory {
 	tf := cmdtesting.NewTestFactory()
 	_, _, codec := cmdtesting.NewExternalScheme()

--- a/releasenotes/notes/27086.yaml
+++ b/releasenotes/notes/27086.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue:
+  - 26080
+
+releaseNotes:
+- |
+  **Added** istioctl commands may now refer to pods indirectly, for example 'istioctl dashboard envoy deployment/httpbin'


### PR DESCRIPTION
For https://github.com/istio/istio/issues/26080

Instead of knowing the pod name, e.g. `istioctl proxy-status httpbin-6674f664d-fw2hd`, users will be able to imply the pod from other types, similar to how 'kubectl logs' or 'kubectl exec' work.  For example

```
kubectl proxy-status deployment/httpbin
kubectl ps service/httpbin
```