### PR TITLE
Fix Inconsistent styling for istioctl example command reference

### DIFF
--- a/istioctl/cmd/add-to-mesh.go
+++ b/istioctl/cmd/add-to-mesh.go
@@ -77,18 +77,17 @@ Use 'add-to-mesh' as an alternate to namespace-wide auto injection for troublesh
 The 'remove-from-mesh' command can be used to restart with the sidecar removed.
 
 THESE COMMANDS ARE UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.`,
-		Example: `
-# Restart all productpage pods with an Istio sidecar
-istioctl experimental add-to-mesh service productpage
+		Example: `  # Restart all productpage pods with an Istio sidecar
+  istioctl experimental add-to-mesh service productpage
 
-# Restart just pods from the productpage-v1 deployment
-istioctl experimental add-to-mesh deployment productpage-v1
+  # Restart just pods from the productpage-v1 deployment
+  istioctl experimental add-to-mesh deployment productpage-v1
 
-# Restart just pods from the details-v1 deployment
-istioctl x add deployment details-v1
+  # Restart just pods from the details-v1 deployment
+  istioctl x add deployment details-v1
 
-# Control how meshed pods see an external service
-istioctl experimental add-to-mesh external-service vmhttp 172.12.23.125,172.12.23.126 \
+  # Control how meshed pods see an external service
+  istioctl experimental add-to-mesh external-service vmhttp 172.12.23.125,172.12.23.126 \
    http:9080 tcp:8888 --labels app=test,version=v1 --annotations env=stage --serviceaccount stageAdmin`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
@@ -136,16 +135,14 @@ See also 'istioctl experimental remove-from-mesh deployment' which does the reve
 
 THIS COMMAND IS UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
 `,
-		Example: `
-# Restart pods from the productpage-v1 deployment with Istio sidecar
-istioctl experimental add-to-mesh deployment productpage-v1
+		Example: `  # Restart pods from the productpage-v1 deployment with Istio sidecar
+  istioctl experimental add-to-mesh deployment productpage-v1
 
-# Restart pods from the details-v1 deployment with Istio sidecar
-istioctl x add-to-mesh deploy details-v1
+  # Restart pods from the details-v1 deployment with Istio sidecar
+  istioctl x add-to-mesh deploy details-v1
 
-# Restart pods from the ratings-v1 deployment with Istio sidecar
-istioctl x add dep ratings-v1
-`,
+  # Restart pods from the ratings-v1 deployment with Istio sidecar
+  istioctl x add dep ratings-v1`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return fmt.Errorf("expecting deployment name")
@@ -197,16 +194,14 @@ See also 'istioctl experimental remove-from-mesh service' which does the reverse
 
 THIS COMMAND IS UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
 `,
-		Example: `
-# Restart all productpage pods with an Istio sidecar
-istioctl experimental add-to-mesh service productpage
+		Example: `  # Restart all productpage pods with an Istio sidecar
+  istioctl experimental add-to-mesh service productpage
 
-# Restart all details-v1 pods with an Istio sidecar
-istioctl x add-to-mesh svc details-v1
+  # Restart all details-v1 pods with an Istio sidecar
+  istioctl x add-to-mesh svc details-v1
 
-# Restart all ratings-v1 pods with an Istio sidecar
-istioctl x add svc ratings-v1
-`,
+  # Restart all ratings-v1 pods with an Istio sidecar
+  istioctl x add svc ratings-v1`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return fmt.Errorf("expecting service name")
@@ -255,9 +250,8 @@ See also 'istioctl experimental remove-from-mesh external-service' which does th
 
 THIS COMMAND IS UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
 `,
-		Example: `
-# Control how meshed pods contact 172.12.23.125 and .126
-istioctl experimental add-to-mesh external-service vmhttp 172.12.23.125,172.12.23.126 \
+		Example: ` # Control how meshed pods contact 172.12.23.125 and .126
+  istioctl experimental add-to-mesh external-service vmhttp 172.12.23.125,172.12.23.126 \
    http:9080 tcp:8888 --labels app=test,version=v1 --annotations env=stage --serviceaccount stageAdmin`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 3 {

--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -85,29 +85,27 @@ func Analyze() *cobra.Command {
 	analysisCmd := &cobra.Command{
 		Use:   "analyze <file>...",
 		Short: "Analyze Istio configuration and print validation messages",
-		Example: `
-# Analyze the current live cluster
-istioctl analyze
+		Example: `  # Analyze the current live cluster
+  istioctl analyze
 
-# Analyze the current live cluster, simulating the effect of applying additional yaml files
-istioctl analyze a.yaml b.yaml my-app-config/
+  # Analyze the current live cluster, simulating the effect of applying additional yaml files
+  istioctl analyze a.yaml b.yaml my-app-config/
 
-# Analyze the current live cluster, simulating the effect of applying a directory of config recursively
-istioctl analyze --recursive my-istio-config/
+  # Analyze the current live cluster, simulating the effect of applying a directory of config recursively
+  istioctl analyze --recursive my-istio-config/
 
-# Analyze yaml files without connecting to a live cluster
-istioctl analyze --use-kube=false a.yaml b.yaml my-app-config/
+  # Analyze yaml files without connecting to a live cluster
+  istioctl analyze --use-kube=false a.yaml b.yaml my-app-config/
 
-# Analyze the current live cluster and suppress PodMissingProxy for pod mypod in namespace 'testing'.
-istioctl analyze -S "IST0103=Pod mypod.testing"
+  # Analyze the current live cluster and suppress PodMissingProxy for pod mypod in namespace 'testing'.
+  istioctl analyze -S "IST0103=Pod mypod.testing"
 
-# Analyze the current live cluster and suppress PodMissingProxy for all pods in namespace 'testing',
-# and suppress MisplacedAnnotation on deployment foobar in namespace default.
-istioctl analyze -S "IST0103=Pod *.testing" -S "IST0107=Deployment foobar.default"
+  # Analyze the current live cluster and suppress PodMissingProxy for all pods in namespace 'testing',
+  # and suppress MisplacedAnnotation on deployment foobar in namespace default.
+  istioctl analyze -S "IST0103=Pod *.testing" -S "IST0107=Deployment foobar.default"
 
-# List available analyzers
-istioctl analyze -L
-`,
+  # List available analyzers
+  istioctl analyze -L`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			msgOutputFormat = strings.ToLower(msgOutputFormat)
 			_, ok := formatting.MsgOutputFormats[msgOutputFormat]

--- a/istioctl/cmd/config.go
+++ b/istioctl/cmd/config.go
@@ -47,10 +47,8 @@ func configCmd() *cobra.Command {
 		Use:   "config SUBCOMMAND",
 		Short: "Configure istioctl defaults",
 		Args:  cobra.NoArgs,
-		Example: `
-# list configuration parameters
-istioctl config list
-`,
+		Example: `  # list configuration parameters
+  istioctl config list`,
 	}
 	configCmd.AddCommand(listCommand())
 	return configCmd

--- a/istioctl/cmd/dashboard.go
+++ b/istioctl/cmd/dashboard.go
@@ -48,10 +48,14 @@ var (
 func promDashCmd() *cobra.Command {
 	var opts clioptions.ControlPlaneOptions
 	cmd := &cobra.Command{
-		Use:     "prometheus",
-		Short:   "Open Prometheus web UI",
-		Long:    `Open Istio's Prometheus dashboard`,
-		Example: `istioctl dashboard prometheus`,
+		Use:   "prometheus",
+		Short: "Open Prometheus web UI",
+		Long:  `Open Istio's Prometheus dashboard`,
+		Example: `  istioctl dashboard prometheus
+
+  # with short syntax
+  istioctl dash prometheus
+  istioctl d prometheus`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := kubeClientWithRevision(kubeconfig, configContext, opts.Revision)
 			if err != nil {
@@ -80,10 +84,14 @@ func promDashCmd() *cobra.Command {
 func grafanaDashCmd() *cobra.Command {
 	var opts clioptions.ControlPlaneOptions
 	cmd := &cobra.Command{
-		Use:     "grafana",
-		Short:   "Open Grafana web UI",
-		Long:    `Open Istio's Grafana dashboard`,
-		Example: `istioctl dashboard grafana`,
+		Use:   "grafana",
+		Short: "Open Grafana web UI",
+		Long:  `Open Istio's Grafana dashboard`,
+		Example: `  istioctl dashboard grafana
+
+  # with short syntax
+  istioctl dash grafana
+  istioctl d grafana`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := kubeClientWithRevision(kubeconfig, configContext, opts.Revision)
 			if err != nil {
@@ -112,10 +120,14 @@ func grafanaDashCmd() *cobra.Command {
 func kialiDashCmd() *cobra.Command {
 	var opts clioptions.ControlPlaneOptions
 	cmd := &cobra.Command{
-		Use:     "kiali",
-		Short:   "Open Kiali web UI",
-		Long:    `Open Istio's Kiali dashboard`,
-		Example: `istioctl dashboard kiali`,
+		Use:   "kiali",
+		Short: "Open Kiali web UI",
+		Long:  `Open Istio's Kiali dashboard`,
+		Example: `  istioctl dashboard kiali
+
+  # with short syntax
+  istioctl dash kiali
+  istioctl d kiali`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := kubeClientWithRevision(kubeconfig, configContext, opts.Revision)
 			if err != nil {
@@ -144,10 +156,14 @@ func kialiDashCmd() *cobra.Command {
 func jaegerDashCmd() *cobra.Command {
 	var opts clioptions.ControlPlaneOptions
 	cmd := &cobra.Command{
-		Use:     "jaeger",
-		Short:   "Open Jaeger web UI",
-		Long:    `Open Istio's Jaeger dashboard`,
-		Example: `istioctl dashboard jaeger`,
+		Use:   "jaeger",
+		Short: "Open Jaeger web UI",
+		Long:  `Open Istio's Jaeger dashboard`,
+		Example: `  istioctl dashboard jaeger
+
+  # with short syntax
+  istioctl dash jaeger
+  istioctl d jaeger`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := kubeClientWithRevision(kubeconfig, configContext, opts.Revision)
 			if err != nil {
@@ -176,10 +192,14 @@ func jaegerDashCmd() *cobra.Command {
 func zipkinDashCmd() *cobra.Command {
 	var opts clioptions.ControlPlaneOptions
 	cmd := &cobra.Command{
-		Use:     "zipkin",
-		Short:   "Open Zipkin web UI",
-		Long:    `Open Istio's Zipkin dashboard`,
-		Example: `istioctl dashboard zipkin`,
+		Use:   "zipkin",
+		Short: "Open Zipkin web UI",
+		Long:  `Open Istio's Zipkin dashboard`,
+		Example: `  istioctl dashboard zipkin
+
+  # with short syntax
+  istioctl dash zipkin
+  istioctl d zipkin`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := kubeClientWithRevision(kubeconfig, configContext, opts.Revision)
 			if err != nil {
@@ -207,10 +227,14 @@ func zipkinDashCmd() *cobra.Command {
 // port-forward to sidecar Envoy admin port; open browser
 func envoyDashCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "envoy <pod-name[.namespace]>",
-		Short:   "Open Envoy admin web UI",
-		Long:    `Open the Envoy admin dashboard for a sidecar`,
-		Example: `istioctl dashboard envoy productpage-123-456.default`,
+		Use:   "envoy <pod-name[.namespace]>",
+		Short: "Open Envoy admin web UI",
+		Long:  `Open the Envoy admin dashboard for a sidecar`,
+		Example: `  istioctl dashboard envoy productpage-123-456.default
+
+  # with short syntax
+  istioctl dash envoy productpage-123-456.default
+  istioctl d envoy productpage-123-456.default`,
 		RunE: func(c *cobra.Command, args []string) error {
 			if labelSelector == "" && len(args) < 1 {
 				c.Println(c.UsageString())
@@ -261,10 +285,14 @@ func envoyDashCmd() *cobra.Command {
 func controlZDashCmd() *cobra.Command {
 	var opts clioptions.ControlPlaneOptions
 	cmd := &cobra.Command{
-		Use:     "controlz <pod-name[.namespace]>",
-		Short:   "Open ControlZ web UI",
-		Long:    `Open the ControlZ web UI for a pod in the Istio control plane`,
-		Example: `istioctl dashboard controlz pilot-123-456.istio-system`,
+		Use:   "controlz <pod-name[.namespace]>",
+		Short: "Open ControlZ web UI",
+		Long:  `Open the ControlZ web UI for a pod in the Istio control plane`,
+		Example: `  istioctl dashboard controlz pilot-123-456.istio-system
+
+  # with short syntax
+  istioctl dash controlz pilot-123-456.istio-system
+  istioctl d controlz pilot-123-456.istio-system`,
 		RunE: func(c *cobra.Command, args []string) error {
 			if labelSelector == "" && len(args) < 1 {
 				c.Println(c.UsageString())

--- a/istioctl/cmd/deregister.go
+++ b/istioctl/cmd/deregister.go
@@ -28,8 +28,8 @@ var (
 	deregisterCmd = &cobra.Command{
 		Use:   "deregister <svcname> <ip>",
 		Short: "De-registers a service instance",
-		Example: `# de-register an endpoint 172.17.0.2 from service my-svc:
-istioctl deregister my-svc 172.17.0.2`,
+		Example: `  # de-register an endpoint 172.17.0.2 from service my-svc:
+  istioctl deregister my-svc 172.17.0.2`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 2 {
 				cmd.Println(cmd.UsageString())

--- a/istioctl/cmd/describe.go
+++ b/istioctl/cmd/describe.go
@@ -85,7 +85,7 @@ the configuration objects that affect that pod.
 
 THIS COMMAND IS STILL UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
 `,
-		Example: `istioctl experimental describe pod productpage-v1-c7765c886-7zzd4`,
+		Example: `  istioctl experimental describe pod productpage-v1-c7765c886-7zzd4`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return fmt.Errorf("expecting pod name")
@@ -1004,7 +1004,7 @@ the configuration objects that affect that service.
 
 THIS COMMAND IS STILL UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
 `,
-		Example: `istioctl experimental describe service productpage`,
+		Example: `  istioctl experimental describe service productpage`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				cmd.Println(cmd.UsageString())

--- a/istioctl/cmd/kubeinject.go
+++ b/istioctl/cmd/kubeinject.go
@@ -168,7 +168,6 @@ func injectCommand() *cobra.Command {
 		Use:   "kube-inject",
 		Short: "Inject Envoy sidecar into Kubernetes pod resources",
 		Long: `
-
 kube-inject manually injects the Envoy sidecar into Kubernetes
 workloads. Unsupported resources are left unmodified so it is safe to
 run kube-inject over a single file that contains multiple Service,
@@ -184,26 +183,25 @@ The Istio project is continually evolving so the Istio sidecar
 configuration may change unannounced. When in doubt re-run istioctl
 kube-inject on deployments to get the most up-to-date changes.
 `,
-		Example: `
-# Update resources on the fly before applying.
-kubectl apply -f <(istioctl kube-inject -f <resource.yaml>)
+		Example: `  # Update resources on the fly before applying.
+  kubectl apply -f <(istioctl kube-inject -f <resource.yaml>)
 
-# Create a persistent version of the deployment with Envoy sidecar
-# injected.
-istioctl kube-inject -f deployment.yaml -o deployment-injected.yaml
+  # Create a persistent version of the deployment with Envoy sidecar injected.
+  istioctl kube-inject -f deployment.yaml -o deployment-injected.yaml
 
-# Update an existing deployment.
-kubectl get deployment -o yaml | istioctl kube-inject -f - | kubectl apply -f -
+  # Update an existing deployment.
+  kubectl get deployment -o yaml | istioctl kube-inject -f - | kubectl apply -f -
 
-# Capture cluster configuration for later use with kube-inject
-kubectl -n istio-system get cm istio-sidecar-injector  -o jsonpath="{.data.config}" > /tmp/inj-template.tmpl
-kubectl -n istio-system get cm istio -o jsonpath="{.data.mesh}" > /tmp/mesh.yaml
-kubectl -n istio-system get cm istio-sidecar-injector -o jsonpath="{.data.values}" > /tmp/values.json
-# Use kube-inject based on captured configuration
-istioctl kube-inject -f samples/bookinfo/platform/kube/bookinfo.yaml \
-	--injectConfigFile /tmp/inj-template.tmpl \
-	--meshConfigFile /tmp/mesh.yaml \
-	--valuesFile /tmp/values.json
+  # Capture cluster configuration for later use with kube-inject
+  kubectl -n istio-system get cm istio-sidecar-injector  -o jsonpath="{.data.config}" > /tmp/inj-template.tmpl
+  kubectl -n istio-system get cm istio -o jsonpath="{.data.mesh}" > /tmp/mesh.yaml
+  kubectl -n istio-system get cm istio-sidecar-injector -o jsonpath="{.data.values}" > /tmp/values.json
+
+  # Use kube-inject based on captured configuration
+  istioctl kube-inject -f samples/bookinfo/platform/kube/bookinfo.yaml \
+    --injectConfigFile /tmp/inj-template.tmpl \
+    --meshConfigFile /tmp/mesh.yaml \
+    --valuesFile /tmp/values.json
 `,
 		RunE: func(c *cobra.Command, _ []string) (err error) {
 			if err = validateFlags(); err != nil {

--- a/istioctl/cmd/kubeuninject.go
+++ b/istioctl/cmd/kubeuninject.go
@@ -346,21 +346,17 @@ func uninjectCommand() *cobra.Command {
 		Use:   "kube-uninject",
 		Short: "Uninject Envoy sidecar from Kubernetes pod resources",
 		Long: `
-
 kube-uninject is used to prevent Istio from adding a sidecar and
 also provides the inverse of "istioctl kube-inject -f".
-
 `,
-		Example: `
-# Update resources before applying.
-kubectl apply -f <(istioctl experimental kube-uninject -f <resource.yaml>)
+		Example: `  # Update resources before applying.
+  kubectl apply -f <(istioctl experimental kube-uninject -f <resource.yaml>)
 
-# Create a persistent version of the deployment by removing Envoy sidecar.
-istioctl experimental kube-uninject -f deployment.yaml -o deployment-uninjected.yaml
+  # Create a persistent version of the deployment by removing Envoy sidecar.
+  istioctl experimental kube-uninject -f deployment.yaml -o deployment-uninjected.yaml
 
-# Update an existing deployment.
-kubectl get deployment -o yaml | istioctl experimental kube-uninject -f - | kubectl apply -f -
-`,
+  # Update an existing deployment.
+  kubectl get deployment -o yaml | istioctl experimental kube-uninject -f - | kubectl apply -f -`,
 		RunE: func(c *cobra.Command, _ []string) (err error) {
 
 			if err = validateUninjectFlags(); err != nil {

--- a/istioctl/cmd/metrics.go
+++ b/istioctl/cmd/metrics.go
@@ -52,13 +52,11 @@ and error rates are from the perspective of the service itself and not of an
 individual client (or aggregate set of clients). Rates and latencies are
 calculated over a time interval of 1 minute.
 `,
-		Example: `
-# Retrieve workload metrics for productpage-v1 workload
-istioctl experimental metrics productpage-v1
+		Example: `  # Retrieve workload metrics for productpage-v1 workload
+  istioctl experimental metrics productpage-v1
 
-# Retrieve workload metrics for various services in the different namespaces
-istioctl experimental metrics productpage-v1.foo reviews-v1.bar ratings-v1.baz
-`,
+  # Retrieve workload metrics for various services in the different namespaces
+  istioctl experimental metrics productpage-v1.foo reviews-v1.bar ratings-v1.baz`,
 		// nolint: goimports
 		Aliases: []string{"m"},
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -704,7 +704,7 @@ func secretConfigCmd() *cobra.Command {
   ssh <user@hostname> 'curl localhost:15000/config_dump' > envoy-config.json
   istioctl proxy-config secret --file envoy-config.json
 
-THIS COMMAND IS STILL UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
+  THIS COMMAND IS STILL UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
 `,
 		Aliases: []string{"s"},
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/istioctl/cmd/proxystatus.go
+++ b/istioctl/cmd/proxystatus.go
@@ -44,16 +44,16 @@ func statusCommand() *cobra.Command {
 Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in the mesh
 
 `,
-		Example: `# Retrieve sync status for all Envoys in a mesh
-	istioctl proxy-status
+		Example: `  # Retrieve sync status for all Envoys in a mesh
+  istioctl proxy-status
 
-# Retrieve sync diff for a single Envoy and Istiod
-	istioctl proxy-status istio-egressgateway-59585c5b9c-ndc59.istio-system
+  # Retrieve sync diff for a single Envoy and Istiod
+  istioctl proxy-status istio-egressgateway-59585c5b9c-ndc59.istio-system
 
-# Write proxy config-dump to file, and compare to Istio control plane
-    kubectl port-forward -n istio-system istio-egressgateway-59585c5b9c-ndc59 15000 &
-    curl localhost:15000/config_dump > cd.json
-    istioctl proxy-status istio-egressgateway-59585c5b9c-ndc59.istio-system --file cd.json
+  # Write proxy config-dump to file, and compare to Istio control plane
+  kubectl port-forward -n istio-system istio-egressgateway-59585c5b9c-ndc59 15000 &
+  curl localhost:15000/config_dump > cd.json
+  istioctl proxy-status istio-egressgateway-59585c5b9c-ndc59.istio-system --file cd.json
 `,
 		Aliases: []string{"ps"},
 		Args: func(cmd *cobra.Command, args []string) error {
@@ -146,31 +146,30 @@ func xdsStatusCommand() *cobra.Command {
 		Short: "Retrieves the synchronization status of each Envoy in the mesh",
 		Long: `
 Retrieves last sent and last acknowledged xDS sync from Istiod to each Envoy in the mesh
-
 `,
-		Example: `# Retrieve sync status for all Envoys in a mesh
-istioctl x proxy-status
+		Example: `  # Retrieve sync status for all Envoys in a mesh
+  istioctl x proxy-status
 
-# Retrieve sync diff for a single Envoy and Istiod
-istioctl x proxy-status istio-egressgateway-59585c5b9c-ndc59.istio-system
+  # Retrieve sync diff for a single Envoy and Istiod
+  istioctl x proxy-status istio-egressgateway-59585c5b9c-ndc59.istio-system
 
-# SECURITY OPTIONS
+  # SECURITY OPTIONS
 
-# Retrieve proxy status information directly from the control plane, using token security
-# (This is the usual way to get the proxy-status with an out-of-cluster control plane.)
-istioctl x ps --xds-address istio.cloudprovider.example.com:15012
+  # Retrieve proxy status information directly from the control plane, using token security
+  # (This is the usual way to get the proxy-status with an out-of-cluster control plane.)
+  istioctl x ps --xds-address istio.cloudprovider.example.com:15012
 
-# Retrieve proxy status information via Kubernetes config, using token security
-# (This is the usual way to get the proxy-status with an in-cluster control plane.)
-istioctl x proxy-status
+  # Retrieve proxy status information via Kubernetes config, using token security
+  # (This is the usual way to get the proxy-status with an in-cluster control plane.)
+  istioctl x proxy-status
 
-# Retrieve proxy status information directly from the control plane, using RSA certificate security
-# (Certificates must be obtained before this step.  The --cert-dir flag lets istioctl bypass the Kubernetes API server.)
-istioctl x ps --xds-address istio.example.com:15012 --cert-dir ~/.istio-certs
+  # Retrieve proxy status information directly from the control plane, using RSA certificate security
+  # (Certificates must be obtained before this step.  The --cert-dir flag lets istioctl bypass the Kubernetes API server.)
+  istioctl x ps --xds-address istio.example.com:15012 --cert-dir ~/.istio-certs
 
-# Retrieve proxy status information via XDS from specific control plane in multi-control plane in-cluster configuration
-# (Select a specific control plane in an in-cluster canary Istio configuration.)
-istioctl x ps --xds-label istio.io/rev=default
+  # Retrieve proxy status information via XDS from specific control plane in multi-control plane in-cluster configuration
+  # (Select a specific control plane in an in-cluster canary Istio configuration.)
+  istioctl x ps --xds-label istio.io/rev=default
 `,
 		Aliases: []string{"ps"},
 		RunE: func(c *cobra.Command, args []string) error {

--- a/istioctl/cmd/remove-from-mesh.go
+++ b/istioctl/cmd/remove-from-mesh.go
@@ -42,22 +42,18 @@ func removeFromMeshCmd() *cobra.Command {
 		Aliases: []string{"rm"},
 		Short:   "Remove workloads from Istio service mesh",
 		Long: `'istioctl experimental remove-from-mesh' restarts pods without an Istio sidecar or removes external service access configuration.
-
 Use 'remove-from-mesh' to quickly test uninjected behavior as part of compatibility troubleshooting.
-
 The 'add-to-mesh' command can be used to add or restore the sidecar.
 
 THESE COMMANDS ARE UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.`,
-		Example: `
-# Restart all productpage pods without an Istio sidecar
-istioctl experimental remove-from-mesh service productpage
+		Example: `  # Restart all productpage pods without an Istio sidecar
+  istioctl experimental remove-from-mesh service productpage
 
-# Restart all details-v1 pods without an Istio sidecar
-istioctl x rm service details-v1
+  # Restart all details-v1 pods without an Istio sidecar
+  istioctl x rm service details-v1
 
-# Restart all ratings-v1 pods without an Istio sidecar
-istioctl x rm deploy ratings-v1
-`,
+  # Restart all ratings-v1 pods without an Istio sidecar
+  istioctl x rm deploy ratings-v1`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.HelpFunc()(cmd, args)
 			if len(args) != 0 {
@@ -78,21 +74,18 @@ func deploymentUnMeshifyCmd() *cobra.Command {
 		Aliases: []string{"deploy", "dep"},
 		Short:   "Remove deployment from Istio service mesh",
 		Long: `'istioctl experimental remove-from-mesh deployment' restarts pods with the Istio sidecar un-injected.
-
 'remove-from-mesh' is a compatibility troubleshooting tool.
 
 THIS COMMAND IS UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
 `,
-		Example: `
-# Restart all productpage-v1 pods without an Istio sidecar
-istioctl experimental remove-from-mesh deployment productpage-v1
+		Example: `  # Restart all productpage-v1 pods without an Istio sidecar
+  istioctl experimental remove-from-mesh deployment productpage-v1
 
-# Restart all details-v1 pods without an Istio sidecar
-istioctl x remove-from-mesh deploy details-v1
+  # Restart all details-v1 pods without an Istio sidecar
+  istioctl x remove-from-mesh deploy details-v1
 
-# Restart all ratings-v1 pods without an Istio sidecar
-istioctl x rm dep ratings-v1
-`,
+  # Restart all ratings-v1 pods without an Istio sidecar
+  istioctl x rm dep ratings-v1`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return fmt.Errorf("expecting deployment name")
@@ -121,21 +114,18 @@ func svcUnMeshifyCmd() *cobra.Command {
 		Aliases: []string{"svc"},
 		Short:   "Remove Service from Istio service mesh",
 		Long: `'istioctl experimental remove-from-mesh service' restarts pods with the Istio sidecar un-injected.
-
 'remove-from-mesh' is a compatibility troubleshooting tool.
 
 THIS COMMAND IS UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
 `,
-		Example: `
-# Restart all productpage pods without an Istio sidecar
-istioctl experimental remove-from-mesh service productpage
+		Example: `  # Restart all productpage pods without an Istio sidecar
+  istioctl experimental remove-from-mesh service productpage
 
-# Restart all details-v1 pods without an Istio sidecar
-istioctl x remove-from-mesh svc details-v1
+  # Restart all details-v1 pods without an Istio sidecar
+  istioctl x remove-from-mesh svc details-v1
 
-# Restart all ratings-v1 pods without an Istio sidecar
-istioctl x rm svc ratings-v1
-`,
+  # Restart all ratings-v1 pods without an Istio sidecar
+  istioctl x rm svc ratings-v1`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return fmt.Errorf("expecting service name")
@@ -175,16 +165,14 @@ The typical usage scenario is Mesh Expansion on VMs.
 
 THIS COMMAND IS UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
 `,
-		Example: `
-# Remove "vmhttp" service entry rules
-istioctl experimental remove-from-mesh external-service vmhttp
+		Example: `  # Remove "vmhttp" service entry rules
+  istioctl experimental remove-from-mesh external-service vmhttp
 
-# Remove "vmhttp" service entry rules
-istioctl x remove-from-mesh es vmhttp
+  # Remove "vmhttp" service entry rules
+  istioctl x remove-from-mesh es vmhttp
 
-# Remove "vmhttp" service entry rules
-istioctl x rm es vmhttp
-`,
+  # Remove "vmhttp" service entry rules
+  istioctl x rm es vmhttp`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return fmt.Errorf("expecting external service name")

--- a/istioctl/cmd/sidecar-bootstrap.go
+++ b/istioctl/cmd/sidecar-bootstrap.go
@@ -546,13 +546,13 @@ the "--remote-scp-path" option.
 In order to start Istio on the remote node you must have docker installed on the remote node.
 Istio will be started on the host network as a docker container in capture mode.`,
 		Example: `  # Copy certificates to a WorkloadEntry named "we" in the "ns" namespace:
-	istioctl x sidecar-bootstrap we.ns
+  istioctl x sidecar-bootstrap we.ns
 
-	# Copy certificates, and start istio to a WorkloadEntry named "we" in the "ns" namespace:
-	istioctl x sidecar-bootstrap we.ns --start-istio-proxy
+  # Copy certificates, and start istio to a WorkloadEntry named "we" in the "ns" namespace:
+  istioctl x sidecar-bootstrap we.ns --start-istio-proxy
 
-	# Generate Certs locally, but do not copy them to a WorkloadEntry named "we" in the "ns" namespace:
-	istioctl x sidecar-bootstrap we.ns --local-dir path/where/i/want/certs/`,
+  # Generate Certs locally, but do not copy them to a WorkloadEntry named "we" in the "ns" namespace:
+  istioctl x sidecar-bootstrap we.ns --local-dir path/where/i/want/certs/`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if (len(args) == 1) == all {
 				cmd.Println(cmd.UsageString())

--- a/istioctl/cmd/wait.go
+++ b/istioctl/cmd/wait.go
@@ -57,12 +57,11 @@ func waitCmd() *cobra.Command {
 		Use:   "wait [flags] <type> <name>[.<namespace>]",
 		Short: "Wait for an Istio resource",
 		Long:  `Waits for the specified condition to be true of an Istio resource.`,
-		Example: `
-# Wait until the bookinfo virtual service has been distributed to all proxies in the mesh
-istioctl experimental wait --for=distribution virtualservice bookinfo.default
+		Example: `  # Wait until the bookinfo virtual service has been distributed to all proxies in the mesh
+  istioctl experimental wait --for=distribution virtualservice bookinfo.default
 
-# Wait until 99% of the proxies receive the distribution, timing out after 5 minutes
-istioctl experimental wait --for=distribution --threshold=.99 --timeout=300 virtualservice bookinfo.default
+  # Wait until 99% of the proxies receive the distribution, timing out after 5 minutes
+  istioctl experimental wait --for=distribution --threshold=.99 --timeout=300 virtualservice bookinfo.default
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			printVerbosef(cmd, "kubeconfig %s", kubeconfig)

--- a/istioctl/cmd/webhook.go
+++ b/istioctl/cmd/webhook.go
@@ -176,13 +176,12 @@ func newEnableCmd() *cobra.Command {
 		Long: "This command is used to enable webhook configurations after installing Istio.\n" +
 			"For previous Istio versions (e.g., 1.2, 1.3, etc), this command is not needed\n" +
 			"because in previous versions webhooks manage their own configurations.",
-		Example: `
-# Enable the webhook configuration of Galley with the given webhook configuration
-istioctl experimental post-install webhook enable --validation --webhook-secret istio.webhook.galley 
+		Example: `  # Enable the webhook configuration of Galley with the given webhook configuration
+  istioctl experimental post-install webhook enable --validation --webhook-secret istio.webhook.galley 
     --namespace istio-system --validation-path validatingwebhookconfiguration.yaml
 
-# Enable the webhook configuration of Galley with the given webhook configuration and CA certificate
-istioctl experimental post-install webhook enable --validation --webhook-secret istio.webhook.galley 
+  # Enable the webhook configuration of Galley with the given webhook configuration and CA certificate
+  istioctl experimental post-install webhook enable --validation --webhook-secret istio.webhook.galley 
     --namespace istio-system --validation-path validatingwebhookconfiguration.yaml --ca-bundle-file ./k8s-ca-cert.pem
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -241,13 +240,11 @@ func newDisableCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "disable",
 		Short: "Disable webhook configurations",
-		Example: `
-# Disable all webhooks
-istioctl experimental post-install webhook disable
+		Example: `  # Disable all webhooks
+  istioctl experimental post-install webhook disable
 
-# Disable all webhooks except injection
-istioctl experimental post-install webhook disable --injection=false
-`,
+  # Disable all webhooks except injection
+  istioctl experimental post-install webhook disable --injection=false`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Validate(); err != nil {
 				return err
@@ -306,13 +303,12 @@ func newStatusCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Get webhook configurations",
-		Example: `
-# Display the webhook configuration of Galley
-istioctl experimental post-install webhook status --validation --validation-config istio-galley
-# Display the webhook configuration of Galley and Sidecar Injector
-istioctl experimental post-install webhook status --validation --validation-config istio-galley 
-  --injection --injection-config istio-sidecar-injector
-`,
+		Example: `  # Display the webhook configuration of Galley
+  istioctl experimental post-install webhook status --validation --validation-config istio-galley
+
+  # Display the webhook configuration of Galley and Sidecar Injector
+  istioctl experimental post-install webhook status --validation --validation-config istio-galley 
+    --injection --injection-config istio-sidecar-injector`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Validate(); err != nil {
 				return err

--- a/istioctl/cmd/workload.go
+++ b/istioctl/cmd/workload.go
@@ -62,11 +62,11 @@ func workloadCommands() *cobra.Command {
 	workloadCmd := &cobra.Command{
 		Use:   "workload",
 		Short: "Commands to assist in configuring and deploying workloads running on VMs and other non-Kubernetes environments",
-		Example: `# workload group yaml generation
-workload group create
+		Example: `  # workload group yaml generation
+  workload group create
 
-# workload entry configuration generation
-workload entry configure`,
+  # workload entry configuration generation
+  workload entry configure`,
 	}
 	workloadCmd.AddCommand(groupCommand())
 	workloadCmd.AddCommand(entryCommand())
@@ -171,11 +171,11 @@ func configureCommand() *cobra.Command {
 		Long: `Generates all the required configuration files for workload instance on a VM or non-Kubernetes environment from a WorkloadGroup artifact.
 This includes a MeshConfig resource, the cluster.env file, and necessary certificates and security tokens.
 Configure requires either the WorkloadGroup artifact path or its location on the API server.`,
-		Example: `# configure example using a local WorkloadGroup artifact
-configure -f workloadgroup.yaml -o config
+		Example: `  # configure example using a local WorkloadGroup artifact
+  configure -f workloadgroup.yaml -o config
 
-# configure example using the API server
-configure --name foo --namespace bar -o config`,
+  # configure example using the API server
+  configure --name foo --namespace bar -o config`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if filename == "" && (name == "" || namespace == "") {
 				return fmt.Errorf("expecting a WorkloadGroup artifact file or the name and namespace of an existing WorkloadGroup")

--- a/istioctl/pkg/install/pre-check.go
+++ b/istioctl/pkg/install/pre-check.go
@@ -306,18 +306,16 @@ func NewPrecheckCommand() *cobra.Command {
 		Use:   "precheck [-f <deployment or istio operator file>]",
 		Short: "Checks Istio cluster compatibility",
 		Long: `
-		precheck inspects a Kubernetes cluster for Istio install requirements.
+  precheck inspects a Kubernetes cluster for Istio install requirements.
 `,
-		Example: `
-		# Verify that Istio can be installed
-		istioctl experimental precheck
+		Example: `  # Verify that Istio can be installed
+  istioctl experimental precheck
 
-		# Verify the deployment matches a custom Istio deployment configuration
-		istioctl x precheck --set profile=demo
+  # Verify the deployment matches a custom Istio deployment configuration
+  istioctl x precheck --set profile=demo
 
-		# Verify the deployment matches the Istio Operator deployment definition
-		istioctl x precheck -f iop.yaml
-`,
+  # Verify the deployment matches the Istio Operator deployment definition
+  istioctl x precheck -f iop.yaml`,
 		Args: cobra.ExactArgs(0),
 		RunE: func(c *cobra.Command, args []string) error {
 			targetNamespace := istioNamespace

--- a/istioctl/pkg/install/verify.go
+++ b/istioctl/pkg/install/verify.go
@@ -252,27 +252,25 @@ func NewVerifyCommand() *cobra.Command {
 		Use:   "verify-install [-f <deployment or istio operator file>] [--revision <revision>]",
 		Short: "Verifies Istio Installation Status",
 		Long: `
-		verify-install verifies Istio installation status against the installation file
-		you specified when you installed Istio. It loops through all the installation
-		resources defined in your installation file and reports whether all of them are
-		in ready status. It will report failure when any of them are not ready.
+verify-install verifies Istio installation status against the installation file
+you specified when you installed Istio. It loops through all the installation
+resources defined in your installation file and reports whether all of them are
+in ready status. It will report failure when any of them are not ready.
 
-		If you do not specify an installation it will check for an IstioOperator resource
-		and will verify if pods and services defined in it are present.
+If you do not specify an installation it will check for an IstioOperator resource
+and will verify if pods and services defined in it are present.
 
-		Note: For verifying whether your cluster is ready for Istio installation, see
-		istioctl experimental precheck.
+Note: For verifying whether your cluster is ready for Istio installation, see
+istioctl experimental precheck.
 `,
-		Example: `
-		# Verify that Istio is installed correctly via Istio Operator
-		istioctl verify-install
+		Example: `  # Verify that Istio is installed correctly via Istio Operator
+  istioctl verify-install
 
-		# Verify the deployment matches a custom Istio deployment configuration
-		istioctl verify-install -f $HOME/istio.yaml
+  # Verify the deployment matches a custom Istio deployment configuration
+  istioctl verify-install -f $HOME/istio.yaml
 
-		# Verify the deployment matches the Istio Operator deployment definition
-		istioctl verify-install --revision <canary>
-`,
+  # Verify the deployment matches the Istio Operator deployment definition
+  istioctl verify-install --revision <canary>`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(fileNameFlags.ToOptions().Filenames) > 0 && opts.Revision != "" {
 				cmd.Println(cmd.UsageString())

--- a/istioctl/pkg/multicluster/remote_secret.go
+++ b/istioctl/pkg/multicluster/remote_secret.go
@@ -89,19 +89,17 @@ func NewCreateRemoteSecretCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "create-remote-secret",
 		Short: "Create a secret with credentials to allow Istio to access remote Kubernetes apiservers",
-		Example: `
-# Create a secret to access cluster c0's apiserver and install it in cluster c1.
-istioctl --kubeconfig=c0.yaml x create-remote-secret --name c0 \
+		Example: `  # Create a secret to access cluster c0's apiserver and install it in cluster c1.
+  istioctl --kubeconfig=c0.yaml x create-remote-secret --name c0 \
     | kubectl --kubeconfig=c1.yaml apply -f -
 
-# Delete a secret that was previously installed in c1
-istioctl --kubeconfig=c0.yaml x create-remote-secret --name c0 \
+  # Delete a secret that was previously installed in c1
+  istioctl --kubeconfig=c0.yaml x create-remote-secret --name c0 \
     | kubectl --kubeconfig=c1.yaml delete -f -
 
-# Create a secret access a remote cluster with an auth plugin
-istioctl --kubeconfig=c0.yaml x create-remote-secret --name c0 --auth-type=plugin --auth-plugin-name=gcp \
-    | kubectl --kubeconfig=c1.yaml apply -f -
-`,
+  # Create a secret access a remote cluster with an auth plugin
+  istioctl --kubeconfig=c0.yaml x create-remote-secret --name c0 --auth-type=plugin --auth-plugin-name=gcp \
+    | kubectl --kubeconfig=c1.yaml apply -f -`,
 		Args: cobra.NoArgs,
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := opts.prepare(c.Flags()); err != nil {

--- a/istioctl/pkg/validate/validate.go
+++ b/istioctl/pkg/validate/validate.go
@@ -271,21 +271,20 @@ func NewValidateCommand(istioNamespace *string) *cobra.Command {
 		Use:     "validate -f FILENAME [options]",
 		Aliases: []string{"v"},
 		Short:   "Validate Istio policy and rules files",
-		Example: `
-		# Validate bookinfo-gateway.yaml
-		istioctl validate -f samples/bookinfo/networking/bookinfo-gateway.yaml
+		Example: `  # Validate bookinfo-gateway.yaml
+  istioctl validate -f samples/bookinfo/networking/bookinfo-gateway.yaml
 
-		# Validate bookinfo-gateway.yaml with shorthand syntax
-		istioctl v -f samples/bookinfo/networking/bookinfo-gateway.yaml
-		
-		# Validate current deployments under 'default' namespace within the cluster
-		kubectl get deployments -o yaml | istioctl validate -f -
+  # Validate bookinfo-gateway.yaml with shorthand syntax
+  istioctl v -f samples/bookinfo/networking/bookinfo-gateway.yaml
 
-		# Validate current services under 'default' namespace within the cluster
-		kubectl get services -o yaml | istioctl validate -f -
+  # Validate current deployments under 'default' namespace within the cluster
+  kubectl get deployments -o yaml | istioctl validate -f -
 
-		# Also see the related command 'istioctl analyze'
-		istioctl analyze samples/bookinfo/networking/bookinfo-gateway.yaml
+  # Validate current services under 'default' namespace within the cluster
+  kubectl get services -o yaml | istioctl validate -f -
+
+  # Also see the related command 'istioctl analyze'
+  istioctl analyze samples/bookinfo/networking/bookinfo-gateway.yaml
 `,
 		Args: cobra.NoArgs,
 		RunE: func(c *cobra.Command, _ []string) error {

--- a/operator/cmd/mesh/uninstall.go
+++ b/operator/cmd/mesh/uninstall.go
@@ -101,8 +101,7 @@ func UninstallCmd(logOpts *log.Options) *cobra.Command {
   istioctl x uninstall -f iop.yaml
   
   # Uninstall all control planes and shared resources
-  istioctl x uninstall --purge
-`,
+  istioctl x uninstall --purge`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if uiArgs.revision == "" && uiArgs.filename == "" && !uiArgs.purge {
 				return fmt.Errorf("at least one of the --revision, --filename or --purge flags must be set")


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/27106

From this output.
```
$ istioctl verify-install --help

Examples:

                # Verify that Istio is installed correctly via Istio Operator
                istioctl verify-install

                # Verify the deployment matches a custom Istio deployment configuration
                istioctl verify-install -f $HOME/istio.yaml

                # Verify the deployment matches the Istio Operator deployment definition
                istioctl verify-install --revision <canary>
```

To the output which is consistent with other cmd examples.
```
$ istioctl verify-install --help

Examples:
  # Verify that Istio is installed correctly via Istio Operator
  istioctl verify-install

  # Verify the deployment matches a custom Istio deployment configuration
  istioctl verify-install -f $HOME/istio.yaml

  # Verify the deployment matches the Istio Operator deployment definition
  istioctl verify-install --revision <canary>
```

Also added short syntax for dashboard commands.

```
istioctl dash grafana --help

Examples:
  istioctl dashboard grafana

  # with short syntax
  istioctl dash grafana
  istioctl d grafana
```

```
$ istioctl d kiali --help

Examples:
  istioctl dashboard kiali

  # with short syntax
  istioctl dash kiali
  istioctl d kiali
```
