### PR TITLE
Use kubectl version --short flag for bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,7 +31,7 @@ about: Report a bug to help us improve Istio
 
 **Steps to reproduce the bug**
 
-**Version (include the output of `istioctl version --remote` and `kubectl version` and `helm version` if you used Helm)**
+**Version (include the output of `istioctl version --remote` and `kubectl version --short` and `helm version` if you used Helm)**
 
 **How was Istio installed?**
 


### PR DESCRIPTION

This is easier to understand
```
$ kubectl version --short
Client Version: v1.19.0
Server Version: v1.18.2
```

As compared to the full version which has lot of information.
```yaml
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"19", GitVersion:"v1.19.0", GitCommit:"e19964183377d0ec2052d1f1fa930c4d7575bd50", GitTreeState:"clean", BuildDate:"2020-08-28T18:36:35Z", GoVersion:"go1.15", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.2", GitCommit:"52c56ce7a8272c798dbc29846288d7cd9fbae032", GitTreeState:"clean", BuildDate:"2020-04-30T20:19:45Z", GoVersion:"go1.13.9", Compiler:"gc", Platform:"linux/amd64"}
```
