### PR TITLE
Add instruction for local build if the compiled in charts are not found

### DIFF
--- a/operator/cmd/mesh/operator-dump.go
+++ b/operator/cmd/mesh/operator-dump.go
@@ -28,12 +28,7 @@ type operatorDumpArgs struct {
 
 func addOperatorDumpFlags(cmd *cobra.Command, args *operatorDumpArgs) {
 	hub, tag := buildversion.DockerInfo.Hub, buildversion.DockerInfo.Tag
-	if hub == "" {
-		hub = "gcr.io/istio-testing"
-	}
-	if tag == "" {
-		tag = "latest"
-	}
+
 	cmd.PersistentFlags().StringVar(&args.common.hub, "hub", hub, HubFlagHelpStr)
 	cmd.PersistentFlags().StringVar(&args.common.tag, "tag", tag, TagFlagHelpStr)
 	cmd.PersistentFlags().StringVar(&args.common.operatorNamespace, "operatorNamespace", operatorDefaultNamespace, OperatorNamespaceHelpstr)

--- a/operator/cmd/mesh/operator-init.go
+++ b/operator/cmd/mesh/operator-init.go
@@ -40,12 +40,7 @@ type operatorInitArgs struct {
 
 func addOperatorInitFlags(cmd *cobra.Command, args *operatorInitArgs) {
 	hub, tag := buildversion.DockerInfo.Hub, buildversion.DockerInfo.Tag
-	if hub == "" {
-		hub = "gcr.io/istio-testing"
-	}
-	if tag == "" {
-		tag = "latest"
-	}
+
 	cmd.PersistentFlags().StringVarP(&args.inFilename, "filename", "f", "", filenameFlagHelpStr)
 	cmd.PersistentFlags().StringVarP(&args.kubeConfigPath, "kubeconfig", "c", "", KubeConfigFlagHelpStr)
 	cmd.PersistentFlags().StringVar(&args.context, "context", "", ContextFlagHelpStr)

--- a/operator/pkg/helm/vfs_renderer.go
+++ b/operator/pkg/helm/vfs_renderer.go
@@ -30,9 +30,17 @@ import (
 const (
 	// DefaultProfileFilename is the name of the default profile yaml file.
 	DefaultProfileFilename = "default.yaml"
+	ChartsSubdirName       = "charts"
+	profilesRoot           = "profiles"
 
-	ChartsSubdirName = "charts"
-	profilesRoot     = "profiles"
+	// LocalBuildInfo provides instruction on how to build istio
+	// if the compiled in charts are not found
+	LocalBuildInfo = `
+ compiled in charts not found in this development build,
+ use manifests as local charts instead e.g:
+ - istioctl install --set hub=gcr.io/istio-testing -d manifests/
+ - or istioctl operator init --hub=gcr.io/istio-testing -d manifests/
+ - or run make gen-charts and rebuild istioctl`
 )
 
 // VFSRenderer is a helm template renderer that uses compiled-in helm charts.
@@ -175,8 +183,7 @@ func ListProfiles(charts string) ([]string, error) {
 // binaries using go build instead of make and tries to use compiled in charts.
 func CheckCompiledInCharts() error {
 	if _, err := vfs.Stat(ChartsSubdirName); err != nil {
-		return fmt.Errorf("compiled in charts not found in this development build, use --manifests with " +
-			"local charts instead (e.g. istioctl install --manifests manifests/) or run make gen-charts and rebuild istioctl")
+		return fmt.Errorf(LocalBuildInfo)
 	}
 	return nil
 }


### PR DESCRIPTION
Attempt to fix https://github.com/istio/istio/issues/27098 (workaround for now until we find better solution)

Based on https://github.com/istio/istio/issues/27098#issuecomment-688624355

`docker.io/istio/operator:1.8-dev`: we don't publish dev images to docker hub. see https://github.com/istio/istio/issues/27098#issuecomment-688576495

Prior to this PR.
```
$ ./out/linux_amd64/istioctl install
This will install the Istio profile into the cluster. Proceed? (y/N) y
Error: failed to install manifests: failed to read profiles: compiled in charts not found in this development build, use --manifests with local charts instead (e.g. istioctl install --manifests manifests/) or run make gen-charts and rebuild istioctl
```

This PR adds `hub=gcr.io/istio-testing` to fix local build.
```
$ ./out/linux_amd64/istioctl install
This will install the Istio profile into the cluster. Proceed? (y/N) y
Error: failed to install manifests: failed to read profiles: 
 compiled in charts not found in this development build,
 use manifests as local charts instead e.g:
 - istioctl install --set hub=gcr.io/istio-testing -d manifests/
 - or istioctl operator init --hub=gcr.io/istio-testing -d manifests/
 - or run make gen-charts and rebuild istioctl
```