### PR TITLE
Remove clusterrole and clusterrolebinding during istioctl operator remove

### DIFF
--- a/operator/pkg/helmreconciler/prune.go
+++ b/operator/pkg/helmreconciler/prune.go
@@ -70,6 +70,8 @@ var (
 	ClusterCPResources = []schema.GroupVersionKind{
 		{Group: "admissionregistration.k8s.io", Version: "v1beta1", Kind: name.MutatingWebhookConfigurationStr},
 		{Group: "admissionregistration.k8s.io", Version: "v1", Kind: name.MutatingWebhookConfigurationStr},
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: name.ClusterRoleStr},
+		{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: name.ClusterRoleBindingStr},
 	}
 	// AllClusterResources lists all cluster scope resources types which should be deleted in purge case, including CRD.
 	AllClusterResources = append(ClusterResources,


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/27065

Based on https://github.com/istio/istio/issues/27065#issuecomment-688019290
> The CRDs are supposed to kept in that cluster, but the clusterrole and clusterrolebinding are supposed to be removed from the cluster.

Before this PR: Where ClusterRole and ClusterRoleBinding were not deleted

```
$ kubectl get clusterrole | grep istio
istio-operator                                          2020-09-08T07:15:03Z

$ kubectl get clusterrolebinding | grep istio
istio-operator                                         ClusterRole/istio-operator
```
```
$ istioctl operator remove
Removing Istio operator...
  Removed Deployment:istio-operator:istio-operator.
  Removed Service:istio-operator:istio-operator.
  Removed ServiceAccount:istio-operator:istio-operator.
✔ Removal complete
```

After this PR:
```
$ ./out/linux_amd64/istioctl operator remove
Removing Istio operator...
  Removed Deployment:istio-operator:istio-operator.
  Removed Service:istio-operator:istio-operator.
  Removed ServiceAccount:istio-operator:istio-operator.
  Removed ClusterRole::istio-operator.
  Removed ClusterRoleBinding::istio-operator.
✔ Removal complete
```

**Note**: If you use `istioctl install` and  `istioctl x uninstall --purge`. everything will be removed.
