### PR TITLE
Fix contradictory labels for ClusterRoleBinding

### DIFF
--- a/manifests/charts/base/files/gen-istio-cluster.yaml
+++ b/manifests/charts/base/files/gen-istio-cluster.yaml
@@ -3493,9 +3493,9 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istiod-pilot-istio-system
+  name: istiod-istio-system
   labels:
-    app: pilot
+    app: istiod
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/charts/base/templates/clusterrolebinding.yaml
+++ b/manifests/charts/base/templates/clusterrolebinding.yaml
@@ -17,9 +17,9 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istiod-pilot-{{ .Values.global.istioNamespace }}
+  name: istiod-{{ .Values.global.istioNamespace }}
   labels:
-    app: pilot
+    app: istiod
     release: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -189,7 +189,7 @@ func TestManifestGenerateIstiodRemote(t *testing.T) {
 
 		g.Expect(objs.kind(name.ClusterRoleStr).nameEquals("istiod-istio-system")).Should(Not(BeNil()))
 		g.Expect(objs.kind(name.ClusterRoleStr).nameEquals("istio-reader-istio-system")).Should(Not(BeNil()))
-		g.Expect(objs.kind(name.ClusterRoleBindingStr).nameEquals("istiod-pilot-istio-system")).Should(Not(BeNil()))
+		g.Expect(objs.kind(name.ClusterRoleBindingStr).nameEquals("istiod-istio-system")).Should(Not(BeNil()))
 		g.Expect(objs.kind(name.ClusterRoleBindingStr).nameEquals("istio-reader-istio-system")).Should(Not(BeNil()))
 		g.Expect(objs.kind(name.CMStr).nameEquals("istio-sidecar-injector")).Should(Not(BeNil()))
 		g.Expect(objs.kind(name.ServiceStr).nameEquals("istiod")).Should(Not(BeNil()))

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/base/templates/clusterrolebinding.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/base/templates/clusterrolebinding.yaml
@@ -17,9 +17,9 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istiod-pilot-{{ .Values.global.istioNamespace }}
+  name: istiod-{{ .Values.global.istioNamespace }}
   labels:
-    app: pilot
+    app: istiod
     release: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -3521,9 +3521,9 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istiod-pilot-istio-system
+  name: istiod-istio-system
   labels:
-    app: pilot
+    app: istiod
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
@@ -6457,9 +6457,9 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istiod-pilot-istio-system
+  name: istiod-istio-system
   labels:
-    app: pilot
+    app: istiod
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Part of https://github.com/istio/istio/issues/27013

Found during https://github.com/istio/istio/pull/27123

Before this PR:
```
$ istioctl install

$ kubectl get clusterrolebinding | grep istio
istio-reader-istio-system                            ClusterRole/istio-reader-istio-system                                         6m50s
istiod-pilot-istio-system                            ClusterRole/istiod-istio-system                                                   6m50s
```

After this PR:
```
$ ./out/linux_amd64/istioctl install

$ kubectl get clusterrolebinding | grep istio
istio-reader-istio-system                          ClusterRole/istio-reader-istio-system                                       35s
istiod-istio-system                                ClusterRole/istiod-istio-system                                                    35s
```