### PR TITLE
Fix Kiali RBAC and bump to latest stable version that is compatible with Istio 1.7+

### DIFF
--- a/manifests/charts/istio-telemetry/kiali/templates/clusterrole.yaml
+++ b/manifests/charts/istio-telemetry/kiali/templates/clusterrole.yaml
@@ -44,10 +44,11 @@ rules:
       - get
       - list
       - watch
-  - apiGroups: 
+  - apiGroups:
     - config.istio.io
     - networking.istio.io
     - authentication.istio.io
+    - rbac.istio.io
     - security.istio.io
     resources: ["*"]
     verbs:
@@ -110,10 +111,11 @@ rules:
       - get
       - list
       - watch
-  - apiGroups: 
+  - apiGroups:
     - config.istio.io
     - networking.istio.io
     - authentication.istio.io
+    - rbac.istio.io
     - security.istio.io
     resources: ["*"]
     verbs:

--- a/manifests/charts/istio-telemetry/kiali/values.yaml
+++ b/manifests/charts/istio-telemetry/kiali/values.yaml
@@ -5,7 +5,7 @@ kiali:
   enabled: false # Note that if using the demo or demo-auth yaml when installing via Helm, this default will be `true`.
   replicaCount: 1
   hub: quay.io/kiali
-  tag: v1.22
+  tag: v1.23
   image: kiali
   contextPath: /kiali # The root context path to access the Kiali UI.
   nodeSelector: {}

--- a/manifests/charts/istio-telemetry/kiali/values.yaml
+++ b/manifests/charts/istio-telemetry/kiali/values.yaml
@@ -39,7 +39,7 @@ kiali:
 
   dashboard:
     auth:
-      strategy: login # Can be anonymous, login, openshift, or ldap
+      strategy: anonymous # Can be anonymous, openid, openshift, or ldap
       # ldap: # This is required to use the ldap strategy
       #   ldap_base: "DC=example,DC=com"
       #   ldap_bind_dn: "CN={USERID},OU=xyz,OU=Users,OU=Accounts,DC=example,DC=com"

--- a/releasenotes/notes/kiali-fix-rbac.yaml
+++ b/releasenotes/notes/kiali-fix-rbac.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: telemetry
+issue:
+- 27109
+releaseNotes:
+- |
+  **Fixed** an issue with Kiali RBAC permissions which prevented its deployment from working properly.
+upgradeNotes:
+- title: Default auth strategy for Kiali switched to **anonymous**.
+  content: Newer versions of Kiali that are compatible with Istio 1.7+, removed **login** auth strategy so we moved to the updated default one.


### PR DESCRIPTION
#### Description
Attempt to fix https://github.com/istio/istio/issues/27109

Merging directly at `release-1.7` branch as on `master` Kiali manifests have already been removed.

#### Changes Introduced
- **Kiali: Add rbac.istio.io apiGroup to clusterRoles**
Newer versions of Kiali that are compatible with Istio 1.7 require some additional permissions on the utilized clusterRoles. In this PR, we include the missing apiGroup to corresponding Kiali manifests.

- **Kiali: Bump minor version to 1.23** 

- **Kiali: Switch to anonymous auth strategy** 
In newer versions of Kiali that are compatible with Istio 1.7, auth login strategy has been removed thus not supported. In this PR, we are migrating to anonymous auth strategy which is also Kiali's default one.

#### Checklist
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[x] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure

[ ] Does not have any changes that may affect Istio users.
