### PR TITLE
Re-enable protocol sniffing test and add external

### DIFF
--- a/pkg/test/framework/components/echo/call.go
+++ b/pkg/test/framework/components/echo/call.go
@@ -43,6 +43,11 @@ type CallOptions struct {
 	// default is chosen for the target Instance.
 	Host string
 
+	// HostHeader specifies the "Host" header to be used on a request. This will override the Host
+	// field if set, in which case Host will be used for DNS resolution while HostHeader will be set
+	// as a header.
+	HostHeader string
+
 	// Path specifies the URL path for the HTTP(s) request.
 	Path string
 

--- a/pkg/test/framework/components/echo/common/call.go
+++ b/pkg/test/framework/components/echo/common/call.go
@@ -63,7 +63,7 @@ func CallEcho(c *client.Instance, opts *echo.CallOptions, outboundPortSelector O
 	protoHeaders := []*proto.Header{
 		{
 			Key:   "Host",
-			Value: targetHost,
+			Value: opts.HostHeader,
 		},
 	}
 	// Add headers in opts.Headers, e.g., authorization header, etc.
@@ -150,6 +150,11 @@ func fillInCallOptions(opts *echo.CallOptions) error {
 	if opts.Host == "" {
 		// No host specified, use the fully qualified domain name for the service.
 		opts.Host = opts.Target.Config().FQDN()
+	}
+
+	if opts.HostHeader == "" {
+		// No host specified, use the hostname for the service.
+		opts.HostHeader = opts.Target.Config().HostHeader()
 	}
 
 	if opts.Timeout <= 0 {

--- a/pkg/test/framework/components/echo/config.go
+++ b/pkg/test/framework/components/echo/config.go
@@ -29,6 +29,9 @@ type Config struct {
 	// Namespace of the echo Instance. If not provided, a default namespace "apps" is used.
 	Namespace namespace.Instance
 
+	// DefaultHostHeader overrides the default Host header for calls (`service.namespace.svc.cluster.local`)
+	DefaultHostHeader string
+
 	// Domain of the echo Instance. If not provided, a default will be selected.
 	Domain string
 
@@ -108,4 +111,12 @@ func (c Config) FQDN() string {
 		out += "." + c.Domain
 	}
 	return out
+}
+
+// HostHeader returns the Host header that will be used for calls to this service.
+func (c Config) HostHeader() string {
+	if c.DefaultHostHeader != "" {
+		return c.DefaultHostHeader
+	}
+	return c.FQDN()
 }

--- a/pkg/test/framework/components/echo/instances.go
+++ b/pkg/test/framework/components/echo/instances.go
@@ -81,7 +81,7 @@ func InNetwork(n string) Matcher {
 func (i Instances) Match(matches Matcher) Instances {
 	out := make(Instances, 0)
 	for _, i := range i {
-		if matches(i) {
+		if matches == nil || matches(i) {
 			out = append(out, i)
 		}
 	}

--- a/pkg/test/framework/components/echo/instances.go
+++ b/pkg/test/framework/components/echo/instances.go
@@ -81,7 +81,7 @@ func InNetwork(n string) Matcher {
 func (i Instances) Match(matches Matcher) Instances {
 	out := make(Instances, 0)
 	for _, i := range i {
-		if matches == nil || matches(i) {
+		if matches(i) {
 			out = append(out, i)
 		}
 	}

--- a/tests/integration/pilot/common/apps.go
+++ b/tests/integration/pilot/common/apps.go
@@ -64,13 +64,13 @@ const (
 )
 
 var EchoPorts = []echo.Port{
-	{Name: "http", Protocol: protocol.HTTP, ServicePort: 8080, InstancePort: 18080},
+	{Name: "http", Protocol: protocol.HTTP, ServicePort: 80, InstancePort: 18080},
 	{Name: "grpc", Protocol: protocol.GRPC, ServicePort: 7070, InstancePort: 17070},
 	{Name: "tcp", Protocol: protocol.TCP, ServicePort: 9090, InstancePort: 19090},
-	{Name: "tcp-server", Protocol: protocol.TCP, ServicePort: 6060, InstancePort: 16060, ServerFirst: true},
-	{Name: "auto-tcp", Protocol: protocol.TCP, ServicePort: 9091, InstancePort: 19091},
-	{Name: "auto-tcp-server", Protocol: protocol.TCP, ServicePort: 6061, InstancePort: 16061, ServerFirst: true},
-	{Name: "auto-http", Protocol: protocol.HTTP, ServicePort: 8081, InstancePort: 18081},
+	{Name: "tcp-server", Protocol: protocol.TCP, ServicePort: 9091, InstancePort: 16060, ServerFirst: true},
+	{Name: "auto-tcp", Protocol: protocol.TCP, ServicePort: 9092, InstancePort: 19091},
+	{Name: "auto-tcp-server", Protocol: protocol.TCP, ServicePort: 9093, InstancePort: 16061, ServerFirst: true},
+	{Name: "auto-http", Protocol: protocol.HTTP, ServicePort: 81, InstancePort: 18081},
 	{Name: "auto-grpc", Protocol: protocol.GRPC, ServicePort: 7071, InstancePort: 17071},
 }
 
@@ -210,7 +210,8 @@ spec:
 `); err != nil {
 		return err
 	}
-	if se, err := tmpl.Evaluate(`apiVersion: networking.istio.io/v1alpha3
+
+	se, err := tmpl.Evaluate(`apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: external-service
@@ -227,12 +228,12 @@ spec:
     number: {{$p.ServicePort}}
     protocol: "{{$p.Protocol}}"
 {{- end }}
-`, map[string]interface{}{"Namespace": apps.ExternalNamespace.Name(), "Hostname": externalHostname, "Ports": serviceEntryPorts()}); err != nil {
+`, map[string]interface{}{"Namespace": apps.ExternalNamespace.Name(), "Hostname": externalHostname, "Ports": serviceEntryPorts()})
+	if err != nil {
 		return err
-	} else {
-		if err := ctx.Config().ApplyYAML(apps.Namespace.Name(), se); err != nil {
-			return err
-		}
+	}
+	if err := ctx.Config().ApplyYAML(apps.Namespace.Name(), se); err != nil {
+		return err
 	}
 	return nil
 }

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -302,13 +302,14 @@ spec:
 // Todo merge with security TestReachability code
 func protocolSniffingCases(apps *EchoDeployments) []TrafficTestCase {
 	cases := []TrafficTestCase{}
-	// TODO add VMs to clients when DNS works for VMs.
+	// TODO add VMs to clients when DNS works for VMs. Blocked by https://github.com/istio/istio/issues/27154
 	for _, clients := range []echo.Instances{apps.PodA, apps.Naked, apps.Headless} {
 		for _, client := range clients {
 
 			destinationSets := []echo.Instances{
 				apps.PodA,
 				apps.VM,
+				apps.External,
 				// only hit same network naked services
 				apps.Naked.Match(echo.InNetwork(client.Config().Cluster.NetworkName())),
 				// only hit same cluster headless services
@@ -351,10 +352,22 @@ func protocolSniffingCases(apps *EchoDeployments) []TrafficTestCase {
 					cases = append(cases, TrafficTestCase{
 						name: fmt.Sprintf("%v %v->%v from %s", call.port, client.Config().Service, destination.Config().Service, client.Config().Cluster.Name()),
 						call: func() (echoclient.ParsedResponses, error) {
-							return client.Call(echo.CallOptions{Target: destination, PortName: call.port, Scheme: call.scheme, Count: callCount, Timeout: time.Second * 5})
+							return client.Call(echo.CallOptions{
+								Target:   destination,
+								PortName: call.port,
+								Scheme:   call.scheme,
+								Count:    callCount,
+								Timeout:  time.Second * 5,
+							})
 						},
 						validator: func(responses echoclient.ParsedResponses) error {
-							return responses.CheckOK()
+							if err := responses.CheckOK(); err != nil {
+								return err
+							}
+							if err := responses.CheckHost(destination.Config().HostHeader()); err != nil {
+								return err
+							}
+							return nil
 						},
 					})
 				}

--- a/tests/integration/pilot/mirror_test.go
+++ b/tests/integration/pilot/mirror_test.go
@@ -104,8 +104,12 @@ func TestMirroring(t *testing.T) {
 // Thus when "a" tries to mirror to the external service, it is actually connecting to "external" (which is not part of the
 // mesh because of the Sidecar), then we can inspect "external" logs to verify the requests were properly mirrored.
 func TestMirroringExternalService(t *testing.T) {
+	header := ""
+	if len(apps.External) > 0 {
+		header = apps.External[0].Config().HostHeader()
+	}
 	runMirrorTest(t, mirrorTestOptions{
-		mirrorHost: apps.External[0].Config().HostHeader(),
+		mirrorHost: header,
 		cases: []testCaseMirror{
 			{
 				name:                "mirror-external",

--- a/tests/integration/pilot/mirror_test.go
+++ b/tests/integration/pilot/mirror_test.go
@@ -105,7 +105,7 @@ func TestMirroring(t *testing.T) {
 // mesh because of the Sidecar), then we can inspect "external" logs to verify the requests were properly mirrored.
 func TestMirroringExternalService(t *testing.T) {
 	runMirrorTest(t, mirrorTestOptions{
-		mirrorHost: apps.External.GetOrFail(t, nil).Config().HostHeader(),
+		mirrorHost: apps.External[0].Config().HostHeader(),
 		cases: []testCaseMirror{
 			{
 				name:                "mirror-external",

--- a/tests/integration/pilot/mirror_test.go
+++ b/tests/integration/pilot/mirror_test.go
@@ -105,7 +105,7 @@ func TestMirroring(t *testing.T) {
 // mesh because of the Sidecar), then we can inspect "external" logs to verify the requests were properly mirrored.
 func TestMirroringExternalService(t *testing.T) {
 	runMirrorTest(t, mirrorTestOptions{
-		mirrorHost: apps.ExternalHost,
+		mirrorHost: apps.External.GetOrFail(t, nil).Config().HostHeader(),
 		cases: []testCaseMirror{
 			{
 				name:                "mirror-external",

--- a/tests/integration/telemetry/stackdriver/testdata/server_access_log.json.tmpl
+++ b/tests/integration/telemetry/stackdriver/testdata/server_access_log.json.tmpl
@@ -1,7 +1,7 @@
 {
     "http_request": {
         "request_method": "POST",
-        "request_url": "http://srv.{{ .EchoNamespace }}.svc.cluster.local:7070/proto.EchoTestService/Echo",
+        "request_url": "http://srv.{{ .EchoNamespace }}.svc.cluster.local/proto.EchoTestService/Echo",
         "protocol": "grpc",
         "status": "200"
     },

--- a/tests/integration/telemetry/stackdriver/vm/testdata/server_access_log.json.tmpl
+++ b/tests/integration/telemetry/stackdriver/vm/testdata/server_access_log.json.tmpl
@@ -1,7 +1,7 @@
 {
     "http_request": {
         "request_method": "GET",
-        "request_url": "http://server.{{ .EchoNamespace }}.svc.cluster.local:8090/",
+        "request_url": "http://server.{{ .EchoNamespace }}.svc.cluster.local/",
         "protocol": "http",
         "status": "200"
     },


### PR DESCRIPTION
This re-enables the sniffing tests, only skipping the TCP which is
currently flaky due to issues with our `echo` client which is being
addressed separately. In addition, we add testing of the external
service. To support this change, I added a way for an echo instance to
declare its default hostname. This way, we can treat it like any regular
service

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
