### PR TITLE
use cp topology as default cfg topology

### DIFF
--- a/pkg/test/framework/components/environment/kube/flags.go
+++ b/pkg/test/framework/components/environment/kube/flags.go
@@ -102,7 +102,7 @@ func parseKubeConfigs(value string) ([]string, error) {
 	return out, nil
 }
 
-func newControlPlaneTopology(kubeConfigs []string) (map[resource.ClusterIndex]resource.ClusterIndex, error) {
+func newControlPlaneTopology(kubeConfigs []string) (clusterTopology, error) {
 	topology, err := parseControlPlaneTopology()
 	if err != nil {
 		return nil, err
@@ -131,8 +131,8 @@ func newControlPlaneTopology(kubeConfigs []string) (map[resource.ClusterIndex]re
 	return topology, nil
 }
 
-func parseControlPlaneTopology() (map[resource.ClusterIndex]resource.ClusterIndex, error) {
-	out := make(map[resource.ClusterIndex]resource.ClusterIndex)
+func parseControlPlaneTopology() (clusterTopology, error) {
+	out := make(clusterTopology)
 	if controlPlaneTopology == "" {
 		return out, nil
 	}
@@ -156,7 +156,7 @@ func parseControlPlaneTopology() (map[resource.ClusterIndex]resource.ClusterInde
 	return out, nil
 }
 
-func newConfigTopology(kubeConfigs []string, fallback map[resource.ClusterIndex]resource.ClusterIndex) (map[resource.ClusterIndex]resource.ClusterIndex, error) {
+func newConfigTopology(kubeConfigs []string, fallback clusterTopology) (clusterTopology, error) {
 	topology, err := parseConfigTopology()
 	if err != nil {
 		return nil, err
@@ -185,8 +185,8 @@ func newConfigTopology(kubeConfigs []string, fallback map[resource.ClusterIndex]
 	return topology, nil
 }
 
-func parseConfigTopology() (map[resource.ClusterIndex]resource.ClusterIndex, error) {
-	out := make(map[resource.ClusterIndex]resource.ClusterIndex)
+func parseConfigTopology() (clusterTopology, error) {
+	out := make(clusterTopology)
 	if configTopology == "" {
 		return out, nil
 	}

--- a/pkg/test/framework/components/environment/kube/flags.go
+++ b/pkg/test/framework/components/environment/kube/flags.go
@@ -68,7 +68,7 @@ func NewSettingsFromCommandLine() (*Settings, error) {
 		return nil, err
 	}
 
-	s.ConfigTopology, err = newConfigTopology(s.KubeConfig)
+	s.ConfigTopology, err = newConfigTopology(s.KubeConfig, s.ControlPlaneTopology)
 	if err != nil {
 		return nil, err
 	}
@@ -156,16 +156,16 @@ func parseControlPlaneTopology() (map[resource.ClusterIndex]resource.ClusterInde
 	return out, nil
 }
 
-func newConfigTopology(kubeConfigs []string) (map[resource.ClusterIndex]resource.ClusterIndex, error) {
+func newConfigTopology(kubeConfigs []string, fallback map[resource.ClusterIndex]resource.ClusterIndex) (map[resource.ClusterIndex]resource.ClusterIndex, error) {
 	topology, err := parseConfigTopology()
 	if err != nil {
 		return nil, err
 	}
 
 	if len(topology) == 0 {
-		// Default to every cluster manages it's own config.
-		for index := range kubeConfigs {
-			topology[resource.ClusterIndex(index)] = resource.ClusterIndex(index)
+		// Default to every cluster using config from it's control plane cluster.
+		for k, v := range fallback {
+			topology[k] = v
 		}
 		return topology, nil
 	}

--- a/pkg/test/framework/components/environment/kube/settings.go
+++ b/pkg/test/framework/components/environment/kube/settings.go
@@ -24,6 +24,8 @@ import (
 	"istio.io/istio/pkg/test/framework/resource"
 )
 
+type clusterTopology = map[resource.ClusterIndex]resource.ClusterIndex
+
 // ClientFactoryFunc is a transformation function that creates k8s clients
 // from the provided k8s config files.
 type ClientFactoryFunc func(kubeConfigs []string) ([]istioKube.ExtendedClient, error)
@@ -48,7 +50,7 @@ type Settings struct {
 
 	// ControlPlaneTopology maps each cluster to the cluster that runs its control plane. For replicated control
 	// plane cases (where each cluster has its own control plane), the cluster will map to itself (e.g. 0->0).
-	ControlPlaneTopology map[resource.ClusterIndex]resource.ClusterIndex
+	ControlPlaneTopology clusterTopology
 
 	// networkTopology is used for the initial assignment of networks to each cluster.
 	// The source of truth clusters' networks is the Cluster instances themselves, rather than this field.
@@ -57,7 +59,7 @@ type Settings struct {
 	// ConfigTopology maps each cluster to the cluster that runs it's config.
 	// If the cluster runs its own config, the cluster will map to itself (e.g. 0->0)
 	// By default, we use the ControlPlaneTopology as the config topology.
-	ConfigTopology map[resource.ClusterIndex]resource.ClusterIndex
+	ConfigTopology clusterTopology
 }
 
 type SetupSettingsFunc func(s *Settings, ctx resource.Context)

--- a/pkg/test/framework/components/environment/kube/settings.go
+++ b/pkg/test/framework/components/environment/kube/settings.go
@@ -56,6 +56,7 @@ type Settings struct {
 
 	// ConfigTopology maps each cluster to the cluster that runs it's config.
 	// If the cluster runs its own config, the cluster will map to itself (e.g. 0->0)
+	// By default, we use the ControlPlaneTopology as the config topology.
 	ConfigTopology map[resource.ClusterIndex]resource.ClusterIndex
 }
 

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -425,6 +425,7 @@ spec:
 }
 
 func installConfigClusters(i *operatorComponent, cfg Config, cluster resource.Cluster, configIopFile string) error {
+	scopes.Framework.Infof("setting up %s as config cluster", cluster.Name())
 	installSettings, err := i.generateCommonInstallSettings(cfg, cluster, configIopFile)
 	if err != nil {
 		return err
@@ -457,6 +458,8 @@ func multiNetworkFlags(meshID, networkName string) []string {
 }
 
 func installPrimaryClusters(i *operatorComponent, cfg Config, cluster resource.Cluster, iopFile string) error {
+	scopes.Framework.Infof("setting up %s as primary cluster", cluster.Name())
+
 	if !i.environment.IsConfigCluster(cluster) {
 		if err := configExternalControlPlaneCluster(cluster, i.environment, cfg); err != nil {
 			return err
@@ -520,7 +523,7 @@ func installPrimaryClusters(i *operatorComponent, cfg Config, cluster resource.C
 
 // Deploy Istio to remote clusters
 func installRemoteClusters(i *operatorComponent, cfg Config, cluster resource.Cluster, remoteIopFile string) error {
-
+	scopes.Framework.Infof("setting up %s as remote cluster", cluster.Name())
 	installSettings, err := i.generateCommonInstallSettings(cfg, cluster, remoteIopFile)
 	if err != nil {
 		return err

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -425,7 +425,7 @@ spec:
 }
 
 func installConfigClusters(i *operatorComponent, cfg Config, cluster resource.Cluster, configIopFile string) error {
-	installSettings, err := generateCommonInstallSettings(cfg, configIopFile)
+	installSettings, err := i.generateCommonInstallSettings(cfg, cluster, configIopFile)
 	if err != nil {
 		return err
 	}
@@ -462,7 +462,7 @@ func installPrimaryClusters(i *operatorComponent, cfg Config, cluster resource.C
 			return err
 		}
 	}
-	installSettings, err := generateCommonInstallSettings(cfg, iopFile)
+	installSettings, err := i.generateCommonInstallSettings(cfg, cluster, iopFile)
 	if err != nil {
 		return err
 	}
@@ -471,10 +471,6 @@ func installPrimaryClusters(i *operatorComponent, cfg Config, cluster resource.C
 		// Set the clusterName for the local cluster.
 		// This MUST match the clusterName in the remote secret for this cluster.
 		installSettings = append(installSettings, "--set", "values.global.multiCluster.clusterName="+cluster.Name())
-
-		if networkName := cluster.NetworkName(); networkName != "" {
-			installSettings = append(installSettings, multiNetworkFlags(meshID, networkName)...)
-		}
 	}
 	// Create an istioctl to configure this cluster.
 	istioCtl, err := istioctl.New(i.ctx, istioctl.Config{
@@ -525,7 +521,7 @@ func installPrimaryClusters(i *operatorComponent, cfg Config, cluster resource.C
 // Deploy Istio to remote clusters
 func installRemoteClusters(i *operatorComponent, cfg Config, cluster resource.Cluster, remoteIopFile string) error {
 
-	installSettings, err := generateCommonInstallSettings(cfg, remoteIopFile)
+	installSettings, err := i.generateCommonInstallSettings(cfg, cluster, remoteIopFile)
 	if err != nil {
 		return err
 	}
@@ -533,10 +529,6 @@ func installRemoteClusters(i *operatorComponent, cfg Config, cluster resource.Cl
 		// Set the clusterName for the local cluster.
 		// This MUST match the clusterName in the remote secret for this cluster.
 		installSettings = append(installSettings, "--set", "values.global.multiCluster.clusterName="+cluster.Name())
-
-		if networkName := cluster.NetworkName(); networkName != "" {
-			installSettings = append(installSettings, multiNetworkFlags(meshID, networkName)...)
-		}
 	}
 	// Create an istioctl to configure this cluster.
 	istioCtl, err := istioctl.New(i.ctx, istioctl.Config{
@@ -564,7 +556,7 @@ func installRemoteClusters(i *operatorComponent, cfg Config, cluster resource.Cl
 
 }
 
-func generateCommonInstallSettings(cfg Config, iopFile string) ([]string, error) {
+func (i *operatorComponent) generateCommonInstallSettings(cfg Config, cluster resource.Cluster, iopFile string) ([]string, error) {
 
 	s, err := image.SettingsFromCommandLine()
 	if err != nil {
@@ -581,6 +573,11 @@ func generateCommonInstallSettings(cfg Config, iopFile string) ([]string, error)
 		"--set", "values.global.imagePullPolicy=" + s.PullPolicy,
 		"--manifests", filepath.Join(env.IstioSrc, "manifests"),
 	}
+
+	if !i.isExternalControlPlane() && i.environment.IsMulticluster() && cluster.NetworkName() != "" {
+		installSettings = append(installSettings, multiNetworkFlags(meshID, cluster.NetworkName())...)
+	}
+
 	// Include all user-specified values.
 	for k, v := range cfg.Values {
 		installSettings = append(installSettings, "--set", fmt.Sprintf("values.%s=%s", k, v))


### PR DESCRIPTION
When running tests locally, I noticed that this topology `--controlPlaneTopology 0:0,1:0` had what should have been a remote cluster being deployed as a "config cluster". Because the defaults for ConfigClusterValues are not baked into the framework code, but are in the externalistiod test main, these clusters are probably being deployed as if they're independent primary clusters. 

The logs in this PR confirm that switching this deploys things properly:

```
2020-09-09T07:27:20.926092Z	info	tf	setting up cluster-0 as primary cluster
...
2020-09-09T07:27:39.710299Z	info	tf	setting up cluster-2 as primary cluster
...
2020-09-09T07:28:00.393005Z	info	tf	setting up cluster-3 as primary cluster
...
2020-09-09T07:28:25.447590Z	info	tf	setting up cluster-4 as remote cluster
2020-09-09T07:28:25.447601Z	info	tf	setting up cluster-1 as remote cluster
```




[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
