### PR TITLE
default route name set to name of VirtualService name

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -353,6 +353,7 @@ func translateRoute(push *model.PushContext, node *model.Proxy, in *networking.H
 	out := &route.Route{
 		Match:    translateRouteMatch(match, node),
 		Metadata: util.BuildConfigInfoMetadata(virtualService.Meta),
+		Name:     virtualService.Name,
 	}
 
 	routeName := in.Name
@@ -360,7 +361,9 @@ func translateRoute(push *model.PushContext, node *model.Proxy, in *networking.H
 		routeName = routeName + "." + match.Name
 	}
 	// add a name to the route
-	out.Name = routeName
+	if routeName != "" {
+		out.Name = routeName
+	}
 
 	operations := translateHeadersOperations(in.Headers)
 	out.RequestHeadersToAdd = operations.requestHeadersToAdd


### PR DESCRIPTION
Please provide a description for what this PR is for.

For generated routes in XDS from VirtualServices, the route name is empty unless a name is specified VirtualService match criteria.  This PR uses the virtual service name as the default route name if none is provided.  This way, all routes generated by XDS should be able to be modified with an EnvoyFilter since the match criteria is dependent on `name` field

part of #26692

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
