### PR TITLE
re-enable grpc and skip tcp traffic sniffing tests

### DIFF
--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -334,13 +334,15 @@ func protocolSniffingCases(apps *EchoDeployments) []TrafficTestCase {
 				protocols := []protocolCase{
 					{"http", scheme.HTTP},
 					{"auto-http", scheme.HTTP},
+					s{"grpc", scheme.GRPC},
+					s{"auto-grpc", scheme.GRPC},
 				}
 
 				if !apps.PodA.Clusters().IsMulticluster() {
 					// TODO(https://github.com/istio/istio/issues/26798) enable sniffing tcp for multicluster
 					protocols = append(protocols,
-						protocolCase{"grpc", scheme.GRPC},
-						protocolCase{"auto-grpc", scheme.GRPC},
+						protocolCase{"tcp", scheme.TCP},
+						protocolCase{"auto-tcp", scheme.TCP},
 					)
 				}
 

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -334,8 +334,8 @@ func protocolSniffingCases(apps *EchoDeployments) []TrafficTestCase {
 				protocols := []protocolCase{
 					{"http", scheme.HTTP},
 					{"auto-http", scheme.HTTP},
-					s{"grpc", scheme.GRPC},
-					s{"auto-grpc", scheme.GRPC},
+					{"grpc", scheme.GRPC},
+					{"auto-grpc", scheme.GRPC},
 				}
 
 				if !apps.PodA.Clusters().IsMulticluster() {


### PR DESCRIPTION
Accidentally skipped gRPC and removed TCP entirely in #26835 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
