### PR TITLE
disable tcp again

### DIFF
--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -334,16 +334,11 @@ func protocolSniffingCases(apps *EchoDeployments) []TrafficTestCase {
 				protocols := []protocolCase{
 					{"http", scheme.HTTP},
 					{"auto-http", scheme.HTTP},
+					// TODO(https://github.com/istio/istio/issues/26798) enable sniffing tcp
+					//{"tcp", scheme.TCP},
+					//{"auto-tcp", scheme.TCP},
 					{"grpc", scheme.GRPC},
 					{"auto-grpc", scheme.GRPC},
-				}
-
-				if !apps.PodA.Clusters().IsMulticluster() {
-					// TODO(https://github.com/istio/istio/issues/26798) enable sniffing tcp for multicluster
-					protocols = append(protocols,
-						protocolCase{"tcp", scheme.TCP},
-						protocolCase{"auto-tcp", scheme.TCP},
-					)
 				}
 
 				// so we can validate all clusters are hit


### PR DESCRIPTION
#26835 had improvements like telling us how many requests failed, actually including fields like ClusterName in TCP responses but didn't fix the connection resets. 

https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/27049/integ-pilot-k8s-tests_istio/19817

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
