### PR TITLE
Fix Service and WorkloadEntry updates

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -244,6 +244,7 @@ func (instance *ServiceInstance) DeepCopy() *ServiceInstance {
 }
 
 type WorkloadInstance struct {
+	Name      string            `json:"name,omitempty"`
 	Namespace string            `json:"namespace,omitempty"`
 	Endpoint  *IstioEndpoint    `json:"endpoint,omitempty"`
 	PortMap   map[string]uint32 `json:"portMap,omitempty"`
@@ -256,6 +257,7 @@ func (instance *WorkloadInstance) DeepCopy() *WorkloadInstance {
 		pmap[k] = v
 	}
 	return &WorkloadInstance{
+		Name:      instance.Name,
 		Namespace: instance.Namespace,
 		PortMap:   pmap,
 		Endpoint:  instance.Endpoint.DeepCopy(),
@@ -293,6 +295,9 @@ func WorkloadInstancesEqual(first, second *WorkloadInstance) bool {
 		return false
 	}
 	if first.Namespace != second.Namespace {
+		return false
+	}
+	if first.Name != second.Name {
 		return false
 	}
 	if !portMapEquals(first.PortMap, second.PortMap) {

--- a/pilot/pkg/networking/core/v1alpha3/fake.go
+++ b/pilot/pkg/networking/core/v1alpha3/fake.go
@@ -79,6 +79,7 @@ type ConfigGenTest struct {
 	ConfigGen            *ConfigGeneratorImpl
 	MemRegistry          *memregistry.ServiceDiscovery
 	ServiceEntryRegistry *serviceentry.ServiceEntryStore
+	Registry             model.Controller
 }
 
 func NewConfigGenTest(t test.Failer, opts TestOptions) *ConfigGenTest {
@@ -160,6 +161,7 @@ func NewConfigGenTest(t test.Failer, opts TestOptions) *ConfigGenTest {
 		env:                  env,
 		ConfigGen:            NewConfigGenerator(opts.Plugins, &model.DisabledCache{}),
 		MemRegistry:          msd,
+		Registry:             serviceDiscovery,
 		ServiceEntryRegistry: se,
 		pushContextLock:      opts.PushContextLock,
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -206,7 +206,7 @@ type Controller struct {
 	// we run through the label selectors here to pick only ones that we need.
 	// Only nodes with ExternalIP addresses are included in this map !
 	nodeInfoMap map[string]kubernetesNode
-	// externalNameSvcInstanceMap stores hostname ==2> instance, is used to store instances for ExternalName k8s services
+	// externalNameSvcInstanceMap stores hostname ==> instance, is used to store instances for ExternalName k8s services
 	externalNameSvcInstanceMap map[host.Name][]*model.ServiceInstance
 	// workload instances from workload entries  - map of ip -> workload instance
 	workloadInstancesByIP map[string]*model.WorkloadInstance

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -342,8 +342,9 @@ func (c *Controller) onServiceEvent(curr interface{}, event model.Event) error {
 		c.Unlock()
 	}
 
-	// Update endpoint shards when service added, in case endpoint added earlier than service
-	if event == model.EventAdd {
+	// We also need to update when the Service changes. For Kubernetes, a service change will result in Endpoint updates,
+	// but workload entries will also need to be updated.
+	if event == model.EventAdd || event == model.EventUpdate {
 		// Build IstioEndpoints
 		endpoints := c.endpoints.buildIstioEndpointsWithService(svc.Name, svc.Namespace, svcConv.Hostname)
 		if features.EnableK8SServiceSelectWorkloadEntries {

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -314,7 +314,7 @@ func (c *Controller) onServiceEvent(curr interface{}, event model.Event) error {
 		}
 	}
 
-	log.Errorf("Handle event %s for service %s in namespace %s", event, svc.Name, svc.Namespace)
+	log.Debugf("Handle event %s for service %s in namespace %s", event, svc.Name, svc.Namespace)
 
 	svcConv := kube.ConvertService(*svc, c.domainSuffix, c.clusterID)
 	switch event {

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -311,7 +311,7 @@ func (c *Controller) onServiceEvent(curr interface{}, event model.Event) error {
 		}
 	}
 
-	log.Debugf("Handle event %s for service %s in namespace %s", event, svc.Name, svc.Namespace)
+	log.Errorf("Handle event %s for service %s in namespace %s", event, svc.Name, svc.Namespace)
 
 	svcConv := kube.ConvertService(*svc, c.domainSuffix, c.clusterID)
 	switch event {

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -948,12 +948,6 @@ func (c *Controller) WorkloadInstanceHandler(si *model.WorkloadInstance, event m
 				}
 				// Similar code as UpdateServiceShards in eds.go
 				instances := c.InstancesByPort(service, port.Port, labels.Collection{})
-				if err != nil {
-					log.Debugf("Failed to get endpoints for service %s on port %d, in response to workload instance: %v",
-						service.Hostname, port.Port, err)
-					continue
-				}
-
 				for _, inst := range instances {
 					endpoints = append(endpoints, inst.Endpoint)
 				}

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -712,8 +712,9 @@ func (c *Controller) serviceInstancesFromWorkloadInstances(svc *model.Service, r
 	workloadInstancesExist = len(c.workloadInstancesByIP) > 0
 	c.RUnlock()
 
+	// Only select internal Kubernetes services with selectors
 	if !workloadInstancesExist || svc.Attributes.ServiceRegistry != string(serviceregistry.Kubernetes) ||
-		svc.MeshExternal || svc.Resolution != model.ClientSideLB {
+		svc.MeshExternal || svc.Resolution != model.ClientSideLB || svc.Attributes.LabelSelectors == nil {
 		return nil
 	}
 

--- a/pilot/pkg/serviceregistry/kube/controller/pod.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod.go
@@ -126,6 +126,7 @@ func (pc *PodCache) onEvent(curr interface{}, ev model.Event) error {
 		for _, handler := range pc.c.workloadHandlers {
 			ep := NewEndpointBuilder(pc.c, pod).buildIstioEndpoint(ip, 0, "")
 			handler(&model.WorkloadInstance{
+				Name:      pod.Name,
 				Namespace: pod.Namespace,
 				Endpoint:  ep,
 				PortMap:   getPortMap(pod),

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -368,7 +368,7 @@ func convertWorkloadInstanceToServiceInstance(workloadInstance *model.IstioEndpo
 
 // Convenience function to convert a workloadEntry into a ServiceInstance object encoding the endpoint (without service
 // port names) and the namespace - k8s will consume this service instance when selecting workload entries
-func convertWorkloadEntryToWorkloadInstance(namespace string, cfg config.Config) *model.WorkloadInstance {
+func convertWorkloadEntryToWorkloadInstance(cfg config.Config) *model.WorkloadInstance {
 	we := cfg.Spec.(*networking.WorkloadEntry)
 	// we will merge labels from metadata with spec, with precedence to the metadata
 	labels := map[string]string{}
@@ -390,7 +390,7 @@ func convertWorkloadEntryToWorkloadInstance(namespace string, cfg config.Config)
 	tlsMode := getTLSModeFromWorkloadEntry(we)
 	sa := ""
 	if we.ServiceAccount != "" {
-		sa = spiffe.MustGenSpiffeURI(namespace, we.ServiceAccount)
+		sa = spiffe.MustGenSpiffeURI(cfg.Namespace, we.ServiceAccount)
 	}
 	return &model.WorkloadInstance{
 		Endpoint: &model.IstioEndpoint{
@@ -406,6 +406,7 @@ func convertWorkloadEntryToWorkloadInstance(namespace string, cfg config.Config)
 			ServiceAccount: sa,
 		},
 		PortMap:   we.Ports,
-		Namespace: namespace,
+		Namespace: cfg.Namespace,
+		Name:      cfg.Name,
 	}
 }

--- a/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
@@ -764,22 +764,24 @@ func TestConvertWorkloadEntryToWorkloadInstance(t *testing.T) {
 	}
 
 	workloadInstanceTests := []struct {
-		name      string
-		namespace string
-		wle       config.Config
-		out       *model.WorkloadInstance
+		name string
+		wle  config.Config
+		out  *model.WorkloadInstance
 	}{
 		{
-			name:      "simple",
-			namespace: "ns1",
-			wle: config.Config{Spec: &networking.WorkloadEntry{
-				Address: "1.1.1.1",
-				Labels:  labels,
-				Ports: map[string]uint32{
-					"http": 80,
+			name: "simple",
+			wle: config.Config{
+				Meta: config.Meta{
+					Namespace: "ns1",
 				},
-				ServiceAccount: "scooby",
-			}},
+				Spec: &networking.WorkloadEntry{
+					Address: "1.1.1.1",
+					Labels:  labels,
+					Ports: map[string]uint32{
+						"http": 80,
+					},
+					ServiceAccount: "scooby",
+				}},
 			out: &model.WorkloadInstance{
 				Namespace: "ns1",
 				Endpoint: &model.IstioEndpoint{
@@ -794,18 +796,21 @@ func TestConvertWorkloadEntryToWorkloadInstance(t *testing.T) {
 			},
 		},
 		{
-			name:      "simple - tls mode disabled",
-			namespace: "ns1",
-			wle: config.Config{Spec: &networking.WorkloadEntry{
-				Address: "1.1.1.1",
-				Labels: map[string]string{
-					"security.istio.io/tlsMode": "disabled",
+			name: "simple - tls mode disabled",
+			wle: config.Config{
+				Meta: config.Meta{
+					Namespace: "ns1",
 				},
-				Ports: map[string]uint32{
-					"http": 80,
-				},
-				ServiceAccount: "scooby",
-			}},
+				Spec: &networking.WorkloadEntry{
+					Address: "1.1.1.1",
+					Labels: map[string]string{
+						"security.istio.io/tlsMode": "disabled",
+					},
+					Ports: map[string]uint32{
+						"http": 80,
+					},
+					ServiceAccount: "scooby",
+				}},
 			out: &model.WorkloadInstance{
 				Namespace: "ns1",
 				Endpoint: &model.IstioEndpoint{
@@ -822,29 +827,35 @@ func TestConvertWorkloadEntryToWorkloadInstance(t *testing.T) {
 			},
 		},
 		{
-			name:      "unix domain socket",
-			namespace: "ns1",
-			wle: config.Config{Spec: &networking.WorkloadEntry{
-				Address:        "unix://foo/bar",
-				ServiceAccount: "scooby",
-			}},
-			out: nil,
-		},
-		{
-			name:      "DNS address",
-			namespace: "ns1",
-			wle: config.Config{Spec: &networking.WorkloadEntry{
-				Address:        "scooby.com",
-				ServiceAccount: "scooby",
-			}},
-			out: nil,
-		},
-		{
-			name:      "metadata labels only",
-			namespace: "ns1",
+			name: "unix domain socket",
 			wle: config.Config{
 				Meta: config.Meta{
-					Labels: labels,
+					Namespace: "ns1",
+				},
+				Spec: &networking.WorkloadEntry{
+					Address:        "unix://foo/bar",
+					ServiceAccount: "scooby",
+				}},
+			out: nil,
+		},
+		{
+			name: "DNS address",
+			wle: config.Config{
+				Meta: config.Meta{
+					Namespace: "ns1",
+				},
+				Spec: &networking.WorkloadEntry{
+					Address:        "scooby.com",
+					ServiceAccount: "scooby",
+				}},
+			out: nil,
+		},
+		{
+			name: "metadata labels only",
+			wle: config.Config{
+				Meta: config.Meta{
+					Labels:    labels,
+					Namespace: "ns1",
 				},
 				Spec: &networking.WorkloadEntry{
 					Address: "1.1.1.1",
@@ -867,10 +878,10 @@ func TestConvertWorkloadEntryToWorkloadInstance(t *testing.T) {
 			},
 		},
 		{
-			name:      "labels merge",
-			namespace: "ns1",
+			name: "labels merge",
 			wle: config.Config{
 				Meta: config.Meta{
+					Namespace: "ns1",
 					Labels: map[string]string{
 						"my-label": "bar",
 					},
@@ -903,7 +914,7 @@ func TestConvertWorkloadEntryToWorkloadInstance(t *testing.T) {
 
 	for _, tt := range workloadInstanceTests {
 		t.Run(tt.name, func(t *testing.T) {
-			instance := convertWorkloadEntryToWorkloadInstance(tt.namespace, tt.wle)
+			instance := convertWorkloadEntryToWorkloadInstance(tt.wle)
 			if err := compare(t, instance, tt.out); err != nil {
 				t.Fatal(err)
 			}

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
@@ -536,7 +536,7 @@ func (s *ServiceEntryStore) edsUpdate(instances []*model.ServiceInstance, push b
 
 func (s *ServiceEntryStore) edsUpdateByKeys(keys map[instancesKey]struct{}, push bool) {
 	// must call it here to refresh s.instances if necessary
-	// otherwise may get no instances or miss some new addes instances
+	// otherwise may get no instances or miss some new addess instances
 	s.maybeRefreshIndexes()
 	allInstances := []*model.ServiceInstance{}
 	s.storeMutex.RLock()

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
@@ -113,7 +113,7 @@ func (s *ServiceEntryStore) workloadEntryHandler(old, curr config.Config, event 
 
 	// fire off the k8s handlers
 	if len(s.workloadHandlers) > 0 {
-		si := convertWorkloadEntryToWorkloadInstance(curr.Namespace, curr)
+		si := convertWorkloadEntryToWorkloadInstance(curr)
 		if si != nil {
 			for _, h := range s.workloadHandlers {
 				h(si, event)

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
@@ -344,6 +344,7 @@ func (s *ServiceEntryStore) WorkloadInstanceHandler(si *model.WorkloadInstance, 
 	s.storeMutex.Lock()
 	// this is from a pod. Store it in separate map so that
 	// the refreshIndexes function can use these as well as the store ones.
+	k := si.Name + "~" + si.Namespace
 	switch event {
 	case model.EventDelete:
 		if _, exists := s.workloadInstancesByIP[si.Endpoint.Address]; !exists {
@@ -351,10 +352,10 @@ func (s *ServiceEntryStore) WorkloadInstanceHandler(si *model.WorkloadInstance, 
 			redundantEventForPod = true
 		} else {
 			delete(s.workloadInstancesByIP, si.Endpoint.Address)
+			delete(s.workloadInstancesIPsByName, k)
 		}
 	default: // add or update
 		// Check to see if the workload entry changed. If it did, clear the old entry
-		k := si.Name + "~" + si.Namespace
 		existing := s.workloadInstancesIPsByName[k]
 		if existing != "" && existing != si.Endpoint.Address {
 			delete(s.workloadInstancesByIP, existing)

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
@@ -712,7 +712,8 @@ func TestServiceDiscoveryWorkloadInstance(t *testing.T) {
 
 	// Setup a couple of workload instances for test. These will be selected by the `selector` SE
 	fi1 := &model.WorkloadInstance{
-		Namespace: selector.Name,
+		Name:      selector.Name,
+		Namespace: selector.Namespace,
 		Endpoint: &model.IstioEndpoint{
 			Address:        "2.2.2.2",
 			Labels:         map[string]string{"app": "wle"},
@@ -722,7 +723,8 @@ func TestServiceDiscoveryWorkloadInstance(t *testing.T) {
 	}
 
 	fi2 := &model.WorkloadInstance{
-		Namespace: selector.Name,
+		Name:      "some-other-name",
+		Namespace: selector.Namespace,
 		Endpoint: &model.IstioEndpoint{
 			Address:        "3.3.3.3",
 			Labels:         map[string]string{"app": "wle"},

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -217,8 +217,9 @@ func TestWorkloadInstances(t *testing.T) {
 			Protocol: "http",
 		}},
 		Attributes: model.ServiceAttributes{
-			Namespace: namespace,
-			Name:      "service",
+			Namespace:      namespace,
+			Name:           "service",
+			LabelSelectors: labels,
 		},
 	}
 

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -698,7 +698,6 @@ func TestWorkloadInstances(t *testing.T) {
 	})
 
 	t.Run("Service selects WorkloadEntry: update workloadEntry", func(t *testing.T) {
-		t.Skip("this is currently not passing")
 		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 		makeService(t, s.KubeClient(), service)
 		makeIstioObject(t, s.Store(), workloadEntry)

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -685,7 +685,6 @@ func TestWorkloadInstances(t *testing.T) {
 	})
 
 	t.Run("Service selects WorkloadEntry: update service", func(t *testing.T) {
-		t.Skip("this is currently not passing")
 		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 		makeService(t, s.KubeClient(), service)
 		makeIstioObject(t, s.Store(), workloadEntry)

--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -1017,7 +1017,7 @@ func TestXdsCache(t *testing.T) {
 	})
 	ads := s.Connect(&model.Proxy{Locality: &core.Locality{Region: "region"}}, nil, watchAll)
 
-	assertEndpoints(ads, "1.2.3.4", "1.2.3.5")
+	assertEndpoints(ads, "1.2.3.4:80", "1.2.3.5:80")
 	t.Logf("endpoints: %+v", ads.GetEndpoints())
 
 	if _, err := s.Store().Update(makeEndpoint([]*networking.WorkloadEntry{
@@ -1029,7 +1029,7 @@ func TestXdsCache(t *testing.T) {
 	if _, err := ads.Wait(time.Second*5, v3.EndpointType); err != nil {
 		t.Fatal(err)
 	}
-	assertEndpoints(ads, "1.2.3.6", "1.2.3.5")
+	assertEndpoints(ads, "1.2.3.6:80", "1.2.3.5:80")
 	t.Logf("endpoints: %+v", ads.GetEndpoints())
 
 	ads.WaitClear()
@@ -1051,7 +1051,7 @@ func TestXdsCache(t *testing.T) {
 	if _, err := ads.Wait(time.Second*5, v3.EndpointType); err != nil {
 		t.Fatal(err)
 	}
-	assertEndpoints(ads, "1.2.3.6", "1.2.3.5")
+	assertEndpoints(ads, "1.2.3.6:80", "1.2.3.5:80")
 	found := false
 	for _, ep := range ads.GetEndpoints()["outbound|80||foo.com"].Endpoints {
 		if ep.Priority == 1 {

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -116,7 +116,9 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		ServiceRegistries:   []serviceregistry.Instance{k8s},
 		PushContextLock:     &s.updateMutex,
 	})
-	cg.ServiceEntryRegistry.AppendServiceHandler(serviceHandler)
+	if err := cg.ServiceEntryRegistry.AppendServiceHandler(serviceHandler); err != nil {
+		t.Fatal(err)
+	}
 	s.updateMutex.Lock()
 	s.Env = cg.Env()
 	// Disable debounce to reduce test times

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -41,6 +41,7 @@ import (
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
 	kubelib "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/test"
 )
@@ -63,9 +64,10 @@ type FakeOptions struct {
 
 type FakeDiscoveryServer struct {
 	*v1alpha3.ConfigGenTest
-	t         test.Failer
-	Discovery *DiscoveryServer
-	Listener  *bufconn.Listener
+	t          test.Failer
+	Discovery  *DiscoveryServer
+	Listener   *bufconn.Listener
+	kubeClient kubelib.Client
 }
 
 func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServer {
@@ -77,20 +79,18 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	// Init with a dummy environment, since we have a circular dependency with the env creation.
 	s := NewDiscoveryServer(&model.Environment{PushContext: model.NewPushContext()}, []string{plugin.Authn, plugin.Authz})
 
-	k8sObjects := getKubernetesObjects(t, opts)
-
+	kubeClient := kubelib.NewFakeClient(getKubernetesObjects(t, opts)...)
 	k8s, _ := kube.NewFakeControllerWithOptions(kube.FakeControllerOptions{
-		Objects:         k8sObjects,
+		Client:          kubeClient,
 		ClusterID:       "Kubernetes",
 		DomainSuffix:    "cluster.local",
 		XDSUpdater:      s,
 		NetworksWatcher: opts.NetworksWatcher,
 	})
 
-	secretFake := kubelib.NewFakeClient(k8sObjects...)
-	sc := kubesecrets.NewSecretsController(secretFake, "", nil)
+	sc := kubesecrets.NewSecretsController(kubeClient, "", nil)
 	sc.DisableAuthorization()
-	secretFake.RunAndWait(stop)
+	kubeClient.RunAndWait(stop)
 	s.Generators[v3.SecretType] = NewSecretGen(sc, &model.DisabledCache{})
 
 	cg := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{
@@ -141,6 +141,27 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 
 		cg.Store().RegisterEventHandler(schema.Resource().GroupVersionKind(), configHandler)
 	}
+	serviceHandler := func(svc *model.Service, _ model.Event) {
+		pushReq := &model.PushRequest{
+			Full: true,
+			ConfigsUpdated: map[model.ConfigKey]struct{}{{
+				Kind:      gvk.ServiceEntry,
+				Name:      string(svc.Hostname),
+				Namespace: svc.Attributes.Namespace,
+			}: {}},
+			Reason: []model.TriggerReason{model.ServiceUpdate},
+		}
+		s.ConfigUpdate(pushReq)
+	}
+	if err := cg.Registry.AppendServiceHandler(serviceHandler); err != nil {
+		t.Fatalf("append service handler failed: %v", err)
+	}
+	if err := cg.ServiceEntryRegistry.AppendWorkloadHandler(k8s.WorkloadInstanceHandler); err != nil {
+		t.Fatal(err)
+	}
+	if err := k8s.AppendWorkloadHandler(cg.ServiceEntryRegistry.WorkloadInstanceHandler); err != nil {
+		t.Fatal(err)
+	}
 
 	// Start in memory gRPC listener
 	buffer := 1024 * 1024
@@ -167,6 +188,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		Discovery:     s,
 		Listener:      listener,
 		ConfigGenTest: cg,
+		kubeClient:    kubeClient,
 	}
 
 	// currently meshNetworks gateways are stored on the push context
@@ -174,6 +196,10 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	cg.Env().AddNetworksHandler(fake.refreshPushContext)
 
 	return fake
+}
+
+func (f *FakeDiscoveryServer) KubeClient() kubelib.Client {
+	return f.kubeClient
 }
 
 func (f *FakeDiscoveryServer) PushContext() *model.PushContext {
@@ -242,8 +268,6 @@ func (f *FakeDiscoveryServer) Connect(p *model.Proxy, watch []string, wait []str
 
 func (f *FakeDiscoveryServer) Endpoints(p *model.Proxy) []*endpoint.ClusterLoadAssignment {
 	loadAssignments := make([]*endpoint.ClusterLoadAssignment, 0)
-	c := f.Clusters(p)
-	_ = c
 	for _, c := range xdstest.ExtractEdsClusterNames(f.Clusters(p)) {
 		loadAssignments = append(loadAssignments, f.Discovery.generateEndpoints(NewEndpointBuilder(c, p, f.PushContext())))
 	}

--- a/pilot/pkg/xds/xds_test.go
+++ b/pilot/pkg/xds/xds_test.go
@@ -245,7 +245,7 @@ func TestServiceScoping(t *testing.T) {
 		})
 		proxy := s.SetupProxy(baseProxy())
 
-		assertListEqual(t, xdstest.ExtractClusterEndpoints(s.Clusters(proxy))["outbound|80||app.com"], []string{"app.com"})
+		assertListEqual(t, xdstest.ExtractClusterEndpoints(s.Clusters(proxy))["outbound|80||app.com"], []string{"app.com:80"})
 	})
 
 	t.Run("DNS no self import", func(t *testing.T) {
@@ -258,7 +258,7 @@ func TestServiceScoping(t *testing.T) {
 		})
 		proxy := s.SetupProxy(baseProxy())
 
-		assertListEqual(t, xdstest.ExtractClusterEndpoints(s.Clusters(proxy))["outbound|80||app.com"], []string{"included.com"})
+		assertListEqual(t, xdstest.ExtractClusterEndpoints(s.Clusters(proxy))["outbound|80||app.com"], []string{"included.com:80"})
 	})
 }
 

--- a/pilot/pkg/xds/xds_test.go
+++ b/pilot/pkg/xds/xds_test.go
@@ -195,7 +195,7 @@ func TestServiceScoping(t *testing.T) {
 		proxy := s.SetupProxy(baseProxy())
 
 		endpoints := xdstest.ExtractLoadAssignments(s.Endpoints(proxy))
-		if !listEqualUnordered(endpoints["outbound|80||app.com"], []string{"1.1.1.1"}) {
+		if !listEqualUnordered(endpoints["outbound|80||app.com"], []string{"1.1.1.1:80"}) {
 			t.Fatalf("expected 1.1.1.1, got %v", endpoints["outbound|80||app.com"])
 		}
 
@@ -474,6 +474,10 @@ spec:
 						},
 					})
 
+					gatewayPort := "15443"
+					if ingr.Spec.Type == corev1.ServiceTypeNodePort && name == "gateway-registryServiceName" {
+						gatewayPort = "25443"
+					}
 					tests := []struct {
 						p      *model.Proxy
 						expect map[string][]string
@@ -481,43 +485,43 @@ spec:
 						{
 							p: pod,
 							expect: map[string][]string{
-								"outbound|7070||httpbin.com":                 {"10.10.10.10"},
-								"outbound|80||kubeapp.pod.svc.cluster.local": {"10.10.10.20"},
-								"outbound|80||labeled.pod.svc.cluster.local": {"3.3.3.3"},
-								"outbound|80||se-pod.pod.svc.cluster.local":  {"10.10.10.30"},
+								"outbound|7070||httpbin.com":                 {"10.10.10.10:7070"},
+								"outbound|80||kubeapp.pod.svc.cluster.local": {"10.10.10.20:80"},
+								"outbound|80||labeled.pod.svc.cluster.local": {"3.3.3.3:15443"},
+								"outbound|80||se-pod.pod.svc.cluster.local":  {"10.10.10.30:80"},
 							},
 						},
 						{
 							p: labeledPod,
 							expect: map[string][]string{
-								"outbound|7070||httpbin.com":                 {"10.10.10.10"},
-								"outbound|80||kubeapp.pod.svc.cluster.local": {"2.2.2.2"},
-								"outbound|80||labeled.pod.svc.cluster.local": {"10.10.10.40"},
-								"outbound|80||se-pod.pod.svc.cluster.local":  {"2.2.2.2"},
+								"outbound|7070||httpbin.com":                 {"10.10.10.10:7070"},
+								"outbound|80||kubeapp.pod.svc.cluster.local": {"2.2.2.2:" + gatewayPort},
+								"outbound|80||labeled.pod.svc.cluster.local": {"10.10.10.40:80"},
+								"outbound|80||se-pod.pod.svc.cluster.local":  {"2.2.2.2:" + gatewayPort},
 							},
 						},
 						{
 							p: se,
 							expect: map[string][]string{
-								"outbound|7070||httpbin.com":                 {"10.10.10.10"},
-								"outbound|80||kubeapp.pod.svc.cluster.local": {"10.10.10.20"},
-								"outbound|80||labeled.pod.svc.cluster.local": {"3.3.3.3"},
-								"outbound|80||se-pod.pod.svc.cluster.local":  {"10.10.10.30"},
+								"outbound|7070||httpbin.com":                 {"10.10.10.10:7070"},
+								"outbound|80||kubeapp.pod.svc.cluster.local": {"10.10.10.20:80"},
+								"outbound|80||labeled.pod.svc.cluster.local": {"3.3.3.3:15443"},
+								"outbound|80||se-pod.pod.svc.cluster.local":  {"10.10.10.30:80"},
 							},
 						},
 						{
 							p: vm,
 							expect: map[string][]string{
-								"outbound|7070||httpbin.com":                 {"10.10.10.10"},
-								"outbound|80||kubeapp.pod.svc.cluster.local": {"2.2.2.2"},
-								"outbound|80||labeled.pod.svc.cluster.local": {"3.3.3.3"},
-								"outbound|80||se-pod.pod.svc.cluster.local":  {"2.2.2.2"},
+								"outbound|7070||httpbin.com":                 {"10.10.10.10:7070"},
+								"outbound|80||kubeapp.pod.svc.cluster.local": {"2.2.2.2:" + gatewayPort},
+								"outbound|80||labeled.pod.svc.cluster.local": {"3.3.3.3:15443"},
+								"outbound|80||se-pod.pod.svc.cluster.local":  {"2.2.2.2:" + gatewayPort},
 							},
 						},
 						{
 							p: gw,
 							expect: map[string][]string{
-								"outbound|7070||httpbin.com": {"10.10.10.10"},
+								"outbound|7070||httpbin.com": {"10.10.10.10:7070"},
 								// Network view will filter these out
 								"outbound|80||kubeapp.pod.svc.cluster.local": {},
 								"outbound|80||labeled.pod.svc.cluster.local": {},

--- a/pilot/test/xdstest/extract.go
+++ b/pilot/test/xdstest/extract.go
@@ -15,6 +15,7 @@
 package xdstest
 
 import (
+	"fmt"
 	"reflect"
 	"sort"
 	"testing"
@@ -132,7 +133,7 @@ func ExtractEndpoints(cla *endpoint.ClusterLoadAssignment) []string {
 	for _, ep := range cla.Endpoints {
 		for _, lb := range ep.LbEndpoints {
 			if lb.GetEndpoint().Address.GetSocketAddress() != nil {
-				got = append(got, lb.GetEndpoint().Address.GetSocketAddress().Address)
+				got = append(got, fmt.Sprintf("%s:%d", lb.GetEndpoint().Address.GetSocketAddress().Address, lb.GetEndpoint().Address.GetSocketAddress().GetPortValue()))
 			} else {
 				got = append(got, lb.GetEndpoint().Address.GetPipe().Path)
 			}

--- a/releasenotes/notes/we-updates.yaml
+++ b/releasenotes/notes/we-updates.yaml
@@ -4,6 +4,7 @@ area: networking
 issue:
 - 27183
 - 27151
+- 27185
 releaseNotes:
 - |
   **Fixed** issues with WorkloadEntry when the Service or WorkloadEntry is updated after creation.

--- a/releasenotes/notes/we-updates.yaml
+++ b/releasenotes/notes/we-updates.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+issue:
+- 27183
+- 27151
+releaseNotes:
+- |
+  **Fixed** issues with WorkloadEntry when the Service or WorkloadEntry is updated after creation.


### PR DESCRIPTION
PR is split into many commits
1. does some testing refactoring to support this, and adds 2 failing tests
2. Fixes #27151, enables the test
3. Fixes #27183, enables the test
4. Fixes pod updates for SE selects pod
5. Fixes SE updates for SE selects pod
6. Fixes https://github.com/istio/istio/issues/27185

Somehow we managed to have 4 different bugs covering all 4 update scenarios. They should be all fixed and tested now.

cc @kyessenov @JimmyCYJ 