### PR TITLE
Wait for pod in TestAddToAndRemoveFromMesh

### DIFF
--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -36,6 +36,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/framework/components/istioctl"
 	"istio.io/istio/pkg/test/framework/components/namespace"
+	kubetest "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/pkg/test/util/file"
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/url"
@@ -273,6 +274,13 @@ func TestAddToAndRemoveFromMesh(t *testing.T) {
 				"x", "remove-from-mesh", "service", "a"}
 			output, _ = istioCtl.InvokeOrFail(t, args)
 			g.Expect(output).To(gomega.MatchRegexp(removeFromMeshPodAOutput))
+
+			// Wait until the new pod is ready
+			fetch := kubetest.NewPodMustFetch(ctx.Clusters().Default(), ns.Name(), "app=a")
+			_, err := kubetest.WaitUntilPodsAreReady(fetch)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			args = []string{fmt.Sprintf("--namespace=%s", ns.Name()),
 				"x", "add-to-mesh", "service", "a"}


### PR DESCRIPTION
\#27178 removed some waiting logic. This adds it back, due to test
flakes:
https://prow.istio.io/view/gs/istio-prow/logs/integ-pilot-k8s-tests_istio_postsubmit/3647

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
