### PR TITLE
Fix null ingressGateways for minimal and empty profile.

### DIFF
--- a/manifests/profiles/empty.yaml
+++ b/manifests/profiles/empty.yaml
@@ -9,4 +9,5 @@ spec:
     pilot:
       enabled: false
     ingressGateways:
-
+    - name: istio-ingressgateway
+      enabled: false

--- a/manifests/profiles/minimal.yaml
+++ b/manifests/profiles/minimal.yaml
@@ -4,3 +4,5 @@ kind: IstioOperator
 spec:
   components:
     ingressGateways:
+    - name: istio-ingressgateway
+      enabled: false


### PR DESCRIPTION

@linsun Not sure if `ingressGateways` should be enabled for `minimal` profile? See: https://github.com/istio/istio/pull/23977

Before: 
Notice `ingressGateways: null`
```
$ ./out/linux_amd64/istioctl profile diff minimal empty -d manifests/
Difference of profiles:
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   components:
+    base:
+      enabled: false
     ingressGateways: null
+    pilot:
+      enabled: false
```

After:
```
$ ./out/linux_amd64/istioctl profile diff minimal empty -d manifests/
Difference of profiles:
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   components:
+    base:
+      enabled: false
     ingressGateways:
     - enabled: false
       name: istio-ingressgateway
+    pilot:
+      enabled: false
```
