### PR TITLE
Fix failed to create EnvoyFilter in other namespaces

### DIFF
--- a/manifests/charts/base/templates/validatingwebhookconfiguration.yaml
+++ b/manifests/charts/base/templates/validatingwebhookconfiguration.yaml
@@ -15,7 +15,9 @@ webhooks:
       {{- else }}
       service:
         name: istiod
+        {{- if .Values.global.istioNamespace }}
         namespace: {{ .Values.global.istioNamespace }}
+        {{- end }}
         path: "/validate"
       {{- end }}
       caBundle: "" # patched at runtime when the webhook is ready.

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -42,7 +42,6 @@ data:
         zipkin:
           address: zipkin.istio-system:9411
     enablePrometheusMerge: true
-    rootNamespace: istio-system
     trustDomain: cluster.local
 ---
 # Source: istio-discovery/templates/istiod-injector-configmap.yaml

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.6.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.6.yaml
@@ -3,10 +3,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: metadata-exchange-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -51,10 +51,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-metadata-exchange-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -115,10 +115,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stats-filter-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -288,10 +288,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-stats-filter-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -458,10 +458,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stackdriver-filter-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -573,10 +573,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stackdriver-sampling-accesslog-filter-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.6.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.6.yaml
@@ -5,6 +5,8 @@ metadata:
   name: metadata-exchange-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -51,6 +53,8 @@ metadata:
   name: tcp-metadata-exchange-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -113,6 +117,8 @@ metadata:
   name: stats-filter-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -284,6 +290,8 @@ metadata:
   name: tcp-stats-filter-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -452,6 +460,8 @@ metadata:
   name: stackdriver-filter-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -565,6 +575,8 @@ metadata:
   name: stackdriver-sampling-accesslog-filter-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.7.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.7.yaml
@@ -6,6 +6,8 @@ metadata:
   name: metadata-exchange-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -117,6 +119,8 @@ metadata:
   name: tcp-metadata-exchange-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -180,6 +184,8 @@ metadata:
   name: stats-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -353,6 +359,8 @@ metadata:
   name: tcp-stats-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -522,6 +530,8 @@ metadata:
   name: stackdriver-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -641,6 +651,8 @@ metadata:
   name: tcp-stackdriver-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -754,6 +766,8 @@ metadata:
   name: stackdriver-sampling-accesslog-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.7.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.7.yaml
@@ -4,10 +4,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: metadata-exchange-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -117,10 +117,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-metadata-exchange-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -182,10 +182,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stats-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -357,10 +357,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-stats-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -528,10 +528,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stackdriver-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -649,10 +649,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-stackdriver-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -764,10 +764,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stackdriver-sampling-accesslog-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.8.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.8.yaml
@@ -6,6 +6,8 @@ metadata:
   name: metadata-exchange-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -117,6 +119,8 @@ metadata:
   name: tcp-metadata-exchange-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -180,6 +184,8 @@ metadata:
   name: stats-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -353,6 +359,8 @@ metadata:
   name: tcp-stats-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -522,6 +530,8 @@ metadata:
   name: stackdriver-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -641,6 +651,8 @@ metadata:
   name: tcp-stackdriver-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -754,6 +766,8 @@ metadata:
   name: stackdriver-sampling-accesslog-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.8.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.8.yaml
@@ -4,10 +4,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: metadata-exchange-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -117,10 +117,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-metadata-exchange-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -182,10 +182,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stats-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -357,10 +357,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-stats-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -528,10 +528,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stackdriver-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -649,10 +649,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-stackdriver-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -764,10 +764,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stackdriver-sampling-accesslog-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -159,12 +159,6 @@ meshConfig:
       # DNS_AGENT: DNS-TLS
       DNS_AGENT: ""
 
-  # The namespace to treat as the administrative root namespace for Istio configuration.
-  # When processing a leaf namespace Istio will search for declarations in that namespace first
-  # and if none are found it will search in the root namespace. Any matching declaration found in the root namespace
-  # is processed as if it were declared in the leaf namespace.
-  rootNamespace: "istio-system"
-
   # TODO: the intent is to eventually have this enabled by default when security is used.
   # It is not clear if user should normally need to configure - the metadata is typically
   # used as an escape and to control testing and rollout, but it is not intended as a long-term

--- a/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -23,7 +23,6 @@ data:
         zipkin:
           address: zipkin.istio-system:9411
     enablePrometheusMerge: true
-    rootNamespace: istio-system
     trustDomain: cluster.local
 ---
 # Source: istiod-remote/templates/istiod-injector-configmap.yaml

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.6.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.6.yaml
@@ -3,10 +3,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: metadata-exchange-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -51,10 +51,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-metadata-exchange-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -115,10 +115,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stats-filter-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -288,10 +288,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-stats-filter-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -458,10 +458,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stackdriver-filter-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -573,10 +573,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stackdriver-sampling-accesslog-filter-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.6.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.6.yaml
@@ -5,6 +5,8 @@ metadata:
   name: metadata-exchange-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -51,6 +53,8 @@ metadata:
   name: tcp-metadata-exchange-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -113,6 +117,8 @@ metadata:
   name: stats-filter-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -284,6 +290,8 @@ metadata:
   name: tcp-stats-filter-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -452,6 +460,8 @@ metadata:
   name: stackdriver-filter-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -565,6 +575,8 @@ metadata:
   name: stackdriver-sampling-accesslog-filter-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.7.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.7.yaml
@@ -6,6 +6,8 @@ metadata:
   name: metadata-exchange-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -117,6 +119,8 @@ metadata:
   name: tcp-metadata-exchange-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -180,6 +184,8 @@ metadata:
   name: stats-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -353,6 +359,8 @@ metadata:
   name: tcp-stats-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -522,6 +530,8 @@ metadata:
   name: stackdriver-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -641,6 +651,8 @@ metadata:
   name: tcp-stackdriver-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -754,6 +766,8 @@ metadata:
   name: stackdriver-sampling-accesslog-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.7.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.7.yaml
@@ -4,10 +4,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: metadata-exchange-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -117,10 +117,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-metadata-exchange-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -182,10 +182,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stats-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -357,10 +357,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-stats-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -528,10 +528,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stackdriver-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -649,10 +649,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-stackdriver-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -764,10 +764,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stackdriver-sampling-accesslog-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.8.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.8.yaml
@@ -6,6 +6,8 @@ metadata:
   name: metadata-exchange-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -117,6 +119,8 @@ metadata:
   name: tcp-metadata-exchange-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -180,6 +184,8 @@ metadata:
   name: stats-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -353,6 +359,8 @@ metadata:
   name: tcp-stats-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -522,6 +530,8 @@ metadata:
   name: stackdriver-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -641,6 +651,8 @@ metadata:
   name: tcp-stackdriver-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -754,6 +766,8 @@ metadata:
   name: stackdriver-sampling-accesslog-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.8.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.8.yaml
@@ -4,10 +4,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: metadata-exchange-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -117,10 +117,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-metadata-exchange-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -182,10 +182,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stats-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -357,10 +357,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-stats-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -528,10 +528,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stackdriver-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -649,10 +649,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-stackdriver-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -764,10 +764,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stackdriver-sampling-accesslog-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}

--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -110,3 +110,6 @@ global:
 
   # One central istiod controls all remote clusters: disabled by default
   centralIstiod: false
+
+  # Default namespace for Istio configuration
+  istioNamespace: "istio-system"

--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -14,12 +14,6 @@ meshConfig:
       # DNS_AGENT: DNS-TLS
       DNS_AGENT: ""
 
-  # The namespace to treat as the administrative root namespace for Istio configuration.
-  # When processing a leaf namespace Istio will search for declarations in that namespace first
-  # and if none are found it will search in the root namespace. Any matching declaration found in the root namespace
-  # is processed as if it were declared in the leaf namespace.
-  rootNamespace: "istio-system"
-
 sidecarInjectorWebhook:
   # You can use the field called alwaysInjectSelector and neverInjectSelector which will always inject the sidecar or
   # always skip the injection on pods that match that label selector, regardless of the global policy.
@@ -110,6 +104,3 @@ global:
 
   # One central istiod controls all remote clusters: disabled by default
   centralIstiod: false
-
-  # Default namespace for Istio configuration
-  istioNamespace: "istio-system"

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/base/templates/validatingwebhookconfiguration.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/base/templates/validatingwebhookconfiguration.yaml
@@ -15,7 +15,9 @@ webhooks:
       {{- else }}
       service:
         name: istiod
+        {{- if .Values.global.istioNamespace }}
         namespace: {{ .Values.global.istioNamespace }}
+        {{- end }}
         path: "/validate"
       {{- end }}
       caBundle: "" # patched at runtime when the webhook is ready.

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -42,7 +42,6 @@ data:
         zipkin:
           address: zipkin.istio-system:9411
     enablePrometheusMerge: true
-    rootNamespace: istio-system
     trustDomain: cluster.local
 ---
 # Source: istio-discovery/templates/istiod-injector-configmap.yaml

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/templates/telemetryv2_1.6.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/templates/telemetryv2_1.6.yaml
@@ -3,10 +3,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: metadata-exchange-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -51,10 +51,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-metadata-exchange-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -115,10 +115,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stats-filter-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -288,10 +288,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-stats-filter-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -458,10 +458,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stackdriver-filter-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -573,10 +573,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stackdriver-sampling-accesslog-filter-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/templates/telemetryv2_1.6.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/templates/telemetryv2_1.6.yaml
@@ -5,6 +5,8 @@ metadata:
   name: metadata-exchange-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -51,6 +53,8 @@ metadata:
   name: tcp-metadata-exchange-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -113,6 +117,8 @@ metadata:
   name: stats-filter-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -284,6 +290,8 @@ metadata:
   name: tcp-stats-filter-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -452,6 +460,8 @@ metadata:
   name: stackdriver-filter-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -565,6 +575,8 @@ metadata:
   name: stackdriver-sampling-accesslog-filter-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/templates/telemetryv2_1.7.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/templates/telemetryv2_1.7.yaml
@@ -6,6 +6,8 @@ metadata:
   name: metadata-exchange-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -117,6 +119,8 @@ metadata:
   name: tcp-metadata-exchange-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -180,6 +184,8 @@ metadata:
   name: stats-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -353,6 +359,8 @@ metadata:
   name: tcp-stats-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -522,6 +530,8 @@ metadata:
   name: stackdriver-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -754,6 +764,8 @@ metadata:
   name: stackdriver-sampling-accesslog-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/templates/telemetryv2_1.7.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/templates/telemetryv2_1.7.yaml
@@ -4,10 +4,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: metadata-exchange-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -117,10 +117,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-metadata-exchange-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -182,10 +182,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stats-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -357,10 +357,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-stats-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -528,10 +528,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stackdriver-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -762,10 +762,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stackdriver-sampling-accesslog-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/templates/telemetryv2_1.8.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/templates/telemetryv2_1.8.yaml
@@ -6,6 +6,8 @@ metadata:
   name: metadata-exchange-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -117,6 +119,8 @@ metadata:
   name: tcp-metadata-exchange-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -180,6 +184,8 @@ metadata:
   name: stats-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -353,6 +359,8 @@ metadata:
   name: tcp-stats-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -522,6 +530,8 @@ metadata:
   name: stackdriver-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -754,6 +764,8 @@ metadata:
   name: stackdriver-sampling-accesslog-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/templates/telemetryv2_1.8.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/templates/telemetryv2_1.8.yaml
@@ -4,10 +4,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: metadata-exchange-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -117,10 +117,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-metadata-exchange-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -182,10 +182,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stats-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -357,10 +357,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-stats-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -528,10 +528,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stackdriver-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -762,10 +762,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stackdriver-sampling-accesslog-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/values.yaml
@@ -159,12 +159,6 @@ meshConfig:
       # DNS_AGENT: DNS-TLS
       DNS_AGENT: ""
 
-  # The namespace to treat as the administrative root namespace for Istio configuration.
-  # When processing a leaf namespace Istio will search for declarations in that namespace first
-  # and if none are found it will search in the root namespace. Any matching declaration found in the root namespace
-  # is processed as if it were declared in the leaf namespace.
-  rootNamespace: "istio-system"
-
   # TODO: the intent is to eventually have this enabled by default when security is used.
   # It is not clear if user should normally need to configure - the metadata is typically
   # used as an escape and to control testing and rollout, but it is not intended as a long-term

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -23,7 +23,6 @@ data:
         zipkin:
           address: zipkin.istio-system:9411
     enablePrometheusMerge: true
-    rootNamespace: istio-system
     trustDomain: cluster.local
 ---
 # Source: istiod-remote/templates/istiod-injector-configmap.yaml

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/templates/telemetryv2_1.6.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/templates/telemetryv2_1.6.yaml
@@ -5,6 +5,8 @@ metadata:
   name: metadata-exchange-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -51,6 +53,8 @@ metadata:
   name: tcp-metadata-exchange-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -113,6 +117,8 @@ metadata:
   name: stats-filter-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -284,6 +290,8 @@ metadata:
   name: tcp-stats-filter-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -452,6 +460,8 @@ metadata:
   name: stackdriver-filter-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/templates/telemetryv2_1.6.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/templates/telemetryv2_1.6.yaml
@@ -3,10 +3,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: metadata-exchange-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -51,10 +51,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-metadata-exchange-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -115,10 +115,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stats-filter-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -288,10 +288,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-stats-filter-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -458,10 +458,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stackdriver-filter-1.6{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/templates/telemetryv2_1.7.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/templates/telemetryv2_1.7.yaml
@@ -6,6 +6,8 @@ metadata:
   name: metadata-exchange-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -117,6 +119,8 @@ metadata:
   name: tcp-metadata-exchange-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -180,6 +184,8 @@ metadata:
   name: stats-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -353,6 +359,8 @@ metadata:
   name: tcp-stats-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -522,6 +530,8 @@ metadata:
   name: stackdriver-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -754,6 +764,8 @@ metadata:
   name: stackdriver-sampling-accesslog-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/templates/telemetryv2_1.7.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/templates/telemetryv2_1.7.yaml
@@ -4,10 +4,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: metadata-exchange-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -117,10 +117,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-metadata-exchange-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -182,10 +182,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stats-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -357,10 +357,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-stats-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -528,10 +528,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stackdriver-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -762,10 +762,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stackdriver-sampling-accesslog-filter-1.7{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/templates/telemetryv2_1.8.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/templates/telemetryv2_1.8.yaml
@@ -6,6 +6,8 @@ metadata:
   name: metadata-exchange-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -117,6 +119,8 @@ metadata:
   name: tcp-metadata-exchange-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -180,6 +184,8 @@ metadata:
   name: stats-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -353,6 +359,8 @@ metadata:
   name: tcp-stats-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -522,6 +530,8 @@ metadata:
   name: stackdriver-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -754,6 +764,8 @@ metadata:
   name: stackdriver-sampling-accesslog-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
   {{- if .Values.meshConfig.rootNamespace }}
   namespace: {{ .Values.meshConfig.rootNamespace }}
+  {{- else if .Values.global.istioNamespace }}
+  namespace: {{ .Values.global.istioNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/templates/telemetryv2_1.8.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/templates/telemetryv2_1.8.yaml
@@ -4,10 +4,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: metadata-exchange-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -117,10 +117,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-metadata-exchange-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -182,10 +182,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stats-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -357,10 +357,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-stats-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -528,10 +528,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stackdriver-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
@@ -762,10 +762,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stackdriver-sampling-accesslog-filter-1.8{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  {{- if .Values.meshConfig.rootNamespace }}
-  namespace: {{ .Values.meshConfig.rootNamespace }}
-  {{- else if .Values.global.istioNamespace }}
+  {{- if .Values.global.istioNamespace }}
   namespace: {{ .Values.global.istioNamespace }}
+  {{- else if .Values.meshConfig.rootNamespace }}
+  namespace: {{ .Values.meshConfig.rootNamespace }}
   {{- else }}
   namespace: {{ .Release.Namespace }}
   {{- end }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/values.yaml
@@ -14,12 +14,6 @@ meshConfig:
       # DNS_AGENT: DNS-TLS
       DNS_AGENT: ""
 
-  # The namespace to treat as the administrative root namespace for Istio configuration.
-  # When processing a leaf namespace Istio will search for declarations in that namespace first
-  # and if none are found it will search in the root namespace. Any matching declaration found in the root namespace
-  # is processed as if it were declared in the leaf namespace.
-  rootNamespace: "istio-system"
-
 sidecarInjectorWebhook:
   # You can use the field called alwaysInjectSelector and neverInjectSelector which will always inject the sidecar or
   # always skip the injection on pods that match that label selector, regardless of the global policy.

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -4655,7 +4655,6 @@ data:
         zipkin:
           address: zipkin.istio-system:9411
     enablePrometheusMerge: true
-    rootNamespace: istio-system
     trustDomain: cluster.local
 ---
 apiVersion: v1

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: metadata-exchange-1.6
-  namespace: istio-control
+  namespace: istio-system
   labels:
     istio.io/rev: default
 spec:
@@ -37,7 +37,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: metadata-exchange-1.7
-  namespace: istio-control
+  namespace: istio-system
   labels:
     istio.io/rev: default
 spec:
@@ -128,7 +128,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: metadata-exchange-1.8
-  namespace: istio-control
+  namespace: istio-system
   labels:
     istio.io/rev: default
 spec:
@@ -219,7 +219,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stats-filter-1.6
-  namespace: istio-control
+  namespace: istio-system
   labels:
     istio.io/rev: default
 spec:
@@ -326,7 +326,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stats-filter-1.7
-  namespace: istio-control
+  namespace: istio-system
   labels:
     istio.io/rev: default
 spec:
@@ -439,7 +439,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: stats-filter-1.8
-  namespace: istio-control
+  namespace: istio-system
   labels:
     istio.io/rev: default
 spec:
@@ -552,7 +552,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-metadata-exchange-1.6
-  namespace: istio-control
+  namespace: istio-system
   labels:
     istio.io/rev: default
 spec:
@@ -609,7 +609,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-metadata-exchange-1.7
-  namespace: istio-control
+  namespace: istio-system
   labels:
     istio.io/rev: default
 spec:
@@ -666,7 +666,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-metadata-exchange-1.8
-  namespace: istio-control
+  namespace: istio-system
   labels:
     istio.io/rev: default
 spec:
@@ -723,7 +723,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-stats-filter-1.6
-  namespace: istio-control
+  namespace: istio-system
   labels:
     istio.io/rev: default
 spec:
@@ -823,7 +823,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-stats-filter-1.7
-  namespace: istio-control
+  namespace: istio-system
   labels:
     istio.io/rev: default
 spec:
@@ -929,7 +929,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: tcp-stats-filter-1.8
-  namespace: istio-control
+  namespace: istio-system
   labels:
     istio.io/rev: default
 spec:


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/27165 and hopefully https://github.com/istio/istio/issues/26813

Different ways of setting namespaces during installation https://github.com/istio/istio/issues/23401#issuecomment-621916406.

```
--set values.global.istioNamespace=<custom_ns> 
--set meshConfig.rootNamespace=<custom_ns>
```

Related:
@howardjohn comment https://github.com/istio/istio/issues/23401#issuecomment-621543877
rootNamespace : https://github.com/istio/istio/pull/23407


