### PR TITLE
fix help for make cert files

### DIFF
--- a/tools/certs/Makefile.k8s.mk
+++ b/tools/certs/Makefile.k8s.mk
@@ -13,8 +13,8 @@ include $(SELF_DIR)common.mk
 ##help:		print this help message
 .PHONY: help
 
-help: Makefile
-	@sed -n 's/^##//p' $<
+help:
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/##//'
 
 #------------------------------------------------------------------------
 ##fetch-root-ca:	fetch root CA  and key from a k8s cluster.

--- a/tools/certs/Makefile.selfsigned.mk
+++ b/tools/certs/Makefile.selfsigned.mk
@@ -13,8 +13,8 @@ include $(SELF_DIR)common.mk
 ##help:		print this help message
 .PHONY: help
 
-help: Makefile
-	@sed -n 's/^##//p' $<
+help:
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/##//'
 
 #------------------------------------------------------------------------
 ##root-ca:	generate root CA files (key and certifcate) in current directory.


### PR DESCRIPTION
Was trying @esnible 's external istiod istioctl cmd, and couldnot find out how to use these make files without looking at code.

Before:
```
~/go/src/istio.io/istio/tools/certs on  master! ⌚ 16:36:18
$ make -f Makefile.selfsigned.mk 
make: *** No rule to make target `Makefile', needed by `help'.  Stop.
```

After:

```
~/go/src/istio.io/istio/tools/certs on  master! ⌚ 16:59:00
$ make -f Makefile.selfsigned.mk 
help:		print this help message
root-ca:	generate root CA files (key and certifcate) in current directory.
<name>-cacerts: generate self signed intermediate certificates for <name> and store them under <name> directory.
<namespace>-certs: generate intermediate certificates and sign certificates for a virtual machine connected to the namespace `<namespace> using serviceAccount `$SERVICE_ACCOUNT` using self signed root certs.
clean:  Cleans all the intermediate files and folders previously generated.
```

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
