### PR TITLE
Fix crash when first DNS requests comes before NDS is loaded

### DIFF
--- a/pilot/pkg/dns/dns.go
+++ b/pilot/pkg/dns/dns.go
@@ -151,7 +151,15 @@ func (h *LocalDNSServer) ServeDNS(proxy *dnsProxy, w dns.ResponseWriter, req *dn
 		// we expect only one question in the query even though the spec allows many
 		// clients usually do not do more than one query either.
 
-		lookupTable := h.lookupTable.Load().(*LookupTable)
+		lp := h.lookupTable.Load()
+		if lp == nil {
+			response = new(dns.Msg)
+			response.SetReply(req)
+			response.Rcode = dns.RcodeNameError
+			_ = w.WriteMsg(response)
+			return
+		}
+		lookupTable := lp.(*LookupTable)
 		var answers []dns.RR
 
 		// This name will always end in a dot


### PR DESCRIPTION
```
panic: interface conversion: interface {} is nil, not *dns.LookupTable

goroutine 122 [running]:
istio.io/istio/pilot/pkg/dns.(*LocalDNSServer).ServeDNS(0xc0007dc240, 0xc0007f9590, 0x308ff20, 0xc00051e420, 0xc001682c60)
        istio.io/istio/pilot/pkg/dns/dns.go:154 +0x514
istio.io/istio/pilot/pkg/dns.(*dnsProxy).ServeDNS(0xc0007f9590, 0x308ff20, 0xc00051e420, 0xc001682c60)
        istio.io/istio/pilot/pkg/dns/proxy.go:79 +0x52
github.com/miekg/dns.(*ServeMux).ServeDNS(0xc0007c9420, 0x308ff20, 0xc00051e420, 0xc001682c60)
        github.com/miekg/dns@v1.1.30/serve_mux.go:103 +0x5d
github.com/miekg/dns.(*Server).serveDNS(0xc0007e18c0, 0xc000b54000, 0x1b, 0x200, 0xc00051e420)
        github.com/miekg/dns@v1.1.30/server.go:609 +0x2f7
github.com/miekg/dns.(*Server).serveUDPPacket(0xc0007e18c0, 0xc00155a304, 0xc000b54000, 0x1b, 0x200, 0xc000522170, 0xc0011b2ea0)
        github.com/miekg/dns@v1.1.30/server.go:549 +0xb2
created by github.com/miekg/dns.(*Server).serveUDP
        github.com/miekg/dns@v1.1.30/server.go:479 +0x292
```