### PR TITLE
Fix lint for charts icon

### DIFF
--- a/manifests/charts/istiocoredns/Chart.yaml
+++ b/manifests/charts/istiocoredns/Chart.yaml
@@ -6,3 +6,8 @@ appVersion: 0.1
 tillerVersion: ">=2.7.2"
 keywords:
   - istio-addon
+  - istiocoredns
+sources:
+  - https://github.com/istio/istio/
+engine: gotpl
+icon: https://istio.io/latest/favicons/android-192x192.png


### PR DESCRIPTION
Found during https://github.com/istio/istio/pull/27242

Before:
```
$ make lint
...
==> Linting manifests/charts/istio-control/istio-discovery
Lint OK

==> Linting manifests/charts/istio-operator
Lint OK

==> Linting manifests/charts/istiocoredns
[INFO] Chart.yaml: icon is recommended

==> Linting manifests/charts/istiod-remote
Lint OK
```

After:

```
$ make lint
...
==> Linting manifests/charts/istio-control/istio-discovery
Lint OK

==> Linting manifests/charts/istio-operator
Lint OK

==> Linting manifests/charts/istiocoredns
Lint OK

==> Linting manifests/charts/istiod-remote
Lint OK
```