### PR TITLE
Reduce variable duplication in init and makefile

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -21,19 +21,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export GO_TOP=${GO_TOP:-$(echo "${GOPATH}" | cut -d ':' -f1)}
-export OUT_DIR=${OUT_DIR:-${GO_TOP}/out}
-
-export GOPATH=${GOPATH:-$GO_TOP}
-# Normally set by Makefile
-export ISTIO_BIN=${ISTIO_BIN:-${GOPATH}/bin}
-
-# Set the architecture. Matches logic in the Makefile.
-export GOARCH=${GOARCH:-'amd64'}
-
-# test scripts seem to like to run this script directly rather than use make
-export ISTIO_OUT=${ISTIO_OUT:-${ISTIO_BIN}}
-export ISTIO_OUT_LINUX=${ISTIO_OUT_LINUX:-${ISTIO_BIN}}
+if [[ "${ISTIO_ENVOY_LINUX_RELEASE_URL:-}" == "" ]]; then
+  echo "Envoy variables no set. Make sure you run through the makefile (\`make init\`) rather than directly."
+  exit 1
+fi
 
 # Download Envoy debug and release binaries for Linux x86_64. They will be included in the
 # docker images created by Dockerfile.proxyv2.
@@ -117,73 +108,6 @@ function download_wasm_if_necessary () {
     popd
   fi
 }
-
-# Included for support on macOS.
-function realpath () {
-  python -c "import os; print(os.path.realpath('$1'))"
-}
-
-if [[ -z "${PROXY_REPO_SHA:-}" ]] ; then
-  PROXY_REPO_SHA=$(grep PROXY_REPO_SHA istio.deps  -A 4 | grep lastStableSHA | cut -f 4 -d '"')
-  export PROXY_REPO_SHA
-fi
-
-# Defines the base URL to download envoy from
-ISTIO_ENVOY_BASE_URL=${ISTIO_ENVOY_BASE_URL:-https://storage.googleapis.com/istio-build/proxy}
-
-# These variables are normally set by the Makefile.
-# OS-neutral vars. These currently only work for linux.
-ISTIO_ENVOY_VERSION=${ISTIO_ENVOY_VERSION:-${PROXY_REPO_SHA}}
-ISTIO_ENVOY_LINUX_VERSION=${ISTIO_ENVOY_LINUX_VERSION:-${ISTIO_ENVOY_VERSION}}
-ISTIO_ENVOY_DEBUG_URL=${ISTIO_ENVOY_DEBUG_URL:-${ISTIO_ENVOY_BASE_URL}/envoy-debug-${ISTIO_ENVOY_LINUX_VERSION}.tar.gz}
-ISTIO_ENVOY_RELEASE_URL=${ISTIO_ENVOY_RELEASE_URL:-${ISTIO_ENVOY_BASE_URL}/envoy-alpha-${ISTIO_ENVOY_LINUX_VERSION}.tar.gz}
-
-# Envoy Linux vars. Normally set by the Makefile.
-ISTIO_ENVOY_LINUX_DEBUG_URL=${ISTIO_ENVOY_LINUX_DEBUG_URL:-${ISTIO_ENVOY_DEBUG_URL}}
-ISTIO_ENVOY_LINUX_RELEASE_URL=${ISTIO_ENVOY_LINUX_RELEASE_URL:-${ISTIO_ENVOY_RELEASE_URL}}
-# Variables for the extracted debug/release Envoy artifacts.
-ISTIO_ENVOY_LINUX_DEBUG_DIR=${ISTIO_ENVOY_LINUX_DEBUG_DIR:-"${OUT_DIR}/linux_amd64/debug"}
-ISTIO_ENVOY_LINUX_DEBUG_NAME=${ISTIO_ENVOY_LINUX_DEBUG_NAME:-"envoy-debug-${ISTIO_ENVOY_LINUX_VERSION}"}
-ISTIO_ENVOY_LINUX_DEBUG_PATH=${ISTIO_ENVOY_LINUX_DEBUG_PATH:-"${ISTIO_ENVOY_LINUX_DEBUG_DIR}/${ISTIO_ENVOY_LINUX_DEBUG_NAME}"}
-ISTIO_ENVOY_LINUX_RELEASE_DIR=${ISTIO_ENVOY_LINUX_RELEASE_DIR:-"${OUT_DIR}/linux_amd64/release"}
-ISTIO_ENVOY_LINUX_RELEASE_NAME=${ISTIO_ENVOY_LINUX_RELEASE_NAME:-"${SIDECAR}-${ISTIO_ENVOY_LINUX_VERSION}"}
-ISTIO_ENVOY_LINUX_RELEASE_PATH=${ISTIO_ENVOY_LINUX_RELEASE_PATH:-"${ISTIO_ENVOY_LINUX_RELEASE_DIR}/${ISTIO_ENVOY_LINUX_RELEASE_NAME}"}
-
-# Envoy macOS vars. Normally set by the makefile.
-# TODO Change url when official envoy release for macOS is available
-ISTIO_ENVOY_MACOS_VERSION=${ISTIO_ENVOY_MACOS_VERSION:-1.0.2}
-ISTIO_ENVOY_MACOS_RELEASE_URL=${ISTIO_ENVOY_MACOS_RELEASE_URL:-https://github.com/istio/proxy/releases/download/${ISTIO_ENVOY_MACOS_VERSION}/istio-proxy-${ISTIO_ENVOY_MACOS_VERSION}-macos.tar.gz}
-# Variables for the extracted debug/release Envoy artifacts.
-ISTIO_ENVOY_MACOS_RELEASE_DIR=${ISTIO_ENVOY_MACOS_RELEASE_DIR:-"${OUT_DIR}/darwin_amd64/release"}
-ISTIO_ENVOY_MACOS_RELEASE_NAME=${ISTIO_ENVOY_MACOS_RELEASE_NAME:-"envoy-${ISTIO_ENVOY_MACOS_VERSION}"}
-ISTIO_ENVOY_MACOS_RELEASE_PATH=${ISTIO_ENVOY_MACOS_RELEASE_PATH:-"${ISTIO_ENVOY_MACOS_RELEASE_DIR}/${ISTIO_ENVOY_MACOS_RELEASE_NAME}"}
-
-# Allow override with a local build of Envoy
-USE_LOCAL_PROXY=${USE_LOCAL_PROXY:-0}
-if [[ ${USE_LOCAL_PROXY} == 1 ]] ; then
-  ISTIO_ENVOY_LOCAL_PATH=${ISTIO_ENVOY_LOCAL_PATH:-$(realpath "${ISTIO_GO}/../proxy/bazel-bin/src/envoy/envoy")}
-  echo "Using istio-proxy image from local workspace: ${ISTIO_ENVOY_LOCAL_PATH}"
-  if [[ ! -f "${ISTIO_ENVOY_LOCAL_PATH}" ]]; then
-    echo "Error: missing istio-proxy from local workspace: ${ISTIO_ENVOY_LOCAL_PATH}. Check your build path."
-    exit 1
-  fi
-
-  # Point the native paths to the local envoy build.
-  if [[ "$GOOS_LOCAL" == "darwin" ]]; then
-    ISTIO_ENVOY_MACOS_RELEASE_PATH=${ISTIO_ENVOY_LOCAL_PATH}
-
-    ISTIO_ENVOY_LINUX_LOCAL_PATH=${ISTIO_ENVOY_LINUX_LOCAL_PATH:-}
-    if [[ -f "${ISTIO_ENVOY_LINUX_LOCAL_PATH}" ]] ; then
-      ISTIO_ENVOY_LINUX_DEBUG_PATH=${ISTIO_ENVOY_LINUX_LOCAL_PATH}
-      ISTIO_ENVOY_LINUX_RELEASE_PATH=${ISTIO_ENVOY_LINUX_LOCAL_PATH}
-    else
-      echo "Warning: The specified local macOS Envoy will not be included by Docker images. Set ISTIO_ENVOY_LINUX_LOCAL_PATH to specify a custom Linux build."
-    fi
-  else
-    ISTIO_ENVOY_LINUX_DEBUG_PATH=${ISTIO_ENVOY_LOCAL_PATH}
-    ISTIO_ENVOY_LINUX_RELEASE_PATH=${ISTIO_ENVOY_LOCAL_PATH}
-  fi
-fi
 
 mkdir -p "${ISTIO_OUT}"
 


### PR DESCRIPTION
These were duplicated because we had somethings running init.sh directly. We no longer do. In this time, the init.sh directly has broken, which leads me to believe its not used. As a result, I think removing the duplication is a better fix than fixing it, that way we only need to maintain one set of variables.