### PR TITLE
Logo-1: Adding Istio logo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-[![Go Report Card](https://goreportcard.com/badge/github.com/istio/istio)](https://goreportcard.com/report/github.com/istio/istio)
-[![GoDoc](https://godoc.org/istio.io/istio?status.svg)](https://godoc.org/istio.io/istio)
+<a href="https://istio.io/">
+    <img src="logo/istio-bluelogo-whitebackground-unframed.svg" alt="Istio logo" title="Istio" align="right" width="100" />
+</a>
 
 # Istio
+
+[![Go Report Card](https://goreportcard.com/badge/github.com/istio/istio)](https://goreportcard.com/report/github.com/istio/istio)
+[![GoDoc](https://godoc.org/istio.io/istio?status.svg)](https://godoc.org/istio.io/istio)
 
 An open platform to connect, manage, and secure microservices.
 

--- a/logo/istio-bluelogo-whitebackground-unframed.svg
+++ b/logo/istio-bluelogo-whitebackground-unframed.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 160 240"><g id="logo" fill="#466BB0"><rect id="background" width="160" height="240" fill="#fff"/><polygon id="hull" points="0 210 160 210 60 240"/><polygon id="mainsail" points="0 200 60 190 60 80"/><polygon id="headsail" points="70 190 160 200 70 0"/></g></svg>


### PR DESCRIPTION
Adding Istio logo in README.md file, so that when someone will read the README file by clicking on it they will directly redirect to Istio [website](https://istio.io/)

How the README.md file will look [here](https://github.com/RanabirChakraborty/istio/tree/Logo-1)

[X] Docs
[X] User Experience