### PR TITLE
do not apply locality load balancer settings for inbound clusters

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -573,10 +573,13 @@ func setH2Options(cluster *cluster.Cluster) {
 
 func applyTrafficPolicy(opts buildClusterOpts) {
 	connectionPool, outlierDetection, loadBalancer, tls := selectTrafficPolicyComponents(opts.policy)
-	applyH2Upgrade(opts, connectionPool)
+	// Connection pool settings are applicable for both inbound and outbound clusters.
 	applyConnectionPool(opts.mesh, opts.cluster, connectionPool)
-	applyOutlierDetection(opts.cluster, outlierDetection)
-	applyLoadBalancer(opts.cluster, loadBalancer, opts.port, opts.proxy, opts.mesh)
+	if opts.direction != model.TrafficDirectionInbound {
+		applyH2Upgrade(opts, connectionPool)
+		applyOutlierDetection(opts.cluster, outlierDetection)
+		applyLoadBalancer(opts.cluster, loadBalancer, opts.port, opts.proxy, opts.mesh)
+	}
 
 	if opts.clusterMode != SniDnatClusterMode && opts.direction != model.TrafficDirectionInbound {
 		autoMTLSEnabled := opts.mesh.GetEnableAutoMtls().Value

--- a/releasenotes/notes/27293.yaml
+++ b/releasenotes/notes/27293.yaml
@@ -6,4 +6,3 @@ issue:
 releaseNotes:
   - |
     **Fixed** a bug that locality load balancer settings were applied inbound clusters unnecessarily.
-.

--- a/releasenotes/notes/27293.yaml
+++ b/releasenotes/notes/27293.yaml
@@ -5,4 +5,5 @@ issue:
   - 27293
 releaseNotes:
   - |
-    **Fixed** Do not apply locality load balancer settings for inbound clusters.
+    **Fixed** a bug that locality load balancer settings were applied inbound clusters unnecessarily.
+.

--- a/releasenotes/notes/27293.yaml
+++ b/releasenotes/notes/27293.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 27293
+releaseNotes:
+  - |
+    **Fixed** Do not apply locality load balancer settings for inbound clusters.


### PR DESCRIPTION
Do not apply locality load balancer settings for inbound clusters. Fixes https://github.com/istio/istio/issues/27293
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
