### PR TITLE
update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,31 +7,31 @@
 /cni/                                                            @istio/wg-networking-maintainers
 /common/                                                         @istio/wg-test-and-release-maintainers
 /common-protos/                                                  @istio/wg-test-and-release-maintainers
-/galley/                                                         @istio/wg-networking-maintainers
+/galley/                                                         @istio/wg-networking-maintainers-pilot
 /galley/pkg/config/analysis/                                     @istio/wg-user-experience-maintainers
 /install/                                                        @istio/wg-environments-maintainers
 /istioctl/                                                       @istio/wg-user-experience-maintainers
 Makefile*                                                        @istio/wg-test-and-release-maintainers
 /manifests/                                                      @istio/wg-environments-maintainers
 /operator/                                                       @istio/wg-environments-maintainers
-/pilot/                                                          @istio/wg-networking-maintainers
+/pilot/                                                          @istio/wg-networking-maintainers-pilot
 /pilot/pkg/security/                                             @istio/wg-security-maintainers
-/pilot/pkg/config/                                               @istio/wg-networking-maintainers
-/pilot/pkg/networking/plugin/authn/                              @istio/wg-security-maintainers
-/pilot/pkg/networking/plugin/authz/                              @istio/wg-security-maintainers
+/pilot/pkg/config/                                               @istio/wg-networking-maintainers-pilot
+/pilot/pkg/networking/plugin/authn/                              @istio/wg-security-maintainers-pilot
+/pilot/pkg/networking/plugin/authz/                              @istio/wg-security-maintainers-pilot
 /pilot/pkg/serviceregistry/                                      @istio/wg-networking-maintainers-pilot
 /pilot/pkg/model/                                                @istio/wg-networking-maintainers-pilot
 /pilot/pkg/networking/core                                       @istio/wg-networking-maintainers-pilot
 /pilot/pkg/proxy                                                 @istio/wg-networking-maintainers-pilot
-/pkg/adsc/                                                       @istio/wg-networking-maintainers
-/pkg/bootstrap/                                                  @istio/wg-networking-maintainers
-/pkg/config/                                                     @istio/wg-networking-maintainers
-/pkg/envoy/                                                      @istio/wg-networking-maintainers
-/pkg/istio-agent/                                                @istio/wg-networking-maintainers @istio/wg-security-maintainers
-/pkg/keepalive/                                                  @istio/wg-networking-maintainers
-/pkg/kube/                                                       @istio/wg-networking-maintainers
-/pkg/mcp/                                                        @istio/wg-networking-maintainers
-/pkg/queue/                                                      @istio/wg-networking-maintainers
+/pkg/adsc/                                                       @istio/wg-networking-maintainers-pilot
+/pkg/bootstrap/                                                  @istio/wg-networking-maintainers-pilot
+/pkg/config/                                                     @istio/wg-networking-maintainers-pilot
+/pkg/envoy/                                                      @istio/wg-networking-maintainers-pilot
+/pkg/istio-agent/                                                @istio/wg-networking-maintainers-pilot @istio/wg-security-maintainers
+/pkg/keepalive/                                                  @istio/wg-networking-maintainers-pilot
+/pkg/kube/                                                       @istio/wg-networking-maintainers-pilot
+/pkg/mcp/                                                        @istio/wg-networking-maintainers-pilot
+/pkg/queue/                                                      @istio/wg-networking-maintainers-pilot
 /pkg/security/                                                   @istio/wg-security-maintainers @istio/wg-environments-maintainers
 /pkg/spiffe/                                                     @istio/wg-security-maintainers
 /pkg/test/                                                       @istio/wg-test-and-release-maintainers
@@ -46,9 +46,9 @@ Makefile*                                                        @istio/wg-test-
 /tests/                                                          @istio/wg-test-and-release-maintainers
 /tests/integration/conformance/                                  @istio/wg-test-and-release-maintainers
 /tests/integration/framework/                                    @istio/wg-test-and-release-maintainers
-/tests/integration/galley/                                       @istio/wg-networking-maintainers
+/tests/integration/galley/                                       @istio/wg-networking-maintainers-pilot
 /tests/integration/telemetry/                                    @istio/wg-policies-and-telemetry-maintainers
-/tests/integration/pilot/                                        @istio/wg-networking-maintainers
+/tests/integration/pilot/                                        @istio/wg-networking-maintainers-pilot
 /tests/integration/qualification/                                @istio/wg-test-and-release-maintainers
 /tests/integration/security/                                     @istio/wg-security-maintainers
 /tests/integration/istioctl/                                     @istio/wg-user-experience-maintainers


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Remove data-plane folks from pilot reviewers. I can't imagine something like pkg/kube needs envoy reviewers.
This just generates spam.