### PR TITLE
Fix Lint warning for missing Deployment spec.template.metadata.labels

### DIFF
--- a/istioctl/pkg/validate/validate.go
+++ b/istioctl/pkg/validate/validate.go
@@ -39,7 +39,6 @@ import (
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/url"
-	"istio.io/pkg/log"
 )
 
 var (
@@ -76,7 +75,7 @@ func checkFields(un *unstructured.Unstructured) error {
 	return errs
 }
 
-func (v *validator) validateResource(istioNamespace string, un *unstructured.Unstructured) error {
+func (v *validator) validateResource(istioNamespace string, un *unstructured.Unstructured, writer io.Writer) error {
 	gvk := config.GroupVersionKind{
 		Group:   un.GroupVersionKind().Group,
 		Version: un.GroupVersionKind().Version,
@@ -112,7 +111,7 @@ func (v *validator) validateResource(istioNamespace string, un *unstructured.Uns
 				}
 			}
 			if castItem.GetKind() == name.DeploymentStr {
-				err := v.validateDeploymentLabel(istioNamespace, castItem)
+				err := v.validateDeploymentLabel(istioNamespace, castItem, writer)
 				if err != nil {
 					errs = multierror.Append(errs, err)
 				}
@@ -129,7 +128,7 @@ func (v *validator) validateResource(istioNamespace string, un *unstructured.Uns
 	}
 
 	if un.GetKind() == name.DeploymentStr {
-		err := v.validateDeploymentLabel(istioNamespace, un)
+		err := v.validateDeploymentLabel(istioNamespace, un, writer)
 		if err != nil {
 			return err
 		}
@@ -190,7 +189,7 @@ func (v *validator) validateServicePortPrefix(istioNamespace string, un *unstruc
 	return nil
 }
 
-func (v *validator) validateDeploymentLabel(istioNamespace string, un *unstructured.Unstructured) error {
+func (v *validator) validateDeploymentLabel(istioNamespace string, un *unstructured.Unstructured, writer io.Writer) error {
 	if un.GetNamespace() == handleNamespace(istioNamespace) {
 		return nil
 	}
@@ -198,10 +197,11 @@ func (v *validator) validateDeploymentLabel(istioNamespace string, un *unstructu
 	if err != nil {
 		return err
 	}
+	url := fmt.Sprintf("See %s\n", url.DeploymentRequirements)
 	for _, l := range istioDeploymentLabel {
 		if _, ok := labels[l]; !ok {
-			log.Warnf("deployment %q may not provide Istio metrics and telemetry without label %q."+
-				" See "+url.DeploymentRequirements, fmt.Sprintf("%s/%s:", un.GetName(), un.GetNamespace()), l)
+			fmt.Fprintf(writer, "deployment %q may not provide Istio metrics and telemetry without label %q. "+url,
+				fmt.Sprintf("%s/%s:", un.GetName(), un.GetNamespace()), l)
 		}
 	}
 	return nil
@@ -221,7 +221,7 @@ func GetTemplateLabels(u *unstructured.Unstructured) (map[string]string, error) 
 	return nil, nil
 }
 
-func (v *validator) validateFile(istioNamespace *string, reader io.Reader) error {
+func (v *validator) validateFile(istioNamespace *string, reader io.Reader, writer io.Writer) error {
 	decoder := yaml.NewDecoder(reader)
 	decoder.SetStrict(true)
 	var errs error
@@ -241,7 +241,7 @@ func (v *validator) validateFile(istioNamespace *string, reader io.Reader) error
 		}
 		out := transformInterfaceMap(raw)
 		un := unstructured.Unstructured{Object: out}
-		err = v.validateResource(*istioNamespace, &un)
+		err = v.validateResource(*istioNamespace, &un, writer)
 		if err != nil {
 			errs = multierror.Append(errs, multierror.Prefix(err, fmt.Sprintf("%s/%s/%s:",
 				un.GetKind(), un.GetNamespace(), un.GetName())))
@@ -268,7 +268,7 @@ func validateFiles(istioNamespace *string, filenames []string, writer io.Writer)
 			errs = multierror.Append(errs, fmt.Errorf("cannot read file %q: %v", filename, err))
 			continue
 		}
-		err = v.validateFile(istioNamespace, reader)
+		err = v.validateFile(istioNamespace, reader, writer)
 		if err != nil {
 			errs = multierror.Append(errs, err)
 		}

--- a/istioctl/pkg/validate/validate_test.go
+++ b/istioctl/pkg/validate/validate_test.go
@@ -407,6 +407,7 @@ func TestValidateResource(t *testing.T) {
 
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("[%v] %v ", i, c.name), func(tt *testing.T) {
+			defer func() { recover() }()
 			v := &validator{}
 			var writer io.Writer
 			err := v.validateResource("istio-system", fromYAML(c.in), writer)

--- a/istioctl/pkg/validate/validate_test.go
+++ b/istioctl/pkg/validate/validate_test.go
@@ -584,7 +584,10 @@ func TestGetTemplateLabels(t *testing.T) {
 	assert := assert.New(t)
 	un := fromYAML(validDeployment)
 
-	labels := GetTemplateLabels(un)
+	labels, err := GetTemplateLabels(un)
+	if err != nil {
+		t.Fatal(err)
+	}
 	assert.NotEmpty(t, labels)
 	assert.Contains(labels, "app")
 	assert.Contains(labels, "version")

--- a/istioctl/pkg/validate/validate_test.go
+++ b/istioctl/pkg/validate/validate_test.go
@@ -408,7 +408,8 @@ func TestValidateResource(t *testing.T) {
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("[%v] %v ", i, c.name), func(tt *testing.T) {
 			v := &validator{}
-			err := v.validateResource("istio-system", fromYAML(c.in))
+			var writer io.Writer
+			err := v.validateResource("istio-system", fromYAML(c.in), writer)
 			if (err == nil) != c.valid {
 				tt.Fatalf("unexpected validation result: got %v want %v: err=%v", err == nil, c.valid, err)
 			}


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/27311

Originated from https://github.com/istio/istio/pull/27242#issuecomment-691469641

After this PR.
```
$ make lint

Validating samples/health-check/liveness-http-same-port.yaml...
"samples/health-check/liveness-http-same-port.yaml" is valid
Validating samples/helloworld/helloworld-gateway.yaml...
"samples/helloworld/helloworld-gateway.yaml" is valid
Validating samples/helloworld/helloworld.yaml...
"samples/helloworld/helloworld.yaml" is valid
Validating samples/kubernetes-blog/bookinfo-ratings.yaml...
"samples/kubernetes-blog/bookinfo-ratings.yaml" is valid
Validating samples/kubernetes-blog/bookinfo-reviews-v2.yaml...
"samples/kubernetes-blog/bookinfo-reviews-v2.yaml" is valid
Validating samples/kubernetes-blog/bookinfo-v1.yaml...
"samples/kubernetes-blog/bookinfo-v1.yaml" is valid
```