### PR TITLE
disable headless and VM OS tests for multicluster

### DIFF
--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -320,7 +320,7 @@ func protocolSniffingCases(apps *EchoDeployments) []TrafficTestCase {
 				destinations := destinations
 				// grabbing the 0th assumes all echos in destinations have the same service name
 				destination := destinations[0]
-				if apps.Headless.Contains(client) || apps.Headless.Contains(destinations) && len(apps.Headless) > 1 {
+				if (apps.Headless.Contains(client) || apps.Headless.Contains(destinations)) && len(apps.Headless) > 1 {
 					// TODO(landow) fix DNS issues with multicluster/VMs/headless
 					continue
 				}

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -320,7 +320,7 @@ func protocolSniffingCases(apps *EchoDeployments) []TrafficTestCase {
 				destinations := destinations
 				// grabbing the 0th assumes all echos in destinations have the same service name
 				destination := destinations[0]
-				if (apps.Headless.Contains(client) || apps.Headless.Contains(destinations)) && len(apps.Headless) > 1 {
+				if (apps.Headless.Contains(client) || apps.Headless.Contains(destination)) && len(apps.Headless) > 1 {
 					// TODO(landow) fix DNS issues with multicluster/VMs/headless
 					continue
 				}

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -305,7 +305,6 @@ func protocolSniffingCases(apps *EchoDeployments) []TrafficTestCase {
 	// TODO add VMs to clients when DNS works for VMs. Blocked by https://github.com/istio/istio/issues/27154
 	for _, clients := range []echo.Instances{apps.PodA, apps.Naked, apps.Headless} {
 		for _, client := range clients {
-
 			destinationSets := []echo.Instances{
 				apps.PodA,
 				apps.VM,
@@ -321,6 +320,10 @@ func protocolSniffingCases(apps *EchoDeployments) []TrafficTestCase {
 				destinations := destinations
 				// grabbing the 0th assumes all echos in destinations have the same service name
 				destination := destinations[0]
+				if apps.Headless.Contains(client) || apps.Headless.Contains(destinations) && len(apps.Headless) > 1 {
+					// TODO(landow) fix DNS issues with multicluster/VMs/headless
+					continue
+				}
 				if apps.Naked.Contains(client) && apps.VM.Contains(destination) {
 					// Need a sidecar to connect to VMs
 					continue

--- a/tests/integration/pilot/vm_test.go
+++ b/tests/integration/pilot/vm_test.go
@@ -35,6 +35,7 @@ func GetAdditionVMImages() []string {
 func TestVmOSPost(t *testing.T) {
 	framework.
 		NewTest(t).
+		RequiresSingleCluster(). // TODO(landow) fix DNS issues with multicluster/VMs/headless
 		Features("traffic.reachability").
 		Label(label.Postsubmit).
 		Run(func(ctx framework.TestContext) {


### PR DESCRIPTION
At some point [integ-pilot-multicluster-tests_istio](https://testgrid.k8s.io/istio_istio#integ-pilot-multicluster-tests_istio) started failing the VM OS tests and all headless connectivity tests. I think this is related to DNS changes, but I want to get this job to be green and mark it required so it doesn't have any further regressions that block converting our tests. 

cc @nmittler @rshriram 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
