### PR TITLE
Fix handling of empty resources

### DIFF
--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -302,7 +302,7 @@ func (s *DiscoveryServer) shouldRespond(con *Connection, request *discovery.Disc
 		return false
 	}
 
-	if len(request.ResourceNames) == 0 && !isWildcardTypeUrl(request.TypeUrl) {
+	if len(request.ResourceNames) == 0 && !isWildcardTypeURL(request.TypeUrl) {
 		adsLog.Debugf("ADS:%s: UNSUBSCRIBE %s %s %s", stype, con.ConID, request.VersionInfo, request.ResponseNonce)
 		con.proxy.Lock()
 		delete(con.proxy.WatchedResources, request.TypeUrl)
@@ -366,14 +366,14 @@ func (s *DiscoveryServer) shouldRespond(con *Connection, request *discovery.Disc
 	return true
 }
 
-// isWildcardTypeUrl checks whether a given type is a wildcard type
+// isWildcardTypeURL checks whether a given type is a wildcard type
 // https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#how-the-client-specifies-what-resources-to-return
 // If the list of resource names becomes empty, that means that the client is no
 // longer interested in any resources of the specified type. For Listener and
 // Cluster resource types, there is also a “wildcard” mode, which is triggered
 // when the initial request on the stream for that resource type contains no
 // resource names.
-func isWildcardTypeUrl(typeURL string) bool {
+func isWildcardTypeURL(typeURL string) bool {
 	switch typeURL {
 	case v3.SecretType, v3.EndpointType, v3.RouteType:
 		// By XDS spec, these are not wildcard

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -302,8 +302,17 @@ func (s *DiscoveryServer) shouldRespond(con *Connection, request *discovery.Disc
 		return false
 	}
 
+	if len(request.ResourceNames) == 0 && !isWildcardTypeUrl(request.TypeUrl) {
+		adsLog.Debugf("ADS:%s: UNSUBSCRIBE %s %s %s", stype, con.ConID, request.VersionInfo, request.ResponseNonce)
+		con.proxy.Lock()
+		delete(con.proxy.WatchedResources, request.TypeUrl)
+		con.proxy.Unlock()
+		return false
+	}
+
 	// This is first request - initialize typeUrl watches.
 	if request.ResponseNonce == "" {
+		adsLog.Debugf("ADS:%s: INIT %s %s %s", stype, con.ConID, request.VersionInfo, request.ResponseNonce)
 		con.proxy.Lock()
 		con.proxy.WatchedResources[request.TypeUrl] = &model.WatchedResource{TypeUrl: request.TypeUrl, ResourceNames: request.ResourceNames, LastRequest: request}
 		con.proxy.Unlock()
@@ -355,6 +364,27 @@ func (s *DiscoveryServer) shouldRespond(con *Connection, request *discovery.Disc
 		previousResources, request.ResourceNames, con.ConID, request.VersionInfo, request.ResponseNonce)
 
 	return true
+}
+
+// isWildcardTypeUrl checks whether a given type is a wildcard type
+// https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#how-the-client-specifies-what-resources-to-return
+// If the list of resource names becomes empty, that means that the client is no
+// longer interested in any resources of the specified type. For Listener and
+// Cluster resource types, there is also a “wildcard” mode, which is triggered
+// when the initial request on the stream for that resource type contains no
+// resource names.
+func isWildcardTypeUrl(typeURL string) bool {
+	switch typeURL {
+	case v3.SecretType, v3.EndpointType, v3.RouteType:
+		// By XDS spec, these are not wildcard
+		return false
+	case v3.ClusterType, v3.ListenerType:
+		// By XDS spec, these are wildcard
+		return true
+	default:
+		// All of our internal types use wildcard semantics
+		return true
+	}
 }
 
 // listEqualUnordered checks that two lists contain all the same elements

--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -21,6 +21,7 @@ import (
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/golang/protobuf/proto"
 
 	mesh "istio.io/api/mesh/v1alpha1"
@@ -39,6 +40,7 @@ import (
 	istioagent "istio.io/istio/pkg/istio-agent"
 	"istio.io/istio/pkg/security"
 	"istio.io/istio/pkg/spiffe"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/tests/util"
 )
 
@@ -223,8 +225,8 @@ func TestAdsReconnectAfterRestart(t *testing.T) {
 	_ = adscon.CloseSend()
 	adscon = s.ConnectADS()
 
-	// Connect with empty resources.
-	err = sendEDSReq([]string{}, sidecarID(app3Ip, "app3"), res.VersionInfo, res.Nonce, adscon)
+	// Connect with the same resources
+	err = sendEDSReq([]string{"fake-cluster"}, sidecarID(app3Ip, "app3"), res.VersionInfo, res.Nonce, adscon)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -235,8 +237,38 @@ func TestAdsReconnectAfterRestart(t *testing.T) {
 	if res == nil {
 		t.Fatal("Expected EDS response, but go nil")
 	}
-	if len(res.Resources) != 0 || res.TypeUrl != v3.EndpointType {
-		t.Fatalf("Expected zero EDS resource, but got %v %s resources", len(res.Resources), res.TypeUrl)
+	if len(res.Resources) != 1 || res.TypeUrl != v3.EndpointType {
+		t.Fatalf("Expected one EDS resource, but got %v %s resources", len(res.Resources), res.TypeUrl)
+	}
+}
+
+func TestAdsUnsubscribe(t *testing.T) {
+	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+	adscon := s.ConnectADS()
+	err := sendEDSReq([]string{"fake-cluster"}, sidecarID(app3Ip, "app3"), "", "", adscon)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := adsReceive(adscon, 15*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res == nil {
+		t.Fatal("Expected EDS response, but go nil")
+	}
+	if len(res.Resources) != 1 || res.TypeUrl != v3.EndpointType {
+		t.Fatalf("Expected one EDS resource, but got %v %s resources", len(res.Resources), res.TypeUrl)
+	}
+
+	// send empty resources
+	err = sendEDSReq([]string{}, sidecarID(app3Ip, "app3"), res.VersionInfo, res.Nonce, adscon)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// We should get no response
+	_, err = adsReceive(adscon, 250*time.Millisecond)
+	if err == nil || err.Error() != "EOF" {
+		t.Fatalf("got unexpected error: %v", err)
 	}
 }
 
@@ -802,59 +834,57 @@ func TestAdsUpdate(t *testing.T) {
 	}
 }
 
+func expectNoResponse(t test.Failer, c chan *discovery.DiscoveryResponse) {
+	t.Helper()
+	select {
+	case <-time.After(time.Millisecond * 100):
+		return
+	case resp := <-c:
+		t.Fatalf("got unexpected response: %v", resp)
+	}
+}
+
+func expectNonEmptyResource(t test.Failer, c chan *discovery.DiscoveryResponse) *discovery.DiscoveryResponse {
+	t.Helper()
+	select {
+	case <-time.After(time.Second):
+		t.Fatalf("did not get response in time")
+	case resp := <-c:
+		if resp == nil || len(resp.Resources) == 0 {
+			t.Fatalf("got empty response")
+		}
+		return resp
+	}
+	return nil
+}
+
 func TestEnvoyRDSProtocolError(t *testing.T) {
 	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 	adscon := s.ConnectADS()
+	responses := make(chan *discovery.DiscoveryResponse)
+	go adsReceiveChannel(adscon, responses)
 
 	err := sendRDSReq(gatewayID(gatewayIP), []string{routeA}, "", "", adscon)
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := adsReceive(adscon, 15*time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if res == nil || len(res.Resources) == 0 {
-		t.Fatal("No routes returned")
-	}
-
+	res := expectNonEmptyResource(t, responses)
 	xds.AdsPushAll(s.Discovery)
+	res = expectNonEmptyResource(t, responses)
 
-	res, err = adsReceive(adscon, 15*time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if res == nil || len(res.Resources) != 1 {
-		t.Fatal("No routes returned")
-	}
-
-	// send empty response and validate no routes are retuned.
+	// send empty response and validate no response is returned.
 	err = sendRDSReq(gatewayID(gatewayIP), nil, res.VersionInfo, res.Nonce, adscon)
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err = adsReceive(adscon, 15*time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if res == nil || len(res.Resources) != 0 {
-		t.Fatalf("No routes expected but got routes %v", len(res.Resources))
-	}
+	expectNoResponse(t, responses)
 
 	// Refresh routes
 	err = sendRDSReq(gatewayID(gatewayIP), []string{routeA, routeB}, res.VersionInfo, res.Nonce, adscon)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	res, err = adsReceive(adscon, 15*time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if res == nil || len(res.Resources) == 0 {
-		t.Fatal("No routes after protocol error")
-	}
+	res = expectNonEmptyResource(t, responses)
 }
 
 func TestEnvoyRDSUpdatedRouteRequest(t *testing.T) {

--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -868,9 +868,9 @@ func TestEnvoyRDSProtocolError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res := expectNonEmptyResource(t, responses)
+	expectNonEmptyResource(t, responses)
 	xds.AdsPushAll(s.Discovery)
-	res = expectNonEmptyResource(t, responses)
+	res := expectNonEmptyResource(t, responses)
 
 	// send empty response and validate no response is returned.
 	err = sendRDSReq(gatewayID(gatewayIP), nil, res.VersionInfo, res.Nonce, adscon)
@@ -884,7 +884,7 @@ func TestEnvoyRDSProtocolError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res = expectNonEmptyResource(t, responses)
+	expectNonEmptyResource(t, responses)
 }
 
 func TestEnvoyRDSUpdatedRouteRequest(t *testing.T) {

--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -225,7 +225,7 @@ func TestAdsReconnectAfterRestart(t *testing.T) {
 	_ = adscon.CloseSend()
 	adscon = s.ConnectADS()
 
-	// Connect with the same resources
+	// Reconnect with the same resources
 	err = sendEDSReq([]string{"fake-cluster"}, sidecarID(app3Ip, "app3"), res.VersionInfo, res.Nonce, adscon)
 	if err != nil {
 		t.Fatal(err)

--- a/pilot/pkg/xds/discovery_test.go
+++ b/pilot/pkg/xds/discovery_test.go
@@ -437,6 +437,27 @@ func TestShouldRespond(t *testing.T) {
 			},
 			response: false,
 		},
+		{
+			name: "unsubscribe EDS",
+			connection: &Connection{
+				proxy: &model.Proxy{
+					WatchedResources: map[string]*model.WatchedResource{
+						v3.EndpointType: {
+							VersionSent:   "v1",
+							NonceSent:     "nonce",
+							ResourceNames: []string{"cluster2", "cluster1"},
+						},
+					},
+				},
+			},
+			request: &discovery.DiscoveryRequest{
+				TypeUrl:       v3.EndpointType,
+				VersionInfo:   "v1",
+				ResponseNonce: "nonce",
+				ResourceNames: []string{},
+			},
+			response: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pilot/pkg/xds/init_test.go
+++ b/pilot/pkg/xds/init_test.go
@@ -58,6 +58,15 @@ func testIP(id uint32) string {
 	return net.IP(ipb).String()
 }
 
+func adsReceiveChannel(ads AdsClient, c chan *discovery.DiscoveryResponse) {
+	for {
+		resp, err := ads.Recv()
+		if err != nil {
+			return
+		}
+		c <- resp
+	}
+}
 func adsReceive(ads AdsClient, to time.Duration) (*discovery.DiscoveryResponse, error) {
 	done := make(chan int, 1)
 	t := time.NewTimer(to)


### PR DESCRIPTION
Conform to XDS spec in
https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#how-the-client-specifies-what-resources-to-return.

This has not been found as a bug in normal Envoy interaction, but it
breaks `istioctl wait` and `istioctl ps` today. What happens is Envoy
will send an RDS request with empty resources. This can happen at
startup or at any point in time (removing all VS for gateway, for
example). When this happens, today, we just keep sending it an empty
list of resources, which it will accept but never ACK.

This changes to actually drop the subscription, so we never even send
these empty resources.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.