### PR TITLE
Add a global switch so we can disable default retry policy(#27340)

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -350,4 +350,10 @@ var (
 	AllowMetadataCertsInMutualTLS = env.RegisterBoolVar("PILOT_ALLOW_METADATA_CERTS_DR_MUTUAL_TLS", false,
 		"If true, Pilot will allow certs specified in Metadata to override DR certs in MUTUAL TLS mode. "+
 			"This is only enabled for migration and will be removed soon.").Get()
+
+	EnableDefaultRetryPolicy = env.RegisterBoolVar(
+		"PILOT_ENABLE_DEFAULT_RETRY_POLICY",
+		true,
+		"If true, Pilot will set a default retry policy for http routes.",
+	).Get()
 )


### PR DESCRIPTION
The default retry policy causes problems when the service is none-idempotent.

Pilot adds a default retry policy to HTTP routes, which can potentially call a non-idempotent service two times with a single request. Event though retries only happen when the connection fails or an error response by the server, the server may have already done some modification on its state. In this case, it's better to let the downstream decide whether it should retry or not.

Signed-off-by: huabing zhao <zhaohuabing@gmail.com>



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[*] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[*] Does not have any changes that may affect Istio users.