### PR TITLE
pilot tests: vm only validates hitting headless service in local-cluster

### DIFF
--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -410,7 +410,7 @@ func VMTestCases(vms echo.Instances, apps *EchoDeployments) []TrafficTestCase {
 			vmCase{
 				name: "dns: VM to k8s headless service",
 				from: vm,
-				to:   apps.Headless,
+				to:   apps.Headless.Match(echo.InCluster(vm.Config().Cluster)),
 				host: apps.Headless[0].Config().FQDN(),
 			},
 		)


### PR DESCRIPTION
On top of #27332, we need this to get a "green" baseline to fix these tests from. 
#27343 will likely need to re-break some tests for CI to produce valuable debugging info. 

https://prow.istio.io/?pull=27344&job=integ-pilot-multicluster-tests_istio

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
