### PR TITLE
Only check Istiod pod version on port 15014

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -568,7 +568,7 @@ func (c *client) GetIstioPods(ctx context.Context, namespace string, params map[
 
 func (c *client) GetIstioVersions(ctx context.Context, namespace string) (*version.MeshInfo, error) {
 	pods, err := c.GetIstioPods(ctx, namespace, map[string]string{
-		"labelSelector": "istio,istio!=ingressgateway,istio!=egressgateway,istio!=ilbgateway",
+		"labelSelector": "istio=pilot",
 		"fieldSelector": "status.phase=Running",
 	})
 	if err != nil {


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/27317

The 'istioctl version' legacy command should only get the version on :15014/version from Istiod.  There are no longer other microservice pods.

@howardjohn This might be suitable for a `cherry-pick-1.7`.

This problem manifests when a user installs with an Ingress Gateway Deployment Pod with label `istio=<anything-other-than-ingressgateway>`.  

- With this change, `istioctl version` only picks up the version from Istiod pod.  This means `istioctl version` with this applied will not detect if the mixer was not pruned by the install.
- An alternative is to continue contacting all unrecognized `istio=` labelled pods, and suppress this message.
- Another alternative is to continue with this message, which is caused by a user putting `istio: <custom name>` as an override on a second ingress gateway when installing.  If we like this option we should close this PR with WONTFIX.