### PR TITLE
Remove RequireSingleCluster() within security integration tests

### DIFF
--- a/tests/integration/security/ca_custom_root/main_test.go
+++ b/tests/integration/security/ca_custom_root/main_test.go
@@ -35,7 +35,6 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
 		// k8s is required because the plugin CA key and certificate are stored in a k8s secret.
-		RequireSingleCluster().
 		Label(label.CustomSetup).
 		Setup(istio.Setup(&inst, setupConfig, cert.CreateCASecret)).
 		Run()

--- a/tests/integration/security/chiron/main_test.go
+++ b/tests/integration/security/chiron/main_test.go
@@ -32,7 +32,6 @@ func TestMain(m *testing.M) {
 	// Integration test for provisioning DNS certificates.
 	// TODO (lei-tang): investigate whether this test can be moved to integration/security.
 	framework.NewSuite(m).
-		RequireSingleCluster().
 		Label(label.CustomSetup).
 		Setup(istio.Setup(&inst, setupConfig)).
 		Run()

--- a/tests/integration/security/filebased_tls_origination/main_test.go
+++ b/tests/integration/security/filebased_tls_origination/main_test.go
@@ -36,7 +36,6 @@ func TestMain(m *testing.M) {
 
 		// SDS requires Kubernetes 1.13
 		RequireEnvironmentVersion("1.13").
-		RequireSingleCluster().
 		Label("CustomSetup").
 		Setup(istio.Setup(&inst, setupConfig, cert.CreateCustomEgressSecret)).
 		Run()

--- a/tests/integration/security/main_test.go
+++ b/tests/integration/security/main_test.go
@@ -31,7 +31,6 @@ var (
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
-		RequireSingleCluster().
 		Setup(istio.Setup(&ist, setupConfig)).
 		Run()
 }

--- a/tests/integration/security/mtls_first_party_jwt/main_test.go
+++ b/tests/integration/security/mtls_first_party_jwt/main_test.go
@@ -31,7 +31,6 @@ var (
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
-		RequireSingleCluster().
 		Label(label.CustomSetup).
 		Setup(istio.Setup(&inst, setupConfig)).
 		Run()

--- a/tests/integration/security/mtlsk8sca/main_test.go
+++ b/tests/integration/security/mtlsk8sca/main_test.go
@@ -31,7 +31,6 @@ var (
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
-		RequireSingleCluster().
 		Label(label.CustomSetup).
 		Setup(istio.Setup(&inst, setupConfig)).
 		Run()

--- a/tests/integration/security/sds_egress/main_test.go
+++ b/tests/integration/security/sds_egress/main_test.go
@@ -38,7 +38,6 @@ func TestMain(m *testing.M) {
 
 		// SDS requires Kubernetes 1.13
 		RequireEnvironmentVersion("1.13").
-		RequireSingleCluster().
 		Setup(istio.Setup(&inst, setupConfig)).
 		Setup(func(ctx resource.Context) (err error) {
 			if prom, err = prometheus.New(ctx, prometheus.Config{}); err != nil {

--- a/tests/integration/security/sds_ingress/ingress_test.go
+++ b/tests/integration/security/sds_ingress/ingress_test.go
@@ -32,7 +32,6 @@ func TestMain(m *testing.M) {
 	// Integration test for the ingress SDS Gateway flow.
 	framework.
 		NewSuite(m).
-		RequireSingleCluster().
 		Setup(istio.Setup(&inst, nil)).
 		Run()
 }

--- a/tests/integration/security/sds_ingress_istiod/ingress_test.go
+++ b/tests/integration/security/sds_ingress_istiod/ingress_test.go
@@ -32,7 +32,6 @@ func TestMain(m *testing.M) {
 	// Integration test for the ingress SDS Gateway flow with Istiod acting as the SDS server
 	framework.
 		NewSuite(m).
-		RequireSingleCluster().
 		Setup(istio.Setup(&inst, func(ctx resource.Context, cfg *istio.Config) {
 			cfg.Values["pilot.env.ISTIOD_ENABLE_SDS_SERVER"] = "true"
 		})).

--- a/tests/integration/security/sds_ingress_k8sca/main_test.go
+++ b/tests/integration/security/sds_ingress_k8sca/main_test.go
@@ -33,7 +33,6 @@ func TestMain(m *testing.M) {
 	// the control plane certificate provider is k8s CA.
 	framework.
 		NewSuite(m).
-		RequireSingleCluster().
 		Setup(istio.Setup(&inst, setupConfig)).
 		Run()
 

--- a/tests/integration/security/sds_tls_origination/main_test.go
+++ b/tests/integration/security/sds_tls_origination/main_test.go
@@ -35,7 +35,6 @@ func TestMain(m *testing.M) {
 
 		// SDS requires Kubernetes 1.13
 		RequireEnvironmentVersion("1.13").
-		RequireSingleCluster().
 		Label("CustomSetup").
 		Setup(istio.Setup(&inst, setupConfig)).
 		Run()

--- a/tests/integration/security/sds_vault_flow/main_test.go
+++ b/tests/integration/security/sds_vault_flow/main_test.go
@@ -54,7 +54,6 @@ func TestMain(m *testing.M) {
 		Skip("https://github.com/istio/istio/issues/17572").
 		// SDS requires Kubernetes 1.13
 		RequireEnvironmentVersion("1.13").
-		RequireSingleCluster().
 		Setup(istio.Setup(&inst, setupConfig)).
 		Run()
 }

--- a/tests/integration/security/webhook/webhook_test.go
+++ b/tests/integration/security/webhook/webhook_test.go
@@ -35,7 +35,6 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
 		Label(label.CustomSetup).
-		RequireSingleCluster().
 		// Deploy Istio
 		Setup(istio.Setup(&inst, setupConfig)).
 		Run()


### PR DESCRIPTION
This PR is the first step to convert security integration tests to multicluster supported. 


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.