### PR TITLE
Do not set fsGroup when its not needed

### DIFF
--- a/istioctl/pkg/install/k8sversion/version_test.go
+++ b/istioctl/pkg/install/k8sversion/version_test.go
@@ -56,29 +56,34 @@ var (
 
 func TestExtractKubernetesVersion(t *testing.T) {
 	cases := []struct {
-		version *version.Info
-		errMsg  error
-		isValid bool
+		version  *version.Info
+		expected int
+		errMsg   error
+		isValid  bool
 	}{
 		{
-			version: version1_17,
-			errMsg:  nil,
-			isValid: true,
+			version:  version1_17,
+			expected: 17,
+			errMsg:   nil,
+			isValid:  true,
 		},
 		{
-			version: version1_8,
-			errMsg:  nil,
-			isValid: true,
+			version:  version1_8,
+			expected: 8,
+			errMsg:   nil,
+			isValid:  true,
 		},
 		{
-			version: version1_17GKE,
-			errMsg:  nil,
-			isValid: true,
+			version:  version1_17GKE,
+			expected: 17,
+			errMsg:   nil,
+			isValid:  true,
 		},
 		{
-			version: version1_8GKE,
-			errMsg:  nil,
-			isValid: true,
+			version:  version1_8GKE,
+			expected: 8,
+			errMsg:   nil,
+			isValid:  true,
 		},
 		{
 			version: versionInvalid1,
@@ -93,56 +98,12 @@ func TestExtractKubernetesVersion(t *testing.T) {
 	}
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case %d %s", i, c.version), func(t *testing.T) {
-			_, err := extractKubernetesVersion(c.version)
+			got, err := extractKubernetesVersion(c.version)
 			if c.errMsg != err && c.isValid {
 				t.Fatalf("\nwanted: %v \nbut found: %v", c.errMsg, err)
 			}
-		})
-	}
-}
-
-func TestParseVersion(t *testing.T) {
-	cases := []struct {
-		version *version.Info
-		value   int64
-		isValid bool
-	}{
-		{
-			version: version1_17,
-			value:   10017,
-			isValid: true,
-		},
-		{
-			version: version1_8,
-			value:   10008,
-			isValid: true,
-		},
-		{
-			version: version1_17GKE,
-			value:   0,
-			isValid: false,
-		},
-		{
-			version: version1_8GKE,
-			value:   0,
-			isValid: false,
-		},
-		{
-			version: versionInvalid1,
-			value:   0,
-			isValid: false,
-		},
-		{
-			version: versionInvalid2,
-			value:   0,
-			isValid: false,
-		},
-	}
-	for i, c := range cases {
-		t.Run(fmt.Sprintf("case %d %s", i, c.version), func(t *testing.T) {
-			val := parseVersion(c.version.GitVersion, 4)
-			if c.value != val && c.isValid {
-				t.Fatalf("\nwanted: %v \nbut found: %v", c.value, val)
+			if got != c.expected {
+				t.Fatalf("wanted %v got %v", c.expected, got)
 			}
 		})
 	}

--- a/istioctl/pkg/install/pre-check.go
+++ b/istioctl/pkg/install/pre-check.go
@@ -98,7 +98,7 @@ func installPreCheck(istioNamespaceFlag string, restClientGetter genericclioptio
 		errs = multierror.Append(errs, err)
 		fmt.Fprint(writer, err)
 	} else if !res {
-		msg := fmt.Sprintf("The Kubernetes API version: %v is lower than the minimum version: "+k8sversion.MinK8SVersion, v)
+		msg := fmt.Sprintf("The Kubernetes API version: %v is lower than the minimum version: 1.%d", v, k8sversion.MinK8SVersion)
 		errs = multierror.Append(errs, errors.New(msg))
 		fmt.Fprintf(writer, msg+"\n")
 	} else {

--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -171,7 +171,7 @@ func InstallManifests(setOverlay []string, inFilenames []string, force bool, dry
 	}
 	status, err := reconciler.Reconcile()
 	if err != nil {
-		return fmt.Errorf("errors occurred during operation")
+		return fmt.Errorf("errors occurred during operation: %v", err)
 	}
 	if status.Status != v1alpha1.InstallStatus_HEALTHY {
 		return fmt.Errorf("errors occurred during operation")

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -351,10 +351,10 @@ var (
 		"If true, Pilot will allow certs specified in Metadata to override DR certs in MUTUAL TLS mode. "+
 			"This is only enabled for migration and will be removed soon.").Get()
 
-	// first-party-jwt is allowed because we only need the fsGroup configuration for
-	// the projected service account volume mount, which is only used by
-	// first-party-jwt. The installer will automatically configure this on Kubernetes
-	// 1.19+.
+	// EnableLegacyFSGroupInjection has first-party-jwt as allowed because we only
+	// need the fsGroup configuration for the projected service account volume mount,
+	// which is only used by first-party-jwt. The installer will automatically
+	// configure this on Kubernetes 1.19+.
 	EnableLegacyFSGroupInjection = env.RegisterBoolVar("ENABLE_LEGACY_FSGROUP_INJECTION", JwtPolicy.Get() != jwt.PolicyFirstParty,
 		"If true, Istiod will set the pod fsGroup to 1337 on injection. This is required for Kubernetes 1.18 and older "+
 			`(see https://github.com/kubernetes/kubernetes/issues/57923 for details) unless JWT_POLICY is "first-party-jwt".`).Get()

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -351,7 +351,11 @@ var (
 		"If true, Pilot will allow certs specified in Metadata to override DR certs in MUTUAL TLS mode. "+
 			"This is only enabled for migration and will be removed soon.").Get()
 
-	EnableLegacyFSGroupInjection = env.RegisterBoolVar("ENABLE_LEGACY_FSGROUP_INJECTION", true,
+	// first-party-jwt is allowed because we only need the fsGroup configuration for
+	// the projected service account volume mount, which is only used by
+	// first-party-jwt. The installer will automatically configure this on Kubernetes
+	// 1.19+.
+	EnableLegacyFSGroupInjection = env.RegisterBoolVar("ENABLE_LEGACY_FSGROUP_INJECTION", JwtPolicy.Get() != jwt.PolicyFirstParty,
 		"If true, Istiod will set the pod fsGroup to 1337 on injection. This is required for Kubernetes 1.18 and older "+
-			"(see https://github.com/kubernetes/kubernetes/issues/57923 for details).").Get()
+			`(see https://github.com/kubernetes/kubernetes/issues/57923 for details) unless JWT_POLICY is "first-party-jwt".`).Get()
 )

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -350,4 +350,8 @@ var (
 	AllowMetadataCertsInMutualTLS = env.RegisterBoolVar("PILOT_ALLOW_METADATA_CERTS_DR_MUTUAL_TLS", false,
 		"If true, Pilot will allow certs specified in Metadata to override DR certs in MUTUAL TLS mode. "+
 			"This is only enabled for migration and will be removed soon.").Get()
+
+	EnableLegacyFSGroupInjection = env.RegisterBoolVar("ENABLE_LEGACY_FSGROUP_INJECTION", true,
+		"If true, Istiod will set the pod fsGroup to 1337 on injection. This is required for Kubernetes 1.18 and older "+
+			"(see https://github.com/kubernetes/kubernetes/issues/57923 for details).").Get()
 )

--- a/releasenotes/notes/fsgroup.yaml
+++ b/releasenotes/notes/fsgroup.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+issue:
+- 26882
+releaseNotes:
+- |
+  **Improved** sidecar injection to not modify the pod `securityPolicy.fsGroup` which could conflict with existing settings and secret mounts.
+   This option is enabled automatically on Kubernetes 1.19+ and is not supported on older versions.


### PR DESCRIPTION
For issues like https://github.com/istio/istio/issues/26882

On Kubernetes 1.19+ we can avoid this issue. This adds a flag to disable
setting this option, and automatically disables this if we are on
Kubernetes 1.19+



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.