### PR TITLE
tracing: opencensusagent test fixups

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
@@ -43,8 +43,10 @@
           # The global default max number of message events per span.
           maxNumberOfMessageEvents: {{ $.Values.global.tracer.stackdriver.maxNumberOfMessageEvents | default "200" }}
         {{- end }}
+      {{- else if eq .Values.global.proxy.tracer "openCensusAgent" }}
+      {{- /* Fill in openCensusAgent configuration from meshConfig so it isn't overwritten below */ -}}
+        {{ toYaml $.Values.meshConfig.defaultConfig.tracing }}
       {{- end }}
-      {{- /* Ignore openCensusAgent tracer, it can be configured through meshConfig */ -}}
 
       {{- if .Values.global.remotePilotAddress }}
       discoveryAddress: {{ printf "istiod-remote.%s.svc" .Release.Namespace }}:15012

--- a/manifests/charts/istiod-remote/templates/configmap.yaml
+++ b/manifests/charts/istiod-remote/templates/configmap.yaml
@@ -38,6 +38,9 @@
           # The global default max number of message events per span.
           maxNumberOfMessageEvents: {{ $.Values.global.tracer.stackdriver.maxNumberOfMessageEvents | default "200" }}
         {{- end }}
+      {{- else if eq .Values.global.proxy.tracer "openCensusAgent" }}
+      {{- /* Fill in openCensusAgent configuration from meshConfig so it isn't overwritten below */ -}}
+        {{ toYaml $.Values.meshConfig.defaultConfig.tracing }}
       {{- end }}
 
       {{- if .Values.global.remotePilotAddress }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/templates/configmap.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/templates/configmap.yaml
@@ -38,6 +38,9 @@
           # The global default max number of message events per span.
           maxNumberOfMessageEvents: {{ $.Values.global.tracer.stackdriver.maxNumberOfMessageEvents | default "200" }}
         {{- end }}
+      {{- else if eq .Values.global.proxy.tracer "openCensusAgent" }}
+      {{- /* Fill in openCensusAgent configuration from meshConfig so it isn't overwritten below */ -}}
+        {{ toYaml $.Values.meshConfig.defaultConfig.tracing }}
       {{- end }}
 
       {{- if .Values.global.remotePilotAddress }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/templates/configmap.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/templates/configmap.yaml
@@ -38,6 +38,9 @@
           # The global default max number of message events per span.
           maxNumberOfMessageEvents: {{ $.Values.global.tracer.stackdriver.maxNumberOfMessageEvents | default "200" }}
         {{- end }}
+      {{- else if eq .Values.global.proxy.tracer "openCensusAgent" }}
+      {{- /* Fill in openCensusAgent configuration from meshConfig so it isn't overwritten below */ -}}
+        {{ toYaml $.Values.meshConfig.defaultConfig.tracing }}
       {{- end }}
 
       {{- if .Values.global.remotePilotAddress }}

--- a/tests/integration/telemetry/tracing/opencensusagent/tracing_test.go
+++ b/tests/integration/telemetry/tracing/opencensusagent/tracing_test.go
@@ -67,6 +67,7 @@ func TestMain(m *testing.M) {
 		Label(label.CustomSetup).
 		Setup(istio.Setup(tracing.GetIstioInstance(), setupConfig)).
 		Setup(tracing.TestSetup).
+		Setup(testSetup).
 		Run()
 }
 
@@ -83,9 +84,7 @@ meshConfig:
         address: "dns:opentelemetry-collector.istio-system.svc:55678"
         context: [B3]
 `
-	cfg.Values["meshConfig.enableTracing"] = "true"
 	cfg.Values["pilot.traceSampling"] = "100.0"
-
 	cfg.Values["global.proxy.tracer"] = "openCensusAgent"
 }
 


### PR DESCRIPTION
When writing some more e2e tests, I saw that the opencensusagent was sometimes overwritten with the version merged in https://github.com/istio/istio/pull/27019. This change cleans up the tests and configurations to correctly apply the opencensusagent tracer, including for the remote istiod configurations.

There are some other confusing cases when trying to avoid the `values` fields to configure tracers that I'll try to work through.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[X] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
