### PR TITLE
test that we load balance across multiple subsets in remote clusters

### DIFF
--- a/tests/integration/multicluster/helper.go
+++ b/tests/integration/multicluster/helper.go
@@ -94,7 +94,10 @@ func SetupApps(appCtx *AppContext) resource.SetupFn {
 
 		builder := echoboot.NewBuilder(ctx)
 		for _, cluster := range ctx.Clusters() {
-			builder.With(nil, newEchoConfig("echolb", appCtx.Namespace, cluster))
+			echoLbCfg := newEchoConfig("echolb", appCtx.Namespace, cluster)
+			echoLbCfg.Subsets = append(echoLbCfg.Subsets, echo.SubsetConfig{Version: "v2"})
+
+			builder.With(nil, echoLbCfg)
 			builder.With(nil, newEchoConfig("local", appCtx.LocalNamespace, cluster))
 			for i := 0; i < uniqSvcPerCluster; i++ {
 				svcName := fmt.Sprintf("echo-%d-%d", cluster.Index(), i)


### PR DESCRIPTION
Right now we only test that we hit one service in the remote clusters. We should make sure we can have multiple instances in multiple clusters in loadbalancing rotation. 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
