### PR TITLE
Changed term from intermediate Citadels to intermediate CA in Istio/tools/certs/README.md

### DIFF
--- a/tools/certs/README.md
+++ b/tools/certs/README.md
@@ -23,4 +23,4 @@ make -f Makefile.selfsigned.mk root-ca
 
 Note that the Makefile generates long-lived intermediate certificates. While this might be
 acceptable for demonstration purposes, a more realistic and secure deployment would use
-short-lived and automatically renewed certificates for the intermediate Citadels.
+short-lived and automatically renewed certificates for the intermediate CAs.


### PR DESCRIPTION
**Please provide a description for what this PR is for.**
In Istio/tools/certs/README.md, there was an outdated term 'intermediate Citadels'. Since Istio is organized differently now, the term should be 'intermediate CAs'. I updated the term to 'intermediate CAs'.

**And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.**

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


**Pull Request Attributes**

**Please check any characteristics that apply to this pull request.**

[X] Does not have any changes that may affect Istio users.
