### PR TITLE
Small change to STS, to support Istiod JWT

### DIFF
--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -82,7 +82,7 @@ type Options struct {
 	KeyFile string
 
 	// CAEndpoint is the CA endpoint to which node agent sends CSR request.
-	// Defaults to ProxyConfig.discoveryAddress, overriden by env CA_ADDR
+	// Defaults to ProxyConfig.discoveryAddress, overidden by env CA_ADDR
 	CAEndpoint string
 
 	// The CA provider name.

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -82,6 +82,7 @@ type Options struct {
 	KeyFile string
 
 	// CAEndpoint is the CA endpoint to which node agent sends CSR request.
+	// Defaults to ProxyConfig.discoveryAddress, overriden by env CA_ADDR
 	CAEndpoint string
 
 	// The CA provider name.
@@ -131,11 +132,28 @@ type Options struct {
 	// Location of JWTPath to connect to CA.
 	JWTPath string
 
-	// OutputKeyCertToDir is the directory for output the key and certificate
+	// OutputKeyCertToDir (env: OUTPUT_CERTS) is the directory for output the key and certificate.
+	// If not set, the private key and cert will be in memory and made available to Envoy using SDS.
+	//
+	// For VMs must be set to the same value with PROV_CERT to enable auto-refresh of the certificate.
+	// If the PROV_CERT is long lived or rotated by an external tool - this should be empty or have
+	// a different value.
 	OutputKeyCertToDir string
 
-	// ProvCert is the directory for client to provide the key and certificate to server
-	// when do mtls
+	// ProvCert is a directory containing existing certificates.
+	// The certificates will be used to authenticate with the server (CA_ADDR) and
+	// exchanged for fresh certificates.
+	//
+	// Not used if "FileMountedCerts" is set
+	//
+	// This can be used for long-lived certs that are exchanged for short-lived ones, or
+	// to refresh shorter lived certs when set to same value with OutputKeyCertToDir.
+	//
+	// The certificate in this dir will only be used for communication with the CA_ADDR,
+	// the XDS server and all other communication will use the returned certificate and a fresh
+	// key.
+	//
+	// Set using "PROV_CERT" environment. If no private key/certificate is found, token will be used.
 	ProvCert string
 
 	// whether  ControlPlaneAuthPolicy is MUTUAL_TLS

--- a/security/pkg/stsservice/sts.go
+++ b/security/pkg/stsservice/sts.go
@@ -18,6 +18,7 @@ import "time"
 
 // StsRequestParameters stores all STS request attributes defined in
 // https://tools.ietf.org/html/draft-ietf-oauth-token-exchange-16#section-2.1
+// Current standard is RFC8693
 type StsRequestParameters struct {
 	// REQUIRED. The value "urn:ietf:params:oauth:grant-type:token- exchange"
 	// indicates that a token exchange is being performed.


### PR DESCRIPTION
Istiod now supports authenticating XDS connections using JWT. Envoy bootstrap now has a config to switch to JWT 
auth, using STS. 

However the current STS implementation only supports Google JWTs, based on a google scope. This PR 
allows the STS to return the K8S JWT, if scope is not specified. We can refine this further - but this is 
the smallest safe change. 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
