### PR TITLE
bookinfo: propagate all tracing headers

### DIFF
--- a/samples/bookinfo/src/details/details.rb
+++ b/samples/bookinfo/src/details/details.rb
@@ -129,17 +129,53 @@ end
 
 def get_forward_headers(request)
   headers = {}
-  incoming_headers = [ 'x-request-id',
-                       'x-b3-traceid',
-                       'x-b3-spanid',
-                       'x-b3-parentspanid',
-                       'x-b3-sampled',
-                       'x-b3-flags',
-                       'x-ot-span-context',
-                       'x-datadog-trace-id',
-                       'x-datadog-parent-id',
-                       'x-datadog-sampled'
-                     ]
+
+  # Keep this in sync with the headers in productpage and reviews.
+  incoming_headers = [
+      # All applications should propagate x-request-id. This header is
+      # included in access log statements and is used for consistent trace
+      # sampling and log sampling decisions in Istio.
+      'x-request-id',
+
+      # Lightstep tracing header. Propagate this if you use lightstep tracing
+      # in Istio (see
+      # https://istio.io/latest/docs/tasks/observability/distributed-tracing/lightstep/)
+      # Note: this should probably be changed to use B3 or W3C TRACE_CONTEXT.
+      # Lightstep recommends using B3 or TRACE_CONTEXT and most application
+      # libraries from lightstep do not support x-ot-span-context.
+      'x-ot-span-context',
+
+      # Datadog tracing header. Propagate these headers if you use Datadog
+      # tracing.
+      'x-datadog-trace-id',
+      'x-datadog-parent-id',
+      'x-datadog-sampling-priority',
+
+      # W3C Trace Context. Compatible with OpenCensusAgent and Stackdriver Istio
+      # configurations.
+      'traceparent',
+      'tracestate',
+
+      # Cloud trace context. Compatible with OpenCensusAgent and Stackdriver Istio
+      # configurations.
+      'x-cloud-trace-context',
+
+      # Grpc binary trace context. Compatible with OpenCensusAgent nad
+      # Stackdriver Istio configurations.
+      'grpc-trace-bin',
+
+      # b3 trace headers. Compatible with Zipkin, OpenCensusAgent, and
+      # Stackdriver Istio configurations.
+      'x-b3-traceid',
+      'x-b3-spanid',
+      'x-b3-parentspanid',
+      'x-b3-sampled',
+      'x-b3-flags',
+
+      # Application-specific headers to forward.
+      'end-user',
+      'user-agent',
+  ]
 
   request.each do |header, value|
     if incoming_headers.include? header then

--- a/samples/bookinfo/src/productpage/productpage.py
+++ b/samples/bookinfo/src/productpage/productpage.py
@@ -101,15 +101,10 @@ service_dict = {
 # appropriate HTTP headers so that when the proxies send span information, the
 # spans can be correlated correctly into a single trace.
 #
-# To do this, an application needs to collect and propagate the following
-# headers from the incoming request to any outgoing requests:
-#
-# x-request-id
-# x-b3-traceid
-# x-b3-spanid
-# x-b3-parentspanid
-# x-b3-sampled
-# x-b3-flags
+# To do this, an application needs to collect and propagate headers from the
+# incoming request to any outgoing requests. The choice of headers to propagate
+# is determined by the trace configuration used. See getForwardHeaders for
+# the different header options.
 #
 # This example code uses OpenTracing (http://opentracing.io/) to propagate
 # the 'b3' (zipkin) headers. Using OpenTracing for this is not a requirement.
@@ -182,17 +177,65 @@ def getForwardHeaders(request):
     if 'user' in session:
         headers['end-user'] = session['user']
 
-    incoming_headers = ['x-request-id', 'x-datadog-trace-id', 'x-datadog-parent-id', 'x-datadog-sampled']
+    # Keep this in sync with the headers in details and reviews.
+    incoming_headers = [
+        # All applications should propagate x-request-id. This header is
+        # included in access log statements and is used for consistent trace
+        # sampling and log sampling decisions in Istio.
+        'x-request-id',
 
-    # Add user-agent to headers manually
-    if 'user-agent' in request.headers:
-        headers['user-agent'] = request.headers.get('user-agent')
+        # Lightstep tracing header. Propagate this if you use lightstep tracing
+        # in Istio (see
+        # https://istio.io/latest/docs/tasks/observability/distributed-tracing/lightstep/)
+        # Note: this should probably be changed to use B3 or W3C TRACE_CONTEXT.
+        # Lightstep recommends using B3 or TRACE_CONTEXT and most application
+        # libraries from lightstep do not support x-ot-span-context.
+        'x-ot-span-context',
+
+        # Datadog tracing header. Propagate these headers if you use Datadog
+        # tracing.
+        'x-datadog-trace-id',
+        'x-datadog-parent-id',
+        'x-datadog-sampling-priority',
+
+        # W3C Trace Context. Compatible with OpenCensusAgent and Stackdriver Istio
+        # configurations.
+        'traceparent',
+        'tracestate',
+
+        # Cloud trace context. Compatible with OpenCensusAgent and Stackdriver Istio
+        # configurations.
+        'x-cloud-trace-context',
+
+        # Grpc binary trace context. Compatible with OpenCensusAgent nad
+        # Stackdriver Istio configurations.
+        'grpc-trace-bin',
+
+        # b3 trace headers. Compatible with Zipkin, OpenCensusAgent, and
+        # Stackdriver Istio configurations. Commented out since they are
+        # propagated by the OpenTracing tracer above.
+        # 'x-b3-traceid',
+        # 'x-b3-spanid',
+        # 'x-b3-parentspanid',
+        # 'x-b3-sampled',
+        # 'x-b3-flags',
+
+        # Application-specific headers to forward.
+        'user-agent',
+    ]
+    # For Zipkin, always propagate b3 headers.
+    # For Lightstep, always propagate the x-ot-span-context header.
+    # For Datadog, propagate the corresponding datadog headers.
+    # For OpenCensusAgent and Stackdriver configurations, you can choose any
+    # set of compatible headers to propagate within your application. For
+    # example, you can propagate b3 headers or W3C trace context headers with
+    # the same result. This can also allow you to translate between context
+    # propagation mechanisms between different applications.
 
     for ihdr in incoming_headers:
         val = request.headers.get(ihdr)
         if val is not None:
             headers[ihdr] = val
-            # print "incoming: "+ihdr+":"+val
 
     return headers
 

--- a/samples/bookinfo/src/reviews/reviews-application/src/main/java/application/rest/LibertyRestEndpoint.java
+++ b/samples/bookinfo/src/reviews/reviews-application/src/main/java/application/rest/LibertyRestEndpoint.java
@@ -43,8 +43,52 @@ public class LibertyRestEndpoint extends Application {
     private final static String ratings_service = "http://" + ratings_hostname + services_domain + ":9080/ratings";
     // HTTP headers to propagate for distributed tracing are documented at
     // https://istio.io/docs/tasks/telemetry/distributed-tracing/overview/#trace-context-propagation
-    private final static String[] headers_to_propagate = {"x-request-id","x-b3-traceid","x-b3-spanid","x-b3-sampled","x-b3-flags",
-      "x-ot-span-context","x-datadog-trace-id","x-datadog-parent-id","x-datadog-sampled", "end-user","user-agent"};
+    private final static String[] headers_to_propagate = {
+        // All applications should propagate x-request-id. This header is
+        // included in access log statements and is used for consistent trace
+        // sampling and log sampling decisions in Istio.
+        "x-request-id",
+
+        // Lightstep tracing header. Propagate this if you use lightstep tracing
+        // in Istio (see
+        // https://istio.io/latest/docs/tasks/observability/distributed-tracing/lightstep/)
+        // Note: this should probably be changed to use B3 or W3C TRACE_CONTEXT.
+        // Lightstep recommends using B3 or TRACE_CONTEXT and most application
+        // libraries from lightstep do not support x-ot-span-context.
+        "x-ot-span-context",
+
+        // Datadog tracing header. Propagate these headers if you use Datadog
+        // tracing.
+        "x-datadog-trace-id",
+        "x-datadog-parent-id",
+        "x-datadog-sampling-priority",
+
+        // W3C Trace Context. Compatible with OpenCensusAgent and Stackdriver Istio
+        // configurations.
+        "traceparent",
+        "tracestate",
+
+        // Cloud trace context. Compatible with OpenCensusAgent and Stackdriver Istio
+        // configurations.
+        "x-cloud-trace-context",
+
+        // Grpc binary trace context. Compatible with OpenCensusAgent nad
+        // Stackdriver Istio configurations.
+        "grpc-trace-bin",
+
+        // b3 trace headers. Compatible with Zipkin, OpenCensusAgent, and
+        // Stackdriver Istio configurations. Commented out since they are
+        // propagated by the OpenTracing tracer above.
+        "x-b3-traceid",
+        "x-b3-spanid",
+        "x-b3-parentspanid",
+        "x-b3-sampled",
+        "x-b3-flags",
+
+        // Application-specific headers to forward.
+        "end-user",
+        "user-agent",
+    };
 
     private String getJsonResponse (String productId, int starsReviewer1, int starsReviewer2) {
     	String result = "{";


### PR DESCRIPTION
Update bookinfo to propagate all headers that Istio can use for context propagation.

This will let us:
1. Write more thorough e2e tests for tracing.
2. Demonstrate different context propagation in documentation and examples.


[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.