### PR TITLE
Make test client more like curl

### DIFF
--- a/pkg/test/echo/cmd/client/main.go
+++ b/pkg/test/echo/cmd/client/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -37,11 +38,8 @@ var (
 	count       int
 	timeout     time.Duration
 	qps         int
-	url         string
 	uds         string
-	headerKey   string
-	headerVal   string
-	headers     string
+	headers     []string
 	msg         string
 	method      string
 	http2       bool
@@ -62,10 +60,11 @@ For Kubernetes, this can be run from a source pod via "kubectl exec" with the de
 In general, Echo's gRPC interface (ForwardEcho) should be preferred. This client is only needed in cases
 where the network configuration doesn't support gRPC to the source pod.'
 `,
+		Args:              cobra.ExactArgs(1),
 		PersistentPreRunE: configureLogging,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Create a request from the flags.
-			request, err := getRequest()
+			request, err := getRequest(args[0])
 			if err != nil {
 				log.Fatala(err)
 				os.Exit(-1)
@@ -113,14 +112,10 @@ func init() {
 	rootCmd.PersistentFlags().IntVar(&count, "count", common.DefaultCount, "Number of times to make the request")
 	rootCmd.PersistentFlags().IntVar(&qps, "qps", 0, "Queries per second")
 	rootCmd.PersistentFlags().DurationVar(&timeout, "timeout", common.DefaultRequestTimeout, "Request timeout")
-	rootCmd.PersistentFlags().StringVar(&url, "url", "", "Specify URL")
 	rootCmd.PersistentFlags().StringVar(&uds, "uds", "",
 		"Specify the Unix Domain Socket to connect to")
-	rootCmd.PersistentFlags().StringVar(&headerKey, "key", "",
-		"Header key (use Host for authority) - deprecated user headers instead")
-	rootCmd.PersistentFlags().StringVar(&headerVal, "val", "", "Header value - deprecated")
-	rootCmd.PersistentFlags().StringVar(&headers, "headers", "",
-		"A list of http headers (use Host for authority) - name:value[,name:value]*")
+	rootCmd.PersistentFlags().StringSliceVarP(&headers, "header", "H", headers,
+		"A list of http headers (use Host for authority) - 'name: value', following curl syntax")
 	rootCmd.PersistentFlags().StringVar(&caFile, "ca", "/cert.crt", "CA root cert file")
 	rootCmd.PersistentFlags().StringVar(&msg, "msg", "HelloWorld",
 		"message to send (for websockets)")
@@ -137,9 +132,21 @@ func init() {
 	cmd.AddFlags(rootCmd)
 }
 
-func getRequest() (*proto.ForwardEchoRequest, error) {
+// Adds http scheme to and url if not set. This matches curl logic
+func defaultScheme(u string) string {
+	p, err := url.Parse(u)
+	if err != nil {
+		return u
+	}
+	if p.Scheme == "" {
+		return "http://" + u
+	}
+	return u
+}
+
+func getRequest(url string) (*proto.ForwardEchoRequest, error) {
 	request := &proto.ForwardEchoRequest{
-		Url:           url,
+		Url:           defaultScheme(url),
 		TimeoutMicros: common.DurationToMicros(timeout),
 		Count:         int32(count),
 		Qps:           int32(qps),
@@ -149,29 +156,18 @@ func getRequest() (*proto.ForwardEchoRequest, error) {
 		Method:        method,
 	}
 
-	// Old http add header - deprecated
-	if headerKey != "" {
-		request.Headers = append(request.Headers, &proto.Header{
-			Key:   headerKey,
-			Value: headerVal,
-		})
-	}
+	for _, header := range headers {
+		parts := strings.Split(header, ":")
 
-	if headers != "" {
-		headersList := strings.Split(headers, ",")
-		for _, header := range headersList {
-			parts := strings.Split(header, ":")
-
-			// require name:value format
-			if len(parts) != 2 {
-				return nil, fmt.Errorf("invalid header format: %q (want name:value)", header)
-			}
-
-			request.Headers = append(request.Headers, &proto.Header{
-				Key:   parts[0],
-				Value: parts[1],
-			})
+		// require name:value format
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid header format: %q (want name:value)", header)
 		}
+
+		request.Headers = append(request.Headers, &proto.Header{
+			Key:   parts[0],
+			Value: strings.Trim(parts[1], " "),
+		})
 	}
 
 	if clientCert != "" && clientKey != "" {


### PR DESCRIPTION
This allows dropping `client` in for `curl` in many cases



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.