### PR TITLE
Replace rather than overlay mutable parts of existing resources

### DIFF
--- a/operator/pkg/helmreconciler/common.go
+++ b/operator/pkg/helmreconciler/common.go
@@ -129,7 +129,9 @@ func applyOverlay(current, overlay *unstructured.Unstructured) error {
 	// save any immutable values
 	clusterIP := getPath(current, name.ServiceStr, util.PathFromString("spec.clusterIP"))
 
-	err = runtime.DecodeInto(unstructured.UnstructuredJSONScheme, merged, current)
+	if err = runtime.DecodeInto(unstructured.UnstructuredJSONScheme, merged, current); err != nil {
+		return err
+	}
 	uc := current.UnstructuredContent()
 	uo := overlay.UnstructuredContent()
 	writeMap(uc, uo, util.PathFromString("spec"))
@@ -138,7 +140,7 @@ func applyOverlay(current, overlay *unstructured.Unstructured) error {
 	// restore any immutable values
 	writePath(current, name.ServiceStr, util.PathFromString("spec.clusterIP"), clusterIP)
 
-	return err
+	return nil
 
 }
 


### PR DESCRIPTION
Mutable parts of resources being updated should be replaced so that any values that are removed are also removed on the API server. 