### PR TITLE
test(stackdriver): add tracing integration test for VMs

### DIFF
--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -269,6 +269,18 @@ spec:
 
           sudo sh -c 'echo "{{$.VM.IstiodIP}} istiod.istio-system.svc" >> /etc/hosts'
 
+          # Provide a proxyconfig override
+          # Provide a proxyconfig override
+          sudo sh -c 'chmod a+w /etc/istio/config/mesh'
+          sudo sh -c 'echo "defaultConfig:" >> /etc/istio/config/mesh'
+          sudo sh -c 'echo "  tracing:" >> /etc/istio/config/mesh'
+          sudo sh -c 'echo "    stackdriver:" >> /etc/istio/config/mesh'
+          sudo sh -c 'echo "      debug: true" >> /etc/istio/config/mesh'
+
+          # sudo sh -c 'mkdir -p /etc/istio/pod'
+          # sudo sh -c 'touch /etc/istio/pod/annotations'
+          # sudo sh -c 'echo "sidecar.istio.io/bootstrapOverride='stackdriver-bootstrap-config'" >> /etc/istio/pod/annotations'
+
           # TODO: run with systemctl?
           export ISTIO_AGENT_FLAGS="--concurrency 2"
           sudo -E /usr/local/bin/istio-start.sh&
@@ -303,6 +315,8 @@ spec:
           name: {{ $.Service }}-istio-token
         - mountPath: /var/run/secrets/istio
           name: istio-ca-root-cert
+        - mountPath: /etc/istio/custom-bootstrap
+          name: custom-bootstrap-volume
       volumes:
       - secret:
           secretName: {{ $.Service }}-istio-token
@@ -310,6 +324,9 @@ spec:
       - configMap:
           name: istio-ca-root-cert
         name: istio-ca-root-cert
+      - name: custom-bootstrap-volume
+        configMap:
+          name: stackdriver-bootstrap-config
 {{- end}}
 `
 )

--- a/pkg/test/framework/components/stackdriver/stackdriver.yaml
+++ b/pkg/test/framework/components/stackdriver/stackdriver.yaml
@@ -41,7 +41,7 @@ spec:
         app: stackdriver
     spec:
       containers:
-      - image: gcr.io/istio-testing/fake-stackdriver:4.0
+      - image: gcr.io/istio-testing/fake-stackdriver:5.0
         imagePullPolicy: Always
         name: stackdriver
         ports:

--- a/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
@@ -161,8 +161,8 @@ func testSetup(ctx resource.Context) (err error) {
 		return
 	}
 	sdBootstrap, err := tmpl.Evaluate(string(templateBytes), map[string]interface{}{
-		"StackdriverNamespace": sdInst.GetStackdriverNamespace(),
-		"EchoNamespace":        getEchoNamespaceInstance().Name(),
+		"StackdriverAddress": sdInst.Address(),
+		"EchoNamespace":      getEchoNamespaceInstance().Name(),
 	})
 	if err != nil {
 		return

--- a/tests/integration/telemetry/stackdriver/testdata/custom_bootstrap.yaml.tmpl
+++ b/tests/integration/telemetry/stackdriver/testdata/custom_bootstrap.yaml.tmpl
@@ -8,7 +8,7 @@ data:
     {
       "node": {
         "metadata": {
-          "INSECURE_STACKDRIVER_ENDPOINT": "stackdriver.{{ .StackdriverNamespace }}:8090",
+          "INSECURE_STACKDRIVER_ENDPOINT": "{{ .StackdriverAddress }}",
           "STACKDRIVER_MONITORING_EXPORT_INTERVAL_SECS": "10",
           "MESH_ID": "proj-test-mesh",
         }
@@ -30,7 +30,7 @@ data:
             "stackdriver_exporter_enabled": true,
             "stackdriver_grpc_service": {
               "google_grpc": {
-                "target_uri": "stackdriver.{{ .StackdriverNamespace }}.svc.cluster.local:8090",
+                "target_uri": "{{ .StackdriverAddress }}",
                 "stat_prefix": "oc_stackdriver_tracer",
               }
             },

--- a/tests/integration/telemetry/stackdriver/vm/main_test.go
+++ b/tests/integration/telemetry/stackdriver/vm/main_test.go
@@ -16,37 +16,141 @@
 package vm
 
 import (
+	"fmt"
 	"io/ioutil"
 	"testing"
 
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/proto"
+	"google.golang.org/genproto/googleapis/devtools/cloudtrace/v1"
+	loggingpb "google.golang.org/genproto/googleapis/logging/v2"
+	monitoring "google.golang.org/genproto/googleapis/monitoring/v3"
+
+	"istio.io/api/annotation"
+	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
 	"istio.io/istio/pkg/test/framework/components/gcemetadata"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/components/stackdriver"
+	edgespb "istio.io/istio/pkg/test/framework/components/stackdriver/edges"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/util/tmpl"
 )
 
 const (
+	// testdata, including golden files
 	stackdriverBootstrapOverride = "../testdata/custom_bootstrap.yaml.tmpl"
 	serverRequestCount           = "testdata/server_request_count.json.tmpl"
 	clientRequestCount           = "testdata/client_request_count.json.tmpl"
 	serverLogEntry               = "testdata/server_access_log.json.tmpl"
 	serverEdgeFile               = "testdata/server_edge.prototext.tmpl"
+	traceTmplFile                = "testdata/trace.prototext.tmpl"
 	sdBootstrapConfigMap         = "stackdriver-bootstrap-config"
 )
 
 var (
-	i       istio.Instance
-	ns      namespace.Instance
-	gceInst gcemetadata.Instance
-	sdInst  stackdriver.Instance
-	srv     echo.Instance
-	clt     echo.Instance
-	vmEnv   map[string]string
+	istioInst istio.Instance
+	ns        namespace.Instance
+	gceInst   gcemetadata.Instance
+	sdInst    stackdriver.Instance
+	server    echo.Instance
+	client    echo.Instance
+	vmEnv     map[string]string
 )
+
+var (
+	// golden values for tests
+	wantServerReqs       monitoring.TimeSeries
+	wantClientReqs       monitoring.TimeSeries
+	wantLogEntry         loggingpb.LogEntry
+	wantTrafficAssertion *edgespb.TrafficAssertion
+	wantTrace            cloudtrace.Trace
+)
+
+var (
+	clientBuilder, serverBuilder echo.Builder
+)
+
+var (
+	proxyConfigAnnotation = echo.Annotation{
+		Name: annotation.ProxyConfig.Name,
+		Type: echo.WorkloadAnnotation,
+	}
+
+	envTagsProxyConfig = `|0
+tracing:
+  custom_tags:
+    canonical_service_name:
+      environment:
+        name: CANONICAL_SERVICE
+        defaultValue: "unknown"
+    canonical_service_revision:
+      environment:
+        name: CANONICAL_REVISION
+        defaultValue: "earliest"`
+
+	envTagsJSON = `{\"tracing\":{\"custom_tags\":{\"hello\":{\"literal\":{\"value\":\"test\"},\"canonical_service_name\":{\"environment\":{\"name\":\"CANONICAL_SERVICE\",\"defaultValue\":\"unknown\"}},\"canonical_service_revision\":{\"environment\":{\"name\":\"CANONICAL_REVISION\",\"defaultValue\":\"earliest\"}}}}}`
+)
+
+var envoyFilterTpml = `
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: stackdriver-tracing
+  namespace: {{ .EchoNamespace }}
+spec:
+  workloadSelector:
+    labels:
+      service.istio.io/canonical-name: "vm-server"
+  configPatches:
+  - applyTo: NETWORK_FILTER
+    match:
+      context: ANY
+      listener:
+        filterChain:
+          filter:
+            name: "envoy.http_connection_manager"
+    patch:
+      operation: MERGE
+      value:
+        typed_config:
+          "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
+          tracing:
+            random_sampling:
+              value: 100.0
+            custom_tags:
+            - tag: "canonical_service_name"
+              environment:
+                name: "CANONICAL_SERVICE"
+                default_value: "unknown"
+            - tag: "canonical_service_name"
+              environment:
+                name: "CANONICAL_REVISION"
+                default_value: "earliest"
+`
+
+const enforceMTLS = `
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+spec:
+  mtls:
+    mode: STRICT
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: send-mtls
+spec:
+  host: "*.svc.cluster.local"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+`
 
 // Testing telemetry with VM mesh expansion on a simulated GCE instance.
 // Rather than deal with the infra to get a real VM, we will use a pod
@@ -59,7 +163,33 @@ func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
 		RequireSingleCluster().
-		Setup(istio.Setup(&i, func(_ resource.Context, cfg *istio.Config) {
+		Setup(istio.Setup(&istioInst, func(_ resource.Context, cfg *istio.Config) {
+			cfg.Values["meshConfig.enableTracing"] = "true"
+			// 			cfg.ControlPlaneValues = `
+			// meshConfig:
+			//   enableTracing: true
+			//   defaultConfig:
+			//     tracing:
+			//       sampling: "100.0"
+			//       customTags:
+			//         hello:
+			//           literal:
+			//             value: "test"
+			//         canonical_service_name:
+			//           environment:
+			//             name: "CANONICAL_SERVICE"
+			//             defaultValue: "unknown"
+			//         canonical_service_revision:
+			//           environment:
+			//             name: "CANONICAL_REVISION"
+			//             defaultValue: "latest"`
+			cfg.Values["meshConfig.defaultConfig.tracing.sampling"] = "100.0"
+			// cfg.Values["meshConfig.defaultConfig.tracing.custom_tags.canonical_service_name.environment.name"] = "CANONICAL_SERVICE"
+			// cfg.Values["meshConfig.defaultConfig.tracing.custom_tags.canonical_service_name.environment.defaultValue"] = "unknown"
+			// cfg.Values["meshConfig.defaultConfig.tracing.custom_tags.canonical_service_revision.environment.name"] = "CANONICAL_REVISION"
+			// cfg.Values["meshConfig.defaultConfig.tracing.custom_tags.canonical_service_revision.environment.defaultValue"] = "latest"
+			cfg.Values["global.proxy.tracer"] = "stackdriver"
+			// cfg.Values["pilot.traceSampling"] = "100.0"
 			cfg.Values["telemetry.enabled"] = "true"
 			cfg.Values["telemetry.v2.enabled"] = "true"
 			cfg.Values["telemetry.v2.stackdriver.enabled"] = "true"
@@ -71,38 +201,52 @@ func TestMain(m *testing.M) {
 		Run()
 }
 
-func testSetup(ctx resource.Context) (err error) {
-	ns, err = namespace.New(ctx, namespace.Config{
+func testSetup(ctx resource.Context) error {
+	var err error
+
+	if ns, err = namespace.New(ctx, namespace.Config{
 		Prefix: "istio-echo",
 		Inject: true,
-	})
-	if err != nil {
-		return
+	}); err != nil {
+		return err
 	}
 
-	gceInst, err = gcemetadata.New(ctx, gcemetadata.Config{})
-	if err != nil {
-		return
+	if gceInst, err = gcemetadata.New(ctx, gcemetadata.Config{}); err != nil {
+		return err
 	}
 
-	sdInst, err = stackdriver.New(ctx, stackdriver.Config{})
-	if err != nil {
-		return
+	if sdInst, err = stackdriver.New(ctx, stackdriver.Config{}); err != nil {
+		return err
 	}
 
 	templateBytes, err := ioutil.ReadFile(stackdriverBootstrapOverride)
 	if err != nil {
-		return
+		return err
 	}
 	sdBootstrap, err := tmpl.Evaluate(string(templateBytes), map[string]interface{}{
 		"StackdriverNamespace": sdInst.GetStackdriverNamespace(),
+		"StackdriverAddress":   sdInst.Address(),
 		"EchoNamespace":        ns.Name(),
 	})
 	if err != nil {
-		return
+		return err
 	}
 
-	err = ctx.Config().ApplyYAML(ns.Name(), sdBootstrap)
+	if err = ctx.Config().ApplyYAML(ns.Name(), sdBootstrap); err != nil {
+		return err
+	}
+
+	sdFilter, err := tmpl.Evaluate(envoyFilterTpml, map[string]interface{}{
+		"StackdriverAddress": sdInst.Address(),
+		"EchoNamespace":      ns.Name(),
+	})
+	if err != nil {
+		return err
+	}
+
+	if err = ctx.Config().ApplyYAML(ns.Name(), sdFilter); err != nil {
+		return err
+	}
 
 	vmLabelsJSON := "{\\\"service.istio.io/canonical-name\\\":\\\"vm-server\\\",\\\"service.istio.io/canonical-revision\\\":\\\"v1\\\"}"
 
@@ -113,7 +257,155 @@ func testSetup(ctx resource.Context) (err error) {
 		"ISTIO_META_WORKLOAD_NAME":                               "vm-server-v1",
 		"ISTIO_METAJSON_LABELS":                                  vmLabelsJSON,
 		"GCE_METADATA_HOST":                                      gceInst.Address(),
+		"CANONICAL_SERVICE":                                      "vm-server",
+		"CANONICAL_REVISION":                                     "v1",
+		"ISTIO_BOOTSTRAP_OVERRIDE":                               "/etc/istio/custom-bootstrap/custom_bootstrap.json",
 	}
 
+	// read expected values from testdata
+	wantClientReqs, wantServerReqs, err = goldenRequestCounts()
+	if err != nil {
+		return fmt.Errorf("failed to get golden metrics from file: %v", err)
+	}
+	wantLogEntry, err = goldenLogEntry()
+	if err != nil {
+		return fmt.Errorf("failed to get golden log entry from file: %v", err)
+	}
+	wantTrafficAssertion, err = goldenTrafficAssertion()
+	if err != nil {
+		return fmt.Errorf("failed to get golden traffic assertion from file: %v", err)
+	}
+	wantTrace, err = goldenTrace()
+	if err != nil {
+		return fmt.Errorf("failed to get golden trace from file: %v", err)
+	}
+
+	// set up client and server
+	ports := []echo.Port{
+		{
+			Name:     "http",
+			Protocol: protocol.HTTP,
+			// Due to a bug in WorkloadEntry, service port must equal target port for now
+			InstancePort: 8090,
+			ServicePort:  8090,
+		},
+	}
+
+	// builder to build the instances iteratively
+	clientBuilder = echoboot.NewBuilder(ctx).
+		With(&client, echo.Config{
+			Service:   "client",
+			Namespace: ns,
+			Ports:     ports,
+			Subsets: []echo.SubsetConfig{
+				{
+					Annotations: map[echo.Annotation]*echo.AnnotationValue{
+						echo.SidecarBootstrapOverride: {
+							Value: sdBootstrapConfigMap,
+						},
+					},
+				},
+			},
+		})
+
+	serverBuilder = echoboot.NewBuilder(ctx).
+		With(&server, echo.Config{
+			Service:       "server",
+			Namespace:     ns,
+			Ports:         ports,
+			DeployAsVM:    true,
+			VMEnvironment: vmEnv,
+			// Subsets: []echo.SubsetConfig{
+			// 	{
+			// 		Annotations: echo.NewAnnotations().Set(proxyConfigAnnotation, envTagsProxyConfig),
+			// 	},
+			// },
+		})
+
+	return nil
+}
+
+func goldenRequestCounts() (cltRequestCount, srvRequestCount monitoring.TimeSeries, err error) {
+	srvRequestCountTmpl, err := ioutil.ReadFile(serverRequestCount)
+	if err != nil {
+		return
+	}
+	sr, err := tmpl.Evaluate(string(srvRequestCountTmpl), map[string]interface{}{
+		"EchoNamespace": ns.Name(),
+	})
+	if err != nil {
+		return
+	}
+	if err = jsonpb.UnmarshalString(sr, &srvRequestCount); err != nil {
+		return
+	}
+	cltRequestCountTmpl, err := ioutil.ReadFile(clientRequestCount)
+	if err != nil {
+		return
+	}
+	cr, err := tmpl.Evaluate(string(cltRequestCountTmpl), map[string]interface{}{
+		"EchoNamespace": ns.Name(),
+	})
+	if err != nil {
+		return
+	}
+	err = jsonpb.UnmarshalString(cr, &cltRequestCount)
 	return
+}
+
+func goldenLogEntry() (srvLogEntry loggingpb.LogEntry, err error) {
+	srvlogEntryTmpl, err := ioutil.ReadFile(serverLogEntry)
+	if err != nil {
+		return
+	}
+	sr, err := tmpl.Evaluate(string(srvlogEntryTmpl), map[string]interface{}{
+		"EchoNamespace": ns.Name(),
+	})
+	if err != nil {
+		return
+	}
+	if err = jsonpb.UnmarshalString(sr, &srvLogEntry); err != nil {
+		return
+	}
+	return
+}
+
+func goldenTrafficAssertion() (*edgespb.TrafficAssertion, error) {
+	taTmpl, err := ioutil.ReadFile(serverEdgeFile)
+	if err != nil {
+		return nil, err
+	}
+
+	taString, err := tmpl.Evaluate(string(taTmpl), map[string]interface{}{
+		"EchoNamespace": ns.Name(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var ta edgespb.TrafficAssertion
+	err = proto.UnmarshalText(taString, &ta)
+	if err != nil {
+		return nil, err
+	}
+	return &ta, nil
+}
+
+func goldenTrace() (cloudtrace.Trace, error) {
+	traceTmpl, err := ioutil.ReadFile(traceTmplFile)
+	if err != nil {
+		return cloudtrace.Trace{}, err
+	}
+	traceStr, err := tmpl.Evaluate(string(traceTmpl), map[string]interface{}{
+		"EchoNamespace": ns.Name(),
+	})
+	if err != nil {
+		return cloudtrace.Trace{}, err
+	}
+	var trace cloudtrace.Trace
+	err = proto.UnmarshalText(traceStr, &trace)
+	if err != nil {
+		return cloudtrace.Trace{}, err
+	}
+	return trace, nil
 }

--- a/tests/integration/telemetry/stackdriver/vm/main_test.go
+++ b/tests/integration/telemetry/stackdriver/vm/main_test.go
@@ -133,7 +133,7 @@ func TestMain(m *testing.M) {
 			cfg.Values["meshConfig.defaultConfig.tracing.custom_tags.canonical_service_name.environment.name"] = "CANONICAL_SERVICE"
 			cfg.Values["meshConfig.defaultConfig.tracing.custom_tags.canonical_service_name.environment.defaultValue"] = "unknown"
 			cfg.Values["meshConfig.defaultConfig.tracing.custom_tags.canonical_service_revision.environment.name"] = "CANONICAL_REVISION"
-			cfg.Values["meshConfig.defaultConfig.tracing.custom_tags.canonical_service_revision.environment.defaultValue"] = "latest"
+			cfg.Values["meshConfig.defaultConfig.tracing.custom_tags.canonical_service_revision.environment.defaultValue"] = "earliest"
 			cfg.Values["global.proxy.tracer"] = "stackdriver"
 			cfg.Values["telemetry.enabled"] = "true"
 			cfg.Values["telemetry.v2.enabled"] = "true"
@@ -232,11 +232,7 @@ func testSetup(ctx resource.Context) error {
 			Ports:     ports,
 			Subsets: []echo.SubsetConfig{
 				{
-					Annotations: map[echo.Annotation]*echo.AnnotationValue{
-						echo.SidecarBootstrapOverride: {
-							Value: sdBootstrapConfigMap,
-						},
-					},
+					Annotations: echo.NewAnnotations().Set(echo.SidecarBootstrapOverride, sdBootstrapConfigMap),
 				},
 			},
 		})

--- a/tests/integration/telemetry/stackdriver/vm/testdata/server_access_log.json.tmpl
+++ b/tests/integration/telemetry/stackdriver/vm/testdata/server_access_log.json.tmpl
@@ -1,4 +1,5 @@
 {
+    "trace_sampled": true,
     "http_request": {
         "request_method": "GET",
         "request_url": "http://server.{{ .EchoNamespace }}.svc.cluster.local/",

--- a/tests/integration/telemetry/stackdriver/vm/testdata/server_edge.prototext.tmpl
+++ b/tests/integration/telemetry/stackdriver/vm/testdata/server_edge.prototext.tmpl
@@ -2,14 +2,14 @@ source:<
   owner_uid:"kubernetes://apis/apps/v1/namespaces/{{ .EchoNamespace }}/deployments/client-v1"
   workload_name:"client-v1"
   workload_namespace:"{{ .EchoNamespace }}"
-  canonical_service:"client" canonical_revision:"v1" >
+  canonical_service:"client" canonical_revision:"v1" > 
 destination:<
   location:"us-west1-c"
   owner_uid:"//compute.googleapis.com/some-creator"
   workload_name:"vm-server-v1"
   workload_namespace:"{{ .EchoNamespace }}"
   canonical_service:"vm-server"
-  canonical_revision:"v1" >
-protocol:PROTOCOL_HTTP
+  canonical_revision:"v1" > 
+protocol: 1
 destination_service_name:"server"
-destination_service_namespace:"{{ .EchoNamespace }}"
+destination_service_namespace:"{{ .EchoNamespace }}" 

--- a/tests/integration/telemetry/stackdriver/vm/testdata/trace.prototext.tmpl
+++ b/tests/integration/telemetry/stackdriver/vm/testdata/trace.prototext.tmpl
@@ -1,0 +1,28 @@
+project_id:"projects/test-project"
+spans:{ 
+    labels:{key:"OperationName"  value:"Ingress"}
+    labels:{key:"canonical_service_name"  value:"vm-server"}
+    labels:{key:"component"  value:"proxy"}
+    labels:{key:"downstream_cluster"  value:"-"}
+    labels:{key:"http.method"  value:"GET"} 
+    labels:{key:"http.protocol"  value:"HTTP/1.1"}
+    labels:{key:"http.status_code"  value:"200"}
+    labels:{key:"http.url"  value:"http://server.{{ .EchoNamespace }}.svc.cluster.local/"}
+    labels:{key:"request_size"  value:"0"}
+    labels:{key:"response_flags"  value:"-"}
+    labels:{key:"span"  value:"server.{{ .EchoNamespace }}.svc.cluster.local:8090/*"}
+    labels:{key:"upstream_cluster"  value:"inbound|8090|http|server.{{ .EchoNamespace }}.svc.cluster.local"}
+    labels:{key:"user_agent"  value:"Go-http-client/1.1"}}
+spans:{
+    labels:{key:"OperationName" value:"Egress"}
+    labels:{key:"component"  value:"proxy"}
+    labels:{key:"downstream_cluster"  value:"-"}
+    labels:{key:"http.method"  value:"GET"}
+    labels:{key:"http.protocol"  value:"HTTP/1.1"}
+    labels:{key:"http.status_code"  value:"200"}
+    labels:{key:"http.url"  value:"http://server.{{ .EchoNamespace }}.svc.cluster.local/"}
+    labels:{key:"request_size"  value:"0"}
+    labels:{key:"response_flags"  value:"-"}
+    labels:{key:"span"  value:"server.{{ .EchoNamespace }}.svc.cluster.local:8090/*"}
+    labels:{key:"upstream_cluster"  value:"outbound|8090||server.{{ .EchoNamespace }}.svc.cluster.local"}
+    labels:{key:"user_agent"  value:"Go-http-client/1.1"}}

--- a/tests/integration/telemetry/stackdriver/vm/testdata/trace.prototext.tmpl
+++ b/tests/integration/telemetry/stackdriver/vm/testdata/trace.prototext.tmpl
@@ -2,6 +2,7 @@ project_id:"projects/test-project"
 spans:{ 
     labels:{key:"OperationName"  value:"Ingress"}
     labels:{key:"canonical_service_name"  value:"vm-server"}
+    labels:{key:"canonical_service_revision"  value:"v1"}
     labels:{key:"component"  value:"proxy"}
     labels:{key:"downstream_cluster"  value:"-"}
     labels:{key:"http.method"  value:"GET"} 
@@ -15,6 +16,8 @@ spans:{
     labels:{key:"user_agent"  value:"Go-http-client/1.1"}}
 spans:{
     labels:{key:"OperationName" value:"Egress"}
+    labels:{key:"canonical_service_name"  value:"client"}
+    labels:{key:"canonical_service_revision"  value:"v1"}
     labels:{key:"component"  value:"proxy"}
     labels:{key:"downstream_cluster"  value:"-"}
     labels:{key:"http.method"  value:"GET"}

--- a/tests/integration/telemetry/stackdriver/vm/vm_test.go
+++ b/tests/integration/telemetry/stackdriver/vm/vm_test.go
@@ -17,24 +17,21 @@ package vm
 
 import (
 	"fmt"
-	"io/ioutil"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/gogo/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
+	"google.golang.org/genproto/googleapis/devtools/cloudtrace/v1"
 	loggingpb "google.golang.org/genproto/googleapis/logging/v2"
 	monitoring "google.golang.org/genproto/googleapis/monitoring/v3"
 	"gopkg.in/d4l3k/messagediff.v1"
 
-	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
-	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
 	edgespb "istio.io/istio/pkg/test/framework/components/stackdriver/edges"
 	"istio.io/istio/pkg/test/util/retry"
-	"istio.io/istio/pkg/test/util/tmpl"
 	"istio.io/pkg/log"
 )
 
@@ -45,222 +42,150 @@ func TestVMTelemetry(t *testing.T) {
 		Run(func(ctx framework.TestContext) {
 			// Set up strict mTLS. This gives a bit more assurance the calls are actually going through envoy,
 			// and certs are set up correctly.
-			ctx.Config().ApplyYAMLOrFail(ctx, ns.Name(), `
-apiVersion: security.istio.io/v1beta1
-kind: PeerAuthentication
-metadata:
-  name: default
-spec:
-  mtls:
-    mode: STRICT
----
-apiVersion: networking.istio.io/v1alpha3
-kind: DestinationRule
-metadata:
-  name: send-mtls
-spec:
-  host: "*.svc.cluster.local"
-  trafficPolicy:
-    tls:
-      mode: ISTIO_MUTUAL
-`)
-			ports := []echo.Port{
-				{
-					Name:     "http",
-					Protocol: protocol.HTTP,
-					// Due to a bug in WorkloadEntry, service port must equal target port for now
-					InstancePort: 8090,
-					ServicePort:  8090,
-				},
-			}
+			ctx.Config().ApplyYAMLOrFail(ctx, ns.Name(), enforceMTLS)
 
-			// builder to build the instances iteratively
-			echoboot.NewBuilder(ctx).
-				With(&clt, echo.Config{
-					Service:   "client",
-					Namespace: ns,
-					Ports:     ports,
-					Subsets: []echo.SubsetConfig{
-						{
-							Annotations: map[echo.Annotation]*echo.AnnotationValue{
-								echo.SidecarBootstrapOverride: {
-									Value: sdBootstrapConfigMap,
-								},
-							},
-						},
-					},
-				}).
-				BuildOrFail(t)
+			clientBuilder.BuildOrFail(t)
+			serverBuilder.BuildOrFail(t)
 
-			echoboot.NewBuilder(ctx).
-				With(&srv, echo.Config{
-					Service:       "server",
-					Namespace:     ns,
-					Ports:         ports,
-					DeployAsVM:    true,
-					VMEnvironment: vmEnv,
-				}).
-				BuildOrFail(t)
-
-			srvReceived := false
-			cltReceived := false
-			logReceived := false
 			retry.UntilSuccessOrFail(t, func() error {
-				_, err := clt.Call(echo.CallOptions{
-					Target:   srv,
-					PortName: "http",
-					Count:    1,
-				})
-				if err != nil {
+				// send single request from client -> server
+				if _, err := client.Call(echo.CallOptions{Target: server, PortName: "http", Count: 1}); err != nil {
 					return err
 				}
+
 				// Verify stackdriver metrics
-				wantClt, wantSrv, err := getWantRequestCountTS()
-				if err != nil {
-					return err
-				}
-				// Traverse all time series received and compare with expected client and server time series.
-				ts, err := sdInst.ListTimeSeries()
-				if err != nil {
-					return err
-				}
-				for _, tt := range ts {
-					// Making resource nil, as test can run on various platforms.
-					tt.Resource = nil
-					if proto.Equal(tt, &wantSrv) {
-						srvReceived = true
-					}
-					if proto.Equal(tt, &wantClt) {
-						cltReceived = true
-					}
-				}
+				gotMetrics := gotRequestCountMetrics(wantClientReqs, wantServerReqs)
 
 				// Verify log entry
-				wantLog, err := getWantServerLogEntry()
-				if err != nil {
-					return fmt.Errorf("failed to parse wanted log entry: %v", err)
-				}
-				// Traverse all log entries received and compare with expected server log entry.
-				entries, err := sdInst.ListLogEntries()
-				if err != nil {
-					return fmt.Errorf("failed to get received log entries: %v", err)
-				}
-				for _, l := range entries {
-					if proto.Equal(l, &wantLog) {
-						logReceived = true
-					}
-				}
+				gotLogs := gotLogEntry(wantLogEntry)
 
 				// Verify edges
-				edges, err := sdInst.ListTrafficAssertions()
-				if err != nil {
-					return fmt.Errorf("failed to get traffic assertions: %v", err)
+				gotEdges := gotTrafficAssertion(*wantTrafficAssertion)
+
+				// verify traces
+				gotTraces := gotTrace(wantTrace)
+
+				if !(gotMetrics && gotLogs && gotEdges && gotTraces) {
+					return fmt.Errorf("did not receive all expected telemetry; status: metrics=%t, logs=%t, edges=%t, traces=%t", gotMetrics, gotLogs, gotEdges, gotTraces)
 				}
 
-				expectedEdge, err := expectedTrafficAssertion()
-				if err != nil {
-					return fmt.Errorf("failed to get wanted traffic assertion: %v", err)
-				}
-
-				foundEdge := false
-				for _, ta := range edges {
-					srcUID := ta.Source.Uid
-					dstUID := ta.Destination.Uid
-
-					ta.Source.Location = ""
-					ta.Source.ClusterName = ""
-					ta.Source.Uid = ""
-					ta.Destination.Uid = ""
-
-					if diff, equal := messagediff.PrettyDiff(ta, expectedEdge); !equal {
-						log.Infof("different edge found: %v", diff)
-						continue
-					}
-
-					if strings.HasPrefix(dstUID, "//compute.googleapis.com/projects/test-project/zones/us-west1-c/instances/server-v1-") &&
-						strings.HasPrefix(srcUID, "kubernetes://client-v1-") {
-						foundEdge = true
-						break
-					}
-				}
-
-				// Check if both client and server side request count metrics are received
-				if !srvReceived || !cltReceived {
-					return fmt.Errorf("stackdriver server does not received expected server or client request count, server %v client %v", srvReceived, cltReceived)
-				}
-				if !logReceived {
-					return fmt.Errorf("stackdriver server does not received expected log entry")
-				}
-				if !foundEdge {
-					return fmt.Errorf("stackdriver server did not received expected traffic assertion")
-				}
 				return nil
 			}, retry.Delay(3*time.Second), retry.Timeout(40*time.Second))
 		})
 }
 
-func getWantRequestCountTS() (cltRequestCount, srvRequestCount monitoring.TimeSeries, err error) {
-	srvRequestCountTmpl, err := ioutil.ReadFile(serverRequestCount)
-	if err != nil {
-		return
+func traceEqual(got, want *cloudtrace.Trace) bool {
+	if len(got.Spans) != len(want.Spans) {
+		log.Infof("incorrect number of spans: got %d, want: %d", len(got.Spans), len(want.Spans))
+		return false
 	}
-	sr, err := tmpl.Evaluate(string(srvRequestCountTmpl), map[string]interface{}{
-		"EchoNamespace": ns.Name(),
-	})
-	if err != nil {
-		return
+	if got.ProjectId != want.ProjectId {
+		log.Errorf("mismatched project ids: got %q, want %q", got.ProjectId, want.ProjectId)
+		return false
 	}
-	if err = jsonpb.UnmarshalString(sr, &srvRequestCount); err != nil {
-		return
+
+	for _, wantSpan := range want.Spans {
+		foundSpan := false
+		for _, gotSpan := range got.Spans {
+			delete(gotSpan.Labels, "guid:x-request-id")
+			delete(gotSpan.Labels, "node_id")
+			delete(gotSpan.Labels, "peer.address")
+			delete(gotSpan.Labels, "zone")
+			delete(gotSpan.Labels, "g.co/agent")    // ignore OpenCensus lib versions
+			delete(gotSpan.Labels, "response_size") // this could be slightly off, just ignore
+			if foundSpan = reflect.DeepEqual(gotSpan.Labels, wantSpan.Labels); foundSpan {
+				break
+			}
+		}
+		if !foundSpan {
+			log.Errorf("missing span from trace: got %v\nwant %v", got, want)
+			return false
+		}
 	}
-	cltRequestCountTmpl, err := ioutil.ReadFile(clientRequestCount)
-	if err != nil {
-		return
-	}
-	cr, err := tmpl.Evaluate(string(cltRequestCountTmpl), map[string]interface{}{
-		"EchoNamespace": ns.Name(),
-	})
-	if err != nil {
-		return
-	}
-	err = jsonpb.UnmarshalString(cr, &cltRequestCount)
-	return
+
+	return true
 }
 
-func getWantServerLogEntry() (srvLogEntry loggingpb.LogEntry, err error) {
-	srvlogEntryTmpl, err := ioutil.ReadFile(serverLogEntry)
+func gotRequestCountMetrics(wantClient, wantServer monitoring.TimeSeries) bool {
+	ts, err := sdInst.ListTimeSeries()
 	if err != nil {
-		return
+		log.Errorf("could not get list of time-series from stackdriver: %v", err)
+		return false
 	}
-	sr, err := tmpl.Evaluate(string(srvlogEntryTmpl), map[string]interface{}{
-		"EchoNamespace": ns.Name(),
-	})
-	if err != nil {
-		return
+
+	var gotServer, gotClient bool
+	for _, series := range ts {
+		// Making resource nil, as test can run on various platforms.
+		series.Resource = nil
+		if proto.Equal(series, &wantServer) {
+			gotServer = true
+		}
+		if proto.Equal(series, &wantClient) {
+			gotClient = true
+		}
 	}
-	if err = jsonpb.UnmarshalString(sr, &srvLogEntry); err != nil {
-		return
-	}
-	return
+
+	return gotServer && gotClient
 }
 
-func expectedTrafficAssertion() (*edgespb.TrafficAssertion, error) {
-	taTmpl, err := ioutil.ReadFile(serverEdgeFile)
+func gotLogEntry(want loggingpb.LogEntry) bool {
+	entries, err := sdInst.ListLogEntries()
 	if err != nil {
-		return nil, err
+		log.Errorf("failed to get list of log entries from stackdriver: %v", err)
+		return false
+	}
+	for _, l := range entries {
+		l.Trace = ""
+		l.SpanId = ""
+		if proto.Equal(l, &want) {
+			return true
+		}
+		log.Errorf("incorrect log: got %v\nwant %v", *l, want)
+	}
+	return false
+}
+
+func gotTrafficAssertion(want edgespb.TrafficAssertion) bool {
+	edges, err := sdInst.ListTrafficAssertions()
+	if err != nil {
+		log.Errorf("failed to get traffic assertions from stackdriver: %v", err)
+		return false
 	}
 
-	taString, err := tmpl.Evaluate(string(taTmpl), map[string]interface{}{
-		"EchoNamespace": ns.Name(),
-	})
-	if err != nil {
-		return nil, err
+	for _, ta := range edges {
+		srcUID := ta.Source.Uid
+		dstUID := ta.Destination.Uid
+
+		ta.Source.Location = ""
+		ta.Source.ClusterName = ""
+		ta.Source.Uid = ""
+		ta.Destination.Uid = ""
+
+		if diff, equal := messagediff.PrettyDiff(ta, &want); !equal {
+			log.Errorf("different edge found: %v", diff)
+			continue
+		}
+
+		if strings.HasPrefix(dstUID, "//compute.googleapis.com/projects/test-project/zones/us-west1-c/instances/server-v1-") &&
+			strings.HasPrefix(srcUID, "kubernetes://client-v1-") {
+			return true
+		}
 	}
 
-	var ta edgespb.TrafficAssertion
-	err = proto.UnmarshalText(taString, &ta)
+	return false
+}
+
+func gotTrace(want cloudtrace.Trace) bool {
+	traces, err := sdInst.ListTraces()
 	if err != nil {
-		return nil, err
+		log.Errorf("failed to retreive list of tracespans from stackdriver: %v", err)
+		return false
 	}
-	return &ta, nil
+
+	for _, trace := range traces {
+		if found := traceEqual(trace, &want); found {
+			return true
+		}
+	}
+	return false
 }

--- a/tests/integration/telemetry/stackdriver/vm/vm_test.go
+++ b/tests/integration/telemetry/stackdriver/vm/vm_test.go
@@ -60,7 +60,7 @@ func TestVMTelemetry(t *testing.T) {
 				gotLogs := gotLogEntry(wantLogEntry)
 
 				// Verify edges
-				gotEdges := gotTrafficAssertion(*wantTrafficAssertion)
+				gotEdges := gotTrafficAssertion(wantTrafficAssertion)
 
 				// verify traces
 				gotTraces := gotTrace(wantTrace)
@@ -106,7 +106,7 @@ func traceEqual(got, want *cloudtrace.Trace) bool {
 	return true
 }
 
-func gotRequestCountMetrics(wantClient, wantServer monitoring.TimeSeries) bool {
+func gotRequestCountMetrics(wantClient, wantServer *monitoring.TimeSeries) bool {
 	ts, err := sdInst.ListTimeSeries()
 	if err != nil {
 		log.Errorf("could not get list of time-series from stackdriver: %v", err)
@@ -117,10 +117,10 @@ func gotRequestCountMetrics(wantClient, wantServer monitoring.TimeSeries) bool {
 	for _, series := range ts {
 		// Making resource nil, as test can run on various platforms.
 		series.Resource = nil
-		if proto.Equal(series, &wantServer) {
+		if proto.Equal(series, wantServer) {
 			gotServer = true
 		}
-		if proto.Equal(series, &wantClient) {
+		if proto.Equal(series, wantClient) {
 			gotClient = true
 		}
 	}
@@ -128,7 +128,7 @@ func gotRequestCountMetrics(wantClient, wantServer monitoring.TimeSeries) bool {
 	return gotServer && gotClient
 }
 
-func gotLogEntry(want loggingpb.LogEntry) bool {
+func gotLogEntry(want *loggingpb.LogEntry) bool {
 	entries, err := sdInst.ListLogEntries()
 	if err != nil {
 		log.Errorf("failed to get list of log entries from stackdriver: %v", err)
@@ -137,15 +137,15 @@ func gotLogEntry(want loggingpb.LogEntry) bool {
 	for _, l := range entries {
 		l.Trace = ""
 		l.SpanId = ""
-		if proto.Equal(l, &want) {
+		if proto.Equal(l, want) {
 			return true
 		}
-		log.Errorf("incorrect log: got %v\nwant %v", *l, want)
+		log.Errorf("incorrect log: got %v\nwant %v", l, want)
 	}
 	return false
 }
 
-func gotTrafficAssertion(want edgespb.TrafficAssertion) bool {
+func gotTrafficAssertion(want *edgespb.TrafficAssertion) bool {
 	edges, err := sdInst.ListTrafficAssertions()
 	if err != nil {
 		log.Errorf("failed to get traffic assertions from stackdriver: %v", err)
@@ -161,7 +161,7 @@ func gotTrafficAssertion(want edgespb.TrafficAssertion) bool {
 		ta.Source.Uid = ""
 		ta.Destination.Uid = ""
 
-		if diff, equal := messagediff.PrettyDiff(ta, &want); !equal {
+		if diff, equal := messagediff.PrettyDiff(ta, want); !equal {
 			log.Errorf("different edge found: %v", diff)
 			continue
 		}
@@ -175,7 +175,7 @@ func gotTrafficAssertion(want edgespb.TrafficAssertion) bool {
 	return false
 }
 
-func gotTrace(want cloudtrace.Trace) bool {
+func gotTrace(want *cloudtrace.Trace) bool {
 	traces, err := sdInst.ListTraces()
 	if err != nil {
 		log.Errorf("failed to retreive list of tracespans from stackdriver: %v", err)
@@ -183,7 +183,7 @@ func gotTrace(want cloudtrace.Trace) bool {
 	}
 
 	for _, trace := range traces {
-		if found := traceEqual(trace, &want); found {
+		if found := traceEqual(trace, want); found {
 			return true
 		}
 	}


### PR DESCRIPTION
PR to add coverage for tracing to Stackdriver integration tests.  Refactors the test structure a bit in an attempt to improve readability by separating out the tests parts and the setup parts (as well as to fail faster when there are setup issues).

Notes:
- a custom bootstrap override is used for the VM to enable population of a testing endpoint for Cloud Trace (it is not read from env vars, as elsewhere)
- a custom proxy config is used to simulate real-world VM configuration reqs for Cloud Trace.
- `custom_tags` are added to each span to simulate annotation of canonical service information with each span.

[ X ] Policies and Telemetry
[ X ] Test and Release
[ X ] Does not have any changes that may affect Istio users.
