### PR TITLE
rework on ads client 

### DIFF
--- a/istioctl/pkg/xds/client.go
+++ b/istioctl/pkg/xds/client.go
@@ -47,7 +47,7 @@ var (
 
 // GetXdsResponse opens a gRPC connection to opts.xds and waits for a single response
 func GetXdsResponse(dr *xdsapi.DiscoveryRequest, opts *clioptions.CentralControlPlaneOptions, grpcOpts []grpc.DialOption) (*xdsapi.DiscoveryResponse, error) {
-	adscConn, err := adsc.Dial(opts.Xds, &adsc.Config{
+	adscConn, err := adsc.New(opts.Xds, &adsc.Config{
 		Meta: model.NodeMetadata{
 			Generator: "event",
 		}.ToStruct(),

--- a/istioctl/pkg/xds/client.go
+++ b/istioctl/pkg/xds/client.go
@@ -47,10 +47,11 @@ var (
 
 // GetXdsResponse opens a gRPC connection to opts.xds and waits for a single response
 func GetXdsResponse(dr *xdsapi.DiscoveryRequest, opts *clioptions.CentralControlPlaneOptions, grpcOpts []grpc.DialOption) (*xdsapi.DiscoveryResponse, error) {
-	adscConn, err := adsc.Dial(opts.Xds, opts.CertDir, &adsc.Config{
+	adscConn, err := adsc.Dial(opts.Xds, &adsc.Config{
 		Meta: model.NodeMetadata{
 			Generator: "event",
 		}.ToStruct(),
+		CertDir:            opts.CertDir,
 		InsecureSkipVerify: opts.InsecureSkipVerify,
 		XDSSAN:             opts.XDSSAN,
 		GrpcOpts:           grpcOpts,

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -206,6 +206,7 @@ func (s *Server) initConfigSources(args *PilotArgs) (err error) {
 				Meta: model.NodeMetadata{
 					Generator: "api",
 				}.ToStruct(),
+				InitialDiscoveryRequests: adsc.ConfigInitialRequests(),
 			})
 			store := memory.Make(collections.Pilot)
 			configController := memory.NewController(store)
@@ -214,7 +215,6 @@ func (s *Server) initConfigSources(args *PilotArgs) (err error) {
 			if err != nil {
 				return fmt.Errorf("failed to dial XDS %s %v", configSource.Address, err)
 			}
-			go xdsMCP.WatchConfig()
 			s.ConfigStores = append(s.ConfigStores, configController)
 			log.Warna("Started XDS config ", s.ConfigStores)
 			continue

--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -202,9 +202,7 @@ func (s *Server) initConfigSources(args *PilotArgs) (err error) {
 				return fmt.Errorf("invalid XDS config URL %s %v", configSource.Address, err)
 			}
 			// TODO: use a query param or schema to specify insecure
-			xdsMCP, err := adsc.New(&meshconfig.ProxyConfig{
-				DiscoveryAddress: srcAddress.Host,
-			}, &adsc.Config{
+			xdsMCP, err := adsc.New(srcAddress.Host, &adsc.Config{
 				Meta: model.NodeMetadata{
 					Generator: "api",
 				}.ToStruct(),

--- a/pilot/pkg/networking/apigen/apigen_test.go
+++ b/pilot/pkg/networking/apigen/apigen_test.go
@@ -69,7 +69,7 @@ func TestAPIGen(t *testing.T) {
 
 	// Verify we can receive the DNS cluster IPs using XDS
 	t.Run("adsc", func(t *testing.T) {
-		adscConn, err := adsc.Dial(grpcUpstreamAddr, "", &adsc.Config{
+		adscConn, err := adsc.Dial(grpcUpstreamAddr, &adsc.Config{
 			IP: "1.2.3.4",
 			Meta: model.NodeMetadata{
 				Generator: "api",

--- a/pilot/pkg/networking/apigen/apigen_test.go
+++ b/pilot/pkg/networking/apigen/apigen_test.go
@@ -69,7 +69,7 @@ func TestAPIGen(t *testing.T) {
 
 	// Verify we can receive the DNS cluster IPs using XDS
 	t.Run("adsc", func(t *testing.T) {
-		adscConn, err := adsc.Dial(grpcUpstreamAddr, &adsc.Config{
+		adscConn, err := adsc.New(grpcUpstreamAddr, &adsc.Config{
 			IP: "1.2.3.4",
 			Meta: model.NodeMetadata{
 				Generator: "api",

--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -26,6 +26,7 @@ import (
 
 	mesh "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
+
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/util/sets"
 	"istio.io/istio/pilot/pkg/xds"
@@ -116,14 +117,15 @@ func TestAgent(t *testing.T) {
 		}
 
 		// connect to the local XDS proxy - it's using a transient port.
-		ldsr, err := adsc.Dial(sa.GetLocalXDSGeneratorListener().Addr().String(),
+		ldsr, err := adsc.New(sa.GetLocalXDSGeneratorListener().Addr().String(),
 			&adsc.Config{
 				IP:        "10.11.10.1",
 				Namespace: "test",
 				RootCert:  creds.RootCert,
-				Watch: []string{
-					v3.ClusterType,
-					collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind().String()},
+				InitialDiscoveryRequests: []*discovery.DiscoveryRequest{
+					{TypeUrl: v3.ClusterType},
+					{TypeUrl: collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind().String()},
+				},
 			})
 		if err != nil {
 			t.Fatal("Failed to connect", err)
@@ -148,15 +150,15 @@ func TestAgent(t *testing.T) {
 // testAdscTLS tests that ADSC helper can connect using TLS to Istiod
 func testAdscTLS(t *testing.T, creds security.SecretManager) {
 	// connect to the local XDS proxy - it's using a transient port.
-	ldsr, err := adsc.Dial(util.MockPilotSGrpcAddr,
+	ldsr, err := adsc.New(util.MockPilotSGrpcAddr,
 		&adsc.Config{
-			IP:            "10.11.10.1",
-			Namespace:     "test",
-			SecretManager: creds,
-			Watch: []string{
-				v3.ClusterType,
-				xds.TypeURLConnections,
-				collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind().String()},
+			IP:        "10.11.10.1",
+			Namespace: "test",
+			InitialDiscoveryRequests: []*discovery.DiscoveryRequest{
+				{TypeUrl: v3.ClusterType},
+				{TypeUrl: xds.TypeURLConnections},
+				{TypeUrl: collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind().String()},
+			},
 		})
 	if err != nil {
 		t.Fatal("Failed to connect", err)

--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -26,7 +26,6 @@ import (
 
 	mesh "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
-
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/util/sets"
 	"istio.io/istio/pilot/pkg/xds"
@@ -152,8 +151,9 @@ func testAdscTLS(t *testing.T, creds security.SecretManager) {
 	// connect to the local XDS proxy - it's using a transient port.
 	ldsr, err := adsc.New(util.MockPilotSGrpcAddr,
 		&adsc.Config{
-			IP:        "10.11.10.1",
-			Namespace: "test",
+			IP:            "10.11.10.1",
+			Namespace:     "test",
+			SecretManager: creds,
 			InitialDiscoveryRequests: []*discovery.DiscoveryRequest{
 				{TypeUrl: v3.ClusterType},
 				{TypeUrl: xds.TypeURLConnections},

--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -116,7 +116,7 @@ func TestAgent(t *testing.T) {
 		}
 
 		// connect to the local XDS proxy - it's using a transient port.
-		ldsr, err := adsc.Dial(sa.GetLocalXDSGeneratorListener().Addr().String(), "",
+		ldsr, err := adsc.Dial(sa.GetLocalXDSGeneratorListener().Addr().String(),
 			&adsc.Config{
 				IP:        "10.11.10.1",
 				Namespace: "test",
@@ -148,11 +148,11 @@ func TestAgent(t *testing.T) {
 // testAdscTLS tests that ADSC helper can connect using TLS to Istiod
 func testAdscTLS(t *testing.T, creds security.SecretManager) {
 	// connect to the local XDS proxy - it's using a transient port.
-	ldsr, err := adsc.Dial(util.MockPilotSGrpcAddr, "",
+	ldsr, err := adsc.Dial(util.MockPilotSGrpcAddr,
 		&adsc.Config{
-			IP:        "10.11.10.1",
-			Namespace: "test",
-			Secrets:   creds,
+			IP:            "10.11.10.1",
+			Namespace:     "test",
+			SecretManager: creds,
 			Watch: []string{
 				v3.ClusterType,
 				xds.TypeURLConnections,

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -348,7 +348,7 @@ func fullPush(s *xds.FakeDiscoveryServer) {
 }
 
 func adsConnectAndWait(t *testing.T, ip int) *adsc.ADSC {
-	adscConn, err := adsc.Dial(util.MockPilotGrpcAddr, &adsc.Config{
+	adscConn, err := adsc.New(util.MockPilotGrpcAddr, &adsc.Config{
 		IP: testIP(uint32(ip)),
 	})
 	if err != nil {

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -167,7 +167,6 @@ func TestEds(t *testing.T) {
 		}
 		strResponse, _ := json.MarshalIndent(clusters, " ", " ")
 		_ = ioutil.WriteFile(env.IstioOut+"/cdsv2_sidecar.json", strResponse, 0644)
-
 	})
 }
 

--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -348,7 +348,7 @@ func fullPush(s *xds.FakeDiscoveryServer) {
 }
 
 func adsConnectAndWait(t *testing.T, ip int) *adsc.ADSC {
-	adscConn, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.Config{
+	adscConn, err := adsc.Dial(util.MockPilotGrpcAddr, &adsc.Config{
 		IP: testIP(uint32(ip)),
 	})
 	if err != nil {

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -242,7 +242,7 @@ func (f *FakeDiscoveryServer) Connect(p *model.Proxy, watch []string, wait []str
 	if wait == nil {
 		watch = []string{v3.ClusterType}
 	}
-	adscConn, err := adsc.Dial("buffcon", "", &adsc.Config{
+	adscConn, err := adsc.Dial("buffcon", &adsc.Config{
 		IP:        p.IPAddresses[0],
 		Meta:      p.Metadata.ToStruct(),
 		Locality:  p.Locality,

--- a/pilot/pkg/xds/lds_test.go
+++ b/pilot/pkg/xds/lds_test.go
@@ -139,7 +139,7 @@ func TestLDSWithDefaultSidecar(t *testing.T) {
 	s.XDSServer.ConfigUpdate(&model.PushRequest{Full: true})
 	defer tearDown()
 
-	adsResponse, err := adsc.Dial(util.MockPilotGrpcAddr, &adsc.Config{
+	adsResponse, err := adsc.New(util.MockPilotGrpcAddr, &adsc.Config{
 		Meta: model.NodeMetadata{
 			InstanceIPs:  []string{"100.1.1.2"},
 			Namespace:    "ns1",
@@ -203,7 +203,7 @@ func TestLDSWithIngressGateway(t *testing.T) {
 	s.XDSServer.ConfigUpdate(&model.PushRequest{Full: true})
 	defer tearDown()
 
-	adsResponse, err := adsc.Dial(util.MockPilotGrpcAddr, &adsc.Config{
+	adsResponse, err := adsc.New(util.MockPilotGrpcAddr, &adsc.Config{
 		Meta: model.NodeMetadata{
 			InstanceIPs:  []string{"99.1.1.1"}, // as service instance of ingress gateway
 			Namespace:    "istio-system",
@@ -304,7 +304,7 @@ func TestLDSWithSidecarForWorkloadWithoutService(t *testing.T) {
 	s.XDSServer.ConfigUpdate(&model.PushRequest{Full: true})
 	defer tearDown()
 
-	adsResponse, err := adsc.Dial(util.MockPilotGrpcAddr, &adsc.Config{
+	adsResponse, err := adsc.New(util.MockPilotGrpcAddr, &adsc.Config{
 		Meta: model.NodeMetadata{
 			InstanceIPs:  []string{"98.1.1.1"}, // as service instance of ingress gateway
 			Namespace:    "consumerns",
@@ -407,7 +407,7 @@ func TestLDSEnvoyFilterWithWorkloadSelector(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			adsResponse, err := adsc.Dial(util.MockPilotGrpcAddr, &adsc.Config{
+			adsResponse, err := adsc.New(util.MockPilotGrpcAddr, &adsc.Config{
 				Meta: model.NodeMetadata{
 					InstanceIPs:  []string{test.ip}, // as service instance of ingress gateway
 					Namespace:    "istio-system",

--- a/pilot/pkg/xds/lds_test.go
+++ b/pilot/pkg/xds/lds_test.go
@@ -139,7 +139,7 @@ func TestLDSWithDefaultSidecar(t *testing.T) {
 	s.XDSServer.ConfigUpdate(&model.PushRequest{Full: true})
 	defer tearDown()
 
-	adsResponse, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.Config{
+	adsResponse, err := adsc.Dial(util.MockPilotGrpcAddr, &adsc.Config{
 		Meta: model.NodeMetadata{
 			InstanceIPs:  []string{"100.1.1.2"},
 			Namespace:    "ns1",
@@ -203,7 +203,7 @@ func TestLDSWithIngressGateway(t *testing.T) {
 	s.XDSServer.ConfigUpdate(&model.PushRequest{Full: true})
 	defer tearDown()
 
-	adsResponse, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.Config{
+	adsResponse, err := adsc.Dial(util.MockPilotGrpcAddr, &adsc.Config{
 		Meta: model.NodeMetadata{
 			InstanceIPs:  []string{"99.1.1.1"}, // as service instance of ingress gateway
 			Namespace:    "istio-system",
@@ -304,7 +304,7 @@ func TestLDSWithSidecarForWorkloadWithoutService(t *testing.T) {
 	s.XDSServer.ConfigUpdate(&model.PushRequest{Full: true})
 	defer tearDown()
 
-	adsResponse, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.Config{
+	adsResponse, err := adsc.Dial(util.MockPilotGrpcAddr, &adsc.Config{
 		Meta: model.NodeMetadata{
 			InstanceIPs:  []string{"98.1.1.1"}, // as service instance of ingress gateway
 			Namespace:    "consumerns",
@@ -407,7 +407,7 @@ func TestLDSEnvoyFilterWithWorkloadSelector(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			adsResponse, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.Config{
+			adsResponse, err := adsc.Dial(util.MockPilotGrpcAddr, &adsc.Config{
 				Meta: model.NodeMetadata{
 					InstanceIPs:  []string{test.ip}, // as service instance of ingress gateway
 					Namespace:    "istio-system",

--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -452,6 +452,7 @@ func (a *ADSC) hasSynced() bool {
 func (a *ADSC) reconnect() {
 	a.mutex.RLock()
 	if a.closed {
+		a.mutex.RUnlock()
 		return
 	}
 	a.mutex.RUnlock()

--- a/pkg/adsc/adsc_test.go
+++ b/pkg/adsc/adsc_test.go
@@ -61,9 +61,7 @@ func TestADSC_Run(t *testing.T) {
 				Updates:    make(chan string),
 				XDSUpdates: make(chan *xdsapi.DiscoveryResponse),
 				RecvWg:     sync.WaitGroup{},
-				cfg: &Config{
-					Watch: make([]string, 0),
-				},
+				cfg:        &Config{},
 			},
 			port: uint32(49133),
 			streamHandler: func(server xdsapi.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
@@ -81,9 +79,7 @@ func TestADSC_Run(t *testing.T) {
 				Updates:    make(chan string),
 				XDSUpdates: make(chan *xdsapi.DiscoveryResponse),
 				RecvWg:     sync.WaitGroup{},
-				cfg: &Config{
-					Watch: make([]string, 0),
-				},
+				cfg:        &Config{},
 			},
 			port: uint32(49133),
 			streamHandler: func(stream xdsapi.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {

--- a/pkg/adsc/adsc_test.go
+++ b/pkg/adsc/adsc_test.go
@@ -111,6 +111,7 @@ func TestADSC_Run(t *testing.T) {
 			l, err := net.Listen("tcp", ":"+fmt.Sprint(tt.port))
 			if err != nil {
 				t.Errorf("Unable to listen on port %v with tcp err %v", tt.port, err)
+				return
 			}
 			xds := grpc.NewServer()
 			xdsapi.RegisterAggregatedDiscoveryServiceServer(xds, new(testAdscRunServer))
@@ -123,7 +124,14 @@ func TestADSC_Run(t *testing.T) {
 			defer xds.GracefulStop()
 			if err != nil {
 				t.Errorf("Could not start serving ads server %v", err)
+				return
 			}
+
+			if err := tt.inAdsc.Dial(); err != nil {
+				t.Errorf("Dial error: %v", err)
+				return
+			}
+
 			tt.inAdsc.RecvWg.Add(1)
 			err = tt.inAdsc.Run()
 			tt.inAdsc.RecvWg.Wait()

--- a/pkg/adsc/adsc_test.go
+++ b/pkg/adsc/adsc_test.go
@@ -132,8 +132,6 @@ func TestADSC_Run(t *testing.T) {
 				return
 			}
 
-			tt.inAdsc.RecvWg.Add(1)
-			err = tt.inAdsc.Run()
 			tt.inAdsc.RecvWg.Wait()
 			if !cmp.Equal(tt.inAdsc.Received, tt.expectedADSResources.Received, protocmp.Transform()) {
 				t.Errorf("%s: expected recv %v got %v", tt.desc, tt.expectedADSResources.Received, tt.inAdsc.Received)

--- a/pkg/istio-agent/local_xds_generator.go
+++ b/pkg/istio-agent/local_xds_generator.go
@@ -123,12 +123,13 @@ func (sa *Agent) startXDSGenerator(proxyConfig *meshconfig.ProxyConfig, secrets 
 	}
 
 	cfg := &adsc.Config{
-		XDSSAN:          discHost,
-		ResponseHandler: sa.localXDSGenerator.proxyGen,
-		XDSRootCAFile:   sa.FindRootCAForXDS(),
-		RootCert:        sa.RootCert,
-		GrpcOpts:        sa.cfg.GrpcOptions,
-		Namespace:       namespace,
+		XDSSAN:                   discHost,
+		ResponseHandler:          sa.localXDSGenerator.proxyGen,
+		XDSRootCAFile:            sa.FindRootCAForXDS(),
+		RootCert:                 sa.RootCert,
+		GrpcOpts:                 sa.cfg.GrpcOptions,
+		Namespace:                namespace,
+		InitialDiscoveryRequests: append(adsc.ConfigInitialRequests(), adsc.XdsInitialRequests()...),
 	}
 
 	// Set Secrets and JWTPath if the default ControlPlaneAuthPolicy is MUTUAL_TLS
@@ -147,12 +148,6 @@ func (sa *Agent) startXDSGenerator(proxyConfig *meshconfig.ProxyConfig, secrets 
 	ads.LocalCacheDir = savePath.Get()
 	ads.Store = sa.localXDSGenerator.xdsServer.MemoryConfigStore
 	ads.Registry = sa.localXDSGenerator.xdsServer.DiscoveryServer.MemRegistry
-
-	// Send requests for MCP configs, for caching/debugging.
-	ads.WatchConfig()
-
-	// Send requests for normal envoy configs
-	ads.Watch()
 
 	sa.localXDSGenerator.proxyGen.AddClient(ads)
 

--- a/pkg/istio-agent/local_xds_generator.go
+++ b/pkg/istio-agent/local_xds_generator.go
@@ -133,11 +133,11 @@ func (sa *Agent) startXDSGenerator(proxyConfig *meshconfig.ProxyConfig, secrets 
 
 	// Set Secrets and JWTPath if the default ControlPlaneAuthPolicy is MUTUAL_TLS
 	if sa.proxyConfig.ControlPlaneAuthPolicy == meshconfig.AuthenticationPolicy_MUTUAL_TLS {
-		cfg.Secrets = secrets
+		cfg.SecretManager = secrets
 		cfg.JWTPath = sa.secOpts.JWTPath
 	}
 
-	ads, err := adsc.New(proxyConfig, cfg)
+	ads, err := adsc.New(proxyConfig.DiscoveryAddress, cfg)
 	if err != nil {
 		// Error to be handled by caller - probably by exit if
 		// we are in 'envoy using proxy' mode.


### PR DESCRIPTION
This pr mainly addresses two issues:

1. grpc client will reconnect, reply on it and so no connection leak

2.  auto rotate tls certificate