### PR TITLE
Fallback to 'exec' if port forward to 15014 unavailable

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -494,7 +494,7 @@ func (c *client) AllDiscoveryDo(ctx context.Context, istiodNamespace, path strin
 	var errs error
 	result := map[string][]byte{}
 	for _, istiod := range istiods {
-		res, err := c.proxyGet(istiod.Name, istiod.Namespace, path, 150140).DoRaw(ctx)
+		res, err := c.proxyGet(istiod.Name, istiod.Namespace, path, 15014).DoRaw(ctx)
 		if err != nil {
 			execRes, execErr := c.extractExecResult(istiod.Name, istiod.Namespace, discoveryContainer,
 				fmt.Sprintf("%s request GET %s", pilotDiscoveryPath, path))

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -500,7 +500,7 @@ func (c *client) AllDiscoveryDo(ctx context.Context, istiodNamespace, path strin
 				fmt.Sprintf("%s request GET %s", pilotDiscoveryPath, path))
 			if execErr != nil {
 				errs = multierror.Append(errs,
-					fmt.Errorf("error port-forwarding into %s: %v", istiod.Name, err),
+					fmt.Errorf("error port-forwarding into %s.%s: %v", istiod.Name, istiod.Namespace, err),
 					execErr,
 				)
 				continue
@@ -616,7 +616,7 @@ func (c *client) GetIstioVersions(ctx context.Context, namespace string) (*versi
 			bi, execErr := c.getIstioVersionUsingExec(&pod)
 			if execErr != nil {
 				errs = multierror.Append(errs,
-					fmt.Errorf("error port-forwarding into %s: %v", pod.Name, err),
+					fmt.Errorf("error port-forwarding into %s.%s: %v", pod.Name, pod.Namespace, err),
 					execErr,
 				)
 				continue

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -17,6 +17,7 @@ package kube
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -588,7 +589,16 @@ func (c *client) GetIstioVersions(ctx context.Context, namespace string) (*versi
 		// 1.7-alpha.9c900ba74d10a1affe7c23557ef0eebd6103b03c-9c900ba74d10a1affe7c23557ef0eebd6103b03c-Clean
 		result, err := c.proxyGet(pod.Name, pod.Namespace, "/version", 15014).DoRaw(ctx)
 		if err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("error port-forwarding into %s : %v", pod.Name, err))
+			bi, execErr := c.GetIstioVersionUsingExec(&pod)
+			if execErr != nil {
+				errs = multierror.Append(errs,
+					fmt.Errorf("error port-forwarding into %s : %v", pod.Name, err),
+					execErr,
+				)
+				continue
+			}
+			server.Info = *bi
+			res = append(res, server)
 			continue
 		}
 		if len(result) > 0 {
@@ -608,6 +618,54 @@ func (c *client) GetIstioVersions(ctx context.Context, namespace string) (*versi
 		}
 	}
 	return &res, errs
+}
+
+// GetIstioVersionUsingExec gets the version for each Istio control plane component
+func (c *client) GetIstioVersionUsingExec(pod *v1.Pod) (*version.BuildInfo, error) {
+
+	// exclude data plane components from control plane list
+	labelToPodDetail := map[string]struct {
+		binary    string
+		container string
+	}{
+		"pilot":            {"/usr/local/bin/pilot-discovery", "discovery"},
+		"istiod":           {"/usr/local/bin/pilot-discovery", "discovery"},
+		"citadel":          {"/usr/local/bin/istio_ca", "citadel"},
+		"galley":           {"/usr/local/bin/galley", "galley"},
+		"telemetry":        {"/usr/local/bin/mixs", "mixer"},
+		"policy":           {"/usr/local/bin/mixs", "mixer"},
+		"sidecar-injector": {"/usr/local/bin/sidecar-injector", "sidecar-injector-webhook"},
+	}
+
+	component := pod.Labels["istio"]
+
+	// Special cases
+	switch component {
+	case "statsd-prom-bridge":
+		// statsd-prom-bridge doesn't support version
+		return nil, fmt.Errorf("statsd-prom-bridge doesn't support version")
+	case "mixer":
+		component = pod.Labels["istio-mixer-type"]
+	}
+
+	detail, ok := labelToPodDetail[component]
+	if !ok {
+		return nil, fmt.Errorf("unknown Istio component %q", component)
+	}
+
+	stdout, stderr, err := c.PodExec(pod.Name, pod.Namespace, detail.container,
+		fmt.Sprintf("%s version -o json", detail.binary))
+	if err != nil {
+		return nil, fmt.Errorf("error exec'ing into %s %s container: %w", pod.Name, detail.container, err)
+	}
+
+	var v version.Version
+	err = json.Unmarshal([]byte(stdout), &v)
+	if err == nil && v.ClientVersion.Version != "" {
+		return v.ClientVersion, nil
+	}
+
+	return nil, fmt.Errorf("error reading %s %s container version: %v", pod.Name, detail.container, stderr)
 }
 
 func (c *client) NewPortForwarder(podName, ns, localAddress string, localPort int, podPort int) (PortForwarder, error) {


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/27383 by falling back to the exec behavior if port 15014 is unavailable for `istioctl version` and friends.
