### PR TITLE
Implement REPLACE operation for EnvoyFilter patch

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
@@ -299,7 +299,7 @@ func doNetworkFilterListOperation(patchContext networking.EnvoyFilter_PatchConte
 				}
 			}
 			if replacePosition == -1 {
-				log.Debugf("EnvoyFilter patch %v is not applied because no matching network filter found.",cp)
+				log.Debugf("EnvoyFilter patch %v is not applied because no matching network filter found.", cp)
 				continue
 			}
 			fc.Filters[replacePosition] = proto.Clone(cp.Value).(*xdslistener.Filter)
@@ -469,7 +469,7 @@ func doHTTPFilterListOperation(patchContext networking.EnvoyFilter_PatchContext,
 			}
 
 			if replacePosition == -1 {
-				log.Debugf("EnvoyFilter patch %v is not applied because no matching HTTP filter found.",cp)
+				log.Debugf("EnvoyFilter patch %v is not applied because no matching HTTP filter found.", cp)
 				continue
 			}
 

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
@@ -299,6 +299,7 @@ func doNetworkFilterListOperation(patchContext networking.EnvoyFilter_PatchConte
 				}
 			}
 			if replacePosition == -1 {
+				log.Debugf("EnvoyFilter patch %v is not applied because no matching network filter found.",cp)
 				continue
 			}
 			fc.Filters[replacePosition] = proto.Clone(cp.Value).(*xdslistener.Filter)
@@ -468,6 +469,7 @@ func doHTTPFilterListOperation(patchContext networking.EnvoyFilter_PatchContext,
 			}
 
 			if replacePosition == -1 {
+				log.Debugf("EnvoyFilter patch %v is not applied because no matching HTTP filter found.",cp)
 				continue
 			}
 

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
@@ -286,6 +286,22 @@ func doNetworkFilterListOperation(patchContext networking.EnvoyFilter_PatchConte
 			fc.Filters = append(fc.Filters, clonedVal)
 			copy(fc.Filters[insertPosition+1:], fc.Filters[insertPosition:])
 			fc.Filters[insertPosition] = clonedVal
+		} else if cp.Operation == networking.EnvoyFilter_Patch_REPLACE {
+			if !hasNetworkFilterMatch(cp) {
+				continue
+			}
+			// find the matching filter first
+			replacePosition := -1
+			for i := 0; i < len(fc.Filters); i++ {
+				if networkFilterMatch(fc.Filters[i], cp) {
+					replacePosition = i
+					break
+				}
+			}
+			if replacePosition == -1 {
+				continue
+			}
+			fc.Filters[replacePosition] = proto.Clone(cp.Value).(*xdslistener.Filter)
 		}
 	}
 	if networkFiltersRemoved {
@@ -437,6 +453,26 @@ func doHTTPFilterListOperation(patchContext networking.EnvoyFilter_PatchContext,
 			hcm.HttpFilters = append(hcm.HttpFilters, clonedVal)
 			copy(hcm.HttpFilters[insertPosition+1:], hcm.HttpFilters[insertPosition:])
 			hcm.HttpFilters[insertPosition] = clonedVal
+		} else if cp.Operation == networking.EnvoyFilter_Patch_REPLACE {
+			if !hasHTTPFilterMatch(cp) {
+				continue
+			}
+
+			// find the matching filter first
+			replacePosition := -1
+			for i := 0; i < len(hcm.HttpFilters); i++ {
+				if httpFilterMatch(hcm.HttpFilters[i], cp) {
+					replacePosition = i
+					break
+				}
+			}
+
+			if replacePosition == -1 {
+				continue
+			}
+
+			clonedVal := proto.Clone(cp.Value).(*http_conn.HttpFilter)
+			hcm.HttpFilters[replacePosition] = clonedVal
 		}
 	}
 	if httpFiltersRemoved {

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
@@ -490,7 +490,7 @@ func TestApplyListenerPatches(t *testing.T) {
 			},
 			Patch: &networking.EnvoyFilter_Patch{
 				Operation: networking.EnvoyFilter_Patch_REPLACE,
-				Value: buildPatchStruct(`{"name": "network-filter-replaced-should-not-be-applied"}`),
+				Value:     buildPatchStruct(`{"name": "network-filter-replaced-should-not-be-applied"}`),
 			},
 		},
 		{

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
@@ -25,6 +25,7 @@ import (
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	fault "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/fault/v3"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	redis_proxy "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/redis_proxy/v3"
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	wellknown "github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/gogo/protobuf/types"
@@ -442,6 +443,58 @@ func TestApplyListenerPatches(t *testing.T) {
 }`),
 			},
 		},
+		{
+			ApplyTo: networking.EnvoyFilter_NETWORK_FILTER,
+			Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
+				ObjectTypes: &networking.EnvoyFilter_EnvoyConfigObjectMatch_Listener{
+					Listener: &networking.EnvoyFilter_ListenerMatch{
+						PortNumber: 6379,
+						FilterChain: &networking.EnvoyFilter_ListenerMatch_FilterChainMatch{
+							Filter: &networking.EnvoyFilter_ListenerMatch_FilterMatch{
+								Name: "filter1",
+							},
+						},
+					},
+				},
+			},
+			Patch: &networking.EnvoyFilter_Patch{
+				Operation: networking.EnvoyFilter_Patch_REPLACE,
+				Value: buildPatchStruct(`
+{"name": "envoy.redis_proxy",
+ "typed_config": {
+        "@type": "type.googleapis.com/envoy.extensions.filters.network.redis_proxy.v3.RedisProxy",
+         "stat_prefix": "redis_stats",
+         "prefix_routes": {
+             "catch_all_route": {
+                 "cluster": "custom-redis-cluster"
+             }
+         }
+ }
+}`),
+			},
+		},
+		{
+			ApplyTo: networking.EnvoyFilter_HTTP_FILTER,
+			Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
+				ObjectTypes: &networking.EnvoyFilter_EnvoyConfigObjectMatch_Listener{
+					Listener: &networking.EnvoyFilter_ListenerMatch{
+						Name: "listener-to-be-replaced",
+						FilterChain: &networking.EnvoyFilter_ListenerMatch_FilterChainMatch{
+							Filter: &networking.EnvoyFilter_ListenerMatch_FilterMatch{
+								Name: wellknown.HTTPConnectionManager,
+								SubFilter: &networking.EnvoyFilter_ListenerMatch_SubFilterMatch{
+									Name: "http-filter-to-be-replaced",
+								},
+							},
+						},
+					},
+				},
+			},
+			Patch: &networking.EnvoyFilter_Patch{
+				Operation: networking.EnvoyFilter_Patch_REPLACE,
+				Value:     buildPatchStruct(`{"name": "http-filter-replaced"}`),
+			},
+		},
 	}
 
 	sidecarOutboundIn := []*listener.Listener{
@@ -466,7 +519,52 @@ func TestApplyListenerPatches(t *testing.T) {
 			},
 		},
 		{
+			Name: "6379",
+			Address: &core.Address{
+				Address: &core.Address_SocketAddress{
+					SocketAddress: &core.SocketAddress{
+						PortSpecifier: &core.SocketAddress_PortValue{
+							PortValue: 6379,
+						},
+					},
+				},
+			},
+			FilterChains: []*listener.FilterChain{
+				{
+					Filters: []*listener.Filter{
+						{Name: "filter1"},
+						{Name: "filter2"},
+					},
+				},
+			},
+		},
+		{
 			Name: "another-listener",
+		},
+		{
+			Name: "listener-to-be-replaced",
+			FilterChains: []*listener.FilterChain{
+				{
+					FilterChainMatch: &listener.FilterChainMatch{
+						DestinationPort: &wrappers.UInt32Value{
+							Value: 80,
+						},
+					},
+					Filters: []*listener.Filter{
+						{
+							Name: wellknown.HTTPConnectionManager,
+							ConfigType: &listener.Filter_TypedConfig{
+								TypedConfig: util.MessageToAny(&http_conn.HttpConnectionManager{
+									HttpFilters: []*http_conn.HttpFilter{
+										{Name: "http-filter-to-be-replaced"},
+										{Name: "another-http-filter"},
+									},
+								}),
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -492,7 +590,63 @@ func TestApplyListenerPatches(t *testing.T) {
 			},
 		},
 		{
+			Name: "6379",
+			Address: &core.Address{
+				Address: &core.Address_SocketAddress{
+					SocketAddress: &core.SocketAddress{
+						PortSpecifier: &core.SocketAddress_PortValue{
+							PortValue: 6379,
+						},
+					},
+				},
+			},
+			FilterChains: []*listener.FilterChain{
+				{
+					Filters: []*listener.Filter{
+						{Name: "envoy.redis_proxy",
+							ConfigType: &listener.Filter_TypedConfig{
+								TypedConfig: util.MessageToAny(&redis_proxy.RedisProxy{
+									StatPrefix: "redis_stats",
+									PrefixRoutes: &redis_proxy.RedisProxy_PrefixRoutes{
+										CatchAllRoute: &redis_proxy.RedisProxy_PrefixRoutes_Route{
+											Cluster: "custom-redis-cluster",
+										},
+									},
+								}),
+							},
+						},
+						{Name: "filter2"},
+					},
+				},
+			},
+		},
+		{
 			Name: "another-listener",
+		},
+		{
+			Name: "listener-to-be-replaced",
+			FilterChains: []*listener.FilterChain{
+				{
+					FilterChainMatch: &listener.FilterChainMatch{
+						DestinationPort: &wrappers.UInt32Value{
+							Value: 80,
+						},
+					},
+					Filters: []*listener.Filter{
+						{
+							Name: wellknown.HTTPConnectionManager,
+							ConfigType: &listener.Filter_TypedConfig{
+								TypedConfig: util.MessageToAny(&http_conn.HttpConnectionManager{
+									HttpFilters: []*http_conn.HttpFilter{
+										{Name: "http-filter-replaced"},
+										{Name: "another-http-filter"},
+									},
+								}),
+							},
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "new-outbound-listener1",

--- a/releasenotes/notes/27425.yaml
+++ b/releasenotes/notes/27425.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 27425
+releaseNotes:
+  - |
+    **Added** "REPLACE" operation for EnvoyFilter. "REPLACE" opration can replace contents of a named filter with new contents. It is only valid for HTTP_FILTER and NETWORK_FILTER.


### PR DESCRIPTION
Add a "REPLACE" operation for EnvoyFilter patch. This operation only supports Network filter and HTTP filter.

This is the implementation of issue #27425

Signed-off-by: huabing zhao <zhaohuabing@gmail.com>



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[*] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.