### PR TITLE
issues/27428: Change for fixing the build of the operator without a build-tools container.

### DIFF
--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -183,7 +183,7 @@ docker.istioctl: istioctl/docker/Dockerfile.istioctl
 docker.istioctl: $(ISTIO_OUT_LINUX)/istioctl
 	$(DOCKER_RULE)
 
-docker.operator: manifests/
+docker.operator: manifests
 docker.operator: BUILD_ARGS=--build-arg BASE_VERSION=${BASE_VERSION}
 docker.operator: operator/docker/Dockerfile.operator
 docker.operator: $(ISTIO_OUT_LINUX)/operator


### PR DESCRIPTION
**Fix for [27428](https://github.com/istio/istio/issues/27428), Change for fixing the build of the operator without a build-tools container.**


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.