### PR TITLE
fix eastwest gen

### DIFF
--- a/pkg/test/framework/components/istio/eastwest.go
+++ b/pkg/test/framework/components/istio/eastwest.go
@@ -55,14 +55,16 @@ func (i *operatorComponent) deployEastWestGateway(cluster resource.Cluster) erro
 	// generate k8s resources for the gateway
 	cmd := exec.Command(genGatewayScript, generateSettings...)
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env,
-		"CLUSTER="+cluster.Name(),
-		"NETWORK="+cluster.NetworkName(),
-		"MESH="+meshID)
-	if !i.environment.IsMulticluster() {
-		cmd.Env = append(cmd.Env, "SINGLE_CLUSTER=1")
+	customEnv := []string{
+		"CLUSTER=" + cluster.Name(),
+		"NETWORK=" + cluster.NetworkName(),
+		"MESH=" + meshID,
 	}
-	scopes.Framework.Infof("Deploying eastwestgateway in %s: %v", cluster.Name(), append(generateSettings, cmd.Env...))
+	if !i.environment.IsMulticluster() {
+		customEnv = append(customEnv, "SINGLE_CLUSTER=1")
+	}
+	cmd.Env = append(cmd.Env, customEnv...)
+	scopes.Framework.Infof("Deploying eastwestgateway in %s: %v %v", cluster.Name(), customEnv, generateSettings)
 	gwYaml, err := cmd.CombinedOutput()
 
 	if err != nil {

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -79,7 +79,7 @@ test.integration.%.analyze: | $(JUNIT_REPORT)
 
 # Generate integration test targets for kubernetes environment.
 test.integration.%.kube: | $(JUNIT_REPORT)
-	$(GO) test -p 1 ${T} -tags=integ ./tests/integration/$(subst .,/,$*)/... -timeout 30m \
+	PATH=${PATH}:${ISTIO_OUT} $(GO) test -p 1 ${T} -tags=integ ./tests/integration/$(subst .,/,$*)/... -timeout 30m \
 	${_INTEGRATION_TEST_FLAGS} \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
 


### PR DESCRIPTION
- better std err dump
- probably due to using `istioctl` in script, can we rely on `istioctl` being the built one, or should we give `istio.io/istio/out/...` path? 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
