### PR TITLE
consolidate kube make targets

### DIFF
--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -84,7 +84,8 @@ test.integration.%.kube: | $(JUNIT_REPORT)
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
 
 # Generate presubmit integration test targets for each component in kubernetes environment
-test.integration.%.kube.presubmit: test.integration.%.kube
+test.integration.%.kube.presubmit:
+	@make test.integration.$*.kube
 
 # Presubmit integration tests targeting Kubernetes environment. Really used for postsubmit on different k8s versions.
 .PHONY: test.integration.kube.presubmit

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -80,17 +80,13 @@ test.integration.%.analyze: | $(JUNIT_REPORT)
 # Generate integration test targets for kubernetes environment.
 test.integration.%.kube: | $(JUNIT_REPORT)
 	PATH=${PATH}:${ISTIO_OUT} $(GO) test -p 1 ${T} -tags=integ ./tests/integration/$(subst .,/,$*)/... -timeout 30m \
-	${_INTEGRATION_TEST_FLAGS} \
-	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
-
-# Generate presubmit integration test targets for each component in kubernetes environment
-test.integration.%.kube.presubmit: | $(JUNIT_REPORT)
-	PATH=${PATH}:${ISTIO_OUT} $(GO) test -p 1 ${T} -tags=integ ./tests/integration/$(subst .,/,$*)/... -timeout 30m \
 	${_INTEGRATION_TEST_FLAGS} ${_INTEGRATION_TEST_SELECT_FLAGS} \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
 
+# Generate presubmit integration test targets for each component in kubernetes environment
+test.integration.%.kube.presubmit: test.integration.%.kube
 
-# Presubmit integration tests targeting Kubernetes environment.
+# Presubmit integration tests targeting Kubernetes environment. Really used for postsubmit on different k8s versions.
 .PHONY: test.integration.kube.presubmit
 test.integration.kube.presubmit: | $(JUNIT_REPORT)
 	PATH=${PATH}:${ISTIO_OUT} $(GO) test -p 1 ${T} -tags=integ $(shell go list ./tests/integration/... | grep -v /qualification | grep -v /examples) -timeout 30m \


### PR DESCRIPTION
Seems like the presubmit and non-presubmit are identical except for the test select flags and the PATH being set (recently fixed). They can be consolidated to avoid further confusion. 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
