### PR TITLE
Comply to helm3's way of handling namespaces

### DIFF
--- a/manifests/charts/istio-operator/templates/clusterrole_binding.yaml
+++ b/manifests/charts/istio-operator/templates/clusterrole_binding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: istio-operator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  namespace: {{.Chart.Namespace}}
+  namespace: {{.Release.Namespace}}
 roleRef:
   kind: ClusterRole
   name: istio-operator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}

--- a/manifests/charts/istio-operator/templates/clusterrole_binding.yaml
+++ b/manifests/charts/istio-operator/templates/clusterrole_binding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: istio-operator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  namespace: {{.Values.operatorNamespace}}
+  namespace: {{.Chart.Namespace}}
 roleRef:
   kind: ClusterRole
   name: istio-operator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}

--- a/manifests/charts/istio-operator/templates/deployment.yaml
+++ b/manifests/charts/istio-operator/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: istio-operator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  namespace: {{.Release.Namespace}}
 spec:
   replicas: 1
   selector:

--- a/manifests/charts/istio-operator/templates/deployment.yaml
+++ b/manifests/charts/istio-operator/templates/deployment.yaml
@@ -36,13 +36,13 @@ spec:
             - name: WATCH_NAMESPACE
               value: {{.Values.watchedNamespaces | quote}}
             - name: LEADER_ELECTION_NAMESPACE
-              value: {{.Chart.Namespace | quote}}
+              value: {{.Release.Namespace | quote}}
             - name: POD_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
-              value: {{.Chart.Namespace | quote}}
+              value: {{.Release.Namespace | quote}}
             - name: WAIT_FOR_RESOURCES_TIMEOUT
               value: {{.Values.waitForResourcesTimeout | quote}}
             - name: REVISION

--- a/manifests/charts/istio-operator/templates/deployment.yaml
+++ b/manifests/charts/istio-operator/templates/deployment.yaml
@@ -1,7 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: {{.Values.operatorNamespace}}
   name: istio-operator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
 spec:
   replicas: 1
@@ -37,13 +36,13 @@ spec:
             - name: WATCH_NAMESPACE
               value: {{.Values.watchedNamespaces | quote}}
             - name: LEADER_ELECTION_NAMESPACE
-              value: {{.Values.operatorNamespace | quote}}
+              value: {{.Chart.Namespace | quote}}
             - name: POD_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
-              value: {{.Values.operatorNamespace | quote}}
+              value: {{.Chart.Namespace | quote}}
             - name: WAIT_FOR_RESOURCES_TIMEOUT
               value: {{.Values.waitForResourcesTimeout | quote}}
             - name: REVISION

--- a/manifests/charts/istio-operator/templates/namespace.yaml
+++ b/manifests/charts/istio-operator/templates/namespace.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{.Values.operatorNamespace}}
-  labels:
-    istio-operator-managed: Reconcile
-    istio-injection: disabled
----

--- a/manifests/charts/istio-operator/templates/service.yaml
+++ b/manifests/charts/istio-operator/templates/service.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: {{.Values.operatorNamespace}}
   labels:
     name: istio-operator
   name: istio-operator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}

--- a/manifests/charts/istio-operator/templates/service.yaml
+++ b/manifests/charts/istio-operator/templates/service.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     name: istio-operator
   name: istio-operator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  namespace: {{.Release.Namespace}}
 spec:
   ports:
   - name: http-metrics

--- a/manifests/charts/istio-operator/templates/service_account.yaml
+++ b/manifests/charts/istio-operator/templates/service_account.yaml
@@ -1,6 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: {{.Values.operatorNamespace}}
   name: istio-operator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
 ---

--- a/manifests/charts/istio-operator/templates/service_account.yaml
+++ b/manifests/charts/istio-operator/templates/service_account.yaml
@@ -2,4 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: istio-operator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  namespace: {{.Release.Namespace}}
 ---

--- a/manifests/charts/istio-operator/values.yaml
+++ b/manifests/charts/istio-operator/values.yaml
@@ -1,8 +1,6 @@
 hub: gcr.io/istio-testing
 tag: latest
 
-operatorNamespace: istio-operator
-
 # Used to replace istioNamespace to support operator watch multiple namespaces.
 watchedNamespaces: istio-system
 waitForResourcesTimeout: 300s

--- a/operator/cmd/mesh/operator-common.go
+++ b/operator/cmd/mesh/operator-common.go
@@ -112,3 +112,12 @@ func deploymentExists(cs kubernetes.Interface, namespace, name string) (bool, er
 	}
 	return d != nil, nil
 }
+
+// namespaceExists returns true if the given namespace exists.
+func namespaceExists(cs kubernetes.Interface, namespace string) (bool, error) {
+	d, err := cs.AppsV1().Namespaces().Get(context.TODO(), namespace, v12.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+	return d != nil, nil
+}

--- a/operator/cmd/mesh/operator-init.go
+++ b/operator/cmd/mesh/operator-init.go
@@ -82,6 +82,13 @@ func operatorInit(args *rootArgs, oiArgs *operatorInitArgs, l clog.Logger) {
 	if err != nil {
 		l.LogAndFatal(err)
 	}
+
+	// Create operatorNamespace if it does not exist.
+	l.LogAndPrintf("Creating operator namespace %s if it is not created", oiArgs.common.operatorNamespace)
+
+	if err := createNamespace(clientset, oiArgs.common.operatorNamespace); err != nil {
+		l.LogAndFatal(err)
+	}
 	// Error here likely indicates Deployment is missing. If some other K8s error, we will hit it again later.
 	already, _ := isControllerInstalled(clientset, oiArgs.common.operatorNamespace, oiArgs.common.revision)
 	if already {

--- a/operator/cmd/mesh/operator-init.go
+++ b/operator/cmd/mesh/operator-init.go
@@ -84,11 +84,15 @@ func operatorInit(args *rootArgs, oiArgs *operatorInitArgs, l clog.Logger) {
 	}
 
 	// Create operatorNamespace if it does not exist.
-	l.LogAndPrintf("Creating operator namespace %s if it is not created", oiArgs.common.operatorNamespace)
-
-	if err := createNamespace(clientset, oiArgs.common.operatorNamespace); err != nil {
+	if already, err := namespaceExists(clientset, oiArgs.common.operatorNamespace); err != nil {
 		l.LogAndFatal(err)
+	} else if !already {
+		if err := createNamespace(clientset, oiArgs.common.operatorNamespace); err != nil {
+			l.LogAndFatal(err)
+		}
+		l.LogAndPrintf("Operator namespace %s was created.", oiArgs.common.operatorNamespace)
 	}
+
 	// Error here likely indicates Deployment is missing. If some other K8s error, we will hit it again later.
 	already, _ := isControllerInstalled(clientset, oiArgs.common.operatorNamespace, oiArgs.common.revision)
 	if already {


### PR DESCRIPTION
As of now, the helm chart handles namespaces in a "helm2" way:
-  target namespace for the operator is in `values.yaml`
-  there is a `Namespace` resource in `templates/namespace.yaml`

helm3 compliant charts *do not* create namespaces (this is left to the user). They also use the `--namespace` parameter of the `helm install` command to decide where resources in the `templates/` directory should be installed, and if template files ever need to reference the said namespace, it is available under the `.Release.Namespace` built-in variable.

Affects:

[ ] Configuration Infrastructure
[] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


[ ] Does not have any changes that may affect Istio users.
