### PR TITLE
[Test Framework] Support colon-separated KUBECONFIG

### DIFF
--- a/pkg/test/env/istio.go
+++ b/pkg/test/env/istio.go
@@ -54,10 +54,10 @@ var (
 	// nolint: golint, stylecheck
 	PULL_POLICY Variable = "PULL_POLICY"
 
-	// ISTIO_TEST_KUBE_CONFIG is the Kubernetes configuration file to use for testing. If a configuration file
-	// is specified on the command-line, that takes precedence.
+	// KUBECONFIG is the list of Kubernetes configuration files. If configuration files are specified on
+	// the command-line, that takes precedence.
 	// nolint: golint, stylecheck
-	ISTIO_TEST_KUBE_CONFIG Variable = "ISTIO_TEST_KUBE_CONFIG"
+	KUBECONFIG Variable = "KUBECONFIG"
 
 	// IstioSrc is the location of istio source ($TOP/src/istio.io/istio
 	IstioSrc = REPO_ROOT.ValueOrDefaultFunc(getDefaultIstioSrc)


### PR DESCRIPTION
The framework currently assumes that KUBECONFIG is separated by commas, which is not supported by the spec. This change allows the variables to be comma-seprated, but then converts them to being properly colon-separated.

Follow-on PRs will get rid our our usage of commas from prow jobs.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.