### PR TITLE
remove namespace in ClusterRoleBinding's metadata

### DIFF
--- a/manifests/charts/istio-cni/templates/clusterrolebinding.yaml
+++ b/manifests/charts/istio-cni/templates/clusterrolebinding.yaml
@@ -19,7 +19,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: istio-cni-repair-rolebinding
-  namespace: {{ .Release.Namespace}}
   labels:
     k8s-app: istio-cni-repair
 subjects:
@@ -53,7 +52,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: istio-cni-taint-rolebinding
-  namespace: {{ .Release.Namespace}}
   labels:
     k8s-app: istio-cni-taint
 subjects:


### PR DESCRIPTION
ClusterRoleBinding is not namespace scoped.

[] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[] Does not have any changes that may affect Istio users.
