### PR TITLE
Update description for istioctl main commands

### DIFF
--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -85,7 +85,7 @@ func InstallCmd(logOpts *log.Options) *cobra.Command {
 	ic := &cobra.Command{
 		Use:   "install",
 		Short: "Applies an Istio manifest, installing or reconfiguring Istio on a cluster.",
-		Long:  "The install generates an Istio install manifest and applies it to a cluster.",
+		Long:  "The install command generates an Istio install manifest and applies it to a cluster.",
 		// nolint: lll
 		Example: `  # Apply a default Istio installation
   istioctl install

--- a/operator/cmd/mesh/manifest.go
+++ b/operator/cmd/mesh/manifest.go
@@ -25,7 +25,7 @@ func ManifestCmd(logOpts *log.Options) *cobra.Command {
 	mc := &cobra.Command{
 		Use:   "manifest",
 		Short: "Commands related to Istio manifests",
-		Long:  "The manifest subcommand generates, applies, diffs or migrates Istio manifests.",
+		Long:  "The manifest command generates and diffs Istio manifests.",
 	}
 
 	mgcArgs := &manifestGenerateArgs{}

--- a/operator/cmd/mesh/operator.go
+++ b/operator/cmd/mesh/operator.go
@@ -23,7 +23,7 @@ func OperatorCmd() *cobra.Command {
 	oc := &cobra.Command{
 		Use:   "operator",
 		Short: "Commands related to Istio operator controller.",
-		Long:  "The operator subcommand installs, removes and shows the status of the operator controller.",
+		Long:  "The operator command installs, dumps, removes and shows the status of the operator controller.",
 	}
 
 	odArgs := &operatorDumpArgs{}

--- a/operator/cmd/mesh/profile.go
+++ b/operator/cmd/mesh/profile.go
@@ -23,7 +23,7 @@ func ProfileCmd() *cobra.Command {
 	pc := &cobra.Command{
 		Use:   "profile",
 		Short: "Commands related to Istio configuration profiles",
-		Long:  "The profile subcommand lists, dumps or diffs Istio configuration profiles.",
+		Long:  "The profile command lists, dumps or diffs Istio configuration profiles.",
 		Example: "istioctl profile list\n" +
 			"istioctl install --set profile=demo  # Use a profile from the list",
 	}


### PR DESCRIPTION
These are the main commands and not subcommands.

`istioctl install`
`istioctl manifest`
`istioctl operator`
`istioctl profile`