### PR TITLE
Use common warning for experimental commands

### DIFF
--- a/istioctl/cmd/add-to-mesh.go
+++ b/istioctl/cmd/add-to-mesh.go
@@ -71,12 +71,9 @@ func addToMeshCmd() *cobra.Command {
 		Aliases: []string{"add"},
 		Short:   "Add workloads into Istio service mesh",
 		Long: `'istioctl experimental add-to-mesh' restarts pods with an Istio sidecar or configures meshed pod access to external services.
-
 Use 'add-to-mesh' as an alternate to namespace-wide auto injection for troubleshooting compatibility.
 
-The 'remove-from-mesh' command can be used to restart with the sidecar removed.
-
-THESE COMMANDS ARE UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.`,
+The 'remove-from-mesh' command can be used to restart with the sidecar removed.`,
 		Example: `  # Restart all productpage pods with an Istio sidecar
   istioctl experimental add-to-mesh service productpage
 
@@ -114,6 +111,8 @@ THESE COMMANDS ARE UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.`,
 		fmt.Sprintf("ConfigMap name for Istio mesh configuration, key should be %q", configMapKey))
 	addToMeshCmd.PersistentFlags().StringVar(&injectConfigMapName, "injectConfigMapName", defaultInjectConfigMapName,
 		fmt.Sprintf("ConfigMap name for Istio sidecar injection, key should be %q.", injectConfigMapKey))
+
+	addToMeshCmd.Long += "\n\n" + ExperimentalMsg
 	return addToMeshCmd
 }
 
@@ -131,10 +130,7 @@ to test deployments for compatibility with Istio.  It can be used instead of nam
 If your deployment does not function after using 'add-to-mesh' you must re-deploy it and troubleshoot it for Istio compatibility.
 See ` + url.DeploymentRequirements + `
 
-See also 'istioctl experimental remove-from-mesh deployment' which does the reverse.
-
-THIS COMMAND IS UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
-`,
+See also 'istioctl experimental remove-from-mesh deployment' which does the reverse.`,
 		Example: `  # Restart pods from the productpage-v1 deployment with Istio sidecar
   istioctl experimental add-to-mesh deployment productpage-v1
 
@@ -171,7 +167,7 @@ THIS COMMAND IS UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
 				})
 		},
 	}
-
+	cmd.Long += "\n\n" + ExperimentalMsg
 	opts.AttachControlPlaneFlags(cmd)
 	return cmd
 }
@@ -190,10 +186,7 @@ to test deployments for compatibility with Istio.  It can be used instead of nam
 If your service does not function after using 'add-to-mesh' you must re-deploy it and troubleshoot it for Istio compatibility.
 See ` + url.DeploymentRequirements + `
 
-See also 'istioctl experimental remove-from-mesh service' which does the reverse.
-
-THIS COMMAND IS UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
-`,
+See also 'istioctl experimental remove-from-mesh service' which does the reverse.`,
 		Example: `  # Restart all productpage pods with an Istio sidecar
   istioctl experimental add-to-mesh service productpage
 
@@ -232,7 +225,7 @@ THIS COMMAND IS UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
 				})
 		},
 	}
-
+	cmd.Long += "\n\n" + ExperimentalMsg
 	opts.AttachControlPlaneFlags(cmd)
 	return cmd
 }
@@ -246,10 +239,7 @@ func externalSvcMeshifyCmd() *cobra.Command {
 a Service without selector for the specified external service in Istio service mesh.
 The typical usage scenario is Mesh Expansion on VMs.
 
-See also 'istioctl experimental remove-from-mesh external-service' which does the reverse.
-
-THIS COMMAND IS UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
-`,
+See also 'istioctl experimental remove-from-mesh external-service' which does the reverse.`,
 		Example: ` # Control how meshed pods contact 172.12.23.125 and .126
   istioctl experimental add-to-mesh external-service vmhttp 172.12.23.125,172.12.23.126 \
    http:9080 tcp:8888 --labels app=test,version=v1 --annotations env=stage --serviceaccount stageAdmin`,
@@ -280,6 +270,8 @@ THIS COMMAND IS UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
 		nil, "List of string annotations to apply if creating a service/endpoint; e.g. -a foo=bar,x=y")
 	cmd.PersistentFlags().StringVarP(&svcAcctAnn, "serviceaccount", "s",
 		"default", "Service account to link to the service")
+
+	cmd.Long += "\n\n" + ExperimentalMsg
 	return cmd
 }
 

--- a/istioctl/cmd/authz.go
+++ b/istioctl/cmd/authz.go
@@ -42,10 +42,7 @@ the Envoy configuration of the pod. The command is especially useful for inspect
 the policy propagation from Istiod to Envoy and the final AuthorizationPolicy list merged 
 from multiple sources (mesh-level, namespace-level and workload-level).
 
-The command also supports reading from a standalone config dump file with flag -f.
-
-THIS COMMAND IS STILL UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
-`,
+The command also supports reading from a standalone config dump file with flag -f.`,
 		Example: `  # Check AuthorizationPolicy applied to pod httpbin-88ddbcfdd-nt5jb:
   istioctl x authz check httpbin-88ddbcfdd-nt5jb
 
@@ -156,6 +153,7 @@ func AuthZ() *cobra.Command {
 	}
 
 	cmd.AddCommand(checkCmd)
+	cmd.Long += "\n\n" + ExperimentalMsg
 	return cmd
 }
 

--- a/istioctl/cmd/describe.go
+++ b/istioctl/cmd/describe.go
@@ -81,10 +81,7 @@ func podDescribeCmd() *cobra.Command {
 		Use:   "pod <pod>",
 		Short: "Describe pods and their Istio configuration [kube-only]",
 		Long: `Analyzes pod, its Services, DestinationRules, and VirtualServices and reports
-the configuration objects that affect that pod.
-
-THIS COMMAND IS STILL UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
-`,
+the configuration objects that affect that pod.`,
 		Example: `  istioctl experimental describe pod productpage-v1-c7765c886-7zzd4`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
@@ -156,7 +153,7 @@ THIS COMMAND IS STILL UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
 
 	cmd.PersistentFlags().BoolVar(&ignoreUnmeshed, "ignoreUnmeshed", false,
 		"Suppress warnings for unmeshed pods")
-
+	cmd.Long += "\n\n" + ExperimentalMsg
 	return cmd
 }
 
@@ -1000,10 +997,7 @@ func svcDescribeCmd() *cobra.Command {
 		Aliases: []string{"svc"},
 		Short:   "Describe services and their Istio configuration [kube-only]",
 		Long: `Analyzes service, pods, DestinationRules, and VirtualServices and reports
-the configuration objects that affect that service.
-
-THIS COMMAND IS STILL UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
-`,
+the configuration objects that affect that service.`,
 		Example: `  istioctl experimental describe service productpage`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
@@ -1104,7 +1098,7 @@ THIS COMMAND IS STILL UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
 
 	cmd.PersistentFlags().BoolVar(&ignoreUnmeshed, "ignoreUnmeshed", false,
 		"Suppress warnings for unmeshed pods")
-
+	cmd.Long += "\n\n" + ExperimentalMsg
 	return cmd
 }
 

--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -729,10 +729,7 @@ func secretConfigCmd() *cobra.Command {
 
   # Retrieve full bootstrap without using Kubernetes API
   ssh <user@hostname> 'curl localhost:15000/config_dump' > envoy-config.json
-  istioctl proxy-config secret --file envoy-config.json
-
-  THIS COMMAND IS STILL UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
-`,
+  istioctl proxy-config secret --file envoy-config.json`,
 		Aliases: []string{"s"},
 		Args: func(cmd *cobra.Command, args []string) error {
 			if (len(args) == 1) != (configDumpFile == "") {
@@ -769,7 +766,7 @@ func secretConfigCmd() *cobra.Command {
 	secretConfigCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", summaryOutput, "Output format: one of json|short")
 	secretConfigCmd.PersistentFlags().StringVarP(&configDumpFile, "file", "f", "",
 		"Envoy config dump JSON file")
-
+	secretConfigCmd.Long += "\n\n" + ExperimentalMsg
 	return secretConfigCmd
 }
 

--- a/istioctl/cmd/remove-from-mesh.go
+++ b/istioctl/cmd/remove-from-mesh.go
@@ -43,9 +43,7 @@ func removeFromMeshCmd() *cobra.Command {
 		Short:   "Remove workloads from Istio service mesh",
 		Long: `'istioctl experimental remove-from-mesh' restarts pods without an Istio sidecar or removes external service access configuration.
 Use 'remove-from-mesh' to quickly test uninjected behavior as part of compatibility troubleshooting.
-The 'add-to-mesh' command can be used to add or restore the sidecar.
-
-THESE COMMANDS ARE UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.`,
+The 'add-to-mesh' command can be used to add or restore the sidecar.`,
 		Example: `  # Restart all productpage pods without an Istio sidecar
   istioctl experimental remove-from-mesh service productpage
 
@@ -65,6 +63,7 @@ THESE COMMANDS ARE UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.`,
 	removeFromMeshCmd.AddCommand(svcUnMeshifyCmd())
 	removeFromMeshCmd.AddCommand(deploymentUnMeshifyCmd())
 	removeFromMeshCmd.AddCommand(externalSvcUnMeshifyCmd())
+	removeFromMeshCmd.Long += "\n\n" + ExperimentalMsg
 	return removeFromMeshCmd
 }
 
@@ -74,10 +73,7 @@ func deploymentUnMeshifyCmd() *cobra.Command {
 		Aliases: []string{"deploy", "dep"},
 		Short:   "Remove deployment from Istio service mesh",
 		Long: `'istioctl experimental remove-from-mesh deployment' restarts pods with the Istio sidecar un-injected.
-'remove-from-mesh' is a compatibility troubleshooting tool.
-
-THIS COMMAND IS UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
-`,
+'remove-from-mesh' is a compatibility troubleshooting tool.`,
 		Example: `  # Restart all productpage-v1 pods without an Istio sidecar
   istioctl experimental remove-from-mesh deployment productpage-v1
 
@@ -105,6 +101,7 @@ THIS COMMAND IS UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
 			return unInjectSideCarFromDeployment(client, deps, args[0], ns, writer)
 		},
 	}
+	cmd.Long += "\n\n" + ExperimentalMsg
 	return cmd
 }
 
@@ -114,10 +111,7 @@ func svcUnMeshifyCmd() *cobra.Command {
 		Aliases: []string{"svc"},
 		Short:   "Remove Service from Istio service mesh",
 		Long: `'istioctl experimental remove-from-mesh service' restarts pods with the Istio sidecar un-injected.
-'remove-from-mesh' is a compatibility troubleshooting tool.
-
-THIS COMMAND IS UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
-`,
+'remove-from-mesh' is a compatibility troubleshooting tool.`,
 		Example: `  # Restart all productpage pods without an Istio sidecar
   istioctl experimental remove-from-mesh service productpage
 
@@ -151,6 +145,7 @@ THIS COMMAND IS UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
 			return unInjectSideCarFromDeployment(client, matchingDeployments, args[0], ns, writer)
 		},
 	}
+	cmd.Long += "\n\n" + ExperimentalMsg
 	return cmd
 }
 
@@ -161,10 +156,7 @@ func externalSvcUnMeshifyCmd() *cobra.Command {
 		Short:   "Remove Service Entry and Kubernetes Service for the external service from Istio service mesh",
 		Long: `'istioctl experimental remove-from-mesh external-service' removes the ServiceEntry and
 the Kubernetes Service for the specified external service (e.g. services running on a VM) from Istio service mesh.
-The typical usage scenario is Mesh Expansion on VMs.
-
-THIS COMMAND IS UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
-`,
+The typical usage scenario is Mesh Expansion on VMs.`,
 		Example: `  # Remove "vmhttp" service entry rules
   istioctl experimental remove-from-mesh external-service vmhttp
 
@@ -194,6 +186,7 @@ THIS COMMAND IS UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
 			return fmt.Errorf("service %q does not exist, skip", args[0])
 		},
 	}
+	cmd.Long += "\n\n" + ExperimentalMsg
 	return cmd
 }
 

--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -53,6 +53,9 @@ const (
 
 	//deprection messages to be suffixed to the deprecated commands
 	deprecatedMsg = "[Deprecated, it will be removed in Istio 1.9]"
+
+	// ExperimentalMsg indicate active development and not for production use warning.
+	ExperimentalMsg = `THIS COMMAND IS UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.`
 )
 
 var (


### PR DESCRIPTION
Experimental commands have currently 3 different warning message in `istioctl <cmd> --help`.
```
THIS COMMAND IS UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.

THIS COMMAND IS STILL UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.

THESE COMMANDS ARE UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.
```
Use one common warning for all the experimental commands. So that it will be easier to change and update. 

```
THIS COMMAND IS UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE
```

Example:

```
$ ./out/linux_amd64/istioctl x add-to-mesh -h
'istioctl experimental add-to-mesh' restarts pods with an Istio sidecar or configures meshed pod access to external services.
Use 'add-to-mesh' as an alternate to namespace-wide auto injection for troubleshooting compatibility.

The 'remove-from-mesh' command can be used to restart with the sidecar removed.

THIS COMMAND IS UNDER ACTIVE DEVELOPMENT AND NOT READY FOR PRODUCTION USE.

Usage:
  istioctl experimental add-to-mesh [flags]
  istioctl experimental add-to-mesh [command]
```
