### PR TITLE
Allow setting holdApplicationUntilProxyStarts per deployment

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -385,7 +385,7 @@ data:
       {{- if .Values.global.proxy.lifecycle }}
         lifecycle:
           {{ toYaml .Values.global.proxy.lifecycle | indent 4 }}
-      {{- else if .Values.global.proxy.holdApplicationUntilProxyStarts}}
+      {{- else if eq (annotation .ObjectMeta `sidecar.istio.io/holdApplicationUntilProxyStarts` .Values.global.proxy.holdApplicationUntilProxyStarts) `true` }}
         lifecycle:
           postStart:
             exec:

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -174,7 +174,7 @@ template: |
   {{- if .Values.global.proxy.lifecycle }}
     lifecycle:
       {{ toYaml .Values.global.proxy.lifecycle | indent 4 }}
-  {{- else if .Values.global.proxy.holdApplicationUntilProxyStarts}}
+  {{- else if eq (annotation .ObjectMeta `sidecar.istio.io/holdApplicationUntilProxyStarts` .Values.global.proxy.holdApplicationUntilProxyStarts) `true` }}
     lifecycle:
       postStart:
         exec:

--- a/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -365,7 +365,7 @@ data:
       {{- if .Values.global.proxy.lifecycle }}
         lifecycle:
           {{ toYaml .Values.global.proxy.lifecycle | indent 4 }}
-      {{- else if .Values.global.proxy.holdApplicationUntilProxyStarts}}
+      {{- else if eq (annotation .ObjectMeta `sidecar.istio.io/holdApplicationUntilProxyStarts` .Values.global.proxy.holdApplicationUntilProxyStarts) `true` }}
         lifecycle:
           postStart:
             exec:

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -174,7 +174,7 @@ template: |
   {{- if .Values.global.proxy.lifecycle }}
     lifecycle:
       {{ toYaml .Values.global.proxy.lifecycle | indent 4 }}
-  {{- else if .Values.global.proxy.holdApplicationUntilProxyStarts}}
+  {{- else if eq (annotation .ObjectMeta `sidecar.istio.io/holdApplicationUntilProxyStarts` .Values.global.proxy.holdApplicationUntilProxyStarts) `true` }}
     lifecycle:
       postStart:
         exec:

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -174,7 +174,7 @@ template: |
   {{- if .Values.global.proxy.lifecycle }}
     lifecycle:
       {{ toYaml .Values.global.proxy.lifecycle | indent 4 }}
-  {{- else if .Values.global.proxy.holdApplicationUntilProxyStarts}}
+  {{- else if eq (annotation .ObjectMeta `sidecar.istio.io/holdApplicationUntilProxyStarts` .Values.global.proxy.holdApplicationUntilProxyStarts) `true` }}
     lifecycle:
       postStart:
         exec:

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/files/injection-template.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/files/injection-template.yaml
@@ -174,7 +174,7 @@ template: |
   {{- if .Values.global.proxy.lifecycle }}
     lifecycle:
       {{ toYaml .Values.global.proxy.lifecycle | indent 4 }}
-  {{- else if .Values.global.proxy.holdApplicationUntilProxyStarts}}
+  {{- else if eq (annotation .ObjectMeta `sidecar.istio.io/holdApplicationUntilProxyStarts` .Values.global.proxy.holdApplicationUntilProxyStarts) `true` }}
     lifecycle:
       postStart:
         exec:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -4998,7 +4998,7 @@ data:
       {{- if .Values.global.proxy.lifecycle }}
         lifecycle:
           {{ toYaml .Values.global.proxy.lifecycle | indent 4 }}
-      {{- else if .Values.global.proxy.holdApplicationUntilProxyStarts}}
+      {{- else if eq (annotation .ObjectMeta `sidecar.istio.io/holdApplicationUntilProxyStarts` .Values.global.proxy.holdApplicationUntilProxyStarts) `true` }}
         lifecycle:
           postStart:
             exec:

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -1398,7 +1398,7 @@ data:
       {{- if .Values.global.proxy.lifecycle }}
         lifecycle:
           {{ toYaml .Values.global.proxy.lifecycle | indent 4 }}
-      {{- else if .Values.global.proxy.holdApplicationUntilProxyStarts}}
+      {{- else if eq (annotation .ObjectMeta `sidecar.istio.io/holdApplicationUntilProxyStarts` .Values.global.proxy.holdApplicationUntilProxyStarts) `true` }}
         lifecycle:
           postStart:
             exec:


### PR DESCRIPTION
Setting could be useful to only apply to specific workloads and
not as a global setting affecting all workloads. This patch adds
support for an annotation that will allow enabling this feature
per deployment.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.