### PR TITLE
[Test Framework] Fix default for --istio.test.kube.config.

### DIFF
--- a/pkg/test/framework/components/environment/kube/flags.go
+++ b/pkg/test/framework/components/environment/kube/flags.go
@@ -279,8 +279,8 @@ func normalizeFile(path *string) error {
 
 // init registers the command-line flags that we can exposed for "go test".
 func init() {
-	flag.StringVar(&kubeConfigs, "istio.test.kube.config", strings.Join(settingsFromCommandLine.KubeConfig, ":"),
-		"A comma-separated list of paths to kube config files for cluster environments (default is current kube context)")
+	flag.StringVar(&kubeConfigs, "istio.test.kube.config", "",
+		"A comma-separated list of paths to kube config files for cluster environments.")
 	flag.BoolVar(&settingsFromCommandLine.Minikube, "istio.test.kube.minikube", settingsFromCommandLine.Minikube,
 		"Deprecated. See istio.test.kube.loadbalancer. Setting this flag will fail tests.")
 	flag.BoolVar(&settingsFromCommandLine.LoadBalancerSupported, "istio.test.kube.loadbalancer", settingsFromCommandLine.LoadBalancerSupported,


### PR DESCRIPTION
We were unnecessarily setting a default. We later on use the values from the environment as a default if this value is unset.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.