### PR TITLE
test framework: default to single network

### DIFF
--- a/pkg/test/framework/components/environment/kube/flags.go
+++ b/pkg/test/framework/components/environment/kube/flags.go
@@ -239,7 +239,10 @@ func parseConfigTopology() (clusterTopology, error) {
 
 func parseNetworkTopology(kubeConfigs []string) (map[resource.ClusterIndex]string, error) {
 	out := make(map[resource.ClusterIndex]string)
-	if networkTopology == "" {
+	if controlPlaneTopology == "" {
+		for index := range kubeConfigs {
+			out[resource.ClusterIndex(index)] = "network-0"
+		}
 		return out, nil
 	}
 	numClusters := len(kubeConfigs)


### PR DESCRIPTION
Prevents single-network multi-cluster tests from erroring with:
```
2020-09-24T22:45:17.230947Z	error	tf	Test setup error: failed generating eastwestgateway manifest for cluster-0 using "/Users/tairan/Documents/go/src/istio.io/istio/out/darwin_amd64/istioctl\n": exit status 1: The NETWORK environment variable must be set.
```
