### PR TITLE
New flag 'istioctl install --profile-from-cluster

### DIFF
--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -130,7 +130,7 @@ func runApplyCmd(cmd *cobra.Command, rootArgs *rootArgs, iArgs *installArgs, log
 	}
 	if iArgs.profileFromCluster {
 		if err := handleProfileFromCluster(iArgs); err != nil {
-			return fmt.Errorf("could load profile from cluster: %w", err)
+			return fmt.Errorf("could not load profile from cluster: %w", err)
 		}
 	}
 	if err := InstallManifests(applyFlagAliases(iArgs.set, iArgs.manifestsPath, iArgs.revision), iArgs.inFilenames, iArgs.force, rootArgs.dryRun,

--- a/operator/cmd/mesh/root.go
+++ b/operator/cmd/mesh/root.go
@@ -45,14 +45,15 @@ const (
 If set to true, the user is not prompted and a Yes response is assumed in all cases.`
 	filenameFlagHelpStr = `Path to file containing IstioOperator custom resource
 This flag can be specified multiple times to overlay multiple files. Multiple files are overlaid in left to right order.`
-	installationCompleteStr  = `Installation complete`
-	ForceFlagHelpStr         = `Proceed even with validation errors.`
-	KubeConfigFlagHelpStr    = `Path to kube config.`
-	ContextFlagHelpStr       = `The name of the kubeconfig context to use.`
-	HubFlagHelpStr           = `The hub for the operator controller image.`
-	TagFlagHelpStr           = `The tag for the operator controller image.`
-	OperatorNamespaceHelpstr = `The namespace the operator controller is installed into.`
-	ComponentFlagHelpStr     = "Specify which component to generate manifests for."
+	installationCompleteStr   = `Installation complete`
+	ForceFlagHelpStr          = `Proceed even with validation errors.`
+	KubeConfigFlagHelpStr     = `Path to kube config.`
+	ContextFlagHelpStr        = `The name of the kubeconfig context to use.`
+	HubFlagHelpStr            = `The hub for the operator controller image.`
+	TagFlagHelpStr            = `The tag for the operator controller image.`
+	OperatorNamespaceHelpstr  = `The namespace the operator controller is installed into.`
+	ComponentFlagHelpStr      = "Specify which component to generate manifests for."
+	profileFromClusterHelpStr = `Use the settings from the previous install on this cluster`
 )
 
 type rootArgs struct {

--- a/releasenotes/notes/23443.yaml
+++ b/releasenotes/notes/23443.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue:
+  - 23443
+
+releaseNotes:
+- |
+  **Added** `istioctl install` supports a new flag, --profile-from-cluster, to re-use previous install configuration.


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/23443

The implementation is trivial because I did not want to introduce a bunch of changes to the operator.

The implementation: if the user specifies `--profile-from-cluster`, the profile is fetched, stored in a temporary file, and the temporary filename is prepended the the `-f` IstioOperator filename list.