### PR TITLE
read GKE_CLUSTER_URL if set

### DIFF
--- a/security/pkg/nodeagent/plugin/providers/google/stsclient/stsclient.go
+++ b/security/pkg/nodeagent/plugin/providers/google/stsclient/stsclient.go
@@ -131,6 +131,7 @@ func constructAudience(credFetcher security.CredFetcher, trustDomain string) str
 		if GKEClusterURL != "" {
 			provider = GKEClusterURL
 		} else if platform.IsGCP() {
+			stsClientLog.Warn("GKE_CLUSTER_URL is not set, fallback to call metadata server to get identity provider")
 			provider = platform.NewGCP().Metadata()[platform.GCPClusterURL]
 		}
 	}

--- a/security/pkg/stsservice/tokenmanager/google/tokenexchangeplugin.go
+++ b/security/pkg/stsservice/tokenmanager/google/tokenexchangeplugin.go
@@ -30,6 +30,7 @@ import (
 	"istio.io/istio/pkg/security"
 	"istio.io/istio/security/pkg/stsservice"
 	"istio.io/istio/security/pkg/util"
+	"istio.io/pkg/env"
 	"istio.io/pkg/log"
 )
 
@@ -53,6 +54,8 @@ var (
 	// within this period, refresh access token.
 	defaultGracePeriod = 300
 	GCEProvider        = "GoogleComputeEngine"
+	// GKEClusterURL is the URL to send requests to the token exchange service.
+	GKEClusterURL = env.RegisterStringVar("GKE_CLUSTER_URL", "", "The url of GKE cluster").Get()
 )
 
 // Plugin supports token exchange with Google OAuth 2.0 authorization server.
@@ -165,7 +168,12 @@ func (p *Plugin) constructAudience(subjectToken string) string {
 	// For GKE, we do not register IdentityProvider explicitly. The provider name
 	// is GKEClusterURL by default.
 	if provider == "" {
-		provider = p.gkeClusterURL
+		if GKEClusterURL != "" {
+			provider = GKEClusterURL
+		} else {
+			pluginLog.Warn("GKE_CLUSTER_URL is not set, fallback to call metadata server to get identity provider")
+			provider = p.gkeClusterURL
+		}
 	}
 
 	var identityNS string


### PR DESCRIPTION
This is to keep the behavior align with stsclient. Use GKE_CLUSTER_URL as the source of truth if GKE_CLUSTER_URL is set.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.