### PR TITLE
Print cmd for istio/proxy update latest sha to istio/istio

### DIFF
--- a/bin/update_proxy.sh
+++ b/bin/update_proxy.sh
@@ -15,7 +15,12 @@
 # limitations under the License.
 
 # Update the Proxy SHA in istio.deps with the first argument
+# Exit immediately for non zero status
 set -e
+# Check unset variables
+set -u
+# Print commands
+set -x
 
 UPDATE_BRANCH=${UPDATE_BRANCH:-"master"}
 


### PR DESCRIPTION
Try to figure out how does istio/proxy update it's latest sha to istio/istio, since I've been worked on update istio/envoy sha to istio/proxy, in which they fetched the latest istio/test-infra sha not in the targeted repo 
log: https://prow.istio.io/view/gs/istio-prow/logs/update-proxy_envoy_periodic/1