### PR TITLE
Limit concurrency and request rate

### DIFF
--- a/tools/bug-report/pkg/archive/archive.go
+++ b/tools/bug-report/pkg/archive/archive.go
@@ -36,6 +36,12 @@ var (
 	initDir sync.Once
 )
 
+// ArchiveDir is the dir to archive.
+func ArchiveDir(rootDir string) string {
+	return filepath.Dir(getRootDir(rootDir))
+}
+
+// OutputRootDir is the root dir of output artifacts.
 func OutputRootDir(rootDir string) string {
 	return getRootDir(rootDir)
 }
@@ -102,7 +108,8 @@ func getRootDir(rootDir string) string {
 		return rootDir
 	}
 	initDir.Do(func() {
-		tmpDir = filepath.Join(os.TempDir(), bugReportSubdir)
+		// Extra subdir so archive extracts under new ./bug-report subdir.
+		tmpDir = filepath.Join(os.TempDir(), bugReportSubdir, bugReportSubdir)
 	})
 	return tmpDir
 }

--- a/tools/bug-report/pkg/archive/archive.go
+++ b/tools/bug-report/pkg/archive/archive.go
@@ -36,8 +36,8 @@ var (
 	initDir sync.Once
 )
 
-// ArchiveDir is the dir to archive.
-func ArchiveDir(rootDir string) string {
+// DirToArchive is the dir to archive.
+func DirToArchive(rootDir string) string {
 	return filepath.Dir(getRootDir(rootDir))
 }
 

--- a/tools/bug-report/pkg/bugreport/bugreport.go
+++ b/tools/bug-report/pkg/bugreport/bugreport.go
@@ -105,7 +105,7 @@ func runBugReportCommand(_ *cobra.Command, logOpts *log.Options) error {
 		return err
 	}
 
-	logAndPrintf("Running with the following config: \n\n%s\n\n", config)
+	common.LogAndPrintf("Running with the following config: \n\n%s\n\n", config)
 
 	clientConfig, clientset, err := kubeclient.New(config.KubeConfigPath, config.Context)
 	if err != nil {
@@ -126,7 +126,7 @@ func runBugReportCommand(_ *cobra.Command, logOpts *log.Options) error {
 		return err
 	}
 
-	logAndPrintf("Fetching proxy logs for the following containers:\n\n%s\n", strings.Join(paths, "\n"))
+	common.LogAndPrintf("Fetching proxy logs for the following containers:\n\n%s\n", strings.Join(paths, "\n"))
 
 	gatherInfo(client, config, resources, paths)
 	if len(gErrors) != 0 {
@@ -149,17 +149,17 @@ func runBugReportCommand(_ *cobra.Command, logOpts *log.Options) error {
 		outDir = "."
 	}
 	outPath := filepath.Join(outDir, "bug-report.tgz")
-	logAndPrintf("Creating archive at %s.\n", outPath)
+	common.LogAndPrintf("Creating archive at %s.\n", outPath)
 
-	tempRoot := archive.OutputRootDir(tempDir)
-	if err := archive.Create(tempRoot, outPath); err != nil {
+	archiveDir := archive.ArchiveDir(tempDir)
+	if err := archive.Create(archiveDir, outPath); err != nil {
 		return err
 	}
-	logAndPrintf("Cleaning up temporary files in %s.\n", tempRoot)
-	if err := os.RemoveAll(tempRoot); err != nil {
+	common.LogAndPrintf("Cleaning up temporary files in %s.\n", archiveDir)
+	if err := os.RemoveAll(archiveDir); err != nil {
 		return err
 	}
-	logAndPrintf("Done.\n")
+	common.LogAndPrintf("Done.\n")
 	return nil
 }
 
@@ -177,7 +177,7 @@ func gatherInfo(client kube.ExtendedClient, config *config.BugReportConfig, reso
 		Client: client,
 		DryRun: config.DryRun,
 	}
-	logAndPrintf("\nFetching Istio control plane information from cluster.\n\n")
+	common.LogAndPrintf("\nFetching Istio control plane information from cluster.\n\n")
 	getFromCluster(content.GetK8sResources, params, clusterDir, &mandatoryWg)
 	getFromCluster(content.GetCRs, params, clusterDir, &mandatoryWg)
 	getFromCluster(content.GetEvents, params, clusterDir, &mandatoryWg)
@@ -348,13 +348,6 @@ func BuildClientsFromConfig(kubeConfig []byte) (kube.Client, error) {
 		return nil, fmt.Errorf("failed to create kube clients: %v", err)
 	}
 	return clients, nil
-}
-
-func logAndPrintf(format string, a ...interface{}) {
-	fmt.Printf(format, a...)
-	o := []interface{}{format}
-	o = append(o, a...)
-	log.Infof(format, o)
 }
 
 func configLogs(opt *log.Options) error {

--- a/tools/bug-report/pkg/bugreport/bugreport.go
+++ b/tools/bug-report/pkg/bugreport/bugreport.go
@@ -151,7 +151,7 @@ func runBugReportCommand(_ *cobra.Command, logOpts *log.Options) error {
 	outPath := filepath.Join(outDir, "bug-report.tgz")
 	common.LogAndPrintf("Creating archive at %s.\n", outPath)
 
-	archiveDir := archive.ArchiveDir(tempDir)
+	archiveDir := archive.DirToArchive(tempDir)
 	if err := archive.Create(archiveDir, outPath); err != nil {
 		return err
 	}

--- a/tools/bug-report/pkg/common/common.go
+++ b/tools/bug-report/pkg/common/common.go
@@ -15,6 +15,12 @@
 // Package common contains resource names, which may vary from version to version.
 package common
 
+import (
+	"fmt"
+
+	"istio.io/pkg/log"
+)
+
 const (
 	// latestKey is an arbitrary value that represents the fallback version (master).
 	latestKey = "latest"
@@ -102,4 +108,11 @@ func getVersionKey(clusterVersion string) string {
 		return latestKey
 	}
 	return clusterVersion
+}
+
+func LogAndPrintf(format string, a ...interface{}) {
+	fmt.Printf(format, a...)
+	o := []interface{}{format}
+	o = append(o, a...)
+	log.Infof(format, o)
 }

--- a/tools/bug-report/pkg/content/content.go
+++ b/tools/bug-report/pkg/content/content.go
@@ -15,7 +15,6 @@
 package content
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -158,11 +157,11 @@ func GetProxyInfo(p *Params) (map[string]string, error) {
 	}
 	ret := make(map[string]string)
 	for _, url := range common.ProxyDebugURLs(p.ClusterVersion) {
-		out, err := p.Client.EnvoyDo(context.TODO(), p.Pod, p.Namespace, "GET", url, nil)
+		out, err := kubectlcmd.EnvoyGet(p.Client, p.Namespace, p.Pod, url, p.DryRun)
 		if err != nil {
 			return nil, err
 		}
-		ret[url] = string(out)
+		ret[url] = out
 	}
 	return ret, nil
 }

--- a/tools/bug-report/pkg/kubectlcmd/kubectlcmd.go
+++ b/tools/bug-report/pkg/kubectlcmd/kubectlcmd.go
@@ -20,12 +20,47 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
+
+	"golang.org/x/time/rate"
 
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/pkg/kube"
+	"istio.io/istio/tools/bug-report/pkg/common"
 	"istio.io/pkg/log"
 )
+
+const (
+	// maxRequestsPerSecond is the max rate of requests to the API server.
+	maxRequestsPerSecond = 10
+	// maxLogFetchConcurrency is the max number of logs to fetch simultaneously.
+	maxLogFetchConcurrency = 10
+
+	// reportInterval controls how frequently to output progress reports on running tasks.
+	reportInterval = 30 * time.Second
+)
+
+var (
+	requestLimiter  = rate.NewLimiter(maxRequestsPerSecond, maxRequestsPerSecond)
+	logFetchLimitCh = make(chan struct{}, maxLogFetchConcurrency)
+
+	// runningTasks tracks the in-flight fetch operations for user feedback.
+	runningTasks   = make(map[string]struct{})
+	runningTasksMu sync.RWMutex
+
+	// runningTasksTicker is the report interval for running tasks.
+	runningTasksTicker = time.NewTicker(reportInterval)
+)
+
+func init() {
+	go func() {
+		time.Sleep(reportInterval)
+		for range runningTasksTicker.C {
+			printRunningTasks()
+		}
+	}()
+}
 
 // Options contains the Run options.
 type Options struct {
@@ -55,7 +90,28 @@ func Logs(client kube.ExtendedClient, namespace, pod, container string, previous
 	if dryRun {
 		return fmt.Sprintf("Dry run: would be running client.PodLogs(%s, %s, %s)", pod, namespace, container), nil
 	}
+	requestLimiter.Wait(context.TODO())
+	logFetchLimitCh <- struct{}{}
+	defer func() {
+		<-logFetchLimitCh
+	}()
+	task := fmt.Sprintf("PodLogs %s/%s/%s", namespace, pod, container)
+	addRunningTask(task)
+	defer removeRunningTask(task)
 	return client.PodLogs(context.TODO(), pod, namespace, container, previous)
+}
+
+// EnvoyGet sends a GET request for the URL in the Envoy container in the given namespace/pod and returns the result.
+func EnvoyGet(client kube.ExtendedClient, namespace, pod, url string, dryRun bool) (string, error) {
+	if dryRun {
+		return fmt.Sprintf("Dry run: would be running client.EnvoyDo(%s, %s, %s)", pod, namespace, url), nil
+	}
+	requestLimiter.Wait(context.TODO())
+	task := fmt.Sprintf("ProxyGet %s/%s:%s", namespace, pod, url)
+	addRunningTask(task)
+	defer removeRunningTask(task)
+	out, err := client.EnvoyDo(context.TODO(), pod, namespace, "GET", url, nil)
+	return string(out), err
 }
 
 // Cat runs the cat command for the given path in the given namespace/pod/container.
@@ -64,7 +120,10 @@ func Cat(client kube.ExtendedClient, namespace, pod, container, path string, dry
 	if dryRun {
 		return fmt.Sprintf("Dry run: would be running podExec %s/%s/%s:%s", pod, namespace, container, cmdStr), nil
 	}
-	log.Infof("podExec %s/%s/%s:%s", namespace, pod, container, cmdStr)
+	requestLimiter.Wait(context.TODO())
+	task := fmt.Sprintf("PodExec %s/%s/%s:%s", namespace, pod, container, cmdStr)
+	addRunningTask(task)
+	defer removeRunningTask(task)
 	stdout, stderr, err := client.PodExec(pod, namespace, container, cmdStr)
 	if err != nil {
 		return "", fmt.Errorf("podExec error: %s\n\nstderr:\n%s\n\nstdout:\n%s",
@@ -78,7 +137,10 @@ func Exec(client kube.ExtendedClient, namespace, pod, container, cmdStr string, 
 	if dryRun {
 		return fmt.Sprintf("Dry run: would be running podExec %s/%s/%s:%s", pod, namespace, container, cmdStr), nil
 	}
-	log.Infof("podExec %s/%s/%s:%s", namespace, pod, container, cmdStr)
+	requestLimiter.Wait(context.TODO())
+	task := fmt.Sprintf("PodExec %s/%s/%s:%s", namespace, pod, container, cmdStr)
+	addRunningTask(task)
+	defer removeRunningTask(task)
 	stdout, stderr, err := client.PodExec(pod, namespace, container, cmdStr)
 	if err != nil {
 		return "", fmt.Errorf("podExec error: %s\n\nstderr:\n%s\n\nstdout:\n%s",
@@ -125,11 +187,41 @@ func Run(subcmds []string, opts *Options) (string, error) {
 		return "", nil
 	}
 
-	log.Infof("running command: kubectl %s", cmdStr)
+	requestLimiter.Wait(context.TODO())
+	task := fmt.Sprintf("kubectl %s", cmdStr)
+	addRunningTask(task)
+	defer removeRunningTask(task)
 	if err := cmd.Run(); err != nil {
 		return "", fmt.Errorf("kubectl error: %s\n\nstderr:\n%s\n\nstdout:\n%s",
 			err, util.ConsolidateLog(stderr.String()), stdout.String())
 	}
 
 	return stdout.String(), nil
+}
+
+func printRunningTasks() {
+	runningTasksMu.RLock()
+	defer runningTasksMu.RUnlock()
+	if len(runningTasks) == 0 {
+		return
+	}
+	common.LogAndPrintf("The following fetches are still running: \n")
+	for t := range runningTasks {
+		common.LogAndPrintf("  %s\n", t)
+	}
+	common.LogAndPrintf("\n")
+}
+
+func addRunningTask(task string) {
+	runningTasksMu.Lock()
+	defer runningTasksMu.Unlock()
+	log.Infof("STARTING %s", task)
+	runningTasks[task] = struct{}{}
+}
+
+func removeRunningTask(task string) {
+	runningTasksMu.Lock()
+	defer runningTasksMu.Unlock()
+	log.Infof("COMPLETED %s", task)
+	delete(runningTasks, task)
 }

--- a/tools/bug-report/pkg/kubectlcmd/kubectlcmd.go
+++ b/tools/bug-report/pkg/kubectlcmd/kubectlcmd.go
@@ -121,6 +121,10 @@ func Cat(client kube.ExtendedClient, namespace, pod, container, path string, dry
 		return fmt.Sprintf("Dry run: would be running podExec %s/%s/%s:%s", pod, namespace, container, cmdStr), nil
 	}
 	requestLimiter.Wait(context.TODO())
+	logFetchLimitCh <- struct{}{}
+	defer func() {
+		<-logFetchLimitCh
+	}()
 	task := fmt.Sprintf("PodExec %s/%s/%s:%s", namespace, pod, container, cmdStr)
 	addRunningTask(task)
 	defer removeRunningTask(task)

--- a/tools/bug-report/pkg/kubectlcmd/kubectlcmd.go
+++ b/tools/bug-report/pkg/kubectlcmd/kubectlcmd.go
@@ -90,7 +90,8 @@ func Logs(client kube.ExtendedClient, namespace, pod, container string, previous
 	if dryRun {
 		return fmt.Sprintf("Dry run: would be running client.PodLogs(%s, %s, %s)", pod, namespace, container), nil
 	}
-	requestLimiter.Wait(context.TODO())
+	// ignore cancellation errors since this is subject to global timeout.
+	_ = requestLimiter.Wait(context.TODO())
 	logFetchLimitCh <- struct{}{}
 	defer func() {
 		<-logFetchLimitCh
@@ -106,7 +107,7 @@ func EnvoyGet(client kube.ExtendedClient, namespace, pod, url string, dryRun boo
 	if dryRun {
 		return fmt.Sprintf("Dry run: would be running client.EnvoyDo(%s, %s, %s)", pod, namespace, url), nil
 	}
-	requestLimiter.Wait(context.TODO())
+	_ = requestLimiter.Wait(context.TODO())
 	task := fmt.Sprintf("ProxyGet %s/%s:%s", namespace, pod, url)
 	addRunningTask(task)
 	defer removeRunningTask(task)
@@ -120,7 +121,7 @@ func Cat(client kube.ExtendedClient, namespace, pod, container, path string, dry
 	if dryRun {
 		return fmt.Sprintf("Dry run: would be running podExec %s/%s/%s:%s", pod, namespace, container, cmdStr), nil
 	}
-	requestLimiter.Wait(context.TODO())
+	_ = requestLimiter.Wait(context.TODO())
 	logFetchLimitCh <- struct{}{}
 	defer func() {
 		<-logFetchLimitCh
@@ -141,7 +142,7 @@ func Exec(client kube.ExtendedClient, namespace, pod, container, cmdStr string, 
 	if dryRun {
 		return fmt.Sprintf("Dry run: would be running podExec %s/%s/%s:%s", pod, namespace, container, cmdStr), nil
 	}
-	requestLimiter.Wait(context.TODO())
+	_ = requestLimiter.Wait(context.TODO())
 	task := fmt.Sprintf("PodExec %s/%s/%s:%s", namespace, pod, container, cmdStr)
 	addRunningTask(task)
 	defer removeRunningTask(task)
@@ -191,7 +192,7 @@ func Run(subcmds []string, opts *Options) (string, error) {
 		return "", nil
 	}
 
-	requestLimiter.Wait(context.TODO())
+	_ = requestLimiter.Wait(context.TODO())
 	task := fmt.Sprintf("kubectl %s", cmdStr)
 	addRunningTask(task)
 	defer removeRunningTask(task)


### PR DESCRIPTION
Logs are returned through the API server and because bug-report is fully parallel it would be hammered for large clusters. This change both rate limits the rate of API server requests and the number of parallel log fetches (since these can be long running).
The PR also adds a small UX improvement - the still running fetch commands are displayed periodically so user gets some feedback if things are taking a long time. 

e.g. 

The following fetches are still running: 
```
    PodExec istio-system/istiod-version-16-85d45b4dc4-mss5f/discovery:pilot-discovery request GET debug/adsz
    kubectl get --all-namespaces all,jobs,ingresses,endpoints,customresourcedefinitions,configmaps,events -o yaml
    ProxyGet default/reviews-v1-564b97f875-fj45d:certs
    kubectl cluster-info dump
```