### PR TITLE
Wait to send more pushes until receive has ACKed

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -141,7 +141,7 @@ var (
 		"The type of the credential fetcher. Currently supported types include GoogleComputeEngine").Get()
 	credIdentityProvider = env.RegisterStringVar("CREDENTIAL_IDENTITY_PROVIDER", "GoogleComputeEngine",
 		"The identity provider for credential. Currently default supported identity provider is GoogleComputeEngine").Get()
-	proxyXDSViaAgent = env.RegisterBoolVar("PROXY_XDS_VIA_AGENT", true,
+	proxyXDSViaAgent = env.RegisterBoolVar("PROXY_XDS_VIA_AGENT", false,
 		"If set to true, envoy will proxy XDS calls via the agent instead of directly connecting to istiod. This option "+
 			"will be removed once the feature is stabilized.").Get()
 	// This is a copy of the env var in the init code.

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -305,10 +305,10 @@ var (
 	EnableFlowControl = env.RegisterBoolVar(
 		"PILOT_ENABLE_FLOW_CONTROL",
 		false,
-		"If enabled, pilot will wait for the completion of a receive operation before" +
-		"executing a push operation. This is a form of flow control and is useful in" +
-		"environments with high rates of push requests to each gateway. By default," +
-		"this is false.").Get()
+		"If enabled, pilot will wait for the completion of a receive operation before"+
+			"executing a push operation. This is a form of flow control and is useful in"+
+			"environments with high rates of push requests to each gateway. By default,"+
+			"this is false.").Get()
 
 	// CentralIstioD will be Deprecated: TODO remove in 1.9 in favor of `ExternalIstioD`
 	CentralIstioD = env.RegisterBoolVar("CENTRAL_ISTIOD", false,

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -304,7 +304,7 @@ var (
 
 	EnableFlowControl = env.RegisterBoolVar(
 		"PILOT_ENABLE_FLOW_CONTROL",
-		false,
+		true,
 		"If enabled, pilot will wait for the completion of a receive operation before"+
 			"executing a push operation. This is a form of flow control and is useful in"+
 			"environments with high rates of push requests to each gateway. By default,"+

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -301,6 +301,15 @@ var (
 		"If enabled, pilot will set the incremental flag of the options in the mcp controller "+
 			"to true, and then galley may push data incrementally, it depends on whether the "+
 			"resource supports incremental. By default, this is false.").Get()
+
+	EnableFlowControl = env.RegisterBoolVar(
+		"PILOT_ENABLE_FLOW_CONTROL",
+		false,
+		"If enabled, pilot will wait for the completion of a receive operation before" +
+		"executing a push operation. This is a form of flow control and is useful in" +
+		"environments with high rates of push requests to each gateway. By default," +
+		"this is false.").Get()
+
 	// CentralIstioD will be Deprecated: TODO remove in 1.9 in favor of `ExternalIstioD`
 	CentralIstioD = env.RegisterBoolVar("CENTRAL_ISTIOD", false,
 		"If this is set to true, one Istiod will control remote clusters including CA.").Get()

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -770,9 +770,9 @@ func (conn *Connection) send(res *discovery.DiscoveryResponse) error {
 
 		// I don't think this iterative map delete is safe.
 		for k := range conn.semmap {
-			adsLog.Infof("sem Release %v", k)
+			//		adsLog.Infof("sem Release %v", k)
 			conn.semmap[k] <- struct{}{}
-			adsLog.Infof("sem Release Done %v", k)
+			//			adsLog.Infof("sem Release Done %v", k)
 			close(conn.semmap[k])
 			delete(conn.semmap, k)
 		}
@@ -789,9 +789,9 @@ func (conn *Connection) send(res *discovery.DiscoveryResponse) error {
 		errChan <- conn.stream.Send(res)
 		if features.EnableFlowControl {
 			// Flow control - Acquire a semaphore - locking this thread for sendTimeout.
-			adsLog.Infof("sem Acquire %v", curResource)
+			//			adsLog.Infof("sem Acquire %v", curResource)
 			<-conn.semmap[curResource]
-			adsLog.Infof("sem Done Acquire %v", curResource)
+			//			adsLog.Infof("sem Done Acquire %v", curResource)
 		}
 		close(errChan)
 	}()

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -223,6 +223,7 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream discovery.AggregatedD
 		return err
 	}
 	con := newConnection(peerAddr, stream)
+
 	con.Identities = ids
 
 	// Do not call: defer close(con.pushChannel). The push channel will be garbage collected
@@ -766,7 +767,6 @@ func (conn *Connection) send(res *discovery.DiscoveryResponse) error {
 
 	select {
 	case <-t.C:
-		// TODO: wait for ACK
 		adsLog.Infof("Timeout writing %s", conn.ConID)
 		xdsResponseWriteTimeouts.Increment()
 		return status.Errorf(codes.DeadlineExceeded, "timeout sending")

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -62,7 +62,7 @@ const (
 	defaultClientMaxReceiveMessageSize = math.MaxInt32
 	defaultInitialConnWindowSize       = 1024 * 1024            // default gRPC InitialWindowSize
 	defaultInitialWindowSize           = 1024 * 1024            // default gRPC ConnWindowSize
-	sendTimeout                        = 5 * time.Second        // default upstream send timeout.
+	sendTimeout                        = 35 * time.Second       // default upstream send timeout.
 	watchDebounceDelay                 = 100 * time.Millisecond // file watcher event debounce delay.
 )
 


### PR DESCRIPTION
Fixes: https://github.com/istio/istio/issues/25685

Istio suffers from a problem at large scale (800+ services sequentially
created) with significant churn that Envoy becomes overloaded and
produces a zigzaw pattern in acking results. This slows Istio down by
using a semaphore to signal when a receive has occured and wait for the
semaphore prior to new pushes.

Co-Authored-By: John Howard <howardjohn@google.com>

Depends-On: https://github.com/istio/istio/pull/27768