### PR TITLE
Create revision based gateways

### DIFF
--- a/manifests/charts/gateways/istio-egress/values.yaml
+++ b/manifests/charts/gateways/istio-egress/values.yaml
@@ -102,7 +102,10 @@ gateways:
     podAntiAffinityTermLabelSelector: []
 
     # whether to run the gateway in a privileged container
-    runAsRoot: false
+    # At this time, because of several crash related issues, the Istio community strongly recommends
+    # running the gateway as root. See:
+    # https://github.com/istio/istio/issues/27566 and https://github.com/istio/istio/issues/26690
+    runAsRoot: true
 
 # Revision is set as 'version' label and part of the resource names when installing multiple control planes.
 revision: ""

--- a/manifests/charts/gateways/istio-ingress/templates/autoscale.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/autoscale.yaml
@@ -1,5 +1,5 @@
 {{ $gateway := index .Values "gateways" "istio-ingressgateway" }}
-{{- if and $gateway.autoscaleEnabled $gateway.autoscaleMin $gateway.autoscaleMax }}
+{{- if and $gateway.autoscaleEnabled $gateway.autoscaleMin $gateway.autoscaleMax $gateway.revisionDeployment }}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -1,4 +1,5 @@
 {{- $gateway := index .Values "gateways" "istio-ingressgateway" }}
+{{- if $gateway.revisionDeployment }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -46,13 +47,16 @@ spec:
 {{ toYaml $gateway.podAnnotations | indent 8 }}
 {{ end }}
     spec:
-{{- if not $gateway.runAsRoot }}
       securityContext:
-        runAsUser: 1337
         runAsGroup: 1337
-        runAsNonRoot: true
         fsGroup: 1337
-{{- end }}
+      {{- if $gateway.runAsRoot }}
+        runAsUser: 0
+        runAsNonRoot: false
+      {{- else }}
+        runAsUser: 1337
+        runAsNonRoot: true
+      {{- end }}
       serviceAccountName: {{ $gateway.name | default "istio-ingressgateway" }}-service-account
 {{- if .Values.global.priorityClassName }}
       priorityClassName: "{{ .Values.global.priorityClassName }}"
@@ -74,9 +78,18 @@ spec:
             - -c
             - sysctl -w kernel.core_pattern=/var/lib/istio/data/core.proxy && ulimit -c unlimited
           securityContext:
+          {{- if $gateway.runAsRoot }}
             runAsUser: 0
-            runAsGroup: 0
             runAsNonRoot: false
+          {{- else }}
+            runAsUser: 1337
+            runAsNonRoot: true
+          {{- end }}
+            runAsGroup: 0
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             privileged: true
 {{- end }}
       containers:
@@ -126,15 +139,20 @@ spec:
         {{- if .Values.global.trustDomain }}
           - --trust-domain={{ .Values.global.trustDomain }}
         {{- end }}
-        {{- if not $gateway.runAsRoot }}
           securityContext:
+          {{- if $gateway.runAsRoot }}
+            runAsUser: 0
+            runAsNonRoot: false
+          {{- else }}
+            runAsUser: 1337
+            runAsNonRoot: true
+          {{- end }}
             allowPrivilegeEscalation: false
             capabilities:
               drop:
               - ALL
             privileged: false
             readOnlyRootFilesystem: true
-        {{- end }}
           readinessProbe:
             failureThreshold: 30
             httpGet:
@@ -333,4 +351,5 @@ spec:
 {{- else if .Values.global.defaultTolerations }}
       tolerations:
 {{ toYaml .Values.global.defaultTolerations | indent 6 }}
+{{- end }}
 {{- end }}

--- a/manifests/charts/gateways/istio-ingress/templates/poddisruptionbudget.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.global.defaultPodDisruptionBudget.enabled }}
 {{ $gateway := index .Values "gateways" "istio-ingressgateway" }}
+{{- if and .Values.global.defaultPodDisruptionBudget.enabled $gateway.revisionDeployment }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/manifests/charts/gateways/istio-ingress/templates/role.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/role.yaml
@@ -1,4 +1,5 @@
 {{ $gateway := index .Values "gateways" "istio-ingressgateway" }}
+{{- if $gateway.revisionDeployment }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -10,4 +11,4 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["get", "watch", "list"]
----
+{{- end }}

--- a/manifests/charts/gateways/istio-ingress/templates/rolebindings.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/rolebindings.yaml
@@ -1,4 +1,5 @@
 {{ $gateway := index .Values "gateways" "istio-ingressgateway" }}
+{{- if $gateway.revisionDeployment }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -13,4 +14,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ $gateway.name | default "istio-ingressgateway" }}-service-account
----
+{{- end }}

--- a/manifests/charts/gateways/istio-ingress/templates/service.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/service.yaml
@@ -1,5 +1,5 @@
 {{ $gateway := index .Values "gateways" "istio-ingressgateway" }}
-{{- if not $gateway.customService }}
+{{- if or (eq $gateway.customService true) (eq $gateway.revisionService true) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -48,5 +48,4 @@ spec:
       port: {{ $app.port }}
       name: {{ $app.name }}
   {{- end }}
----
 {{ end }}

--- a/manifests/charts/gateways/istio-ingress/templates/serviceaccount.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/serviceaccount.yaml
@@ -1,4 +1,5 @@
 {{ $gateway := index .Values "gateways" "istio-ingressgateway" }}
+{{- if $gateway.revisionDeployment }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.global.imagePullSecrets }}
@@ -13,3 +14,4 @@ metadata:
   labels:
 {{ $gateway.labels | toYaml | trim | indent 4 }}
     release: {{ .Release.Name }}
+{{- end }}

--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -7,6 +7,7 @@ gateways:
     labels:
       app: istio-ingressgateway
       istio: ingressgateway
+      istio.io/rev: latest
     ports:
     ## You can add custom gateway ports in user values overrides, but it must include those ports since helm replaces.
     # Note that AWS ELB will by default perform health checks on the first port
@@ -87,6 +88,8 @@ gateways:
       mountPath: /etc/istio/ingressgateway-ca-certs
 
     customService: false
+    revisionService: true
+    revisionDeployment: true
     externalTrafficPolicy: ""
 
     ingressPorts: []

--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -125,7 +125,10 @@ gateways:
     podAntiAffinityTermLabelSelector: []
 
     # whether to run the gateway in a privileged container
-    runAsRoot: false
+    # At this time, because of several crash related issues, the Istio community strongly recommends
+    # running the gateway as root. See:
+    # https://github.com/istio/istio/issues/27566 and https://github.com/istio/istio/issues/26690
+    runAsRoot: true
 
 # Revision is set as 'version' label and part of the resource names when installing multiple control planes.
 revision: ""


### PR DESCRIPTION
How this is used:

Assume I break out the <1024 port problem

1. During initial deployment: If gateway.deployService is true -service will be deployed with a label of istio.io/rev: revision and a selector of the same. If a gateway.deployGateway is true - a gateway deployment and all its requirements will be deployed wit ha label of istio.io/rev: revision and a selector of the same.
1. User wishes to deploy a canary revision: Set gateway.deployService to false and set a new revision for the gateway. This will deploy only a gateway deployment that is not selected by any service type load balancer. The gateway is a new version of envoy, but has no service associated with it.
1. Uise new gateway: the label for the service is modified - in place. The IP of the service does not change because it is not deleted and created.

Finally:
the label selects the new gateway - running a new dataplane envoy version.

Depends-On: https://github.com/istio/istio/pull/27403