### PR TITLE
Use revision for validatingwebhookconfiguration

### DIFF
--- a/manifests/charts/base/templates/validatingwebhookconfiguration.yaml
+++ b/manifests/charts/base/templates/validatingwebhookconfiguration.yaml
@@ -14,7 +14,7 @@ webhooks:
       url: {{ .Values.base.validationURL }}
       {{- else }}
       service:
-        name: istiod
+        name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
         namespace: {{ .Values.global.istioNamespace }}
         path: "/validate"
       {{- end }}

--- a/manifests/charts/base/values.yaml
+++ b/manifests/charts/base/values.yaml
@@ -23,3 +23,6 @@ base:
 
   # For istioctl usage to disable istio config crds in base
   enableIstioConfigCRDs: true
+
+# Revision is set as 'version' label and part of the resource names when installing multiple control planes.
+revision: ""

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/base/templates/validatingwebhookconfiguration.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/base/templates/validatingwebhookconfiguration.yaml
@@ -14,7 +14,7 @@ webhooks:
       url: {{ .Values.base.validationURL }}
       {{- else }}
       service:
-        name: istiod
+        name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
         namespace: {{ .Values.global.istioNamespace }}
         path: "/validate"
       {{- end }}

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/base/values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/base/values.yaml
@@ -23,3 +23,6 @@ base:
 
   # For istioctl usage to disable istio config crds in base
   enableIstioConfigCRDs: true
+
+# Revision is set as 'version' label and part of the resource names when installing multiple control planes.
+revision: ""


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/27501

Before
```
[istio-1.7.2]$ ./bin/istioctl install --set revision=1-7-2
✔ Istio core installed                                                                                                               
✔ Istiod installed                                                                                                                   
✔ Ingress gateways installed                                                                                                         
✔ Installation complete

$ kubectl logs istiod-1-7-2-6875d8d57f-gr59x -n istio-system

2020-09-28T08:06:58.895004Z     info    validationController    validatingwebhookconfiguration istiod-istio-system (failurePolicy=Ignore, resourceVersion=116583) is up-to-date. No change required.
2020-09-28T08:06:58.895036Z     info    validationController    Reconcile(enter): retry dry-run creation of invalid config
2020-09-28T08:06:59.916203Z     info    validationController    Not ready to switch validation to fail-closed: dummy invalid config not rejected
2020-09-28T08:06:59.917029Z     info    validationController    validatingwebhookconfiguration istiod-istio-system (failurePolicy=Ignore, resourceVersion=116583) is up-to-date. No change required.
2020-09-28T08:06:59.917064Z     info    validationController    Reconcile(enter): retry dry-run creation of invalid config
2020-09-28T08:07:00.938849Z     info    validationController    Not ready to switch validation to fail-closed: dummy invalid config not rejected
2020-09-28T08:07:00.939272Z     info    validationController    validatingwebhookconfiguration istiod-istio-system (failurePolicy=Ignore, resourceVersion=116583) is up-to-date. No change required.
2020-09-28T08:07:00.939287Z     info    validationController    Reconcile(enter): retry dry-run creation of invalid config
2020-09-28T08:07:01.969251Z     info    validationController    Not ready to switch validation to fail-closed: dummy invalid config not rejected
2020-09-28T08:07:01.969988Z     info    validationController    validatingwebhookconfiguration istiod-istio-system (failurePolicy=Ignore, resourceVersion=116583) is up-to-date. No change required.
2020-09-28T08:07:01.970083Z     info    validationController    Reconcile(enter): retry dry-run creation of invalid config
2020-09-28T08:07:02.991563Z     info    validationController    Not ready to switch validation to fail-closed: dummy invalid config not rejected
2020-09-28T08:07:02.993862Z     info    validationController    validatingwebhookconfiguration istiod-istio-system (failurePolicy=Ignore, resourceVersion=116583) is up-to-date. No change required.
2020-09-28T08:07:02.994506Z     info    validationController    Reconcile(enter): retry dry-run creation of invalid config
2020-09-28T08:07:04.125367Z     info    validationController    Not ready to switch validation to fail-closed: dummy invalid config not rejected
2020-09-28T08:07:04.126248Z     info    validationController    validatingwebhookconfiguration istiod-istio-system (failurePolicy=Ignore, resourceVersion=116583) is up-to-date. No change required.
```

After:

```
$ ./out/linux_amd64/istioctl install --set hub=gcr.io/istio-testing --set revision=1-8-dev -d manifests/

$ kubectl get pods -n istio-system
NAME                                    READY   STATUS    RESTARTS   AGE
istio-ingressgateway-5c846977bb-48jmh   1/1     Running   0          20s
istiod-1-7-2-6875d8d57f-gr59x           1/1     Running   0          20m
istiod-1-8-dev-6f569c59c-wv5rf          1/1     Running   0          25s
istiod-6fc8557fbc-8n4wc                 0/1     Running   2          4d
```
```
$ kubectl logs -n istio-system istiod-1-8-dev-6f569c59c-wv5rf

No logs for validatingwebhookconfiguration
```