### PR TITLE
Remove multicluster flag

### DIFF
--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -34,7 +34,7 @@ endif
 
 _INTEGRATION_TEST_SELECT_FLAGS ?= --istio.test.select=$(TEST_SELECT)
 ifeq ($(TEST_SELECT),)
-    _INTEGRATION_TEST_SELECT_FLAGS = --istio.test.select=-postsubmit,-flaky,-multicluster
+    _INTEGRATION_TEST_SELECT_FLAGS = --istio.test.select=-postsubmit,-flaky
 endif
 
 # $(INTEGRATION_TEST_KUBECONFIG) overrides all kube config settings.


### PR DESCRIPTION
This is handled by RequireSingleCluster. Adding this causes our k8s
version tests  to skip almost all versions



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.