### PR TITLE
Minor UX fixes to bug-report

### DIFF
--- a/tools/bug-report/pkg/bugreport/bugreport.go
+++ b/tools/bug-report/pkg/bugreport/bugreport.go
@@ -110,6 +110,12 @@ func runBugReportCommand(_ *cobra.Command, logOpts *log.Options) error {
 		return err
 	}
 
+	clusterCtxStr, err := content.GetClusterContext()
+	if err != nil {
+		return err
+	}
+
+	common.LogAndPrintf("\nTarget cluster context: %s\n", clusterCtxStr)
 	common.LogAndPrintf("Running with the following config: \n\n%s\n\n", config)
 
 	clientConfig, clientset, err := kubeclient.New(config.KubeConfigPath, config.Context)

--- a/tools/bug-report/pkg/cluster/cluster.go
+++ b/tools/bug-report/pkg/cluster/cluster.go
@@ -194,7 +194,6 @@ func getOwnerDeployment(pod *corev1.Pod, replicasets []v1.ReplicaSet) string {
 			}
 		}
 	}
-	log.Infof("no owning Deployment found for pod %s", pod.Name)
 	return ""
 }
 

--- a/tools/bug-report/pkg/content/content.go
+++ b/tools/bug-report/pkg/content/content.go
@@ -130,8 +130,13 @@ func GetCRs(p *Params) (map[string]string, error) {
 
 // GetClusterInfo returns the cluster info.
 func GetClusterInfo(p *Params) (map[string]string, error) {
-	out, err := kubectlcmd.RunCmd("cluster-info dump", "", p.DryRun)
-	return retMap("cluster-info", out, err)
+	out, err := kubectlcmd.RunCmd("config current-context", "", p.DryRun)
+	return retMap("cluster-context", out, err)
+}
+
+// GetClusterContext returns the cluster context.
+func GetClusterContext() (string, error) {
+	return kubectlcmd.RunCmd("config current-context", "", false)
 }
 
 // GetDescribePods returns describe pods for istioNamespace.

--- a/tools/bug-report/pkg/content/content.go
+++ b/tools/bug-report/pkg/content/content.go
@@ -131,7 +131,17 @@ func GetCRs(p *Params) (map[string]string, error) {
 // GetClusterInfo returns the cluster info.
 func GetClusterInfo(p *Params) (map[string]string, error) {
 	out, err := kubectlcmd.RunCmd("config current-context", "", p.DryRun)
-	return retMap("cluster-context", out, err)
+	if err != nil {
+		return nil, err
+	}
+	ret := make(map[string]string)
+	ret["cluster-context"] = out
+	out, err = kubectlcmd.RunCmd("version", "", p.DryRun)
+	if err != nil {
+		return nil, err
+	}
+	ret["kubectl-version"] = out
+	return ret, nil
 }
 
 // GetClusterContext returns the cluster context.


### PR DESCRIPTION
- replace "cluster-info dump" with "config current-context" and display this in the logs and CLI
- remove noisy log about missing owning deployment
