### PR TITLE
fix cluster vip resolution for multi-cluster

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -969,6 +969,8 @@ func (ps *PushContext) updateContext(
 	} else {
 		ps.ServiceIndex = oldPushContext.ServiceIndex
 		ps.ServiceAccounts = oldPushContext.ServiceAccounts
+		// TODO should this be a deep copy, or is the old push context discarded?
+		ps.ClusterVIPs = oldPushContext.ClusterVIPs
 	}
 
 	if virtualServicesChanged {

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -587,7 +587,8 @@ func (s *Service) GetServiceAddressForProxy(node *Proxy, push *PushContext) stri
 		return push.ClusterVIPs[s][node.Metadata.ClusterID]
 	} else if node.Metadata != nil && node.Metadata.ClusterID != "" {
 		if len(push.ClusterVIPs) == 0 {
-			log.Warnf("cluster vips for %s: %v", s, push.ClusterVIPs[s])
+			log.Warnf("key cluster vips for %s: %v", s.Hostname, s.ClusterVIPs)
+			log.Warnf("cached cluster vips for %s: %v", s.Hostname, push.ClusterVIPs[s])
 		}
 	}
 	if node.Metadata != nil && node.Metadata.DNSCapture != "" &&

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -580,8 +580,15 @@ func ParseSubsetKey(s string) (direction TrafficDirection, subsetName string, ho
 
 // GetServiceAddressForProxy returns a Service's IP address specific to the cluster where the node resides
 func (s *Service) GetServiceAddressForProxy(node *Proxy, push *PushContext) string {
+	if len(push.ClusterVIPs) == 0 {
+		log.Warnf("push context has empty ClusterVIPs cache")
+	}
 	if node.Metadata != nil && node.Metadata.ClusterID != "" && push.ClusterVIPs[s][node.Metadata.ClusterID] != "" {
 		return push.ClusterVIPs[s][node.Metadata.ClusterID]
+	} else if node.Metadata != nil && node.Metadata.ClusterID != "" {
+		if len(push.ClusterVIPs) == 0 {
+			log.Warnf("cluster vips for %s: %v", s, push.ClusterVIPs[s])
+		}
 	}
 	if node.Metadata != nil && node.Metadata.DNSCapture != "" &&
 		s.Address == constants.UnspecifiedIP && s.AutoAllocatedAddress != "" {

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -580,16 +580,8 @@ func ParseSubsetKey(s string) (direction TrafficDirection, subsetName string, ho
 
 // GetServiceAddressForProxy returns a Service's IP address specific to the cluster where the node resides
 func (s *Service) GetServiceAddressForProxy(node *Proxy, push *PushContext) string {
-	if len(push.ClusterVIPs) == 0 {
-		log.Warnf("push context has empty ClusterVIPs cache")
-	}
 	if node.Metadata != nil && node.Metadata.ClusterID != "" && push.ClusterVIPs[s][node.Metadata.ClusterID] != "" {
 		return push.ClusterVIPs[s][node.Metadata.ClusterID]
-	} else if node.Metadata != nil && node.Metadata.ClusterID != "" {
-		if len(push.ClusterVIPs) == 0 {
-			log.Warnf("key cluster vips for %s: %v", s.Hostname, s.ClusterVIPs)
-			log.Warnf("cached cluster vips for %s: %v", s.Hostname, push.ClusterVIPs[s])
-		}
 	}
 	if node.Metadata != nil && node.Metadata.DNSCapture != "" &&
 		s.Address == constants.UnspecifiedIP && s.AutoAllocatedAddress != "" {

--- a/tests/integration/pilot/endpointslice/endpointslice_test.go
+++ b/tests/integration/pilot/endpointslice/endpointslice_test.go
@@ -36,9 +36,6 @@ var (
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
-		// EndpointSlice is not enabled by default on older clusters
-		// TODO fix cluster vip issue - fails endpoint slice with multi-cluster
-		RequireSingleCluster().
 		RequireEnvironmentVersion("1.17").
 		Setup(istio.Setup(&i, func(ctx resource.Context, cfg *istio.Config) {
 			cfg.ControlPlaneValues = `


### PR DESCRIPTION
Caching the cluster VIPs only happens when we initServiceRegistry in the push context. We skip that if no services were changed. In that case, we need copy the cluster vip cache from the previous push context. 