### PR TITLE
Fix ingress status update bug (istio#27523)

### DIFF
--- a/pilot/pkg/config/kube/ingress/status.go
+++ b/pilot/pkg/config/kube/ingress/status.go
@@ -139,7 +139,7 @@ func (s *StatusSyncer) updateStatus(status []coreV1.LoadBalancerIngress) error {
 
 		if ingressSliceEqual(status, curIPs) {
 			log.Debugf("skipping update of Ingress %v/%v (no change)", currIng.Namespace, currIng.Name)
-			return nil
+			continue
 		}
 
 		currIng.Status.LoadBalancer.Ingress = status


### PR DESCRIPTION
Don't stop processing ingress status updates just because a record is found that doesn't need to be updated, as there may be records later in the list that do need to be updated.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.