### PR TITLE
Support TargetPort for DNS Service Entry

### DIFF
--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -305,10 +305,14 @@ func convertServiceEntryToInstances(cfg config.Config, services []*model.Service
 				// we create endpoints from service's host
 				// Do not use serviceentry.hosts as a service entry is converted into
 				// multiple services (one for each host)
+				endpointPort := serviceEntryPort.Number
+				if serviceEntryPort.TargetPort > 0 {
+					endpointPort = serviceEntryPort.TargetPort
+				}
 				out = append(out, &model.ServiceInstance{
 					Endpoint: &model.IstioEndpoint{
 						Address:         string(service.Hostname),
-						EndpointPort:    serviceEntryPort.Number,
+						EndpointPort:    endpointPort,
 						ServicePortName: serviceEntryPort.Name,
 						Labels:          nil,
 						TLSMode:         model.DisabledTLSModeLabel,

--- a/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
@@ -149,6 +149,23 @@ var httpDNSnoEndpoints = &config.Config{
 	},
 }
 
+var dnsTargetPort = &config.Config{
+	Meta: config.Meta{
+		GroupVersionKind:  gvk.ServiceEntry,
+		Name:              "dnsTargetPort",
+		Namespace:         "dnsTargetPort",
+		CreationTimestamp: GlobalTime,
+	},
+	Spec: &networking.ServiceEntry{
+		Hosts: []string{"google.com"},
+		Ports: []*networking.Port{
+			{Number: 80, Name: "http-port", Protocol: "http", TargetPort: 8080},
+		},
+		Location:   networking.ServiceEntry_MESH_EXTERNAL,
+		Resolution: networking.ServiceEntry_DNS,
+	},
+}
+
 var httpDNS = &config.Config{
 	Meta: config.Meta{
 		GroupVersionKind:  gvk.ServiceEntry,
@@ -537,6 +554,13 @@ func TestConvertService(t *testing.T) {
 			},
 		},
 		{
+			// service entry dns with target port
+			externalSvc: dnsTargetPort,
+			services: []*model.Service{makeService("google.com", "dnsTargetPort", constants.UnspecifiedIP,
+				map[string]int{"http-port": 80}, true, model.DNSLB),
+			},
+		},
+		{
 			// service entry tcp DNS
 			externalSvc: tcpDNS,
 			services: []*model.Service{makeService("tcpdns.com", "tcpDNS", constants.UnspecifiedIP,
@@ -654,6 +678,13 @@ func TestConvertInstances(t *testing.T) {
 				makeInstance(httpDNS, "uk.google.com", 8080, httpDNS.Spec.(*networking.ServiceEntry).Ports[1], nil, MTLS),
 				makeInstance(httpDNS, "de.google.com", 80, httpDNS.Spec.(*networking.ServiceEntry).Ports[0], map[string]string{"foo": "bar"}, MTLS),
 				makeInstance(httpDNS, "de.google.com", 8080, httpDNS.Spec.(*networking.ServiceEntry).Ports[1], map[string]string{"foo": "bar"}, MTLS),
+			},
+		},
+		{
+			// service entry dns with target port
+			externalSvc: dnsTargetPort,
+			out: []*model.ServiceInstance{
+				makeInstance(dnsTargetPort, "google.com", 8080, dnsTargetPort.Spec.(*networking.ServiceEntry).Ports[0], nil, PlainText),
 			},
 		},
 		{


### PR DESCRIPTION
Aside from consistency/completeness, this is really useful for TLS
origination. Rather than modifying apps (to switch port from 80 to 443,
but stay plaintext, which is weird), we can transparently add tls
origination like:

```yaml
apiVersion: networking.istio.io/v1beta1
kind: ServiceEntry
metadata:
  name: httpbin
spec:
  hosts:
  - httpbin.org
  ports:
  - number: 80
    name: http
    protocol: HTTP
    targetPort: 443
  resolution: DNS
---
apiVersion: networking.istio.io/v1beta1
kind: DestinationRule
metadata:
  name: originate-tls
spec:
  host: httpbin.org
  trafficPolicy:
    tls:
      mode: SIMPLE
```



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.