### PR TITLE
Add multicluster support for Gateway SDS

### DIFF
--- a/pilot/pkg/secrets/kube/multicluster.go
+++ b/pilot/pkg/secrets/kube/multicluster.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package kube
 
 import (

--- a/pilot/pkg/secrets/kube/multicluster.go
+++ b/pilot/pkg/secrets/kube/multicluster.go
@@ -1,0 +1,109 @@
+package kube
+
+import (
+	"fmt"
+	"sync"
+
+	"istio.io/istio/pilot/pkg/secrets"
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/secretcontroller"
+	"istio.io/pkg/log"
+)
+
+// Multicluster structure holds the remote kube Controllers and multicluster specific attributes.
+type Multicluster struct {
+	remoteKubeControllers map[string]*SecretsController
+	m                     sync.Mutex // protects remoteKubeControllers
+	secretController      *secretcontroller.Controller
+	localCluster          string
+}
+
+var _ secrets.Controller = &Multicluster{}
+
+func NewMulticluster(client kube.Client, localClusterId, secretNamespace string) *Multicluster {
+	m := &Multicluster{
+		remoteKubeControllers: map[string]*SecretsController{},
+		localCluster:          localClusterId,
+	}
+	// Add the local cluster
+	if err := m.AddMemberCluster(client, localClusterId); err != nil {
+		return nil
+	}
+	sc := secretcontroller.StartSecretController(client,
+		m.AddMemberCluster,
+		m.UpdateMemberCluster,
+		m.DeleteMemberCluster,
+		secretNamespace)
+	m.secretController = sc
+	return m
+}
+
+func (m *Multicluster) AddMemberCluster(clients kube.Client, key string) error {
+	stopCh := make(chan struct{})
+	log.Infof("initializing Kubernetes credential reader for cluster %v", key)
+	sc := NewSecretsController(clients, key)
+	m.m.Lock()
+	m.remoteKubeControllers[key] = sc
+	m.m.Unlock()
+	clients.RunAndWait(stopCh)
+	return nil
+}
+
+func (m *Multicluster) UpdateMemberCluster(clients kube.Client, key string) error {
+	if err := m.DeleteMemberCluster(key); err != nil {
+		return err
+	}
+	return m.AddMemberCluster(clients, key)
+}
+
+func (m *Multicluster) DeleteMemberCluster(key string) error {
+	m.m.Lock()
+	delete(m.remoteKubeControllers, key)
+	m.m.Unlock()
+	return nil
+}
+
+func (m *Multicluster) GetKeyAndCert(name, namespace string) (key []byte, cert []byte) {
+	// Prefer local cluster
+	if lk, lc := m.remoteKubeControllers[m.localCluster].GetKeyAndCert(name, namespace); lk != nil && lc != nil {
+		return lk, lc
+	}
+	// Search through all clusters
+	for _, c := range m.remoteKubeControllers {
+		k, c := c.GetKeyAndCert(name, namespace)
+		if k != nil && c != nil {
+			return k, c
+		}
+	}
+	return nil, nil
+}
+
+func (m *Multicluster) GetCaCert(name, namespace string) (cert []byte) {
+	// Prefer local cluster
+	if lk := m.remoteKubeControllers[m.localCluster].GetCaCert(name, namespace); lk != nil {
+		return lk
+	}
+	// Search through all clusters
+	for _, c := range m.remoteKubeControllers {
+		k := c.GetCaCert(name, namespace)
+		if k != nil {
+			return k
+		}
+	}
+	return nil
+}
+
+func (m *Multicluster) Authorize(serviceAccount, namespace, clusterID string) error {
+	if c, f := m.remoteKubeControllers[clusterID]; f {
+		// For auth, we always lookup in the same namespace as the proxy is running
+		return c.Authorize(serviceAccount, namespace, clusterID)
+	} else {
+		return fmt.Errorf("client for cluster %q not found", clusterID)
+	}
+}
+
+func (m *Multicluster) AddEventHandler(f func(name string, namespace string)) {
+	for _, c := range m.remoteKubeControllers {
+		c.AddEventHandler(f)
+	}
+}

--- a/pilot/pkg/secrets/kube/multicluster.go
+++ b/pilot/pkg/secrets/kube/multicluster.go
@@ -34,13 +34,13 @@ type Multicluster struct {
 
 var _ secrets.Controller = &Multicluster{}
 
-func NewMulticluster(client kube.Client, localClusterId, secretNamespace string) *Multicluster {
+func NewMulticluster(client kube.Client, localCluster, secretNamespace string) *Multicluster {
 	m := &Multicluster{
 		remoteKubeControllers: map[string]*SecretsController{},
-		localCluster:          localClusterId,
+		localCluster:          localCluster,
 	}
 	// Add the local cluster
-	if err := m.AddMemberCluster(client, localClusterId); err != nil {
+	if err := m.AddMemberCluster(client, localCluster); err != nil {
 		return nil
 	}
 	sc := secretcontroller.StartSecretController(client,
@@ -111,9 +111,8 @@ func (m *Multicluster) Authorize(serviceAccount, namespace, clusterID string) er
 	if c, f := m.remoteKubeControllers[clusterID]; f {
 		// For auth, we always lookup in the same namespace as the proxy is running
 		return c.Authorize(serviceAccount, namespace, clusterID)
-	} else {
-		return fmt.Errorf("client for cluster %q not found", clusterID)
 	}
+	return fmt.Errorf("client for cluster %q not found", clusterID)
 }
 
 func (m *Multicluster) AddEventHandler(f func(name string, namespace string)) {

--- a/pilot/pkg/secrets/kube/secrets.go
+++ b/pilot/pkg/secrets/kube/secrets.go
@@ -176,7 +176,11 @@ func (s *SecretsController) Authorize(serviceAccount, namespace, clusterID strin
 		return cached
 	}
 	resp := func() error {
-		resp, err := s.sar.Create(context.Background(), &authorizationv1.SubjectAccessReview{
+		sar := s.getAccessReviewClient(clusterID)
+		if sar == nil {
+			return fmt.Errorf("client for cluster %v is missing", clusterID)
+		}
+		resp, err := sar.Create(context.Background(), &authorizationv1.SubjectAccessReview{
 			ObjectMeta: metav1.ObjectMeta{},
 			Spec: authorizationv1.SubjectAccessReviewSpec{
 				ResourceAttributes: &authorizationv1.ResourceAttributes{

--- a/pilot/pkg/secrets/kube/secrets_test.go
+++ b/pilot/pkg/secrets/kube/secrets_test.go
@@ -141,10 +141,10 @@ func allowIdentities(c kube.Client, identities ...string) {
 func TestAuthorize(t *testing.T) {
 	localClient := kube.NewFakeClient()
 	remoteClient := kube.NewFakeClient()
-	sc := NewMulticluster(localClient, "local", "")
-	sc.AddMemberCluster(remoteClient, "remote")
 	allowIdentities(localClient, "system:serviceaccount:ns-local:sa-allowed")
 	allowIdentities(remoteClient, "system:serviceaccount:ns-remote:sa-allowed")
+	sc := NewMulticluster(localClient, "local", "")
+	sc.AddMemberCluster(remoteClient, "remote")
 	cases := []struct {
 		sa      string
 		ns      string

--- a/pilot/pkg/secrets/model.go
+++ b/pilot/pkg/secrets/model.go
@@ -17,6 +17,10 @@ package secrets
 type Controller interface {
 	GetKeyAndCert(name, namespace string) (key []byte, cert []byte)
 	GetCaCert(name, namespace string) (cert []byte)
-	Authorize(serviceAccount, namespace, clusterID string) error
+	Authorize(serviceAccount, namespace string) error
 	AddEventHandler(func(name, namespace string))
+}
+
+type MulticlusterController interface {
+	ForCluster(cluster string) (Controller, error)
 }

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -190,7 +190,7 @@ func BenchmarkNameTableGeneration(b *testing.B) {
 }
 
 func BenchmarkSecretGeneration(b *testing.B) {
-	disableLogging()
+	//disableLogging()
 	cases := []ConfigInput{
 		{
 			Name:     "secrets",

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -190,7 +190,7 @@ func BenchmarkNameTableGeneration(b *testing.B) {
 }
 
 func BenchmarkSecretGeneration(b *testing.B) {
-	//disableLogging()
+	disableLogging()
 	cases := []ConfigInput{
 		{
 			Name:     "secrets",

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -26,11 +26,13 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/ptypes/any"
+	"k8s.io/client-go/kubernetes/fake"
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/config/kube/crd"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
+	kubesecrets "istio.io/istio/pilot/pkg/secrets/kube"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
 	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/pkg/config"
@@ -209,6 +211,7 @@ func BenchmarkSecretGeneration(b *testing.B) {
 			s := NewFakeDiscoveryServer(b, FakeOptions{
 				KubernetesObjectString: buf.String(),
 			})
+			kubesecrets.DisableAuthorizationForTest(s.KubeClient().Kube().(*fake.Clientset))
 			watchedResources := []string{}
 			for i := 0; i < tt.Services; i++ {
 				watchedResources = append(watchedResources, fmt.Sprintf("kubernetes://istio-system/sds-credential-%d", i))

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -109,7 +109,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		NetworksWatcher: opts.NetworksWatcher,
 	})
 
-	sc := kubesecrets.NewSecretsController(kubeClient, "Kubernetes")
+	sc := kubesecrets.NewMulticluster(kubeClient, "", "")
 	s.Generators[v3.SecretType] = NewSecretGen(sc, &model.DisabledCache{})
 
 	ingr := ingress.NewController(kubeClient, mesh.NewFixedWatcher(m), kube.Options{

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -110,7 +110,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	})
 
 	sc := kubesecrets.NewSecretsController(kubeClient, "", nil)
-	sc.DisableAuthorization()
+	//sc.DisableAuthorization()
 	s.Generators[v3.SecretType] = NewSecretGen(sc, &model.DisabledCache{})
 
 	ingr := ingress.NewController(kubeClient, mesh.NewFixedWatcher(m), kube.Options{

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -109,8 +109,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 		NetworksWatcher: opts.NetworksWatcher,
 	})
 
-	sc := kubesecrets.NewSecretsController(kubeClient, "", nil)
-	//sc.DisableAuthorization()
+	sc := kubesecrets.NewSecretsController(kubeClient, "Kubernetes")
 	s.Generators[v3.SecretType] = NewSecretGen(sc, &model.DisabledCache{})
 
 	ingr := ingress.NewController(kubeClient, mesh.NewFixedWatcher(m), kube.Options{

--- a/pilot/pkg/xds/sds.go
+++ b/pilot/pkg/xds/sds.go
@@ -104,7 +104,7 @@ func (s *SecretGen) Generate(proxy *model.Proxy, _ *model.PushContext, w *model.
 		adsLog.Warnf("proxy %v is not authorized to receive secrets. Ensure you are connecting over TLS port and are authenticated.", proxy.ID)
 		return nil
 	}
-	if err := s.secrets.Authorize(proxy.VerifiedIdentity.ServiceAccount, proxy.VerifiedIdentity.Namespace, ""); err != nil {
+	if err := s.secrets.Authorize(proxy.VerifiedIdentity.ServiceAccount, proxy.VerifiedIdentity.Namespace, proxy.Metadata.ClusterID); err != nil {
 		adsLog.Warnf("proxy %v is not authorized to receive secrets: %v", proxy.ID, err)
 		return nil
 	}

--- a/pilot/pkg/xds/sds_test.go
+++ b/pilot/pkg/xds/sds_test.go
@@ -257,11 +257,14 @@ func TestGenerate(t *testing.T) {
 				KubernetesObjects: []runtime.Object{genericCert, genericMtlsCert, genericMtlsCertSplit, genericMtlsCertSplitCa},
 			})
 			cc := s.KubeClient().Kube().(*fake.Clientset)
+
+			cc.Fake.Lock()
 			if tt.accessReviewResponse != nil {
 				cc.Fake.PrependReactor("create", "subjectaccessreviews", tt.accessReviewResponse)
 			} else {
 				kubesecrets.DisableAuthorizationForTest(cc)
 			}
+			cc.Fake.Unlock()
 
 			gen := s.Discovery.Generators[v3.SecretType]
 


### PR DESCRIPTION
* Add testing for authorization
* Add testing for multicluster
* Add support for multicluster. credentials are read from ANY cluster; authorization is check only in the local (to proxy) cluster.