### PR TITLE
xds: push cds on vs update

### DIFF
--- a/pilot/pkg/xds/cds.go
+++ b/pilot/pkg/xds/cds.go
@@ -30,7 +30,6 @@ var _ model.XdsResourceGenerator = &CdsGenerator{}
 // Map of all configs that do not impact CDS
 var skippedCdsConfigs = map[config.GroupVersionKind]struct{}{
 	gvk.Gateway:               {},
-	gvk.VirtualService:        {},
 	gvk.WorkloadEntry:         {},
 	gvk.WorkloadGroup:         {},
 	gvk.AuthorizationPolicy:   {},

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -320,7 +320,6 @@ var _ model.XdsResourceGenerator = &EdsGenerator{}
 // Map of all configs that do not impact EDS
 var skippedEdsConfigs = map[config.GroupVersionKind]struct{}{
 	gvk.Gateway:               {},
-	gvk.VirtualService:        {},
 	gvk.WorkloadGroup:         {},
 	gvk.AuthorizationPolicy:   {},
 	gvk.RequestAuthentication: {},

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -320,6 +320,7 @@ var _ model.XdsResourceGenerator = &EdsGenerator{}
 // Map of all configs that do not impact EDS
 var skippedEdsConfigs = map[config.GroupVersionKind]struct{}{
 	gvk.Gateway:               {},
+	gvk.VirtualService:        {},
 	gvk.WorkloadGroup:         {},
 	gvk.AuthorizationPolicy:   {},
 	gvk.RequestAuthentication: {},

--- a/releasenotes/notes/push-cds-and-eds-on-virtualservice-update.yaml
+++ b/releasenotes/notes/push-cds-and-eds-on-virtualservice-update.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: release-notes/v2
+kind: bug-fix
+area: networking
+issue:
+  - 27650
+
+releaseNotes:
+  - |
+    **Fixed** CDS is not updated as destination changes in VirtualService


### PR DESCRIPTION
Currently, VirtualService changes do not trigger CDS updates.
Istio is supposed to transitively include all destinations specified in
the VirtualService as part of the CDS. This is correctly calculated
after https://github.com/istio/istio/pull/20408 was included, but if the
change is actually made to the virtualservice and no subsequent changes
are made to the DestinationRule or Service, the new cluster will not
actually get pushed.

Only LDS & RDS trigger, so we will route to a nonexistent cluster,
resulting in 503 NR errors in envoy until a full push of clusters is
triggered again.

Fixes https://github.com/istio/istio/issues/27650

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
