### PR TITLE
Add traffic passthrough testing with simulation

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -972,6 +972,7 @@ func (ps *PushContext) updateContext(
 		ps.ServiceAccounts = oldPushContext.ServiceAccounts
 		// TODO should this be a deep copy, or is the old push context discarded?
 		ps.ClusterVIPs = oldPushContext.ClusterVIPs
+		ps.instancesByPort = oldPushContext.instancesByPort
 	}
 
 	if virtualServicesChanged {

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -44,6 +44,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	istionetworking "istio.io/istio/pilot/pkg/networking"
 	"istio.io/istio/pilot/pkg/networking/plugin"
+	"istio.io/istio/pilot/pkg/networking/plugin/registry"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	memregistry "istio.io/istio/pilot/pkg/serviceregistry/memory"
@@ -146,10 +147,6 @@ var (
 )
 
 func TestInboundListenerConfig(t *testing.T) {
-	defaultValue := features.EnableProtocolSniffingForInbound
-	features.EnableProtocolSniffingForInbound = true
-	defer func() { features.EnableProtocolSniffingForInbound = defaultValue }()
-
 	for _, p := range []*model.Proxy{getProxy(), &proxyHTTP10} {
 		testInboundListenerConfig(t, p,
 			buildService("test1.com", wildcardIP, protocol.HTTP, tnow.Add(1*time.Second)),
@@ -877,7 +874,7 @@ func getHTTPFilterChain(t *testing.T, l *listener.Listener) *listener.FilterChai
 
 func testInboundListenerConfig(t *testing.T, proxy *model.Proxy, services ...*model.Service) {
 	t.Helper()
-	p := &fakePlugin{}
+	p := registry.NewPlugins([]string{plugin.Authn})[0]
 	listeners := buildInboundListeners(t, p, proxy, nil, services...)
 	if len(listeners) != 1 {
 		t.Fatalf("expected %d listeners, found %d", 1, len(listeners))
@@ -903,7 +900,7 @@ func testInboundListenerConfigWithGrpc(t *testing.T, proxy *model.Proxy, service
 
 func testInboundListenerConfigWithSidecar(t *testing.T, proxy *model.Proxy, services ...*model.Service) {
 	t.Helper()
-	p := &fakePlugin{}
+	p := registry.NewPlugins([]string{plugin.Authn})[0]
 	sidecarConfig := &config.Config{
 		Meta: config.Meta{
 			Name:      "foo",
@@ -932,7 +929,8 @@ func testInboundListenerConfigWithSidecar(t *testing.T, proxy *model.Proxy, serv
 
 func testInboundListenerConfigWithSidecarWithoutServices(t *testing.T, proxy *model.Proxy) {
 	t.Helper()
-	p := &fakePlugin{}
+
+	p := registry.NewPlugins([]string{plugin.Authn})[0]
 	sidecarConfig := &config.Config{
 		Meta: config.Meta{
 			Name:      "foo-without-service",

--- a/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
@@ -1,0 +1,194 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha3_test
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/istio/pilot/pkg/simulation"
+	"istio.io/istio/pilot/pkg/util/sets"
+	"istio.io/istio/pilot/pkg/xds"
+	"istio.io/istio/pkg/config/mesh"
+)
+
+func TestPassthroughTraffic(t *testing.T) {
+	calls := map[string]simulation.Call{}
+	for port := 80; port < 87; port++ {
+		for _, call := range []simulation.Call{
+			{Port: port, Protocol: simulation.HTTP, HostHeader: "foo"},
+			{Port: port, Protocol: simulation.HTTPS, HostHeader: "foo"},
+			{Port: port, Protocol: simulation.HTTPS, HostHeader: "foo", Alpn: "http/1.1"},
+			{Port: port, Protocol: simulation.TCP, HostHeader: "foo"},
+			{Port: port, Protocol: simulation.GRPC, HostHeader: "foo"},
+		} {
+			suffix := ""
+			if call.Alpn != "" {
+				suffix = "-" + call.Alpn
+			}
+			calls[fmt.Sprintf("%v-%v%v", call.Protocol, port, suffix)] = call
+		}
+	}
+	ports := `
+  ports:
+  - name: http
+    number: 80
+    protocol: HTTP
+  - name: auto
+    number: 81
+  - name: tcp
+    number: 82
+    protocol: TCP
+  - name: tls
+    number: 83
+    protocol: TLS
+  - name: https
+    number: 84
+    protocol: HTTPS
+  - name: grpc
+    number: 85
+    protocol: GRPC
+  - name: h2
+    number: 86
+    protocol: HTTP2`
+
+	// TODO: https://github.com/istio/istio/issues/26079 this should be empty list
+	expectedFailures := sets.NewSet(
+		"https-80-http/1.1",
+		"https-85-http/1.1",
+		"https-86-http/1.1",
+	)
+	isHttpPort := func(p int) bool {
+		switch p {
+		case 80, 85, 86:
+			return true
+		default:
+			return false
+		}
+	}
+	isAutoPort := func(p int) bool {
+		switch p {
+		case 81:
+			return true
+		default:
+			return false
+		}
+	}
+	for _, tp := range []meshconfig.MeshConfig_OutboundTrafficPolicy_Mode{meshconfig.MeshConfig_OutboundTrafficPolicy_REGISTRY_ONLY, meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY} {
+		t.Run(tp.String(), func(t *testing.T) {
+			o := xds.FakeOptions{
+				MeshConfig: func() *meshconfig.MeshConfig {
+					m := mesh.DefaultMeshConfig()
+					m.OutboundTrafficPolicy.Mode = tp
+					return &m
+				}(),
+			}
+			expectedCluster := map[meshconfig.MeshConfig_OutboundTrafficPolicy_Mode]string{
+				meshconfig.MeshConfig_OutboundTrafficPolicy_REGISTRY_ONLY: util.BlackHoleCluster,
+				meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY:     util.PassthroughCluster,
+			}[tp]
+			t.Run("with VIP", func(t *testing.T) {
+				testCalls := []simulation.Expect{}
+				for name, call := range calls {
+					e := simulation.Expect{
+						Name: name,
+						Call: call,
+						Result: simulation.Result{
+							ClusterMatched: expectedCluster,
+						},
+					}
+					// For blackhole, we will 502 where possible instead of blackhole cluster
+					// This only works for HTTP on HTTP
+					if expectedCluster == util.BlackHoleCluster && call.Protocol.IsHttp() && isHttpPort(call.Port) {
+						e.Result.ClusterMatched = ""
+						e.Result.VirtualHostMatched = util.BlackHole
+					}
+					if expectedFailures.Contains(name) {
+						e.Result.Error = simulation.ErrProtocolError
+						e.Result.ClusterMatched = ""
+					}
+					testCalls = append(testCalls, e)
+				}
+				sort.Slice(testCalls, func(i, j int) bool {
+					return testCalls[i].Name < testCalls[j].Name
+				})
+				runSimulationTest(t, nil,
+					simulationTest{
+						config: `
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: se
+spec:
+  hosts:
+  - istio.io
+  addresses: [1.2.3.4]
+  location: MESH_EXTERNAL
+  resolution: DNS` + ports,
+						calls: testCalls,
+					}, o)
+			})
+			t.Run("without VIP", func(t *testing.T) {
+				testCalls := []simulation.Expect{}
+				for name, call := range calls {
+					e := simulation.Expect{
+						Name: name,
+						Call: call,
+						Result: simulation.Result{
+							ClusterMatched: expectedCluster,
+						},
+					}
+					// For blackhole, we will 502 where possible instead of blackhole cluster
+					// This only works for HTTP on HTTP
+					if expectedCluster == util.BlackHoleCluster && call.Protocol.IsHttp() && (isHttpPort(call.Port) || isAutoPort(call.Port)) {
+						e.Result.ClusterMatched = ""
+						e.Result.VirtualHostMatched = util.BlackHole
+					}
+					// TCP without a VIP will capture everything.
+					// Auto without a VIP is similar, but HTTP happens to work because routing is done on header
+					if call.Port == 82 || (call.Port == 81 && !call.Protocol.IsHttp()) {
+						e.Result.Error = nil
+						e.Result.ClusterMatched = ""
+					}
+					if expectedFailures.Contains(name) {
+						e.Result.Error = simulation.ErrProtocolError
+						e.Result.ClusterMatched = ""
+					}
+					testCalls = append(testCalls, e)
+				}
+				sort.Slice(testCalls, func(i, j int) bool {
+					return testCalls[i].Name < testCalls[j].Name
+				})
+				runSimulationTest(t, nil,
+					simulationTest{
+						config: `
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: se
+spec:
+  hosts:
+  - istio.io
+  location: MESH_EXTERNAL
+  resolution: DNS` + ports,
+						calls: testCalls,
+					}, o)
+			})
+		})
+	}
+}

--- a/pilot/pkg/networking/core/v1alpha3/tls.go
+++ b/pilot/pkg/networking/core/v1alpha3/tls.go
@@ -182,6 +182,7 @@ func buildSidecarOutboundTLSFilterChainOpts(node *model.Proxy, push *model.PushC
 		// having to generate expensive permutations of the host name just like RDS does..
 		// NOTE that we cannot have two services with the same VIP as our listener build logic will treat it as a collision and
 		// ignore one of the services.
+		// TODO: https://github.com/istio/istio/issues/27677 reconsider this logic
 		svcListenAddress := service.GetServiceAddressForProxy(node, push)
 		if strings.Contains(svcListenAddress, "/") {
 			// Address is a CIDR, already captured by destinationCIDR parameter.

--- a/pilot/pkg/simulation/traffic.go
+++ b/pilot/pkg/simulation/traffic.go
@@ -52,7 +52,7 @@ const (
 	TLS   Protocol = "tls"
 )
 
-func (p Protocol) IsHttp() bool {
+func (p Protocol) IsHTTP() bool {
 	return httpProtocols.Contains(string(p))
 }
 
@@ -66,7 +66,7 @@ var (
 	ErrNoRoute             = errors.New("no route matched")
 	ErrNoVirtualHost       = errors.New("no virtual host matched")
 	ErrMultipleFilterChain = errors.New("multiple filter chains matched")
-	// Sending TLS/TCP request to HCM, for example
+	// ErrProtocolError happens when sending TLS/TCP request to HCM, for example
 	ErrProtocolError = errors.New("protocol error")
 )
 
@@ -97,7 +97,7 @@ func (c Call) FillDefaults() Call {
 	if c.HostHeader != "" {
 		c.Headers["Host"] = []string{c.HostHeader}
 	}
-	if c.Sni == "" && c.Protocol == HTTPS {
+	if c.Sni == "" && (c.Protocol == HTTPS || c.Protocol == TLS) {
 		c.Sni = c.HostHeader
 	}
 	if c.Path == "" {
@@ -207,7 +207,7 @@ func (sim *Simulation) Run(input Call) (result Result) {
 	result.FilterChainMatched = fc.Name
 
 	if hcm := xdstest.ExtractHTTPConnectionManager(sim.t, fc); hcm != nil {
-		if !input.Protocol.IsHttp() && fc.TransportSocket == nil {
+		if !input.Protocol.IsHTTP() && fc.TransportSocket == nil {
 			result.Error = ErrProtocolError
 			return
 		}

--- a/pilot/test/xdstest/validate.go
+++ b/pilot/test/xdstest/validate.go
@@ -111,7 +111,7 @@ func validateListenerTLS(t testing.TB, l *listener.Listener) {
 			continue
 		}
 		// if we are matching TLS traffic and doing HTTP traffic, we must terminate the TLS
-		if m.TransportProtocol == xdsfilters.TLSTransportProtocol && fc.TransportSocket != nil && ExtractHTTPConnectionManager(t, fc) == nil {
+		if m.TransportProtocol == xdsfilters.TLSTransportProtocol && fc.TransportSocket == nil && ExtractHTTPConnectionManager(t, fc) != nil {
 			t.Errorf("listener %v is invalid: tls traffic may not be terminated: %v", l.Name, Dump(t, fc))
 		}
 	}


### PR DESCRIPTION
This is just expanding testing. This covers the outbound passthrough cases, and captures one (known) bug.

Additionally, I noticed some incorrect logic in the validation that I fixed.