### PR TITLE
Always treat Envoy routes as v3, even if Envoy doesn't

### DIFF
--- a/istioctl/pkg/util/configdump/listener.go
+++ b/istioctl/pkg/util/configdump/listener.go
@@ -41,11 +41,12 @@ func (w *Wrapper) GetDynamicListenerDump(stripVersions bool) (*adminapi.Listener
 		}
 	}
 
+	// Support v2 or v3 in config dump. See ads.go:RequestedTypes for more info.
+	for i := range dal {
+		dal[i].ActiveState.Listener.TypeUrl = v3.ListenerType
+	}
 	sort.Slice(dal, func(i, j int) bool {
 		l := &listener.Listener{}
-		// Support v2 or v3 in config dump. See ads.go:RequestedTypes for more info.
-		dal[i].ActiveState.Listener.TypeUrl = v3.ListenerType
-		dal[j].ActiveState.Listener.TypeUrl = v3.ListenerType
 		err = ptypes.UnmarshalAny(dal[i].ActiveState.Listener, l)
 		if err != nil {
 			return false

--- a/istioctl/pkg/util/configdump/route.go
+++ b/istioctl/pkg/util/configdump/route.go
@@ -78,6 +78,9 @@ func (w *Wrapper) GetDynamicRouteDump(stripVersions bool) (*adminapi.RoutesConfi
 	// within a route might have a different order.  Sort those too.
 	for i := range drc {
 		route := &route.RouteConfiguration{}
+		// Support v2 or v3 in config dump. See ads.go:RequestedTypes for more info.
+		// (This is done in the sort, but the sort skip this if the slice has length 1!)
+		drc[i].RouteConfig.TypeUrl = v3.RouteType
 		err = ptypes.UnmarshalAny(drc[i].RouteConfig, route)
 		if err != nil {
 			return nil, err

--- a/istioctl/pkg/util/configdump/route.go
+++ b/istioctl/pkg/util/configdump/route.go
@@ -57,11 +57,12 @@ func (w *Wrapper) GetDynamicRouteDump(stripVersions bool) (*adminapi.RoutesConfi
 		return nil, err
 	}
 	drc := routeDump.GetDynamicRouteConfigs()
-	sort.Slice(drc, func(i, j int) bool {
-		// Support v2 or v3 in config dump. See ads.go:RequestedTypes for more info.
-		r := &route.RouteConfiguration{}
+	// Support v2 or v3 in config dump. See ads.go:RequestedTypes for more info.
+	for i := range drc {
 		drc[i].RouteConfig.TypeUrl = v3.RouteType
-		drc[j].RouteConfig.TypeUrl = v3.RouteType
+	}
+	sort.Slice(drc, func(i, j int) bool {
+		r := &route.RouteConfiguration{}
 		err = ptypes.UnmarshalAny(drc[i].RouteConfig, r)
 		if err != nil {
 			return false
@@ -78,9 +79,6 @@ func (w *Wrapper) GetDynamicRouteDump(stripVersions bool) (*adminapi.RoutesConfi
 	// within a route might have a different order.  Sort those too.
 	for i := range drc {
 		route := &route.RouteConfiguration{}
-		// Support v2 or v3 in config dump. See ads.go:RequestedTypes for more info.
-		// (This is done in the sort, but the sort skip this if the slice has length 1!)
-		drc[i].RouteConfig.TypeUrl = v3.RouteType
 		err = ptypes.UnmarshalAny(drc[i].RouteConfig, route)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/27665

No test added.  I don't want to check in Envoy config, and I don't have an integration test that includes a 1.6.x ingressgateway as part of the mesh.