### PR TITLE
add benchmark test for endpoint labels

### DIFF
--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -503,32 +503,9 @@ func BuildLbEndpointMetadata(network string, tlsMode string) *core.Metadata {
 
 	metadata.FilterMetadata[IstioMetadataKey] = &pstruct.Struct{
 		Fields: map[string]*pstruct.Value{
-			"name": {
+			"workload": {
 				Kind: &pstruct.Value_StringValue{
-					StringValue: "some-workload-name",
-				},
-			},
-			"namespace": {
-				Kind: &pstruct.Value_StringValue{
-					StringValue: "some-workload-namespace",
-				},
-			},
-			"labels": {
-				Kind: &pstruct.Value_StructValue{
-					StructValue: &pstruct.Struct{
-						Fields: map[string]*pstruct.Value{
-							"service.istio.io/canonical-service": {
-								Kind: &pstruct.Value_StringValue{
-									StringValue: "some-canonical-service-name",
-								},
-							},
-							"service.istio.io/canonical-revision": {
-								Kind: &pstruct.Value_StringValue{
-									StringValue: "revision-123",
-								},
-							},
-						},
-					},
+					StringValue: "some-workload-name|some-workload-namespace|some-canonical-service-name|revision-123",
 				},
 			},
 		},

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -497,12 +497,14 @@ func MergeAnyWithAny(dst *any.Any, src *any.Any) (*any.Any, error) {
 
 // BuildLbEndpointMetadata adds metadata values to a lb endpoint
 func BuildLbEndpointMetadata(network string, tlsMode string) *core.Metadata {
-	if network == "" && tlsMode == model.DisabledTLSModeLabel {
-		return nil
-	}
-
 	metadata := &core.Metadata{
 		FilterMetadata: map[string]*pstruct.Struct{},
+	}
+
+	metadata.FilterMetadata[EnvoyTransportSocketMetadataKey] = &pstruct.Struct{
+		Fields: map[string]*pstruct.Value{
+			model.TLSModeLabelShortname: {Kind: &pstruct.Value_StringValue{StringValue: tlsMode}},
+		},
 	}
 
 	if network != "" {
@@ -512,14 +514,6 @@ func BuildLbEndpointMetadata(network string, tlsMode string) *core.Metadata {
 
 		if network != "" {
 			metadata.FilterMetadata[IstioMetadataKey].Fields["network"] = &pstruct.Value{Kind: &pstruct.Value_StringValue{StringValue: network}}
-		}
-	}
-
-	if tlsMode != "" {
-		metadata.FilterMetadata[EnvoyTransportSocketMetadataKey] = &pstruct.Struct{
-			Fields: map[string]*pstruct.Value{
-				model.TLSModeLabelShortname: {Kind: &pstruct.Value_StringValue{StringValue: tlsMode}},
-			},
 		}
 	}
 

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -501,9 +501,36 @@ func BuildLbEndpointMetadata(network string, tlsMode string) *core.Metadata {
 		FilterMetadata: map[string]*pstruct.Struct{},
 	}
 
-	metadata.FilterMetadata[EnvoyTransportSocketMetadataKey] = &pstruct.Struct{
+	metadata.FilterMetadata[IstioMetadataKey] = &pstruct.Struct{
 		Fields: map[string]*pstruct.Value{
-			model.TLSModeLabelShortname: {Kind: &pstruct.Value_StringValue{StringValue: tlsMode}},
+			"name": {
+				Kind: &pstruct.Value_StringValue{
+					StringValue: "some-workload-name",
+				},
+			},
+			"namespace": {
+				Kind: &pstruct.Value_StringValue{
+					StringValue: "some-workload-namespace",
+				},
+			},
+			"labels": {
+				Kind: &pstruct.Value_StructValue{
+					StructValue: &pstruct.Struct{
+						Fields: map[string]*pstruct.Value{
+							"service.istio.io/canonical-service": {
+								Kind: &pstruct.Value_StringValue{
+									StringValue: "some-canonical-service-name",
+								},
+							},
+							"service.istio.io/canonical-revision": {
+								Kind: &pstruct.Value_StringValue{
+									StringValue: "revision-123",
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
Without any metadata:
```
BenchmarkEndpointGeneration/1/100-64                3133            355366 ns/op                 5.79 kb/msg           100 resources/msg    94299 B/op        1511 allocs/op
BenchmarkEndpointGeneration/10/10-64                9488            123404 ns/op                 2.83 kb/msg            10.0 resources/msg   12611 B/op        158 allocs/op
BenchmarkEndpointGeneration/100/10-64               1234            968544 ns/op                26.2 kb/msg             10.0 resources/msg   45112 B/op        164 allocs/op
BenchmarkEndpointGeneration/1000/1-64               1278            933978 ns/op                26.6 kb/msg              1.00 resources/msg        36836 B/op         25 allocs/op
```

Add tlsMode (https://github.com/istio/istio/pull/27676/commits/03b117da56c50dbbc1e902951d70c04afb047213):
```
BenchmarkEndpointGeneration/1/100-64                1759            674742 ns/op                11.7 kb/msg            100 resources/msg          164795 B/op       2912 allocs/op
BenchmarkEndpointGeneration/10/10-64                2971            408148 ns/op                 8.73 kb/msg            10.0 resources/msg         82767 B/op       1558 allocs/op
BenchmarkEndpointGeneration/100/10-64                307           3819991 ns/op                85.2 kb/msg             10.0 resources/msg        756464 B/op      14210 allocs/op
BenchmarkEndpointGeneration/1000/1-64                312           3816892 ns/op                85.6 kb/msg              1.00 resources/msg       743106 B/op      14070 allocs/op
```

Add uncompressed workload metadata (https://github.com/istio/istio/pull/27676/commits/5f8e81a1139ebd2ae9e39320deae12fff5a103f5):
```
BenchmarkEndpointGeneration/1/100-64                 998           1136226 ns/op                28.5 kb/msg            100 resources/msg          244950 B/op       4613 allocs/op
BenchmarkEndpointGeneration/10/10-64                1357            852594 ns/op                25.4 kb/msg             10.0 resources/msg        164814 B/op       3260 allocs/op
BenchmarkEndpointGeneration/100/10-64                142           8338818 ns/op               252 kb/msg               10.0 resources/msg       1583355 B/op      31350 allocs/op
BenchmarkEndpointGeneration/1000/1-64                145           8198915 ns/op               253 kb/msg                1.00 resources/msg      1555361 B/op      31205 allocs/op
```

Add compressed workload metadata (https://github.com/istio/istio/pull/27676/commits/e5fdbe2859461d6dc33fc3ac4f7d298cde1ee8da):
```
BenchmarkEndpointGeneration/1/100-64                1761            684854 ns/op                17.2 kb/msg            100 resources/msg          169597 B/op       2912 allocs/op
BenchmarkEndpointGeneration/10/10-64                2929            416968 ns/op                14.1 kb/msg             10.0 resources/msg         89170 B/op       1558 allocs/op
BenchmarkEndpointGeneration/100/10-64                302           3907421 ns/op               139 kb/msg               10.0 resources/msg        805193 B/op      14211 allocs/op
BenchmarkEndpointGeneration/1000/1-64                308           3851497 ns/op               140 kb/msg                1.00 resources/msg       800486 B/op      14071 allocs/op
```