### PR TITLE
set ISTIO_META_NETWORK on egress gateway

### DIFF
--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -220,6 +220,11 @@ spec:
             value: |
 {{ toJson $gateway.podAnnotations | indent 16}}
 {{ end }}
+          {{ $network_set := index $gateway.env "ISTIO_META_NETWORK" }}
+          {{- if and (not $network_set) .Values.global.network }}
+          - name: ISTIO_META_NETWORK
+            value: {{ .Values.global.network }}
+          {{- end }}
           - name: ISTIO_META_CLUSTER_ID
             value: "{{ $.Values.global.multiCluster.clusterName | default `Kubernetes` }}"
           volumeMounts:


### PR DESCRIPTION
https://storage.googleapis.com/istio-prow/pr-logs/pull/istio_istio/27491/integ-telemetry-multicluster-k8s-tests_istio/1/artifacts/telemetry-outboundtrafficpolicy-/_suite_context/istio-state-cluster-0-212811862/cluster-0/istio-egressgateway-6d95c887d4-w4pg2_proxy-clusters.txt

Egress gateways build an endpoint for the multinetwork gateway for all in-mesh endpoints without this set.