### PR TITLE
Speed up JWKS tests (15s -> 0.5s)

### DIFF
--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -770,7 +770,7 @@ func TestGetPoliciesForWorkloadWithJwksResolver(t *testing.T) {
 func getTestAuthenticationPolicies(configs []*config.Config, t *testing.T) *AuthenticationPolicies {
 	configStore := NewFakeStore()
 	for _, cfg := range configs {
-		log.Infof("add config %s\n", cfg.Name)
+		log.Infof("add config %s", cfg.Name)
 		if _, err := configStore.Create(*cfg); err != nil {
 			t.Fatalf("getTestAuthenticationPolicies %v", err)
 		}

--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -59,9 +59,9 @@ const (
 	// JwtPubKeyRefreshInterval is the running interval of JWT pubKey refresh job.
 	JwtPubKeyRefreshInterval = time.Minute * 20
 
-	// getRemoteContentRetryInSec is the retry interval between the attempt to retry getting the remote
+	// JwtPubKeyRetryInterval is the retry interval between the attempt to retry getting the remote
 	// content from network.
-	getRemoteContentRetryInSec = 1
+	JwtPubKeyRetryInterval = time.Second
 
 	// How many times should we retry the failed network fetch on main flow. The main flow
 	// means it's called when Pilot is pushing configs. Do not retry to make sure not to block Pilot
@@ -130,6 +130,8 @@ type JwksResolver struct {
 	// Refresher job running interval.
 	refreshInterval time.Duration
 
+	retryInterval time.Duration
+
 	// How many times refresh job has detected JWT public key change happened, used in unit test.
 	refreshJobKeyChangedCount uint64
 
@@ -142,10 +144,11 @@ func init() {
 }
 
 // NewJwksResolver creates new instance of JwksResolver.
-func NewJwksResolver(evictionDuration, refreshInterval time.Duration) *JwksResolver {
+func NewJwksResolver(evictionDuration, refreshInterval, retryInterval time.Duration) *JwksResolver {
 	return newJwksResolverWithCABundlePaths(
 		evictionDuration,
 		refreshInterval,
+		retryInterval,
 		[]string{jwksPublicRootCABundlePath, jwksExtraRootCABundlePath},
 	)
 }
@@ -153,16 +156,17 @@ func NewJwksResolver(evictionDuration, refreshInterval time.Duration) *JwksResol
 // GetJwtKeyResolver lazy-creates JwtKeyResolver resolves JWT public key and JwksURI.
 func GetJwtKeyResolver() *JwksResolver {
 	jwtKeyResolverOnce.Do(func() {
-		jwtKeyResolver = NewJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval)
+		jwtKeyResolver = NewJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval, JwtPubKeyRetryInterval)
 	})
 	return jwtKeyResolver
 }
 
-func newJwksResolverWithCABundlePaths(evictionDuration, refreshInterval time.Duration, caBundlePaths []string) *JwksResolver {
+func newJwksResolverWithCABundlePaths(evictionDuration, refreshInterval, retryInterval time.Duration, caBundlePaths []string) *JwksResolver {
 	ret := &JwksResolver{
 		JwksURICache:     cache.NewTTL(jwksURICacheExpiration, jwksURICacheEviction),
 		evictionDuration: evictionDuration,
 		refreshInterval:  refreshInterval,
+		retryInterval:    retryInterval,
 		httpClient: &http.Client{
 			Timeout: jwksHTTPTimeOutInSec * time.Second,
 			Transport: &http.Transport{
@@ -317,8 +321,8 @@ func (r *JwksResolver) getRemoteContentWithRetry(uri string, retry int) ([]byte,
 		if err == nil {
 			return body, nil
 		}
-		log.Warnf("Failed to GET from %q: %s. Retry in %d seconds", uri, err, getRemoteContentRetryInSec)
-		time.Sleep(getRemoteContentRetryInSec * time.Second)
+		log.Warnf("Failed to GET from %q: %s. Retry in %v", uri, err, r.retryInterval)
+		time.Sleep(r.retryInterval)
 	}
 
 	// Return the last fetch directly, reaching here means we have tried `retry` times, this will be

--- a/pilot/pkg/model/jwks_resolver_test.go
+++ b/pilot/pkg/model/jwks_resolver_test.go
@@ -378,7 +378,7 @@ func TestJwtPubKeyEvictionForNotRefreshed(t *testing.T) {
 	retry.UntilSuccessOrFail(t, func() error {
 		_, err = r.GetPublicKey(mockCertURL)
 		if err == nil {
-			return fmt.Errorf("GetPublicKey(%+v) fails: expected error, got no error", mockCertURL)
+			return fmt.Errorf("getPublicKey(%+v) fails: expected error, got no error", mockCertURL)
 		}
 		return nil
 	})
@@ -406,7 +406,6 @@ func TestJwtPubKeyRefreshWithNetworkError(t *testing.T) {
 	t.Logf("%v: %v", time.Now(), 0)
 	ms := startMockServer(t)
 	defer ms.Stop()
-	return
 
 	// Configures the mock server to return error after the first request.
 	ms.ReturnErrorAfterFirstNumHits = 1

--- a/pilot/pkg/model/jwks_resolver_test.go
+++ b/pilot/pkg/model/jwks_resolver_test.go
@@ -15,6 +15,7 @@
 package model
 
 import (
+	"fmt"
 	"reflect"
 	"sync/atomic"
 	"testing"
@@ -24,10 +25,13 @@ import (
 
 	"istio.io/api/security/v1beta1"
 	"istio.io/istio/pilot/pkg/model/test"
+	"istio.io/istio/pkg/test/util/retry"
 )
 
+const testRetryInterval = time.Millisecond * 10
+
 func TestResolveJwksURIUsingOpenID(t *testing.T) {
-	r := NewJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval)
+	r := NewJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval, testRetryInterval)
 
 	ms, err := test.StartNewServer()
 	defer ms.Stop()
@@ -73,7 +77,7 @@ func TestResolveJwksURIUsingOpenID(t *testing.T) {
 }
 
 func TestResolveJwksURI(t *testing.T) {
-	r := NewJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval)
+	r := NewJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval, testRetryInterval)
 
 	ms, err := test.StartNewServer()
 	defer ms.Stop()
@@ -173,7 +177,7 @@ func TestResolveJwksURI(t *testing.T) {
 }
 
 func TestGetPublicKey(t *testing.T) {
-	r := NewJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval)
+	r := NewJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval, testRetryInterval)
 	defer r.Close()
 
 	ms, err := test.StartNewServer()
@@ -214,7 +218,7 @@ func TestGetPublicKey(t *testing.T) {
 }
 
 func TestGetPublicKeyReorderedKey(t *testing.T) {
-	r := NewJwksResolver(JwtPubKeyEvictionDuration, time.Millisecond*20)
+	r := NewJwksResolver(JwtPubKeyEvictionDuration, testRetryInterval*20, testRetryInterval)
 	defer r.Close()
 
 	ms, err := test.StartNewServer()
@@ -257,7 +261,7 @@ func TestGetPublicKeyReorderedKey(t *testing.T) {
 }
 
 func TestGetPublicKeyUsingTLS(t *testing.T) {
-	r := newJwksResolverWithCABundlePaths(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval, []string{"./test/testcert/cert.pem"})
+	r := newJwksResolverWithCABundlePaths(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval, testRetryInterval, []string{"./test/testcert/cert.pem"})
 	defer r.Close()
 
 	ms, err := test.StartNewTLSServer("./test/testcert/cert.pem", "./test/testcert/key.pem")
@@ -277,7 +281,7 @@ func TestGetPublicKeyUsingTLS(t *testing.T) {
 }
 
 func TestGetPublicKeyUsingTLSBadCert(t *testing.T) {
-	r := newJwksResolverWithCABundlePaths(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval, []string{"./test/testcert/cert2.pem"})
+	r := newJwksResolverWithCABundlePaths(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval, testRetryInterval, []string{"./test/testcert/cert2.pem"})
 	defer r.Close()
 
 	ms, err := test.StartNewTLSServer("./test/testcert/cert.pem", "./test/testcert/key.pem")
@@ -294,7 +298,7 @@ func TestGetPublicKeyUsingTLSBadCert(t *testing.T) {
 }
 
 func TestGetPublicKeyUsingTLSWithoutCABundles(t *testing.T) {
-	r := newJwksResolverWithCABundlePaths(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval, []string{})
+	r := newJwksResolverWithCABundlePaths(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval, testRetryInterval, []string{})
 	defer r.Close()
 
 	ms, err := test.StartNewTLSServer("./test/testcert/cert.pem", "./test/testcert/key.pem")
@@ -311,7 +315,7 @@ func TestGetPublicKeyUsingTLSWithoutCABundles(t *testing.T) {
 }
 
 func TestJwtPubKeyEvictionForNotUsed(t *testing.T) {
-	r := NewJwksResolver(100*time.Millisecond /*EvictionDuration*/, 2*time.Millisecond /*RefreshInterval*/)
+	r := NewJwksResolver(100*time.Millisecond /*EvictionDuration*/, 2*time.Millisecond /*RefreshInterval*/, testRetryInterval)
 	defer r.Close()
 
 	ms := startMockServer(t)
@@ -323,23 +327,17 @@ func TestJwtPubKeyEvictionForNotUsed(t *testing.T) {
 
 	// Wait until unused keys are evicted.
 	mockCertURL := ms.URL + "/oauth2/v3/certs"
-	retries := 0
-	for ; retries < 3; retries++ {
-		time.Sleep(time.Second)
+	retry.UntilSuccessOrFail(t, func() error {
 		// Verify the public key is evicted.
 		if _, found := r.keyEntries.Load(mockCertURL); found {
-			// Retry after some sleep.
-			continue
+			return fmt.Errorf("public key is not evicted")
 		}
-		break
-	}
-	if retries == 3 {
-		t.Errorf("Unused keys failed to be evicted")
-	}
+		return nil
+	})
 }
 
 func TestJwtPubKeyEvictionForNotRefreshed(t *testing.T) {
-	r := NewJwksResolver(2*time.Second /*EvictionDuration*/, 100*time.Millisecond /*RefreshInterval*/)
+	r := NewJwksResolver(100*time.Millisecond /*EvictionDuration*/, 10*time.Millisecond /*RefreshInterval*/, testRetryInterval /*RetryInterval*/)
 	defer r.Close()
 
 	ms := startMockServer(t)
@@ -350,10 +348,19 @@ func TestJwtPubKeyEvictionForNotRefreshed(t *testing.T) {
 
 	mockCertURL := ms.URL + "/oauth2/v3/certs"
 
+	pk, err := r.GetPublicKey(mockCertURL)
+	if err != nil {
+		t.Fatalf("GetPublicKey(%+v) fails: expected no error, got (%v)", mockCertURL, err)
+	}
+	// Mock server returns JwtPubKey1 for first call.
+	if test.JwtPubKey1 != pk {
+		t.Fatalf("GetPublicKey(%+v): expected (%s), got (%s)", mockCertURL, test.JwtPubKey1, pk)
+	}
+
 	// Keep getting the public key to change the lastUsedTime of the public key.
 	done := make(chan struct{})
 	go func() {
-		c := time.NewTicker(100 * time.Millisecond)
+		c := time.NewTicker(10 * time.Millisecond)
 		for {
 			select {
 			case <-done:
@@ -367,25 +374,18 @@ func TestJwtPubKeyEvictionForNotRefreshed(t *testing.T) {
 		done <- struct{}{}
 	}()
 
-	pk, err := r.GetPublicKey(mockCertURL)
-	if err != nil {
-		t.Fatalf("GetPublicKey(%+v) fails: expected no error, got (%v)", mockCertURL, err)
-	}
-	// Mock server returns JwtPubKey1 for first call.
-	if test.JwtPubKey1 != pk {
-		t.Fatalf("GetPublicKey(%+v): expected (%s), got (%s)", mockCertURL, test.JwtPubKey1, pk)
-	}
-
 	// Verify the cached public key is removed after failed to refresh longer than the eviction duration.
-	time.Sleep(5 * time.Second)
-	_, err = r.GetPublicKey(mockCertURL)
-	if err == nil {
-		t.Errorf("GetPublicKey(%+v) fails: expected error, got no error", mockCertURL)
-	}
+	retry.UntilSuccessOrFail(t, func() error {
+		_, err = r.GetPublicKey(mockCertURL)
+		if err == nil {
+			return fmt.Errorf("GetPublicKey(%+v) fails: expected error, got no error", mockCertURL)
+		}
+		return nil
+	})
 }
 
 func TestJwtPubKeyLastRefreshedTime(t *testing.T) {
-	r := NewJwksResolver(JwtPubKeyEvictionDuration, 2*time.Millisecond /*RefreshInterval*/)
+	r := NewJwksResolver(JwtPubKeyEvictionDuration, 2*time.Millisecond /*RefreshInterval*/, testRetryInterval /*RetryInterval*/)
 	defer r.Close()
 
 	ms := startMockServer(t)
@@ -400,17 +400,22 @@ func TestJwtPubKeyLastRefreshedTime(t *testing.T) {
 }
 
 func TestJwtPubKeyRefreshWithNetworkError(t *testing.T) {
-	r := NewJwksResolver(JwtPubKeyEvictionDuration, time.Second /*RefreshInterval*/)
+	r := NewJwksResolver(JwtPubKeyEvictionDuration, time.Second /*RefreshInterval*/, testRetryInterval)
 	defer r.Close()
 
+	t.Logf("%v: %v", time.Now(), 0)
 	ms := startMockServer(t)
 	defer ms.Stop()
+	return
 
 	// Configures the mock server to return error after the first request.
 	ms.ReturnErrorAfterFirstNumHits = 1
 
+	t.Logf("%v: %v", time.Now(), 1)
+
 	// The refresh job should continue using the previously fetched public key (JwtPubKey1).
 	verifyKeyRefresh(t, r, ms, test.JwtPubKey1)
+	t.Logf("%v: %v", time.Now(), 2)
 
 	// The lastRefreshedTime should not change the refresh failed due to network error.
 	verifyKeyLastRefreshedTime(t, r, ms, false /* wantChanged */)
@@ -429,7 +434,7 @@ func getCounterValue(counterName string, t *testing.T) float64 {
 }
 
 func TestJwtPubKeyMetric(t *testing.T) {
-	r := NewJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval)
+	r := NewJwksResolver(JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval, testRetryInterval)
 	defer r.Close()
 
 	ms, err := test.StartNewServer()
@@ -497,18 +502,13 @@ func verifyKeyRefresh(t *testing.T, r *JwksResolver, ms *test.MockOpenIDDiscover
 	}
 
 	// Wait until refresh job at least finished once.
-	retries := 0
-	for ; retries < 20; retries++ {
-		time.Sleep(time.Second)
+	retry.UntilSuccessOrFail(t, func() error {
 		// Make sure refresh job has run and detect change or refresh happened.
 		if atomic.LoadUint64(&r.refreshJobKeyChangedCount) > 0 || atomic.LoadUint64(&r.refreshJobFetchFailedCount) > 0 {
-			break
+			return nil
 		}
-	}
-	if retries == 20 {
-		t.Fatalf("Refresher failed to run")
-	}
-
+		return fmt.Errorf("refresher failed to run")
+	})
 	pk, err = r.GetPublicKey(mockCertURL)
 	if err != nil {
 		t.Fatalf("GetPublicKey(%+v) fails: expected no error, got (%v)", mockCertURL, err)

--- a/pilot/pkg/model/test/mockopenidserver.go
+++ b/pilot/pkg/model/test/mockopenidserver.go
@@ -168,14 +168,14 @@ func (ms *MockOpenIDDiscoveryServer) Start() error {
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		},
 	}
-	wait := 300 * time.Millisecond
-	for try := 0; try < 5; try++ {
-		time.Sleep(wait)
+	wait := 10 * time.Millisecond
+	for try := 0; try < 10; try++ {
 		// Try to call the server
 		if _, err := httpClient.Get(fmt.Sprintf("%s/.well-known/openid-configuration", ms.URL)); err != nil {
 			log.Infof("Server not yet serving: %v", err)
 			// Retry after some sleep.
 			wait *= 2
+			time.Sleep(wait)
 			continue
 		}
 


### PR DESCRIPTION
This should have no real impact on the production code, other than a new
variable that is set to the same value it was previously but set
different for tests (to avoid slow 1s retries).



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.