### PR TITLE
Optimize docker building

### DIFF
--- a/pkg/test/echo/docker/Dockerfile.app_sidecar_base_centos
+++ b/pkg/test/echo/docker/Dockerfile.app_sidecar_base_centos
@@ -1,4 +1,5 @@
-FROM centos:8
+ARG VM_IMAGE_VERSION=8
+FROM centos:${VM_IMAGE_VERSION}
 
 # hadolint ignore=DL3005,DL3008
 RUN yum upgrade -y && \

--- a/pkg/test/echo/docker/Dockerfile.app_sidecar_centos_7
+++ b/pkg/test/echo/docker/Dockerfile.app_sidecar_centos_7
@@ -1,18 +1,5 @@
-FROM centos:7
-
-# hadolint ignore=DL3005,DL3008
-RUN yum upgrade -y && \
-    yum install -y \
-    iptables \
-    iproute \
-    sudo \
-    && update-ca-trust \
-    yum clean all && \
-    rm -rf /var/cache/yum
-
-# Add a user that will run the application. This allows running as this user and capture iptables
-RUN useradd -m --uid 1338 application && \
-    echo "application ALL=NOPASSWD: ALL" >> /etc/sudoers
+ARG BASE_VERSION=latest
+FROM docker.io/istio/app_sidecar_base_centos_7:${BASE_VERSION}
 
 # Install the certs.
 COPY certs/                           /var/lib/istio/

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -420,7 +420,7 @@ func generateYAMLWithSettings(
 	}
 	params := map[string]interface{}{
 		"Hub":                settings.Hub,
-		"Tag":                settings.Tag,
+		"Tag":                strings.TrimSuffix(settings.Tag, "-distroless"),
 		"PullPolicy":         settings.PullPolicy,
 		"Service":            cfg.Service,
 		"Version":            cfg.Version,

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -76,14 +76,19 @@ function build_images() {
   targets="docker.pilot docker.proxyv2 "
 
   # use ubuntu:bionic to test vms by default
-  targets+="docker.app docker.app_sidecar_ubuntu_bionic "
+  nonDistrolessTargets="docker.app docker.app_sidecar_ubuntu_bionic "
   if [[ "${SELECT_TEST}" == "test.integration.pilot.kube" ]]; then
-    targets+="docker.app_sidecar_ubuntu_xenial docker.app_sidecar_ubuntu_focal docker.app_sidecar_ubuntu_bionic "
-    targets+="docker.app_sidecar_debian_9 docker.app_sidecar_debian_10 docker.app_sidecar_centos_7 docker.app_sidecar_centos_8 "
+    nonDistrolessTargets+="docker.app_sidecar_ubuntu_xenial docker.app_sidecar_ubuntu_focal docker.app_sidecar_ubuntu_bionic "
+    nonDistrolessTargets+="docker.app_sidecar_debian_9 docker.app_sidecar_debian_10 docker.app_sidecar_centos_7 docker.app_sidecar_centos_8 "
   fi
   targets+="docker.operator "
   targets+="docker.install-cni "
-  DOCKER_BUILD_VARIANTS="${VARIANT:-default}" DOCKER_TARGETS="${targets}" make dockerx.pushx
+  if [[ "${VARIANT:-default}" == "distroless" ]]; then
+    DOCKER_BUILD_VARIANTS="distroless" DOCKER_TARGETS="${targets}" make dockerx.pushx
+    DOCKER_BUILD_VARIANTS="default" DOCKER_TARGETS="${nonDistrolessTargets}" make dockerx.pushx
+  else
+    DOCKER_BUILD_VARIANTS="${VARIANT:-default}" DOCKER_TARGETS="${targets} ${nonDistrolessTargets}" make dockerx.pushx
+  fi
 }
 
 # Creates a local registry for kind nodes to pull images from. Expects that the "kind" network already exists.

--- a/tools/build-base-images.sh
+++ b/tools/build-base-images.sh
@@ -22,4 +22,4 @@ set -ex
 HUB="${HUB:-istio.io/docker}"
 TAG="${TAG:?specify a tag}"
 
-DOCKER_TARGETS="docker.base docker.distroless docker.app_sidecar_base_debian_9 docker.app_sidecar_base_debian_10 docker.app_sidecar_base_ubuntu_xenial docker.app_sidecar_base_ubuntu_bionic docker.app_sidecar_base_ubuntu_focal docker.app_sidecar_base_centos_8" make dockerx.pushx
+DOCKER_TARGETS="docker.base docker.distroless docker.app_sidecar_base_debian_9 docker.app_sidecar_base_debian_10 docker.app_sidecar_base_ubuntu_xenial docker.app_sidecar_base_ubuntu_bionic docker.app_sidecar_base_ubuntu_focal docker.app_sidecar_base_centos_7 docker.app_sidecar_base_centos_8" make dockerx.pushx

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -326,10 +326,14 @@ $(foreach TGT,$(DOCKER_TARGETS),$(eval DOCKER_TAR_TARGETS+=tar.$(TGT)))
 # this target saves a tar.gz of each docker image to ${ISTIO_OUT_LINUX}/docker/
 dockerx.save: dockerx $(ISTIO_DOCKER_TAR)
 	$(foreach TGT,$(DOCKER_TARGETS), \
-	$(foreach VARIANT,$(DOCKER_BUILD_VARIANTS), time ( \
-		 docker save -o ${ISTIO_DOCKER_TAR}/$(subst docker.,,$(TGT))$(subst -$(DEFAULT_DISTRIBUTION),,-$(VARIANT)).tar $(HUB)/$(subst docker.,,$(TGT)):$(subst -$(DEFAULT_DISTRIBUTION),,$(TAG)-$(VARIANT)) && \
-		 gzip -f ${ISTIO_DOCKER_TAR}/$(subst docker.,,$(TGT))$(subst -$(DEFAULT_DISTRIBUTION),,-$(VARIANT)).tar \
-		   ); \
+	$(foreach VARIANT,$(DOCKER_BUILD_VARIANTS), \
+	   if ! ./tools/skip-image.sh $(TGT) $(VARIANT); then \
+	   time ( \
+		 echo $(TGT)-$(VARIANT); \
+		 docker save $(HUB)/$(subst docker.,,$(TGT)):$(subst -$(DEFAULT_DISTRIBUTION),,$(TAG)-$(VARIANT)) |\
+		 gzip --fast > ${ISTIO_DOCKER_TAR}/$(subst docker.,,$(TGT))$(subst -$(DEFAULT_DISTRIBUTION),,-$(VARIANT)).tar.gz \
+	   ); \
+	   fi; \
 	 ))
 
 docker.save: dockerx.save

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -278,6 +278,11 @@ docker.app_sidecar_base_centos_8: pkg/test/echo/docker/Dockerfile.app_sidecar_ba
 	$(RENAME_TEMPLATE)
 	$(DOCKER_RULE)
 
+docker.app_sidecar_base_centos_7: VM_OS_DOCKERFILE_TEMPLATE=Dockerfile.app_sidecar_base_centos
+docker.app_sidecar_base_centos_7: pkg/test/echo/docker/Dockerfile.app_sidecar_base_centos
+	$(RENAME_TEMPLATE)
+	$(DOCKER_RULE)
+
 docker.distroless: docker/Dockerfile.distroless
 	$(DOCKER_RULE)
 

--- a/tools/skip-image.sh
+++ b/tools/skip-image.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Copyright 2019 Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+# This is a dedicated script to allow reference from script and makefile
+
+# Determine if we should skip an image
+# $1 = docker target
+# $2 = variant
+# We will filter out test image distroless variant; they do not need to support distroless
+if [[ $2 == "distroless" ]]; then
+  if [[ $1 =~ docker.app ]]; then
+    exit 0
+  fi
+fi
+exit 1


### PR DESCRIPTION
    Skip distroless for `app-*` images. These add substantial amount of load
    to CI, for no benefit. They are NOT distroless images, we just build
    everything 2x.
