### PR TITLE
make xds send timeout configurable

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -361,4 +361,10 @@ var (
 
 	EnableTLSv2OnInboundPath = env.RegisterBoolVar("PILOT_SIDECAR_ENABLE_INBOUND_TLS_V2", true,
 		"If true, Pilot will set the TLS version on server side as TLSv1_2 and also enforce strong cipher suites").Get()
+
+	XdsPushSendTimeout = env.RegisterDurationVar(
+		"PILOT_XDS_SEND_TIMEOUT",
+		5*time.Second,
+		"The timeout to send the XDS configuration to proxies. After this timeout is reached, Pilot will discard that push.",
+	).Get()
 )

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -42,7 +42,7 @@ var (
 
 	// sendTimeout is the max time to wait for a ADS send to complete. This helps detect
 	// clients in a bad state (not reading). In future it may include checking for ACK
-	sendTimeout = 5 * time.Second
+	sendTimeout = features.XdsPushSendTimeout
 
 	// Tracks connections, increment on each new connection.
 	connectionNumber = int64(0)


### PR DESCRIPTION
We are seeing "2020-09-25T18:36:23.207985Z	info	ads	Timeout writing sidecar~10.100.181.200" in some envs occasionally. 

Making this configurable to test if it helps

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X ] Does not have any changes that may affect Istio users.
