### PR TITLE
Setup ConfigStore in xDS

### DIFF
--- a/manifests/charts/base/files/gen-istio-cluster.yaml
+++ b/manifests/charts/base/files/gen-istio-cluster.yaml
@@ -3502,7 +3502,7 @@ rules:
     resources: ["*"]
   - apiGroups: ["networking.istio.io"]
     verbs: [ "get", "watch", "list", "update", "create", "delete" ]
-    resources: [ "workloadentries" ]
+    resources: [ "workloadentries/status" ]
 
   # auto-detect installed CRD definitions
   - apiGroups: ["apiextensions.k8s.io"]

--- a/manifests/charts/base/files/gen-istio-cluster.yaml
+++ b/manifests/charts/base/files/gen-istio-cluster.yaml
@@ -3502,7 +3502,7 @@ rules:
     resources: ["*"]
   - apiGroups: ["networking.istio.io"]
     verbs: [ "get", "watch", "list", "update", "create", "delete" ]
-    resources: [ "workloadgroups" ]
+    resources: [ "workloadentries" ]
 
   # auto-detect installed CRD definitions
   - apiGroups: ["apiextensions.k8s.io"]

--- a/manifests/charts/base/files/gen-istio-cluster.yaml
+++ b/manifests/charts/base/files/gen-istio-cluster.yaml
@@ -3500,6 +3500,9 @@ rules:
   - apiGroups: ["config.istio.io", "security.istio.io", "networking.istio.io", "authentication.istio.io"]
     verbs: ["get", "watch", "list"]
     resources: ["*"]
+  - apiGroups: ["networking.istio.io"]
+    verbs: [ "get", "watch", "list", "update", "create", "delete" ]
+    resources: [ "workloadgroups" ]
 
   # auto-detect installed CRD definitions
   - apiGroups: ["apiextensions.k8s.io"]

--- a/manifests/charts/base/templates/clusterrole.yaml
+++ b/manifests/charts/base/templates/clusterrole.yaml
@@ -28,7 +28,7 @@ rules:
 {{- end }}
   - apiGroups: ["networking.istio.io"]
     verbs: [ "get", "watch", "list", "update", "create", "delete" ]
-    resources: [ "workloadentries" ]
+    resources: [ "workloadentries/status" ]
 
   # auto-detect installed CRD definitions
   - apiGroups: ["apiextensions.k8s.io"]

--- a/manifests/charts/base/templates/clusterrole.yaml
+++ b/manifests/charts/base/templates/clusterrole.yaml
@@ -26,6 +26,9 @@ rules:
     # TODO: should be on just */status but wildcard is not supported
     resources: ["*"]
 {{- end }}
+  - apiGroups: ["networking.istio.io"]
+    verbs: [ "get", "watch", "list", "update", "create", "delete" ]
+    resources: [ "workloadgroups" ]
 
   # auto-detect installed CRD definitions
   - apiGroups: ["apiextensions.k8s.io"]

--- a/manifests/charts/base/templates/clusterrole.yaml
+++ b/manifests/charts/base/templates/clusterrole.yaml
@@ -28,7 +28,7 @@ rules:
 {{- end }}
   - apiGroups: ["networking.istio.io"]
     verbs: [ "get", "watch", "list", "update", "create", "delete" ]
-    resources: [ "workloadgroups" ]
+    resources: [ "workloadentries" ]
 
   # auto-detect installed CRD definitions
   - apiGroups: ["apiextensions.k8s.io"]

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -239,6 +239,8 @@ func NewServer(args *PilotArgs) (*Server, error) {
 		return nil, err
 	}
 
+	s.XDSServer.InternalGen.Store = s.configController
+
 	s.initJwtPolicy()
 
 	// Options based on the current 'defaults' in istio.

--- a/pilot/pkg/xds/internalgen.go
+++ b/pilot/pkg/xds/internalgen.go
@@ -52,6 +52,8 @@ const (
 type InternalGen struct {
 	Server *DiscoveryServer
 
+	Store model.ConfigStore
+
 	// TODO: track last N Nacks and connection events, with 'version' based on timestamp.
 	// On new connect, use version to send recent events since last update.
 }


### PR DESCRIPTION
This PR makes way for vm auto registration and healthchecking by including `ConfigStore` in `XDSServer`.

The reason this is done separate from VM Auto Registration (#25434) is so VM healthchecking can progress.

cc @howardjohn @stevenctl (taking over auto registration i think)