### PR TITLE
Fix kube controller test flakes.

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -282,27 +282,7 @@ func TestController_GetPodLocality(t *testing.T) {
 			controller, fx := NewFakeControllerWithOptions(FakeControllerOptions{Mode: EndpointsOnly})
 			defer controller.Stop()
 			addNodes(t, controller, tc.nodes...)
-			for _, node := range tc.nodes {
-				if err := waitForNode(controller, node.Name); err != nil {
-					// Ideally we would fail here, but there is a bug in Kubernetes fake client where
-					// it occasionally just does not update informer at all. Rather than skipping the entire test, we will
-					// just skip it if we encounter this condition. Because it happens rarely, we should still
-					// get coverage 99% of the time.
-					t.Skip("https://github.com/kubernetes/kubernetes/issues/88508")
-				}
-			}
-			addPods(t, controller, tc.pods...)
-			for _, pod := range tc.pods {
-				if err := waitForPod(controller, pod.Status.PodIP); err != nil {
-					// Ideally we would fail here, but there is a bug in Kubernetes fake client where
-					// it occasionally just does not update informer at all. Rather than skipping the entire test, we will
-					// just skip it if we encounter this condition. Because it happens rarely, we should still
-					// get coverage 99% of the time.
-					t.Skip("https://github.com/kubernetes/kubernetes/issues/88508")
-				}
-				// pod first time occur will trigger proxy push
-				fx.Wait("proxy")
-			}
+			addPods(t, controller, fx, tc.pods...)
 
 			// Verify expected existing pod AZs
 			for pod, wantAZ := range tc.wantAZ {
@@ -333,10 +313,7 @@ func TestGetProxyServiceInstances(t *testing.T) {
 			})
 			defer controller.Stop()
 			p := generatePod("128.0.0.1", "pod1", "nsa", "foo", "node1", map[string]string{"app": "test-app"}, map[string]string{})
-			addPods(t, controller, p)
-			if err := waitForPod(controller, p.Status.PodIP); err != nil {
-				t.Fatalf("wait for pod err: %v", err)
-			}
+			addPods(t, controller, fx, p)
 
 			k8sSaOnVM := "acct4"
 			canonicalSaOnVM := "acctvm2@gserviceaccount2.com"
@@ -459,10 +436,7 @@ func TestGetProxyServiceInstances(t *testing.T) {
 			// 1. pod without `istio-locality` label, get locality from node label.
 			p = generatePod("129.0.0.1", "pod2", "nsa", "svcaccount", "node1",
 				map[string]string{"app": "prod-app"}, nil)
-			addPods(t, controller, p)
-			if err := waitForPod(controller, p.Status.PodIP); err != nil {
-				t.Fatalf("wait for pod err: %v", err)
-			}
+			addPods(t, controller, fx, p)
 
 			podServices, err := controller.GetProxyServiceInstances(&model.Proxy{
 				Type:            "sidecar",
@@ -518,10 +492,7 @@ func TestGetProxyServiceInstances(t *testing.T) {
 			// 2. pod with `istio-locality` label, ignore node label.
 			p = generatePod("129.0.0.2", "pod3", "nsa", "svcaccount", "node1",
 				map[string]string{"app": "prod-app", "istio-locality": "region.zone"}, nil)
-			addPods(t, controller, p)
-			if err := waitForPod(controller, p.Status.PodIP); err != nil {
-				t.Fatalf("wait for pod err: %v", err)
-			}
+			addPods(t, controller, fx, p)
 
 			podServices, err = controller.GetProxyServiceInstances(&model.Proxy{
 				Type:            "sidecar",
@@ -710,12 +681,7 @@ func TestGetProxyServiceInstancesWithMultiIPsAndTargetPorts(t *testing.T) {
 				// Setup kube caches
 				controller, fx := NewFakeControllerWithOptions(FakeControllerOptions{Mode: mode})
 				defer controller.Stop()
-				addPods(t, controller, c.pods...)
-				for _, pod := range c.pods {
-					if err := waitForPod(controller, pod.Status.PodIP); err != nil {
-						t.Fatalf("wait for pod err: %v", err)
-					}
-				}
+				addPods(t, controller, fx, c.pods...)
 
 				createServiceWithTargetPorts(controller, "svc1", "nsa",
 					map[string]string{
@@ -761,12 +727,7 @@ func TestController_GetIstioServiceAccounts(t *testing.T) {
 				generatePod("128.0.0.2", "pod2", "nsA", sa2, "node2", map[string]string{"app": "prod-app"}, map[string]string{}),
 				generatePod("128.0.0.3", "pod3", "nsB", sa3, "node1", map[string]string{"app": "prod-app"}, map[string]string{}),
 			}
-			addPods(t, controller, pods...)
-			for _, pod := range pods {
-				if err := waitForPod(controller, pod.Status.PodIP); err != nil {
-					t.Fatalf("wait for pod err: %v", err)
-				}
-			}
+			addPods(t, controller, fx, pods...)
 
 			createService(controller, "svc1", "nsA",
 				map[string]string{
@@ -1308,28 +1269,39 @@ func deleteExternalNameService(controller *FakeController, name, namespace strin
 	}
 }
 
-func addPods(t *testing.T, controller *FakeController, pods ...*coreV1.Pod) {
-	for _, pod := range pods {
-		p, _ := controller.client.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metaV1.GetOptions{})
-		var newPod *coreV1.Pod
-		var err error
-		if p == nil {
-			newPod, err = controller.client.CoreV1().Pods(pod.Namespace).Create(context.TODO(), pod, metaV1.CreateOptions{})
-			if err != nil {
-				t.Fatalf("Cannot create %s in namespace %s (error: %v)", pod.ObjectMeta.Name, pod.ObjectMeta.Namespace, err)
+func addPods(t *testing.T, controller *FakeController, fx *FakeXdsUpdater, pods ...*coreV1.Pod) {
+	// Ideally we would fail here, instead of retry but there is a bug in Kubernetes fake client where
+	// it occasionally just does not update informer at all.
+	t.Skip("https://github.com/kubernetes/kubernetes/issues/88508")
+	retry.UntilSuccessOrFail(t, func() error {
+		for _, pod := range pods {
+			p, _ := controller.client.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metaV1.GetOptions{})
+			var newPod *coreV1.Pod
+			var err error
+			if p == nil {
+				newPod, err = controller.client.CoreV1().Pods(pod.Namespace).Create(context.TODO(), pod, metaV1.CreateOptions{})
+				if err != nil {
+					t.Fatalf("Cannot create %s in namespace %s (error: %v)", pod.ObjectMeta.Name, pod.ObjectMeta.Namespace, err)
+				}
+			} else {
+				newPod, err = controller.client.CoreV1().Pods(pod.Namespace).Update(context.TODO(), pod, metaV1.UpdateOptions{})
+				if err != nil {
+					t.Fatalf("Cannot update %s in namespace %s (error: %v)", pod.ObjectMeta.Name, pod.ObjectMeta.Namespace, err)
+				}
 			}
-		} else {
-			newPod, err = controller.client.CoreV1().Pods(pod.Namespace).Update(context.TODO(), pod, metaV1.UpdateOptions{})
-			if err != nil {
-				t.Fatalf("Cannot update %s in namespace %s (error: %v)", pod.ObjectMeta.Name, pod.ObjectMeta.Namespace, err)
+			// Apiserver doesn't allow Create/Update to modify the pod status. Creating doesn't result in
+			// events - since PodIP will be "".
+			newPod.Status.PodIP = pod.Status.PodIP
+			newPod.Status.Phase = coreV1.PodRunning
+			_, _ = controller.client.CoreV1().Pods(pod.Namespace).UpdateStatus(context.TODO(), newPod, metaV1.UpdateOptions{})
+			if err := waitForPod(controller, pod.Status.PodIP); err != nil {
+				return err
 			}
+			// pod first time occur will trigger proxy push
+			fx.Wait("proxy")
 		}
-		// Apiserver doesn't allow Create/Update to modify the pod status. Creating doesn't result in
-		// events - since PodIP will be "".
-		newPod.Status.PodIP = pod.Status.PodIP
-		newPod.Status.Phase = coreV1.PodRunning
-		_, _ = controller.client.CoreV1().Pods(pod.Namespace).UpdateStatus(context.TODO(), newPod, metaV1.UpdateOptions{})
-	}
+		return nil
+	}, retry.Timeout(time.Second*5), retry.Delay(time.Millisecond*10))
 }
 
 func generatePod(ip, name, namespace, saName, node string, labels map[string]string, annotations map[string]string) *coreV1.Pod {
@@ -1377,14 +1349,22 @@ func generateNode(name string, labels map[string]string) *coreV1.Node {
 
 func addNodes(t *testing.T, controller *FakeController, nodes ...*coreV1.Node) {
 	fakeClient := controller.client
-
-	for _, node := range nodes {
-		_, err := fakeClient.CoreV1().Nodes().Create(context.TODO(), node, metaV1.CreateOptions{})
-		if err != nil {
-			t.Fatal(err)
+	retry.UntilSuccessOrFail(t, func() error {
+		for _, node := range nodes {
+			_, err := fakeClient.CoreV1().Nodes().Create(context.TODO(), node, metaV1.CreateOptions{})
+			if errors.IsAlreadyExists(err) {
+				if _, err := fakeClient.CoreV1().Nodes().Update(context.TODO(), node, metaV1.UpdateOptions{}); err != nil {
+					t.Fatal(err)
+				}
+			} else if err != nil {
+				t.Fatal(err)
+			}
+			if err := waitForNode(controller, node.Name); err != nil {
+				return err
+			}
 		}
-	}
-
+		return nil
+	}, retry.Timeout(time.Second*5), retry.Delay(time.Millisecond*10))
 }
 
 func TestEndpointUpdate(t *testing.T) {
@@ -1396,16 +1376,7 @@ func TestEndpointUpdate(t *testing.T) {
 
 			pod1 := generatePod("128.0.0.1", "pod1", "nsA", "", "node1", map[string]string{"app": "prod-app"}, map[string]string{})
 			pods := []*coreV1.Pod{pod1}
-			addPods(t, controller, pods...)
-			for _, pod := range pods {
-				if err := waitForPod(controller, pod.Status.PodIP); err != nil {
-					t.Fatalf("wait for pod err: %v", err)
-				}
-				// pod first time occur will trigger proxy push
-				if ev := fx.Wait("proxy"); ev == nil {
-					t.Fatal("Timeout creating service")
-				}
-			}
+			addPods(t, controller, fx, pods...)
 
 			// 1. incremental eds for normal service endpoint update
 			createService(controller, "svc1", "nsa", nil,
@@ -1468,14 +1439,7 @@ func TestEndpointUpdateBeforePodUpdate(t *testing.T) {
 			// Setup help functions to make the test more explicit
 			addPod := func(name, ip string) {
 				pod := generatePod(ip, name, "nsA", name, "node1", map[string]string{"app": "prod-app"}, map[string]string{})
-				addPods(t, controller, pod)
-				if err := waitForPod(controller, pod.Status.PodIP); err != nil {
-					t.Fatalf("wait for pod err: %v", err)
-				}
-				// pod first time occur will trigger proxy push
-				if ev := fx.Wait("proxy"); ev == nil {
-					t.Fatal("Timeout creating pod")
-				}
+				addPods(t, controller, fx, pod)
 			}
 			deletePod := func(name, ip string) {
 				if err := controller.client.CoreV1().Pods("nsA").Delete(context.TODO(), name, metaV1.DeleteOptions{}); err != nil {
@@ -1631,16 +1595,7 @@ func TestWorkloadInstanceHandlerMultipleEndpoints(t *testing.T) {
 		generateNode("node1", map[string]string{NodeZoneLabel: "zone1", NodeRegionLabel: "region1", IstioSubzoneLabel: "subzone1"}),
 	}
 	addNodes(t, controller, nodes...)
-	addPods(t, controller, pods...)
-	for _, pod := range pods {
-		if err := waitForPod(controller, pod.Status.PodIP); err != nil {
-			t.Fatalf("wait for pod err: %v", err)
-		}
-		// pod first time occurrence will trigger proxy push
-		if ev := fx.Wait("proxy"); ev == nil {
-			t.Fatal("Timeout creating pods")
-		}
-	}
+	addPods(t, controller, fx, pods...)
 	createService(controller, "svc1", "nsA", nil,
 		[]int32{8080}, map[string]string{"app": "prod-app"}, t)
 	if ev := fx.Wait("service"); ev == nil {

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -1270,9 +1270,6 @@ func deleteExternalNameService(controller *FakeController, name, namespace strin
 }
 
 func addPods(t *testing.T, controller *FakeController, fx *FakeXdsUpdater, pods ...*coreV1.Pod) {
-	// Ideally we would fail here, instead of retry but there is a bug in Kubernetes fake client where
-	// it occasionally just does not update informer at all.
-	t.Skip("https://github.com/kubernetes/kubernetes/issues/88508")
 	retry.UntilSuccessOrFail(t, func() error {
 		for _, pod := range pods {
 			p, _ := controller.client.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metaV1.GetOptions{})

--- a/pilot/pkg/serviceregistry/kube/controller/pod_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod_test.go
@@ -113,13 +113,17 @@ func TestIPReuse(t *testing.T) {
 	defer c.Stop()
 	initTestEnv(t, c.client, fx)
 
-	createPod(t, c, "128.0.0.1", "pod")
+	createPod := func(ip, name string) {
+		addPods(t, c, fx, generatePod(ip, name, "ns", "1", "", map[string]string{}, map[string]string{}))
+	}
+
+	createPod("128.0.0.1", "pod")
 	if p, f := c.pods.getPodKey("128.0.0.1"); !f || p != "ns/pod" {
 		t.Fatalf("unexpected pod: %v", p)
 	}
 
 	// Change the pod IP. This can happen if the pod moves to another node, for example.
-	createPod(t, c, "128.0.0.2", "pod")
+	createPod("128.0.0.2", "pod")
 	if p, f := c.pods.getPodKey("128.0.0.2"); !f || p != "ns/pod" {
 		t.Fatalf("unexpected pod: %v", p)
 	}
@@ -128,13 +132,13 @@ func TestIPReuse(t *testing.T) {
 	}
 
 	// A new pod is created with the old IP. We should get new-pod, not pod
-	createPod(t, c, "128.0.0.1", "new-pod")
+	createPod("128.0.0.1", "new-pod")
 	if p, f := c.pods.getPodKey("128.0.0.1"); !f || p != "ns/new-pod" {
 		t.Fatalf("unexpected pod: %v", p)
 	}
 
 	// A new pod is created with the same IP. In theory this should never happen, but maybe we miss an update somehow.
-	createPod(t, c, "128.0.0.1", "another-pod")
+	createPod("128.0.0.1", "another-pod")
 	if p, f := c.pods.getPodKey("128.0.0.1"); !f || p != "ns/another-pod" {
 		t.Fatalf("unexpected pod: %v", p)
 	}
@@ -153,15 +157,8 @@ func TestIPReuse(t *testing.T) {
 	}
 }
 
-func createPod(t *testing.T, c *FakeController, ip, name string) {
-	addPods(t, c, generatePod(ip, name, "ns", "1", "", map[string]string{}, map[string]string{}))
-	if err := waitForPod(c, ip); err != nil {
-		t.Fatal(err)
-	}
-}
-
 func waitForPod(c *FakeController, ip string) error {
-	return wait.Poll(10*time.Millisecond, 5*time.Second, func() (bool, error) {
+	return wait.Poll(10*time.Millisecond, 1*time.Second, func() (bool, error) {
 		c.pods.RLock()
 		defer c.pods.RUnlock()
 		if _, ok := c.pods.podsByIP[ip]; ok {
@@ -175,7 +172,7 @@ func waitForNode(c *FakeController, name string) error {
 	return retry.UntilSuccess(func() error {
 		_, err := c.nodeLister.Get(name)
 		return err
-	}, retry.Timeout(time.Second*5))
+	}, retry.Timeout(time.Second*1), retry.Delay(time.Millisecond*500))
 }
 
 func testPodCache(t *testing.T) {
@@ -194,12 +191,7 @@ func testPodCache(t *testing.T) {
 		generatePod("128.0.0.3", "cpod3", "nsb", "", "", map[string]string{"app": "prod-app-2"}, map[string]string{}),
 	}
 
-	for _, pod := range pods {
-		pod := pod
-		addPods(t, c, pod)
-		// Wait for the workload event
-		_ = waitForPod(c, pod.Status.PodIP)
-	}
+	addPods(t, c, fx, pods...)
 
 	// Verify podCache
 	wantLabels := map[string]labels.Instance{


### PR DESCRIPTION
Previously, we skip tests where the k8s bug is hit. However, we only did
this for some of the tests, so other ones were still flaking. Now, I
tested we can simply retry the create and it will consistently work. I
then abstracted this out to a function that is used by all tests. I
tested this 20k times without failure.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.