### PR TITLE
long log on shifting test failure

### DIFF
--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -324,7 +324,7 @@ spec:
 							return strings.HasPrefix(r.Hostname, host+"-")
 						})
 						if !AlmostEquals(len(hostResponses), exp, errorThreshold) {
-							return fmt.Errorf("expected %v calls to %q, got %v", exp, host, hostResponses)
+							return fmt.Errorf("expected %v calls to %q, got %v", exp, host, len(hostResponses))
 						}
 
 						hostDestinations := apps.All.Match(echo.Service(host))


### PR DESCRIPTION
No need to log the list of ~50 responses (in mc mode). The count is what we're checking here.  