### PR TITLE
proxyv2 - update Dockerfile to use distroless multi-arch image

### DIFF
--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -14,12 +14,11 @@ COPY gcp_envoy_bootstrap.json /var/lib/istio/envoy/gcp_envoy_bootstrap_tmpl.json
 RUN chown -R istio-proxy /var/lib/istio
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
-FROM gcr.io/distroless/cc@sha256:f81e5db8287d66b012d874a6f7fea8da5b96d9cc509aa5a9b5d095a604d4bca1 as distroless
+FROM gcr.io/distroless/cc@sha256:ac75dbf0b249e5e3758134458d447bfd6a85d74c262ecb7cd88df68a3f53c6e3 as distroless
 
 # TODO(https://github.com/istio/istio/issues/17656) clean up this hack
 COPY --from=default /sbin/xtables-multi /sbin/iptables* /sbin/ip6tables* /sbin/ip /sbin/
-COPY --from=default /usr/lib/x86_64-linux-gnu/xtables/ /usr/lib/x86_64-linux-gnu/xtables
-COPY --from=default /usr/lib/x86_64-linux-gnu/ /usr/lib/x86_64-linux-gnu
+COPY --from=default /usr/lib/*-linux-gnu /usr/lib/
 COPY --from=default /etc/iproute2 /etc/iproute2
 
 # Copy Envoy bootstrap templates used by pilot-agent


### PR DESCRIPTION
Addresses #26652 by using a multi-arch Distroless image for proxyv2 and making the COPY architecture agnostic.

This PR replaces https://github.com/istio/istio/pull/27700, which was closed due to a bad re-base from master when trying to fix a failing **integ-distroless-k8s-tests_istio** test.

This change builds/tests locally, however it fails Prow with the error `iptables-restore v1.6.1: unknown option "--dport"`. See https://github.com/istio/istio/pull/27700#issuecomment-703020915 for more information.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[X] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.