### PR TITLE
Update SHAs to pick up Envoy CVE and spanKind

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,7 +4,7 @@
     "name": "PROXY_REPO_SHA",
     "repoName": "proxy",
     "file": "",
-    "lastStableSHA": "ccae1bd37085ecd78415dc06b50233b3b97e30c0"
+    "lastStableSHA": "ef96e9c2f0b0d2a31e3a9426c4b339db0b33885f"
   },
   {
     "_comment": "",


### PR DESCRIPTION
This PR updates the proxy SHA for release-1.6