### PR TITLE
Move shouldRespond

### DIFF
--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -155,6 +155,10 @@ func (s *DiscoveryServer) receive(con *Connection, reqChannel chan *discovery.Di
 			}()
 		}
 
+		if !s.shouldRespond(con, req) {
+			continue
+		}
+
 		select {
 		case reqChannel <- req:
 		case <-con.stream.Context().Done():
@@ -170,10 +174,6 @@ func (s *DiscoveryServer) receive(con *Connection, reqChannel chan *discovery.Di
 func (s *DiscoveryServer) processRequest(req *discovery.DiscoveryRequest, con *Connection) error {
 	if s.StatusReporter != nil {
 		s.StatusReporter.RegisterEvent(con.ConID, req.TypeUrl, req.ResponseNonce)
-	}
-
-	if !s.shouldRespond(con, req) {
-		return nil
 	}
 
 	push := s.globalPushContext()


### PR DESCRIPTION
This moves the shouldRespond to a higher place in the call stack
(the actual recieve go routine) rather than within the receipt of the
channel message on `con.reqChannel`. Goal of this PR is to pull out
the change needed for flow control that is independent of the actual
FlowControl code, as the flow control code is recording race conditions
during testing.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.