### PR TITLE
eastwest sample script generates operator yaml

### DIFF
--- a/pkg/test/framework/components/istio/eastwest.go
+++ b/pkg/test/framework/components/istio/eastwest.go
@@ -61,6 +61,9 @@ func (i *operatorComponent) deployEastWestGateway(cluster resource.Cluster) erro
 	}
 	cmd.Env = append(cmd.Env, customEnv...)
 	gwIOP, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed generating eastwestgateway operator yaml: %v", err)
+	}
 	iopFile := path.Join(i.workDir, fmt.Sprintf("eastwest-%s.yaml", cluster.Name()))
 	if err := ioutil.WriteFile(iopFile, gwIOP, os.ModePerm); err != nil {
 		return err
@@ -94,7 +97,7 @@ func (i *operatorComponent) deployEastWestGateway(cluster resource.Cluster) erro
 	if err := i.ctx.Config(cluster).ApplyYAML(i.settings.SystemNamespace, gwYaml); err != nil {
 		return err
 	}
-	
+
 	// cleanup using operator yaml later
 	i.saveManifestForCleanup(cluster.Name(), string(gwYaml))
 

--- a/pkg/test/framework/components/istio/eastwest.go
+++ b/pkg/test/framework/components/istio/eastwest.go
@@ -62,8 +62,7 @@ func (i *operatorComponent) deployEastWestGateway(cluster resource.Cluster) erro
 	cmd.Env = append(cmd.Env, customEnv...)
 	gwIOP, err := cmd.CombinedOutput()
 	iopFile := path.Join(i.workDir, fmt.Sprintf("eastwest-%s.yaml", cluster.Name()))
-	err = ioutil.WriteFile(iopFile, gwIOP, os.ModePerm)
-	if err != nil {
+	if err := ioutil.WriteFile(iopFile, gwIOP, os.ModePerm); err != nil {
 		return err
 	}
 
@@ -83,8 +82,10 @@ func (i *operatorComponent) deployEastWestGateway(cluster resource.Cluster) erro
 		"-f", iopFile,
 	}
 	scopes.Framework.Infof("Deploying eastwestgateway in %s: %v", cluster.Name(), installSettings)
-	_, _, err = istioCtl.Invoke(installSettings)
-	if err != nil {
+	if stdout, stderr, err := istioCtl.Invoke(installSettings); err != nil {
+		scopes.Framework.Error(stdout)
+		scopes.Framework.Error(stderr)
+		scopes.Framework.Error(err)
 		return fmt.Errorf("failed installing eastwestgateway via IstioOperator: %v", err)
 	}
 

--- a/pkg/test/framework/components/istio/eastwest.go
+++ b/pkg/test/framework/components/istio/eastwest.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"istio.io/istio/pkg/test/framework/components/istioctl"
 	"os"
 	"os/exec"
 	"path"
@@ -28,6 +27,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/istio/pkg/test/env"
+	"istio.io/istio/pkg/test/framework/components/istioctl"
 	"istio.io/istio/pkg/test/framework/image"
 	"istio.io/istio/pkg/test/framework/resource"
 	"istio.io/istio/pkg/test/scopes"
@@ -99,7 +99,7 @@ func (i *operatorComponent) deployEastWestGateway(cluster resource.Cluster) erro
 	}
 
 	// cleanup using operator yaml later
-	i.saveManifestForCleanup(cluster.Name(), string(gwYaml))
+	i.saveManifestForCleanup(cluster.Name(), gwYaml)
 
 	// wait for a ready pod
 	if err := retry.UntilSuccess(func() error {

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -76,6 +76,7 @@ type operatorComponent struct {
 	// The key is the cluster name
 	installManifest map[string][]string
 	ingress         map[resource.ClusterIndex]map[string]ingress.Instance
+	workDir         string
 }
 
 var _ io.Closer = &operatorComponent{}
@@ -225,6 +226,7 @@ func deploy(ctx resource.Context, env *kube.Environment, cfg Config) (Instance, 
 	if err != nil {
 		return nil, err
 	}
+	i.workDir = workDir
 
 	//generate istioctl config files for config, control plane(primary) and remote clusters
 	istioctlConfigFiles, err := createIstioctlConfigFile(workDir, cfg, env)

--- a/samples/multicluster/gen-eastwest-gateway.sh
+++ b/samples/multicluster/gen-eastwest-gateway.sh
@@ -20,6 +20,8 @@ set -euo pipefail
 IOP=$(cat <<EOF
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
+metadata:
+  name: eastwest
 spec:
   # Only generate a gateway component defined below.
   # Using this with "istioctl install" will reconcile and remove existing control-plane components.

--- a/samples/multicluster/gen-eastwest-gateway.sh
+++ b/samples/multicluster/gen-eastwest-gateway.sh
@@ -14,8 +14,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-ARGS=("${@:-}")
-
 set -euo pipefail
 
 # single-cluster installations may need this gateway to allow VMs to get discovery
@@ -82,12 +80,4 @@ EOF
 )
 fi
 
-if [[ "${#}" -gt 0 ]]; then
-  GEN_PARAMS=("${ARGS[@]}")
-fi
-GEN_PARAMS+=("-f" "-")
-
-# Generate the YAML for the east-west gateway.
-istioctl manifest generate "${GEN_PARAMS[@]}" <<EOF
-$IOP
-EOF
+echo "$IOP"


### PR DESCRIPTION
This removes istioctl from the script, the user can use the generated yaml with`isitoctl generate` and `kubectl` or modify it and use it how they see fit. We will need to update any docs that reference this script. 

fixes https://github.com/istio/istio/issues/27644