### PR TITLE
[Test Framework] Skip suite for custom setup with pre-installed Istio.

### DIFF
--- a/pkg/test/framework/components/istio/istio.go
+++ b/pkg/test/framework/components/istio/istio.go
@@ -75,6 +75,10 @@ func Setup(i *Instance, cfn SetupConfigFn, ctxFns ...SetupContextFn) resource.Se
 			return err
 		}
 		if cfn != nil {
+			if !cfg.DeployIstio {
+				ctx.Skip("Custom setup cannot be applied to pre-installed Istio")
+				return nil
+			}
 			cfn(ctx, &cfg)
 		}
 		for _, ctxFn := range ctxFns {

--- a/pkg/test/framework/resource/context.go
+++ b/pkg/test/framework/resource/context.go
@@ -76,4 +76,7 @@ type Context interface {
 	// Config returns a ConfigManager that writes config to the provide clusers. If
 	// no clusters are provided, writes to all clusters.
 	Config(clusters ...Cluster) ConfigManager
+
+	// Skip the tests associated with this context with the given message.
+	Skip(args ...interface{})
 }

--- a/pkg/test/framework/runtime.go
+++ b/pkg/test/framework/runtime.go
@@ -29,8 +29,8 @@ type runtime struct {
 }
 
 // newRuntime returns a new runtime instance.
-func newRuntime(s *resource.Settings, fn resource.EnvironmentFactory, labels label.Set) (*runtime, error) {
-	ctx, err := newSuiteContext(s, fn, labels)
+func newRuntime(suite Suite, settings *resource.Settings, fn resource.EnvironmentFactory, labels label.Set) (*runtime, error) {
+	ctx, err := newSuiteContext(suite, settings, fn, labels)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/test/framework/suite.go
+++ b/pkg/test/framework/suite.go
@@ -466,7 +466,7 @@ func initRuntime(s *suiteImpl) error {
 	}
 	scopes.Framework.Infof("Test run dir: %v", settings.RunDir())
 
-	rt, err = newRuntime(settings, environmentFactory, s.labels)
+	rt, err = newRuntime(s, settings, environmentFactory, s.labels)
 	return err
 }
 


### PR DESCRIPTION
Currently, we can't run all of our tests against a pre-installed Istio because many rely on custom installation configuration. This change detects which suites require this custom setup and skips the suite automatically.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.