### PR TITLE
Add validation warnings to webhook

### DIFF
--- a/pkg/kube/adapter.go
+++ b/pkg/kube/adapter.go
@@ -150,6 +150,12 @@ type AdmissionResponse struct {
 	// admission webhook name (e.g. imagepolicy.example.com/error=image-blacklisted). AuditAnnotations will be provided by
 	// the admission webhook to add additional context to the audit log for this request.
 	AuditAnnotations map[string]string `json:"auditAnnotations,omitempty"`
+
+	// warnings is a list of warning messages to return to the requesting API client.
+	// Warning messages describe a problem the client making the API request should correct or be aware of.
+	// Limit warnings to 120 characters if possible.
+	// Warnings over 256 characters and large numbers of warnings may be truncated.
+	Warnings []string `json:"warnings,omitempty"`
 }
 
 func AdmissionReviewKubeToAdapter(object runtime.Object) (*AdmissionReview, error) {
@@ -163,10 +169,11 @@ func AdmissionReviewKubeToAdapter(object runtime.Object) (*AdmissionReview, erro
 		arv1beta1Request := obj.Request
 		if arv1beta1Response != nil {
 			resp = &AdmissionResponse{
-				UID:     arv1beta1Response.UID,
-				Allowed: arv1beta1Response.Allowed,
-				Result:  arv1beta1Response.Result,
-				Patch:   arv1beta1Response.Patch,
+				UID:      arv1beta1Response.UID,
+				Allowed:  arv1beta1Response.Allowed,
+				Result:   arv1beta1Response.Result,
+				Patch:    arv1beta1Response.Patch,
+				Warnings: arv1beta1Response.Warnings,
 			}
 			if arv1beta1Response.PatchType != nil {
 				patchType := string(*arv1beta1Response.PatchType)
@@ -193,10 +200,11 @@ func AdmissionReviewKubeToAdapter(object runtime.Object) (*AdmissionReview, erro
 		arv1Request := obj.Request
 		if arv1Response != nil {
 			resp = &AdmissionResponse{
-				UID:     arv1Response.UID,
-				Allowed: arv1Response.Allowed,
-				Result:  arv1Response.Result,
-				Patch:   arv1Response.Patch,
+				UID:      arv1Response.UID,
+				Allowed:  arv1Response.Allowed,
+				Result:   arv1Response.Result,
+				Patch:    arv1Response.Patch,
+				Warnings: arv1Response.Warnings,
 			}
 			if arv1Response.PatchType != nil {
 				patchType := string(*arv1Response.PatchType)
@@ -270,6 +278,7 @@ func AdmissionReviewAdapterToKube(ar *AdmissionReview, apiVersion string) runtim
 				Patch:            arResponse.Patch,
 				PatchType:        patchType,
 				AuditAnnotations: arResponse.AuditAnnotations,
+				Warnings:         arResponse.Warnings,
 			}
 		}
 		arv1beta1.TypeMeta = ar.TypeMeta
@@ -307,6 +316,7 @@ func AdmissionReviewAdapterToKube(ar *AdmissionReview, apiVersion string) runtim
 				Patch:            arResponse.Patch,
 				PatchType:        patchType,
 				AuditAnnotations: arResponse.AuditAnnotations,
+				Warnings:         arResponse.Warnings,
 			}
 		}
 		arv1.TypeMeta = ar.TypeMeta

--- a/releasenotes/notes/validation-warning.yaml
+++ b/releasenotes/notes/validation-warning.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+issue:
+  - 27179
+releaseNotes:
+  - |
+    **Added** support for warnings to the validation webhook, allowing deprecated feature usage to be reported. This is only supported in Kubernetes 1.19+.


### PR DESCRIPTION
Output:
```
$ kaf /tmp/old.yaml
Warning: outlier detection consecutive errors is deprecated, use consecutiveGatewayErrors or consecutive5xxErrors instead
destinationrule.networking.istio.io/reviews-cb-policy created
```

Note - output format is dictated by Kubernetes, I have no control over that.

On older kubernetes, this field is ignored



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.