### PR TITLE
Use Info instead of Warn for istioctl analyzer istio injection

### DIFF
--- a/galley/pkg/config/analysis/analyzers/injection/injection.go
+++ b/galley/pkg/config/analysis/analyzers/injection/injection.go
@@ -72,7 +72,7 @@ func (a *Analyzer) Analyze(c analysis.Context) {
 			// TODO: if Istio is installed with sidecarInjectorWebhook.enableNamespacesByDefault=true
 			// (in the istio-sidecar-injector configmap), we need to reverse this logic and treat this as an injected namespace
 
-			m := msg.NewNamespaceNotInjected(r, r.Metadata.FullName.String(), r.Metadata.FullName.String())
+			m := msg.NewNamespaceNotInjected(r, ns, ns)
 
 			if line, ok := util.ErrorLine(r, fmt.Sprintf(util.MetadataName)); ok {
 				m.Line = line
@@ -85,9 +85,7 @@ func (a *Analyzer) Analyze(c analysis.Context) {
 		if okNewInjectionLabel {
 			if injectionLabel != "" {
 
-				m := msg.NewNamespaceMultipleInjectionLabels(r,
-					r.Metadata.FullName.String(),
-					r.Metadata.FullName.String())
+				m := msg.NewNamespaceMultipleInjectionLabels(r, ns, ns)
 
 				if line, ok := util.ErrorLine(r, fmt.Sprintf(util.MetadataName)); ok {
 					m.Line = line
@@ -101,7 +99,7 @@ func (a *Analyzer) Analyze(c analysis.Context) {
 			return true
 		}
 
-		injectedNamespaces[r.Metadata.FullName.String()] = true
+		injectedNamespaces[ns] = true
 
 		return true
 	})

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -23,7 +23,7 @@ var (
 
 	// NamespaceNotInjected defines a diag.MessageType for message "NamespaceNotInjected".
 	// Description: A namespace is not enabled for Istio injection.
-	NamespaceNotInjected = diag.NewMessageType(diag.Warning, "IST0102", "The namespace is not enabled for Istio injection. Run 'kubectl label namespace %s istio-injection=enabled' to enable it, or 'kubectl label namespace %s istio-injection=disabled' to explicitly mark it as not needing injection")
+	NamespaceNotInjected = diag.NewMessageType(diag.Info, "IST0102", "The namespace is not enabled for Istio injection. Run 'kubectl label namespace %s istio-injection=enabled' to enable it, or 'kubectl label namespace %s istio-injection=disabled' to explicitly mark it as not needing injection.")
 
 	// PodMissingProxy defines a diag.MessageType for message "PodMissingProxy".
 	// Description: A pod is missing the Istio proxy.

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -32,9 +32,9 @@ messages:
 
   - name: "NamespaceNotInjected"
     code: IST0102
-    level: Warning
+    level: Info
     description: "A namespace is not enabled for Istio injection."
-    template: "The namespace is not enabled for Istio injection. Run 'kubectl label namespace %s istio-injection=enabled' to enable it, or 'kubectl label namespace %s istio-injection=disabled' to explicitly mark it as not needing injection"
+    template: "The namespace is not enabled for Istio injection. Run 'kubectl label namespace %s istio-injection=enabled' to enable it, or 'kubectl label namespace %s istio-injection=disabled' to explicitly mark it as not needing injection."
     args:
       - name: namespace
         type: string


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/27390

Before:
```
$ istioctl analyze --all-namespaces
Warning [IST0102] (Namespace kube-node-lease) The namespace is not enabled for Istio injection. Run 'kubectl label namespace kube-node-lease istio-injection=enabled' to enable it, or 'kubectl label namespace kube-node-lease istio-injection=disabled' to explicitly mark it as not needing injection
Warning [IST0102] (Namespace local-path-storage) The namespace is not enabled for Istio injection. Run 'kubectl label namespace local-path-storage istio-injection=enabled' to enable it, or 'kubectl label namespace local-path-storage istio-injection=disabled' to explicitly mark it as not needing injection
Error: Analyzers found issues when analyzing all namespaces.
See https://istio.io/v1.8/docs/reference/config/analysis for more information about causes and resolutions.
```

After:
```
$ ./out/linux_amd64/istioctl analyze --all-namespaces
Info [IST0102] (Namespace kube-node-lease) The namespace is not enabled for Istio injection. Run 'kubectl label namespace kube-node-lease istio-injection=enabled' to enable it, or 'kubectl label namespace kube-node-lease istio-injection=disabled' to explicitly mark it as not needing injection.
Info [IST0102] (Namespace local-path-storage) The namespace is not enabled for Istio injection. Run 'kubectl label namespace local-path-storage istio-injection=enabled' to enable it, or 'kubectl label namespace local-path-storage istio-injection=disabled' to explicitly mark it as not needing injection.
```