### PR TITLE
Exclude kube system namespaces for istioctl analyze

### DIFF
--- a/galley/pkg/config/analysis/analyzers/util/config.go
+++ b/galley/pkg/config/analysis/analyzers/util/config.go
@@ -19,8 +19,15 @@ import (
 )
 
 // IsSystemNamespace returns true for system namespaces
+// Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/#viewing-namespaces
+// "kube-system": The namespace for objects created by the Kubernetes system.
+// "kube-public": This namespace is mostly reserved for cluster usage.
+// "kube-node-lease": This namespace for the lease objects associated with each node
+//    which improves the performance of the node heartbeats as the cluster scales.
+// "local-path-storage": Dynamically provisioning persistent local storage with Kubernetes.
+//    used with Kind cluster: https://github.com/rancher/local-path-provisioner
 func IsSystemNamespace(ns resource.Namespace) bool {
-	return ns == "kube-system" || ns == "kube-public"
+	return ns == "kube-system" || ns == "kube-public" || ns == "kube-node-lease" || ns == "local-path-storage"
 }
 
 // IsIstioControlPlane returns true for resources that are part of the Istio control plane


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/27791

Before:
```
$ istioctl analyze --all-namespaces
Warning [IST0102] (Namespace kube-node-lease) The namespace is not enabled for Istio injection. Run 'kubectl label namespace kube-node-lease istio-injection=enabled' to enable it, or 'kubectl label namespace kube-node-lease istio-injection=disabled' to explicitly mark it as not needing injection
Warning [IST0102] (Namespace local-path-storage) The namespace is not enabled for Istio injection. Run 'kubectl label namespace local-path-storage istio-injection=enabled' to enable it, or 'kubectl label namespace local-path-storage istio-injection=disabled' to explicitly mark it as not needing injection
Error: Analyzers found issues when analyzing all namespaces.
See https://istio.io/v1.8/docs/reference/config/analysis for more information about causes and resolutions.
```

After:
```
$ ./out/linux_amd64/istioctl analyze --all-namespaces

✔ No validation issues found when analyzing all namespaces.
```