### PR TITLE
allow configuring pull secrets for operator

### DIFF
--- a/manifests/charts/istio-operator/templates/service_account.yaml
+++ b/manifests/charts/istio-operator/templates/service_account.yaml
@@ -1,5 +1,11 @@
 apiVersion: v1
 kind: ServiceAccount
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
 metadata:
   namespace: {{.Values.operatorNamespace}}
   name: istio-operator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}

--- a/manifests/charts/istio-operator/values.yaml
+++ b/manifests/charts/istio-operator/values.yaml
@@ -1,3 +1,10 @@
+
+global:
+  # ImagePullSecrets for operator ServiceAccount, list of secrets in the same namespace
+  # to use for pulling any images in pods that reference this ServiceAccount.
+  # Must be set for any cluster configured with private docker registry.
+  imagePullSecrets: []
+
 hub: gcr.io/istio-testing
 tag: latest
 


### PR DESCRIPTION
Currently all the components allow configuring a docker pull secret in their service accounts, except for the operator itself. This PR allows configuring pull secrets for the operator. The result is an end-to-end support for private docker registries.

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

The list is optional and contains the names of kubernetes secrets to use as docker pull secrets in the operator's service accounts. For example, this input in the chart values:
```yaml
global:
  imagePullSecrets:
  - my-pull-secret
  - another-pull-secret
```
causes generating the following part in the service account:
```yaml
apiVersion: v1
kind: ServiceAccount
imagePullSecrets:
- name: my-pull-secret
- name: another-pull-secret
...
```
The secrets are assumed to exist in the same namespace istio-operator is installed in. More info in the official documentation https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod