### PR TITLE
make sure concatenated certs are separated by new lines

### DIFF
--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -873,10 +873,7 @@ func (sc *SecretCache) generateSecret(ctx context.Context, token string, connKey
 	cacheLog.Debugf("%s received CSR response with certificate chain %+v \n",
 		logPrefix, certChainPEM)
 
-	certChain := []byte{}
-	for _, c := range certChainPEM {
-		certChain = append(certChain, []byte(c)...)
-	}
+	certChain := concatCerts(certChainPEM)
 
 	var expireTime time.Time
 	// Cert expire time by default is createTime + sc.configOptions.SecretTTL.
@@ -1044,4 +1041,19 @@ func (sc *SecretCache) useCertToRotate() bool {
 		return false
 	}
 	return true
+}
+
+// concatCerts concatenates PEM certificates, making sure each one starts on a new line
+func concatCerts(certsPEM []string) []byte {
+	if len(certsPEM) == 0 {
+		return []byte{}
+	}
+	var certChain bytes.Buffer
+	for i, c := range certsPEM {
+		certChain.WriteString(c)
+		if i < len(certsPEM)-1 && !strings.HasSuffix(c, "\n") {
+			certChain.WriteString("\n")
+		}
+	}
+	return certChain.Bytes()
 }

--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -1201,3 +1201,42 @@ func TestShouldRotate(t *testing.T) {
 		}
 	}
 }
+
+func TestConcatCerts(t *testing.T) {
+	cases := []struct {
+		name     string
+		certs    []string
+		expected string
+	}{
+		{
+			name:     "no certs",
+			certs:    []string{},
+			expected: "",
+		},
+		{
+			name:     "single cert",
+			certs:    []string{"a"},
+			expected: "a",
+		},
+		{
+			name:     "multiple certs",
+			certs:    []string{"a", "b"},
+			expected: "a\nb",
+		},
+		{
+			name:     "existing newline",
+			certs:    []string{"a\n", "b"},
+			expected: "a\nb",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := string(concatCerts(c.certs))
+			if result != c.expected {
+				t.Fatalf("expected %q, got %q", c.expected, result)
+			}
+		})
+
+	}
+}


### PR DESCRIPTION

Fixes https://github.com/istio/istio/issues/24609.

Istio installation fails when using an existing CA, unless the cert chain ends with a newline.
The reason is that the code concatenates the cert chain with the root cert, resulting in an invalid PEM certificate due the following line: 
```
-----END CERTIFICATE----------BEGIN CERTIFICATE-----
``` 

This PR makes sure that when concatenating certificates they are always separated by a newline. If the cert chain doesn't end with a newline, it adds it resulting in a valid 
```
-----END CERTIFICATE-----
-----BEGIN CERTIFICATE-----
```


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.