### PR TITLE
Enable ADS proxy by default

### DIFF
--- a/manifests/profiles/preview.yaml
+++ b/manifests/profiles/preview.yaml
@@ -10,8 +10,6 @@ spec:
         # Enable Istio agent to handle DNS requests for known hosts
         # Unknown hosts will automatically be resolved using upstream dns servers in resolv.conf
         ISTIO_META_DNS_CAPTURE: "true"
-        # proxy envoy xds via istio agent (pre-req for dns)
-        ISTIO_META_PROXY_XDS_VIA_AGENT: "true"
   values:
     telemetry:
       v2:

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -150,7 +150,7 @@ var (
 	skipParseTokenEnv = env.RegisterBoolVar("SKIP_PARSE_TOKEN", false,
 		"Skip Parse token to inspect information like expiration time in proxy. This may be possible "+
 			"for example in vm we don't use token to rotate cert.").Get()
-	proxyXDSViaAgent = env.RegisterBoolVar("ISTIO_META_PROXY_XDS_VIA_AGENT", false,
+	proxyXDSViaAgent = env.RegisterBoolVar("PROXY_XDS_VIA_AGENT", true,
 		"If set to true, envoy will proxy XDS calls via the agent instead of directly connecting to istiod. This option "+
 			"will be removed once the feature is stabilized.").Get()
 	// This is a copy of the env var in the init code.

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -492,9 +492,6 @@ type NodeMetadata struct {
 	// DNSCapture indicates whether the workload has enabled dns capture
 	DNSCapture string `json:"DNS_CAPTURE,omitempty"`
 
-	// ProxyXDSViaAgent indicates that xds data is being proxied via the agent
-	ProxyXDSViaAgent string `json:"PROXY_XDS_VIA_AGENT,omitempty"`
-
 	// Contains a copy of the raw metadata. This is needed to lookup arbitrary values.
 	// If a value is known ahead of time it should be added to the struct rather than reading from here,
 	Raw map[string]interface{} `json:"-"`

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -263,7 +263,7 @@ spec:
           # Block standard inbound ports
           sudo sh -c 'echo ISTIO_LOCAL_EXCLUDE_PORTS="15090,15021,15020" >> /var/lib/istio/envoy/cluster.env'
           # Proxy XDS via agent first
-          sudo sh -c 'echo ISTIO_META_PROXY_XDS_VIA_AGENT=true >> /var/lib/istio/envoy/cluster.env'
+          sudo sh -c 'echo PROXY_XDS_VIA_AGENT=true >> /var/lib/istio/envoy/cluster.env'
           # Capture all DNS traffic in the VM and forward to Envoy
           sudo sh -c 'echo ISTIO_META_DNS_CAPTURE=true >> /var/lib/istio/envoy/cluster.env'
           sudo sh -c 'echo ISTIO_PILOT_PORT={{$.VM.IstiodPort}} >> /var/lib/istio/envoy/cluster.env'

--- a/releasenotes/notes/agent-xds-proxy.yaml
+++ b/releasenotes/notes/agent-xds-proxy.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+issue: []
+releaseNotes:
+- |
+  **Updated** the XDS connection to be proxied through the local agent. This enables a number of new features,
+  but should otherwise be transparent to users. This feature is enabled by default and can be disable by setting the following in the
+  Istio Operator: `meshConfig.defaultConfig.proxyMetadata.PROXY_XDS_VIA_AGENT="false"`.

--- a/releasenotes/notes/agent-xds-proxy.yaml
+++ b/releasenotes/notes/agent-xds-proxy.yaml
@@ -4,6 +4,7 @@ area: networking
 issue: []
 releaseNotes:
 - |
-  **Updated** the XDS connection to be proxied through the local agent. This enables a number of new features,
-  but should otherwise be transparent to users. This feature is enabled by default and can be disable by setting the following in the
-  Istio Operator: `meshConfig.defaultConfig.proxyMetadata.PROXY_XDS_VIA_AGENT="false"`.
+  **Updated** XDS connections from Envoy will be proxied through the Istio sidecar agent. Doing so allows
+  for consolidation of multiple connections from a pod to Istiod into a single connection, in addition to
+  other planned future improvements. This feature (and change) is transparent to users and is enabled by default.
+  It can be disabled by setting the following in the Istio Operator: meshConfig.defaultConfig.proxyMetadata.PROXY_XDS_VIA_AGENT="false".

--- a/tests/integration/iop-integration-test-defaults.yaml
+++ b/tests/integration/iop-integration-test-defaults.yaml
@@ -6,7 +6,6 @@ spec:
     accessLogFile: "/dev/stdout"
     defaultConfig:
       proxyMetadata:
-        ISTIO_META_PROXY_XDS_VIA_AGENT: "true"
         ISTIO_META_DNS_CAPTURE: "true"
   components:
     ingressGateways:


### PR DESCRIPTION
Additionally, stop sending it in the node metadata since this is
transparent to Istiod. This is not required and I can revert if there
are objections, the reason I included this was becuase if we actually
want to include it in the metadata we need to explicitly export the env
var, rather than this approach where the env is just an override.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.