### PR TITLE
Add OWNERS for samples/multicluster

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -42,6 +42,7 @@ Makefile*                                                        @istio/wg-test-
 /releasenotes/                                                   @istio/wg-test-and-release-maintainers @istio/release-managers
 /samples/                                                        @istio/wg-docs-maintainers
 /samples/addons                                                  @istio/wg-policies-and-telemetry-maintainers @istio/wg-environments-maintainers
+/samples/multicluster                                            @istio/wg-networking-maintainers
 /security/                                                       @istio/wg-security-maintainers
 /tests/                                                          @istio/wg-test-and-release-maintainers
 /tests/integration/conformance/                                  @istio/wg-test-and-release-maintainers


### PR DESCRIPTION
This is currently owned by docs which doesn't make sense as its scripts and install YAMLs owned by networking