### PR TITLE
helm: sort crd files by name

### DIFF
--- a/operator/pkg/helm/helm.go
+++ b/operator/pkg/helm/helm.go
@@ -43,7 +43,8 @@ const (
 	// DefaultProfileString is the name of the default profile.
 	DefaultProfileString = "default"
 
-	// notes file name suffix for the helm chart.
+	// NotesFileNameSuffix is the file name suffix for helm notes.
+	// see https://helm.sh/docs/chart_template_guide/notes_files/
 	NotesFileNameSuffix = ".txt"
 )
 
@@ -143,6 +144,9 @@ func renderChart(namespace, values string, chrt *chart.Chart) (string, error) {
 			return "", err
 		}
 	}
+
+	// Sort crd files by name to ensure stable manifest output
+	sort.Slice(crdFiles, func(i, j int) bool { return crdFiles[i].Name < crdFiles[j].Name })
 	for _, crdFile := range crdFiles {
 		f := string(crdFile.File.Data)
 		// add yaml separator if the rendered file doesn't have one at the end


### PR DESCRIPTION
When validating the differences between deployed manifests, I've found that the output from VFS-embedded CRD files is not completely stable between different compilations of istioctl. In particular, the CRDs appear to be in different orders depending on the particular binary I use (or maybe something else at runtime). For non-CRD files, [the output is sorted by filename](https://github.com/istio/istio/blob/master/operator/pkg/helm/helm.go#L123-L131), but the CRD files [are not sorted](https://github.com/istio/istio/blob/master/operator/pkg/helm/helm.go#L146).

This only becomes an issue when a chart has multiple CRD files. This occurs in Istio in the [base chart](https://github.com/istio/istio/tree/master/manifests/charts/base/crds). This appears to only happen occasionally, I've observed unstable ordering on several Istio release binaries.

This PR sorts the CRD files before writing them to the output strings.Builder to achieve stable output.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
