### PR TITLE
Add support for custom headers in the agent proxy

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -413,16 +413,16 @@ var (
 // Simplified extraction of gRPC headers from environment.
 // Unlike ISTIO_META, where we need JSON and advanced features - this is just for small string headers.
 func extractXDSHeadersFromEnv(config *istio_agent.AgentConfig) {
-		envs := os.Environ()
-		for _, e := range envs {
-			if strings.HasPrefix(e, xdsHeaderPrefix) {
-				parts := strings.SplitN(e, "=", 2)
-				if len(parts) != 2 {
-					continue
-				}
-				config.XDSHeaders[parts[0][len(xdsHeaderPrefix):]] = parts[1]
+	envs := os.Environ()
+	for _, e := range envs {
+		if strings.HasPrefix(e, xdsHeaderPrefix) {
+			parts := strings.SplitN(e, "=", 2)
+			if len(parts) != 2 {
+				continue
 			}
+			config.XDSHeaders[parts[0][len(xdsHeaderPrefix):]] = parts[1]
 		}
+	}
 }
 
 func initStatusServer(ctx context.Context, proxyIPv6 bool, proxyConfig meshconfig.ProxyConfig) error {

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -147,6 +147,9 @@ type AgentConfig struct {
 	// CARootCerts of the location of the root CA for the CA connection. Used for setting platform certs or
 	// using custom roots.
 	CARootCerts string
+
+	// Extra headers to add to the XDS connection.
+	XDSHeaders map[string]string
 }
 
 // NewAgent wraps the logic for a local SDS. It will check if the JWT token required for local SDS is


### PR DESCRIPTION
Change-Id: I0dee2da459f05ee5a32a23438a03ab516877cd6f

Envoy - when using google-grpc - supports adding custom headers. 
This is needed when the XDS server is running behind external load balancers, or needs special handling.

Note that "ClusterID" is already added to headers. 

Using the same mechanism we use for node metadata - env variables - this is not a candidate for 
ProxyConfig because we can't guarantee support for all cases. 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
