### PR TITLE
support PATCH in crdclient

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,6 +89,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
+	gomodules.xyz/jsonpatch/v2 v2.0.1
 	google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d
 	google.golang.org/grpc v1.33.0-dev.0.20200828165940-d8ef479ab79a
 	google.golang.org/grpc/examples v0.0.0-20200825162801-44d73dff99bf // indirect

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -28,11 +28,14 @@ import (
 	"fmt"
 	"time"
 
+	"gomodules.xyz/jsonpatch/v2"
+
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/client-go/informers"
 
 	//  import GKE cluster authentication plugin
@@ -109,7 +112,7 @@ func (cl *Client) RegisterEventHandler(kind config.GroupVersionKind, handler fun
 	h.handlers = append(h.handlers, handler)
 }
 
-// Start the queue and all informers. Callers should  wait for HasSynced() before depending on results.
+// Run the queue and all informers. Callers should  wait for HasSynced() before depending on results.
 func (cl *Client) Run(stop <-chan struct{}) {
 	t0 := time.Now()
 	scope.Infoa("Starting Pilot K8S CRD controller")
@@ -230,6 +233,28 @@ func (cl *Client) Update(config config.Config) (string, error) {
 	return meta.GetResourceVersion(), nil
 }
 
+// PatchFunc provides the cached config as a base for modification. The diff between the input value and the modified
+// return will be used to apply a patch in Kubrenetes.
+type PatchFunc func(cfg config.Config) config.Config
+
+// Patch applies only the modifications made in the PatchFunc rather than doing a full replace. Useful to avoid
+// read-modify-write conflicts when there are many concurrent-writers to the same resource.
+func (cl *Client) Patch(typ config.GroupVersionKind, name, namespace string, patchFn PatchFunc) (string, error) {
+	orig := cl.Get(typ, name, namespace)
+	if orig == nil {
+		// TODO error from GET
+		return "", fmt.Errorf("failed getting base config")
+	}
+	modified := patchFn(orig.DeepCopy())
+
+	oo := *orig
+	meta, err := patch(cl.istioClient, cl.serviceApisClient, oo, getObjectMetadata(oo), modified, getObjectMetadata(modified))
+	if err != nil {
+		return "", err
+	}
+	return meta.GetResourceVersion(), nil
+}
+
 // Delete implements store interface
 func (cl *Client) Delete(typ config.GroupVersionKind, name, namespace string) error {
 	return delete(cl.istioClient, cl.serviceApisClient, typ, name, namespace)
@@ -322,4 +347,22 @@ func getObjectMetadata(config config.Config) metav1.ObjectMeta {
 		Labels:      config.Labels,
 		Annotations: config.Annotations,
 	}
+}
+
+func genPatchBytes(oldRes, modRes runtime.Object) ([]byte, error) {
+	oldJson, err := json.Marshal(oldRes)
+	if err != nil {
+		return nil, err
+	}
+	newJson, err := json.Marshal(modRes)
+	if err != nil {
+		return nil, err
+	}
+	// TODO apply requires a "merge" style patch; see CreateTwoWayMerge patch or CreateMergePatch
+	ops, err := jsonpatch.CreatePatch(oldJson, newJson)
+	if err != nil {
+		return nil, err
+	}
+	// TODO apply may require setting gvk ourselves on the patch payload
+	return json.Marshal(ops)
 }

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"gomodules.xyz/jsonpatch/v2"
-
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -350,16 +349,16 @@ func getObjectMetadata(config config.Config) metav1.ObjectMeta {
 }
 
 func genPatchBytes(oldRes, modRes runtime.Object) ([]byte, error) {
-	oldJson, err := json.Marshal(oldRes)
+	oldJSON, err := json.Marshal(oldRes)
 	if err != nil {
 		return nil, err
 	}
-	newJson, err := json.Marshal(modRes)
+	newJSON, err := json.Marshal(modRes)
 	if err != nil {
 		return nil, err
 	}
 	// TODO apply requires a "merge" style patch; see CreateTwoWayMerge patch or CreateMergePatch
-	ops, err := jsonpatch.CreatePatch(oldJson, newJson)
+	ops, err := jsonpatch.CreatePatch(oldJSON, newJSON)
 	if err != nil {
 		return nil, err
 	}

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -239,6 +239,7 @@ type PatchFunc func(cfg config.Config) config.Config
 // Patch applies only the modifications made in the PatchFunc rather than doing a full replace. Useful to avoid
 // read-modify-write conflicts when there are many concurrent-writers to the same resource.
 func (cl *Client) Patch(typ config.GroupVersionKind, name, namespace string, patchFn PatchFunc) (string, error) {
+	// it is okay if orig is stale - we just care about the diff
 	orig := cl.Get(typ, name, namespace)
 	if orig == nil {
 		// TODO error from GET

--- a/pilot/pkg/config/kube/crdclient/gen/types.go.tmpl
+++ b/pilot/pkg/config/kube/crdclient/gen/types.go.tmpl
@@ -28,9 +28,10 @@ import (
 	versionedclient "istio.io/client-go/pkg/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+    "k8s.io/apimachinery/pkg/types"
 	serviceapisclient "sigs.k8s.io/service-apis/pkg/client/clientset/versioned"
 
-	config "istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
 
 	networkingv1alpha3 "istio.io/api/networking/v1alpha3"
@@ -68,6 +69,35 @@ func update(ic versionedclient.Interface, sc serviceapisclient.Interface, cfg co
 		return nil, fmt.Errorf("unsupported type: %v", cfg.GroupVersionKind)
 	}
 }
+
+func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig config.Config, origMeta metav1.ObjectMeta, mod config.Config, modMeta metav1.ObjectMeta) (metav1.Object, error) {
+	if orig.GroupVersionKind != mod.GroupVersionKind {
+		return nil, fmt.Errorf("gvk mismatch: %v, modified: %v", orig.GroupVersionKind, mod.GroupVersionKind)
+	}
+    // TODO support multiple patch types and setting field manager
+	switch orig.GroupVersionKind {
+{{- range . }}
+    case collections.{{ .VariableName }}.Resource().GroupVersionKind():
+        oldRes := &{{ .ClientImport }}.{{ .Kind }}{
+            ObjectMeta: origMeta,
+            Spec:       *(orig.Spec.(*{{ .APIImport }}.{{ .Kind }}{{ .TypeSuffix }})),
+        }
+        modRes := &{{ .ClientImport }}.{{ .Kind }}{
+            ObjectMeta: modMeta,
+            Spec:       *(mod.Spec.(*{{ .APIImport }}.{{ .Kind }}{{ .TypeSuffix }})),
+        }
+        patchBytes, err := genPatchBytes(oldRes, modRes)
+        if err != nil {
+            return nil, err
+        }
+        return {{.Client}}.{{ .ClientGroupPath }}().{{ .ClientTypePath }}({{if .Namespaced}}orig.Namespace{{end}}).
+            Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+{{- end }}
+	default:
+		return nil, fmt.Errorf("unsupported type: %v", orig.GroupVersionKind)
+	}
+}
+
 
 func delete(ic versionedclient.Interface, sc serviceapisclient.Interface, typ config.GroupVersionKind, name, namespace string) error {
 	switch typ {

--- a/pilot/pkg/config/kube/crdclient/types.gen.go
+++ b/pilot/pkg/config/kube/crdclient/types.gen.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	serviceapisclient "sigs.k8s.io/service-apis/pkg/client/clientset/versioned"
 
-	config "istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collections"
 
 	networkingv1alpha3 "istio.io/api/networking/v1alpha3"

--- a/pilot/pkg/config/kube/crdclient/types.gen.go
+++ b/pilot/pkg/config/kube/crdclient/types.gen.go
@@ -28,6 +28,7 @@ import (
 	versionedclient "istio.io/client-go/pkg/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	serviceapisclient "sigs.k8s.io/service-apis/pkg/client/clientset/versioned"
 
 	config "istio.io/istio/pkg/config"
@@ -202,6 +203,242 @@ func update(ic versionedclient.Interface, sc serviceapisclient.Interface, cfg co
 		}, metav1.UpdateOptions{})
 	default:
 		return nil, fmt.Errorf("unsupported type: %v", cfg.GroupVersionKind)
+	}
+}
+
+func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig config.Config, origMeta metav1.ObjectMeta, mod config.Config, modMeta metav1.ObjectMeta) (metav1.Object, error) {
+	if orig.GroupVersionKind != mod.GroupVersionKind {
+		return nil, fmt.Errorf("gvk mismatch: %v, modified: %v", orig.GroupVersionKind, mod.GroupVersionKind)
+	}
+	// TODO support multiple patch types and setting field manager
+	switch orig.GroupVersionKind {
+	case collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind():
+		oldRes := &clientnetworkingv1alpha3.DestinationRule{
+			ObjectMeta: origMeta,
+			Spec:       *(orig.Spec.(*networkingv1alpha3.DestinationRule)),
+		}
+		modRes := &clientnetworkingv1alpha3.DestinationRule{
+			ObjectMeta: modMeta,
+			Spec:       *(mod.Spec.(*networkingv1alpha3.DestinationRule)),
+		}
+		patchBytes, err := genPatchBytes(oldRes, modRes)
+		if err != nil {
+			return nil, err
+		}
+		return ic.NetworkingV1alpha3().DestinationRules(orig.Namespace).
+			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+	case collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind():
+		oldRes := &clientnetworkingv1alpha3.EnvoyFilter{
+			ObjectMeta: origMeta,
+			Spec:       *(orig.Spec.(*networkingv1alpha3.EnvoyFilter)),
+		}
+		modRes := &clientnetworkingv1alpha3.EnvoyFilter{
+			ObjectMeta: modMeta,
+			Spec:       *(mod.Spec.(*networkingv1alpha3.EnvoyFilter)),
+		}
+		patchBytes, err := genPatchBytes(oldRes, modRes)
+		if err != nil {
+			return nil, err
+		}
+		return ic.NetworkingV1alpha3().EnvoyFilters(orig.Namespace).
+			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+	case collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind():
+		oldRes := &clientnetworkingv1alpha3.Gateway{
+			ObjectMeta: origMeta,
+			Spec:       *(orig.Spec.(*networkingv1alpha3.Gateway)),
+		}
+		modRes := &clientnetworkingv1alpha3.Gateway{
+			ObjectMeta: modMeta,
+			Spec:       *(mod.Spec.(*networkingv1alpha3.Gateway)),
+		}
+		patchBytes, err := genPatchBytes(oldRes, modRes)
+		if err != nil {
+			return nil, err
+		}
+		return ic.NetworkingV1alpha3().Gateways(orig.Namespace).
+			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+	case collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind():
+		oldRes := &clientnetworkingv1alpha3.ServiceEntry{
+			ObjectMeta: origMeta,
+			Spec:       *(orig.Spec.(*networkingv1alpha3.ServiceEntry)),
+		}
+		modRes := &clientnetworkingv1alpha3.ServiceEntry{
+			ObjectMeta: modMeta,
+			Spec:       *(mod.Spec.(*networkingv1alpha3.ServiceEntry)),
+		}
+		patchBytes, err := genPatchBytes(oldRes, modRes)
+		if err != nil {
+			return nil, err
+		}
+		return ic.NetworkingV1alpha3().ServiceEntries(orig.Namespace).
+			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+	case collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind():
+		oldRes := &clientnetworkingv1alpha3.Sidecar{
+			ObjectMeta: origMeta,
+			Spec:       *(orig.Spec.(*networkingv1alpha3.Sidecar)),
+		}
+		modRes := &clientnetworkingv1alpha3.Sidecar{
+			ObjectMeta: modMeta,
+			Spec:       *(mod.Spec.(*networkingv1alpha3.Sidecar)),
+		}
+		patchBytes, err := genPatchBytes(oldRes, modRes)
+		if err != nil {
+			return nil, err
+		}
+		return ic.NetworkingV1alpha3().Sidecars(orig.Namespace).
+			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+	case collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind():
+		oldRes := &clientnetworkingv1alpha3.VirtualService{
+			ObjectMeta: origMeta,
+			Spec:       *(orig.Spec.(*networkingv1alpha3.VirtualService)),
+		}
+		modRes := &clientnetworkingv1alpha3.VirtualService{
+			ObjectMeta: modMeta,
+			Spec:       *(mod.Spec.(*networkingv1alpha3.VirtualService)),
+		}
+		patchBytes, err := genPatchBytes(oldRes, modRes)
+		if err != nil {
+			return nil, err
+		}
+		return ic.NetworkingV1alpha3().VirtualServices(orig.Namespace).
+			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+	case collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind():
+		oldRes := &clientnetworkingv1alpha3.WorkloadEntry{
+			ObjectMeta: origMeta,
+			Spec:       *(orig.Spec.(*networkingv1alpha3.WorkloadEntry)),
+		}
+		modRes := &clientnetworkingv1alpha3.WorkloadEntry{
+			ObjectMeta: modMeta,
+			Spec:       *(mod.Spec.(*networkingv1alpha3.WorkloadEntry)),
+		}
+		patchBytes, err := genPatchBytes(oldRes, modRes)
+		if err != nil {
+			return nil, err
+		}
+		return ic.NetworkingV1alpha3().WorkloadEntries(orig.Namespace).
+			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+	case collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind():
+		oldRes := &clientnetworkingv1alpha3.WorkloadGroup{
+			ObjectMeta: origMeta,
+			Spec:       *(orig.Spec.(*networkingv1alpha3.WorkloadGroup)),
+		}
+		modRes := &clientnetworkingv1alpha3.WorkloadGroup{
+			ObjectMeta: modMeta,
+			Spec:       *(mod.Spec.(*networkingv1alpha3.WorkloadGroup)),
+		}
+		patchBytes, err := genPatchBytes(oldRes, modRes)
+		if err != nil {
+			return nil, err
+		}
+		return ic.NetworkingV1alpha3().WorkloadGroups(orig.Namespace).
+			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+	case collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind():
+		oldRes := &clientsecurityv1beta1.AuthorizationPolicy{
+			ObjectMeta: origMeta,
+			Spec:       *(orig.Spec.(*securityv1beta1.AuthorizationPolicy)),
+		}
+		modRes := &clientsecurityv1beta1.AuthorizationPolicy{
+			ObjectMeta: modMeta,
+			Spec:       *(mod.Spec.(*securityv1beta1.AuthorizationPolicy)),
+		}
+		patchBytes, err := genPatchBytes(oldRes, modRes)
+		if err != nil {
+			return nil, err
+		}
+		return ic.SecurityV1beta1().AuthorizationPolicies(orig.Namespace).
+			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+	case collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind():
+		oldRes := &clientsecurityv1beta1.PeerAuthentication{
+			ObjectMeta: origMeta,
+			Spec:       *(orig.Spec.(*securityv1beta1.PeerAuthentication)),
+		}
+		modRes := &clientsecurityv1beta1.PeerAuthentication{
+			ObjectMeta: modMeta,
+			Spec:       *(mod.Spec.(*securityv1beta1.PeerAuthentication)),
+		}
+		patchBytes, err := genPatchBytes(oldRes, modRes)
+		if err != nil {
+			return nil, err
+		}
+		return ic.SecurityV1beta1().PeerAuthentications(orig.Namespace).
+			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+	case collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind():
+		oldRes := &clientsecurityv1beta1.RequestAuthentication{
+			ObjectMeta: origMeta,
+			Spec:       *(orig.Spec.(*securityv1beta1.RequestAuthentication)),
+		}
+		modRes := &clientsecurityv1beta1.RequestAuthentication{
+			ObjectMeta: modMeta,
+			Spec:       *(mod.Spec.(*securityv1beta1.RequestAuthentication)),
+		}
+		patchBytes, err := genPatchBytes(oldRes, modRes)
+		if err != nil {
+			return nil, err
+		}
+		return ic.SecurityV1beta1().RequestAuthentications(orig.Namespace).
+			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+	case collections.K8SServiceApisV1Alpha1Gatewayclasses.Resource().GroupVersionKind():
+		oldRes := &servicev1alpha1.GatewayClass{
+			ObjectMeta: origMeta,
+			Spec:       *(orig.Spec.(*servicev1alpha1.GatewayClassSpec)),
+		}
+		modRes := &servicev1alpha1.GatewayClass{
+			ObjectMeta: modMeta,
+			Spec:       *(mod.Spec.(*servicev1alpha1.GatewayClassSpec)),
+		}
+		patchBytes, err := genPatchBytes(oldRes, modRes)
+		if err != nil {
+			return nil, err
+		}
+		return sc.NetworkingV1alpha1().GatewayClasses().
+			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+	case collections.K8SServiceApisV1Alpha1Gateways.Resource().GroupVersionKind():
+		oldRes := &servicev1alpha1.Gateway{
+			ObjectMeta: origMeta,
+			Spec:       *(orig.Spec.(*servicev1alpha1.GatewaySpec)),
+		}
+		modRes := &servicev1alpha1.Gateway{
+			ObjectMeta: modMeta,
+			Spec:       *(mod.Spec.(*servicev1alpha1.GatewaySpec)),
+		}
+		patchBytes, err := genPatchBytes(oldRes, modRes)
+		if err != nil {
+			return nil, err
+		}
+		return sc.NetworkingV1alpha1().Gateways(orig.Namespace).
+			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+	case collections.K8SServiceApisV1Alpha1Httproutes.Resource().GroupVersionKind():
+		oldRes := &servicev1alpha1.HTTPRoute{
+			ObjectMeta: origMeta,
+			Spec:       *(orig.Spec.(*servicev1alpha1.HTTPRouteSpec)),
+		}
+		modRes := &servicev1alpha1.HTTPRoute{
+			ObjectMeta: modMeta,
+			Spec:       *(mod.Spec.(*servicev1alpha1.HTTPRouteSpec)),
+		}
+		patchBytes, err := genPatchBytes(oldRes, modRes)
+		if err != nil {
+			return nil, err
+		}
+		return sc.NetworkingV1alpha1().HTTPRoutes(orig.Namespace).
+			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+	case collections.K8SServiceApisV1Alpha1Tcproutes.Resource().GroupVersionKind():
+		oldRes := &servicev1alpha1.TCPRoute{
+			ObjectMeta: origMeta,
+			Spec:       *(orig.Spec.(*servicev1alpha1.TCPRouteSpec)),
+		}
+		modRes := &servicev1alpha1.TCPRoute{
+			ObjectMeta: modMeta,
+			Spec:       *(mod.Spec.(*servicev1alpha1.TCPRouteSpec)),
+		}
+		patchBytes, err := genPatchBytes(oldRes, modRes)
+		if err != nil {
+			return nil, err
+		}
+		return sc.NetworkingV1alpha1().TCPRoutes(orig.Namespace).
+			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+	default:
+		return nil, fmt.Errorf("unsupported type: %v", orig.GroupVersionKind)
 	}
 }
 


### PR DESCRIPTION
Part of this is already in #27761 tested and working. For now, only supporting regular [RFC 6902](https://tools.ietf.org/html/rfc6902) json patch, not strategic merge or any of the other k8s patch types. 

As far as the auto-registration code is concerned, this simple patch helps a lot to avoid conflicts when writers have completely separate concerns. 