### PR TITLE
ext_authz: add initial EXTERNAL action support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -98,7 +98,7 @@ require (
 	gopkg.in/yaml.v2 v2.3.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 	helm.sh/helm/v3 v3.2.4
-	istio.io/api v0.0.0-20201007205536-38d3c76a5557
+	istio.io/api v0.0.0-20201008225629-ae1b3ec96a86
 	istio.io/client-go v0.0.0-20200908160912-f99162621a1a
 	istio.io/gogo-genproto v0.0.0-20200908160912-66171252e3db
 	istio.io/pkg v0.0.0-20200922180714-670b76a68558

--- a/go.sum
+++ b/go.sum
@@ -1237,8 +1237,8 @@ honnef.co/go/tools v0.0.1-2020.1.4 h1:UoveltGrhghAA7ePc+e+QYDHXrBps2PqFZiHkGR/xK
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 istio.io/api v0.0.0-20190515205759-982e5c3888c6/go.mod h1:hhLFQmpHia8zgaM37vb2ml9iS5NfNfqZGRt1pS9aVEo=
 istio.io/api v0.0.0-20200812202721-24be265d41c3/go.mod h1:88HN3o1fSD1jo+Z1WTLlJfMm9biopur6Ct9BFKjiB64=
-istio.io/api v0.0.0-20201007205536-38d3c76a5557 h1:EDgHyV3kq988v2vb4p4j/D0saXf1JGh43uWhEkD4x+M=
-istio.io/api v0.0.0-20201007205536-38d3c76a5557/go.mod h1:88HN3o1fSD1jo+Z1WTLlJfMm9biopur6Ct9BFKjiB64=
+istio.io/api v0.0.0-20201008225629-ae1b3ec96a86 h1:QgC20sitvu9fBhW6n7w4qJweM2IvRFPsXKWLorWN3so=
+istio.io/api v0.0.0-20201008225629-ae1b3ec96a86/go.mod h1:88HN3o1fSD1jo+Z1WTLlJfMm9biopur6Ct9BFKjiB64=
 istio.io/client-go v0.0.0-20200908160912-f99162621a1a h1:clPn0fz+rXq5Ytj6Ppb1ygUKeU0RImT4ZbT1oMd1G04=
 istio.io/client-go v0.0.0-20200908160912-f99162621a1a/go.mod h1:SO65MWt7I45dvUwuDowoiB0SVcGpfWZfUTlopvYpbZc=
 istio.io/gogo-genproto v0.0.0-20190930162913-45029607206a/go.mod h1:OzpAts7jljZceG4Vqi5/zXy/pOg1b209T3jb7Nv5wIs=

--- a/manifests/charts/base/crds/crd-all.gen.yaml
+++ b/manifests/charts/base/crds/crd-all.gen.yaml
@@ -3022,6 +3022,13 @@ spec:
         spec:
           description: 'Configuration for access control on workloads. See more details
             at: https://istio.io/docs/reference/config/security/authorization-policy.html'
+          oneOf:
+          - not:
+              anyOf:
+              - required:
+                - external
+          - required:
+            - external
           properties:
             action:
               description: Optional.
@@ -3029,7 +3036,72 @@ spec:
               - ALLOW
               - DENY
               - AUDIT
+              - EXTERNAL
               type: string
+            external:
+              description: Configures how to talk to the external server.
+              properties:
+                http:
+                  properties:
+                    authorizationRequest:
+                      description: Settings used for controlling authorization request
+                        metadata.
+                      properties:
+                        allowedHeaders:
+                          description: Authorization request will include the client
+                            request headers that have a correspondent match.
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                      type: object
+                    authorizationResponse:
+                      description: Settings used for controlling authorization response
+                        metadata.
+                      properties:
+                        forwardToDownstream:
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        forwardToUpstream:
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                      type: object
+                    includePeerCertificate:
+                      description: Specifies if the peer certificate is included in
+                        the external authorization request.
+                      type: boolean
+                    server:
+                      description: Supplies the full URL of the external server that
+                        implements the Envoy ext_authz filter check request API.
+                      format: string
+                      type: string
+                    timeout:
+                      description: Sets the maximum duration in milliseconds for connection
+                        to the external server (default is 200ms).
+                      type: string
+                  type: object
+                tcp:
+                  properties:
+                    includePeerCertificate:
+                      description: Specifies if the peer certificate is included in
+                        the external authorization request.
+                      type: boolean
+                    server:
+                      description: Supplies the full URL of the external server that
+                        implements the Envoy ext_authz filter authorization request
+                        API.
+                      format: string
+                      type: string
+                    timeout:
+                      description: Sets the maximum duration in milliseconds for connection
+                        to the external server (default is 200ms).
+                      type: string
+                  type: object
+              type: object
             rules:
               description: Optional.
               items:

--- a/manifests/charts/base/files/gen-istio-cluster.yaml
+++ b/manifests/charts/base/files/gen-istio-cluster.yaml
@@ -3024,6 +3024,13 @@ spec:
         spec:
           description: 'Configuration for access control on workloads. See more details
             at: https://istio.io/docs/reference/config/security/authorization-policy.html'
+          oneOf:
+          - not:
+              anyOf:
+              - required:
+                - external
+          - required:
+            - external
           properties:
             action:
               description: Optional.
@@ -3031,7 +3038,72 @@ spec:
               - ALLOW
               - DENY
               - AUDIT
+              - EXTERNAL
               type: string
+            external:
+              description: Configures how to talk to the external server.
+              properties:
+                http:
+                  properties:
+                    authorizationRequest:
+                      description: Settings used for controlling authorization request
+                        metadata.
+                      properties:
+                        allowedHeaders:
+                          description: Authorization request will include the client
+                            request headers that have a correspondent match.
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                      type: object
+                    authorizationResponse:
+                      description: Settings used for controlling authorization response
+                        metadata.
+                      properties:
+                        forwardToDownstream:
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        forwardToUpstream:
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                      type: object
+                    includePeerCertificate:
+                      description: Specifies if the peer certificate is included in
+                        the external authorization request.
+                      type: boolean
+                    server:
+                      description: Supplies the full URL of the external server that
+                        implements the Envoy ext_authz filter check request API.
+                      format: string
+                      type: string
+                    timeout:
+                      description: Sets the maximum duration in milliseconds for connection
+                        to the external server (default is 200ms).
+                      type: string
+                  type: object
+                tcp:
+                  properties:
+                    includePeerCertificate:
+                      description: Specifies if the peer certificate is included in
+                        the external authorization request.
+                      type: boolean
+                    server:
+                      description: Supplies the full URL of the external server that
+                        implements the Envoy ext_authz filter authorization request
+                        API.
+                      format: string
+                      type: string
+                    timeout:
+                      description: Sets the maximum duration in milliseconds for connection
+                        to the external server (default is 200ms).
+                      type: string
+                  type: object
+              type: object
             rules:
               description: Optional.
               items:

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -74,6 +74,7 @@ var (
 	// DefaultPlugins is the default list of plugins to enable, when no plugin(s)
 	// is specified through the command line
 	DefaultPlugins = []string{
+		plugin.AuthzExternal,
 		plugin.Authn,
 		plugin.Authz,
 		plugin.Health,

--- a/pilot/pkg/model/authorization.go
+++ b/pilot/pkg/model/authorization.go
@@ -65,11 +65,18 @@ func GetAuthorizationPolicies(env *Environment) (*AuthorizationPolicies, error) 
 	return policy, nil
 }
 
+type AuthorizationPoliciesResult struct {
+	External []AuthorizationPolicy
+	Deny     []AuthorizationPolicy
+	Allow    []AuthorizationPolicy
+	Audit    []AuthorizationPolicy
+}
+
 // ListAuthorizationPolicies returns the deny, allow, and audit AuthorizationPolicies for the workload in the given namespace.
-func (policy *AuthorizationPolicies) ListAuthorizationPolicies(namespace string, workload labels.Collection) (
-	denyPolicies []AuthorizationPolicy, allowPolicies []AuthorizationPolicy, auditPolicies []AuthorizationPolicy) {
+func (policy *AuthorizationPolicies) ListAuthorizationPolicies(namespace string, workload labels.Collection) AuthorizationPoliciesResult {
+	ret := AuthorizationPoliciesResult{}
 	if policy == nil {
-		return
+		return ret
 	}
 
 	var namespaces []string
@@ -88,11 +95,13 @@ func (policy *AuthorizationPolicies) ListAuthorizationPolicies(namespace string,
 			if workload.IsSupersetOf(selector) {
 				switch config.Spec.GetAction() {
 				case authpb.AuthorizationPolicy_ALLOW:
-					allowPolicies = append(allowPolicies, config)
+					ret.Allow = append(ret.Allow, config)
 				case authpb.AuthorizationPolicy_DENY:
-					denyPolicies = append(denyPolicies, config)
+					ret.Deny = append(ret.Deny, config)
 				case authpb.AuthorizationPolicy_AUDIT:
-					auditPolicies = append(auditPolicies, config)
+					ret.Audit = append(ret.Audit, config)
+				case authpb.AuthorizationPolicy_EXTERNAL:
+					ret.External = append(ret.External, config)
 				default:
 					log.Errorf("ignored authorization policy %s.%s with unsupported action: %s",
 						config.Namespace, config.Name, config.Spec.GetAction())
@@ -101,5 +110,5 @@ func (policy *AuthorizationPolicies) ListAuthorizationPolicies(namespace string,
 		}
 	}
 
-	return
+	return ret
 }

--- a/pilot/pkg/networking/core/v1alpha3/fake.go
+++ b/pilot/pkg/networking/core/v1alpha3/fake.go
@@ -143,7 +143,7 @@ func NewConfigGenTest(t test.Failer, opts TestOptions) *ConfigGenTest {
 	env.NetworksWatcher = opts.NetworksWatcher
 
 	if opts.Plugins == nil {
-		opts.Plugins = registry.NewPlugins([]string{plugin.Authn, plugin.Authz})
+		opts.Plugins = registry.NewPlugins([]string{plugin.AuthzExternal, plugin.Authn, plugin.Authz})
 	}
 
 	fake := &ConfigGenTest{

--- a/pilot/pkg/networking/plugin/plugin.go
+++ b/pilot/pkg/networking/plugin/plugin.go
@@ -20,9 +20,11 @@ import (
 )
 
 const (
+	// AuthzExternal is the name of the authorization plugin for action EXTERNAL passed through the command line
+	AuthzExternal = "authz-external"
 	// Authn is the name of the authentication plugin passed through the command line
 	Authn = "authn"
-	// Authz is the name of the rbac plugin passed through the command line
+	// Authz is the name of the authorization plugin for action ALLOW, DENY and AUDIT passed through the command line
 	Authz = "authz"
 	// Health is the name of the health plugin passed through the command line
 	Health = "health"

--- a/pilot/pkg/networking/plugin/registry/registry.go
+++ b/pilot/pkg/networking/plugin/registry/registry.go
@@ -24,8 +24,11 @@ import (
 )
 
 var availablePlugins = map[string]plugin.Plugin{
-	plugin.Authn: authn.NewPlugin(),
-	plugin.Authz: authz.NewPlugin(),
+	// Currently the ext_authz filter is added in front of other security filters.
+	// TODO(yangminzhu): Probably better to refactor to use a single security plugin for all security filters?
+	plugin.AuthzExternal: authz.NewPlugin(authz.External),
+	plugin.Authn:         authn.NewPlugin(),
+	plugin.Authz:         authz.NewPlugin(authz.Default),
 }
 
 // NewPlugins returns a slice of default Plugins.

--- a/pilot/pkg/security/authz/builder/builder_test.go
+++ b/pilot/pkg/security/authz/builder/builder_test.go
@@ -51,6 +51,7 @@ func TestGenerator_GenerateHTTP(t *testing.T) {
 		name        string
 		tdBundle    trustdomain.Bundle
 		isVersion14 bool
+		isExternal  bool
 		input       string
 		want        []string
 	}{
@@ -76,6 +77,12 @@ func TestGenerator_GenerateHTTP(t *testing.T) {
 			name:  "all-fields",
 			input: "all-fields-in.yaml",
 			want:  []string{"all-fields-out.yaml"},
+		},
+		{
+			name:       "action-external-HTTP-all-fields",
+			input:      "action-external-HTTP-all-fields-in.yaml",
+			isExternal: true,
+			want:       []string{"action-external-HTTP-all-fields-out.yaml"},
 		},
 		{
 			name:  "allow-all",
@@ -133,6 +140,7 @@ func TestGenerator_GenerateHTTP(t *testing.T) {
 			option := Option{
 				IsIstioVersionGE15:     !tc.isVersion14,
 				IsOnInboundPassthrough: false,
+				IsExternal:             tc.isExternal,
 			}
 			g := New(tc.tdBundle, httpbin, "foo", yamlPolicy(t, basePath+tc.input), option)
 			if g == nil {
@@ -146,10 +154,11 @@ func TestGenerator_GenerateHTTP(t *testing.T) {
 
 func TestGenerator_GenerateTCP(t *testing.T) {
 	testCases := []struct {
-		name     string
-		tdBundle trustdomain.Bundle
-		input    string
-		want     []string
+		name       string
+		tdBundle   trustdomain.Bundle
+		isExternal bool
+		input      string
+		want       []string
 	}{
 		{
 			name:  "action-allow-HTTP-for-TCP-filter",
@@ -166,6 +175,12 @@ func TestGenerator_GenerateTCP(t *testing.T) {
 			input: "action-audit-HTTP-for-TCP-filter-in.yaml",
 			want:  []string{"action-audit-HTTP-for-TCP-filter-out.yaml"},
 		},
+		{
+			name:       "action-external-TCP-all-fields",
+			input:      "action-external-TCP-all-fields-in.yaml",
+			isExternal: true,
+			want:       []string{"action-external-TCP-all-fields-out.yaml"},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -173,6 +188,7 @@ func TestGenerator_GenerateTCP(t *testing.T) {
 			option := Option{
 				IsIstioVersionGE15:     true,
 				IsOnInboundPassthrough: false,
+				IsExternal:             tc.isExternal,
 			}
 			g := New(tc.tdBundle, httpbin, "foo", yamlPolicy(t, basePath+tc.input), option)
 			if g == nil {

--- a/pilot/pkg/security/authz/builder/testdata/action-external-HTTP-all-fields-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/action-external-HTTP-all-fields-in.yaml
@@ -1,0 +1,48 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: httpbin-1
+  namespace: foo
+spec:
+  selector:
+    matchLabels:
+      app: httpbin
+      version: v1
+  action: EXTERNAL
+  external:
+    http:
+      server: "http://ext-authz.foo.svc.cluster.local/"
+  rules:
+    - from:
+        - source:
+            ipBlocks: ["1.2.3.4", "5.6.0.0/16"]
+            notIpBlocks: ["9.0.0.1", "9.2.0.0/16"]
+      to:
+        - operation:
+            methods: ["method", "method-prefix-*", "*-suffix-method", "*"]
+            hosts: ["exact.com", "*.suffix.com", "prefix.*", "*"]
+            ports: ["80", "90"]
+            paths: ["/exact", "/prefix/*", "*/suffix", "*"]
+            notMethods: ["not-method", "not-method-prefix-*", "*-not-suffix-method", "*"]
+            notHosts: ["not-exact.com", "*.not-suffix.com", "not-prefix.*", "*"]
+            notPorts: ["8000", "9000"]
+            notPaths: ["/not-exact", "/not-prefix/*", "*/not-suffix", "*"]
+      when:
+        - key: "request.headers[X-header]"
+          values: ["header", "header-prefix-*", "*-suffix-header", "*"]
+          notValues: ["not-header", "not-header-prefix-*", "*-not-suffix-header", "*"]
+        - key: "source.ip"
+          values: ["10.10.10.10", "192.168.10.0/24"]
+          notValues: ["90.10.10.10", "90.168.10.0/24"]
+        - key: "destination.ip"
+          values: ["10.10.10.10", "192.168.10.0/24"]
+          notValues: ["90.10.10.10", "90.168.10.0/24"]
+        - key: "destination.port"
+          values: ["91", "92"]
+          notValues: ["9001", "9002"]
+        - key: "connection.sni"
+          values: ["exact.com", "*.suffix.com", "prefix.*", "*"]
+          notValues: ["not-exact.com", "*.not-suffix.com", "not-prefix.*", "*"]
+        - key: "experimental.envoy.filters.a.b[c]"
+          values: ["exact", "prefix-*", "*-suffix", "*"]
+          notValues: ["not-exact", "not-prefix-*", "*-not-suffix", "*"]

--- a/pilot/pkg/security/authz/builder/testdata/action-external-HTTP-all-fields-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/action-external-HTTP-all-fields-out.yaml
@@ -1,0 +1,291 @@
+name: envoy.filters.http.rbac
+typedConfig:
+  '@type': type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC
+  shadowRules:
+    policies:
+      ext-authz-matching-ns[foo]-policy[httpbin-1]-rule[0]:
+        permissions:
+        - andRules:
+            rules:
+            - orRules:
+                rules:
+                - header:
+                    exactMatch: exact.com
+                    name: :authority
+                - header:
+                    name: :authority
+                    suffixMatch: .suffix.com
+                - header:
+                    name: :authority
+                    prefixMatch: prefix.
+                - header:
+                    name: :authority
+                    presentMatch: true
+            - notRule:
+                orRules:
+                  rules:
+                  - header:
+                      exactMatch: not-exact.com
+                      name: :authority
+                  - header:
+                      name: :authority
+                      suffixMatch: .not-suffix.com
+                  - header:
+                      name: :authority
+                      prefixMatch: not-prefix.
+                  - header:
+                      name: :authority
+                      presentMatch: true
+            - orRules:
+                rules:
+                - header:
+                    exactMatch: method
+                    name: :method
+                - header:
+                    name: :method
+                    prefixMatch: method-prefix-
+                - header:
+                    name: :method
+                    suffixMatch: -suffix-method
+                - header:
+                    name: :method
+                    presentMatch: true
+            - notRule:
+                orRules:
+                  rules:
+                  - header:
+                      exactMatch: not-method
+                      name: :method
+                  - header:
+                      name: :method
+                      prefixMatch: not-method-prefix-
+                  - header:
+                      name: :method
+                      suffixMatch: -not-suffix-method
+                  - header:
+                      name: :method
+                      presentMatch: true
+            - orRules:
+                rules:
+                - urlPath:
+                    path:
+                      exact: /exact
+                - urlPath:
+                    path:
+                      prefix: /prefix/
+                - urlPath:
+                    path:
+                      suffix: /suffix
+                - urlPath:
+                    path:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .+
+            - notRule:
+                orRules:
+                  rules:
+                  - urlPath:
+                      path:
+                        exact: /not-exact
+                  - urlPath:
+                      path:
+                        prefix: /not-prefix/
+                  - urlPath:
+                      path:
+                        suffix: /not-suffix
+                  - urlPath:
+                      path:
+                        safeRegex:
+                          googleRe2: {}
+                          regex: .+
+            - orRules:
+                rules:
+                - destinationPort: 80
+                - destinationPort: 90
+            - notRule:
+                orRules:
+                  rules:
+                  - destinationPort: 8000
+                  - destinationPort: 9000
+            - orRules:
+                rules:
+                - destinationIp:
+                    addressPrefix: 10.10.10.10
+                    prefixLen: 32
+                - destinationIp:
+                    addressPrefix: 192.168.10.0
+                    prefixLen: 24
+            - notRule:
+                orRules:
+                  rules:
+                  - destinationIp:
+                      addressPrefix: 90.10.10.10
+                      prefixLen: 32
+                  - destinationIp:
+                      addressPrefix: 90.168.10.0
+                      prefixLen: 24
+            - orRules:
+                rules:
+                - destinationPort: 91
+                - destinationPort: 92
+            - notRule:
+                orRules:
+                  rules:
+                  - destinationPort: 9001
+                  - destinationPort: 9002
+            - orRules:
+                rules:
+                - requestedServerName:
+                    exact: exact.com
+                - requestedServerName:
+                    suffix: .suffix.com
+                - requestedServerName:
+                    prefix: prefix.
+                - requestedServerName:
+                    safeRegex:
+                      googleRe2: {}
+                      regex: .+
+            - notRule:
+                orRules:
+                  rules:
+                  - requestedServerName:
+                      exact: not-exact.com
+                  - requestedServerName:
+                      suffix: .not-suffix.com
+                  - requestedServerName:
+                      prefix: not-prefix.
+                  - requestedServerName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .+
+            - orRules:
+                rules:
+                - metadata:
+                    filter: envoy.filters.a.b
+                    path:
+                    - key: c
+                    value:
+                      stringMatch:
+                        exact: exact
+                - metadata:
+                    filter: envoy.filters.a.b
+                    path:
+                    - key: c
+                    value:
+                      stringMatch:
+                        prefix: prefix-
+                - metadata:
+                    filter: envoy.filters.a.b
+                    path:
+                    - key: c
+                    value:
+                      stringMatch:
+                        suffix: -suffix
+                - metadata:
+                    filter: envoy.filters.a.b
+                    path:
+                    - key: c
+                    value:
+                      stringMatch:
+                        safeRegex:
+                          googleRe2: {}
+                          regex: .+
+            - notRule:
+                orRules:
+                  rules:
+                  - metadata:
+                      filter: envoy.filters.a.b
+                      path:
+                      - key: c
+                      value:
+                        stringMatch:
+                          exact: not-exact
+                  - metadata:
+                      filter: envoy.filters.a.b
+                      path:
+                      - key: c
+                      value:
+                        stringMatch:
+                          prefix: not-prefix-
+                  - metadata:
+                      filter: envoy.filters.a.b
+                      path:
+                      - key: c
+                      value:
+                        stringMatch:
+                          suffix: -not-suffix
+                  - metadata:
+                      filter: envoy.filters.a.b
+                      path:
+                      - key: c
+                      value:
+                        stringMatch:
+                          safeRegex:
+                            googleRe2: {}
+                            regex: .+
+        principals:
+        - andIds:
+            ids:
+            - orIds:
+                ids:
+                - sourceIp:
+                    addressPrefix: 1.2.3.4
+                    prefixLen: 32
+                - sourceIp:
+                    addressPrefix: 5.6.0.0
+                    prefixLen: 16
+            - notId:
+                orIds:
+                  ids:
+                  - sourceIp:
+                      addressPrefix: 9.0.0.1
+                      prefixLen: 32
+                  - sourceIp:
+                      addressPrefix: 9.2.0.0
+                      prefixLen: 16
+            - orIds:
+                ids:
+                - header:
+                    exactMatch: header
+                    name: X-header
+                - header:
+                    name: X-header
+                    prefixMatch: header-prefix-
+                - header:
+                    name: X-header
+                    suffixMatch: -suffix-header
+                - header:
+                    name: X-header
+                    presentMatch: true
+            - notId:
+                orIds:
+                  ids:
+                  - header:
+                      exactMatch: not-header
+                      name: X-header
+                  - header:
+                      name: X-header
+                      prefixMatch: not-header-prefix-
+                  - header:
+                      name: X-header
+                      suffixMatch: -not-suffix-header
+                  - header:
+                      name: X-header
+                      presentMatch: true
+            - orIds:
+                ids:
+                - sourceIp:
+                    addressPrefix: 10.10.10.10
+                    prefixLen: 32
+                - sourceIp:
+                    addressPrefix: 192.168.10.0
+                    prefixLen: 24
+            - notId:
+                orIds:
+                  ids:
+                  - sourceIp:
+                      addressPrefix: 90.10.10.10
+                      prefixLen: 32
+                  - sourceIp:
+                      addressPrefix: 90.168.10.0
+                      prefixLen: 24

--- a/pilot/pkg/security/authz/builder/testdata/action-external-TCP-all-fields-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/action-external-TCP-all-fields-in.yaml
@@ -1,0 +1,64 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: httpbin-1
+  namespace: foo
+spec:
+  selector:
+    matchLabels:
+      app: httpbin
+      version: v1
+  action: EXTERNAL
+  external:
+    tcp:
+      server: "grpc://ext-authz.foo.svc.cluster.local/"
+  rules:
+    - from:
+      - source:
+          ipBlocks: ["1.2.3.4", "5.6.0.0/16"]
+          notIpBlocks: ["9.0.0.1", "9.2.0.0/16"]
+    - when:
+      - key: "source.ip"
+        values: ["10.10.10.10", "192.168.10.0/24"]
+        notValues: ["90.10.10.10", "90.168.10.0/24"]
+      - key: "destination.ip"
+        values: ["10.10.10.10", "192.168.10.0/24"]
+        notValues: ["90.10.10.10", "90.168.10.0/24"]
+      - key: "destination.port"
+        values: ["91", "92"]
+        notValues: ["9001", "9002"]
+      - key: "connection.sni"
+        values: ["exact.com", "*.suffix.com", "prefix.*", "*"]
+        notValues: ["not-exact.com", "*.not-suffix.com", "not-prefix.*", "*"]
+      - key: "experimental.envoy.filters.a.b[c]"
+        values: ["exact", "prefix-*", "*-suffix", "*"]
+        notValues: ["not-exact", "not-prefix-*", "*-not-suffix", "*"]
+    - to:
+        - operation:
+            methods: ["method", "method-prefix-*", "*-suffix-method", "*"]
+            hosts: ["exact.com", "*.suffix.com", "prefix.*", "*"]
+            ports: ["80", "90"]
+            paths: ["/exact", "/prefix/*", "*/suffix", "*"]
+            notMethods: ["not-method", "not-method-prefix-*", "*-not-suffix-method", "*"]
+            notHosts: ["not-exact.com", "*.not-suffix.com", "not-prefix.*", "*"]
+            notPorts: ["8000", "9000"]
+            notPaths: ["/not-exact", "/not-prefix/*", "*/not-suffix", "*"]
+    - when:
+        - key: "request.headers[X-header]"
+          values: ["header", "header-prefix-*", "*-suffix-header", "*"]
+          notValues: ["not-header", "not-header-prefix-*", "*-not-suffix-header", "*"]
+        - key: "source.ip"
+          values: ["10.10.10.10", "192.168.10.0/24"]
+          notValues: ["90.10.10.10", "90.168.10.0/24"]
+        - key: "destination.ip"
+          values: ["10.10.10.10", "192.168.10.0/24"]
+          notValues: ["90.10.10.10", "90.168.10.0/24"]
+        - key: "destination.port"
+          values: ["91", "92"]
+          notValues: ["9001", "9002"]
+        - key: "connection.sni"
+          values: ["exact.com", "*.suffix.com", "prefix.*", "*"]
+          notValues: ["not-exact.com", "*.not-suffix.com", "not-prefix.*", "*"]
+        - key: "experimental.envoy.filters.a.b[c]"
+          values: ["exact", "prefix-*", "*-suffix", "*"]
+          notValues: ["not-exact", "not-prefix-*", "*-not-suffix", "*"]

--- a/pilot/pkg/security/authz/builder/testdata/action-external-TCP-all-fields-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/action-external-TCP-all-fields-out.yaml
@@ -1,0 +1,171 @@
+name: envoy.filters.network.rbac
+typedConfig:
+  '@type': type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC
+  shadowRules:
+    policies:
+      ext-authz-matching-ns[foo]-policy[httpbin-1]-rule[0]:
+        permissions:
+        - andRules:
+            rules:
+            - any: true
+        principals:
+        - andIds:
+            ids:
+            - orIds:
+                ids:
+                - sourceIp:
+                    addressPrefix: 1.2.3.4
+                    prefixLen: 32
+                - sourceIp:
+                    addressPrefix: 5.6.0.0
+                    prefixLen: 16
+            - notId:
+                orIds:
+                  ids:
+                  - sourceIp:
+                      addressPrefix: 9.0.0.1
+                      prefixLen: 32
+                  - sourceIp:
+                      addressPrefix: 9.2.0.0
+                      prefixLen: 16
+      ext-authz-matching-ns[foo]-policy[httpbin-1]-rule[1]:
+        permissions:
+        - andRules:
+            rules:
+            - orRules:
+                rules:
+                - destinationIp:
+                    addressPrefix: 10.10.10.10
+                    prefixLen: 32
+                - destinationIp:
+                    addressPrefix: 192.168.10.0
+                    prefixLen: 24
+            - notRule:
+                orRules:
+                  rules:
+                  - destinationIp:
+                      addressPrefix: 90.10.10.10
+                      prefixLen: 32
+                  - destinationIp:
+                      addressPrefix: 90.168.10.0
+                      prefixLen: 24
+            - orRules:
+                rules:
+                - destinationPort: 91
+                - destinationPort: 92
+            - notRule:
+                orRules:
+                  rules:
+                  - destinationPort: 9001
+                  - destinationPort: 9002
+            - orRules:
+                rules:
+                - requestedServerName:
+                    exact: exact.com
+                - requestedServerName:
+                    suffix: .suffix.com
+                - requestedServerName:
+                    prefix: prefix.
+                - requestedServerName:
+                    safeRegex:
+                      googleRe2: {}
+                      regex: .+
+            - notRule:
+                orRules:
+                  rules:
+                  - requestedServerName:
+                      exact: not-exact.com
+                  - requestedServerName:
+                      suffix: .not-suffix.com
+                  - requestedServerName:
+                      prefix: not-prefix.
+                  - requestedServerName:
+                      safeRegex:
+                        googleRe2: {}
+                        regex: .+
+            - orRules:
+                rules:
+                - metadata:
+                    filter: envoy.filters.a.b
+                    path:
+                    - key: c
+                    value:
+                      stringMatch:
+                        exact: exact
+                - metadata:
+                    filter: envoy.filters.a.b
+                    path:
+                    - key: c
+                    value:
+                      stringMatch:
+                        prefix: prefix-
+                - metadata:
+                    filter: envoy.filters.a.b
+                    path:
+                    - key: c
+                    value:
+                      stringMatch:
+                        suffix: -suffix
+                - metadata:
+                    filter: envoy.filters.a.b
+                    path:
+                    - key: c
+                    value:
+                      stringMatch:
+                        safeRegex:
+                          googleRe2: {}
+                          regex: .+
+            - notRule:
+                orRules:
+                  rules:
+                  - metadata:
+                      filter: envoy.filters.a.b
+                      path:
+                      - key: c
+                      value:
+                        stringMatch:
+                          exact: not-exact
+                  - metadata:
+                      filter: envoy.filters.a.b
+                      path:
+                      - key: c
+                      value:
+                        stringMatch:
+                          prefix: not-prefix-
+                  - metadata:
+                      filter: envoy.filters.a.b
+                      path:
+                      - key: c
+                      value:
+                        stringMatch:
+                          suffix: -not-suffix
+                  - metadata:
+                      filter: envoy.filters.a.b
+                      path:
+                      - key: c
+                      value:
+                        stringMatch:
+                          safeRegex:
+                            googleRe2: {}
+                            regex: .+
+        principals:
+        - andIds:
+            ids:
+            - orIds:
+                ids:
+                - sourceIp:
+                    addressPrefix: 10.10.10.10
+                    prefixLen: 32
+                - sourceIp:
+                    addressPrefix: 192.168.10.0
+                    prefixLen: 24
+            - notId:
+                orIds:
+                  ids:
+                  - sourceIp:
+                      addressPrefix: 90.10.10.10
+                      prefixLen: 32
+                  - sourceIp:
+                      addressPrefix: 90.168.10.0
+                      prefixLen: 24
+  statPrefix: tcp.

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -84,7 +84,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	}
 
 	// Init with a dummy environment, since we have a circular dependency with the env creation.
-	s := NewDiscoveryServer(&model.Environment{PushContext: model.NewPushContext()}, []string{plugin.Authn, plugin.Authz})
+	s := NewDiscoveryServer(&model.Environment{PushContext: model.NewPushContext()}, []string{plugin.AuthzExternal, plugin.Authn, plugin.Authz})
 
 	serviceHandler := func(svc *model.Service, _ model.Event) {
 		pushReq := &model.PushRequest{

--- a/pkg/config/schema/fuzz_test.go
+++ b/pkg/config/schema/fuzz_test.go
@@ -31,6 +31,7 @@ import (
 
 	authentication "istio.io/api/authentication/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
+	security "istio.io/api/security/v1beta1"
 	clientnetworkingalpha "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	clientnetworkingbeta "istio.io/client-go/pkg/apis/networking/v1beta1"
 	clientsecurity "istio.io/client-go/pkg/apis/security/v1beta1"
@@ -161,6 +162,10 @@ func fixProtoFuzzer(codecs serializer.CodecFactory) []interface{} {
 		},
 		func(t *networking.ReadinessProbe, c fuzz.Continue) {
 			*t = networking.ReadinessProbe{}
+		},
+		func(t *security.AuthorizationPolicy, c fuzz.Continue) {
+			// The oneof field `actionDetails` just caused the fuzzer to crash.
+			*t = security.AuthorizationPolicy{}
 		},
 	}
 }

--- a/pkg/config/security/security.go
+++ b/pkg/config/security/security.go
@@ -178,3 +178,26 @@ func validateMapKey(key string) error {
 	}
 	return fmt.Errorf("bad key (%s): should have format a[b]", key)
 }
+
+func ValidateServer(server string, isTCP bool) error {
+	u, err := url.Parse(server)
+	if err != nil {
+		return err
+	}
+	switch u.Scheme {
+	case "grpc":
+	case "http", "https":
+		if isTCP {
+			return fmt.Errorf("scheme for TCP filter chain must be grpc, found %s", u.Scheme)
+		}
+	default:
+		return fmt.Errorf("scheme for HTTP filter chain must be http, https or grpc, found %s", u.Scheme)
+	}
+	if u.Fragment != "" {
+		return fmt.Errorf("must not include fragment, found %s", u.Fragment)
+	}
+	if u.RawQuery != "" {
+		return fmt.Errorf("must not include query, found %s", u.RawQuery)
+	}
+	return nil
+}

--- a/pkg/test/framework/features/features.yaml
+++ b/pkg/test/framework/features/features.yaml
@@ -88,6 +88,7 @@ features:
       jwt-token:
       workload-selector:
       deny-action:
+      external-action:
       negative-match:
       ingress-gateway:
       egress-gateway:

--- a/tests/integration/security/testdata/authz/v1beta1-external.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/v1beta1-external.yaml.tmpl
@@ -1,0 +1,21 @@
+apiVersion: "security.istio.io/v1beta1"
+kind: AuthorizationPolicy
+metadata:
+  name: policy-b-external
+  namespace: "{{ .Namespace }}"
+spec:
+  selector:
+    matchLabels:
+      "app": "b"
+  action: EXTERNAL
+  external:
+    http:
+      server: "http://ext-authz.foo.svc.cluster.local/"
+  rules:
+  - to:
+    - operation:
+        paths: ["/external1"]
+  - to:
+    - operation:
+        paths: ["/external2"]
+---


### PR DESCRIPTION
This PR updates the API with new changes in CRD (the `EXTERNAL` action in authz policy), adds validation for the new fields and deploys a shadow mode RBAC filter to evaluate the matching rules for EXTERNAL action.

The ext_authz filter will be added soon in a follow PR when the Envoy sha is updated to include the necessary changes in ext_authz filter.

For #27790.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
(will add release note in later PR when this feature becomes ready for use)