### PR TITLE
istioctl analyze: do not error if the threshold is warning

### DIFF
--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -64,8 +64,8 @@ func (f FileParseError) Error() string {
 var (
 	listAnalyzers     bool
 	useKube           bool
-	failureThreshold  = formatting.MessageThreshold{diag.Warning} // messages at least this level will generate an error exit code
-	outputThreshold   = formatting.MessageThreshold{diag.Info}    // messages at least this level will be included in the output
+	failureThreshold  = formatting.MessageThreshold{diag.Error} // messages at least this level will generate an error exit code
+	outputThreshold   = formatting.MessageThreshold{diag.Info}  // messages at least this level will be included in the output
 	colorize          bool
 	msgOutputFormat   string
 	meshCfgFile       string

--- a/istioctl/cmd/analyze_test.go
+++ b/istioctl/cmd/analyze_test.go
@@ -53,7 +53,7 @@ func TestNoErrorIfMessageLevelsBelowThreshold(t *testing.T) {
 			"",
 		),
 		diag.NewMessage(
-			diag.NewMessageType(diag.Info, "A1", "Template: %q"),
+			diag.NewMessageType(diag.Warning, "A1", "Template: %q"),
 			nil,
 			"",
 		),


### PR DESCRIPTION
Follow up for https://github.com/istio/istio/pull/27793

Based on @esnible https://github.com/istio/istio/issues/27390#issuecomment-696908674

> We should not say ERROR if the highest level is WARNING

Before:
```
$ istioctl analyze --all-namespaces
Warning [IST0102] (Namespace default) The namespace is not enabled for Istio injection. Run 'kubectl label namespace default istio-injection=enabled' to enable it, or 'kubectl label namespace default istio-injection=disabled' to explicitly mark it as not needing injection.
Error: Analyzers found issues when analyzing all namespaces.
See https://istio.io/v1.8/docs/reference/config/analysis for more information about causes and resolutions.
```

After:
```
$ ./out/linux_amd64/istioctl analyze --all-namespaces
Warning [IST0102] (Namespace default) The namespace is not enabled for Istio injection. Run 'kubectl label namespace default istio-injection=enabled' to enable it, or 'kubectl label namespace default istio-injection=disabled' to explicitly mark it as not needing injection.
```
After https://github.com/istio/istio/pull/27793 is merged. 
```
$ ./out/linux_amd64/istioctl analyze --all-namespaces
Info [IST0102] (Namespace default) The namespace is not enabled for Istio injection. Run 'kubectl label namespace default istio-injection=enabled' to enable it, or 'kubectl label namespace default istio-injection=disabled' to explicitly mark it as not needing injection.
```