### PR TITLE
Added missing default values to enable Helm3

### DIFF
--- a/manifests/charts/gateways/istio-egress/values.yaml
+++ b/manifests/charts/gateways/istio-egress/values.yaml
@@ -163,6 +163,16 @@ global:
   # To output all istio components logs in json format by adding --log_as_json argument to each container argument
   logAsJson: false
 
+  # Specify pod scheduling arch(amd64, ppc64le, s390x) and weight as follows:
+  #   0 - Never scheduled
+  #   1 - Least preferred
+  #   2 - No preference
+  #   3 - Most preferred
+  arch:
+    amd64: 2
+    s390x: 2
+    ppc64le: 2
+
   # Comma-separated minimum per-scope logging level of messages to output, in the form of <scope>:<level>,<scope>:<level>
   # The control plane has different scopes depending on component, but can configure default log level across all components
   # If empty, default scope and level will be used as configured in code

--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -183,6 +183,16 @@ global:
   # To output all istio components logs in json format by adding --log_as_json argument to each container argument
   logAsJson: false
 
+  # Specify pod scheduling arch(amd64, ppc64le, s390x) and weight as follows:
+  #   0 - Never scheduled
+  #   1 - Least preferred
+  #   2 - No preference
+  #   3 - Most preferred
+  arch:
+    amd64: 2
+    s390x: 2
+    ppc64le: 2
+
   # Comma-separated minimum per-scope logging level of messages to output, in the form of <scope>:<level>,<scope>:<level>
   # The control plane has different scopes depending on component, but can configure default log level across all components
   # If empty, default scope and level will be used as configured in code

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -193,6 +193,9 @@ global:
     #   cpu: 100m
     #   memory: 128Mi
 
+  # Used to locate istiod.
+  istioNamespace: istio-system
+
   # Default hub for Istio images.
   # Releases are published to docker hub under 'istio' project.
   # Dev builds from prow are on gcr.io


### PR DESCRIPTION
Ingress/Egress gateway charts won't install without the `global.arch` values.

Istio discovery chart will install without `istioNamespace` value but the
default mesh config in the `istio` config map has zipkin address with the
template characters in it causing any proxy (sidecar or gateways) to crash after
start.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
