### PR TITLE
remove unused path param from istiod-remote

### DIFF
--- a/manifests/charts/istiod-remote/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istiod-remote/templates/mutatingwebhook.yaml
@@ -16,8 +16,8 @@ webhooks:
   - name: sidecar-injector.istio.io
     clientConfig:
       {{- if .Values.istiodRemote.injectionURL }}
-      # the url doesn't take query params, so use inject/cluster/x/net/y format
-      url: {{ .Values.istiodRemote.injectionURL }}/cluster/{{ .Values.global.multiCluster.clusterName | default "remote0" }}/net/{{ .Values.global.network | default "network0" }}
+      # the url supports to use inject/cluster/x/net/y format
+      url: {{ .Values.istiodRemote.injectionURL }}
       {{- else }}
       service:
         name: istiod

--- a/operator/cmd/mesh/manifest-generate_test.go
+++ b/operator/cmd/mesh/manifest-generate_test.go
@@ -197,7 +197,7 @@ func TestManifestGenerateIstiodRemote(t *testing.T) {
 		g.Expect(objs.kind(name.SAStr).nameEquals("istiod-service-account")).Should(Not(BeNil()))
 
 		mwc := mustGetMutatingWebhookConfiguration(g, objs, "istio-sidecar-injector").Unstructured()
-		g.Expect(mwc).Should(HavePathValueEqual(PathValue{"webhooks.[0].clientConfig.url", "https://xxx:15017/inject/cluster/remote0/net/network2"}))
+		g.Expect(mwc).Should(HavePathValueEqual(PathValue{"webhooks.[0].clientConfig.url", "https://xxx:15017/inject"}))
 		g.Expect(mwc).Should(HavePathValueContain(PathValue{"webhooks.[0].namespaceSelector.matchLabels", toMap("istio-injection:enabled")}))
 
 		vwc := mustGetValidatingWebhookConfiguration(g, objs, "istiod-istio-system").Unstructured()

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/templates/mutatingwebhook.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/templates/mutatingwebhook.yaml
@@ -16,8 +16,8 @@ webhooks:
   - name: sidecar-injector.istio.io
     clientConfig:
       {{- if .Values.istiodRemote.injectionURL }}
-      # the url doesn't take query params, so use inject/cluster/x/net/y format
-      url: {{ .Values.istiodRemote.injectionURL }}/cluster/{{ .Values.global.multiCluster.clusterName | default "remote0" }}/net/{{ .Values.global.network | default "network0" }}
+      # the url supports to use inject/cluster/x/net/y format
+      url: {{ .Values.istiodRemote.injectionURL }}
       {{- else }}
       service:
         name: istiod


### PR DESCRIPTION
Since we support to set clusterID and network via `values.global` in https://github.com/istio/istio/pull/25554 we do not need set this in injection template any more.

THis also fixed the error that the default `remote0` we used does not work when we only have 1 cluster.