### PR TITLE
add RESPONSE_CODE_DETAILS and CONNECTION_TERMINATION_DETAILS to access log

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/accesslog.go
+++ b/pilot/pkg/networking/core/v1alpha3/accesslog.go
@@ -28,6 +28,7 @@ import (
 	structpb "github.com/golang/protobuf/ptypes/struct"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pkg/util/protomarshal"
 	"istio.io/pkg/log"
@@ -37,6 +38,17 @@ const (
 	// EnvoyTextLogFormat format for envoy text based access logs for Istio 1.3 onwards
 	EnvoyTextLogFormat = "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% " +
 		"%PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% " +
+		"\"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% " +
+		"%DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" " +
+		"\"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" " +
+		"%UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% " +
+		"%DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME% %ROUTE_NAME%\n"
+	// EnvoyTextLogFormatIstio18 format for envoy text based access logs for Istio 1.8 onwards
+	// This includes the additional new operator RESPONSE_CODE_DETAILS and CONNECTION_TERMINATION_DETAILS that includes
+	// the reason for Envoy to reject a request.
+	EnvoyTextLogFormatIstio18 = "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% " +
+		"%PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% " +
+		"%RESPONSE_CODE_DETAILS% %CONNECTION_TERMINATION_DETAILS% " +
 		"\"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% " +
 		"%DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" " +
 		"\"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" " +
@@ -86,6 +98,37 @@ var (
 			"upstream_transport_failure_reason": {Kind: &structpb.Value_StringValue{StringValue: "%UPSTREAM_TRANSPORT_FAILURE_REASON%"}},
 		},
 	}
+	// EnvoyJSONLogFormatIstio18 map of values for envoy json based access logs for Istio 1.8 onwards
+	// This includes the additional new operator RESPONSE_CODE_DETAILS and CONNECTION_TERMINATION_DETAILS that includes
+	// the reason for Envoy to reject a request.
+	EnvoyJSONLogFormatIstio18 = &structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			"start_time":                        {Kind: &structpb.Value_StringValue{StringValue: "%START_TIME%"}},
+			"route_name":                        {Kind: &structpb.Value_StringValue{StringValue: "%ROUTE_NAME%"}},
+			"method":                            {Kind: &structpb.Value_StringValue{StringValue: "%REQ(:METHOD)%"}},
+			"path":                              {Kind: &structpb.Value_StringValue{StringValue: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"}},
+			"protocol":                          {Kind: &structpb.Value_StringValue{StringValue: "%PROTOCOL%"}},
+			"response_code":                     {Kind: &structpb.Value_StringValue{StringValue: "%RESPONSE_CODE%"}},
+			"response_flags":                    {Kind: &structpb.Value_StringValue{StringValue: "%RESPONSE_FLAGS%"}},
+			"response_code_details":             {Kind: &structpb.Value_StringValue{StringValue: "%RESPONSE_CODE_DETAILS%"}},
+			"connection_termination_details":    {Kind: &structpb.Value_StringValue{StringValue: "%CONNECTION_TERMINATION_DETAILS%"}},
+			"bytes_received":                    {Kind: &structpb.Value_StringValue{StringValue: "%BYTES_RECEIVED%"}},
+			"bytes_sent":                        {Kind: &structpb.Value_StringValue{StringValue: "%BYTES_SENT%"}},
+			"duration":                          {Kind: &structpb.Value_StringValue{StringValue: "%DURATION%"}},
+			"upstream_service_time":             {Kind: &structpb.Value_StringValue{StringValue: "%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%"}},
+			"x_forwarded_for":                   {Kind: &structpb.Value_StringValue{StringValue: "%REQ(X-FORWARDED-FOR)%"}},
+			"user_agent":                        {Kind: &structpb.Value_StringValue{StringValue: "%REQ(USER-AGENT)%"}},
+			"request_id":                        {Kind: &structpb.Value_StringValue{StringValue: "%REQ(X-REQUEST-ID)%"}},
+			"authority":                         {Kind: &structpb.Value_StringValue{StringValue: "%REQ(:AUTHORITY)%"}},
+			"upstream_host":                     {Kind: &structpb.Value_StringValue{StringValue: "%UPSTREAM_HOST%"}},
+			"upstream_cluster":                  {Kind: &structpb.Value_StringValue{StringValue: "%UPSTREAM_CLUSTER%"}},
+			"upstream_local_address":            {Kind: &structpb.Value_StringValue{StringValue: "%UPSTREAM_LOCAL_ADDRESS%"}},
+			"downstream_local_address":          {Kind: &structpb.Value_StringValue{StringValue: "%DOWNSTREAM_LOCAL_ADDRESS%"}},
+			"downstream_remote_address":         {Kind: &structpb.Value_StringValue{StringValue: "%DOWNSTREAM_REMOTE_ADDRESS%"}},
+			"requested_server_name":             {Kind: &structpb.Value_StringValue{StringValue: "%REQUESTED_SERVER_NAME%"}},
+			"upstream_transport_failure_reason": {Kind: &structpb.Value_StringValue{StringValue: "%UPSTREAM_TRANSPORT_FAILURE_REASON%"}},
+		},
+	}
 
 	// State logged by the metadata exchange filter about the upstream and downstream service instances
 	// We need to propagate these as part of access log service stream
@@ -106,9 +149,11 @@ type AccessLogBuilder struct {
 	tcpGrpcListenerAccessLog *accesslog.AccessLog
 
 	// file accessLog which is cached and reset on MeshConfig change.
-	mutex                 sync.RWMutex
-	fileAccessLog         *accesslog.AccessLog
-	listenerFileAccessLog *accesslog.AccessLog
+	mutex                     sync.RWMutex
+	fileAccessLog             *accesslog.AccessLog
+	fileAccesslogGE18         *accesslog.AccessLog
+	listenerFileAccessLog     *accesslog.AccessLog
+	listenerFileAccessLogGE18 *accesslog.AccessLog
 }
 
 func newAccessLogBuilder() *AccessLogBuilder {
@@ -119,9 +164,9 @@ func newAccessLogBuilder() *AccessLogBuilder {
 	}
 }
 
-func (b *AccessLogBuilder) setTCPAccessLog(mesh *meshconfig.MeshConfig, config *tcp.TcpProxy) {
+func (b *AccessLogBuilder) setTCPAccessLog(mesh *meshconfig.MeshConfig, config *tcp.TcpProxy, node *model.Proxy) {
 	if mesh.AccessLogFile != "" {
-		config.AccessLog = append(config.AccessLog, b.buildFileAccessLog(mesh))
+		config.AccessLog = append(config.AccessLog, b.buildFileAccessLog(mesh, node))
 	}
 
 	if mesh.EnableEnvoyAccessLogService {
@@ -129,9 +174,9 @@ func (b *AccessLogBuilder) setTCPAccessLog(mesh *meshconfig.MeshConfig, config *
 	}
 }
 
-func (b *AccessLogBuilder) setHTTPAccessLog(mesh *meshconfig.MeshConfig, connectionManager *hcm.HttpConnectionManager) {
+func (b *AccessLogBuilder) setHTTPAccessLog(mesh *meshconfig.MeshConfig, connectionManager *hcm.HttpConnectionManager, node *model.Proxy) {
 	if mesh.AccessLogFile != "" {
-		connectionManager.AccessLog = append(connectionManager.AccessLog, b.buildFileAccessLog(mesh))
+		connectionManager.AccessLog = append(connectionManager.AccessLog, b.buildFileAccessLog(mesh, node))
 	}
 
 	if mesh.EnableEnvoyAccessLogService {
@@ -139,12 +184,12 @@ func (b *AccessLogBuilder) setHTTPAccessLog(mesh *meshconfig.MeshConfig, connect
 	}
 }
 
-func (b *AccessLogBuilder) setListenerAccessLog(mesh *meshconfig.MeshConfig, listener *listener.Listener) {
+func (b *AccessLogBuilder) setListenerAccessLog(mesh *meshconfig.MeshConfig, listener *listener.Listener, node *model.Proxy) {
 	if mesh.DisableEnvoyListenerLog {
 		return
 	}
 	if mesh.AccessLogFile != "" {
-		listener.AccessLog = append(listener.AccessLog, b.buildListenerFileAccessLog(mesh))
+		listener.AccessLog = append(listener.AccessLog, b.buildListenerFileAccessLog(mesh, node))
 	}
 
 	if mesh.EnableEnvoyAccessLogService {
@@ -153,7 +198,7 @@ func (b *AccessLogBuilder) setListenerAccessLog(mesh *meshconfig.MeshConfig, lis
 	}
 }
 
-func buildFileAccessLogHelper(mesh *meshconfig.MeshConfig) *accesslog.AccessLog {
+func buildFileAccessLogHelper(mesh *meshconfig.MeshConfig, isVersionGE18 bool) *accesslog.AccessLog {
 
 	// We need to build access log. This is needed either on first access or when mesh config changes.
 	fl := &fileaccesslog.FileAccessLog{
@@ -163,6 +208,9 @@ func buildFileAccessLogHelper(mesh *meshconfig.MeshConfig) *accesslog.AccessLog 
 	switch mesh.AccessLogEncoding {
 	case meshconfig.MeshConfig_TEXT:
 		formatString := EnvoyTextLogFormat
+		if isVersionGE18 {
+			formatString = EnvoyTextLogFormatIstio18
+		}
 		if mesh.AccessLogFormat != "" {
 			formatString = mesh.AccessLogFormat
 		}
@@ -179,6 +227,9 @@ func buildFileAccessLogHelper(mesh *meshconfig.MeshConfig) *accesslog.AccessLog 
 		if err := protomarshal.ApplyJSON(mesh.AccessLogFormat, &parsedJSONLogStruct); err != nil {
 			log.Errorf("error parsing provided json log format, default log format will be used: %v", err)
 			jsonLogStruct = EnvoyJSONLogFormat
+			if isVersionGE18 {
+				jsonLogStruct = EnvoyJSONLogFormatIstio18
+			}
 		} else {
 			jsonLogStruct = &parsedJSONLogStruct
 		}
@@ -201,23 +252,28 @@ func buildFileAccessLogHelper(mesh *meshconfig.MeshConfig) *accesslog.AccessLog 
 	return al
 }
 
-func (b *AccessLogBuilder) buildFileAccessLog(mesh *meshconfig.MeshConfig) *accesslog.AccessLog {
+func (b *AccessLogBuilder) buildFileAccessLog(mesh *meshconfig.MeshConfig, node *model.Proxy) *accesslog.AccessLog {
 	// Check if cached config is available, and return immediately.
-	if cal := b.cachedFileAccessLog(); cal != nil {
+	isVersionGE18 := util.IsIstioVersionGE18(node)
+	if cal := b.cachedFileAccessLog(isVersionGE18); cal != nil {
 		return cal
 	}
 
 	// We need to build access log. This is needed either on first access or when mesh config changes.
-	al := buildFileAccessLogHelper(mesh)
+	al := buildFileAccessLogHelper(mesh, isVersionGE18)
 
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
-	b.fileAccessLog = al
+	if isVersionGE18 {
+		b.fileAccesslogGE18 = al
+	} else {
+		b.fileAccessLog = al
+	}
 
 	return al
 }
 
-func addAccessLogFiler() *accesslog.AccessLogFilter {
+func addAccessLogFilter() *accesslog.AccessLogFilter {
 	return &accesslog.AccessLogFilter{
 		FilterSpecifier: &accesslog.AccessLogFilter_ResponseFlagFilter{
 			ResponseFlagFilter: &accesslog.ResponseFlagFilter{Flags: []string{"NR"}},
@@ -225,34 +281,45 @@ func addAccessLogFiler() *accesslog.AccessLogFilter {
 	}
 }
 
-func (b *AccessLogBuilder) buildListenerFileAccessLog(mesh *meshconfig.MeshConfig) *accesslog.AccessLog {
+func (b *AccessLogBuilder) buildListenerFileAccessLog(mesh *meshconfig.MeshConfig, node *model.Proxy) *accesslog.AccessLog {
 	// Check if cached config is available, and return immediately.
-	if cal := b.cachedListenerFileAccessLog(); cal != nil {
+	isVersionGE18 := util.IsIstioVersionGE18(node)
+	if cal := b.cachedListenerFileAccessLog(isVersionGE18); cal != nil {
 		return cal
 	}
 
 	// We need to build access log. This is needed either on first access or when mesh config changes.
-	lal := buildFileAccessLogHelper(mesh)
+	lal := buildFileAccessLogHelper(mesh, isVersionGE18)
 	// We add ResponseFlagFilter here, as we want to get listener access logs only on scenarios where we might
 	// not get filter Access Logs like in cases like NR to upstream.
-	lal.Filter = addAccessLogFiler()
+	lal.Filter = addAccessLogFilter()
 
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
-	b.listenerFileAccessLog = lal
+	if isVersionGE18 {
+		b.listenerFileAccessLogGE18 = lal
+	} else {
+		b.listenerFileAccessLog = lal
+	}
 
 	return lal
 }
 
-func (b *AccessLogBuilder) cachedFileAccessLog() *accesslog.AccessLog {
+func (b *AccessLogBuilder) cachedFileAccessLog(isVersionGE18 bool) *accesslog.AccessLog {
 	b.mutex.RLock()
 	defer b.mutex.RUnlock()
+	if isVersionGE18 {
+		return b.fileAccesslogGE18
+	}
 	return b.fileAccessLog
 }
 
-func (b *AccessLogBuilder) cachedListenerFileAccessLog() *accesslog.AccessLog {
+func (b *AccessLogBuilder) cachedListenerFileAccessLog(isVersionGE18 bool) *accesslog.AccessLog {
 	b.mutex.RLock()
 	defer b.mutex.RUnlock()
+	if isVersionGE18 {
+		return b.listenerFileAccessLogGE18
+	}
 	return b.listenerFileAccessLog
 }
 
@@ -277,7 +344,7 @@ func buildTCPGrpcAccessLog(isListener bool) *accesslog.AccessLog {
 
 	var filter *accesslog.AccessLogFilter
 	if isListener {
-		filter = addAccessLogFiler()
+		filter = addAccessLogFilter()
 	}
 	return &accesslog.AccessLog{
 		Name:       tcpEnvoyALSName,
@@ -310,6 +377,8 @@ func buildHTTPGrpcAccessLog() *accesslog.AccessLog {
 func (b *AccessLogBuilder) reset() {
 	b.mutex.Lock()
 	b.fileAccessLog = nil
+	b.fileAccesslogGE18 = nil
 	b.listenerFileAccessLog = nil
+	b.listenerFileAccessLogGE18 = nil
 	b.mutex.Unlock()
 }

--- a/pilot/pkg/networking/core/v1alpha3/accesslog_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/accesslog_test.go
@@ -1,0 +1,174 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha3
+
+import (
+	"testing"
+
+	accesslog "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
+	httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	tcp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/conversion"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/istio/pkg/util/protomarshal"
+)
+
+func TestListenerAccessLog(t *testing.T) {
+	version18 := &model.IstioVersion{Major: 1, Minor: 8}
+	version19 := &model.IstioVersion{Major: 1, Minor: 9}
+	defaultFormatJSON, _ := protomarshal.ToJSON(EnvoyJSONLogFormat)
+	ge19FormatJSON, _ := protomarshal.ToJSON(EnvoyJSONLogFormatIstio19)
+
+	for _, tc := range []struct {
+		name         string
+		encoding     meshconfig.MeshConfig_AccessLogEncoding
+		proxyVersion *model.IstioVersion
+		format       string
+		wantFormat   string
+	}{
+		{
+			name:         "valid json object",
+			encoding:     meshconfig.MeshConfig_JSON,
+			proxyVersion: version18,
+			format:       `{"foo": "bar"}`,
+			wantFormat:   `{"foo":"bar"}`,
+		},
+		{
+			name:         "valid nested json object",
+			encoding:     meshconfig.MeshConfig_JSON,
+			proxyVersion: version18,
+			format:       `{"foo": {"bar": "ha"}}`,
+			wantFormat:   `{"foo":{"bar":"ha"}}`,
+		},
+		{
+			name:         "invalid json object",
+			encoding:     meshconfig.MeshConfig_JSON,
+			proxyVersion: version18,
+			format:       `foo`,
+			wantFormat:   defaultFormatJSON,
+		},
+		{
+			name:         "incorrect json type",
+			encoding:     meshconfig.MeshConfig_JSON,
+			proxyVersion: version18,
+			format:       `[]`,
+			wantFormat:   defaultFormatJSON,
+		},
+		{
+			name:         "incorrect json type",
+			encoding:     meshconfig.MeshConfig_JSON,
+			proxyVersion: version18,
+			format:       `"{}"`,
+			wantFormat:   defaultFormatJSON,
+		},
+		{
+			name:         "default json format",
+			encoding:     meshconfig.MeshConfig_JSON,
+			proxyVersion: version18,
+			wantFormat:   defaultFormatJSON,
+		},
+		{
+			name:         "default json format proxy 1.9",
+			encoding:     meshconfig.MeshConfig_JSON,
+			proxyVersion: version19,
+			wantFormat:   ge19FormatJSON,
+		},
+		{
+			name:         "default text format",
+			encoding:     meshconfig.MeshConfig_TEXT,
+			proxyVersion: version18,
+			wantFormat:   EnvoyTextLogFormat,
+		},
+		{
+			name:         "default text format proxy 1.9",
+			encoding:     meshconfig.MeshConfig_TEXT,
+			proxyVersion: version19,
+			wantFormat:   EnvoyTextLogFormatIstio19,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// Update MeshConfig
+			env := buildListenerEnv(nil)
+			env.Mesh().AccessLogFile = "foo"
+			env.Mesh().AccessLogEncoding = tc.encoding
+			env.Mesh().AccessLogFormat = tc.format
+
+			// Trigger MeshConfig change and validate that access log is recomputed.
+			accessLogBuilder.reset()
+
+			// Validate that access log filter uses the new format.
+			listeners := buildAllListeners(&fakePlugin{}, env, tc.proxyVersion)
+			for _, l := range listeners {
+				if l.AccessLog[0].Filter == nil {
+					t.Fatal("expected filter config in listener access log configuration")
+				}
+				// Verify listener access log.
+				verify(t, tc.encoding, l.AccessLog[0], tc.wantFormat)
+
+				for _, fc := range l.FilterChains {
+					for _, filter := range fc.Filters {
+						switch filter.Name {
+						case wellknown.TCPProxy:
+							tcpConfig := &tcp.TcpProxy{}
+							if err := filter.GetTypedConfig().UnmarshalTo(tcpConfig); err != nil {
+								t.Fatal(err)
+							}
+							if tcpConfig.GetCluster() == util.BlackHoleCluster {
+								// Ignore the tcp_proxy filter with black hole cluster that just doesn't have access log.
+								continue
+							}
+							if len(tcpConfig.AccessLog) < 1 {
+								t.Fatalf("tcp_proxy want at least 1 access log, got 0")
+							}
+							// Verify tcp proxy access log.
+							verify(t, tc.encoding, tcpConfig.AccessLog[0], tc.wantFormat)
+						case wellknown.HTTPConnectionManager:
+							httpConfig := &httppb.HttpConnectionManager{}
+							if err := filter.GetTypedConfig().UnmarshalTo(httpConfig); err != nil {
+								t.Fatal(err)
+							}
+							if len(httpConfig.AccessLog) < 1 {
+								t.Fatalf("http_connection_manager want at least 1 access log, got 0")
+							}
+							// Verify HTTP connection manager access log.
+							verify(t, tc.encoding, httpConfig.AccessLog[0], tc.wantFormat)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func verify(t *testing.T, encoding meshconfig.MeshConfig_AccessLogEncoding, got *accesslog.AccessLog, wantFormat string) {
+	cfg, _ := conversion.MessageToStruct(got.GetTypedConfig())
+	if encoding == meshconfig.MeshConfig_JSON {
+		jsonFormat := cfg.GetFields()["log_format"].GetStructValue().GetFields()["json_format"]
+		jsonFormatString, _ := protomarshal.ToJSON(jsonFormat)
+		if jsonFormatString != wantFormat {
+			t.Errorf("\nwant: %s\n got: %s", wantFormat, jsonFormatString)
+		}
+	} else {
+		textFormatString := cfg.GetFields()["log_format"].GetStructValue().GetFields()["text_format"].GetStringValue()
+		if textFormatString != wantFormat {
+			t.Errorf("\nwant: %s\n got: %s", wantFormat, textFormatString)
+		}
+	}
+}

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1706,7 +1706,7 @@ func buildHTTPConnectionManager(listenerOpts buildListenerOpts, httpOpts *httpLi
 		connectionManager.RouteSpecifier = &hcm.HttpConnectionManager_RouteConfig{RouteConfig: httpOpts.routeConfig}
 	}
 
-	accessLogBuilder.setHTTPAccessLog(listenerOpts.push.Mesh, connectionManager)
+	accessLogBuilder.setHTTPAccessLog(listenerOpts.push.Mesh, connectionManager, listenerOpts.proxy)
 
 	if listenerOpts.push.Mesh.EnableTracing {
 		proxyConfig := listenerOpts.proxy.Metadata.ProxyConfigOrDefault(listenerOpts.push.Mesh.DefaultConfig)
@@ -2009,7 +2009,7 @@ func buildListener(opts buildListenerOpts) *listener.Listener {
 		DeprecatedV1:    deprecatedV1,
 	}
 
-	accessLogBuilder.setListenerAccessLog(opts.push.Mesh, listener)
+	accessLogBuilder.setListenerAccessLog(opts.push.Mesh, listener, opts.proxy)
 
 	if opts.proxy.Type != model.Router {
 		listener.ListenerFiltersTimeout = gogo.DurationToProtoDuration(opts.push.Mesh.ProtocolDetectionTimeout)

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -339,7 +339,7 @@ func (lb *ListenerBuilder) buildVirtualOutboundListener(configgen *ConfigGenerat
 		FilterChains:                        filterChains,
 		TrafficDirection:                    core.TrafficDirection_OUTBOUND,
 	}
-	accessLogBuilder.setListenerAccessLog(lb.push.Mesh, ipTablesListener)
+	accessLogBuilder.setListenerAccessLog(lb.push.Mesh, ipTablesListener, lb.node)
 	lb.virtualOutboundListener = ipTablesListener
 	return lb
 }
@@ -368,7 +368,7 @@ func (lb *ListenerBuilder) buildVirtualInboundListener(configgen *ConfigGenerato
 		TrafficDirection:                    core.TrafficDirection_INBOUND,
 		FilterChains:                        filterChains,
 	}
-	accessLogBuilder.setListenerAccessLog(lb.push.Mesh, lb.virtualInboundListener)
+	accessLogBuilder.setListenerAccessLog(lb.push.Mesh, lb.virtualInboundListener, lb.node)
 	lb.aggregateVirtualInboundListener(needTLSForPassThroughFilterChain)
 
 	return lb
@@ -494,7 +494,7 @@ func buildInboundCatchAllNetworkFilterChains(configgen *ConfigGeneratorImpl,
 			matchingIP = "::0/0"
 		}
 
-		accessLogBuilder.setTCPAccessLog(push.Mesh, tcpProxy)
+		accessLogBuilder.setTCPAccessLog(push.Mesh, tcpProxy, node)
 		tcpProxyFilter := &listener.Filter{
 			Name:       wellknown.TCPProxy,
 			ConfigType: &listener.Filter_TypedConfig{TypedConfig: util.MessageToAny(tcpProxy)},
@@ -683,7 +683,7 @@ func buildOutboundCatchAllNetworkFiltersOnly(push *model.PushContext, node *mode
 		StatPrefix:       egressCluster,
 		ClusterSpecifier: &tcp.TcpProxy_Cluster{Cluster: egressCluster},
 	}
-	accessLogBuilder.setTCPAccessLog(push.Mesh, tcpProxy)
+	accessLogBuilder.setTCPAccessLog(push.Mesh, tcpProxy, node)
 	filterStack = append(filterStack, &listener.Filter{
 		Name:       wellknown.TCPProxy,
 		ConfigType: &listener.Filter_TypedConfig{TypedConfig: util.MessageToAny(tcpProxy)},

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -57,7 +57,6 @@ import (
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
-	"istio.io/istio/pkg/util/protomarshal"
 )
 
 const (
@@ -1450,7 +1449,7 @@ func TestOutboundListenerAccessLogs(t *testing.T) {
 	p := &fakePlugin{}
 	env := buildListenerEnv(nil)
 	env.Mesh().AccessLogFile = "foo"
-	listeners := buildAllListeners(p, env)
+	listeners := buildAllListeners(p, env, nil)
 	found := false
 	for _, l := range listeners {
 		if l.Name == VirtualOutboundListenerName {
@@ -1476,7 +1475,7 @@ func TestOutboundListenerAccessLogs(t *testing.T) {
 	accessLogBuilder.reset()
 
 	// Validate that access log filter uses the new format.
-	listeners = buildAllListeners(p, env)
+	listeners = buildAllListeners(p, env, nil)
 	for _, l := range listeners {
 		if l.Name == VirtualOutboundListenerName {
 			validateAccessLog(t, l, "format modified")
@@ -1489,7 +1488,7 @@ func TestListenerAccessLogs(t *testing.T) {
 	p := &fakePlugin{}
 	env := buildListenerEnv(nil)
 	env.Mesh().AccessLogFile = "foo"
-	listeners := buildAllListeners(p, env)
+	listeners := buildAllListeners(p, env, nil)
 	for _, l := range listeners {
 
 		if l.AccessLog == nil {
@@ -1506,7 +1505,7 @@ func TestListenerAccessLogs(t *testing.T) {
 	accessLogBuilder.reset()
 
 	// Validate that access log filter uses the new format.
-	listeners = buildAllListeners(p, env)
+	listeners = buildAllListeners(p, env, nil)
 	for _, l := range listeners {
 		if l.AccessLog[0].Filter == nil {
 			t.Fatal("expected filter config in listener access log configuration")
@@ -1516,78 +1515,6 @@ func TestListenerAccessLogs(t *testing.T) {
 		if textFormat != env.Mesh().AccessLogFormat {
 			t.Fatalf("expected format to be %s, but got %s", env.Mesh().AccessLogFormat, textFormat)
 		}
-	}
-}
-
-func TestListenerAccessLogsJSON(t *testing.T) {
-	t.Helper()
-	p := &fakePlugin{}
-	env := buildListenerEnv(nil)
-	env.Mesh().AccessLogFile = "foo"
-	listeners := buildAllListeners(p, env)
-
-	defaultFormatJSON, _ := protomarshal.ToJSON(EnvoyJSONLogFormat)
-
-	for _, tc := range []struct {
-		name       string
-		format     string
-		wantFormat string
-	}{
-		{
-			name:       "valid json object",
-			format:     `{"foo": "bar"}`,
-			wantFormat: `{"foo":"bar"}`,
-		},
-		{
-			name:       "valid nested json object",
-			format:     `{"foo": {"bar": "ha"}}`,
-			wantFormat: `{"foo":{"bar":"ha"}}`,
-		},
-		{
-			name:       "invalid json object",
-			format:     `foo`,
-			wantFormat: defaultFormatJSON,
-		},
-		{
-			name:       "incorrect json type",
-			format:     `[]`,
-			wantFormat: defaultFormatJSON,
-		},
-		{
-			name:       "incorrect json type",
-			format:     `"{}"`,
-			wantFormat: defaultFormatJSON,
-		},
-		{
-			name:       "empty string",
-			format:     ``,
-			wantFormat: defaultFormatJSON,
-		},
-	} {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			// Update MeshConfig
-			env.Mesh().AccessLogEncoding = meshconfig.MeshConfig_JSON
-			env.Mesh().AccessLogFormat = tc.format
-
-			// Trigger MeshConfig change and validate that access log is recomputed.
-			accessLogBuilder.reset()
-
-			// Validate that access log filter uses the new format.
-			listeners = buildAllListeners(p, env)
-			for _, l := range listeners {
-				if l.AccessLog[0].Filter == nil {
-					t.Fatal("expected filter config in listener access log configuration")
-				}
-				cfg, _ := conversion.MessageToStruct(l.AccessLog[0].GetTypedConfig())
-				jsonFormat := cfg.GetFields()["log_format"].GetStructValue().GetFields()["json_format"]
-				jsonFormatString, _ := protomarshal.ToJSON(jsonFormat)
-
-				if jsonFormatString != tc.wantFormat {
-					t.Fatalf("expected format to be %s, but got %s", tc.format, jsonFormatString)
-				}
-			}
-		})
 	}
 }
 
@@ -2279,7 +2206,7 @@ func getOldestService(services ...*model.Service) *model.Service {
 	return oldestService
 }
 
-func buildAllListeners(p plugin.Plugin, env model.Environment) []*listener.Listener {
+func buildAllListeners(p plugin.Plugin, env model.Environment, proxyVersion *model.IstioVersion) []*listener.Listener {
 	configgen := NewConfigGenerator([]plugin.Plugin{p}, &model.DisabledCache{})
 
 	if err := env.PushContext.InitContext(&env, nil, nil); err != nil {
@@ -2289,6 +2216,7 @@ func buildAllListeners(p plugin.Plugin, env model.Environment) []*listener.Liste
 	proxy := getProxy()
 	proxy.ServiceInstances = nil
 	proxy.SidecarScope = model.DefaultSidecarScopeForNamespace(env.PushContext, "not-default")
+	proxy.IstioVersion = proxyVersion
 	builder := NewListenerBuilder(proxy, env.PushContext)
 	return configgen.buildSidecarListeners(builder).getListeners()
 }

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -53,14 +53,14 @@ func buildInboundNetworkFilters(push *model.PushContext, instance *model.Service
 		StatPrefix:       statPrefix,
 		ClusterSpecifier: &tcp.TcpProxy_Cluster{Cluster: clusterName},
 	}
-	tcpFilter := setAccessLogAndBuildTCPFilter(push, tcpProxy)
+	tcpFilter := setAccessLogAndBuildTCPFilter(push, tcpProxy, node)
 	return buildNetworkFiltersStack(instance.ServicePort, tcpFilter, statPrefix, clusterName)
 }
 
 // setAccessLogAndBuildTCPFilter sets the AccessLog configuration in the given
 // TcpProxy instance and builds a TCP filter out of it.
-func setAccessLogAndBuildTCPFilter(push *model.PushContext, config *tcp.TcpProxy) *listener.Filter {
-	accessLogBuilder.setTCPAccessLog(push.Mesh, config)
+func setAccessLogAndBuildTCPFilter(push *model.PushContext, config *tcp.TcpProxy, node *model.Proxy) *listener.Filter {
+	accessLogBuilder.setTCPAccessLog(push.Mesh, config, node)
 
 	tcpFilter := &listener.Filter{
 		Name:       wellknown.TCPProxy,
@@ -85,7 +85,7 @@ func buildOutboundNetworkFiltersWithSingleDestination(push *model.PushContext, n
 		tcpProxy.IdleTimeout = ptypes.DurationProto(idleTimeout)
 	}
 
-	tcpFilter := setAccessLogAndBuildTCPFilter(push, tcpProxy)
+	tcpFilter := setAccessLogAndBuildTCPFilter(push, tcpProxy, node)
 	return buildNetworkFiltersStack(port, tcpFilter, statPrefix, clusterName)
 }
 
@@ -123,7 +123,7 @@ func buildOutboundNetworkFiltersWithWeightedClusters(node *model.Proxy, routes [
 
 	// TODO: Need to handle multiple cluster names for Redis
 	clusterName := clusterSpecifier.WeightedClusters.Clusters[0].Name
-	tcpFilter := setAccessLogAndBuildTCPFilter(push, proxyConfig)
+	tcpFilter := setAccessLogAndBuildTCPFilter(push, proxyConfig, node)
 	return buildNetworkFiltersStack(port, tcpFilter, statPrefix, clusterName)
 }
 

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -270,10 +270,10 @@ func SortVirtualHosts(hosts []*route.VirtualHost) {
 	})
 }
 
-// IsIstioVersionGE15 checks whether the given Istio version is greater than or equals 1.5.
-func IsIstioVersionGE15(node *model.Proxy) bool {
-	return node.IstioVersion == nil ||
-		node.IstioVersion.Compare(&model.IstioVersion{Major: 1, Minor: 5, Patch: -1}) >= 0
+// IsIstioVersionGE19 checks whether the given Istio version is greater than or equals 1.9.
+func IsIstioVersionGE19(node *model.Proxy) bool {
+	return node == nil || node.IstioVersion == nil ||
+		node.IstioVersion.Compare(&model.IstioVersion{Major: 1, Minor: 9, Patch: -1}) >= 0
 }
 
 // IsIstioVersionGE18 checks whether the given Istio version is greater than or equals 1.8.

--- a/releasenotes/notes/default-access-log.yaml
+++ b/releasenotes/notes/default-access-log.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+releaseNotes:
+  - |
+    **Updated** default access log to include `RESPONSE_CODE_DETAILS` and `CONNECTION_TERMINATION_DETAILS` for proxy version >= 1.9.


### PR DESCRIPTION
These log operators should be very useful for troubleshooting and debugging in many cases. 

Example Logs (RESPONSE_CODE_DETAILS): (`via_upstream` , `filter_chain_not_found`, `http1.codec_error`, `rbac_access_denied_matched_policy[none]`)
```
[2020-10-29T03:22:16.126Z] "GET /headers HTTP/1.1" 200 - via_upstream - "-" 0 547 5 4 "-" "curl/7.73.0-DEV" "24e58e43-e576-9048-829b-02e3f3da16f0" "httpbin:8000" "127.0.0.1:80" inbound|8000|| 127.0.0.1:51680 172.17.0.7:80 172.17.0.6:59022 outbound_.8000_._.httpbin.foo.svc.cluster.local default
[2020-10-29T03:23:33.415Z] "- - -" 0 NR filter_chain_not_found - "-" 0 0 0 - "-" "-" "-" "-" "-" - - 172.17.0.7:80 172.17.0.6:59800 - -
[2020-10-29T03:24:13.520Z] "- - HTTP/1.1" 400 DPE http1.codec_error - "-" 0 11 0 - "-" "-" "-" "-" "-" - - 172.17.0.7:80 172.17.0.6:60214 - -
[2020-10-29T03:25:20.162Z] "GET /headers HTTP/1.1" 403 - rbac_access_denied_matched_policy[none] - "-" 0 19 0 - "-" "curl/7.73.0-DEV" "07541777-6ee2-908f-a78b-867fe257ac80" "httpbin:8000" "-" - - 172.17.0.7:80 172.17.0.6:60898 outbound_.8000_._.httpbin.foo.svc.cluster.local -
[2020-10-29T03:26:11.561Z] "GET /headers HTTP/1.1" 403 - rbac_access_denied_matched_policy[ns[foo]-policy[httpbin]-rule[0]] - "-" 0 19 0 - "-" "curl/7.73.0-DEV" "090a1897-d696-99b1-90f0-2673113ba258" "httpbin:8000" "-" - - 172.17.0.7:80 172.17.0.6:33204 outbound_.8000_._.httpbin.foo.svc.cluster.local -
```

Example Logs (CONNECTION_TERMINATION_DETAILS): (`rbac_access_denied_matched_policy[ns[foo]-policy[httpbin]-rule[0]]`)
```
[2020-10-29T03:28:26.690Z] "- - -" 0 - - rbac_access_denied_matched_policy[ns[foo]-policy[httpbin]-rule[0]] "-" 761 701 5 - "-" "-" "-" "-" "127.0.0.1:80" inbound|8000|| 127.0.0.1:55464 172.17.0.7:80 172.17.0.6:34574 outbound_.8000_._.httpbin.foo.svc.cluster.local -
```

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[X] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.