### PR TITLE
xdsproxy: add tests for reconnect

### DIFF
--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -210,7 +210,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	grpcServer := grpc.NewServer()
 	s.Register(grpcServer)
 	go func() {
-		if err := grpcServer.Serve(listener); err != nil && err != grpc.ErrServerStopped {
+		if err := grpcServer.Serve(listener); err != nil && !(err == grpc.ErrServerStopped || err.Error() == "closed") {
 			t.Fatal(err)
 		}
 	}()

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -177,7 +177,6 @@ func (p *XdsProxy) StreamAggregatedResources(downstream discovery.AggregatedDisc
 	}
 	defer upstreamConn.Close()
 	proxyLog.Debugf("connected to %s", p.istiodAddress)
-
 	xds := discovery.NewAggregatedDiscoveryServiceClient(upstreamConn)
 	ctx := metadata.AppendToOutgoingContext(context.Background(), "ClusterID", p.clusterID)
 	if p.agent.cfg.XDSHeaders != nil {
@@ -202,7 +201,6 @@ RecreateUpstream:
 			resp, err := upstream.Recv()
 			if err != nil {
 				upstreamError <- err
-				close(upstreamError)
 				return
 			}
 			responsesChan <- resp

--- a/pkg/istio-agent/xds_proxy_test.go
+++ b/pkg/istio-agent/xds_proxy_test.go
@@ -140,11 +140,7 @@ func TestXdsProxyReconnects(t *testing.T) {
 		grpcServer := grpc.NewServer()
 		t.Cleanup(grpcServer.Stop)
 		f.Discovery.Register(grpcServer)
-		go func() {
-			if err := grpcServer.Serve(listener); err != nil && !(err == grpc.ErrServerStopped || err.Error() == "closed") {
-				t.Fatal(err)
-			}
-		}()
+		go grpcServer.Serve(listener)
 
 		// Send initial request
 		conn := setupDownstreamConnection(t)
@@ -160,11 +156,7 @@ func TestXdsProxyReconnects(t *testing.T) {
 		grpcServer = grpc.NewServer()
 		t.Cleanup(grpcServer.Stop)
 		f.Discovery.Register(grpcServer)
-		go func() {
-			if err := grpcServer.Serve(listener); err != nil && !(err == grpc.ErrServerStopped || err.Error() == "closed") {
-				t.Fatal(err)
-			}
-		}()
+		go grpcServer.Serve(listener)
 
 		// Send downstream again
 		downstream = stream(t, conn)

--- a/pkg/istio-agent/xds_proxy_test.go
+++ b/pkg/istio-agent/xds_proxy_test.go
@@ -24,6 +24,7 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/test/bufconn"
 
 	"istio.io/istio/pilot/pkg/xds"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
@@ -34,6 +35,15 @@ import (
 
 // Validates basic xds proxy flow by proxying one CDS requests end to end.
 func TestXdsProxyBasicFlow(t *testing.T) {
+	proxy := setupXdsProxy(t)
+	f := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+	setDialOptions(proxy, f.Listener)
+	conn := setupDownstreamConnection(t)
+	downstream := stream(t, conn)
+	sendDownstream(t, downstream)
+}
+
+func setupXdsProxy(t *testing.T) *XdsProxy {
 	secOpts := &security.Options{
 		FileMountedCerts: true,
 	}
@@ -57,69 +67,156 @@ func TestXdsProxyBasicFlow(t *testing.T) {
 		t.Fatalf("Failed to initialize xds proxy %v", err)
 	}
 
-	f := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+	return proxy
+}
 
+func setDialOptions(p *XdsProxy, l *bufconn.Listener) {
 	// Override istiodDialOptions so that the test can connect with plain text and with buffcon listener.
-	proxy.istiodDialOptions = []grpc.DialOption{
+	p.istiodDialOptions = []grpc.DialOption{
 		grpc.WithBlock(),
 		grpc.WithInsecure(),
 		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
-			return f.Listener.Dial()
+			return l.Dial()
 		}),
 	}
 
-	res, err := setupDownstreamAndWait(xdsUdsPath, &discovery.DiscoveryRequest{
+}
+
+var ctx = metadata.AppendToOutgoingContext(context.Background(), "ClusterID", "Kubernetes")
+
+// Validates basic xds proxy flow by proxying one CDS requests end to end.
+func TestXdsProxyReconnects(t *testing.T) {
+	t.Run("Envoy close and open stream", func(t *testing.T) {
+		proxy := setupXdsProxy(t)
+		f := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+		setDialOptions(proxy, f.Listener)
+
+		conn := setupDownstreamConnection(t)
+		downstream := stream(t, conn)
+		sendDownstream(t, downstream)
+
+		downstream.CloseSend()
+		downstream = stream(t, conn)
+		sendDownstream(t, downstream)
+	})
+	t.Run("Envoy opens multiple stream", func(t *testing.T) {
+		proxy := setupXdsProxy(t)
+		f := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+		setDialOptions(proxy, f.Listener)
+
+		conn := setupDownstreamConnection(t)
+		downstream := stream(t, conn)
+		sendDownstream(t, downstream)
+		downstream = stream(t, conn)
+		sendDownstream(t, downstream)
+	})
+	t.Run("Envoy closes connection", func(t *testing.T) {
+		proxy := setupXdsProxy(t)
+		f := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+		setDialOptions(proxy, f.Listener)
+
+		conn := setupDownstreamConnection(t)
+		downstream := stream(t, conn)
+		sendDownstream(t, downstream)
+		conn.Close()
+		conn = setupDownstreamConnection(t)
+		downstream = stream(t, conn)
+		sendDownstream(t, downstream)
+	})
+	t.Run("Istiod closes connection", func(t *testing.T) {
+		proxy := setupXdsProxy(t)
+		f := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+
+		// Here we set up a real listener (instead of in memory) since we need to close and re-open
+		// a new listener on the same port, which we cannot do with the in memory listener.
+		listener, err := net.Listen("tcp", ":0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		proxy.istiodAddress = listener.Addr().String()
+		proxy.istiodDialOptions = []grpc.DialOption{grpc.WithBlock(), grpc.WithInsecure()}
+
+		// Setup gRPC server
+		grpcServer := grpc.NewServer()
+		t.Cleanup(grpcServer.Stop)
+		f.Discovery.Register(grpcServer)
+		go func() {
+			if err := grpcServer.Serve(listener); err != nil && !(err == grpc.ErrServerStopped || err.Error() == "closed") {
+				t.Fatal(err)
+			}
+		}()
+
+		// Send initial request
+		conn := setupDownstreamConnection(t)
+		downstream := stream(t, conn)
+		sendDownstream(t, downstream)
+
+		// Stop server, setup a new one. This simulates an Istiod pod being torn down
+		grpcServer.Stop()
+		listener, err = net.Listen("tcp", listener.Addr().String())
+		if err != nil {
+			t.Fatal(err)
+		}
+		grpcServer = grpc.NewServer()
+		t.Cleanup(grpcServer.Stop)
+		f.Discovery.Register(grpcServer)
+		go func() {
+			if err := grpcServer.Serve(listener); err != nil && !(err == grpc.ErrServerStopped || err.Error() == "closed") {
+				t.Fatal(err)
+			}
+		}()
+
+		// Send downstream again
+		downstream = stream(t, conn)
+		sendDownstream(t, downstream)
+	})
+}
+
+func stream(t *testing.T, conn *grpc.ClientConn) discovery.AggregatedDiscoveryService_StreamAggregatedResourcesClient {
+	t.Helper()
+	adsClient := discovery.NewAggregatedDiscoveryServiceClient(conn)
+	downstream, err := adsClient.StreamAggregatedResources(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return downstream
+}
+
+func sendDownstream(t *testing.T, downstream discovery.AggregatedDiscoveryService_StreamAggregatedResourcesClient) {
+	t.Helper()
+	err := downstream.Send(&discovery.DiscoveryRequest{
 		TypeUrl: v3.ClusterType,
 		Node: &core.Node{
 			Id: "sidecar~0.0.0.0~debug~cluster.local",
 		},
 	})
 	if err != nil {
-		t.Fatalf("Failed to receive proxied response %v", err)
+		t.Fatal(err)
+	}
+	res, err := downstream.Recv()
+	if err != nil {
+		t.Fatal(err)
 	}
 	if res == nil || res.TypeUrl != v3.ClusterType {
 		t.Fatalf("Expected to get cluster response but got %v", res)
 	}
 }
 
-func setupDownstreamAndWait(socket string, req *discovery.DiscoveryRequest) (*discovery.DiscoveryResponse, error) {
-	conn, err := setupConnection(socket)
-	if err != nil {
-		return nil, err
-	}
-	defer conn.Close()
-
-	adsClient := discovery.NewAggregatedDiscoveryServiceClient(conn)
-	ctx := metadata.AppendToOutgoingContext(context.Background(), "ClusterID", "Kubernetes")
-	downstream, err := adsClient.StreamAggregatedResources(ctx,
-		grpc.MaxCallRecvMsgSize(defaultClientMaxReceiveMessageSize))
-	if err != nil {
-		return nil, err
-	}
-	err = downstream.Send(req)
-	if err != nil {
-		return nil, err
-	}
-	res, err := downstream.Recv()
-
-	if err != nil {
-		return nil, err
-	}
-	return res, nil
-}
-
-func setupConnection(socket string) (*grpc.ClientConn, error) {
+func setupDownstreamConnection(t *testing.T) *grpc.ClientConn {
 	var opts []grpc.DialOption
 
 	opts = append(opts, grpc.WithInsecure(), grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
 		var d net.Dialer
-		return d.DialContext(ctx, "unix", socket)
+		return d.DialContext(ctx, "unix", xdsUdsPath)
 	}))
 
-	conn, err := grpc.Dial(socket, opts...)
+	conn, err := grpc.Dial(xdsUdsPath, opts...)
 	if err != nil {
-		return nil, err
+		t.Fatal(err)
 	}
 
-	return conn, nil
+	t.Cleanup(func() {
+		conn.Close()
+	})
+	return conn
 }


### PR DESCRIPTION
Extend testing. Fix a bug when reusing closed upstream error channel