### PR TITLE
Refactor file watching for injection

### DIFF
--- a/pkg/kube/inject/watcher.go
+++ b/pkg/kube/inject/watcher.go
@@ -1,0 +1,87 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inject
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/howeyc/fsnotify"
+
+	"istio.io/pkg/log"
+)
+
+// Watcher watches for and reacts to injection config updates.
+type Watcher interface {
+	// Run starts the Watcher.
+	Run(<-chan struct{})
+}
+
+var _ Watcher = &fileWatcher{}
+
+type fileWatcher struct {
+	watcher    *fsnotify.Watcher
+	configFile string
+	valuesFile string
+	callback   func(*Config, string)
+}
+
+// NewFileWatcher creates a Watcher for local config and values files.
+func NewFileWatcher(configFile, valuesFile string, callback func(*Config, string)) (Watcher, error) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	// watch the parent directory of the target files so we can catch
+	// symlink updates of k8s ConfigMaps volumes.
+	watchDir, _ := filepath.Split(configFile)
+	if err := watcher.Watch(watchDir); err != nil {
+		return nil, fmt.Errorf("could not watch %v: %v", watchDir, err)
+	}
+	return &fileWatcher{
+		watcher:    watcher,
+		configFile: configFile,
+		valuesFile: valuesFile,
+		callback:   callback,
+	}, nil
+}
+
+func (w *fileWatcher) Run(stop <-chan struct{}) {
+	defer w.watcher.Close()
+	var timerC <-chan time.Time
+	for {
+		select {
+		case <-timerC:
+			timerC = nil
+			sidecarConfig, valuesConfig, err := loadConfig(w.configFile, w.valuesFile)
+			if err != nil {
+				log.Errorf("update error: %v", err)
+				break
+			}
+			w.callback(sidecarConfig, valuesConfig)
+		case event := <-w.watcher.Event:
+			log.Debugf("Injector watch update: %+v", event)
+			// use a timer to debounce configuration updates
+			if (event.IsModify() || event.IsCreate()) && timerC == nil {
+				timerC = time.After(watchDebounceDelay)
+			}
+		case err := <-w.watcher.Error:
+			log.Errorf("Watcher error: %v", err)
+		case <-stop:
+			return
+		}
+	}
+}

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -78,9 +78,6 @@ type Webhook struct {
 	healthCheckInterval time.Duration
 	healthCheckFile     string
 
-	configFile string
-	valuesFile string
-
 	watcher Watcher
 
 	mon      *monitor

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -29,7 +28,6 @@ import (
 	"time"
 
 	"github.com/ghodss/yaml"
-	"github.com/howeyc/fsnotify"
 	kubeApiAdmissionv1 "k8s.io/api/admission/v1"
 	kubeApiAdmissionv1beta1 "k8s.io/api/admission/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -83,7 +81,7 @@ type Webhook struct {
 	configFile string
 	valuesFile string
 
-	watcher *fsnotify.Watcher
+	watcher Watcher
 
 	mon      *monitor
 	env      *model.Environment
@@ -159,32 +157,24 @@ func NewWebhook(p WebhookParameters) (*Webhook, error) {
 	if err != nil {
 		return nil, err
 	}
-	watcher, err := fsnotify.NewWatcher()
-	if err != nil {
-		return nil, err
-	}
-	// watch the parent directory of the target files so we can catch
-	// symlink updates of k8s ConfigMaps volumes.
-	for _, file := range []string{p.ConfigFile} {
-		watchDir, _ := filepath.Split(file)
-		if err := watcher.Watch(watchDir); err != nil {
-			return nil, fmt.Errorf("could not watch %v: %v", file, err)
-		}
-	}
 
 	wh := &Webhook{
 		Config:                 sidecarConfig,
 		sidecarTemplateVersion: sidecarTemplateVersionHash(sidecarConfig.Template),
 		meshConfig:             p.Env.Mesh(),
-		configFile:             p.ConfigFile,
-		valuesFile:             p.ValuesFile,
 		valuesConfig:           valuesConfig,
-		watcher:                watcher,
 		healthCheckInterval:    p.HealthCheckInterval,
 		healthCheckFile:        p.HealthCheckFile,
 		env:                    p.Env,
 		revision:               p.Revision,
 	}
+
+	watcher, err := NewFileWatcher(p.ConfigFile, p.ValuesFile, wh.updateConfig)
+	if err != nil {
+		return nil, err
+	}
+	wh.watcher = watcher
+
 	p.Mux.HandleFunc("/inject", wh.serveInject)
 	p.Mux.HandleFunc("/inject/", wh.serveInject)
 
@@ -207,7 +197,7 @@ func NewWebhook(p WebhookParameters) (*Webhook, error) {
 
 // Run implements the webhook server
 func (wh *Webhook) Run(stop <-chan struct{}) {
-	defer wh.watcher.Close()
+	go wh.watcher.Run(stop)
 
 	if wh.mon != nil {
 		defer wh.mon.monitoringServer.Close()
@@ -219,36 +209,9 @@ func (wh *Webhook) Run(stop <-chan struct{}) {
 		healthC = t.C
 		defer t.Stop()
 	}
-	var timerC <-chan time.Time
 
 	for {
 		select {
-		case <-timerC:
-			timerC = nil
-			sidecarConfig, valuesConfig, err := loadConfig(wh.configFile, wh.valuesFile)
-			if err != nil {
-				log.Errorf("update error: %v", err)
-				break
-			}
-
-			version := sidecarTemplateVersionHash(sidecarConfig.Template)
-			if err != nil {
-				log.Errorf("reload cert error: %v", err)
-				break
-			}
-			wh.mu.Lock()
-			wh.Config = sidecarConfig
-			wh.valuesConfig = valuesConfig
-			wh.sidecarTemplateVersion = version
-			wh.mu.Unlock()
-		case event := <-wh.watcher.Event:
-			log.Debugf("Injector watch update: %+v", event)
-			// use a timer to debounce configuration updates
-			if (event.IsModify() || event.IsCreate()) && timerC == nil {
-				timerC = time.After(watchDebounceDelay)
-			}
-		case err := <-wh.watcher.Error:
-			log.Errorf("Watcher error: %v", err)
 		case <-healthC:
 			content := []byte(`ok`)
 			if err := ioutil.WriteFile(wh.healthCheckFile, content, 0644); err != nil {
@@ -258,6 +221,15 @@ func (wh *Webhook) Run(stop <-chan struct{}) {
 			return
 		}
 	}
+}
+
+func (wh *Webhook) updateConfig(sidecarConfig *Config, valuesConfig string) {
+	version := sidecarTemplateVersionHash(sidecarConfig.Template)
+	wh.mu.Lock()
+	wh.Config = sidecarConfig
+	wh.valuesConfig = valuesConfig
+	wh.sidecarTemplateVersion = version
+	wh.mu.Unlock()
 }
 
 // It would be great to use https://github.com/mattbaird/jsonpatch to


### PR DESCRIPTION
Work towards being able to use a ConfigMap watcher instead for #27707

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

Pull Request Attributes

[X] Does not have any changes that may affect Istio users.