### PR TITLE
xds proxy: recreate closed chan after goto

### DIFF
--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -135,7 +135,6 @@ func (p *XdsProxy) StreamAggregatedResources(downstream discovery.AggregatedDisc
 	upstreamError := make(chan error)
 	downstreamError := make(chan error)
 	requestsChan := make(chan *discovery.DiscoveryRequest, 10)
-	responsesChan := make(chan *discovery.DiscoveryResponse, 10)
 	healthEventsChan := make(chan *health.ProbeEvent, 5)
 	// A separate channel for nds requests to not contend with the ones from envoys
 	ndsRequestChan := make(chan *discovery.DiscoveryRequest, 5)
@@ -187,6 +186,7 @@ func (p *XdsProxy) StreamAggregatedResources(downstream discovery.AggregatedDisc
 	}
 
 RecreateUpstream:
+	responsesChan := make(chan *discovery.DiscoveryResponse, 10)
 	upstream, err := xds.StreamAggregatedResources(ctx,
 		grpc.MaxCallRecvMsgSize(defaultClientMaxReceiveMessageSize))
 	if err != nil {


### PR DESCRIPTION
Seeing errors like

```
2020-10-13T23:46:06.216668Z	warn	xdsproxy	upstream terminated with unexpected error <nil>
```

because this channel is closed when we read from it. There is no code path that sends `nil` on this channel. 