### PR TITLE
istioctl proxy-config log: add label selector to filter logs

### DIFF
--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -831,8 +831,8 @@ func getPodName(podflag string) (string, string, error) {
 
 func getPodNameBySelector(labelSelector string) ([]string, string, error) {
 	var (
-		podName []string
-		ns      string
+		podNames []string
+		ns       string
 	)
 	client, err := kubeClient(kubeconfig, configContext)
 	if err != nil {
@@ -845,12 +845,9 @@ func getPodNameBySelector(labelSelector string) ([]string, string, error) {
 	if len(pl.Items) < 1 {
 		return nil, "", errors.New("no pods found")
 	}
-	if len(pl.Items) > 1 {
-		log.Warnf("more than 1 pods fits selector: %s; will use pod: %s", labelSelector, pl.Items[0].Name)
-	}
 	for _, pod := range pl.Items {
-		podName = append(podName, pod.Name)
+		podNames = append(podNames, pod.Name)
 	}
 	ns = pl.Items[0].Namespace
-	return podName, ns, nil
+	return podNames, ns, nil
 }

--- a/istioctl/cmd/proxyconfig_test.go
+++ b/istioctl/cmd/proxyconfig_test.go
@@ -61,6 +61,11 @@ func TestProxyConfig(t *testing.T) {
 			expectedString: "unable to retrieve Pod: pods \"invalid\" not found",
 			wantException:  true, // "istioctl proxy-config listeners invalid" should fail
 		},
+		{ // logging empty
+			args:           strings.Split("proxy-config log", " "),
+			expectedString: "Error: log requires pod name or --selector",
+			wantException:  true, // "istioctl proxy-config logging empty" should fail
+		},
 		{ // logging invalid
 			args:           strings.Split("proxy-config log invalid", " "),
 			expectedString: "unable to retrieve Pod: pods \"invalid\" not found",

--- a/releasenotes/notes/27490.yaml
+++ b/releasenotes/notes/27490.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue:
+  - 27490
+
+releaseNotes:
+- |
+  **Added** `istioctl proxy-config log` now accept label selectors to filter logs based on label.

--- a/releasenotes/notes/27490.yaml
+++ b/releasenotes/notes/27490.yaml
@@ -6,4 +6,4 @@ issue:
 
 releaseNotes:
 - |
-  **Added** `istioctl proxy-config log` now accept label selectors to filter logs based on label.
+  **Updated** `istioctl proxy-config log` to allow filtering logs based on label.


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/27490

Based on @esnible  https://github.com/istio/istio/issues/27490#issuecomment-698413935

> istioctl does accept a --selector <selector> for some commands, e.g. istioctl dashboard envoy. There is no reason not to make some/all of the istioctl proxy-config commands take the same --selector argument if it will help.

Logs by directly passing pods name.
```
$ istioctl pc log istiod-5d884bcc7-mpbpt -n istio-system
2020-10-14T08:45:00.146435Z     error   klog    an error occurred forwarding 41023 -> 15000: error forwarding port 15000 to pod 8becc3bca0ef848c919139d7ecba423647ed738989d12abb5c17425ccd4a4948, uid : failed to execute portforward in network namespace "/var/run/netns/cni-f636d912-b685-538b-d549-29e6d71feb3d": failed to dial 15000: dial tcp4 127.0.0.1:15000: connect: connection refused
Error: failed to execute command on Envoy: failure running port forward process: Post "http://localhost:41023/logging": EOF
```

The same can be achieved by using `log -l app=istiod `.

```
$ istioctl pc log -l app=istiod -n istio-system
2020-10-14T08:45:04.621479Z     error   klog    an error occurred forwarding 33105 -> 15000: error forwarding port 15000 to pod 8becc3bca0ef848c919139d7ecba423647ed738989d12abb5c17425ccd4a4948, uid : failed to execute portforward in network namespace "/var/run/netns/cni-f636d912-b685-538b-d549-29e6d71feb3d": failed to dial 15000: dial tcp4 127.0.0.1:15000: connect: connection refused
Error: failed to execute command on Envoy: failure running port forward process: Post "http://localhost:33105/logging": EOF
```