### PR TITLE
Add-image-pull-secrets

### DIFF
--- a/manifests/charts/istio-operator/Chart.yaml
+++ b/manifests/charts/istio-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: istio-operator
-version: 1.7.0
+version: 1.7.1
 tillerVersion: ">=2.7.2"
 description: Helm chart for deploying Istio operator
 keywords:

--- a/manifests/charts/istio-operator/templates/deployment.yaml
+++ b/manifests/charts/istio-operator/templates/deployment.yaml
@@ -13,6 +13,12 @@ spec:
       labels:
         name: istio-operator
     spec:
+    {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+    {{- end }}
       serviceAccountName: istio-operator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
       containers:
         - name: istio-operator


### PR DESCRIPTION

The helm chart manifest for the istio operator doesn't have the imagePullSecrets, so it is not possible to use a private registry like nexus to host the istio operator images.

I added the possibility to use imagePullSecrets


[ ] Configuration Infrastructure
[ ] Docs
[ X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.