### PR TITLE
Support the docker build on s390x

### DIFF
--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -23,10 +23,12 @@ docker: docker.all
 
 # Add new docker targets to the end of the DOCKER_TARGETS list.
 
-DOCKER_TARGETS ?= docker.pilot docker.proxyv2 docker.app docker.app_sidecar_ubuntu_xenial \
+DOCKER_TARGETS ?= docker.pilot docker.proxyv2 docker.app docker.istioctl docker.operator docker.install-cni \
+$(if $(findstring s390x, $(TARGET_ARCH)),, \
 docker.app_sidecar_ubuntu_bionic docker.app_sidecar_ubuntu_focal docker.app_sidecar_debian_9 \
 docker.app_sidecar_debian_10 docker.app_sidecar_centos_8 docker.app_sidecar_centos_7 \
-docker.istioctl docker.operator docker.install-cni
+docker.app_sidecar_ubuntu_xenial \
+)
 
 # Echo docker directory and the template to pass image name and version to for VM testing
 ECHO_DOCKER ?= pkg/test/echo/docker


### PR DESCRIPTION
To enable to build the docker image for `s390x` with:

* <del> To update the hash for the `distroless/static-debian10` docker image</del> (not necessary thanks to https://github.com/istio/istio/pull/28686)

* To rule out the distro dependent targets from `DOCKER_TARGETS` for s390x
 
* <del> To configure the intermediate `distroless-s390x` image and use it again for `distroless` in `Dockerfile.proxyv2`</del> (not necessary thanks to https://github.com/istio/istio/pull/28940)
* <del> To update the `distroless` image from `cc` to `cc-debian10`. (the multi-arch images are available thanks to https://github.com/GoogleContainerTools/distroless/pull/632)</del> (not necessary thanks to https://github.com/istio/istio/pull/28940)

This is the follow-up PR after #27319 and the [PR](https://github.com/istio/common-files/pull/326) in the `istio/common-files`. But this can be independently merged (no impacts on `x86_64`). This is also extended work for s390x from https://github.com/istio/istio/pull/28686.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[x] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.