### PR TITLE
Remove unused/wrong expiry on token

### DIFF
--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -347,8 +347,7 @@ func isExpectedGRPCError(err error) bool {
 }
 
 type fileTokenSource struct {
-	path   string
-	period time.Duration
+	path string
 }
 
 var _ = oauth2.TokenSource(&fileTokenSource{})
@@ -367,7 +366,6 @@ func (ts *fileTokenSource) Token() (*oauth2.Token, error) {
 
 	return &oauth2.Token{
 		AccessToken: tok,
-		Expiry:      time.Now().Add(ts.period),
 	}, nil
 }
 
@@ -430,10 +428,7 @@ func (p *XdsProxy) buildUpstreamClientDialOpts(sa *Agent) ([]grpc.DialOption, er
 	// as the intention behind provisioned certs on k8s pods is only for data plane comm.
 	if sa.proxyConfig.ControlPlaneAuthPolicy != meshconfig.AuthenticationPolicy_NONE {
 		if sa.secOpts.ProvCert == "" || !sa.secOpts.FileMountedCerts {
-			dialOptions = append(dialOptions, grpc.WithPerRPCCredentials(oauth.TokenSource{TokenSource: &fileTokenSource{
-				sa.secOpts.JWTPath,
-				time.Second * 300,
-			}}))
+			dialOptions = append(dialOptions, grpc.WithPerRPCCredentials(oauth.TokenSource{TokenSource: &fileTokenSource{sa.secOpts.JWTPath}}))
 		}
 	}
 	return dialOptions, nil


### PR DESCRIPTION
This is refreshed on every call regardless of the expiry, remove to
avoid confusion.

(cherry picked from commit 47c202d5c029d69f0c66baf8de4148a8b77a4d92)



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.