### PR TITLE
align mutatingwebhook.yaml in istiod-remote with istiod-discovery

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -352,6 +352,7 @@ sync-configs-from-istiod:
 	cp manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.7.yaml manifests/charts/istiod-remote/templates/
 	cp manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.8.yaml manifests/charts/istiod-remote/templates/
 	cp manifests/charts/istio-control/istio-discovery/templates/configmap.yaml manifests/charts/istiod-remote/templates
+	cp manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml manifests/charts/istiod-remote/templates
 
 # Generate kustomize templates.
 gen-kustomize:

--- a/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -15,10 +15,14 @@ metadata:
 webhooks:
   - name: sidecar-injector.istio.io
     clientConfig:
+      {{- if .Values.istiodRemote.injectionURL }}
+      url: {{ .Values.istiodRemote.injectionURL }}
+      {{- else }}
       service:
         name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
         namespace: {{ .Release.Namespace }}
         path: "/inject"
+      {{- end }}
       caBundle: ""
     sideEffects: None
     rules:

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -97,7 +97,10 @@ sidecarInjectorWebhook:
     autoInject: true
 
   rewriteAppHTTPProbe: true
-
+istiodRemote:
+  # Sidecar injector mutating webhook configuration url
+  # For example: https://$remotePilotAddress:15017/inject
+  injectionURL: ""
 telemetry:
   enabled: true
   v2:

--- a/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -671,7 +671,8 @@ webhooks:
         name: istiod
         namespace: istio-system
         path: "/inject"
-      caBundle: 
+      caBundle: ""
+    sideEffects: None
     rules:
       - operations: [ "CREATE" ]
         apiGroups: [""]
@@ -679,7 +680,6 @@ webhooks:
         resources: ["pods"]
     failurePolicy: Fail
     admissionReviewVersions: ["v1beta1", "v1"]
-    sideEffects: None
     namespaceSelector:
       matchLabels:
         istio-injection: enabled

--- a/manifests/charts/istiod-remote/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istiod-remote/templates/mutatingwebhook.yaml
@@ -16,15 +16,15 @@ webhooks:
   - name: sidecar-injector.istio.io
     clientConfig:
       {{- if .Values.istiodRemote.injectionURL }}
-      # the url supports to use inject/cluster/x/net/y format
       url: {{ .Values.istiodRemote.injectionURL }}
       {{- else }}
       service:
-        name: istiod
-        namespace: {{ .Values.global.istioNamespace }}
+        name: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+        namespace: {{ .Release.Namespace }}
         path: "/inject"
       {{- end }}
-      caBundle: {{ .Values.sidecarInjectorWebhook.caBundle }}
+      caBundle: ""
+    sideEffects: None
     rules:
       - operations: [ "CREATE" ]
         apiGroups: [""]
@@ -32,7 +32,6 @@ webhooks:
         resources: ["pods"]
     failurePolicy: Fail
     admissionReviewVersions: ["v1beta1", "v1"]
-    sideEffects: None
     namespaceSelector:
 {{- if .Values.sidecarInjectorWebhook.enableNamespacesByDefault }}
       matchExpressions:


### PR DESCRIPTION
instead of keeping a private version of mutatingwebhook.yaml under istiod-remote, we  should use the same version from istio-discovery, This will make future update more smoothly. 