### PR TITLE
Include networkName in remote secret

### DIFF
--- a/istioctl/cmd/add-to-mesh.go
+++ b/istioctl/cmd/add-to-mesh.go
@@ -381,7 +381,7 @@ func findDeploymentsForSvc(client kubernetes.Interface, ns, name string) ([]apps
 }
 
 func createDynamicInterface(kubeconfig string) (dynamic.Interface, error) {
-	restConfig, err := kube.BuildClientConfig(kubeconfig, configContext)
+	restConfig, err := kube.BuildClientConfig(kubeconfig, configContext).ClientConfig()
 
 	if err != nil {
 		return nil, err

--- a/istioctl/cmd/deprecated_cmd.go
+++ b/istioctl/cmd/deprecated_cmd.go
@@ -27,11 +27,8 @@ var (
 )
 
 func newConfigStore() (istioclient.Interface, error) {
-	cfg, err := kubecfg.BuildClientConfig(kubeconfig, configContext)
-	if err != nil {
-		return nil, err
-	}
-	kclient, err := kubecfg.NewClient(kubecfg.NewClientConfigForRestConfig(cfg))
+	cfg := kubecfg.BuildClientConfig(kubeconfig, configContext)
+	kclient, err := kubecfg.NewClient(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/istioctl/cmd/kubeinject.go
+++ b/istioctl/cmd/kubeinject.go
@@ -43,7 +43,7 @@ const (
 )
 
 func createInterface(kubeconfig string) (kubernetes.Interface, error) {
-	restConfig, err := kube.BuildClientConfig(kubeconfig, configContext)
+	restConfig, err := kube.BuildClientConfig(kubeconfig, configContext).ClientConfig()
 
 	if err != nil {
 		return nil, err

--- a/istioctl/cmd/wait.go
+++ b/istioctl/cmd/wait.go
@@ -211,7 +211,7 @@ func poll(acceptedVersions []string, targetResource string, opts clioptions.Cont
 
 func init() {
 	clientGetter = func(kubeconfig, context string) (dynamic.Interface, error) {
-		config, err := kube.DefaultRestConfig(kubeconfig, context)
+		_, config, err := kube.DefaultRestConfig(kubeconfig, context)
 		if err != nil {
 			return nil, err
 		}

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -21,6 +21,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io/ioutil"
+	"k8s.io/client-go/tools/clientcmd"
 	"net"
 	"net/http"
 	"os"
@@ -477,8 +478,9 @@ func (s *Server) initKubeClient(args *PilotArgs) error {
 
 	if hasK8SConfigStore || hasKubeRegistry(args.RegistryOptions.Registries) {
 		var err error
+		var clientCfg clientcmd.ClientConfig
 		// Used by validation
-		s.kubeRestConfig, err = kubelib.DefaultRestConfig(args.RegistryOptions.KubeConfig, "", func(config *rest.Config) {
+		clientCfg, s.kubeRestConfig, err = kubelib.DefaultRestConfig(args.RegistryOptions.KubeConfig, "", func(config *rest.Config) {
 			config.QPS = args.RegistryOptions.KubeOptions.KubernetesAPIQPS
 			config.Burst = args.RegistryOptions.KubeOptions.KubernetesAPIBurst
 		})
@@ -486,7 +488,7 @@ func (s *Server) initKubeClient(args *PilotArgs) error {
 			return fmt.Errorf("failed creating kube config: %v", err)
 		}
 
-		s.kubeClient, err = kubelib.NewClient(kubelib.NewClientConfigForRestConfig(s.kubeRestConfig))
+		s.kubeClient, err = kubelib.NewClient(clientCfg)
 		if err != nil {
 			return fmt.Errorf("failed creating kube client: %v", err)
 		}

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -255,6 +255,12 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 		metrics:                     options.Metrics,
 	}
 
+	if ext := kubeClient.ClusterExtension(c.clusterID); ext != nil {
+		if ext.Network != "" {
+			c.networkForRegistry = ext.Network
+		}
+	}
+
 	c.serviceInformer = kubeClient.KubeInformer().Core().V1().Services().Informer()
 	c.serviceLister = kubeClient.KubeInformer().Core().V1().Services().Lister()
 	registerHandlers(c.serviceInformer, c.queue, "Services", c.onServiceEvent, nil)

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -334,7 +334,7 @@ func (c *client) ClusterExtension(clusterName string) *ClusterExtension {
 	if !ok {
 		return nil
 	}
-	extObj, ok := cluster.Extensions["istio"]
+	extObj, ok := cluster.Extensions[ClusterExtensionKey]
 	if !ok {
 		return nil
 	}

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -272,6 +272,13 @@ func newClientInternal(clientFactory util.Factory, revision string) (*client, er
 		return nil, err
 	}
 
+	rc, err := json.Marshal(c.rawConfig)
+	if err != nil {
+		return nil, err
+	}
+	log.Infof("raw cfg: %s", string(rc))
+
+
 	c.Interface, err = kubernetes.NewForConfig(c.config)
 	c.kube = c.Interface
 	if err != nil {

--- a/pkg/kube/extension.go
+++ b/pkg/kube/extension.go
@@ -1,5 +1,22 @@
 package kube
 
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const ClusterExtensionKey = "istio"
+
+var _ runtime.Object = ClusterExtension{}
+
 type ClusterExtension struct {
 	Network string `json:"network,omitempty"`
+}
+
+func (c ClusterExtension) GetObjectKind() schema.ObjectKind {
+	return schema.EmptyObjectKind
+}
+
+func (c ClusterExtension) DeepCopyObject() runtime.Object {
+	return c
 }

--- a/pkg/kube/extension.go
+++ b/pkg/kube/extension.go
@@ -1,0 +1,5 @@
+package kube
+
+type ClusterExtension struct {
+	Network string `json:"network,omitempty"`
+}

--- a/pkg/kube/util.go
+++ b/pkg/kube/util.go
@@ -92,6 +92,10 @@ func DefaultRestConfig(kubeconfig, configContext string, fns ...func(*rest.Confi
 	}
 	restCfg = SetRestDefaults(restCfg)
 
+	// TODO somehow apply restCfg fns to any rest config derived from the clientcmd.Client config
+	// TODO could just wrap both in a struct with restCfg override?
+	// TODO we really just need the raw config. maybe return that instead of clientcmd.ClientCOnfig
+	// TODO could also push this down into a NewClient like fn, they're always used together.
 	for _, fn := range fns {
 		fn(restCfg)
 	}

--- a/pkg/kube/util_test.go
+++ b/pkg/kube/util_test.go
@@ -88,7 +88,7 @@ func TestBuildClientConfig(t *testing.T) {
 			}
 			defer os.Setenv("KUBECONFIG", currentEnv)
 
-			resp, err := BuildClientConfig(tt.explicitKubeconfig, tt.context)
+			resp, err := BuildClientConfig(tt.explicitKubeconfig, tt.context).ClientConfig()
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("BuildClientConfig() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/pkg/test/framework/components/environment/kube/settings.go
+++ b/pkg/test/framework/components/environment/kube/settings.go
@@ -122,14 +122,14 @@ func newClients(kubeConfigs []string) ([]istioKube.ExtendedClient, error) {
 	out := make([]istioKube.ExtendedClient, 0, len(kubeConfigs))
 	for _, cfg := range kubeConfigs {
 		if len(cfg) > 0 {
-			rc, err := istioKube.DefaultRestConfig(cfg, "", func(config *rest.Config) {
+			cfg, rc, err := istioKube.DefaultRestConfig(cfg, "", func(config *rest.Config) {
 				config.QPS = 200
 				config.Burst = 400
 			})
 			if err != nil {
 				return nil, err
 			}
-			a, err := istioKube.NewExtendedClient(istioKube.NewClientConfigForRestConfig(rc), "")
+			a, err := istioKube.NewExtendedClient(cfg, "")
 			if err != nil {
 				return nil, fmt.Errorf("client setup: %v", err)
 			}

--- a/pkg/test/framework/components/environment/kube/settings.go
+++ b/pkg/test/framework/components/environment/kube/settings.go
@@ -122,7 +122,7 @@ func newClients(kubeConfigs []string) ([]istioKube.ExtendedClient, error) {
 	out := make([]istioKube.ExtendedClient, 0, len(kubeConfigs))
 	for _, cfg := range kubeConfigs {
 		if len(cfg) > 0 {
-			cfg, rc, err := istioKube.DefaultRestConfig(cfg, "", func(config *rest.Config) {
+			cfg, _, err := istioKube.DefaultRestConfig(cfg, "", func(config *rest.Config) {
 				config.QPS = 200
 				config.Burst = 400
 			})

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -672,6 +672,7 @@ func createRemoteSecret(ctx resource.Context, cluster resource.Cluster, cfg Conf
 	cmd := []string{
 		"x", "create-remote-secret",
 		"--name", cluster.Name(),
+		"--network", cluster.NetworkName(),
 		"--namespace", cfg.SystemNamespace,
 	}
 

--- a/pkg/test/kube/mock_client.go
+++ b/pkg/test/kube/mock_client.go
@@ -140,6 +140,11 @@ func (c MockClient) RESTConfig() *rest.Config {
 	return c.ConfigValue
 }
 
+func (c MockClient) ClusterExtension(clusterName string) *kube.ClusterExtension {
+	// TODO implement if necessary
+	return nil
+}
+
 func (c MockClient) GetIstioVersions(_ context.Context, _ string) (*version.MeshInfo, error) {
 	return c.IstioVersions, nil
 }


### PR DESCRIPTION
Implementation of unapproved [RFC](https://docs.google.com/document/d/19PPGzw04gjk4evQA85oscYbJBOS6G8DMwc2q_UNBsZA/edit#)

TODO: make this work with in-cluster serviceaccount auth. 