### PR TITLE
istioctl bug-report: skip system namespaces to analyze

### DIFF
--- a/tools/bug-report/pkg/bugreport/bugreport.go
+++ b/tools/bug-report/pkg/bugreport/bugreport.go
@@ -32,7 +32,9 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
 
+	analyzer_util "istio.io/istio/galley/pkg/config/analysis/analyzers/util"
 	"istio.io/istio/operator/pkg/util"
+	"istio.io/istio/pkg/config/resource"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/proxy"
 	"istio.io/istio/tools/bug-report/pkg/archive"
@@ -97,11 +99,6 @@ var (
 	// Aggregated errors for all fetch operations.
 	gErrors util.Errors
 	lock    = sync.RWMutex{}
-
-	isSystemNamespace = map[string]bool{
-		"kube-system": true,
-		"kube-public": true,
-	}
 )
 
 func runBugReportCommand(_ *cobra.Command, logOpts *log.Options) error {
@@ -390,7 +387,7 @@ func getLog(client kube.ExtendedClient, resources *cluster2.Resources, config *c
 
 func runAnalyze(config *config.BugReportConfig, resources *cluster2.Resources, params *content.Params) {
 	for ns := range resources.Root {
-		if isSystemNamespace[ns] {
+		if analyzer_util.IsSystemNamespace(resource.Namespace(ns)) {
 			continue
 		}
 		common.LogAndPrintf("Running istio analyze on namespace %s.\n", ns)

--- a/tools/bug-report/pkg/cluster/cluster.go
+++ b/tools/bug-report/pkg/cluster/cluster.go
@@ -20,6 +20,8 @@ import (
 	"regexp"
 	"strings"
 
+	analyzer_util "istio.io/istio/galley/pkg/config/analysis/analyzers/util"
+	"istio.io/istio/pkg/config/resource"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -67,6 +69,10 @@ func GetClusterResources(ctx context.Context, clientset *kubernetes.Clientset) (
 		return nil, err
 	}
 	for _, ns := range namespaces.Items {
+		// skip system namesapces
+		if analyzer_util.IsSystemNamespace(resource.Namespace(ns.Name)) {
+			continue
+		}
 		pods, err := clientset.CoreV1().Pods(ns.Name).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return nil, err

--- a/tools/bug-report/pkg/cluster/cluster.go
+++ b/tools/bug-report/pkg/cluster/cluster.go
@@ -20,13 +20,13 @@ import (
 	"regexp"
 	"strings"
 
-	analyzer_util "istio.io/istio/galley/pkg/config/analysis/analyzers/util"
-	"istio.io/istio/pkg/config/resource"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	analyzer_util "istio.io/istio/galley/pkg/config/analysis/analyzers/util"
+	"istio.io/istio/pkg/config/resource"
 	"istio.io/istio/tools/bug-report/pkg/common"
 	"istio.io/istio/tools/bug-report/pkg/util/path"
 	"istio.io/pkg/log"


### PR DESCRIPTION
Found during debugging of https://github.com/istio/istio/issues/27177

More Info: https://github.com/istio/istio/pull/27794

Before:
```
$ istioctl bug-report
...

Fetching proxy logs for the following containers:

istio-system/istio-ingressgateway/istio-ingressgateway-5cf694469b-2677k/istio-proxy
istio-system/istiod/istiod-7c65b8f5cf-rssbd/discovery
local-path-storage/local-path-provisioner/local-path-provisioner-78776bfc44-pf6bv/local-path-provisioner

Fetching Istio control plane information from cluster.

Running istio analyze on namespace istio-system.
Running istio analyze on namespace local-path-storage.

Creating archive at /home/shaansar/Projects/src/istio.io/istio/bug-report.tgz.
Cleaning up temporary files in /tmp/bug-report.
Done.
```

After:
```
$ istioctl bug-report
...

Fetching proxy logs for the following containers:

istio-system/istio-ingressgateway/istio-ingressgateway-5cf694469b-2677k/istio-proxy
istio-system/istiod/istiod-7c65b8f5cf-rssbd/discovery

Fetching Istio control plane information from cluster.

Running istio analyze on namespace istio-system.

Creating archive at /home/shaansar/Projects/src/istio.io/istio/bug-report.tgz.
Cleaning up temporary files in /tmp/bug-report.
Done.
```