### PR TITLE
respect env def for Values.pilot.env.INJECTION_WEBHOOK_CONFIG_NAME

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -138,12 +138,14 @@ spec:
             value: "{{ .Values.pilot.enableProtocolSniffingForOutbound }}"
           - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND
             value: "{{ .Values.pilot.enableProtocolSniffingForInbound }}"
+{{- if not .Values.pilot.env.INJECTION_WEBHOOK_CONFIG_NAME }}
           - name: INJECTION_WEBHOOK_CONFIG_NAME
           {{- if eq .Release.Namespace "istio-system" }}
             value: istio-sidecar-injector{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
           {{- else }}
             value: istio-sidecar-injector{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}-{{ .Release.Namespace }}
           {{- end }}
+{{- end }}
           - name: ISTIOD_ADDR
             value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Release.Namespace }}.svc:15012
           - name: PILOT_ENABLE_ANALYSIS

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -138,7 +138,7 @@ spec:
             value: "{{ .Values.pilot.enableProtocolSniffingForOutbound }}"
           - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND
             value: "{{ .Values.pilot.enableProtocolSniffingForInbound }}"
-{{- if not .Values.pilot.env.INJECTION_WEBHOOK_CONFIG_NAME }}
+{{- if not (hasKey .Values.pilot.env "INJECTION_WEBHOOK_CONFIG_NAME") }}
           - name: INJECTION_WEBHOOK_CONFIG_NAME
           {{- if eq .Release.Namespace "istio-system" }}
             value: istio-sidecar-injector{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}


### PR DESCRIPTION
A possible fix for https://github.com/istio/istio/issues/27986

with this fix, one thing is you need to make sure you are using
```
    pilot:
      env:
        INJECTION_WEBHOOK_CONFIG_NAME: " "
```
instead of
```
    pilot:
      env:
        INJECTION_WEBHOOK_CONFIG_NAME: ""
```