### PR TITLE
istioctl bug-report: do not override system namespaces if --exclude flag is provided

### DIFF
--- a/galley/pkg/config/analysis/analyzers/util/config.go
+++ b/galley/pkg/config/analysis/analyzers/util/config.go
@@ -18,7 +18,6 @@ import (
 	"istio.io/istio/pkg/config/resource"
 )
 
-// IsSystemNamespace returns true for system namespaces
 // Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/#viewing-namespaces
 // "kube-system": The namespace for objects created by the Kubernetes system.
 // "kube-public": This namespace is mostly reserved for cluster usage.
@@ -26,8 +25,13 @@ import (
 //    which improves the performance of the node heartbeats as the cluster scales.
 // "local-path-storage": Dynamically provisioning persistent local storage with Kubernetes.
 //    used with Kind cluster: https://github.com/rancher/local-path-provisioner
+var (
+	SystemNamespaces = []string{"kube-system", "kube-public", "kube-node-lease", "local-path-storage"}
+)
+
+// IsSystemNamespace returns true for system namespaces
 func IsSystemNamespace(ns resource.Namespace) bool {
-	return ns == "kube-system" || ns == "kube-public" || ns == "kube-node-lease" || ns == "local-path-storage"
+	return IsIncluded(SystemNamespaces, ns.String())
 }
 
 // IsIstioControlPlane returns true for resources that are part of the Istio control plane
@@ -37,6 +41,16 @@ func IsIstioControlPlane(r *resource.Instance) bool {
 	}
 	if r.Metadata.Labels["release"] == "istio" {
 		return true
+	}
+	return false
+}
+
+// IsIncluded check if the term exists in a slice of string
+func IsIncluded(slice []string, term string) bool {
+	for _, val := range slice {
+		if val == term {
+			return true
+		}
 	}
 	return false
 }

--- a/tools/bug-report/pkg/bugreport/bugreport.go
+++ b/tools/bug-report/pkg/bugreport/bugreport.go
@@ -58,7 +58,7 @@ const (
 var (
 	bugReportDefaultIstioNamespace = "istio-system"
 	bugReportDefaultInclude        = []string{""}
-	bugReportDefaultExclude        = []string{"kube-system,kube-public"}
+	bugReportDefaultExclude        = []string{strings.Join(analyzer_util.SystemNamespaces, ", ")}
 )
 
 // Cmd returns a cobra command for bug-report.
@@ -162,7 +162,7 @@ func runBugReportCommand(_ *cobra.Command, logOpts *log.Options) error {
 		outDir = "."
 	}
 	outPath := filepath.Join(outDir, "bug-report.tgz")
-	common.LogAndPrintf("Creating archive at %s.\n", outPath)
+	common.LogAndPrintf("Creating an archive at %s.\n", outPath)
 
 	archiveDir := archive.DirToArchive(tempDir)
 	if err := archive.Create(archiveDir, outPath); err != nil {

--- a/tools/bug-report/pkg/bugreport/flags.go
+++ b/tools/bug-report/pkg/bugreport/flags.go
@@ -116,14 +116,20 @@ func parseConfig() (*config2.BugReportConfig, error) {
 		}
 		gConfig.Include = append(gConfig.Include, ss)
 	}
+	// Exclude default system namespaces eg: bugReportDefaultExclude
+	dss := &config2.SelectionSpec{}
+	if err := dss.UnmarshalJSON([]byte(bugReportDefaultExclude[0])); err != nil {
+		return nil, err
+	}
+	gConfig.Exclude = append(gConfig.Exclude, dss)
+	// Exclude namespace provided by --exclude flag
 	for _, s := range excluded {
-		ss := &config2.SelectionSpec{}
-		if err := ss.UnmarshalJSON([]byte(s)); err != nil {
+		ess := &config2.SelectionSpec{}
+		if err := ess.UnmarshalJSON([]byte(s)); err != nil {
 			return nil, err
 		}
-		gConfig.Exclude = append(gConfig.Exclude, ss)
+		gConfig.Exclude = append(gConfig.Exclude, ess)
 	}
-
 	return overlayConfig(fileConfig, gConfig)
 }
 

--- a/tools/bug-report/pkg/config/config.go
+++ b/tools/bug-report/pkg/config/config.go
@@ -79,22 +79,22 @@ func (s SelectionSpecs) String() string {
 	for _, ss := range s {
 		st := ""
 		if !defaultListSetting(ss.Namespaces) {
-			st += fmt.Sprintf("Namespaces:%s", strings.Join(ss.Namespaces, ","))
+			st += fmt.Sprintf("Namespaces: %s", strings.Join(ss.Namespaces, ","))
 		}
 		if !defaultListSetting(ss.Deployments) {
-			st += fmt.Sprintf("/Deployments:%s", strings.Join(ss.Deployments, ","))
+			st += fmt.Sprintf("/Deployments: %s", strings.Join(ss.Deployments, ","))
 		}
 		if !defaultListSetting(ss.Pods) {
 			st += fmt.Sprintf("/Pods:%s", strings.Join(ss.Pods, ","))
 		}
 		if !defaultListSetting(ss.Containers) {
-			st += fmt.Sprintf("/Containers:%s", strings.Join(ss.Containers, ","))
+			st += fmt.Sprintf("/Containers: %s", strings.Join(ss.Containers, ","))
 		}
 		if len(ss.Labels) > 0 {
-			st += fmt.Sprintf("/Labels:%v", ss.Labels)
+			st += fmt.Sprintf("/Labels: %v", ss.Labels)
 		}
 		if len(ss.Annotations) > 0 {
-			st += fmt.Sprintf("/Annotations:%v", ss.Annotations)
+			st += fmt.Sprintf("/Annotations: %v", ss.Annotations)
 		}
 		out = append(out, "{ "+st+" }")
 	}


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/27988

Good to merge after https://github.com/istio/istio/pull/27980

Before:
```
$ istioctl bug-report --exclude=ns1,ns2

Running with the following config: 

istio-namespace: istio-system
...
exclude:  { Namespaces: ns1 } AND { Namespaces: ns2 }
...

Fetching proxy logs for the following containers:

istio-system/istio-ingressgateway/istio-ingressgateway-5cf694469b-2677k/istio-proxy
istio-system/istiod/istiod-7c65b8f5cf-rssbd/discovery
kube-system//etcd-istio-testing-control-plane/etcd
kube-system//kindnet-8c86m/kindnet-cni
kube-system//kube-apiserver-istio-testing-control-plane/kube-apiserver
kube-system//kube-controller-manager-istio-testing-control-plane/kube-controller-manager
kube-system//kube-proxy-rn9g6/kube-proxy
kube-system//kube-scheduler-istio-testing-control-plane/kube-scheduler
kube-system/coredns/coredns-f9fd979d6-kvdz5/coredns
kube-system/coredns/coredns-f9fd979d6-pk848/coredns
local-path-storage/local-path-provisioner/local-path-provisioner-78776bfc44-pf6bv/local-path-provisioner
...

Creating an archive at /home/shaansar/Projects/src/istio.io/istio/bug-report.tgz.
Cleaning up temporary files in /tmp/bug-report.
Done.
```

After:
```
$ ./out/linux_amd64/istioctl bug-report --exclude=ns1,ns2

Running with the following config: 

istio-namespace: istio-system
...
exclude: { Namespaces: kube-system, kube-public, kube-node-lease, local-path-storage } AND { Namespaces: ns1 } AND { Namespaces: ns2 }
...

Fetching proxy logs for the following containers:

istio-system/istio-ingressgateway/istio-ingressgateway-5cf694469b-2677k/istio-proxy
istio-system/istiod/istiod-7c65b8f5cf-rssbd/discovery
local-path-storage/local-path-provisioner/local-path-provisioner-78776bfc44-pf6bv/local-path-provisioner
...

Creating an archive at /home/shaansar/Projects/src/istio.io/istio/bug-report.tgz.
Cleaning up temporary files in /tmp/bug-report.
Done.
```