### PR TITLE
Handle ads conflict

### DIFF
--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -600,7 +600,12 @@ func (s *DiscoveryServer) pushConnection(con *Connection, pushEv *Event) error {
 			return err
 		}
 		if w.TypeUrl == v3.RouteType {
-			close(con.initDone)
+			select {
+			case <-con.initDone:
+			default:
+				// notify initial xds config has been pushed
+				close(con.initDone)
+			}
 		}
 	}
 	if pushRequest.Full {

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -248,8 +248,7 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream discovery.AggregatedD
 		case pushEv := <-con.pushChannel:
 			// Note this is to handle possible race condition: if a config change happens while the envoy
 			// was getting the initial config, between LDS and RDS, the push will miss the
-			// monitored 'routes'. Same for CDS/EDS interval. It is very tricky to handle
-			// due to the protocol - but the periodic push recovers from it.
+			// monitored 'routes'. Same for CDS/EDS interval.
 			// Wait for proxy initialization
 			<-con.initDone
 			err := s.pushConnection(con, pushEv)

--- a/pilot/pkg/xds/gen.go
+++ b/pilot/pkg/xds/gen.go
@@ -100,8 +100,8 @@ func (s *DiscoveryServer) pushXds(con *Connection, push *model.PushContext,
 
 	t0 := time.Now()
 
-	cl := gen.Generate(con.proxy, push, w, req)
-	if cl == nil {
+	resources := gen.Generate(con.proxy, push, w, req)
+	if resources == nil {
 		// If we have nothing to send, report that we got an ACK for this version.
 		if s.StatusReporter != nil {
 			s.StatusReporter.RegisterEvent(con.ConID, w.TypeUrl, push.Version)
@@ -114,7 +114,7 @@ func (s *DiscoveryServer) pushXds(con *Connection, push *model.PushContext,
 		TypeUrl:     w.TypeUrl,
 		VersionInfo: currentVersion,
 		Nonce:       nonce(push.Version),
-		Resources:   cl,
+		Resources:   resources,
 	}
 
 	err := con.send(resp)
@@ -125,7 +125,7 @@ func (s *DiscoveryServer) pushXds(con *Connection, push *model.PushContext,
 
 	// Some types handle logs inside Generate, skip them here
 	if _, f := SkipLogTypes[w.TypeUrl]; !f {
-		adsLog.Infof("%s: PUSH for node:%s resources:%d", v3.GetShortType(w.TypeUrl), con.proxy.ID, len(cl))
+		adsLog.Infof("%s: PUSH for node:%s resources:%d", v3.GetShortType(w.TypeUrl), con.proxy.ID, len(resources))
 	}
 	return nil
 }


### PR DESCRIPTION
			// handle possible race condition: if a config change happens while the envoy
			// was getting the initial config, between LDS and RDS, the push will miss the
			// monitored 'routes'. Same for CDS/EDS interval.
			// Wait for proxy initialization