### PR TITLE
Watch injector ConfigMap when local config is absent

### DIFF
--- a/pilot/pkg/bootstrap/mesh.go
+++ b/pilot/pkg/bootstrap/mesh.go
@@ -26,9 +26,9 @@ import (
 )
 
 const (
-	// defaultConfigMapName is the default name of the ConfigMap with the mesh config
-	// The actual name can be different - use getConfigMapName
-	defaultConfigMapName = "istio"
+	// defaultMeshConfigMapName is the default name of the ConfigMap with the mesh config
+	// The actual name can be different - use getMeshConfigMapName
+	defaultMeshConfigMapName = "istio"
 	// configMapKey should match the expected MeshConfig file name
 	configMapKey = "mesh"
 )
@@ -65,7 +65,7 @@ func (s *Server) initMeshConfiguration(args *PilotArgs, fileWatcher filewatcher.
 
 	// Watch the istio ConfigMap for mesh config changes.
 	// This may be necessary for external Istiod.
-	configMapName := getConfigMapName(args.Revision)
+	configMapName := getMeshConfigMapName(args.Revision)
 	s.environment.Watcher = mesh.NewConfigMapWatcher(
 		s.kubeClient, args.Namespace, configMapName, configMapKey)
 }
@@ -88,8 +88,8 @@ func (s *Server) initMeshNetworks(args *PilotArgs, fileWatcher filewatcher.FileW
 	}
 }
 
-func getConfigMapName(revision string) string {
-	name := defaultConfigMapName
+func getMeshConfigMapName(revision string) string {
+	name := defaultMeshConfigMapName
 	if revision == "" || revision == "default" {
 		return name
 	}

--- a/pkg/kube/inject/watcher.go
+++ b/pkg/kube/inject/watcher.go
@@ -31,14 +31,15 @@ import (
 
 // Watcher watches for and reacts to injection config updates.
 type Watcher interface {
-	// Run starts the Watcher.
+	// SetHandler sets the handler that is run when the config changes.
+	// Must call this before Run.
+	SetHandler(func(*Config, string))
+
+	// Run starts the Watcher. Must call this after SetHandler.
 	Run(<-chan struct{})
 
 	// Get returns the sidecar and values configuration.
 	Get() (*Config, string, error)
-
-	// SetHandler sets the handler that is run when the config changes.
-	SetHandler(func(*Config, string))
 }
 
 var _ Watcher = &fileWatcher{}

--- a/pkg/kube/inject/watcher.go
+++ b/pkg/kube/inject/watcher.go
@@ -15,12 +15,14 @@
 package inject
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"time"
 
 	"github.com/howeyc/fsnotify"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/configmapwatcher"
@@ -31,6 +33,12 @@ import (
 type Watcher interface {
 	// Run starts the Watcher.
 	Run(<-chan struct{})
+
+	// Get returns the sidecar and values configuration.
+	Get() (*Config, string, error)
+
+	// SetHandler sets the handler that is run when the config changes.
+	SetHandler(func(*Config, string))
 }
 
 var _ Watcher = &fileWatcher{}
@@ -41,15 +49,21 @@ type fileWatcher struct {
 	watcher    *fsnotify.Watcher
 	configFile string
 	valuesFile string
-	callback   func(*Config, string)
+	handler    func(*Config, string)
 }
 
 type configMapWatcher struct {
-	c *configmapwatcher.Controller
+	c         *configmapwatcher.Controller
+	client    kube.Client
+	namespace string
+	name      string
+	configKey string
+	valuesKey string
+	handler   func(*Config, string)
 }
 
 // NewFileWatcher creates a Watcher for local config and values files.
-func NewFileWatcher(configFile, valuesFile string, callback func(*Config, string)) (Watcher, error) {
+func NewFileWatcher(configFile, valuesFile string) (Watcher, error) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		return nil, err
@@ -64,7 +78,6 @@ func NewFileWatcher(configFile, valuesFile string, callback func(*Config, string
 		watcher:    watcher,
 		configFile: configFile,
 		valuesFile: valuesFile,
-		callback:   callback,
 	}, nil
 }
 
@@ -75,12 +88,14 @@ func (w *fileWatcher) Run(stop <-chan struct{}) {
 		select {
 		case <-timerC:
 			timerC = nil
-			sidecarConfig, valuesConfig, err := loadConfig(w.configFile, w.valuesFile)
+			sidecarConfig, valuesConfig, err := w.Get()
 			if err != nil {
 				log.Errorf("update error: %v", err)
 				break
 			}
-			w.callback(sidecarConfig, valuesConfig)
+			if w.handler != nil {
+				w.handler(sidecarConfig, valuesConfig)
+			}
 		case event := <-w.watcher.Event:
 			log.Debugf("Injector watch update: %+v", event)
 			// use a timer to debounce configuration updates
@@ -95,21 +110,51 @@ func (w *fileWatcher) Run(stop <-chan struct{}) {
 	}
 }
 
+func (w *fileWatcher) Get() (*Config, string, error) {
+	return loadConfig(w.configFile, w.valuesFile)
+}
+
+func (w *fileWatcher) SetHandler(handler func(*Config, string)) {
+	w.handler = handler
+}
+
 // NewConfigMapWatcher creates a new Watcher for changes to the given ConfigMap.
-func NewConfigMapWatcher(client kube.Client, namespace, name, configKey, valuesKey string, callback func(*Config, string)) Watcher {
-	c := configmapwatcher.NewController(client, namespace, name, func(cm *v1.ConfigMap) {
+func NewConfigMapWatcher(client kube.Client, namespace, name, configKey, valuesKey string) Watcher {
+	w := &configMapWatcher{
+		client:    client,
+		namespace: namespace,
+		name:      name,
+		configKey: configKey,
+		valuesKey: valuesKey,
+	}
+	w.c = configmapwatcher.NewController(client, namespace, name, func(cm *v1.ConfigMap) {
 		sidecarConfig, valuesConfig, err := readConfigMap(cm, configKey, valuesKey)
 		if err != nil {
 			log.Warnf("failed to read injection config from ConfigMap: %v", err)
 			return
 		}
-		callback(sidecarConfig, valuesConfig)
+		if w.handler != nil {
+			w.handler(sidecarConfig, valuesConfig)
+		}
 	})
-	return &configMapWatcher{c: c}
+	return w
 }
 
 func (w *configMapWatcher) Run(stop <-chan struct{}) {
 	w.c.Run(stop)
+}
+
+func (w *configMapWatcher) Get() (*Config, string, error) {
+	cms := w.client.CoreV1().ConfigMaps(w.namespace)
+	cm, err := cms.Get(context.TODO(), w.name, metav1.GetOptions{})
+	if err != nil {
+		return nil, "", err
+	}
+	return readConfigMap(cm, w.configKey, w.valuesKey)
+}
+
+func (w *configMapWatcher) SetHandler(handler func(*Config, string)) {
+	w.handler = handler
 }
 
 func readConfigMap(cm *v1.ConfigMap, configKey, valuesKey string) (*Config, string, error) {

--- a/pkg/kube/inject/watcher_test.go
+++ b/pkg/kube/inject/watcher_test.go
@@ -75,7 +75,8 @@ func TestNewConfigMapWatcher(t *testing.T) {
 	var newValues string
 
 	client := kube.NewFakeClient()
-	w := NewConfigMapWatcher(client, namespace, cmName, configKey, valuesKey, func(config *Config, values string) {
+	w := NewConfigMapWatcher(client, namespace, cmName, configKey, valuesKey)
+	w.SetHandler(func(config *Config, values string) {
 		mu.Lock()
 		defer mu.Unlock()
 		newConfig = config

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -993,6 +993,10 @@ func createWebhook(t testing.TB, cfg *Config) (*Webhook, func()) {
 		Watcher: mesh.NewFixedWatcher(&m),
 	}
 	watcher, err := NewFileWatcher(configFile, valuesFile)
+	if err != nil {
+		cleanup()
+		t.Fatalf("NewFileWatcher() failed: %v", err)
+	}
 	wh, err := NewWebhook(WebhookParameters{
 		Watcher:        watcher,
 		Port:           port,

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -992,9 +992,9 @@ func createWebhook(t testing.TB, cfg *Config) (*Webhook, func()) {
 	env := model.Environment{
 		Watcher: mesh.NewFixedWatcher(&m),
 	}
+	watcher, err := NewFileWatcher(configFile, valuesFile)
 	wh, err := NewWebhook(WebhookParameters{
-		ConfigFile:     configFile,
-		ValuesFile:     valuesFile,
+		Watcher:        watcher,
 		Port:           port,
 		MonitoringPort: monitoringPort,
 		Env:            &env,

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -963,10 +963,10 @@ func createWebhook(t testing.TB, cfg *Config) (*Webhook, func()) {
 	cleanup := func() {
 		_ = os.RemoveAll(dir)
 	}
+	t.Cleanup(cleanup)
 
 	configBytes, err := yaml.Marshal(cfg)
 	if err != nil {
-		cleanup()
 		t.Fatalf("Could not marshal test injection config: %v", err)
 	}
 	_, values, _ := loadInjectionSettings(t, nil, "")
@@ -978,12 +978,10 @@ func createWebhook(t testing.TB, cfg *Config) (*Webhook, func()) {
 	)
 
 	if err := ioutil.WriteFile(configFile, configBytes, 0644); err != nil { // nolint: vetshadow
-		cleanup()
 		t.Fatalf("WriteFile(%v) failed: %v", configFile, err)
 	}
 
 	if err := ioutil.WriteFile(valuesFile, []byte(values), 0644); err != nil { // nolint: vetshadow
-		cleanup()
 		t.Fatalf("WriteFile(%v) failed: %v", valuesFile, err)
 	}
 
@@ -994,7 +992,6 @@ func createWebhook(t testing.TB, cfg *Config) (*Webhook, func()) {
 	}
 	watcher, err := NewFileWatcher(configFile, valuesFile)
 	if err != nil {
-		cleanup()
 		t.Fatalf("NewFileWatcher() failed: %v", err)
 	}
 	wh, err := NewWebhook(WebhookParameters{
@@ -1005,7 +1002,6 @@ func createWebhook(t testing.TB, cfg *Config) (*Webhook, func()) {
 		Mux:            http.NewServeMux(),
 	})
 	if err != nil {
-		cleanup()
 		t.Fatalf("NewWebhook() failed: %v", err)
 	}
 	return wh, cleanup


### PR DESCRIPTION
As part of #27707

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

Pull Request Attributes

[X] Does not have any changes that may affect Istio users.

This should only affect istiod deployments that are manually edited to remove mounting of the inject volume