### PR TITLE
Wait for injector ConfigMap watcher to sync in flaky test

### DIFF
--- a/pkg/kube/inject/watcher_test.go
+++ b/pkg/kube/inject/watcher_test.go
@@ -25,6 +25,7 @@ import (
 	"gopkg.in/yaml.v2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
 
 	"istio.io/istio/pkg/kube"
 )
@@ -83,6 +84,8 @@ func TestNewConfigMapWatcher(t *testing.T) {
 	})
 	stop := make(chan struct{})
 	go w.Run(stop)
+	controller := w.(*configMapWatcher).c
+	cache.WaitForCacheSync(stop, controller.HasSynced)
 
 	cms := client.Kube().CoreV1().ConfigMaps(namespace)
 	steps := []struct {


### PR DESCRIPTION
Fixes #28012

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

Pull Request Attributes

[X] Does not have any changes that may affect Istio users.