### PR TITLE
Add test flag to overwrite default namespace label with revision

### DIFF
--- a/pkg/test/framework/components/bookinfo/kube.go
+++ b/pkg/test/framework/components/bookinfo/kube.go
@@ -40,7 +40,11 @@ const (
 func deploy(ctx resource.Context, cfg Config) (undeployFunc func(), err error) {
 	ns := cfg.Namespace
 	if ns == nil {
-		ns, err = namespace.Claim(ctx, "default", true)
+		nsCfg := namespace.Config{
+			Prefix: "default",
+			Inject: true,
+		}
+		ns, err = namespace.Claim(ctx, nsCfg)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -294,7 +294,11 @@ func ClaimSystemNamespace(ctx resource.Context) (namespace.Instance, error) {
 	if err != nil {
 		return nil, err
 	}
-	return namespace.Claim(ctx, istioCfg.SystemNamespace, false)
+	nsCfg := namespace.Config{
+		Prefix: istioCfg.SystemNamespace,
+		Inject: false,
+	}
+	return namespace.Claim(ctx, nsCfg)
 }
 
 // ClaimSystemNamespaceOrFail calls ClaimSystemNamespace, failing the test if an error occurs.

--- a/pkg/test/framework/components/namespace/kube.go
+++ b/pkg/test/framework/components/namespace/kube.go
@@ -86,26 +86,22 @@ func (n *kubeNamespace) Close() (err error) {
 	return
 }
 
-func claimKube(ctx resource.Context, name string, injectSidecar bool) (Instance, error) {
+func claimKube(ctx resource.Context, nsConfig *Config) (Instance, error) {
 	env := ctx.Environment().(*kube.Environment)
 
 	for _, cluster := range env.KubeClusters {
-		if !kube2.NamespaceExists(cluster, name) {
-			nsConfig := Config{
-				Inject: injectSidecar,
-			}
-
+		if !kube2.NamespaceExists(cluster, nsConfig.Prefix) {
 			if _, err := cluster.CoreV1().Namespaces().Create(context.TODO(), &kubeApiCore.Namespace{
 				ObjectMeta: kubeApiMeta.ObjectMeta{
-					Name:   name,
-					Labels: createNamespaceLabels(&nsConfig),
+					Name:   nsConfig.Prefix,
+					Labels: createNamespaceLabels(nsConfig),
 				},
 			}, kubeApiMeta.CreateOptions{}); err != nil {
 				return nil, err
 			}
 		}
 	}
-	return &kubeNamespace{name: name}, nil
+	return &kubeNamespace{name: nsConfig.Prefix}, nil
 }
 
 // NewNamespace allocates a new testing namespace.

--- a/pkg/test/framework/components/namespace/namespace.go
+++ b/pkg/test/framework/components/namespace/namespace.go
@@ -37,14 +37,19 @@ type Instance interface {
 }
 
 // Claim an existing namespace in all clusters, or create a new one if doesn't exist.
-func Claim(ctx resource.Context, name string, injectSidecar bool) (i Instance, err error) {
-	return claimKube(ctx, name, injectSidecar)
+func Claim(ctx resource.Context, nsConfig Config) (i Instance, err error) {
+	overwriteRevisionIfEmpty(&nsConfig, ctx.Settings().Revision)
+	return claimKube(ctx, &nsConfig)
 }
 
 // ClaimOrFail calls Claim and fails test if it returns error
 func ClaimOrFail(t test.Failer, ctx resource.Context, name string) Instance {
 	t.Helper()
-	i, err := Claim(ctx, name, true)
+	nsCfg := Config{
+		Prefix: name,
+		Inject: true,
+	}
+	i, err := Claim(ctx, nsCfg)
 	if err != nil {
 		t.Fatalf("namespace.ClaimOrFail:: %v", err)
 	}
@@ -53,8 +58,9 @@ func ClaimOrFail(t test.Failer, ctx resource.Context, name string) Instance {
 
 // New creates a new Namespace in all clusters.
 func New(ctx resource.Context, nsConfig Config) (i Instance, err error) {
+	overwriteRevisionIfEmpty(&nsConfig, ctx.Settings().Revision)
 	if ctx.Settings().StableNamespaces {
-		return Claim(ctx, nsConfig.Prefix, nsConfig.Inject)
+		return Claim(ctx, nsConfig)
 	}
 	return newKube(ctx, &nsConfig)
 }
@@ -67,4 +73,13 @@ func NewOrFail(t test.Failer, ctx resource.Context, nsConfig Config) Instance {
 		t.Fatalf("namespace.NewOrFail: %v", err)
 	}
 	return i
+}
+
+func overwriteRevisionIfEmpty(nsConfig *Config, revision string) {
+	// Overwrite the default namespace label (istio-injection=enabled)
+	// with istio.io/rev=XXX. If a revision label is already provided,
+	// the label will remain as is.
+	if nsConfig.Revision == "" {
+		nsConfig.Revision = revision
+	}
 }

--- a/pkg/test/framework/components/namespace/namespace_test.go
+++ b/pkg/test/framework/components/namespace/namespace_test.go
@@ -1,0 +1,70 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package namespace
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestConfigRevisionOverwrite(t *testing.T) {
+	testCases := []struct {
+		name string
+
+		// test inputs.
+		revision string
+		cfg      Config
+
+		// expected results.
+		wantRevision string
+	}{
+		{
+			name:     "NoOverwriteEmptyInput",
+			revision: "",
+			cfg: Config{
+				Prefix:   "default",
+				Revision: "istio.io/rev=XXX",
+			},
+			wantRevision: "istio.io/rev=XXX",
+		},
+		{
+			name:     "NoOverwriteNonEmptyInput",
+			revision: "BadRevision",
+			cfg: Config{
+				Prefix:   "default",
+				Revision: "istio.io/rev=XXX",
+			},
+			wantRevision: "istio.io/rev=XXX",
+		},
+		{
+			name:     "OverwriteNonEmptyInput",
+			revision: "istio.io/rev=canary",
+			cfg: Config{
+				Prefix:   "default",
+				Revision: "",
+			},
+			wantRevision: "istio.io/rev=canary",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			overwriteRevisionIfEmpty(&tc.cfg, tc.revision)
+			g := NewWithT(t)
+			g.Expect(tc.cfg.Revision).Should(Equal(tc.wantRevision))
+		})
+	}
+}

--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -76,4 +76,7 @@ func init() {
 
 	flag.BoolVar(&settingsFromCommandLine.FailOnDeprecation, "istio.test.deprecation_failure", settingsFromCommandLine.FailOnDeprecation,
 		"Make tests fail if any usage of deprecated stuff (e.g. Envoy flags) is detected.")
+
+	flag.StringVar(&settingsFromCommandLine.Revision, "istio.test.revision", settingsFromCommandLine.Revision,
+		"If set to XXX, overwrite the default namespace label (istio-injection=enabled) with istio.io/rev=XXX.")
 }

--- a/pkg/test/framework/resource/settings.go
+++ b/pkg/test/framework/resource/settings.go
@@ -66,6 +66,10 @@ type Settings struct {
 	// EnvironmentFactory allows caller to override the environment creation. If nil, a default is used based
 	// on the known environment names.
 	EnvironmentFactory EnvironmentFactory
+
+	// The revision label on a namespace for injection webhook.
+	// If set to XXX, all the namespaces created with istio-injection=enabled will be replaced with istio.io/rev=XXX.
+	Revision string
 }
 
 // RunDir is the name of the dir to output, for this particular run.

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -565,6 +565,9 @@ The test framework supports the following command-line flags:
 
   -istio.test.kube.loadbalancer bool
         Used to obtain the right IP address for ingress gateway. This should be false for any environment that doesn't support a LoadBalancer type.
+
+  -istio.test.revision string
+        Overwrite the default namespace label (istio-enabled=true) with revision lable (istio.io/rev=XXX). (default is no overwrite)
 ```
 
 }


### PR DESCRIPTION
Add test flag to overwrite the default namespace label for sidecar
injection. If a namespace is created with a revision label, the
label will remain as is.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.