### PR TITLE
add cluster NetworkingMetadata

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -1177,12 +1177,10 @@ func getOrCreateIstioMetadata(cluster *cluster.Cluster) *structpb.Struct {
 		}
 	}
 	// Create Istio metadata if does not exist yet
-	if im, ok := cluster.Metadata.FilterMetadata[util.IstioMetadataKey]; !ok {
+	if _, ok := cluster.Metadata.FilterMetadata[util.IstioMetadataKey]; !ok {
 		cluster.Metadata.FilterMetadata[util.IstioMetadataKey] = &structpb.Struct{
 			Fields: map[string]*structpb.Value{},
 		}
-		return cluster.Metadata.FilterMetadata[util.IstioMetadataKey]
-	} else {
-		return im
 	}
+	return cluster.Metadata.FilterMetadata[util.IstioMetadataKey]
 }

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -1078,20 +1078,8 @@ func addTelemetryMetadata(opts buildClusterOpts, service *model.Service, directi
 		// At outbound, the service corresponding to the cluster has to be provided.
 		return
 	}
-	if opts.cluster.Metadata == nil {
-		opts.cluster.Metadata = &core.Metadata{
-			FilterMetadata: map[string]*structpb.Struct{},
-		}
-	}
 
-	// Create Istio metadata if does not exist yet
-	if _, ok := opts.cluster.Metadata.FilterMetadata[util.IstioMetadataKey]; !ok {
-		opts.cluster.Metadata.FilterMetadata[util.IstioMetadataKey] = &structpb.Struct{
-			Fields: map[string]*structpb.Value{},
-		}
-	}
-
-	im := opts.cluster.Metadata.FilterMetadata[util.IstioMetadataKey]
+	im := getOrCreateIstioMetadata(opts.cluster)
 
 	// Add services field into istio metadata
 	im.Fields["services"] = &structpb.Value{
@@ -1104,7 +1092,7 @@ func addTelemetryMetadata(opts buildClusterOpts, service *model.Service, directi
 
 	svcMetaList := im.Fields["services"].GetListValue()
 
-	// Add servie related metadata. This will be consumed by telemetry v2 filter for metric labels.
+	// Add service related metadata. This will be consumed by telemetry v2 filter for metric labels.
 	if direction == model.TrafficDirectionInbound {
 		// For inbound cluster, add all services on the cluster port
 		have := make(map[host.Name]bool)
@@ -1128,13 +1116,37 @@ func addTelemetryMetadata(opts buildClusterOpts, service *model.Service, directi
 	}
 }
 
+// Insert the original port into the istio metadata. The port is used in BTS delivered from client sidecar to server sidecar.
+// Server side car uses this port after de-multiplexed from tunnel.
+func addNetworkingMetadata(opts buildClusterOpts, service *model.Service, direction model.TrafficDirection) {
+	if opts.cluster == nil || direction == model.TrafficDirectionInbound {
+		return
+	}
+	if service == nil {
+		// At outbound, the service corresponding to the cluster has to be provided.
+		return
+	}
+
+	if port, ok := service.Ports.GetByPort(opts.port.Port); ok {
+		im := getOrCreateIstioMetadata(opts.cluster)
+
+		// Add original_port field into istio metadata
+		// Endpoint could override this port but the chance should be small.
+		im.Fields["default_original_port"] = &structpb.Value{
+			Kind: &structpb.Value_NumberValue{
+				NumberValue: float64(port.Port),
+			},
+		}
+	}
+}
+
 // Build a struct which contains service metadata and will be added into cluster label.
 func buildServiceMetadata(svc *model.Service) *structpb.Value {
 	return &structpb.Value{
 		Kind: &structpb.Value_StructValue{
 			StructValue: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
-					// serivce fqdn
+					// service fqdn
 					"host": {
 						Kind: &structpb.Value_StringValue{
 							StringValue: string(svc.Hostname),
@@ -1155,5 +1167,22 @@ func buildServiceMetadata(svc *model.Service) *structpb.Value {
 				},
 			},
 		},
+	}
+}
+
+func getOrCreateIstioMetadata(cluster *cluster.Cluster) *structpb.Struct {
+	if cluster.Metadata == nil {
+		cluster.Metadata = &core.Metadata{
+			FilterMetadata: map[string]*structpb.Struct{},
+		}
+	}
+	// Create Istio metadata if does not exist yet
+	if im, ok := cluster.Metadata.FilterMetadata[util.IstioMetadataKey]; !ok {
+		cluster.Metadata.FilterMetadata[util.IstioMetadataKey] = &structpb.Struct{
+			Fields: map[string]*structpb.Value{},
+		}
+		return cluster.Metadata.FilterMetadata[util.IstioMetadataKey]
+	} else {
+		return im
 	}
 }

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -96,7 +96,6 @@ func (cb *ClusterBuilder) applyDestinationRule(c *cluster.Cluster, clusterMode C
 		if clusterMode == DefaultClusterMode {
 			subsetClusterName = model.BuildSubsetKey(model.TrafficDirectionOutbound, subset.Name, service.Hostname, port.Port)
 			defaultSni = model.BuildDNSSrvSubsetKey(model.TrafficDirectionOutbound, subset.Name, service.Hostname, port.Port)
-
 		} else {
 			subsetClusterName = model.BuildDNSSrvSubsetKey(model.TrafficDirectionOutbound, subset.Name, service.Hostname, port.Port)
 		}
@@ -122,7 +121,7 @@ func (cb *ClusterBuilder) applyDestinationRule(c *cluster.Cluster, clusterMode C
 		}
 		setUpstreamProtocol(cb.proxy, subsetCluster, port, model.TrafficDirectionOutbound)
 
-		// Apply traffic policy for subset cluster with the destination rule traffice policy.
+		// Apply traffic policy for subset cluster with the destination rule traffic policy.
 		opts.cluster = subsetCluster
 		opts.istioMtlsSni = defaultSni
 
@@ -238,7 +237,7 @@ func (cb *ClusterBuilder) buildDefaultCluster(name string, discoveryType cluster
 	}
 	applyTrafficPolicy(opts)
 	addTelemetryMetadata(opts, service, direction)
-
+	addNetworkingMetadata(opts, service, direction)
 	return c
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -637,7 +637,7 @@ func TestBuildDefaultCluster(t *testing.T) {
 										},
 									}}}},
 								}}}},
-								"default_original_port": &structpb.Value{
+								"default_original_port": {
 									Kind: &structpb.Value_NumberValue{
 										NumberValue: float64(8080),
 									},
@@ -731,7 +731,7 @@ func TestBuildDefaultCluster(t *testing.T) {
 									},
 								}}}},
 							}}}},
-							"default_original_port": &structpb.Value{
+							"default_original_port": {
 								Kind: &structpb.Value_NumberValue{
 									NumberValue: float64(8080),
 								},

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -616,27 +616,33 @@ func TestBuildDefaultCluster(t *testing.T) {
 				},
 				Metadata: &core.Metadata{
 					FilterMetadata: map[string]*structpb.Struct{
-						util.IstioMetadataKey: {Fields: map[string]*structpb.Value{
-							"services": {Kind: &structpb.Value_ListValue{ListValue: &structpb.ListValue{Values: []*structpb.Value{
-								{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: map[string]*structpb.Value{
-									"host": {
-										Kind: &structpb.Value_StringValue{
-											StringValue: "host",
+						util.IstioMetadataKey: {
+							Fields: map[string]*structpb.Value{
+								"services": {Kind: &structpb.Value_ListValue{ListValue: &structpb.ListValue{Values: []*structpb.Value{
+									{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: map[string]*structpb.Value{
+										"host": {
+											Kind: &structpb.Value_StringValue{
+												StringValue: "host",
+											},
 										},
-									},
-									"name": {
-										Kind: &structpb.Value_StringValue{
-											StringValue: "svc",
+										"name": {
+											Kind: &structpb.Value_StringValue{
+												StringValue: "svc",
+											},
 										},
-									},
-									"namespace": {
-										Kind: &structpb.Value_StringValue{
-											StringValue: "default",
+										"namespace": {
+											Kind: &structpb.Value_StringValue{
+												StringValue: "default",
+											},
 										},
-									},
+									}}}},
 								}}}},
-							}}}},
-						}},
+								"default_original_port": &structpb.Value{
+									Kind: &structpb.Value_NumberValue{
+										NumberValue: float64(8080),
+									},
+								},
+							}},
 					},
 				},
 			},
@@ -725,6 +731,11 @@ func TestBuildDefaultCluster(t *testing.T) {
 									},
 								}}}},
 							}}}},
+							"default_original_port": &structpb.Value{
+								Kind: &structpb.Value_NumberValue{
+									NumberValue: float64(8080),
+								},
+							},
 						}},
 					},
 				},
@@ -739,7 +750,10 @@ func TestBuildDefaultCluster(t *testing.T) {
 
 			defaultCluster := cb.buildDefaultCluster(tt.clusterName, tt.discovery,
 				tt.endpoints, tt.direction, servicePort,
-				&model.Service{Hostname: "host", MeshExternal: false, Attributes: model.ServiceAttributes{Name: "svc", Namespace: "default"}})
+				&model.Service{Ports: model.PortList{
+					servicePort,
+				},
+					Hostname: "host", MeshExternal: false, Attributes: model.ServiceAttributes{Name: "svc", Namespace: "default"}})
 
 			if diff := cmp.Diff(defaultCluster, tt.expectedCluster, protocmp.Transform()); diff != "" {
 				t.Errorf("Unexpected default cluster, diff: %v", diff)


### PR DESCRIPTION
This original port is used by tunnel between client sidecar and server sidecar.
Once the request is tunneled at client sidecar, the server sidecar must recover the original network attributes when extract the request from the tunnel.

Follow up PRs will address the cases that endpoints port are not unique. 

For H2 BTS tunnel, I will introduce another http connection pool to read this metadata and encode the metadata into the upstream request.

Imagine the k8s service is 
```
name: foo.ns
port: 80
target_port: 8080
```

So the outbound EDS cluster config is: 
```
CDS:
cluster: outbound|80||foo.ns
cluster_metadata: 
- original_port: 8080
endpoints:  EDS_XYZ
```

```
EDS:
name: EDS_XYZ
- address: 1.2.3.4:15009   # server pod has sidecar
- address: 1.2.3.5:15009   # server pod has sidecar
- address: 1.2.3.5:9090     # server pod doesn't have sidecar 
```


Signed-off-by: Yuchen Dai <silentdai@gmail.com>

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
