### PR TITLE
cluster info config map

### DIFF
--- a/manifests/charts/base/files/gen-istio-cluster.yaml
+++ b/manifests/charts/base/files/gen-istio-cluster.yaml
@@ -3654,7 +3654,7 @@ rules:
     resources: ["*"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
-    resources: ["endpoints", "pods", "services", "nodes", "replicationcontrollers", "namespaces"]
+    resources: ["endpoints", "pods", "services", "nodes", "replicationcontrollers", "namespaces", "configmaps"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["discovery.k8s.io"]
     resources: ["endpointslices"]

--- a/manifests/charts/base/templates/clusterrole.yaml
+++ b/manifests/charts/base/templates/clusterrole.yaml
@@ -115,7 +115,7 @@ rules:
     resources: ["*"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
-    resources: ["endpoints", "pods", "services", "nodes", "replicationcontrollers", "namespaces"]
+    resources: ["endpoints", "pods", "services", "nodes", "replicationcontrollers", "namespaces", "configmaps"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["discovery.k8s.io"]
     resources: ["endpointslices"]

--- a/manifests/charts/base/templates/configmap.yaml
+++ b/manifests/charts/base/templates/configmap.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.global.multiCluster.clusterName }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio-cluster{{- if .Values.revision }}-{{ .Values.revision }}{{- end }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    istio.io/rev: {{ .Values.revision | default "default" }}
+    release: {{ .Release.Name }}
+    istio/multiCluster: true
+data:
+  cluster: {{ .Values.global.multiCluster.clusterName }}
+{{- if .Values.global.network }}
+  network: {{ .Values.global.network }}
+{{- end }}
+{{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
@@ -88,3 +88,20 @@ data:
 {{- end }}
 ---
 {{- end }}
+
+{{- if .Values.global.multiCluster.clusterName }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio-cluster{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    istio.io/rev: {{ .Values.revision | default "default" }}
+    release: {{ .Release.Name }}
+    istio/multiCluster: true
+data:
+  cluster: {{ .Values.global.multiCluster.clusterName }}
+  {{- if .Values.global.network }}
+  network: {{ .Values.global.network }}
+  {{- end }}
+{{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml
@@ -88,20 +88,3 @@ data:
 {{- end }}
 ---
 {{- end }}
-
-{{- if .Values.global.multiCluster.clusterName }}
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: istio-cluster{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    istio.io/rev: {{ .Values.revision | default "default" }}
-    release: {{ .Release.Name }}
-    istio/multiCluster: true
-data:
-  cluster: {{ .Values.global.multiCluster.clusterName }}
-  {{- if .Values.global.network }}
-  network: {{ .Values.global.network }}
-  {{- end }}
-{{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -138,12 +138,14 @@ spec:
             value: "{{ .Values.pilot.enableProtocolSniffingForOutbound }}"
           - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND
             value: "{{ .Values.pilot.enableProtocolSniffingForInbound }}"
+{{- if not (hasKey .Values.pilot.env "INJECTION_WEBHOOK_CONFIG_NAME") }}
           - name: INJECTION_WEBHOOK_CONFIG_NAME
           {{- if eq .Release.Namespace "istio-system" }}
             value: istio-sidecar-injector{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
           {{- else }}
             value: istio-sidecar-injector{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}-{{ .Release.Namespace }}
           {{- end }}
+{{- end }}
           - name: ISTIOD_ADDR
             value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Release.Namespace }}.svc:15012
           - name: PILOT_ENABLE_ANALYSIS

--- a/manifests/charts/istiod-remote/templates/configmap.yaml
+++ b/manifests/charts/istiod-remote/templates/configmap.yaml
@@ -88,3 +88,20 @@ data:
 {{- end }}
 ---
 {{- end }}
+
+{{- if .Values.global.multiCluster.clusterName }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio-cluster{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    istio.io/rev: {{ .Values.revision | default "default" }}
+    release: {{ .Release.Name }}
+    istio/multiCluster: true
+data:
+  cluster: {{ .Values.global.multiCluster.clusterName }}
+  {{- if .Values.global.network }}
+  network: {{ .Values.global.network }}
+  {{- end }}
+{{- end }}

--- a/manifests/charts/istiod-remote/templates/configmap.yaml
+++ b/manifests/charts/istiod-remote/templates/configmap.yaml
@@ -88,20 +88,3 @@ data:
 {{- end }}
 ---
 {{- end }}
-
-{{- if .Values.global.multiCluster.clusterName }}
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: istio-cluster{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    istio.io/rev: {{ .Values.revision | default "default" }}
-    release: {{ .Release.Name }}
-    istio/multiCluster: true
-data:
-  cluster: {{ .Values.global.multiCluster.clusterName }}
-  {{- if .Values.global.network }}
-  network: {{ .Values.global.network }}
-  {{- end }}
-{{- end }}

--- a/manifests/profiles/remote.yaml
+++ b/manifests/profiles/remote.yaml
@@ -1,3 +1,10 @@
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
-spec: {}
+spec:
+  # install only "base" component
+  components:
+    pilot:
+      enabled: false
+    ingressGateways:
+      - name: istio-ingressgateway
+        enabled: false

--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -152,7 +152,7 @@ func init() {
 		"Controller resync interval")
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.RegistryOptions.KubeOptions.DomainSuffix, "domain", constants.DefaultKubernetesDomain,
 		"DNS domain suffix")
-	discoveryCmd.PersistentFlags().StringVar(&serverArgs.RegistryOptions.KubeOptions.ClusterID, "clusterID", features.ClusterName,
+	discoveryCmd.PersistentFlags().StringVar(&serverArgs.RegistryOptions.KubeOptions.ClusterMeta.ID, "clusterID", features.ClusterName,
 		"The ID of the cluster that this Istiod instance resides")
 	// Deprecated - use mesh config
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.RegistryOptions.KubeOptions.TrustDomain, "trust-domain", "",

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -343,7 +343,7 @@ func NewServer(args *PilotArgs) (*Server, error) {
 }
 
 func getClusterID(args *PilotArgs) string {
-	clusterID := args.RegistryOptions.KubeOptions.ClusterID
+	clusterID := args.RegistryOptions.KubeOptions.ClusterMeta.ID
 	if clusterID == "" {
 		if hasKubeRegistry(args.RegistryOptions.Registries) {
 			clusterID = string(serviceregistry.Kubernetes)

--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -80,12 +80,13 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 
 // initKubeRegistry creates all the k8s service controllers under this pilot
 func (s *Server) initKubeRegistry(serviceControllers *aggregate.Controller, args *PilotArgs) (err error) {
-	args.RegistryOptions.KubeOptions.ClusterID = s.clusterID
+	// TODO allow overriding with configmap
+	args.RegistryOptions.KubeOptions.ClusterMeta.ID = s.clusterID
 	args.RegistryOptions.KubeOptions.Metrics = s.environment
 	args.RegistryOptions.KubeOptions.XDSUpdater = s.XDSServer
 	args.RegistryOptions.KubeOptions.NetworksWatcher = s.environment.NetworksWatcher
 
-	log.Infof("Initializing Kubernetes service registry %q", args.RegistryOptions.KubeOptions.ClusterID)
+	log.Infof("Initializing Kubernetes service registry %q", args.RegistryOptions.KubeOptions.ClusterMeta.ID)
 	kubeRegistry := kubecontroller.NewController(s.kubeClient, args.RegistryOptions.KubeOptions)
 	s.kubeRegistry = kubeRegistry
 	serviceControllers.AddRegistry(kubeRegistry)

--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -16,6 +16,7 @@ package bootstrap
 
 import (
 	"fmt"
+	"istio.io/istio/pkg/kube"
 
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
@@ -80,8 +81,11 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 
 // initKubeRegistry creates all the k8s service controllers under this pilot
 func (s *Server) initKubeRegistry(serviceControllers *aggregate.Controller, args *PilotArgs) (err error) {
-	// TODO allow overriding with configmap
-	args.RegistryOptions.KubeOptions.ClusterMeta.ID = s.clusterID
+	// TODO init single-cluster registry in a common-way as multi-cluster registries
+	if cm := kube.ClusterMetaFromConfigMap(s.kubeClient, args.Namespace); cm != nil {
+		args.RegistryOptions.KubeOptions.ClusterMeta = *cm
+		s.clusterID = cm.ID
+	}
 	args.RegistryOptions.KubeOptions.Metrics = s.environment
 	args.RegistryOptions.KubeOptions.XDSUpdater = s.XDSServer
 	args.RegistryOptions.KubeOptions.NetworksWatcher = s.environment.NetworksWatcher

--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -16,7 +16,7 @@ package bootstrap
 
 import (
 	"fmt"
-	"istio.io/istio/pkg/kube"
+
 
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
@@ -26,6 +26,7 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/mock"
 	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
 	"istio.io/istio/pkg/config/host"
+	"istio.io/istio/pkg/kube"
 	"istio.io/pkg/log"
 )
 

--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -17,7 +17,6 @@ package bootstrap
 import (
 	"fmt"
 
-
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"

--- a/pilot/pkg/secrets/kube/multicluster.go
+++ b/pilot/pkg/secrets/kube/multicluster.go
@@ -26,6 +26,9 @@ import (
 
 // Multicluster structure holds the remote kube Controllers and multicluster specific attributes.
 type Multicluster struct {
+	// maps the key (could be a secret name or other reliable key) to the cluster id
+	clusterIDByKey map[string]string
+	// maps cluster id to the related controller
 	remoteKubeControllers map[string]*SecretsController
 	m                     sync.Mutex // protects remoteKubeControllers
 	secretController      *secretcontroller.Controller
@@ -36,38 +39,49 @@ var _ secrets.MulticlusterController = &Multicluster{}
 
 func NewMulticluster(client kube.Client, localCluster, secretNamespace string) *Multicluster {
 	m := &Multicluster{
+		clusterIDByKey:        map[string]string{},
 		remoteKubeControllers: map[string]*SecretsController{},
 		localCluster:          localCluster,
 	}
+
+	// TODO move this to bootstrap and re-use it for serviceregistry
+	clusterMeta := &kube.ClusterMeta{ID: localCluster}
+	if cmMeta := kube.ClusterMetaFromConfigMap(client, secretNamespace); cmMeta != nil {
+		clusterMeta = cmMeta
+	}
+
 	// Add the local cluster
-	m.addMemberCluster(client, localCluster)
+	m.addMemberCluster(client, localCluster, clusterMeta)
 	sc := secretcontroller.StartSecretController(client,
-		func(c kube.Client, k string) error { m.addMemberCluster(c, k); return nil },
-		func(c kube.Client, k string) error { m.updateMemberCluster(c, k); return nil },
+		func(c kube.Client, k string, cm *kube.ClusterMeta) error { m.addMemberCluster(c, k, cm); return nil },
+		func(c kube.Client, k string, cm *kube.ClusterMeta) error { m.updateMemberCluster(c, k, cm); return nil },
 		func(k string) error { m.deleteMemberCluster(k); return nil },
 		secretNamespace)
 	m.secretController = sc
 	return m
 }
 
-func (m *Multicluster) addMemberCluster(clients kube.Client, key string) {
+func (m *Multicluster) addMemberCluster(clients kube.Client, key string, cm *kube.ClusterMeta) {
 	stopCh := make(chan struct{})
 	log.Infof("initializing Kubernetes credential reader for cluster %v", key)
-	sc := NewSecretsController(clients, key)
+	sc := NewSecretsController(clients, cm.ID)
 	m.m.Lock()
-	m.remoteKubeControllers[key] = sc
+	m.clusterIDByKey[key] = cm.ID
+	m.remoteKubeControllers[cm.ID] = sc
 	m.m.Unlock()
 	clients.RunAndWait(stopCh)
 }
 
-func (m *Multicluster) updateMemberCluster(clients kube.Client, key string) {
+func (m *Multicluster) updateMemberCluster(clients kube.Client, key string, cm *kube.ClusterMeta) {
 	m.deleteMemberCluster(key)
-	m.addMemberCluster(clients, key)
+	m.addMemberCluster(clients, key, cm)
 }
 
 func (m *Multicluster) deleteMemberCluster(key string) {
 	m.m.Lock()
-	delete(m.remoteKubeControllers, key)
+	cid := m.clusterIDByKey[key]
+	delete(m.remoteKubeControllers, cid)
+	delete(m.clusterIDByKey, key)
 	m.m.Unlock()
 }
 

--- a/pilot/pkg/secrets/kube/secrets_test.go
+++ b/pilot/pkg/secrets/kube/secrets_test.go
@@ -142,8 +142,8 @@ func TestForCluster(t *testing.T) {
 	localClient := kube.NewFakeClient()
 	remoteClient := kube.NewFakeClient()
 	sc := NewMulticluster(localClient, "local", "")
-	sc.addMemberCluster(remoteClient, "remote")
-	sc.addMemberCluster(remoteClient, "remote2")
+	sc.addMemberCluster(remoteClient, "remoteKey", kube.ClusterMeta{ID: "remote"})
+	sc.addMemberCluster(remoteClient, "remoteKey2", kube.ClusterMeta{ID: "remote2"})
 	cases := []struct {
 		cluster string
 		allowed bool
@@ -169,7 +169,7 @@ func TestAuthorize(t *testing.T) {
 	allowIdentities(localClient, "system:serviceaccount:ns-local:sa-allowed")
 	allowIdentities(remoteClient, "system:serviceaccount:ns-remote:sa-allowed")
 	sc := NewMulticluster(localClient, "local", "")
-	sc.addMemberCluster(remoteClient, "remote")
+	sc.addMemberCluster(remoteClient, "remoteKey123", kube.ClusterMeta{ID: "remote"})
 	cases := []struct {
 		sa      string
 		ns      string
@@ -221,8 +221,8 @@ func TestSecretsControllerMulticluster(t *testing.T) {
 	remoteClient := kube.NewFakeClient(secretsRemote...)
 	otherRemoteClient := kube.NewFakeClient()
 	sc := NewMulticluster(localClient, "local", "")
-	sc.addMemberCluster(remoteClient, "remote")
-	sc.addMemberCluster(otherRemoteClient, "other")
+	sc.addMemberCluster(remoteClient, "remotekey", kube.ClusterMeta{ID: "remote"})
+	sc.addMemberCluster(otherRemoteClient, "otherkey", kube.ClusterMeta{ID: "other"})
 	cases := []struct {
 		name      string
 		namespace string

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -106,8 +106,8 @@ type Options struct {
 	ResyncPeriod      time.Duration
 	DomainSuffix      string
 
-	// ClusterID identifies the remote cluster in a multicluster env.
-	ClusterID string
+	// ClusterMeta contains the multi-cluster ClusterID and optionally the default network for the cluster.
+	ClusterMeta kubelib.ClusterMeta
 
 	// FetchCaRoot defines the function to get caRoot
 	FetchCaRoot func() map[string]string
@@ -173,6 +173,8 @@ type kubernetesNode struct {
 // Controller is a collection of synchronized resource watchers
 // Caches are thread-safe
 type Controller struct {
+	kubelib.ClusterMeta
+
 	client kubernetes.Interface
 
 	queue queue.Instance
@@ -194,7 +196,6 @@ type Controller struct {
 	networksWatcher mesh.NetworksWatcher
 	xdsUpdater      model.XDSUpdater
 	domainSuffix    string
-	clusterID       string
 
 	serviceHandlers  []func(*model.Service, model.Event)
 	workloadHandlers []func(*model.WorkloadInstance, model.Event)
@@ -223,7 +224,7 @@ type Controller struct {
 	// CIDR ranger based on path-compressed prefix trie
 	ranger cidranger.Ranger
 
-	// Network name for the registry as specified by the MeshNetworks configmap
+	// Network name for the registry as specified by the MeshNetworks configmap, overrides ClusterMeta network.
 	networkForRegistry string
 	// tracks which services on which ports should act as a gateway for networkForRegistry
 	registryServiceNameGateways map[host.Name]uint32
@@ -238,10 +239,10 @@ type Controller struct {
 func NewController(kubeClient kubelib.Client, options Options) *Controller {
 	// The queue requires a time duration for a retry delay after a handler error
 	c := &Controller{
+		ClusterMeta:                 options.ClusterMeta,
 		domainSuffix:                options.DomainSuffix,
 		client:                      kubeClient.Kube(),
 		queue:                       queue.NewQueue(1 * time.Second),
-		clusterID:                   options.ClusterID,
 		xdsUpdater:                  options.XDSUpdater,
 		servicesMap:                 make(map[host.Name]*model.Service),
 		nodeSelectorsForServices:    make(map[host.Name]labels.Instance),
@@ -295,7 +296,7 @@ func (c *Controller) Provider() serviceregistry.ProviderID {
 }
 
 func (c *Controller) Cluster() string {
-	return c.clusterID
+	return c.ID
 }
 
 func (c *Controller) Cleanup() error {
@@ -306,7 +307,7 @@ func (c *Controller) Cleanup() error {
 	}
 	for _, s := range svcs {
 		name := kube.ServiceHostname(s.Name, s.Namespace, c.domainSuffix)
-		c.xdsUpdater.SvcUpdate(c.clusterID, string(name), s.Namespace, model.EventDelete)
+		c.xdsUpdater.SvcUpdate(c.ID, string(name), s.Namespace, model.EventDelete)
 		// TODO(landow) do we need to notify service handlers?
 	}
 	return nil
@@ -329,7 +330,7 @@ func (c *Controller) onServiceEvent(curr interface{}, event model.Event) error {
 
 	log.Debugf("Handle event %s for service %s in namespace %s", event, svc.Name, svc.Namespace)
 
-	svcConv := kube.ConvertService(*svc, c.domainSuffix, c.clusterID)
+	svcConv := kube.ConvertService(*svc, c.domainSuffix, c.ID)
 	switch event {
 	case model.EventDelete:
 		c.Lock()
@@ -372,11 +373,11 @@ func (c *Controller) onServiceEvent(curr interface{}, event model.Event) error {
 		}
 
 		if len(endpoints) > 0 {
-			c.xdsUpdater.EDSCacheUpdate(c.clusterID, string(svcConv.Hostname), svc.Namespace, endpoints)
+			c.xdsUpdater.EDSCacheUpdate(c.ID, string(svcConv.Hostname), svc.Namespace, endpoints)
 		}
 	}
 
-	c.xdsUpdater.SvcUpdate(c.clusterID, string(svcConv.Hostname), svc.Namespace, event)
+	c.xdsUpdater.SvcUpdate(c.ID, string(svcConv.Hostname), svc.Namespace, event)
 	// Notify service handlers.
 	for _, f := range c.serviceHandlers {
 		f(svcConv, event)
@@ -791,7 +792,7 @@ func (c *Controller) GetProxyServiceInstances(proxy *model.Proxy) ([]*model.Serv
 			return c.hydrateWorkloadInstance(workload), nil
 		} else if pod != nil {
 			if !c.isControllerForProxy(proxy) {
-				return nil, fmt.Errorf("proxy is in cluster %v, but controller is for cluster %v", proxy.Metadata.ClusterID, c.clusterID)
+				return nil, fmt.Errorf("proxy is in cluster %v, but controller is for cluster %v", proxy.Metadata.ClusterID, c.ID)
 			}
 
 			// 1. find proxy service by label selector, if not any, there may exist headless service without selector
@@ -921,7 +922,7 @@ func (c *Controller) WorkloadInstanceHandler(si *model.WorkloadInstance, event m
 				}
 			}
 			// fire off eds update
-			c.xdsUpdater.EDSUpdate(c.clusterID, string(service.Hostname), service.Attributes.Namespace, endpoints)
+			c.xdsUpdater.EDSUpdate(c.ID, string(service.Hostname), service.Attributes.Namespace, endpoints)
 		}
 	}
 }
@@ -929,7 +930,7 @@ func (c *Controller) WorkloadInstanceHandler(si *model.WorkloadInstance, event m
 // isControllerForProxy should be used for proxies assumed to be in the kube cluster for this controller. Workload Entries
 // may not necessarily pass this check, but we still want to allow kube services to select workload instances.
 func (c *Controller) isControllerForProxy(proxy *model.Proxy) bool {
-	return proxy.Metadata.ClusterID == c.clusterID
+	return proxy.Metadata.ClusterID == c.ID
 }
 
 // getProxyServiceInstancesFromMetadata retrieves ServiceInstances using proxy Metadata rather than
@@ -941,7 +942,7 @@ func (c *Controller) getProxyServiceInstancesFromMetadata(proxy *model.Proxy) ([
 	}
 
 	if !c.isControllerForProxy(proxy) {
-		return nil, fmt.Errorf("proxy is in cluster %v, but controller is for cluster %v", proxy.Metadata.ClusterID, c.clusterID)
+		return nil, fmt.Errorf("proxy is in cluster %v, but controller is for cluster %v", proxy.Metadata.ClusterID, c.ID)
 	}
 
 	// Create a pod with just the information needed to find the associated Services

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -15,7 +15,10 @@
 package controller
 
 import (
+	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/watch"
 	"sort"
 	"sync"
 	"time"
@@ -190,6 +193,9 @@ type Controller struct {
 	nodeInformer cache.SharedIndexInformer
 	nodeLister   listerv1.NodeLister
 
+	// cmWatch checks for updates to the istio-cluster ConfigMap used to configure per-cluster fields.
+	cmWatch watch.Interface
+
 	pods *PodCache
 
 	metrics         model.Metrics
@@ -256,6 +262,13 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 		metrics:                     options.Metrics,
 	}
 
+	cmWatch, err := c.client.CoreV1().ConfigMaps("istio-system").Watch(context.TODO(), metav1.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector("metadata.name", "istio-cluster").String(),
+	})
+	if err != nil {
+		log.Warnf("failed creating istio-cluster ConfigMap watch in %s: %v", c.ID, err)
+	}
+	c.cmWatch = cmWatch
 	c.serviceInformer = kubeClient.KubeInformer().Core().V1().Services().Informer()
 	c.serviceLister = kubeClient.KubeInformer().Core().V1().Services().Lister()
 	registerHandlers(c.serviceInformer, c.queue, "Services", c.onServiceEvent, nil)
@@ -581,6 +594,52 @@ func (c *Controller) Run(stop <-chan struct{}) {
 	cache.WaitForCacheSync(stop, c.HasSynced)
 	c.queue.Run(stop)
 	log.Infof("Controller terminated")
+}
+
+func (c *Controller) watchConfigMap(stop <-chan struct{}) {
+	select {
+	case event := <-c.cmWatch.ResultChan():
+		c.queue.Push(func() error {
+			if event.Type != watch.Added && event.Type != watch.Modified {
+				// err or delete
+				log.Warnf("istio-cluster ConfigMap: %v", event.Type)
+				return nil
+			}
+
+			cm, ok := event.Object.(*v1.ConfigMap)
+			if !ok {
+				log.Warnf("non ConfigMap object in istio-cluster update")
+				return nil
+			}
+
+			// we can only update the network here, updating the cluster name affects many other
+			// areas such as secret controller, jwt auth and tracking the loaded registries
+			// changing the cluster ID while running is an unsafe operation
+			nw, ok := cm.Data["network"]
+			if !ok {
+				return nil
+			}
+			c.Lock()
+			c.Network = nw
+			defer c.Unlock()
+
+			// apply the new network to all pods/endpoints, then trigger a push
+			if err := c.syncPods(); err != nil {
+				log.Errorf("one or more errors force-syncing pods: %v", err)
+			}
+			if err := c.syncEndpoints(); err != nil {
+				log.Errorf("one or more errors force-syncing endpoints: %v", err)
+			}
+			c.xdsUpdater.ConfigUpdate(&model.PushRequest{
+				Full:   true,
+				Reason: []model.TriggerReason{model.GlobalUpdate},
+			})
+
+			return nil
+		})
+	case <-stop:
+		c.cmWatch.Stop()
+	}
 }
 
 // Stop the controller. Only for tests, to simplify the code (defer c.Stop())

--- a/pilot/pkg/serviceregistry/kube/controller/endpoint_builder.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoint_builder.go
@@ -56,7 +56,7 @@ func NewEndpointBuilder(c *Controller, pod *v1.Pod) *EndpointBuilder {
 		serviceAccount: sa,
 		locality: model.Locality{
 			Label:     locality,
-			ClusterID: c.clusterID,
+			ClusterID: c.ID,
 		},
 		tlsMode: kube.PodTLSMode(pod),
 	}
@@ -70,7 +70,7 @@ func NewEndpointBuilderFromMetadata(c *Controller, proxy *model.Proxy) *Endpoint
 		serviceAccount: proxy.Metadata.ServiceAccount,
 		locality: model.Locality{
 			Label:     util.LocalityToString(proxy.Locality),
-			ClusterID: c.clusterID,
+			ClusterID: c.ID,
 		},
 		tlsMode: model.GetTLSModeFromEndpointLabels(proxy.Metadata.Labels),
 	}
@@ -126,5 +126,5 @@ func (b *EndpointBuilder) endpointNetwork(endpointIP string) string {
 	}
 
 	// Fallback to legacy fromRegistry setting, all endpoints from this cluster are on that network.
-	return b.controller.networkForRegistry
+	return b.controller.DefaultNetwork()
 }

--- a/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpointcontroller.go
@@ -110,7 +110,7 @@ func updateEDS(c *Controller, epc kubeEndpointsController, ep interface{}, event
 		}
 	}
 
-	c.xdsUpdater.EDSUpdate(c.clusterID, string(host), ns, endpoints)
+	c.xdsUpdater.EDSUpdate(c.ID, string(host), ns, endpoints)
 }
 
 // getPod fetches a pod by IP address.

--- a/pilot/pkg/serviceregistry/kube/controller/fake.go
+++ b/pilot/pkg/serviceregistry/kube/controller/fake.go
@@ -159,7 +159,7 @@ func NewFakeControllerWithOptions(opts FakeControllerOptions) (*FakeController, 
 		Metrics:           &model.Environment{},
 		NetworksWatcher:   opts.NetworksWatcher,
 		EndpointMode:      opts.Mode,
-		ClusterID:         opts.ClusterID,
+		ClusterMeta:       kubelib.ClusterMeta{ID: opts.ClusterID},
 	}
 	c := NewController(opts.Client, options)
 	if opts.ServiceHandler != nil {

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -115,9 +115,9 @@ func (m *Multicluster) AddMemberCluster(clients kubelib.Client, key string, cm k
 		DomainSuffix:      m.DomainSuffix,
 		XDSUpdater:        m.XDSUpdater,
 		ClusterMeta:       cm,
-		NetworksWatcher: m.networksWatcher,
-		Metrics:         m.metrics,
-		EndpointMode:    m.endpointMode,
+		NetworksWatcher:   m.networksWatcher,
+		Metrics:           m.metrics,
+		EndpointMode:      m.endpointMode,
 	}
 	log.Infof("Initializing Kubernetes service registry %q", options.ClusterMeta.ID)
 	kubectl := NewController(clients, options)

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -150,7 +150,7 @@ func (m *Multicluster) AddMemberCluster(clients kubelib.Client, key string, cm k
 	return nil
 }
 
-func (m *Multicluster) UpdateMemberCluster(clients kubelib.Client, clusterID string, cm *kubelib.ClusterMeta) error {
+func (m *Multicluster) UpdateMemberCluster(clients kubelib.Client, clusterID string, cm kubelib.ClusterMeta) error {
 	if err := m.DeleteMemberCluster(clusterID); err != nil {
 		return err
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -103,7 +103,7 @@ func NewMulticluster(kc kubernetes.Interface, secretNamespace string, opts Optio
 // AddMemberCluster is passed to the secret controller as a callback to be called
 // when a remote cluster is added.  This function needs to set up all the handlers
 // to watch for resources being added, deleted or changed on remote clusters.
-func (m *Multicluster) AddMemberCluster(clients kubelib.Client, key string, cm *kubelib.ClusterMeta) error {
+func (m *Multicluster) AddMemberCluster(clients kubelib.Client, key string, cm kubelib.ClusterMeta) error {
 	// stopCh to stop controller created here when cluster removed.
 	stopCh := make(chan struct{})
 	var remoteKubeController kubeController
@@ -114,13 +114,12 @@ func (m *Multicluster) AddMemberCluster(clients kubelib.Client, key string, cm *
 		ResyncPeriod:      m.ResyncPeriod,
 		DomainSuffix:      m.DomainSuffix,
 		XDSUpdater:        m.XDSUpdater,
-		ClusterID:         cm.ID,
-		// TODO network or just the entire ClusterMeta
+		ClusterMeta:       cm,
 		NetworksWatcher: m.networksWatcher,
 		Metrics:         m.metrics,
 		EndpointMode:    m.endpointMode,
 	}
-	log.Infof("Initializing Kubernetes service registry %q", options.ClusterID)
+	log.Infof("Initializing Kubernetes service registry %q", options.ClusterMeta.ID)
 	kubectl := NewController(clients, options)
 
 	remoteKubeController.Controller = kubectl

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -60,6 +60,7 @@ type Multicluster struct {
 	endpointMode      EndpointMode
 
 	m                     sync.Mutex // protects remoteKubeControllers
+	clusterIDByKey        map[string]string
 	remoteKubeControllers map[string]*kubeController
 	networksWatcher       mesh.NetworksWatcher
 
@@ -74,8 +75,6 @@ type Multicluster struct {
 // It also starts the secret controller
 func NewMulticluster(kc kubernetes.Interface, secretNamespace string, opts Options,
 	serviceController *aggregate.Controller, xds model.XDSUpdater, networksWatcher mesh.NetworksWatcher) (*Multicluster, error) {
-
-	remoteKubeController := make(map[string]*kubeController)
 	if opts.ResyncPeriod == 0 {
 		// make sure a resync time of 0 wasn't passed in.
 		opts.ResyncPeriod = 30 * time.Second
@@ -87,7 +86,8 @@ func NewMulticluster(kc kubernetes.Interface, secretNamespace string, opts Optio
 		ResyncPeriod:          opts.ResyncPeriod,
 		serviceController:     serviceController,
 		XDSUpdater:            xds,
-		remoteKubeControllers: remoteKubeController,
+		clusterIDByKey:        make(map[string]string),
+		remoteKubeControllers: make(map[string]*kubeController),
 		networksWatcher:       networksWatcher,
 		metrics:               opts.Metrics,
 		fetchCaRoot:           opts.FetchCaRoot,
@@ -103,7 +103,7 @@ func NewMulticluster(kc kubernetes.Interface, secretNamespace string, opts Optio
 // AddMemberCluster is passed to the secret controller as a callback to be called
 // when a remote cluster is added.  This function needs to set up all the handlers
 // to watch for resources being added, deleted or changed on remote clusters.
-func (m *Multicluster) AddMemberCluster(clients kubelib.Client, clusterID string) error {
+func (m *Multicluster) AddMemberCluster(clients kubelib.Client, key string, cm *kubelib.ClusterMeta) error {
 	// stopCh to stop controller created here when cluster removed.
 	stopCh := make(chan struct{})
 	var remoteKubeController kubeController
@@ -114,10 +114,11 @@ func (m *Multicluster) AddMemberCluster(clients kubelib.Client, clusterID string
 		ResyncPeriod:      m.ResyncPeriod,
 		DomainSuffix:      m.DomainSuffix,
 		XDSUpdater:        m.XDSUpdater,
-		ClusterID:         clusterID,
-		NetworksWatcher:   m.networksWatcher,
-		Metrics:           m.metrics,
-		EndpointMode:      m.endpointMode,
+		ClusterID:         cm.ID,
+		// TODO network or just the entire ClusterMeta
+		NetworksWatcher: m.networksWatcher,
+		Metrics:         m.metrics,
+		EndpointMode:    m.endpointMode,
 	}
 	log.Infof("Initializing Kubernetes service registry %q", options.ClusterID)
 	kubectl := NewController(clients, options)
@@ -125,7 +126,8 @@ func (m *Multicluster) AddMemberCluster(clients kubelib.Client, clusterID string
 	remoteKubeController.Controller = kubectl
 	m.serviceController.AddRegistry(kubectl)
 
-	m.remoteKubeControllers[clusterID] = &remoteKubeController
+	m.clusterIDByKey[key] = cm.ID
+	m.remoteKubeControllers[cm.ID] = &remoteKubeController
 	m.m.Unlock()
 
 	// Only need to add service handler for kubernetes registry as `initRegistryEventHandlers`,
@@ -149,20 +151,21 @@ func (m *Multicluster) AddMemberCluster(clients kubelib.Client, clusterID string
 	return nil
 }
 
-func (m *Multicluster) UpdateMemberCluster(clients kubelib.Client, clusterID string) error {
+func (m *Multicluster) UpdateMemberCluster(clients kubelib.Client, clusterID string, cm *kubelib.ClusterMeta) error {
 	if err := m.DeleteMemberCluster(clusterID); err != nil {
 		return err
 	}
-	return m.AddMemberCluster(clients, clusterID)
+	return m.AddMemberCluster(clients, clusterID, cm)
 }
 
 // DeleteMemberCluster is passed to the secret controller as a callback to be called
 // when a remote cluster is deleted.  Also must clear the cache so remote resources
 // are removed.
-func (m *Multicluster) DeleteMemberCluster(clusterID string) error {
+func (m *Multicluster) DeleteMemberCluster(key string) error {
 
 	m.m.Lock()
 	defer m.m.Unlock()
+	clusterID := m.clusterIDByKey[key]
 	m.serviceController.DeleteRegistry(clusterID)
 	kc, ok := m.remoteKubeControllers[clusterID]
 	if !ok {
@@ -174,6 +177,7 @@ func (m *Multicluster) DeleteMemberCluster(clusterID string) error {
 	}
 	close(m.remoteKubeControllers[clusterID].stopCh)
 	delete(m.remoteKubeControllers, clusterID)
+	delete(m.clusterIDByKey, key)
 	if m.XDSUpdater != nil {
 		m.XDSUpdater.ConfigUpdate(&model.PushRequest{Full: true})
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/pod.go
+++ b/pilot/pkg/serviceregistry/kube/controller/pod.go
@@ -203,7 +203,7 @@ func (pc *PodCache) endpointDeleted(key string, ip string) {
 
 func (pc *PodCache) proxyUpdates(ip string) {
 	if pc.c != nil && pc.c.xdsUpdater != nil {
-		pc.c.xdsUpdater.ProxyUpdate(pc.c.clusterID, ip)
+		pc.c.xdsUpdater.ProxyUpdate(pc.c.ID, ip)
 	}
 }
 

--- a/pkg/kube/meta.go
+++ b/pkg/kube/meta.go
@@ -2,8 +2,8 @@ package kube
 
 import (
 	"context"
-
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"istio.io/pkg/log"
@@ -16,21 +16,12 @@ type ClusterMeta struct {
 
 // ClusterMetaFromConfigMap attempts to load the istio multicluster config to get overrides for cluster and network names.
 func ClusterMetaFromConfigMap(client kubernetes.Interface, namespace string) *ClusterMeta {
-	// TODO fix circular import for label const
 	log.Infof("looking for istio-cluster vm in namespace %s", namespace)
-	res, err := client.CoreV1().ConfigMaps(namespace).List(context.TODO(), v1.ListOptions{LabelSelector: "istio/multiCluster=true"})
+	cm, err := client.CoreV1().ConfigMaps(namespace).Get(context.TODO(), "istio-cluster", metaV1.GetOptions{})
 	if err != nil {
-		log.Errorf("failed fetching cluster meta configmap: %v", err)
+		log.Errorf("error fetching istio-cluster configmap: %v", err)
 		return nil
 	}
-	if len(res.Items) == 0 {
-		log.Errorf("no matching configmap: %v", err)
-		return nil
-	}
-	if len(res.Items) > 1 {
-		log.Warnf("multiple ConfigMaps with istio/multiCluster=true; using %s", res.Items[0].Name)
-	}
-	cm := res.Items[0]
 
 	return &ClusterMeta{ID: cm.Data["cluster"], Network: cm.Data["network"]}
 }

--- a/pkg/kube/meta.go
+++ b/pkg/kube/meta.go
@@ -1,0 +1,32 @@
+package kube
+
+import (
+	"context"
+	"istio.io/pkg/log"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type ClusterMeta struct {
+	ID      string
+	Network string
+}
+
+// ClusterMetaFromConfigMap attempts to load the istio multicluster config to get overrides for cluster and network names.
+func ClusterMetaFromConfigMap(client kubernetes.Interface, namespace string) *ClusterMeta {
+	// TODO fix circular import for label const
+	res, err := client.CoreV1().ConfigMaps(namespace).List(context.TODO(), v1.ListOptions{LabelSelector: "istio/multiCluster=true"})
+	if err != nil {
+		log.Errorf("failed fetching cluster meta configmap: %v", err)
+		return nil
+	}
+	if len(res.Items) == 0 {
+		return nil
+	}
+	if len(res.Items) > 1 {
+		log.Warnf("multiple ConfigMaps with istio/multiCluster=true; using %s", res.Items[0].Name)
+	}
+	cm := res.Items[0]
+
+	return &ClusterMeta{ID: cm.Data["cluster"], Network: cm.Data["network"]}
+}

--- a/pkg/kube/meta.go
+++ b/pkg/kube/meta.go
@@ -2,9 +2,11 @@ package kube
 
 import (
 	"context"
-	"istio.io/pkg/log"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+
+	"istio.io/pkg/log"
 )
 
 type ClusterMeta struct {

--- a/pkg/kube/meta.go
+++ b/pkg/kube/meta.go
@@ -1,8 +1,22 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package kube
 
 import (
 	"context"
-	
+
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 

--- a/pkg/kube/meta.go
+++ b/pkg/kube/meta.go
@@ -17,12 +17,14 @@ type ClusterMeta struct {
 // ClusterMetaFromConfigMap attempts to load the istio multicluster config to get overrides for cluster and network names.
 func ClusterMetaFromConfigMap(client kubernetes.Interface, namespace string) *ClusterMeta {
 	// TODO fix circular import for label const
+	log.Infof("looking for istio-cluster vm in namespace %s", namespace)
 	res, err := client.CoreV1().ConfigMaps(namespace).List(context.TODO(), v1.ListOptions{LabelSelector: "istio/multiCluster=true"})
 	if err != nil {
 		log.Errorf("failed fetching cluster meta configmap: %v", err)
 		return nil
 	}
 	if len(res.Items) == 0 {
+		log.Errorf("no matching configmap: %v", err)
 		return nil
 	}
 	if len(res.Items) > 1 {

--- a/pkg/kube/secretcontroller/secretcontroller.go
+++ b/pkg/kube/secretcontroller/secretcontroller.go
@@ -46,10 +46,10 @@ const (
 )
 
 // addSecretCallback prototype for the add secret callback function.
-type addSecretCallback func(clients kube.Client, dataKey string, cm *kube.ClusterMeta) error
+type addSecretCallback func(clients kube.Client, dataKey string, cm kube.ClusterMeta) error
 
 // updateSecretCallback prototype for the update secret callback function.
-type updateSecretCallback func(clients kube.Client, dataKey string, cm *kube.ClusterMeta) error
+type updateSecretCallback func(clients kube.Client, dataKey string, cm kube.ClusterMeta) error
 
 // removeSecretCallback prototype for the remove secret callback function.
 type removeSecretCallback func(dataKey string) error
@@ -348,9 +348,9 @@ func (c *Controller) deleteMemberCluster(secretName string) {
 	log.Infof("Number of remote clusters: %d", len(c.cs.remoteClusters))
 }
 
-func (c *Controller) clusterMetaOrDefault(clients kubernetes.Interface, defaultClusterID string) *kube.ClusterMeta {
+func (c *Controller) clusterMetaOrDefault(clients kubernetes.Interface, defaultClusterID string) kube.ClusterMeta {
 	if cm := kube.ClusterMetaFromConfigMap(clients, c.namespace); cm != nil {
-		return cm
+		return *cm
 	}
-	return &kube.ClusterMeta{ID: defaultClusterID}
+	return kube.ClusterMeta{ID: defaultClusterID}
 }

--- a/pkg/kube/secretcontroller/secretcontroller.go
+++ b/pkg/kube/secretcontroller/secretcontroller.go
@@ -77,7 +77,7 @@ type RemoteCluster struct {
 }
 
 // ClusterStore is a collection of clusters, keyed by a reliable key. The clusterID can be the same as the key, but
-// that is not guaranteed as it could be overriden by a ConfigMap.
+// that is not guaranteed as it could be overridden by a ConfigMap.
 type ClusterStore struct {
 	remoteClusters map[string]*RemoteCluster
 }

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"istio.io/pkg/log"
 	"net"
 	"os"
 	"path"
@@ -691,11 +692,12 @@ func createRemoteSecret(ctx resource.Context, cluster resource.Cluster, cfg Conf
 		"--namespace", cfg.SystemNamespace,
 	}
 
-	scopes.Framework.Infof("Creating remote secret for cluster cluster %s %v", cluster.Name(), cmd)
+	scopes.Framework.Infof("Creating remote secret for %s: %v", cluster.Name(), cmd)
 	out, _, err := istioCtl.Invoke(cmd)
 	if err != nil {
 		return "", fmt.Errorf("create remote secret failed for cluster %s: %v", cluster.Name(), err)
 	}
+	log.Infof("remote secret for %s:\n%s", cluster.Name(), out)
 	return out, nil
 }
 

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -511,6 +511,7 @@ func installRemoteCluster(i *operatorComponent, cfg Config, cluster resource.Clu
 		// It also sets up the "istio-cluster" ConfigMap that must exist before creating remote secrets, to give topology info
 		// to pilots discovering endpoints in this cluster.
 		baseInstallSettings := []string{
+			"--manifests", filepath.Join(testenv.IstioSrc, "manifests"),
 			"--set", "profile=remote",
 			"--set", "values.global.network=" + cluster.NetworkName(),
 			"--set", "values.global.multiCluster.clusterName=" + cluster.Name(),

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -510,7 +510,11 @@ func installRemoteCluster(i *operatorComponent, cfg Config, cluster resource.Clu
 		// Installing with only "base" component creates the ServiceAccount used to access the cluster via the remote secret.
 		// It also sets up the "istio-cluster" ConfigMap that must exist before creating remote secrets, to give topology info
 		// to pilots discovering endpoints in this cluster.
-		baseInstallSettings := append(installSettings, "--set", "profile=remote")
+		baseInstallSettings := []string{
+			"--set", "profile=remote",
+			"--set", "values.global.network=" + cluster.NetworkName(),
+			"--set", "values.global.multiCluster.clusterName=" + cluster.Name(),
+		}
 		if err := install(i, baseInstallSettings, istioCtl, cluster.Name()); err != nil {
 			return err
 		}


### PR DESCRIPTION
Proof of concept, needs cleanup. 

- On install (base component), create a configmap with cluster name and network from install values. 
- Setting up a remote cluster needs `base` installed before the remote secret is created. We might be able to deal with this by setting up a watch for the config map. 
- When creating a kube registry, read the config map to allow overriding cluster name and optionally overriding network name in a way that does not require updating values in every connected cluster. 

We might want to use this in injection as well for setting `ISTIO_META_CLUSTER_*` when that's not set via url values. 

This fixes tests that reach `naked` service in  [integ-pilot-multicluster-tests_istio](https://prow.istio.io/?repo=istio%2Fistio&pull=28035&job=integ-pilot-multicluster-tests_istio).