### PR TITLE
Add simulation tests for inbound traffic

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_simulation_test.go
@@ -595,24 +595,26 @@ func runGatewayTest(t *testing.T, cases ...simulationTest) {
 }
 
 func runSimulationTest(t *testing.T, proxy *model.Proxy, o xds.FakeOptions, tt simulationTest) {
-	o.ConfigString = tt.config
-	o.KubernetesObjectString = tt.kubeConfig
-	s := xds.NewFakeDiscoveryServer(t, o)
-	sim := simulation.NewSimulation(t, s, s.SetupProxy(proxy))
-	sim.RunExpectations(tt.calls)
-	if t.Failed() && debugMode {
-		t.Log(xdstest.MapKeys(xdstest.ExtractClusters(sim.Clusters)))
-		t.Log(xdstest.ExtractListenerNames(sim.Listeners))
-		t.Log(xdstest.DumpList(t, xdstest.InterfaceSlice(sim.Listeners)))
-		t.Log(xdstest.DumpList(t, xdstest.InterfaceSlice(sim.Routes)))
-		t.Log(tt.config)
-		t.Log(tt.kubeConfig)
-	}
-	if !tt.skipValidation {
-		xdstest.ValidateClusters(t, sim.Clusters)
-		xdstest.ValidateListeners(t, sim.Listeners)
-		xdstest.ValidateRouteConfigurations(t, sim.Routes)
-	}
+	t.Run(tt.name, func(t *testing.T) {
+		o.ConfigString = tt.config
+		o.KubernetesObjectString = tt.kubeConfig
+		s := xds.NewFakeDiscoveryServer(t, o)
+		sim := simulation.NewSimulation(t, s, s.SetupProxy(proxy))
+		sim.RunExpectations(tt.calls)
+		if t.Failed() && debugMode {
+			t.Log(xdstest.MapKeys(xdstest.ExtractClusters(sim.Clusters)))
+			t.Log(xdstest.ExtractListenerNames(sim.Listeners))
+			t.Log(xdstest.DumpList(t, xdstest.InterfaceSlice(sim.Listeners)))
+			t.Log(xdstest.DumpList(t, xdstest.InterfaceSlice(sim.Routes)))
+			t.Log(tt.config)
+			t.Log(tt.kubeConfig)
+		}
+		if !tt.skipValidation {
+			xdstest.ValidateClusters(t, sim.Clusters)
+			xdstest.ValidateListeners(t, sim.Listeners)
+			xdstest.ValidateRouteConfigurations(t, sim.Routes)
+		}
+	})
 }
 
 func createGateway(name, namespace string, servers ...string) string {


### PR DESCRIPTION
This will be used as regression testing for a change I will make to the inbound filter chains. Additionally, it captures a few bugs in the current filter chains