### PR TITLE
Add host ip interpretation into pilot agent

### DIFF
--- a/releasenotes/notes/zipkin-datadog-host-ip-interpretation.yaml
+++ b/releasenotes/notes/zipkin-datadog-host-ip-interpretation.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: telemetry
+issue:
+  - 27911
+releaseNotes:
+  - |
+    **Fixed** interpretation of $(HOST_IP) in Zipkin and Datadog tracer address.


### PR DESCRIPTION
This is to support some tracer setting (Datadog, Zipkin), where `$(HOST_IP)` is used for address. Tracer address used to be specified within proxy container params, and thus could be interpreted with pod HOST_IP env var. Now tracer config is passed in with mesh config volumn at gateway, k8s env var interpretation does not work. This is to achieve the same interpretation as k8s.

fix https://github.com/istio/istio/issues/27911 and fix https://github.com/istio/istio/issues/27016