### PR TITLE
Allow create-remote-secret to create istio-reader-service-account

### DIFF
--- a/istioctl/pkg/multicluster/cluster.go
+++ b/istioctl/pkg/multicluster/cluster.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/secretcontroller"
 	pkiutil "istio.io/istio/security/pkg/pki/util"
 )
@@ -43,7 +44,7 @@ type Cluster struct {
 	clusterName string
 	// TODO - differentiate NO_INSTALL, REMOTE, and MASTER
 	installed bool
-	client    kubernetes.Interface
+	client    kube.ExtendedClient
 }
 
 const (
@@ -68,7 +69,7 @@ func NewCluster(ctx string, desc ClusterDesc, env Environment) (*Cluster, error)
 		desc.ServiceAccountReader = constants.DefaultServiceAccountName
 	}
 
-	client, err := env.CreateClientSet(ctx)
+	client, err := env.CreateClient(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/istioctl/pkg/multicluster/cluster_test.go
+++ b/istioctl/pkg/multicluster/cluster_test.go
@@ -289,7 +289,7 @@ func TestReadRemoteSecrets(t *testing.T) {
 				reaction := func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
 					return true, nil, c.injectListFailure
 				}
-				env.client.PrependReactor("list", "secrets", reaction)
+				env.client.Kube().(*fake.Clientset).PrependReactor("list", "secrets", reaction)
 			}
 			got := cluster.readRemoteSecrets(env)
 			g.Expect(got).To(Equal(c.want))
@@ -500,14 +500,14 @@ func TestReadCACerts(t *testing.T) {
 				reaction := func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
 					return true, nil, c.listFailure
 				}
-				env.client.PrependReactor("list", "secrets", reaction)
+				env.client.Kube().(*fake.Clientset).PrependReactor("list", "secrets", reaction)
 			}
 
 			if c.getFailure != nil {
 				reaction := func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
 					return true, nil, c.getFailure
 				}
-				env.client.PrependReactor("get", "secrets", reaction)
+				env.client.Kube().(*fake.Clientset).PrependReactor("get", "secrets", reaction)
 			}
 
 			got := cluster.readCACerts(env)

--- a/istioctl/pkg/multicluster/env.go
+++ b/istioctl/pkg/multicluster/env.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd/api"
 
 	"istio.io/istio/pkg/kube"
@@ -32,7 +31,7 @@ type ConditionFunc func() (done bool, err error)
 
 type Environment interface {
 	GetConfig() *api.Config
-	CreateClientSet(context string) (kubernetes.Interface, error)
+	CreateClient(context string) (kube.ExtendedClient, error)
 	Stdout() io.Writer
 	Stderr() io.Writer
 	ReadFile(filename string) ([]byte, error)
@@ -48,8 +47,12 @@ type KubeEnvironment struct {
 	kubeconfig string
 }
 
-func (e *KubeEnvironment) CreateClientSet(context string) (kubernetes.Interface, error) {
-	return kube.CreateClientset(e.kubeconfig, context)
+func (e *KubeEnvironment) CreateClient(context string) (kube.ExtendedClient, error) {
+	cfg, err := kube.BuildClientConfig(e.kubeconfig, context)
+	if err != nil {
+		return nil, err
+	}
+	return kube.NewExtendedClient(kube.NewClientConfigForRestConfig(cfg), "")
 }
 
 func (e *KubeEnvironment) Printf(format string, a ...interface{}) {

--- a/istioctl/pkg/multicluster/remote_secret.go
+++ b/istioctl/pkg/multicluster/remote_secret.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -29,15 +30,17 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/runtime/serializer/versioning"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/kubernetes"
 
 	//  to avoid 'No Auth Provider found for name "gcp"'
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/tools/clientcmd/api/latest"
 
+	"istio.io/istio/operator/cmd/mesh"
+	"istio.io/istio/operator/pkg/helm"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/labels"
+	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/kube/secretcontroller"
 )
 
@@ -222,21 +225,126 @@ func createRemoteSecretFromTokenAndServer(tokenSecret *v1.Secret, clusterName, s
 	return createRemoteServiceAccountSecret(kubeconfig, clusterName, secName)
 }
 
-func getServiceAccountSecret(kube kubernetes.Interface, saName, saNamespace string) (*v1.Secret, error) {
-	serviceAccount, err := kube.CoreV1().ServiceAccounts(saNamespace).Get(context.TODO(), saName, metav1.GetOptions{})
+func getServiceAccountSecret(client kube.ExtendedClient, opt RemoteSecretOptions) (*v1.Secret, error) {
+	// Create the service account if it doesn't exist.
+	serviceAccount, err := getOrCreateServiceAccount(client, opt)
 	if err != nil {
 		return nil, err
 	}
+
 	if len(serviceAccount.Secrets) != 1 {
 		return nil, fmt.Errorf("wrong number of secrets (%v) in serviceaccount %s/%s",
-			len(serviceAccount.Secrets), saNamespace, saName)
+			len(serviceAccount.Secrets), opt.Namespace, opt.ServiceAccountName)
 	}
+
 	secretName := serviceAccount.Secrets[0].Name
 	secretNamespace := serviceAccount.Secrets[0].Namespace
 	if secretNamespace == "" {
-		secretNamespace = saNamespace
+		secretNamespace = opt.Namespace
 	}
-	return kube.CoreV1().Secrets(secretNamespace).Get(context.TODO(), secretName, metav1.GetOptions{})
+	return client.CoreV1().Secrets(secretNamespace).Get(context.TODO(), secretName, metav1.GetOptions{})
+}
+
+func getOrCreateServiceAccount(client kube.ExtendedClient, opt RemoteSecretOptions) (*v1.ServiceAccount, error) {
+	if sa, err := client.CoreV1().ServiceAccounts(opt.Namespace).Get(
+		context.TODO(), opt.ServiceAccountName, metav1.GetOptions{}); err == nil {
+		return sa, nil
+	} else if !opt.CreateServiceAccount {
+		// User chose not to automatically create the service account.
+		return nil, fmt.Errorf("failed retrieving service account %s.%s required for creating "+
+			"the remote secret (hint: try installing a minimal Istio profile on the cluster first, "+
+			"or run with '--create-service-account=true'): %v",
+			opt.ServiceAccountName,
+			opt.Namespace,
+			err)
+	}
+
+	if err := createServiceAccount(client, opt); err != nil {
+		return nil, err
+	}
+
+	// Return the newly created service account.
+	sa, err := client.CoreV1().ServiceAccounts(opt.Namespace).Get(
+		context.TODO(), opt.ServiceAccountName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed retrieving service account %s.%s after creating it: %v",
+			opt.ServiceAccountName, opt.Namespace, err)
+	}
+	return sa, nil
+}
+
+func createServiceAccount(client kube.ExtendedClient, opt RemoteSecretOptions) error {
+	// Create a renderer for the base installation.
+	r, err := helm.NewHelmRenderer(opt.ManifestsPath, "base", "Base", opt.Namespace)
+	if err != nil {
+		return fmt.Errorf("failed creating Helm renderer: %v", err)
+	}
+
+	if err := r.Run(); err != nil {
+		return fmt.Errorf("failed running Helm renderer: %v", err)
+	}
+
+	values := fmt.Sprintf(`
+global:
+  istioNamespace: %s
+  istiod:
+    enableAnalysis: false
+  configValidation: false
+base:
+  enableCRDTemplates: false
+`, opt.Namespace)
+
+	yamlContent, err := r.RenderManifest(values)
+	if err != nil {
+		return fmt.Errorf("failed rendering base manifest: %v", err)
+	}
+
+	// Before we can apply the yaml, we have to ensure the system namespace exists.
+	if err := createNamespaceIfNotExist(client, opt.Namespace); err != nil {
+		return err
+	}
+
+	// Apply the YAML to the cluster.
+	return applyYAML(client, yamlContent, opt.Namespace)
+}
+
+func applyYAML(client kube.ExtendedClient, yamlContent, ns string) error {
+	yamlFile, err := writeToTempFile(yamlContent)
+	if err != nil {
+		return fmt.Errorf("failed creating manifest file: %v", err)
+	}
+
+	// Apply the YAML to the cluster.
+	if err := client.ApplyYAMLFiles(ns, yamlFile); err != nil {
+		return fmt.Errorf("failed applying manifest %s: %v", yamlFile, err)
+	}
+	return nil
+}
+
+func createNamespaceIfNotExist(client kube.Client, ns string) error {
+	if _, err := client.CoreV1().Namespaces().Get(context.TODO(), ns, metav1.GetOptions{}); err != nil {
+		if _, err := client.CoreV1().Namespaces().Create(context.TODO(), &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ns,
+			},
+		}, metav1.CreateOptions{}); err != nil {
+			return fmt.Errorf("failed creating namespace %s: %v", ns, err)
+		}
+	}
+	return nil
+}
+
+func writeToTempFile(content string) (string, error) {
+	outFile, err := ioutil.TempFile("", "remote-secret-manifest-*")
+	if err != nil {
+		return "", fmt.Errorf("failed creating temp file for manifest: %v", err)
+	}
+	defer func() { _ = outFile.Close() }()
+
+	if _, err := outFile.Write([]byte(content)); err != nil {
+		return "", fmt.Errorf("failed writing manifest file: %v", err)
+	}
+	return outFile.Name(), nil
 }
 
 func getServerFromKubeconfig(context string, config *api.Config) (string, error) {
@@ -329,6 +437,10 @@ type RemoteSecretOptions struct {
 	// Create a secret with this service account's credentials.
 	ServiceAccountName string
 
+	// CreateServiceAccount if true, the service account specified by ServiceAccountName
+	// will be created if it doesn't exist.
+	CreateServiceAccount bool
+
 	// Authentication method for the remote Kubernetes cluster.
 	AuthType RemoteSecretAuthType
 	// Authenticator plugin configuration
@@ -337,13 +449,21 @@ type RemoteSecretOptions struct {
 
 	// Type of the generated secret
 	Type SecretType
+
+	// ManifestsPath is a path to a manifestsPath and profiles directory in the local filesystem,
+	// or URL with a release tgz. This is only used when no reader service account exists and has
+	// to be created.
+	ManifestsPath string
 }
 
 func (o *RemoteSecretOptions) addFlags(flagset *pflag.FlagSet) {
 	flagset.StringVar(&o.ServiceAccountName, "service-account", "",
 		"Create a secret with this service account's credentials. Use \""+
 			constants.DefaultServiceAccountName+"\" as default value if --type is \"remote\", use \""+
-			constants.DefaultConfigServiceAccountName+"\" as default value if --type is \"config\"")
+			constants.DefaultConfigServiceAccountName+"\" as default value if --type is \"config\".")
+	flagset.BoolVar(&o.CreateServiceAccount, "create-service-account", true,
+		"If true, the service account needed for creating the remote secret will be created "+
+			"if it doesn't exist.")
 	flagset.StringVar(&o.ClusterName, "name", "",
 		"Name of the local cluster whose credentials are stored "+
 			"in the secret. If a name is not specified the kube-system namespace's UUID of "+
@@ -367,6 +487,8 @@ func (o *RemoteSecretOptions) addFlags(flagset *pflag.FlagSet) {
 			RemoteSecretAuthTypePlugin))
 	flagset.Var(&o.Type, "type",
 		fmt.Sprintf("Type of the generated secret. supported values = %v", supportedSecretType))
+	flagset.StringVarP(&o.ManifestsPath, "manifests", "d", "", mesh.ManifestsFlagHelpStr)
+
 }
 
 func (o *RemoteSecretOptions) prepare(flags *pflag.FlagSet) error {
@@ -380,7 +502,7 @@ func (o *RemoteSecretOptions) prepare(flags *pflag.FlagSet) error {
 	return nil
 }
 
-func createRemoteSecret(opt RemoteSecretOptions, client kubernetes.Interface, env Environment) (*v1.Secret, error) {
+func createRemoteSecret(opt RemoteSecretOptions, client kube.ExtendedClient, env Environment) (*v1.Secret, error) {
 	// generate the clusterName if not specified
 	if opt.ClusterName == "" {
 		uid, err := clusterUID(client)
@@ -405,7 +527,7 @@ func createRemoteSecret(opt RemoteSecretOptions, client kubernetes.Interface, en
 	default:
 		return nil, fmt.Errorf("unsupported type: %v", opt.Type)
 	}
-	tokenSecret, err := getServiceAccountSecret(client, opt.ServiceAccountName, opt.Namespace)
+	tokenSecret, err := getServiceAccountSecret(client, opt)
 	if err != nil {
 		return nil, fmt.Errorf("could not get access token to read resources from local kube-apiserver: %v", err)
 	}
@@ -440,7 +562,7 @@ func createRemoteSecret(opt RemoteSecretOptions, client kubernetes.Interface, en
 // CreateRemoteSecret creates a remote secret with credentials of the specified service account.
 // This is useful for providing a cluster access to a remote apiserver.
 func CreateRemoteSecret(opt RemoteSecretOptions, env Environment) (string, error) {
-	client, err := env.CreateClientSet(opt.Context)
+	client, err := env.CreateClient(opt.Context)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -184,7 +184,7 @@ var _ ExtendedClient = &client{}
 const resyncInterval = 0
 
 // NewFakeClient creates a new, fake, client
-func NewFakeClient(objects ...runtime.Object) Client {
+func NewFakeClient(objects ...runtime.Object) ExtendedClient {
 	var c client
 	c.Interface = fake.NewSimpleClientset(objects...)
 	c.kube = c.Interface


### PR DESCRIPTION
Currently, creation of a remote secret requires that the istio-reader-service-account has been installed on the remote cluster. This will fail if we haven't already installed Istio on the remote cluster.

Conversely, the installation of Istio on the remote cluster requires that the primary cluster has already been given its remote secret. If this doesn't happen, Istio workloads (e.g. istio-ingressgateway) will never be able to start because the control plane in the primary cluster will reject the requests.

This creates a chicken-or-the-egg problem which makes installation difficult.

With this change, we can modify the installation flow for remote clusters to the following:

1) Install Istio on primary cluster
2) Create remote secret and install in primary cluster
3) Install Istio on remote cluster

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
