### PR TITLE
kube-inject: hide namespace flag in favour of istioNamespace

### DIFF
--- a/istioctl/cmd/root.go
+++ b/istioctl/cmd/root.go
@@ -172,7 +172,10 @@ debug and diagnose their Istio mesh.
 	rootCmd.AddCommand(registerCmd)
 	deprecate(deregisterCmd)
 	rootCmd.AddCommand(deregisterCmd)
-	rootCmd.AddCommand(injectCommand())
+
+	kubeInjectCmd := injectCommand()
+	hideInheritedFlags(kubeInjectCmd, "namespace")
+	rootCmd.AddCommand(kubeInjectCmd)
 
 	postInstallCmd := &cobra.Command{
 		Use:   "post-install",


### PR DESCRIPTION
Attempt to fix https://github.com/istio/istio/issues/28005

Based on @linsun comments

> I recommend us enhance it to search for sidecar innjector cm in the -n ns.