### PR TITLE
configurable logging in operator chart

### DIFF
--- a/manifests/charts/istio-operator/templates/deployment.yaml
+++ b/manifests/charts/istio-operator/templates/deployment.yaml
@@ -20,6 +20,12 @@ spec:
           command:
           - operator
           - server
+        {{- if .Values.global.logging.level }}
+          - --log_output_level={{ .Values.global.logging.level }}
+        {{- end}}
+        {{- if .Values.global.logAsJson }}
+          - --log_as_json
+        {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/manifests/charts/istio-operator/values.yaml
+++ b/manifests/charts/istio-operator/values.yaml
@@ -1,3 +1,13 @@
+
+global:
+  # To output all istio components logs in json format by adding --log_as_json argument to each container argument
+  logAsJson: false
+  # Comma-separated minimum per-scope logging level of messages to output, in the form of <scope>:<level>,<scope>:<level>
+  # The control plane has different scopes depending on component, but can configure default log level across all components
+  # If empty, default scope and level will be used as configured in code
+  logging:
+    level: "default:info"
+
 hub: gcr.io/istio-testing
 tag: latest
 


### PR DESCRIPTION
Allow configuring the log level and format via operator chart. This align this section in the configuration with all other istio charts as the operator is the only chart that does not have it.

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

To change log level, modify `global.logging.level` in chart values:
```yaml
global:
  logging:
    level: "default:error"
```
To enable json output for logger, set the `logAsJson` flag to `true`:
```yaml
global:
  logAsJson: true
```