### PR TITLE
Add OpenShift install profile

### DIFF
--- a/manifests/profiles/openshift.yaml
+++ b/manifests/profiles/openshift.yaml
@@ -1,0 +1,20 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  components:
+    cni:
+      enabled: true
+      namespace: kube-system
+  values:
+    cni:
+      cniBinDir: /var/lib/cni/bin
+      cniConfDir: /etc/cni/multus/net.d
+      chained: false
+      cniConfFileName: "istio-cni.conf"
+      excludeNamespaces:
+       - istio-system
+       - kube-system
+      logLevel: info
+    sidecarInjectorWebhook:
+      injectedAnnotations:
+        k8s.v1.cni.cncf.io/networks: istio-cni


### PR DESCRIPTION
Adds an install profile to help users install Istio on an OpenShift platform.

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

[x] Does not have any changes that may affect Istio users.
