### PR TITLE
istioctl upgrade: simplify upgrade error message

### DIFF
--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -438,13 +438,13 @@ func (client *Client) GetIstioVersions(namespace string) ([]ComponentVersion, er
 			if pv == "" {
 				pv = cv
 			} else if pv != cv {
-				err := fmt.Errorf("differrent versions of containers in the same pod: %v", pod.Spec.Containers)
+				err := fmt.Errorf("differrent versions of containers in the same pod: %v", pod.Name)
 				errs = util.AppendErr(errs, err)
 			}
 		}
 		server.Version, err = pkgversion.TagToVersionString(pv)
 		if err != nil {
-			tagErr := fmt.Errorf("unable to convert tag %s into version in pod: %v", pv, pod.Spec.Containers[0].Name)
+			tagErr := fmt.Errorf("unable to convert tag %s into version in pod: %v", pv, pod.Name)
 			errs = util.AppendErr(errs, tagErr)
 		}
 		res = append(res, server)

--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -444,7 +444,7 @@ func (client *Client) GetIstioVersions(namespace string) ([]ComponentVersion, er
 		}
 		server.Version, err = pkgversion.TagToVersionString(pv)
 		if err != nil {
-			tagErr := fmt.Errorf("unable to convert tag %s into version in pod: %v", pv, pod.Spec.Containers)
+			tagErr := fmt.Errorf("unable to convert tag %s into version in pod: %v", pv, pod.Spec.Containers[0].Name)
 			errs = util.AppendErr(errs, tagErr)
 		}
 		res = append(res, server)


### PR DESCRIPTION
Part of https://github.com/istio/istio/issues/26775

Before:
```
$ istioctl install --set hub=gcr.io/istio-testing --set tag=latest
```
```
$ istioctl upgrade
2020-08-24T18:22:46.801539Z	info	Error: failed to read the current Istio version,
error: failed to retrieve Istio control plane version, error: unable to convert tag latest into version in pod: [{istio-proxy gcr.io/istio-testing/proxyv2:latest [] [proxy router --domain $(POD_NAMESPACE).svc.cluster.local 
--proxyLogLevel=warning --proxyComponentLogLevel=misc:error --log_output_level=default:info --serviceCluster istio-ingressgateway --trust-domain=cluster.local]  [{ 0 15021 TCP } { 0 8080 TCP } { 0 8443 TCP } { 0 15443 TCP } {http-envoy-prom 0 15090 TCP }] [] [{JWT_POLICY third-party-jwt nil} {PILOT_CERT_PROVIDER istiod nil} {CA_ADDR istiod.istio-system.svc:15012 nil} {NODE_NAME  
&EnvVarSource{FieldRef:&ObjectFieldSelector{APIVersion:v1,FieldPath:spec.nodeName,},ResourceFieldRef:nil,ConfigMapKeyRef:nil,SecretKeyRef:nil,}} {POD_NAME  &EnvVarSource{FieldRef:&ObjectFieldSelector{APIVersion:v1,FieldPath:metadata.name,},ResourceFieldRef:nil,ConfigMapKeyRef:nil,SecretKeyRef:nil,}} {POD_NAMESPACE  
&EnvVarSource{FieldRef:&ObjectFieldSelector{APIVersion:v1,FieldPath:metadata.namespace,},ResourceFieldRef:nil,ConfigMapKeyRef:nil,SecretKeyRef:nil,}} {INSTANCE_IP  
&EnvVarSource{FieldRef:&ObjectFieldSelector{APIVersion:v1,FieldPath:status.podIP,},ResourceFieldRef:nil,ConfigMapKeyRef:nil,SecretKeyRef:nil,}} {HOST_IP  
&EnvVarSource{FieldRef:&ObjectFieldSelector{APIVersion:v1,FieldPath:status.hostIP,},ResourceFieldRef:nil,ConfigMapKeyRef:nil,SecretKeyRef:nil,}} {SERVICE_ACCOUNT  
&EnvVarSource{FieldRef:&ObjectFieldSelector{APIVersion:v1,FieldPath:spec.serviceAccountName,},ResourceFieldRef:nil,ConfigMapKeyRef:nil,SecretKeyRef:nil,}} {CANONICAL_SERVICE  
&EnvVarSource{FieldRef:&ObjectFieldSelector{APIVersion:v1,FieldPath:metadata.labels['service.istio.io/canonical-name'],},ResourceFieldRef:nil,ConfigMapKeyRef:nil,SecretKeyRef:nil,}} {CANONICAL_REVISION  
&EnvVarSource{FieldRef:&ObjectFieldSelector{APIVersion:v1,FieldPath:metadata.labels['service.istio.io/canonical-revision'],},ResourceFieldRef:nil,ConfigMapKeyRef:nil,SecretKeyRef:nil,}} {ISTIO_META_WORKLOAD_NAME istio-ingressgateway nil} {ISTIO_META_OWNER kubernetes://apis/apps/v1/namespaces/istio-system/deployments/istio-ingressgateway nil} {ISTIO_META_MESH_ID cluster.local nil} {ISTIO_META_ROUTER_MODE sni-dnat nil} 
{ISTIO_META_CLUSTER_ID Kubernetes nil}] {map[cpu:{{2 0} {<nil>} 2 DecimalSI} memory:{{1073741824 0} {<nil>} 1Gi BinarySI}] map[cpu:{{100 -3} {<nil>} 100m DecimalSI} memory:{{134217728 0} {<nil>}  BinarySI}]} [{istio-envoy false /etc/istio/proxy  <nil> } {config-volume false /etc/istio/config  <nil> } {istiod-ca-cert false /var/run/secrets/istio  <nil> } {istio-token true /var/run/secrets/tokens  <nil> } {gatewaysdsudspath false /var/run/ingress_gateway  <nil> } {podinfo false /etc/istio/pod  <nil> } {ingressgateway-certs true /etc/istio/ingressgateway-certs  <nil> } {ingressgateway-ca-certs true /etc/istio/ingressgateway-ca-certs  <nil> } {istio-ingressgateway-service-account-token-dhp8f true /var/run/secrets/kubernetes.io/serviceaccount  <nil> }] [] nil 
&Probe{Handler:Handler{Exec:nil,HTTPGet:&HTTPGetAction{Path:/healthz/ready,Port:{0 15021 },Host:,Scheme:HTTP,HTTPHeaders:[]HTTPHeader{},},TCPSocket:nil,},InitialDelaySeconds:1,TimeoutSeconds:1,PeriodSeconds:2,SuccessThreshold:1,FailureThreshold:30,} nil nil /dev/termination-log File Always &SecurityContext{Capabilities:&Capabilities{Add:[],Drop:[ALL],},Privileged:*false,SELinuxOptions:nil,RunAsUser:nil,RunAsNonRoot:nil,ReadOnlyRootFilesystem:*true,AllowPrivilegeEscalation:*false,RunAsGroup:nil,ProcMount:nil,WindowsOptions:nil,} false false false}], unable to convert tag latest into version in pod: [{discovery gcr.io/istio-testing/pilot:latest [] [discovery --monitoringAddr=:15014 --log_output_level=default:info --domain cluster.local --trust-domain=cluster.local --keepaliveMaxServerConnectionAge 30m]  [{ 0 8080 TCP } { 0 15010 TCP } { 0 15017 TCP } { 0 15053 TCP }] [] [{REVISION default nil} {JWT_POLICY third-party-jwt nil} {PILOT_CERT_PROVIDER istiod nil} {POD_NAME  &EnvVarSource{FieldRef:&ObjectFieldSelector{APIVersion:v1,FieldPath:metadata.name,},ResourceFieldRef:nil,ConfigMapKeyRef:nil,SecretKeyRef:nil,}} {POD_NAMESPACE  &EnvVarSource{FieldRef:&ObjectFieldSelector{APIVersion:v1,FieldPath:metadata.namespace,},ResourceFieldRef:nil,ConfigMapKeyRef:nil,SecretKeyRef:nil,}} {SERVICE_ACCOUNT  &EnvVarSource{FieldRef:&ObjectFieldSelector{APIVersion:v1,FieldPath:spec.serviceAccountName,},ResourceFieldRef:nil,ConfigMapKeyRef:nil,SecretKeyRef:nil,}} {KUBECONFIG /var/run/secrets/remote/config nil} {PILOT_TRACE_SAMPLING 1 nil} {PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_OUTBOUND true nil} {PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND true nil} {INJECTION_WEBHOOK_CONFIG_NAME istio-sidecar-injector nil} {ISTIOD_ADDR istiod.istio-system.svc:15012 nil} {PILOT_ENABLE_ANALYSIS true nil} {CLUSTER_ID Kubernetes nil} {CENTRAL_ISTIOD false nil}] {map[] map[cpu:{{500 -3} {<nil>} 500m DecimalSI} memory:{{2147483648 0} {<nil>} 2Gi BinarySI}]} [{config-volume false /etc/istio/config  <nil> } {istio-token true /var/run/secrets/tokens  <nil> } {local-certs false /var/run/secrets/istio-dns  <nil> } {cacerts true /etc/cacerts  <nil> } {istio-kubeconfig true /var/run/secrets/remote  <nil> } {inject true /var/lib/istio/inject  <nil> } {istiod-service-account-token-ss5hx true /var/run/secrets/kubernetes.io/serviceaccount  <nil> }] [] nil &Probe{Handler:Handler{Exec:nil,HTTPGet:&HTTPGetAction{Path:/ready,Port:{0 8080 },Host:,Scheme:HTTP,HTTPHeaders:[]HTTPHeader{},},TCPSocket:nil,},InitialDelaySeconds:1,TimeoutSeconds:5,PeriodSeconds:3,SuccessThreshold:1,FailureThreshold:3,} nil nil /dev/termination-log File Always &SecurityContext{Capabilities:&Capabilities{Add:[],Drop:[ALL],},Privileged:nil,SELinuxOptions:nil,RunAsUser:*1337,RunAsNonRoot:*true,ReadOnlyRootFilesystem:nil,AllowPrivilegeEscalation:nil,RunAsGroup:*1337,ProcMount:nil,WindowsOptions:nil,} false false false}]
```

After:
```
$ ./out/linux_amd64/istioctl upgrade --set hub=gcr.io/istio-testing -d manifests/
2020-10-20T15:37:26.439181Z     info    proto: tag has too few fields: "-"
2020-10-20T15:37:26.515009Z     info    Error: failed to read the current Istio version, error: failed to retrieve Istio control plane version, error: unable to convert tag latest into version in pod: istio-ingressgateway-788c5b5b6d-6slkp, unable to convert tag latest into version in pod: istiod-7b68df49d9-z2vgh

Error: failed to read the current Istio version, error: failed to retrieve Istio control plane version, 
error: unable to convert tag latest into version in pod: istio-ingressgateway-788c5b5b6d-6slkp, 
unable to convert tag latest into version in pod: istiod-7b68df49d9-z2vgh
```