### PR TITLE
fix multicluster vm test

### DIFF
--- a/tests/integration/pilot/common/apps.go
+++ b/tests/integration/pilot/common/apps.go
@@ -188,7 +188,7 @@ func SetupApps(ctx resource.Context, i istio.Instance, apps *EchoDeployments) er
 			Namespace:      apps.Namespace,
 			Ports:          EchoPorts,
 			DeployAsVM:     true,
-			AutoRegisterVM: true,
+			AutoRegisterVM: false, // TODO support auto-registration with multi-primary
 			Subsets:        []echo.SubsetConfig{{}},
 			Cluster:        c[0],
 		})


### PR DESCRIPTION
Setting this value breaks the VM tests in the multi-cluster pilot job. Due to this setting, WorkloadEntries aren't created in all clusters, only the ones that the agent connects to. 

In the future we will need to improve auto-registration to be compatible with multi-primary multicluster. 