### PR TITLE
[release-1.7] Manual cherry-pick: skip Ingress test on unsupported k8s versions (#25853)

### DIFF
--- a/tests/integration/pilot/ingress/ingress_test.go
+++ b/tests/integration/pilot/ingress/ingress_test.go
@@ -158,11 +158,23 @@ spec:
 		})
 }
 
+func skipIfIngressClassUnsupported(ctx framework.TestContext) {
+	ver, err := ctx.Clusters().Default().GetKubernetesVersion()
+	if err != nil {
+		ctx.Fatalf("failed to get Kubernetes version: %v", err)
+	}
+	serverVersion := fmt.Sprintf("%s.%s", ver.Major, ver.Minor)
+	if serverVersion < "1.18" {
+		ctx.Skip("IngressClass not supported")
+	}
+}
+
 // TestIngress tests that we can route using standard Kubernetes Ingress objects.
 func TestIngress(t *testing.T) {
 	framework.
 		NewTest(t).
 		Run(func(ctx framework.TestContext) {
+			skipIfIngressClassUnsupported(ctx)
 			ns := namespace.NewOrFail(t, ctx, namespace.Config{
 				Prefix: "ingress",
 				Inject: true,


### PR DESCRIPTION
Resolve: https://github.com/istio/istio/issues/28113

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.