### PR TITLE
Update fake-stackdriver to the one used in istio/proxy release-1.6

### DIFF
--- a/pkg/test/framework/components/stackdriver/stackdriver.yaml
+++ b/pkg/test/framework/components/stackdriver/stackdriver.yaml
@@ -41,7 +41,7 @@ spec:
         app: stackdriver
     spec:
       containers:
-      - image: gcr.io/istio-testing/fake-stackdriver:2.0
+      - image: gcr.io/istio-testing/fake-stackdriver:3.0
         imagePullPolicy: Always
         name: stackdriver
         ports:


### PR DESCRIPTION
See
https://github.com/istio/proxy/blob/release-1.6/test/envoye2e/stackdriver_plugin/cmd/Makefile#L21



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[X] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.