### PR TITLE
Add 'secrets' alias to 'istioctl proxy-config secret' command

### DIFF
--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -730,7 +730,7 @@ func secretConfigCmd() *cobra.Command {
   # Retrieve full bootstrap without using Kubernetes API
   ssh <user@hostname> 'curl localhost:15000/config_dump' > envoy-config.json
   istioctl proxy-config secret --file envoy-config.json`,
-		Aliases: []string{"s"},
+		Aliases: []string{"secrets", "s"},
 		Args: func(cmd *cobra.Command, args []string) error {
 			if (len(args) == 1) != (configDumpFile == "") {
 				cmd.Println(cmd.UsageString())


### PR DESCRIPTION
Makes it possible to do `istioctl proxy-config secrets ...`

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[x] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
