### PR TITLE
[release-1.7] Bump the build image

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -22,7 +22,7 @@ SHELL := /bin/bash -o pipefail
 VERSION ?= 1.7-dev
 
 # Base version of Istio image to use
-BASE_VERSION ?= 1.7-dev.6
+BASE_VERSION ?= 1.7-dev.8
 
 export GO111MODULE ?= on
 export GOPROXY ?= https://proxy.golang.org


### PR DESCRIPTION
I bumped the image 2 values since a prior version, dev.7, had vulnerabilities and I'm not sure how long the scanner would hold on to those results.