### PR TITLE
Support more than one deployment per cluster

### DIFF
--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -284,6 +284,7 @@ func (c *Config) String() string {
 	result += fmt.Sprintf("IOPFile:                        %s\n", c.IOPFile)
 	result += fmt.Sprintf("SkipWaitForValidationWebhook:   %v\n", c.SkipWaitForValidationWebhook)
 	result += fmt.Sprintf("CustomSidecarInjectorNamespace: %s\n", c.CustomSidecarInjectorNamespace)
+	result += fmt.Sprintf("ControlPlaneValues:             \"%s\"\n", c.ControlPlaneValues)
 
 	return result
 }


### PR DESCRIPTION
Save all manifests used for deployments instead of having only
the last one.

Also dump all manifests used when a test fails.
