### PR TITLE
Show empty routes in pc routes

### DIFF
--- a/istioctl/pkg/writer/envoy/configdump/route.go
+++ b/istioctl/pkg/writer/envoy/configdump/route.go
@@ -70,6 +70,13 @@ func (c *ConfigWriter) PrintRouteSummary(filter RouteFilter) error {
 								describeManagement(r.GetMetadata()))
 						}
 					}
+					if len(vhosts.Routes) == 0 {
+						fmt.Fprintf(w, "%v\t%s\t%s\t%s\n",
+							route.Name,
+							describeRouteDomains(vhosts.GetDomains()),
+							"/*",
+							"404")
+					}
 				}
 			} else {
 				fmt.Fprintf(w, "%v\t%v\n", route.Name, len(route.GetVirtualHosts()))


### PR DESCRIPTION
```
NOTE: This output only contains routes loaded via RDS.
NAME                                                                                                     DOMAINS                      MATCH                  VIRTUAL SERVICE
https.443.https-443-ingress-service1-default-0.service1-istio-autogenerated-k8s-ingress.istio-system     *                            /*                     404
https.443.https-443-ingress-service2-default-0.service2-istio-autogenerated-k8s-ingress.istio-system     *                            /*                     404
http.80                                                                                                  service1.demo.........io     /*                     service1-demo-......-io-service1-istio-autogenerated-k8s-ingress.default
http.80                                                                                                  service2.demo.........io     /*                     service2-demo-.....i-io-service2-istio-autogenerated-k8s-ingress.default
                                                                                                         *                            /stats/prometheus*
                                                                                                         *                            /healthz/ready*
```

The first 2 lines would not show up without this PR


I put cherrypick since this is a regression from #27746