### PR TITLE
Add support for applications listening on Pod IP

### DIFF
--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -27,6 +27,7 @@ import (
 // UnixAddressPrefix is the prefix used to indicate an address is for a Unix Domain socket. It is used in
 // ServiceEntry.Endpoint.Address message.
 const UnixAddressPrefix = "unix://"
+const PodIpAddressPrefix = "0.0.0.0"
 
 // Validate ensures that the service object is well-defined
 func (s *Service) Validate() error {

--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -27,7 +27,7 @@ import (
 // UnixAddressPrefix is the prefix used to indicate an address is for a Unix Domain socket. It is used in
 // ServiceEntry.Endpoint.Address message.
 const UnixAddressPrefix = "unix://"
-const PodIpAddressPrefix = "0.0.0.0"
+const PodIPAddressPrefix = "0.0.0.0"
 
 // Validate ensures that the service object is well-defined
 func (s *Service) Validate() error {

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -311,6 +311,7 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusters(cb *ClusterBuilder, i
 			endpointAddress := actualLocalHost
 			port := 0
 			var err error
+			instanceIpCluster := false
 			if strings.HasPrefix(ingressListener.DefaultEndpoint, model.UnixAddressPrefix) {
 				// this is a UDS endpoint. assign it as is
 				endpointAddress = ingressListener.DefaultEndpoint
@@ -322,6 +323,10 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusters(cb *ClusterBuilder, i
 				}
 				if port, err = strconv.Atoi(parts[1]); err != nil {
 					continue
+				}
+				if parts[0] == model.PodIpAddressPrefix {
+					endpointAddress = cb.proxy.IPAddresses[0]
+					instanceIpCluster = true
 				}
 			}
 
@@ -335,6 +340,19 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusters(cb *ClusterBuilder, i
 			instance.Endpoint.EndpointPort = uint32(port)
 
 			localCluster := cb.buildInboundClusterForPortOrUDS(nil, instance, endpointAddress)
+			if instanceIpCluster {
+				// IPTables will redirect our own traffic back to us if we do not use the "magic" upstream bind
+				// config which will be skipped. This mirrors the "passthrough" clusters.
+				// TODO: consider moving all clusters to use this for consistency.
+				localCluster.UpstreamBindConfig = &core.BindConfig{
+					SourceAddress: &core.SocketAddress{
+						Address: util.InboundPassthroughBindIpv4,
+						PortSpecifier: &core.SocketAddress_PortValue{
+							PortValue: uint32(0),
+						},
+					},
+				}
+			}
 			clusters = cp.conditionallyAppend(clusters, localCluster)
 		}
 	}

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -311,7 +311,7 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusters(cb *ClusterBuilder, i
 			endpointAddress := actualLocalHost
 			port := 0
 			var err error
-			instanceIpCluster := false
+			instanceIPCluster := false
 			if strings.HasPrefix(ingressListener.DefaultEndpoint, model.UnixAddressPrefix) {
 				// this is a UDS endpoint. assign it as is
 				endpointAddress = ingressListener.DefaultEndpoint
@@ -324,9 +324,9 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusters(cb *ClusterBuilder, i
 				if port, err = strconv.Atoi(parts[1]); err != nil {
 					continue
 				}
-				if parts[0] == model.PodIpAddressPrefix {
+				if parts[0] == model.PodIPAddressPrefix {
 					endpointAddress = cb.proxy.IPAddresses[0]
-					instanceIpCluster = true
+					instanceIPCluster = true
 				}
 			}
 
@@ -340,7 +340,7 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusters(cb *ClusterBuilder, i
 			instance.Endpoint.EndpointPort = uint32(port)
 
 			localCluster := cb.buildInboundClusterForPortOrUDS(nil, instance, endpointAddress)
-			if instanceIpCluster {
+			if instanceIPCluster {
 				// IPTables will redirect our own traffic back to us if we do not use the "magic" upstream bind
 				// config which will be skipped. This mirrors the "passthrough" clusters.
 				// TODO: consider moving all clusters to use this for consistency.

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -767,10 +767,10 @@ var ValidateSidecar = registerValidateFunc("ValidateSidecar",
 					// format should be 127.0.0.1:port or :port
 					parts := strings.Split(i.DefaultEndpoint, ":")
 					if len(parts) < 2 {
-						errs = appendErrors(errs, fmt.Errorf("sidecar: defaultEndpoint must be of form 127.0.0.1:<port>"))
+						errs = appendErrors(errs, fmt.Errorf("sidecar: defaultEndpoint must be of form 127.0.0.1:<port> or 0.0.0.0:<port>"))
 					} else {
-						if len(parts[0]) > 0 && parts[0] != "127.0.0.1" {
-							errs = appendErrors(errs, fmt.Errorf("sidecar: defaultEndpoint must be of form 127.0.0.1:<port>"))
+						if len(parts[0]) > 0 && parts[0] != "127.0.0.1" && parts[0] != "0.0.0.0" {
+							errs = appendErrors(errs, fmt.Errorf("sidecar: defaultEndpoint must be of form 127.0.0.1:<port> or 0.0.0.0:<port>"))
 						}
 
 						port, err := strconv.Atoi(parts[1])

--- a/pkg/test/echo/common/model.go
+++ b/pkg/test/echo/common/model.go
@@ -49,6 +49,9 @@ type Port struct {
 
 	// ServerFirst if a port will be server first
 	ServerFirst bool
+
+	// InstanceIP determines if echo will listen on the instance IP, or wildcard
+	InstanceIP bool
 }
 
 // PortList is a set of ports

--- a/pkg/test/framework/components/echo/echo.go
+++ b/pkg/test/framework/components/echo/echo.go
@@ -115,6 +115,9 @@ type Port struct {
 
 	// ServerFirst determines whether the port will use server first communication, meaning the client will not send the first byte.
 	ServerFirst bool
+
+	// InstanceIP determines if echo will listen on the instance IP, or wildcard
+	InstanceIP bool
 }
 
 // Workload provides an interface for a single deployed echo server.

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -140,9 +140,6 @@ spec:
 {{- if $p.ServerFirst }}
           - --server-first={{ $p.Port }}
 {{- end }}
-{{- if $p.InstanceIP }}
-          - --bind-ip={{ $p.Port }}
-{{- end }}
 {{- end }}
           - --version
           - "{{ $subset.Version }}"

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -123,6 +123,9 @@ spec:
 {{- if $p.ServerFirst }}
           - --server-first={{ $p.Port }}
 {{- end }}
+{{- if $p.InstanceIP }}
+          - --bind-ip={{ $p.Port }}
+{{- end }}
 {{- end }}
 {{- range $i, $p := $.WorkloadOnlyPorts }}
 {{- if eq .Protocol "TCP" }}
@@ -136,6 +139,9 @@ spec:
 {{- end }}
 {{- if $p.ServerFirst }}
           - --server-first={{ $p.Port }}
+{{- end }}
+{{- if $p.InstanceIP }}
+          - --bind-ip={{ $p.Port }}
 {{- end }}
 {{- end }}
           - --version
@@ -308,6 +314,9 @@ spec:
              "{{ $p.Port }}" \
 {{- if $p.ServerFirst }}
              --server-first={{ $p.Port }} \
+{{- end }}
+{{- if $p.InstanceIP }}
+             --bind-ip={{ $p.Port }} \
 {{- end }}
 {{- end }}
         env:

--- a/pkg/test/framework/components/echo/kube/instance.go
+++ b/pkg/test/framework/components/echo/kube/instance.go
@@ -254,6 +254,7 @@ func getContainerPorts(ports []echo.Port) echoCommon.PortList {
 			Port:        p.InstancePort,
 			TLS:         p.TLS,
 			ServerFirst: p.ServerFirst,
+			InstanceIP:  p.InstanceIP,
 		}
 		containerPorts = append(containerPorts, cport)
 

--- a/releasenotes/notes/pod-ip-listener.yaml
+++ b/releasenotes/notes/pod-ip-listener.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: installation
+releaseNotes:
+- |
+  **Added** support for applications that bind to their pod IP address, rather than wildcard or localhost address, through the `Sidecar` API.

--- a/tests/integration/pilot/common/apps.go
+++ b/tests/integration/pilot/common/apps.go
@@ -78,6 +78,7 @@ var EchoPorts = []echo.Port{
 	{Name: "auto-tcp-server", Protocol: protocol.TCP, ServicePort: 9093, InstancePort: 16061, ServerFirst: true},
 	{Name: "auto-http", Protocol: protocol.HTTP, ServicePort: 81, InstancePort: 18081},
 	{Name: "auto-grpc", Protocol: protocol.GRPC, ServicePort: 7071, InstancePort: 17071},
+	{Name: "http-instance", Protocol: protocol.HTTP, ServicePort: 82, InstancePort: 18082, InstanceIP: true},
 }
 
 func serviceEntryPorts() []echo.Port {

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -565,22 +565,23 @@ func instanceIPTests(apps *EchoDeployments) []TrafficTestCase {
 		destination := apps.PodB[0]
 		// so we can validate all clusters are hit
 		callCount := callsPerCluster * len(apps.PodB)
-		cases = append(cases, TrafficTestCase{
-			name: "without sidecar",
-			call: client.CallWithRetryOrFail,
-			opts: echo.CallOptions{
-				Target:    destination,
-				PortName:  "http-instance",
-				Scheme:    scheme.HTTP,
-				Count:     callCount,
-				Timeout:   time.Second * 5,
-				Validator: echo.And(echo.ExpectCode("503")),
+		cases = append(cases,
+			TrafficTestCase{
+				name: "without sidecar",
+				call: client.CallWithRetryOrFail,
+				opts: echo.CallOptions{
+					Target:    destination,
+					PortName:  "http-instance",
+					Scheme:    scheme.HTTP,
+					Count:     callCount,
+					Timeout:   time.Second * 5,
+					Validator: echo.And(echo.ExpectCode("503")),
+				},
 			},
-		})
-		cases = append(cases, TrafficTestCase{
-			name: "with sidecar",
-			call: client.CallWithRetryOrFail,
-			config: `
+			TrafficTestCase{
+				name: "with sidecar",
+				call: client.CallWithRetryOrFail,
+				config: `
 apiVersion: networking.istio.io/v1alpha3
 kind: Sidecar
 metadata:
@@ -598,15 +599,15 @@ spec:
       protocol: HTTP
     defaultEndpoint: 0.0.0.0:82
 `,
-			opts: echo.CallOptions{
-				Target:    destination,
-				PortName:  "http-instance",
-				Scheme:    scheme.HTTP,
-				Count:     callCount,
-				Timeout:   time.Second * 5,
-				Validator: echo.And(echo.ExpectOK()),
-			},
-		})
+				opts: echo.CallOptions{
+					Target:    destination,
+					PortName:  "http-instance",
+					Scheme:    scheme.HTTP,
+					Count:     callCount,
+					Timeout:   time.Second * 5,
+					Validator: echo.And(echo.ExpectOK()),
+				},
+			})
 	}
 	return cases
 }

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -557,6 +557,60 @@ func protocolSniffingCases(apps *EchoDeployments) []TrafficTestCase {
 	return cases
 }
 
+// Todo merge with security TestReachability code
+func instanceIPTests(apps *EchoDeployments) []TrafficTestCase {
+	cases := []TrafficTestCase{}
+	for _, client := range apps.PodA {
+		client := client
+		destination := apps.PodB[0]
+		// so we can validate all clusters are hit
+		callCount := callsPerCluster * len(apps.PodB)
+		cases = append(cases, TrafficTestCase{
+			name: "without sidecar",
+			call: client.CallWithRetryOrFail,
+			opts: echo.CallOptions{
+				Target:    destination,
+				PortName:  "http-instance",
+				Scheme:    scheme.HTTP,
+				Count:     callCount,
+				Timeout:   time.Second * 5,
+				Validator: echo.And(echo.ExpectCode("503")),
+			},
+		})
+		cases = append(cases, TrafficTestCase{
+			name: "with sidecar",
+			call: client.CallWithRetryOrFail,
+			config: `
+apiVersion: networking.istio.io/v1alpha3
+kind: Sidecar
+metadata:
+  name: sidecar
+spec:
+  workloadSelector:
+    labels:
+      app: b
+  egress:
+  - hosts:
+    - "./*"
+  ingress:
+  - port:
+      number: 82
+      protocol: HTTP
+    defaultEndpoint: 0.0.0.0:82
+`,
+			opts: echo.CallOptions{
+				Target:    destination,
+				PortName:  "http-instance",
+				Scheme:    scheme.HTTP,
+				Count:     callCount,
+				Timeout:   time.Second * 5,
+				Validator: echo.And(echo.ExpectOK()),
+			},
+		})
+	}
+	return cases
+}
+
 type vmCase struct {
 	name string
 	from echo.Instance

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -91,6 +91,7 @@ func RunAllTrafficTests(ctx framework.TestContext, apps *EchoDeployments) {
 	cases["serverfirst"] = serverFirstTestCases(apps)
 	cases["gateway"] = gatewayCases(apps)
 	cases["loop"] = trafficLoopCases(apps)
+	cases["instanceip"] = instanceIPTests(apps)
 	if !ctx.Settings().SkipVM {
 		cases["vm"] = VMTestCases(apps.VM, apps)
 	}

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -52,6 +52,7 @@ var (
    Port: auto-tcp-server 9093/UnsupportedProtocol targets pod port 16061
    Port: auto-http 81/UnsupportedProtocol targets pod port 18081
    Port: auto-grpc 7071/UnsupportedProtocol targets pod port 17071
+   Port: http-instance 82/HTTP targets pod port 18082
 80 DestinationRule: a\..* for "a"
    Matching subsets: v1
    No Traffic Policy
@@ -84,6 +85,12 @@ var (
 7071 DestinationRule: a\..* for "a"
    Matching subsets: v1
    No Traffic Policy
+82 DestinationRule: a\..* for "a"
+   Matching subsets: v1
+   No Traffic Policy
+82 VirtualService: a\..*
+   when headers are end-user=jason
+82 RBAC policies: ns\[.*\]-policy\[integ-test\]-rule\[0\]
 `)
 
 	describePodAOutput = regexp.MustCompile(`Service: a\..*
@@ -95,6 +102,7 @@ var (
    Port: auto-tcp-server 9093/UnsupportedProtocol targets pod port 16061
    Port: auto-http 81/UnsupportedProtocol targets pod port 18081
    Port: auto-grpc 7071/UnsupportedProtocol targets pod port 17071
+   Port: http-instance 82/HTTP targets pod port 18082
 80 DestinationRule: a\..* for "a"
    Matching subsets: v1
    No Traffic Policy
@@ -127,6 +135,12 @@ var (
 7071 DestinationRule: a\..* for "a"
    Matching subsets: v1
    No Traffic Policy
+82 DestinationRule: a\..* for "a"
+   Matching subsets: v1
+   No Traffic Policy
+82 VirtualService: a\..*
+   when headers are end-user=jason
+82 RBAC policies: ns\[.*\]-policy\[integ-test\]-rule\[0\]
 `)
 
 	addToMeshPodAOutput = `deployment .* updated successfully with Istio sidecar injected.


### PR DESCRIPTION
Copy of https://github.com/istio/api/pull/1314 and https://github.com/istio/istio/pull/22117 but with a different implementation

This allows defining a Sidecar like
```yaml
apiVersion: networking.istio.io/v1beta1
kind: Sidecar
metadata:
  name: echo
spec:
  workloadSelector:
    labels:
      app: echo
  ingress:
  - port:
      number: 8080
      protocol: HTTP
      name: http
    defaultEndpoint: pod:8080
  egress:
  - hosts:
    - "*/*"
```

and instead of 127.0.0.1 we send to <POD_IP>

`pod` is probably the wrong name here since it applies to VMs, etc.