### PR TITLE
istioctl can specify different tags with multi gateways

### DIFF
--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -84,10 +84,18 @@ spec:
 {{- end }}
       containers:
         - name: istio-proxy
+{{- if $gateway.tag }}
+{{- if $gateway.hub }}
+          image: "{{ $gateway.hub }}/{{ .Values.global.proxy.image | default "proxyv2" }}:{{ $gateway.tag }}"
+{{- else}}
+          image: "{{ .Values.global.hub }}/{{ .Values.global.proxy.image | default "proxyv2" }}:{{ $gateway.tag }}"
+{{- end }}
+{{- else }}
 {{- if contains "/" .Values.global.proxy.image }}
           image: "{{ .Values.global.proxy.image }}"
 {{- else }}
           image: "{{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}"
+{{- end }}
 {{- end }}
 {{- if .Values.global.imagePullPolicy }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -84,10 +84,18 @@ spec:
 {{- end }}
       containers:
         - name: istio-proxy
+{{- if $gateway.tag }}
+{{- if $gateway.hub }}
+          image: "{{ $gateway.hub }}/{{ .Values.global.proxy.image | default "proxyv2" }}:{{ $gateway.tag }}"
+{{- else}}
+          image: "{{ .Values.global.hub }}/{{ .Values.global.proxy.image | default "proxyv2" }}:{{ $gateway.tag }}"
+{{- end }}
+{{- else }}
 {{- if contains "/" .Values.global.proxy.image }}
           image: "{{ .Values.global.proxy.image }}"
 {{- else }}
           image: "{{ .Values.global.hub }}/{{ .Values.global.proxy.image | default "proxyv2" }}:{{ .Values.global.tag }}"
+{{- end }}
 {{- end }}
 {{- if .Values.global.imagePullPolicy }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}

--- a/operator/pkg/translate/translate.go
+++ b/operator/pkg/translate/translate.go
@@ -357,6 +357,12 @@ func applyGatewayTranslations(iop []byte, componentName name.ComponentName, comp
 	switch componentName {
 	case name.IngressComponentName:
 		setYAMLNodeByMapPath(iopt, util.PathFromString("gateways.istio-ingressgateway.name"), gwSpec.Name)
+		if len(gwSpec.Hub) != 0 {
+			setYAMLNodeByMapPath(iopt, util.PathFromString("gateways.istio-ingressgateway.hub"), gwSpec.Hub)
+		}
+		if gwSpec.Tag != nil {
+			setYAMLNodeByMapPath(iopt, util.PathFromString("gateways.istio-ingressgateway.tag"), gwSpec.Tag)
+		}
 		if len(gwSpec.Label) != 0 {
 			setYAMLNodeByMapPath(iopt, util.PathFromString("gateways.istio-ingressgateway.labels"), gwSpec.Label)
 		}
@@ -365,6 +371,12 @@ func applyGatewayTranslations(iop []byte, componentName name.ComponentName, comp
 		}
 	case name.EgressComponentName:
 		setYAMLNodeByMapPath(iopt, util.PathFromString("gateways.istio-egressgateway.name"), gwSpec.Name)
+		if len(gwSpec.Hub) != 0 {
+			setYAMLNodeByMapPath(iopt, util.PathFromString("gateways.istio-ingressgateway.hub"), gwSpec.Hub)
+		}
+		if gwSpec.Tag != nil {
+			setYAMLNodeByMapPath(iopt, util.PathFromString("gateways.istio-ingressgateway.tag"), gwSpec.Tag)
+		}
 		if len(gwSpec.Label) != 0 {
 			setYAMLNodeByMapPath(iopt, util.PathFromString("gateways.istio-egressgateway.labels"), gwSpec.Label)
 		}


### PR DESCRIPTION
And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.

For example, I want to specify different tags with multi gateways.
```
apiVersion: install.istio.io/v1alpha1
kind: IstioOperator
spec:
  hub: hub.docker.io/istio
  tag: 1.7.2
  meshConfig:
    accessLogFile: /dev/stdout
  components:
    ingressGateways:
      - name: istio-ingressgateway
        enabled: false
      - name: istio-ingressgateway-test
        enabled: true
        hub: hub.docker.io/istio
        tag: 1.7.2-test
        k8s:
          replicaCount: 3
```
I find the GatewaySpec has the tag attribute, but it is useless.