### PR TITLE
remove-from-mesh: skip system namespace to remove sidecar

### DIFF
--- a/istioctl/cmd/remove-from-mesh.go
+++ b/istioctl/cmd/remove-from-mesh.go
@@ -30,8 +30,11 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"istio.io/api/annotation"
+	analyzer_util "istio.io/istio/galley/pkg/config/analysis/analyzers/util"
 	"istio.io/istio/istioctl/pkg/util/handlers"
 	istioStatus "istio.io/istio/pilot/cmd/pilot-agent/status"
+	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/config/resource"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/pkg/log"
 )
@@ -86,16 +89,19 @@ func deploymentUnMeshifyCmd() *cobra.Command {
 			if len(args) != 1 {
 				return fmt.Errorf("expecting deployment name")
 			}
+			ns := handlers.HandleNamespace(namespace, defaultNamespace)
+			if analyzer_util.IsSystemNamespace(resource.Namespace(ns)) || ns == constants.IstioSystemNamespace {
+				return fmt.Errorf("namespace %s is a system namesapce and has no Istio sidecar injected", ns)
+			}
 			client, err := interfaceFactory(kubeconfig)
 			if err != nil {
 				return err
 			}
-			ns := handlers.HandleNamespace(namespace, defaultNamespace)
-			writer := cmd.OutOrStdout()
 			dep, err := client.AppsV1().Deployments(ns).Get(context.TODO(), args[0], metav1.GetOptions{})
 			if err != nil {
 				return fmt.Errorf("deployment %q does not exist", args[0])
 			}
+			writer := cmd.OutOrStdout()
 			deps := []appsv1.Deployment{}
 			deps = append(deps, *dep)
 			return unInjectSideCarFromDeployment(client, deps, args[0], ns, writer)
@@ -124,12 +130,14 @@ func svcUnMeshifyCmd() *cobra.Command {
 			if len(args) != 1 {
 				return fmt.Errorf("expecting service name")
 			}
+			ns := handlers.HandleNamespace(namespace, defaultNamespace)
+			if analyzer_util.IsSystemNamespace(resource.Namespace(ns)) || ns == constants.IstioSystemNamespace {
+				return fmt.Errorf("namespace %s is a system namesapce and has no Istio sidecar injected", ns)
+			}
 			client, err := interfaceFactory(kubeconfig)
 			if err != nil {
 				return err
 			}
-			ns := handlers.HandleNamespace(namespace, defaultNamespace)
-			writer := cmd.OutOrStdout()
 			_, err = client.CoreV1().Services(ns).Get(context.TODO(), args[0], metav1.GetOptions{})
 			if err != nil {
 				return fmt.Errorf("service %q does not exist, skip", args[0])
@@ -138,6 +146,7 @@ func svcUnMeshifyCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			writer := cmd.OutOrStdout()
 			if len(matchingDeployments) == 0 {
 				fmt.Fprintf(writer, "No deployments found for service %s.%s\n", args[0], ns)
 				return nil

--- a/istioctl/cmd/remove-from-mesh.go
+++ b/istioctl/cmd/remove-from-mesh.go
@@ -33,7 +33,6 @@ import (
 	analyzer_util "istio.io/istio/galley/pkg/config/analysis/analyzers/util"
 	"istio.io/istio/istioctl/pkg/util/handlers"
 	istioStatus "istio.io/istio/pilot/cmd/pilot-agent/status"
-	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/resource"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/pkg/log"
@@ -90,7 +89,7 @@ func deploymentUnMeshifyCmd() *cobra.Command {
 				return fmt.Errorf("expecting deployment name")
 			}
 			ns := handlers.HandleNamespace(namespace, defaultNamespace)
-			if analyzer_util.IsSystemNamespace(resource.Namespace(ns)) || ns == constants.IstioSystemNamespace {
+			if analyzer_util.IsSystemNamespace(resource.Namespace(ns)) || ns == istioNamespace {
 				return fmt.Errorf("namespace %s is a system namesapce and has no Istio sidecar injected", ns)
 			}
 			client, err := interfaceFactory(kubeconfig)
@@ -131,7 +130,7 @@ func svcUnMeshifyCmd() *cobra.Command {
 				return fmt.Errorf("expecting service name")
 			}
 			ns := handlers.HandleNamespace(namespace, defaultNamespace)
-			if analyzer_util.IsSystemNamespace(resource.Namespace(ns)) || ns == constants.IstioSystemNamespace {
+			if analyzer_util.IsSystemNamespace(resource.Namespace(ns)) || ns == istioNamespace {
 				return fmt.Errorf("namespace %s is a system namesapce and has no Istio sidecar injected", ns)
 			}
 			client, err := interfaceFactory(kubeconfig)

--- a/istioctl/cmd/remove-from-mesh_test.go
+++ b/istioctl/cmd/remove-from-mesh_test.go
@@ -140,6 +140,20 @@ func TestRemoveFromMesh(t *testing.T) {
 			expectedOutput:    "Error: expecting deployment name\n",
 		},
 		{
+			description:       "Invalid namespace - system namespace not allowed",
+			args:              strings.Split("experimental remove-from-mesh deployment local-path-storage", " "),
+			expectedException: true,
+			namespace:         "local-path-storage",
+			expectedOutput:    "Error: namespace local-path-storage is a system namesapce and has no Istio sidecar injected\n",
+		},
+		{
+			description:       "Invalid namespace - system namespace not allowed",
+			args:              strings.Split("experimental remove-from-mesh service istio-ingressgateway", " "),
+			expectedException: true,
+			namespace:         "istio-system",
+			expectedOutput:    "Error: namespace istio-system is a system namesapce and has no Istio sidecar injected\n",
+		},
+		{
 			description:       "valid case - remove service from mesh",
 			args:              strings.Split("experimental remove-from-mesh service details", " "),
 			expectedException: false,


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/28186

Before:
Where `local-path-provisioner` don't have sidecar as it is in system namespace, still we get.
```
$ istioctl experimental remove-from-mesh deploy local-path-provisioner -n local-path-storage
deployment "local-path-provisioner.local-path-storage" updated successfully with Istio sidecar un-injected.
```
```
$ istioctl experimental remove-from-mesh deployment istio-egressgateway  -n istio-system
Error: 1 error occurred:
	* failed to update deployment "istio-egressgateway.istio-system" for service "istio-egressgateway.istio-system" due to Deployment.apps "istio-egressgateway" is invalid: spec.template.spec.containers: Required value
```

After:
```
$ ./out/linux_amd64/istioctl x rm deploy local-path-provisioner -n local-path-storage
Error: namespace local-path-storage is a system namesapce and has no Istio sidecar injected
```
```
$ ./out/linux_amd64/istioctl x rm deploy istio-ingressgateway-5fc96f8db6-rh69b -n istio-system
Error: namespace istio-system is a system namesapce and has no Istio sidecar injected
```