### PR TITLE
refactor eastwest script to use args

### DIFF
--- a/pkg/test/framework/components/istio/eastwest.go
+++ b/pkg/test/framework/components/istio/eastwest.go
@@ -49,17 +49,15 @@ func (i *operatorComponent) deployEastWestGateway(cluster resource.Cluster) erro
 	}
 
 	// generate istio operator yaml
-	cmd := exec.Command(genGatewayScript)
-	cmd.Env = os.Environ()
-	customEnv := []string{
-		"CLUSTER=" + cluster.Name(),
-		"NETWORK=" + cluster.NetworkName(),
-		"MESH=" + meshID,
+	args := []string{
+		"--cluster", cluster.Name(),
+		"--network", cluster.NetworkName(),
+		"--mesh", meshID,
 	}
 	if !i.environment.IsMulticluster() {
-		customEnv = append(customEnv, "SINGLE_CLUSTER=1")
+		args = []string{"--single-cluster"}
 	}
-	cmd.Env = append(cmd.Env, customEnv...)
+	cmd := exec.Command(genGatewayScript, args...)
 	gwIOP, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed generating eastwestgateway operator yaml: %v", err)

--- a/samples/multicluster/gen-eastwest-gateway.sh
+++ b/samples/multicluster/gen-eastwest-gateway.sh
@@ -16,20 +16,41 @@
 
 set -euo pipefail
 
+SINGLE_CLUSTER=0
+while (( "$#" )); do
+  case "$1" in
+    # Node images can be found at https://github.com/kubernetes-sigs/kind/releases
+    # For example, kindest/node:v1.14.0
+    --single-cluster)
+      SINGLE_CLUSTER=1
+      shift
+    ;;
+    --cluster)
+      CLUSTER=$2
+      shift 2
+    ;;
+    --network)
+      NETWORK=$2
+      shift 2
+    ;;
+    --mesh)
+      MESH=$2
+      shift 2
+    ;;
+    -*)
+      echo "Error: Unsupported flag $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+
 # single-cluster installations may need this gateway to allow VMs to get discovery
 # for non-single cluster, we add additional topology information
 SINGLE_CLUSTER="${SINGLE_CLUSTER:-0}"
 if [[ "${SINGLE_CLUSTER}" -eq 0 ]]; then
-  if [[ -z "${CLUSTER:-}" ]]; then
-  echo The CLUSTER environment variable must be set.
-  exit 1
-  fi
-  if [[ -z "${NETWORK:-}" ]]; then
-    echo The NETWORK environment variable must be set.
-    exit 1
-  fi
-  if [[ -z "${MESH:-}" ]]; then
-    echo The MESH environment variable must be set.
+  if [[ -z "${CLUSTER:-}" ]] || [[ -z "${NETWORK:-}" ]] || [[ -z "${MESH:-}" ]]; then
+    echo "Must specify either --single-cluster or --mesh, --cluster, and --network."
     exit 1
   fi
 fi


### PR DESCRIPTION
Use `--arg <value>` instead of environment vars to improve UX. 

fixes #28197