### PR TITLE
[release-1.7] Delete istiod pods on cleanup

### DIFF
--- a/tests/integration/operator/switch_cr_test.go
+++ b/tests/integration/operator/switch_cr_test.go
@@ -123,7 +123,11 @@ func TestController(t *testing.T) {
 			t.Cleanup(func() {
 				scopes.Framework.Infof("cleaning up resources")
 				if err := cs.DeleteYAMLFiles(IstioNamespace, iopCRFile); err != nil {
-					t.Errorf("faild to delete test IstioOperator CR: %v", err)
+					t.Errorf("failed to delete test IstioOperator CR: %v", err)
+				}
+				if err := cs.AppsV1().Deployments(IstioNamespace).DeleteCollection(context.TODO(),
+					kube2.DeleteOptionsForeground(), kubeApiMeta.ListOptions{LabelSelector: "app=istiod"}); err != nil {
+					t.Errorf("failed to remove istiod deployments: %v", err)
 				}
 			})
 		})


### PR DESCRIPTION
Otherwise they stay around and can cause other tests to fail.

In a concrete example, deployment "istiod-canary" stays live
and interferes in pilot's TestMultiRevision test, which also
deploys a "istiod-canary", but, since a deployment with that
name already exists, operator doesn't redeploy it, because it's
already there.

Manual cherrypick of https://github.com/istio/istio/pull/28205