### PR TITLE
Update Ingress status for same set of Ingresses that the controller handles

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -96,7 +96,7 @@ func (s *Server) initConfigController(args *PilotArgs) error {
 			leaderelection.
 				NewLeaderElection(args.Namespace, args.PodName, leaderelection.IngressController, s.kubeClient.Kube()).
 				AddRunFunction(func(leaderStop <-chan struct{}) {
-					ingressSyncer := ingress.NewStatusSyncer(meshConfig, s.kubeClient)
+					ingressSyncer := ingress.NewStatusSyncer(s.environment.Watcher, s.kubeClient)
 					// Start informers again. This fixes the case where informers for namespace do not start,
 					// as we create them only after acquiring the leader lock
 					// Note: stop here should be the overall pilot stop, NOT the leader election stop. We are

--- a/pilot/pkg/config/kube/ingress/conversion.go
+++ b/pilot/pkg/config/kube/ingress/conversion.go
@@ -291,8 +291,9 @@ func resolveNamedPort(backend *v1beta1.IngressBackend, namespace string, service
 }
 
 // shouldProcessIngress determines whether the given ingress resource should be processed
-// by the controller, based on its ingress class annotation.
-// See https://github.com/kubernetes/ingress/blob/master/examples/PREREQUISITES.md#ingress-class
+// by the controller, based on its ingress class annotation or, in more recent versions of
+// kubernetes (v1.18+), based on the Ingress's specified IngressClass
+// See https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class
 func shouldProcessIngressWithClass(mesh *meshconfig.MeshConfig, ingress *v1beta1.Ingress, ingressClass *v1beta1.IngressClass) bool {
 	if class, exists := ingress.Annotations[kube.IngressClassAnnotation]; exists {
 		switch mesh.IngressControllerMode {

--- a/pilot/pkg/config/kube/ingress/conversion_test.go
+++ b/pilot/pkg/config/kube/ingress/conversion_test.go
@@ -326,6 +326,8 @@ func TestIngressClass(t *testing.T) {
 		{ingressMode: meshconfig.MeshConfig_STRICT, ingressClass: nil, shouldProcess: false},
 
 		// IngressClass and Annotation
+		// note: k8s rejects Ingress resources configured with kubernetes.io/ingress.class annotation *and* ingressClassName field so this shouldn't happen
+		// see https://github.com/kubernetes/kubernetes/blob/ededd08ba131b727e60f663bd7217fffaaccd448/pkg/apis/networking/validation/validation.go#L226
 		{ingressMode: meshconfig.MeshConfig_STRICT, ingressClass: ingressClassIstio, annotation: "nginx", shouldProcess: false},
 		{ingressMode: meshconfig.MeshConfig_STRICT, ingressClass: ingressClassOther, annotation: istio, shouldProcess: true},
 		{ingressMode: -1, shouldProcess: false},

--- a/pilot/pkg/config/kube/ingress/status.go
+++ b/pilot/pkg/config/kube/ingress/status.go
@@ -23,6 +23,7 @@ import (
 
 	coreV1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -30,8 +31,7 @@ import (
 	listerv1 "k8s.io/client-go/listers/core/v1"
 	listerv1beta1 "k8s.io/client-go/listers/networking/v1beta1"
 
-	meshconfig "istio.io/api/mesh/v1alpha1"
-	"istio.io/istio/pilot/pkg/serviceregistry/kube"
+	"istio.io/istio/pkg/config/mesh"
 	kubelib "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/queue"
 	"istio.io/pkg/log"
@@ -43,19 +43,18 @@ const (
 
 // StatusSyncer keeps the status IP in each Ingress resource updated
 type StatusSyncer struct {
-	client kubernetes.Interface
-
-	ingressClass        string
-	defaultIngressClass string
+	meshHolder mesh.Holder
+	client     kubernetes.Interface
 
 	// Name of service (ingressgateway default) to find the IP
 	ingressService string
 
-	queue         queue.Instance
-	ingressLister listerv1beta1.IngressLister
-	podLister     listerv1.PodLister
-	serviceLister listerv1.ServiceLister
-	nodeLister    listerv1.NodeLister
+	queue              queue.Instance
+	ingressLister      listerv1beta1.IngressLister
+	podLister          listerv1.PodLister
+	serviceLister      listerv1.ServiceLister
+	nodeLister         listerv1.NodeLister
+	ingressClassLister listerv1beta1.IngressClassLister
 }
 
 // Run the syncer until stopCh is closed
@@ -65,25 +64,27 @@ func (s *StatusSyncer) Run(stopCh <-chan struct{}) {
 }
 
 // NewStatusSyncer creates a new instance
-func NewStatusSyncer(mesh *meshconfig.MeshConfig, client kubelib.Client) *StatusSyncer {
+func NewStatusSyncer(meshHolder mesh.Holder, client kubelib.Client) *StatusSyncer {
 
-	// we need to use the defined ingress class to allow multiple leaders
-	// in order to update information about ingress status
-	ingressClass, defaultIngressClass := convertIngressControllerMode(mesh.IngressControllerMode, mesh.IngressClass)
+	// as in controller, ingressClassListener can be nil since not supported in k8s version <1.18
+	var ingressClassLister listerv1beta1.IngressClassLister
+	if NetworkingIngressAvailable(client) {
+		ingressClassLister = client.KubeInformer().Networking().V1beta1().IngressClasses().Lister()
+	}
 
 	// queue requires a time duration for a retry delay after a handler error
 	q := queue.NewQueue(1 * time.Second)
 
 	return &StatusSyncer{
-		client:              client,
-		ingressLister:       client.KubeInformer().Networking().V1beta1().Ingresses().Lister(),
-		podLister:           client.KubeInformer().Core().V1().Pods().Lister(),
-		serviceLister:       client.KubeInformer().Core().V1().Services().Lister(),
-		nodeLister:          client.KubeInformer().Core().V1().Nodes().Lister(),
-		queue:               q,
-		ingressClass:        ingressClass,
-		defaultIngressClass: defaultIngressClass,
-		ingressService:      mesh.IngressService,
+		meshHolder:         meshHolder,
+		client:             client,
+		ingressLister:      client.KubeInformer().Networking().V1beta1().Ingresses().Lister(),
+		podLister:          client.KubeInformer().Core().V1().Pods().Lister(),
+		serviceLister:      client.KubeInformer().Core().V1().Services().Lister(),
+		nodeLister:         client.KubeInformer().Core().V1().Nodes().Lister(),
+		ingressClassLister: ingressClassLister,
+		queue:              q,
+		ingressService:     meshHolder.Mesh().IngressService,
 	}
 }
 
@@ -127,7 +128,12 @@ func (s *StatusSyncer) updateStatus(status []coreV1.LoadBalancerIngress) error {
 		return err
 	}
 	for _, currIng := range l {
-		if !classIsValid(currIng, s.ingressClass, s.defaultIngressClass) {
+		shouldTarget, err := s.shouldTargetIngress(currIng)
+		if err != nil {
+			log.Warnf("error determining whether should target ingress for status update: %v", err)
+			return err
+		}
+		if !shouldTarget {
 			continue
 		}
 
@@ -142,7 +148,7 @@ func (s *StatusSyncer) updateStatus(status []coreV1.LoadBalancerIngress) error {
 
 		currIng.Status.LoadBalancer.Ingress = status
 
-		_, err := s.client.NetworkingV1beta1().Ingresses(currIng.Namespace).UpdateStatus(context.TODO(), currIng, metaV1.UpdateOptions{})
+		_, err = s.client.NetworkingV1beta1().Ingresses(currIng.Namespace).UpdateStatus(context.TODO(), currIng, metaV1.UpdateOptions{})
 		if err != nil {
 			log.Warnf("error updating ingress status: %v", err)
 		}
@@ -151,14 +157,15 @@ func (s *StatusSyncer) updateStatus(status []coreV1.LoadBalancerIngress) error {
 	return nil
 }
 
-// runningAddresses returns a list of IP addresses and/or FQDN where the
-// ingress controller is currently running
+// runningAddresses returns a list of IP addresses and/or FQDN in the namespace
+// where the ingress controller is currently running
 func (s *StatusSyncer) runningAddresses(ingressNs string) ([]string, error) {
 	addrs := make([]string, 0)
 
 	if s.ingressService != "" {
 		svc, err := s.serviceLister.Services(ingressNs).Get(s.ingressService)
 		if err != nil {
+			log.Warnf("error retrieving ingress service with name %s in namespace %s", s.ingressService, ingressNs)
 			return nil, err
 		}
 
@@ -221,7 +228,7 @@ func addressInSlice(addr string, list []string) bool {
 
 // sliceToStatus converts a slice of IP and/or hostnames to LoadBalancerIngress
 func sliceToStatus(endpoints []string) []coreV1.LoadBalancerIngress {
-	lbi := make([]coreV1.LoadBalancerIngress, 0)
+	lbi := make([]coreV1.LoadBalancerIngress, 0, len(endpoints))
 	for _, ep := range endpoints {
 		if net.ParseIP(ep) == nil {
 			lbi = append(lbi, coreV1.LoadBalancerIngress{Hostname: ep})
@@ -261,42 +268,15 @@ func ingressSliceEqual(lhs, rhs []coreV1.LoadBalancerIngress) bool {
 	return true
 }
 
-// convertIngressControllerMode converts Ingress controller mode into k8s ingress status syncer ingress class and
-// default ingress class. Ingress class and default ingress class are used by the syncer to determine whether or not to
-// update the IP of a ingress resource.
-func convertIngressControllerMode(mode meshconfig.MeshConfig_IngressControllerMode,
-	class string) (string, string) {
-	var ingressClass, defaultIngressClass string
-	switch mode {
-	case meshconfig.MeshConfig_DEFAULT:
-		defaultIngressClass = class
-		ingressClass = class
-	case meshconfig.MeshConfig_STRICT:
-		ingressClass = class
+// shouldTargetIngress determines whether the status watcher should target a given ingress resource
+func (s *StatusSyncer) shouldTargetIngress(ingress *v1beta1.Ingress) (bool, error) {
+	var ingressClass *v1beta1.IngressClass
+	if s.ingressClassLister != nil && ingress.Spec.IngressClassName != nil {
+		c, err := s.ingressClassLister.Get(*ingress.Spec.IngressClassName)
+		if err != nil && !kerrors.IsNotFound(err) {
+			return false, err
+		}
+		ingressClass = c
 	}
-	return ingressClass, defaultIngressClass
-}
-
-// classIsValid returns true if the given Ingress either doesn't specify
-// the ingress.class annotation, or it's set to the configured in the
-// ingress controller.
-func classIsValid(ing *v1beta1.Ingress, controller, defClass string) bool {
-	// ingress fetched through annotation.
-	var ingress string
-	if ing != nil && len(ing.GetAnnotations()) != 0 {
-		ingress = ing.GetAnnotations()[kube.IngressClassAnnotation]
-	}
-
-	// we have 2 valid combinations
-	// 1 - ingress with default class | blank annotation on ingress
-	// 2 - ingress with specific class | same annotation on ingress
-	//
-	// and 2 invalid combinations
-	// 3 - ingress with default class | fixed annotation on ingress
-	// 4 - ingress with specific class | different annotation on ingress
-	if ingress == "" && controller == defClass {
-		return true
-	}
-
-	return ingress == controller
+	return shouldProcessIngressWithClass(s.meshHolder.Mesh(), ingress, ingressClass), nil
 }


### PR DESCRIPTION
Addresses #25308 

Before, we had two different places where we decided (1) which Ingress resources the controller should process and (2) which Ingress resources the StatusWatcher should update statuses for. However, the controller and status watcher should operate on the same set of Ingresses.

The old StatusWatcher mechanism did not take `IngressClass` into account at all when deciding whether to update Ingress status so this PR updates it to use the same decision mechanism as the main controller.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
