### PR TITLE
Add warnings for unknown fields in EnvoyFilter

### DIFF
--- a/pilot/pkg/model/envoyfilter.go
+++ b/pilot/pkg/model/envoyfilter.go
@@ -74,7 +74,9 @@ func convertToEnvoyFilterWrapper(local *config.Config) *EnvoyFilterWrapper {
 			Operation: cp.Patch.Operation,
 		}
 		var err error
-		cpw.Value, err = xds.BuildXDSObjectFromStruct(cp.ApplyTo, cp.Patch.Value)
+		// Use non-strict building to avoid issues where EnvoyFilter is valid but meant
+		// for a different version of the API than we are built with
+		cpw.Value, err = xds.BuildXDSObjectFromStruct(cp.ApplyTo, cp.Patch.Value, false)
 		// There generally won't be an error here because validation catches mismatched types
 		// Should only happen in tests or without validation
 		if err != nil {


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/26390

Example run:
```
istioctl validate -f /tmp/envoyfilter.yaml
"/tmp/envoyfilter.yaml" has warnings:
        * EnvoyFilter//custom-protocol: Envoy filter: unknown field "address" in envoy.config.endpoint.v3.LbEndpoint
```