### PR TITLE
set network label when istioctl creates namespace

### DIFF
--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -177,7 +177,7 @@ func InstallManifests(setOverlay []string, inFilenames []string, force bool, dry
 		return err
 	}
 
-	if err := createNamespace(clientset, iop.Namespace); err != nil {
+	if err := createNamespace(clientset, iop.Namespace, networkName(iop)); err != nil {
 		return err
 	}
 

--- a/operator/cmd/mesh/manifest_shared_test.go
+++ b/operator/cmd/mesh/manifest_shared_test.go
@@ -206,7 +206,7 @@ func fakeControllerReconcile(inFile string, chartSource chartSourceType) (*Objec
 
 	iop.Spec.InstallPackagePath = string(chartSource)
 
-	if err := createNamespace(testK8Interface, iop.Namespace); err != nil {
+	if err := createNamespace(testK8Interface, iop.Namespace, networkName(iop)); err != nil {
 		return nil, err
 	}
 

--- a/operator/cmd/mesh/operator-init.go
+++ b/operator/cmd/mesh/operator-init.go
@@ -123,7 +123,7 @@ func operatorInit(args *rootArgs, oiArgs *operatorInitArgs, l clog.Logger) {
 	}
 
 	if customResource != "" {
-		if err := createNamespace(clientset, istioNamespace); err != nil {
+		if err := createNamespace(clientset, istioNamespace, ""); err != nil {
 			l.LogAndFatal(err)
 
 		}

--- a/operator/cmd/mesh/shared.go
+++ b/operator/cmd/mesh/shared.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"istio.io/api/label"
 	"os"
 	"strings"
 	"sync"
@@ -36,6 +35,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"istio.io/api/label"
 	"istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/cache"
 	"istio.io/istio/operator/pkg/helmreconciler"

--- a/operator/cmd/mesh/shared.go
+++ b/operator/cmd/mesh/shared.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"istio.io/api/label"
 	"os"
 	"strings"
 	"sync"
@@ -242,7 +243,7 @@ func getCRAndNamespaceFromFile(filePath string, l clog.Logger) (customResource s
 }
 
 // createNamespace creates a namespace using the given k8s interface.
-func createNamespace(cs kubernetes.Interface, namespace string) error {
+func createNamespace(cs kubernetes.Interface, namespace string, network string) error {
 	if namespace == "" {
 		// Setup default namespace
 		namespace = istioDefaultNamespace
@@ -257,6 +258,9 @@ func createNamespace(cs kubernetes.Interface, namespace string) error {
 					"istio-injection": "disabled",
 				},
 			}}
+			if network != "" {
+				ns.Labels[label.IstioNetwork] = network
+			}
 			_, err := cs.CoreV1().Namespaces().Create(context.TODO(), ns, v12.CreateOptions{})
 			if err != nil {
 				return fmt.Errorf("failed to create namespace %v: %v", namespace, err)
@@ -267,6 +271,22 @@ func createNamespace(cs kubernetes.Interface, namespace string) error {
 	}
 
 	return nil
+}
+
+func networkName(iop *v1alpha1.IstioOperator) string {
+	if iop == nil || iop.Spec == nil || iop.Spec.Values == nil {
+		return ""
+	}
+	globalI := iop.Spec.Values["global"]
+	global, ok := globalI.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	nw, ok := global["network"].(string)
+	if !ok {
+		return ""
+	}
+	return nw
 }
 
 // saveIOPToCluster saves the state in an IOP CR in the cluster.


### PR DESCRIPTION
Follow up to #28126 – istioctl should set this label if it has the `network` and is creating the system namespace. 