### PR TITLE
Add remoteIpBlocks functionality to AuthorizationPolicy (#27906)

### DIFF
--- a/pilot/pkg/security/authz/builder/testdata/action-audit-HTTP-for-TCP-filter-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/action-audit-HTTP-for-TCP-filter-in.yaml
@@ -13,10 +13,12 @@ spec:
         requestPrincipals: ["requestPrincipals"]
         namespaces: ["ns"]
         ipBlocks: ["1.2.3.4"]
+        remoteIpBlocks: ["10.250.90.4"]
         notPrincipals: ["not-principal"]
         notRequestPrincipals: ["not-requestPrincipals"]
         notNamespaces: ["not-ns"]
         notIpBlocks: ["9.0.0.1"]
+        notRemoteIpBlocks: ["10.133.154.65"]
     to:
     - operation:
         methods: ["method"]
@@ -34,6 +36,9 @@ spec:
       - key: "source.ip"
         values: ["10.10.10.10"]
         notValues: ["90.10.10.10"]
+      - key: "remote.ip"
+        values: ["192.168.7.7"]
+        notValues: ["192.168.10.9"]
       - key: "source.namespace"
         values: ["ns"]
         notValues: ["not-ns"]

--- a/pilot/pkg/security/authz/builder/testdata/action-audit-HTTP-for-TCP-filter-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/action-audit-HTTP-for-TCP-filter-out.yaml
@@ -92,25 +92,47 @@ typedConfig:
                           regex: .*/ns/not-ns/.*
             - orIds:
                 ids:
-                - sourceIp:
+                - remoteIp:
+                    addressPrefix: 10.250.90.4
+                    prefixLen: 32
+            - notId:
+                orIds:
+                  ids:
+                  - remoteIp:
+                      addressPrefix: 10.133.154.65
+                      prefixLen: 32
+            - orIds:
+                ids:
+                - directRemoteIp:
                     addressPrefix: 1.2.3.4
                     prefixLen: 32
             - notId:
                 orIds:
                   ids:
-                  - sourceIp:
+                  - directRemoteIp:
                       addressPrefix: 9.0.0.1
                       prefixLen: 32
             - orIds:
                 ids:
-                - sourceIp:
+                - directRemoteIp:
                     addressPrefix: 10.10.10.10
                     prefixLen: 32
             - notId:
                 orIds:
                   ids:
-                  - sourceIp:
+                  - directRemoteIp:
                       addressPrefix: 90.10.10.10
+                      prefixLen: 32
+            - orIds:
+                ids:
+                - remoteIp:
+                    addressPrefix: 192.168.7.7
+                    prefixLen: 32
+            - notId:
+                orIds:
+                  ids:
+                  - remoteIp:
+                      addressPrefix: 192.168.10.9
                       prefixLen: 32
             - orIds:
                 ids:

--- a/pilot/pkg/security/authz/builder/testdata/action-deny-HTTP-for-TCP-filter-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/action-deny-HTTP-for-TCP-filter-in.yaml
@@ -57,10 +57,12 @@ spec:
         requestPrincipals: ["requestPrincipals"]
         namespaces: ["ns", "*ns-suffix", "ns-prefix*", "*"]
         ipBlocks: ["1.2.3.4"]
+        remoteIpBlocks: ["172.18.4.0/22"]
         notPrincipals: ["not-principal", "*not-principal-suffix", "not-principal-prefix*", "*"]
         notRequestPrincipals: ["not-requestPrincipals"]
         notNamespaces: ["not-ns", "*not-ns-suffix", "not-ns-prefix*", "*"]
         notIpBlocks: ["9.0.0.1"]
+        notRemoteIpBlocks: ["192.168.244.139"]
     to:
     - operation:
         methods: ["method"]
@@ -78,6 +80,9 @@ spec:
       - key: "source.ip"
         values: ["10.10.10.10"]
         notValues: ["90.10.10.10"]
+      - key: "remote.ip"
+        values: ["192.168.3.3"]
+        notValues: ["172.19.31.3"]
       - key: "source.namespace"
         values: ["ns", "*ns-suffix", "ns-prefix*", "*"]
         notValues: ["not-ns", "*not-ns-suffix", "not-ns-prefix*", "*"]

--- a/pilot/pkg/security/authz/builder/testdata/action-deny-HTTP-for-TCP-filter-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/action-deny-HTTP-for-TCP-filter-out.yaml
@@ -238,25 +238,47 @@ typedConfig:
                           regex: .*/ns/.*/.*
             - orIds:
                 ids:
-                - sourceIp:
+                - remoteIp:
+                    addressPrefix: 172.18.4.0
+                    prefixLen: 22
+            - notId:
+                orIds:
+                  ids:
+                  - remoteIp:
+                      addressPrefix: 192.168.244.139
+                      prefixLen: 32
+            - orIds:
+                ids:
+                - directRemoteIp:
                     addressPrefix: 1.2.3.4
                     prefixLen: 32
             - notId:
                 orIds:
                   ids:
-                  - sourceIp:
+                  - directRemoteIp:
                       addressPrefix: 9.0.0.1
                       prefixLen: 32
             - orIds:
                 ids:
-                - sourceIp:
+                - directRemoteIp:
                     addressPrefix: 10.10.10.10
                     prefixLen: 32
             - notId:
                 orIds:
                   ids:
-                  - sourceIp:
+                  - directRemoteIp:
                       addressPrefix: 90.10.10.10
+                      prefixLen: 32
+            - orIds:
+                ids:
+                - remoteIp:
+                    addressPrefix: 192.168.3.3
+                    prefixLen: 32
+            - notId:
+                orIds:
+                  ids:
+                  - remoteIp:
+                      addressPrefix: 172.19.31.3
                       prefixLen: 32
             - orIds:
                 ids:

--- a/pilot/pkg/security/authz/builder/testdata/all-fields-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/all-fields-in.yaml
@@ -15,10 +15,12 @@ spec:
             requestPrincipals: ["requestPrincipals", "requestPrincipals-prefix-*", "*-suffix-requestPrincipals", "*"]
             namespaces: ["ns", "ns-prefix-*", "*-ns-suffix", "*"]
             ipBlocks: ["1.2.3.4", "5.6.0.0/16"]
+            remoteIpBlocks: ["1.2.3.4", "5.6.0.0/16"]
             notPrincipals: ["not-principal", "not-principal-prefix-*", "*-not-suffix-principal", "*"]
             notRequestPrincipals: ["not-requestPrincipals", "not-requestPrincipals-prefix-*", "*-not-suffix-requestPrincipals", "*"]
             notNamespaces: ["not-ns", "not-ns-prefix-*", "*-not-ns-suffix", "*"]
             notIpBlocks: ["9.0.0.1", "9.2.0.0/16"]
+            notRemoteIpBlocks: ["9.0.0.1", "9.2.0.0/16"]
       to:
         - operation:
             methods: ["method", "method-prefix-*", "*-suffix-method", "*"]
@@ -34,6 +36,9 @@ spec:
           values: ["header", "header-prefix-*", "*-suffix-header", "*"]
           notValues: ["not-header", "not-header-prefix-*", "*-not-suffix-header", "*"]
         - key: "source.ip"
+          values: ["10.10.10.10", "192.168.10.0/24"]
+          notValues: ["90.10.10.10", "90.168.10.0/24"]
+        - key: "remote.ip"
           values: ["10.10.10.10", "192.168.10.0/24"]
           notValues: ["90.10.10.10", "90.168.10.0/24"]
         - key: "source.namespace"

--- a/pilot/pkg/security/authz/builder/testdata/all-fields-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/all-fields-out.yaml
@@ -435,19 +435,36 @@ typedConfig:
                             regex: .*/ns/.*/.*
             - orIds:
                 ids:
-                - sourceIp:
+                - remoteIp:
                     addressPrefix: 1.2.3.4
                     prefixLen: 32
-                - sourceIp:
+                - remoteIp:
                     addressPrefix: 5.6.0.0
                     prefixLen: 16
             - notId:
                 orIds:
                   ids:
-                  - sourceIp:
+                  - remoteIp:
                       addressPrefix: 9.0.0.1
                       prefixLen: 32
-                  - sourceIp:
+                  - remoteIp:
+                      addressPrefix: 9.2.0.0
+                      prefixLen: 16
+            - orIds:
+                ids:
+                - directRemoteIp:
+                    addressPrefix: 1.2.3.4
+                    prefixLen: 32
+                - directRemoteIp:
+                    addressPrefix: 5.6.0.0
+                    prefixLen: 16
+            - notId:
+                orIds:
+                  ids:
+                  - directRemoteIp:
+                      addressPrefix: 9.0.0.1
+                      prefixLen: 32
+                  - directRemoteIp:
                       addressPrefix: 9.2.0.0
                       prefixLen: 16
             - orIds:
@@ -481,19 +498,36 @@ typedConfig:
                       presentMatch: true
             - orIds:
                 ids:
-                - sourceIp:
+                - directRemoteIp:
                     addressPrefix: 10.10.10.10
                     prefixLen: 32
-                - sourceIp:
+                - directRemoteIp:
                     addressPrefix: 192.168.10.0
                     prefixLen: 24
             - notId:
                 orIds:
                   ids:
-                  - sourceIp:
+                  - directRemoteIp:
                       addressPrefix: 90.10.10.10
                       prefixLen: 32
-                  - sourceIp:
+                  - directRemoteIp:
+                      addressPrefix: 90.168.10.0
+                      prefixLen: 24
+            - orIds:
+                ids:
+                - remoteIp:
+                    addressPrefix: 10.10.10.10
+                    prefixLen: 32
+                - remoteIp:
+                    addressPrefix: 192.168.10.0
+                    prefixLen: 24
+            - notId:
+                orIds:
+                  ids:
+                  - remoteIp:
+                      addressPrefix: 90.10.10.10
+                      prefixLen: 32
+                  - remoteIp:
                       addressPrefix: 90.168.10.0
                       prefixLen: 24
             - orIds:

--- a/pilot/pkg/security/authz/builder/testdata/multiple-policies-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/multiple-policies-out.yaml
@@ -149,10 +149,10 @@ typedConfig:
             ids:
             - orIds:
                 ids:
-                - sourceIp:
+                - directRemoteIp:
                     addressPrefix: 1.2.3.4
                     prefixLen: 32
-                - sourceIp:
+                - directRemoteIp:
                     addressPrefix: 5.6.7.0
                     prefixLen: 24
       ns[foo]-policy[httpbin-9]-rule[0]:

--- a/pilot/pkg/security/authz/builder/testdata/single-policy-in.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/single-policy-in.yaml
@@ -15,11 +15,13 @@ spec:
             requestPrincipals: ["rule[0]-from[0]-requestPrincipal[1]", "rule[0]-from[0]-requestPrincipal[2]"]
             namespaces: ["rule[0]-from[0]-ns[1]", "rule[0]-from[0]-ns[2]"]
             ipBlocks: ["10.0.0.1", "10.0.0.2"]
+            remoteIpBlocks: ["172.16.10.10"]
         - source:
             principals: ["rule[0]-from[1]-principal[1]", "rule[0]-from[1]-principal[2]"]
             requestPrincipals: ["rule[0]-from[1]-requestPrincipal[1]", "rule[0]-from[1]-requestPrincipal[2]"]
             namespaces: ["rule[0]-from[1]-ns[1]", "rule[0]-from[1]-ns[2]"]
             ipBlocks: ["10.0.1.1", "192.0.1.2"]
+            remoteIpBlocks: ["172.17.8.0/24", "172.17.9.4"]
       to:
         - operation:
             methods: ["rule[0]-to[0]-method[1]", "rule[0]-to[0]-method[2]"]
@@ -36,17 +38,21 @@ spec:
           values: ["header", "header-prefix-*", "*-suffix-header", "*"]
         - key: "destination.ip"
           values: ["10.10.10.10", "192.168.10.0/24"]
+        - key: "remote.ip"
+          values: ["10.99.10.8", "10.80.64.0/18"]
     - from:
         - source:
             principals: ["rule[1]-from[0]-principal[1]", "rule[1]-from[0]-principal[2]"]
             requestPrincipals: ["rule[1]-from[0]-requestPrincipal[1]", "rule[1]-from[0]-requestPrincipal[2]"]
             namespaces: ["rule[1]-from[0]-ns[1]", "rule[1]-from[0]-ns[2]"]
             ipBlocks: ["10.1.0.1", "10.1.0.2"]
+            remoteIpBlocks: ["172.22.2.0/23", "172.21.234.254"]
         - source:
             principals: ["rule[1]-from[1]-principal[1]", "rule[1]-from[1]-principal[2]"]
             requestPrincipals: ["rule[1]-from[1]-requestPrincipal[1]", "rule[1]-from[1]-requestPrincipal[2]"]
             namespaces: ["rule[1]-from[1]-ns[1]", "rule[1]-from[1]-ns[2]"]
             ipBlocks: ["10.1.1.1", "192.1.1.2"]
+            remoteIpBlocks: ["192.168.4.0/24", "192.168.7.8"]
       to:
         - operation:
             methods: ["rule[1]-to[0]-method[1]", "rule[1]-to[0]-method[2]"]

--- a/pilot/pkg/security/authz/builder/testdata/single-policy-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/single-policy-out.yaml
@@ -138,10 +138,15 @@ typedConfig:
                           regex: .*/ns/rule[0]-from[0]-ns[2]/.*
             - orIds:
                 ids:
-                - sourceIp:
+                - remoteIp:
+                    addressPrefix: 172.16.10.10
+                    prefixLen: 32
+            - orIds:
+                ids:
+                - directRemoteIp:
                     addressPrefix: 10.0.0.1
                     prefixLen: 32
-                - sourceIp:
+                - directRemoteIp:
                     addressPrefix: 10.0.0.2
                     prefixLen: 32
             - orIds:
@@ -158,6 +163,14 @@ typedConfig:
                 - header:
                     name: X-header
                     presentMatch: true
+            - orIds:
+                ids:
+                - remoteIp:
+                    addressPrefix: 10.99.10.8
+                    prefixLen: 32
+                - remoteIp:
+                    addressPrefix: 10.80.64.0
+                    prefixLen: 18
         - andIds:
             ids:
             - orIds:
@@ -214,10 +227,18 @@ typedConfig:
                           regex: .*/ns/rule[0]-from[1]-ns[2]/.*
             - orIds:
                 ids:
-                - sourceIp:
+                - remoteIp:
+                    addressPrefix: 172.17.8.0
+                    prefixLen: 24
+                - remoteIp:
+                    addressPrefix: 172.17.9.4
+                    prefixLen: 32
+            - orIds:
+                ids:
+                - directRemoteIp:
                     addressPrefix: 10.0.1.1
                     prefixLen: 32
-                - sourceIp:
+                - directRemoteIp:
                     addressPrefix: 192.0.1.2
                     prefixLen: 32
             - orIds:
@@ -234,6 +255,14 @@ typedConfig:
                 - header:
                     name: X-header
                     presentMatch: true
+            - orIds:
+                ids:
+                - remoteIp:
+                    addressPrefix: 10.99.10.8
+                    prefixLen: 32
+                - remoteIp:
+                    addressPrefix: 10.80.64.0
+                    prefixLen: 18
       ns[foo]-policy[httpbin]-rule[1]:
         permissions:
         - andRules:
@@ -353,10 +382,18 @@ typedConfig:
                           regex: .*/ns/rule[1]-from[0]-ns[2]/.*
             - orIds:
                 ids:
-                - sourceIp:
+                - remoteIp:
+                    addressPrefix: 172.22.2.0
+                    prefixLen: 23
+                - remoteIp:
+                    addressPrefix: 172.21.234.254
+                    prefixLen: 32
+            - orIds:
+                ids:
+                - directRemoteIp:
                     addressPrefix: 10.1.0.1
                     prefixLen: 32
-                - sourceIp:
+                - directRemoteIp:
                     addressPrefix: 10.1.0.2
                     prefixLen: 32
         - andIds:
@@ -415,9 +452,17 @@ typedConfig:
                           regex: .*/ns/rule[1]-from[1]-ns[2]/.*
             - orIds:
                 ids:
-                - sourceIp:
+                - remoteIp:
+                    addressPrefix: 192.168.4.0
+                    prefixLen: 24
+                - remoteIp:
+                    addressPrefix: 192.168.7.8
+                    prefixLen: 32
+            - orIds:
+                ids:
+                - directRemoteIp:
                     addressPrefix: 10.1.1.1
                     prefixLen: 32
-                - sourceIp:
+                - directRemoteIp:
                     addressPrefix: 192.1.1.2
                     prefixLen: 32

--- a/pilot/pkg/security/authz/model/generator.go
+++ b/pilot/pkg/security/authz/model/generator.go
@@ -105,7 +105,22 @@ func (srcIPGenerator) principal(_, value string, _ bool) (*rbacpb.Principal, err
 	if err != nil {
 		return nil, err
 	}
-	return principalSourceIP(cidr), nil
+	return principalDirectRemoteIP(cidr), nil
+}
+
+type remoteIPGenerator struct {
+}
+
+func (remoteIPGenerator) permission(_, _ string, _ bool) (*rbacpb.Permission, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+
+func (remoteIPGenerator) principal(_, value string, _ bool) (*rbacpb.Principal, error) {
+	cidr, err := matcher.CidrRange(value)
+	if err != nil {
+		return nil, err
+	}
+	return principalRemoteIP(cidr), nil
 }
 
 type srcNamespaceGenerator struct {

--- a/pilot/pkg/security/authz/model/generator_test.go
+++ b/pilot/pkg/security/authz/model/generator_test.go
@@ -93,7 +93,16 @@ func TestGenerator(t *testing.T) {
 			g:     srcIPGenerator{},
 			value: "1.2.3.4",
 			want: yamlPrincipal(t, `
-         sourceIp:
+         directRemoteIp:
+          addressPrefix: 1.2.3.4
+          prefixLen: 32`),
+		},
+		{
+			name:  "remoteIPGenerator",
+			g:     remoteIPGenerator{},
+			value: "1.2.3.4",
+			want: yamlPrincipal(t, `
+         remoteIp:
           addressPrefix: 1.2.3.4
           prefixLen: 32`),
 		},

--- a/pilot/pkg/security/authz/model/model.go
+++ b/pilot/pkg/security/authz/model/model.go
@@ -34,6 +34,7 @@ const (
 
 	attrRequestHeader    = "request.headers"             // header name is surrounded by brackets, e.g. "request.headers[User-Agent]".
 	attrSrcIP            = "source.ip"                   // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
+	attrRemoteIP         = "remote.ip"                   // original client ip determined from x-forwarded-for or proxy protocol.
 	attrSrcNamespace     = "source.namespace"            // e.g. "default".
 	attrSrcPrincipal     = "source.principal"            // source identity, e,g, "cluster.local/ns/default/sa/productpage".
 	attrRequestPrincipal = "request.auth.principal"      // authenticated principal of the request.
@@ -90,6 +91,8 @@ func New(r *authzpb.Rule, isIstioVersionGE15 bool) (*Model, error) {
 			basePermission.appendLast(envoyFilterGenerator{}, k, when.Values, when.NotValues)
 		case k == attrSrcIP:
 			basePrincipal.appendLast(srcIPGenerator{}, k, when.Values, when.NotValues)
+		case k == attrRemoteIP:
+			basePrincipal.appendLast(remoteIPGenerator{}, k, when.Values, when.NotValues)
 		case k == attrSrcNamespace:
 			basePrincipal.appendLast(srcNamespaceGenerator{}, k, when.Values, when.NotValues)
 		case k == attrSrcPrincipal:
@@ -113,6 +116,7 @@ func New(r *authzpb.Rule, isIstioVersionGE15 bool) (*Model, error) {
 		merged := basePrincipal.copy()
 		if s := from.Source; s != nil {
 			merged.insertFront(srcIPGenerator{}, attrSrcIP, s.IpBlocks, s.NotIpBlocks)
+			merged.insertFront(remoteIPGenerator{}, attrRemoteIP, s.RemoteIpBlocks, s.NotRemoteIpBlocks)
 			merged.insertFront(srcNamespaceGenerator{}, attrSrcNamespace, s.Namespaces, s.NotNamespaces)
 			merged.insertFront(requestPrincipalGenerator{}, attrRequestPrincipal, s.RequestPrincipals, s.NotRequestPrincipals)
 			merged.insertFront(srcPrincipalGenerator{}, attrSrcPrincipal, s.Principals, s.NotPrincipals)

--- a/pilot/pkg/security/authz/model/principal.go
+++ b/pilot/pkg/security/authz/model/principal.go
@@ -67,10 +67,18 @@ func principalAuthenticated(name *matcherpb.StringMatcher) *rbacpb.Principal {
 	}
 }
 
-func principalSourceIP(cidr *corepb.CidrRange) *rbacpb.Principal {
+func principalDirectRemoteIP(cidr *corepb.CidrRange) *rbacpb.Principal {
 	return &rbacpb.Principal{
-		Identifier: &rbacpb.Principal_SourceIp{
-			SourceIp: cidr,
+		Identifier: &rbacpb.Principal_DirectRemoteIp{
+			DirectRemoteIp: cidr,
+		},
+	}
+}
+
+func principalRemoteIP(cidr *corepb.CidrRange) *rbacpb.Principal {
+	return &rbacpb.Principal{
+		Identifier: &rbacpb.Principal_RemoteIp{
+			RemoteIp: cidr,
 		},
 	}
 }

--- a/pkg/config/security/security.go
+++ b/pkg/config/security/security.go
@@ -37,6 +37,7 @@ type JwksInfo struct {
 const (
 	attrRequestHeader    = "request.headers"        // header name is surrounded by brackets, e.g. "request.headers[User-Agent]".
 	attrSrcIP            = "source.ip"              // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
+	attrRemoteIP         = "remote.ip"              // original client ip determined from x-forwarded-for or proxy protocol.
 	attrSrcNamespace     = "source.namespace"       // e.g. "default".
 	attrSrcPrincipal     = "source.principal"       // source identity, e,g, "cluster.local/ns/default/sa/productpage".
 	attrRequestPrincipal = "request.auth.principal" // authenticated principal of the request.
@@ -104,6 +105,8 @@ func ValidateAttribute(key string, values []string) error {
 	case hasPrefix(key, attrRequestHeader):
 		return validateMapKey(key)
 	case isEqual(key, attrSrcIP):
+		return ValidateIPs(values)
+	case isEqual(key, attrRemoteIP):
 		return ValidateIPs(values)
 	case isEqual(key, attrSrcNamespace):
 	case isEqual(key, attrSrcPrincipal):

--- a/pkg/config/security/security_test.go
+++ b/pkg/config/security/security_test.go
@@ -117,6 +117,15 @@ func TestValidateCondition(t *testing.T) {
 			wantError: true,
 		},
 		{
+			key:    "remote.ip",
+			values: []string{"1.2.3.4", "5.6.7.0/24"},
+		},
+		{
+			key:       "remote.ip",
+			values:    []string{"a.b.c.d"},
+			wantError: true,
+		},
+		{
 			key:    "source.namespace",
 			values: []string{"value"},
 		},

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1432,19 +1432,24 @@ var ValidateAuthorizationPolicy = registerValidateFunc("ValidateAuthorizationPol
 				} else {
 					src := from.Source
 					if len(src.Principals) == 0 && len(src.RequestPrincipals) == 0 && len(src.Namespaces) == 0 && len(src.IpBlocks) == 0 &&
-						len(src.NotPrincipals) == 0 && len(src.NotRequestPrincipals) == 0 && len(src.NotNamespaces) == 0 && len(src.NotIpBlocks) == 0 {
+						len(src.RemoteIpBlocks) == 0 && len(src.NotPrincipals) == 0 && len(src.NotRequestPrincipals) == 0 && len(src.NotNamespaces) == 0 &&
+						len(src.NotIpBlocks) == 0 && len(src.NotRemoteIpBlocks) == 0 {
 						errs = appendErrors(errs, fmt.Errorf("`from.source` must not be empty, found at rule %d in %s.%s", i, name, namespace))
 					}
 					errs = appendErrors(errs, security.ValidateIPs(from.Source.GetIpBlocks()))
 					errs = appendErrors(errs, security.ValidateIPs(from.Source.GetNotIpBlocks()))
+					errs = appendErrors(errs, security.ValidateIPs(from.Source.GetRemoteIpBlocks()))
+					errs = appendErrors(errs, security.ValidateIPs(from.Source.GetNotRemoteIpBlocks()))
 					errs = appendErrors(errs, security.CheckEmptyValues("Principals", src.Principals))
 					errs = appendErrors(errs, security.CheckEmptyValues("RequestPrincipals", src.RequestPrincipals))
 					errs = appendErrors(errs, security.CheckEmptyValues("Namespaces", src.Namespaces))
 					errs = appendErrors(errs, security.CheckEmptyValues("IpBlocks", src.IpBlocks))
+					errs = appendErrors(errs, security.CheckEmptyValues("RemoteIpBlocks", src.RemoteIpBlocks))
 					errs = appendErrors(errs, security.CheckEmptyValues("NotPrincipals", src.NotPrincipals))
 					errs = appendErrors(errs, security.CheckEmptyValues("NotRequestPrincipals", src.NotRequestPrincipals))
 					errs = appendErrors(errs, security.CheckEmptyValues("NotNamespaces", src.NotNamespaces))
 					errs = appendErrors(errs, security.CheckEmptyValues("NotIpBlocks", src.NotIpBlocks))
+					errs = appendErrors(errs, security.CheckEmptyValues("NotRemoteIpBlocks", src.NotRemoteIpBlocks))
 				}
 			}
 			if rule.To != nil && len(rule.To) == 0 {

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -3756,6 +3756,40 @@ func TestValidateAuthorizationPolicy(t *testing.T) {
 			valid: false,
 		},
 		{
+			name: "RemoteIpBlocks-empty",
+			in: &security_beta.AuthorizationPolicy{
+				Rules: []*security_beta.Rule{
+					{
+						From: []*security_beta.Rule_From{
+							{
+								Source: &security_beta.Source{
+									RemoteIpBlocks: []string{"1.2.3.4", ""},
+								},
+							},
+						},
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "NotRemoteIpBlocks-empty",
+			in: &security_beta.AuthorizationPolicy{
+				Rules: []*security_beta.Rule{
+					{
+						From: []*security_beta.Rule_From{
+							{
+								Source: &security_beta.Source{
+									NotRemoteIpBlocks: []string{"1.2.3.4", ""},
+								},
+							},
+						},
+					},
+				},
+			},
+			valid: false,
+		},
+		{
 			name: "Hosts-empty",
 			in: &security_beta.AuthorizationPolicy{
 				Rules: []*security_beta.Rule{
@@ -3908,7 +3942,7 @@ func TestValidateAuthorizationPolicy(t *testing.T) {
 			valid: false,
 		},
 		{
-			name: "invalid ip and port",
+			name: "invalid ip and port in ipBlocks",
 			in: &security_beta.AuthorizationPolicy{
 				Rules: []*security_beta.Rule{
 					{
@@ -3917,6 +3951,32 @@ func TestValidateAuthorizationPolicy(t *testing.T) {
 								Source: &security_beta.Source{
 									IpBlocks:    []string{"1.2.3.4", "ip1"},
 									NotIpBlocks: []string{"5.6.7.8", "ip2"},
+								},
+							},
+						},
+						To: []*security_beta.Rule_To{
+							{
+								Operation: &security_beta.Operation{
+									Ports:    []string{"80", "port1"},
+									NotPorts: []string{"90", "port2"},
+								},
+							},
+						},
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "invalid ip and port in remoteIpBlocks",
+			in: &security_beta.AuthorizationPolicy{
+				Rules: []*security_beta.Rule{
+					{
+						From: []*security_beta.Rule_From{
+							{
+								Source: &security_beta.Source{
+									RemoteIpBlocks:    []string{"1.2.3.4", "ip1"},
+									NotRemoteIpBlocks: []string{"5.6.7.8", "ip2"},
 								},
 							},
 						},

--- a/releasenotes/notes/remote-ip.yaml
+++ b/releasenotes/notes/remote-ip.yaml
@@ -1,0 +1,21 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+issue:
+  - 22341
+
+releaseNotes:
+  - |
+    **Added** AuthorizationPolicy now supports a Source of type remoteIpBlocks/notRemoteIpBlocks that map to a new Condition attribute called "remote.ip" that can also be used in the "when" clause.  If using an http/https load balancer in front of the ingress gateway, the "remote.ip" attribute is set to the original client IP address determined by the X-Forwarded-For http header from the trusted proxy configured through the numTrustedProxies field of the gatewayTopology under the meshConfig when you install Istio or set it via an annotation on the ingress gateway.  See the documentation here: [Configuring Gateway Network Topology](https://istio.io/latest/docs/ops/configuration/traffic-management/network-topologies/). If using a TCP load balancer with the Proxy Protocol in front of the ingress gateway, the "remote.ip" is set to the original client IP address as given by the Proxy Protocol.
+  - |
+    **Updated** The ipBlocks/notIpBlocks fields of an AuthorizationPolicy now strictly refer to the source IP address of the IP packet as it arrives to the sidecar.  Prior to this release, if using the Proxy Protocol, then the ipBlocks/notIpBlocks would refer to the IP address determined by the Proxy Protocol.  Now the remoteIpBlocks/notRemoteIpBlocks fields must be used to refer to the client IP address from the Proxy Protocol.
+
+upgradeNotes:
+  - title: Update AuthorizationPolicy resources to use remoteIpBlocks/notRemoteIpBlocks instead of ipBlocks/notIpBlocks if using the Proxy Protocol.
+    content: |
+      If using the Proxy Protocol on a load balancer in front an ingress gateway in conjunction with ipBlocks/notIpBlocks on an AuthorizationPolicy to perform IP-based access control, then please update the AuthorizationPolicy to use remoteIpBlocks/notRemoteIpBlocks instead after upgrading. The ipBlocks/notIpBlocks fields now strictly refer to the source IP address of the packet that arrives at the sidecar. 
+
+docs:
+  - '[reference] https://istio.io/latest/docs/reference/config/security/authorization-policy/'
+  - '[usage] https://istio.io/latest/docs/ops/configuration/traffic-management/network-topologies/'
+  - '[usage] https://istio.io/latest/docs/tasks/security/authorization/authz-ingress/'

--- a/releasenotes/template.yaml
+++ b/releasenotes/template.yaml
@@ -32,8 +32,8 @@ releaseNotes:
 # upgradeNotes is a markdown listing of any changes that will affect the upgrade
 # process. This will appear in the release notes.
 upgradeNotes:
-  title:
-  content:
+  - title:
+    content:
 
 # docs is a list of related docs to the change.
 docs:

--- a/tests/integration/security/authorization_test.go
+++ b/tests/integration/security/authorization_test.go
@@ -476,43 +476,108 @@ func TestAuthorization_IngressGateway(t *testing.T) {
 				Name     string
 				Host     string
 				Path     string
+				IP       string
 				WantCode int
 			}{
 				{
 					Name:     "allow www.company.com",
 					Host:     "www.company.com",
 					Path:     "/",
+					IP:       "172.16.0.1",
 					WantCode: 200,
 				},
 				{
 					Name:     "deny www.company.com/private",
 					Host:     "www.company.com",
 					Path:     "/private",
+					IP:       "172.16.0.1",
 					WantCode: 403,
 				},
 				{
 					Name:     "allow www.company.com/public",
 					Host:     "www.company.com",
 					Path:     "/public",
+					IP:       "172.16.0.1",
 					WantCode: 200,
 				},
 				{
 					Name:     "deny internal.company.com",
 					Host:     "internal.company.com",
 					Path:     "/",
+					IP:       "172.16.0.1",
 					WantCode: 403,
 				},
 				{
 					Name:     "deny internal.company.com/private",
 					Host:     "internal.company.com",
 					Path:     "/private",
+					IP:       "172.16.0.1",
 					WantCode: 403,
+				},
+				{
+					Name:     "deny 172.17.72.46",
+					Host:     "remoteipblocks.company.com",
+					Path:     "/",
+					IP:       "172.17.72.46",
+					WantCode: 403,
+				},
+				{
+					Name:     "deny 192.168.5.233",
+					Host:     "remoteipblocks.company.com",
+					Path:     "/",
+					IP:       "192.168.5.233",
+					WantCode: 403,
+				},
+				{
+					Name:     "allow 10.4.5.6",
+					Host:     "remoteipblocks.company.com",
+					Path:     "/",
+					IP:       "10.4.5.6",
+					WantCode: 200,
+				},
+				{
+					Name:     "deny 10.2.3.4",
+					Host:     "notremoteipblocks.company.com",
+					Path:     "/",
+					IP:       "10.2.3.4",
+					WantCode: 403,
+				},
+				{
+					Name:     "allow 172.23.242.188",
+					Host:     "notremoteipblocks.company.com",
+					Path:     "/",
+					IP:       "172.23.242.188",
+					WantCode: 200,
+				},
+				{
+					Name:     "deny 10.242.5.7",
+					Host:     "remoteipattr.company.com",
+					Path:     "/",
+					IP:       "10.242.5.7",
+					WantCode: 403,
+				},
+				{
+					Name:     "deny 10.124.99.10",
+					Host:     "remoteipattr.company.com",
+					Path:     "/",
+					IP:       "10.124.99.10",
+					WantCode: 403,
+				},
+				{
+					Name:     "allow 10.4.5.6",
+					Host:     "remoteipattr.company.com",
+					Path:     "/",
+					IP:       "10.4.5.6",
+					WantCode: 200,
 				},
 			}
 
 			for _, tc := range cases {
 				ctx.NewSubTest(tc.Name).Run(func(ctx framework.TestContext) {
-					authn.CheckIngressOrFail(ctx, ingr, tc.Host, tc.Path, "", tc.WantCode)
+					headers := map[string][]string{
+						"X-Forwarded-For": {tc.IP},
+					}
+					authn.CheckIngressOrFail(ctx, ingr, tc.Host, tc.Path, headers, "", tc.WantCode)
 				})
 			}
 		})

--- a/tests/integration/security/jwt_test.go
+++ b/tests/integration/security/jwt_test.go
@@ -462,7 +462,7 @@ func TestIngressRequestAuthentication(t *testing.T) {
 
 			for _, c := range ingTestCases {
 				ctx.NewSubTest(c.Name).Run(func(ctx framework.TestContext) {
-					authn.CheckIngressOrFail(ctx, ingr, c.Host, c.Path, c.Token, c.ExpectResponseCode)
+					authn.CheckIngressOrFail(ctx, ingr, c.Host, c.Path, nil, c.Token, c.ExpectResponseCode)
 				})
 			}
 		})

--- a/tests/integration/security/main_test.go
+++ b/tests/integration/security/main_test.go
@@ -34,9 +34,23 @@ var (
 func TestMain(m *testing.M) {
 	framework.
 		NewSuite(m).
-		Setup(istio.Setup(&ist, nil)).
+		Setup(istio.Setup(&ist, setupConfig)).
 		Setup(func(ctx resource.Context) error {
 			return util.SetupApps(ctx, ist, apps, true)
 		}).
 		Run()
+}
+
+func setupConfig(_ resource.Context, cfg *istio.Config) {
+	if cfg == nil {
+		return
+	}
+	cfg.ControlPlaneValues = `
+meshConfig:
+  accessLogEncoding: JSON
+  accessLogFile: /dev/stdout
+  defaultConfig:
+    gatewayTopology:
+      numTrustedProxies: 1
+`
 }

--- a/tests/integration/security/testdata/authz/v1beta1-ingress-gateway.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/v1beta1-ingress-gateway.yaml.tmpl
@@ -1,4 +1,8 @@
-# The following policy denies access to "internal.company.com" and path "/private"
+# The following policy denies access to "internal.company.com" and path "/private",
+# denies access from 172.17.72.46 or 192.168.4.0/23 to "remoteipblocks.company.com",
+# denies access from anything but 172.23.240.0/22 to "notremoteipblocks.company.com",
+# and denies access to "remoteipattr.company.com" when the remote ip is 10.242.5.7 or 
+# in the network 10.124.99.0/24.
 
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
@@ -16,6 +20,24 @@ spec:
             hosts: ["internal.company.com"]
         - operation:
             paths: ["/private"]
+    - from:
+        - source:
+            remoteIpBlocks: ["172.17.72.46", "192.168.4.0/23"]
+      to:
+        - operation:
+            hosts: ["remoteipblocks.company.com"]
+    - from:
+        - source:
+            notRemoteIpBlocks: ["172.23.240.0/22"]
+      to:
+        - operation:
+            hosts: ["notremoteipblocks.company.com"]
+    - to:
+        - operation:
+            hosts: ["remoteipattr.company.com"]
+      when:
+        - key: remote.ip
+          values: ["10.242.5.7", "10.124.99.0/24"]
 ---
 
 # The following gateway allows request to "*.company.com"

--- a/tests/integration/security/util/authn/authn_util.go
+++ b/tests/integration/security/util/authn/authn_util.go
@@ -72,15 +72,20 @@ func (c *TestCase) CheckAuthn() error {
 
 // CheckIngressOrFail checks a request for the ingress gateway.
 func CheckIngressOrFail(ctx framework.TestContext, ingr ingress.Instance, host string, path string,
-	token string, expectResponseCode int) {
+	headers map[string][]string, token string, expectResponseCode int) {
+	if headers == nil {
+		headers = map[string][]string{
+			"Host": {host},
+		}
+	} else {
+		headers["Host"] = []string{host}
+	}
 	opts := echo.CallOptions{
 		Port: &echo.Port{
 			Protocol: protocol.HTTP,
 		},
-		Path: path,
-		Headers: map[string][]string{
-			"Host": {host},
-		},
+		Path:      path,
+		Headers:   headers,
 		Validator: echo.ExpectCode(strconv.Itoa(expectResponseCode)),
 	}
 	if len(token) != 0 {
@@ -88,6 +93,5 @@ func CheckIngressOrFail(ctx framework.TestContext, ingr ingress.Instance, host s
 			fmt.Sprintf("Bearer %s", token),
 		}
 	}
-
 	ingr.CallEchoWithRetryOrFail(ctx, opts)
 }


### PR DESCRIPTION
cherry-pick https://github.com/istio/istio/pull/27906

* create remoteIpBlocks and update ipBlocks for AuthorizationPolicy

 By adding remoteIpBlocks and notRemoteIpBlocks in Source,
 an AuthorizationPolicy can trigger actions based on the original
 client IP address gleaned from the X-Forwarded-For header or the
 proxy protocol. The ipBlocks and notIpBlocks fields have also been
 updated to use direct_remote_ip in Envoy instead of source_ip

* use correct attribute for RemoteIpBlocks

* fix unit tests and add integration tests for remote.ip attribute

* fix notRemoteIp integration test

* initialize headers if it is nil

* Combine remoteIp tests into IngressGateway test and add release note

* add titles to links

* remove unneeded tests

* fix quotes in releasenote, run make gen

* make upgradeNotes a list

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
