### PR TITLE
Improve error when users use removed addon

### DIFF
--- a/operator/pkg/helm/fs_renderer_test.go
+++ b/operator/pkg/helm/fs_renderer_test.go
@@ -127,7 +127,7 @@ keywords:
 				helmChartDirPath: "foo/bar",
 			},
 			wantResult: "",
-			wantErr:    errors.New("stat foo/bar: no such file or directory"),
+			wantErr:    errors.New(`component "foo-component" does not exist`),
 		},
 	}
 	for _, tt := range tests {

--- a/operator/pkg/helm/vfs_renderer.go
+++ b/operator/pkg/helm/vfs_renderer.go
@@ -134,6 +134,9 @@ func (h *VFSRenderer) loadChart() error {
 	prefix := h.helmChartDirPath
 	fnames, err := vfs.GetFilesRecursive(prefix)
 	if err != nil {
+		if err.Error() == fmt.Sprintf("Asset %s not found", prefix) {
+			return missingComponentMessages(h.componentName)
+		}
 		return err
 	}
 	var bfs []*loader.BufferedFile


### PR DESCRIPTION
After and before:
```
$ grun ./istioctl/cmd/istioctl manifest generate --set addonComponents.foo.enabled=true -d manifests
Error: component "foo" does not exist
$ ik manifest generate --set addonComponents.foo.enabled=true -d manifests
Error: stat manifests/charts/addons/foo: no such file or directory
```



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.