### PR TITLE
Remove unnecessary warning log from ingress status watcher

### DIFF
--- a/pilot/pkg/config/kube/ingress/status.go
+++ b/pilot/pkg/config/kube/ingress/status.go
@@ -165,7 +165,6 @@ func (s *StatusSyncer) runningAddresses(ingressNs string) ([]string, error) {
 	if s.ingressService != "" {
 		svc, err := s.serviceLister.Services(ingressNs).Get(s.ingressService)
 		if err != nil {
-			log.Warnf("error retrieving ingress service with name %s in namespace %s", s.ingressService, ingressNs)
 			return nil, err
 		}
 


### PR DESCRIPTION
This warning spams clusters that have no ingress service (#28252)

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
