### PR TITLE
When installing istio-cni remove existing istio-cni plugin before inserting a new one

### DIFF
--- a/cni/pkg/install-cni/pkg/install/cniconfig.go
+++ b/cni/pkg/install-cni/pkg/install/cniconfig.go
@@ -306,6 +306,18 @@ func insertCNIConfig(newCNIConfig, existingCNIConfig []byte) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("existing CNI config: %v", err)
 		}
+
+		for i, rawPlugin := range plugins {
+			plugin, err := util.GetPlugin(rawPlugin)
+			if err != nil {
+				return nil, fmt.Errorf("existing CNI plugin: %v", err)
+			}
+			if plugin["type"] == "istio-cni" {
+				plugins = append(plugins[:i], plugins[i+1:]...)
+				break
+			}
+		}
+
 		newMap["plugins"] = append(plugins, istioMap)
 	}
 

--- a/cni/pkg/install-cni/pkg/install/cniconfig_test.go
+++ b/cni/pkg/install-cni/pkg/install/cniconfig_test.go
@@ -353,6 +353,11 @@ func TestInsertCNIConfig(t *testing.T) {
 			existingConfFilename: "list.conflist",
 			newConfFilename:      "istio-cni.conf",
 		},
+		{
+			name:                 "list network file with existing istio",
+			existingConfFilename: "list-with-istio.conflist",
+			newConfFilename:      "istio-cni.conf",
+		},
 	}
 
 	for _, c := range cases {

--- a/cni/pkg/install-cni/pkg/install/testdata/list-with-istio.conflist
+++ b/cni/pkg/install-cni/pkg/install/testdata/list-with-istio.conflist
@@ -1,0 +1,40 @@
+{
+  "cniVersion": "0.4.0",
+  "name": "dbnet",
+  "plugins": [
+    {
+      "args": {
+        "labels": {
+          "appVersion": "1.0"
+        }
+      },
+      "bridge": "cni0",
+      "dns": {
+        "nameservers": [
+          "10.1.0.1"
+        ]
+      },
+      "ipam": {
+        "gateway": "10.1.0.1",
+        "subnet": "10.1.0.0/16",
+        "type": "host-local"
+      },
+      "type": "bridge"
+    },
+    {
+      "sysctl": {
+        "net.core.somaxconn": "500"
+      },
+      "type": "tuning"
+    },
+    {
+      "kubernetes": {
+        "cni_bin_dir": "/path/cni/bin",
+        "kubeconfig": "/path/to/kubeconfig"
+      },
+      "log_level": "debug",
+      "name": "istio-cni",
+      "type": "istio-cni"
+    }
+  ]
+}

--- a/cni/pkg/install-cni/pkg/install/testdata/list-with-istio.conflist.golden
+++ b/cni/pkg/install-cni/pkg/install/testdata/list-with-istio.conflist.golden
@@ -1,0 +1,40 @@
+{
+  "cniVersion": "0.4.0",
+  "name": "dbnet",
+  "plugins": [
+    {
+      "args": {
+        "labels": {
+          "appVersion": "1.0"
+        }
+      },
+      "bridge": "cni0",
+      "dns": {
+        "nameservers": [
+          "10.1.0.1"
+        ]
+      },
+      "ipam": {
+        "gateway": "10.1.0.1",
+        "subnet": "10.1.0.0/16",
+        "type": "host-local"
+      },
+      "type": "bridge"
+    },
+    {
+      "sysctl": {
+        "net.core.somaxconn": "500"
+      },
+      "type": "tuning"
+    },
+    {
+      "kubernetes": {
+        "cni_bin_dir": "/path/cni/bin",
+        "kubeconfig": "/path/to/kubeconfig"
+      },
+      "log_level": "debug",
+      "name": "istio-cni",
+      "type": "istio-cni"
+    }
+  ]
+}

--- a/releasenotes/notes/27771.yaml
+++ b/releasenotes/notes/27771.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 27771
+releaseNotes:
+- |
+  **Fixed** how install-cni applies istio-cni plugin configuration,
+  Install-cni will now remove existing istio-cni plugins from the CNI config
+  before inserting istio-cni plugin configuration (new behaviour)
+  rather than just append a new configuration to the existing list (former behaviour).


### PR DESCRIPTION
Fixes: #27771 

Before the PR, istio-cni plugin configuration was inserted into the CNI plugin list everytime (e.g. after node reboot), which resulted in multiple istio-cni plugins in the final config. Which caused `iptables-restore` to fail and blocked `azure-cni` from making network requests needed to assign pod IP, causing pods fail to start.

PR adds code to remove existing `type: istio-cni` plugins from the config, before inserting the new plugin.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
