### PR TITLE
pilot: GlobalUnicastIP of a model.Proxy should be set to the 1st applicable IP address in the list

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -715,7 +715,7 @@ func (node *Proxy) DiscoverIPVersions() {
 			// skip it to prevent a panic.
 			continue
 		}
-		if addr.IsGlobalUnicast() {
+		if node.GlobalUnicastIP == "" && addr.IsGlobalUnicast() {
 			node.GlobalUnicastIP = addr.String()
 		}
 		if addr.To4() != nil {

--- a/pilot/pkg/model/context_test.go
+++ b/pilot/pkg/model/context_test.go
@@ -549,3 +549,52 @@ func TestSetServiceInstances(t *testing.T) {
 	assert.Equal(t, proxy.ServiceInstances[1].Service.Hostname, host.Name("test3.com"))
 	assert.Equal(t, proxy.ServiceInstances[2].Service.Hostname, host.Name("test1.com"))
 }
+
+func TestGlobalUnicastIP(t *testing.T) {
+	cases := []struct {
+		name   string
+		in     []string
+		expect string
+	}{
+		{
+			name:   "single IPv4 (k8s)",
+			in:     []string{"10.0.4.16"},
+			expect: "10.0.4.16",
+		},
+		{
+			name:   "single IPv6 (k8s)",
+			in:     []string{"fc00:f853:ccd:e793::1"},
+			expect: "fc00:f853:ccd:e793::1",
+		},
+		{
+			name:   "multi IPv4 [1st] (VM)",
+			in:     []string{"10.128.0.51", "fc00:f853:ccd:e793::1", "172.17.0.1", "fe80::42:35ff:fec1:7436", "fe80::345d:33ff:fe54:5c8e"},
+			expect: "10.128.0.51",
+		},
+		{
+			name:   "multi IPv6 [1st] (VM)",
+			in:     []string{"fc00:f853:ccd:e793::1", "172.17.0.1", "fe80::42:35ff:fec1:7436", "10.128.0.51", "fe80::345d:33ff:fe54:5c8e"},
+			expect: "fc00:f853:ccd:e793::1",
+		},
+		{
+			name:   "multi IPv4 [2nd] (VM)",
+			in:     []string{"127.0.0.1", "10.128.0.51", "fc00:f853:ccd:e793::1", "172.17.0.1", "fe80::42:35ff:fec1:7436", "fe80::345d:33ff:fe54:5c8e"},
+			expect: "10.128.0.51",
+		},
+		{
+			name:   "multi IPv6 [2nd] (VM)",
+			in:     []string{"fe80::42:35ff:fec1:7436", "fc00:f853:ccd:e793::1", "172.17.0.1", "10.128.0.51", "fe80::345d:33ff:fe54:5c8e"},
+			expect: "fc00:f853:ccd:e793::1",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			var node model.Proxy
+			node.IPAddresses = tt.in
+			node.DiscoverIPVersions()
+			if got := node.GlobalUnicastIP; got != tt.expect {
+				t.Errorf("GlobalUnicastIP = %v, want %v", got, tt.expect)
+			}
+		})
+	}
+}

--- a/releasenotes/notes/28269.yaml
+++ b/releasenotes/notes/28269.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 28269
+releaseNotes:
+- |
+  **Fixed** when a node has multiple IP addresses (e.g., a VM in the mesh expansion scenario),
+  Istio Proxy will now bind `inbound` listeners to the first applicable address in the list
+  (new behaviour) rather than to the last one (former behaviour).


### PR DESCRIPTION
Signed-off-by: Yaroslav Skopets <yaroslav@tetrate.io>

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.

## Summary

* This PR changes the algorithm of choosing the IP address to bind `inbound` listener to in case of a node with multiple IP addresses
  * In `k8s` case
    * nodes typically have only a single IP address
    * this PR doesn't affect this use case 
  * In `VM` case
    * nodes commonly have multiple IP addresses (1 physical, 1 Docker bridge, etc)
    * in that case a user wants be in control what IP address will be used to bind `inbound` listeners to
    * a user indicates the "primary" address of a node via the `INSTANCE_IP` environment variable or `--ip` flag to `pilot-agent`
    * up until now, `pilot` was picking the last applicable IP address (effectively ignoring user's choice of a "primary" IP address)
    * this PR changes this logic to pick the first applicable IP address instead

## Context

* Consider a mesh expansion use case:
  * a user has a VM with Docker on it (therefore, multiple IP addresses)
  * a user is not using IPtables redirection
  * a user defines a `WorkloadEntry` resource and sets `Address` field to the externally accessible IP address of a VM
  * at the moment, `Istio` will "ignore" this choice and bind `inbound` listener to IP address of a Docker bridge
  * a user could have used `Sidecar` resource to explicitly choose IP address to bind to, however
    * `Sidecar` resource is intended for a group of workloads; creating a `Sidecar` per `WorkloadEntry` (only to fix bind address) is a workaround rather than a long-term solution
    * although a user could have created a single `Sidecar` resource with `Bind: 0.0.0.0`, it would make it impossible to bind both user app and Istio Proxy to the same port (e.g., `10.0.0.1:8080` (Istio Proxy) and `127.0.0.1:8080` (user app))