### PR TITLE
Wait until ACK before sending additional pushes

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -386,4 +386,18 @@ var (
 
 	WorkloadEntryHealthChecks = env.RegisterBoolVar("PILOT_ENABLE_WORKLOAD_ENTRY_HEALTHCHECKS", false,
 		"Enables automatic health checks of WorkloadEntries based on the config provided in the associated WorkloadGroup").Get()
+
+	EnableFlowControl = env.RegisterBoolVar(
+		"PILOT_ENABLE_FLOW_CONTROL",
+		false,
+		"If enabled, pilot will wait for the completion of a receive operation before"+
+			"executing a push operation. This is a form of flow control and is useful in"+
+			"environments with high rates of push requests to each gateway. By default,"+
+			"this is false.").Get()
+
+	FlowControlTimeout = env.RegisterDurationVar(
+		"PILOT_FLOW_CONTROL_TIMEOUT",
+		15*time.Second,
+		"If set, the max amount of time to delay a push by. Depends on PILOT_ENABLE_FLOW_CONTROL.",
+	).Get()
 )

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -270,6 +270,9 @@ type WatchedResource struct {
 	// NonceAcked is the last acked message.
 	NonceAcked string
 
+	// NonceNacked is the last nacked message. This is reset following a successful ACK
+	NonceNacked string
+
 	// LastSent tracks the time of the generated push, to determine the time it takes the client to ack.
 	LastSent time.Time
 

--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -22,9 +22,11 @@ import (
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"google.golang.org/genproto/googleapis/rpc/status"
 
 	mesh "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/util/sets"
 	"istio.io/istio/pilot/pkg/xds"
@@ -40,6 +42,7 @@ import (
 	"istio.io/istio/pkg/security"
 	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/tests/util"
+	"istio.io/pkg/log"
 )
 
 const (
@@ -753,6 +756,68 @@ func TestEnvoyRDSProtocolError(t *testing.T) {
 		ResourceNames: []string{routeA, routeB},
 		VersionInfo:   res.VersionInfo,
 		ResponseNonce: res.Nonce,
+	})
+}
+
+func TestBlockedPush(t *testing.T) {
+	original := features.EnableFlowControl
+	t.Cleanup(func() {
+		features.EnableFlowControl = original
+	})
+	t.Run("flow control enabled", func(t *testing.T) {
+		features.EnableFlowControl = true
+		log.FindScope("ads").SetOutputLevel(log.DebugLevel)
+		features.EnableFlowControl = true
+		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+		ads := s.ConnectADS().WithType(v3.ClusterType)
+		ads.RequestResponseAck(nil)
+		// Send push, get a response but do not ACK it
+		xds.AdsPushAll(s.Discovery)
+		res := ads.ExpectResponse()
+
+		// Another push results in no response as we are blocked
+		xds.AdsPushAll(s.Discovery)
+		ads.ExpectNoResponse()
+
+		// ACK, unblocking the previous push
+		ads.Request(&discovery.DiscoveryRequest{ResponseNonce: res.Nonce})
+		ads.ExpectResponse()
+	})
+	t.Run("flow control enabled NACK", func(t *testing.T) {
+		log.FindScope("ads").SetOutputLevel(log.DebugLevel)
+		features.EnableFlowControl = true
+		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+		ads := s.ConnectADS().WithType(v3.ClusterType)
+		ads.RequestResponseAck(nil)
+		// Send push, get a response and NACK it
+		xds.AdsPushAll(s.Discovery)
+		res := ads.ExpectResponse()
+		ads.Request(&discovery.DiscoveryRequest{ResponseNonce: res.Nonce, ErrorDetail: &status.Status{Message: "Test request NACK"}})
+
+		// Another push results in no response as we are blocked
+		xds.AdsPushAll(s.Discovery)
+		ads.ExpectResponse()
+
+		// ACK, unblocking the previous push
+		ads.Request(&discovery.DiscoveryRequest{ResponseNonce: res.Nonce})
+		ads.ExpectNoResponse()
+	})
+	t.Run("flow control disabled", func(t *testing.T) {
+		features.EnableFlowControl = false
+		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+		ads := s.ConnectADS().WithType(v3.ClusterType)
+		ads.RequestResponseAck(nil)
+		// Send push, get a response but do not ACK it
+		xds.AdsPushAll(s.Discovery)
+		res := ads.ExpectResponse()
+
+		// Another push results in response as we do not care that we are blocked
+		xds.AdsPushAll(s.Discovery)
+		ads.ExpectResponse()
+
+		// ACK, unblocking the previous push
+		ads.Request(&discovery.DiscoveryRequest{ResponseNonce: res.Nonce})
+		ads.ExpectNoResponse()
 	})
 }
 

--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -784,6 +784,13 @@ func TestBlockedPush(t *testing.T) {
 		// ACK again, ensure we do not response
 		ads.Request(&discovery.DiscoveryRequest{ResponseNonce: res.Nonce})
 		ads.ExpectNoResponse()
+
+		// request new resources, expect response
+		ads.Request(&discovery.DiscoveryRequest{ResponseNonce: res.Nonce, ResourceNames: []string{"foo"}})
+		res = ads.ExpectResponse()
+		// request new resources, expect response, even without explicit ACK
+		ads.Request(&discovery.DiscoveryRequest{ResponseNonce: res.Nonce, ResourceNames: []string{"foo", "bar"}})
+		ads.ExpectResponse()
 	})
 	t.Run("flow control enabled NACK", func(t *testing.T) {
 		log.FindScope("ads").SetOutputLevel(log.DebugLevel)

--- a/pilot/pkg/xds/monitoring.go
+++ b/pilot/pkg/xds/monitoring.go
@@ -65,6 +65,21 @@ var (
 		monitoring.WithLabels(typeTag),
 	)
 
+	// Number of delayed pushes. Currently this happens only when the last push has not been ACKed
+	totalDelayedPushes = monitoring.NewSum(
+		"pilot_xds_delayed_pushes_total",
+		"Total number of XDS pushes that are delayed.",
+		monitoring.WithLabels(typeTag),
+	)
+
+	// Number of delayed pushes that we pushed prematurely as a failsafe.
+	// This indicates that either the failsafe timeout is too aggressive or there is a deadlock
+	totalDelayedPushTimeouts = monitoring.NewSum(
+		"pilot_xds_delayed_push_timeouts_total",
+		"Total number of XDS pushes that are delayed and timed out",
+		monitoring.WithLabels(typeTag),
+	)
+
 	xdsExpiredNonce = monitoring.NewSum(
 		"pilot_xds_expired_nonce",
 		"Total number of XDS requests with an expired nonce.",
@@ -235,5 +250,7 @@ func init() {
 		inboundUpdates,
 		pushTriggers,
 		sendTime,
+		totalDelayedPushes,
+		totalDelayedPushTimeouts,
 	)
 }

--- a/releasenotes/notes/backpressure.yaml
+++ b/releasenotes/notes/backpressure.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+issue:
+- https://github.com/istio/istio/issues/25685
+releaseNotes:
+- |
+  **Added** support for backpressure on XDS pushes to avoid overloading Envoy during periods of high configuration
+  churn. This is disabled by default and can be enabled by setting the PILOT_ENABLE_FLOW_CONTROL environment variable in Istiod.
+


### PR DESCRIPTION
Fixes: #25685

At large scale, Envoy suffers from overload of XDS pushes, and there is
no backpressure in the system. Other control planes, such as any based
on go-control-plane, outperform Istio in config update propogations
under load as a result.

This changes adds a backpressure mechanism to ensure we do not push more
configs than Envoy can handle. By slowing down the pushes, the
propogation time of new configurations actually increases. We do this by
keeping note, but not sending, any push requests where that TypeUrl has
an un-ACKed request in flight. When we get an ACK, if there is a pending
push request we will immediately trigger it. This effectively means that
in a high churn environment, each proxy will always have exactly 1
outstanding push per type, and when the ACK is recieved we will
immediately send a new update.

This graph shows the time between sending a VirtualService and the route being active in Envoy. X axis is number of virtual services, Y axis is ms to get ready:

![2020-04-09_15-55-30](https://user-images.githubusercontent.com/623453/97120921-f3dc1a80-16d7-11eb-870e-a59349c48b1a.png)

This PR is co-authored by Steve, who did a huge amount of work in
developing this into the state it is today, as wel as finding and
testing the problem. See https://github.com/istio/istio/pull/27563 for
much of this work.

Co-Authored-By: Steven Dake sdake@ibm.com
