### PR TITLE
Add ingress status integration test

### DIFF
--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -16,6 +16,7 @@
 package pilot
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -23,8 +24,10 @@ import (
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/environment/kube"
 	"istio.io/istio/pkg/test/util/retry"
 	ingressutil "istio.io/istio/tests/integration/security/sds_ingress/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGateway(t *testing.T) {
@@ -257,5 +260,23 @@ spec:
 					apps.Ingress.CallEchoWithRetryOrFail(ctx, c.call, retry.Timeout(time.Minute*2))
 				})
 			}
+
+			t.Run("status", func(t *testing.T) {
+				if !ctx.Environment().(*kube.Environment).Settings().LoadBalancerSupported {
+					t.Skip("ingress status not supported without load balancer")
+				}
+				ip := apps.Ingress.HTTPAddress().IP.String()
+				retry.UntilSuccessOrFail(t, func() error {
+					ing, err := ctx.Clusters().Default().NetworkingV1beta1().Ingresses(apps.Namespace.Name()).Get(context.Background(), "istio-test", metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+					if len(ing.Status.LoadBalancer.Ingress) != 1 || ing.Status.LoadBalancer.Ingress[0].IP != ip {
+						return fmt.Errorf("unexpected ingress status, got %+v want %v", ing.Status.LoadBalancer, ip)
+					}
+					return nil
+				})
+
+			})
 		})
 }


### PR DESCRIPTION
Adds an integration test to make sure ingress status is updated for ingresses we're handling (#28225) 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
