### PR TITLE
pilot: skip privileged ports when building listeners for non-root gateways

### DIFF
--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -38,9 +38,6 @@ spec:
 {{- else}}
         service.istio.io/canonical-revision: latest
 {{- end }}
-{{- if not $gateway.runAsRoot }}
-        istio.io/unprivileged-pod: "true"
-{{- end }}
       annotations:
         {{- if .Values.meshConfig.enablePrometheusMerge }}
         prometheus.io/port: "15020"
@@ -209,7 +206,11 @@ spec:
           - name: ISTIO_META_MESH_ID
             value: "{{ $.Values.global.trustDomain }}"
           {{- end }}
-          {{- if $gateway.env }}
+          {{- if not $gateway.runAsRoot }}
+          - name: ISTIO_META_UNPRIVILEGED_POD
+            value: "true"
+          {{- end }}
+            {{- if $gateway.env }}
           {{- range $key, $val := $gateway.env }}
           - name: {{ $key }}
             value: {{ $val }}

--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -38,6 +38,9 @@ spec:
 {{- else}}
         service.istio.io/canonical-revision: latest
 {{- end }}
+{{- if not $gateway.runAsRoot }}
+        istio.io/unprivileged-pod: "true"
+{{- end }}
       annotations:
         {{- if .Values.meshConfig.enablePrometheusMerge }}
         prometheus.io/port: "15020"

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -38,6 +38,9 @@ spec:
         {{- else}}
         service.istio.io/canonical-revision: latest
         {{- end }}
+{{- if not $gateway.runAsRoot }}
+        istio.io/unprivileged-pod: "true"
+{{- end }}
       annotations:
         {{- if .Values.meshConfig.enablePrometheusMerge }}
         prometheus.io/port: "15020"

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -38,9 +38,6 @@ spec:
         {{- else}}
         service.istio.io/canonical-revision: latest
         {{- end }}
-{{- if not $gateway.runAsRoot }}
-        istio.io/unprivileged-pod: "true"
-{{- end }}
       annotations:
         {{- if .Values.meshConfig.enablePrometheusMerge }}
         prometheus.io/port: "15020"
@@ -214,6 +211,10 @@ spec:
           {{- else if $.Values.global.trustDomain }}
           - name: ISTIO_META_MESH_ID
             value: "{{ $.Values.global.trustDomain }}"
+          {{- end }}
+          {{- if not $gateway.runAsRoot }}
+          - name: ISTIO_META_UNPRIVILEGED_POD
+            value: "true"
           {{- end }}
           {{- range $key, $val := $gateway.env }}
           - name: {{ $key }}

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -492,6 +492,9 @@ type NodeMetadata struct {
 	// AutoRegister will enable auto registration of the connected endpoint to the service registry using the given WorkloadGroup name
 	AutoRegisterGroup string `json:"AUTO_REGISTER_GROUP,omitempty"`
 
+	// UnprivilegedPod is used to determine whether a Gateway Pod can open ports < 1024
+	UnprivilegedPod string `json:"UNPRIVILEGED_POD,omitempty"`
+
 	// Contains a copy of the raw metadata. This is needed to lookup arbitrary values.
 	// If a value is known ahead of time it should be added to the struct rather than reading from here,
 	Raw map[string]interface{} `json:"-"`

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -78,6 +78,14 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(builder *ListenerBui
 		if si != nil && si.Endpoint != nil {
 			portNumber = si.Endpoint.EndpointPort
 		}
+		// TODO: replace with reference to istio/api var
+		labelName := "istio.io/unprivileged-pod"
+		if builder.node.Metadata.Labels[labelName] != "" && portNumber < 1024 {
+			log.Warnf("buildGatewayListeners: skipping privileged gateway port %d for node %s due to %s label being set",
+				portNumber, builder.node.ID, labelName)
+			continue
+		}
+
 		// on a given port, we can either have plain text HTTP servers or
 		// HTTPS/TLS servers with SNI. We cannot have a mix of http and https server on same port.
 		opts := buildListenerOpts{

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -78,11 +78,9 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(builder *ListenerBui
 		if si != nil && si.Endpoint != nil {
 			portNumber = si.Endpoint.EndpointPort
 		}
-		// TODO: replace with reference to istio/api var
-		labelName := "istio.io/unprivileged-pod"
-		if builder.node.Metadata.Labels[labelName] != "" && portNumber < 1024 {
-			log.Warnf("buildGatewayListeners: skipping privileged gateway port %d for node %s due to %s label being set",
-				portNumber, builder.node.ID, labelName)
+		if builder.node.Metadata.UnprivilegedPod != "" && portNumber < 1024 {
+			log.Warnf("buildGatewayListeners: skipping privileged gateway port %d for node %s as it is an unprivileged pod",
+				portNumber, builder.node.ID)
 			continue
 		}
 

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -1410,9 +1410,7 @@ func TestBuildGatewayListeners(t *testing.T) {
 			"privileged port on unprivileged pod",
 			&pilot_model.Proxy{
 				Metadata: &pilot_model.NodeMetadata{
-					Labels: map[string]string{
-						"istio.io/unprivileged-pod": "true",
-					},
+					UnprivilegedPod: "true",
 				},
 			},
 			&networking.Gateway{

--- a/pilot/pkg/networking/core/v1alpha3/gateway_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_test.go
@@ -1406,6 +1406,42 @@ func TestBuildGatewayListeners(t *testing.T) {
 			},
 			[]string{"0.0.0.0_80", "0.0.0.0_801"},
 		},
+		{
+			"privileged port on unprivileged pod",
+			&pilot_model.Proxy{
+				Metadata: &pilot_model.NodeMetadata{
+					Labels: map[string]string{
+						"istio.io/unprivileged-pod": "true",
+					},
+				},
+			},
+			&networking.Gateway{
+				Servers: []*networking.Server{
+					{
+						Port: &networking.Port{Name: "http", Number: 80, Protocol: "HTTP"},
+					},
+					{
+						Port: &networking.Port{Name: "http", Number: 8080, Protocol: "HTTP"},
+					},
+				},
+			},
+			[]string{"0.0.0.0_8080"},
+		},
+		{
+			"privileged port on privileged pod",
+			&pilot_model.Proxy{},
+			&networking.Gateway{
+				Servers: []*networking.Server{
+					{
+						Port: &networking.Port{Name: "http", Number: 80, Protocol: "HTTP"},
+					},
+					{
+						Port: &networking.Port{Name: "http", Number: 8080, Protocol: "HTTP"},
+					},
+				},
+			},
+			[]string{"0.0.0.0_80", "0.0.0.0_8080"},
+		},
 	}
 
 	for _, tt := range cases {
@@ -1414,6 +1450,12 @@ func TestBuildGatewayListeners(t *testing.T) {
 		})
 		proxy := cg.SetupProxy(&proxyGateway)
 		proxy.ServiceInstances = tt.node.ServiceInstances
+		if tt.node.Metadata != nil {
+			proxy.Metadata = tt.node.Metadata
+		} else {
+			proxy.Metadata = &proxyGatewayMetadata
+		}
+
 		builder := cg.ConfigGen.buildGatewayListeners(&ListenerBuilder{node: proxy, push: cg.PushContext()})
 		listeners := xdstest.ExtractListenerNames(builder.gatewayListeners)
 		sort.Strings(listeners)

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -94,17 +94,18 @@ var (
 		ConfigNamespace: "not-default",
 	}
 	proxyGateway = model.Proxy{
-		Type:        model.Router,
-		IPAddresses: []string{"1.1.1.1"},
-		ID:          "v0.default",
-		DNSDomain:   "default.example.org",
-		Metadata: &model.NodeMetadata{
-			Namespace: "not-default",
-			Labels: map[string]string{
-				"istio": "ingressgateway",
-			},
-		},
+		Type:            model.Router,
+		IPAddresses:     []string{"1.1.1.1"},
+		ID:              "v0.default",
+		DNSDomain:       "default.example.org",
+		Metadata:        &proxyGatewayMetadata,
 		ConfigNamespace: "not-default",
+	}
+	proxyGatewayMetadata = model.NodeMetadata{
+		Namespace: "not-default",
+		Labels: map[string]string{
+			"istio": "ingressgateway",
+		},
 	}
 	proxyInstances = []*model.ServiceInstance{
 		{

--- a/releasenotes/notes/27566.yaml
+++ b/releasenotes/notes/27566.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+  - 27566
+releaseNotes:
+  - |
+    **Fixed** istiod will no longer generate listeners for privileged gateway ports (<1024) if the gateway Pod does not have sufficient permissions


### PR DESCRIPTION
To fix #27566 -- even though the crash is gone, the gateway will still send a NACK and will essentially be blocked from receiving further updates.

I tried to make it as non-intrusive as possible, only marking the pod if you're deploying a non-root gateway, so that root gateway deployments do not require any changes (as they're also not affected by the problem).