### PR TITLE
cherry-pick: pilot: GlobalUnicastIP of a model.Proxy should be set to the 1st applicable IP address in the list (#28260)

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -740,7 +740,7 @@ func (node *Proxy) DiscoverIPVersions() {
 			// skip it to prevent a panic.
 			continue
 		}
-		if addr.IsGlobalUnicast() {
+		if node.GlobalUnicastIP == "" && addr.IsGlobalUnicast() {
 			node.GlobalUnicastIP = addr.String()
 		}
 		if addr.To4() != nil {

--- a/releasenotes/notes/28269.yaml
+++ b/releasenotes/notes/28269.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: traffic-management
+issue:
+- 28269
+releaseNotes:
+- |
+  **Fixed** when a node has multiple IP addresses (e.g., a VM in the mesh expansion scenario),
+  Istio Proxy will now bind `inbound` listeners to the first applicable address in the list
+  (new behaviour) rather than to the last one (former behaviour).


### PR DESCRIPTION
Signed-off-by: Yaroslav Skopets <yaroslav@tetrate.io>

## Summary

* cherry-picking https://github.com/istio/istio/pull/28260 into `release-1.7`