### PR TITLE
Make ingress gateway selector in status watcher match the one used to generate gateway

### DIFF
--- a/pilot/pkg/config/kube/ingress/conversion.go
+++ b/pilot/pkg/config/kube/ingress/conversion.go
@@ -292,7 +292,6 @@ func shouldProcessIngressWithClass(mesh *meshconfig.MeshConfig, ingress *v1beta1
 			return false
 		}
 	} else if ingressClass != nil {
-		// TODO support ingressclass.kubernetes.io/is-default-class annotation
 		return ingressClass.Spec.Controller == IstioIngressController
 	} else {
 		switch mesh.IngressControllerMode {
@@ -334,12 +333,7 @@ func createFallbackStringMatch(s string) *networking.StringMatch {
 	}
 }
 
-// defaultSelector defines the default selector that will be used if one is not provided
-// This will select the default ingressgateway deployment provided by the standard installation
-// Configurable by meshConfig.ingressSelector.
-var defaultSelector = labels.Instance{constants.IstioLabel: constants.IstioIngressLabelValue}
-
-func getIngressGatewaySelector(ingressSelector, ingressService string) labels.Instance {
+func getIngressGatewaySelector(ingressSelector, ingressService string) map[string]string {
 	// Setup the selector for the gateway
 	if ingressSelector != "" {
 		// If explicitly defined, use this one
@@ -350,6 +344,8 @@ func getIngressGatewaySelector(ingressSelector, ingressService string) labels.In
 		// However, if its istio-ingressgateway we need to use the old values for backwards compatibility
 		return labels.Instance{constants.IstioLabel: ingressService}
 	} else {
-		return defaultSelector
+		// If we have neither an explicitly defined ingressSelector or ingressService then use a selector
+		// pointing to the ingressgateway from the default installation
+		return labels.Instance{constants.IstioLabel: constants.IstioIngressLabelValue}
 	}
 }

--- a/pilot/pkg/config/kube/ingress/conversion.go
+++ b/pilot/pkg/config/kube/ingress/conversion.go
@@ -74,26 +74,10 @@ func decodeIngressRuleName(name string) (ingressName string, ruleNum, pathNum in
 	return
 }
 
-// defaultSelector defines the default selector that will be used if one is not provided
-// This will select the default ingressgateway deployment provided by the standard installation
-// Configurable by meshConfig.ingressSelector.
-var defaultSelector = labels.Instance{constants.IstioLabel: constants.IstioIngressLabelValue}
-
 // ConvertIngressV1alpha3 converts from ingress spec to Istio Gateway
 func ConvertIngressV1alpha3(ingress v1beta1.Ingress, mesh *meshconfig.MeshConfig, domainSuffix string) config.Config {
 	gateway := &networking.Gateway{}
-	// Setup the selector for the gateway
-	if mesh.IngressSelector != "" {
-		// If explicitly defined, use this one
-		gateway.Selector = labels.Instance{constants.IstioLabel: mesh.IngressSelector}
-	} else if mesh.IngressService != "istio-ingressgateway" && mesh.IngressService != "" {
-		// Otherwise, we will use the ingress service as the default. It is common for the selector and service
-		// to be the same, so this removes the need for two configurations
-		// However, if its istio-ingressgateway we need to use the old values for backwards compatibility
-		gateway.Selector = labels.Instance{constants.IstioLabel: mesh.IngressService}
-	} else {
-		gateway.Selector = defaultSelector
-	}
+	gateway.Selector = getIngressGatewaySelector(mesh.IngressSelector, mesh.IngressService)
 
 	for i, tls := range ingress.Spec.TLS {
 		if tls.SecretName == "" {
@@ -347,5 +331,25 @@ func createFallbackStringMatch(s string) *networking.StringMatch {
 	// Replace e.g. "foo" with a exact match
 	return &networking.StringMatch{
 		MatchType: &networking.StringMatch_Exact{Exact: s},
+	}
+}
+
+// defaultSelector defines the default selector that will be used if one is not provided
+// This will select the default ingressgateway deployment provided by the standard installation
+// Configurable by meshConfig.ingressSelector.
+var defaultSelector = labels.Instance{constants.IstioLabel: constants.IstioIngressLabelValue}
+
+func getIngressGatewaySelector(ingressSelector, ingressService string) labels.Instance {
+	// Setup the selector for the gateway
+	if ingressSelector != "" {
+		// If explicitly defined, use this one
+		return labels.Instance{constants.IstioLabel: ingressSelector}
+	} else if ingressService != "istio-ingressgateway" && ingressService != "" {
+		// Otherwise, we will use the ingress service as the default. It is common for the selector and service
+		// to be the same, so this removes the need for two configurations
+		// However, if its istio-ingressgateway we need to use the old values for backwards compatibility
+		return labels.Instance{constants.IstioLabel: ingressService}
+	} else {
+		return defaultSelector
 	}
 }

--- a/pilot/pkg/config/kube/ingress/conversion.go
+++ b/pilot/pkg/config/kube/ingress/conversion.go
@@ -83,10 +83,10 @@ var defaultSelector = labels.Instance{constants.IstioLabel: constants.IstioIngre
 func ConvertIngressV1alpha3(ingress v1beta1.Ingress, mesh *meshconfig.MeshConfig, domainSuffix string) config.Config {
 	gateway := &networking.Gateway{}
 	// Setup the selector for the gateway
-	if len(mesh.IngressSelector) > 0 {
+	if mesh.IngressSelector != "" {
 		// If explicitly defined, use this one
 		gateway.Selector = labels.Instance{constants.IstioLabel: mesh.IngressSelector}
-	} else if mesh.IngressService != "istio-ingressgateway" {
+	} else if mesh.IngressService != "istio-ingressgateway" && mesh.IngressService != "" {
 		// Otherwise, we will use the ingress service as the default. It is common for the selector and service
 		// to be the same, so this removes the need for two configurations
 		// However, if its istio-ingressgateway we need to use the old values for backwards compatibility


### PR DESCRIPTION
Before, if there was no `IngressService` specified, we would use the `app: ingressgateway` selector to find running IngressGateway instances. However, we should be taking into account  the `IngressSelector` config option (and use `istio: ingressgateway` as the default). Also adds a missing check for unspecified (`""`) IngressService (from #27751). 

However, before merging this, I'm pretty confused on why the behavior here is how it is in the first place: https://github.com/istio/istio/blob/22d9a05c0f85a9da74e17211d50087a7dc713dc5/pilot/pkg/config/kube/ingress/status.go#L184-L209

Why does it make sense to add the public IPs of nodes running IngressGateways to the Ingress's status if no IngressService is specified? The service meant to be exposed in the Ingress won't actually be reachable at those addresses, right? (didn't want to remove it in case I'm just not understanding why we're doing it that way)

Update: never-mind on that last part, I understand now. Didn't realize that creating `LoadBalancer` service automatically created `NodePort` service.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
