### PR TITLE
update warning message for upgrading istio version

### DIFF
--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -249,7 +249,7 @@ func DetectIstioVersionDiff(cmd *cobra.Command, tag string, kubeClient kube.Exte
 		// when the revision is not passed
 		if iArgs.revision == "" && tag != icpTag {
 			cmd.Printf("! Istio control planes installed: %s.\n"+
-				"! Use --revision or --force to install Istio.\n", strings.Join(icpTags, ", "))
+				"! An older installed version of Istio has been detected. Running this command will overwrite it.\n", strings.Join(icpTags, ", "))
 		}
 		// when the revision is passed
 		if icpTag != "" && tag != icpTag && iArgs.revision != "" {

--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -254,7 +254,7 @@ func DetectIstioVersionDiff(cmd *cobra.Command, tag string, kubeClient kube.Exte
 		// when the revision is passed
 		if icpTag != "" && tag != icpTag && iArgs.revision != "" {
 			cmd.Printf("! Istio is being upgraded from %s -> %s.\n"+
-				"! Before upgrading, you may wish to 'istioctl analyze' to check for IST0002 deprecation warnings.\n", icpTag, tag)
+				"! Before upgrading, you may wish to use 'istioctl analyze' to check for IST0002 deprecation warnings.\n", icpTag, tag)
 		}
 	}
 	return nil


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/28208

Before:
```
$ istioctl install --set hub=gcr.io/istio-testing -d manifests/
! Istio control planes installed: 1.7.3.
! Use --revision or --force to install Istio.
This will install the Istio 1.8.0 profile into the cluster. Proceed? (y/N)
```

After:
```
$ istioctl install --set hub=gcr.io/istio-testing -d manifests/
! Istio control planes installed: 1.7.3.
! An older installed version of Istio has been detected. Running this command will overwrite it.
This will install the Istio 1.9.0 profile into the cluster. Proceed? (y/N)
```

```
$ istioctl install --revision=1-9-0 --set hub=gcr.io/istio-testing -d manifests/
! Istio is being upgraded from 1.7.3 -> 1.9.0.
! Before upgrading, you may wish to use 'istioctl analyze' to check for IST0002 deprecation warnings.
This will install the Istio 1.9.0 profile into the cluster. Proceed? (y/N)
```

```
$ kubectl get pods -n istio-system
NAME                                    READY   STATUS    RESTARTS   AGE
istio-ingressgateway-5bdb464488-gtp6h   1/1     Running   0          35s
istiod-1-7-3-b5c499b7b-nvfcp            1/1     Running   0          6m54s
istiod-1-9-0-fd59b7bf8-bdq9n            1/1     Running   0          59s
```
