### PR TITLE
istioctl analyze: check targetPort instead of port for gateway

### DIFF
--- a/galley/pkg/config/analysis/analyzers/gateway/gateway.go
+++ b/galley/pkg/config/analysis/analyzers/gateway/gateway.go
@@ -86,7 +86,7 @@ func (*IngressGatewayPortAnalyzer) analyzeGateway(r *resource.Instance, c analys
 				if svcSelector.Matches(podLabels) {
 					for _, port := range service.Ports {
 						if port.Protocol == "TCP" {
-							servicePorts[uint32(port.Port)] = true
+							servicePorts[uint32(port.TargetPort.IntValue())] = true
 						}
 					}
 				}

--- a/galley/pkg/config/analysis/analyzers/testdata/gateway-custom-ingressgateway-badport.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/gateway-custom-ingressgateway-badport.yaml
@@ -36,6 +36,6 @@ spec:
     nodePort: 31380
     port: 8003
     protocol: TCP
-    targetPort: 80
+    targetPort: 8003
   selector:
     myapp: private-ingressgateway

--- a/galley/pkg/config/analysis/analyzers/testdata/gateway-custom-ingressgateway-svcselector.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/gateway-custom-ingressgateway-svcselector.yaml
@@ -62,7 +62,7 @@ spec:
     nodePort: 31380
     port: 8002
     protocol: TCP
-    targetPort: 80
+    targetPort: 8002
   selector:
     myapp: ingressgateway-8002
 ---
@@ -75,6 +75,7 @@ spec:
   - name: http2
     port: 8001
     protocol: TCP
+    targetPort: 8001
   selector:
     myapp: ingressgateway-8001
     

--- a/galley/pkg/config/analysis/analyzers/testdata/gateway-custom-ingressgateway.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/gateway-custom-ingressgateway.yaml
@@ -36,6 +36,6 @@ spec:
     nodePort: 31380
     port: 8003
     protocol: TCP
-    targetPort: 80
+    targetPort: 8003
   selector:
     myapp: private-ingressgateway


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/28259

Use https://github.com/istio/istio/issues/28259#issue-729120543 instruction to setup `frontend-gateway`, then run analyzer.

Before:
```
$ istioctl analyze -n default
Warning [IST0104] (Gateway frontend-gateway.default) The gateway refers to a port that is not exposed on the workload (pod selector istio=ingressgateway; port 8080)
Info [IST0102] (Namespace default) The namespace is not enabled for Istio injection. Run 'kubectl label namespace default istio-injection=enabled' to enable it, or 'kubectl label namespace default istio-injection=disabled' to explicitly mark it as not needing injection.
```

After:
```
$ istioctl analyze -n default
Info [IST0102] (Namespace default) The namespace is not enabled for Istio injection. Run 'kubectl label namespace default istio-injection=enabled' to enable it, or 'kubectl label namespace default istio-injection=disabled' to explicitly mark it as not needing injection.
```