### PR TITLE
Xds proxy improve

### DIFF
--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -51,12 +51,7 @@ import (
 	"istio.io/istio/pkg/istio-agent/metrics"
 	"istio.io/istio/pkg/mcp/status"
 	"istio.io/istio/pkg/uds"
-	"istio.io/pkg/filewatcher"
 	"istio.io/pkg/log"
-)
-
-var (
-	newFileWatcher = filewatcher.NewWatcher
 )
 
 const (
@@ -286,7 +281,7 @@ func (p *XdsProxy) HandleUpstream(ctx context.Context, con *ProxyConnection, xds
 }
 
 func (p *XdsProxy) handleUpstreamRequest(ctx context.Context, con *ProxyConnection) {
-	defer con.upstream.CloseSend()
+	defer con.upstream.CloseSend() // nolint
 	for {
 		select {
 		case req := <-con.requestsChan:


### PR DESCRIPTION
This solves two main issues:

1. prevent upstream receive goroutine from leaking
2. split upstream request handling and response handling, as we know the send could take very long