### PR TITLE
skip ingress test in multicluster

### DIFF
--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -140,6 +140,9 @@ func TestIngress(t *testing.T) {
 	framework.
 		NewTest(t).
 		Run(func(ctx framework.TestContext) {
+			if ctx.Clusters().IsMulticluster() {
+				t.Skip("TODO convert this test to support multicluster")
+			}
 			skipIfIngressClassUnsupported(ctx)
 			// Set up secret contain some TLS certs for *.example.com
 			// we will define one for foo.example.com and one for bar.example.com, to ensure both can co-exist


### PR DESCRIPTION
The sooner we get multicluster pilot test consistently passing, the sooner we can make it required and avoid having new things be added without passing under multi-cluster mode. 

