### PR TITLE
GetProxyServiceInstances cleanup

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -959,3 +959,8 @@ func (node *Proxy) GetInterceptionMode() TrafficInterceptionMode {
 
 	return InterceptionRedirect
 }
+
+func (node *Proxy) IsVM() bool {
+	// TODO use node metadata to indicate that this is a VM intstead of the TestVMLabel
+	return node.Metadata != nil && node.Metadata.Labels[constants.TestVMLabel] != ""
+}

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -242,8 +242,6 @@ func skipSearchingRegistryForProxy(nodeClusterID, registryClusterID, selfCluster
 // GetProxyServiceInstances lists service instances co-located with a given proxy
 func (c *Controller) GetProxyServiceInstances(node *model.Proxy) []*model.ServiceInstance {
 	out := make([]*model.ServiceInstance, 0)
-	// It doesn't make sense for a single proxy to be found in more than one registry.
-	// TODO: if otherwise, warning or else what to do about it.
 	for _, r := range c.GetRegistries() {
 		nodeClusterID := nodeClusterID(node)
 		if skipSearchingRegistryForProxy(nodeClusterID, r.Cluster(), features.ClusterName) {
@@ -255,7 +253,6 @@ func (c *Controller) GetProxyServiceInstances(node *model.Proxy) []*model.Servic
 		instances := r.GetProxyServiceInstances(node)
 		if len(instances) > 0 {
 			out = append(out, instances...)
-			break
 		}
 	}
 

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -850,7 +850,7 @@ func (c *Controller) GetProxyServiceInstances(proxy *model.Proxy) []*model.Servi
 		pod := c.pods.getPodByIP(proxyIP)
 		if workload, f := c.workloadInstancesByIP[proxyIP]; f {
 			return c.hydrateWorkloadInstance(workload)
-		} else if pod != nil {
+		} else if pod != nil && proxy.Metadata.Labels["istio.io/test-vm"] == "" {
 			if !c.isControllerForProxy(proxy) {
 				log.Errorf("proxy is in cluster %v, but controller is for cluster %v", proxy.Metadata.ClusterID, c.clusterID)
 				return nil
@@ -1013,7 +1013,7 @@ func (c *Controller) onNamespaceEvent(obj interface{}, ev model.Event) error {
 // isControllerForProxy should be used for proxies assumed to be in the kube cluster for this controller. Workload Entries
 // may not necessarily pass this check, but we still want to allow kube services to select workload instances.
 func (c *Controller) isControllerForProxy(proxy *model.Proxy) bool {
-	return proxy.Metadata.ClusterID == c.clusterID
+	return proxy.Metadata.ClusterID == "" || proxy.Metadata.ClusterID == c.clusterID
 }
 
 // getProxyServiceInstancesFromMetadata retrieves ServiceInstances using proxy Metadata rather than

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -852,8 +852,8 @@ func (c *Controller) GetProxyServiceInstances(proxy *model.Proxy) []*model.Servi
 		if workload, f := c.workloadInstancesByIP[proxyIP]; f {
 			return c.hydrateWorkloadInstance(workload)
 		} else if pod != nil && proxy.Metadata.Labels[constants.TestVMLabel] == "" {
-			// we don't want to use this block for our test "VM" which is actually a Pod. This
-			// TODO use node metadata to indicate that this is a VM
+			// we don't want to use this block for our test "VM" which is actually a Pod.
+			// TODO use node metadata to indicate that this is a VM intstead of the TestVMLabel
 
 			if !c.isControllerForProxy(proxy) {
 				log.Errorf("proxy is in cluster %v, but controller is for cluster %v", proxy.Metadata.ClusterID, c.clusterID)

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -37,6 +37,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/mesh"
@@ -850,7 +851,7 @@ func (c *Controller) GetProxyServiceInstances(proxy *model.Proxy) []*model.Servi
 		pod := c.pods.getPodByIP(proxyIP)
 		if workload, f := c.workloadInstancesByIP[proxyIP]; f {
 			return c.hydrateWorkloadInstance(workload)
-		} else if pod != nil && proxy.Metadata.Labels["istio.io/test-vm"] == "" {
+		} else if pod != nil && proxy.Metadata.Labels[constants.TestVMLabel] == "" {
 			if !c.isControllerForProxy(proxy) {
 				log.Errorf("proxy is in cluster %v, but controller is for cluster %v", proxy.Metadata.ClusterID, c.clusterID)
 				return nil

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -37,7 +37,6 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
-	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/mesh"
@@ -851,9 +850,8 @@ func (c *Controller) GetProxyServiceInstances(proxy *model.Proxy) []*model.Servi
 		pod := c.pods.getPodByIP(proxyIP)
 		if workload, f := c.workloadInstancesByIP[proxyIP]; f {
 			return c.hydrateWorkloadInstance(workload)
-		} else if pod != nil && proxy.Metadata.Labels[constants.TestVMLabel] == "" {
+		} else if pod != nil && !proxy.IsVM() {
 			// we don't want to use this block for our test "VM" which is actually a Pod.
-			// TODO use node metadata to indicate that this is a VM intstead of the TestVMLabel
 
 			if !c.isControllerForProxy(proxy) {
 				log.Errorf("proxy is in cluster %v, but controller is for cluster %v", proxy.Metadata.ClusterID, c.clusterID)

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -1062,10 +1062,18 @@ func (c *Controller) getProxyServiceInstancesFromMetadata(proxy *model.Proxy) ([
 			if !f {
 				return nil, fmt.Errorf("failed to get svc port for %v", port.Name)
 			}
-			portNum, err := findPortFromMetadata(port, proxy.Metadata.PodPorts)
-			if err != nil {
-				return nil, fmt.Errorf("failed to find target port for %v: %v", proxy.ID, err)
+
+			var portNum int
+			if len(proxy.Metadata.PodPorts) > 0 {
+				portNum, err = findPortFromMetadata(port, proxy.Metadata.PodPorts)
+				if err != nil {
+					return nil, fmt.Errorf("failed to find target port for %v: %v", proxy.ID, err)
+				}
+			} else {
+				// most likely a VM - we assume the WorkloadEntry won't remap any ports
+				portNum = port.TargetPort.IntValue()
 			}
+
 			// Dedupe the target ports here - Service might have configured multiple ports to the same target port,
 			// we will have to create only one ingress listener per port and protocol so that we do not endup
 			// complaining about listener conflicts.

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -852,6 +852,9 @@ func (c *Controller) GetProxyServiceInstances(proxy *model.Proxy) []*model.Servi
 		if workload, f := c.workloadInstancesByIP[proxyIP]; f {
 			return c.hydrateWorkloadInstance(workload)
 		} else if pod != nil && proxy.Metadata.Labels[constants.TestVMLabel] == "" {
+			// we don't want to use this block for our test "VM" which is actually a Pod. This
+			// TODO use node metadata to indicate that this is a VM
+
 			if !c.isControllerForProxy(proxy) {
 				log.Errorf("proxy is in cluster %v, but controller is for cluster %v", proxy.Metadata.ClusterID, c.clusterID)
 				return nil

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -99,4 +99,6 @@ const (
 
 	// DefaultConfigServiceAccountName is the default service account to use for external Istiod cluster access.
 	DefaultConfigServiceAccountName = "istiod-service-account"
+
+	TestVMLabel = "istio.io/test-vm"
 )

--- a/pkg/test/framework/components/echo/kube/builder.go
+++ b/pkg/test/framework/components/echo/kube/builder.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/resource"
@@ -110,7 +111,7 @@ func (b *builder) initializeInstances(instances []echo.Instance) error {
 			defer wg.Done()
 			selector := "app"
 			if inst.Config().DeployAsVM {
-				selector = "istio.io/test-vm"
+				selector = constants.TestVMLabel
 			}
 			// Wait until all the pods are ready for this service
 			fetch := kube.NewPodMustFetch(cluster, serviceNamespace, fmt.Sprintf("%s=%s", selector, serviceName))


### PR DESCRIPTION
* Allow fallthrough to `getProxyServiceInstancesFromMetadata` for VMs in kube-controller
  * We could implement something similar in the serviceentry registry, not sure how valuable this would be. 
* Clean up noise due to our test "vms" being a pod. 
  * Should fix #27234 – the change to `isControllerForProxy` prevents the `frommetadata` method from returning early for a vm. 
* Remove `break` that prevents a Workload to be selected by Services and ServiceEntries simultaneously