### PR TITLE
fix uninstall test

### DIFF
--- a/operator/pkg/name/name.go
+++ b/operator/pkg/name/name.go
@@ -64,6 +64,7 @@ const (
 	MeshPolicyStr         = "MeshPolicy"
 	PeerAuthenticationStr = "PeerAuthentication"
 	VirtualServiceStr     = "VirtualService"
+	IstioOperatorStr      = "IstioOperator"
 )
 
 // Istio API Group Names

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -178,7 +178,7 @@ fi
 
 # Run the test target if provided.
 if [[ -n "${PARAMS:-}" ]]; then
-  make "test.integration.kube.presubmit"
+  make "${PARAMS[*]}"
 fi
 
 # Check if the user is running the clusters in manual mode.

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -178,7 +178,7 @@ fi
 
 # Run the test target if provided.
 if [[ -n "${PARAMS:-}" ]]; then
-  make "${PARAMS[*]}"
+  make "test.integration.kube.presubmit"
 fi
 
 # Check if the user is running the clusters in manual mode.

--- a/tests/integration/pilot/revisions/uninstall_test.go
+++ b/tests/integration/pilot/revisions/uninstall_test.go
@@ -163,7 +163,14 @@ func checkResourcesNotInCluster(cs kube.Cluster, gvr schema.GroupVersionResource
 	if usList != nil && len(usList.Items) != 0 {
 		var stalelist []string
 		for _, item := range usList.Items {
+			// ignore IstioOperator CRD because the operator CR is not in the pruning list
+			if item.GetName() == "istiooperators.install.istio.io" {
+				continue
+			}
 			stalelist = append(stalelist, item.GroupVersionKind().String()+"/"+item.GetName())
+		}
+		if len(stalelist) == 0 {
+			return nil
 		}
 		msg := fmt.Sprintf("resources expected to be pruned but still exist in the cluster: %s",
 			strings.Join(stalelist, " "))


### PR DESCRIPTION
update prow/integ-suite-kind.sh temporarily to check the postsubmit job. (reverted now as the tests passed)

the reason why the postsubmit test starts failing is because there is istiooperator CR still in the cluster during postsubmit tests so deleting the CRD would hang because of the finalizer. But indeed the uninstall command did not remove the istioOperator CR by design, so remove the check in the test