### PR TITLE
fix manifestpath for verify install.

### DIFF
--- a/istioctl/pkg/install/verify.go
+++ b/istioctl/pkg/install/verify.go
@@ -74,7 +74,7 @@ func verifyInstallIOPrevision(enableVerbose bool, istioNamespaceFlag string,
 
 func verifyInstall(enableVerbose bool, istioNamespaceFlag string,
 	restClientGetter genericclioptions.RESTClientGetter, options resource.FilenameOptions,
-	writer io.Writer) error {
+	writer io.Writer, manifestsPath string) error {
 
 	// This is not a pre-check.  Check that the supplied resources exist in the cluster
 	r := resource.NewBuilder(restClientGetter).
@@ -91,7 +91,8 @@ func verifyInstall(enableVerbose bool, istioNamespaceFlag string,
 		visitor,
 		strings.Join(options.Filenames, ","),
 		restClientGetter,
-		writer)
+		writer,
+		manifestsPath)
 	return show(crdCount, istioDeploymentCount, err, writer)
 }
 
@@ -110,7 +111,7 @@ func show(crdCount, istioDeploymentCount int, err error, writer io.Writer) error
 }
 
 func verifyPostInstall(enableVerbose bool, istioNamespaceFlag string,
-	visitor resource.Visitor, filename string, restClientGetter genericclioptions.RESTClientGetter, writer io.Writer) (int, int, error) {
+	visitor resource.Visitor, filename string, restClientGetter genericclioptions.RESTClientGetter, writer io.Writer, manifestsPath string) (int, int, error) {
 	crdCount := 0
 	istioDeploymentCount := 0
 	err := visitor.Visit(func(info *resource.Info, err error) error {
@@ -187,6 +188,9 @@ func verifyPostInstall(enableVerbose bool, istioNamespaceFlag string,
 			iop, err := operator_istio.UnmarshalIstioOperator(by, true)
 			if err != nil {
 				return err
+			}
+			if manifestsPath != "" {
+				iop.Spec.InstallPackagePath = manifestsPath
 			}
 			generatedCrds, generatedDeployments, err := verifyPostInstallIstioOperator(enableVerbose, istioNamespaceFlag, iop, filename, restClientGetter, writer)
 			if err != nil {
@@ -286,7 +290,7 @@ istioctl experimental precheck.
 			}
 			// When the user specifies a file, compare against it.
 			return verifyInstall(enableVerbose, istioNamespace, kubeConfigFlags,
-				fileNameFlags.ToOptions(), c.OutOrStderr())
+				fileNameFlags.ToOptions(), c.OutOrStderr(), manifestsPath)
 		},
 	}
 
@@ -394,7 +398,8 @@ func verifyPostInstallIstioOperator(enableVerbose bool, istioNamespaceFlag strin
 		visitor,
 		fmt.Sprintf("generated from %s", filename),
 		restClientGetter,
-		writer)
+		writer,
+		iop.Spec.InstallPackagePath)
 	if err != nil {
 		return generatedCrds, generatedDeployments, err
 	}


### PR DESCRIPTION
resolve: https://github.com/istio/istio/issues/28284#issuecomment-716934577

Fix the manifests path missing issue for `verify-install` command in the development build:
```
# out/linux_amd64/istioctl install -f manifests/profiles/default.yaml -d manifests/
This will install the Istio 1.9.0 profile into the cluster. Proceed? (y/N) y
✔ Istio core installed
✔ Istiod installed
✔ Ingress gateways installed
✔ Installation complete                                                                                                                                                  
# out/linux_amd64/istioctl verify-install -f manifests/profiles/default.yaml -d manifests/
Error:
 compiled in charts not found in this development build,
 use manifests as local charts instead e.g:
 - istioctl install --set hub=gcr.io/istio-testing -d manifests/
 - or istioctl operator init --hub=gcr.io/istio-testing -d manifests/
 - or run make gen-charts and rebuild istioctl
```

[ ] Configuration Infrastructure
[ ] Docs
[ X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.