### PR TITLE
cni: fix order dependent test failures

### DIFF
--- a/cni/cmd/istio-cni/main_test.go
+++ b/cni/cmd/istio-cni/main_test.go
@@ -97,6 +97,11 @@ type mockInterceptRuleMgr struct {
 	lastRedirect []*Redirect
 }
 
+func init() {
+	interceptRuleMgrType = "mock"
+	testAnnotations[sidecarStatusKey] = "true"
+}
+
 func (mrdir *mockInterceptRuleMgr) Program(netns string, redirect *Redirect) error {
 	nsenterFuncCalled = true
 	mrdir.lastRedirect = append(mrdir.lastRedirect, redirect)


### PR DESCRIPTION
The `interceptRuleMgrType` decalred in main.go as "iptables", it would
be changed to "mock" in func resetGlobalTestVariables().

When run single test, it would be "iptables" and make test failed.

Signed-off-by: Xiang Dai <long0dai@foxmail.com>

Fix #28333

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.

/release-note-none