### PR TITLE
Improve wle reg/unreg robustness

### DIFF
--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -519,8 +519,9 @@ func (s *DiscoveryServer) initProxy(node *core.Node, con *Connection) (*model.Pr
 
 	// this should be done before we look for service instances, but after we load metadata
 	// TODO fix check in kubecontroller treat echo VMs like there isn't a pod
-	s.InternalGen.RegisterWorkload(proxy, con)
-
+	if err := s.InternalGen.RegisterWorkload(proxy, con); err != nil {
+		return nil, err
+	}
 	s.setProxyState(proxy, s.globalPushContext())
 
 	// Get the locality from the proxy's service instances.

--- a/pilot/pkg/xds/workloadentry.go
+++ b/pilot/pkg/xds/workloadentry.go
@@ -119,7 +119,7 @@ func (sg *InternalGen) QueueUnregisterWorkload(proxy *model.Proxy) {
 	}
 	wle := cfg.DeepCopy()
 	delete(wle.Annotations, WorkloadControllerAnnotation)
-	cfg.Annotations[DisconnectedAtAnnotation] = time.Now().Format(timeFormat)
+	wle.Annotations[DisconnectedAtAnnotation] = time.Now().Format(timeFormat)
 	// use update instead of patch to prevent race condition
 	_, err := sg.Store.Update(wle)
 	if err != nil && !errors.IsConflict(err) {

--- a/pilot/pkg/xds/workloadentry.go
+++ b/pilot/pkg/xds/workloadentry.go
@@ -26,7 +26,6 @@ import (
 
 	"istio.io/api/meta/v1alpha1"
 	"istio.io/api/networking/v1alpha3"
-
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"

--- a/pilot/pkg/xds/workloadentry.go
+++ b/pilot/pkg/xds/workloadentry.go
@@ -45,7 +45,7 @@ const (
 	// DisconnectedAtAnnotation on a WorkloadEntry stores the time in nanoseconds when the associated workload disconnected from a Pilot instance.
 	DisconnectedAtAnnotation = "istio.io/disconnectedAt"
 
-	timeFormat = "2006-01-02 15:04:05"
+	timeFormat = time.RFC3339Nano
 )
 
 type HealthEvent struct {

--- a/pilot/pkg/xds/workloadentry.go
+++ b/pilot/pkg/xds/workloadentry.go
@@ -16,7 +16,7 @@ package xds
 
 import (
 	"context"
-	"strconv"
+	"fmt"
 	"strings"
 	"time"
 
@@ -26,6 +26,7 @@ import (
 
 	"istio.io/api/meta/v1alpha1"
 	"istio.io/api/networking/v1alpha3"
+
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
@@ -44,23 +45,25 @@ const (
 	ConnectedAtAnnotation = "istio.io/connectedAt"
 	// DisconnectedAtAnnotation on a WorkloadEntry stores the time in nanoseconds when the associated workload disconnected from a Pilot instance.
 	DisconnectedAtAnnotation = "istio.io/disconnectedAt"
+
+	timeFormat = "2006-01-02 15:04:05"
 )
 
 type HealthEvent struct {
 	// whether or not the agent thought the target was empty
 	Healthy bool `json:"healthy,omitempty"`
-	// error message propogated
+	// error message propagated
 	Message string `json:"err_message,omitempty"`
 }
 
-func (sg *InternalGen) RegisterWorkload(proxy *model.Proxy, con *Connection) {
+func (sg *InternalGen) RegisterWorkload(proxy *model.Proxy, con *Connection) error {
 	if !features.WorkloadEntryAutoRegistration {
-		return
+		return nil
 	}
 	// check if the WE already exists, update the status
 	entryName := autoregisteredWorkloadEntryName(proxy)
 	if entryName == "" {
-		return
+		return nil
 	}
 
 	// Try to patch, if it fails then try to create
@@ -70,24 +73,28 @@ func (sg *InternalGen) RegisterWorkload(proxy *model.Proxy, con *Connection) {
 	})
 	// TODO return err from Patch through Get
 	if err == nil {
-		return
+		return nil
 	} else if !errors.IsNotFound(err) && err.Error() != "item not found" {
-		adsLog.Warnf("updating auto-registered WorkloadEntry %s/%s: %v", proxy.Metadata.Namespace, entryName, err)
+		adsLog.Errorf("updating auto-registered WorkloadEntry %s/%s: %v", proxy.Metadata.Namespace, entryName, err)
+		return fmt.Errorf("updating auto-registered WorkloadEntry %s/%s err: %v", proxy.Metadata.Namespace, entryName, err)
 	}
 
 	// No WorkloadEntry, create one using fields from the associated WorkloadGroup
 	groupCfg := sg.Store.Get(gvk.WorkloadGroup, proxy.Metadata.AutoRegisterGroup, proxy.Metadata.Namespace)
 	if groupCfg == nil {
-		adsLog.Warnf("auto-registration of %v failed: cannot find WorkloadGroup %s/%s", proxy.ID, proxy.Metadata.Namespace, proxy.Metadata.AutoRegisterGroup)
-		return
+		adsLog.Errorf("auto-registration of %v failed: cannot find WorkloadGroup %s/%s",
+			proxy.ID, proxy.Metadata.Namespace, proxy.Metadata.AutoRegisterGroup)
+		return fmt.Errorf("auto-registration of %v failed: cannot find WorkloadGroup %s/%s",
+			proxy.ID, proxy.Metadata.Namespace, proxy.Metadata.AutoRegisterGroup)
 	}
 	entry := workloadEntryFromGroup(entryName, proxy, groupCfg)
 	setConnectMeta(entry, sg.Server.instanceID, con)
 	_, err = sg.Store.Create(*entry)
 	if err != nil {
-		// TODO retry to handle transient failures
 		adsLog.Errorf("auto-registration of %v failed: error creating WorkloadEntry: %v", proxy.ID, err)
+		return fmt.Errorf("auto-registration of %v failed: error creating WorkloadEntry: %v", proxy.ID, err)
 	}
+	return nil
 }
 
 func (sg *InternalGen) QueueUnregisterWorkload(proxy *model.Proxy) {
@@ -101,15 +108,11 @@ func (sg *InternalGen) QueueUnregisterWorkload(proxy *model.Proxy) {
 	}
 
 	// unset controller, set disconnect time
-	cfg := sg.Store.Get(gvk.WorkloadEntry, entryName, proxy.Metadata.Namespace)
-	if cfg == nil {
-		// we failed to create the workload entry in the first place
-		return
-	}
-	wle := cfg.DeepCopy()
-	delete(wle.Annotations, WorkloadControllerAnnotation)
-	wle.Annotations[DisconnectedAtAnnotation] = strconv.FormatInt(time.Now().UnixNano(), 10)
-	_, err := sg.Store.Update(wle)
+	_, err := sg.Store.Patch(gvk.WorkloadEntry, entryName, proxy.Metadata.Namespace, func(cfg config.Config) config.Config {
+		delete(cfg.Annotations, WorkloadControllerAnnotation)
+		cfg.Annotations[DisconnectedAtAnnotation] = time.Now().Format(timeFormat)
+		return cfg
+	})
 	if err != nil {
 		adsLog.Warnf("disconnect: failed patching WorkloadEntry %s/%s: %v", proxy.Metadata.Namespace, entryName, err)
 		return
@@ -122,10 +125,9 @@ func (sg *InternalGen) QueueUnregisterWorkload(proxy *model.Proxy) {
 		if wle == nil {
 			return nil
 		}
-		if !shouldCleanupEntry(*wle) {
-			return nil
+		if shouldCleanupEntry(*wle) {
+			sg.cleanupEntry(*wle)
 		}
-		sg.cleanupEntry(*wle)
 		return nil
 	}, features.WorkloadEntryCleanupGracePeriod)
 }
@@ -158,16 +160,13 @@ func (sg *InternalGen) UpdateWorkloadEntryHealth(proxy *model.Proxy, event Healt
 	var status *v1alpha1.IstioStatus
 	if wle.Status == nil {
 		// for some reason we have a nil status, just make conditions
-		//an empty array
-		status = &v1alpha1.IstioStatus{
+		// an empty array
+		wle.Status = &v1alpha1.IstioStatus{
 			Conditions: []*v1alpha1.IstioCondition{},
 		}
-	} else {
-		status = wle.Status.(*v1alpha1.IstioStatus)
-
 	}
+	status = wle.Status.(*v1alpha1.IstioStatus)
 	status.Conditions = UpdateHealthCondition(status.Conditions, event)
-	wle.Status = status
 
 	// update the status
 	_, err := sg.Store.UpdateStatus(wle)
@@ -193,13 +192,12 @@ func (sg *InternalGen) periodicWorkloadEntryCleanup(stopCh <-chan struct{}) {
 			}
 			for _, wle := range wles {
 				wle := wle
-				if !shouldCleanupEntry(wle) {
-					continue
+				if shouldCleanupEntry(wle) {
+					sg.cleanupQueue.Push(func() error {
+						sg.cleanupEntry(wle)
+						return nil
+					})
 				}
-				sg.cleanupQueue.Push(func() error {
-					sg.cleanupEntry(wle)
-					return nil
-				})
 			}
 		case <-stopCh:
 			return
@@ -218,17 +216,17 @@ func (sg *InternalGen) cleanupEntry(wle config.Config) {
 
 func shouldCleanupEntry(wle config.Config) bool {
 	// don't clean-up if connected or non-autoregistered WorkloadEntries
-	_, ok := wle.Annotations[WorkloadControllerAnnotation]
-	if wle.Annotations[AutoRegistrationGroupAnnotation] == "" || ok {
+	if wle.Annotations[AutoRegistrationGroupAnnotation] == "" ||
+		wle.Annotations[WorkloadControllerAnnotation] != "" {
 		return false
 	}
 
-	disconnUnixTime, err := strconv.Atoi(wle.Annotations[DisconnectedAtAnnotation])
-	if err != nil {
-		// remove workload entries with invalid disconnect times - they need to be re-registered and fixed.
-		adsLog.Warnf("invalid disconnect time for WorkloadEntry %s/%s: %s", wle.Annotations[DisconnectedAtAnnotation])
+	disconnTime := wle.Annotations[DisconnectedAtAnnotation]
+	if disconnTime == "" {
+		return false
 	}
-	disconnAt := time.Unix(0, int64(disconnUnixTime))
+
+	disconnAt, err := time.Parse(timeFormat, disconnTime)
 	// if we haven't passed the grace period, don't cleanup
 	if err == nil && time.Since(disconnAt) < features.WorkloadEntryCleanupGracePeriod {
 		return false
@@ -239,7 +237,7 @@ func shouldCleanupEntry(wle config.Config) bool {
 
 func setConnectMeta(c *config.Config, controller string, con *Connection) {
 	c.Annotations[WorkloadControllerAnnotation] = controller
-	c.Annotations[ConnectedAtAnnotation] = strconv.FormatInt(con.Connect.UnixNano(), 10)
+	c.Annotations[ConnectedAtAnnotation] = con.Connect.Format(timeFormat)
 }
 
 func workloadEntryFromGroup(name string, proxy *model.Proxy, groupCfg *config.Config) *config.Config {


### PR DESCRIPTION
- When `RegisterWorkload` fails(maybe workloadgroup not exist), close the stream and make retry originated from sidecar. This is to make istiod stateless in this case.

- use patch instead of update for unregister

- make connect/disconnect time readable

