### PR TITLE
istioctl verify-install: enhance error output with --verbose

### DIFF
--- a/istioctl/pkg/install/verify.go
+++ b/istioctl/pkg/install/verify.go
@@ -409,7 +409,9 @@ func verifyPostInstallIstioOperator(enableVerbose bool, istioNamespaceFlag strin
 
 // Find an IstioOperator matching revision in the cluster.  The IstioOperators
 // don't have a label for their revision, so we parse them and check .Spec.Revision
-func operatorFromCluster(enableVerbose bool, istioNamespaceFlag string, revision string, restClientGetter genericclioptions.RESTClientGetter) (*v1alpha1.IstioOperator, error) {
+// nolint: lll
+func operatorFromCluster(enableVerbose bool, istioNamespaceFlag string, revision string,
+	restClientGetter genericclioptions.RESTClientGetter) (*v1alpha1.IstioOperator, error) {
 	restConfig, err := restClientGetter.ToRESTConfig()
 	if err != nil {
 		return nil, err

--- a/istioctl/pkg/install/verify.go
+++ b/istioctl/pkg/install/verify.go
@@ -56,9 +56,9 @@ func verifyInstallIOPrevision(enableVerbose bool, istioNamespaceFlag string,
 	restClientGetter genericclioptions.RESTClientGetter,
 	writer io.Writer, opts clioptions.ControlPlaneOptions, manifestsPath string) error {
 
-	iop, err := operatorFromCluster(istioNamespaceFlag, opts.Revision, restClientGetter)
+	iop, err := operatorFromCluster(enableVerbose, istioNamespaceFlag, opts.Revision, restClientGetter)
 	if err != nil {
-		return fmt.Errorf("could not load IstioOperator from cluster: %v.  Use --filename", err)
+		return fmt.Errorf("could not load IstioOperator from cluster: %v", err)
 	}
 	if manifestsPath != "" {
 		iop.Spec.InstallPackagePath = manifestsPath
@@ -299,7 +299,7 @@ istioctl experimental precheck.
 		"Istio system namespace")
 	kubeConfigFlags.AddFlags(flags)
 	fileNameFlags.AddFlags(flags)
-	verifyInstallCmd.Flags().BoolVar(&enableVerbose, "enableVerbose", true,
+	verifyInstallCmd.Flags().BoolVar(&enableVerbose, "verbose", false,
 		"Enable verbose output")
 	verifyInstallCmd.PersistentFlags().StringVarP(&manifestsPath, "manifests", "d", "", mesh.ManifestsFlagHelpStr)
 	opts.AttachControlPlaneFlags(verifyInstallCmd)
@@ -409,7 +409,7 @@ func verifyPostInstallIstioOperator(enableVerbose bool, istioNamespaceFlag strin
 
 // Find an IstioOperator matching revision in the cluster.  The IstioOperators
 // don't have a label for their revision, so we parse them and check .Spec.Revision
-func operatorFromCluster(istioNamespaceFlag string, revision string, restClientGetter genericclioptions.RESTClientGetter) (*v1alpha1.IstioOperator, error) {
+func operatorFromCluster(enableVerbose bool, istioNamespaceFlag string, revision string, restClientGetter genericclioptions.RESTClientGetter) (*v1alpha1.IstioOperator, error) {
 	restConfig, err := restClientGetter.ToRESTConfig()
 	if err != nil {
 		return nil, err
@@ -430,6 +430,9 @@ func operatorFromCluster(istioNamespaceFlag string, revision string, restClientG
 		by := util.ToYAML(un.Object)
 		iop, err := operator_istio.UnmarshalIstioOperator(by, true)
 		if err != nil {
+			if enableVerbose {
+				return nil, fmt.Errorf("could not unmarshal: %s\n\nYAML:\n%s", err, by)
+			}
 			return nil, err
 		}
 		if iop.Spec.Revision == revision {

--- a/operator/pkg/apis/istio/common.go
+++ b/operator/pkg/apis/istio/common.go
@@ -41,7 +41,7 @@ func UnmarshalAndValidateIOPS(iopsYAML string) (*v1alpha1.IstioOperatorSpec, err
 func UnmarshalIstioOperator(iopYAML string, allowUnknownField bool) (*operator_v1alpha1.IstioOperator, error) {
 	iop := &operator_v1alpha1.IstioOperator{}
 	if err := util.UnmarshalWithJSONPB(iopYAML, iop, allowUnknownField); err != nil {
-		return nil, fmt.Errorf("could not unmarshal: %s\n\nYAML:\n%s", err, iopYAML)
+		return nil, fmt.Errorf("could not unmarshal: %v", err)
 	}
 	return iop, nil
 }


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/18855
Part of https://github.com/istio/istio/issues/28148

Without `--verbose` flag
```
$ istioctl verify-install
Error: could not load IstioOperator from cluster: could not unmarshal: json: cannot unmarshal string into Go value of type map[string]json.RawMessage
```

With `--verbose` flag:
```
$ istioctl verify-install --verbose
Error: could not load IstioOperator from cluster: could not unmarshal: could not unmarshal: json: cannot unmarshal string into Go value of type map[string]json.RawMessage

YAML:
apiVersion: install.istio.io/v1alpha1
kind: IstioOperator
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"install.istio.io/v1alpha1","kind":"IstioOperator","metadata":{"annotations":{},"creationTimestamp":null,"name":"installed-state-1-8-0","namespace":"istio-system"}
}}
...
```