### PR TITLE
Fix routing for TPROXY mode

### DIFF
--- a/pilot/pkg/xds/filters/filters.go
+++ b/pilot/pkg/xds/filters/filters.go
@@ -28,6 +28,7 @@ import (
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"google.golang.org/protobuf/types/known/wrapperspb"
+	"os"
 
 	"istio.io/istio/pilot/pkg/networking/util"
 	alpn "istio.io/istio/pkg/envoy/config/filter/http/alpn/v2alpha1"
@@ -104,7 +105,9 @@ var (
 	OriginalSrc = &listener.ListenerFilter{
 		Name: OriginalSrcFilterName,
 		ConfigType: &listener.ListenerFilter_TypedConfig{
-			TypedConfig: util.MessageToAny(&originalsrc.OriginalSrc{}),
+			TypedConfig: util.MessageToAny(&originalsrc.OriginalSrc{
+				Mark: uint32(os.Getegid()),
+			}),
 		},
 	}
 	Alpn = &hcm.HttpFilter{


### PR DESCRIPTION
This PR fixes #23369 

In the old versions, envoy sent upstream requests to 127.0.0.1, but now it sends to original dest ip ( pod ip), which causes TPROXY to not work properly.

this PR will:
1. ensure correct routing for traffic from workload to envoy
2. prevent infinite redirecting
3. change TPROXY target port from 15001 to 15006

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure