### PR TITLE
istio-agent: only send NDS if DNS is enabled

### DIFF
--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -194,7 +194,7 @@ func (p *XdsProxy) StreamAggregatedResources(downstream discovery.AggregatedDisc
 			}
 			// forward to istiod
 			con.requestsChan <- req
-			if !firstNDSSent && req.TypeUrl == v3.ListenerType {
+			if p.localDNSServer != nil && !firstNDSSent && req.TypeUrl == v3.ListenerType {
 				// fire off an initial NDS request
 				con.requestsChan <- &discovery.DiscoveryRequest{
 					TypeUrl: v3.NameTableType,


### PR DESCRIPTION
Signed-off-by: Xiang Dai <long0dai@foxmail.com>

Fix #28382
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[X] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


[X] Does not have any changes that may affect Istio users.
