### PR TITLE
set validationwebhookconfig as Fail close by default for remote clusters

### DIFF
--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -364,6 +364,10 @@ func (c *Controller) reconcileRequest(req *reconcileRequest) error {
 }
 
 func (c *Controller) readyForFailClose() bool {
+	//for remote clusters, we will set fail-close by default
+	if c.o.RemoteWebhookConfig {
+		return true
+	}
 	if !c.dryRunOfInvalidConfigRejected {
 		if rejected, reason := c.isDryRunOfInvalidConfigRejected(); !rejected {
 			scope.Infof("Not ready to switch validation to fail-closed: %v", reason)

--- a/pkg/webhooks/validation/controller/controller.go
+++ b/pkg/webhooks/validation/controller/controller.go
@@ -364,7 +364,7 @@ func (c *Controller) reconcileRequest(req *reconcileRequest) error {
 }
 
 func (c *Controller) readyForFailClose() bool {
-	//for remote clusters, we will set fail-close by default
+	//no synchronization issues for remote cluster, set as fail-close by default
 	if c.o.RemoteWebhookConfig {
 		return true
 	}


### PR DESCRIPTION
when we use istiod-less as default remote for multi-cluster, we have below error:

```
info	validationController	Not ready to switch validation to fail-closed: dummy invalid rejected for the wrong reason: gateways.networking.istio.io is forbidden: User "system:serviceaccount:istio-system:istio-reader-service-account" cannot create resource "gateways" in API group "networking.istio.io" in the namespace "istio-system"
```


