### PR TITLE
istioctl profile diff: using profile names

### DIFF
--- a/operator/cmd/mesh/profile-diff.go
+++ b/operator/cmd/mesh/profile-diff.go
@@ -39,6 +39,11 @@ func profileDiffCmd(rootArgs *rootArgs, pfArgs *profileDiffArgs) *cobra.Command 
 		Use:   "diff <file1.yaml> <file2.yaml>",
 		Short: "Diffs two Istio configuration profiles",
 		Long:  "The diff subcommand displays the differences between two Istio configuration profiles.",
+		Example: `  # Profile diff by providing yaml files
+  istioctl profile diff manifests/profiles/default.yaml manifests/profiles/demo.yaml
+
+  # Profile diff by providing a profile name
+  istioctl profile diff default demo`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 2 {
 				return fmt.Errorf("diff requires two profiles")

--- a/operator/cmd/mesh/profile-diff.go
+++ b/operator/cmd/mesh/profile-diff.go
@@ -74,7 +74,7 @@ func profileDiff(rootArgs *rootArgs, pfArgs *profileDiffArgs, args []string) err
 	if diff == "" {
 		fmt.Println("Profiles are identical")
 	} else {
-		fmt.Printf("Difference of profiles:\n%s", diff)
+		fmt.Printf("The difference between profiles:\n%s", diff)
 		os.Exit(1)
 	}
 

--- a/operator/pkg/helm/helm.go
+++ b/operator/pkg/helm/helm.go
@@ -72,13 +72,13 @@ func NewHelmRenderer(operatorDataDir, helmSubdir, componentName, namespace strin
 
 // ReadProfileYAML reads the YAML values associated with the given profile. It uses an appropriate reader for the
 // profile format (compiled-in, file, HTTP, etc.).
-func ReadProfileYAML(profile, chartsDir string) (string, error) {
+func ReadProfileYAML(profile, manifestsPath string) (string, error) {
 	var err error
 	var globalValues string
 
 	// Get global values from profile.
 	switch {
-	case chartsDir == "":
+	case manifestsPath == "":
 		if globalValues, err = LoadValuesVFS(profile); err != nil {
 			return "", err
 		}
@@ -87,8 +87,8 @@ func ReadProfileYAML(profile, chartsDir string) (string, error) {
 			return "", err
 		}
 	default:
-		if globalValues, err = LoadValues(profile, chartsDir); err != nil {
-			return "", fmt.Errorf("failed to read profile %v from %v: %v", profile, chartsDir, err)
+		if globalValues, err = LoadValues(profile, manifestsPath); err != nil {
+			return "", fmt.Errorf("failed to read profile %v from %v: %v", profile, manifestsPath, err)
 		}
 	}
 


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/19044

The feature to use profile names for diff is implemented previously. This PR just add examples on how to use diff using profile names.

```
$ istioctl profile diff -h
The diff subcommand displays the differences between two Istio configuration profiles.

Usage:
  istioctl profile diff <file1.yaml> <file2.yaml> [flags]

Examples:
  # Profile diff by providing yaml files
  istioctl profile diff manifests/profiles/default.yaml manifests/profiles/demo.yaml

  # Profile diff by providing a profile name
  istioctl profile diff default demo
```

Diff using profile names:
```
$ ./out/linux_amd64/istioctl profile diff minimal preview -d manifests/
The difference between profiles:
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
-  components:
-    ingressGateways:
-    - enabled: false
-      name: istio-ingressgateway
+  meshConfig:
+    defaultConfig:
+      proxyMetadata:
+        ISTIO_META_DNS_CAPTURE: "true"
+  values:
+    telemetry:
+      v2:
+        metadataExchange:
+          wasmEnabled: true
+        prometheus:
+          wasmEnabled: true
```