### PR TITLE
istio-discovery: validate keepaliveMaxServerConnectionAge duration

### DIFF
--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -30,6 +30,7 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pkg/cmd"
 	"istio.io/istio/pkg/config/constants"
+	"istio.io/istio/pkg/config/validation"
 	"istio.io/pkg/collateral"
 	"istio.io/pkg/ctrlz"
 	"istio.io/pkg/log"
@@ -65,6 +66,12 @@ var (
 
 			// Create the stop channel for all of the servers.
 			stop := make(chan struct{})
+
+			// If keepaliveMaxServerConnectionAge is negative, istiod crash
+			// https://github.com/istio/istio/issues/27257
+			if err := validation.ValidateMaxServerConnectionAge(serverArgs.KeepaliveOptions.MaxServerConnectionAge); err != nil {
+				return err
+			}
 
 			// Create the server for the discovery service.
 			discoveryServer, err := bootstrap.NewServer(serverArgs)

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -57,7 +57,6 @@ import (
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/config/schema/gvk"
-	"istio.io/istio/pkg/config/validation"
 	"istio.io/istio/pkg/jwt"
 	istiokeepalive "istio.io/istio/pkg/keepalive"
 	kubelib "istio.io/istio/pkg/kube"
@@ -204,12 +203,6 @@ func NewServer(args *PilotArgs) (*Server, error) {
 
 	if args.ShutdownDuration == 0 {
 		s.shutdownDuration = 10 * time.Second // If not specified set to 10 seconds.
-	}
-
-	// If keepaliveMaxServerConnectionAge is negative, istiod crash
-	// https://github.com/istio/istio/issues/27257
-	if err := validation.ValidateMaxServerConnectionAge(args.KeepaliveOptions.MaxServerConnectionAge); err != nil {
-		return nil, err
 	}
 
 	if args.RegistryOptions.KubeOptions.WatchedNamespaces != "" {

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -209,7 +209,7 @@ func NewServer(args *PilotArgs) (*Server, error) {
 	// If keepaliveMaxServerConnectionAge is negative, istiod crash
 	// https://github.com/istio/istio/issues/27257
 	if err := IsNegativeDuration(args.KeepaliveOptions.MaxServerConnectionAge); err != nil {
-		return nil, fmt.Errorf("%v: --keepaliveMaxServerConnectionAge only accepts postive duration eg: 30m", err)
+		return nil, fmt.Errorf("%v: --keepaliveMaxServerConnectionAge only accepts positive duration eg: 30m", err)
 	}
 
 	if args.RegistryOptions.KubeOptions.WatchedNamespaces != "" {

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1235,7 +1235,7 @@ func ValidateProtocolDetectionTimeout(timeout *types.Duration) error {
 	return nil
 }
 
-// ValidateMaxServerConnectionAge validate positive duration
+// ValidateMaxServerConnectionAge validate negative duration
 func ValidateMaxServerConnectionAge(in time.Duration) error {
 	if err := IsNegativeDuration(in); err != nil {
 		return fmt.Errorf("%v: --keepaliveMaxServerConnectionAge only accepts positive duration eg: 30m", err)
@@ -1245,9 +1245,8 @@ func ValidateMaxServerConnectionAge(in time.Duration) error {
 
 // IsNegativeDuration check if the duration is negative
 func IsNegativeDuration(in time.Duration) error {
-	out := in.String()
-	if strings.HasPrefix(out, "-") {
-		return fmt.Errorf("invalid duration: %s", out)
+	if in < 0 {
+		return fmt.Errorf("invalid duration: %s", in.String())
 	}
 	return nil
 }

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1235,6 +1235,23 @@ func ValidateProtocolDetectionTimeout(timeout *types.Duration) error {
 	return nil
 }
 
+// ValidateMaxServerConnectionAge validate positive duration
+func ValidateMaxServerConnectionAge(in time.Duration) error {
+	if err := IsNegativeDuration(in); err != nil {
+		return fmt.Errorf("%v: --keepaliveMaxServerConnectionAge only accepts positive duration eg: 30m", err)
+	}
+	return nil
+}
+
+// IsNegativeDuration check if the duration is negative
+func IsNegativeDuration(in time.Duration) error {
+	out := in.String()
+	if strings.HasPrefix(out, "-") {
+		return fmt.Errorf("invalid duration: %s", out)
+	}
+	return nil
+}
+
 // ValidateMeshConfig checks that the mesh config is well-formed
 func ValidateMeshConfig(mesh *meshconfig.MeshConfig) (errs error) {
 	if err := ValidatePort(int(mesh.ProxyListenPort)); err != nil {

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -314,6 +314,35 @@ func TestValidateConnectTimeout(t *testing.T) {
 	}
 }
 
+func TestValidateMaxServerConnectionAge(t *testing.T) {
+	type durationCheck struct {
+		duration time.Duration
+		isValid  bool
+	}
+	durMin, _ := time.ParseDuration("-30m")
+	durHr, _ := time.ParseDuration("-1.5h")
+	checks := []durationCheck{
+		{
+			duration: 30 * time.Minute,
+			isValid:  true,
+		},
+		{
+			duration: durMin,
+			isValid:  false,
+		},
+		{
+			duration: durHr,
+			isValid:  false,
+		},
+	}
+
+	for _, check := range checks {
+		if got := ValidateMaxServerConnectionAge(check.duration); (got == nil) != check.isValid {
+			t.Errorf("Failed: got valid=%t but wanted valid=%t: %v for %v", got == nil, check.isValid, got, check.duration)
+		}
+	}
+}
+
 func TestValidateProtocolDetectionTimeout(t *testing.T) {
 	type durationCheck struct {
 		duration *types.Duration


### PR DESCRIPTION
Attempt to fix https://github.com/istio/istio/issues/27257
 
Installing Istio with `keepaliveMaxServerConnectionAge` negative duration fails.
```
$ istioctl install --set values.pilot.keepaliveMaxServerConnectionAge="-30m"
```

```
$ kubectl logs -l app=istiod -n istio-system
google.golang.org/grpc/internal/transport.NewServerTransport(...)
        google.golang.org/grpc@v1.33.1/internal/transport/transport.go:537
google.golang.org/grpc.(*Server).newHTTP2Transport(0xc001396fc0, 0x32a2760, 0xc0011a7240, 0x320b9c0, 0xc0026ea840, 0x320b9c0, 0xc0026ea840)
        google.golang.org/grpc@v1.33.1/server.go:837 +0x18b
google.golang.org/grpc.(*Server).handleRawConn(0xc001396fc0, 0x32a3f00, 0xc0024bea28)
        google.golang.org/grpc@v1.33.1/server.go:804 +0x47e
google.golang.org/grpc.(*Server).Serve.func3(0xc001396fc0, 0x32a3f00, 0xc0024bea28)
        google.golang.org/grpc@v1.33.1/server.go:774 +0x3f
created by google.golang.org/grpc.(*Server).Serve
        google.golang.org/grpc@v1.33.1/server.go:773 +0x81e
```

After the validation:

```
$ kubectl logs -l app=istiod -n istio-system
2020-11-03T07:28:09.467922Z     error   invalid duration: -30m0s: --keepaliveMaxServerConnectionAge only accepts positive duration eg: 30m
Error: invalid duration: -30m0s: --keepaliveMaxServerConnectionAge only accepts positive duration eg: 30m
```

```
$ pilot-discovery discovery --keepaliveMaxServerConnectionAge="-30m"
Error: invalid duration: -30m0s: --keepaliveMaxServerConnectionAge only accepts positive duration eg: 30m
2020-11-02T05:09:41.836884Z     error   invalid duration: -30m0s: --keepaliveMaxServerConnectionAge only accepts positive duration eg: 30m
```