### PR TITLE
Preserve global.proxy resource requests when applying sidecar annotations

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -276,30 +276,32 @@ data:
         {{- end }}
       {{- end }}
         resources:
-      {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+          {{ if or .Values.global.proxy.resources.requests (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
           requests:
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-            {{ end }}
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
-            {{ end }}
-        {{- end }}
-        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` -}}
+            cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}
+            {{- else if .Values.global.proxy.resources.requests.cpu -}}
+            cpu: {{ .Values.global.proxy.resources.requests.cpu }}
+            {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` -}}
+            memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}
+            {{- else if .Values.global.proxy.resources.requests.memory -}}
+            memory: {{ .Values.global.proxy.resources.requests.memory }}
+            {{- end }}
+          {{- end }}
+          {{ if or .Values.global.proxy.resources.limits (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
           limits:
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
-            {{ end }}
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
-            {{ end }}
-        {{- end }}
-      {{- else }}
-        {{- if .Values.global.proxy.resources }}
-          {{ toYaml .Values.global.proxy.resources | indent 4 }}
-        {{- end }}
-      {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` -}}
+            cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}
+            {{- else if .Values.global.proxy.resources.limits.cpu -}}
+            cpu: {{ .Values.global.proxy.resources.limits.cpu }}
+            {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` -}}
+            memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}
+            {{- else if .Values.global.proxy.resources.limits.memory -}}
+            memory: {{ .Values.global.proxy.resources.limits.memory }}
+            {{- end }}
+          {{- end }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
@@ -536,30 +538,32 @@ data:
           runAsUser: 1337
           {{- end }}
         resources:
-      {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+          {{ if or .Values.global.proxy.resources.requests (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
           requests:
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-            {{ end }}
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
-            {{ end }}
-        {{- end }}
-        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` -}}
+            cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}
+            {{- else if .Values.global.proxy.resources.requests.cpu -}}
+            cpu: {{ .Values.global.proxy.resources.requests.cpu }}
+            {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` -}}
+            memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}
+            {{- else if .Values.global.proxy.resources.requests.memory -}}
+            memory: {{ .Values.global.proxy.resources.requests.memory }}
+            {{- end }}
+          {{- end }}
+          {{ if or .Values.global.proxy.resources.limits (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
           limits:
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
-            {{ end }}
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
-            {{ end }}
-        {{- end }}
-      {{- else }}
-        {{- if .Values.global.proxy.resources }}
-          {{ toYaml .Values.global.proxy.resources | indent 4 }}
-        {{- end }}
-      {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` -}}
+            cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}
+            {{- else if .Values.global.proxy.resources.limits.cpu -}}
+            cpu: {{ .Values.global.proxy.resources.limits.cpu }}
+            {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` -}}
+            memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}
+            {{- else if .Values.global.proxy.resources.limits.memory -}}
+            memory: {{ .Values.global.proxy.resources.limits.memory }}
+            {{- end }}
+          {{- end }}
         volumeMounts:
         {{- if eq .Values.global.pilotCertProvider "istiod" }}
         - mountPath: /var/run/secrets/istio

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -59,30 +59,32 @@ template: |
     {{- end }}
   {{- end }}
     resources:
-  {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+      {{ if or .Values.global.proxy.resources.requests (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
       requests:
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-        {{ end }}
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
-        {{ end }}
-    {{- end }}
-    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` -}}
+        cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}
+        {{- else if .Values.global.proxy.resources.requests.cpu -}}
+        cpu: {{ .Values.global.proxy.resources.requests.cpu }}
+        {{- end }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` -}}
+        memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}
+        {{- else if .Values.global.proxy.resources.requests.memory -}}
+        memory: {{ .Values.global.proxy.resources.requests.memory }}
+        {{- end }}
+      {{- end }}
+      {{ if or .Values.global.proxy.resources.limits (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
       limits:
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
-        {{ end }}
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
-        {{ end }}
-    {{- end }}
-  {{- else }}
-    {{- if .Values.global.proxy.resources }}
-      {{ toYaml .Values.global.proxy.resources | indent 4 }}
-    {{- end }}
-  {{- end }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` -}}
+        cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}
+        {{- else if .Values.global.proxy.resources.limits.cpu -}}
+        cpu: {{ .Values.global.proxy.resources.limits.cpu }}
+        {{- end }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` -}}
+        memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}
+        {{- else if .Values.global.proxy.resources.limits.memory -}}
+        memory: {{ .Values.global.proxy.resources.limits.memory }}
+        {{- end }}
+      {{- end }}
     securityContext:
       allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
       privileged: {{ .Values.global.proxy.privileged }}
@@ -319,30 +321,32 @@ template: |
       runAsUser: 1337
       {{- end }}
     resources:
-  {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+      {{ if or .Values.global.proxy.resources.requests (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
       requests:
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-        {{ end }}
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
-        {{ end }}
-    {{- end }}
-    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` -}}
+        cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}
+        {{- else if .Values.global.proxy.resources.requests.cpu -}}
+        cpu: {{ .Values.global.proxy.resources.requests.cpu }}
+        {{- end }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` -}}
+        memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}
+        {{- else if .Values.global.proxy.resources.requests.memory -}}
+        memory: {{ .Values.global.proxy.resources.requests.memory }}
+        {{- end }}
+      {{- end }}
+      {{ if or .Values.global.proxy.resources.limits (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
       limits:
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
-        {{ end }}
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
-        {{ end }}
-    {{- end }}
-  {{- else }}
-    {{- if .Values.global.proxy.resources }}
-      {{ toYaml .Values.global.proxy.resources | indent 4 }}
-    {{- end }}
-  {{- end }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` -}}
+        cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}
+        {{- else if .Values.global.proxy.resources.limits.cpu -}}
+        cpu: {{ .Values.global.proxy.resources.limits.cpu }}
+        {{- end }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` -}}
+        memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}
+        {{- else if .Values.global.proxy.resources.limits.memory -}}
+        memory: {{ .Values.global.proxy.resources.limits.memory }}
+        {{- end }}
+      {{- end }}
     volumeMounts:
     {{- if eq .Values.global.pilotCertProvider "istiod" }}
     - mountPath: /var/run/secrets/istio

--- a/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -255,30 +255,32 @@ data:
         {{- end }}
       {{- end }}
         resources:
-      {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+          {{ if or .Values.global.proxy.resources.requests (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
           requests:
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-            {{ end }}
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
-            {{ end }}
-        {{- end }}
-        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` -}}
+            cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}
+            {{- else if .Values.global.proxy.resources.requests.cpu -}}
+            cpu: {{ .Values.global.proxy.resources.requests.cpu }}
+            {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` -}}
+            memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}
+            {{- else if .Values.global.proxy.resources.requests.memory -}}
+            memory: {{ .Values.global.proxy.resources.requests.memory }}
+            {{- end }}
+          {{- end }}
+          {{ if or .Values.global.proxy.resources.limits (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
           limits:
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
-            {{ end }}
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
-            {{ end }}
-        {{- end }}
-      {{- else }}
-        {{- if .Values.global.proxy.resources }}
-          {{ toYaml .Values.global.proxy.resources | indent 4 }}
-        {{- end }}
-      {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` -}}
+            cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}
+            {{- else if .Values.global.proxy.resources.limits.cpu -}}
+            cpu: {{ .Values.global.proxy.resources.limits.cpu }}
+            {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` -}}
+            memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}
+            {{- else if .Values.global.proxy.resources.limits.memory -}}
+            memory: {{ .Values.global.proxy.resources.limits.memory }}
+            {{- end }}
+          {{- end }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
@@ -515,30 +517,35 @@ data:
           runAsUser: 1337
           {{- end }}
         resources:
-      {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+          {{ if or .Values.global.proxy.resources.requests (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
           requests:
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-            {{ end }}
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
-            {{ end }}
-        {{- end }}
-        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` -}}
+            cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}
+            {{- else if .Values.global.proxy.resources.requests.cpu -}}
+            cpu: {{ .Values.global.proxy.resources.requests.cpu }}
+            {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` -}}
+            memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}
+            {{- else if .Values.global.proxy.resources.requests.memory -}}
+            memory: {{ .Values.global.proxy.resources.requests.memory }}
+            {{- end }}
+          {{- end }}
+          {{ if or .Values.global.proxy.resources.limits (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
           limits:
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
-            {{ end }}
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
-            {{ end }}
-        {{- end }}
-      {{- else }}
-        {{- if .Values.global.proxy.resources }}
-          {{ toYaml .Values.global.proxy.resources | indent 4 }}
-        {{- end }}
-      {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` -}}
+            cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}
+            {{- else if .Values.global.proxy.resources.limits.cpu -}}
+            cpu: {{ .Values.global.proxy.resources.limits.cpu }}
+            {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` -}}
+            memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}
+            {{- else if .Values.global.proxy.resources.limits.memory -}}
+            memory: {{ .Values.global.proxy.resources.limits.memory }}
+            {{- end }}
+            {{ if .Values.global.proxy.resources.limits.memory -}}
+            memory: {{ .Values.global.proxy.resources.limits.memory }}
+            {{- end }}
+          {{- end }}
         volumeMounts:
         {{- if eq .Values.global.pilotCertProvider "istiod" }}
         - mountPath: /var/run/secrets/istio

--- a/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -542,9 +542,6 @@ data:
             {{- else if .Values.global.proxy.resources.limits.memory -}}
             memory: {{ .Values.global.proxy.resources.limits.memory }}
             {{- end }}
-            {{ if .Values.global.proxy.resources.limits.memory -}}
-            memory: {{ .Values.global.proxy.resources.limits.memory }}
-            {{- end }}
           {{- end }}
         volumeMounts:
         {{- if eq .Values.global.pilotCertProvider "istiod" }}

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -59,30 +59,32 @@ template: |
     {{- end }}
   {{- end }}
     resources:
-  {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+      {{ if or .Values.global.proxy.resources.requests (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
       requests:
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-        {{ end }}
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
-        {{ end }}
-    {{- end }}
-    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` -}}
+        cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}
+        {{- else if .Values.global.proxy.resources.requests.cpu -}}
+        cpu: {{ .Values.global.proxy.resources.requests.cpu }}
+        {{- end }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` -}}
+        memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}
+        {{- else if .Values.global.proxy.resources.requests.memory -}}
+        memory: {{ .Values.global.proxy.resources.requests.memory }}
+        {{- end }}
+      {{- end }}
+      {{ if or .Values.global.proxy.resources.limits (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
       limits:
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
-        {{ end }}
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
-        {{ end }}
-    {{- end }}
-  {{- else }}
-    {{- if .Values.global.proxy.resources }}
-      {{ toYaml .Values.global.proxy.resources | indent 4 }}
-    {{- end }}
-  {{- end }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` -}}
+        cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}
+        {{- else if .Values.global.proxy.resources.limits.cpu -}}
+        cpu: {{ .Values.global.proxy.resources.limits.cpu }}
+        {{- end }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` -}}
+        memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}
+        {{- else if .Values.global.proxy.resources.limits.memory -}}
+        memory: {{ .Values.global.proxy.resources.limits.memory }}
+        {{- end }}
+      {{- end }}
     securityContext:
       allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
       privileged: {{ .Values.global.proxy.privileged }}
@@ -319,30 +321,32 @@ template: |
       runAsUser: 1337
       {{- end }}
     resources:
-  {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+      {{ if or .Values.global.proxy.resources.requests (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
       requests:
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-        {{ end }}
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
-        {{ end }}
-    {{- end }}
-    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` -}}
+        cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}
+        {{- else if .Values.global.proxy.resources.requests.cpu -}}
+        cpu: {{ .Values.global.proxy.resources.requests.cpu }}
+        {{- end }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` -}}
+        memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}
+        {{- else if .Values.global.proxy.resources.requests.memory -}}
+        memory: {{ .Values.global.proxy.resources.requests.memory }}
+        {{- end }}
+      {{- end }}
+      {{ if or .Values.global.proxy.resources.limits (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
       limits:
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
-        {{ end }}
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
-        {{ end }}
-    {{- end }}
-  {{- else }}
-    {{- if .Values.global.proxy.resources }}
-      {{ toYaml .Values.global.proxy.resources | indent 4 }}
-    {{- end }}
-  {{- end }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` -}}
+        cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}
+        {{- else if .Values.global.proxy.resources.limits.cpu -}}
+        cpu: {{ .Values.global.proxy.resources.limits.cpu }}
+        {{- end }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` -}}
+        memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}
+        {{- else if .Values.global.proxy.resources.limits.memory -}}
+        memory: {{ .Values.global.proxy.resources.limits.memory }}
+        {{- end }}
+      {{- end }}
     volumeMounts:
     {{- if eq .Values.global.pilotCertProvider "istiod" }}
     - mountPath: /var/run/secrets/istio

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -277,30 +277,32 @@ data:
         {{- end }}
       {{- end }}
         resources:
-      {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+          {{ if or .Values.global.proxy.resources.requests (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
           requests:
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-            {{ end }}
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
-            {{ end }}
-        {{- end }}
-        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` -}}
+            cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}
+            {{- else if .Values.global.proxy.resources.requests.cpu -}}
+            cpu: {{ .Values.global.proxy.resources.requests.cpu }}
+            {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` -}}
+            memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}
+            {{- else if .Values.global.proxy.resources.requests.memory -}}
+            memory: {{ .Values.global.proxy.resources.requests.memory }}
+            {{- end }}
+          {{- end }}
+          {{ if or .Values.global.proxy.resources.limits (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
           limits:
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
-            {{ end }}
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
-            {{ end }}
-        {{- end }}
-      {{- else }}
-        {{- if .Values.global.proxy.resources }}
-          {{ toYaml .Values.global.proxy.resources | indent 4 }}
-        {{- end }}
-      {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` -}}
+            cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}
+            {{- else if .Values.global.proxy.resources.limits.cpu -}}
+            cpu: {{ .Values.global.proxy.resources.limits.cpu }}
+            {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` -}}
+            memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}
+            {{- else if .Values.global.proxy.resources.limits.memory -}}
+            memory: {{ .Values.global.proxy.resources.limits.memory }}
+            {{- end }}
+          {{- end }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
@@ -533,30 +535,32 @@ data:
           runAsUser: 1337
           {{- end }}
         resources:
-      {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+          {{ if or .Values.global.proxy.resources.requests (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
           requests:
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-            {{ end }}
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
-            {{ end }}
-        {{- end }}
-        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` -}}
+            cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}
+            {{- else if .Values.global.proxy.resources.requests.cpu -}}
+            cpu: {{ .Values.global.proxy.resources.requests.cpu }}
+            {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` -}}
+            memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}
+            {{- else if .Values.global.proxy.resources.requests.memory -}}
+            memory: {{ .Values.global.proxy.resources.requests.memory }}
+            {{- end }}
+          {{- end }}
+          {{ if or .Values.global.proxy.resources.limits (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
           limits:
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
-            {{ end }}
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
-            {{ end }}
-        {{- end }}
-      {{- else }}
-        {{- if .Values.global.proxy.resources }}
-          {{ toYaml .Values.global.proxy.resources | indent 4 }}
-        {{- end }}
-      {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` -}}
+            cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}
+            {{- else if .Values.global.proxy.resources.limits.cpu -}}
+            cpu: {{ .Values.global.proxy.resources.limits.cpu }}
+            {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` -}}
+            memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}
+            {{- else if .Values.global.proxy.resources.limits.memory -}}
+            memory: {{ .Values.global.proxy.resources.limits.memory }}
+            {{- end }}
+          {{- end }}
         volumeMounts:
         {{- if eq .Values.global.pilotCertProvider "istiod" }}
         - mountPath: /var/run/secrets/istio

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -59,30 +59,32 @@ template: |
     {{- end }}
   {{- end }}
     resources:
-  {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+      {{ if or .Values.global.proxy.resources.requests (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
       requests:
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-        {{ end }}
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
-        {{ end }}
-    {{- end }}
-    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` -}}
+        cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}
+        {{- else if .Values.global.proxy.resources.requests.cpu -}}
+        cpu: {{ .Values.global.proxy.resources.requests.cpu }}
+        {{- end }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` -}}
+        memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}
+        {{- else if .Values.global.proxy.resources.requests.memory -}}
+        memory: {{ .Values.global.proxy.resources.requests.memory }}
+        {{- end }}
+      {{- end }}
+      {{ if or .Values.global.proxy.resources.limits (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
       limits:
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
-        {{ end }}
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
-        {{ end }}
-    {{- end }}
-  {{- else }}
-    {{- if .Values.global.proxy.resources }}
-      {{ toYaml .Values.global.proxy.resources | indent 4 }}
-    {{- end }}
-  {{- end }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` -}}
+        cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}
+        {{- else if .Values.global.proxy.resources.limits.cpu -}}
+        cpu: {{ .Values.global.proxy.resources.limits.cpu }}
+        {{- end }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` -}}
+        memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}
+        {{- else if .Values.global.proxy.resources.limits.memory -}}
+        memory: {{ .Values.global.proxy.resources.limits.memory }}
+        {{- end }}
+      {{- end }}
     securityContext:
       allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
       privileged: {{ .Values.global.proxy.privileged }}
@@ -314,30 +316,32 @@ template: |
       runAsUser: 1337
       {{- end }}
     resources:
-  {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+      {{ if or .Values.global.proxy.resources.requests (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
       requests:
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-        {{ end }}
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
-        {{ end }}
-    {{- end }}
-    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` -}}
+        cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}
+        {{- else if .Values.global.proxy.resources.requests.cpu -}}
+        cpu: {{ .Values.global.proxy.resources.requests.cpu }}
+        {{- end }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` -}}
+        memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}
+        {{- else if .Values.global.proxy.resources.requests.memory -}}
+        memory: {{ .Values.global.proxy.resources.requests.memory }}
+        {{- end }}
+      {{- end }}
+      {{ if or .Values.global.proxy.resources.limits (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
       limits:
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
-        {{ end }}
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
-        {{ end }}
-    {{- end }}
-  {{- else }}
-    {{- if .Values.global.proxy.resources }}
-      {{ toYaml .Values.global.proxy.resources | indent 4 }}
-    {{- end }}
-  {{- end }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` -}}
+        cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}
+        {{- else if .Values.global.proxy.resources.limits.cpu -}}
+        cpu: {{ .Values.global.proxy.resources.limits.cpu }}
+        {{- end }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` -}}
+        memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}
+        {{- else if .Values.global.proxy.resources.limits.memory -}}
+        memory: {{ .Values.global.proxy.resources.limits.memory }}
+        {{- end }}
+      {{- end }}
     volumeMounts:
     {{- if eq .Values.global.pilotCertProvider "istiod" }}
     - mountPath: /var/run/secrets/istio

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -256,30 +256,32 @@ data:
         {{- end }}
       {{- end }}
         resources:
-      {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+          {{ if or .Values.global.proxy.resources.requests (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
           requests:
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-            {{ end }}
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
-            {{ end }}
-        {{- end }}
-        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` -}}
+            cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}
+            {{- else if .Values.global.proxy.resources.requests.cpu -}}
+            cpu: {{ .Values.global.proxy.resources.requests.cpu }}
+            {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` -}}
+            memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}
+            {{- else if .Values.global.proxy.resources.requests.memory -}}
+            memory: {{ .Values.global.proxy.resources.requests.memory }}
+            {{- end }}
+          {{- end }}
+          {{ if or .Values.global.proxy.resources.limits (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
           limits:
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
-            {{ end }}
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
-            {{ end }}
-        {{- end }}
-      {{- else }}
-        {{- if .Values.global.proxy.resources }}
-          {{ toYaml .Values.global.proxy.resources | indent 4 }}
-        {{- end }}
-      {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` -}}
+            cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}
+            {{- else if .Values.global.proxy.resources.limits.cpu -}}
+            cpu: {{ .Values.global.proxy.resources.limits.cpu }}
+            {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` -}}
+            memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}
+            {{- else if .Values.global.proxy.resources.limits.memory -}}
+            memory: {{ .Values.global.proxy.resources.limits.memory }}
+            {{- end }}
+          {{- end }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
@@ -512,30 +514,32 @@ data:
           runAsUser: 1337
           {{- end }}
         resources:
-      {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+          {{ if or .Values.global.proxy.resources.requests (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
           requests:
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-            {{ end }}
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
-            {{ end }}
-        {{- end }}
-        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` -}}
+            cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}
+            {{- else if .Values.global.proxy.resources.requests.cpu -}}
+            cpu: {{ .Values.global.proxy.resources.requests.cpu }}
+            {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` -}}
+            memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}
+            {{- else if .Values.global.proxy.resources.requests.memory -}}
+            memory: {{ .Values.global.proxy.resources.requests.memory }}
+            {{- end }}
+          {{- end }}
+          {{ if or .Values.global.proxy.resources.limits (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
           limits:
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
-            {{ end }}
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
-            {{ end }}
-        {{- end }}
-      {{- else }}
-        {{- if .Values.global.proxy.resources }}
-          {{ toYaml .Values.global.proxy.resources | indent 4 }}
-        {{- end }}
-      {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` -}}
+            cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}
+            {{- else if .Values.global.proxy.resources.limits.cpu -}}
+            cpu: {{ .Values.global.proxy.resources.limits.cpu }}
+            {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` -}}
+            memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}
+            {{- else if .Values.global.proxy.resources.limits.memory -}}
+            memory: {{ .Values.global.proxy.resources.limits.memory }}
+            {{- end }}
+          {{- end }}
         volumeMounts:
         {{- if eq .Values.global.pilotCertProvider "istiod" }}
         - mountPath: /var/run/secrets/istio

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/files/injection-template.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istiod-remote/files/injection-template.yaml
@@ -59,30 +59,32 @@ template: |
     {{- end }}
   {{- end }}
     resources:
-  {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+      {{ if or .Values.global.proxy.resources.requests (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
       requests:
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-        {{ end }}
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
-        {{ end }}
-    {{- end }}
-    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` -}}
+        cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}
+        {{- else if .Values.global.proxy.resources.requests.cpu -}}
+        cpu: {{ .Values.global.proxy.resources.requests.cpu }}
+        {{- end }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` -}}
+        memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}
+        {{- else if .Values.global.proxy.resources.requests.memory -}}
+        memory: {{ .Values.global.proxy.resources.requests.memory }}
+        {{- end }}
+      {{- end }}
+      {{ if or .Values.global.proxy.resources.limits (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
       limits:
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
-        {{ end }}
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
-        {{ end }}
-    {{- end }}
-  {{- else }}
-    {{- if .Values.global.proxy.resources }}
-      {{ toYaml .Values.global.proxy.resources | indent 4 }}
-    {{- end }}
-  {{- end }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` -}}
+        cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}
+        {{- else if .Values.global.proxy.resources.limits.cpu -}}
+        cpu: {{ .Values.global.proxy.resources.limits.cpu }}
+        {{- end }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` -}}
+        memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}
+        {{- else if .Values.global.proxy.resources.limits.memory -}}
+        memory: {{ .Values.global.proxy.resources.limits.memory }}
+        {{- end }}
+      {{- end }}
     securityContext:
       allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
       privileged: {{ .Values.global.proxy.privileged }}
@@ -315,30 +317,32 @@ template: |
       runAsUser: 1337
       {{- end }}
     resources:
-  {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+      {{ if or .Values.global.proxy.resources.requests (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
       requests:
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-        {{ end }}
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
-        {{ end }}
-    {{- end }}
-    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` -}}
+        cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}
+        {{- else if .Values.global.proxy.resources.requests.cpu -}}
+        cpu: {{ .Values.global.proxy.resources.requests.cpu }}
+        {{- end }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` -}}
+        memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}
+        {{- else if .Values.global.proxy.resources.requests.memory -}}
+        memory: {{ .Values.global.proxy.resources.requests.memory }}
+        {{- end }}
+      {{- end }}
+      {{ if or .Values.global.proxy.resources.limits (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
       limits:
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
-        {{ end }}
-        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
-        {{ end }}
-    {{- end }}
-  {{- else }}
-    {{- if .Values.global.proxy.resources }}
-      {{ toYaml .Values.global.proxy.resources | indent 4 }}
-    {{- end }}
-  {{- end }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` -}}
+        cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}
+        {{- else if .Values.global.proxy.resources.limits.cpu -}}
+        cpu: {{ .Values.global.proxy.resources.limits.cpu }}
+        {{- end }}
+        {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` -}}
+        memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}
+        {{- else if .Values.global.proxy.resources.limits.memory -}}
+        memory: {{ .Values.global.proxy.resources.limits.memory }}
+        {{- end }}
+      {{- end }}
     volumeMounts:
     {{- if eq .Values.global.pilotCertProvider "istiod" }}
     - mountPath: /var/run/secrets/istio

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -5128,30 +5128,32 @@ data:
         {{- end }}
       {{- end }}
         resources:
-      {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+          {{ if or .Values.global.proxy.resources.requests (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
           requests:
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-            {{ end }}
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
-            {{ end }}
-        {{- end }}
-        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` -}}
+            cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}
+            {{- else if .Values.global.proxy.resources.requests.cpu -}}
+            cpu: {{ .Values.global.proxy.resources.requests.cpu }}
+            {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` -}}
+            memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}
+            {{- else if .Values.global.proxy.resources.requests.memory -}}
+            memory: {{ .Values.global.proxy.resources.requests.memory }}
+            {{- end }}
+          {{- end }}
+          {{ if or .Values.global.proxy.resources.limits (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
           limits:
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
-            {{ end }}
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
-            {{ end }}
-        {{- end }}
-      {{- else }}
-        {{- if .Values.global.proxy.resources }}
-          {{ toYaml .Values.global.proxy.resources | indent 4 }}
-        {{- end }}
-      {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` -}}
+            cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}
+            {{- else if .Values.global.proxy.resources.limits.cpu -}}
+            cpu: {{ .Values.global.proxy.resources.limits.cpu }}
+            {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` -}}
+            memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}
+            {{- else if .Values.global.proxy.resources.limits.memory -}}
+            memory: {{ .Values.global.proxy.resources.limits.memory }}
+            {{- end }}
+          {{- end }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
@@ -5383,30 +5385,32 @@ data:
           runAsUser: 1337
           {{- end }}
         resources:
-      {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+          {{ if or .Values.global.proxy.resources.requests (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
           requests:
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-            {{ end }}
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
-            {{ end }}
-        {{- end }}
-        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` -}}
+            cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}
+            {{- else if .Values.global.proxy.resources.requests.cpu -}}
+            cpu: {{ .Values.global.proxy.resources.requests.cpu }}
+            {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` -}}
+            memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}
+            {{- else if .Values.global.proxy.resources.requests.memory -}}
+            memory: {{ .Values.global.proxy.resources.requests.memory }}
+            {{- end }}
+          {{- end }}
+          {{ if or .Values.global.proxy.resources.limits (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
           limits:
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
-            {{ end }}
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
-            {{ end }}
-        {{- end }}
-      {{- else }}
-        {{- if .Values.global.proxy.resources }}
-          {{ toYaml .Values.global.proxy.resources | indent 4 }}
-        {{- end }}
-      {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` -}}
+            cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}
+            {{- else if .Values.global.proxy.resources.limits.cpu -}}
+            cpu: {{ .Values.global.proxy.resources.limits.cpu }}
+            {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` -}}
+            memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}
+            {{- else if .Values.global.proxy.resources.limits.memory -}}
+            memory: {{ .Values.global.proxy.resources.limits.memory }}
+            {{- end }}
+          {{- end }}
         volumeMounts:
         {{- if eq .Values.global.pilotCertProvider "istiod" }}
         - mountPath: /var/run/secrets/istio

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
@@ -8009,30 +8009,32 @@ data:
           runAsUser: 1337
           {{- end }}
         resources:
-      {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+          {{ if or .Values.global.proxy.resources.requests (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
           requests:
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-            {{ end }}
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
-            {{ end }}
-        {{- end }}
-        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` -}}
+            cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}
+            {{- else if .Values.global.proxy.resources.requests.cpu -}}
+            cpu: {{ .Values.global.proxy.resources.requests.cpu }}
+            {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` -}}
+            memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}
+            {{- else if .Values.global.proxy.resources.requests.memory -}}
+            memory: {{ .Values.global.proxy.resources.requests.memory }}
+            {{- end }}
+          {{- end }}
+          {{ if or .Values.global.proxy.resources.limits (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
           limits:
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
-            {{ end }}
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
-            {{ end }}
-        {{- end }}
-      {{- else }}
-        {{- if .Values.global.proxy.resources }}
-          {{ toYaml .Values.global.proxy.resources | indent 4 }}
-        {{- end }}
-      {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` -}}
+            cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}
+            {{- else if .Values.global.proxy.resources.limits.cpu -}}
+            cpu: {{ .Values.global.proxy.resources.limits.cpu }}
+            {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` -}}
+            memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}
+            {{- else if .Values.global.proxy.resources.limits.memory -}}
+            memory: {{ .Values.global.proxy.resources.limits.memory }}
+            {{- end }}
+          {{- end }}
         volumeMounts:
         {{- if eq .Values.global.pilotCertProvider "istiod" }}
         - mountPath: /var/run/secrets/istio

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -1362,30 +1362,32 @@ data:
         {{- end }}
       {{- end }}
         resources:
-      {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+          {{ if or .Values.global.proxy.resources.requests (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
           requests:
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-            {{ end }}
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
-            {{ end }}
-        {{- end }}
-        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` -}}
+            cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}
+            {{- else if .Values.global.proxy.resources.requests.cpu -}}
+            cpu: {{ .Values.global.proxy.resources.requests.cpu }}
+            {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` -}}
+            memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}
+            {{- else if .Values.global.proxy.resources.requests.memory -}}
+            memory: {{ .Values.global.proxy.resources.requests.memory }}
+            {{- end }}
+          {{- end }}
+          {{ if or .Values.global.proxy.resources.limits (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
           limits:
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
-            {{ end }}
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
-            {{ end }}
-        {{- end }}
-      {{- else }}
-        {{- if .Values.global.proxy.resources }}
-          {{ toYaml .Values.global.proxy.resources | indent 4 }}
-        {{- end }}
-      {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` -}}
+            cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}
+            {{- else if .Values.global.proxy.resources.limits.cpu -}}
+            cpu: {{ .Values.global.proxy.resources.limits.cpu }}
+            {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` -}}
+            memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}
+            {{- else if .Values.global.proxy.resources.limits.memory -}}
+            memory: {{ .Values.global.proxy.resources.limits.memory }}
+            {{- end }}
+          {{- end }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
           privileged: {{ .Values.global.proxy.privileged }}
@@ -1617,30 +1619,32 @@ data:
           runAsUser: 1337
           {{- end }}
         resources:
-      {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+          {{ if or .Values.global.proxy.resources.requests (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
           requests:
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-            {{ end }}
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
-            {{ end }}
-        {{- end }}
-        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` -}}
+            cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}
+            {{- else if .Values.global.proxy.resources.requests.cpu -}}
+            cpu: {{ .Values.global.proxy.resources.requests.cpu }}
+            {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` -}}
+            memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}
+            {{- else if .Values.global.proxy.resources.requests.memory -}}
+            memory: {{ .Values.global.proxy.resources.requests.memory }}
+            {{- end }}
+          {{- end }}
+          {{ if or .Values.global.proxy.resources.limits (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
           limits:
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
-            {{ end }}
-            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
-            {{ end }}
-        {{- end }}
-      {{- else }}
-        {{- if .Values.global.proxy.resources }}
-          {{ toYaml .Values.global.proxy.resources | indent 4 }}
-        {{- end }}
-      {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` -}}
+            cpu: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}
+            {{- else if .Values.global.proxy.resources.limits.cpu -}}
+            cpu: {{ .Values.global.proxy.resources.limits.cpu }}
+            {{- end }}
+            {{ if isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` -}}
+            memory: {{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}
+            {{- else if .Values.global.proxy.resources.limits.memory -}}
+            memory: {{ .Values.global.proxy.resources.limits.memory }}
+            {{- end }}
+          {{- end }}
         volumeMounts:
         {{- if eq .Values.global.pilotCertProvider "istiod" }}
         - mountPath: /var/run/secrets/istio

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml
@@ -12,6 +12,7 @@ spec:
       annotations:
         # We set 4 CPUs here and concurrency=0 below. Expect concurrency to be set to 4.
         sidecar.istio.io/proxyCPU: 4000m
+        sidecar.istio.io/proxyCPULimit: 4000m
         traffic.sidecar.istio.io/includeInboundPorts: "1,2,3"
         traffic.sidecar.istio.io/excludeInboundPorts: "4,5,6"
         traffic.sidecar.istio.io/excludeOutboundPorts: "7,8,9"

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -21,6 +21,7 @@ spec:
           proxyMetadata:
             FOO: bar
         sidecar.istio.io/proxyCPU: 4000m
+        sidecar.istio.io/proxyCPULimit: 4000m
         sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
@@ -104,7 +105,7 @@ spec:
           value: REDIRECT
         - name: ISTIO_METAJSON_ANNOTATIONS
           value: |
-            {"proxy.istio.io/config":"discoveryAddress: foo:123\nconcurrency: 0\nproxyMetadata:\n  FOO: bar","sidecar.istio.io/proxyCPU":"4000m","traffic.sidecar.istio.io/excludeInboundPorts":"4,5,6","traffic.sidecar.istio.io/excludeOutboundIPRanges":"10.96.0.2/24,10.96.0.3/24","traffic.sidecar.istio.io/excludeOutboundPorts":"7,8,9","traffic.sidecar.istio.io/includeInboundPorts":"1,2,3","traffic.sidecar.istio.io/includeOutboundIPRanges":"127.0.0.1/24,10.96.0.1/24"}
+            {"proxy.istio.io/config":"discoveryAddress: foo:123\nconcurrency: 0\nproxyMetadata:\n  FOO: bar","sidecar.istio.io/proxyCPU":"4000m","sidecar.istio.io/proxyCPULimit":"4000m","traffic.sidecar.istio.io/excludeInboundPorts":"4,5,6","traffic.sidecar.istio.io/excludeOutboundIPRanges":"10.96.0.2/24,10.96.0.3/24","traffic.sidecar.istio.io/excludeOutboundPorts":"7,8,9","traffic.sidecar.istio.io/includeInboundPorts":"1,2,3","traffic.sidecar.istio.io/includeOutboundIPRanges":"127.0.0.1/24,10.96.0.1/24"}
         - name: ISTIO_META_WORKLOAD_NAME
           value: traffic
         - name: ISTIO_META_OWNER
@@ -128,8 +129,12 @@ spec:
           initialDelaySeconds: 1
           periodSeconds: 2
         resources:
+          limits:
+            cpu: "4"
+            memory: 1Gi
           requests:
             cpu: "4"
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -179,8 +184,12 @@ spec:
         imagePullPolicy: Always
         name: istio-init
         resources:
+          limits:
+            cpu: "4"
+            memory: 1Gi
           requests:
             cpu: "4"
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
When templating a sidecar spec having any resource annotations present such as `sidecar.istio.io/proxyMemory` currently causes the entire `Values.global.proxy.resources` block to be ignored.

In particular this means setting something like `sidecar.istio.io/proxyMemory` on a pod will unset any globally defined limits or cpu request for that pod's sidecar.

This PR changes the behaviour so that the resource annotations instead override the global values settings individually.

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
