### PR TITLE
support service.spec.externalIPs for multi-network gateway address

### DIFF
--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -150,6 +150,13 @@ func ConvertService(svc coreV1.Service, domainSuffix string, clusterID string) *
 		}
 	}
 
+	for _, extIP := range svc.Spec.ExternalIPs {
+		if istioService.Attributes.ClusterExternalAddresses == nil {
+			istioService.Attributes.ClusterExternalAddresses = map[string][]string{}
+		}
+		istioService.Attributes.ClusterExternalAddresses[clusterID] = append(istioService.Attributes.ClusterExternalAddresses[clusterID], extIP)
+	}
+
 	return istioService
 }
 

--- a/pilot/pkg/xds/mesh_network_test.go
+++ b/pilot/pkg/xds/mesh_network_test.go
@@ -67,6 +67,33 @@ func TestMeshNetworking(t *testing.T) {
 				},
 			}},
 		},
+		corev1.ServiceTypeClusterIP: {
+			// cluster/network 1's ingress can be found up by registry service name in meshNetworks
+			"cluster-1": {&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "istio-ingressgateway",
+					Namespace: "istio-system",
+				},
+				Spec: corev1.ServiceSpec{
+					Type:        corev1.ServiceTypeClusterIP,
+					ExternalIPs: []string{"2.2.2.2"},
+				},
+			}},
+			// cluster/network 2's ingress can be found by it's network label
+			"cluster-2": {&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "istio-ingressgateway",
+					Namespace: "istio-system",
+					Labels: map[string]string{
+						label.IstioNetwork: "network-2",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Type:        corev1.ServiceTypeClusterIP,
+					ExternalIPs: []string{"3.3.3.3"},
+				},
+			}},
+		},
 		corev1.ServiceTypeNodePort: {
 			"cluster-1": {
 				&corev1.Node{Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeExternalIP, Address: "2.2.2.2"}}}},

--- a/releasenotes/notes/28406.yaml
+++ b/releasenotes/notes/28406.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+issue:
+  - 28381
+
+releaseNotes:
+- |
+  **Improved** Automatic detection of [externalIPs](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#servicespec-v1-core)
+  for multi-network gateways.


### PR DESCRIPTION
This allows usecases like https://github.com/istio/istio/issues/28381 without having to manually specify gateway IP in meshNetworks. 