### PR TITLE
Fix duplicates in HTTP domains

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -23,7 +23,6 @@ import (
 	"github.com/golang/protobuf/ptypes"
 
 	networking "istio.io/api/networking/v1alpha3"
-
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/envoyfilter"
@@ -236,8 +235,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundVirtualHosts(node *mod
 	}
 
 	// Get list of virtual services bound to the mesh gateway
-	virtualHostWrappers := istio_route.BuildSidecarVirtualHostsFromConfigAndRegistry(node, push, nameToServiceMap, services,
-		virtualServices, listenerPort)
+	virtualHostWrappers := istio_route.BuildSidecarVirtualHostsFromConfigAndRegistry(node, push, nameToServiceMap, virtualServices, listenerPort)
 	vHostPortMap := make(map[int][]*route.VirtualHost)
 
 	vhosts := sets.Set{}

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -23,6 +23,7 @@ import (
 	"github.com/golang/protobuf/ptypes"
 
 	networking "istio.io/api/networking/v1alpha3"
+
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/envoyfilter"
@@ -235,12 +236,21 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundVirtualHosts(node *mod
 	}
 
 	// Get list of virtual services bound to the mesh gateway
-	virtualHostWrappers := istio_route.BuildSidecarVirtualHostsFromConfigAndRegistry(node, push, nameToServiceMap,
+	virtualHostWrappers := istio_route.BuildSidecarVirtualHostsFromConfigAndRegistry(node, push, nameToServiceMap, services,
 		virtualServices, listenerPort)
 	vHostPortMap := make(map[int][]*route.VirtualHost)
 
 	vhosts := sets.Set{}
 	vhdomains := sets.Set{}
+	knownFQDN := sets.Set{}
+
+	for _, virtualHostWrapper := range virtualHostWrappers {
+		for _, svc := range virtualHostWrapper.Services {
+			name := domainName(string(svc.Hostname), virtualHostWrapper.Port)
+			knownFQDN.Insert(name)
+			knownFQDN.Insert(string(svc.Hostname))
+		}
+	}
 
 	for _, virtualHostWrapper := range virtualHostWrappers {
 		// If none of the routes matched by source, skip this virtual host
@@ -255,16 +265,18 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundVirtualHosts(node *mod
 			if !duplicate {
 				domains := []string{hostname, name}
 				dl := len(domains)
-				domains = dedupeDomains(domains, vhdomains)
+				domains = dedupeDomains(domains, vhdomains, nil, nil)
 				if dl != len(domains) {
 					duplicate = true
 				}
-				virtualHosts = append(virtualHosts, &route.VirtualHost{
-					Name:                       name,
-					Domains:                    domains,
-					Routes:                     virtualHostWrapper.Routes,
-					IncludeRequestAttemptCount: true,
-				})
+				if len(domains) > 0 {
+					virtualHosts = append(virtualHosts, &route.VirtualHost{
+						Name:                       name,
+						Domains:                    domains,
+						Routes:                     virtualHostWrapper.Routes,
+						IncludeRequestAttemptCount: true,
+					})
+				}
 			}
 
 			if duplicate {
@@ -277,23 +289,25 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundVirtualHosts(node *mod
 			name := domainName(string(svc.Hostname), virtualHostWrapper.Port)
 			duplicate := duplicateVirtualHost(name, vhosts)
 			if !duplicate {
-				domains := generateVirtualHostDomains(svc, virtualHostWrapper.Port, node, push)
+				domains, altHosts := generateVirtualHostDomains(svc, virtualHostWrapper.Port, node, push)
 				dl := len(domains)
-				domains = dedupeDomains(domains, vhdomains)
+				domains = dedupeDomains(domains, vhdomains, altHosts, knownFQDN)
 				if dl != len(domains) {
 					duplicate = true
 				}
-				virtualHosts = append(virtualHosts, &route.VirtualHost{
-					Name:                       name,
-					Domains:                    domains,
-					Routes:                     virtualHostWrapper.Routes,
-					IncludeRequestAttemptCount: true,
-				})
+				if len(domains) > 0 {
+					virtualHosts = append(virtualHosts, &route.VirtualHost{
+						Name:                       name,
+						Domains:                    domains,
+						Routes:                     virtualHostWrapper.Routes,
+						IncludeRequestAttemptCount: true,
+					})
+				}
 			}
 
 			if duplicate {
 				// This means we have hit a duplicate virtual host name/ domain name.
-				push.AddMetric(model.DuplicatedDomains, name, node.ID, fmt.Sprintf("duplicate domain from  service: %s", name))
+				push.AddMetric(model.DuplicatedDomains, name, node.ID, fmt.Sprintf("duplicate domain from service: %s", name))
 			}
 		}
 
@@ -320,13 +334,22 @@ func duplicateVirtualHost(vhost string, vhosts sets.Set) bool {
 }
 
 // dedupeDomains removes the duplicate domains from the passed in domains.
-func dedupeDomains(domains []string, vhdomains sets.Set) []string {
+func dedupeDomains(domains []string, vhdomains sets.Set, expandedHosts []string, knownFQDNs sets.Set) []string {
 	temp := domains[:0]
 	for _, d := range domains {
-		if !vhdomains.Contains(d) {
-			temp = append(temp, d)
-			vhdomains.Insert(d)
+		if vhdomains.Contains(d) {
+			continue
 		}
+		// Check if the domain is an "expanded" host, and its also a known FQDN
+		// This prevents a case where a domain like "foo.com.cluster.local" gets expanded to "foo.com", overwriting
+		// the real "foo.com"
+		// This works by providing a list of domains that were added as expanding the DNS domain as part of expandedHosts,
+		// and a list of known unexpanded FQDNs to compare against
+		if util.ListContains(expandedHosts, d) && knownFQDNs.Contains(d) { // O(n) search, but n is at most 10
+			continue
+		}
+		temp = append(temp, d)
+		vhdomains.Insert(d)
 	}
 	return temp
 }
@@ -353,9 +376,10 @@ func getVirtualHostsForSniffedServicePort(vhosts []*route.VirtualHost, routeName
 
 // generateVirtualHostDomains generates the set of domain matches for a service being accessed from
 // a proxy node
-func generateVirtualHostDomains(service *model.Service, port int, node *model.Proxy, push *model.PushContext) []string {
+func generateVirtualHostDomains(service *model.Service, port int, node *model.Proxy, push *model.PushContext) ([]string, []string) {
+	altHosts := generateAltVirtualHosts(string(service.Hostname), port, node.DNSDomain)
 	domains := []string{string(service.Hostname), domainName(string(service.Hostname), port)}
-	domains = append(domains, generateAltVirtualHosts(string(service.Hostname), port, node.DNSDomain)...)
+	domains = append(domains, altHosts...)
 
 	if service.Resolution == model.Passthrough &&
 		service.Attributes.ServiceRegistry == string(serviceregistry.Kubernetes) {
@@ -372,7 +396,7 @@ func generateVirtualHostDomains(service *model.Service, port int, node *model.Pr
 			domains = append(domains, svcAddr, domainName(svcAddr, port))
 		}
 	}
-	return domains
+	return domains, altHosts
 }
 
 // Given a service, and a port, this function generates all possible HTTP Host headers.
@@ -405,6 +429,7 @@ func generateAltVirtualHosts(hostname string, port int, proxyDomain string) []st
 	vhosts = append(vhosts, uniqHostname, domainName(uniqHostname, port))
 
 	// adds all the other variants (foo.local, foo.local:80)
+	// TODO(https://github.com/istio/istio/issues/28407) splitting on each dot is not right
 	for i := len(sharedDNSDomain) - 1; i > 0; i-- {
 		if sharedDNSDomain[i] == '.' {
 			variant := uniqHostname + "." + sharedDNSDomain[:i]

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+	"time"
 
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 
@@ -32,6 +33,7 @@ import (
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/visibility"
 )
 
@@ -84,7 +86,7 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		out := generateVirtualHostDomains(c.service, c.port, c.node, model.NewPushContext())
+		out, _ := generateVirtualHostDomains(c.service, c.port, c.node, model.NewPushContext())
 		sort.SliceStable(c.want, func(i, j int) bool { return c.want[i] < c.want[j] })
 		sort.SliceStable(out, func(i, j int) bool { return out[i] < out[j] })
 		if !reflect.DeepEqual(out, c.want) {
@@ -94,10 +96,7 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 }
 
 func TestSidecarOutboundHTTPRouteConfigWithDuplicateHosts(t *testing.T) {
-	services := []*model.Service{
-		buildHTTPService("test-duplicate-domains.default.svc.cluster.local", visibility.Public, "172.10.10.19", "default", 7443, 70),
-	}
-	virtualServiceSpec6 := &networking.VirtualService{
+	virtualServiceSpec := &networking.VirtualService{
 		Hosts:    []string{"test-duplicate-domains.default.svc.cluster.local", "test-duplicate-domains.default"},
 		Gateways: []string{"mesh"},
 		Http: []*networking.HTTPRoute{
@@ -105,7 +104,22 @@ func TestSidecarOutboundHTTPRouteConfigWithDuplicateHosts(t *testing.T) {
 				Route: []*networking.HTTPRouteDestination{
 					{
 						Destination: &networking.Destination{
-							Host: "test-duplicate-domains.default.svc.cluster.local",
+							Host: "test-duplicate-domains.default",
+						},
+					},
+				},
+			},
+		},
+	}
+	virtualServiceSpecDefault := &networking.VirtualService{
+		Hosts:    []string{"test.default"},
+		Gateways: []string{"mesh"},
+		Http: []*networking.HTTPRoute{
+			{
+				Route: []*networking.HTTPRouteDestination{
+					{
+						Destination: &networking.Destination{
+							Host: "test.default",
 						},
 					},
 				},
@@ -113,49 +127,171 @@ func TestSidecarOutboundHTTPRouteConfigWithDuplicateHosts(t *testing.T) {
 		},
 	}
 
-	virtualService6 := config.Config{
-		Meta: config.Meta{
-			GroupVersionKind: collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind(),
-			Name:             "acme-v3",
-			Namespace:        "not-default",
+	cases := []struct {
+		name                string
+		services            []*model.Service
+		config              []config.Config
+		expectedHosts       map[string][]string
+		expectedDestination map[string]string
+	}{
+		{
+			"more exact first",
+			[]*model.Service{
+				buildHTTPService("test.local", visibility.Public, "", "default", 80),
+				buildHTTPService("test", visibility.Public, "", "default", 80),
+			},
+			nil,
+			map[string][]string{
+				"allow_any": {"*"},
+				// BUG: test should be below
+				"test.local:80": {"test.local", "test.local:80"},
+				"test:80":       {"test", "test:80"},
+			},
+			map[string]string{
+				"allow_any":     "PassthroughCluster",
+				"test.local:80": "outbound|80||test.local",
+				"test:80":       "outbound|80||test",
+			},
 		},
-		Spec: virtualServiceSpec6,
-	}
-
-	virtualServices := []*config.Config{&virtualService6}
-	p := &fakePlugin{}
-	configgen := NewConfigGenerator([]plugin.Plugin{p}, &model.DisabledCache{})
-
-	env := buildListenerEnvWithVirtualServices(services, virtualServices)
-
-	if err := env.PushContext.InitContext(&env, nil, nil); err != nil {
-		t.Fatalf("failed to initialize push context")
-	}
-	env.Mesh().OutboundTrafficPolicy = &meshapi.MeshConfig_OutboundTrafficPolicy{Mode: meshapi.MeshConfig_OutboundTrafficPolicy_REGISTRY_ONLY}
-
-	proxy := model.Proxy{
-		Type:        model.SidecarProxy,
-		IPAddresses: []string{"1.1.1.1"},
-		ID:          "v0.default",
-		DNSDomain:   "svc.cluster.local",
-		Metadata: &model.NodeMetadata{
-			Namespace: "not-default",
+		{
+			"more exact first with full cluster domain",
+			[]*model.Service{
+				buildHTTPService("test.default.svc.cluster.local", visibility.Public, "", "default", 80),
+				buildHTTPService("test", visibility.Public, "", "default", 80),
+			},
+			nil,
+			map[string][]string{
+				"allow_any": {"*"},
+				"test.default.svc.cluster.local:80": {
+					"test.default.svc.cluster.local", "test.default.svc.cluster.local:80",
+					"test.default.svc.cluster", "test.default.svc.cluster:80",
+					"test.default.svc", "test.default.svc:80",
+					"test.default", "test.default:80",
+				},
+				"test:80": {"test", "test:80"},
+			},
+			map[string]string{
+				"allow_any":                         "PassthroughCluster",
+				"test.default.svc.cluster.local:80": "outbound|80||test.default.svc.cluster.local",
+				"test:80":                           "outbound|80||test",
+			},
 		},
-		ConfigNamespace: "not-default",
+		{
+			"more exact second",
+			[]*model.Service{
+				buildHTTPService("test", visibility.Public, "", "default", 80),
+				buildHTTPService("test.local", visibility.Public, "", "default", 80),
+			},
+			nil,
+			map[string][]string{
+				"allow_any":     {"*"},
+				"test.local:80": {"test.local", "test.local:80"},
+				"test:80":       {"test", "test:80"},
+			},
+			map[string]string{
+				"allow_any":     "PassthroughCluster",
+				"test.local:80": "outbound|80||test.local",
+				"test:80":       "outbound|80||test",
+			},
+		},
+		{
+			"virtual service",
+			[]*model.Service{
+				buildHTTPService("test-duplicate-domains.default.svc.cluster.local", visibility.Public, "", "default", 80),
+			},
+			[]config.Config{{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.VirtualService,
+					Name:             "acme",
+				},
+				Spec: virtualServiceSpec,
+			}},
+			map[string][]string{
+				"allow_any": {"*"},
+				"test-duplicate-domains.default.svc.cluster.local:80": {
+					"test-duplicate-domains.default.svc.cluster.local", "test-duplicate-domains.default.svc.cluster.local:80",
+					"test-duplicate-domains", "test-duplicate-domains:80",
+					"test-duplicate-domains.default.svc.cluster", "test-duplicate-domains.default.svc.cluster:80",
+					"test-duplicate-domains.default.svc", "test-duplicate-domains.default.svc:80",
+				},
+				"test-duplicate-domains.default:80": {"test-duplicate-domains.default", "test-duplicate-domains.default:80"},
+			},
+			map[string]string{
+				"allow_any": "PassthroughCluster",
+				// Virtual service destination takes precedence
+				"test-duplicate-domains.default.svc.cluster.local:80": "outbound|80||test-duplicate-domains.default",
+				"test-duplicate-domains.default:80":                   "outbound|80||test-duplicate-domains.default",
+			},
+		},
+		{
+			"virtual service conflict",
+			[]*model.Service{
+				buildHTTPService("test.default.svc.cluster.local", visibility.Public, "", "default", 80),
+			},
+			[]config.Config{{
+				Meta: config.Meta{
+					GroupVersionKind: gvk.VirtualService,
+					Name:             "acme",
+				},
+				Spec: virtualServiceSpecDefault,
+			}},
+			map[string][]string{
+				"allow_any": {"*"},
+				"test.default.svc.cluster.local:80": {
+					"test.default.svc.cluster.local", "test.default.svc.cluster.local:80",
+					"test", "test:80",
+					"test.default.svc.cluster", "test.default.svc.cluster:80",
+					"test.default.svc", "test.default.svc:80",
+				},
+				"test.default:80": {"test.default", "test.default:80"},
+			},
+			map[string]string{
+				"allow_any": "PassthroughCluster",
+				// From the service, go to the service
+				"test.default.svc.cluster.local:80": "outbound|80||test.default.svc.cluster.local",
+				// From the VS, go to VS destination
+				"test.default:80": "outbound|80||test.default",
+			},
+		},
 	}
-	proxy.SidecarScope = model.DefaultSidecarScopeForNamespace(env.PushContext, "not-default")
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			// ensure services are ordered
+			t0 := time.Now()
+			for _, svc := range tt.services {
+				svc.CreationTime = t0
+				t0 = t0.Add(time.Minute)
+			}
+			cg := NewConfigGenTest(t, TestOptions{
+				Services: tt.services,
+				Configs:  tt.config,
+			})
 
-	vHostCache := make(map[int][]*route.VirtualHost)
-	routeName := "7443"
-	routeCfg := configgen.buildSidecarOutboundHTTPRouteConfig(&proxy, env.PushContext, "7443", vHostCache)
-	xdstest.ValidateRouteConfiguration(t, routeCfg)
-	if routeCfg == nil {
-		t.Fatalf("got nil route for %s", routeName)
+			vHostCache := make(map[int][]*route.VirtualHost)
+			routeName := "80"
+			routeCfg := cg.ConfigGen.buildSidecarOutboundHTTPRouteConfig(cg.SetupProxy(nil), cg.PushContext(), "80", vHostCache)
+			xdstest.ValidateRouteConfiguration(t, routeCfg)
+			if routeCfg == nil {
+				t.Fatalf("got nil route for %s", routeName)
+			}
+
+			got := map[string][]string{}
+			clusters := map[string]string{}
+			for _, vh := range routeCfg.VirtualHosts {
+				got[vh.Name] = vh.Domains
+				clusters[vh.Name] = vh.GetRoutes()[0].GetRoute().GetCluster()
+			}
+
+			if !reflect.DeepEqual(tt.expectedHosts, got) {
+				t.Fatalf("unexpected virtual hosts\n%v, wanted\n%v", got, tt.expectedHosts)
+			}
+
+			if !reflect.DeepEqual(tt.expectedDestination, clusters) {
+				t.Fatalf("unexpected destinations\n%v, wanted\n%v", clusters, tt.expectedDestination)
+			}
+		})
 	}
 
-	if len(routeCfg.VirtualHosts) != 3 {
-		t.Fatalf("unexpected virtual hosts %v", routeCfg.VirtualHosts)
-	}
 }
 
 func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -253,6 +253,22 @@ func TestSidecarOutboundHTTPRouteConfigWithDuplicateHosts(t *testing.T) {
 				"test.default:80": "outbound|80||test.default",
 			},
 		},
+		{
+			"multiple ports",
+			[]*model.Service{
+				buildHTTPService("test.local", visibility.Public, "", "default", 70, 80, 90),
+			},
+			nil,
+			map[string][]string{
+				"allow_any": {"*"},
+				// BUG: test should be below
+				"test.local:80": {"test.local", "test.local:80", "test", "test:80"},
+			},
+			map[string]string{
+				"allow_any":     "PassthroughCluster",
+				"test.local:80": "outbound|80||test.local",
+			},
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -99,7 +99,7 @@ type VirtualHostWrapper struct {
 // service registry. Services are indexed by FQDN hostnames.
 // The list of services is also passed to allow maintaining consistent ordering.
 func BuildSidecarVirtualHostsFromConfigAndRegistry(node *model.Proxy, push *model.PushContext, serviceRegistry map[host.Name]*model.Service,
-	services []*model.Service, virtualServices []config.Config, listenPort int) []VirtualHostWrapper {
+	virtualServices []config.Config, listenPort int) []VirtualHostWrapper {
 
 	out := make([]VirtualHostWrapper, 0)
 
@@ -125,10 +125,8 @@ func BuildSidecarVirtualHostsFromConfigAndRegistry(node *model.Proxy, push *mode
 	}
 
 	// append default hosts for the service missing virtual services
-	for _, svc := range services {
-		if _, f := missing[svc.Hostname]; !f {
-			continue
-		}
+	for hn := range missing {
+		svc := serviceRegistry[hn]
 		for _, port := range svc.Ports {
 			if port.Protocol.IsHTTP() || util.IsProtocolSniffingEnabledForPort(port) {
 				cluster := model.BuildSubsetKey(model.TrafficDirectionOutbound, "", svc.Hostname, port.Port)

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -97,12 +97,9 @@ type VirtualHostWrapper struct {
 // BuildSidecarVirtualHostsFromConfigAndRegistry creates virtual hosts from
 // the given set of virtual services and a list of services from the
 // service registry. Services are indexed by FQDN hostnames.
-func BuildSidecarVirtualHostsFromConfigAndRegistry(
-	node *model.Proxy,
-	push *model.PushContext,
-	serviceRegistry map[host.Name]*model.Service,
-	virtualServices []config.Config,
-	listenPort int) []VirtualHostWrapper {
+// The list of services is also passed to allow maintaining consistent ordering.
+func BuildSidecarVirtualHostsFromConfigAndRegistry(node *model.Proxy, push *model.PushContext, serviceRegistry map[host.Name]*model.Service,
+	services []*model.Service, virtualServices []config.Config, listenPort int) []VirtualHostWrapper {
 
 	out := make([]VirtualHostWrapper, 0)
 
@@ -117,9 +114,9 @@ func BuildSidecarVirtualHostsFromConfigAndRegistry(
 	}
 
 	// compute services missing virtual service configs
-	missing := make(map[host.Name]bool)
+	missing := make(map[host.Name]struct{})
 	for fqdn := range serviceRegistry {
-		missing[fqdn] = true
+		missing[fqdn] = struct{}{}
 	}
 	for _, wrapper := range out {
 		for _, service := range wrapper.Services {
@@ -128,8 +125,10 @@ func BuildSidecarVirtualHostsFromConfigAndRegistry(
 	}
 
 	// append default hosts for the service missing virtual services
-	for fqdn := range missing {
-		svc := serviceRegistry[fqdn]
+	for _, svc := range services {
+		if _, f := missing[svc.Hostname]; !f {
+			continue
+		}
 		for _, port := range svc.Ports {
 			if port.Protocol.IsHTTP() || util.IsProtocolSniffingEnabledForPort(port) {
 				cluster := model.BuildSubsetKey(model.TrafficDirectionOutbound, "", svc.Hostname, port.Port)

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -56,7 +56,6 @@ func TestBuildHTTPRoutes(t *testing.T) {
 			},
 		},
 	}
-	serviceList := []*model.Service{serviceRegistry["*.example.org"]}
 
 	node := &model.Proxy{
 		Type:        model.SidecarProxy,
@@ -639,7 +638,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 				},
 				Spec: networkingDestinationRule,
 			}})
-		vhosts := route.BuildSidecarVirtualHostsFromConfigAndRegistry(node, push, serviceRegistry, serviceList, []config.Config{}, 8080)
+		vhosts := route.BuildSidecarVirtualHostsFromConfigAndRegistry(node, push, serviceRegistry, []config.Config{}, 8080)
 		g.Expect(vhosts[0].Routes[0].Action.(*envoyroute.Route_Route).Route.HashPolicy).NotTo(gomega.BeNil())
 	})
 	t.Run("for no virtualservice but has destinationrule with portLevel consistentHash loadbalancer", func(t *testing.T) {
@@ -657,7 +656,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 				Spec: networkingDestinationRuleWithPortLevelTrafficPolicy,
 			}})
 
-		vhosts := route.BuildSidecarVirtualHostsFromConfigAndRegistry(node, push, serviceRegistry, serviceList, []config.Config{}, 8080)
+		vhosts := route.BuildSidecarVirtualHostsFromConfigAndRegistry(node, push, serviceRegistry, []config.Config{}, 8080)
 
 		hashPolicy := &envoyroute.RouteAction_HashPolicy{
 			PolicySpecifier: &envoyroute.RouteAction_HashPolicy_Cookie_{

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -56,6 +56,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 			},
 		},
 	}
+	serviceList := []*model.Service{serviceRegistry["*.example.org"]}
 
 	node := &model.Proxy{
 		Type:        model.SidecarProxy,
@@ -638,7 +639,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 				},
 				Spec: networkingDestinationRule,
 			}})
-		vhosts := route.BuildSidecarVirtualHostsFromConfigAndRegistry(node, push, serviceRegistry, []config.Config{}, 8080)
+		vhosts := route.BuildSidecarVirtualHostsFromConfigAndRegistry(node, push, serviceRegistry, serviceList, []config.Config{}, 8080)
 		g.Expect(vhosts[0].Routes[0].Action.(*envoyroute.Route_Route).Route.HashPolicy).NotTo(gomega.BeNil())
 	})
 	t.Run("for no virtualservice but has destinationrule with portLevel consistentHash loadbalancer", func(t *testing.T) {
@@ -656,7 +657,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 				Spec: networkingDestinationRuleWithPortLevelTrafficPolicy,
 			}})
 
-		vhosts := route.BuildSidecarVirtualHostsFromConfigAndRegistry(node, push, serviceRegistry, []config.Config{}, 8080)
+		vhosts := route.BuildSidecarVirtualHostsFromConfigAndRegistry(node, push, serviceRegistry, serviceList, []config.Config{}, 8080)
 
 		hashPolicy := &envoyroute.RouteAction_HashPolicy{
 			PolicySpecifier: &envoyroute.RouteAction_HashPolicy_Cookie_{

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -153,6 +153,15 @@ func getMaxCidrPrefix(addr string) uint32 {
 	return 32
 }
 
+func ListContains(haystack []string, needle string) bool {
+	for _, n := range haystack {
+		if needle == n {
+			return true
+		}
+	}
+	return false
+}
+
 // ConvertAddressToCidr converts from string to CIDR proto
 func ConvertAddressToCidr(addr string) *core.CidrRange {
 	if len(addr) == 0 {


### PR DESCRIPTION
if we have domains like {foo, foo.local}, the order we build matters. If
foo is first, we will build the foo virtual host, then the foo.local.
But if foo.local is first, we build a single virtual host with both
domains, and then a second one with empty domain.

This is broken for three reasons
1. Empty domain list is rejected by envoy
2. The behavior is nondeterministic. Should have stable Service ordering
3. You may explicitly want the non-expanded versions
