### PR TITLE
Improve using system certs on CA/XDS

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -97,11 +97,11 @@ var (
 	provCert = env.RegisterStringVar("PROV_CERT", "",
 		"Set to a directory containing provisioned certs, for VMs").Get()
 
-	// set to "/etc/ssl/certs/ca-certificates.crt" on debian/ubuntu for ACME/public signed XDS servers.
+	// set to "SYSTEM" for ACME/public signed XDS servers.
 	xdsRootCA = env.RegisterStringVar("XDS_ROOT_CA", "",
 		"Explicitly set the root CA to expect for the XDS connection.").Get()
 
-	// set to "/etc/ssl/certs/ca-certificates.crt" on debian/ubuntu for ACME/public signed CA servers.
+	// set to "SYSTEM" for ACME/public signed CA servers.
 	caRootCA = env.RegisterStringVar("CA_ROOT_CA", "",
 		"Explicitly set the root CA to expect for the CA connection.").Get()
 
@@ -296,6 +296,13 @@ var (
 				}
 			}
 
+			provCert := sa.FindRootCAForXDS()
+			if provCert == "" {
+				// Envoy only supports load from file. If we want to use system certs, use best guess
+				// To be more correct this could lookup all the "well known" paths but this is extremely \
+				// unlikely to run on a non-debian based machine, and if it is it can be explicitly configured
+				provCert = "/etc/ssl/certs/ca-certificates.crt"
+			}
 			envoyProxy := envoy.NewProxy(envoy.ProxyConfig{
 				Config:              proxyConfig,
 				Node:                role.ServiceNode(),
@@ -307,7 +314,7 @@ var (
 				STSPort:             stsPort,
 				OutlierLogPath:      outlierLogPath,
 				PilotCertProvider:   pilotCertProvider,
-				ProvCert:            sa.FindRootCAForXDS(),
+				ProvCert:            provCert,
 				Sidecar:             role.Type == model.SidecarProxy,
 				ProxyViaAgent:       agentConfig.ProxyXDSViaAgent,
 				CallCredentials:     callCredentials.Get(),

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -522,15 +522,22 @@ func (p *XdsProxy) getRootCertificate(agent *Agent) (*x509.CertPool, error) {
 	var err error
 	var rootCert []byte
 	xdsCACertPath := agent.FindRootCAForXDS()
-	rootCert, err = ioutil.ReadFile(xdsCACertPath)
-	if err != nil {
-		return nil, err
-	}
+	if xdsCACertPath != "" {
+		rootCert, err = ioutil.ReadFile(xdsCACertPath)
+		if err != nil {
+			return nil, err
+		}
 
-	certPool = x509.NewCertPool()
-	ok := certPool.AppendCertsFromPEM(rootCert)
-	if !ok {
-		return nil, fmt.Errorf("failed to create TLS dial option with root certificates")
+		certPool = x509.NewCertPool()
+		ok := certPool.AppendCertsFromPEM(rootCert)
+		if !ok {
+			return nil, fmt.Errorf("failed to create TLS dial option with root certificates")
+		}
+	} else {
+		certPool, err = x509.SystemCertPool()
+		if err != nil {
+			return nil, err
+		}
 	}
 	return certPool, nil
 }

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -42,6 +42,9 @@ const (
 	// LocalSDS is the location of the in-process SDS server - must be in a writeable dir.
 	DefaultLocalSDSPath = "./etc/istio/proxy/SDS"
 
+	// SystemRootCerts is special case input for root cert configuration to use system root certificates.
+	SystemRootCerts = "SYSTEM"
+
 	// Credential fetcher type
 	GCE  = "GoogleComputeEngine"
 	Mock = "Mock" // testing only


### PR DESCRIPTION
Benefits of this PR:
* Can support any platform without needing to remember/change the path
* We don't log the 100s of lines of the system certs

Negatives:
* New magic SYSTEM value
* Old non xds-proxy is a bit hacky, but should work



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.