### PR TITLE
Improved performance of MostSpecificHostMatch

### DIFF
--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -365,17 +365,39 @@ func resolveGatewayName(gwname string, meta ConfigMeta) string {
 
 // MostSpecificHostMatch compares the elements of the stack to the needle, and returns the longest stack element
 // matching the needle, or false if no element in the stack matches the needle.
-func MostSpecificHostMatch(needle host.Name, stack []host.Name) (host.Name, bool) {
+func MostSpecificHostMatch(needle host.Name, m map[host.Name]struct{}, stack []host.Name) (host.Name, bool) {
 	matches := []host.Name{}
-	for _, h := range stack {
-		if needle == h {
-			// exact match, return immediately
-			return needle, true
+
+	// exact match, use map
+	if _, ok := m[needle]; ok {
+		return needle, true
+	}
+
+	if needle.IsWildCarded() {
+		// slice has better loop performance than map, so use stack to range
+		// and stack is ordered before
+		for _, h := range stack {
+			// both needle and h are wildcards
+			if h.IsWildCarded() {
+				if len(needle) < len(h) {
+					continue
+				}
+				if strings.HasSuffix(string(needle[1:]), string(h[1:])) {
+					matches = append(matches, h)
+				}
+			}
 		}
-		if needle.SubsetOf(h) {
-			matches = append(matches, h)
+	} else {
+		for _, h := range stack {
+			// only n is wildcard
+			if h.IsWildCarded() {
+				if strings.HasSuffix(string(needle), string(h[1:])) {
+					matches = append(matches, h)
+				}
+			}
 		}
 	}
+
 	if len(matches) > 0 {
 		// TODO: return closest match out of all non-exact matching hosts
 		return matches[0], true

--- a/pilot/pkg/model/destination_rule.go
+++ b/pilot/pkg/model/destination_rule.go
@@ -79,6 +79,7 @@ func (ps *PushContext) mergeDestinationRule(p *processedDestRules, destRuleConfi
 
 	// DestinationRule does not exist for the resolved host so add it
 	p.hosts = append(p.hosts, resolvedHost)
+	p.hostsMap[resolvedHost] = struct{}{}
 	p.destRule[resolvedHost] = &destRuleConfig
 	p.exportTo[resolvedHost] = exportToMap
 }


### PR DESCRIPTION
1.  Use map instead of loop statement to match exactly
2. Add benchmark testcase for MostSpecificHostMatch
3. Refer the necessary judgment statements to the outside of the looping structure like `needle.IsWildCarded()`


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[x] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.