### PR TITLE
Improved performance of MostSpecificHostMatch

### DIFF
--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -248,17 +248,39 @@ func resolveGatewayName(gwname string, meta config.Meta) string {
 
 // MostSpecificHostMatch compares the elements of the stack to the needle, and returns the longest stack element
 // matching the needle, or false if no element in the stack matches the needle.
-func MostSpecificHostMatch(needle host.Name, stack []host.Name) (host.Name, bool) {
+func MostSpecificHostMatch(needle host.Name, m map[host.Name]struct{}, stack []host.Name) (host.Name, bool) {
 	matches := []host.Name{}
-	for _, h := range stack {
-		if needle == h {
-			// exact match, return immediately
-			return needle, true
+
+	// exact match, use map
+	if _, ok := m[needle]; ok {
+		return needle, true
+	}
+
+	if needle.IsWildCarded() {
+		// slice has better loop performance than map, so use stack to range
+		// and stack is ordered before
+		for _, h := range stack {
+			// both needle and h are wildcards
+			if h.IsWildCarded() {
+				if len(needle) < len(h) {
+					continue
+				}
+				if strings.HasSuffix(string(needle[1:]), string(h[1:])) {
+					matches = append(matches, h)
+				}
+			}
 		}
-		if needle.SubsetOf(h) {
-			matches = append(matches, h)
+	} else {
+		for _, h := range stack {
+			// only n is wildcard
+			if h.IsWildCarded() {
+				if strings.HasSuffix(string(needle), string(h[1:])) {
+					matches = append(matches, h)
+				}
+			}
 		}
 	}
+
 	if len(matches) > 0 {
 		// TODO: return closest match out of all non-exact matching hosts
 		return matches[0], true

--- a/pilot/pkg/model/config_test.go
+++ b/pilot/pkg/model/config_test.go
@@ -17,6 +17,7 @@ package model_test
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
@@ -243,42 +244,104 @@ func TestResolveShortnameToFQDN(t *testing.T) {
 func TestMostSpecificHostMatch(t *testing.T) {
 	tests := []struct {
 		in     []host.Name
+		m      map[host.Name]struct{}
 		needle host.Name
 		want   host.Name
 	}{
 		// this has to be a sorted list
-		{[]host.Name{}, "*", ""},
-		{[]host.Name{"*.foo.com", "*.com"}, "bar.foo.com", "*.foo.com"},
-		{[]host.Name{"*.foo.com", "*.com"}, "foo.com", "*.com"},
-		{[]host.Name{"foo.com", "*.com"}, "*.foo.com", "*.com"},
+		{[]host.Name{}, make(map[host.Name]struct{}), "*", ""},
+		{[]host.Name{"*.foo.com", "*.com"}, make(map[host.Name]struct{}), "bar.foo.com", "*.foo.com"},
+		{[]host.Name{"*.foo.com", "*.com"}, make(map[host.Name]struct{}), "foo.com", "*.com"},
+		{[]host.Name{"foo.com", "*.com"}, make(map[host.Name]struct{}), "*.foo.com", "*.com"},
 
-		{[]host.Name{"*.foo.com", "foo.com"}, "foo.com", "foo.com"},
-		{[]host.Name{"*.foo.com", "foo.com"}, "*.foo.com", "*.foo.com"},
+		{[]host.Name{"*.foo.com", "foo.com"}, make(map[host.Name]struct{}), "foo.com", "foo.com"},
+		{[]host.Name{"*.foo.com", "foo.com"}, make(map[host.Name]struct{}), "*.foo.com", "*.foo.com"},
 
 		// this passes because we sort alphabetically
-		{[]host.Name{"bar.com", "foo.com"}, "*.com", ""},
+		{[]host.Name{"bar.com", "foo.com"}, make(map[host.Name]struct{}), "*.com", ""},
 
-		{[]host.Name{"bar.com", "*.foo.com"}, "*foo.com", ""},
-		{[]host.Name{"foo.com", "*.foo.com"}, "*foo.com", ""},
+		{[]host.Name{"bar.com", "*.foo.com"}, make(map[host.Name]struct{}), "*foo.com", ""},
+		{[]host.Name{"foo.com", "*.foo.com"}, make(map[host.Name]struct{}), "*foo.com", ""},
 
 		// should prioritize closest match
-		{[]host.Name{"*.bar.com", "foo.bar.com"}, "foo.bar.com", "foo.bar.com"},
-		{[]host.Name{"*.foo.bar.com", "bar.foo.bar.com"}, "bar.foo.bar.com", "bar.foo.bar.com"},
+		{[]host.Name{"*.bar.com", "foo.bar.com"}, make(map[host.Name]struct{}), "foo.bar.com", "foo.bar.com"},
+		{[]host.Name{"*.foo.bar.com", "bar.foo.bar.com"}, make(map[host.Name]struct{}), "bar.foo.bar.com", "bar.foo.bar.com"},
 
 		// should not match non-wildcards for wildcard needle
-		{[]host.Name{"bar.foo.com", "foo.bar.com"}, "*.foo.com", ""},
-		{[]host.Name{"foo.bar.foo.com", "bar.foo.bar.com"}, "*.bar.foo.com", ""},
+		{[]host.Name{"bar.foo.com", "foo.bar.com"}, make(map[host.Name]struct{}), "*.foo.com", ""},
+		{[]host.Name{"foo.bar.foo.com", "bar.foo.bar.com"}, make(map[host.Name]struct{}), "*.bar.foo.com", ""},
 	}
 
 	for idx, tt := range tests {
+		for _, h := range tt.in {
+			tt.m[h] = struct{}{}
+		}
+
 		t.Run(fmt.Sprintf("[%d] %s", idx, tt.needle), func(t *testing.T) {
-			actual, found := model.MostSpecificHostMatch(tt.needle, tt.in)
+			actual, found := model.MostSpecificHostMatch(tt.needle, tt.m, tt.in)
 			if tt.want != "" && !found {
 				t.Fatalf("model.MostSpecificHostMatch(%q, %v) = %v, %t; want: %v", tt.needle, tt.in, actual, found, tt.want)
 			} else if actual != tt.want {
 				t.Fatalf("model.MostSpecificHostMatch(%q, %v) = %v, %t; want: %v", tt.needle, tt.in, actual, found, tt.want)
 			}
 		})
+	}
+}
+
+func BenchmarkMostSpecificHostMatchExact(b *testing.B) {
+	length := 5000
+	m := make(map[host.Name]struct{})
+	var l []host.Name
+
+	for i := 0; i <= length; i++ {
+		h := host.Name(strconv.Itoa(i) + ".foo.bar.com")
+		l = append(l, h)
+		m[h] = struct{}{}
+	}
+
+	needle := host.Name(strconv.Itoa(length) + ".foo.bar.com")
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		_, _ = model.MostSpecificHostMatch(needle, m, l)
+	}
+}
+
+func BenchmarkMostSpecificHostMatchDestWildcard(b *testing.B) {
+	length := 5000
+	m := make(map[host.Name]struct{})
+	var l []host.Name
+
+	for i := 0; i <= length; i++ {
+		h := host.Name("*." + strconv.Itoa(i) + ".foo.bar.com")
+		l = append(l, h)
+		m[h] = struct{}{}
+	}
+
+	needle := host.Name("bar." + strconv.Itoa(length) + ".foo.bar.com")
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		_, _ = model.MostSpecificHostMatch(needle, m, l)
+	}
+}
+
+func BenchmarkMostSpecificHostMatchNeedleWildcard(b *testing.B) {
+	length := 5000
+	m := make(map[host.Name]struct{})
+	var l []host.Name
+
+	for i := 0; i <= length; i++ {
+		h := host.Name("*." + strconv.Itoa(i) + ".foo.bar.com")
+		l = append(l, h)
+		m[h] = struct{}{}
+	}
+
+	needle := host.Name("*." + strconv.Itoa(length+1) + ".foo.bar.com")
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		_, _ = model.MostSpecificHostMatch(needle, m, l)
 	}
 }
 

--- a/pilot/pkg/model/destination_rule.go
+++ b/pilot/pkg/model/destination_rule.go
@@ -19,6 +19,7 @@ import (
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/visibility"
 )
 
@@ -79,6 +80,9 @@ func (ps *PushContext) mergeDestinationRule(p *processedDestRules, destRuleConfi
 
 	// DestinationRule does not exist for the resolved host so add it
 	p.hosts = append(p.hosts, resolvedHost)
+	if p.hostsMap == nil {
+		p.hostsMap = make(map[host.Name]struct{})
+	}
 	p.hostsMap[resolvedHost] = struct{}{}
 	p.destRule[resolvedHost] = &destRuleConfig
 	p.exportTo[resolvedHost] = exportToMap

--- a/pilot/pkg/model/destination_rule.go
+++ b/pilot/pkg/model/destination_rule.go
@@ -79,6 +79,7 @@ func (ps *PushContext) mergeDestinationRule(p *processedDestRules, destRuleConfi
 
 	// DestinationRule does not exist for the resolved host so add it
 	p.hosts = append(p.hosts, resolvedHost)
+	p.hostsMap[resolvedHost] = struct{}{}
 	p.destRule[resolvedHost] = &destRuleConfig
 	p.exportTo[resolvedHost] = exportToMap
 }

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -222,6 +222,8 @@ type Gateway struct {
 type processedDestRules struct {
 	// List of dest rule hosts. We match with the most specific host first
 	hosts []host.Name
+	// Map of dest rule hosts.
+	hostsMap map[host.Name]struct{}
 	// Map of dest rule host to the list of namespaces to which this destination rule has been exported to
 	exportTo map[host.Name]map[visibility.Instance]bool
 	// Map of dest rule host and the merged destination rules for that host
@@ -758,7 +760,9 @@ func (ps *PushContext) DestinationRule(proxy *Proxy, service *Service) *config.C
 		// search through the DestinationRules in proxy's namespace first
 		if ps.destinationRuleIndex.namespaceLocal[proxy.ConfigNamespace] != nil {
 			if hostname, ok := MostSpecificHostMatch(service.Hostname,
-				ps.destinationRuleIndex.namespaceLocal[proxy.ConfigNamespace].hosts); ok {
+				ps.destinationRuleIndex.namespaceLocal[proxy.ConfigNamespace].hostsMap,
+				ps.destinationRuleIndex.namespaceLocal[proxy.ConfigNamespace].hosts,
+			); ok {
 				return ps.destinationRuleIndex.namespaceLocal[proxy.ConfigNamespace].destRule[hostname]
 			}
 		}
@@ -767,7 +771,9 @@ func (ps *PushContext) DestinationRule(proxy *Proxy, service *Service) *config.C
 		// need to worry about overriding other DRs with *.local type rules here. If we ignore this, then exportTo=. in
 		// root namespace would always be ignored
 		if hostname, ok := MostSpecificHostMatch(service.Hostname,
-			ps.destinationRuleIndex.rootNamespaceLocal.hosts); ok {
+			ps.destinationRuleIndex.rootNamespaceLocal.hostsMap,
+			ps.destinationRuleIndex.rootNamespaceLocal.hosts,
+		); ok {
 			return ps.destinationRuleIndex.rootNamespaceLocal.destRule[hostname]
 		}
 	}
@@ -806,7 +812,10 @@ func (ps *PushContext) DestinationRule(proxy *Proxy, service *Service) *config.C
 
 func (ps *PushContext) getExportedDestinationRuleFromNamespace(owningNamespace string, hostname host.Name, clientNamespace string) *config.Config {
 	if ps.destinationRuleIndex.exportedByNamespace[owningNamespace] != nil {
-		if specificHostname, ok := MostSpecificHostMatch(hostname, ps.destinationRuleIndex.exportedByNamespace[owningNamespace].hosts); ok {
+		if specificHostname, ok := MostSpecificHostMatch(hostname,
+			ps.destinationRuleIndex.exportedByNamespace[owningNamespace].hostsMap,
+			ps.destinationRuleIndex.exportedByNamespace[owningNamespace].hosts,
+		); ok {
 			// Check if the dest rule for this host is actually exported to the proxy's (client) namespace
 			exportToMap := ps.destinationRuleIndex.exportedByNamespace[owningNamespace].exportTo[specificHostname]
 			if len(exportToMap) == 0 || exportToMap[visibility.Public] || exportToMap[visibility.Instance(clientNamespace)] {
@@ -820,7 +829,11 @@ func (ps *PushContext) getExportedDestinationRuleFromNamespace(owningNamespace s
 // IsClusterLocal indicates whether the endpoints for the service should only be accessible to clients
 // within the cluster.
 func (ps *PushContext) IsClusterLocal(service *Service) bool {
-	_, ok := MostSpecificHostMatch(service.Hostname, ps.clusterLocalHosts)
+	m := make(map[host.Name]struct{}, len(ps.clusterLocalHosts))
+	for _, h := range ps.clusterLocalHosts {
+		m[h] = struct{}{}
+	}
+	_, ok := MostSpecificHostMatch(service.Hostname, m, ps.clusterLocalHosts)
 	return ok
 }
 


### PR DESCRIPTION
Use map instead of loop statement to match exactly
    - Add benchmark testcase for MostSpecificHostMatch
    - Refer the necessary judgment statements to the outside of the looping structure like needle.IsWildCarded()

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[x] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

Pull Request Attributes

Please check any characteristics that apply to this pull request.

[x] Does not have any changes that may affect Istio users.