### PR TITLE
fix(prometheus): remove k8s pod/node/service labels from collection 

### DIFF
--- a/manifests/addons/values-prometheus.yaml
+++ b/manifests/addons/values-prometheus.yaml
@@ -22,5 +22,167 @@ server:
 
   # Match legacy addon deployment
   fullnameOverride: prometheus
+serverFiles:
+  # Duplicates the helm community repo values.yaml, removing the pod labels
+  # and service labels for the pod and service jobs (to cut down on metrics
+  # cardinality and waste).
+  prometheus.yml:
+    scrape_configs:
+      - job_name: prometheus
+        static_configs:
+          - targets:
+            - localhost:9090
+      - job_name: 'kubernetes-apiservers'
+        kubernetes_sd_configs:
+          - role: endpoints
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+            action: keep
+            regex: default;kubernetes;https
+      - job_name: 'kubernetes-nodes'
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        kubernetes_sd_configs:
+          - role: node
+        relabel_configs:
+          - action: labelmap
+            regex: __meta_kubernetes_node_label_(.+)
+          - target_label: __address__
+            replacement: kubernetes.default.svc:443
+          - source_labels: [__meta_kubernetes_node_name]
+            regex: (.+)
+            target_label: __metrics_path__
+            replacement: /api/v1/nodes/$1/proxy/metrics
+      - job_name: 'kubernetes-nodes-cadvisor'
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        kubernetes_sd_configs:
+          - role: node
+        relabel_configs:
+          - action: labelmap
+            regex: __meta_kubernetes_node_label_(.+)
+          - target_label: __address__
+            replacement: kubernetes.default.svc:443
+          - source_labels: [__meta_kubernetes_node_name]
+            regex: (.+)
+            target_label: __metrics_path__
+            replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+      - job_name: 'kubernetes-service-endpoints'
+        kubernetes_sd_configs:
+          - role: endpoints
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+            action: keep
+            regex: true
+          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+            action: replace
+            target_label: __scheme__
+            regex: (https?)
+          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+            action: replace
+            target_label: __address__
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+      - job_name: 'kubernetes-service-endpoints-slow'
+        scrape_interval: 5m
+        scrape_timeout: 30s
+        kubernetes_sd_configs:
+          - role: endpoints
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape_slow]
+            action: keep
+            regex: true
+          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+            action: replace
+            target_label: __scheme__
+            regex: (https?)
+          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+            action: replace
+            target_label: __address__
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+      - job_name: 'prometheus-pushgateway'
+        honor_labels: true
+        kubernetes_sd_configs:
+          - role: service
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_probe]
+            action: keep
+            regex: pushgateway
+      - job_name: 'kubernetes-services'
+        metrics_path: /probe
+        params:
+          module: [http_2xx]
+        kubernetes_sd_configs:
+          - role: service
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_probe]
+            action: keep
+            regex: true
+          - source_labels: [__address__]
+            target_label: __param_target
+          - target_label: __address__
+            replacement: blackbox
+          - source_labels: [__param_target]
+            target_label: instance
+      - job_name: 'kubernetes-pods'
+        kubernetes_sd_configs:
+        - role: pod
+        relabel_configs:
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+          action: keep
+          regex: true
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+          action: replace
+          target_label: __metrics_path__
+          regex: (.+)
+        - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+          action: replace
+          regex: ([^:]+)(?::\d+)?;(\d+)
+          replacement: $1:$2
+          target_label: __address__
+        - source_labels: [__meta_kubernetes_pod_phase]
+          regex: Pending|Succeeded|Failed
+          action: drop
+      - job_name: 'kubernetes-pods-slow'
+        scrape_interval: 5m
+        scrape_timeout: 30s
+        kubernetes_sd_configs:
+        - role: pod
+        relabel_configs:
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape_slow]
+          action: keep
+          regex: true
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+          action: replace
+          target_label: __metrics_path__
+          regex: (.+)
+        - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+          action: replace
+          regex: ([^:]+)(?::\d+)?;(\d+)
+          replacement: $1:$2
+          target_label: __address__
+        - source_labels: [__meta_kubernetes_pod_phase]
+          regex: Pending|Succeeded|Failed
+          action: drop
 image:
   tag: v2.19.2

--- a/samples/addons/extras/prometheus-operator.yaml
+++ b/samples/addons/extras/prometheus-operator.yaml
@@ -29,12 +29,6 @@ spec:
       targetLabel: __address__
     - action: labeldrop
       regex: "__meta_kubernetes_pod_label_(.+)"
-    - sourceLabels: [__meta_kubernetes_namespace]
-      action: replace
-      targetLabel: namespace
-    - sourceLabels: [__meta_kubernetes_pod_name]
-      action: replace
-      targetLabel: pod_name
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/samples/addons/prometheus.yaml
+++ b/samples/addons/prometheus.yaml
@@ -122,20 +122,6 @@ data:
         - __address__
         - __meta_kubernetes_service_annotation_prometheus_io_port
         target_label: __address__
-      - action: labelmap
-        regex: __meta_kubernetes_service_label_(.+)
-      - action: replace
-        source_labels:
-        - __meta_kubernetes_namespace
-        target_label: kubernetes_namespace
-      - action: replace
-        source_labels:
-        - __meta_kubernetes_service_name
-        target_label: kubernetes_name
-      - action: replace
-        source_labels:
-        - __meta_kubernetes_pod_node_name
-        target_label: kubernetes_node
     - job_name: kubernetes-service-endpoints-slow
       kubernetes_sd_configs:
       - role: endpoints
@@ -161,20 +147,6 @@ data:
         - __address__
         - __meta_kubernetes_service_annotation_prometheus_io_port
         target_label: __address__
-      - action: labelmap
-        regex: __meta_kubernetes_service_label_(.+)
-      - action: replace
-        source_labels:
-        - __meta_kubernetes_namespace
-        target_label: kubernetes_namespace
-      - action: replace
-        source_labels:
-        - __meta_kubernetes_service_name
-        target_label: kubernetes_name
-      - action: replace
-        source_labels:
-        - __meta_kubernetes_pod_node_name
-        target_label: kubernetes_node
       scrape_interval: 5m
       scrape_timeout: 30s
     - honor_labels: true
@@ -206,14 +178,6 @@ data:
       - source_labels:
         - __param_target
         target_label: instance
-      - action: labelmap
-        regex: __meta_kubernetes_service_label_(.+)
-      - source_labels:
-        - __meta_kubernetes_namespace
-        target_label: kubernetes_namespace
-      - source_labels:
-        - __meta_kubernetes_service_name
-        target_label: kubernetes_name
     - job_name: kubernetes-pods
       kubernetes_sd_configs:
       - role: pod
@@ -234,16 +198,6 @@ data:
         - __address__
         - __meta_kubernetes_pod_annotation_prometheus_io_port
         target_label: __address__
-      - action: labelmap
-        regex: __meta_kubernetes_pod_label_(.+)
-      - action: replace
-        source_labels:
-        - __meta_kubernetes_namespace
-        target_label: kubernetes_namespace
-      - action: replace
-        source_labels:
-        - __meta_kubernetes_pod_name
-        target_label: kubernetes_pod_name
       - action: drop
         regex: Pending|Succeeded|Failed
         source_labels:
@@ -268,16 +222,6 @@ data:
         - __address__
         - __meta_kubernetes_pod_annotation_prometheus_io_port
         target_label: __address__
-      - action: labelmap
-        regex: __meta_kubernetes_pod_label_(.+)
-      - action: replace
-        source_labels:
-        - __meta_kubernetes_namespace
-        target_label: kubernetes_namespace
-      - action: replace
-        source_labels:
-        - __meta_kubernetes_pod_name
-        target_label: kubernetes_pod_name
       - action: drop
         regex: Pending|Succeeded|Failed
         source_labels:


### PR DESCRIPTION
This PR removes some of the "k8s" features currently configured in our sample prometheus configuration. In particular, it is meant to remove the copying of pod and node labels to each time-series, as well as the relabelings that result in labels like `kubernetes_namespace` in the metrics.

For Istio metrics, the underlying issue is repeatedly worked around in the community ([example talk](https://grafana.com/go/observabilitycon/building-observability-infrastructure-on-istio-using-prometheus-and-jaeger-at-lastpass/) - ~7:00). Kiali does not use the removed labels either. We already don't pod labels in our example operator config (https://github.com/istio/istio/blob/master/samples/addons/extras/prometheus-operator.yaml#L30-L31).

Pros:
- Reduced overall dimensionality of metrics collected by Prometheus
- Eliminates duplicative labeling

Some drawbacks:
- Removing `pod_name` label allows for potential collision when IPs are reused
- Loss of k8s information from envoy metrics

If we decide this is the right way to move forward, we should update our website docs around this as well.

Example Impact:

Before (34 labels):

```
istio_requests_total{
app="details",
connection_security_policy="mutual_tls",
destination_app="details",
destination_canonical_revision="v1",
destination_canonical_service="details",
destination_principal="spiffe://cluster.local/ns/bookinfo/sa/bookinfo-details",
destination_service="details.bookinfo.svc.cluster.local",
destination_service_name="details",
destination_service_namespace="bookinfo",
destination_version="v1",
destination_workload="details-v1",
destination_workload_namespace="bookinfo",
instance="10.76.1.6:15020",
istio_io_rev="default",
job="kubernetes-pods",
kubernetes_namespace="bookinfo",
kubernetes_pod_name="details-v1-5974b67c8-gzrkf",
pod_template_hash="5974b67c8",
reporter="destination",
request_protocol="http",
response_code="200",
response_flags="-",
security_istio_io_tlsMode="istio",
service_istio_io_canonical_name="details",
service_istio_io_canonical_revision="v1",
source_app="productpage",
source_canonical_revision="v1",
source_canonical_service="productpage",
source_principal="spiffe://cluster.local/ns/bookinfo/sa/bookinfo-productpage",
source_version="v1",
source_workload="productpage-v1",
source_workload_namespace="bookinfo",
version="v1"
}
```

After (24 labels):

```
istio_requests_total{
connection_security_policy="mutual_tls",
destination_app="details",
destination_canonical_revision="v1",
destination_canonical_service="details",
destination_principal="spiffe://cluster.local/ns/bookinfo/sa/bookinfo-details",
destination_service="details.bookinfo.svc.cluster.local",
destination_service_name="details",
destination_service_namespace="bookinfo",
destination_version="v1",
destination_workload="details-v1",
destination_workload_namespace="bookinfo",
instance="10.76.1.6:15020",
job="kubernetes-pods",
reporter="destination",
request_protocol="http",
response_code="200",
response_flags="-",
source_app="productpage",
source_canonical_revision="v1",
source_canonical_service="productpage",
source_principal="spiffe://cluster.local/ns/bookinfo/sa/bookinfo-productpage",
source_version="v1",
source_workload="productpage-v1",
source_workload_namespace="bookinfo"
}
```

After envoy metric:

```
envoy_server_uptime{instance="10.76.1.5:15020",job="kubernetes-pods"}
```

[ X ] Policies and Telemetry

/cc @jshaughn