### PR TITLE
workload entry configure command allows specifying ingress service name

### DIFF
--- a/istioctl/cmd/workload.go
+++ b/istioctl/cmd/workload.go
@@ -219,7 +219,7 @@ Configure requires either the WorkloadGroup artifact path or its location on the
 	configureCmd.PersistentFlags().StringVar(&clusterID, "clusterID", "Kubernetes", "The ID used to identify the cluster")
 	configureCmd.PersistentFlags().Int64Var(&tokenDuration, "tokenDuration", 3600, "The token duration in seconds (default: 1 hour)")
 	configureCmd.PersistentFlags().StringVar(&ingressSvc, "ingressService", multicluster.IstioEastWestGatewayServiceName, "Name of the Service to be"+
-		" used as the ingress gateway, in the format <service>.<namespace>. If no namespace is provided, the default "+ istioNamespace +" namespace will be used.")
+		" used as the ingress gateway, in the format <service>.<namespace>. If no namespace is provided, the default "+istioNamespace+" namespace will be used.")
 	configureCmd.PersistentFlags().StringVar(&ingressIP, "ingressIP", "", "IP address of the ingress gateway")
 	configureCmd.PersistentFlags().BoolVar(&autoRegister, "autoregister", false, "Creates a WorkloadEntry upon connection to istiod (if enabled in pilot).")
 	opts.AttachControlPlaneFlags(configureCmd)

--- a/istioctl/cmd/workload.go
+++ b/istioctl/cmd/workload.go
@@ -51,6 +51,7 @@ var (
 	outputDir      string
 	clusterID      string
 	ingressIP      string
+	ingressSvc     string
 	autoRegister   bool
 	ports          []string
 )
@@ -217,6 +218,8 @@ Configure requires either the WorkloadGroup artifact path or its location on the
 	configureCmd.PersistentFlags().StringVarP(&outputDir, "output", "o", "", "Output directory for generated files")
 	configureCmd.PersistentFlags().StringVar(&clusterID, "clusterID", "Kubernetes", "The ID used to identify the cluster")
 	configureCmd.PersistentFlags().Int64Var(&tokenDuration, "tokenDuration", 3600, "The token duration in seconds (default: 1 hour)")
+	configureCmd.PersistentFlags().StringVar(&ingressSvc, "ingressService", multicluster.IstioEastWestGatewayServiceName, "Name of the Service to be"+
+		" used as the ingress gateway, in the format <service>.<namespace>. If no namespace is provided, the system namespace will be used.")
 	configureCmd.PersistentFlags().StringVar(&ingressIP, "ingressIP", "", "IP address of the ingress gateway")
 	configureCmd.PersistentFlags().BoolVar(&autoRegister, "autoregister", false, "Creates a WorkloadEntry upon connection to istiod (if enabled in pilot).")
 	opts.AttachControlPlaneFlags(configureCmd)
@@ -394,7 +397,13 @@ func createMeshConfig(kubeClient kube.ExtendedClient, wg *clientv1alpha3.Workloa
 func createHosts(kubeClient kube.ExtendedClient, ingressIP, dir string) error {
 	// try to infer the ingress IP if the provided one is invalid
 	if validation.ValidateIPAddress(ingressIP) != nil {
-		ingress, err := kubeClient.CoreV1().Services(istioNamespace).Get(context.Background(), multicluster.IstioEastWestGatewayServiceName, metav1.GetOptions{})
+		p := strings.Split(ingressSvc, ".")
+		ingressNs := istioNamespace
+		if len(p) == 2 {
+			ingressSvc = p[0]
+			ingressNs = p[1]
+		}
+		ingress, err := kubeClient.CoreV1().Services(ingressNs).Get(context.Background(), ingressSvc, metav1.GetOptions{})
 		if err == nil {
 			if ingress.Status.LoadBalancer.Ingress != nil && len(ingress.Status.LoadBalancer.Ingress) > 0 {
 				ingressIP = ingress.Status.LoadBalancer.Ingress[0].IP

--- a/istioctl/cmd/workload.go
+++ b/istioctl/cmd/workload.go
@@ -219,7 +219,7 @@ Configure requires either the WorkloadGroup artifact path or its location on the
 	configureCmd.PersistentFlags().StringVar(&clusterID, "clusterID", "Kubernetes", "The ID used to identify the cluster")
 	configureCmd.PersistentFlags().Int64Var(&tokenDuration, "tokenDuration", 3600, "The token duration in seconds (default: 1 hour)")
 	configureCmd.PersistentFlags().StringVar(&ingressSvc, "ingressService", multicluster.IstioEastWestGatewayServiceName, "Name of the Service to be"+
-		" used as the ingress gateway, in the format <service>.<namespace>. If no namespace is provided, the system namespace will be used.")
+		" used as the ingress gateway, in the format <service>.<namespace>. If no namespace is provided, the default "+ istioNamespace +" namespace will be used.")
 	configureCmd.PersistentFlags().StringVar(&ingressIP, "ingressIP", "", "IP address of the ingress gateway")
 	configureCmd.PersistentFlags().BoolVar(&autoRegister, "autoregister", false, "Creates a WorkloadEntry upon connection to istiod (if enabled in pilot).")
 	opts.AttachControlPlaneFlags(configureCmd)

--- a/istioctl/pkg/multicluster/cluster.go
+++ b/istioctl/pkg/multicluster/cluster.go
@@ -182,7 +182,8 @@ func (g Gateway) String() string {
 }
 
 const (
-	IstioIngressGatewayServiceName = "istio-ingressgateway"
+	IstioIngressGatewayServiceName  = "istio-ingressgateway"
+	IstioEastWestGatewayServiceName = "istio-eastwestgateway"
 )
 
 func (c *Cluster) readIngressGateways() []*Gateway {


### PR DESCRIPTION
We're now using east-west gateway (soon to be called expansion gateway #28196) for accessing istiod from outside the cluster. The `istioctl x workload entry configure` command needs to grab the IP from this instead of the ingressgateway. 