### PR TITLE
autoregister flag for workload entry command

### DIFF
--- a/istioctl/cmd/workload.go
+++ b/istioctl/cmd/workload.go
@@ -51,6 +51,7 @@ var (
 	outputDir      string
 	clusterID      string
 	ingressIP      string
+	autoRegister   bool
 	ports          []string
 )
 
@@ -217,6 +218,7 @@ Configure requires either the WorkloadGroup artifact path or its location on the
 	configureCmd.PersistentFlags().StringVar(&clusterID, "clusterID", "Kubernetes", "The ID used to identify the cluster")
 	configureCmd.PersistentFlags().Int64Var(&tokenDuration, "tokenDuration", 3600, "The token duration in seconds (default: 1 hour)")
 	configureCmd.PersistentFlags().StringVar(&ingressIP, "ingressIP", "", "IP address of the ingress gateway")
+	configureCmd.PersistentFlags().BoolVar(&autoRegister, "autoregister", false, "If set, a WorkloadEntry will be created upon connection to istiod (if enabled in pilot).")
 	opts.AttachControlPlaneFlags(configureCmd)
 	return configureCmd
 }
@@ -375,6 +377,10 @@ func createMeshConfig(kubeClient kube.ExtendedClient, wg *clientv1alpha3.Workloa
 	labels["service.istio.io/canonical-version"] = md["CANONICAL_REVISION"]
 	if labelsJSON, err := json.Marshal(labels); err == nil {
 		md["ISTIO_METAJSON_LABELS"] = string(labelsJSON)
+	}
+
+	if autoRegister {
+		md["ISTIO_META_AUTO_REGISTER_GROUP"] = wg.Name
 	}
 
 	proxyYAML, err := gogoprotomarshal.ToYAML(meshConfig.DefaultConfig)

--- a/istioctl/cmd/workload.go
+++ b/istioctl/cmd/workload.go
@@ -218,7 +218,7 @@ Configure requires either the WorkloadGroup artifact path or its location on the
 	configureCmd.PersistentFlags().StringVar(&clusterID, "clusterID", "Kubernetes", "The ID used to identify the cluster")
 	configureCmd.PersistentFlags().Int64Var(&tokenDuration, "tokenDuration", 3600, "The token duration in seconds (default: 1 hour)")
 	configureCmd.PersistentFlags().StringVar(&ingressIP, "ingressIP", "", "IP address of the ingress gateway")
-	configureCmd.PersistentFlags().BoolVar(&autoRegister, "autoregister", false, "If set, a WorkloadEntry will be created upon connection to istiod (if enabled in pilot).")
+	configureCmd.PersistentFlags().BoolVar(&autoRegister, "autoregister", false, "Creates a WorkloadEntry upon connection to istiod (if enabled in pilot).")
 	opts.AttachControlPlaneFlags(configureCmd)
 	return configureCmd
 }

--- a/pkg/test/framework/components/echo/config.go
+++ b/pkg/test/framework/components/echo/config.go
@@ -80,7 +80,7 @@ type Config struct {
 	// disable sidecar injection, etc.
 	DeployAsVM bool
 
-	// If enabled, ISTIO_META_AUTO_REGISTER will be set on the VM and the WorkloadEntry will be created automatically.
+	// If enabled, ISTIO_META_AUTO_REGISTER_GROUP will be set on the VM and the WorkloadEntry will be created automatically.
 	AutoRegisterVM bool
 
 	// The image name to be used to pull the image for the VM. `DeployAsVM` must be enabled.

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -409,6 +409,7 @@ func generateYAMLWithSettings(
 
 	var vmImage, istiodIP, istiodPort string
 	if cfg.DeployAsVM {
+		// TODO if possible, use istioctl x workload ... to configure the VM
 		ist, err := istio.Get(ctx)
 		if err != nil {
 			return "", "", err


### PR DESCRIPTION
Allows using the `istioctl x workload entry configure` command to generate config that's ready-to-go for autoregistration. 