### PR TITLE
Disable strict_1xx_and_204_reponse_headers in envoy bootstrap config

### DIFF
--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -12,6 +12,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
+                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -12,6 +12,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
+                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },

--- a/pkg/bootstrap/testdata/authsds_golden.json
+++ b/pkg/bootstrap/testdata/authsds_golden.json
@@ -12,6 +12,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
+                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -12,6 +12,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
+                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -17,6 +17,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
+                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },

--- a/pkg/bootstrap/testdata/runningsds_golden.json
+++ b/pkg/bootstrap/testdata/runningsds_golden.json
@@ -17,6 +17,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
+                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -12,6 +12,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
+                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -12,6 +12,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
+                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -12,6 +12,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
+                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },

--- a/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
+++ b/pkg/bootstrap/testdata/tracing_opencensusagent_golden.json
@@ -12,6 +12,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
+                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },

--- a/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
+++ b/pkg/bootstrap/testdata/tracing_stackdriver_golden.json
@@ -12,6 +12,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
+                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },

--- a/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_custom_sni_golden.json
@@ -12,6 +12,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
+                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },

--- a/pkg/bootstrap/testdata/tracing_tls_golden.json
+++ b/pkg/bootstrap/testdata/tracing_tls_golden.json
@@ -12,6 +12,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
+                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -12,6 +12,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
+                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },

--- a/pkg/bootstrap/testdata/xdsproxy_golden.json
+++ b/pkg/bootstrap/testdata/xdsproxy_golden.json
@@ -12,6 +12,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
+                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },
@@ -249,9 +250,11 @@
       "transport_api_version": "V3",
       "grpc_services": [
         {
+        
           "envoy_grpc": {
             "cluster_name": "xds-grpc"
           }
+        
         }
       ]
     }
@@ -322,8 +325,8 @@
             }]
           }]
         }
-      },
-      {
+      } 
+       , {
         "name": "xds-grpc",
         "type" : "STATIC",
         "connect_timeout": "1s",
@@ -366,6 +369,7 @@
         "max_requests_per_connection": 1,
         "http2_protocol_options": { }
       }
+      
       
       
     ],

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -27,6 +27,7 @@
               "name": "deprecation",
               "static_layer": {
                   "envoy.deprecated_features:envoy.config.listener.v3.Listener.hidden_envoy_deprecated_use_original_dst": true,
+                  "envoy.reloadable_features.strict_1xx_and_204_response_headers": false,
                   "re2.max_program_size.error_level": 1024
               }
           },


### PR DESCRIPTION
Addresses #28433. In short, this change is needed to keep certain requests from 1.7 proxies -> 1.6 proxies from 503ing.

Having the `strict_1xx_and_204_response_headers` envoy config enabled (default-on) makes it so that proxies will reject http responses having code 1xx/204 and having the "Transfer-Encoding" header present. Our proxies <=v.1.6.x will send such responses by default (this [envoy change](https://github.com/envoyproxy/envoy/pull/11458) was just merged ~5mos ago), resulting in our 1.7 proxies 503ing in those cases.

My main concern here (and I have been able to confirm this) is that this will introduce the same compatibility issue between 1.7 proxies that have this feature enabled -> 1.7 proxies that don't (since from the relevant Envoy PR, disabling the `strict_..._response_headers` flag both allows requests received with 204 + Transfer Encoding header to succeed _and_ causes the envoy instances _sending_ those responses to continue sending 204 responses with Transfer Encoding set). 

So due to this issue, from what I can tell, 1.8 proxies will either also have to have this disabled to avoid issues or we'll have to enable the config on 1.7 proxies at that point.

cc @howardjohn @lambdai 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
