### PR TITLE
Display schema validation warnings in istioctl analyze

### DIFF
--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -42,7 +42,7 @@ var (
 	SchemaValidationError = diag.NewMessageType(diag.Error, "IST0106", "Schema validation error: %v")
 
 	// SchemaWarning defines a diag.MessageType for message "SchemaWarning".
-	// Description: The resource has a schema validation waring.
+	// Description: The resource has a schema validation warning.
 	SchemaWarning = diag.NewMessageType(diag.Warning, "IST0132", "Schema validation warning: %v")
 
 	// MisplacedAnnotation defines a diag.MessageType for message "MisplacedAnnotation".

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -41,6 +41,10 @@ var (
 	// Description: The resource has a schema validation error.
 	SchemaValidationError = diag.NewMessageType(diag.Error, "IST0106", "Schema validation error: %v")
 
+	// SchemaWarning defines a diag.MessageType for message "SchemaWarning".
+	// Description: The resource has a schema validation waring.
+	SchemaWarning = diag.NewMessageType(diag.Warning, "IST0132", "Schema validation warning: %v")
+
 	// MisplacedAnnotation defines a diag.MessageType for message "MisplacedAnnotation".
 	// Description: An Istio annotation is applied to the wrong kind of resource.
 	MisplacedAnnotation = diag.NewMessageType(diag.Warning, "IST0107", "Misplaced annotation: %s can only be applied to %s")
@@ -153,6 +157,7 @@ func All() []*diag.MessageType {
 		GatewayPortNotOnWorkload,
 		IstioProxyImageMismatch,
 		SchemaValidationError,
+		SchemaWarning,
 		MisplacedAnnotation,
 		UnknownAnnotation,
 		ConflictingMeshGatewayVirtualServiceHosts,
@@ -251,6 +256,15 @@ func NewIstioProxyImageMismatch(r *resource.Instance, proxyImage string, injecti
 func NewSchemaValidationError(r *resource.Instance, err error) diag.Message {
 	return diag.NewMessage(
 		SchemaValidationError,
+		r,
+		err,
+	)
+}
+
+// NewSchemaWarning returns a new diag.Message based on SchemaWarning.
+func NewSchemaWarning(r *resource.Instance, err error) diag.Message {
+	return diag.NewMessage(
+		SchemaWarning,
 		r,
 		err,
 	)

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -43,7 +43,7 @@ var (
 
 	// SchemaWarning defines a diag.MessageType for message "SchemaWarning".
 	// Description: The resource has a schema validation warning.
-	SchemaWarning = diag.NewMessageType(diag.Warning, "IST0132", "Schema validation warning: %v")
+	SchemaWarning = diag.NewMessageType(diag.Warning, "IST0133", "Schema validation warning: %v")
 
 	// MisplacedAnnotation defines a diag.MessageType for message "MisplacedAnnotation".
 	// Description: An Istio annotation is applied to the wrong kind of resource.

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -80,7 +80,7 @@ messages:
         type: error
 
   - name: "SchemaWarning"
-    code: IST0132
+    code: IST0133
     level: Warning
     description: "The resource has a schema validation warning."
     template: "Schema validation warning: %v"

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -79,6 +79,15 @@ messages:
       - name: err
         type: error
 
+  - name: "SchemaWarning"
+    code: IST0132
+    level: Warning
+    description: "The resource has a schema validation waring."
+    template: "Schema validation warning: %v"
+    args:
+      - name: err
+        type: error
+
   - name: "MisplacedAnnotation"
     code: IST0107
     level: Warning

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -82,7 +82,7 @@ messages:
   - name: "SchemaWarning"
     code: IST0132
     level: Warning
-    description: "The resource has a schema validation waring."
+    description: "The resource has a schema validation warning."
     template: "Schema validation warning: %v"
     args:
       - name: err


### PR DESCRIPTION
Example:
```
$ grun ./istioctl/cmd/istioctl analyze /tmp/dr.yaml --use-kube=false -A
Error [IST0106] (DestinationRule reviews-cb-policy /tmp/dr.yaml:1) Schema validation error: duration must be greater than 1ms
Warning [IST0132] (DestinationRule reviews-cb-policy /tmp/dr.yaml:1) Schema validation warning: outlier detection consecutive errors is deprecated, use consecutiveGatewayErrors or consecutive5xxErrors instead
Error: Analyzers found issues when analyzing all namespaces.
See https://istio.io/v1.9/docs/reference/config/analysis for more information about causes and resolutions.
```

For https://github.com/istio/istio/issues/27179

Open question: what do we want to do about current single-resource validation messages, such as InvalidRegexp. We want to add them to the standard warnings so they show up everywhere (namely webhooks). Should we deprecate the explicit messages when we add them to the standard warnings? How do we deprecate a message?