### PR TITLE
istioctl bug-report: skip further scanning if istio is not installed in any namespace

### DIFF
--- a/tools/bug-report/pkg/bugreport/bugreport.go
+++ b/tools/bug-report/pkg/bugreport/bugreport.go
@@ -109,15 +109,6 @@ func runBugReportCommand(_ *cobra.Command, logOpts *log.Options) error {
 	if err != nil {
 		return err
 	}
-
-	clusterCtxStr, err := content.GetClusterContext()
-	if err != nil {
-		return err
-	}
-
-	common.LogAndPrintf("\nTarget cluster context: %s\n", clusterCtxStr)
-	common.LogAndPrintf("Running with the following config: \n\n%s\n\n", config)
-
 	clientConfig, clientset, err := kubeclient.New(config.KubeConfigPath, config.Context)
 	if err != nil {
 		return fmt.Errorf("could not initialize k8s client: %s ", err)
@@ -126,6 +117,19 @@ func runBugReportCommand(_ *cobra.Command, logOpts *log.Options) error {
 	if err != nil {
 		return err
 	}
+	// Do not proceed if Istio is not installed in any namespace.
+	if _, err = client.GetIstioVersions(context.Background(), config.IstioNamespace); err != nil {
+		common.LogAndPrintf("%v\n", err)
+		return nil
+	}
+	clusterCtxStr, err := content.GetClusterContext()
+	if err != nil {
+		return err
+	}
+
+	common.LogAndPrintf("\nTarget cluster context: %s\n", clusterCtxStr)
+	common.LogAndPrintf("Running with the following config: \n\n%s\n\n", config)
+
 	resources, err := cluster2.GetClusterResources(context.Background(), clientset)
 	if err != nil {
 		return err


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/28401

Before:
```
$ istioctl bug-report

Target cluster context: kind-istio-testing

Running with the following config: 

istio-namespace: istio-system
full-secrets: false
timeout (mins): 30
include: {  }
exclude: { Namespaces: kube-system, kube-public, kube-node-lease, local-path-storage }
end-time: 2020-10-29 19:15:14.8697752 +0530 IST

The following Istio control plane revisions/versions were found in the cluster:
The following proxy revisions/versions were found in the cluster:

Fetching proxy logs for the following containers:
Fetching Istio control plane information from cluster.

Creating an archive at /home/shaansar/Projects/src/istio.io/istio/bug-report.tgz.
Cleaning up temporary files in /tmp/bug-report.
Done.
```



After:

Check-in default namespace. 
```
$ istioctl bug-report
no running Istio pods in "istio-system"
```

Check-in another namespace. 
```
$ istioctl bug-report --istio-namespace=redhat
no running Istio pods in "redhat"
```

```
$ istioctl install

$ istioctl bug-report
Target cluster context: kind-istio-testing
Running with the following config: 

istio-namespace: istio-system
full-secrets: false
timeout (mins): 30

Fetching proxy logs for the following containers:

istio-system/istio-ingressgateway/istio-ingressgateway-547cfbdf4b-5wgns/istio-proxy
istio-system/istiod-1-9-0/istiod-1-9-0-fd59b7bf8-mdkvl/discovery

Fetching Istio control plane information from cluster.

Running istio analyze on namespace istio-system.

Creating an archive at /home/shaansar/Projects/src/istio.io/istio/bug-report.tgz.
Cleaning up temporary files in /tmp/bug-report.
Done.
```