### PR TITLE
prow: overwrite existing node annotations

### DIFF
--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -109,7 +109,7 @@ function setup_kind_registry() {
     # TODO get context/config from existing variables
     kind export kubeconfig --name="${cluster}"
     for node in $(kind get nodes --name="${cluster}"); do
-      kubectl annotate node "${node}" "kind.x-k8s.io/registry=localhost:${KIND_REGISTRY_PORT}";
+      kubectl annotate node "${node}" "kind.x-k8s.io/registry=localhost:${KIND_REGISTRY_PORT}" --overwrite;
     done
   done
 }


### PR DESCRIPTION
If we don't do this, calling the prow script might fail if we have clusters that persist throughout multiple runs. This happened to me while running tests locally, as I had a few other active kind clusters:


```
+ for cluster in $(kind get clusters)
+ kind export kubeconfig --name=primary
Set kubectl context to "kind-primary"
++ kind get nodes --name=primary
+ for node in $(kind get nodes --name="${cluster}")
+ kubectl annotate node primary-control-plane kind.x-k8s.io/registry=localhost:5000
error: --overwrite is false but found the following declared annotation(s): 'kind.x-k8s.io/registry' already has a value (localhost:5000)

```


You only hit this on the second run, as all nodes of the non-istio clusters have then already been annotated

[x] Test and Release
[x] Developer Infrastructure
[x] Does not have any changes that may affect Istio users.
