### PR TITLE
add analyzer for incompatible host between VirtualService and Gateway

### DIFF
--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -417,11 +417,11 @@ var testGrid = []testCase{
 	{
 		name: "host defined in virtualservice not found in the gateway",
 		inputFiles: []string{
-			"testdata/virtualservice_host_not_defined_gateway.yaml",
+			"testdata/virtualservice_host_not_found_gateway.yaml",
 		},
 		analyzer: &virtualservice.GatewayAnalyzer{},
 		expected: []message{
-			{msg.VirtualServiceHostNotFoundInGateway, "VirtualService ratings-fake-service"},
+			{msg.VirtualServiceHostNotFoundInGateway, "VirtualService ratings-wrong-host-service.default"},
 		},
 	},
 }

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -425,7 +425,9 @@ var testGrid = []testCase{
 		},
 		analyzer: &virtualservice.GatewayAnalyzer{},
 		expected: []message{
-			{msg.VirtualServiceHostNotFoundInGateway, "VirtualService ratings-wrong-host-service.default"},
+			{msg.VirtualServiceHostNotFoundInGateway, "VirtualService testing-service-02-test-01.default"},
+			{msg.VirtualServiceHostNotFoundInGateway, "VirtualService testing-service-02-test-02.default"},
+			{msg.VirtualServiceHostNotFoundInGateway, "VirtualService testing-service-02-test-03.default"},
 		},
 	},
 }

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -428,6 +428,7 @@ var testGrid = []testCase{
 			{msg.VirtualServiceHostNotFoundInGateway, "VirtualService testing-service-02-test-01.default"},
 			{msg.VirtualServiceHostNotFoundInGateway, "VirtualService testing-service-02-test-02.default"},
 			{msg.VirtualServiceHostNotFoundInGateway, "VirtualService testing-service-02-test-03.default"},
+			{msg.VirtualServiceHostNotFoundInGateway, "VirtualService testing-service-03-test-04.default"},
 		},
 	},
 }

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -264,6 +264,10 @@ var testGrid = []testCase{
 		analyzer:   &virtualservice.GatewayAnalyzer{},
 		expected: []message{
 			{msg.ReferencedResourceNotFound, "VirtualService httpbin-bogus"},
+
+			{msg.VirtualServiceHostNotFoundInGateway, "VirtualService cross-test.default"},
+			{msg.VirtualServiceHostNotFoundInGateway, "VirtualService httpbin-bogus"},
+			{msg.VirtualServiceHostNotFoundInGateway, "VirtualService httpbin"},
 		},
 	},
 	{

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -415,7 +415,7 @@ var testGrid = []testCase{
 		},
 	},
 	{
-		name: "host defined in virtualservice not defined in the gateway",
+		name: "host defined in virtualservice not found in the gateway",
 		inputFiles: []string{
 			"testdata/virtualservice_host_not_defined_gateway.yaml",
 		},

--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -414,6 +414,16 @@ var testGrid = []testCase{
 			{msg.VirtualServiceIneffectiveMatch, "VirtualService tls-routing.none"},
 		},
 	},
+	{
+		name: "host defined in virtualservice not defined in the gateway",
+		inputFiles: []string{
+			"testdata/virtualservice_host_not_defined_gateway.yaml",
+		},
+		analyzer: &virtualservice.GatewayAnalyzer{},
+		expected: []message{
+			{msg.VirtualServiceHostNotFoundInGateway, "VirtualService ratings-fake-service"},
+		},
+	},
 }
 
 // regex patterns for analyzer names that should be explicitly ignored for testing

--- a/galley/pkg/config/analysis/analyzers/testdata/virtualservice_host_not_defined_gateway.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/virtualservice_host_not_defined_gateway.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: gw
+  namespace: istio-system
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - hosts:
+    - foo.com
+    port:
+      name: http
+      number: 80
+      protocol: HTTP
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: ratings-service
+  namespace: default
+spec:
+  gateways:
+  - istio-system/gw
+  hosts:
+  - foo.com # Expected: no validation error since this host exists
+  http:
+  - match:
+    - uri:
+        prefix: /
+  - route:
+    - destination:
+        host: ratings
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: ratings-fake-service
+  namespace: default
+spec:
+  gateways:
+  - istio-system/gw
+  hosts:
+  - bar.com # Expected: validation error since this host does not exist
+  http:
+  - match:
+    - uri:
+        prefix: /
+  - route:
+    - destination:
+        host: ratings

--- a/galley/pkg/config/analysis/analyzers/testdata/virtualservice_host_not_found_gateway.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/virtualservice_host_not_found_gateway.yaml
@@ -2,14 +2,14 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
-  name: gw
+  name: testing-gateway-01-test-01
   namespace: istio-system
 spec:
   selector:
     istio: ingressgateway
   servers:
   - hosts:
-    - foo.com
+    - testing-01.com
     port:
       name: http
       number: 80
@@ -18,35 +18,158 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: ratings-service
+  name: testing-service-01-test-01
   namespace: default
 spec:
   gateways:
-  - istio-system/gw
+  - istio-system/testing-gateway-01-test-01
   hosts:
-  - foo.com # Expected: no validation error since this host exists
+  - testing-01.com # Expected: no validation error since this host exists
   http:
   - match:
     - uri:
         prefix: /
-  - route:
+    route:
     - destination:
         host: ratings
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: ratings-wrong-host-service
+  name: testing-service-02-test-01
   namespace: default
 spec:
   gateways:
-  - istio-system/gw
+  - istio-system/testing-gateway-01-test-01
   hosts:
-  - bar.com # Expected: validation error since this host does not exist
+  - wrong-01.com # Expected: validation error since this host does not exist
   http:
   - match:
     - uri:
         prefix: /
-  - route:
+    route:
+    - destination:
+        host: ratings
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: testing-gateway-01-test-02
+  namespace: istio-system
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - hosts:
+    - '*.testing-02.com'
+    port:
+      name: http
+      number: 80
+      protocol: HTTP
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: testing-service-01-test-02
+  namespace: default
+spec:
+  gateways:
+  - istio-system/testing-gateway-01-test-02
+  hosts:
+  - 'web.testing-02.com' # Expected: no validation error since this host match the wildcard
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: ratings
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: testing-service-02-test-02
+  namespace: default
+spec:
+  gateways:
+  - istio-system/testing-gateway-01-test-02
+  hosts:
+  - 'web.wrong.com' # Expected: validation error since this host does not exist
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: ratings
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: testing-gateway-01-test-03
+  namespace: istio-system
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - hosts:
+    - '*.api.testing-03.com'
+    port:
+      name: http
+      number: 80
+      protocol: HTTP
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: testing-gateway-02-test-03
+  namespace: istio-system
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - hosts:
+    - '*.homepage.testing-03.com'
+    port:
+      name: http
+      number: 80
+      protocol: HTTP
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: testing-service-01-test-03
+  namespace: default
+spec:
+  gateways:
+  - istio-system/testing-gateway-01-test-03
+  - istio-system/testing-gateway-02-test-03
+  hosts:
+  - 'user.api.testing-03.com'
+  - 'profile.homepage.testing-03.com' # Expected: no validation error since this host match the wildcard
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: ratings
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: testing-service-02-test-03
+  namespace: default
+spec:
+  gateways:
+  - istio-system/testing-gateway-01-test-03
+  - istio-system/testing-gateway-02-test-03
+  hosts:
+  - 'user.api.testing-03.com' # Expected: validation error since this host does not exist
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
     - destination:
         host: ratings

--- a/galley/pkg/config/analysis/analyzers/testdata/virtualservice_host_not_found_gateway.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/virtualservice_host_not_found_gateway.yaml
@@ -173,3 +173,80 @@ spec:
     route:
     - destination:
         host: ratings
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: testing-gateway-01-test-04
+  namespace: istio-system
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - hosts:
+    - '*.testing-01-04.com'
+    port:
+      name: http
+      number: 80
+      protocol: HTTP
+  - hosts:
+    - 'web.testing-02-04.com'
+    port:
+      name: http
+      number: 80
+      protocol: HTTP
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: testing-service-01-test-04
+  namespace: default
+spec:
+  gateways:
+  - istio-system/testing-gateway-01-test-04
+  hosts:
+  - 'web.testing-02-04.com' # Expected: no validation error since this host exists
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: ratings
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: testing-service-02-test-04
+  namespace: default
+spec:
+  gateways:
+  - istio-system/testing-gateway-01-test-04
+  hosts:
+  - 'profile.user.testing-01-04.com' # Expected: no validation error since this host match the wildcard
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: ratings
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: testing-service-03-test-04
+  namespace: default
+spec:
+  gateways:
+  - istio-system/testing-gateway-01-test-04
+  hosts:
+  - 'user.testing-02-04.com'
+  - 'users.testing-02-04.com' # Expected: validation error since this host does not exist
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: ratings

--- a/galley/pkg/config/analysis/analyzers/testdata/virtualservice_host_not_found_gateway.yaml
+++ b/galley/pkg/config/analysis/analyzers/testdata/virtualservice_host_not_found_gateway.yaml
@@ -36,7 +36,7 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: ratings-fake-service
+  name: ratings-wrong-host-service
   namespace: default
 spec:
   gateways:

--- a/galley/pkg/config/analysis/analyzers/virtualservice/gateways.go
+++ b/galley/pkg/config/analysis/analyzers/virtualservice/gateways.go
@@ -102,12 +102,12 @@ func vsHostInGateway(c analysis.Context, gateway resource.FullName, vsHost []str
 	})
 
 	for _, gh := range gatewayHost {
-		if gh == "*" {
+		if gh == util.Wildcard {
 			return true
 		}
 
 		for _, vsh := range vsHost {
-			if gh == vsh {
+			if vsh == util.Wildcard || vsh == gh {
 				return true
 			}
 		}

--- a/galley/pkg/config/analysis/analyzers/virtualservice/gateways.go
+++ b/galley/pkg/config/analysis/analyzers/virtualservice/gateways.go
@@ -53,8 +53,9 @@ func (s *GatewayAnalyzer) Analyze(c analysis.Context) {
 
 func (s *GatewayAnalyzer) analyzeVirtualService(r *resource.Instance, c analysis.Context) {
 	vs := r.Message.(*v1alpha3.VirtualService)
-
 	vsNs := r.Metadata.FullName.Namespace
+	vsName := r.Metadata.FullName
+
 	for i, gwName := range vs.Gateways {
 		// This is a special-case accepted value
 		if gwName == util.MeshGateway {
@@ -74,7 +75,7 @@ func (s *GatewayAnalyzer) analyzeVirtualService(r *resource.Instance, c analysis
 		}
 
 		if !vsHostInGateway(c, gwFullName, vs.Hosts) {
-			m := msg.NewVirtualServiceHostNotFoundInGateway(r, gwName)
+			m := msg.NewVirtualServiceHostNotFoundInGateway(r, vs.Hosts, vsName.String(), gwFullName.String())
 
 			if line, ok := util.ErrorLine(r, fmt.Sprintf(util.VSGateway, i)); ok {
 				m.Line = line

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -139,7 +139,7 @@ var (
 
 	// VirtualServiceHostNotFoundInGateway defines a diag.MessageType for message "VirtualServiceHostNotFoundInGateway".
 	// Description: Host defined in VirtualService not found in Gateway object.
-	VirtualServiceHostNotFoundInGateway = diag.NewMessageType(diag.Error, "IST0132", "one or more host %v defined in VirtualService %s not found in Gateway %s.")
+	VirtualServiceHostNotFoundInGateway = diag.NewMessageType(diag.Warning, "IST0132", "one or more host %v defined in VirtualService %s not found in Gateway %s.")
 )
 
 // All returns a list of all known message types.

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -138,7 +138,7 @@ var (
 	VirtualServiceIneffectiveMatch = diag.NewMessageType(diag.Info, "IST0131", "VirtualService rule %v match %v is not used (duplicates a match in rule %v).")
 
 	// VirtualServiceHostNotFoundInGateway defines a diag.MessageType for message "VirtualServiceHostNotFoundInGateway".
-	// Description: Host defined in VirtualService not found in Gateway object.
+	// Description: Host defined in VirtualService not found in Gateway.
 	VirtualServiceHostNotFoundInGateway = diag.NewMessageType(diag.Warning, "IST0132", "one or more host %v defined in VirtualService %s not found in Gateway %s.")
 )
 

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -136,6 +136,10 @@ var (
 	// VirtualServiceIneffectiveMatch defines a diag.MessageType for message "VirtualServiceIneffectiveMatch".
 	// Description: A VirtualService rule match duplicates a match in a previous rule.
 	VirtualServiceIneffectiveMatch = diag.NewMessageType(diag.Info, "IST0131", "VirtualService rule %v match %v is not used (duplicates a match in rule %v).")
+
+	// VirtualServiceHostNotFoundInGateway defines a diag.MessageType for message "VirtualServiceHostNotFoundInGateway".
+	// Description: Host defined in VirtualService not found in Gateway object.
+	VirtualServiceHostNotFoundInGateway = diag.NewMessageType(diag.Error, "IST0132", "Host defined in VirtualService not defined in Gateway %s.")
 )
 
 // All returns a list of all known message types.
@@ -173,6 +177,7 @@ func All() []*diag.MessageType {
 		NoServerCertificateVerificationPortLevel,
 		VirtualServiceUnreachableRule,
 		VirtualServiceIneffectiveMatch,
+		VirtualServiceHostNotFoundInGateway,
 	}
 }
 
@@ -495,5 +500,14 @@ func NewVirtualServiceIneffectiveMatch(r *resource.Instance, ruleno string, matc
 		ruleno,
 		matchno,
 		dupno,
+	)
+}
+
+// NewVirtualServiceHostNotFoundInGateway returns a new diag.Message based on VirtualServiceHostNotFoundInGateway.
+func NewVirtualServiceHostNotFoundInGateway(r *resource.Instance, gateway string) diag.Message {
+	return diag.NewMessage(
+		VirtualServiceHostNotFoundInGateway,
+		r,
+		gateway,
 	)
 }

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -139,7 +139,7 @@ var (
 
 	// VirtualServiceHostNotFoundInGateway defines a diag.MessageType for message "VirtualServiceHostNotFoundInGateway".
 	// Description: Host defined in VirtualService not found in Gateway object.
-	VirtualServiceHostNotFoundInGateway = diag.NewMessageType(diag.Error, "IST0132", "one or more host %v defined in VirtualService %s not defined in Gateway %s.")
+	VirtualServiceHostNotFoundInGateway = diag.NewMessageType(diag.Error, "IST0132", "one or more host %v defined in VirtualService %s not found in Gateway %s.")
 )
 
 // All returns a list of all known message types.

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -139,7 +139,7 @@ var (
 
 	// VirtualServiceHostNotFoundInGateway defines a diag.MessageType for message "VirtualServiceHostNotFoundInGateway".
 	// Description: Host defined in VirtualService not found in Gateway object.
-	VirtualServiceHostNotFoundInGateway = diag.NewMessageType(diag.Error, "IST0132", "Host defined in VirtualService not defined in Gateway %s.")
+	VirtualServiceHostNotFoundInGateway = diag.NewMessageType(diag.Error, "IST0132", "one or more host %v defined in VirtualService %s not defined in Gateway %s.")
 )
 
 // All returns a list of all known message types.
@@ -504,10 +504,12 @@ func NewVirtualServiceIneffectiveMatch(r *resource.Instance, ruleno string, matc
 }
 
 // NewVirtualServiceHostNotFoundInGateway returns a new diag.Message based on VirtualServiceHostNotFoundInGateway.
-func NewVirtualServiceHostNotFoundInGateway(r *resource.Instance, gateway string) diag.Message {
+func NewVirtualServiceHostNotFoundInGateway(r *resource.Instance, host []string, virtualservice string, gateway string) diag.Message {
 	return diag.NewMessage(
 		VirtualServiceHostNotFoundInGateway,
 		r,
+		host,
+		virtualservice,
 		gateway,
 	)
 }

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -358,7 +358,7 @@ messages:
     code: IST0132
     level: Error
     description: "Host defined in VirtualService not found in Gateway object."
-    template: "one or more host %v defined in VirtualService %s not defined in Gateway %s."
+    template: "one or more host %v defined in VirtualService %s not found in Gateway %s."
     args:
       - name: host
         type: "[]string"

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -353,3 +353,12 @@ messages:
         type: string
       - name: dupno
         type: string
+
+  - name: "VirtualServiceHostNotFoundInGateway"
+    code: IST0132
+    level: Error
+    description: "Host defined in VirtualService not found in Gateway object."
+    template: "Host defined in VirtualService not defined in Gateway %s."
+    args:
+      - name: gateway
+        type: string

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -358,7 +358,11 @@ messages:
     code: IST0132
     level: Error
     description: "Host defined in VirtualService not found in Gateway object."
-    template: "Host defined in VirtualService not defined in Gateway %s."
+    template: "one or more host %v defined in VirtualService %s not defined in Gateway %s."
     args:
+      - name: host
+        type: "[]string"
+      - name: virtualservice
+        type: string
       - name: gateway
         type: string

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -356,7 +356,7 @@ messages:
 
   - name: "VirtualServiceHostNotFoundInGateway"
     code: IST0132
-    level: Error
+    level: Warning
     description: "Host defined in VirtualService not found in Gateway object."
     template: "one or more host %v defined in VirtualService %s not found in Gateway %s."
     args:

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -357,7 +357,7 @@ messages:
   - name: "VirtualServiceHostNotFoundInGateway"
     code: IST0132
     level: Warning
-    description: "Host defined in VirtualService not found in Gateway object."
+    description: "Host defined in VirtualService not found in Gateway."
     template: "one or more host %v defined in VirtualService %s not found in Gateway %s."
     args:
       - name: host


### PR DESCRIPTION
This PR adding analyzer in `istioctl analyze` to check incompatible host between VirtualService and Gateway.

Issue: https://github.com/istio/istio/issues/28172

data:
```
apiVersion: networking.istio.io/v1alpha3
kind: Gateway
metadata:
  name: gw
  namespace: istio-system
spec:
  selector:
    istio: ingressgateway
  servers:
  - hosts:
    - foo.com
    port:
      name: http
      number: 80
      protocol: HTTP
---
apiVersion: networking.istio.io/v1alpha3
kind: VirtualService
metadata:
  name: service
spec:
  gateways:
  - istio-system/gw
  hosts:
  - bar.com
  http:
  - match:
    - uri:
        prefix: /
    route:
      - destination:
          host: helloworld
```
result:
```
istio $ ./out/linux_amd64/istioctl analyze --use-kube=false testing.yaml -n default                                                 master*
Error [IST0132] (VirtualService service.default testing.yaml:24) Host defined in VirtualService not defined in Gateway istio-system/gw.
Error: Analyzers found issues when analyzing namespace: default.
```

[x] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
