### PR TITLE
Fully flag protect service-apis

### DIFF
--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -133,9 +133,13 @@ func (cl *Client) HasSynced() bool {
 }
 
 func New(client kube.Client, revision string, options controller2.Options) (model.ConfigStoreCache, error) {
+	schemas := collections.Pilot
+	if features.EnableServiceApis {
+		schemas = collections.PilotServiceApi
+	}
 	out := &Client{
 		domainSuffix:      options.DomainSuffix,
-		schemas:           collections.PilotServiceApi,
+		schemas:           schemas,
 		revision:          revision,
 		queue:             queue.NewQueue(1 * time.Second),
 		kinds:             map[config.GroupVersionKind]*cacheHandler{},

--- a/pilot/pkg/config/kube/crdclient/client_test.go
+++ b/pilot/pkg/config/kube/crdclient/client_test.go
@@ -27,6 +27,7 @@ import (
 
 	"istio.io/api/meta/v1alpha1"
 	"istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 	"istio.io/istio/pkg/config"
@@ -37,6 +38,7 @@ import (
 )
 
 func makeClient(t *testing.T, schemas collection.Schemas) model.ConfigStoreCache {
+	features.EnableServiceApis = true
 	fake := kube.NewFakeClient()
 	for _, s := range schemas.All() {
 		fake.Ext().ApiextensionsV1beta1().CustomResourceDefinitions().Create(context.TODO(), &v1beta1.CustomResourceDefinition{


### PR DESCRIPTION
It doesn't make sense to read the CRDs if we are already disabling the
controller if the flag is not enabled



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.