### PR TITLE
Sidecar.Egress: provide default and allow unset

### DIFF
--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -249,7 +249,12 @@ func ConvertToSidecarScope(ps *PushContext, sidecarConfig *config.Config, config
 	}
 
 	out.EgressListeners = make([]*IstioEgressListenerWrapper, 0)
-	for _, e := range sidecar.Egress {
+	egressConfigs := sidecar.Egress
+	//If egress not set, setup a default listener
+	if len(egressConfigs) == 0 {
+		egressConfigs = append(egressConfigs, &networking.IstioEgressListener{Hosts: []string{"*/*"}})
+	}
+	for _, e := range egressConfigs {
 		out.EgressListeners = append(out.EgressListeners,
 			convertIstioListenerToWrapper(ps, configNamespace, e))
 	}

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -136,7 +136,6 @@ var (
 			},
 		},
 	}
-
 	configs2 = &config.Config{
 		Meta: config.Meta{
 			Name:      "foo",
@@ -717,7 +716,14 @@ func TestCreateSidecarScope(t *testing.T) {
 			configs2,
 			services4,
 			nil,
-			nil,
+			[]*Service{
+				{
+					Hostname: "bar",
+				},
+				{
+					Hostname: "barprime",
+				},
+			},
 		},
 		{
 			"sidecar-with-multiple-egress-noport",
@@ -1021,7 +1027,9 @@ func TestCreateSidecarScope(t *testing.T) {
 			configuredListeneres := 1
 			if sidecarConfig != nil {
 				r := sidecarConfig.Spec.(*networking.Sidecar)
-				configuredListeneres = len(r.Egress)
+				if len(r.Egress) > 0 {
+					configuredListeneres = len(r.Egress)
+				}
 			}
 
 			numberListeners := len(sidecarScope.EgressListeners)

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -812,8 +812,8 @@ var ValidateSidecar = registerValidateFunc("ValidateSidecar",
 			return nil, err
 		}
 
-		if len(rule.Egress) == 0 {
-			return nil, fmt.Errorf("sidecar: missing egress")
+		if len(rule.Egress) == 0 && len(rule.Ingress) == 0 && rule.OutboundTrafficPolicy == nil {
+			return nil, fmt.Errorf("sidecar: empty configuration provided")
 		}
 
 		portMap := make(map[uint32]struct{})

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -4903,7 +4903,11 @@ func TestValidateSidecar(t *testing.T) {
 					DefaultEndpoint: "127.0.0.1:9999",
 				},
 			},
-		}, false},
+		}, true},
+		{"empty", &networking.Sidecar{}, false},
+		{"just outbound traffic policy", &networking.Sidecar{OutboundTrafficPolicy: &networking.OutboundTrafficPolicy{
+			Mode: networking.OutboundTrafficPolicy_ALLOW_ANY,
+		}}, true},
 		{"empty protocol", &networking.Sidecar{
 			Ingress: []*networking.IstioIngressListener{
 				{


### PR DESCRIPTION
Currently sidecar.Egress is required. This is a major pain when you just
want to set outbound traffic policy or ingress settings.

I have changed this to be optional. When its not set, the existing
behavior (`hosts: [*/*]`) is maintained.

The API docs already say this field is not required