### PR TITLE
Add sprig to injection template

### DIFF
--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/Masterminds/sprig/v3"
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/ghodss/yaml"
 	"github.com/gogo/protobuf/jsonpb"
@@ -600,7 +601,7 @@ func InjectionData(params InjectionParameters, typeMetadata *metav1.TypeMeta, de
 func parseTemplate(tmplStr string, funcMap map[string]interface{}, data SidecarTemplateData) (bytes.Buffer, error) {
 	var tmpl bytes.Buffer
 	temp := template.New("inject")
-	t, err := temp.Funcs(funcMap).Parse(tmplStr)
+	t, err := temp.Funcs(sprig.TxtFuncMap()).Funcs(funcMap).Parse(tmplStr)
 	if err != nil {
 		log.Infof("Failed to parse template: %v %v\n", err, tmplStr)
 		return bytes.Buffer{}, err


### PR DESCRIPTION
This is for future proofing. Its painful to change the injection
template since if the injector and the template and image fall out of
sync new functions fail. Adding sprig now will ensure in the future when
we inevitably need new functions in sprig we can easily add them



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.