### PR TITLE
Increase upgrade support for 1.9

### DIFF
--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -261,7 +261,7 @@ func waitForConfirmation(skipConfirmation bool, l clog.Logger) {
 	}
 }
 
-var SupportedIstioVersions, _ = goversion.NewConstraint(">=1.6.0, <1.8")
+var SupportedIstioVersions, _ = goversion.NewConstraint(">=1.6.0, <1.9")
 
 func checkSupportedVersions(kubeClient *Client, currentVersion string) error {
 	curGoVersion, err := goversion.NewVersion(currentVersion)


### PR DESCRIPTION
Increased upgrade support range.

Install `1.8.0-alpha.2`
```
[1.8.0-alpha.2] $ istioctl install
``` 
Try upgrading with `master` build.

```
$ ./out/linux_amd64/istioctl upgrade -d manifests/
2020-11-04T08:38:51.365718Z     info    proto: tag has too few fields: "-"
Control Plane - ingressgateway pod - istio-ingressgateway-7856bd4877-bb4mc - version: 1.8.0
Control Plane - pilot pod - istiod-6ff7599b89-mb4jv - version: 1.8.0

2020-11-04T08:38:51.385886Z     info    Error: upgrade version check failed: 1.8.0 -> 1.9.0. Error: upgrade is currently not supported from version: 1.8.0

Error: upgrade version check failed: 1.8.0 -> 1.9.0. Error: upgrade is currently not supported from version: 1.8.0
```