### PR TITLE
istioctl upgrade: use yaml diff for upgrade iops

### DIFF
--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -32,7 +32,6 @@ import (
 
 	"istio.io/istio/istioctl/pkg/clioptions"
 	"istio.io/istio/istioctl/pkg/verifier"
-	"istio.io/istio/operator/pkg/compare"
 	"istio.io/istio/operator/pkg/manifest"
 	"istio.io/istio/operator/pkg/name"
 	"istio.io/istio/operator/pkg/tpath"
@@ -204,7 +203,7 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 		return fmt.Errorf("failed to generate Istio configs from file %s for the current version: %s, error: %v",
 			args.inFilenames, currentVersion, err)
 	}
-	checkUpgradeIOPS(currentProfileIOPSYaml, targetIOPYaml, overrideIOPYaml, l)
+	checkUpgradeIOPS(currentProfileIOPSYaml, targetIOPYaml, l)
 
 	waitForConfirmation(args.skipConfirmation && !rootArgs.dryRun, l)
 
@@ -259,8 +258,8 @@ func releaseURLFromVersion(version string) string {
 }
 
 // checkUpgradeIOPS checks the upgrade eligibility by comparing the current IOPS with the target IOPS
-func checkUpgradeIOPS(curIOPS, tarIOPS, ignoreIOPS string, l clog.Logger) {
-	diff := compare.YAMLCmpWithIgnore(curIOPS, tarIOPS, nil, ignoreIOPS)
+func checkUpgradeIOPS(curIOPS, tarIOPS string, l clog.Logger) {
+	diff := util.YAMLDiff(curIOPS, tarIOPS)
 	if util.IsYAMLEqual(curIOPS, tarIOPS) {
 		l.LogAndPrintf("Upgrade check: IOPS unchanged. The target IOPS are identical to the current IOPS.\n")
 	} else {

--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -34,7 +34,6 @@ import (
 	"istio.io/istio/istioctl/pkg/verifier"
 	"istio.io/istio/operator/pkg/manifest"
 	"istio.io/istio/operator/pkg/name"
-	"istio.io/istio/operator/pkg/tpath"
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/operator/pkg/util/clog"
 	pkgversion "istio.io/istio/operator/pkg/version"
@@ -170,22 +169,6 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 			currentVersion, targetVersion, err)
 	}
 	l.LogAndPrintf("Upgrade version check passed: %v -> %v.\n", currentVersion, targetVersion)
-
-	// Read the overridden IOP from args.inFilenames
-	overrideIOPYaml := ""
-	if args.inFilenames != nil {
-		overrideIOPYaml, err = manifest.ReadLayeredYAMLs(args.inFilenames)
-		if err != nil {
-			return fmt.Errorf("failed to read override IOPS from file: %v, error: %v", args.inFilenames, err)
-		}
-		if overrideIOPYaml != "" {
-			// Grab the IstioOperatorSpec subtree.
-			overrideIOPYaml, err = tpath.GetSpecSubtree(overrideIOPYaml)
-			if err != nil {
-				return fmt.Errorf("failed to get spec subtree from IOPS yaml, error: %v", err)
-			}
-		}
-	}
 
 	// Read the current installation's profile IOP yaml to check the changed profile settings between versions.
 	currentSets := args.set

--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -247,7 +247,7 @@ func checkUpgradeIOPS(curIOPS, tarIOPS string, l clog.Logger) {
 		l.LogAndPrintf("Upgrade check: IOPS unchanged. The target IOPS are identical to the current IOPS.\n")
 	} else {
 		l.LogAndPrintf("Upgrade check: Warning!!! The following IOPS will be changed as part of upgrade. "+
-			"Please double check they are correct:\n%s", diff)
+			"Please double check they are correct:\n%s", strings.Join(util.PrettyDiff(diff), "\n"))
 	}
 }
 

--- a/operator/pkg/util/util.go
+++ b/operator/pkg/util/util.go
@@ -23,6 +23,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/fatih/color"
 )
 
 type FileFilter func(fileName string) bool
@@ -139,4 +141,20 @@ func RenderTemplate(tmpl string, ts interface{}) (string, error) {
 		return "", err
 	}
 	return buf.String(), nil
+}
+
+// PrettyDiff decorate output with color like git diff
+func PrettyDiff(diff string) []string {
+	lines := strings.Split(diff, "\n")
+	coloredLines := []string{}
+	for _, line := range lines {
+		coloredLine := line
+		if strings.HasPrefix(line, "+") {
+			coloredLine = color.New(color.FgGreen).Sprintln(line)
+		} else if strings.HasPrefix(line, "-") {
+			coloredLine = color.New(color.FgRed).Sprintln(line)
+		}
+		coloredLines = append(coloredLines, coloredLine)
+	}
+	return coloredLines
 }


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/28555

Based on https://github.com/istio/istio/issues/28555#issuecomment-721655199


```
[istio-1.7.3] $ istioctl install 
[istio-1.8.0-alpha.2] $ istioctl upgrade
```
Before:

```
    ingressGateways:
      '[#0]':
        k8s:
          env:
            '[#0]':
              value: sni-dnat -> standard
          resources:
            requests:
              cpu: 100m -> 200m
          service:
            ports:
              '[?->0]': -> map[name:tcp-citadel-grpc-tls port:8060 targetPort:8060]
              '[?->1]': -> map[name:tcp-dns port:5353]
              '[0->?]': map[name:status-port port:15021 targetPort:15021] ->
              '[1->?]': map[name:http2 port:80 targetPort:8080] ->
              '[2->?]': map[name:https port:443 targetPort:8443] ->
              '[3->?]': map[name:tls port:15443 targetPort:15443] ->
          serviceAnnotations: -> map[cloud.google.com/load-balancer-type:internal]
```

After:

![colored-output](https://user-images.githubusercontent.com/2920003/98231267-33c9ba00-1f82-11eb-9041-508009002804.png)
