### PR TITLE
Fix issue with any marshal of nil

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -908,17 +908,17 @@ func applyUpstreamTLSSettings(opts *buildClusterOpts, tls *networking.ClientTLSS
 		return
 	}
 
-	tc := util.MessageToAny(tlsContext)
-	// Moving from v2 tls <-> v3 tls seems to cause downtime: https://github.com/envoyproxy/envoy/issues/13864
-	// Instead, we should tie this to the cluster version, which is fixed, so we do not switch at runtime during
-	// an in place upgrade of the control plane only
-	// However, there is an edge case: users with 1.6 proxy, connecting to 1.7.x control plane without this code, then updating
-	// to 1.7.y control plane with this code. This would cause this code to cause another downtime by downgrading from v3 to v2.
-	// To workaround this, we will have a flag to disable this behavior
-	if tc != nil && features.EnableTLSXDSDynamicTypes && node.RequestedTypes.CDS == xdsv2.ClusterType {
-		tc.TypeUrl = "type.googleapis.com/envoy.api.v2.auth.UpstreamTlsContext"
-	}
 	if tlsContext != nil {
+		tc := util.MessageToAny(tlsContext)
+		// Moving from v2 tls <-> v3 tls seems to cause downtime: https://github.com/envoyproxy/envoy/issues/13864
+		// Instead, we should tie this to the cluster version, which is fixed, so we do not switch at runtime during
+		// an in place upgrade of the control plane only
+		// However, there is an edge case: users with 1.6 proxy, connecting to 1.7.x control plane without this code, then updating
+		// to 1.7.y control plane with this code. This would cause this code to cause another downtime by downgrading from v3 to v2.
+		// To workaround this, we will have a flag to disable this behavior
+		if features.EnableTLSXDSDynamicTypes && node.RequestedTypes.CDS == xdsv2.ClusterType {
+			tc.TypeUrl = "type.googleapis.com/envoy.api.v2.auth.UpstreamTlsContext"
+		}
 		c.TransportSocket = &core.TransportSocket{
 			Name:       util.EnvoyTLSSocketName,
 			ConfigType: &core.TransportSocket_TypedConfig{TypedConfig: tc},


### PR DESCRIPTION
This is fixing a small regression in #28498 that caused excessive
logging for clusters without TLS settings.

Old code:
```go
    if tlsContext != nil {
        c.TransportSocket = &core.TransportSocket{
            Name:       util.EnvoyTLSSocketName,
            ConfigType: &core.TransportSocket_TypedConfig{TypedConfig:
util.MessageToAny(tlsContext)},
        }
    }
```

You can see the MessageToAny was guarded by nil check. In the current
code, we nil check *after* the MessageToAny. In practice, MessageToAny
will handle nil pretty well and return nil back, but it will spam
confusing error level logs in the meantime.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.