### PR TITLE
istioctl upgrade: display warning when skipping past minor versions

### DIFF
--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -160,7 +160,7 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 	}
 
 	// Check if the upgrade currentVersion -> targetVersion is supported
-	err = checkSupportedVersions(kubeClient, currentVersion)
+	err = checkSupportedVersions(kubeClient, currentVersion, targetVersion, l)
 	if err != nil && !args.force {
 		return fmt.Errorf("upgrade version check failed: %v -> %v. Error: %v",
 			currentVersion, targetVersion, err)
@@ -263,14 +263,23 @@ func waitForConfirmation(skipConfirmation bool, l clog.Logger) {
 
 var SupportedIstioVersions, _ = goversion.NewConstraint(">=1.6.0, <1.9")
 
-func checkSupportedVersions(kubeClient *Client, currentVersion string) error {
+func checkSupportedVersions(kubeClient *Client, currentVersion, targetVersion string, l clog.Logger) error {
 	curGoVersion, err := goversion.NewVersion(currentVersion)
 	if err != nil {
 		return fmt.Errorf("failed to parse the current version %q: %v", currentVersion, err)
 	}
-
+	targetGoVersion, err := goversion.NewVersion(targetVersion)
+	if err != nil {
+		return fmt.Errorf("failed to parse the target version %q: %v", targetVersion, err)
+	}
 	if !SupportedIstioVersions.Check(curGoVersion) {
 		return fmt.Errorf("upgrade is currently not supported from version: %v", currentVersion)
+	}
+	// Warn if user is trying skip one minor verion eg: 1.6.x to 1.8.x
+	if (targetGoVersion.Segments()[1] - curGoVersion.Segments()[1]) > 1 {
+		l.LogAndPrint("!!! WARNING !!!")
+		l.LogAndPrintf("Upgrading across more than one minor version (e.g., %v to %v)"+
+			" in one step is not officially tested or recommended.\n", curGoVersion, targetGoVersion)
 	}
 
 	return kubeClient.CheckUnsupportedAlphaSecurityCRD()


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/28583

Ref: https://preliminary.istio.io/latest/docs/setup/upgrade/

```
[istio-1.6.8] $ istioctl install
```
```
[istio-master]$ ./out/linux_amd64/istioctl upgrade -d manifests/
2020-11-05T06:54:38.281839Z     info    proto: tag has too few fields: "-"
Control Plane - ingressgateway pod - istio-ingressgateway-795d8b6644-6dsxv - version: 1.6.8
Control Plane - pilot pod - istiod-5475dd875b-tlzwd - version: 1.6.8

!!! WARNING !!!
Upgrading across more than one minor version (e.g., 1.6.8 to 1.9.0) in one step is not officially tested or recommended.

2020-11-05T06:54:38.328235Z     warn    found 4 CRD of unsupported v1alpha1 security policy: [clusterrbacconfigs.rbac.istio.io rbacconfigs.rbac.istio.io servicerolebindings.rbac.istio.io serviceroles.rbac.istio.io]. The v1alpha1 security policy is no longer supported starting 1.6. It's strongly recommended to delete the CRD of the v1alpha1 security policy to avoid applying any of the v1alpha1 security policy in the unsupported version
Upgrade version check passed: 1.6.8 -> 1.9.0.

```