### PR TITLE
Max workload cert lifetime should not apply to istiod's server cert

### DIFF
--- a/pilot/pkg/bootstrap/certcontroller.go
+++ b/pilot/pkg/bootstrap/certcontroller.go
@@ -143,7 +143,7 @@ func (s *Server) initDNSCerts(hostname, customHost, namespace string) error {
 		s.caBundlePath = defaultCACertPath
 	} else if features.PilotCertProvider.Get() == IstiodCAProvider {
 		log.Infof("Generating istiod-signed cert for %v", names)
-		certChain, keyPEM, err = s.CA.GenKeyCertNoLifetimeCheck(names, SelfSignedCACertTTL.Get())
+		certChain, keyPEM, err = s.CA.GenKeyCert(names, SelfSignedCACertTTL.Get(), false)
 
 		signingKeyFile := path.Join(LocalCertDir.Get(), "ca-key.pem")
 		// check if signing key file exists the cert dir

--- a/pilot/pkg/bootstrap/certcontroller.go
+++ b/pilot/pkg/bootstrap/certcontroller.go
@@ -143,7 +143,7 @@ func (s *Server) initDNSCerts(hostname, customHost, namespace string) error {
 		s.caBundlePath = defaultCACertPath
 	} else if features.PilotCertProvider.Get() == IstiodCAProvider {
 		log.Infof("Generating istiod-signed cert for %v", names)
-		certChain, keyPEM, err = s.CA.GenKeyCert(names, SelfSignedCACertTTL.Get())
+		certChain, keyPEM, err = s.CA.GenKeyCertNoLifetimeCheck(names, SelfSignedCACertTTL.Get())
 
 		signingKeyFile := path.Join(LocalCertDir.Get(), "ca-key.pem")
 		// check if signing key file exists the cert dir

--- a/pilot/pkg/bootstrap/istio_ca.go
+++ b/pilot/pkg/bootstrap/istio_ca.go
@@ -360,11 +360,6 @@ func (s *Server) createIstioCA(client corev1.CoreV1Interface, opts *caOptions) (
 	var caOpts *ca.IstioCAOptions
 	var err error
 
-	maxCertTTL := maxWorkloadCertTTL.Get()
-	if SelfSignedCACertTTL.Get().Seconds() > maxCertTTL.Seconds() {
-		maxCertTTL = SelfSignedCACertTTL.Get()
-	}
-
 	// In pods, this is the optional 'cacerts' Secret.
 	// TODO: also check for key.pem ( for interop )
 	signingKeyFile := path.Join(LocalCertDir.Get(), "ca-key.pem")
@@ -385,13 +380,10 @@ func (s *Server) createIstioCA(client corev1.CoreV1Interface, opts *caOptions) (
 		// rootCertFile will be added to "ca-cert.pem".
 		// readSigningCertOnly set to false - it doesn't seem to be used in Citadel, nor do we have a way
 		// to set it only for one job.
-		// maxCertTTL in NewSelfSignedIstioCAOptions() is set to be the same as
-		// SelfSignedCACertTTL because the istiod certificate issued by Citadel
-		// will have a TTL equal to SelfSignedCACertTTL.
 		caOpts, err = ca.NewSelfSignedIstioCAOptions(ctx,
 			selfSignedRootCertGracePeriodPercentile.Get(), SelfSignedCACertTTL.Get(),
 			selfSignedRootCertCheckInterval.Get(), workloadCertTTL.Get(),
-			maxCertTTL, opts.TrustDomain, true,
+			maxWorkloadCertTTL.Get(), opts.TrustDomain, true,
 			opts.Namespace, -1, client, rootCertFile,
 			enableJitterForRootCertRotator.Get(), caRSAKeySize.Get())
 		if err != nil {
@@ -410,7 +402,7 @@ func (s *Server) createIstioCA(client corev1.CoreV1Interface, opts *caOptions) (
 		certChainFile := path.Join(LocalCertDir.Get(), "cert-chain.pem")
 		s.caBundlePath = certChainFile
 		caOpts, err = ca.NewPluggedCertIstioCAOptions(certChainFile, signingCertFile, signingKeyFile,
-			rootCertFile, workloadCertTTL.Get(), maxCertTTL, caRSAKeySize.Get())
+			rootCertFile, workloadCertTTL.Get(), maxWorkloadCertTTL.Get(), caRSAKeySize.Get())
 		if err != nil {
 			return nil, fmt.Errorf("failed to create an istiod CA: %v", err)
 		}

--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -80,7 +80,7 @@ func TestAgent(t *testing.T) {
 	defer tearDown()
 
 	// TODO: when authz is implemented, verify labels are checked.
-	cert, key, err := bs.CA.GenKeyCertNoLifetimeCheck([]string{spiffe.Identity{"cluster.local", "test", "sa"}.String()}, 1*time.Hour)
+	cert, key, err := bs.CA.GenKeyCert([]string{spiffe.Identity{"cluster.local", "test", "sa"}.String()}, 1*time.Hour, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -80,7 +80,7 @@ func TestAgent(t *testing.T) {
 	defer tearDown()
 
 	// TODO: when authz is implemented, verify labels are checked.
-	cert, key, err := bs.CA.GenKeyCert([]string{spiffe.Identity{"cluster.local", "test", "sa"}.String()}, 1*time.Hour)
+	cert, key, err := bs.CA.GenKeyCertNoLifetimeCheck([]string{spiffe.Identity{"cluster.local", "test", "sa"}.String()}, 1*time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -308,10 +308,9 @@ func (ca *IstioCA) GetCAKeyCertBundle() util.KeyCertBundle {
 	return ca.keyCertBundle
 }
 
-// GenKeyCertNoLifetimeCheck generates a certificate signed by the CA,
+// GenKeyCert generates a certificate signed by the CA,
 // returns the certificate chain and the private key.
-// Max cert lifetime check is skipped. This is only for issuing certificates to Istio managed services.
-func (ca *IstioCA) GenKeyCertNoLifetimeCheck(hostnames []string, certTTL time.Duration) ([]byte, []byte, error) {
+func (ca *IstioCA) GenKeyCert(hostnames []string, certTTL time.Duration, checkLifetime bool) ([]byte, []byte, error) {
 	opts := util.CertOptions{
 		RSAKeySize: rsaKeySize,
 	}
@@ -328,7 +327,7 @@ func (ca *IstioCA) GenKeyCertNoLifetimeCheck(hostnames []string, certTTL time.Du
 		return nil, nil, err
 	}
 
-	certPEM, err := ca.signWithCertChain(csrPEM, hostnames, certTTL, false, false)
+	certPEM, err := ca.signWithCertChain(csrPEM, hostnames, certTTL, checkLifetime, false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -292,53 +292,15 @@ func (ca *IstioCA) Run(stopChan chan struct{}) {
 // Sign takes a PEM-encoded CSR, subject IDs and lifetime, and returns a signed certificate. If forCA is true,
 // the signed certificate is a CA certificate, otherwise, it is a workload certificate.
 // TODO(myidpt): Add error code to identify the Sign error types.
-func (ca *IstioCA) Sign(csrPEM []byte, subjectIDs []string, requestedLifetime time.Duration, forCA bool) ([]byte, error) {
-	signingCert, signingKey, _, _ := ca.keyCertBundle.GetAll()
-	if signingCert == nil {
-		return nil, caerror.NewError(caerror.CANotReady, fmt.Errorf("Istio CA is not ready")) // nolint
-	}
-
-	csr, err := util.ParsePemEncodedCSR(csrPEM)
-	if err != nil {
-		return nil, caerror.NewError(caerror.CSRError, err)
-	}
-
-	lifetime := requestedLifetime
-	// If the requested requestedLifetime is non-positive, apply the default TTL.
-	if requestedLifetime.Seconds() <= 0 {
-		lifetime = ca.defaultCertTTL
-	}
-	// If the requested TTL is greater than maxCertTTL, return an error
-	if requestedLifetime.Seconds() > ca.maxCertTTL.Seconds() {
-		return nil, caerror.NewError(caerror.TTLError, fmt.Errorf(
-			"requested TTL %s is greater than the max allowed TTL %s", requestedLifetime, ca.maxCertTTL))
-	}
-
-	certBytes, err := util.GenCertFromCSR(csr, signingCert, csr.PublicKey, *signingKey, subjectIDs, lifetime, forCA)
-	if err != nil {
-		return nil, caerror.NewError(caerror.CertGenError, err)
-	}
-
-	block := &pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: certBytes,
-	}
-	cert := pem.EncodeToMemory(block)
-
-	return cert, nil
+func (ca *IstioCA) Sign(csrPEM []byte, subjectIDs []string, requestedLifetime time.Duration, forCA bool) (
+	[]byte, error) {
+	return ca.sign(csrPEM, subjectIDs, requestedLifetime, true, forCA)
 }
 
 // SignWithCertChain is similar to Sign but returns the leaf cert and the entire cert chain.
-func (ca *IstioCA) SignWithCertChain(csrPEM []byte, subjectIDs []string, ttl time.Duration, forCA bool) ([]byte, error) {
-	cert, err := ca.Sign(csrPEM, subjectIDs, ttl, forCA)
-	if err != nil {
-		return nil, err
-	}
-	chainPem := ca.GetCAKeyCertBundle().GetCertChainPem()
-	if len(chainPem) > 0 {
-		cert = append(cert, chainPem...)
-	}
-	return cert, nil
+func (ca *IstioCA) SignWithCertChain(csrPEM []byte, subjectIDs []string, requestedLifetime time.Duration, forCA bool) (
+	[]byte, error) {
+	return ca.signWithCertChain(csrPEM, subjectIDs, requestedLifetime, true, forCA)
 }
 
 // GetCAKeyCertBundle returns the KeyCertBundle for the CA.
@@ -346,9 +308,10 @@ func (ca *IstioCA) GetCAKeyCertBundle() util.KeyCertBundle {
 	return ca.keyCertBundle
 }
 
-// GenKeyCert() generates a certificate signed by the CA and
+// GenKeyCertNoLifetimeCheck generates a certificate signed by the CA,
 // returns the certificate chain and the private key.
-func (ca *IstioCA) GenKeyCert(hostnames []string, certTTL time.Duration) ([]byte, []byte, error) {
+// Max cert lifetime check is skipped. This is only for issuing certificates to Istio managed services.
+func (ca *IstioCA) GenKeyCertNoLifetimeCheck(hostnames []string, certTTL time.Duration) ([]byte, []byte, error) {
 	opts := util.CertOptions{
 		RSAKeySize: rsaKeySize,
 	}
@@ -365,7 +328,7 @@ func (ca *IstioCA) GenKeyCert(hostnames []string, certTTL time.Duration) ([]byte
 		return nil, nil, err
 	}
 
-	certPEM, err := ca.SignWithCertChain(csrPEM, hostnames, certTTL, false)
+	certPEM, err := ca.signWithCertChain(csrPEM, hostnames, certTTL, false, false)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -393,4 +356,53 @@ func (ca *IstioCA) minTTL(defaultCertTTL time.Duration) (time.Duration, error) {
 	}
 
 	return defaultCertTTL, nil
+}
+
+func (ca *IstioCA) sign(csrPEM []byte, subjectIDs []string, requestedLifetime time.Duration, checkLifetime, forCA bool) ([]byte, error) {
+	signingCert, signingKey, _, _ := ca.keyCertBundle.GetAll()
+	if signingCert == nil {
+		return nil, caerror.NewError(caerror.CANotReady, fmt.Errorf("Istio CA is not ready")) // nolint
+	}
+
+	csr, err := util.ParsePemEncodedCSR(csrPEM)
+	if err != nil {
+		return nil, caerror.NewError(caerror.CSRError, err)
+	}
+
+	lifetime := requestedLifetime
+	// If the requested requestedLifetime is non-positive, apply the default TTL.
+	if requestedLifetime.Seconds() <= 0 {
+		lifetime = ca.defaultCertTTL
+	}
+	// If checkLifetime is set and the requested TTL is greater than maxCertTTL, return an error
+	if checkLifetime && requestedLifetime.Seconds() > ca.maxCertTTL.Seconds() {
+		return nil, caerror.NewError(caerror.TTLError, fmt.Errorf(
+			"requested TTL %s is greater than the max allowed TTL %s", requestedLifetime, ca.maxCertTTL))
+	}
+
+	certBytes, err := util.GenCertFromCSR(csr, signingCert, csr.PublicKey, *signingKey, subjectIDs, lifetime, forCA)
+	if err != nil {
+		return nil, caerror.NewError(caerror.CertGenError, err)
+	}
+
+	block := &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	}
+	cert := pem.EncodeToMemory(block)
+
+	return cert, nil
+}
+
+func (ca *IstioCA) signWithCertChain(csrPEM []byte, subjectIDs []string, requestedLifetime time.Duration, lifetimeCheck,
+	forCA bool) ([]byte, error) {
+	cert, err := ca.sign(csrPEM, subjectIDs, requestedLifetime, lifetimeCheck, forCA)
+	if err != nil {
+		return nil, err
+	}
+	chainPem := ca.GetCAKeyCertBundle().GetCertChainPem()
+	if len(chainPem) > 0 {
+		cert = append(cert, chainPem...)
+	}
+	return cert, nil
 }

--- a/security/pkg/pki/ca/ca_test.go
+++ b/security/pkg/pki/ca/ca_test.go
@@ -609,7 +609,7 @@ func TestSignWithCertChain(t *testing.T) {
 	}
 }
 
-func TestGenKeyCert(t *testing.T) {
+func TestGenKeyCertNoLifetimeCheck(t *testing.T) {
 	cases := map[string]struct {
 		rootCertFile    string
 		certChainFile   string
@@ -630,7 +630,7 @@ func TestGenKeyCert(t *testing.T) {
 		},
 	}
 	defaultWorkloadCertTTL := 30 * time.Minute
-	maxWorkloadCertTTL := 3650 * 24 * time.Hour
+	maxWorkloadCertTTL := 24 * time.Hour
 	rsaKeySize := 2048
 
 	for id, tc := range cases {
@@ -648,7 +648,7 @@ func TestGenKeyCert(t *testing.T) {
 			t.Fatalf("failed to create a plugged-cert CA.")
 		}
 
-		certPEM, privPEM, err := ca.GenKeyCert([]string{"host1", "host2"}, 3650*24*time.Hour)
+		certPEM, privPEM, err := ca.GenKeyCertNoLifetimeCheck([]string{"host1", "host2"}, 3650*24*time.Hour)
 		if err != nil {
 			t.Errorf("%s: GenKeyCert error: %v", id, err)
 		}

--- a/security/pkg/pki/ca/ca_test.go
+++ b/security/pkg/pki/ca/ca_test.go
@@ -609,24 +609,51 @@ func TestSignWithCertChain(t *testing.T) {
 	}
 }
 
-func TestGenKeyCertNoLifetimeCheck(t *testing.T) {
+func TestGenKeyCert(t *testing.T) {
 	cases := map[string]struct {
-		rootCertFile    string
-		certChainFile   string
-		signingCertFile string
-		signingKeyFile  string
+		rootCertFile      string
+		certChainFile     string
+		signingCertFile   string
+		signingKeyFile    string
+		certLifetime      time.Duration
+		checkCertLifetime bool
+		expectedError     string
 	}{
 		"RSA cryptography": {
-			rootCertFile:    "../testdata/multilevelpki/root-cert.pem",
-			certChainFile:   "../testdata/multilevelpki/int-cert-chain.pem",
-			signingCertFile: "../testdata/multilevelpki/int-cert.pem",
-			signingKeyFile:  "../testdata/multilevelpki/int-key.pem",
+			rootCertFile:      "../testdata/multilevelpki/root-cert.pem",
+			certChainFile:     "../testdata/multilevelpki/int-cert-chain.pem",
+			signingCertFile:   "../testdata/multilevelpki/int-cert.pem",
+			signingKeyFile:    "../testdata/multilevelpki/int-key.pem",
+			certLifetime:      3650 * 24 * time.Hour,
+			checkCertLifetime: false,
+			expectedError:     "",
 		},
 		"EC cryptography": {
-			rootCertFile:    "../testdata/multilevelpki/ecc-root-cert.pem",
-			certChainFile:   "../testdata/multilevelpki/ecc-int-cert-chain.pem",
-			signingCertFile: "../testdata/multilevelpki/ecc-int-cert.pem",
-			signingKeyFile:  "../testdata/multilevelpki/ecc-int-key.pem",
+			rootCertFile:      "../testdata/multilevelpki/ecc-root-cert.pem",
+			certChainFile:     "../testdata/multilevelpki/ecc-int-cert-chain.pem",
+			signingCertFile:   "../testdata/multilevelpki/ecc-int-cert.pem",
+			signingKeyFile:    "../testdata/multilevelpki/ecc-int-key.pem",
+			certLifetime:      3650 * 24 * time.Hour,
+			checkCertLifetime: false,
+			expectedError:     "",
+		},
+		"Pass lifetime check": {
+			rootCertFile:      "../testdata/multilevelpki/ecc-root-cert.pem",
+			certChainFile:     "../testdata/multilevelpki/ecc-int-cert-chain.pem",
+			signingCertFile:   "../testdata/multilevelpki/ecc-int-cert.pem",
+			signingKeyFile:    "../testdata/multilevelpki/ecc-int-key.pem",
+			certLifetime:      24 * time.Hour,
+			checkCertLifetime: true,
+			expectedError:     "",
+		},
+		"Error lifetime check": {
+			rootCertFile:      "../testdata/multilevelpki/ecc-root-cert.pem",
+			certChainFile:     "../testdata/multilevelpki/ecc-int-cert-chain.pem",
+			signingCertFile:   "../testdata/multilevelpki/ecc-int-cert.pem",
+			signingKeyFile:    "../testdata/multilevelpki/ecc-int-key.pem",
+			certLifetime:      25 * time.Hour,
+			checkCertLifetime: true,
+			expectedError:     "requested TTL 25h0m0s is greater than the max allowed TTL 24h0m0s",
 		},
 	}
 	defaultWorkloadCertTTL := 30 * time.Minute
@@ -642,24 +669,32 @@ func TestGenKeyCertNoLifetimeCheck(t *testing.T) {
 
 		ca, err := NewIstioCA(caopts)
 		if err != nil {
-			t.Errorf("%s: got error while creating plugged-cert CA: %v", id, err)
+			t.Fatalf("%s: got error while creating plugged-cert CA: %v", id, err)
 		}
 		if ca == nil {
 			t.Fatalf("failed to create a plugged-cert CA.")
 		}
 
-		certPEM, privPEM, err := ca.GenKeyCertNoLifetimeCheck([]string{"host1", "host2"}, 3650*24*time.Hour)
+		certPEM, privPEM, err := ca.GenKeyCert([]string{"host1", "host2"}, tc.certLifetime, tc.checkCertLifetime)
 		if err != nil {
-			t.Errorf("%s: GenKeyCert error: %v", id, err)
+			if tc.expectedError == "" {
+				t.Fatalf("[%s] Unexpected error: %v", id, err)
+			}
+			if err.Error() != tc.expectedError {
+				t.Fatalf("[%s] Error returned does not match expectation: %v VS (expected) %v", id, err, tc.expectedError)
+			}
+			continue
+		} else if tc.expectedError != "" {
+			t.Fatalf("[%s] GenKeyCert succeeded but expected error: %v", id, tc.expectedError)
 		}
 
 		cert, err := tls.X509KeyPair(certPEM, privPEM)
 		if err != nil {
-			t.Errorf("%s: X509KeyPair error: %v", id, err)
+			t.Fatalf("[%s] X509KeyPair error: %v", id, err)
 		}
 
 		if len(cert.Certificate) != 3 {
-			t.Errorf("%s: unexpected number of certificates returned: %d (expected 3)", id, len(cert.Certificate))
+			t.Fatalf("[%s] unexpected number of certificates returned: %d (expected 3)", id, len(cert.Certificate))
 		}
 	}
 }


### PR DESCRIPTION
When using self-signed Istiod CA, Istiod server needs a long-lived cert signed by Istiod CA itself (we make its lifetime equals the CA cert lifetime). Because the Istiod CA checks the requested lifetime should be smaller than the max workload cert lifetime, we extended the max workload cert to be equal to the CA cert lifetime. This actually makes the max workload cert lifetime effectiveless.

This PR fixes this by not conducting the max workload cert lifetime check for the Istiod server's certificate issuance (called via GenKeyCertNoLifetimeChecking). The max workload cert lifetime is still effective (by default 90 days) against normal workload cert issuance.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ X ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.