### PR TITLE
add runAsUser to bookinfo samples to run as non-root

### DIFF
--- a/samples/bookinfo/platform/kube/bookinfo-details-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-details-v2.yaml
@@ -43,4 +43,6 @@ spec:
         env:
         - name: DO_NOT_ENCRYPT
           value: "true"
+        securityContext:
+          runAsUser: 1000
 ---

--- a/samples/bookinfo/platform/kube/bookinfo-details.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-details.yaml
@@ -54,4 +54,6 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
+        securityContext:
+          runAsUser: 1000
 ---

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-vm.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-vm.yaml
@@ -50,4 +50,6 @@ spec:
             value: password
         ports:
         - containerPort: 9080
+        securityContext:
+          runAsUser: 1000
 ---

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql.yaml
@@ -53,4 +53,6 @@ spec:
             value: password
         ports:
         - containerPort: 9080
+        securityContext:
+          runAsUser: 1000
 ---

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml
@@ -60,4 +60,6 @@ spec:
             value: mongodb://mongodb:27017/test
         ports:
         - containerPort: 9080
+        securityContext:
+          runAsUser: 1000
 ---

--- a/samples/bookinfo/platform/kube/bookinfo-ratings.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings.yaml
@@ -54,4 +54,6 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
+        securityContext:
+          runAsUser: 1000
 ---

--- a/samples/bookinfo/platform/kube/bookinfo-reviews-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-reviews-v2.yaml
@@ -48,6 +48,8 @@ spec:
           mountPath: /tmp
         - name: wlp-output
           mountPath: /opt/ibm/wlp/output
+        securityContext:
+          runAsUser: 1000
       volumes:
       - name: wlp-output
         emptyDir: {}

--- a/samples/bookinfo/platform/kube/bookinfo.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo.yaml
@@ -190,6 +190,8 @@ spec:
           mountPath: /tmp
         - name: wlp-output
           mountPath: /opt/ibm/wlp/output
+        securityContext:
+          runAsUser: 1000
       volumes:
       - name: wlp-output
         emptyDir: {}
@@ -230,6 +232,8 @@ spec:
           mountPath: /tmp
         - name: wlp-output
           mountPath: /opt/ibm/wlp/output
+        securityContext:
+          runAsUser: 1000
       volumes:
       - name: wlp-output
         emptyDir: {}
@@ -270,6 +274,8 @@ spec:
           mountPath: /tmp
         - name: wlp-output
           mountPath: /opt/ibm/wlp/output
+        securityContext:
+          runAsUser: 1000
       volumes:
       - name: wlp-output
         emptyDir: {}

--- a/samples/bookinfo/platform/kube/bookinfo.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo.yaml
@@ -76,6 +76,8 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
+        securityContext:
+          runAsUser: 1000
 ---
 ##################################################################################################
 # Ratings service
@@ -127,6 +129,8 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
+        securityContext:
+          runAsUser: 1000
 ---
 ##################################################################################################
 # Reviews service
@@ -325,6 +329,8 @@ spec:
         volumeMounts:
         - name: tmp
           mountPath: /tmp
+        securityContext:
+          runAsUser: 1000
       volumes:
       - name: tmp
         emptyDir: {}


### PR DESCRIPTION
All of the bookinfo samples containers are able to run as non-root. Therefore it's okay to also add the `securityContext` to the Kubernetes deployments.

This PR resolves issue #23232 

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure


[x] Does not have any changes that may affect Istio users.

<sub>Tobias Giese <tobias.giese@daimler.com>, Daimler TSS GmbH, [legal info/Impressum](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)</sub>