### PR TITLE
Update istiod cluster role to create gateways if configValidation is …

### DIFF
--- a/manifests/charts/base/templates/clusterrole.yaml
+++ b/manifests/charts/base/templates/clusterrole.yaml
@@ -28,7 +28,7 @@ rules:
 {{- end }}
 {{- if .Values.global.configValidation }}
   - apiGroups: ["networking.istio.io"]
-    verbs: [ "create" ]
+    verbs: [ "create", "update" ]
     resources: [ "gateways" ]
 {{- end }}
   - apiGroups: ["networking.istio.io"]

--- a/manifests/charts/base/templates/clusterrole.yaml
+++ b/manifests/charts/base/templates/clusterrole.yaml
@@ -26,6 +26,11 @@ rules:
     # TODO: should be on just */status but wildcard is not supported
     resources: ["*"]
 {{- end }}
+{{- if .Values.global.configValidation }}
+  - apiGroups: ["networking.istio.io"]
+    verbs: [ "create" ]
+    resources: [ "gateways" ]
+{{- end }}
   - apiGroups: ["networking.istio.io"]
     verbs: [ "get", "watch", "list", "update", "patch", "create", "delete" ]
     resources: [ "workloadentries" ]


### PR DESCRIPTION
…enabled"

Signed-off-by: Shakti <shaktiprakash.das@salesforce.com>

If `configValidation` is enabled, Istiod tries to create/update an invalid gateway before moving the validation webhook config from `Ignore` to `Fail`. This PR sets up the `ClusterRole` with the verbs to create/update gateways.

Code reference: https://github.com/istio/istio/blob/eaacb6e0037b81551fa2c6017406d4f3de703d80/pkg/webhooks/validation/controller/controller.go#L398

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.