### PR TITLE
Fix trust domain RM

### DIFF
--- a/releasenotes/notes/trust-domain-validation.yaml
+++ b/releasenotes/notes/trust-domain-validation.yaml
@@ -5,5 +5,5 @@ issue:
   - 26224
 releaseNotes:
 - |
-  *Added* Trust Domain Validation by default rejecting requests in sidecars if the request is not from same trust domain
+  **Added** Trust Domain Validation by default rejecting requests in sidecars if the request is not from same trust domain
   or if it's not in the TrustDomainAliases specified in the MeshConfig.


### PR DESCRIPTION
The trust domain release note doesn't have a properly formatted action. This can cause issues with validation in the release notes tooling. 
