### PR TITLE
Add explicit check for IP addresses when resolving VirtualService host shortname

### DIFF
--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	"hash/crc32"
+	"net"
 	"sort"
 	"strings"
 
@@ -197,6 +198,12 @@ func ResolveShortnameToFQDN(hostname string, meta config.Meta) host.Name {
 	if hostname == "*" {
 		return host.Name(out)
 	}
+
+	// if the hostname is a valid ipv4 or ipv6 address, do not append domain or namespace
+	if net.ParseIP(hostname) != nil {
+		return host.Name(out)
+	}
+
 	// if FQDN is specified, do not append domain or namespace to hostname
 	if !strings.Contains(hostname, ".") {
 		if meta.Namespace != "" {

--- a/pilot/pkg/model/config_test.go
+++ b/pilot/pkg/model/config_test.go
@@ -230,6 +230,18 @@ func TestResolveShortnameToFQDN(t *testing.T) {
 		{
 			"foo", config.Meta{Namespace: "default"}, "foo.default",
 		},
+		{
+			"42.185.131.210", config.Meta{Namespace: "default"}, "42.185.131.210",
+		},
+		{
+			"42.185.131.210", config.Meta{Namespace: "cluster.local"}, "42.185.131.210",
+		},
+		{
+			"2a00:4000::614", config.Meta{Namespace: "default"}, "2a00:4000::614",
+		},
+		{
+			"2a00:4000::614", config.Meta{Namespace: "cluster.local"}, "2a00:4000::614",
+		},
 	}
 
 	for idx, tt := range tests {


### PR DESCRIPTION
Addresses #28645. Docs for VirtualService `hosts` field say `Could be a DNS name with wildcard prefix or an IP address. Depending on the platform, short-names can also be used instead of a FQDN (i.e. has no dots in the name)`. However, current logic does not actually support IPs in that field. 

Think it's by accident that `IPv4` worked (logic checked for `'.'`), but `IPv6` addresses are mistakenly treated as shortnames and have service domains added. Should be corrected to make sure we're not adding service domains to IPs (unless I'm mistaken in my reading of the docs and this is intended behavior).

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure