### PR TITLE
Trim agent binary by 14mb by conditionally compiled XDS filters

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -262,10 +262,15 @@ fmt: format-go format-python tidy-go
 buildcache:
 	GOBUILDFLAGS=-i $(MAKE) -e -f Makefile.core.mk build
 
+# gobuild script uses custom linker flag to set the variables.
+RELEASE_LDFLAGS='-extldflags -static -s -w'
+
 # List of all binaries to build
-BINARIES:=./istioctl/cmd/istioctl \
+# We split the binaries into "agent" binaries and standard ones. This corresponds to build "agent".
+# This allows conditional compilation to avoid pulling in costly dependencies to the agent, such as XDS and k8s.
+AGENT_BINARIES:=./pilot/cmd/pilot-agent
+STANDARD_BINARIES:=./istioctl/cmd/istioctl \
   ./pilot/cmd/pilot-discovery \
-  ./pilot/cmd/pilot-agent \
   ./pkg/test/echo/cmd/client \
   ./pkg/test/echo/cmd/server \
   ./operator/cmd/operator \
@@ -275,13 +280,15 @@ BINARIES:=./istioctl/cmd/istioctl \
   ./cni/cmd/install-cni \
   ./tools/istio-iptables \
   ./tools/bug-report
+BINARIES:=$(STANDARD_BINARIES) $(AGENT_BINARIES)
 
 # List of binaries included in releases
 RELEASE_BINARIES:=pilot-discovery pilot-agent istioctl bug-report
 
 .PHONY: build
 build: depend ## Builds all go binaries.
-	GOOS=$(GOOS_LOCAL) GOARCH=$(GOARCH_LOCAL) LDFLAGS=$(RELEASE_LDFLAGS) common/scripts/gobuild.sh $(ISTIO_OUT)/ $(BINARIES)
+	GOOS=$(GOOS_LOCAL) GOARCH=$(GOARCH_LOCAL) LDFLAGS=$(RELEASE_LDFLAGS) common/scripts/gobuild.sh $(ISTIO_OUT)/ $(STANDARD_BINARIES)
+	GOOS=$(GOOS_LOCAL) GOARCH=$(GOARCH_LOCAL) LDFLAGS=$(RELEASE_LDFLAGS) common/scripts/gobuild.sh $(ISTIO_OUT)/ -tags=agent $(AGENT_BINARIES)
 
 # The build-linux target is responsible for building binaries used within containers.
 # This target should be expanded upon as we add more Linux architectures: i.e. build-arm64.
@@ -289,7 +296,8 @@ build: depend ## Builds all go binaries.
 # various platform images.
 .PHONY: build-linux
 build-linux: depend
-	GOOS=linux GOARCH=$(GOARCH_LOCAL) LDFLAGS=$(RELEASE_LDFLAGS) common/scripts/gobuild.sh $(ISTIO_OUT_LINUX)/ $(BINARIES)
+	GOOS=linux GOARCH=$(GOARCH_LOCAL) LDFLAGS=$(RELEASE_LDFLAGS) common/scripts/gobuild.sh $(ISTIO_OUT_LINUX)/ $(STANDARD_BINARIES)
+	GOOS=linux GOARCH=$(GOARCH_LOCAL) LDFLAGS=$(RELEASE_LDFLAGS) common/scripts/gobuild.sh $(ISTIO_OUT_LINUX)/ -tags=agent $(AGENT_BINARIES)
 
 # Create targets for ISTIO_OUT_LINUX/binary
 # There are two use cases here:
@@ -302,11 +310,12 @@ ifeq ($(BUILD_ALL),true)
 $(ISTIO_OUT_LINUX)/$(shell basename $(1)): build-linux
 else
 $(ISTIO_OUT_LINUX)/$(shell basename $(1)): $(ISTIO_OUT_LINUX)
-	GOOS=linux GOARCH=$(GOARCH_LOCAL) LDFLAGS=$(RELEASE_LDFLAGS) common/scripts/gobuild.sh $(ISTIO_OUT_LINUX)/ $(1)
+	GOOS=linux GOARCH=$(GOARCH_LOCAL) LDFLAGS=$(RELEASE_LDFLAGS) common/scripts/gobuild.sh $(ISTIO_OUT_LINUX)/ -tags=$(2) $(1)
 endif
 endef
 
-$(foreach bin,$(BINARIES),$(eval $(call build-linux,$(bin))))
+$(foreach bin,$(STANDARD_BINARIES),$(eval $(call build-linux,$(bin),"")))
+$(foreach bin,$(AGENT_BINARIES),$(eval $(call build-linux,$(bin),"agent")))
 
 # Create helper targets for each binary, like "pilot-discovery"
 # As an optimization, these still build everything
@@ -366,10 +375,6 @@ gen-kustomize:
 #-----------------------------------------------------------------------------
 # Target: go build
 #-----------------------------------------------------------------------------
-
-# gobuild script uses custom linker flag to set the variables.
-
-RELEASE_LDFLAGS='-extldflags -static -s -w'
 
 # Non-static istioctl targets. These are typically a build artifact.
 ${ISTIO_OUT}/release/istioctl-linux-amd64: depend

--- a/pilot/pkg/xds/v2/model.go
+++ b/pilot/pkg/xds/v2/model.go
@@ -14,9 +14,7 @@
 
 package v2
 
-import "github.com/envoyproxy/go-control-plane/pkg/resource/v2"
-
 const (
 	// EndpointType is used for EDS and ADS endpoint discovery. Typically second request.
-	EndpointType = resource.EndpointType
+	EndpointType = "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment"
 )

--- a/pkg/config/xds/filter_types.gen.go
+++ b/pkg/config/xds/filter_types.gen.go
@@ -1,3 +1,4 @@
+// +build !agent
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/config/xds/filter_types.go
+++ b/pkg/config/xds/filter_types.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:generate sh -c "echo '// Copyright Istio Authors' > filter_types.gen.go"
+//go:generate sh -c "echo '// +build !agent' > filter_types.gen.go"
+//go:generate sh -c "echo '// Copyright Istio Authors' >> filter_types.gen.go"
 //go:generate sh -c "echo '//' >> filter_types.gen.go"
 //go:generate sh -c "echo '// Licensed under the Apache License, Version 2.0 (the \"License\");' >> filter_types.gen.go"
 //go:generate sh -c "echo '// you may not use this file except in compliance with the License.' >> filter_types.gen.go"


### PR DESCRIPTION
Part of https://github.com/istio/istio/issues/26232

75mb -> 64mb

We could have also done massive refactoring to avoid using build tags,
but I think in the near future we will need build tags for dropping k8s
import, so it seems useful to implement this at least for the short
term.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.