### PR TITLE
Move fake XDS server into dedicated package

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway_simulation_test.go
@@ -19,7 +19,7 @@ import (
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/simulation"
-	"istio.io/istio/pilot/pkg/xds"
+	"istio.io/istio/pilot/pkg/xds/xdsfake"
 	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/pkg/test/util/tmpl"
 	"istio.io/pkg/env"
@@ -597,16 +597,16 @@ func runGatewayTest(t *testing.T, cases ...simulationTest) {
 				Metadata: &model.NodeMetadata{Labels: map[string]string{"istio": "ingressgateway"}},
 				Type:     model.Router,
 			}
-			runSimulationTest(t, proxy, xds.FakeOptions{}, tt)
+			runSimulationTest(t, proxy, xdsfake.Options{}, tt)
 		})
 	}
 }
 
-func runSimulationTest(t *testing.T, proxy *model.Proxy, o xds.FakeOptions, tt simulationTest) {
+func runSimulationTest(t *testing.T, proxy *model.Proxy, o xdsfake.Options, tt simulationTest) {
 	runTest := func(t *testing.T) {
 		o.ConfigString = tt.config
 		o.KubernetesObjectString = tt.kubeConfig
-		s := xds.NewFakeDiscoveryServer(t, o)
+		s := xdsfake.NewDiscoveryServer(t, o)
 		sim := simulation.NewSimulation(t, s, s.SetupProxy(proxy))
 		sim.RunExpectations(tt.calls)
 		if t.Failed() && debugMode {

--- a/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
@@ -22,7 +22,7 @@ import (
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/simulation"
-	"istio.io/istio/pilot/pkg/xds"
+	"istio.io/istio/pilot/pkg/xds/xdsfake"
 	"istio.io/istio/pkg/config/mesh"
 )
 
@@ -58,7 +58,7 @@ spec:
     number: 81
 ---
 `
-	runSimulationTest(t, nil, xds.FakeOptions{}, simulationTest{
+	runSimulationTest(t, nil, xdsfake.Options{}, simulationTest{
 		name:   "disable",
 		config: svc + mtlsMode("DISABLE"),
 		calls: []simulation.Expect{
@@ -152,7 +152,7 @@ spec:
 		},
 	})
 
-	runSimulationTest(t, nil, xds.FakeOptions{}, simulationTest{
+	runSimulationTest(t, nil, xdsfake.Options{}, simulationTest{
 		name:   "permissive",
 		config: svc + mtlsMode("PERMISSIVE"),
 		calls: []simulation.Expect{
@@ -370,7 +370,7 @@ spec:
 		},
 	})
 
-	runSimulationTest(t, nil, xds.FakeOptions{}, simulationTest{
+	runSimulationTest(t, nil, xdsfake.Options{}, simulationTest{
 		name:           "strict",
 		config:         svc + mtlsMode("STRICT"),
 		skipValidation: false,
@@ -537,7 +537,7 @@ func TestHeadlessServices(t *testing.T) {
 			},
 		})
 	}
-	runSimulationTest(t, nil, xds.FakeOptions{}, simulationTest{
+	runSimulationTest(t, nil, xdsfake.Options{}, simulationTest{
 		kubeConfig: `apiVersion: v1
 kind: Service
 metadata:
@@ -625,7 +625,7 @@ func TestPassthroughTraffic(t *testing.T) {
 		meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY,
 	} {
 		t.Run(tp.String(), func(t *testing.T) {
-			o := xds.FakeOptions{
+			o := xdsfake.Options{
 				MeshConfig: func() *meshconfig.MeshConfig {
 					m := mesh.DefaultMeshConfig()
 					m.OutboundTrafficPolicy.Mode = tp
@@ -720,7 +720,7 @@ spec:
 }
 
 func TestLoop(t *testing.T) {
-	runSimulationTest(t, nil, xds.FakeOptions{}, simulationTest{
+	runSimulationTest(t, nil, xdsfake.Options{}, simulationTest{
 		calls: []simulation.Expect{
 			{
 				Name: "direct request to outbound port",

--- a/pilot/pkg/serviceregistry/serviceregistry_test.go
+++ b/pilot/pkg/serviceregistry/serviceregistry_test.go
@@ -36,7 +36,7 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	kubecontroller "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
-	"istio.io/istio/pilot/pkg/xds"
+	"istio.io/istio/pilot/pkg/xds/xdsfake"
 	"istio.io/istio/pilot/test/util"
 	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/pkg/config"
@@ -656,7 +656,7 @@ func TestWorkloadInstances(t *testing.T) {
 	})
 
 	t.Run("Service selects WorkloadEntry: update service", func(t *testing.T) {
-		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+		s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 		makeService(t, s.KubeClient(), service)
 		makeIstioObject(t, s.Store(), workloadEntry)
 		expectEndpoints(t, s, "outbound|80||service.namespace.svc.cluster.local", []string{"2.3.4.5:80"})
@@ -679,7 +679,7 @@ func TestWorkloadInstances(t *testing.T) {
 	})
 
 	t.Run("Service selects WorkloadEntry: update workloadEntry", func(t *testing.T) {
-		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+		s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 		makeService(t, s.KubeClient(), service)
 		makeIstioObject(t, s.Store(), workloadEntry)
 		expectEndpoints(t, s, "outbound|80||service.namespace.svc.cluster.local", []string{"2.3.4.5:80"})
@@ -696,7 +696,7 @@ func TestWorkloadInstances(t *testing.T) {
 	})
 
 	t.Run("ServiceEntry selects Pod: update service entry", func(t *testing.T) {
-		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+		s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 		makeIstioObject(t, s.Store(), serviceEntry)
 		makePod(t, s.KubeClient(), pod)
 		expectEndpoints(t, s, "outbound|80||service.namespace.svc.cluster.local", []string{"1.2.3.4:80"})
@@ -730,7 +730,7 @@ func TestWorkloadInstances(t *testing.T) {
 	})
 
 	t.Run("ServiceEntry selects Pod: update pod", func(t *testing.T) {
-		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+		s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 		makeIstioObject(t, s.Store(), serviceEntry)
 		makePod(t, s.KubeClient(), pod)
 		expectEndpoints(t, s, "outbound|80||service.namespace.svc.cluster.local", []string{"1.2.3.4:80"})
@@ -759,7 +759,7 @@ func waitForEdsUpdate(t *testing.T, xdsUpdater *FakeXdsUpdater, expected int) {
 }
 
 func TestEndpointsDeduping(t *testing.T) {
-	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
+	s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{
 		KubernetesEndpointMode: kubecontroller.EndpointSliceOnly,
 	})
 	namespace := "namespace"
@@ -834,7 +834,7 @@ type ServiceInstanceResponse struct {
 	Port       uint32
 }
 
-func expectEndpoints(t *testing.T, s *xds.FakeDiscoveryServer, cluster string, expected []string) {
+func expectEndpoints(t *testing.T, s *xdsfake.DiscoveryServer, cluster string, expected []string) {
 	t.Helper()
 	retry.UntilSuccessOrFail(t, func() error {
 		got := xdstest.ExtractLoadAssignments(s.Endpoints(s.SetupProxy(nil)))

--- a/pilot/pkg/simulation/traffic.go
+++ b/pilot/pkg/simulation/traffic.go
@@ -34,8 +34,8 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3"
 	"istio.io/istio/pilot/pkg/util/sets"
-	"istio.io/istio/pilot/pkg/xds"
 	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
+	"istio.io/istio/pilot/pkg/xds/xdsfake"
 	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/test"
@@ -205,7 +205,7 @@ func NewSimulationFromConfigGen(t *testing.T, s *v1alpha3.ConfigGenTest, proxy *
 	return sim
 }
 
-func NewSimulation(t *testing.T, s *xds.FakeDiscoveryServer, proxy *model.Proxy) *Simulation {
+func NewSimulation(t *testing.T, s *xdsfake.DiscoveryServer, proxy *model.Proxy) *Simulation {
 	return NewSimulationFromConfigGen(t, s.ConfigGenTest, proxy)
 }
 

--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -31,6 +31,7 @@ import (
 	"istio.io/istio/pilot/pkg/util/sets"
 	"istio.io/istio/pilot/pkg/xds"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pilot/pkg/xds/xdsfake"
 	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/pkg/adsc"
 	"istio.io/istio/pkg/config"
@@ -171,7 +172,7 @@ func testAdscTLS(t *testing.T, creds security.SecretManager) {
 }
 
 func TestInternalEvents(t *testing.T) {
-	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+	s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 
 	ads := s.Connect(
 		&model.Proxy{
@@ -210,7 +211,7 @@ func TestInternalEvents(t *testing.T) {
 }
 
 func TestAdsReconnectAfterRestart(t *testing.T) {
-	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+	s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 
 	ads := s.ConnectADS().WithType(v3.EndpointType)
 	res := ads.RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: []string{"fake-cluster"}})
@@ -227,7 +228,7 @@ func TestAdsReconnectAfterRestart(t *testing.T) {
 }
 
 func TestAdsUnsubscribe(t *testing.T) {
-	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+	s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 
 	ads := s.ConnectADS().WithType(v3.EndpointType)
 	res := ads.RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: []string{"fake-cluster"}})
@@ -241,7 +242,7 @@ func TestAdsUnsubscribe(t *testing.T) {
 
 // Regression for envoy restart and overlapping connections
 func TestAdsReconnect(t *testing.T) {
-	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+	s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 	ads := s.ConnectADS().WithType(v3.ClusterType)
 	ads.RequestResponseAck(nil)
 
@@ -258,7 +259,7 @@ func TestAdsReconnect(t *testing.T) {
 }
 
 func TestAdsClusterUpdate(t *testing.T) {
-	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+	s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 	ads := s.ConnectADS().WithType(v3.EndpointType)
 
 	version := ""
@@ -288,7 +289,7 @@ func TestAdsClusterUpdate(t *testing.T) {
 
 // nolint: lll
 func TestAdsPushScoping(t *testing.T) {
-	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+	s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 
 	const (
 		svcSuffix = ".testPushScoping.com"
@@ -692,7 +693,7 @@ func TestAdsPushScoping(t *testing.T) {
 }
 
 func TestAdsUpdate(t *testing.T) {
-	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+	s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 	ads := s.ConnectADS()
 
 	s.Discovery.MemRegistry.AddService("adsupdate.default.svc.cluster.local", &model.Service{
@@ -739,7 +740,7 @@ func TestAdsUpdate(t *testing.T) {
 }
 
 func TestEnvoyRDSProtocolError(t *testing.T) {
-	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+	s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 	ads := s.ConnectADS().WithType(v3.RouteType)
 	ads.RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: []string{routeA}})
 
@@ -769,7 +770,7 @@ func TestBlockedPush(t *testing.T) {
 	})
 	t.Run("flow control enabled", func(t *testing.T) {
 		features.EnableFlowControl = true
-		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+		s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 		ads := s.ConnectADS().WithType(v3.ClusterType)
 		ads.RequestResponseAck(nil)
 		// Send push, get a response but do not ACK it
@@ -798,7 +799,7 @@ func TestBlockedPush(t *testing.T) {
 	t.Run("flow control enabled NACK", func(t *testing.T) {
 		log.FindScope("ads").SetOutputLevel(log.DebugLevel)
 		features.EnableFlowControl = true
-		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+		s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 		ads := s.ConnectADS().WithType(v3.ClusterType)
 		ads.RequestResponseAck(nil)
 
@@ -817,7 +818,7 @@ func TestBlockedPush(t *testing.T) {
 	})
 	t.Run("flow control disabled", func(t *testing.T) {
 		features.EnableFlowControl = false
-		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+		s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 		ads := s.ConnectADS().WithType(v3.ClusterType)
 		ads.RequestResponseAck(nil)
 		// Send push, get a response but do not ACK it
@@ -842,7 +843,7 @@ func TestEnvoyRDSUpdatedRouteRequest(t *testing.T) {
 			t.Fatalf("expected routes %v got %v", expected, got)
 		}
 	}
-	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+	s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 	ads := s.ConnectADS().WithType(v3.RouteType)
 	resp := ads.RequestResponseAck(&discovery.DiscoveryRequest{ResourceNames: []string{routeA}})
 	expectRoutes(resp, routeA)
@@ -894,7 +895,7 @@ func TestXdsCache(t *testing.T) {
 		}
 	}
 
-	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
+	s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{
 		Configs: []config.Config{
 			makeEndpoint([]*networking.WorkloadEntry{
 				{Address: "1.2.3.4", Locality: "region/zone"},

--- a/pilot/pkg/xds/cds_test.go
+++ b/pilot/pkg/xds/cds_test.go
@@ -16,12 +16,12 @@ package xds_test
 import (
 	"testing"
 
-	"istio.io/istio/pilot/pkg/xds"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pilot/pkg/xds/xdsfake"
 )
 
 func TestCDS(t *testing.T) {
-	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+	s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 	ads := s.ConnectADS().WithType(v3.ClusterType)
 	ads.RequestResponseAck(nil)
 }

--- a/pilot/pkg/xds/debug_test.go
+++ b/pilot/pkg/xds/debug_test.go
@@ -27,11 +27,12 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/xds"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pilot/pkg/xds/xdsfake"
 )
 
 func TestSyncz(t *testing.T) {
 	t.Run("return the sent and ack status of adsClient connections", func(t *testing.T) {
-		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+		s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 		ads := s.ConnectADS()
 
 		ads.RequestResponseAck(&discovery.DiscoveryRequest{TypeUrl: v3.ClusterType})
@@ -49,7 +50,7 @@ func TestSyncz(t *testing.T) {
 		verifySyncStatus(t, s.Discovery, node.ID, true, true)
 	})
 	t.Run("sync status not set when Nackd", func(t *testing.T) {
-		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+		s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 		ads := s.ConnectADS()
 
 		ads.RequestResponseNack(&discovery.DiscoveryRequest{TypeUrl: v3.ClusterType})
@@ -154,7 +155,7 @@ func TestConfigDump(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+			s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 			ads := s.ConnectADS()
 			ads.RequestResponseAck(&discovery.DiscoveryRequest{TypeUrl: v3.ClusterType})
 			ads.RequestResponseAck(&discovery.DiscoveryRequest{TypeUrl: v3.ListenerType})
@@ -201,7 +202,7 @@ func getConfigDump(t *testing.T, s *xds.DiscoveryServer, proxyID string, wantCod
 }
 
 func TestDebugHandlers(t *testing.T) {
-	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+	s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 	req, err := http.NewRequest("GET", "/debug", nil)
 	if err != nil {
 		t.Fatal(err)

--- a/pilot/pkg/xds/discovery_test.go
+++ b/pilot/pkg/xds/discovery_test.go
@@ -28,6 +28,7 @@ import (
 
 	"istio.io/istio/pilot/pkg/model"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pilot/pkg/xds/xdsfake"
 	"istio.io/istio/pkg/test/util/retry"
 )
 
@@ -462,7 +463,7 @@ func TestShouldRespond(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewFakeDiscoveryServer(t, FakeOptions{})
+			s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 			if response := s.Discovery.shouldRespond(tt.connection, tt.request); response != tt.response {
 				t.Fatalf("Unexpected value for response, expected %v, got %v", tt.response, response)
 			}

--- a/pilot/pkg/xds/eds_sh_test.go
+++ b/pilot/pkg/xds/eds_sh_test.go
@@ -28,8 +28,8 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	"istio.io/istio/pilot/pkg/serviceregistry/memory"
-	"istio.io/istio/pilot/pkg/xds"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pilot/pkg/xds/xdsfake"
 	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/protocol"
@@ -48,7 +48,7 @@ type expectedResults struct {
 // the Split Horizon EDS - all local endpoints + endpoint per remote network that also has
 // endpoints for the service.
 func TestSplitHorizonEds(t *testing.T) {
-	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+	s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 
 	// Set up a cluster registry for network 1 with 1 instance for the service 'service5'
 	// Network has 1 gateway
@@ -155,7 +155,7 @@ func TestSplitHorizonEds(t *testing.T) {
 }
 
 // Tests whether an EDS response from the provided network matches the expected results
-func verifySplitHorizonResponse(t *testing.T, s *xds.FakeDiscoveryServer, network string, sidecarID string, expected expectedResults) {
+func verifySplitHorizonResponse(t *testing.T, s *xdsfake.DiscoveryServer, network string, sidecarID string, expected expectedResults) {
 	t.Helper()
 	ads := s.ConnectADS().WithID(sidecarID)
 
@@ -213,7 +213,7 @@ func verifySplitHorizonResponse(t *testing.T, s *xds.FakeDiscoveryServer, networ
 // initRegistry creates and initializes a memory registry that holds a single
 // service with the provided amount of endpoints. It also creates a service for
 // the ingress with the provided external IP
-func initRegistry(server *xds.FakeDiscoveryServer, clusterNum int, gatewaysIP []string, numOfEndpoints int) {
+func initRegistry(server *xdsfake.DiscoveryServer, clusterNum int, gatewaysIP []string, numOfEndpoints int) {
 	id := fmt.Sprintf("network%d", clusterNum)
 	memRegistry := memory.NewServiceDiscovery(nil)
 	memRegistry.EDSUpdater = server.Discovery
@@ -282,7 +282,7 @@ func initRegistry(server *xds.FakeDiscoveryServer, clusterNum int, gatewaysIP []
 	memRegistry.SetEndpoints("service5.default.svc.cluster.local", "default", istioEndpoints)
 }
 
-func addNetwork(server *xds.FakeDiscoveryServer, id string, network *meshconfig.Network) {
+func addNetwork(server *xdsfake.DiscoveryServer, id string, network *meshconfig.Network) {
 	meshNetworks := *server.Env().Networks()
 	c := map[string]*meshconfig.Network{}
 	for k, v := range meshNetworks.Networks {

--- a/pilot/pkg/xds/lds_test.go
+++ b/pilot/pkg/xds/lds_test.go
@@ -30,8 +30,8 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/memory"
-	"istio.io/istio/pilot/pkg/xds"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pilot/pkg/xds/xdsfake"
 	"istio.io/istio/pkg/adsc"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/test/env"
@@ -40,7 +40,7 @@ import (
 
 // TestLDS using isolated namespaces
 func TestLDSIsolated(t *testing.T) {
-	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{ConfigString: mustReadfolder(t, "tests/testdata/config")})
+	s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{ConfigString: mustReadfolder(t, "tests/testdata/config")})
 
 	// Sidecar in 'none' mode
 	t.Run("sidecar_none", func(t *testing.T) {
@@ -247,14 +247,14 @@ func TestLDSWithIngressGateway(t *testing.T) {
 // TestLDS is running LDS tests.
 func TestLDS(t *testing.T) {
 	t.Run("sidecar", func(t *testing.T) {
-		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+		s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 		ads := s.ConnectADS().WithType(v3.ListenerType)
 		ads.RequestResponseAck(nil)
 	})
 
 	// 'router' or 'gateway' type of listener
 	t.Run("gateway", func(t *testing.T) {
-		s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{ConfigString: mustReadfolder(t, "tests/testdata/config")})
+		s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{ConfigString: mustReadfolder(t, "tests/testdata/config")})
 		// Matches Gateway config in test data
 		labels := map[string]string{"version": "v2", "app": "my-gateway-controller"}
 		ads := s.ConnectADS().WithType(v3.ListenerType).WithID(gatewayID(gatewayIP))

--- a/pilot/pkg/xds/mesh_network_test.go
+++ b/pilot/pkg/xds/mesh_network_test.go
@@ -31,6 +31,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
+	"istio.io/istio/pilot/pkg/xds/xdsfake"
 	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/labels"
@@ -240,7 +241,7 @@ func runMeshNetworkingTest(t *testing.T, tt meshNetworkingTest) {
 		}
 		configObjects = append(configObjects, w.configs()...)
 	}
-	s := NewFakeDiscoveryServer(t, FakeOptions{
+	s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{
 		KubernetesObjectsByCluster: kubeObjects,
 		Configs:                    configObjects,
 		NetworksWatcher:            mesh.NewFixedNetworksWatcher(tt.meshNetworkConfig),
@@ -340,7 +341,7 @@ func (w *workload) configs() []config.Config {
 	return nil
 }
 
-func (w *workload) setupProxy(s *FakeDiscoveryServer) *model.Proxy {
+func (w *workload) setupProxy(s *xdsfake.DiscoveryServer) *model.Proxy {
 	if w.proxy == nil {
 		p := &model.Proxy{
 			ID: strings.Join([]string{w.name, w.namespace}, "."),

--- a/pilot/pkg/xds/nds_test.go
+++ b/pilot/pkg/xds/nds_test.go
@@ -24,12 +24,12 @@ import (
 
 	"istio.io/istio/pilot/pkg/model"
 	nds "istio.io/istio/pilot/pkg/proto"
-	"istio.io/istio/pilot/pkg/xds"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pilot/pkg/xds/xdsfake"
 )
 
 func TestNDS(t *testing.T) {
-	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{
+	s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{
 		ConfigString: mustReadFile(t, "./testdata/nds-se.yaml"),
 	})
 

--- a/pilot/pkg/xds/rds_test.go
+++ b/pilot/pkg/xds/rds_test.go
@@ -18,8 +18,8 @@ import (
 
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
-	"istio.io/istio/pilot/pkg/xds"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pilot/pkg/xds/xdsfake"
 )
 
 func TestRDS(t *testing.T) {
@@ -47,7 +47,7 @@ func TestRDS(t *testing.T) {
 		},
 	}
 
-	s := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+	s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ads := s.ConnectADS().WithType(v3.RouteType).WithID(tt.node)

--- a/pilot/pkg/xds/sds_test.go
+++ b/pilot/pkg/xds/sds_test.go
@@ -29,6 +29,7 @@ import (
 	kubesecrets "istio.io/istio/pilot/pkg/secrets/kube"
 	authnmodel "istio.io/istio/pilot/pkg/security/model"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pilot/pkg/xds/xdsfake"
 	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/spiffe"
@@ -308,7 +309,7 @@ func TestGenerate(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewFakeDiscoveryServer(t, FakeOptions{
+			s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{
 				KubernetesObjects: []runtime.Object{genericCert, genericMtlsCert, genericMtlsCertSplit, genericMtlsCertSplitCa},
 			})
 			cc := s.KubeClient().Kube().(*fake.Clientset)

--- a/pilot/pkg/xds/xds_test.go
+++ b/pilot/pkg/xds/xds_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/xds/xdsfake"
 	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/env"
@@ -175,7 +176,7 @@ func TestServiceScoping(t *testing.T) {
 	}
 
 	t.Run("STATIC", func(t *testing.T) {
-		s := NewFakeDiscoveryServer(t, FakeOptions{
+		s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{
 			ConfigString: scopeConfig,
 			ConfigTemplateInput: SidecarTestConfig{
 				ImportedNamespaces: []string{"./*", "included/*"},
@@ -198,7 +199,7 @@ func TestServiceScoping(t *testing.T) {
 	})
 
 	t.Run("Ingress Listener", func(t *testing.T) {
-		s := NewFakeDiscoveryServer(t, FakeOptions{
+		s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{
 			ConfigString: scopeConfig,
 			ConfigTemplateInput: SidecarTestConfig{
 				ImportedNamespaces: []string{"./*", "included/*"},
@@ -226,7 +227,7 @@ func TestServiceScoping(t *testing.T) {
 	})
 
 	t.Run("DNS", func(t *testing.T) {
-		s := NewFakeDiscoveryServer(t, FakeOptions{
+		s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{
 			ConfigString: scopeConfig,
 			ConfigTemplateInput: SidecarTestConfig{
 				ImportedNamespaces: []string{"./*", "included/*"},
@@ -239,7 +240,7 @@ func TestServiceScoping(t *testing.T) {
 	})
 
 	t.Run("DNS no self import", func(t *testing.T) {
-		s := NewFakeDiscoveryServer(t, FakeOptions{
+		s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{
 			ConfigString: scopeConfig,
 			ConfigTemplateInput: SidecarTestConfig{
 				ImportedNamespaces: []string{"included/*"},
@@ -254,7 +255,7 @@ func TestServiceScoping(t *testing.T) {
 
 func TestSidecarListeners(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		s := NewFakeDiscoveryServer(t, FakeOptions{})
+		s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 		proxy := s.SetupProxy(&model.Proxy{
 			IPAddresses: []string{"10.2.0.1"},
 			ID:          "app3.testns",
@@ -272,7 +273,7 @@ func TestSidecarListeners(t *testing.T) {
 	})
 
 	t.Run("mongo", func(t *testing.T) {
-		s := NewFakeDiscoveryServer(t, FakeOptions{
+		s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{
 			ConfigString: mustReadFile(t, "./tests/testdata/config/se-example.yaml"),
 		})
 		proxy := s.SetupProxy(&model.Proxy{
@@ -299,7 +300,7 @@ func TestSidecarListeners(t *testing.T) {
 }
 
 func TestEgressProxy(t *testing.T) {
-	s := NewFakeDiscoveryServer(t, FakeOptions{
+	s := xdsfake.NewDiscoveryServer(t, xdsfake.Options{
 		ConfigString: `
 # Add a random endpoint, otherwise there will be no routes to check
 apiVersion: networking.istio.io/v1alpha3

--- a/pkg/istio-agent/xds_proxy_test.go
+++ b/pkg/istio-agent/xds_proxy_test.go
@@ -26,8 +26,8 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/test/bufconn"
 
-	"istio.io/istio/pilot/pkg/xds"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pilot/pkg/xds/xdsfake"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/security"
 	"istio.io/istio/pkg/test/env"
@@ -36,7 +36,7 @@ import (
 // Validates basic xds proxy flow by proxying one CDS requests end to end.
 func TestXdsProxyBasicFlow(t *testing.T) {
 	proxy := setupXdsProxy(t)
-	f := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+	f := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 	setDialOptions(proxy, f.Listener)
 	conn := setupDownstreamConnection(t)
 	downstream := stream(t, conn)
@@ -88,7 +88,7 @@ var ctx = metadata.AppendToOutgoingContext(context.Background(), "ClusterID", "K
 func TestXdsProxyReconnects(t *testing.T) {
 	t.Run("Envoy close and open stream", func(t *testing.T) {
 		proxy := setupXdsProxy(t)
-		f := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+		f := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 		setDialOptions(proxy, f.Listener)
 
 		conn := setupDownstreamConnection(t)
@@ -101,7 +101,7 @@ func TestXdsProxyReconnects(t *testing.T) {
 	})
 	t.Run("Envoy opens multiple stream", func(t *testing.T) {
 		proxy := setupXdsProxy(t)
-		f := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+		f := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 		setDialOptions(proxy, f.Listener)
 
 		conn := setupDownstreamConnection(t)
@@ -112,7 +112,7 @@ func TestXdsProxyReconnects(t *testing.T) {
 	})
 	t.Run("Envoy closes connection", func(t *testing.T) {
 		proxy := setupXdsProxy(t)
-		f := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+		f := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 		setDialOptions(proxy, f.Listener)
 
 		conn := setupDownstreamConnection(t)
@@ -125,7 +125,7 @@ func TestXdsProxyReconnects(t *testing.T) {
 	})
 	t.Run("Istiod closes connection", func(t *testing.T) {
 		proxy := setupXdsProxy(t)
-		f := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+		f := xdsfake.NewDiscoveryServer(t, xdsfake.Options{})
 
 		// Here we set up a real listener (instead of in memory) since we need to close and re-open
 		// a new listener on the same port, which we cannot do with the in memory listener.


### PR DESCRIPTION
Aside from general code hygiene, this is required by
https://github.com/istio/istio/issues/26232 to allow the agent to be
built without importing the entire world (ie Kubernetes)



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.