### PR TITLE
Drop dependency on the operator from the agent

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -536,13 +536,17 @@ func (s *Server) initIstiodAdminServer(args *PilotArgs, wh *inject.Webhook) erro
 		log.Info("initializing Istiod admin server")
 	}
 
+	whc := func() string {
+		return wh.Config.Template
+	}
+
 	// Debug Server.
-	s.XDSServer.InitDebug(s.monitoringMux, s.ServiceController(), args.ServerOptions.EnableProfiling, wh)
+	s.XDSServer.InitDebug(s.monitoringMux, s.ServiceController(), args.ServerOptions.EnableProfiling, whc)
 
 	// Debug handlers are currently added on monitoring mux and readiness mux.
 	// If monitoring addr is empty, the mux is shared and we only add it once on the shared mux .
 	if !shouldMultiplex {
-		s.XDSServer.AddDebugHandlers(s.httpMux, args.ServerOptions.EnableProfiling, wh)
+		s.XDSServer.AddDebugHandlers(s.httpMux, args.ServerOptions.EnableProfiling, whc)
 	}
 
 	// Monitoring Server.


### PR DESCRIPTION
Agent -> pkg/xds -> debug.go -> inject/ -> operator/

Cut the chain at debug.go to not import inject/

Agent binary size 77.9mb -> 76.8mb

Part of https://github.com/istio/istio/issues/26232

Also will be *required* long term to drop k8s dependency, so its not just 1mb