### PR TITLE
allow passing unset map to MostSpecificHostMatch

### DIFF
--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -258,9 +258,17 @@ func resolveGatewayName(gwname string, meta config.Meta) string {
 func MostSpecificHostMatch(needle host.Name, m map[host.Name]struct{}, stack []host.Name) (host.Name, bool) {
 	matches := []host.Name{}
 
-	// exact match, use map
-	if _, ok := m[needle]; ok {
-		return needle, true
+	// exact match first
+	if m != nil {
+		if _, ok := m[needle]; ok {
+			return needle, true
+		}
+	} else {
+		for _, h := range stack {
+			if h == needle {
+				return needle, true
+			}
+		}
 	}
 
 	if needle.IsWildCarded() {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -829,11 +829,7 @@ func (ps *PushContext) getExportedDestinationRuleFromNamespace(owningNamespace s
 // IsClusterLocal indicates whether the endpoints for the service should only be accessible to clients
 // within the cluster.
 func (ps *PushContext) IsClusterLocal(service *Service) bool {
-	m := make(map[host.Name]struct{}, len(ps.clusterLocalHosts))
-	for _, h := range ps.clusterLocalHosts {
-		m[h] = struct{}{}
-	}
-	_, ok := MostSpecificHostMatch(service.Hostname, m, ps.clusterLocalHosts)
+	_, ok := MostSpecificHostMatch(service.Hostname, nil, ps.clusterLocalHosts)
 	return ok
 }
 


### PR DESCRIPTION
Allow passing unset map to MostSpecificHostMatch to avoid allocs in IsClusterLocal.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[x] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
