### PR TITLE
bump Dockerfile.distroless to a multi-arch version gcr.io/distroless/static-debian10@sha256:5a4bd6a17f8d3c3e78df7ae62a95809e705c7315bccf59091af04b7b554cd037

### DIFF
--- a/docker/Dockerfile.distroless
+++ b/docker/Dockerfile.distroless
@@ -1,5 +1,5 @@
 # prepare a distroless source context to copy files from
-FROM gcr.io/distroless/static-debian10@sha256:4433370ec2b3b97b338674b4de5ffaef8ce5a38d1c9c0cb82403304b8718cde9 as distroless_source
+FROM gcr.io/distroless/static-debian10@sha256:5a4bd6a17f8d3c3e78df7ae62a95809e705c7315bccf59091af04b7b554cd037 as distroless_source
 
 # prepare a base dev to modify file contents
 FROM ubuntu:bionic as ubuntu_source
@@ -14,7 +14,7 @@ RUN echo isito-proxy:x:1337:1337:istio-proxy:/nonexistent:/sbin/nologin >> /home
 # - password file
 # - groups file
 # - /home/nonroot directory
-FROM gcr.io/distroless/static-debian10@sha256:4433370ec2b3b97b338674b4de5ffaef8ce5a38d1c9c0cb82403304b8718cde9
+FROM gcr.io/distroless/static-debian10@sha256:5a4bd6a17f8d3c3e78df7ae62a95809e705c7315bccf59091af04b7b554cd037
 COPY --from=ubuntu_source /home/etc/passwd /etc/passwd
 COPY --from=ubuntu_source /home/etc/group /etc/group
 COPY --from=ubuntu_source /home/nonroot /home/nonroot


### PR DESCRIPTION
Signed-off-by: Morlay <morlay.null@gmail.com>


Since multi-arch images of https://gcr.io/distroless/cc-debian10 and https://gcr.io/distroless/static-debian10 published,
We could updates Dockerfiles to support building multi-arch images

This will be a base of https://github.com/istio/istio/issues/26652


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.