### PR TITLE
Drop kube import from ca auth

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -66,6 +66,7 @@ import (
 	"istio.io/istio/security/pkg/pki/ca"
 	"istio.io/istio/security/pkg/pki/ra"
 	"istio.io/istio/security/pkg/server/ca/authenticate"
+	"istio.io/istio/security/pkg/server/ca/authenticate/kubeauth"
 	"istio.io/pkg/ctrlz"
 	"istio.io/pkg/filewatcher"
 	"istio.io/pkg/log"
@@ -313,7 +314,7 @@ func NewServer(args *PilotArgs) (*Server, error) {
 	// The JWT authenticator requires the multicluster registry to be initialized, so we build this later
 	authenticators := []authenticate.Authenticator{
 		&authenticate.ClientCertAuthenticator{},
-		authenticate.NewKubeJWTAuthenticator(s.kubeClient, s.clusterID, s.multicluster.GetRemoteKubeClient, spiffe.GetTrustDomain(), features.JwtPolicy.Get()),
+		kubeauth.NewKubeJWTAuthenticator(s.kubeClient, s.clusterID, s.multicluster.GetRemoteKubeClient, spiffe.GetTrustDomain(), features.JwtPolicy.Get()),
 	}
 
 	caOpts.Authenticators = authenticators

--- a/security/pkg/server/ca/authenticate/cert_authenticator.go
+++ b/security/pkg/server/ca/authenticate/cert_authenticator.go
@@ -25,9 +25,7 @@ import (
 )
 
 const (
-	bearerTokenPrefix = "Bearer "
-	authorizationMeta = "authorization"
-	clusterIDMeta     = "clusterid"
+	BearerTokenPrefix = "Bearer "
 
 	ClientCertAuthenticatorType = "ClientCertAuthenticator"
 )

--- a/security/pkg/server/ca/authenticate/cert_authenticator_test.go
+++ b/security/pkg/server/ca/authenticate/cert_authenticator_test.go
@@ -23,7 +23,6 @@ import (
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 
 	"istio.io/istio/security/pkg/pki/util"
@@ -122,70 +121,6 @@ func TestAuthenticate_clientCertAuthenticator(t *testing.T) {
 		if !reflect.DeepEqual(tc.caller, result) {
 			t.Errorf("Case %q: Unexpected authentication result: want %v but got %v",
 				id, tc.caller, result)
-		}
-	}
-}
-
-func TestExtractBearerToken(t *testing.T) {
-	testCases := map[string]struct {
-		metadata                 metadata.MD
-		expectedToken            string
-		extractBearerTokenErrMsg string
-	}{
-		"No metadata": {
-			expectedToken:            "",
-			extractBearerTokenErrMsg: "no metadata is attached",
-		},
-		"No auth header": {
-			metadata: metadata.MD{
-				"random": []string{},
-			},
-			expectedToken:            "",
-			extractBearerTokenErrMsg: "no HTTP authorization header exists",
-		},
-		"No bearer token": {
-			metadata: metadata.MD{
-				"random": []string{},
-				"authorization": []string{
-					"Basic callername",
-				},
-			},
-			expectedToken:            "",
-			extractBearerTokenErrMsg: "no bearer token exists in HTTP authorization header",
-		},
-		"With bearer token": {
-			metadata: metadata.MD{
-				"random": []string{},
-				"authorization": []string{
-					"Basic callername",
-					"Bearer bearer-token",
-				},
-			},
-			expectedToken: "bearer-token",
-		},
-	}
-
-	for id, tc := range testCases {
-		ctx := context.Background()
-		if tc.metadata != nil {
-			ctx = metadata.NewIncomingContext(ctx, tc.metadata)
-		}
-
-		actual, err := extractBearerToken(ctx)
-		if len(tc.extractBearerTokenErrMsg) > 0 {
-			if err == nil {
-				t.Errorf("Case %s: Succeeded. Error expected: %v", id, err)
-			} else if err.Error() != tc.extractBearerTokenErrMsg {
-				t.Errorf("Case %s: Incorrect error message: %s VS %s",
-					id, err.Error(), tc.extractBearerTokenErrMsg)
-			}
-			continue
-		} else if err != nil {
-			t.Fatalf("Case %s: Unexpected Error: %v", id, err)
-		}
-
-		if actual != tc.expectedToken {
-			t.Errorf("Case %q: Unexpected token: want %s but got %s", id, tc.expectedToken, actual)
 		}
 	}
 }

--- a/security/pkg/server/ca/authenticate/common.go
+++ b/security/pkg/server/ca/authenticate/common.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package authenticate
 
 import (

--- a/security/pkg/server/ca/authenticate/common.go
+++ b/security/pkg/server/ca/authenticate/common.go
@@ -1,0 +1,36 @@
+package authenticate
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"google.golang.org/grpc/metadata"
+)
+
+const (
+	// IdentityTemplate is the SPIFFE format template of the identity.
+	IdentityTemplate = "spiffe://%s/ns/%s/sa/%s"
+
+	authorizationMeta = "authorization"
+)
+
+func ExtractBearerToken(ctx context.Context) (string, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return "", fmt.Errorf("no metadata is attached")
+	}
+
+	authHeader, exists := md[authorizationMeta]
+	if !exists {
+		return "", fmt.Errorf("no HTTP authorization header exists")
+	}
+
+	for _, value := range authHeader {
+		if strings.HasPrefix(value, BearerTokenPrefix) {
+			return strings.TrimPrefix(value, BearerTokenPrefix), nil
+		}
+	}
+
+	return "", fmt.Errorf("no bearer token exists in HTTP authorization header")
+}

--- a/security/pkg/server/ca/authenticate/common_test.go
+++ b/security/pkg/server/ca/authenticate/common_test.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package authenticate
 
 import (

--- a/security/pkg/server/ca/authenticate/common_test.go
+++ b/security/pkg/server/ca/authenticate/common_test.go
@@ -1,0 +1,72 @@
+package authenticate
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/metadata"
+)
+
+func TestExtractBearerToken(t *testing.T) {
+	testCases := map[string]struct {
+		metadata                 metadata.MD
+		expectedToken            string
+		extractBearerTokenErrMsg string
+	}{
+		"No metadata": {
+			expectedToken:            "",
+			extractBearerTokenErrMsg: "no metadata is attached",
+		},
+		"No auth header": {
+			metadata: metadata.MD{
+				"random": []string{},
+			},
+			expectedToken:            "",
+			extractBearerTokenErrMsg: "no HTTP authorization header exists",
+		},
+		"No bearer token": {
+			metadata: metadata.MD{
+				"random": []string{},
+				"authorization": []string{
+					"Basic callername",
+				},
+			},
+			expectedToken:            "",
+			extractBearerTokenErrMsg: "no bearer token exists in HTTP authorization header",
+		},
+		"With bearer token": {
+			metadata: metadata.MD{
+				"random": []string{},
+				"authorization": []string{
+					"Basic callername",
+					"Bearer bearer-token",
+				},
+			},
+			expectedToken: "bearer-token",
+		},
+	}
+
+	for id, tc := range testCases {
+		ctx := context.Background()
+		if tc.metadata != nil {
+			ctx = metadata.NewIncomingContext(ctx, tc.metadata)
+		}
+
+		actual, err := ExtractBearerToken(ctx)
+		if len(tc.extractBearerTokenErrMsg) > 0 {
+			if err == nil {
+				t.Errorf("Case %s: Succeeded. Error expected: %v", id, err)
+			} else if err.Error() != tc.extractBearerTokenErrMsg {
+				t.Errorf("Case %s: Incorrect error message: %s VS %s",
+					id, err.Error(), tc.extractBearerTokenErrMsg)
+			}
+			continue
+		} else if err != nil {
+			t.Fatalf("Case %s: Unexpected Error: %v", id, err)
+		}
+
+		if actual != tc.expectedToken {
+			t.Errorf("Case %q: Unexpected token: want %s but got %s", id, tc.expectedToken, actual)
+		}
+	}
+}

--- a/security/pkg/server/ca/authenticate/kubeauth/kube_jwt_test.go
+++ b/security/pkg/server/ca/authenticate/kubeauth/kube_jwt_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package authenticate
+package kubeauth
 
 import (
 	"fmt"
@@ -29,6 +29,7 @@ import (
 
 	"istio.io/istio/pkg/jwt"
 	"istio.io/istio/pkg/security"
+	"istio.io/istio/security/pkg/server/ca/authenticate"
 )
 
 func TestNewKubeJWTAuthenticator(t *testing.T) {
@@ -89,7 +90,7 @@ func TestAuthenticate(t *testing.T) {
 				},
 			},
 			jwtPolicy:      jwt.PolicyFirstParty,
-			expectedID:     fmt.Sprintf(identityTemplate, "example.com", "default", "example-pod-sa"),
+			expectedID:     fmt.Sprintf(authenticate.IdentityTemplate, "example.com", "default", "example-pod-sa"),
 			expectedErrMsg: "",
 		},
 		"not found remote cluster results in error": {
@@ -111,7 +112,7 @@ func TestAuthenticate(t *testing.T) {
 			ctx := context.Background()
 			if tc.metadata != nil {
 				if tc.token != "" {
-					token := bearerTokenPrefix + tc.token
+					token := authenticate.BearerTokenPrefix + tc.token
 					tc.metadata.Append("authorization", token)
 				}
 				ctx = metadata.NewIncomingContext(ctx, tc.metadata)
@@ -169,8 +170,8 @@ func TestAuthenticate(t *testing.T) {
 				return
 			}
 
-			expectedCaller := &Caller{
-				AuthSource: AuthSourceIDToken,
+			expectedCaller := &authenticate.Caller{
+				AuthSource: authenticate.AuthSourceIDToken,
 				Identities: []string{tc.expectedID},
 			}
 

--- a/security/pkg/server/ca/authenticate/oidc.go
+++ b/security/pkg/server/ca/authenticate/oidc.go
@@ -52,7 +52,7 @@ func NewJwtAuthenticator(iss string, trustDomain, audience string) (*JwtAuthenti
 
 // Authenticate - based on the old OIDC authenticator for mesh expansion.
 func (j *JwtAuthenticator) Authenticate(ctx context.Context) (*Caller, error) {
-	bearerToken, err := extractBearerToken(ctx)
+	bearerToken, err := ExtractBearerToken(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("ID token extraction error: %v", err)
 	}
@@ -77,7 +77,7 @@ func (j *JwtAuthenticator) Authenticate(ctx context.Context) (*Caller, error) {
 
 	return &Caller{
 		AuthSource: AuthSourceIDToken,
-		Identities: []string{fmt.Sprintf(identityTemplate, j.trustDomain, ns, ksa)},
+		Identities: []string{fmt.Sprintf(IdentityTemplate, j.trustDomain, ns, ksa)},
 	}, nil
 }
 


### PR DESCRIPTION
Part of https://github.com/istio/istio/issues/26232

Importing k8s libraries adds up to 40mb to the binary. This, along with many other changes, allows completely dropping the imports and cutting the agent binary size in half. See https://github.com/howardjohn/istio/pull/new/agent/tiny-binary-full-branch for this end state.