### PR TITLE
Mirror http prober API

### DIFF
--- a/istioctl/cmd/kubeuninject.go
+++ b/istioctl/cmd/kubeuninject.go
@@ -119,7 +119,7 @@ func removeInjectedContainers(containers []corev1.Container, injectedContainerNa
 	return containers
 }
 
-func restoreAppProbes(containers []corev1.Container, probers map[string]*istioStatus.Prober) []corev1.Container {
+func restoreAppProbes(containers []corev1.Container, probers map[string]*inject.Prober) []corev1.Container {
 	re := regexp.MustCompile("/app-health/([a-z]+)/(readyz|livez|startupz)")
 	for name, prober := range probers {
 		matches := re.FindStringSubmatch(name)
@@ -160,7 +160,6 @@ func restoreAppProbes(containers []corev1.Container, probers map[string]*istioSt
 	}
 	return containers
 }
-
 func retrieveAppProbe(containers []corev1.Container) string {
 	for _, c := range containers {
 		if c.Name != proxyContainerName {
@@ -310,7 +309,7 @@ func extractObject(in runtime.Object) (interface{}, error) {
 		return out, nil
 	}
 
-	var appProbe istioStatus.KubeAppProbers
+	var appProbe inject.KubeAppProbers
 	appProbeStr := retrieveAppProbe(podSpec.Containers)
 	if appProbeStr != "" {
 		if err := json.Unmarshal([]byte(appProbeStr), &appProbe); err != nil {

--- a/istioctl/cmd/remove-from-mesh.go
+++ b/istioctl/cmd/remove-from-mesh.go
@@ -32,9 +32,9 @@ import (
 	"istio.io/api/annotation"
 	analyzer_util "istio.io/istio/galley/pkg/config/analysis/analyzers/util"
 	"istio.io/istio/istioctl/pkg/util/handlers"
-	istioStatus "istio.io/istio/pilot/cmd/pilot-agent/status"
 	"istio.io/istio/pkg/config/resource"
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/kube/inject"
 	"istio.io/pkg/log"
 )
 
@@ -223,7 +223,7 @@ func unInjectSideCarFromDeployment(client kubernetes.Interface, deps []appsv1.De
 			}
 		}
 
-		var appProbe istioStatus.KubeAppProbers
+		var appProbe inject.KubeAppProbers
 		appProbeStr := retrieveAppProbe(podSpec.Containers)
 		if appProbeStr != "" {
 			err := json.Unmarshal([]byte(appProbeStr), &appProbe)

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -37,12 +37,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/expfmt"
 	"go.opencensus.io/stats/view"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"istio.io/istio/pilot/cmd/pilot-agent/metrics"
 	"istio.io/istio/pilot/cmd/pilot-agent/status/ready"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/kube/apimirror"
 	"istio.io/pkg/env"
 	"istio.io/pkg/log"
 )
@@ -76,8 +76,8 @@ type KubeAppProbers map[string]*Prober
 
 // Prober represents a single container prober
 type Prober struct {
-	HTTPGet        *corev1.HTTPGetAction `json:"httpGet"`
-	TimeoutSeconds int32                 `json:"timeoutSeconds,omitempty"`
+	HTTPGet        *apimirror.HTTPGetAction `json:"httpGet"`
+	TimeoutSeconds int32                    `json:"timeoutSeconds,omitempty"`
 }
 
 // Config for the status server.
@@ -432,7 +432,7 @@ func (s *Server) handleAppProbe(w http.ResponseWriter, req *http.Request) {
 		proberPath = "/" + proberPath
 	}
 	var url string
-	if prober.HTTPGet.Scheme == corev1.URISchemeHTTPS {
+	if prober.HTTPGet.Scheme == apimirror.URISchemeHTTPS {
 		url = fmt.Sprintf("https://localhost:%v%s", prober.HTTPGet.Port.IntValue(), proberPath)
 	} else {
 		url = fmt.Sprintf("http://localhost:%v%s", prober.HTTPGet.Port.IntValue(), proberPath)

--- a/pilot/cmd/pilot-agent/status/server_test.go
+++ b/pilot/cmd/pilot-agent/status/server_test.go
@@ -30,9 +30,9 @@ import (
 	"time"
 
 	"github.com/prometheus/common/expfmt"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"istio.io/istio/pkg/kube/apimirror"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/pkg/log"
@@ -330,13 +330,13 @@ func TestAppProbe(t *testing.T) {
 
 	simpleConfig := KubeAppProbers{
 		"/app-health/hello-world/readyz": &Prober{
-			HTTPGet: &v1.HTTPGetAction{
+			HTTPGet: &apimirror.HTTPGetAction{
 				Path: "/hello/sunnyvale",
 				Port: intstr.IntOrString{IntVal: int32(appPort)},
 			},
 		},
 		"/app-health/hello-world/livez": &Prober{
-			HTTPGet: &v1.HTTPGetAction{
+			HTTPGet: &apimirror.HTTPGetAction{
 				Port: intstr.IntOrString{IntVal: int32(appPort)},
 			},
 		},
@@ -366,10 +366,10 @@ func TestAppProbe(t *testing.T) {
 			probePath: "app-health/header/readyz",
 			config: KubeAppProbers{
 				"/app-health/header/readyz": &Prober{
-					HTTPGet: &v1.HTTPGetAction{
+					HTTPGet: &apimirror.HTTPGetAction{
 						Port: intstr.IntOrString{IntVal: int32(appPort)},
 						Path: "/header",
-						HTTPHeaders: []v1.HTTPHeader{
+						HTTPHeaders: []apimirror.HTTPHeader{
 							{"Host", testHostValue},
 							{testHeader, testHeaderValue},
 						},
@@ -382,7 +382,7 @@ func TestAppProbe(t *testing.T) {
 			probePath: "app-health/hello-world/readyz",
 			config: KubeAppProbers{
 				"/app-health/hello-world/readyz": &Prober{
-					HTTPGet: &v1.HTTPGetAction{
+					HTTPGet: &apimirror.HTTPGetAction{
 						Path: "hello/texas",
 						Port: intstr.IntOrString{IntVal: int32(appPort)},
 					},
@@ -394,7 +394,7 @@ func TestAppProbe(t *testing.T) {
 			probePath: "app-health/hello-world/livez",
 			config: KubeAppProbers{
 				"/app-health/hello-world/livez": &Prober{
-					HTTPGet: &v1.HTTPGetAction{
+					HTTPGet: &apimirror.HTTPGetAction{
 						Path: "hello/texas",
 						Port: intstr.IntOrString{IntVal: int32(appPort)},
 					},

--- a/pkg/kube/apimirror/probe.go
+++ b/pkg/kube/apimirror/probe.go
@@ -1,0 +1,58 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apimirror
+
+import "k8s.io/apimachinery/pkg/util/intstr"
+
+// apimirror contains copies of Kubernetes APIs. This allows json serialization, without worrying about
+// importing the massive 15mb+ Kubernetes API libraries.
+
+// HTTPGetAction describes an action based on HTTP Get requests.
+type HTTPGetAction struct {
+	// Path to access on the HTTP server.
+	// +optional
+	Path string `json:"path,omitempty" protobuf:"bytes,1,opt,name=path"`
+	// Name or number of the port to access on the container.
+	// Number must be in the range 1 to 65535.
+	// Name must be an IANA_SVC_NAME.
+	Port intstr.IntOrString `json:"port" protobuf:"bytes,2,opt,name=port"`
+	// Host name to connect to, defaults to the pod IP. You probably want to set
+	// "Host" in httpHeaders instead.
+	// +optional
+	Host string `json:"host,omitempty" protobuf:"bytes,3,opt,name=host"`
+	// Scheme to use for connecting to the host.
+	// Defaults to HTTP.
+	// +optional
+	Scheme URIScheme `json:"scheme,omitempty" protobuf:"bytes,4,opt,name=scheme,casttype=URIScheme"`
+	// Custom headers to set in the request. HTTP allows repeated headers.
+	// +optional
+	HTTPHeaders []HTTPHeader `json:"httpHeaders,omitempty" protobuf:"bytes,5,rep,name=httpHeaders"`
+}
+
+// URIScheme identifies the scheme used for connection to a host for Get actions
+type URIScheme string
+
+const (
+	// URISchemeHTTPS means that the scheme used will be https://
+	URISchemeHTTPS URIScheme = "HTTPS"
+)
+
+// HTTPHeader describes a custom header to be used in HTTP probes
+type HTTPHeader struct {
+	// The header field name
+	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
+	// The header field value
+	Value string `json:"value" protobuf:"bytes,2,opt,name=value"`
+}

--- a/pkg/kube/apimirror/probe.go
+++ b/pkg/kube/apimirror/probe.go
@@ -12,12 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+
+// apimirror contains copies of Kubernetes APIs. This allows json serialization, without worrying about
+// importing the massive 15mb+ Kubernetes API libraries.
+// This is intended for import only by istio-agent. Any other binaries (Istiod) should likely import the
+// upstream Kubernetes API instead.
 package apimirror
 
 import "k8s.io/apimachinery/pkg/util/intstr"
 
-// apimirror contains copies of Kubernetes APIs. This allows json serialization, without worrying about
-// importing the massive 15mb+ Kubernetes API libraries.
 
 // HTTPGetAction describes an action based on HTTP Get requests.
 type HTTPGetAction struct {

--- a/pkg/kube/apimirror/probe.go
+++ b/pkg/kube/apimirror/probe.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 // apimirror contains copies of Kubernetes APIs. This allows json serialization, without worrying about
 // importing the massive 15mb+ Kubernetes API libraries.
 // This is intended for import only by istio-agent. Any other binaries (Istiod) should likely import the
@@ -20,7 +19,6 @@
 package apimirror
 
 import "k8s.io/apimachinery/pkg/util/intstr"
-
 
 // HTTPGetAction describes an action based on HTTP Get requests.
 type HTTPGetAction struct {

--- a/pkg/kube/inject/app_probe.go
+++ b/pkg/kube/inject/app_probe.go
@@ -72,11 +72,19 @@ func convertAppProber(probe *corev1.Probe, newURL string, statusPort int) *corev
 	return p
 }
 
+type KubeAppProbers map[string]*Prober
+
+// Prober represents a single container prober
+type Prober struct {
+	HTTPGet        *corev1.HTTPGetAction `json:"httpGet"`
+	TimeoutSeconds int32                 `json:"timeoutSeconds,omitempty"`
+}
+
 // DumpAppProbers returns a json encoded string as `status.KubeAppProbers`.
 // Also update the probers so that all usages of named port will be resolved to integer.
 func DumpAppProbers(podspec *corev1.PodSpec, targetPort int32) string {
-	out := status.KubeAppProbers{}
-	updateNamedPort := func(p *status.Prober, portMap map[string]int32) *status.Prober {
+	out := KubeAppProbers{}
+	updateNamedPort := func(p *Prober, portMap map[string]int32) *Prober {
 		if p == nil || p.HTTPGet == nil {
 			return nil
 		}
@@ -164,7 +172,7 @@ func patchRewriteProbe(annotations map[string]string, pod *corev1.Pod, defaultPo
 }
 
 // kubeProbeToInternalProber converts a Kubernetes Probe to an Istio internal Prober
-func kubeProbeToInternalProber(probe *corev1.Probe) *status.Prober {
+func kubeProbeToInternalProber(probe *corev1.Probe) *Prober {
 	if probe == nil {
 		return nil
 	}
@@ -173,7 +181,7 @@ func kubeProbeToInternalProber(probe *corev1.Probe) *status.Prober {
 		return nil
 	}
 
-	return &status.Prober{
+	return &Prober{
 		HTTPGet:        probe.HTTPGet,
 		TimeoutSeconds: probe.TimeoutSeconds,
 	}


### PR DESCRIPTION
Importing k8s libraries adds up to 40mb to the binary. This, along with many other changes, allows completely dropping the imports and cutting the agent binary size in half. See https://github.com/howardjohn/istio/pull/new/agent/tiny-binary-full-branch for this end state.