### PR TITLE
istioctl upgrade: check previous version of Istio is installed with revision.

### DIFF
--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -181,7 +181,7 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 		return fmt.Errorf("failed to fetch the existing istiod pod for checking revision, error: %v", err)
 	}
 	for _, pod := range pods.Items {
-		revision := pod.ObjectMeta.GetLabels()[label.IstioRev]
+		revision := pod.ObjectMeta.GetLabels()[label.IoIstioRev.Name]
 		// If --revision is not passed, istio.io/rev: default
 		if revision != "" && revision != "default" {
 			err = fmt.Errorf("can not upgrade because the previous version of Istio is installed with revision." +

--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -182,7 +182,7 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 	for _, pod := range pods.Items {
 		revision := pod.ObjectMeta.GetLabels()[label.IstioRev]
 		// If --revision is not passed, istio.io/rev: default
-		if revision != "" && revision != "default" {
+		if revision != "" && revision == "default" {
 			err = fmt.Errorf("can not upgrade because the previous version of Istio is installed with revision")
 		}
 	}

--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -188,7 +188,7 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 				"\nUse canary upgrades instead: " + url.CanaryUpgrades)
 		}
 	}
-	if err != nil {
+	if err != nil && !args.force {
 		return err
 	}
 	// Check if the upgrade currentVersion -> targetVersion is supported

--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -42,6 +42,7 @@ import (
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/operator/pkg/util/clog"
 	pkgversion "istio.io/istio/operator/pkg/version"
+	"istio.io/istio/pkg/url"
 	"istio.io/pkg/log"
 )
 
@@ -183,7 +184,8 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 		revision := pod.ObjectMeta.GetLabels()[label.IstioRev]
 		// If --revision is not passed, istio.io/rev: default
 		if revision != "" && revision != "default" {
-			err = fmt.Errorf("can not upgrade because the previous version of Istio is installed with revision")
+			err = fmt.Errorf("can not upgrade because the previous version of Istio is installed with revision." +
+				"\nUse canary upgrades instead: " + url.CanaryUpgrades)
 		}
 	}
 	if err != nil {

--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -31,6 +31,7 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 
+	"istio.io/api/label"
 	"istio.io/istio/istioctl/pkg/clioptions"
 	"istio.io/istio/istioctl/pkg/install/k8sversion"
 	"istio.io/istio/istioctl/pkg/verifier"
@@ -172,6 +173,22 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 		return fmt.Errorf("failed to read the current Istio version, error: %v", err)
 	}
 
+	// Upgrade won't work, if the previous version of Istio is installed with revision
+	// Ref: https://github.com/istio/istio/issues/28566
+	pods, err := kubeClient.PodsForSelector(istioNamespace, "app=istiod")
+	if err != nil {
+		return fmt.Errorf("failed to fetch istiod pod, error: %v", err)
+	}
+	for _, pod := range pods.Items {
+		revision := pod.ObjectMeta.GetLabels()[label.IstioRev]
+		// If --revision is not passed, istio.io/rev: default
+		if revision != "" && revision != "default" {
+			err = fmt.Errorf("can not upgrade because the previous version of Istio is installed with revision")
+		}
+	}
+	if err != nil {
+		return err
+	}
 	// Check if the upgrade currentVersion -> targetVersion is supported
 	err = checkSupportedVersions(kubeClient, currentVersion, targetVersion, l)
 	if err != nil && !args.force {

--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -178,7 +178,7 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 	// Ref: https://github.com/istio/istio/issues/28566
 	pods, err := kubeClient.PodsForSelector(istioNamespace, "app=istiod")
 	if err != nil {
-		return fmt.Errorf("failed to fetch istiod pod, error: %v", err)
+		return fmt.Errorf("failed to fetch the existing istiod pod for checking revision, error: %v", err)
 	}
 	for _, pod := range pods.Items {
 		revision := pod.ObjectMeta.GetLabels()[label.IstioRev]

--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -182,7 +182,7 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 	for _, pod := range pods.Items {
 		revision := pod.ObjectMeta.GetLabels()[label.IstioRev]
 		// If --revision is not passed, istio.io/rev: default
-		if revision != "" && revision == "default" {
+		if revision != "" && revision != "default" {
 			err = fmt.Errorf("can not upgrade because the previous version of Istio is installed with revision")
 		}
 	}

--- a/pkg/url/url.go
+++ b/pkg/url/url.go
@@ -55,6 +55,10 @@ var (
 	// https://istio.io/v1.7/docs/setup/additional-setup/sidecar-injection/#deploying-an-app
 	SidecarDeployingApp = fmt.Sprintf("%s%s", SetupURL, "additional-setup/sidecar-injection/#deploying-an-app")
 
+	// CanaryUpgrades should generate
+	// https://istio.io/v1.8/docs/setup/upgrade/canary
+	CanaryUpgrades = fmt.Sprintf("%s%s", SetupURL, "upgrade/canary")
+
 	// #####################################
 	// Tasks related URLs for istio.io
 	// #####################################


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/28566

Based on https://github.com/istio/istio/issues/28566#issuecomment-721937551

Before:
```
[istio-1.7.3] $ istioctl install -r 1-7-3

[1.8.0-alpha.2] $ istioctl upgrade
```
Goes into an infinite loop and the upgrade is never finished.
```
$ istioctl upgrade
2020-11-04T07:15:07.053176Z     info    proto: tag has too few fields: "-"
Control Plane - ingressgateway pod - istio-ingressgateway-5cf98b4d7d-vrqxc - version: 1.7.3
Control Plane - istiod pod - istiod-1-7-3-b5c499b7b-xzmvp - version: 1.7.3

Upgrade version check passed: 1.7.3 -> 1.8.0.

Confirm to proceed [y/N]? y
✔ Istio core installed                                                                                                                                             
✔ Istiod installed                                                                                                                                                 
✔ Ingress gateways installed                                                                                                                                       
✔ Installation complete                                                                                                                                            ..........
Control Plane - istiod pod - istiod-1-7-3-b5c499b7b-xzmvp - version: 1.7.3 does not match the target version 1.8.0
..........
Control Plane - istiod pod - istiod-1-7-3-b5c499b7b-xzmvp - version: 1.7.3 does not match the target version 1.8.0
..........
Control Plane - istiod pod - istiod-1-7-3-b5c499b7b-xzmvp - version: 1.7.3 does not match the target version 1.8.0
.
.
.
.
.
Control Plane - istiod pod - istiod-1-7-3-b5c499b7b-xzmvp - version: 1.7.3 does not match the target version 1.8.0
........
```

After:
```
$ ./out/linux_amd64/istioctl upgrade -d manifests/
2020-11-19T10:04:42.916754Z     info    proto: tag has too few fields: "-"
Control Plane - ingressgateway pod - istio-ingressgateway-69cccb7b54-sltvf - version: 1.8.0
Control Plane - istiod pod - istiod-1-8-0-7d9947f98b-z52zs - version: 1.8.0

2020-11-19T10:04:42.935391Z     info    Error: can not upgrade because the previous version of Istio is installed with revision.
Use canary upgrades instead: https://istio.io/v1.8/docs/setup/upgrade/canary

Error: can not upgrade because the previous version of Istio is installed with revision.
Use canary upgrades instead: https://istio.io/v1.8/docs/setup/upgrade/canary

```

Related:
https://github.com/istio/istio.io/pull/8447