### PR TITLE
Add 'Upgrade' product area to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,6 +20,7 @@ about: Report a bug to help us improve Istio
 [ ] Test and Release
 [ ] User Experience
 [ ] Developer Infrastructure
+[ ] Upgrade
 
 **Affected features (please put an X in all that apply)**
 


### PR DESCRIPTION
Adds `Upgrade[ ]` to our bug report issue template so that we can better track upgrade problems. Considered also adding `upgrading from` and `upgrading to` versions on the template but decided against. Accompanied by autolabeler change [here](https://github.com/istio/bots/pull/302) 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[x] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
