### PR TITLE
[1.7] Remove dependency on google.golang.org/api (#26242)

### DIFF
--- a/pkg/bootstrap/platform/gcp.go
+++ b/pkg/bootstrap/platform/gcp.go
@@ -16,6 +16,7 @@ package platform
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"regexp"
@@ -24,9 +25,8 @@ import (
 
 	"cloud.google.com/go/compute/metadata"
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	"google.golang.org/api/compute/v1"
-	"google.golang.org/api/option"
 
 	"istio.io/pkg/env"
 	"istio.io/pkg/log"
@@ -239,6 +239,8 @@ func (e *gcpEnv) Locality() *core.Locality {
 	return &l
 }
 
+const ComputeReadonlyScope = "https://www.googleapis.com/auth/compute.readonly"
+
 // Labels attempts to retrieve the GCE instance labels within the timeout
 // Requires read access to the Compute API (compute.instances.get)
 func (e *gcpEnv) Labels() map[string]string {
@@ -251,26 +253,28 @@ func (e *gcpEnv) Labels() map[string]string {
 	var instanceLabels map[string]string
 	go func() {
 		// use explicit credentials with compute.instances.get IAM permissions
-		creds, err := google.FindDefaultCredentials(ctx, compute.ComputeReadonlyScope)
+		creds, err := google.FindDefaultCredentials(ctx, ComputeReadonlyScope)
 		if err != nil {
 			log.Warnf("failed to find default credentials: %v", err)
 			success <- false
 			return
 		}
-		computeService, err := compute.NewService(ctx, option.WithCredentials(creds))
+		url := fmt.Sprintf("https://compute.googleapis.com/compute/v1/projects/%s/zones/%s/instances/%s", md[GCPProject], md[GCPLocation], md[GCEInstance])
+		resp, err := oauth2.NewClient(ctx, creds.TokenSource).Get(url)
 		if err != nil {
-			log.Warnf("failed to create new service: %v", err)
+			log.Warnf("unable to retrieve instance labels: %v", err)
+			success <- false
+			return
+
+		}
+		defer resp.Body.Close()
+		instance := &GcpInstance{}
+		if err := json.NewDecoder(resp.Body).Decode(instance); err != nil {
+			log.Warnf("failed to decode response: %v", err)
 			success <- false
 			return
 		}
-		// instance.Labels is nil if no labels are present
-		instanceObj, err := computeService.Instances.Get(md[GCPProject], md[GCPLocation], md[GCEInstance]).Do()
-		if err != nil {
-			log.Warnf("unable to retrieve instance: %v", err)
-			success <- false
-			return
-		}
-		instanceLabels = instanceObj.Labels
+		instanceLabels = instance.Labels
 		success <- true
 	}()
 	select {
@@ -282,6 +286,12 @@ func (e *gcpEnv) Labels() map[string]string {
 		}
 	}
 	return labels
+}
+
+// GcpInstance the instances response. Only contains fields we care about, rest are ignored
+type GcpInstance struct {
+	// Labels: Labels to apply to this instance.
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // Checks metadata to see if GKE metadata or Kubernetes env vars exist


### PR DESCRIPTION
* Remove dependency on google.golang.org/api

This dependency is ~22mb which bloats the binary

* lint
For https://github.com/istio/istio/issues/26232

Drops compiled agent from 78mb to 73mb