### PR TITLE
run iptables init container as non root user

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -314,8 +314,8 @@ data:
         {{- if not .Values.istio_cni.enabled }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsNonRoot: true
+          runAsUser: 1337
         {{- else }}
           readOnlyRootFilesystem: true
           runAsGroup: 1337

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -97,8 +97,8 @@ template: |
     {{- if not .Values.istio_cni.enabled }}
       readOnlyRootFilesystem: false
       runAsGroup: 0
-      runAsNonRoot: false
-      runAsUser: 0
+      runAsNonRoot: true
+      runAsUser: 1337
     {{- else }}
       readOnlyRootFilesystem: true
       runAsGroup: 1337

--- a/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -293,8 +293,8 @@ data:
         {{- if not .Values.istio_cni.enabled }}
           readOnlyRootFilesystem: false
           runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsNonRoot: true
+          runAsUser: 1337
         {{- else }}
           readOnlyRootFilesystem: true
           runAsGroup: 1337

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -97,8 +97,8 @@ template: |
     {{- if not .Values.istio_cni.enabled }}
       readOnlyRootFilesystem: false
       runAsGroup: 0
-      runAsNonRoot: false
-      runAsUser: 0
+      runAsNonRoot: true
+      runAsUser: 1337
     {{- else }}
       readOnlyRootFilesystem: true
       runAsGroup: 1337

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -13,11 +13,14 @@ COPY gcp_envoy_bootstrap.json /var/lib/istio/envoy/gcp_envoy_bootstrap_tmpl.json
 
 RUN chown -R istio-proxy /var/lib/istio
 
+RUN apt-get update && apt-get install --no-install-recommends -y libcap2-bin && apt-get clean && rm -rf  /var/log/*log /var/lib/apt/lists/* /var/log/apt/* /var/lib/dpkg/*-old /var/cache/debconf/*-old
+RUN chmod u+s /sbin/xtables-multi && setcap cap_net_admin,cap_net_raw=+eip /sbin/xtables-multi
+
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 FROM gcr.io/distroless/cc@sha256:f81e5db8287d66b012d874a6f7fea8da5b96d9cc509aa5a9b5d095a604d4bca1 as distroless
 
 # TODO(https://github.com/istio/istio/issues/17656) clean up this hack
-COPY --from=default /sbin/xtables-multi /sbin/iptables* /sbin/ip6tables* /sbin/ip /sbin/
+COPY --from=default /sbin/xtables-multi /sbin/iptables* /sbin/ip6tables* /sbin/ip /sbin/setcap /sbin/
 COPY --from=default /usr/lib/x86_64-linux-gnu/xtables/ /usr/lib/x86_64-linux-gnu/xtables
 COPY --from=default /usr/lib/x86_64-linux-gnu/ /usr/lib/x86_64-linux-gnu
 COPY --from=default /etc/iproute2 /etc/iproute2
@@ -45,6 +48,7 @@ ENV ISTIO_META_ISTIO_PROXY_SHA $proxy_version
 ENV ISTIO_META_ISTIO_VERSION $istio_version
 
 COPY pilot-agent /usr/local/bin/pilot-agent
+RUN setcap cap_net_admin,cap_net_raw=+eip /usr/local/bin/pilot-agent
 
 COPY stats-filter.wasm /etc/istio/extensions/stats-filter.wasm
 COPY stats-filter.compiled.wasm /etc/istio/extensions/stats-filter.compiled.wasm


### PR DESCRIPTION
It would be nice if the iptables initContainer would be run as non-root user.
This should be possible by adding the necessary capabilities to the pilot-agent and iptables.
Group 0 is still required as `iptables-restore` needs it to read the `/proc/net/ip_tables_names` file.

This PR resolves #28710

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.

I'm not entirely sure if I got all files which would have to be changed. I ran the resulting image in our cluster in combination
with an adjusted `istio-sidecar-injector` ConfigMap. (Our clusters enforce non-root User via PSP, but still allow group 0)
