### PR TITLE
Switch gRPC dial params on xds-proxy

### DIFF
--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -34,7 +34,6 @@ import (
 	"golang.org/x/oauth2"
 	google_rpc "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/oauth"
@@ -438,12 +437,7 @@ func (p *XdsProxy) buildUpstreamClientDialOpts(sa *Agent) ([]grpc.DialOption, er
 	// connection to upstream has been made.
 	dialOptions := []grpc.DialOption{
 		tlsOpts,
-		grpc.WithConnectParams(grpc.ConnectParams{
-			Backoff:           backoff.DefaultConfig,
-			MinConnectTimeout: 1 * time.Second,
-		}),
 		keepaliveOption, initialWindowSizeOption, initialConnWindowSizeOption, msgSizeOption,
-		grpc.WithBlock(),
 	}
 
 	// TODO: This is not a valid way of detecting if we are on VM vs k8s


### PR DESCRIPTION
Currently, we have a WithBlock, BackoffConfig, 5s timeout, and
(implicitly) Envoy's downstream retry/backoff logic. These
interact poorly.

Because we have a 5s timeout, the gRPC backoff config doesn't actually
work, since we are cutting it off. When its cut off, we get an error
like "context cancelled", rather than a useful one like "cert
verification failed".

This change drops the WithBlock and backoff config. Instead, we will
rely on Envoy's own retry and backoff logic.

The end result is we do not have any conflicting retry/backoff configs,
and the error messages when we fail to connect to istiod will now give
proper context.
