### PR TITLE
[1.7] Trim agent binary by 14mb by conditionally compiled XDS filters (#28670)

### DIFF
--- a/pilot/pkg/xds/v2/model.go
+++ b/pilot/pkg/xds/v2/model.go
@@ -14,15 +14,13 @@
 
 package v2
 
-import "github.com/envoyproxy/go-control-plane/pkg/resource/v2"
-
 const (
 	// ClusterType is used for cluster discovery. Typically first request received
-	ClusterType = resource.ClusterType
+	ClusterType = "type.googleapis.com/envoy.api.v2.Cluster"
 	// EndpointType is used for EDS and ADS endpoint discovery. Typically second request.
-	EndpointType = resource.EndpointType
+	EndpointType = "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment"
 	// ListenerType is sent after clusters and endpoints.
-	ListenerType = resource.ListenerType
+	ListenerType = "type.googleapis.com/envoy.api.v2.Listener"
 	// RouteType is sent after listeners.
-	RouteType = resource.RouteType
+	RouteType = "type.googleapis.com/envoy.api.v2.RouteConfiguration"
 )

--- a/pkg/config/xds/filter_types.gen.go
+++ b/pkg/config/xds/filter_types.gen.go
@@ -1,3 +1,4 @@
+// +build !agent
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/config/xds/filter_types.go
+++ b/pkg/config/xds/filter_types.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:generate sh -c "echo '// Copyright Istio Authors' > filter_types.gen.go"
+//go:generate sh -c "echo '// +build !agent' > filter_types.gen.go"
+//go:generate sh -c "echo '// Copyright Istio Authors' >> filter_types.gen.go"
 //go:generate sh -c "echo '//' >> filter_types.gen.go"
 //go:generate sh -c "echo '// Licensed under the Apache License, Version 2.0 (the \"License\");' >> filter_types.gen.go"
 //go:generate sh -c "echo '// you may not use this file except in compliance with the License.' >> filter_types.gen.go"


### PR DESCRIPTION
* Trim agent binary by 11mb by conditionally compiled XDS filters

Part of https://github.com/istio/istio/issues/26232

75mb -> 64mb

We could have also done massive refactoring to avoid using build tags,
but I think in the near future we will need build tags for dropping k8s
import, so it seems useful to implement this at least for the short
term.

* Trim another 4mb

(cherry picked from commit 19c8ea42031a5fb19c64654e6d8c9e468339460b)



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.