### PR TITLE
test framework: deploy gateways for remote clusters

### DIFF
--- a/tests/integration/iop-remote-integration-test-defaults.yaml
+++ b/tests/integration/iop-remote-integration-test-defaults.yaml
@@ -14,12 +14,6 @@ spec:
       enabled: false
     istiodRemote:
       enabled: true
-    ingressGateways:
-      - enabled: false
-        name: istio-ingressgateway
-    egressGateways:
-      - enabled: false
-        name: istio-egressgateway
   values:
     global:
       externalIstiod: true


### PR DESCRIPTION
Recent changed disabled ingress/egress – this brings them back and deploys eastwest in parallel. 

 Needed for multicluster testing of ingress, security, telemetry