### PR TITLE
Skip VM related parts for TestTraffic

### DIFF
--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -79,4 +79,7 @@ func init() {
 
 	flag.StringVar(&settingsFromCommandLine.Revision, "istio.test.revision", settingsFromCommandLine.Revision,
 		"If set to XXX, overwrite the default namespace label (istio-injection=enabled) with istio.io/rev=XXX.")
+
+	flag.BoolVar(&settingsFromCommandLine.SkipVM, "istio.test.skipVM", settingsFromCommandLine.SkipVM,
+		"Skip VM related parts in all tests.")
 }

--- a/pkg/test/framework/resource/settings.go
+++ b/pkg/test/framework/resource/settings.go
@@ -70,6 +70,9 @@ type Settings struct {
 	// The revision label on a namespace for injection webhook.
 	// If set to XXX, all the namespaces created with istio-injection=enabled will be replaced with istio.io/rev=XXX.
 	Revision string
+
+	// Skip VM related parts for all the tests.
+	SkipVM bool
 }
 
 // RunDir is the name of the dir to output, for this particular run.
@@ -112,5 +115,7 @@ func (s *Settings) String() string {
 	result += fmt.Sprintf("CIMode:            %v\n", s.CIMode)
 	result += fmt.Sprintf("Retries:           %v\n", s.Retries)
 	result += fmt.Sprintf("StableNamespaces:  %v\n", s.StableNamespaces)
+	result += fmt.Sprintf("Revision:          %v\n", s.Revision)
+	result += fmt.Sprintf("SkipVM:            %v\n", s.SkipVM)
 	return result
 }

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -561,6 +561,9 @@ The test framework supports the following command-line flags:
 
   -istio.test.revision string
         Overwrite the default namespace label (istio-enabled=true) with revision lable (istio.io/rev=XXX). (default is no overwrite)
+
+  -istio.test.skipVM bool
+        Skip all the VM related parts in all the tests. (default is "false")
 ```
 
 }

--- a/tests/integration/pilot/common/apps.go
+++ b/tests/integration/pilot/common/apps.go
@@ -181,17 +181,18 @@ func SetupApps(ctx resource.Context, i istio.Instance, apps *EchoDeployments) er
 				Cluster: c,
 			})
 	}
-
-	for _, c := range ctx.Clusters().ByNetwork() {
-		builder.With(nil, echo.Config{
-			Service:        VMSvc,
-			Namespace:      apps.Namespace,
-			Ports:          EchoPorts,
-			DeployAsVM:     true,
-			AutoRegisterVM: false, // TODO support auto-registration with multi-primary
-			Subsets:        []echo.SubsetConfig{{}},
-			Cluster:        c[0],
-		})
+	if !ctx.Settings().SkipVM {
+		for _, c := range ctx.Clusters().ByNetwork() {
+			builder.With(nil, echo.Config{
+				Service:        VMSvc,
+				Namespace:      apps.Namespace,
+				Ports:          EchoPorts,
+				DeployAsVM:     true,
+				AutoRegisterVM: false, // TODO support auto-registration with multi-primary
+				Subsets:        []echo.SubsetConfig{{}},
+				Cluster:        c[0],
+			})
+		}
 	}
 
 	echos, err := builder.Build()
@@ -205,7 +206,9 @@ func SetupApps(ctx resource.Context, i istio.Instance, apps *EchoDeployments) er
 	apps.Headless = echos.Match(echo.Service(HeadlessSvc))
 	apps.Naked = echos.Match(echo.Service(NakedSvc))
 	apps.External = echos.Match(echo.Service(ExternalSvc))
-	apps.VM = echos.Match(echo.Service(VMSvc))
+	if !ctx.Settings().SkipVM {
+		apps.VM = echos.Match(echo.Service(VMSvc))
+	}
 
 	if err := ctx.Config().ApplyYAML(apps.Namespace.Name(), `
 apiVersion: networking.istio.io/v1alpha3

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -328,6 +328,18 @@ spec:
 				NakedSvc: 10,
 			},
 		}
+		if len(apps.VM) == 0 {
+			splits = []map[string]int{
+				{
+					PodBSvc:  67,
+					NakedSvc: 33,
+				},
+				{
+					PodBSvc:  88,
+					NakedSvc: 12,
+				},
+			}
+		}
 
 		for _, split := range splits {
 			split := split
@@ -431,6 +443,7 @@ func gatewayCases(apps *EchoDeployments) []TrafficTestCase {
 		apps.Headless,
 		apps.External,
 	}
+
 	for _, d := range destinationSets {
 		d := d
 		if len(d) == 0 {
@@ -486,6 +499,9 @@ func protocolSniffingCases(apps *EchoDeployments) []TrafficTestCase {
 			}
 
 			for _, destinations := range destinationSets {
+				if len(destinations) == 0 {
+					continue
+				}
 				client := client
 				destinations := destinations
 				// grabbing the 0th assumes all echos in destinations have the same service name

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -91,7 +91,9 @@ func RunAllTrafficTests(ctx framework.TestContext, apps *EchoDeployments) {
 	cases["serverfirst"] = serverFirstTestCases(apps)
 	cases["gateway"] = gatewayCases(apps)
 	cases["loop"] = trafficLoopCases(apps)
-	cases["vm"] = VMTestCases(apps.VM, apps)
+	if !ctx.Settings().SkipVM {
+		cases["vm"] = VMTestCases(apps.VM, apps)
+	}
 	for name, tts := range cases {
 		ctx.NewSubTest(name).Run(func(ctx framework.TestContext) {
 			for _, tt := range tts {


### PR DESCRIPTION
1. Add test input config argument to disable VM related parts in
TestTraffic.
2. Skip all the VM related parts based on the input argument.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.