### PR TITLE
Add health check using TCP

### DIFF
--- a/samples/health-check/liveness-tcp.yml
+++ b/samples/health-check/liveness-tcp.yml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: liveness-tcp
+  labels:
+    app: liveness-tcp
+    service: liveness-tcp
+spec:
+  ports:
+  - name: tcp
+    port: 8001
+  selector:
+    app: liveness-tcp
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: liveness-tcp
+spec:
+  selector:
+    matchLabels:
+      app: liveness-tcp
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: liveness-tcp
+        version: v1
+    spec:
+      containers:
+      - name: liveness-tcp
+        image: docker.io/istio/health:example
+        ports:
+        - containerPort: 8001
+        livenessProbe:
+          tcpSocket:
+            port: 8001
+          initialDelaySeconds: 5
+          periodSeconds: 5


### PR DESCRIPTION
Based on https://github.com/istio/istio.io/pull/8246#issuecomment-704190021

Follow up for https://github.com/istio/istio.io/pull/8246

```
$ kubectl get pods
NAME                             READY   STATUS    RESTARTS   AGE
liveness-http-86c7cc8f45-s4h7m   1/1     Running   0          1m
liveness-tcp-59f6d56f7-69f7k     1/1     Running   0          2m
```
Using the HTTP probe
```
$ kubectl describe pod liveness-http-86c7cc8f45-s4h7m
...
Liveness:       http-get http://:8001/foo delay=5s timeout=1s period=5s #success=1 #failure=3
```

Using TCP probe
```
$ kubectl describe pod liveness-tcp-59f6d56f7-69f7k
...
Liveness:       tcp-socket :8001 delay=5s timeout=1s period=5s #success=1 #failure=3
```
