### PR TITLE
Fix bad revision in IOP

### DIFF
--- a/operator/pkg/validate/validate.go
+++ b/operator/pkg/validate/validate.go
@@ -24,6 +24,7 @@ import (
 	operator_v1alpha1 "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/operator/pkg/metrics"
 	"istio.io/istio/operator/pkg/util"
+	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/util/gogoprotomarshal"
 )
@@ -37,6 +38,7 @@ var (
 		"MeshConfig":                         validateMeshConfig,
 		"Hub":                                validateHub,
 		"Tag":                                validateTag,
+		"Revision":                           validateRevision,
 		"Components.IngressGateways[*].Name": validateGatewayName,
 		"Components.EgressGateways[*].Name":  validateGatewayName,
 	}
@@ -188,6 +190,14 @@ func validateHub(path util.Path, val interface{}) util.Errors {
 
 func validateTag(path util.Path, val interface{}) util.Errors {
 	return validateWithRegex(path, val, TagRegexp)
+}
+
+func validateRevision(_ util.Path, val interface{}) util.Errors {
+	if !labels.IsDNS1123Label(val.(string)) {
+		err := fmt.Errorf("invalid revision specified: %s", val.(string))
+		return util.Errors{err}
+	}
+	return nil
 }
 
 func validateGatewayName(path util.Path, val interface{}) util.Errors {


### PR DESCRIPTION
Partial fix for https://github.com/istio/istio/issues/24819

Apply invalid revision eg: `1.8.0`,  revision should use a valid label like. `1-8-0`.
```yaml
apiVersion: install.istio.io/v1alpha1
kind: IstioOperator
metadata:
  namespace: istio-system
spec:
  profile: default
  revision: "1.8.0"
```

Output:
```
$ ./out/linux_amd64/istioctl install -f test.yaml --set hub=gcr.io/istio-testing -d manifests/
Error: failed to get profile and enabled components: failed to read profile: validation errors (use --force to override): 
invalid revision specified: 1.8.0
```
