### PR TITLE
deploy vms to all clusters

### DIFF
--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -275,7 +275,8 @@ spec:
           # Capture all DNS traffic in the VM and forward to Envoy
           sudo sh -c 'echo ISTIO_META_DNS_CAPTURE=true >> /var/lib/istio/envoy/cluster.env'
           sudo sh -c 'echo ISTIO_PILOT_PORT={{$.VM.IstiodPort}} >> /var/lib/istio/envoy/cluster.env'
-
+          # Specify the Network that we reside on:
+          sudo sh -c 'echo ISTIO_META_NETWORK={{$.Network}} >> /var/lib/istio/envoy/cluster.env'
           # Setup the namespace
           sudo sh -c 'echo ISTIO_NAMESPACE={{ $.Namespace }} >> /var/lib/istio/envoy/sidecar.env'
 
@@ -458,6 +459,7 @@ func generateYAMLWithSettings(
 		"Subsets":            cfg.Subsets,
 		"TLSSettings":        cfg.TLSSettings,
 		"Cluster":            cfg.Cluster.Name(),
+		"Network":            cfg.Cluster.NetworkName(),
 		"Namespace":          namespace,
 		"VM": map[string]interface{}{
 			"Image":        vmImage,

--- a/tests/integration/pilot/common/apps.go
+++ b/tests/integration/pilot/common/apps.go
@@ -180,9 +180,7 @@ func SetupApps(ctx resource.Context, i istio.Instance, apps *EchoDeployments) er
 				},
 				Cluster: c,
 			})
-	}
-	if !ctx.Settings().SkipVM {
-		for _, c := range ctx.Clusters().ByNetwork() {
+		if !ctx.Settings().SkipVM {
 			builder.With(nil, echo.Config{
 				Service:        VMSvc,
 				Namespace:      apps.Namespace,
@@ -190,7 +188,7 @@ func SetupApps(ctx resource.Context, i istio.Instance, apps *EchoDeployments) er
 				DeployAsVM:     true,
 				AutoRegisterVM: false, // TODO support auto-registration with multi-primary
 				Subsets:        []echo.SubsetConfig{{}},
-				Cluster:        c[0],
+				Cluster:        c,
 			})
 		}
 	}
@@ -206,9 +204,7 @@ func SetupApps(ctx resource.Context, i istio.Instance, apps *EchoDeployments) er
 	apps.Headless = echos.Match(echo.Service(HeadlessSvc))
 	apps.Naked = echos.Match(echo.Service(NakedSvc))
 	apps.External = echos.Match(echo.Service(ExternalSvc))
-	if !ctx.Settings().SkipVM {
-		apps.VM = echos.Match(echo.Service(VMSvc))
-	}
+	apps.VM = echos.Match(echo.Service(VMSvc))
 
 	if err := ctx.Config().ApplyYAML(apps.Namespace.Name(), `
 apiVersion: networking.istio.io/v1alpha3

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -486,7 +486,7 @@ func gatewayCases(apps *EchoDeployments) []TrafficTestCase {
 func protocolSniffingCases(apps *EchoDeployments) []TrafficTestCase {
 	cases := []TrafficTestCase{}
 	// TODO add VMs to clients when DNS works for VMs. Blocked by https://github.com/istio/istio/issues/27154
-	for _, clients := range []echo.Instances{apps.PodA, apps.Naked, apps.Headless} {
+	for _, clients := range []echo.Instances{apps.PodA, apps.Naked, apps.Headless, apps.VM} {
 		for _, client := range clients {
 			destinationSets := []echo.Instances{
 				apps.PodA,
@@ -507,7 +507,7 @@ func protocolSniffingCases(apps *EchoDeployments) []TrafficTestCase {
 				// grabbing the 0th assumes all echos in destinations have the same service name
 				destination := destinations[0]
 				if (apps.Headless.Contains(client) || apps.Headless.Contains(destination)) && len(apps.Headless) > 1 {
-					// TODO(landow) fix DNS issues with multicluster/VMs/headless
+					// TODO(landow) fix multicluster + headless (https://github.com/istio/istio/issues/27342)
 					continue
 				}
 				if apps.Naked.Contains(client) && apps.VM.Contains(destination) {

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -486,7 +486,7 @@ func gatewayCases(apps *EchoDeployments) []TrafficTestCase {
 func protocolSniffingCases(apps *EchoDeployments) []TrafficTestCase {
 	cases := []TrafficTestCase{}
 	// TODO add VMs to clients when DNS works for VMs. Blocked by https://github.com/istio/istio/issues/27154
-	for _, clients := range []echo.Instances{apps.PodA, apps.Naked, apps.Headless, apps.VM} {
+	for _, clients := range []echo.Instances{apps.PodA, apps.Naked, apps.Headless} {
 		for _, client := range clients {
 			destinationSets := []echo.Instances{
 				apps.PodA,


### PR DESCRIPTION
trying to get a better understanding of why tests break with more than 1 vm per-network. 