### PR TITLE
Add istioctl profile list test

### DIFF
--- a/operator/cmd/mesh/profile-diff.go
+++ b/operator/cmd/mesh/profile-diff.go
@@ -51,13 +51,13 @@ func profileDiffCmd(rootArgs *rootArgs, pfArgs *profileDiffArgs) *cobra.Command 
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return profileDiff(rootArgs, pfArgs, args)
+			return profileDiff(cmd, rootArgs, pfArgs, args)
 		}}
 
 }
 
 // profileDiff compare two profile files.
-func profileDiff(rootArgs *rootArgs, pfArgs *profileDiffArgs, args []string) error {
+func profileDiff(cmd *cobra.Command, rootArgs *rootArgs, pfArgs *profileDiffArgs, args []string) error {
 	initLogsOrExit(rootArgs)
 
 	a, err := helm.ReadProfileYAML(args[0], pfArgs.manifestsPath)
@@ -72,9 +72,9 @@ func profileDiff(rootArgs *rootArgs, pfArgs *profileDiffArgs, args []string) err
 
 	diff := util.YAMLDiff(a, b)
 	if diff == "" {
-		fmt.Println("Profiles are identical")
+		cmd.Println("Profiles are identical")
 	} else {
-		fmt.Printf("The difference between profiles:\n%s", diff)
+		cmd.Printf("The difference between profiles:\n%s", diff)
 		os.Exit(1)
 	}
 

--- a/operator/cmd/mesh/profile-list.go
+++ b/operator/cmd/mesh/profile-list.go
@@ -15,7 +15,6 @@
 package mesh
 
 import (
-	"fmt"
 	"sort"
 
 	"github.com/spf13/cobra"
@@ -40,25 +39,25 @@ func profileListCmd(rootArgs *rootArgs, plArgs *profileListArgs) *cobra.Command 
 		Long:  "The list subcommand lists the available Istio configuration profiles.",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return profileList(rootArgs, plArgs)
+			return profileList(cmd, rootArgs, plArgs)
 		}}
 
 }
 
 // profileList list all the builtin profiles.
-func profileList(args *rootArgs, plArgs *profileListArgs) error {
+func profileList(cmd *cobra.Command, args *rootArgs, plArgs *profileListArgs) error {
 	initLogsOrExit(args)
 	profiles, err := helm.ListProfiles(plArgs.manifestsPath)
 	if err != nil {
 		return err
 	}
 	if len(profiles) == 0 {
-		fmt.Println("No profiles available.")
+		cmd.Println("No profiles available.")
 	} else {
-		fmt.Println("Istio configuration profiles:")
+		cmd.Println("Istio configuration profiles:")
 		sort.Strings(profiles)
 		for _, profile := range profiles {
-			fmt.Printf("    %s\n", profile)
+			cmd.Printf("    %s\n", profile)
 		}
 	}
 

--- a/operator/cmd/mesh/profile-list_test.go
+++ b/operator/cmd/mesh/profile-list_test.go
@@ -38,7 +38,7 @@ func TestProfileList(t *testing.T) {
 		t.Fatalf("failed to execute istioctl profile command: %v", err)
 	}
 	output := out.String()
-	expectedProfiles := []string{"default", "demo", "empty", "minimal", "openshift", "remote"}
+	expectedProfiles := []string{"default", "demo", "empty", "minimal", "openshift", "preview", "remote"}
 	for _, prof := range expectedProfiles {
 		g.Expect(output).To(gomega.ContainSubstring(prof))
 	}

--- a/operator/cmd/mesh/profile-list_test.go
+++ b/operator/cmd/mesh/profile-list_test.go
@@ -16,19 +16,30 @@ package mesh
 
 import (
 	"bytes"
+	"path/filepath"
 	"testing"
 
 	"github.com/onsi/gomega"
+
+	"istio.io/istio/pkg/test/env"
 )
 
-func TestInstallEmptyRevision(t *testing.T) {
+func TestProfileList(t *testing.T) {
 	g := gomega.NewWithT(t)
-	args := []string{"install", "--dry-run", "--revision", ""}
+	args := []string{"profile", "list", "--dry-run", "--manifests", filepath.Join(env.IstioSrc, "manifests")}
+
 	rootCmd := GetRootCmd(args)
 	var out bytes.Buffer
 	rootCmd.SetOut(&out)
 	rootCmd.SetErr(&out)
 
 	err := rootCmd.Execute()
-	g.Expect(err).To(gomega.HaveOccurred())
+	if err != nil {
+		t.Fatalf("failed to execute istioctl profile command: %v", err)
+	}
+	output := out.String()
+	expectedProfiles := []string{"default", "demo", "empty", "minimal", "openshift", "remote"}
+	for _, prof := range expectedProfiles {
+		g.Expect(output).To(gomega.ContainSubstring(prof))
+	}
 }

--- a/operator/cmd/mesh/profile.go
+++ b/operator/cmd/mesh/profile.go
@@ -26,6 +26,7 @@ func ProfileCmd() *cobra.Command {
 		Long:  "The profile command lists, dumps or diffs Istio configuration profiles.",
 		Example: "istioctl profile list\n" +
 			"istioctl install --set profile=demo  # Use a profile from the list",
+		Aliases: []string{"profiles"},
 	}
 
 	pdArgs := &profileDumpArgs{}


### PR DESCRIPTION
Adds test for `istioctl profile list` command. Also changes `fmt.Print` to `cmd.Print` in various places to allow for better testing (`fmt.Print` will not capture command output with `SetOut`).

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
