### PR TITLE
Add terminationGracePeriodSeconds=0 to sleep sample

### DIFF
--- a/samples/sleep/sleep.yaml
+++ b/samples/sleep/sleep.yaml
@@ -48,6 +48,7 @@ spec:
       labels:
         app: sleep
     spec:
+      terminationGracePeriodSeconds: 0
       serviceAccountName: sleep
       containers:
       - name: sleep


### PR DESCRIPTION
Otherwise, the pods always stick around for 30s after removal, slowing
down following the tasks.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.