### PR TITLE
Fix observed generation release note

### DIFF
--- a/releasenotes/notes/28003.yaml
+++ b/releasenotes/notes/28003.yaml
@@ -2,7 +2,7 @@ apiVersion: release-notes/v2
 kind: feature
 area: traffic-management
 issue:
-  - 24471
+  - 28003
 
 releaseNotes:
 - |


### PR DESCRIPTION
This will need to go into the 1.8 release notes. This is pointing at the wrong issue. 
