### PR TITLE
istioctl install: validate --revision param

### DIFF
--- a/operator/cmd/mesh/install.go
+++ b/operator/cmd/mesh/install.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/util/validation"
 
 	"istio.io/api/operator/v1alpha1"
 	"istio.io/istio/istioctl/pkg/clioptions"
@@ -40,6 +39,7 @@ import (
 	pkgversion "istio.io/istio/operator/pkg/version"
 	operatorVer "istio.io/istio/operator/version"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
+	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/kube"
 	"istio.io/pkg/log"
 )
@@ -112,9 +112,8 @@ func InstallCmd(logOpts *log.Options) *cobra.Command {
 `,
 		Args: cobra.ExactArgs(0),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			errs := validation.IsQualifiedName(iArgs.revision)
-			if len(errs) != 0 && cmd.PersistentFlags().Changed("revision") {
-				return fmt.Errorf("invalid revision specified:\n%v", strings.Join(errs, "\n"))
+			if !labels.IsDNS1123Label(iArgs.revision) && cmd.PersistentFlags().Changed("revision") {
+				return fmt.Errorf("invalid revision specified: %v", iArgs.revision)
 			}
 			return nil
 		},


### PR DESCRIPTION
Found during https://github.com/istio/istio/pull/28745

Before:
The existing validation was wrong which does not check for invalid `--revision`. 
```
$ ./out/linux_amd64/istioctl install -r "1.8:" --set hub=gcr.io/istio-testing -d manifests/
Error: invalid revision specified:
name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')
```

```
$ ./out/linux_amd64/istioctl install -r 1.8 --set hub=gcr.io/istio-testing -d manifests/
Error: failed to get profile and enabled components: failed to generate IOP from profile default:
could not unmarshal merged YAML: json: cannot unmarshal number into Go value of type string
```

After:
```
$ ./out/linux_amd64/istioctl install -r 1.8.0 --set hub=gcr.io/istio-testing -d manifests/
Error: failed to get profile and enabled components: failed to read profile: validation errors (use --force to override): 
invalid revision specified: 1.8.0
```