### PR TITLE
Fix invalid revision in IOP

### DIFF
--- a/operator/pkg/validate/common.go
+++ b/operator/pkg/validate/common.go
@@ -284,6 +284,11 @@ func UnmarshalIOP(iopYAML string) (*v1alpha1.IstioOperator, error) {
 		un.SetCreationTimestamp(meta_v1.Time{}) // UnmarshalIstioOperator chokes on these
 		iopYAML = util.ToYAML(un)
 	}
+	// TODO: find a better way to validate all the invalid values in IOP YAML
+	// before it is unmarshal into IstioOperator
+	if err := validateRevisionFromIOPYAML(iopYAML); err != nil {
+		return nil, err
+	}
 	iop := &v1alpha1.IstioOperator{}
 	if err := util.UnmarshalWithJSONPB(iopYAML, iop, false); err != nil {
 		return nil, fmt.Errorf("%s:\n\nYAML:\n%s", err, iopYAML)

--- a/operator/pkg/validate/common.go
+++ b/operator/pkg/validate/common.go
@@ -286,7 +286,7 @@ func UnmarshalIOP(iopYAML string) (*v1alpha1.IstioOperator, error) {
 	}
 	// TODO: find a better way to validate all the invalid values in IOP YAML
 	// before it is unmarshal into IstioOperator
-	if err := validateRevisionFromIOPYAML(iopYAML); err != nil {
+	if err := IsRevisionString(iopYAML); err != nil {
 		return nil, err
 	}
 	iop := &v1alpha1.IstioOperator{}

--- a/operator/pkg/validate/validate.go
+++ b/operator/pkg/validate/validate.go
@@ -211,13 +211,17 @@ func validateRevisionFromIOPYAML(iopYAML string) error {
 	if err != nil {
 		return fmt.Errorf("error unmarshalling spec overlay yaml into untype tree %v", err)
 	}
-	// fail early if revision is not a string eg: revision: 18, revision: 1.8, revision: 1.8.0
 	rev := specTree["revision"]
-	if !util.IsString(rev) {
+	// Skip if revision is not specified in any of the profile
+	if util.IsEmptyString(rev) {
+		return nil
+	}
+	revision, ok := rev.(string)
+	// fail early if revision is not a string eg: revision: 18, revision: 1.8, revision: 1.8.0
+	if !ok {
 		return fmt.Errorf("invalid revision specified: %v", rev.(float64))
 	}
 	// revision can be invalid string eg: "1.8", "1.8.0", which will be validated in next step
-	revision := rev.(string)
 	if !labels.IsDNS1123Label(revision) {
 		return fmt.Errorf("invalid revision specified: %s", rev)
 	}

--- a/operator/pkg/validate/validate.go
+++ b/operator/pkg/validate/validate.go
@@ -201,7 +201,8 @@ func validateRevision(_ util.Path, val interface{}) util.Errors {
 	return nil
 }
 
-func validateRevisionFromIOPYAML(iopYAML string) error {
+// IsRevisionString returns error if non-string revision is passed
+func IsRevisionString(iopYAML string) error {
 	var specTree = make(map[string]interface{})
 	spec, err := tpath.GetConfigSubtree(iopYAML, "spec")
 	if err != nil {
@@ -216,14 +217,11 @@ func validateRevisionFromIOPYAML(iopYAML string) error {
 	if util.IsEmptyString(rev) {
 		return nil
 	}
-	revision, ok := rev.(string)
+	_, ok := rev.(string)
 	// fail early if revision is not a string eg: revision: 18, revision: 1.8, revision: 1.8.0
 	if !ok {
-		return fmt.Errorf("invalid revision specified: %v", rev.(float64))
-	}
-	// revision can be invalid string eg: "1.8", "1.8.0", which will be validated in next step
-	if !labels.IsDNS1123Label(revision) {
-		return fmt.Errorf("invalid revision specified: %s", rev)
+		rev = fmt.Sprintf("%v", rev)
+		return fmt.Errorf("invalid revision specified: %v. revision must be a string eg: %q", rev, "1-9-0")
 	}
 	return nil
 }

--- a/operator/pkg/validate/validate.go
+++ b/operator/pkg/validate/validate.go
@@ -210,7 +210,7 @@ func IsRevisionString(iopYAML string) error {
 	}
 	err = yaml.Unmarshal([]byte(spec), &specTree)
 	if err != nil {
-		return fmt.Errorf("error unmarshalling spec overlay yaml into untype tree %v", err)
+		return fmt.Errorf("invalid IstioOperator: %v", err)
 	}
 	rev := specTree["revision"]
 	// Skip if revision is not specified in any of the profile
@@ -221,7 +221,7 @@ func IsRevisionString(iopYAML string) error {
 	// fail early if revision is not a string eg: revision: 18, revision: 1.8, revision: 1.8.0
 	if !ok {
 		rev = fmt.Sprintf("%v", rev)
-		return fmt.Errorf("invalid revision specified: %v. revision must be a string eg: %q", rev, "1-9-0")
+		return fmt.Errorf("invalid revision specified: %v. Revision must be a string eg: %q", rev, "1-9-0")
 	}
 	return nil
 }

--- a/operator/pkg/validate/validate_test.go
+++ b/operator/pkg/validate/validate_test.go
@@ -181,7 +181,7 @@ meshConfig:
 	}
 }
 
-func TestValidateRevisionFromIOPYAML(t *testing.T) {
+func TestIsRevisionString(t *testing.T) {
 	tests := []struct {
 		desc    string
 		yamlStr string
@@ -266,11 +266,19 @@ spec:
 `,
 			isValid: false,
 		},
+		{
+			desc: "invalid revision with boolean value",
+			yamlStr: `
+spec:
+  revision: false
+`,
+			isValid: false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			errs := validateRevisionFromIOPYAML(tt.yamlStr)
+			errs := IsRevisionString(tt.yamlStr)
 			if tt.isValid && errs != nil {
 				t.Errorf("(%v)(%v)", tt.yamlStr, errs)
 			}

--- a/operator/pkg/validate/validate_test.go
+++ b/operator/pkg/validate/validate_test.go
@@ -180,3 +180,85 @@ meshConfig:
 		})
 	}
 }
+
+func TestValidateRevisionFromIOPYAML(t *testing.T) {
+	tests := []struct {
+		desc    string
+		yamlStr string
+		isValid bool
+	}{
+		{
+			desc: "valid revision string",
+			yamlStr: `
+spec:
+  revision: "1-8-0"
+`,
+			isValid: true,
+		},
+		{
+			desc: "valid revision string",
+			yamlStr: `
+spec:
+  revision: "canary"
+`,
+			isValid: true,
+		},
+		{
+			desc: "invalid revision with float64 value",
+			yamlStr: `
+spec:
+  revision: 18
+`,
+			isValid: false,
+		},
+		{
+			desc: "invalid revision with float64 value",
+			yamlStr: `
+spec:
+  revision: 1.8
+`,
+			isValid: false,
+		},
+		{
+			desc: "invalid revision with float64 value",
+			yamlStr: `
+spec:
+  revision: 1.8.0
+`,
+			isValid: false,
+		},
+		{
+			desc: "invalid revision string",
+			yamlStr: `
+spec:
+  revision: "18"
+`,
+			isValid: false,
+		},
+		{
+			desc: "invalid revision string",
+			yamlStr: `
+spec:
+  revision: "1.8"
+`,
+			isValid: false,
+		},
+		{
+			desc: "invalid revision string",
+			yamlStr: `
+spec:
+  revision: "1.8.0"
+`,
+			isValid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			errs := validateRevisionFromIOPYAML(tt.yamlStr)
+			if tt.isValid && errs != nil {
+				t.Errorf("(%v)(%v)", tt.yamlStr, errs)
+			}
+		})
+	}
+}

--- a/operator/pkg/validate/validate_test.go
+++ b/operator/pkg/validate/validate_test.go
@@ -188,6 +188,21 @@ func TestValidateRevisionFromIOPYAML(t *testing.T) {
 		isValid bool
 	}{
 		{
+			desc: "empty revision string",
+			yamlStr: `
+spec:
+  revision: ""
+`,
+			isValid: true,
+		},
+		{
+			desc: "no revision string",
+			yamlStr: `
+spec:
+`,
+			isValid: true,
+		},
+		{
 			desc: "valid revision string",
 			yamlStr: `
 spec:


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/24819

```yaml
# iop.yaml
apiVersion: install.istio.io/v1alpha1
kind: IstioOperator
metadata:
  namespace: istio-system
spec:
  profile: default
  revision: 18  # All of these values will fail:  18, 1.8, 1.8.0, "18", "1.8", "1.8.0"
```

```
$ ./out/linux_amd64/istioctl install -f iop.yaml --set hub=gcr.io/istio-testing -d manifests/

Error: failed to get profile, namespace or enabled components: failed to read profile:
invalid revision specified: 18. revision must be a string eg: "1-9-0"
```

Related:
https://github.com/istio/istio/pull/28745
https://github.com/istio/istio/pull/28778