### PR TITLE
support imagePullSecret for pulling operator image.

### DIFF
--- a/manifests/charts/istio-operator/templates/service_account.yaml
+++ b/manifests/charts/istio-operator/templates/service_account.yaml
@@ -3,4 +3,10 @@ kind: ServiceAccount
 metadata:
   namespace: {{.Values.operatorNamespace}}
   name: istio-operator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+{{- if .Values.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.imagePullSecrets }}
+- name: {{ . }}
+{{- end }}
+{{- end }}
 ---

--- a/manifests/charts/istio-operator/values.yaml
+++ b/manifests/charts/istio-operator/values.yaml
@@ -1,6 +1,10 @@
 hub: gcr.io/istio-testing
 tag: latest
 
+# ImagePullSecrets for operator ServiceAccount, list of secrets in the same namespace
+# used to pull operator image. Must be set for any cluster configured with private docker registry.
+imagePullSecrets: []
+
 operatorNamespace: istio-operator
 
 # Used to replace istioNamespace to support operator watch multiple namespaces.

--- a/operator/cmd/mesh/operator-common.go
+++ b/operator/cmd/mesh/operator-common.go
@@ -16,7 +16,6 @@ package mesh
 
 import (
 	"context"
-	"strings"
 
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -34,8 +33,8 @@ type operatorCommonArgs struct {
 	hub string
 	// tag is the tag for the operator image.
 	tag string
-	// comma sepatated imagePullSecrets used to pull operator image from private registry
-	imagePullSecrets string
+	// imagePullSecrets is an array of imagePullSecret to pull operator image from the private registry
+	imagePullSecrets []string
 	// operatorNamespace is the namespace the operator controller is installed into.
 	operatorNamespace string
 	// watchedNamespaces is the namespaces the operator controller watches, could be namespace list separated by comma.
@@ -75,11 +74,6 @@ func renderOperatorManifest(_ *rootArgs, ocArgs *operatorCommonArgs) (string, st
 		return "", "", err
 	}
 
-	var imagePullSecrets []string
-	if ocArgs.imagePullSecrets != "" {
-		imagePullSecrets = strings.Split(ocArgs.imagePullSecrets, ",")
-	}
-
 	tmpl := `
 operatorNamespace: {{.OperatorNamespace}}
 istioNamespace: {{.IstioNamespace}}
@@ -109,7 +103,7 @@ revision: {{if .Revision }} {{.Revision}} {{else}} "" {{end}}
 		WatchedNamespaces: ocArgs.watchedNamespaces,
 		Hub:               ocArgs.hub,
 		Tag:               ocArgs.tag,
-		ImagePullSecrets:  imagePullSecrets,
+		ImagePullSecrets:  ocArgs.imagePullSecrets,
 		Revision:          ocArgs.revision,
 	}
 	vals, err := util.RenderTemplate(tmpl, tv)

--- a/operator/cmd/mesh/operator-dump.go
+++ b/operator/cmd/mesh/operator-dump.go
@@ -31,7 +31,7 @@ func addOperatorDumpFlags(cmd *cobra.Command, args *operatorDumpArgs) {
 
 	cmd.PersistentFlags().StringVar(&args.common.hub, "hub", hub, HubFlagHelpStr)
 	cmd.PersistentFlags().StringVar(&args.common.tag, "tag", tag, TagFlagHelpStr)
-	cmd.PersistentFlags().StringVar(&args.common.imagePullSecrets, "imagePullSecrets", "", ImagePullSecretsHelpStr)
+	cmd.PersistentFlags().StringSliceVar(&args.common.imagePullSecrets, "imagePullSecrets", nil, ImagePullSecretsHelpStr)
 	cmd.PersistentFlags().StringVar(&args.common.operatorNamespace, "operatorNamespace", operatorDefaultNamespace, OperatorNamespaceHelpstr)
 	cmd.PersistentFlags().StringVar(&args.common.istioNamespace, "istioNamespace", istioDefaultNamespace,
 		"The namespace Istio is installed into")

--- a/operator/cmd/mesh/operator-dump.go
+++ b/operator/cmd/mesh/operator-dump.go
@@ -31,9 +31,7 @@ func addOperatorDumpFlags(cmd *cobra.Command, args *operatorDumpArgs) {
 
 	cmd.PersistentFlags().StringVar(&args.common.hub, "hub", hub, HubFlagHelpStr)
 	cmd.PersistentFlags().StringVar(&args.common.tag, "tag", tag, TagFlagHelpStr)
-	// nolint: lll
-	cmd.PersistentFlags().StringVar(&args.common.imagePullSecrets, "imagePullSecrets", "",
-		"The imagePullSecrets used to pull the operator image from private registry, could be secret list separated by comma, eg. 'imagePullSecret1,imagePullSecret2'")
+	cmd.PersistentFlags().StringVar(&args.common.imagePullSecrets, "imagePullSecrets", "", ImagePullSecretsHelpStr)
 	cmd.PersistentFlags().StringVar(&args.common.operatorNamespace, "operatorNamespace", operatorDefaultNamespace, OperatorNamespaceHelpstr)
 	cmd.PersistentFlags().StringVar(&args.common.istioNamespace, "istioNamespace", istioDefaultNamespace,
 		"The namespace Istio is installed into")

--- a/operator/cmd/mesh/operator-dump.go
+++ b/operator/cmd/mesh/operator-dump.go
@@ -31,6 +31,9 @@ func addOperatorDumpFlags(cmd *cobra.Command, args *operatorDumpArgs) {
 
 	cmd.PersistentFlags().StringVar(&args.common.hub, "hub", hub, HubFlagHelpStr)
 	cmd.PersistentFlags().StringVar(&args.common.tag, "tag", tag, TagFlagHelpStr)
+	// nolint: lll
+	cmd.PersistentFlags().StringVar(&args.common.imagePullSecrets, "imagePullSecrets", "",
+		"The imagePullSecrets used to pull the operator image from private registry, could be secret list separated by comma, eg. 'imagePullSecret1,imagePullSecret2'")
 	cmd.PersistentFlags().StringVar(&args.common.operatorNamespace, "operatorNamespace", operatorDefaultNamespace, OperatorNamespaceHelpstr)
 	cmd.PersistentFlags().StringVar(&args.common.istioNamespace, "istioNamespace", istioDefaultNamespace,
 		"The namespace Istio is installed into")

--- a/operator/cmd/mesh/operator-init.go
+++ b/operator/cmd/mesh/operator-init.go
@@ -46,9 +46,7 @@ func addOperatorInitFlags(cmd *cobra.Command, args *operatorInitArgs) {
 	cmd.PersistentFlags().StringVar(&args.context, "context", "", ContextFlagHelpStr)
 	cmd.PersistentFlags().StringVar(&args.common.hub, "hub", hub, HubFlagHelpStr)
 	cmd.PersistentFlags().StringVar(&args.common.tag, "tag", tag, TagFlagHelpStr)
-	// nolint: lll
-	cmd.PersistentFlags().StringVar(&args.common.imagePullSecrets, "imagePullSecrets", "",
-		"The imagePullSecrets used to pull the operator image from private registry, could be secret list separated by comma, eg. 'imagePullSecret1,imagePullSecret2'")
+	cmd.PersistentFlags().StringVar(&args.common.imagePullSecrets, "imagePullSecrets", "", ImagePullSecretsHelpStr)
 	cmd.PersistentFlags().StringVar(&args.common.operatorNamespace, "operatorNamespace", operatorDefaultNamespace, OperatorNamespaceHelpstr)
 	cmd.PersistentFlags().StringVar(&args.common.istioNamespace, "istioNamespace", istioDefaultNamespace,
 		"The namespace Istio is installed into. Deprecated, use '--watchedNamespaces' instead.")

--- a/operator/cmd/mesh/operator-init.go
+++ b/operator/cmd/mesh/operator-init.go
@@ -46,7 +46,7 @@ func addOperatorInitFlags(cmd *cobra.Command, args *operatorInitArgs) {
 	cmd.PersistentFlags().StringVar(&args.context, "context", "", ContextFlagHelpStr)
 	cmd.PersistentFlags().StringVar(&args.common.hub, "hub", hub, HubFlagHelpStr)
 	cmd.PersistentFlags().StringVar(&args.common.tag, "tag", tag, TagFlagHelpStr)
-	cmd.PersistentFlags().StringVar(&args.common.imagePullSecrets, "imagePullSecrets", "", ImagePullSecretsHelpStr)
+	cmd.PersistentFlags().StringSliceVar(&args.common.imagePullSecrets, "imagePullSecrets", nil, ImagePullSecretsHelpStr)
 	cmd.PersistentFlags().StringVar(&args.common.operatorNamespace, "operatorNamespace", operatorDefaultNamespace, OperatorNamespaceHelpstr)
 	cmd.PersistentFlags().StringVar(&args.common.istioNamespace, "istioNamespace", istioDefaultNamespace,
 		"The namespace Istio is installed into. Deprecated, use '--watchedNamespaces' instead.")

--- a/operator/cmd/mesh/operator-init.go
+++ b/operator/cmd/mesh/operator-init.go
@@ -46,6 +46,9 @@ func addOperatorInitFlags(cmd *cobra.Command, args *operatorInitArgs) {
 	cmd.PersistentFlags().StringVar(&args.context, "context", "", ContextFlagHelpStr)
 	cmd.PersistentFlags().StringVar(&args.common.hub, "hub", hub, HubFlagHelpStr)
 	cmd.PersistentFlags().StringVar(&args.common.tag, "tag", tag, TagFlagHelpStr)
+	// nolint: lll
+	cmd.PersistentFlags().StringVar(&args.common.imagePullSecrets, "imagePullSecrets", "",
+		"The imagePullSecrets used to pull the operator image from private registry, could be secret list separated by comma, eg. 'imagePullSecret1,imagePullSecret2'")
 	cmd.PersistentFlags().StringVar(&args.common.operatorNamespace, "operatorNamespace", operatorDefaultNamespace, OperatorNamespaceHelpstr)
 	cmd.PersistentFlags().StringVar(&args.common.istioNamespace, "istioNamespace", istioDefaultNamespace,
 		"The namespace Istio is installed into. Deprecated, use '--watchedNamespaces' instead.")

--- a/operator/cmd/mesh/operator_test.go
+++ b/operator/cmd/mesh/operator_test.go
@@ -18,6 +18,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"istio.io/istio/operator/pkg/util"
@@ -33,7 +34,7 @@ func TestOperatorDump(t *testing.T) {
 		common: operatorCommonArgs{
 			hub:               "foo.io/istio",
 			tag:               "1.2.3",
-			imagePullSecrets:  "imagePullSecret1,imagePullSecret2",
+			imagePullSecrets:  []string{"imagePullSecret1,imagePullSecret2"},
 			operatorNamespace: "operator-test-namespace",
 			watchedNamespaces: "istio-test-namespace1,istio-test-namespace2",
 		},
@@ -41,10 +42,10 @@ func TestOperatorDump(t *testing.T) {
 
 	cmd := "operator dump --hub " + odArgs.common.hub
 	cmd += " --tag " + odArgs.common.tag
-	cmd += " --imagePullSecrets " + odArgs.common.imagePullSecrets
+	cmd += " --imagePullSecrets " + strings.Join(odArgs.common.imagePullSecrets, ",")
 	cmd += " --operatorNamespace " + odArgs.common.operatorNamespace
 	cmd += " --istioNamespace " + odArgs.common.istioNamespace
-	cmd += " --manifests=" + string(liveCharts)
+	cmd += " --manifests=" + string(snapshotCharts)
 
 	gotYAML, err := runCommand(cmd)
 	if err != nil {
@@ -78,7 +79,7 @@ func TestOperatorInit(t *testing.T) {
 			tag:               "1.2.3",
 			operatorNamespace: "operator-test-namespace",
 			watchedNamespaces: "istio-test-namespace1,istio-test-namespace2",
-			manifestsPath:     string(liveCharts),
+			manifestsPath:     string(snapshotCharts),
 		},
 	}
 

--- a/operator/cmd/mesh/operator_test.go
+++ b/operator/cmd/mesh/operator_test.go
@@ -27,12 +27,13 @@ import (
 
 // TODO: rewrite this with running the actual top level command.
 func TestOperatorDump(t *testing.T) {
-	goldenFilepath := filepath.Join(env.IstioSrc, "operator/cmd/mesh/testdata/operator/output/operator-init.yaml")
+	goldenFilepath := filepath.Join(env.IstioSrc, "operator/cmd/mesh/testdata/operator/output/operator-dump.yaml")
 
 	odArgs := &operatorDumpArgs{
 		common: operatorCommonArgs{
 			hub:               "foo.io/istio",
 			tag:               "1.2.3",
+			imagePullSecrets:  "imagePullSecret1,imagePullSecret2",
 			operatorNamespace: "operator-test-namespace",
 			watchedNamespaces: "istio-test-namespace1,istio-test-namespace2",
 		},
@@ -40,9 +41,10 @@ func TestOperatorDump(t *testing.T) {
 
 	cmd := "operator dump --hub " + odArgs.common.hub
 	cmd += " --tag " + odArgs.common.tag
+	cmd += " --imagePullSecrets " + odArgs.common.imagePullSecrets
 	cmd += " --operatorNamespace " + odArgs.common.operatorNamespace
 	cmd += " --istioNamespace " + odArgs.common.istioNamespace
-	cmd += " --manifests=" + string(snapshotCharts)
+	cmd += " --manifests=" + string(liveCharts)
 
 	gotYAML, err := runCommand(cmd)
 	if err != nil {
@@ -76,7 +78,7 @@ func TestOperatorInit(t *testing.T) {
 			tag:               "1.2.3",
 			operatorNamespace: "operator-test-namespace",
 			watchedNamespaces: "istio-test-namespace1,istio-test-namespace2",
-			manifestsPath:     string(snapshotCharts),
+			manifestsPath:     string(liveCharts),
 		},
 	}
 

--- a/operator/cmd/mesh/root.go
+++ b/operator/cmd/mesh/root.go
@@ -51,7 +51,7 @@ This flag can be specified multiple times to overlay multiple files. Multiple fi
 	ContextFlagHelpStr      = `The name of the kubeconfig context to use.`
 	HubFlagHelpStr          = `The hub for the operator controller image.`
 	TagFlagHelpStr          = `The tag for the operator controller image.`
-	ImagePullSecretsHelpStr = `The imagePullSecrets used to pull the operator image from private registry,
+	ImagePullSecretsHelpStr = `The imagePullSecrets is used to pull the operator image from the private registry,
 could be secret list separated by comma, eg. 'imagePullSecret1,imagePullSecret2'`
 	OperatorNamespaceHelpstr = `The namespace the operator controller is installed into.`
 	ComponentFlagHelpStr     = "Specify which component to generate manifests for."

--- a/operator/cmd/mesh/root.go
+++ b/operator/cmd/mesh/root.go
@@ -51,8 +51,8 @@ This flag can be specified multiple times to overlay multiple files. Multiple fi
 	ContextFlagHelpStr      = `The name of the kubeconfig context to use.`
 	HubFlagHelpStr          = `The hub for the operator controller image.`
 	TagFlagHelpStr          = `The tag for the operator controller image.`
-	ImagePullSecretsHelpStr = `The imagePullSecrets is used to pull the operator image from the private registry,
-could be secret list separated by comma, eg. 'imagePullSecret1,imagePullSecret2'`
+	ImagePullSecretsHelpStr = `The imagePullSecrets are used to pull the operator image from the private registry,
+could be secret list separated by comma, eg. '--imagePullSecrets imagePullSecret1,imagePullSecret2'`
 	OperatorNamespaceHelpstr = `The namespace the operator controller is installed into.`
 	ComponentFlagHelpStr     = "Specify which component to generate manifests for."
 	VerifyCRInstallHelpStr   = "Verify the Istio control plane after installation/in-place upgrade"

--- a/operator/cmd/mesh/root.go
+++ b/operator/cmd/mesh/root.go
@@ -45,12 +45,14 @@ const (
 If set to true, the user is not prompted and a Yes response is assumed in all cases.`
 	filenameFlagHelpStr = `Path to file containing IstioOperator custom resource
 This flag can be specified multiple times to overlay multiple files. Multiple files are overlaid in left to right order.`
-	installationCompleteStr  = `Installation complete`
-	ForceFlagHelpStr         = `Proceed even with validation errors.`
-	KubeConfigFlagHelpStr    = `Path to kube config.`
-	ContextFlagHelpStr       = `The name of the kubeconfig context to use.`
-	HubFlagHelpStr           = `The hub for the operator controller image.`
-	TagFlagHelpStr           = `The tag for the operator controller image.`
+	installationCompleteStr = `Installation complete`
+	ForceFlagHelpStr        = `Proceed even with validation errors.`
+	KubeConfigFlagHelpStr   = `Path to kube config.`
+	ContextFlagHelpStr      = `The name of the kubeconfig context to use.`
+	HubFlagHelpStr          = `The hub for the operator controller image.`
+	TagFlagHelpStr          = `The tag for the operator controller image.`
+	ImagePullSecretsHelpStr = `The imagePullSecrets used to pull the operator image from private registry,
+could be secret list separated by comma, eg. 'imagePullSecret1,imagePullSecret2'`
 	OperatorNamespaceHelpstr = `The namespace the operator controller is installed into.`
 	ComponentFlagHelpStr     = "Specify which component to generate manifests for."
 	VerifyCRInstallHelpStr   = "Verify the Istio control plane after installation/in-place upgrade"

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-operator/templates/service_account.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-operator/templates/service_account.yaml
@@ -3,4 +3,10 @@ kind: ServiceAccount
 metadata:
   namespace: {{.Values.operatorNamespace}}
   name: istio-operator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+{{- if .Values.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.imagePullSecrets }}
+- name: {{ . }}
+{{- end }}
+{{- end }}
 ---

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-operator/values.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-operator/values.yaml
@@ -1,6 +1,10 @@
 hub: gcr.io/istio-testing
 tag: latest
 
+# ImagePullSecrets for operator ServiceAccount, list of secrets in the same namespace
+# used to pull operator image. Must be set for any cluster configured with private docker registry.
+imagePullSecrets: []
+
 operatorNamespace: istio-operator
 
 # Used to replace istioNamespace to support operator watch multiple namespaces.

--- a/operator/cmd/mesh/testdata/operator/output/operator-dump.yaml
+++ b/operator/cmd/mesh/testdata/operator/output/operator-dump.yaml
@@ -1,0 +1,260 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: istio-operator
+rules:
+# istio groups
+- apiGroups:
+  - authentication.istio.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - config.istio.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - install.istio.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - security.istio.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+# k8s groups
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - '*'
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions.apiextensions.k8s.io
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - deployments/finalizers
+  - ingresses
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - roles
+  - rolebindings
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - events
+  - namespaces
+  - pods
+  - pods/proxy
+  - persistentvolumeclaims
+  - secrets
+  - services
+  - serviceaccounts
+  verbs:
+  - '*'
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: istio-operator
+subjects:
+- kind: ServiceAccount
+  name: istio-operator
+  namespace: operator-test-namespace
+roleRef:
+  kind: ClusterRole
+  name: istio-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: operator-test-namespace
+  name: istio-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: istio-operator
+  template:
+    metadata:
+      labels:
+        name: istio-operator
+    spec:
+      serviceAccountName: istio-operator
+      containers:
+        - name: istio-operator
+          image: foo.io/istio/operator:1.2.3
+          command:
+          - operator
+          - server
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1337
+            runAsUser: 1337
+            runAsNonRoot: true
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 50m
+              memory: 128Mi
+          env:
+            - name: WATCH_NAMESPACE
+              value: 
+            - name: LEADER_ELECTION_NAMESPACE
+              value: "operator-test-namespace"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "operator-test-namespace"
+            - name: WAIT_FOR_RESOURCES_TIMEOUT
+              value: "300s"
+            - name: REVISION
+              value: ""
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: operator-test-namespace
+  labels:
+    istio-operator-managed: Reconcile
+    istio-injection: disabled
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: operator-test-namespace
+  labels:
+    name: istio-operator
+  name: istio-operator
+spec:
+  ports:
+  - name: http-metrics
+    port: 8383
+    targetPort: 8383
+    protocol: TCP
+  selector:
+    name: istio-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: operator-test-namespace
+  name: istio-operator
+imagePullSecrets:
+- name: imagePullSecret1
+- name: imagePullSecret2
+---
+# SYNC WITH manifests/charts/base/files
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: istiooperators.install.istio.io
+spec:
+  group: install.istio.io
+  names:
+    kind: IstioOperator
+    plural: istiooperators
+    singular: istiooperator
+    shortNames:
+    - iop
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values.
+            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase.
+            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        spec:
+          description: 'Specification of the desired state of the istio control plane resource.
+            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          type: object
+        status:
+          description: 'Status describes each of istio control plane component status at the current time.
+            0 means NONE, 1 means UPDATING, 2 means HEALTHY, 3 means ERROR, 4 means RECONCILING.
+            More info: https://github.com/istio/api/blob/master/operator/v1alpha1/istio.operator.v1alpha1.pb.html &
+            https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          type: object
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+---


### PR DESCRIPTION
Support set imagePullSecrets for operator init and dump commands by `--imagePullSecrets` flag.
Also fix the wrong operator dump golden file name.

[ ] Configuration Infrastructure
[ ] Docs
[ X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.