### PR TITLE
Operator helm chart: allow to override image name and set nodeSelector for operator

### DIFF
--- a/manifests/charts/istio-operator/templates/deployment.yaml
+++ b/manifests/charts/istio-operator/templates/deployment.yaml
@@ -14,9 +14,13 @@ spec:
         name: istio-operator
     spec:
       serviceAccountName: istio-operator{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
+{{- with .Values.operator.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | trim | indent 8 }}
+{{- end }}
       containers:
         - name: istio-operator
-          image: {{.Values.hub}}/operator:{{.Values.tag}}
+          image: {{.Values.hub}}/{{.Values.image}}:{{.Values.tag}}
           command:
           - operator
           - server

--- a/manifests/charts/istio-operator/values.yaml
+++ b/manifests/charts/istio-operator/values.yaml
@@ -1,4 +1,5 @@
 hub: gcr.io/istio-testing
+image: operator
 tag: latest
 
 operatorNamespace: istio-operator
@@ -15,6 +16,7 @@ revision: ""
 
 # Operator resource defaults
 operator:
+  nodeSelector: {}
   resources:
     limits:
       cpu: 200m
@@ -22,4 +24,3 @@ operator:
     requests:
       cpu: 50m
       memory: 128Mi
-


### PR DESCRIPTION


[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.


This small tweak for Helm chart for istio-operator allows to change image name (ie. from "operator" to "istio-operator") that it might be important when operator is installed from mirrored image (ie. because of introduced docker.io limits).

Additional change is to allow to set nodeSelector for istio-operator deployment, which might be required in some cluster setups.