### PR TITLE
inject: split massive file

### DIFF
--- a/pkg/kube/inject/template.go
+++ b/pkg/kube/inject/template.go
@@ -1,0 +1,320 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inject
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"reflect"
+	"strconv"
+	"strings"
+	"text/template"
+
+	"github.com/ghodss/yaml"
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pkg/config/mesh"
+	"istio.io/pkg/log"
+)
+
+func CreateInjectionFuncmap() template.FuncMap {
+	return template.FuncMap{
+		"formatDuration":      formatDuration,
+		"isset":               isset,
+		"excludeInboundPort":  excludeInboundPort,
+		"includeInboundPorts": includeInboundPorts,
+		"kubevirtInterfaces":  kubevirtInterfaces,
+		"applicationPorts":    applicationPorts,
+		"annotation":          getAnnotation,
+		"valueOrDefault":      valueOrDefault,
+		"toJSON":              toJSON,
+		"toJson":              toJSON, // Used by, e.g. Istio 1.0.5 template sidecar-injector-configmap.yaml
+		"fromJSON":            fromJSON,
+		"structToJSON":        structToJSON,
+		"protoToJSON":         protoToJSON,
+		"toYaml":              toYaml,
+		"indent":              indent,
+		"directory":           directory,
+		"contains":            flippedContains,
+		"toLower":             strings.ToLower,
+		"appendMultusNetwork": appendMultusNetwork,
+		"env":                 env,
+	}
+}
+
+// Allows the template to use env variables from istiod.
+// Istiod will use a custom template, without 'values.yaml', and the pod will have
+// an optional 'vendor' configmap where additional settings can be defined.
+func env(key string, def string) string {
+	val := os.Getenv(key)
+	if val == "" {
+		return def
+	}
+	return val
+}
+
+func formatDuration(in *types.Duration) string {
+	dur, err := types.DurationFromProto(in)
+	if err != nil {
+		return "1s"
+	}
+	return dur.String()
+}
+
+func isset(m map[string]string, key string) bool {
+	_, ok := m[key]
+	return ok
+}
+
+func directory(filepath string) string {
+	dir, _ := path.Split(filepath)
+	return dir
+}
+
+func flippedContains(needle, haystack string) bool {
+	return strings.Contains(haystack, needle)
+}
+
+func excludeInboundPort(port interface{}, excludedInboundPorts string) string {
+	portStr := strings.TrimSpace(fmt.Sprint(port))
+	if len(portStr) == 0 || portStr == "0" {
+		// Nothing to do.
+		return excludedInboundPorts
+	}
+
+	// Exclude the readiness port if not already excluded.
+	ports := splitPorts(excludedInboundPorts)
+	outPorts := make([]string, 0, len(ports))
+	for _, port := range ports {
+		if port == portStr {
+			// The port is already excluded.
+			return excludedInboundPorts
+		}
+		port = strings.TrimSpace(port)
+		if len(port) > 0 {
+			outPorts = append(outPorts, port)
+		}
+	}
+
+	// The port was not already excluded - exclude it now.
+	outPorts = append(outPorts, portStr)
+	return strings.Join(outPorts, ",")
+}
+
+func valueOrDefault(value interface{}, defaultValue interface{}) interface{} {
+	if value == "" || value == nil {
+		return defaultValue
+	}
+	return value
+}
+
+func toJSON(m map[string]string) string {
+	if m == nil {
+		return "{}"
+	}
+
+	ba, err := json.Marshal(m)
+	if err != nil {
+		log.Warnf("Unable to marshal %v", m)
+		return "{}"
+	}
+
+	return string(ba)
+}
+
+func fromJSON(j string) interface{} {
+	var m interface{}
+	err := json.Unmarshal([]byte(j), &m)
+	if err != nil {
+		log.Warnf("Unable to unmarshal %s", j)
+		return "{}"
+	}
+
+	log.Warnf("%v", m)
+	return m
+}
+
+func indent(spaces int, source string) string {
+	res := strings.Split(source, "\n")
+	for i, line := range res {
+		if i > 0 {
+			res[i] = fmt.Sprintf(fmt.Sprintf("%% %ds%%s", spaces), "", line)
+		}
+	}
+	return strings.Join(res, "\n")
+}
+
+func toYaml(value interface{}) string {
+	y, err := yaml.Marshal(value)
+	if err != nil {
+		log.Warnf("Unable to marshal %v", value)
+		return ""
+	}
+
+	return string(y)
+}
+
+func getAnnotation(meta metav1.ObjectMeta, name string, defaultValue interface{}) string {
+	value, ok := meta.Annotations[name]
+	if !ok {
+		value = fmt.Sprint(defaultValue)
+	}
+	return value
+}
+
+func appendMultusNetwork(existingValue, istioCniNetwork string) string {
+	if existingValue == "" {
+		return istioCniNetwork
+	}
+	i := strings.LastIndex(existingValue, "]")
+	isJSON := i != -1
+	if isJSON {
+		return existingValue[0:i] + fmt.Sprintf(`, {"name": "%s"}`, istioCniNetwork) + existingValue[i:]
+	}
+	return existingValue + ", " + istioCniNetwork
+}
+
+// this function is no longer used by the template but kept around for backwards compatibility
+func applicationPorts(containers []corev1.Container) string {
+	return getContainerPorts(containers, func(c corev1.Container) bool {
+		return c.Name != ProxyContainerName
+	})
+}
+
+func includeInboundPorts(containers []corev1.Container) string {
+	// Include the ports from all containers in the deployment.
+	return getContainerPorts(containers, func(corev1.Container) bool { return true })
+}
+
+func getPortsForContainer(container corev1.Container) []string {
+	parts := make([]string, 0)
+	for _, p := range container.Ports {
+		if p.Protocol == corev1.ProtocolUDP || p.Protocol == corev1.ProtocolSCTP {
+			continue
+		}
+		parts = append(parts, strconv.Itoa(int(p.ContainerPort)))
+	}
+	return parts
+}
+
+func getContainerPorts(containers []corev1.Container, shouldIncludePorts func(corev1.Container) bool) string {
+	parts := make([]string, 0)
+	for _, c := range containers {
+		if shouldIncludePorts(c) {
+			parts = append(parts, getPortsForContainer(c)...)
+		}
+	}
+
+	return strings.Join(parts, ",")
+}
+
+func kubevirtInterfaces(s string) string {
+	return s
+}
+
+func structToJSON(v interface{}) string {
+	if v == nil {
+		return "{}"
+	}
+
+	ba, err := json.Marshal(v)
+	if err != nil {
+		log.Warnf("Unable to marshal %v", v)
+		return "{}"
+	}
+
+	return string(ba)
+}
+
+func protoToJSON(v proto.Message) string {
+	v = cleanProxyConfig(v)
+	if v == nil {
+		return "{}"
+	}
+
+	m := jsonpb.Marshaler{}
+	ba, err := m.MarshalToString(v)
+	if err != nil {
+		log.Warnf("Unable to marshal %v: %v", v, err)
+		return "{}"
+	}
+
+	return ba
+}
+
+// Rather than dump the entire proxy config, we remove fields that are default
+// This makes the pod spec much smaller
+// This is not comprehensive code, but nothing will break if this misses some fields
+func cleanProxyConfig(msg proto.Message) proto.Message {
+	originalProxyConfig, ok := msg.(*meshconfig.ProxyConfig)
+	if !ok || originalProxyConfig == nil {
+		return msg
+	}
+	pc := *originalProxyConfig
+	defaults := mesh.DefaultProxyConfig()
+	if pc.ConfigPath == defaults.ConfigPath {
+		pc.ConfigPath = ""
+	}
+	if pc.BinaryPath == defaults.BinaryPath {
+		pc.BinaryPath = ""
+	}
+	if pc.ControlPlaneAuthPolicy == defaults.ControlPlaneAuthPolicy {
+		pc.ControlPlaneAuthPolicy = 0
+	}
+	if pc.ServiceCluster == defaults.ServiceCluster {
+		pc.ServiceCluster = ""
+	}
+	if reflect.DeepEqual(pc.DrainDuration, defaults.DrainDuration) {
+		pc.DrainDuration = nil
+	}
+	if reflect.DeepEqual(pc.TerminationDrainDuration, defaults.TerminationDrainDuration) {
+		pc.TerminationDrainDuration = nil
+	}
+	if reflect.DeepEqual(pc.ParentShutdownDuration, defaults.ParentShutdownDuration) {
+		pc.ParentShutdownDuration = nil
+	}
+	if pc.DiscoveryAddress == defaults.DiscoveryAddress {
+		pc.DiscoveryAddress = ""
+	}
+	if reflect.DeepEqual(pc.EnvoyMetricsService, defaults.EnvoyMetricsService) {
+		pc.EnvoyMetricsService = nil
+	}
+	if reflect.DeepEqual(pc.EnvoyAccessLogService, defaults.EnvoyAccessLogService) {
+		pc.EnvoyAccessLogService = nil
+	}
+	if reflect.DeepEqual(pc.Tracing, defaults.Tracing) {
+		pc.Tracing = nil
+	}
+	if pc.ProxyAdminPort == defaults.ProxyAdminPort {
+		pc.ProxyAdminPort = 0
+	}
+	if pc.StatNameLength == defaults.StatNameLength {
+		pc.StatNameLength = 0
+	}
+	if pc.StatusPort == defaults.StatusPort {
+		pc.StatusPort = 0
+	}
+	if reflect.DeepEqual(pc.Concurrency, defaults.Concurrency) {
+		pc.Concurrency = nil
+	}
+	return proto.Message(&pc)
+}

--- a/pkg/kube/inject/validate.go
+++ b/pkg/kube/inject/validate.go
@@ -1,0 +1,209 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inject
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+
+	"istio.io/api/annotation"
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config/mesh"
+	"istio.io/istio/pkg/config/validation"
+	"istio.io/istio/pkg/util/gogoprotomarshal"
+	"istio.io/pkg/log"
+)
+
+type annotationValidationFunc func(value string) error
+
+// per-sidecar policy and status
+var (
+	alwaysValidFunc = func(value string) error {
+		return nil
+	}
+
+	AnnotationValidation = map[string]annotationValidationFunc{
+		annotation.SidecarInject.Name:                             alwaysValidFunc,
+		annotation.SidecarStatus.Name:                             alwaysValidFunc,
+		annotation.SidecarRewriteAppHTTPProbers.Name:              alwaysValidFunc,
+		annotation.SidecarControlPlaneAuthPolicy.Name:             alwaysValidFunc,
+		annotation.SidecarDiscoveryAddress.Name:                   alwaysValidFunc,
+		annotation.SidecarProxyImage.Name:                         alwaysValidFunc,
+		annotation.SidecarProxyCPU.Name:                           alwaysValidFunc,
+		annotation.SidecarProxyCPULimit.Name:                      alwaysValidFunc,
+		annotation.SidecarProxyMemory.Name:                        alwaysValidFunc,
+		annotation.SidecarProxyMemoryLimit.Name:                   alwaysValidFunc,
+		annotation.SidecarInterceptionMode.Name:                   validateInterceptionMode,
+		annotation.SidecarBootstrapOverride.Name:                  alwaysValidFunc,
+		annotation.SidecarStatsInclusionPrefixes.Name:             alwaysValidFunc,
+		annotation.SidecarStatsInclusionSuffixes.Name:             alwaysValidFunc,
+		annotation.SidecarStatsInclusionRegexps.Name:              alwaysValidFunc,
+		annotation.SidecarUserVolume.Name:                         alwaysValidFunc,
+		annotation.SidecarUserVolumeMount.Name:                    alwaysValidFunc,
+		annotation.SidecarEnableCoreDump.Name:                     validateBool,
+		annotation.SidecarStatusPort.Name:                         validateStatusPort,
+		annotation.SidecarStatusReadinessInitialDelaySeconds.Name: validateUInt32,
+		annotation.SidecarStatusReadinessPeriodSeconds.Name:       validateUInt32,
+		annotation.SidecarStatusReadinessFailureThreshold.Name:    validateUInt32,
+		annotation.SidecarTrafficIncludeOutboundIPRanges.Name:     ValidateIncludeIPRanges,
+		annotation.SidecarTrafficExcludeOutboundIPRanges.Name:     ValidateExcludeIPRanges,
+		annotation.SidecarTrafficIncludeInboundPorts.Name:         ValidateIncludeInboundPorts,
+		annotation.SidecarTrafficExcludeInboundPorts.Name:         ValidateExcludeInboundPorts,
+		annotation.SidecarTrafficExcludeOutboundPorts.Name:        ValidateExcludeOutboundPorts,
+		annotation.SidecarTrafficKubevirtInterfaces.Name:          alwaysValidFunc,
+		annotation.PrometheusMergeMetrics.Name:                    validateBool,
+		annotation.ProxyConfig.Name:                               validateProxyConfig,
+		"k8s.v1.cni.cncf.io/networks":                             alwaysValidFunc,
+	}
+)
+
+func validateProxyConfig(value string) error {
+	config := mesh.DefaultProxyConfig()
+	if err := gogoprotomarshal.ApplyYAML(value, &config); err != nil {
+		return fmt.Errorf("failed to convert to apply proxy config: %v", err)
+	}
+	return validation.ValidateProxyConfig(&config)
+}
+
+func validateAnnotations(annotations map[string]string) (err error) {
+	for name, value := range annotations {
+		if v, ok := AnnotationValidation[name]; ok {
+			if e := v(value); e != nil {
+				err = multierror.Append(err, fmt.Errorf("invalid value '%s' for annotation '%s': %v", value, name, e))
+			}
+		} else if strings.Contains(name, "istio") {
+			log.Warnf("Potentially misspelled annotation '%s' with value '%s' encountered", name, value)
+		}
+	}
+	return
+}
+
+func validatePortList(parameterName, ports string) error {
+	if _, err := parsePorts(ports); err != nil {
+		return fmt.Errorf("%s invalid: %v", parameterName, err)
+	}
+	return nil
+}
+
+// validateInterceptionMode validates the interceptionMode annotation
+func validateInterceptionMode(mode string) error {
+	switch mode {
+	case meshconfig.ProxyConfig_REDIRECT.String():
+	case meshconfig.ProxyConfig_TPROXY.String():
+	case string(model.InterceptionNone): // not a global mesh config - must be enabled for each sidecar
+	default:
+		return fmt.Errorf("interceptionMode invalid, use REDIRECT,TPROXY,NONE: %v", mode)
+	}
+	return nil
+}
+
+// ValidateIncludeIPRanges validates the includeIPRanges parameter
+func ValidateIncludeIPRanges(ipRanges string) error {
+	if ipRanges != "*" {
+		if e := validateCIDRList(ipRanges); e != nil {
+			return fmt.Errorf("includeIPRanges invalid: %v", e)
+		}
+	}
+	return nil
+}
+
+// ValidateExcludeIPRanges validates the excludeIPRanges parameter
+func ValidateExcludeIPRanges(ipRanges string) error {
+	if e := validateCIDRList(ipRanges); e != nil {
+		return fmt.Errorf("excludeIPRanges invalid: %v", e)
+	}
+	return nil
+}
+
+// ValidateIncludeInboundPorts validates the includeInboundPorts parameter
+func ValidateIncludeInboundPorts(ports string) error {
+	if ports != "*" {
+		return validatePortList("includeInboundPorts", ports)
+	}
+	return nil
+}
+
+// ValidateExcludeInboundPorts validates the excludeInboundPorts parameter
+func ValidateExcludeInboundPorts(ports string) error {
+	return validatePortList("excludeInboundPorts", ports)
+}
+
+// ValidateExcludeOutboundPorts validates the excludeOutboundPorts parameter
+func ValidateExcludeOutboundPorts(ports string) error {
+	return validatePortList("excludeOutboundPorts", ports)
+}
+
+// validateStatusPort validates the statusPort parameter
+func validateStatusPort(port string) error {
+	if _, e := parsePort(port); e != nil {
+		return fmt.Errorf("excludeInboundPorts invalid: %v", e)
+	}
+	return nil
+}
+
+// validateUInt32 validates that the given annotation value is a positive integer.
+func validateUInt32(value string) error {
+	_, err := strconv.ParseUint(value, 10, 32)
+	return err
+}
+
+// validateBool validates that the given annotation value is a boolean.
+func validateBool(value string) error {
+	_, err := strconv.ParseBool(value)
+	return err
+}
+
+func validateCIDRList(cidrs string) error {
+	if len(cidrs) > 0 {
+		for _, cidr := range strings.Split(cidrs, ",") {
+			if _, _, err := net.ParseCIDR(cidr); err != nil {
+				return fmt.Errorf("failed parsing cidr '%s': %v", cidr, err)
+			}
+		}
+	}
+	return nil
+}
+
+func splitPorts(portsString string) []string {
+	return strings.Split(portsString, ",")
+}
+
+func parsePort(portStr string) (int, error) {
+	port, err := strconv.ParseUint(strings.TrimSpace(portStr), 10, 16)
+	if err != nil {
+		return 0, fmt.Errorf("failed parsing port '%d': %v", port, err)
+	}
+	return int(port), nil
+}
+
+func parsePorts(portsString string) ([]int, error) {
+	portsString = strings.TrimSpace(portsString)
+	ports := make([]int, 0)
+	if len(portsString) > 0 {
+		for _, portStr := range splitPorts(portsString) {
+			port, err := parsePort(portStr)
+			if err != nil {
+				return nil, fmt.Errorf("failed parsing port '%d': %v", port, err)
+			}
+			ports = append(ports, port)
+		}
+	}
+	return ports, nil
+}


### PR DESCRIPTION
Currently we have a big inject.go file serving many tasks. This splits
it up into validation, templating, and the core injection.

This will be useful to make a future PR I have not so big. This PR is
strictly moving code around, there should be no functional changes



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.