### PR TITLE
enable dns capture by default in workload command

### DIFF
--- a/releasenotes/notes/28794.yaml
+++ b/releasenotes/notes/28794.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+releaseNotes:
+- |
+  **Enabled** DNS capture in istio-agent by default for VMs installed using `istioctl x workload entry configure`.


### PR DESCRIPTION
cc @howardjohn 

We mentioned we wanted to turn this on by default in 1.8 (https://github.com/istio/istio.io/pull/8418) – with the docs changes to use this command, here is where we'd set that default. 