### PR TITLE
Refactor injection internals

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,6 +94,7 @@ require (
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 	golang.org/x/tools v0.0.0-20201017001424-6003fad69a88 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.1.0
+	gomodules.xyz/jsonpatch/v3 v3.0.1
 	google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154
 	google.golang.org/grpc v1.33.1
 	google.golang.org/grpc/examples v0.0.0-20200825162801-44d73dff99bf // indirect

--- a/go.sum
+++ b/go.sum
@@ -1338,6 +1338,10 @@ gomodules.xyz/jsonpatch/v2 v2.0.1 h1:xyiBuvkD2g5n7cYzx6u2sxQvsAy4QJsZFCzGVdzOXZ0
 gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
 gomodules.xyz/jsonpatch/v2 v2.1.0 h1:Phva6wqu+xR//Njw6iorylFFgn/z547tw5Ne3HZPQ+k=
 gomodules.xyz/jsonpatch/v2 v2.1.0/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
+gomodules.xyz/jsonpatch/v3 v3.0.1 h1:Te7hKxV52TKCbNYq3t84tzKav3xhThdvSsSp/W89IyI=
+gomodules.xyz/jsonpatch/v3 v3.0.1/go.mod h1:CBhndykehEwTOlEfnsfJwvkFQbSN8YZFr9M+cIHAJto=
+gomodules.xyz/orderedmap v0.1.0 h1:fM/+TGh/O1KkqGR5xjTKg6bU8OKBkg7p0Y+x/J9m8Os=
+gomodules.xyz/orderedmap v0.1.0/go.mod h1:g9/TPUCm1t2gwD3j3zfV8uylyYhVdCNSi+xCEIu7yTU=
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=

--- a/licenses/gomodules.xyz/jsonpatch/v3/LICENSE
+++ b/licenses/gomodules.xyz/jsonpatch/v3/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/licenses/gomodules.xyz/orderedmap/LICENSE
+++ b/licenses/gomodules.xyz/orderedmap/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Ian Coleman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, Subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or Substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -15,11 +15,11 @@ template: |
     args:
     - istio-iptables
     - "-p"
-    - 15001
+    - "15001"
     - "-z"
     - "15006"
     - "-u"
-    - 1337
+    - "1337"
     - "-m"
     - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
     - "-i"

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -4702,11 +4702,11 @@ data:
         args:
         - istio-iptables
         - "-p"
-        - 15001
+        - "15001"
         - "-z"
         - "15006"
         - "-u"
-        - 1337
+        - "1337"
         - "-m"
         - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
         - "-i"

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -936,11 +936,11 @@ data:
         args:
         - istio-iptables
         - "-p"
-        - 15001
+        - "15001"
         - "-z"
         - "15006"
         - "-u"
-        - 1337
+        - "1337"
         - "-m"
         - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
         - "-i"

--- a/pkg/kube/inject/app_probe.go
+++ b/pkg/kube/inject/app_probe.go
@@ -18,9 +18,9 @@ package inject
 
 import (
 	"encoding/json"
-	"fmt"
 	"strconv"
 
+	"github.com/gogo/protobuf/types"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -30,7 +30,7 @@ import (
 )
 
 // ShouldRewriteAppHTTPProbers returns if we should rewrite apps' probers config.
-func ShouldRewriteAppHTTPProbers(annotations map[string]string, spec *SidecarInjectionSpec) bool {
+func ShouldRewriteAppHTTPProbers(annotations map[string]string, specSetting *types.BoolValue) bool {
 	if annotations != nil {
 		if value, ok := annotations[annotation.SidecarRewriteAppHTTPProbers.Name]; ok {
 			if isSetInAnnotation, err := strconv.ParseBool(value); err == nil {
@@ -38,10 +38,10 @@ func ShouldRewriteAppHTTPProbers(annotations map[string]string, spec *SidecarInj
 			}
 		}
 	}
-	if spec == nil {
+	if specSetting == nil {
 		return false
 	}
-	return spec.RewriteAppHTTPProbe
+	return specSetting.GetValue()
 }
 
 // FindSidecar returns the pointer to the first container whose name matches the "istio-proxy".
@@ -74,7 +74,7 @@ func convertAppProber(probe *corev1.Probe, newURL string, statusPort int) *corev
 
 // DumpAppProbers returns a json encoded string as `status.KubeAppProbers`.
 // Also update the probers so that all usages of named port will be resolved to integer.
-func DumpAppProbers(podspec *corev1.PodSpec) string {
+func DumpAppProbers(podspec *corev1.PodSpec, targetPort int32) string {
 	out := status.KubeAppProbers{}
 	updateNamedPort := func(p *status.Prober, portMap map[string]int32) *status.Prober {
 		if p == nil || p.HTTPGet == nil {
@@ -86,6 +86,9 @@ func DumpAppProbers(podspec *corev1.PodSpec) string {
 				return nil
 			}
 			p.HTTPGet.Port = intstr.FromInt(int(port))
+		} else if p.HTTPGet.Port.IntVal == targetPort {
+			// Already is rewritten
+			return nil
 		}
 		return p
 	}
@@ -123,15 +126,11 @@ func DumpAppProbers(podspec *corev1.PodSpec) string {
 	return string(b)
 }
 
-// createProbeRewritePatch generates the patch for webhook.
-func createProbeRewritePatch(annotations map[string]string, podSpec *corev1.PodSpec, spec *SidecarInjectionSpec, defaultPort int32) []rfc6902PatchOperation {
-	if !ShouldRewriteAppHTTPProbers(annotations, spec) {
-		return []rfc6902PatchOperation{}
-	}
-	podPatches := []rfc6902PatchOperation{}
-	sidecar := FindSidecar(spec.Containers)
+// patchRewriteProbe generates the patch for webhook.
+func patchRewriteProbe(annotations map[string]string, pod *corev1.Pod, defaultPort int32) {
+	sidecar := FindSidecar(pod.Spec.Containers)
 	if sidecar == nil {
-		return nil
+		return
 	}
 	statusPort := int(defaultPort)
 	if v, f := annotations[annotation.SidecarStatusPort.Name]; f {
@@ -141,7 +140,7 @@ func createProbeRewritePatch(annotations map[string]string, podSpec *corev1.PodS
 		}
 		statusPort = p
 	}
-	for i, c := range podSpec.Containers {
+	for i, c := range pod.Spec.Containers {
 		// Skip sidecar container.
 		if c.Name == ProxyContainerName {
 			continue
@@ -152,28 +151,16 @@ func createProbeRewritePatch(annotations map[string]string, podSpec *corev1.PodS
 		}
 		readyz, livez, startupz := status.FormatProberURL(c.Name)
 		if probePatch := convertAppProber(c.ReadinessProbe, readyz, statusPort); probePatch != nil {
-			podPatches = append(podPatches, rfc6902PatchOperation{
-				Op:    "replace",
-				Path:  fmt.Sprintf("/spec/containers/%v/readinessProbe", i),
-				Value: *probePatch,
-			})
+			c.ReadinessProbe = probePatch
 		}
 		if probePatch := convertAppProber(c.LivenessProbe, livez, statusPort); probePatch != nil {
-			podPatches = append(podPatches, rfc6902PatchOperation{
-				Op:    "replace",
-				Path:  fmt.Sprintf("/spec/containers/%v/livenessProbe", i),
-				Value: *probePatch,
-			})
+			c.LivenessProbe = probePatch
 		}
 		if probePatch := convertAppProber(c.StartupProbe, startupz, statusPort); probePatch != nil {
-			podPatches = append(podPatches, rfc6902PatchOperation{
-				Op:    "replace",
-				Path:  fmt.Sprintf("/spec/containers/%v/startupProbe", i),
-				Value: *probePatch,
-			})
+			c.StartupProbe = probePatch
 		}
+		pod.Spec.Containers[i] = c
 	}
-	return podPatches
 }
 
 // kubeProbeToInternalProber converts a Kubernetes Probe to an Istio internal Prober

--- a/pkg/kube/inject/app_probe_test.go
+++ b/pkg/kube/inject/app_probe_test.go
@@ -16,6 +16,7 @@ package inject
 import (
 	"testing"
 
+	"github.com/gogo/protobuf/types"
 	corev1 "k8s.io/api/core/v1"
 
 	"istio.io/api/annotation"
@@ -48,61 +49,61 @@ func TestFindSidecar(t *testing.T) {
 
 func TestShouldRewriteAppHTTPProbers(t *testing.T) {
 	for _, tc := range []struct {
-		name                 string
-		sidecarInjectionSpec SidecarInjectionSpec
-		annotations          map[string]string
-		expected             bool
+		name        string
+		specSetting bool
+		annotations map[string]string
+		expected    bool
 	}{
 		{
-			name:                 "RewriteAppHTTPProbe-set-in-annotations",
-			sidecarInjectionSpec: SidecarInjectionSpec{RewriteAppHTTPProbe: false},
-			annotations:          nil,
-			expected:             false,
+			name:        "RewriteAppHTTPProbe-set-in-annotations",
+			specSetting: false,
+			annotations: nil,
+			expected:    false,
 		},
 		{
-			name:                 "RewriteAppHTTPProbe-set-in-annotations",
-			sidecarInjectionSpec: SidecarInjectionSpec{RewriteAppHTTPProbe: true},
-			annotations:          nil,
-			expected:             true,
+			name:        "RewriteAppHTTPProbe-set-in-annotations",
+			specSetting: true,
+			annotations: nil,
+			expected:    true,
 		},
 		{
-			name:                 "RewriteAppHTTPProbe-set-in-sidecar-injection-spec",
-			sidecarInjectionSpec: SidecarInjectionSpec{RewriteAppHTTPProbe: false},
-			annotations:          map[string]string{},
-			expected:             false,
+			name:        "RewriteAppHTTPProbe-set-in-sidecar-injection-spec",
+			specSetting: false,
+			annotations: map[string]string{},
+			expected:    false,
 		},
 		{
-			name:                 "RewriteAppHTTPProbe-set-in-sidecar-injection-spec",
-			sidecarInjectionSpec: SidecarInjectionSpec{RewriteAppHTTPProbe: true},
-			annotations:          map[string]string{},
-			expected:             true,
+			name:        "RewriteAppHTTPProbe-set-in-sidecar-injection-spec",
+			specSetting: true,
+			annotations: map[string]string{},
+			expected:    true,
 		},
 		{
-			name:                 "RewriteAppHTTPProbe-set-in-annotations",
-			sidecarInjectionSpec: SidecarInjectionSpec{RewriteAppHTTPProbe: false},
-			annotations:          map[string]string{annotation.SidecarRewriteAppHTTPProbers.Name: "true"},
-			expected:             true,
+			name:        "RewriteAppHTTPProbe-set-in-annotations",
+			specSetting: false,
+			annotations: map[string]string{annotation.SidecarRewriteAppHTTPProbers.Name: "true"},
+			expected:    true,
 		},
 		{
-			name:                 "RewriteAppHTTPProbe-set-in-sidecar-injection-spec-&-annotations",
-			sidecarInjectionSpec: SidecarInjectionSpec{RewriteAppHTTPProbe: true},
-			annotations:          map[string]string{annotation.SidecarRewriteAppHTTPProbers.Name: "true"},
-			expected:             true,
+			name:        "RewriteAppHTTPProbe-set-in-sidecar-injection-spec-&-annotations",
+			specSetting: true,
+			annotations: map[string]string{annotation.SidecarRewriteAppHTTPProbers.Name: "true"},
+			expected:    true,
 		},
 		{
-			name:                 "RewriteAppHTTPProbe-set-in-annotations",
-			sidecarInjectionSpec: SidecarInjectionSpec{RewriteAppHTTPProbe: false},
-			annotations:          map[string]string{annotation.SidecarRewriteAppHTTPProbers.Name: "false"},
-			expected:             false,
+			name:        "RewriteAppHTTPProbe-set-in-annotations",
+			specSetting: false,
+			annotations: map[string]string{annotation.SidecarRewriteAppHTTPProbers.Name: "false"},
+			expected:    false,
 		},
 		{
-			name:                 "RewriteAppHTTPProbe-set-in-sidecar-injection-spec-&-annotations",
-			sidecarInjectionSpec: SidecarInjectionSpec{RewriteAppHTTPProbe: true},
-			annotations:          map[string]string{annotation.SidecarRewriteAppHTTPProbers.Name: "false"},
-			expected:             false,
+			name:        "RewriteAppHTTPProbe-set-in-sidecar-injection-spec-&-annotations",
+			specSetting: true,
+			annotations: map[string]string{annotation.SidecarRewriteAppHTTPProbers.Name: "false"},
+			expected:    false,
 		},
 	} {
-		got := ShouldRewriteAppHTTPProbers(tc.annotations, &tc.sidecarInjectionSpec)
+		got := ShouldRewriteAppHTTPProbers(tc.annotations, &types.BoolValue{Value: tc.specSetting})
 		want := tc.expected
 		if got != want {
 			t.Errorf("[%v] failed, want %v, got %v", tc.name, want, got)

--- a/pkg/kube/inject/inject_test.go
+++ b/pkg/kube/inject/inject_test.go
@@ -343,52 +343,10 @@ func TestInjection(t *testing.T) {
 				wantYAMLs := splitYamlFile(wantFilePath, t)
 				for i := 0; i < len(inputYAMLs); i++ {
 					t.Run(fmt.Sprintf("yamlPart[%d]", i), func(t *testing.T) {
-						// Convert the input YAML to a deployment.
-						inputYAML := inputYAMLs[i]
-						inputRaw, err := FromRawToObject(inputYAML)
-						if err != nil {
-							t.Fatal(err)
-						}
-						inputPod := objectToPod(t, inputRaw)
-
-						// Convert the wanted YAML to a deployment.
-						wantYAML := wantYAMLs[i]
-						wantRaw, err := FromRawToObject(wantYAML)
-						if err != nil {
-							t.Fatal(err)
-						}
-						wantPod := objectToPod(t, wantRaw)
-
-						// Generate the patch.  At runtime, the webhook would actually generate the patch against the
-						// pod configuration. But since our input files are deployments, rather than actual pod instances,
-						// we have to apply the patch to the template portion of the deployment only.
-						templateJSON := convertToJSON(inputPod, t)
-						got := webhook.inject(&kube.AdmissionReview{
-							Request: &kube.AdmissionRequest{
-								Object: runtime.RawExtension{
-									Raw: templateJSON,
-								},
-								Namespace: jsonToUnstructured(inputYAML, t).GetNamespace(),
-							},
-						}, "")
-						var gotPod *corev1.Pod
-						// Apply the generated patch to the template.
-						if got.Patch != nil {
-							patchedPod := &corev1.Pod{}
-							patch := prettyJSON(got.Patch, t)
-							patchedTemplateJSON := applyJSONPatch(templateJSON, patch, t)
-							if err := json.Unmarshal(patchedTemplateJSON, patchedPod); err != nil {
-								t.Fatal(err)
-							}
-							gotPod = patchedPod
-						} else {
-							gotPod = inputPod
-						}
-
-						// normalize and compare the patched deployment with the one we expected.
-						if err := normalizeAndCompareDeployments(gotPod, wantPod, t); err != nil {
-							t.Fatal(err)
-						}
+						runWebhook(t, webhook, inputYAMLs[i], wantYAMLs[i])
+						t.Run("idempotency", func(t *testing.T) {
+							runWebhook(t, webhook, wantYAMLs[i], wantYAMLs[i])
+						})
 					})
 				}
 			})
@@ -401,6 +359,116 @@ func TestInjection(t *testing.T) {
 	}
 	if len(allOutputFiles) != 0 {
 		t.Fatalf("stale golden files found: %v", allOutputFiles.UnsortedList())
+	}
+}
+
+// TestStrategicMerge ensures we can use https://github.com/kubernetes/community/blob/master/contributors/devel/sig-api-machinery/strategic-merge-patch.md
+// directives in the injection template
+func TestStrategicMerge(t *testing.T) {
+	webhook := &Webhook{
+		Config: &Config{
+			Template: `
+containers:
+- name: hello
+  image: "fake.docker.io/google-samples/hello-go-gke:1.1"
+  resources:
+    $patch: replace
+    limits:
+      cpu: 100m
+      memory: 50m
+`,
+			Policy: InjectionPolicyEnabled,
+		},
+	}
+	pod := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello
+spec:
+  containers:
+  - name: hello
+    image: "fake.docker.io/google-samples/hello-go-gke:1.0"
+    resources:
+      requests:
+        cpu: 100m
+        memory: 50m
+`
+	// nolint: lll
+	expectedPod := `
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    prometheus.io/path: /stats/prometheus
+    prometheus.io/port: "0"
+    prometheus.io/scrape: "true"
+    sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}'
+  name: hello
+  labels:
+    istio.io/rev: ""
+    security.istio.io/tlsMode: istio
+    service.istio.io/canonical-name: hello
+    service.istio.io/canonical-revision: latest
+spec:
+  containers:
+  - name: hello
+    image: "fake.docker.io/google-samples/hello-go-gke:1.1"
+    resources:
+     limits:
+       cpu: 100m
+       memory: 50m
+  securityContext:
+    fsGroup: 1337
+`
+	// We expect resources to only have limits, since we had the "replace" directive.
+	runWebhook(t, webhook, []byte(pod), []byte(expectedPod))
+}
+
+func runWebhook(t *testing.T, webhook *Webhook, inputYAML []byte, wantYAML []byte) {
+	// Convert the input YAML to a deployment.
+	inputRaw, err := FromRawToObject(inputYAML)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inputPod := objectToPod(t, inputRaw)
+
+	// Convert the wanted YAML to a deployment.
+	wantRaw, err := FromRawToObject(wantYAML)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantPod := objectToPod(t, wantRaw)
+
+	// Generate the patch.  At runtime, the webhook would actually generate the patch against the
+	// pod configuration. But since our input files are deployments, rather than actual pod instances,
+	// we have to apply the patch to the template portion of the deployment only.
+	templateJSON := convertToJSON(inputPod, t)
+	got := webhook.inject(&kube.AdmissionReview{
+		Request: &kube.AdmissionRequest{
+			Object: runtime.RawExtension{
+				Raw: templateJSON,
+			},
+			Namespace: jsonToUnstructured(inputYAML, t).GetNamespace(),
+		},
+	}, "")
+	var gotPod *corev1.Pod
+	// Apply the generated patch to the template.
+	if got.Patch != nil {
+		patchedPod := &corev1.Pod{}
+		patch := prettyJSON(got.Patch, t)
+		patchedTemplateJSON := applyJSONPatch(templateJSON, patch, t)
+		if err := json.Unmarshal(patchedTemplateJSON, patchedPod); err != nil {
+			t.Fatal(err)
+		}
+		gotPod = patchedPod
+	} else {
+		gotPod = inputPod
+	}
+
+	// normalize and compare the patched deployment with the one we expected.
+	if err := normalizeAndCompareDeployments(gotPod, wantPod, t); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/pkg/kube/inject/testdata/inject/hello-multiple-image-secrets.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multiple-image-secrets.yaml.injected
@@ -148,8 +148,8 @@ spec:
         - mountPath: /etc/istio/pod
           name: istio-podinfo
       imagePullSecrets:
-      - name: fooSecret
       - name: barSecret
+      - name: fooSecret
       initContainers:
       - args:
         - istio-iptables

--- a/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -197,9 +197,6 @@ spec:
       securityContext:
         fsGroup: 1337
       volumes:
-      - hostPath:
-          path: /mnt/disks/ssd0
-        name: data
       - emptyDir:
           medium: Memory
         name: istio-envoy
@@ -224,6 +221,9 @@ spec:
       - configMap:
           name: istio-ca-root-cert
         name: istiod-ca-cert
+      - hostPath:
+          path: /mnt/disks/ssd0
+        name: data
   updateStrategy: {}
 status:
   replicas: 0

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject.patch
@@ -1,50 +1,23 @@
 [
   {
     "op": "add",
-    "path": "/spec/initContainers/-",
+    "path": "/metadata/labels",
     "value": {
-      "name": "istio-init",
-      "image": "example.com/init:latest",
-      "resources": {}
+      "istio.io/rev": "",
+      "security.istio.io/tlsMode": "istio",
+      "service.istio.io/canonical-name": "",
+      "service.istio.io/canonical-revision": "latest"
     }
   },
   {
     "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/metadata/annotations",
     "value": {
-      "name": "istio-proxy",
-      "image": "example.com/proxy:latest",
-      "resources": {}
+      "prometheus.io/path": "/stats/prometheus",
+      "prometheus.io/port": "15020",
+      "prometheus.io/scrape": "true",
+      "sidecar.istio.io/status": "{\"version\":\"unit-test-fake-version\",\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
     }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-envoy",
-      "emptyDir": {
-        "medium": "Memory"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-certs",
-      "secret": {
-        "secretName": "istio.default"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/imagePullSecrets",
-    "value": [
-      {
-        "name": "istio-image-pull-secrets"
-      }
-    ]
   },
   {
     "op": "add",
@@ -52,49 +25,5 @@
     "value": {
       "fsGroup": 1337
     }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations",
-    "value": {
-      "prometheus.io/path": "/stats/prometheus"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1port",
-    "value": "15020"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1scrape",
-    "value": "true"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/sidecar.istio.io~1status",
-    "value": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels",
-    "value": {
-      "istio.io/rev": ""
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/security.istio.io~1tlsMode",
-    "value": "istio"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-name",
-    "value": ""
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-revision",
-    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_cron_job.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_cron_job.patch
@@ -1,6 +1,26 @@
 [
   {
     "op": "add",
+    "path": "/metadata/labels",
+    "value": {
+      "istio.io/rev": "",
+      "security.istio.io/tlsMode": "istio",
+      "service.istio.io/canonical-name": "hello",
+      "service.istio.io/canonical-revision": "latest"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/annotations",
+    "value": {
+      "prometheus.io/path": "/stats/prometheus",
+      "prometheus.io/port": "15020",
+      "prometheus.io/scrape": "true",
+      "sidecar.istio.io/status": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":null,\"imagePullSecrets\":null}"
+    }
+  },
+  {
+    "op": "add",
     "path": "/spec/initContainers",
     "value": [
       {
@@ -12,7 +32,7 @@
   },
   {
     "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/spec/containers/1",
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
@@ -35,49 +55,5 @@
     "value": {
       "fsGroup": 1337
     }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations",
-    "value": {
-      "prometheus.io/path": "/stats/prometheus"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1port",
-    "value": "15020"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1scrape",
-    "value": "true"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/sidecar.istio.io~1status",
-    "value": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":null,\"imagePullSecrets\":null}"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels",
-    "value": {
-      "istio.io/rev": ""
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/security.istio.io~1tlsMode",
-    "value": "istio"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-name",
-    "value": "hello"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-revision",
-    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_nosidecar_rewrite.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_nosidecar_rewrite.patch
@@ -1,79 +1,27 @@
 [
   {
-    "op": "replace",
-    "path": "/spec/containers/0/readinessProbe",
-    "value": {
-      "httpGet": {
-        "path": "/app-health/hello/readyz",
-        "port": 15020
-      }
-    }
-  },
-  {
-    "op": "replace",
-    "path": "/spec/containers/0/livenessProbe",
-    "value": {
-      "httpGet": {
-        "path": "/app-health/hello/livez",
-        "port": 15020
-      }
-    }
-  },
-  {
-    "op": "replace",
-    "path": "/spec/containers/1/livenessProbe",
-    "value": {
-      "httpGet": {
-        "path": "/app-health/second/livez",
-        "port": 15020
-      }
-    }
-  },
-  {
-    "op": "remove",
-    "path": "/spec/initContainers/0"
-  },
-  {
     "op": "add",
-    "path": "/spec/initContainers/-",
+    "path": "/metadata/labels",
     "value": {
-      "name": "istio-init",
-      "image": "example.com/init:latest",
-      "resources": {}
+      "istio.io/rev": "",
+      "security.istio.io/tlsMode": "istio",
+      "service.istio.io/canonical-name": "",
+      "service.istio.io/canonical-revision": "latest"
     }
   },
   {
     "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/metadata/annotations",
     "value": {
-      "name": "istio-proxy",
-      "image": "example.com/proxy:latest",
-      "args": [
-        "--statusPort",
-        "15020"
-      ],
-      "env": [
-        {
-          "name": "ISTIO_KUBE_APP_PROBERS",
-          "value": "{\"/app-health/hello/livez\":{\"httpGet\":{\"path\":\"/live\",\"port\":80}},\"/app-health/hello/readyz\":{\"httpGet\":{\"path\":\"/ready\",\"port\":3333}},\"/app-health/second/livez\":{\"httpGet\":{\"port\":9000}}}"
-        }
-      ],
-      "resources": {}
+      "prometheus.io/path": "/stats/prometheus",
+      "prometheus.io/port": "15020",
+      "prometheus.io/scrape": "true",
+      "sidecar.istio.io/status": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
     }
   },
   {
     "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-envoy",
-      "emptyDir": {
-        "medium": "Memory"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
+    "path": "/spec/volumes/1",
     "value": {
       "name": "istio-certs",
       "secret": {
@@ -83,12 +31,40 @@
   },
   {
     "op": "add",
-    "path": "/spec/imagePullSecrets",
-    "value": [
-      {
-        "name": "istio-image-pull-secrets"
-      }
-    ]
+    "path": "/spec/volumes/2",
+    "value": {
+      "name": "v0"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/volumes/0/name",
+    "value": "istio-envoy"
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/0/emptyDir",
+    "value": {
+      "medium": "Memory"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers/0/image",
+    "value": "example.com/init:latest"
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/2",
+    "value": {
+      "name": "istio-proxy",
+      "image": "example.com/proxy:latest",
+      "args": [
+        "--statusPort",
+        "15020"
+      ],
+      "resources": {}
+    }
   },
   {
     "op": "add",
@@ -99,46 +75,11 @@
   },
   {
     "op": "add",
-    "path": "/metadata/annotations",
-    "value": {
-      "prometheus.io/path": "/stats/prometheus"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1port",
-    "value": "15020"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1scrape",
-    "value": "true"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/sidecar.istio.io~1status",
-    "value": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels",
-    "value": {
-      "istio.io/rev": ""
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/security.istio.io~1tlsMode",
-    "value": "istio"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-name",
-    "value": ""
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-revision",
-    "value": "latest"
+    "path": "/spec/imagePullSecrets",
+    "value": [
+      {
+        "name": "istio-image-pull-secrets"
+      }
+    ]
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_nosidecar_rewrite_template.yaml
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_nosidecar_rewrite_template.yaml
@@ -12,7 +12,7 @@ template: |-
     image: example.com/proxy:latest
     args:
       - --statusPort
-      - 15020
+      - "15020"
   imagePullSecrets:
   - name: istio-image-pull-secrets
   volumes:

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite.patch
@@ -1,83 +1,27 @@
 [
   {
-    "op": "replace",
-    "path": "/spec/containers/1/readinessProbe",
-    "value": {
-      "httpGet": {
-        "path": "/app-health/hello/readyz",
-        "port": 15020
-      }
-    }
-  },
-  {
-    "op": "replace",
-    "path": "/spec/containers/1/livenessProbe",
-    "value": {
-      "httpGet": {
-        "path": "/app-health/hello/livez",
-        "port": 15020
-      }
-    }
-  },
-  {
-    "op": "replace",
-    "path": "/spec/containers/2/livenessProbe",
-    "value": {
-      "httpGet": {
-        "path": "/app-health/second/livez",
-        "port": 15020
-      }
-    }
-  },
-  {
-    "op": "remove",
-    "path": "/spec/initContainers/0"
-  },
-  {
-    "op": "remove",
-    "path": "/spec/containers/0"
-  },
-  {
     "op": "add",
-    "path": "/spec/initContainers/-",
+    "path": "/metadata/labels",
     "value": {
-      "name": "istio-init",
-      "image": "example.com/init:latest",
-      "resources": {}
+      "istio.io/rev": "",
+      "security.istio.io/tlsMode": "istio",
+      "service.istio.io/canonical-name": "",
+      "service.istio.io/canonical-revision": "latest"
     }
   },
   {
     "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/metadata/annotations",
     "value": {
-      "name": "istio-proxy",
-      "image": "example.com/proxy:latest",
-      "args": [
-        "--statusPort",
-        "15020"
-      ],
-      "env": [
-        {
-          "name": "ISTIO_KUBE_APP_PROBERS",
-          "value": "{\"/app-health/hello/livez\":{\"httpGet\":{\"path\":\"/live\",\"port\":80}},\"/app-health/hello/readyz\":{\"httpGet\":{\"path\":\"/ready\",\"port\":3333}},\"/app-health/second/livez\":{\"httpGet\":{\"port\":9000}}}"
-        }
-      ],
-      "resources": {}
+      "prometheus.io/path": "/stats/prometheus",
+      "prometheus.io/port": "15020",
+      "prometheus.io/scrape": "true",
+      "sidecar.istio.io/status": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
     }
   },
   {
     "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-envoy",
-      "emptyDir": {
-        "medium": "Memory"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
+    "path": "/spec/volumes/1",
     "value": {
       "name": "istio-certs",
       "secret": {
@@ -87,12 +31,115 @@
   },
   {
     "op": "add",
-    "path": "/spec/imagePullSecrets",
+    "path": "/spec/volumes/2",
+    "value": {
+      "name": "v0"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/volumes/0/name",
+    "value": "istio-envoy"
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/0/emptyDir",
+    "value": {
+      "medium": "Memory"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers/0/image",
+    "value": "example.com/init:latest"
+  },
+  {
+    "op": "replace",
+    "path": "/spec/containers/0/name",
+    "value": "hello"
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/0/image",
+    "value": "fake.docker.io/google-samples/hello-go-gke:1.0"
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/0/ports",
     "value": [
       {
-        "name": "istio-image-pull-secrets"
+        "name": "http",
+        "containerPort": 80
       }
     ]
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/0/livenessProbe",
+    "value": {
+      "httpGet": {
+        "path": "/live",
+        "port": "http"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/0/readinessProbe",
+    "value": {
+      "httpGet": {
+        "path": "/ready",
+        "port": 3333
+      }
+    }
+  },
+  {
+    "op": "remove",
+    "path": "/spec/containers/0/args"
+  },
+  {
+    "op": "replace",
+    "path": "/spec/containers/1/name",
+    "value": "second"
+  },
+  {
+    "op": "replace",
+    "path": "/spec/containers/1/livenessProbe/httpGet/port",
+    "value": 9000
+  },
+  {
+    "op": "remove",
+    "path": "/spec/containers/1/livenessProbe/httpGet/path"
+  },
+  {
+    "op": "remove",
+    "path": "/spec/containers/1/ports"
+  },
+  {
+    "op": "remove",
+    "path": "/spec/containers/1/readinessProbe"
+  },
+  {
+    "op": "replace",
+    "path": "/spec/containers/2/name",
+    "value": "istio-proxy"
+  },
+  {
+    "op": "replace",
+    "path": "/spec/containers/2/image",
+    "value": "example.com/proxy:latest"
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/2/args",
+    "value": [
+      "--statusPort",
+      "15020"
+    ]
+  },
+  {
+    "op": "remove",
+    "path": "/spec/containers/2/livenessProbe"
   },
   {
     "op": "add",
@@ -103,46 +150,11 @@
   },
   {
     "op": "add",
-    "path": "/metadata/annotations",
-    "value": {
-      "prometheus.io/path": "/stats/prometheus"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1port",
-    "value": "15020"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1scrape",
-    "value": "true"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/sidecar.istio.io~1status",
-    "value": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels",
-    "value": {
-      "istio.io/rev": ""
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/security.istio.io~1tlsMode",
-    "value": "istio"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-name",
-    "value": ""
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-revision",
-    "value": "latest"
+    "path": "/spec/imagePullSecrets",
+    "value": [
+      {
+        "name": "istio-image-pull-secrets"
+      }
+    ]
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_disabled_via_annotation.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_disabled_via_annotation.patch
@@ -1,56 +1,12 @@
 [
   {
     "op": "add",
-    "path": "/spec/initContainers/-",
+    "path": "/metadata/labels",
     "value": {
-      "name": "istio-init",
-      "image": "example.com/init:latest",
-      "resources": {}
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/containers/-",
-    "value": {
-      "name": "istio-proxy",
-      "image": "example.com/proxy:latest",
-      "resources": {}
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-envoy",
-      "emptyDir": {
-        "medium": "Memory"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-certs",
-      "secret": {
-        "secretName": "istio.default"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/imagePullSecrets",
-    "value": [
-      {
-        "name": "istio-image-pull-secrets"
-      }
-    ]
-  },
-  {
-    "op": "add",
-    "path": "/spec/securityContext",
-    "value": {
-      "fsGroup": 1337
+      "istio.io/rev": "",
+      "security.istio.io/tlsMode": "istio",
+      "service.istio.io/canonical-name": "",
+      "service.istio.io/canonical-revision": "latest"
     }
   },
   {
@@ -75,24 +31,65 @@
   },
   {
     "op": "add",
-    "path": "/metadata/labels",
+    "path": "/spec/volumes/1",
     "value": {
-      "istio.io/rev": ""
+      "name": "istio-certs",
+      "secret": {
+        "secretName": "istio.default"
+      }
     }
   },
   {
     "op": "add",
-    "path": "/metadata/labels/security.istio.io~1tlsMode",
-    "value": "istio"
+    "path": "/spec/volumes/2",
+    "value": {
+      "name": "v0"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/volumes/0/name",
+    "value": "istio-envoy"
   },
   {
     "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-name",
-    "value": ""
+    "path": "/spec/volumes/0/emptyDir",
+    "value": {
+      "medium": "Memory"
+    }
   },
   {
     "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-revision",
-    "value": "latest"
+    "path": "/spec/initContainers/1",
+    "value": {
+      "name": "istio-init",
+      "image": "example.com/init:latest",
+      "resources": {}
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/1",
+    "value": {
+      "name": "istio-proxy",
+      "image": "example.com/proxy:latest",
+      "resources": {}
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/securityContext",
+    "value": {
+      "fsGroup": 1337
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/imagePullSecrets",
+    "value": [
+      {
+        "name": "istio-image-pull-secrets"
+      }
+    ]
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_enabled_via_annotation.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_enabled_via_annotation.patch
@@ -1,104 +1,12 @@
 [
   {
-    "op": "replace",
-    "path": "/spec/containers/1/readinessProbe",
-    "value": {
-      "httpGet": {
-        "path": "/app-health/hello/readyz",
-        "port": 15020
-      }
-    }
-  },
-  {
-    "op": "replace",
-    "path": "/spec/containers/1/livenessProbe",
-    "value": {
-      "httpGet": {
-        "path": "/app-health/hello/livez",
-        "port": 15020
-      }
-    }
-  },
-  {
-    "op": "replace",
-    "path": "/spec/containers/2/livenessProbe",
-    "value": {
-      "httpGet": {
-        "path": "/app-health/second/livez",
-        "port": 15020
-      }
-    }
-  },
-  {
-    "op": "remove",
-    "path": "/spec/initContainers/0"
-  },
-  {
-    "op": "remove",
-    "path": "/spec/containers/0"
-  },
-  {
     "op": "add",
-    "path": "/spec/initContainers/-",
+    "path": "/metadata/labels",
     "value": {
-      "name": "istio-init",
-      "image": "example.com/init:latest",
-      "resources": {}
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/containers/-",
-    "value": {
-      "name": "istio-proxy",
-      "image": "example.com/proxy:latest",
-      "args": [
-        "--statusPort",
-        "15020"
-      ],
-      "env": [
-        {
-          "name": "ISTIO_KUBE_APP_PROBERS",
-          "value": "{\"/app-health/hello/livez\":{\"httpGet\":{\"path\":\"/live\",\"port\":80}},\"/app-health/hello/readyz\":{\"httpGet\":{\"path\":\"/ready\",\"port\":3333}},\"/app-health/second/livez\":{\"httpGet\":{\"port\":9000}}}"
-        }
-      ],
-      "resources": {}
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-envoy",
-      "emptyDir": {
-        "medium": "Memory"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-certs",
-      "secret": {
-        "secretName": "istio.default"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/imagePullSecrets",
-    "value": [
-      {
-        "name": "istio-image-pull-secrets"
-      }
-    ]
-  },
-  {
-    "op": "add",
-    "path": "/spec/securityContext",
-    "value": {
-      "fsGroup": 1337
+      "istio.io/rev": "",
+      "security.istio.io/tlsMode": "istio",
+      "service.istio.io/canonical-name": "",
+      "service.istio.io/canonical-revision": "latest"
     }
   },
   {
@@ -123,24 +31,151 @@
   },
   {
     "op": "add",
-    "path": "/metadata/labels",
+    "path": "/spec/volumes/1",
     "value": {
-      "istio.io/rev": ""
+      "name": "istio-certs",
+      "secret": {
+        "secretName": "istio.default"
+      }
     }
   },
   {
     "op": "add",
-    "path": "/metadata/labels/security.istio.io~1tlsMode",
-    "value": "istio"
+    "path": "/spec/volumes/2",
+    "value": {
+      "name": "v0"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/volumes/0/name",
+    "value": "istio-envoy"
   },
   {
     "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-name",
-    "value": ""
+    "path": "/spec/volumes/0/emptyDir",
+    "value": {
+      "medium": "Memory"
+    }
   },
   {
     "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-revision",
-    "value": "latest"
+    "path": "/spec/initContainers/0/image",
+    "value": "example.com/init:latest"
+  },
+  {
+    "op": "replace",
+    "path": "/spec/containers/0/name",
+    "value": "hello"
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/0/image",
+    "value": "fake.docker.io/google-samples/hello-go-gke:1.0"
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/0/ports",
+    "value": [
+      {
+        "name": "http",
+        "containerPort": 80
+      }
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/0/livenessProbe",
+    "value": {
+      "httpGet": {
+        "path": "/app-health/hello/livez",
+        "port": 15020
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/0/readinessProbe",
+    "value": {
+      "httpGet": {
+        "path": "/app-health/hello/readyz",
+        "port": 15020
+      }
+    }
+  },
+  {
+    "op": "remove",
+    "path": "/spec/containers/0/args"
+  },
+  {
+    "op": "replace",
+    "path": "/spec/containers/1/name",
+    "value": "second"
+  },
+  {
+    "op": "replace",
+    "path": "/spec/containers/1/livenessProbe/httpGet/path",
+    "value": "/app-health/second/livez"
+  },
+  {
+    "op": "replace",
+    "path": "/spec/containers/1/livenessProbe/httpGet/port",
+    "value": 15020
+  },
+  {
+    "op": "remove",
+    "path": "/spec/containers/1/ports"
+  },
+  {
+    "op": "remove",
+    "path": "/spec/containers/1/readinessProbe"
+  },
+  {
+    "op": "replace",
+    "path": "/spec/containers/2/name",
+    "value": "istio-proxy"
+  },
+  {
+    "op": "replace",
+    "path": "/spec/containers/2/image",
+    "value": "example.com/proxy:latest"
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/2/args",
+    "value": [
+      "--statusPort",
+      "15020"
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/2/env",
+    "value": [
+      {
+        "name": "ISTIO_KUBE_APP_PROBERS",
+        "value": "{\"/app-health/hello/livez\":{\"httpGet\":{\"path\":\"/live\",\"port\":80}},\"/app-health/hello/readyz\":{\"httpGet\":{\"path\":\"/ready\",\"port\":3333}},\"/app-health/second/livez\":{\"httpGet\":{\"port\":9000}}}"
+      }
+    ]
+  },
+  {
+    "op": "remove",
+    "path": "/spec/containers/2/livenessProbe"
+  },
+  {
+    "op": "add",
+    "path": "/spec/securityContext",
+    "value": {
+      "fsGroup": 1337
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/imagePullSecrets",
+    "value": [
+      {
+        "name": "istio-image-pull-secrets"
+      }
+    ]
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_enabled_via_annotation_template.yaml
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_enabled_via_annotation_template.yaml
@@ -12,7 +12,7 @@ template: |-
     image: example.com/proxy:latest
     args:
       - --statusPort
-      - 15020
+      - "15020"
   imagePullSecrets:
   - name: istio-image-pull-secrets
   volumes:

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_template.yaml
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_template.yaml
@@ -12,7 +12,7 @@ template: |-
     image: example.com/proxy:latest
     args:
       - --statusPort
-      - 15020
+      - "15020"
   imagePullSecrets:
   - name: istio-image-pull-secrets
   volumes:

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_https_probe_rewrite.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_https_probe_rewrite.patch
@@ -1,84 +1,27 @@
 [
   {
-    "op": "replace",
-    "path": "/spec/containers/1/readinessProbe",
-    "value": {
-      "httpGet": {
-        "path": "/app-health/hello/readyz",
-        "port": 15020,
-        "scheme": "HTTP"
-      }
-    }
-  },
-  {
-    "op": "replace",
-    "path": "/spec/containers/1/livenessProbe",
-    "value": {
-      "httpGet": {
-        "path": "/app-health/hello/livez",
-        "port": 15020
-      }
-    }
-  },
-  {
-    "op": "replace",
-    "path": "/spec/containers/2/livenessProbe",
-    "value": {
-      "httpGet": {
-        "path": "/app-health/second/livez",
-        "port": 15020
-      }
-    }
-  },
-  {
-    "op": "remove",
-    "path": "/spec/initContainers/0"
-  },
-  {
-    "op": "remove",
-    "path": "/spec/containers/0"
-  },
-  {
     "op": "add",
-    "path": "/spec/initContainers/-",
+    "path": "/metadata/labels",
     "value": {
-      "name": "istio-init",
-      "image": "example.com/init:latest",
-      "resources": {}
+      "istio.io/rev": "",
+      "security.istio.io/tlsMode": "istio",
+      "service.istio.io/canonical-name": "",
+      "service.istio.io/canonical-revision": "latest"
     }
   },
   {
     "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/metadata/annotations",
     "value": {
-      "name": "istio-proxy",
-      "image": "example.com/proxy:latest",
-      "args": [
-        "--statusPort",
-        "15020"
-      ],
-      "env": [
-        {
-          "name": "ISTIO_KUBE_APP_PROBERS",
-          "value": "{\"/app-health/hello/livez\":{\"httpGet\":{\"path\":\"/live\",\"port\":80}},\"/app-health/hello/readyz\":{\"httpGet\":{\"path\":\"/ready\",\"port\":3333,\"scheme\":\"HTTPS\"}},\"/app-health/second/livez\":{\"httpGet\":{\"port\":9000}}}"
-        }
-      ],
-      "resources": {}
+      "prometheus.io/path": "/stats/prometheus",
+      "prometheus.io/port": "15020",
+      "prometheus.io/scrape": "true",
+      "sidecar.istio.io/status": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
     }
   },
   {
     "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-envoy",
-      "emptyDir": {
-        "medium": "Memory"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
+    "path": "/spec/volumes/1",
     "value": {
       "name": "istio-certs",
       "secret": {
@@ -88,12 +31,116 @@
   },
   {
     "op": "add",
-    "path": "/spec/imagePullSecrets",
+    "path": "/spec/volumes/2",
+    "value": {
+      "name": "v0"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/volumes/0/name",
+    "value": "istio-envoy"
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/0/emptyDir",
+    "value": {
+      "medium": "Memory"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers/0/image",
+    "value": "example.com/init:latest"
+  },
+  {
+    "op": "replace",
+    "path": "/spec/containers/0/name",
+    "value": "hello"
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/0/image",
+    "value": "fake.docker.io/google-samples/hello-go-gke:1.0"
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/0/ports",
     "value": [
       {
-        "name": "istio-image-pull-secrets"
+        "name": "http",
+        "containerPort": 80
       }
     ]
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/0/livenessProbe",
+    "value": {
+      "httpGet": {
+        "path": "/live",
+        "port": "http"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/0/readinessProbe",
+    "value": {
+      "httpGet": {
+        "path": "/ready",
+        "port": 3333,
+        "scheme": "HTTPS"
+      }
+    }
+  },
+  {
+    "op": "remove",
+    "path": "/spec/containers/0/args"
+  },
+  {
+    "op": "replace",
+    "path": "/spec/containers/1/name",
+    "value": "second"
+  },
+  {
+    "op": "replace",
+    "path": "/spec/containers/1/livenessProbe/httpGet/port",
+    "value": 9000
+  },
+  {
+    "op": "remove",
+    "path": "/spec/containers/1/livenessProbe/httpGet/path"
+  },
+  {
+    "op": "remove",
+    "path": "/spec/containers/1/ports"
+  },
+  {
+    "op": "remove",
+    "path": "/spec/containers/1/readinessProbe"
+  },
+  {
+    "op": "replace",
+    "path": "/spec/containers/2/name",
+    "value": "istio-proxy"
+  },
+  {
+    "op": "replace",
+    "path": "/spec/containers/2/image",
+    "value": "example.com/proxy:latest"
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/2/args",
+    "value": [
+      "--statusPort",
+      "15020"
+    ]
+  },
+  {
+    "op": "remove",
+    "path": "/spec/containers/2/livenessProbe"
   },
   {
     "op": "add",
@@ -104,46 +151,11 @@
   },
   {
     "op": "add",
-    "path": "/metadata/annotations",
-    "value": {
-      "prometheus.io/path": "/stats/prometheus"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1port",
-    "value": "15020"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1scrape",
-    "value": "true"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/sidecar.istio.io~1status",
-    "value": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels",
-    "value": {
-      "istio.io/rev": ""
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/security.istio.io~1tlsMode",
-    "value": "istio"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-name",
-    "value": ""
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-revision",
-    "value": "latest"
+    "path": "/spec/imagePullSecrets",
+    "value": [
+      {
+        "name": "istio-image-pull-secrets"
+      }
+    ]
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_https_probe_rewrite_template.yaml
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_https_probe_rewrite_template.yaml
@@ -12,7 +12,7 @@ template: |-
     image: example.com/proxy:latest
     args:
       - --statusPort
-      - 15020
+      - "15020"
   imagePullSecrets:
   - name: istio-image-pull-secrets
   volumes:

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_injectorAnnotations.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_injectorAnnotations.patch
@@ -1,7 +1,67 @@
 [
   {
     "op": "add",
-    "path": "/spec/initContainers/-",
+    "path": "/metadata/labels",
+    "value": {
+      "istio.io/rev": "",
+      "security.istio.io/tlsMode": "istio",
+      "service.istio.io/canonical-name": "something",
+      "service.istio.io/canonical-revision": "latest"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/annotations",
+    "value": {
+      "bar": "baz",
+      "foo": "bar",
+      "prometheus.io/path": "/stats/prometheus",
+      "prometheus.io/port": "15020",
+      "prometheus.io/scrape": "true",
+      "sidecar.istio.io/status": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/2",
+    "value": {
+      "name": "v0"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/3",
+    "value": {
+      "name": "injected2"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/volumes/0/name",
+    "value": "istio-envoy"
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/0/emptyDir",
+    "value": {
+      "medium": "Memory"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/volumes/1/name",
+    "value": "istio-certs"
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/1/secret",
+    "value": {
+      "secretName": "istio.default"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers/2",
     "value": {
       "name": "istio-init",
       "image": "example.com/init:latest",
@@ -10,41 +70,12 @@
   },
   {
     "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/spec/containers/2",
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
       "resources": {}
     }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-envoy",
-      "emptyDir": {
-        "medium": "Memory"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-certs",
-      "secret": {
-        "secretName": "istio.default"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/imagePullSecrets",
-    "value": [
-      {
-        "name": "istio-image-pull-secrets"
-      }
-    ]
   },
   {
     "op": "add",
@@ -55,56 +86,11 @@
   },
   {
     "op": "add",
-    "path": "/metadata/annotations",
-    "value": {
-      "bar": "baz"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/foo",
-    "value": "bar"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1path",
-    "value": "/stats/prometheus"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1port",
-    "value": "15020"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1scrape",
-    "value": "true"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/sidecar.istio.io~1status",
-    "value": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels",
-    "value": {
-      "istio.io/rev": ""
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/security.istio.io~1tlsMode",
-    "value": "istio"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-name",
-    "value": "something"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-revision",
-    "value": "latest"
+    "path": "/spec/imagePullSecrets",
+    "value": [
+      {
+        "name": "istio-image-pull-secrets"
+      }
+    ]
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_mtls_not_ready.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_mtls_not_ready.patch
@@ -1,82 +1,6 @@
 [
   {
     "op": "add",
-    "path": "/spec/initContainers/-",
-    "value": {
-      "name": "istio-init",
-      "image": "example.com/init:latest",
-      "resources": {}
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/containers/-",
-    "value": {
-      "name": "istio-proxy",
-      "image": "example.com/proxy:latest",
-      "resources": {}
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-envoy",
-      "emptyDir": {
-        "medium": "Memory"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-certs",
-      "secret": {
-        "secretName": "istio.default"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/imagePullSecrets",
-    "value": [
-      {
-        "name": "istio-image-pull-secrets"
-      }
-    ]
-  },
-  {
-    "op": "add",
-    "path": "/spec/securityContext",
-    "value": {
-      "fsGroup": 1337
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations",
-    "value": {
-      "prometheus.io/path": "/stats/prometheus"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1port",
-    "value": "15020"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1scrape",
-    "value": "true"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/sidecar.istio.io~1status",
-    "value": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
-  },
-  {
-    "op": "add",
     "path": "/metadata/labels/istio.io~1rev",
     "value": ""
   },
@@ -89,5 +13,22 @@
     "op": "add",
     "path": "/metadata/labels/service.istio.io~1canonical-revision",
     "value": "latest"
+  },
+  {
+    "op": "add",
+    "path": "/metadata/annotations",
+    "value": {
+      "prometheus.io/path": "/stats/prometheus",
+      "prometheus.io/port": "15020",
+      "prometheus.io/scrape": "true",
+      "sidecar.istio.io/status": "{\"version\":\"unit-test-fake-version\",\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/securityContext",
+    "value": {
+      "fsGroup": 1337
+    }
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers.patch
@@ -1,50 +1,28 @@
 [
   {
     "op": "add",
-    "path": "/spec/initContainers/-",
+    "path": "/metadata/labels",
     "value": {
-      "name": "istio-init",
-      "image": "example.com/init:latest",
-      "resources": {}
+      "istio.io/rev": "",
+      "security.istio.io/tlsMode": "istio",
+      "service.istio.io/canonical-name": "",
+      "service.istio.io/canonical-revision": "latest"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/annotations",
+    "value": {
+      "prometheus.io/path": "/stats/prometheus",
+      "prometheus.io/port": "15020",
+      "prometheus.io/scrape": "true",
+      "sidecar.istio.io/status": "{\"version\":\"unit-test-fake-version\",\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
     }
   },
   {
     "op": "add",
     "path": "/spec/containers",
-    "value": [
-      {
-        "name": "istio-proxy",
-        "image": "example.com/proxy:latest",
-        "resources": {}
-      }
-    ]
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-envoy",
-      "emptyDir": {
-        "medium": "Memory"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-certs",
-      "secret": {
-        "secretName": "istio.default"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/imagePullSecrets/-",
-    "value": {
-      "name": "istio-image-pull-secrets"
-    }
+    "value": []
   },
   {
     "op": "add",
@@ -52,49 +30,5 @@
     "value": {
       "fsGroup": 1337
     }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations",
-    "value": {
-      "prometheus.io/path": "/stats/prometheus"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1port",
-    "value": "15020"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1scrape",
-    "value": "true"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/sidecar.istio.io~1status",
-    "value": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels",
-    "value": {
-      "istio.io/rev": ""
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/security.istio.io~1tlsMode",
-    "value": "istio"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-name",
-    "value": ""
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-revision",
-    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_imagePullSecrets.patch
@@ -1,52 +1,28 @@
 [
   {
     "op": "add",
-    "path": "/spec/initContainers/-",
+    "path": "/metadata/labels",
     "value": {
-      "name": "istio-init",
-      "image": "example.com/init:latest",
-      "resources": {}
+      "istio.io/rev": "",
+      "security.istio.io/tlsMode": "istio",
+      "service.istio.io/canonical-name": "",
+      "service.istio.io/canonical-revision": "latest"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/annotations",
+    "value": {
+      "prometheus.io/path": "/stats/prometheus",
+      "prometheus.io/port": "15020",
+      "prometheus.io/scrape": "true",
+      "sidecar.istio.io/status": "{\"version\":\"unit-test-fake-version\",\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
     }
   },
   {
     "op": "add",
     "path": "/spec/containers",
-    "value": [
-      {
-        "name": "istio-proxy",
-        "image": "example.com/proxy:latest",
-        "resources": {}
-      }
-    ]
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-envoy",
-      "emptyDir": {
-        "medium": "Memory"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-certs",
-      "secret": {
-        "secretName": "istio.default"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/imagePullSecrets",
-    "value": [
-      {
-        "name": "istio-image-pull-secrets"
-      }
-    ]
+    "value": []
   },
   {
     "op": "add",
@@ -54,49 +30,5 @@
     "value": {
       "fsGroup": 1337
     }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations",
-    "value": {
-      "prometheus.io/path": "/stats/prometheus"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1port",
-    "value": "15020"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1scrape",
-    "value": "true"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/sidecar.istio.io~1status",
-    "value": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels",
-    "value": {
-      "istio.io/rev": ""
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/security.istio.io~1tlsMode",
-    "value": "istio"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-name",
-    "value": ""
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-revision",
-    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes.patch
@@ -1,52 +1,28 @@
 [
   {
     "op": "add",
-    "path": "/spec/initContainers/-",
+    "path": "/metadata/labels",
     "value": {
-      "name": "istio-init",
-      "image": "example.com/init:latest",
-      "resources": {}
+      "istio.io/rev": "",
+      "security.istio.io/tlsMode": "istio",
+      "service.istio.io/canonical-name": "",
+      "service.istio.io/canonical-revision": "latest"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/annotations",
+    "value": {
+      "prometheus.io/path": "/stats/prometheus",
+      "prometheus.io/port": "15020",
+      "prometheus.io/scrape": "true",
+      "sidecar.istio.io/status": "{\"version\":\"unit-test-fake-version\",\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
     }
   },
   {
     "op": "add",
     "path": "/spec/containers",
-    "value": [
-      {
-        "name": "istio-proxy",
-        "image": "example.com/proxy:latest",
-        "resources": {}
-      }
-    ]
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes",
-    "value": [
-      {
-        "name": "istio-envoy",
-        "emptyDir": {
-          "medium": "Memory"
-        }
-      }
-    ]
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-certs",
-      "secret": {
-        "secretName": "istio.default"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/imagePullSecrets/-",
-    "value": {
-      "name": "istio-image-pull-secrets"
-    }
+    "value": []
   },
   {
     "op": "add",
@@ -54,49 +30,5 @@
     "value": {
       "fsGroup": 1337
     }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations",
-    "value": {
-      "prometheus.io/path": "/stats/prometheus"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1port",
-    "value": "15020"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1scrape",
-    "value": "true"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/sidecar.istio.io~1status",
-    "value": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels",
-    "value": {
-      "istio.io/rev": ""
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/security.istio.io~1tlsMode",
-    "value": "istio"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-name",
-    "value": ""
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-revision",
-    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes_imagePullSecrets.patch
@@ -1,54 +1,28 @@
 [
   {
     "op": "add",
-    "path": "/spec/initContainers/-",
+    "path": "/metadata/labels",
     "value": {
-      "name": "istio-init",
-      "image": "example.com/init:latest",
-      "resources": {}
+      "istio.io/rev": "",
+      "security.istio.io/tlsMode": "istio",
+      "service.istio.io/canonical-name": "",
+      "service.istio.io/canonical-revision": "latest"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/annotations",
+    "value": {
+      "prometheus.io/path": "/stats/prometheus",
+      "prometheus.io/port": "15020",
+      "prometheus.io/scrape": "true",
+      "sidecar.istio.io/status": "{\"version\":\"unit-test-fake-version\",\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
     }
   },
   {
     "op": "add",
     "path": "/spec/containers",
-    "value": [
-      {
-        "name": "istio-proxy",
-        "image": "example.com/proxy:latest",
-        "resources": {}
-      }
-    ]
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes",
-    "value": [
-      {
-        "name": "istio-envoy",
-        "emptyDir": {
-          "medium": "Memory"
-        }
-      }
-    ]
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-certs",
-      "secret": {
-        "secretName": "istio.default"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/imagePullSecrets",
-    "value": [
-      {
-        "name": "istio-image-pull-secrets"
-      }
-    ]
+    "value": []
   },
   {
     "op": "add",
@@ -56,49 +30,5 @@
     "value": {
       "fsGroup": 1337
     }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations",
-    "value": {
-      "prometheus.io/path": "/stats/prometheus"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1port",
-    "value": "15020"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1scrape",
-    "value": "true"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/sidecar.istio.io~1status",
-    "value": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels",
-    "value": {
-      "istio.io/rev": ""
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/security.istio.io~1tlsMode",
-    "value": "istio"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-name",
-    "value": ""
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-revision",
-    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_imagePullSecrets.patch
@@ -1,50 +1,23 @@
 [
   {
     "op": "add",
-    "path": "/spec/initContainers/-",
+    "path": "/metadata/labels",
     "value": {
-      "name": "istio-init",
-      "image": "example.com/init:latest",
-      "resources": {}
+      "istio.io/rev": "",
+      "security.istio.io/tlsMode": "istio",
+      "service.istio.io/canonical-name": "",
+      "service.istio.io/canonical-revision": "latest"
     }
   },
   {
     "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/metadata/annotations",
     "value": {
-      "name": "istio-proxy",
-      "image": "example.com/proxy:latest",
-      "resources": {}
+      "prometheus.io/path": "/stats/prometheus",
+      "prometheus.io/port": "15020",
+      "prometheus.io/scrape": "true",
+      "sidecar.istio.io/status": "{\"version\":\"unit-test-fake-version\",\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
     }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-envoy",
-      "emptyDir": {
-        "medium": "Memory"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-certs",
-      "secret": {
-        "secretName": "istio.default"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/imagePullSecrets",
-    "value": [
-      {
-        "name": "istio-image-pull-secrets"
-      }
-    ]
   },
   {
     "op": "add",
@@ -52,49 +25,5 @@
     "value": {
       "fsGroup": 1337
     }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations",
-    "value": {
-      "prometheus.io/path": "/stats/prometheus"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1port",
-    "value": "15020"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1scrape",
-    "value": "true"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/sidecar.istio.io~1status",
-    "value": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels",
-    "value": {
-      "istio.io/rev": ""
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/security.istio.io~1tlsMode",
-    "value": "istio"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-name",
-    "value": ""
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-revision",
-    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers.patch
@@ -1,49 +1,22 @@
 [
   {
     "op": "add",
-    "path": "/spec/initContainers",
-    "value": [
-      {
-        "name": "istio-init",
-        "image": "example.com/init:latest",
-        "resources": {}
-      }
-    ]
-  },
-  {
-    "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/metadata/labels",
     "value": {
-      "name": "istio-proxy",
-      "image": "example.com/proxy:latest",
-      "resources": {}
+      "istio.io/rev": "",
+      "security.istio.io/tlsMode": "istio",
+      "service.istio.io/canonical-name": "",
+      "service.istio.io/canonical-revision": "latest"
     }
   },
   {
     "op": "add",
-    "path": "/spec/volumes/-",
+    "path": "/metadata/annotations",
     "value": {
-      "name": "istio-envoy",
-      "emptyDir": {
-        "medium": "Memory"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-certs",
-      "secret": {
-        "secretName": "istio.default"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/imagePullSecrets/-",
-    "value": {
-      "name": "istio-image-pull-secrets"
+      "prometheus.io/path": "/stats/prometheus",
+      "prometheus.io/port": "15020",
+      "prometheus.io/scrape": "true",
+      "sidecar.istio.io/status": "{\"version\":\"unit-test-fake-version\",\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
     }
   },
   {
@@ -52,49 +25,5 @@
     "value": {
       "fsGroup": 1337
     }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations",
-    "value": {
-      "prometheus.io/path": "/stats/prometheus"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1port",
-    "value": "15020"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1scrape",
-    "value": "true"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/sidecar.istio.io~1status",
-    "value": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels",
-    "value": {
-      "istio.io/rev": ""
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/security.istio.io~1tlsMode",
-    "value": "istio"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-name",
-    "value": ""
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-revision",
-    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers.patch
@@ -1,52 +1,28 @@
 [
   {
     "op": "add",
-    "path": "/spec/initContainers",
-    "value": [
-      {
-        "name": "istio-init",
-        "image": "example.com/init:latest",
-        "resources": {}
-      }
-    ]
+    "path": "/metadata/labels",
+    "value": {
+      "istio.io/rev": "",
+      "security.istio.io/tlsMode": "istio",
+      "service.istio.io/canonical-name": "",
+      "service.istio.io/canonical-revision": "latest"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/annotations",
+    "value": {
+      "prometheus.io/path": "/stats/prometheus",
+      "prometheus.io/port": "15020",
+      "prometheus.io/scrape": "true",
+      "sidecar.istio.io/status": "{\"version\":\"unit-test-fake-version\",\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
+    }
   },
   {
     "op": "add",
     "path": "/spec/containers",
-    "value": [
-      {
-        "name": "istio-proxy",
-        "image": "example.com/proxy:latest",
-        "resources": {}
-      }
-    ]
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-envoy",
-      "emptyDir": {
-        "medium": "Memory"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-certs",
-      "secret": {
-        "secretName": "istio.default"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/imagePullSecrets/-",
-    "value": {
-      "name": "istio-image-pull-secrets"
-    }
+    "value": []
   },
   {
     "op": "add",
@@ -54,49 +30,5 @@
     "value": {
       "fsGroup": 1337
     }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations",
-    "value": {
-      "prometheus.io/path": "/stats/prometheus"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1port",
-    "value": "15020"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1scrape",
-    "value": "true"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/sidecar.istio.io~1status",
-    "value": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels",
-    "value": {
-      "istio.io/rev": ""
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/security.istio.io~1tlsMode",
-    "value": "istio"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-name",
-    "value": ""
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-revision",
-    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_imagePullSecrets.patch
@@ -1,54 +1,28 @@
 [
   {
     "op": "add",
-    "path": "/spec/initContainers",
-    "value": [
-      {
-        "name": "istio-init",
-        "image": "example.com/init:latest",
-        "resources": {}
-      }
-    ]
+    "path": "/metadata/labels",
+    "value": {
+      "istio.io/rev": "",
+      "security.istio.io/tlsMode": "istio",
+      "service.istio.io/canonical-name": "",
+      "service.istio.io/canonical-revision": "latest"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/annotations",
+    "value": {
+      "prometheus.io/path": "/stats/prometheus",
+      "prometheus.io/port": "15020",
+      "prometheus.io/scrape": "true",
+      "sidecar.istio.io/status": "{\"version\":\"unit-test-fake-version\",\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
+    }
   },
   {
     "op": "add",
     "path": "/spec/containers",
-    "value": [
-      {
-        "name": "istio-proxy",
-        "image": "example.com/proxy:latest",
-        "resources": {}
-      }
-    ]
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-envoy",
-      "emptyDir": {
-        "medium": "Memory"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-certs",
-      "secret": {
-        "secretName": "istio.default"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/imagePullSecrets",
-    "value": [
-      {
-        "name": "istio-image-pull-secrets"
-      }
-    ]
+    "value": []
   },
   {
     "op": "add",
@@ -56,49 +30,5 @@
     "value": {
       "fsGroup": 1337
     }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations",
-    "value": {
-      "prometheus.io/path": "/stats/prometheus"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1port",
-    "value": "15020"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1scrape",
-    "value": "true"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/sidecar.istio.io~1status",
-    "value": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels",
-    "value": {
-      "istio.io/rev": ""
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/security.istio.io~1tlsMode",
-    "value": "istio"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-name",
-    "value": ""
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-revision",
-    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_volumes.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_volumes.patch
@@ -1,54 +1,28 @@
 [
   {
     "op": "add",
-    "path": "/spec/initContainers",
-    "value": [
-      {
-        "name": "istio-init",
-        "image": "example.com/init:latest",
-        "resources": {}
-      }
-    ]
+    "path": "/metadata/labels",
+    "value": {
+      "istio.io/rev": "",
+      "security.istio.io/tlsMode": "istio",
+      "service.istio.io/canonical-name": "",
+      "service.istio.io/canonical-revision": "latest"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/annotations",
+    "value": {
+      "prometheus.io/path": "/stats/prometheus",
+      "prometheus.io/port": "15020",
+      "prometheus.io/scrape": "true",
+      "sidecar.istio.io/status": "{\"version\":\"unit-test-fake-version\",\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
+    }
   },
   {
     "op": "add",
     "path": "/spec/containers",
-    "value": [
-      {
-        "name": "istio-proxy",
-        "image": "example.com/proxy:latest",
-        "resources": {}
-      }
-    ]
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes",
-    "value": [
-      {
-        "name": "istio-envoy",
-        "emptyDir": {
-          "medium": "Memory"
-        }
-      }
-    ]
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-certs",
-      "secret": {
-        "secretName": "istio.default"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/imagePullSecrets/-",
-    "value": {
-      "name": "istio-image-pull-secrets"
-    }
+    "value": []
   },
   {
     "op": "add",
@@ -56,49 +30,5 @@
     "value": {
       "fsGroup": 1337
     }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations",
-    "value": {
-      "prometheus.io/path": "/stats/prometheus"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1port",
-    "value": "15020"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1scrape",
-    "value": "true"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/sidecar.istio.io~1status",
-    "value": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels",
-    "value": {
-      "istio.io/rev": ""
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/security.istio.io~1tlsMode",
-    "value": "istio"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-name",
-    "value": ""
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-revision",
-    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_imagePullSecrets.patch
@@ -1,52 +1,23 @@
 [
   {
     "op": "add",
-    "path": "/spec/initContainers",
-    "value": [
-      {
-        "name": "istio-init",
-        "image": "example.com/init:latest",
-        "resources": {}
-      }
-    ]
-  },
-  {
-    "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/metadata/labels",
     "value": {
-      "name": "istio-proxy",
-      "image": "example.com/proxy:latest",
-      "resources": {}
+      "istio.io/rev": "",
+      "security.istio.io/tlsMode": "istio",
+      "service.istio.io/canonical-name": "",
+      "service.istio.io/canonical-revision": "latest"
     }
   },
   {
     "op": "add",
-    "path": "/spec/volumes/-",
+    "path": "/metadata/annotations",
     "value": {
-      "name": "istio-envoy",
-      "emptyDir": {
-        "medium": "Memory"
-      }
+      "prometheus.io/path": "/stats/prometheus",
+      "prometheus.io/port": "15020",
+      "prometheus.io/scrape": "true",
+      "sidecar.istio.io/status": "{\"version\":\"unit-test-fake-version\",\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
     }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-certs",
-      "secret": {
-        "secretName": "istio.default"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/imagePullSecrets",
-    "value": [
-      {
-        "name": "istio-image-pull-secrets"
-      }
-    ]
   },
   {
     "op": "add",
@@ -54,49 +25,5 @@
     "value": {
       "fsGroup": 1337
     }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations",
-    "value": {
-      "prometheus.io/path": "/stats/prometheus"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1port",
-    "value": "15020"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1scrape",
-    "value": "true"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/sidecar.istio.io~1status",
-    "value": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels",
-    "value": {
-      "istio.io/rev": ""
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/security.istio.io~1tlsMode",
-    "value": "istio"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-name",
-    "value": ""
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-revision",
-    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes.patch
@@ -1,52 +1,23 @@
 [
   {
     "op": "add",
-    "path": "/spec/initContainers",
-    "value": [
-      {
-        "name": "istio-init",
-        "image": "example.com/init:latest",
-        "resources": {}
-      }
-    ]
-  },
-  {
-    "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/metadata/labels",
     "value": {
-      "name": "istio-proxy",
-      "image": "example.com/proxy:latest",
-      "resources": {}
+      "istio.io/rev": "",
+      "security.istio.io/tlsMode": "istio",
+      "service.istio.io/canonical-name": "",
+      "service.istio.io/canonical-revision": "latest"
     }
   },
   {
     "op": "add",
-    "path": "/spec/volumes/-",
+    "path": "/metadata/annotations",
     "value": {
-      "name": "istio-envoy",
-      "emptyDir": {
-        "medium": "Memory"
-      }
+      "prometheus.io/path": "/stats/prometheus",
+      "prometheus.io/port": "15020",
+      "prometheus.io/scrape": "true",
+      "sidecar.istio.io/status": "{\"version\":\"unit-test-fake-version\",\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
     }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-certs",
-      "secret": {
-        "secretName": "istio.default"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/imagePullSecrets",
-    "value": [
-      {
-        "name": "istio-image-pull-secrets"
-      }
-    ]
   },
   {
     "op": "add",
@@ -54,49 +25,5 @@
     "value": {
       "fsGroup": 1337
     }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations",
-    "value": {
-      "prometheus.io/path": "/stats/prometheus"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1port",
-    "value": "15020"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1scrape",
-    "value": "true"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/sidecar.istio.io~1status",
-    "value": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels",
-    "value": {
-      "istio.io/rev": ""
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/security.istio.io~1tlsMode",
-    "value": "istio"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-name",
-    "value": ""
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-revision",
-    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes_imagePullSecrets.patch
@@ -1,54 +1,23 @@
 [
   {
     "op": "add",
-    "path": "/spec/initContainers",
-    "value": [
-      {
-        "name": "istio-init",
-        "image": "example.com/init:latest",
-        "resources": {}
-      }
-    ]
-  },
-  {
-    "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/metadata/labels",
     "value": {
-      "name": "istio-proxy",
-      "image": "example.com/proxy:latest",
-      "resources": {}
+      "istio.io/rev": "",
+      "security.istio.io/tlsMode": "istio",
+      "service.istio.io/canonical-name": "",
+      "service.istio.io/canonical-revision": "latest"
     }
   },
   {
     "op": "add",
-    "path": "/spec/volumes",
-    "value": [
-      {
-        "name": "istio-envoy",
-        "emptyDir": {
-          "medium": "Memory"
-        }
-      }
-    ]
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
+    "path": "/metadata/annotations",
     "value": {
-      "name": "istio-certs",
-      "secret": {
-        "secretName": "istio.default"
-      }
+      "prometheus.io/path": "/stats/prometheus",
+      "prometheus.io/port": "15020",
+      "prometheus.io/scrape": "true",
+      "sidecar.istio.io/status": "{\"version\":\"unit-test-fake-version\",\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
     }
-  },
-  {
-    "op": "add",
-    "path": "/spec/imagePullSecrets",
-    "value": [
-      {
-        "name": "istio-image-pull-secrets"
-      }
-    ]
   },
   {
     "op": "add",
@@ -56,49 +25,5 @@
     "value": {
       "fsGroup": 1337
     }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations",
-    "value": {
-      "prometheus.io/path": "/stats/prometheus"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1port",
-    "value": "15020"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1scrape",
-    "value": "true"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/sidecar.istio.io~1status",
-    "value": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels",
-    "value": {
-      "istio.io/rev": ""
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/security.istio.io~1tlsMode",
-    "value": "istio"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-name",
-    "value": ""
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-revision",
-    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initcontainers_containers_volumes_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initcontainers_containers_volumes_imagePullSecrets.patch
@@ -1,56 +1,28 @@
 [
   {
     "op": "add",
-    "path": "/spec/initContainers",
-    "value": [
-      {
-        "name": "istio-init",
-        "image": "example.com/init:latest",
-        "resources": {}
-      }
-    ]
-  },
-  {
-    "op": "add",
-    "path": "/spec/containers",
-    "value": [
-      {
-        "name": "istio-proxy",
-        "image": "example.com/proxy:latest",
-        "resources": {}
-      }
-    ]
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes",
-    "value": [
-      {
-        "name": "istio-envoy",
-        "emptyDir": {
-          "medium": "Memory"
-        }
-      }
-    ]
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
+    "path": "/metadata/labels",
     "value": {
-      "name": "istio-certs",
-      "secret": {
-        "secretName": "istio.default"
-      }
+      "istio.io/rev": "",
+      "security.istio.io/tlsMode": "istio",
+      "service.istio.io/canonical-name": "",
+      "service.istio.io/canonical-revision": "latest"
     }
   },
   {
     "op": "add",
-    "path": "/spec/imagePullSecrets",
-    "value": [
-      {
-        "name": "istio-image-pull-secrets"
-      }
-    ]
+    "path": "/metadata/annotations",
+    "value": {
+      "prometheus.io/path": "/stats/prometheus",
+      "prometheus.io/port": "15020",
+      "prometheus.io/scrape": "true",
+      "sidecar.istio.io/status": "{\"version\":\"unit-test-fake-version\",\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers",
+    "value": []
   },
   {
     "op": "add",
@@ -58,49 +30,5 @@
     "value": {
       "fsGroup": 1337
     }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations",
-    "value": {
-      "prometheus.io/path": "/stats/prometheus"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1port",
-    "value": "15020"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1scrape",
-    "value": "true"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/sidecar.istio.io~1status",
-    "value": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels",
-    "value": {
-      "istio.io/rev": ""
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/security.istio.io~1tlsMode",
-    "value": "istio"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-name",
-    "value": ""
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-revision",
-    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes.patch
@@ -1,49 +1,22 @@
 [
   {
     "op": "add",
-    "path": "/spec/initContainers/-",
+    "path": "/metadata/labels",
     "value": {
-      "name": "istio-init",
-      "image": "example.com/init:latest",
-      "resources": {}
+      "istio.io/rev": "",
+      "security.istio.io/tlsMode": "istio",
+      "service.istio.io/canonical-name": "",
+      "service.istio.io/canonical-revision": "latest"
     }
   },
   {
     "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/metadata/annotations",
     "value": {
-      "name": "istio-proxy",
-      "image": "example.com/proxy:latest",
-      "resources": {}
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes",
-    "value": [
-      {
-        "name": "istio-envoy",
-        "emptyDir": {
-          "medium": "Memory"
-        }
-      }
-    ]
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-certs",
-      "secret": {
-        "secretName": "istio.default"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/imagePullSecrets/-",
-    "value": {
-      "name": "istio-image-pull-secrets"
+      "prometheus.io/path": "/stats/prometheus",
+      "prometheus.io/port": "15020",
+      "prometheus.io/scrape": "true",
+      "sidecar.istio.io/status": "{\"version\":\"unit-test-fake-version\",\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
     }
   },
   {
@@ -52,49 +25,5 @@
     "value": {
       "fsGroup": 1337
     }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations",
-    "value": {
-      "prometheus.io/path": "/stats/prometheus"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1port",
-    "value": "15020"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1scrape",
-    "value": "true"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/sidecar.istio.io~1status",
-    "value": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels",
-    "value": {
-      "istio.io/rev": ""
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/security.istio.io~1tlsMode",
-    "value": "istio"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-name",
-    "value": ""
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-revision",
-    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes_imagePullSecrets.patch
@@ -1,52 +1,23 @@
 [
   {
     "op": "add",
-    "path": "/spec/initContainers/-",
+    "path": "/metadata/labels",
     "value": {
-      "name": "istio-init",
-      "image": "example.com/init:latest",
-      "resources": {}
+      "istio.io/rev": "",
+      "security.istio.io/tlsMode": "istio",
+      "service.istio.io/canonical-name": "",
+      "service.istio.io/canonical-revision": "latest"
     }
   },
   {
     "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/metadata/annotations",
     "value": {
-      "name": "istio-proxy",
-      "image": "example.com/proxy:latest",
-      "resources": {}
+      "prometheus.io/path": "/stats/prometheus",
+      "prometheus.io/port": "15020",
+      "prometheus.io/scrape": "true",
+      "sidecar.istio.io/status": "{\"version\":\"unit-test-fake-version\",\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
     }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes",
-    "value": [
-      {
-        "name": "istio-envoy",
-        "emptyDir": {
-          "medium": "Memory"
-        }
-      }
-    ]
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-certs",
-      "secret": {
-        "secretName": "istio.default"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/imagePullSecrets",
-    "value": [
-      {
-        "name": "istio-image-pull-secrets"
-      }
-    ]
   },
   {
     "op": "add",
@@ -54,49 +25,5 @@
     "value": {
       "fsGroup": 1337
     }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations",
-    "value": {
-      "prometheus.io/path": "/stats/prometheus"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1port",
-    "value": "15020"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1scrape",
-    "value": "true"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/sidecar.istio.io~1status",
-    "value": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels",
-    "value": {
-      "istio.io/rev": ""
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/security.istio.io~1tlsMode",
-    "value": "istio"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-name",
-    "value": ""
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-revision",
-    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_probe_rewrite_timeout_retention.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_probe_rewrite_timeout_retention.patch
@@ -1,86 +1,27 @@
 [
   {
-    "op": "replace",
-    "path": "/spec/containers/1/readinessProbe",
-    "value": {
-      "httpGet": {
-        "path": "/app-health/hello/readyz",
-        "port": 15020
-      },
-      "timeoutSeconds": 5
-    }
-  },
-  {
-    "op": "replace",
-    "path": "/spec/containers/1/livenessProbe",
-    "value": {
-      "httpGet": {
-        "path": "/app-health/hello/livez",
-        "port": 15020
-      },
-      "timeoutSeconds": 5
-    }
-  },
-  {
-    "op": "replace",
-    "path": "/spec/containers/2/livenessProbe",
-    "value": {
-      "httpGet": {
-        "path": "/app-health/second/livez",
-        "port": 15020
-      },
-      "timeoutSeconds": 5
-    }
-  },
-  {
-    "op": "remove",
-    "path": "/spec/initContainers/0"
-  },
-  {
-    "op": "remove",
-    "path": "/spec/containers/0"
-  },
-  {
     "op": "add",
-    "path": "/spec/initContainers/-",
+    "path": "/metadata/labels",
     "value": {
-      "name": "istio-init",
-      "image": "example.com/init:latest",
-      "resources": {}
+      "istio.io/rev": "",
+      "security.istio.io/tlsMode": "istio",
+      "service.istio.io/canonical-name": "",
+      "service.istio.io/canonical-revision": "latest"
     }
   },
   {
     "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/metadata/annotations",
     "value": {
-      "name": "istio-proxy",
-      "image": "example.com/proxy:latest",
-      "args": [
-        "--statusPort",
-        "15020"
-      ],
-      "env": [
-        {
-          "name": "ISTIO_KUBE_APP_PROBERS",
-          "value": "{\"/app-health/hello/livez\":{\"httpGet\":{\"path\":\"/live\",\"port\":80},\"timeoutSeconds\":5},\"/app-health/hello/readyz\":{\"httpGet\":{\"path\":\"/ready\",\"port\":3333},\"timeoutSeconds\":5},\"/app-health/second/livez\":{\"httpGet\":{\"port\":9000},\"timeoutSeconds\":5}}"
-        }
-      ],
-      "resources": {}
+      "prometheus.io/path": "/stats/prometheus",
+      "prometheus.io/port": "15020",
+      "prometheus.io/scrape": "true",
+      "sidecar.istio.io/status": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
     }
   },
   {
     "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-envoy",
-      "emptyDir": {
-        "medium": "Memory"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
+    "path": "/spec/volumes/1",
     "value": {
       "name": "istio-certs",
       "secret": {
@@ -90,12 +31,117 @@
   },
   {
     "op": "add",
-    "path": "/spec/imagePullSecrets",
+    "path": "/spec/volumes/2",
+    "value": {
+      "name": "v0"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/volumes/0/name",
+    "value": "istio-envoy"
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/0/emptyDir",
+    "value": {
+      "medium": "Memory"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers/0/image",
+    "value": "example.com/init:latest"
+  },
+  {
+    "op": "replace",
+    "path": "/spec/containers/0/name",
+    "value": "hello"
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/0/image",
+    "value": "fake.docker.io/google-samples/hello-go-gke:1.0"
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/0/ports",
     "value": [
       {
-        "name": "istio-image-pull-secrets"
+        "name": "http",
+        "containerPort": 80
       }
     ]
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/0/livenessProbe",
+    "value": {
+      "httpGet": {
+        "path": "/live",
+        "port": "http"
+      },
+      "timeoutSeconds": 5
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/0/readinessProbe",
+    "value": {
+      "httpGet": {
+        "path": "/ready",
+        "port": 3333
+      },
+      "timeoutSeconds": 5
+    }
+  },
+  {
+    "op": "remove",
+    "path": "/spec/containers/0/args"
+  },
+  {
+    "op": "replace",
+    "path": "/spec/containers/1/name",
+    "value": "second"
+  },
+  {
+    "op": "replace",
+    "path": "/spec/containers/1/livenessProbe/httpGet/port",
+    "value": 9000
+  },
+  {
+    "op": "remove",
+    "path": "/spec/containers/1/livenessProbe/httpGet/path"
+  },
+  {
+    "op": "remove",
+    "path": "/spec/containers/1/ports"
+  },
+  {
+    "op": "remove",
+    "path": "/spec/containers/1/readinessProbe"
+  },
+  {
+    "op": "replace",
+    "path": "/spec/containers/2/name",
+    "value": "istio-proxy"
+  },
+  {
+    "op": "replace",
+    "path": "/spec/containers/2/image",
+    "value": "example.com/proxy:latest"
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/2/args",
+    "value": [
+      "--statusPort",
+      "15020"
+    ]
+  },
+  {
+    "op": "remove",
+    "path": "/spec/containers/2/livenessProbe"
   },
   {
     "op": "add",
@@ -106,46 +152,11 @@
   },
   {
     "op": "add",
-    "path": "/metadata/annotations",
-    "value": {
-      "prometheus.io/path": "/stats/prometheus"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1port",
-    "value": "15020"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1scrape",
-    "value": "true"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/sidecar.istio.io~1status",
-    "value": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels",
-    "value": {
-      "istio.io/rev": ""
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/security.istio.io~1tlsMode",
-    "value": "istio"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-name",
-    "value": ""
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-revision",
-    "value": "latest"
+    "path": "/spec/imagePullSecrets",
+    "value": [
+      {
+        "name": "istio-image-pull-secrets"
+      }
+    ]
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_probe_rewrite_timeout_retention_template.yaml
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_probe_rewrite_timeout_retention_template.yaml
@@ -12,7 +12,7 @@ template: |-
     image: example.com/proxy:latest
     args:
       - --statusPort
-      - 15020
+      - "15020"
   imagePullSecrets:
   - name: istio-image-pull-secrets
   volumes:

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace.patch
@@ -1,68 +1,12 @@
 [
   {
-    "op": "remove",
-    "path": "/spec/initContainers/1"
-  },
-  {
-    "op": "remove",
-    "path": "/spec/containers/1"
-  },
-  {
-    "op": "remove",
-    "path": "/spec/volumes/1"
-  },
-  {
     "op": "add",
-    "path": "/spec/initContainers/-",
+    "path": "/metadata/labels",
     "value": {
-      "name": "istio-init",
-      "image": "example.com/init:latest",
-      "resources": {}
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/containers/-",
-    "value": {
-      "name": "istio-proxy",
-      "image": "example.com/proxy:latest",
-      "resources": {}
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-envoy",
-      "emptyDir": {
-        "medium": "Memory"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-certs",
-      "secret": {
-        "secretName": "istio.default"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/imagePullSecrets",
-    "value": [
-      {
-        "name": "istio-image-pull-secrets"
-      }
-    ]
-  },
-  {
-    "op": "add",
-    "path": "/spec/securityContext",
-    "value": {
-      "fsGroup": 1337
+      "istio.io/rev": "",
+      "security.istio.io/tlsMode": "istio",
+      "service.istio.io/canonical-name": "replace",
+      "service.istio.io/canonical-revision": "latest"
     }
   },
   {
@@ -83,28 +27,13 @@
   {
     "op": "replace",
     "path": "/metadata/annotations/sidecar.istio.io~1status",
-    "value": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
+    "value": "{\"version\":\"unit-test-fake-version\",\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
   },
   {
     "op": "add",
-    "path": "/metadata/labels",
+    "path": "/spec/securityContext",
     "value": {
-      "istio.io/rev": ""
+      "fsGroup": 1337
     }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/security.istio.io~1tlsMode",
-    "value": "istio"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-name",
-    "value": "replace"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-revision",
-    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace_backwards_compat.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace_backwards_compat.patch
@@ -1,72 +1,12 @@
 [
   {
-    "op": "remove",
-    "path": "/spec/initContainers/0"
-  },
-  {
-    "op": "remove",
-    "path": "/spec/containers/0"
-  },
-  {
-    "op": "remove",
-    "path": "/spec/volumes/1"
-  },
-  {
-    "op": "remove",
-    "path": "/spec/volumes/0"
-  },
-  {
     "op": "add",
-    "path": "/spec/initContainers/-",
+    "path": "/metadata/labels",
     "value": {
-      "name": "istio-init",
-      "image": "example.com/init:latest",
-      "resources": {}
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/containers/-",
-    "value": {
-      "name": "istio-proxy",
-      "image": "example.com/proxy:latest",
-      "resources": {}
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-envoy",
-      "emptyDir": {
-        "medium": "Memory"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-certs",
-      "secret": {
-        "secretName": "istio.default"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/imagePullSecrets",
-    "value": [
-      {
-        "name": "istio-image-pull-secrets"
-      }
-    ]
-  },
-  {
-    "op": "add",
-    "path": "/spec/securityContext",
-    "value": {
-      "fsGroup": 1337
+      "istio.io/rev": "",
+      "security.istio.io/tlsMode": "istio",
+      "service.istio.io/canonical-name": "replace-backwards-compat",
+      "service.istio.io/canonical-revision": "latest"
     }
   },
   {
@@ -87,28 +27,13 @@
   {
     "op": "replace",
     "path": "/metadata/annotations/sidecar.istio.io~1status",
-    "value": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
+    "value": "{\"version\":\"unit-test-fake-version\",\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
   },
   {
     "op": "add",
-    "path": "/metadata/labels",
+    "path": "/spec/securityContext",
     "value": {
-      "istio.io/rev": ""
+      "fsGroup": 1337
     }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/security.istio.io~1tlsMode",
-    "value": "istio"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-name",
-    "value": "replace-backwards-compat"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-revision",
-    "value": "latest"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_template.yaml
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_template.yaml
@@ -3,22 +3,23 @@ alwaysInjectSelector: []
 neverInjectSelector: []
 injectedAnnotations: {}
 template: |-
-  initContainers:
-  - name: istio-init
-    image: example.com/init:latest
-  containers:
-  - name: istio-proxy
-    image: example.com/proxy:latest
-  imagePullSecrets:
-  - name: istio-image-pull-secrets
-  volumes:
-  - emptyDir:
-      medium: Memory
-    name: istio-envoy
-  - name: istio-certs
-    secret:
-      {{ if eq .Spec.ServiceAccountName "" -}}
-      secretName: istio.default
-      {{ else -}}
-      secretName: {{ printf "istio.%s" .Spec.ServiceAccountName }}
-      {{ end -}}
+  spec:
+    initContainers:
+    - name: istio-init
+      image: example.com/init:latest
+    containers:
+    - name: istio-proxy
+      image: example.com/proxy:latest
+    imagePullSecrets:
+    - name: istio-image-pull-secrets
+    volumes:
+    - emptyDir:
+        medium: Memory
+      name: istio-envoy
+    - name: istio-certs
+      secret:
+        {{ if eq .Spec.ServiceAccountName "" -}}
+        secretName: istio.default
+        {{ else -}}
+        secretName: {{ printf "istio.%s" .Spec.ServiceAccountName }}
+        {{ end -}}

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_validationOrder.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_validationOrder.patch
@@ -1,7 +1,73 @@
 [
   {
     "op": "add",
-    "path": "/spec/initContainers/-",
+    "path": "/metadata/labels",
+    "value": {
+      "istio.io/rev": "",
+      "security.istio.io/tlsMode": "istio",
+      "service.istio.io/canonical-name": "something",
+      "service.istio.io/canonical-revision": "latest"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/annotations",
+    "value": {
+      "prometheus.io/path": "/stats/prometheus",
+      "prometheus.io/port": "15020",
+      "prometheus.io/scrape": "true",
+      "sidecar.istio.io/status": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\",\"istio-validation\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/2",
+    "value": {
+      "name": "v0"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/3",
+    "value": {
+      "name": "injected2"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/volumes/0/name",
+    "value": "istio-envoy"
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/0/emptyDir",
+    "value": {
+      "medium": "Memory"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/volumes/1/name",
+    "value": "istio-certs"
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/1/secret",
+    "value": {
+      "secretName": "istio.default"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers/2",
+    "value": {
+      "name": "injected0",
+      "resources": {}
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers/3",
     "value": {
       "name": "istio-init",
       "image": "example.com/init:latest",
@@ -9,51 +75,28 @@
     }
   },
   {
-    "op": "add",
-    "path": "/spec/initContainers/0",
-    "value": {
-      "name": "istio-validation",
-      "image": "example.com/init:latest",
-      "resources": {}
-    }
+    "op": "replace",
+    "path": "/spec/initContainers/0/name",
+    "value": "istio-validation"
   },
   {
     "op": "add",
-    "path": "/spec/containers/-",
+    "path": "/spec/initContainers/0/image",
+    "value": "example.com/init:latest"
+  },
+  {
+    "op": "replace",
+    "path": "/spec/initContainers/1/name",
+    "value": "c0"
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/2",
     "value": {
       "name": "istio-proxy",
       "image": "example.com/proxy:latest",
       "resources": {}
     }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-envoy",
-      "emptyDir": {
-        "medium": "Memory"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes/-",
-    "value": {
-      "name": "istio-certs",
-      "secret": {
-        "secretName": "istio.default"
-      }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/spec/imagePullSecrets",
-    "value": [
-      {
-        "name": "istio-image-pull-secrets"
-      }
-    ]
   },
   {
     "op": "add",
@@ -64,46 +107,11 @@
   },
   {
     "op": "add",
-    "path": "/metadata/annotations",
-    "value": {
-      "prometheus.io/path": "/stats/prometheus"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1port",
-    "value": "15020"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/prometheus.io~1scrape",
-    "value": "true"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/annotations/sidecar.istio.io~1status",
-    "value": "{\"version\":\"unit-test-fake-version\",\"initContainers\":[\"istio-init\",\"istio-validation\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels",
-    "value": {
-      "istio.io/rev": ""
-    }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/security.istio.io~1tlsMode",
-    "value": "istio"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-name",
-    "value": "something"
-  },
-  {
-    "op": "add",
-    "path": "/metadata/labels/service.istio.io~1canonical-revision",
-    "value": "latest"
+    "path": "/spec/imagePullSecrets",
+    "value": [
+      {
+        "name": "istio-image-pull-secrets"
+      }
+    ]
   }
 ]

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -21,13 +21,13 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/ghodss/yaml"
+	"gomodules.xyz/jsonpatch/v3"
 	kubeApiAdmissionv1 "k8s.io/api/admission/v1"
 	kubeApiAdmissionv1beta1 "k8s.io/api/admission/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -35,14 +35,17 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	kjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 
 	"istio.io/api/annotation"
 	"istio.io/api/label"
 	meshconfig "istio.io/api/mesh/v1alpha1"
+	opconfig "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/istio/pilot/cmd/pilot-agent/status"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/util/gogoprotomarshal"
 	"istio.io/pkg/log"
 )
 
@@ -229,339 +232,46 @@ func (wh *Webhook) updateConfig(sidecarConfig *Config, valuesConfig string) {
 	wh.mu.Unlock()
 }
 
-// It would be great to use https://github.com/mattbaird/jsonpatch to
-// generate RFC6902 JSON patches. Unfortunately, it doesn't produce
-// correct patches for object removal. Fortunately, our patching needs
-// are fairly simple so generating them manually isn't horrible (yet).
-type rfc6902PatchOperation struct {
-	Op    string      `json:"op"`
-	Path  string      `json:"path"`
-	Value interface{} `json:"value,omitempty"`
+func setIfUnset(m map[string]string, k, v string) {
+	if _, f := m[k]; f {
+		// already set
+		return
+	}
+	m[k] = v
 }
 
-// JSONPatch `remove` is applied sequentially. Remove items in reverse
-// order to avoid renumbering indices.
-func removeContainers(containers []corev1.Container, removed []string, path string) (patch []rfc6902PatchOperation) {
-	names := map[string]bool{}
-	for _, name := range removed {
-		names[name] = true
-	}
-	for i := len(containers) - 1; i >= 0; i-- {
-		if _, ok := names[containers[i].Name]; ok {
-			patch = append(patch, rfc6902PatchOperation{
-				Op:   "remove",
-				Path: fmt.Sprintf("%v/%v", path, i),
-			})
-		}
-	}
-	return patch
-}
+type ContainerReorder int
 
-func removeVolumes(volumes []corev1.Volume, removed []string, path string) (patch []rfc6902PatchOperation) {
-	names := map[string]bool{}
-	for _, name := range removed {
-		names[name] = true
-	}
-	for i := len(volumes) - 1; i >= 0; i-- {
-		if _, ok := names[volumes[i].Name]; ok {
-			patch = append(patch, rfc6902PatchOperation{
-				Op:   "remove",
-				Path: fmt.Sprintf("%v/%v", path, i),
-			})
-		}
-	}
-	return patch
-}
+const (
+	MoveFirst ContainerReorder = iota
+	MoveLast
+	Remove
+)
 
-func removeImagePullSecrets(imagePullSecrets []corev1.LocalObjectReference, removed []string, path string) (patch []rfc6902PatchOperation) {
-	names := map[string]bool{}
-	for _, name := range removed {
-		names[name] = true
-	}
-	for i := len(imagePullSecrets) - 1; i >= 0; i-- {
-		if _, ok := names[imagePullSecrets[i].Name]; ok {
-			patch = append(patch, rfc6902PatchOperation{
-				Op:   "remove",
-				Path: fmt.Sprintf("%v/%v", path, i),
-			})
-		}
-	}
-	return patch
-}
-
-func addContainer(sic *SidecarInjectionSpec, target, added []corev1.Container, basePath string) (patch []rfc6902PatchOperation) {
-	saJwtSecretMountName := ""
-	var saJwtSecretMount corev1.VolumeMount
-	// find service account secret volume mount(/var/run/secrets/kubernetes.io/serviceaccount,
-	// https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#service-account-automation) from app container
-	for _, add := range target {
-		for _, vmount := range add.VolumeMounts {
-			if vmount.MountPath == "/var/run/secrets/kubernetes.io/serviceaccount" {
-				saJwtSecretMountName = vmount.Name
-				saJwtSecretMount = vmount
-			}
-		}
-	}
-	first := len(target) == 0
-	var value interface{}
-	for _, add := range added {
-		if add.Name == "istio-proxy" && saJwtSecretMountName != "" {
-			// add service account secret volume mount(/var/run/secrets/kubernetes.io/serviceaccount,
-			// https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#service-account-automation) to istio-proxy container,
-			// so that envoy could fetch/pass k8s sa jwt and pass to sds server, which will be used to request workload identity for the pod.
-			add.VolumeMounts = append(add.VolumeMounts, saJwtSecretMount)
-		}
-		value = add
-		path := basePath
-		if first {
-			first = false
-			value = []corev1.Container{add}
-		} else if shouldBeInjectedInFront(add, sic) {
-			path += "/0"
+func modifyContainers(cl []corev1.Container, name string, modifier ContainerReorder) []corev1.Container {
+	containers := []corev1.Container{}
+	var match *corev1.Container
+	for _, c := range cl {
+		c := c
+		if c.Name != name {
+			containers = append(containers, c)
 		} else {
-			path += "/-"
+			match = &c
 		}
-		patch = append(patch, rfc6902PatchOperation{
-			Op:    "add",
-			Path:  path,
-			Value: value,
-		})
 	}
-	return patch
-}
-
-func shouldBeInjectedInFront(container corev1.Container, sic *SidecarInjectionSpec) bool {
-	switch container.Name {
-	case ValidationContainerName:
-		return true
-	case ProxyContainerName:
-		return sic.HoldApplicationUntilProxyStarts
+	if match == nil {
+		return containers
+	}
+	switch modifier {
+	case MoveFirst:
+		return append([]corev1.Container{*match}, containers...)
+	case MoveLast:
+		return append(containers, *match)
+	case Remove:
+		return containers
 	default:
-		return false
+		return cl
 	}
-}
-
-func addSecurityContext(target *corev1.PodSecurityContext, basePath string) (patch []rfc6902PatchOperation) {
-	patch = append(patch, rfc6902PatchOperation{
-		Op:    "add",
-		Path:  basePath,
-		Value: target,
-	})
-	return patch
-}
-
-func addVolume(target, added []corev1.Volume, basePath string) (patch []rfc6902PatchOperation) {
-	first := len(target) == 0
-	var value interface{}
-	for _, add := range added {
-		value = add
-		path := basePath
-		if first {
-			first = false
-			value = []corev1.Volume{add}
-		} else {
-			path += "/-"
-		}
-		patch = append(patch, rfc6902PatchOperation{
-			Op:    "add",
-			Path:  path,
-			Value: value,
-		})
-	}
-	return patch
-}
-
-func addImagePullSecrets(target, added []corev1.LocalObjectReference, basePath string) (patch []rfc6902PatchOperation) {
-	first := len(target) == 0
-	var value interface{}
-	for _, add := range added {
-		value = add
-		path := basePath
-		if first {
-			first = false
-			value = []corev1.LocalObjectReference{add}
-		} else {
-			path += "/-"
-		}
-		patch = append(patch, rfc6902PatchOperation{
-			Op:    "add",
-			Path:  path,
-			Value: value,
-		})
-	}
-	return patch
-}
-
-func addPodDNSConfig(target *corev1.PodDNSConfig, basePath string) (patch []rfc6902PatchOperation) {
-	patch = append(patch, rfc6902PatchOperation{
-		Op:    "add",
-		Path:  basePath,
-		Value: target,
-	})
-	return patch
-}
-
-// escape JSON Pointer value per https://tools.ietf.org/html/rfc6901
-func escapeJSONPointerValue(in string) string {
-	step := strings.Replace(in, "~", "~0", -1)
-	return strings.Replace(step, "/", "~1", -1)
-}
-
-// adds labels to the target spec, will not overwrite label's value if it already exists
-func addLabels(target map[string]string, added map[string]string) []rfc6902PatchOperation {
-	patches := []rfc6902PatchOperation{}
-
-	addedKeys := make([]string, 0, len(added))
-	for key := range added {
-		addedKeys = append(addedKeys, key)
-	}
-	sort.Strings(addedKeys)
-
-	for _, key := range addedKeys {
-		value := added[key]
-		patch := rfc6902PatchOperation{
-			Op:    "add",
-			Path:  "/metadata/labels/" + escapeJSONPointerValue(key),
-			Value: value,
-		}
-
-		if target == nil {
-			target = map[string]string{}
-			patch.Path = "/metadata/labels"
-			patch.Value = map[string]string{
-				key: value,
-			}
-		}
-
-		if target[key] == "" {
-			patches = append(patches, patch)
-		}
-	}
-
-	return patches
-}
-
-func updateAnnotation(target map[string]string, added map[string]string) (patch []rfc6902PatchOperation) {
-	// To ensure deterministic patches, we sort the keys
-	var keys []string
-	for k := range added {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
-	for _, key := range keys {
-		value := added[key]
-		if target == nil {
-			target = map[string]string{}
-			patch = append(patch, rfc6902PatchOperation{
-				Op:   "add",
-				Path: "/metadata/annotations",
-				Value: map[string]string{
-					key: value,
-				},
-			})
-		} else {
-			op := "add"
-			if target[key] != "" {
-				op = "replace"
-			}
-			patch = append(patch, rfc6902PatchOperation{
-				Op:    op,
-				Path:  "/metadata/annotations/" + escapeJSONPointerValue(key),
-				Value: value,
-			})
-		}
-	}
-	return patch
-}
-
-func createPatch(pod *corev1.Pod, prevStatus *SidecarInjectionStatus, revision string, annotations map[string]string,
-	sic *SidecarInjectionSpec, workloadName string, mesh *meshconfig.MeshConfig) ([]byte, error) {
-
-	var patch []rfc6902PatchOperation
-
-	rewrite := ShouldRewriteAppHTTPProbers(pod.Annotations, sic)
-
-	sidecar := FindSidecar(sic.Containers)
-	// We don't have to escape json encoding here when using golang libraries.
-	if rewrite && sidecar != nil {
-		if prober := DumpAppProbers(&pod.Spec); prober != "" {
-			sidecar.Env = append(sidecar.Env, corev1.EnvVar{Name: status.KubeAppProberEnvName, Value: prober})
-		}
-	}
-
-	if rewrite {
-		patch = append(patch, createProbeRewritePatch(pod.Annotations, &pod.Spec, sic, mesh.GetDefaultConfig().GetStatusPort())...)
-	}
-
-	// Remove any containers previously injected by kube-inject using
-	// container and volume name as unique key for removal.
-	patch = append(patch, removeContainers(pod.Spec.InitContainers, prevStatus.InitContainers, "/spec/initContainers")...)
-	patch = append(patch, removeContainers(pod.Spec.Containers, prevStatus.Containers, "/spec/containers")...)
-	patch = append(patch, removeVolumes(pod.Spec.Volumes, prevStatus.Volumes, "/spec/volumes")...)
-	patch = append(patch, removeImagePullSecrets(pod.Spec.ImagePullSecrets, prevStatus.ImagePullSecrets, "/spec/imagePullSecrets")...)
-
-	if enablePrometheusMerge(mesh, pod.ObjectMeta.Annotations) {
-		scrape := status.PrometheusScrapeConfiguration{
-			Scrape: pod.ObjectMeta.Annotations["prometheus.io/scrape"],
-			Path:   pod.ObjectMeta.Annotations["prometheus.io/path"],
-			Port:   pod.ObjectMeta.Annotations["prometheus.io/port"],
-		}
-		empty := status.PrometheusScrapeConfiguration{}
-		if sidecar != nil && scrape != empty {
-			by, err := json.Marshal(scrape)
-			if err != nil {
-				return nil, err
-			}
-			sidecar.Env = append(sidecar.Env, corev1.EnvVar{Name: status.PrometheusScrapingConfig.Name, Value: string(by)})
-		}
-		annotations["prometheus.io/port"] = strconv.Itoa(int(mesh.GetDefaultConfig().GetStatusPort()))
-		annotations["prometheus.io/path"] = "/stats/prometheus"
-		annotations["prometheus.io/scrape"] = "true"
-	}
-
-	patch = append(patch, addContainer(sic, pod.Spec.InitContainers, sic.InitContainers, "/spec/initContainers")...)
-	patch = append(patch, addContainer(sic, pod.Spec.Containers, sic.Containers, "/spec/containers")...)
-	patch = append(patch, addVolume(pod.Spec.Volumes, sic.Volumes, "/spec/volumes")...)
-	patch = append(patch, addImagePullSecrets(pod.Spec.ImagePullSecrets, sic.ImagePullSecrets, "/spec/imagePullSecrets")...)
-
-	if sic.DNSConfig != nil {
-		patch = append(patch, addPodDNSConfig(sic.DNSConfig, "/spec/dnsConfig")...)
-	}
-
-	if pod.Spec.SecurityContext != nil {
-		patch = append(patch, addSecurityContext(pod.Spec.SecurityContext, "/spec/securityContext")...)
-	}
-
-	patch = append(patch, updateAnnotation(pod.Annotations, annotations)...)
-
-	canonicalSvc, canonicalRev := ExtractCanonicalServiceLabels(pod.Labels, workloadName)
-	patchLabels := map[string]string{
-		label.TLSMode:                                model.IstioMutualTLSModeLabel,
-		model.IstioCanonicalServiceLabelName:         canonicalSvc,
-		label.IstioRev:                               revision,
-		model.IstioCanonicalServiceRevisionLabelName: canonicalRev,
-	}
-	if network := topologyValues(sic); network != "" {
-		// only added if if not already set
-		patchLabels[label.IstioNetwork] = network
-	}
-	patch = append(patch, addLabels(pod.Labels, patchLabels)...)
-
-	return json.Marshal(patch)
-}
-
-// topologyValues will find the value of ISTIO_META_NETWORK in the spec or return a zero-value
-func topologyValues(sic *SidecarInjectionSpec) string {
-	// TODO should we just return the values used to populate the template from InjectionData?
-	for _, c := range sic.Containers {
-		for _, e := range c.Env {
-			if e.Name == "ISTIO_META_NETWORK" {
-				return e.Value
-			}
-		}
-	}
-	return ""
 }
 
 func enablePrometheusMerge(mesh *meshconfig.MeshConfig, anno map[string]string) bool {
@@ -619,45 +329,6 @@ func extractCanonicalServiceLabel(podLabels map[string]string, workloadName stri
 	return workloadName
 }
 
-// Retain deprecated hardcoded container and volumes names to aid in
-// backwards compatible migration to the new SidecarInjectionStatus.
-var (
-	legacyInitContainerNames = []string{"istio-init", "enable-core-dump"}
-	legacyContainerNames     = []string{"istio-proxy"}
-	legacyVolumeNames        = []string{"istio-certs", "istio-envoy"}
-)
-
-func injectionStatus(pod *corev1.Pod) *SidecarInjectionStatus {
-	var statusBytes []byte
-	if pod.ObjectMeta.Annotations != nil {
-		if value, ok := pod.ObjectMeta.Annotations[annotation.SidecarStatus.Name]; ok {
-			statusBytes = []byte(value)
-		}
-	}
-
-	// default case when injected pod has explicit status
-	var iStatus SidecarInjectionStatus
-	if err := json.Unmarshal(statusBytes, &iStatus); err == nil {
-		// heuristic assumes status is valid if any of the resource
-		// lists is non-empty.
-		if len(iStatus.InitContainers) != 0 ||
-			len(iStatus.Containers) != 0 ||
-			len(iStatus.Volumes) != 0 ||
-			len(iStatus.ImagePullSecrets) != 0 {
-			return &iStatus
-		}
-	}
-
-	// backwards compatibility case when injected pod has legacy
-	// status. Infer status from the list of legacy hardcoded
-	// container and volume names.
-	return &SidecarInjectionStatus{
-		InitContainers: legacyInitContainerNames,
-		Containers:     legacyContainerNames,
-		Volumes:        legacyVolumeNames,
-	}
-}
-
 func toAdmissionResponse(err error) *kube.AdmissionResponse {
 	return &kube.AdmissionResponse{Result: &metav1.Status{Message: err.Error()}}
 }
@@ -675,9 +346,177 @@ type InjectionParameters struct {
 	injectedAnnotations map[string]string
 }
 
-func injectPod(req InjectionParameters) ([]byte, error) {
-	pod := req.pod
+func checkPreconditions(params InjectionParameters) {
+	spec := params.pod.Spec
+	metadata := params.pod.ObjectMeta
+	// If DNSPolicy is not ClusterFirst, the Envoy sidecar may not able to connect to Istio Pilot.
+	if spec.DNSPolicy != "" && spec.DNSPolicy != corev1.DNSClusterFirst {
+		podName := potentialPodName(metadata)
+		log.Warnf("%q's DNSPolicy is not %q. The Envoy sidecar may not able to connect to Istio Pilot",
+			metadata.Namespace+"/"+podName, corev1.DNSClusterFirst)
+	}
+}
 
+func getInjectionStatus(podSpec corev1.PodSpec, version string) string {
+	stat := &SidecarInjectionStatus{Version: version}
+	for _, c := range podSpec.InitContainers {
+		stat.InitContainers = append(stat.InitContainers, c.Name)
+	}
+	for _, c := range podSpec.Containers {
+		stat.Containers = append(stat.Containers, c.Name)
+	}
+	for _, c := range podSpec.Volumes {
+		stat.Volumes = append(stat.Volumes, c.Name)
+	}
+	for _, c := range podSpec.ImagePullSecrets {
+		stat.ImagePullSecrets = append(stat.ImagePullSecrets, c.Name)
+	}
+	statusAnnotationValue, err := json.Marshal(stat)
+	if err != nil {
+		return "{}"
+	}
+	return string(statusAnnotationValue)
+}
+
+func injectPod(req InjectionParameters) ([]byte, error) {
+	checkPreconditions(req)
+	originalPodSpec, err := json.Marshal(req.pod)
+	if err != nil {
+		return nil, err
+	}
+
+	// Run the injection template, giving us a partial pod spec
+	spec, injectedSpec, err := RunTemplate(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to run injection template: %v", err)
+	}
+
+	// Merge the original pod spec with the injected overlay
+	mergedPodSpec, err := mergeInjectedConfig(req, spec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to merge pod spec: %v", err)
+	}
+	pod := req.pod.DeepCopy()
+	pod.Spec = mergedPodSpec
+
+	// Apply some additional transformations to the pod
+	if err := postProcessPod(pod, *injectedSpec, req); err != nil {
+		return nil, fmt.Errorf("failed to process pod: %v", err)
+	}
+
+	patch, err := createPatch(pod, originalPodSpec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create patch: %v", err)
+	}
+
+	log.Debugf("AdmissionResponse: patch=%v\n", string(patch))
+	return patch, nil
+}
+
+func createPatch(pod *corev1.Pod, original []byte) ([]byte, error) {
+	reinjected, err := json.Marshal(pod)
+	if err != nil {
+		return nil, err
+	}
+	p, err := jsonpatch.CreatePatch(original, reinjected)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(p)
+}
+
+// postProcessPod applies additionally transformations to the pod after merging with the injected template
+// This is generally things that cannot reasonably be added to the template
+func postProcessPod(pod *corev1.Pod, injectedPodSpec corev1.PodSpec, req InjectionParameters) error {
+	if pod.Annotations == nil {
+		pod.Annotations = map[string]string{}
+	}
+	if pod.Labels == nil {
+		pod.Labels = map[string]string{}
+	}
+
+	applyConcurrency(pod.Spec.Containers)
+
+	overwriteClusterInfo(pod.Spec.Containers, req)
+
+	if err := applyPrometheusMerge(pod, req.meshConfig); err != nil {
+		return err
+	}
+
+	applyFSGroup(pod)
+
+	if err := applyRewrite(pod, req); err != nil {
+		return err
+	}
+
+	applyMetadata(pod, injectedPodSpec, req)
+
+	if err := reorderPod(pod, req); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func applyMetadata(pod *corev1.Pod, injectedPodSpec corev1.PodSpec, req InjectionParameters) {
+	canonicalSvc, canonicalRev := ExtractCanonicalServiceLabels(pod.Labels, req.deployMeta.Name)
+	setIfUnset(pod.Labels, label.TLSMode, model.IstioMutualTLSModeLabel)
+	setIfUnset(pod.Labels, model.IstioCanonicalServiceLabelName, canonicalSvc)
+	setIfUnset(pod.Labels, label.IstioRev, req.revision)
+	setIfUnset(pod.Labels, model.IstioCanonicalServiceRevisionLabelName, canonicalRev)
+
+	// Add all additional injected annotations. These are overridden if needed
+	pod.Annotations[annotation.SidecarStatus.Name] = getInjectionStatus(injectedPodSpec, req.version)
+	for k, v := range req.injectedAnnotations {
+		pod.Annotations[k] = v
+	}
+
+}
+
+// reorderPod ensures containers are properly ordered after merging
+func reorderPod(pod *corev1.Pod, req InjectionParameters) error {
+	valuesStruct := &opconfig.Values{}
+	if err := gogoprotomarshal.ApplyYAML(req.valuesConfig, valuesStruct); err != nil {
+		return fmt.Errorf("could not parse configuration values: %v", err)
+	}
+	holdPod := valuesStruct.GetGlobal().GetProxy().GetHoldApplicationUntilProxyStarts().GetValue()
+	proxyLocation := MoveLast
+	if holdPod {
+		proxyLocation = MoveFirst
+	}
+	// Proxy container should be last, unless HoldApplicationUntilProxyStarts is set
+	// This is to ensure `kubectl exec` and similar commands continue to default to the user's container
+	pod.Spec.Containers = modifyContainers(pod.Spec.Containers, ProxyContainerName, proxyLocation)
+	// Validation container must be first to block any user containers
+	pod.Spec.InitContainers = modifyContainers(pod.Spec.InitContainers, ValidationContainerName, MoveFirst)
+	// Init container must be last to allow any traffic to pass before iptables is setup
+	pod.Spec.InitContainers = modifyContainers(pod.Spec.InitContainers, InitContainerName, MoveLast)
+	pod.Spec.InitContainers = modifyContainers(pod.Spec.InitContainers, EnableCoreDumpName, MoveLast)
+
+	return nil
+}
+
+func applyRewrite(pod *corev1.Pod, req InjectionParameters) error {
+	valuesStruct := &opconfig.Values{}
+	if err := gogoprotomarshal.ApplyYAML(req.valuesConfig, valuesStruct); err != nil {
+		log.Infof("Failed to parse values config: %v [%v]\n", err, req.valuesConfig)
+		return fmt.Errorf("could not parse configuration values: %v", err)
+	}
+
+	rewrite := ShouldRewriteAppHTTPProbers(pod.Annotations, valuesStruct.GetSidecarInjectorWebhook().GetRewriteAppHTTPProbe())
+	sidecar := FindSidecar(pod.Spec.Containers)
+
+	// We don't have to escape json encoding here when using golang libraries.
+	if rewrite && sidecar != nil {
+		if prober := DumpAppProbers(&pod.Spec, req.meshConfig.GetDefaultConfig().GetStatusPort()); prober != "" {
+			sidecar.Env = append(sidecar.Env, corev1.EnvVar{Name: status.KubeAppProberEnvName, Value: prober})
+		}
+		patchRewriteProbe(pod.Annotations, pod, req.meshConfig.GetDefaultConfig().GetStatusPort())
+	}
+	return nil
+}
+
+func applyFSGroup(pod *corev1.Pod) {
 	if features.EnableLegacyFSGroupInjection {
 		// due to bug https://github.com/kubernetes/kubernetes/issues/57923,
 		// k8s sa jwt token volume mount file is only accessible to root user, not istio-proxy(the user that istio proxy runs as).
@@ -691,26 +530,67 @@ func injectPod(req InjectionParameters) ([]byte, error) {
 			pod.Spec.SecurityContext.FSGroup = &grp
 		}
 	}
+}
 
-	spec, iStatus, err := InjectionData(req, req.typeMeta, req.deployMeta)
+// applyPrometheusMerge configures prometheus scraping annotations for the "metrics merge" feature.
+// This moves the current prometheus.io annotations into an environment variable and replaces them
+// pointing to the agent.
+func applyPrometheusMerge(pod *corev1.Pod, mesh *meshconfig.MeshConfig) error {
+	sidecar := FindSidecar(pod.Spec.Containers)
+	if enablePrometheusMerge(mesh, pod.ObjectMeta.Annotations) {
+		targetPort := strconv.Itoa(int(mesh.GetDefaultConfig().GetStatusPort()))
+		if cur, f := pod.Annotations["prometheus.io/port"]; f {
+			// We have already set the port, assume user is controlling this or, more likely, re-injected
+			// the pod.
+			if cur == targetPort {
+				return nil
+			}
+		}
+		scrape := status.PrometheusScrapeConfiguration{
+			Scrape: pod.Annotations["prometheus.io/scrape"],
+			Path:   pod.Annotations["prometheus.io/path"],
+			Port:   pod.Annotations["prometheus.io/port"],
+		}
+		empty := status.PrometheusScrapeConfiguration{}
+		if sidecar != nil && scrape != empty {
+			by, err := json.Marshal(scrape)
+			if err != nil {
+				return err
+			}
+			sidecar.Env = append(sidecar.Env, corev1.EnvVar{Name: status.PrometheusScrapingConfig.Name, Value: string(by)})
+		}
+		if pod.Annotations == nil {
+			pod.Annotations = map[string]string{}
+		}
+		pod.Annotations["prometheus.io/port"] = targetPort
+		pod.Annotations["prometheus.io/path"] = "/stats/prometheus"
+		pod.Annotations["prometheus.io/scrape"] = "true"
+	}
+	return nil
+}
+
+func mergeInjectedConfig(req InjectionParameters, injected []byte) (corev1.PodSpec, error) {
+	current, err := json.Marshal(req.pod.Spec)
 	if err != nil {
-		return nil, err
+		return corev1.PodSpec{}, err
 	}
 
-	annotations := map[string]string{annotation.SidecarStatus.Name: iStatus}
-
-	// Add all additional injected annotations
-	for k, v := range req.injectedAnnotations {
-		annotations[k] = v
-	}
-
-	patchBytes, err := createPatch(pod, injectionStatus(pod), req.revision, annotations, spec, req.deployMeta.Name, req.meshConfig)
+	// The template is yaml, StrategicMergePatch expects JSON
+	injectedJSON, err := yaml.YAMLToJSON(injected)
 	if err != nil {
-		return nil, err
+		return corev1.PodSpec{}, fmt.Errorf("yaml to json: %v", err)
 	}
 
-	log.Debugf("AdmissionResponse: patch=%v\n", string(patchBytes))
-	return patchBytes, nil
+	pod := corev1.PodSpec{}
+	// Overlay the injected template onto the original pod spec
+	patched, err := strategicpatch.StrategicMergePatch(current, injectedJSON, pod)
+	if err != nil {
+		return corev1.PodSpec{}, fmt.Errorf("strategic merge: %v", err)
+	}
+	if err := json.Unmarshal(patched, &pod); err != nil {
+		return corev1.PodSpec{}, fmt.Errorf("unmarshal patched pod: %v", err)
+	}
+	return pod, nil
 }
 
 func (wh *Webhook) inject(ar *kube.AdmissionReview, path string) *kube.AdmissionResponse {
@@ -723,7 +603,7 @@ func (wh *Webhook) inject(ar *kube.AdmissionReview, path string) *kube.Admission
 	}
 
 	// Deal with potential empty fields, e.g., when the pod is created by a deployment
-	podName := potentialPodName(&pod.ObjectMeta)
+	podName := potentialPodName(pod.ObjectMeta)
 	if pod.ObjectMeta.Namespace == "" {
 		pod.ObjectMeta.Namespace = req.Namespace
 	}
@@ -731,7 +611,7 @@ func (wh *Webhook) inject(ar *kube.AdmissionReview, path string) *kube.Admission
 	log.Debugf("Object: %v", string(req.Object.Raw))
 	log.Debugf("OldObject: %v", string(req.OldObject.Raw))
 
-	if !injectRequired(ignoredNamespaces, wh.Config, &pod.Spec, &pod.ObjectMeta) {
+	if !injectRequired(ignoredNamespaces, wh.Config, &pod.Spec, pod.ObjectMeta) {
 		log.Infof("Skipping %s/%s due to policy check", pod.ObjectMeta.Namespace, podName)
 		totalSkippedInjections.Increment()
 		return &kube.AdmissionResponse{

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -87,7 +87,7 @@ func TestInjectRequired(t *testing.T) {
 	cases := []struct {
 		config  *Config
 		podSpec *corev1.PodSpec
-		meta    *metav1.ObjectMeta
+		meta    metav1.ObjectMeta
 		want    bool
 	}{
 		{
@@ -95,7 +95,7 @@ func TestInjectRequired(t *testing.T) {
 				Policy: InjectionPolicyEnabled,
 			},
 			podSpec: podSpec,
-			meta: &metav1.ObjectMeta{
+			meta: metav1.ObjectMeta{
 				Name:        "no-policy",
 				Namespace:   "test-namespace",
 				Annotations: map[string]string{},
@@ -107,7 +107,7 @@ func TestInjectRequired(t *testing.T) {
 				Policy: InjectionPolicyEnabled,
 			},
 			podSpec: podSpec,
-			meta: &metav1.ObjectMeta{
+			meta: metav1.ObjectMeta{
 				Name:      "default-policy",
 				Namespace: "test-namespace",
 			},
@@ -118,7 +118,7 @@ func TestInjectRequired(t *testing.T) {
 				Policy: InjectionPolicyEnabled,
 			},
 			podSpec: podSpec,
-			meta: &metav1.ObjectMeta{
+			meta: metav1.ObjectMeta{
 				Name:        "force-on-policy",
 				Namespace:   "test-namespace",
 				Annotations: map[string]string{annotation.SidecarInject.Name: "true"},
@@ -130,7 +130,7 @@ func TestInjectRequired(t *testing.T) {
 				Policy: InjectionPolicyEnabled,
 			},
 			podSpec: podSpec,
-			meta: &metav1.ObjectMeta{
+			meta: metav1.ObjectMeta{
 				Name:        "force-off-policy",
 				Namespace:   "test-namespace",
 				Annotations: map[string]string{annotation.SidecarInject.Name: "false"},
@@ -142,7 +142,7 @@ func TestInjectRequired(t *testing.T) {
 				Policy: InjectionPolicyDisabled,
 			},
 			podSpec: podSpec,
-			meta: &metav1.ObjectMeta{
+			meta: metav1.ObjectMeta{
 				Name:        "no-policy",
 				Namespace:   "test-namespace",
 				Annotations: map[string]string{},
@@ -154,7 +154,7 @@ func TestInjectRequired(t *testing.T) {
 				Policy: InjectionPolicyDisabled,
 			},
 			podSpec: podSpec,
-			meta: &metav1.ObjectMeta{
+			meta: metav1.ObjectMeta{
 				Name:      "default-policy",
 				Namespace: "test-namespace",
 			},
@@ -165,7 +165,7 @@ func TestInjectRequired(t *testing.T) {
 				Policy: InjectionPolicyDisabled,
 			},
 			podSpec: podSpec,
-			meta: &metav1.ObjectMeta{
+			meta: metav1.ObjectMeta{
 				Name:        "force-on-policy",
 				Namespace:   "test-namespace",
 				Annotations: map[string]string{annotation.SidecarInject.Name: "true"},
@@ -177,7 +177,7 @@ func TestInjectRequired(t *testing.T) {
 				Policy: InjectionPolicyDisabled,
 			},
 			podSpec: podSpec,
-			meta: &metav1.ObjectMeta{
+			meta: metav1.ObjectMeta{
 				Name:        "force-off-policy",
 				Namespace:   "test-namespace",
 				Annotations: map[string]string{annotation.SidecarInject.Name: "false"},
@@ -189,7 +189,7 @@ func TestInjectRequired(t *testing.T) {
 				Policy: InjectionPolicyEnabled,
 			},
 			podSpec: podSpecHostNetwork,
-			meta: &metav1.ObjectMeta{
+			meta: metav1.ObjectMeta{
 				Name:        "force-off-policy",
 				Namespace:   "test-namespace",
 				Annotations: map[string]string{},
@@ -201,7 +201,7 @@ func TestInjectRequired(t *testing.T) {
 				Policy: "wrong_policy",
 			},
 			podSpec: podSpec,
-			meta: &metav1.ObjectMeta{
+			meta: metav1.ObjectMeta{
 				Name:        "wrong-policy",
 				Namespace:   "test-namespace",
 				Annotations: map[string]string{},
@@ -214,7 +214,7 @@ func TestInjectRequired(t *testing.T) {
 				AlwaysInjectSelector: []metav1.LabelSelector{{MatchLabels: map[string]string{"foo": "bar"}}},
 			},
 			podSpec: podSpec,
-			meta: &metav1.ObjectMeta{
+			meta: metav1.ObjectMeta{
 				Name:      "policy-enabled-always-inject-no-labels",
 				Namespace: "test-namespace",
 			},
@@ -226,7 +226,7 @@ func TestInjectRequired(t *testing.T) {
 				AlwaysInjectSelector: []metav1.LabelSelector{{MatchLabels: map[string]string{"foo": "bar"}}},
 			},
 			podSpec: podSpec,
-			meta: &metav1.ObjectMeta{
+			meta: metav1.ObjectMeta{
 				Name:      "policy-enabled-always-inject-with-labels",
 				Namespace: "test-namespace",
 				Labels:    map[string]string{"foo": "bar1"},
@@ -239,7 +239,7 @@ func TestInjectRequired(t *testing.T) {
 				AlwaysInjectSelector: []metav1.LabelSelector{{MatchLabels: map[string]string{"foo": "bar"}}},
 			},
 			podSpec: podSpec,
-			meta: &metav1.ObjectMeta{
+			meta: metav1.ObjectMeta{
 				Name:      "policy-disabled-always-inject-no-labels",
 				Namespace: "test-namespace",
 			},
@@ -251,7 +251,7 @@ func TestInjectRequired(t *testing.T) {
 				AlwaysInjectSelector: []metav1.LabelSelector{{MatchLabels: map[string]string{"foo": "bar"}}},
 			},
 			podSpec: podSpec,
-			meta: &metav1.ObjectMeta{
+			meta: metav1.ObjectMeta{
 				Name:      "policy-disabled-always-inject-with-labels",
 				Namespace: "test-namespace",
 				Labels:    map[string]string{"foo": "bar"},
@@ -264,7 +264,7 @@ func TestInjectRequired(t *testing.T) {
 				NeverInjectSelector: []metav1.LabelSelector{{MatchLabels: map[string]string{"foo": "bar"}}},
 			},
 			podSpec: podSpec,
-			meta: &metav1.ObjectMeta{
+			meta: metav1.ObjectMeta{
 				Name:      "policy-enabled-never-inject-no-labels",
 				Namespace: "test-namespace",
 			},
@@ -276,7 +276,7 @@ func TestInjectRequired(t *testing.T) {
 				NeverInjectSelector: []metav1.LabelSelector{{MatchLabels: map[string]string{"foo": "bar"}}},
 			},
 			podSpec: podSpec,
-			meta: &metav1.ObjectMeta{
+			meta: metav1.ObjectMeta{
 				Name:      "policy-enabled-never-inject-with-labels",
 				Namespace: "test-namespace",
 				Labels:    map[string]string{"foo": "bar"},
@@ -289,7 +289,7 @@ func TestInjectRequired(t *testing.T) {
 				NeverInjectSelector: []metav1.LabelSelector{{MatchLabels: map[string]string{"foo": "bar"}}},
 			},
 			podSpec: podSpec,
-			meta: &metav1.ObjectMeta{
+			meta: metav1.ObjectMeta{
 				Name:      "policy-disabled-never-inject-no-labels",
 				Namespace: "test-namespace",
 			},
@@ -301,7 +301,7 @@ func TestInjectRequired(t *testing.T) {
 				NeverInjectSelector: []metav1.LabelSelector{{MatchLabels: map[string]string{"foo": "bar"}}},
 			},
 			podSpec: podSpec,
-			meta: &metav1.ObjectMeta{
+			meta: metav1.ObjectMeta{
 				Name:      "policy-disabled-never-inject-with-labels",
 				Namespace: "test-namespace",
 				Labels:    map[string]string{"foo": "bar"},
@@ -314,7 +314,7 @@ func TestInjectRequired(t *testing.T) {
 				NeverInjectSelector: []metav1.LabelSelector{*parseToLabelSelector(t, "foo")},
 			},
 			podSpec: podSpec,
-			meta: &metav1.ObjectMeta{
+			meta: metav1.ObjectMeta{
 				Name:      "policy-enabled-never-inject-with-empty-label",
 				Namespace: "test-namespace",
 				Labels:    map[string]string{"foo": "", "foo2": "bar2"},
@@ -327,7 +327,7 @@ func TestInjectRequired(t *testing.T) {
 				AlwaysInjectSelector: []metav1.LabelSelector{*parseToLabelSelector(t, "foo")},
 			},
 			podSpec: podSpec,
-			meta: &metav1.ObjectMeta{
+			meta: metav1.ObjectMeta{
 				Name:      "policy-disabled-always-inject-with-empty-label",
 				Namespace: "test-namespace",
 				Labels:    map[string]string{"foo": "", "foo2": "bar2"},
@@ -341,7 +341,7 @@ func TestInjectRequired(t *testing.T) {
 				NeverInjectSelector:  []metav1.LabelSelector{*parseToLabelSelector(t, "never")},
 			},
 			podSpec: podSpec,
-			meta: &metav1.ObjectMeta{
+			meta: metav1.ObjectMeta{
 				Name:      "policy-disabled-always-never-inject-with-label-returns-true",
 				Namespace: "test-namespace",
 				Labels:    map[string]string{"always": "bar", "foo2": "bar2"},
@@ -355,7 +355,7 @@ func TestInjectRequired(t *testing.T) {
 				NeverInjectSelector:  []metav1.LabelSelector{*parseToLabelSelector(t, "never")},
 			},
 			podSpec: podSpec,
-			meta: &metav1.ObjectMeta{
+			meta: metav1.ObjectMeta{
 				Name:      "policy-disabled-always-never-inject-with-label-returns-false",
 				Namespace: "test-namespace",
 				Labels:    map[string]string{"never": "bar", "foo2": "bar2"},
@@ -369,7 +369,7 @@ func TestInjectRequired(t *testing.T) {
 				NeverInjectSelector:  []metav1.LabelSelector{*parseToLabelSelector(t, "never")},
 			},
 			podSpec: podSpec,
-			meta: &metav1.ObjectMeta{
+			meta: metav1.ObjectMeta{
 				Name:      "policy-disabled-always-never-inject-with-both-labels",
 				Namespace: "test-namespace",
 				Labels:    map[string]string{"always": "bar", "never": "bar2"},
@@ -382,7 +382,7 @@ func TestInjectRequired(t *testing.T) {
 				NeverInjectSelector: []metav1.LabelSelector{*parseToLabelSelector(t, "foo")},
 			},
 			podSpec: podSpec,
-			meta: &metav1.ObjectMeta{
+			meta: metav1.ObjectMeta{
 				Name:        "policy-enabled-annotation-true-never-inject",
 				Namespace:   "test-namespace",
 				Annotations: map[string]string{annotation.SidecarInject.Name: "true"},
@@ -396,7 +396,7 @@ func TestInjectRequired(t *testing.T) {
 				AlwaysInjectSelector: []metav1.LabelSelector{*parseToLabelSelector(t, "foo")},
 			},
 			podSpec: podSpec,
-			meta: &metav1.ObjectMeta{
+			meta: metav1.ObjectMeta{
 				Name:        "policy-enabled-annotation-false-always-inject",
 				Namespace:   "test-namespace",
 				Annotations: map[string]string{annotation.SidecarInject.Name: "false"},
@@ -410,7 +410,7 @@ func TestInjectRequired(t *testing.T) {
 				AlwaysInjectSelector: []metav1.LabelSelector{*parseToLabelSelector(t, "foo")},
 			},
 			podSpec: podSpec,
-			meta: &metav1.ObjectMeta{
+			meta: metav1.ObjectMeta{
 				Name:        "policy-disabled-annotation-false-always-inject",
 				Namespace:   "test-namespace",
 				Annotations: map[string]string{annotation.SidecarInject.Name: "false"},
@@ -424,7 +424,7 @@ func TestInjectRequired(t *testing.T) {
 				NeverInjectSelector: []metav1.LabelSelector{*parseToLabelSelector(t, "foo"), *parseToLabelSelector(t, "bar")},
 			},
 			podSpec: podSpec,
-			meta: &metav1.ObjectMeta{
+			meta: metav1.ObjectMeta{
 				Name:      "policy-enabled-never-inject-multiple-labels",
 				Namespace: "test-namespace",
 				Labels:    map[string]string{"label1": "", "bar": "anything"},
@@ -437,7 +437,7 @@ func TestInjectRequired(t *testing.T) {
 				AlwaysInjectSelector: []metav1.LabelSelector{*parseToLabelSelector(t, "foo"), *parseToLabelSelector(t, "bar")},
 			},
 			podSpec: podSpec,
-			meta: &metav1.ObjectMeta{
+			meta: metav1.ObjectMeta{
 				Name:      "policy-enabled-always-inject-multiple-labels",
 				Namespace: "test-namespace",
 				Labels:    map[string]string{"label1": "", "bar": "anything"},
@@ -450,7 +450,7 @@ func TestInjectRequired(t *testing.T) {
 				NeverInjectSelector: []metav1.LabelSelector{*parseToLabelSelector(t, "foo")},
 			},
 			podSpec: podSpec,
-			meta: &metav1.ObjectMeta{
+			meta: metav1.ObjectMeta{
 				Name:        "policy-disabled-annotation-true-never-inject",
 				Namespace:   "test-namespace",
 				Annotations: map[string]string{annotation.SidecarInject.Name: "true"},
@@ -605,7 +605,6 @@ func TestWebhookInject(t *testing.T) {
 		}
 		c := c
 		t.Run(fmt.Sprintf("[%d] %s", i, c.inputFile), func(t *testing.T) {
-			t.Parallel()
 			wh := createTestWebhookFromFile(filepath.Join("testdata/webhook", templateFile), t)
 			podYAML := util.ReadFile(input, t)
 			podJSON, err := yaml.YAMLToJSON(podYAML)
@@ -1021,91 +1020,73 @@ func TestRunAndServe(t *testing.T) {
 
 	// nolint: lll
 	validPatch := []byte(`[
-   {
-      "op":"add",
-      "path":"/spec/initContainers/-",
-      "value":{
-         "name":"istio-init",
-         "resources":{
-
-         }
-      }
-   },
-   {
-      "op":"add",
-      "path":"/spec/containers/-",
-      "value":{
-         "name":"istio-proxy",
-         "resources":{
-
-         }
-      }
-   },
-   {
-      "op":"add",
-      "path":"/spec/volumes/-",
-      "value":{
-         "name":"istio-envoy"
-      }
-   },
-   {
-      "op":"add",
-      "path":"/spec/imagePullSecrets/-",
-      "value":{
-         "name":"istio-image-pull-secrets"
-      }
-   },
-   {
-      "op":"add",
-      "path":"/spec/securityContext",
-      "value":{
-         "fsGroup":1337
-      }
-   },
-   {
-      "op":"add",
-      "path":"/metadata/annotations",
-      "value":{
-         "prometheus.io/path":"/stats/prometheus"
-      }
-   },
-   {
-      "op": "add",
-      "path": "/metadata/annotations/prometheus.io~1port",
-      "value": "15020"
-   },
-   {
-      "op": "add",
-      "path": "/metadata/annotations/prometheus.io~1scrape",
-      "value": "true"
-   },
-   {
-      "op":"add",
-      "path":"/metadata/annotations/sidecar.istio.io~1status",
-      "value": "{\"version\":\"461c380844de8df1d1e2a80a09b6d7b58b8313c4a7d6796530eb124740a1440f\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
-   },
-    {
-      "op":"add",
-      "path":"/metadata/labels",
-      "value":{
-         "istio.io/rev":""
-      }
-    },
-    {
-      "op":"add",
-      "path":"/metadata/labels/security.istio.io~1tlsMode",
-      "value":"istio"
-    },
-    {
-      "op": "add",
-      "path": "/metadata/labels/service.istio.io~1canonical-name",
-      "value": "test"
-	},
-	{
-		"op": "add",
-		"path": "/metadata/labels/service.istio.io~1canonical-revision",
-		"value": "latest"
-	}
+{
+    "op": "add",
+    "path": "/metadata/labels",
+    "value": {
+        "istio.io/rev": "",
+        "security.istio.io/tlsMode": "istio",
+        "service.istio.io/canonical-name": "test",
+        "service.istio.io/canonical-revision": "latest"
+    }
+},
+{
+    "op": "add",
+    "path": "/metadata/annotations",
+    "value": {
+        "prometheus.io/path": "/stats/prometheus",
+        "prometheus.io/port": "15020",
+        "prometheus.io/scrape": "true",
+        "sidecar.istio.io/status": "{\"version\":\"461c380844de8df1d1e2a80a09b6d7b58b8313c4a7d6796530eb124740a1440f\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
+    }
+},
+{
+    "op": "add",
+    "path": "/spec/volumes/1",
+    "value": {
+        "name": "v0"
+    }
+},
+{
+    "op": "replace",
+    "path": "/spec/volumes/0/name",
+    "value": "istio-envoy"
+},
+{
+    "op": "add",
+    "path": "/spec/initContainers/1",
+    "value": {
+        "name": "istio-init",
+        "resources": {}
+    }
+},
+{
+    "op": "add",
+    "path": "/spec/containers/1",
+    "value": {
+        "name": "istio-proxy",
+        "resources": {}
+    }
+},
+{
+    "op": "add",
+    "path": "/spec/securityContext",
+    "value": {
+        "fsGroup": 1337
+    }
+},
+{
+    "op": "add",
+    "path": "/spec/imagePullSecrets/1",
+    "value": {
+        "name": "p0"
+    }
+},
+{
+    "op": "replace",
+    "path": "/spec/imagePullSecrets/0/name",
+    "value": "istio-image-pull-secrets"
+}
 ]`)
 
 	cases := []struct {


### PR DESCRIPTION
This implements the first two parts of https://docs.google.com/document/d/1Rmp9B3DDypgMCau-YAqidx_r3qvKLZj6jUX-t22zj84/. Please see "Refactor injector internals" and "Make sidecar injection idempotent" of that doc for some additional details

Fixes https://github.com/istio/istio/issues/25931

This deeply modifies the logic we use for injection. Rather than hand crafting a json patch, which is tedious and not flexible, we just do a merge of the template with the original pod, then directly modify the `corev1.Pod`. This has extremely minimal user impact; all existing templates should continue to work, but some additional options may now be available.

This can be seen by the fact the InjectTest has no changes and still passes. It should be noted the Webhook test DOES have a lot of changes - this is because the jsonpatch library we use is generating the patches, and it does so differently than we used to. However, the end result to the user is the same.

This change is quite large. Sorry. I think the new code is far simpler and more maintainable though.