### PR TITLE
Refactor: extract Kubernetes version

### DIFF
--- a/istioctl/pkg/install/k8sversion/version.go
+++ b/istioctl/pkg/install/k8sversion/version.go
@@ -45,7 +45,7 @@ func CheckKubernetesVersion(versionInfo *version.Info) (bool, error) {
 func extractKubernetesVersion(versionInfo *version.Info) (int, error) {
 	ver, err := goversion.NewVersion(versionInfo.String())
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("could not parse %v", err)
 	}
 	// Segments provide slice of int eg: v1.19.1 => [1, 19, 1]
 	num := ver.Segments()[1]

--- a/istioctl/pkg/install/k8sversion/version.go
+++ b/istioctl/pkg/install/k8sversion/version.go
@@ -17,11 +17,11 @@ package k8sversion
 import (
 	"fmt"
 
+	goversion "github.com/hashicorp/go-version"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
-	goversion "github.com/hashicorp/go-version"
 	"istio.io/istio/operator/pkg/util/clog"
 	pkgVersion "istio.io/pkg/version"
 )

--- a/istioctl/pkg/install/k8sversion/version_test.go
+++ b/istioctl/pkg/install/k8sversion/version_test.go
@@ -32,6 +32,11 @@ var (
 		Minor:      "8",
 		GitVersion: "1.8",
 	}
+	version1_19 = &version.Info{
+		Major:      "1",
+		Minor:      "19",
+		GitVersion: "v1.19.4",
+	}
 	version1_17GKE = &version.Info{
 		Major:      "1",
 		Minor:      "17+",
@@ -74,6 +79,12 @@ func TestExtractKubernetesVersion(t *testing.T) {
 			isValid:  true,
 		},
 		{
+			version:  version1_19,
+			expected: 19,
+			errMsg:   nil,
+			isValid:  true,
+		},
+		{
 			version:  version1_17GKE,
 			expected: 17,
 			errMsg:   nil,
@@ -87,12 +98,12 @@ func TestExtractKubernetesVersion(t *testing.T) {
 		},
 		{
 			version: versionInvalid1,
-			errMsg:  fmt.Errorf("the version %q is invalid", versionInvalid1.GitVersion),
+			errMsg:  fmt.Errorf("Malformed version: %v", versionInvalid1.GitVersion),
 			isValid: false,
 		},
 		{
 			version: versionInvalid2,
-			errMsg:  fmt.Errorf("could not parse %q as version", versionInvalid2.GitVersion),
+			errMsg:  fmt.Errorf("Malformed version: %v", versionInvalid2.GitVersion),
 			isValid: false,
 		},
 	}

--- a/istioctl/pkg/install/k8sversion/version_test.go
+++ b/istioctl/pkg/install/k8sversion/version_test.go
@@ -37,6 +37,11 @@ var (
 		Minor:      "19",
 		GitVersion: "v1.19.4",
 	}
+	version1_19_rc = &version.Info{
+		Major:      "1",
+		Minor:      "19",
+		GitVersion: "v1.19.5-rc.0",
+	}
 	version1_17GKE = &version.Info{
 		Major:      "1",
 		Minor:      "17+",
@@ -85,6 +90,12 @@ func TestExtractKubernetesVersion(t *testing.T) {
 			isValid:  true,
 		},
 		{
+			version:  version1_19_rc,
+			expected: 19,
+			errMsg:   nil,
+			isValid:  true,
+		},
+		{
 			version:  version1_17GKE,
 			expected: 17,
 			errMsg:   nil,
@@ -98,12 +109,12 @@ func TestExtractKubernetesVersion(t *testing.T) {
 		},
 		{
 			version: versionInvalid1,
-			errMsg:  fmt.Errorf("Malformed version: %v", versionInvalid1.GitVersion),
+			errMsg:  fmt.Errorf("could not parse Malformed version: %v", versionInvalid1.GitVersion),
 			isValid: false,
 		},
 		{
 			version: versionInvalid2,
-			errMsg:  fmt.Errorf("Malformed version: %v", versionInvalid2.GitVersion),
+			errMsg:  fmt.Errorf("could not parse Malformed version: %v", versionInvalid2.GitVersion),
 			isValid: false,
 		},
 	}

--- a/istioctl/pkg/install/k8sversion/version_test.go
+++ b/istioctl/pkg/install/k8sversion/version_test.go
@@ -37,7 +37,7 @@ var (
 		Minor:      "19",
 		GitVersion: "v1.19.4",
 	}
-	version1_19_rc = &version.Info{
+	version1_19RC = &version.Info{
 		Major:      "1",
 		Minor:      "19",
 		GitVersion: "v1.19.5-rc.0",
@@ -90,7 +90,7 @@ func TestExtractKubernetesVersion(t *testing.T) {
 			isValid:  true,
 		},
 		{
-			version:  version1_19_rc,
+			version:  version1_19RC,
 			expected: 19,
 			errMsg:   nil,
 			isValid:  true,


### PR DESCRIPTION

`version.Segments()` is useful to extract valid version info.
 
```
[istio-master] $ ./out/linux_amd64/istioctl x precheck
...

#2. Kubernetes-version
-----------------------
Istio is compatible with Kubernetes: v1.19.1.

...
```