### PR TITLE
Update min k8 supported version for istio 1.8

### DIFF
--- a/istioctl/pkg/install/k8sversion/version.go
+++ b/istioctl/pkg/install/k8sversion/version.go
@@ -31,7 +31,7 @@ import (
 const (
 	// MinK8SVersion is the minimum k8s version required to run this version of Istio
 	// https://istio.io/docs/setup/platform-setup/
-	MinK8SVersion = 17
+	MinK8SVersion = 16
 )
 
 // CheckKubernetesVersion checks if this Istio version is supported in the k8s version

--- a/istioctl/pkg/install/k8sversion/version_test.go
+++ b/istioctl/pkg/install/k8sversion/version_test.go
@@ -22,6 +22,11 @@ import (
 )
 
 var (
+	version1_16 = &version.Info{
+		Major:      "1",
+		Minor:      "16",
+		GitVersion: "1.16",
+	}
 	version1_17 = &version.Info{
 		Major:      "1",
 		Minor:      "17",
@@ -61,6 +66,12 @@ func TestExtractKubernetesVersion(t *testing.T) {
 		errMsg   error
 		isValid  bool
 	}{
+		{
+			version:  version1_16,
+			expected: 16,
+			errMsg:   nil,
+			isValid:  true,
+		},
 		{
 			version:  version1_17,
 			expected: 17,

--- a/releasenotes/notes/min-k8-ver-for-1.8.yaml
+++ b/releasenotes/notes/min-k8-ver-for-1.8.yaml
@@ -1,6 +1,8 @@
 apiVersion: release-notes/v2
 kind: feature
 area: installation
+issue:
+- 28814
 releaseNotes:
 - |
   **Added** Istio 1.8 supports kubernetes versions 1.16 to 1.19.

--- a/releasenotes/notes/min-k8-ver-for-1.8.yaml
+++ b/releasenotes/notes/min-k8-ver-for-1.8.yaml
@@ -1,8 +1,6 @@
 apiVersion: release-notes/v2
 kind: feature
 area: installation
-issue:
-- 25793
 releaseNotes:
 - |
-  **Added** Istio 1.8 supports kubernetes versions 1.17 to 1.19.
+  **Added** Istio 1.8 supports kubernetes versions 1.16 to 1.19.


### PR DESCRIPTION
> From TOC meeting, support for 1.8 is 1.16->1.19.

A recent change in docs https://github.com/istio/istio.io/pull/8421

Previous change:
https://github.com/istio/istio/pull/25793
