### PR TITLE
set PROV_CERT to empty in workload command

### DIFF
--- a/istioctl/cmd/workload.go
+++ b/istioctl/cmd/workload.go
@@ -289,6 +289,9 @@ func createClusterEnv(wg *clientv1alpha3.WorkloadGroup, dir string) error {
 
 	// default attributes and service name, namespace, ports, service account, service CIDR
 	clusterEnv := map[string]string{
+		// TODO use a better mechanism to trigger using token-auth
+		// TODO allow configuring cert vs token auth in cmd
+		"PROV_CERT":           "",
 		"ISTIO_INBOUND_PORTS": portBehavior,
 		"ISTIO_NAMESPACE":     wg.Namespace,
 		"ISTIO_SERVICE":       fmt.Sprintf("%s.%s", wg.Name, wg.Namespace),


### PR DESCRIPTION
https://github.com/istio/istio.io/pull/8418 in combination with this change fixes #28824 

We should start using the workload command in our VM setup for integration tests to keep the docs in sync with what we test. 