### PR TITLE
Remove analysis codes that are no longer used

### DIFF
--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -41,10 +41,6 @@ var (
 	// Description: The resource has a schema validation error.
 	SchemaValidationError = diag.NewMessageType(diag.Error, "IST0106", "Schema validation error: %v")
 
-	// SchemaWarning defines a diag.MessageType for message "SchemaWarning".
-	// Description: The resource has a schema validation warning.
-	SchemaWarning = diag.NewMessageType(diag.Warning, "IST0133", "Schema validation warning: %v")
-
 	// MisplacedAnnotation defines a diag.MessageType for message "MisplacedAnnotation".
 	// Description: An Istio annotation is applied to the wrong kind of resource.
 	MisplacedAnnotation = diag.NewMessageType(diag.Warning, "IST0107", "Misplaced annotation: %s can only be applied to %s")
@@ -73,14 +69,6 @@ var (
 	// Description: A DestinationRule and Policy are in conflict with regards to mTLS.
 	MTLSPolicyConflict = diag.NewMessageType(diag.Error, "IST0113", "A DestinationRule and Policy are in conflict with regards to mTLS for host %s. The DestinationRule %q specifies that mTLS must be %t but the Policy object %q specifies %s.")
 
-	// PolicySpecifiesPortNameThatDoesntExist defines a diag.MessageType for message "PolicySpecifiesPortNameThatDoesntExist".
-	// Description: A Policy targets a port name that cannot be found.
-	PolicySpecifiesPortNameThatDoesntExist = diag.NewMessageType(diag.Warning, "IST0114", "Port name %s could not be found for host %s, which means the Policy won't be enforced.")
-
-	// DestinationRuleUsesMTLSForWorkloadWithoutSidecar defines a diag.MessageType for message "DestinationRuleUsesMTLSForWorkloadWithoutSidecar".
-	// Description: A DestinationRule uses mTLS for a workload that has no sidecar.
-	DestinationRuleUsesMTLSForWorkloadWithoutSidecar = diag.NewMessageType(diag.Error, "IST0115", "DestinationRule %s uses mTLS for workload %s that has no sidecar. Traffic from workloads with sidecars will fail.")
-
 	// DeploymentAssociatedToMultipleServices defines a diag.MessageType for message "DeploymentAssociatedToMultipleServices".
 	// Description: The resulting pods of a service mesh deployment can't be associated with multiple services using the same port but different protocols.
 	DeploymentAssociatedToMultipleServices = diag.NewMessageType(diag.Warning, "IST0116", "This deployment %s is associated with multiple services using port %d but different protocols: %v")
@@ -96,14 +84,6 @@ var (
 	// JwtFailureDueToInvalidServicePortPrefix defines a diag.MessageType for message "JwtFailureDueToInvalidServicePortPrefix".
 	// Description: Authentication policy with JWT targets Service with invalid port specification.
 	JwtFailureDueToInvalidServicePortPrefix = diag.NewMessageType(diag.Warning, "IST0119", "Authentication policy with JWT targets Service with invalid port specification (port: %d, name: %s, protocol: %s, targetPort: %s).")
-
-	// PolicyResourceIsDeprecated defines a diag.MessageType for message "PolicyResourceIsDeprecated".
-	// Description: The Policy resource is deprecated and will be removed in a future Istio release. Migrate to the PeerAuthentication resource.
-	PolicyResourceIsDeprecated = diag.NewMessageType(diag.Info, "IST0120", "The Policy resource is deprecated and will be removed in a future Istio release. Migrate to the PeerAuthentication resource.")
-
-	// MeshPolicyResourceIsDeprecated defines a diag.MessageType for message "MeshPolicyResourceIsDeprecated".
-	// Description: The MeshPolicy resource is deprecated and will be removed in a future Istio release. Migrate to the PeerAuthentication resource.
-	MeshPolicyResourceIsDeprecated = diag.NewMessageType(diag.Info, "IST0121", "The MeshPolicy resource is deprecated and will be removed in a future Istio release. Migrate to the PeerAuthentication resource.")
 
 	// InvalidRegexp defines a diag.MessageType for message "InvalidRegexp".
 	// Description: Invalid Regex
@@ -144,6 +124,10 @@ var (
 	// VirtualServiceHostNotFoundInGateway defines a diag.MessageType for message "VirtualServiceHostNotFoundInGateway".
 	// Description: Host defined in VirtualService not found in Gateway.
 	VirtualServiceHostNotFoundInGateway = diag.NewMessageType(diag.Warning, "IST0132", "one or more host %v defined in VirtualService %s not found in Gateway %s.")
+
+	// SchemaWarning defines a diag.MessageType for message "SchemaWarning".
+	// Description: The resource has a schema validation warning.
+	SchemaWarning = diag.NewMessageType(diag.Warning, "IST0133", "Schema validation warning: %v")
 )
 
 // All returns a list of all known message types.
@@ -157,7 +141,6 @@ func All() []*diag.MessageType {
 		GatewayPortNotOnWorkload,
 		IstioProxyImageMismatch,
 		SchemaValidationError,
-		SchemaWarning,
 		MisplacedAnnotation,
 		UnknownAnnotation,
 		ConflictingMeshGatewayVirtualServiceHosts,
@@ -165,14 +148,10 @@ func All() []*diag.MessageType {
 		MultipleSidecarsWithoutWorkloadSelectors,
 		VirtualServiceDestinationPortSelectorRequired,
 		MTLSPolicyConflict,
-		PolicySpecifiesPortNameThatDoesntExist,
-		DestinationRuleUsesMTLSForWorkloadWithoutSidecar,
 		DeploymentAssociatedToMultipleServices,
 		DeploymentRequiresServiceAssociated,
 		PortNameIsNotUnderNamingConvention,
 		JwtFailureDueToInvalidServicePortPrefix,
-		PolicyResourceIsDeprecated,
-		MeshPolicyResourceIsDeprecated,
 		InvalidRegexp,
 		NamespaceMultipleInjectionLabels,
 		InvalidAnnotation,
@@ -183,6 +162,7 @@ func All() []*diag.MessageType {
 		VirtualServiceUnreachableRule,
 		VirtualServiceIneffectiveMatch,
 		VirtualServiceHostNotFoundInGateway,
+		SchemaWarning,
 	}
 }
 
@@ -261,15 +241,6 @@ func NewSchemaValidationError(r *resource.Instance, err error) diag.Message {
 	)
 }
 
-// NewSchemaWarning returns a new diag.Message based on SchemaWarning.
-func NewSchemaWarning(r *resource.Instance, err error) diag.Message {
-	return diag.NewMessage(
-		SchemaWarning,
-		r,
-		err,
-	)
-}
-
 // NewMisplacedAnnotation returns a new diag.Message based on MisplacedAnnotation.
 func NewMisplacedAnnotation(r *resource.Instance, annotation string, kind string) diag.Message {
 	return diag.NewMessage(
@@ -343,26 +314,6 @@ func NewMTLSPolicyConflict(r *resource.Instance, host string, destinationRuleNam
 	)
 }
 
-// NewPolicySpecifiesPortNameThatDoesntExist returns a new diag.Message based on PolicySpecifiesPortNameThatDoesntExist.
-func NewPolicySpecifiesPortNameThatDoesntExist(r *resource.Instance, portName string, host string) diag.Message {
-	return diag.NewMessage(
-		PolicySpecifiesPortNameThatDoesntExist,
-		r,
-		portName,
-		host,
-	)
-}
-
-// NewDestinationRuleUsesMTLSForWorkloadWithoutSidecar returns a new diag.Message based on DestinationRuleUsesMTLSForWorkloadWithoutSidecar.
-func NewDestinationRuleUsesMTLSForWorkloadWithoutSidecar(r *resource.Instance, destinationRuleName string, host string) diag.Message {
-	return diag.NewMessage(
-		DestinationRuleUsesMTLSForWorkloadWithoutSidecar,
-		r,
-		destinationRuleName,
-		host,
-	)
-}
-
 // NewDeploymentAssociatedToMultipleServices returns a new diag.Message based on DeploymentAssociatedToMultipleServices.
 func NewDeploymentAssociatedToMultipleServices(r *resource.Instance, deployment string, port int32, services []string) diag.Message {
 	return diag.NewMessage(
@@ -402,22 +353,6 @@ func NewJwtFailureDueToInvalidServicePortPrefix(r *resource.Instance, port int, 
 		portName,
 		protocol,
 		targetPort,
-	)
-}
-
-// NewPolicyResourceIsDeprecated returns a new diag.Message based on PolicyResourceIsDeprecated.
-func NewPolicyResourceIsDeprecated(r *resource.Instance) diag.Message {
-	return diag.NewMessage(
-		PolicyResourceIsDeprecated,
-		r,
-	)
-}
-
-// NewMeshPolicyResourceIsDeprecated returns a new diag.Message based on MeshPolicyResourceIsDeprecated.
-func NewMeshPolicyResourceIsDeprecated(r *resource.Instance) diag.Message {
-	return diag.NewMessage(
-		MeshPolicyResourceIsDeprecated,
-		r,
 	)
 }
 
@@ -525,5 +460,14 @@ func NewVirtualServiceHostNotFoundInGateway(r *resource.Instance, host []string,
 		host,
 		virtualservice,
 		gateway,
+	)
+}
+
+// NewSchemaWarning returns a new diag.Message based on SchemaWarning.
+func NewSchemaWarning(r *resource.Instance, err error) diag.Message {
+	return diag.NewMessage(
+		SchemaWarning,
+		r,
+		err,
 	)
 }

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -79,15 +79,6 @@ messages:
       - name: err
         type: error
 
-  - name: "SchemaWarning"
-    code: IST0133
-    level: Warning
-    description: "The resource has a schema validation warning."
-    template: "Schema validation warning: %v"
-    args:
-      - name: err
-        type: error
-
   - name: "MisplacedAnnotation"
     code: IST0107
     level: Warning
@@ -171,27 +162,8 @@ messages:
       - name: policyMTLSMode
         type: string
 
-  - name: "PolicySpecifiesPortNameThatDoesntExist"
-    code: IST0114
-    level: Warning
-    description: "A Policy targets a port name that cannot be found."
-    template: "Port name %s could not be found for host %s, which means the Policy won't be enforced."
-    args:
-      - name: portName
-        type: string
-      - name: host
-        type: string
-
-  - name: "DestinationRuleUsesMTLSForWorkloadWithoutSidecar"
-    code: IST0115
-    level: Error
-    description: "A DestinationRule uses mTLS for a workload that has no sidecar."
-    template: "DestinationRule %s uses mTLS for workload %s that has no sidecar. Traffic from workloads with sidecars will fail."
-    args:
-      - name: destinationRuleName
-        type: string
-      - name: host
-        type: string
+  # IST0114 RETIRED
+  # IST0115 RETIRED
 
   - name: "DeploymentAssociatedToMultipleServices"
     code: IST0116
@@ -240,17 +212,8 @@ messages:
       - name: targetPort
         type: string
 
-  - name: "PolicyResourceIsDeprecated"
-    code: IST0120
-    level: Info
-    description: "The Policy resource is deprecated and will be removed in a future Istio release. Migrate to the PeerAuthentication resource."
-    template: "The Policy resource is deprecated and will be removed in a future Istio release. Migrate to the PeerAuthentication resource."
-
-  - name: "MeshPolicyResourceIsDeprecated"
-    code: IST0121
-    level: Info
-    description: "The MeshPolicy resource is deprecated and will be removed in a future Istio release. Migrate to the PeerAuthentication resource."
-    template: "The MeshPolicy resource is deprecated and will be removed in a future Istio release. Migrate to the PeerAuthentication resource."
+  # IST0120 RETIRED
+  # IST0121 RETIRED
 
   - name: "InvalidRegexp"
     code: IST0122
@@ -375,3 +338,13 @@ messages:
         type: string
       - name: gateway
         type: string
+
+  - name: "SchemaWarning"
+    code: IST0133
+    level: Warning
+    description: "The resource has a schema validation warning."
+    template: "Schema validation warning: %v"
+    args:
+      - name: err
+        type: error
+


### PR DESCRIPTION
Four analysis codes are no longer generated by Istio.  See https://github.com/istio/istio.io/issues/7844#issuecomment-726350837 for list.

Removing these dead codes will remove them from http://istio.io/latest/docs/reference/config/analysis/

cc @frankbu 