### PR TITLE
Adding version label to Sleep deployment

### DIFF
--- a/samples/sleep/sleep-vault.yaml
+++ b/samples/sleep/sleep-vault.yaml
@@ -43,10 +43,12 @@ spec:
   selector:
     matchLabels:
       app: sleep
+      version: v1
   template:
     metadata:
       labels:
         app: sleep
+        version: v1
     spec:
       serviceAccountName: vault-citadel-sa
       containers:

--- a/samples/sleep/sleep.yaml
+++ b/samples/sleep/sleep.yaml
@@ -43,10 +43,12 @@ spec:
   selector:
     matchLabels:
       app: sleep
+      version: v1
   template:
     metadata:
       labels:
         app: sleep
+        version: v1
     spec:
       serviceAccountName: sleep
       containers:


### PR DESCRIPTION
This will help in https://github.com/istio/istio.io/pull/8402 to allow add_locality_label() to
add the istio-locality label immediately after
occurrences of the version label.



[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.