### PR TITLE
try token if certs specified by PROV_CERT don't exist for the first time bootstrapping

### DIFF
--- a/istioctl/cmd/workload.go
+++ b/istioctl/cmd/workload.go
@@ -289,6 +289,9 @@ func createClusterEnv(wg *clientv1alpha3.WorkloadGroup, dir string) error {
 
 	// default attributes and service name, namespace, ports, service account, service CIDR
 	clusterEnv := map[string]string{
+		// TODO use a better mechanism to trigger using token-auth
+		// TODO allow configuring cert vs token auth in cmd
+		"PROV_CERT":           "",
 		"ISTIO_INBOUND_PORTS": portBehavior,
 		"ISTIO_NAMESPACE":     wg.Namespace,
 		"ISTIO_SERVICE":       fmt.Sprintf("%s.%s", wg.Name, wg.Namespace),

--- a/istioctl/cmd/workload.go
+++ b/istioctl/cmd/workload.go
@@ -289,9 +289,6 @@ func createClusterEnv(wg *clientv1alpha3.WorkloadGroup, dir string) error {
 
 	// default attributes and service name, namespace, ports, service account, service CIDR
 	clusterEnv := map[string]string{
-		// TODO use a better mechanism to trigger using token-auth
-		// TODO allow configuring cert vs token auth in cmd
-		"PROV_CERT":           "",
 		"ISTIO_INBOUND_PORTS": portBehavior,
 		"ISTIO_NAMESPACE":     wg.Namespace,
 		"ISTIO_SERVICE":       fmt.Sprintf("%s.%s", wg.Name, wg.Namespace),

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -52,9 +52,7 @@ var (
 	).Get()
 
 	// FilterGatewayClusterConfig controls if a subset of clusters(only those required) should be pushed to gateways
-	// TODO enable by default once https://github.com/istio/istio/issues/28315 is resolved
-	// Currently this may cause a bug when we go from N clusters -> 0 clusters -> N clusters
-	FilterGatewayClusterConfig = env.RegisterBoolVar("PILOT_FILTER_GATEWAY_CLUSTER_CONFIG", false, "").Get()
+	FilterGatewayClusterConfig = env.RegisterBoolVar("PILOT_FILTER_GATEWAY_CLUSTER_CONFIG", true, "").Get()
 
 	DebounceAfter = env.RegisterDurationVar(
 		"PILOT_DEBOUNCE_AFTER",

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"math"
 	"net"
+	"os"
 	"path"
 	"strings"
 	"sync"
@@ -412,6 +413,14 @@ func (p *XdsProxy) getCertKeyPaths(agent *Agent) (string, string) {
 	if agent.secOpts.ProvCert != "" {
 		key = path.Join(agent.secOpts.ProvCert, constants.KeyFilename)
 		cert = path.Join(path.Join(agent.secOpts.ProvCert, constants.CertChainFilename))
+
+		// CSR may not have completed – use JWT to auth.
+		if _, err := os.Stat(key); os.IsNotExist(err) {
+			return "", ""
+		}
+		if _, err := os.Stat(cert); os.IsNotExist(err) {
+			return "", ""
+		}
 	} else if agent.secOpts.FileMountedCerts {
 		key = agent.proxyConfig.ProxyMetadata[MetadataClientCertKey]
 		cert = agent.proxyConfig.ProxyMetadata[MetadataClientCertChain]

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -263,12 +263,12 @@ spec:
         - bash
         - -c
         - |-
-          # TODO make token short-lived in tests – switch to cert after expiry
-
           # Capture all inbound and outbound traffic
           sudo sh -c 'echo ISTIO_SERVICE_CIDR=* >> /var/lib/istio/envoy/cluster.env'
           sudo sh -c 'echo ISTIO_INBOUND_PORTS=* >> /var/lib/istio/envoy/cluster.env'
-          
+          # Read root cert from and place signed certs here
+          sudo sh -c 'echo PROV_CERT=/var/run/secrets/istio >> /var/lib/istio/envoy/cluster.env'
+          sudo sh -c 'echo OUTPUT_CERTS=/var/run/secrets/istio >> /var/lib/istio/envoy/cluster.env'
           # Block standard inbound ports
           sudo sh -c 'echo ISTIO_LOCAL_EXCLUDE_PORTS="15090,15021,15020" >> /var/lib/istio/envoy/cluster.env'
           # Proxy XDS via agent first

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -270,7 +270,6 @@ spec:
           sudo mkdir -p /var/run/secrets/istio
           sudo cp /var/run/secrets/istio/rootmount/* /var/run/secrets/istio
           sudo sh -c 'echo PROV_CERT=/var/run/secrets/istio >> /var/lib/istio/envoy/cluster.env'
-          sudo sh -c 'echo OUTPUT_CERTS=/var/run/secrets/istio >> /var/lib/istio/envoy/cluster.env'
           # Block standard inbound ports
           sudo sh -c 'echo ISTIO_LOCAL_EXCLUDE_PORTS="15090,15021,15020" >> /var/lib/istio/envoy/cluster.env'
           # Proxy XDS via agent first
@@ -317,7 +316,7 @@ spec:
 {{- end }}
 {{- if $p.InstanceIP }}
              --bind-ip={{ $p.Port }} \
-{{- end }} 
+{{- end }}
 {{- end }}
         env:
         - name: INSTANCE_IP

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -270,6 +270,7 @@ spec:
           sudo mkdir -p /var/run/secrets/istio
           sudo cp /var/run/secrets/istio/rootmount/* /var/run/secrets/istio
           sudo sh -c 'echo PROV_CERT=/var/run/secrets/istio >> /var/lib/istio/envoy/cluster.env'
+          sudo sh -c 'echo OUTPUT_CERTS=/var/run/secrets/istio >> /var/lib/istio/envoy/cluster.env'
           # Block standard inbound ports
           sudo sh -c 'echo ISTIO_LOCAL_EXCLUDE_PORTS="15090,15021,15020" >> /var/lib/istio/envoy/cluster.env'
           # Proxy XDS via agent first
@@ -316,7 +317,7 @@ spec:
 {{- end }}
 {{- if $p.InstanceIP }}
              --bind-ip={{ $p.Port }} \
-{{- end }}
+{{- end }} 
 {{- end }}
         env:
         - name: INSTANCE_IP

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -263,11 +263,12 @@ spec:
         - bash
         - -c
         - |-
+          # TODO make token short-lived in tests – switch to cert after expiry
+
           # Capture all inbound and outbound traffic
           sudo sh -c 'echo ISTIO_SERVICE_CIDR=* >> /var/lib/istio/envoy/cluster.env'
           sudo sh -c 'echo ISTIO_INBOUND_PORTS=* >> /var/lib/istio/envoy/cluster.env'
-          # Use token auth not certs
-          sudo sh -c 'echo PROV_CERT="" >> /var/lib/istio/envoy/cluster.env'
+          
           # Block standard inbound ports
           sudo sh -c 'echo ISTIO_LOCAL_EXCLUDE_PORTS="15090,15021,15020" >> /var/lib/istio/envoy/cluster.env'
           # Proxy XDS via agent first

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -266,8 +266,15 @@ spec:
           # Capture all inbound and outbound traffic
           sudo sh -c 'echo ISTIO_SERVICE_CIDR=* >> /var/lib/istio/envoy/cluster.env'
           sudo sh -c 'echo ISTIO_INBOUND_PORTS=* >> /var/lib/istio/envoy/cluster.env'
+          
           # Read root cert from and place signed certs here
           sudo mkdir -p /var/run/secrets/istio
+ 
+          # hack: remove certs that are bundled in the image
+          sudo rm /var/run/secrets/istio/cert-chain.pem  
+          sudo rm /var/run/secrets/istio/key.pem  
+
+          # replace root-cert with what was mounted
           sudo cp /var/run/secrets/istio/rootmount/* /var/run/secrets/istio
           sudo sh -c 'echo PROV_CERT=/var/run/secrets/istio >> /var/lib/istio/envoy/cluster.env'
           sudo sh -c 'echo OUTPUT_CERTS=/var/run/secrets/istio >> /var/lib/istio/envoy/cluster.env'
@@ -317,7 +324,7 @@ spec:
 {{- end }}
 {{- if $p.InstanceIP }}
              --bind-ip={{ $p.Port }} \
-{{- end }} 
+{{- end }}
 {{- end }}
         env:
         - name: INSTANCE_IP

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -267,6 +267,8 @@ spec:
           sudo sh -c 'echo ISTIO_SERVICE_CIDR=* >> /var/lib/istio/envoy/cluster.env'
           sudo sh -c 'echo ISTIO_INBOUND_PORTS=* >> /var/lib/istio/envoy/cluster.env'
           # Read root cert from and place signed certs here
+          sudo mkdir -p /var/run/secrets/istio
+          sudo cp /var/run/secrets/istio/rootmount/* /var/run/secrets/istio
           sudo sh -c 'echo PROV_CERT=/var/run/secrets/istio >> /var/lib/istio/envoy/cluster.env'
           sudo sh -c 'echo OUTPUT_CERTS=/var/run/secrets/istio >> /var/lib/istio/envoy/cluster.env'
           # Block standard inbound ports
@@ -315,7 +317,7 @@ spec:
 {{- end }}
 {{- if $p.InstanceIP }}
              --bind-ip={{ $p.Port }} \
-{{- end }}
+{{- end }} 
 {{- end }}
         env:
         - name: INSTANCE_IP
@@ -336,7 +338,7 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/tokens
           name: {{ $.Service }}-istio-token
-        - mountPath: /var/run/secrets/istio
+        - mountPath: /var/run/secrets/istio/rootmount
           name: istio-ca-root-cert
         {{- range $name, $value := $subset.Annotations }}
         {{- if eq $name.Name "sidecar.istio.io/bootstrapOverride" }}

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -273,6 +273,7 @@ spec:
           # hack: remove certs that are bundled in the image
           sudo rm /var/run/secrets/istio/cert-chain.pem  
           sudo rm /var/run/secrets/istio/key.pem  
+          sudo chown -R istio-proxy /var/run/secrets
 
           # replace root-cert with what was mounted
           sudo cp /var/run/secrets/istio/rootmount/* /var/run/secrets/istio


### PR DESCRIPTION
This will use JWT if we have PROV_CERT but the certs don't exist. 

* fixes #28824 where we never use the JWT fo fetch cert/key because they're not found. This will make us fallthrough to use the JWT first, and only use cert/key once they exist. 
* Integration tests are now closer to what we document