### PR TITLE
[release-1.6] cherry-pick: do not update root certs for destination rule certs (#27268)

### DIFF
--- a/common/scripts/gobuild.sh
+++ b/common/scripts/gobuild.sh
@@ -86,6 +86,6 @@ fi
 time GOOS=${BUILD_GOOS} GOARCH=${BUILD_GOARCH} ${GOBINARY} build \
         ${V} "${GOBUILDFLAGS_ARRAY[@]}" ${GCFLAGS:+-gcflags "${GCFLAGS}"} \
         -o "${OUT}" \
-        ${OPTIMIZATION_FLAGS} \
+        "${OPTIMIZATION_FLAGS}" \
         -pkgdir="${GOPKG}/${BUILD_GOOS}_${BUILD_GOARCH}" \
         -ldflags "${LDFLAGS} ${LD_EXTRAFLAGS}" "${@}"

--- a/common/scripts/setup_env.sh
+++ b/common/scripts/setup_env.sh
@@ -69,7 +69,7 @@ export UID
 DOCKER_GID=$(grep '^docker:' /etc/group | cut -f3 -d:)
 export DOCKER_GID
 
-TIMEZONE=$(readlink $readlink_flags /etc/localtime | sed -e 's/^.*zoneinfo\///')
+TIMEZONE=$(readlink "$readlink_flags" /etc/localtime | sed -e 's/^.*zoneinfo\///')
 export TIMEZONE
 
 export TARGET_OUT="${TARGET_OUT:-$(pwd)/out/${TARGET_OS}_${TARGET_ARCH}}"


### PR DESCRIPTION
While Istio 1.6 is nearing end of support, we'd like this patch to be included in any final 1.6 release, since CA root certs included in `DestinationRule` TLS config can cause mesh communication to break. (The DR's root cert is used to validate the peer Pod's certificate instead of the istio CA root). 

(cherry picked from commit 2cbbf53da0acb42d23decabd2dacd7929961f515)



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.