### PR TITLE
Allow unknown fields in istioctl cluster dump

### DIFF
--- a/istioctl/pkg/util/clusters/wrapper.go
+++ b/istioctl/pkg/util/clusters/wrapper.go
@@ -41,7 +41,7 @@ func (w *Wrapper) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON is a custom unmarshaller to handle protobuf pain
 func (w *Wrapper) UnmarshalJSON(b []byte) error {
 	buf := bytes.NewBuffer(b)
-	jsonum := &jsonpb.Unmarshaler{}
+	jsonum := &jsonpb.Unmarshaler{AllowUnknownFields: true}
 	cd := &adminapi.Clusters{}
 	err := jsonum.Unmarshal(buf, cd)
 	*w = Wrapper{cd}


### PR DESCRIPTION
This mirrors the logic for config dump



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.