### PR TITLE
Improve speed of YAML apply/echo init

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -290,7 +290,7 @@ type client struct {
 }
 
 // newClientInternal creates a Kubernetes client from the given factory.
-func newClientInternal(clientFactory util.Factory, revision string, extended bool) (*client, error) {
+func newClientInternal(clientFactory util.Factory, revision string) (*client, error) {
 	var c client
 	var err error
 
@@ -301,20 +301,18 @@ func newClientInternal(clientFactory util.Factory, revision string, extended boo
 		return nil, err
 	}
 
-	if extended {
-		c.revision = revision
+	c.revision = revision
 
-		c.restClient, err = clientFactory.RESTClient()
-		if err != nil {
-			return nil, err
-		}
-
-		c.discoveryClient, err = clientFactory.ToDiscoveryClient()
-		if err != nil {
-			return nil, err
-		}
-		c.mapper = restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(c.discoveryClient))
+	c.restClient, err = clientFactory.RESTClient()
+	if err != nil {
+		return nil, err
 	}
+
+	c.discoveryClient, err = clientFactory.ToDiscoveryClient()
+	if err != nil {
+		return nil, err
+	}
+	c.mapper = restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(c.discoveryClient))
 
 	c.Interface, err = kubernetes.NewForConfig(c.config)
 	c.kube = c.Interface
@@ -360,12 +358,12 @@ func newClientInternal(clientFactory util.Factory, revision string, extended boo
 // NewExtendedClient creates a Kubernetes client from the given ClientConfig. The "revision" parameter
 // controls the behavior of GetIstioPods, by selecting a specific revision of the control plane.
 func NewExtendedClient(clientConfig clientcmd.ClientConfig, revision string) (ExtendedClient, error) {
-	return newClientInternal(newClientFactory(clientConfig), revision, true)
+	return newClientInternal(newClientFactory(clientConfig), revision)
 }
 
 // NewClient creates a Kubernetes client from the given rest config.
 func NewClient(clientConfig clientcmd.ClientConfig) (Client, error) {
-	return newClientInternal(newClientFactory(clientConfig), "", true)
+	return newClientInternal(newClientFactory(clientConfig), "")
 }
 
 func (c *client) RESTConfig() *rest.Config {

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -34,6 +34,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	kubeExtClient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	extfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -44,6 +45,7 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
@@ -55,6 +57,7 @@ import (
 	metadatafake "k8s.io/client-go/metadata/fake"
 	"k8s.io/client-go/metadata/metadatainformer"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
@@ -89,9 +92,6 @@ type Client interface {
 	kubernetes.Interface
 	// RESTConfig returns the Kubernetes rest.Config used to configure the clients.
 	RESTConfig() *rest.Config
-
-	// Rest returns the raw Kubernetes REST client.
-	REST() rest.Interface
 
 	// Ext returns the API extensions client.
 	Ext() kubeExtClient.Interface
@@ -257,12 +257,8 @@ func NewFakeClient(objects ...runtime.Object) ExtendedClient {
 type client struct {
 	kubernetes.Interface
 
-	// These may be set only when creating an extended client. TODO: remove this entirely
 	clientFactory util.Factory
-	restClient    *rest.RESTClient
-	revision      string
-
-	config *rest.Config
+	config        *rest.Config
 
 	extSet        kubeExtClient.Interface
 	versionClient discovery.ServerVersionInterface
@@ -285,24 +281,39 @@ type client struct {
 	// If enable, will wait for cache syncs with extremely short delay. This should be used only for tests
 	fastSync               bool
 	informerWatchesPending *atomic.Int32
+
+	// These may be set only when creating an extended client.
+	revision        string
+	restClient      *rest.RESTClient
+	discoveryClient discovery.CachedDiscoveryInterface
+	mapper          meta.RESTMapper
 }
 
 // newClientInternal creates a Kubernetes client from the given factory.
-func newClientInternal(clientFactory util.Factory, revision string) (*client, error) {
+func newClientInternal(clientFactory util.Factory, revision string, extended bool) (*client, error) {
 	var c client
 	var err error
 
 	c.clientFactory = clientFactory
-	c.revision = revision
-
-	c.restClient, err = clientFactory.RESTClient()
-	if err != nil {
-		return nil, err
-	}
 
 	c.config, err = clientFactory.ToRESTConfig()
 	if err != nil {
 		return nil, err
+	}
+
+	if extended {
+		c.revision = revision
+
+		c.restClient, err = clientFactory.RESTClient()
+		if err != nil {
+			return nil, err
+		}
+
+		c.discoveryClient, err = clientFactory.ToDiscoveryClient()
+		if err != nil {
+			return nil, err
+		}
+		c.mapper = restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(c.discoveryClient))
 	}
 
 	c.Interface, err = kubernetes.NewForConfig(c.config)
@@ -349,21 +360,17 @@ func newClientInternal(clientFactory util.Factory, revision string) (*client, er
 // NewExtendedClient creates a Kubernetes client from the given ClientConfig. The "revision" parameter
 // controls the behavior of GetIstioPods, by selecting a specific revision of the control plane.
 func NewExtendedClient(clientConfig clientcmd.ClientConfig, revision string) (ExtendedClient, error) {
-	return newClientInternal(newClientFactory(clientConfig), revision)
+	return newClientInternal(newClientFactory(clientConfig), revision, true)
 }
 
 // NewClient creates a Kubernetes client from the given rest config.
 func NewClient(clientConfig clientcmd.ClientConfig) (Client, error) {
-	return newClientInternal(newClientFactory(clientConfig), "")
+	return newClientInternal(newClientFactory(clientConfig), "", true)
 }
 
 func (c *client) RESTConfig() *rest.Config {
 	cpy := *c.config
 	return &cpy
-}
-
-func (c *client) REST() rest.Interface {
-	return c.restClient
 }
 
 func (c *client) Ext() kubeExtClient.Interface {
@@ -818,21 +825,14 @@ func (c *client) UtilFactory() util.Factory {
 	return c.clientFactory
 }
 
+// TODO once we drop Kubernetes 1.15 support we can drop all of this code in favor of Server Side Apply
+// Following https://ymmt2005.hatenablog.com/entry/2020/04/14/An_example_of_using_dynamic_client_of_k8s.io/client-go
 func (c *client) applyYAMLFile(namespace string, dryRun bool, file string) error {
-	dynamicClient, err := c.clientFactory.DynamicClient()
-	if err != nil {
-		return err
-	}
-	discoveryClient, err := c.clientFactory.ToDiscoveryClient()
-	if err != nil {
-		return err
-	}
-
 	// Create the options.
 	streams, _, stdout, stderr := genericclioptions.NewTestIOStreams()
 	opts := apply.NewApplyOptions(streams)
-	opts.DynamicClient = dynamicClient
-	opts.DryRunVerifier = resource.NewDryRunVerifier(dynamicClient, discoveryClient)
+	opts.DynamicClient = c.dynamic
+	opts.DryRunVerifier = resource.NewDryRunVerifier(c.dynamic, c.discoveryClient)
 	opts.FieldManager = fieldManager
 	if dryRun {
 		opts.DryRunStrategy = util.DryRunServer
@@ -858,22 +858,20 @@ func (c *client) applyYAMLFile(namespace string, dryRun bool, file string) error
 
 	opts.DeleteFlags.FileNameFlags.Filenames = &[]string{file}
 	opts.DeleteOptions = &kubectlDelete.DeleteOptions{
-		DynamicClient:   dynamicClient,
+		DynamicClient:   c.dynamic,
 		IOStreams:       streams,
 		FilenameOptions: opts.DeleteFlags.FileNameFlags.ToOptions(),
 	}
 
 	opts.OpenAPISchema, _ = c.clientFactory.OpenAPISchema()
 
+	var err error
 	opts.Validator, err = c.clientFactory.Validator(true)
 	if err != nil {
 		return err
 	}
 	opts.Builder = c.clientFactory.NewBuilder()
-	opts.Mapper, err = c.clientFactory.ToRESTMapper()
-	if err != nil {
-		return err
-	}
+	opts.Mapper = c.mapper
 
 	opts.PostProcessorFn = opts.PrintAndPrunePostProcessor()
 
@@ -917,14 +915,6 @@ func (c *client) deleteFile(namespace string, dryRun bool, file string) error {
 		Filenames: []string{file},
 	}
 
-	dynamicClient, err := c.clientFactory.DynamicClient()
-	if err != nil {
-		return err
-	}
-	discoveryClient, err := c.clientFactory.ToDiscoveryClient()
-	if err != nil {
-		return err
-	}
 	opts := kubectlDelete.DeleteOptions{
 		FilenameOptions:  fileOpts,
 		Cascade:          true,
@@ -932,8 +922,8 @@ func (c *client) deleteFile(namespace string, dryRun bool, file string) error {
 		IgnoreNotFound:   true,
 		WaitForDeletion:  true,
 		WarnClusterScope: enforceNamespace,
-		DynamicClient:    dynamicClient,
-		DryRunVerifier:   resource.NewDryRunVerifier(dynamicClient, discoveryClient),
+		DynamicClient:    c.dynamic,
+		DryRunVerifier:   resource.NewDryRunVerifier(c.dynamic, c.discoveryClient),
 		IOStreams:        streams,
 	}
 	if dryRun {
@@ -957,10 +947,7 @@ func (c *client) deleteFile(namespace string, dryRun bool, file string) error {
 	}
 	opts.Result = r
 
-	opts.Mapper, err = c.clientFactory.ToRESTMapper()
-	if err != nil {
-		return err
-	}
+	opts.Mapper = c.mapper
 
 	if err := opts.RunDelete(c.clientFactory); err != nil {
 		// Concatenate the stdout and stderr

--- a/pkg/test/framework/components/echo/config.go
+++ b/pkg/test/framework/components/echo/config.go
@@ -138,7 +138,10 @@ func (c Config) HostHeader() string {
 
 // DeepCopy creates a clone of IstioEndpoint.
 func (c Config) DeepCopy() Config {
-	return copyInternal(c).(Config)
+	newc := copyInternal(c).(Config)
+	newc.Cluster = c.Cluster
+	newc.Namespace = c.Namespace
+	return newc
 }
 
 func copyInternal(v interface{}) interface{} {

--- a/pkg/test/framework/components/echo/config.go
+++ b/pkg/test/framework/components/echo/config.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/mitchellh/copystructure"
+
 	"istio.io/istio/pkg/test/echo/common"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/resource"
@@ -132,4 +134,21 @@ func (c Config) HostHeader() string {
 		return c.DefaultHostHeader
 	}
 	return c.FQDN()
+}
+
+// DeepCopy creates a clone of IstioEndpoint.
+func (c Config) DeepCopy() Config {
+	return copyInternal(c).(Config)
+}
+
+func copyInternal(v interface{}) interface{} {
+	copied, err := copystructure.Copy(v)
+	if err != nil {
+		// There are 2 locations where errors are generated in copystructure.Copy:
+		//  * The reflection walk over the structure fails, which should never happen
+		//  * A configurable copy function returns an error. This is only used for copying times, which never returns an error.
+		// Therefore, this should never happen
+		panic(err)
+	}
+	return copied
 }

--- a/pkg/test/framework/components/echo/kube/instance.go
+++ b/pkg/test/framework/components/echo/kube/instance.go
@@ -62,7 +62,8 @@ type instance struct {
 	cluster   resource.Cluster
 }
 
-func newInstance(ctx resource.Context, cfg echo.Config) (out *instance, err error) {
+func newInstance(ctx resource.Context, originalCfg echo.Config) (out *instance, err error) {
+	cfg := originalCfg
 	// Fill in defaults for any missing values.
 	common.AddPortIfMissing(&cfg, protocol.GRPC)
 	if err = common.FillInDefaults(ctx, defaultDomain, &cfg); err != nil {

--- a/pkg/test/framework/components/echo/kube/instance.go
+++ b/pkg/test/framework/components/echo/kube/instance.go
@@ -63,7 +63,7 @@ type instance struct {
 }
 
 func newInstance(ctx resource.Context, originalCfg echo.Config) (out *instance, err error) {
-	cfg := originalCfg
+	cfg := originalCfg.DeepCopy()
 	// Fill in defaults for any missing values.
 	common.AddPortIfMissing(&cfg, protocol.GRPC)
 	if err = common.FillInDefaults(ctx, defaultDomain, &cfg); err != nil {


### PR DESCRIPTION
Currently every call to ApplyYAML will reinitialize discovery, which can
take O(seconds) on slow clusters. This likely doesn't impact CI much, which
runs in kind, but on GKE I saw echo deployment times go from 30s+ to 5s.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.