### PR TITLE
Align proxy queue time and convergence time histogram buckets

### DIFF
--- a/pilot/pkg/xds/monitoring.go
+++ b/pilot/pkg/xds/monitoring.go
@@ -135,7 +135,7 @@ var (
 	proxiesQueueTime = monitoring.NewDistribution(
 		"pilot_proxy_queue_time",
 		"Time in seconds, a proxy is in the push queue before being dequeued.",
-		[]float64{.1, 1, 3, 5, 10, 20, 30},
+		[]float64{.1, .5, 1, 3, 5, 10, 20, 30},
 	)
 
 	pushTriggers = monitoring.NewSum(


### PR DESCRIPTION
Currently pilot_proxy_queue_time contains pilot_proxy_convergence_time, but they
use different buckets, when they land between 0.1 and 1 second, histogram_quantile()
returns bigger queue time than convergence time.

[X] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

[X] Does not have any changes that may affect Istio users.
