### PR TITLE
[release-1.6] Prevent HPA scaling from being overridden on V1 Telemetry when re-installing the control plane

### DIFF
--- a/manifests/charts/istio-telemetry/mixer-telemetry/templates/deployment.yaml
+++ b/manifests/charts/istio-telemetry/mixer-telemetry/templates/deployment.yaml
@@ -8,7 +8,11 @@ metadata:
     istio: mixer
     release: {{ .Release.Name }}
 spec:
+{{- if not .Values.mixer.telemetry.autoscaleEnabled }}
+{{- if .Values.mixer.telemetry.replicaCount }}
   replicas: {{ .Values.mixer.telemetry.replicaCount }}
+{{- end }}
+{{- end }}
   strategy:
     rollingUpdate:
       maxSurge: {{ .Values.mixer.telemetry.rollingMaxSurge }}

--- a/releasenotes/notes/28916.yaml
+++ b/releasenotes/notes/28916.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+issue:
+  - 28916
+releaseNotes:
+  - |
+    **Fixed** Fix HPA settings for telemetry is overridden by the inline replicas.

--- a/releasenotes/notes/28916.yaml
+++ b/releasenotes/notes/28916.yaml
@@ -5,4 +5,4 @@ issue:
   - 28916
 releaseNotes:
   - |
-    **Fixed** Fix HPA settings for telemetry is overridden by the inline replicas.
+    **Fixed** HPA settings for telemetry is overridden by the inline replicas.


### PR DESCRIPTION
Only set V1 Telemetry `spec.replicas` if `autoscaleEnabled: false` and. `replicaCount` is set

Makes the `Deployment` consistent with that of `policy` and `istiod` and avoids `istioctl` force scaling in/out the `Deployment` during an install, which the `HorizontalPodAutoscaler` then has to correct.

Fixes #28916 (although needs cherrypick to `release-1.7` and not sure on process for this)

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure