### PR TITLE
Remove golangci badge from operator README

### DIFF
--- a/operator/README.md
+++ b/operator/README.md
@@ -1,5 +1,4 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/istio/operator)](https://goreportcard.com/report/github.com/istio/operator)
-[![GolangCI](https://golangci.com/badges/github.com/istio/operator.svg)](https://golangci.com/r/github.com/istio/operator)
 
 # Istio Operator
 


### PR DESCRIPTION
Removed the golangci badge since [the service has stopped working](https://medium.com/golangci/golangci-com-is-closing-d1fc1bd30e0e) so the badge doesn't make sense.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

Pull Request Attributes

[X] Does not have any changes that may affect Istio users.
