### PR TITLE
Fix the duplicate test cases because of multiple b services deployed and skip the current failed ca_custom_root test cases in multicluster setup

### DIFF
--- a/tests/integration/security/ca_custom_root/secure_naming_test.go
+++ b/tests/integration/security/ca_custom_root/secure_naming_test.go
@@ -104,6 +104,10 @@ func TestSecureNaming(t *testing.T) {
 	framework.NewTest(t).
 		Features("security.peer.secure-naming").
 		Run(func(ctx framework.TestContext) {
+			//TODO: remove the skip when https://github.com/istio/istio/issues/28798 is fixed
+			if ctx.Clusters().IsMulticluster() {
+				ctx.Skip()
+			}
 			istioCfg := istio.DefaultConfigOrFail(t, ctx)
 			testNamespace := apps.Namespace
 			namespace.ClaimOrFail(t, ctx, istioCfg.SystemNamespace)

--- a/tests/integration/security/ca_custom_root/trust_domain_alias_secure_naming_test.go
+++ b/tests/integration/security/ca_custom_root/trust_domain_alias_secure_naming_test.go
@@ -68,6 +68,10 @@ func TestTrustDomainAliasSecureNaming(t *testing.T) {
 	framework.NewTest(t).
 		Features("security.peer.trust-domain-alias-secure-naming").
 		Run(func(ctx framework.TestContext) {
+			//TODO: remove the skip when https://github.com/istio/istio/issues/28798 is fixed
+			if ctx.Clusters().IsMulticluster() {
+				ctx.Skip()
+			}
 			testNS := apps.Namespace
 
 			ctx.Config().ApplyYAMLOrFail(ctx, testNS.Name(), POLICY)

--- a/tests/integration/security/util/reachability/context.go
+++ b/tests/integration/security/util/reachability/context.go
@@ -104,7 +104,7 @@ func Run(testCases []TestCase, ctx framework.TestContext, apps *util.EchoDeploym
 					log.Errorf("failed to delete configuration: %v", err)
 				}
 			})
-			for _, clients := range []echo.Instances{apps.A, apps.B, apps.Headless, apps.Naked, apps.HeadlessNaked} {
+			for _, clients := range []echo.Instances{apps.A, apps.B.Match(echo.Namespace(apps.Namespace1.Name())), apps.Headless, apps.Naked, apps.HeadlessNaked} {
 				for _, client := range clients {
 					ctx.NewSubTest(fmt.Sprintf("%s in %s",
 						client.Config().Service, client.Config().Cluster.Name())).Run(func(ctx framework.TestContext) {


### PR DESCRIPTION


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.