### PR TITLE
Remove distroless copying hacks

### DIFF
--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -8,9 +8,9 @@ ARG BASE_VERSION=latest
 FROM gcr.io/istio-release/base:${BASE_VERSION} as default
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
-# This image is a custom built debian9, nonroot distroless image with multiarchitecture support.
+# This image is a custom built debian9 distroless image with multiarchitecture support.
 # It is built on the base distroless image, with iptables binary and libraries added
-FROM gcr.io/istio-release/iptables@sha256:8601b3cb13984e375d9a9a85687f23c88bc798e4f2ec9a80cca5e6abda66c6f9 as distroless
+FROM gcr.io/istio-release/iptables:d71c854a55d9661ea1c45ee4391335a67030a617 as distroless
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -7,24 +7,10 @@ ARG BASE_VERSION=latest
 # The following section is used as base image if BASE_DISTRIBUTION=default
 FROM gcr.io/istio-release/base:${BASE_VERSION} as default
 
-# Copy Envoy bootstrap templates used by pilot-agent
-COPY envoy_bootstrap.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
-COPY gcp_envoy_bootstrap.json /var/lib/istio/envoy/gcp_envoy_bootstrap_tmpl.json
-
 RUN chown -R istio-proxy /var/lib/istio
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
-FROM gcr.io/distroless/cc@sha256:f81e5db8287d66b012d874a6f7fea8da5b96d9cc509aa5a9b5d095a604d4bca1 as distroless
-
-# TODO(https://github.com/istio/istio/issues/17656) clean up this hack
-COPY --from=default /sbin/xtables-multi /sbin/iptables* /sbin/ip6tables* /sbin/ip /sbin/
-COPY --from=default /usr/lib/x86_64-linux-gnu/xtables/ /usr/lib/x86_64-linux-gnu/xtables
-COPY --from=default /usr/lib/x86_64-linux-gnu/ /usr/lib/x86_64-linux-gnu
-COPY --from=default /etc/iproute2 /etc/iproute2
-
-# Copy Envoy bootstrap templates used by pilot-agent
-COPY --chown=nonroot:nonroot envoy_bootstrap.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
-COPY --chown=nonroot:nonroot gcp_envoy_bootstrap.json /var/lib/istio/envoy/gcp_envoy_bootstrap_tmpl.json
+FROM gcr.io/howardjohn-istio/distroless:iptables as distroless
 
 WORKDIR /
 
@@ -35,6 +21,10 @@ FROM ${BASE_DISTRIBUTION}
 ARG proxy_version
 ARG istio_version
 ARG SIDECAR=envoy
+
+# Copy Envoy bootstrap templates used by pilot-agent
+COPY envoy_bootstrap.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
+COPY gcp_envoy_bootstrap.json /var/lib/istio/envoy/gcp_envoy_bootstrap_tmpl.json
 
 # Install Envoy.
 COPY $SIDECAR /usr/local/bin/$SIDECAR

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -8,9 +8,9 @@ ARG BASE_VERSION=latest
 FROM gcr.io/istio-release/base:${BASE_VERSION} as default
 
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
-FROM gcr.io/howardjohn-istio/distroless:iptables as distroless
-
-WORKDIR /
+# This image is a custom built debian9, nonroot distroless image with multiarchitecture support.
+# It is built on the base distroless image, with iptables binary and libraries added
+FROM gcr.io/istio-release/iptables@sha256:8601b3cb13984e375d9a9a85687f23c88bc798e4f2ec9a80cca5e6abda66c6f9 as distroless
 
 # This will build the final image based on either default or distroless from above
 # hadolint ignore=DL3006

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -16,6 +16,8 @@ FROM gcr.io/istio-release/iptables@sha256:8601b3cb13984e375d9a9a85687f23c88bc798
 # hadolint ignore=DL3006
 FROM ${BASE_DISTRIBUTION}
 
+WORKDIR /
+
 ARG proxy_version
 ARG istio_version
 ARG SIDECAR=envoy

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -7,8 +7,6 @@ ARG BASE_VERSION=latest
 # The following section is used as base image if BASE_DISTRIBUTION=default
 FROM gcr.io/istio-release/base:${BASE_VERSION} as default
 
-RUN chown -R istio-proxy /var/lib/istio
-
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 FROM gcr.io/howardjohn-istio/distroless:iptables as distroless
 

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -83,7 +83,7 @@ $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/metadata-exchange-filter.wasm: init
 $(ISTIO_ENVOY_LINUX_RELEASE_DIR)/metadata-exchange-filter.compiled.wasm: init
 
 # Default proxy image.
-docker.proxyv2: BUILD_PRE=&& chmod 755 ${SIDECAR} pilot-agent
+docker.proxyv2: BUILD_PRE=&& chmod 755 ${SIDECAR} pilot-agent && chmod 644 envoy_bootstrap.json gcp_envoy_bootstrap.json
 docker.proxyv2: BUILD_ARGS=--build-arg proxy_version=istio-proxy:${PROXY_REPO_SHA} --build-arg istio_version=${VERSION} --build-arg BASE_VERSION=${BASE_VERSION} --build-arg SIDECAR=${SIDECAR}
 docker.proxyv2: ${ISTIO_ENVOY_BOOTSTRAP_CONFIG_DIR}/envoy_bootstrap.json
 docker.proxyv2: ${ISTIO_ENVOY_BOOTSTRAP_CONFIG_DIR}/gcp_envoy_bootstrap.json


### PR DESCRIPTION
When/if this is approved, I will fork off https://github.com/GoogleContainerTools/distroless/compare/master...howardjohn:iptables?expand=1 into an istio org repo.

This replaces our current hacks to get iptables into distroless. The end result:
* No longer relying on fragile copying from ubuntu
* Easy multi-arch support
* We are only adding the minimal dependencies for iptables now; the resulting docker image is ~40mb smaller since previously we copied unneeded extras.