### PR TITLE
Fix webhook tests for rewrite probe

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -202,7 +202,6 @@ data:
 
     template: |
       {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
-      rewriteAppHTTPProbe: {{ valueOrDefault .Values.sidecarInjectorWebhook.rewriteAppHTTPProbe false }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
       {{ if .Values.istio_cni.enabled -}}

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -1,6 +1,5 @@
 template: |
   {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
-  rewriteAppHTTPProbe: {{ valueOrDefault .Values.sidecarInjectorWebhook.rewriteAppHTTPProbe false }}
   initContainers:
   {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
   {{ if .Values.istio_cni.enabled -}}

--- a/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -182,7 +182,6 @@ data:
 
     template: |
       {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
-      rewriteAppHTTPProbe: {{ valueOrDefault .Values.sidecarInjectorWebhook.rewriteAppHTTPProbe false }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
       {{ if .Values.istio_cni.enabled -}}

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -1,6 +1,5 @@
 template: |
   {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
-  rewriteAppHTTPProbe: {{ valueOrDefault .Values.sidecarInjectorWebhook.rewriteAppHTTPProbe false }}
   initContainers:
   {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
   {{ if .Values.istio_cni.enabled -}}

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_nosidecar_rewrite.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_nosidecar_rewrite.patch
@@ -63,8 +63,44 @@
         "--statusPort",
         "15020"
       ],
+      "env": [
+        {
+          "name": "ISTIO_KUBE_APP_PROBERS",
+          "value": "{\"/app-health/hello/livez\":{\"httpGet\":{\"path\":\"/live\",\"port\":80}},\"/app-health/hello/readyz\":{\"httpGet\":{\"path\":\"/ready\",\"port\":3333}},\"/app-health/second/livez\":{\"httpGet\":{\"port\":9000}}}"
+        }
+      ],
       "resources": {}
     }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/containers/0/livenessProbe/httpGet/path",
+    "value": "/app-health/hello/livez"
+  },
+  {
+    "op": "replace",
+    "path": "/spec/containers/0/livenessProbe/httpGet/port",
+    "value": 15020
+  },
+  {
+    "op": "replace",
+    "path": "/spec/containers/0/readinessProbe/httpGet/path",
+    "value": "/app-health/hello/readyz"
+  },
+  {
+    "op": "replace",
+    "path": "/spec/containers/0/readinessProbe/httpGet/port",
+    "value": 15020
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/1/livenessProbe/httpGet/path",
+    "value": "/app-health/second/livez"
+  },
+  {
+    "op": "replace",
+    "path": "/spec/containers/1/livenessProbe/httpGet/port",
+    "value": 15020
   },
   {
     "op": "add",

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_nosidecar_rewrite_template.yaml
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_nosidecar_rewrite_template.yaml
@@ -2,8 +2,8 @@ policy: enabled
 alwaysInjectSelector: []
 neverInjectSelector: []
 injectedAnnotations: {}
+values: '{"sidecarInjectorWebhook":{"rewriteAppHTTPProbe": true}}'
 template: |-
-  rewriteAppHTTPProbe: true
   initContainers:
   - name: istio-init
     image: example.com/init:latest

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite.patch
@@ -78,8 +78,8 @@
     "path": "/spec/containers/0/livenessProbe",
     "value": {
       "httpGet": {
-        "path": "/live",
-        "port": "http"
+        "path": "/app-health/hello/livez",
+        "port": 15020
       }
     }
   },
@@ -88,8 +88,8 @@
     "path": "/spec/containers/0/readinessProbe",
     "value": {
       "httpGet": {
-        "path": "/ready",
-        "port": 3333
+        "path": "/app-health/hello/readyz",
+        "port": 15020
       }
     }
   },
@@ -104,12 +104,13 @@
   },
   {
     "op": "replace",
-    "path": "/spec/containers/1/livenessProbe/httpGet/port",
-    "value": 9000
+    "path": "/spec/containers/1/livenessProbe/httpGet/path",
+    "value": "/app-health/second/livez"
   },
   {
-    "op": "remove",
-    "path": "/spec/containers/1/livenessProbe/httpGet/path"
+    "op": "replace",
+    "path": "/spec/containers/1/livenessProbe/httpGet/port",
+    "value": 15020
   },
   {
     "op": "remove",
@@ -135,6 +136,16 @@
     "value": [
       "--statusPort",
       "15020"
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/2/env",
+    "value": [
+      {
+        "name": "ISTIO_KUBE_APP_PROBERS",
+        "value": "{\"/app-health/hello/livez\":{\"httpGet\":{\"path\":\"/live\",\"port\":80}},\"/app-health/hello/readyz\":{\"httpGet\":{\"path\":\"/ready\",\"port\":3333}},\"/app-health/second/livez\":{\"httpGet\":{\"port\":9000}}}"
+      }
     ]
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_disabled_via_annotation_template.yaml
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_disabled_via_annotation_template.yaml
@@ -2,8 +2,8 @@ policy: enabled
 alwaysInjectSelector: []
 neverInjectSelector: []
 injectedAnnotations: {}
+values: '{"sidecarInjectorWebhook":{"rewriteAppHTTPProbe": true}}'
 template: |-
-  rewriteAppHTTPProbe: true
   initContainers:
   - name: istio-init
     image: example.com/init:latest

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_enabled_via_annotation_template.yaml
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_enabled_via_annotation_template.yaml
@@ -2,8 +2,8 @@ policy: enabled
 alwaysInjectSelector: []
 neverInjectSelector: []
 injectedAnnotations: {}
+values: '{"sidecarInjectorWebhook":{"rewriteAppHTTPProbe": true}}'
 template: |-
-  rewriteAppHTTPProbe: true
   initContainers:
   - name: istio-init
     image: example.com/init:latest

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_template.yaml
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_http_probe_rewrite_template.yaml
@@ -2,8 +2,8 @@ policy: enabled
 alwaysInjectSelector: []
 neverInjectSelector: []
 injectedAnnotations: {}
+values: '{"sidecarInjectorWebhook":{"rewriteAppHTTPProbe": true}}'
 template: |-
-  rewriteAppHTTPProbe: true
   initContainers:
   - name: istio-init
     image: example.com/init:latest

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_https_probe_rewrite.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_https_probe_rewrite.patch
@@ -78,8 +78,8 @@
     "path": "/spec/containers/0/livenessProbe",
     "value": {
       "httpGet": {
-        "path": "/live",
-        "port": "http"
+        "path": "/app-health/hello/livez",
+        "port": 15020
       }
     }
   },
@@ -88,9 +88,9 @@
     "path": "/spec/containers/0/readinessProbe",
     "value": {
       "httpGet": {
-        "path": "/ready",
-        "port": 3333,
-        "scheme": "HTTPS"
+        "path": "/app-health/hello/readyz",
+        "port": 15020,
+        "scheme": "HTTP"
       }
     }
   },
@@ -105,12 +105,13 @@
   },
   {
     "op": "replace",
-    "path": "/spec/containers/1/livenessProbe/httpGet/port",
-    "value": 9000
+    "path": "/spec/containers/1/livenessProbe/httpGet/path",
+    "value": "/app-health/second/livez"
   },
   {
-    "op": "remove",
-    "path": "/spec/containers/1/livenessProbe/httpGet/path"
+    "op": "replace",
+    "path": "/spec/containers/1/livenessProbe/httpGet/port",
+    "value": 15020
   },
   {
     "op": "remove",
@@ -136,6 +137,16 @@
     "value": [
       "--statusPort",
       "15020"
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/2/env",
+    "value": [
+      {
+        "name": "ISTIO_KUBE_APP_PROBERS",
+        "value": "{\"/app-health/hello/livez\":{\"httpGet\":{\"path\":\"/live\",\"port\":80}},\"/app-health/hello/readyz\":{\"httpGet\":{\"path\":\"/ready\",\"port\":3333,\"scheme\":\"HTTPS\"}},\"/app-health/second/livez\":{\"httpGet\":{\"port\":9000}}}"
+      }
     ]
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_https_probe_rewrite_template.yaml
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_https_probe_rewrite_template.yaml
@@ -2,8 +2,8 @@ policy: enabled
 alwaysInjectSelector: []
 neverInjectSelector: []
 injectedAnnotations: {}
+values: '{"sidecarInjectorWebhook":{"rewriteAppHTTPProbe": true}}'
 template: |-
-  rewriteAppHTTPProbe: true
   initContainers:
   - name: istio-init
     image: example.com/init:latest

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_probe_rewrite_timeout_retention.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_probe_rewrite_timeout_retention.patch
@@ -78,8 +78,8 @@
     "path": "/spec/containers/0/livenessProbe",
     "value": {
       "httpGet": {
-        "path": "/live",
-        "port": "http"
+        "path": "/app-health/hello/livez",
+        "port": 15020
       },
       "timeoutSeconds": 5
     }
@@ -89,8 +89,8 @@
     "path": "/spec/containers/0/readinessProbe",
     "value": {
       "httpGet": {
-        "path": "/ready",
-        "port": 3333
+        "path": "/app-health/hello/readyz",
+        "port": 15020
       },
       "timeoutSeconds": 5
     }
@@ -106,12 +106,13 @@
   },
   {
     "op": "replace",
-    "path": "/spec/containers/1/livenessProbe/httpGet/port",
-    "value": 9000
+    "path": "/spec/containers/1/livenessProbe/httpGet/path",
+    "value": "/app-health/second/livez"
   },
   {
-    "op": "remove",
-    "path": "/spec/containers/1/livenessProbe/httpGet/path"
+    "op": "replace",
+    "path": "/spec/containers/1/livenessProbe/httpGet/port",
+    "value": 15020
   },
   {
     "op": "remove",
@@ -137,6 +138,16 @@
     "value": [
       "--statusPort",
       "15020"
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/2/env",
+    "value": [
+      {
+        "name": "ISTIO_KUBE_APP_PROBERS",
+        "value": "{\"/app-health/hello/livez\":{\"httpGet\":{\"path\":\"/live\",\"port\":80},\"timeoutSeconds\":5},\"/app-health/hello/readyz\":{\"httpGet\":{\"path\":\"/ready\",\"port\":3333},\"timeoutSeconds\":5},\"/app-health/second/livez\":{\"httpGet\":{\"port\":9000},\"timeoutSeconds\":5}}"
+      }
     ]
   },
   {

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_probe_rewrite_timeout_retention_template.yaml
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_probe_rewrite_timeout_retention_template.yaml
@@ -2,8 +2,8 @@ policy: enabled
 alwaysInjectSelector: []
 neverInjectSelector: []
 injectedAnnotations: {}
+values: '{"sidecarInjectorWebhook":{"rewriteAppHTTPProbe": true}}'
 template: |-
-  rewriteAppHTTPProbe: true
   initContainers:
   - name: istio-init
     image: example.com/init:latest

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -698,11 +698,20 @@ func createTestWebhookFromFile(templateFile string, t *testing.T) *Webhook {
 	if err := yaml.Unmarshal(util.ReadFile(templateFile, t), injectConfig); err != nil {
 		t.Fatalf("failed to unmarshal injectionConfig: %v", err)
 	}
+	valuesConfig := &struct {
+		Values string `json:"values"`
+	}{}
+	if err := yaml.Unmarshal(util.ReadFile(templateFile, t), valuesConfig); err != nil {
+		t.Fatalf("failed to unmarshal injectionConfig: %v", err)
+	}
+	if valuesConfig.Values == "" {
+		valuesConfig.Values = "{}"
+	}
 	m := mesh.DefaultMeshConfig()
 	return &Webhook{
 		Config:       injectConfig,
 		meshConfig:   &m,
-		valuesConfig: "{}",
+		valuesConfig: valuesConfig.Values,
 	}
 }
 


### PR DESCRIPTION
In https://github.com/istio/istio/pull/28800, we changed to reading the
probe setting indirectly from the injection template to reading it
directly from the source (values). This made these tests, which have a
custom template and don't set the values, not test the right thing.

This updates the tests to set the values correctly. Additionally, I
removed the obsolete field in injector template.

An alternative to this PR would be to continue to read the setting from
the template. I do not think its a better option, but don't feel
strongly either way; it should not impact users either way
