### PR TITLE
Fix istioctl manifest generate command example

### DIFF
--- a/operator/cmd/mesh/manifest-generate.go
+++ b/operator/cmd/mesh/manifest-generate.go
@@ -71,7 +71,7 @@ func manifestGenerateCmd(rootArgs *rootArgs, mgArgs *manifestGenerateArgs, logOp
   istioctl manifest generate
 
   # Enable Tracing
-  istioctl install --set meshConfig.enableTracing=true
+  istioctl manifest generate --set meshConfig.enableTracing=true
 
   # Generate the demo profile
   istioctl manifest generate --set profile=demo


### PR DESCRIPTION
Fixes in `istioctl manifest generate` command examples mistakenly showing `istioctl install`

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure