### PR TITLE
injector: internally support multiple injector templates

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -193,6 +193,9 @@ data:
   # New fields should not use Values - it is a 'primary' config object, users should be able
   # to fine tune it or use it with kube-inject.
   config: |-
+    # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
+    # NOTE: this currently only allows a single element
+    defaultTemplates: [sidecar]
     policy: enabled
     alwaysInjectSelector:
       []

--- a/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
@@ -20,6 +20,9 @@ data:
   # New fields should not use Values - it is a 'primary' config object, users should be able
   # to fine tune it or use it with kube-inject.
   config: |-
+    # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
+    # NOTE: this currently only allows a single element
+    defaultTemplates: [sidecar]
     policy: {{ .Values.global.proxy.autoInject }}
     alwaysInjectSelector:
 {{ toYaml .Values.sidecarInjectorWebhook.alwaysInjectSelector | trim | indent 6 }}

--- a/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -173,6 +173,9 @@ data:
   # New fields should not use Values - it is a 'primary' config object, users should be able
   # to fine tune it or use it with kube-inject.
   config: |-
+    # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
+    # NOTE: this currently only allows a single element
+    defaultTemplates: [sidecar]
     policy: enabled
     alwaysInjectSelector:
       []

--- a/manifests/charts/istiod-remote/templates/istiod-injector-configmap.yaml
+++ b/manifests/charts/istiod-remote/templates/istiod-injector-configmap.yaml
@@ -20,6 +20,9 @@ data:
   # New fields should not use Values - it is a 'primary' config object, users should be able
   # to fine tune it or use it with kube-inject.
   config: |-
+    # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
+    # NOTE: this currently only allows a single element
+    defaultTemplates: [sidecar]
     policy: {{ .Values.global.proxy.autoInject }}
     alwaysInjectSelector:
 {{ toYaml .Values.sidecarInjectorWebhook.alwaysInjectSelector | trim | indent 6 }}

--- a/pkg/kube/inject/inject_test.go
+++ b/pkg/kube/inject/inject_test.go
@@ -314,7 +314,7 @@ func TestInjection(t *testing.T) {
 			// First we test kube-inject. This will run exactly what kube-inject does, and write output to the golden files
 			t.Run("kube-inject", func(t *testing.T) {
 				var got bytes.Buffer
-				if err = IntoResourceFile(sidecarTemplate.Template, valuesConfig, "", mc, in, &got, nullWarningHandler); err != nil {
+				if err = IntoResourceFile(sidecarTemplate.Templates, valuesConfig, "", mc, in, &got, nullWarningHandler); err != nil {
 					if c.expectedError != "" {
 						if !strings.Contains(strings.ToLower(err.Error()), c.expectedError) {
 							t.Fatalf("expected error %q got %q", c.expectedError, err)
@@ -379,7 +379,7 @@ func TestInjection(t *testing.T) {
 func TestStrategicMerge(t *testing.T) {
 	webhook := &Webhook{
 		Config: &Config{
-			Template: `
+			Templates: map[string]string{SidecarTemplateName: `
 containers:
 - name: hello
   image: "fake.docker.io/google-samples/hello-go-gke:1.1"
@@ -388,7 +388,7 @@ containers:
     limits:
       cpu: 100m
       memory: 50m
-`,
+`},
 			Policy: InjectionPolicyEnabled,
 		},
 	}

--- a/pkg/kube/inject/watcher_test.go
+++ b/pkg/kube/inject/watcher_test.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
-	"gopkg.in/yaml.v2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -49,9 +48,9 @@ func makeConfigMap(resourceVersion string, data map[string]string) *v1.ConfigMap
 }
 
 func TestNewConfigMapWatcher(t *testing.T) {
-	var c Config
 	configYaml := "policy: enabled"
-	if err := yaml.Unmarshal([]byte(configYaml), &c); err != nil {
+	c, err := UnmarshalConfig([]byte(configYaml))
+	if err != nil {
 		t.Fatal(err)
 	}
 	valuesConfig := "sidecarInjectorWebhook: {}"

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -108,8 +108,8 @@ func loadConfig(injectFile, valuesFile string) (*Config, string, error) {
 }
 
 func unmarshalConfig(data []byte) (*Config, error) {
-	var c Config
-	if err := yaml.Unmarshal(data, &c); err != nil {
+	c, err := UnmarshalConfig(data)
+	if err != nil {
 		return nil, err
 	}
 
@@ -117,7 +117,7 @@ func unmarshalConfig(data []byte) (*Config, error) {
 	log.Debugf("Policy: %v", c.Policy)
 	log.Debugf("AlwaysInjectSelector: %v", c.AlwaysInjectSelector)
 	log.Debugf("NeverInjectSelector: %v", c.NeverInjectSelector)
-	log.Debugf("Template: |\n  %v", strings.Replace(c.Template, "\n", "\n  ", -1))
+	log.Debugf("Templates: |\n  %v", c.Templates, "\n", "\n  ", -1)
 	return &c, nil
 }
 
@@ -335,7 +335,7 @@ type InjectionParameters struct {
 	pod                 *corev1.Pod
 	deployMeta          *metav1.ObjectMeta
 	typeMeta            *metav1.TypeMeta
-	template            string
+	template            Templates
 	meshConfig          *meshconfig.MeshConfig
 	valuesConfig        string
 	revision            string
@@ -648,7 +648,7 @@ func (wh *Webhook) inject(ar *kube.AdmissionReview, path string) *kube.Admission
 		pod:                 &pod,
 		deployMeta:          deploy,
 		typeMeta:            typeMeta,
-		template:            wh.Config.Template,
+		template:            wh.Config.Templates,
 		meshConfig:          wh.meshConfig,
 		valuesConfig:        wh.valuesConfig,
 		revision:            wh.revision,


### PR DESCRIPTION
Part of https://docs.google.com/document/d/1Rmp9B3DDypgMCau-YAqidx_r3qvKLZj6jUX-t22zj84/edit?ts=5fa915aa#

This allows the injector internals to support multiple injectors. This does NOT change the actual injection template, which will be done in another PR. This both proves this is backwards compatible and keeps the PR smaller.

Depends on https://github.com/istio/istio/pull/29012