### PR TITLE
Fix the long description of istio-iptables shown in the 'help' output

### DIFF
--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -43,7 +43,7 @@ var (
 var rootCmd = &cobra.Command{
 	Use:   "istio-iptables",
 	Short: "Set up iptables rules for Istio Sidecar",
-	Long:  "Script responsible for setting up port forwarding for Istio sidecar.",
+	Long:  "istio-iptables is responsible for setting up port forwarding for Istio Sidecar.",
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg := constructConfig()
 		var ext dep.Dependencies


### PR DESCRIPTION
istio-iptables is now a binary instead of a script, so we should fix its long description shown in the "help" output.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.