### PR TITLE
Fix nil pointer dereference in initSidecarInjector of Pilot

### DIFF
--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -251,8 +251,8 @@ func TestNewServerWithMockRegistry(t *testing.T) {
 		secureGRPCport   string
 	}{
 		{
-			name:           "Mock Registry",
-			registry:       "Mock",
+			name:             "Mock Registry",
+			registry:         "Mock",
 			expectedRegistry: serviceregistry.Mock,
 		},
 	}
@@ -285,8 +285,8 @@ func TestNewServerWithMockRegistry(t *testing.T) {
 				}
 
 				p.RegistryOptions = RegistryOptions{
-					Registries: []string{c.registry},
-					FileDir: configDir,
+					Registries:  []string{c.registry},
+					FileDir:     configDir,
 				}
 
 				// Include all of the default plugins

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -285,8 +285,8 @@ func TestNewServerWithMockRegistry(t *testing.T) {
 				}
 
 				p.RegistryOptions = RegistryOptions{
-					Registries:  []string{c.registry},
-					FileDir:     configDir,
+					Registries: []string{c.registry},
+					FileDir:    configDir,
 				}
 
 				// Include all of the default plugins

--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pilot/pkg/serviceregistry"
 	kubecontroller "istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/testcerts"
@@ -238,6 +239,73 @@ func TestNewServer(t *testing.T) {
 			}()
 
 			g.Expect(s.environment.GetDomainSuffix()).To(Equal(c.expectedDomain))
+		})
+	}
+}
+
+func TestNewServerWithMockRegistry(t *testing.T) {
+	cases := []struct {
+		name             string
+		registry         string
+		expectedRegistry serviceregistry.ProviderID
+		secureGRPCport   string
+	}{
+		{
+			name:           "Mock Registry",
+			registry:       "Mock",
+			expectedRegistry: serviceregistry.Mock,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			configDir, err := ioutil.TempDir("", "TestNewServer")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			defer func() {
+				_ = os.RemoveAll(configDir)
+			}()
+
+			args := NewPilotArgs(func(p *PilotArgs) {
+				p.Namespace = "istio-system"
+
+				// As the same with args in main go of pilot-discovery
+				p.InjectionOptions = InjectionOptions{
+					InjectionDirectory: "./var/lib/istio/inject",
+				}
+
+				p.ServerOptions = DiscoveryServerOptions{
+					// Dynamically assign all ports.
+					HTTPAddr:       ":0",
+					MonitoringAddr: ":0",
+					GRPCAddr:       ":0",
+					SecureGRPCAddr: c.secureGRPCport,
+				}
+
+				p.RegistryOptions = RegistryOptions{
+					Registries: []string{c.registry},
+					FileDir: configDir,
+				}
+
+				// Include all of the default plugins
+				p.Plugins = DefaultPlugins
+				p.ShutdownDuration = 1 * time.Millisecond
+			})
+
+			g := NewWithT(t)
+			s, err := NewServer(args)
+			g.Expect(err).To(Succeed())
+
+			stop := make(chan struct{})
+			g.Expect(s.Start(stop)).To(Succeed())
+			defer func() {
+				close(stop)
+				s.WaitUntilCompletion()
+			}()
+
+			g.Expect(s.ServiceController().GetRegistries()[0].Provider()).To(Equal(c.expectedRegistry))
 		})
 	}
 }

--- a/pilot/pkg/bootstrap/sidecarinjector.go
+++ b/pilot/pkg/bootstrap/sidecarinjector.go
@@ -59,7 +59,7 @@ func (s *Server) initSidecarInjector(args *PilotArgs) (*inject.Webhook, error) {
 		if err != nil {
 			return nil, err
 		}
-	} else {
+	} else if s.kubeClient != nil {
 		configMapName := getInjectorConfigMapName(args.Revision)
 		cms := s.kubeClient.CoreV1().ConfigMaps(args.Namespace)
 		if _, err := cms.Get(context.TODO(), configMapName, metav1.GetOptions{}); err != nil {
@@ -70,6 +70,9 @@ func (s *Server) initSidecarInjector(args *PilotArgs) (*inject.Webhook, error) {
 			return nil, err
 		}
 		watcher = inject.NewConfigMapWatcher(s.kubeClient, args.Namespace, configMapName, "config", "values")
+	} else {
+		log.Infof("Skipping sidecar injector, template not found")
+		return nil, nil
 	}
 
 	log.Info("initializing sidecar injector")


### PR DESCRIPTION
When the Pilot is deployed in a non-K8s environment, the process of initializing the server will cause the program to panic. In order to reproduce this issue, as in the following example, set the service registry of the Pilot to Mock registry,  build and run discovery cmd.
```
./pilot-discovery discovery --registries=mock --configDir=/tmp
```
Then, I got the nil pointer dereference error.
```
panic: runtime error: invalid memory address or nil pointer dereference
```
I find the reason. When the local injection config is not exist in the path `./var/lib/istio/inject` specified in initial `serverArgs`, the  server will find the remote injection config by accessing ConfigMap with KubeClient. Our Pilot is deployed in a non-K8s environment and the KubeClient will not be created, so we get the nil pointer dereference.

I improve the code of this method `initSidecarInjector ` to avoid the above issue. 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
