### PR TITLE
properly use cluster id and provider id

### DIFF
--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -155,7 +155,7 @@ func (c *Controller) GetService(hostname host.Name) (*model.Service, error) {
 		if service == nil {
 			continue
 		}
-		if r.Provider() == serviceregistry.External {
+		if r.Provider() != serviceregistry.Kubernetes {
 			return service, nil
 		}
 		service.Mutex.RLock()
@@ -214,7 +214,7 @@ func nodeClusterID(node *model.Proxy) string {
 // Skip the service registry when there won't be a match
 // because the proxy is in a different cluster.
 func skipSearchingRegistryForProxy(nodeClusterID string, r serviceregistry.Instance) bool {
-	// Always search External (serviceentry) registry.
+	// Always search non-kube (usually serviceentry) registry.
 	// Check every registry if cluster ID isn't specified.
 	if r.Provider() == serviceregistry.External || nodeClusterID == "" {
 		return false

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 
-	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pkg/config/host"
@@ -120,11 +119,7 @@ func (c *Controller) Services() ([]*model.Service, error) {
 		// Race condition: multiple threads may call Services, and multiple services
 		// may modify one of the service's cluster ID
 		clusterAddressesMutex.Lock()
-		if r.Cluster() == "" { // Should we instead check for registry name to be on safe side?
-			// If the service does not have a cluster ID (ServiceEntries, CloudFoundry, etc.)
-			// Do not bother checking for the cluster ID.
-			// DO NOT ASSIGN CLUSTER ID to non-k8s registries. This will prevent service entries with multiple
-			// VIPs or CIDR ranges in the address field
+		if r.Provider() == serviceregistry.External {
 			services = append(services, svcs...)
 		} else {
 			// This is K8S typically
@@ -160,7 +155,7 @@ func (c *Controller) GetService(hostname host.Name) (*model.Service, error) {
 		if service == nil {
 			continue
 		}
-		if r.Cluster() == "" {
+		if r.Provider() == serviceregistry.External {
 			return service, nil
 		}
 		service.Mutex.RLock()
@@ -218,21 +213,14 @@ func nodeClusterID(node *model.Proxy) string {
 
 // Skip the service registry when there won't be a match
 // because the proxy is in a different cluster.
-func skipSearchingRegistryForProxy(nodeClusterID, registryClusterID, selfClusterID string) bool {
-	// We can't trust the default service registry because its always
-	// named `Kubernetes`. Use the `CLUSTER_ID` envvar to find the
-	// local cluster name in these cases.
-	// TODO(https://github.com/istio/istio/issues/22093)
-	if registryClusterID == string(serviceregistry.Kubernetes) {
-		registryClusterID = selfClusterID
-	}
-
-	// Kube registries can have WorkloadEntry instances
-	if registryClusterID == "" || nodeClusterID == "" {
+func skipSearchingRegistryForProxy(nodeClusterID string, r serviceregistry.Instance) bool {
+	// Always search External (serviceentry) registry.
+	// Check every registry if cluster ID isn't specified.
+	if r.Provider() == serviceregistry.External || nodeClusterID == "" {
 		return false
 	}
 
-	return registryClusterID != nodeClusterID
+	return r.Cluster() != nodeClusterID
 }
 
 // GetProxyServiceInstances lists service instances co-located with a given proxy
@@ -240,7 +228,7 @@ func (c *Controller) GetProxyServiceInstances(node *model.Proxy) []*model.Servic
 	out := make([]*model.ServiceInstance, 0)
 	for _, r := range c.GetRegistries() {
 		nodeClusterID := nodeClusterID(node)
-		if skipSearchingRegistryForProxy(nodeClusterID, r.Cluster(), features.ClusterName) {
+		if skipSearchingRegistryForProxy(nodeClusterID, r) {
 			log.Debugf("GetProxyServiceInstances(): not searching registry %v: proxy %v CLUSTER_ID is %v",
 				r.Cluster(), node.ID, nodeClusterID)
 			continue

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -119,7 +119,7 @@ func (c *Controller) Services() ([]*model.Service, error) {
 		// Race condition: multiple threads may call Services, and multiple services
 		// may modify one of the service's cluster ID
 		clusterAddressesMutex.Lock()
-		if r.Provider() == serviceregistry.External {
+		if r.Provider() != serviceregistry.Kubernetes {
 			services = append(services, svcs...)
 		} else {
 			// This is K8S typically
@@ -216,7 +216,7 @@ func nodeClusterID(node *model.Proxy) string {
 func skipSearchingRegistryForProxy(nodeClusterID string, r serviceregistry.Instance) bool {
 	// Always search non-kube (usually serviceentry) registry.
 	// Check every registry if cluster ID isn't specified.
-	if r.Provider() == serviceregistry.External || nodeClusterID == "" {
+	if r.Provider() != serviceregistry.Kubernetes || nodeClusterID == "" {
 		return false
 	}
 

--- a/pilot/pkg/serviceregistry/aggregate/controller_test.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller_test.go
@@ -93,14 +93,14 @@ func buildMockControllerForMultiCluster() *Controller {
 		}, 2)
 
 	registry1 := serviceregistry.Simple{
-		ProviderID:       serviceregistry.ProviderID("mockAdapter1"),
+		ProviderID:       serviceregistry.Kubernetes,
 		ClusterID:        "cluster-1",
 		ServiceDiscovery: discovery1,
 		Controller:       &mock.Controller{},
 	}
 
 	registry2 := serviceregistry.Simple{
-		ProviderID:       serviceregistry.ProviderID("mockAdapter2"),
+		ProviderID:       serviceregistry.Kubernetes,
 		ClusterID:        "cluster-2",
 		ServiceDiscovery: discovery2,
 		Controller:       &mock.Controller{},

--- a/pilot/pkg/serviceregistry/aggregate/controller_test.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller_test.go
@@ -49,16 +49,16 @@ var (
 func buildMockController() *Controller {
 	discovery1 = mock.NewDiscovery(
 		map[host.Name]*model.Service{
-			mock.ReplicatedFooServiceName: mock.ReplicatedFooServiceV1,
-			mock.HelloService.Hostname:    mock.HelloService,
-			mock.ExtHTTPService.Hostname:  mock.ExtHTTPService,
+			mock.ReplicatedFooServiceName: mock.ReplicatedFooServiceV1.DeepCopy(),
+			mock.HelloService.Hostname:    mock.HelloService.DeepCopy(),
+			mock.ExtHTTPService.Hostname:  mock.ExtHTTPService.DeepCopy(),
 		}, 2)
 
 	discovery2 = mock.NewDiscovery(
 		map[host.Name]*model.Service{
-			mock.ReplicatedFooServiceName: mock.ReplicatedFooServiceV2,
-			mock.WorldService.Hostname:    mock.WorldService,
-			mock.ExtHTTPSService.Hostname: mock.ExtHTTPSService,
+			mock.ReplicatedFooServiceName: mock.ReplicatedFooServiceV2.DeepCopy(),
+			mock.WorldService.Hostname:    mock.WorldService.DeepCopy(),
+			mock.ExtHTTPSService.Hostname: mock.ExtHTTPSService.DeepCopy(),
 		}, 2)
 
 	registry1 := serviceregistry.Simple{
@@ -89,7 +89,7 @@ func buildMockControllerForMultiCluster() *Controller {
 	discovery2 = mock.NewDiscovery(
 		map[host.Name]*model.Service{
 			mock.HelloService.Hostname: mock.MakeService("hello.default.svc.cluster.local", "10.1.2.0", []string{}),
-			mock.WorldService.Hostname: mock.WorldService,
+			mock.WorldService.Hostname: mock.WorldService.DeepCopy(),
 		}, 2)
 
 	registry1 := serviceregistry.Simple{
@@ -248,9 +248,6 @@ func TestGetServiceError(t *testing.T) {
 	svc, err = aggregateCtl.GetService(mock.WorldService.Hostname)
 	if err != nil {
 		t.Fatal("Aggregate controller should not return error if service is found")
-	}
-	if svc == nil {
-		t.Fatal("Fail to get service")
 	}
 	if svc.Hostname != mock.WorldService.Hostname {
 		t.Fatal("Returned service is incorrect")


### PR DESCRIPTION
fixes https://github.com/istio/istio/issues/22093 and is pre-work for #29026 

The main advantage is that we can actually associate the ServiceEntry registry with a cluster (no longer rely on `ClusterID == ""`). We eventually plan on [reading WorkloadEntry from multiple clusters](https://docs.google.com/document/d/1Q_JqW7v1SC2Crg5ped9Bf8fyauglB-YqHYk7hwSuWOk/edit). To do this, we need to be able to shard the WorkloadInstances/Endpoints by source cluster. 