### PR TITLE
Remove all manifests in parallel

### DIFF
--- a/pkg/test/util/yml/file.go
+++ b/pkg/test/util/yml/file.go
@@ -52,21 +52,20 @@ func NewFileWriter(workDir string) FileWriter {
 // WriteYAML writes the given YAML content to one or more YAML files.
 func (w *writerImpl) WriteYAML(filenamePrefix string, contents ...string) ([]string, error) {
 	out := make([]string, 0, len(contents))
-	for _, content := range contents {
-		files, err := splitContentsToFiles(w.workDir, content, filenamePrefix)
+	content := JoinString(contents...)
+	files, err := splitContentsToFiles(w.workDir, content, filenamePrefix)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(files) == 0 {
+		f, err := writeContentsToTempFile(w.workDir, content)
 		if err != nil {
 			return nil, err
 		}
-
-		if len(files) == 0 {
-			f, err := writeContentsToTempFile(w.workDir, content)
-			if err != nil {
-				return nil, err
-			}
-			files = append(files, f)
-		}
-		out = append(out, files...)
+		files = append(files, f)
 	}
+	out = append(out, files...)
 	return out, nil
 }
 


### PR DESCRIPTION
This will make it so eastwest gateway is removed in parallel. This
doesn't impact CI much, but on GKE it takes ~1min to remove a LB service so
this makes the cleanup 1min faster



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.