### PR TITLE
Enable dual-stack ingress traffic in K8s clusters

### DIFF
--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -187,6 +187,19 @@ func ConvertAddressToCidr(addr string) *core.CidrRange {
 // BuildAddress returns a SocketAddress with the given ip and port or uds.
 func BuildAddress(bind string, port uint32) *core.Address {
 	if port != 0 {
+		if bind == "::" {
+			return &core.Address{
+				Address: &core.Address_SocketAddress{
+					SocketAddress: &core.SocketAddress{
+						Address: bind,
+						Ipv4Compat: true,
+						PortSpecifier: &core.SocketAddress_PortValue{
+							PortValue: port,
+						},
+					},
+				},
+			}
+		}
 		return &core.Address{
 			Address: &core.Address_SocketAddress{
 				SocketAddress: &core.SocketAddress{

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -121,7 +121,7 @@ func (cfg Config) toTemplateParams() (map[string]interface{}, error) {
 	} else {
 		opts = append(opts,
 			option.Localhost(option.LocalhostIPv4),
-			option.Wildcard(option.WildcardIPv4),
+			option.Wildcard(option.WildcardIPv6),
 			option.DNSLookupFamily(option.DNSLookupFamilyIPv4))
 	}
 

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -229,8 +229,13 @@ func configFile(config string, epoch int) string {
 }
 
 // isIPv6Proxy check the addresses slice and returns true for a valid IPv6 address
-// for all other cases it returns false
+// for all other cases it returns false. In K8s returns true is the default family is IPv6.
 func isIPv6Proxy(ipAddrs []string) bool {
+	if k8sServiceHost := os.Getenv("KUBERNETES_SERVICE_HOST"); k8sServiceHost != "" {
+		if k8sServiceHostIP := net.ParseIP(k8sServiceHost); k8sServiceHostIP != nil {
+			return k8sServiceHostIP.To4() == nil
+		}
+	}
 	for i := 0; i < len(ipAddrs); i++ {
 		addr := net.ParseIP(ipAddrs[i])
 		if addr == nil {

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -121,6 +121,15 @@ func constructConfig() *config.Config {
 	}
 	cfg.EnableInboundIPv6 = podIP.To4() == nil
 
+	// In a K8s dual-stack setup both families are used so check the
+	// kubernetes service address instead.
+	if k8sServiceHost := os.Getenv("KUBERNETES_SERVICE_HOST"); k8sServiceHost != "" {
+		if k8sServiceHostIP := net.ParseIP(k8sServiceHost); k8sServiceHostIP != nil {
+			cfg.EnableInboundIPv6 = k8sServiceHostIP.To4() == nil
+		}
+	}
+
+
 	return cfg
 }
 

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -494,7 +494,8 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "{{ .wildcard }}",
-            "port_value": 15090
+            "port_value": 15090,
+            "ipv4_compat": true
           }
         },
         "filter_chains": [
@@ -543,7 +544,8 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "{{ .wildcard }}",
-            "port_value": 15021
+            "port_value": 15021,
+            "ipv4_compat": true
           }
         },
         "filter_chains": [


### PR DESCRIPTION
This PR enables dual-stack for Istio ingress traffic in Kubernetes dual-stack clusters.

It also enables Istio in a IPv6 based dual-stack K8s cluster.

Internal traffic (microservices) handled by Istio is still single-stack using the K8s default family (the one you get if the `ipFamily` is not explicitly specified in the manifest).

I have tested all combinations manually; single-stack ipv4/ipv6 and dual-stack with default family ipv4/ipv6. I have used calico/cni:v3.16.0 on K8s v1.19.4 and v1.20.0-beta.1 (including dual-stack phase.3)

The envoy listeners now uses the ipv6 wildcard address "::" in `ipv4_compat` mode. This means that they accept both ipv4 and ipv6 traffic. Most important are the listeners in `istio-ingressgateway` that handles external traffic.

```
      "name": "::_8080",
      "active_state": {
        "version_info": "2020-11-20T06:49:57Z/7",
        "listener": {
          "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
          "name": "::_8080",
          "address": {
            "socket_address": {
              "address": "::",
              "port_value": 8080,
              "ipv4_compat": true
            }
...
```

The `istio-ingressgateway` service uses the default family (in this case IPv4).

```
$ kubectl get svc -n istio-system istio-ingressgateway
NAME                   TYPE           CLUSTER-IP   EXTERNAL-IP   PORT(S) ...
istio-ingressgateway   LoadBalancer   12.0.9.95    10.0.0.10     80:31407/TCP,443: ...
```

But a new service can be specified for IPv6;

```yaml
apiVersion: v1
kind: Service
metadata:
  name: istio-ipv6
  namespace: istio-system
spec:
  ipFamily: IPv6
  ports:
  - name: http2
    port: 80
    protocol: TCP
    targetPort: 8080
  - name: https
    port: 443
    protocol: TCP
    targetPort: 8443
  selector:
    app: istio-ingressgateway
  type: LoadBalancer
```

With an external IPv6 address.

```
$ kubectl get svc -n istio-system istio-ipv6
NAME         TYPE           CLUSTER-IP        EXTERNAL-IP   PORT(S)                      AGE
istio-ipv6   LoadBalancer   fd00:4000::132e   1000::20      80:31728/TCP,443:30170/TCP   9m20s
```

Now from an external machine both addresses can be used;

```
$ curl --resolv kahttp.external:80:10.0.0.10 --silent -D - http://kahttp.external/
HTTP/1.1 200 OK
x-kahttp-server-host: Kahttp/v1.1.0@kahttp-6hcdj
date: Fri, 20 Nov 2020 07:03:13 GMT
content-length: 816
content-type: text/plain; charset=utf-8
x-envoy-upstream-service-time: 1
server: istio-envoy
...
$ curl --resolv kahttp.external:80:[1000::20] --silent -D - http://kahttp.external/
HTTP/1.1 200 OK
x-kahttp-server-host: Kahttp/v1.1.0@kahttp-km58n
date: Fri, 20 Nov 2020 07:05:02 GMT
content-length: 841
content-type: text/plain; charset=utf-8
x-envoy-upstream-service-time: 3
server: istio-envoy
...
```

### IPv6 based dual-stack clusters

Without this PR Istio does not work for K8s dual-stack clusters with IPv6 as default family. This because the detection of the family just checks addresses and assumes IPv4 if any IPv4 address exist, and it does since it's dual-stack. However probes and internal traffic uses IPv6 so nothing works.

The detection has been altered to check the family of the kubernetes API service using the `$KUBERNETES_SERVICE_HOST` variable, example;

```go
	// In a K8s dual-stack setup both families are used so check the
	// kubernetes service address instead.
	if k8sServiceHost := os.Getenv("KUBERNETES_SERVICE_HOST"); k8sServiceHost != "" {
		if k8sServiceHostIP := net.ParseIP(k8sServiceHost); k8sServiceHostIP != nil {
			cfg.EnableInboundIPv6 = k8sServiceHostIP.To4() == nil
		}
	}
```

### K8s dual-stack phase.3

In the upcoming K8s v1.20.x dual-stack services are supported. Then one service can be specified to support dual-stack traffic to the `istio-ingressgateway`;

```yaml
apiVersion: v1
kind: Service
metadata:
  name: istio-dual
  namespace: istio-system
spec:
  ipFamilyPolicy: PreferDualStack
  ports:
  - name: http2
    port: 80
    protocol: TCP
    targetPort: 8080
  - name: https
    port: 443
    protocol: TCP
    targetPort: 8443
  selector:
    app: istio-ingressgateway
  type: LoadBalancer
```

With dual addresses;

```
$ kubectl get svc -n istio-system istio-dual
NAME         TYPE           CLUSTER-IP     EXTERNAL-IP          PORT(S)                      AGE
istio-dual   LoadBalancer   12.0.194.156   10.0.0.30,1000::30   80:31285/TCP,443:30786/TCP   77s
```


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
