### PR TITLE
Allow passing full pod object as injection template

### DIFF
--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject.patch
@@ -16,7 +16,54 @@
       "prometheus.io/path": "/stats/prometheus",
       "prometheus.io/port": "15020",
       "prometheus.io/scrape": "true",
-      "sidecar.istio.io/status": "{\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
+      "sidecar.istio.io/status": "{\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/1",
+    "value": {
+      "name": "istio-certs",
+      "secret": {
+        "secretName": "istio.default"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/2",
+    "value": {
+      "name": "v0"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/volumes/0/name",
+    "value": "istio-envoy"
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/0/emptyDir",
+    "value": {
+      "medium": "Memory"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers/1",
+    "value": {
+      "name": "istio-init",
+      "image": "example.com/init:latest",
+      "resources": {}
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/1",
+    "value": {
+      "name": "istio-proxy",
+      "image": "example.com/proxy:latest",
+      "resources": {}
     }
   },
   {
@@ -25,5 +72,14 @@
     "value": {
       "fsGroup": 1337
     }
+  },
+  {
+    "op": "add",
+    "path": "/spec/imagePullSecrets",
+    "value": [
+      {
+        "name": "istio-image-pull-secrets"
+      }
+    ]
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_mtls_not_ready.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_mtls_not_ready.patch
@@ -21,7 +21,54 @@
       "prometheus.io/path": "/stats/prometheus",
       "prometheus.io/port": "15020",
       "prometheus.io/scrape": "true",
-      "sidecar.istio.io/status": "{\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
+      "sidecar.istio.io/status": "{\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/1",
+    "value": {
+      "name": "istio-certs",
+      "secret": {
+        "secretName": "istio.default"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/2",
+    "value": {
+      "name": "v0"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/volumes/0/name",
+    "value": "istio-envoy"
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/0/emptyDir",
+    "value": {
+      "medium": "Memory"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers/1",
+    "value": {
+      "name": "istio-init",
+      "image": "example.com/init:latest",
+      "resources": {}
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/1",
+    "value": {
+      "name": "istio-proxy",
+      "image": "example.com/proxy:latest",
+      "resources": {}
     }
   },
   {
@@ -30,5 +77,14 @@
     "value": {
       "fsGroup": 1337
     }
+  },
+  {
+    "op": "add",
+    "path": "/spec/imagePullSecrets",
+    "value": [
+      {
+        "name": "istio-image-pull-secrets"
+      }
+    ]
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers.patch
@@ -16,13 +16,57 @@
       "prometheus.io/path": "/stats/prometheus",
       "prometheus.io/port": "15020",
       "prometheus.io/scrape": "true",
-      "sidecar.istio.io/status": "{\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
+      "sidecar.istio.io/status": "{\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/1",
+    "value": {
+      "name": "istio-certs",
+      "secret": {
+        "secretName": "istio.default"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/2",
+    "value": {
+      "name": "v0"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/volumes/0/name",
+    "value": "istio-envoy"
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/0/emptyDir",
+    "value": {
+      "medium": "Memory"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers/1",
+    "value": {
+      "name": "istio-init",
+      "image": "example.com/init:latest",
+      "resources": {}
     }
   },
   {
     "op": "add",
     "path": "/spec/containers",
-    "value": []
+    "value": [
+      {
+        "name": "istio-proxy",
+        "image": "example.com/proxy:latest",
+        "resources": {}
+      }
+    ]
   },
   {
     "op": "add",
@@ -30,5 +74,17 @@
     "value": {
       "fsGroup": 1337
     }
+  },
+  {
+    "op": "add",
+    "path": "/spec/imagePullSecrets/1",
+    "value": {
+      "name": "p0"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/imagePullSecrets/0/name",
+    "value": "istio-image-pull-secrets"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_imagePullSecrets.patch
@@ -16,13 +16,57 @@
       "prometheus.io/path": "/stats/prometheus",
       "prometheus.io/port": "15020",
       "prometheus.io/scrape": "true",
-      "sidecar.istio.io/status": "{\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
+      "sidecar.istio.io/status": "{\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/1",
+    "value": {
+      "name": "istio-certs",
+      "secret": {
+        "secretName": "istio.default"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/2",
+    "value": {
+      "name": "v0"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/volumes/0/name",
+    "value": "istio-envoy"
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/0/emptyDir",
+    "value": {
+      "medium": "Memory"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers/1",
+    "value": {
+      "name": "istio-init",
+      "image": "example.com/init:latest",
+      "resources": {}
     }
   },
   {
     "op": "add",
     "path": "/spec/containers",
-    "value": []
+    "value": [
+      {
+        "name": "istio-proxy",
+        "image": "example.com/proxy:latest",
+        "resources": {}
+      }
+    ]
   },
   {
     "op": "add",
@@ -30,5 +74,14 @@
     "value": {
       "fsGroup": 1337
     }
+  },
+  {
+    "op": "add",
+    "path": "/spec/imagePullSecrets",
+    "value": [
+      {
+        "name": "istio-image-pull-secrets"
+      }
+    ]
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes.patch
@@ -16,13 +16,46 @@
       "prometheus.io/path": "/stats/prometheus",
       "prometheus.io/port": "15020",
       "prometheus.io/scrape": "true",
-      "sidecar.istio.io/status": "{\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
+      "sidecar.istio.io/status": "{\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes",
+    "value": [
+      {
+        "name": "istio-envoy",
+        "emptyDir": {
+          "medium": "Memory"
+        }
+      },
+      {
+        "name": "istio-certs",
+        "secret": {
+          "secretName": "istio.default"
+        }
+      }
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers/1",
+    "value": {
+      "name": "istio-init",
+      "image": "example.com/init:latest",
+      "resources": {}
     }
   },
   {
     "op": "add",
     "path": "/spec/containers",
-    "value": []
+    "value": [
+      {
+        "name": "istio-proxy",
+        "image": "example.com/proxy:latest",
+        "resources": {}
+      }
+    ]
   },
   {
     "op": "add",
@@ -30,5 +63,17 @@
     "value": {
       "fsGroup": 1337
     }
+  },
+  {
+    "op": "add",
+    "path": "/spec/imagePullSecrets/1",
+    "value": {
+      "name": "v0"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/imagePullSecrets/0/name",
+    "value": "istio-image-pull-secrets"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_containers_volumes_imagePullSecrets.patch
@@ -16,13 +16,46 @@
       "prometheus.io/path": "/stats/prometheus",
       "prometheus.io/port": "15020",
       "prometheus.io/scrape": "true",
-      "sidecar.istio.io/status": "{\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
+      "sidecar.istio.io/status": "{\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes",
+    "value": [
+      {
+        "name": "istio-envoy",
+        "emptyDir": {
+          "medium": "Memory"
+        }
+      },
+      {
+        "name": "istio-certs",
+        "secret": {
+          "secretName": "istio.default"
+        }
+      }
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers/1",
+    "value": {
+      "name": "istio-init",
+      "image": "example.com/init:latest",
+      "resources": {}
     }
   },
   {
     "op": "add",
     "path": "/spec/containers",
-    "value": []
+    "value": [
+      {
+        "name": "istio-proxy",
+        "image": "example.com/proxy:latest",
+        "resources": {}
+      }
+    ]
   },
   {
     "op": "add",
@@ -30,5 +63,14 @@
     "value": {
       "fsGroup": 1337
     }
+  },
+  {
+    "op": "add",
+    "path": "/spec/imagePullSecrets",
+    "value": [
+      {
+        "name": "istio-image-pull-secrets"
+      }
+    ]
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_imagePullSecrets.patch
@@ -16,7 +16,54 @@
       "prometheus.io/path": "/stats/prometheus",
       "prometheus.io/port": "15020",
       "prometheus.io/scrape": "true",
-      "sidecar.istio.io/status": "{\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
+      "sidecar.istio.io/status": "{\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/1",
+    "value": {
+      "name": "istio-certs",
+      "secret": {
+        "secretName": "istio.default"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/2",
+    "value": {
+      "name": "v0"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/volumes/0/name",
+    "value": "istio-envoy"
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/0/emptyDir",
+    "value": {
+      "medium": "Memory"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers/1",
+    "value": {
+      "name": "istio-init",
+      "image": "example.com/init:latest",
+      "resources": {}
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/1",
+    "value": {
+      "name": "istio-proxy",
+      "image": "example.com/proxy:latest",
+      "resources": {}
     }
   },
   {
@@ -25,5 +72,14 @@
     "value": {
       "fsGroup": 1337
     }
+  },
+  {
+    "op": "add",
+    "path": "/spec/imagePullSecrets",
+    "value": [
+      {
+        "name": "istio-image-pull-secrets"
+      }
+    ]
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers.patch
@@ -16,7 +16,56 @@
       "prometheus.io/path": "/stats/prometheus",
       "prometheus.io/port": "15020",
       "prometheus.io/scrape": "true",
-      "sidecar.istio.io/status": "{\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
+      "sidecar.istio.io/status": "{\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/1",
+    "value": {
+      "name": "istio-certs",
+      "secret": {
+        "secretName": "istio.default"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/2",
+    "value": {
+      "name": "v0"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/volumes/0/name",
+    "value": "istio-envoy"
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/0/emptyDir",
+    "value": {
+      "medium": "Memory"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers",
+    "value": [
+      {
+        "name": "istio-init",
+        "image": "example.com/init:latest",
+        "resources": {}
+      }
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/1",
+    "value": {
+      "name": "istio-proxy",
+      "image": "example.com/proxy:latest",
+      "resources": {}
     }
   },
   {
@@ -25,5 +74,17 @@
     "value": {
       "fsGroup": 1337
     }
+  },
+  {
+    "op": "add",
+    "path": "/spec/imagePullSecrets/1",
+    "value": {
+      "name": "p0"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/imagePullSecrets/0/name",
+    "value": "istio-image-pull-secrets"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers.patch
@@ -16,13 +16,59 @@
       "prometheus.io/path": "/stats/prometheus",
       "prometheus.io/port": "15020",
       "prometheus.io/scrape": "true",
-      "sidecar.istio.io/status": "{\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
+      "sidecar.istio.io/status": "{\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
     }
   },
   {
     "op": "add",
+    "path": "/spec/volumes/1",
+    "value": {
+      "name": "istio-certs",
+      "secret": {
+        "secretName": "istio.default"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/2",
+    "value": {
+      "name": "v0"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/volumes/0/name",
+    "value": "istio-envoy"
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/0/emptyDir",
+    "value": {
+      "medium": "Memory"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers",
+    "value": [
+      {
+        "name": "istio-init",
+        "image": "example.com/init:latest",
+        "resources": {}
+      }
+    ]
+  },
+  {
+    "op": "add",
     "path": "/spec/containers",
-    "value": []
+    "value": [
+      {
+        "name": "istio-proxy",
+        "image": "example.com/proxy:latest",
+        "resources": {}
+      }
+    ]
   },
   {
     "op": "add",
@@ -30,5 +76,17 @@
     "value": {
       "fsGroup": 1337
     }
+  },
+  {
+    "op": "add",
+    "path": "/spec/imagePullSecrets/1",
+    "value": {
+      "name": "p0"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/imagePullSecrets/0/name",
+    "value": "istio-image-pull-secrets"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_imagePullSecrets.patch
@@ -16,13 +16,59 @@
       "prometheus.io/path": "/stats/prometheus",
       "prometheus.io/port": "15020",
       "prometheus.io/scrape": "true",
-      "sidecar.istio.io/status": "{\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
+      "sidecar.istio.io/status": "{\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
     }
   },
   {
     "op": "add",
+    "path": "/spec/volumes/1",
+    "value": {
+      "name": "istio-certs",
+      "secret": {
+        "secretName": "istio.default"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/2",
+    "value": {
+      "name": "v0"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/volumes/0/name",
+    "value": "istio-envoy"
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/0/emptyDir",
+    "value": {
+      "medium": "Memory"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers",
+    "value": [
+      {
+        "name": "istio-init",
+        "image": "example.com/init:latest",
+        "resources": {}
+      }
+    ]
+  },
+  {
+    "op": "add",
     "path": "/spec/containers",
-    "value": []
+    "value": [
+      {
+        "name": "istio-proxy",
+        "image": "example.com/proxy:latest",
+        "resources": {}
+      }
+    ]
   },
   {
     "op": "add",
@@ -30,5 +76,14 @@
     "value": {
       "fsGroup": 1337
     }
+  },
+  {
+    "op": "add",
+    "path": "/spec/imagePullSecrets",
+    "value": [
+      {
+        "name": "istio-image-pull-secrets"
+      }
+    ]
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_volumes.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_containers_volumes.patch
@@ -16,13 +16,48 @@
       "prometheus.io/path": "/stats/prometheus",
       "prometheus.io/port": "15020",
       "prometheus.io/scrape": "true",
-      "sidecar.istio.io/status": "{\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
+      "sidecar.istio.io/status": "{\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
     }
   },
   {
     "op": "add",
+    "path": "/spec/volumes",
+    "value": [
+      {
+        "name": "istio-envoy",
+        "emptyDir": {
+          "medium": "Memory"
+        }
+      },
+      {
+        "name": "istio-certs",
+        "secret": {
+          "secretName": "istio.default"
+        }
+      }
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers",
+    "value": [
+      {
+        "name": "istio-init",
+        "image": "example.com/init:latest",
+        "resources": {}
+      }
+    ]
+  },
+  {
+    "op": "add",
     "path": "/spec/containers",
-    "value": []
+    "value": [
+      {
+        "name": "istio-proxy",
+        "image": "example.com/proxy:latest",
+        "resources": {}
+      }
+    ]
   },
   {
     "op": "add",
@@ -30,5 +65,17 @@
     "value": {
       "fsGroup": 1337
     }
+  },
+  {
+    "op": "add",
+    "path": "/spec/imagePullSecrets/1",
+    "value": {
+      "name": "p0"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/imagePullSecrets/0/name",
+    "value": "istio-image-pull-secrets"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_imagePullSecrets.patch
@@ -16,7 +16,56 @@
       "prometheus.io/path": "/stats/prometheus",
       "prometheus.io/port": "15020",
       "prometheus.io/scrape": "true",
-      "sidecar.istio.io/status": "{\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
+      "sidecar.istio.io/status": "{\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/1",
+    "value": {
+      "name": "istio-certs",
+      "secret": {
+        "secretName": "istio.default"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/2",
+    "value": {
+      "name": "v0"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/volumes/0/name",
+    "value": "istio-envoy"
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/0/emptyDir",
+    "value": {
+      "medium": "Memory"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers",
+    "value": [
+      {
+        "name": "istio-init",
+        "image": "example.com/init:latest",
+        "resources": {}
+      }
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/1",
+    "value": {
+      "name": "istio-proxy",
+      "image": "example.com/proxy:latest",
+      "resources": {}
     }
   },
   {
@@ -25,5 +74,14 @@
     "value": {
       "fsGroup": 1337
     }
+  },
+  {
+    "op": "add",
+    "path": "/spec/imagePullSecrets",
+    "value": [
+      {
+        "name": "istio-image-pull-secrets"
+      }
+    ]
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes.patch
@@ -16,7 +16,56 @@
       "prometheus.io/path": "/stats/prometheus",
       "prometheus.io/port": "15020",
       "prometheus.io/scrape": "true",
-      "sidecar.istio.io/status": "{\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
+      "sidecar.istio.io/status": "{\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/1",
+    "value": {
+      "name": "istio-certs",
+      "secret": {
+        "secretName": "istio.default"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/2",
+    "value": {
+      "name": "v0"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/volumes/0/name",
+    "value": "istio-envoy"
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/0/emptyDir",
+    "value": {
+      "medium": "Memory"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers",
+    "value": [
+      {
+        "name": "istio-init",
+        "image": "example.com/init:latest",
+        "resources": {}
+      }
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/1",
+    "value": {
+      "name": "istio-proxy",
+      "image": "example.com/proxy:latest",
+      "resources": {}
     }
   },
   {
@@ -25,5 +74,14 @@
     "value": {
       "fsGroup": 1337
     }
+  },
+  {
+    "op": "add",
+    "path": "/spec/imagePullSecrets",
+    "value": [
+      {
+        "name": "istio-image-pull-secrets"
+      }
+    ]
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initContainers_volumes_imagePullSecrets.patch
@@ -16,7 +16,45 @@
       "prometheus.io/path": "/stats/prometheus",
       "prometheus.io/port": "15020",
       "prometheus.io/scrape": "true",
-      "sidecar.istio.io/status": "{\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
+      "sidecar.istio.io/status": "{\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes",
+    "value": [
+      {
+        "name": "istio-envoy",
+        "emptyDir": {
+          "medium": "Memory"
+        }
+      },
+      {
+        "name": "istio-certs",
+        "secret": {
+          "secretName": "istio.default"
+        }
+      }
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers",
+    "value": [
+      {
+        "name": "istio-init",
+        "image": "example.com/init:latest",
+        "resources": {}
+      }
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/1",
+    "value": {
+      "name": "istio-proxy",
+      "image": "example.com/proxy:latest",
+      "resources": {}
     }
   },
   {
@@ -25,5 +63,14 @@
     "value": {
       "fsGroup": 1337
     }
+  },
+  {
+    "op": "add",
+    "path": "/spec/imagePullSecrets",
+    "value": [
+      {
+        "name": "istio-image-pull-secrets"
+      }
+    ]
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initcontainers_containers_volumes_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_initcontainers_containers_volumes_imagePullSecrets.patch
@@ -16,13 +16,48 @@
       "prometheus.io/path": "/stats/prometheus",
       "prometheus.io/port": "15020",
       "prometheus.io/scrape": "true",
-      "sidecar.istio.io/status": "{\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
+      "sidecar.istio.io/status": "{\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
     }
   },
   {
     "op": "add",
+    "path": "/spec/volumes",
+    "value": [
+      {
+        "name": "istio-envoy",
+        "emptyDir": {
+          "medium": "Memory"
+        }
+      },
+      {
+        "name": "istio-certs",
+        "secret": {
+          "secretName": "istio.default"
+        }
+      }
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers",
+    "value": [
+      {
+        "name": "istio-init",
+        "image": "example.com/init:latest",
+        "resources": {}
+      }
+    ]
+  },
+  {
+    "op": "add",
     "path": "/spec/containers",
-    "value": []
+    "value": [
+      {
+        "name": "istio-proxy",
+        "image": "example.com/proxy:latest",
+        "resources": {}
+      }
+    ]
   },
   {
     "op": "add",
@@ -30,5 +65,14 @@
     "value": {
       "fsGroup": 1337
     }
+  },
+  {
+    "op": "add",
+    "path": "/spec/imagePullSecrets",
+    "value": [
+      {
+        "name": "istio-image-pull-secrets"
+      }
+    ]
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes.patch
@@ -16,7 +16,43 @@
       "prometheus.io/path": "/stats/prometheus",
       "prometheus.io/port": "15020",
       "prometheus.io/scrape": "true",
-      "sidecar.istio.io/status": "{\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
+      "sidecar.istio.io/status": "{\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes",
+    "value": [
+      {
+        "name": "istio-envoy",
+        "emptyDir": {
+          "medium": "Memory"
+        }
+      },
+      {
+        "name": "istio-certs",
+        "secret": {
+          "secretName": "istio.default"
+        }
+      }
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers/1",
+    "value": {
+      "name": "istio-init",
+      "image": "example.com/init:latest",
+      "resources": {}
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/1",
+    "value": {
+      "name": "istio-proxy",
+      "image": "example.com/proxy:latest",
+      "resources": {}
     }
   },
   {
@@ -25,5 +61,17 @@
     "value": {
       "fsGroup": 1337
     }
+  },
+  {
+    "op": "add",
+    "path": "/spec/imagePullSecrets/1",
+    "value": {
+      "name": "p0"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/imagePullSecrets/0/name",
+    "value": "istio-image-pull-secrets"
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes_imagePullSecrets.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_no_volumes_imagePullSecrets.patch
@@ -16,7 +16,43 @@
       "prometheus.io/path": "/stats/prometheus",
       "prometheus.io/port": "15020",
       "prometheus.io/scrape": "true",
-      "sidecar.istio.io/status": "{\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
+      "sidecar.istio.io/status": "{\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes",
+    "value": [
+      {
+        "name": "istio-envoy",
+        "emptyDir": {
+          "medium": "Memory"
+        }
+      },
+      {
+        "name": "istio-certs",
+        "secret": {
+          "secretName": "istio.default"
+        }
+      }
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers/1",
+    "value": {
+      "name": "istio-init",
+      "image": "example.com/init:latest",
+      "resources": {}
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/1",
+    "value": {
+      "name": "istio-proxy",
+      "image": "example.com/proxy:latest",
+      "resources": {}
     }
   },
   {
@@ -25,5 +61,14 @@
     "value": {
       "fsGroup": 1337
     }
+  },
+  {
+    "op": "add",
+    "path": "/spec/imagePullSecrets",
+    "value": [
+      {
+        "name": "istio-image-pull-secrets"
+      }
+    ]
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace.patch
@@ -27,7 +27,63 @@
   {
     "op": "replace",
     "path": "/metadata/annotations/sidecar.istio.io~1status",
-    "value": "{\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
+    "value": "{\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/2",
+    "value": {
+      "name": "v0"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/3",
+    "value": {
+      "name": "injected2"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/volumes/0/name",
+    "value": "istio-envoy"
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/0/emptyDir",
+    "value": {
+      "medium": "Memory"
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/spec/volumes/1/name",
+    "value": "istio-certs"
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/1/secret",
+    "value": {
+      "secretName": "istio.default"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers/2",
+    "value": {
+      "name": "istio-init",
+      "image": "example.com/init:latest",
+      "resources": {}
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/2",
+    "value": {
+      "name": "istio-proxy",
+      "image": "example.com/proxy:latest",
+      "resources": {}
+    }
   },
   {
     "op": "add",
@@ -35,5 +91,14 @@
     "value": {
       "fsGroup": 1337
     }
+  },
+  {
+    "op": "add",
+    "path": "/spec/imagePullSecrets",
+    "value": [
+      {
+        "name": "istio-image-pull-secrets"
+      }
+    ]
   }
 ]

--- a/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace_backwards_compat.patch
+++ b/pkg/kube/inject/testdata/webhook/TestWebhookInject_replace_backwards_compat.patch
@@ -27,7 +27,31 @@
   {
     "op": "replace",
     "path": "/metadata/annotations/sidecar.istio.io~1status",
-    "value": "{\"initContainers\":null,\"containers\":null,\"volumes\":null,\"imagePullSecrets\":null}"
+    "value": "{\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":[\"istio-image-pull-secrets\"]}"
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/0/emptyDir",
+    "value": {
+      "medium": "Memory"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/1/secret",
+    "value": {
+      "secretName": "istio.default"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers/0/image",
+    "value": "example.com/init:latest"
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/0/image",
+    "value": "example.com/proxy:latest"
   },
   {
     "op": "add",
@@ -35,5 +59,14 @@
     "value": {
       "fsGroup": 1337
     }
+  },
+  {
+    "op": "add",
+    "path": "/spec/imagePullSecrets",
+    "value": [
+      {
+        "name": "istio-image-pull-secrets"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Depends on https://github.com/istio/istio/pull/29023

    This allows the template to be a Pod instead of a PodSpec. This is
    implemented with support for the old behavior as well, so its fully
    backwards compatible. In a followup PR, I will modify the default
    template to use this format
