### PR TITLE
Move some special injection logic into the templates

### DIFF
--- a/istioctl/cmd/testdata/deployment/hello.yaml.injected
+++ b/istioctl/cmd/testdata/deployment/hello.yaml.injected
@@ -21,10 +21,6 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
-        security.istio.io/tlsMode: istio
-        service.istio.io/canonical-name: hello
-        service.istio.io/canonical-revision: latest
         tier: backend
         track: stable
     spec:
@@ -42,7 +38,5 @@ spec:
       - image: docker.io/istio/proxy_init:unittest-test
         name: istio-init
         resources: {}
-      securityContext:
-        fsGroup: 1337
 status: {}
 ---

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -205,6 +205,11 @@ data:
 
     template: |
       metadata:
+        labels:
+          security.istio.io/tlsMode: {{ index .ObjectMeta.Labels `security.istio.io/tlsMode` | default "istio" }}
+          service.istio.io/canonical-name: {{ index .ObjectMeta.Labels `service.istio.io/canonical-name` | default (index .ObjectMeta.Labels `app.kubernetes.io/name`) | default (index .ObjectMeta.Labels `app`) | default .DeploymentMeta.Name }}
+          service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest" }}
+          istio.io/rev: {{ .Revision | default "default" }}
         annotations: {
           {{- if eq (len .Spec.Containers) 1 }}
           kubectl.kubernetes.io/default-logs-container: "{{ (index .Spec.Containers 0).Name }}",
@@ -672,6 +677,10 @@ data:
           {{- range .Values.global.imagePullSecrets }}
           - name: {{ . }}
           {{- end }}
+        {{- end }}
+        {{- if eq (env "ENABLE_LEGACY_FSGROUP_INJECTION" "true") "true" }}
+        securityContext:
+          fsGroup: 1337
         {{- end }}
 ---
 # Source: istio-discovery/templates/service.yaml

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -1,5 +1,10 @@
 template: |
   metadata:
+    labels:
+      security.istio.io/tlsMode: {{ index .ObjectMeta.Labels `security.istio.io/tlsMode` | default "istio" }}
+      service.istio.io/canonical-name: {{ index .ObjectMeta.Labels `service.istio.io/canonical-name` | default (index .ObjectMeta.Labels `app.kubernetes.io/name`) | default (index .ObjectMeta.Labels `app`) | default .DeploymentMeta.Name }}
+      service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest" }}
+      istio.io/rev: {{ .Revision | default "default" }}
     annotations: {
       {{- if eq (len .Spec.Containers) 1 }}
       kubectl.kubernetes.io/default-logs-container: "{{ (index .Spec.Containers 0).Name }}",
@@ -467,4 +472,8 @@ template: |
       {{- range .Values.global.imagePullSecrets }}
       - name: {{ . }}
       {{- end }}
+    {{- end }}
+    {{- if eq (env "ENABLE_LEGACY_FSGROUP_INJECTION" "true") "true" }}
+    securityContext:
+      fsGroup: 1337
     {{- end }}

--- a/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -185,6 +185,11 @@ data:
 
     template: |
       metadata:
+        labels:
+          security.istio.io/tlsMode: {{ index .ObjectMeta.Labels `security.istio.io/tlsMode` | default "istio" }}
+          service.istio.io/canonical-name: {{ index .ObjectMeta.Labels `service.istio.io/canonical-name` | default (index .ObjectMeta.Labels `app.kubernetes.io/name`) | default (index .ObjectMeta.Labels `app`) | default .DeploymentMeta.Name }}
+          service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest" }}
+          istio.io/rev: {{ .Revision | default "default" }}
         annotations: {
           {{- if eq (len .Spec.Containers) 1 }}
           kubectl.kubernetes.io/default-logs-container: "{{ (index .Spec.Containers 0).Name }}",
@@ -652,6 +657,10 @@ data:
           {{- range .Values.global.imagePullSecrets }}
           - name: {{ . }}
           {{- end }}
+        {{- end }}
+        {{- if eq (env "ENABLE_LEGACY_FSGROUP_INJECTION" "true") "true" }}
+        securityContext:
+          fsGroup: 1337
         {{- end }}
 ---
 # Source: istiod-remote/templates/mutatingwebhook.yaml

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -1,5 +1,10 @@
 template: |
   metadata:
+    labels:
+      security.istio.io/tlsMode: {{ index .ObjectMeta.Labels `security.istio.io/tlsMode` | default "istio" }}
+      service.istio.io/canonical-name: {{ index .ObjectMeta.Labels `service.istio.io/canonical-name` | default (index .ObjectMeta.Labels `app.kubernetes.io/name`) | default (index .ObjectMeta.Labels `app`) | default .DeploymentMeta.Name }}
+      service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest" }}
+      istio.io/rev: {{ .Revision | default "default" }}
     annotations: {
       {{- if eq (len .Spec.Containers) 1 }}
       kubectl.kubernetes.io/default-logs-container: "{{ (index .Spec.Containers 0).Name }}",
@@ -467,4 +472,8 @@ template: |
       {{- range .Values.global.imagePullSecrets }}
       - name: {{ . }}
       {{- end }}
+    {{- end }}
+    {{- if eq (env "ENABLE_LEGACY_FSGROUP_INJECTION" "true") "true" }}
+    securityContext:
+      fsGroup: 1337
     {{- end }}

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -92,6 +92,7 @@ type SidecarTemplateData struct {
 	ProxyConfig    *meshconfig.ProxyConfig
 	MeshConfig     *meshconfig.MeshConfig
 	Values         map[string]interface{}
+	Revision       string
 }
 
 type Template *corev1.Pod
@@ -330,6 +331,7 @@ func RunTemplate(params InjectionParameters) (mergedPod *corev1.Pod, templatePod
 		ProxyConfig:    meshConfig.GetDefaultConfig(),
 		MeshConfig:     meshConfig,
 		Values:         values,
+		Revision:       params.revision,
 	}
 	funcMap := CreateInjectionFuncmap()
 

--- a/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -22,7 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -22,7 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -14,7 +14,7 @@ spec:
         sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hellocron
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -20,7 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -35,7 +35,7 @@ items:
         creationTimestamp: null
         labels:
           app: hello
-          istio.io/rev: ""
+          istio.io/rev: default
           security.istio.io/tlsMode: istio
           service.istio.io/canonical-name: hello
           service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/deploymentconfig-with-canonical-service-label.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig-with-canonical-service-label.yaml.injected
@@ -20,7 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: test-service-name
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -20,7 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -22,7 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -22,7 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -36,7 +36,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -22,7 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-cncf-networks.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-cncf-networks.yaml.injected
@@ -27,7 +27,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks-json.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks-json.yaml.injected
@@ -27,7 +27,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-existing-cncf-networks.yaml.injected
@@ -27,7 +27,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-image-pull-secret.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-image-pull-secret.yaml.injected
@@ -22,7 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-image-secrets-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-image-secrets-in-values.yaml.injected
@@ -22,7 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mount-mtls-certs.yaml.injected
@@ -22,7 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-mtls-not-ready.yaml.injected
@@ -22,7 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: disabled
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -23,7 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: v1
@@ -248,7 +248,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: v2

--- a/pkg/kube/inject/testdata/inject/hello-multiple-image-secrets.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-multiple-image-secrets.yaml.injected
@@ -22,7 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -23,7 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -22,7 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-no-seccontext.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-no-seccontext.yaml.injected
@@ -18,7 +18,6 @@ spec:
         prometheus.io/path: /stats/prometheus
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
-        sidecar.istio.io/enableCoreDump: "true"
         sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
@@ -97,9 +96,6 @@ spec:
           value: Kubernetes
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        - name: ISTIO_METAJSON_ANNOTATIONS
-          value: |
-            {"sidecar.istio.io/enableCoreDump":"true"}
         - name: ISTIO_META_WORKLOAD_NAME
           value: hello
         - name: ISTIO_META_OWNER
@@ -196,8 +192,6 @@ spec:
           runAsGroup: 0
           runAsNonRoot: false
           runAsUser: 0
-      securityContext:
-        fsGroup: 1337
       volumes:
       - emptyDir:
           medium: Memory

--- a/pkg/kube/inject/testdata/inject/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-noProxyHoldApplication-ProxyConfig.yaml.injected
@@ -22,7 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-probes-proxyHoldApplication-ProxyConfig.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-proxyHoldApplication-ProxyConfig.yaml.injected
@@ -22,7 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-probes-with-flag-set-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-with-flag-set-in-annotation.yaml.injected
@@ -22,7 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-probes-with-flag-unset-in-annotation.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes-with-flag-unset-in-annotation.yaml.injected
@@ -22,7 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-probes.proxyHoldsApplication.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes.proxyHoldsApplication.yaml.injected
@@ -21,7 +21,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-probes.yaml.injected
@@ -21,7 +21,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -23,7 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-readiness.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-readiness.yaml.injected
@@ -22,7 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-template-in-values.yaml.injected
@@ -22,7 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -22,7 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello.proxyHoldsApplication.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.proxyHoldsApplication.yaml.injected
@@ -22,7 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.cni.injected
@@ -26,7 +26,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -22,7 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/https-probes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/https-probes.yaml.injected
@@ -21,7 +21,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -14,7 +14,7 @@ spec:
         sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: pi
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -23,7 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -23,7 +23,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -37,7 +37,7 @@ items:
         creationTimestamp: null
         labels:
           app: hello
-          istio.io/rev: ""
+          istio.io/rev: default
           security.istio.io/tlsMode: istio
           service.istio.io/canonical-name: hello
           service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -25,7 +25,7 @@ items:
         creationTimestamp: null
         labels:
           app: hello
-          istio.io/rev: ""
+          istio.io/rev: default
           security.istio.io/tlsMode: istio
           service.istio.io/canonical-name: hello
           service.istio.io/canonical-revision: v1
@@ -249,7 +249,7 @@ items:
         creationTimestamp: null
         labels:
           app: hello
-          istio.io/rev: ""
+          istio.io/rev: default
           security.istio.io/tlsMode: istio
           service.istio.io/canonical-name: hello
           service.istio.io/canonical-revision: v2

--- a/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-container.yaml.injected
@@ -19,7 +19,7 @@ spec:
       creationTimestamp: null
       labels:
         app: app
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: app
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -22,7 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/named_port.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/named_port.yaml.injected
@@ -22,7 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/one_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/one_container.yaml.injected
@@ -22,7 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -9,7 +9,7 @@ metadata:
     sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}'
   creationTimestamp: null
   labels:
-    istio.io/rev: ""
+    istio.io/rev: default
     security.istio.io/tlsMode: istio
     service.istio.io/canonical-name: hellopod
     service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/ready_live.yaml.injected
@@ -21,7 +21,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/ready_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/ready_only.yaml.injected
@@ -22,7 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -19,7 +19,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -18,7 +18,7 @@ spec:
       creationTimestamp: null
       labels:
         app: nginx
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: nginx
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/resource_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/resource_annotations.yaml.injected
@@ -24,7 +24,7 @@ spec:
       creationTimestamp: null
       labels:
         app: resource
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: resource
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/startup_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/startup_live.yaml.injected
@@ -21,7 +21,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/startup_only.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/startup_only.yaml.injected
@@ -22,7 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/startup_ready_live.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/startup_ready_live.yaml.injected
@@ -21,7 +21,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -22,7 +22,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -25,7 +25,7 @@ spec:
       creationTimestamp: null
       labels:
         app: status
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: status
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/status_annotations_zeroport.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_annotations_zeroport.yaml.injected
@@ -25,7 +25,7 @@ spec:
       creationTimestamp: null
       labels:
         app: status
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: status
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -20,7 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: status
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: status
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -24,7 +24,7 @@ spec:
       creationTimestamp: null
       labels:
         app: traffic
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: traffic
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -24,7 +24,7 @@ spec:
       creationTimestamp: null
       labels:
         app: traffic
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: traffic
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -31,7 +31,7 @@ spec:
       creationTimestamp: null
       labels:
         app: traffic
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: traffic
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -20,7 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: traffic
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: traffic
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -20,7 +20,7 @@ spec:
       creationTimestamp: null
       labels:
         app: traffic
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: traffic
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/two_container.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/two_container.yaml.injected
@@ -21,7 +21,7 @@ spec:
       creationTimestamp: null
       labels:
         app: hello
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: hello
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/testdata/inject/user-volume.yaml.injected
+++ b/pkg/kube/inject/testdata/inject/user-volume.yaml.injected
@@ -24,7 +24,7 @@ spec:
       creationTimestamp: null
       labels:
         app: user-volume
-        istio.io/rev: ""
+        istio.io/rev: default
         security.istio.io/tlsMode: istio
         service.istio.io/canonical-name: user-volume
         service.istio.io/canonical-revision: latest

--- a/pkg/kube/inject/webhook_test.go
+++ b/pkg/kube/inject/webhook_test.go
@@ -862,16 +862,6 @@ func TestRunAndServe(t *testing.T) {
 	validPatch := []byte(`[
 {
     "op": "add",
-    "path": "/metadata/labels",
-    "value": {
-        "istio.io/rev": "",
-        "security.istio.io/tlsMode": "istio",
-        "service.istio.io/canonical-name": "test",
-        "service.istio.io/canonical-revision": "latest"
-    }
-},
-{
-    "op": "add",
     "path": "/metadata/annotations",
     "value": {
         "prometheus.io/path": "/stats/prometheus",
@@ -906,13 +896,6 @@ func TestRunAndServe(t *testing.T) {
     "value": {
         "name": "istio-proxy",
         "resources": {}
-    }
-},
-{
-    "op": "add",
-    "path": "/spec/securityContext",
-    "value": {
-        "fsGroup": 1337
     }
 },
 {


### PR DESCRIPTION
Depends on https://github.com/istio/istio/pull/29105

    When the logic is hard coded in the go code, its misleading to users and
    doesn't allow customization. this will be critical to allow gateway
    injection
