### PR TITLE
Remove duplicate istioNamespace definitions in values.yaml

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -201,9 +201,6 @@ global:
     #   cpu: 100m
     #   memory: 128Mi
 
-  # Used to locate istiod.
-  istioNamespace: istio-system
-
   # Default hub for Istio images.
   # Releases are published to docker hub under 'istio' project.
   # Dev builds from prow are on gcr.io

--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -174,8 +174,6 @@ global:
       # limits:
       #   cpu: 100m
       #   memory: 128Mi
-  # Used to locate istiod.
-  istioNamespace: istio-system
   # Default hub for Istio images.
   # Releases are published to docker hub under 'istio' project.
   # Dev builds from prow are on gcr.io


### PR DESCRIPTION
Default for `global.istioNamespace` set twice in `istiod-remote/values.yaml` and `istio-discovery/values.yaml`, this change removes the duplicates.

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
