### PR TITLE
Add ErrorOrNil to multierror append in cleanup to avoid extraneous error

### DIFF
--- a/pkg/test/framework/scope.go
+++ b/pkg/test/framework/scope.go
@@ -153,7 +153,7 @@ func (s *scope) done(nocleanup bool) error {
 		scopes.Framework.Debugf("Begin cleaning up %s", name)
 		if e := c.Close(); e != nil {
 			scopes.Framework.Debugf("Error cleaning up %s: %v", name, e)
-			err = multierror.Append(err, e)
+			err = multierror.Append(err, e).ErrorOrNil()
 		}
 		scopes.Framework.Debugf("Cleanup complete for %s", name)
 	}


### PR DESCRIPTION
Before this change we'd get an error like

`2020-11-23T21:30:35.889236Z     error   tf      Error during close: 0 errors occurred:`
                                                                                                                                                 
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
