### PR TITLE
Remove dead SDS debug code

### DIFF
--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -109,9 +109,6 @@ type Options struct {
 	// Recycle job running interval (to clean up staled sds client connections).
 	RecycleInterval time.Duration
 
-	// Debug server port from which node_agent serves SDS configuration dumps
-	DebugPort int
-
 	// EnableWorkloadSDS indicates whether node agent works as SDS server for workload proxies.
 	EnableWorkloadSDS bool
 

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -17,7 +17,6 @@ package sds
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -133,24 +132,6 @@ type sdsservice struct {
 	credFetcher security.CredFetcher
 }
 
-// ClientDebug represents a single SDS connection to the ndoe agent
-type ClientDebug struct {
-	ConnectionID string `json:"connection_id"`
-	ProxyID      string `json:"proxy"`
-	ResourceName string `json:"resource_name"`
-
-	// fields from secret item
-	CertificateChain string `json:"certificate_chain"`
-	RootCert         string `json:"root_cert"`
-	CreatedTime      string `json:"created_time"`
-	ExpireTime       string `json:"expire_time"`
-}
-
-// Debug represents all clients connected to this node agent endpoint and their supplied secrets
-type Debug struct {
-	Clients []ClientDebug `json:"clients"`
-}
-
 // newSDSService creates Secret Discovery Service which implements envoy SDS API.
 func newSDSService(st security.SecretManager,
 	secOpt *security.Options,
@@ -179,42 +160,6 @@ func newSDSService(st security.SecretManager,
 // register adds the SDS handle to the grpc server
 func (s *sdsservice) register(rpcs *grpc.Server) {
 	sds.RegisterSecretDiscoveryServiceServer(rpcs, s)
-}
-
-// DebugInfo serializes the current sds client data into JSON for the debug endpoint
-func (s *sdsservice) DebugInfo() (string, error) {
-	sdsClientsMutex.RLock()
-	defer sdsClientsMutex.RUnlock()
-	clientDebug := make([]ClientDebug, 0)
-	for connKey, conn := range sdsClients {
-		// it's possible for the connection to be established without an instantiated secret
-		if conn.secret == nil {
-			continue
-		}
-
-		conn.mutex.RLock()
-		c := ClientDebug{
-			ConnectionID:     connKey.ConnectionID,
-			ProxyID:          conn.proxyID,
-			ResourceName:     conn.ResourceName,
-			CertificateChain: string(conn.secret.CertificateChain),
-			RootCert:         string(conn.secret.RootCert),
-			CreatedTime:      conn.secret.CreatedTime.Format(time.RFC3339),
-			ExpireTime:       conn.secret.ExpireTime.Format(time.RFC3339),
-		}
-		clientDebug = append(clientDebug, c)
-		conn.mutex.RUnlock()
-	}
-
-	debug := Debug{
-		Clients: clientDebug,
-	}
-	debugJSON, err := json.MarshalIndent(debug, " ", "	")
-	if err != nil {
-		return "", err
-	}
-
-	return string(debugJSON), nil
 }
 
 func (s *sdsservice) DeltaSecrets(stream sds.SecretDiscoveryService_DeltaSecretsServer) error {

--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -16,7 +16,6 @@ package sds
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"net/http"
 	"time"
@@ -33,7 +32,6 @@ import (
 
 const (
 	// base HTTP route for debug endpoints
-	debugBase     = "/debug"
 	maxStreams    = 100000
 	maxRetryTimes = 5
 )
@@ -63,9 +61,6 @@ func NewServer(options *ca2.Options, workloadSecretCache ca2.SecretManager) (*Se
 
 	version.Info.RecordComponentBuildTag("citadel_agent")
 
-	if options.DebugPort > 0 {
-		s.initDebugServer(options.DebugPort)
-	}
 	return s, nil
 }
 
@@ -102,37 +97,6 @@ func NewPlugins(in []string) []ca2.TokenExchanger {
 		}
 	}
 	return plugins
-}
-
-func (s *Server) initDebugServer(port int) {
-	mux := http.NewServeMux()
-	mux.HandleFunc(fmt.Sprintf("%s/sds/workload", debugBase), s.workloadSds.debugHTTPHandler)
-	s.debugServer = &http.Server{
-		Addr:    fmt.Sprintf("127.0.0.1:%d", port),
-		Handler: mux,
-	}
-
-	go func() {
-		err := s.debugServer.ListenAndServe()
-		sdsServiceLog.Errorf("debug server failure: %s", err)
-	}()
-}
-
-func (s *sdsservice) debugHTTPHandler(w http.ResponseWriter, req *http.Request) {
-	w.Header().Add("Content-Type", "application/json")
-
-	workloadJSON, err := s.DebugInfo()
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		failureMessage := fmt.Sprintf("debug endpoint failure: %s", err)
-		if _, err := w.Write([]byte(failureMessage)); err != nil {
-			sdsServiceLog.Errorf("debug endpoint failed to write error response: %s", err)
-		}
-		return
-	}
-	if _, err := w.Write([]byte(workloadJSON)); err != nil {
-		sdsServiceLog.Errorf("debug endpoint failed to write response: %s", err)
-	}
 }
 
 func (s *Server) initWorkloadSdsService(options *ca2.Options) error { //nolint: unparam


### PR DESCRIPTION
This is obsolete with istio-agent SDS, we now have metrics integrated
into agent, and debug integrated in istioctl. This code was never used.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.