### PR TITLE
nil check to fix mock registry crash

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -115,6 +115,9 @@ func (s *Server) initConfigController(args *PilotArgs) error {
 }
 
 func (s *Server) initK8SConfigStore(args *PilotArgs) error {
+	if s.kubeClient == nil {
+		return nil
+	}
 	configController, err := s.makeKubeConfigController(args)
 	if err != nil {
 		return err


### PR DESCRIPTION
https://github.com/istio/istio/blob/887439cbbfde1b1af62cb2a8ac0cc654ea36afec/pilot/pkg/bootstrap/server.go#L479

kubeClient is only set if we have a kube registry. We need the client for the crdclient – in "Mock" mode we will crash

 fixes https://github.com/istio/istio/issues/29048