### PR TITLE
istioctl upgrade: use app label for components

### DIFF
--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -441,7 +441,8 @@ func (client *Client) GetIstioVersions(namespace string) ([]ComponentVersion, er
 	var errs util.Errors
 	var res []ComponentVersion
 	for _, pod := range pods.Items {
-		component := pod.Labels["istio"]
+		// label for components app: istiod, istio-ingressgateway, istio-egressgateway
+		component := pod.Labels["app"]
 
 		switch component {
 		case "statsd-prom-bridge":


### PR DESCRIPTION
Part of https://github.com/istio/istio/issues/27013 and will close https://github.com/istio/istio/issues/27013

Before:

```
[istio-1.8.0] $ istioctl install
```
```
[istio-master] $ ./out/linux_amd64/istioctl upgrade --set hub=gcr.io/istio-testing -d manifests/

Control Plane - ingressgateway pod - istio-ingressgateway-668bb75ddc-n6tk8 - version: 1.9.0
Control Plane - pilot pod - istiod-567dc84cc6-4q6fg - version: 1.9.0
```

After:
```
[istio-master] $ ./out/linux_amd64/istioctl upgrade --set hub=gcr.io/istio-testing -d manifests/
2020-11-24T11:23:12.882651Z     info    proto: tag has too few fields: "-"
Control Plane - istio-ingressgateway pod - istio-ingressgateway-848588d9cb-2dr4b - version: 1.8.0
Control Plane - istiod pod - istiod-767798f6fd-glzj9 - version: 1.8.0

Upgrade version check passed: 1.8.0 -> 1.9.0.

```

