### PR TITLE
init k8s config store when pilot integrate mock registry in k8s envir…

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -476,7 +476,7 @@ func (s *Server) initKubeClient(args *PilotArgs) error {
 					hasK8SConfigStore = true
 				}
 			}
-		}  else if args.RegistryOptions.KubeConfig != "" {
+		} else if args.RegistryOptions.KubeConfig != "" {
 			hasK8SConfigStore = true
 		}
 	}

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -468,11 +468,16 @@ func (s *Server) initKubeClient(args *PilotArgs) error {
 			if err != nil {
 				return fmt.Errorf("failed reading mesh config: %v", err)
 			}
+			if len(meshConfig.ConfigSources) == 0 && args.RegistryOptions.KubeConfig != "" {
+				hasK8SConfigStore = true
+			}
 			for _, cs := range meshConfig.ConfigSources {
 				if cs.Address == "k8s://" {
 					hasK8SConfigStore = true
 				}
 			}
+		}  else if args.RegistryOptions.KubeConfig != "" {
+			hasK8SConfigStore = true
 		}
 	}
 

--- a/pilot/pkg/serviceregistry/mock/discovery.go
+++ b/pilot/pkg/serviceregistry/mock/discovery.go
@@ -245,7 +245,7 @@ func (sd *ServiceDiscovery) GetIstioServiceAccounts(svc *model.Service, ports []
 
 func (sd *ServiceDiscovery) NetworkGateways() map[string][]*model.Gateway {
 	// TODO use logic from kube controller if needed
-	panic("implement me")
+	return map[string][]*model.Gateway{}
 }
 
 type Controller struct{}


### PR DESCRIPTION

Pilot should init k8s config store in k8s environment when istio discovery service flag --registries=Mock is set. 
fixes #29146


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[X ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure