### PR TITLE
Add a type ConfigSourceScheme to make code clean and avoid hard code

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -17,7 +17,6 @@ package bootstrap
 import (
 	"fmt"
 	"net/url"
-	"strings"
 	"time"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -38,10 +37,20 @@ import (
 	"istio.io/pkg/log"
 )
 
+// URL schemes supported by the config store
+type ConfigSourceAddressScheme string
+
 const (
-	// URL types supported by the config store
+	// fs:///PATH will load local files. This replaces --configDir.
 	// example fs:///tmp/configroot
-	fsScheme = "fs"
+	// PATH can be mounted from a config map or volume
+	File ConfigSourceAddressScheme = "fs"
+	// xds://ADDRESS - load XDS-over-MCP sources
+	// example xds://127.0.0.1:49133
+	XDS ConfigSourceAddressScheme = "xds"
+	// k8s:// - load in-cluster k8s controller
+	// example k8s://
+	Kubernetes ConfigSourceAddressScheme = "k8s"
 )
 
 // initConfigController creates the config controller in the pilotConfig.
@@ -134,43 +143,27 @@ func (s *Server) initK8SConfigStore(args *PilotArgs) error {
 
 // initConfigSources will process mesh config 'configSources' and initialize
 // associated configs.
-//
-// - fs:///PATH will load local files. This replaces --configDir.
-//   PATH can be mounted from a config map or volume
-//
-// - k8s:// - load in-cluster k8s controller.
-//
-// - xds://ADDRESS - load XDS-over-MCP sources
-//
-// -
 func (s *Server) initConfigSources(args *PilotArgs) (err error) {
 	for _, configSource := range s.environment.Mesh().ConfigSources {
-		if strings.Contains(configSource.Address, fsScheme+"://") {
-			srcAddress, err := url.Parse(configSource.Address)
-			if err != nil {
-				return fmt.Errorf("invalid config URL %s %v", configSource.Address, err)
-			}
-			if srcAddress.Scheme == fsScheme {
-				if srcAddress.Path == "" {
-					return fmt.Errorf("invalid fs config URL %s, contains no file path", configSource.Address)
-				}
-				store := memory.MakeSkipValidation(collections.Pilot, false)
-				configController := memory.NewController(store)
-
-				err := s.makeFileMonitor(srcAddress.Path, args.RegistryOptions.KubeOptions.DomainSuffix, configController)
-				if err != nil {
-					return err
-				}
-				s.ConfigStores = append(s.ConfigStores, configController)
-				continue
-			}
+		srcAddress, err := url.Parse(configSource.Address)
+		if err != nil {
+			return fmt.Errorf("invalid config URL %s %v", configSource.Address, err)
 		}
-		if strings.Contains(configSource.Address, "xds://") {
-			srcAddress, err := url.Parse(configSource.Address)
-			if err != nil {
-				return fmt.Errorf("invalid XDS config URL %s %v", configSource.Address, err)
+		scheme := ConfigSourceAddressScheme(srcAddress.Scheme)
+		switch scheme {
+		case File:
+			if srcAddress.Path == "" {
+				return fmt.Errorf("invalid fs config URL %s, contains no file path", configSource.Address)
 			}
-			// TODO: use a query param or schema to specify insecure
+			store := memory.MakeSkipValidation(collections.Pilot, false)
+			configController := memory.NewController(store)
+
+			err := s.makeFileMonitor(srcAddress.Path, args.RegistryOptions.KubeOptions.DomainSuffix, configController)
+			if err != nil {
+				return err
+			}
+			s.ConfigStores = append(s.ConfigStores, configController)
+		case XDS:
 			xdsMCP, err := adsc.New(srcAddress.Host, &adsc.Config{
 				Meta: model.NodeMetadata{
 					Generator: "api",
@@ -189,13 +182,7 @@ func (s *Server) initConfigSources(args *PilotArgs) (err error) {
 			}
 			s.ConfigStores = append(s.ConfigStores, configController)
 			log.Warn("Started XDS config ", s.ConfigStores)
-			continue
-		}
-		if strings.Contains(configSource.Address, "k8s://") {
-			srcAddress, err := url.Parse(configSource.Address)
-			if err != nil {
-				return fmt.Errorf("invalid K8S config URL %s %v", configSource.Address, err)
-			}
+		case Kubernetes:
 			if srcAddress.Path == "" || srcAddress.Path == "/" {
 				err2 := s.initK8SConfigStore(args)
 				if err2 != nil {
@@ -208,9 +195,9 @@ func (s *Server) initConfigSources(args *PilotArgs) (err error) {
 				// TODO: handle k8s:// scheme for remote cluster. Use same mechanism as service registry,
 				// using the cluster name as key to match a secret.
 			}
-			continue
+		default:
+			log.Warnf("Ignoring unsupported config source: %v", configSource.Address)
 		}
-		log.Warnf("Ignoring unsupported config source: %v", configSource.Address)
 	}
 	return nil
 }

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -469,7 +469,7 @@ func (s *Server) initKubeClient(args *PilotArgs) error {
 				return fmt.Errorf("failed reading mesh config: %v", err)
 			}
 			for _, cs := range meshConfig.ConfigSources {
-				if cs.Address == "k8s://" {
+				if cs.Address == string(Kubernetes)+"://" {
 					hasK8SConfigStore = true
 				}
 			}

--- a/releasenotes/notes/config-source-scheme.yaml
+++ b/releasenotes/notes/config-source-scheme.yaml
@@ -1,6 +1,0 @@
-apiVersion: release-notes/v2
-kind: feature
-area: networking
-releaseNotes:
-  - |
-    **Added** a type "ConfigSourceScheme" to avoid hard code in the process of initializing config sources and make code clean.

--- a/releasenotes/notes/config-source-scheme.yaml
+++ b/releasenotes/notes/config-source-scheme.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+releaseNotes:
+  - |
+    **Added** a type "ConfigSourceScheme" to avoid hard code in the process of initializing config sources and make code clean.


### PR DESCRIPTION
Now we choose a type of config source by the following code.
```
// for file
strings.Contains(configSource.Address, fsScheme+"://")
// for xds server
strings.Contains(configSource.Address, "xds://")
// for k8s controller
strings.Contains(configSource.Address, "k8s://")
```
Since the scheme is always in the prefix of the url, we should use `strings.HasPrefix` instead of `strings.Contains` when we initial config sources of Pilot server. In addition, the method `url.Parse` appears once in each conditional branch, and it appears 3 times in total. In order to make code clean and avoid hard code, we introduce the new type `ConfigSourceScheme`.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
