### PR TITLE
merge labels and annotations from workloadgroup.spec.metadata

### DIFF
--- a/pilot/pkg/xds/workloadentry.go
+++ b/pilot/pkg/xds/workloadentry.go
@@ -258,7 +258,12 @@ func workloadEntryFromGroup(name string, proxy *model.Proxy, groupCfg *config.Co
 	entry.Address = proxy.IPAddresses[0]
 	// TODO move labels out of entry
 	// node metadata > WorkloadGroup.Metadata > WorkloadGroup.Template
-	entry.Labels = mergeLabels(entry.Labels, group.Metadata.Labels, proxy.Metadata.Labels)
+	if group.Metadata != nil && group.Metadata.Labels != nil {
+		entry.Labels = mergeLabels(entry.Labels, group.Metadata.Labels)
+	}
+	if proxy.Metadata != nil && proxy.Metadata.Labels != nil {
+		entry.Labels = mergeLabels(entry.Labels, proxy.Metadata.Labels)
+	}
 
 	if proxy.Metadata.Network != "" {
 		entry.Network = proxy.Metadata.Network

--- a/pilot/pkg/xds/workloadentry.go
+++ b/pilot/pkg/xds/workloadentry.go
@@ -265,6 +265,11 @@ func workloadEntryFromGroup(name string, proxy *model.Proxy, groupCfg *config.Co
 		entry.Labels = mergeLabels(entry.Labels, proxy.Metadata.Labels)
 	}
 
+	annotations := map[string]string{AutoRegistrationGroupAnnotation: groupCfg.Name}
+	if group.Metadata != nil && group.Metadata.Annotations != nil {
+		annotations = mergeLabels(annotations, group.Metadata.Annotations)
+	}
+
 	if proxy.Metadata.Network != "" {
 		entry.Network = proxy.Metadata.Network
 	}
@@ -277,10 +282,7 @@ func workloadEntryFromGroup(name string, proxy *model.Proxy, groupCfg *config.Co
 			Name:             name,
 			Namespace:        proxy.Metadata.Namespace,
 			Labels:           entry.Labels,
-			Annotations: mergeLabels(
-				map[string]string{AutoRegistrationGroupAnnotation: groupCfg.Name},
-				group.Metadata.Annotations,
-			),
+			Annotations:      annotations,
 			OwnerReferences: []metav1.OwnerReference{{
 				APIVersion: groupCfg.GroupVersionKind.GroupVersion(),
 				Kind:       groupCfg.GroupVersionKind.Kind,

--- a/pilot/pkg/xds/workloadentry.go
+++ b/pilot/pkg/xds/workloadentry.go
@@ -257,7 +257,8 @@ func workloadEntryFromGroup(name string, proxy *model.Proxy, groupCfg *config.Co
 	entry := group.Template.DeepCopy()
 	entry.Address = proxy.IPAddresses[0]
 	// TODO move labels out of entry
-	entry.Labels = mergeLabels(entry.Labels, proxy.Metadata.Labels)
+	// node metadata > WorkloadGroup.Metadata > WorkloadGroup.Template
+	entry.Labels = mergeLabels(entry.Labels, group.Metadata.Labels, proxy.Metadata.Labels)
 
 	if proxy.Metadata.Network != "" {
 		entry.Network = proxy.Metadata.Network
@@ -271,7 +272,10 @@ func workloadEntryFromGroup(name string, proxy *model.Proxy, groupCfg *config.Co
 			Name:             name,
 			Namespace:        proxy.Metadata.Namespace,
 			Labels:           entry.Labels,
-			Annotations:      map[string]string{AutoRegistrationGroupAnnotation: groupCfg.Name},
+			Annotations: mergeLabels(
+				map[string]string{AutoRegistrationGroupAnnotation: groupCfg.Name},
+				group.Metadata.Annotations,
+			),
 			OwnerReferences: []metav1.OwnerReference{{
 				APIVersion: groupCfg.GroupVersionKind.GroupVersion(),
 				Kind:       groupCfg.GroupVersionKind.Kind,
@@ -290,7 +294,7 @@ func mergeLabels(labels ...map[string]string) map[string]string {
 	if len(labels) == 0 {
 		return map[string]string{}
 	}
-	out := make(map[string]string, len(labels)*len(labels[1]))
+	out := make(map[string]string, len(labels)*len(labels[0]))
 	for _, lm := range labels {
 		for k, v := range lm {
 			out[k] = v

--- a/pilot/pkg/xds/workloadentry_test.go
+++ b/pilot/pkg/xds/workloadentry_test.go
@@ -239,7 +239,7 @@ func TestWorkloadEntryFromGroup(t *testing.T) {
 			}},
 		},
 		Spec: &v1alpha3.WorkloadEntry{
-			Address: "1.2.3.4",
+			Address: "10.0.0.1",
 			Ports: map[string]uint32{
 				"http": 80,
 			},

--- a/pilot/pkg/xds/workloadentry_test.go
+++ b/pilot/pkg/xds/workloadentry_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-multierror"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubetypes "k8s.io/apimachinery/pkg/types"
 

--- a/pilot/pkg/xds/workloadentry_test.go
+++ b/pilot/pkg/xds/workloadentry_test.go
@@ -20,7 +20,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-multierror"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubetypes "k8s.io/apimachinery/pkg/types"
 
 	"istio.io/api/meta/v1alpha1"
 	"istio.io/api/networking/v1alpha3"
@@ -184,6 +188,73 @@ func TestUpdateHealthCondition(t *testing.T) {
 		})
 		checkHealthOrFail(t, store, p, false)
 	})
+}
+
+func TestWorkloadEntryFromGroup(t *testing.T) {
+	group := config.Config{
+		Meta: config.Meta{
+			GroupVersionKind: gvk.WorkloadGroup,
+			Namespace:        "a",
+			Name:             "wg-a",
+			Labels: map[string]string{
+				"grouplabel": "notonentry",
+			},
+		},
+		Spec: &v1alpha3.WorkloadGroup{
+			Metadata: &v1alpha3.WorkloadGroup_ObjectMeta{
+				Labels:      map[string]string{"foo": "bar"},
+				Annotations: map[string]string{"foo": "bar"},
+			},
+			Template: &v1alpha3.WorkloadEntry{
+				Ports:          map[string]uint32{"http": 80},
+				Labels:         map[string]string{"app": "a"},
+				Weight:         1,
+				ServiceAccount: "sa-a",
+			},
+		},
+	}
+	proxy := fakeProxy("1.2.3.4", group, "nw1")
+
+	wantLabels := map[string]string{
+		"app":   "a",   // from WorkloadEntry template
+		"foo":   "bar", // from WorkloadGroup.Metadata
+		"merge": "me",  // from Node metadata
+	}
+
+	want := config.Config{
+		Meta: config.Meta{
+			GroupVersionKind: gvk.WorkloadEntry,
+			Name:             "test-we",
+			Namespace:        proxy.Metadata.Namespace,
+			Labels:           wantLabels,
+			Annotations: map[string]string{
+				AutoRegistrationGroupAnnotation: group.Name,
+				"foo":                           "bar",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: group.GroupVersionKind.GroupVersion(),
+				Kind:       group.GroupVersionKind.Kind,
+				Name:       group.Name,
+				UID:        kubetypes.UID(group.UID),
+				Controller: &workloadGroupIsController,
+			}},
+		},
+		Spec: &v1alpha3.WorkloadEntry{
+			Address: "1.2.3.4",
+			Ports: map[string]uint32{
+				"http": 80,
+			},
+			Labels:         wantLabels,
+			Network:        "nw1",
+			Weight:         1,
+			ServiceAccount: "sa-a",
+		},
+	}
+
+	got := workloadEntryFromGroup("test-we", proxy, &group)
+	if diff := cmp.Diff(got, &want); diff != "" {
+		t.Errorf(diff)
+	}
 }
 
 func setup(t *testing.T) (*InternalGen, *InternalGen, model.ConfigStoreCache) {

--- a/pilot/pkg/xds/workloadentry_test.go
+++ b/pilot/pkg/xds/workloadentry_test.go
@@ -213,7 +213,7 @@ func TestWorkloadEntryFromGroup(t *testing.T) {
 			},
 		},
 	}
-	proxy := fakeProxy("1.2.3.4", group, "nw1")
+	proxy := fakeProxy("10.0.0.1", group, "nw1")
 
 	wantLabels := map[string]string{
 		"app":   "a",   // from WorkloadEntry template


### PR DESCRIPTION
Previously we only used WorkloadGroup.Spec.Template.Labels + the labels from the Node metadata sent in the XDS request. 

This includes both the labels and annotations from WorkloadGroup.Spec.Metadata in the generated WorkloadEntries to fix #29151. 