### PR TITLE
Cleanup security/SDS interfaces

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -256,7 +256,6 @@ var (
 				secOpts.CAEndpoint = proxyConfig.DiscoveryAddress
 			}
 
-			secOpts.EnableWorkloadSDS = true
 			secOpts.CAProviderName = caProviderEnv
 
 			secOpts.TrustDomain = trustDomainEnv

--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -59,11 +59,6 @@ func (sc *clientSecrets) GenerateSecret(ctx context.Context, connectionID, resou
 	return &sc.SecretItem, nil
 }
 
-// ShouldWaitForGatewaySecret indicates whether a valid gateway secret is expected.
-func (sc *clientSecrets) ShouldWaitForGatewaySecret(connectionID, resourceName, token string, fileMountedCertsOnly bool) bool {
-	return false
-}
-
 // TODO: must fix SDS, it uses existence to detect it's an ACK !!
 func (sc *clientSecrets) SecretExist(connectionID, resourceName, token, version string) bool {
 	return false

--- a/security/pkg/nodeagent/cache/helper.go
+++ b/security/pkg/nodeagent/cache/helper.go
@@ -38,9 +38,3 @@ func cacheLogPrefix(resourceName string) string {
 	lPrefix := fmt.Sprintf("resource:%s", resourceName)
 	return lPrefix
 }
-
-// cacheLogPrefix returns a unified log prefix.
-func cacheLogPrefixWithReqID(resourceName, reqID string) string {
-	lPrefix := fmt.Sprintf("resource:%s request:%s", resourceName, reqID)
-	return lPrefix
-}

--- a/security/pkg/nodeagent/cache/mock/secretcache_mock.go
+++ b/security/pkg/nodeagent/cache/mock/secretcache_mock.go
@@ -70,8 +70,7 @@ func NewMockCAClient(errors uint64, certLifetime time.Duration) (*CAClient, erro
 }
 
 // CSRSign returns the certificate or errors depending on the settings.
-func (c *CAClient) CSRSign(ctx context.Context, reqID string, csrPEM []byte, exchangedToken string,
-	certValidTTLInSec int64) ([]string /*PEM-encoded certificate chain*/, error) {
+func (c *CAClient) CSRSign(ctx context.Context, csrPEM []byte, token string, certValidTTLInSec int64) ([]string, error) {
 	c.errorCountMutex.Lock()
 	if c.errorCount < c.errors {
 		c.errorCount++

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -29,8 +29,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/google/uuid"
-
 	pilotmodel "istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/mcp/status"
 	"istio.io/istio/pkg/security"
@@ -781,10 +779,7 @@ func (sc *SecretCache) sendRetriableRequest(ctx context.Context, csrPEM []byte,
 	}
 	retryBackoffInMS := int64(firstRetryBackOffInMilliSec)
 
-	// Assign a unique request ID for all the retries.
-	reqID := uuid.New().String()
-
-	logPrefix := cacheLogPrefixWithReqID(connKey.ResourceName, reqID)
+	logPrefix := cacheLogPrefix(connKey.ResourceName)
 	startTime := time.Now()
 	var certChainPEM []string
 	exchangedToken := providedExchangedToken
@@ -801,8 +796,7 @@ func (sc *SecretCache) sendRetriableRequest(ctx context.Context, csrPEM []byte,
 				// if CSR request is without token, set the token to empty
 				exchangedToken = ""
 			}
-			certChainPEM, err = sc.fetcher.CaClient.CSRSign(
-				ctx, reqID, csrPEM, exchangedToken, int64(sc.configOptions.SecretTTL.Seconds()))
+			certChainPEM, err = sc.fetcher.CaClient.CSRSign(ctx, csrPEM, exchangedToken, int64(sc.configOptions.SecretTTL.Seconds()))
 		} else {
 			requestErrorString = fmt.Sprintf("%s TokExch", logPrefix)
 			p := sc.configOptions.TokenExchangers[0]

--- a/security/pkg/nodeagent/caclient/providers/citadel/client.go
+++ b/security/pkg/nodeagent/caclient/providers/citadel/client.go
@@ -77,8 +77,7 @@ func NewCitadelClient(endpoint string, tls bool, rootCert []byte, clusterID stri
 }
 
 // CSR Sign calls Citadel to sign a CSR.
-func (c *citadelClient) CSRSign(ctx context.Context, reqID string, csrPEM []byte, token string,
-	certValidTTLInSec int64) ([]string /*PEM-encoded certificate chain*/, error) {
+func (c *citadelClient) CSRSign(ctx context.Context, csrPEM []byte, token string, certValidTTLInSec int64) ([]string /*PEM-encoded certificate chain*/, error) {
 	req := &pb.IstioCertificateRequest{
 		Csr:              string(csrPEM),
 		ValidityDuration: certValidTTLInSec,

--- a/security/pkg/nodeagent/caclient/providers/citadel/client_test.go
+++ b/security/pkg/nodeagent/caclient/providers/citadel/client_test.go
@@ -100,7 +100,7 @@ func TestCitadelClient(t *testing.T) {
 			t.Errorf("Test case [%s]: failed to create ca client: %v", id, err)
 		}
 
-		resp, err := cli.CSRSign(context.Background(), "12345678-1234-1234-1234-123456789012", []byte{01}, fakeToken, 1)
+		resp, err := cli.CSRSign(context.Background(), []byte{01}, fakeToken, 1)
 		if err != nil {
 			if err.Error() != tc.expectedErr {
 				t.Errorf("Test case [%s]: error (%s) does not match expected error (%s)", id, err.Error(), tc.expectedErr)
@@ -199,7 +199,7 @@ func TestCitadelClientWithDifferentTypeToken(t *testing.T) {
 				if err != nil {
 					return fmt.Errorf("test case [%s]: failed to create ca client: %v", id, err)
 				}
-				resp, err := cli.CSRSign(context.Background(), "12345678-1234-1234-1234-123456789012", []byte{01}, tc.token, 1)
+				resp, err := cli.CSRSign(context.Background(), []byte{01}, tc.token, 1)
 				if err != nil {
 					if err.Error() != tc.expectedErr {
 						return fmt.Errorf("test case [%s]: error (%s) does not match expected error (%s)", id, err.Error(), tc.expectedErr)

--- a/security/pkg/nodeagent/caclient/providers/google/client.go
+++ b/security/pkg/nodeagent/caclient/providers/google/client.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/golang/protobuf/ptypes/duration"
+	"github.com/google/uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
@@ -79,10 +80,9 @@ func NewGoogleCAClient(endpoint string, tls bool) (security.Client, error) {
 }
 
 // CSR Sign calls Google CA to sign a CSR.
-func (cl *googleCAClient) CSRSign(ctx context.Context, reqID string, csrPEM []byte, token string,
-	certValidTTLInSec int64) ([]string /*PEM-encoded certificate chain*/, error) {
+func (cl *googleCAClient) CSRSign(ctx context.Context, csrPEM []byte, token string, certValidTTLInSec int64) ([]string, error) {
 	req := &gcapb.MeshCertificateRequest{
-		RequestId: reqID,
+		RequestId: uuid.New().String(),
 		Csr:       string(csrPEM),
 		Validity:  &duration.Duration{Seconds: certValidTTLInSec},
 	}

--- a/security/pkg/nodeagent/caclient/providers/google/client_test.go
+++ b/security/pkg/nodeagent/caclient/providers/google/client_test.go
@@ -72,7 +72,7 @@ func TestGoogleCAClient(t *testing.T) {
 			t.Errorf("Test case [%s]: failed to create ca client: %v", id, err)
 		}
 
-		resp, err := cli.CSRSign(context.Background(), "12345678-1234-1234-1234-123456789012", []byte{01}, fakeToken, 1)
+		resp, err := cli.CSRSign(context.Background(), []byte{01}, fakeToken, 1)
 		if err != nil {
 			if err.Error() != tc.expectedErr {
 				t.Errorf("Test case [%s]: error (%s) does not match expected error (%s)", id, err.Error(), tc.expectedErr)

--- a/security/pkg/nodeagent/sds/sds_stream_test.go
+++ b/security/pkg/nodeagent/sds/sds_stream_test.go
@@ -312,10 +312,6 @@ func (ms *mockIngressGatewaySecretStore) DeleteSecret(conID, resourceName string
 	ms.secrets.Delete(key)
 }
 
-func (ms *mockIngressGatewaySecretStore) ShouldWaitForGatewaySecret(connectionID, resourceName, token string, fileMountedCertsOnly bool) bool {
-	return false
-}
-
 // StartStreamTest starts SDS server and checks SDS connectivity.
 func StartStreamTest(t *testing.T) *StreamSetup {
 	s := &StreamSetup{t: t}
@@ -347,9 +343,8 @@ func StartStreamTest(t *testing.T) *StreamSetup {
 
 func createStreamSDSServer(t *testing.T, socket string) (*Server, *mockIngressGatewaySecretStore) {
 	arg := security.Options{
-		EnableWorkloadSDS: true,
-		RecycleInterval:   100 * time.Second,
-		WorkloadUDSPath:   socket,
+		RecycleInterval: 100 * time.Second,
+		WorkloadUDSPath: socket,
 	}
 	st := &mockIngressGatewaySecretStore{
 		checkToken: false,

--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -140,9 +140,8 @@ func setupSDS(t *testing.T) *TestServer {
 		expectedToken: fakeToken1,
 	}
 	opts := &ca2.Options{
-		WorkloadUDSPath:   fmt.Sprintf("/tmp/workload_gotest%s.sock", string(uuid.NewUUID())),
-		EnableWorkloadSDS: true,
-		RecycleInterval:   time.Second * 30,
+		WorkloadUDSPath: fmt.Sprintf("/tmp/workload_gotest%s.sock", string(uuid.NewUUID())),
+		RecycleInterval: time.Second * 30,
 	}
 	server, err := NewServer(opts, st)
 	if err != nil {
@@ -289,10 +288,8 @@ func (s *TestServer) GeneratePushSecret(conID, token string) *ca2.SecretItem {
 
 func TestStreamSecretsForWorkloadSds(t *testing.T) {
 	arg := ca2.Options{
-		EnableWorkloadSDS: true,
-		RecycleInterval:   30 * time.Second,
-		GatewayUDSPath:    "",
-		WorkloadUDSPath:   fmt.Sprintf("/tmp/workload_gotest%q.sock", string(uuid.NewUUID())),
+		RecycleInterval: 30 * time.Second,
+		WorkloadUDSPath: fmt.Sprintf("/tmp/workload_gotest%q.sock", string(uuid.NewUUID())),
 	}
 	testHelper(t, arg, sdsRequestStream, false)
 }
@@ -302,12 +299,10 @@ func TestStreamSecretsForCredentialFetcherGetTokenWorkloadSds(t *testing.T) {
 	cf := plugin.CreateMockPlugin(FirstPartyJwt)
 
 	arg := ca2.Options{
-		EnableWorkloadSDS: true,
-		RecycleInterval:   30 * time.Second,
-		GatewayUDSPath:    "",
-		WorkloadUDSPath:   fmt.Sprintf("/tmp/workload_gotest%q.sock", string(uuid.NewUUID())),
-		UseLocalJWT:       true,
-		CredFetcher:       cf,
+		RecycleInterval: 30 * time.Second,
+		WorkloadUDSPath: fmt.Sprintf("/tmp/workload_gotest%q.sock", string(uuid.NewUUID())),
+		UseLocalJWT:     true,
+		CredFetcher:     cf,
 	}
 	testCredentialFetcherHelper(t, arg, sdsRequestStream, FirstPartyJwt, FirstPartyJwt)
 }
@@ -317,12 +312,10 @@ func TestStreamSecretsForCredentialFetcherGetEmptyTokenWorkloadSds(t *testing.T)
 	cf := plugin.CreateMockPlugin(emptyToken)
 
 	arg := ca2.Options{
-		EnableWorkloadSDS: true,
-		RecycleInterval:   30 * time.Second,
-		GatewayUDSPath:    "",
-		WorkloadUDSPath:   fmt.Sprintf("/tmp/workload_gotest%q.sock", string(uuid.NewUUID())),
-		UseLocalJWT:       true,
-		CredFetcher:       cf,
+		RecycleInterval: 30 * time.Second,
+		WorkloadUDSPath: fmt.Sprintf("/tmp/workload_gotest%q.sock", string(uuid.NewUUID())),
+		UseLocalJWT:     true,
+		CredFetcher:     cf,
 	}
 	testCredentialFetcherHelper(t, arg, sdsRequestStream, FirstPartyJwt, emptyToken)
 }
@@ -330,12 +323,10 @@ func TestStreamSecretsForCredentialFetcherGetEmptyTokenWorkloadSds(t *testing.T)
 // Validate that StreamSecrets works correctly for file mounted certs i.e. when UseLocalJWT is set to false and FileMountedCerts to true.
 func TestStreamSecretsForFileMountedsWorkloadSds(t *testing.T) {
 	arg := ca2.Options{
-		EnableWorkloadSDS: true,
-		RecycleInterval:   30 * time.Second,
-		GatewayUDSPath:    "",
-		WorkloadUDSPath:   fmt.Sprintf("/tmp/workload_gotest%q.sock", string(uuid.NewUUID())),
-		FileMountedCerts:  true,
-		UseLocalJWT:       false,
+		RecycleInterval:  30 * time.Second,
+		WorkloadUDSPath:  fmt.Sprintf("/tmp/workload_gotest%q.sock", string(uuid.NewUUID())),
+		FileMountedCerts: true,
+		UseLocalJWT:      false,
 	}
 	wst := &mockSecretStore{
 		checkToken: false,
@@ -358,20 +349,16 @@ func TestStreamSecretsForFileMountedsWorkloadSds(t *testing.T) {
 
 func TestFetchSecretsForWorkloadSds(t *testing.T) {
 	arg := ca2.Options{
-		EnableWorkloadSDS: true,
-		RecycleInterval:   30 * time.Second,
-		GatewayUDSPath:    "",
-		WorkloadUDSPath:   fmt.Sprintf("/tmp/workload_gotest%q.sock", string(uuid.NewUUID())),
+		RecycleInterval: 30 * time.Second,
+		WorkloadUDSPath: fmt.Sprintf("/tmp/workload_gotest%q.sock", string(uuid.NewUUID())),
 	}
 	testHelper(t, arg, sdsRequestFetch, false)
 }
 
 func TestStreamSecretsInvalidResourceName(t *testing.T) {
 	arg := ca2.Options{
-		EnableWorkloadSDS: true,
-		RecycleInterval:   30 * time.Second,
-		GatewayUDSPath:    "",
-		WorkloadUDSPath:   fmt.Sprintf("/tmp/workload_gotest%s.sock", string(uuid.NewUUID())),
+		RecycleInterval: 30 * time.Second,
+		WorkloadUDSPath: fmt.Sprintf("/tmp/workload_gotest%s.sock", string(uuid.NewUUID())),
 	}
 	testHelper(t, arg, sdsRequestStream, true)
 }
@@ -380,14 +367,9 @@ type secretCallback func(string, *discovery.DiscoveryRequest) (*discovery.Discov
 
 func testHelper(t *testing.T, arg ca2.Options, cb secretCallback, testInvalidResourceNames bool) {
 	resetEnvironments()
-	var wst ca2.SecretManager
-	if arg.EnableWorkloadSDS {
-		wst = &mockSecretStore{
-			checkToken:    true,
-			expectedToken: fakeToken1,
-		}
-	} else {
-		wst = nil
+	wst := &mockSecretStore{
+		checkToken:    true,
+		expectedToken: fakeToken1,
 	}
 	server, err := NewServer(&arg, wst)
 	defer server.Stop()
@@ -396,33 +378,26 @@ func testHelper(t *testing.T, arg ca2.Options, cb secretCallback, testInvalidRes
 	}
 
 	proxyID := "sidecar~127.0.0.1~id1~local"
-	if testInvalidResourceNames && arg.EnableWorkloadSDS {
+	if testInvalidResourceNames {
 		sendRequestAndVerifyResponse(t, cb, arg.WorkloadUDSPath, proxyID, testInvalidResourceNames)
 		return
 	}
 
-	if arg.EnableWorkloadSDS {
-		sendRequestAndVerifyResponse(t, cb, arg.WorkloadUDSPath, proxyID, testInvalidResourceNames)
-		// Request for root certificate.
-		sendRequestForRootCertAndVerifyResponse(t, cb, arg.WorkloadUDSPath, proxyID)
+	sendRequestAndVerifyResponse(t, cb, arg.WorkloadUDSPath, proxyID, testInvalidResourceNames)
+	// Request for root certificate.
+	sendRequestForRootCertAndVerifyResponse(t, cb, arg.WorkloadUDSPath, proxyID)
 
-		recycleConnection(getClientConID(proxyID), testResourceName)
-		recycleConnection(getClientConID(proxyID), "ROOTCA")
-	}
+	recycleConnection(getClientConID(proxyID), testResourceName)
+	recycleConnection(getClientConID(proxyID), "ROOTCA")
 	// Check to make sure number of staled connections is 0.
 	checkStaledConnCount(t)
 }
 
 func testCredentialFetcherHelper(t *testing.T, arg ca2.Options, cb secretCallback, expectedToken, token string) {
 	resetEnvironments()
-	var wst ca2.SecretManager
-	if arg.EnableWorkloadSDS {
-		wst = &mockSecretStore{
-			checkToken:    true,
-			expectedToken: expectedToken,
-		}
-	} else {
-		wst = nil
+	wst := &mockSecretStore{
+		checkToken:    true,
+		expectedToken: expectedToken,
 	}
 
 	server, err := NewServer(&arg, wst)
@@ -432,19 +407,17 @@ func testCredentialFetcherHelper(t *testing.T, arg ca2.Options, cb secretCallbac
 	}
 
 	proxyID := "sidecar~127.0.0.1~id1~local"
-	if token == emptyToken && arg.EnableWorkloadSDS {
+	if token == emptyToken {
 		sendRequestAndVerifyResponseWithCredentialFetcher(t, cb, arg.WorkloadUDSPath, proxyID, token)
 		return
 	}
 
-	if arg.EnableWorkloadSDS {
-		sendRequestAndVerifyResponseWithCredentialFetcher(t, cb, arg.WorkloadUDSPath, proxyID, token)
-		// Request for root certificate.
-		sendRequestForRootCertAndVerifyResponse(t, cb, arg.WorkloadUDSPath, proxyID)
+	sendRequestAndVerifyResponseWithCredentialFetcher(t, cb, arg.WorkloadUDSPath, proxyID, token)
+	// Request for root certificate.
+	sendRequestForRootCertAndVerifyResponse(t, cb, arg.WorkloadUDSPath, proxyID)
 
-		recycleConnection(getClientConID(proxyID), testResourceName)
-		recycleConnection(getClientConID(proxyID), "ROOTCA")
-	}
+	recycleConnection(getClientConID(proxyID), testResourceName)
+	recycleConnection(getClientConID(proxyID), "ROOTCA")
 	// Check to make sure number of staled connections is 0.
 	checkStaledConnCount(t)
 }
@@ -573,9 +546,8 @@ func verifyResponseForEmptyToken(err error) bool {
 
 func createSDSServer(t *testing.T, socket string) (*Server, *mockSecretStore) {
 	arg := ca2.Options{
-		EnableWorkloadSDS: true,
-		RecycleInterval:   100 * time.Second,
-		WorkloadUDSPath:   socket,
+		RecycleInterval: 100 * time.Second,
+		WorkloadUDSPath: socket,
 	}
 	st := &mockSecretStore{
 		checkToken: false,
@@ -1307,10 +1279,6 @@ func (ms *mockSecretStore) DeleteSecret(conID, resourceName string) {
 		ResourceName: resourceName,
 	}
 	ms.secrets.Delete(key)
-}
-
-func (ms *mockSecretStore) ShouldWaitForGatewaySecret(connectionID, resourceName, token string, fileMountedCertsOnly bool) bool {
-	return false
 }
 
 func checkStaledConnCount(t *testing.T) {

--- a/security/pkg/nodeagent/sds/server_test.go
+++ b/security/pkg/nodeagent/sds/server_test.go
@@ -163,9 +163,8 @@ func createRealSDSServer(t *testing.T, socket string) *Server {
 	stsclient.GKEClusterURL = msts.FakeGKEClusterURL
 	stsclient.SecureTokenEndpoint = mockSTSServer.URL + "/v1/identitybindingtoken"
 	arg := security.Options{
-		EnableWorkloadSDS: true,
-		RecycleInterval:   100 * time.Millisecond,
-		WorkloadUDSPath:   socket,
+		RecycleInterval: 100 * time.Millisecond,
+		WorkloadUDSPath: socket,
 	}
 	caClient, err := gca.NewGoogleCAClient(mockMeshCAServer.Address, false)
 	if err != nil {

--- a/security/pkg/nodeagent/test/setup.go
+++ b/security/pkg/nodeagent/test/setup.go
@@ -162,12 +162,11 @@ func (e *Env) StartProxy(t *testing.T) {
 // StartSDSServer starts SDS server
 func (e *Env) StartSDSServer(t *testing.T) {
 	serverOptions := &security.Options{
-		WorkloadUDSPath:   e.ProxySetup.SDSPath(),
-		UseLocalJWT:       true,
-		JWTPath:           proxyTokenPath,
-		CAEndpoint:        fmt.Sprintf("127.0.0.1:%d", e.ProxySetup.Ports().ExtraPort),
-		EnableWorkloadSDS: true,
-		RecycleInterval:   5 * time.Minute,
+		WorkloadUDSPath: e.ProxySetup.SDSPath(),
+		UseLocalJWT:     true,
+		JWTPath:         proxyTokenPath,
+		CAEndpoint:      fmt.Sprintf("127.0.0.1:%d", e.ProxySetup.Ports().ExtraPort),
+		RecycleInterval: 5 * time.Minute,
 	}
 
 	caClient, err := citadel.NewCitadelClient(serverOptions.CAEndpoint, false, nil, "")


### PR DESCRIPTION
Removes a lot of fields that are never set. Most of this is from gateway
SDS removal.

Also cleanup CSRSign interface. There was a ReqId field which doesn't
need to be part of the interface, as well as a misnamed field



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.