### PR TITLE
exclude istiod pods by default in webhook objectSelector

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -63,8 +63,12 @@ webhooks:
 {{- end }}
 {{- if .Values.sidecarInjectorWebhook.objectSelector.enabled }}
     objectSelector:
-{{- if .Values.sidecarInjectorWebhook.objectSelector.autoInject }}
       matchExpressions:
+      - key: app
+        operator: NotIn
+        values:
+        - "istiod"
+{{- if .Values.sidecarInjectorWebhook.objectSelector.autoInject }}
       - key: "sidecar.istio.io/inject"
         operator: NotIn
         values:

--- a/manifests/charts/istiod-remote/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istiod-remote/templates/mutatingwebhook.yaml
@@ -63,8 +63,12 @@ webhooks:
 {{- end }}
 {{- if .Values.sidecarInjectorWebhook.objectSelector.enabled }}
     objectSelector:
-{{- if .Values.sidecarInjectorWebhook.objectSelector.autoInject }}
       matchExpressions:
+      - key: app
+        operator: NotIn
+        values:
+        - "istiod"
+{{- if .Values.sidecarInjectorWebhook.objectSelector.autoInject }}
       - key: "sidecar.istio.io/inject"
         operator: NotIn
         values:


### PR DESCRIPTION

Istio installation should have good defaults. If objectSelector were to be enabled, it is only fair to expect that all `istiod` pods be exempt from the webhook. This way, we get out of the deadlock scenario where the webhook blocks the creation of the pod that acts as the backend for that same webhook.


[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.