### PR TITLE
enable ObjectSelector by default in istiod MWC

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -181,7 +181,7 @@ data:
         "neverInjectSelector": [],
         "objectSelector": {
           "autoInject": true,
-          "enabled": false
+          "enabled": true
         },
         "rewriteAppHTTPProbe": true
       }
@@ -744,6 +744,7 @@ spec:
         app: istiod
         istio.io/rev: default
         install.operator.istio.io/owning-resource: unknown
+        sidecar.istio.io/inject: "false"
         operator.istio.io/component: "Pilot"
         istio: pilot
       annotations:
@@ -1678,3 +1679,9 @@ webhooks:
     namespaceSelector:
       matchLabels:
         istio-injection: enabled
+    objectSelector:
+      matchExpressions:
+      - key: "sidecar.istio.io/inject"
+        operator: NotIn
+        values:
+        - "false"

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -37,6 +37,7 @@ spec:
         app: istiod
         istio.io/rev: {{ .Values.revision | default "default" }}
         install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
+        sidecar.istio.io/inject: "false"
         operator.istio.io/component: "Pilot"
         {{- if eq .Values.revision ""}}
         istio: pilot

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -90,10 +90,10 @@ sidecarInjectorWebhook:
   # Only one environment should have this enabled.
   enableNamespacesByDefault: false
 
-  # Enable objectSelector to filter out pods with no need for sidecar before calling istio-sidecar-injector.
-  # It is disabled by default since this function will only work after k8s v1.15.
+  # Enable objectSelector to filter out pods with no need for sidecar before calling istiod.
+  # It is enabled by default as the minimum supported Kubernetes version is 1.15+
   objectSelector:
-    enabled: false
+    enabled: true
     autoInject: true
 
   rewriteAppHTTPProbe: true

--- a/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -161,7 +161,7 @@ data:
         "neverInjectSelector": [],
         "objectSelector": {
           "autoInject": true,
-          "enabled": false
+          "enabled": true
         },
         "rewriteAppHTTPProbe": true
       }
@@ -695,3 +695,9 @@ webhooks:
     namespaceSelector:
       matchLabels:
         istio-injection: enabled
+    objectSelector:
+      matchExpressions:
+      - key: "sidecar.istio.io/inject"
+        operator: NotIn
+        values:
+        - "false"

--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -71,10 +71,10 @@ sidecarInjectorWebhook:
   # with the exception of namespaces with "istio-injection:disabled" annotation
   # Only one environment should have this enabled.
   enableNamespacesByDefault: false
-  # Enable objectSelector to filter out pods with no need for sidecar before calling istio-sidecar-injector.
-  # It is disabled by default since this function will only work after k8s v1.15.
+  # Enable objectSelector to filter out pods with no need for sidecar before calling istiod.
+  # It is enabled by default as the minimum supported Kubernetes version is 1.15+
   objectSelector:
-    enabled: false
+    enabled: true
     autoInject: true
   rewriteAppHTTPProbe: true
 istiodRemote:


### PR DESCRIPTION

As Kubernetes 1.15 is the minimum supported K8s for Istio, we should be enabling `objectSelector` by default.


[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.