### PR TITLE
ext-authz: add e2e tests and example configuration for local ext-authz server in the same pod

### DIFF
--- a/pkg/test/framework/components/echo/config.go
+++ b/pkg/test/framework/components/echo/config.go
@@ -90,6 +90,11 @@ type Config struct {
 
 	// The set of environment variables to set for `DeployAsVM` instances.
 	VMEnvironment map[string]string
+
+	// If enabled, an additional ext-authz container will be included in the deployment. This is mainly used to test
+	// the CUSTOM authorization policy when the ext-authz server is deployed locally with the application container in
+	// the same pod.
+	IncludeExtAuthz bool
 }
 
 // SubsetConfig is the config for a group of Subsets (e.g. Kubernetes deployment).

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -101,6 +101,14 @@ spec:
       serviceAccountName: {{ $.Service }}
 {{- end }}
       containers:
+{{- if $.IncludeExtAuthz }}
+      - name: ext-authz
+        image: docker.io/istio/ext-authz:0.5
+        imagePullPolicy: {{ $.PullPolicy }}
+        ports:
+        - containerPort: 8000
+        - containerPort: 9000
+{{- end }}
       - name: app
         image: {{ $.Hub }}/app:{{ $.Tag }}
         imagePullPolicy: {{ $.PullPolicy }}
@@ -482,8 +490,9 @@ func generateYAMLWithSettings(
 			"IstiodPort":   istiodPort,
 			"AutoRegister": cfg.AutoRegisterVM,
 		},
-		"Environment":  cfg.VMEnvironment,
-		"StartupProbe": supportStartupProbe,
+		"Environment":     cfg.VMEnvironment,
+		"StartupProbe":    supportStartupProbe,
+		"IncludeExtAuthz": cfg.IncludeExtAuthz,
 	}
 
 	serviceYAML, err = tmpl.Execute(serviceTemplate, params)

--- a/samples/extauthz/README.md
+++ b/samples/extauthz/README.md
@@ -8,13 +8,15 @@ will allow the request if it includes the header `x-ext-authz: allow`.
 
 ## Usage
 
-1. Deploy the Ext Authz service:
+1. Deploy the Ext Authz service in a dedicated pod:
 
     ```console
     $ kubectl apply -f ext-authz.yaml
     service/ext-authz created
     deployment.extensions/ext-authz created
     ```
+
+    Note, you can also deploy the Ext Authz service locally with the application container in the same pod, see the example in `local-ext-authz.yaml`.
 
 1. Verify the Ext Authz server is up and running:
 

--- a/samples/extauthz/ext-authz.yaml
+++ b/samples/extauthz/ext-authz.yaml
@@ -1,3 +1,19 @@
+# Copyright Istio Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# Example configurations for deploying ext-authz server separately in the mesh.
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/samples/extauthz/local-ext-authz.yaml
+++ b/samples/extauthz/local-ext-authz.yaml
@@ -1,0 +1,99 @@
+# Copyright Istio Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# Example configurations for deploying ext-authz server locally with the application container in the same pod.
+
+# Define the service entry for the local ext-authz service on port 8000.
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: httpbin-ext-authz-http
+spec:
+  hosts:
+  - "ext-authz-http.local"
+  endpoints:
+  - address: "127.0.0.1"
+  ports:
+  - name: http
+    number: 8000
+    protocol: HTTP
+  resolution: STATIC
+---
+# Define the service entry for the local ext-authz service on port 9000.
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: httpbin-ext-authz-grpc
+spec:
+  hosts:
+  - "ext-authz-grpc.local"
+  endpoints:
+  - address: "127.0.0.1"
+  ports:
+  - name: grpc
+    number: 9000
+    protocol: GRPC
+  resolution: STATIC
+---
+# Deploy the ext-authz server locally with the application container in the same pod.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: httpbin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: httpbin
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: httpbin
+        version: v1
+    spec:
+      serviceAccountName: httpbin
+      containers:
+      - image: docker.io/kennethreitz/httpbin
+        imagePullPolicy: IfNotPresent
+        name: httpbin
+        ports:
+        - containerPort: 80
+      - image: docker.io/istio/ext-authz:0.5
+        imagePullPolicy: IfNotPresent
+        name: ext-authz
+        ports:
+        - containerPort: 8000
+        - containerPort: 9000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin
+  labels:
+    app: httpbin
+    service: httpbin
+spec:
+  ports:
+  - name: http
+    port: 8000
+    targetPort: 80
+  selector:
+    app: httpbin
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: httpbin
+---

--- a/tests/integration/security/authorization_test.go
+++ b/tests/integration/security/authorization_test.go
@@ -1297,11 +1297,18 @@ func TestAuthorization_Custom(t *testing.T) {
 			policy := applyYAML("testdata/authz/v1beta1-custom.yaml.tmpl", ns)
 			defer ctx.Config().DeleteYAMLOrFail(t, ns.Name(), policy...)
 
-			var a, b, c echo.Instance
+			var a, b, c, d, e echo.Instance
+			echoConfig := func(name string, includeExtAuthz bool) echo.Config {
+				cfg := util.EchoConfig(name, ns, false, nil, nil)
+				cfg.IncludeExtAuthz = includeExtAuthz
+				return cfg
+			}
 			echoboot.NewBuilder(ctx).
-				With(&a, util.EchoConfig("a", ns, false, nil, nil)).
-				With(&b, util.EchoConfig("b", ns, false, nil, nil)).
-				With(&c, util.EchoConfig("c", ns, false, nil, nil)).
+				With(&a, echoConfig("a", false)).
+				With(&b, echoConfig("b", false)).
+				With(&c, echoConfig("c", false)).
+				With(&d, echoConfig("d", true)).
+				With(&e, echoConfig("e", true)).
 				BuildOrFail(t)
 
 			newTestCase := func(target echo.Instance, path string, header string, expectAllowed bool) rbacUtil.TestCase {
@@ -1322,15 +1329,29 @@ func TestAuthorization_Custom(t *testing.T) {
 			// Path "/custom" is protected by ext-authz service and is accessible with the header `x-ext-authz: allow`.
 			// Path "/health" is not protected and is accessible to public.
 			cases := []rbacUtil.TestCase{
+				// workload b is using an ext-authz service in its own pod of HTTP API.
 				newTestCase(b, "/custom", "allow", true),
 				newTestCase(b, "/custom", "deny", false),
 				newTestCase(b, "/health", "allow", true),
 				newTestCase(b, "/health", "deny", true),
 
+				// workload c is using an ext-authz service in its own pod of gRPC API.
 				newTestCase(c, "/custom", "allow", true),
 				newTestCase(c, "/custom", "deny", false),
 				newTestCase(c, "/health", "allow", true),
 				newTestCase(c, "/health", "deny", true),
+
+				// workload d is using an local ext-authz service in the same pod as the application of HTTP API.
+				newTestCase(d, "/custom", "allow", true),
+				newTestCase(d, "/custom", "deny", false),
+				newTestCase(d, "/health", "allow", true),
+				newTestCase(d, "/health", "deny", true),
+
+				// workload e is using an local ext-authz service in the same pod as the application of gRPC API.
+				newTestCase(e, "/custom", "allow", true),
+				newTestCase(e, "/custom", "deny", false),
+				newTestCase(e, "/health", "allow", true),
+				newTestCase(e, "/health", "deny", true),
 			}
 
 			rbacUtil.RunRBACTest(ctx, cases)

--- a/tests/integration/security/main_test.go
+++ b/tests/integration/security/main_test.go
@@ -76,5 +76,15 @@ meshConfig:
     envoyExtAuthzGrpc:
       service: %q
       port: 9000
+  - name: "ext-authz-http-local"
+    envoyExtAuthzHttp:
+      service: ext-authz-http.local
+      port: 8000
+      pathPrefix: "/check"
+      includeHeadersInCheck: ["x-ext-authz"]
+  - name: "ext-authz-grpc-local"
+    envoyExtAuthzGrpc:
+      service: ext-authz-grpc.local
+      port: 9000
 `, service, serviceWithNamespace)
 }

--- a/tests/integration/security/testdata/authz/v1beta1-custom.yaml.tmpl
+++ b/tests/integration/security/testdata/authz/v1beta1-custom.yaml.tmpl
@@ -37,3 +37,77 @@ spec:
     - operation:
         paths: ["/custom"]
 ---
+
+# The following policy applies the CUSTOM action with the ext-authz-http-local provider on workload d for path /custom.
+
+apiVersion: "security.istio.io/v1beta1"
+kind: AuthorizationPolicy
+metadata:
+  name: policy-d
+  namespace: "{{ .Namespace }}"
+spec:
+  selector:
+    matchLabels:
+      "app": "d"
+  action: CUSTOM
+  provider:
+    name: ext-authz-http-local
+  rules:
+  - to:
+    - operation:
+        paths: ["/custom"]
+---
+
+# The following policy applies the CUSTOM action with the ext-authz-grpc-local provider on workload e for path /custom.
+
+apiVersion: "security.istio.io/v1beta1"
+kind: AuthorizationPolicy
+metadata:
+  name: policy-e
+  namespace: "{{ .Namespace }}"
+spec:
+  selector:
+    matchLabels:
+      "app": "e"
+  action: CUSTOM
+  provider:
+    name: ext-authz-grpc-local
+  rules:
+  - to:
+    - operation:
+        paths: ["/custom"]
+---
+
+# Define the service entry for the local ext-authz service on port 8000.
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: httpbin-ext-authz-http
+spec:
+  hosts:
+  - "ext-authz-http.local"
+  endpoints:
+  - address: "127.0.0.1"
+  ports:
+  - name: http
+    number: 8000
+    protocol: HTTP
+  resolution: STATIC
+---
+
+# Define the service entry for the local ext-authz service on port 9000.
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: httpbin-ext-authz-grpc
+spec:
+  hosts:
+  - "ext-authz-grpc.local"
+  endpoints:
+  - address: "127.0.0.1"
+  ports:
+  - name: grpc
+    number: 9000
+    protocol: GRPC
+  resolution: STATIC
+---


### PR DESCRIPTION




[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.