### PR TITLE
istioctl upgrade: fix downgrade to lower version

### DIFF
--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -282,6 +282,13 @@ func waitForConfirmation(skipConfirmation bool, l clog.Logger) {
 var upgradeSupportStart, _ = goversion.NewVersion("1.6.0")
 
 func checkSupportedVersions(kubeClient *Client, currentVersion, targetVersion string, l clog.Logger) error {
+	if err := verifySupportedVersion(currentVersion, targetVersion, l); err != nil {
+		return err
+	}
+	return kubeClient.CheckUnsupportedAlphaSecurityCRD()
+}
+
+func verifySupportedVersion(currentVersion, targetVersion string, l clog.Logger) error {
 	curGoVersion, err := goversion.NewVersion(currentVersion)
 	if err != nil {
 		return fmt.Errorf("failed to parse the current version %q: %v", currentVersion, err)
@@ -299,8 +306,7 @@ func checkSupportedVersions(kubeClient *Client, currentVersion, targetVersion st
 		l.LogAndPrintf("Upgrading across more than one minor version (e.g., %v to %v)"+
 			" in one step is not officially tested or recommended.\n", curGoVersion, targetGoVersion)
 	}
-
-	return kubeClient.CheckUnsupportedAlphaSecurityCRD()
+	return nil
 }
 
 // retrieveControlPlaneVersion retrieves the version number from the Istio control plane

--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -279,7 +279,7 @@ func waitForConfirmation(skipConfirmation bool, l clog.Logger) {
 	}
 }
 
-var SupportedIstioVersions, _ = goversion.NewConstraint(">=1.6.0, <1.9")
+var upgradeSupportStart, _ = goversion.NewVersion("1.6.0")
 
 func checkSupportedVersions(kubeClient *Client, currentVersion, targetVersion string, l clog.Logger) error {
 	curGoVersion, err := goversion.NewVersion(currentVersion)
@@ -290,8 +290,8 @@ func checkSupportedVersions(kubeClient *Client, currentVersion, targetVersion st
 	if err != nil {
 		return fmt.Errorf("failed to parse the target version %q: %v", targetVersion, err)
 	}
-	if !SupportedIstioVersions.Check(curGoVersion) {
-		return fmt.Errorf("upgrade is currently not supported from version: %v", currentVersion)
+	if upgradeSupportStart.Segments()[1] > curGoVersion.Segments()[1] {
+		return fmt.Errorf("upgrade is not supported before version: %v", upgradeSupportStart)
 	}
 	// Warn if user is trying skip one minor verion eg: 1.6.x to 1.8.x
 	if (targetGoVersion.Segments()[1] - curGoVersion.Segments()[1]) > 1 {

--- a/operator/cmd/mesh/upgrade_test.go
+++ b/operator/cmd/mesh/upgrade_test.go
@@ -1,0 +1,85 @@
+// Copyright Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mesh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"istio.io/istio/operator/pkg/util/clog"
+)
+
+func TestVerifySupportedVersions(t *testing.T) {
+	cases := []struct {
+		currentVer string
+		targetVer  string
+		err        error
+		isValid    bool
+	}{
+		{
+			currentVer: "",
+			targetVer:  "1.9.0",
+			err:        fmt.Errorf("failed to parse the current version %v: Malformed version: ", ""),
+			isValid:    false,
+		},
+		{
+			currentVer: "master",
+			targetVer:  "1.9.0",
+			err:        fmt.Errorf("failed to parse the current version %v: Malformed version: ", "master"),
+			isValid:    false,
+		},
+		{
+			currentVer: "1.7.4",
+			targetVer:  "1.8.0",
+			err:        nil,
+			isValid:    true,
+		},
+		{
+			currentVer: "1.8.0",
+			targetVer:  "1.9.0",
+			err:        nil,
+			isValid:    true,
+		},
+		{
+			currentVer: "1.8.0",
+			targetVer:  "1.7.4",
+			err:        nil,
+			isValid:    true,
+		},
+		{
+			currentVer: "1.9.0",
+			targetVer:  "",
+			err:        fmt.Errorf("failed to parse the target version %v: Malformed version: %v", "", ""),
+			isValid:    false,
+		},
+		{
+			currentVer: "1.5.8",
+			targetVer:  "1.8.0",
+			err:        fmt.Errorf("upgrade is not supported before version: %v", upgradeSupportStart),
+			isValid:    false,
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case %d %s", i, c.currentVer), func(t *testing.T) {
+			l := clog.NewConsoleLogger(os.Stdout, os.Stderr, nil)
+			err := verifySupportedVersion(c.currentVer, c.targetVer, l)
+			if c.isValid && err != nil {
+				t.Errorf("(curr: %v)(target: %v)(%v)", c.currentVer, c.targetVer, err)
+			}
+		})
+	}
+}

--- a/operator/cmd/mesh/upgrade_test.go
+++ b/operator/cmd/mesh/upgrade_test.go
@@ -71,6 +71,12 @@ func TestVerifySupportedVersions(t *testing.T) {
 			err:        fmt.Errorf("upgrade is not supported before version: %v", upgradeSupportStart),
 			isValid:    false,
 		},
+		{
+			currentVer: "1.8.0",
+			targetVer:  "1.8.0",
+			err:        nil,
+			isValid:    true,
+		},
 	}
 
 	for i, c := range cases {

--- a/releasenotes/notes/29183.yaml
+++ b/releasenotes/notes/29183.yaml
@@ -8,4 +8,4 @@ issue:
 
 releaseNotes:
   - |
-    **Fixed** downgrade to lower version of Istio.
+    **Fixed** an issue showing unnecessary warnings when downgrading to a lower version of Istio.

--- a/releasenotes/notes/29183.yaml
+++ b/releasenotes/notes/29183.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind:
+  bug-fix
+area:
+  istioctl
+issue:
+  - 29183
+
+releaseNotes:
+  - |
+    **Fixed** downgrade to lower version of Istio.


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/29183

The error message was misleading when the user is trying to downgrade to a lower version. eg: `1.8.0` to `1.7.4`.

We should only check if the upgrade or downgrade version is lower than `1.6.0` as the support for the upgrade was introduced in `1.6.0`.
 


Before:
```
[istio-1.8.0] $ istioctl install

[istio-1.7.4] $ istioctl upgrade
Control Plane - ingressgateway pod - istio-ingressgateway-848588d9cb-7ffzv - version: 1.8.0
Control Plane - pilot pod - istiod-767798f6fd-5rv8l - version: 1.8.0

2020-11-25T05:56:02.092649Z     info    Error: upgrade version check failed: 1.8.0 -> 1.7.4. Error: upgrade is currently not supported from version: 1.8.0

Error: upgrade version check failed: 1.8.0 -> 1.7.4. Error: upgrade is currently not supported from version: 1.8.0
```

Other tests.
```
$ ./out/linux_amd64/istioctl upgrade -d manifests/
2020-11-25T10:14:20.795380Z     info    proto: tag has too few fields: "-"
Control Plane - istio-ingressgateway pod - istio-ingressgateway-fcb46d98b-m6tls - version: 1.5.10
Control Plane - istiod pod - istiod-6f5d894bd8-nfwzv - version: 1.5.10

2020-11-25T10:14:20.813024Z     info    Error: upgrade version check failed: 1.5.10 -> 1.9.0. Error: upgrade is not supported before version: 1.6.0

Error: upgrade version check failed: 1.5.10 -> 1.9.0. Error: upgrade is not supported before version: 1.6.0
```

```
$ ./out/linux_amd64/istioctl upgrade -d manifests/
2020-11-25T10:17:45.715121Z     info    proto: tag has too few fields: "-"
Control Plane - istio-ingressgateway pod - istio-ingressgateway-795d8b6644-2z2lp - version: 1.6.8
Control Plane - istiod pod - istiod-5475dd875b-6rwd8 - version: 1.6.8

!!! WARNING !!!
Upgrading across more than one minor version (e.g., 1.6.8 to 1.9.0) in one step is not officially tested or recommended.

Upgrade version check passed: 1.6.8 -> 1.9.0.
```

```
$ ./out/linux_amd64/istioctl upgrade -d manifests/
2020-11-25T10:21:26.971989Z     info    proto: tag has too few fields: "-"
Control Plane - istio-ingressgateway pod - istio-ingressgateway-55f67b4b7f-skkpr - version: 1.7.4
Control Plane - istiod pod - istiod-7c487bdcd7-lpzvz - version: 1.7.4

!!! WARNING !!!
Upgrading across more than one minor version (e.g., 1.7.4 to 1.9.0) in one step is not officially tested or recommended.

Upgrade version check passed: 1.7.4 -> 1.9.0.
```