### PR TITLE
Switch inbound cluster naming to use workload port, rather than Service port

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -298,7 +298,11 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusters(cb *ClusterBuilder, i
 			// However, we still need to capture all the instances on this port, as its required to populate telemetry metadata
 			// The first instance will be used as the "primary" instance; this means if we have an conflicts between
 			// Services the first one wins
-			ep := int(instance.Endpoint.EndpointPort)
+			ep := instance.ServicePort.Port
+			if util.IsIstioVersionGE181(cb.proxy) {
+				// Istio 1.8.1+ switched to keying on EndpointPort. We need both logics in place to support smooth upgrade from 1.8.0 to 1.8.x
+				ep = int(instance.Endpoint.EndpointPort)
+			}
 			clustersToBuild[ep] = append(clustersToBuild[ep], instance)
 		}
 

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -250,7 +250,8 @@ func (cb *ClusterBuilder) buildDefaultCluster(name string, discoveryType cluster
 // requires a single protocol per port, and the DestinationRule issue is slated to move to Sidecar.
 // Note: clusterPort and instance.Endpoint.EndpointPort are identical for standard Services; however,
 // Sidecar.Ingress allows these to be different.
-func (cb *ClusterBuilder) buildInboundClusterForPortOrUDS(proxy *model.Proxy, clusterPort int, bind string, instance *model.ServiceInstance, allInstance []*model.ServiceInstance) *cluster.Cluster {
+func (cb *ClusterBuilder) buildInboundClusterForPortOrUDS(proxy *model.Proxy, clusterPort int, bind string,
+	instance *model.ServiceInstance, allInstance []*model.ServiceInstance) *cluster.Cluster {
 	clusterName := util.BuildInboundSubsetKey(proxy, instance.ServicePort.Name,
 		instance.Service.Hostname, instance.ServicePort.Port, clusterPort)
 	localityLbEndpoints := buildInboundLocalityLbEndpoints(bind, instance.Endpoint.EndpointPort)

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -241,10 +241,13 @@ func (cb *ClusterBuilder) buildDefaultCluster(name string, discoveryType cluster
 	return c
 }
 
-// buildInboundClusterForPortOrUDS constructs a single inbound listener. The cluster will be bound to `inbound|clusterPort||`, and send traffic to <bind>:<instance.Endpoint.EndpointPort>
-// A workload will have a single inbound cluster per port. In general this works properly, with the exception of the Service-oriented DestinationRule, and upstream
-// protocol selection. Our documentation currently requires a single protocol per port, and the DestinationRule issue is slated to move to Sidecar.
-// Note: clusterPort and instance.Endpoint.EndpointPort are identical for standard Services; however, Sidecar.Ingress allows these to be different.
+// buildInboundClusterForPortOrUDS constructs a single inbound listener. The cluster will be bound to
+// `inbound|clusterPort||`, and send traffic to <bind>:<instance.Endpoint.EndpointPort>. A workload
+// will have a single inbound cluster per port. In general this works properly, with the exception of
+// the Service-oriented DestinationRule, and upstream protocol selection. Our documentation currently
+// requires a single protocol per port, and the DestinationRule issue is slated to move to Sidecar.
+// Note: clusterPort and instance.Endpoint.EndpointPort are identical for standard Services; however,
+// Sidecar.Ingress allows these to be different.
 func (cb *ClusterBuilder) buildInboundClusterForPortOrUDS(proxy *model.Proxy, clusterPort int, instance *model.ServiceInstance, bind string) *cluster.Cluster {
 	clusterName := util.BuildInboundSubsetKey(proxy, instance.ServicePort.Name,
 		instance.Service.Hostname, instance.ServicePort.Port, clusterPort)

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -748,12 +748,10 @@ func TestBuildDefaultCluster(t *testing.T) {
 			cg := NewConfigGenTest(t, TestOptions{MeshConfig: &testMesh})
 			cb := NewClusterBuilder(cg.SetupProxy(nil), cg.PushContext())
 
-			defaultCluster := cb.buildDefaultCluster(tt.clusterName, tt.discovery,
-				tt.endpoints, tt.direction, servicePort,
-				&model.Service{Ports: model.PortList{
-					servicePort,
-				},
-					Hostname: "host", MeshExternal: false, Attributes: model.ServiceAttributes{Name: "svc", Namespace: "default"}})
+			defaultCluster := cb.buildDefaultCluster(tt.clusterName, tt.discovery, tt.endpoints, tt.direction, servicePort, &model.Service{Ports: model.PortList{
+				servicePort,
+			},
+				Hostname: "host", MeshExternal: false, Attributes: model.ServiceAttributes{Name: "svc", Namespace: "default"}}, nil)
 
 			if diff := cmp.Diff(defaultCluster, tt.expectedCluster, protocmp.Transform()); diff != "" {
 				t.Errorf("Unexpected default cluster, diff: %v", diff)

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -3631,7 +3631,7 @@ func TestTelemetryMetadata(t *testing.T) {
 					ServiceInstances: tt.svcInsts,
 				},
 			}
-			addTelemetryMetadata(opt, tt.service, tt.direction)
+			addTelemetryMetadata(opt, tt.service, tt.direction, tt.svcInsts)
 			if opt.cluster != nil && !reflect.DeepEqual(opt.cluster.Metadata, tt.want) {
 				t.Errorf("cluster metadata does not match expectation want %+v, got %+v", tt.want, opt.cluster.Metadata)
 			}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -79,7 +79,7 @@ var (
 )
 
 func TestHTTPCircuitBreakerThresholds(t *testing.T) {
-	checkClusters := []string{"outbound|8080||*.example.org", "inbound|8080||"}
+	checkClusters := []string{"outbound|8080||*.example.org", "inbound|10001||"}
 	settings := []*networking.ConnectionPoolSettings{
 		nil,
 		{
@@ -112,6 +112,9 @@ func TestHTTPCircuitBreakerThresholds(t *testing.T) {
 
 			for _, c := range checkClusters {
 				cluster := clusters[c]
+				if cluster == nil {
+					t.Fatalf("cluster %v not found", c)
+				}
 				g.Expect(len(cluster.CircuitBreakers.Thresholds)).To(Equal(1))
 				thresholds := cluster.CircuitBreakers.Thresholds[0]
 
@@ -149,7 +152,7 @@ func TestCommonHttpProtocolOptions(t *testing.T) {
 			proxyType:                 model.SidecarProxy,
 			clusters:                  8,
 		}, {
-			clusterName:               "inbound|8080||",
+			clusterName:               "inbound|10001||",
 			useDownStreamProtocol:     false,
 			sniffingEnabledForInbound: false,
 			proxyType:                 model.SidecarProxy,
@@ -162,7 +165,7 @@ func TestCommonHttpProtocolOptions(t *testing.T) {
 			clusters:                  8,
 		},
 		{
-			clusterName:               "inbound|9090||",
+			clusterName:               "inbound|10002||",
 			useDownStreamProtocol:     true,
 			sniffingEnabledForInbound: true,
 			proxyType:                 model.SidecarProxy,
@@ -209,7 +212,7 @@ func TestCommonHttpProtocolOptions(t *testing.T) {
 			g.Expect(len(clusters)).To(Equal(tc.clusters))
 			c := clusters[tc.clusterName]
 
-			g.Expect(c.CommonHttpProtocolOptions).To(Not(BeNil()))
+			g.Expect(c.GetCommonHttpProtocolOptions()).To(Not(BeNil()))
 			commonHTTPProtocolOptions := c.CommonHttpProtocolOptions
 
 			if tc.useDownStreamProtocol && tc.proxyType == model.SidecarProxy {
@@ -333,7 +336,7 @@ func buildTestClusters(c clusterTest) []*cluster.Cluster {
 			ServicePort: servicePort[1],
 			Endpoint: &model.IstioEndpoint{
 				Address:      "6.6.6.6",
-				EndpointPort: 10001,
+				EndpointPort: 10002,
 				Locality: model.Locality{
 					ClusterID: "",
 					Label:     "region1/zone1/subzone1",
@@ -1069,7 +1072,7 @@ func TestStatNamePattern(t *testing.T) {
 			Host: "*.example.org",
 		}})
 	g.Expect(xdstest.ExtractCluster("outbound|8080||*.example.org", clusters).AltStatName).To(Equal("*.example.org_default_8080"))
-	g.Expect(xdstest.ExtractCluster("inbound|8080||", clusters).AltStatName).To(Equal("LocalService_*.example.org"))
+	g.Expect(xdstest.ExtractCluster("inbound|10001||", clusters).AltStatName).To(Equal("LocalService_*.example.org"))
 }
 
 func TestDuplicateClusters(t *testing.T) {

--- a/pilot/pkg/networking/core/v1alpha3/fake.go
+++ b/pilot/pkg/networking/core/v1alpha3/fake.go
@@ -200,7 +200,9 @@ func (f *ConfigGenTest) SetupProxy(p *model.Proxy) *model.Proxy {
 		p.Metadata = &model.NodeMetadata{}
 	}
 	if p.Metadata.IstioVersion == "" {
-		p.Metadata.IstioVersion = "1.8.0"
+		p.Metadata.IstioVersion = "1.9.0"
+	}
+	if p.IstioVersion == nil {
 		p.IstioVersion = model.ParseIstioVersion(p.Metadata.IstioVersion)
 	}
 	if p.Type == "" {

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -472,7 +472,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundHTTPListenerOptsForPort
 		// names here because the inbound clusters are not referred to anywhere in the API, unlike the outbound
 		// clusters and these are static endpoint clusters used only for sidecar (proxy -> app)
 		clusterName = util.BuildInboundSubsetKey(node, pluginParams.ServiceInstance.ServicePort.Name,
-			pluginParams.ServiceInstance.Service.Hostname, pluginParams.ServiceInstance.ServicePort.Port)
+			pluginParams.ServiceInstance.Service.Hostname, pluginParams.ServiceInstance.ServicePort.Port, int(pluginParams.ServiceInstance.Endpoint.EndpointPort))
 	}
 
 	httpOpts := &httpListenerOpts{
@@ -515,7 +515,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarThriftListenerOptsForPortOrUDS
 	// names here because the inbound clusters are not referred to anywhere in the API, unlike the outbound
 	// clusters and these are static endpoint clusters used only for sidecar (proxy -> app)
 	clusterName := util.BuildInboundSubsetKey(pluginParams.Node, pluginParams.ServiceInstance.ServicePort.Name,
-		pluginParams.ServiceInstance.Service.Hostname, int(pluginParams.ServiceInstance.Endpoint.EndpointPort))
+		pluginParams.ServiceInstance.Service.Hostname, pluginParams.ServiceInstance.ServicePort.Port, int(pluginParams.ServiceInstance.Endpoint.EndpointPort))
 
 	thriftOpts := &thriftListenerOpts{
 		transport:   thrift.TransportType_AUTO_TRANSPORT,
@@ -545,6 +545,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListenerForPortOrUDS(no
 		if old.instanceHostname != pluginParams.ServiceInstance.Service.Hostname {
 			// For sidecar specified listeners, the caller is expected to supply a dummy service instance
 			// with the right port and a hostname constructed from the sidecar config's name+namespace
+			// TODO everything in inbound listener is now workload oriented. We should no longer have listener conflicts.
 			pluginParams.Push.AddMetric(model.ProxyStatusConflictInboundListener, pluginParams.Node.ID, pluginParams.Node.ID,
 				fmt.Sprintf("Conflicting inbound listener:%d. existing: %s, incoming: %s", listenerOpts.port.Port,
 					old.instanceHostname, pluginParams.ServiceInstance.Service.Hostname))

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -43,7 +43,8 @@ var (
 
 // buildInboundNetworkFilters generates a TCP proxy network filter on the inbound path
 func buildInboundNetworkFilters(push *model.PushContext, instance *model.ServiceInstance, node *model.Proxy) []*listener.Filter {
-	clusterName := util.BuildInboundSubsetKey(node, instance.ServicePort.Name, instance.Service.Hostname, instance.ServicePort.Port)
+	clusterName := util.BuildInboundSubsetKey(node, instance.ServicePort.Name,
+		instance.Service.Hostname, instance.ServicePort.Port, int(instance.Endpoint.EndpointPort))
 	statPrefix := clusterName
 	// If stat name is configured, build the stat prefix from configured pattern.
 	if len(push.Mesh.InboundClusterStatName) != 0 {

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter_test.go
@@ -62,7 +62,7 @@ func TestInboundNetworkFilterStatPrefix(t *testing.T) {
 		{
 			"no pattern",
 			"",
-			"inbound|9999||",
+			"inbound|8888||",
 		},
 		{
 			"service only pattern",
@@ -96,7 +96,9 @@ func TestInboundNetworkFilterStatPrefix(t *testing.T) {
 					Port: 9999,
 					Name: "http",
 				},
-				Endpoint: &model.IstioEndpoint{},
+				Endpoint: &model.IstioEndpoint{
+					EndpointPort: 8888,
+				},
 			}
 
 			listeners := buildInboundNetworkFilters(env.PushContext, instance, &model.Proxy{})

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -282,10 +282,20 @@ func IsIstioVersionGE18(node *model.Proxy) bool {
 		node.IstioVersion.Compare(&model.IstioVersion{Major: 1, Minor: 8, Patch: -1}) >= 0
 }
 
+// IsIstioVersionGE181 checks whether the given Istio version is greater than or equals 1.8.1
+func IsIstioVersionGE181(node *model.Proxy) bool {
+	return node == nil || node.IstioVersion == nil ||
+		node.IstioVersion.Compare(&model.IstioVersion{Major: 1, Minor: 8, Patch: 1}) >= 0
+}
+
 func BuildInboundSubsetKey(node *model.Proxy, subsetName string, hostname host.Name, servicePort int, endpointPort int) string {
-	if IsIstioVersionGE18(node) {
-		// On 1.8+ Proxies, we use format inbound|port||. Telemetry no longer requires the hostname
+	if IsIstioVersionGE181(node) {
+		// On 1.8.1+ Proxies, we use format inbound|endpointPort||. Telemetry no longer requires the hostname
 		return model.BuildSubsetKey(model.TrafficDirectionInbound, "", "", endpointPort)
+	} else if IsIstioVersionGE18(node) {
+		// On 1.8.0 Proxies, we used format inbound|servicePort||. Since changing a cluster name leads to a 503
+		// blip on upgrade, we will support this legacy format.
+		return model.BuildSubsetKey(model.TrafficDirectionInbound, "", "", servicePort)
 	}
 	return model.BuildSubsetKey(model.TrafficDirectionInbound, subsetName, hostname, servicePort)
 }

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -282,12 +282,12 @@ func IsIstioVersionGE18(node *model.Proxy) bool {
 		node.IstioVersion.Compare(&model.IstioVersion{Major: 1, Minor: 8, Patch: -1}) >= 0
 }
 
-func BuildInboundSubsetKey(node *model.Proxy, subsetName string, hostname host.Name, port int) string {
+func BuildInboundSubsetKey(node *model.Proxy, subsetName string, hostname host.Name, servicePort int, endpointPort int) string {
 	if IsIstioVersionGE18(node) {
 		// On 1.8+ Proxies, we use format inbound|port||. Telemetry no longer requires the hostname
-		return model.BuildSubsetKey(model.TrafficDirectionInbound, "", "", port)
+		return model.BuildSubsetKey(model.TrafficDirectionInbound, "", "", endpointPort)
 	}
-	return model.BuildSubsetKey(model.TrafficDirectionInbound, subsetName, hostname, port)
+	return model.BuildSubsetKey(model.TrafficDirectionInbound, subsetName, hostname, servicePort)
 }
 
 func IsProtocolSniffingEnabledForPort(port *model.Port) bool {

--- a/pilot/pkg/simulation/traffic.go
+++ b/pilot/pkg/simulation/traffic.go
@@ -397,17 +397,18 @@ func (sim *Simulation) matchFilterChain(chains []*listener.FilterChain, defaultC
 	}, func(fc *listener.FilterChainMatch) bool {
 		ranger := cidranger.NewPCTrieRanger()
 		for _, a := range fc.GetPrefixRanges() {
-			_, cidr, err := net.ParseCIDR(fmt.Sprintf("%s/%d", a.AddressPrefix, a.GetPrefixLen().GetValue()))
+			s := fmt.Sprintf("%s/%d", a.AddressPrefix, a.GetPrefixLen().GetValue())
+			_, cidr, err := net.ParseCIDR(s)
 			if err != nil {
-				sim.t.Fatal(err)
+				sim.t.Fatalf("failed to parse cidr %v: %v", s, err)
 			}
 			if err := ranger.Insert(cidranger.NewBasicRangerEntry(*cidr)); err != nil {
-				sim.t.Fatal(err)
+				sim.t.Fatalf("failed to insert cidr %v: %v", cidr, err)
 			}
 		}
 		f, err := ranger.Contains(net.ParseIP(input.Address))
 		if err != nil {
-			sim.t.Fatal(err)
+			sim.t.Fatalf("cidr containers %v failed: %v", input.Address, err)
 		}
 		return f
 	})

--- a/releasenotes/notes/inbound-cluster-rename.yaml
+++ b/releasenotes/notes/inbound-cluster-rename.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: bug-fix
+issue:
+- 29199
+
+releaseNotes:
+- |
+  **Fixed** a regression in Istio 1.8.0 causing workloads with multiple Services with overlapping ports to send
+  traffic to the wrong port.

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -543,7 +543,7 @@ spec:
     targetPort: %d
   selector:
     app: b`, FindPortByName("http").ServicePort, WorkloadPorts[0].Port)
-		case2 := TrafficTestCase{
+		cases = append(cases, TrafficTestCase{
 			name:   "case 2 service port match",
 			config: svc,
 			call:   c.CallWithRetryOrFail,
@@ -554,9 +554,7 @@ spec:
 				Timeout:   time.Millisecond * 100,
 				Validator: echo.ExpectOK(),
 			},
-		}
-		// TODO(https://github.com/istio/istio/issues/29199) enable this test
-		_ = case2
+		})
 
 		// Case 3
 		// We match the target port, but front with a different service port

--- a/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
@@ -125,8 +125,8 @@ func TestStackdriverMonitoring(t *testing.T) {
 func TestMain(m *testing.M) {
 	framework.NewSuite(m).
 		Label(label.CustomSetup).
-		Setup(istio.Setup(getIstioInstance(), setupConfig)).
 		Setup(testSetup).
+		Setup(istio.Setup(getIstioInstance(), setupConfig)).
 		Run()
 }
 

--- a/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
@@ -125,8 +125,8 @@ func TestStackdriverMonitoring(t *testing.T) {
 func TestMain(m *testing.M) {
 	framework.NewSuite(m).
 		Label(label.CustomSetup).
-		Setup(testSetup).
 		Setup(istio.Setup(getIstioInstance(), setupConfig)).
+		Setup(testSetup).
 		Run()
 }
 

--- a/tests/integration/telemetry/stackdriver/testdata/tcp_server_access_log.json.tmpl
+++ b/tests/integration/telemetry/stackdriver/testdata/tcp_server_access_log.json.tmpl
@@ -24,6 +24,6 @@
         "protocol": "tcp",
         "log_sampled": "false",
         "requested_server_name": "outbound_.9090_._.srv.{{ .EchoNamespace }}.svc.cluster.local",
-        "upstream_cluster": "inbound|9090||"
+        "upstream_cluster": "inbound|9000||"
     }
 }


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/29199

In Istio 1.8, we dropped the Service name from the inbound cluster
specifier. As a result, we have a regression due to overlapping
Services. The problem comes from the fact that inbound listener is based
on workload/target port, but the cluster name is based on Service port.
This means we can only have a single cluster per Service port. In
reality, we should have a single cluster per workload port.

This switches the naming to use workload port. Regression integration
tests for this issue were added in
https://github.com/istio/istio/pull/29201 and activated in this PR, as
well as additional unit tests which I think give pretty solid coverage
of this change.