### PR TITLE
Fix: adsc is blocked by sync chan

### DIFF
--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -520,8 +520,10 @@ func (a *ADSC) handleRecv() {
 		a.mutex.Lock()
 		if len(gvk) == 3 {
 			gt := config.GroupVersionKind{Group: gvk[0], Version: gvk[1], Kind: gvk[2]}
-			a.sync[gt.String()] = time.Now()
-			a.syncCh <- gt.String()
+			if _, exist := a.sync[gt.String()]; !exist {
+				a.sync[gt.String()] = time.Now()
+				a.syncCh <- gt.String()
+			}
 		}
 		a.Received[msg.TypeUrl] = msg
 		a.ack(msg)


### PR DESCRIPTION
Signed-off-by: huabing zhao <huabingzhao@tencent.com>

Please provide a description for what this PR is for.

Fix the issue in adsc: handleRecv is blocked by sync chan.  

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
