### PR TITLE
istioctl profile: remove profiles aliase

### DIFF
--- a/operator/cmd/mesh/profile.go
+++ b/operator/cmd/mesh/profile.go
@@ -26,7 +26,6 @@ func ProfileCmd() *cobra.Command {
 		Long:  "The profile command lists, dumps or diffs Istio configuration profiles.",
 		Example: "istioctl profile list\n" +
 			"istioctl install --set profile=demo  # Use a profile from the list",
-		Aliases: []string{"profiles"},
 	}
 
 	pdArgs := &profileDumpArgs{}


### PR DESCRIPTION

`profiles` became an alias for `istioctl profile` and not `istioctl profile list`.

Either of `istioctl profile` and `istioctl profiles` display the same help text.
```
$ istioctl profiles
The profile command lists, dumps or diffs Istio configuration profiles.

Usage:
  istioctl profile [command]

Aliases:
  profile, profiles

Available Commands:
  diff        Diffs two Istio configuration profiles
  dump        Dumps an Istio configuration profile
  list        Lists available Istio configuration profiles
```