### PR TITLE
Add SetLabel to test framework namespace interface

### DIFF
--- a/pkg/test/framework/components/echo/common/envoy_test.go
+++ b/pkg/test/framework/components/echo/common/envoy_test.go
@@ -132,6 +132,10 @@ func (n *fakeNamespace) ID() resource.ID {
 	panic("not implemented")
 }
 
+func (n *fakeNamespace) SetLabel(key, value string) error {
+	panic("not implemented")
+}
+
 func (*testConfig) Logs() (string, error) {
 	panic("not implemented")
 }

--- a/pkg/test/framework/components/namespace/namespace.go
+++ b/pkg/test/framework/components/namespace/namespace.go
@@ -34,6 +34,7 @@ type Config struct {
 // Instance represents an allocated namespace that can be used to create config, or deploy components in.
 type Instance interface {
 	Name() string
+	SetLabel(key, value string) error
 }
 
 // Claim an existing namespace in all clusters, or create a new one if doesn't exist.

--- a/tests/integration/security/authorization_test.go
+++ b/tests/integration/security/authorization_test.go
@@ -56,6 +56,10 @@ func (i rootNS) Name() string {
 	return i.rootNamespace
 }
 
+func (i rootNS) SetLabel(key, value string) error {
+	return nil
+}
+
 func newRootNS(ctx framework.TestContext) rootNS {
 	return rootNS{
 		rootNamespace: istio.GetOrFail(ctx, ctx).Settings().SystemNamespace,


### PR DESCRIPTION
Adds `SetLabel` to the test framework's namespace interface. Useful for upcoming work around upgrade testing

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
