### PR TITLE
pilot/xds: replace mutex with atomic.Bool when accessing cache sync

### DIFF
--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -159,7 +159,6 @@ func NewDiscoveryServer(env *model.Environment, plugins []string, instanceID str
 		pushQueue:               NewPushQueue(),
 		debugHandlers:           map[string]string{},
 		adsClients:              map[string]*Connection{},
-		serverReady:             false,
 		debounceOptions: debounceOptions{
 			debounceAfter:     features.DebounceAfter,
 			debounceMax:       features.DebounceMax,

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -118,7 +118,7 @@ type DiscoveryServer struct {
 	InternalGen *InternalGen
 
 	// serverReady indicates caches have been synced up and server is ready to process requests.
-	serverReady bool
+	serverReady atomic.Bool
 
 	debounceOptions debounceOptions
 
@@ -198,15 +198,11 @@ var (
 // CachesSynced is called when caches have been synced so that server can accept connections.
 func (s *DiscoveryServer) CachesSynced() {
 	adsLog.Infof("All caches have been synced up in %v, marking server ready", time.Since(processStartTime))
-	s.updateMutex.Lock()
-	s.serverReady = true
-	s.updateMutex.Unlock()
+	s.serverReady.Store(true)
 }
 
 func (s *DiscoveryServer) IsServerReady() bool {
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
-	return s.serverReady
+	return s.serverReady.Load()
 }
 
 func (s *DiscoveryServer) Start(stopCh <-chan struct{}) {


### PR DESCRIPTION
It seems to me that the synchronization for `serverReady` could be atomic.Bool instead of two mutexs, unless the `IsServerReady()` should be blocked during the `EndpointShardsByService` is being updated.

Please correct me if I misunderstood anything here.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[x] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
