### PR TITLE
pilot-agent/status: improve the feature of caching k8s probe HTTP client

### DIFF
--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -485,10 +485,6 @@ func (s *Server) handleAppProbe(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	httpClient := s.appProbeClient
-	// Reset the timeout duration of HTTP client for each specific prober.
-	httpClient.Timeout = time.Duration(prober.TimeoutSeconds) * time.Second
-
 	proberPath := prober.HTTPGet.Path
 	if !strings.HasPrefix(proberPath, "/") {
 		proberPath = "/" + proberPath
@@ -522,8 +518,11 @@ func (s *Server) handleAppProbe(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
+	// Reset the timeout duration of HTTP client for each specific prober.
+	s.appProbeClient.Timeout = time.Duration(prober.TimeoutSeconds) * time.Second
+
 	// Send the request.
-	response, err := httpClient.Do(appReq)
+	response, err := s.appProbeClient.Do(appReq)
 	if err != nil {
 		log.Errorf("Request to probe app failed: %v, original URL path = %v\napp URL path = %v", err, path, proberPath)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -97,7 +97,7 @@ type Server struct {
 	prometheus          *PrometheusScrapeConfiguration
 	mutex               sync.RWMutex
 	appKubeProbers      KubeAppProbers
-	appProbeClient      map[string]*http.Client
+	appProbeClient      *http.Client
 	statusPort          uint16
 	lastProbeSuccessful bool
 	envoyStatsPort      int
@@ -162,7 +162,6 @@ func NewServer(config Config) (*Server, error) {
 		return nil, fmt.Errorf("failed to decode app prober err = %v, json string = %v", err, config.KubeAppProbers)
 	}
 
-	s.appProbeClient = make(map[string]*http.Client, len(s.appKubeProbers))
 	// Validate the map key matching the regex pattern.
 	for path, prober := range s.appKubeProbers {
 		if !appProberPattern.Match([]byte(path)) {
@@ -174,14 +173,16 @@ func NewServer(config Config) (*Server, error) {
 		if prober.HTTPGet.Port.Type != intstr.Int {
 			return nil, fmt.Errorf("invalid prober config for %v, the port must be int type", path)
 		}
-		// Construct a http client and cache it in order to reuse the connection.
-		s.appProbeClient[path] = &http.Client{
-			Timeout: time.Duration(prober.TimeoutSeconds) * time.Second,
-			// We skip the verification since kubelet skips the verification for HTTPS prober as well
-			// https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			},
+
+		// Construct a http client and cache it in order to reuse the cached TCP connections.
+		if s.appProbeClient == nil {
+			s.appProbeClient = &http.Client{
+				// We skip the verification since kubelet skips the verification for HTTPS prober as well
+				// https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+				Transport: &http.Transport{
+					TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+				},
+			}
 		}
 	}
 
@@ -198,6 +199,12 @@ func FormatProberURL(container string) (string, string, string) {
 
 // Run opens a the status port and begins accepting probes.
 func (s *Server) Run(ctx context.Context) {
+	defer func() {
+		if s.appProbeClient != nil {
+			s.appProbeClient.CloseIdleConnections()
+		}
+	}()
+
 	log.Infof("Opening status port %d\n", s.statusPort)
 
 	mux := http.NewServeMux()
@@ -477,8 +484,10 @@ func (s *Server) handleAppProbe(w http.ResponseWriter, req *http.Request) {
 		_, _ = w.Write([]byte(fmt.Sprintf("app prober config does not exists for %v", path)))
 		return
 	}
-	// get the http client must exist because
-	httpClient := s.appProbeClient[path]
+
+	httpClient := s.appProbeClient
+	// Reset the timeout duration of HTTP client for each specific prober.
+	httpClient.Timeout = time.Duration(prober.TimeoutSeconds) * time.Second
 
 	proberPath := prober.HTTPGet.Path
 	if !strings.HasPrefix(proberPath, "/") {


### PR DESCRIPTION
There is no need to cache an `http.Client` for each probe, `http.Client` is goroutine-safe and the Go team encourages users to reuse it to benefit from the cached TCP connections in its internal `RoundTripper`, see https://golang.org/pkg/net/http/#Client.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[x] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
