### PR TITLE
pilot-agent: reuse HTTP client to benefit from cached TCP connections

### DIFF
--- a/pilot/cmd/pilot-agent/status/util/util.go
+++ b/pilot/cmd/pilot-agent/status/util/util.go
@@ -24,11 +24,10 @@ import (
 
 const requestTimeout = time.Second * 1 // Default timeout.
 
-func doHTTPGetWithTimeout(requestURL string, t time.Duration) (*bytes.Buffer, error) {
-	httpClient := &http.Client{
-		Timeout: t,
-	}
+var httpClient = http.Client{}
 
+func doHTTPGetWithTimeout(requestURL string, t time.Duration) (*bytes.Buffer, error) {
+	httpClient.Timeout = t
 	response, err := httpClient.Get(requestURL)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
`http.Client` is goroutine-safe and the Go team encourages users to reuse it to benefit from the cached TCP connections in its internal `RoundTripper`, see https://golang.org/pkg/net/http/#Client.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[x] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
