### PR TITLE
Fix istioctl upgrade fails for 1.6.x to 1.7.x

### DIFF
--- a/operator/pkg/helm/helm.go
+++ b/operator/pkg/helm/helm.go
@@ -326,7 +326,7 @@ func GetProfileYAML(installPackagePath, profileOrPath string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		baseCRYAML, err = util.OverlayIOP(defaultYAML, baseCRYAML)
+		baseCRYAML, err = util.OverlayYAML(defaultYAML, baseCRYAML)
 		if err != nil {
 			return "", err
 		}

--- a/releasenotes/notes/28595.yaml
+++ b/releasenotes/notes/28595.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+issue:
+  - 28595
+releaseNotes:
+  - |
+    **Fixed** istioctl upgrade failure from 1.6.x to 1.7.x


### PR DESCRIPTION
Please provide a description for what this PR is for. 
https://github.com/istio/istio/issues/28595

The current output is:

```
2020-11-29T23:35:47.590678Z     info    Error: failed to generate Istio configs from file [] for the current version: 1.6.8, error: externalComponentSpec for the json field "grafana" is not supported in current version

Error: failed to generate Istio configs from file [] for the current version: 1.6.8, error: externalComponentSpec for the json field "grafana" is not supported in current version
```

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
