### PR TITLE
[DNS Capture]: Do not allocate ip address for DNSLB service

### DIFF
--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -185,7 +185,7 @@ func convertServices(cfg config.Config) []*model.Service {
 						Ports:        svcPorts,
 						Resolution:   resolution,
 						Attributes: model.ServiceAttributes{
-							ServiceRegistry: string(serviceregistry.External),
+							ServiceRegistry: serviceregistry.External,
 							Name:            hostname,
 							Namespace:       cfg.Namespace,
 							ExportTo:        exportTo,
@@ -202,7 +202,7 @@ func convertServices(cfg config.Config) []*model.Service {
 						Ports:        svcPorts,
 						Resolution:   resolution,
 						Attributes: model.ServiceAttributes{
-							ServiceRegistry: string(serviceregistry.External),
+							ServiceRegistry: serviceregistry.External,
 							Name:            hostname,
 							Namespace:       cfg.Namespace,
 							ExportTo:        exportTo,
@@ -221,7 +221,7 @@ func convertServices(cfg config.Config) []*model.Service {
 				Ports:        svcPorts,
 				Resolution:   resolution,
 				Attributes: model.ServiceAttributes{
-					ServiceRegistry: string(serviceregistry.External),
+					ServiceRegistry: serviceregistry.External,
 					Name:            hostname,
 					Namespace:       cfg.Namespace,
 					ExportTo:        exportTo,

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
@@ -856,7 +856,7 @@ func autoAllocateIPs(services []*model.Service) []*model.Service {
 	// To avoid allocating 240.240.(i).255, if X % 255 is 0, increment X.
 	// For example, when X=510, the resulting IP would be 240.240.2.0 (invalid)
 	// So we bump X to 511, so that the resulting IP is 240.240.2.1
-	maxIPs := 255 * 255 // are we going to exceeed this limit by processing 64K services?
+	maxIPs := 255 * 255 // are we going to exceed this limit by processing 64K services?
 	x := 0
 	for _, svc := range services {
 		// we can allocate IPs only if
@@ -865,7 +865,7 @@ func autoAllocateIPs(services []*model.Service) []*model.Service {
 		// 2. the address is not set (0.0.0.0)
 		// 3. the hostname is not a wildcard
 		if svc.Address == constants.UnspecifiedIP && !svc.Hostname.IsWildCarded() &&
-			svc.Resolution != model.Passthrough {
+			svc.Resolution != model.Passthrough && svc.Resolution != model.DNSLB {
 			x++
 			if x%255 == 0 {
 				x++

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
@@ -1303,7 +1303,7 @@ func Test_autoAllocateIP_conditions(t *testing.T) {
 			},
 		},
 		{
-			name: "allocate IP for dns lb",
+			name: "no allocate IP for dns lb",
 			inServices: []*model.Service{
 				{
 					Hostname:   "foo.com",
@@ -1313,10 +1313,9 @@ func Test_autoAllocateIP_conditions(t *testing.T) {
 			},
 			wantServices: []*model.Service{
 				{
-					Hostname:             "foo.com",
-					Resolution:           model.DNSLB,
-					Address:              "0.0.0.0",
-					AutoAllocatedAddress: "240.240.0.1",
+					Hostname:   "foo.com",
+					Resolution: model.DNSLB,
+					Address:    "0.0.0.0",
 				},
 			},
 		},

--- a/pilot/pkg/xds/nds_test.go
+++ b/pilot/pkg/xds/nds_test.go
@@ -54,16 +54,12 @@ func TestNDS(t *testing.T) {
 	}
 	expectedNameTable := &nds.NameTable{
 		Table: map[string]*nds.NameTable_NameInfo{
-			"random-1.host.example": {
-				Ips:      []string{"240.240.0.1"},
-				Registry: "External",
-			},
 			"random-2.host.example": {
 				Ips:      []string{"9.9.9.9"},
 				Registry: "External",
 			},
 			"random-3.host.example": {
-				Ips:      []string{"240.240.0.2"},
+				Ips:      []string{"240.240.0.1"},
 				Registry: "External",
 			},
 		},

--- a/pilot/pkg/xds/testdata/nds-se.yaml
+++ b/pilot/pkg/xds/testdata/nds-se.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   hosts:
     - random-1.host.example
-  # expect address to be auto allocated
   ports:
     - number: 80
       name: http


### PR DESCRIPTION
Fix part of #29224

Without this, 

if we have defined this SE:

```
apiVersion: networking.istio.io/v1alpha3
kind: ServiceEntry
metadata:
  name: external-svc-https
spec:
  hosts:
  - www.google.com
  location: MESH_EXTERNAL
  ports:
  - number: 443
    name: https
    protocol: TLS
  resolution: DNS

```

Then we could not access `curl http://www.google.com:80`, the address is unaccessible.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.