### PR TITLE
istio-agent/health: reuse the HTTP client of prober

### DIFF
--- a/pkg/istio-agent/health/health_check.go
+++ b/pkg/istio-agent/health/health_check.go
@@ -51,7 +51,7 @@ func NewWorkloadHealthChecker(cfg *v1alpha3.ReadinessProbe) *WorkloadHealthCheck
 	var prober Prober
 	switch healthCheckMethod := cfg.HealthCheckMethod.(type) {
 	case *v1alpha3.ReadinessProbe_HttpGet:
-		prober = &HTTPProber{Config: healthCheckMethod.HttpGet}
+		prober = NewHTTPProber(healthCheckMethod.HttpGet)
 	case *v1alpha3.ReadinessProbe_TcpSocket:
 		prober = &TCPProber{Config: healthCheckMethod.TcpSocket}
 	case *v1alpha3.ReadinessProbe_Exec:

--- a/pkg/istio-agent/health/health_probers.go
+++ b/pkg/istio-agent/health/health_probers.go
@@ -66,7 +66,9 @@ type HTTPProber struct {
 
 func NewHTTPProber(cfg *v1alpha3.HTTPHealthCheckConfig) *HTTPProber {
 	h := new(HTTPProber)
-	// Create a http.Transport with TLSClientConfig for HTTPProber if the scheme is https,
+	h.Config = cfg
+
+	// Create an http.Transport with TLSClientConfig for HTTPProber if the scheme is https,
 	// otherwise set up an empty one.
 	if cfg.Scheme == string(scheme.HTTPS) {
 		h.Transport = &http.Transport{

--- a/pkg/istio-agent/health/health_probers_test.go
+++ b/pkg/istio-agent/health/health_probers_test.go
@@ -58,14 +58,13 @@ func TestHttpProber(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			server, port := createHTTPServer(tt.statusCode)
 			defer server.Close()
-			httpProber := HTTPProber{
-				Config: &v1alpha3.HTTPHealthCheckConfig{
+			httpProber := NewHTTPProber(
+				&v1alpha3.HTTPHealthCheckConfig{
 					Path:   "/test/health/check",
 					Port:   port,
 					Host:   "127.0.0.1",
 					Scheme: "http",
-				},
-			}
+				})
 
 			if tt.statusCode == -1 {
 				server.Close()


### PR DESCRIPTION
Reuse the HTTP client for each prober to benefit from cached TCP connections inside the `http.Transport`.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[x] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
