### PR TITLE
pkg/queue: improve the capacity of execute channel

### DIFF
--- a/pkg/queue/delay.go
+++ b/pkg/queue/delay.go
@@ -122,11 +122,11 @@ var workerChanBuf = func() int {
 		return 0
 	}
 
-	// Make channel non-blocking and set up the its capacity with GOMAXPROCS if GOMAXPROCS>1,
+	// Make channel non-blocking and set up its capacity with GOMAXPROCS if GOMAXPROCS>1,
 	// otherwise the sender might be dragged down if the receiver is CPU-bound.
 	//
 	// GOMAXPROCS determines how many goroutines can run in parallel,
-	// which make it the best choice as the channel capacity,
+	// which makes it the best choice as the channel capacity,
 	return n
 }()
 

--- a/pkg/queue/delay.go
+++ b/pkg/queue/delay.go
@@ -113,17 +113,21 @@ func DelayQueueWorkers(workers int) DelayQueueOption {
 
 // workerChanBuf determines whether the channel of a worker should be a buffered channel
 // to get the best performance.
-var workerChanBuf = func() (n int) {
+var workerChanBuf = func() int {
 	// Use blocking channel if GOMAXPROCS=1.
 	// This switches context from sender to receiver immediately,
 	// which results in higher performance.
+	var n int
 	if n = runtime.GOMAXPROCS(0); n == 1 {
 		return 0
 	}
 
-	// Use non-blocking workerChan if GOMAXPROCS>1,
-	// since otherwise the sender might be dragged down if the receiver is CPU-bound.
-	return
+	// Make channel non-blocking and set up the its capacity with GOMAXPROCS if GOMAXPROCS>1,
+	// otherwise the sender might be dragged down if the receiver is CPU-bound.
+	//
+	// GOMAXPROCS determines how many goroutines can run in parallel,
+	// which make it the best choice as the channel capacity,
+	return n
 }()
 
 // NewDelayed gives a Delayed queue with maximum concurrency specified by workers.

--- a/pkg/queue/delay.go
+++ b/pkg/queue/delay.go
@@ -113,17 +113,17 @@ func DelayQueueWorkers(workers int) DelayQueueOption {
 
 // workerChanBuf determines whether the channel of a worker should be a buffered channel
 // to get the best performance.
-var workerChanBuf = func() int {
+var workerChanBuf = func() (n int) {
 	// Use blocking channel if GOMAXPROCS=1.
 	// This switches context from sender to receiver immediately,
 	// which results in higher performance.
-	if runtime.GOMAXPROCS(0) == 1 {
+	if n = runtime.GOMAXPROCS(0); n == 1 {
 		return 0
 	}
 
 	// Use non-blocking workerChan if GOMAXPROCS>1,
 	// since otherwise the sender might be dragged down if the receiver is CPU-bound.
-	return 1
+	return
 }()
 
 // NewDelayed gives a Delayed queue with maximum concurrency specified by workers.


### PR DESCRIPTION
This is a tiny improvement for #29226 
As we all know, the number of `P` determines how many goroutines can run in parallel, thus it would be a better choice for the buffered size of `execute` channel.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[x] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
