### PR TITLE
Fix CNI test flakes

### DIFF
--- a/cni/pkg/install-cni/pkg/install/cniconfig_test.go
+++ b/cni/pkg/install-cni/pkg/install/cniconfig_test.go
@@ -279,7 +279,7 @@ func TestGetCNIConfigFilepath(t *testing.T) {
 				return
 			case err := <-errChan:
 				t.Fatal(err)
-			case <-time.After(100 * time.Millisecond):
+			case <-time.After(250 * time.Millisecond):
 				if len(c.delayedConfName) > 0 {
 					// Delayed case
 					// Write delayed CNI config file
@@ -311,7 +311,7 @@ func TestGetCNIConfigFilepath(t *testing.T) {
 				}
 			case err := <-errChan:
 				t.Fatal(err)
-			case <-time.After(100 * time.Millisecond):
+			case <-time.After(250 * time.Millisecond):
 				t.Fatalf("timed out waiting for expected %s", expectedFilepath)
 			}
 		})


### PR DESCRIPTION
This is timing out very rarely, seems like 1/10000 runs locally. Bump the timeout a bit to resolve