### PR TITLE
Fix and run  Test_KubeSecretController in CI

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -160,7 +160,7 @@ func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string)
 	if m.serviceController.Running() {
 		go kubeRegistry.Run(stopCh)
 	}
-	if m.fetchCaRoot() != nil && (features.ExternalIstioD || features.CentralIstioD || localCluster) {
+	if m.fetchCaRoot != nil && m.fetchCaRoot() != nil && (features.ExternalIstioD || features.CentralIstioD || localCluster) {
 		// TODO remove initNamespaceController (and probably need leader election here? how will that work with multi-primary?)
 		log.Infof("joining leader-election for %s in %s", leaderelection.NamespaceController, options.SystemNamespace)
 		go leaderelection.

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
@@ -1,5 +1,3 @@
-// +build !race
-
 // Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -77,7 +75,6 @@ func verifyControllers(t *testing.T, m *Multicluster, expectedControllerCount in
 	})
 }
 
-// This test is skipped by the build tag !race due to https://github.com/istio/istio/issues/15610
 func Test_KubeSecretController(t *testing.T) {
 	secretcontroller.BuildClientsFromConfig = func(kubeConfig []byte) (kube.Client, error) {
 		return kube.NewFakeClient(), nil
@@ -99,7 +96,7 @@ func Test_KubeSecretController(t *testing.T) {
 		},
 		mockserviceController,
 		nil, "", nil, nil)
-
+	mc.InitSecretController(stop)
 	cache.WaitForCacheSync(stop, mc.HasSynced)
 	clientset.RunAndWait(stop)
 


### PR DESCRIPTION
This was skipped in race test, which is always used in our CI. Enabling
in all modes and fixing the failures (this broke a week ago or so)



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.