### PR TITLE
[release-1.8] istioctl upgrade: fix downgrade to lower version (#29191)

### DIFF
--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -160,7 +160,7 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l clog.Logger) (err error) {
 	}
 
 	// Check if the upgrade currentVersion -> targetVersion is supported
-	err = checkSupportedVersions(kubeClient, currentVersion)
+	err = checkSupportedVersions(kubeClient, currentVersion, targetVersion, l)
 	if err != nil && !args.force {
 		return fmt.Errorf("upgrade version check failed: %v -> %v. Error: %v",
 			currentVersion, targetVersion, err)

--- a/operator/cmd/mesh/upgrade.go
+++ b/operator/cmd/mesh/upgrade.go
@@ -261,19 +261,34 @@ func waitForConfirmation(skipConfirmation bool, l clog.Logger) {
 	}
 }
 
-var SupportedIstioVersions, _ = goversion.NewConstraint(">=1.6.0, <1.8")
+var upgradeSupportStart, _ = goversion.NewVersion("1.6.0")
 
-func checkSupportedVersions(kubeClient *Client, currentVersion string) error {
+func checkSupportedVersions(kubeClient *Client, currentVersion, targetVersion string, l clog.Logger) error {
+	if err := verifySupportedVersion(currentVersion, targetVersion, l); err != nil {
+		return err
+	}
+	return kubeClient.CheckUnsupportedAlphaSecurityCRD()
+}
+
+func verifySupportedVersion(currentVersion, targetVersion string, l clog.Logger) error {
 	curGoVersion, err := goversion.NewVersion(currentVersion)
 	if err != nil {
 		return fmt.Errorf("failed to parse the current version %q: %v", currentVersion, err)
 	}
-
-	if !SupportedIstioVersions.Check(curGoVersion) {
-		return fmt.Errorf("upgrade is currently not supported from version: %v", currentVersion)
+	targetGoVersion, err := goversion.NewVersion(targetVersion)
+	if err != nil {
+		return fmt.Errorf("failed to parse the target version %q: %v", targetVersion, err)
 	}
-
-	return kubeClient.CheckUnsupportedAlphaSecurityCRD()
+	if upgradeSupportStart.Segments()[1] > curGoVersion.Segments()[1] {
+		return fmt.Errorf("upgrade is not supported before version: %v", upgradeSupportStart)
+	}
+	// Warn if user is trying skip one minor verion eg: 1.6.x to 1.8.x
+	if (targetGoVersion.Segments()[1] - curGoVersion.Segments()[1]) > 1 {
+		l.LogAndPrint("!!! WARNING !!!")
+		l.LogAndPrintf("Upgrading across more than one minor version (e.g., %v to %v)"+
+			" in one step is not officially tested or recommended.\n", curGoVersion, targetGoVersion)
+	}
+	return nil
 }
 
 // retrieveControlPlaneVersion retrieves the version number from the Istio control plane

--- a/operator/cmd/mesh/upgrade_test.go
+++ b/operator/cmd/mesh/upgrade_test.go
@@ -1,0 +1,91 @@
+// Copyright Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mesh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"istio.io/istio/operator/pkg/util/clog"
+)
+
+func TestVerifySupportedVersions(t *testing.T) {
+	cases := []struct {
+		currentVer string
+		targetVer  string
+		err        error
+		isValid    bool
+	}{
+		{
+			currentVer: "",
+			targetVer:  "1.9.0",
+			err:        fmt.Errorf("failed to parse the current version %v: Malformed version: ", ""),
+			isValid:    false,
+		},
+		{
+			currentVer: "master",
+			targetVer:  "1.9.0",
+			err:        fmt.Errorf("failed to parse the current version %v: Malformed version: ", "master"),
+			isValid:    false,
+		},
+		{
+			currentVer: "1.7.4",
+			targetVer:  "1.8.0",
+			err:        nil,
+			isValid:    true,
+		},
+		{
+			currentVer: "1.8.0",
+			targetVer:  "1.9.0",
+			err:        nil,
+			isValid:    true,
+		},
+		{
+			currentVer: "1.8.0",
+			targetVer:  "1.7.4",
+			err:        nil,
+			isValid:    true,
+		},
+		{
+			currentVer: "1.9.0",
+			targetVer:  "",
+			err:        fmt.Errorf("failed to parse the target version %v: Malformed version: %v", "", ""),
+			isValid:    false,
+		},
+		{
+			currentVer: "1.5.8",
+			targetVer:  "1.8.0",
+			err:        fmt.Errorf("upgrade is not supported before version: %v", upgradeSupportStart),
+			isValid:    false,
+		},
+		{
+			currentVer: "1.8.0",
+			targetVer:  "1.8.0",
+			err:        nil,
+			isValid:    true,
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case %d %s", i, c.currentVer), func(t *testing.T) {
+			l := clog.NewConsoleLogger(os.Stdout, os.Stderr, nil)
+			err := verifySupportedVersion(c.currentVer, c.targetVer, l)
+			if c.isValid && err != nil {
+				t.Errorf("(curr: %v)(target: %v)(%v)", c.currentVer, c.targetVer, err)
+			}
+		})
+	}
+}

--- a/releasenotes/notes/29183.yaml
+++ b/releasenotes/notes/29183.yaml
@@ -1,0 +1,11 @@
+apiVersion: release-notes/v2
+kind:
+  bug-fix
+area:
+  istioctl
+issue:
+  - 29183
+
+releaseNotes:
+  - |
+    **Fixed** an issue showing unnecessary warnings when downgrading to a lower version of Istio.


### PR DESCRIPTION
Manually cherry-pick of https://github.com/istio/istio/pull/29191



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.