### PR TITLE
Add 2 fuzzers

### DIFF
--- a/tests/fuzz/fuzz.go
+++ b/tests/fuzz/fuzz.go
@@ -1,0 +1,38 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build gofuzz
+
+package fuzz
+
+import (
+	"github.com/istio/istio/pilot/pkg/config/kube/crd"
+	"github.com/istio/istio/pkg/config/schema"
+)
+
+func FuzzParseInputs(data []byte) int {
+	_, _, err := crd.ParseInputs(string(data))
+	if err != nil {
+		return 0
+	}
+	return 1
+}
+
+func FuzzParseAndBuildSchema(data []byte) int {
+	_, err := schema.ParseAndBuild(string(data))
+	if err != nil {
+		return 0
+	}
+	return 1
+}

--- a/tests/fuzz/fuzz.go
+++ b/tests/fuzz/fuzz.go
@@ -17,8 +17,8 @@
 package fuzz
 
 import (
-	"github.com/istio/istio/pilot/pkg/config/kube/crd"
-	"github.com/istio/istio/pkg/config/schema"
+	"istio.io/istio/pilot/pkg/config/kube/crd"
+	"istio.io/istio/pkg/config/schema"
 )
 
 func FuzzParseInputs(data []byte) int {


### PR DESCRIPTION
There have been discussions on adding fuzzing to Istio and setting up continuous fuzzing as well. See https://github.com/istio/istio/issues/14935

This PR adds 2 fuzzers that are implemented by way of Dvyukovs go-fuzz which is supported by OSS-fuzz.

In a few minutes I will set up the integration files on the OSS-fuzz side. They will fail for now, but once the fuzzers are merged here, they will build sucessfully.
