### PR TITLE
fix(listener_builder.go): move tcpProxyFilter pointer constructor to for loop #29318

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -495,10 +495,6 @@ func buildInboundCatchAllNetworkFilterChains(configgen *ConfigGeneratorImpl,
 		}
 
 		accessLogBuilder.setTCPAccessLog(push.Mesh, tcpProxy, node)
-		tcpProxyFilter := &listener.Filter{
-			Name:       wellknown.TCPProxy,
-			ConfigType: &listener.Filter_TypedConfig{TypedConfig: util.MessageToAny(tcpProxy)},
-		}
 
 		in := &plugin.InputParams{
 			Node:             node,
@@ -533,6 +529,10 @@ func buildInboundCatchAllNetworkFilterChains(configgen *ConfigGeneratorImpl,
 
 		// Construct the actual filter chains for each of the filter chain from the plugin.
 		for _, chain := range allChains {
+			tcpProxyFilter := &listener.Filter{
+				Name:       wellknown.TCPProxy,
+				ConfigType: &listener.Filter_TypedConfig{TypedConfig: util.MessageToAny(tcpProxy)},
+			}
 			filterChain := &listener.FilterChain{
 				FilterChainMatch: chain.FilterChainMatch,
 				Filters:          append(chain.TCP, tcpProxyFilter),


### PR DESCRIPTION
avoid tcpProxyFilter pointer shared causing envoyfilter patch twice to the same filter


refer to issue #29318


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.