### PR TITLE
remove unused cert option in self sign ca flow

### DIFF
--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -141,7 +141,6 @@ func NewSelfSignedIstioCAOptions(ctx context.Context,
 			IsCA:         true,
 			IsSelfSigned: true,
 			RSAKeySize:   caRSAKeySize,
-			IsDualUse:    dualUse,
 		}
 		pemCert, pemKey, ckErr := util.GenCertKeyFromOptions(options)
 		if ckErr != nil {


### PR DESCRIPTION

"IsDualUse" option is provide but not used.

```go
// security/pkg/pki/util/generate_cert.go

func genCertTemplateFromOptions() {
 ...
	exts := []pkix.Extension{}
	if h := options.Host; len(h) > 0 {
		s, err := BuildSubjectAltNameExtension(h)
		if err != nil {
			return nil, err
		}
		if options.IsDualUse {
			cn, err := DualUseCommonName(h)
			if err != nil {
				// log and continue
				log.Errorf("dual-use failed for cert template - omitting CN (%v)", err)
			} else {
				subject.CommonName = cn
			}
		}
		exts = []pkix.Extension{*s}
	}
...
}
```

This option is used unless cert Host is specified.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[X] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.