### PR TITLE
istioctl uninstall: disallow using --purge flag with revision or operator file

### DIFF
--- a/operator/cmd/mesh/uninstall.go
+++ b/operator/cmd/mesh/uninstall.go
@@ -106,6 +106,9 @@ func UninstallCmd(logOpts *log.Options) *cobra.Command {
 			if uiArgs.revision == "" && uiArgs.filename == "" && !uiArgs.purge {
 				return fmt.Errorf("at least one of the --revision, --filename or --purge flags must be set")
 			}
+			if uiArgs.purge && (uiArgs.revision != "" || uiArgs.filename != "") {
+				return fmt.Errorf("cannot uninstall with the purge option while specifying a revision or operator file")
+			}
 			if len(args) > 0 {
 				return fmt.Errorf("istioctl uninstall does not take arguments")
 			}


### PR DESCRIPTION
When performing a `--purge` uninstall all istio resources will be removed. If a user specified a revision or operator file along with the `--purge` flag, it was most likely a mistake and we should display a warning + bail out. 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
