### PR TITLE
[1.8] Cherrypick inbound cluster format changes

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -850,7 +850,8 @@ func ParseIstioVersion(ver string) *IstioVersion {
 	// we are guaranteed to have atleast major and minor based on the regex
 	major, _ := strconv.Atoi(parts[0])
 	minor, _ := strconv.Atoi(parts[1])
-	patch := 0
+	// Assume very large patch release if not set
+	patch := 65535
 	if len(parts) > 2 {
 		patch, _ = strconv.Atoi(parts[2])
 	}

--- a/pilot/pkg/model/context_test.go
+++ b/pilot/pkg/model/context_test.go
@@ -469,17 +469,17 @@ func Test_parseIstioVersion(t *testing.T) {
 		{
 			name: "major.minor",
 			args: args{ver: "1.2"},
-			want: &model.IstioVersion{Major: 1, Minor: 2, Patch: 0},
+			want: &model.IstioVersion{Major: 1, Minor: 2, Patch: 65535},
 		},
 		{
 			name: "dev",
 			args: args{ver: "1.5-alpha.f70faea2aa817eeec0b08f6cc3b5078e5dcf3beb"},
-			want: &model.IstioVersion{Major: 1, Minor: 5, Patch: 0},
+			want: &model.IstioVersion{Major: 1, Minor: 5, Patch: 65535},
 		},
 		{
 			name: "release-major.minor-date",
 			args: args{ver: "release-1.2-123214234"},
-			want: &model.IstioVersion{Major: 1, Minor: 2, Patch: 0},
+			want: &model.IstioVersion{Major: 1, Minor: 2, Patch: 65535},
 		},
 		{
 			name: "master-date",

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder.go
@@ -110,8 +110,7 @@ func (cb *ClusterBuilder) applyDestinationRule(c *cluster.Cluster, clusterMode C
 			}
 		}
 
-		subsetCluster := cb.buildDefaultCluster(subsetClusterName, c.GetType(), lbEndpoints,
-			model.TrafficDirectionOutbound, port, service)
+		subsetCluster := cb.buildDefaultCluster(subsetClusterName, c.GetType(), lbEndpoints, model.TrafficDirectionOutbound, port, service, nil)
 
 		if subsetCluster == nil {
 			continue
@@ -190,7 +189,10 @@ func MergeTrafficPolicy(original, subsetPolicy *networking.TrafficPolicy, port *
 // buildDefaultCluster builds the default cluster and also applies default traffic policy.
 func (cb *ClusterBuilder) buildDefaultCluster(name string, discoveryType cluster.Cluster_DiscoveryType,
 	localityLbEndpoints []*endpoint.LocalityLbEndpoints, direction model.TrafficDirection,
-	port *model.Port, service *model.Service) *cluster.Cluster {
+	port *model.Port, service *model.Service, allInstances []*model.ServiceInstance) *cluster.Cluster {
+	if allInstances == nil {
+		allInstances = cb.proxy.ServiceInstances
+	}
 	c := &cluster.Cluster{
 		Name:                 name,
 		ClusterDiscoveryType: &cluster.Cluster_Type{Type: discoveryType},
@@ -236,17 +238,25 @@ func (cb *ClusterBuilder) buildDefaultCluster(name string, discoveryType cluster
 		opts.meshExternal = service.MeshExternal
 	}
 	applyTrafficPolicy(opts)
-	addTelemetryMetadata(opts, service, direction)
+	addTelemetryMetadata(opts, service, direction, allInstances)
 	addNetworkingMetadata(opts, service, direction)
 	return c
 }
 
-func (cb *ClusterBuilder) buildInboundClusterForPortOrUDS(proxy *model.Proxy, instance *model.ServiceInstance, bind string) *cluster.Cluster {
+// buildInboundClusterForPortOrUDS constructs a single inbound listener. The cluster will be bound to
+// `inbound|clusterPort||`, and send traffic to <bind>:<instance.Endpoint.EndpointPort>. A workload
+// will have a single inbound cluster per port. In general this works properly, with the exception of
+// the Service-oriented DestinationRule, and upstream protocol selection. Our documentation currently
+// requires a single protocol per port, and the DestinationRule issue is slated to move to Sidecar.
+// Note: clusterPort and instance.Endpoint.EndpointPort are identical for standard Services; however,
+// Sidecar.Ingress allows these to be different.
+func (cb *ClusterBuilder) buildInboundClusterForPortOrUDS(proxy *model.Proxy, clusterPort int, bind string,
+	instance *model.ServiceInstance, allInstance []*model.ServiceInstance) *cluster.Cluster {
 	clusterName := util.BuildInboundSubsetKey(proxy, instance.ServicePort.Name,
-		instance.Service.Hostname, instance.ServicePort.Port)
+		instance.Service.Hostname, instance.ServicePort.Port, clusterPort)
 	localityLbEndpoints := buildInboundLocalityLbEndpoints(bind, instance.Endpoint.EndpointPort)
 	localCluster := cb.buildDefaultCluster(clusterName, cluster.Cluster_STATIC, localityLbEndpoints,
-		model.TrafficDirectionInbound, instance.ServicePort, instance.Service)
+		model.TrafficDirectionInbound, instance.ServicePort, instance.Service, allInstance)
 	// If stat name is configured, build the alt statname.
 	if len(cb.push.Mesh.InboundClusterStatName) != 0 {
 		localCluster.AltStatName = util.BuildStatPrefix(cb.push.Mesh.InboundClusterStatName,

--- a/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_builder_test.go
@@ -748,12 +748,10 @@ func TestBuildDefaultCluster(t *testing.T) {
 			cg := NewConfigGenTest(t, TestOptions{MeshConfig: &testMesh})
 			cb := NewClusterBuilder(cg.SetupProxy(nil), cg.PushContext())
 
-			defaultCluster := cb.buildDefaultCluster(tt.clusterName, tt.discovery,
-				tt.endpoints, tt.direction, servicePort,
-				&model.Service{Ports: model.PortList{
-					servicePort,
-				},
-					Hostname: "host", MeshExternal: false, Attributes: model.ServiceAttributes{Name: "svc", Namespace: "default"}})
+			defaultCluster := cb.buildDefaultCluster(tt.clusterName, tt.discovery, tt.endpoints, tt.direction, servicePort, &model.Service{Ports: model.PortList{
+				servicePort,
+			},
+				Hostname: "host", MeshExternal: false, Attributes: model.ServiceAttributes{Name: "svc", Namespace: "default"}}, nil)
 
 			if diff := cmp.Diff(defaultCluster, tt.expectedCluster, protocmp.Transform()); diff != "" {
 				t.Errorf("Unexpected default cluster, diff: %v", diff)

--- a/pilot/pkg/networking/core/v1alpha3/fake.go
+++ b/pilot/pkg/networking/core/v1alpha3/fake.go
@@ -210,6 +210,9 @@ func (f *ConfigGenTest) SetupProxy(p *model.Proxy) *model.Proxy {
 	if p.ConfigNamespace == "" {
 		p.ConfigNamespace = "default"
 	}
+	if p.Metadata.Namespace == "" {
+		p.Metadata.Namespace = p.ConfigNamespace
+	}
 	if p.ID == "" {
 		p.ID = "app.test"
 	}

--- a/pilot/pkg/networking/core/v1alpha3/fake.go
+++ b/pilot/pkg/networking/core/v1alpha3/fake.go
@@ -199,7 +199,9 @@ func (f *ConfigGenTest) SetupProxy(p *model.Proxy) *model.Proxy {
 		p.Metadata = &model.NodeMetadata{}
 	}
 	if p.Metadata.IstioVersion == "" {
-		p.Metadata.IstioVersion = "1.8.0"
+		p.Metadata.IstioVersion = "1.9.0"
+	}
+	if p.IstioVersion == nil {
 		p.IstioVersion = model.ParseIstioVersion(p.Metadata.IstioVersion)
 	}
 	if p.Type == "" {

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -472,7 +472,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundHTTPListenerOptsForPort
 		// names here because the inbound clusters are not referred to anywhere in the API, unlike the outbound
 		// clusters and these are static endpoint clusters used only for sidecar (proxy -> app)
 		clusterName = util.BuildInboundSubsetKey(node, pluginParams.ServiceInstance.ServicePort.Name,
-			pluginParams.ServiceInstance.Service.Hostname, pluginParams.ServiceInstance.ServicePort.Port)
+			pluginParams.ServiceInstance.Service.Hostname, pluginParams.ServiceInstance.ServicePort.Port, int(pluginParams.ServiceInstance.Endpoint.EndpointPort))
 	}
 
 	httpOpts := &httpListenerOpts{
@@ -515,7 +515,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarThriftListenerOptsForPortOrUDS
 	// names here because the inbound clusters are not referred to anywhere in the API, unlike the outbound
 	// clusters and these are static endpoint clusters used only for sidecar (proxy -> app)
 	clusterName := util.BuildInboundSubsetKey(pluginParams.Node, pluginParams.ServiceInstance.ServicePort.Name,
-		pluginParams.ServiceInstance.Service.Hostname, int(pluginParams.ServiceInstance.Endpoint.EndpointPort))
+		pluginParams.ServiceInstance.Service.Hostname, pluginParams.ServiceInstance.ServicePort.Port, int(pluginParams.ServiceInstance.Endpoint.EndpointPort))
 
 	thriftOpts := &thriftListenerOpts{
 		transport:   thrift.TransportType_AUTO_TRANSPORT,
@@ -545,6 +545,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListenerForPortOrUDS(no
 		if old.instanceHostname != pluginParams.ServiceInstance.Service.Hostname {
 			// For sidecar specified listeners, the caller is expected to supply a dummy service instance
 			// with the right port and a hostname constructed from the sidecar config's name+namespace
+			// TODO everything in inbound listener is now workload oriented. We should no longer have listener conflicts.
 			pluginParams.Push.AddMetric(model.ProxyStatusConflictInboundListener, pluginParams.Node.ID, pluginParams.Node.ID,
 				fmt.Sprintf("Conflicting inbound listener:%d. existing: %s, incoming: %s", listenerOpts.port.Port,
 					old.instanceHostname, pluginParams.ServiceInstance.Service.Hostname))

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -43,7 +43,8 @@ var (
 
 // buildInboundNetworkFilters generates a TCP proxy network filter on the inbound path
 func buildInboundNetworkFilters(push *model.PushContext, instance *model.ServiceInstance, node *model.Proxy) []*listener.Filter {
-	clusterName := util.BuildInboundSubsetKey(node, instance.ServicePort.Name, instance.Service.Hostname, instance.ServicePort.Port)
+	clusterName := util.BuildInboundSubsetKey(node, instance.ServicePort.Name,
+		instance.Service.Hostname, instance.ServicePort.Port, int(instance.Endpoint.EndpointPort))
 	statPrefix := clusterName
 	// If stat name is configured, build the stat prefix from configured pattern.
 	if len(push.Mesh.InboundClusterStatName) != 0 {

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter_test.go
@@ -62,7 +62,7 @@ func TestInboundNetworkFilterStatPrefix(t *testing.T) {
 		{
 			"no pattern",
 			"",
-			"inbound|9999||",
+			"inbound|8888||",
 		},
 		{
 			"service only pattern",
@@ -96,7 +96,9 @@ func TestInboundNetworkFilterStatPrefix(t *testing.T) {
 					Port: 9999,
 					Name: "http",
 				},
-				Endpoint: &model.IstioEndpoint{},
+				Endpoint: &model.IstioEndpoint{
+					EndpointPort: 8888,
+				},
 			}
 
 			listeners := buildInboundNetworkFilters(env.PushContext, instance, &model.Proxy{})

--- a/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
@@ -523,6 +523,271 @@ func extractClusterMetadataServices(t test.Failer, c *cluster.Cluster) []string 
 	return res
 }
 
+func TestPortLevelPeerAuthentication(t *testing.T) {
+	pa := `
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+spec:
+  selector:
+    matchLabels:
+      app: foo
+  mtls:
+    mode: STRICT
+  portLevelMtls:
+    9090:
+      mode: DISABLE
+---`
+	sidecar := `
+apiVersion: networking.istio.io/v1alpha3
+kind: Sidecar
+metadata:
+  labels:
+    app: foo
+  name: sidecar
+spec:
+  ingress:
+  - defaultEndpoint: 127.0.0.1:8080
+    port:
+      name: tls
+      number: 8080
+      protocol: TCP
+  - defaultEndpoint: 127.0.0.1:9090
+    port:
+      name: plaintext
+      number: 9090
+      protocol: TCP
+  egress:
+  - hosts:
+    - "*/*"
+  workloadSelector:
+    labels:
+      app: foo
+---`
+	partialSidecar := `
+apiVersion: networking.istio.io/v1alpha3
+kind: Sidecar
+metadata:
+  labels:
+    app: foo
+  name: sidecar
+spec:
+  ingress:
+  - defaultEndpoint: 127.0.0.1:8080
+    port:
+      name: tls
+      number: 8080
+      protocol: TCP
+  egress:
+  - hosts:
+    - "*/*"
+  workloadSelector:
+    labels:
+      app: foo
+---`
+	instancePorts := `
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: se
+spec:
+  hosts:
+  - foo.bar
+  endpoints:
+  - address: 1.1.1.1
+    labels:
+      app: foo
+  location: MESH_INTERNAL
+  resolution: STATIC
+  ports:
+  - name: tls
+    number: 8080
+    protocol: TCP
+  - name: plaintext
+    number: 9090
+    protocol: TCP
+---`
+	instanceNoPorts := `
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: se
+spec:
+  hosts:
+  - foo.bar
+  endpoints:
+  - address: 1.1.1.1
+    labels:
+      app: foo
+  location: MESH_INTERNAL
+  resolution: STATIC
+  ports:
+  - name: random
+    number: 5050
+    protocol: TCP
+---`
+	mkCall := func(port int, tls simulation.TLSMode) simulation.Call {
+		// TODO https://github.com/istio/istio/issues/28506 address should not be required here
+		return simulation.Call{Port: port, CallMode: simulation.CallModeInbound, TLS: tls, Address: "1.1.1.1"}
+	}
+	cases := []struct {
+		name   string
+		config string
+		calls  []simulation.Expect
+	}{
+		{
+			name:   "service, no sidecar",
+			config: pa + instancePorts,
+			calls: []simulation.Expect{
+				{
+					Name:   "plaintext on tls port",
+					Call:   mkCall(8080, simulation.Plaintext),
+					Result: simulation.Result{Error: simulation.ErrNoFilterChain},
+				},
+				{
+					Name:   "tls on tls port",
+					Call:   mkCall(8080, simulation.MTLS),
+					Result: simulation.Result{ClusterMatched: "inbound|8080||"},
+				},
+				{
+					Name:   "plaintext on plaintext port",
+					Call:   mkCall(9090, simulation.Plaintext),
+					Result: simulation.Result{ClusterMatched: "inbound|9090||"},
+				},
+				{
+					Name:   "tls on plaintext port",
+					Call:   mkCall(9090, simulation.MTLS),
+					Result: simulation.Result{Error: simulation.ErrNoFilterChain},
+				},
+			},
+		},
+		{
+			name:   "service, full sidecar",
+			config: pa + sidecar + instancePorts,
+			calls: []simulation.Expect{
+				{
+					Name:   "plaintext on tls port",
+					Call:   mkCall(8080, simulation.Plaintext),
+					Result: simulation.Result{Error: simulation.ErrNoFilterChain},
+				},
+				{
+					Name:   "tls on tls port",
+					Call:   mkCall(8080, simulation.MTLS),
+					Result: simulation.Result{ClusterMatched: "inbound|8080||"},
+				},
+				{
+					Name:   "plaintext on plaintext port",
+					Call:   mkCall(9090, simulation.Plaintext),
+					Result: simulation.Result{ClusterMatched: "inbound|9090||"},
+				},
+				{
+					Name:   "tls on plaintext port",
+					Call:   mkCall(9090, simulation.MTLS),
+					Result: simulation.Result{Error: simulation.ErrNoFilterChain},
+				},
+			},
+		},
+		{
+			name:   "no service, no sidecar",
+			config: pa + instanceNoPorts,
+			calls: []simulation.Expect{
+				{
+					Name:   "plaintext on tls port",
+					Call:   mkCall(8080, simulation.Plaintext),
+					Result: simulation.Result{Error: simulation.ErrNoFilterChain},
+				},
+				{
+					Name: "tls on tls port",
+					Call: mkCall(8080, simulation.MTLS),
+					// no ports defined, so we will passthrough
+					Result: simulation.Result{ClusterMatched: "InboundPassthroughClusterIpv4"},
+				},
+				{
+					Name: "plaintext on plaintext port",
+					Call: mkCall(9090, simulation.Plaintext),
+					// no ports defined, so we will fail. STRICT enforced
+					// TODO(https://github.com/istio/istio/issues/27994) portLevelMtls should still apply
+					Result: simulation.Result{Error: simulation.ErrNoFilterChain},
+				},
+				{
+					Name: "tls on plaintext port",
+					Call: mkCall(9090, simulation.MTLS),
+					// no ports defined, so we will fail. STRICT allows
+					// TODO(https://github.com/istio/istio/issues/27994) portLevelMtls should still apply
+					Result: simulation.Result{ClusterMatched: "InboundPassthroughClusterIpv4"},
+				},
+			},
+		},
+		{
+			name:   "no service, full sidecar",
+			config: pa + sidecar + instanceNoPorts,
+			calls: []simulation.Expect{
+				{
+					Name:   "plaintext on tls port",
+					Call:   mkCall(8080, simulation.Plaintext),
+					Result: simulation.Result{Error: simulation.ErrNoFilterChain},
+				},
+				{
+					Name:   "tls on tls port",
+					Call:   mkCall(8080, simulation.MTLS),
+					Result: simulation.Result{ClusterMatched: "inbound|8080||"},
+				},
+				{
+					Name:   "plaintext on plaintext port",
+					Call:   mkCall(9090, simulation.Plaintext),
+					Result: simulation.Result{ClusterMatched: "inbound|9090||"},
+				},
+				{
+					Name:   "tls on plaintext port",
+					Call:   mkCall(9090, simulation.MTLS),
+					Result: simulation.Result{Error: simulation.ErrNoFilterChain},
+				},
+			},
+		},
+		{
+			name:   "service, partial sidecar",
+			config: pa + partialSidecar + instancePorts,
+			calls: []simulation.Expect{
+				{
+					Name:   "plaintext on tls port",
+					Call:   mkCall(8080, simulation.Plaintext),
+					Result: simulation.Result{Error: simulation.ErrNoFilterChain},
+				},
+				{
+					Name:   "tls on tls port",
+					Call:   mkCall(8080, simulation.MTLS),
+					Result: simulation.Result{ClusterMatched: "inbound|8080||"},
+				},
+				// Despite being defined in the Service, we get no filter chain since its not in Sidecar
+				// Since we do not create configs on passthrough, our port level policy is not defined
+				{
+					Name: "plaintext on plaintext port",
+					Call: mkCall(9090, simulation.Plaintext),
+					// no ports defined, so we will fail. STRICT enforced
+					// TODO(https://github.com/istio/istio/issues/27994) portLevelMtls should still apply
+					Result: simulation.Result{Error: simulation.ErrNoFilterChain},
+				},
+				{
+					Name: "tls on plaintext port",
+					Call: mkCall(9090, simulation.MTLS),
+					// no ports defined, so we will fail. STRICT allows
+					// TODO(https://github.com/istio/istio/issues/27994) portLevelMtls should still apply
+					Result: simulation.Result{ClusterMatched: "InboundPassthroughClusterIpv4"},
+				},
+			},
+		},
+	}
+	proxy := &model.Proxy{Metadata: &model.NodeMetadata{Labels: map[string]string{"app": "foo"}}}
+	for _, tt := range cases {
+		runSimulationTest(t, proxy, xds.FakeOptions{}, simulationTest{
+			name:   tt.name,
+			config: tt.config,
+			calls:  tt.calls,
+		})
+	}
+}
+
 func TestInbound(t *testing.T) {
 	mtlsMode := func(m string) string {
 		return fmt.Sprintf(`apiVersion: security.istio.io/v1beta1

--- a/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
@@ -15,16 +15,513 @@
 package v1alpha3_test
 
 import (
+	"encoding/json"
 	"fmt"
+	"reflect"
 	"sort"
+	"strings"
 	"testing"
 
+	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	"github.com/golang/protobuf/jsonpb"
+
 	meshconfig "istio.io/api/mesh/v1alpha1"
+	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/core/v1alpha3"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/simulation"
 	"istio.io/istio/pilot/pkg/xds"
+	"istio.io/istio/pilot/test/xdstest"
+	"istio.io/istio/pkg/config"
+	"istio.io/istio/pkg/config/host"
 	"istio.io/istio/pkg/config/mesh"
+	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/test"
 )
+
+func flattenInstances(il ...[]*model.ServiceInstance) []*model.ServiceInstance {
+	ret := []*model.ServiceInstance{}
+	for _, i := range il {
+		ret = append(ret, i...)
+	}
+	return ret
+}
+
+func makeInstances(proxy *model.Proxy, svc *model.Service, servicePort int, targetPort int) []*model.ServiceInstance {
+	ret := []*model.ServiceInstance{}
+	for _, p := range svc.Ports {
+		if p.Port != servicePort {
+			continue
+		}
+		ret = append(ret, &model.ServiceInstance{
+			Service:     svc,
+			ServicePort: p,
+			Endpoint: &model.IstioEndpoint{
+				Address:         proxy.IPAddresses[0],
+				ServicePortName: p.Name,
+				EndpointPort:    uint32(targetPort),
+			},
+		})
+	}
+	return ret
+}
+
+func TestInboundClusters(t *testing.T) {
+	proxy := &model.Proxy{
+		IPAddresses: []string{"1.2.3.4"},
+	}
+	proxy180 := &model.Proxy{
+		IPAddresses: []string{"1.2.3.4"},
+		Metadata:    &model.NodeMetadata{IstioVersion: "1.8.0"},
+	}
+	service := &model.Service{
+		Hostname:    host.Name("backend.default.svc.cluster.local"),
+		Address:     "1.1.1.1",
+		ClusterVIPs: make(map[string]string),
+		Ports: model.PortList{&model.Port{
+			Name:     "default",
+			Port:     80,
+			Protocol: protocol.HTTP,
+		}, &model.Port{
+			Name:     "other",
+			Port:     81,
+			Protocol: protocol.HTTP,
+		}},
+		Resolution: model.ClientSideLB,
+	}
+	serviceAlt := &model.Service{
+		Hostname:    host.Name("backend-alt.default.svc.cluster.local"),
+		Address:     "1.1.1.2",
+		ClusterVIPs: make(map[string]string),
+		Ports: model.PortList{&model.Port{
+			Name:     "default",
+			Port:     80,
+			Protocol: protocol.HTTP,
+		}, &model.Port{
+			Name:     "other",
+			Port:     81,
+			Protocol: protocol.HTTP,
+		}},
+		Resolution: model.ClientSideLB,
+	}
+
+	cases := []struct {
+		name      string
+		configs   []config.Config
+		services  []*model.Service
+		instances []*model.ServiceInstance
+		// Assertions
+		clusters    map[string][]string
+		telemetry   map[string][]string
+		legacyProxy bool
+	}{
+		// Proxy 1.8.1+ tests
+		{name: "empty"},
+		{name: "empty service", services: []*model.Service{service}},
+		{
+			name:      "single service, partial instance",
+			services:  []*model.Service{service},
+			instances: makeInstances(proxy, service, 80, 8080),
+			clusters: map[string][]string{
+				"inbound|8080||": {"127.0.0.1:8080"},
+			},
+			telemetry: map[string][]string{
+				"inbound|8080||": {string(service.Hostname)},
+			},
+		},
+		{
+			name:     "single service, multiple instance",
+			services: []*model.Service{service},
+			instances: flattenInstances(
+				makeInstances(proxy, service, 80, 8080),
+				makeInstances(proxy, service, 81, 8081)),
+			clusters: map[string][]string{
+				"inbound|8080||": {"127.0.0.1:8080"},
+				"inbound|8081||": {"127.0.0.1:8081"},
+			},
+			telemetry: map[string][]string{
+				"inbound|8080||": {string(service.Hostname)},
+				"inbound|8081||": {string(service.Hostname)},
+			},
+		},
+		{
+			name:     "multiple services with same service port, different target",
+			services: []*model.Service{service, serviceAlt},
+			instances: flattenInstances(
+				makeInstances(proxy, service, 80, 8080),
+				makeInstances(proxy, service, 81, 8081),
+				makeInstances(proxy, serviceAlt, 80, 8082),
+				makeInstances(proxy, serviceAlt, 81, 8083)),
+			clusters: map[string][]string{
+				"inbound|8080||": {"127.0.0.1:8080"},
+				"inbound|8081||": {"127.0.0.1:8081"},
+				"inbound|8082||": {"127.0.0.1:8082"},
+				"inbound|8083||": {"127.0.0.1:8083"},
+			},
+			telemetry: map[string][]string{
+				"inbound|8080||": {string(service.Hostname)},
+				"inbound|8081||": {string(service.Hostname)},
+				"inbound|8082||": {string(serviceAlt.Hostname)},
+				"inbound|8083||": {string(serviceAlt.Hostname)},
+			},
+		},
+		{
+			name:     "multiple services with same service port and target",
+			services: []*model.Service{service, serviceAlt},
+			instances: flattenInstances(
+				makeInstances(proxy, service, 80, 8080),
+				makeInstances(proxy, service, 81, 8081),
+				makeInstances(proxy, serviceAlt, 80, 8080),
+				makeInstances(proxy, serviceAlt, 81, 8081)),
+			clusters: map[string][]string{
+				"inbound|8080||": {"127.0.0.1:8080"},
+				"inbound|8081||": {"127.0.0.1:8081"},
+			},
+			telemetry: map[string][]string{
+				"inbound|8080||": {string(serviceAlt.Hostname), string(service.Hostname)},
+				"inbound|8081||": {string(serviceAlt.Hostname), string(service.Hostname)},
+			},
+		},
+		{
+			name: "ingress to same port",
+			configs: []config.Config{
+				{
+					Meta: config.Meta{GroupVersionKind: gvk.Sidecar, Namespace: "default", Name: "sidecar"},
+					Spec: &networking.Sidecar{Ingress: []*networking.IstioIngressListener{{
+						Port: &networking.Port{
+							Number:   80,
+							Protocol: "HTTP",
+							Name:     "http",
+						},
+						DefaultEndpoint: "127.0.0.1:80",
+					}}},
+				},
+			},
+			clusters: map[string][]string{
+				"inbound|80||": {"127.0.0.1:80"},
+			},
+		},
+		{
+			name: "ingress to different port",
+			configs: []config.Config{
+				{
+					Meta: config.Meta{GroupVersionKind: gvk.Sidecar, Namespace: "default", Name: "sidecar"},
+					Spec: &networking.Sidecar{Ingress: []*networking.IstioIngressListener{{
+						Port: &networking.Port{
+							Number:   80,
+							Protocol: "HTTP",
+							Name:     "http",
+						},
+						DefaultEndpoint: "127.0.0.1:8080",
+					}}},
+				},
+			},
+			clusters: map[string][]string{
+				"inbound|80||": {"127.0.0.1:8080"},
+			},
+		},
+		{
+			name: "ingress to socket",
+			configs: []config.Config{
+				{
+					Meta: config.Meta{GroupVersionKind: gvk.Sidecar, Namespace: "default", Name: "sidecar"},
+					Spec: &networking.Sidecar{Ingress: []*networking.IstioIngressListener{{
+						Port: &networking.Port{
+							Number:   80,
+							Protocol: "HTTP",
+							Name:     "http",
+						},
+						DefaultEndpoint: "unix:///socket",
+					}}},
+				},
+			},
+			clusters: map[string][]string{
+				"inbound|80||": {"/socket"},
+			},
+		},
+		{
+			name: "multiple ingress",
+			configs: []config.Config{
+				{
+					Meta: config.Meta{GroupVersionKind: gvk.Sidecar, Namespace: "default", Name: "sidecar"},
+					Spec: &networking.Sidecar{Ingress: []*networking.IstioIngressListener{
+						{
+							Port: &networking.Port{
+								Number:   80,
+								Protocol: "HTTP",
+								Name:     "http",
+							},
+							DefaultEndpoint: "127.0.0.1:8080",
+						},
+						{
+							Port: &networking.Port{
+								Number:   81,
+								Protocol: "HTTP",
+								Name:     "http",
+							},
+							DefaultEndpoint: "127.0.0.1:8080",
+						},
+					}},
+				},
+			},
+			clusters: map[string][]string{
+				"inbound|80||": {"127.0.0.1:8080"},
+				"inbound|81||": {"127.0.0.1:8080"},
+			},
+		},
+
+		// Proxy 1.8.0 tests
+		{
+			name:        "single service, partial instance",
+			legacyProxy: true,
+			services:    []*model.Service{service},
+			instances:   makeInstances(proxy180, service, 80, 8080),
+			clusters: map[string][]string{
+				"inbound|80||": {"127.0.0.1:8080"},
+			},
+			telemetry: map[string][]string{
+				"inbound|80||": {string(service.Hostname)},
+			},
+		},
+		{
+			name:        "single service, multiple instance",
+			legacyProxy: true,
+			services:    []*model.Service{service},
+			instances: flattenInstances(
+				makeInstances(proxy180, service, 80, 8080),
+				makeInstances(proxy180, service, 81, 8081)),
+			clusters: map[string][]string{
+				"inbound|80||": {"127.0.0.1:8080"},
+				"inbound|81||": {"127.0.0.1:8081"},
+			},
+			telemetry: map[string][]string{
+				"inbound|80||": {string(service.Hostname)},
+				"inbound|81||": {string(service.Hostname)},
+			},
+		},
+		{
+			name:        "multiple services with same service port, different target",
+			legacyProxy: true,
+			services:    []*model.Service{service, serviceAlt},
+			instances: flattenInstances(
+				makeInstances(proxy180, service, 80, 8080),
+				makeInstances(proxy180, service, 81, 8081),
+				makeInstances(proxy180, serviceAlt, 80, 8082),
+				makeInstances(proxy180, serviceAlt, 81, 8083)),
+			clusters: map[string][]string{
+				// BUG: we are missing 8080 and 8081. This is fixed for 1.8.1+
+				"inbound|80||": {"127.0.0.1:8082"},
+				"inbound|81||": {"127.0.0.1:8083"},
+			},
+			telemetry: map[string][]string{
+				"inbound|80||": {string(serviceAlt.Hostname), string(service.Hostname)},
+				"inbound|81||": {string(serviceAlt.Hostname), string(service.Hostname)},
+			},
+		},
+		{
+			name:        "multiple services with same service port and target",
+			legacyProxy: true,
+			services:    []*model.Service{service, serviceAlt},
+			instances: flattenInstances(
+				makeInstances(proxy180, service, 80, 8080),
+				makeInstances(proxy180, service, 81, 8081),
+				makeInstances(proxy180, serviceAlt, 80, 8080),
+				makeInstances(proxy180, serviceAlt, 81, 8081)),
+			clusters: map[string][]string{
+				"inbound|80||": {"127.0.0.1:8080"},
+				"inbound|81||": {"127.0.0.1:8081"},
+			},
+			telemetry: map[string][]string{
+				"inbound|80||": {string(serviceAlt.Hostname), string(service.Hostname)},
+				"inbound|81||": {string(serviceAlt.Hostname), string(service.Hostname)},
+			},
+		},
+		{
+			name:        "ingress to same port",
+			legacyProxy: true,
+			configs: []config.Config{
+				{
+					Meta: config.Meta{GroupVersionKind: gvk.Sidecar, Namespace: "default", Name: "sidecar"},
+					Spec: &networking.Sidecar{Ingress: []*networking.IstioIngressListener{{
+						Port: &networking.Port{
+							Number:   80,
+							Protocol: "HTTP",
+							Name:     "http",
+						},
+						DefaultEndpoint: "127.0.0.1:80",
+					}}},
+				},
+			},
+			clusters: map[string][]string{
+				"inbound|80||": {"127.0.0.1:80"},
+			},
+		},
+		{
+			name:        "ingress to different port",
+			legacyProxy: true,
+			configs: []config.Config{
+				{
+					Meta: config.Meta{GroupVersionKind: gvk.Sidecar, Namespace: "default", Name: "sidecar"},
+					Spec: &networking.Sidecar{Ingress: []*networking.IstioIngressListener{{
+						Port: &networking.Port{
+							Number:   80,
+							Protocol: "HTTP",
+							Name:     "http",
+						},
+						DefaultEndpoint: "127.0.0.1:8080",
+					}}},
+				},
+			},
+			clusters: map[string][]string{
+				"inbound|80||": {"127.0.0.1:8080"},
+			},
+		},
+		{
+			name:        "ingress to socket",
+			legacyProxy: true,
+			configs: []config.Config{
+				{
+					Meta: config.Meta{GroupVersionKind: gvk.Sidecar, Namespace: "default", Name: "sidecar"},
+					Spec: &networking.Sidecar{Ingress: []*networking.IstioIngressListener{{
+						Port: &networking.Port{
+							Number:   80,
+							Protocol: "HTTP",
+							Name:     "http",
+						},
+						DefaultEndpoint: "unix:///socket",
+					}}},
+				},
+			},
+			clusters: map[string][]string{
+				"inbound|80||": {"/socket"},
+			},
+		},
+		{
+			name:        "multiple ingress",
+			legacyProxy: true,
+			configs: []config.Config{
+				{
+					Meta: config.Meta{GroupVersionKind: gvk.Sidecar, Namespace: "default", Name: "sidecar"},
+					Spec: &networking.Sidecar{Ingress: []*networking.IstioIngressListener{
+						{
+							Port: &networking.Port{
+								Number:   80,
+								Protocol: "HTTP",
+								Name:     "http",
+							},
+							DefaultEndpoint: "127.0.0.1:8080",
+						},
+						{
+							Port: &networking.Port{
+								Number:   81,
+								Protocol: "HTTP",
+								Name:     "http",
+							},
+							DefaultEndpoint: "127.0.0.1:8080",
+						},
+					}},
+				},
+			},
+			clusters: map[string][]string{
+				"inbound|80||": {"127.0.0.1:8080"},
+				"inbound|81||": {"127.0.0.1:8080"},
+			},
+		},
+	}
+	for _, tt := range cases {
+		name := tt.name
+		if tt.legacyProxy {
+			name += "-legacy"
+		}
+		t.Run(name, func(t *testing.T) {
+			s := v1alpha3.NewConfigGenTest(t, v1alpha3.TestOptions{
+				Services:  tt.services,
+				Instances: tt.instances,
+				Configs:   tt.configs,
+			})
+			testProxy := proxy
+			if tt.legacyProxy {
+				testProxy = proxy180
+			}
+			sim := simulation.NewSimulationFromConfigGen(t, s, s.SetupProxy(testProxy))
+
+			clusters := xdstest.FilterClusters(sim.Clusters, func(c *cluster.Cluster) bool {
+				return strings.HasPrefix(c.Name, "inbound")
+			})
+			if len(s.PushContext().ProxyStatus) != 0 {
+				// TODO make this fatal, once inbound conflict is silenced
+				t.Logf("got unexpected error: %+v", s.PushContext().ProxyStatus)
+			}
+			cmap := xdstest.ExtractClusters(clusters)
+			got := xdstest.MapKeys(cmap)
+
+			// Check we have all expected clusters
+			if !reflect.DeepEqual(xdstest.MapKeys(tt.clusters), got) {
+				t.Errorf("expected clusters: %v, got: %v", xdstest.MapKeys(tt.clusters), got)
+			}
+
+			for name, c := range cmap {
+				// Check the upstream endpoints match
+				got := xdstest.ExtractLoadAssignments([]*endpoint.ClusterLoadAssignment{c.GetLoadAssignment()})[name]
+				if !reflect.DeepEqual(tt.clusters[name], got) {
+					t.Errorf("%v: expected endpoints %v, got %v", name, tt.clusters[name], got)
+				}
+				gotTelemetry := extractClusterMetadataServices(t, c)
+				if !reflect.DeepEqual(tt.telemetry[name], gotTelemetry) {
+					t.Errorf("%v: expected telemetry services %v, got %v", name, tt.telemetry[name], gotTelemetry)
+				}
+
+				if tt.legacyProxy {
+					// This doesn't work with the legacy proxies which have issues (https://github.com/istio/istio/issues/29199)
+					continue
+				}
+				// simulate an actual call, this ensures we are aligned with the inbound listener configuration
+				_, _, _, port := model.ParseSubsetKey(name)
+				sim.Run(simulation.Call{
+					Port:     port,
+					Address:  "1.2.3.4",
+					CallMode: simulation.CallModeInbound,
+				}).Matches(t, simulation.Result{
+					ClusterMatched: fmt.Sprintf("inbound|%d||", port),
+				})
+			}
+			if t.Failed() {
+				t.Log(xdstest.DumpList(t, xdstest.InterfaceSlice(sim.Listeners)))
+			}
+		})
+	}
+}
+
+type clusterServicesMetadata struct {
+	Services []struct {
+		Host      string
+		Name      string
+		Namespace string
+	}
+}
+
+func extractClusterMetadataServices(t test.Failer, c *cluster.Cluster) []string {
+	got := c.GetMetadata().GetFilterMetadata()[util.IstioMetadataKey]
+	if got == nil {
+		return nil
+	}
+	s, err := (&jsonpb.Marshaler{}).MarshalToString(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta := clusterServicesMetadata{}
+	if err := json.Unmarshal([]byte(s), &meta); err != nil {
+		t.Fatal(err)
+	}
+	res := []string{}
+	for _, m := range meta.Services {
+		res = append(res, m.Host)
+	}
+	return res
+}
 
 func TestInbound(t *testing.T) {
 	mtlsMode := func(m string) string {

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -273,12 +273,22 @@ func IsIstioVersionGE18(node *model.Proxy) bool {
 		node.IstioVersion.Compare(&model.IstioVersion{Major: 1, Minor: 8, Patch: -1}) >= 0
 }
 
-func BuildInboundSubsetKey(node *model.Proxy, subsetName string, hostname host.Name, port int) string {
-	if IsIstioVersionGE18(node) {
-		// On 1.8+ Proxies, we use format inbound|port||. Telemetry no longer requires the hostname
-		return model.BuildSubsetKey(model.TrafficDirectionInbound, "", "", port)
+// IsIstioVersionGE181 checks whether the given Istio version is greater than or equals 1.8.1
+func IsIstioVersionGE181(node *model.Proxy) bool {
+	return node == nil || node.IstioVersion == nil ||
+		node.IstioVersion.Compare(&model.IstioVersion{Major: 1, Minor: 8, Patch: 1}) >= 0
+}
+
+func BuildInboundSubsetKey(node *model.Proxy, subsetName string, hostname host.Name, servicePort int, endpointPort int) string {
+	if IsIstioVersionGE181(node) {
+		// On 1.8.1+ Proxies, we use format inbound|endpointPort||. Telemetry no longer requires the hostname
+		return model.BuildSubsetKey(model.TrafficDirectionInbound, "", "", endpointPort)
+	} else if IsIstioVersionGE18(node) {
+		// On 1.8.0 Proxies, we used format inbound|servicePort||. Since changing a cluster name leads to a 503
+		// blip on upgrade, we will support this legacy format.
+		return model.BuildSubsetKey(model.TrafficDirectionInbound, "", "", servicePort)
 	}
-	return model.BuildSubsetKey(model.TrafficDirectionInbound, subsetName, hostname, port)
+	return model.BuildSubsetKey(model.TrafficDirectionInbound, subsetName, hostname, servicePort)
 }
 
 func IsProtocolSniffingEnabledForPort(port *model.Port) bool {

--- a/pilot/pkg/simulation/traffic.go
+++ b/pilot/pkg/simulation/traffic.go
@@ -397,17 +397,18 @@ func (sim *Simulation) matchFilterChain(chains []*listener.FilterChain, defaultC
 	}, func(fc *listener.FilterChainMatch) bool {
 		ranger := cidranger.NewPCTrieRanger()
 		for _, a := range fc.GetPrefixRanges() {
-			_, cidr, err := net.ParseCIDR(fmt.Sprintf("%s/%d", a.AddressPrefix, a.GetPrefixLen().GetValue()))
+			s := fmt.Sprintf("%s/%d", a.AddressPrefix, a.GetPrefixLen().GetValue())
+			_, cidr, err := net.ParseCIDR(s)
 			if err != nil {
-				sim.t.Fatal(err)
+				sim.t.Fatalf("failed to parse cidr %v: %v", s, err)
 			}
 			if err := ranger.Insert(cidranger.NewBasicRangerEntry(*cidr)); err != nil {
-				sim.t.Fatal(err)
+				sim.t.Fatalf("failed to insert cidr %v: %v", cidr, err)
 			}
 		}
 		f, err := ranger.Contains(net.ParseIP(input.Address))
 		if err != nil {
-			sim.t.Fatal(err)
+			sim.t.Fatalf("cidr containers %v failed: %v", input.Address, err)
 		}
 		return f
 	})

--- a/pilot/pkg/xds/lds_test.go
+++ b/pilot/pkg/xds/lds_test.go
@@ -30,6 +30,7 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/memory"
 	"istio.io/istio/pilot/pkg/xds"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pilot/test/xdstest"
 	"istio.io/istio/pkg/adsc"
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/test/env"
@@ -58,7 +59,7 @@ func TestLDSIsolated(t *testing.T) {
 
 		// 7071 (inbound), 2001 (service - also as http proxy), 18010 (fortio), 15006 (virtual inbound)
 		if len(adscon.GetHTTPListeners()) != 4 {
-			t.Error("HTTP listeners, expecting 4 got ", len(adscon.GetHTTPListeners()), adscon.GetHTTPListeners())
+			t.Error("HTTP listeners, expecting 4 got", len(adscon.GetHTTPListeners()), xdstest.MapKeys(adscon.GetHTTPListeners()))
 		}
 
 		// s1tcp:2000 outbound, bind=true (to reach other instances of the service)

--- a/releasenotes/notes/inbound-cluster-rename.yaml
+++ b/releasenotes/notes/inbound-cluster-rename.yaml
@@ -1,0 +1,10 @@
+apiVersion: release-notes/v2
+kind: feature
+area: bug-fix
+issue:
+- 29199
+
+releaseNotes:
+- |
+  **Fixed** a regression in Istio 1.8.0 causing workloads with multiple Services with overlapping ports to send
+  traffic to the wrong port.

--- a/tests/integration/pilot/common/apps.go
+++ b/tests/integration/pilot/common/apps.go
@@ -80,6 +80,20 @@ var EchoPorts = []echo.Port{
 	{Name: "auto-grpc", Protocol: protocol.GRPC, ServicePort: 7071, InstancePort: 17071},
 }
 
+var WorkloadPorts = []echo.WorkloadPort{
+	{Protocol: protocol.TCP, Port: 19092},
+	{Protocol: protocol.HTTP, Port: 18083},
+}
+
+func FindPortByName(name string) echo.Port {
+	for _, p := range EchoPorts {
+		if p.Name == name {
+			return p
+		}
+	}
+	return echo.Port{}
+}
+
 func serviceEntryPorts() []echo.Port {
 	res := []echo.Port{}
 	for _, p := range EchoPorts {
@@ -122,34 +136,38 @@ func SetupApps(ctx resource.Context, i istio.Instance, apps *EchoDeployments) er
 	for _, c := range ctx.Environment().Clusters() {
 		builder.
 			With(nil, echo.Config{
-				Service:   PodASvc,
-				Namespace: apps.Namespace,
-				Ports:     EchoPorts,
-				Subsets:   []echo.SubsetConfig{{}},
-				Locality:  "region.zone.subzone",
-				Cluster:   c,
+				Service:           PodASvc,
+				Namespace:         apps.Namespace,
+				Ports:             EchoPorts,
+				Subsets:           []echo.SubsetConfig{{}},
+				Locality:          "region.zone.subzone",
+				Cluster:           c,
+				WorkloadOnlyPorts: WorkloadPorts,
 			}).
 			With(nil, echo.Config{
-				Service:   PodBSvc,
-				Namespace: apps.Namespace,
-				Ports:     EchoPorts,
-				Subsets:   []echo.SubsetConfig{{}},
-				Cluster:   c,
+				Service:           PodBSvc,
+				Namespace:         apps.Namespace,
+				Ports:             EchoPorts,
+				Subsets:           []echo.SubsetConfig{{}},
+				Cluster:           c,
+				WorkloadOnlyPorts: WorkloadPorts,
 			}).
 			With(nil, echo.Config{
-				Service:   PodCSvc,
-				Namespace: apps.Namespace,
-				Ports:     EchoPorts,
-				Subsets:   []echo.SubsetConfig{{}},
-				Cluster:   c,
+				Service:           PodCSvc,
+				Namespace:         apps.Namespace,
+				Ports:             EchoPorts,
+				Subsets:           []echo.SubsetConfig{{}},
+				Cluster:           c,
+				WorkloadOnlyPorts: WorkloadPorts,
 			}).
 			With(nil, echo.Config{
-				Service:   HeadlessSvc,
-				Headless:  true,
-				Namespace: apps.Namespace,
-				Ports:     headlessPorts,
-				Subsets:   []echo.SubsetConfig{{}},
-				Cluster:   c,
+				Service:           HeadlessSvc,
+				Headless:          true,
+				Namespace:         apps.Namespace,
+				Ports:             headlessPorts,
+				Subsets:           []echo.SubsetConfig{{}},
+				Cluster:           c,
+				WorkloadOnlyPorts: WorkloadPorts,
 			}).
 			With(nil, echo.Config{
 				Service:   NakedSvc,
@@ -163,7 +181,8 @@ func SetupApps(ctx resource.Context, i istio.Instance, apps *EchoDeployments) er
 						},
 					},
 				},
-				Cluster: c,
+				Cluster:           c,
+				WorkloadOnlyPorts: WorkloadPorts,
 			}).
 			With(nil, echo.Config{
 				Service:           ExternalSvc,
@@ -178,7 +197,8 @@ func SetupApps(ctx resource.Context, i istio.Instance, apps *EchoDeployments) er
 						},
 					},
 				},
-				Cluster: c,
+				Cluster:           c,
+				WorkloadOnlyPorts: WorkloadPorts,
 			})
 	}
 
@@ -191,7 +211,7 @@ func SetupApps(ctx resource.Context, i istio.Instance, apps *EchoDeployments) er
 			AutoRegisterVM: false, // TODO support auto-registration with multi-primary
 			Subsets:        []echo.SubsetConfig{{}},
 			Cluster:        c[0],
-		})
+		WorkloadOnlyPorts: WorkloadPorts,})
 	}
 
 	echos, err := builder.Build()

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -530,7 +530,7 @@ spec:
     targetPort: %d
   selector:
     app: b`, FindPortByName("http").ServicePort, WorkloadPorts[0].Port)
-		case2 := TrafficTestCase{
+		cases = append(cases, TrafficTestCase{
 			name:   "case 2 service port match",
 			config: svc,
 			call:   c.CallWithRetryOrFail,
@@ -541,9 +541,7 @@ spec:
 				Timeout:   time.Millisecond * 100,
 				Validator: echo.ExpectOK(),
 			},
-		}
-		// TODO(https://github.com/istio/istio/issues/29199) enable this test
-		_ = case2
+		})
 
 		// Case 3
 		// We match the target port, but front with a different service port

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -471,6 +471,138 @@ func gatewayCases(apps *EchoDeployments) []TrafficTestCase {
 	return cases
 }
 
+// serviceCases tests overlapping Services. There are a few cases.
+// Consider we have our base service B, with service port P and target port T
+// 1) Another service, B', with P -> T. In this case, both the listener and the cluster will conflict.
+//    Because everything is workload oriented, this is not a problem unless they try to make them different
+//    protocols (this is explicitly called out as "not supported") or control inbound connectionPool settings
+//    (which is moving to Sidecar soon)
+// 2) Another service, B', with P -> T'. In this case, the listener will be distinct, since its based on the target.
+//    The cluster, however, will be shared, which is broken, because we should be forwarding to T when we call B, and T' when we call B'.
+// 3) Another service, B', with P' -> T. In this case, the listener is shared. This is fine, with the exception of different protocols
+//    The cluster is distinct.
+// 4) Another service, B', with P' -> T'. There is no conflicts here at all.
+func serviceCases(apps *EchoDeployments) []TrafficTestCase {
+	cases := []TrafficTestCase{}
+	for _, c := range apps.PodA {
+		c := c
+
+		// Case 1
+		// Identical to port "http" or service B, just behind another service name
+		svc := fmt.Sprintf(`apiVersion: v1
+kind: Service
+metadata:
+  name: b-alt-1
+  labels:
+    app: b
+spec:
+  ports:
+  - name: http
+    port: %d
+    targetPort: %d
+  selector:
+    app: b`, FindPortByName("http").ServicePort, FindPortByName("http").InstancePort)
+		cases = append(cases, TrafficTestCase{
+			name:   "case 1 both match",
+			config: svc,
+			call:   c.CallWithRetryOrFail,
+			opts: echo.CallOptions{
+				Address:   "b-alt-1",
+				Port:      &echo.Port{ServicePort: FindPortByName("http").ServicePort, Protocol: protocol.HTTP},
+				Timeout:   time.Millisecond * 100,
+				Validator: echo.ExpectOK(),
+			},
+		})
+
+		// Case 2
+		// We match the service port, but forward to a different port
+		// Here we make the new target tcp so the test would fail if it went to the http port
+		svc = fmt.Sprintf(`apiVersion: v1
+kind: Service
+metadata:
+  name: b-alt-2
+  labels:
+    app: b
+spec:
+  ports:
+  - name: tcp
+    port: %d
+    targetPort: %d
+  selector:
+    app: b`, FindPortByName("http").ServicePort, WorkloadPorts[0].Port)
+		case2 := TrafficTestCase{
+			name:   "case 2 service port match",
+			config: svc,
+			call:   c.CallWithRetryOrFail,
+			opts: echo.CallOptions{
+				Address:   "b-alt-2",
+				Port:      &echo.Port{ServicePort: FindPortByName("http").ServicePort, Protocol: protocol.TCP},
+				Scheme:    scheme.TCP,
+				Timeout:   time.Millisecond * 100,
+				Validator: echo.ExpectOK(),
+			},
+		}
+		// TODO(https://github.com/istio/istio/issues/29199) enable this test
+		_ = case2
+
+		// Case 3
+		// We match the target port, but front with a different service port
+		svc = fmt.Sprintf(`apiVersion: v1
+kind: Service
+metadata:
+  name: b-alt-3
+  labels:
+    app: b
+spec:
+  ports:
+  - name: http
+    port: 12345
+    targetPort: %d
+  selector:
+    app: b`, FindPortByName("http").InstancePort)
+		cases = append(cases, TrafficTestCase{
+			name:   "case 3 target port match",
+			config: svc,
+			call:   c.CallWithRetryOrFail,
+			opts: echo.CallOptions{
+				Address:   "b-alt-3",
+				Port:      &echo.Port{ServicePort: 12345, Protocol: protocol.HTTP},
+				Timeout:   time.Millisecond * 100,
+				Validator: echo.ExpectOK(),
+			},
+		})
+
+		// Case 4
+		// Completely new set of ports
+		svc = fmt.Sprintf(`apiVersion: v1
+kind: Service
+metadata:
+  name: b-alt-4
+  labels:
+    app: b
+spec:
+  ports:
+  - name: http
+    port: 12346
+    targetPort: %d
+  selector:
+    app: b`, WorkloadPorts[1].Port)
+		cases = append(cases, TrafficTestCase{
+			name:   "case 4 no match",
+			config: svc,
+			call:   c.CallWithRetryOrFail,
+			opts: echo.CallOptions{
+				Address:   "b-alt-4",
+				Port:      &echo.Port{ServicePort: 12346, Protocol: protocol.HTTP},
+				Timeout:   time.Millisecond * 100,
+				Validator: echo.ExpectOK(),
+			},
+		})
+	}
+
+	return cases
+}
+
 // Todo merge with security TestReachability code
 func protocolSniffingCases(apps *EchoDeployments) []TrafficTestCase {
 	cases := []TrafficTestCase{}

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -92,6 +92,7 @@ func RunAllTrafficTests(ctx framework.TestContext, apps *EchoDeployments) {
 	cases["gateway"] = gatewayCases(apps)
 	cases["loop"] = trafficLoopCases(apps)
 	cases["vm"] = VMTestCases(apps.VM, apps)
+	cases["services"] = serviceCases(apps)
 	for name, tts := range cases {
 		ctx.NewSubTest(name).Run(func(ctx framework.TestContext) {
 			for _, tt := range tts {

--- a/tests/integration/telemetry/stackdriver/testdata/tcp_server_access_log.json.tmpl
+++ b/tests/integration/telemetry/stackdriver/testdata/tcp_server_access_log.json.tmpl
@@ -24,6 +24,6 @@
         "protocol": "tcp",
         "log_sampled": "false",
         "requested_server_name": "outbound_.9090_._.srv.{{ .EchoNamespace }}.svc.cluster.local",
-        "upstream_cluster": "inbound|9090||"
+        "upstream_cluster": "inbound|9000||"
     }
 }


### PR DESCRIPTION
Cherrypick:
* #28507 (dependency)
* #29201 (tests)
* #29203 (implementation)
