### PR TITLE
endpointslice config uses kind-registry

### DIFF
--- a/prow/config/endpointslice.yaml
+++ b/prow/config/endpointslice.yaml
@@ -19,3 +19,7 @@ kubeadmConfigPatches:
       "controllers": "*,endpointslice"
       # Reduce number to allow testing multiple slices without requiring 100+ pods
       "max-endpoints-per-slice": "3"
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
+      endpoint = ["http://kind-registry:5000"]


### PR DESCRIPTION
Copies config from our default trustworthy-jwt.yaml

allows un-reverting https://github.com/istio/test-infra/pull/3080