### PR TITLE
Verify install keep going

### DIFF
--- a/istioctl/pkg/verifier/verifier.go
+++ b/istioctl/pkg/verifier/verifier.go
@@ -310,14 +310,15 @@ func (v *StatusVerifier) operatorFromCluster(revision string) (*v1alpha1.IstioOp
 }
 
 func (v *StatusVerifier) reportStatus(crdCount, istioDeploymentCount int, err error) error {
-	if err != nil {
-		return err
-	}
 	v.logger.LogAndPrintf("Checked %v custom resource definitions", crdCount)
 	v.logger.LogAndPrintf("Checked %v Istio Deployments", istioDeploymentCount)
 	if istioDeploymentCount == 0 {
 		v.logger.LogAndPrintf("! No Istio installation found")
 		return fmt.Errorf("no Istio installation found")
+	}
+	if err != nil {
+		// Don't return full error; it is usually an unwielded aggregate
+		return fmt.Errorf("installation errors found")
 	}
 	v.logger.LogAndPrintf("✔ Istio is installed and verified successfully")
 	return nil

--- a/istioctl/pkg/verifier/verifier.go
+++ b/istioctl/pkg/verifier/verifier.go
@@ -144,7 +144,7 @@ func (v *StatusVerifier) verifyPostInstallIstioOperator(iop *v1alpha1.IstioOpera
 		return 0, 0, errs.ToError()
 	}
 
-	builder := resource.NewBuilder(v.k8sConfig()).Unstructured()
+	builder := resource.NewBuilder(v.k8sConfig()).ContinueOnError().Unstructured()
 	for cat, manifest := range manifests {
 		for i, manitem := range manifest {
 			reader := strings.NewReader(manitem)
@@ -202,10 +202,13 @@ func (v *StatusVerifier) verifyPostInstall(visitor resource.Visitor, filename st
 				Do(context.TODO()).
 				Into(deployment)
 			if err != nil {
+				v.reportFailure(kind, name, namespace, err)
 				return err
 			}
 			if err = verifyDeploymentStatus(deployment); err != nil {
-				return istioVerificationFailureError(filename, err)
+				ivf := istioVerificationFailureError(filename, err)
+				v.reportFailure(kind, name, namespace, ivf)
+				return ivf
 			}
 			if namespace == v.istioNamespace && strings.HasPrefix(name, "istio") {
 				istioDeploymentCount++
@@ -221,10 +224,13 @@ func (v *StatusVerifier) verifyPostInstall(visitor resource.Visitor, filename st
 				Do(context.TODO()).
 				Into(job)
 			if err != nil {
+				v.reportFailure(kind, name, namespace, err)
 				return err
 			}
 			if err := verifyJobPostInstall(job); err != nil {
-				return istioVerificationFailureError(filename, err)
+				ivf := istioVerificationFailureError(filename, err)
+				v.reportFailure(kind, name, namespace, ivf)
+				return ivf
 			}
 		case "IstioOperator":
 			// It is not a problem if the cluster does not include the IstioOperator
@@ -238,6 +244,7 @@ func (v *StatusVerifier) verifyPostInstall(visitor resource.Visitor, filename st
 			by := util.ToYAML(un)
 			iop, err := operator_istio.UnmarshalIstioOperator(by, true)
 			if err != nil {
+				v.reportFailure(kind, name, namespace, err)
 				return err
 			}
 			if v.manifestsPath != "" {
@@ -263,6 +270,7 @@ func (v *StatusVerifier) verifyPostInstall(visitor resource.Visitor, filename st
 					Name(name).
 					Do(context.TODO())
 				if result.Error() != nil {
+					v.reportFailure(kind, name, namespace, result.Error())
 					return istioVerificationFailureError(filename,
 						fmt.Errorf("the required %s:%s is not ready due to: %v",
 							kind, name, result.Error()))
@@ -346,9 +354,13 @@ func AllOperatorsInCluster(client dynamic.Interface) ([]*v1alpha1.IstioOperator,
 }
 
 func istioVerificationFailureError(filename string, reason error) error {
-	return fmt.Errorf("istio installation failed, incomplete or does not match \"%s\": %v", filename, reason)
+	return fmt.Errorf("Istio installation failed, incomplete or does not match \"%s\": %v", filename, reason) // nolint
 }
 
 func (v *StatusVerifier) k8sConfig() *genericclioptions.ConfigFlags {
 	return &genericclioptions.ConfigFlags{KubeConfig: &v.kubeconfig, Context: &v.context}
+}
+
+func (v *StatusVerifier) reportFailure(kind, name, namespace string, err error) {
+	v.logger.LogAndPrintf("✘ %s: %s.%s: %v", kind, name, namespace, err)
 }

--- a/istioctl/pkg/verifier/verifier.go
+++ b/istioctl/pkg/verifier/verifier.go
@@ -318,7 +318,7 @@ func (v *StatusVerifier) reportStatus(crdCount, istioDeploymentCount int, err er
 	}
 	if err != nil {
 		// Don't return full error; it is usually an unwielded aggregate
-		return fmt.Errorf("installation errors found")
+		return fmt.Errorf("Istio installation failed") // nolint
 	}
 	v.logger.LogAndPrintf("✔ Istio is installed and verified successfully")
 	return nil


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/26276

When `verify-install` fails, it was only printing the first problem it found.  The user with multiple problems rarely wants to see only one, often a different problem is the underlying one.

This is especially burdensome when the CLI is on a different version than the control plane.  (There will be other PRs tacking that more specifically).  What was happening was that only the first difference between the CLI's expected install and the actual install was being shown.

With this change instead of stopping on the first mistake we print an error message for each one:

```
istioctl verify-install --context istio-test-paid2 -d manifests
✔ ClusterRole: istiod-istio-system.default checked successfully
...
✘ EnvoyFilter: metadata-exchange-1.9.istio-system: envoyfilters.networking.istio.io "metadata-exchange-1.9" not found
✘ EnvoyFilter: tcp-metadata-exchange-1.9.istio-system: envoyfilters.networking.istio.io "tcp-metadata-exchange-1.9" not found
✘ EnvoyFilter: stats-filter-1.9.istio-system: envoyfilters.networking.istio.io "stats-filter-1.9" not found
✘ EnvoyFilter: tcp-stats-filter-1.9.istio-system: envoyfilters.networking.istio.io "tcp-stats-filter-1.9" not found
✔ HorizontalPodAutoscaler: istio-ingressgateway.istio-system checked successfully
...
Checked 12 custom resource definitions
Checked 2 Istio Deployments
Error: installation errors found
```
