### PR TITLE
Treat unset patch as highest, rather than lowest, patch version

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -853,7 +853,8 @@ func ParseIstioVersion(ver string) *IstioVersion {
 	// we are guaranteed to have atleast major and minor based on the regex
 	major, _ := strconv.Atoi(parts[0])
 	minor, _ := strconv.Atoi(parts[1])
-	patch := 0
+	// Assume very large patch release if not set
+	patch := 65535
 	if len(parts) > 2 {
 		patch, _ = strconv.Atoi(parts[2])
 	}

--- a/pilot/pkg/model/context_test.go
+++ b/pilot/pkg/model/context_test.go
@@ -469,17 +469,17 @@ func Test_parseIstioVersion(t *testing.T) {
 		{
 			name: "major.minor",
 			args: args{ver: "1.2"},
-			want: &model.IstioVersion{Major: 1, Minor: 2, Patch: 0},
+			want: &model.IstioVersion{Major: 1, Minor: 2, Patch: 65535},
 		},
 		{
 			name: "dev",
 			args: args{ver: "1.5-alpha.f70faea2aa817eeec0b08f6cc3b5078e5dcf3beb"},
-			want: &model.IstioVersion{Major: 1, Minor: 5, Patch: 0},
+			want: &model.IstioVersion{Major: 1, Minor: 5, Patch: 65535},
 		},
 		{
 			name: "release-major.minor-date",
 			args: args{ver: "release-1.2-123214234"},
-			want: &model.IstioVersion{Major: 1, Minor: 2, Patch: 0},
+			want: &model.IstioVersion{Major: 1, Minor: 2, Patch: 65535},
 		},
 		{
 			name: "master-date",


### PR DESCRIPTION
For dev versions, we get a version set like 1.8-alpha.SHA. We do not
know the patch version of these.

This changes the behavior to treat these as the max patch version,
rather than `.0`. This mirrors the bevaior of an unset version, which is
also treated as "latest".

The motivation for this is to allow checks like `>= 1.8.1`; with the
current code the dev builds do not pass this check.

Blocker for https://github.com/istio/istio/pull/29333