### PR TITLE
start fake discovery server to avoid deadlock

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/fake.go
+++ b/pilot/pkg/serviceregistry/kube/controller/fake.go
@@ -133,6 +133,9 @@ type FakeControllerOptions struct {
 	WatchedNamespaces string
 	DomainSuffix      string
 	XDSUpdater        model.XDSUpdater
+
+	// when calling from NewFakeDiscoveryServer, we wait for the aggregate cache to sync. Waiting here can cause deadlock.
+	SkipCacheSyncWait bool
 }
 
 type FakeController struct {
@@ -172,9 +175,10 @@ func NewFakeControllerWithOptions(opts FakeControllerOptions) (*FakeController, 
 	// TODO: fix it, so we can remove `stop` channel
 	go c.Run(c.stop)
 	opts.Client.RunAndWait(c.stop)
-	// Wait for the caches to sync, otherwise we may hit race conditions where events are dropped
-	cache.WaitForCacheSync(c.stop, c.HasSynced)
-
+	if !opts.SkipCacheSyncWait {
+		// Wait for the caches to sync, otherwise we may hit race conditions where events are dropped
+		cache.WaitForCacheSync(c.stop, c.HasSynced)
+	}
 	var fx *FakeXdsUpdater
 	if x, ok := xdsUpdater.(*FakeXdsUpdater); ok {
 		fx = x

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -98,6 +98,7 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 
 	// Init with a dummy environment, since we have a circular dependency with the env creation.
 	s := NewDiscoveryServer(&model.Environment{PushContext: model.NewPushContext()}, []string{plugin.AuthzCustom, plugin.Authn, plugin.Authz}, "pilot-123")
+	s.Start(stop)
 
 	serviceHandler := func(svc *model.Service, _ model.Event) {
 		pushReq := &model.PushRequest{
@@ -223,7 +224,6 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	cg.ServiceEntryRegistry.XdsUpdater = s
 	// Start the discovery server
 	s.CachesSynced()
-	s.Start(stop)
 	cg.ServiceEntryRegistry.ResyncEDS()
 
 	// Now that handlers are added, get everything started

--- a/pilot/pkg/xds/fake.go
+++ b/pilot/pkg/xds/fake.go
@@ -98,6 +98,8 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 
 	// Init with a dummy environment, since we have a circular dependency with the env creation.
 	s := NewDiscoveryServer(&model.Environment{PushContext: model.NewPushContext()}, []string{plugin.AuthzCustom, plugin.Authn, plugin.Authz}, "pilot-123")
+	// Disable debounce to reduce test times
+	s.debounceOptions.debounceAfter = opts.DebounceTime
 	s.Start(stop)
 
 	serviceHandler := func(svc *model.Service, _ model.Event) {
@@ -161,8 +163,6 @@ func NewFakeDiscoveryServer(t test.Failer, opts FakeOptions) *FakeDiscoveryServe
 	cg.ServiceEntryRegistry.AppendServiceHandler(serviceHandler)
 	s.updateMutex.Lock()
 	s.Env = cg.Env()
-	// Disable debounce to reduce test times
-	s.debounceOptions.debounceAfter = opts.DebounceTime
 	s.MemRegistry = cg.MemRegistry
 	s.MemRegistry.EDSUpdater = s
 	s.updateMutex.Unlock()


### PR DESCRIPTION
fixes deadlock in https://github.com/istio/istio/issues/29341 (tested by setting chan capacity to 1)
 
doesn't fix the fact that we have 6 discovery servers.... could be the `t.Cleanup` not being called in timeout failures? 