### PR TITLE
Add validation for workload group

### DIFF
--- a/galley/testdatasets/validation/dataset.gen.go
+++ b/galley/testdatasets/validation/dataset.gen.go
@@ -528,7 +528,7 @@ spec:
     labels:
       app.kubernetes.io/name: reviews
       app.kubernetes.io/version: "1.3.4"
-  template:
+  template: {}
 `)
 
 func datasetNetworkingV1alpha3WorkloadgroupInvalidYamlBytes() ([]byte, error) {

--- a/galley/testdatasets/validation/dataset.gen.go
+++ b/galley/testdatasets/validation/dataset.gen.go
@@ -560,6 +560,7 @@ spec:
       grpc: 3550
       http: 8080
     serviceAccount: default
+    address: 1.2.3.4
 `)
 
 func datasetNetworkingV1alpha3WorkloadgroupValidYamlBytes() ([]byte, error) {

--- a/galley/testdatasets/validation/dataset.gen.go
+++ b/galley/testdatasets/validation/dataset.gen.go
@@ -528,7 +528,7 @@ spec:
     labels:
       app.kubernetes.io/name: reviews
       app.kubernetes.io/version: "1.3.4"
-  template: {}
+      ".": "~"
 `)
 
 func datasetNetworkingV1alpha3WorkloadgroupInvalidYamlBytes() ([]byte, error) {
@@ -560,7 +560,6 @@ spec:
       grpc: 3550
       http: 8080
     serviceAccount: default
-    address: 1.2.3.4
 `)
 
 func datasetNetworkingV1alpha3WorkloadgroupValidYamlBytes() ([]byte, error) {

--- a/galley/testdatasets/validation/dataset/networking-v1alpha3-WorkloadGroup-invalid.yaml
+++ b/galley/testdatasets/validation/dataset/networking-v1alpha3-WorkloadGroup-invalid.yaml
@@ -7,3 +7,4 @@ spec:
     labels:
       app.kubernetes.io/name: reviews
       app.kubernetes.io/version: "1.3.4"
+      ".": "~"

--- a/galley/testdatasets/validation/dataset/networking-v1alpha3-WorkloadGroup-invalid.yaml
+++ b/galley/testdatasets/validation/dataset/networking-v1alpha3-WorkloadGroup-invalid.yaml
@@ -7,4 +7,3 @@ spec:
     labels:
       app.kubernetes.io/name: reviews
       app.kubernetes.io/version: "1.3.4"
-  template: {}

--- a/galley/testdatasets/validation/dataset/networking-v1alpha3-WorkloadGroup-invalid.yaml
+++ b/galley/testdatasets/validation/dataset/networking-v1alpha3-WorkloadGroup-invalid.yaml
@@ -7,4 +7,4 @@ spec:
     labels:
       app.kubernetes.io/name: reviews
       app.kubernetes.io/version: "1.3.4"
-  template:
+  template: {}

--- a/pkg/config/schema/collections/collections.agent.gen.go
+++ b/pkg/config/schema/collections/collections.agent.gen.go
@@ -204,7 +204,7 @@ var (
 			ReflectType: reflect.TypeOf(&istioioapinetworkingv1alpha3.WorkloadGroup{}).Elem(), StatusType: reflect.TypeOf(&istioioapimetav1alpha1.IstioStatus{}).Elem(),
 			ProtoPackage: "istio.io/api/networking/v1alpha3", StatusPackage: "istio.io/api/meta/v1alpha1",
 			ClusterScoped: false,
-			ValidateProto: validation.EmptyValidate,
+			ValidateProto: validation.ValidateWorkloadGroup,
 		}.MustBuild(),
 	}.MustBuild()
 

--- a/pkg/config/schema/collections/collections.gen.go
+++ b/pkg/config/schema/collections/collections.gen.go
@@ -210,7 +210,7 @@ var (
 			ReflectType: reflect.TypeOf(&istioioapinetworkingv1alpha3.WorkloadGroup{}).Elem(), StatusType: reflect.TypeOf(&istioioapimetav1alpha1.IstioStatus{}).Elem(),
 			ProtoPackage: "istio.io/api/networking/v1alpha3", StatusPackage: "istio.io/api/meta/v1alpha1",
 			ClusterScoped: false,
-			ValidateProto: validation.EmptyValidate,
+			ValidateProto: validation.ValidateWorkloadGroup,
 		}.MustBuild(),
 	}.MustBuild()
 
@@ -601,7 +601,7 @@ var (
 			ReflectType: reflect.TypeOf(&istioioapinetworkingv1alpha3.WorkloadGroup{}).Elem(), StatusType: reflect.TypeOf(&istioioapimetav1alpha1.IstioStatus{}).Elem(),
 			ProtoPackage: "istio.io/api/networking/v1alpha3", StatusPackage: "istio.io/api/meta/v1alpha1",
 			ClusterScoped: false,
-			ValidateProto: validation.EmptyValidate,
+			ValidateProto: validation.ValidateWorkloadGroup,
 		}.MustBuild(),
 	}.MustBuild()
 

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -2259,11 +2259,18 @@ var ValidateWorkloadGroup = registerValidateFunc("ValidateWorkloadGroup",
 		if !ok {
 			return nil, fmt.Errorf("cannot cast to workload entry")
 		}
+
 		if wg.Template == nil {
 			return nil, fmt.Errorf("template is required")
 		}
 		// Do not call validateWorkloadEntry. Some fields, such as address, are required in WorkloadEntry
 		// but not in the template since they are auto populated
+
+		if wg.Metadata != nil {
+			if err := labels.Instance(wg.Metadata.Labels).Validate(); err != nil {
+				return nil, fmt.Errorf("invalid labels: %v", err)
+			}
+		}
 		return nil, nil
 	})
 

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -2259,7 +2259,12 @@ var ValidateWorkloadGroup = registerValidateFunc("ValidateWorkloadGroup",
 		if !ok {
 			return nil, fmt.Errorf("cannot cast to workload entry")
 		}
-		return validateWorkloadEntry(wg.Template)
+		if wg.Template == nil {
+			return nil, fmt.Errorf("template is required")
+		}
+		// Do not call validateWorkloadEntry. Some fields, such as address, are required in WorkloadEntry
+		// but not in the template since they are auto populated
+		return nil, nil
 	})
 
 // ValidateServiceEntry validates a service entry.

--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -2240,12 +2240,26 @@ var ValidateWorkloadEntry = registerValidateFunc("ValidateWorkloadEntry",
 		if !ok {
 			return nil, fmt.Errorf("cannot cast to workload entry")
 		}
-		if we.Address == "" {
-			return nil, fmt.Errorf("address must be set")
+		return validateWorkloadEntry(we)
+	})
+
+func validateWorkloadEntry(we *networking.WorkloadEntry) (warnings Warning, errs error) {
+	if we.Address == "" {
+		return nil, fmt.Errorf("address must be set")
+	}
+	// TODO: add better validation. The tricky thing is that we don't know if its meant to be
+	// DNS or STATIC type without association with a ServiceEntry
+	return nil, nil
+}
+
+// ValidateWorkloadGroup validates a workload group.
+var ValidateWorkloadGroup = registerValidateFunc("ValidateWorkloadGroup",
+	func(cfg config.Config) (warnings Warning, errs error) {
+		wg, ok := cfg.Spec.(*networking.WorkloadGroup)
+		if !ok {
+			return nil, fmt.Errorf("cannot cast to workload entry")
 		}
-		// TODO: add better validation. The tricky thing is that we don't know if its meant to be
-		// DNS or STATIC type without association with a ServiceEntry
-		return nil, nil
+		return validateWorkloadEntry(wg.Template)
 	})
 
 // ValidateServiceEntry validates a service entry.

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -2327,6 +2327,60 @@ func TestValidateVirtualService(t *testing.T) {
 	}
 }
 
+func TestValidateWorkloadEntry(t *testing.T) {
+	testCases := []struct {
+		name    string
+		in      proto.Message
+		valid   bool
+		warning bool
+	}{
+		{
+			name:  "valid",
+			in:    &networking.WorkloadEntry{Address: "1.2.3.4"},
+			valid: true,
+		},
+		{
+			name:  "missing address",
+			in:    &networking.WorkloadEntry{},
+			valid: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			warn, err := ValidateWorkloadEntry(config.Config{Spec: tc.in})
+			checkValidation(t, warn, err, tc.valid, tc.warning)
+		})
+	}
+}
+
+func TestValidateWorkloadGroup(t *testing.T) {
+	testCases := []struct {
+		name    string
+		in      proto.Message
+		valid   bool
+		warning bool
+	}{
+		{
+			name:  "valid",
+			in:    &networking.WorkloadGroup{Template: &networking.WorkloadEntry{}},
+			valid: true,
+		},
+		{
+			name:  "invalid",
+			in:    &networking.WorkloadGroup{Template: &networking.WorkloadEntry{}, Metadata: &networking.WorkloadGroup_ObjectMeta{Labels: map[string]string{
+				".": "~",
+			}}},
+			valid: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			warn, err := ValidateWorkloadGroup(config.Config{Spec: tc.in})
+			checkValidation(t, warn, err, tc.valid, tc.warning)
+		})
+	}
+}
+
 func checkValidation(t *testing.T, gotWarning Warning, gotError error, valid bool, warning bool) {
 	t.Helper()
 	if (gotError == nil) != valid {

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -2366,8 +2366,8 @@ func TestValidateWorkloadGroup(t *testing.T) {
 			valid: true,
 		},
 		{
-			name:  "invalid",
-			in:    &networking.WorkloadGroup{Template: &networking.WorkloadEntry{}, Metadata: &networking.WorkloadGroup_ObjectMeta{Labels: map[string]string{
+			name: "invalid",
+			in: &networking.WorkloadGroup{Template: &networking.WorkloadEntry{}, Metadata: &networking.WorkloadGroup_ObjectMeta{Labels: map[string]string{
 				".": "~",
 			}}},
 			valid: false,


### PR DESCRIPTION
Kubernetes 1.20 tests are currently broken, since our old invalid config
is now considered valid (see
https://github.com/kubernetes/kubernetes/pull/95423). In fixing this, I
realized we don't have any validation for WorkloadGroup! This adds
validation, by applying the same validation WorkloadEntry has to the
template of workload group. However, workload entry validation is pretty
much nil, so this change isn't very beneficial beyond getting tests
passing.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.