### PR TITLE
Fix flaky integration test - helm/TestInstallWithFirstPartyJwt

### DIFF
--- a/pkg/test/helm/helm.go
+++ b/pkg/test/helm/helm.go
@@ -17,6 +17,7 @@ package helm
 import (
 	"fmt"
 	"path/filepath"
+	"time"
 
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/test/shell"
@@ -37,9 +38,9 @@ func New(kubeConfig, baseWorkDir string) *Helm {
 }
 
 // InstallChart installs the specified chart with its given name to the given namespace
-func (h *Helm) InstallChart(name, relpath, namespace, overridesFile string) error {
+func (h *Helm) InstallChart(name, relpath, namespace, overridesFile string, timeout time.Duration) error {
 	p := filepath.Join(h.baseDir, relpath)
-	command := fmt.Sprintf("helm install %s %s --namespace %s -f %s --kubeconfig %s", name, p, namespace, overridesFile, h.kubeConfig)
+	command := fmt.Sprintf("helm install %s %s --namespace %s -f %s --kubeconfig %s --timeout %s", name, p, namespace, overridesFile, h.kubeConfig, timeout)
 	return execCommand(command)
 }
 

--- a/tests/integration/helm/install_test.go
+++ b/tests/integration/helm/install_test.go
@@ -56,7 +56,7 @@ const (
 	GatewayChartsDir    = "gateways"
 	retryDelay          = 2 * time.Second
 	retryTimeOut        = 5 * time.Minute
-	helmTimeout = 2 * time.Minute
+	helmTimeout         = 2 * time.Minute
 )
 
 var (

--- a/tests/integration/helm/install_test.go
+++ b/tests/integration/helm/install_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 	"time"
 
-	"istio.io/pkg/log"
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,6 +38,7 @@ import (
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/tests/util/sanitycheck"
+	"istio.io/pkg/log"
 )
 
 const (

--- a/tests/integration/helm/install_test.go
+++ b/tests/integration/helm/install_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"istio.io/pkg/log"
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,7 +39,6 @@ import (
 	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/tests/util/sanitycheck"
-	"istio.io/pkg/log"
 )
 
 const (
@@ -56,6 +56,7 @@ const (
 	GatewayChartsDir    = "gateways"
 	retryDelay          = 2 * time.Second
 	retryTimeOut        = 5 * time.Minute
+	helmTimeout = 2 * time.Minute
 )
 
 var (
@@ -94,7 +95,7 @@ global:
 			verifyInstallation(t, ctx, cs)
 
 			t.Cleanup(func() {
-				deleteIstio(t, h)
+				deleteIstio(t, cs, h)
 			})
 		})
 }
@@ -132,7 +133,7 @@ global:
 			verifyInstallation(t, ctx, cs)
 
 			t.Cleanup(func() {
-				deleteIstio(t, h)
+				deleteIstio(t, cs, h)
 			})
 		})
 }
@@ -155,35 +156,35 @@ func installIstio(t *testing.T, cs resource.Cluster,
 
 	// Install base chart
 	err := h.InstallChart(BaseReleaseName, BaseChart,
-		IstioNamespace, overrideValuesFile)
+		IstioNamespace, overrideValuesFile, helmTimeout)
 	if err != nil {
 		t.Errorf("failed to install istio %s chart", BaseChart)
 	}
 
 	// Install discovery chart
 	err = h.InstallChart(IstiodReleaseName, filepath.Join(ControlChartsDir, DiscoveryChart),
-		IstioNamespace, overrideValuesFile)
+		IstioNamespace, overrideValuesFile, helmTimeout)
 	if err != nil {
 		t.Errorf("failed to install istio %s chart", DiscoveryChart)
 	}
 
 	// Install ingress gateway chart
 	err = h.InstallChart(IngressReleaseName, filepath.Join(GatewayChartsDir, IngressGatewayChart),
-		IstioNamespace, overrideValuesFile)
+		IstioNamespace, overrideValuesFile, helmTimeout)
 	if err != nil {
 		t.Errorf("failed to install istio %s chart", IngressGatewayChart)
 	}
 
 	// Install egress gateway chart
 	err = h.InstallChart(EgressReleaseName, filepath.Join(GatewayChartsDir, EgressGatewayChart),
-		IstioNamespace, overrideValuesFile)
+		IstioNamespace, overrideValuesFile, helmTimeout)
 	if err != nil {
 		t.Errorf("failed to install istio %s chart", EgressGatewayChart)
 	}
 }
 
 // deleteIstio deletes installed Istio Helm charts and resources
-func deleteIstio(t *testing.T, h *helm.Helm) {
+func deleteIstio(t *testing.T, cs resource.Cluster, h *helm.Helm) {
 	scopes.Framework.Infof("cleaning up resources")
 	if err := h.DeleteChart(EgressReleaseName, IstioNamespace); err != nil {
 		t.Errorf("failed to delete %s release", EgressReleaseName)
@@ -196,6 +197,12 @@ func deleteIstio(t *testing.T, h *helm.Helm) {
 	}
 	if err := h.DeleteChart(BaseReleaseName, IstioNamespace); err != nil {
 		t.Errorf("failed to delete %s release", BaseReleaseName)
+	}
+	if err := cs.CoreV1().Namespaces().Delete(context.TODO(), IstioNamespace, metav1.DeleteOptions{}); err != nil {
+		t.Errorf("failed to delete istio namespace: %v", err)
+	}
+	if err := kubetest.WaitForNamespaceDeletion(cs, IstioNamespace, retry.Timeout(retryTimeOut)); err != nil {
+		t.Errorf("wating for istio namespace to be deleted: %v", err)
 	}
 }
 


### PR DESCRIPTION
Attempt to fix https://github.com/istio/istio/issues/29167
based on data from https://storage.googleapis.com/istio-prow/logs/integ-k8s-115_istio_postsubmit/1331309815770648576/build-log.txt

There's reason to believe that the test doing a helm delete and an
immediate helm install was causing issues between test runs. Post-merge
this will still need to be monitored.

* Add --timeout flag to helm install command with a default of
  2 minutes, up from 30s.
* Delete the istio-system namespace in-between tests and wait for it to
  be removed before proceeding.



[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.