### PR TITLE
Restore registry order: the main k8s registry at first

### DIFF
--- a/pilot/pkg/bootstrap/server_test.go
+++ b/pilot/pkg/bootstrap/server_test.go
@@ -305,7 +305,7 @@ func TestNewServerWithMockRegistry(t *testing.T) {
 				s.WaitUntilCompletion()
 			}()
 
-			g.Expect(s.ServiceController().GetRegistries()[1].Provider()).To(Equal(c.expectedRegistry))
+			g.Expect(s.ServiceController().GetRegistries()[0].Provider()).To(Equal(c.expectedRegistry))
 		})
 	}
 }

--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -34,6 +34,8 @@ func (s *Server) ServiceController() *aggregate.Controller {
 // initServiceControllers creates and initializes the service controllers
 func (s *Server) initServiceControllers(args *PilotArgs) error {
 	registered := make(map[serviceregistry.ProviderID]bool)
+	// serviceentry store must be created before creating multucluster registry, so that it can wire up handlers.
+	s.serviceEntryStore = serviceentry.NewServiceDiscovery(s.configController, s.environment.IstioConfigStore, s.XDSServer)
 	for _, r := range args.RegistryOptions.Registries {
 		serviceRegistry := serviceregistry.ProviderID(r)
 		if _, exists := registered[serviceRegistry]; exists {
@@ -54,7 +56,6 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 		}
 	}
 
-	s.serviceEntryStore = serviceentry.NewServiceDiscovery(s.configController, s.environment.IstioConfigStore, s.XDSServer)
 	serviceControllers := s.ServiceController()
 	serviceControllers.AddRegistry(s.serviceEntryStore)
 	// Defer running of the service controllers.

--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -33,11 +33,6 @@ func (s *Server) ServiceController() *aggregate.Controller {
 
 // initServiceControllers creates and initializes the service controllers
 func (s *Server) initServiceControllers(args *PilotArgs) error {
-	serviceControllers := s.ServiceController()
-
-	s.serviceEntryStore = serviceentry.NewServiceDiscovery(s.configController, s.environment.IstioConfigStore, s.XDSServer)
-	serviceControllers.AddRegistry(s.serviceEntryStore)
-
 	registered := make(map[serviceregistry.ProviderID]bool)
 	for _, r := range args.RegistryOptions.Registries {
 		serviceRegistry := serviceregistry.ProviderID(r)
@@ -59,6 +54,9 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 		}
 	}
 
+	s.serviceEntryStore = serviceentry.NewServiceDiscovery(s.configController, s.environment.IstioConfigStore, s.XDSServer)
+	serviceControllers := s.ServiceController()
+	serviceControllers.AddRegistry(s.serviceEntryStore)
 	// Defer running of the service controllers.
 	s.addStartFunc(func(stop <-chan struct{}) error {
 		go serviceControllers.Run(stop)


### PR DESCRIPTION

This is the right order we have been using for long. 


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.