### PR TITLE
istioctl verify-install: Colorize success/failure markers

### DIFF
--- a/istioctl/cmd/analyze.go
+++ b/istioctl/cmd/analyze.go
@@ -39,7 +39,6 @@ import (
 	"istio.io/istio/pkg/config/schema"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/url"
-	"istio.io/pkg/env"
 )
 
 // AnalyzerFoundIssuesError indicates that at least one analyzer found problems.
@@ -74,8 +73,6 @@ var (
 	suppress          []string
 	analysisTimeout   time.Duration
 	recursive         bool
-
-	termEnvVar = env.RegisterStringVar("TERM", "", "Specifies terminal type.  Use 'dumb' to suppress color output")
 
 	fileExtensions = []string{".json", ".yaml", ".yml"}
 )
@@ -271,7 +268,7 @@ func Analyze() *cobra.Command {
 		"List the analyzers available to run. Suppresses normal execution.")
 	analysisCmd.PersistentFlags().BoolVarP(&useKube, "use-kube", "k", true,
 		"Use live Kubernetes cluster for analysis. Set --use-kube=false to analyze files only.")
-	analysisCmd.PersistentFlags().BoolVar(&colorize, "color", istioctlColorDefault(analysisCmd),
+	analysisCmd.PersistentFlags().BoolVar(&colorize, "color", formatting.IstioctlColorDefault(analysisCmd.OutOrStdout()),
 		"Default true.  Disable with '=false' or set $TERM to dumb")
 	analysisCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false,
 		"Enable verbose output")
@@ -376,21 +373,6 @@ func gatherFilesInDirectory(cmd *cobra.Command, dir string) ([]local.ReaderSourc
 		return nil
 	})
 	return readers, err
-}
-
-func istioctlColorDefault(cmd *cobra.Command) bool {
-	if strings.EqualFold(termEnvVar.Get(), "dumb") {
-		return false
-	}
-
-	file, ok := cmd.OutOrStdout().(*os.File)
-	if ok {
-		if !isatty.IsTerminal(file.Fd()) {
-			return false
-		}
-	}
-
-	return true
 }
 
 func errorIfMessagesExceedThreshold(messages []diag.Message) error {

--- a/istioctl/pkg/install/verify.go
+++ b/istioctl/pkg/install/verify.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"istio.io/istio/istioctl/pkg/clioptions"
+	"istio.io/istio/istioctl/pkg/util/formatting"
 	"istio.io/istio/istioctl/pkg/verifier"
 	"istio.io/istio/operator/cmd/mesh"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller"
@@ -74,6 +75,9 @@ istioctl experimental precheck.
 		RunE: func(c *cobra.Command, args []string) error {
 			installationVerifier := verifier.NewStatusVerifier(istioNamespace, manifestsPath,
 				*kubeConfigFlags.KubeConfig, *kubeConfigFlags.Context, filenames, opts, nil, nil)
+			if formatting.IstioctlColorDefault(c.OutOrStdout()) {
+				installationVerifier.Colorize()
+			}
 			return installationVerifier.Verify()
 		},
 	}

--- a/istioctl/pkg/verifier/verifier.go
+++ b/istioctl/pkg/verifier/verifier.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/fatih/color"
 	appsv1 "k8s.io/api/apps/v1"
 	v1batch "k8s.io/api/batch/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -58,6 +59,8 @@ type StatusVerifier struct {
 	controlPlaneOpts clioptions.ControlPlaneOptions
 	logger           clog.Logger
 	iop              *v1alpha1.IstioOperator
+	successMarker    string
+	failureMarker    string
 }
 
 // NewStatusVerifier creates a new instance of post-install verifier
@@ -78,7 +81,14 @@ func NewStatusVerifier(istioNamespace, manifestsPath, kubeconfig, context string
 		kubeconfig:       kubeconfig,
 		context:          context,
 		iop:              installedIOP,
+		successMarker:    "✔",
+		failureMarker:    "✘",
 	}
+}
+
+func (v *StatusVerifier) Colorize() {
+	v.successMarker = color.New(color.FgGreen).Sprint("✔")
+	v.failureMarker = color.New(color.FgRed).Sprint("✘")
 }
 
 // Verify implements Verifier interface. Here we check status of deployment
@@ -280,7 +290,7 @@ func (v *StatusVerifier) verifyPostInstall(visitor resource.Visitor, filename st
 				crdCount++
 			}
 		}
-		v.logger.LogAndPrintf("✔ %s: %s.%s checked successfully", kind, name, namespace)
+		v.logger.LogAndPrintf("%s %s: %s.%s checked successfully", v.successMarker, kind, name, namespace)
 		return nil
 	})
 	return crdCount, istioDeploymentCount, err
@@ -320,7 +330,7 @@ func (v *StatusVerifier) reportStatus(crdCount, istioDeploymentCount int, err er
 		// Don't return full error; it is usually an unwielded aggregate
 		return fmt.Errorf("Istio installation failed") // nolint
 	}
-	v.logger.LogAndPrintf("✔ Istio is installed and verified successfully")
+	v.logger.LogAndPrintf("%s Istio is installed and verified successfully", v.successMarker)
 	return nil
 }
 
@@ -363,5 +373,5 @@ func (v *StatusVerifier) k8sConfig() *genericclioptions.ConfigFlags {
 }
 
 func (v *StatusVerifier) reportFailure(kind, name, namespace string, err error) {
-	v.logger.LogAndPrintf("✘ %s: %s.%s: %v", kind, name, namespace, err)
+	v.logger.LogAndPrintf("%s %s: %s.%s: %v", v.failureMarker, kind, name, namespace, err)
 }

--- a/istioctl/pkg/verifier/verifier.go
+++ b/istioctl/pkg/verifier/verifier.go
@@ -87,8 +87,8 @@ func NewStatusVerifier(istioNamespace, manifestsPath, kubeconfig, context string
 }
 
 func (v *StatusVerifier) Colorize() {
-	v.successMarker = color.New(color.FgGreen).Sprint("✔")
-	v.failureMarker = color.New(color.FgRed).Sprint("✘")
+	v.successMarker = color.New(color.FgGreen).Sprint(v.successMarker)
+	v.failureMarker = color.New(color.FgRed).Sprint(v.failureMarker)
 }
 
 // Verify implements Verifier interface. Here we check status of deployment

--- a/releasenotes/notes/29376.yaml
+++ b/releasenotes/notes/29376.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue:
+  - 29336
+
+releaseNotes:
+- |
+  **Added** `istioctl verify-install` will indicate errors in red and expected configuration in green.


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/29336

The only output change is to colorize the little ✔ and ✘ markers.

Uses the same technique as `istioctl analyze` to see if it is safe to colorize.

I didn't test this on Windows.  Windows has some non-ANSI terminals.  Our progress bar uses github.com/mattn/go-colorable for those Windows terminals.  I didn't bring that it, because I don't have a Windows machine to test on and invoking it directly outside of a progress bar would mean changing _go.mod_.