### PR TITLE
set default priorityClass for istiod

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -99,7 +99,7 @@ data:
         "oneNamespace": false,
         "operatorManageWebhooks": false,
         "pilotCertProvider": "istiod",
-        "priorityClassName": "",
+        "priorityClassName": "system-cluster-critical",
         "proxy": {
           "autoInject": "enabled",
           "clusterDomain": "cluster.local",
@@ -753,6 +753,7 @@ spec:
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: istiod-service-account
+      priorityClassName: "system-cluster-critical"
       securityContext:
         fsGroup: 1337
       containers:

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -265,8 +265,8 @@ global:
   # system-node-critical, it is better to configure this in order to make sure your Istio pods
   # will not be killed because of low priority class.
   # Refer to https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
-  # for more detail.
-  priorityClassName: ""
+  # for more details.
+  priorityClassName: "system-cluster-critical"
 
   proxy:
     image: proxyv2

--- a/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -79,7 +79,7 @@ data:
         "oneNamespace": false,
         "operatorManageWebhooks": false,
         "pilotCertProvider": "istiod",
-        "priorityClassName": "",
+        "priorityClassName": "system-cluster-critical",
         "proxy": {
           "autoInject": "enabled",
           "clusterDomain": "cluster.local",

--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -229,8 +229,8 @@ global:
   # system-node-critical, it is better to configure this in order to make sure your Istio pods
   # will not be killed because of low priority class.
   # Refer to https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
-  # for more detail.
-  priorityClassName: ""
+  # for more details.
+  priorityClassName: "system-cluster-critical"
   proxy:
     image: proxyv2
     # This controls the 'policy' in the sidecar injector.


### PR DESCRIPTION
Raising this PR after discussing with @morvencao on this. Since `istiod` acts as as a SPOF of sorts, it's important that we set a high priority class to it by default

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
