### PR TITLE
Various improvements to health checking for VMs

### DIFF
--- a/pkg/istio-agent/health/health_check.go
+++ b/pkg/istio-agent/health/health_check.go
@@ -15,9 +15,11 @@
 package health
 
 import (
+	"strings"
 	"time"
 
 	"istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pkg/kube/apimirror"
 )
 
 type WorkloadHealthChecker struct {
@@ -40,6 +42,34 @@ type ProbeEvent struct {
 	UnhealthyMessage string
 }
 
+func fillInDefaults(cfg *v1alpha3.ReadinessProbe) *v1alpha3.ReadinessProbe {
+	cfg = cfg.DeepCopy()
+	// Thresholds have a minimum of 1
+	cfg.FailureThreshold = orDefault(cfg.FailureThreshold, 1)
+	cfg.SuccessThreshold = orDefault(cfg.SuccessThreshold, 1)
+
+	// InitialDelaySeconds allows zero, no default needed
+	cfg.TimeoutSeconds = orDefault(cfg.TimeoutSeconds, 1)
+	cfg.PeriodSeconds = orDefault(cfg.PeriodSeconds, 10)
+
+	switch h := cfg.HealthCheckMethod.(type) {
+	case *v1alpha3.ReadinessProbe_HttpGet:
+		if h.HttpGet.Path == "" {
+			h.HttpGet.Path = "/"
+		}
+		if h.HttpGet.Scheme == "" {
+			h.HttpGet.Scheme = string(apimirror.URISchemeHTTP)
+		}
+		h.HttpGet.Scheme = strings.ToLower(h.HttpGet.Scheme)
+		if h.HttpGet.Host == "" {
+			// Kubernetes uses pod IP. However, the istio rewrite app probe uses localhost, so we
+			// should probably favor consistency with Istio than Kubernetes
+			h.HttpGet.Host = "localhost"
+		}
+	}
+	return cfg
+}
+
 func NewWorkloadHealthChecker(cfg *v1alpha3.ReadinessProbe) *WorkloadHealthChecker {
 	// if a config does not exist return a no-op prober
 	if cfg == nil {
@@ -48,6 +78,7 @@ func NewWorkloadHealthChecker(cfg *v1alpha3.ReadinessProbe) *WorkloadHealthCheck
 			prober: nil,
 		}
 	}
+	cfg = fillInDefaults(cfg)
 	var prober Prober
 	switch healthCheckMethod := cfg.HealthCheckMethod.(type) {
 	case *v1alpha3.ReadinessProbe_HttpGet:
@@ -72,6 +103,13 @@ func NewWorkloadHealthChecker(cfg *v1alpha3.ReadinessProbe) *WorkloadHealthCheck
 	}
 }
 
+func orDefault(val int32, def int32) int32 {
+	if val == 0 {
+		return def
+	}
+	return val
+}
+
 // PerformApplicationHealthCheck Performs the application-provided configuration health check.
 // Instead of a heartbeat-based health checks, we only send on a health state change, and this is
 // determined by the success & failure threshold provided by the user.
@@ -80,6 +118,8 @@ func (w *WorkloadHealthChecker) PerformApplicationHealthCheck(callback func(*Pro
 	if w.prober == nil {
 		return
 	}
+
+	healthCheckLog.Infof("starting health check for %T", w.prober)
 
 	// delay before starting probes.
 	time.Sleep(w.config.InitialDelay)
@@ -105,23 +145,27 @@ func (w *WorkloadHealthChecker) PerformApplicationHealthCheck(callback func(*Pro
 			// probe target
 			healthy, err := w.prober.Probe(w.config.ProbeTimeout)
 			if healthy.IsHealthy() {
+				healthCheckLog.Debug("probe completed with healthy status")
 				// we were healthy, increment success counter
 				numSuccess++
 				// wipe numFail (need consecutive success)
 				numFail = 0
 				// if we reached the threshold, mark the target as healthy
 				if numSuccess == w.config.SuccessThresh && !lastStateHealthy {
+					healthCheckLog.Info("success threshold hit, marking as healthy")
 					callback(&ProbeEvent{Healthy: true})
 					numSuccess = 0
 					lastStateHealthy = true
 				}
 			} else {
+				healthCheckLog.Debugf("probe completed with unhealthy status: %v", err)
 				// we were not healthy, increment fail counter
 				numFail++
 				// wipe numSuccess (need consecutive failure)
 				numSuccess = 0
 				// if we reached the fail threshold, mark the target as unhealthy
 				if numFail == w.config.FailThresh && lastStateHealthy {
+					healthCheckLog.Infof("failure threshold hit, marking as unhealthy: %v", err)
 					callback(&ProbeEvent{
 						Healthy:          false,
 						UnhealthyStatus:  500,

--- a/pkg/istio-agent/health/health_probers.go
+++ b/pkg/istio-agent/health/health_probers.go
@@ -15,6 +15,7 @@
 package health
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -72,10 +73,13 @@ func NewHTTPProber(cfg *v1alpha3.HTTPHealthCheckConfig) *HTTPProber {
 	// otherwise set up an empty one.
 	if cfg.Scheme == string(scheme.HTTPS) {
 		h.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			DisableKeepAlives: true,
+			TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
 		}
 	} else {
-		h.Transport = &http.Transport{}
+		h.Transport = &http.Transport{
+			DisableKeepAlives: true,
+		}
 	}
 	return h
 }
@@ -114,10 +118,13 @@ func (h *HTTPProber) Probe(timeout time.Duration) (ProbeResult, error) {
 	if headers.Get("Host") != "" {
 		req.Host = headers.Get("Host")
 	}
+	if _, ok := headers["User-Agent"]; !ok {
+		// explicitly set User-Agent so it's not set to default Go value. K8s use kube-probe.
+		headers.Set("User-Agent", "istio-probe/1.0")
+	}
 	res, err := client.Do(req)
 	// if we were unable to connect, count as failure
 	if err != nil {
-		healthCheckLog.Infof("Health Check failed for %v: %v", targetURL.String(), err)
 		return Unhealthy, err
 	}
 	defer func() {
@@ -128,7 +135,6 @@ func (h *HTTPProber) Probe(timeout time.Duration) (ProbeResult, error) {
 	}()
 	// from [200,400)
 	if res.StatusCode >= http.StatusOK && res.StatusCode < http.StatusBadRequest {
-		healthCheckLog.Debugf("Health check succeeded for %v", targetURL.String())
 		return Healthy, nil
 	}
 	return Unhealthy, fmt.Errorf("status code was not from [200,400), bad code %v", res.StatusCode)
@@ -156,43 +162,16 @@ type ExecProber struct {
 }
 
 func (e *ExecProber) Probe(timeout time.Duration) (ProbeResult, error) {
-	cmd := exec.Cmd{
-		Path: e.Config.Command[0],
-		Args: e.Config.Command[1:],
-	}
-	if err := cmd.Start(); err != nil {
-		// should this be unknown? exit code returns status, this shouldnt
-		// should we extract exit status from here?
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, e.Config.Command[0], e.Config.Command[1:]...)
+	if err := cmd.Run(); err != nil {
+		select {
+		case <-ctx.Done():
+			return Unhealthy, fmt.Errorf("command timeout exceeded: %v", err)
+		default:
+		}
 		return Unhealthy, err
 	}
-
-	// wait on another channel
-	done := make(chan error)
-	go func() { done <- cmd.Wait() }()
-	// start timeout timer
-	timeoutTimer := time.After(timeout)
-
-	select {
-	case <-timeoutTimer:
-		if err := cmd.Process.Kill(); err != nil {
-			healthCheckLog.Errorf("Unable to kill process after timeout: %v", err)
-			return Unhealthy, err
-		}
-		// timeout exceeded counts as unhealthy, return nil err
-		return Unhealthy, nil
-	case err := <-done:
-		// extract exit status, log and return
-		if err == nil {
-			return Healthy, nil
-		}
-		if exitError, ok := err.(*exec.ExitError); ok {
-			if exitError.ExitCode() == 0 {
-				// exited successfully
-				return Healthy, nil
-			}
-			healthCheckLog.Infof("Command %v exited with non-zero status %v", cmd.String(), exitError.ExitCode())
-			return Unhealthy, err
-		}
-		return Unhealthy, fmt.Errorf("could not extract ExitError from command error")
-	}
+	return Healthy, nil
 }

--- a/pkg/kube/apimirror/probe.go
+++ b/pkg/kube/apimirror/probe.go
@@ -46,10 +46,10 @@ type HTTPGetAction struct {
 type URIScheme string
 
 const (
-	// URISchemeHTTPS means that the scheme used will be https://
-	URISchemeHTTPS URIScheme = "HTTPS"
 	// URISchemeHTTP means that the scheme used will be http://
 	URISchemeHTTP URIScheme = "HTTP"
+	// URISchemeHTTPS means that the scheme used will be https://
+	URISchemeHTTPS URIScheme = "HTTPS"
 )
 
 // HTTPHeader describes a custom header to be used in HTTP probes


### PR DESCRIPTION
* Correctly set default settings
* Match Kubernetes options more closely, including setting user agent
header and sending `connection: close`.
* Add some debug logging
* Simplify exec code by using more of the exec library builtins. This
also fixes the `$PATH`



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.