### PR TITLE
add metrics for file watchers is sds

### DIFF
--- a/security/pkg/nodeagent/cache/monitoring.go
+++ b/security/pkg/nodeagent/cache/monitoring.go
@@ -50,11 +50,11 @@ var (
 		monitoring.WithLabels(RequestType))
 
 	numFileWatcherFailures = monitoring.NewSum(
-		"num_file_watcher_failures",
+		"num_file_watcher_failures_total",
 		"Number of times file watcher failed to add watchers")
 
 	numFileSecretFailures = monitoring.NewSum(
-		"num_file_secret_failures",
+		"num_file_secret_failures_total",
 		"Number of times secret generation failed for files")
 )
 

--- a/security/pkg/nodeagent/cache/monitoring.go
+++ b/security/pkg/nodeagent/cache/monitoring.go
@@ -48,6 +48,14 @@ var (
 		"num_failed_outgoing_requests",
 		"Number of failed outgoing requests (e.g. to a token exchange server, CA, etc.)",
 		monitoring.WithLabels(RequestType))
+
+	numFileWatcherFailures = monitoring.NewSum(
+		"num_file_watcher_failures",
+		"Number of times file watcher failed to add watchers")
+
+	numFileSecretFailures = monitoring.NewSum(
+		"num_file_secret_failures",
+		"Number of times secret generation failed for files")
 )
 
 func init() {
@@ -56,5 +64,7 @@ func init() {
 		numOutgoingRequests,
 		numOutgoingRetries,
 		numFailedOutgoingRequests,
+		numFileWatcherFailures,
+		numFileSecretFailures,
 	)
 }

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -284,6 +284,7 @@ func (sc *SecretCache) addFileWatcher(file string, token string, connKey ConnKey
 	cacheLog.Infof("adding watcher for file %s", file)
 	if err := sc.certWatcher.Add(file); err != nil {
 		cacheLog.Errorf("%v: error adding watcher for file, skipping watches [%s] %v", connKey, file, err)
+		numFileWatcherFailures.Increment()
 		return
 	}
 	go func() {
@@ -302,6 +303,7 @@ func (sc *SecretCache) addFileWatcher(file string, token string, connKey ConnKey
 						// Regenerate the Secret and trigger the callback that pushes the secrets to proxy.
 						if _, secret, err := sc.generateFileSecret(ckey, token); err != nil {
 							cacheLog.Errorf("%v: error in generating secret after file change [%s] %v", ckey, file, err)
+							numFileSecretFailures.Increment()
 						} else {
 							cacheLog.Infof("%v: file changed, triggering secret push to proxy [%s]", ckey, file)
 							sc.callbackWithTimeout(ckey, secret)


### PR DESCRIPTION
When File watchers fails to add a watcher for example watches have exceeded etc. in secret cache, it just logs message. We would like add a metric so that we can alert when such a thing happens. It also adds metric when the secret generation fails for files. 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ X] Does not have any changes that may affect Istio users.
