### PR TITLE
listener: merge slashes in path

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -65,6 +65,9 @@ var (
 	// Currently this may cause a bug when we go from N clusters -> 0 clusters -> N clusters
 	FilterGatewayClusterConfig = env.RegisterBoolVar("PILOT_FILTER_GATEWAY_CLUSTER_CONFIG", false, "").Get()
 
+	// MergeSlashesInPath determines if adjacent slashes in the path are merged into one before processing.
+	MergeSlashesInPath = env.RegisterBoolVar("PILOT_HTTP_MERGE_SLASHES_IN_PATH", false, "").Get()
+
 	DebounceAfter = env.RegisterDurationVar(
 		"PILOT_DEBOUNCE_AFTER",
 		100*time.Millisecond,

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -353,6 +353,7 @@ func (configgen *ConfigGeneratorImpl) createGatewayHTTPFilterChainOpts(node *mod
 				useRemoteAddress: true,
 				connectionManager: &hcm.HttpConnectionManager{
 					XffNumTrustedHops: xffNumTrustedHops,
+					MergeSlashes:      features.MergeSlashesInPath,
 					// Forward client cert if connection is mTLS
 					ForwardClientCertDetails: forwardClientCertDetails,
 					SetCurrentClientCertDetails: &hcm.HttpConnectionManager_SetCurrentClientCertDetails{
@@ -383,6 +384,7 @@ func (configgen *ConfigGeneratorImpl) createGatewayHTTPFilterChainOpts(node *mod
 			useRemoteAddress: true,
 			connectionManager: &hcm.HttpConnectionManager{
 				XffNumTrustedHops: xffNumTrustedHops,
+				MergeSlashes:      features.MergeSlashesInPath,
 				// Forward client cert if connection is mTLS
 				ForwardClientCertDetails: forwardClientCertDetails,
 				SetCurrentClientCertDetails: &hcm.HttpConnectionManager_SetCurrentClientCertDetails{

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -483,6 +483,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundHTTPListenerOptsForPort
 		connectionManager: &hcm.HttpConnectionManager{
 			// Append and forward client cert to backend.
 			ForwardClientCertDetails: hcm.HttpConnectionManager_APPEND_FORWARD,
+			MergeSlashes:             features.MergeSlashesInPath,
 			SetCurrentClientCertDetails: &hcm.HttpConnectionManager_SetCurrentClientCertDetails{
 				Subject: proto.BoolTrue,
 				Uri:     true,
@@ -1669,6 +1670,8 @@ func buildHTTPConnectionManager(listenerOpts buildListenerOpts, httpOpts *httpLi
 	connectionManager.HttpFilters = filters
 	connectionManager.StatPrefix = httpOpts.statPrefix
 	connectionManager.NormalizePath = proto.BoolTrue
+	connectionManager.MergeSlashes = features.MergeSlashesInPath
+
 	if httpOpts.useRemoteAddress {
 		connectionManager.UseRemoteAddress = proto.BoolTrue
 	} else {

--- a/releasenotes/notes/merge-slashes.yaml
+++ b/releasenotes/notes/merge-slashes.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+
+releaseNotes:
+  - |
+    **Added** support merging slashes in the HTTP path. This can be enabled by setting "PILOT_HTTP_MERGE_SLASHES_IN_PATH"
+    to true.
+


### PR DESCRIPTION
Some deployments want to have the slashes merged in the paths https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto.html?highlight=merge_slashes. This can not be achieved by EnvoyFilter because it is a simple boolean and proto.merge will fail.  

This PR controls that behaviour via config option defaulted to false.
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
