### PR TITLE
'istioctl verify-install' improper default of Istio namespace

### DIFF
--- a/istioctl/pkg/verifier/verifier.go
+++ b/istioctl/pkg/verifier/verifier.go
@@ -63,6 +63,7 @@ type StatusVerifier struct {
 	iop              *v1alpha1.IstioOperator
 	successMarker    string
 	failureMarker    string
+	noIstioMarker    string
 }
 
 // NewStatusVerifier creates a new instance of post-install verifier
@@ -85,12 +86,14 @@ func NewStatusVerifier(istioNamespace, manifestsPath, kubeconfig, context string
 		iop:              installedIOP,
 		successMarker:    "✔",
 		failureMarker:    "✘",
+		noIstioMarker:    "!",
 	}
 }
 
 func (v *StatusVerifier) Colorize() {
 	v.successMarker = color.New(color.FgGreen).Sprint(v.successMarker)
 	v.failureMarker = color.New(color.FgRed).Sprint(v.failureMarker)
+	v.noIstioMarker = color.New(color.FgRed).Sprint(v.noIstioMarker)
 }
 
 // Verify implements Verifier interface. Here we check status of deployment
@@ -368,9 +371,10 @@ func (v *StatusVerifier) reportStatus(crdCount, istioDeploymentCount int, err er
 	v.logger.LogAndPrintf("Checked %v Istio Deployments", istioDeploymentCount)
 	if istioDeploymentCount == 0 {
 		if err != nil {
-			v.logger.LogAndPrintf("! No Istio installation found: %v", err)
+			v.logger.LogAndPrintf("%s No Istio installation found: %v", v.noIstioMarker, err)
+		} else {
+			v.logger.LogAndPrintf("%s No Istio installation found", v.noIstioMarker)
 		}
-		v.logger.LogAndPrintf("! No Istio installation found")
 		return fmt.Errorf("no Istio installation found")
 	}
 	if err != nil {

--- a/istioctl/pkg/verifier/verifier.go
+++ b/istioctl/pkg/verifier/verifier.go
@@ -239,7 +239,7 @@ func (v *StatusVerifier) verifyPostInstall(visitor resource.Visitor, filename st
 			kinds = strings.ToLower(kind) + "s"
 		}
 		if namespace == "" {
-			namespace = "default"
+			namespace = v.istioNamespace
 		}
 		switch kind {
 		case "Deployment":
@@ -301,12 +301,15 @@ func (v *StatusVerifier) verifyPostInstall(visitor resource.Visitor, filename st
 			if v.manifestsPath != "" {
 				iop.Spec.InstallPackagePath = v.manifestsPath
 			}
+			if v1alpha1.Namespace(iop.Spec) == "" {
+				v1alpha1.SetNamespace(iop.Spec, v.istioNamespace)
+			}
 			generatedCrds, generatedDeployments, err := v.verifyPostInstallIstioOperator(iop, filename)
+			crdCount += generatedCrds
+			istioDeploymentCount += generatedDeployments
 			if err != nil {
 				return err
 			}
-			crdCount += generatedCrds
-			istioDeploymentCount += generatedDeployments
 		default:
 			result := info.Client.
 				Get().
@@ -364,11 +367,11 @@ func (v *StatusVerifier) reportStatus(crdCount, istioDeploymentCount int, err er
 	v.logger.LogAndPrintf("Checked %v custom resource definitions", crdCount)
 	v.logger.LogAndPrintf("Checked %v Istio Deployments", istioDeploymentCount)
 	if istioDeploymentCount == 0 {
-		v.logger.LogAndPrintf("! No Istio installation found")
+		v.logger.LogAndPrintf("! No Istio installation found: %v", err)
 		return fmt.Errorf("no Istio installation found")
 	}
 	if err != nil {
-		// Don't return full error; it is usually an unwielded aggregate
+		// Don't return full error; it is usually an unwieldy aggregate
 		return fmt.Errorf("Istio installation failed") // nolint
 	}
 	v.logger.LogAndPrintf("%s Istio is installed and verified successfully", v.successMarker)

--- a/istioctl/pkg/verifier/verifier.go
+++ b/istioctl/pkg/verifier/verifier.go
@@ -63,7 +63,6 @@ type StatusVerifier struct {
 	iop              *v1alpha1.IstioOperator
 	successMarker    string
 	failureMarker    string
-	noIstioMarker    string
 }
 
 // NewStatusVerifier creates a new instance of post-install verifier
@@ -86,14 +85,12 @@ func NewStatusVerifier(istioNamespace, manifestsPath, kubeconfig, context string
 		iop:              installedIOP,
 		successMarker:    "✔",
 		failureMarker:    "✘",
-		noIstioMarker:    "!",
 	}
 }
 
 func (v *StatusVerifier) Colorize() {
 	v.successMarker = color.New(color.FgGreen).Sprint(v.successMarker)
 	v.failureMarker = color.New(color.FgRed).Sprint(v.failureMarker)
-	v.noIstioMarker = color.New(color.FgRed).Sprint(v.noIstioMarker)
 }
 
 // Verify implements Verifier interface. Here we check status of deployment
@@ -371,9 +368,9 @@ func (v *StatusVerifier) reportStatus(crdCount, istioDeploymentCount int, err er
 	v.logger.LogAndPrintf("Checked %v Istio Deployments", istioDeploymentCount)
 	if istioDeploymentCount == 0 {
 		if err != nil {
-			v.logger.LogAndPrintf("%s No Istio installation found: %v", v.noIstioMarker, err)
+			v.logger.LogAndPrintf("! No Istio installation found: %v", err)
 		} else {
-			v.logger.LogAndPrintf("%s No Istio installation found", v.noIstioMarker)
+			v.logger.LogAndPrintf("! No Istio installation found")
 		}
 		return fmt.Errorf("no Istio installation found")
 	}

--- a/istioctl/pkg/verifier/verifier.go
+++ b/istioctl/pkg/verifier/verifier.go
@@ -367,7 +367,10 @@ func (v *StatusVerifier) reportStatus(crdCount, istioDeploymentCount int, err er
 	v.logger.LogAndPrintf("Checked %v custom resource definitions", crdCount)
 	v.logger.LogAndPrintf("Checked %v Istio Deployments", istioDeploymentCount)
 	if istioDeploymentCount == 0 {
-		v.logger.LogAndPrintf("! No Istio installation found: %v", err)
+		if err != nil {
+			v.logger.LogAndPrintf("! No Istio installation found: %v", err)
+		}
+		v.logger.LogAndPrintf("! No Istio installation found")
 		return fmt.Errorf("no Istio installation found")
 	}
 	if err != nil {


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/26266

Fixing the following:

- if using a file IOP with no namespace set, defaults to `default` instead of `istio-system` for control plane components
- Does not count Deployment if other things in IOP are incorrect -- we want to acknowledge there was at least an IOP
- If we fail because of something early (e.g. no manifests) we should display that failure rather than having a generic message

cc @ostromart @su225 it would be great if one of you could review