### PR TITLE
add service label to helloworld sample

### DIFF
--- a/samples/helloworld/helloworld.yaml
+++ b/samples/helloworld/helloworld.yaml
@@ -4,6 +4,7 @@ metadata:
   name: helloworld
   labels:
     app: helloworld
+    service: helloworld
 spec:
   ports:
   - port: 5000


### PR DESCRIPTION
Backports a change from our new samples

Blocks https://github.com/istio/istio.io/pull/8539

This change allows us to run the following to deploy only the Service to each cluster:


```bash
# svc
kubectl apply --context="${CTX_CLUSTER1}" \
    -f $ISTIO_DIR/samples/helloworld/helloworld.yaml \
    -l service=helloworld -n sample
kubectl apply --context="${CTX_CLUSTER2}" \
    -f $ISTIO_DIR/samples/helloworld/helloworld.yaml \
    -l service=helloworld -n sample

```