### PR TITLE
Fix: telemetry httpmx filter patch at Gateway should have wasmEnabled option

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.8.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.8.yaml
@@ -108,10 +108,18 @@ spec:
                   value: |
                     {}
                 vm_config:
+                  {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
+                  runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
+                  code:
+                    local:
+                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
+                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: envoy.wasm.metadata_exchange
+                  {{- end }}
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.9.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.9.yaml
@@ -108,10 +108,18 @@ spec:
                   value: |
                     {}
                 vm_config:
+                  {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
+                  runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
+                  code:
+                    local:
+                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
+                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: envoy.wasm.metadata_exchange
+                  {{- end }}
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.8.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.8.yaml
@@ -108,10 +108,18 @@ spec:
                   value: |
                     {}
                 vm_config:
+                  {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
+                  runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
+                  code:
+                    local:
+                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
+                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: envoy.wasm.metadata_exchange
+                  {{- end }}
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.9.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.9.yaml
@@ -108,10 +108,18 @@ spec:
                   value: |
                     {}
                 vm_config:
+                  {{- if .Values.telemetry.v2.metadataExchange.wasmEnabled }}
+                  runtime: envoy.wasm.runtime.v8
+                  allow_precompiled: true
+                  code:
+                    local:
+                      filename: /etc/istio/extensions/metadata-exchange-filter.compiled.wasm
+                  {{- else }}
                   runtime: envoy.wasm.runtime.null
                   code:
                     local:
                       inline_string: envoy.wasm.metadata_exchange
+                  {{- end }}
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter


### PR DESCRIPTION
Bug fix: In the existing telemetry charts we missed the wasmEnabled option for Gateway httpmx filter



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.