### PR TITLE
Cleanup multicluster tests faster

### DIFF
--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -231,7 +231,7 @@ spec:
           {{- $network_set := index $gateway.env "ISTIO_META_NETWORK" }}
           {{- if and (not $network_set) .Values.global.network }}
           - name: ISTIO_META_NETWORK
-            value: {{ .Values.global.network }}
+            value: "{{ .Values.global.network }}"
           {{- end }}
 {{- if $gateway.podAnnotations }}
           - name: "ISTIO_METAJSON_ANNOTATIONS"

--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -228,6 +228,11 @@ spec:
           - name: {{ $key }}
             value: "{{ $value }}"
           {{- end }}
+          {{- $network_set := index $gateway.env "ISTIO_META_NETWORK" }}
+          {{- if and (not $network_set) .Values.global.network }}
+          - name: ISTIO_META_NETWORK
+            value: {{ .Values.global.network }}
+          {{- end }}
 {{- if $gateway.podAnnotations }}
           - name: "ISTIO_METAJSON_ANNOTATIONS"
             value: |

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -235,7 +235,7 @@ spec:
           {{- $network_set := index $gateway.env "ISTIO_META_NETWORK" }}
           {{- if and (not $network_set) .Values.global.network }}
           - name: ISTIO_META_NETWORK
-            value: {{ .Values.global.network }}
+            value: "{{ .Values.global.network }}"
           {{- end }}
 {{- if $gateway.podAnnotations }}
           - name: "ISTIO_METAJSON_ANNOTATIONS"

--- a/pkg/test/framework/components/istio/eastwest.go
+++ b/pkg/test/framework/components/istio/eastwest.go
@@ -86,6 +86,15 @@ func (i *operatorComponent) deployEastWestGateway(cluster resource.Cluster, revi
 		installSettings = append(installSettings, "--revision", revision)
 	}
 
+	// Save the manifest generate output so we can later cleanup
+	genCmd := []string{"manifest", "generate"}
+	genCmd = append(genCmd, installSettings...)
+	out, _, err := istioCtl.Invoke(genCmd)
+	if err != nil {
+		return err
+	}
+	i.saveManifestForCleanup(cluster.Name(), out)
+
 	scopes.Framework.Infof("Deploying eastwestgateway in %s: %v", cluster.Name(), installSettings)
 	err = install(i, installSettings, istioCtl, cluster.Name())
 	if err != nil {

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -192,22 +192,15 @@ func (i *operatorComponent) Close() error {
 				if e := i.ctx.Config(cluster).DeleteYAML("", removeCRDsSlice(i.installManifest[cluster.Name()])); e != nil {
 					err = multierror.Append(err, e)
 				}
-				// Clean up dynamic leader election locks. This allows new test suites to become the leader without waiting 30s
-				for _, cm := range leaderElectionConfigMaps {
-					if e := cluster.CoreV1().ConfigMaps(i.settings.SystemNamespace).Delete(context.TODO(), cm,
-						kubeApiMeta.DeleteOptions{}); e != nil {
-						err = multierror.Append(err, e)
-					}
+				// Cleanup all secrets and configmaps - these are dynamically created by tests and/or istiod so they are not captured above
+				// This includes things like leader election locks (allowing next test to start without 30s delay),
+				// custom cacerts, custom kubeconfigs, etc.
+				// We avoid deleting the whole namespace since its extremely slow in Kubernetes (30-60s+)
+				if e := cluster.CoreV1().Secrets(i.settings.SystemNamespace).DeleteCollection(context.Background(), kubeApiMeta.DeleteOptions{}, kubeApiMeta.ListOptions{}); e != nil {
+					err = multierror.Append(err, e)
 				}
-				if i.environment.IsMulticluster() {
-					// in multicluster mode we simply delete the namespace
-					if e := cluster.CoreV1().Namespaces().Delete(context.TODO(), i.settings.SystemNamespace,
-						kube2.DeleteOptionsForeground()); e != nil {
-						err = multierror.Append(err, e)
-					}
-					if e := kube2.WaitForNamespaceDeletion(cluster, i.settings.SystemNamespace, retry.Timeout(time.Minute)); e != nil {
-						err = multierror.Append(err, e)
-					}
+				if e := cluster.CoreV1().ConfigMaps(i.settings.SystemNamespace).DeleteCollection(context.Background(), kubeApiMeta.DeleteOptions{}, kubeApiMeta.ListOptions{}); e != nil {
+					err = multierror.Append(err, e)
 				}
 				return
 			})
@@ -758,15 +751,35 @@ func deployCACerts(workDir string, env *kube.Environment, cfg Config) error {
 				Name:   cfg.SystemNamespace,
 			},
 		}, kubeApiMeta.CreateOptions{}); err != nil {
-			scopes.Framework.Infof("failed creating namespace %s on cluster %s. This can happen when deploying "+
-				"multiple control planes. Error: %v", cfg.SystemNamespace, cluster.Name(), err)
+			if errors.IsAlreadyExists(err) {
+				if _, err := cluster.CoreV1().Namespaces().Update(context.TODO(), &kubeApiCore.Namespace{
+					ObjectMeta: kubeApiMeta.ObjectMeta{
+						Labels: nsLabels,
+						Name:   cfg.SystemNamespace,
+					},
+				}, kubeApiMeta.UpdateOptions{}); err != nil {
+					scopes.Framework.Errorf("failed updating namespace %s on cluster %s. This can happen when deploying "+
+						"multiple control planes. Error: %v", cfg.SystemNamespace, cluster.Name(), err)
+				}
+			} else {
+				scopes.Framework.Errorf("failed creating namespace %s on cluster %s. This can happen when deploying "+
+					"multiple control planes. Error: %v", cfg.SystemNamespace, cluster.Name(), err)
+			}
 		}
 
 		// Create the secret for the cacerts.
 		if _, err := cluster.CoreV1().Secrets(cfg.SystemNamespace).Create(context.TODO(), secret,
 			kubeApiMeta.CreateOptions{}); err != nil {
-			scopes.Framework.Infof("failed to create CA secrets on cluster %s. This can happen when deploying "+
-				"multiple control planes. Error: %v", cluster.Name(), err)
+			if errors.IsAlreadyExists(err) {
+				if _, err := cluster.CoreV1().Secrets(cfg.SystemNamespace).Update(context.TODO(), secret,
+					kubeApiMeta.UpdateOptions{}); err != nil {
+					scopes.Framework.Errorf("failed to create CA secrets on cluster %s. This can happen when deploying "+
+						"multiple control planes. Error: %v", cluster.Name(), err)
+				}
+			} else {
+				scopes.Framework.Errorf("failed to create CA secrets on cluster %s. This can happen when deploying "+
+					"multiple control planes. Error: %v", cluster.Name(), err)
+			}
 		}
 	}
 	return nil
@@ -862,7 +875,7 @@ func (i *operatorComponent) configureRemoteConfigForControlPlane(cluster resourc
 		return err
 	}
 
-	scopes.Framework.Infof("configuring external control plane %s to use config cluster in %s", cluster.Name())
+	scopes.Framework.Infof("configuring external control plane to use config cluster in %s", cluster.Name())
 	// ensure system namespace exists
 	_, err = cluster.CoreV1().Namespaces().
 		Create(context.TODO(), &kubeApiCore.Namespace{

--- a/pkg/test/framework/components/istio/operator.go
+++ b/pkg/test/framework/components/istio/operator.go
@@ -37,7 +37,6 @@ import (
 	"istio.io/api/label"
 	opAPI "istio.io/api/operator/v1alpha1"
 	pkgAPI "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
-	"istio.io/istio/pilot/pkg/leaderelection"
 	"istio.io/istio/pkg/test/cert/ca"
 	testenv "istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework/components/environment/kube"
@@ -119,12 +118,6 @@ func removeCRDs(istioYaml string) string {
 	return yml.JoinString(nonCrds...)
 }
 
-var leaderElectionConfigMaps = []string{
-	leaderelection.IngressController,
-	leaderelection.NamespaceController,
-	leaderelection.ValidationController,
-}
-
 type istioctlConfigFiles struct {
 	iopFile            string
 	operatorSpec       *opAPI.IstioOperatorSpec
@@ -196,10 +189,12 @@ func (i *operatorComponent) Close() error {
 				// This includes things like leader election locks (allowing next test to start without 30s delay),
 				// custom cacerts, custom kubeconfigs, etc.
 				// We avoid deleting the whole namespace since its extremely slow in Kubernetes (30-60s+)
-				if e := cluster.CoreV1().Secrets(i.settings.SystemNamespace).DeleteCollection(context.Background(), kubeApiMeta.DeleteOptions{}, kubeApiMeta.ListOptions{}); e != nil {
+				if e := cluster.CoreV1().Secrets(i.settings.SystemNamespace).DeleteCollection(
+					context.Background(), kubeApiMeta.DeleteOptions{}, kubeApiMeta.ListOptions{}); e != nil {
 					err = multierror.Append(err, e)
 				}
-				if e := cluster.CoreV1().ConfigMaps(i.settings.SystemNamespace).DeleteCollection(context.Background(), kubeApiMeta.DeleteOptions{}, kubeApiMeta.ListOptions{}); e != nil {
+				if e := cluster.CoreV1().ConfigMaps(i.settings.SystemNamespace).DeleteCollection(
+					context.Background(), kubeApiMeta.DeleteOptions{}, kubeApiMeta.ListOptions{}); e != nil {
 					err = multierror.Append(err, e)
 				}
 				return

--- a/tests/integration/security/util/cert/cert.go
+++ b/tests/integration/security/util/cert/cert.go
@@ -182,6 +182,10 @@ func CreateCustomEgressSecret(ctx resource.Context) error {
 
 	_, err = kubeAccessor.CoreV1().Secrets(systemNs.Name()).Create(context.TODO(), secret, metav1.CreateOptions{})
 	if err != nil {
+		if errors.IsAlreadyExists(err) {
+			_, err = kubeAccessor.CoreV1().Secrets(systemNs.Name()).Update(context.TODO(), secret, metav1.UpdateOptions{})
+			return err
+		}
 		return err
 	}
 


### PR DESCRIPTION
Currently, we cleanup MC tests by deleting istio-system ns, but single cluster by just removing the yamls we applied. This changes them to have the same flow.

Cleaning up a namespace takes ~1 min, while this approach takes ~1 second, so its a few minutes improvement and simpler code