### PR TITLE
Add envoy health check for VMs

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -285,6 +285,7 @@ var (
 				XDSRootCerts: xdsRootCA,
 				CARootCerts:  caRootCA,
 				XDSHeaders:   map[string]string{},
+				IsIPv6:       proxyIPv6,
 			}
 			extractXDSHeadersFromEnv(agentConfig)
 			if proxyXDSViaAgent {

--- a/pilot/cmd/pilot-agent/status/ready/probe.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe.go
@@ -21,18 +21,23 @@ import (
 
 	"istio.io/istio/pilot/cmd/pilot-agent/metrics"
 	"istio.io/istio/pilot/cmd/pilot-agent/status/util"
-	"istio.io/istio/pilot/pkg/model"
 )
 
 // Probe for readiness.
 type Probe struct {
 	LocalHostAddr       string
-	NodeType            model.NodeType
 	AdminPort           uint16
 	receivedFirstUpdate bool
 	// Indicates that Envoy is ready atleast once so that we can cache and reuse that probe.
 	atleastOnceReady bool
 }
+
+type Prober interface {
+	// Check executes the probe and returns an error if the probe fails.
+	Check() error
+}
+
+var _ Prober = &Probe{}
 
 // Check executes the probe and returns an error if the probe fails.
 func (p *Probe) Check() error {

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -125,7 +125,6 @@ func NewServer(config Config) (*Server, error) {
 		ready: &ready.Probe{
 			LocalHostAddr: config.LocalHostAddr,
 			AdminPort:     config.AdminPort,
-			NodeType:      config.NodeType,
 		},
 		envoyStatsPort: 15090,
 	}
@@ -198,7 +197,7 @@ func FormatProberURL(container string) (string, string, string) {
 
 // Run opens a the status port and begins accepting probes.
 func (s *Server) Run(ctx context.Context) {
-	log.Infof("Opening status port %d\n", s.statusPort)
+	log.Infof("Opening status port %d", s.statusPort)
 
 	mux := http.NewServeMux()
 

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -577,6 +577,7 @@ func (s *DiscoveryServer) preProcessRequest(proxy *model.Proxy, req *discovery.D
 				event.Healthy = false
 				event.Message = req.ErrorDetail.Message
 			}
+			adsLog.Debugf("updated health status of %v to %v", proxy.ID, event.Healthy)
 			s.InternalGen.UpdateWorkloadEntryHealth(proxy, event)
 		}
 		return false

--- a/pilot/pkg/xds/workloadentry.go
+++ b/pilot/pkg/xds/workloadentry.go
@@ -74,7 +74,7 @@ func (sg *InternalGen) RegisterWorkload(proxy *model.Proxy, con *Connection) err
 	})
 	// TODO return err from Patch through Get
 	if err == nil {
-		adsLog.Debugf("updated auto-registered WorkloadEntry %s/%s", proxy.Metadata.Namespace, entryName)
+		adsLog.Infof("updated auto-registered WorkloadEntry %s/%s", proxy.Metadata.Namespace, entryName)
 		return nil
 	} else if !errors.IsNotFound(err) && err.Error() != "item not found" {
 		adsLog.Errorf("updating auto-registered WorkloadEntry %s/%s: %v", proxy.Metadata.Namespace, entryName, err)

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -148,6 +148,9 @@ type AgentConfig struct {
 
 	// Extra headers to add to the XDS connection.
 	XDSHeaders map[string]string
+
+	// Is the proxy an IPv6 proxy
+	IsIPv6 bool
 }
 
 // NewAgent wraps the logic for a local SDS. It will check if the JWT token required for local SDS is

--- a/pkg/istio-agent/health/health_check.go
+++ b/pkg/istio-agent/health/health_check.go
@@ -19,7 +19,9 @@ import (
 	"time"
 
 	"istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/cmd/pilot-agent/status/ready"
 	"istio.io/istio/pkg/kube/apimirror"
+	"istio.io/pkg/log"
 )
 
 type WorkloadHealthChecker struct {
@@ -70,7 +72,7 @@ func fillInDefaults(cfg *v1alpha3.ReadinessProbe) *v1alpha3.ReadinessProbe {
 	return cfg
 }
 
-func NewWorkloadHealthChecker(cfg *v1alpha3.ReadinessProbe) *WorkloadHealthChecker {
+func NewWorkloadHealthChecker(cfg *v1alpha3.ReadinessProbe, envoyProbe ready.Prober) *WorkloadHealthChecker {
 	// if a config does not exist return a no-op prober
 	if cfg == nil {
 		return &WorkloadHealthChecker{
@@ -91,6 +93,11 @@ func NewWorkloadHealthChecker(cfg *v1alpha3.ReadinessProbe) *WorkloadHealthCheck
 		prober = nil
 	}
 
+	probers := []Prober{}
+	if envoyProbe != nil {
+		probers = append(probers, &EnvoyProber{envoyProbe})
+	}
+	probers = append(probers, prober)
 	return &WorkloadHealthChecker{
 		config: applicationHealthCheckConfig{
 			InitialDelay:   time.Duration(cfg.InitialDelaySeconds) * time.Second,
@@ -99,7 +106,7 @@ func NewWorkloadHealthChecker(cfg *v1alpha3.ReadinessProbe) *WorkloadHealthCheck
 			SuccessThresh:  int(cfg.SuccessThreshold),
 			FailThresh:     int(cfg.FailureThreshold),
 		},
-		prober: prober,
+		prober: AggregateProber{Probes: probers},
 	}
 }
 
@@ -118,11 +125,13 @@ func (w *WorkloadHealthChecker) PerformApplicationHealthCheck(callback func(*Pro
 	if w.prober == nil {
 		return
 	}
-
-	healthCheckLog.Infof("starting health check for %T", w.prober)
+	healthCheckLog.SetOutputLevel(log.DebugLevel)
+	healthCheckLog.Infof("starting health check for %T in %v", w.prober, w.config.InitialDelay)
 
 	// delay before starting probes.
 	time.Sleep(w.config.InitialDelay)
+
+	healthCheckLog.Debugf("health check initial delay complete")
 
 	// tracks number of success & failures after last success/failure
 	numSuccess, numFail := 0, 0
@@ -130,56 +139,51 @@ func (w *WorkloadHealthChecker) PerformApplicationHealthCheck(callback func(*Pro
 	// first send a healthy message.
 	lastStateHealthy := false
 
-	if w.config.CheckFrequency == time.Second*0 {
-		// should probably hard-code a value somewhere else.
-		// like k8s, default to 10s
-		w.config.CheckFrequency = time.Second * 10
+	doCheck := func() {
+		// probe target
+		healthy, err := w.prober.Probe(w.config.ProbeTimeout)
+		if healthy.IsHealthy() {
+			healthCheckLog.Debug("probe completed with healthy status")
+			// we were healthy, increment success counter
+			numSuccess++
+			// wipe numFail (need consecutive success)
+			numFail = 0
+			// if we reached the threshold, mark the target as healthy
+			if numSuccess == w.config.SuccessThresh && !lastStateHealthy {
+				healthCheckLog.Info("success threshold hit, marking as healthy")
+				callback(&ProbeEvent{Healthy: true})
+				numSuccess = 0
+				lastStateHealthy = true
+			}
+		} else {
+			healthCheckLog.Debugf("probe completed with unhealthy status: %v", err)
+			// we were not healthy, increment fail counter
+			numFail++
+			// wipe numSuccess (need consecutive failure)
+			numSuccess = 0
+			// if we reached the fail threshold, mark the target as unhealthy
+			if numFail == w.config.FailThresh && lastStateHealthy {
+				healthCheckLog.Infof("failure threshold hit, marking as unhealthy: %v", err)
+				callback(&ProbeEvent{
+					Healthy:          false,
+					UnhealthyStatus:  500,
+					UnhealthyMessage: err.Error(),
+				})
+				numFail = 0
+				lastStateHealthy = false
+			}
+		}
 	}
 
+	// Send the first request immediately
+	doCheck()
 	periodTicker := time.NewTicker(w.config.CheckFrequency)
 	for {
 		select {
 		case <-quit:
 			return
 		case <-periodTicker.C:
-			// probe target
-			healthy, err := w.prober.Probe(w.config.ProbeTimeout)
-			if healthy.IsHealthy() {
-				healthCheckLog.Debug("probe completed with healthy status")
-				// we were healthy, increment success counter
-				numSuccess++
-				// wipe numFail (need consecutive success)
-				numFail = 0
-				// if we reached the threshold, mark the target as healthy
-				if numSuccess == w.config.SuccessThresh && !lastStateHealthy {
-					healthCheckLog.Info("success threshold hit, marking as healthy")
-					callback(&ProbeEvent{Healthy: true})
-					numSuccess = 0
-					lastStateHealthy = true
-				}
-			} else {
-				healthCheckLog.Debugf("probe completed with unhealthy status: %v", err)
-				// we were not healthy, increment fail counter
-				numFail++
-				// wipe numSuccess (need consecutive failure)
-				numSuccess = 0
-				// if we reached the fail threshold, mark the target as unhealthy
-				if numFail == w.config.FailThresh && lastStateHealthy {
-					healthCheckLog.Infof("failure threshold hit, marking as unhealthy: %v", err)
-					callback(&ProbeEvent{
-						Healthy:          false,
-						UnhealthyStatus:  500,
-						UnhealthyMessage: err.Error(),
-					})
-					numFail = 0
-					lastStateHealthy = false
-				}
-			}
+			doCheck()
 		}
 	}
-}
-
-// TODO implement
-func (w *WorkloadHealthChecker) PerformEnvoyHealthCheck() {
-
 }

--- a/pkg/istio-agent/health/health_check_test.go
+++ b/pkg/istio-agent/health/health_check_test.go
@@ -44,7 +44,7 @@ func TestWorkloadHealthChecker_PerformApplicationHealthCheck(t *testing.T) {
 					Port: uint32(port),
 				},
 			},
-		})
+		}, nil)
 		// Speed up tests
 		tcpHealthChecker.config.CheckFrequency = time.Millisecond
 
@@ -114,7 +114,7 @@ func TestWorkloadHealthChecker_PerformApplicationHealthCheck(t *testing.T) {
 					Host:   "127.0.0.1",
 				},
 			},
-		})
+		}, nil)
 		// Speed up tests
 		httpHealthChecker.config.CheckFrequency = time.Millisecond
 		quitChan := make(chan struct{})


### PR DESCRIPTION
    Currently we only check application health. This expands this to also
    perform the same health checks that k8s gets on the agent. These are
    aggregated with AggregateProbe.


Depends on https://github.com/istio/istio/pull/29426