### PR TITLE
Experiment with in memory etcd storage

### DIFF
--- a/prow/config/trustworthy-jwt.yaml
+++ b/prow/config/trustworthy-jwt.yaml
@@ -7,6 +7,10 @@ kubeadmConfigPatches:
     kind: ClusterConfiguration
     metadata:
       name: config
+    etcd:
+      local:
+        # Run etcd in a tmpfs (in RAM) for performance improvements
+        dataDir: /tmp/kind-cluster-etcd
     apiServer:
       extraArgs:
         "service-account-issuer": "kubernetes.default.svc"


### PR DESCRIPTION
This is attempting to resolve some issues where etcd is overloaded especially in multicluster tests (like https://github.com/istio/istio/issues/29458), by putting etcd memory in ram. 

After a few iterations in CI, RAM usage by the test pods is not detectably increased. Fairly low sample save, but there seems to be less etcd timeouts in logs. Test times are pretty variable currently so not sure if its faster - I expect it to be trivially faster but more reliable, which is harder to test in a PR