### PR TITLE
Fix generate-workload.sh working when fullpaths contain '.'

### DIFF
--- a/samples/certs/generate-workload.sh
+++ b/samples/certs/generate-workload.sh
@@ -14,6 +14,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+set -euxo pipefail
+
 name=${1:-foo}
 ns=${2:-$name}
 sa=${3:-$name}
@@ -22,13 +24,35 @@ san="spiffe://trust-domain-$name/ns/$ns/sa/$sa"
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-if [ ! -d "$DIR/$tmp" ]; then
-  mkdir "$DIR/$tmp"
+FINAL_DIR=$DIR
+if [ -n "$tmp" ]; then
+  FINAL_DIR=$tmp
+  cp "$DIR"/root-cert.pem "$FINAL_DIR"
+  cp "$DIR"/ca-cert.pem "$FINAL_DIR"
+  cp "$DIR"/ca-key.pem "$FINAL_DIR"
+  cp "$DIR"/cert-chain.pem "$FINAL_DIR"
 fi
 
-openssl genrsa -out "$DIR/$tmp/workload-$name-key.pem" 2048
+function cleanup() {
+  if [ -f "$FINAL_DIR"/.srl ]; then
+    rm "$FINAL_DIR"/.srl
+  fi
+  if [ -f "$FINAL_DIR"/ca-cert.srl ]; then
+    rm "$FINAL_DIR"/ca-cert.srl
+  fi
+  if [ -f "$FINAL_DIR"/workload.cfg ]; then
+    rm "$FINAL_DIR"/workload.cfg
+  fi
+  if [ -f "$FINAL_DIR"/workload.csr ]; then
+    rm "$FINAL_DIR"/workload.csr
+  fi
+}
 
-cat > "$DIR"/workload.cfg <<EOF
+trap cleanup EXIT
+
+openssl genrsa -out "$FINAL_DIR/workload-$name-key.pem" 2048
+
+cat > "$FINAL_DIR"/workload.cfg <<EOF
 [req]
 distinguished_name = req_distinguished_name
 req_extensions = v3_req
@@ -45,21 +69,13 @@ subjectAltName = critical, @alt_names
 URI = $san
 EOF
 
-openssl req -new -key "$DIR/$tmp/workload-$name-key.pem" -subj "/" -out "$DIR"/workload.csr -config "$DIR"/workload.cfg
+openssl req -new -key "$FINAL_DIR/workload-$name-key.pem" -subj "/" -out "$FINAL_DIR"/workload.csr -config "$FINAL_DIR"/workload.cfg
 
-openssl x509 -req -in "$DIR"/workload.csr -CA "$DIR"/ca-cert.pem -CAkey "$DIR"/ca-key.pem -CAcreateserial \
--out "$DIR/$tmp/workload-$name-cert.pem" -days 3650 -extensions v3_req -extfile "$DIR"/workload.cfg
+openssl x509 -req -in "$FINAL_DIR"/workload.csr -CA "$FINAL_DIR"/ca-cert.pem -CAkey "$FINAL_DIR"/ca-key.pem -CAcreateserial \
+-out "$FINAL_DIR/workload-$name-cert.pem" -days 3650 -extensions v3_req -extfile "$FINAL_DIR"/workload.cfg
 
-cat "$DIR"/cert-chain.pem >> "$DIR/$tmp/workload-$name-cert.pem"
+cat "$FINAL_DIR"/cert-chain.pem >> "$FINAL_DIR/workload-$name-cert.pem"
 
 echo "Generated workload-$name-[cert|key].pem with URI SAN $san"
-openssl verify -CAfile <(cat "$DIR"/cert-chain.pem "$DIR"/root-cert.pem) "$DIR/$tmp/workload-$name-cert.pem"
+openssl verify -CAfile <(cat "$FINAL_DIR"/cert-chain.pem "$FINAL_DIR"/root-cert.pem) "$FINAL_DIR/workload-$name-cert.pem"
 
-# clean temporary files
-if [ -f "$DIR"/.srl ]; then
-  rm "$DIR"/.srl
-fi
-if [ -f "$DIR"/ca-cert.srl ]; then
-  rm "$DIR"/ca-cert.srl
-fi
-rm "$DIR"/workload.cfg "$DIR"/workload.csr

--- a/samples/certs/generate-workload.sh
+++ b/samples/certs/generate-workload.sh
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-set -euxo pipefail
+set -euo pipefail
 
 name=${1:-foo}
 ns=${2:-$name}
@@ -25,12 +25,17 @@ san="spiffe://trust-domain-$name/ns/$ns/sa/$sa"
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 FINAL_DIR=$DIR
-if [ -n "$tmp" ]; then
-  FINAL_DIR=$tmp
-  cp "$DIR"/root-cert.pem "$FINAL_DIR"
-  cp "$DIR"/ca-cert.pem "$FINAL_DIR"
-  cp "$DIR"/ca-key.pem "$FINAL_DIR"
-  cp "$DIR"/cert-chain.pem "$FINAL_DIR"
+if [ ! -z "$tmp" ]; then
+  if [ -d "$tmp" ]; then
+    FINAL_DIR=$tmp
+    cp "$DIR"/root-cert.pem "$FINAL_DIR"
+    cp "$DIR"/ca-cert.pem "$FINAL_DIR"
+    cp "$DIR"/ca-key.pem "$FINAL_DIR"
+    cp "$DIR"/cert-chain.pem "$FINAL_DIR"
+  else
+    echo "tmp argument is not a directory: $tmp"
+    exit 1
+  fi
 fi
 
 function cleanup() {

--- a/samples/certs/generate-workload.sh
+++ b/samples/certs/generate-workload.sh
@@ -25,7 +25,7 @@ san="spiffe://trust-domain-$name/ns/$ns/sa/$sa"
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 FINAL_DIR=$DIR
-if [ ! -z "$tmp" ]; then
+if [ -n "$tmp" ]; then
   if [ -d "$tmp" ]; then
     FINAL_DIR=$tmp
     cp "$DIR"/root-cert.pem "$FINAL_DIR"

--- a/tests/integration/security/ca_custom_root/main_test.go
+++ b/tests/integration/security/ca_custom_root/main_test.go
@@ -55,8 +55,8 @@ type EchoDeployments struct {
 }
 
 var (
-	inst    istio.Instance
-	apps    = &EchoDeployments{}
+	inst istio.Instance
+	apps = &EchoDeployments{}
 )
 
 func SetupApps(ctx resource.Context, apps *EchoDeployments) error {

--- a/tests/integration/security/ca_custom_root/main_test.go
+++ b/tests/integration/security/ca_custom_root/main_test.go
@@ -220,8 +220,8 @@ func SetupApps(ctx resource.Context, apps *EchoDeployments) error {
 	return nil
 }
 
-func loadCert(name string) (string, error) {
-	data, err := cert.ReadSampleCertFromFile(name)
+func loadCert(filename string) (string, error) {
+	data, err := cert.ReadSampleCertFromFile(filename)
 	if err != nil {
 		return "", err
 	}

--- a/tests/integration/security/ca_custom_root/trust_domain_alias_secure_naming_test.go
+++ b/tests/integration/security/ca_custom_root/trust_domain_alias_secure_naming_test.go
@@ -127,7 +127,5 @@ func TestTrustDomainAliasSecureNaming(t *testing.T) {
 					}
 				})
 			}
-
-			ctx.WhenDone(Cleanup)
 		})
 }

--- a/tests/integration/security/ca_custom_root/trust_domain_alias_secure_naming_test.go
+++ b/tests/integration/security/ca_custom_root/trust_domain_alias_secure_naming_test.go
@@ -26,7 +26,6 @@ import (
 )
 
 const (
-	TmpDir = "tmp"
 	HTTPS  = "https"
 	POLICY = `
 apiVersion: "security.istio.io/v1beta1"

--- a/tests/integration/security/util/cert/cert.go
+++ b/tests/integration/security/util/cert/cert.go
@@ -133,7 +133,11 @@ func CreateCASecret(ctx resource.Context) error {
 }
 
 func ReadSampleCertFromFile(f string) ([]byte, error) {
-	b, err := ioutil.ReadFile(path.Join(env.IstioSrc, "samples/certs", f))
+	filename := f
+	if !path.IsAbs(filename) {
+		filename = path.Join(env.IstioSrc, "samples/certs", f)
+	}
+	b, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Due to https://github.com/openssl/openssl/issues/10442 I am not able to
generate workload certificates since my username contains a '.' on my
development machine (e.g. `j.delgado`)

To be specific, openssl fails on https://github.com/istio/istio/blob/917fd076c4514b2c16c79e6feeae1dcbd8358580/samples/certs/generate-workload.sh#L50 due to the `-CA "$DIR"/ca-cert.pem` cli argument.

Attempts to read from /Users/j.srl. Have it use a full temp directory
passed in. Otherwise default to the previous behavior.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.