### PR TITLE
Revert "set default priorityClass for istiod (#29392)"

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -99,7 +99,7 @@ data:
         "oneNamespace": false,
         "operatorManageWebhooks": false,
         "pilotCertProvider": "istiod",
-        "priorityClassName": "system-cluster-critical",
+        "priorityClassName": "",
         "proxy": {
           "autoInject": "enabled",
           "clusterDomain": "cluster.local",
@@ -765,7 +765,6 @@ spec:
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: istiod-service-account
-      priorityClassName: "system-cluster-critical"
       securityContext:
         fsGroup: 1337
       containers:

--- a/manifests/charts/istio-control/istio-discovery/values.yaml
+++ b/manifests/charts/istio-control/istio-discovery/values.yaml
@@ -262,8 +262,8 @@ global:
   # system-node-critical, it is better to configure this in order to make sure your Istio pods
   # will not be killed because of low priority class.
   # Refer to https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
-  # for more details.
-  priorityClassName: "system-cluster-critical"
+  # for more detail.
+  priorityClassName: ""
 
   proxy:
     image: proxyv2

--- a/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -79,7 +79,7 @@ data:
         "oneNamespace": false,
         "operatorManageWebhooks": false,
         "pilotCertProvider": "istiod",
-        "priorityClassName": "system-cluster-critical",
+        "priorityClassName": "",
         "proxy": {
           "autoInject": "enabled",
           "clusterDomain": "cluster.local",

--- a/manifests/charts/istiod-remote/values.yaml
+++ b/manifests/charts/istiod-remote/values.yaml
@@ -227,8 +227,8 @@ global:
   # system-node-critical, it is better to configure this in order to make sure your Istio pods
   # will not be killed because of low priority class.
   # Refer to https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
-  # for more details.
-  priorityClassName: "system-cluster-critical"
+  # for more detail.
+  priorityClassName: ""
   proxy:
     image: proxyv2
     # This controls the 'policy' in the sidecar injector.


### PR DESCRIPTION
This reverts commit 65c0c1ee27a0154226f0306d54cd5ce7800f2b46.
This led to 100% failure of k8s 1.15/1.16 tests. Not sure why - maybe it only works on 1.17+?

See https://github.com/istio/istio/issues/29456