### PR TITLE
remove empty proxy config to reduce data size sent in xds request

### DIFF
--- a/pkg/config/mesh/mesh.go
+++ b/pkg/config/mesh/mesh.go
@@ -39,7 +39,6 @@ func DefaultProxyConfig() meshconfig.ProxyConfig {
 	// TODO: include revision based on REVISION env
 	// TODO: set default namespace based on POD_NAMESPACE env
 	return meshconfig.ProxyConfig{
-		// missing: ConnectTimeout: 10 * time.Second,
 		ConfigPath:               constants.ConfigPathDir,
 		ServiceCluster:           constants.ServiceClusterName,
 		DrainDuration:            types.DurationProto(45 * time.Second),
@@ -58,13 +57,9 @@ func DefaultProxyConfig() meshconfig.ProxyConfig {
 		},
 
 		// Code defaults
-		BinaryPath:            constants.BinaryPathFilename,
-		StatsdUdpAddress:      "",
-		EnvoyMetricsService:   &meshconfig.RemoteService{Address: ""},
-		EnvoyAccessLogService: &meshconfig.RemoteService{Address: ""},
-		CustomConfigFile:      "",
-		StatNameLength:        189,
-		StatusPort:            15020,
+		BinaryPath:     constants.BinaryPathFilename,
+		StatNameLength: 189,
+		StatusPort:     15020,
 	}
 }
 


### PR DESCRIPTION

Without this the node meta is 

```
{
	"APP_CONTAINERS": "sleep",
	"CLUSTER_ID": "Kubernetes",
	"DNS_CAPTURE": "true",
	"EXCHANGE_KEYS": "NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,MESH_ID,SERVICE_ACCOUNT,CLUSTER_ID",
	"INSTANCE_IPS": "10.244.0.15,fe80::a833:8bff:fe1a:9476",
	"INTERCEPTION_MODE": "REDIRECT",
	"ISTIO_PROXY_SHA": "istio-proxy:ed0e581060499e4ed0f68925fbbc8f2f12340c9a",
	"ISTIO_VERSION": "1.8.0",
	"LABELS": {
		"app": "sleep",
		"istio.io/rev": "default",
		"pod-template-hash": "8f795f47d",
		"security.istio.io/tlsMode": "istio",
		"service.istio.io/canonical-name": "sleep",
		"service.istio.io/canonical-revision": "latest"
	},
	"MESH_ID": "cluster.local",
	"NAME": "sleep-8f795f47d-fs998",
	"NAMESPACE": "default",
	"OWNER": "kubernetes://apis/apps/v1/namespaces/default/deployments/sleep",
	"POD_PORTS": "[\n]",
	"PROXY_CONFIG": {
		"binaryPath": "/usr/local/bin/envoy",
		"concurrency": 2,
		"configPath": "./etc/istio/proxy",
		"controlPlaneAuthPolicy": "MUTUAL_TLS",
		"discoveryAddress": "istiod.istio-system.svc:15012",
		"drainDuration": "45s",
		"envoyAccessLogService": {},
		"envoyMetricsService": {},
		"parentShutdownDuration": "60s",
		"proxyAdminPort": 15000,
		"proxyMetadata": {
			"DNS_AGENT": ""
		},
		"serviceCluster": "sleep.default",
		"statNameLength": 189,
		"statusPort": 15020,
		"terminationDrainDuration": "5s",
		"tracing": {
			"zipkin": {
				"address": "zipkin.istio-system:9411"
			}
		}
	},
	"SERVICE_ACCOUNT": "sleep",
	"WORKLOAD_NAME": "sleep"
}
```

With this:

envoyAccessLogService and envoyMetricsService will not be sent



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.