### PR TITLE
always ignore kube's known system namespaces during injection

### DIFF
--- a/galley/pkg/config/analysis/analyzers/util/config.go
+++ b/galley/pkg/config/analysis/analyzers/util/config.go
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/resource"
 )
 
@@ -26,7 +27,12 @@ import (
 // "local-path-storage": Dynamically provisioning persistent local storage with Kubernetes.
 //    used with Kind cluster: https://github.com/rancher/local-path-provisioner
 var (
-	SystemNamespaces = []string{"kube-system", "kube-public", "kube-node-lease", "local-path-storage"}
+	SystemNamespaces = []string{
+		constants.KubeSystemNamespace,
+		constants.KubePublicNamespace,
+		constants.KubeNodeLeaseNamespace,
+		constants.LocalPathStorageNamespace,
+	}
 )
 
 // IsSystemNamespace returns true for system namespaces

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -108,5 +108,18 @@ const (
 	// DefaultConfigServiceAccountName is the default service account to use for external Istiod cluster access.
 	DefaultConfigServiceAccountName = "istiod-service-account"
 
+	// KubeSystemNamespace is the system namespace where we place kubernetes system components.
+	KubeSystemNamespace string = "kube-system"
+
+	// KubePublicNamespace is the namespace where we place kubernetes public info (ConfigMaps).
+	KubePublicNamespace string = "kube-public"
+
+	// KubeNodeLeaseNamespace is the namespace for the lease objects associated with each kubernetes node.
+	KubeNodeLeaseNamespace string = "kube-node-lease"
+
+	// LocalPathStorageNamespace is the namespace for dynamically provisioning persistent local storage with
+	// Kubernetes. Typically used with the Kind cluster: https://github.com/rancher/local-path-provisioner
+	LocalPathStorageNamespace string = "local-path-storage"
+
 	TestVMLabel = "istio.io/test-vm"
 )

--- a/pkg/kube/inject/initializer.go
+++ b/pkg/kube/inject/initializer.go
@@ -20,14 +20,17 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/api/batch/v2alpha1"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"istio.io/istio/pkg/config/constants"
 )
 
 var ignoredNamespaces = []string{
-	metav1.NamespaceSystem,
-	metav1.NamespacePublic,
+	constants.KubeSystemNamespace,
+	constants.KubePublicNamespace,
+	constants.KubeNodeLeaseNamespace,
+	constants.LocalPathStorageNamespace,
 }
 
 var (


### PR DESCRIPTION

Right now, during injection, only `kube-system` and `kube-public` are recognised as system namespaces. We want to enable an `AllNamespaces` option in our mutating webhooks, so we would need to ignore the other known system namespaces by default as well.


[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.