### PR TITLE
do not add locality endpoints for passthrough subsets

### DIFF
--- a/releasenotes/notes/passthrough-subsets.yaml
+++ b/releasenotes/notes/passthrough-subsets.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: networking
+issue:
+- 25691
+releaseNotes:
+- |
+  **Fixed** a bug where load assignments were added to passthrough subsets resulting in Envoy rejecting those subset clusters.


### PR DESCRIPTION
When we generate passthrough subsets(Subset trafficpolicy sets load balancer as Passthrough), we add locality endpoints for non EDS discovery types and Envoy rejects those subset clusters with the error
"ORIGINAL_DST clusters must have no load assignment or hosts configured,"

This PR skips adding locality endpoints for pass through subsets.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
