### PR TITLE
only perform patch-cert loop on remote clusters in external istiod mode

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -161,7 +161,6 @@ func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string)
 		go kubeRegistry.Run(stopCh)
 	}
 	if m.fetchCaRoot != nil && m.fetchCaRoot() != nil && (features.ExternalIstioD || features.CentralIstioD || localCluster) {
-		// TODO remove initNamespaceController (and probably need leader election here? how will that work with multi-primary?)
 		log.Infof("joining leader-election for %s in %s", leaderelection.NamespaceController, options.SystemNamespace)
 		go leaderelection.
 			NewLeaderElection(options.SystemNamespace, m.serverID, leaderelection.NamespaceController, client.Kube()).
@@ -182,7 +181,7 @@ func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string)
 	// This requires RBAC permissions - a low-priv Istiod should not attempt to patch but rely on
 	// operator or CI/CD
 	webhookConfigName := strings.ReplaceAll(validationWebhookConfigNameTemplate, validationWebhookConfigNameTemplateVar, m.secretNamespace)
-	if features.InjectionWebhookConfigName.Get() != "" && m.caBundlePath != "" && !localCluster {
+	if features.InjectionWebhookConfigName.Get() != "" && m.caBundlePath != "" && !localCluster && (features.ExternalIstioD || features.CentralIstioD) {
 		// TODO remove the patch loop init from initSidecarInjector (does this need leader elect? how well does it work with multi-primary?)
 		log.Infof("initializing webhook cert patch for cluster %s", clusterID)
 		go webhooks.PatchCertLoop(features.InjectionWebhookConfigName.Get(), webhookName, m.caBundlePath, client.Kube(), stopCh)


### PR DESCRIPTION
Although we need this for istiod-less remotes, it can be undesirable in some scenarios so we should guard it with flags. 

Related discussion: https://github.com/istio/istio/pull/28768#discussion_r539052937

cc @ramaraochavali 