### PR TITLE
Set standard alpns as well in outbound traffic

### DIFF
--- a/pilot/pkg/xds/filters/filters.go
+++ b/pilot/pkg/xds/filters/filters.go
@@ -160,9 +160,12 @@ var (
 	// These ALPNs are injected in the client side by the ALPN filter.
 	// "istio" is added for each upstream protocol in order to make it
 	// backward compatible. e.g., 1.4 proxy -> 1.3 proxy.
-	mtlsHTTP10ALPN = []string{"istio-http/1.0", "istio"}
-	mtlsHTTP11ALPN = []string{"istio-http/1.1", "istio"}
-	mtlsHTTP2ALPN  = []string{"istio-h2", "istio"}
+	// Non istio-* variants are added to ensure that traffic sent out of the mesh has a valid ALPN;
+	// ideally this would not be added, but because the override filter is in the HCM, rather than cluster,
+	// we do not yet know the upstream so we cannot determine if its in or out of the mesh
+	mtlsHTTP10ALPN = []string{"istio-http/1.0", "istio", "http/1.0"}
+	mtlsHTTP11ALPN = []string{"istio-http/1.1", "istio", "http/1.1"}
+	mtlsHTTP2ALPN  = []string{"istio-h2", "istio", "h2"}
 )
 
 func buildHTTPMxFilter() *hcm.HttpFilter {

--- a/pkg/test/echo/client/parsedresponse.go
+++ b/pkg/test/echo/client/parsedresponse.go
@@ -243,6 +243,15 @@ func almostEquals(a, b, precision int) bool {
 	return true
 }
 
+func (r ParsedResponses) CheckKey(key, expected string) error {
+	return r.Check(func(i int, response *ParsedResponse) error {
+		if response.RawResponse[key] != expected {
+			return fmt.Errorf("response[%d] %s: expected %s, received %s", i, key, expected, response.RawResponse[key])
+		}
+		return nil
+	})
+}
+
 func (r ParsedResponses) CheckCluster(expected string) error {
 	return r.Check(func(i int, response *ParsedResponse) error {
 		if response.Cluster != expected {

--- a/pkg/test/echo/server/endpoint/http.go
+++ b/pkg/test/echo/server/endpoint/http.go
@@ -87,7 +87,17 @@ func (s *httpInstance) Start(onReady OnReadyFunc) error {
 		if cerr != nil {
 			return fmt.Errorf("could not load TLS keys: %v", cerr)
 		}
-		config := &tls.Config{Certificates: []tls.Certificate{cert}}
+		config := &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			NextProtos:   []string{"h2", "http/1.1", "http/1.0"},
+			GetConfigForClient: func(info *tls.ClientHelloInfo) (*tls.Config, error) {
+				// There isn't a way to pass through all ALPNs presented by the client down to the
+				// HTTP server to return in the response. However, for debugging, we can at least log
+				// them at this level.
+				epLog.Infof("TLS connection with alpn: %v", info.SupportedProtos)
+				return nil, nil
+			},
+		}
 		// Listen on the given port and update the port if it changed from what was passed in.
 		listener, port, err = listenOnAddressTLS(s.ListenerIP, s.Port.Port, config)
 		// Store the actual listening port back to the argument.
@@ -297,6 +307,14 @@ func (h *httpHandler) addResponsePayload(r *http.Request, body *bytes.Buffer) {
 	writeField(body, "Proto", r.Proto)
 	ip, _, _ := net.SplitHostPort(r.RemoteAddr)
 	writeField(body, response.IPField, ip)
+
+	// Note: since this is the NegotiatedProtocol, it will be set to empty if the client sends an ALPN
+	// not supported by the server (ie one of h2,http/1.1,http/1.0)
+	var alpn string
+	if r.TLS != nil {
+		alpn = r.TLS.NegotiatedProtocol
+	}
+	writeField(body, "Alpn", alpn)
 
 	keys := []string{}
 	for k := range r.Header {

--- a/pkg/test/framework/components/echo/call.go
+++ b/pkg/test/framework/components/echo/call.go
@@ -154,6 +154,13 @@ func ExpectCluster(expected string) Validator {
 	})
 }
 
+// ExpectKey returns a validator that checks a key matches the provided value
+func ExpectKey(key, expected string) Validator {
+	return ValidatorFunc(func(responses client.ParsedResponses, _ error) error {
+		return responses.CheckKey(key, expected)
+	})
+}
+
 // ExpectHost returns a Validator that checks the responses for the given host header.
 func ExpectHost(expected string) Validator {
 	return ValidatorFunc(func(responses client.ParsedResponses, _ error) error {

--- a/pkg/test/framework/components/echo/common/call.go
+++ b/pkg/test/framework/components/echo/common/call.go
@@ -174,8 +174,8 @@ func fillInCallOptions(opts *echo.CallOptions) error {
 				return fmt.Errorf("callOptions: no port named %s available in Target Instance", opts.PortName)
 			}
 		}
-	} else if opts.Port == nil || opts.Port.ServicePort == 0 || opts.Port.Protocol == "" || opts.Address == "" {
-		return fmt.Errorf("if target is not set, then port.servicePort, port.protocol, and host must be set")
+	} else if opts.Port == nil || opts.Port.ServicePort == 0 || (opts.Port.Protocol == "" && opts.Scheme == "") || opts.Address == "" {
+		return fmt.Errorf("if target is not set, then port.servicePort, port.protocol or schema, and address must be set")
 	}
 
 	if opts.Scheme == "" {

--- a/releasenotes/notes/standard-alpn.yaml
+++ b/releasenotes/notes/standard-alpn.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+releaseNotes:
+- |
+  **Added** support for virtual service delegate for sidecar proxies.

--- a/releasenotes/notes/standard-alpn.yaml
+++ b/releasenotes/notes/standard-alpn.yaml
@@ -1,6 +1,8 @@
 apiVersion: release-notes/v2
-kind: feature
+kind: bug-fix
 area: networking
+issue:
+- 24619
 releaseNotes:
 - |
-  **Added** support for virtual service delegate for sidecar proxies.
+  **Fixed** an issue causing only internal ALPN values to be set during external TLS origination.

--- a/tests/integration/pilot/common/apps.go
+++ b/tests/integration/pilot/common/apps.go
@@ -76,11 +76,13 @@ var EchoPorts = []echo.Port{
 	{Name: "http", Protocol: protocol.HTTP, ServicePort: 80, InstancePort: 18080},
 	{Name: "grpc", Protocol: protocol.GRPC, ServicePort: 7070, InstancePort: 17070},
 	{Name: "tcp", Protocol: protocol.TCP, ServicePort: 9090, InstancePort: 19090},
+	{Name: "https", Protocol: protocol.HTTPS, ServicePort: 443, InstancePort: 18443, TLS: true},
 	{Name: "tcp-server", Protocol: protocol.TCP, ServicePort: 9091, InstancePort: 16060, ServerFirst: true},
 	{Name: "auto-tcp", Protocol: protocol.TCP, ServicePort: 9092, InstancePort: 19091},
 	{Name: "auto-tcp-server", Protocol: protocol.TCP, ServicePort: 9093, InstancePort: 16061, ServerFirst: true},
 	{Name: "auto-http", Protocol: protocol.HTTP, ServicePort: 81, InstancePort: 18081},
 	{Name: "auto-grpc", Protocol: protocol.GRPC, ServicePort: 7071, InstancePort: 17071},
+	{Name: "auto-https", Protocol: protocol.HTTPS, ServicePort: 9443, InstancePort: 19443},
 	{Name: "http-instance", Protocol: protocol.HTTP, ServicePort: 82, InstancePort: 18082, InstanceIP: true},
 }
 
@@ -273,6 +275,14 @@ spec:
   endpoints:
   - address: external.{{.Namespace}}.svc.cluster.local
   ports:
+  - name: http-tls-origination
+    number: 8888
+    protocol: http
+    targetPort: 443
+  - name: http2-tls-origination
+    number: 8882
+    protocol: http2
+    targetPort: 443
 {{- range $i, $p := .Ports }}
   - name: {{$p.Name}}
     number: {{$p.ServicePort}}

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -404,12 +404,61 @@ spec:
 	return cases
 }
 
+func HostHeader(header string) http.Header {
+	h := http.Header{}
+	h["Host"] = []string{header}
+	return h
+}
+
+// tlsOriginationCases contains tests TLS origination from DestinationRule
+func tlsOriginationCases(apps *EchoDeployments) []TrafficTestCase {
+	cases := []TrafficTestCase{}
+	expects := []struct {
+		port int
+		alpn string
+	}{
+		{8888, "http/1.1"},
+		{8882, "h2"},
+	}
+	for _, c := range apps.PodA {
+		for _, e := range expects {
+			c := c
+			e := e
+
+			cases = append(cases, TrafficTestCase{
+				name: fmt.Sprintf("%s: %s", c.Config().Cluster.Name(), e.alpn),
+				config: fmt.Sprintf(`
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: external
+spec:
+  host: %s
+  trafficPolicy:
+    tls:
+      mode: SIMPLE
+`, apps.External[0].Config().DefaultHostHeader),
+				opts: echo.CallOptions{
+					Port:      &echo.Port{ServicePort: e.port, Protocol: protocol.HTTP},
+					Address:   apps.External[0].Address(),
+					Headers:   HostHeader(apps.External[0].Config().DefaultHostHeader),
+					Scheme:    scheme.HTTP,
+					Validator: echo.And(echo.ExpectOK(), echo.ExpectKey("Alpn", e.alpn)),
+				},
+				call: c.CallWithRetryOrFail,
+			})
+		}
+	}
+	return cases
+}
+
 // trafficLoopCases contains tests to ensure traffic does not loop through the sidecar
 func trafficLoopCases(apps *EchoDeployments) []TrafficTestCase {
 	cases := []TrafficTestCase{}
 	for _, c := range apps.PodA {
 		for _, d := range apps.PodB {
 			for _, port := range []string{"15001", "15006"} {
+				c, d, port := c, d, port
 				cases = append(cases, TrafficTestCase{
 					name: port,
 					call: func(t test.Failer, options echo.CallOptions, retryOptions ...retry.Option) echoclient.ParsedResponses {

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -91,6 +91,7 @@ func RunAllTrafficTests(ctx framework.TestContext, apps *EchoDeployments) {
 	cases["serverfirst"] = serverFirstTestCases(apps)
 	cases["gateway"] = gatewayCases(apps)
 	cases["loop"] = trafficLoopCases(apps)
+	cases["tls-origination"] = tlsOriginationCases(apps)
 	cases["instanceip"] = instanceIPTests(apps)
 	cases["services"] = serviceCases(apps)
 	if !ctx.Settings().SkipVM {

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -69,6 +69,10 @@ var (
    Matching subsets: v1
    No Traffic Policy
 9090 RBAC policies: ns\[.*\]-policy\[integ-test\]-rule\[0\]
+443 DestinationRule: a.echo-1-20670 for "a"
+   Matching subsets: v1
+   No Traffic Policy
+443 RBAC policies: ns[echo-1-20670]-policy[integ-test]-rule[0]
 9091 DestinationRule: a\..* for "a"
    Matching subsets: v1
    No Traffic Policy

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -47,11 +47,13 @@ var (
    Port: http 80/HTTP targets pod port 18080
    Port: grpc 7070/GRPC targets pod port 17070
    Port: tcp 9090/TCP targets pod port 19090
+   Port: https 443/HTTPS targets pod port 18443
    Port: tcp-server 9091/TCP targets pod port 16060
    Port: auto-tcp 9092/UnsupportedProtocol targets pod port 19091
    Port: auto-tcp-server 9093/UnsupportedProtocol targets pod port 16061
    Port: auto-http 81/UnsupportedProtocol targets pod port 18081
    Port: auto-grpc 7071/UnsupportedProtocol targets pod port 17071
+   Port: auto-https 9443/UnsupportedProtocol targets pod port 19443
    Port: http-instance 82/HTTP targets pod port 18082
 80 DestinationRule: a\..* for "a"
    Matching subsets: v1
@@ -96,6 +98,11 @@ var (
    Matching subsets: v1
    No Traffic Policy
 7071 VirtualService: a\..*
+   when headers are end-user=jason
+9443 DestinationRule: a\..* for "a"
+   Matching subsets: v1
+   No Traffic Policy
+9443 VirtualService: a\..*
    when headers are end-user=jason
 82 DestinationRule: a\..* for "a"
    Matching subsets: v1

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -43,73 +43,15 @@ import (
 )
 
 var (
-	describeSvcAOutput = regexp.MustCompile(`Service: a\..*
+	// The full describe output is much larger, but testing for it requires a change anytime the test
+	// app changes which is tedious. Instead, just check a minimum subset; unit test cover the
+	// details.
+	describeSvcAOutput = regexp.MustCompile(`(?s)Service: a\..*
    Port: http 80/HTTP targets pod port 18080
-   Port: grpc 7070/GRPC targets pod port 17070
-   Port: tcp 9090/TCP targets pod port 19090
-   Port: https 443/HTTPS targets pod port 18443
-   Port: tcp-server 9091/TCP targets pod port 16060
-   Port: auto-tcp 9092/UnsupportedProtocol targets pod port 19091
-   Port: auto-tcp-server 9093/UnsupportedProtocol targets pod port 16061
-   Port: auto-http 81/UnsupportedProtocol targets pod port 18081
-   Port: auto-grpc 7071/UnsupportedProtocol targets pod port 17071
-   Port: auto-https 9443/UnsupportedProtocol targets pod port 19443
-   Port: http-instance 82/HTTP targets pod port 18082
+.*
 80 DestinationRule: a\..* for "a"
    Matching subsets: v1
    No Traffic Policy
-80 VirtualService: a\..*
-   when headers are end-user=jason
-80 RBAC policies: ns\[.*\]-policy\[integ-test\]-rule\[0\]
-7070 DestinationRule: a\..* for "a"
-   Matching subsets: v1
-   No Traffic Policy
-7070 VirtualService: a\..*
-   when headers are end-user=jason
-7070 RBAC policies: ns\[.*\]-policy\[integ-test\]-rule\[0\]
-9090 DestinationRule: a\..* for "a"
-   Matching subsets: v1
-   No Traffic Policy
-9090 RBAC policies: ns\[.*\]-policy\[integ-test\]-rule\[0\]
-443 DestinationRule: a.echo-1-20670 for "a"
-   Matching subsets: v1
-   No Traffic Policy
-443 RBAC policies: ns\[echo-1-20670\]-policy\[integ-test\]-rule\[0\]
-9091 DestinationRule: a\..* for "a"
-   Matching subsets: v1
-   No Traffic Policy
-9091 RBAC policies: ns\[.*\]-policy\[integ-test\]-rule\[0\]
-9092 DestinationRule: a\..* for "a"
-   Matching subsets: v1
-   No Traffic Policy
-9092 VirtualService: a\..*
-   when headers are end-user=jason
-9093 DestinationRule: a\..* for "a"
-   Matching subsets: v1
-   No Traffic Policy
-9093 VirtualService: a\..*
-   when headers are end-user=jason
-81 DestinationRule: a\..* for "a"
-   Matching subsets: v1
-   No Traffic Policy
-81 VirtualService: a\..*
-   when headers are end-user=jason
-7071 DestinationRule: a\..* for "a"
-   Matching subsets: v1
-   No Traffic Policy
-7071 VirtualService: a\..*
-   when headers are end-user=jason
-9443 DestinationRule: a\..* for "a"
-   Matching subsets: v1
-   No Traffic Policy
-9443 VirtualService: a\..*
-   when headers are end-user=jason
-82 DestinationRule: a\..* for "a"
-   Matching subsets: v1
-   No Traffic Policy
-82 VirtualService: a\..*
-   when headers are end-user=jason
-82 RBAC policies: ns\[.*\]-policy\[integ-test\]-rule\[0\]
 `)
 
 	describePodAOutput = describeSvcAOutput

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -72,7 +72,7 @@ var (
 443 DestinationRule: a.echo-1-20670 for "a"
    Matching subsets: v1
    No Traffic Policy
-443 RBAC policies: ns[echo-1-20670]-policy[integ-test]-rule[0]
+443 RBAC policies: ns\[echo-1-20670\]-policy\[integ-test\]-rule\[0\]
 9091 DestinationRule: a\..* for "a"
    Matching subsets: v1
    No Traffic Policy


### PR DESCRIPTION
Fixes #24619

This allows outbound TLS origination to maintain standard ALPN values
(rather than `istio-` values). A more proper solution would be to send
only istio ones when the destination is a sidecar, and only standard
ones when not, but this requires a total change of how the filter works.

The end result here is no impact on sidecar traffic other than an
additional ALPN set, which should never impact filter chain matching
(since first ALPN has precedence), but outbound TLS will have multiple
ALPNs set and the standard ALPNs should be selected.