### PR TITLE
use rfc7396 json merge patch in crdclient

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/envoyproxy/go-control-plane v0.9.8-0.20201019204000-12785f608982
 	github.com/evanphx/json-patch v4.9.0+incompatible
+	github.com/evanphx/json-patch/v5 v5.1.0
 	github.com/fatih/color v1.9.0
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -256,6 +256,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrp
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v0.0.0-20190815234213-e83c0a1c26c8 h1:DM7gHzQfHwIj+St8zaPOI6iQEPAxOwIkskvw6s9rDaM=
 github.com/evanphx/json-patch v0.0.0-20190815234213-e83c0a1c26c8/go.mod h1:pmLOTb3x90VhIKxsA9yeQG5yfOkkKnkk1h+Ql8NDYDw=
+github.com/evanphx/json-patch/v5 v5.1.0 h1:B0aXl1o/1cP8NbviYiBMkcHBtUjIJ1/Ccg6b+SwCLQg=
+github.com/evanphx/json-patch/v5 v5.1.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d h1:105gxyaGwCFad8crR9dcMQWvV9Hvulu6hwUh4tWPJnM=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
@@ -555,6 +557,7 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/istio/viper v1.3.3-0.20190515210538-2789fed3109c h1:EFWADU43GY2T7NIYYbIHWdrG2hRiWyGSHeON57ZADBE=
 github.com/istio/viper v1.3.3-0.20190515210538-2789fed3109c/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jingyugao/rowserrcheck v0.0.0-20191204022205-72ab7603b68a/go.mod h1:xRskid8CManxVta/ALEhJha/pweKBaVG6fWgc0yH25s=
 github.com/jirfag/go-printf-func-name v0.0.0-20191110105641-45db9963cdd3/go.mod h1:HEWGJkRDzjJY2sqdDwxccsGicWEf9BQOZsq2tV+xzM0=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/licenses/github.com/evanphx/json-patch/v5/LICENSE
+++ b/licenses/github.com/evanphx/json-patch/v5/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2014, Evan Phoenix
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of the Evan Phoenix nor the names of its contributors 
+  may be used to endorse or promote products derived from this software 
+  without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE 
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/pilot/pkg/config/aggregate/config.go
+++ b/pilot/pkg/config/aggregate/config.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 
 	"github.com/hashicorp/go-multierror"
+	"k8s.io/apimachinery/pkg/types"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config"
@@ -159,11 +160,11 @@ func (cr *store) UpdateStatus(c config.Config) (string, error) {
 	return cr.writer.UpdateStatus(c)
 }
 
-func (cr *store) Patch(typ config.GroupVersionKind, name, namespace string, patchFn config.PatchFunc) (string, error) {
+func (cr *store) Patch(typ config.GroupVersionKind, name, namespace string, patchType types.PatchType, patchFn config.PatchFunc) (string, error) {
 	if cr.writer == nil {
 		return "", errorUnsupported
 	}
-	return cr.writer.Patch(typ, name, namespace, patchFn)
+	return cr.writer.Patch(typ, name, namespace, patchType, patchFn)
 }
 
 type storeCache struct {

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -247,7 +247,7 @@ func (cl *Client) UpdateStatus(cfg config.Config) (string, error) {
 
 // Patch applies only the modifications made in the PatchFunc rather than doing a full replace. Useful to avoid
 // read-modify-write conflicts when there are many concurrent-writers to the same resource.
-func (cl *Client) Patch(typ config.GroupVersionKind, name, namespace string, patchFn config.PatchFunc) (string, error) {
+func (cl *Client) Patch(typ config.GroupVersionKind, name, namespace string, patchType types.PatchType, patchFn config.PatchFunc) (string, error) {
 	// it is okay if orig is stale - we just care about the diff
 	orig := cl.Get(typ, name, namespace)
 	if orig == nil {
@@ -257,7 +257,7 @@ func (cl *Client) Patch(typ config.GroupVersionKind, name, namespace string, pat
 	modified := patchFn(orig.DeepCopy())
 
 	oo := *orig
-	meta, err := patch(cl.istioClient, cl.serviceApisClient, oo, getObjectMetadata(oo), modified, getObjectMetadata(modified))
+	meta, err := patch(cl.istioClient, cl.serviceApisClient, patchType, oo, getObjectMetadata(oo), modified, getObjectMetadata(modified))
 	if err != nil {
 		return "", err
 	}

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -373,7 +373,8 @@ func genPatchBytes(oldRes, modRes runtime.Object, typ types.PatchType) ([]byte, 
 	switch typ {
 	case types.MergePatchType:
 		return jsonmerge.CreateMergePatch(oldJSON, newJSON)
-	case types.MergePatchType:
+	case types.JSONPatchType:
+		// TODO can we consolidate to one lib?
 		ops, err := jsonpatch.CreatePatch(oldJSON, newJSON)
 		if err != nil {
 			return nil, err

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -373,7 +373,7 @@ func genPatchBytes(oldRes, modRes runtime.Object, typ types.PatchType) ([]byte, 
 	switch typ {
 	case types.MergePatchType:
 		return jsonmerge.CreateMergePatch(oldJSON, newJSON)
-	case types.JSONPatchType:
+	case types.MergePatchType:
 		ops, err := jsonpatch.CreatePatch(oldJSON, newJSON)
 		if err != nil {
 			return nil, err

--- a/pilot/pkg/config/kube/crdclient/client_test.go
+++ b/pilot/pkg/config/kube/crdclient/client_test.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 
 	"istio.io/api/meta/v1alpha1"
@@ -192,7 +193,7 @@ func TestClient(t *testing.T) {
 
 			// check we can patch items
 			var patchedCfg config.Config
-			if _, err := store.(*Client).Patch(r.GroupVersionKind(), configName, configNamespace, func(cfg config.Config) config.Config {
+			if _, err := store.(*Client).Patch(r.GroupVersionKind(), configName, configNamespace, types.JSONPatchType, func(cfg config.Config) config.Config {
 				cfg.Annotations["fizz"] = "buzz"
 				patchedCfg = cfg
 				return cfg

--- a/pilot/pkg/config/kube/crdclient/gen/types.go.tmpl
+++ b/pilot/pkg/config/kube/crdclient/gen/types.go.tmpl
@@ -101,7 +101,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
             ObjectMeta: modMeta,
             Spec:       *(mod.Spec.(*{{ .APIImport }}.{{ .Kind }}{{ .TypeSuffix }})),
         }
-        patchBytes, err := genPatchBytes(oldRes, modRes)
+        patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
         if err != nil {
             return nil, err
         }

--- a/pilot/pkg/config/kube/crdclient/gen/types.go.tmpl
+++ b/pilot/pkg/config/kube/crdclient/gen/types.go.tmpl
@@ -85,11 +85,11 @@ func updateStatus(ic versionedclient.Interface, sc serviceapisclient.Interface, 
     	}
 }
 
-func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig config.Config, origMeta metav1.ObjectMeta, mod config.Config, modMeta metav1.ObjectMeta) (metav1.Object, error) {
+func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, typ types.PatchType,
+	orig config.Config, origMeta metav1.ObjectMeta, mod config.Config, modMeta metav1.ObjectMeta) (metav1.Object, error) {
 	if orig.GroupVersionKind != mod.GroupVersionKind {
 		return nil, fmt.Errorf("gvk mismatch: %v, modified: %v", orig.GroupVersionKind, mod.GroupVersionKind)
 	}
-    // TODO support multiple patch types and setting field manager
 	switch orig.GroupVersionKind {
 {{- range . }}
     case collections.{{ .VariableName }}.Resource().GroupVersionKind():
@@ -101,12 +101,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
             ObjectMeta: modMeta,
             Spec:       *(mod.Spec.(*{{ .APIImport }}.{{ .Kind }}{{ .TypeSuffix }})),
         }
-        patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
+        patchBytes, err := genPatchBytes(oldRes, modRes, typ)
         if err != nil {
             return nil, err
         }
         return {{.Client}}.{{ .ClientGroupPath }}().{{ .ClientTypePath }}({{if .Namespaced}}orig.Namespace{{end}}).
-            Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+            Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 {{- end }}
 	default:
 		return nil, fmt.Errorf("unsupported type: %v", orig.GroupVersionKind)

--- a/pilot/pkg/config/kube/crdclient/types.gen.go
+++ b/pilot/pkg/config/kube/crdclient/types.gen.go
@@ -319,11 +319,11 @@ func updateStatus(ic versionedclient.Interface, sc serviceapisclient.Interface, 
 	}
 }
 
-func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig config.Config, origMeta metav1.ObjectMeta, mod config.Config, modMeta metav1.ObjectMeta) (metav1.Object, error) {
+func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, typ types.PatchType,
+	orig config.Config, origMeta metav1.ObjectMeta, mod config.Config, modMeta metav1.ObjectMeta) (metav1.Object, error) {
 	if orig.GroupVersionKind != mod.GroupVersionKind {
 		return nil, fmt.Errorf("gvk mismatch: %v, modified: %v", orig.GroupVersionKind, mod.GroupVersionKind)
 	}
-	// TODO support multiple patch types and setting field manager
 	switch orig.GroupVersionKind {
 	case collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind():
 		oldRes := &clientnetworkingv1alpha3.DestinationRule{
@@ -334,12 +334,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*networkingv1alpha3.DestinationRule)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return ic.NetworkingV1alpha3().DestinationRules(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind():
 		oldRes := &clientnetworkingv1alpha3.EnvoyFilter{
 			ObjectMeta: origMeta,
@@ -349,12 +349,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*networkingv1alpha3.EnvoyFilter)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return ic.NetworkingV1alpha3().EnvoyFilters(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind():
 		oldRes := &clientnetworkingv1alpha3.Gateway{
 			ObjectMeta: origMeta,
@@ -364,12 +364,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*networkingv1alpha3.Gateway)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return ic.NetworkingV1alpha3().Gateways(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind():
 		oldRes := &clientnetworkingv1alpha3.ServiceEntry{
 			ObjectMeta: origMeta,
@@ -379,12 +379,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*networkingv1alpha3.ServiceEntry)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return ic.NetworkingV1alpha3().ServiceEntries(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind():
 		oldRes := &clientnetworkingv1alpha3.Sidecar{
 			ObjectMeta: origMeta,
@@ -394,12 +394,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*networkingv1alpha3.Sidecar)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return ic.NetworkingV1alpha3().Sidecars(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind():
 		oldRes := &clientnetworkingv1alpha3.VirtualService{
 			ObjectMeta: origMeta,
@@ -409,12 +409,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*networkingv1alpha3.VirtualService)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return ic.NetworkingV1alpha3().VirtualServices(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind():
 		oldRes := &clientnetworkingv1alpha3.WorkloadEntry{
 			ObjectMeta: origMeta,
@@ -424,12 +424,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*networkingv1alpha3.WorkloadEntry)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return ic.NetworkingV1alpha3().WorkloadEntries(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind():
 		oldRes := &clientnetworkingv1alpha3.WorkloadGroup{
 			ObjectMeta: origMeta,
@@ -439,12 +439,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*networkingv1alpha3.WorkloadGroup)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return ic.NetworkingV1alpha3().WorkloadGroups(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind():
 		oldRes := &clientsecurityv1beta1.AuthorizationPolicy{
 			ObjectMeta: origMeta,
@@ -454,12 +454,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*securityv1beta1.AuthorizationPolicy)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return ic.SecurityV1beta1().AuthorizationPolicies(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind():
 		oldRes := &clientsecurityv1beta1.PeerAuthentication{
 			ObjectMeta: origMeta,
@@ -469,12 +469,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*securityv1beta1.PeerAuthentication)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return ic.SecurityV1beta1().PeerAuthentications(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind():
 		oldRes := &clientsecurityv1beta1.RequestAuthentication{
 			ObjectMeta: origMeta,
@@ -484,12 +484,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*securityv1beta1.RequestAuthentication)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return ic.SecurityV1beta1().RequestAuthentications(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.K8SServiceApisV1Alpha1Backendpolicies.Resource().GroupVersionKind():
 		oldRes := &servicev1alpha1.BackendPolicy{
 			ObjectMeta: origMeta,
@@ -499,12 +499,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*servicev1alpha1.BackendPolicySpec)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return sc.NetworkingV1alpha1().BackendPolicies(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.K8SServiceApisV1Alpha1Gatewayclasses.Resource().GroupVersionKind():
 		oldRes := &servicev1alpha1.GatewayClass{
 			ObjectMeta: origMeta,
@@ -514,12 +514,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*servicev1alpha1.GatewayClassSpec)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return sc.NetworkingV1alpha1().GatewayClasses().
-			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.K8SServiceApisV1Alpha1Gateways.Resource().GroupVersionKind():
 		oldRes := &servicev1alpha1.Gateway{
 			ObjectMeta: origMeta,
@@ -529,12 +529,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*servicev1alpha1.GatewaySpec)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return sc.NetworkingV1alpha1().Gateways(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.K8SServiceApisV1Alpha1Httproutes.Resource().GroupVersionKind():
 		oldRes := &servicev1alpha1.HTTPRoute{
 			ObjectMeta: origMeta,
@@ -544,12 +544,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*servicev1alpha1.HTTPRouteSpec)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return sc.NetworkingV1alpha1().HTTPRoutes(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.K8SServiceApisV1Alpha1Tcproutes.Resource().GroupVersionKind():
 		oldRes := &servicev1alpha1.TCPRoute{
 			ObjectMeta: origMeta,
@@ -559,12 +559,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*servicev1alpha1.TCPRouteSpec)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return sc.NetworkingV1alpha1().TCPRoutes(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.K8SServiceApisV1Alpha1Tlsroutes.Resource().GroupVersionKind():
 		oldRes := &servicev1alpha1.TLSRoute{
 			ObjectMeta: origMeta,
@@ -574,12 +574,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*servicev1alpha1.TLSRouteSpec)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return sc.NetworkingV1alpha1().TLSRoutes(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	default:
 		return nil, fmt.Errorf("unsupported type: %v", orig.GroupVersionKind)
 	}
@@ -934,3 +934,4 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 		}
 	},
 }
+

--- a/pilot/pkg/config/kube/crdclient/types.gen.go
+++ b/pilot/pkg/config/kube/crdclient/types.gen.go
@@ -334,7 +334,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*networkingv1alpha3.DestinationRule)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
 		if err != nil {
 			return nil, err
 		}
@@ -349,7 +349,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*networkingv1alpha3.EnvoyFilter)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
 		if err != nil {
 			return nil, err
 		}
@@ -364,7 +364,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*networkingv1alpha3.Gateway)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
 		if err != nil {
 			return nil, err
 		}
@@ -379,7 +379,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*networkingv1alpha3.ServiceEntry)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
 		if err != nil {
 			return nil, err
 		}
@@ -394,7 +394,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*networkingv1alpha3.Sidecar)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
 		if err != nil {
 			return nil, err
 		}
@@ -409,7 +409,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*networkingv1alpha3.VirtualService)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
 		if err != nil {
 			return nil, err
 		}
@@ -424,12 +424,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*networkingv1alpha3.WorkloadEntry)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
 		if err != nil {
 			return nil, err
 		}
 		return ic.NetworkingV1alpha3().WorkloadEntries(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind():
 		oldRes := &clientnetworkingv1alpha3.WorkloadGroup{
 			ObjectMeta: origMeta,
@@ -439,7 +439,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*networkingv1alpha3.WorkloadGroup)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
 		if err != nil {
 			return nil, err
 		}
@@ -454,7 +454,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*securityv1beta1.AuthorizationPolicy)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
 		if err != nil {
 			return nil, err
 		}
@@ -469,7 +469,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*securityv1beta1.PeerAuthentication)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
 		if err != nil {
 			return nil, err
 		}
@@ -484,7 +484,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*securityv1beta1.RequestAuthentication)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
 		if err != nil {
 			return nil, err
 		}
@@ -499,7 +499,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*servicev1alpha1.BackendPolicySpec)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
 		if err != nil {
 			return nil, err
 		}
@@ -514,7 +514,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*servicev1alpha1.GatewayClassSpec)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
 		if err != nil {
 			return nil, err
 		}
@@ -529,7 +529,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*servicev1alpha1.GatewaySpec)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
 		if err != nil {
 			return nil, err
 		}
@@ -544,7 +544,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*servicev1alpha1.HTTPRouteSpec)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
 		if err != nil {
 			return nil, err
 		}
@@ -559,7 +559,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*servicev1alpha1.TCPRouteSpec)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
 		if err != nil {
 			return nil, err
 		}
@@ -574,7 +574,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*servicev1alpha1.TLSRouteSpec)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, types.MergePatchType)
 		if err != nil {
 			return nil, err
 		}

--- a/pilot/pkg/config/kube/crdclient/types.gen.go
+++ b/pilot/pkg/config/kube/crdclient/types.gen.go
@@ -339,7 +339,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			return nil, err
 		}
 		return ic.NetworkingV1alpha3().DestinationRules(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind():
 		oldRes := &clientnetworkingv1alpha3.EnvoyFilter{
 			ObjectMeta: origMeta,
@@ -354,7 +354,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			return nil, err
 		}
 		return ic.NetworkingV1alpha3().EnvoyFilters(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind():
 		oldRes := &clientnetworkingv1alpha3.Gateway{
 			ObjectMeta: origMeta,
@@ -369,7 +369,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			return nil, err
 		}
 		return ic.NetworkingV1alpha3().Gateways(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind():
 		oldRes := &clientnetworkingv1alpha3.ServiceEntry{
 			ObjectMeta: origMeta,
@@ -384,7 +384,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			return nil, err
 		}
 		return ic.NetworkingV1alpha3().ServiceEntries(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind():
 		oldRes := &clientnetworkingv1alpha3.Sidecar{
 			ObjectMeta: origMeta,
@@ -399,7 +399,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			return nil, err
 		}
 		return ic.NetworkingV1alpha3().Sidecars(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind():
 		oldRes := &clientnetworkingv1alpha3.VirtualService{
 			ObjectMeta: origMeta,
@@ -414,7 +414,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			return nil, err
 		}
 		return ic.NetworkingV1alpha3().VirtualServices(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind():
 		oldRes := &clientnetworkingv1alpha3.WorkloadEntry{
 			ObjectMeta: origMeta,
@@ -444,7 +444,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			return nil, err
 		}
 		return ic.NetworkingV1alpha3().WorkloadGroups(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind():
 		oldRes := &clientsecurityv1beta1.AuthorizationPolicy{
 			ObjectMeta: origMeta,
@@ -459,7 +459,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			return nil, err
 		}
 		return ic.SecurityV1beta1().AuthorizationPolicies(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind():
 		oldRes := &clientsecurityv1beta1.PeerAuthentication{
 			ObjectMeta: origMeta,
@@ -474,7 +474,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			return nil, err
 		}
 		return ic.SecurityV1beta1().PeerAuthentications(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind():
 		oldRes := &clientsecurityv1beta1.RequestAuthentication{
 			ObjectMeta: origMeta,
@@ -489,7 +489,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			return nil, err
 		}
 		return ic.SecurityV1beta1().RequestAuthentications(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.K8SServiceApisV1Alpha1Backendpolicies.Resource().GroupVersionKind():
 		oldRes := &servicev1alpha1.BackendPolicy{
 			ObjectMeta: origMeta,
@@ -504,7 +504,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			return nil, err
 		}
 		return sc.NetworkingV1alpha1().BackendPolicies(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.K8SServiceApisV1Alpha1Gatewayclasses.Resource().GroupVersionKind():
 		oldRes := &servicev1alpha1.GatewayClass{
 			ObjectMeta: origMeta,
@@ -519,7 +519,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			return nil, err
 		}
 		return sc.NetworkingV1alpha1().GatewayClasses().
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.K8SServiceApisV1Alpha1Gateways.Resource().GroupVersionKind():
 		oldRes := &servicev1alpha1.Gateway{
 			ObjectMeta: origMeta,
@@ -534,7 +534,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			return nil, err
 		}
 		return sc.NetworkingV1alpha1().Gateways(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.K8SServiceApisV1Alpha1Httproutes.Resource().GroupVersionKind():
 		oldRes := &servicev1alpha1.HTTPRoute{
 			ObjectMeta: origMeta,
@@ -549,7 +549,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			return nil, err
 		}
 		return sc.NetworkingV1alpha1().HTTPRoutes(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.K8SServiceApisV1Alpha1Tcproutes.Resource().GroupVersionKind():
 		oldRes := &servicev1alpha1.TCPRoute{
 			ObjectMeta: origMeta,
@@ -564,7 +564,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			return nil, err
 		}
 		return sc.NetworkingV1alpha1().TCPRoutes(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.K8SServiceApisV1Alpha1Tlsroutes.Resource().GroupVersionKind():
 		oldRes := &servicev1alpha1.TLSRoute{
 			ObjectMeta: origMeta,
@@ -579,7 +579,7 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			return nil, err
 		}
 		return sc.NetworkingV1alpha1().TLSRoutes(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	default:
 		return nil, fmt.Errorf("unsupported type: %v", orig.GroupVersionKind)
 	}

--- a/pilot/pkg/config/kube/crdclient/types.gen.go
+++ b/pilot/pkg/config/kube/crdclient/types.gen.go
@@ -934,4 +934,3 @@ var translationMap = map[config.GroupVersionKind]func(r runtime.Object) *config.
 		}
 	},
 }
-

--- a/pilot/pkg/config/kube/gateway/controller.go
+++ b/pilot/pkg/config/kube/gateway/controller.go
@@ -20,6 +20,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 
 	"istio.io/istio/pilot/pkg/model"
@@ -145,7 +146,7 @@ func (c controller) UpdateStatus(config config.Config) (newRevision string, err 
 	return "", errUnsupportedOp
 }
 
-func (c controller) Patch(typ config.GroupVersionKind, name, namespace string, patchFn config.PatchFunc) (string, error) {
+func (c controller) Patch(typ config.GroupVersionKind, name, namespace string, patchType types.PatchType, patchFn config.PatchFunc) (string, error) {
 	return "", errUnsupportedOp
 }
 

--- a/pilot/pkg/config/kube/ingress/controller.go
+++ b/pilot/pkg/config/kube/ingress/controller.go
@@ -25,6 +25,7 @@ import (
 
 	ingress "k8s.io/api/networking/v1beta1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/client-go/informers/networking/v1beta1"
 	"k8s.io/client-go/kubernetes"
@@ -366,7 +367,7 @@ func (c *controller) UpdateStatus(config.Config) (string, error) {
 	return "", errUnsupportedOp
 }
 
-func (c *controller) Patch(_ config.GroupVersionKind, _, _ string, _ config.PatchFunc) (string, error) {
+func (c *controller) Patch(_ config.GroupVersionKind, _, _ string, _ types.PatchType, _ config.PatchFunc) (string, error) {
 	return "", errUnsupportedOp
 }
 

--- a/pilot/pkg/config/memory/config.go
+++ b/pilot/pkg/config/memory/config.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"sync"
 	"time"
-	
+
 	"k8s.io/apimachinery/pkg/types"
 
 	"istio.io/istio/pilot/pkg/model"

--- a/pilot/pkg/config/memory/config.go
+++ b/pilot/pkg/config/memory/config.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"sync"
 	"time"
+	
+	"k8s.io/apimachinery/pkg/types"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config"
@@ -222,7 +224,7 @@ func (cr *store) UpdateStatus(cfg config.Config) (string, error) {
 	return rev, nil
 }
 
-func (cr *store) Patch(typ config.GroupVersionKind, name, namespace string, patchFn config.PatchFunc) (string, error) {
+func (cr *store) Patch(typ config.GroupVersionKind, name, namespace string, patchType types.PatchType, patchFn config.PatchFunc) (string, error) {
 	cr.mutex.Lock()
 	defer cr.mutex.Unlock()
 

--- a/pilot/pkg/config/memory/controller.go
+++ b/pilot/pkg/config/memory/controller.go
@@ -16,6 +16,7 @@ package memory
 
 import (
 	"errors"
+	"k8s.io/apimachinery/pkg/types"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config"
@@ -102,7 +103,7 @@ func (c *controller) UpdateStatus(config config.Config) (newRevision string, err
 	return
 }
 
-func (c *controller) Patch(typ config.GroupVersionKind, name, namespace string, patchFn config.PatchFunc) (newRevision string, err error) {
+func (c *controller) Patch(typ config.GroupVersionKind, name, namespace string, patchType types.PatchType, patchFn config.PatchFunc) (newRevision string, err error) {
 	oldconfig := c.configStore.Get(typ, name, namespace)
 	if oldconfig == nil {
 		return "", errNotFound

--- a/pilot/pkg/config/memory/controller.go
+++ b/pilot/pkg/config/memory/controller.go
@@ -16,6 +16,7 @@ package memory
 
 import (
 	"errors"
+
 	"k8s.io/apimachinery/pkg/types"
 
 	"istio.io/istio/pilot/pkg/model"
@@ -103,7 +104,8 @@ func (c *controller) UpdateStatus(config config.Config) (newRevision string, err
 	return
 }
 
-func (c *controller) Patch(typ config.GroupVersionKind, name, namespace string, patchType types.PatchType, patchFn config.PatchFunc) (newRevision string, err error) {
+func (c *controller) Patch(typ config.GroupVersionKind, name, namespace string,
+	patchType types.PatchType, patchFn config.PatchFunc) (newRevision string, err error) {
 	oldconfig := c.configStore.Get(typ, name, namespace)
 	if oldconfig == nil {
 		return "", errNotFound

--- a/pilot/pkg/model/authorization_test.go
+++ b/pilot/pkg/model/authorization_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
+	"k8s.io/apimachinery/pkg/types"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	authpb "istio.io/api/security/v1beta1"
@@ -420,6 +421,6 @@ func (fs *authzFakeStore) UpdateStatus(config.Config) (string, error) {
 	return "not implemented", nil
 }
 
-func (fs *authzFakeStore) Patch(typ config.GroupVersionKind, name, namespace string, patchFn config.PatchFunc) (string, error) {
+func (fs *authzFakeStore) Patch(typ config.GroupVersionKind, name, namespace string, patchType types.PatchType, patchFn config.PatchFunc) (string, error) {
 	return "not implemented", nil
 }

--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	udpa "github.com/cncf/udpa/go/udpa/type/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pkg/config"
@@ -135,7 +136,7 @@ type ConfigStore interface {
 
 	// Patch applies only the modifications made in the PatchFunc rather than doing a full replace. Useful to avoid
 	// read-modify-write conflicts when there are many concurrent-writers to the same resource.
-	Patch(typ config.GroupVersionKind, name, namespace string, patchFn config.PatchFunc) (string, error)
+	Patch(typ config.GroupVersionKind, name, namespace string, patchType types.PatchType, patchFn config.PatchFunc) (string, error)
 
 	// Delete removes an object from the store by key
 	Delete(typ config.GroupVersionKind, name, namespace string) error

--- a/pilot/pkg/model/fake_store.go
+++ b/pilot/pkg/model/fake_store.go
@@ -15,6 +15,8 @@
 package model
 
 import (
+	"k8s.io/apimachinery/pkg/types"
+
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
@@ -68,7 +70,7 @@ func (*FakeStore) Update(config config.Config) (newRevision string, err error) {
 
 func (*FakeStore) UpdateStatus(config config.Config) (string, error) { return "", nil }
 
-func (*FakeStore) Patch(typ config.GroupVersionKind, name, namespace string, patchFn config.PatchFunc) (string, error) {
+func (*FakeStore) Patch(typ config.GroupVersionKind, name, namespace string, patchType types.PatchType, patchFn config.PatchFunc) (string, error) {
 	return "", nil
 }
 

--- a/pilot/pkg/xds/workloadentry.go
+++ b/pilot/pkg/xds/workloadentry.go
@@ -67,7 +67,7 @@ func (sg *InternalGen) RegisterWorkload(proxy *model.Proxy, con *Connection) err
 	}
 
 	// Try to patch, if it fails then try to create
-	_, err := sg.store.Patch(gvk.WorkloadEntry, entryName, proxy.Metadata.Namespace, func(cfg config.Config) config.Config {
+	_, err := sg.store.Patch(gvk.WorkloadEntry, entryName, proxy.Metadata.Namespace, kubetypes.MergePatchType, func(cfg config.Config) config.Config {
 		setConnectMeta(&cfg, sg.Server.instanceID, con)
 		return cfg
 	})


### PR DESCRIPTION
Tested on my own GKE 1.17 cluster, fixes issue 1 described in #28799 

The merge patch is more robust, it can be ambiguous whether an `add` or `replace` op (see [rfc6902](https://tools.ietf.org/html/rfc6902)) is appropriate when we really want "create if not there, otherwise replace. 

Not to be confused with strategic merge patch ([k8s patch types](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#use-a-json-merge-patch-to-update-a-deployment))
