### PR TITLE
use auto-registration for main vm in single-cluster pilot test

### DIFF
--- a/tests/integration/pilot/common/apps.go
+++ b/tests/integration/pilot/common/apps.go
@@ -209,7 +209,7 @@ func SetupApps(ctx resource.Context, i istio.Instance, apps *EchoDeployments) er
 				Namespace:         apps.Namespace,
 				Ports:             EchoPorts,
 				DeployAsVM:        true,
-				AutoRegisterVM:    false, // TODO support auto-registration with multi-primary
+				AutoRegisterVM:    !ctx.Clusters().IsMulticluster(), // TODO support auto-registration with multi-primary
 				Subsets:           []echo.SubsetConfig{{}},
 				Cluster:           c[0],
 				WorkloadOnlyPorts: WorkloadPorts,


### PR DESCRIPTION
This may give us a little more coverage on a stable connection with an auto-registered VM