### PR TITLE
Fixes BusyBox nsenter from parsing iptables script args

### DIFF
--- a/cni/cmd/istio-cni/iptables.go
+++ b/cni/cmd/istio-cni/iptables.go
@@ -42,6 +42,7 @@ func (ipt *iptables) Program(netns string, rdrct *Redirect) error {
 	nsSetupExecutable := fmt.Sprintf("%s/%s", nsSetupBinDir, nsSetupProg)
 	nsenterArgs := []string{
 		netnsArg,
+		"--", // separate nsenter args from the rest with `--`, needed for hosts using BusyBox binaries
 		nsSetupExecutable,
 		"-p", rdrct.targetPort,
 		"-u", rdrct.noRedirectUID,


### PR DESCRIPTION
Prevents BusyBox's build of `nsenter` from incorrectly parsing `istio-iptables.sh` arguments as its own. Discovered when using the Kubernetes distribution "k3s" (https://github.com/k3s-io/k3s/issues/1434). A similar fix was used for [Linkerd](https://github.com/linkerd/linkerd2-proxy-init/pull/26).

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

Pull Request Attributes

[X] Does not have any changes that may affect Istio users.
