### PR TITLE
Environment proxy pilot

### DIFF
--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -168,6 +168,7 @@ func newJwksResolverWithCABundlePaths(evictionDuration, refreshInterval, retryIn
 		httpClient: &http.Client{
 			Timeout: jwksHTTPTimeOutInSec * time.Second,
 			Transport: &http.Transport{
+				Proxy:             http.ProxyFromEnvironment,
 				DisableKeepAlives: true,
 				TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
 			},
@@ -190,6 +191,7 @@ func newJwksResolverWithCABundlePaths(evictionDuration, refreshInterval, retryIn
 		ret.secureHTTPClient = &http.Client{
 			Timeout: jwksHTTPTimeOutInSec * time.Second,
 			Transport: &http.Transport{
+				Proxy:             http.ProxyFromEnvironment,
 				DisableKeepAlives: true,
 				TLSClientConfig: &tls.Config{
 					RootCAs: caCertPool,


### PR DESCRIPTION
For a cluster behind a corporate proxy server, istiod needs internet access to fetch jwt. This PR utilizes the proxy environment variables (say http_proxy) to connect to "issuer" and "jwksUri".

We have edited deployment/istiod using following command:

kubectl set env deployment/istiod http_proxy="http://192.168.1.47:3128" https_proxy="http://192.168.1.47:3128" NO_PROXY="10.234.0.0/20,*.svc.cluster.local,istiod.istio-system.svc,istio-ingressgateway,localhost,*.istio-system.svc" -n istio-system

And to help us figure out who should review this PR, please
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
