### PR TITLE
operator init: update revision help str

### DIFF
--- a/operator/cmd/mesh/operator-init.go
+++ b/operator/cmd/mesh/operator-init.go
@@ -54,8 +54,7 @@ func addOperatorInitFlags(cmd *cobra.Command, args *operatorInitArgs) {
 		"The namespaces the operator controller watches, could be namespace list separated by comma, eg. 'ns1,ns2'")
 	cmd.PersistentFlags().StringVarP(&args.common.manifestsPath, "charts", "", "", ChartsDeprecatedStr)
 	cmd.PersistentFlags().StringVarP(&args.common.manifestsPath, "manifests", "d", "", ManifestsFlagHelpStr)
-	cmd.PersistentFlags().StringVarP(&args.common.revision, "revision", "r", "",
-		revisionFlagHelpStr)
+	cmd.PersistentFlags().StringVarP(&args.common.revision, "revision", "r", "", OperatorRevFlagHelpStr)
 }
 
 func operatorInitCmd(rootArgs *rootArgs, oiArgs *operatorInitArgs) *cobra.Command {

--- a/operator/cmd/mesh/root.go
+++ b/operator/cmd/mesh/root.go
@@ -54,6 +54,7 @@ This flag can be specified multiple times to overlay multiple files. Multiple fi
 	ImagePullSecretsHelpStr = `The imagePullSecrets are used to pull the operator image from the private registry,
 could be secret list separated by comma, eg. '--imagePullSecrets imagePullSecret1,imagePullSecret2'`
 	OperatorNamespaceHelpstr = `The namespace the operator controller is installed into.`
+	OperatorRevFlagHelpStr   = `Target revision for the operator.`
 	ComponentFlagHelpStr     = "Specify which component to generate manifests for."
 	VerifyCRInstallHelpStr   = "Verify the Istio control plane after installation/in-place upgrade"
 )


### PR DESCRIPTION
Old:
```
$ istioctl operator init -h

-r, --revision string            Target control plane revision for the command.
```
New:
```
$ istioctl operator init -h

-r, --revision string            Target revision for the operator.
```