### PR TITLE
Remove the code that repeatedly obtained ISTIO_META

### DIFF
--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -388,9 +388,6 @@ func extractMetadata(envs []string, prefix string, set setMetaFunc, meta map[str
 }
 
 func shouldExtract(envVar, prefix string) bool {
-	if strings.HasPrefix(envVar, "ISTIO_META_WORKLOAD") {
-		return false
-	}
 	return strings.HasPrefix(envVar, prefix)
 }
 
@@ -427,10 +424,6 @@ func extractAttributesMetadata(envVars []string, plat platform.Environment, meta
 			meta.InstanceName = val
 		case "POD_NAMESPACE":
 			meta.Namespace = val
-		case "ISTIO_META_OWNER":
-			meta.Owner = val
-		case "ISTIO_META_WORKLOAD_NAME":
-			meta.WorkloadName = val
 		case "SERVICE_ACCOUNT":
 			meta.ServiceAccount = val
 		}

--- a/pkg/bootstrap/config_test.go
+++ b/pkg/bootstrap/config_test.go
@@ -15,9 +15,11 @@
 package bootstrap
 
 import (
+	"os"
 	"reflect"
 	"testing"
 
+	. "github.com/onsi/gomega"
 	"k8s.io/kubectl/pkg/util/fieldpath"
 )
 
@@ -70,4 +72,24 @@ other: setting`,
 			}
 		})
 	}
+}
+
+func TestGetNodeMetaData(t *testing.T) {
+	inputOwner := "test"
+	inputWorkloadName := "workload"
+
+	expectOwner := "test"
+	expectWorkloadName := "workload"
+
+	os.Setenv(IstioMetaPrefix+"OWNER", inputOwner)
+	os.Setenv(IstioMetaPrefix+"WORKLOAD_NAME", inputWorkloadName)
+
+	meta, rawMeta, err := getNodeMetaData(os.Environ(), nil, nil, 0, nil)
+
+	g := NewWithT(t)
+	g.Expect(err).Should(BeNil())
+	g.Expect(meta.Owner).To(Equal(expectOwner))
+	g.Expect(meta.WorkloadName).To(Equal(expectWorkloadName))
+	g.Expect(rawMeta["OWNER"]).To(Equal(expectOwner))
+	g.Expect(rawMeta["WORKLOAD_NAME"]).To(Equal(expectWorkloadName))
 }


### PR DESCRIPTION
Since we have already get information ISTIO_META in method `extractMetadata`, we need not get information ISTIO_META again in method `extractAttributesMetadata`.
 
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
