### PR TITLE
handle WorkloadEntry auto-registration races

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -395,6 +395,9 @@ var (
 		"The amount of time an auto-registered workload can remain disconnected from all Pilot instances before the "+
 			"associated WorkloadEntry is cleaned up.").Get()
 
+	WorkloadEntryCleanupRateLimit = env.RegisterFloatVar("PILOT_WORKLOAD_ENTRY_CLEANUP_RATE", 50,
+		"The maximum number of WorkloadEntries that pilot will attempt to delete per-second.").Get()
+
 	WorkloadEntryHealthChecks = env.RegisterBoolVar("PILOT_ENABLE_WORKLOAD_ENTRY_HEALTHCHECKS", false,
 		"Enables automatic health checks of WorkloadEntries based on the config provided in the associated WorkloadGroup").Get()
 

--- a/pilot/pkg/xds/internalgen.go
+++ b/pilot/pkg/xds/internalgen.go
@@ -86,7 +86,7 @@ func (sg *InternalGen) OnDisconnect(con *Connection) {
 func (sg *InternalGen) EnableWorkloadEntryController(store model.ConfigStoreCache) {
 	if features.WorkloadEntryAutoRegistration || features.WorkloadEntryHealthChecks {
 		sg.store = store
-		sg.cleanupLimit = rate.NewLimiter(rate.Limit(20), 1)
+		sg.cleanupLimit = rate.NewLimiter(rate.Limit(features.WorkloadEntryCleanupRateLimit), 1)
 		sg.cleanupQueue = queue.NewDelayed()
 	}
 }

--- a/pilot/pkg/xds/workloadentry.go
+++ b/pilot/pkg/xds/workloadentry.go
@@ -115,6 +115,7 @@ func (sg *InternalGen) QueueUnregisterWorkload(proxy *model.Proxy) {
 	// unset controller, set disconnect time
 	cfg := sg.store.Get(gvk.WorkloadEntry, entryName, proxy.Metadata.Namespace)
 	if cfg == nil {
+		// TODO retry to handle slow propagation
 		// we failed to create the workload entry in the first place or it is not propagated
 		return
 	}

--- a/pilot/pkg/xds/workloadentry.go
+++ b/pilot/pkg/xds/workloadentry.go
@@ -17,9 +17,6 @@ package xds
 import (
 	"context"
 	"fmt"
-	"istio.io/pkg/log"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/util/retry"
 	"strings"
 	"time"
 
@@ -27,6 +24,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubetypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 
 	"istio.io/api/meta/v1alpha1"
 	"istio.io/api/networking/v1alpha3"
@@ -35,6 +34,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/pkg/log"
 )
 
 const (

--- a/pilot/pkg/xds/workloadentry.go
+++ b/pilot/pkg/xds/workloadentry.go
@@ -117,7 +117,7 @@ func (sg *InternalGen) QueueUnregisterWorkload(proxy *model.Proxy) {
 
 	var cfg config.Config
 	// unset controller, set disconnect time
-	if err := retry.OnError(wait.Backoff{Duration: time.Millisecond * 10, Factor: 2, Steps: 3}, func(err error) bool {
+	if err := retry.OnError(wait.Backoff{Duration: time.Millisecond * 500, Factor: 3, Steps: 3}, func(err error) bool {
 		// TODO retry on NotFound when Get returns an err
 		return err != nil
 	}, func() error {

--- a/pilot/pkg/xds/workloadentry.go
+++ b/pilot/pkg/xds/workloadentry.go
@@ -217,9 +217,11 @@ func (sg *InternalGen) periodicWorkloadEntryCleanup(stopCh <-chan struct{}) {
 func (sg *InternalGen) cleanupEntry(wle config.Config) {
 	if err := sg.cleanupLimit.Wait(context.TODO()); err != nil {
 		adsLog.Errorf("error in WorkloadEntry cleanup rate limiter: %v", err)
+		return
 	}
 	if err := sg.store.Delete(gvk.WorkloadEntry, wle.Name, wle.Namespace); err != nil {
 		adsLog.Warnf("failed cleaning up auto-registered WorkloadEntry %s/%s: %v", wle.Namespace, wle.Name, err)
+		return
 	}
 	adsLog.Infof("cleaned up auto-registered WorkloadEntry %s/%s", wle.Namespace, wle.Name)
 }


### PR DESCRIPTION
Tested scenarios described in #28799 with 2500 connections

---

### Case 1: Proxy disconnects before registration is complete, does not reconnect

| t0 | Proxy Connects    |                                                                                                                |
|----|-------------------|----------------------------------------------------------------------------------------------------------------|
| t1 | Proxy Disconnects | Registration Logic Still Running                                                                               |
| t2 |                   | Un-Register Logic always happens _after_ Registration, but could still happen very quickly after registration. |

Symptom: a WorkloadEntry that should be, but is never cleaned up. 

Cause: [QueueUnregisterWorkload](https://github.com/istio/istio/blob/994b0b7460c8358f4a467e4e08371985351498bf/pilot/pkg/xds/workloadentry.go#L102) attempts to `Get` the WorkloadEntry, it may be so soon after successful registration (observed to be sub-millisecond) that the `Get` returns `NotFound`.  

Possible solution: backoff and retry the Get, but that would have issues in Case 2


### Case 2: Proxy disconnects before registration is complete, then reconnects before de-registration is done

| t0 | Proxy Connects    |                                              |                                            |
|----|-------------------|----------------------------------------------|--------------------------------------------|
| t1 | Proxy Disconnects | Registration Logic Still Running             |                                            |
| t2 | Proxy Reconnects  | First `Get` fails in Unregister, backoff     | Initial connection register succeeds       |
| t3 |                   | Second `Get` occurs                          | Reconnection updates connectedAt timestamp |
| t4 |                   | Disconnect timestamp is set, causing cleanup |                                            |


Symptom: A WorkloadEntry that should _not_ be cleaned up gets deleted

Cause: A fast reconnect sets the new timestamp _before_ the disconnect timestamp is properly set. It's less likely, but without a retried-Get this could still occur. 

Solution: Pin the timestamp before fetching the WorkloadEntry at all




