### PR TITLE
zipkin address validation for $(HOST_IP) tracer

### DIFF
--- a/pkg/config/validation/validation.go
+++ b/pkg/config/validation/validation.go
@@ -1275,7 +1275,7 @@ func ValidateLightstepCollector(ls *meshconfig.Tracing_Lightstep) error {
 
 // ValidateZipkinCollector validates the configuration for sending envoy spans to Zipkin
 func ValidateZipkinCollector(z *meshconfig.Tracing_Zipkin) error {
-	return ValidateProxyAddress(z.GetAddress())
+	return ValidateProxyAddress(strings.Replace(z.GetAddress(), "$(HOST_IP)", "127.0.0.1", 1))
 }
 
 // ValidateDatadogCollector validates the configuration for sending envoy spans to Datadog

--- a/pkg/config/validation/validation_test.go
+++ b/pkg/config/validation/validation_test.go
@@ -550,6 +550,21 @@ func TestValidateProxyConfig(t *testing.T) {
 			isValid: true,
 		},
 		{
+			name: "zipkin address with $(HOST_IP) is valid",
+			in: modify(valid,
+				func(c *meshconfig.ProxyConfig) {
+					c.Tracing = &meshconfig.Tracing{
+						Tracer: &meshconfig.Tracing_Zipkin_{
+							Zipkin: &meshconfig.Tracing_Zipkin{
+								Address: "$(HOST_IP):9411",
+							},
+						},
+					}
+				},
+			),
+			isValid: true,
+		},
+		{
 			name: "zipkin config invalid",
 			in: modify(valid,
 				func(c *meshconfig.ProxyConfig) {


### PR DESCRIPTION
validation was failing for istioctl when attempting to use `$(HOST_IP):9411`

https://github.com/istio/istio/pull/28043#issuecomment-742971357


[ ] Configuration Infrastructure
[ ] Docs
[X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.