### PR TITLE
remove port 15053 from discover deployment

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -785,8 +785,6 @@ spec:
             protocol: TCP
           - containerPort: 15017
             protocol: TCP
-          - containerPort: 15053
-            protocol: TCP
           readinessProbe:
             httpGet:
               path: /ready

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -97,8 +97,6 @@ spec:
             protocol: TCP
           - containerPort: 15017
             protocol: TCP
-          - containerPort: 15053
-            protocol: TCP
           readinessProbe:
             httpGet:
               path: /ready

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -769,8 +769,6 @@ spec:
             protocol: TCP
           - containerPort: 15017
             protocol: TCP
-          - containerPort: 15053
-            protocol: TCP
           readinessProbe:
             httpGet:
               path: /ready

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -96,8 +96,6 @@ spec:
             protocol: TCP
           - containerPort: 15017
             protocol: TCP
-          - containerPort: 15053
-            protocol: TCP
           readinessProbe:
             httpGet:
               path: /ready

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -5760,8 +5760,6 @@ spec:
           protocol: TCP
         - containerPort: 15017
           protocol: TCP
-        - containerPort: 15053
-          protocol: TCP
         readinessProbe:
           httpGet:
             path: /ready

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output.golden.yaml
@@ -91,8 +91,6 @@ spec:
           protocol: TCP
         - containerPort: 15017
           protocol: TCP
-        - containerPort: 15053
-          protocol: TCP
         readinessProbe:
           httpGet:
             path: /ready

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.golden.yaml
@@ -8270,7 +8270,6 @@ spec:
             - containerPort: 8080
             - containerPort: 15010
             - containerPort: 15017
-            - containerPort: 15053
           readinessProbe:
             httpGet:
               path: /ready
@@ -8388,14 +8387,6 @@ spec:
       targetPort: 15017
     - port: 15014
       name: http-monitoring # prometheus stats
-    - name: dns
-      port: 53
-      targetPort: 15053
-      protocol: UDP
-    - name: dns-tls
-      port: 853
-      targetPort: 15053
-      protocol: TCP
   selector:
     app: istiod
     # Label used by the 'default' service. For versioned deployments we match with app and version.

--- a/operator/cmd/mesh/testdata/manifest-generate/output/install_package_path.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/install_package_path.golden.yaml
@@ -52,8 +52,6 @@ spec:
             protocol: TCP
           - containerPort: 15017
             protocol: TCP
-          - containerPort: 15053
-            protocol: TCP
           readinessProbe:
             httpGet:
               path: /ready

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -1508,8 +1508,6 @@ spec:
           protocol: TCP
         - containerPort: 15017
           protocol: TCP
-        - containerPort: 15053
-          protocol: TCP
         readinessProbe:
           httpGet:
             path: /ready

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.golden.yaml
@@ -95,8 +95,6 @@ spec:
           protocol: TCP
         - containerPort: 15017
           protocol: TCP
-        - containerPort: 15053
-          protocol: TCP
         readinessProbe:
           httpGet:
             path: /ready

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_kubernetes.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_kubernetes.golden.yaml
@@ -145,8 +145,6 @@ spec:
           protocol: TCP
         - containerPort: 15017
           protocol: TCP
-        - containerPort: 15053
-          protocol: TCP
         readinessProbe:
           httpGet:
             path: /ready

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_values.golden.yaml
@@ -91,8 +91,6 @@ spec:
           protocol: TCP
         - containerPort: 15017
           protocol: TCP
-        - containerPort: 15053
-          protocol: TCP
         readinessProbe:
           httpGet:
             path: /ready

--- a/tests/integration/pilot/testdata/upgrade/1.8.0-install.yaml
+++ b/tests/integration/pilot/testdata/upgrade/1.8.0-install.yaml
@@ -1838,8 +1838,6 @@ spec:
           protocol: TCP
         - containerPort: 15017
           protocol: TCP
-        - containerPort: 15053
-          protocol: TCP
         readinessProbe:
           httpGet:
             path: /ready


### PR DESCRIPTION
Removing port 15053 from the deployments and services of the Istio Pilot

Resolves #29578