### PR TITLE
Fixing wrong message level mapping in validationMessages

### DIFF
--- a/galley/pkg/config/analysis/diag/message.go
+++ b/galley/pkg/config/analysis/diag/message.go
@@ -102,11 +102,11 @@ func (m *Message) UnstructuredAnalysisMessageBase() map[string]interface{} {
 	docURL := fmt.Sprintf("%s/%s/%s", url.ConfigAnalysis, strings.ToLower(m.Type.Code()), docQueryString)
 
 	mb := v1alpha1.AnalysisMessageBase{
+		DocumentationUrl: docURL,
+		Level:            v1alpha1.AnalysisMessageBase_Level(v1alpha1.AnalysisMessageBase_Level_value[strings.ToUpper(m.Type.Level().String())]),
 		Type: &v1alpha1.AnalysisMessageBase_Type{
 			Code: m.Type.Code(),
 		},
-		Level:            v1alpha1.AnalysisMessageBase_Level(v1alpha1.AnalysisMessageBase_Level_value[m.Type.Level().String()]),
-		DocumentationUrl: docURL,
 	}
 
 	var r map[string]interface{}

--- a/galley/pkg/config/analysis/diag/message_test.go
+++ b/galley/pkg/config/analysis/diag/message_test.go
@@ -16,6 +16,7 @@ package diag
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -81,4 +82,20 @@ func TestMessage_ReplaceLine(t *testing.T) {
 		result = append(result, m.ReplaceLine(v))
 	}
 	g.Expect(result).To(Equal([]string{"test.yaml", "test.yaml:321", "test.yaml:321", "test.yaml:321", "test", "test:321", "123:321", "123"}))
+}
+
+func TestMessage_UnstructuredAnalysisMessageBase(t *testing.T) {
+	g := NewWithT(t)
+	mt := NewMessageType(Error, "IST0042", "Cheese type not found: %q")
+	m := NewMessage(mt, &resource.Instance{Origin: testOrigin{name: "toppings/cheese", ref: testReference{"path/to/file"}}}, "Feta")
+	m.DocRef = "test-ref"
+
+	mb := m.UnstructuredAnalysisMessageBase()
+	g.Expect(mb["documentation_url"]).To(Equal(fmt.Sprintf("%s/%s/%s", url.ConfigAnalysis, "ist0042", "?ref=test-ref")))
+	g.Expect(mb["level"]).To(Equal(3.))
+	g.Expect(mb["type"]).To(Equal(
+		map[string]interface{}{
+			"code": "IST0042",
+		},
+	))
 }

--- a/releasenotes/notes/29445.yaml
+++ b/releasenotes/notes/29445.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: istioctl
+issue:
+  - 29445
+
+releaseNotes:
+  - |
+    **Added** the severity level for each analysis message in the `validationMessages` field within the `status` field.


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/29445
Relates to https://github.com/kiali/kiali/issues/3505

The severity level for the `validationMessages` in the status field are not present.
It looks like the mapping from Message descriptor the the message object was wrong (needs to be uppercased).


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
