### PR TITLE
Make webhook patch work with multiple revisions

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -824,8 +824,6 @@ spec:
             value: "true"
           - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND
             value: "true"
-          - name: INJECTION_WEBHOOK_CONFIG_NAME
-            value: istio-sidecar-injector
           - name: ISTIOD_ADDR
             value: istiod.istio-system.svc:15012
           - name: PILOT_ENABLE_ANALYSIS

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -144,14 +144,6 @@ spec:
             value: "{{ .Values.pilot.enableProtocolSniffingForOutbound }}"
           - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND
             value: "{{ .Values.pilot.enableProtocolSniffingForInbound }}"
-{{- if not (hasKey .Values.pilot.env "INJECTION_WEBHOOK_CONFIG_NAME") }}
-          - name: INJECTION_WEBHOOK_CONFIG_NAME
-          {{- if eq .Release.Namespace "istio-system" }}
-            value: istio-sidecar-injector{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-          {{- else }}
-            value: istio-sidecar-injector{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}-{{ .Release.Namespace }}
-          {{- end }}
-{{- end }}
           - name: ISTIOD_ADDR
             value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Release.Namespace }}.svc:15012
           - name: PILOT_ENABLE_ANALYSIS

--- a/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/data-snapshot/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -143,14 +143,6 @@ spec:
             value: "{{ .Values.pilot.enableProtocolSniffingForOutbound }}"
           - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND
             value: "{{ .Values.pilot.enableProtocolSniffingForInbound }}"
-{{- if not (hasKey .Values.pilot.env "INJECTION_WEBHOOK_CONFIG_NAME") }}
-          - name: INJECTION_WEBHOOK_CONFIG_NAME
-          {{- if eq .Release.Namespace "istio-system" }}
-            value: istio-sidecar-injector{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}
-          {{- else }}
-            value: istio-sidecar-injector{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}-{{ .Release.Namespace }}
-          {{- end }}
-{{- end }}
           - name: ISTIOD_ADDR
             value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Release.Namespace }}.svc:15012
           - name: PILOT_ENABLE_ANALYSIS

--- a/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/all_on.golden-show-in-gh-pull-request.yaml
@@ -5739,8 +5739,6 @@ spec:
           value: "true"
         - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND
           value: "true"
-        - name: INJECTION_WEBHOOK_CONFIG_NAME
-          value: istio-sidecar-injector
         - name: ISTIOD_ADDR
           value: istiod.istio-system.svc:15012
         - name: PILOT_ENABLE_ANALYSIS

--- a/operator/cmd/mesh/testdata/manifest-generate/output/flag_output.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/flag_output.golden.yaml
@@ -70,8 +70,6 @@ spec:
           value: "true"
         - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND
           value: "true"
-        - name: INJECTION_WEBHOOK_CONFIG_NAME
-          value: istio-sidecar-injector
         - name: ISTIOD_ADDR
           value: istiod.istio-system.svc:15012
         - name: PILOT_ENABLE_ANALYSIS

--- a/operator/cmd/mesh/testdata/manifest-generate/output/install_package_path.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/install_package_path.golden.yaml
@@ -91,8 +91,6 @@ spec:
             value: "true"
           - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND
             value: "true"
-          - name: INJECTION_WEBHOOK_CONFIG_NAME
-            value: istio-sidecar-injector
           - name: ISTIOD_ADDR
             value: istiod.istio-system.svc:15012
           - name: PILOT_ENABLE_ANALYSIS

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_default.golden.yaml
@@ -1487,8 +1487,6 @@ spec:
           value: "true"
         - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND
           value: "true"
-        - name: INJECTION_WEBHOOK_CONFIG_NAME
-          value: istio-sidecar-injector
         - name: ISTIOD_ADDR
           value: istiod.istio-system.svc:15012
         - name: PILOT_ENABLE_ANALYSIS

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.golden.yaml
@@ -74,8 +74,6 @@ spec:
           value: "true"
         - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND
           value: "true"
-        - name: INJECTION_WEBHOOK_CONFIG_NAME
-          value: istio-sidecar-injector-istio-control
         - name: ISTIOD_ADDR
           value: istiod.istio-control.svc:15012
         - name: PILOT_ENABLE_ANALYSIS

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_kubernetes.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_kubernetes.golden.yaml
@@ -124,8 +124,6 @@ spec:
           value: "true"
         - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND
           value: "true"
-        - name: INJECTION_WEBHOOK_CONFIG_NAME
-          value: istio-sidecar-injector-istio-control
         - name: ISTIOD_ADDR
           value: istiod.istio-control.svc:15012
         - name: PILOT_ENABLE_ANALYSIS

--- a/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_values.golden.yaml
+++ b/operator/cmd/mesh/testdata/manifest-generate/output/pilot_override_values.golden.yaml
@@ -70,8 +70,6 @@ spec:
           value: "true"
         - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND
           value: "true"
-        - name: INJECTION_WEBHOOK_CONFIG_NAME
-          value: istio-sidecar-injector-istio-control
         - name: ISTIOD_ADDR
           value: istiod.istio-control.svc:15012
         - name: PILOT_ENABLE_ANALYSIS

--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -88,6 +88,7 @@ func (s *Server) initKubeRegistry(args *PilotArgs) (err error) {
 		s.ServiceController(),
 		s.serviceEntryStore,
 		caBundlePath,
+		args.Revision,
 		s.fetchCARoot,
 		s.environment)
 

--- a/pilot/pkg/bootstrap/sidecarinjector.go
+++ b/pilot/pkg/bootstrap/sidecarinjector.go
@@ -100,7 +100,13 @@ func (s *Server) initSidecarInjector(args *PilotArgs) (*inject.Webhook, error) {
 			if hasCustomTLSCerts(args.ServerOptions.TLSOptions) {
 				caBundlePath = args.ServerOptions.TLSOptions.CaCertFile
 			}
-			webhooks.PatchCertLoop(args.Revision, webhookName, caBundlePath, s.kubeClient, stop)
+			patcher, err := webhooks.NewWebhookCertPatcher(s.kubeClient, args.Revision, webhookName, caBundlePath)
+			if err != nil {
+				log.Errorf("failed to create webhook cert patcher: %v", err)
+				return nil
+			}
+
+			patcher.Run(stop)
 			return nil
 		})
 	}

--- a/pilot/pkg/bootstrap/sidecarinjector.go
+++ b/pilot/pkg/bootstrap/sidecarinjector.go
@@ -93,14 +93,14 @@ func (s *Server) initSidecarInjector(args *PilotArgs) (*inject.Webhook, error) {
 	// Patch cert if a webhook config name is provided.
 	// This requires RBAC permissions - a low-priv Istiod should not attempt to patch but rely on
 	// operator or CI/CD
-	if features.InjectionWebhookConfigName.Get() != "" {
+	if features.InjectionWebhookConfigName != "" {
 		s.addStartFunc(func(stop <-chan struct{}) error {
 			// No leader election - different istiod revisions will patch their own cert.
 			caBundlePath := s.caBundlePath
 			if hasCustomTLSCerts(args.ServerOptions.TLSOptions) {
 				caBundlePath = args.ServerOptions.TLSOptions.CaCertFile
 			}
-			webhooks.PatchCertLoop(features.InjectionWebhookConfigName.Get(), webhookName, caBundlePath, s.kubeClient, stop)
+			webhooks.PatchCertLoop(args.Revision, features.InjectionWebhookConfigName, webhookName, caBundlePath, s.kubeClient, stop)
 			return nil
 		})
 	}

--- a/pilot/pkg/bootstrap/sidecarinjector.go
+++ b/pilot/pkg/bootstrap/sidecarinjector.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/kube/inject"
 	"istio.io/istio/pkg/webhooks"
 	"istio.io/pkg/env"
@@ -90,20 +89,17 @@ func (s *Server) initSidecarInjector(args *PilotArgs) (*inject.Webhook, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create injection webhook: %v", err)
 	}
-	// Patch cert if a webhook config name is provided.
-	// This requires RBAC permissions - a low-priv Istiod should not attempt to patch but rely on
+	// Patching certs requires RBAC permissions, low-priv Istiod should not attempt to patch but rely on
 	// operator or CI/CD
-	if features.InjectionWebhookConfigName != "" {
-		s.addStartFunc(func(stop <-chan struct{}) error {
-			// No leader election - different istiod revisions will patch their own cert.
-			caBundlePath := s.caBundlePath
-			if hasCustomTLSCerts(args.ServerOptions.TLSOptions) {
-				caBundlePath = args.ServerOptions.TLSOptions.CaCertFile
-			}
-			webhooks.PatchCertLoop(args.Revision, features.InjectionWebhookConfigName, webhookName, caBundlePath, s.kubeClient, stop)
-			return nil
-		})
-	}
+	s.addStartFunc(func(stop <-chan struct{}) error {
+		// No leader election - different istiod revisions will patch their own cert.
+		caBundlePath := s.caBundlePath
+		if hasCustomTLSCerts(args.ServerOptions.TLSOptions) {
+			caBundlePath = args.ServerOptions.TLSOptions.CaCertFile
+		}
+		webhooks.PatchCertLoop(args.Revision, webhookName, caBundlePath, s.kubeClient, stop)
+		return nil
+	})
 	s.addStartFunc(func(stop <-chan struct{}) error {
 		go wh.Run(stop)
 		return nil

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -342,6 +342,8 @@ var (
 	EnableK8SServiceSelectWorkloadEntries = env.RegisterBoolVar("PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES", true,
 		"If enabled, Kubernetes services with selectors will select workload entries with matching labels. "+
 			"It is safe to disable it if you are quite sure you don't need this feature").Get()
+	InjectionWebhookConfigName = env.RegisterStringVar("INJECTION_WEBHOOK_CONFIG_NAME", "istio-sidecar-injector",
+		"Name of the mutatingwebhookconfiguration to patch, if istioctl is not used.")
 
 	SpiffeBundleEndpoints = env.RegisterStringVar("SPIFFE_BUNDLE_ENDPOINTS", "",
 		"The SPIFFE bundle trust domain to endpoint mappings. Istiod retrieves the root certificate from each SPIFFE "+

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -344,7 +344,6 @@ var (
 			"It is safe to disable it if you are quite sure you don't need this feature").Get()
 	InjectionWebhookConfigName = env.RegisterStringVar("INJECTION_WEBHOOK_CONFIG_NAME", "istio-sidecar-injector",
 		"Name of the mutatingwebhookconfiguration to patch, if istioctl is not used.").Get()
-	Revision = env.RegisterStringVar("REVISION", "", "Control plane revision for this pilot instance").Get()
 
 	SpiffeBundleEndpoints = env.RegisterStringVar("SPIFFE_BUNDLE_ENDPOINTS", "",
 		"The SPIFFE bundle trust domain to endpoint mappings. Istiod retrieves the root certificate from each SPIFFE "+

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -342,8 +342,6 @@ var (
 	EnableK8SServiceSelectWorkloadEntries = env.RegisterBoolVar("PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES", true,
 		"If enabled, Kubernetes services with selectors will select workload entries with matching labels. "+
 			"It is safe to disable it if you are quite sure you don't need this feature").Get()
-	InjectionWebhookConfigName = env.RegisterStringVar("INJECTION_WEBHOOK_CONFIG_NAME", "istio-sidecar-injector",
-		"Name of the mutatingwebhookconfiguration to patch, if istioctl is not used.").Get()
 
 	SpiffeBundleEndpoints = env.RegisterStringVar("SPIFFE_BUNDLE_ENDPOINTS", "",
 		"The SPIFFE bundle trust domain to endpoint mappings. Istiod retrieves the root certificate from each SPIFFE "+

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -343,7 +343,8 @@ var (
 		"If enabled, Kubernetes services with selectors will select workload entries with matching labels. "+
 			"It is safe to disable it if you are quite sure you don't need this feature").Get()
 	InjectionWebhookConfigName = env.RegisterStringVar("INJECTION_WEBHOOK_CONFIG_NAME", "istio-sidecar-injector",
-		"Name of the mutatingwebhookconfiguration to patch, if istioctl is not used.")
+		"Name of the mutatingwebhookconfiguration to patch, if istioctl is not used.").Get()
+	Revision = env.RegisterStringVar("REVISION", "", "Control plane revision for this pilot instance").Get()
 
 	SpiffeBundleEndpoints = env.RegisterStringVar("SPIFFE_BUNDLE_ENDPOINTS", "",
 		"The SPIFFE bundle trust domain to endpoint mappings. Istiod retrieves the root certificate from each SPIFFE "+

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -184,10 +184,10 @@ func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string)
 	// This requires RBAC permissions - a low-priv Istiod should not attempt to patch but rely on
 	// operator or CI/CD
 	webhookConfigName := strings.ReplaceAll(validationWebhookConfigNameTemplate, validationWebhookConfigNameTemplateVar, m.secretNamespace)
-	if features.InjectionWebhookConfigName != "" && m.caBundlePath != "" && !localCluster && (features.ExternalIstioD || features.CentralIstioD) {
+	if m.caBundlePath != "" && !localCluster && (features.ExternalIstioD || features.CentralIstioD) {
 		// TODO remove the patch loop init from initSidecarInjector (does this need leader elect? how well does it work with multi-primary?)
 		log.Infof("initializing webhook cert patch for cluster %s", clusterID)
-		go webhooks.PatchCertLoop(m.revision, features.InjectionWebhookConfigName, webhookName, m.caBundlePath, client.Kube(), stopCh)
+		go webhooks.PatchCertLoop(m.revision, webhookName, m.caBundlePath, client.Kube(), stopCh)
 		validationWebhookController := webhooks.CreateValidationWebhookController(client, webhookConfigName,
 			m.secretNamespace, m.caBundlePath, true)
 		if validationWebhookController != nil {

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -181,10 +181,10 @@ func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string)
 	// This requires RBAC permissions - a low-priv Istiod should not attempt to patch but rely on
 	// operator or CI/CD
 	webhookConfigName := strings.ReplaceAll(validationWebhookConfigNameTemplate, validationWebhookConfigNameTemplateVar, m.secretNamespace)
-	if features.InjectionWebhookConfigName.Get() != "" && m.caBundlePath != "" && !localCluster && (features.ExternalIstioD || features.CentralIstioD) {
+	if features.InjectionWebhookConfigName != "" && m.caBundlePath != "" && !localCluster && (features.ExternalIstioD || features.CentralIstioD) {
 		// TODO remove the patch loop init from initSidecarInjector (does this need leader elect? how well does it work with multi-primary?)
 		log.Infof("initializing webhook cert patch for cluster %s", clusterID)
-		go webhooks.PatchCertLoop(features.InjectionWebhookConfigName.Get(), webhookName, m.caBundlePath, client.Kube(), stopCh)
+		go webhooks.PatchCertLoop(features.Revision, features.InjectionWebhookConfigName, webhookName, m.caBundlePath, client.Kube(), stopCh)
 		validationWebhookController := webhooks.CreateValidationWebhookController(client, webhookConfigName,
 			m.secretNamespace, m.caBundlePath, true)
 		if validationWebhookController != nil {

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -184,7 +184,7 @@ func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string)
 	// This requires RBAC permissions - a low-priv Istiod should not attempt to patch but rely on
 	// operator or CI/CD
 	webhookConfigName := strings.ReplaceAll(validationWebhookConfigNameTemplate, validationWebhookConfigNameTemplateVar, m.secretNamespace)
-	if m.caBundlePath != "" && !localCluster && (features.ExternalIstioD || features.CentralIstioD) {
+	if features.InjectionWebhookConfigName.Get() != "" && m.caBundlePath != "" && !localCluster && (features.ExternalIstioD || features.CentralIstioD) {
 		// TODO remove the patch loop init from initSidecarInjector (does this need leader elect? how well does it work with multi-primary?)
 		log.Infof("initializing webhook cert patch for cluster %s", clusterID)
 		go webhooks.PatchCertLoop(m.revision, webhookName, m.caBundlePath, client.Kube(), stopCh)

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
@@ -93,9 +93,7 @@ func Test_KubeSecretController(t *testing.T) {
 			DomainSuffix:      DomainSuffix,
 			ResyncPeriod:      ResyncPeriod,
 			SyncInterval:      time.Microsecond,
-		},
-		mockserviceController,
-		nil, "", nil, nil)
+		}, mockserviceController, nil, "", "default", nil, nil)
 	mc.InitSecretController(stop)
 	cache.WaitForCacheSync(stop, mc.HasSynced)
 	clientset.RunAndWait(stop)

--- a/pkg/webhooks/webhookpatch.go
+++ b/pkg/webhooks/webhookpatch.go
@@ -35,7 +35,7 @@ import (
 	"istio.io/pkg/log"
 )
 
-var revisionError = errors.New("webhook does not belong to target revision")
+var errWrongRevision = errors.New("webhook does not belong to target revision")
 
 func patchMutatingWebhookConfig(client admissionregistrationv1beta1client.MutatingWebhookConfigurationInterface,
 	revision, webhookConfigName, webhookName string, caBundle []byte) error {
@@ -45,7 +45,7 @@ func patchMutatingWebhookConfig(client admissionregistrationv1beta1client.Mutati
 	}
 	v, ok := config.Labels[label.IstioRev]
 	if v != revision || !ok {
-		return revisionError
+		return errWrongRevision
 	}
 
 	found := false
@@ -115,7 +115,7 @@ func doPatchWithRetries(client kubernetes.Interface, revision, webhookConfigName
 	for {
 		if err := doPatch(client, revision, webhookConfigName, webhookName, caCertPem); err != nil {
 			// if the webhook no longer has the target revision, bail out
-			if errors.Is(err, revisionError) {
+			if errors.Is(err, errWrongRevision) {
 				return
 			}
 

--- a/pkg/webhooks/webhookpatch.go
+++ b/pkg/webhooks/webhookpatch.go
@@ -28,6 +28,7 @@ import (
 	admissionregistrationv1beta1client "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1"
 	"k8s.io/client-go/tools/cache"
 
+	"istio.io/api/label"
 	"istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/webhooks/validation/controller"
 	"istio.io/pkg/log"
@@ -74,7 +75,7 @@ func PatchCertLoop(revision, injectionWebhookConfigName, webhookName, caBundlePa
 		"mutatingwebhookconfigurations",
 		"",
 		func(options *metav1.ListOptions) {
-			options.LabelSelector = fmt.Sprintf("istio.io/rev=%s", revision)
+			options.LabelSelector = fmt.Sprintf("%s=%s", label.IstioRev, revision)
 		})
 
 	_, controller := cache.NewInformer(

--- a/pkg/webhooks/webhookpatch_test.go
+++ b/pkg/webhooks/webhookpatch_test.go
@@ -20,10 +20,11 @@ import (
 	"strings"
 	"testing"
 
-	"istio.io/api/label"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+
+	"istio.io/api/label"
 )
 
 func TestMutatingWebhookPatch(t *testing.T) {
@@ -112,7 +113,7 @@ func TestMutatingWebhookPatch(t *testing.T) {
 			"config1",
 			"webhook1",
 			[]byte("fake CA"),
-			revisionError.Error(),
+			errWrongRevision.Error(),
 		},
 		{
 			"WrongRevisionWebhookNotUpdated",
@@ -136,7 +137,7 @@ func TestMutatingWebhookPatch(t *testing.T) {
 			"config1",
 			"webhook1",
 			[]byte("fake CA"),
-			revisionError.Error(),
+			errWrongRevision.Error(),
 		},
 		{
 			"MultipleWebhooks",


### PR DESCRIPTION
Required for [revision tag](https://docs.google.com/document/d/13IGuJg8swtLdNGW5cpF7ZdVkgge8voNp9DWBD93Wb1Q/edit#) work (needed whether we use operator or command to create webhooks)

This change makes it so that we patch any webhooks with an `istio.io/rev` label matching the pilot instance's revision (in addition to patching the canonical webhook created at installation).

Relies on the fact that our mutating injection webhooks are tagged with `istio.io/rev`

cc @howardjohn 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
