### PR TITLE
Expand and fix testing of inbound filter chains

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -722,19 +722,19 @@ func buildOutboundCatchAllNetworkFilterChains(_ *ConfigGeneratorImpl,
 	return chains
 }
 
-// EvaluateListenerFilterPredicatesInternal runs through the ListenerFilterChainMatchPredicate logic
-// This is expose for testing only, and should not be used in XDS generation code
-func EvaluateListenerFilterPredicatesInternal(predicate *listener.ListenerFilterChainMatchPredicate, invertMatch bool, port int) bool {
+// EvaluateListenerFilterPredicates runs through the ListenerFilterChainMatchPredicate logic
+// This is exposed for testing only, and should not be used in XDS generation code
+func EvaluateListenerFilterPredicates(predicate *listener.ListenerFilterChainMatchPredicate, invertMatch bool, port int) bool {
 	if predicate == nil {
 		return false
 	}
 	switch r := predicate.Rule.(type) {
 	case *listener.ListenerFilterChainMatchPredicate_NotMatch:
-		return EvaluateListenerFilterPredicatesInternal(r.NotMatch, !invertMatch, port)
+		return EvaluateListenerFilterPredicates(r.NotMatch, !invertMatch, port)
 	case *listener.ListenerFilterChainMatchPredicate_OrMatch:
 		matches := false
 		for _, r := range r.OrMatch.Rules {
-			matches = matches || EvaluateListenerFilterPredicatesInternal(r, invertMatch, port)
+			matches = matches || EvaluateListenerFilterPredicates(r, invertMatch, port)
 		}
 		if invertMatch {
 			matches = !matches

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder.go
@@ -721,28 +721,3 @@ func buildOutboundCatchAllNetworkFilterChains(_ *ConfigGeneratorImpl,
 	chains = append(chains, &listener.FilterChain{Name: VirtualOutboundCatchAllTCPFilterChainName, Filters: filterStack})
 	return chains
 }
-
-// EvaluateListenerFilterPredicates runs through the ListenerFilterChainMatchPredicate logic
-// This is exposed for testing only, and should not be used in XDS generation code
-func EvaluateListenerFilterPredicates(predicate *listener.ListenerFilterChainMatchPredicate, invertMatch bool, port int) bool {
-	if predicate == nil {
-		return false
-	}
-	switch r := predicate.Rule.(type) {
-	case *listener.ListenerFilterChainMatchPredicate_NotMatch:
-		return EvaluateListenerFilterPredicates(r.NotMatch, !invertMatch, port)
-	case *listener.ListenerFilterChainMatchPredicate_OrMatch:
-		matches := false
-		for _, r := range r.OrMatch.Rules {
-			matches = matches || EvaluateListenerFilterPredicates(r, invertMatch, port)
-		}
-		if invertMatch {
-			matches = !matches
-		}
-		return matches
-	case *listener.ListenerFilterChainMatchPredicate_DestinationPortRange:
-		return int32(port) >= r.DestinationPortRange.GetStart() && int32(port) < r.DestinationPortRange.GetEnd()
-	default:
-		panic("unsupported predicate")
-	}
-}

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
@@ -709,7 +709,7 @@ func TestInboundListenerFilters(t *testing.T) {
 func evaluateListenerFilterPredicates(t testing.TB, predicate *listener.ListenerFilterChainMatchPredicate, expected map[int]bool) {
 	t.Helper()
 	for port, expect := range expected {
-		got := EvaluateListenerFilterPredicatesInternal(predicate, false, port)
+		got := EvaluateListenerFilterPredicates(predicate, false, port)
 		if got != expect {
 			t.Errorf("expected port %v to have match=%v, got match=%v", port, expect, got)
 		}

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
@@ -709,7 +709,7 @@ func TestInboundListenerFilters(t *testing.T) {
 func evaluateListenerFilterPredicates(t testing.TB, predicate *listener.ListenerFilterChainMatchPredicate, expected map[int]bool) {
 	t.Helper()
 	for port, expect := range expected {
-		got := EvaluateListenerFilterPredicates(predicate, false, port)
+		got := xdstest.EvaluateListenerFilterPredicates(predicate, false, port)
 		if got != expect {
 			t.Errorf("expected port %v to have match=%v, got match=%v", port, expect, got)
 		}

--- a/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
@@ -709,32 +709,9 @@ func TestInboundListenerFilters(t *testing.T) {
 func evaluateListenerFilterPredicates(t testing.TB, predicate *listener.ListenerFilterChainMatchPredicate, expected map[int]bool) {
 	t.Helper()
 	for port, expect := range expected {
-		got := evaluateListenerFilterPredicatesInternal(predicate, false, port)
+		got := EvaluateListenerFilterPredicatesInternal(predicate, false, port)
 		if got != expect {
 			t.Errorf("expected port %v to have match=%v, got match=%v", port, expect, got)
 		}
-	}
-}
-
-func evaluateListenerFilterPredicatesInternal(predicate *listener.ListenerFilterChainMatchPredicate, invertMatch bool, port int) bool {
-	if predicate == nil {
-		return false
-	}
-	switch r := predicate.Rule.(type) {
-	case *listener.ListenerFilterChainMatchPredicate_NotMatch:
-		return evaluateListenerFilterPredicatesInternal(r.NotMatch, !invertMatch, port)
-	case *listener.ListenerFilterChainMatchPredicate_OrMatch:
-		matches := false
-		for _, r := range r.OrMatch.Rules {
-			matches = matches || evaluateListenerFilterPredicatesInternal(r, invertMatch, port)
-		}
-		if invertMatch {
-			matches = !matches
-		}
-		return matches
-	case *listener.ListenerFilterChainMatchPredicate_DestinationPortRange:
-		return int32(port) >= r.DestinationPortRange.GetStart() && int32(port) < r.DestinationPortRange.GetEnd()
-	default:
-		panic("unsupported predicate")
 	}
 }

--- a/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
@@ -521,6 +521,7 @@ func TestInboundClusters(t *testing.T) {
 				_, _, _, port := model.ParseSubsetKey(name)
 				sim.Run(simulation.Call{
 					Port:     port,
+					Protocol: simulation.HTTP,
 					Address:  "1.2.3.4",
 					CallMode: simulation.CallModeInbound,
 				}).Matches(t, simulation.Result{
@@ -584,6 +585,9 @@ spec:
   location: MESH_INTERNAL
   resolution: STATIC
   ports:
+  - name: tcp
+    number: 70
+    protocol: TCP
   - name: http
     number: 80
     protocol: HTTP
@@ -591,446 +595,556 @@ spec:
     number: 81
 ---
 `
-	runSimulationTest(t, nil, xds.FakeOptions{}, simulationTest{
-		name:   "disable",
-		config: svc + mtlsMode("DISABLE"),
-		calls: []simulation.Expect{
-			{
-				Name: "http inbound",
-				Call: simulation.Call{
-					Port:     80,
-					Protocol: simulation.HTTP,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					VirtualHostMatched: "inbound|http|80",
-					ClusterMatched:     "inbound|80||",
-				},
+	cases := []struct {
+		Name       string
+		Call       simulation.Call
+		Disabled   simulation.Result
+		Permissive simulation.Result
+		Strict     simulation.Result
+	}{
+		{
+			Name: "tcp",
+			Call: simulation.Call{
+				Port:     70,
+				Protocol: simulation.TCP,
+				CallMode: simulation.CallModeInbound,
 			},
-			{
-				Name: "auto port inbound",
-				Call: simulation.Call{
-					Port:     81,
-					Protocol: simulation.HTTP,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					VirtualHostMatched: "inbound|http|81",
-					ClusterMatched:     "inbound|81||",
-				},
+			Disabled: simulation.Result{
+				ClusterMatched: "inbound|70||",
 			},
-			{
-				Name: "auto port2 inbound",
-				Call: simulation.Call{
-					Port:     81,
-					Protocol: simulation.HTTP2,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					VirtualHostMatched: "inbound|http|81",
-					ClusterMatched:     "inbound|81||",
-				},
+			Permissive: simulation.Result{
+				ClusterMatched: "inbound|70||",
 			},
-			{
-				Name: "auto tcp inbound",
-				Call: simulation.Call{
-					Port:     81,
-					Protocol: simulation.TCP,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ListenerMatched:    "virtualInbound",
-					FilterChainMatched: "0.0.0.0_81",
-					ClusterMatched:     "inbound|81||",
-					StrictMatch:        true,
-				},
-			},
-			{
-				Name: "passthrough http",
-				Call: simulation.Call{
-					Address:  "1.2.3.4",
-					Port:     82,
-					Protocol: simulation.HTTP,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ClusterMatched: "InboundPassthroughClusterIpv4",
-				},
-			},
-			{
-				Name: "passthrough tcp",
-				Call: simulation.Call{
-					Address:  "1.2.3.4",
-					Port:     82,
-					Protocol: simulation.TCP,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ClusterMatched: "InboundPassthroughClusterIpv4",
-				},
-			},
-			{
-				Name: "passthrough tls",
-				Call: simulation.Call{
-					Address:  "1.2.3.4",
-					Port:     82,
-					Protocol: simulation.TCP,
-					TLS:      simulation.TLS,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ClusterMatched: "InboundPassthroughClusterIpv4",
-				},
+			Strict: simulation.Result{
+				// Plaintext to strict, should fail
+				Error: simulation.ErrNoFilterChain,
 			},
 		},
+		{
+			Name: "http to tcp",
+			Call: simulation.Call{
+				Port:     70,
+				Protocol: simulation.HTTP,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				ClusterMatched: "inbound|70||",
+			},
+			Permissive: simulation.Result{
+				ClusterMatched: "inbound|70||",
+			},
+			Strict: simulation.Result{
+				// Plaintext to strict, should fail
+				Error: simulation.ErrNoFilterChain,
+			},
+		},
+		{
+			Name: "tls to tcp",
+			Call: simulation.Call{
+				Port:     70,
+				Protocol: simulation.TCP,
+				TLS:      simulation.TLS,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				ClusterMatched: "inbound|70||",
+			},
+			Permissive: simulation.Result{
+				// This breaks because we don't match the mtls rule (alpn) but we don't match the plaintext rule either
+				Error: simulation.ErrNoFilterChain,
+				Skip:  "https://github.com/istio/istio/issues/29538",
+			},
+			Strict: simulation.Result{
+				// TLS, but not mTLS
+				Error: simulation.ErrMTLSError,
+			},
+		},
+		{
+			Name: "https to tcp",
+			Call: simulation.Call{
+				Port:     70,
+				Protocol: simulation.HTTP,
+				TLS:      simulation.TLS,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				ClusterMatched: "inbound|70||",
+			},
+			Permissive: simulation.Result{
+				// This breaks because we don't match the mtls rule (alpn) but we don't match the plaintext rule either
+				Error: simulation.ErrNoFilterChain,
+				Skip:  "https://github.com/istio/istio/issues/29538",
+			},
+			Strict: simulation.Result{
+				// TLS, but not mTLS
+				Error: simulation.ErrMTLSError,
+			},
+		},
+		{
+			Name: "mtls tcp to tcp",
+			Call: simulation.Call{
+				Port:     70,
+				Protocol: simulation.TCP,
+				TLS:      simulation.MTLS,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				// This is probably a user error, but there is no reason we should block mTLS traffic
+				// we just will not terminate it
+				ClusterMatched: "inbound|70||",
+			},
+			Permissive: simulation.Result{
+				ClusterMatched: "inbound|70||",
+			},
+			Strict: simulation.Result{
+				ClusterMatched: "inbound|70||",
+			},
+		},
+		{
+			Name: "mtls http to tcp",
+			Call: simulation.Call{
+				Port:     70,
+				Protocol: simulation.HTTP,
+				TLS:      simulation.MTLS,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				// This is probably a user error, but there is no reason we should block mTLS traffic
+				// we just will not terminate it
+				ClusterMatched: "inbound|70||",
+			},
+			Permissive: simulation.Result{
+				Error: simulation.ErrNoFilterChain,
+				Skip:  "https://github.com/istio/istio/issues/29538#issuecomment-742890598",
+			},
+			Strict: simulation.Result{
+				ClusterMatched: "inbound|70||",
+			},
+		},
+		{
+			Name: "http",
+			Call: simulation.Call{
+				Port:     80,
+				Protocol: simulation.HTTP,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				VirtualHostMatched: "inbound|http|80",
+				ClusterMatched:     "inbound|80||",
+			},
+			Permissive: simulation.Result{
+				VirtualHostMatched: "inbound|http|80",
+				ClusterMatched:     "inbound|80||",
+			},
+			Strict: simulation.Result{
+				// Plaintext to strict, should fail
+				Error: simulation.ErrNoFilterChain,
+			},
+		},
+		{
+			Name: "tls to http",
+			Call: simulation.Call{
+				Port:     80,
+				Protocol: simulation.HTTP,
+				TLS:      simulation.TLS,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				// TLS is not terminated, so we will attempt to decode as HTTP and fail
+				Error: simulation.ErrProtocolError,
+			},
+			Permissive: simulation.Result{
+				// Fails for the wrong reason, should be a protocol error instead
+				Error: simulation.ErrNoFilterChain,
+				Skip:  "https://github.com/istio/istio/issues/29538",
+			},
+			Strict: simulation.Result{
+				// TLS, but not mTLS
+				Error: simulation.ErrMTLSError,
+			},
+		},
+		{
+			Name: "https to http",
+			Call: simulation.Call{
+				Port:     80,
+				Protocol: simulation.HTTP,
+				TLS:      simulation.TLS,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				// TLS is not terminated, so we will attempt to decode as HTTP and fail
+				Error: simulation.ErrProtocolError,
+			},
+			Permissive: simulation.Result{
+				// Fails for the wrong reason, should be a protocol error instead
+				Error: simulation.ErrNoFilterChain,
+				Skip:  "https://github.com/istio/istio/issues/29538",
+			},
+			Strict: simulation.Result{
+				// TLS, but not mTLS
+				Error: simulation.ErrMTLSError,
+			},
+		},
+		{
+			Name: "mtls to http",
+			Call: simulation.Call{
+				Port:     80,
+				Protocol: simulation.HTTP,
+				TLS:      simulation.MTLS,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				// TLS is not terminated, so we will attempt to decode as HTTP and fail
+				Error: simulation.ErrProtocolError,
+			},
+			Permissive: simulation.Result{
+				VirtualHostMatched: "inbound|http|80",
+				ClusterMatched:     "inbound|80||",
+			},
+			Strict: simulation.Result{
+				VirtualHostMatched: "inbound|http|80",
+				ClusterMatched:     "inbound|80||",
+			},
+		},
+		{
+			Name: "tcp to http",
+			Call: simulation.Call{
+				Port:     80,
+				Protocol: simulation.TCP,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				// Expected, the port only supports HTTP
+				Error: simulation.ErrProtocolError,
+			},
+			Permissive: simulation.Result{
+				// Expected, the port only supports HTTP
+				Error: simulation.ErrProtocolError,
+			},
+			Strict: simulation.Result{
+				// Plaintext to strict fails
+				Error: simulation.ErrNoFilterChain,
+			},
+		},
+		{
+			Name: "auto port http",
+			Call: simulation.Call{
+				Port:     81,
+				Protocol: simulation.HTTP,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				VirtualHostMatched: "inbound|http|81",
+				ClusterMatched:     "inbound|81||",
+			},
+			Permissive: simulation.Result{
+				VirtualHostMatched: "inbound|http|81",
+				ClusterMatched:     "inbound|81||",
+			},
+			Strict: simulation.Result{
+				// Plaintext to strict fails
+				Error: simulation.ErrNoFilterChain,
+			},
+		},
+		{
+			Name: "auto port http2",
+			Call: simulation.Call{
+				Port:     81,
+				Protocol: simulation.HTTP2,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				VirtualHostMatched: "inbound|http|81",
+				ClusterMatched:     "inbound|81||",
+			},
+			Permissive: simulation.Result{
+				VirtualHostMatched: "inbound|http|81",
+				ClusterMatched:     "inbound|81||",
+			},
+			Strict: simulation.Result{
+				// Plaintext to strict fails
+				Error: simulation.ErrNoFilterChain,
+			},
+		},
+		{
+			Name: "auto port tcp",
+			Call: simulation.Call{
+				Port:     81,
+				Protocol: simulation.TCP,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				ListenerMatched:    "virtualInbound",
+				FilterChainMatched: "0.0.0.0_81",
+				ClusterMatched:     "inbound|81||",
+				StrictMatch:        true,
+			},
+			Permissive: simulation.Result{
+				ListenerMatched:    "virtualInbound",
+				FilterChainMatched: "0.0.0.0_81",
+				ClusterMatched:     "inbound|81||",
+				StrictMatch:        true,
+			},
+			Strict: simulation.Result{
+				// Plaintext to strict fails
+				Error: simulation.ErrNoFilterChain,
+			},
+		},
+		{
+			Name: "tls to auto port",
+			Call: simulation.Call{
+				Port:     81,
+				Protocol: simulation.TCP,
+				TLS:      simulation.TLS,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				// Should go through the TCP chains
+				ListenerMatched:    "virtualInbound",
+				FilterChainMatched: "0.0.0.0_81",
+				ClusterMatched:     "inbound|81||",
+				StrictMatch:        true,
+			},
+			Permissive: simulation.Result{
+				// Should go through the TCP chains
+				ListenerMatched:    "virtualInbound",
+				FilterChainMatched: "0.0.0.0_81",
+				ClusterMatched:     "inbound|81||",
+				StrictMatch:        true,
+			},
+			Strict: simulation.Result{
+				// Tls, but not mTLS
+				Error: simulation.ErrMTLSError,
+			},
+		},
+		{
+			Name: "https to auto port",
+			Call: simulation.Call{
+				Port:     81,
+				Protocol: simulation.HTTP,
+				TLS:      simulation.TLS,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				// Should go through the TCP chains
+				ListenerMatched:    "virtualInbound",
+				FilterChainMatched: "0.0.0.0_81",
+				ClusterMatched:     "inbound|81||",
+				StrictMatch:        true,
+			},
+			Permissive: simulation.Result{
+				// Should go through the TCP chains
+				ListenerMatched:    "virtualInbound",
+				FilterChainMatched: "0.0.0.0_81",
+				ClusterMatched:     "inbound|81||",
+				StrictMatch:        true,
+			},
+			Strict: simulation.Result{
+				// Tls, but not mTLS
+				Error: simulation.ErrMTLSError,
+			},
+		},
+		{
+			Name: "mtls tcp to auto port",
+			Call: simulation.Call{
+				Port:     81,
+				Protocol: simulation.TCP,
+				TLS:      simulation.MTLS,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				// This is probably a user error, but there is no reason we should block mTLS traffic
+				// we just will not terminate it
+				ClusterMatched: "inbound|81||",
+			},
+			Permissive: simulation.Result{
+				// Should go through the TCP chains
+				ListenerMatched:    "virtualInbound",
+				FilterChainMatched: "0.0.0.0_81",
+				ClusterMatched:     "inbound|81||",
+				StrictMatch:        true,
+			},
+			Strict: simulation.Result{
+				// Should go through the TCP chains
+				ListenerMatched:    "virtualInbound",
+				FilterChainMatched: "0.0.0.0_81",
+				ClusterMatched:     "inbound|81||",
+				StrictMatch:        true,
+			},
+		},
+		{
+			Name: "mtls http to auto port",
+			Call: simulation.Call{
+				Port:     81,
+				Protocol: simulation.HTTP,
+				TLS:      simulation.MTLS,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				// This is probably a user error, but there is no reason we should block mTLS traffic
+				// we just will not terminate it
+				ClusterMatched: "inbound|81||",
+			},
+			Permissive: simulation.Result{
+				// Should go through the HTTP chains
+				VirtualHostMatched: "inbound|http|81",
+				ClusterMatched:     "inbound|81||",
+			},
+			Strict: simulation.Result{
+				// Should go through the HTTP chains
+				VirtualHostMatched: "inbound|http|81",
+				ClusterMatched:     "inbound|81||",
+			},
+		},
+		{
+			Name: "passthrough http",
+			Call: simulation.Call{
+				Address:  "1.2.3.4",
+				Port:     82,
+				Protocol: simulation.HTTP,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				ClusterMatched:     "InboundPassthroughClusterIpv4",
+				FilterChainMatched: "virtualInbound-catchall-http",
+			},
+			Permissive: simulation.Result{
+				ClusterMatched:     "InboundPassthroughClusterIpv4",
+				FilterChainMatched: "virtualInbound-catchall-http",
+			},
+			Strict: simulation.Result{
+				// Plaintext to strict fails
+				Error: simulation.ErrNoFilterChain,
+			},
+		},
+		{
+			Name: "passthrough tcp",
+			Call: simulation.Call{
+				Address:  "1.2.3.4",
+				Port:     82,
+				Protocol: simulation.TCP,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				ClusterMatched:     "InboundPassthroughClusterIpv4",
+				FilterChainMatched: "virtualInbound",
+			},
+			Permissive: simulation.Result{
+				ClusterMatched:     "InboundPassthroughClusterIpv4",
+				FilterChainMatched: "virtualInbound",
+			},
+			Strict: simulation.Result{
+				// Plaintext to strict fails
+				Error: simulation.ErrNoFilterChain,
+			},
+		},
+		{
+			Name: "passthrough tls",
+			Call: simulation.Call{
+				Address:  "1.2.3.4",
+				Port:     82,
+				Protocol: simulation.TCP,
+				TLS:      simulation.TLS,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				ClusterMatched:     "InboundPassthroughClusterIpv4",
+				FilterChainMatched: "virtualInbound",
+			},
+			Permissive: simulation.Result{
+				Error: simulation.ErrNoFilterChain,
+				Skip:  "https://github.com/istio/istio/issues/29538",
+			},
+			Strict: simulation.Result{
+				// tls, but not mTLS
+				Error: simulation.ErrMTLSError,
+			},
+		},
+		{
+			Name: "passthrough https",
+			Call: simulation.Call{
+				Address:  "1.2.3.4",
+				Port:     82,
+				Protocol: simulation.HTTP,
+				TLS:      simulation.TLS,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				ClusterMatched: "InboundPassthroughClusterIpv4",
+			},
+			Permissive: simulation.Result{
+				Error: simulation.ErrMTLSError,
+				// We are matching the mtls chain unexpectedly
+				Skip: "https://github.com/istio/istio/issues/29538#issuecomment-742819586",
+			},
+			Strict: simulation.Result{
+				// tls, but not mTLS
+				Error: simulation.ErrMTLSError,
+			},
+		},
+		{
+			Name: "passthrough mtls",
+			Call: simulation.Call{
+				Address:  "1.2.3.4",
+				Port:     82,
+				Protocol: simulation.HTTP,
+				TLS:      simulation.MTLS,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				ClusterMatched: "InboundPassthroughClusterIpv4",
+			},
+			Permissive: simulation.Result{
+				ClusterMatched: "InboundPassthroughClusterIpv4",
+			},
+			Strict: simulation.Result{
+				ClusterMatched: "InboundPassthroughClusterIpv4",
+			},
+		},
+	}
+	t.Run("Disable", func(t *testing.T) {
+		calls := []simulation.Expect{}
+		for _, c := range cases {
+			calls = append(calls, simulation.Expect{
+				Name:   c.Name,
+				Call:   c.Call,
+				Result: c.Disabled,
+			})
+		}
+		runSimulationTest(t, nil, xds.FakeOptions{}, simulationTest{
+			config: svc + mtlsMode("DISABLE"),
+			calls:  calls,
+		})
 	})
 
-	runSimulationTest(t, nil, xds.FakeOptions{}, simulationTest{
-		name:   "permissive",
-		config: svc + mtlsMode("PERMISSIVE"),
-		calls: []simulation.Expect{
-			{
-				Name: "http port",
-				Call: simulation.Call{
-					Port:     80,
-					Protocol: simulation.HTTP,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					VirtualHostMatched: "inbound|http|80",
-					ClusterMatched:     "inbound|80||",
-				},
-			},
-			{
-				Name: "http port tls",
-				Call: simulation.Call{
-					Port:     80,
-					Protocol: simulation.HTTP,
-					TLS:      simulation.TLS,
-					Alpn:     "http/1.1",
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					// This is expected. Protocol is explicitly declared HTTP but we send TLS traffic
-					Error: simulation.ErrNoFilterChain,
-				},
-			},
-			{
-				Name: "http port mtls",
-				Call: simulation.Call{
-					Port:     80,
-					Protocol: simulation.HTTP,
-					TLS:      simulation.MTLS,
-					Alpn:     "istio-http/1.1",
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					VirtualHostMatched: "inbound|http|80",
-					ClusterMatched:     "inbound|80||",
-				},
-			},
-			{
-				Name: "auto port port",
-				Call: simulation.Call{
-					Port:     81,
-					Protocol: simulation.HTTP,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					VirtualHostMatched: "inbound|http|81",
-					ClusterMatched:     "inbound|81||",
-				},
-			},
-			{
-				Name: "auto port port https",
-				Call: simulation.Call{
-					Port:     81,
-					Protocol: simulation.HTTP,
-					TLS:      simulation.TLS,
-					Alpn:     "http/1.1",
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					// Passed through as plain tcp
-					ClusterMatched:     "inbound|81||",
-					ListenerMatched:    "virtualInbound",
-					FilterChainMatched: "0.0.0.0_81",
-					StrictMatch:        true,
-				},
-			},
-			{
-				Name: "auto port port https mtls",
-				Call: simulation.Call{
-					Port:     81,
-					Protocol: simulation.HTTP,
-					TLS:      simulation.MTLS,
-					Alpn:     "istio-http/1.1",
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ListenerMatched:    "virtualInbound",
-					FilterChainMatched: "0.0.0.0_81",
-					VirtualHostMatched: "inbound|http|81",
-					ClusterMatched:     "inbound|81||",
-					RouteMatched:       "default",
-					StrictMatch:        true,
-				},
-			},
-			{
-				Name: "auto port tcp",
-				Call: simulation.Call{
-					Port:     81,
-					Protocol: simulation.TCP,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ListenerMatched:    "virtualInbound",
-					FilterChainMatched: "0.0.0.0_81",
-					ClusterMatched:     "inbound|81||",
-					StrictMatch:        true,
-				},
-			},
-			{
-				Name: "auto port tls",
-				Call: simulation.Call{
-					Port:     81,
-					Protocol: simulation.TCP,
-					TLS:      simulation.TLS,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ListenerMatched:    "virtualInbound",
-					FilterChainMatched: "0.0.0.0_81",
-					ClusterMatched:     "inbound|81||",
-					StrictMatch:        true,
-				},
-			},
-			{
-				Name: "auto port mtls",
-				Call: simulation.Call{
-					Port:     81,
-					Protocol: simulation.TCP,
-					TLS:      simulation.MTLS,
-					Alpn:     "istio",
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ListenerMatched:    "virtualInbound",
-					FilterChainMatched: "0.0.0.0_81",
-					ClusterMatched:     "inbound|81||",
-					StrictMatch:        true,
-				},
-			},
-			{
-				Name: "passthrough http",
-				Call: simulation.Call{
-					Address:  "1.2.3.4",
-					Port:     82,
-					Protocol: simulation.HTTP,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ClusterMatched:     "InboundPassthroughClusterIpv4",
-					FilterChainMatched: "virtualInbound-catchall-http",
-				},
-			},
-			{
-				Name: "passthrough tcp",
-				Call: simulation.Call{
-					Address:  "1.2.3.4",
-					Port:     82,
-					Protocol: simulation.TCP,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ClusterMatched:     "InboundPassthroughClusterIpv4",
-					FilterChainMatched: "virtualInbound",
-				},
-			},
-			{
-				Name: "passthrough tls",
-				Call: simulation.Call{
-					Address:  "1.2.3.4",
-					Port:     82,
-					Protocol: simulation.TCP,
-					TLS:      simulation.TLS,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					// TODO: This is a bug, see https://github.com/istio/istio/issues/26079#issuecomment-673699228
-					Error: simulation.ErrNoFilterChain,
-				},
-			},
-			{
-				Name: "passthrough mtls",
-				Call: simulation.Call{
-					Address:  "1.2.3.4",
-					Port:     82,
-					Alpn:     "istio",
-					Protocol: simulation.TCP,
-					TLS:      simulation.MTLS,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ClusterMatched:     "InboundPassthroughClusterIpv4",
-					ListenerMatched:    "virtualInbound",
-					FilterChainMatched: "virtualInbound",
-					StrictMatch:        true,
-				},
-			},
-			{
-				Name: "passthrough https",
-				Call: simulation.Call{
-					Address:  "1.2.3.4",
-					Port:     82,
-					Alpn:     "http/1.1",
-					Protocol: simulation.HTTP,
-					TLS:      simulation.TLS,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ClusterMatched:     "InboundPassthroughClusterIpv4",
-					ListenerMatched:    "virtualInbound",
-					FilterChainMatched: "virtualInbound-catchall-http",
-					RouteMatched:       "default",
-					VirtualHostMatched: "inbound|http|0",
-					// TODO: This is a bug, see https://github.com/istio/istio/issues/26079#issuecomment-673699228
-					// We should NOT be terminating TLs here, this is supposed to be passthrough. This breaks traffic
-					// sending TLS with ALPN (ie curl, or many other clients) to a port not exposed in the service.
-					StrictMatch: true,
-				},
-			},
-		},
+	t.Run("Permissive", func(t *testing.T) {
+		calls := []simulation.Expect{}
+		for _, c := range cases {
+			calls = append(calls, simulation.Expect{
+				Name:   c.Name,
+				Call:   c.Call,
+				Result: c.Permissive,
+			})
+		}
+		runSimulationTest(t, nil, xds.FakeOptions{}, simulationTest{
+			config: svc + mtlsMode("PERMISSIVE"),
+			calls:  calls,
+		})
 	})
 
-	runSimulationTest(t, nil, xds.FakeOptions{}, simulationTest{
-		name:           "strict",
-		config:         svc + mtlsMode("STRICT"),
-		skipValidation: false,
-		calls: []simulation.Expect{
-			{
-				Name: "http port",
-				Call: simulation.Call{
-					Port:     80,
-					Protocol: simulation.HTTP,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					// Plaintext to strict, should fail
-					Error: simulation.ErrNoFilterChain,
-				},
-			},
-			{
-				Name: "auto port http",
-				Call: simulation.Call{
-					Port:     81,
-					Protocol: simulation.HTTP,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					// Plaintext to strict, should fail
-					Error: simulation.ErrNoFilterChain,
-				},
-			},
-			{
-				Name: "auto port http mtls",
-				Call: simulation.Call{
-					Port:     81,
-					Protocol: simulation.HTTP,
-					TLS:      simulation.MTLS,
-					Alpn:     "istio-http/1.1",
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					VirtualHostMatched: "inbound|http|81",
-					ClusterMatched:     "inbound|81||",
-				},
-			},
-			{
-				Name: "auto port tcp",
-				Call: simulation.Call{
-					Port:     81,
-					Protocol: simulation.TCP,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					// Plaintext to strict, should fail
-					Error: simulation.ErrNoFilterChain,
-				},
-			},
-			{
-				Name: "passthrough plaintext",
-				Call: simulation.Call{
-					Port:     82,
-					Address:  "1.2.3.4",
-					Protocol: simulation.TCP,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					// Cannot send plaintext with strict
-					Error: simulation.ErrNoFilterChain,
-				},
-			},
-			{
-				Name: "passthrough tls",
-				Call: simulation.Call{
-					Port:     82,
-					Address:  "1.2.3.4",
-					Protocol: simulation.TCP,
-					TLS:      simulation.TLS,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ClusterMatched:     "InboundPassthroughClusterIpv4",
-					FilterChainMatched: "virtualInbound",
-				},
-			},
-			{
-				Name: "passthrough mtls",
-				Call: simulation.Call{
-					Port:     82,
-					Address:  "1.2.3.4",
-					Protocol: simulation.TCP,
-					TLS:      simulation.MTLS,
-					Alpn:     "istio",
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ClusterMatched:     "InboundPassthroughClusterIpv4",
-					FilterChainMatched: "virtualInbound",
-				},
-			},
-			{
-				Name: "passthrough mtls http",
-				Call: simulation.Call{
-					Port:     82,
-					Address:  "1.2.3.4",
-					Protocol: simulation.TCP,
-					TLS:      simulation.TLS,
-					Alpn:     "istio-http/1.1",
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ClusterMatched:     "InboundPassthroughClusterIpv4",
-					VirtualHostMatched: "inbound|http|0",
-				},
-			},
-			{
-				Name: "passthrough mtls http legacy",
-				Call: simulation.Call{
-					Port:     82,
-					Address:  "1.2.3.4",
-					Protocol: simulation.TCP,
-					TLS:      simulation.MTLS,
-					Alpn:     "http/1.1",
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ClusterMatched:     "InboundPassthroughClusterIpv4",
-					VirtualHostMatched: "inbound|http|0",
-				},
-			},
-		},
+	t.Run("Strict", func(t *testing.T) {
+		calls := []simulation.Expect{}
+		for _, c := range cases {
+			calls = append(calls, simulation.Expect{
+				Name:   c.Name,
+				Call:   c.Call,
+				Result: c.Strict,
+			})
+		}
+		runSimulationTest(t, nil, xds.FakeOptions{}, simulationTest{
+			config: svc + mtlsMode("STRICT"),
+			calls:  calls,
+		})
 	})
 }
 

--- a/pilot/pkg/simulation/traffic.go
+++ b/pilot/pkg/simulation/traffic.go
@@ -247,7 +247,7 @@ func hasFilterOnPort(l *listener.Listener, filter string, port int) bool {
 	if got.FilterDisabled == nil {
 		return true
 	}
-	return !v1alpha3.EvaluateListenerFilterPredicates(got.FilterDisabled, false, port)
+	return !xdstest.EvaluateListenerFilterPredicates(got.FilterDisabled, false, port)
 }
 
 func (sim *Simulation) Run(input Call) (result Result) {

--- a/pilot/pkg/simulation/traffic.go
+++ b/pilot/pkg/simulation/traffic.go
@@ -156,12 +156,12 @@ type Result struct {
 	RouteConfigMatched string
 	VirtualHostMatched string
 	ClusterMatched     string
-	// StrictMatch controls whether we will strictly match the result. If not set, empty fields will
+	// StrictMatch controls whether we will strictly match the result. If unset, empty fields will
 	// be ignored, allowing testing only fields we care about This allows asserting that the result
 	// is *exactly* equal, allowing asserting a field is empty
 	StrictMatch bool
 	// If set, this will mark a test as skipped. Note the result is still checked first - we skip only
-	// if we pass the test. This is to ensure that if the behaviour changes, we still capture it; the skip
+	// if we pass the test. This is to ensure that if the behavior changes, we still capture it; the skip
 	// just ensures we notice a test is wrong
 	Skip string
 	t    test.Failer
@@ -247,7 +247,7 @@ func hasFilterOnPort(l *listener.Listener, filter string, port int) bool {
 	if got.FilterDisabled == nil {
 		return true
 	}
-	return !v1alpha3.EvaluateListenerFilterPredicatesInternal(got.FilterDisabled, false, port)
+	return !v1alpha3.EvaluateListenerFilterPredicates(got.FilterDisabled, false, port)
 }
 
 func (sim *Simulation) Run(input Call) (result Result) {
@@ -357,7 +357,7 @@ func (sim *Simulation) requiresMTLS(fc *listener.FilterChain) bool {
 	if len(t.GetCommonTlsContext().GetTlsCertificateSdsSecretConfigs()) == 0 {
 		return false
 	}
-	// This is a lazy heuristic, we could check for explicit default resource or spiffee if it becomes neccesary
+	// This is a lazy heuristic, we could check for explicit default resource or spiffe if it becomes necessary
 	return t.GetCommonTlsContext().GetTlsCertificateSdsSecretConfigs()[0].Name == "default"
 }
 

--- a/pilot/pkg/simulation/traffic.go
+++ b/pilot/pkg/simulation/traffic.go
@@ -27,6 +27,8 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	"github.com/golang/protobuf/ptypes"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/yl2chen/cidranger"
@@ -74,6 +76,7 @@ var (
 	// ErrProtocolError happens when sending TLS/TCP request to HCM, for example
 	ErrProtocolError = errors.New("protocol error")
 	ErrTLSError      = errors.New("invalid TLS")
+	ErrMTLSError     = errors.New("invalid mTLS")
 )
 
 type Expect struct {
@@ -136,6 +139,12 @@ func (c Call) FillDefaults() Call {
 		// pick a random address, assumption is the test does not care
 		c.Address = "1.3.3.7"
 	}
+	if c.TLS == MTLS && c.Alpn == "" {
+		c.Alpn = protocolToMTLSAlpn(c.Protocol)
+	}
+	if c.TLS == TLS && c.Alpn == "" {
+		c.Alpn = protocolToTLSAlpn(c.Protocol)
+	}
 	return c
 }
 
@@ -147,16 +156,20 @@ type Result struct {
 	RouteConfigMatched string
 	VirtualHostMatched string
 	ClusterMatched     string
-	// StrictMatch controls whether we will strictly match the result. If not set,
-	// empty fields will be ignored, allowing testing only fields we care about This
-	// allows asserting that the result is *exactly* equal, allowing asserting a
-	// field is empty
+	// StrictMatch controls whether we will strictly match the result. If not set, empty fields will
+	// be ignored, allowing testing only fields we care about This allows asserting that the result
+	// is *exactly* equal, allowing asserting a field is empty
 	StrictMatch bool
-	t           test.Failer
+	// If set, this will mark a test as skipped. Note the result is still checked first - we skip only
+	// if we pass the test. This is to ensure that if the behaviour changes, we still capture it; the skip
+	// just ensures we notice a test is wrong
+	Skip string
+	t    test.Failer
 }
 
 func (r Result) Matches(t *testing.T, want Result) {
 	r.StrictMatch = want.StrictMatch // to make diff pass
+	r.Skip = want.Skip               // to make diff pass
 	diff := cmp.Diff(want, r, cmpopts.IgnoreUnexported(Result{}), cmpopts.EquateErrors())
 	if want.StrictMatch && diff != "" {
 		t.Errorf("Diff: %v", diff)
@@ -185,6 +198,8 @@ func (r Result) Matches(t *testing.T, want Result) {
 	}
 	if t.Failed() {
 		t.Logf("Diff: %+v", diff)
+	} else if want.Skip != "" {
+		t.Skip(fmt.Sprintf("Known bug: %v", r.Skip))
 	}
 }
 
@@ -224,9 +239,24 @@ func (sim *Simulation) RunExpectations(es []Expect) {
 	}
 }
 
+func hasFilterOnPort(l *listener.Listener, filter string, port int) bool {
+	got, f := xdstest.ExtractListenerFilters(l)[filter]
+	if !f {
+		return false
+	}
+	if got.FilterDisabled == nil {
+		return true
+	}
+	return !v1alpha3.EvaluateListenerFilterPredicatesInternal(got.FilterDisabled, false, port)
+}
+
 func (sim *Simulation) Run(input Call) (result Result) {
 	result = Result{t: sim.t}
 	input = input.FillDefaults()
+	if input.Alpn != "" && input.TLS == Plaintext {
+		result.Error = fmt.Errorf("invalid call, ALPN can only be sent in TLS requests")
+		return result
+	}
 
 	// First we will match a listener
 	l := matchListener(sim.Listeners, input)
@@ -236,26 +266,46 @@ func (sim *Simulation) Run(input Call) (result Result) {
 	}
 	result.ListenerMatched = l.Name
 
-	// Apply listener filters. This will likely need the TLS inspector in the future as well
-	if _, f := xdstest.ExtractListenerFilters(l)[xdsfilters.HTTPInspector.Name]; f {
+	hasTLSInspector := hasFilterOnPort(l, xdsfilters.TLSInspector.Name, input.Port)
+	if !hasTLSInspector {
+		// Without tls inspector, Envoy would not read the ALPN in the TLS handshake
+		// HTTP inspector still may set it though
+		input.Alpn = ""
+	}
+
+	// Apply listener filters
+	if hasFilterOnPort(l, xdsfilters.HTTPInspector.Name, input.Port) {
 		if alpn := protocolToAlpn(input.Protocol); alpn != "" && input.TLS == Plaintext {
 			input.Alpn = alpn
 		}
 	}
-	_, hasTLSInspector := xdstest.ExtractListenerFilters(l)[xdsfilters.TLSInspector.Name]
+
 	fc, err := sim.matchFilterChain(l.FilterChains, l.DefaultFilterChain, input, hasTLSInspector)
 	if err != nil {
 		result.Error = err
 		return
 	}
 	result.FilterChainMatched = fc.Name
+	// Plaintext to TLS is an error
 	if fc.TransportSocket != nil && input.TLS == Plaintext {
 		result.Error = ErrTLSError
 		return
 	}
+	// mTLS listener will only accept mTLS traffic
+	if fc.TransportSocket != nil && sim.requiresMTLS(fc) != (input.TLS == MTLS) {
+		// If there is no tls inspector, then
+		result.Error = ErrMTLSError
+		return
+	}
 
 	if hcm := xdstest.ExtractHTTPConnectionManager(sim.t, fc); hcm != nil {
+		// We matched HCM and didn't terminate TLS, but we are sending TLS traffic - decoding will fail
 		if input.TLS != Plaintext && fc.TransportSocket == nil {
+			result.Error = ErrProtocolError
+			return
+		}
+		// TCP to HCM is invalid
+		if input.Protocol != HTTP && input.Protocol != HTTP2 {
 			result.Error = ErrProtocolError
 			return
 		}
@@ -293,6 +343,22 @@ func (sim *Simulation) Run(input Call) (result Result) {
 		result.ClusterMatched = tcp.GetCluster()
 	}
 	return
+}
+
+func (sim *Simulation) requiresMTLS(fc *listener.FilterChain) bool {
+	if fc.TransportSocket == nil {
+		return false
+	}
+	t := &tls.DownstreamTlsContext{}
+	if err := ptypes.UnmarshalAny(fc.GetTransportSocket().GetTypedConfig(), t); err != nil {
+		sim.t.Fatal(err)
+	}
+
+	if len(t.GetCommonTlsContext().GetTlsCertificateSdsSecretConfigs()) == 0 {
+		return false
+	}
+	// This is a lazy heuristic, we could check for explicit default resource or spiffee if it becomes neccesary
+	return t.GetCommonTlsContext().GetTlsCertificateSdsSecretConfigs()[0].Name == "default"
 }
 
 func (sim *Simulation) matchRoute(vh *route.VirtualHost, input Call) *route.Route {
@@ -486,6 +552,28 @@ func filter(chains []*listener.FilterChain,
 		}
 	}
 	return res
+}
+
+func protocolToMTLSAlpn(s Protocol) string {
+	switch s {
+	case HTTP:
+		return "istio-http/1.1"
+	case HTTP2:
+		return "istio-h2"
+	default:
+		return "istio"
+	}
+}
+
+func protocolToTLSAlpn(s Protocol) string {
+	switch s {
+	case HTTP:
+		return "http/1.1"
+	case HTTP2:
+		return "h2"
+	default:
+		return ""
+	}
 }
 
 func protocolToAlpn(s Protocol) string {

--- a/pilot/test/xdstest/test.go
+++ b/pilot/test/xdstest/test.go
@@ -1,0 +1,44 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xdstest
+
+import (
+	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+)
+
+// EvaluateListenerFilterPredicates runs through the ListenerFilterChainMatchPredicate logic
+// This is exposed for testing only, and should not be used in XDS generation code
+func EvaluateListenerFilterPredicates(predicate *listener.ListenerFilterChainMatchPredicate, invertMatch bool, port int) bool {
+	if predicate == nil {
+		return false
+	}
+	switch r := predicate.Rule.(type) {
+	case *listener.ListenerFilterChainMatchPredicate_NotMatch:
+		return EvaluateListenerFilterPredicates(r.NotMatch, !invertMatch, port)
+	case *listener.ListenerFilterChainMatchPredicate_OrMatch:
+		matches := false
+		for _, r := range r.OrMatch.Rules {
+			matches = matches || EvaluateListenerFilterPredicates(r, invertMatch, port)
+		}
+		if invertMatch {
+			matches = !matches
+		}
+		return matches
+	case *listener.ListenerFilterChainMatchPredicate_DestinationPortRange:
+		return int32(port) >= r.DestinationPortRange.GetStart() && int32(port) < r.DestinationPortRange.GetEnd()
+	default:
+		panic("unsupported predicate")
+	}
+}


### PR DESCRIPTION
This expands a bunch of testing of inbound filter chains, in particular with mtls modes. Part of this is fixing the tests to properly account for the disabled filter predicate, which is why some tests results have changed to closer match real envoy behavior. Additionally, there are a lot of incorrect behaviors that are marked