### PR TITLE
pilot: cleanup mx feature flag

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -172,12 +172,6 @@ var (
 		"If enabled, protocol sniffing will be used for inbound listeners whose port protocol is not specified or unsupported",
 	).Get()
 
-	EnableTCPMetadataExchange = env.RegisterBoolVar(
-		"PILOT_ENABLE_TCP_METADATA_EXCHANGE",
-		true,
-		"If enabled, metadata exchange will be enabled for TCP using ALPN and Network Metadata Exchange filters in Envoy",
-	).Get()
-
 	EnableWasmTelemetry = env.RegisterBoolVar(
 		"ENABLE_WASM_TELEMETRY",
 		false,

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -962,22 +962,10 @@ func buildUpstreamClusterTLSContext(opts *buildClusterOpts, tls *networking.Clie
 		default:
 			if c.Http2ProtocolOptions != nil {
 				// This is HTTP/2 in-mesh cluster, advertise it with ALPN.
-				// Enable sending `istio-peer-exchange`	ALPN in ALPN list if TCP
-				// metadataexchange is enabled.
-				if features.EnableTCPMetadataExchange {
-					tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNInMeshH2WithMxc
-				} else {
-					tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNInMeshH2
-				}
+				tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNInMeshH2WithMxc
 			} else {
 				// This is in-mesh cluster, advertise it with ALPN.
-				// Also, Enable sending `istio-peer-exchange` ALPN in ALPN list if TCP
-				// metadataexchange is enabled.
-				if features.EnableTCPMetadataExchange {
-					tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNInMeshWithMxc
-				} else {
-					tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNInMesh
-				}
+				tlsContext.CommonTlsContext.AlpnProtocols = util.ALPNInMeshWithMxc
 			}
 		}
 	case networking.ClientTLSSettings_SIMPLE:

--- a/pilot/pkg/networking/plugin/metadataexchange/metadataexchange.go
+++ b/pilot/pkg/networking/plugin/metadataexchange/metadataexchange.go
@@ -15,7 +15,6 @@
 package metadataexchange
 
 import (
-	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking"
 	"istio.io/istio/pilot/pkg/networking/plugin"
@@ -67,8 +66,8 @@ func buildFilter(in *plugin.InputParams, mutable *networking.MutableObjects) err
 		if in.ListenerProtocol == networking.ListenerProtocolHTTP || mutable.FilterChains[i].ListenerProtocol == networking.ListenerProtocolHTTP {
 			mutable.FilterChains[i].HTTP = append(mutable.FilterChains[i].HTTP, xdsfilters.HTTPMx)
 		}
-		if features.EnableTCPMetadataExchange && (in.ListenerProtocol == networking.ListenerProtocolTCP ||
-			mutable.FilterChains[i].ListenerProtocol == networking.ListenerProtocolTCP) {
+		if in.ListenerProtocol == networking.ListenerProtocolTCP ||
+			mutable.FilterChains[i].ListenerProtocol == networking.ListenerProtocolTCP {
 			mutable.FilterChains[i].TCP = append(mutable.FilterChains[i].TCP, xdsfilters.TCPMx)
 		}
 	}

--- a/pilot/pkg/security/authn/utils/utils.go
+++ b/pilot/pkg/security/authn/utils/utils.go
@@ -55,8 +55,7 @@ func BuildInboundFilterChain(mTLSMode model.MutualTLSMode, sdsUdsPath string, no
 	meta := node.Metadata
 	var alpnIstioMatch *listener.FilterChainMatch
 	var ctx *tls.DownstreamTlsContext
-	if features.EnableTCPMetadataExchange &&
-		(listenerProtocol == networking.ListenerProtocolTCP || listenerProtocol == networking.ListenerProtocolAuto) {
+	if listenerProtocol == networking.ListenerProtocolTCP || listenerProtocol == networking.ListenerProtocolAuto {
 		alpnIstioMatch = &listener.FilterChainMatch{
 			ApplicationProtocols: util.ALPNInMeshWithMxc,
 		}


### PR DESCRIPTION
This has been enabled by default since 1.5 and was intended only as a
feature flag. Removing now to simplify the code.
