### PR TITLE
objectSelector should ignore istio control plane pods

### DIFF
--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -41,6 +41,7 @@ spec:
         istio.io/rev: {{ .Values.revision | default "default" }}
         install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
         operator.istio.io/component: "EgressGateways"
+        sidecar.istio.io/inject: "false"
       annotations:
         {{- if .Values.meshConfig.enablePrometheusMerge }}
         prometheus.io/port: "15020"

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -41,6 +41,7 @@ spec:
         istio.io/rev: {{ .Values.revision | default "default" }}
         install.operator.istio.io/owning-resource: {{ .Values.ownerName | default "unknown" }}
         operator.istio.io/component: "IngressGateways"
+        sidecar.istio.io/inject: "false"
       annotations:
         {{- if .Values.meshConfig.enablePrometheusMerge }}
         prometheus.io/port: "15020"

--- a/manifests/charts/istio-cni/templates/daemonset.yaml
+++ b/manifests/charts/istio-cni/templates/daemonset.yaml
@@ -24,6 +24,7 @@ spec:
     metadata:
       labels:
         k8s-app: istio-cni-node
+        sidecar.istio.io/inject: "false"
       annotations:
         # This, along with the CriticalAddonsOnly toleration below,
         # marks the pod as a critical add-on, ensuring it gets


### PR DESCRIPTION
As object selectors have been enabled by default since the merging of this [PR](https://github.com/istio/istio/pull/29174), it would be good to have mutatingwebhooks ignore istio control components by default instead of filtering them out at the webhok service layer.

As `objectSelectors` only process labels, we need to these k-v pairs into the labels.

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.