### PR TITLE
Remove experimental marker from istioctl pc secret command

### DIFF
--- a/istioctl/cmd/proxyconfig.go
+++ b/istioctl/cmd/proxyconfig.go
@@ -743,8 +743,8 @@ func secretConfigCmd() *cobra.Command {
 
 	secretConfigCmd := &cobra.Command{
 		Use:   "secret [<type>/]<name>[.<namespace>]",
-		Short: "(experimental) Retrieves secret configuration for the Envoy in the specified pod",
-		Long:  `(experimental) Retrieve information about secret configuration for the Envoy instance in the specified pod.`,
+		Short: "Retrieves secret configuration for the Envoy in the specified pod",
+		Long:  `Retrieve information about secret configuration for the Envoy instance in the specified pod.`,
 		Example: `  # Retrieve full secret configuration for a given pod from Envoy.
   istioctl proxy-config secret <pod-name[.namespace]>
 


### PR DESCRIPTION
Added >1 year ago now, has as much test coverage (and works the same way) as the other `istioctl proxy-config` commands

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
