### PR TITLE
Fix Services with multiple ports and targetPort selecting WorkloadEntry

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -812,23 +812,13 @@ func (c *Controller) collectWorkloadInstanceEndpoints(svc *model.Service) []*mod
 		return nil
 	}
 
-	instances := c.serviceInstancesFromWorkloadInstances(svc, svc.Ports[0].Port)
 	endpoints := make([]*model.IstioEndpoint, 0)
-
-	// all endpoints for ports[0]
-	for _, instance := range instances {
-		endpoints = append(endpoints, instance.Endpoint)
-	}
-
-	// build an endpoint for each remaining service port
-	for i := 1; i < len(svc.Ports); i++ {
-		for _, instance := range instances {
-			ep := *instance.Endpoint
-			ep.EndpointPort = uint32(svc.Ports[i].Port)
-			ep.ServicePortName = svc.Ports[i].Name
-			endpoints = append(endpoints, &ep)
+	for _, port := range svc.Ports {
+		for _, instance := range c.serviceInstancesFromWorkloadInstances(svc, port.Port) {
+			endpoints = append(endpoints, instance.Endpoint)
 		}
 	}
+
 	return endpoints
 }
 

--- a/releasenotes/notes/vm-multiple-targetport.yaml
+++ b/releasenotes/notes/vm-multiple-targetport.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: networking
+issue: []
+releaseNotes:
+- |
+  **Fixed** an issue causing the `targetPort` option to not take affect for `WorkloadEntry`s with multiple ports.
+
+


### PR DESCRIPTION
Previously, if you have a service with multiple ports, only the first targetPort is applied - the rest will get the targetPort ignored. This was due to an optimization trying to make serviceInstancesFromWorkloadInstances only called for O(services) rather than O(services*ports).

This removes the optimization, fixing the bug. I don't think we need to fix the optimization as its over complex for minimal gain IMO. If we see this showing high usage we can re-evaluate