### PR TITLE
Handle the case when there is no authenticators

### DIFF
--- a/pilot/pkg/xds/authentication.go
+++ b/pilot/pkg/xds/authentication.go
@@ -31,8 +31,11 @@ import (
 // If no authenticators are configured, or if the request is on a non-secure
 // stream ( 15010 ) - returns an empty list of principals and no errors.
 func (s *DiscoveryServer) authenticate(ctx context.Context) ([]string, error) {
-	if !features.XDSAuth || len(s.Authenticators) == 0 {
+	if !features.XDSAuth {
 		return nil, nil
+	}
+	if len(s.Authenticators) == 0 {
+		return nil, errors.New("XDSAuth is true but there is no authenticator")
 	}
 
 	// Authenticate - currently just checks that request has a certificate signed with the our key.

--- a/pilot/pkg/xds/authentication.go
+++ b/pilot/pkg/xds/authentication.go
@@ -31,7 +31,7 @@ import (
 // If no authenticators are configured, or if the request is on a non-secure
 // stream ( 15010 ) - returns an empty list of principals and no errors.
 func (s *DiscoveryServer) authenticate(ctx context.Context) ([]string, error) {
-	if !features.XDSAuth {
+	if !features.XDSAuth || len(s.Authenticators) == 0 {
 		return nil, nil
 	}
 


### PR DESCRIPTION
Please provide a description for what this PR is for:
In func (s *DiscoveryServer) authenticate(ctx context.Context), when there is no s.Authenticators, authenticate() should return (nil, nil) instead of (nil, error).


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.