### PR TITLE
Do not prune eastwest gateway on deployment

### DIFF
--- a/tests/integration/iop-integration-test-defaults.yaml
+++ b/tests/integration/iop-integration-test-defaults.yaml
@@ -1,6 +1,8 @@
 # This file provides some defaults for integration testing.
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
+metadata:
+  name: install
 spec:
   meshConfig:
     accessLogFile: "/dev/stdout"


### PR DESCRIPTION
This is helpful for local testing, where we run multiple times.
Currently, the eastwest gateway would get pruned since the IstioOperator
of the control plane has no name.

Possible we should look into making it so this isn't needed, filing
another issue for that: https://github.com/istio/istio/issues/29633