### PR TITLE
Bail out on webhook cert patch retries when webhook not found

### DIFF
--- a/pkg/webhooks/webhookpatch.go
+++ b/pkg/webhooks/webhookpatch.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"k8s.io/api/admissionregistration/v1beta1"
+	kubeErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	admissionregistrationv1beta1client "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1"
@@ -141,7 +142,7 @@ func (w *WebhookCertPatcher) webhookPatchTask(webhookConfigName string) error {
 
 	// do not want to retry the task if these errors occur, they indicate that
 	// we should no longer be patching the given webhook
-	if errors.Is(err, errWrongRevision) || errors.Is(err, errNoWebhookWithName) {
+	if kubeErrors.IsNotFound(err) || errors.Is(err, errWrongRevision) || errors.Is(err, errNoWebhookWithName) {
 		return nil
 	}
 


### PR DESCRIPTION
Follow-up from #29583, keeps the retries from going on forever when a webhook is removed @howardjohn

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
