### PR TITLE
injection: remove attempted legacy injection template support

### DIFF
--- a/istioctl/cmd/testdata/inject-config.yaml
+++ b/istioctl/cmd/testdata/inject-config.yaml
@@ -1,7 +1,8 @@
 template: |-
-  initContainers:
-  - name: istio-init
-    image: docker.io/istio/proxy_init:unittest-{{.Values.global.suffix}}
-  containers:
-  - name: istio-proxy
-    image: docker.io/istio/proxy_debug:unittest
+  spec:
+    initContainers:
+    - name: istio-init
+      image: docker.io/istio/proxy_init:unittest-{{.Values.global.suffix}}
+    containers:
+    - name: istio-proxy
+      image: docker.io/istio/proxy_debug:unittest

--- a/pkg/kube/inject/inject_test.go
+++ b/pkg/kube/inject/inject_test.go
@@ -424,45 +424,6 @@ func testInjectionTemplate(t *testing.T, template, input, expected string) {
 	runWebhook(t, webhook, []byte(input), []byte(expected), false)
 }
 
-// TestPodTemplate ensures we can use a legacy pod spec resource as the template schema (rather than Pod)
-func TestPodSpecTemplate(t *testing.T) {
-	testInjectionTemplate(t,
-		`
-containers:
-- name: istio-proxy
-  image: proxy`,
-		`
-apiVersion: v1
-kind: Pod
-metadata:
-  name: hello
-spec:
-  containers:
-  - name: hello
-    image: "fake.docker.io/google-samples/hello-go-gke:1.0"
-`,
-
-		// We expect resources to only have limits, since we had the "replace" directive.
-		// nolint: lll
-		`
-apiVersion: v1
-kind: Pod
-metadata:
-  annotations:
-    prometheus.io/path: /stats/prometheus
-    prometheus.io/port: "0"
-    prometheus.io/scrape: "true"
-    sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}'
-  name: hello
-spec:
-  containers:
-    - name: hello
-      image: fake.docker.io/google-samples/hello-go-gke:1.0
-    - name: istio-proxy
-      image: proxy
-`)
-}
-
 // TestStrategicMerge ensures we can use https://github.com/kubernetes/community/blob/master/contributors/devel/sig-api-machinery/strategic-merge-patch.md
 // directives in the injection template
 func TestStrategicMerge(t *testing.T) {

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -708,33 +708,6 @@ func applyOverlay(target *corev1.Pod, overlayJSON []byte) (*corev1.Pod, error) {
 	return &pod, nil
 }
 
-func mergeInjectedConfigLegacy(req *corev1.Pod, injected []byte) (*corev1.Pod, error) {
-	current, err := json.Marshal(req.Spec)
-	if err != nil {
-		return nil, err
-	}
-
-	// The template is yaml, StrategicMergePatch expects JSON
-	injectedJSON, err := yaml.YAMLToJSON(injected)
-	if err != nil {
-		return nil, fmt.Errorf("yaml to json: %v", err)
-	}
-
-	podSpec := corev1.PodSpec{}
-	// Overlay the injected template onto the original podSpec
-	patched, err := strategicpatch.StrategicMergePatch(current, injectedJSON, podSpec)
-	if err != nil {
-		return nil, fmt.Errorf("strategic merge: %v", err)
-	}
-	if err := json.Unmarshal(patched, &podSpec); err != nil {
-		return nil, fmt.Errorf("unmarshal patched pod: %v", err)
-	}
-	pod := req.DeepCopy()
-	pod.Spec = podSpec
-
-	return pod, nil
-}
-
 func mergeInjectedConfig(req *corev1.Pod, injected []byte) (*corev1.Pod, error) {
 	// The template is yaml, StrategicMergePatch expects JSON
 	injectedJSON, err := yaml.YAMLToJSON(injected)


### PR DESCRIPTION
I originally added this in an attempt to support reading 1.8 template by
1.9 istiod. This is *not* something we have backwards compatibility
guarantees, and its something we have broken almost every release.

I later realized its not feasible to support this, and since its not
even very useful (it mostly helps when someone accidentally uses the
`latest` image but release charts - which is good to fail fast). So this
PR cleans it up.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.