### PR TITLE
Do not send NXDOMAIN on dns failures

### DIFF
--- a/pilot/pkg/dns/dns_test.go
+++ b/pilot/pkg/dns/dns_test.go
@@ -55,11 +55,11 @@ func initDNS() error {
 				Namespace: "ns1",
 				Shortname: "productpage",
 			},
-			"reviews.ns2.svc.cluster.local": {
+			"example.ns2.svc.cluster.local": {
 				Ips:       []string{"10.10.10.10"},
 				Registry:  "Kubernetes",
 				Namespace: "ns2",
-				Shortname: "reviews",
+				Shortname: "example",
 			},
 			"details.ns2.svc.cluster.remote": {
 				Ips:       []string{"11.11.11.11", "12.12.12.12"},
@@ -94,7 +94,7 @@ func TestDNS(t *testing.T) {
 		host                     string
 		queryAAAA                bool
 		expected                 []dns.RR
-		expectResolutionFailure  bool
+		expectResolutionFailure  int
 		expectExternalResolution bool
 	}{
 		{
@@ -138,27 +138,27 @@ func TestDNS(t *testing.T) {
 			name:                    "failure: AAAA query for IPv4 k8s host (name.namespace) with search namespace",
 			host:                    "productpage.ns1.ns1.svc.cluster.local.",
 			queryAAAA:               true,
-			expectResolutionFailure: true,
+			expectResolutionFailure: dns.RcodeNameError,
 		},
 		{
 			name:     "success: k8s host - non local namespace - name.namespace",
-			host:     "reviews.ns2.",
-			expected: a("reviews.ns2.", []net.IP{net.ParseIP("10.10.10.10").To4()}),
+			host:     "example.ns2.",
+			expected: a("example.ns2.", []net.IP{net.ParseIP("10.10.10.10").To4()}),
 		},
 		{
 			name:     "success: k8s host - non local namespace - fqdn",
-			host:     "reviews.ns2.svc.cluster.local.",
-			expected: a("reviews.ns2.svc.cluster.local.", []net.IP{net.ParseIP("10.10.10.10").To4()}),
+			host:     "example.ns2.svc.cluster.local.",
+			expected: a("example.ns2.svc.cluster.local.", []net.IP{net.ParseIP("10.10.10.10").To4()}),
 		},
 		{
 			name:     "success: k8s host - non local namespace - name.namespace.svc",
-			host:     "reviews.ns2.svc.",
-			expected: a("reviews.ns2.svc.", []net.IP{net.ParseIP("10.10.10.10").To4()}),
+			host:     "example.ns2.svc.",
+			expected: a("example.ns2.svc.", []net.IP{net.ParseIP("10.10.10.10").To4()}),
 		},
 		{
 			name:                    "failure: k8s host - non local namespace - shortname",
-			host:                    "reviews.",
-			expectResolutionFailure: true,
+			host:                    "example.",
+			expectResolutionFailure: dns.RcodeNameError,
 		},
 		{
 			name: "success: remote cluster k8s svc - same ns and different domain - fqdn",
@@ -169,7 +169,7 @@ func TestDNS(t *testing.T) {
 		{
 			name:                    "failure: remote cluster k8s svc - same ns and different domain - name.namespace",
 			host:                    "details.ns2.",
-			expectResolutionFailure: true, // on home machines, the ISP may resolve to some generic webpage. So this test may fail on laptops
+			expectResolutionFailure: dns.RcodeNameError, // on home machines, the ISP may resolve to some generic webpage. So this test may fail on laptops
 		},
 		{
 			name:     "success: TypeA query returns A records only",
@@ -185,13 +185,13 @@ func TestDNS(t *testing.T) {
 		{
 			name:                    "failure: Error response if only AAAA records exist for typeA",
 			host:                    "ipv6.localhost.",
-			expectResolutionFailure: true,
+			expectResolutionFailure: dns.RcodeNameError,
 		},
 		{
 			name:                    "failure: Error response if only A records exist for typeAAAA",
 			host:                    "ipv4.localhost.",
 			queryAAAA:               true,
-			expectResolutionFailure: true,
+			expectResolutionFailure: dns.RcodeNameError,
 		},
 	}
 
@@ -226,7 +226,7 @@ func TestDNS(t *testing.T) {
 							t.Errorf("upstream dns resolution for %s failed", tt.host)
 						}
 					} else {
-						if tt.expectResolutionFailure && res.Rcode != dns.RcodeNameError {
+						if tt.expectResolutionFailure != res.Rcode {
 							t.Errorf("expected resolution failure but it succeeded for %s", tt.host)
 						}
 						if !equalsDNSrecords(res.Answer, tt.expected) {


### PR DESCRIPTION
Sending NXDOMAIN means we are able to handle the request, and we know
it does not exist. Instead, we should send an err.

This was tested with
https://www.dns-oarc.net/files/dnsperf/data/queryfile-example-10million-201202.gz,
comparing the results of DNS queries through the proxy and direct.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.