### PR TITLE
Set INET class for CNAME response

### DIFF
--- a/pilot/pkg/dns/dns.go
+++ b/pilot/pkg/dns/dns.go
@@ -383,6 +383,8 @@ func cname(host string, targetHost string) []dns.RR {
 	answer.Hdr = dns.RR_Header{
 		Name:   host,
 		Rrtype: dns.TypeCNAME,
+		Class:  dns.ClassINET,
+		Ttl:    defaultTTLInSeconds,
 	}
 	answer.Target = targetHost
 	return []dns.RR{answer}

--- a/pilot/pkg/dns/dns_test.go
+++ b/pilot/pkg/dns/dns_test.go
@@ -220,6 +220,11 @@ func TestDNS(t *testing.T) {
 				if err != nil {
 					t.Errorf("Failed to resolve query for %s: %v", tt.host, err)
 				} else {
+					for _, answer := range res.Answer {
+						if answer.Header().Class != dns.ClassINET {
+							t.Errorf("expected class INET for all responses, got %+v for host %s", answer.Header(), tt.host)
+						}
+					}
 					if tt.expectExternalResolution {
 						// just make sure that the response has a valid DNS response from upstream resolvers
 						if res.Rcode != dns.RcodeSuccess {

--- a/releasenotes/notes/29681.yaml
+++ b/releasenotes/notes/29681.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: networking
+issue:
+- 28970
+releaseNotes:
+- |
+  **Fixed** a bug where DNS agent preview produces malformed DNS responses


### PR DESCRIPTION
The answer records for the CNAME did not have any class. This works for
some code paths in glibc, but it does not work when `ai_family` is set to
`AF_INET`.

	$ nslookup www.google.com
	;; Warning: Message parser reports malformed message packet.
	Server:		172.20.0.10
	Address:	172.20.0.10#53

	Non-authoritative answer:
	www.google.com.namespace.svc.cluster.local	canonical name = www.google.com.
	Name:	www.google.com
	Address: 240.240.0.13
	** server can't find www.google.com: NXDOMAIN

Fixes #29681

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
