### PR TITLE
istioctl verify-install:  display count of multiple control planes

### DIFF
--- a/istioctl/pkg/verifier/verifier.go
+++ b/istioctl/pkg/verifier/verifier.go
@@ -144,7 +144,7 @@ func (v *StatusVerifier) getRevision() (string, error) {
 		}
 		revision = rev
 	}
-	v.logger.LogAndPrintf("%d Istio control planes detected, checking %s only", revCount, revision)
+	v.logger.LogAndPrintf("%d Istio control planes detected, checking --revision %s only", revCount, revision)
 	return revision, nil
 }
 

--- a/istioctl/pkg/verifier/verifier.go
+++ b/istioctl/pkg/verifier/verifier.go
@@ -127,6 +127,7 @@ func (v *StatusVerifier) verifyInstallIOPRevision() error {
 
 func (v *StatusVerifier) getRevision() (string, error) {
 	var revision string
+	revCount := 0
 	kubeClient, err := v.createClient()
 	if err != nil {
 		return "", err
@@ -137,11 +138,13 @@ func (v *StatusVerifier) getRevision() (string, error) {
 	}
 	for _, pod := range pods.Items {
 		rev := pod.ObjectMeta.GetLabels()[label.IstioRev]
+		revCount++
 		if rev == "default" {
 			continue
 		}
 		revision = rev
 	}
+	v.logger.LogAndPrintf("%d Istio control planes detected, checking %s only", revCount, revision)
 	return revision, nil
 }
 


### PR DESCRIPTION
Part of https://github.com/istio/istio/issues/29371

Follow up for https://github.com/istio/istio/pull/29442

Install multiple control planes.
```
[istio-1.7.4]$ ./bin/istioctl install

[istio-1.8.1]$ ./bin/istioctl install -r 1-8-1

[istio-master]$ ./out/linux_amd64/istioctl install -r 1-9-0
```

```
$ k get pod -n istio-system
NAME                                    READY   STATUS    RESTARTS   AGE
istio-ingressgateway-5b67df9bf4-qxb6k   1/1     Running   0          49s
istiod-1-8-1-7b67c8cdfc-4rzcv           1/1     Running   0          2m2s
istiod-1-9-0-7fcf88df57-wmw99           1/1     Running   0          53s
istiod-7c487bdcd7-sb2t8                 1/1     Running   0          4m26s
```

**Notice**: `3 Istio control planes detected, checking --revision 1-9-0 only`.
```
$ ./out/linux_amd64/istioctl verify-install -d manifests/
3 Istio control planes detected, checking --revision 1-9-0 only
✔ HorizontalPodAutoscaler: istio-ingressgateway.istio-system checked successfully
✔ Deployment: istio-ingressgateway.istio-system checked successfully
...
✔ EnvoyFilter: stats-filter-1.9-1-9-0.istio-system checked successfully
✔ EnvoyFilter: tcp-stats-filter-1.9-1-9-0.istio-system checked successfully
Checked 12 custom resource definitions
Checked 2 Istio Deployments
✔ Istio is installed and verified successfully
```