### PR TITLE
vm auto registration: discard stale disconnect events

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/envoyproxy/go-control-plane v0.9.8-0.20201019204000-12785f608982
 	github.com/evanphx/json-patch v4.9.0+incompatible
+	github.com/evanphx/json-patch/v5 v5.1.0
 	github.com/fatih/color v1.9.0
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -263,6 +263,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrp
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v0.0.0-20190815234213-e83c0a1c26c8 h1:DM7gHzQfHwIj+St8zaPOI6iQEPAxOwIkskvw6s9rDaM=
 github.com/evanphx/json-patch v0.0.0-20190815234213-e83c0a1c26c8/go.mod h1:pmLOTb3x90VhIKxsA9yeQG5yfOkkKnkk1h+Ql8NDYDw=
+github.com/evanphx/json-patch/v5 v5.1.0 h1:B0aXl1o/1cP8NbviYiBMkcHBtUjIJ1/Ccg6b+SwCLQg=
+github.com/evanphx/json-patch/v5 v5.1.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d h1:105gxyaGwCFad8crR9dcMQWvV9Hvulu6hwUh4tWPJnM=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
@@ -541,6 +543,7 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/istio/viper v1.3.3-0.20190515210538-2789fed3109c h1:EFWADU43GY2T7NIYYbIHWdrG2hRiWyGSHeON57ZADBE=
 github.com/istio/viper v1.3.3-0.20190515210538-2789fed3109c/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jingyugao/rowserrcheck v0.0.0-20191204022205-72ab7603b68a/go.mod h1:xRskid8CManxVta/ALEhJha/pweKBaVG6fWgc0yH25s=
 github.com/jirfag/go-printf-func-name v0.0.0-20191110105641-45db9963cdd3/go.mod h1:HEWGJkRDzjJY2sqdDwxccsGicWEf9BQOZsq2tV+xzM0=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/licenses/github.com/evanphx/json-patch/v5/LICENSE
+++ b/licenses/github.com/evanphx/json-patch/v5/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2014, Evan Phoenix
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of the Evan Phoenix nor the names of its contributors 
+  may be used to endorse or promote products derived from this software 
+  without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE 
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/pilot/pkg/config/kube/crdclient/client.go
+++ b/pilot/pkg/config/kube/crdclient/client.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 	"time"
 
+	jsonmerge "github.com/evanphx/json-patch/v5"
 	"gomodules.xyz/jsonpatch/v2"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -247,9 +248,9 @@ func (cl *Client) UpdateStatus(cfg config.Config) (string, error) {
 // Patch applies only the modifications made in the PatchFunc rather than doing a full replace. Useful to avoid
 // read-modify-write conflicts when there are many concurrent-writers to the same resource.
 func (cl *Client) Patch(orig config.Config, patchFn config.PatchFunc) (string, error) {
-	modified := patchFn(orig.DeepCopy())
+	modified, patchType := patchFn(orig.DeepCopy())
 
-	meta, err := patch(cl.istioClient, cl.serviceApisClient, orig, getObjectMetadata(orig), modified, getObjectMetadata(modified))
+	meta, err := patch(cl.istioClient, cl.serviceApisClient, orig, getObjectMetadata(orig), modified, getObjectMetadata(modified), patchType)
 	if err != nil {
 		return "", err
 	}
@@ -354,20 +355,25 @@ func getObjectMetadata(config config.Config) metav1.ObjectMeta {
 	}
 }
 
-func genPatchBytes(oldRes, modRes runtime.Object) ([]byte, error) {
+func genPatchBytes(oldRes, modRes runtime.Object, patchType types.PatchType) ([]byte, error) {
 	oldJSON, err := json.Marshal(oldRes)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed marhsalling original resource: %v", err)
 	}
 	newJSON, err := json.Marshal(modRes)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed marhsalling modified resource: %v", err)
 	}
-	// TODO apply requires a "merge" style patch; see CreateTwoWayMerge patch or CreateMergePatch
-	ops, err := jsonpatch.CreatePatch(oldJSON, newJSON)
-	if err != nil {
-		return nil, err
+	switch patchType {
+	case types.JSONPatchType:
+		ops, err := jsonpatch.CreatePatch(oldJSON, newJSON)
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(ops)
+	case types.MergePatchType:
+		return jsonmerge.CreateMergePatch(oldJSON, newJSON)
+	default:
+		return nil, fmt.Errorf("unsupported patch type: %v. must be one of JSONPatchType or MergePatchType", patchType)
 	}
-	// TODO apply may require setting gvk ourselves on the patch payload
-	return json.Marshal(ops)
 }

--- a/pilot/pkg/config/kube/crdclient/client_test.go
+++ b/pilot/pkg/config/kube/crdclient/client_test.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 
 	"istio.io/api/meta/v1alpha1"
@@ -193,10 +194,10 @@ func TestClient(t *testing.T) {
 
 			// check we can patch items
 			var patchedCfg config.Config
-			if _, err := store.(*Client).Patch(*cfg, func(cfg config.Config) config.Config {
+			if _, err := store.(*Client).Patch(*cfg, func(cfg config.Config) (config.Config, types.PatchType) {
 				cfg.Annotations["fizz"] = "buzz"
 				patchedCfg = cfg
-				return cfg
+				return cfg, types.JSONPatchType
 			}); err != nil {
 				t.Errorf("unexpected err in Patch: %v", err)
 			}

--- a/pilot/pkg/config/kube/crdclient/gen/types.go.tmpl
+++ b/pilot/pkg/config/kube/crdclient/gen/types.go.tmpl
@@ -85,11 +85,11 @@ func updateStatus(ic versionedclient.Interface, sc serviceapisclient.Interface, 
     	}
 }
 
-func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig config.Config, origMeta metav1.ObjectMeta, mod config.Config, modMeta metav1.ObjectMeta) (metav1.Object, error) {
+func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig config.Config, origMeta metav1.ObjectMeta, mod config.Config, modMeta metav1.ObjectMeta, typ types.PatchType) (metav1.Object, error) {
 	if orig.GroupVersionKind != mod.GroupVersionKind {
 		return nil, fmt.Errorf("gvk mismatch: %v, modified: %v", orig.GroupVersionKind, mod.GroupVersionKind)
 	}
-    // TODO support multiple patch types and setting field manager
+    // TODO support setting field manager
 	switch orig.GroupVersionKind {
 {{- range . }}
     case collections.{{ .VariableName }}.Resource().GroupVersionKind():
@@ -101,12 +101,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
             ObjectMeta: modMeta,
             Spec:       *(mod.Spec.(*{{ .APIImport }}.{{ .Kind }}{{ .TypeSuffix }})),
         }
-        patchBytes, err := genPatchBytes(oldRes, modRes)
+        patchBytes, err := genPatchBytes(oldRes, modRes, typ)
         if err != nil {
             return nil, err
         }
         return {{.Client}}.{{ .ClientGroupPath }}().{{ .ClientTypePath }}({{if .Namespaced}}orig.Namespace{{end}}).
-            Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+            Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 {{- end }}
 	default:
 		return nil, fmt.Errorf("unsupported type: %v", orig.GroupVersionKind)

--- a/pilot/pkg/config/kube/crdclient/types.gen.go
+++ b/pilot/pkg/config/kube/crdclient/types.gen.go
@@ -319,11 +319,11 @@ func updateStatus(ic versionedclient.Interface, sc serviceapisclient.Interface, 
 	}
 }
 
-func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig config.Config, origMeta metav1.ObjectMeta, mod config.Config, modMeta metav1.ObjectMeta) (metav1.Object, error) {
+func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig config.Config, origMeta metav1.ObjectMeta, mod config.Config, modMeta metav1.ObjectMeta, typ types.PatchType) (metav1.Object, error) {
 	if orig.GroupVersionKind != mod.GroupVersionKind {
 		return nil, fmt.Errorf("gvk mismatch: %v, modified: %v", orig.GroupVersionKind, mod.GroupVersionKind)
 	}
-	// TODO support multiple patch types and setting field manager
+	// TODO support setting field manager
 	switch orig.GroupVersionKind {
 	case collections.IstioNetworkingV1Alpha3Destinationrules.Resource().GroupVersionKind():
 		oldRes := &clientnetworkingv1alpha3.DestinationRule{
@@ -334,12 +334,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*networkingv1alpha3.DestinationRule)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return ic.NetworkingV1alpha3().DestinationRules(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioNetworkingV1Alpha3Envoyfilters.Resource().GroupVersionKind():
 		oldRes := &clientnetworkingv1alpha3.EnvoyFilter{
 			ObjectMeta: origMeta,
@@ -349,12 +349,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*networkingv1alpha3.EnvoyFilter)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return ic.NetworkingV1alpha3().EnvoyFilters(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioNetworkingV1Alpha3Gateways.Resource().GroupVersionKind():
 		oldRes := &clientnetworkingv1alpha3.Gateway{
 			ObjectMeta: origMeta,
@@ -364,12 +364,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*networkingv1alpha3.Gateway)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return ic.NetworkingV1alpha3().Gateways(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioNetworkingV1Alpha3Serviceentries.Resource().GroupVersionKind():
 		oldRes := &clientnetworkingv1alpha3.ServiceEntry{
 			ObjectMeta: origMeta,
@@ -379,12 +379,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*networkingv1alpha3.ServiceEntry)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return ic.NetworkingV1alpha3().ServiceEntries(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioNetworkingV1Alpha3Sidecars.Resource().GroupVersionKind():
 		oldRes := &clientnetworkingv1alpha3.Sidecar{
 			ObjectMeta: origMeta,
@@ -394,12 +394,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*networkingv1alpha3.Sidecar)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return ic.NetworkingV1alpha3().Sidecars(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioNetworkingV1Alpha3Virtualservices.Resource().GroupVersionKind():
 		oldRes := &clientnetworkingv1alpha3.VirtualService{
 			ObjectMeta: origMeta,
@@ -409,12 +409,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*networkingv1alpha3.VirtualService)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return ic.NetworkingV1alpha3().VirtualServices(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioNetworkingV1Alpha3Workloadentries.Resource().GroupVersionKind():
 		oldRes := &clientnetworkingv1alpha3.WorkloadEntry{
 			ObjectMeta: origMeta,
@@ -424,12 +424,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*networkingv1alpha3.WorkloadEntry)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return ic.NetworkingV1alpha3().WorkloadEntries(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioNetworkingV1Alpha3Workloadgroups.Resource().GroupVersionKind():
 		oldRes := &clientnetworkingv1alpha3.WorkloadGroup{
 			ObjectMeta: origMeta,
@@ -439,12 +439,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*networkingv1alpha3.WorkloadGroup)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return ic.NetworkingV1alpha3().WorkloadGroups(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioSecurityV1Beta1Authorizationpolicies.Resource().GroupVersionKind():
 		oldRes := &clientsecurityv1beta1.AuthorizationPolicy{
 			ObjectMeta: origMeta,
@@ -454,12 +454,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*securityv1beta1.AuthorizationPolicy)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return ic.SecurityV1beta1().AuthorizationPolicies(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioSecurityV1Beta1Peerauthentications.Resource().GroupVersionKind():
 		oldRes := &clientsecurityv1beta1.PeerAuthentication{
 			ObjectMeta: origMeta,
@@ -469,12 +469,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*securityv1beta1.PeerAuthentication)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return ic.SecurityV1beta1().PeerAuthentications(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.IstioSecurityV1Beta1Requestauthentications.Resource().GroupVersionKind():
 		oldRes := &clientsecurityv1beta1.RequestAuthentication{
 			ObjectMeta: origMeta,
@@ -484,12 +484,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*securityv1beta1.RequestAuthentication)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return ic.SecurityV1beta1().RequestAuthentications(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.K8SServiceApisV1Alpha1Backendpolicies.Resource().GroupVersionKind():
 		oldRes := &servicev1alpha1.BackendPolicy{
 			ObjectMeta: origMeta,
@@ -499,12 +499,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*servicev1alpha1.BackendPolicySpec)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return sc.NetworkingV1alpha1().BackendPolicies(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.K8SServiceApisV1Alpha1Gatewayclasses.Resource().GroupVersionKind():
 		oldRes := &servicev1alpha1.GatewayClass{
 			ObjectMeta: origMeta,
@@ -514,12 +514,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*servicev1alpha1.GatewayClassSpec)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return sc.NetworkingV1alpha1().GatewayClasses().
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.K8SServiceApisV1Alpha1Gateways.Resource().GroupVersionKind():
 		oldRes := &servicev1alpha1.Gateway{
 			ObjectMeta: origMeta,
@@ -529,12 +529,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*servicev1alpha1.GatewaySpec)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return sc.NetworkingV1alpha1().Gateways(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.K8SServiceApisV1Alpha1Httproutes.Resource().GroupVersionKind():
 		oldRes := &servicev1alpha1.HTTPRoute{
 			ObjectMeta: origMeta,
@@ -544,12 +544,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*servicev1alpha1.HTTPRouteSpec)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return sc.NetworkingV1alpha1().HTTPRoutes(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.K8SServiceApisV1Alpha1Tcproutes.Resource().GroupVersionKind():
 		oldRes := &servicev1alpha1.TCPRoute{
 			ObjectMeta: origMeta,
@@ -559,12 +559,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*servicev1alpha1.TCPRouteSpec)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return sc.NetworkingV1alpha1().TCPRoutes(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	case collections.K8SServiceApisV1Alpha1Tlsroutes.Resource().GroupVersionKind():
 		oldRes := &servicev1alpha1.TLSRoute{
 			ObjectMeta: origMeta,
@@ -574,12 +574,12 @@ func patch(ic versionedclient.Interface, sc serviceapisclient.Interface, orig co
 			ObjectMeta: modMeta,
 			Spec:       *(mod.Spec.(*servicev1alpha1.TLSRouteSpec)),
 		}
-		patchBytes, err := genPatchBytes(oldRes, modRes)
+		patchBytes, err := genPatchBytes(oldRes, modRes, typ)
 		if err != nil {
 			return nil, err
 		}
 		return sc.NetworkingV1alpha1().TLSRoutes(orig.Namespace).
-			Patch(context.TODO(), orig.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
+			Patch(context.TODO(), orig.Name, typ, patchBytes, metav1.PatchOptions{FieldManager: "pilot-discovery"})
 	default:
 		return nil, fmt.Errorf("unsupported type: %v", orig.GroupVersionKind)
 	}

--- a/pilot/pkg/config/memory/config.go
+++ b/pilot/pkg/config/memory/config.go
@@ -232,7 +232,7 @@ func (cr *store) Patch(orig config.Config, patchFn config.PatchFunc) (string, er
 		return "", errors.New("unknown type")
 	}
 
-	cfg := patchFn(orig)
+	cfg, _ := patchFn(orig)
 	if _, err := s.Resource().ValidateConfig(cfg); err != nil {
 		return "", err
 	}

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -161,7 +161,7 @@ func (s *DiscoveryServer) receive(con *Connection, reqChannel chan *discovery.Di
 				if s.StatusGen != nil {
 					s.StatusGen.OnDisconnect(con)
 				}
-				s.WorkloadEntryController.QueueUnregisterWorkload(con.proxy)
+				s.WorkloadEntryController.QueueUnregisterWorkload(con.proxy, con.Connect)
 			}()
 		}
 

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -30,6 +30,7 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubetypes "k8s.io/apimachinery/pkg/types"
 
 	"istio.io/istio/pkg/util/gogoprotomarshal"
 	"istio.io/istio/pkg/util/protomarshal"
@@ -331,4 +332,4 @@ func (g GroupVersionKind) CanonicalGroup() string {
 
 // PatchFunc provides the cached config as a base for modification. Only diff the between the cfg
 // parameter and the returned Config will be applied.
-type PatchFunc func(cfg Config) Config
+type PatchFunc func(cfg Config) (Config, kubetypes.PatchType)


### PR DESCRIPTION
#29685 handles the case where we `QueueUnregisterWorkload` is called for the orignal connection _after_ a reconnect by dropping the disconnect event. 

This PR handles the case where `QueueUnregisterWorkload` is called _before_ the reconnect logic, but it's queued workitem is handled _after_. This is robust to both same-instance, and multiple-instance cases. 

We use the merge patch to reduce the number of failures from `Patch`. Using another retry loop would require additional complexity to stop retrying if the connection is terminated. 


<details>

<summary> old description </summary>

This may solve part of the case that https://github.com/istio/istio/pull/29685 describes without being tied to a single istiod. 

Now we check if the `ConnectedAt` timestamp was set using the same connection before executing any of the logic in `unregisterWorkload` to set the disconnect annotation or enqueue delayed cleanup. 

* If the reconnect completely succeeds (including the patch) then the unnecessary disconnect event will be dropped. 
* If the Delete succeeds before we run the reconnect, that's just the happy path where the order makes sense. 
* If we do the `Get` in the delete, then perform the `Patch` in reconnect, the `Update` will fail due to conflict, then when it retries the next `Get` will see the updated `ConnectedAt`
* If we perform the `Get` for the reconnect, then the unregister `Update` succeeds before our `Patch` completes, the patch will fail with `422 Invalid` because it wants to do `op: replace` on the ConnectedAt annotation, but the `Update` now required that we use `op: add`. This problem can be fixed by using JSONMergePatch (#29534). Using a retry may cause more race conditions/confusion if events occur on other istiods while we're in our retry loop. 
* 

</details>