### PR TITLE
Simplify internal generator and refactor a wle controller (#29554)

### DIFF
--- a/pilot/pkg/bootstrap/configcontroller.go
+++ b/pilot/pkg/bootstrap/configcontroller.go
@@ -38,6 +38,7 @@ import (
 	"istio.io/istio/pilot/pkg/config/kube/ingress"
 	"istio.io/istio/pilot/pkg/config/memory"
 	configmonitor "istio.io/istio/pilot/pkg/config/monitor"
+	"istio.io/istio/pilot/pkg/controller/workloadentry"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/leaderelection"
 	"istio.io/istio/pilot/pkg/model"
@@ -148,7 +149,7 @@ func (s *Server) initK8SConfigStore(args *PilotArgs) error {
 			return err
 		}
 	}
-	s.XDSServer.InternalGen.EnableWorkloadEntryController(configController)
+	s.XDSServer.WorkloadEntryController = workloadentry.NewController(configController, args.PodName)
 	return nil
 }
 

--- a/pilot/pkg/controller/workloadentry/workloadentry_controller.go
+++ b/pilot/pkg/controller/workloadentry/workloadentry_controller.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package xds
+package workloadentry
 
 import (
 	"context"
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/time/rate"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubetypes "k8s.io/apimachinery/pkg/types"
@@ -30,6 +31,8 @@ import (
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/config/schema/gvk"
+	"istio.io/istio/pkg/queue"
+	istiolog "istio.io/pkg/log"
 )
 
 const (
@@ -47,8 +50,49 @@ const (
 	timeFormat = time.RFC3339Nano
 )
 
-func (sg *InternalGen) RegisterWorkload(proxy *model.Proxy, con *Connection) error {
-	if !features.WorkloadEntryAutoRegistration {
+var log = istiolog.RegisterScope("wle", "wle controller debugging", 0)
+
+type Controller struct {
+	instanceID string
+	// TODO move WorkloadEntry related tasks into their own object and give InternalGen a reference.
+	// store should either be k8s (for running pilot) or in-memory (for tests). MCP and other config store implementations
+	// do not support writing. We only use it here for reading WorkloadEntry/WorkloadGroup.
+	store model.ConfigStoreCache
+	// cleanupLimit rate limit's autoregistered WorkloadEntry cleanup calls to k8s
+	cleanupLimit *rate.Limiter
+	// cleanupQueue delays the cleanup of autoregsitered WorkloadEntries to allow for grace period
+	cleanupQueue queue.Delayed
+}
+
+func NewController(store model.ConfigStoreCache, instanceID string) *Controller {
+	if features.WorkloadEntryAutoRegistration {
+		return &Controller{
+			instanceID:   instanceID,
+			store:        store,
+			cleanupLimit: rate.NewLimiter(rate.Limit(20), 1),
+			cleanupQueue: queue.NewDelayed(),
+		}
+	}
+	return nil
+}
+
+func (c *Controller) Run(stop <-chan struct{}) {
+	if c == nil {
+		return
+	}
+	if c.store != nil && c.cleanupQueue != nil {
+		go c.periodicWorkloadEntryCleanup(stop)
+		go c.cleanupQueue.Run(stop)
+	}
+}
+
+func setConnectMeta(c *config.Config, controller string, conTime time.Time) {
+	c.Annotations[WorkloadControllerAnnotation] = controller
+	c.Annotations[ConnectedAtAnnotation] = conTime.Format(timeFormat)
+}
+
+func (c *Controller) RegisterWorkload(proxy *model.Proxy, conTime time.Time) error {
+	if !features.WorkloadEntryAutoRegistration || c == nil {
 		return nil
 	}
 	// check if the WE already exists, update the status
@@ -58,40 +102,40 @@ func (sg *InternalGen) RegisterWorkload(proxy *model.Proxy, con *Connection) err
 	}
 
 	// Try to patch, if it fails then try to create
-	_, err := sg.store.Patch(gvk.WorkloadEntry, entryName, proxy.Metadata.Namespace, func(cfg config.Config) config.Config {
-		setConnectMeta(&cfg, sg.Server.instanceID, con)
+	_, err := c.store.Patch(gvk.WorkloadEntry, entryName, proxy.Metadata.Namespace, func(cfg config.Config) config.Config {
+		setConnectMeta(&cfg, c.instanceID, conTime)
 		return cfg
 	})
 	// TODO return err from Patch through Get
 	if err == nil {
-		adsLog.Debugf("updated auto-registered WorkloadEntry %s/%s", proxy.Metadata.Namespace, entryName)
+		log.Debugf("updated auto-registered WorkloadEntry %s/%s", proxy.Metadata.Namespace, entryName)
 		return nil
 	} else if !errors.IsNotFound(err) && err.Error() != "item not found" {
-		adsLog.Errorf("updating auto-registered WorkloadEntry %s/%s: %v", proxy.Metadata.Namespace, entryName, err)
+		log.Errorf("updating auto-registered WorkloadEntry %s/%s: %v", proxy.Metadata.Namespace, entryName, err)
 		return fmt.Errorf("updating auto-registered WorkloadEntry %s/%s err: %v", proxy.Metadata.Namespace, entryName, err)
 	}
 
 	// No WorkloadEntry, create one using fields from the associated WorkloadGroup
-	groupCfg := sg.store.Get(gvk.WorkloadGroup, proxy.Metadata.AutoRegisterGroup, proxy.Metadata.Namespace)
+	groupCfg := c.store.Get(gvk.WorkloadGroup, proxy.Metadata.AutoRegisterGroup, proxy.Metadata.Namespace)
 	if groupCfg == nil {
-		adsLog.Errorf("auto-registration of %v failed: cannot find WorkloadGroup %s/%s",
+		log.Errorf("auto-registration of %v failed: cannot find WorkloadGroup %s/%s",
 			proxy.ID, proxy.Metadata.Namespace, proxy.Metadata.AutoRegisterGroup)
 		return fmt.Errorf("auto-registration of %v failed: cannot find WorkloadGroup %s/%s",
 			proxy.ID, proxy.Metadata.Namespace, proxy.Metadata.AutoRegisterGroup)
 	}
 	entry := workloadEntryFromGroup(entryName, proxy, groupCfg)
-	setConnectMeta(entry, sg.Server.instanceID, con)
-	_, err = sg.store.Create(*entry)
+	setConnectMeta(entry, c.instanceID, conTime)
+	_, err = c.store.Create(*entry)
 	if err != nil {
-		adsLog.Errorf("auto-registration of %v failed: error creating WorkloadEntry: %v", proxy.ID, err)
+		log.Errorf("auto-registration of %v failed: error creating WorkloadEntry: %v", proxy.ID, err)
 		return fmt.Errorf("auto-registration of %v failed: error creating WorkloadEntry: %v", proxy.ID, err)
 	}
-	adsLog.Infof("auto-registered WorkloadEntry %s/%s", proxy.Metadata.Namespace, entryName)
+	log.Infof("auto-registered WorkloadEntry %s/%s", proxy.Metadata.Namespace, entryName)
 	return nil
 }
 
-func (sg *InternalGen) QueueUnregisterWorkload(proxy *model.Proxy) {
-	if !features.WorkloadEntryAutoRegistration {
+func (c *Controller) QueueUnregisterWorkload(proxy *model.Proxy) {
+	if !features.WorkloadEntryAutoRegistration || c == nil {
 		return
 	}
 	// check if the WE already exists, update the status
@@ -101,42 +145,42 @@ func (sg *InternalGen) QueueUnregisterWorkload(proxy *model.Proxy) {
 	}
 
 	// unset controller, set disconnect time
-	cfg := sg.store.Get(gvk.WorkloadEntry, entryName, proxy.Metadata.Namespace)
+	cfg := c.store.Get(gvk.WorkloadEntry, entryName, proxy.Metadata.Namespace)
 	if cfg == nil {
 		// we failed to create the workload entry in the first place or it is not propagated
 		return
 	}
 
 	// The wle has reconnected to another istiod and controlled by it.
-	if cfg.Annotations[WorkloadControllerAnnotation] != sg.Server.instanceID {
+	if cfg.Annotations[WorkloadControllerAnnotation] != c.instanceID {
 		return
 	}
 	wle := cfg.DeepCopy()
 	delete(wle.Annotations, WorkloadControllerAnnotation)
 	wle.Annotations[DisconnectedAtAnnotation] = time.Now().Format(timeFormat)
 	// use update instead of patch to prevent race condition
-	_, err := sg.store.Update(wle)
+	_, err := c.store.Update(wle)
 	if err != nil && !errors.IsConflict(err) {
-		adsLog.Warnf("disconnect: failed updating WorkloadEntry %s/%s: %v", proxy.Metadata.Namespace, entryName, err)
+		log.Warnf("disconnect: failed updating WorkloadEntry %s/%s: %v", proxy.Metadata.Namespace, entryName, err)
 		return
 	}
 
 	// after grace period, check if the workload ever reconnected
 	ns := proxy.Metadata.Namespace
-	sg.cleanupQueue.PushDelayed(func() error {
-		wle := sg.store.Get(gvk.WorkloadEntry, entryName, ns)
+	c.cleanupQueue.PushDelayed(func() error {
+		wle := c.store.Get(gvk.WorkloadEntry, entryName, ns)
 		if wle == nil {
 			return nil
 		}
 		if shouldCleanupEntry(*wle) {
-			sg.cleanupEntry(*wle)
+			c.cleanupEntry(*wle)
 		}
 		return nil
 	}, features.WorkloadEntryCleanupGracePeriod)
 }
 
 // periodicWorkloadEntryCleanup checks lists all WorkloadEntry
-func (sg *InternalGen) periodicWorkloadEntryCleanup(stopCh <-chan struct{}) {
+func (c *Controller) periodicWorkloadEntryCleanup(stopCh <-chan struct{}) {
 	if !features.WorkloadEntryAutoRegistration {
 		return
 	}
@@ -145,16 +189,16 @@ func (sg *InternalGen) periodicWorkloadEntryCleanup(stopCh <-chan struct{}) {
 	for {
 		select {
 		case <-ticker.C:
-			wles, err := sg.store.List(gvk.WorkloadEntry, metav1.NamespaceAll)
+			wles, err := c.store.List(gvk.WorkloadEntry, metav1.NamespaceAll)
 			if err != nil {
-				adsLog.Warnf("error listing WorkloadEntry for cleanup: %v", err)
+				log.Warnf("error listing WorkloadEntry for cleanup: %v", err)
 				continue
 			}
 			for _, wle := range wles {
 				wle := wle
 				if shouldCleanupEntry(wle) {
-					sg.cleanupQueue.Push(func() error {
-						sg.cleanupEntry(wle)
+					c.cleanupQueue.Push(func() error {
+						c.cleanupEntry(wle)
 						return nil
 					})
 				}
@@ -163,16 +207,6 @@ func (sg *InternalGen) periodicWorkloadEntryCleanup(stopCh <-chan struct{}) {
 			return
 		}
 	}
-}
-
-func (sg *InternalGen) cleanupEntry(wle config.Config) {
-	if err := sg.cleanupLimit.Wait(context.TODO()); err != nil {
-		adsLog.Errorf("error in WorkloadEntry cleanup rate limiter: %v", err)
-	}
-	if err := sg.store.Delete(gvk.WorkloadEntry, wle.Name, wle.Namespace); err != nil {
-		adsLog.Warnf("failed cleaning up auto-registered WorkloadEntry %s/%s: %v", wle.Namespace, wle.Name, err)
-	}
-	adsLog.Infof("cleaned up auto-registered WorkloadEntry %s/%s", wle.Namespace, wle.Name)
 }
 
 func shouldCleanupEntry(wle config.Config) bool {
@@ -196,9 +230,54 @@ func shouldCleanupEntry(wle config.Config) bool {
 	return true
 }
 
-func setConnectMeta(c *config.Config, controller string, con *Connection) {
-	c.Annotations[WorkloadControllerAnnotation] = controller
-	c.Annotations[ConnectedAtAnnotation] = con.Connect.Format(timeFormat)
+func (c *Controller) cleanupEntry(wle config.Config) {
+	if err := c.cleanupLimit.Wait(context.TODO()); err != nil {
+		log.Errorf("error in WorkloadEntry cleanup rate limiter: %v", err)
+		return
+	}
+	if err := c.store.Delete(gvk.WorkloadEntry, wle.Name, wle.Namespace); err != nil {
+		log.Warnf("failed cleaning up auto-registered WorkloadEntry %s/%s: %v", wle.Namespace, wle.Name, err)
+		return
+	}
+	log.Infof("cleaned up auto-registered WorkloadEntry %s/%s", wle.Namespace, wle.Name)
+}
+
+func autoregisteredWorkloadEntryName(proxy *model.Proxy) string {
+	if proxy.Metadata.AutoRegisterGroup == "" {
+		return ""
+	}
+	if len(proxy.IPAddresses) == 0 {
+		log.Errorf("auto-registration of %v failed: missing IP addresses", proxy.ID)
+		return ""
+	}
+	if len(proxy.Metadata.Namespace) == 0 {
+		log.Errorf("auto-registration of %v failed: missing namespace", proxy.ID)
+		return ""
+	}
+	p := []string{proxy.Metadata.AutoRegisterGroup, proxy.IPAddresses[0]}
+	if proxy.Metadata.Network != "" {
+		p = append(p, proxy.Metadata.Network)
+	}
+
+	name := strings.Join(p, "-")
+	if len(name) > 253 {
+		name = name[len(name)-253:]
+		log.Warnf("generated WorkloadEntry name is too long, consider making the WorkloadGroup name shorter. Shortening from beginning to: %s", name)
+	}
+	return name
+}
+
+func mergeLabels(labels ...map[string]string) map[string]string {
+	if len(labels) == 0 {
+		return map[string]string{}
+	}
+	out := make(map[string]string, len(labels)*len(labels[0]))
+	for _, lm := range labels {
+		for k, v := range lm {
+			out[k] = v
+		}
+	}
+	return out
 }
 
 var workloadGroupIsController = true
@@ -246,42 +325,4 @@ func workloadEntryFromGroup(name string, proxy *model.Proxy, groupCfg *config.Co
 		// TODO status fields used for garbage collection
 		Status: nil,
 	}
-}
-
-func mergeLabels(labels ...map[string]string) map[string]string {
-	if len(labels) == 0 {
-		return map[string]string{}
-	}
-	out := make(map[string]string, len(labels)*len(labels[0]))
-	for _, lm := range labels {
-		for k, v := range lm {
-			out[k] = v
-		}
-	}
-	return out
-}
-
-func autoregisteredWorkloadEntryName(proxy *model.Proxy) string {
-	if proxy.Metadata.AutoRegisterGroup == "" {
-		return ""
-	}
-	if len(proxy.IPAddresses) == 0 {
-		adsLog.Errorf("auto-registration of %v failed: missing IP addresses", proxy.ID)
-		return ""
-	}
-	if len(proxy.Metadata.Namespace) == 0 {
-		adsLog.Errorf("auto-registration of %v failed: missing namespace", proxy.ID)
-		return ""
-	}
-	p := []string{proxy.Metadata.AutoRegisterGroup, proxy.IPAddresses[0]}
-	if proxy.Metadata.Network != "" {
-		p = append(p, proxy.Metadata.Network)
-	}
-
-	name := strings.Join(p, "-")
-	if len(name) > 253 {
-		name = name[len(name)-253:]
-		adsLog.Warnf("generated WorkloadEntry name is too long, consider making the WorkloadGroup name shorter. Shortening from beginning to: %s", name)
-	}
-	return name
 }

--- a/pilot/pkg/controller/workloadentry/workloadentry_controller_test.go
+++ b/pilot/pkg/controller/workloadentry/workloadentry_controller_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package xds
+package workloadentry
 
 import (
 	"fmt"
@@ -66,11 +66,10 @@ var (
 
 func TestNonAutoregisteredWorkloads(t *testing.T) {
 	store := memory.NewController(memory.Make(collections.All))
-	ig := NewInternalGen(&DiscoveryServer{instanceID: "pilot-1"})
-	ig.EnableWorkloadEntryController(store)
+	c := NewController(store, "")
 	createOrFail(t, store, wgA)
 	stop := make(chan struct{})
-	go ig.Run(stop)
+	go c.Run(stop)
 	defer close(stop)
 
 	cases := map[string]*model.Proxy{
@@ -83,7 +82,7 @@ func TestNonAutoregisteredWorkloads(t *testing.T) {
 	for name, tc := range cases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
-			_ = ig.RegisterWorkload(tc, &Connection{proxy: tc, Connect: time.Now()})
+			_ = c.RegisterWorkload(tc, time.Now())
 			items, err := store.List(gvk.WorkloadEntry, model.NamespaceAll)
 			if err != nil {
 				t.Fatalf("failed listing WorkloadEntry: %v", err)
@@ -97,7 +96,7 @@ func TestNonAutoregisteredWorkloads(t *testing.T) {
 }
 
 func TestAutoregistrationLifecycle(t *testing.T) {
-	ig1, ig2, store := setup(t)
+	c1, c2, store := setup(t)
 	stopped1 := false
 	stop1, stop2 := make(chan struct{}), make(chan struct{})
 	defer func() {
@@ -107,57 +106,57 @@ func TestAutoregistrationLifecycle(t *testing.T) {
 		}
 	}()
 	defer close(stop2)
-	go ig1.Run(stop1)
-	go ig2.Run(stop2)
+	go c1.Run(stop1)
+	go c2.Run(stop2)
 
 	p := fakeProxy("1.2.3.4", wgA, "nw1")
 	p2 := fakeProxy("1.2.3.4", wgA, "nw2")
 
 	t.Run("initial registration", func(t *testing.T) {
 		// simply make sure the entry exists after connecting
-		_ = ig1.RegisterWorkload(p, &Connection{proxy: p, Connect: time.Now()})
-		checkEntryOrFail(t, store, wgA, p, ig1.Server.instanceID)
+		_ = c1.RegisterWorkload(p, time.Now())
+		checkEntryOrFail(t, store, wgA, p, c1.instanceID)
 	})
 	t.Run("multinetwork same ip", func(t *testing.T) {
 		// make sure we don't overrwrite a similar entry for a different network
-		_ = ig2.RegisterWorkload(p2, &Connection{proxy: p2, Connect: time.Now()})
-		checkEntryOrFail(t, store, wgA, p, ig1.Server.instanceID)
-		checkEntryOrFail(t, store, wgA, p2, ig2.Server.instanceID)
+		_ = c2.RegisterWorkload(p2, time.Now())
+		checkEntryOrFail(t, store, wgA, p, c1.instanceID)
+		checkEntryOrFail(t, store, wgA, p2, c2.instanceID)
 	})
 	t.Run("fast reconnect", func(t *testing.T) {
 		t.Run("same instance", func(t *testing.T) {
 			// disconnect, make sure entry is still there with disconnect meta
-			ig1.QueueUnregisterWorkload(p)
+			c1.QueueUnregisterWorkload(p)
 			time.Sleep(features.WorkloadEntryCleanupGracePeriod / 2)
 			checkEntryOrFail(t, store, wgA, p, "")
 			// reconnect, ensure entry is there with the same instance id
-			_ = ig1.RegisterWorkload(p, &Connection{proxy: p, Connect: time.Now()})
-			checkEntryOrFail(t, store, wgA, p, ig1.Server.instanceID)
+			_ = c1.RegisterWorkload(p, time.Now())
+			checkEntryOrFail(t, store, wgA, p, c1.instanceID)
 		})
 		t.Run("different instance", func(t *testing.T) {
 			// disconnect, make sure entry is still there with disconnect metadata
-			ig1.QueueUnregisterWorkload(p)
+			c1.QueueUnregisterWorkload(p)
 			time.Sleep(features.WorkloadEntryCleanupGracePeriod / 2)
 			checkEntryOrFail(t, store, wgA, p, "")
 			// reconnect, ensure entry is there with the new instance id
-			_ = ig2.RegisterWorkload(p, &Connection{proxy: p, Connect: time.Now()})
-			checkEntryOrFail(t, store, wgA, p, ig2.Server.instanceID)
+			_ = c2.RegisterWorkload(p, time.Now())
+			checkEntryOrFail(t, store, wgA, p, c2.instanceID)
 		})
 	})
 	t.Run("slow reconnect", func(t *testing.T) {
 		// disconnect, wait and make sure entry is gone
-		ig2.QueueUnregisterWorkload(p)
+		c2.QueueUnregisterWorkload(p)
 		retry.UntilSuccessOrFail(t, func() error {
 			return checkNoEntry(store, wgA, p)
 		})
 		// reconnect
-		_ = ig1.RegisterWorkload(p, &Connection{proxy: p, Connect: time.Now()})
-		checkEntryOrFail(t, store, wgA, p, ig1.Server.instanceID)
+		_ = c1.RegisterWorkload(p, time.Now())
+		checkEntryOrFail(t, store, wgA, p, c1.instanceID)
 	})
 	t.Run("garbage collected if pilot stops after disconnect", func(t *testing.T) {
 		// disconnect, kill the cleanup queue from the first controller
-		ig1.QueueUnregisterWorkload(p)
-		// stop processing the delayed close queue in ig1, forces using periodic cleanup
+		c1.QueueUnregisterWorkload(p)
+		// stop processing the delayed close queue in c1, forces using periodic cleanup
 		close(stop1)
 		stopped1 = true
 		// unfortunately, this retry at worst could be twice as long as the sweep interval
@@ -235,14 +234,12 @@ func TestWorkloadEntryFromGroup(t *testing.T) {
 	}
 }
 
-func setup(t *testing.T) (*InternalGen, *InternalGen, model.ConfigStoreCache) {
+func setup(t *testing.T) (*Controller, *Controller, model.ConfigStoreCache) {
 	store := memory.NewController(memory.Make(collections.All))
-	ig1 := NewInternalGen(&DiscoveryServer{instanceID: "pilot-1"})
-	ig1.EnableWorkloadEntryController(store)
-	ig2 := NewInternalGen(&DiscoveryServer{instanceID: "pilot-2"})
-	ig2.EnableWorkloadEntryController(store)
+	c1 := NewController(store, "pilot-1")
+	c2 := NewController(store, "pilot-2")
 	createOrFail(t, store, wgA)
-	return ig1, ig2, store
+	return c1, c2, store
 }
 
 func checkNoEntry(store model.ConfigStoreCache, wg config.Config, proxy *model.Proxy) error {

--- a/pilot/pkg/xds/ads_test.go
+++ b/pilot/pkg/xds/ads_test.go
@@ -191,21 +191,6 @@ func TestInternalEvents(t *testing.T) {
 	if dr.Resources == nil || len(dr.Resources) == 0 {
 		t.Error("No data")
 	}
-
-	// Create a second connection - we should get an event.s
-	ads2 := s.Connect(nil, nil, nil)
-	defer ads2.Close()
-
-	dr, err = ads.WaitVersion(5*time.Second, xds.TypeURLConnections,
-		dr.VersionInfo)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if dr.Resources == nil || len(dr.Resources) == 0 {
-		t.Fatal("No data")
-	}
-	t.Log(dr.Resources[0])
-
 }
 
 func TestAdsReconnectAfterRestart(t *testing.T) {

--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -24,6 +24,7 @@ import (
 	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 
+	"istio.io/istio/pilot/pkg/controller/workloadentry"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/apigen"
@@ -115,7 +116,8 @@ type DiscoveryServer struct {
 	Authenticators []authenticate.Authenticator
 
 	// InternalGen is notified of connect/disconnect/nack on all connections
-	InternalGen *InternalGen
+	InternalGen             *InternalGen
+	WorkloadEntryController *workloadentry.Controller
 
 	// serverReady indicates caches have been synced up and server is ready to process requests.
 	serverReady bool
@@ -210,9 +212,7 @@ func (s *DiscoveryServer) IsServerReady() bool {
 }
 
 func (s *DiscoveryServer) Start(stopCh <-chan struct{}) {
-	if s.InternalGen != nil {
-		s.InternalGen.Run(stopCh)
-	}
+	go s.WorkloadEntryController.Run(stopCh)
 	go s.handleUpdates(stopCh)
 	go s.periodicRefreshMetrics(stopCh)
 	go s.sendPushes(stopCh)

--- a/pilot/pkg/xds/internalgen.go
+++ b/pilot/pkg/xds/internalgen.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Istio Authors
+// Copyright Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,31 +18,19 @@ import (
 	"fmt"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	status "github.com/envoyproxy/go-control-plane/envoy/service/status/v3"
-	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
-	structpb "github.com/golang/protobuf/ptypes/struct"
-	"golang.org/x/time/rate"
 
-	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
-	"istio.io/istio/pkg/queue"
 	"istio.io/pkg/log"
 )
 
 const (
 	TypeURLConnections = "istio.io/connections"
-	TypeURLDisconnect  = "istio.io/disconnect"
 
 	// TODO: TypeURLReady - readiness events for endpoints, agent can propagate
-
-	// TypeURLNACK will receive messages of type DiscoveryRequest, containing
-	// the 'NACK' from envoy on rejected configs. Only ID is set in metadata.
-	// This includes all the info that envoy (client) provides.
-	TypeURLNACK = "istio.io/nack"
 
 	// TypeDebugSyncronization requests Envoy CSDS for proxy sync status
 	TypeDebugSyncronization = "istio.io/debug/syncz"
@@ -51,18 +39,9 @@ const (
 	TypeDebugConfigDump = "istio.io/debug/config_dump"
 )
 
-// InternalGen is a Generator for XDS status updates: connect, disconnect, nacks, acks
+// InternalGen is a Generator for XDS status: connections, syncz, configdump
 type InternalGen struct {
 	Server *DiscoveryServer
-
-	// TODO move WorkloadEntry related tasks into their own object and give InternalGen a reference.
-	// store should either be k8s (for running pilot) or in-memory (for tests). MCP and other config store implementations
-	// do not support writing. We only use it here for reading WorkloadEntry/WorkloadGroup.
-	store model.ConfigStoreCache
-	// cleanupLimit rate limit's autoregistered WorkloadEntry cleanup calls to k8s
-	cleanupLimit *rate.Limiter
-	// cleanupQueue delays the cleanup of autoregsitered WorkloadEntries to allow for grace period
-	cleanupQueue queue.Delayed
 
 	// TODO: track last N Nacks and connection events, with 'version' based on timestamp.
 	// On new connect, use version to send recent events since last update.
@@ -72,119 +51,6 @@ func NewInternalGen(s *DiscoveryServer) *InternalGen {
 	return &InternalGen{
 		Server: s,
 	}
-}
-
-func (sg *InternalGen) OnConnect(con *Connection) {
-	if con.node.Metadata != nil && con.node.Metadata.Fields != nil {
-		con.node.Metadata.Fields["istiod"] = &structpb.Value{
-			Kind: &structpb.Value_StringValue{
-				StringValue: "TODO", // TODO: fill in the Istiod address - may include network, cluster, IP
-			},
-		}
-		con.node.Metadata.Fields["con"] = &structpb.Value{
-			Kind: &structpb.Value_StringValue{
-				StringValue: con.ConID,
-			},
-		}
-	}
-	sg.startPush(TypeURLConnections, []proto.Message{con.node})
-}
-
-func (sg *InternalGen) OnDisconnect(con *Connection) {
-	sg.QueueUnregisterWorkload(con.proxy)
-
-	sg.startPush(TypeURLDisconnect, []proto.Message{con.node})
-
-	if con.node.Metadata != nil && con.node.Metadata.Fields != nil {
-		con.node.Metadata.Fields["istiod"] = &structpb.Value{
-			Kind: &structpb.Value_StringValue{
-				StringValue: "", // TODO: using empty string to indicate this node has no istiod connection. We'll iterate.
-			},
-		}
-	}
-
-	// Note that it is quite possible for a 'connect' on a different istiod to happen before a disconnect.
-}
-
-func (sg *InternalGen) EnableWorkloadEntryController(store model.ConfigStoreCache) {
-	if features.WorkloadEntryAutoRegistration {
-		sg.store = store
-		sg.cleanupLimit = rate.NewLimiter(rate.Limit(20), 1)
-		sg.cleanupQueue = queue.NewDelayed()
-	}
-}
-
-func (sg *InternalGen) Run(stop <-chan struct{}) {
-	if sg.store != nil && sg.cleanupQueue != nil {
-		go sg.periodicWorkloadEntryCleanup(stop)
-		go sg.cleanupQueue.Run(stop)
-	}
-}
-
-func (sg *InternalGen) OnNack(node *model.Proxy, dr *discovery.DiscoveryRequest) {
-	// Make sure we include the ID - the DR may not include metadata
-	if dr.Node == nil {
-		dr.Node = &core.Node{}
-	}
-	dr.Node.Id = node.ID
-	sg.startPush(TypeURLNACK, []proto.Message{dr})
-}
-
-// PushAll will immediately send a response to all connections that
-// are watching for the specific type.
-// TODO: additional filters can be added, for example namespace.
-func (s *DiscoveryServer) PushAll(res *discovery.DiscoveryResponse) {
-	// Push config changes, iterating over connected envoys. This cover ADS and EDS(0.7), both share
-	// the same connection table
-	s.adsClientsMutex.RLock()
-	// Create a temp map to avoid locking the add/remove
-	pending := []*Connection{}
-	for _, v := range s.adsClients {
-		v.proxy.RLock()
-		if v.proxy.WatchedResources[res.TypeUrl] != nil {
-			pending = append(pending, v)
-		}
-		v.proxy.RUnlock()
-	}
-	s.adsClientsMutex.RUnlock()
-
-	// only marshal resources if there are connected clients
-	if len(pending) == 0 {
-		return
-	}
-
-	for _, p := range pending {
-		// p.send() waits for an ACK - which is reasonable for normal push,
-		// but in this case we want to sync fast and not bother with stuck connections.
-		// This is expecting a relatively small number of watchers - each other istiod
-		// plus few admin tools or bridges to real message brokers. The normal
-		// push expects 1000s of envoy connections.
-		con := p
-		go func() {
-			err := con.stream.Send(res)
-			if err != nil {
-				adsLog.Infoa("Failed to send internal event ", con.ConID, " ", err)
-			}
-		}()
-	}
-}
-
-// startPush is similar with DiscoveryServer.startPush() - but called directly,
-// since status discovery is not driven by config change events.
-// We also want connection events to be dispatched as soon as possible,
-// they may be consumed by other instances of Istiod to update internal state.
-func (sg *InternalGen) startPush(typeURL string, data []proto.Message) {
-
-	resources := make([]*any.Any, 0, len(data))
-	for _, v := range data {
-		resources = append(resources, util.MessageToAny(v))
-	}
-	dr := &discovery.DiscoveryResponse{
-		TypeUrl:   typeURL,
-		Resources: resources,
-	}
-
-	sg.Server.PushAll(dr)
 }
 
 // Generate XDS responses about internal events:

--- a/tests/integration/pilot/vm_test.go
+++ b/tests/integration/pilot/vm_test.go
@@ -27,7 +27,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"istio.io/istio/pilot/pkg/xds"
+	"istio.io/istio/pilot/pkg/controller/workloadentry"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
@@ -126,7 +126,7 @@ func TestVMRegistrationLifecycle(t *testing.T) {
 				initialWLE := entries[0]
 
 				// keep force-disconnecting until we observe a reconnect to a different istiod instance
-				initialPilot := initialWLE.Annotations[xds.WorkloadControllerAnnotation]
+				initialPilot := initialWLE.Annotations[workloadentry.WorkloadControllerAnnotation]
 				disconnectProxy(ctx, initialPilot, autoVM)
 				retry.UntilSuccessOrFail(ctx, func() error {
 					entries := getWorkloadEntriesOrFail(ctx, autoVM)
@@ -134,7 +134,7 @@ func TestVMRegistrationLifecycle(t *testing.T) {
 						ctx.Fatalf("WorkloadEntry was cleaned up unexpectedly")
 					}
 
-					currentPilot := entries[0].Annotations[xds.WorkloadControllerAnnotation]
+					currentPilot := entries[0].Annotations[workloadentry.WorkloadControllerAnnotation]
 					if currentPilot == initialPilot || !strings.HasPrefix(currentPilot, "istiod-") {
 						disconnectProxy(ctx, currentPilot, autoVM)
 						return errors.New("expected WorkloadEntry to be updated by other pilot")


### PR DESCRIPTION
Trying to backport various fixes to auto-registration for the next 1.8 patch release. Do the changes here depend on #29257? @hzxuzhonghu @howardjohn 

---

* Refactor internal generator and workloadentry controller

* Simplify internal gen

* fix ci

* fix lint

* fix comment

(cherry picked from commit 07c3b30dd0cd7a84dcf997600d22848888e94a5a)
