### PR TITLE
fix incorrect example for profile diff command.

### DIFF
--- a/operator/cmd/mesh/profile-diff.go
+++ b/operator/cmd/mesh/profile-diff.go
@@ -39,11 +39,11 @@ func profileDiffCmd(rootArgs *rootArgs, pfArgs *profileDiffArgs) *cobra.Command 
 		Use:   "diff <file1.yaml> <file2.yaml>",
 		Short: "Diffs two Istio configuration profiles",
 		Long:  "The diff subcommand displays the differences between two Istio configuration profiles.",
-		Example: `  # Profile diff by providing yaml files
-  istioctl profile diff --manifests manifests default demo
+		Example: `  # Profile diff by providing profile names
+  istioctl profile diff default demo
 
-  # Profile diff by providing a profile name
-  istioctl profile diff default demo`,
+  # Profile diff by providing manifests path and profile names
+  istioctl profile diff default demo -d manifests/`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 2 {
 				return fmt.Errorf("diff requires two profiles")

--- a/operator/cmd/mesh/profile-diff.go
+++ b/operator/cmd/mesh/profile-diff.go
@@ -40,7 +40,7 @@ func profileDiffCmd(rootArgs *rootArgs, pfArgs *profileDiffArgs) *cobra.Command 
 		Short: "Diffs two Istio configuration profiles",
 		Long:  "The diff subcommand displays the differences between two Istio configuration profiles.",
 		Example: `  # Profile diff by providing yaml files
-  istioctl profile diff manifests/profiles/default.yaml manifests/profiles/demo.yaml
+  istioctl profile diff --manifests manifests default demo
 
   # Profile diff by providing a profile name
   istioctl profile diff default demo`,


### PR DESCRIPTION

fix the incorrect message for `istioctl profile diff` command for https://github.com/istio/istio/issues/29677



[ ] Configuration Infrastructure
[ ] Docs
[ X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.