### PR TITLE
add connect/disconnect events back in internalgen

### DIFF
--- a/pilot/pkg/xds/simple.go
+++ b/pilot/pkg/xds/simple.go
@@ -172,37 +172,7 @@ type ProxyGen struct {
 func (p *ProxyGen) HandleResponse(con *adsc.ADSC, res *discovery.DiscoveryResponse) {
 	// TODO: filter the push to only connections that
 	// match a filter.
-	// Push config changes, iterating over connected envoys. This cover ADS and EDS(0.7), both share
-	// the same connection table
-	// Create a temp map to avoid locking the add/remove
-	pending := []*Connection{}
-	for _, v := range p.server.DiscoveryServer.Clients() {
-		v.proxy.RLock()
-		if v.proxy.WatchedResources[res.TypeUrl] != nil {
-			pending = append(pending, v)
-		}
-		v.proxy.RUnlock()
-	}
-
-	// only marshal resources if there are connected clients
-	if len(pending) == 0 {
-		return
-	}
-
-	for _, p := range pending {
-		// p.send() waits for an ACK - which is reasonable for normal push,
-		// but in this case we want to sync fast and not bother with stuck connections.
-		// This is expecting a relatively small number of watchers - each other istiod
-		// plus few admin tools or bridges to real message brokers. The normal
-		// push expects 1000s of envoy connections.
-		con := p
-		go func() {
-			err := con.stream.Send(res)
-			if err != nil {
-				adsLog.Info("Failed to send internal event ", con.ConID, " ", err)
-			}
-		}()
-	}
+	p.server.DiscoveryServer.SendResponse(res)
 }
 
 func (s *SimpleServer) NewProxy() *ProxyGen {

--- a/pkg/istio-agent/local_xds_generator.go
+++ b/pkg/istio-agent/local_xds_generator.go
@@ -93,7 +93,7 @@ func (sa *Agent) initXDSGenerator() {
 	g["api"] = &apigen.APIGenerator{}
 	g["api/"+envoyv2.EndpointType] = epGen
 
-	g[xds.TypeURLConnections] = p
+	g[xds.TypeURLConnect] = p
 	g[v3.ClusterType] = p
 
 	var err error


### PR DESCRIPTION
Adds connect/disconnect events back and does minor refactoring (renaming it to statusgen, if folks does not like it I can put it back).

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X ] Does not have any changes that may affect Istio users.
