### PR TITLE
Create container containing helm manifests

### DIFF
--- a/manifests/Dockerfile.manifests
+++ b/manifests/Dockerfile.manifests
@@ -1,0 +1,52 @@
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is used to build Istio's primary build container, which contains all the tools
+# necessary to perform and all build activities in all Istio repos.
+#
+# The container is built using different contexts, one per execution environment (plain binaries, Ruby, nodejs), and
+# then combined into the final image.
+#
+# We pin versions of stuff we install. Modify the various XXX_VERSION variables within the individual build contexts
+# in order to control these versions.
+
+FROM golang:1.15
+
+RUN apt-get update \
+    && apt-get install -y git
+
+ENV OUTDIR=/out
+RUN mkdir -p ${OUTDIR}/usr/bin
+
+ENV HELM3_VERSION=v3.4.2
+
+# Helm version 3
+ADD https://get.helm.sh/helm-${HELM3_VERSION}-linux-amd64.tar.gz /tmp
+RUN mkdir /tmp/helm3 \
+    && tar -xf /tmp/helm-${HELM3_VERSION}-linux-amd64.tar.gz -C /tmp/helm3 \
+    && cp /tmp/helm3/linux-amd64/helm ${OUTDIR}/usr/bin/helm3 \
+    && mv /tmp/helm3/linux-amd64/helm ${OUTDIR}/usr/bin/helm
+
+RUN mkdir /manifests
+RUN git clone https://github.com/istio/istio /istio
+
+COPY copy-release-manifests.sh /istio
+
+WORKDIR /istio
+
+RUN ./copy-release-manifests.sh
+
+WORKDIR /
+
+ENTRYPOINT ["/out/usr/bin/helm"]

--- a/manifests/Dockerfile.manifests
+++ b/manifests/Dockerfile.manifests
@@ -21,9 +21,16 @@
 # We pin versions of stuff we install. Modify the various XXX_VERSION variables within the individual build contexts
 # in order to control these versions.
 
-FROM golang:1.15
+# BASE_DISTRIBUTION is used to switch between the old base distribution and distroless base images
+ARG BASE_DISTRIBUTION=default
 
-RUN apt-get update \
+# Version is the base image version from the TLD Makefile
+ARG BASE_VERSION=latest
+
+# The following section is used as base image if BASE_DISTRIBUTION=default
+FROM gcr.io/istio-release/base:${BASE_VERSION} as default
+
+ RUN apt-get update \
     && apt-get install -y git --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/manifests/Dockerfile.manifests
+++ b/manifests/Dockerfile.manifests
@@ -24,7 +24,9 @@
 FROM golang:1.15
 
 RUN apt-get update \
-    && apt-get install -y git
+    && apt-get install -y git --no-install-recommends \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV OUTDIR=/out
 RUN mkdir -p ${OUTDIR}/usr/bin

--- a/manifests/copy-release-manifests.sh
+++ b/manifests/copy-release-manifests.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+supported_releases="1.8"
+
+for release in $supported_releases
+do
+  releases=$(git tag -l "$release*" | grep -v rc | grep -v alpha)
+  for rel in $releases
+  do
+    git checkout $rel
+    cp -R manifests/charts /manifests/$rel
+  done
+done

--- a/manifests/copy-release-manifests.sh
+++ b/manifests/copy-release-manifests.sh
@@ -1,5 +1,28 @@
 #!/usr/bin/env bash
 
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is used to build Istio's primary build container, which contains all the tools
+# necessary to perform and all build activities in all Istio repos.
+#
+# The container is built using different contexts, one per execution environment (plain binaries, Ruby, nodejs), and
+# then combined into the final image.
+#
+# We pin versions of stuff we install. Modify the various XXX_VERSION variables within the individual build contexts
+# in order to control these versions.
+
 supported_releases="1.8"
 
 for release in $supported_releases
@@ -7,7 +30,7 @@ do
   releases=$(git tag -l "$release*" | grep -v rc | grep -v alpha)
   for rel in $releases
   do
-    git checkout $rel
-    cp -R manifests/charts /manifests/$rel
+    git checkout "$rel"
+    cp -R manifests/charts "/manifests/$rel"
   done
 done

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -247,6 +247,11 @@ dockerx.%:
 docker.base: docker/Dockerfile.base
 	$(DOCKER_RULE)
 
+docker.manifests: manifests/copy-release-manifests.sh
+docker.manifests: manifests/helm-runner.sh
+docker.manifests: manifests/Dockerfile.manifests
+	$(DOCKER_RULE)
+
 docker.app_sidecar_base_debian_9: BUILD_ARGS=--build-arg VM_IMAGE_NAME=debian --build-arg VM_IMAGE_VERSION=9
 docker.app_sidecar_base_debian_9: VM_OS_DOCKERFILE_TEMPLATE=Dockerfile.app_sidecar_base
 docker.app_sidecar_base_debian_9: pkg/test/echo/docker/Dockerfile.app_sidecar_base

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -247,6 +247,7 @@ dockerx.%:
 docker.base: docker/Dockerfile.base
 	$(DOCKER_RULE)
 
+docker.manifests: BUILD_ARGS=--build-arg BASE_VERSION=${BASE_VERSION}
 docker.manifests: manifests/copy-release-manifests.sh
 docker.manifests: manifests/Dockerfile.manifests
 	$(DOCKER_RULE)

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -248,7 +248,6 @@ docker.base: docker/Dockerfile.base
 	$(DOCKER_RULE)
 
 docker.manifests: manifests/copy-release-manifests.sh
-docker.manifests: manifests/helm-runner.sh
 docker.manifests: manifests/Dockerfile.manifests
 	$(DOCKER_RULE)
 


### PR DESCRIPTION
Issue: Upgrade testing for helm requires access to each of the manifest
charts for each potentially each version of istio (e.g. 1.8.0, 1.8.1,
etc...). However, checking in these charts is problematic as they are
10k+ lines with few changes per patch release and potentially a lot of
change for minor versions.

Solution: Create a docker image that contains the helm charts
for each version post 1.8.0. The integration testing framework will have
to be extended to call this docker file similar to the following

docker run -v KUBEPATH:/kubeconfig/kube.config gcr.io/istio:manifests \
    install istio -n istio-system /manifests/1.8.0/base \
    --kubeconfig /kubeconfig/kube.config



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.