### PR TITLE
add destination port support for envoyfilter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ require (
 	gopkg.in/yaml.v2 v2.3.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 	helm.sh/helm/v3 v3.2.4
-	istio.io/api v0.0.0-20201215013001-d474186cff8d
+	istio.io/api v0.0.0-20201217155105-21c3bd1ba1d3
 	istio.io/client-go v0.0.0-20200908160912-f99162621a1a
 	istio.io/gogo-genproto v0.0.0-20201015184601-1e80d26d6249
 	istio.io/pkg v0.0.0-20201106170352-6775f12cf100

--- a/go.sum
+++ b/go.sum
@@ -1401,8 +1401,8 @@ honnef.co/go/tools v0.0.1-2020.1.5 h1:nI5egYTGJakVyOryqLs1cQO5dO0ksin5XXs2pspk75
 honnef.co/go/tools v0.0.1-2020.1.5/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 istio.io/api v0.0.0-20190515205759-982e5c3888c6/go.mod h1:hhLFQmpHia8zgaM37vb2ml9iS5NfNfqZGRt1pS9aVEo=
 istio.io/api v0.0.0-20200812202721-24be265d41c3/go.mod h1:88HN3o1fSD1jo+Z1WTLlJfMm9biopur6Ct9BFKjiB64=
-istio.io/api v0.0.0-20201215013001-d474186cff8d h1:kjVuf0y0Hu0NFZqcSVWMeCUQjid3Svc11BDXOJW5xpc=
-istio.io/api v0.0.0-20201215013001-d474186cff8d/go.mod h1:88HN3o1fSD1jo+Z1WTLlJfMm9biopur6Ct9BFKjiB64=
+istio.io/api v0.0.0-20201217155105-21c3bd1ba1d3 h1:Y13oEDRSjdfH4wXskV1FqmsxiDLMhKEgo/QlyNU70oY=
+istio.io/api v0.0.0-20201217155105-21c3bd1ba1d3/go.mod h1:88HN3o1fSD1jo+Z1WTLlJfMm9biopur6Ct9BFKjiB64=
 istio.io/client-go v0.0.0-20200908160912-f99162621a1a h1:clPn0fz+rXq5Ytj6Ppb1ygUKeU0RImT4ZbT1oMd1G04=
 istio.io/client-go v0.0.0-20200908160912-f99162621a1a/go.mod h1:SO65MWt7I45dvUwuDowoiB0SVcGpfWZfUTlopvYpbZc=
 istio.io/gogo-genproto v0.0.0-20190930162913-45029607206a/go.mod h1:OzpAts7jljZceG4Vqi5/zXy/pOg1b209T3jb7Nv5wIs=

--- a/manifests/charts/base/crds/crd-all.gen.yaml
+++ b/manifests/charts/base/crds/crd-all.gen.yaml
@@ -1287,6 +1287,10 @@ spec:
                                 description: Applies only to sidecars.
                                 format: string
                                 type: string
+                              destinationPort:
+                                description: The destination_port value used by a
+                                  filter chain's match condition.
+                                type: integer
                               filter:
                                 description: The name of a specific filter to apply
                                   the patch to.

--- a/manifests/charts/base/files/gen-istio-cluster.yaml
+++ b/manifests/charts/base/files/gen-istio-cluster.yaml
@@ -1289,6 +1289,10 @@ spec:
                                 description: Applies only to sidecars.
                                 format: string
                                 type: string
+                              destinationPort:
+                                description: The destination_port value used by a
+                                  filter chain's match condition.
+                                type: integer
                               filter:
                                 description: The name of a specific filter to apply
                                   the patch to.

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
@@ -585,10 +585,16 @@ func filterChainMatch(fc *xdslistener.FilterChain, cp *model.EnvoyFilterConfigPa
 	}
 
 	// check match for destination port within the FilterChainMatch
-	if cMatch.PortNumber > 0 &&
-		fc.FilterChainMatch != nil && fc.FilterChainMatch.DestinationPort != nil &&
-		fc.FilterChainMatch.DestinationPort.Value != cMatch.PortNumber {
-		return false
+	if fc.FilterChainMatch != nil && fc.FilterChainMatch.DestinationPort != nil {
+		if match.DestinationPort > 0 {
+			if fc.FilterChainMatch.DestinationPort.Value != match.DestinationPort {
+				return false
+			}
+		} else if cMatch.PortNumber > 0 { //Compare listenerMatch's port number for back compatibility
+			if fc.FilterChainMatch.DestinationPort.Value != cMatch.PortNumber {
+				return false
+			}
+		}
 	}
 
 	return true

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
@@ -575,6 +575,37 @@ func TestApplyListenerPatches(t *testing.T) {
 				Value:     buildPatchStruct(`{"name": "http-filter-replaced-should-not-be-applied"}`),
 			},
 		},
+		{
+			ApplyTo: networking.EnvoyFilter_NETWORK_FILTER,
+			Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
+				ObjectTypes: &networking.EnvoyFilter_EnvoyConfigObjectMatch_Listener{
+					Listener: &networking.EnvoyFilter_ListenerMatch{
+						Name: VirtualInboundListenerName,
+						FilterChain: &networking.EnvoyFilter_ListenerMatch_FilterChainMatch{
+							DestinationPort: 6380,
+							Filter: &networking.EnvoyFilter_ListenerMatch_FilterMatch{
+								Name: "network-filter-to-be-replaced",
+							},
+						},
+					},
+				},
+			},
+			Patch: &networking.EnvoyFilter_Patch{
+				Operation: networking.EnvoyFilter_Patch_REPLACE,
+				Value: buildPatchStruct(`
+{"name": "envoy.redis_proxy",
+ "typed_config": {
+        "@type": "type.googleapis.com/envoy.extensions.filters.network.redis_proxy.v3.RedisProxy",
+         "stat_prefix": "redis_stats",
+         "prefix_routes": {
+             "catch_all_route": {
+                 "cluster": "custom-redis-cluster"
+             }
+         }
+ }
+}`),
+			},
+		},
 	}
 
 	sidecarOutboundIn := []*listener.Listener{
@@ -1177,6 +1208,16 @@ func TestApplyListenerPatches(t *testing.T) {
 						},
 					},
 				},
+				{
+					FilterChainMatch: &listener.FilterChainMatch{
+						DestinationPort: &wrappers.UInt32Value{
+							Value: 6380,
+						},
+					},
+					Filters: []*listener.Filter{
+						{Name: "network-filter-to-be-replaced"},
+					},
+				},
 			},
 		},
 	}
@@ -1217,6 +1258,27 @@ func TestApplyListenerPatches(t *testing.T) {
 										{Name: "http-filter3"},
 										{Name: "http-filter2"},
 										{Name: "http-filter4"},
+									},
+								}),
+							},
+						},
+					},
+				},
+				{
+					FilterChainMatch: &listener.FilterChainMatch{
+						DestinationPort: &wrappers.UInt32Value{
+							Value: 6380,
+						},
+					},
+					Filters: []*listener.Filter{
+						{Name: "envoy.redis_proxy",
+							ConfigType: &listener.Filter_TypedConfig{
+								TypedConfig: util.MessageToAny(&redis_proxy.RedisProxy{
+									StatPrefix: "redis_stats",
+									PrefixRoutes: &redis_proxy.RedisProxy_PrefixRoutes{
+										CatchAllRoute: &redis_proxy.RedisProxy_PrefixRoutes_Route{
+											Cluster: "custom-redis-cluster",
+										},
 									},
 								}),
 							},


### PR DESCRIPTION
I'm working on [Aeraki](https://github.com/aeraki-framework/aeraki) to extend Istio's traffic management to other layer-7 protocols. When trying to build EnvoyFilters for inbound listeners, I find that we need a destination port match condition to distinguish multiple service ports in the virtual inbound listener.

Signed-off-by: zhaohuabing <huabingzhao@tencent.com>



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.