### PR TITLE
fix app probe to reuse connection

### DIFF
--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -498,6 +498,9 @@ func (s *Server) handleAppProbe(w http.ResponseWriter, req *http.Request) {
 
 	// Forward incoming headers to the application.
 	for name, values := range req.Header {
+		if name == "Connection" {
+			continue
+		}
 		newValues := make([]string, len(values))
 		copy(newValues, values)
 		appReq.Header[name] = newValues


### PR DESCRIPTION
Follow up pr to https://github.com/istio/istio/pull/27864
The previous fix wouldn't fix app probes from making new connections since they send "Connection: close" header with it.
This fixes it by removing "Connection: close" header, and it is tested with our infra.

- Connections before fix

```
root@REDUCTED:/# ss -atnp | grep ":8080 "
LISTEN     0      128          *:8080                     *:*                   users:(("java",pid=64,fd=215))
TIME-WAIT  0      0      127.0.0.1:44936              127.0.0.1:8080
TIME-WAIT  0      0      127.0.0.1:60330              127.0.0.1:8080
TIME-WAIT  0      0      127.0.0.1:8080               127.0.0.1:45102
TIME-WAIT  0      0      127.0.0.1:60472              127.0.0.1:8080
TIME-WAIT  0      0      127.0.0.1:60830              127.0.0.1:8080
ESTAB      0      0      127.0.0.1:42672              127.0.0.1:8080
ESTAB      0      0      127.0.0.1:38938              127.0.0.1:8080
ESTAB      0      0      127.0.0.1:8080               127.0.0.1:42672               users:(("java",pid=64,fd=264))
ESTAB      0      0      127.0.0.1:38796              127.0.0.1:8080
TIME-WAIT  0      0      127.0.0.1:60682              127.0.0.1:8080
TIME-WAIT  0      0      127.0.0.1:8080               127.0.0.1:60330
TIME-WAIT  0      0      127.0.0.1:59948              127.0.0.1:8080
ESTAB      0      0      127.0.0.1:8080               127.0.0.1:38796               users:(("java",pid=64,fd=226))
TIME-WAIT  0      0      127.0.0.1:59802              127.0.0.1:8080
ESTAB      0      0      127.0.0.1:8080               127.0.0.1:53278               users:(("java",pid=64,fd=218))
TIME-WAIT  0      0      127.0.0.1:40282              127.0.0.1:8080
ESTAB      0      0      127.0.0.1:8080               127.0.0.1:38400               users:(("java",pid=64,fd=220))
ESTAB      0      0      127.0.0.1:8080               127.0.0.1:42282               users:(("java",pid=64,fd=268))
TIME-WAIT  0      0      127.0.0.1:44598              127.0.0.1:8080
TIME-WAIT  0      0      127.0.0.1:36036              127.0.0.1:8080
TIME-WAIT  0      0      127.0.0.1:45266              127.0.0.1:8080
TIME-WAIT  0      0      127.0.0.1:33254              127.0.0.1:8080
TIME-WAIT  0      0      127.0.0.1:44438              127.0.0.1:8080
ESTAB      0      0      10.239.206.203:44606              10.239.3.116:8080
TIME-WAIT  0      0      127.0.0.1:44256              127.0.0.1:8080
TIME-WAIT  0      0      127.0.0.1:44772              127.0.0.1:8080
ESTAB      0      0      127.0.0.1:8080               127.0.0.1:38938               users:(("java",pid=64,fd=269))
ESTAB      0      0      127.0.0.1:38400              127.0.0.1:8080
ESTAB      0      0      127.0.0.1:53278              127.0.0.1:8080
TIME-WAIT  0      0      127.0.0.1:8080               127.0.0.1:44598
ESTAB      0      0      127.0.0.1:42282              127.0.0.1:8080
TIME-WAIT  0      0      127.0.0.1:60982              127.0.0.1:8080
ESTAB      0      0      10.239.206.203:60308              10.234.126.80:8080
ESTAB      0      0      10.239.206.203:47690              10.234.126.80:8080
TIME-WAIT  0      0      127.0.0.1:44094              127.0.0.1:8080
TIME-WAIT  0      0      127.0.0.1:60156              127.0.0.1:8080
ESTAB      0      0      10.239.206.203:48070              10.234.126.80:8080
TIME-WAIT  0      0      127.0.0.1:33100              127.0.0.1:8080
ESTAB      0      0      10.239.206.203:42144              10.239.3.116:8080
TIME-WAIT  0      0      127.0.0.1:32918              127.0.0.1:8080
```

- After fix

```
root@REDUCTED:/# ss -atnp | grep ":8080 "
LISTEN     0      128          *:8080                     *:*                   users:(("java",pid=64,fd=214))
ESTAB      0      0      127.0.0.1:57966              127.0.0.1:8080
ESTAB      0      0      127.0.0.1:8080               127.0.0.1:57966               users:(("java",pid=64,fd=219))
```

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.