### PR TITLE
fix proxy.istio.io/config annotation not setting concurrency option

### DIFF
--- a/pilot/cmd/pilot-agent/config.go
+++ b/pilot/cmd/pilot-agent/config.go
@@ -66,7 +66,7 @@ func constructProxyConfig(role *model.Proxy) (meshconfig.ProxyConfig, error) {
 		if byResources != nil {
 			proxyConfig.Concurrency = byResources
 		}
-	} else {
+	} else if concurrency != 0 && proxyConfig.Concurrency == &types.Int32Value{Value: int32(0)} {
 		proxyConfig.Concurrency = &types.Int32Value{Value: int32(concurrency)}
 	}
 	proxyConfig.ServiceCluster = serviceCluster


### PR DESCRIPTION
this fixes https://github.com/istio/istio/issues/19588#issuecomment-716330991 comment. Which is `proxy.istio.io/config: '{"concurrency" : "XX" }'` not working.
when we use the annotation, that value is always overridden by `concurrency` even when the container doesn't have the concurrency flag, default value 0 overrides the annotation's value.
this is a problem for us because we use istio operator, then we had no way to set the concurrency value for ingress gateways.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[X] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.