### PR TITLE
Allow directly passing an injection template to kube-inject

### DIFF
--- a/istioctl/cmd/add-to-mesh.go
+++ b/istioctl/cmd/add-to-mesh.go
@@ -305,11 +305,11 @@ func setupParameters(sidecarTemplate *inject.Templates, valuesConfig *string) (*
 		if err != nil {
 			return nil, err
 		}
-		injectConfig, err := inject.UnmarshalConfig(injectionConfig)
+		injectConfig, err := readInjectConfigFile(injectionConfig)
 		if err != nil {
 			return nil, multierror.Append(err, fmt.Errorf("loading --injectConfigFile"))
 		}
-		*sidecarTemplate = injectConfig.Templates
+		*sidecarTemplate = injectConfig
 	} else if *sidecarTemplate, err = getInjectConfigFromConfigMap(kubeconfig); err != nil {
 		return nil, err
 	}

--- a/istioctl/cmd/kubeinject.go
+++ b/istioctl/cmd/kubeinject.go
@@ -101,6 +101,20 @@ func getValuesFromConfigMap(kubeconfig string) (string, error) {
 	return valuesData, nil
 }
 
+func readInjectConfigFile(f []byte) (inject.Templates, error) {
+	var injectConfig inject.Config
+	err := yaml.Unmarshal(f, &injectConfig)
+	if err != nil || len(injectConfig.Templates) == 0 && len(injectConfig.Template) == 0 {
+		// This must be a direct template, instead of an inject.Config. We support both formats
+		return map[string]string{inject.SidecarTemplateName: string(f)}, nil
+	}
+	cfg, err := inject.UnmarshalConfig(f)
+	if err != nil {
+		return nil, err
+	}
+	return cfg.Templates, err
+}
+
 func getInjectConfigFromConfigMap(kubeconfig string) (inject.Templates, error) {
 	client, err := createInterface(kubeconfig)
 	if err != nil {
@@ -269,11 +283,11 @@ kube-inject on deployments to get the most up-to-date changes.
 				if err != nil {
 					return err
 				}
-				injectConfig, err := inject.UnmarshalConfig(injectionConfig)
+				injectConfig, err := readInjectConfigFile(injectionConfig)
 				if err != nil {
 					return multierror.Append(err, fmt.Errorf("loading --injectConfigFile"))
 				}
-				sidecarTemplate = injectConfig.Templates
+				sidecarTemplate = injectConfig
 			} else if sidecarTemplate, err = getInjectConfigFromConfigMap(kubeconfig); err != nil {
 				return err
 			}

--- a/istioctl/cmd/kubeinject_test.go
+++ b/istioctl/cmd/kubeinject_test.go
@@ -40,6 +40,14 @@ func TestKubeInject(t *testing.T) {
 				" "),
 			goldenFilename: "testdata/deployment/hello.yaml.injected",
 		},
+		{ // case 3
+			args: strings.Split(
+				"kube-inject --meshConfigFile testdata/mesh-config.yaml"+
+					" --injectConfigFile testdata/inject-config-inline.yaml -f testdata/deployment/hello.yaml"+
+					" --valuesFile testdata/inject-values.yaml",
+				" "),
+			goldenFilename: "testdata/deployment/hello.yaml.injected",
+		},
 	}
 
 	for i, c := range cases {

--- a/istioctl/cmd/testdata/inject-config-inline.yaml
+++ b/istioctl/cmd/testdata/inject-config-inline.yaml
@@ -1,0 +1,7 @@
+spec:
+  initContainers:
+  - name: istio-init
+    image: docker.io/istio/proxy_init:unittest-{{.Values.global.suffix}}
+  containers:
+  - name: istio-proxy
+    image: docker.io/istio/proxy_debug:unittest

--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -202,498 +202,498 @@ data:
     neverInjectSelector:
       []
     injectedAnnotations:
-
-    template: |
-      {{- $containers := list }}
-      {{- range $index, $container := .Spec.Containers }}{{ if not (eq $container.Name "istio-proxy") }}{{ $containers = append $containers $container.Name }}{{end}}{{- end}}
-      metadata:
-        labels:
-          security.istio.io/tlsMode: {{ index .ObjectMeta.Labels `security.istio.io/tlsMode` | default "istio" }}
-          service.istio.io/canonical-name: {{ index .ObjectMeta.Labels `service.istio.io/canonical-name` | default (index .ObjectMeta.Labels `app.kubernetes.io/name`) | default (index .ObjectMeta.Labels `app`) | default .DeploymentMeta.Name }}
-          service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest" }}
-          istio.io/rev: {{ .Revision | default "default" }}
-        annotations: {
-          {{- if eq (len $containers) 1 }}
-          kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
-          {{ end }}
-      {{- if .Values.istio_cni.enabled }}
-          {{- if not .Values.istio_cni.chained }}
-          k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `istio-cni` }}',
-          {{- end }}
-          sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
-          {{ with annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundIPRanges` .Values.global.proxy.includeIPRanges }}traffic.sidecar.istio.io/includeOutboundIPRanges: "{{.}}",{{ end }}
-          {{ with annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundIPRanges` .Values.global.proxy.excludeIPRanges }}traffic.sidecar.istio.io/excludeOutboundIPRanges: "{{.}}",{{ end }}
-          traffic.sidecar.istio.io/includeInboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}",
-          traffic.sidecar.istio.io/excludeInboundPorts: "{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}",
-          {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/includeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.includeOutboundPorts "") "") }}
-          traffic.sidecar.istio.io/includeOutboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundPorts` .Values.global.proxy.includeOutboundPorts }}",
-          {{- end }}
-          {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne .Values.global.proxy.excludeOutboundPorts "") }}
-          traffic.sidecar.istio.io/excludeOutboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}",
-          {{- end }}
-          {{ with index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}traffic.sidecar.istio.io/kubevirtInterfaces: "{{.}}",{{ end }}
-      {{- end }}
-        }
-      spec:
-        {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
-        initContainers:
-        {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-        {{ if .Values.istio_cni.enabled -}}
-        - name: istio-validation
-        {{ else -}}
-        - name: istio-init
-        {{ end -}}
-        {{- if contains "/" .Values.global.proxy_init.image }}
-          image: "{{ .Values.global.proxy_init.image }}"
-        {{- else }}
-          image: "{{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}"
-        {{- end }}
-          args:
-          - istio-iptables
-          - "-p"
-          - "15001"
-          - "-z"
-          - "15006"
-          - "-u"
-          - "1337"
-          - "-m"
-          - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
-          - "-i"
-          - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundIPRanges` .Values.global.proxy.includeIPRanges }}"
-          - "-x"
-          - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundIPRanges` .Values.global.proxy.excludeIPRanges }}"
-          - "-b"
-          - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
-          - "-d"
-        {{- if excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}
-          - "15090,15021,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
-        {{- else }}
-          - "15090,15021"
-        {{- end }}
-          {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/includeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.includeOutboundPorts "") "") -}}
-          - "-q"
-          - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundPorts` .Values.global.proxy.includeOutboundPorts }}"
-          {{ end -}}
-          {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.excludeOutboundPorts "") "") -}}
-          - "-o"
-          - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}"
-          {{ end -}}
-          {{ if (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces`) -}}
-          - "-k"
-          - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
-          {{ end -}}
-          {{ if .Values.istio_cni.enabled -}}
-          - "--run-validation"
-          - "--skip-rule-apply"
-          {{ end -}}
-          imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
-        {{- if .ProxyConfig.ProxyMetadata }}
-          env:
-          {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
-          - name: {{ $key }}
-            value: "{{ $value }}"
-          {{- end }}
-        {{- end }}
-          resources:
-        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-          {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
-            requests:
-              {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-              cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-              {{ end }}
-              {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-              memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
-              {{ end }}
-          {{- end }}
-          {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-            limits:
-              {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-              cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
-              {{ end }}
-              {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-              memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
-              {{ end }}
-          {{- end }}
-        {{- else }}
-          {{- if .Values.global.proxy.resources }}
-            {{ toYaml .Values.global.proxy.resources | indent 6 }}
-          {{- end }}
-        {{- end }}
-          securityContext:
-            allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
-            privileged: {{ .Values.global.proxy.privileged }}
-            capabilities:
-          {{- if not .Values.istio_cni.enabled }}
-              add:
-              - NET_ADMIN
-              - NET_RAW
-          {{- end }}
-              drop:
-              - ALL
-          {{- if not .Values.istio_cni.enabled }}
-            readOnlyRootFilesystem: false
-            runAsGroup: 0
-            runAsNonRoot: false
-            runAsUser: 0
-          {{- else }}
-            readOnlyRootFilesystem: true
-            runAsGroup: 1337
-            runAsUser: 1337
-            runAsNonRoot: true
-          {{- end }}
-          restartPolicy: Always
-        {{ end -}}
-        {{- if eq .Values.global.proxy.enableCoreDump true }}
-        - name: enable-core-dump
-          args:
-          - -c
-          - sysctl -w kernel.core_pattern=/var/lib/istio/data/core.proxy && ulimit -c unlimited
-          command:
-            - /bin/sh
-        {{- if contains "/" .Values.global.proxy_init.image }}
-          image: "{{ .Values.global.proxy_init.image }}"
-        {{- else }}
-          image: "{{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}"
-        {{- end }}
-          imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
-          resources: {}
-          securityContext:
-            allowPrivilegeEscalation: true
-            capabilities:
-              add:
-              - SYS_ADMIN
-              drop:
-              - ALL
-            privileged: true
-            readOnlyRootFilesystem: false
-            runAsGroup: 0
-            runAsNonRoot: false
-            runAsUser: 0
-        {{ end }}
-        containers:
-        - name: istio-proxy
-        {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
-          image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
-        {{- else }}
-          image: "{{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}"
-        {{- end }}
-          ports:
-          - containerPort: 15090
-            protocol: TCP
-            name: http-envoy-prom
-          args:
-          - proxy
-          - sidecar
-          - --domain
-          - $(POD_NAMESPACE).svc.{{ .Values.global.proxy.clusterDomain }}
-          - --serviceCluster
-          {{ if ne "" (index .ObjectMeta.Labels "app") -}}
-          - "{{ index .ObjectMeta.Labels `app` }}.$(POD_NAMESPACE)"
-          {{ else -}}
-          - "{{ valueOrDefault .DeploymentMeta.Name `istio-proxy` }}.{{ valueOrDefault .DeploymentMeta.Namespace `default` }}"
-          {{ end -}}
-          - --proxyLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel}}
-          - --proxyComponentLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel}}
-        {{- if .Values.global.sts.servicePort }}
-          - --stsPort={{ .Values.global.sts.servicePort }}
-        {{- end }}
-        {{- if .Values.global.logAsJson }}
-          - --log_as_json
-        {{- end }}
-        {{- if gt .ProxyConfig.Concurrency.GetValue 0 }}
-          - --concurrency
-          - "{{ .ProxyConfig.Concurrency.GetValue }}"
-        {{- end -}}
-        {{- if .Values.global.proxy.lifecycle }}
-          lifecycle:
-            {{ toYaml .Values.global.proxy.lifecycle | indent 6 }}
-        {{- else if $holdProxy }}
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                - pilot-agent
-                - wait
-        {{- end }}
-          env:
-          - name: JWT_POLICY
-            value: {{ .Values.global.jwtPolicy }}
-          - name: PILOT_CERT_PROVIDER
-            value: {{ .Values.global.pilotCertProvider }}
-          - name: CA_ADDR
-          {{- if .Values.global.caAddress }}
-            value: {{ .Values.global.caAddress }}
-          {{- else }}
-            value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
-          {{- end }}
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: INSTANCE_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
-          - name: SERVICE_ACCOUNT
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.serviceAccountName
-          - name: HOST_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.hostIP
-          - name: CANONICAL_SERVICE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.labels['service.istio.io/canonical-name']
-          - name: CANONICAL_REVISION
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.labels['service.istio.io/canonical-revision']
-          - name: PROXY_CONFIG
-            value: |
-                   {{ protoToJSON .ProxyConfig }}
-          - name: ISTIO_META_POD_PORTS
-            value: |-
-              [
-              {{- $first := true }}
-              {{- range $index1, $c := .Spec.Containers }}
-                {{- range $index2, $p := $c.Ports }}
-                  {{- if (structToJSON $p) }}
-                  {{if not $first}},{{end}}{{ structToJSON $p }}
-                  {{- $first = false }}
-                  {{- end }}
-                {{- end}}
-              {{- end}}
-              ]
-          - name: ISTIO_META_APP_CONTAINERS
-            value: "{{ $containers | join "," }}"
-          - name: ISTIO_META_CLUSTER_ID
-            value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
-          - name: ISTIO_META_INTERCEPTION_MODE
-            value: "{{ or (index .ObjectMeta.Annotations `sidecar.istio.io/interceptionMode`) .ProxyConfig.InterceptionMode.String }}"
-          {{- if .Values.global.network }}
-          - name: ISTIO_META_NETWORK
-            value: "{{ .Values.global.network }}"
-          {{- end }}
-          {{ if .ObjectMeta.Annotations }}
-          - name: ISTIO_METAJSON_ANNOTATIONS
-            value: |
-                   {{ toJSON .ObjectMeta.Annotations }}
-          {{ end }}
-          {{- if .DeploymentMeta.Name }}
-          - name: ISTIO_META_WORKLOAD_NAME
-            value: "{{ .DeploymentMeta.Name }}"
-          {{ end }}
-          {{- if and .TypeMeta.APIVersion .DeploymentMeta.Name }}
-          - name: ISTIO_META_OWNER
-            value: kubernetes://apis/{{ .TypeMeta.APIVersion }}/namespaces/{{ valueOrDefault .DeploymentMeta.Namespace `default` }}/{{ toLower .TypeMeta.Kind}}s/{{ .DeploymentMeta.Name }}
-          {{- end}}
-          {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
-          - name: ISTIO_BOOTSTRAP_OVERRIDE
-            value: "/etc/istio/custom-bootstrap/custom_bootstrap.json"
-          {{- end }}
-          {{- if .Values.global.meshID }}
-          - name: ISTIO_META_MESH_ID
-            value: "{{ .Values.global.meshID }}"
-          {{- else if (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}
-          - name: ISTIO_META_MESH_ID
-            value: "{{ (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}"
-          {{- end }}
-          {{- with (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain)  }}
-          - name: TRUST_DOMAIN
-            value: "{{ . }}"
-          {{- end }}
-          {{- if and (eq .Values.global.proxy.tracer "datadog") (isset .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}
-          {{- range $key, $value := fromJSON (index .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}
-          - name: {{ $key }}
-            value: "{{ $value }}"
-          {{- end }}
-          {{- end }}
-          {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
-          - name: {{ $key }}
-            value: "{{ $value }}"
-          {{- end }}
-          imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
-          {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
-          readinessProbe:
-            httpGet:
-              path: /healthz/ready
-              port: 15021
-            initialDelaySeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/initialDelaySeconds` .Values.global.proxy.readinessInitialDelaySeconds }}
-            periodSeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/periodSeconds` .Values.global.proxy.readinessPeriodSeconds }}
-            timeoutSeconds: 3
-            failureThreshold: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/failureThreshold` .Values.global.proxy.readinessFailureThreshold }}
-          {{ end -}}
-          securityContext:
-            allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
-            capabilities:
-              {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
-              add:
-              {{ if eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY` -}}
-              - NET_ADMIN
-              {{- end }}
-              {{ if eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true` -}}
-              - NET_BIND_SERVICE
-              {{- end }}
-              {{- end }}
-              drop:
-              - ALL
-            privileged: {{ .Values.global.proxy.privileged }}
-            readOnlyRootFilesystem: {{ not .Values.global.proxy.enableCoreDump }}
-            runAsGroup: 1337
-            fsGroup: 1337
-            {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
-            runAsNonRoot: false
-            runAsUser: 0
-            {{- else -}}
-            runAsNonRoot: true
-            runAsUser: 1337
+    templates:
+      sidecar: |
+        {{- $containers := list }}
+        {{- range $index, $container := .Spec.Containers }}{{ if not (eq $container.Name "istio-proxy") }}{{ $containers = append $containers $container.Name }}{{end}}{{- end}}
+        metadata:
+          labels:
+            security.istio.io/tlsMode: {{ index .ObjectMeta.Labels `security.istio.io/tlsMode` | default "istio" }}
+            service.istio.io/canonical-name: {{ index .ObjectMeta.Labels `service.istio.io/canonical-name` | default (index .ObjectMeta.Labels `app.kubernetes.io/name`) | default (index .ObjectMeta.Labels `app`) | default .DeploymentMeta.Name }}
+            service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest" }}
+            istio.io/rev: {{ .Revision | default "default" }}
+          annotations: {
+            {{- if eq (len $containers) 1 }}
+            kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
+            {{ end }}
+        {{- if .Values.istio_cni.enabled }}
+            {{- if not .Values.istio_cni.chained }}
+            k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `istio-cni` }}',
             {{- end }}
-          resources:
-        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-          {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
-            requests:
-              {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-              cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-              {{ end }}
-              {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-              memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
-              {{ end }}
-          {{- end }}
-          {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-            limits:
-              {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-              cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
-              {{ end }}
-              {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-              memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
-              {{ end }}
-          {{- end }}
-        {{- else }}
-          {{- if .Values.global.proxy.resources }}
-            {{ toYaml .Values.global.proxy.resources | indent 6 }}
-          {{- end }}
+            sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
+            {{ with annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundIPRanges` .Values.global.proxy.includeIPRanges }}traffic.sidecar.istio.io/includeOutboundIPRanges: "{{.}}",{{ end }}
+            {{ with annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundIPRanges` .Values.global.proxy.excludeIPRanges }}traffic.sidecar.istio.io/excludeOutboundIPRanges: "{{.}}",{{ end }}
+            traffic.sidecar.istio.io/includeInboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}",
+            traffic.sidecar.istio.io/excludeInboundPorts: "{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}",
+            {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/includeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.includeOutboundPorts "") "") }}
+            traffic.sidecar.istio.io/includeOutboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundPorts` .Values.global.proxy.includeOutboundPorts }}",
+            {{- end }}
+            {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne .Values.global.proxy.excludeOutboundPorts "") }}
+            traffic.sidecar.istio.io/excludeOutboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}",
+            {{- end }}
+            {{ with index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}traffic.sidecar.istio.io/kubevirtInterfaces: "{{.}}",{{ end }}
         {{- end }}
-          volumeMounts:
-          {{- if eq .Values.global.pilotCertProvider "istiod" }}
-          - mountPath: /var/run/secrets/istio
-            name: istiod-ca-cert
+          }
+        spec:
+          {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
+          initContainers:
+          {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
+          {{ if .Values.istio_cni.enabled -}}
+          - name: istio-validation
+          {{ else -}}
+          - name: istio-init
+          {{ end -}}
+          {{- if contains "/" .Values.global.proxy_init.image }}
+            image: "{{ .Values.global.proxy_init.image }}"
+          {{- else }}
+            image: "{{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}"
           {{- end }}
-          - mountPath: /var/lib/istio/data
-            name: istio-data
-          {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
-          - mountPath: /etc/istio/custom-bootstrap
-            name: custom-bootstrap-volume
+            args:
+            - istio-iptables
+            - "-p"
+            - "15001"
+            - "-z"
+            - "15006"
+            - "-u"
+            - "1337"
+            - "-m"
+            - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
+            - "-i"
+            - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundIPRanges` .Values.global.proxy.includeIPRanges }}"
+            - "-x"
+            - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundIPRanges` .Values.global.proxy.excludeIPRanges }}"
+            - "-b"
+            - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
+            - "-d"
+          {{- if excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}
+            - "15090,15021,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
+          {{- else }}
+            - "15090,15021"
+          {{- end }}
+            {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/includeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.includeOutboundPorts "") "") -}}
+            - "-q"
+            - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundPorts` .Values.global.proxy.includeOutboundPorts }}"
+            {{ end -}}
+            {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.excludeOutboundPorts "") "") -}}
+            - "-o"
+            - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}"
+            {{ end -}}
+            {{ if (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces`) -}}
+            - "-k"
+            - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
+            {{ end -}}
+            {{ if .Values.istio_cni.enabled -}}
+            - "--run-validation"
+            - "--skip-rule-apply"
+            {{ end -}}
+            imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
+          {{- if .ProxyConfig.ProxyMetadata }}
+            env:
+            {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+            {{- end }}
+          {{- end }}
+            resources:
+          {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+            {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+              requests:
+                {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
+                cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+                {{ end }}
+                {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
+                memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+                {{ end }}
+            {{- end }}
+            {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+              limits:
+                {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
+                cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+                {{ end }}
+                {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
+                memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+                {{ end }}
+            {{- end }}
+          {{- else }}
+            {{- if .Values.global.proxy.resources }}
+              {{ toYaml .Values.global.proxy.resources | indent 6 }}
+            {{- end }}
+          {{- end }}
+            securityContext:
+              allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
+              privileged: {{ .Values.global.proxy.privileged }}
+              capabilities:
+            {{- if not .Values.istio_cni.enabled }}
+                add:
+                - NET_ADMIN
+                - NET_RAW
+            {{- end }}
+                drop:
+                - ALL
+            {{- if not .Values.istio_cni.enabled }}
+              readOnlyRootFilesystem: false
+              runAsGroup: 0
+              runAsNonRoot: false
+              runAsUser: 0
+            {{- else }}
+              readOnlyRootFilesystem: true
+              runAsGroup: 1337
+              runAsUser: 1337
+              runAsNonRoot: true
+            {{- end }}
+            restartPolicy: Always
+          {{ end -}}
+          {{- if eq .Values.global.proxy.enableCoreDump true }}
+          - name: enable-core-dump
+            args:
+            - -c
+            - sysctl -w kernel.core_pattern=/var/lib/istio/data/core.proxy && ulimit -c unlimited
+            command:
+              - /bin/sh
+          {{- if contains "/" .Values.global.proxy_init.image }}
+            image: "{{ .Values.global.proxy_init.image }}"
+          {{- else }}
+            image: "{{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}"
+          {{- end }}
+            imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
+            resources: {}
+            securityContext:
+              allowPrivilegeEscalation: true
+              capabilities:
+                add:
+                - SYS_ADMIN
+                drop:
+                - ALL
+              privileged: true
+              readOnlyRootFilesystem: false
+              runAsGroup: 0
+              runAsNonRoot: false
+              runAsUser: 0
+          {{ end }}
+          containers:
+          - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
+            image: "{{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}"
+          {{- end }}
+            ports:
+            - containerPort: 15090
+              protocol: TCP
+              name: http-envoy-prom
+            args:
+            - proxy
+            - sidecar
+            - --domain
+            - $(POD_NAMESPACE).svc.{{ .Values.global.proxy.clusterDomain }}
+            - --serviceCluster
+            {{ if ne "" (index .ObjectMeta.Labels "app") -}}
+            - "{{ index .ObjectMeta.Labels `app` }}.$(POD_NAMESPACE)"
+            {{ else -}}
+            - "{{ valueOrDefault .DeploymentMeta.Name `istio-proxy` }}.{{ valueOrDefault .DeploymentMeta.Namespace `default` }}"
+            {{ end -}}
+            - --proxyLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel}}
+            - --proxyComponentLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel}}
+          {{- if .Values.global.sts.servicePort }}
+            - --stsPort={{ .Values.global.sts.servicePort }}
+          {{- end }}
+          {{- if .Values.global.logAsJson }}
+            - --log_as_json
+          {{- end }}
+          {{- if gt .ProxyConfig.Concurrency.GetValue 0 }}
+            - --concurrency
+            - "{{ .ProxyConfig.Concurrency.GetValue }}"
+          {{- end -}}
+          {{- if .Values.global.proxy.lifecycle }}
+            lifecycle:
+              {{ toYaml .Values.global.proxy.lifecycle | indent 6 }}
+          {{- else if $holdProxy }}
+            lifecycle:
+              postStart:
+                exec:
+                  command:
+                  - pilot-agent
+                  - wait
+          {{- end }}
+            env:
+            - name: JWT_POLICY
+              value: {{ .Values.global.jwtPolicy }}
+            - name: PILOT_CERT_PROVIDER
+              value: {{ .Values.global.pilotCertProvider }}
+            - name: CA_ADDR
+            {{- if .Values.global.caAddress }}
+              value: {{ .Values.global.caAddress }}
+            {{- else }}
+              value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
+            {{- end }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: INSTANCE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: CANONICAL_SERVICE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['service.istio.io/canonical-name']
+            - name: CANONICAL_REVISION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['service.istio.io/canonical-revision']
+            - name: PROXY_CONFIG
+              value: |
+                     {{ protoToJSON .ProxyConfig }}
+            - name: ISTIO_META_POD_PORTS
+              value: |-
+                [
+                {{- $first := true }}
+                {{- range $index1, $c := .Spec.Containers }}
+                  {{- range $index2, $p := $c.Ports }}
+                    {{- if (structToJSON $p) }}
+                    {{if not $first}},{{end}}{{ structToJSON $p }}
+                    {{- $first = false }}
+                    {{- end }}
+                  {{- end}}
+                {{- end}}
+                ]
+            - name: ISTIO_META_APP_CONTAINERS
+              value: "{{ $containers | join "," }}"
+            - name: ISTIO_META_CLUSTER_ID
+              value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
+            - name: ISTIO_META_INTERCEPTION_MODE
+              value: "{{ or (index .ObjectMeta.Annotations `sidecar.istio.io/interceptionMode`) .ProxyConfig.InterceptionMode.String }}"
+            {{- if .Values.global.network }}
+            - name: ISTIO_META_NETWORK
+              value: "{{ .Values.global.network }}"
+            {{- end }}
+            {{ if .ObjectMeta.Annotations }}
+            - name: ISTIO_METAJSON_ANNOTATIONS
+              value: |
+                     {{ toJSON .ObjectMeta.Annotations }}
+            {{ end }}
+            {{- if .DeploymentMeta.Name }}
+            - name: ISTIO_META_WORKLOAD_NAME
+              value: "{{ .DeploymentMeta.Name }}"
+            {{ end }}
+            {{- if and .TypeMeta.APIVersion .DeploymentMeta.Name }}
+            - name: ISTIO_META_OWNER
+              value: kubernetes://apis/{{ .TypeMeta.APIVersion }}/namespaces/{{ valueOrDefault .DeploymentMeta.Namespace `default` }}/{{ toLower .TypeMeta.Kind}}s/{{ .DeploymentMeta.Name }}
+            {{- end}}
+            {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
+            - name: ISTIO_BOOTSTRAP_OVERRIDE
+              value: "/etc/istio/custom-bootstrap/custom_bootstrap.json"
+            {{- end }}
+            {{- if .Values.global.meshID }}
+            - name: ISTIO_META_MESH_ID
+              value: "{{ .Values.global.meshID }}"
+            {{- else if (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}
+            - name: ISTIO_META_MESH_ID
+              value: "{{ (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}"
+            {{- end }}
+            {{- with (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain)  }}
+            - name: TRUST_DOMAIN
+              value: "{{ . }}"
+            {{- end }}
+            {{- if and (eq .Values.global.proxy.tracer "datadog") (isset .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}
+            {{- range $key, $value := fromJSON (index .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+            {{- end }}
+            {{- end }}
+            {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+            {{- end }}
+            imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
+            {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
+            readinessProbe:
+              httpGet:
+                path: /healthz/ready
+                port: 15021
+              initialDelaySeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/initialDelaySeconds` .Values.global.proxy.readinessInitialDelaySeconds }}
+              periodSeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/periodSeconds` .Values.global.proxy.readinessPeriodSeconds }}
+              timeoutSeconds: 3
+              failureThreshold: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/failureThreshold` .Values.global.proxy.readinessFailureThreshold }}
+            {{ end -}}
+            securityContext:
+              allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
+              capabilities:
+                {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
+                add:
+                {{ if eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY` -}}
+                - NET_ADMIN
+                {{- end }}
+                {{ if eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true` -}}
+                - NET_BIND_SERVICE
+                {{- end }}
+                {{- end }}
+                drop:
+                - ALL
+              privileged: {{ .Values.global.proxy.privileged }}
+              readOnlyRootFilesystem: {{ not .Values.global.proxy.enableCoreDump }}
+              runAsGroup: 1337
+              fsGroup: 1337
+              {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
+              runAsNonRoot: false
+              runAsUser: 0
+              {{- else -}}
+              runAsNonRoot: true
+              runAsUser: 1337
+              {{- end }}
+            resources:
+          {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+            {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+              requests:
+                {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
+                cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+                {{ end }}
+                {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
+                memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+                {{ end }}
+            {{- end }}
+            {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+              limits:
+                {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
+                cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+                {{ end }}
+                {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
+                memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+                {{ end }}
+            {{- end }}
+          {{- else }}
+            {{- if .Values.global.proxy.resources }}
+              {{ toYaml .Values.global.proxy.resources | indent 6 }}
+            {{- end }}
+          {{- end }}
+            volumeMounts:
+            {{- if eq .Values.global.pilotCertProvider "istiod" }}
+            - mountPath: /var/run/secrets/istio
+              name: istiod-ca-cert
+            {{- end }}
+            - mountPath: /var/lib/istio/data
+              name: istio-data
+            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
+            - mountPath: /etc/istio/custom-bootstrap
+              name: custom-bootstrap-volume
+            {{- end }}
+            # SDS channel between istioagent and Envoy
+            - mountPath: /etc/istio/proxy
+              name: istio-envoy
+            {{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
+            - mountPath: /var/run/secrets/tokens
+              name: istio-token
+            {{- end }}
+            {{- if .Values.global.mountMtlsCerts }}
+            # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.
+            - mountPath: /etc/certs/
+              name: istio-certs
+              readOnly: true
+            {{- end }}
+            - name: istio-podinfo
+              mountPath: /etc/istio/pod
+             {{- if and (eq .Values.global.proxy.tracer "lightstep") .ProxyConfig.GetTracing.GetTlsSettings }}
+            - mountPath: {{ directory .ProxyConfig.GetTracing.GetTlsSettings.GetCaCertificates }}
+              name: lightstep-certs
+              readOnly: true
+            {{- end }}
+              {{- if isset .ObjectMeta.Annotations `sidecar.istio.io/userVolumeMount` }}
+              {{ range $index, $value := fromJSON (index .ObjectMeta.Annotations `sidecar.istio.io/userVolumeMount`) }}
+            - name: "{{  $index }}"
+              {{ toYaml $value | indent 6 }}
+              {{ end }}
+              {{- end }}
+          volumes:
+          {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
+          - name: custom-bootstrap-volume
+            configMap:
+              name: {{ annotation .ObjectMeta `sidecar.istio.io/bootstrapOverride` "" }}
           {{- end }}
           # SDS channel between istioagent and Envoy
-          - mountPath: /etc/istio/proxy
+          - emptyDir:
+              medium: Memory
             name: istio-envoy
+          - name: istio-data
+            emptyDir: {}
+          - name: istio-podinfo
+            downwardAPI:
+              items:
+                - path: "labels"
+                  fieldRef:
+                    fieldPath: metadata.labels
+                - path: "annotations"
+                  fieldRef:
+                    fieldPath: metadata.annotations
+                - path: "cpu-limit"
+                  resourceFieldRef:
+                    containerName: istio-proxy
+                    resource: limits.cpu
+                    divisor: 1m
+                - path: "cpu-request"
+                  resourceFieldRef:
+                    containerName: istio-proxy
+                    resource: requests.cpu
+                    divisor: 1m
           {{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
-          - mountPath: /var/run/secrets/tokens
-            name: istio-token
+          - name: istio-token
+            projected:
+              sources:
+              - serviceAccountToken:
+                  path: istio-token
+                  expirationSeconds: 43200
+                  audience: {{ .Values.global.sds.token.aud }}
+          {{- end }}
+          {{- if eq .Values.global.pilotCertProvider "istiod" }}
+          - name: istiod-ca-cert
+            configMap:
+              name: istio-ca-root-cert
           {{- end }}
           {{- if .Values.global.mountMtlsCerts }}
           # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.
-          - mountPath: /etc/certs/
-            name: istio-certs
-            readOnly: true
+          - name: istio-certs
+            secret:
+              optional: true
+              {{ if eq .Spec.ServiceAccountName "" }}
+              secretName: istio.default
+              {{ else -}}
+              secretName: {{  printf "istio.%s" .Spec.ServiceAccountName }}
+              {{  end -}}
           {{- end }}
-          - name: istio-podinfo
-            mountPath: /etc/istio/pod
-           {{- if and (eq .Values.global.proxy.tracer "lightstep") .ProxyConfig.GetTracing.GetTlsSettings }}
-          - mountPath: {{ directory .ProxyConfig.GetTracing.GetTlsSettings.GetCaCertificates }}
-            name: lightstep-certs
-            readOnly: true
-          {{- end }}
-            {{- if isset .ObjectMeta.Annotations `sidecar.istio.io/userVolumeMount` }}
-            {{ range $index, $value := fromJSON (index .ObjectMeta.Annotations `sidecar.istio.io/userVolumeMount`) }}
-          - name: "{{  $index }}"
-            {{ toYaml $value | indent 6 }}
+            {{- if isset .ObjectMeta.Annotations `sidecar.istio.io/userVolume` }}
+            {{range $index, $value := fromJSON (index .ObjectMeta.Annotations `sidecar.istio.io/userVolume`) }}
+          - name: "{{ $index }}"
+            {{ toYaml $value | indent 4 }}
             {{ end }}
-            {{- end }}
-        volumes:
-        {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
-        - name: custom-bootstrap-volume
-          configMap:
-            name: {{ annotation .ObjectMeta `sidecar.istio.io/bootstrapOverride` "" }}
-        {{- end }}
-        # SDS channel between istioagent and Envoy
-        - emptyDir:
-            medium: Memory
-          name: istio-envoy
-        - name: istio-data
-          emptyDir: {}
-        - name: istio-podinfo
-          downwardAPI:
-            items:
-              - path: "labels"
-                fieldRef:
-                  fieldPath: metadata.labels
-              - path: "annotations"
-                fieldRef:
-                  fieldPath: metadata.annotations
-              - path: "cpu-limit"
-                resourceFieldRef:
-                  containerName: istio-proxy
-                  resource: limits.cpu
-                  divisor: 1m
-              - path: "cpu-request"
-                resourceFieldRef:
-                  containerName: istio-proxy
-                  resource: requests.cpu
-                  divisor: 1m
-        {{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
-        - name: istio-token
-          projected:
-            sources:
-            - serviceAccountToken:
-                path: istio-token
-                expirationSeconds: 43200
-                audience: {{ .Values.global.sds.token.aud }}
-        {{- end }}
-        {{- if eq .Values.global.pilotCertProvider "istiod" }}
-        - name: istiod-ca-cert
-          configMap:
-            name: istio-ca-root-cert
-        {{- end }}
-        {{- if .Values.global.mountMtlsCerts }}
-        # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.
-        - name: istio-certs
-          secret:
-            optional: true
-            {{ if eq .Spec.ServiceAccountName "" }}
-            secretName: istio.default
-            {{ else -}}
-            secretName: {{  printf "istio.%s" .Spec.ServiceAccountName }}
-            {{  end -}}
-        {{- end }}
-          {{- if isset .ObjectMeta.Annotations `sidecar.istio.io/userVolume` }}
-          {{range $index, $value := fromJSON (index .ObjectMeta.Annotations `sidecar.istio.io/userVolume`) }}
-        - name: "{{ $index }}"
-          {{ toYaml $value | indent 4 }}
-          {{ end }}
-          {{ end }}
-        {{- if and (eq .Values.global.proxy.tracer "lightstep") .ProxyConfig.GetTracing.GetTlsSettings }}
-        - name: lightstep-certs
-          secret:
-            optional: true
-            secretName: lightstep.cacert
-        {{- end }}
-        {{- if .Values.global.imagePullSecrets }}
-        imagePullSecrets:
-          {{- range .Values.global.imagePullSecrets }}
-          - name: {{ . }}
+            {{ end }}
+          {{- if and (eq .Values.global.proxy.tracer "lightstep") .ProxyConfig.GetTracing.GetTlsSettings }}
+          - name: lightstep-certs
+            secret:
+              optional: true
+              secretName: lightstep.cacert
           {{- end }}
-        {{- end }}
-        {{- if eq (env "ENABLE_LEGACY_FSGROUP_INJECTION" "true") "true" }}
-        securityContext:
-          fsGroup: 1337
-        {{- end }}
+          {{- if .Values.global.imagePullSecrets }}
+          imagePullSecrets:
+            {{- range .Values.global.imagePullSecrets }}
+            - name: {{ . }}
+            {{- end }}
+          {{- end }}
+          {{- if eq (env "ENABLE_LEGACY_FSGROUP_INJECTION" "true") "true" }}
+          securityContext:
+            fsGroup: 1337
+          {{- end }}
 ---
 # Source: istio-discovery/templates/service.yaml
 apiVersion: v1

--- a/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/injection-template.yaml
@@ -1,491 +1,490 @@
-template: |
-  {{- $containers := list }}
-  {{- range $index, $container := .Spec.Containers }}{{ if not (eq $container.Name "istio-proxy") }}{{ $containers = append $containers $container.Name }}{{end}}{{- end}}
-  metadata:
-    labels:
-      security.istio.io/tlsMode: {{ index .ObjectMeta.Labels `security.istio.io/tlsMode` | default "istio" }}
-      service.istio.io/canonical-name: {{ index .ObjectMeta.Labels `service.istio.io/canonical-name` | default (index .ObjectMeta.Labels `app.kubernetes.io/name`) | default (index .ObjectMeta.Labels `app`) | default .DeploymentMeta.Name }}
-      service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest" }}
-      istio.io/rev: {{ .Revision | default "default" }}
-    annotations: {
-      {{- if eq (len $containers) 1 }}
-      kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
-      {{ end }}
-  {{- if .Values.istio_cni.enabled }}
-      {{- if not .Values.istio_cni.chained }}
-      k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `istio-cni` }}',
-      {{- end }}
-      sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
-      {{ with annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundIPRanges` .Values.global.proxy.includeIPRanges }}traffic.sidecar.istio.io/includeOutboundIPRanges: "{{.}}",{{ end }}
-      {{ with annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundIPRanges` .Values.global.proxy.excludeIPRanges }}traffic.sidecar.istio.io/excludeOutboundIPRanges: "{{.}}",{{ end }}
-      traffic.sidecar.istio.io/includeInboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}",
-      traffic.sidecar.istio.io/excludeInboundPorts: "{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}",
-      {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/includeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.includeOutboundPorts "") "") }}
-      traffic.sidecar.istio.io/includeOutboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundPorts` .Values.global.proxy.includeOutboundPorts }}",
-      {{- end }}
-      {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne .Values.global.proxy.excludeOutboundPorts "") }}
-      traffic.sidecar.istio.io/excludeOutboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}",
-      {{- end }}
-      {{ with index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}traffic.sidecar.istio.io/kubevirtInterfaces: "{{.}}",{{ end }}
-  {{- end }}
-    }
-  spec:
-    {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
-    initContainers:
-    {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-    {{ if .Values.istio_cni.enabled -}}
-    - name: istio-validation
-    {{ else -}}
-    - name: istio-init
-    {{ end -}}
-    {{- if contains "/" .Values.global.proxy_init.image }}
-      image: "{{ .Values.global.proxy_init.image }}"
-    {{- else }}
-      image: "{{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}"
-    {{- end }}
-      args:
-      - istio-iptables
-      - "-p"
-      - "15001"
-      - "-z"
-      - "15006"
-      - "-u"
-      - "1337"
-      - "-m"
-      - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
-      - "-i"
-      - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundIPRanges` .Values.global.proxy.includeIPRanges }}"
-      - "-x"
-      - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundIPRanges` .Values.global.proxy.excludeIPRanges }}"
-      - "-b"
-      - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
-      - "-d"
-    {{- if excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}
-      - "15090,15021,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
-    {{- else }}
-      - "15090,15021"
-    {{- end }}
-      {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/includeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.includeOutboundPorts "") "") -}}
-      - "-q"
-      - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundPorts` .Values.global.proxy.includeOutboundPorts }}"
-      {{ end -}}
-      {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.excludeOutboundPorts "") "") -}}
-      - "-o"
-      - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}"
-      {{ end -}}
-      {{ if (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces`) -}}
-      - "-k"
-      - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
-      {{ end -}}
-      {{ if .Values.istio_cni.enabled -}}
-      - "--run-validation"
-      - "--skip-rule-apply"
-      {{ end -}}
-      imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
-    {{- if .ProxyConfig.ProxyMetadata }}
-      env:
-      {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
-      - name: {{ $key }}
-        value: "{{ $value }}"
-      {{- end }}
-    {{- end }}
-      resources:
-    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-      {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
-        requests:
-          {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-          cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-          {{ end }}
-          {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-          memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
-          {{ end }}
-      {{- end }}
-      {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-        limits:
-          {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-          cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
-          {{ end }}
-          {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-          memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
-          {{ end }}
-      {{- end }}
-    {{- else }}
-      {{- if .Values.global.proxy.resources }}
-        {{ toYaml .Values.global.proxy.resources | indent 6 }}
-      {{- end }}
-    {{- end }}
-      securityContext:
-        allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
-        privileged: {{ .Values.global.proxy.privileged }}
-        capabilities:
-      {{- if not .Values.istio_cni.enabled }}
-          add:
-          - NET_ADMIN
-          - NET_RAW
-      {{- end }}
-          drop:
-          - ALL
-      {{- if not .Values.istio_cni.enabled }}
-        readOnlyRootFilesystem: false
-        runAsGroup: 0
-        runAsNonRoot: false
-        runAsUser: 0
-      {{- else }}
-        readOnlyRootFilesystem: true
-        runAsGroup: 1337
-        runAsUser: 1337
-        runAsNonRoot: true
-      {{- end }}
-      restartPolicy: Always
-    {{ end -}}
-    {{- if eq .Values.global.proxy.enableCoreDump true }}
-    - name: enable-core-dump
-      args:
-      - -c
-      - sysctl -w kernel.core_pattern=/var/lib/istio/data/core.proxy && ulimit -c unlimited
-      command:
-        - /bin/sh
-    {{- if contains "/" .Values.global.proxy_init.image }}
-      image: "{{ .Values.global.proxy_init.image }}"
-    {{- else }}
-      image: "{{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}"
-    {{- end }}
-      imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
-      resources: {}
-      securityContext:
-        allowPrivilegeEscalation: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-          drop:
-          - ALL
-        privileged: true
-        readOnlyRootFilesystem: false
-        runAsGroup: 0
-        runAsNonRoot: false
-        runAsUser: 0
+ {{- $containers := list }}
+{{- range $index, $container := .Spec.Containers }}{{ if not (eq $container.Name "istio-proxy") }}{{ $containers = append $containers $container.Name }}{{end}}{{- end}}
+metadata:
+  labels:
+    security.istio.io/tlsMode: {{ index .ObjectMeta.Labels `security.istio.io/tlsMode` | default "istio" }}
+    service.istio.io/canonical-name: {{ index .ObjectMeta.Labels `service.istio.io/canonical-name` | default (index .ObjectMeta.Labels `app.kubernetes.io/name`) | default (index .ObjectMeta.Labels `app`) | default .DeploymentMeta.Name }}
+    service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest" }}
+    istio.io/rev: {{ .Revision | default "default" }}
+  annotations: {
+    {{- if eq (len $containers) 1 }}
+    kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
     {{ end }}
-    containers:
-    - name: istio-proxy
-    {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
-      image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
-    {{- else }}
-      image: "{{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}"
+{{- if .Values.istio_cni.enabled }}
+    {{- if not .Values.istio_cni.chained }}
+    k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `istio-cni` }}',
     {{- end }}
-      ports:
-      - containerPort: 15090
-        protocol: TCP
-        name: http-envoy-prom
-      args:
-      - proxy
-      - sidecar
-      - --domain
-      - $(POD_NAMESPACE).svc.{{ .Values.global.proxy.clusterDomain }}
-      - --serviceCluster
-      {{ if ne "" (index .ObjectMeta.Labels "app") -}}
-      - "{{ index .ObjectMeta.Labels `app` }}.$(POD_NAMESPACE)"
-      {{ else -}}
-      - "{{ valueOrDefault .DeploymentMeta.Name `istio-proxy` }}.{{ valueOrDefault .DeploymentMeta.Namespace `default` }}"
-      {{ end -}}
-      - --proxyLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel}}
-      - --proxyComponentLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel}}
-    {{- if .Values.global.sts.servicePort }}
-      - --stsPort={{ .Values.global.sts.servicePort }}
+    sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
+    {{ with annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundIPRanges` .Values.global.proxy.includeIPRanges }}traffic.sidecar.istio.io/includeOutboundIPRanges: "{{.}}",{{ end }}
+    {{ with annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundIPRanges` .Values.global.proxy.excludeIPRanges }}traffic.sidecar.istio.io/excludeOutboundIPRanges: "{{.}}",{{ end }}
+    traffic.sidecar.istio.io/includeInboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}",
+    traffic.sidecar.istio.io/excludeInboundPorts: "{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}",
+    {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/includeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.includeOutboundPorts "") "") }}
+    traffic.sidecar.istio.io/includeOutboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundPorts` .Values.global.proxy.includeOutboundPorts }}",
     {{- end }}
-    {{- if .Values.global.logAsJson }}
-      - --log_as_json
+    {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne .Values.global.proxy.excludeOutboundPorts "") }}
+    traffic.sidecar.istio.io/excludeOutboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}",
     {{- end }}
-    {{- if gt .ProxyConfig.Concurrency.GetValue 0 }}
-      - --concurrency
-      - "{{ .ProxyConfig.Concurrency.GetValue }}"
-    {{- end -}}
-    {{- if .Values.global.proxy.lifecycle }}
-      lifecycle:
-        {{ toYaml .Values.global.proxy.lifecycle | indent 6 }}
-    {{- else if $holdProxy }}
-      lifecycle:
-        postStart:
-          exec:
-            command:
-            - pilot-agent
-            - wait
+    {{ with index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}traffic.sidecar.istio.io/kubevirtInterfaces: "{{.}}",{{ end }}
+{{- end }}
+  }
+spec:
+  {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
+  initContainers:
+  {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
+  {{ if .Values.istio_cni.enabled -}}
+  - name: istio-validation
+  {{ else -}}
+  - name: istio-init
+  {{ end -}}
+  {{- if contains "/" .Values.global.proxy_init.image }}
+    image: "{{ .Values.global.proxy_init.image }}"
+  {{- else }}
+    image: "{{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}"
+  {{- end }}
+    args:
+    - istio-iptables
+    - "-p"
+    - "15001"
+    - "-z"
+    - "15006"
+    - "-u"
+    - "1337"
+    - "-m"
+    - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
+    - "-i"
+    - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundIPRanges` .Values.global.proxy.includeIPRanges }}"
+    - "-x"
+    - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundIPRanges` .Values.global.proxy.excludeIPRanges }}"
+    - "-b"
+    - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
+    - "-d"
+  {{- if excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}
+    - "15090,15021,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
+  {{- else }}
+    - "15090,15021"
+  {{- end }}
+    {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/includeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.includeOutboundPorts "") "") -}}
+    - "-q"
+    - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundPorts` .Values.global.proxy.includeOutboundPorts }}"
+    {{ end -}}
+    {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.excludeOutboundPorts "") "") -}}
+    - "-o"
+    - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}"
+    {{ end -}}
+    {{ if (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces`) -}}
+    - "-k"
+    - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
+    {{ end -}}
+    {{ if .Values.istio_cni.enabled -}}
+    - "--run-validation"
+    - "--skip-rule-apply"
+    {{ end -}}
+    imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
+  {{- if .ProxyConfig.ProxyMetadata }}
+    env:
+    {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+    - name: {{ $key }}
+      value: "{{ $value }}"
     {{- end }}
-      env:
-      - name: JWT_POLICY
-        value: {{ .Values.global.jwtPolicy }}
-      - name: PILOT_CERT_PROVIDER
-        value: {{ .Values.global.pilotCertProvider }}
-      - name: CA_ADDR
-      {{- if .Values.global.caAddress }}
-        value: {{ .Values.global.caAddress }}
-      {{- else }}
-        value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
-      {{- end }}
-      - name: POD_NAME
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.name
-      - name: POD_NAMESPACE
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.namespace
-      - name: INSTANCE_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      - name: SERVICE_ACCOUNT
-        valueFrom:
-          fieldRef:
-            fieldPath: spec.serviceAccountName
-      - name: HOST_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.hostIP
-      - name: CANONICAL_SERVICE
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.labels['service.istio.io/canonical-name']
-      - name: CANONICAL_REVISION
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.labels['service.istio.io/canonical-revision']
-      - name: PROXY_CONFIG
-        value: |
-               {{ protoToJSON .ProxyConfig }}
-      - name: ISTIO_META_POD_PORTS
-        value: |-
-          [
-          {{- $first := true }}
-          {{- range $index1, $c := .Spec.Containers }}
-            {{- range $index2, $p := $c.Ports }}
-              {{- if (structToJSON $p) }}
-              {{if not $first}},{{end}}{{ structToJSON $p }}
-              {{- $first = false }}
-              {{- end }}
-            {{- end}}
-          {{- end}}
-          ]
-      - name: ISTIO_META_APP_CONTAINERS
-        value: "{{ $containers | join "," }}"
-      - name: ISTIO_META_CLUSTER_ID
-        value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
-      - name: ISTIO_META_INTERCEPTION_MODE
-        value: "{{ or (index .ObjectMeta.Annotations `sidecar.istio.io/interceptionMode`) .ProxyConfig.InterceptionMode.String }}"
-      {{- if .Values.global.network }}
-      - name: ISTIO_META_NETWORK
-        value: "{{ .Values.global.network }}"
-      {{- end }}
-      {{ if .ObjectMeta.Annotations }}
-      - name: ISTIO_METAJSON_ANNOTATIONS
-        value: |
-               {{ toJSON .ObjectMeta.Annotations }}
-      {{ end }}
-      {{- if .DeploymentMeta.Name }}
-      - name: ISTIO_META_WORKLOAD_NAME
-        value: "{{ .DeploymentMeta.Name }}"
-      {{ end }}
-      {{- if and .TypeMeta.APIVersion .DeploymentMeta.Name }}
-      - name: ISTIO_META_OWNER
-        value: kubernetes://apis/{{ .TypeMeta.APIVersion }}/namespaces/{{ valueOrDefault .DeploymentMeta.Namespace `default` }}/{{ toLower .TypeMeta.Kind}}s/{{ .DeploymentMeta.Name }}
-      {{- end}}
-      {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
-      - name: ISTIO_BOOTSTRAP_OVERRIDE
-        value: "/etc/istio/custom-bootstrap/custom_bootstrap.json"
-      {{- end }}
-      {{- if .Values.global.meshID }}
-      - name: ISTIO_META_MESH_ID
-        value: "{{ .Values.global.meshID }}"
-      {{- else if (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}
-      - name: ISTIO_META_MESH_ID
-        value: "{{ (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}"
-      {{- end }}
-      {{- with (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain)  }}
-      - name: TRUST_DOMAIN
-        value: "{{ . }}"
-      {{- end }}
-      {{- if and (eq .Values.global.proxy.tracer "datadog") (isset .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}
-      {{- range $key, $value := fromJSON (index .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}
-      - name: {{ $key }}
-        value: "{{ $value }}"
-      {{- end }}
-      {{- end }}
-      {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
-      - name: {{ $key }}
-        value: "{{ $value }}"
-      {{- end }}
-      imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
-      {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
-      readinessProbe:
-        httpGet:
-          path: /healthz/ready
-          port: 15021
-        initialDelaySeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/initialDelaySeconds` .Values.global.proxy.readinessInitialDelaySeconds }}
-        periodSeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/periodSeconds` .Values.global.proxy.readinessPeriodSeconds }}
-        timeoutSeconds: 3
-        failureThreshold: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/failureThreshold` .Values.global.proxy.readinessFailureThreshold }}
-      {{ end -}}
-      securityContext:
-        allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
-        capabilities:
-          {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
-          add:
-          {{ if eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY` -}}
-          - NET_ADMIN
-          {{- end }}
-          {{ if eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true` -}}
-          - NET_BIND_SERVICE
-          {{- end }}
-          {{- end }}
-          drop:
-          - ALL
-        privileged: {{ .Values.global.proxy.privileged }}
-        readOnlyRootFilesystem: {{ not .Values.global.proxy.enableCoreDump }}
-        runAsGroup: 1337
-        fsGroup: 1337
-        {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
-        runAsNonRoot: false
-        runAsUser: 0
-        {{- else -}}
-        runAsNonRoot: true
-        runAsUser: 1337
-        {{- end }}
-      resources:
-    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-      {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
-        requests:
-          {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-          cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-          {{ end }}
-          {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-          memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
-          {{ end }}
-      {{- end }}
-      {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-        limits:
-          {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-          cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
-          {{ end }}
-          {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-          memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
-          {{ end }}
-      {{- end }}
-    {{- else }}
-      {{- if .Values.global.proxy.resources }}
-        {{ toYaml .Values.global.proxy.resources | indent 6 }}
-      {{- end }}
-    {{- end }}
-      volumeMounts:
-      {{- if eq .Values.global.pilotCertProvider "istiod" }}
-      - mountPath: /var/run/secrets/istio
-        name: istiod-ca-cert
-      {{- end }}
-      - mountPath: /var/lib/istio/data
-        name: istio-data
-      {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
-      - mountPath: /etc/istio/custom-bootstrap
-        name: custom-bootstrap-volume
-      {{- end }}
-      # SDS channel between istioagent and Envoy
-      - mountPath: /etc/istio/proxy
-        name: istio-envoy
-      {{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
-      - mountPath: /var/run/secrets/tokens
-        name: istio-token
-      {{- end }}
-      {{- if .Values.global.mountMtlsCerts }}
-      # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.
-      - mountPath: /etc/certs/
-        name: istio-certs
-        readOnly: true
-      {{- end }}
-      - name: istio-podinfo
-        mountPath: /etc/istio/pod
-       {{- if and (eq .Values.global.proxy.tracer "lightstep") .ProxyConfig.GetTracing.GetTlsSettings }}
-      - mountPath: {{ directory .ProxyConfig.GetTracing.GetTlsSettings.GetCaCertificates }}
-        name: lightstep-certs
-        readOnly: true
-      {{- end }}
-        {{- if isset .ObjectMeta.Annotations `sidecar.istio.io/userVolumeMount` }}
-        {{ range $index, $value := fromJSON (index .ObjectMeta.Annotations `sidecar.istio.io/userVolumeMount`) }}
-      - name: "{{  $index }}"
-        {{ toYaml $value | indent 6 }}
+  {{- end }}
+    resources:
+  {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+      requests:
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
+        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
         {{ end }}
-        {{- end }}
-    volumes:
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
+        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+        {{ end }}
+    {{- end }}
+    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+      limits:
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
+        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+        {{ end }}
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
+        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+        {{ end }}
+    {{- end }}
+  {{- else }}
+    {{- if .Values.global.proxy.resources }}
+      {{ toYaml .Values.global.proxy.resources | indent 6 }}
+    {{- end }}
+  {{- end }}
+    securityContext:
+      allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
+      privileged: {{ .Values.global.proxy.privileged }}
+      capabilities:
+    {{- if not .Values.istio_cni.enabled }}
+        add:
+        - NET_ADMIN
+        - NET_RAW
+    {{- end }}
+        drop:
+        - ALL
+    {{- if not .Values.istio_cni.enabled }}
+      readOnlyRootFilesystem: false
+      runAsGroup: 0
+      runAsNonRoot: false
+      runAsUser: 0
+    {{- else }}
+      readOnlyRootFilesystem: true
+      runAsGroup: 1337
+      runAsUser: 1337
+      runAsNonRoot: true
+    {{- end }}
+    restartPolicy: Always
+  {{ end -}}
+  {{- if eq .Values.global.proxy.enableCoreDump true }}
+  - name: enable-core-dump
+    args:
+    - -c
+    - sysctl -w kernel.core_pattern=/var/lib/istio/data/core.proxy && ulimit -c unlimited
+    command:
+      - /bin/sh
+  {{- if contains "/" .Values.global.proxy_init.image }}
+    image: "{{ .Values.global.proxy_init.image }}"
+  {{- else }}
+    image: "{{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}"
+  {{- end }}
+    imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
+    resources: {}
+    securityContext:
+      allowPrivilegeEscalation: true
+      capabilities:
+        add:
+        - SYS_ADMIN
+        drop:
+        - ALL
+      privileged: true
+      readOnlyRootFilesystem: false
+      runAsGroup: 0
+      runAsNonRoot: false
+      runAsUser: 0
+  {{ end }}
+  containers:
+  - name: istio-proxy
+  {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+    image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+  {{- else }}
+    image: "{{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}"
+  {{- end }}
+    ports:
+    - containerPort: 15090
+      protocol: TCP
+      name: http-envoy-prom
+    args:
+    - proxy
+    - sidecar
+    - --domain
+    - $(POD_NAMESPACE).svc.{{ .Values.global.proxy.clusterDomain }}
+    - --serviceCluster
+    {{ if ne "" (index .ObjectMeta.Labels "app") -}}
+    - "{{ index .ObjectMeta.Labels `app` }}.$(POD_NAMESPACE)"
+    {{ else -}}
+    - "{{ valueOrDefault .DeploymentMeta.Name `istio-proxy` }}.{{ valueOrDefault .DeploymentMeta.Namespace `default` }}"
+    {{ end -}}
+    - --proxyLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel}}
+    - --proxyComponentLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel}}
+  {{- if .Values.global.sts.servicePort }}
+    - --stsPort={{ .Values.global.sts.servicePort }}
+  {{- end }}
+  {{- if .Values.global.logAsJson }}
+    - --log_as_json
+  {{- end }}
+  {{- if gt .ProxyConfig.Concurrency.GetValue 0 }}
+    - --concurrency
+    - "{{ .ProxyConfig.Concurrency.GetValue }}"
+  {{- end -}}
+  {{- if .Values.global.proxy.lifecycle }}
+    lifecycle:
+      {{ toYaml .Values.global.proxy.lifecycle | indent 6 }}
+  {{- else if $holdProxy }}
+    lifecycle:
+      postStart:
+        exec:
+          command:
+          - pilot-agent
+          - wait
+  {{- end }}
+    env:
+    - name: JWT_POLICY
+      value: {{ .Values.global.jwtPolicy }}
+    - name: PILOT_CERT_PROVIDER
+      value: {{ .Values.global.pilotCertProvider }}
+    - name: CA_ADDR
+    {{- if .Values.global.caAddress }}
+      value: {{ .Values.global.caAddress }}
+    {{- else }}
+      value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
+    {{- end }}
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: INSTANCE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    - name: SERVICE_ACCOUNT
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.serviceAccountName
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
+    - name: CANONICAL_SERVICE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.labels['service.istio.io/canonical-name']
+    - name: CANONICAL_REVISION
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.labels['service.istio.io/canonical-revision']
+    - name: PROXY_CONFIG
+      value: |
+             {{ protoToJSON .ProxyConfig }}
+    - name: ISTIO_META_POD_PORTS
+      value: |-
+        [
+        {{- $first := true }}
+        {{- range $index1, $c := .Spec.Containers }}
+          {{- range $index2, $p := $c.Ports }}
+            {{- if (structToJSON $p) }}
+            {{if not $first}},{{end}}{{ structToJSON $p }}
+            {{- $first = false }}
+            {{- end }}
+          {{- end}}
+        {{- end}}
+        ]
+    - name: ISTIO_META_APP_CONTAINERS
+      value: "{{ $containers | join "," }}"
+    - name: ISTIO_META_CLUSTER_ID
+      value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
+    - name: ISTIO_META_INTERCEPTION_MODE
+      value: "{{ or (index .ObjectMeta.Annotations `sidecar.istio.io/interceptionMode`) .ProxyConfig.InterceptionMode.String }}"
+    {{- if .Values.global.network }}
+    - name: ISTIO_META_NETWORK
+      value: "{{ .Values.global.network }}"
+    {{- end }}
+    {{ if .ObjectMeta.Annotations }}
+    - name: ISTIO_METAJSON_ANNOTATIONS
+      value: |
+             {{ toJSON .ObjectMeta.Annotations }}
+    {{ end }}
+    {{- if .DeploymentMeta.Name }}
+    - name: ISTIO_META_WORKLOAD_NAME
+      value: "{{ .DeploymentMeta.Name }}"
+    {{ end }}
+    {{- if and .TypeMeta.APIVersion .DeploymentMeta.Name }}
+    - name: ISTIO_META_OWNER
+      value: kubernetes://apis/{{ .TypeMeta.APIVersion }}/namespaces/{{ valueOrDefault .DeploymentMeta.Namespace `default` }}/{{ toLower .TypeMeta.Kind}}s/{{ .DeploymentMeta.Name }}
+    {{- end}}
     {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
-    - name: custom-bootstrap-volume
-      configMap:
-        name: {{ annotation .ObjectMeta `sidecar.istio.io/bootstrapOverride` "" }}
+    - name: ISTIO_BOOTSTRAP_OVERRIDE
+      value: "/etc/istio/custom-bootstrap/custom_bootstrap.json"
+    {{- end }}
+    {{- if .Values.global.meshID }}
+    - name: ISTIO_META_MESH_ID
+      value: "{{ .Values.global.meshID }}"
+    {{- else if (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}
+    - name: ISTIO_META_MESH_ID
+      value: "{{ (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}"
+    {{- end }}
+    {{- with (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain)  }}
+    - name: TRUST_DOMAIN
+      value: "{{ . }}"
+    {{- end }}
+    {{- if and (eq .Values.global.proxy.tracer "datadog") (isset .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}
+    {{- range $key, $value := fromJSON (index .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}
+    - name: {{ $key }}
+      value: "{{ $value }}"
+    {{- end }}
+    {{- end }}
+    {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+    - name: {{ $key }}
+      value: "{{ $value }}"
+    {{- end }}
+    imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
+    {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
+    readinessProbe:
+      httpGet:
+        path: /healthz/ready
+        port: 15021
+      initialDelaySeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/initialDelaySeconds` .Values.global.proxy.readinessInitialDelaySeconds }}
+      periodSeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/periodSeconds` .Values.global.proxy.readinessPeriodSeconds }}
+      timeoutSeconds: 3
+      failureThreshold: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/failureThreshold` .Values.global.proxy.readinessFailureThreshold }}
+    {{ end -}}
+    securityContext:
+      allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
+      capabilities:
+        {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
+        add:
+        {{ if eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY` -}}
+        - NET_ADMIN
+        {{- end }}
+        {{ if eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true` -}}
+        - NET_BIND_SERVICE
+        {{- end }}
+        {{- end }}
+        drop:
+        - ALL
+      privileged: {{ .Values.global.proxy.privileged }}
+      readOnlyRootFilesystem: {{ not .Values.global.proxy.enableCoreDump }}
+      runAsGroup: 1337
+      fsGroup: 1337
+      {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
+      runAsNonRoot: false
+      runAsUser: 0
+      {{- else -}}
+      runAsNonRoot: true
+      runAsUser: 1337
+      {{- end }}
+    resources:
+  {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+      requests:
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
+        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+        {{ end }}
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
+        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+        {{ end }}
+    {{- end }}
+    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+      limits:
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
+        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+        {{ end }}
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
+        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+        {{ end }}
+    {{- end }}
+  {{- else }}
+    {{- if .Values.global.proxy.resources }}
+      {{ toYaml .Values.global.proxy.resources | indent 6 }}
+    {{- end }}
+  {{- end }}
+    volumeMounts:
+    {{- if eq .Values.global.pilotCertProvider "istiod" }}
+    - mountPath: /var/run/secrets/istio
+      name: istiod-ca-cert
+    {{- end }}
+    - mountPath: /var/lib/istio/data
+      name: istio-data
+    {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
+    - mountPath: /etc/istio/custom-bootstrap
+      name: custom-bootstrap-volume
     {{- end }}
     # SDS channel between istioagent and Envoy
-    - emptyDir:
-        medium: Memory
+    - mountPath: /etc/istio/proxy
       name: istio-envoy
-    - name: istio-data
-      emptyDir: {}
-    - name: istio-podinfo
-      downwardAPI:
-        items:
-          - path: "labels"
-            fieldRef:
-              fieldPath: metadata.labels
-          - path: "annotations"
-            fieldRef:
-              fieldPath: metadata.annotations
-          - path: "cpu-limit"
-            resourceFieldRef:
-              containerName: istio-proxy
-              resource: limits.cpu
-              divisor: 1m
-          - path: "cpu-request"
-            resourceFieldRef:
-              containerName: istio-proxy
-              resource: requests.cpu
-              divisor: 1m
     {{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
-    - name: istio-token
-      projected:
-        sources:
-        - serviceAccountToken:
-            path: istio-token
-            expirationSeconds: 43200
-            audience: {{ .Values.global.sds.token.aud }}
-    {{- end }}
-    {{- if eq .Values.global.pilotCertProvider "istiod" }}
-    - name: istiod-ca-cert
-      configMap:
-        name: istio-ca-root-cert
+    - mountPath: /var/run/secrets/tokens
+      name: istio-token
     {{- end }}
     {{- if .Values.global.mountMtlsCerts }}
     # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.
-    - name: istio-certs
-      secret:
-        optional: true
-        {{ if eq .Spec.ServiceAccountName "" }}
-        secretName: istio.default
-        {{ else -}}
-        secretName: {{  printf "istio.%s" .Spec.ServiceAccountName }}
-        {{  end -}}
+    - mountPath: /etc/certs/
+      name: istio-certs
+      readOnly: true
     {{- end }}
-      {{- if isset .ObjectMeta.Annotations `sidecar.istio.io/userVolume` }}
-      {{range $index, $value := fromJSON (index .ObjectMeta.Annotations `sidecar.istio.io/userVolume`) }}
-    - name: "{{ $index }}"
-      {{ toYaml $value | indent 4 }}
-      {{ end }}
-      {{ end }}
-    {{- if and (eq .Values.global.proxy.tracer "lightstep") .ProxyConfig.GetTracing.GetTlsSettings }}
-    - name: lightstep-certs
-      secret:
-        optional: true
-        secretName: lightstep.cacert
+    - name: istio-podinfo
+      mountPath: /etc/istio/pod
+     {{- if and (eq .Values.global.proxy.tracer "lightstep") .ProxyConfig.GetTracing.GetTlsSettings }}
+    - mountPath: {{ directory .ProxyConfig.GetTracing.GetTlsSettings.GetCaCertificates }}
+      name: lightstep-certs
+      readOnly: true
     {{- end }}
-    {{- if .Values.global.imagePullSecrets }}
-    imagePullSecrets:
-      {{- range .Values.global.imagePullSecrets }}
-      - name: {{ . }}
+      {{- if isset .ObjectMeta.Annotations `sidecar.istio.io/userVolumeMount` }}
+      {{ range $index, $value := fromJSON (index .ObjectMeta.Annotations `sidecar.istio.io/userVolumeMount`) }}
+    - name: "{{  $index }}"
+      {{ toYaml $value | indent 6 }}
+      {{ end }}
       {{- end }}
+  volumes:
+  {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
+  - name: custom-bootstrap-volume
+    configMap:
+      name: {{ annotation .ObjectMeta `sidecar.istio.io/bootstrapOverride` "" }}
+  {{- end }}
+  # SDS channel between istioagent and Envoy
+  - emptyDir:
+      medium: Memory
+    name: istio-envoy
+  - name: istio-data
+    emptyDir: {}
+  - name: istio-podinfo
+    downwardAPI:
+      items:
+        - path: "labels"
+          fieldRef:
+            fieldPath: metadata.labels
+        - path: "annotations"
+          fieldRef:
+            fieldPath: metadata.annotations
+        - path: "cpu-limit"
+          resourceFieldRef:
+            containerName: istio-proxy
+            resource: limits.cpu
+            divisor: 1m
+        - path: "cpu-request"
+          resourceFieldRef:
+            containerName: istio-proxy
+            resource: requests.cpu
+            divisor: 1m
+  {{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
+  - name: istio-token
+    projected:
+      sources:
+      - serviceAccountToken:
+          path: istio-token
+          expirationSeconds: 43200
+          audience: {{ .Values.global.sds.token.aud }}
+  {{- end }}
+  {{- if eq .Values.global.pilotCertProvider "istiod" }}
+  - name: istiod-ca-cert
+    configMap:
+      name: istio-ca-root-cert
+  {{- end }}
+  {{- if .Values.global.mountMtlsCerts }}
+  # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.
+  - name: istio-certs
+    secret:
+      optional: true
+      {{ if eq .Spec.ServiceAccountName "" }}
+      secretName: istio.default
+      {{ else -}}
+      secretName: {{  printf "istio.%s" .Spec.ServiceAccountName }}
+      {{  end -}}
+  {{- end }}
+    {{- if isset .ObjectMeta.Annotations `sidecar.istio.io/userVolume` }}
+    {{range $index, $value := fromJSON (index .ObjectMeta.Annotations `sidecar.istio.io/userVolume`) }}
+  - name: "{{ $index }}"
+    {{ toYaml $value | indent 4 }}
+    {{ end }}
+    {{ end }}
+  {{- if and (eq .Values.global.proxy.tracer "lightstep") .ProxyConfig.GetTracing.GetTlsSettings }}
+  - name: lightstep-certs
+    secret:
+      optional: true
+      secretName: lightstep.cacert
+  {{- end }}
+  {{- if .Values.global.imagePullSecrets }}
+  imagePullSecrets:
+    {{- range .Values.global.imagePullSecrets }}
+    - name: {{ . }}
     {{- end }}
-    {{- if eq (env "ENABLE_LEGACY_FSGROUP_INJECTION" "true") "true" }}
-    securityContext:
-      fsGroup: 1337
-    {{- end }}
+  {{- end }}
+  {{- if eq (env "ENABLE_LEGACY_FSGROUP_INJECTION" "true") "true" }}
+  securityContext:
+    fsGroup: 1337
+  {{- end }}

--- a/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/istiod-injector-configmap.yaml
@@ -32,7 +32,8 @@ data:
       {{- range $key, $val := .Values.sidecarInjectorWebhook.injectedAnnotations }}
       "{{ $key }}": "{{ $val }}"
       {{- end }}
-
-{{ .Files.Get "files/injection-template.yaml" | trim | indent 4 }}
+    templates:
+      sidecar: |
+{{ .Files.Get "files/injection-template.yaml" | trim | indent 8 }}
 
 {{- end }}

--- a/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
+++ b/manifests/charts/istiod-remote/files/gen-istiod-remote.yaml
@@ -182,498 +182,498 @@ data:
     neverInjectSelector:
       []
     injectedAnnotations:
-
-    template: |
-      {{- $containers := list }}
-      {{- range $index, $container := .Spec.Containers }}{{ if not (eq $container.Name "istio-proxy") }}{{ $containers = append $containers $container.Name }}{{end}}{{- end}}
-      metadata:
-        labels:
-          security.istio.io/tlsMode: {{ index .ObjectMeta.Labels `security.istio.io/tlsMode` | default "istio" }}
-          service.istio.io/canonical-name: {{ index .ObjectMeta.Labels `service.istio.io/canonical-name` | default (index .ObjectMeta.Labels `app.kubernetes.io/name`) | default (index .ObjectMeta.Labels `app`) | default .DeploymentMeta.Name }}
-          service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest" }}
-          istio.io/rev: {{ .Revision | default "default" }}
-        annotations: {
-          {{- if eq (len $containers) 1 }}
-          kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
-          {{ end }}
-      {{- if .Values.istio_cni.enabled }}
-          {{- if not .Values.istio_cni.chained }}
-          k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `istio-cni` }}',
-          {{- end }}
-          sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
-          {{ with annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundIPRanges` .Values.global.proxy.includeIPRanges }}traffic.sidecar.istio.io/includeOutboundIPRanges: "{{.}}",{{ end }}
-          {{ with annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundIPRanges` .Values.global.proxy.excludeIPRanges }}traffic.sidecar.istio.io/excludeOutboundIPRanges: "{{.}}",{{ end }}
-          traffic.sidecar.istio.io/includeInboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}",
-          traffic.sidecar.istio.io/excludeInboundPorts: "{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}",
-          {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/includeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.includeOutboundPorts "") "") }}
-          traffic.sidecar.istio.io/includeOutboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundPorts` .Values.global.proxy.includeOutboundPorts }}",
-          {{- end }}
-          {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne .Values.global.proxy.excludeOutboundPorts "") }}
-          traffic.sidecar.istio.io/excludeOutboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}",
-          {{- end }}
-          {{ with index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}traffic.sidecar.istio.io/kubevirtInterfaces: "{{.}}",{{ end }}
-      {{- end }}
-        }
-      spec:
-        {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
-        initContainers:
-        {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-        {{ if .Values.istio_cni.enabled -}}
-        - name: istio-validation
-        {{ else -}}
-        - name: istio-init
-        {{ end -}}
-        {{- if contains "/" .Values.global.proxy_init.image }}
-          image: "{{ .Values.global.proxy_init.image }}"
-        {{- else }}
-          image: "{{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}"
-        {{- end }}
-          args:
-          - istio-iptables
-          - "-p"
-          - "15001"
-          - "-z"
-          - "15006"
-          - "-u"
-          - "1337"
-          - "-m"
-          - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
-          - "-i"
-          - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundIPRanges` .Values.global.proxy.includeIPRanges }}"
-          - "-x"
-          - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundIPRanges` .Values.global.proxy.excludeIPRanges }}"
-          - "-b"
-          - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
-          - "-d"
-        {{- if excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}
-          - "15090,15021,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
-        {{- else }}
-          - "15090,15021"
-        {{- end }}
-          {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/includeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.includeOutboundPorts "") "") -}}
-          - "-q"
-          - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundPorts` .Values.global.proxy.includeOutboundPorts }}"
-          {{ end -}}
-          {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.excludeOutboundPorts "") "") -}}
-          - "-o"
-          - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}"
-          {{ end -}}
-          {{ if (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces`) -}}
-          - "-k"
-          - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
-          {{ end -}}
-          {{ if .Values.istio_cni.enabled -}}
-          - "--run-validation"
-          - "--skip-rule-apply"
-          {{ end -}}
-          imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
-        {{- if .ProxyConfig.ProxyMetadata }}
-          env:
-          {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
-          - name: {{ $key }}
-            value: "{{ $value }}"
-          {{- end }}
-        {{- end }}
-          resources:
-        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-          {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
-            requests:
-              {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-              cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-              {{ end }}
-              {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-              memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
-              {{ end }}
-          {{- end }}
-          {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-            limits:
-              {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-              cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
-              {{ end }}
-              {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-              memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
-              {{ end }}
-          {{- end }}
-        {{- else }}
-          {{- if .Values.global.proxy.resources }}
-            {{ toYaml .Values.global.proxy.resources | indent 6 }}
-          {{- end }}
-        {{- end }}
-          securityContext:
-            allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
-            privileged: {{ .Values.global.proxy.privileged }}
-            capabilities:
-          {{- if not .Values.istio_cni.enabled }}
-              add:
-              - NET_ADMIN
-              - NET_RAW
-          {{- end }}
-              drop:
-              - ALL
-          {{- if not .Values.istio_cni.enabled }}
-            readOnlyRootFilesystem: false
-            runAsGroup: 0
-            runAsNonRoot: false
-            runAsUser: 0
-          {{- else }}
-            readOnlyRootFilesystem: true
-            runAsGroup: 1337
-            runAsUser: 1337
-            runAsNonRoot: true
-          {{- end }}
-          restartPolicy: Always
-        {{ end -}}
-        {{- if eq .Values.global.proxy.enableCoreDump true }}
-        - name: enable-core-dump
-          args:
-          - -c
-          - sysctl -w kernel.core_pattern=/var/lib/istio/data/core.proxy && ulimit -c unlimited
-          command:
-            - /bin/sh
-        {{- if contains "/" .Values.global.proxy_init.image }}
-          image: "{{ .Values.global.proxy_init.image }}"
-        {{- else }}
-          image: "{{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}"
-        {{- end }}
-          imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
-          resources: {}
-          securityContext:
-            allowPrivilegeEscalation: true
-            capabilities:
-              add:
-              - SYS_ADMIN
-              drop:
-              - ALL
-            privileged: true
-            readOnlyRootFilesystem: false
-            runAsGroup: 0
-            runAsNonRoot: false
-            runAsUser: 0
-        {{ end }}
-        containers:
-        - name: istio-proxy
-        {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
-          image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
-        {{- else }}
-          image: "{{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}"
-        {{- end }}
-          ports:
-          - containerPort: 15090
-            protocol: TCP
-            name: http-envoy-prom
-          args:
-          - proxy
-          - sidecar
-          - --domain
-          - $(POD_NAMESPACE).svc.{{ .Values.global.proxy.clusterDomain }}
-          - --serviceCluster
-          {{ if ne "" (index .ObjectMeta.Labels "app") -}}
-          - "{{ index .ObjectMeta.Labels `app` }}.$(POD_NAMESPACE)"
-          {{ else -}}
-          - "{{ valueOrDefault .DeploymentMeta.Name `istio-proxy` }}.{{ valueOrDefault .DeploymentMeta.Namespace `default` }}"
-          {{ end -}}
-          - --proxyLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel}}
-          - --proxyComponentLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel}}
-        {{- if .Values.global.sts.servicePort }}
-          - --stsPort={{ .Values.global.sts.servicePort }}
-        {{- end }}
-        {{- if .Values.global.logAsJson }}
-          - --log_as_json
-        {{- end }}
-        {{- if gt .ProxyConfig.Concurrency.GetValue 0 }}
-          - --concurrency
-          - "{{ .ProxyConfig.Concurrency.GetValue }}"
-        {{- end -}}
-        {{- if .Values.global.proxy.lifecycle }}
-          lifecycle:
-            {{ toYaml .Values.global.proxy.lifecycle | indent 6 }}
-        {{- else if $holdProxy }}
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                - pilot-agent
-                - wait
-        {{- end }}
-          env:
-          - name: JWT_POLICY
-            value: {{ .Values.global.jwtPolicy }}
-          - name: PILOT_CERT_PROVIDER
-            value: {{ .Values.global.pilotCertProvider }}
-          - name: CA_ADDR
-          {{- if .Values.global.caAddress }}
-            value: {{ .Values.global.caAddress }}
-          {{- else }}
-            value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
-          {{- end }}
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: INSTANCE_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
-          - name: SERVICE_ACCOUNT
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.serviceAccountName
-          - name: HOST_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.hostIP
-          - name: CANONICAL_SERVICE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.labels['service.istio.io/canonical-name']
-          - name: CANONICAL_REVISION
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.labels['service.istio.io/canonical-revision']
-          - name: PROXY_CONFIG
-            value: |
-                   {{ protoToJSON .ProxyConfig }}
-          - name: ISTIO_META_POD_PORTS
-            value: |-
-              [
-              {{- $first := true }}
-              {{- range $index1, $c := .Spec.Containers }}
-                {{- range $index2, $p := $c.Ports }}
-                  {{- if (structToJSON $p) }}
-                  {{if not $first}},{{end}}{{ structToJSON $p }}
-                  {{- $first = false }}
-                  {{- end }}
-                {{- end}}
-              {{- end}}
-              ]
-          - name: ISTIO_META_APP_CONTAINERS
-            value: "{{ $containers | join "," }}"
-          - name: ISTIO_META_CLUSTER_ID
-            value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
-          - name: ISTIO_META_INTERCEPTION_MODE
-            value: "{{ or (index .ObjectMeta.Annotations `sidecar.istio.io/interceptionMode`) .ProxyConfig.InterceptionMode.String }}"
-          {{- if .Values.global.network }}
-          - name: ISTIO_META_NETWORK
-            value: "{{ .Values.global.network }}"
-          {{- end }}
-          {{ if .ObjectMeta.Annotations }}
-          - name: ISTIO_METAJSON_ANNOTATIONS
-            value: |
-                   {{ toJSON .ObjectMeta.Annotations }}
-          {{ end }}
-          {{- if .DeploymentMeta.Name }}
-          - name: ISTIO_META_WORKLOAD_NAME
-            value: "{{ .DeploymentMeta.Name }}"
-          {{ end }}
-          {{- if and .TypeMeta.APIVersion .DeploymentMeta.Name }}
-          - name: ISTIO_META_OWNER
-            value: kubernetes://apis/{{ .TypeMeta.APIVersion }}/namespaces/{{ valueOrDefault .DeploymentMeta.Namespace `default` }}/{{ toLower .TypeMeta.Kind}}s/{{ .DeploymentMeta.Name }}
-          {{- end}}
-          {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
-          - name: ISTIO_BOOTSTRAP_OVERRIDE
-            value: "/etc/istio/custom-bootstrap/custom_bootstrap.json"
-          {{- end }}
-          {{- if .Values.global.meshID }}
-          - name: ISTIO_META_MESH_ID
-            value: "{{ .Values.global.meshID }}"
-          {{- else if (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}
-          - name: ISTIO_META_MESH_ID
-            value: "{{ (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}"
-          {{- end }}
-          {{- with (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain)  }}
-          - name: TRUST_DOMAIN
-            value: "{{ . }}"
-          {{- end }}
-          {{- if and (eq .Values.global.proxy.tracer "datadog") (isset .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}
-          {{- range $key, $value := fromJSON (index .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}
-          - name: {{ $key }}
-            value: "{{ $value }}"
-          {{- end }}
-          {{- end }}
-          {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
-          - name: {{ $key }}
-            value: "{{ $value }}"
-          {{- end }}
-          imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
-          {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
-          readinessProbe:
-            httpGet:
-              path: /healthz/ready
-              port: 15021
-            initialDelaySeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/initialDelaySeconds` .Values.global.proxy.readinessInitialDelaySeconds }}
-            periodSeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/periodSeconds` .Values.global.proxy.readinessPeriodSeconds }}
-            timeoutSeconds: 3
-            failureThreshold: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/failureThreshold` .Values.global.proxy.readinessFailureThreshold }}
-          {{ end -}}
-          securityContext:
-            allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
-            capabilities:
-              {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
-              add:
-              {{ if eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY` -}}
-              - NET_ADMIN
-              {{- end }}
-              {{ if eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true` -}}
-              - NET_BIND_SERVICE
-              {{- end }}
-              {{- end }}
-              drop:
-              - ALL
-            privileged: {{ .Values.global.proxy.privileged }}
-            readOnlyRootFilesystem: {{ not .Values.global.proxy.enableCoreDump }}
-            runAsGroup: 1337
-            fsGroup: 1337
-            {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
-            runAsNonRoot: false
-            runAsUser: 0
-            {{- else -}}
-            runAsNonRoot: true
-            runAsUser: 1337
+    templates:
+      sidecar: |
+        {{- $containers := list }}
+        {{- range $index, $container := .Spec.Containers }}{{ if not (eq $container.Name "istio-proxy") }}{{ $containers = append $containers $container.Name }}{{end}}{{- end}}
+        metadata:
+          labels:
+            security.istio.io/tlsMode: {{ index .ObjectMeta.Labels `security.istio.io/tlsMode` | default "istio" }}
+            service.istio.io/canonical-name: {{ index .ObjectMeta.Labels `service.istio.io/canonical-name` | default (index .ObjectMeta.Labels `app.kubernetes.io/name`) | default (index .ObjectMeta.Labels `app`) | default .DeploymentMeta.Name }}
+            service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest" }}
+            istio.io/rev: {{ .Revision | default "default" }}
+          annotations: {
+            {{- if eq (len $containers) 1 }}
+            kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
+            {{ end }}
+        {{- if .Values.istio_cni.enabled }}
+            {{- if not .Values.istio_cni.chained }}
+            k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `istio-cni` }}',
             {{- end }}
-          resources:
-        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-          {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
-            requests:
-              {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-              cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-              {{ end }}
-              {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-              memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
-              {{ end }}
-          {{- end }}
-          {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-            limits:
-              {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-              cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
-              {{ end }}
-              {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-              memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
-              {{ end }}
-          {{- end }}
-        {{- else }}
-          {{- if .Values.global.proxy.resources }}
-            {{ toYaml .Values.global.proxy.resources | indent 6 }}
-          {{- end }}
+            sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
+            {{ with annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundIPRanges` .Values.global.proxy.includeIPRanges }}traffic.sidecar.istio.io/includeOutboundIPRanges: "{{.}}",{{ end }}
+            {{ with annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundIPRanges` .Values.global.proxy.excludeIPRanges }}traffic.sidecar.istio.io/excludeOutboundIPRanges: "{{.}}",{{ end }}
+            traffic.sidecar.istio.io/includeInboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}",
+            traffic.sidecar.istio.io/excludeInboundPorts: "{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}",
+            {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/includeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.includeOutboundPorts "") "") }}
+            traffic.sidecar.istio.io/includeOutboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundPorts` .Values.global.proxy.includeOutboundPorts }}",
+            {{- end }}
+            {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne .Values.global.proxy.excludeOutboundPorts "") }}
+            traffic.sidecar.istio.io/excludeOutboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}",
+            {{- end }}
+            {{ with index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}traffic.sidecar.istio.io/kubevirtInterfaces: "{{.}}",{{ end }}
         {{- end }}
-          volumeMounts:
-          {{- if eq .Values.global.pilotCertProvider "istiod" }}
-          - mountPath: /var/run/secrets/istio
-            name: istiod-ca-cert
+          }
+        spec:
+          {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
+          initContainers:
+          {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
+          {{ if .Values.istio_cni.enabled -}}
+          - name: istio-validation
+          {{ else -}}
+          - name: istio-init
+          {{ end -}}
+          {{- if contains "/" .Values.global.proxy_init.image }}
+            image: "{{ .Values.global.proxy_init.image }}"
+          {{- else }}
+            image: "{{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}"
           {{- end }}
-          - mountPath: /var/lib/istio/data
-            name: istio-data
-          {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
-          - mountPath: /etc/istio/custom-bootstrap
-            name: custom-bootstrap-volume
+            args:
+            - istio-iptables
+            - "-p"
+            - "15001"
+            - "-z"
+            - "15006"
+            - "-u"
+            - "1337"
+            - "-m"
+            - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
+            - "-i"
+            - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundIPRanges` .Values.global.proxy.includeIPRanges }}"
+            - "-x"
+            - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundIPRanges` .Values.global.proxy.excludeIPRanges }}"
+            - "-b"
+            - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
+            - "-d"
+          {{- if excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}
+            - "15090,15021,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
+          {{- else }}
+            - "15090,15021"
+          {{- end }}
+            {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/includeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.includeOutboundPorts "") "") -}}
+            - "-q"
+            - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundPorts` .Values.global.proxy.includeOutboundPorts }}"
+            {{ end -}}
+            {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.excludeOutboundPorts "") "") -}}
+            - "-o"
+            - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}"
+            {{ end -}}
+            {{ if (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces`) -}}
+            - "-k"
+            - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
+            {{ end -}}
+            {{ if .Values.istio_cni.enabled -}}
+            - "--run-validation"
+            - "--skip-rule-apply"
+            {{ end -}}
+            imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
+          {{- if .ProxyConfig.ProxyMetadata }}
+            env:
+            {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+            {{- end }}
+          {{- end }}
+            resources:
+          {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+            {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+              requests:
+                {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
+                cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+                {{ end }}
+                {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
+                memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+                {{ end }}
+            {{- end }}
+            {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+              limits:
+                {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
+                cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+                {{ end }}
+                {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
+                memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+                {{ end }}
+            {{- end }}
+          {{- else }}
+            {{- if .Values.global.proxy.resources }}
+              {{ toYaml .Values.global.proxy.resources | indent 6 }}
+            {{- end }}
+          {{- end }}
+            securityContext:
+              allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
+              privileged: {{ .Values.global.proxy.privileged }}
+              capabilities:
+            {{- if not .Values.istio_cni.enabled }}
+                add:
+                - NET_ADMIN
+                - NET_RAW
+            {{- end }}
+                drop:
+                - ALL
+            {{- if not .Values.istio_cni.enabled }}
+              readOnlyRootFilesystem: false
+              runAsGroup: 0
+              runAsNonRoot: false
+              runAsUser: 0
+            {{- else }}
+              readOnlyRootFilesystem: true
+              runAsGroup: 1337
+              runAsUser: 1337
+              runAsNonRoot: true
+            {{- end }}
+            restartPolicy: Always
+          {{ end -}}
+          {{- if eq .Values.global.proxy.enableCoreDump true }}
+          - name: enable-core-dump
+            args:
+            - -c
+            - sysctl -w kernel.core_pattern=/var/lib/istio/data/core.proxy && ulimit -c unlimited
+            command:
+              - /bin/sh
+          {{- if contains "/" .Values.global.proxy_init.image }}
+            image: "{{ .Values.global.proxy_init.image }}"
+          {{- else }}
+            image: "{{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}"
+          {{- end }}
+            imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
+            resources: {}
+            securityContext:
+              allowPrivilegeEscalation: true
+              capabilities:
+                add:
+                - SYS_ADMIN
+                drop:
+                - ALL
+              privileged: true
+              readOnlyRootFilesystem: false
+              runAsGroup: 0
+              runAsNonRoot: false
+              runAsUser: 0
+          {{ end }}
+          containers:
+          - name: istio-proxy
+          {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+            image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+          {{- else }}
+            image: "{{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}"
+          {{- end }}
+            ports:
+            - containerPort: 15090
+              protocol: TCP
+              name: http-envoy-prom
+            args:
+            - proxy
+            - sidecar
+            - --domain
+            - $(POD_NAMESPACE).svc.{{ .Values.global.proxy.clusterDomain }}
+            - --serviceCluster
+            {{ if ne "" (index .ObjectMeta.Labels "app") -}}
+            - "{{ index .ObjectMeta.Labels `app` }}.$(POD_NAMESPACE)"
+            {{ else -}}
+            - "{{ valueOrDefault .DeploymentMeta.Name `istio-proxy` }}.{{ valueOrDefault .DeploymentMeta.Namespace `default` }}"
+            {{ end -}}
+            - --proxyLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel}}
+            - --proxyComponentLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel}}
+          {{- if .Values.global.sts.servicePort }}
+            - --stsPort={{ .Values.global.sts.servicePort }}
+          {{- end }}
+          {{- if .Values.global.logAsJson }}
+            - --log_as_json
+          {{- end }}
+          {{- if gt .ProxyConfig.Concurrency.GetValue 0 }}
+            - --concurrency
+            - "{{ .ProxyConfig.Concurrency.GetValue }}"
+          {{- end -}}
+          {{- if .Values.global.proxy.lifecycle }}
+            lifecycle:
+              {{ toYaml .Values.global.proxy.lifecycle | indent 6 }}
+          {{- else if $holdProxy }}
+            lifecycle:
+              postStart:
+                exec:
+                  command:
+                  - pilot-agent
+                  - wait
+          {{- end }}
+            env:
+            - name: JWT_POLICY
+              value: {{ .Values.global.jwtPolicy }}
+            - name: PILOT_CERT_PROVIDER
+              value: {{ .Values.global.pilotCertProvider }}
+            - name: CA_ADDR
+            {{- if .Values.global.caAddress }}
+              value: {{ .Values.global.caAddress }}
+            {{- else }}
+              value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
+            {{- end }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: INSTANCE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: CANONICAL_SERVICE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['service.istio.io/canonical-name']
+            - name: CANONICAL_REVISION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['service.istio.io/canonical-revision']
+            - name: PROXY_CONFIG
+              value: |
+                     {{ protoToJSON .ProxyConfig }}
+            - name: ISTIO_META_POD_PORTS
+              value: |-
+                [
+                {{- $first := true }}
+                {{- range $index1, $c := .Spec.Containers }}
+                  {{- range $index2, $p := $c.Ports }}
+                    {{- if (structToJSON $p) }}
+                    {{if not $first}},{{end}}{{ structToJSON $p }}
+                    {{- $first = false }}
+                    {{- end }}
+                  {{- end}}
+                {{- end}}
+                ]
+            - name: ISTIO_META_APP_CONTAINERS
+              value: "{{ $containers | join "," }}"
+            - name: ISTIO_META_CLUSTER_ID
+              value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
+            - name: ISTIO_META_INTERCEPTION_MODE
+              value: "{{ or (index .ObjectMeta.Annotations `sidecar.istio.io/interceptionMode`) .ProxyConfig.InterceptionMode.String }}"
+            {{- if .Values.global.network }}
+            - name: ISTIO_META_NETWORK
+              value: "{{ .Values.global.network }}"
+            {{- end }}
+            {{ if .ObjectMeta.Annotations }}
+            - name: ISTIO_METAJSON_ANNOTATIONS
+              value: |
+                     {{ toJSON .ObjectMeta.Annotations }}
+            {{ end }}
+            {{- if .DeploymentMeta.Name }}
+            - name: ISTIO_META_WORKLOAD_NAME
+              value: "{{ .DeploymentMeta.Name }}"
+            {{ end }}
+            {{- if and .TypeMeta.APIVersion .DeploymentMeta.Name }}
+            - name: ISTIO_META_OWNER
+              value: kubernetes://apis/{{ .TypeMeta.APIVersion }}/namespaces/{{ valueOrDefault .DeploymentMeta.Namespace `default` }}/{{ toLower .TypeMeta.Kind}}s/{{ .DeploymentMeta.Name }}
+            {{- end}}
+            {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
+            - name: ISTIO_BOOTSTRAP_OVERRIDE
+              value: "/etc/istio/custom-bootstrap/custom_bootstrap.json"
+            {{- end }}
+            {{- if .Values.global.meshID }}
+            - name: ISTIO_META_MESH_ID
+              value: "{{ .Values.global.meshID }}"
+            {{- else if (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}
+            - name: ISTIO_META_MESH_ID
+              value: "{{ (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}"
+            {{- end }}
+            {{- with (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain)  }}
+            - name: TRUST_DOMAIN
+              value: "{{ . }}"
+            {{- end }}
+            {{- if and (eq .Values.global.proxy.tracer "datadog") (isset .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}
+            {{- range $key, $value := fromJSON (index .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+            {{- end }}
+            {{- end }}
+            {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+            {{- end }}
+            imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
+            {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
+            readinessProbe:
+              httpGet:
+                path: /healthz/ready
+                port: 15021
+              initialDelaySeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/initialDelaySeconds` .Values.global.proxy.readinessInitialDelaySeconds }}
+              periodSeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/periodSeconds` .Values.global.proxy.readinessPeriodSeconds }}
+              timeoutSeconds: 3
+              failureThreshold: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/failureThreshold` .Values.global.proxy.readinessFailureThreshold }}
+            {{ end -}}
+            securityContext:
+              allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
+              capabilities:
+                {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
+                add:
+                {{ if eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY` -}}
+                - NET_ADMIN
+                {{- end }}
+                {{ if eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true` -}}
+                - NET_BIND_SERVICE
+                {{- end }}
+                {{- end }}
+                drop:
+                - ALL
+              privileged: {{ .Values.global.proxy.privileged }}
+              readOnlyRootFilesystem: {{ not .Values.global.proxy.enableCoreDump }}
+              runAsGroup: 1337
+              fsGroup: 1337
+              {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
+              runAsNonRoot: false
+              runAsUser: 0
+              {{- else -}}
+              runAsNonRoot: true
+              runAsUser: 1337
+              {{- end }}
+            resources:
+          {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+            {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+              requests:
+                {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
+                cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+                {{ end }}
+                {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
+                memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+                {{ end }}
+            {{- end }}
+            {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+              limits:
+                {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
+                cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+                {{ end }}
+                {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
+                memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+                {{ end }}
+            {{- end }}
+          {{- else }}
+            {{- if .Values.global.proxy.resources }}
+              {{ toYaml .Values.global.proxy.resources | indent 6 }}
+            {{- end }}
+          {{- end }}
+            volumeMounts:
+            {{- if eq .Values.global.pilotCertProvider "istiod" }}
+            - mountPath: /var/run/secrets/istio
+              name: istiod-ca-cert
+            {{- end }}
+            - mountPath: /var/lib/istio/data
+              name: istio-data
+            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
+            - mountPath: /etc/istio/custom-bootstrap
+              name: custom-bootstrap-volume
+            {{- end }}
+            # SDS channel between istioagent and Envoy
+            - mountPath: /etc/istio/proxy
+              name: istio-envoy
+            {{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
+            - mountPath: /var/run/secrets/tokens
+              name: istio-token
+            {{- end }}
+            {{- if .Values.global.mountMtlsCerts }}
+            # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.
+            - mountPath: /etc/certs/
+              name: istio-certs
+              readOnly: true
+            {{- end }}
+            - name: istio-podinfo
+              mountPath: /etc/istio/pod
+             {{- if and (eq .Values.global.proxy.tracer "lightstep") .ProxyConfig.GetTracing.GetTlsSettings }}
+            - mountPath: {{ directory .ProxyConfig.GetTracing.GetTlsSettings.GetCaCertificates }}
+              name: lightstep-certs
+              readOnly: true
+            {{- end }}
+              {{- if isset .ObjectMeta.Annotations `sidecar.istio.io/userVolumeMount` }}
+              {{ range $index, $value := fromJSON (index .ObjectMeta.Annotations `sidecar.istio.io/userVolumeMount`) }}
+            - name: "{{  $index }}"
+              {{ toYaml $value | indent 6 }}
+              {{ end }}
+              {{- end }}
+          volumes:
+          {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
+          - name: custom-bootstrap-volume
+            configMap:
+              name: {{ annotation .ObjectMeta `sidecar.istio.io/bootstrapOverride` "" }}
           {{- end }}
           # SDS channel between istioagent and Envoy
-          - mountPath: /etc/istio/proxy
+          - emptyDir:
+              medium: Memory
             name: istio-envoy
+          - name: istio-data
+            emptyDir: {}
+          - name: istio-podinfo
+            downwardAPI:
+              items:
+                - path: "labels"
+                  fieldRef:
+                    fieldPath: metadata.labels
+                - path: "annotations"
+                  fieldRef:
+                    fieldPath: metadata.annotations
+                - path: "cpu-limit"
+                  resourceFieldRef:
+                    containerName: istio-proxy
+                    resource: limits.cpu
+                    divisor: 1m
+                - path: "cpu-request"
+                  resourceFieldRef:
+                    containerName: istio-proxy
+                    resource: requests.cpu
+                    divisor: 1m
           {{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
-          - mountPath: /var/run/secrets/tokens
-            name: istio-token
+          - name: istio-token
+            projected:
+              sources:
+              - serviceAccountToken:
+                  path: istio-token
+                  expirationSeconds: 43200
+                  audience: {{ .Values.global.sds.token.aud }}
+          {{- end }}
+          {{- if eq .Values.global.pilotCertProvider "istiod" }}
+          - name: istiod-ca-cert
+            configMap:
+              name: istio-ca-root-cert
           {{- end }}
           {{- if .Values.global.mountMtlsCerts }}
           # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.
-          - mountPath: /etc/certs/
-            name: istio-certs
-            readOnly: true
+          - name: istio-certs
+            secret:
+              optional: true
+              {{ if eq .Spec.ServiceAccountName "" }}
+              secretName: istio.default
+              {{ else -}}
+              secretName: {{  printf "istio.%s" .Spec.ServiceAccountName }}
+              {{  end -}}
           {{- end }}
-          - name: istio-podinfo
-            mountPath: /etc/istio/pod
-           {{- if and (eq .Values.global.proxy.tracer "lightstep") .ProxyConfig.GetTracing.GetTlsSettings }}
-          - mountPath: {{ directory .ProxyConfig.GetTracing.GetTlsSettings.GetCaCertificates }}
-            name: lightstep-certs
-            readOnly: true
-          {{- end }}
-            {{- if isset .ObjectMeta.Annotations `sidecar.istio.io/userVolumeMount` }}
-            {{ range $index, $value := fromJSON (index .ObjectMeta.Annotations `sidecar.istio.io/userVolumeMount`) }}
-          - name: "{{  $index }}"
-            {{ toYaml $value | indent 6 }}
+            {{- if isset .ObjectMeta.Annotations `sidecar.istio.io/userVolume` }}
+            {{range $index, $value := fromJSON (index .ObjectMeta.Annotations `sidecar.istio.io/userVolume`) }}
+          - name: "{{ $index }}"
+            {{ toYaml $value | indent 4 }}
             {{ end }}
-            {{- end }}
-        volumes:
-        {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
-        - name: custom-bootstrap-volume
-          configMap:
-            name: {{ annotation .ObjectMeta `sidecar.istio.io/bootstrapOverride` "" }}
-        {{- end }}
-        # SDS channel between istioagent and Envoy
-        - emptyDir:
-            medium: Memory
-          name: istio-envoy
-        - name: istio-data
-          emptyDir: {}
-        - name: istio-podinfo
-          downwardAPI:
-            items:
-              - path: "labels"
-                fieldRef:
-                  fieldPath: metadata.labels
-              - path: "annotations"
-                fieldRef:
-                  fieldPath: metadata.annotations
-              - path: "cpu-limit"
-                resourceFieldRef:
-                  containerName: istio-proxy
-                  resource: limits.cpu
-                  divisor: 1m
-              - path: "cpu-request"
-                resourceFieldRef:
-                  containerName: istio-proxy
-                  resource: requests.cpu
-                  divisor: 1m
-        {{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
-        - name: istio-token
-          projected:
-            sources:
-            - serviceAccountToken:
-                path: istio-token
-                expirationSeconds: 43200
-                audience: {{ .Values.global.sds.token.aud }}
-        {{- end }}
-        {{- if eq .Values.global.pilotCertProvider "istiod" }}
-        - name: istiod-ca-cert
-          configMap:
-            name: istio-ca-root-cert
-        {{- end }}
-        {{- if .Values.global.mountMtlsCerts }}
-        # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.
-        - name: istio-certs
-          secret:
-            optional: true
-            {{ if eq .Spec.ServiceAccountName "" }}
-            secretName: istio.default
-            {{ else -}}
-            secretName: {{  printf "istio.%s" .Spec.ServiceAccountName }}
-            {{  end -}}
-        {{- end }}
-          {{- if isset .ObjectMeta.Annotations `sidecar.istio.io/userVolume` }}
-          {{range $index, $value := fromJSON (index .ObjectMeta.Annotations `sidecar.istio.io/userVolume`) }}
-        - name: "{{ $index }}"
-          {{ toYaml $value | indent 4 }}
-          {{ end }}
-          {{ end }}
-        {{- if and (eq .Values.global.proxy.tracer "lightstep") .ProxyConfig.GetTracing.GetTlsSettings }}
-        - name: lightstep-certs
-          secret:
-            optional: true
-            secretName: lightstep.cacert
-        {{- end }}
-        {{- if .Values.global.imagePullSecrets }}
-        imagePullSecrets:
-          {{- range .Values.global.imagePullSecrets }}
-          - name: {{ . }}
+            {{ end }}
+          {{- if and (eq .Values.global.proxy.tracer "lightstep") .ProxyConfig.GetTracing.GetTlsSettings }}
+          - name: lightstep-certs
+            secret:
+              optional: true
+              secretName: lightstep.cacert
           {{- end }}
-        {{- end }}
-        {{- if eq (env "ENABLE_LEGACY_FSGROUP_INJECTION" "true") "true" }}
-        securityContext:
-          fsGroup: 1337
-        {{- end }}
+          {{- if .Values.global.imagePullSecrets }}
+          imagePullSecrets:
+            {{- range .Values.global.imagePullSecrets }}
+            - name: {{ . }}
+            {{- end }}
+          {{- end }}
+          {{- if eq (env "ENABLE_LEGACY_FSGROUP_INJECTION" "true") "true" }}
+          securityContext:
+            fsGroup: 1337
+          {{- end }}
 ---
 # Source: istiod-remote/templates/mutatingwebhook.yaml
 # Installed for each revision - not installed for cluster resources ( cluster roles, bindings, crds)

--- a/manifests/charts/istiod-remote/files/injection-template.yaml
+++ b/manifests/charts/istiod-remote/files/injection-template.yaml
@@ -1,491 +1,490 @@
-template: |
-  {{- $containers := list }}
-  {{- range $index, $container := .Spec.Containers }}{{ if not (eq $container.Name "istio-proxy") }}{{ $containers = append $containers $container.Name }}{{end}}{{- end}}
-  metadata:
-    labels:
-      security.istio.io/tlsMode: {{ index .ObjectMeta.Labels `security.istio.io/tlsMode` | default "istio" }}
-      service.istio.io/canonical-name: {{ index .ObjectMeta.Labels `service.istio.io/canonical-name` | default (index .ObjectMeta.Labels `app.kubernetes.io/name`) | default (index .ObjectMeta.Labels `app`) | default .DeploymentMeta.Name }}
-      service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest" }}
-      istio.io/rev: {{ .Revision | default "default" }}
-    annotations: {
-      {{- if eq (len $containers) 1 }}
-      kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
-      {{ end }}
-  {{- if .Values.istio_cni.enabled }}
-      {{- if not .Values.istio_cni.chained }}
-      k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `istio-cni` }}',
-      {{- end }}
-      sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
-      {{ with annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundIPRanges` .Values.global.proxy.includeIPRanges }}traffic.sidecar.istio.io/includeOutboundIPRanges: "{{.}}",{{ end }}
-      {{ with annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundIPRanges` .Values.global.proxy.excludeIPRanges }}traffic.sidecar.istio.io/excludeOutboundIPRanges: "{{.}}",{{ end }}
-      traffic.sidecar.istio.io/includeInboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}",
-      traffic.sidecar.istio.io/excludeInboundPorts: "{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}",
-      {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/includeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.includeOutboundPorts "") "") }}
-      traffic.sidecar.istio.io/includeOutboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundPorts` .Values.global.proxy.includeOutboundPorts }}",
-      {{- end }}
-      {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne .Values.global.proxy.excludeOutboundPorts "") }}
-      traffic.sidecar.istio.io/excludeOutboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}",
-      {{- end }}
-      {{ with index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}traffic.sidecar.istio.io/kubevirtInterfaces: "{{.}}",{{ end }}
-  {{- end }}
-    }
-  spec:
-    {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
-    initContainers:
-    {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
-    {{ if .Values.istio_cni.enabled -}}
-    - name: istio-validation
-    {{ else -}}
-    - name: istio-init
-    {{ end -}}
-    {{- if contains "/" .Values.global.proxy_init.image }}
-      image: "{{ .Values.global.proxy_init.image }}"
-    {{- else }}
-      image: "{{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}"
-    {{- end }}
-      args:
-      - istio-iptables
-      - "-p"
-      - "15001"
-      - "-z"
-      - "15006"
-      - "-u"
-      - "1337"
-      - "-m"
-      - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
-      - "-i"
-      - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundIPRanges` .Values.global.proxy.includeIPRanges }}"
-      - "-x"
-      - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundIPRanges` .Values.global.proxy.excludeIPRanges }}"
-      - "-b"
-      - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
-      - "-d"
-    {{- if excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}
-      - "15090,15021,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
-    {{- else }}
-      - "15090,15021"
-    {{- end }}
-      {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/includeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.includeOutboundPorts "") "") -}}
-      - "-q"
-      - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundPorts` .Values.global.proxy.includeOutboundPorts }}"
-      {{ end -}}
-      {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.excludeOutboundPorts "") "") -}}
-      - "-o"
-      - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}"
-      {{ end -}}
-      {{ if (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces`) -}}
-      - "-k"
-      - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
-      {{ end -}}
-      {{ if .Values.istio_cni.enabled -}}
-      - "--run-validation"
-      - "--skip-rule-apply"
-      {{ end -}}
-      imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
-    {{- if .ProxyConfig.ProxyMetadata }}
-      env:
-      {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
-      - name: {{ $key }}
-        value: "{{ $value }}"
-      {{- end }}
-    {{- end }}
-      resources:
-    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-      {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
-        requests:
-          {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-          cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-          {{ end }}
-          {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-          memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
-          {{ end }}
-      {{- end }}
-      {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-        limits:
-          {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-          cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
-          {{ end }}
-          {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-          memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
-          {{ end }}
-      {{- end }}
-    {{- else }}
-      {{- if .Values.global.proxy.resources }}
-        {{ toYaml .Values.global.proxy.resources | indent 6 }}
-      {{- end }}
-    {{- end }}
-      securityContext:
-        allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
-        privileged: {{ .Values.global.proxy.privileged }}
-        capabilities:
-      {{- if not .Values.istio_cni.enabled }}
-          add:
-          - NET_ADMIN
-          - NET_RAW
-      {{- end }}
-          drop:
-          - ALL
-      {{- if not .Values.istio_cni.enabled }}
-        readOnlyRootFilesystem: false
-        runAsGroup: 0
-        runAsNonRoot: false
-        runAsUser: 0
-      {{- else }}
-        readOnlyRootFilesystem: true
-        runAsGroup: 1337
-        runAsUser: 1337
-        runAsNonRoot: true
-      {{- end }}
-      restartPolicy: Always
-    {{ end -}}
-    {{- if eq .Values.global.proxy.enableCoreDump true }}
-    - name: enable-core-dump
-      args:
-      - -c
-      - sysctl -w kernel.core_pattern=/var/lib/istio/data/core.proxy && ulimit -c unlimited
-      command:
-        - /bin/sh
-    {{- if contains "/" .Values.global.proxy_init.image }}
-      image: "{{ .Values.global.proxy_init.image }}"
-    {{- else }}
-      image: "{{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}"
-    {{- end }}
-      imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
-      resources: {}
-      securityContext:
-        allowPrivilegeEscalation: true
-        capabilities:
-          add:
-          - SYS_ADMIN
-          drop:
-          - ALL
-        privileged: true
-        readOnlyRootFilesystem: false
-        runAsGroup: 0
-        runAsNonRoot: false
-        runAsUser: 0
+ {{- $containers := list }}
+{{- range $index, $container := .Spec.Containers }}{{ if not (eq $container.Name "istio-proxy") }}{{ $containers = append $containers $container.Name }}{{end}}{{- end}}
+metadata:
+  labels:
+    security.istio.io/tlsMode: {{ index .ObjectMeta.Labels `security.istio.io/tlsMode` | default "istio" }}
+    service.istio.io/canonical-name: {{ index .ObjectMeta.Labels `service.istio.io/canonical-name` | default (index .ObjectMeta.Labels `app.kubernetes.io/name`) | default (index .ObjectMeta.Labels `app`) | default .DeploymentMeta.Name }}
+    service.istio.io/canonical-revision: {{ index .ObjectMeta.Labels `service.istio.io/canonical-revision` | default (index .ObjectMeta.Labels `app.kubernetes.io/version`) | default (index .ObjectMeta.Labels `version`) | default "latest" }}
+    istio.io/rev: {{ .Revision | default "default" }}
+  annotations: {
+    {{- if eq (len $containers) 1 }}
+    kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
     {{ end }}
-    containers:
-    - name: istio-proxy
-    {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
-      image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
-    {{- else }}
-      image: "{{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}"
+{{- if .Values.istio_cni.enabled }}
+    {{- if not .Values.istio_cni.chained }}
+    k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `istio-cni` }}',
     {{- end }}
-      ports:
-      - containerPort: 15090
-        protocol: TCP
-        name: http-envoy-prom
-      args:
-      - proxy
-      - sidecar
-      - --domain
-      - $(POD_NAMESPACE).svc.{{ .Values.global.proxy.clusterDomain }}
-      - --serviceCluster
-      {{ if ne "" (index .ObjectMeta.Labels "app") -}}
-      - "{{ index .ObjectMeta.Labels `app` }}.$(POD_NAMESPACE)"
-      {{ else -}}
-      - "{{ valueOrDefault .DeploymentMeta.Name `istio-proxy` }}.{{ valueOrDefault .DeploymentMeta.Namespace `default` }}"
-      {{ end -}}
-      - --proxyLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel}}
-      - --proxyComponentLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel}}
-    {{- if .Values.global.sts.servicePort }}
-      - --stsPort={{ .Values.global.sts.servicePort }}
+    sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
+    {{ with annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundIPRanges` .Values.global.proxy.includeIPRanges }}traffic.sidecar.istio.io/includeOutboundIPRanges: "{{.}}",{{ end }}
+    {{ with annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundIPRanges` .Values.global.proxy.excludeIPRanges }}traffic.sidecar.istio.io/excludeOutboundIPRanges: "{{.}}",{{ end }}
+    traffic.sidecar.istio.io/includeInboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}",
+    traffic.sidecar.istio.io/excludeInboundPorts: "{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}",
+    {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/includeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.includeOutboundPorts "") "") }}
+    traffic.sidecar.istio.io/includeOutboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundPorts` .Values.global.proxy.includeOutboundPorts }}",
     {{- end }}
-    {{- if .Values.global.logAsJson }}
-      - --log_as_json
+    {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne .Values.global.proxy.excludeOutboundPorts "") }}
+    traffic.sidecar.istio.io/excludeOutboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}",
     {{- end }}
-    {{- if gt .ProxyConfig.Concurrency.GetValue 0 }}
-      - --concurrency
-      - "{{ .ProxyConfig.Concurrency.GetValue }}"
-    {{- end -}}
-    {{- if .Values.global.proxy.lifecycle }}
-      lifecycle:
-        {{ toYaml .Values.global.proxy.lifecycle | indent 6 }}
-    {{- else if $holdProxy }}
-      lifecycle:
-        postStart:
-          exec:
-            command:
-            - pilot-agent
-            - wait
+    {{ with index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}traffic.sidecar.istio.io/kubevirtInterfaces: "{{.}}",{{ end }}
+{{- end }}
+  }
+spec:
+  {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
+  initContainers:
+  {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
+  {{ if .Values.istio_cni.enabled -}}
+  - name: istio-validation
+  {{ else -}}
+  - name: istio-init
+  {{ end -}}
+  {{- if contains "/" .Values.global.proxy_init.image }}
+    image: "{{ .Values.global.proxy_init.image }}"
+  {{- else }}
+    image: "{{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}"
+  {{- end }}
+    args:
+    - istio-iptables
+    - "-p"
+    - "15001"
+    - "-z"
+    - "15006"
+    - "-u"
+    - "1337"
+    - "-m"
+    - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
+    - "-i"
+    - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundIPRanges` .Values.global.proxy.includeIPRanges }}"
+    - "-x"
+    - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundIPRanges` .Values.global.proxy.excludeIPRanges }}"
+    - "-b"
+    - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
+    - "-d"
+  {{- if excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}
+    - "15090,15021,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
+  {{- else }}
+    - "15090,15021"
+  {{- end }}
+    {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/includeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.includeOutboundPorts "") "") -}}
+    - "-q"
+    - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundPorts` .Values.global.proxy.includeOutboundPorts }}"
+    {{ end -}}
+    {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.excludeOutboundPorts "") "") -}}
+    - "-o"
+    - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}"
+    {{ end -}}
+    {{ if (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces`) -}}
+    - "-k"
+    - "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
+    {{ end -}}
+    {{ if .Values.istio_cni.enabled -}}
+    - "--run-validation"
+    - "--skip-rule-apply"
+    {{ end -}}
+    imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
+  {{- if .ProxyConfig.ProxyMetadata }}
+    env:
+    {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+    - name: {{ $key }}
+      value: "{{ $value }}"
     {{- end }}
-      env:
-      - name: JWT_POLICY
-        value: {{ .Values.global.jwtPolicy }}
-      - name: PILOT_CERT_PROVIDER
-        value: {{ .Values.global.pilotCertProvider }}
-      - name: CA_ADDR
-      {{- if .Values.global.caAddress }}
-        value: {{ .Values.global.caAddress }}
-      {{- else }}
-        value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
-      {{- end }}
-      - name: POD_NAME
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.name
-      - name: POD_NAMESPACE
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.namespace
-      - name: INSTANCE_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      - name: SERVICE_ACCOUNT
-        valueFrom:
-          fieldRef:
-            fieldPath: spec.serviceAccountName
-      - name: HOST_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.hostIP
-      - name: CANONICAL_SERVICE
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.labels['service.istio.io/canonical-name']
-      - name: CANONICAL_REVISION
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.labels['service.istio.io/canonical-revision']
-      - name: PROXY_CONFIG
-        value: |
-               {{ protoToJSON .ProxyConfig }}
-      - name: ISTIO_META_POD_PORTS
-        value: |-
-          [
-          {{- $first := true }}
-          {{- range $index1, $c := .Spec.Containers }}
-            {{- range $index2, $p := $c.Ports }}
-              {{- if (structToJSON $p) }}
-              {{if not $first}},{{end}}{{ structToJSON $p }}
-              {{- $first = false }}
-              {{- end }}
-            {{- end}}
-          {{- end}}
-          ]
-      - name: ISTIO_META_APP_CONTAINERS
-        value: "{{ $containers | join "," }}"
-      - name: ISTIO_META_CLUSTER_ID
-        value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
-      - name: ISTIO_META_INTERCEPTION_MODE
-        value: "{{ or (index .ObjectMeta.Annotations `sidecar.istio.io/interceptionMode`) .ProxyConfig.InterceptionMode.String }}"
-      {{- if .Values.global.network }}
-      - name: ISTIO_META_NETWORK
-        value: "{{ .Values.global.network }}"
-      {{- end }}
-      {{ if .ObjectMeta.Annotations }}
-      - name: ISTIO_METAJSON_ANNOTATIONS
-        value: |
-               {{ toJSON .ObjectMeta.Annotations }}
-      {{ end }}
-      {{- if .DeploymentMeta.Name }}
-      - name: ISTIO_META_WORKLOAD_NAME
-        value: "{{ .DeploymentMeta.Name }}"
-      {{ end }}
-      {{- if and .TypeMeta.APIVersion .DeploymentMeta.Name }}
-      - name: ISTIO_META_OWNER
-        value: kubernetes://apis/{{ .TypeMeta.APIVersion }}/namespaces/{{ valueOrDefault .DeploymentMeta.Namespace `default` }}/{{ toLower .TypeMeta.Kind}}s/{{ .DeploymentMeta.Name }}
-      {{- end}}
-      {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
-      - name: ISTIO_BOOTSTRAP_OVERRIDE
-        value: "/etc/istio/custom-bootstrap/custom_bootstrap.json"
-      {{- end }}
-      {{- if .Values.global.meshID }}
-      - name: ISTIO_META_MESH_ID
-        value: "{{ .Values.global.meshID }}"
-      {{- else if (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}
-      - name: ISTIO_META_MESH_ID
-        value: "{{ (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}"
-      {{- end }}
-      {{- with (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain)  }}
-      - name: TRUST_DOMAIN
-        value: "{{ . }}"
-      {{- end }}
-      {{- if and (eq .Values.global.proxy.tracer "datadog") (isset .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}
-      {{- range $key, $value := fromJSON (index .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}
-      - name: {{ $key }}
-        value: "{{ $value }}"
-      {{- end }}
-      {{- end }}
-      {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
-      - name: {{ $key }}
-        value: "{{ $value }}"
-      {{- end }}
-      imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
-      {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
-      readinessProbe:
-        httpGet:
-          path: /healthz/ready
-          port: 15021
-        initialDelaySeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/initialDelaySeconds` .Values.global.proxy.readinessInitialDelaySeconds }}
-        periodSeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/periodSeconds` .Values.global.proxy.readinessPeriodSeconds }}
-        timeoutSeconds: 3
-        failureThreshold: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/failureThreshold` .Values.global.proxy.readinessFailureThreshold }}
-      {{ end -}}
-      securityContext:
-        allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
-        capabilities:
-          {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
-          add:
-          {{ if eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY` -}}
-          - NET_ADMIN
-          {{- end }}
-          {{ if eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true` -}}
-          - NET_BIND_SERVICE
-          {{- end }}
-          {{- end }}
-          drop:
-          - ALL
-        privileged: {{ .Values.global.proxy.privileged }}
-        readOnlyRootFilesystem: {{ not .Values.global.proxy.enableCoreDump }}
-        runAsGroup: 1337
-        fsGroup: 1337
-        {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
-        runAsNonRoot: false
-        runAsUser: 0
-        {{- else -}}
-        runAsNonRoot: true
-        runAsUser: 1337
-        {{- end }}
-      resources:
-    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-      {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
-        requests:
-          {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
-          cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
-          {{ end }}
-          {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
-          memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
-          {{ end }}
-      {{- end }}
-      {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
-        limits:
-          {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
-          cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
-          {{ end }}
-          {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
-          memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
-          {{ end }}
-      {{- end }}
-    {{- else }}
-      {{- if .Values.global.proxy.resources }}
-        {{ toYaml .Values.global.proxy.resources | indent 6 }}
-      {{- end }}
-    {{- end }}
-      volumeMounts:
-      {{- if eq .Values.global.pilotCertProvider "istiod" }}
-      - mountPath: /var/run/secrets/istio
-        name: istiod-ca-cert
-      {{- end }}
-      - mountPath: /var/lib/istio/data
-        name: istio-data
-      {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
-      - mountPath: /etc/istio/custom-bootstrap
-        name: custom-bootstrap-volume
-      {{- end }}
-      # SDS channel between istioagent and Envoy
-      - mountPath: /etc/istio/proxy
-        name: istio-envoy
-      {{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
-      - mountPath: /var/run/secrets/tokens
-        name: istio-token
-      {{- end }}
-      {{- if .Values.global.mountMtlsCerts }}
-      # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.
-      - mountPath: /etc/certs/
-        name: istio-certs
-        readOnly: true
-      {{- end }}
-      - name: istio-podinfo
-        mountPath: /etc/istio/pod
-       {{- if and (eq .Values.global.proxy.tracer "lightstep") .ProxyConfig.GetTracing.GetTlsSettings }}
-      - mountPath: {{ directory .ProxyConfig.GetTracing.GetTlsSettings.GetCaCertificates }}
-        name: lightstep-certs
-        readOnly: true
-      {{- end }}
-        {{- if isset .ObjectMeta.Annotations `sidecar.istio.io/userVolumeMount` }}
-        {{ range $index, $value := fromJSON (index .ObjectMeta.Annotations `sidecar.istio.io/userVolumeMount`) }}
-      - name: "{{  $index }}"
-        {{ toYaml $value | indent 6 }}
+  {{- end }}
+    resources:
+  {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+      requests:
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
+        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
         {{ end }}
-        {{- end }}
-    volumes:
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
+        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+        {{ end }}
+    {{- end }}
+    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+      limits:
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
+        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+        {{ end }}
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
+        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+        {{ end }}
+    {{- end }}
+  {{- else }}
+    {{- if .Values.global.proxy.resources }}
+      {{ toYaml .Values.global.proxy.resources | indent 6 }}
+    {{- end }}
+  {{- end }}
+    securityContext:
+      allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
+      privileged: {{ .Values.global.proxy.privileged }}
+      capabilities:
+    {{- if not .Values.istio_cni.enabled }}
+        add:
+        - NET_ADMIN
+        - NET_RAW
+    {{- end }}
+        drop:
+        - ALL
+    {{- if not .Values.istio_cni.enabled }}
+      readOnlyRootFilesystem: false
+      runAsGroup: 0
+      runAsNonRoot: false
+      runAsUser: 0
+    {{- else }}
+      readOnlyRootFilesystem: true
+      runAsGroup: 1337
+      runAsUser: 1337
+      runAsNonRoot: true
+    {{- end }}
+    restartPolicy: Always
+  {{ end -}}
+  {{- if eq .Values.global.proxy.enableCoreDump true }}
+  - name: enable-core-dump
+    args:
+    - -c
+    - sysctl -w kernel.core_pattern=/var/lib/istio/data/core.proxy && ulimit -c unlimited
+    command:
+      - /bin/sh
+  {{- if contains "/" .Values.global.proxy_init.image }}
+    image: "{{ .Values.global.proxy_init.image }}"
+  {{- else }}
+    image: "{{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}"
+  {{- end }}
+    imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
+    resources: {}
+    securityContext:
+      allowPrivilegeEscalation: true
+      capabilities:
+        add:
+        - SYS_ADMIN
+        drop:
+        - ALL
+      privileged: true
+      readOnlyRootFilesystem: false
+      runAsGroup: 0
+      runAsNonRoot: false
+      runAsUser: 0
+  {{ end }}
+  containers:
+  - name: istio-proxy
+  {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
+    image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
+  {{- else }}
+    image: "{{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}"
+  {{- end }}
+    ports:
+    - containerPort: 15090
+      protocol: TCP
+      name: http-envoy-prom
+    args:
+    - proxy
+    - sidecar
+    - --domain
+    - $(POD_NAMESPACE).svc.{{ .Values.global.proxy.clusterDomain }}
+    - --serviceCluster
+    {{ if ne "" (index .ObjectMeta.Labels "app") -}}
+    - "{{ index .ObjectMeta.Labels `app` }}.$(POD_NAMESPACE)"
+    {{ else -}}
+    - "{{ valueOrDefault .DeploymentMeta.Name `istio-proxy` }}.{{ valueOrDefault .DeploymentMeta.Namespace `default` }}"
+    {{ end -}}
+    - --proxyLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/logLevel` .Values.global.proxy.logLevel}}
+    - --proxyComponentLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` .Values.global.proxy.componentLogLevel}}
+  {{- if .Values.global.sts.servicePort }}
+    - --stsPort={{ .Values.global.sts.servicePort }}
+  {{- end }}
+  {{- if .Values.global.logAsJson }}
+    - --log_as_json
+  {{- end }}
+  {{- if gt .ProxyConfig.Concurrency.GetValue 0 }}
+    - --concurrency
+    - "{{ .ProxyConfig.Concurrency.GetValue }}"
+  {{- end -}}
+  {{- if .Values.global.proxy.lifecycle }}
+    lifecycle:
+      {{ toYaml .Values.global.proxy.lifecycle | indent 6 }}
+  {{- else if $holdProxy }}
+    lifecycle:
+      postStart:
+        exec:
+          command:
+          - pilot-agent
+          - wait
+  {{- end }}
+    env:
+    - name: JWT_POLICY
+      value: {{ .Values.global.jwtPolicy }}
+    - name: PILOT_CERT_PROVIDER
+      value: {{ .Values.global.pilotCertProvider }}
+    - name: CA_ADDR
+    {{- if .Values.global.caAddress }}
+      value: {{ .Values.global.caAddress }}
+    {{- else }}
+      value: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
+    {{- end }}
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: INSTANCE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    - name: SERVICE_ACCOUNT
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.serviceAccountName
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
+    - name: CANONICAL_SERVICE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.labels['service.istio.io/canonical-name']
+    - name: CANONICAL_REVISION
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.labels['service.istio.io/canonical-revision']
+    - name: PROXY_CONFIG
+      value: |
+             {{ protoToJSON .ProxyConfig }}
+    - name: ISTIO_META_POD_PORTS
+      value: |-
+        [
+        {{- $first := true }}
+        {{- range $index1, $c := .Spec.Containers }}
+          {{- range $index2, $p := $c.Ports }}
+            {{- if (structToJSON $p) }}
+            {{if not $first}},{{end}}{{ structToJSON $p }}
+            {{- $first = false }}
+            {{- end }}
+          {{- end}}
+        {{- end}}
+        ]
+    - name: ISTIO_META_APP_CONTAINERS
+      value: "{{ $containers | join "," }}"
+    - name: ISTIO_META_CLUSTER_ID
+      value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
+    - name: ISTIO_META_INTERCEPTION_MODE
+      value: "{{ or (index .ObjectMeta.Annotations `sidecar.istio.io/interceptionMode`) .ProxyConfig.InterceptionMode.String }}"
+    {{- if .Values.global.network }}
+    - name: ISTIO_META_NETWORK
+      value: "{{ .Values.global.network }}"
+    {{- end }}
+    {{ if .ObjectMeta.Annotations }}
+    - name: ISTIO_METAJSON_ANNOTATIONS
+      value: |
+             {{ toJSON .ObjectMeta.Annotations }}
+    {{ end }}
+    {{- if .DeploymentMeta.Name }}
+    - name: ISTIO_META_WORKLOAD_NAME
+      value: "{{ .DeploymentMeta.Name }}"
+    {{ end }}
+    {{- if and .TypeMeta.APIVersion .DeploymentMeta.Name }}
+    - name: ISTIO_META_OWNER
+      value: kubernetes://apis/{{ .TypeMeta.APIVersion }}/namespaces/{{ valueOrDefault .DeploymentMeta.Namespace `default` }}/{{ toLower .TypeMeta.Kind}}s/{{ .DeploymentMeta.Name }}
+    {{- end}}
     {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
-    - name: custom-bootstrap-volume
-      configMap:
-        name: {{ annotation .ObjectMeta `sidecar.istio.io/bootstrapOverride` "" }}
+    - name: ISTIO_BOOTSTRAP_OVERRIDE
+      value: "/etc/istio/custom-bootstrap/custom_bootstrap.json"
+    {{- end }}
+    {{- if .Values.global.meshID }}
+    - name: ISTIO_META_MESH_ID
+      value: "{{ .Values.global.meshID }}"
+    {{- else if (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}
+    - name: ISTIO_META_MESH_ID
+      value: "{{ (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}"
+    {{- end }}
+    {{- with (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain)  }}
+    - name: TRUST_DOMAIN
+      value: "{{ . }}"
+    {{- end }}
+    {{- if and (eq .Values.global.proxy.tracer "datadog") (isset .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}
+    {{- range $key, $value := fromJSON (index .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}
+    - name: {{ $key }}
+      value: "{{ $value }}"
+    {{- end }}
+    {{- end }}
+    {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+    - name: {{ $key }}
+      value: "{{ $value }}"
+    {{- end }}
+    imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
+    {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
+    readinessProbe:
+      httpGet:
+        path: /healthz/ready
+        port: 15021
+      initialDelaySeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/initialDelaySeconds` .Values.global.proxy.readinessInitialDelaySeconds }}
+      periodSeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/periodSeconds` .Values.global.proxy.readinessPeriodSeconds }}
+      timeoutSeconds: 3
+      failureThreshold: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/failureThreshold` .Values.global.proxy.readinessFailureThreshold }}
+    {{ end -}}
+    securityContext:
+      allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
+      capabilities:
+        {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
+        add:
+        {{ if eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY` -}}
+        - NET_ADMIN
+        {{- end }}
+        {{ if eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true` -}}
+        - NET_BIND_SERVICE
+        {{- end }}
+        {{- end }}
+        drop:
+        - ALL
+      privileged: {{ .Values.global.proxy.privileged }}
+      readOnlyRootFilesystem: {{ not .Values.global.proxy.enableCoreDump }}
+      runAsGroup: 1337
+      fsGroup: 1337
+      {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
+      runAsNonRoot: false
+      runAsUser: 0
+      {{- else -}}
+      runAsNonRoot: true
+      runAsUser: 1337
+      {{- end }}
+    resources:
+  {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+      requests:
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
+        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+        {{ end }}
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
+        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+        {{ end }}
+    {{- end }}
+    {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+      limits:
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
+        cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+        {{ end }}
+        {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
+        memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+        {{ end }}
+    {{- end }}
+  {{- else }}
+    {{- if .Values.global.proxy.resources }}
+      {{ toYaml .Values.global.proxy.resources | indent 6 }}
+    {{- end }}
+  {{- end }}
+    volumeMounts:
+    {{- if eq .Values.global.pilotCertProvider "istiod" }}
+    - mountPath: /var/run/secrets/istio
+      name: istiod-ca-cert
+    {{- end }}
+    - mountPath: /var/lib/istio/data
+      name: istio-data
+    {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
+    - mountPath: /etc/istio/custom-bootstrap
+      name: custom-bootstrap-volume
     {{- end }}
     # SDS channel between istioagent and Envoy
-    - emptyDir:
-        medium: Memory
+    - mountPath: /etc/istio/proxy
       name: istio-envoy
-    - name: istio-data
-      emptyDir: {}
-    - name: istio-podinfo
-      downwardAPI:
-        items:
-          - path: "labels"
-            fieldRef:
-              fieldPath: metadata.labels
-          - path: "annotations"
-            fieldRef:
-              fieldPath: metadata.annotations
-          - path: "cpu-limit"
-            resourceFieldRef:
-              containerName: istio-proxy
-              resource: limits.cpu
-              divisor: 1m
-          - path: "cpu-request"
-            resourceFieldRef:
-              containerName: istio-proxy
-              resource: requests.cpu
-              divisor: 1m
     {{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
-    - name: istio-token
-      projected:
-        sources:
-        - serviceAccountToken:
-            path: istio-token
-            expirationSeconds: 43200
-            audience: {{ .Values.global.sds.token.aud }}
-    {{- end }}
-    {{- if eq .Values.global.pilotCertProvider "istiod" }}
-    - name: istiod-ca-cert
-      configMap:
-        name: istio-ca-root-cert
+    - mountPath: /var/run/secrets/tokens
+      name: istio-token
     {{- end }}
     {{- if .Values.global.mountMtlsCerts }}
     # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.
-    - name: istio-certs
-      secret:
-        optional: true
-        {{ if eq .Spec.ServiceAccountName "" }}
-        secretName: istio.default
-        {{ else -}}
-        secretName: {{  printf "istio.%s" .Spec.ServiceAccountName }}
-        {{  end -}}
+    - mountPath: /etc/certs/
+      name: istio-certs
+      readOnly: true
     {{- end }}
-      {{- if isset .ObjectMeta.Annotations `sidecar.istio.io/userVolume` }}
-      {{range $index, $value := fromJSON (index .ObjectMeta.Annotations `sidecar.istio.io/userVolume`) }}
-    - name: "{{ $index }}"
-      {{ toYaml $value | indent 4 }}
-      {{ end }}
-      {{ end }}
-    {{- if and (eq .Values.global.proxy.tracer "lightstep") .ProxyConfig.GetTracing.GetTlsSettings }}
-    - name: lightstep-certs
-      secret:
-        optional: true
-        secretName: lightstep.cacert
+    - name: istio-podinfo
+      mountPath: /etc/istio/pod
+     {{- if and (eq .Values.global.proxy.tracer "lightstep") .ProxyConfig.GetTracing.GetTlsSettings }}
+    - mountPath: {{ directory .ProxyConfig.GetTracing.GetTlsSettings.GetCaCertificates }}
+      name: lightstep-certs
+      readOnly: true
     {{- end }}
-    {{- if .Values.global.imagePullSecrets }}
-    imagePullSecrets:
-      {{- range .Values.global.imagePullSecrets }}
-      - name: {{ . }}
+      {{- if isset .ObjectMeta.Annotations `sidecar.istio.io/userVolumeMount` }}
+      {{ range $index, $value := fromJSON (index .ObjectMeta.Annotations `sidecar.istio.io/userVolumeMount`) }}
+    - name: "{{  $index }}"
+      {{ toYaml $value | indent 6 }}
+      {{ end }}
       {{- end }}
+  volumes:
+  {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
+  - name: custom-bootstrap-volume
+    configMap:
+      name: {{ annotation .ObjectMeta `sidecar.istio.io/bootstrapOverride` "" }}
+  {{- end }}
+  # SDS channel between istioagent and Envoy
+  - emptyDir:
+      medium: Memory
+    name: istio-envoy
+  - name: istio-data
+    emptyDir: {}
+  - name: istio-podinfo
+    downwardAPI:
+      items:
+        - path: "labels"
+          fieldRef:
+            fieldPath: metadata.labels
+        - path: "annotations"
+          fieldRef:
+            fieldPath: metadata.annotations
+        - path: "cpu-limit"
+          resourceFieldRef:
+            containerName: istio-proxy
+            resource: limits.cpu
+            divisor: 1m
+        - path: "cpu-request"
+          resourceFieldRef:
+            containerName: istio-proxy
+            resource: requests.cpu
+            divisor: 1m
+  {{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
+  - name: istio-token
+    projected:
+      sources:
+      - serviceAccountToken:
+          path: istio-token
+          expirationSeconds: 43200
+          audience: {{ .Values.global.sds.token.aud }}
+  {{- end }}
+  {{- if eq .Values.global.pilotCertProvider "istiod" }}
+  - name: istiod-ca-cert
+    configMap:
+      name: istio-ca-root-cert
+  {{- end }}
+  {{- if .Values.global.mountMtlsCerts }}
+  # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.
+  - name: istio-certs
+    secret:
+      optional: true
+      {{ if eq .Spec.ServiceAccountName "" }}
+      secretName: istio.default
+      {{ else -}}
+      secretName: {{  printf "istio.%s" .Spec.ServiceAccountName }}
+      {{  end -}}
+  {{- end }}
+    {{- if isset .ObjectMeta.Annotations `sidecar.istio.io/userVolume` }}
+    {{range $index, $value := fromJSON (index .ObjectMeta.Annotations `sidecar.istio.io/userVolume`) }}
+  - name: "{{ $index }}"
+    {{ toYaml $value | indent 4 }}
+    {{ end }}
+    {{ end }}
+  {{- if and (eq .Values.global.proxy.tracer "lightstep") .ProxyConfig.GetTracing.GetTlsSettings }}
+  - name: lightstep-certs
+    secret:
+      optional: true
+      secretName: lightstep.cacert
+  {{- end }}
+  {{- if .Values.global.imagePullSecrets }}
+  imagePullSecrets:
+    {{- range .Values.global.imagePullSecrets }}
+    - name: {{ . }}
     {{- end }}
-    {{- if eq (env "ENABLE_LEGACY_FSGROUP_INJECTION" "true") "true" }}
-    securityContext:
-      fsGroup: 1337
-    {{- end }}
+  {{- end }}
+  {{- if eq (env "ENABLE_LEGACY_FSGROUP_INJECTION" "true") "true" }}
+  securityContext:
+    fsGroup: 1337
+  {{- end }}

--- a/manifests/charts/istiod-remote/templates/istiod-injector-configmap.yaml
+++ b/manifests/charts/istiod-remote/templates/istiod-injector-configmap.yaml
@@ -32,7 +32,8 @@ data:
       {{- range $key, $val := .Values.sidecarInjectorWebhook.injectedAnnotations }}
       "{{ $key }}": "{{ $val }}"
       {{- end }}
-
-{{ .Files.Get "files/injection-template.yaml" | trim | indent 4 }}
+    templates:
+      sidecar: |
+{{ .Files.Get "files/injection-template.yaml" | trim | indent 8 }}
 
 {{- end }}


### PR DESCRIPTION
Allows our templates to be in dedicated files. This makes it easier to
edit (IDE will see a helm template, rather than opaque string), and also
allows us to allow a values.sidecar.additionalTemplates field in a
followup PR. This is not possible today, as the injection template is
NOT templated by Helm, so we need to move the field level a bit up.

For webhook users, this has no impact (but will enable more features in
a followup). For kube-inject users, this allows them use a different
file format (just drop the `template:` key and unindent by 2) *if they
want* - the old format is still allowed.
