### PR TITLE
remove use deprecated envoy.listener.original_src

### DIFF
--- a/pilot/pkg/xds/filters/filters.go
+++ b/pilot/pkg/xds/filters/filters.go
@@ -42,12 +42,9 @@ import (
 )
 
 const (
-	OriginalSrcFilterName = "envoy.listener.original_src"
+	OriginalSrcFilterName = "envoy.filters.listener.original_src"
 	// Alpn HTTP filter name which will override the ALPN for upstream TLS connection.
 	AlpnFilterName = "istio.alpn"
-
-	// DNSListenerFilterName is the name of UDP listener filter for resolving DNS queries
-	DNSListenerFilterName = "envoy.filters.udp.dns_filter"
 
 	TLSTransportProtocol       = "tls"
 	RawBufferTransportProtocol = "raw_buffer"

--- a/tools/istio-iptables/pkg/cmd/run.go
+++ b/tools/istio-iptables/pkg/cmd/run.go
@@ -492,7 +492,7 @@ func (iptConfigurator *IptablesConfigurator) run() {
 	}
 
 	if iptConfigurator.cfg.InboundInterceptionMode == constants.TPROXY {
-		// save packet mark set by envoy.listener.original_src as connection mark
+		// save packet mark set by envoy.filters.listener.original_src as connection mark
 		iptConfigurator.iptables.AppendRuleV4(constants.PREROUTING, constants.MANGLE,
 			"-p", constants.TCP, "-m", "mark", "--mark", iptConfigurator.cfg.InboundTProxyMark, "-j", "CONNMARK", "--save-mark")
 		// mark outgoing packets from workload, match it to policy routing entry setup for TPROXY mode


### PR DESCRIPTION
It was deprecated since https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.14.0#deprecated