### PR TITLE
Use ctx.Run rather than t.Run in integration/pilot tests

### DIFF
--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -263,7 +263,7 @@ spec:
 				})
 			}
 
-			ctx.NewSubTest("status").Run(func (ctx framework.TestContext) {
+			ctx.NewSubTest("status").Run(func(ctx framework.TestContext) {
 				if !ctx.Environment().(*kube.Environment).Settings().LoadBalancerSupported {
 					t.Skip("ingress status not supported without load balancer")
 				}

--- a/tests/integration/pilot/ingress_test.go
+++ b/tests/integration/pilot/ingress_test.go
@@ -263,13 +263,13 @@ spec:
 				})
 			}
 
-			t.Run("status", func(t *testing.T) {
+			ctx.NewSubTest("status").Run(func (ctx framework.TestContext) {
 				if !ctx.Environment().(*kube.Environment).Settings().LoadBalancerSupported {
 					t.Skip("ingress status not supported without load balancer")
 				}
 
 				ip := apps.Ingress.HTTPAddress().IP.String()
-				retry.UntilSuccessOrFail(t, func() error {
+				retry.UntilSuccessOrFail(ctx, func() error {
 					ing, err := ctx.Clusters().Default().NetworkingV1beta1().Ingresses(apps.Namespace.Name()).Get(context.Background(), "ingress", metav1.GetOptions{})
 					if err != nil {
 						return err

--- a/tests/integration/pilot/multi_version_revision_test.go
+++ b/tests/integration/pilot/multi_version_revision_test.go
@@ -64,7 +64,7 @@ func TestMultiVersionRevision(t *testing.T) {
 
 			revisionedNamespaces := []revisionedNamespace{}
 			for _, v := range installVersions {
-				installRevisionOrFail(ctx, t, v, configs)
+				installRevisionOrFail(ctx, v, configs)
 
 				// create a namespace pointed to the revisioned control plane we just installed
 				rev := strings.ReplaceAll(v, ".", "-")
@@ -74,7 +74,7 @@ func TestMultiVersionRevision(t *testing.T) {
 					Revision: rev,
 				})
 				if err != nil {
-					t.Fatalf("failed to created revisioned namespace: %v", err)
+					ctx.Fatalf("failed to created revisioned namespace: %v", err)
 				}
 				revisionedNamespaces = append(revisionedNamespaces, revisionedNamespace{
 					revision:  rev,
@@ -114,14 +114,14 @@ func TestMultiVersionRevision(t *testing.T) {
 					},
 				})
 			}
-			builder.BuildOrFail(t)
-			testAllEchoCalls(t, instances)
+			builder.BuildOrFail(ctx)
+			testAllEchoCalls(ctx, instances)
 		})
 }
 
 // testAllEchoCalls takes list of revisioned namespaces and generates list of echo calls covering
 // communication between every pair of namespaces
-func testAllEchoCalls(t *testing.T, echoInstances []echo.Instance) {
+func testAllEchoCalls(ctx framework.TestContext, echoInstances []echo.Instance) {
 	trafficTypes := []string{"http", "tcp", "grpc"}
 	for _, source := range echoInstances {
 		for _, dest := range echoInstances {
@@ -129,8 +129,9 @@ func testAllEchoCalls(t *testing.T, echoInstances []echo.Instance) {
 				continue
 			}
 			for _, trafficType := range trafficTypes {
-				t.Run(fmt.Sprintf("%s-%s->%s", trafficType, source.Config().Service, dest.Config().Service), func(t *testing.T) {
-					retry.UntilSuccessOrFail(t, func() error {
+				ctx.NewSubTest(fmt.Sprintf("%s-%s->%s", trafficType, source.Config().Service, dest.Config().Service)).
+					Run(func (ctx framework.TestContext){
+					retry.UntilSuccessOrFail(ctx, func() error {
 						resp, err := source.Call(echo.CallOptions{
 							Target:   dest,
 							PortName: trafficType,
@@ -148,16 +149,16 @@ func testAllEchoCalls(t *testing.T, echoInstances []echo.Instance) {
 
 // installRevisionOrFail takes an Istio version and installs a revisioned control plane running that version
 // provided istio version must be present in tests/integration/pilot/testdata/upgrade for the installation to succeed
-func installRevisionOrFail(ctx framework.TestContext, t *testing.T, version string, configs map[string]string) {
+func installRevisionOrFail(ctx framework.TestContext, version string, configs map[string]string) {
 	installationTestdataDir := filepath.Join(env.IstioSrc, "tests/integration/pilot/testdata/upgrade")
 	installationConfigPath := filepath.Join(installationTestdataDir, fmt.Sprintf("%s-install.yaml", version))
 	configBytes, err := ioutil.ReadFile(installationConfigPath)
 	if err != nil {
-		t.Fatalf("could not read installation config at path %s: %v", installationConfigPath, err)
+		ctx.Fatalf("could not read installation config at path %s: %v", installationConfigPath, err)
 	}
 
 	configs[version] = string(configBytes)
-	ctx.Config().ApplyYAMLOrFail(t, i.Settings().SystemNamespace, string(configBytes))
+	ctx.Config().ApplyYAMLOrFail(ctx, i.Settings().SystemNamespace, string(configBytes))
 }
 
 // skipIfK8sVersionUnsupported skips the test if we're running on a k8s version that is not expected to work

--- a/tests/integration/pilot/multi_version_revision_test.go
+++ b/tests/integration/pilot/multi_version_revision_test.go
@@ -130,18 +130,18 @@ func testAllEchoCalls(ctx framework.TestContext, echoInstances []echo.Instance) 
 			}
 			for _, trafficType := range trafficTypes {
 				ctx.NewSubTest(fmt.Sprintf("%s-%s->%s", trafficType, source.Config().Service, dest.Config().Service)).
-					Run(func (ctx framework.TestContext){
-					retry.UntilSuccessOrFail(ctx, func() error {
-						resp, err := source.Call(echo.CallOptions{
-							Target:   dest,
-							PortName: trafficType,
-						})
-						if err != nil {
-							return err
-						}
-						return resp.CheckOK()
-					}, retry.Delay(time.Millisecond*150))
-				})
+					Run(func(ctx framework.TestContext) {
+						retry.UntilSuccessOrFail(ctx, func() error {
+							resp, err := source.Call(echo.CallOptions{
+								Target:   dest,
+								PortName: trafficType,
+							})
+							if err != nil {
+								return err
+							}
+							return resp.CheckOK()
+						}, retry.Delay(time.Millisecond*150))
+					})
 			}
 		}
 	}

--- a/tests/integration/pilot/revisioned_upgrade_test.go
+++ b/tests/integration/pilot/revisioned_upgrade_test.go
@@ -62,7 +62,7 @@ func testUpgradeFromVersion(ctx framework.TestContext, t *testing.T, fromVersion
 	})
 
 	// install control plane on the specified version and create namespace pointed to that control plane
-	installRevisionOrFail(ctx, t, fromVersion, configs)
+	installRevisionOrFail(ctx, fromVersion, configs)
 	revision := strings.ReplaceAll(fromVersion, ".", "-")
 	revisionedNamespace := namespace.NewOrFail(t, ctx, namespace.Config{
 		Prefix:   revision,


### PR DESCRIPTION
Cleanup PR, moves from `t.Run(...)` to `ctx.NewSubtest(...).Run(...)` in `integration/pilot` suite (per [writing good integration tests](https://github.com/istio/istio/wiki/Writing-Good-Integration-Tests#prefer-frameworktestcontext-over-testingt) guide)

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
