### PR TITLE
do not use the name label key in namespaceSelector

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/mutatingwebhook.yaml
@@ -37,10 +37,6 @@ webhooks:
     namespaceSelector:
 {{- if .Values.sidecarInjectorWebhook.enableNamespacesByDefault }}
       matchExpressions:
-      - key: name
-        operator: NotIn
-        values:
-        - {{ .Release.Namespace }}
       - key: istio-injection
         operator: NotIn
         values:

--- a/manifests/charts/istiod-remote/templates/mutatingwebhook.yaml
+++ b/manifests/charts/istiod-remote/templates/mutatingwebhook.yaml
@@ -37,10 +37,6 @@ webhooks:
     namespaceSelector:
 {{- if .Values.sidecarInjectorWebhook.enableNamespacesByDefault }}
       matchExpressions:
-      - key: name
-        operator: NotIn
-        values:
-        - {{ .Release.Namespace }}
       - key: istio-injection
         operator: NotIn
         values:

--- a/pkg/kube/inject/inject.go
+++ b/pkg/kube/inject/inject.go
@@ -659,7 +659,8 @@ func IntoObject(sidecarTemplate Templates, valuesConfig string, revision string,
 		ObjectMeta: *metadata,
 		Spec:       *podSpec,
 	}
-	if !injectRequired(ignoredNamespaces, &Config{Policy: InjectionPolicyEnabled}, &pod.Spec, pod.ObjectMeta) {
+	filteredNamespaces := append(ignoredNamespaces, meshconfig.RootNamespace)
+	if !injectRequired(filteredNamespaces, &Config{Policy: InjectionPolicyEnabled}, &pod.Spec, pod.ObjectMeta) {
 		warningHandler(fmt.Sprintf("===> Skipping injection because %q has sidecar injection disabled\n", name))
 		return out, nil
 	}

--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -745,7 +745,8 @@ func (wh *Webhook) inject(ar *kube.AdmissionReview, path string) *kube.Admission
 	log.Debugf("OldObject: %v", string(req.OldObject.Raw))
 
 	wh.mu.RLock()
-	if !injectRequired(ignoredNamespaces, wh.Config, &pod.Spec, pod.ObjectMeta) {
+	filteredNamespaces := append(ignoredNamespaces, wh.meshConfig.RootNamespace)
+	if !injectRequired(filteredNamespaces, wh.Config, &pod.Spec, pod.ObjectMeta) {
 		log.Infof("Skipping %s/%s due to policy check", pod.ObjectMeta.Namespace, podName)
 		totalSkippedInjections.Increment()
 		wh.mu.RUnlock()


### PR DESCRIPTION

Based on discussions in environments WG, we have arrived at the understanding that using the `name:` label key in MWC's namespaceSelector is problematic and bad-practice overall. This PR removes that completely and does is so in a way it won't break users who might be relying on this particular helm logic


[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.