### PR TITLE
WIP: improve the serviceentryhandle performance

### DIFF
--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -290,7 +290,7 @@ func convertWorkloadEntryToServiceInstances(wle *networking.WorkloadEntry, servi
 	for _, service := range services {
 		for _, port := range se.Ports {
 			serviceInstance := convertEndpoint(service, port, wle, wleck)
-			out[makeIpKey(serviceInstance)] = serviceInstance
+			out[makeIPKey(serviceInstance)] = serviceInstance
 		}
 	}
 	return out
@@ -326,11 +326,11 @@ func convertServiceEntryToInstances(cfg config.Config, services []*model.Service
 					Service:     service,
 					ServicePort: convertPort(serviceEntryPort),
 				}
-				out[makeIpKey(serviceInstance)] = serviceInstance
+				out[makeIPKey(serviceInstance)] = serviceInstance
 			} else {
 				for _, endpoint := range serviceEntry.Endpoints {
 					serviceInstance := convertEndpoint(service, serviceEntryPort, endpoint, &configKey{})
-					out[makeIpKey(serviceInstance)] = serviceInstance
+					out[makeIPKey(serviceInstance)] = serviceInstance
 				}
 			}
 		}
@@ -373,7 +373,7 @@ func convertWorkloadInstanceToServiceInstance(workloadInstance *model.IstioEndpo
 				Service:     service,
 				ServicePort: convertPort(serviceEntryPort),
 			}
-			out[makeIpKey(serviceInstance)] = serviceInstance
+			out[makeIPKey(serviceInstance)] = serviceInstance
 		}
 	}
 	return out

--- a/pilot/pkg/serviceregistry/serviceentry/conversion.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion.go
@@ -286,7 +286,7 @@ func convertEndpoint(service *model.Service, servicePort *networking.Port,
 // same as the ServiceEntry convertServiceEntryToInstances.
 func convertWorkloadEntryToServiceInstances(wle *networking.WorkloadEntry, services []*model.Service,
 	se *networking.ServiceEntry, wleck *configKey) map[ipKey]*model.ServiceInstance {
-	out := make(map[ipKey]*model.ServiceInstance, 0)
+	out := make(map[ipKey]*model.ServiceInstance)
 	for _, service := range services {
 		for _, port := range se.Ports {
 			serviceInstance := convertEndpoint(service, port, wle, wleck)
@@ -297,7 +297,7 @@ func convertWorkloadEntryToServiceInstances(wle *networking.WorkloadEntry, servi
 }
 
 func convertServiceEntryToInstances(cfg config.Config, services []*model.Service) map[ipKey]*model.ServiceInstance {
-	out := make(map[ipKey]*model.ServiceInstance, 0)
+	out := make(map[ipKey]*model.ServiceInstance)
 	serviceEntry := cfg.Spec.(*networking.ServiceEntry)
 	if services == nil {
 		services = convertServices(cfg)
@@ -355,7 +355,7 @@ func getTLSModeFromWorkloadEntry(wle *networking.WorkloadEntry) string {
 // We need to create our own but we can retain the endpoint already created.
 func convertWorkloadInstanceToServiceInstance(workloadInstance *model.IstioEndpoint, serviceEntryServices []*model.Service,
 	serviceEntry *networking.ServiceEntry) map[ipKey]*model.ServiceInstance {
-	out := make(map[ipKey]*model.ServiceInstance, 0)
+	out := make(map[ipKey]*model.ServiceInstance)
 	for _, service := range serviceEntryServices {
 		for _, serviceEntryPort := range serviceEntry.Ports {
 			ep := *workloadInstance

--- a/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/conversion_test.go
@@ -714,7 +714,8 @@ func TestConvertInstances(t *testing.T) {
 
 	for _, tt := range serviceInstanceTests {
 		t.Run(strings.Join(tt.externalSvc.Spec.(*networking.ServiceEntry).Hosts, "_"), func(t *testing.T) {
-			instances := convertServiceEntryToInstances(*tt.externalSvc, nil)
+			instancesMap := convertServiceEntryToInstances(*tt.externalSvc, nil)
+			instances := convertInstanceMapToList(instancesMap)
 			sortServiceInstances(instances)
 			sortServiceInstances(tt.out)
 			if err := compare(t, instances, tt.out); err != nil {
@@ -779,7 +780,8 @@ func TestConvertWorkloadEntryToServiceInstances(t *testing.T) {
 	for _, tt := range serviceInstanceTests {
 		t.Run(tt.name, func(t *testing.T) {
 			services := convertServices(*tt.se)
-			instances := convertWorkloadEntryToServiceInstances(tt.wle, services, tt.se.Spec.(*networking.ServiceEntry), &configKey{})
+			instancesMap := convertWorkloadEntryToServiceInstances(tt.wle, services, tt.se.Spec.(*networking.ServiceEntry), &configKey{})
+			instances := convertInstanceMapToList(instancesMap)
 			sortServiceInstances(instances)
 			sortServiceInstances(tt.out)
 			if err := compare(t, instances, tt.out); err != nil {

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
@@ -15,6 +15,7 @@
 package serviceentry
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -53,10 +54,15 @@ type ipKey struct {
 	service   string
 	namespace string
 	port      int
+	labels    string
 }
 
 func makeIPKey(i *model.ServiceInstance) ipKey {
-	return ipKey{i.Endpoint.Address, string(i.Service.Hostname), i.Service.Attributes.Namespace, i.ServicePort.Port}
+	labelBytes, err := json.Marshal(i.Endpoint.Labels)
+	if err != nil {
+		labelBytes = []byte{}
+	}
+	return ipKey{i.Endpoint.Address, string(i.Service.Hostname), i.Service.Attributes.Namespace, i.ServicePort.Port, string(labelBytes)}
 }
 
 type externalConfigType int

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
@@ -391,7 +391,7 @@ func (s *ServiceEntryStore) serviceEntryHandler(old, curr config.Config, event m
 				s.instances[ikey][key] = []*model.ServiceInstance{}
 			}
 			for key := range dip {
-				for instanceKey, _ := range dip[key] {
+				for instanceKey := range dip[key] {
 					if _, exists := s.ip2instance[key]; exists {
 						delete(s.ip2instance[key], instanceKey)
 					}
@@ -408,7 +408,7 @@ func (s *ServiceEntryStore) serviceEntryHandler(old, curr config.Config, event m
 					s.instances[ikey][key] = []*model.ServiceInstance{}
 				}
 				for key := range dip {
-					for instanceKey, _ := range dip[key] {
+					for instanceKey := range dip[key] {
 						if _, exists := s.ip2instance[key]; exists {
 							delete(s.ip2instance[key], instanceKey)
 						}
@@ -428,7 +428,7 @@ func (s *ServiceEntryStore) serviceEntryHandler(old, curr config.Config, event m
 					s.instances[ikey][key] = []*model.ServiceInstance{}
 				}
 				for key := range delDip {
-					for instanceKey, _ := range dip[key] {
+					for instanceKey := range dip[key] {
 						if _, exists := s.ip2instance[key]; exists {
 							delete(s.ip2instance[key], instanceKey)
 						}

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
@@ -359,9 +359,9 @@ func (s *ServiceEntryStore) serviceEntryHandler(old, curr config.Config, event m
 	}
 
 	serviceEntry := curr.Spec.(*networking.ServiceEntry)
-	portChanged := false
+	serviceDataChanged := false
 	if event == model.EventUpdate && len(addedSvcs)+len(updatedSvcs) > 0 {
-		portChanged = true
+		serviceDataChanged = true
 	}
 	s.storeMutex.Lock()
 	if serviceEntry.WorkloadSelector == nil {
@@ -408,11 +408,11 @@ func (s *ServiceEntryStore) serviceEntryHandler(old, curr config.Config, event m
 					}
 				}
 			}
-			if portChanged {
+			if serviceDataChanged {
 				// delete all
 				delDi := map[instancesKey]map[configKey][]*model.ServiceInstance{}
 				delDip := map[string]map[ipKey]*model.ServiceInstance{}
-				updateInstances(key, convertServiceEntryToInstances(old, append(allServices)), delDi, delDip)
+				updateInstances(key, convertServiceEntryToInstances(old, allServices), delDi, delDip)
 				for ikey := range delDi {
 					if _, f := s.instances[ikey]; !f {
 						s.instances[ikey] = map[configKey][]*model.ServiceInstance{}
@@ -495,7 +495,7 @@ func (s *ServiceEntryStore) serviceEntryHandler(old, curr config.Config, event m
 	} else {
 		//1. process pods
 		workloadInstanceCount := 0
-		if portChanged {
+		if serviceDataChanged {
 			oldServiceEntry := old.Spec.(*networking.ServiceEntry)
 			di := map[instancesKey]map[configKey][]*model.ServiceInstance{}
 			dip := map[string]map[ipKey]*model.ServiceInstance{}

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery.go
@@ -56,7 +56,7 @@ type ipKey struct {
 	labels    string
 }
 
-func makeIpKey(i *model.ServiceInstance) ipKey {
+func makeIPKey(i *model.ServiceInstance) ipKey {
 	labelStr, err := json.Marshal(i.Endpoint.Labels)
 	if err != nil {
 		labelStr = []byte{}
@@ -177,7 +177,7 @@ func (s *ServiceEntryStore) workloadEntryHandler(old, curr config.Config, event 
 					selected = true
 					instance := convertWorkloadEntryToServiceInstances(oldWle, se.services, se.entry, &key)
 					for _, ins := range instance {
-						instancesDeleted[makeIpKey(ins)] = ins
+						instancesDeleted[makeIPKey(ins)] = ins
 					}
 				}
 			}
@@ -185,7 +185,7 @@ func (s *ServiceEntryStore) workloadEntryHandler(old, curr config.Config, event 
 			selected = true
 			instance := convertWorkloadEntryToServiceInstances(wle, se.services, se.entry, &key)
 			for _, ins := range instance {
-				instancesUpdated[makeIpKey(ins)] = ins
+				instancesUpdated[makeIPKey(ins)] = ins
 			}
 		}
 
@@ -636,13 +636,13 @@ func (s *ServiceEntryStore) WorkloadInstanceHandler(wi *model.WorkloadInstance, 
 		}
 		instance := convertWorkloadInstanceToServiceInstance(wi.Endpoint, se.services, se.entry)
 		for _, ins := range instance {
-			instances[makeIpKey(ins)] = ins
+			instances[makeIPKey(ins)] = ins
 		}
 		if addressToDelete != "" {
 			for _, i := range instance {
 				di := i.DeepCopy()
 				di.Endpoint.Address = addressToDelete
-				instancesDeleted[makeIpKey(di)] = di
+				instancesDeleted[makeIPKey(di)] = di
 			}
 		}
 	}
@@ -758,7 +758,7 @@ func (s *ServiceEntryStore) ResyncEDS() {
 	for _, imap := range s.instances {
 		for _, i := range imap {
 			for _, ins := range i {
-				allInstances[makeIpKey(ins)] = ins
+				allInstances[makeIPKey(ins)] = ins
 			}
 		}
 	}
@@ -879,7 +879,7 @@ func updateInstances(key configKey, instances map[ipKey]*model.ServiceInstance,
 		if _, f := instanceMap[ikey]; !f {
 			instanceMap[ikey] = map[configKey][]*model.ServiceInstance{}
 		}
-		jkey := makeIpKey(instance)
+		jkey := makeIPKey(instance)
 		instanceMap[ikey][key] = append(instanceMap[ikey][key], instance)
 		if ip2instance[instance.Endpoint.Address] == nil {
 			ip2instance[instance.Endpoint.Address] = make(map[ipKey]*model.ServiceInstance)

--- a/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/serviceentry/servicediscovery_test.go
@@ -1213,6 +1213,13 @@ func sortServiceInstances(instances []*model.ServiceInstance) {
 		return instances[i].Service.Hostname < instances[j].Service.Hostname
 	})
 }
+func convertInstanceMapToList(instancesMap map[ipKey]*model.ServiceInstance) []*model.ServiceInstance {
+	instances := make([]*model.ServiceInstance, 0)
+	for _, v := range instancesMap {
+		instances = append(instances, v)
+	}
+	return instances
+}
 
 func sortPorts(ports []*model.Port) {
 	sort.Slice(ports, func(i, j int) bool {

--- a/pilot/test/xdstest/extract.go
+++ b/pilot/test/xdstest/extract.go
@@ -122,9 +122,9 @@ func ExtractHTTPConnectionManager(t test.Failer, fcs *listener.FilterChain) *hcm
 	return nil
 }
 
-func ExtractLoadAssignments(cla []*endpoint.ClusterLoadAssignment) map[string][]string {
+func ExtractLoadAssignments(clas []*endpoint.ClusterLoadAssignment) map[string][]string {
 	got := map[string][]string{}
-	for _, cla := range cla {
+	for _, cla := range clas {
 		if cla == nil {
 			continue
 		}

--- a/pilot/test/xdstest/extract.go
+++ b/pilot/test/xdstest/extract.go
@@ -122,9 +122,9 @@ func ExtractHTTPConnectionManager(t test.Failer, fcs *listener.FilterChain) *hcm
 	return nil
 }
 
-func ExtractLoadAssignments(clas []*endpoint.ClusterLoadAssignment) map[string][]string {
+func ExtractLoadAssignments(cla []*endpoint.ClusterLoadAssignment) map[string][]string {
 	got := map[string][]string{}
-	for _, cla := range clas {
+	for _, cla := range cla {
 		if cla == nil {
 			continue
 		}


### PR DESCRIPTION
### improve the performance with serviceentry & workloadnentry

[x] Performance and Scalability

When use  ```maybeRefreshIndexes``` to do a full update, the performance is terrible.
I have 5000 wles and 5000 serviceentries in the same namespace. once do a full update, it will be executed for 25 000 000 times.
From prometheus metrics , cds update time quantile(0.9) will use at least 1min.
```
	for _, wcfg := range wles { 
		wle := wcfg.Spec.(*networking.WorkloadEntry)
		key := configKey{
			kind:      workloadEntryConfigType,
			name:      wcfg.Name,
			namespace: wcfg.Namespace,
		}
		// We will only select entries in the same namespace
		entries := seWithSelectorByNamespace[wcfg.Namespace]
		for _, se := range entries {
			workloadLabels := labels.Collection{wle.Labels}
			if !workloadLabels.IsSupersetOf(se.entry.WorkloadSelector.Labels) {
				// Not a match, skip this one
				continue
			}
			updateInstances(key, convertWorkloadEntryToServiceInstances(wle, se.services, se.entry, &key), instanceMap, ip2instances)
		}
	}
```

I remove function ```maybeRefreshIndexes``` body, update instancesmap in ```servicentryhandler```.
In my environment, it does work and cds update time reduce to 1s.
But it may have some problems by design.