### PR TITLE
[test-framework] Add restart to echo instance

### DIFF
--- a/pkg/test/framework/components/echo/common/envoy_test.go
+++ b/pkg/test/framework/components/echo/common/envoy_test.go
@@ -120,6 +120,10 @@ func (*testConfig) ForwardEcho(_ context.Context, _ *proto.ForwardEchoRequest) (
 	panic("not implemented")
 }
 
+func (*testConfig) Rollout() error {
+	panic("not implemented")
+}
+
 type fakeNamespace struct {
 	name string
 }

--- a/pkg/test/framework/components/echo/common/envoy_test.go
+++ b/pkg/test/framework/components/echo/common/envoy_test.go
@@ -120,7 +120,7 @@ func (*testConfig) ForwardEcho(_ context.Context, _ *proto.ForwardEchoRequest) (
 	panic("not implemented")
 }
 
-func (*testConfig) Rollout() error {
+func (*testConfig) Restart() error {
 	panic("not implemented")
 }
 

--- a/pkg/test/framework/components/echo/echo.go
+++ b/pkg/test/framework/components/echo/echo.go
@@ -76,6 +76,9 @@ type Instance interface {
 	// options. If no options are provided, uses defaults.
 	CallWithRetry(options CallOptions, retryOptions ...retry.Option) (client.ParsedResponses, error)
 	CallWithRetryOrFail(t test.Failer, options CallOptions, retryOptions ...retry.Option) client.ParsedResponses
+
+	// Rollout restarts the workloads associated with this echo instance
+	Rollout() error
 }
 
 // Workload port exposed by an Echo instance

--- a/pkg/test/framework/components/echo/echo.go
+++ b/pkg/test/framework/components/echo/echo.go
@@ -77,8 +77,8 @@ type Instance interface {
 	CallWithRetry(options CallOptions, retryOptions ...retry.Option) (client.ParsedResponses, error)
 	CallWithRetryOrFail(t test.Failer, options CallOptions, retryOptions ...retry.Option) client.ParsedResponses
 
-	// Rollout restarts the workloads associated with this echo instance
-	Rollout() error
+	// Restart restarts the workloads associated with this echo instance
+	Restart() error
 }
 
 // Workload port exposed by an Echo instance

--- a/pkg/test/framework/components/echo/kube/instance.go
+++ b/pkg/test/framework/components/echo/kube/instance.go
@@ -26,8 +26,6 @@ import (
 	"strings"
 	"time"
 
-	"istio.io/istio/pkg/test/shell"
-
 	"github.com/hashicorp/go-multierror"
 	kubeCore "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -48,6 +46,7 @@ import (
 	"istio.io/istio/pkg/test/framework/resource"
 	kubeTest "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/pkg/test/scopes"
+	"istio.io/istio/pkg/test/shell"
 	"istio.io/istio/pkg/test/util/retry"
 	"istio.io/istio/pkg/util/gogoprotomarshal"
 )

--- a/pkg/test/framework/components/echo/kube/instance.go
+++ b/pkg/test/framework/components/echo/kube/instance.go
@@ -602,7 +602,7 @@ func (c *instance) Restart() error {
 		return err
 	}
 	// give the rollout a few seconds to get underway
-	time.Sleep(time.Second * 2)
+	time.Sleep(time.Second * 4)
 	var pods []kubeCore.Pod
 	err = retry.UntilSuccess(func() error {
 		pods, err = kubeTest.CheckPodsAreReady(fetch)

--- a/pkg/test/framework/components/echo/kube/instance.go
+++ b/pkg/test/framework/components/echo/kube/instance.go
@@ -588,7 +588,7 @@ func (c *instance) CallWithRetryOrFail(t test.Failer, opts echo.CallOptions,
 	return r
 }
 
-func (c *instance) Rollout() error {
+func (c *instance) Restart() error {
 	if err := c.Close(); err != nil {
 		return err
 	}

--- a/pkg/test/framework/components/echo/kube/instance.go
+++ b/pkg/test/framework/components/echo/kube/instance.go
@@ -598,7 +598,7 @@ func (c *instance) Restart() error {
 	if err != nil {
 		return err
 	}
-	if err := c.restartNamespaceDeployments(); err != nil {
+	if err := c.restartEchoDeployments(); err != nil {
 		return err
 	}
 	// give the rollout a few seconds to get underway
@@ -627,8 +627,8 @@ func (c *instance) Restart() error {
 	return nil
 }
 
-//restartNamespaceDeployments performs a `kubectl rollout restart` on the instance namespace.
-func (c *instance) restartNamespaceDeployments() error {
+//restartEchoDeployments performs a `kubectl rollout restart` on the echo deployments.
+func (c *instance) restartEchoDeployments() error {
 	var errs error
 	for _, s := range c.cfg.Subsets {
 		// TODO(Monkeyanator) move to common place so doesn't fall out of sync with templates

--- a/pkg/test/framework/components/echo/kube/instance.go
+++ b/pkg/test/framework/components/echo/kube/instance.go
@@ -602,7 +602,7 @@ func (c *instance) Restart() error {
 		return err
 	}
 	// give the rollout a few seconds to get underway
-	time.Sleep(time.Second * 3)
+	time.Sleep(time.Second * 2)
 	var pods []kubeCore.Pod
 	err = retry.UntilSuccess(func() error {
 		pods, err = kubeTest.CheckPodsAreReady(fetch)
@@ -631,6 +631,7 @@ func (c *instance) Restart() error {
 func (c *instance) restartNamespaceDeployments() error {
 	var errs error
 	for _, s := range c.cfg.Subsets {
+		// TODO(Monkeyanator) move to common place so doesn't fall out of sync with templates
 		deploymentName := fmt.Sprintf("%s-%s", c.cfg.Service, s.Version)
 		execCmd := fmt.Sprintf("kubectl rollout restart deployment/%s -n %s", deploymentName, c.cfg.Namespace.Name())
 		_, err := shell.Execute(true, execCmd)

--- a/tests/integration/pilot/multi_version_revision_test.go
+++ b/tests/integration/pilot/multi_version_revision_test.go
@@ -49,7 +49,6 @@ func TestMultiVersionRevision(t *testing.T) {
 			skipIfK8sVersionUnsupported(ctx)
 
 			// keep these at the latest patch version of each minor version
-			// TODO(samnaser) add 1.7.4 once we flag-protection for reading service-api CRDs (https://github.com/istio/istio/issues/29054)
 			installVersions := []string{"1.6.11", "1.7.6", "1.8.0"}
 
 			// keep track of applied configurations and clean up after the test

--- a/tests/integration/pilot/revisioned_upgrade_test.go
+++ b/tests/integration/pilot/revisioned_upgrade_test.go
@@ -96,8 +96,8 @@ func testUpgradeFromVersion(ctx framework.TestContext, t *testing.T, fromVersion
 	}
 	for _, p := range pods {
 		for _, c := range p.Spec.Containers {
-			if !strings.Contains(c.Image, ":latest") {
-				ctx.Fatalf("expected post-upgrade container image with tag %q, got %s", "latest", c.Image)
+			if strings.Contains(c.Image, fromVersion) {
+				ctx.Fatalf("expected post-upgrade container image not to include %q, got %s", fromVersion, c.Image)
 			}
 		}
 	}

--- a/tests/integration/pilot/revisioned_upgrade_test.go
+++ b/tests/integration/pilot/revisioned_upgrade_test.go
@@ -84,10 +84,10 @@ func testUpgradeFromVersion(ctx framework.TestContext, t *testing.T, fromVersion
 	sendSimpleTrafficOrFail(t, revisionedInstance)
 
 	if err := enableDefaultInjection(revisionedNamespace); err != nil {
-		t.Fatalf("could not relabel namespace to enable default injection: %v", err)
+		ctx.Fatalf("could not relabel namespace to enable default injection: %v", err)
 	}
 	if err := revisionedInstance.Restart(); err != nil {
-		t.Fatalf("revisioned instance rollout failed with: %v", err)
+		ctx.Fatalf("revisioned instance rollout failed with: %v", err)
 	}
 	fetch := kubetest.NewPodMustFetch(ctx.Clusters().Default(), revisionedInstance.Config().Namespace.Name(), fmt.Sprintf("app=%s", revisionedInstance.Config().Service)) // nolint: lll
 	pods, err := kubetest.CheckPodsAreReady(fetch)

--- a/tests/integration/pilot/revisioned_upgrade_test.go
+++ b/tests/integration/pilot/revisioned_upgrade_test.go
@@ -20,8 +20,6 @@ import (
 	"strings"
 	"testing"
 
-	kubetest "istio.io/istio/pkg/test/kube"
-
 	"github.com/hashicorp/go-multierror"
 
 	"istio.io/istio/pkg/config/protocol"
@@ -29,6 +27,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
 	"istio.io/istio/pkg/test/framework/components/namespace"
+	kubetest "istio.io/istio/pkg/test/kube"
 )
 
 // TestRevisionedUpgrade tests a revision-based upgrade from the specified versions to current master

--- a/tests/integration/pilot/revisioned_upgrade_test.go
+++ b/tests/integration/pilot/revisioned_upgrade_test.go
@@ -106,14 +106,14 @@ func testUpgradeFromVersion(ctx framework.TestContext, t *testing.T, fromVersion
 }
 
 // sendSimpleTrafficOrFail sends an echo call to the upgrading echo instance
-func sendSimpleTrafficOrFail(t *testing.T, i echo.Instance) {
-	t.Helper()
+func sendSimpleTrafficOrFail(ctx *testing.T, i echo.Instance) {
+	ctx.Helper()
 	resp, err := apps.PodA[0].Call(echo.CallOptions{
 		Target:   i,
 		PortName: "http",
 	})
 	if resp.CheckOK() != nil {
-		t.Fatalf("error in call: %v", err)
+		ctx.Fatalf("error in call: %v", err)
 	}
 }
 

--- a/tests/integration/pilot/revisioned_upgrade_test.go
+++ b/tests/integration/pilot/revisioned_upgrade_test.go
@@ -87,7 +87,7 @@ func testUpgradeFromVersion(ctx framework.TestContext, t *testing.T, fromVersion
 	if err := enableDefaultInjection(revisionedNamespace); err != nil {
 		t.Fatalf("could not relabel namespace to enable default injection: %v", err)
 	}
-	if err := revisionedInstance.Rollout(); err != nil {
+	if err := revisionedInstance.Restart(); err != nil {
 		t.Fatalf("revisioned instance rollout failed with: %v", err)
 	}
 	fetch := kubetest.NewPodMustFetch(ctx.Clusters().Default(), revisionedInstance.Config().Namespace.Name(), fmt.Sprintf("app=%s", revisionedInstance.Config().Service)) // nolint: lll


### PR DESCRIPTION
Allows echo instances to be restarted without port forwarding failures. 

The flow is (1) close all websocket connections to old workloads, (2) do a `kubectl rollout restart` on the echo deployment, and (3) re-initialize the echo instance's workloads.

cc @nmittler since we talked about this a few weeks ago

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
