### PR TITLE
Add support for helm installs to integration framework

### DIFF
--- a/pkg/test/framework/components/istio/config.go
+++ b/pkg/test/framework/components/istio/config.go
@@ -146,6 +146,22 @@ type Config struct {
 	// Indicates that the test should deploy Istio's east west gateway into the target Kubernetes cluster
 	// before running tests.
 	DeployEastWestGW bool
+
+	// Indicates that the test should deploy Istio's using helm charts
+	DeployHelm bool
+}
+
+func (c *Config) OverridesYAML() string {
+	s, err := image.SettingsFromCommandLine()
+	if err != nil {
+		return ""
+	}
+
+	return fmt.Sprintf(`
+global:
+  hub: %s
+  tag: %s
+`, s.Hub, s.Tag)
 }
 
 func (c *Config) IstioOperatorConfigYAML(iopYaml string) string {
@@ -305,6 +321,7 @@ func (c *Config) String() string {
 	result += fmt.Sprintf("ConfigClusterIOPFile:           %s\n", c.ConfigClusterIOPFile)
 	result += fmt.Sprintf("RemoteClusterIOPFile:           %s\n", c.RemoteClusterIOPFile)
 	result += fmt.Sprintf("SkipWaitForValidationWebhook:   %v\n", c.SkipWaitForValidationWebhook)
+	result += fmt.Sprintf("DeployHelm:                     %v\n", c.DeployHelm)
 	return result
 }
 

--- a/pkg/test/framework/components/istio/flags.go
+++ b/pkg/test/framework/components/istio/flags.go
@@ -46,4 +46,6 @@ func init() {
 		"Manual overrides for Helm values file. Only valid when deploying Istio.")
 	flag.BoolVar(&settingsFromCommandline.DeployEastWestGW, "istio.test.kube.deployEastWestGW", settingsFromCommandline.DeployEastWestGW,
 		"Deploy Istio east west gateway into the target Kubernetes environment.")
+	flag.BoolVar(&settingsFromCommandline.DeployHelm, "istio.test.helm.deploy", settingsFromCommandline.DeployHelm,
+		"Deploy Istio into the target Kubernetes environment with Helm.")
 }

--- a/pkg/test/framework/components/istio/helm.go
+++ b/pkg/test/framework/components/istio/helm.go
@@ -1,0 +1,223 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package istio
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"path/filepath"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"istio.io/istio/pkg/test/env"
+	"istio.io/istio/pkg/test/framework/components/environment/kube"
+	"istio.io/istio/pkg/test/framework/components/istio/ingress"
+	"istio.io/istio/pkg/test/framework/image"
+	"istio.io/istio/pkg/test/framework/resource"
+	"istio.io/istio/pkg/test/helm"
+	kube2 "istio.io/istio/pkg/test/kube"
+	"istio.io/istio/pkg/test/scopes"
+	"istio.io/istio/pkg/test/util/retry"
+)
+
+const (
+	ReleasePrefix     = "istio-"
+	BaseChart         = "base"
+	DiscoveryChart    = "istio-discovery"
+	BaseReleaseName   = ReleasePrefix + BaseChart
+	IstiodReleaseName = "istiod"
+	ControlChartsDir  = "istio-control"
+	retryTimeOut      = 5 * time.Minute
+	helmTimeout       = 2 * time.Minute
+)
+
+var _ io.Closer = &helmComponent{}
+var _ Instance = &helmComponent{}
+var _ resource.Dumper = &helmComponent{}
+
+var (
+	// chartPath is path of local Helm charts used for testing.
+	chartPath = filepath.Join(env.IstioSrc, "manifests/charts")
+)
+
+type helmComponent struct {
+	id         resource.ID
+	settings   Config
+	helmCmd    *helm.Helm
+	cs         resource.Cluster
+	deployTime time.Duration
+}
+
+func (h *helmComponent) Dump(ctx resource.Context) {
+	scopes.Framework.Errorf("=== Dumping Istio Deployment State...")
+	ns := h.settings.SystemNamespace
+	d, err := ctx.CreateTmpDirectory("istio-state")
+	if err != nil {
+		scopes.Framework.Errorf("Unable to create directory for dumping Istio contents: %v", err)
+		return
+	}
+	kube2.DumpPods(ctx, d, ns)
+}
+
+func (h *helmComponent) ID() resource.ID {
+	return h.id
+}
+
+func (h *helmComponent) IngressFor(cluster resource.Cluster) ingress.Instance {
+	panic("implement me")
+}
+
+func (h *helmComponent) CustomIngressFor(cluster resource.Cluster, serviceName, istioLabel string) ingress.Instance {
+	panic("implement me")
+}
+
+func (h *helmComponent) RemoteDiscoveryAddressFor(cluster resource.Cluster) (net.TCPAddr, error) {
+	panic("implement me")
+}
+
+func (h *helmComponent) Settings() Config {
+	return h.settings
+}
+
+func (h *helmComponent) Close() error {
+	scopes.Framework.Infof("cleaning up resources")
+	// TODO remove ingress and egress charts
+	if err := h.helmCmd.DeleteChart(IstiodReleaseName, h.settings.IstioNamespace); err != nil {
+		return fmt.Errorf("failed to delete %s release", IstiodReleaseName)
+	}
+	if err := h.helmCmd.DeleteChart(BaseReleaseName, h.settings.IstioNamespace); err != nil {
+		return fmt.Errorf("failed to delete %s release", BaseReleaseName)
+	}
+	if err := h.cs.CoreV1().Namespaces().Delete(context.TODO(), h.settings.IstioNamespace, metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("failed to delete istio namespace: %v", err)
+	}
+	if err := kube2.WaitForNamespaceDeletion(h.cs, h.settings.IstioNamespace, retry.Timeout(retryTimeOut)); err != nil {
+		return fmt.Errorf("wating for istio namespace to be deleted: %v", err)
+	}
+
+	return nil
+}
+
+func deployWithHelm(ctx resource.Context, env *kube.Environment, cfg Config) (Instance, error) {
+	scopes.Framework.Infof("=== Istio Component Config ===")
+	scopes.Framework.Infof("\n%s", cfg.String())
+	scopes.Framework.Infof("================================")
+
+	// install control plane clusters
+	cluster := ctx.Clusters().Default().(*kube.Cluster)
+	helmCmd := helm.New(cluster.Filename(), chartPath)
+
+	h := &helmComponent{
+		settings: cfg,
+		helmCmd:  helmCmd,
+		cs:       cluster,
+	}
+
+	t0 := time.Now()
+	defer func() {
+		h.deployTime = time.Since(t0)
+	}()
+	h.id = ctx.TrackResource(h)
+
+	if !cfg.DeployIstio {
+		scopes.Framework.Info("skipping helm deployment as specified in the config")
+		return h, nil
+	}
+
+	if env.IsMulticluster() || len(ctx.Clusters()) > 1 {
+		scopes.Framework.Error("multicluster support not implemented for helm deployments")
+		return h, nil
+	}
+
+	err := helmInstall(h)
+	if err != nil {
+		scopes.Framework.Error("multicluster support not implemented for helm deployments")
+		return h, err
+	}
+
+	return h, nil
+}
+
+func helmInstall(h *helmComponent) error {
+	scopes.Framework.Infof("setting up %s as control-plane cluster", h.cs.Name())
+
+	if !h.cs.IsConfig() {
+		return fmt.Errorf("cluster is not config cluster")
+	}
+
+	if _, err := h.cs.CoreV1().Namespaces().Create(context.TODO(), &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: h.settings.SystemNamespace,
+		},
+	}, metav1.CreateOptions{}); err != nil {
+		if errors.IsAlreadyExists(err) {
+			if _, err := h.cs.CoreV1().Namespaces().Update(context.TODO(), &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: h.settings.SystemNamespace,
+				},
+			}, metav1.UpdateOptions{}); err != nil {
+				scopes.Framework.Errorf("failed updating namespace %s on cluster %s. This can happen when deploying "+
+					"multiple control planes. Error: %v", h.settings.SystemNamespace, h.cs.Name(), err)
+			}
+		} else {
+			scopes.Framework.Errorf("failed creating namespace %s on cluster %s. This can happen when deploying "+
+				"multiple control planes. Error: %v", h.settings.SystemNamespace, h.cs.Name(), err)
+		}
+	}
+
+	overridesArgs, err := generateCommonInstallSettings(h.settings)
+	if err != nil {
+		return fmt.Errorf("failed to install istio %s chart", BaseChart)
+	}
+
+	// Install base chart
+	err = h.helmCmd.InstallChartWithValues(BaseReleaseName, BaseChart,
+		h.settings.IstioNamespace, overridesArgs, helmTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to install istio %s chart", BaseChart)
+	}
+
+	// Install discovery chart
+	err = h.helmCmd.InstallChartWithValues(IstiodReleaseName, filepath.Join(ControlChartsDir, DiscoveryChart),
+		h.settings.IstioNamespace, overridesArgs, helmTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to install istio %s chart", DiscoveryChart)
+	}
+
+	return nil
+}
+
+func generateCommonInstallSettings(cfg Config) ([]string, error) {
+	s, err := image.SettingsFromCommandLine()
+	if err != nil {
+		return nil, err
+	}
+
+	installSettings := []string{
+		"--set", "global.imagePullPolicy=" + s.PullPolicy,
+	}
+
+	// Include all user-specified values.
+	for k, v := range cfg.Values {
+		installSettings = append(installSettings, "--set", fmt.Sprintf("%s=%s", k, v))
+	}
+
+	return installSettings, nil
+}

--- a/pkg/test/framework/components/istio/istio.go
+++ b/pkg/test/framework/components/istio/istio.go
@@ -121,6 +121,10 @@ func Deploy(ctx resource.Context, cfg *Config) (i Instance, err error) {
 		}
 	}()
 
-	i, err = deploy(ctx, ctx.Environment().(*kube.Environment), *cfg)
+	if cfg.DeployHelm {
+		i, err = deployWithHelm(ctx, ctx.Environment().(*kube.Environment), *cfg)
+	} else {
+		i, err = deploy(ctx, ctx.Environment().(*kube.Environment), *cfg)
+	}
 	return
 }

--- a/pkg/test/helm/helm.go
+++ b/pkg/test/helm/helm.go
@@ -17,6 +17,7 @@ package helm
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"istio.io/istio/pkg/test/scopes"
@@ -35,6 +36,15 @@ func New(kubeConfig, baseWorkDir string) *Helm {
 		kubeConfig: kubeConfig,
 		baseDir:    baseWorkDir,
 	}
+}
+
+// InstallChart installs the specified chart with its given name to the given namespace
+func (h *Helm) InstallChartWithValues(name, relpath, namespace string, values []string, timeout time.Duration) error {
+	p := filepath.Join(h.baseDir, relpath)
+
+	command := fmt.Sprintf("helm install %s %s --namespace %s --kubeconfig %s --timeout %s %s",
+		name, p, namespace, h.kubeConfig, timeout, strings.Join(values, " "))
+	return execCommand(command)
 }
 
 // InstallChart installs the specified chart with its given name to the given namespace

--- a/tests/integration/helm/main_test.go
+++ b/tests/integration/helm/main_test.go
@@ -19,11 +19,17 @@ import (
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/resource"
 )
 
 func TestMain(m *testing.M) {
+	var ist istio.Instance
 	framework.
 		NewSuite(m).
 		RequireSingleCluster().
+		Setup(istio.Setup(&ist, func(ctx resource.Context, cfg *istio.Config) {
+			cfg.DeployHelm = true
+		})).
 		Run()
 }


### PR DESCRIPTION
The current suite of helm-based installs do not conform to the
integration testing framework. For scenarios where installation will
differ from the istioctl variant, built-in functionality would make it
easier for others to write tests. This would help also in that it would
support such flags such as --istio.test.nocleanup.

There is no multi-cluster support.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
