### PR TITLE
[FIX]the cluster name may should be keep consistent

### DIFF
--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -192,13 +192,12 @@
   "static_resources": {
     "clusters": [
       {
-        "name": "prometheus",
-        "alt_stat_name": "prometheus_stats",
+        "name": "prometheus_stats",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
         "load_assignment": {
-          "cluster_name": "prometheus",
+          "cluster_name": "prometheus_stats",
           "endpoints": [{
             "lb_endpoints": [{
               "endpoint": {
@@ -216,7 +215,6 @@
       },
       {
         "name": "agent",
-        "alt_stat_name": "agent_stats",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",

--- a/tools/packaging/common/envoy_bootstrap.json
+++ b/tools/packaging/common/envoy_bootstrap.json
@@ -192,12 +192,13 @@
   "static_resources": {
     "clusters": [
       {
-        "name": "prometheus_stats",
+        "name": "prometheus",
+        "alt_stat_name": "prometheus_stats",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
         "load_assignment": {
-          "cluster_name": "prometheus_stats",
+          "cluster_name": "prometheus",
           "endpoints": [{
             "lb_endpoints": [{
               "endpoint": {
@@ -215,11 +216,12 @@
       },
       {
         "name": "agent",
+        "alt_stat_name": "agent_stats",
         "type": "STATIC",
         "connect_timeout": "0.250s",
         "lb_policy": "ROUND_ROBIN",
         "load_assignment": {
-          "cluster_name": "prometheus_stats",
+          "cluster_name": "agent",
           "endpoints": [{
             "lb_endpoints": [{
               "endpoint": {


### PR DESCRIPTION
1. The cluster name in load_assignment may should be keep consistent with cluster's name in static_resources. 
2. ~~When sending out statistics, it may be clearer to use alt_stat_name~~

[ X ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ X ] Does not have any changes that may affect Istio users.
