### PR TITLE
enhance multi-clusters: pass inject info to injector template,

### DIFF
--- a/pkg/kube/inject/webhook.go
+++ b/pkg/kube/inject/webhook.go
@@ -331,7 +331,7 @@ type InjectionParameters struct {
 	meshConfig          *meshconfig.MeshConfig
 	valuesConfig        string
 	revision            string
-	proxyEnvs           map[string]string
+	injectEnvs          map[string]string
 	injectedAnnotations map[string]string
 }
 
@@ -766,7 +766,7 @@ func (wh *Webhook) inject(ar *kube.AdmissionReview, path string) *kube.Admission
 		valuesConfig:        wh.valuesConfig,
 		revision:            wh.revision,
 		injectedAnnotations: wh.Config.InjectedAnnotations,
-		proxyEnvs:           parseInjectEnvs(path),
+		injectEnvs:          parseInjectEnvs(path),
 	}
 	wh.mu.RUnlock()
 


### PR DESCRIPTION
for multiple clusters mesh using central istiod, clusters may want different inject patch，like image hub address, resources, and so on.
the only variables which cluster can pass to istiod is inject url (done in https://github.com/istio/istio/pull/25968).

the purpose of this pr:
pass **InjectEnvs** (parse from inject url) to inject template,  so user can customize some attributes of pods, base on inject url.
in this way, it's flexible for users adding custom logic to inject template, without add more and more k-v to istio template struct. 

so to solve https://github.com/istio/istio/issues/29772, user just need change central injector configmap:
```
{{ if eq (index .InjectEnvs "REGION") "us"}}
    image: "us.docker.io/xxxx"
{{ else }}
    image: "docker.io/xxxx"
{{end}}
```
and, the inject url of one cluster may like this: `/inject/region/us`


[X] Configuration Infrastructure
[X] User Experience

