### PR TITLE
Log if probe exceeds the timeout seconds to help debug

### DIFF
--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -295,6 +295,7 @@ func (s *Server) handlePprofTrace(w http.ResponseWriter, r *http.Request) {
 }
 
 const (
+	// TODO: update when is is able to customize the timeout.
 	ReadinessTimeout = time.Second * 3 // Default Readiness probe timeout. It is set the same in helm charts.
 )
 
@@ -302,7 +303,7 @@ func (s *Server) handleReadyProbe(w http.ResponseWriter, _ *http.Request) {
 	t0 := time.Now()
 	defer func() {
 		if time.Since(t0) > ReadinessTimeout {
-			log.Warnf("handleReadyProbe timed out")
+			log.Infof("handleReadyProbe takes more than 3 second")
 		}
 	}()
 

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -294,7 +294,18 @@ func (s *Server) handlePprofTrace(w http.ResponseWriter, r *http.Request) {
 	pprof.Trace(w, r)
 }
 
+const (
+	ReadinessTimeout = time.Second * 3 // Default Readiness probe timeout. It is set the same in helm charts.
+)
+
 func (s *Server) handleReadyProbe(w http.ResponseWriter, _ *http.Request) {
+	t0 := time.Now()
+	defer func() {
+		if time.Since(t0) > ReadinessTimeout {
+			log.Warnf("handleReadyProbe timed out")
+		}
+	}()
+
 	err := s.ready.Check()
 
 	s.mutex.Lock()

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -295,7 +295,7 @@ func (s *Server) handlePprofTrace(w http.ResponseWriter, r *http.Request) {
 }
 
 const (
-	// TODO: update when is is able to customize the timeout.
+	// TODO: update when it is able to customize the timeout.
 	ReadinessTimeout = time.Second * 3 // Default Readiness probe timeout. It is set the same in helm charts.
 )
 

--- a/pilot/cmd/pilot-agent/status/util/stats.go
+++ b/pilot/cmd/pilot-agent/status/util/stats.go
@@ -35,8 +35,8 @@ const (
 	updateStatsRegex   = "^(cluster_manager\\.cds|listener_manager\\.lds)\\.(update_success|update_rejected)$"
 )
 
-var (
-	readinessTimeout = time.Second * 3 // Default Readiness timeout. It is set the same in helm charts.
+const (
+	timeout = time.Second * 15 // the timeout for calling envoy admin api.
 )
 
 type stat struct {
@@ -74,7 +74,7 @@ func GetReadinessStats(localHostAddr string, adminPort uint16) (*uint64, bool, e
 	}
 
 	readinessURL := fmt.Sprintf("http://%s:%d/stats?usedonly&filter=%s", localHostAddr, adminPort, readyStatsRegex)
-	stats, err := doHTTPGetWithTimeout(readinessURL, readinessTimeout)
+	stats, err := doHTTPGetWithTimeout(readinessURL, timeout)
 	if err != nil {
 		return nil, false, err
 	}
@@ -105,7 +105,8 @@ func GetUpdateStatusStats(localHostAddr string, adminPort uint16) (*Stats, error
 		localHostAddr = "localhost"
 	}
 
-	stats, err := doHTTPGet(fmt.Sprintf("http://%s:%d/stats?usedonly&filter=%s", localHostAddr, adminPort, updateStatsRegex))
+	url := fmt.Sprintf("http://%s:%d/stats?usedonly&filter=%s", localHostAddr, adminPort, updateStatsRegex)
+	stats, err := doHTTPGetWithTimeout(url, timeout)
 	if err != nil {
 		return nil, err
 	}

--- a/pilot/cmd/pilot-agent/status/util/util.go
+++ b/pilot/cmd/pilot-agent/status/util/util.go
@@ -22,8 +22,6 @@ import (
 	"time"
 )
 
-const requestTimeout = time.Second * 1 // Default timeout.
-
 func doHTTPGetWithTimeout(requestURL string, t time.Duration) (*bytes.Buffer, error) {
 	httpClient := &http.Client{
 		Timeout: t,
@@ -44,8 +42,4 @@ func doHTTPGetWithTimeout(requestURL string, t time.Duration) (*bytes.Buffer, er
 		return nil, err
 	}
 	return &b, nil
-}
-
-func doHTTPGet(requestURL string) (*bytes.Buffer, error) {
-	return doHTTPGetWithTimeout(requestURL, requestTimeout)
 }


### PR DESCRIPTION
We have met many issues #29777,  reporting readiness probe timed out without knowing specific reasons(network down or envoy admin calling ).


The readiness probe handler currently check the status by calling:

- loclahost:15000/stats?usedonly&filter=^(cluster_manager\.cds|listener_manager\.lds)\.(update_success|update_rejected)$    with 1s timeout
- loclahost:15000/stats?usedonly&filter=^(server\.state|listener_manager\.workers_started) with 3s timeout

And mark ready status according to the result, and all probes later will use the result.  

However, if any calling of the api timedout maybe because of envoy is time costing, then proxy can never turn ready.   @ramaraochavali I remember the initial timeout is setup by, maybe we should increase the timeout to the above 2 api calls to resolve this case.

