### PR TITLE
Fix: EnvoyFilter destination port match is incorrect

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch.go
@@ -585,15 +585,11 @@ func filterChainMatch(fc *xdslistener.FilterChain, cp *model.EnvoyFilterConfigPa
 	}
 
 	// check match for destination port within the FilterChainMatch
-	if fc.FilterChainMatch != nil && fc.FilterChainMatch.DestinationPort != nil {
-		if match.DestinationPort > 0 {
-			if fc.FilterChainMatch.DestinationPort.Value != match.DestinationPort {
-				return false
-			}
-		} else if cMatch.PortNumber > 0 { //Compare listenerMatch's port number for back compatibility
-			if fc.FilterChainMatch.DestinationPort.Value != cMatch.PortNumber {
-				return false
-			}
+	if match.DestinationPort > 0 {
+		if fc.FilterChainMatch == nil || fc.FilterChainMatch.DestinationPort == nil {
+			return false
+		} else if fc.FilterChainMatch.DestinationPort.Value != match.DestinationPort {
+			return false
 		}
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
@@ -1210,6 +1210,14 @@ func TestApplyListenerPatches(t *testing.T) {
 				},
 				{
 					FilterChainMatch: &listener.FilterChainMatch{
+						AddressSuffix: "0.0.0.0",
+					},
+					Filters: []*listener.Filter{
+						{Name: "network-filter-should-not-be-replaced"},
+					},
+				},
+				{
+					FilterChainMatch: &listener.FilterChainMatch{
 						DestinationPort: &wrappers.UInt32Value{
 							Value: 6380,
 						},
@@ -1262,6 +1270,14 @@ func TestApplyListenerPatches(t *testing.T) {
 								}),
 							},
 						},
+					},
+				},
+				{
+					FilterChainMatch: &listener.FilterChainMatch{
+						AddressSuffix: "0.0.0.0",
+					},
+					Filters: []*listener.Filter{
+						{Name: "network-filter-should-not-be-replaced"},
 					},
 				},
 				{


### PR DESCRIPTION
The current implementation affects the filterChains even though the destination port doesn't match.
We should only apply the EnvoyFilter when the destination port matches.

Signed-off-by: zhaohuabing <huabingzhao@tencent.com>

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.
