### PR TITLE
Add size to EDS log

### DIFF
--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -367,11 +367,11 @@ func (eds *EdsGenerator) Generate(proxy *model.Proxy, push *model.PushContext, w
 		}
 	}
 	if len(edsUpdatedServices) == 0 {
-		adsLog.Infof("EDS: PUSH for node:%s resources:%d empty:%v cached:%v/%v",
-			proxy.ID, len(resources), empty, cached, cached+regenerated)
-	} else {
-		adsLog.Debugf("EDS: PUSH INC for node:%s clusters:%d empty:%v cached:%v/%v",
-			proxy.ID, len(resources), empty, cached, cached+regenerated)
+		adsLog.Infof("EDS: PUSH for node:%s resources:%d size:%s empty:%v cached:%v/%v",
+			proxy.ID, len(resources), util.ByteCount(ResourceSize(resources)), empty, cached, cached+regenerated)
+	} else if adsLog.DebugEnabled() {
+		adsLog.Debugf("EDS: PUSH INC for node:%s clusters:%d size:%s empty:%vcached:%v/%v",
+			proxy.ID, len(resources), util.ByteCount(ResourceSize(resources)), empty, cached, cached+regenerated)
 	}
 	return resources
 }

--- a/pilot/pkg/xds/gen.go
+++ b/pilot/pkg/xds/gen.go
@@ -101,8 +101,8 @@ func (s *DiscoveryServer) pushXds(con *Connection, push *model.PushContext,
 
 	t0 := time.Now()
 
-	cl := gen.Generate(con.proxy, push, w, req)
-	if cl == nil {
+	res := gen.Generate(con.proxy, push, w, req)
+	if res == nil {
 		// If we have nothing to send, report that we got an ACK for this version.
 		if s.StatusReporter != nil {
 			s.StatusReporter.RegisterEvent(con.ConID, w.TypeUrl, push.Version)
@@ -115,25 +115,28 @@ func (s *DiscoveryServer) pushXds(con *Connection, push *model.PushContext,
 		TypeUrl:     w.TypeUrl,
 		VersionInfo: currentVersion,
 		Nonce:       nonce(push.Version),
-		Resources:   cl,
+		Resources:   res,
 	}
 
-	// Approximate size by looking at the Any marshaled size. This avoids high cost
-	// proto.Size, at the expense of slightly under counting.
-	size := 0
-	for _, r := range cl {
-		size += len(r.Value)
-	}
-
-	err := con.send(resp)
-	if err != nil {
+	if err := con.send(resp); err != nil {
 		recordSendError(w.TypeUrl, con.ConID, err)
 		return err
 	}
 
 	// Some types handle logs inside Generate, skip them here
 	if _, f := SkipLogTypes[w.TypeUrl]; !f {
-		adsLog.Infof("%s: PUSH for node:%s resources:%d size:%s", v3.GetShortType(w.TypeUrl), con.proxy.ID, len(cl), util.ByteCount(size))
+		adsLog.Infof("%s: PUSH for node:%s resources:%d size:%s",
+			v3.GetShortType(w.TypeUrl), con.proxy.ID, len(res), util.ByteCount(ResourceSize(res)))
 	}
 	return nil
+}
+
+func ResourceSize(r model.Resources) int {
+	// Approximate size by looking at the Any marshaled size. This avoids high cost
+	// proto.Size, at the expense of slightly under counting.
+	size := 0
+	for _, r := range r {
+		size += len(r.Value)
+	}
+	return size
 }


### PR DESCRIPTION
This was present on others, but missing for EDS. Add it for consistency.

End result:
```
2020-12-29T16:06:02.397001Z     info    ads     CDS: PUSH for node:4c5bab2845ad.default resources:10 size:4.1kB
2020-12-29T16:06:02.397126Z     info    ads     EDS: PUSH for node:4c5bab2845ad.default resources:5 size:981B empty:1 cached:0/5
2020-12-29T16:06:02.397683Z     info    ads     LDS: PUSH for node:4c5bab2845ad.default resources:7 size:15.3kB
2020-12-29T16:06:02.397902Z     info    ads     NDS: PUSH for node:4c5bab2845ad.default resources:1 size:330B
2020-12-29T16:06:02.398067Z     info    ads     RDS: PUSH for node:4c5bab2845ad.default resources:3 size:1.9kB
```

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
