### PR TITLE
Add golang compiled tests to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ out/
 etc/
 var/
 .idea/
+# Go compiled tests
+*.test


### PR DESCRIPTION
Generated when running `go test -c`. I have seen a few users check these
in accidentally (mostly me).
