### PR TITLE
Move retry into TokenExchanger implementation

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -127,8 +127,7 @@ var (
 		"The ticker to detect and rotate the certificates, by default 5 minutes").Get()
 	staledConnectionRecycleIntervalEnv = env.RegisterDurationVar("STALED_CONNECTION_RECYCLE_RUN_INTERVAL", 5*time.Minute,
 		"The ticker to detect and close stale connections").Get()
-	initialBackoffInMilliSecEnv = env.RegisterIntVar("INITIAL_BACKOFF_MSEC", 0, "").Get()
-	pkcs8KeysEnv                = env.RegisterBoolVar("PKCS8_KEY", false,
+	pkcs8KeysEnv = env.RegisterBoolVar("PKCS8_KEY", false,
 		"Whether to generate PKCS#8 private keys").Get()
 	eccSigAlgEnv        = env.RegisterStringVar("ECC_SIGNATURE_ALGORITHM", "", "The type of ECC signature algorithm to use when generating private keys").Get()
 	fileMountedCertsEnv = env.RegisterBoolVar("FILE_MOUNTED_CERTS", false, "").Get()
@@ -265,7 +264,6 @@ var (
 			secOpts.SecretTTL = secretTTLEnv
 			secOpts.SecretRotationGracePeriodRatio = secretRotationGracePeriodRatioEnv
 			secOpts.RotationInterval = secretRotationIntervalEnv
-			secOpts.InitialBackoffInMilliSec = int64(initialBackoffInMilliSecEnv)
 			// Disable the secret eviction for istio agent.
 			secOpts.EvictionDuration = 0
 

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -372,7 +372,7 @@ func (sa *Agent) newWorkloadSecretCache() *cache.SecretCache {
 	// This has to be called after pluginNames is set. Otherwise,
 	// TokenExchanger will contain an empty plugin, causing cert provisioning to fail.
 	if sa.secOpts.TokenExchangers == nil {
-		sa.secOpts.TokenExchangers = sds.NewPlugins(pluginNames)
+		sa.secOpts.TokenExchangers = sds.NewPlugins(pluginNames, sa.secOpts)
 	}
 
 	if err != nil {

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -124,9 +124,6 @@ type Options struct {
 	// secret TTL.
 	SecretTTL time.Duration
 
-	// The initial backoff time in millisecond to avoid the thundering herd problem.
-	InitialBackoffInMilliSec int64
-
 	// secret should be rotated if:
 	// time.Now.After(<secret ExpireTime> - <secret TTL> * SecretRotationGracePeriodRatio)
 	SecretRotationGracePeriodRatio float64
@@ -185,8 +182,7 @@ type SecretManager interface {
 
 // TokenExchanger provides common interfaces so that authentication providers could choose to implement their specific logic.
 type TokenExchanger interface {
-	ExchangeToken(ctx context.Context, credFetcher CredFetcher, trustDomain,
-		serviceAccountToken string) (string /*access token*/, time.Time /*expireTime*/, int /*httpRespCode*/, error)
+	ExchangeToken(trustDomain, serviceAccountToken string) (string, error)
 }
 
 // SecretItem is the cached item in in-memory secret store.

--- a/security/pkg/monitoring/monitoring.go
+++ b/security/pkg/monitoring/monitoring.go
@@ -1,0 +1,29 @@
+package monitoring
+
+import "istio.io/pkg/monitoring"
+
+var (
+	RequestType = monitoring.MustCreateLabel("request_type")
+)
+
+const (
+	TokenExchange = "token_exchange"
+	CSR           = "csr"
+)
+
+var (
+	NumOutgoingRetries = monitoring.NewSum(
+		"num_outgoing_retries",
+		"Number of outgoing retry requests (e.g. to a token exchange server, CA, etc.)",
+		monitoring.WithLabels(RequestType))
+)
+
+func init() {
+	monitoring.MustRegister(
+		NumOutgoingRetries,
+	)
+}
+
+func Reset() {
+	NumOutgoingRetries.Record(0)
+}

--- a/security/pkg/monitoring/monitoring.go
+++ b/security/pkg/monitoring/monitoring.go
@@ -1,3 +1,17 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package monitoring
 
 import "istio.io/pkg/monitoring"

--- a/security/pkg/monitoring/monitoring.go
+++ b/security/pkg/monitoring/monitoring.go
@@ -17,6 +17,7 @@ package monitoring
 import "istio.io/pkg/monitoring"
 
 var (
+	// RequestType specifies the type of request we are monitoring. Current supported are CSR and TokenExchange
 	RequestType = monitoring.MustCreateLabel("request_type")
 )
 

--- a/security/pkg/nodeagent/cache/helper.go
+++ b/security/pkg/nodeagent/cache/helper.go
@@ -21,13 +21,9 @@ import (
 )
 
 // isRetryableErr checks if a failed request should be retry based on gRPC resp code or http status code.
-func isRetryableErr(c codes.Code, httpRespCode int, isGrpc bool) bool {
-	if isGrpc {
-		switch c {
-		case codes.Canceled, codes.DeadlineExceeded, codes.ResourceExhausted, codes.Aborted, codes.Internal, codes.Unavailable:
-			return true
-		}
-	} else if httpRespCode >= 500 && !(httpRespCode == 501 || httpRespCode == 505 || httpRespCode == 511) {
+func isRetryableErr(c codes.Code) bool {
+	switch c {
+	case codes.Canceled, codes.DeadlineExceeded, codes.ResourceExhausted, codes.Aborted, codes.Internal, codes.Unavailable:
 		return true
 	}
 	return false

--- a/security/pkg/nodeagent/cache/monitoring.go
+++ b/security/pkg/nodeagent/cache/monitoring.go
@@ -16,11 +16,6 @@ package cache
 
 import "istio.io/pkg/monitoring"
 
-const (
-	TokenExchange = "token_exchange"
-	CSR           = "csr"
-)
-
 var (
 	RequestType = monitoring.MustCreateLabel("request_type")
 )
@@ -37,11 +32,6 @@ var (
 	numOutgoingRequests = monitoring.NewSum(
 		"num_outgoing_requests",
 		"Number of total outgoing requests (e.g. to a token exchange server, CA, etc.)",
-		monitoring.WithLabels(RequestType))
-
-	numOutgoingRetries = monitoring.NewSum(
-		"num_outgoing_retries",
-		"Number of outgoing retry requests (e.g. to a token exchange server, CA, etc.)",
 		monitoring.WithLabels(RequestType))
 
 	numFailedOutgoingRequests = monitoring.NewSum(
@@ -62,7 +52,6 @@ func init() {
 	monitoring.MustRegister(
 		outgoingLatency,
 		numOutgoingRequests,
-		numOutgoingRetries,
 		numFailedOutgoingRequests,
 		numFileWatcherFailures,
 		numFileSecretFailures,

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -33,6 +33,7 @@ import (
 	"istio.io/istio/pkg/mcp/status"
 	"istio.io/istio/pkg/security"
 	"istio.io/istio/pkg/spiffe"
+	"istio.io/istio/security/pkg/monitoring"
 	"istio.io/istio/security/pkg/nodeagent/secretfetcher"
 	nodeagentutil "istio.io/istio/security/pkg/nodeagent/util"
 	pkiutil "istio.io/istio/security/pkg/pki/util"
@@ -669,13 +670,13 @@ func (sc *SecretCache) generateFileSecret(connKey ConnKey, token string) (bool, 
 func (sc *SecretCache) generateSecret(ctx context.Context, token string, connKey ConnKey, t time.Time) (*security.SecretItem, error) {
 	logPrefix := cacheLogPrefix(connKey.ResourceName)
 	// call authentication provider specific plugins to exchange token if necessary.
-	numOutgoingRequests.With(RequestType.Value(TokenExchange)).Increment()
+	numOutgoingRequests.With(RequestType.Value(monitoring.TokenExchange)).Increment()
 	timeBeforeTokenExchange := time.Now()
-	exchangedToken, err := sc.getExchangedToken(ctx, token, connKey)
+	exchangedToken, err := sc.getExchangedToken(token, connKey)
 	tokenExchangeLatency := float64(time.Since(timeBeforeTokenExchange).Nanoseconds()) / float64(time.Millisecond)
-	outgoingLatency.With(RequestType.Value(TokenExchange)).Record(tokenExchangeLatency)
+	outgoingLatency.With(RequestType.Value(monitoring.TokenExchange)).Record(tokenExchangeLatency)
 	if err != nil {
-		numFailedOutgoingRequests.With(RequestType.Value(TokenExchange)).Increment()
+		numFailedOutgoingRequests.With(RequestType.Value(monitoring.TokenExchange)).Increment()
 		return nil, err
 	}
 	csrHostName := &spiffe.Identity{
@@ -699,13 +700,13 @@ func (sc *SecretCache) generateSecret(ctx context.Context, token string, connKey
 		return nil, err
 	}
 
-	numOutgoingRequests.With(RequestType.Value(CSR)).Increment()
+	numOutgoingRequests.With(RequestType.Value(monitoring.CSR)).Increment()
 	timeBeforeCSR := time.Now()
-	certChainPEM, err := sc.sendRetriableRequest(ctx, csrPEM, exchangedToken, connKey, true)
+	certChainPEM, err := sc.sendRetriableRequest(ctx, csrPEM, exchangedToken, connKey)
 	csrLatency := float64(time.Since(timeBeforeCSR).Nanoseconds()) / float64(time.Millisecond)
-	outgoingLatency.With(RequestType.Value(CSR)).Record(csrLatency)
+	outgoingLatency.With(RequestType.Value(monitoring.CSR)).Record(csrLatency)
 	if err != nil {
-		numFailedOutgoingRequests.With(RequestType.Value(CSR)).Increment()
+		numFailedOutgoingRequests.With(RequestType.Value(monitoring.CSR)).Increment()
 		return nil, err
 	}
 
@@ -764,44 +765,28 @@ func (sc *SecretCache) shouldRotate(secret *security.SecretItem) bool {
 	return rotate
 }
 
-// sendRetriableRequest sends retriable requests for either CSR or ExchangeToken.
+// sendRetriableRequest sends retriable requests for CSR
 // Prior to sending the request, it also sleep random millisecond to avoid thundering herd problem.
-func (sc *SecretCache) sendRetriableRequest(ctx context.Context, csrPEM []byte,
-	providedExchangedToken string, connKey ConnKey, isCSR bool) ([]string, error) {
-
-	if sc.configOptions.InitialBackoffInMilliSec > 0 {
-		sc.randMutex.Lock()
-		randomizedInitialBackOffInMS := sc.rand.Int63n(sc.configOptions.InitialBackoffInMilliSec)
-		sc.randMutex.Unlock()
-		cacheLog.Debugf("Wait for %d millisec for jitter", randomizedInitialBackOffInMS)
-		// Add a jitter to initial CSR to avoid thundering herd problem.
-		time.Sleep(time.Duration(randomizedInitialBackOffInMS) * time.Millisecond)
-	}
+func (sc *SecretCache) sendRetriableRequest(ctx context.Context, csrPEM []byte, token string, connKey ConnKey) ([]string, error) {
 	retryBackoffInMS := int64(firstRetryBackOffInMilliSec)
 
 	logPrefix := cacheLogPrefix(connKey.ResourceName)
 	startTime := time.Now()
 	var certChainPEM []string
-	exchangedToken := providedExchangedToken
 	var requestErrorString string
 	var err error
 
 	// Keep trying until no error or timeout.
 	for {
 		var httpRespCode int
-		if isCSR {
-			requestErrorString = fmt.Sprintf("%s CSR", logPrefix)
-			// Check if we can use cert instead of the token to do CSR Sign request.
-			if sc.useCertToRotate() {
-				// if CSR request is without token, set the token to empty
-				exchangedToken = ""
-			}
-			certChainPEM, err = sc.fetcher.CaClient.CSRSign(ctx, csrPEM, exchangedToken, int64(sc.configOptions.SecretTTL.Seconds()))
-		} else {
-			requestErrorString = fmt.Sprintf("%s TokExch", logPrefix)
-			p := sc.configOptions.TokenExchangers[0]
-			exchangedToken, _, httpRespCode, err = p.ExchangeToken(ctx, sc.configOptions.CredFetcher, sc.configOptions.TrustDomain, exchangedToken)
+		requestErrorString = fmt.Sprintf("%s CSR", logPrefix)
+		// Check if we can use cert instead of the token to do CSR Sign request.
+		if sc.useCertToRotate() {
+			// if CSR request is without token, set the token to empty
+			token = ""
 		}
+		certChainPEM, err = sc.fetcher.CaClient.CSRSign(ctx, csrPEM, token, int64(sc.configOptions.SecretTTL.Seconds()))
+
 		cacheLog.Debugf("%s", requestErrorString)
 
 		if err == nil {
@@ -809,7 +794,7 @@ func (sc *SecretCache) sendRetriableRequest(ctx context.Context, csrPEM []byte,
 		}
 
 		// If non-retryable error, fail the request by returning err
-		if !isRetryableErr(status.Code(err), httpRespCode, isCSR) {
+		if !isRetryableErr(status.Code(err)) {
 			cacheLog.Errorf("%s hit non-retryable error (HTTP code: %d). Error: %v", requestErrorString, httpRespCode, err)
 			return nil, err
 		}
@@ -824,22 +809,16 @@ func (sc *SecretCache) sendRetriableRequest(ctx context.Context, csrPEM []byte,
 		retryBackoffInMS *= 2 // Exponentially increase the retry backoff time.
 
 		// Record retry metrics.
-		if isCSR {
-			numOutgoingRetries.With(RequestType.Value(CSR)).Increment()
-		} else {
-			numOutgoingRetries.With(RequestType.Value(TokenExchange)).Increment()
-		}
+		// TODO token exchange metrics
+		monitoring.NumOutgoingRetries.With(RequestType.Value(monitoring.CSR)).Increment()
 	}
 
-	if isCSR {
-		return certChainPEM, nil
-	}
-	return []string{exchangedToken}, nil
+	return certChainPEM, nil
 }
 
 // getExchangedToken gets the exchanged token for the CSR. The token is either the k8s jwt token of the
 // workload or another token from a plug in provider.
-func (sc *SecretCache) getExchangedToken(ctx context.Context, k8sJwtToken string, connKey ConnKey) (string, error) {
+func (sc *SecretCache) getExchangedToken(k8sJwtToken string, connKey ConnKey) (string, error) {
 	logPrefix := cacheLogPrefix(connKey.ResourceName)
 	cacheLog.Debugf("Start token exchange process for %s", logPrefix)
 	if sc.configOptions.TokenExchangers == nil || len(sc.configOptions.TokenExchangers) == 0 {
@@ -850,14 +829,14 @@ func (sc *SecretCache) getExchangedToken(ctx context.Context, k8sJwtToken string
 		cacheLog.Errorf("Found more than one plugin for %s", logPrefix)
 		return "", fmt.Errorf("found more than one plugin")
 	}
-	exchangedTokens, err := sc.sendRetriableRequest(ctx, nil, k8sJwtToken,
-		ConnKey{ConnectionID: "", ResourceName: ""}, false)
-	if err != nil || len(exchangedTokens) == 0 {
+	p := sc.configOptions.TokenExchangers[0]
+	exchangedToken, err := p.ExchangeToken(sc.configOptions.TrustDomain, k8sJwtToken)
+	if err != nil || len(exchangedToken) == 0 {
 		cacheLog.Errorf("Failed to exchange token for %s: %v", logPrefix, err)
 		return "", err
 	}
 	cacheLog.Debugf("Token exchange succeeded for %s", logPrefix)
-	return exchangedTokens[0], nil
+	return exchangedToken, nil
 }
 
 // useCertToRotate checks if we can use cert instead of token to do CSR.

--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -56,8 +56,7 @@ func testWorkloadAgentGenerateSecret(t *testing.T, isUsingPluginProvider bool) {
 	}
 
 	if isUsingPluginProvider {
-		// The mocked token exchanger server returns 3 errors before returning a valid response.
-		fakePlugin := mock.NewMockTokenExchangeServer(3)
+		fakePlugin := mock.NewMockTokenExchangeServer()
 		opt.TokenExchangers = []security.TokenExchanger{fakePlugin}
 	}
 

--- a/security/pkg/nodeagent/plugin/providers/google/stsclient/stsclient.go
+++ b/security/pkg/nodeagent/plugin/providers/google/stsclient/stsclient.go
@@ -17,11 +17,7 @@ package stsclient
 
 import (
 	"bytes"
-	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -29,6 +25,7 @@ import (
 
 	"istio.io/istio/pkg/bootstrap/platform"
 	"istio.io/istio/pkg/security"
+	"istio.io/istio/security/pkg/monitoring"
 	"istio.io/pkg/env"
 	"istio.io/pkg/log"
 )
@@ -39,13 +36,12 @@ var (
 	// SecureTokenEndpoint is the Endpoint the STS client calls to.
 	SecureTokenEndpoint = "https://securetoken.googleapis.com/v1/identitybindingtoken"
 	stsClientLog        = log.RegisterScope("stsclient", "STS client debugging", 0)
-	GCEProvider         = "GoogleComputeEngine"
 )
 
 const (
-	httpTimeOutInSec = 5
-	contentType      = "application/json"
-	scope            = "https://www.googleapis.com/auth/cloud-platform"
+	httpTimeout = time.Second * 5
+	contentType = "application/json"
+	scope       = "https://www.googleapis.com/auth/cloud-platform"
 )
 
 type federatedTokenResponse struct {
@@ -57,67 +53,86 @@ type federatedTokenResponse struct {
 
 // TokenExchanger for google securetoken api interaction.
 type Plugin struct {
-	hTTPClient *http.Client
+	httpClient  *http.Client
+	credFetcher security.CredFetcher
+	backoff     time.Duration
 }
 
 // NewPlugin returns an instance of secure token service client plugin
-func NewPlugin() security.TokenExchanger {
-	caCertPool, err := x509.SystemCertPool()
-	if err != nil {
-		stsClientLog.Errorf("Failed to get SystemCertPool: %v", err)
-		return nil
-	}
-	return Plugin{
-		hTTPClient: &http.Client{
-			Timeout: httpTimeOutInSec * time.Second,
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{
-					RootCAs: caCertPool,
-				},
-			},
+func NewPlugin(credFetcher security.CredFetcher) *Plugin {
+	stsClientLog.SetOutputLevel(log.DebugLevel)
+	return &Plugin{
+		httpClient: &http.Client{
+			Timeout: httpTimeout,
 		},
+		backoff:     time.Millisecond * 50,
+		credFetcher: credFetcher,
 	}
 }
 
-// ExchangeToken exchange oauth access token from trusted domain and k8s sa jwt.
-func (p Plugin) ExchangeToken(ctx context.Context, credFetcher security.CredFetcher, trustDomain, k8sSAjwt string) (
-	string /*access token*/, time.Time /*expireTime*/, int /*httpRespCode*/, error) {
-	aud := constructAudience(credFetcher, trustDomain)
-	var jsonStr = constructFederatedTokenRequest(aud, k8sSAjwt)
-	req, _ := http.NewRequest("POST", SecureTokenEndpoint, bytes.NewBuffer(jsonStr))
-	req.Header.Set("Content-Type", contentType)
+func retryable(code int) bool {
+	return code >= 500 && !(code == 501 || code == 505 || code == 511)
+}
 
-	resp, err := p.hTTPClient.Do(req)
-	errMsg := "failed to call token exchange service. "
-	if err != nil || resp == nil {
-		statusCode := http.StatusServiceUnavailable
-		// If resp is not null, return the actually status code returned from the token service.
-		// If resp is null, return a service unavailable status and try again.
-		if resp != nil {
-			statusCode = resp.StatusCode
-			errMsg += fmt.Sprintf("HTTP status: %s. Error: %v", resp.Status, err)
-		} else {
-			errMsg += fmt.Sprintf("HTTP response empty. Error: %v", err)
+func (p *Plugin) requestWithRetry(reqBytes []byte) ([]byte, error) {
+	attempts := 0
+	var lastError error
+	for attempts < 5 {
+		attempts++
+		req, err := http.NewRequest("POST", SecureTokenEndpoint, bytes.NewBuffer(reqBytes))
+		if err != nil {
+			return nil, err
 		}
-		return "", time.Now(), statusCode, errors.New(errMsg)
-	}
-	defer resp.Body.Close()
+		req.Header.Set("Content-Type", contentType)
 
-	body, _ := ioutil.ReadAll(resp.Body)
+		resp, err := p.httpClient.Do(req)
+		if err != nil {
+			lastError = err
+			stsClientLog.Debugf("token exchange request failed: %v", err)
+			time.Sleep(p.backoff)
+			monitoring.NumOutgoingRetries.With(monitoring.RequestType.Value(monitoring.TokenExchange)).Increment()
+			continue
+		}
+		if resp.StatusCode == http.StatusOK {
+			defer resp.Body.Close()
+			body, err := ioutil.ReadAll(resp.Body)
+			return body, err
+		}
+		if retryable(resp.StatusCode) {
+			body, _ := ioutil.ReadAll(resp.Body)
+			lastError = fmt.Errorf("token exchange request failed: status code %v", resp.StatusCode)
+			stsClientLog.Debugf("token exchange request failed: status code %v, body %v", resp.StatusCode, string(body))
+			resp.Body.Close()
+			time.Sleep(p.backoff)
+			monitoring.NumOutgoingRetries.With(monitoring.RequestType.Value(monitoring.TokenExchange)).Increment()
+			continue
+		}
+	}
+	return nil, fmt.Errorf("exchange failed all retries, last error: %v", lastError)
+}
+
+// ExchangeToken exchange oauth access token from trusted domain and k8s sa jwt.
+func (p *Plugin) ExchangeToken(trustDomain, k8sSAjwt string) (string, error) {
+	aud := constructAudience(p.credFetcher, trustDomain)
+	jsonStr := constructFederatedTokenRequest(aud, k8sSAjwt)
+
+	body, err := p.requestWithRetry(jsonStr)
+	if err != nil {
+		return "", err
+	}
 	respData := &federatedTokenResponse{}
 	if err := json.Unmarshal(body, respData); err != nil {
 		// Normally the request should json - extremely hard to debug otherwise, not enough info in status/err
 		stsClientLog.Debugf("Unexpected unmarshal error, response was %s", string(body))
-		return "", time.Now(), resp.StatusCode, fmt.Errorf(
-			"failed to unmarshal response data. HTTP status: %s. Error: %v. Body size: %d", resp.Status, err, len(body))
+		return "", fmt.Errorf("failed to unmarshal response data of size %v: %v", len(body), err)
 	}
 
 	if respData.AccessToken == "" {
-		return "", time.Now(), resp.StatusCode, fmt.Errorf(
-			"exchanged empty token. HTTP status: %s. Response: %v", resp.Status, string(body))
+		return "", fmt.Errorf(
+			"exchanged empty token, response: %v", string(body))
 	}
 
-	return respData.AccessToken, time.Now().Add(time.Second * time.Duration(respData.ExpiresIn)), resp.StatusCode, nil
+	return respData.AccessToken, nil
 }
 
 func constructAudience(credFetcher security.CredFetcher, trustDomain string) string {

--- a/security/pkg/nodeagent/plugin/providers/google/stsclient/stsclient_test.go
+++ b/security/pkg/nodeagent/plugin/providers/google/stsclient/stsclient_test.go
@@ -15,33 +15,79 @@
 package stsclient
 
 import (
-	"context"
+	"errors"
+	"fmt"
 	"testing"
+	"time"
 
+	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/istio/security/pkg/monitoring"
+	"istio.io/istio/security/pkg/nodeagent/util"
 	"istio.io/istio/security/pkg/stsservice/tokenmanager/google/mock"
+	"istio.io/istio/tests/util/leak"
 )
 
 func TestGetFederatedToken(t *testing.T) {
 	GKEClusterURL = mock.FakeGKEClusterURL
-	r := NewPlugin()
+	r := NewPlugin(nil)
+	r.backoff = time.Millisecond
 
 	ms, err := mock.StartNewServer(t, mock.Config{Port: 0})
 	if err != nil {
 		t.Fatalf("failed to start a mock server: %v", err)
 	}
 	SecureTokenEndpoint = ms.URL + "/v1/identitybindingtoken"
-	defer func() {
+	t.Cleanup(func() {
 		if err := ms.Stop(); err != nil {
 			t.Logf("failed to stop mock server: %v", err)
 		}
 		SecureTokenEndpoint = "https://securetoken.googleapis.com/v1/identitybindingtoken"
-	}()
+	})
 
-	token, _, _, err := r.ExchangeToken(context.Background(), nil, mock.FakeTrustDomain, mock.FakeSubjectToken)
-	if err != nil {
-		t.Fatalf("failed to call exchange token %v", err)
-	}
-	if token != mock.FakeFederatedToken {
-		t.Errorf("Access token got %q, expected %q", token, mock.FakeFederatedToken)
-	}
+	t.Run("exchange", func(t *testing.T) {
+		token, err := r.ExchangeToken(mock.FakeTrustDomain, mock.FakeSubjectToken)
+		if err != nil {
+			t.Fatalf("failed to call exchange token %v", err)
+		}
+		if token != mock.FakeFederatedToken {
+			t.Errorf("Access token got %q, expected %q", token, mock.FakeFederatedToken)
+		}
+	})
+	t.Run("error", func(t *testing.T) {
+		ms.SetGenFedTokenError(errors.New("fake error"))
+		t.Cleanup(func() {
+			ms.SetGenFedTokenError(nil)
+		})
+		_, err := r.ExchangeToken(mock.FakeTrustDomain, mock.FakeSubjectToken)
+		if err == nil {
+			t.Fatalf("expected error %v", err)
+		}
+	})
+
+	t.Run("retry", func(t *testing.T) {
+		monitoring.Reset()
+		ms.SetGenFedTokenError(errors.New("fake error"))
+		_, err := r.ExchangeToken(mock.FakeTrustDomain, mock.FakeSubjectToken)
+		if err == nil {
+			t.Fatalf("expected error %v", err)
+		}
+
+		retry.UntilSuccessOrFail(t, func() error {
+			g, err := util.GetMetricsCounterValueWithTags("num_outgoing_retries", map[string]string{
+				"request_type": monitoring.TokenExchange,
+			})
+			if err != nil {
+				return err
+			}
+			if g <= 0 {
+				return fmt.Errorf("expected retries, got %v", g)
+			}
+			return nil
+		}, retry.Timeout(time.Second*5))
+	})
+
+}
+
+func TestMain(m *testing.M) {
+	leak.CheckMain(m)
 }

--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -80,9 +80,9 @@ func (s *Server) Stop() {
 }
 
 // NewPlugins returns a slice of default Plugins.
-func NewPlugins(in []string) []ca2.TokenExchanger {
+func NewPlugins(in []string, opts *ca2.Options) []ca2.TokenExchanger {
 	var availablePlugins = map[string]ca2.TokenExchanger{
-		plugin.GoogleTokenExchange: stsclient.NewPlugin(),
+		plugin.GoogleTokenExchange: stsclient.NewPlugin(opts.CredFetcher),
 	}
 	var plugins []ca2.TokenExchanger
 	for _, pl := range in {

--- a/security/pkg/nodeagent/sds/server_test.go
+++ b/security/pkg/nodeagent/sds/server_test.go
@@ -178,9 +178,8 @@ func createRealSDSServer(t *testing.T, socket string) *Server {
 	workloadSdsCacheOptions := &security.Options{}
 	workloadSdsCacheOptions.TrustDomain = "FakeTrustDomain"
 	workloadSdsCacheOptions.Pkcs8Keys = false
-	workloadSdsCacheOptions.TokenExchangers = NewPlugins([]string{"GoogleTokenExchange"})
+	workloadSdsCacheOptions.TokenExchangers = NewPlugins([]string{"GoogleTokenExchange"}, workloadSdsCacheOptions)
 	workloadSdsCacheOptions.RotationInterval = 10 * time.Minute
-	workloadSdsCacheOptions.InitialBackoffInMilliSec = 10
 	workloadSecretCache := cache.NewSecretCache(wSecretFetcher, NotifyProxy, workloadSdsCacheOptions)
 
 	server, err := NewServer(&arg, workloadSecretCache)

--- a/security/pkg/nodeagent/util/util.go
+++ b/security/pkg/nodeagent/util/util.go
@@ -56,6 +56,29 @@ func GetMetricsCounterValue(metricName string) (float64, error) {
 	return rows[0].Data.(*view.SumData).Value, nil
 }
 
+//GetMetricsCounterValue returns counter value in float64. For test purpose only.
+func GetMetricsCounterValueWithTags(metricName string, tags map[string]string) (float64, error) {
+	rows, err := view.RetrieveData(metricName)
+	if err != nil {
+		return float64(0), err
+	}
+	if len(rows) == 0 {
+		return 0, nil
+	}
+	for _, row := range rows {
+		need := len(tags)
+		for _, t := range row.Tags {
+			if tags[t.Key.Name()] == t.Value {
+				need--
+			}
+		}
+		if need == 0 {
+			return rows[0].Data.(*view.SumData).Value, nil
+		}
+	}
+	return float64(0), fmt.Errorf("no metrics matched tags %s: %d", metricName, len(rows))
+}
+
 // Output the key and certificate to the given directory.
 // If directory is empty, return nil.
 func OutputKeyCertToDir(dir string, privateKey, certChain, rootCert []byte) error {

--- a/security/pkg/stsservice/tokenmanager/google/mock/mockserver.go
+++ b/security/pkg/stsservice/tokenmanager/google/mock/mockserver.go
@@ -15,7 +15,6 @@
 package mock
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -208,7 +207,7 @@ func (ms *AuthorizationServer) Start(port int) error {
 	mux.HandleFunc("/v1/identitybindingtoken", ms.getFederatedToken)
 	mux.HandleFunc(atEndpoint, ms.getAccessToken)
 	ms.t.Logf("Registered handler for endpoints:\n%s\n%s", atEndpoint, "/v1/identitybindingtoken")
-	server := &http.Server{
+	ms.server = &http.Server{
 		Addr:    fmt.Sprintf("127.0.0.1:%d", port),
 		Handler: mux,
 	}
@@ -224,7 +223,7 @@ func (ms *AuthorizationServer) Start(port int) error {
 	ms.URL = fmt.Sprintf("http://localhost:%d", port)
 
 	go func() {
-		if err := server.Serve(ln); err != nil {
+		if err := ms.server.Serve(ln); err != nil {
 			log.Errorf("Server failed to serve in %q: %v", ms.URL, err)
 		}
 	}()
@@ -240,7 +239,7 @@ func (ms *AuthorizationServer) Stop() error {
 	if ms.server == nil {
 		return nil
 	}
-	return ms.server.Shutdown(context.TODO())
+	return ms.server.Close()
 }
 
 func (ms *AuthorizationServer) getFederatedToken(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
Broken out of https://github.com/istio/istio/pull/29688. Current `secretcache` and `TokenExchanger` are overloaded, and deals with details they shouldn't. This refactors the TokenExchanger interface to stop leaking HTTP details (stop returning http codes), and `secretcache` to stop leaking sts plugin details (handling http retries). Instead, the retries are moved into the token exchanger directly.

In another PR I will split out the code to do the same for CSR retries (already done in the big PR), then the logic in secret cache is much simpler since there is no retries at all.

This should have roughly the same coverage as before; previously the secretcache tested retries and now the sts client tests directly test these. Logging and metrics for these retries are preserved.