### PR TITLE
Fix TestExecProber flakes

### DIFF
--- a/pkg/istio-agent/health/health_probers_test.go
+++ b/pkg/istio-agent/health/health_probers_test.go
@@ -25,7 +25,12 @@ import (
 	"time"
 
 	"istio.io/api/networking/v1alpha3"
+	"istio.io/istio/tests/util/leak"
 )
+
+func TestMain(m *testing.M) {
+	leak.CheckMain(m)
+}
 
 func TestHttpProber(t *testing.T) {
 	tests := []struct {
@@ -140,7 +145,7 @@ func TestExecProber(t *testing.T) {
 		},
 		{
 			desc:                "Timeout",
-			command:             []string{"sleep", "1"},
+			command:             []string{"sleep", "10"},
 			expectedProbeResult: Unhealthy,
 			expectedError:       errors.New("command timeout exceeded: signal: killed"),
 		},
@@ -154,7 +159,7 @@ func TestExecProber(t *testing.T) {
 				},
 			}
 
-			got, err := execProber.Probe(time.Second)
+			got, err := execProber.Probe(time.Millisecond * 200)
 			if got != tt.expectedProbeResult {
 				t.Errorf("got: %v, expected: %v", got, tt.expectedProbeResult)
 			}


### PR DESCRIPTION
Example:
https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/29646/unit-tests_istio/1343983060076466176

The problem is we have a 1s timeout, but the command also takes 1s. This
makes it racy. Instead, make the timeout shorter and command longer.
```
4072 runs so far, 0 failures (100.00% pass rate). 530.759386ms avg, 927.967307ms max, 298.880314ms min
```