### PR TITLE
Fix TestXdsProxyReconnects flakes

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -285,6 +285,7 @@ var (
 				XDSRootCerts: xdsRootCA,
 				CARootCerts:  caRootCA,
 				XDSHeaders:   map[string]string{},
+				XdsUdsPath:   constants.DefaultXdsUdsPath,
 				IsIPv6:       proxyIPv6,
 			}
 			extractXDSHeadersFromEnv(agentConfig)

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -102,6 +102,9 @@ const (
 	// mtls.
 	DefaultSdsUdsPath = "unix:./etc/istio/proxy/SDS"
 
+	// DefaultXdsUdsPath is the path used for XDS communication between istio-agent and proxy
+	DefaultXdsUdsPath = "./etc/istio/proxy/XDS"
+
 	// DefaultServiceAccountName is the default service account to use for remote cluster access.
 	DefaultServiceAccountName = "istio-reader-service-account"
 

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -137,6 +137,9 @@ type AgentConfig struct {
 
 	// Is the proxy an IPv6 proxy
 	IsIPv6 bool
+
+	// Path to local UDS to communicate with Envoy
+	XdsUdsPath string
 }
 
 // NewAgent wraps the logic for a local SDS. It will check if the JWT token required for local SDS is

--- a/pkg/istio-agent/xds_proxy_test.go
+++ b/pkg/istio-agent/xds_proxy_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -48,7 +49,7 @@ func TestXdsProxyBasicFlow(t *testing.T) {
 	proxy := setupXdsProxy(t)
 	f := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 	setDialOptions(proxy, f.Listener)
-	conn := setupDownstreamConnection(t)
+	conn := setupDownstreamConnection(t, proxy)
 	downstream := stream(t, conn)
 	sendDownstream(t, downstream)
 }
@@ -88,7 +89,7 @@ func TestXdsProxyHealthCheck(t *testing.T) {
 		t.Fatal(err)
 	}
 	setDialOptions(proxy, f.Listener)
-	conn := setupDownstreamConnection(t)
+	conn := setupDownstreamConnection(t, proxy)
 	downstream := stream(t, conn)
 	sendDownstreamWithNode(t, downstream, node)
 
@@ -121,7 +122,7 @@ func TestXdsProxyHealthCheck(t *testing.T) {
 				return fmt.Errorf("expected status %q got %q", expected, con.Status)
 			}
 			return nil
-		}, retry.Timeout(time.Second))
+		}, retry.Timeout(time.Second*2))
 	}
 
 	// On initial connect, status is unset.
@@ -139,7 +140,7 @@ func TestXdsProxyHealthCheck(t *testing.T) {
 	conn.Close()
 	downstream.CloseSend()
 	waitDisconnect()
-	conn = setupDownstreamConnection(t)
+	conn = setupDownstreamConnection(t, proxy)
 	downstream = stream(t, conn)
 	sendDownstreamWithNode(t, downstream, node)
 
@@ -154,7 +155,7 @@ func TestXdsProxyHealthCheck(t *testing.T) {
 	downstream.CloseSend()
 	waitDisconnect()
 	proxy.PersistRequest(healthy)
-	conn = setupDownstreamConnection(t)
+	conn = setupDownstreamConnection(t, proxy)
 	downstream = stream(t, conn)
 	sendDownstreamWithNode(t, downstream, node)
 
@@ -174,7 +175,7 @@ func TestXdsProxyHealthCheck(t *testing.T) {
 	waitDisconnect()
 	f.Store().Delete(gvk.WorkloadEntry, "group-1.1.1.1", "default", nil)
 	proxy.PersistRequest(healthy)
-	conn = setupDownstreamConnection(t)
+	conn = setupDownstreamConnection(t, proxy)
 	downstream = stream(t, conn)
 	sendDownstreamWithNode(t, downstream, node)
 
@@ -202,8 +203,10 @@ func setupXdsProxy(t *testing.T) *XdsProxy {
 		MetadataClientCertKey:   path.Join(env.IstioSrc, "tests/testdata/certs/pilot/key.pem"),
 		MetadataClientRootCert:  path.Join(env.IstioSrc, "tests/testdata/certs/pilot/root-cert.pem"),
 	}
-	ia := NewAgent(&proxyConfig,
-		&AgentConfig{}, secOpts)
+	dir := t.TempDir()
+	ia := NewAgent(&proxyConfig, &AgentConfig{
+		XdsUdsPath: filepath.Join(dir, "XDS"),
+	}, secOpts)
 	t.Cleanup(func() {
 		ia.Close()
 	})
@@ -246,7 +249,7 @@ func TestXdsProxyReconnects(t *testing.T) {
 		f := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 		setDialOptions(proxy, f.Listener)
 
-		conn := setupDownstreamConnection(t)
+		conn := setupDownstreamConnection(t, proxy)
 		downstream := stream(t, conn)
 		sendDownstream(t, downstream)
 
@@ -261,7 +264,7 @@ func TestXdsProxyReconnects(t *testing.T) {
 		f := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 		setDialOptions(proxy, f.Listener)
 
-		conn := setupDownstreamConnection(t)
+		conn := setupDownstreamConnection(t, proxy)
 		downstream := stream(t, conn)
 		sendDownstream(t, downstream)
 		downstream = stream(t, conn)
@@ -272,12 +275,31 @@ func TestXdsProxyReconnects(t *testing.T) {
 		f := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
 		setDialOptions(proxy, f.Listener)
 
-		conn := setupDownstreamConnection(t)
+		conn := setupDownstreamConnection(t, proxy)
 		downstream := stream(t, conn)
 		sendDownstream(t, downstream)
 		conn.Close()
-		conn = setupDownstreamConnection(t)
-		downstream = stream(t, conn)
+
+		c := setupDownstreamConnection(t, proxy)
+		downstream = stream(t, c)
+		sendDownstream(t, downstream)
+	})
+	t.Run("Envoy sends concurrent requests", func(t *testing.T) {
+		// Envoy doesn't really do this, in reality it should only have a single connection. However,
+		// this ensures we are robust against cases where envoy rapidly disconnects and reconnects
+		proxy := setupXdsProxy(t)
+		f := xds.NewFakeDiscoveryServer(t, xds.FakeOptions{})
+		setDialOptions(proxy, f.Listener)
+
+		conn := setupDownstreamConnection(t, proxy)
+		downstream := stream(t, conn)
+		sendDownstream(t, downstream)
+
+		c := setupDownstreamConnection(t, proxy)
+		downstream = stream(t, c)
+		sendDownstream(t, downstream)
+		conn.Close()
+
 		sendDownstream(t, downstream)
 	})
 	t.Run("Istiod closes connection", func(t *testing.T) {
@@ -300,7 +322,7 @@ func TestXdsProxyReconnects(t *testing.T) {
 		go grpcServer.Serve(listener)
 
 		// Send initial request
-		conn := setupDownstreamConnection(t)
+		conn := setupDownstreamConnection(t, proxy)
 		downstream := stream(t, conn)
 		sendDownstream(t, downstream)
 
@@ -371,15 +393,15 @@ func sendDownstream(t *testing.T, downstream discovery.AggregatedDiscoveryServic
 	})
 }
 
-func setupDownstreamConnection(t *testing.T) *grpc.ClientConn {
+func setupDownstreamConnection(t *testing.T, proxy *XdsProxy) *grpc.ClientConn {
 	var opts []grpc.DialOption
 
 	opts = append(opts, grpc.WithInsecure(), grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
 		var d net.Dialer
-		return d.DialContext(ctx, "unix", xdsUdsPath)
+		return d.DialContext(ctx, "unix", proxy.xdsUdsPath)
 	}))
 
-	conn, err := grpc.Dial(xdsUdsPath, opts...)
+	conn, err := grpc.Dial(proxy.xdsUdsPath, opts...)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/29749

This is a real bug, although one that probably has minimal to no impact.

What happens is we register a stream, then call close. Normally, this
unregisters the stream, then the new connection is established and
everything works fine.

In some cases, the new connection happens *before* we unregister the old
stream, so unregister closes the new stream instead of the old one.

If this were to happen in the real world, Envoy would just reconnect
again so not much harm done.

The fix here is to make it so we only close the old connection when its
matching the one we expect. We also explicitly close the old stream if
we have two concurrent streams (shouldn't happen, but who knows...)

Additionally, made the XDS path configurable so unit tests can run in
parallel.

`627 runs so far, 0 failures (100.00% pass rate). 1.817777539s avg, 2.517386605s max, 1.182963188s min`
