### PR TITLE
Fix RegisterTaints test flakes

### DIFF
--- a/cni/cmd/istio-cni-taint/main.go
+++ b/cni/cmd/istio-cni-taint/main.go
@@ -97,7 +97,7 @@ kubernetes controller and checking on the readiness of critical label
 			leadelectionCallback := leaderelection.LeaderCallbacks{
 				OnStartedLeading: func(ctx context.Context) {
 					//once leader elected it should taint all nodes at first to prevent race condition
-					tc.RegistTaints()
+					tc.RegisterTaints()
 					tc.Run(ctx.Done()) //graceful shut down
 				},
 				OnStoppedLeading: func() {

--- a/cni/pkg/taint/taintcontroller.go
+++ b/cni/pkg/taint/taintcontroller.go
@@ -316,7 +316,8 @@ func (tc Controller) ListAllNode() []*v1.Node {
 	}
 	return nodes
 }
-func (tc Controller) RegistTaints() {
+
+func (tc Controller) RegisterTaints() {
 	nodes := tc.ListAllNode()
 	for _, node := range nodes {
 		err := tc.taintsetter.AddReadinessTaint(node)


### PR DESCRIPTION
The issue here is we add the nodes to our fake informer but not to the
fake client, so if the informer updates it breaks the test. This means
we are actually only passing when the informer is empty.

The real logic in the CNI code is also highly suspicious, I am pretty
sure RegisterTaints will always return 0 nodes since we have the same
issue of not loading the informer first. However, I am focusing only on
fixing the tests right now.

`9502 runs so far, 0 failures (100.00% pass rate). 106.009871ms avg, 215.807378ms max, 61.498086ms min`
