### PR TITLE
Add retry.Until helper function

### DIFF
--- a/pilot/pkg/config/aggregate/config_test.go
+++ b/pilot/pkg/config/aggregate/config_test.go
@@ -15,7 +15,6 @@
 package aggregate
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -244,12 +243,7 @@ func TestAggregateStoreCache(t *testing.T) {
 				Name:             "another",
 			},
 		})
-		retry.UntilSuccessOrFail(t, func() error {
-			if !handled.Load() {
-				return fmt.Errorf("not handled")
-			}
-			return nil
-		}, retry.Timeout(time.Second))
+		retry.UntilOrFail(t, handled.Load, retry.Timeout(time.Second))
 	})
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/fake.go
+++ b/pilot/pkg/networking/core/v1alpha3/fake.go
@@ -17,7 +17,6 @@ package v1alpha3
 
 import (
 	"bytes"
-	"errors"
 	"sync"
 	"text/template"
 	"time"
@@ -176,12 +175,7 @@ func (f *ConfigGenTest) Run() {
 
 	// TODO allow passing event handlers for controller
 
-	retry.UntilSuccessOrFail(f.t, func() error {
-		if !f.Registry.HasSynced() {
-			return errors.New("not synced")
-		}
-		return nil
-	})
+	retry.UntilOrFail(f.t, f.Registry.HasSynced)
 
 	f.ServiceEntryRegistry.ResyncEDS()
 	if err := f.PushContext().InitContext(f.env, nil, nil); err != nil {


### PR DESCRIPTION
This adds a new retry method, that takes a bool function instead of an
error function. Its very common to have functions doing
```go
if cond() { return error } else { return nil }
```

Now they can just do `retry.Until(cond)`, which is a bit simpler.

I also moved a few examples over to the new syntax to validate the API
makes sense and works.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.