### PR TITLE
WIP: annotate remote secrets with cluster type to customize behavior

### DIFF
--- a/istioctl/pkg/multicluster/remote_secret_test.go
+++ b/istioctl/pkg/multicluster/remote_secret_test.go
@@ -119,7 +119,7 @@ func TestCreateRemoteSecrets(t *testing.T) {
 		config  *api.Config
 		objs    []runtime.Object
 		name    string
-		secType SecretType
+		secType secretcontroller.SecretType
 
 		// inject errors
 		badStartingConfig bool
@@ -217,8 +217,8 @@ func TestCreateRemoteSecrets(t *testing.T) {
 			makeOutputWriterTestHook = func() writer {
 				return &fakeOutputWriter{injectError: c.outputWriterError}
 			}
-			if c.secType != SecretTypeConfig {
-				c.secType = SecretTypeRemote
+			if c.secType != secretcontroller.SecretTypeConfig {
+				c.secType = secretcontroller.SecretTypeRemote
 			}
 			opts := RemoteSecretOptions{
 				ServiceAccountName: testServiceAccountName,
@@ -246,7 +246,7 @@ func TestCreateRemoteSecrets(t *testing.T) {
 			} else if c.want != "" {
 				var secretName, key string
 				switch c.secType {
-				case SecretTypeConfig:
+				case secretcontroller.SecretTypeConfig:
 					secretName = configSecretName
 					key = configSecretKey
 				default:

--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -16,6 +16,7 @@ package bootstrap
 
 import (
 	"fmt"
+	"istio.io/istio/istioctl/pkg/multicluster"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
@@ -93,7 +94,7 @@ func (s *Server) initKubeRegistry(args *PilotArgs) (err error) {
 		s.environment)
 
 	// initialize the "main" cluster registry before starting controllers for remote clusters
-	if err := mc.AddMemberCluster(s.kubeClient, args.RegistryOptions.KubeOptions.ClusterID); err != nil {
+	if err := mc.AddMemberCluster(s.kubeClient, args.RegistryOptions.KubeOptions.ClusterID, multicluster.SecretTypeConfig); err != nil {
 		log.Errorf("failed initializing registry for %s: %v", args.RegistryOptions.KubeOptions.ClusterID, err)
 		return err
 	}

--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -16,8 +16,6 @@ package bootstrap
 
 import (
 	"fmt"
-	"istio.io/istio/istioctl/pkg/multicluster"
-
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
@@ -25,6 +23,7 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/mock"
 	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
 	"istio.io/istio/pkg/config/host"
+	"istio.io/istio/pkg/kube/secretcontroller"
 	"istio.io/pkg/log"
 )
 
@@ -94,7 +93,7 @@ func (s *Server) initKubeRegistry(args *PilotArgs) (err error) {
 		s.environment)
 
 	// initialize the "main" cluster registry before starting controllers for remote clusters
-	if err := mc.AddMemberCluster(s.kubeClient, args.RegistryOptions.KubeOptions.ClusterID, multicluster.SecretTypeConfig); err != nil {
+	if err := mc.AddMemberCluster(s.kubeClient, args.RegistryOptions.KubeOptions.ClusterID, secretcontroller.SecretTypeConfig); err != nil {
 		log.Errorf("failed initializing registry for %s: %v", args.RegistryOptions.KubeOptions.ClusterID, err)
 		return err
 	}

--- a/pilot/pkg/secrets/kube/multicluster.go
+++ b/pilot/pkg/secrets/kube/multicluster.go
@@ -16,7 +16,6 @@ package kube
 
 import (
 	"fmt"
-	"istio.io/istio/istioctl/pkg/multicluster"
 	"sync"
 	"time"
 
@@ -46,8 +45,8 @@ func NewMulticluster(client kube.Client, localCluster, secretNamespace string, s
 	// Add the local cluster
 	m.addMemberCluster(client, localCluster)
 	sc := secretcontroller.StartSecretController(client,
-		func(c kube.Client, k string, _ multicluster.SecretType) error { m.addMemberCluster(c, k); return nil },
-		func(c kube.Client, k string, _ multicluster.SecretType) error { m.updateMemberCluster(c, k); return nil },
+		func(c kube.Client, k string, _ secretcontroller.SecretType) error { m.addMemberCluster(c, k); return nil },
+		func(c kube.Client, k string, _ secretcontroller.SecretType) error { m.updateMemberCluster(c, k); return nil },
 		func(k string) error { m.deleteMemberCluster(k); return nil },
 		secretNamespace,
 		time.Millisecond*100,

--- a/pilot/pkg/secrets/kube/multicluster.go
+++ b/pilot/pkg/secrets/kube/multicluster.go
@@ -16,6 +16,7 @@ package kube
 
 import (
 	"fmt"
+	"istio.io/istio/istioctl/pkg/multicluster"
 	"sync"
 	"time"
 
@@ -45,8 +46,8 @@ func NewMulticluster(client kube.Client, localCluster, secretNamespace string, s
 	// Add the local cluster
 	m.addMemberCluster(client, localCluster)
 	sc := secretcontroller.StartSecretController(client,
-		func(c kube.Client, k string) error { m.addMemberCluster(c, k); return nil },
-		func(c kube.Client, k string) error { m.updateMemberCluster(c, k); return nil },
+		func(c kube.Client, k string, _ multicluster.SecretType) error { m.addMemberCluster(c, k); return nil },
+		func(c kube.Client, k string, _ multicluster.SecretType) error { m.updateMemberCluster(c, k); return nil },
 		func(k string) error { m.deleteMemberCluster(k); return nil },
 		secretNamespace,
 		time.Millisecond*100,

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -15,6 +15,7 @@
 package controller
 
 import (
+	"istio.io/istio/istioctl/pkg/multicluster"
 	"strings"
 	"sync"
 	"time"
@@ -123,7 +124,7 @@ func NewMulticluster(
 // AddMemberCluster is passed to the secret controller as a callback to be called
 // when a remote cluster is added.  This function needs to set up all the handlers
 // to watch for resources being added, deleted or changed on remote clusters.
-func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string) error {
+func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string, clusterType multicluster.SecretType) error {
 	// stopCh to stop controller created here when cluster removed.
 	stopCh := make(chan struct{})
 	m.m.Lock()
@@ -212,11 +213,11 @@ func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string)
 	return nil
 }
 
-func (m *Multicluster) UpdateMemberCluster(clients kubelib.Client, clusterID string) error {
+func (m *Multicluster) UpdateMemberCluster(clients kubelib.Client, clusterID string, clusterType multicluster.SecretType) error {
 	if err := m.DeleteMemberCluster(clusterID); err != nil {
 		return err
 	}
-	return m.AddMemberCluster(clients, clusterID)
+	return m.AddMemberCluster(clients, clusterID, clusterType)
 }
 
 // DeleteMemberCluster is passed to the secret controller as a callback to be called

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -15,7 +15,6 @@
 package controller
 
 import (
-	"istio.io/istio/istioctl/pkg/multicluster"
 	"strings"
 	"sync"
 	"time"
@@ -124,7 +123,7 @@ func NewMulticluster(
 // AddMemberCluster is passed to the secret controller as a callback to be called
 // when a remote cluster is added.  This function needs to set up all the handlers
 // to watch for resources being added, deleted or changed on remote clusters.
-func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string, clusterType multicluster.SecretType) error {
+func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string, clusterType secretcontroller.SecretType) error {
 	// stopCh to stop controller created here when cluster removed.
 	stopCh := make(chan struct{})
 	m.m.Lock()
@@ -167,7 +166,7 @@ func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string,
 		go kubeRegistry.Run(stopCh)
 	}
 
-	controlRemote := (features.ExternalIstioD || features.CentralIstioD) && clusterType == multicluster.SecretTypeRemote
+	controlRemote := (features.ExternalIstioD || features.CentralIstioD) && clusterType == secretcontroller.SecretTypeRemote
 	if m.fetchCaRoot != nil && m.fetchCaRoot() != nil && (controlRemote || localCluster) {
 		log.Infof("joining leader-election for %s in %s", leaderelection.NamespaceController, options.SystemNamespace)
 		go leaderelection.
@@ -215,7 +214,7 @@ func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string,
 	return nil
 }
 
-func (m *Multicluster) UpdateMemberCluster(clients kubelib.Client, clusterID string, clusterType multicluster.SecretType) error {
+func (m *Multicluster) UpdateMemberCluster(clients kubelib.Client, clusterID string, clusterType secretcontroller.SecretType) error {
 	if err := m.DeleteMemberCluster(clusterID); err != nil {
 		return err
 	}

--- a/pkg/kube/secretcontroller/secretcontroller.go
+++ b/pkg/kube/secretcontroller/secretcontroller.go
@@ -20,7 +20,6 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
-	"istio.io/istio/istioctl/pkg/multicluster"
 	"reflect"
 	"time"
 
@@ -47,10 +46,10 @@ const (
 )
 
 // addSecretCallback prototype for the add secret callback function.
-type addSecretCallback func(clients kube.Client, dataKey string, clusterType multicluster.SecretType) error
+type addSecretCallback func(clients kube.Client, dataKey string, clusterType SecretType) error
 
 // updateSecretCallback prototype for the update secret callback function.
-type updateSecretCallback func(clients kube.Client, dataKey string, clusterType multicluster.SecretType) error
+type updateSecretCallback func(clients kube.Client, dataKey string, clusterType SecretType) error
 
 // removeSecretCallback prototype for the remove secret callback function.
 type removeSecretCallback func(dataKey string) error
@@ -352,10 +351,26 @@ func (c *Controller) deleteMemberCluster(secretName string) {
 	log.Infof("Number of remote clusters: %d", len(c.cs.remoteClusters))
 }
 
-func getClusterType(s *corev1.Secret) multicluster.SecretType {
+
+type SecretType string
+
+func (at *SecretType) String() string { return string(*at) }
+func (at *SecretType) Type() string   { return "SecretType" }
+func (at *SecretType) Set(in string) error {
+	*at = SecretType(in)
+	return nil
+}
+
+const SecretTypeRemote SecretType = "remote"
+
+const SecretTypePrimary SecretType = "primary"
+
+const SecretTypeConfig SecretType = "config"
+
+func getClusterType(s *corev1.Secret) SecretType {
 	clusterTypeStr, ok := s.Annotations["topology.istio.io/clusterType"]
 	if !ok {
-		return multicluster.SecretTypeRemote
+		return SecretTypeRemote
 	}
-	return multicluster.SecretType(clusterTypeStr)
+	return SecretType(clusterTypeStr)
 }


### PR DESCRIPTION
Prevent us from spinning up namepsace controller or webhook patchers against other clusters running istiod. 

fixes #29419 and fixes #29600

This is an example implementation and should also have a design comparing the following options:

https://github.com/istio/istio/issues/29419#issuecomment-752697613
> For the issues we're running into here, we don't actually care if the cluster serves discovery to proxies. We care about whether or not _any_ istiod is going to manage the resources in the cluster. If we had a combinaton of istiod-less remotes, and old-style remotes, we wouldn't want to patch the old-style remote clusters either.
> 
> Things we could check:
> 
> * If there is an istiod deployment
>   * pro: no new config
>   * con: if the remote secret is created early, this could cause issues.
> * Label on the system namespace
>   * pro: no duplication of info in the remote secret for each cluster
>   * con: new config that can be missed
> * Embed information on the remote secrets
>   * con: duplicated for each primary cluster containing a similar secret, new config for users to spec on primary clusters