### PR TITLE
Remove spammy logs in unit tests

### DIFF
--- a/pkg/kube/secretcontroller/secretcontroller.go
+++ b/pkg/kube/secretcontroller/secretcontroller.go
@@ -168,9 +168,7 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 	go c.informer.Run(stopCh)
 
 	// Wait for the caches to be synced before starting workers
-	log.Info("Waiting for informer caches to sync")
 	if !kube.WaitForCacheSyncInterval(stopCh, c.syncInterval, c.informer.HasSynced) {
-		utilruntime.HandleError(fmt.Errorf("timed out waiting for caches to sync"))
 		return
 	}
 	// all secret events before this signal must be processed before we're marked "ready"


### PR DESCRIPTION
This causes a bunch of logs like `klog  timed out waiting for caches to sync` in all of our tests,
which gets highlighted by Prow and obscures real errors. I don't think
we really need this log, it only happens when the stop channel is closed
so Istio is shutting down; no other controllers do it.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.