### PR TITLE
Fix TestEndpointFlipFlops test flakes

### DIFF
--- a/pilot/pkg/xds/eds_test.go
+++ b/pilot/pkg/xds/eds_test.go
@@ -398,14 +398,14 @@ func TestEndpointFlipFlops(t *testing.T) {
 				EndpointPort:    8080,
 			}})
 
-	upd, _ = adscConn.Wait(5 * time.Second)
+	upd, _ = adscConn.Wait(5*time.Second, v3.EndpointType)
 
-	if contains(upd, "cds") {
-		t.Fatal("Expecting only EDS update as part of a partial push. But received CDS also +v", upd)
+	if contains(upd, v3.ClusterType) {
+		t.Fatalf("expecting only EDS update as part of a partial push. But received CDS also %+v", upd)
 	}
 
 	if len(upd) > 0 && !contains(upd, v3.EndpointType) {
-		t.Fatal("Expecting EDS push as part of a partial push. But did not receive +v", upd)
+		t.Fatalf("expecting EDS push as part of a partial push. But did not receive %+v", upd)
 	}
 
 	testEndpoints("10.10.1.1", "outbound|8080||flipflop.com", adscConn, t)


### PR DESCRIPTION
The root cause is we may have some lingering RDS/LDS pushes not
finished. Instead, we should wait for EDS response specifically, not any
respones, and check that we didn't get any CDS response.

963 runs so far, 0 failures (100.00% pass rate). 7.433370536s avg, 9.768572747s max, 5.345023667s min



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.