### PR TITLE
[release-1.7] Add ECC_SIGNATURE_ALGORITHM env integration test (#28894)

### DIFF
--- a/pkg/test/framework/features/features.yaml
+++ b/pkg/test/framework/features/features.yaml
@@ -59,6 +59,7 @@ features:
     peer:
       secure-naming:
       trust-domain-validation:
+      ecc-signature-algorithm:
     user:
     ingress:
       mtls:

--- a/tests/integration/security/ecc_signature_algorithm/main_test.go
+++ b/tests/integration/security/ecc_signature_algorithm/main_test.go
@@ -1,0 +1,116 @@
+// +build integ
+//  Copyright Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package eccsignaturealgorithm
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/config/protocol"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/components/namespace"
+	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+var (
+	inst istio.Instance
+	apps = &EchoDeployments{}
+)
+
+type EchoDeployments struct {
+	// Namespace is used as the default namespace for reachability tests and other tests which can reuse the same config for echo instances
+	Namespace      namespace.Instance
+	Client, Server echo.Instance
+}
+
+func TestMain(m *testing.M) {
+	framework.
+		NewSuite(m).
+		// Needed as it requires an environmental variable
+		Label(label.CustomSetup).
+		Setup(istio.Setup(&inst, setupConfig)).
+		Setup(func(ctx resource.Context) error {
+			return SetupApps(ctx, apps)
+		}).
+		Run()
+}
+
+func setupConfig(_ resource.Context, cfg *istio.Config) {
+	if cfg == nil {
+		return
+	}
+	cfg.ControlPlaneValues = `
+values:
+  meshConfig:
+    defaultConfig:
+      proxyMetadata:
+        ECC_SIGNATURE_ALGORITHM: "ECDSA"
+`
+}
+
+func SetupApps(ctx resource.Context, apps *EchoDeployments) error {
+	var err error
+	apps.Namespace, err = namespace.New(ctx, namespace.Config{
+		Prefix: "test-ns",
+		Inject: true,
+	})
+	if err != nil {
+		return err
+	}
+
+	builder := echoboot.NewBuilder(ctx)
+	for _, cluster := range ctx.Clusters() {
+		builder.
+			With(nil, echo.Config{
+				Namespace: apps.Namespace,
+				Service:   "client",
+				Cluster:   cluster,
+			}).
+			With(nil, echo.Config{
+				Subsets:        []echo.SubsetConfig{{}},
+				Namespace:      apps.Namespace,
+				Service:        "server",
+				ServiceAccount: true,
+				Ports: []echo.Port{
+					{
+						Name:         "http",
+						Protocol:     protocol.HTTP,
+						ServicePort:  8091,
+						InstancePort: 8091,
+					},
+				},
+				Cluster: cluster,
+			})
+	}
+	echoes, err := builder.Build()
+	if err != nil {
+		return err
+	}
+	apps.Client, err = echoes.Get(echo.Service("client"))
+	if err != nil {
+		return err
+	}
+
+	apps.Server, err = echoes.Get(echo.Service("server"))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/tests/integration/security/ecc_signature_algorithm/mtls_strict_test.go
+++ b/tests/integration/security/ecc_signature_algorithm/mtls_strict_test.go
@@ -1,0 +1,108 @@
+// +build integ
+//  Copyright Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package eccsignaturealgorithm
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"testing"
+
+	"istio.io/istio/pkg/test/echo/common/scheme"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/util/tmpl"
+	"istio.io/istio/tests/integration/security/util"
+	"istio.io/istio/tests/integration/security/util/cert"
+)
+
+const (
+	DestinationRuleConfigIstioMutual = `
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: server
+  namespace: {{.AppNamespace}}
+spec:
+  host: "server.{{.AppNamespace}}.svc.cluster.local"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+`
+
+	PeerAuthenticationConfig = `
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace: {{.AppNamespace}}
+spec:
+  mtls:
+    mode: STRICT
+`
+)
+
+func TestStrictMTLS(t *testing.T) {
+	framework.
+		NewTest(t).
+		Features("security.peer.ecc-signature-algorithm").
+		Run(func(ctx framework.TestContext) {
+			peerTemplate := tmpl.EvaluateOrFail(ctx, PeerAuthenticationConfig, map[string]string{"AppNamespace": apps.Namespace.Name()})
+			ctx.Config().ApplyYAMLOrFail(ctx, apps.Namespace.Name(), peerTemplate)
+			ctx.WhenDone(func() error {
+				return ctx.Config().DeleteYAML(apps.Namespace.Name(), peerTemplate)
+			})
+			util.WaitForConfigWithSleep(ctx, peerTemplate, apps.Namespace)
+
+			drTemplate := tmpl.EvaluateOrFail(ctx, DestinationRuleConfigIstioMutual, map[string]string{"AppNamespace": apps.Namespace.Name()})
+			ctx.Config().ApplyYAMLOrFail(ctx, apps.Namespace.Name(), drTemplate)
+			ctx.WhenDone(func() error {
+				return ctx.Config().DeleteYAML(apps.Namespace.Name(), drTemplate)
+			})
+			util.WaitForConfigWithSleep(ctx, drTemplate, apps.Namespace)
+
+			response := apps.Client.CallOrFail(t, echo.CallOptions{
+				Target:   apps.Server,
+				PortName: "http",
+				Scheme:   scheme.HTTP,
+				Count:    1,
+			})
+
+			if err := response.CheckOK(); err != nil {
+				ctx.Fatalf("client could not reach server: %v", err)
+			}
+
+			target := fmt.Sprintf("server.%s:8091", apps.Namespace.Name())
+			certPEM, err := cert.DumpCertFromSidecar(apps.Namespace, "app=client", "istio-proxy", target)
+			if err != nil {
+				ctx.Fatalf("client could not get certificate from server: %v", err)
+			}
+			block, _ := pem.Decode([]byte(certPEM))
+			if block == nil {
+				ctx.Fatalf("failed to parse certificate PEM")
+			}
+
+			// nolint: staticcheck
+			certificate, parseErr := x509.ParseCertificate(block.Bytes)
+			if err != nil {
+				ctx.Fatalf("failed to parse certificate: %v", parseErr)
+			}
+
+			if certificate.PublicKeyAlgorithm != x509.ECDSA {
+				ctx.Fatalf("public key used in server cert is not ECDSA: %v", certificate.PublicKeyAlgorithm)
+			}
+		})
+}


### PR DESCRIPTION
Fixes https://github.com/istio/istio/pull/28894

Cherry-pick of https://github.com/istio/istio/pull/28894 with sha 5a5c0ebf40d232d0886389d4b6a74976dba87a14

* Add integration test for ECC_SIGNATURE_ALGORITHM

There was a previous regression when specifying ECC_SIGNATURE_ALGORITHM,
see https://github.com/istio/istio/pull/25203.

Setup:
- A test namespace is created
- A client and server Echo deployment is created in this namespace
- The appropriate PeerAuthentication and DestinationRule resources are
set so that mTLS is strict and used
- The root CA is not altered and it will use a generated certificate
using RSA. Due to https://github.com/istio/istio/pull/27239, the
root CA no longer has to ECC to enable ECC_SIGNATURE_ALGORITHM. This has
the benefit of additional testing as well.

Test:
- The client sends a request to the server deployment to make sure
communication works inside of the mesh when using ECC certificates.
- Using kubectl/openssl, the client then gets the certificate from the
server deployment. It then verifies that the certificate is using ECC,
notably ECDSA, algorithms.

* Add license to top of file; lint errors

* Run make gen

* Fix linting issue

* Add proper feature label

* Fix name of feature


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.