### PR TITLE
translate shared helm values only once for different istio components.

### DIFF
--- a/operator/pkg/helmreconciler/prune_test.go
+++ b/operator/pkg/helmreconciler/prune_test.go
@@ -28,8 +28,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"istio.io/istio/operator/pkg/apis/istio/v1alpha1"
+	"istio.io/istio/operator/pkg/controlplane"
 	"istio.io/istio/operator/pkg/name"
 	"istio.io/istio/operator/pkg/object"
+	"istio.io/istio/operator/pkg/translate"
 	"istio.io/istio/operator/pkg/util"
 	"istio.io/istio/operator/pkg/util/clog"
 	"istio.io/istio/operator/pkg/util/progress"
@@ -56,6 +58,11 @@ func TestHelmReconciler_DeleteControlPlaneByManifest(t *testing.T) {
 		iop.Spec.Revision = testRevision
 		iop.Spec.InstallPackagePath = filepath.Join(env.IstioSrc, "manifests")
 
+		cp, err := controlplane.NewIstioControlPlane(iop.Spec, translate.NewTranslator())
+		if err != nil {
+			t.Fatalf("failed to create istio installation control plane: %v", err)
+		}
+
 		h := &HelmReconciler{
 			client: cl,
 			opts: &Options{
@@ -63,6 +70,7 @@ func TestHelmReconciler_DeleteControlPlaneByManifest(t *testing.T) {
 				Log:         clog.NewDefaultLogger(),
 			},
 			iop:           iop,
+			istiocp:       cp,
 			countLock:     &sync.Mutex{},
 			prunedKindSet: map[schema.GroupKind]struct{}{},
 		}

--- a/operator/pkg/helmreconciler/render.go
+++ b/operator/pkg/helmreconciler/render.go
@@ -17,9 +17,7 @@ package helmreconciler
 import (
 	"fmt"
 
-	"istio.io/istio/operator/pkg/controlplane"
 	"istio.io/istio/operator/pkg/name"
-	"istio.io/istio/operator/pkg/translate"
 	"istio.io/istio/operator/pkg/validate"
 )
 
@@ -33,17 +31,12 @@ func (h *HelmReconciler) RenderCharts() (name.ManifestMap, error) {
 		h.opts.Log.PrintErr(fmt.Sprintf("spec invalid; continuing because of --force: %v\n", err))
 	}
 
-	t := translate.NewTranslator()
-
-	cp, err := controlplane.NewIstioControlPlane(iopSpec, t)
+	err := h.istiocp.Run()
 	if err != nil {
-		return nil, err
-	}
-	if err := cp.Run(); err != nil {
 		return nil, fmt.Errorf("failed to create Istio control plane with spec: \n%v\nerror: %s", iopSpec, err)
 	}
 
-	manifests, errs := cp.RenderManifest()
+	manifests, errs := h.istiocp.RenderManifest()
 	if errs != nil {
 		err = errs.ToError()
 	}


### PR DESCRIPTION
The helm reconciler renders the manifests for different istio components with the same helm values translated from istio operator api, we should use the shared helm values, so that we only need to translate helm values only once.

[ ] Configuration Infrastructure
[ ] Docs
[ X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.