### PR TITLE
integ-suite-kind.sh requires ARTIFACTS variable

### DIFF
--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -134,10 +134,10 @@ fi
 export T="${T:-"-v -count=1"}"
 export CI="true"
 
+export ARTIFACTS="${ARTIFACTS:-$(mktemp -d)}"
 trace "init" make init
 
 if [[ -z "${SKIP_SETUP:-}" ]]; then
-  export ARTIFACTS="${ARTIFACTS:-$(mktemp -d)}"
   export DEFAULT_CLUSTER_YAML="./prow/config/trustworthy-jwt.yaml"
   export METRICS_SERVER_CONFIG_DIR='./prow/config/metrics'
 


### PR DESCRIPTION
The trace command, defined in prow/lib.sh, requires the ARTIFACTS
variable be set otherwise it crashes. When running the integ-suite-kind.sh script to get
a multicluster setup I had to define this manually. Move the definition
of this variable from a later defined location to that before trace is executed.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X] Does not have any changes that may affect Istio users.