### PR TITLE
Fix the debug log format for the kubernetes endpoints synchronizations

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -614,7 +614,7 @@ func (c *Controller) syncPods() error {
 func (c *Controller) syncEndpoints() error {
 	var err *multierror.Error
 	endpoints := c.endpoints.getInformer().GetStore().List()
-	log.Debugf("initializing%d endpoints", len(endpoints))
+	log.Debugf("initializing %d endpoints", len(endpoints))
 	for _, s := range endpoints {
 		err = multierror.Append(err, c.endpoints.onEvent(s, model.EventAdd))
 	}


### PR DESCRIPTION
- Just fixing the debug log format for the kubernetes endpoints synchronization:

### before:

```
debug   initializing 0 nodes
debug   initializing 0 services
debug   initializing 0 pods
debug   initializing0 endpoints
```

### after:

```
debug   initializing 0 nodes
debug   initializing 0 services
debug   initializing 0 pods
debug   initializing 0 endpoints
```

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
