### PR TITLE
Fix race conditions in multinetwork

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/yl2chen/cidranger"
+	"go.uber.org/atomic"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -252,6 +253,9 @@ type Controller struct {
 	networkGateways map[host.Name]map[string][]*model.Gateway
 
 	once sync.Once
+	// initialized is set to true once the controller is running successfully. This ensures we do not
+	// return HasSynced=true before we are running
+	initialized *atomic.Bool
 
 	// Duration to wait for cache syncs
 	syncInterval time.Duration
@@ -278,6 +282,7 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 		networksWatcher:             options.NetworksWatcher,
 		metrics:                     options.Metrics,
 		syncInterval:                options.GetSyncInterval(),
+		initialized:                 atomic.NewBool(false),
 	}
 
 	if options.SystemNamespace != "" {
@@ -332,10 +337,14 @@ func (c *Controller) Cluster() string {
 }
 
 func (c *Controller) cidrRanger() cidranger.Ranger {
+	c.RLock()
+	defer c.RUnlock()
 	return c.ranger
 }
 
 func (c *Controller) defaultNetwork() string {
+	c.RLock()
+	defer c.RUnlock()
 	if c.networkForRegistry != "" {
 		return c.networkForRegistry
 	}
@@ -551,6 +560,9 @@ func tryGetLatestObject(informer cache.SharedIndexInformer, obj interface{}) int
 
 // HasSynced returns true after the initial state synchronization
 func (c *Controller) HasSynced() bool {
+	if !c.initialized.Load() {
+		return false
+	}
 	if (c.nsInformer != nil && !c.nsInformer.HasSynced()) ||
 		!c.serviceInformer.HasSynced() ||
 		!c.endpoints.HasSynced() ||
@@ -630,6 +642,7 @@ func (c *Controller) Run(stop <-chan struct{}) {
 	if c.nsInformer != nil {
 		go c.nsInformer.Run(stop)
 	}
+	c.initialized.Store(true)
 	kubelib.WaitForCacheSyncInterval(stop, c.syncInterval, c.HasSynced)
 	c.queue.Run(stop)
 	log.Infof("Controller terminated")


### PR DESCRIPTION
Race 1: simple data race, add proper RLock since we mutate these
variables (with Lock())

Race 2: Run() is called in a goroutine. This means we may start doing
things before Run() actually happens. HasSynced can pass without Run()
being called, so the issue that arises is that reloadNetworkLookup
doesn't run, and multinetwork gives unexpected results. This is
trivially reproducible with a sleep(1s) in start of Run().

This was tested (along with some other fixes I am working on) by running
TestMeshNetworking 10k times over 1hr and getting 0 failures.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.