### PR TITLE
Fix various races in push context initialization

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -767,7 +767,7 @@ func (s *Server) waitForCacheSync(stop <-chan struct{}) bool {
 	// condition where we are marked ready prior to updating the push context, leading to incomplete
 	// pushes.
 	if !cache.WaitForCacheSync(stop, func() bool {
-		return s.XDSServer.CommittedUpdates.Load() > expected
+		return s.XDSServer.CommittedUpdates.Load() >= expected
 	}) {
 		log.Errorf("Failed waiting for push context initialization")
 		return false

--- a/pilot/pkg/networking/core/v1alpha3/fake.go
+++ b/pilot/pkg/networking/core/v1alpha3/fake.go
@@ -133,13 +133,12 @@ func NewConfigGenTest(t test.Failer, opts TestOptions) *ConfigGenTest {
 	}
 
 	env := &model.Environment{}
-	env.PushContext = model.NewPushContext()
-	env.ServiceDiscovery = serviceDiscovery
-	env.IstioConfigStore = model.MakeIstioStore(configController)
 	env.Watcher = mesh.NewFixedWatcher(m)
 	if opts.NetworksWatcher == nil {
 		opts.NetworksWatcher = mesh.NewFixedNetworksWatcher(nil)
 	}
+	env.ServiceDiscovery = serviceDiscovery
+	env.IstioConfigStore = model.MakeIstioStore(configController)
 	env.NetworksWatcher = opts.NetworksWatcher
 
 	if opts.Plugins == nil {
@@ -160,6 +159,10 @@ func NewConfigGenTest(t test.Failer, opts TestOptions) *ConfigGenTest {
 	}
 	if !opts.SkipRun {
 		fake.Run()
+		env.PushContext = model.NewPushContext()
+		if err := env.PushContext.InitContext(env, nil, nil); err != nil {
+			t.Fatalf("Failed to initialize push context: %v", err)
+		}
 	}
 	return fake
 }
@@ -175,12 +178,10 @@ func (f *ConfigGenTest) Run() {
 
 	// TODO allow passing event handlers for controller
 
-	retry.UntilOrFail(f.t, f.Registry.HasSynced)
+	retry.UntilOrFail(f.t, f.store.HasSynced, retry.Delay(time.Millisecond))
+	retry.UntilOrFail(f.t, f.Registry.HasSynced, retry.Delay(time.Millisecond))
 
 	f.ServiceEntryRegistry.ResyncEDS()
-	if err := f.PushContext().InitContext(f.env, nil, nil); err != nil {
-		f.t.Fatalf("Failed to initialize push context: %v", err)
-	}
 }
 
 // SetupProxy initializes a proxy for the current environment. This should generally be used when creating

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/yl2chen/cidranger"
+	"go.uber.org/atomic"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -252,6 +253,9 @@ type Controller struct {
 	networkGateways map[host.Name]map[string][]*model.Gateway
 
 	once sync.Once
+	// initialized is set to true once the controller is running successfully. This ensures we do not
+	// return HasSynced=true before we are running
+	initialized *atomic.Bool
 
 	// Duration to wait for cache syncs
 	syncInterval time.Duration
@@ -278,6 +282,7 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 		networksWatcher:             options.NetworksWatcher,
 		metrics:                     options.Metrics,
 		syncInterval:                options.GetSyncInterval(),
+		initialized:                 atomic.NewBool(false),
 	}
 
 	if options.SystemNamespace != "" {
@@ -332,10 +337,14 @@ func (c *Controller) Cluster() string {
 }
 
 func (c *Controller) cidrRanger() cidranger.Ranger {
+	c.RLock()
+	defer c.RUnlock()
 	return c.ranger
 }
 
 func (c *Controller) defaultNetwork() string {
+	c.RLock()
+	defer c.RUnlock()
 	if c.networkForRegistry != "" {
 		return c.networkForRegistry
 	}
@@ -551,6 +560,9 @@ func tryGetLatestObject(informer cache.SharedIndexInformer, obj interface{}) int
 
 // HasSynced returns true after the initial state synchronization
 func (c *Controller) HasSynced() bool {
+	if !c.initialized.Load() {
+		return false
+	}
 	if (c.nsInformer != nil && !c.nsInformer.HasSynced()) ||
 		!c.serviceInformer.HasSynced() ||
 		!c.endpoints.HasSynced() ||
@@ -630,6 +642,7 @@ func (c *Controller) Run(stop <-chan struct{}) {
 	if c.nsInformer != nil {
 		go c.nsInformer.Run(stop)
 	}
+	c.initialized.Store(true)
 	kubelib.WaitForCacheSyncInterval(stop, c.syncInterval, c.HasSynced)
 	c.queue.Run(stop)
 	log.Infof("Controller terminated")

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -82,6 +82,10 @@ type Connection struct {
 	// This is included in internal events.
 	node *core.Node
 
+	// initialized channel will be closed when proxy is initialized. Pushes, or anything accessing
+	// the proxy, should not be started until this channel is closed.
+	initialized chan struct{}
+
 	// stop can be used to end the connection manually via debug endpoints. Only to be used for testing.
 	stop chan struct{}
 
@@ -103,6 +107,7 @@ type Event struct {
 func newConnection(peerAddr string, stream DiscoveryStream) *Connection {
 	return &Connection{
 		pushChannel:   make(chan *Event),
+		initialized:   make(chan struct{}),
 		stop:          make(chan struct{}),
 		PeerAddr:      peerAddr,
 		Connect:       time.Now(),
@@ -266,6 +271,13 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream discovery.AggregatedD
 	reqChannel := make(chan *discovery.DiscoveryRequest, 1)
 	go s.receive(con, reqChannel, &receiveError)
 
+	// Wait for the proxy to be fully initialized before we start serving traffic. Because
+	// initialization doesn't have dependencies that will block, there is no need to add any timeout
+	// here. Prior to this explicit wait, we were implicitly waiting by receive() not sending to
+	// reqChannel and the connection not being enqueued for pushes to pushChannel until the
+	// initialization is complete.
+	<-con.initialized
+
 	for {
 		// Block until either a request is received or a push is triggered.
 		// We need 2 go routines because 'read' blocks in Recv().
@@ -288,10 +300,6 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream discovery.AggregatedD
 			}
 
 		case pushEv := <-con.pushChannel:
-			// TODO: possible race condition: if a config change happens while the envoy
-			// was getting the initial config, between LDS and RDS, the push will miss the
-			// monitored 'routes'. Same for CDS/EDS interval. It is very tricky to handle
-			// due to the protocol - but the periodic push recovers from it.
 			err := s.pushConnection(con, pushEv)
 			pushEv.done()
 			if err != nil {
@@ -444,33 +452,40 @@ func listEqualUnordered(a []string, b []string) bool {
 // update the node associated with the connection, after receiving a a packet from envoy, also adds the connection
 // to the tracking map.
 func (s *DiscoveryServer) initConnection(node *core.Node, con *Connection) error {
-	proxy, err := s.initProxy(node, con)
-	if err != nil {
-		return err
-	}
-
-	proxy.WatchedResources = map[string]*model.WatchedResource{}
-	// Based on node metadata and version, we can associate a different generator.
-	if proxy.Metadata.Generator != "" {
-		proxy.XdsResourceGenerator = s.Generators[proxy.Metadata.Generator]
-	}
-
 	// First request so initialize connection id and start tracking it.
-	con.proxy = proxy
 	con.ConID = connectionID(node.Id)
 	con.node = node
 
+	var id *spiffe.Identity
 	if features.EnableXDSIdentityCheck && con.Identities != nil {
 		// TODO: allow locking down, rejecting unauthenticated requests.
-		id, err := checkConnectionIdentity(con)
+		var err error
+		id, err = checkConnectionIdentity(con)
 		if err != nil {
 			adsLog.Warnf("Unauthorized XDS: %v with identity %v: %v", con.PeerAddr, con.Identities, err)
 			return fmt.Errorf("authorization failed: %v", err)
 		}
-		con.proxy.VerifiedIdentity = id
 	}
 
+	// Register the connection; this allows pushes to be triggered for the proxy. Note: the timing of
+	// this an initProxy is important. While registering for pushes *after* initialization is
+	// complete seems like a better choice, it introduces a race condition; If we complete
+	// initialization of a new push context between initProxy and addCon, we would not get any pushes
+	// triggered for the new push context, leading the proxy to have a stale state until the next
+	// full push.
 	s.addCon(con.ConID, con)
+
+	// Initialize the proxy struct
+	proxy, err := s.initProxy(node, con)
+	if err != nil {
+		return err
+	}
+	con.proxy = proxy
+	con.proxy.VerifiedIdentity = id
+
+	// Register that initialization is complete. This triggers to calls that it is safe to access the
+	// proxy.
+	close(con.initialized)
 
 	if s.StatusGen != nil {
 		s.StatusGen.OnConnect(con)
@@ -541,6 +556,13 @@ func (s *DiscoveryServer) initProxy(node *core.Node, con *Connection) (*model.Pr
 	// Discover supported IP Versions of proxy so that appropriate config can be delivered.
 	proxy.DiscoverIPVersions()
 
+	proxy.WatchedResources = map[string]*model.WatchedResource{}
+	// Based on node metadata and version, we can associate a different generator.
+	if proxy.Metadata.Generator != "" {
+		proxy.XdsResourceGenerator = s.Generators[proxy.Metadata.Generator]
+	}
+
+	recordXDSClients(proxy.Metadata.IstioVersion, 1)
 	return proxy, nil
 }
 
@@ -791,7 +813,7 @@ func (s *DiscoveryServer) startPush(req *model.PushRequest) {
 		}
 	}
 	req.Start = time.Now()
-	for _, p := range s.Clients() {
+	for _, p := range s.AllClients() {
 		s.pushQueue.Enqueue(p, req)
 	}
 }
@@ -800,7 +822,6 @@ func (s *DiscoveryServer) addCon(conID string, con *Connection) {
 	s.adsClientsMutex.Lock()
 	defer s.adsClientsMutex.Unlock()
 	s.adsClients[conID] = con
-	recordXDSClients(con.proxy.Metadata.IstioVersion, 1)
 }
 
 func (s *DiscoveryServer) removeCon(conID string) {

--- a/pilot/pkg/xds/discovery_test.go
+++ b/pilot/pkg/xds/discovery_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	uatomic "go.uber.org/atomic"
 	"google.golang.org/grpc"
 
 	"istio.io/istio/pilot/pkg/model"
@@ -291,10 +292,11 @@ func TestDebounce(t *testing.T) {
 					atomic.AddInt32(&partialPushes, 1)
 				}
 			}
+			updateSent := uatomic.NewInt64(0)
 
 			wg.Add(1)
 			go func() {
-				debounce(updateCh, stopCh, opts, fakePush)
+				debounce(updateCh, stopCh, opts, fakePush, updateSent)
 				wg.Done()
 			}()
 

--- a/pilot/pkg/xds/eds.go
+++ b/pilot/pkg/xds/eds.go
@@ -141,7 +141,7 @@ func (s *DiscoveryServer) edsCacheUpdate(clusterID, hostname string, namespace s
 	ep, created := s.getOrCreateEndpointShard(hostname, namespace)
 	// If we create a new endpoint shard, that means we have not seen the service earlier. We should do a full push.
 	if created {
-		adsLog.Infof("Full push, new service %s", hostname)
+		adsLog.Infof("Full push, new service %s/%s", namespace, hostname)
 		fullPush = true
 	}
 


### PR DESCRIPTION
This contains 3 fixes for 3 races mentioned in detail in https://github.com/istio/istio/issues/29830

1. concurrent PushContext initialization may lead to storing resulting push contexts out of order, dropping a later push context. This is fixed by simply dropping `go` on AdsPushAll. It doesn't need to be a goroutine anyways, its not doing any blocking work.

2. A race between initProxy and addCon; we get some PC-1 when we init proxy, then PC-2 starts to push, but since we are not registered, we miss the push and never get an update. The fix here is to add the connection first, but block pushes until the proxy has completed initialized

3. HasSynced returns true before push context initialization is complete, leading to early connecting proxies not getting the full state of the world. This is fixed by keeping track of the configs we have send to configupdate after we are synced (it is synchronous, and so we know if we are synced its full up to date) and the configs we have finished push context initialization of, and comparing before marking as ready.

I have run this 10k+ without failures, previously it fails every ~100 runs or so

This is built on https://github.com/istio/istio/pull/29869, will be slightly smaller when that merges