### PR TITLE
Remove container metrics from dashboard tests

### DIFF
--- a/tests/integration/telemetry/stats/prometheus/nullvm/dashboard_test.go
+++ b/tests/integration/telemetry/stats/prometheus/nullvm/dashboard_test.go
@@ -69,6 +69,9 @@ var (
 				"galley_validation_passed",
 				// cAdvisor does not expose this metrics, and we don't have kubelet in kind
 				"container_fs_usage_bytes",
+				// flakes: https://github.com/istio/istio/issues/29871
+				"container_memory_working_set_bytes",
+				"container_cpu_usage_seconds_total",
 			},
 			// Pilot is installed only on Primary cluster, hence validate for primary clusters only.
 			true,
@@ -103,11 +106,11 @@ var (
 			"istio-grafana-dashboards",
 			"istio-performance-dashboard.json",
 			[]string{
-				// TODO add these back: https://github.com/istio/istio/issues/20175
-				`istio-telemetry`,
-				`istio-policy`,
 				// cAdvisor does not expose this metrics, and we don't have kubelet in kind
 				"container_fs_usage_bytes",
+				// flakes: https://github.com/istio/istio/issues/29871
+				"container_memory_working_set_bytes",
+				"container_cpu_usage_seconds_total",
 			},
 			true,
 		},
@@ -116,6 +119,9 @@ var (
 			"istio-extension-dashboard.json",
 			[]string{
 				"avg(envoy_wasm_vm_v8_",
+				// flakes: https://github.com/istio/istio/issues/29871
+				"container_memory_working_set_bytes",
+				"container_cpu_usage_seconds_total",
 			},
 			false,
 		},


### PR DESCRIPTION
This PR attempts to address test flakes related to querying of k8s container metrics in the dashboard tests. It removes them from consideration in evaluating dashboard queries.

Resolves https://github.com/istio/istio/issues/29871

[ X ] Policies and Telemetry
[ X ] Test and Release
[ X ] Does not have any changes that may affect Istio users.
