### PR TITLE
[test framework] Bump timeout for echo instance rollout

### DIFF
--- a/pkg/test/framework/components/echo/kube/instance.go
+++ b/pkg/test/framework/components/echo/kube/instance.go
@@ -643,7 +643,7 @@ func (c *instance) Restart() error {
 			return fmt.Errorf("expected %d pods, got %d", len(origPods), len(pods))
 		}
 		return nil
-	}, retry.Delay(time.Second*2), retry.Timeout(time.Second*30))
+	}, retry.Delay(time.Second*2), retry.Timeout(time.Minute))
 	if err != nil {
 		return fmt.Errorf("failed waiting for rollout pods ready")
 	}

--- a/tests/integration/pilot/revisioned_upgrade_test.go
+++ b/tests/integration/pilot/revisioned_upgrade_test.go
@@ -28,6 +28,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	kubetest "istio.io/istio/pkg/test/kube"
+	"istio.io/pkg/log"
 )
 
 // TestRevisionedUpgrade tests a revision-based upgrade from the specified versions to current master
@@ -86,6 +87,8 @@ func testUpgradeFromVersion(ctx framework.TestContext, t *testing.T, fromVersion
 	if err := enableDefaultInjection(revisionedNamespace); err != nil {
 		ctx.Fatalf("could not relabel namespace to enable default injection: %v", err)
 	}
+
+	log.Infof("rolling out echo workloads behind service %q", revisionedInstance.Config().Service)
 	if err := revisionedInstance.Restart(); err != nil {
 		ctx.Fatalf("revisioned instance rollout failed with: %v", err)
 	}


### PR DESCRIPTION
Bump timeout for rollout readiness from 30->60 seconds, addresses failures like [https://prow.istio.io/view/gs/istio-prow/logs/integ-pilot-k8s-tests_istio_postsubmit/1346538920686391296](https://prow.istio.io/view/gs/istio-prow/logs/integ-pilot-k8s-tests_istio_postsubmit/1346538920686391296)

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[x] Does not have any changes that may affect Istio users.
