### PR TITLE
Support non-GCP envs for Stackdriver trace

### DIFF
--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -301,13 +301,7 @@ func getProxyConfigOptions(config *meshAPI.ProxyConfig, metadata *model.Bootstra
 		case *meshAPI.Tracing_Datadog_:
 			opts = append(opts, option.DataDogAddress(tracer.Datadog.Address))
 		case *meshAPI.Tracing_Stackdriver_:
-			var projectID string
-			var projFound bool
-
-			if projectID, projFound = metadata.PlatformMetadata[platform.GCPProject]; !projFound {
-				projectID, projFound = metadata.PlatformMetadata[platform.GCPProjectNumber]
-			}
-
+			projectID, projFound := metadata.PlatformMetadata[platform.GCPProject]
 			if !projFound {
 				return nil, errors.New("unable to process Stackdriver tracer: missing GCP Project")
 			}

--- a/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
+++ b/tests/integration/telemetry/stackdriver/stackdriver_filter_test.go
@@ -35,6 +35,7 @@ import (
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/echo/echoboot"
+	"istio.io/istio/pkg/test/framework/components/gcemetadata"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/components/stackdriver"
@@ -57,11 +58,17 @@ const (
 	sdBootstrapConfigMap         = "stackdriver-bootstrap-config"
 
 	projectsPrefix = "projects/test-project"
+
+	fakeGCEMetadataServerValues = `
+  defaultConfig:
+    proxyMetadata:
+      GCE_METADATA_HOST: `
 )
 
 var (
 	ist        istio.Instance
 	echoNsInst namespace.Instance
+	gceInst    gcemetadata.Instance
 	sdInst     stackdriver.Instance
 	srv        echo.Instances
 	clt        echo.Instances
@@ -142,6 +149,7 @@ func TestStackdriverMonitoring(t *testing.T) {
 func TestMain(m *testing.M) {
 	framework.NewSuite(m).
 		Label(label.CustomSetup).
+		Setup(conditionallySetupMetadataServer).
 		Setup(istio.Setup(getIstioInstance(), setupConfig)).
 		Setup(testSetup).
 		Run()
@@ -154,22 +162,33 @@ func setupConfig(_ resource.Context, cfg *istio.Config) {
 	cfg.ControlPlaneValues = `
 meshConfig:
   enableTracing: true
-values:
-  telemetry:
-    v2:
-      stackdriver:
-        configOverride:
-          meshEdgesReportingDuration: "5s"
-          enable_mesh_edges_reporting: true
 `
 	// enable stackdriver filter
 	cfg.Values["telemetry.v2.stackdriver.enabled"] = "true"
 	cfg.Values["telemetry.v2.stackdriver.logging"] = "true"
 	cfg.Values["telemetry.v2.stackdriver.topology"] = "true"
 	cfg.Values["telemetry.v2.stackdriver.configOverride.enable_audit_log"] = "true"
+	cfg.Values["telemetry.v2.stackdriver.configOverride.meshEdgesReportingDuration"] = "5s"
+	cfg.Values["telemetry.v2.stackdriver.configOverride.enable_mesh_edges_reporting"] = "true"
 	cfg.Values["global.proxy.tracer"] = "stackdriver"
 	cfg.Values["pilot.traceSampling"] = "100"
 	cfg.Values["telemetry.v2.accessLogPolicy.enabled"] = "true"
+
+	// conditionally use a fake metadata server for testing off of GCP
+	if gceInst != nil {
+		cfg.ControlPlaneValues = strings.Join([]string{cfg.ControlPlaneValues, fakeGCEMetadataServerValues, gceInst.Address()}, "")
+		cfg.Values["gateways.istio-ingressgateway.env.GCE_METADATA_HOST"] = gceInst.Address()
+		cfg.Values["gateways.istio-egressgateway.env.GCE_METADATA_HOST"] = gceInst.Address()
+	}
+}
+
+func conditionallySetupMetadataServer(ctx resource.Context) (err error) {
+	if !metadata.OnGCE() {
+		if gceInst, err = gcemetadata.New(ctx, gcemetadata.Config{}); err != nil {
+			return
+		}
+	}
+	return nil
 }
 
 func testSetup(ctx resource.Context) (err error) {


### PR DESCRIPTION
Instead of attempting to contact the MD server directly, this redirects through the metadata exported by the platform. This should allow "proper" behavior when not directly on GCP envs.

Resolves https://github.com/istio/istio/issues/29268


