### PR TITLE
[1.8] Various TLS fixes

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_builder_test.go
@@ -709,32 +709,9 @@ func TestInboundListenerFilters(t *testing.T) {
 func evaluateListenerFilterPredicates(t testing.TB, predicate *listener.ListenerFilterChainMatchPredicate, expected map[int]bool) {
 	t.Helper()
 	for port, expect := range expected {
-		got := evaluateListenerFilterPredicatesInternal(predicate, false, port)
+		got := xdstest.EvaluateListenerFilterPredicates(predicate, false, port)
 		if got != expect {
 			t.Errorf("expected port %v to have match=%v, got match=%v", port, expect, got)
 		}
-	}
-}
-
-func evaluateListenerFilterPredicatesInternal(predicate *listener.ListenerFilterChainMatchPredicate, invertMatch bool, port int) bool {
-	if predicate == nil {
-		return false
-	}
-	switch r := predicate.Rule.(type) {
-	case *listener.ListenerFilterChainMatchPredicate_NotMatch:
-		return evaluateListenerFilterPredicatesInternal(r.NotMatch, !invertMatch, port)
-	case *listener.ListenerFilterChainMatchPredicate_OrMatch:
-		matches := false
-		for _, r := range r.OrMatch.Rules {
-			matches = matches || evaluateListenerFilterPredicatesInternal(r, invertMatch, port)
-		}
-		if invertMatch {
-			matches = !matches
-		}
-		return matches
-	case *listener.ListenerFilterChainMatchPredicate_DestinationPortRange:
-		return int32(port) >= r.DestinationPortRange.GetStart() && int32(port) < r.DestinationPortRange.GetEnd()
-	default:
-		panic("unsupported predicate")
 	}
 }

--- a/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
@@ -482,6 +482,7 @@ func TestInboundClusters(t *testing.T) {
 				_, _, _, port := model.ParseSubsetKey(name)
 				sim.Run(simulation.Call{
 					Port:     port,
+					Protocol: simulation.HTTP,
 					Address:  "1.2.3.4",
 					CallMode: simulation.CallModeInbound,
 				}).Matches(t, simulation.Result{
@@ -656,9 +657,10 @@ spec:
 					Result: simulation.Result{ClusterMatched: "inbound|9090||"},
 				},
 				{
-					Name:   "tls on plaintext port",
-					Call:   mkCall(9090, simulation.MTLS),
-					Result: simulation.Result{Error: simulation.ErrNoFilterChain},
+					Name: "tls on plaintext port",
+					Call: mkCall(9090, simulation.MTLS),
+					// TLS is fine here; we are not sniffing TLS at all so anything is allowed
+					Result: simulation.Result{ClusterMatched: "inbound|9090||"},
 				},
 			},
 		},
@@ -682,9 +684,10 @@ spec:
 					Result: simulation.Result{ClusterMatched: "inbound|9090||"},
 				},
 				{
-					Name:   "tls on plaintext port",
-					Call:   mkCall(9090, simulation.MTLS),
-					Result: simulation.Result{Error: simulation.ErrNoFilterChain},
+					Name: "tls on plaintext port",
+					Call: mkCall(9090, simulation.MTLS),
+					// TLS is fine here; we are not sniffing TLS at all so anything is allowed
+					Result: simulation.Result{ClusterMatched: "inbound|9090||"},
 				},
 			},
 		},
@@ -739,9 +742,10 @@ spec:
 					Result: simulation.Result{ClusterMatched: "inbound|9090||"},
 				},
 				{
-					Name:   "tls on plaintext port",
-					Call:   mkCall(9090, simulation.MTLS),
-					Result: simulation.Result{Error: simulation.ErrNoFilterChain},
+					Name: "tls on plaintext port",
+					Call: mkCall(9090, simulation.MTLS),
+					// TLS is fine here; we are not sniffing TLS at all so anything is allowed
+					Result: simulation.Result{ClusterMatched: "inbound|9090||"},
 				},
 			},
 		},
@@ -813,6 +817,9 @@ spec:
   location: MESH_INTERNAL
   resolution: STATIC
   ports:
+  - name: tcp
+    number: 70
+    protocol: TCP
   - name: http
     number: 80
     protocol: HTTP
@@ -820,446 +827,556 @@ spec:
     number: 81
 ---
 `
-	runSimulationTest(t, nil, xds.FakeOptions{}, simulationTest{
-		name:   "disable",
-		config: svc + mtlsMode("DISABLE"),
-		calls: []simulation.Expect{
-			{
-				Name: "http inbound",
-				Call: simulation.Call{
-					Port:     80,
-					Protocol: simulation.HTTP,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					VirtualHostMatched: "inbound|http|80",
-					ClusterMatched:     "inbound|80||",
-				},
+	cases := []struct {
+		Name       string
+		Call       simulation.Call
+		Disabled   simulation.Result
+		Permissive simulation.Result
+		Strict     simulation.Result
+	}{
+		{
+			Name: "tcp",
+			Call: simulation.Call{
+				Port:     70,
+				Protocol: simulation.TCP,
+				CallMode: simulation.CallModeInbound,
 			},
-			{
-				Name: "auto port inbound",
-				Call: simulation.Call{
-					Port:     81,
-					Protocol: simulation.HTTP,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					VirtualHostMatched: "inbound|http|81",
-					ClusterMatched:     "inbound|81||",
-				},
+			Disabled: simulation.Result{
+				ClusterMatched: "inbound|70||",
 			},
-			{
-				Name: "auto port2 inbound",
-				Call: simulation.Call{
-					Port:     81,
-					Protocol: simulation.HTTP2,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					VirtualHostMatched: "inbound|http|81",
-					ClusterMatched:     "inbound|81||",
-				},
+			Permissive: simulation.Result{
+				ClusterMatched: "inbound|70||",
 			},
-			{
-				Name: "auto tcp inbound",
-				Call: simulation.Call{
-					Port:     81,
-					Protocol: simulation.TCP,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ListenerMatched:    "virtualInbound",
-					FilterChainMatched: "0.0.0.0_81",
-					ClusterMatched:     "inbound|81||",
-					StrictMatch:        true,
-				},
-			},
-			{
-				Name: "passthrough http",
-				Call: simulation.Call{
-					Address:  "1.2.3.4",
-					Port:     82,
-					Protocol: simulation.HTTP,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ClusterMatched: "InboundPassthroughClusterIpv4",
-				},
-			},
-			{
-				Name: "passthrough tcp",
-				Call: simulation.Call{
-					Address:  "1.2.3.4",
-					Port:     82,
-					Protocol: simulation.TCP,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ClusterMatched: "InboundPassthroughClusterIpv4",
-				},
-			},
-			{
-				Name: "passthrough tls",
-				Call: simulation.Call{
-					Address:  "1.2.3.4",
-					Port:     82,
-					Protocol: simulation.TCP,
-					TLS:      simulation.TLS,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ClusterMatched: "InboundPassthroughClusterIpv4",
-				},
+			Strict: simulation.Result{
+				// Plaintext to strict, should fail
+				Error: simulation.ErrNoFilterChain,
 			},
 		},
+		{
+			Name: "http to tcp",
+			Call: simulation.Call{
+				Port:     70,
+				Protocol: simulation.HTTP,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				ClusterMatched: "inbound|70||",
+			},
+			Permissive: simulation.Result{
+				ClusterMatched: "inbound|70||",
+			},
+			Strict: simulation.Result{
+				// Plaintext to strict, should fail
+				Error: simulation.ErrNoFilterChain,
+			},
+		},
+		{
+			Name: "tls to tcp",
+			Call: simulation.Call{
+				Port:     70,
+				Protocol: simulation.TCP,
+				TLS:      simulation.TLS,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				ClusterMatched: "inbound|70||",
+			},
+			Permissive: simulation.Result{
+				// This breaks because we don't match the mtls rule (alpn) but we don't match the plaintext rule either
+				Error: simulation.ErrNoFilterChain,
+				Skip:  "https://github.com/istio/istio/issues/29538",
+			},
+			Strict: simulation.Result{
+				// TLS, but not mTLS
+				Error: simulation.ErrMTLSError,
+			},
+		},
+		{
+			Name: "https to tcp",
+			Call: simulation.Call{
+				Port:     70,
+				Protocol: simulation.HTTP,
+				TLS:      simulation.TLS,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				ClusterMatched: "inbound|70||",
+			},
+			Permissive: simulation.Result{
+				// This breaks because we don't match the mtls rule (alpn) but we don't match the plaintext rule either
+				Error: simulation.ErrNoFilterChain,
+				Skip:  "https://github.com/istio/istio/issues/29538",
+			},
+			Strict: simulation.Result{
+				// TLS, but not mTLS
+				Error: simulation.ErrMTLSError,
+			},
+		},
+		{
+			Name: "mtls tcp to tcp",
+			Call: simulation.Call{
+				Port:     70,
+				Protocol: simulation.TCP,
+				TLS:      simulation.MTLS,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				// This is probably a user error, but there is no reason we should block mTLS traffic
+				// we just will not terminate it
+				ClusterMatched: "inbound|70||",
+			},
+			Permissive: simulation.Result{
+				ClusterMatched: "inbound|70||",
+			},
+			Strict: simulation.Result{
+				ClusterMatched: "inbound|70||",
+			},
+		},
+		{
+			Name: "mtls http to tcp",
+			Call: simulation.Call{
+				Port:     70,
+				Protocol: simulation.HTTP,
+				TLS:      simulation.MTLS,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				// This is probably a user error, but there is no reason we should block mTLS traffic
+				// we just will not terminate it
+				ClusterMatched: "inbound|70||",
+			},
+			Permissive: simulation.Result{
+				Error: simulation.ErrNoFilterChain,
+				Skip:  "https://github.com/istio/istio/issues/29538#issuecomment-742890598",
+			},
+			Strict: simulation.Result{
+				ClusterMatched: "inbound|70||",
+			},
+		},
+		{
+			Name: "http",
+			Call: simulation.Call{
+				Port:     80,
+				Protocol: simulation.HTTP,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				VirtualHostMatched: "inbound|http|80",
+				ClusterMatched:     "inbound|80||",
+			},
+			Permissive: simulation.Result{
+				VirtualHostMatched: "inbound|http|80",
+				ClusterMatched:     "inbound|80||",
+			},
+			Strict: simulation.Result{
+				// Plaintext to strict, should fail
+				Error: simulation.ErrNoFilterChain,
+			},
+		},
+		{
+			Name: "tls to http",
+			Call: simulation.Call{
+				Port:     80,
+				Protocol: simulation.HTTP,
+				TLS:      simulation.TLS,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				// TLS is not terminated, so we will attempt to decode as HTTP and fail
+				Error: simulation.ErrProtocolError,
+			},
+			Permissive: simulation.Result{
+				// Fails for the wrong reason, should be a protocol error instead
+				Error: simulation.ErrNoFilterChain,
+				Skip:  "https://github.com/istio/istio/issues/29538",
+			},
+			Strict: simulation.Result{
+				// TLS, but not mTLS
+				Error: simulation.ErrMTLSError,
+			},
+		},
+		{
+			Name: "https to http",
+			Call: simulation.Call{
+				Port:     80,
+				Protocol: simulation.HTTP,
+				TLS:      simulation.TLS,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				// TLS is not terminated, so we will attempt to decode as HTTP and fail
+				Error: simulation.ErrProtocolError,
+			},
+			Permissive: simulation.Result{
+				// Fails for the wrong reason, should be a protocol error instead
+				Error: simulation.ErrNoFilterChain,
+				Skip:  "https://github.com/istio/istio/issues/29538",
+			},
+			Strict: simulation.Result{
+				// TLS, but not mTLS
+				Error: simulation.ErrMTLSError,
+			},
+		},
+		{
+			Name: "mtls to http",
+			Call: simulation.Call{
+				Port:     80,
+				Protocol: simulation.HTTP,
+				TLS:      simulation.MTLS,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				// TLS is not terminated, so we will attempt to decode as HTTP and fail
+				Error: simulation.ErrProtocolError,
+			},
+			Permissive: simulation.Result{
+				VirtualHostMatched: "inbound|http|80",
+				ClusterMatched:     "inbound|80||",
+			},
+			Strict: simulation.Result{
+				VirtualHostMatched: "inbound|http|80",
+				ClusterMatched:     "inbound|80||",
+			},
+		},
+		{
+			Name: "tcp to http",
+			Call: simulation.Call{
+				Port:     80,
+				Protocol: simulation.TCP,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				// Expected, the port only supports HTTP
+				Error: simulation.ErrProtocolError,
+			},
+			Permissive: simulation.Result{
+				// Expected, the port only supports HTTP
+				Error: simulation.ErrProtocolError,
+			},
+			Strict: simulation.Result{
+				// Plaintext to strict fails
+				Error: simulation.ErrNoFilterChain,
+			},
+		},
+		{
+			Name: "auto port http",
+			Call: simulation.Call{
+				Port:     81,
+				Protocol: simulation.HTTP,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				VirtualHostMatched: "inbound|http|81",
+				ClusterMatched:     "inbound|81||",
+			},
+			Permissive: simulation.Result{
+				VirtualHostMatched: "inbound|http|81",
+				ClusterMatched:     "inbound|81||",
+			},
+			Strict: simulation.Result{
+				// Plaintext to strict fails
+				Error: simulation.ErrNoFilterChain,
+			},
+		},
+		{
+			Name: "auto port http2",
+			Call: simulation.Call{
+				Port:     81,
+				Protocol: simulation.HTTP2,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				VirtualHostMatched: "inbound|http|81",
+				ClusterMatched:     "inbound|81||",
+			},
+			Permissive: simulation.Result{
+				VirtualHostMatched: "inbound|http|81",
+				ClusterMatched:     "inbound|81||",
+			},
+			Strict: simulation.Result{
+				// Plaintext to strict fails
+				Error: simulation.ErrNoFilterChain,
+			},
+		},
+		{
+			Name: "auto port tcp",
+			Call: simulation.Call{
+				Port:     81,
+				Protocol: simulation.TCP,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				ListenerMatched:    "virtualInbound",
+				FilterChainMatched: "0.0.0.0_81",
+				ClusterMatched:     "inbound|81||",
+				StrictMatch:        true,
+			},
+			Permissive: simulation.Result{
+				ListenerMatched:    "virtualInbound",
+				FilterChainMatched: "0.0.0.0_81",
+				ClusterMatched:     "inbound|81||",
+				StrictMatch:        true,
+			},
+			Strict: simulation.Result{
+				// Plaintext to strict fails
+				Error: simulation.ErrNoFilterChain,
+			},
+		},
+		{
+			Name: "tls to auto port",
+			Call: simulation.Call{
+				Port:     81,
+				Protocol: simulation.TCP,
+				TLS:      simulation.TLS,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				// Should go through the TCP chains
+				ListenerMatched:    "virtualInbound",
+				FilterChainMatched: "0.0.0.0_81",
+				ClusterMatched:     "inbound|81||",
+				StrictMatch:        true,
+			},
+			Permissive: simulation.Result{
+				// Should go through the TCP chains
+				ListenerMatched:    "virtualInbound",
+				FilterChainMatched: "0.0.0.0_81",
+				ClusterMatched:     "inbound|81||",
+				StrictMatch:        true,
+			},
+			Strict: simulation.Result{
+				// Tls, but not mTLS
+				Error: simulation.ErrMTLSError,
+			},
+		},
+		{
+			Name: "https to auto port",
+			Call: simulation.Call{
+				Port:     81,
+				Protocol: simulation.HTTP,
+				TLS:      simulation.TLS,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				// Should go through the TCP chains
+				ListenerMatched:    "virtualInbound",
+				FilterChainMatched: "0.0.0.0_81",
+				ClusterMatched:     "inbound|81||",
+				StrictMatch:        true,
+			},
+			Permissive: simulation.Result{
+				// Should go through the TCP chains
+				ListenerMatched:    "virtualInbound",
+				FilterChainMatched: "0.0.0.0_81",
+				ClusterMatched:     "inbound|81||",
+				StrictMatch:        true,
+			},
+			Strict: simulation.Result{
+				// Tls, but not mTLS
+				Error: simulation.ErrMTLSError,
+			},
+		},
+		{
+			Name: "mtls tcp to auto port",
+			Call: simulation.Call{
+				Port:     81,
+				Protocol: simulation.TCP,
+				TLS:      simulation.MTLS,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				// This is probably a user error, but there is no reason we should block mTLS traffic
+				// we just will not terminate it
+				ClusterMatched: "inbound|81||",
+			},
+			Permissive: simulation.Result{
+				// Should go through the TCP chains
+				ListenerMatched:    "virtualInbound",
+				FilterChainMatched: "0.0.0.0_81",
+				ClusterMatched:     "inbound|81||",
+				StrictMatch:        true,
+			},
+			Strict: simulation.Result{
+				// Should go through the TCP chains
+				ListenerMatched:    "virtualInbound",
+				FilterChainMatched: "0.0.0.0_81",
+				ClusterMatched:     "inbound|81||",
+				StrictMatch:        true,
+			},
+		},
+		{
+			Name: "mtls http to auto port",
+			Call: simulation.Call{
+				Port:     81,
+				Protocol: simulation.HTTP,
+				TLS:      simulation.MTLS,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				// This is probably a user error, but there is no reason we should block mTLS traffic
+				// we just will not terminate it
+				ClusterMatched: "inbound|81||",
+			},
+			Permissive: simulation.Result{
+				// Should go through the HTTP chains
+				VirtualHostMatched: "inbound|http|81",
+				ClusterMatched:     "inbound|81||",
+			},
+			Strict: simulation.Result{
+				// Should go through the HTTP chains
+				VirtualHostMatched: "inbound|http|81",
+				ClusterMatched:     "inbound|81||",
+			},
+		},
+		{
+			Name: "passthrough http",
+			Call: simulation.Call{
+				Address:  "1.2.3.4",
+				Port:     82,
+				Protocol: simulation.HTTP,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				ClusterMatched:     "InboundPassthroughClusterIpv4",
+				FilterChainMatched: "virtualInbound-catchall-http",
+			},
+			Permissive: simulation.Result{
+				ClusterMatched:     "InboundPassthroughClusterIpv4",
+				FilterChainMatched: "virtualInbound-catchall-http",
+			},
+			Strict: simulation.Result{
+				// Plaintext to strict fails
+				Error: simulation.ErrNoFilterChain,
+			},
+		},
+		{
+			Name: "passthrough tcp",
+			Call: simulation.Call{
+				Address:  "1.2.3.4",
+				Port:     82,
+				Protocol: simulation.TCP,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				ClusterMatched:     "InboundPassthroughClusterIpv4",
+				FilterChainMatched: "virtualInbound",
+			},
+			Permissive: simulation.Result{
+				ClusterMatched:     "InboundPassthroughClusterIpv4",
+				FilterChainMatched: "virtualInbound",
+			},
+			Strict: simulation.Result{
+				// Plaintext to strict fails
+				Error: simulation.ErrNoFilterChain,
+			},
+		},
+		{
+			Name: "passthrough tls",
+			Call: simulation.Call{
+				Address:  "1.2.3.4",
+				Port:     82,
+				Protocol: simulation.TCP,
+				TLS:      simulation.TLS,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				ClusterMatched:     "InboundPassthroughClusterIpv4",
+				FilterChainMatched: "virtualInbound",
+			},
+			Permissive: simulation.Result{
+				Error: simulation.ErrNoFilterChain,
+				Skip:  "https://github.com/istio/istio/issues/29538",
+			},
+			Strict: simulation.Result{
+				// tls, but not mTLS
+				Error: simulation.ErrMTLSError,
+			},
+		},
+		{
+			Name: "passthrough https",
+			Call: simulation.Call{
+				Address:  "1.2.3.4",
+				Port:     82,
+				Protocol: simulation.HTTP,
+				TLS:      simulation.TLS,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				ClusterMatched: "InboundPassthroughClusterIpv4",
+			},
+			Permissive: simulation.Result{
+				Error: simulation.ErrMTLSError,
+				// We are matching the mtls chain unexpectedly
+				Skip: "https://github.com/istio/istio/issues/29538#issuecomment-742819586",
+			},
+			Strict: simulation.Result{
+				// tls, but not mTLS
+				Error: simulation.ErrMTLSError,
+			},
+		},
+		{
+			Name: "passthrough mtls",
+			Call: simulation.Call{
+				Address:  "1.2.3.4",
+				Port:     82,
+				Protocol: simulation.HTTP,
+				TLS:      simulation.MTLS,
+				CallMode: simulation.CallModeInbound,
+			},
+			Disabled: simulation.Result{
+				ClusterMatched: "InboundPassthroughClusterIpv4",
+			},
+			Permissive: simulation.Result{
+				ClusterMatched: "InboundPassthroughClusterIpv4",
+			},
+			Strict: simulation.Result{
+				ClusterMatched: "InboundPassthroughClusterIpv4",
+			},
+		},
+	}
+	t.Run("Disable", func(t *testing.T) {
+		calls := []simulation.Expect{}
+		for _, c := range cases {
+			calls = append(calls, simulation.Expect{
+				Name:   c.Name,
+				Call:   c.Call,
+				Result: c.Disabled,
+			})
+		}
+		runSimulationTest(t, nil, xds.FakeOptions{}, simulationTest{
+			config: svc + mtlsMode("DISABLE"),
+			calls:  calls,
+		})
 	})
 
-	runSimulationTest(t, nil, xds.FakeOptions{}, simulationTest{
-		name:   "permissive",
-		config: svc + mtlsMode("PERMISSIVE"),
-		calls: []simulation.Expect{
-			{
-				Name: "http port",
-				Call: simulation.Call{
-					Port:     80,
-					Protocol: simulation.HTTP,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					VirtualHostMatched: "inbound|http|80",
-					ClusterMatched:     "inbound|80||",
-				},
-			},
-			{
-				Name: "http port tls",
-				Call: simulation.Call{
-					Port:     80,
-					Protocol: simulation.HTTP,
-					TLS:      simulation.TLS,
-					Alpn:     "http/1.1",
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					// This is expected. Protocol is explicitly declared HTTP but we send TLS traffic
-					Error: simulation.ErrNoFilterChain,
-				},
-			},
-			{
-				Name: "http port mtls",
-				Call: simulation.Call{
-					Port:     80,
-					Protocol: simulation.HTTP,
-					TLS:      simulation.MTLS,
-					Alpn:     "istio-http/1.1",
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					VirtualHostMatched: "inbound|http|80",
-					ClusterMatched:     "inbound|80||",
-				},
-			},
-			{
-				Name: "auto port port",
-				Call: simulation.Call{
-					Port:     81,
-					Protocol: simulation.HTTP,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					VirtualHostMatched: "inbound|http|81",
-					ClusterMatched:     "inbound|81||",
-				},
-			},
-			{
-				Name: "auto port port https",
-				Call: simulation.Call{
-					Port:     81,
-					Protocol: simulation.HTTP,
-					TLS:      simulation.TLS,
-					Alpn:     "http/1.1",
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					// Passed through as plain tcp
-					ClusterMatched:     "inbound|81||",
-					ListenerMatched:    "virtualInbound",
-					FilterChainMatched: "0.0.0.0_81",
-					StrictMatch:        true,
-				},
-			},
-			{
-				Name: "auto port port https mtls",
-				Call: simulation.Call{
-					Port:     81,
-					Protocol: simulation.HTTP,
-					TLS:      simulation.MTLS,
-					Alpn:     "istio-http/1.1",
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ListenerMatched:    "virtualInbound",
-					FilterChainMatched: "0.0.0.0_81",
-					VirtualHostMatched: "inbound|http|81",
-					ClusterMatched:     "inbound|81||",
-					RouteMatched:       "default",
-					StrictMatch:        true,
-				},
-			},
-			{
-				Name: "auto port tcp",
-				Call: simulation.Call{
-					Port:     81,
-					Protocol: simulation.TCP,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ListenerMatched:    "virtualInbound",
-					FilterChainMatched: "0.0.0.0_81",
-					ClusterMatched:     "inbound|81||",
-					StrictMatch:        true,
-				},
-			},
-			{
-				Name: "auto port tls",
-				Call: simulation.Call{
-					Port:     81,
-					Protocol: simulation.TCP,
-					TLS:      simulation.TLS,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ListenerMatched:    "virtualInbound",
-					FilterChainMatched: "0.0.0.0_81",
-					ClusterMatched:     "inbound|81||",
-					StrictMatch:        true,
-				},
-			},
-			{
-				Name: "auto port mtls",
-				Call: simulation.Call{
-					Port:     81,
-					Protocol: simulation.TCP,
-					TLS:      simulation.MTLS,
-					Alpn:     "istio",
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ListenerMatched:    "virtualInbound",
-					FilterChainMatched: "0.0.0.0_81",
-					ClusterMatched:     "inbound|81||",
-					StrictMatch:        true,
-				},
-			},
-			{
-				Name: "passthrough http",
-				Call: simulation.Call{
-					Address:  "1.2.3.4",
-					Port:     82,
-					Protocol: simulation.HTTP,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ClusterMatched:     "InboundPassthroughClusterIpv4",
-					FilterChainMatched: "virtualInbound-catchall-http",
-				},
-			},
-			{
-				Name: "passthrough tcp",
-				Call: simulation.Call{
-					Address:  "1.2.3.4",
-					Port:     82,
-					Protocol: simulation.TCP,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ClusterMatched:     "InboundPassthroughClusterIpv4",
-					FilterChainMatched: "virtualInbound",
-				},
-			},
-			{
-				Name: "passthrough tls",
-				Call: simulation.Call{
-					Address:  "1.2.3.4",
-					Port:     82,
-					Protocol: simulation.TCP,
-					TLS:      simulation.TLS,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					// TODO: This is a bug, see https://github.com/istio/istio/issues/26079#issuecomment-673699228
-					Error: simulation.ErrNoFilterChain,
-				},
-			},
-			{
-				Name: "passthrough mtls",
-				Call: simulation.Call{
-					Address:  "1.2.3.4",
-					Port:     82,
-					Alpn:     "istio",
-					Protocol: simulation.TCP,
-					TLS:      simulation.MTLS,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ClusterMatched:     "InboundPassthroughClusterIpv4",
-					ListenerMatched:    "virtualInbound",
-					FilterChainMatched: "virtualInbound",
-					StrictMatch:        true,
-				},
-			},
-			{
-				Name: "passthrough https",
-				Call: simulation.Call{
-					Address:  "1.2.3.4",
-					Port:     82,
-					Alpn:     "http/1.1",
-					Protocol: simulation.HTTP,
-					TLS:      simulation.TLS,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ClusterMatched:     "InboundPassthroughClusterIpv4",
-					ListenerMatched:    "virtualInbound",
-					FilterChainMatched: "virtualInbound-catchall-http",
-					RouteMatched:       "default",
-					VirtualHostMatched: "inbound|http|0",
-					// TODO: This is a bug, see https://github.com/istio/istio/issues/26079#issuecomment-673699228
-					// We should NOT be terminating TLs here, this is supposed to be passthrough. This breaks traffic
-					// sending TLS with ALPN (ie curl, or many other clients) to a port not exposed in the service.
-					StrictMatch: true,
-				},
-			},
-		},
+	t.Run("Permissive", func(t *testing.T) {
+		calls := []simulation.Expect{}
+		for _, c := range cases {
+			calls = append(calls, simulation.Expect{
+				Name:   c.Name,
+				Call:   c.Call,
+				Result: c.Permissive,
+			})
+		}
+		runSimulationTest(t, nil, xds.FakeOptions{}, simulationTest{
+			config: svc + mtlsMode("PERMISSIVE"),
+			calls:  calls,
+		})
 	})
 
-	runSimulationTest(t, nil, xds.FakeOptions{}, simulationTest{
-		name:           "strict",
-		config:         svc + mtlsMode("STRICT"),
-		skipValidation: false,
-		calls: []simulation.Expect{
-			{
-				Name: "http port",
-				Call: simulation.Call{
-					Port:     80,
-					Protocol: simulation.HTTP,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					// Plaintext to strict, should fail
-					Error: simulation.ErrNoFilterChain,
-				},
-			},
-			{
-				Name: "auto port http",
-				Call: simulation.Call{
-					Port:     81,
-					Protocol: simulation.HTTP,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					// Plaintext to strict, should fail
-					Error: simulation.ErrNoFilterChain,
-				},
-			},
-			{
-				Name: "auto port http mtls",
-				Call: simulation.Call{
-					Port:     81,
-					Protocol: simulation.HTTP,
-					TLS:      simulation.MTLS,
-					Alpn:     "istio-http/1.1",
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					VirtualHostMatched: "inbound|http|81",
-					ClusterMatched:     "inbound|81||",
-				},
-			},
-			{
-				Name: "auto port tcp",
-				Call: simulation.Call{
-					Port:     81,
-					Protocol: simulation.TCP,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					// Plaintext to strict, should fail
-					Error: simulation.ErrNoFilterChain,
-				},
-			},
-			{
-				Name: "passthrough plaintext",
-				Call: simulation.Call{
-					Port:     82,
-					Address:  "1.2.3.4",
-					Protocol: simulation.TCP,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					// Cannot send plaintext with strict
-					Error: simulation.ErrNoFilterChain,
-				},
-			},
-			{
-				Name: "passthrough tls",
-				Call: simulation.Call{
-					Port:     82,
-					Address:  "1.2.3.4",
-					Protocol: simulation.TCP,
-					TLS:      simulation.TLS,
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ClusterMatched:     "InboundPassthroughClusterIpv4",
-					FilterChainMatched: "virtualInbound",
-				},
-			},
-			{
-				Name: "passthrough mtls",
-				Call: simulation.Call{
-					Port:     82,
-					Address:  "1.2.3.4",
-					Protocol: simulation.TCP,
-					TLS:      simulation.MTLS,
-					Alpn:     "istio",
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ClusterMatched:     "InboundPassthroughClusterIpv4",
-					FilterChainMatched: "virtualInbound",
-				},
-			},
-			{
-				Name: "passthrough mtls http",
-				Call: simulation.Call{
-					Port:     82,
-					Address:  "1.2.3.4",
-					Protocol: simulation.TCP,
-					TLS:      simulation.TLS,
-					Alpn:     "istio-http/1.1",
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ClusterMatched:     "InboundPassthroughClusterIpv4",
-					VirtualHostMatched: "inbound|http|0",
-				},
-			},
-			{
-				Name: "passthrough mtls http legacy",
-				Call: simulation.Call{
-					Port:     82,
-					Address:  "1.2.3.4",
-					Protocol: simulation.TCP,
-					TLS:      simulation.MTLS,
-					Alpn:     "http/1.1",
-					CallMode: simulation.CallModeInbound,
-				},
-				Result: simulation.Result{
-					ClusterMatched:     "InboundPassthroughClusterIpv4",
-					VirtualHostMatched: "inbound|http|0",
-				},
-			},
-		},
+	t.Run("Strict", func(t *testing.T) {
+		calls := []simulation.Expect{}
+		for _, c := range cases {
+			calls = append(calls, simulation.Expect{
+				Name:   c.Name,
+				Call:   c.Call,
+				Result: c.Strict,
+			})
+		}
+		runSimulationTest(t, nil, xds.FakeOptions{}, simulationTest{
+			config: svc + mtlsMode("STRICT"),
+			calls:  calls,
+		})
 	})
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/sidecar_simulation_test.go
@@ -882,9 +882,7 @@ spec:
 				ClusterMatched: "inbound|70||",
 			},
 			Permissive: simulation.Result{
-				// This breaks because we don't match the mtls rule (alpn) but we don't match the plaintext rule either
-				Error: simulation.ErrNoFilterChain,
-				Skip:  "https://github.com/istio/istio/issues/29538",
+				ClusterMatched: "inbound|70||",
 			},
 			Strict: simulation.Result{
 				// TLS, but not mTLS
@@ -903,9 +901,7 @@ spec:
 				ClusterMatched: "inbound|70||",
 			},
 			Permissive: simulation.Result{
-				// This breaks because we don't match the mtls rule (alpn) but we don't match the plaintext rule either
-				Error: simulation.ErrNoFilterChain,
-				Skip:  "https://github.com/istio/istio/issues/29538",
+				ClusterMatched: "inbound|70||",
 			},
 			Strict: simulation.Result{
 				// TLS, but not mTLS
@@ -946,8 +942,7 @@ spec:
 				ClusterMatched: "inbound|70||",
 			},
 			Permissive: simulation.Result{
-				Error: simulation.ErrNoFilterChain,
-				Skip:  "https://github.com/istio/istio/issues/29538#issuecomment-742890598",
+				ClusterMatched: "inbound|70||",
 			},
 			Strict: simulation.Result{
 				ClusterMatched: "inbound|70||",
@@ -977,7 +972,7 @@ spec:
 			Name: "tls to http",
 			Call: simulation.Call{
 				Port:     80,
-				Protocol: simulation.HTTP,
+				Protocol: simulation.TCP,
 				TLS:      simulation.TLS,
 				CallMode: simulation.CallModeInbound,
 			},
@@ -986,9 +981,10 @@ spec:
 				Error: simulation.ErrProtocolError,
 			},
 			Permissive: simulation.Result{
-				// Fails for the wrong reason, should be a protocol error instead
+				// This could also be a protocol error. In the current implementation, we choose not
+				// to create a match since if we did it would just be rejected in HCM; no match
+				// is more performant
 				Error: simulation.ErrNoFilterChain,
-				Skip:  "https://github.com/istio/istio/issues/29538",
 			},
 			Strict: simulation.Result{
 				// TLS, but not mTLS
@@ -1008,9 +1004,10 @@ spec:
 				Error: simulation.ErrProtocolError,
 			},
 			Permissive: simulation.Result{
-				// Fails for the wrong reason, should be a protocol error instead
+				// This could also be a protocol error. In the current implementation, we choose not
+				// to create a match since if we did it would just be rejected in HCM; no match
+				// is more performant
 				Error: simulation.ErrNoFilterChain,
-				Skip:  "https://github.com/istio/istio/issues/29538",
 			},
 			Strict: simulation.Result{
 				// TLS, but not mTLS

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -831,23 +831,13 @@ func (c *Controller) collectWorkloadInstanceEndpoints(svc *model.Service) []*mod
 		return nil
 	}
 
-	instances := c.serviceInstancesFromWorkloadInstances(svc, svc.Ports[0].Port)
 	endpoints := make([]*model.IstioEndpoint, 0)
-
-	// all endpoints for ports[0]
-	for _, instance := range instances {
-		endpoints = append(endpoints, instance.Endpoint)
-	}
-
-	// build an endpoint for each remaining service port
-	for i := 1; i < len(svc.Ports); i++ {
-		for _, instance := range instances {
-			ep := *instance.Endpoint
-			ep.EndpointPort = uint32(svc.Ports[i].Port)
-			ep.ServicePortName = svc.Ports[i].Name
-			endpoints = append(endpoints, &ep)
+	for _, port := range svc.Ports {
+		for _, instance := range c.serviceInstancesFromWorkloadInstances(svc, port.Port) {
+			endpoints = append(endpoints, instance.Endpoint)
 		}
 	}
+
 	return endpoints
 }
 

--- a/pilot/pkg/xds/filters/filters.go
+++ b/pilot/pkg/xds/filters/filters.go
@@ -134,7 +134,10 @@ var (
 	// These ALPNs are injected in the client side by the ALPN filter.
 	// "istio" is added for each upstream protocol in order to make it
 	// backward compatible. e.g., 1.4 proxy -> 1.3 proxy.
-	mtlsHTTP10ALPN = []string{"istio-http/1.0", "istio"}
-	mtlsHTTP11ALPN = []string{"istio-http/1.1", "istio"}
-	mtlsHTTP2ALPN  = []string{"istio-h2", "istio"}
+	// Non istio-* variants are added to ensure that traffic sent out of the mesh has a valid ALPN;
+	// ideally this would not be added, but because the override filter is in the HCM, rather than cluster,
+	// we do not yet know the upstream so we cannot determine if its in or out of the mesh
+	mtlsHTTP10ALPN = []string{"istio-http/1.0", "istio", "http/1.0"}
+	mtlsHTTP11ALPN = []string{"istio-http/1.1", "istio", "http/1.1"}
+	mtlsHTTP2ALPN  = []string{"istio-h2", "istio", "h2"}
 )

--- a/pilot/test/xdstest/test.go
+++ b/pilot/test/xdstest/test.go
@@ -1,0 +1,44 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xdstest
+
+import (
+	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+)
+
+// EvaluateListenerFilterPredicates runs through the ListenerFilterChainMatchPredicate logic
+// This is exposed for testing only, and should not be used in XDS generation code
+func EvaluateListenerFilterPredicates(predicate *listener.ListenerFilterChainMatchPredicate, invertMatch bool, port int) bool {
+	if predicate == nil {
+		return false
+	}
+	switch r := predicate.Rule.(type) {
+	case *listener.ListenerFilterChainMatchPredicate_NotMatch:
+		return EvaluateListenerFilterPredicates(r.NotMatch, !invertMatch, port)
+	case *listener.ListenerFilterChainMatchPredicate_OrMatch:
+		matches := false
+		for _, r := range r.OrMatch.Rules {
+			matches = matches || EvaluateListenerFilterPredicates(r, invertMatch, port)
+		}
+		if invertMatch {
+			matches = !matches
+		}
+		return matches
+	case *listener.ListenerFilterChainMatchPredicate_DestinationPortRange:
+		return int32(port) >= r.DestinationPortRange.GetStart() && int32(port) < r.DestinationPortRange.GetEnd()
+	default:
+		panic("unsupported predicate")
+	}
+}

--- a/pkg/test/echo/client/parsedresponse.go
+++ b/pkg/test/echo/client/parsedresponse.go
@@ -239,6 +239,15 @@ func almostEquals(a, b, precision int) bool {
 	return true
 }
 
+func (r ParsedResponses) CheckKey(key, expected string) error {
+	return r.Check(func(i int, response *ParsedResponse) error {
+		if response.RawResponse[key] != expected {
+			return fmt.Errorf("response[%d] %s: expected %s, received %s", i, key, expected, response.RawResponse[key])
+		}
+		return nil
+	})
+}
+
 func (r ParsedResponses) CheckCluster(expected string) error {
 	return r.Check(func(i int, response *ParsedResponse) error {
 		if response.Cluster != expected {

--- a/pkg/test/framework/components/echo/call.go
+++ b/pkg/test/framework/components/echo/call.go
@@ -154,6 +154,13 @@ func ExpectCluster(expected string) Validator {
 	})
 }
 
+// ExpectKey returns a validator that checks a key matches the provided value
+func ExpectKey(key, expected string) Validator {
+	return ValidatorFunc(func(responses client.ParsedResponses, _ error) error {
+		return responses.CheckKey(key, expected)
+	})
+}
+
 // ExpectHost returns a Validator that checks the responses for the given host header.
 func ExpectHost(expected string) Validator {
 	return ValidatorFunc(func(responses client.ParsedResponses, _ error) error {

--- a/pkg/test/framework/components/echo/common/call.go
+++ b/pkg/test/framework/components/echo/common/call.go
@@ -170,8 +170,8 @@ func fillInCallOptions(opts *echo.CallOptions) error {
 				return fmt.Errorf("callOptions: no port named %s available in Target Instance", opts.PortName)
 			}
 		}
-	} else if opts.Port == nil || opts.Port.ServicePort == 0 || opts.Port.Protocol == "" || opts.Address == "" {
-		return fmt.Errorf("if target is not set, then port.servicePort, port.protocol, and host must be set")
+	} else if opts.Port == nil || opts.Port.ServicePort == 0 || (opts.Port.Protocol == "" && opts.Scheme == "") || opts.Address == "" {
+		return fmt.Errorf("if target is not set, then port.servicePort, port.protocol or schema, and address must be set")
 	}
 
 	if opts.Scheme == "" {

--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -141,6 +141,9 @@ spec:
 {{- if $.TLSSettings }}
           - --crt=/etc/certs/custom/cert-chain.pem
           - --key=/etc/certs/custom/key.pem
+{{- else }}
+          - --crt=/cert.crt
+          - --key=/cert.key
 {{- end }}
         ports:
 {{- range $i, $p := $.ContainerPorts }}
@@ -255,10 +258,10 @@ spec:
         - |-
           # Read root cert from and place signed certs here (can't mount directly or the dir would be unwritable)
           sudo mkdir -p /var/run/secrets/istio
- 
+
           # hack: remove certs that are bundled in the image
-          sudo rm /var/run/secrets/istio/cert-chain.pem  
-          sudo rm /var/run/secrets/istio/key.pem  
+          sudo rm /var/run/secrets/istio/cert-chain.pem
+          sudo rm /var/run/secrets/istio/key.pem
           sudo chown -R istio-proxy /var/run/secrets
 
           # place mounted bootstrap files (token is mounted directly to the correct location)
@@ -289,7 +292,12 @@ spec:
 {{- if $p.ServerFirst }}
              --server-first={{ $p.Port }} \
 {{- end }}
+{{- if $p.TLS }}
+             --tls={{ $p.Port }} \
 {{- end }}
+{{- end }}
+             --crt=/var/lib/istio/cert.crt \
+             --key=/var/lib/istio/cert.key
         env:
         - name: INSTANCE_IP
           valueFrom:

--- a/pkg/test/framework/components/echo/kube/testdata/basic.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/basic.yaml
@@ -48,6 +48,8 @@ spec:
           - "3333"
           - --version
           - "bar"
+          - --crt=/cert.crt
+          - --key=/cert.key
         ports:
         - containerPort: 8090
         - containerPort: 8080

--- a/pkg/test/framework/components/echo/kube/testdata/healthcheck-rewrite.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/healthcheck-rewrite.yaml
@@ -47,6 +47,8 @@ spec:
           - "3333"
           - --version
           - "v1"
+          - --crt=/cert.crt
+          - --key=/cert.key
         ports:
         - containerPort: 8080
         - containerPort: 3333

--- a/pkg/test/framework/components/echo/kube/testdata/multiversion.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/multiversion.yaml
@@ -58,6 +58,8 @@ spec:
           - "3333"
           - --version
           - "v-istio"
+          - --crt=/cert.crt
+          - --key=/cert.key
         ports:
         - containerPort: 8090
         - containerPort: 9000
@@ -124,6 +126,8 @@ spec:
           - "3333"
           - --version
           - "v-legacy"
+          - --crt=/cert.crt
+          - --key=/cert.key
         ports:
         - containerPort: 8090
         - containerPort: 9000

--- a/pkg/test/framework/components/echo/kube/testdata/two-workloads-one-nosidecar.yaml
+++ b/pkg/test/framework/components/echo/kube/testdata/two-workloads-one-nosidecar.yaml
@@ -48,6 +48,8 @@ spec:
           - "3333"
           - --version
           - "v1"
+          - --crt=/cert.crt
+          - --key=/cert.key
         ports:
         - containerPort: 8090
         - containerPort: 8080
@@ -108,6 +110,8 @@ spec:
           - "3333"
           - --version
           - "nosidecar"
+          - --crt=/cert.crt
+          - --key=/cert.key
         ports:
         - containerPort: 8090
         - containerPort: 8080

--- a/releasenotes/notes/standard-alpn.yaml
+++ b/releasenotes/notes/standard-alpn.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: networking
+issue:
+- 24619
+releaseNotes:
+- |
+  **Fixed** an issue causing only internal ALPN values to be set during external TLS origination.

--- a/releasenotes/notes/tls-fc.yaml
+++ b/releasenotes/notes/tls-fc.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: networking
+issue:
+- 29538
+releaseNotes:
+- |
+  **Fixed** an issue causing client side application TLS requests sent to a PERMISSIVE mode enabled server to fail.

--- a/releasenotes/notes/vm-multiple-targetport.yaml
+++ b/releasenotes/notes/vm-multiple-targetport.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: networking
+issue: []
+releaseNotes:
+- |
+  **Fixed** an issue causing the `targetPort` option to not take affect for `WorkloadEntry`s with multiple ports.
+
+

--- a/tests/integration/pilot/common/apps.go
+++ b/tests/integration/pilot/common/apps.go
@@ -73,11 +73,13 @@ var EchoPorts = []echo.Port{
 	{Name: "http", Protocol: protocol.HTTP, ServicePort: 80, InstancePort: 18080},
 	{Name: "grpc", Protocol: protocol.GRPC, ServicePort: 7070, InstancePort: 17070},
 	{Name: "tcp", Protocol: protocol.TCP, ServicePort: 9090, InstancePort: 19090},
+	{Name: "https", Protocol: protocol.HTTPS, ServicePort: 443, InstancePort: 18443, TLS: true},
 	{Name: "tcp-server", Protocol: protocol.TCP, ServicePort: 9091, InstancePort: 16060, ServerFirst: true},
 	{Name: "auto-tcp", Protocol: protocol.TCP, ServicePort: 9092, InstancePort: 19091},
 	{Name: "auto-tcp-server", Protocol: protocol.TCP, ServicePort: 9093, InstancePort: 16061, ServerFirst: true},
 	{Name: "auto-http", Protocol: protocol.HTTP, ServicePort: 81, InstancePort: 18081},
 	{Name: "auto-grpc", Protocol: protocol.GRPC, ServicePort: 7071, InstancePort: 17071},
+	{Name: "auto-https", Protocol: protocol.HTTPS, ServicePort: 9443, InstancePort: 19443},
 }
 
 var WorkloadPorts = []echo.WorkloadPort{
@@ -255,6 +257,14 @@ spec:
   endpoints:
   - address: external.{{.Namespace}}.svc.cluster.local
   ports:
+  - name: http-tls-origination
+    number: 8888
+    protocol: http
+    targetPort: 443
+  - name: http2-tls-origination
+    number: 8882
+    protocol: http2
+    targetPort: 443
 {{- range $i, $p := .Ports }}
   - name: {{$p.Name}}
     number: {{$p.ServicePort}}

--- a/tests/integration/pilot/common/routing.go
+++ b/tests/integration/pilot/common/routing.go
@@ -404,12 +404,61 @@ spec:
 	return cases
 }
 
+func HostHeader(header string) http.Header {
+	h := http.Header{}
+	h["Host"] = []string{header}
+	return h
+}
+
+// tlsOriginationCases contains tests TLS origination from DestinationRule
+func tlsOriginationCases(apps *EchoDeployments) []TrafficTestCase {
+	cases := []TrafficTestCase{}
+	expects := []struct {
+		port int
+		alpn string
+	}{
+		{8888, "http/1.1"},
+		{8882, "h2"},
+	}
+	for _, c := range apps.PodA {
+		for _, e := range expects {
+			c := c
+			e := e
+
+			cases = append(cases, TrafficTestCase{
+				name: fmt.Sprintf("%s: %s", c.Config().Cluster.Name(), e.alpn),
+				config: fmt.Sprintf(`
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: external
+spec:
+  host: %s
+  trafficPolicy:
+    tls:
+      mode: SIMPLE
+`, apps.External[0].Config().DefaultHostHeader),
+				opts: echo.CallOptions{
+					Port:      &echo.Port{ServicePort: e.port, Protocol: protocol.HTTP},
+					Address:   apps.External[0].Address(),
+					Headers:   HostHeader(apps.External[0].Config().DefaultHostHeader),
+					Scheme:    scheme.HTTP,
+					Validator: echo.And(echo.ExpectOK(), echo.ExpectKey("Alpn", e.alpn)),
+				},
+				call: c.CallWithRetryOrFail,
+			})
+		}
+	}
+	return cases
+}
+
 // trafficLoopCases contains tests to ensure traffic does not loop through the sidecar
 func trafficLoopCases(apps *EchoDeployments) []TrafficTestCase {
 	cases := []TrafficTestCase{}
 	for _, c := range apps.PodA {
 		for _, d := range apps.PodB {
 			for _, port := range []string{"15001", "15006"} {
+				c, d, port := c, d, port
 				cases = append(cases, TrafficTestCase{
 					name: port,
 					call: func(t test.Failer, options echo.CallOptions, retryOptions ...retry.Option) echoclient.ParsedResponses {

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -56,7 +56,7 @@ type TrafficTestCase struct {
 }
 
 func (c TrafficTestCase) Run(ctx framework.TestContext, namespace string) {
-	ctx.NewSubTest(c.name).Run(func(ctx framework.TestContext) {
+	job := func(ctx framework.TestContext) {
 		if c.skip {
 			ctx.SkipNow()
 		}
@@ -81,7 +81,12 @@ func (c TrafficTestCase) Run(ctx framework.TestContext, namespace string) {
 				child.call(ctx, child.opts, retryOptions...)
 			})
 		}
-	})
+	}
+	if c.name != "" {
+		ctx.NewSubTest(c.name).Run(job)
+	} else {
+		job(ctx)
+	}
 }
 
 func RunAllTrafficTests(ctx framework.TestContext, apps *EchoDeployments) {

--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -91,6 +91,7 @@ func RunAllTrafficTests(ctx framework.TestContext, apps *EchoDeployments) {
 	cases["serverfirst"] = serverFirstTestCases(apps)
 	cases["gateway"] = gatewayCases(apps)
 	cases["loop"] = trafficLoopCases(apps)
+	cases["tls-origination"] = tlsOriginationCases(apps)
 	if !ctx.Settings().SkipVM {
 		cases["vm"] = VMTestCases(apps.VM, apps)
 	}

--- a/tests/integration/pilot/istioctl_test.go
+++ b/tests/integration/pilot/istioctl_test.go
@@ -43,91 +43,18 @@ import (
 )
 
 var (
-	describeSvcAOutput = regexp.MustCompile(`Service: a\..*
+	// The full describe output is much larger, but testing for it requires a change anytime the test
+	// app changes which is tedious. Instead, just check a minimum subset; unit test cover the
+	// details.
+	describeSvcAOutput = regexp.MustCompile(`(?s)Service: a\..*
    Port: http 80/HTTP targets pod port 18080
-   Port: grpc 7070/GRPC targets pod port 17070
-   Port: tcp 9090/TCP targets pod port 19090
-   Port: tcp-server 9091/TCP targets pod port 16060
-   Port: auto-tcp 9092/UnsupportedProtocol targets pod port 19091
-   Port: auto-tcp-server 9093/UnsupportedProtocol targets pod port 16061
-   Port: auto-http 81/UnsupportedProtocol targets pod port 18081
-   Port: auto-grpc 7071/UnsupportedProtocol targets pod port 17071
+.*
 80 DestinationRule: a\..* for "a"
-   Matching subsets: v1
-   No Traffic Policy
-80 VirtualService: a\..*
-   when headers are end-user=jason
-80 RBAC policies: ns\[.*\]-policy\[integ-test\]-rule\[0\]
-7070 DestinationRule: a\..* for "a"
-   Matching subsets: v1
-   No Traffic Policy
-7070 VirtualService: a\..*
-   when headers are end-user=jason
-7070 RBAC policies: ns\[.*\]-policy\[integ-test\]-rule\[0\]
-9090 DestinationRule: a\..* for "a"
-   Matching subsets: v1
-   No Traffic Policy
-9090 RBAC policies: ns\[.*\]-policy\[integ-test\]-rule\[0\]
-9091 DestinationRule: a\..* for "a"
-   Matching subsets: v1
-   No Traffic Policy
-9091 RBAC policies: ns\[.*\]-policy\[integ-test\]-rule\[0\]
-9092 DestinationRule: a\..* for "a"
-   Matching subsets: v1
-   No Traffic Policy
-9093 DestinationRule: a\..* for "a"
-   Matching subsets: v1
-   No Traffic Policy
-81 DestinationRule: a\..* for "a"
-   Matching subsets: v1
-   No Traffic Policy
-7071 DestinationRule: a\..* for "a"
    Matching subsets: v1
    No Traffic Policy
 `)
 
-	describePodAOutput = regexp.MustCompile(`Service: a\..*
-   Port: http 80/HTTP targets pod port 18080
-   Port: grpc 7070/GRPC targets pod port 17070
-   Port: tcp 9090/TCP targets pod port 19090
-   Port: tcp-server 9091/TCP targets pod port 16060
-   Port: auto-tcp 9092/UnsupportedProtocol targets pod port 19091
-   Port: auto-tcp-server 9093/UnsupportedProtocol targets pod port 16061
-   Port: auto-http 81/UnsupportedProtocol targets pod port 18081
-   Port: auto-grpc 7071/UnsupportedProtocol targets pod port 17071
-80 DestinationRule: a\..* for "a"
-   Matching subsets: v1
-   No Traffic Policy
-80 VirtualService: a\..*
-   when headers are end-user=jason
-80 RBAC policies: ns\[.*\]-policy\[integ-test\]-rule\[0\]
-7070 DestinationRule: a\..* for "a"
-   Matching subsets: v1
-   No Traffic Policy
-7070 VirtualService: a\..*
-   when headers are end-user=jason
-7070 RBAC policies: ns\[.*\]-policy\[integ-test\]-rule\[0\]
-9090 DestinationRule: a\..* for "a"
-   Matching subsets: v1
-   No Traffic Policy
-9090 RBAC policies: ns\[.*\]-policy\[integ-test\]-rule\[0\]
-9091 DestinationRule: a\..* for "a"
-   Matching subsets: v1
-   No Traffic Policy
-9091 RBAC policies: ns\[.*\]-policy\[integ-test\]-rule\[0\]
-9092 DestinationRule: a\..* for "a"
-   Matching subsets: v1
-   No Traffic Policy
-9093 DestinationRule: a\..* for "a"
-   Matching subsets: v1
-   No Traffic Policy
-81 DestinationRule: a\..* for "a"
-   Matching subsets: v1
-   No Traffic Policy
-7071 DestinationRule: a\..* for "a"
-   Matching subsets: v1
-   No Traffic Policy
-`)
+	describePodAOutput = describeSvcAOutput
 
 	addToMeshPodAOutput = `deployment .* updated successfully with Istio sidecar injected.
 Next Step: Add related labels to the deployment to align with Istio's requirement: ` + url.DeploymentRequirements
@@ -226,7 +153,7 @@ func TestDescribe(t *testing.T) {
 					return err
 				}
 				if !describePodAOutput.MatchString(output) {
-					return fmt.Errorf("output:\n%v\n does not match regex:\n%v", output, describeSvcAOutput)
+					return fmt.Errorf("output:\n%v\n does not match regex:\n%v", output, describePodAOutput)
 				}
 				return nil
 			}, retry.Timeout(time.Second*5))

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"istio.io/istio/pkg/test/echo/common/scheme"
-
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/echo"
 	"istio.io/istio/pkg/test/framework/components/istio"
@@ -75,6 +74,17 @@ func TestReachability(t *testing.T) {
 					Include: func(src echo.Instance, opts echo.CallOptions) bool {
 						// Exclude calls from naked->VM.
 						return !(apps.IsNaked(src) && apps.VM.Contains(opts.Target))
+					},
+					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
+						return true
+					},
+					SkippedForMulticluster: true,
+				},
+				{
+					ConfigFile: "plaintext-to-permissive.yaml",
+					Namespace:  systemNM,
+					Include: func(src echo.Instance, opts echo.CallOptions) bool {
+						return true
 					},
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
 						return true

--- a/tests/integration/security/reachability_test.go
+++ b/tests/integration/security/reachability_test.go
@@ -84,7 +84,8 @@ func TestReachability(t *testing.T) {
 					ConfigFile: "plaintext-to-permissive.yaml",
 					Namespace:  systemNM,
 					Include: func(src echo.Instance, opts echo.CallOptions) bool {
-						return true
+						// Exclude calls from naked->VM.
+						return !(apps.IsNaked(src) && apps.VM.Contains(opts.Target))
 					},
 					ExpectSuccess: func(src echo.Instance, opts echo.CallOptions) bool {
 						return true

--- a/tests/integration/security/testdata/plaintext-to-permissive.yaml
+++ b/tests/integration/security/testdata/plaintext-to-permissive.yaml
@@ -1,0 +1,21 @@
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+  annotations:
+    test-suite: plaintext-to-permissive
+spec:
+  mtls:
+    mode: PERMISSIVE
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: default
+  annotations:
+    test-suite: plaintext-to-permissive
+spec:
+  host: "*.local"
+  trafficPolicy:
+    tls:
+      mode: DISABLE

--- a/tests/integration/security/util/framework.go
+++ b/tests/integration/security/util/framework.go
@@ -90,9 +90,16 @@ func EchoConfig(name string, ns namespace.Instance, headless bool, annos echo.An
 				Name:     "grpc",
 				Protocol: protocol.GRPC,
 			},
+			{
+				Name:         "https",
+				Protocol:     protocol.HTTPS,
+				ServicePort:  443,
+				InstancePort: 8443,
+				TLS:          true,
+			},
 		},
 		// Workload Ports needed by TestPassThroughFilterChain
-		// The port 8085,8086,8087,8088 will be defined only in the workload and not in the k8s service.
+		// The port 8085,8086,8087,8088,8089 will be defined only in the workload and not in the k8s service.
 		WorkloadOnlyPorts: []echo.WorkloadPort{
 			{
 				Port:     8085,
@@ -110,6 +117,10 @@ func EchoConfig(name string, ns namespace.Instance, headless bool, annos echo.An
 				Port:     8088,
 				Protocol: protocol.TCP,
 			},
+			{
+				Port:     8089,
+				Protocol: protocol.HTTPS,
+			},
 		},
 		Cluster: cluster,
 	}
@@ -117,7 +128,9 @@ func EchoConfig(name string, ns namespace.Instance, headless bool, annos echo.An
 	// for headless service with selector, the port and target port must be equal
 	// Ref: https://kubernetes.io/docs/concepts/services-networking/service/#headless-services
 	if headless {
-		out.Ports[0].ServicePort = 8090
+		for i := range out.Ports {
+			out.Ports[i].ServicePort = out.Ports[i].InstancePort
+		}
 	}
 	return out
 }

--- a/tests/integration/security/util/reachability/context.go
+++ b/tests/integration/security/util/reachability/context.go
@@ -78,6 +78,10 @@ func Run(testCases []TestCase, ctx framework.TestContext, apps *util.EchoDeploym
 			PortName: "grpc",
 			Scheme:   scheme.GRPC,
 		},
+		{
+			PortName: "https",
+			Scheme:   scheme.HTTPS,
+		},
 	}
 
 	for _, c := range testCases {


### PR DESCRIPTION
* #29584 provides baseline testing
* #29589 fixes critical regression in TLS
* #29529 fixes a long standing bug causing the incorrect ALPN to be sent to external services
* #29621 fixes an issue with WorkloadEntry causing tests to fail

These are all in one PR since they all depend on each other.