### PR TITLE
Fix race in delayed queue

### DIFF
--- a/pkg/queue/delay.go
+++ b/pkg/queue/delay.go
@@ -81,7 +81,7 @@ func (q *pq) Peek() interface{} {
 	return (*q)[0]
 }
 
-// Delayed ipmlements queue such that tasks are executed after a specified delay.
+// Delayed implements queue such that tasks are executed after a specified delay.
 type Delayed interface {
 	Instance
 	PushDelayed(t Task, delay time.Duration)
@@ -217,7 +217,9 @@ func (d *delayQueue) Run(stop <-chan struct{}) {
 			// no items, wait for Push or stop
 			select {
 			case t := <-d.enqueue:
+				d.mu.Lock()
 				d.queue.Push(t)
+				d.mu.Unlock()
 			case <-stop:
 				return
 			}

--- a/pkg/queue/delay_test.go
+++ b/pkg/queue/delay_test.go
@@ -91,6 +91,29 @@ func TestDelayQueueOrdering(t *testing.T) {
 	mu.Unlock()
 }
 
+func TestDelayQueuePushBeforeRun(t *testing.T) {
+	// This is a regression test to ensure we can push while Run() is called without a race
+	dq := NewDelayed(DelayQueueBuffer(0))
+	st := make(chan struct{})
+	go func() {
+		// Enqueue a bunch until we stop
+		for {
+			select {
+			case <-st:
+				return
+			default:
+			}
+			dq.Push(func() error {
+				return nil
+			})
+		}
+	}()
+	go dq.Run(st)
+	// Wait a bit
+	<-time.After(time.Millisecond * 10)
+	close(st)
+}
+
 func TestDelayQueuePushNonblockingWithFullBuffer(t *testing.T) {
 	queuedItems := 50
 	dq := NewDelayed(DelayQueueBuffer(0), DelayQueueWorkers(0))


### PR DESCRIPTION
Tested with `7397 runs so far, 0 failures (100.00% pass rate). 258.117472ms avg, 570.8326ms max, 35.770251ms min`

Before fix, failed with:
```
==================
WARNING: DATA RACE
Read at 0x00c0000c20e0 by goroutine 34:
  istio.io/istio/pkg/queue.(*pq).Push()
      /home/howardjohn/go/src/istio.io/istio/pkg/queue/delay.go:54 +0x6db
  istio.io/istio/pkg/queue.(*delayQueue).Run()
      /home/howardjohn/go/src/istio.io/istio/pkg/queue/delay.go:220 +0x688

Previous write at 0x00c0000c20e0 by goroutine 33:
  istio.io/istio/pkg/queue.(*pq).Push()
      /home/howardjohn/go/src/istio.io/istio/pkg/queue/delay.go:54 +0xc6
  container/heap.Push()
      /usr/lib/go-1.15/src/container/heap/heap.go:53 +0x56
  istio.io/istio/pkg/queue.(*delayQueue).PushDelayed()
      /home/howardjohn/go/src/istio.io/istio/pkg/queue/delay.go:168 +0x1cb
  istio.io/istio/pkg/queue.(*delayQueue).Push()
      /home/howardjohn/go/src/istio.io/istio/pkg/queue/delay.go:175 +0x4b
  istio.io/istio/pkg/queue.TestRace.func1()
      /home/howardjohn/go/src/istio.io/istio/pkg/queue/delay_test.go:99 +0x4a

Goroutine 34 (running) created at:
  istio.io/istio/pkg/queue.TestRace()
      /home/howardjohn/go/src/istio.io/istio/pkg/queue/delay_test.go:104 +0x104
  testing.tRunner()
      /usr/lib/go-1.15/src/testing/testing.go:1123 +0x202

Goroutine 33 (running) created at:
  istio.io/istio/pkg/queue.TestRace()
      /home/howardjohn/go/src/istio.io/istio/pkg/queue/delay_test.go:97 +0xd1
  testing.tRunner()
      /usr/lib/go-1.15/src/testing/testing.go:1123 +0x202
==================
```