### PR TITLE
Make host lowercase

### DIFF
--- a/pilot/pkg/dns/dns.go
+++ b/pilot/pkg/dns/dns.go
@@ -328,6 +328,7 @@ func (table *LookupTable) lookupHost(qtype uint16, hostname string) ([]dns.RR, b
 // the lookup table, where N is number of search namespaces.
 func (table *LookupTable) buildDNSAnswers(altHosts map[string]struct{}, ipv4 []net.IP, ipv6 []net.IP, searchNamespaces []string) {
 	for h := range altHosts {
+		h = strings.ToLower(h)
 		table.allHosts[h] = struct{}{}
 		if len(ipv4) > 0 {
 			table.name4[h] = a(h, ipv4)
@@ -342,7 +343,7 @@ func (table *LookupTable) buildDNSAnswers(altHosts map[string]struct{}, ipv4 []n
 
 			// host h already ends with a .
 			// search namespace does not. So we append one in the end
-			expandedHost := h + searchNamespaces[0] + "."
+			expandedHost := strings.ToLower(h + searchNamespaces[0] + ".")
 			// make sure this is not a proper hostname
 			// if host is productpage, and search namespace is ns1.svc.cluster.local
 			// then the expanded host productpage.ns1.svc.cluster.local is a valid hostname


### PR DESCRIPTION
When host contains capital letters，it will resolv fail by smart dns proxy。
![image](https://user-images.githubusercontent.com/10192658/103844688-5b014c80-50d5-11eb-9e26-3ed39edb4588.png)
In this place,it make the query name to lowercase.
[ x] Configuration Infrastructure
[ x] Docs
[ x] Installation
[Y] Networking
[ x] Performance and Scalability
[ x] Policies and Telemetry
[ x] Security
[ x] Test and Release
[ x] User Experience
[ x] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
