### PR TITLE
pilot-agent: use file.AtomicWrite() for OutputKeyCertToDir()

### DIFF
--- a/security/pkg/nodeagent/util/util.go
+++ b/security/pkg/nodeagent/util/util.go
@@ -18,11 +18,12 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"path"
 	"time"
 
 	"go.opencensus.io/stats/view"
+
+	"istio.io/istio/pkg/file"
 )
 
 // ParseCertAndGetExpiryTimestamp parses the first certificate in certByte and returns cert expire
@@ -91,17 +92,17 @@ func OutputKeyCertToDir(dir string, privateKey, certChain, rootCert []byte) erro
 	}
 
 	if privateKey != nil {
-		if err := ioutil.WriteFile(path.Join(dir, "key.pem"), privateKey, 0600); err != nil {
+		if err := file.AtomicWrite(path.Join(dir, "key.pem"), privateKey, 0600); err != nil {
 			return fmt.Errorf("failed to write private key to file: %v", err)
 		}
 	}
 	if certChain != nil {
-		if err := ioutil.WriteFile(path.Join(dir, "cert-chain.pem"), certChain, 0600); err != nil {
+		if err := file.AtomicWrite(path.Join(dir, "cert-chain.pem"), certChain, 0600); err != nil {
 			return fmt.Errorf("failed to write cert chain to file: %v", err)
 		}
 	}
 	if rootCert != nil {
-		if err := ioutil.WriteFile(path.Join(dir, "root-cert.pem"), rootCert, 0600); err != nil {
+		if err := file.AtomicWrite(path.Join(dir, "root-cert.pem"), rootCert, 0600); err != nil {
 			return fmt.Errorf("failed to write root cert to file: %v", err)
 		}
 	}


### PR DESCRIPTION
pilot-agent SDS just writes the key and certificate files to the given
directory if configured w/ a non-empty path. This may cause issues for services
that only watch that file path for moves (e.g. envoy) due to atomicity
consideration. Use file.AtomicWrite() to ensure a `move` like ops is conducted.

Fixes https://github.com/istio/istio/issues/24850

Signed-off-by: Kailun Qin <kailun.qin@intel.com>