### PR TITLE
sds: remove obsolete code due to gateway SDS removal

### DIFF
--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -120,8 +120,6 @@ type sdsservice struct {
 	// skipToken indicates whether token is required.
 	skipToken bool
 
-	fileMountedCertsOnly bool
-
 	localJWT bool
 
 	jwtPath string
@@ -134,22 +132,20 @@ type sdsservice struct {
 
 // newSDSService creates Secret Discovery Service which implements envoy SDS API.
 func newSDSService(st security.SecretManager,
-	secOpt *security.Options,
-	skipTokenVerification bool) *sdsservice {
+	secOpt *security.Options) *sdsservice {
 	if st == nil {
 		return nil
 	}
 
 	ret := &sdsservice{
-		st:                   st,
-		skipToken:            skipTokenVerification,
-		fileMountedCertsOnly: secOpt.FileMountedCerts,
-		tickerInterval:       secOpt.RecycleInterval,
-		closing:              make(chan bool),
-		localJWT:             secOpt.UseLocalJWT,
-		jwtPath:              secOpt.JWTPath,
-		outputKeyCertToDir:   secOpt.OutputKeyCertToDir,
-		credFetcher:          secOpt.CredFetcher,
+		st:                 st,
+		skipToken:          secOpt.FileMountedCerts,
+		tickerInterval:     secOpt.RecycleInterval,
+		closing:            make(chan bool),
+		localJWT:           secOpt.UseLocalJWT,
+		jwtPath:            secOpt.JWTPath,
+		outputKeyCertToDir: secOpt.OutputKeyCertToDir,
+		credFetcher:        secOpt.CredFetcher,
 	}
 
 	go ret.clearStaledClientsJob()

--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -47,7 +47,7 @@ type Server struct {
 // NewServer creates and starts the Grpc server for SDS.
 func NewServer(options *ca2.Options, workloadSecretCache ca2.SecretManager) (*Server, error) {
 	s := &Server{
-		workloadSds: newSDSService(workloadSecretCache, options, options.FileMountedCerts),
+		workloadSds: newSDSService(workloadSecretCache, options),
 	}
 	if err := s.initWorkloadSdsService(options); err != nil {
 		sdsServiceLog.Errorf("Failed to initialize secret discovery service for workload proxies: %v", err)


### PR DESCRIPTION
* remove `fileMountedCertsOnly` field

* use directly `FileMountedCerts` opt of proxy agent to indicate whether token
  is required

Signed-off-by: Kailun Qin <kailun.qin@intel.com>