### PR TITLE
Update istio iptables CLI to specify DNS redirection

### DIFF
--- a/releasenotes/notes/redirect-dns-iptables.yaml
+++ b/releasenotes/notes/redirect-dns-iptables.yaml
@@ -3,4 +3,4 @@ kind: feature
 area: networking
 releaseNotes:
 - |
-  **Added** Allow specifying dns capture via CLI in istio-iptables script.
+  **Added** flag to enable capture of dns traffic to the istio-iptables script.

--- a/releasenotes/notes/redirect-dns-iptables.yaml
+++ b/releasenotes/notes/redirect-dns-iptables.yaml
@@ -1,0 +1,6 @@
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+releaseNotes:
+- |
+  **Added** Allow specifying dns capture via CLI in istio-iptables script.

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -95,6 +95,7 @@ func constructConfig() *config.Config {
 		ProbeTimeout:            viper.GetDuration(constants.ProbeTimeout),
 		SkipRuleApply:           viper.GetBool(constants.SkipRuleApply),
 		RunValidation:           viper.GetBool(constants.RunValidation),
+		RedirectDNS:             viper.GetBool(constants.RedirectDNS),
 	}
 
 	// TODO: Make this more configurable, maybe with an allowlist of users to be captured for output instead of a denylist.
@@ -300,7 +301,7 @@ func init() {
 	}
 	viper.SetDefault(constants.RunValidation, false)
 
-	rootCmd.Flags().Bool(constants.RedirectDNS, dnsCaptureByAgent, "If set to true, enable the capture of outgoing DNS packets on port 53, redirecting to istio-agent on :15053")
+	rootCmd.Flags().Bool(constants.RedirectDNS, dnsCaptureByAgent, "Enable capture of dns traffic by istio-agent")
 	if err := viper.BindPFlag(constants.RedirectDNS, rootCmd.Flags().Lookup(constants.RedirectDNS)); err != nil {
 		handleError(err)
 	}

--- a/tools/istio-iptables/pkg/cmd/root.go
+++ b/tools/istio-iptables/pkg/cmd/root.go
@@ -299,6 +299,12 @@ func init() {
 		handleError(err)
 	}
 	viper.SetDefault(constants.RunValidation, false)
+
+	rootCmd.Flags().Bool(constants.RedirectDNS, dnsCaptureByAgent, "If set to true, enable the capture of outgoing DNS packets on port 53, redirecting to istio-agent on :15053")
+	if err := viper.BindPFlag(constants.RedirectDNS, rootCmd.Flags().Lookup(constants.RedirectDNS)); err != nil {
+		handleError(err)
+	}
+	viper.SetDefault(constants.RedirectDNS, dnsCaptureByAgent)
 }
 
 func GetCommand() *cobra.Command {

--- a/tools/istio-iptables/pkg/cmd/run.go
+++ b/tools/istio-iptables/pkg/cmd/run.go
@@ -364,10 +364,7 @@ func (iptConfigurator *IptablesConfigurator) run() {
 		panic(err)
 	}
 
-	redirectDNS := false
-	if dnsCaptureByAgent {
-		redirectDNS = true
-	}
+	redirectDNS := iptConfigurator.cfg.RedirectDNS
 	iptConfigurator.logConfig()
 
 	if iptConfigurator.cfg.EnableInboundIPv6 {

--- a/tools/istio-iptables/pkg/cmd/run_test.go
+++ b/tools/istio-iptables/pkg/cmd/run_test.go
@@ -119,7 +119,7 @@ func TestRulesWithIpRange(t *testing.T) {
 	cfg.OutboundIPRangesExclude = "1.1.0.0/16"
 	cfg.OutboundIPRangesInclude = "9.9.0.0/16"
 	cfg.DryRun = true
-	dnsCaptureByAgent = true
+	cfg.RedirectDNS = true
 	iptConfigurator := NewIptablesConfigurator(cfg, &dep.StdoutStubDependencies{})
 	iptConfigurator.cfg.EnableInboundIPv6 = false
 	iptConfigurator.cfg.ProxyGID = "1,2"
@@ -172,7 +172,7 @@ func TestRulesWithTproxy(t *testing.T) {
 	cfg.OutboundIPRangesExclude = "1.1.0.0/16"
 	cfg.OutboundIPRangesInclude = "9.9.0.0/16"
 	cfg.DryRun = true
-	dnsCaptureByAgent = true
+	cfg.RedirectDNS = true
 	iptConfigurator := NewIptablesConfigurator(cfg, &dep.StdoutStubDependencies{})
 	iptConfigurator.cfg.EnableInboundIPv6 = false
 	iptConfigurator.cfg.ProxyGID = "1337"
@@ -678,7 +678,7 @@ func TestHandleInboundPortsIncludeWithWildcardInboundPortsAndTproxy(t *testing.T
 func TestHandleInboundIpv4RulesWithUidGid(t *testing.T) {
 	cfg := constructConfig()
 	cfg.DryRun = true
-	dnsCaptureByAgent = true
+	cfg.RedirectDNS = true
 	iptConfigurator := NewIptablesConfigurator(cfg, &dep.StdoutStubDependencies{})
 	iptConfigurator.cfg.EnableInboundIPv6 = false
 	iptConfigurator.cfg.ProxyGID = "1,2"
@@ -725,7 +725,7 @@ func TestHandleInboundIpv4RulesWithUidGid(t *testing.T) {
 func TestGenerateEmptyV6ConfigOnV4OnlyEnv(t *testing.T) {
 	cfg := constructConfig()
 	cfg.DryRun = true
-	dnsCaptureByAgent = true
+	cfg.RedirectDNS = true
 	iptConfigurator := NewIptablesConfigurator(cfg, &dep.StdoutStubDependencies{})
 	iptConfigurator.cfg.EnableInboundIPv6 = false
 	iptConfigurator.cfg.ProxyGID = "1,2"
@@ -764,7 +764,7 @@ func TestRulesWithLoopbackIpInOutboundIpRanges(t *testing.T) {
 	cfg := constructTestConfig()
 	cfg.OutboundIPRangesInclude = "127.1.2.3/32"
 	cfg.DryRun = true
-	dnsCaptureByAgent = true
+	cfg.RedirectDNS = true
 	iptConfigurator := NewIptablesConfigurator(cfg, &dep.StdoutStubDependencies{})
 	iptConfigurator.cfg.EnableInboundIPv6 = false
 	iptConfigurator.cfg.ProxyGID = "1,2"

--- a/tools/istio-iptables/pkg/config/config.go
+++ b/tools/istio-iptables/pkg/config/config.go
@@ -46,6 +46,7 @@ type Config struct {
 	RestoreFormat           bool          `json:"RESTORE_FORMAT"`
 	SkipRuleApply           bool          `json:"SKIP_RULE_APPLY"`
 	RunValidation           bool          `json:"RUN_VALIDATION"`
+	RedirectDNS             bool          `json:"REDIRECT_DNS"`
 	EnableInboundIPv6       bool          `json:"ENABLE_INBOUND_IPV6"`
 }
 

--- a/tools/istio-iptables/pkg/constants/constants.go
+++ b/tools/istio-iptables/pkg/constants/constants.go
@@ -87,6 +87,7 @@ const (
 	RunValidation             = "run-validation"
 	IptablesProbePort         = "iptables-probe-port"
 	ProbeTimeout              = "probe-timeout"
+	RedirectDNS               = "redirect-dns"
 )
 
 const (


### PR DESCRIPTION
In current state it is impossible to reasonably use dns redirection to agent when imported iptables package is used by other golang module. Environmental variable "ISTIO_META_DNS_CAPTURE" is added as global private module variable forcing potential users of the library to have to set up this variable in environment before their binary is up and running.

This change fixes that problem by simply adding "redirect-dns" option to iptables CLI, making it possible to use dns redirection directly from within go code that imports that package without having to set up environmental variable.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

[ ] Does not have any changes that may affect Istio users.
