### PR TITLE
Enable VM native health checking for tests

### DIFF
--- a/pkg/test/framework/components/echo/kube/deployment.go
+++ b/pkg/test/framework/components/echo/kube/deployment.go
@@ -322,13 +322,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        readinessProbe:
-          httpGet:
-            path: /healthz/ready
-            port: 15021
-          initialDelaySeconds: 1
-          periodSeconds: 2
-          failureThreshold: 10
         volumeMounts:
         - mountPath: /var/run/secrets/tokens
           name: {{ $.Service }}-istio-token

--- a/tests/integration/iop-integration-test-defaults.yaml
+++ b/tests/integration/iop-integration-test-defaults.yaml
@@ -58,6 +58,7 @@ spec:
         PILOT_ENABLED_SERVICE_APIS: true
         ENABLE_ADMIN_ENDPOINTS: true
         PILOT_ENABLE_WORKLOAD_ENTRY_AUTOREGISTRATION: true
+        PILOT_ENABLE_WORKLOAD_ENTRY_HEALTHCHECKS: true
 
     gateways:
       istio-ingressgateway:


### PR DESCRIPTION
Currently, we rely on Kubernetes health checking, which isn't actually
available in a real VM. This changes our tests to exercise the health
checking we will actually run
