### PR TITLE
annotation deprecation and alpha status analyzer

### DIFF
--- a/galley/pkg/config/analysis/analyzers/analyzers_test.go
+++ b/galley/pkg/config/analysis/analyzers/analyzers_test.go
@@ -79,6 +79,11 @@ var testGrid = []testCase{
 			{msg.MisplacedAnnotation, "Pod grafana-test"},
 			{msg.MisplacedAnnotation, "Deployment fortio-deploy"},
 			{msg.MisplacedAnnotation, "Namespace staging"},
+			{msg.DeprecatedAnnotation, "Deployment fortio-deploy"},
+			{msg.AlphaAnnotation, "Deployment fortio-deploy"},
+			{msg.AlphaAnnotation, "Pod invalid-annotations"},
+			{msg.AlphaAnnotation, "Pod invalid-annotations"},
+			{msg.AlphaAnnotation, "Service httpbin"},
 		},
 	},
 	{

--- a/galley/pkg/config/analysis/analyzers/annotations/annotations.go
+++ b/galley/pkg/config/analysis/analyzers/annotations/annotations.go
@@ -15,7 +15,6 @@
 package annotations
 
 import (
-	"fmt"
 	"strings"
 
 	"istio.io/api/annotation"
@@ -84,13 +83,24 @@ outer:
 		annotationDef := lookupAnnotation(ann)
 		if annotationDef == nil {
 			m := msg.NewUnknownAnnotation(r, ann)
-
-			if line, ok := util.ErrorLine(r, fmt.Sprintf(util.Annotation, ann)); ok {
-				m.Line = line
-			}
+			util.AddLineNumber(r, ann, m)
 
 			ctx.Report(collectionType, m)
 			continue
+		}
+
+		if annotationDef.Deprecated {
+			m := msg.NewDeprecatedAnnotation(r, ann)
+			util.AddLineNumber(r, ann, m)
+
+			ctx.Report(collectionType, m)
+		}
+
+		if annotationDef.FeatureStatus == annotation.Alpha {
+			m := msg.NewAlphaAnnotation(r, ann, annotationDef.FeatureStatus.String())
+			util.AddLineNumber(r, ann, m)
+
+			ctx.Report(collectionType, m)
 		}
 
 		// If the annotation def attaches to Any, exit early
@@ -103,25 +113,17 @@ outer:
 		attachesTo := resourceTypesAsStrings(annotationDef.Resources)
 		if !contains(attachesTo, kind) {
 			m := msg.NewMisplacedAnnotation(r, ann, strings.Join(attachesTo, ", "))
-
-			if line, ok := util.ErrorLine(r, fmt.Sprintf(util.Annotation, ann)); ok {
-				m.Line = line
-			}
+			util.AddLineNumber(r, ann, m)
 
 			ctx.Report(collectionType, m)
 			continue
 		}
 
-		// TODO: Check annotation.Deprecated.  Not implemented because no
-		// deprecations in the table have yet been deprecated!
 		validationFunction := inject.AnnotationValidation[ann]
 		if validationFunction != nil {
 			if err := validationFunction(value); err != nil {
 				m := msg.NewInvalidAnnotation(r, ann, err.Error())
-
-				if line, ok := util.ErrorLine(r, fmt.Sprintf(util.Annotation, ann)); ok {
-					m.Line = line
-				}
+				util.AddLineNumber(r, ann, m)
 
 				ctx.Report(collectionType, m)
 				continue

--- a/galley/pkg/config/analysis/analyzers/annotations/annotations.go
+++ b/galley/pkg/config/analysis/analyzers/annotations/annotations.go
@@ -97,7 +97,7 @@ outer:
 		}
 
 		if annotationDef.FeatureStatus == annotation.Alpha {
-			m := msg.NewAlphaAnnotation(r, ann, annotationDef.FeatureStatus.String())
+			m := msg.NewAlphaAnnotation(r, ann)
 			util.AddLineNumber(r, ann, m)
 
 			ctx.Report(collectionType, m)

--- a/galley/pkg/config/analysis/analyzers/util/find_errorline_utils.go
+++ b/galley/pkg/config/analysis/analyzers/util/find_errorline_utils.go
@@ -15,8 +15,10 @@
 package util
 
 import (
+	"fmt"
 	"strings"
 
+	"istio.io/istio/galley/pkg/config/analysis/diag"
 	"istio.io/istio/pkg/config/resource"
 )
 
@@ -107,4 +109,12 @@ func ErrorLine(r *resource.Instance, path string) (line int, found bool) {
 func ExtractLabelFromSelectorString(s string) string {
 	equalIndex := strings.Index(s, "=")
 	return s[:equalIndex]
+}
+
+func AddLineNumber(r *resource.Instance, ann string, m diag.Message) bool {
+	if line, ok := ErrorLine(r, fmt.Sprintf(Annotation, ann)); ok {
+		m.Line = line
+		return true
+	}
+	return false
 }

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -132,6 +132,14 @@ var (
 	// ServiceEntryAddressesRequired defines a diag.MessageType for message "ServiceEntryAddressesRequired".
 	// Description: Virtual IP addresses are required for ports serving TCP (or unset) protocol
 	ServiceEntryAddressesRequired = diag.NewMessageType(diag.Warning, "IST0134", "ServiceEntry addresses are required for this protocol.")
+
+	// DeprecatedAnnotation defines a diag.MessageType for message "DeprecatedAnnotation".
+	// Description: A resource is using a deprecated Istio annotation.
+	DeprecatedAnnotation = diag.NewMessageType(diag.Info, "IST0135", "Annotation %q has been deprecated and may not work in future Istio versions.")
+
+	// AlphaAnnotation defines a diag.MessageType for message "AlphaAnnotation".
+	// Description: An Istio annotation is not recognized for any kind of resource.
+	AlphaAnnotation = diag.NewMessageType(diag.Info, "IST0136", "Annotation %q is %s level and may be incompletely supported.")
 )
 
 // All returns a list of all known message types.
@@ -168,6 +176,8 @@ func All() []*diag.MessageType {
 		VirtualServiceHostNotFoundInGateway,
 		SchemaWarning,
 		ServiceEntryAddressesRequired,
+		DeprecatedAnnotation,
+		AlphaAnnotation,
 	}
 }
 
@@ -482,5 +492,24 @@ func NewServiceEntryAddressesRequired(r *resource.Instance) diag.Message {
 	return diag.NewMessage(
 		ServiceEntryAddressesRequired,
 		r,
+	)
+}
+
+// NewDeprecatedAnnotation returns a new diag.Message based on DeprecatedAnnotation.
+func NewDeprecatedAnnotation(r *resource.Instance, annotation string) diag.Message {
+	return diag.NewMessage(
+		DeprecatedAnnotation,
+		r,
+		annotation,
+	)
+}
+
+// NewAlphaAnnotation returns a new diag.Message based on AlphaAnnotation.
+func NewAlphaAnnotation(r *resource.Instance, annotation string, level string) diag.Message {
+	return diag.NewMessage(
+		AlphaAnnotation,
+		r,
+		annotation,
+		level,
 	)
 }

--- a/galley/pkg/config/analysis/msg/messages.gen.go
+++ b/galley/pkg/config/analysis/msg/messages.gen.go
@@ -138,8 +138,8 @@ var (
 	DeprecatedAnnotation = diag.NewMessageType(diag.Info, "IST0135", "Annotation %q has been deprecated and may not work in future Istio versions.")
 
 	// AlphaAnnotation defines a diag.MessageType for message "AlphaAnnotation".
-	// Description: An Istio annotation is not recognized for any kind of resource.
-	AlphaAnnotation = diag.NewMessageType(diag.Info, "IST0136", "Annotation %q is %s level and may be incompletely supported.")
+	// Description: An Istio annotation may not be suitable for production.
+	AlphaAnnotation = diag.NewMessageType(diag.Info, "IST0136", "Annotation %q is part of an alpha-phase feature and may be incompletely supported.")
 )
 
 // All returns a list of all known message types.
@@ -505,11 +505,10 @@ func NewDeprecatedAnnotation(r *resource.Instance, annotation string) diag.Messa
 }
 
 // NewAlphaAnnotation returns a new diag.Message based on AlphaAnnotation.
-func NewAlphaAnnotation(r *resource.Instance, annotation string, level string) diag.Message {
+func NewAlphaAnnotation(r *resource.Instance, annotation string) diag.Message {
 	return diag.NewMessage(
 		AlphaAnnotation,
 		r,
 		annotation,
-		level,
 	)
 }

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -367,9 +367,7 @@ messages:
     code: IST0136
     level: Info
     description: "An Istio annotation may not be suitable for production."
-    template: "Annotation %q is %s level and may be incompletely supported."
+    template: "Annotation %q is part of an alpha-phase feature and may be incompletely supported."
     args:
       - name: annotation
-        type: string
-      - name: level
         type: string

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -353,3 +353,23 @@ messages:
     level: Warning
     description: "Virtual IP addresses are required for ports serving TCP (or unset) protocol"
     template: "ServiceEntry addresses are required for this protocol."
+
+  - name: "DeprecatedAnnotation"
+    code: IST0135
+    level: Info
+    description: "A resource is using a deprecated Istio annotation."
+    template: "Annotation %q has been deprecated and may not work in future Istio versions."
+    args:
+      - name: annotation
+        type: string
+
+  - name: "AlphaAnnotation"
+    code: IST0136
+    level: Info
+    description: "An Istio annotation is not recognized for any kind of resource."
+    template: "Annotation %q is %s level and may be incompletely supported."
+    args:
+      - name: annotation
+        type: string
+      - name: level
+        type: string

--- a/galley/pkg/config/analysis/msg/messages.yaml
+++ b/galley/pkg/config/analysis/msg/messages.yaml
@@ -366,7 +366,7 @@ messages:
   - name: "AlphaAnnotation"
     code: IST0136
     level: Info
-    description: "An Istio annotation is not recognized for any kind of resource."
+    description: "An Istio annotation may not be suitable for production."
     template: "Annotation %q is %s level and may be incompletely supported."
     args:
       - name: annotation

--- a/releasenotes/notes/29918.yaml
+++ b/releasenotes/notes/29918.yaml
@@ -6,4 +6,6 @@ issue:
 
 releaseNotes:
 - |
-  **Added** `istioctl analyze` now informs if deprecated or alpha-level annotations are present
+  **Added** `istioctl analyze` now informs if deprecated or alpha-level annotations are present.
+  (These checks can be disabled using `--suppress "IST0135=*"` and `--suppress "IST0136=*"`
+  respectively.)

--- a/releasenotes/notes/29918.yaml
+++ b/releasenotes/notes/29918.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: istioctl
+issue:
+  - 29154
+
+releaseNotes:
+- |
+  **Added** `istioctl analyze` now informs if deprecated or alpha-level annotations are present


### PR DESCRIPTION
This is the first part of an implementation for https://github.com/istio/istio/issues/29154

Check annotations and report at INFO level if they are deprecated or alpha

To test interactively, built _istioctl_ and run `istioctl analyze`.

Create a deprecated/alpha annotation for testing
```
kubectl create svc nodeport foo --tcp 8080
kubectl annotate svc foo alpha.istio.io/canonical-serviceaccounts=bar
```

@nmittler Would love to have your input, as your framework provided the ability.