### PR TITLE
Increase timeout for TestAgent

### DIFF
--- a/pkg/istio-agent/agent_test.go
+++ b/pkg/istio-agent/agent_test.go
@@ -442,7 +442,7 @@ func expectFileChanged(t *testing.T, files ...string) {
 			}
 		}
 		return nil
-	}, retry.Delay(time.Millisecond*10), retry.Timeout(time.Second*5))
+	}, retry.Delay(time.Millisecond*10), retry.Timeout(time.Second*15))
 }
 
 func expectFileUnchanged(t *testing.T, files ...string) {


### PR DESCRIPTION
The 2048 bit RSA is so expensive on a highly contended node sometimes
signing the cert times out in CI

Fixes https://github.com/istio/istio/issues/29920



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.