### PR TITLE
Improve debugging around push contexts, sidecar scope

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -204,7 +204,11 @@ type PushContext struct {
 	// AuthnBetaPolicies contains (beta) Authn policies by namespace.
 	AuthnBetaPolicies *AuthenticationPolicies `json:"-"`
 
-	Version string
+	// PushVersion describes the push version this push context was computed for
+	PushVersion string
+
+	// LedgerVersion is the version of the configuration ledger
+	LedgerVersion string
 
 	// cache gateways addresses for each network
 	// this is mainly used for kubernetes multi-cluster scenario
@@ -890,7 +894,7 @@ func (ps *PushContext) InitContext(env *Environment, oldPushContext *PushContext
 	ps.MeshNetworks = env.Networks()
 	ps.ServiceDiscovery = env
 	ps.IstioConfigStore = env
-	ps.Version = env.Version()
+	ps.LedgerVersion = env.Version()
 
 	// Must be initialized first
 	// as initServiceRegistry/VirtualServices/Destrules

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -122,17 +122,17 @@ type SidecarScope struct {
 }
 
 // Implement json.Marshaller
-func (d *SidecarScope) MarshalJSON() ([]byte, error) {
+func (sc *SidecarScope) MarshalJSON() ([]byte, error) {
 	// Json cannot expose unexported fields, so copy the ones we want here
 	return json.MarshalIndent(map[string]interface{}{
-		"version":               d.Version,
-		"rootNamespace":         d.RootNamespace,
-		"name":                  d.Name,
-		"namespace":             d.Namespace,
-		"outboundTrafficPolicy": d.OutboundTrafficPolicy,
-		"services":              d.services,
-		"sidecar":               d.Sidecar,
-		"destinationRules":      d.destinationRules,
+		"version":               sc.Version,
+		"rootNamespace":         sc.RootNamespace,
+		"name":                  sc.Name,
+		"namespace":             sc.Namespace,
+		"outboundTrafficPolicy": sc.OutboundTrafficPolicy,
+		"services":              sc.services,
+		"sidecar":               sc.Sidecar,
+		"destinationRules":      sc.destinationRules,
 	}, "", "  ")
 }
 

--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -15,6 +15,7 @@
 package model
 
 import (
+	"encoding/json"
 	"sort"
 	"strings"
 
@@ -73,6 +74,9 @@ type SidecarScope struct {
 	// sidecar scope
 	Sidecar *networking.Sidecar
 
+	// Version this sidecar was computed for
+	Version string
+
 	// Set of egress listeners, and their associated services.  A sidecar
 	// scope should have either ingress/egress listeners or both.  For
 	// every proxy workload that maps to a sidecar API object (or the
@@ -115,6 +119,21 @@ type SidecarScope struct {
 	//
 	// Changes to Sidecar resources in this namespace will trigger a push.
 	RootNamespace string
+}
+
+// Implement json.Marshaller
+func (d *SidecarScope) MarshalJSON() ([]byte, error) {
+	// Json cannot expose unexported fields, so copy the ones we want here
+	return json.MarshalIndent(map[string]interface{}{
+		"version":               d.Version,
+		"rootNamespace":         d.RootNamespace,
+		"name":                  d.Name,
+		"namespace":             d.Namespace,
+		"outboundTrafficPolicy": d.OutboundTrafficPolicy,
+		"services":              d.services,
+		"sidecar":               d.Sidecar,
+		"destinationRules":      d.destinationRules,
+	}, "", "  ")
 }
 
 // IstioEgressListenerWrapper is a wrapper for
@@ -184,6 +203,7 @@ func DefaultSidecarScopeForNamespace(ps *PushContext, configNamespace string) *S
 		servicesByHostname: make(map[host.Name]*Service),
 		configDependencies: make(map[uint32]struct{}),
 		RootNamespace:      ps.Mesh.RootNamespace,
+		Version:            ps.PushVersion,
 	}
 
 	// Now that we have all the services that sidecars using this scope (in
@@ -246,6 +266,7 @@ func ConvertToSidecarScope(ps *PushContext, sidecarConfig *config.Config, config
 		Sidecar:            sidecar,
 		configDependencies: make(map[uint32]struct{}),
 		RootNamespace:      ps.Mesh.RootNamespace,
+		Version:            ps.PushVersion,
 	}
 
 	out.EgressListeners = make([]*IstioEgressListenerWrapper, 0)

--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -647,7 +647,7 @@ func (s *DiscoveryServer) pushConnection(con *Connection, pushEv *Event) error {
 		adsLog.Debugf("Skipping push to %v, no updates required", con.ConID)
 		if pushRequest.Full {
 			// Only report for full versions, incremental pushes do not have a new version
-			reportAllEvents(s.StatusReporter, con.ConID, pushRequest.Push.Version, nil)
+			reportAllEvents(s.StatusReporter, con.ConID, pushRequest.Push.LedgerVersion, nil)
 		}
 		return nil
 	}
@@ -692,7 +692,7 @@ func (s *DiscoveryServer) pushConnection(con *Connection, pushEv *Event) error {
 	}
 	if pushRequest.Full {
 		// Report all events for unwatched resources. Watched resources will be reported in pushXds or on ack.
-		reportAllEvents(s.StatusReporter, con.ConID, pushRequest.Push.Version, con.proxy.WatchedResources)
+		reportAllEvents(s.StatusReporter, con.ConID, pushRequest.Push.LedgerVersion, con.proxy.WatchedResources)
 	}
 
 	proxiesConvergeDelay.Record(time.Since(pushRequest.Start).Seconds())
@@ -798,12 +798,12 @@ func (s *DiscoveryServer) AdsPushAll(version string, req *model.PushRequest) {
 		s.Cache.Clear(req.ConfigsUpdated)
 	}
 	if !req.Full {
-		adsLog.Infof("XDS: Incremental Pushing:%s ConnectedEndpoints:%d",
-			version, s.adsClientCount())
+		adsLog.Infof("XDS: Incremental Pushing:%s ConnectedEndpoints:%d Version:%s",
+			version, s.adsClientCount(), req.Push.PushVersion)
 	} else {
 		totalService := len(req.Push.Services(nil))
-		adsLog.Infof("XDS: Pushing:%s Services:%d ConnectedEndpoints:%d",
-			version, totalService, s.adsClientCount())
+		adsLog.Infof("XDS: Pushing:%s Services:%d ConnectedEndpoints:%d  Version:%s",
+			version, totalService, s.adsClientCount(), req.Push.PushVersion)
 		monServices.Record(float64(totalService))
 
 		// Make sure the ConfigsUpdated map exists

--- a/pilot/pkg/xds/bench_test.go
+++ b/pilot/pkg/xds/bench_test.go
@@ -268,7 +268,7 @@ func BenchmarkEndpointGeneration(b *testing.B) {
 					l := s.Discovery.generateEndpoints(NewEndpointBuilder(fmt.Sprintf("outbound|80||foo-%d.com", svc), proxy, push))
 					loadAssignments = append(loadAssignments, util.MessageToAny(l))
 				}
-				response = endpointDiscoveryResponse(loadAssignments, version, push.Version)
+				response = endpointDiscoveryResponse(loadAssignments, version, push.LedgerVersion)
 			}
 			logDebug(b, response.GetResources())
 		})

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -429,7 +429,6 @@ func (s *DiscoveryServer) sidecarz(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	_, _ = w.Write(by)
-	return
 }
 
 // Resource debugging.


### PR DESCRIPTION
Add the version information into push context and sidecar scope, add
version/nonce to some additional (debug logs), and add /debug/sidecarz
endpoint. All of these are helpful around debugging issues with push
context initialization, version ordering, etc.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.