### PR TITLE
tf: rename multicluster clusters

### DIFF
--- a/prow/config/topology/multicluster-large.json
+++ b/prow/config/topology/multicluster-large.json
@@ -1,6 +1,6 @@
 [
   {
-    "cluster_name": "cluster1",
+    "cluster_name": "cluster-0",
     "pod_subnet": "10.10.0.0/16",
     "svc_subnet": "10.255.10.0/24",
     "network_id": 0,
@@ -8,7 +8,7 @@
     "config_index": 0
   },
   {
-    "cluster_name": "cluster2",
+    "cluster_name": "cluster-1",
     "pod_subnet": "10.20.0.0/16",
     "svc_subnet": "10.255.20.0/24",
     "network_id": 0,
@@ -16,7 +16,7 @@
     "config_index": 0
   },
   {
-    "cluster_name": "cluster3",
+    "cluster_name": "cluster-2",
     "pod_subnet": "10.30.0.0/16",
     "svc_subnet": "10.255.30.0/24",
     "network_id": 0,
@@ -24,7 +24,7 @@
     "config_index": 2
   },
   {
-    "cluster_name": "cluster4",
+    "cluster_name": "cluster-3",
     "pod_subnet": "10.40.0.0/16",
     "svc_subnet": "10.255.40.0/24",
     "network_id": 1,
@@ -32,7 +32,7 @@
     "config_index": 3
   },
   {
-    "cluster_name": "cluster5",
+    "cluster_name": "cluster-4",
     "pod_subnet": "10.50.0.0/16",
     "svc_subnet": "10.255.50.0/24",
     "network_id": 1,

--- a/prow/config/topology/multicluster.json
+++ b/prow/config/topology/multicluster.json
@@ -1,6 +1,6 @@
 [
   {
-    "cluster_name": "cluster1",
+    "cluster_name": "cluster-0",
     "pod_subnet": "10.10.0.0/16",
     "svc_subnet": "10.255.10.0/24",
     "network_id": 0,
@@ -8,7 +8,7 @@
     "config_index": 0
   },
   {
-    "cluster_name": "cluster2",
+    "cluster_name": "cluster-1",
     "pod_subnet": "10.20.0.0/16",
     "svc_subnet": "10.255.20.0/24",
     "network_id": 0,
@@ -16,7 +16,7 @@
     "config_index": 0
   },
   {
-    "cluster_name": "cluster3",
+    "cluster_name": "cluster-2",
     "pod_subnet": "10.30.0.0/16",
     "svc_subnet": "10.255.30.0/24",
     "network_id": 1,


### PR DESCRIPTION
These clusters are named cluster1, cluster2, etc. But in the test
framework, they end up like cluster-0, cluster-1, etc.

Changing these for consistency to avoid the confusion of differernt
numbering schemes



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.