### PR TITLE
Filter CIDRs in NDS response

### DIFF
--- a/pilot/pkg/dns/dns.go
+++ b/pilot/pkg/dns/dns.go
@@ -237,6 +237,7 @@ func separateIPtypes(ips []string) (ipv4, ipv6 []net.IP) {
 	for _, ip := range ips {
 		addr := net.ParseIP(ip)
 		if addr == nil {
+			log.Debugf("ignoring un-parsable IP address: %v", ip)
 			continue
 		}
 		if addr.To4() != nil {

--- a/pilot/pkg/networking/core/v1alpha3/name_table.go
+++ b/pilot/pkg/networking/core/v1alpha3/name_table.go
@@ -15,6 +15,8 @@
 package v1alpha3
 
 import (
+	"net"
+
 	"istio.io/istio/pilot/pkg/model"
 	nds "istio.io/istio/pilot/pkg/proto"
 	"istio.io/istio/pilot/pkg/serviceregistry"
@@ -90,6 +92,11 @@ func (configgen *ConfigGeneratorImpl) BuildNameTable(node *model.Proxy, push *mo
 				continue
 			}
 		} else {
+			// Filter out things we cannot parse as IP. Generally this means CIDRs, as anything else
+			// should be caught in validation.
+			if addr := net.ParseIP(svcAddress); addr == nil {
+				continue
+			}
 			addressList = append(addressList, svcAddress)
 		}
 

--- a/pilot/pkg/xds/testdata/nds-se.yaml
+++ b/pilot/pkg/xds/testdata/nds-se.yaml
@@ -80,3 +80,16 @@ spec:
       protocol: HTTP
   resolution: NONE
 ---
+apiVersion: networking.istio.io/v1beta1
+kind: ServiceEntry
+metadata:
+  name: cidr
+spec:
+  addresses:
+  - 198.51.100.0/31
+  hosts:
+  - address.internal
+  ports:
+  - name: tcp
+    number: 8888
+    protocol: TCP


### PR DESCRIPTION
These are filtered in istio-agent anyways, but this just makes it more
clear they are not supported. There should be no user facing change -
CIDR is not supported in DNS response before nor after this change



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.