### PR TITLE
add --server flag to create-remote-secret

### DIFF
--- a/istioctl/pkg/multicluster/remote_secret.go
+++ b/istioctl/pkg/multicluster/remote_secret.go
@@ -29,10 +29,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/runtime/serializer/versioning"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/tools/clientcmd"
 
 	//  to avoid 'No Auth Provider found for name "gcp"'
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/tools/clientcmd/api/latest"
 

--- a/istioctl/pkg/multicluster/remote_secret.go
+++ b/istioctl/pkg/multicluster/remote_secret.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/runtime/serializer/versioning"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/clientcmd"
 
 	//  to avoid 'No Auth Provider found for name "gcp"'
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -193,6 +194,9 @@ func createRemoteSecretFromPlugin(
 
 	// Create a Kubeconfig to access the remote cluster using the auth provider plugin.
 	kubeconfig := createPluginKubeconfig(caData, clusterName, server, authProviderConfig)
+	if err := clientcmd.Validate(*kubeconfig); err != nil {
+		return nil, fmt.Errorf("invalid kubeconfig: %v", err)
+	}
 
 	// Encode the Kubeconfig in a secret that can be loaded by Istio to dynamically discover and access the remote cluster.
 	return createRemoteServiceAccountSecret(kubeconfig, clusterName, secName)
@@ -215,6 +219,9 @@ func createRemoteSecretFromTokenAndServer(tokenSecret *v1.Secret, clusterName, s
 
 	// Create a Kubeconfig to access the remote cluster using the remote service account credentials.
 	kubeconfig := createBearerTokenKubeconfig(caData, token, clusterName, server)
+	if err := clientcmd.Validate(*kubeconfig); err != nil {
+		return nil, fmt.Errorf("invalid kubeconfig: %v", err)
+	}
 
 	// Encode the Kubeconfig in a secret that can be loaded by Istio to dynamically discover and access the remote cluster.
 	return createRemoteServiceAccountSecret(kubeconfig, clusterName, secName)

--- a/istioctl/pkg/multicluster/remote_secret.go
+++ b/istioctl/pkg/multicluster/remote_secret.go
@@ -467,7 +467,7 @@ func (o *RemoteSecretOptions) addFlags(flagset *pflag.FlagSet) {
 			"in the secret. If a name is not specified the kube-system namespace's UUID of "+
 			"the local cluster will be used.")
 	flagset.StringVar(&o.ServerOverride, "server", "",
-		"Overrides the server field from the Kubeconfg.")
+		"The address and port of the Kubernetes API server.")
 	var supportedAuthType []string
 	for _, at := range []RemoteSecretAuthType{RemoteSecretAuthTypeBearerToken, RemoteSecretAuthTypePlugin} {
 		supportedAuthType = append(supportedAuthType, string(at))

--- a/istioctl/pkg/multicluster/remote_secret_test.go
+++ b/istioctl/pkg/multicluster/remote_secret_test.go
@@ -477,7 +477,7 @@ func TestCreateRemoteKubeconfig(t *testing.T) {
 clusters:
 - cluster:
     certificate-authority-data: Y2FEYXRh
-    server: ""
+    server: https://1.2.3.4
   name: {cluster}
 contexts:
 - context:
@@ -517,10 +517,19 @@ users:
 			wantErrStr:  errMissingTokenKey.Error(),
 		},
 		{
+			name:        "bad server name",
+			in:          makeSecret("", "caData", "token"),
+			context:     "c0",
+			clusterName: fakeClusterName,
+			server:      "",
+			wantErrStr:  "invalid kubeconfig:",
+		},
+		{
 			name:        "success",
 			in:          makeSecret("", "caData", "token"),
 			context:     "c0",
 			clusterName: fakeClusterName,
+			server:      "https://1.2.3.4",
 			want: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: remoteSecretNameFromClusterName(fakeClusterName),
@@ -604,7 +613,7 @@ func TestCreateRemoteSecretFromPlugin(t *testing.T) {
 clusters:
 - cluster:
     certificate-authority-data: Y2FEYXRh
-    server: ""
+    server: https://1.2.3.4
   name: {cluster}
 contexts:
 - context:
@@ -645,6 +654,7 @@ users:
 			in:          makeSecret("", "caData", ""),
 			context:     "c0",
 			clusterName: fakeClusterName,
+			server:      "https://1.2.3.4",
 			authProviderConfig: &api.AuthProviderConfig{
 				Name: "foobar",
 				Config: map[string]string{
@@ -671,6 +681,7 @@ users:
 			in:          makeSecret("", "caData", "token"),
 			context:     "c0",
 			clusterName: fakeClusterName,
+			server:      "https://1.2.3.4",
 			authProviderConfig: &api.AuthProviderConfig{
 				Name: "foobar",
 				Config: map[string]string{


### PR DESCRIPTION
Allows overriding the `server` when we want istiod to access the API server using a specific IP/hostname. 

Could be useful in environments that have private-IPs for the API server, or to help with allowing multi-cluster tests to workaround [the lack of docker0 on MacOS](https://docs.docker.com/docker-for-mac/networking/#there-is-no-docker0-bridge-on-macos).

cc @myidpt 