### PR TITLE
Fix tls-origination test flakes

### DIFF
--- a/tests/integration/pilot/common/traffic.go
+++ b/tests/integration/pilot/common/traffic.go
@@ -56,7 +56,7 @@ type TrafficTestCase struct {
 }
 
 func (c TrafficTestCase) Run(ctx framework.TestContext, namespace string) {
-	ctx.NewSubTest(c.name).Run(func(ctx framework.TestContext) {
+	job := func(ctx framework.TestContext) {
 		if c.skip {
 			ctx.SkipNow()
 		}
@@ -81,7 +81,12 @@ func (c TrafficTestCase) Run(ctx framework.TestContext, namespace string) {
 				child.call(ctx, child.opts, retryOptions...)
 			})
 		}
-	})
+	}
+	if c.name != "" {
+		ctx.NewSubTest(c.name).Run(job)
+	} else {
+		job(ctx)
+	}
 }
 
 func RunAllTrafficTests(ctx framework.TestContext, apps *EchoDeployments) {


### PR DESCRIPTION
This works around a real bug to make our tests less flaky.

Fixes https://github.com/istio/istio/issues/29915

The bug is well understood at this point I think
(https://github.com/envoyproxy/envoy/issues/14598), so for now there is
no need to suffer flakes while its being worked on.

The issue with the previous test is it rapidly adds and removes TLS
options to the cluster. Envoy appear to have a race where it sometimes
drops the last update. The changes here ensure we apply the TLS options
a single time, then send a bunch of requests, rather than flip-flopping.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.