### PR TITLE
pilot: when `PILOT_FILTER_GATEWAY_CLUSTER_CONFIG=true`, `pilot` should push CDS updates to a gateway proxy whenever a Gateway or VirtualService changes

### DIFF
--- a/pilot/pkg/xds/ads_common.go
+++ b/pilot/pkg/xds/ads_common.go
@@ -15,6 +15,7 @@
 package xds
 
 import (
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/config/schema/resource"
@@ -175,9 +176,15 @@ func PushTypeFor(proxy *model.Proxy, pushEv *Event) map[Type]bool {
 		for config := range pushEv.configsUpdated {
 			switch config.Kind {
 			case gvk.VirtualService:
+				if features.FilterGatewayClusterConfig {
+					out[CDS] = true
+				}
 				out[LDS] = true
 				out[RDS] = true
 			case gvk.Gateway:
+				if features.FilterGatewayClusterConfig {
+					out[CDS] = true
+				}
 				out[LDS] = true
 				out[RDS] = true
 			case gvk.ServiceEntry:


### PR DESCRIPTION
Signed-off-by: Yaroslav Skopets <yaroslav@tetrate.io>

## Summary

* in `Istio 1.7.x`, when `PILOT_FILTER_GATEWAY_CLUSTER_CONFIG=true`, `pilot` should push CDS updates to a gateway proxy whenever a `Gateway` or a `VirtualService` changes
* fixes https://github.com/istio/istio/issues/29954



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.