### PR TITLE
Fix gateways discoveryAddress outside istio-system

### DIFF
--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -49,6 +49,10 @@ spec:
         prometheus.io/path: "/stats/prometheus"
         {{- end }}
         sidecar.istio.io/inject: "false"
+        {{- if not (eq .Release.Namespace "istio-system") }}
+        proxy.istio.io/config: |-
+          discoveryAddress: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
+        {{- end }}
 {{- if $gateway.podAnnotations }}
 {{ toYaml $gateway.podAnnotations | indent 8 }}
 {{ end }}

--- a/manifests/charts/gateways/istio-egress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-egress/templates/deployment.yaml
@@ -51,7 +51,57 @@ spec:
         sidecar.istio.io/inject: "false"
         {{- if not (eq .Release.Namespace "istio-system") }}
         proxy.istio.io/config: |-
-          discoveryAddress: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
+          {{- if .Values.global.meshID }}
+          meshId: {{ .Values.global.meshID }}
+          {{- else if .Values.global.trustDomain }}
+          meshId: {{ .Values.global.trustDomain }}
+          {{- end }}
+          tracing:
+          {{- if eq .Values.global.proxy.tracer "lightstep" }}
+            lightstep:
+              # Address of the LightStep Satellite pool
+              address: {{ .Values.global.tracer.lightstep.address }}
+              # Access Token used to communicate with the Satellite pool
+              accessToken: {{ .Values.global.tracer.lightstep.accessToken }}
+          {{- else if eq .Values.global.proxy.tracer "zipkin" }}
+            zipkin:
+              # Address of the Zipkin collector
+              address: {{ .Values.global.tracer.zipkin.address | default (print "zipkin." .Values.global.istioNamespace ":9411") }}
+          {{- else if eq .Values.global.proxy.tracer "datadog" }}
+            datadog:
+              # Address of the Datadog Agent
+              address: {{ .Values.global.tracer.datadog.address | default "$(HOST_IP):8126" }}
+          {{- else if eq .Values.global.proxy.tracer "stackdriver" }}
+            stackdriver:
+              # enables trace output to stdout.
+            {{- if $.Values.global.tracer.stackdriver.debug }}
+              debug: {{ $.Values.global.tracer.stackdriver.debug }}
+            {{- end }}
+            {{- if $.Values.global.tracer.stackdriver.maxNumberOfAttributes }}
+              # The global default max number of attributes per span.
+              maxNumberOfAttributes: {{ $.Values.global.tracer.stackdriver.maxNumberOfAttributes | default "200" }}
+            {{- end }}
+            {{- if $.Values.global.tracer.stackdriver.maxNumberOfAnnotations }}
+              # The global default max number of annotation events per span.
+              maxNumberOfAnnotations: {{ $.Values.global.tracer.stackdriver.maxNumberOfAnnotations | default "200" }}
+            {{- end }}
+            {{- if $.Values.global.tracer.stackdriver.maxNumberOfMessageEvents }}
+              # The global default max number of message events per span.
+              maxNumberOfMessageEvents: {{ $.Values.global.tracer.stackdriver.maxNumberOfMessageEvents | default "200" }}
+            {{- end }}
+          {{- else if eq .Values.global.proxy.tracer "openCensusAgent" }}
+          {{- /* Fill in openCensusAgent configuration from meshConfig so it isn't overwritten below */ -}}
+            {{ toYaml $.Values.meshConfig.defaultConfig.tracing }}
+          {{- end }}
+          {{- if .Values.global.remotePilotAddress }}
+             {{- if .Values.pilot.enabled }}
+              discoveryAddress: {{ printf "istiod-remote.%s.svc" .Release.Namespace }}:15012
+             {{- else }}
+              discoveryAddress: {{ printf "istiod.%s.svc" .Release.Namespace }}:15012
+             {{- end }}
+          {{- else }}
+          discoveryAddress: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{.Release.Namespace}}.svc:15012
+          {{- end }}
         {{- end }}
 {{- if $gateway.podAnnotations }}
 {{ toYaml $gateway.podAnnotations | indent 8 }}

--- a/manifests/charts/gateways/istio-egress/values.yaml
+++ b/manifests/charts/gateways/istio-egress/values.yaml
@@ -332,6 +332,9 @@ global:
       # zipkin service (port 9411) in the same namespace as the other istio components.
       address: ""
 
+  # configure remote pilot and istiod service and endpoint
+  remotePilotAddress: ""
+
 meshConfig:
   enablePrometheusMerge: true
   defaultConfig:

--- a/manifests/charts/gateways/istio-egress/values.yaml
+++ b/manifests/charts/gateways/istio-egress/values.yaml
@@ -313,6 +313,22 @@ meshConfig:
     #        caCertificates:    # example: /etc/istio/tracer/root-cert.pem
     #        sni:               # example: tracer.somedomain
     #        subjectAltNames: []
-
-      # Configuration for each of the supported tracers
-      tracer: {}
+      datadog:
+        # Host:Port for submitting traces to the Datadog agent.
+        address: "$(HOST_IP):8126"
+      lightstep:
+        address: ""                # example: lightstep-satellite:443
+        accessToken: ""            # example: abcdefg1234567
+      stackdriver:
+        # enables trace output to stdout.
+        debug: false
+        # The global default max number of message events per span.
+        maxNumberOfMessageEvents: 200
+        # The global default max number of annotation events per span.
+        maxNumberOfAnnotations: 200
+        # The global default max number of attributes per span.
+        maxNumberOfAttributes: 200
+      zipkin:
+        # Host:Port for reporting trace data in zipkin format. If not specified, will default to
+        # zipkin service (port 9411) in the same namespace as the other istio components.
+        address: "zipkin.istio-system:9411"

--- a/manifests/charts/gateways/istio-egress/values.yaml
+++ b/manifests/charts/gateways/istio-egress/values.yaml
@@ -313,4 +313,6 @@ meshConfig:
     #        caCertificates:    # example: /etc/istio/tracer/root-cert.pem
     #        sni:               # example: tracer.somedomain
     #        subjectAltNames: []
-    # - tracer.somedomain
+
+      # Configuration for each of the supported tracers
+      tracer: {}

--- a/manifests/charts/gateways/istio-egress/values.yaml
+++ b/manifests/charts/gateways/istio-egress/values.yaml
@@ -301,6 +301,33 @@ global:
   # Deprecated, use meshConfig.trustDomain
   trustDomain: ""
 
+  # Configuration for each of the supported tracers
+  tracer:
+    # Configuration for envoy to send trace data to LightStep.
+    # Disabled by default.
+    # address: the <host>:<port> of the satellite pool
+    # accessToken: required for sending data to the pool
+    #
+    datadog:
+      # Host:Port for submitting traces to the Datadog agent.
+      address: "$(HOST_IP):8126"
+    lightstep:
+      address: ""                # example: lightstep-satellite:443
+      accessToken: ""            # example: abcdefg1234567
+    stackdriver:
+      # enables trace output to stdout.
+      debug: false
+      # The global default max number of message events per span.
+      maxNumberOfMessageEvents: 200
+      # The global default max number of annotation events per span.
+      maxNumberOfAnnotations: 200
+      # The global default max number of attributes per span.
+      maxNumberOfAttributes: 200
+    zipkin:
+      # Host:Port for reporting trace data in zipkin format. If not specified, will default to
+      # zipkin service (port 9411) in the same namespace as the other istio components.
+      address: ""
+
 meshConfig:
   enablePrometheusMerge: true
   defaultConfig:
@@ -313,22 +340,4 @@ meshConfig:
     #        caCertificates:    # example: /etc/istio/tracer/root-cert.pem
     #        sni:               # example: tracer.somedomain
     #        subjectAltNames: []
-      datadog:
-        # Host:Port for submitting traces to the Datadog agent.
-        address: "$(HOST_IP):8126"
-      lightstep:
-        address: ""                # example: lightstep-satellite:443
-        accessToken: ""            # example: abcdefg1234567
-      stackdriver:
-        # enables trace output to stdout.
-        debug: false
-        # The global default max number of message events per span.
-        maxNumberOfMessageEvents: 200
-        # The global default max number of annotation events per span.
-        maxNumberOfAnnotations: 200
-        # The global default max number of attributes per span.
-        maxNumberOfAttributes: 200
-      zipkin:
-        # Host:Port for reporting trace data in zipkin format. If not specified, will default to
-        # zipkin service (port 9411) in the same namespace as the other istio components.
-        address: "zipkin.istio-system:9411"
+    # - tracer.somedomain

--- a/manifests/charts/gateways/istio-egress/values.yaml
+++ b/manifests/charts/gateways/istio-egress/values.yaml
@@ -224,6 +224,10 @@ global:
     # Expected values are: trace|debug|info|warning|error|critical|off
     logLevel: warning
 
+    # Specify which tracer to use. One of: zipkin, lightstep, datadog, stackdriver.
+    # If using stackdriver tracer outside GCP, set env GOOGLE_APPLICATION_CREDENTIALS to the GCP credential file.
+    tracer: "zipkin"
+
   ##############################################################################################
   # The following values are found in other charts. To effectively modify these values, make   #
   # make sure they are consistent across your Istio helm charts                                #

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -49,6 +49,10 @@ spec:
         prometheus.io/path: "/stats/prometheus"
         {{- end }}
         sidecar.istio.io/inject: "false"
+        {{- if not (eq .Release.Namespace "istio-system") }}
+        proxy.istio.io/config: |-
+          discoveryAddress: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
+        {{- end }}
 {{- if $gateway.podAnnotations }}
 {{ toYaml $gateway.podAnnotations | indent 8 }}
 {{ end }}

--- a/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
+++ b/manifests/charts/gateways/istio-ingress/templates/deployment.yaml
@@ -51,7 +51,57 @@ spec:
         sidecar.istio.io/inject: "false"
         {{- if not (eq .Release.Namespace "istio-system") }}
         proxy.istio.io/config: |-
-          discoveryAddress: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{ .Values.global.istioNamespace }}.svc:15012
+          {{- if .Values.global.meshID }}
+          meshId: {{ .Values.global.meshID }}
+          {{- else if .Values.global.trustDomain }}
+          meshId: {{ .Values.global.trustDomain }}
+          {{- end }}
+          tracing:
+          {{- if eq .Values.global.proxy.tracer "lightstep" }}
+            lightstep:
+              # Address of the LightStep Satellite pool
+              address: {{ .Values.global.tracer.lightstep.address }}
+              # Access Token used to communicate with the Satellite pool
+              accessToken: {{ .Values.global.tracer.lightstep.accessToken }}
+          {{- else if eq .Values.global.proxy.tracer "zipkin" }}
+            zipkin:
+              # Address of the Zipkin collector
+              address: {{ .Values.global.tracer.zipkin.address | default (print "zipkin." .Values.global.istioNamespace ":9411") }}
+          {{- else if eq .Values.global.proxy.tracer "datadog" }}
+            datadog:
+              # Address of the Datadog Agent
+              address: {{ .Values.global.tracer.datadog.address | default "$(HOST_IP):8126" }}
+          {{- else if eq .Values.global.proxy.tracer "stackdriver" }}
+            stackdriver:
+              # enables trace output to stdout.
+            {{- if $.Values.global.tracer.stackdriver.debug }}
+              debug: {{ $.Values.global.tracer.stackdriver.debug }}
+            {{- end }}
+            {{- if $.Values.global.tracer.stackdriver.maxNumberOfAttributes }}
+              # The global default max number of attributes per span.
+              maxNumberOfAttributes: {{ $.Values.global.tracer.stackdriver.maxNumberOfAttributes | default "200" }}
+            {{- end }}
+            {{- if $.Values.global.tracer.stackdriver.maxNumberOfAnnotations }}
+              # The global default max number of annotation events per span.
+              maxNumberOfAnnotations: {{ $.Values.global.tracer.stackdriver.maxNumberOfAnnotations | default "200" }}
+            {{- end }}
+            {{- if $.Values.global.tracer.stackdriver.maxNumberOfMessageEvents }}
+              # The global default max number of message events per span.
+              maxNumberOfMessageEvents: {{ $.Values.global.tracer.stackdriver.maxNumberOfMessageEvents | default "200" }}
+            {{- end }}
+          {{- else if eq .Values.global.proxy.tracer "openCensusAgent" }}
+          {{- /* Fill in openCensusAgent configuration from meshConfig so it isn't overwritten below */ -}}
+            {{ toYaml $.Values.meshConfig.defaultConfig.tracing }}
+          {{- end }}
+          {{- if .Values.global.remotePilotAddress }}
+             {{- if .Values.pilot.enabled }}
+              discoveryAddress: {{ printf "istiod-remote.%s.svc" .Release.Namespace }}:15012
+             {{- else }}
+              discoveryAddress: {{ printf "istiod.%s.svc" .Release.Namespace }}:15012
+             {{- end }}
+          {{- else }}
+          discoveryAddress: istiod{{- if not (eq .Values.revision "") }}-{{ .Values.revision }}{{- end }}.{{.Release.Namespace}}.svc:15012
+          {{- end }}
         {{- end }}
 {{- if $gateway.podAnnotations }}
 {{ toYaml $gateway.podAnnotations | indent 8 }}

--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -342,6 +342,22 @@ meshConfig:
     #        caCertificates:    # example: /etc/istio/tracer/root-cert.pem
     #        sni:               # example: tracer.somedomain
     #        subjectAltNames: []
-
-      # Configuration for each of the supported tracers
-      tracer: {}
+      datadog:
+        # Host:Port for submitting traces to the Datadog agent.
+        address: "$(HOST_IP):8126"
+      lightstep:
+        address: ""                # example: lightstep-satellite:443
+        accessToken: ""            # example: abcdefg1234567
+      stackdriver:
+        # enables trace output to stdout.
+        debug: false
+        # The global default max number of message events per span.
+        maxNumberOfMessageEvents: 200
+        # The global default max number of annotation events per span.
+        maxNumberOfAnnotations: 200
+        # The global default max number of attributes per span.
+        maxNumberOfAttributes: 200
+      zipkin:
+        # Host:Port for reporting trace data in zipkin format. If not specified, will default to
+        # zipkin service (port 9411) in the same namespace as the other istio components.
+        address: "zipkin.istio-system:9411"

--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -361,6 +361,9 @@ global:
       # zipkin service (port 9411) in the same namespace as the other istio components.
       address: ""
 
+  # configure remote pilot and istiod service and endpoint
+  remotePilotAddress: ""
+
 meshConfig:
   enablePrometheusMerge: true
   defaultConfig:

--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -342,4 +342,6 @@ meshConfig:
     #        caCertificates:    # example: /etc/istio/tracer/root-cert.pem
     #        sni:               # example: tracer.somedomain
     #        subjectAltNames: []
-    # - tracer.somedomain
+
+      # Configuration for each of the supported tracers
+      tracer: {}

--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -330,6 +330,33 @@ global:
   # Deprecated, use meshConfig.trustDomain
   trustDomain: ""
 
+  # Configuration for each of the supported tracers
+  tracer:
+    # Configuration for envoy to send trace data to LightStep.
+    # Disabled by default.
+    # address: the <host>:<port> of the satellite pool
+    # accessToken: required for sending data to the pool
+    #
+    datadog:
+      # Host:Port for submitting traces to the Datadog agent.
+      address: "$(HOST_IP):8126"
+    lightstep:
+      address: ""                # example: lightstep-satellite:443
+      accessToken: ""            # example: abcdefg1234567
+    stackdriver:
+      # enables trace output to stdout.
+      debug: false
+      # The global default max number of message events per span.
+      maxNumberOfMessageEvents: 200
+      # The global default max number of annotation events per span.
+      maxNumberOfAnnotations: 200
+      # The global default max number of attributes per span.
+      maxNumberOfAttributes: 200
+    zipkin:
+      # Host:Port for reporting trace data in zipkin format. If not specified, will default to
+      # zipkin service (port 9411) in the same namespace as the other istio components.
+      address: ""
+
 meshConfig:
   enablePrometheusMerge: true
   defaultConfig:
@@ -342,22 +369,4 @@ meshConfig:
     #        caCertificates:    # example: /etc/istio/tracer/root-cert.pem
     #        sni:               # example: tracer.somedomain
     #        subjectAltNames: []
-      datadog:
-        # Host:Port for submitting traces to the Datadog agent.
-        address: "$(HOST_IP):8126"
-      lightstep:
-        address: ""                # example: lightstep-satellite:443
-        accessToken: ""            # example: abcdefg1234567
-      stackdriver:
-        # enables trace output to stdout.
-        debug: false
-        # The global default max number of message events per span.
-        maxNumberOfMessageEvents: 200
-        # The global default max number of annotation events per span.
-        maxNumberOfAnnotations: 200
-        # The global default max number of attributes per span.
-        maxNumberOfAttributes: 200
-      zipkin:
-        # Host:Port for reporting trace data in zipkin format. If not specified, will default to
-        # zipkin service (port 9411) in the same namespace as the other istio components.
-        address: "zipkin.istio-system:9411"
+    # - tracer.somedomain

--- a/manifests/charts/gateways/istio-ingress/values.yaml
+++ b/manifests/charts/gateways/istio-ingress/values.yaml
@@ -249,6 +249,10 @@ global:
     # Expected values are: trace|debug|info|warning|error|critical|off
     logLevel: warning
 
+    # Specify which tracer to use. One of: zipkin, lightstep, datadog, stackdriver.
+    # If using stackdriver tracer outside GCP, set env GOOGLE_APPLICATION_CREDENTIALS to the GCP credential file.
+    tracer: "zipkin"
+
   ##############################################################################################
   # The following values are found in other charts. To effectively modify these values, make   #
   # make sure they are consistent across your Istio helm charts                                #

--- a/releasenotes/notes/27265.yaml
+++ b/releasenotes/notes/27265.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: installation
+issue:
+- 27265
+
+releaseNotes:
+- |
+  **Fixed** gateways outside istio-system now can get the correct revisioned discoveryAddress renderred by manifests.


### PR DESCRIPTION
Please provide a description for what this PR is for.

Resolve: https://github.com/istio/istio/issues/27265

Tested by input IstioOperator:

```
apiVersion: install.istio.io/v1alpha1
kind: IstioOperator
spec:
  profile: empty
  components:
    ingressGateways:
    - name: default-ingressgateway
      enabled: true
      namespace: "gateways"
    egressGateways:
    - name: default-egressgateway
      enabled: true
      namespace: "gateways"
```
Install: `istioctldev install --set hub=gcr.io/istio-testing --set tag=1.9-dev --revision dev19 -f gateways-outside-istio-system.yaml`

Output of manifets:
https://gist.github.com/elfinhe/2dbb16471beb9f9e32efabdbd97087a3


And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.
