### PR TITLE
update ext authz tag in make file

### DIFF
--- a/samples/extauthz/src/Makefile
+++ b/samples/extauthz/src/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 HUB ?= docker.io/istio/ext-authz
-TAG ?= 0.5
+TAG ?= 0.6
 
 build: main.go go.mod go.sum Dockerfile
 	docker build . -t $(HUB):$(TAG)


### PR DESCRIPTION
ext authz sample current tag is 0.6 but makefile still uses 0.5. This PR fixes it

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X ] Does not have any changes that may affect Istio users.
