### PR TITLE
Another attempt at xds proxy log cleanup

### DIFF
--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -85,8 +85,6 @@ type XdsProxy struct {
 	connected      *ProxyConnection
 	initialRequest *discovery.DiscoveryRequest
 	connectedMutex sync.RWMutex
-
-	consecutiveUpstreamConnectFailures int
 }
 
 var proxyLog = log.RegisterScope("xdsproxy", "XDS Proxy in Istio Agent", 0)
@@ -201,7 +199,7 @@ type ProxyConnection struct {
 // This ensures that a new connection between istiod and agent doesn't end up consuming pending messages from envoy
 // as the new connection may not go to the same istiod. Vice versa case also applies.
 func (p *XdsProxy) StreamAggregatedResources(downstream discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
-	proxyLog.Infof("Envoy ADS stream established")
+	proxyLog.Infof("accepted XDS connection from Envoy, forwarding to upstream XDS server")
 
 	con := &ProxyConnection{
 		upstreamError:   make(chan error, 2), // can be produced by recv and send
@@ -268,19 +266,15 @@ func (p *XdsProxy) StreamAggregatedResources(downstream discovery.AggregatedDisc
 }
 
 func (p *XdsProxy) HandleUpstream(ctx context.Context, con *ProxyConnection, xds discovery.AggregatedDiscoveryServiceClient) error {
-	proxyLog.Infof("connecting to upstream XDS server: %s", p.istiodAddress)
-	defer proxyLog.Infof("disconnected from XDS server: %s", p.istiodAddress)
 	upstream, err := xds.StreamAggregatedResources(ctx,
 		grpc.MaxCallRecvMsgSize(defaultClientMaxReceiveMessageSize))
 	if err != nil {
-		p.consecutiveUpstreamConnectFailures++
-		if p.consecutiveUpstreamConnectFailures > 10 {
-			proxyLog.Errorf("failed to create upstream grpc client after %d attempts : %v", p.consecutiveUpstreamConnectFailures, err)
-		}
+		// Envoy logs errors again, so no need to log beyond debug level
+		proxyLog.Debugf("failed to create upstream grpc client: %v", err)
 		return err
 	}
-
-	p.consecutiveUpstreamConnectFailures = 0
+	proxyLog.Debugf("connecting to upstream XDS server: %s", p.istiodAddress)
+	defer proxyLog.Debugf("disconnected from XDS server: %s", p.istiodAddress)
 
 	con.upstream = upstream
 

--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -199,7 +199,7 @@ type ProxyConnection struct {
 // This ensures that a new connection between istiod and agent doesn't end up consuming pending messages from envoy
 // as the new connection may not go to the same istiod. Vice versa case also applies.
 func (p *XdsProxy) StreamAggregatedResources(downstream discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
-	proxyLog.Infof("accepted XDS connection from Envoy, forwarding to upstream XDS server")
+	proxyLog.Debugf("accepted XDS connection from Envoy, forwarding to upstream XDS server")
 
 	con := &ProxyConnection{
 		upstreamError:   make(chan error, 2), // can be produced by recv and send
@@ -273,7 +273,7 @@ func (p *XdsProxy) HandleUpstream(ctx context.Context, con *ProxyConnection, xds
 		proxyLog.Debugf("failed to create upstream grpc client: %v", err)
 		return err
 	}
-	proxyLog.Debugf("connecting to upstream XDS server: %s", p.istiodAddress)
+	proxyLog.Infof("connected to upstream XDS server: %s", p.istiodAddress)
 	defer proxyLog.Debugf("disconnected from XDS server: %s", p.istiodAddress)
 
 	con.upstream = upstream


### PR DESCRIPTION
Results, assuming https://github.com/envoyproxy/envoy/pull/14616#pullrequestreview-565567086 removes envoy logs for status code=0
```
# Initial connection
2021-01-11T18:05:53.451244Z     info    xdsproxy        connected to upstream XDS server: localhost:15012

# Keep alive triggered (if envoy pr merges, the StreamAggregatedResources log will be hiddden)
2021-01-11T10:06:14.309738Z     warning envoy config    StreamAggregatedResources gRPC config stream closed: 0,
2021-01-11T18:06:14.759961Z     info    xdsproxy        connected to upstream XDS server: localhost:15012

# Failures (until eventual recovery)
2021-01-11T10:06:17.576631Z     warning envoy config    StreamAggregatedResources gRPC config stream closed: 14, connection error: desc = "transport: Error while dialing dial tcp [::1]:15012: connect: connection refused"
2021-01-11T10:06:18.262982Z     warning envoy config    StreamAggregatedResources gRPC config stream closed: 14, connection error: desc = "transport: Error while dialing dial tcp [::1]:15012: connect: connection refused"
2021-01-11T10:06:18.284543Z     warning envoy config    StreamAggregatedResources gRPC config stream closed: 14, connection error: desc = "transport: Error while dialing dial tcp [::1]:15012: connect: connection refused"
2021-01-11T10:06:19.577431Z     warning envoy config    StreamAggregatedResources gRPC config stream closed: 14, connection error: desc = "transport: Error while dialing dial tcp [::1]:15012: connect: connection refused"
2021-01-11T10:06:23.110776Z     warning envoy config    StreamAggregatedResources gRPC config stream closed: 14, connection error: desc = "transport: Error while dialing dial tcp [::1]:15012: connect: connection refused"
2021-01-11T18:06:27.502452Z     info    xdsproxy        connected to upstream XDS server: localhost:15012
```