### PR TITLE
Prevent EnvoyFilter overwriting others when using deprecated names

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter/listener_patch_test.go
@@ -434,13 +434,34 @@ func TestApplyListenerPatches(t *testing.T) {
 			Patch: &networking.EnvoyFilter_Patch{
 				Operation: networking.EnvoyFilter_Patch_MERGE,
 				Value: buildPatchStruct(`
-{"name": "envoy.filters.network.http_connection_manager", 
+{"name": "envoy.http_connection_manager", 
  "typed_config": {
         "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
          "mergeSlashes": true,
          "alwaysSetRequestIdInResponse": true
  }
 }`),
+			},
+		},
+		{
+			ApplyTo: networking.EnvoyFilter_HTTP_FILTER,
+			Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
+				Context: networking.EnvoyFilter_SIDECAR_INBOUND,
+				ObjectTypes: &networking.EnvoyFilter_EnvoyConfigObjectMatch_Listener{
+					Listener: &networking.EnvoyFilter_ListenerMatch{
+						PortNumber: 80,
+						FilterChain: &networking.EnvoyFilter_ListenerMatch_FilterChainMatch{
+							Filter: &networking.EnvoyFilter_ListenerMatch_FilterMatch{
+								Name:      "envoy.http_connection_manager", // Use deprecated name for test.
+								SubFilter: &networking.EnvoyFilter_ListenerMatch_SubFilterMatch{Name: "http-filter2"},
+							},
+						},
+					},
+				},
+			},
+			Patch: &networking.EnvoyFilter_Patch{
+				Operation: networking.EnvoyFilter_Patch_INSERT_AFTER,
+				Value:     buildPatchStruct(`{"name": "http-filter-5"}`),
 			},
 		},
 		{
@@ -1048,6 +1069,7 @@ func TestApplyListenerPatches(t *testing.T) {
 										},
 										{Name: "http-filter3"},
 										{Name: "http-filter2"},
+										{Name: "http-filter-5"},
 										{Name: "http-filter4"},
 									},
 								}),
@@ -1265,6 +1287,7 @@ func TestApplyListenerPatches(t *testing.T) {
 										},
 										{Name: "http-filter3"},
 										{Name: "http-filter2"},
+										{Name: "http-filter-5"},
 										{Name: "http-filter4"},
 									},
 								}),

--- a/releasenotes/notes/envoyfilter-legacy-names.yaml
+++ b/releasenotes/notes/envoyfilter-legacy-names.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: networking
+issues:
+- 29909
+- 29858
+releaseNotes:
+- |
+  **Fixed** an issue causing usage of deprecated filter names in `EnvoyFilter` to overwrite other `EnvoyFilter`s.


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/29858
Fixes https://github.com/istio/istio/issues/29909

The issue here is we apply a merge with the legacy filter name,
overwriting the filter name, then
later expect to match on the new filter name, which fails (since its now
the legacy name).



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.