### PR TITLE
Fix networks initialization

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -637,7 +637,8 @@ func (c *Controller) syncEndpoints() error {
 func (c *Controller) Run(stop <-chan struct{}) {
 	if c.networksWatcher != nil {
 		c.networksWatcher.AddNetworksHandler(c.reloadNetworkLookup)
-		c.reloadNetworkLookup()
+		c.reloadMeshNetworks()
+		c.reloadNetworkGateways()
 	}
 	if c.nsInformer != nil {
 		go c.nsInformer.Run(stop)


### PR DESCRIPTION
Currently, we trigger all the pod and endpoint read events. This always
fails, and spams the logs, since Services have not been synced.

Instead, at startup just prepare the networks/gateways and rely on the
standard SyncAll call to trigger the explicit pod sync.
Without this, we get many `Handle EDS endpoint: skip collecting workload entry endpoints, service rancher.io-local-path/local-path-storage has not been populated`