### PR TITLE
filter multi-network gateway services by revision label

### DIFF
--- a/pilot/pkg/bootstrap/servicecontroller.go
+++ b/pilot/pkg/bootstrap/servicecontroller.go
@@ -75,6 +75,7 @@ func (s *Server) initKubeRegistry(args *PilotArgs) (err error) {
 	args.RegistryOptions.KubeOptions.XDSUpdater = s.XDSServer
 	args.RegistryOptions.KubeOptions.NetworksWatcher = s.environment.NetworksWatcher
 	args.RegistryOptions.KubeOptions.SystemNamespace = args.Namespace
+	args.RegistryOptions.KubeOptions.Revision = args.Revision
 
 	caBundlePath := s.caBundlePath
 	if hasCustomTLSCerts(args.ServerOptions.TLSOptions) {
@@ -88,7 +89,6 @@ func (s *Server) initKubeRegistry(args *PilotArgs) (err error) {
 		s.ServiceController(),
 		s.serviceEntryStore,
 		caBundlePath,
-		args.Revision,
 		s.fetchCARoot,
 		s.environment)
 

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -113,6 +113,9 @@ type Options struct {
 	// ClusterID identifies the remote cluster in a multicluster env.
 	ClusterID string
 
+	// Revision this control plane is a part of
+	Revision string
+
 	// Metrics for capturing node-based metrics.
 	Metrics model.Metrics
 
@@ -215,6 +218,7 @@ type Controller struct {
 	xdsUpdater      model.XDSUpdater
 	domainSuffix    string
 	clusterID       string
+	revision        string
 
 	serviceHandlers  []func(*model.Service, model.Event)
 	workloadHandlers []func(*model.WorkloadInstance, model.Event)
@@ -270,6 +274,7 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 		client:                      kubeClient.Kube(),
 		queue:                       queue.NewQueue(1 * time.Second),
 		clusterID:                   options.ClusterID,
+		revision:                    options.Revision,
 		xdsUpdater:                  options.XDSUpdater,
 		servicesMap:                 make(map[host.Name]*model.Service),
 		nodeSelectorsForServices:    make(map[host.Name]labels.Instance),

--- a/pilot/pkg/serviceregistry/kube/controller/fake.go
+++ b/pilot/pkg/serviceregistry/kube/controller/fake.go
@@ -166,6 +166,7 @@ func NewFakeControllerWithOptions(opts FakeControllerOptions) (*FakeController, 
 		EndpointMode:      opts.Mode,
 		ClusterID:         opts.ClusterID,
 		SyncInterval:      time.Microsecond,
+		Revision:          "default",
 	}
 	c := NewController(opts.Client, options)
 	if opts.ServiceHandler != nil {

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -73,7 +73,6 @@ type Multicluster struct {
 	// fetchCaRoot maps the certificate name to the certificate
 	fetchCaRoot  func() map[string]string
 	caBundlePath string
-	revision     string
 
 	// secretNamespace where we get cluster-access secrets
 	secretNamespace  string
@@ -91,7 +90,6 @@ func NewMulticluster(
 	serviceController *aggregate.Controller,
 	serviceEntryStore *serviceentry.ServiceEntryStore,
 	caBundlePath string,
-	revision string,
 	fetchCaRoot func() map[string]string,
 	networksWatcher mesh.NetworksWatcher,
 ) *Multicluster {
@@ -107,7 +105,6 @@ func NewMulticluster(
 		serviceController:     serviceController,
 		serviceEntryStore:     serviceEntryStore,
 		caBundlePath:          caBundlePath,
-		revision:              revision,
 		fetchCaRoot:           fetchCaRoot,
 		XDSUpdater:            opts.XDSUpdater,
 		remoteKubeControllers: remoteKubeController,
@@ -190,7 +187,7 @@ func (m *Multicluster) AddMemberCluster(client kubelib.Client, clusterID string)
 		if features.InjectionWebhookConfigName.Get() != "" && m.caBundlePath != "" {
 			// TODO prevent istiods in primary clusters from trying to patch eachother. should we also leader-elect?
 			log.Infof("initializing webhook cert patch for cluster %s", clusterID)
-			patcher, err := webhooks.NewWebhookCertPatcher(client.Kube(), m.revision, webhookName, m.caBundlePath)
+			patcher, err := webhooks.NewWebhookCertPatcher(client.Kube(), options.Revision, webhookName, m.caBundlePath)
 			if err != nil {
 				log.Errorf("could not initialize webhook cert patcher: %v", err)
 			} else {

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster_test.go
@@ -93,7 +93,7 @@ func Test_KubeSecretController(t *testing.T) {
 			DomainSuffix:      DomainSuffix,
 			ResyncPeriod:      ResyncPeriod,
 			SyncInterval:      time.Microsecond,
-		}, mockserviceController, nil, "", "default", nil, nil)
+		}, mockserviceController, nil, "", nil, nil)
 	mc.InitSecretController(stop)
 	cache.WaitForCacheSync(stop, mc.HasSynced)
 	clientset.RunAndWait(stop)

--- a/pilot/pkg/serviceregistry/kube/controller/network.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network.go
@@ -185,6 +185,10 @@ func (c *Controller) extractGatewaysInner(svc *model.Service) {
 // getGatewayDetails finds the port and network to use for cross-network traffic on the given service.
 // Zero values are returned if the service is not a cross-network gateway.
 func (c *Controller) getGatewayDetails(svc *model.Service) (uint32, string) {
+	if rev, ok := svc.Attributes.Labels[label.IstioRev]; !ok || rev != c.revision {
+		// the gateway service isn't part of this revision
+		return 0, ""
+	}
 	// label based gateways
 	if nw := svc.Attributes.Labels[label.IstioNetwork]; nw != "" {
 		if gwPortStr := svc.Attributes.Labels[IstioGatewayPortLabel]; gwPortStr != "" {


### PR DESCRIPTION
Necessary for upgrades in multi-network configurations. Without this, Gateways configured by an old control plane may be part of the multi-network loadbalancing rotation. 

cc @nmittler @howardjohn 