### PR TITLE
do not try to pre generate certs for file mounted certs

### DIFF
--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -91,7 +91,7 @@ func NewXdsServer(stop chan struct{}, gen model.XdsResourceGenerator) *xds.Disco
 }
 
 // newSDSService creates Secret Discovery Service which implements envoy SDS API.
-func newSDSService(st security.SecretManager) *sdsservice {
+func newSDSService(st security.SecretManager, options security.Options) *sdsservice {
 	if st == nil {
 		return nil
 	}
@@ -101,6 +101,10 @@ func newSDSService(st security.SecretManager) *sdsservice {
 		stop: make(chan struct{}),
 	}
 	ret.XdsServer = NewXdsServer(ret.stop, ret)
+
+	if options.FileMountedCerts {
+		return ret
+	}
 
 	// Pre-generate workload certificates to improve startup latency and ensure that for OUTPUT_CERTS
 	// case we always write a certificate. A workload can technically run without any mTLS/CA

--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -43,7 +43,7 @@ type Server struct {
 // NewServer creates and starts the Grpc server for SDS.
 func NewServer(options security.Options, workloadSecretCache security.SecretManager) (*Server, error) {
 	s := &Server{}
-	s.workloadSds = newSDSService(workloadSecretCache)
+	s.workloadSds = newSDSService(workloadSecretCache, options)
 	s.initWorkloadSdsService(options)
 	sdsServiceLog.Infof("SDS server for workload certificates started, listening on %q", options.WorkloadUDSPath)
 	return s, nil


### PR DESCRIPTION
SDS Service trying to pre generate certs and fills the logs with warning "failed to warm certificate: failed to generate workload certificate: attempted to fetch secret, but ca client is nil".  This is not needed for file mounted certs case.
[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[X ] Does not have any changes that may affect Istio users.
