### PR TITLE
retry.sh: stream output to stdout

### DIFF
--- a/bin/retry.sh
+++ b/bin/retry.sh
@@ -31,10 +31,10 @@ function retry {
   local n=1
   local max=5
   while true; do
-    out="$("$@" 2>&1)"
+    exec 5>&1
+    out="$("$@" 2>&1 | tee /dev/fd/5)"
     # shellcheck disable=SC2181
     if [[ $? == 0 ]]; then
-      echo "${out}"
       break
     fi
     if ! grep "${failureRegex}" <<< "${out}"; then


### PR DESCRIPTION
Currently, retry.sh is buffering up all the output which makes it hard
to tell what is going on.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.