### PR TITLE
Add cluster labels to all prom metrics for all topologies

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
+++ b/manifests/charts/istio-control/istio-discovery/files/gen-istio.yaml
@@ -1466,7 +1466,15 @@ spec:
                   value: |
                     {
                       "debug": "false",
-                      "stat_prefix": "istio"
+                      "stat_prefix": "istio",
+                      "metrics": [
+                        {
+                          "dimensions": {
+                            "source_cluster": "node.metadata['CLUSTER_ID']",
+                            "destination_cluster": "upstream_peer.cluster_id"
+                          }
+                        }
+                      ]
                     }
                 vm_config:
                   vm_id: stats_outbound
@@ -1500,7 +1508,15 @@ spec:
                   value: |
                     {
                       "debug": "false",
-                      "stat_prefix": "istio"
+                      "stat_prefix": "istio",
+                      "metrics": [
+                        {
+                          "dimensions": {
+                            "destination_cluster": "node.metadata['CLUSTER_ID']",
+                            "source_cluster": "downstream_peer.cluster_id"
+                          }
+                        }
+                      ]
                     }
                 vm_config:
                   vm_id: stats_inbound
@@ -1535,7 +1551,15 @@ spec:
                     {
                       "debug": "false",
                       "stat_prefix": "istio",
-                      "disable_host_header_fallback": true
+                      "disable_host_header_fallback": true,
+                      "metrics": [
+                        {
+                          "dimensions": {
+                            "source_cluster": "node.metadata['CLUSTER_ID']",
+                            "destination_cluster": "upstream_peer.cluster_id"
+                          }
+                        }
+                      ]
                     }
                 vm_config:
                   vm_id: stats_outbound
@@ -1579,7 +1603,15 @@ spec:
                   value: |
                     {
                       "debug": "false",
-                      "stat_prefix": "istio"
+                      "stat_prefix": "istio",
+                      "metrics": [
+                        {
+                          "dimensions": {
+                            "destination_cluster": "node.metadata['CLUSTER_ID']",
+                            "source_cluster": "downstream_peer.cluster_id"
+                          }
+                        }
+                      ]
                     }
                 vm_config:
                   vm_id: tcp_stats_inbound
@@ -1611,7 +1643,15 @@ spec:
                   value: |
                     {
                       "debug": "false",
-                      "stat_prefix": "istio"
+                      "stat_prefix": "istio",
+                      "metrics": [
+                        {
+                          "dimensions": {
+                            "source_cluster": "node.metadata['CLUSTER_ID']",
+                            "destination_cluster": "upstream_peer.cluster_id"
+                          }
+                        }
+                      ]
                     }
                 vm_config:
                   vm_id: tcp_stats_outbound
@@ -1643,7 +1683,15 @@ spec:
                   value: |
                     {
                       "debug": "false",
-                      "stat_prefix": "istio"
+                      "stat_prefix": "istio",
+                      "metrics": [
+                        {
+                          "dimensions": {
+                            "source_cluster": "node.metadata['CLUSTER_ID']",
+                            "destination_cluster": "upstream_peer.cluster_id"
+                          }
+                        }
+                      ]
                     }
                 vm_config:
                   vm_id: tcp_stats_outbound

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.9.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.9.yaml
@@ -400,7 +400,7 @@ spec:
                     {{- if not .Values.telemetry.v2.prometheus.configOverride.inboundSidecar }}
                     {
                       "debug": "false",
-                      "stat_prefix": "istio"
+                      "stat_prefix": "istio",
                       "metrics": [
                         {
                           "dimensions": {
@@ -452,7 +452,7 @@ spec:
                     {{- if not .Values.telemetry.v2.prometheus.configOverride.outboundSidecar }}
                     {
                       "debug": "false",
-                      "stat_prefix": "istio"
+                      "stat_prefix": "istio",
                       "metrics": [
                         {
                           "dimensions": {
@@ -504,7 +504,7 @@ spec:
                     {{- if not .Values.telemetry.v2.prometheus.configOverride.gateway }}
                     {
                       "debug": "false",
-                      "stat_prefix": "istio"
+                      "stat_prefix": "istio",
                       "metrics": [
                         {
                           "dimensions": {

--- a/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.9.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_1.9.yaml
@@ -224,7 +224,7 @@ spec:
                     {{- if not .Values.telemetry.v2.prometheus.configOverride.outboundSidecar }}
                     {
                       "debug": "false",
-                      "stat_prefix": "istio"{{- if .Values.global.multiCluster.clusterName }},
+                      "stat_prefix": "istio",
                       "metrics": [
                         {
                           "dimensions": {
@@ -233,7 +233,6 @@ spec:
                           }
                         }
                       ]
-                      {{- end }}
                     }
                     {{- else }}
                     {{ toJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar | indent 18 }}
@@ -279,7 +278,7 @@ spec:
                     {{- if not .Values.telemetry.v2.prometheus.configOverride.inboundSidecar }}
                     {
                       "debug": "false",
-                      "stat_prefix": "istio"{{- if .Values.global.multiCluster.clusterName }},
+                      "stat_prefix": "istio",
                       "metrics": [
                         {
                           "dimensions": {
@@ -288,7 +287,6 @@ spec:
                           }
                         }
                       ]
-                      {{- end }}
                     }
                     {{- else }}
                     {{ toJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar | indent 18 }}
@@ -335,7 +333,7 @@ spec:
                     {
                       "debug": "false",
                       "stat_prefix": "istio",
-                      "disable_host_header_fallback": true{{- if .Values.global.multiCluster.clusterName }},
+                      "disable_host_header_fallback": true,
                       "metrics": [
                         {
                           "dimensions": {
@@ -344,7 +342,6 @@ spec:
                           }
                         }
                       ]
-                      {{- end }}
                     }
                     {{- else }}
                     {{ toJson .Values.telemetry.v2.prometheus.configOverride.gateway | indent 18 }}
@@ -403,7 +400,7 @@ spec:
                     {{- if not .Values.telemetry.v2.prometheus.configOverride.inboundSidecar }}
                     {
                       "debug": "false",
-                      "stat_prefix": "istio"{{- if .Values.global.multiCluster.clusterName }},
+                      "stat_prefix": "istio"
                       "metrics": [
                         {
                           "dimensions": {
@@ -412,7 +409,6 @@ spec:
                           }
                         }
                       ]
-                      {{- end }}
                     }
                     {{- else }}
                     {{ toJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar | indent 18 }}
@@ -456,7 +452,7 @@ spec:
                     {{- if not .Values.telemetry.v2.prometheus.configOverride.outboundSidecar }}
                     {
                       "debug": "false",
-                      "stat_prefix": "istio"{{- if .Values.global.multiCluster.clusterName }},
+                      "stat_prefix": "istio"
                       "metrics": [
                         {
                           "dimensions": {
@@ -465,7 +461,6 @@ spec:
                           }
                         }
                       ]
-                      {{- end }}
                     }
                     {{- else }}
                     {{ toJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar | indent 18 }}
@@ -509,7 +504,7 @@ spec:
                     {{- if not .Values.telemetry.v2.prometheus.configOverride.gateway }}
                     {
                       "debug": "false",
-                      "stat_prefix": "istio"{{- if .Values.global.multiCluster.clusterName }},
+                      "stat_prefix": "istio"
                       "metrics": [
                         {
                           "dimensions": {
@@ -518,7 +513,6 @@ spec:
                           }
                         }
                       ]
-                      {{- end }}
                     }
                     {{- else }}
                     {{ toJson .Values.telemetry.v2.prometheus.configOverride.gateway | indent 18 }}

--- a/manifests/charts/istiod-remote/templates/telemetryv2_1.9.yaml
+++ b/manifests/charts/istiod-remote/templates/telemetryv2_1.9.yaml
@@ -224,7 +224,7 @@ spec:
                     {{- if not .Values.telemetry.v2.prometheus.configOverride.outboundSidecar }}
                     {
                       "debug": "false",
-                      "stat_prefix": "istio"{{- if .Values.global.multiCluster.clusterName }},
+                      "stat_prefix": "istio",
                       "metrics": [
                         {
                           "dimensions": {
@@ -233,7 +233,6 @@ spec:
                           }
                         }
                       ]
-                      {{- end }}
                     }
                     {{- else }}
                     {{ toJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar | indent 18 }}
@@ -279,7 +278,7 @@ spec:
                     {{- if not .Values.telemetry.v2.prometheus.configOverride.inboundSidecar }}
                     {
                       "debug": "false",
-                      "stat_prefix": "istio"{{- if .Values.global.multiCluster.clusterName }},
+                      "stat_prefix": "istio",
                       "metrics": [
                         {
                           "dimensions": {
@@ -288,7 +287,6 @@ spec:
                           }
                         }
                       ]
-                      {{- end }}
                     }
                     {{- else }}
                     {{ toJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar | indent 18 }}
@@ -335,7 +333,7 @@ spec:
                     {
                       "debug": "false",
                       "stat_prefix": "istio",
-                      "disable_host_header_fallback": true{{- if .Values.global.multiCluster.clusterName }},
+                      "disable_host_header_fallback": true,
                       "metrics": [
                         {
                           "dimensions": {
@@ -344,7 +342,6 @@ spec:
                           }
                         }
                       ]
-                      {{- end }}
                     }
                     {{- else }}
                     {{ toJson .Values.telemetry.v2.prometheus.configOverride.gateway | indent 18 }}
@@ -403,7 +400,7 @@ spec:
                     {{- if not .Values.telemetry.v2.prometheus.configOverride.inboundSidecar }}
                     {
                       "debug": "false",
-                      "stat_prefix": "istio"{{- if .Values.global.multiCluster.clusterName }},
+                      "stat_prefix": "istio",
                       "metrics": [
                         {
                           "dimensions": {
@@ -412,7 +409,6 @@ spec:
                           }
                         }
                       ]
-                      {{- end }}
                     }
                     {{- else }}
                     {{ toJson .Values.telemetry.v2.prometheus.configOverride.inboundSidecar | indent 18 }}
@@ -456,7 +452,7 @@ spec:
                     {{- if not .Values.telemetry.v2.prometheus.configOverride.outboundSidecar }}
                     {
                       "debug": "false",
-                      "stat_prefix": "istio"{{- if .Values.global.multiCluster.clusterName }},
+                      "stat_prefix": "istio",
                       "metrics": [
                         {
                           "dimensions": {
@@ -465,7 +461,6 @@ spec:
                           }
                         }
                       ]
-                      {{- end }}
                     }
                     {{- else }}
                     {{ toJson .Values.telemetry.v2.prometheus.configOverride.outboundSidecar | indent 18 }}
@@ -509,7 +504,7 @@ spec:
                     {{- if not .Values.telemetry.v2.prometheus.configOverride.gateway }}
                     {
                       "debug": "false",
-                      "stat_prefix": "istio"{{- if .Values.global.multiCluster.clusterName }},
+                      "stat_prefix": "istio",
                       "metrics": [
                         {
                           "dimensions": {
@@ -518,7 +513,6 @@ spec:
                           }
                         }
                       ]
-                      {{- end }}
                     }
                     {{- else }}
                     {{ toJson .Values.telemetry.v2.prometheus.configOverride.gateway | indent 18 }}

--- a/releasenotes/notes/cluster-labels-prometheus.yaml
+++ b/releasenotes/notes/cluster-labels-prometheus.yaml
@@ -1,0 +1,7 @@
+apiVersion: release-notes/v2
+kind: feature
+area: telemetry
+
+releaseNotes:
+  - |
+    **Updated** prometheus metrics to include source_cluster and destination_cluster labels by default for all scenarios. Previously, this was only enabled for multi-cluster scenarios.

--- a/tests/integration/telemetry/stats/prometheus/stats.go
+++ b/tests/integration/telemetry/stats/prometheus/stats.go
@@ -79,8 +79,6 @@ func TestStatsFilter(t *testing.T, feature features.Feature) {
 	framework.NewTest(t).
 		Features(feature).
 		Run(func(ctx framework.TestContext) {
-			sourceQuery, destinationQuery, appQuery := buildQuery()
-
 			g, _ := errgroup.WithContext(context.Background())
 			for _, cltInstance := range client {
 				g.Go(func() error {
@@ -89,6 +87,7 @@ func TestStatsFilter(t *testing.T, feature features.Feature) {
 							return err
 						}
 						c := cltInstance.Config().Cluster
+						sourceQuery, destinationQuery, appQuery := buildQuery(c.Name())
 						// Query client side metrics
 						if _, err := QueryPrometheus(t, c, sourceQuery, GetPromInstance()); err != nil {
 							t.Logf("prometheus values for istio_requests_total for cluster %v: \n%s", c, util.PromDump(c, promInst, "istio_requests_total"))
@@ -124,8 +123,6 @@ func TestStatsTCPFilter(t *testing.T, feature features.Feature) {
 	framework.NewTest(t).
 		Features(feature).
 		Run(func(ctx framework.TestContext) {
-			destinationQuery := buildTCPQuery()
-
 			g, _ := errgroup.WithContext(context.Background())
 			for _, cltInstance := range client {
 				g.Go(func() error {
@@ -134,6 +131,7 @@ func TestStatsTCPFilter(t *testing.T, feature features.Feature) {
 							return err
 						}
 						c := cltInstance.Config().Cluster
+						destinationQuery := buildTCPQuery(c.Name())
 						if _, err := QueryPrometheus(t, c, destinationQuery, GetPromInstance()); err != nil {
 							t.Logf("prometheus values for istio_tcp_connections_opened_total: \n%s", util.PromDump(c, promInst, "istio_tcp_connections_opened_total"))
 							return err
@@ -251,7 +249,7 @@ func BuildQueryCommon(labels map[string]string, ns string) (sourceQuery, destina
 	return
 }
 
-func buildQuery() (sourceQuery, destinationQuery, appQuery string) {
+func buildQuery(sourceCluster string) (sourceQuery, destinationQuery, appQuery string) {
 	ns := GetAppNamespace()
 	labels := map[string]string{
 		"request_protocol":               "http",
@@ -266,12 +264,13 @@ func buildQuery() (sourceQuery, destinationQuery, appQuery string) {
 		"source_version":                 "v1",
 		"source_workload":                "client-v1",
 		"source_workload_namespace":      ns.Name(),
+		"source_cluster":                 sourceCluster,
 	}
 
 	return BuildQueryCommon(labels, ns.Name())
 }
 
-func buildTCPQuery() (destinationQuery string) {
+func buildTCPQuery(sourceCluster string) (destinationQuery string) {
 	ns := GetAppNamespace()
 	destinationQuery = `istio_tcp_connections_opened_total{reporter="destination",`
 	labels := map[string]string{
@@ -287,6 +286,7 @@ func buildTCPQuery() (destinationQuery string) {
 		"source_version":                 "v1",
 		"source_workload":                "client-v1",
 		"source_workload_namespace":      ns.Name(),
+		"source_cluster":                 sourceCluster,
 	}
 	for k, v := range labels {
 		destinationQuery += fmt.Sprintf(`%s=%q,`, k, v)

--- a/tests/integration/telemetry/stats/prometheus/stats.go
+++ b/tests/integration/telemetry/stats/prometheus/stats.go
@@ -87,7 +87,11 @@ func TestStatsFilter(t *testing.T, feature features.Feature) {
 							return err
 						}
 						c := cltInstance.Config().Cluster
-						sourceQuery, destinationQuery, appQuery := buildQuery(c.Name())
+						sourceCluster := "Kubernetes"
+						if len(ctx.Clusters()) > 1 {
+							sourceCluster = c.Name()
+						}
+						sourceQuery, destinationQuery, appQuery := buildQuery(sourceCluster)
 						// Query client side metrics
 						if _, err := QueryPrometheus(t, c, sourceQuery, GetPromInstance()); err != nil {
 							t.Logf("prometheus values for istio_requests_total for cluster %v: \n%s", c, util.PromDump(c, promInst, "istio_requests_total"))
@@ -131,7 +135,11 @@ func TestStatsTCPFilter(t *testing.T, feature features.Feature) {
 							return err
 						}
 						c := cltInstance.Config().Cluster
-						destinationQuery := buildTCPQuery(c.Name())
+						sourceCluster := "Kubernetes"
+						if len(ctx.Clusters()) > 1 {
+							sourceCluster = c.Name()
+						}
+						destinationQuery := buildTCPQuery(sourceCluster)
 						if _, err := QueryPrometheus(t, c, destinationQuery, GetPromInstance()); err != nil {
 							t.Logf("prometheus values for istio_tcp_connections_opened_total: \n%s", util.PromDump(c, promInst, "istio_tcp_connections_opened_total"))
 							return err


### PR DESCRIPTION
Part of the plan for 1.9 release was to make all prometheus metrics include source/destination cluster labels (not just for multicluster scenarios). This PR is meant to accomplish that goal by removing the conditional logic in the manifests.

For 1.10+, we should absorb this logic into the istio/proxy extension code itself (or similar).

[ X ] Policies and Telemetry
