### PR TITLE
Make integ test support go 1.15

### DIFF
--- a/tests/integration/pilot/multi_version_revision_test.go
+++ b/tests/integration/pilot/multi_version_revision_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -162,7 +161,7 @@ func installRevisionOrFail(ctx framework.TestContext, version string, configs ma
 
 // ReadInstallFile reads a tar compress installation file from the embedded
 func ReadInstallFile(f string) (string, error) {
-	b, err := os.ReadFile(filepath.Join("testdata/upgrade", f+".tar"))
+	b, err := ioutil.ReadFile(filepath.Join("testdata/upgrade", f+".tar"))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Accidentally introduced a go 1.16 feature



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any changes that may affect Istio users.