### PR TITLE
trigger push when networks change

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -963,7 +963,7 @@ func (ps *PushContext) updateContext(
 	pushReq *PushRequest) error {
 
 	var servicesChanged, virtualServicesChanged, destinationRulesChanged, gatewayChanged,
-	authnChanged, authzChanged, envoyFiltersChanged, sidecarsChanged bool
+		authnChanged, authzChanged, envoyFiltersChanged, sidecarsChanged bool
 
 	for conf := range pushReq.ConfigsUpdated {
 		switch conf.Kind {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -328,6 +328,8 @@ const (
 	DebugTrigger TriggerReason = "debug"
 	// Describes a push triggered for a Secret change
 	SecretTrigger TriggerReason = "secret"
+	// Describes a push triggered for Networks change
+	NetworksTrigger TriggerReason = "networks"
 )
 
 // Merge two update requests together
@@ -960,7 +962,7 @@ func (ps *PushContext) updateContext(
 	pushReq *PushRequest) error {
 
 	var servicesChanged, virtualServicesChanged, destinationRulesChanged, gatewayChanged,
-		authnChanged, authzChanged, envoyFiltersChanged, sidecarsChanged bool
+	authnChanged, authzChanged, envoyFiltersChanged, sidecarsChanged bool
 
 	for conf := range pushReq.ConfigsUpdated {
 		switch conf.Kind {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -962,7 +962,7 @@ func (ps *PushContext) updateContext(
 	pushReq *PushRequest) error {
 
 	var servicesChanged, virtualServicesChanged, destinationRulesChanged, gatewayChanged,
-	authnChanged, authzChanged, envoyFiltersChanged, sidecarsChanged bool
+		authnChanged, authzChanged, envoyFiltersChanged, sidecarsChanged bool
 
 	for conf := range pushReq.ConfigsUpdated {
 		switch conf.Kind {

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -209,6 +209,7 @@ type PushContext struct {
 
 	// cache gateways addresses for each network
 	// this is mainly used for kubernetes multi-cluster scenario
+	networksMu      sync.RWMutex
 	networkGateways map[string][]*Gateway
 
 	initDone        atomic.Bool
@@ -962,7 +963,7 @@ func (ps *PushContext) updateContext(
 	pushReq *PushRequest) error {
 
 	var servicesChanged, virtualServicesChanged, destinationRulesChanged, gatewayChanged,
-		authnChanged, authzChanged, envoyFiltersChanged, sidecarsChanged bool
+	authnChanged, authzChanged, envoyFiltersChanged, sidecarsChanged bool
 
 	for conf := range pushReq.ConfigsUpdated {
 		switch conf.Kind {
@@ -1634,6 +1635,8 @@ func (ps *PushContext) mergeGateways(proxy *Proxy) *MergedGateway {
 
 // pre computes gateways for each network
 func (ps *PushContext) initMeshNetworks(meshNetworks *meshconfig.MeshNetworks) {
+	ps.networksMu.Lock()
+	defer ps.networksMu.Unlock()
 	ps.networkGateways = map[string][]*Gateway{}
 
 	// First, use addresses directly specified in meshNetworks
@@ -1655,7 +1658,6 @@ func (ps *PushContext) initMeshNetworks(meshNetworks *meshconfig.MeshNetworks) {
 		// - the computed map from meshNetworks (triggered by reloadNetworkLookup, the ported logic from getGatewayAddresses)
 		ps.networkGateways[network] = append(ps.networkGateways[network], gateways...)
 	}
-
 }
 
 func (ps *PushContext) initClusterLocalHosts(e *Environment) {
@@ -1707,10 +1709,14 @@ func (ps *PushContext) initClusterLocalHosts(e *Environment) {
 }
 
 func (ps *PushContext) NetworkGateways() map[string][]*Gateway {
+	ps.networksMu.RLock()
+	defer ps.networksMu.RUnlock()
 	return ps.networkGateways
 }
 
 func (ps *PushContext) NetworkGatewaysByNetwork(network string) []*Gateway {
+	ps.networksMu.RLock()
+	defer ps.networksMu.RUnlock()
 	if ps.networkGateways != nil {
 		return ps.networkGateways[network]
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -392,6 +392,7 @@ func (c *Controller) onServiceEvent(curr interface{}, event model.Event) error {
 		delete(c.networkGateways, svcConv.Hostname)
 		c.Unlock()
 	default:
+		needsFullPush := false
 		if isNodePortGatewayService(svc) {
 			// We need to know which services are using node selectors because during node events,
 			// we have to update all the node port services accordingly.
@@ -400,10 +401,15 @@ func (c *Controller) onServiceEvent(curr interface{}, event model.Event) error {
 			// only add when it is nodePort gateway service
 			c.nodeSelectorsForServices[svcConv.Hostname] = nodeSelector
 			c.Unlock()
-			c.updateServiceNodePortAddresses(svcConv)
+			needsFullPush = c.updateServiceNodePortAddresses(svcConv)
 		} else {
-			c.extractGatewaysFromService(svcConv)
+			needsFullPush = c.extractGatewaysFromService(svcConv)
 		}
+		if needsFullPush {
+			// networks are different, we need to update all eds endpoints
+			c.xdsUpdater.ConfigUpdate(&model.PushRequest{Full: true})
+		}
+
 		// instance conversion is only required when service is added/updated.
 		instances := kube.ExternalNameServiceInstances(svc, svcConv)
 		c.Lock()

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -407,7 +407,7 @@ func (c *Controller) onServiceEvent(curr interface{}, event model.Event) error {
 		}
 		if needsFullPush {
 			// networks are different, we need to update all eds endpoints
-			c.xdsUpdater.ConfigUpdate(&model.PushRequest{Full: true})
+			c.xdsUpdater.ConfigUpdate(&model.PushRequest{Full: true, Reason: []model.TriggerReason{model.NetworksTrigger}})
 		}
 
 		// instance conversion is only required when service is added/updated.

--- a/pilot/pkg/serviceregistry/kube/controller/fake.go
+++ b/pilot/pkg/serviceregistry/kube/controller/fake.go
@@ -32,11 +32,17 @@ const (
 type FakeXdsUpdater struct {
 	// Events tracks notifications received by the updater
 	Events chan FakeXdsEvent
+
+	// Updater if given, will actually trigger calls to the fake updater
+	Updater model.XDSUpdater
 }
 
 var _ model.XDSUpdater = &FakeXdsUpdater{}
 
 func (fx *FakeXdsUpdater) ConfigUpdate(req *model.PushRequest) {
+	if fx.Updater != nil {
+		fx.Updater.ConfigUpdate(req)
+	}
 	var id string
 	if req != nil && len(req.ConfigsUpdated) > 0 {
 		for key := range req.ConfigsUpdated {
@@ -49,7 +55,10 @@ func (fx *FakeXdsUpdater) ConfigUpdate(req *model.PushRequest) {
 	}
 }
 
-func (fx *FakeXdsUpdater) ProxyUpdate(_, _ string) {
+func (fx *FakeXdsUpdater) ProxyUpdate(clusterID, ip string) {
+	if fx.Updater != nil {
+		fx.Updater.ProxyUpdate(clusterID, ip)
+	}
 	select {
 	case fx.Events <- FakeXdsEvent{Type: "proxy"}:
 	default:
@@ -70,12 +79,22 @@ type FakeXdsEvent struct {
 
 // NewFakeXDS creates a XdsUpdater reporting events via a channel.
 func NewFakeXDS() *FakeXdsUpdater {
+	return NewFakeXDSWithUpdater(nil)
+}
+
+// NewFakeXDSWithUpdater creates a XdsUpdater reporting events via a channel.
+// If a non-nil updater is given, it will be triggered before events are put on the channel.
+func NewFakeXDSWithUpdater(updater model.XDSUpdater) *FakeXdsUpdater {
 	return &FakeXdsUpdater{
-		Events: make(chan FakeXdsEvent, 100),
+		Events:  make(chan FakeXdsEvent, 100),
+		Updater: updater,
 	}
 }
 
-func (fx *FakeXdsUpdater) EDSUpdate(_, hostname string, _ string, entry []*model.IstioEndpoint) {
+func (fx *FakeXdsUpdater) EDSUpdate(shard, hostname, namespace string, entry []*model.IstioEndpoint) {
+	if fx.Updater != nil {
+		fx.Updater.EDSCacheUpdate(shard, hostname, namespace, entry)
+	}
 	if len(entry) > 0 {
 		select {
 		case fx.Events <- FakeXdsEvent{Type: "eds", ID: hostname, Endpoints: entry}:
@@ -84,14 +103,20 @@ func (fx *FakeXdsUpdater) EDSUpdate(_, hostname string, _ string, entry []*model
 	}
 }
 
-func (fx *FakeXdsUpdater) EDSCacheUpdate(_, _, _ string, entry []*model.IstioEndpoint) {
+func (fx *FakeXdsUpdater) EDSCacheUpdate(shard, hostname string, namespace string, entry []*model.IstioEndpoint) {
+	if fx.Updater != nil {
+		fx.Updater.EDSCacheUpdate(shard, hostname, namespace, entry)
+	}
 }
 
 // SvcUpdate is called when a service port mapping definition is updated.
 // This interface is WIP - labels, annotations and other changes to service may be
 // updated to force a EDS and CDS recomputation and incremental push, as it doesn't affect
 // LDS/RDS.
-func (fx *FakeXdsUpdater) SvcUpdate(_, hostname string, _ string, _ model.Event) {
+func (fx *FakeXdsUpdater) SvcUpdate(shard, hostname, namespace string, event model.Event) {
+	if fx.Updater != nil {
+		fx.Updater.SvcUpdate(shard, hostname, namespace, event)
+	}
 	select {
 	case fx.Events <- FakeXdsEvent{Type: "service", ID: hostname}:
 	default:

--- a/pilot/pkg/serviceregistry/kube/controller/network.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network.go
@@ -129,30 +129,40 @@ func (c *Controller) NetworkGateways() map[string][]*model.Gateway {
 
 // extractGatewaysFromService checks if the service is a cross-network gateway
 // and if it is, updates the controller's gateways.
-func (c *Controller) extractGatewaysFromService(svc *model.Service) {
+func (c *Controller) extractGatewaysFromService(svc *model.Service) bool {
 	c.Lock()
 	defer c.Unlock()
-	c.extractGatewaysInner(svc)
+	return c.extractGatewaysInner(svc)
 }
 
 // reloadNetworkGateways performs extractGatewaysFromService for all services registered with the controller.
 func (c *Controller) reloadNetworkGateways() {
 	c.Lock()
 	defer c.Unlock()
+	gwsChanged := false
 	for _, svc := range c.servicesMap {
-		c.extractGatewaysInner(svc)
+		if c.extractGatewaysInner(svc) {
+			gwsChanged = true
+		}
+	}
+	if gwsChanged {
+		c.xdsUpdater.ConfigUpdate(&model.PushRequest{
+			Full: true,
+		})
 	}
 }
 
-// extractGatewaysInner performs the logic for extractGatewaysFromService without locking the controller
-func (c *Controller) extractGatewaysInner(svc *model.Service) {
+// extractGatewaysInner performs the logic for extractGatewaysFromService without locking the controller.
+// Returns true if any gateways changed.
+func (c *Controller) extractGatewaysInner(svc *model.Service) bool {
 	svc.Mutex.RLock()
 	defer svc.Mutex.RUnlock()
 
 	gwPort, network := c.getGatewayDetails(svc)
 	if gwPort == 0 || network == "" {
+		// TODO detect if this previously had the gateway label so we can cleanup the old value
 		// not a gateway
-		return
+		return false
 	}
 
 	if c.networkGateways[svc.Hostname] == nil {
@@ -179,7 +189,23 @@ func (c *Controller) extractGatewaysInner(svc *model.Service) {
 			gws = append(gws, &model.Gateway{Addr: ip, Port: gwPort})
 		}
 	}
+
+	gwsChanged := len(c.networkGateways[svc.Hostname][network]) != len(gws)
+	if !gwsChanged {
+		// number of gateways are the same, check that their contents are the same
+		found := map[model.Gateway]bool{}
+		for _, gw := range gws {
+			found[*gw] = true
+		}
+		for _, gw := range c.networkGateways[svc.Hostname][network] {
+			if _, ok := found[*gw]; !ok {
+				gwsChanged = true
+				break
+			}
+		}
+	}
 	c.networkGateways[svc.Hostname][network] = gws
+	return gwsChanged
 }
 
 // getGatewayDetails finds the port and network to use for cross-network traffic on the given service.

--- a/pilot/pkg/serviceregistry/kube/controller/network.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network.go
@@ -146,9 +146,7 @@ func (c *Controller) reloadNetworkGateways() {
 		}
 	}
 	if gwsChanged {
-		c.xdsUpdater.ConfigUpdate(&model.PushRequest{
-			Full: true,
-		})
+		c.xdsUpdater.ConfigUpdate(&model.PushRequest{Full: true, Reason: []model.TriggerReason{model.NetworksTrigger}})
 	}
 }
 

--- a/pilot/pkg/xds/mesh_network_test.go
+++ b/pilot/pkg/xds/mesh_network_test.go
@@ -15,7 +15,9 @@
 package xds
 
 import (
+	"context"
 	"fmt"
+	"istio.io/istio/pkg/test/util/retry"
 	"strings"
 	"testing"
 	"time"
@@ -37,6 +39,71 @@ import (
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/collections"
 )
+
+func TestNetworkGatewayUpdates(t *testing.T) {
+	pod := &workload{
+		kind: Pod,
+		name: "app", namespace: "pod",
+		ip: "10.10.10.10", port: 8080,
+		metaNetwork: "network-1",
+		labels:      map[string]string{label.IstioNetwork: "network-1"},
+	}
+	vm := &workload{
+		kind: VirtualMachine,
+		name: "vm", namespace: "default",
+		ip: "10.10.10.30", port: 9090,
+		metaNetwork: "vm",
+	}
+	workloads := []*workload{pod, vm}
+
+	kubeObjects := []runtime.Object{}
+	var configObjects []config.Config
+	for _, w := range workloads {
+		_, objs := w.kubeObjects()
+		kubeObjects = append(kubeObjects, objs...)
+		configObjects = append(configObjects, w.configs()...)
+	}
+	s := NewFakeDiscoveryServer(t, FakeOptions{
+		KubernetesObjects: kubeObjects,
+		Configs:           configObjects,
+	})
+	for _, w := range workloads {
+		w.setupProxy(s)
+	}
+
+	t.Run("no gateway", func(t *testing.T) {
+		vm.Expect(pod, "10.10.10.10:8080")
+		vm.Test(t, s)
+	})
+	t.Run("gateway added", func(t *testing.T) {
+		_, err := s.KubeClient().CoreV1().Services("istio-system").Create(context.TODO(), &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "istio-ingressgateway",
+				Namespace: "istio-system",
+				Labels: map[string]string{
+					label.IstioNetwork: "network-1",
+				},
+			},
+			Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+			Status: corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{{IP: "3.3.3.3"}}},
+			},
+		}, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if s.XDSUpdater.Wait("xds") == nil {
+			t.Fatal("did not trigger xds event")
+		}
+		if err := retry.Until(func() bool {
+			return len(s.PushContext().NetworkGatewaysByNetwork("network-1")) == 1
+		}); err != nil {
+			t.Fatal("push context did not reinitialize with gateways")
+		}
+		vm.Expect(pod, "3.3.3.3:15443")
+		vm.Test(t, s)
+	})
+}
 
 func TestMeshNetworking(t *testing.T) {
 	ingressServiceScenarios := map[corev1.ServiceType]map[string][]runtime.Object{
@@ -248,19 +315,8 @@ func runMeshNetworkingTest(t *testing.T, tt meshNetworkingTest) {
 	for _, w := range tt.workloads {
 		w.setupProxy(s)
 	}
-
 	for _, w := range tt.workloads {
-		if w.expectations == nil {
-			continue
-		}
-		eps := xdstest.ExtractLoadAssignments(s.Endpoints(w.proxy))
-		t.Run(fmt.Sprintf("from %s", w.proxy.ID), func(t *testing.T) {
-			for c, ips := range w.expectations {
-				t.Run(c, func(t *testing.T) {
-					assertListEqual(t, eps[c], ips)
-				})
-			}
-		})
+		w.Test(t, s)
 	}
 }
 
@@ -297,6 +353,21 @@ func (w *workload) Expect(target *workload, ips ...string) {
 		w.expectations = map[string][]string{}
 	}
 	w.expectations[target.clusterName()] = ips
+}
+
+func (w *workload) Test(t *testing.T, s *FakeDiscoveryServer) {
+	if w.expectations == nil {
+		return
+	}
+
+	t.Run(fmt.Sprintf("from %s", w.proxy.ID), func(t *testing.T) {
+		eps := xdstest.ExtractLoadAssignments(s.Endpoints(w.proxy))
+		for c, ips := range w.expectations {
+			t.Run(c, func(t *testing.T) {
+				assertListEqual(t, eps[c], ips)
+			})
+		}
+	})
 }
 
 func (w *workload) clusterName() string {

--- a/pilot/pkg/xds/mesh_network_test.go
+++ b/pilot/pkg/xds/mesh_network_test.go
@@ -92,13 +92,10 @@ func TestNetworkGatewayUpdates(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if s.XDSUpdater.Wait("xds") == nil {
-			t.Fatal("did not trigger xds event")
-		}
 		if err := retry.Until(func() bool {
 			return len(s.PushContext().NetworkGatewaysByNetwork("network-1")) == 1
 		}); err != nil {
-			t.Fatal("push context did not reinitialize with gateways")
+			t.Fatal("push context did not reinitialize with gateways; xds event may not have been triggred")
 		}
 		vm.Expect(pod, "3.3.3.3:15443")
 		vm.Test(t, s)

--- a/pilot/pkg/xds/mesh_network_test.go
+++ b/pilot/pkg/xds/mesh_network_test.go
@@ -17,7 +17,6 @@ package xds
 import (
 	"context"
 	"fmt"
-	"istio.io/istio/pkg/test/util/retry"
 	"strings"
 	"testing"
 	"time"
@@ -38,6 +37,7 @@ import (
 	"istio.io/istio/pkg/config/labels"
 	"istio.io/istio/pkg/config/mesh"
 	"istio.io/istio/pkg/config/schema/collections"
+	"istio.io/istio/pkg/test/util/retry"
 )
 
 func TestNetworkGatewayUpdates(t *testing.T) {

--- a/pilot/pkg/xds/mesh_network_test.go
+++ b/pilot/pkg/xds/mesh_network_test.go
@@ -408,24 +408,21 @@ func (w *workload) configs() []config.Config {
 	return nil
 }
 
-func (w *workload) setupProxy(s *FakeDiscoveryServer) *model.Proxy {
-	if w.proxy == nil {
-		p := &model.Proxy{
-			ID: strings.Join([]string{w.name, w.namespace}, "."),
-			Metadata: &model.NodeMetadata{
-				Network:              w.metaNetwork,
-				Labels:               w.labels,
-				RequestedNetworkView: w.networkView,
-			},
-		}
-		if w.kind == Pod {
-			p.Metadata.ClusterID = w.clusterID
-		} else {
-			p.Metadata.InterceptionMode = "NONE"
-		}
-		w.proxy = s.SetupProxy(p)
+func (w *workload) setupProxy(s *FakeDiscoveryServer) {
+	p := &model.Proxy{
+		ID: strings.Join([]string{w.name, w.namespace}, "."),
+		Metadata: &model.NodeMetadata{
+			Network:              w.metaNetwork,
+			Labels:               w.labels,
+			RequestedNetworkView: w.networkView,
+		},
 	}
-	return w.proxy
+	if w.kind == Pod {
+		p.Metadata.ClusterID = w.clusterID
+	} else {
+		p.Metadata.InterceptionMode = "NONE"
+	}
+	w.proxy = s.SetupProxy(p)
 }
 
 func (w *workload) buildPodService() []runtime.Object {

--- a/releasenotes/notes/30070.yaml
+++ b/releasenotes/notes/30070.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: networking
+issue:
+  - 30054
+releaseNotes:
+- |
+  **Fixed** Modifying multi-network gateway configuration via Services with the label `topology.istio.io/network` will
+  now cause endpoints to be updated on all proxies.


### PR DESCRIPTION
fixes https://github.com/istio/istio/issues/30054 by checking for a diff in the networks for a given service that was updated. If there is any difference, we trigger a push. 

This does _not_ cover what happens if the label _was_ on a Service and was then removed. It's difficult to tell which network the label was previously, so we don't know which network to remove this gateway from. 