### PR TITLE
test framework: allow skipping tests as a CLI flag

### DIFF
--- a/pkg/test/framework/resource/flags.go
+++ b/pkg/test/framework/resource/flags.go
@@ -42,6 +42,11 @@ func SettingsFromCommandLine(testID string) (*Settings, error) {
 	}
 	s.Selector = f
 
+	s.SkipMatcher, err = NewMatcher(s.SkipString)
+	if err != nil {
+		return nil, err
+	}
+
 	if s.FailOnDeprecation && s.NoCleanup {
 		return nil,
 			fmt.Errorf("checking for deprecation occurs at cleanup level, thus flags -istio.test.nocleanup and" +
@@ -67,6 +72,9 @@ func init() {
 
 	flag.StringVar(&settingsFromCommandLine.SelectorString, "istio.test.select", settingsFromCommandLine.SelectorString,
 		"Comma separated list of labels for selecting tests to run (e.g. 'foo,+bar-baz').")
+
+	flag.StringVar(&settingsFromCommandLine.SkipString, "istio.test.skip", settingsFromCommandLine.SkipString,
+		"Skip tests matching the regular expression. This follows the semantics of -test.run.")
 
 	flag.IntVar(&settingsFromCommandLine.Retries, "istio.test.retries", settingsFromCommandLine.Retries,
 		"Number of times to retry tests")

--- a/pkg/test/framework/resource/matcher.go
+++ b/pkg/test/framework/resource/matcher.go
@@ -1,0 +1,138 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type Matcher struct {
+	filter []*regexp.Regexp
+}
+
+// Matcher reimplements the logic of Go's -test.run. The code is mostly directly copied from Go's
+// source.
+func NewMatcher(regex string) (*Matcher, error) {
+	if regex == "" {
+		return &Matcher{}, nil
+	}
+	filter := splitRegexp(regex)
+	for i, s := range filter {
+		filter[i] = rewrite(s)
+	}
+	rxs := []*regexp.Regexp{}
+	for _, f := range filter {
+		r, err := regexp.Compile(f)
+		if err != nil {
+			return nil, err
+		}
+		rxs = append(rxs, r)
+	}
+	return &Matcher{filter: rxs}, nil
+}
+
+func (m *Matcher) MatchTest(testName string) bool {
+	elem := strings.Split(testName, "/")
+	if len(m.filter) > len(elem) {
+		return false
+	}
+	for i, s := range elem {
+		if i >= len(m.filter) {
+			break
+		}
+		if !m.filter[i].MatchString(s) {
+			return false
+		}
+	}
+	return true
+}
+
+// From go/src/testing/match.go
+// nolint
+func splitRegexp(s string) []string {
+	a := make([]string, 0, strings.Count(s, "/"))
+	cs := 0
+	cp := 0
+	for i := 0; i < len(s); {
+		switch s[i] {
+		case '[':
+			cs++
+		case ']':
+			if cs--; cs < 0 { // An unmatched ']' is legal.
+				cs = 0
+			}
+		case '(':
+			if cs == 0 {
+				cp++
+			}
+		case ')':
+			if cs == 0 {
+				cp--
+			}
+		case '\\':
+			i++
+		case '/':
+			if cs == 0 && cp == 0 {
+				a = append(a, s[:i])
+				s = s[i+1:]
+				i = 0
+				continue
+			}
+		}
+		i++
+	}
+	return append(a, s)
+}
+
+// rewrite rewrites a subname to having only printable characters and no white
+// space.
+// From go/src/testing/match.go
+func rewrite(s string) string {
+	b := []byte{}
+	for _, r := range s {
+		switch {
+		case isSpace(r):
+			b = append(b, '_')
+		case !strconv.IsPrint(r):
+			s := strconv.QuoteRune(r)
+			b = append(b, s[1:len(s)-1]...)
+		default:
+			b = append(b, string(r)...)
+		}
+	}
+	return string(b)
+}
+
+// From go/src/testing/match.go
+func isSpace(r rune) bool {
+	if r < 0x2000 {
+		switch r {
+		// Note: not the same as Unicode Z class.
+		case '\t', '\n', '\v', '\f', '\r', ' ', 0x85, 0xA0, 0x1680:
+			return true
+		}
+	} else {
+		if r <= 0x200a {
+			return true
+		}
+		switch r {
+		case 0x2028, 0x2029, 0x202f, 0x205f, 0x3000:
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/test/framework/resource/matcher_test.go
+++ b/pkg/test/framework/resource/matcher_test.go
@@ -1,0 +1,76 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import "testing"
+
+func TestMatcher(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		matches   []string
+		nomatches []string
+	}{
+		{
+			name:      "empty",
+			input:     "",
+			matches:   []string{"", "foo", "foo/bar", ".*"},
+			nomatches: []string{},
+		},
+		{
+			name:      "single",
+			input:     "Foo",
+			matches:   []string{"TestFoo", "TestMyFooBar", "TestFoo/TestBar"},
+			nomatches: []string{"baz", "baz/foo", "TestBar/TestFoo"},
+		},
+		{
+			name:      "double",
+			input:     "Foo/Bar",
+			matches:   []string{"TestFoo/TestBar", "TestFoo/TestBar/TestBaz"},
+			nomatches: []string{"TestFoo", "TestBar", "TestMyFooBar"},
+		},
+		{
+			name:    "space",
+			input:   "TestFoo/with space",
+			matches: []string{"TestFoo/with_space"},
+		},
+		{
+			name:      "regex",
+			input:     "Foo/.*/Baz",
+			matches:   []string{"TestFoo/something/TestBaz"},
+			nomatches: []string{"TestFoo", "TestFoo/TestBaz", "TestFoo/something/TestBar"},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			matcher, err := NewMatcher(tt.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, m := range tt.matches {
+				got := matcher.MatchTest(m)
+				if !got {
+					t.Fatalf("expected match for %q", m)
+				}
+			}
+			for _, m := range tt.nomatches {
+				got := matcher.MatchTest(m)
+				if got {
+					t.Fatalf("expected no match for %q", m)
+				}
+			}
+		})
+	}
+}

--- a/pkg/test/framework/resource/settings.go
+++ b/pkg/test/framework/resource/settings.go
@@ -60,6 +60,13 @@ type Settings struct {
 	// The label selector that the user has specified.
 	SelectorString string
 
+	// The regex specifying which tests to skip. This follows inverted semantics of golang's
+	// -test.run flag, which only supports positive match. If an entire package is meant to be
+	// excluded, it can be filtered with `go list` and explicitly passing the list of desired
+	// packages. For example: `go test $(go list ./... | grep -v bad-package)`.
+	SkipString  string
+	SkipMatcher *Matcher
+
 	// The label selector, in parsed form.
 	Selector label.Selector
 

--- a/pkg/test/framework/testcontext.go
+++ b/pkg/test/framework/testcontext.go
@@ -159,6 +159,10 @@ func newTestContext(test *testImpl, goTest *testing.T, s *suiteContext, parentSc
 		goTest.Skipf("Skipping: label mismatch: labels=%v, filter=%v", allLabels, s.settings.Selector)
 	}
 
+	if s.settings.SkipMatcher.MatchTest(goTest.Name()) {
+		goTest.Skipf("Skipping: test %v matched -istio.test.skip regex", goTest.Name())
+	}
+
 	scopes.Framework.Debugf("Creating New test context")
 	workDir := path.Join(s.settings.RunDir(), goTest.Name(), "_test_context")
 	if err := os.MkdirAll(workDir, os.ModePerm); err != nil {


### PR DESCRIPTION
Currently, tests can be selectively run with -test.run or testing only
specific packages with `go list`. However, test.run cannot do
exclusions, so if we want to skip a single test its quite hard. For
example, as an internal user I may not support the FooBar feature and
may want to skip the test. With this change, I can add
`--istio.test.skip=FooBar`.
